### PR TITLE
Adding CORS rules to allow edxapp to upload files to storage bucket

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -160,6 +160,19 @@ edxapp_storage_bucket = s3.Bucket(
     bucket=storage_bucket_name,
     versioning=s3.BucketVersioningArgs(enabled=True),
     tags=aws_config.tags,
+    cors_rules=[
+        s3.BucketCorsRuleArgs(
+            allowed_headers=["*"],
+            allowed_methods=[
+                "GET",
+                "PUT",
+                "POST",
+            ],
+            allowed_origins=[f"https://{domain}" for domain in edxapp_domains.values()],
+            expose_headers=["ETag"],
+            max_age_seconds=3000,
+        )
+    ],
 )
 
 course_bucket_name = f"{env_name}-edxapp-courses"


### PR DESCRIPTION
Because the upload is happening from a React app in the learner MFE it needs to have CORS headers present from the S3 backend.