### PR TITLE
Updating discovery of edxapp DB from DNS to template

### DIFF
--- a/src/bilder/images/edxapp/templates/edxapp/mitx-staging/common_values.yml
+++ b/src/bilder/images/edxapp/templates/edxapp/mitx-staging/common_values.yml
@@ -13,6 +13,7 @@ mongodb_settings: &mongo_params
 {{ with secret "mariadb-mitx-staging/creds/edxapp" }}
 mysql_creds: &mysql_creds
   ENGINE: django.db.backends.mysql
+  HOST: {{ keyOrDefault "edxapp/rds-host", "edxapp-db.service.consul" }}
   PORT: 3306
   USER: {{ .Data.username }}
   PASSWORD: {{ .Data.password }}
@@ -69,13 +70,11 @@ DATABASES:
   default:
     ATOMIC_REQUESTS: true
     CONN_MAX_AGE: 0
-    HOST: edxapp-db.service.consul
     NAME: edxapp
     OPTIONS: {}
     <<: *mysql_creds
   read_replica:
     CONN_MAX_AGE: 0
-    HOST: edxapp-db.service.consul
     NAME: edxapp
     OPTIONS: {}
     <<: *mysql_creds
@@ -83,7 +82,7 @@ DATABASES:
     CONN_MAX_AGE: 0
     ENGINE: django.db.backends.mysql
     PORT: 3306
-    HOST: edxapp-db.service.consul
+    HOST: {{ keyOrDefault "edxapp/rds-host", "edxapp-db.service.consul" }}
     NAME: edxapp_csmh
     OPTIONS: {}
     {{ with secret "mariadb-mitx-staging/creds/edxapp-csmh"}}

--- a/src/bilder/images/edxapp/templates/edxapp/mitx/common_values.yml
+++ b/src/bilder/images/edxapp/templates/edxapp/mitx/common_values.yml
@@ -13,6 +13,7 @@ mongodb_settings: &mongo_params
 {{ with secret "mariadb-mitx/creds/edxapp" }}
 mysql_creds: &mysql_creds
   ENGINE: django.db.backends.mysql
+  HOST: {{ keyOrDefault "edxapp/rds-host", "edxapp-db.service.consul" }}
   PORT: 3306
   USER: {{ .Data.username }}
   PASSWORD: {{ .Data.password }}
@@ -69,13 +70,11 @@ DATABASES:
   default:
     ATOMIC_REQUESTS: true
     CONN_MAX_AGE: 0
-    HOST: edxapp-db.service.consul
     NAME: edxapp
     OPTIONS: {}
     <<: *mysql_creds
   read_replica:
     CONN_MAX_AGE: 0
-    HOST: edxapp-db.service.consul
     NAME: edxapp
     OPTIONS: {}
     <<: *mysql_creds
@@ -83,7 +82,7 @@ DATABASES:
     CONN_MAX_AGE: 0
     ENGINE: django.db.backends.mysql
     PORT: 3306
-    HOST: edxapp-db.service.consul
+    HOST: {{ keyOrDefault "edxapp/rds-host", "edxapp-db.service.consul" }}
     NAME: edxapp_csmh
     OPTIONS: {}
     {{ with secret "mariadb-mitx/creds/edxapp-csmh"}}

--- a/src/bilder/images/edxapp/templates/edxapp/mitxonline/common_values.yml
+++ b/src/bilder/images/edxapp/templates/edxapp/mitxonline/common_values.yml
@@ -13,6 +13,7 @@ mongodb_settings: &mongo_params
 {{ with secret "mariadb-mitxonline/creds/edxapp" }}
 mysql_creds: &mysql_creds
   ENGINE: django.db.backends.mysql
+  HOST: {{ keyOrDefault "edxapp/rds-host", "edxapp-db.service.consul" }}
   PORT: 3306
   USER: {{ .Data.username }}
   PASSWORD: {{ .Data.password }}
@@ -63,13 +64,11 @@ DATABASES:
   default:
     ATOMIC_REQUESTS: true
     CONN_MAX_AGE: 0
-    HOST: edxapp-db.service.consul
     NAME: edxapp
     OPTIONS: {}
     <<: *mysql_creds
   read_replica:
     CONN_MAX_AGE: 0
-    HOST: edxapp-db.service.consul
     NAME: edxapp
     OPTIONS: {}
     <<: *mysql_creds
@@ -77,7 +76,7 @@ DATABASES:
     CONN_MAX_AGE: 0
     ENGINE: django.db.backends.mysql
     PORT: 3306
