### PR TITLE
Excluding cgroups from host metrics collection

### DIFF
--- a/src/bilder/images/consul/templates/vector/metrics.yaml
+++ b/src/bilder/images/consul/templates/vector/metrics.yaml
@@ -8,6 +8,15 @@ sources:
 
   host_metrics:
     type: host_metrics
+    scrape_interval_secs: 60
+    collectors:
+    - cpu
+    - disk
+    - filesystem
+    - load
+    - host
+    - memory
+    - network
 
 transforms:
   host_metrics_relabel:

--- a/src/bilder/images/edxapp/templates/vector/metrics.yaml.j2
+++ b/src/bilder/images/edxapp/templates/vector/metrics.yaml.j2
@@ -2,6 +2,15 @@
 sources:
   host_metrics:
     type: host_metrics
+    scrape_interval_secs: 60
+    collectors:
+      - cpu
+      - disk
+      - filesystem
+      - load
+      - host
+      - memory
+      - network
   nginx_metrics:
     type: nginx_metrics
     endpoints:

--- a/src/bilder/images/vault/templates/vector/metrics.yaml
+++ b/src/bilder/images/vault/templates/vector/metrics.yaml
@@ -10,6 +10,15 @@ sources:
 
   host_metrics:
     type: host_metrics
+    scrape_interval_secs: 60
+    collectors:
+    - cpu
+    - disk
+    - filesystem
+    - load
+    - host
+    - memory
+    - network
 
 transforms:
   host_metrics_relabel:


### PR DESCRIPTION
The cgroups metrics are contributing significantly to our overall metrics cardinality in Grafana. This also sets the scrape interval to 60 seconds.