### PR TITLE
Fixing sender email address and cookie name conflicts in edX deployments

### DIFF
--- a/pipelines/edx/mfe-frontend-app-learning-mitx-ci.yaml
+++ b/pipelines/edx/mfe-frontend-app-learning-mitx-ci.yaml
@@ -40,7 +40,7 @@ jobs:
       outputs:
       - name: mfe-app-learning/dist
       params:
-        ACCESS_TOKEN_COOKIE_NAME: edx-jwt-cookie-header-payload
+        ACCESS_TOKEN_COOKIE_NAME: mitx-ci-edx-jwt-cookie-header-payload
         BASE_URL: https://lms-ci.mitx.mit.edu
         CSRF_TOKEN_API_PATH: /csrf/api/v1/token
         FAVICON_URL: https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/favicon.ico
@@ -59,7 +59,7 @@ jobs:
         SITE_NAME: MITx Residential
         STUDIO_BASE_URL: https://studio-ci.mitx.mit.edu
         SUPPORT_URL: https://odl.zendesk.com/hc/en-us/requests/new
-        USER_INFO_COOKIE_NAME: edx-user-info
+        USER_INFO_COOKIE_NAME: mitx-ci-edx-user-info
       run:
         path: sh
         dir: mfe-app-learning

--- a/pipelines/edx/mfe-frontend-app-learning-mitx-production.yaml
+++ b/pipelines/edx/mfe-frontend-app-learning-mitx-production.yaml
@@ -40,7 +40,7 @@ jobs:
       outputs:
       - name: mfe-app-learning/dist
       params:
-        ACCESS_TOKEN_COOKIE_NAME: edx-jwt-cookie-header-payload
+        ACCESS_TOKEN_COOKIE_NAME: mitx-production-edx-jwt-cookie-header-payload
         BASE_URL: https://lms.mitx.mit.edu
         CSRF_TOKEN_API_PATH: /csrf/api/v1/token
         FAVICON_URL: https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/favicon.ico
@@ -59,7 +59,7 @@ jobs:
         SITE_NAME: MITx Residential
         STUDIO_BASE_URL: https://studio.mitx.mit.edu
         SUPPORT_URL: https://odl.zendesk.com/hc/en-us/requests/new
-        USER_INFO_COOKIE_NAME: edx-user-info
+        USER_INFO_COOKIE_NAME: mitx-production-edx-user-info
       run:
         path: sh
         dir: mfe-app-learning

--- a/pipelines/edx/mfe-frontend-app-learning-mitx-qa.yaml
+++ b/pipelines/edx/mfe-frontend-app-learning-mitx-qa.yaml
@@ -40,7 +40,7 @@ jobs:
       outputs:
       - name: mfe-app-learning/dist
       params:
-        ACCESS_TOKEN_COOKIE_NAME: edx-jwt-cookie-header-payload
+        ACCESS_TOKEN_COOKIE_NAME: mitx-qa-edx-jwt-cookie-header-payload
         BASE_URL: https://lms-qa.mitx.mit.edu
         CSRF_TOKEN_API_PATH: /csrf/api/v1/token
         FAVICON_URL: https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/favicon.ico
@@ -59,7 +59,7 @@ jobs:
         SITE_NAME: MITx Residential
         STUDIO_BASE_URL: https://studio-mitx-qa.mitx.mit.edu
         SUPPORT_URL: https://odl.zendesk.com/hc/en-us/requests/new
-        USER_INFO_COOKIE_NAME: edx-user-info
+        USER_INFO_COOKIE_NAME: mitx-qa-edx-user-info
       run:
         path: sh
         dir: mfe-app-learning

--- a/pipelines/edx/mfe-frontend-app-learning-mitx-staging-ci.yaml
+++ b/pipelines/edx/mfe-frontend-app-learning-mitx-staging-ci.yaml
@@ -40,7 +40,7 @@ jobs:
       outputs:
       - name: mfe-app-learning/dist
       params:
-        ACCESS_TOKEN_COOKIE_NAME: edx-jwt-cookie-header-payload
+        ACCESS_TOKEN_COOKIE_NAME: mitx-staging-ci-edx-jwt-cookie-header-payload
         BASE_URL: https://staging-ci.mitx.mit.edu
         CSRF_TOKEN_API_PATH: /csrf/api/v1/token
         FAVICON_URL: https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/favicon.ico
