### PR TITLE
Fix concourse permissions

### DIFF
--- a/src/ol_infrastructure/applications/concourse/__main__.py
+++ b/src/ol_infrastructure/applications/concourse/__main__.py
@@ -100,7 +100,7 @@ concourse_iam_permissions = {
         {
             "Effect": "Allow",
             "Action": [
-                "s3:GetObject",
+                "s3:GetObject*",
                 "s3:PutObject",
                 "s3:DeleteObject",
                 "s3:ListBucket*",

--- a/src/ol_infrastructure/applications/concourse/__main__.py
+++ b/src/ol_infrastructure/applications/concourse/__main__.py
@@ -101,7 +101,7 @@ concourse_iam_permissions = {
             "Effect": "Allow",
             "Action": [
                 "s3:GetObject*",
-                "s3:PutObject",
+                "s3:PutObject*",
                 "s3:DeleteObject",
                 "s3:ListBucket*",
             ],


### PR DESCRIPTION
OCW publishing was failing with error below:
```An error occurred (AccessDenied) when calling the GetObjectTagging operation: Access Denied```

PR adds the necessary permissions