### PR TITLE
Added ES policy to edxapp

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -311,6 +311,12 @@ edxapp_policy_document = {
             "Action": ["ses:GetSendQuota"],
             "Resource": "*",
         },
+        {
+            "Effect": "Allow",
+            "Action": ["es:ESHttp*"],
+            "Condition": {"IpAddress": {"aws:SourceIp": [edxapp_vpc["cidr"]]}},
+            "Resource": f"arn:aws:es:::domain/opensearch-{stack_info.env_prefix}-{stack_info.env_suffix}/*",
+        },
     ],
 }
 


### PR DESCRIPTION
This is currently failing when I tried it out with the following error:
```TypeError: Object of type Output is not JSON serializable```

I tried different combinations for rendering `edxapp_vpc["cidr"]` however it was either the error above or it ended up returning an object instead of the IP strings