@@ -59,7 +59,7 @@ jobs:
         SITE_NAME: MITx Residential
         STUDIO_BASE_URL: https://studio-staging-ci.mitx.mit.edu
         SUPPORT_URL: https://odl.zendesk.com/hc/en-us/requests/new
-        USER_INFO_COOKIE_NAME: edx-user-info
+        USER_INFO_COOKIE_NAME: mitx-staging-ci-edx-user-info
       run:
         path: sh
         dir: mfe-app-learning

--- a/pipelines/edx/mfe-frontend-app-learning-mitx-staging-production.yaml
+++ b/pipelines/edx/mfe-frontend-app-learning-mitx-staging-production.yaml
@@ -40,26 +40,26 @@ jobs:
       outputs:
       - name: mfe-app-learning/dist
       params:
-        ACCESS_TOKEN_COOKIE_NAME: edx-jwt-cookie-header-payload
+        ACCESS_TOKEN_COOKIE_NAME: mitx-staging-production-edx-jwt-cookie-header-payload
         BASE_URL: https://staging.mitx.mit.edu
         CSRF_TOKEN_API_PATH: /csrf/api/v1/token
+        FAVICON_URL: https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/favicon.ico
         LMS_BASE_URL: https://staging.mitx.mit.edu
         LOGIN_URL: https://staging.mitx.mit.edu/login
         LOGOUT_URL: https://staging.mitx.mit.edu/logout
-        LOGO_URL: https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/logo.png
         LOGO_TRADEMARK_URL: https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/logo.png
+        LOGO_URL: https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/logo.png
         LOGO_WHITE_URL: https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/logo.png
-        FAVICON_URL: https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/favicon.ico
         MARKETING_SITE_BASE_URL: https://staging.mitx.mit.edu
         ORDER_HISTORY_URL:
         PUBLIC_PATH: /learn/
         REFRESH_ACCESS_TOKEN_ENDPOINT: https://staging.mitx.mit.edu/login_refresh
         SEARCH_CATALOG_URL: https://staging.mitx.mit.edu/courses
+        SESSION_COOKIE_DOMAIN: staging.mitx.mit.edu
         SITE_NAME: MITx Residential
         STUDIO_BASE_URL: https://studio-staging.mitx.mit.edu
         SUPPORT_URL: https://odl.zendesk.com/hc/en-us/requests/new
-        USER_INFO_COOKIE_NAME: edx-user-info
-        SESSION_COOKIE_DOMAIN: staging.mitx.mit.edu
+        USER_INFO_COOKIE_NAME: mitx-staging-production-edx-user-info
       run:
         path: sh
         dir: mfe-app-learning

--- a/pipelines/edx/mfe-frontend-app-learning-mitx-staging-qa.yaml
+++ b/pipelines/edx/mfe-frontend-app-learning-mitx-staging-qa.yaml
@@ -40,26 +40,26 @@ jobs:
       outputs:
       - name: mfe-app-learning/dist
       params:
-        ACCESS_TOKEN_COOKIE_NAME: edx-jwt-cookie-header-payload
+        ACCESS_TOKEN_COOKIE_NAME: mitx-staging-qa-edx-jwt-cookie-header-payload
         BASE_URL: https://staging-qa.mitx.mit.edu
         CSRF_TOKEN_API_PATH: /csrf/api/v1/token
+        FAVICON_URL: https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/favicon.ico
         LMS_BASE_URL: https://mitx-qa-draft.mitx.mit.edu
         LOGIN_URL: https://mitx-qa-draft.mitx.mit.edu/login
         LOGOUT_URL: https://mitx-qa-draft.mitx.mit.edu/logout
-        LOGO_URL: https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/logo.png
         LOGO_TRADEMARK_URL: https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/logo.png
+        LOGO_URL: https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/logo.png
         LOGO_WHITE_URL: https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/logo.png
-        FAVICON_URL: https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/favicon.ico
         MARKETING_SITE_BASE_URL: https://mitx-qa-draft.mitx.mit.edu
         ORDER_HISTORY_URL:
         PUBLIC_PATH: /learn/
         REFRESH_ACCESS_TOKEN_ENDPOINT: https://mitx-qa-draft.mitx.mit.edu/login_refresh
         SEARCH_CATALOG_URL: https://mitx-qa-draft.mitx.mit.edu/courses
