### PR TITLE
Adding stack definitions for QA and production edxapp deployment

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.CI.yaml
@@ -17,6 +17,7 @@ config:
   edxapp:elb_healthcheck_interval: '30'
   edxapp:google_analytics_id: ''
   edxapp:mail_domain: edxapp-mail-staging-ci.mitx.mit.edu
+  edxapp:manage_dns: 'true'
   edxapp:min_web_nodes: '1'
   edxapp:min_worker_nodes: '1'
   edxapp:sender_email_address: support@edxapp-mail-staging-ci.mitx.mit.edu

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.QA.yaml
@@ -1,0 +1,29 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-qa
+encryptedkey: AQICAHijXuVxVlAL6bY9xCOrzO3YYhFlQBPt6jNyJGkhYu+q4QF1vipPwcs5DYUCID6n71sNAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM7MTxzuqtH4h1G7OjAgEQgDs1KFGvvzfEsUH+Ruqvoan4KiobuQwXywYiJnJGq1fYnIhY15awZKIWQ5G7vJke7b6zD4/YwST/BT0YDw==
+config:
+  aws:region: us-east-1
+  consul:address: https://consul-mitx-qa.odl.mit.edu
+  edxapp:business_unit: residential-staging
+  edxapp:db_password:
+    secure: v1:trksER57bitzZxTJ:KCl9E7b1N9vfaNk0V4fJ2AmmXt5fCy6SQiZyqV8ULFkfUDChMD/Js2K50mlQMfN1kkRSnJtYSr4=
+  edxapp:dns_zone: mitx
+  edxapp:domains:
+    lms: mitx-qa-draft.mitx.mit.edu
+    preview: preview-mitx-qa-draft.mitx.mit.edu
+    studio: studio-mitx-qa-draft.mitx.mit.edu
+  edxapp:edx_forum_secrets:
+    secure: v1:KMWZXKBsEvC8Uaue:1Q6pU2/TB/Y6yzu1f/tjCSeA0Qmy7csbV5JxlbhyB0CBlE3fO6+hJJEnzeKJxmNIlpPMUtptddiQsgV4wl2XEFIvDAEflMWjqV51VGA=
+  edxapp:elb_healthcheck_interval: '30'
+  edxapp:google_analytics_id: ''
+  edxapp:mail_domain: edxapp-mail-staging-qa.mitx.mit.edu
+  edxapp:manage_dns: 'false'
+  edxapp:min_web_nodes: '1'
+  edxapp:min_worker_nodes: '1'
+  edxapp:sender_email_address: support@edxapp-mail-staging-qa.mitx.mit.edu
+  edxapp:target_vpc: residential_mitx_staging_vpc
+  edxapp:web_node_capacity: '1'
+  edxapp:worker_node_capacity: '1'
+  mongodb:atlas_project_id: 61a8fc35438c21331e5773f6
+  vault:address: https://vault-qa.odl.mit.edu
+  vault_server:env_namespace: operations.qa

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.CI.yaml
@@ -1,3 +1,4 @@
+---
 secretsprovider: awskms://alias/infrastructure-secrets-ci
 encryptedkey: AQICAHjs8ajWpT7YRhWXwI//wPkHX53RHlo0DjkgQOwCBTUBwQFx9m+5C+NdLferEI0btCZKAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMyumhy7Iitmb+QbeVAgEQgDsWf6EA6MbapG+Oj/VU4e+E9bMhpzXOObyHByUDT1VBvg7Jmgo8YHS+Ca8R+wG9nNzizvISO2S9V8SlLg==
 config:
@@ -13,15 +14,16 @@ config:
     studio: studio-ci.mitx.mit.edu
   edxapp:edx_forum_secrets:
     secure: v1:Cv6WRoXTzc4X0Mt/:JfUayMiJ3oXbRcmhCWfCLJqVvMAx3c8M0z4e5fXVj9L2fLMHfRVUhhQEn1O5lrbwnewNkzGIci1ArchaMiC9BpbVRYqfihQhT5/KH2UkaoVS6kvbgbL/M489Wa7AYpLxK47F/BPaBGLGkIZMesuo
-  edxapp:elb_healthcheck_interval: "30"
-  edxapp:google_analytics_id: ""
+  edxapp:elb_healthcheck_interval: '30'
+  edxapp:google_analytics_id: ''
   edxapp:mail_domain: edxapp-mail-ci.mitx.mit.edu
-  edxapp:min_web_nodes: "1"
-  edxapp:min_worker_nodes: "1"
+  edxapp:manage_dns: 'true'
+  edxapp:min_web_nodes: '1'
+  edxapp:min_worker_nodes: '1'
   edxapp:sender_email_address: support@edxapp-mail-ci.mitx.mit.edu
   edxapp:target_vpc: residential_mitx_vpc
