### PR TITLE
Remove stub storage config from Vault build to fix auto clustering

### DIFF
--- a/src/bilder/components/hashicorp/vault/models.py
+++ b/src/bilder/components/hashicorp/vault/models.py
@@ -245,7 +245,8 @@ class VaultServerConfig(HashicorpConfig):
     plugin_directory: Optional[Path]
     seal: Optional[List[VaultSealConfig]]
     service_registration: Optional[VaultServiceRegistration]
-    storage: VaultStorageBackend
+    # Set storage as optional to allow for splitting into a separate config file
+    storage: Optional[VaultStorageBackend]
     telemetry: Optional[VaultTelemetryConfig]
     ui: Optional[bool] = False
 
@@ -263,7 +264,7 @@ class Vault(HashicorpProduct):
     data_directory: Path = Path("/var/lib/vault/")
 
     @validator("configuration")
-    def validate_consistent_config_types(cls, configuration):
+    def validate_consistent_config_types(cls, configuration):  # noqa: N805
         type_set = {type(config_obj) for config_obj in configuration.values()}
         if len(type_set) > 1:
             raise ValueError("There are server and agent configuration objects present")

--- a/src/bilder/images/vault/deploy.py
+++ b/src/bilder/images/vault/deploy.py
@@ -24,7 +24,6 @@ from bilder.components.hashicorp.vault.models import (
     VaultSealConfig,
     VaultServerConfig,
     VaultServiceRegistration,
-    VaultStorageBackend,
     VaultTCPListener,
 )
 from bilder.components.vector.models import VectorConfig
@@ -64,7 +63,6 @@ caddy_config_changed = configure_caddy(caddy_config)
 
 # Install Consul agent and Vault server
 hours_in_six_months = HOURS_IN_MONTH * 6
-raft_config = IntegratedRaftStorageBackend()
 vault = Vault(
     configuration={
         Path("00-vault.json"): VaultServerConfig(
@@ -82,7 +80,6 @@ vault = Vault(
             # Disable swapping to disk because we are using the integrated raft storage
             # backend.
             disable_mlock=True,
-            storage=VaultStorageBackend(raft=raft_config),
             ui=True,
             service_registration=VaultServiceRegistration(
                 consul=ConsulServiceRegistration()
@@ -100,6 +97,8 @@ consul_configuration = {
 consul = Consul(version=VERSIONS["consul"], configuration=consul_configuration)
 hashicorp_products = [vault, consul]
 install_hashicorp_products(hashicorp_products)
+# Ensure raft config path exists but exact config is loaded via cloud-init
+raft_config = IntegratedRaftStorageBackend()
 files.directory(
     name="Ensure raft directory exists with proper permissions",
     path=raft_config.path,


### PR DESCRIPTION
The specific configuration for the raft cloud auto-join is written in by cloud-init. Having the stub storage configuration in the pre-baked config file conflicts with loading the full storage configuration at run time which prevents the node from automatically joining the cluster. This sets the storage block to optional in the Vault config model so that we can exclude it from the baked image in order for the proper config to load and join the running cluster.