### PR TITLE
Pipeline for ocw-www homepage

### DIFF
--- a/pipelines/ocw/pipeline-ocw-www.yml
+++ b/pipelines/ocw/pipeline-ocw-www.yml
@@ -14,8 +14,8 @@ resources:
   - name: course-markdown
     type: git
     source:
-      uri: git@((git-domain)):((github-org))/((course-repo)).git
-      branch: ((course-repo-branch))
+      uri: git@((git-domain)):((github-org))/((ocw-www-repo)).git
+      branch: ((ocw-www-repo-branch))
       private_key: ((git-private-key))
   - name: ocw-hugo-projects
     type: git
@@ -64,7 +64,7 @@ jobs:
               tar -xvzf ocw-hugo-themes/ocw-hugo-themes-*.tgz -C ocw-hugo-themes/theme
               cd course-markdown
               export OCW_STUDIO_BASE_URL=((ocw-studio-url))
-              hugo --config ../ocw-hugo-projects/((site-config))/config.yaml --themesDir ../ocw-hugo-themes/theme
+              hugo --config ../ocw-hugo-projects/ocw-www/config.yaml --themesDir ../ocw-hugo-themes/theme
       - put: ocw-site
         params:
           source: course-markdown/public

--- a/pipelines/ocw/pipeline-ocw-www.yml
+++ b/pipelines/ocw/pipeline-ocw-www.yml
@@ -1,0 +1,102 @@
+---
+resource_types:
+  - name: rclone
+    type: docker-image
+    source:
+      repository: mitodl/concourse-rclone-resource
+      tag: latest
+resources:
+  - name: ocw-hugo-themes
+    type: s3
+    source:
+      bucket: ((artifact-bucket))
+      regexp: ocw-hugo-themes/((hugo-theme-branch))/ocw-hugo-themes-(.*).tgz
+  - name: course-markdown
+    type: git
+    source:
+      uri: git@((git-domain)):((github-org))/((course-repo)).git
+      branch: ((course-repo-branch))
+      private_key: ((git-private-key))
+  - name: ocw-hugo-projects
+    type: git
+    source:
+      uri: https://github.com/mitodl/ocw-hugo-projects.git
+      branch: main
+  - name: ocw-site
+    type: rclone
+    source:
+      config: |
+        [s3-remote]
+        type = s3
+        provider = AWS
+        env_auth = true
+        region = us-east-1
+
+jobs:
+  - name: build-ocw-www
+    serial: true
+    plan:
+      - get: ocw-hugo-themes
+        trigger: true
+      - get: ocw-hugo-projects
+        trigger: true
+      - get: course-markdown
+        trigger: true
+      - task: build-ocw-www-task
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source: {repository: mitodl/ocw-course-publisher, tag: latest}
+          inputs:
+            - name: ocw-hugo-themes
+            - name: course-markdown
+            - name: ocw-hugo-projects
+          outputs:
+            - name: course-markdown
+            - name: ocw-hugo-themes
+          run:
+            path: sh
+            args:
+            - -exc
+            - |
+              mkdir ocw-hugo-themes/theme
+              tar -xvzf ocw-hugo-themes/ocw-hugo-themes-*.tgz -C ocw-hugo-themes/theme
+              cd course-markdown
+              export OCW_STUDIO_BASE_URL=((ocw-studio-url))
+              hugo --config ../ocw-hugo-projects/((site-config))/config.yaml --themesDir ../ocw-hugo-themes/theme
+      - put: ocw-site
+        params:
+          source: course-markdown/public
+          destination:
+            - dir: s3-remote:((ocw-bucket))
+              command: copyto
+              args:
+                - --ignore-size
+                - --checksum
+      - put: ocw-site
+        params:
+          source: ocw-hugo-themes/theme/base-theme/dist
+          destination:
+            - dir: s3-remote:((ocw-bucket))
+              command: copyto
+              args:
+                - --ignore-size
+                - --checksum
+      - task: clear-cdn-cache
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source: {repository: curlimages/curl}
+          run:
+            path: curl
+            args:
+              - -f
+              - -X
+              - POST
+              - -H
+              - 'Fastly-Key: ((fastly-api-token))'
+              - -H
+              - 'Fastly-Soft-Purge: 1'
+              - https://api.fastly.com/service/((fastly-service-id))/purge_all

