### PR TITLE
MFE Gradebook pipelines for QA envs

### DIFF
--- a/pipelines/edx/mfe-frontend-app-gradebook-mitx-qa.yaml
+++ b/pipelines/edx/mfe-frontend-app-gradebook-mitx-qa.yaml
@@ -1,0 +1,78 @@
+---
+resource_types:
+- name: rclone
+  type: docker-image
+  source:
+    repository: mitodl/concourse-rclone-resource
+    tag: latest
+
+resources:
+- name: mfe-app-gradebook
+  type: git
+  source:
+    uri: https://github.com/edx/frontend-app-gradebook.git
+    branch: open-release/maple.master
+- name: mfe-app-bucket
+  type: rclone
+  source:
+    config: |
+      [s3-remote]
+      type = s3
+      provider = AWS
+      env_auth = true
+      region = us-east-1
+
+jobs:
+- name: build
+  plan:
+  - get: mfe-app-gradebook
+    trigger: true
+  - task: npm-install-and-build
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: nikolaik/python-nodejs
+          tag: python3.10-nodejs12
+      inputs:
+      - name: mfe-app-gradebook
+      outputs:
+      - name: mfe-app-gradebook/dist
+      params:
+        ACCESS_TOKEN_COOKIE_NAME: edx-jwt-cookie-header-payload
+        BASE_URL: https://lms-qa.mitx.mit.edu
+        CSRF_TOKEN_API_PATH: /csrf/api/v1/token
+        LMS_BASE_URL: https://mitx-qa.mitx.mit.edu
+        LOGIN_URL: https://mitx-qa.mitx.mit.edu/login
+        LOGOUT_URL: https://mitx-qa.mitx.mit.edu/logout
+        LOGO_URL: https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/logo.png
+        LOGO_TRADEMARK_URL: https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/logo.png
+        LOGO_WHITE_URL: https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/logo.png
+        FAVICON_URL: https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/favicon.ico
+        MARKETING_SITE_BASE_URL: https://mitx-qa.mitx.mit.edu
+        ORDER_HISTORY_URL:
+        PUBLIC_PATH: /gradebook/
+        REFRESH_ACCESS_TOKEN_ENDPOINT: https://mitx-qa.mitx.mit.edu/login_refresh
+        SEARCH_CATALOG_URL: https://mitx-qa.mitx.mit.edu/courses
+        SITE_NAME: MITx Residential
+        STUDIO_BASE_URL: https://studio-mitx-qa.mitx.mit.edu
+        SUPPORT_URL: https://odl.zendesk.com/hc/en-us/requests/new
+        USER_INFO_COOKIE_NAME: edx-user-info
+        SESSION_COOKIE_DOMAIN: mitx-qa.mitx.mit.edu
+      run:
+        path: sh
+        dir: mfe-app-gradebook
+        args:
+        - -exc
+        - |
+          npm install
+          npm install @edx/frontend-component-footer@npm:@mitodl/frontend-component-footer-mitol@latest --legacy-peer-deps
+          npm install @edx/frontend-component-header@npm:@mitodl/frontend-component-header-mitol@latest --legacy-peer-deps
+          NODE_ENV=production npm run build
+  - put: mfe-app-bucket
+    params:
+      source: mfe-app-gradebook/dist
+      destination:
+      - command: sync
+        dir: s3-remote:mitx-qa-edxapp-mfe/gradebook/