+        SESSION_COOKIE_DOMAIN: staging-mitx-qa-draft.mitx.mit.edu
         SITE_NAME: MITx Residential
         STUDIO_BASE_URL: https://studio-mitx-qa-draft.mitx.mit.edu
         SUPPORT_URL: https://odl.zendesk.com/hc/en-us/requests/new
-        USER_INFO_COOKIE_NAME: edx-user-info
-        SESSION_COOKIE_DOMAIN: staging-mitx-qa-draft.mitx.mit.edu
+        USER_INFO_COOKIE_NAME: mitx-staging-qa-edx-user-info
       run:
         path: sh
         dir: mfe-app-learning

--- a/pipelines/edx/mfe-frontend-app-learning-mitxonline-production.yml
+++ b/pipelines/edx/mfe-frontend-app-learning-mitxonline-production.yml
@@ -40,36 +40,36 @@ jobs:
       outputs:
       - name: mfe-app-learning/dist
       params:
-        ACCESS_TOKEN_COOKIE_NAME: edx-jwt-cookie-header-payload
+        ABOUT_US_URL: https://mitxonline.mit.edu/about-us/
+        ACCESS_TOKEN_COOKIE_NAME: mitxonline-production-edx-jwt-cookie-header-payload
         BASE_URL: https://courses.mitxonline.mit.edu/learn
         CSRF_TOKEN_API_PATH: /csrf/api/v1/token
+        Contact: https://mitxonline.zendesk.com/hc/en-us/requests/new
+        FAVICON_URL: https://raw.githubusercontent.com/mitodl/mitxonline-theme/main/lms/static/images/favicon.ico
+        HONOR_CODE_URL: https://mitxonline.mit.edu/honor-code/
         LMS_BASE_URL: https://courses.mitxonline.mit.edu
         LOGIN_URL: https://courses.mitxonline.mit.edu/login
         LOGOUT_URL: https://courses.mitxonline.mit.edu/logout
-        LOGO_URL: https://raw.githubusercontent.com/mitodl/mitxonline-theme/main/lms/static/images/logo.png
+        LOGO_ALT_TEXT: ''
         LOGO_TRADEMARK_URL: https://raw.githubusercontent.com/mitodl/mitxonline-theme/main/lms/static/images/logo.png
+        LOGO_URL: https://raw.githubusercontent.com/mitodl/mitxonline-theme/main/lms/static/images/logo.png
         LOGO_WHITE_URL: https://raw.githubusercontent.com/mitodl/mitxonline-theme/main/lms/static/images/logo.png
-        FAVICON_URL: https://raw.githubusercontent.com/mitodl/mitxonline-theme/main/lms/static/images/favicon.ico
         MARKETING_SITE_BASE_URL: https://mitxonline.mit.edu
         ORDER_HISTORY_URL:
+        PRIVACY_POLICY_URL: https://mitxonline.mit.edu/privacy-policy/
         PUBLIC_PATH: /learn/
         REFRESH_ACCESS_TOKEN_ENDPOINT: https://courses.mitxonline.mit.edu/login_refresh
         SEARCH_CATALOG_URL: https://courses.mitxonline.mit.edu/courses
-        SITE_NAME: MITx Online
-        STUDIO_BASE_URL: https://studio.mitxonline.mit.edu
-        SUPPORT_URL: https://mitxonline.zendesk.com/hc/en-us
-        USER_INFO_COOKIE_NAME: edx-user-info
         SESSION_COOKIE_DOMAIN: .mitxonline.mit.edu
-        ABOUT_US_URL: https://mitxonline.mit.edu/about-us/
-        PRIVACY_POLICY_URL: https://mitxonline.mit.edu/privacy-policy/
-        HONOR_CODE_URL: https://mitxonline.mit.edu/honor-code/
-        TERMS_OF_SERVICE_URL: https://mitxonline.mit.edu/terms-of-service/
-        Contact: https://mitxonline.zendesk.com/hc/en-us/requests/new
-        SUPPORT_CENTER_URL: https://mitxonline.zendesk.com/hc/en-us
-        SUPPORT_CENTER_TEXT: Support Center
-        TRADEMARK_TEXT: © MITxOnline. All rights reserved except where noted.
+        SITE_NAME: MITx Online
         SITE_URL: https://mitxonline.mit.edu
