### PR TITLE
Fixing compilation of theme during AMI build

### DIFF
--- a/src/bilder/components/baseline/steps.py
+++ b/src/bilder/components/baseline/steps.py
@@ -7,20 +7,23 @@ from pyinfra.operations import apt, files, systemd
 
 @deploy("Install baseline requirements")
 def install_baseline_packages(
-    packages: List[str] = None, state=None, host=None, sudo=True
+    packages: List[str] = None,
+    upgrade_system: bool = False,
+    state=None,
+    host=None,
 ):
     apt.packages(
         name="Install baseline packages for Debian based hosts",
         packages=packages or ["curl"],
         update=True,
+        upgrade=upgrade_system,
         state=state,
         host=host,
-        sudo=sudo,
     )
 
 
 @deploy("Reload services on config change")
-def service_configuration_watches(
+def service_configuration_watches(  # noqa: WPS211
     service_name: str,
     watched_files: List[Path],
     onchange_command: Optional[str] = None,

--- a/src/bilder/images/edxapp/deploy.py
+++ b/src/bilder/images/edxapp/deploy.py
@@ -1,14 +1,10 @@
-import os
 import tempfile
 from pathlib import Path
 
 from pyinfra import host
-from pyinfra.operations import files, git, pip, server
+from pyinfra.operations import files, pip
 
-from bilder.components.baseline.steps import (
-    install_baseline_packages,
-    service_configuration_watches,
-)
+from bilder.components.baseline.steps import service_configuration_watches
 from bilder.components.hashicorp.consul.models import (
     Consul,
     ConsulConfig,
@@ -52,6 +48,7 @@ from bilder.components.vector.steps import (
     vector_service,
 )
 from bilder.facts import has_systemd  # noqa: F401
+from bilder.images.edxapp.lib import WEB_NODE_TYPE, node_type
 from bridge.lib.magic_numbers import VAULT_HTTP_PORT
 
 VERSIONS = {  # noqa: WPS407
@@ -60,11 +57,6 @@ VERSIONS = {  # noqa: WPS407
     "consul-template": "0.26.0",
 }
 TEMPLATES_DIRECTORY = Path(__file__).parent.joinpath("templates")
-WEB_NODE_TYPE = "web"
-WORKER_NODE_TYPE = "worker"
-node_type = host.data.node_type or os.environ.get("NODE_TYPE", WEB_NODE_TYPE)
-
-install_baseline_packages()
 
 ###########
 # edX App #
@@ -121,25 +113,6 @@ consul_templates = [
     ),
 ]
 if node_type == WEB_NODE_TYPE:
-    files.directory(
-        name="Ensure themes directory is present",
-        path="/edx/app/edxapp/themes/",
-        user="edxapp",
-        group="edxapp",
-        present=True,
-    )
-    git.repo(
-        name="Load theme repository",
-        src="https://github.com/mitodl/mitxonline-theme",
-        # Using a generic directory to simplify usage across deployments
-        dest="/edx/app/edxapp/themes/edxapp-theme",
-        branch="main",
-        user="edxapp",
-        group="edxapp",
-    )
-    server.shell(
-        name="Compile theme assets", commands=["/edx/bin/edxapp-update-assets"]
-    )
     vector.configuration_templates.update(
         {
             TEMPLATES_DIRECTORY.joinpath("vector", "nginx.yaml"): {},

--- a/src/bilder/images/edxapp/deploy.py
+++ b/src/bilder/images/edxapp/deploy.py
@@ -131,7 +131,8 @@ if node_type == WEB_NODE_TYPE:
     git.repo(
         name="Load theme repository",
         src="https://github.com/mitodl/mitxonline-theme",
-        dest="/edx/app/edxapp/themes/mitxonline-theme",
+        # Using a generic directory to simplify usage across deployments
+        dest="/edx/app/edxapp/themes/edxapp-theme",
         branch="main",
         user="edxapp",
         group="edxapp",

--- a/src/bilder/images/edxapp/files/edxapp_web_playbook.yml
+++ b/src/bilder/images/edxapp/files/edxapp_web_playbook.yml
@@ -6,28 +6,32 @@
   vars:
     serial_count: 1
     CLUSTER_NAME: edxapp
-    EDXAPP_CMS_MAX_REQ: 1000
-    EDXAPP_LMS_MAX_REQ: 1000
-    EDXAPP_LMS_PREVIEW_NGINX_PORT: 80
-    EDXAPP_CMS_NGINX_PORT: 80
-    EDXAPP_LMS_NGINX_PORT: 80
-    EDXAPP_CMS_SSL_NGINX_PORT: 443
-    EDXAPP_LMS_SSL_NGINX_PORT: 443
-    NGINX_ENABLE_SSL: true
-    NGINX_REDIRECT_TO_HTTPS: true
-    NGINX_HTTPS_REDIRECT_STRATEGY: forward_for_proto
-    NGINX_SSL_CERTIFICATE: /tmp/edxapp.cert
-    NGINX_SSL_KEY: /tmp/edxapp.key
-    NGINX_LOG_FORMAT_NAME: app_metrics
     COMMON_CONFIG_NO_LOGGING: false
+    CREATE_SERVICE_WORKER_USERS: false
+    EDXAPP_CMS_MAX_REQ: 1000
+    EDXAPP_CMS_NGINX_PORT: 80
+    EDXAPP_CMS_SSL_NGINX_PORT: 443
+    EDXAPP_COMPREHENSIVE_THEME_DIRS:
+    - /edx/app/edxapp/themes/
+    EDXAPP_DEFAULT_SITE_THEME: edxapp-theme
     # yamllint disable-line rule:line-length
     EDXAPP_EDXAPP_SECRET_KEY: this-is-just-a-temporary-placeholder # pragma: allowlist secret
-    CREATE_SERVICE_WORKER_USERS: false
-    FORUM_USE_TCP: true
+    EDXAPP_ENABLE_COMPREHENSIVE_THEMING: true
+    EDXAPP_LMS_MAX_REQ: 1000
+    EDXAPP_LMS_NGINX_PORT: 80
+    EDXAPP_LMS_PREVIEW_NGINX_PORT: 80
+    EDXAPP_LMS_SSL_NGINX_PORT: 443
     # Set to empty values so that the tests don't fail since we are managing the
     # config file directly
     FORUM_MONGO_HOSTS: []
     forum_services: []
+    FORUM_USE_TCP: true
+    NGINX_ENABLE_SSL: true
+    NGINX_HTTPS_REDIRECT_STRATEGY: forward_for_proto
+    NGINX_LOG_FORMAT_NAME: app_metrics
+    NGINX_REDIRECT_TO_HTTPS: true
+    NGINX_SSL_CERTIFICATE: /tmp/edxapp.cert
+    NGINX_SSL_KEY: /tmp/edxapp.key
   serial: '{{ serial_count }}'
   roles:
   - forum

--- a/src/bilder/images/edxapp/lib.py
+++ b/src/bilder/images/edxapp/lib.py
@@ -1,0 +1,5 @@
+import os
+
+WEB_NODE_TYPE = "web"
+WORKER_NODE_TYPE = "worker"
+node_type = os.environ.get("NODE_TYPE", WEB_NODE_TYPE)

--- a/src/bilder/images/edxapp/packer.pkr.hcl
+++ b/src/bilder/images/edxapp/packer.pkr.hcl
@@ -87,7 +87,7 @@ build {
     ]
     inline = [
       "sleep 15",
-      "pyinfra --sudo --user ${build.User} --port ${build.Port} --key /tmp/packer-${build.ID}.pem ${build.Host} apt.packages packages='[\"git\", \"libmariadbclient-dev\", \"python3-pip\", \"python3-venv\", \"python3-dev\", \"build-essential\"]' upgrade=True update=True"
+      "pyinfra --sudo --user ${build.User} --port ${build.Port} --key /tmp/packer-${build.ID}.pem ${build.Host} ${path.root}/prebuild.py"
     ]
   }
   provisioner "shell" {

--- a/src/bilder/images/edxapp/prebuild.py
+++ b/src/bilder/images/edxapp/prebuild.py
@@ -1,25 +1,36 @@
-from pyinfra.operations import files, git
+from pyinfra.operations import files, git, server
 
 from bilder.components.baseline.steps import install_baseline_packages
 from bilder.images.edxapp.lib import WEB_NODE_TYPE, node_type
 
+EDX_USER = "edxapp"
+
 install_baseline_packages(
     packages=[
+        "build-essential",
         "curl",
         "git",
         "libmariadbclient-dev",
+        "python3-dev",
         "python3-pip",
         "python3-venv",
-        "python3-dev",
-        "build-essential",
+        "python3-wheel",
     ],
     upgrade_system=True,
 )
 
 if node_type == WEB_NODE_TYPE:
+    server.user(
+        name="Proactively create edxapp user for setting permissions on theme repo",
+        user=EDX_USER,
+        present=True,
+        shell="/bin/false",  # noqa: S604
+    )
     files.directory(
         name="Ensure themes directory is present",
         path="/edx/app/edxapp/themes/",
+        user=EDX_USER,
+        group=EDX_USER,
         present=True,
     )
     git.repo(
@@ -28,4 +39,6 @@ if node_type == WEB_NODE_TYPE:
         # Using a generic directory to simplify usage across deployments
         dest="/edx/app/edxapp/themes/edxapp-theme",
         branch="main",
+        user=EDX_USER,
+        group=EDX_USER,
     )

--- a/src/bilder/images/edxapp/prebuild.py
+++ b/src/bilder/images/edxapp/prebuild.py
@@ -1,0 +1,31 @@
+from pyinfra.operations import files, git
+
+from bilder.components.baseline.steps import install_baseline_packages
+from bilder.images.edxapp.lib import WEB_NODE_TYPE, node_type
+
+install_baseline_packages(
+    packages=[
+        "curl",
+        "git",
+        "libmariadbclient-dev",
+        "python3-pip",
+        "python3-venv",
+        "python3-dev",
+        "build-essential",
+    ],
+    upgrade_system=True,
+)
+
+if node_type == WEB_NODE_TYPE:
+    files.directory(
+        name="Ensure themes directory is present",
+        path="/edx/app/edxapp/themes/",
+        present=True,
+    )
+    git.repo(
+        name="Load theme repository",
+        src="https://github.com/mitodl/mitxonline-theme",
+        # Using a generic directory to simplify usage across deployments
+        dest="/edx/app/edxapp/themes/edxapp-theme",
+        branch="main",
+    )

--- a/src/bilder/images/edxapp/templates/common_values.yml
+++ b/src/bilder/images/edxapp/templates/common_values.yml
@@ -223,7 +223,7 @@ DEFAULT_FEEDBACK_EMAIL: support@mitxonline.mit.edu # MODIFIED
 DEFAULT_FILE_STORAGE: storages.backends.s3boto.S3BotoStorage  # MODIFIED
 DEFAULT_FROM_EMAIL: mitxonline-support@mit.edu # MODIFIED
 DEFAULT_MOBILE_AVAILABLE: false
-DEFAULT_SITE_THEME: mitxonline-theme  # MODIFIED
+DEFAULT_SITE_THEME: edxapp-theme  # MODIFIED - Using a generic name to simplify usage across deployments
 DEPRECATED_ADVANCED_COMPONENT_TYPES: []
 DJFS:
     directory_root: /edx/var/edxapp/django-pyfs/static/django-pyfs


### PR DESCRIPTION
The theme wasn't being compiled fully during the AMI build because the configuration necessary to point the update-assets script at the right location isn't getting loaded until the instance is launched. This adds the necessary Ansible values to the playbook file so that the minimal necessary config is in place at build/compilation time.