### PR TITLE
config: Add support URL to be linked with help button

### DIFF
--- a/pipelines/edx/mfe-frontend-app-learning-production.yml
+++ b/pipelines/edx/mfe-frontend-app-learning-production.yml
@@ -56,6 +56,7 @@ jobs:
         SEARCH_CATALOG_URL: https://courses.mitxonline.mit.edu/courses
         SITE_NAME: MITx Online
         STUDIO_BASE_URL: https://studio.mitxonline.mit.edu
+        SUPPORT_URL: https://mitx-micromasters.zendesk.com/hc/en-us/requests/new
         USER_INFO_COOKIE_NAME: edx-user-info
         SESSION_COOKIE_DOMAIN: .mitxonline.mit.edu
       run:

--- a/pipelines/edx/mfe-frontend-app-learning-qa.yml
+++ b/pipelines/edx/mfe-frontend-app-learning-qa.yml
@@ -56,6 +56,7 @@ jobs:
         SEARCH_CATALOG_URL: https://courses-qa.mitxonline.mit.edu/courses
         SITE_NAME: MITx Online QA
         STUDIO_BASE_URL: https://studio-qa.mitxonline.mit.edu
+        SUPPORT_URL: https://mitx-micromasters.zendesk.com/hc/en-us/requests/new
         USER_INFO_COOKIE_NAME: edx-user-info
         SESSION_COOKIE_DOMAIN: .mitxonline.mit.edu
       run:

--- a/src/bilder/images/edxapp/templates/common_values.yml
+++ b/src/bilder/images/edxapp/templates/common_values.yml
@@ -421,7 +421,7 @@ STATIC_ROOT_BASE: /edx/var/edxapp/staticfiles
 STATIC_URL_BASE: /static/
 STUDIO_NAME: Studio
 STUDIO_SHORT_NAME: Studio
-SUPPORT_SITE_LINK: ''
+SUPPORT_SITE_LINK: https://mitx-micromasters.zendesk.com/hc/en-us/requests/new
 SYSTEM_WIDE_ROLE_CLASSES: []
 TECH_SUPPORT_EMAIL: odl-devops@mit.edu  # MODIFIED
 TIME_ZONE: America/New_York


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/mitxonline/issues/265

### What does this PR do?
- Adds the Zendesk support URL as mentioned in the ticket for both, the MFE and the LMS.

### How to test?
Once the change is successfully deployed you should be able to test the following:

- Visit any LMS page e.g. `/dashboard` in the edx platform and click `Help` You should be taken to the zendesk(https://mitx-micromasters.zendesk.com/hc/en-us/requests/new) page of Micromasters.
- Visit any course within the new learning MFE e.g. on `/learn` and click the `Help` button to the left of the menu on the top right.