--- a/pipelines/edx/mfe-frontend-app-gradebook-mitxonline-qa.yaml
+++ b/pipelines/edx/mfe-frontend-app-gradebook-mitxonline-qa.yaml
@@ -1,0 +1,88 @@
+---
+resource_types:
+- name: rclone
+  type: docker-image
+  source:
+    repository: mitodl/concourse-rclone-resource
+    tag: latest
+
+resources:
+- name: mfe-app-gradebook
+  type: git
+  source:
+    uri: https://github.com/openedx/frontend-app-gradebook.git
+    branch: master
+- name: mfe-app-gradebook-bucket
+  type: rclone
+  source:
+    config: |
+      [s3-remote]
+      type = s3
+      provider = AWS
+      env_auth = true
+      region = us-east-1
+
+jobs:
+- name: build
+  plan:
+  - get: mfe-app-gradebook
+    trigger: true
+  - task: npm-install-and-build
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: nikolaik/python-nodejs
+          tag: python3.10-nodejs12
+      inputs:
+      - name: mfe-app-gradebook
+      outputs:
+      - name: mfe-app-gradebook/dist
+      params:
+        ACCESS_TOKEN_COOKIE_NAME: edx-jwt-cookie-header-payload
+        BASE_URL: https://courses-qa.mitxonline.mit.edu
+        CSRF_TOKEN_API_PATH: /csrf/api/v1/token
+        LMS_BASE_URL: https://courses-qa.mitxonline.mit.edu
+        LOGIN_URL: https://courses-qa.mitxonline.mit.edu/login
+        LOGOUT_URL: https://courses-qa.mitxonline.mit.edu/logout
+        LOGO_URL: https://raw.githubusercontent.com/mitodl/mitxonline-theme/main/lms/static/images/logo.png
+        LOGO_TRADEMARK_URL: https://raw.githubusercontent.com/mitodl/mitxonline-theme/main/lms/static/images/logo.png
+        LOGO_WHITE_URL: https://raw.githubusercontent.com/mitodl/mitxonline-theme/main/lms/static/images/logo.png
+        FAVICON_URL: https://raw.githubusercontent.com/mitodl/mitxonline-theme/main/lms/static/images/favicon.ico
+        MARKETING_SITE_BASE_URL: https://rc.mitxonline.mit.edu
+        ORDER_HISTORY_URL:
+        PUBLIC_PATH: /gradebook/
+        REFRESH_ACCESS_TOKEN_ENDPOINT: https://courses-qa.mitxonline.mit.edu/login_refresh
+        SEARCH_CATALOG_URL: https://courses-qa.mitxonline.mit.edu/courses
+        SITE_NAME: MITx Online QA
+        STUDIO_BASE_URL: https://studio-qa.mitxonline.mit.edu
+        SUPPORT_URL: https://mitx-micromasters.zendesk.com/hc/en-us/requests/new
+        USER_INFO_COOKIE_NAME: edx-user-info
+        SESSION_COOKIE_DOMAIN: .mitxonline.mit.edu
+        ABOUT_US_URL: https://rc.mitxonline.mit.edu/about-us/
+        PRIVACY_POLICY_URL: https://rc.mitxonline.mit.edu/privacy-policy/
+        HONOR_CODE_URL: https://rc.mitxonline.mit.edu/honor-code/
+        TERMS_OF_SERVICE_URL: https://rc.mitxonline.mit.edu/terms-of-service/
+        Contact: mailto:mitxonline-support@mit.edu
+        SUPPORT_CENTER_URL: https://mitx-micromasters.zendesk.com/hc/
+        SUPPORT_CENTER_TEXT: Support Center
+        TRADEMARK_TEXT: © MITxOnline. All rights reserved except where noted.
+        SITE_URL: https://rc.mitxonline.mit.edu
+        LOGO_ALT_TEXT: ''
+      run:
+        path: sh
+        dir: mfe-app-gradebook
+        args:
+        - -exc
+        - |
+          npm install
+          npm install @edx/frontend-component-footer@npm:@mitodl/frontend-component-footer-mitol@latest --legacy-peer-deps
+          npm install @edx/frontend-component-header@npm:@mitodl/frontend-component-header-mitol@latest --legacy-peer-deps
+          NODE_ENV=production npm run build
+  - put: mfe-app-gradebook-bucket
+    params:
+      source: mfe-app-gradebook/dist
+      destination:
+      - command: sync
+        dir: s3-remote:mitxonline-qa-edxapp-mfe/gradebook/

