### PR TITLE
Adding filtering of IAM lint findings and fixing Open S3 permissions

### DIFF
--- a/src/ol_infrastructure/applications/mit_open/__main__.py
+++ b/src/ol_infrastructure/applications/mit_open/__main__.py
@@ -43,12 +43,19 @@ course_data_bucket = s3.Bucket(
     tags=aws_config.tags,
 )
 
+parliament_config = {
+    "PERMISSIONS_MANAGEMENT_ACTIONS": {
+        "ignore_locations": [{"actions": ["s3:putobjectacl"]}]
+    }
+}
+
 s3_bucket_permissions = [
     {
         "Action": [
             "s3:GetObject*",
             "s3:ListBucket*",
             "s3:PutObject",
+            "s3:PutObjectAcl",
             "S3:DeleteObject",
         ],
         "Effect": "Allow",
@@ -167,7 +174,9 @@ mit_open_iam_policy = iam.Policy(
     f"mit_open_iam_permissions_{stack_info.env_suffix}",
     name=f"mit-open-application-permissions-{stack_info.env_suffix}",
     path=f"/ol-applications/mit-open/{stack_info.env_suffix}/",
-    policy=lint_iam_policy(open_policy_document, stringify=True),
+    policy=lint_iam_policy(
+        open_policy_document, stringify=True, parliament_config=parliament_config
+    ),
 )
 
 mit_open_vault_iam_role = aws.SecretBackendRole(

--- a/src/ol_infrastructure/lib/aws/iam_helper.py
+++ b/src/ol_infrastructure/lib/aws/iam_helper.py
@@ -1,9 +1,32 @@
 import json
+import re
 from typing import Any, Dict, Union
 
 from parliament import analyze_policy_string
+from parliament.finding import Finding
 
 IAM_POLICY_VERSION = "2012-10-17"
+
+
+def _is_parliament_finding_filtered(
+    finding: Finding, parliament_config: Dict[str, Any]
+) -> bool:
+    issue_match = finding.issue in parliament_config.keys()
+    if not issue_match:
+        return False
+    action_matches = []
+    for location in parliament_config[finding.issue][  # noqa: WPS426, WPS352
+        "ignore_locations"
+    ]:
+        for action in location["actions"]:  # noqa: WPS426
+            matches = map(
+                lambda finding_action: re.findall(
+                    action, finding_action, re.IGNORECASE
+                ),
+                finding.location["actions"],
+            )
+            action_matches.append(any(matches))
+    return any(action_matches)
 
 
 def lint_iam_policy(
@@ -40,6 +63,11 @@ def lint_iam_policy(
         include_community_auditors=True,
         config=parliament_config,
     ).findings
+    findings = [
+        finding
+        for finding in findings
+        if not _is_parliament_finding_filtered(finding, parliament_config or {})
+    ]
     if findings:
         raise Exception(  # noqa: WPS454
             "Potential issues found with IAM policy document", findings


### PR DESCRIPTION
There are some cases where we want to be able to ignore the findings from Parliament. This adds a way to pass an explicit configuration object as documented in the upstream projects README and then apply filtering of the findings to allow some to pass through.