### PR TITLE
Added logic to check out our custom branch of edx-platform

### DIFF
--- a/src/bilder/images/edxapp/group_data/all.py
+++ b/src/bilder/images/edxapp/group_data/all.py
@@ -46,6 +46,8 @@ edx_plugins = {
         "ol-openedx-logging",
         "ol-openedx-sentry",
         "rapid-response-xblock==0.6.0",
+        "ol-openedx-canvas-integration",
+        "ol-openedx-rapid-response-reports",
     ],
     "mitx-staging": [
         "celery-redbeat",  # Support for using Redis as the lock for Celery schedules
@@ -55,5 +57,26 @@ edx_plugins = {
         "ol-openedx-logging",
         "ol-openedx-sentry",
         "rapid-response-xblock==0.6.0",
+        "ol-openedx-canvas-integration",
+        "ol-openedx-rapid-response-reports",
     ],
+}
+
+edx_platform_repository = {
+    "mitxonline": {
+        "origin": "https://github.com/edx/edx-platform",
+        "branch": "release",
+    },
+    "xpro": {
+        "origin": "https://github.com/edx/edx-platform",
+        "branch": "open-release/maple.master",
+    },
+    "mitx": {
+        "origin": "https://github.com/mitodl/edx-platform",
+        "branch": "mitx/maple",
+    },
+    "mitx-staging": {
+        "origin": "https://github.com/mitodl/edx-platform",
+        "branch": "mitx/maple",
+    },
 }


### PR DESCRIPTION
We often have to add custom logic for our installations of edx-platform to handle use cases that are unique to us. This adds a step to check out our branch of the platform during the AMI build that contains any patches that we need to maintain for a given release. Rather than fall back on conditional logic, this sets the origin and branch for any unmodified deployments to be the same as what is already present on disk which ends up being a no-op.