-        LOGO_ALT_TEXT: ''
+        STUDIO_BASE_URL: https://studio.mitxonline.mit.edu
+        SUPPORT_CENTER_TEXT: Support Center
+        SUPPORT_CENTER_URL: https://mitxonline.zendesk.com/hc/en-us
+        SUPPORT_URL: https://mitxonline.zendesk.com/hc/en-us
+        TERMS_OF_SERVICE_URL: https://mitxonline.mit.edu/terms-of-service/
+        TRADEMARK_TEXT: © MITxOnline. All rights reserved except where noted.
+        USER_INFO_COOKIE_NAME: mitxonline-production-edx-user-info
       run:
         path: sh
         dir: mfe-app-learning

--- a/pipelines/edx/mfe-frontend-app-learning-mitxonline-qa.yml
+++ b/pipelines/edx/mfe-frontend-app-learning-mitxonline-qa.yml
@@ -41,7 +41,7 @@ jobs:
       - name: mfe-app-learning/dist
       params:
         ABOUT_US_URL: https://rc.mitxonline.mit.edu/about-us/
-        ACCESS_TOKEN_COOKIE_NAME: edx-jwt-cookie-header-payload
+        ACCESS_TOKEN_COOKIE_NAME: mitxonline-qa-edx-jwt-cookie-header-payload
         BASE_URL: https://courses-qa.mitxonline.mit.edu/learn
         CSRF_TOKEN_API_PATH: /csrf/api/v1/token
         Contact: mailto:mitxonline-support@mit.edu
@@ -69,7 +69,7 @@ jobs:
         SUPPORT_URL: https://mitx-micromasters.zendesk.com/hc/en-us/requests/new
         TERMS_OF_SERVICE_URL: https://rc.mitxonline.mit.edu/terms-of-service/
         TRADEMARK_TEXT: © MITxOnline. All rights reserved except where noted.
-        USER_INFO_COOKIE_NAME: edx-user-info
+        USER_INFO_COOKIE_NAME: mitxonline-qa-edx-user-info
       run:
         path: sh
         dir: mfe-app-learning

--- a/pipelines/edx/mfe-frontend-app-learning-xpro-ci.yaml
+++ b/pipelines/edx/mfe-frontend-app-learning-xpro-ci.yaml
@@ -40,7 +40,7 @@ jobs:
       outputs:
       - name: mfe-app-learning/dist
       params:
-        ACCESS_TOKEN_COOKIE_NAME: edx-jwt-cookie-header-payload
+        ACCESS_TOKEN_COOKIE_NAME: xpro-ci-edx-jwt-cookie-header-payload
         BASE_URL: https://courses-ci.xpro.mit.edu
         CSRF_TOKEN_API_PATH: /csrf/api/v1/token
         FAVICON_URL: https://raw.githubusercontent.com/mitodl/mitxpro-theme/master/lms/static/images/favicon.ico
@@ -59,7 +59,7 @@ jobs:
         SITE_NAME: MIT xPRO
         STUDIO_BASE_URL: https://studio-ci.xpro.mit.edu
         SUPPORT_URL: https://xpro.zendesk.com/hc
-        USER_INFO_COOKIE_NAME: edx-user-info
+        USER_INFO_COOKIE_NAME: xpro-ci-edx-user-info
       run:
         path: sh
         dir: mfe-app-learning

--- a/pipelines/edx/mfe-frontend-app-learning-xpro-production.yaml
+++ b/pipelines/edx/mfe-frontend-app-learning-xpro-production.yaml
@@ -40,7 +40,7 @@ jobs:
       outputs:
       - name: mfe-app-learning/dist
       params:
-        ACCESS_TOKEN_COOKIE_NAME: edx-jwt-cookie-header-payload
+        ACCESS_TOKEN_COOKIE_NAME: xpro-production-edx-jwt-cookie-header-payload
         BASE_URL: https://courses.xpro.mit.edu
         CSRF_TOKEN_API_PATH: /csrf/api/v1/token
         FAVICON_URL: https://raw.githubusercontent.com/mitodl/mitxpro-theme/master/lms/static/images/favicon.ico
