### PR TITLE
sync static resources during ocw-to-hugo run

### DIFF
--- a/pipelines/ocw/ocw-to-hugo.yml
+++ b/pipelines/ocw/ocw-to-hugo.yml
@@ -46,13 +46,12 @@ jobs:
       run:
         args:
         - -exc
-        - >
-          yarn install --pure-lockfile
-
-          node . \
-          -i ../ocw-json \
-          -o ../ocw-markdown \
-          --staticPrefix /courses \
+        - >-
+          yarn install --pure-lockfile &&
+          node .
+          -i ../ocw-json
+          -o ../ocw-markdown
+          --staticPrefix /courses
           --strips3
         dir: ocw-to-hugo
         path: sh

--- a/pipelines/ocw/ocw-to-hugo.yml
+++ b/pipelines/ocw/ocw-to-hugo.yml
@@ -20,15 +20,15 @@ jobs:
         path: sh
         args:
         - -exc
-        - |-
-          aws s3 sync \
-          s3://((open-learning-course-data-bucket))/ \
-          s3://((ol-ocw-studio-app-bucket))/courses/ \
-          --include '*' \
-          --exclude "extracts/*" \
-          --exclude "*.html" \
-          --exclude "*.html.json" \
-          --exclude "*_master.json" \
+        - >-
+          aws s3 sync
+          s3://((open-learning-course-data-bucket))/
+          s3://((ol-ocw-studio-app-bucket))/courses/
+          --include '*'
+          --exclude "extracts/*"
+          --exclude "*.html"
+          --exclude "*.html.json"
+          --exclude "*_master.json"
           --exclude "*parsed.json"
   - config:
       image_resource:

--- a/pipelines/ocw/ocw-to-hugo.yml
+++ b/pipelines/ocw/ocw-to-hugo.yml
@@ -1,11 +1,35 @@
 ---
 jobs:
 - name: convert-plone-to-hugo
+  serial: true
   plan:
   - get: ocw-to-hugo
     trigger: true
   - get: ocw-json
     trigger: true
+  - task: sync-static-resources-task
+    config:
+      platform: linux
+      image_resource:
+        name: ''
+        source:
+          repository: amazon/aws-cli
+          tag: latest
+        type: docker-image
+      run:
+        path: sh
+        args:
+        - -exc
+        - |-
+          aws s3 sync \
+          s3://((open-learning-course-data-bucket))/ \
+          s3://((ol-ocw-studio-app-bucket))/courses/ \
+          --include '*' \
+          --exclude "extracts/*" \
+          --exclude "*.html" \
+          --exclude "*.html.json" \
+          --exclude "*_master.json" \
+          --exclude "*parsed.json"
   - config:
       image_resource:
         name: ''
@@ -22,9 +46,11 @@ jobs:
       run:
         args:
         - -exc
-        - |
+        - >
           yarn install --pure-lockfile
-          node . -i ../ocw-json -o ../ocw-markdown --staticPrefix /courses --strips3
+
+          node . -i ../ocw-json -o ../ocw-markdown --staticPrefix /courses
+          --strips3
         dir: ocw-to-hugo
         path: sh
     task: convert-json-to-markdown

--- a/pipelines/ocw/ocw-to-hugo.yml
+++ b/pipelines/ocw/ocw-to-hugo.yml
@@ -49,7 +49,10 @@ jobs:
         - >
           yarn install --pure-lockfile
 
-          node . -i ../ocw-json -o ../ocw-markdown --staticPrefix /courses
+          node . \
+          -i ../ocw-json \
+          -o ../ocw-markdown \
+          --staticPrefix /courses \
           --strips3
         dir: ocw-to-hugo
         path: sh

--- a/pipelines/ocw/vars/ocw-to-hugo/prod.yml
+++ b/pipelines/ocw/vars/ocw-to-hugo/prod.yml
@@ -1,0 +1,4 @@
+---
+open-learning-course-data-bucket: open-learning-course-data-production
+ol-ocw-studio-app-bucket: ol-ocw-studio-app-production
+ocw-studio-import-bucket: ocw-to-hugo-output-production

--- a/pipelines/ocw/vars/ocw-to-hugo/rc.yml
+++ b/pipelines/ocw/vars/ocw-to-hugo/rc.yml
@@ -1,0 +1,4 @@
+---
+open-learning-course-data-bucket: open-learning-course-data-rc
+ol-ocw-studio-app-bucket: ol-ocw-studio-app-qa
+ocw-studio-import-bucket: ocw-to-hugo-output-qa


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ol-infrastructure/issues/444

#### What's this PR do?
This PR adds a step to the `ocw-to-hugo.yml` pipeline definition that will sync static resources (pdfs, images, etc.) from a defined `open-learning-course-data-bucket` to an `ol-ocw-studio-app-bucket` as part of the pipeline run, ensuring that these will be in place when the converted courses are eventually published by `ocw-studio`.  Vars for RC and production have been included.

#### How should this be manually tested?
 - Make sure you have a Concourse target locally set up to RC on the `ocw` team.  I named mine `rc`.
 - Upsert the pipeline to Concourse RC with ` fly -t rc set-pipeline --pipeline ocw-to-hugo-rc --config pipelines/ocw/ocw-to-hugo.yml --load-vars-from pipelines/ocw/vars/ocw-to-hugo/rc.yml`
 - Run the pipeline and ensure it completes successfully without error