### PR TITLE
asadiqbal08/suggested_price should not be null

### DIFF
--- a/src/bilder/images/edxapp/templates/edxapp/mitx/common_values.yml
+++ b/src/bilder/images/edxapp/templates/edxapp/mitx/common_values.yml
@@ -566,16 +566,6 @@ STUDENT_FILEUPLOAD_MAX_SIZE: 52428800
 EMAIL_HOST: outgoing.mit.edu
 EMAIL_PORT: 587
 EMAIL_USE_TLS: true
-COURSE_MODE_DEFAULTS:
-  name: Honor
-  bulk_sku: null
-  currency: usd
-  description: null
-  expiration_datetime: null
-  min_price: 0
-  sku: null
-  slug: honor
-  suggested_prices:
 ADMINS:
   - ["MITx Stacktrace Recipients", "cuddle-bunnies@mit.edu"]
 ALLOW_ALL_ADVANCED_COMPONENTS: true


### PR DESCRIPTION
fixes: https://github.com/mitodl/mitx-theme/issues/136

`COURSE_MODE_DEFAULTS` has honor slug and with some suggested price is not set in it. If that is the case then `OpenEdx` is keeping the course behind the paywall by following this [condition](https://github.com/edx/edx-platform/blob/open-release/maple.master/common/djangoapps/course_modes/models.py#L729-L754)

