### PR TITLE
Added Vault backends and roles

### DIFF
--- a/src/ol_infrastructure/components/services/vault.py
+++ b/src/ol_infrastructure/components/services/vault.py
@@ -74,7 +74,7 @@ class OLVaultDatabaseBackend(ComponentResource):
             db_config: Union[OLVaultMysqlDatabaseConfig, OLVaultPostgresDatabaseConfig],
             opts: ResourceOptions = None
     ):
-        super().__init__('ol:services:VaultDatabaseBackend', db_config.db_name, None, opts)
+        super().__init__('ol:services:Vault:DatabaseBackend', db_config.db_name, None, opts)
 
         resource_opts = ResourceOptions.merge(ResourceOptions(parent=self), opts)  # type: ignore
 
@@ -146,15 +146,15 @@ class OLVaultAWSSecretsEngineConfig(BaseModel):
     max_lease_ttl_seconds: int = SIX_MONTHS
     description: Text
     aws_secret_key: Text
-    path: Text
+    vault_backend_path: Text
     policy_documents: Dict[Text, Text]
     credential_type: Text = 'iam_user'
 
-    @validator('path')
-    def is_valid_path(cls: 'OLVaultAWSSecretsEngineConfig', path: Text) -> Text:
-        if path.startswith('/') or path.endswith('/'):
-            raise ValueError(f'The specified path value {path} can not start or end with a slash')
-        return path
+    @validator('vault_backend_path')
+    def is_valid_path(cls: 'OLVaultAWSSecretsEngineConfig', vault_backend_path: Text) -> Text:
+        if vault_backend_path.startswith('/') or vault_backend_path.endswith('/'):
+            raise ValueError(f'The specified path value {vault_backend_path} can not start or end with a slash')
+        return vault_backend_path
 
 
 class OLVaultAWSSecretsEngine(ComponentResource):
@@ -164,7 +164,7 @@ class OLVaultAWSSecretsEngine(ComponentResource):
             engine_config: OLVaultAWSSecretsEngineConfig,
             opts: ResourceOptions = None
     ):
-        super().__init__('ol:services:VaultAWSSecretsEngine', engine_config.app_name, None, opts)
+        super().__init__('ol:services:Vault:AWSSecretsEngine', engine_config.app_name, None, opts)
 
         resource_options = ResourceOptions(parent=self).merge(opts)  # type: ignore
 
@@ -173,7 +173,7 @@ class OLVaultAWSSecretsEngine(ComponentResource):
             f'aws-{engine_config.app_name}',
             access_key=engine_config.aws_access_key,
             secret_key=engine_config.aws_secret_key,
-            path=f'aws-{engine_config.app_name}',
+            path=f'aws-{engine_config.vault_backend_path}',
             opts=resource_options,
         )
 
@@ -210,7 +210,7 @@ class OLVaultAppRoleAuthBackend(ComponentResource):
             approle_config: OLVaultAppRoleAuthBackendConfig,
             opts: ResourceOptions = None
     ):
-        super().__init__('ol:services:VaultAppRoleAuthBackend', approle_config.authbackend_name, None, opts)
+        super().__init__('ol:services:Vault:AppRoleAuthBackend', approle_config.authbackend_name, None, opts)
 
         resource_options = ResourceOptions(parent=self).merge(opts)  # type: ignore
 

--- a/src/ol_infrastructure/components/services/vault.py
+++ b/src/ol_infrastructure/components/services/vault.py
@@ -166,12 +166,15 @@ class OLVaultAWSSecretsEngine(ComponentResource):
     ):
         super().__init__('ol:services:VaultAWSSecretsEngine', engine_config.app_name, None, opts)
 
