### PR TITLE
Adding access to Atlas clusters from data pipeline VPC

### DIFF
--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitx.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitx.QA.yaml
@@ -7,9 +7,9 @@ config:
   consul:scheme: https
   environment:business_unit: residential
   environment:target_vpc: residential_mitx_vpc
-  mongodb_atlas:disk_autoscale_max_gb: '200'
-  mongodb_atlas:disk_size_gb: '100'
+  mongodb_atlas:disk_autoscale_max_gb: "200"
+  mongodb_atlas:disk_size_gb: "100"
   mongodb_atlas:instance_size: M20
   mongodb_atlas:organization_id: 611ab793e07f5965c7b9e4f6
-  mongodb_atlas:ready_for_traffic: 'true'
-  mongodb_atlas:version: '4.4'
+  mongodb_atlas:ready_for_traffic: "true"
+  mongodb_atlas:version: "4.4"

--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitxonline.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitxonline.CI.yaml
@@ -7,7 +7,7 @@ config:
   consul:scheme: https
   environment:business_unit: mitxonline
   environment:target_vpc: mitxonline_vpc
-  mongodb_atlas:disk_autoscale_max_gb: '100'
+  mongodb_atlas:disk_autoscale_max_gb: "100"
   mongodb_atlas:instance_size: M10
   mongodb_atlas:organization_id: 611ab793e07f5965c7b9e4f6
-  mongodb_atlas:version: '4.4'
+  mongodb_atlas:version: "4.4"

--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitxonline.Production.yaml
@@ -7,10 +7,10 @@ config:
   consul:scheme: https
   environment:business_unit: mitxonline
   environment:target_vpc: mitxonline_vpc
-  mongodb_atlas:disk_autoscale_max_gb: '200'
-  mongodb_atlas:disk_size_gb: 50
+  mongodb_atlas:cluster_autoscale_max_size: M50
+  mongodb_atlas:cluster_instance_count: "5"
+  mongodb_atlas:disk_autoscale_max_gb: "200"
+  mongodb_atlas:disk_size_gb: "50"
   mongodb_atlas:instance_size: M30
   mongodb_atlas:organization_id: 611ab793e07f5965c7b9e4f6
-  mongodb_atlas:version: '4.4'
-  mongodb_atlas:cluster_autoscale_max_size: M50
-  mongodb_atlas:cluster_instance_count: 5
+  mongodb_atlas:version: "4.4"

--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitxonline.QA.yaml
@@ -7,7 +7,7 @@ config:
   consul:scheme: https
   environment:business_unit: mitxonline
   environment:target_vpc: mitxonline_vpc
-  mongodb_atlas:disk_autoscale_max_gb: '100'
+  mongodb_atlas:disk_autoscale_max_gb: "100"
   mongodb_atlas:instance_size: M10
   mongodb_atlas:organization_id: 611ab793e07f5965c7b9e4f6
-  mongodb_atlas:version: '4.4'
+  mongodb_atlas:version: "4.4"

--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.xpro.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.xpro.QA.yaml
@@ -7,8 +7,8 @@ config:
   consul:scheme: https
   environment:business_unit: mitxpro
   environment:target_vpc: xpro_vpc
-  mongodb_atlas:disk_autoscale_max_gb: '100'
+  mongodb_atlas:disk_autoscale_max_gb: "100"
   mongodb_atlas:instance_size: M10
   mongodb_atlas:organization_id: 611ab793e07f5965c7b9e4f6
-  mongodb_atlas:ready_for_traffic: 'true'
-  mongodb_atlas:version: '4.4'
+  mongodb_atlas:ready_for_traffic: "true"
+  mongodb_atlas:version: "4.4"

--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/__main__.py
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/__main__.py
@@ -18,7 +18,11 @@ from ol_infrastructure.lib.pulumi_helper import parse_stack
 atlas_config = pulumi.Config("mongodb_atlas")
 env_config = pulumi.Config("environment")
 stack_info = parse_stack()
+dagster_env_name = stack_info.name
+if stack_info.name == "CI":
+    dagster_env_name = "QA"
 network_stack = pulumi.StackReference(f"infrastructure.aws.network.{stack_info.name}")
+dagster_stack = pulumi.StackReference(f"applications.dagster.{dagster_env_name}")
 consul_stack = pulumi.StackReference(
     f"infrastructure.consul.{stack_info.env_prefix}.{stack_info.name}"
 )
