### PR TITLE
add MARKETING_SITE_BASE_URL

### DIFF
--- a/src/bilder/images/edxapp/templates/common_values.yml
+++ b/src/bilder/images/edxapp/templates/common_values.yml
@@ -360,6 +360,7 @@ LOGIN_REDIRECT_WHITELIST:  # MODIFIED
   - learning-mfe-qa.mitxonline.mit.edu
 LOG_DIR: /edx/var/log/edx
 MAINTENANCE_BANNER_TEXT: Sample banner message
+MARKETING_SITE_BASE_URL: https://rc.mitxonline.mit.edu/ # ADDED - to support mitxonline-theme
 MEDIA_ROOT: media/  # MODIFIED - with s3 storage backend this is the path within the bucket. No leading / allowed
 MEDIA_URL: /media/
 MICROSITE_CONFIGURATION: {}


### PR DESCRIPTION
so it's possible to link from the mitxonline-theme to the mitxonline catalog web site.

part of https://github.com/mitodl/mitxonline-theme/issues/4

This setting may also be needed by MFEs. 