### PR TITLE
Added logo urls for learning MFE

### DIFF
--- a/pipelines/edx/mfe-frontend-app-learning.yml
+++ b/pipelines/edx/mfe-frontend-app-learning.yml
@@ -45,6 +45,10 @@ jobs:
         LMS_BASE_URL: https://courses-qa.mitxonline.mit.edu
         LOGIN_URL: https://courses-qa.mitxonline.mit.edu/login
         LOGOUT_URL: https://courses-qa.mitxonline.mit.edu/logout
+        LOGO_URL: https://raw.githubusercontent.com/mitodl/mitxonline-theme/main/lms/static/images/logo.png
+        LOGO_TRADEMARK_URL: https://raw.githubusercontent.com/mitodl/mitxonline-theme/main/lms/static/images/logo.png
+        LOGO_WHITE_URL: https://raw.githubusercontent.com/mitodl/mitxonline-theme/main/lms/static/images/logo.png
+        FAVICON_URL: https://raw.githubusercontent.com/mitodl/mitxonline-theme/main/lms/static/images/favicon.ico
         MARKETING_SITE_BASE_URL: https://courses-qa.mitxonline.mit.edu
         PUBLIC_PATH: /learn
         REFRESH_ACCESS_TOKEN_ENDPOINT: https://courses-qa.mitxonline.mit.edu/login_refresh


### PR DESCRIPTION
This should address [issue#279 ](https://github.com/mitodl/ol-infrastructure/issues/279)