### PR TITLE
Add OCW build for Concourse

### DIFF
--- a/dockerfiles/ocw/node-hugo/Dockerfile
+++ b/dockerfiles/ocw/node-hugo/Dockerfile
@@ -1,0 +1,23 @@
+FROM  node:14
+LABEL maintainer="MIT Open Learning (odl-devops@mit.edu)"
+LABEL description="Node and Hugo, used for building OCW website"
+WORKDIR /tmp
+ENV HUGO_VERSION='0.80.0'
+ENV HUGO_NAME="hugo_extended_${HUGO_VERSION}_Linux-64bit"
+ENV GO_FILE_NAME="go1.16.4.linux-amd64.tar.gz"
+ENV GO_URL="https://golang.org/dl/${GO_FILE_NAME}"
+ENV HUGO_URL="https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_NAME}.deb"
+ENV BUILD_DEPS="wget"
+RUN apt update && \
+    apt install -y git "${BUILD_DEPS}" && \
+    wget "${HUGO_URL}" && \
+    apt install "./${HUGO_NAME}.deb" && \
+    rm -rf "./${HUGO_NAME}.deb" "${HUGO_NAME}" && \
+    wget "${GO_URL}" && \
+    tar -xvf ${GO_FILE_NAME} && \
+    mv go /usr/local && \
+    rm "${GO_FILE_NAME}" && \
+    apt remove -y "${BUILD_DEPS}" && \
+    apt autoremove -y && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/ocw/node-hugo/README.txt
+++ b/dockerfiles/ocw/node-hugo/README.txt
@@ -1,0 +1,11 @@
+This is the Dockerfile for
+https://hub.docker.com/r/mitodl/ocw-course-publisher
+
+The docker image is used in the Concourse pipeline for building the OCW
+site. See pipelines/ocw/pipeline.yml.
+
+This should be built and tagged as mitodl/ocw-course-publisher:latest and
+pushed to Docker Hub:
+
+	$ docker build -t mitodl/ocw-course-publisher:latest .
+	$ docker push mitodl/ocw-course-publisher:latest

--- a/pipelines/ocw/pipeline.yml
+++ b/pipelines/ocw/pipeline.yml
@@ -74,5 +74,7 @@ jobs:
           source: ocw-www/dist/
           destination:
             - dir: s3-remote:((ocw-site-bucket))
+            - command: sync
             - args:
-              - "--dry-run"
+              - "--exclude"
+              - "courses"

--- a/pipelines/ocw/pipeline.yml
+++ b/pipelines/ocw/pipeline.yml
@@ -77,4 +77,4 @@ jobs:
               command: sync
               args:
                 - "--exclude"
-                - "courses"
+                - "/courses/**"

--- a/pipelines/ocw/pipeline.yml
+++ b/pipelines/ocw/pipeline.yml
@@ -37,7 +37,9 @@ jobs:
     plan:
       - get: ol-infrastructure
       - get: ocw-www
+        trigger: true
       - get: ocw-hugo-themes
+        trigger: true
       - task: copy-go-mod-file
         config:
           platform: linux

--- a/pipelines/ocw/pipeline.yml
+++ b/pipelines/ocw/pipeline.yml
@@ -1,0 +1,76 @@
+---
+resource_types:
+  - name: rclone
+    type: docker-image
+    source:
+      repository: sothr/concourse-rclone-resource
+      tag: latest
+resources:
+  - name: ol-infrastructure
+    type: git
+    source:
+      uri: https://github.com/mitodl/ol-infrastructure.git
+      branch: ((ol-infrastructure-git-ref))
+  - name: ocw-www
+    type: git
+    source:
+      uri: https://github.com/mitodl/ocw-www.git
+      branch: ((ocw-www-git-ref))
+  - name: ocw-hugo-themes
+    type: git
+    source:
+      uri: https://github.com/mitodl/ocw-hugo-themes.git
+      branch: ((ocw-hugo-theme-git-ref))
+  - name: ocw-site
+    type: rclone
+    source:
+      config: |
+        [s3-remote]
+        type = s3
+        provider = AWS
+        env_auth = true
+        region = us-east-1
+
+jobs:
+  - name: build
+    serial: true
+    plan:
+      - get: ol-infrastructure
+      - get: ocw-www
+      - get: ocw-hugo-themes
+      - task: copy-go-mod-file
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source: {repository: busybox}
+          inputs:
+            - name: ol-infrastructure
+            - name: ocw-hugo-themes
+            - name: ocw-www
+          outputs:
+            - name: ocw-www
+            - name: ocw-hugo-themes
+          run:
+            path: ol-infrastructure/pipelines/ocw/scripts/modify-go-mod.sh
+      - task: build-ocw-www-hugo-themes
+        config:
+          platform: linux
+          image_resource:
+            type:  docker-image
+            source: {repository: mitodl/ocw-course-publisher, tag: "latest"}
+          inputs:
+            - name: ol-infrastructure
+            - name: ocw-hugo-themes
+            - name: ocw-www
+          outputs:
+            - name: ocw-www
+          run:
+            path: ol-infrastructure/pipelines/ocw/scripts/build-hugo-themes.sh
+      - put: ocw-site
+        params:
+          source: ocw-www/dist/
+          destination:
+            - dir: s3-remote:((ocw-site-bucket))
+            - args:
+              - "--dry-run"