--- a/pipelines/ocw/pipeline-ocw-www.yml
+++ b/pipelines/ocw/pipeline-ocw-www.yml
@@ -21,7 +21,7 @@ resources:
     type: git
     source:
       uri: https://github.com/mitodl/ocw-hugo-projects.git
-      branch: main
+      branch: ((ocw-hugo-projects-branch))
   - name: ocw-site
     type: rclone
     source:

--- a/pipelines/ocw/pipeline-ocw-www.yml
+++ b/pipelines/ocw/pipeline-ocw-www.yml
@@ -10,7 +10,7 @@ resources:
     type: s3
     source:
       bucket: ol-eng-artifacts
-      regexp: ocw-hugo-themes/((hugo-theme-branch))/ocw-hugo-themes-(.*).tgz
+      regexp: ocw-hugo-themes/release/ocw-hugo-themes-(.*).tgz
   - name: course-markdown
     type: git
     source:

--- a/pipelines/ocw/pipeline-ocw-www.yml
+++ b/pipelines/ocw/pipeline-ocw-www.yml
@@ -5,12 +5,23 @@ resource_types:
     source:
       repository: mitodl/concourse-rclone-resource
       tag: latest
+  - name: simple-s3
+    type: docker-image
+    source:
+      repository: 18fgsa/s3-resource-simple
 resources:
   - name: ocw-hugo-themes
     type: s3
     source:
       bucket: ol-eng-artifacts
       regexp: ocw-hugo-themes/release/ocw-hugo-themes-(.*).tgz
+  - name: ocw-studio-s3
+    type: simple-s3
+    source:
+      bucket: ((ocw-studio-bucket))
+      options:
+        - "--exclude '*'"
+        - "--include '((ocw-www-site))/*'"
   - name: course-markdown
     type: git
     source:
@@ -42,6 +53,8 @@ jobs:
         trigger: true
       - get: course-markdown
         trigger: true
+      - get: ocw-studio-s3
+        trigger: false
       - task: build-ocw-www-task
         params:
           OCW_STUDIO_BASE_URL: ((ocw-studio-url))
@@ -78,6 +91,15 @@ jobs:
       - put: ocw-site
         params:
           source: ocw-hugo-themes/theme/base-theme/dist
+          destination:
+            - dir: s3-remote:((ocw-bucket))
+              command: copyto
+              args:
+                - --ignore-size
+                - --checksum
+      - put: ocw-site
+        params:
+          source: ocw-studio-s3
           destination:
             - dir: s3-remote:((ocw-bucket))
               command: copyto

--- a/pipelines/ocw/pipeline-ocw-www.yml
+++ b/pipelines/ocw/pipeline-ocw-www.yml
@@ -9,7 +9,7 @@ resources:
   - name: ocw-hugo-themes
     type: s3
     source:
-      bucket: ((artifact-bucket))
+      bucket: ol-eng-artifacts
       regexp: ocw-hugo-themes/((hugo-theme-branch))/ocw-hugo-themes-(.*).tgz
   - name: course-markdown
     type: git
@@ -43,6 +43,8 @@ jobs:
       - get: course-markdown
         trigger: true
       - task: build-ocw-www-task
+        params:
+          OCW_STUDIO_BASE_URL: ((ocw-studio-url))
         config:
           platform: linux
           image_resource:
@@ -56,14 +58,13 @@ jobs:
             - name: course-markdown
             - name: ocw-hugo-themes
           run:
+            dir: course-markdown
             path: sh
             args:
             - -exc
             - |
-              mkdir ocw-hugo-themes/theme
-              tar -xvzf ocw-hugo-themes/ocw-hugo-themes-*.tgz -C ocw-hugo-themes/theme
-              cd course-markdown
-              export OCW_STUDIO_BASE_URL=((ocw-studio-url))
+              mkdir ../ocw-hugo-themes/theme
+              tar -xvzf ../ocw-hugo-themes/ocw-hugo-themes-*.tgz -C ../ocw-hugo-themes/theme
               hugo --config ../ocw-hugo-projects/ocw-www/config.yaml --themesDir ../ocw-hugo-themes/theme
       - put: ocw-site
         params:

--- a/pipelines/ocw/pipeline-ocw-www.yml
+++ b/pipelines/ocw/pipeline-ocw-www.yml
@@ -109,7 +109,7 @@ jobs:
               - -X
               - POST
               - -H
-              - 'Fastly-Key: ((fastly-api-token))'
+              - 'Fastly-Key: ((fastly.api_token))'
               - -H
               - 'Fastly-Soft-Purge: 1'