-    HOST: edxapp-db.service.consul
+    HOST: {{ keyOrDefault "edxapp/rds-host", "edxapp-db.service.consul" }}
     NAME: edxapp_csmh
     OPTIONS: {}
     {{ with secret "mariadb-mitxonline/creds/edxapp-csmh"}}

--- a/src/bilder/images/edxapp/templates/edxapp/xpro/common_values.yml
+++ b/src/bilder/images/edxapp/templates/edxapp/xpro/common_values.yml
@@ -13,6 +13,7 @@ mongodb_settings: &mongo_params
 {{ with secret "mariadb-xpro/creds/edxapp" }}
 mysql_creds: &mysql_creds
   ENGINE: django.db.backends.mysql
+  HOST: {{ keyOrDefault "edxapp/rds-host", "edxapp-db.service.consul" }}
   PORT: 3306
   USER: {{ .Data.username }}
   PASSWORD: {{ .Data.password }}
@@ -66,13 +67,11 @@ DATABASES:
   default:
     ATOMIC_REQUESTS: true
     CONN_MAX_AGE: 0
-    HOST: edxapp-db.service.consul
     NAME: edxapp
     OPTIONS: {}
     <<: *mysql_creds
   read_replica:
     CONN_MAX_AGE: 0
-    HOST: edxapp-db.service.consul
     NAME: edxapp
     OPTIONS: {}
     <<: *mysql_creds
@@ -80,7 +79,7 @@ DATABASES:
     CONN_MAX_AGE: 0
     ENGINE: django.db.backends.mysql
     PORT: 3306
-    HOST: edxapp-db.service.consul
+    HOST: {{ keyOrDefault "edxapp/rds-host", "edxapp-db.service.consul" }}
     NAME: edxapp_csmh
     OPTIONS: {}
     {{ with secret "mariadb-xpro/creds/edxapp-csmh"}}

--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -241,31 +241,6 @@ s3.BucketPublicAccessBlock(
     block_public_policy=True,
 )
 
-######################
-# Manage Consul Data #
-######################
-consul_kv_data = {
-    "google-analytics-id": edxapp_config.require("google_analytics_id"),
-    "lms-domain": edxapp_domains["lms"],
-    "preview-domain": edxapp_domains["preview"],
-    "s3-course-bucket": course_bucket_name,
-    "s3-grades-bucket": grades_bucket_name,
-    "s3-storage-bucket": storage_bucket_name,
-    "sender-email-address": edxapp_config.require("sender_email_address"),
-    "ses-configuration-set": f"edxapp-{env_name}",
-    "ses-mail-domain": edxapp_mail_domain,
-    "session-cookie-domain": ".{}".format(edxapp_domains["lms"].split(".", 1)[-1]),
-    "studio-domain": edxapp_domains["studio"],
-}
-consul.Keys(
-    "edxapp-consul-template-data",
-    keys=[
-        consul.KeysKeyArgs(path=f"edxapp/{key}", value=config_value)
-        for key, config_value in consul_kv_data.items()
-    ],
-    opts=consul_provider,
-)
-
 ########################
 # IAM Roles & Policies #
 ########################
@@ -876,6 +851,32 @@ edxapp_ses_event_destintations = ses.EventDestination(
             value_source="emailHeader",
         )
     ],
+)
+
+######################
+# Manage Consul Data #
+######################
+consul_kv_data = {
+    "google-analytics-id": edxapp_config.require("google_analytics_id"),
+    "lms-domain": edxapp_domains["lms"],
+    "preview-domain": edxapp_domains["preview"],
+    "rds-host": edxapp_db.db_instance.address,
+    "s3-course-bucket": course_bucket_name,
+    "s3-grades-bucket": grades_bucket_name,
+    "s3-storage-bucket": storage_bucket_name,
+    "sender-email-address": edxapp_config.require("sender_email_address"),
+    "ses-configuration-set": f"edxapp-{env_name}",
+    "ses-mail-domain": edxapp_mail_domain,
+    "session-cookie-domain": ".{}".format(edxapp_domains["lms"].split(".", 1)[-1]),
+    "studio-domain": edxapp_domains["studio"],
+}
+consul.Keys(
+    "edxapp-consul-template-data",
+    keys=[
+        consul.KeysKeyArgs(path=f"edxapp/{key}", value=config_value)
+        for key, config_value in consul_kv_data.items()
+    ],
+    opts=consul_provider,
 )
 
 ##########################


### PR DESCRIPTION
- Adds an entry in Consul KV store for the RDS host address
- Updates the Consul template to retrieve that key instead of relying on DNS discovery for communicating with the DB

This is necessary because of periodic but frequent errors with address resolution through Consul for the database host which has performance impacts for end users.