### PR TITLE
Adding fix for conditional resource imports to avoid loops

### DIFF
--- a/src/ol_infrastructure/components/aws/olvpc.py
+++ b/src/ol_infrastructure/components/aws/olvpc.py
@@ -171,7 +171,7 @@ class OLVPC(ComponentResource):
                 availability_zone=zone,
                 vpc_id=self.olvpc.id,
                 map_public_ip_on_launch=vpc_config.default_public_ip,
-                tags=vpc_config.tags,
+                tags=vpc_config.merged_tags({'Name': net_name}),
                 assign_ipv6_address_on_creation=vpc_config.enable_ipv6,
                 opts=ResourceOptions.merge(resource_options, subnet_resource_opts)
             )

--- a/src/ol_infrastructure/lib/aws/ec2_helper.py
+++ b/src/ol_infrastructure/lib/aws/ec2_helper.py
@@ -127,6 +127,13 @@ def _conditional_import(  # noqa: WPS210
         opts = pulumi.ResourceOptions(
             import_=resource_id,
             ignore_changes=change_attributes_ignored)
+        if not pulumi.runtime.is_dry_run():
+            ec2_client.create_tags(
+                Resources=[resource_id],
+                Tags=[
+                    {'Key': 'pulumi_managed', 'Value': 'true'}
+                ]
+            )
     return opts, resource_id
 
 
@@ -254,7 +261,7 @@ def build_userdata(  # noqa: WPS211
             'bootcmd': [
                 'wget -O /tmp/salt_bootstrap.sh https://raw.githubusercontent.com/mitodl/salt-bootstrap/develop/bootstrap-salt.sh',  # noqa: E501
                 'chmod +x /tmp/salt_bootstrap.sh',
-                'sh /tmp/salt_bootstrap.sh -U -N -z'
+                'sh /tmp/salt_bootstrap.sh -N -z'
             ],
             'package_update': True,
             'salt_minion': {


### PR DESCRIPTION
In the current implementation the imported resource doesn't get the `pulumi_managed` tag applied so that subsequent runs will try to import the same resource again. This adds a step to use boto3 to apply that tag after generating the ResourceOptions that specify the import but only when the resources are actually being manipulated.