-              - https://api.fastly.com/service/((fastly-service-id))/purge_all
+              - https://api.fastly.com/service/((fastly.service_id))/purge_all

--- a/pipelines/ocw/pipeline-ocw-www.yml
+++ b/pipelines/ocw/pipeline-ocw-www.yml
@@ -5,23 +5,12 @@ resource_types:
     source:
       repository: mitodl/concourse-rclone-resource
       tag: latest
-  - name: simple-s3
-    type: docker-image
-    source:
-      repository: 18fgsa/s3-resource-simple
 resources:
   - name: ocw-hugo-themes
     type: s3
     source:
       bucket: ol-eng-artifacts
       regexp: ocw-hugo-themes/release/ocw-hugo-themes-(.*).tgz
-  - name: ocw-studio-s3
-    type: simple-s3
-    source:
-      bucket: ((ocw-studio-bucket))
-      options:
-        - "--exclude '*'"
-        - "--include '((ocw-www-site))/*'"
   - name: course-markdown
     type: git
     source:
@@ -53,8 +42,6 @@ jobs:
         trigger: true
       - get: course-markdown
         trigger: true
-      - get: ocw-studio-s3
-        trigger: false
       - task: build-ocw-www-task
         params:
           OCW_STUDIO_BASE_URL: ((ocw-studio-url))
@@ -79,6 +66,18 @@ jobs:
               mkdir ../ocw-hugo-themes/theme
               tar -xvzf ../ocw-hugo-themes/ocw-hugo-themes-*.tgz -C ../ocw-hugo-themes/theme
               hugo --config ../ocw-hugo-projects/ocw-www/config.yaml --themesDir ../ocw-hugo-themes/theme
+      - task: copy-s3-buckets
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source: {repository: amazon/aws-cli, tag: latest}
+          run:
+            path: sh
+            args:
+            - -exc
+            - |
+              aws s3 sync s3://((ocw-studio-bucket)) s3://((ocw-bucket)) --exclude '*' --include '((ocw-www-site))/*'
       - put: ocw-site
         params:
           source: course-markdown/public
@@ -91,15 +90,6 @@ jobs:
       - put: ocw-site
         params:
           source: ocw-hugo-themes/theme/base-theme/dist
-          destination:
-            - dir: s3-remote:((ocw-bucket))
-              command: copyto
-              args:
-                - --ignore-size
-                - --checksum
-      - put: ocw-site
-        params:
-          source: ocw-studio-s3
           destination:
             - dir: s3-remote:((ocw-bucket))
               command: copyto

--- a/pipelines/ocw/pipeline-theme-assets.yml
+++ b/pipelines/ocw/pipeline-theme-assets.yml
@@ -50,7 +50,7 @@ jobs:
         params:
           source: ocw-hugo-themes/dist/
           destination:
-            - dir: s3-remote:((artifact-bucket))
+            - dir: s3-remote:ol-eng-artifacts
               command: sync
               args:
                 - --ignore-size

--- a/pipelines/ocw/scripts/pipeline-ocw-www.sh
+++ b/pipelines/ocw/scripts/pipeline-ocw-www.sh
@@ -26,19 +26,20 @@ do
   if [[ $branch == "preview" ]]
   then
     OCW_CONTENT_BUCKET=$OCW_CONTENT_BUCKET_PREVIEW
+    VERSION="draft"
   elif [[ $branch == "release" ]]
   then
     OCW_CONTENT_BUCKET=$OCW_CONTENT_BUCKET_RELEASE
+    VERSION="live"
   else
     echo "Invalid branch $1"
     exit 1
   fi
 
   yes | fly -t odl-concourse set-pipeline \
-  -p ocw-www-pipeline-via-vault \
+  -p ocw-www-pipeline-$VERSION \
   --team=ocw \
   --config=pipelines/ocw/pipeline-ocw-www.yml \
-  --instance-var branch=$branch \
   -v git-domain=$GITHUB_DOMAIN \
   -v github-org=$GIT_CONFIG_ORG \
   -v ocw-www-repo=$OCW_WWW_REPO \

--- a/pipelines/ocw/scripts/pipeline-ocw-www.sh
+++ b/pipelines/ocw/scripts/pipeline-ocw-www.sh
@@ -37,9 +37,10 @@ do
   fi
 
   yes | fly -t odl-concourse set-pipeline \
