### PR TITLE
Adding Vector and Concourse configurations to ship metrics to Cloudwatch

### DIFF
--- a/src/bilder/components/concourse/models.py
+++ b/src/bilder/components/concourse/models.py
@@ -1,8 +1,9 @@
 import secrets
 from enum import Enum
 from functools import partial
+from ipaddress import IPv4Address, IPv6Address
 from pathlib import Path
-from typing import Dict, Generator, List, Optional
+from typing import Dict, Generator, List, Optional, Union
 
 from pydantic import Field, PositiveInt, SecretStr, validator
 
@@ -1003,12 +1004,12 @@ class ConcourseWebConfig(ConcourseBaseConfig):
         concourse_env_var="CONCOURSE_POLICY_CHECK_FILTER_HTTP_METHOD",
         description="API http method to go through policy check",
     )
-    prometheus_bind_ip: Optional[str] = Field(
+    prometheus_bind_ip: Optional[Union[IPv4Address, IPv6Address]] = Field(
         None,
         concourse_env_var="CONCOURSE_PROMETHEUS_BIND_IP",
         description="IP to listen on to expose Prometheus metrics.",
     )
-    prometheus_bind_port: Optional[str] = Field(
+    prometheus_bind_port: Optional[int] = Field(
         None,
         concourse_env_var="CONCOURSE_PROMETHEUS_BIND_PORT",
         description="Port to listen on to expose Prometheus metrics.",
@@ -1673,7 +1674,7 @@ class ConcourseWorkerConfig(ConcourseBaseConfig):
         description="Path to a config file to use for the Garden backend. "
         "e.g. 'foo-bar=a,b' for '--foo-bar a --foo-bar b'.",
     )
-    garden_dns_server: Optiona[str] = Field(
+    garden_dns_server: Optional[str] = Field(
         None,
         concourse_env_var="CONCOURSE_GARDEN_DNS_SERVER",
         description="DNS server IP address to use instead of automatically determined "

--- a/src/bilder/components/vector/steps.py
+++ b/src/bilder/components/vector/steps.py
@@ -41,6 +41,7 @@ def _install_from_package(state=None, host=None):
     files.directory(
         name="Remove example configurations",
         path="/etc/vector/examples/",
+        assume_present=True,
         present=False,
         state=state,
         host=host,
@@ -48,6 +49,7 @@ def _install_from_package(state=None, host=None):
     files.file(
         name="Remove example vector.toml",
         path="/etc/vector/vector.toml",
+        assume_present=True,
         present=False,
         state=state,
         host=host,

--- a/src/bilder/images/concourse/packer.pkr.hcl
+++ b/src/bilder/images/concourse/packer.pkr.hcl
@@ -46,6 +46,12 @@ source "amazon-ebs" "concourse" {
     }
     random = true
   }
+  run_tags = {
+    Name    = "${local.app_name}-${var.node_type}"
+    OU      = "${local.business_unit}"
+    app     = "${local.app_name}"
+    purpose = "${local.app_name}-${var.node_type}"
+  }
   tags = {
     Name    = "${local.app_name}-${var.node_type}"
     OU      = "${local.business_unit}"

--- a/src/bilder/images/concourse/templates/vector.yaml
+++ b/src/bilder/images/concourse/templates/vector.yaml
@@ -1,0 +1,46 @@
+---
+sources:
+  concourse_metrics:
+    type: prometheus_scrape
+    endpoints:
+    - http://localhost:{{ context.concourse_prometheus_port }}/metrics
+    scrape_interval_secs: 10
+
+  concourse_logs:
+    type: journald
+    include_units:
+    - concourse
+
+transforms:
+  concourse_parsed_message:
+    type: remap
+    inputs:
+    - concourse_logs
+    source: |
+      event, err = parse_json(.message)
+      if event != null {
+        . = merge(., event)
+        .@timestamp = .timestamp
+        .labels = ["concourse", "${ENVIRONMENT}"]
+        .environment = "${ENVIRONMENT}"
+      }
+
+  concourse_enriched_logs:
+    type: aws_ec2_metadata
+    inputs:
+    - concourse_parsed_message
+    namespace: ec2
+
+sinks:
+  elasticsearch_logs:
+    type: elasticsearch
+    inputs:
+    - concourse_enriched_logs
+    endpoint: http://logging-elasticsearch.query.consul:9200
+    index: logs-${ENVIRONMENT}-concourse-%Y.%W
+    healthcheck: false
+
+  cloudwatch_metrics:
+    type: cloudwatch_metrics
+    inputs:
+    - concourse_metrics

--- a/src/bridge/lib/magic_numbers.py
+++ b/src/bridge/lib/magic_numbers.py
@@ -5,6 +5,7 @@ This module consists of constants that are used to provide meaningful representa
 integer values used in infrastructure management.
 """
 
+CONCOURSE_PROMETHEUS_EXPORTER_DEFAULT_PORT = 9391
 CONCOURSE_WEB_HOST_COMMUNICATION_PORT = 2222
 CONSUL_DNS_PORT = 8600
 CONSUL_HTTP_PORT = 8500


### PR DESCRIPTION
In order for us to autoscale Concourse worker pools intelligently based on queued jobs we need to be able to populate Cloudwatch with the useful metrics.

- Add Vector install to Concourse
- Add IAM permissions to write metrics to cloudwatch
- Add Vector configuration to read prometheus metrics from Concourse and write to Cloudwatch