### PR TITLE
Add pipeline to build OCW build Docker image

### DIFF
--- a/dockerfiles/ocw/node-hugo/Dockerfile
+++ b/dockerfiles/ocw/node-hugo/Dockerfile
@@ -1,4 +1,4 @@
-FROM  node:14
+FROM  node:14-buster-slim
 LABEL maintainer="MIT Open Learning (odl-devops@mit.edu)"
 LABEL description="Node and Hugo, used for building OCW website"
 WORKDIR /tmp

--- a/pipelines/ocw/docker-image-pipeline.yml
+++ b/pipelines/ocw/docker-image-pipeline.yml
@@ -14,8 +14,8 @@ resources:
     - name: ocw-course-publisher-image
       type: docker-image
       source:
-          username: ((docker-hub-username))
-          password: ((docker-hub-password))
+          username: ((dockerhub.username))
+          password: ((dockerhub.password))
           repository: mitodl/ocw-course-publisher
           tag: latest
 

--- a/pipelines/ocw/docker-image-pipeline.yml
+++ b/pipelines/ocw/docker-image-pipeline.yml
@@ -5,6 +5,8 @@ resources:
       source:
           uri: https://github.com/mitodl/ol-infrastructure.git
           branch: ((ol-infrastructure-git-ref))
+          paths:
+              - dockerfiles/ocw/node-hugo/Dockerfile
     - name: node-image
       type: docker-image
       check_every: 1h
@@ -28,6 +30,7 @@ jobs:
           - get: node-image
             trigger: true
           - get: ol-infrastructure
+            trigger: true
           - put: ocw-course-publisher-image
             params:
                 build: ol-infrastructure/dockerfiles/ocw/node-hugo

--- a/pipelines/ocw/docker-image-pipeline.yml
+++ b/pipelines/ocw/docker-image-pipeline.yml
@@ -12,7 +12,7 @@ resources:
       check_every: 1h
       source:
           repository: node
-          tag: '14'
+          tag: 14-buster-slim
     - name: ocw-course-publisher-image
       type: docker-image
       source:
@@ -29,6 +29,7 @@ jobs:
       plan:
           - get: node-image
             trigger: true
+            params: {skip_download: true}
           - get: ol-infrastructure
             trigger: true
           - put: ocw-course-publisher-image

--- a/pipelines/ocw/docker-image-pipeline.yml
+++ b/pipelines/ocw/docker-image-pipeline.yml
@@ -1,0 +1,33 @@
+---
+resources:
+    - name: ol-infrastructure
+      type: git
+      source:
+          uri: https://github.com/mitodl/ol-infrastructure.git
+          branch: ((ol-infrastructure-git-ref))
+    - name: node-image
+      type: docker-image
+      check_every: 1h
+      source:
+          repository: node
+          tag: '14'
+    - name: ocw-course-publisher-image
+      type: docker-image
+      source:
+          username: ((docker-hub-username))
+          password: ((docker-hub-password))
+          repository: mitodl/ocw-course-publisher
+          tag: latest
+
+
+jobs:
+    - name: publish
+      public: true
+      serial: true
+      plan:
+          - get: node-image
+            trigger: true
+          - get: ol-infrastructure
+          - put: ocw-course-publisher-image
+            params:
+                build: ol-infrastructure/dockerfiles/ocw/node-hugo


### PR DESCRIPTION
This pipeline checks the `node:14` Docker image on Docker Hub every hour and builds another image of `mitodl/ocw-course-publisher:latest` and uploads it to Docker Hub.

I've tested it in a localhost Concourse installation using credentials passed on the commandline to `fly set-pipeline`. I then set the Docker Hub credential variable names to match the ones that I'm seeing in the `sign-and-verify.yml` pipeline. Should I assume that the `dockerhub.username` and `dockerhub.password` variables will be picked up and filled in automatically if I install this pipeline on our Concourse server?

If that works, then I can put this pipeline on our Concourse so we can try it.

I want to make a subsequent change to alter the name of the docker image. The name `ocw-course-publisher` is not really correct. It is really just Hugo plus Node. After I rename the image, I intend to issue a PR for `ocw-course-hugo-theme` to update [its Dockerfile](https://github.com/mitodl/ocw-course-hugo-theme/blob/888e39659f99e200d2b3079b10d0d33467d4de52/docker/Dockerfile) to inherit this docker image with `FROM mitodl/node-hugo:latest` so that the development image is in sync with what we're using to build the site.