@@ -28,7 +32,7 @@ consul_stack = pulumi.StackReference(
 #############
 environment_name = f"{stack_info.env_prefix}-{stack_info.env_suffix}"
 target_vpc = network_stack.require_output(env_config.require("target_vpc"))
-data_vpc = network_stack.require_output("data_vpc")
+dagster_ip = dagster_stack.require_output("dagster_app")["elastic_ip"]
 business_unit = env_config.get("business_unit") or "operations"
 aws_config = AWSBase(tags={"OU": business_unit, "Environment": environment_name})
 max_disk_size = atlas_config.get_int("disk_autoscale_max_gb")
@@ -185,97 +189,41 @@ if atlas_config.get_bool("ready_for_traffic"):
 ########################
 # Data Pipeline Access #
 ########################
-atlas_data_security_group = aws.ec2.SecurityGroup(
-    f"mongodb-atlas-data {stack_info.env_suffix}",
-    name=f"mongodb-atlas-data {stack_info.env_suffix}",
-    description=f"Access control to Mongodb Atlas instances in data {stack_info.env_suffix}",  # noqa: E501
-    tags=aws_config.merged_tags(
-        {"Name": f"data {stack_info.env_suffix}-mongodb-atlas"}
-    ),
-    vpc_id=target_vpc["id"],
-    ingress=[
-        aws.ec2.SecurityGroupIngressArgs(
-            protocol="tcp",
-            from_port=DEFAULT_MONGODB_PORT,
-            to_port=DEFAULT_MONGODB_PORT,
-            cidr_blocks=[target_vpc["cidr"]],
-            ipv6_cidr_blocks=[target_vpc["cidr_v6"]],
-            description=f"Access to Mongodb cluster from data {stack_info.env_suffix}",
-        ),
-    ],
-    egress=default_egress_args,
-)
-
-# It is necessary to manually go to the Mongo Atlas UI and fetch the IP CIDR for adding
-# to the VPC route table
-atlas_aws_data_network_peer = atlas.NetworkPeering(
-    f"mongo-atlas-network-peering-data-{stack_info.env_suffix}",
-    accepter_region_name=data_vpc["region"],
-    container_id=atlas_cluster.container_id,
-    vpc_id=data_vpc["id"],
-    aws_account_id=aws.get_caller_identity().account_id,
-    project_id=atlas_project.id,
-    provider_name="AWS",
-    route_table_cidr_block=data_vpc["cidr"],
-    opts=atlas_provider,
-)
-
-accept_atlas_data_network_peer = aws.ec2.VpcPeeringConnectionAccepter(
-    "mongo-atlas-data-peering-connection-accepter",
-    vpc_peering_connection_id=atlas_aws_network_peer.connection_id,
-    auto_accept=True,
-    accepter=aws.ec2.VpcPeeringConnectionAccepterAccepterArgs(
-        allow_remote_vpc_dns_resolution=True,
-    ),
-    tags=aws_config.tags,
-)
-
-atlas_data_secgroup_network_access = atlas.ProjectIpAccessList(
-    "mongo-atlas-data-network-security-group-permissions",
-    aws_security_group=atlas_security_group.id,
-    project_id=atlas_project.id,
-    opts=pulumi.ResourceOptions(
-        depends_on=[atlas_aws_network_peer, accept_atlas_network_peer]
-    ).merge(atlas_provider),
-)
-
 atlas_data_cidr_network_access = atlas.ProjectIpAccessList(
     "mongo-atlas-data-network-cidr-block-permissions",
     project_id=atlas_project.id,
-    cidr_block=data_vpc["cidr"],
+    cidr_block=dagster_ip.apply("{}/32".format),
     opts=pulumi.ResourceOptions(
         depends_on=[atlas_aws_network_peer, accept_atlas_network_peer]
     ).merge(atlas_provider),
-)
-
-aws.ec2.Route(
-    "mongo-atlas-data-network-route",
-    route_table_id=data_vpc["route_table_id"],
-    destination_cidr_block=atlas_config.get("project_cidr_block") or "192.168.248.0/21",
-    vpc_peering_connection_id=atlas_aws_data_network_peer.connection_id,
 )
 
 consul.Keys(
     "set-mongo-connection-info-in-consul-for-data-pipelines",
     keys=[
         consul.KeysKeyArgs(
-            path="mongodb/host",
+            path=f"{stack_info.env_prefix}/mongodb/host",
             delete=True,
             value=atlas_cluster.mongo_uri.apply(lambda uri: urlparse(uri).netloc),
         ),
         consul.KeysKeyArgs(
-            path="mongodb/use-ssl",
+            path=f"{stack_info.env_prefix}/mongodb/use-ssl",
             delete=True,
             value=atlas_cluster.mongo_uri_with_options.apply(
                 lambda uri: parse_qs(urlparse(uri).query)["ssl"][0]
             ),
         ),
         consul.KeysKeyArgs(
-            path="mongodb/replica-set",
+            path=f"{stack_info.env_prefix}/mongodb/replica-set",
             delete=True,
             value=atlas_cluster.mongo_uri_with_options.apply(
                 lambda uri: parse_qs(urlparse(uri).query)["replicaSet"][0]
             ),
+        ),
+        consul.KeysKeyArgs(
+            path=f"{stack_info.env_prefix}/mongodb/connection-string",
+            delete=True,
+            value=atlas_cluster.mongo_uri_with_options,
         ),
         consul.KeysKeyArgs(path="mongodb/auth-source", delete=True, value="admin"),
     ],


### PR DESCRIPTION
In order for us to run the edX data pipelines we need to grant access from the VPC where the pipelines run to the Mongo Atlas networks.