-  edxapp:web_node_capacity: "1"
-  edxapp:worker_node_capacity: "1"
+  edxapp:web_node_capacity: '1'
+  edxapp:worker_node_capacity: '1'
   mongodb:atlas_project_id: 617858f961f3016e0ade73e7
   vault:address: https://vault-ci.odl.mit.edu
   vault_server:env_namespace: operations.ci

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.QA.yaml
@@ -1,0 +1,29 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-qa
+encryptedkey: AQICAHijXuVxVlAL6bY9xCOrzO3YYhFlQBPt6jNyJGkhYu+q4QHu2G/FW4u/U5Mp8aTRLJeWAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMdB8kGMGowYQAC3ApAgEQgDt0MEeCrQrnWpiTFSBChBGs/9oayfWkynSljhyzjHpEKhj6+Km58XIEXGNAweJWGzLEXfQ188zRq/+8IQ==
+config:
+  aws:region: us-east-1
+  consul:address: https://consul-mitx-qa.odl.mit.edu
+  edxapp:business_unit: residential
+  edxapp:db_password:
+    secure: v1:xglzNDR1j+CDTk3s:4TyRALK3e/ncPRhuFTUQQqRBSTwyrCWWcTn/Y6G9XjG+ms/biXjoKbleFdMo0omPC83nGiI5mBc=
+  edxapp:dns_zone: mitx
+  edxapp:domains:
+    lms: mitx-qa.mitx.mit.edu
+    preview: preview-mitx-qa.mitx.mit.edu
+    studio: studio-mitx-qa.mitx.mit.edu
+  edxapp:edx_forum_secrets:
+    secure: v1:0/vZ/fZAoI9JRgrT:spK/nul4YYGNS+fn3dgRpOewZPmN5X6esiAJaJqgRY4CTjLrjSBC6VMZsXjJoDCIgVSAOoY3ClPFge6kYy02EAJMORtlHhuuBxxl2wY=
+  edxapp:elb_healthcheck_interval: '30'
+  edxapp:google_analytics_id: ''
+  edxapp:mail_domain: edxapp-mail-qa.mitx.mit.edu
+  edxapp:manage_dns: 'false'
+  edxapp:min_web_nodes: '1'
+  edxapp:min_worker_nodes: '1'
+  edxapp:sender_email_address: support@edxapp-mail-qa.mitx.mit.edu
+  edxapp:target_vpc: residential_mitx_vpc
+  edxapp:web_node_capacity: '2'
+  edxapp:worker_node_capacity: '1'
+  mongodb:atlas_project_id: 61a8f2d2c263e144f50f13b4
+  vault:address: https://vault-qa.odl.mit.edu
+  vault_server:env_namespace: operations.qa

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.CI.yaml
@@ -28,3 +28,4 @@ config:
   edxapp:web_node_capacity: '1'
   edxapp:min_worker_nodes: '1'
   edxapp:worker_node_capacity: '1'
+  edxapp:manage_dns: true

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
@@ -24,3 +24,4 @@ config:
   edxapp:sender_email_address: mitxonline-support@mit.edu
   edxapp:web_node_capacity: '6'
   edxapp:worker_node_capacity: '3'
+  edxapp:manage_dns: true

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
@@ -1,3 +1,4 @@
+---
 secretsprovider: awskms://alias/infrastructure-secrets-qa
 encryptedkey: AQICAHijXuVxVlAL6bY9xCOrzO3YYhFlQBPt6jNyJGkhYu+q4QGxrnJ+jhHLuJokM5S8zndOAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMo53bqUNDbCTvBcF/AgEQgDsAe8gB0NwcmYHRW5FQhRokmUaBcfKWMa0mocOIQnaLrZ/jjXsfgIuGFd3cnQeytgce4vOEMB7zR27yvQ==
 config:
@@ -16,7 +17,7 @@ config:
     studio: studio-qa.mitxonline.mit.edu
   edxapp:edx_forum_secrets:
     secure: v1:IqXRArQveCV+9lkE:cRaraFuN2dDmI29PD4QifOU7MrRFdszOoaUb7o3pDJordt4TSjw8fIxldWfMzNhZRLC+NS291DorO1IuN6ASdCbt5d53aMvHVt+3hA6wyuI11OFjk7U=
-  edxapp:elb_healthcheck_interval: "30"
+  edxapp:elb_healthcheck_interval: '30'
   edxapp:google_analytics_id: UA-5145472-46
   edxapp:mail_domain: edxapp-mail-qa.mitxonline.mit.edu
   edxapp:sender_email_address: support@edxapp-mail-qa.mitxonline.mit.edu
@@ -24,3 +25,4 @@ config:
     secure: v1:LSQgiUW2n8fzAks9:+ZYckckuLvNozc/WBbKA+Ppjf9pZWoP+OjLlLAunW81jR/3iJnbcn0MJBdAcgNtdTHVKDqu5
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa
+  edxapp:manage_dns: true

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.CI.yaml
@@ -1,3 +1,4 @@
+---
 secretsprovider: awskms://alias/infrastructure-secrets-ci
 encryptedkey: AQICAHjs8ajWpT7YRhWXwI//wPkHX53RHlo0DjkgQOwCBTUBwQEGbYgV2EePyiT5w7gRTcESAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMb2PbdiRcIyCZthwPAgEQgDuscsOYMog2r1o62iQXSB7L5jAcWAHrnq5jnmotuj1OGz7Zz2kefvuXRecCo0OSa8E7qxsR1swcFePXSw==
 config:
@@ -13,14 +14,15 @@ config:
     studio: studio-ci.xpro.mit.edu
   edxapp:edx_forum_secrets:
     secure: v1:QSW6gq7cQ6t65Glo:OGJ5X4YYEi2ZdyrpnML25p10mQrodNNLaF5zyV1242ZcQz1TkRsTdpmv9HghIhgHxykYd2NK7kyRkvphd5pfI56xAg/de/8PuHNuPx5kg3IZCrFktYuE2Nyzjxhg7aGHNhA6JQEf95925WPwAG3V
-  edxapp:elb_healthcheck_interval: "30"
-  edxapp:google_analytics_id: ""
+  edxapp:elb_healthcheck_interval: '30'
+  edxapp:google_analytics_id: ''
   edxapp:mail_domain: edxapp-mail-ci.xpro.mit.edu
-  edxapp:min_web_nodes: "1"
-  edxapp:min_worker_nodes: "1"
+  edxapp:min_web_nodes: '1'
+  edxapp:min_worker_nodes: '1'
   edxapp:sender_email_address: support@edxapp-mail-ci.xpro.mit.edu
-  edxapp:web_node_capacity: "1"
-  edxapp:worker_node_capacity: "1"
+  edxapp:web_node_capacity: '1'
+  edxapp:worker_node_capacity: '1'
   mongodb:atlas_project_id: 619395b5ab3fc40d5942a23c
   vault:address: https://vault-ci.odl.mit.edu
   vault_server:env_namespace: operations.ci
+  edxapp:manage_dns: true

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.QA.yaml
@@ -1,0 +1,28 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-qa
+encryptedkey: AQICAHijXuVxVlAL6bY9xCOrzO3YYhFlQBPt6jNyJGkhYu+q4QHxoDDVZ4kHnQtnulqE8eItAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMeGSsSAPUvuFuK1SwAgEQgDuut7OU4DXxUypEiE2n4yE3EUThzyvZr8ZqEznWZ1yOfVNnOlAt+f2VFaNTRs0c+hRr8Yq+e6OER/sWdA==
+config:
+  aws:region: us-east-1
+  consul:address: https://consul-xpro-qa.odl.mit.edu
+  edxapp:business_unit: mitxpro
+  edxapp:db_password:
+    secure: v1:+Bcw4dSZUPqWY2cL:g/KKgzrmRlgx2SOuOOB4grCveVaNv5mZVuuFrpGgAGwKEussIqUWTBnFJknEdJ4Hjf5Jw/1W560=
+  edxapp:dns_zone: xpro
+  edxapp:domains:
+    lms: courses-rc.xpro.mit.edu
+    preview: preview-rc.xpro.mit.edu
+    studio: studio-rc.xpro.mit.edu
+  edxapp:edx_forum_secrets:
+    secure: v1:Tpg1BEYCoSw2D6HQ:yGnhmeKYzo+EetdiUpY/7VzE9vq+OtX/O02d6ugQwMI3D57r3yvxtsY3u+lRYwr0R2yvvVr/Lhm9xXQ3EfycxNtpOUxviHCFsL5wXLA=
+  edxapp:elb_healthcheck_interval: '30'
+  edxapp:google_analytics_id: ''
+  edxapp:mail_domain: edxapp-mail-qa.xpro.mit.edu
+  edxapp:manage_dns: 'false'
+  edxapp:min_web_nodes: '1'
+  edxapp:min_worker_nodes: '1'
+  edxapp:sender_email_address: support@edxapp-mail-qa.xpro.mit.edu
+  edxapp:web_node_capacity: '1'
+  edxapp:worker_node_capacity: '1'
+  mongodb:atlas_project_id: 61a8f5e33456732be1fbb699
+  vault:address: https://vault-qa.odl.mit.edu
+  vault_server:env_namespace: operations.qa

--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -1261,25 +1261,26 @@ worker_asg = autoscaling.Group(
 )
 
 # Create Route53 DNS records for Edxapp web nodes
-for domain_key, domain_value in edxapp_domains.items():
-    if domain_key == "lms":
-        route53.Record(
-            f"edxapp-web-{domain_key}-dns-record",
-            name=domain_value,
-            type="CNAME",
-            ttl=FIVE_MINUTES,
-            records=["j.sni.global.fastly.net"],
-            zone_id=edxapp_zone_id,
-        )
-    else:
-        route53.Record(
-            f"edxapp-web-{domain_key}-dns-record",
-            name=domain_value,
-            type="CNAME",
-            ttl=FIVE_MINUTES,
-            records=[web_lb.dns_name],
-            zone_id=edxapp_zone_id,
-        )
+if edxapp_config.get_bool("manage_dns"):
+    for domain_key, domain_value in edxapp_domains.items():
+        if domain_key == "lms":
+            route53.Record(
+                f"edxapp-web-{domain_key}-dns-record",
+                name=domain_value,
+                type="CNAME",
+                ttl=FIVE_MINUTES,
+                records=["j.sni.global.fastly.net"],
+                zone_id=edxapp_zone_id,
+            )
+        else:
+            route53.Record(
+                f"edxapp-web-{domain_key}-dns-record",
+                name=domain_value,
+                type="CNAME",
+                ttl=FIVE_MINUTES,
+                records=[web_lb.dns_name],
+                zone_id=edxapp_zone_id,
+            )
 
 
 export(

--- a/src/ol_infrastructure/components/aws/cache.py
+++ b/src/ol_infrastructure/components/aws/cache.py
@@ -60,7 +60,7 @@ class OLAmazonCacheConfig(AWSBase):
         engine_version: str,
         values: Dict,  # noqa: WPS110
     ) -> str:
