### PR TITLE
Redirect the user on openedx if they go to /login

### DIFF
--- a/src/bilder/images/edxapp/templates/common_values.yml
+++ b/src/bilder/images/edxapp/templates/common_values.yml
@@ -370,7 +370,7 @@ MEDIA_ROOT: media/  # MODIFIED - with s3 storage backend this is the path within
 MEDIA_URL: /media/
 MICROSITE_CONFIGURATION: {}
 MICROSITE_ROOT_DIR: /edx/app/edxapp/edx-microsite
-MITXPRO_CORE_REDIRECT_ALLOW_RE_LIST: ["^/(admin|auth|login|logout|register|api|oauth2|user_api|heartbeat)", "^/courses/.*/xblock/.*/handler_noauth/outcome_service_handler"]  # ADDED VALUE
+MITXPRO_CORE_REDIRECT_ALLOW_RE_LIST: ["^/(admin|auth|logout|register|api|oauth2|user_api|heartbeat)", "^/courses/.*/xblock/.*/handler_noauth/outcome_service_handler"]  # ADDED VALUE
 MKTG_URLS: {}
 MKTG_URL_LINK_MAP: {}
 MOBILE_STORE_URLS: {}


### PR DESCRIPTION
Fixes #329 

Removes `/login` as a url that is allowed without redirect. `django-oauth-toolkit` appears to redirect to `/login` so when attempting to start an oauth login the user ends up seeing this page when they shouldn't.