-  -p ocw-www-pipeline-$VERSION \
+  -p $VERSION \
   --team=ocw \
   --config=pipelines/ocw/pipeline-ocw-www.yml \
+  --instance-var site=$OCW_STUDIO_SITE \
   -v git-domain=$GITHUB_DOMAIN \
   -v github-org=$GIT_CONFIG_ORG \
   -v ocw-www-repo=$OCW_WWW_REPO \

--- a/pipelines/ocw/scripts/pipeline-ocw-www.sh
+++ b/pipelines/ocw/scripts/pipeline-ocw-www.sh
@@ -9,6 +9,7 @@
 # OCW_CONTENT_BUCKET_PREVIEW=<the S3 preview bucket>
 # OCW_CONTENT_BUCKET_RELEASE=<the S3 release bucket>
 # OCW_STUDIO_BASE_URL=<the ocw-studio base url>
+# OCW_HUGO_PROJECTS_BRANCH=<'release-candidate' on RC, 'release' on production>
 
 # The following need to be set via vault, per environment and pipeline group (preview, release):
 # fastly-service-id
@@ -41,5 +42,6 @@ do
   -v ocw-www-repo=$OCW_WWW_REPO \
   -v ocw-www-repo-branch=$branch \
   -v ocw-bucket=$OCW_CONTENT_BUCKET \
-  -v ocw-studio-url=$OCW_STUDIO_BASE_URL
+  -v ocw-studio-url=$OCW_STUDIO_BASE_URL \
+  -v ocw-hugo-projects-branch=$OCW_HUGO_PROJECTS_BRANCH
 done

--- a/pipelines/ocw/scripts/pipeline-ocw-www.sh
+++ b/pipelines/ocw/scripts/pipeline-ocw-www.sh
@@ -18,9 +18,8 @@ fi
 
 yes | fly -t $FLY_TARGET set-pipeline \
 -p ocw-www-pipeline-$SITE_BRANCH \
---team=$FLY_TEAM \
+--team=ocw \
 --config=pipelines/ocw/pipeline-ocw-www.yml \
--v artifact-bucket=$ARTIFACT_BUCKET \
 -v git-domain=$GITHUB_DOMAIN \
 -v github-org=$GIT_CONFIG_ORG \
 -v hugo-theme-branch=$HUGO_THEME_BRANCH \

--- a/pipelines/ocw/scripts/pipeline-ocw-www.sh
+++ b/pipelines/ocw/scripts/pipeline-ocw-www.sh
@@ -1,32 +1,45 @@
 #!/bin/bash
 
-SITE_BRANCH=$1  # Should be "preview" or "release"
-if [[ $SITE_BRANCH == "preview" ]]
-then
-  FASTLY_SERVICE_ID=$FASTLY_SERVICE_ID_PREVIEW
-  FASTLY_API_TOKEN=$FASTLY_API_TOKEN_PREVIEW
-  OCW_CONTENT_BUCKET=$OCW_CONTENT_BUCKET_PREVIEW
-elif [[ $SITE_BRANCH == "release" ]]
-then
-  FASTLY_SERVICE_ID=$FASTLY_SERVICE_ID_RELEASE
-  FASTLY_API_TOKEN=$FASTLY_API_TOKEN_RELEASE
-  OCW_CONTENT_BUCKET=$OCW_CONTENT_BUCKET_RELEASE
-else
-  echo "Invalid branch $1"
-  exit 1
-fi
+# This script requires prior authentication via target "odl-concourse"
 
