### PR TITLE
Renaming KMS key to indicate its use for both SOPS and Pulumi

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,6 @@ backend:
 
 Create the directory path according to the conventions detailed above and then create these files. Once that is done you
 will need to create the stack definitions (again according to the above conventions). To do this, `cd` to the target
-directory and run the command `pulumi stack init --secrets-provider=awskms://alias/PulumiSecrets <your.dotted.stack.name.QA>`
+directory and run the command `pulumi stack init --secrets-provider=awskms://alias/infrastructure-secrets-qa <your.dotted.stack.name.QA>`
 
 Now you're ready to start writing the code that will define the target deployment.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,12 @@
 [flake8]
 max_line_length = 88
 max_local_variables = 10
+max_string_usages = 5
 ignore =
     # C812: missing trailing comma - ignored because Black handles placement of trailing commas
     C812,
+    # P101: format string contains unindexed parameters (e.g. {} vs {0})
+    P101,
     # W503: line break before binary operator - ignored to allow for how Black splits lines
     W503,
     # WPS305: Forbid `f` strings - Ignored to allow for the use of f-strings


### PR DESCRIPTION
Changing the provisioned keys and aliases to separate out the permissions boundaries between different environments. This will provide us with separation of access between production and non-production secrets in Pulumi and allow us to manage those same permissions for SOPS secrets.