### PR TITLE
Enable disk metric collection with vector

### DIFF
--- a/src/bilder/components/vector/templates/host_metrics.yaml
+++ b/src/bilder/components/vector/templates/host_metrics.yaml
@@ -5,11 +5,18 @@ sources:
     scrape_interval_secs: 60
     collectors:
     - cpu
+    - disk
     - filesystem
     - load
     - host
     - memory
     - network
+    disk:
+      devices:
+        excludes:
+        - '*'
+        includes:
+        - 'nvme?n?'
 
 transforms:
   cleanup_host_metrics:

--- a/src/bilder/components/vector/templates/host_metrics.yaml
+++ b/src/bilder/components/vector/templates/host_metrics.yaml
@@ -13,8 +13,6 @@ sources:
     - network
     disk:
       devices:
-        excludes:
-        - '*'
         includes:
         - 'nvme?n?'
 


### PR DESCRIPTION
Updated the global vector host metric configuration file to collect disk metrics but only from root devices and not partitions.

Closes #649 