-yes | fly -t $FLY_TARGET set-pipeline \
--p ocw-www-pipeline-$SITE_BRANCH \
---team=ocw \
---config=pipelines/ocw/pipeline-ocw-www.yml \
--v git-domain=$GITHUB_DOMAIN \
--v github-org=$GIT_CONFIG_ORG \
--v hugo-theme-branch=$HUGO_THEME_BRANCH \
--v ocw-www-repo=$OCW_WWW_REPO \
--v ocw-www-repo-branch=$SITE_BRANCH \
--v ocw-bucket=$OCW_CONTENT_BUCKET \
--v ocw-studio-url=$OCW_STUDIO_BASE_URL \
--v fastly-service-id=$FASTLY_SERVICE_ID \
--v fastly-api-token=$FASTLY_API_TOKEN \
--v git-private-key="$GIT_PRIVATE_KEY"
+# The following variables need to be set, and will be different between RC and production:
+# GIT_CONFIG_ORG=<the github organization>
+# GITHUB_DOMAIN=<the github domain>
+# OCW_WWW_REPO=<the github repo for the ocw-www site>
+# OCW_CONTENT_BUCKET_PREVIEW=<the S3 preview bucket>
+# OCW_CONTENT_BUCKET_RELEASE=<the S3 release bucket>
+# OCW_STUDIO_BASE_URL=<the ocw-studio base url>
+
+# The following need to be set via vault, per environment and pipeline group (preview, release):
+# fastly-service-id
+# fastly-api-token
+# git-private-key
+
+
+BRANCHES=("preview" "release")
+
+for branch in "${BRANCHES[@]}"
+do
+  if [[ $branch == "preview" ]]
+  then
+    OCW_CONTENT_BUCKET=$OCW_CONTENT_BUCKET_PREVIEW
+  elif [[ $branch == "release" ]]
+  then
+    OCW_CONTENT_BUCKET=$OCW_CONTENT_BUCKET_RELEASE
+  else
+    echo "Invalid branch $1"
+    exit 1
+  fi
+
+  yes | fly -t odl-concourse set-pipeline \
+  -p ocw-www-pipeline-via-vault \
+  --team=ocw \
+  --config=pipelines/ocw/pipeline-ocw-www.yml \
+  --instance-var branch=$branch \
+  -v git-domain=$GITHUB_DOMAIN \
+  -v github-org=$GIT_CONFIG_ORG \
+  -v ocw-www-repo=$OCW_WWW_REPO \
+  -v ocw-www-repo-branch=$branch \
+  -v ocw-bucket=$OCW_CONTENT_BUCKET \
+  -v ocw-studio-url=$OCW_STUDIO_BASE_URL
+done

--- a/pipelines/ocw/scripts/pipeline-ocw-www.sh
+++ b/pipelines/ocw/scripts/pipeline-ocw-www.sh
@@ -9,6 +9,8 @@
 # OCW_CONTENT_BUCKET_PREVIEW=<the S3 preview bucket>
 # OCW_CONTENT_BUCKET_RELEASE=<the S3 release bucket>
 # OCW_STUDIO_BASE_URL=<the ocw-studio base url>
+# OCW_STUDIO_BUCKET=<The S3 bucket used by ocw-studio>
+# OCW_STUDIO_SITE=<The ocw-www website name (ie slug) in studio>
 # OCW_HUGO_PROJECTS_BRANCH=<'release-candidate' on RC, 'release' on production>
 
 # The following need to be set via vault, per environment and pipeline group (preview, release):
@@ -42,6 +44,8 @@ do
   -v ocw-www-repo=$OCW_WWW_REPO \
   -v ocw-www-repo-branch=$branch \
   -v ocw-bucket=$OCW_CONTENT_BUCKET \
+  -v ocw-hugo-projects-branch=$OCW_HUGO_PROJECTS_BRANCH \
   -v ocw-studio-url=$OCW_STUDIO_BASE_URL \
-  -v ocw-hugo-projects-branch=$OCW_HUGO_PROJECTS_BRANCH
+  -v ocw-studio-bucket=$OCW_STUDIO_BUCKET \
+  -v ocw-www-site=$OCW_STUDIO_SITE
 done

--- a/pipelines/ocw/scripts/pipeline-ocw-www.sh
+++ b/pipelines/ocw/scripts/pipeline-ocw-www.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+SITE_BRANCH=$1  # Should be "preview" or "release"
+if [[ $SITE_BRANCH == "preview" ]]
+then
+  FASTLY_SERVICE_ID=$FASTLY_SERVICE_ID_PREVIEW
+  FASTLY_API_TOKEN=$FASTLY_API_TOKEN_PREVIEW
+  OCW_CONTENT_BUCKET=$OCW_CONTENT_BUCKET_PREVIEW
+elif [[ $SITE_BRANCH == "release" ]]
+then
+  FASTLY_SERVICE_ID=$FASTLY_SERVICE_ID_RELEASE
+  FASTLY_API_TOKEN=$FASTLY_API_TOKEN_RELEASE
+  OCW_CONTENT_BUCKET=$OCW_CONTENT_BUCKET_RELEASE
+else
+  echo "Invalid branch $1"
+  exit 1
+fi
+
+yes | fly -t $FLY_TARGET set-pipeline \
+-p ocw-www-pipeline-$SITE_BRANCH \
+--team=$FLY_TEAM \
+--config=pipelines/ocw/pipeline-ocw-www.yml \
+-v artifact-bucket=$ARTIFACT_BUCKET \
+-v git-domain=$GITHUB_DOMAIN \
+-v github-org=$GIT_CONFIG_ORG \
+-v hugo-theme-branch=$HUGO_THEME_BRANCH \
+-v ocw-www-repo=$OCW_WWW_REPO \
+-v ocw-www-repo-branch=$SITE_BRANCH \
+-v ocw-bucket=$OCW_CONTENT_BUCKET \
+-v ocw-studio-url=$OCW_STUDIO_BASE_URL \
+-v fastly-service-id=$FASTLY_SERVICE_ID \
+-v fastly-api-token=$FASTLY_API_TOKEN \
+-v git-private-key="$GIT_PRIVATE_KEY"