@@ -59,7 +59,7 @@ jobs:
         SITE_NAME: MIT xPRO
         STUDIO_BASE_URL: https://studio.xpro.mit.edu
         SUPPORT_URL: https://xpro.zendesk.com/hc
-        USER_INFO_COOKIE_NAME: edx-user-info
+        USER_INFO_COOKIE_NAME: xpro-production-edx-user-info
       run:
         path: sh
         dir: mfe-app-learning

--- a/pipelines/edx/mfe-frontend-app-learning-xpro-qa.yaml
+++ b/pipelines/edx/mfe-frontend-app-learning-xpro-qa.yaml
@@ -40,7 +40,7 @@ jobs:
       outputs:
       - name: mfe-app-learning/dist
       params:
-        ACCESS_TOKEN_COOKIE_NAME: edx-jwt-cookie-header-payload
+        ACCESS_TOKEN_COOKIE_NAME: xpro-qa-edx-jwt-cookie-header-payload
         BASE_URL: https://courses-rc.xpro.mit.edu
         CSRF_TOKEN_API_PATH: /csrf/api/v1/token
         FAVICON_URL: https://raw.githubusercontent.com/mitodl/mitxpro-theme/master/lms/static/images/favicon.ico
@@ -59,7 +59,7 @@ jobs:
         SITE_NAME: MIT xPRO
         STUDIO_BASE_URL: https://studio-rc.xpro.mit.edu
         SUPPORT_URL: https://xpro.zendesk.com/hc
-        USER_INFO_COOKIE_NAME: edx-user-info
+        USER_INFO_COOKIE_NAME: xpro-qa-edx-user-info
       run:
         path: sh
         dir: mfe-app-learning

--- a/src/bilder/images/edxapp/templates/edxapp/mitx-staging/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp/templates/edxapp/mitx-staging/common_values.yml.tmpl
@@ -36,8 +36,8 @@ SECRET_KEY: {{ .Data.django_secret_key }}
 JWT_AUTH:  # NEEDS ATTENTION
     JWT_AUDIENCE: mitx
     JWT_AUTH_COOKIE: {{ env "ENVIRONMENT"}}-edx-jwt-cookie
-    JWT_AUTH_COOKIE_HEADER_PAYLOAD: edx-jwt-cookie-header-payload
-    JWT_AUTH_COOKIE_SIGNATURE: edx-jwt-cookie-signature
+    JWT_AUTH_COOKIE_HEADER_PAYLOAD: {{ env "ENVIRONMENT" }}-edx-jwt-cookie-header-payload
+    JWT_AUTH_COOKIE_SIGNATURE: {{ env "ENVIRONMENT" }}-edx-jwt-cookie-signature
     JWT_ISSUER: 'https://{{ key "edxapp/lms-domain" }}/oauth2'
     JWT_LOGIN_CLIENT_ID: login-service-client-id
     JWT_LOGIN_SERVICE_USERNAME: login_service_user
@@ -141,6 +141,7 @@ BUGS_EMAIL: odl-devops@mit.edu  # MODIFIED
 EMAIL_USE_DEFAULT_FROM_FOR_BULK: true
 BULK_EMAIL_EMAILS_PER_TASK: 500
 BULK_EMAIL_LOG_SENT_EMAILS: false
+BULK_EMAIL_DEFAULT_FROM_EMAIL: {{ key "edxapp/sender-email-address" }} # ADDED
 CACHES:  # MODIFIED
     celery:
       <<: *redis_cache_config
@@ -243,7 +244,7 @@ DJFS:
     type: osfs
     url_root: /static/django-pyfs
 
-EDXMKTG_USER_INFO_COOKIE_NAME: edx-user-info
+EDXMKTG_USER_INFO_COOKIE_NAME: {{ env "ENVIRONMENT" }}-edx-user-info
 EDX_PLATFORM_REVISION: release
 ELASTIC_SEARCH_CONFIG:
 -   host: elasticsearch.service.consul
@@ -361,7 +362,7 @@ INTEGRATED_CHANNELS_API_CHUNK_TRANSMISSION_LIMIT:
     SAP: 1
 JWT_EXPIRATION: 30
 LANGUAGE_CODE: en
