### PR TITLE
Revert "fix: update Learning MFE BASE_URL to match PUBLIC_PATH"

### DIFF
--- a/pipelines/edx/mfe-frontend-app-learning-qa.yml
+++ b/pipelines/edx/mfe-frontend-app-learning-qa.yml
@@ -41,7 +41,7 @@ jobs:
       - name: mfe-app-learning/dist
       params:
         ACCESS_TOKEN_COOKIE_NAME: edx-jwt-cookie-header-payload
-        BASE_URL: https://courses-qa.mitxonline.mit.edu/learn
+        BASE_URL: https://courses-qa.mitxonline.mit.edu
         CSRF_TOKEN_API_PATH: /csrf/api/v1/token
         LMS_BASE_URL: https://courses-qa.mitxonline.mit.edu
         LOGIN_URL: https://courses-qa.mitxonline.mit.edu/login


### PR DESCRIPTION
Reverts mitodl/ol-infrastructure#386

Reverting this PR since the breadcrumb implementation has been changed again and that doesn't use MFE's `BASE_URL`. Instead, it's using router-based paths now along with `JumpNav`.

**Note 1:** There is some helpful information and links in https://github.com/mitodl/mitxpro/issues/2326#issuecomment-996736653.


**Note 2:** I'm not sure at which commit we're currently for MFE's `Maple` branch but whenever we pull to the latest `Maple` branch we'll need to merge this Revert PR to be on the safe side from seeing intermittent issues if any. (As of our current deployment of the MFE, things are working so it's not necessary to merge this right away)