### PR TITLE
Adding Dockerfile definition for vdist build container

### DIFF
--- a/dockerfiles/vdist_debian
+++ b/dockerfiles/vdist_debian
@@ -1,0 +1,16 @@
+#-*- mode: dockerfile -*-
+FROM debian:buster
+LABEL maintainer="MIT Open Learning (odl-devops@mit.edu)"
+LABEL description="Image to be used by vdist to package python applications into debian deb packages."
+# Abort on error.
+RUN set -e
+# Sometimes deb-src repositories comes disabled by default, we're activating it
+# to use them for apt-get build-dep.
+RUN printf "deb-src http://deb.debian.org/debian buster main \ndeb-src http://deb.debian.org/debian buster-updates main\ndeb-src http://security.debian.org buster/updates main\n" >> /etc/apt/sources.list
+# Install build tools.
+RUN apt-get update && \
+    apt-get install ruby-dev build-essential git python-virtualenv curl libssl-dev libsqlite3-dev libgdbm-dev libreadline-dev libbz2-dev libncurses5-dev tk-dev python3 python3-pip libffi-dev -y
+# Preload useful dependencies to compile python distributions.
+RUN apt-get build-dep python python3 -y
+# FPM installation to bundle app built directories into a system package file.
+RUN gem install fpm --no-doc


### PR DESCRIPTION
Using the ol-infrastructure repository as the default home for dockerfiles to be used to build utility containers. I'm still not totally convinced that this is the right solution, but wanted to get this somewhere other than my local disk.