-LANGUAGE_COOKIE: openedx-language-preference
+LANGUAGE_COOKIE: {{ env "ENVIRONMENT" }}-openedx-language-preference
 LEARNER_PORTAL_URL_ROOT: https://learner-portal-localhost:18000
 LMS_BASE: {{ key "edxapp/lms-domain" }}  # MODIFIED
 LMS_INTERNAL_ROOT_URL: https://{{ key "edxapp/lms-domain" }}  # MODIFIED

--- a/src/bilder/images/edxapp/templates/edxapp/mitx/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp/templates/edxapp/mitx/common_values.yml.tmpl
@@ -36,8 +36,8 @@ SECRET_KEY: {{ .Data.django_secret_key }}
 JWT_AUTH:  # NEEDS ATTENTION
     JWT_AUDIENCE: mitx
     JWT_AUTH_COOKIE: {{ env "ENVIRONMENT"}}-edx-jwt-cookie
-    JWT_AUTH_COOKIE_HEADER_PAYLOAD: edx-jwt-cookie-header-payload
-    JWT_AUTH_COOKIE_SIGNATURE: edx-jwt-cookie-signature
+    JWT_AUTH_COOKIE_HEADER_PAYLOAD: {{ env "ENVIRONMENT" }}-edx-jwt-cookie-header-payload
+    JWT_AUTH_COOKIE_SIGNATURE: {{ env "ENVIRONMENT" }}-edx-jwt-cookie-signature
     JWT_ISSUER: https://{{ key "edxapp/lms-domain" }}/oauth2
     JWT_LOGIN_CLIENT_ID: login-service-client-id
     JWT_LOGIN_SERVICE_USERNAME: login_service_user
@@ -142,6 +142,7 @@ BUGS_EMAIL: odl-devops@mit.edu  # MODIFIED
 EMAIL_USE_DEFAULT_FROM_FOR_BULK: true
 BULK_EMAIL_EMAILS_PER_TASK: 500
 BULK_EMAIL_LOG_SENT_EMAILS: false
+BULK_EMAIL_DEFAULT_FROM_EMAIL: {{ key "edxapp/sender-email-address" }} # ADDED
 CACHES:  # MODIFIED
     celery:
       <<: *redis_cache_config
@@ -243,7 +244,7 @@ DJFS:
     type: osfs
     url_root: /static/django-pyfs
 
-EDXMKTG_USER_INFO_COOKIE_NAME: edx-user-info
+EDXMKTG_USER_INFO_COOKIE_NAME: {{ env "ENVIRONMENT" }}-edx-user-info
 EDX_PLATFORM_REVISION: release
 ELASTIC_SEARCH_CONFIG:
 -   host: elasticsearch.service.consul
@@ -361,7 +362,7 @@ INTEGRATED_CHANNELS_API_CHUNK_TRANSMISSION_LIMIT:
     SAP: 1
 JWT_EXPIRATION: 30
 LANGUAGE_CODE: en
-LANGUAGE_COOKIE: openedx-language-preference
+LANGUAGE_COOKIE: {{ env "ENVIRONMENT" }}-openedx-language-preference
 LEARNER_PORTAL_URL_ROOT: https://learner-portal-localhost:18000
 LMS_BASE: {{ key "edxapp/lms-domain" }}  # MODIFIED
 LMS_INTERNAL_ROOT_URL: https://{{ key "edxapp/lms-domain" }}  # MODIFIED

--- a/src/bilder/images/edxapp/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -32,8 +32,8 @@ SECRET_KEY: {{ .Data.django_secret_key }}
 JWT_AUTH:  # NEEDS ATTENTION
     JWT_AUDIENCE: mitxonline
     JWT_AUTH_COOKIE: {{ env "ENVIRONMENT"}}-edx-jwt-cookie
-    JWT_AUTH_COOKIE_HEADER_PAYLOAD: edx-jwt-cookie-header-payload
-    JWT_AUTH_COOKIE_SIGNATURE: edx-jwt-cookie-signature
+    JWT_AUTH_COOKIE_HEADER_PAYLOAD: {{ env "ENVIRONMENT" }}-edx-jwt-cookie-header-payload
+    JWT_AUTH_COOKIE_SIGNATURE: {{ env "ENVIRONMENT" }}-edx-jwt-cookie-signature
     JWT_ISSUER: 'https://{{ key "edxapp/lms-domain" }}/oauth2'
     JWT_LOGIN_CLIENT_ID: login-service-client-id
     JWT_LOGIN_SERVICE_USERNAME: login_service_user
