### PR TITLE
Add pipeline to build our own concourse-rclone-resource

### DIFF
--- a/pipelines/concourse-rclone-docker-image/docker-image-pipeline.yml
+++ b/pipelines/concourse-rclone-docker-image/docker-image-pipeline.yml
@@ -1,0 +1,26 @@
+---
+resources:
+  - name: concourse-rclone-resource
+    type: git
+    source:
+      uri: https://github.com/mitodl/concourse-rclone-resource.git
+      branch: mitodl
+  - name: concourse-rclone-resource-image
+    type: docker-image
+    source:
+      username: ((dockerhub.username))
+      password: ((dockerhub.password))
+      repository: mitodl/concourse-rclone-resource
+      tag: latest
+
+
+jobs:
+  - name: publish
+    public: true
+    serial: true
+    plan:
+      - get: concourse-rclone-resource
+        trigger: true
+      - put: concourse-rclone-resource-image
+        params:
+          build: concourse-rclone-resource


### PR DESCRIPTION
Build our own Docker image for concourse-rclone-resource so that we can use our own fork of the project, which removes a hardcoded argument to 'rclone' that we do not want.
