### PR TITLE
Feature/concourse worker classes

### DIFF
--- a/src/bilder/components/concourse/templates/concourse.service.j2
+++ b/src/bilder/components/concourse/templates/concourse.service.j2
@@ -14,6 +14,8 @@ EnvironmentFile=-{{ concourse_config.env_file_path }}
 ExecReload=/bin/kill -HUP $MAINPID
 {% endif %}
 {% if concourse_config._node_type == "worker" %}
+EnvironmentFile=-/etc/default/concourse-team 
+EnvironmentFile=-/etc/default/concourse-tags 
 Delegate=true  {# Allow the Concourse worker to manage its own cgroups for container execution #}
 KillSignal=SIGUSR2
 KillMode=process

--- a/src/ol_infrastructure/applications/concourse/Pulumi.applications.concourse.CI.yaml
+++ b/src/ol_infrastructure/applications/concourse/Pulumi.applications.concourse.CI.yaml
@@ -10,17 +10,63 @@ config:
     secure: v1:qHlfVScY6TRQO3Xy:Yvn53MfChba/lCUxcp3hKjKJX9cqjfR2OcsrbJFEY36IhwJIW7V16PKpuHc9cjjk
   concourse:dockerhub_credentials:
     secure: v1:slySRgEfav4QWI/c:WGfHXvftFBvFnuK5SctOZTn9zjkx+bPb9PGsoaL4T2LFUK/M3Ba1JC9hu3h2IPjTOG4RIaD155eMhC/LJ0GCw5c8hQFJHhZJ1dbatoY1bo6kH483ICy7EZ0hUQf/bPZmMag=
-  concourse:iam_policies:
-  - base
-  - ocw
-  - operations
   concourse:pypi_credentials:
     secure: v1:GxB2bdvsKAefNBQi:CmibK+AuqOF8K77zHl9qjzOvQ6wplpNKFgTpxdFwY8wDoQJKpD7mOArnyaBI1OO/BzSAl5HmgFdSskWHKFrZXV8DlzRo2N2sx2n1P7HF4/dHAXTIY7yhWLgavogXAw==
   concourse:target_vpc: operations_vpc
+  concourse:web_auto_scale:
+    desired: 1
+    max: 3
+    min: 1
   concourse:web_host_domain: cicd-ci.odl.mit.edu
-  concourse:web_node_capacity: "1"
-  concourse:worker_disk_size: "200"
-  concourse:worker_node_capacity: "2"
+  concourse:web_iam_policies:
+  - base
+  - ocw
+  - operations
+  concourse:workers:
+  - auto_scale:
+      desired: 1
+      max: 10
+      min: 1
+    aws_tags:
+      OU: open-courseware
+    concourse_tags: []
+    concourse_team:
+    - ocw
+    disk_size_gb: 200
+    iam_policies:
+    - base
+    - ocw
+    instance_type: m5a.xlarge
+    name: ocw
+  - auto_scale:
+      desired: 1
+      max: 2
+      min: 1
+    aws_tags:
+      OU: operations
+    concourse_tags: []
+    concourse_team:
+    - infra
+    disk_size_gb: 100
+    iam_policies:
+    - base
+    instance_type: t3a.medium
+    name: infrastructure
+  - auto_scale:
+      desired: 1
+      max: 2
+      min: 1
+    aws_tags:
+      OU: operations
+    concourse_tags:
+    concourse_team:
+    desired_capacity: 2
+    disk_size_gb: 100
+    iam_policies:
+    - base
+    - operations
+    instance_type: t3a.medium
+    name: generic
   consul:address: https://consul-operations-ci.odl.mit.edu
   vault:address: https://vault-ci.odl.mit.edu
   vault_server:env_namespace: operations.ci

--- a/src/ol_infrastructure/applications/concourse/Pulumi.applications.concourse.CI.yaml
+++ b/src/ol_infrastructure/applications/concourse/Pulumi.applications.concourse.CI.yaml
@@ -1,4 +1,3 @@
----
 secretsprovider: awskms://alias/infrastructure-secrets-ci
 encryptedkey: AQICAHjEYf3gV5ZTnviCJcHwGnUuLzld5EuYumgMrRde6bvXUgE9rvKwMh36kigoyf0oNRRpAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM3ptgm6NCCpX9CmtCAgEQgDseumxlwIAYWyEvpYheyiv6TaJwKSlDTcyCRfrJ30eGefNBoi3DJK6NfWf2V7R6RsCBq8uoJfoOL/Cshw==
 config:
@@ -29,9 +28,10 @@ config:
       min: 1
     aws_tags:
       OU: open-courseware
-    concourse_tags: []
-    concourse_team:
-    - ocw
+    concourse_tags:
+    - tag1
+    - tag2
+    concourse_team: ocw
     disk_size_gb: 200
     iam_policies:
     - base
@@ -44,9 +44,9 @@ config:
       min: 1
     aws_tags:
       OU: operations
-    concourse_tags: []
-    concourse_team:
-    - infra
+    concourse_tags:
+    - tag3
+    concourse_team: infra
     disk_size_gb: 100
     iam_policies:
     - base
@@ -58,13 +58,14 @@ config:
       min: 1
     aws_tags:
       OU: operations
-    concourse_tags:
-    concourse_team:
+    concourse_tags: null
+    concourse_team: null
     desired_capacity: 2
     disk_size_gb: 100
     iam_policies:
     - base
     - operations
+    - infra
     instance_type: t3a.medium
     name: generic
   consul:address: https://consul-operations-ci.odl.mit.edu

--- a/src/ol_infrastructure/applications/concourse/Pulumi.applications.concourse.Production.yaml
+++ b/src/ol_infrastructure/applications/concourse/Pulumi.applications.concourse.Production.yaml
@@ -11,19 +11,59 @@ config:
     secure: v1:MVLu2ciX/IoD8sgo:Jgmo9VuyRaTNqVBdX0vQtBmI2cMQ5dbrSJ6AWReAw9mh6BRFs4M3mWdOlLha7P2FJz1i+zyiy4z8s0/LHvYtJBDJuvDvn6OEAt58zF+F1LMyr3k3+H7/Vryg
   concourse:dockerhub_credentials:
     secure: v1:RHqcCACmlYI66ydu:Ip3KUF8DM0GkBcWQg3Jfz+bQHtJ0IgQK2D3s8VdI+U+fcMdqy4xxeM8uEwkES/OrWeAYgIUzEHao7KtqS9O6vbtd0K7lib6n7KEdLSS4HWt6CmkPHaV+/EY+APJHpZqx8BQ=
-  concourse:iam_policies:
-  - base
-  - ocw
-  - operations
   concourse:pypi_credentials:
     secure: v1:i3a+7goVdWZMQS9Y:wnaKtictwJtO06zrMQAowVQCenHH1A9z3GjL31QtmHDyxwJKApCzlxcpUDEAaMGBW/EUogMnrrKxjO/PLCt0/HBqe6Rc8RCoSI+TlKeqbADFFxRB3RkIMyPt
   concourse:target_vpc: operations_vpc
   concourse:web_host_domain: cicd.odl.mit.edu
   concourse:web_instance_type: general_purpose_large
-  concourse:web_node_capacity: "6"
-  concourse:worker_disk_size: "500"
-  concourse:worker_instance_type: general_purpose_xlarge
-  concourse:worker_node_capacity: "30"
+  concourse:web_iam_policies:
+  - base
+  - ocw
+  - operations
+  concourse:web_auto_scale:
+    desired: 4
+    max: 10
+    min: 1
+  concourse:workers:
+  - auto_scale:
+      desired: 20
+      max: 50
+      min: 3
+    aws_tags:
+      OU: open-courseware
+    concourse_team: ocw
+    disk_size_gb: 500
+    iam_policies:
+    - base
+    - ocw
+    instance_type: m5a.xlarge
+    name: ocw
+  - auto_scale:
+      desired: 2
+      max: 2
+      min: 2
+    aws_tags:
+      OU: operations
+    concourse_team: infrastructure
+    disk_size_gb: 100
+    iam_policies:
+    - base
+    - infra
+    - operations
+    instance_type: t3a.medium
+    name: infra
+  - auto_scale:
+      desired: 3
+      max: 5
+      min: 2
+    aws_tags:
+      OU: operations
+    disk_size_gb: 200
+    iam_policies:
+    - base
+    - operations
+    instance_type: t3a.large
+    name: generic
   consul:address: https://consul-operations-production.odl.mit.edu
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production

--- a/src/ol_infrastructure/applications/concourse/Pulumi.applications.concourse.QA.yaml
+++ b/src/ol_infrastructure/applications/concourse/Pulumi.applications.concourse.QA.yaml
@@ -11,19 +11,59 @@ config:
     secure: v1:cINWNdW8VXvoHANP:vYFipTry9pNokRsD9FnC0+8eurxu28iewwca52MXCyrVflWnaWWvi3FD3LP9O73KL/wznZCUSXk9lbsv6vySTSDR+1II7fNr1AnrjdQclygaFKBpb2EJgcwd1w==
   concourse:dockerhub_credentials:
     secure: v1:mTp3onp07/AT5WuS:iz87DQjylNjzuYMCyvpQohqo6nxBiAHGpt0OOUMRjVgAVekosjiXT7yabTTxXmQobnxwOuGcH/SOvwmu6wy+hmVlTLJjkO7Hd6O5SW5/KRADBzYLyrP/1Kl8LU5aU2qFZpc=
-  concourse:iam_policies:
-  - base
-  - ocw
-  - operations
   concourse:pypi_credentials:
     secure: v1:LqP0Y/263bKeJDvo:2OOk40+MkkZvclKWn+l1lQer0DH6nG7FzGXHO2yjSmXG0KCBAdZldwjU+17+Yrj6hiQSZuDe7C/fUo+egWWKO9lRIR7zebOvywdXMlCOd0/d/nh5uXeeUcqTeQiVlg==
   concourse:target_vpc: operations_vpc
+  concourse:web_auto_scale:
+    desired: 4
+    max: 10
+    min: 1
   concourse:web_host_domain: cicd-qa.odl.mit.edu
+  concourse:web_iam_policies:
+  - base
+  - ocw
+  - operations
   concourse:web_instance_type: general_purpose_large
-  concourse:web_node_capacity: "3"
-  concourse:worker_disk_size: "200"
-  concourse:worker_instance_type: general_purpose_xlarge
-  concourse:worker_node_capacity: "30"
+  concourse:workers:
+  - auto_scale:
+      desired: 20
+      max: 50
+      min: 3
+    aws_tags:
+      OU: open-courseware
+    concourse_team: ocw
+    disk_size_gb: 500
+    iam_policies:
+    - base
+    - ocw
+    instance_type: m5a.xlarge
+    name: ocw
+  - auto_scale:
+      desired: 2
+      max: 2
+      min: 2
+    aws_tags:
+      OU: operations
+    concourse_team: infrastructure
+    disk_size_gb: 100
+    iam_policies:
+    - base
+    - infra
+    - operations
+    instance_type: t3a.medium
+    name: infra
+  - auto_scale:
+      desired: 3
+      max: 5
+      min: 2
+    aws_tags:
+      OU: operations
+    disk_size_gb: 200
+    iam_policies:
+    - base
+    - operations
+    instance_type: t3a.large
+    name: generic
   consul:address: https://consul-operations-qa.odl.mit.edu
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa

--- a/src/ol_infrastructure/applications/concourse/__main__.py
+++ b/src/ol_infrastructure/applications/concourse/__main__.py
@@ -623,7 +623,7 @@ for worker_def in concourse_config.get_object("workers") or []:
                 resource_type="instance",
                 tags=aws_config.merged_tags(
                     {
-                        "Name": f"concoruse-worker-{worker_class_name}-{stack_info.env_suffix}"
+                        "Name": f"concourse-worker-{worker_class_name}-{stack_info.env_suffix}"
                     },
                     worker_def["aws_tags"],
                 ),
@@ -632,7 +632,7 @@ for worker_def in concourse_config.get_object("workers") or []:
                 resource_type="volume",
                 tags=aws_config.merged_tags(
                     {
-                        "Name": f"concoruse-worker-{worker_class_name}-{stack_info.env_suffix}"
+                        "Name": f"concourse-worker-{worker_class_name}-{stack_info.env_suffix}"
                     },
                     worker_def["aws_tags"],
                 ),

--- a/src/ol_infrastructure/applications/concourse/__main__.py
+++ b/src/ol_infrastructure/applications/concourse/__main__.py
@@ -43,7 +43,9 @@ from ol_infrastructure.lib.stack_defaults import defaults
 from ol_infrastructure.lib.vault import setup_vault_provider
 
 
-def build_worker_user_data(concourse_team, concourse_tags, consul_dc):
+def build_worker_user_data(
+    concourse_team: str, concourse_tags: List[str], consul_dc: str
+) -> str:
     yaml_contents = {
         "write_files": [
             {
@@ -652,7 +654,7 @@ for worker_def in concourse_config.get_object("workers") or []:
     build_worker_user_data_partial = partial(
         build_worker_user_data,
         worker_def.get("concourse_team"),
-        worker_def.get("concourse_tags") or [],
+        worker_def.get("concourse_tags", []),
     )
 
     worker_instance_type = (

--- a/src/ol_infrastructure/applications/concourse/iam_policies/base.py
+++ b/src/ol_infrastructure/applications/concourse/iam_policies/base.py
@@ -9,6 +9,8 @@ policy_definition = {
         {
             "Effect": "Allow",
             "Action": [
+                "ec2:DescribeInstances",
+                "ec2:DescribeInstanceStatus",
                 "cloudwatch:PutMetricData",
             ],
             "Resource": "*",

--- a/src/ol_infrastructure/infrastructure/vault/Pulumi.infrastructure.vault.operations.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/vault/Pulumi.infrastructure.vault.operations.CI.yaml
@@ -4,7 +4,7 @@ encryptedkey: AQICAHjEYf3gV5ZTnviCJcHwGnUuLzld5EuYumgMrRde6bvXUgEw9qZV909uOvshim
 config:
   aws:region: us-east-1
   vault:business_unit: operations
-  vault:cluster_size: '3'
+  vault:cluster_size: "3"
   vault:domain: vault-ci.odl.mit.edu
-  vault:storage_disk_capacity: '200'
+  vault:storage_disk_capacity: "200"
   vault:target_vpc: operations

--- a/src/ol_infrastructure/lib/ol_types.py
+++ b/src/ol_infrastructure/lib/ol_types.py
@@ -96,14 +96,15 @@ class AWSBase(BaseModel):
             raise ValueError("The specified region does not exist")
         return region
 
-    def merged_tags(self, new_tags: Dict[str, str]) -> Dict[str, str]:
+    def merged_tags(self, *new_tags: Dict[str, str]) -> Dict[str, str]:
         """Return a dictionary of existing tags with the ones passed in.
 
         This generates a new dictionary of tags in order to allow for a broadly
-        applicable set of tagsto then be updated with specific tags to be set on child
+        applicable set of tags to then be updated with specific tags to be set on child
         resources in a ComponentResource class.
 
-        :param new_tags: Dictionary of specific tags to be set on a child resource.
+        :param *new_tags: One or more dictionaries of specific tags to be set on
+                                                                        a child resource.
         :type new_tags: Dict[Text, Text]
 
         :returns: Merged dictionary of base tags and specific tags to be set on a child
@@ -112,5 +113,6 @@ class AWSBase(BaseModel):
         :rtype: Dict[Text, Text]
         """
         tag_dict = self.tags.copy()
-        tag_dict.update(new_tags)
+        for tags in new_tags:
+            tag_dict.update(tags)
         return tag_dict


### PR DESCRIPTION
Created the ability to define classes of concourse workers, each with their own tags and teams. These workers can also have over-ridden AWS tags for cost reporting. Each class of worker can be customized with different instance types + storage. 