--- a/pipelines/ocw/pipeline.yml
+++ b/pipelines/ocw/pipeline.yml
@@ -73,7 +73,16 @@ jobs:
         params:
           source: ocw-www/dist/
           destination:
-            - dir: s3-remote:((ocw-site-bucket))
+            - dir: s3-remote:((ocw-draft-bucket))
+              command: sync
+              args:
+                - "--exclude"
+                - "/courses/**"
+      - put: ocw-site
+        params:
+          source: ocw-www/dist/
+          destination:
+            - dir: s3-remote:((ocw-live-bucket))
               command: sync
               args:
                 - "--exclude"

--- a/pipelines/ocw/pipeline.yml
+++ b/pipelines/ocw/pipeline.yml
@@ -74,7 +74,7 @@ jobs:
           source: ocw-www/dist/
           destination:
             - dir: s3-remote:((ocw-site-bucket))
-            - command: sync
-            - args:
-              - "--exclude"
-              - "courses"
+              command: sync
+              args:
+                - "--exclude"
+                - "courses"

--- a/pipelines/ocw/scripts/build-hugo-themes.sh
+++ b/pipelines/ocw/scripts/build-hugo-themes.sh
@@ -12,6 +12,4 @@ npm run build:githash
 npm run build
 
 # Just for testing rclone!
-mkdir ../ocw-www/dist/courses
-date > ../ocw-www/dist/courses/testfile1
-date > ../ocw-www/dist/testfile2
+date > ../ocw-www/dist/testfile3

--- a/pipelines/ocw/scripts/build-hugo-themes.sh
+++ b/pipelines/ocw/scripts/build-hugo-themes.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e  # exit on error
+set -x  # show commands on stdout
+
+export PATH=$PATH:/usr/local/go/bin
+export EXTERNAL_SITE_PATH=../ocw-www
+
+cd ocw-hugo-themes
+yarn install --pure-lockfile
+npm run build:githash
+npm run build

--- a/pipelines/ocw/scripts/build-hugo-themes.sh
+++ b/pipelines/ocw/scripts/build-hugo-themes.sh
@@ -10,3 +10,8 @@ cd ocw-hugo-themes
 yarn install --pure-lockfile
 npm run build:githash
 npm run build
+
+# Just for testing rclone!
+mkdir ../ocw-www/dist/courses
+date > ../ocw-www/dist/courses/testfile1
+date > ../ocw-www/dist/testfile2

--- a/pipelines/ocw/scripts/build-hugo-themes.sh
+++ b/pipelines/ocw/scripts/build-hugo-themes.sh
@@ -10,8 +10,3 @@ cd ocw-hugo-themes
 yarn install --pure-lockfile
 npm run build:githash
 npm run build
-
-# Just for testing rclone!
-mkdir ../ocw-www/dist/courses
-date > ../ocw-www/dist/courses/testfile1
-date > ../ocw-www/dist/testfile2

--- a/pipelines/ocw/scripts/build-hugo-themes.sh
+++ b/pipelines/ocw/scripts/build-hugo-themes.sh
@@ -12,4 +12,6 @@ npm run build:githash
 npm run build
 
 # Just for testing rclone!
-date > ../ocw-www/dist/testfile3
+mkdir ../ocw-www/dist/courses
+date > ../ocw-www/dist/courses/testfile1
+date > ../ocw-www/dist/testfile2

--- a/pipelines/ocw/scripts/modify-go-mod.sh
+++ b/pipelines/ocw/scripts/modify-go-mod.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e  # fail on error
+set -x  # show commands on stdout
+
+basepath=`pwd`
+cd ocw-www
+cp go.mod go.mod.backup
+printf "\nreplace github.com/mitodl/ocw-hugo-themes/base-theme => $basepath/ocw-hugo-themes/base-theme\n" >> go.mod
+printf "\nreplace github.com/mitodl/ocw-hugo-themes/www => $basepath/ocw-hugo-themes/www\n" >> go.mod


### PR DESCRIPTION
This adds a Concourse pipeline for building just the "main" pages of the OCW site and the page assets.
I'm mainly looking for feedback to make sure I'm on the right track. My main issue is the Rclone resource. It's probably OK, because I can get it to show the files in the correct directory `ocw-www/dist` and it seems to be trying to sync them; but it retries repeatedly because it doesn't have any credentials set up. It's intended to work with an IAM instance profile. The real way to test this will be to put it on our QA concourse server.

The build seems to work and populates the `ocw-www/dist` directory as I expected it to.
