### PR TITLE
run npm run build:githash after building ocw webpack assets

### DIFF
--- a/pipelines/ocw/pipeline-theme-assets.yml
+++ b/pipelines/ocw/pipeline-theme-assets.yml
@@ -46,6 +46,7 @@ jobs:
           cd ocw-hugo-themes
           yarn install --pure-lockfile
           npm run build:webpack
+          npm run build:githash
           dt=$(date +%s)
           echo $dt > base-theme/dist/static/version.$dt.txt
           mkdir -p dist/ocw-hugo-themes/((hugo-theme-branch))


### PR DESCRIPTION
Closes https://github.com/mitodl/ol-infrastructure/issues/565

This PR adds the `npm run build:githash` command to the theme assets pipeline definition so that the `hash.txt` file is generated alongside the theme assets and Doof will be able to read the current deployed commit from the Concourse generated OCW Next sites.