--- a/pipelines/ocw/scripts/pipeline-theme-assets.sh
+++ b/pipelines/ocw/scripts/pipeline-theme-assets.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+yes | fly -t $FLY_TARGET set-pipeline \
+-p ocw-theme-assets-$HUGO_THEME_BRANCH \
+--team=$FLY_TEAM \
+--config=pipelines/ocw/pipeline-theme-assets.yml \
+-v hugo-theme-branch=$HUGO_THEME_BRANCH \
+-v artifact-bucket=$ARTIFACT_BUCKET

--- a/pipelines/ocw/scripts/pipeline-theme-assets.sh
+++ b/pipelines/ocw/scripts/pipeline-theme-assets.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 
-yes | fly -t $FLY_TARGET set-pipeline \
--p ocw-theme-assets-$HUGO_THEME_BRANCH \
---team=ocw \
---config=pipelines/ocw/pipeline-theme-assets.yml \
--v hugo-theme-branch=$HUGO_THEME_BRANCH
+# This script requires prior authentication via target "odl-concourse"
+
+BRANCHES=("release" "release-candidate")
+
+for branch in "${BRANCHES[@]}"
+do
+  yes | fly -t odl-concourse set-pipeline \
+  -p ocw-theme-assets \
+  --team=ocw \
+  --config=pipelines/ocw/pipeline-theme-assets.yml \
+  --instance-var branch=$branch \
+  -v hugo-theme-branch=$branch
+done

--- a/pipelines/ocw/scripts/pipeline-theme-assets.sh
+++ b/pipelines/ocw/scripts/pipeline-theme-assets.sh
@@ -2,7 +2,6 @@
 
 yes | fly -t $FLY_TARGET set-pipeline \
 -p ocw-theme-assets-$HUGO_THEME_BRANCH \
---team=$FLY_TEAM \
+--team=ocw \
 --config=pipelines/ocw/pipeline-theme-assets.yml \
--v hugo-theme-branch=$HUGO_THEME_BRANCH \
--v artifact-bucket=$ARTIFACT_BUCKET
+-v hugo-theme-branch=$HUGO_THEME_BRANCH


### PR DESCRIPTION
Related to #196 

Pipeline for previewing/publishing the ocw-www homepage.
Can be tested on the concourse QA site at ../teams/ocw/pipelines/ocw-www-preview-pipeline/jobs/build-ocw-www/

Also added fly bash scripts for creating the pipelines.  To try them, you'll have to set the following env variables:

```
export FLY_TARGET=<your_concourse_target>
export FLY_TEAM=ocw
export ARTIFACT_BUCKET=ol-eng-artifacts
export GIT_CONFIG_ORG=ocw-content-rc
export GITHUB_DOMAIN=<MIT github domain>
export HUGO_THEME_BRANCH=release
export OCW_WWW_REPO=the-ocw-www-rc_2b7b49fc4f784ca293edee4368e35a88
export OCW_CONTENT_BUCKET_PREVIEW=ocw-content-draft-qa
export OCW_CONTENT_BUCKET_RELEASE=<TBD>
export OCW_STUDIO_BASE_URL=<RC or prod base url of ocw-studio>
export FASTLY_SERVICE_ID_PREVIEW=<secret>
export FASTLY_API_TOKEN_PREVIEW=<secret>
export FASTLY_SERVICE_ID_RELEASE=<secret>
export FASTLY_API_TOKEN_RELEASE=<secret>
export GIT_PRIVATE_KEY=<secret>
```

Then you can run:
```
sh pipeline-theme-assets.sh
```

and 
```
sh pipeline-ocw-www.sh preview
```
or
```
sh pipeline-ocw-www.sh release
```