### PR TITLE
Hide the 'country' field for registration

### DIFF
--- a/src/bilder/images/edxapp/templates/common_values.yml
+++ b/src/bilder/images/edxapp/templates/common_values.yml
@@ -414,7 +414,7 @@ PROCTORING_SETTINGS: {}
 REGISTRATION_EXTRA_FIELDS:
     city: hidden
     confirm_email: hidden
-    country: required
+    country: hidden
     gender: optional
     goals: optional
     honor_code: required


### PR DESCRIPTION
This hides the country field so that users can login without being prompted to fill it out.

See https://github.com/mitodl/salt-ops/blob/ab5b7491de4fd5b63a432123b2a0d9f6b4919bb5/pillar/edx/ansible_vars/xpro.sls#L71