### PR TITLE
add s3:CopyObject permission to OCW IAM profile

### DIFF
--- a/src/ol_infrastructure/applications/concourse/__main__.py
+++ b/src/ol_infrastructure/applications/concourse/__main__.py
@@ -114,7 +114,7 @@ concourse_iam_permissions = {
         },
         {
             "Effect": "Allow",
-            "Action": ["s3:GetObject*", "s3:ListBucket"],
+            "Action": ["s3:GetObject*", "s3:ListBucket", "s3:CopyObject"],
             "Resource": [
                 "arn:aws:s3:::ol-ocw-studio-app*",
                 "arn:aws:s3:::ol-ocw-studio-app*/*",


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://github.com/mitodl/ol-infrastructure/issues/458

#### What's this PR do?
In https://github.com/mitodl/ol-infrastructure/pull/445, we added a step to the `ocw-to-hugo` Concourse pipeline that syncs resources from a configured `open-learning-course-data` bucket to the appropriate `ol-ocw-studio-app` bucket, so when these courses are eventually imported all of the static resources are in the right place. This PR adds the `s3:CopyObject` permission to the Concourse IAM profile for OCW S3 buckets which was missed in the original PR and is necessary to avoid permissions errors during the sync step.

#### How should this be manually tested?
Needs to be tested in QA once the new permissions are applied.