### PR TITLE
Modify the ocw-studio event rule for sns notifications

### DIFF
--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -283,7 +283,12 @@ ocw_studio_mediaconvert_cloudwatch_rule = cloudwatch.EventRule(
         {
             "source": ["aws.mediaconvert"],
             "detail-type": ["MediaConvert Job State Change"],
-            "detail": {"status": ["COMPLETE", "ERROR"]},
+            "detail": {
+                "userMetadata": {
+                    "filter": [f"ocw-studio-mediaconvert-queue-{stack_info.env_suffix}"]
+                },
+                "status": ["COMPLETE", "ERROR"]
+            }
         }
     ),
 )

--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -287,8 +287,8 @@ ocw_studio_mediaconvert_cloudwatch_rule = cloudwatch.EventRule(
                 "userMetadata": {
                     "filter": [f"ocw-studio-mediaconvert-queue-{stack_info.env_suffix}"]
                 },
-                "status": ["COMPLETE", "ERROR"]
-            }
+                "status": ["COMPLETE", "ERROR"],
+            },
         }
     ),
 )


### PR DESCRIPTION
Adds an additional filter to the event rule for ocw-studio MediaConvert SNS notifications.

Should not be merged/applied until after https://github.com/mitodl/ocw-studio/pull/1018 and https://github.com/mitodl/salt-ops/pull/1501