@@ -136,6 +136,7 @@ BUGS_EMAIL: odl-devops@mit.edu  # MODIFIED
 EMAIL_USE_DEFAULT_FROM_FOR_BULK: true
 BULK_EMAIL_EMAILS_PER_TASK: 500
 BULK_EMAIL_LOG_SENT_EMAILS: false
+BULK_EMAIL_DEFAULT_FROM_EMAIL: {{ key "edxapp/sender-email-address" }} # ADDED
 CACHES:  # MODIFIED
     celery:
       <<: *redis_cache_config
@@ -228,7 +229,7 @@ DJFS:
     type: osfs
     url_root: /static/django-pyfs
 
-EDXMKTG_USER_INFO_COOKIE_NAME: edx-user-info
+EDXMKTG_USER_INFO_COOKIE_NAME: {{ env "ENVIRONMENT" }}-edx-user-info
 EDX_PLATFORM_REVISION: release
 ELASTIC_SEARCH_CONFIG:
 -   host: elasticsearch.service.consul
@@ -317,7 +318,7 @@ INTEGRATED_CHANNELS_API_CHUNK_TRANSMISSION_LIMIT:
     SAP: 1
 JWT_EXPIRATION: 30
 LANGUAGE_CODE: en
-LANGUAGE_COOKIE: openedx-language-preference
+LANGUAGE_COOKIE: {{ env "ENVIRONMENT" }}-openedx-language-preference
 LEARNER_PORTAL_URL_ROOT: https://learner-portal-localhost:18000
 LMS_BASE: {{ key "edxapp/lms-domain" }}  # MODIFIED
 LMS_INTERNAL_ROOT_URL: https://{{ key "edxapp/lms-domain" }}  # MODIFIED

--- a/src/bilder/images/edxapp/templates/edxapp/xpro/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp/templates/edxapp/xpro/common_values.yml.tmpl
@@ -35,8 +35,8 @@ SECRET_KEY: {{ .Data.django_secret_key }}
 JWT_AUTH:  # NEEDS ATTENTION
     JWT_AUDIENCE: xpro
     JWT_AUTH_COOKIE: {{ env "ENVIRONMENT"}}-edx-jwt-cookie
-    JWT_AUTH_COOKIE_HEADER_PAYLOAD: edx-jwt-cookie-header-payload
-    JWT_AUTH_COOKIE_SIGNATURE: edx-jwt-cookie-signature
+    JWT_AUTH_COOKIE_HEADER_PAYLOAD: {{ env "ENVIRONMENT" }}-edx-jwt-cookie-header-payload
+    JWT_AUTH_COOKIE_SIGNATURE: {{ env "ENVIRONMENT" }}-edx-jwt-cookie-signature
     JWT_ISSUER: 'https://{{ key "edxapp/lms-domain" }}/oauth2'
     JWT_LOGIN_CLIENT_ID: login-service-client-id
     JWT_LOGIN_SERVICE_USERNAME: login_service_user
@@ -139,6 +139,7 @@ BUGS_EMAIL: odl-devops@mit.edu  # MODIFIED
 EMAIL_USE_DEFAULT_FROM_FOR_BULK: true
 BULK_EMAIL_EMAILS_PER_TASK: 500
 BULK_EMAIL_LOG_SENT_EMAILS: false
+BULK_EMAIL_DEFAULT_FROM_EMAIL: {{ key "edxapp/sender-email-address" }} # ADDED
 CACHES:  # MODIFIED
     celery:
       <<: *redis_cache_config
@@ -231,7 +232,7 @@ DJFS:
     type: osfs
     url_root: /static/django-pyfs
 
-EDXMKTG_USER_INFO_COOKIE_NAME: edx-user-info
+EDXMKTG_USER_INFO_COOKIE_NAME: {{ env "ENVIRONMENT" }}-edx-user-info
 EDX_PLATFORM_REVISION: release
 ELASTIC_SEARCH_CONFIG:
 -   host: elasticsearch.service.consul
@@ -338,7 +339,7 @@ INTEGRATED_CHANNELS_API_CHUNK_TRANSMISSION_LIMIT:
     SAP: 1
 JWT_EXPIRATION: 30
 LANGUAGE_CODE: en