--- a/pipelines/edx/mfe-frontend-app-gradebook-xpro-qa.yaml
+++ b/pipelines/edx/mfe-frontend-app-gradebook-xpro-qa.yaml
@@ -1,0 +1,78 @@
+---
+resource_types:
+- name: rclone
+  type: docker-image
+  source:
+    repository: mitodl/concourse-rclone-resource
+    tag: latest
+
+resources:
+- name: mfe-app-gradebook
+  type: git
+  source:
+    uri: https://github.com/edx/frontend-app-gradebook.git
+    branch: open-release/maple.master
+- name: mfe-app-bucket
+  type: rclone
+  source:
+    config: |
+      [s3-remote]
+      type = s3
+      provider = AWS
+      env_auth = true
+      region = us-east-1
+
+jobs:
+- name: build
+  plan:
+  - get: mfe-app-gradebook
+    trigger: true
+  - task: npm-install-and-build
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: nikolaik/python-nodejs
+          tag: 1python3.10-nodejs12
+      inputs:
+      - name: mfe-app-gradebook
+      outputs:
+      - name: mfe-app-gradebook/dist
+      params:
+        ACCESS_TOKEN_COOKIE_NAME: edx-jwt-cookie-header-payload
+        BASE_URL: https://courses-rc.xpro.mit.edu
+        CSRF_TOKEN_API_PATH: /csrf/api/v1/token
+        LMS_BASE_URL: https://courses-rc.xpro.mit.edu
+        LOGIN_URL: https://courses-rc.xpro.mit.edu/login
+        LOGOUT_URL: https://courses-rc.xpro.mit.edu/logout
+        LOGO_URL: https://raw.githubusercontent.com/mitodl/mitxpro-theme/master/lms/static/images/logo.png
+        LOGO_TRADEMARK_URL: https://raw.githubusercontent.com/mitodl/mitxpro-theme/master/lms/static/images/logo.png
+        LOGO_WHITE_URL: https://raw.githubusercontent.com/mitodl/mitxpro-theme/master/lms/static/images/logo.png
+        FAVICON_URL: https://raw.githubusercontent.com/mitodl/mitxpro-theme/master/lms/static/images/favicon.ico
+        MARKETING_SITE_BASE_URL: https://rc.xpro.mit.edu
+        ORDER_HISTORY_URL:
+        PUBLIC_PATH: /gradebook/
+        REFRESH_ACCESS_TOKEN_ENDPOINT: https://courses-rc.xpro.mit.edu/login_refresh
+        SEARCH_CATALOG_URL: https://courses-rc.xpro.mit.edu/courses
+        SITE_NAME: MIT xPRO
+        STUDIO_BASE_URL: https://studio-rc.xpro.mit.edu
+        SUPPORT_URL: https://xpro.zendesk.com/hc
+        USER_INFO_COOKIE_NAME: edx-user-info
+        SESSION_COOKIE_DOMAIN: courses-rc.mitxpro.mit.edu
+      run:
+        path: sh
+        dir: mfe-app-gradebook
+        args:
+        - -exc
+        - |
+          npm install
+          npm install @edx/frontend-component-footer@npm:@mitodl/frontend-component-footer-mitol@latest --legacy-peer-deps
+          npm install @edx/frontend-component-header@npm:@mitodl/frontend-component-header-mitol@latest --legacy-peer-deps
+          NODE_ENV=production npm run build
+  - put: mfe-app-bucket
+    params:
+      source: mfe-app-gradebook/dist
+      destination:
+      - command: sync
+        dir: s3-remote:xpro-qa-edxapp-mfe/gradebook/

--- a/src/bilder/images/edxapp/templates/edxapp/mitx/lms_only.yml.tmpl
+++ b/src/bilder/images/edxapp/templates/edxapp/mitx/lms_only.yml.tmpl
@@ -89,7 +89,7 @@ VERIFY_STUDENT:
     EXPIRING_SOON_WINDOW: 28
 VIDEO_CDN_URL:
     EXAMPLE_COUNTRY_CODE: http://example.com/edx/video?s3_url=
-WRITABLE_GRADEBOOK_URL: null
+WRITABLE_GRADEBOOK_URL: /gradebook # MODIFIED for use with Gradeook MFE
 
 ########################################################
 # We are not using any of the enterprise functionality #

--- a/src/bilder/images/edxapp/templates/edxapp/mitxonline/lms_only.yml.tmpl
+++ b/src/bilder/images/edxapp/templates/edxapp/mitxonline/lms_only.yml.tmpl
@@ -102,7 +102,7 @@ VERIFY_STUDENT:
     EXPIRING_SOON_WINDOW: 28
 VIDEO_CDN_URL:
     EXAMPLE_COUNTRY_CODE: http://example.com/edx/video?s3_url=
-WRITABLE_GRADEBOOK_URL: null
+WRITABLE_GRADEBOOK_URL: /gradebook  # MODIFIED for use with Gradeook MFE
 
 ########################################################
 # We are not using any of the enterprise functionality #

--- a/src/bilder/images/edxapp/templates/edxapp/xpro/lms_only.yml.tmpl
+++ b/src/bilder/images/edxapp/templates/edxapp/xpro/lms_only.yml.tmpl
@@ -102,7 +102,7 @@ VERIFY_STUDENT:
     EXPIRING_SOON_WINDOW: 28
 VIDEO_CDN_URL:
     EXAMPLE_COUNTRY_CODE: http://example.com/edx/video?s3_url=
-WRITABLE_GRADEBOOK_URL: null
+WRITABLE_GRADEBOOK_URL: /gradebook # MODIFIED for use with Gradeook MFE
 
 ########################################################
 # We are not using any of the enterprise functionality #


### PR DESCRIPTION
Adds QA pipelines for the gradebook MFE along with a single key change to the lms config. I have deployed this manually on mitxonline QA and it can be tested for this [course](https://courses-qa.mitxonline.mit.edu/gradebook/course-v1:TobiasU+Test101+TestSemester)