+        resource_options = ResourceOptions(parent=self).merge(opts)  # type: ignore
+
         self.aws_secrets_engine = aws.SecretBackend(
             # TODO verify app_name exists based on Apps class in ol_types
             f'aws-{engine_config.app_name}',
             access_key=engine_config.aws_access_key,
             secret_key=engine_config.aws_secret_key,
-            path=f'aws-{engine_config.app_name}'
+            path=f'aws-{engine_config.app_name}',
+            opts=resource_options,
         )
 
         for role_name, policy in engine_config.policy_documents.items():
@@ -209,11 +212,15 @@ class OLVaultAppRoleAuthBackend(ComponentResource):
     ):
         super().__init__('ol:services:VaultAppRoleAuthBackend', approle_config.authbackend_name, None, opts)
 
+        resource_options = ResourceOptions(parent=self).merge(opts)  # type: ignore
+
         self.approle_backend = AuthBackend(
             approle_config.authbackend_name,
             description=approle_config.description,
             path=approle_config.authbackend_name,
-            type=approle_config.backend_type)
+            type=approle_config.backend_type,
+            opts=resource_options,
+        )
 
         token_policy_names = []
         for policy_key, policy_value in approle_config.token_policies.items():
@@ -225,6 +232,7 @@ class OLVaultAppRoleAuthBackend(ComponentResource):
             backend=self.approle_backend.path,
             role_name=approle_config.role_name,
             token_policies=token_policy_names,
+            opts=resource_options,
         )
 
         self.register_outputs({})

--- a/src/ol_infrastructure/components/services/vault.py
+++ b/src/ol_infrastructure/components/services/vault.py
@@ -147,7 +147,7 @@ class OLVaultAWSSecretsEngineConfig(BaseModel):
     description: Text
     secret_key: Text
     path: Text
-    policy_documents: Dict
+    policy_documents: Dict[Text, Text]
     credential_type: str = 'iam_user'
 
 

--- a/src/ol_infrastructure/components/services/vault.py
+++ b/src/ol_infrastructure/components/services/vault.py
@@ -184,7 +184,7 @@ class OLVaultAWSSecretsEngine(ComponentResource):
                 credential_type=engine_config.credential_type,
                 name=role_name,
                 policy_document=json.dumps(policy),
-                opts=ResourceOptions(depends_on=[self.aws_secrets_engine])
+                opts=resource_options,
             )
 
         self.register_outputs({})

--- a/src/ol_infrastructure/components/services/vault.py
+++ b/src/ol_infrastructure/components/services/vault.py
@@ -17,10 +17,7 @@ from pulumi_vault import AuthBackend, Mount, Policy, approle, aws, database
 from pydantic import BaseModel
 
 from ol_infrastructure.lib.ol_types import Apps
-from ol_infrastructure.lib.vault import (
-    mysql_sql_statements,
-    postgres_sql_statements
-)
+from ol_infrastructure.lib.vault import mysql_sql_statements, postgres_sql_statements
 
 DEFAULT_PORT_POSTGRES = 5432
 DEFAULT_PORT_MYSQL = 3306

--- a/src/ol_infrastructure/lib/ol_types.py
+++ b/src/ol_infrastructure/lib/ol_types.py
@@ -25,6 +25,21 @@ class BusinessUnit(str, Enum):  # noqa: WPS600
     starteam = 'starteam'
     xpro = 'mitxpro'
 
+@unique
+class Apps(str, Enum):  # noqa: WPS600
+    """Canonical source of truth for defining apps."""
+
+    bootcamps = 'bootcamps'
+    micromasters = 'micromasters'
+    ocw_build = 'ocw-build'
+    redash = 'redash'
+    dagster = 'dagster'
+    mitxpro_edx = 'xpro-edx'
+    mitx_edx = 'mitx-edx'
+    odl_video_service = 'ovs'
+    mit_open = 'open'
+    starcellbio = 'starcellbio'
+
 
 class AWSBase(BaseModel):
     """Base class for deriving configuration objects to pass to AWS component resources."""


### PR DESCRIPTION
Added ability to create Vault AWS secrets engine and approle along with the ability to pass policies and creates those vault policies as part of enabling the vault backends.