### PR TITLE
Changed service role path

### DIFF
--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -140,8 +140,7 @@ ocw_studio_mediaconvert_role = iam.Role(
             },
         }
     ),
-    name=f"ocw-studio-mediaconvert-role-{stack_info.env_suffix}",
-    path="/ol-applications/ocw-studio-role/",
+    name=f"service-role-mediaconvert-ocw-studio-{stack_info.env_suffix}",
     tags=aws_config.tags,
 )
 


### PR DESCRIPTION
Based on [AWS Case ID](https://console.aws.amazon.com/support/home#/case/?displayId=8719817001&language=en) MediaConvert role is expected to have the following format:
`arn:aws:iam::0000000000:role/ROLENAME format`

Any nesting in the role name was leading to a failure in parsing and thus making an anonymous call to S3 which was naturally failing. This changes the role name and removes the path nesting. 