-LANGUAGE_COOKIE: openedx-language-preference
+LANGUAGE_COOKIE: {{ env "ENVIRONMENT" }}-openedx-language-preference
 LEARNER_PORTAL_URL_ROOT: https://learner-portal-localhost:18000
 LMS_BASE: {{ key "edxapp/lms-domain" }}  # MODIFIED
 LMS_INTERNAL_ROOT_URL: https://{{ key "edxapp/lms-domain" }}  # MODIFIED

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.Production.yaml
@@ -22,7 +22,7 @@ config:
   edxapp:manage_dns: 'true'
   edxapp:min_web_nodes: '5'
   edxapp:min_worker_nodes: '2'
-  edxapp:sender_email_address: support@edxapp-mail-production.mitx.mit.edu
+  edxapp:sender_email_address: mitx-support@mit.edu
   edxapp:target_vpc: residential_mitx_vpc
   edxapp:web_instance_type: general_purpose_xlarge
   edxapp:web_node_capacity: '5'

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
@@ -19,10 +19,10 @@ config:
     secure: v1:qzfe99Jb8n0TnEQS:Y6fSOS8lksj7WvED+V7kCtV7arDtwx7184Fw330Mwh9JDHW72rVd8y7Nm0fF8ANCcFCwDV5EwSU2Fcc+X47NHDOLCOQv16lyB6jWOF2mTr/veRax6MbXY9NlLmsfp9EBQesDCitULbkz9hyHcHT3GPI=
   edxapp:google_analytics_id: UA-5145472-48
   edxapp:mail_domain: edxapp-mail.mitxonline.mit.edu
-  edxapp:manage_dns: 'true'
+  edxapp:manage_dns: "true"
   edxapp:sender_email_address: mitxonline-support@mit.edu
-  edxapp:web_node_capacity: '6'
-  edxapp:worker_node_capacity: '3'
+  edxapp:web_node_capacity: "9"
+  edxapp:worker_node_capacity: "5"
   mongodb:admin_password:
     secure: v1:Z57JZ5RX59bVTb2j:zIERkkj7Vs1e7J+qZNhaPOo3H6owlQn3Ovj9VpikQaXbWa4uBV4B7Lf6I9KWoDMohXYJoId1Dn5waiSlmOBp19NhoPQNilteLJDmjyl5T2N6zNxsLi8T3u7C
   vault:address: https://vault-production.odl.mit.edu

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.Production.yaml
@@ -16,12 +16,12 @@ config:
     secure: v1:YHqAWSdn7TNUn7d+:IBgiGsl4r8vymID8NV43rnfJy+qsJSXm/jXaWWALUfF9zXqRO4zJZhLS0d+etijGVwaZnF8v5zXlo+EczFrCe7ICHpS85zHgifbfDcw=
   edxapp:google_analytics_id: UA-5145472-38
   edxapp:mail_domain: edxapp-mail-production.xpro.mit.edu
-  edxapp:manage_dns: 'true'
-  edxapp:min_web_nodes: '3'
-  edxapp:min_worker_nodes: '2'
-  edxapp:sender_email_address: support@edxapp-mail-production.xpro.mit.edu
-  edxapp:web_node_capacity: '5'
-  edxapp:worker_node_capacity: '3'
+  edxapp:manage_dns: "true"
+  edxapp:min_web_nodes: "3"
+  edxapp:min_worker_nodes: "2"
+  edxapp:sender_email_address: support@xpro.mit.edu
+  edxapp:web_node_capacity: "5"
+  edxapp:worker_node_capacity: "3"
   mongodb:atlas_project_id: 61b727c6b5bd11656741308b
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production


### PR DESCRIPTION
This fixes two distinct and unrelated issues that we are seeing in our edX installations.

- When working across installations that share a subdomain (e.g. QA and production or residential staging and live) users are unable to stay logged into the corresponding edX installations. This is due to a conflict in the cookie names related to JWT sessions for e.g. the learner MFE. This adds environment scoping to all of the cookie names that might conflict across installations.
- When sending bulk emails through the instructor dashboard we are seeing various failure modes. The root of the issue is that the `BULK_EMAIL_DEFAULT_FROM_EMAIL` value needs to be overridden or else those bulk emails will be sent from `no-reply@example.com`. This adds an appropriate value for that setting to each of the configuration templates relating to our separate deployments.