### PR TITLE
version bump edx-sga on Residential MITx

### DIFF
--- a/src/bilder/images/edxapp/group_data/all.py
+++ b/src/bilder/images/edxapp/group_data/all.py
@@ -45,6 +45,7 @@ edx_plugins = {
     "mitx": [
         "celery-redbeat",  # Support for using Redis as the lock for Celery schedules
         "django-redis",  # Support for Redis caching in Django
+        "edx-sga==0.17.3", # remove pin when upgrading to nutmeg
         "edx-sysadmin",
         "git+https://github.com/raccoongang/xblock-pdf.git@8d63047c53bc8fdd84fa7b0ec577bb0a729c215f#egg=xblock-pdf",  # noqa: E501
         "ol-openedx-logging",
@@ -56,6 +57,7 @@ edx_plugins = {
     "mitx-staging": [
         "celery-redbeat",  # Support for using Redis as the lock for Celery schedules
         "django-redis",  # Support for Redis caching in Django
+        "edx-sga==0.17.3", # remove pin when upgrading to nutmeg
         "edx-sysadmin",
         "git+https://github.com/raccoongang/xblock-pdf.git@8d63047c53bc8fdd84fa7b0ec577bb0a729c215f#egg=xblock-pdf",  # noqa: E501
         "ol-openedx-logging",


### PR DESCRIPTION
fixes #583 

version 0.17.3 fixes display bugs related to the Learner MFE. As far as I know, we only use edx-sga on Residential MITx. The other deployments can wait for a regular update cycle.