-        engine: str = values.get("engine")
+        engine: str = str(values.get("engine"))
         engines_map = cache_engines()
         if engine_version not in engines_map.get(engine, []):
             raise ValueError(
@@ -175,7 +175,9 @@ class OLAmazonCache(pulumi.ComponentResource):
 
         self.parameter_group = elasticache.ParameterGroup(
             f"{cache_config.cluster_name}-{cache_config.engine}-{cache_config.engine_version}-parameter-group",  # noqa: E501
-            name=(f"{cache_config.cluster_name}-{cache_config.engine_version.replace('.', '')}-parameter-group"),  # noqa: E501
+            name=(
+                f"{cache_config.cluster_name}-{cache_config.engine_version.replace('.', '')}-parameter-group"  # noqa: E501, WPS237
+            ),  # noqa: E501
             family=parameter_group_family(
                 cache_config.engine, cache_config.engine_version
             ),
@@ -234,7 +236,9 @@ class OLAmazonCache(pulumi.ComponentResource):
             automatic_failover_enabled=True,
             cluster_mode=cluster_mode_param,
             engine="redis",
-            engine_version=cache_config.engine_version,
+            engine_version="6.x"
+            if cache_config.engine_version.startswith("6")
+            else cache_config.engine_version,
             kms_key_id=cache_config.kms_key_id,
             node_type=cache_config.instance_type,
             number_cache_clusters=cache_node_count,

--- a/src/ol_infrastructure/infrastructure/aws/network/Pulumi.infrastructure.aws.network.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/network/Pulumi.infrastructure.aws.network.Production.yaml
@@ -8,7 +8,7 @@ config:
   mitx_online_vpc:cidr_block: 10.22.0.0/16
   operations_vpc:cidr_block: 10.0.0.0/16
   operations_vpc:name: operations
-  residential_vpc:cidr_block: 10.7.0.0/16
   residential_staging_vpc:cidr_block: 10.31.0.0/16
+  residential_vpc:cidr_block: 10.7.0.0/16
   xpro_vpc:cidr_block: 10.8.0.0/16
   xpro_vpc:name: mitxpro-production

--- a/src/ol_infrastructure/infrastructure/aws/network/Pulumi.infrastructure.aws.network.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/network/Pulumi.infrastructure.aws.network.QA.yaml
@@ -9,6 +9,6 @@ config:
   ocw_vpc:cidr_block: 10.99.0.0/16
   operations_vpc:cidr_block: 10.1.0.0/16
   operations_vpc:name: operations-qa
-  residential_vpc:cidr_block: 10.5.0.0/16
   residential_staging_vpc:cidr_block: 10.30.0.0/16
+  residential_vpc:cidr_block: 10.5.0.0/16
   xpro_vpc:cidr_block: 10.6.0.0/16

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitx-staging.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitx-staging.Production.yaml
@@ -1,0 +1,9 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-production
+encryptedkey: AQICAHgQalNS7T35ZlcFdhF0QuKeiJAbXMUbm01pjGwHEsjRCgGRxHJk4xj649uZw8TWwLaLAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMZx1529xtlcUlsI8dAgEQgDsdC6gITieimk8Ts316IQviDpDu1PzluylxQ8EkYxWP2QCuU8fMn196rHQz0gqI2RC6SgMTpU9Dbor+Qg==
+config:
+  aws:region: us-east-1
+  consul:address: https://consul-mitx-staging-production.odl.mit.edu
+  consul:scheme: https
+  environment:business_unit: residential-staging
+  environment:target_vpc: residential_mitx_staging_vpc

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitx-staging.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitx-staging.QA.yaml
@@ -1,0 +1,9 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-qa
+encryptedkey: AQICAHijXuVxVlAL6bY9xCOrzO3YYhFlQBPt6jNyJGkhYu+q4QGsHG7KqITsfxkrb5K4spKNAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMvORgiuzy360jw+FUAgEQgDsTWk8PPseIjeZoB5CCpfF/OBjpowYI3BZYEo5mBxbjIVW6OCLaj4IhH/oNmo4AJHWHdjdsOc/T4Eljfg==
+config:
+  aws:region: us-east-1
+  consul:address: https://consul-mitx-staging-qa.odl.mit.edu
+  consul:scheme: https
+  environment:business_unit: residential-staging
+  environment:target_vpc: residential_mitx_staging_vpc

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitx.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitx.CI.yaml
@@ -1,3 +1,4 @@
+---
 secretsprovider: awskms://alias/infrastructure-secrets-ci
 encryptedkey: AQICAHjs8ajWpT7YRhWXwI//wPkHX53RHlo0DjkgQOwCBTUBwQFnF3VtI0sUWurNkTzq6JKzAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMNJeKKNEx8nOGv805AgEQgDvKAEG3LSFe5m7ULan9loh0ha2vZQFYSbWm6vzIpThtK2TD5MEOKe96E5ilp75PiK/Kq5ksGOJTqb03nQ==
 config:
@@ -6,5 +7,3 @@ config:
   consul:scheme: https
   environment:business_unit: residential
   environment:target_vpc: residential_mitx_vpc
-  consul:address: https://consul-mitx-ci.odl.mit.edu
-  consul:scheme: https

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitx.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitx.Production.yaml
@@ -1,0 +1,9 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-production
+encryptedkey: AQICAHgQalNS7T35ZlcFdhF0QuKeiJAbXMUbm01pjGwHEsjRCgHpUG+YJaLuKDx49I9RPgcoAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMBi/tRU9MqCr+c6lkAgEQgDtudjA9P++osUQOPuvIAokgLBfbQOOmqNi1R9469QplE8bq6wuxXXNoxVMcorvbiSWCWO4TAtqRn1lyhQ==
+config:
+  aws:region: us-east-1
+  consul:address: https://consul-mitx-production.odl.mit.edu
+  consul:scheme: https
+  environment:business_unit: residential
+  environment:target_vpc: residential_mitx_vpc

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitx.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitx.QA.yaml
@@ -1,0 +1,9 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-qa
+encryptedkey: AQICAHijXuVxVlAL6bY9xCOrzO3YYhFlQBPt6jNyJGkhYu+q4QHDxAJYbPVh3rqYtFhzPTZJAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM5G+7DUS2BD9NxHxeAgEQgDtmQUfuyn8ZR3aRMXgahZZajbWYZ+mmIb1GQAntCOEXEHKkYmBLmHKKhgTzi4+osa6Cye2NdbN+Tz443w==
+config:
+  aws:region: us-east-1
+  consul:address: https://consul-mitx-qa.odl.mit.edu
+  consul:scheme: https
+  environment:business_unit: residential
+  environment:target_vpc: residential_mitx_vpc

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitxonline.Production.yaml
@@ -1,0 +1,9 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-production
+encryptedkey: AQICAHgQalNS7T35ZlcFdhF0QuKeiJAbXMUbm01pjGwHEsjRCgGpRBmG/Po/eu5M6Zr8pUxsAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMoiPUhXEdwEncC9gqAgEQgDskeYuDomotB5kPQt2cl/z5ch1R/3hi84k8MczVf811gsoBsoD0uEAugXqcpuiCGb5RsSZsQ5DJ30RhIA==
+config:
+  aws:region: us-east-1
+  consul:address: https://consul-mitxonline-production.odl.mit.edu
+  consul:scheme: https
+  environment:business_unit: mitxonline
+  environment:target_vpc: mitxonline_vpc

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitxonline.QA.yaml
@@ -1,0 +1,9 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-qa
+encryptedkey: AQICAHijXuVxVlAL6bY9xCOrzO3YYhFlQBPt6jNyJGkhYu+q4QGQhYOrNjE2pqNXr2GiIy/+AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQME2Bnvb8fGK/02N3IAgEQgDtElDkqUNXXGNiO+wxdiS1dy04QfjnKVdAAmdaQZ5fSkM5TX9/2LlPS6bgxW/qCQCkgG4Ek2Rk1xM4mIg==
+config:
+  aws:region: us-east-1
+  consul:address: https://consul-mitxonline-qa.odl.mit.edu
+  consul:scheme: https
+  environment:business_unit: mitxonline
+  environment:target_vpc: mitxonline_vpc

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.xpro.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.xpro.Production.yaml
@@ -1,0 +1,9 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-production
+encryptedkey: AQICAHgQalNS7T35ZlcFdhF0QuKeiJAbXMUbm01pjGwHEsjRCgFkQEnRPcfUvgTUOD4wi1JBAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMAYcezP6YDqBrBvcJAgEQgDsSTF48mLbyKmEA+aqC99ZLJsigI8s+91Js6TWAUkaLkZVTlE4rlWu4HGjVAX7elk64HnO/W13PSeklcA==
+config:
+  aws:region: us-east-1
+  consul:address: https://consul-xpro-production.odl.mit.edu
+  consul:scheme: https
+  environment:business_unit: mitxpro
+  environment:target_vpc: xpro_vpc

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.xpro.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.xpro.QA.yaml
@@ -1,0 +1,9 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-qa
+encryptedkey: AQICAHijXuVxVlAL6bY9xCOrzO3YYhFlQBPt6jNyJGkhYu+q4QGCf2z2jNtu8pUNU78dldK/AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMFPLwOGHDiGKWZ0IUAgEQgDsf9k2V08oW7HP8v6pMWjKSoVi19uMi11EszakDPkFgOZPOC3KYboPm+mSbYMtWw7e3Elke2oFAhWBCcA==
+config:
+  aws:region: us-east-1
+  consul:address: https://consul-xpro-qa.odl.mit.edu
+  consul:scheme: https
+  environment:business_unit: mitxpro
+  environment:target_vpc: xpro_vpc

--- a/src/ol_infrastructure/infrastructure/consul/Pulumi.infrastructure.consul.mitx-staging.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/consul/Pulumi.infrastructure.consul.mitx-staging.QA.yaml
@@ -1,0 +1,7 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-qa
+encryptedkey: AQICAHijXuVxVlAL6bY9xCOrzO3YYhFlQBPt6jNyJGkhYu+q4QHtoktUQmX78UHX+0XFAlaMAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMtwTtyIu612lya3pDAgEQgDv+q9HmLgGu1wMDOn6om5wfhiKF7aTNU3v3mTjND8Y7R86mmFRiktiMExhxDoiARogAQlPSjHqRKPNbNg==
+config:
+  aws:region: us-east-1
+  environment:business_unit: residential-staging
+  environment:vpc_reference: residential_mitx_staging_vpc

--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitx-staging.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitx-staging.CI.yaml
@@ -1,3 +1,4 @@
+---
 secretsprovider: awskms://alias/infrastructure-secrets-ci
 encryptedkey: AQICAHjs8ajWpT7YRhWXwI//wPkHX53RHlo0DjkgQOwCBTUBwQE3+th9LoHhHWGwWV0WCoxbAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMSQIAMldczD9izw79AgEQgDtleOZjc2aO8Lu8tW1sJ5B6E/ajRXdtMgkwkrPvHz5mn7zSekuw7Ecly+XFsON1wafC44y3XpEQOCoSMw==
 config:
@@ -6,7 +7,8 @@ config:
   consul:scheme: https
   environment:business_unit: residential-staging
   environment:target_vpc: residential_mitx_staging_vpc
-  mongodb_atlas:disk_autoscale_max_gb: "100"
+  mongodb_atlas:disk_autoscale_max_gb: '100'
   mongodb_atlas:instance_size: M10
   mongodb_atlas:organization_id: 611ab793e07f5965c7b9e4f6
-  mongodb_atlas:version: "4.4"
+  mongodb_atlas:ready_for_traffic: 'true'
+  mongodb_atlas:version: '4.4'

--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitx-staging.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitx-staging.Production.yaml
@@ -1,0 +1,16 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-production
+encryptedkey: AQICAHgQalNS7T35ZlcFdhF0QuKeiJAbXMUbm01pjGwHEsjRCgEH/Ldr/W/9AqE0WvSsooQQAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMQO1uRm9iFyL7OgvmAgEQgDtQSaxLII38vLduNnCVTKk4KSMYRusv1pvOrboW/ToGQWaNWjR4V81HqDkKWsN0tkrl8pVvVVTOc3E+8A==
+config:
+  aws:region: us-east-1
+  consul:address: https://consul-mitx-staging-production.odl.mit.edu
+  consul:scheme: https
+  environment:business_unit: residential-staging
+  environment:target_vpc: residential_mitx_staging_vpc
+  mongodb_atlas:disk_autoscale_max_gb: '200'
+  mongodb_atlas:disk_size_gb: 100
+  mongodb_atlas:instance_size: M20
+  mongodb_atlas:organization_id: 611ab793e07f5965c7b9e4f6
+  mongodb_atlas:version: '4.4'
+  mongodb_atlas:ready_for_traffic: true
+  mongodb_atlas:cluster_autoscale_max_size: M50

--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitx-staging.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitx-staging.QA.yaml
@@ -1,0 +1,15 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-qa
+encryptedkey: AQICAHijXuVxVlAL6bY9xCOrzO3YYhFlQBPt6jNyJGkhYu+q4QH2A6PnHsHnYW0C/BYCK6uFAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMNFbl4znx8Miko9D0AgEQgDuq7PNl0v225H8QtEBmiV9I6W5x8RW/m/veT33HraczaZdrwRwSNAeg6OaISPJtcJeGawxD5IUWLH2zfg==
+config:
+  aws:region: us-east-1
+  consul:address: https://consul-mitx-staging-qa.odl.mit.edu
+  consul:scheme: https
+  environment:business_unit: residential-staging
+  environment:target_vpc: residential_mitx_staging_vpc
+  mongodb_atlas:disk_autoscale_max_gb: '200'
+  mongodb_atlas:disk_size_gb: 100
+  mongodb_atlas:instance_size: M20
+  mongodb_atlas:organization_id: 611ab793e07f5965c7b9e4f6
+  mongodb_atlas:ready_for_traffic: 'true'
+  mongodb_atlas:version: '4.4'

--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitx.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitx.CI.yaml
@@ -10,4 +10,5 @@ config:
   mongodb_atlas:disk_autoscale_max_gb: '100'
   mongodb_atlas:instance_size: M10
   mongodb_atlas:organization_id: 611ab793e07f5965c7b9e4f6
+  mongodb_atlas:ready_for_traffic: 'true'
   mongodb_atlas:version: '4.4'

--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitx.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitx.Production.yaml
@@ -1,0 +1,16 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-production
+encryptedkey: AQICAHgQalNS7T35ZlcFdhF0QuKeiJAbXMUbm01pjGwHEsjRCgHmWivPkd877aOUWMwSqd1KAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMbucetPm1Nyed5WWqAgEQgDt0EbWaCbIAwWRPDhRRjDd1tKLOjVkdy5lR9hrlFpwxXFGkwZ4UWiy2Xxv5M9g2EPqoxGsoadLt9bYVEw==
+config:
+  aws:region: us-east-1
+  consul:address: https://consul-mitx-production.odl.mit.edu
+  consul:scheme: https
+  environment:business_unit: residential
+  environment:target_vpc: residential_mitx_vpc
+  mongodb_atlas:disk_autoscale_max_gb: '300'
+  mongodb_atlas:disk_size: 150
+  mongodb_atlas:instance_size: M30
+  mongodb_atlas:organization_id: 611ab793e07f5965c7b9e4f6
+  mongodb_atlas:version: '4.4'
+  mongodb_atlas:ready_for_traffic: true
+  mongodb_atlas:cluster_autoscale_max_size: M50

--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitx.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitx.QA.yaml
@@ -1,0 +1,15 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-qa
+encryptedkey: AQICAHijXuVxVlAL6bY9xCOrzO3YYhFlQBPt6jNyJGkhYu+q4QFqnCZkB/FKA+NYkHX2ontQAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMv9SWZurZCB8X84eFAgEQgDuJIDAG4l2pwKedRX7FidwguT271f1PEXxrVcWJ8BxdpQxLaO/zUSxd+mRR+DHbg6FZZNp+pnM5c1x7WQ==
+config:
+  aws:region: us-east-1
+  consul:address: https://consul-mitx-qa.odl.mit.edu
+  consul:scheme: https
+  environment:business_unit: residential
+  environment:target_vpc: residential_mitx_vpc
+  mongodb_atlas:disk_autoscale_max_gb: '200'
+  mongodb_atlas:disk_size_gb: '100'
+  mongodb_atlas:instance_size: M20
+  mongodb_atlas:organization_id: 611ab793e07f5965c7b9e4f6
+  mongodb_atlas:ready_for_traffic: 'true'
+  mongodb_atlas:version: '4.4'

--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitxonline.Production.yaml
@@ -1,0 +1,15 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-production
+encryptedkey: AQICAHgQalNS7T35ZlcFdhF0QuKeiJAbXMUbm01pjGwHEsjRCgFal60HQ0Je+YLZE9pUc/F1AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMB8BfTLnR4rtOOpFOAgEQgDuENYE+UppJjNmnJ/qJdI/kI6z8Ea8VdjEN+qIEQX4ilbtK4iGu1kd8j4xdYnAY4Qu9ged/Vz8jobGI2A==
+config:
+  aws:region: us-east-1
+  consul:address: https://consul-mitxonline-production.odl.mit.edu
+  consul:scheme: https
+  environment:business_unit: mitxonline
+  environment:target_vpc: mitxonline_vpc
+  mongodb_atlas:disk_autoscale_max_gb: '200'
+  mongodb_atlas:disk_size_gb: 50
+  mongodb_atlas:instance_size: M30
+  mongodb_atlas:organization_id: 611ab793e07f5965c7b9e4f6
+  mongodb_atlas:version: '4.4'
+  mongodb_atlas:cluster_autoscale_max_size: M50

--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitxonline.QA.yaml
@@ -1,0 +1,13 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-qa
+encryptedkey: AQICAHijXuVxVlAL6bY9xCOrzO3YYhFlQBPt6jNyJGkhYu+q4QG9C19SaryoIRFl5Iie18WHAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM1y/vrB5PLIyeXayMAgEQgDvyu4DehsxzMcxZNE7JSwNWEGna1CVh4HqctM1uey64hOVuuuG1/5WCB9PCRVl4w8b//AsSS0qM+O2wpw==
+config:
+  aws:region: us-east-1
+  consul:address: https://consul-mitxonline-qa.odl.mit.edu
+  consul:scheme: https
+  environment:business_unit: mitxonline
+  environment:target_vpc: mitxonline_vpc
+  mongodb_atlas:disk_autoscale_max_gb: '100'
+  mongodb_atlas:instance_size: M10
+  mongodb_atlas:organization_id: 611ab793e07f5965c7b9e4f6
+  mongodb_atlas:version: '4.4'

--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.xpro.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.xpro.CI.yaml
@@ -10,4 +10,5 @@ config:
   mongodb_atlas:disk_autoscale_max_gb: '100'
   mongodb_atlas:instance_size: M10
   mongodb_atlas:organization_id: 611ab793e07f5965c7b9e4f6
+  mongodb_atlas:ready_for_traffic: 'true'
   mongodb_atlas:version: '4.4'

--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.xpro.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.xpro.Production.yaml
@@ -1,0 +1,16 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-production
+encryptedkey: AQICAHgQalNS7T35ZlcFdhF0QuKeiJAbXMUbm01pjGwHEsjRCgFfroapXwSHv88dXriBdV6oAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMobwZVQqh9A7EQ0wRAgEQgDukWYU342rS8faFkTtLbQjjUdCKmI/u7pwwuynfENn9Osrv+/goEKowBUwbec9q8r5fIdMWuiuOW5A5PA==
+config:
+  aws:region: us-east-1
+  consul:address: https://consul-mitx-ci.odl.mit.edu
+  consul:scheme: https
+  environment:business_unit: xpro
+  environment:target_vpc: xpro_vpc
+  mongodb_atlas:disk_autoscale_max_gb: '200'
+  mongodb_atlas:disk_size_gb: '50'
+  mongodb_atlas:instance_size: M30
+  mongodb_atlas:organization_id: 611ab793e07f5965c7b9e4f6
+  mongodb_atlas:version: '4.4'
+  mongodb_atlas:ready_for_traffic: true
+  mongodb_atlas:cluster_autoscale_max_size: M50

--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.xpro.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.xpro.QA.yaml
@@ -1,0 +1,14 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-qa
+encryptedkey: AQICAHijXuVxVlAL6bY9xCOrzO3YYhFlQBPt6jNyJGkhYu+q4QEla+OdP68/Tfch6vKE6qu6AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMwwafVPMCBWD25o01AgEQgDvlmAFcrMc0KSMbhu8aeiAQ0eUI0z04hT4wFZdof2pgqMH3Ga3jllRHd9NjeFmFU1njonAHNKz/HeDOZQ==
+config:
+  aws:region: us-east-1
+  consul:address: https://consul-xpro-qa.odl.mit.edu
+  consul:scheme: https
+  environment:business_unit: mitxpro
+  environment:target_vpc: xpro_vpc
+  mongodb_atlas:disk_autoscale_max_gb: '100'
+  mongodb_atlas:instance_size: M10
+  mongodb_atlas:organization_id: 611ab793e07f5965c7b9e4f6
+  mongodb_atlas:ready_for_traffic: 'true'
+  mongodb_atlas:version: '4.4'

--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/__main__.py
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/__main__.py
@@ -36,6 +36,7 @@ aws_config = AWSBase(tags={"OU": business_unit, "Environment": environment_name}
 max_disk_size = atlas_config.get("disk_autoscale_max_gb")
 max_instance_type = atlas_config.get("cluster_autoscale_max_size")
 min_instance_type = atlas_config.get("cluster_autoscale_min_size")
+num_instances = atlas_config.get("cluster_instance_count") or 3
 vault_server = vault_stack.require_output("vault_server")
 
 #################
@@ -62,6 +63,9 @@ atlas_cluster = atlas.Cluster(
     project_id=atlas_project.id,
     provider_instance_size_name=atlas_config.get("instance_size") or "M10",
     provider_region_name=atlas_config.get("cloud_region") or "US_EAST_1",
+    provider_auto_scaling_compute_max_instance_size=max_instance_type,
+    provider_auto_scaling_compute_min_instance_size=min_instance_type,
+    replication_factor=num_instances,
 )
 
 atlas_security_group = aws.ec2.SecurityGroup(

--- a/src/ol_infrastructure/substructure/consul/Pulumi.substructure.consul.mitx-staging.QA.yaml
+++ b/src/ol_infrastructure/substructure/consul/Pulumi.substructure.consul.mitx-staging.QA.yaml
@@ -1,0 +1,5 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-qa
+encryptedkey: AQICAHijXuVxVlAL6bY9xCOrzO3YYhFlQBPt6jNyJGkhYu+q4QHdwsaUZvov36NuZ+zJLrnTAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM6Bs85RJA1my80qbpAgEQgDsoUWQlLaSqsuLMa6K/RD81mfvWV1h5/VCcfmblwPSpazLosHs91Rn8FRi5ZoJRlYC2+ox2U5TQQ/lNEg==
+config:
+  consul:address: https://consul-mitx-staging-qa.odl.mit.edu

--- a/src/ol_infrastructure/substructure/consul/Pulumi.substructure.consul.mitx.QA.yaml
+++ b/src/ol_infrastructure/substructure/consul/Pulumi.substructure.consul.mitx.QA.yaml
@@ -1,0 +1,5 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-qa
+encryptedkey: AQICAHijXuVxVlAL6bY9xCOrzO3YYhFlQBPt6jNyJGkhYu+q4QGPnfv/3a3+373eZlyFP/aoAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM1rdbDMuhi5LoWb4OAgEQgDvpMQeVxP7sCrNN1SkUfSYZGJG67S9lJZTfkCHSDb4yyYjtiiZF+NqAEin3uRed4JbH6AsPU8UQwl6MSA==
+config:
+  consul:address: https://consul-mitx-qa.odl.mit.edu


### PR DESCRIPTION
- Define stacks for AWS managed elasticsearch clusters
- Define stacks for MongoDB Atlas clusters
- Define needed stacks for Consul clusters
- Define stacks for provisioning Consul clusters with prepared queries
- Define stacks for QA environments of xPro and residential edxapp deployment
- Minor fixes to logic to prevent disrupting existing environments while migrating data