### PR TITLE
Make the concourse AMI builds run in parallel 

### DIFF
--- a/pipelines/infrastructure/concourse_ami_new_release.yaml
+++ b/pipelines/infrastructure/concourse_ami_new_release.yaml
@@ -52,20 +52,21 @@ jobs:
   - get: gh-release
     trigger: true
   - get: packer_templates
-  - put: packer
-    params:
-      template: packer_templates/src/bilder/images/.
-      objective: validate
-      vars:
-        app_name: concourse
-        node_type: web
-  - put: packer
-    params:
-      template: packer_templates/src/bilder/images/.
-      objective: validate
-      vars:
-        app_name: concourse
-        node_type: worker
+  - in_parallel:
+    - put: packer
+      params:
+        template: packer_templates/src/bilder/images/.
+        objective: validate
+        vars:
+          app_name: concourse
+          node_type: web
+    - put: packer
+      params:
+        template: packer_templates/src/bilder/images/.
+        objective: validate
+        vars:
+          app_name: concourse
+          node_type: worker
 
 - name: packer-build-workflow
   plan:
@@ -76,31 +77,32 @@ jobs:
     trigger: true
   - get: gh-release
     trigger: false
-  - put: packer-build
-    params:
-      template: packer_templates/src/bilder/images/.
-      objective: build
-      vars:
-        app_name: concourse
-        node_type: web
-      env_vars:
-        AWS_REGION: us-east-1
-        PYTHONPATH: "${PYTHONPATH}:packer_templates/src"
-      env_vars_from_files:
-        CONCOURSE_VERSION: gh-release/version
-      only:
-      - amazon-ebs.third-party
-  - put: packer-build
-    params:
-      template: packer_templates/src/bilder/images/.
-      objective: build
-      vars:
-        app_name: concourse
-        node_type: worker
-      env_vars:
-        AWS_REGION: us-east-1
-        PYTHONPATH: "${PYTHONPATH}:packer_templates/src"
-      env_vars_from_files:
-        CONCOURSE_VERSION: gh-release/version
-      only:
-      - amazon-ebs.third-party
+  - in_parallel:
+    - put: packer-build
+      params:
+        template: packer_templates/src/bilder/images/.
+        objective: build
+        vars:
+          app_name: concourse
+          node_type: web
+        env_vars:
+          AWS_REGION: us-east-1
+          PYTHONPATH: "${PYTHONPATH}:packer_templates/src"
+        env_vars_from_files:
+          CONCOURSE_VERSION: gh-release/version
+        only:
+        - amazon-ebs.third-party
+    - put: packer-build
+      params:
+        template: packer_templates/src/bilder/images/.
+        objective: build
+        vars:
+          app_name: concourse
+          node_type: worker
+        env_vars:
+          AWS_REGION: us-east-1
+          PYTHONPATH: "${PYTHONPATH}:packer_templates/src"
+        env_vars_from_files:
+          CONCOURSE_VERSION: gh-release/version
+        only:
+        - amazon-ebs.third-party


### PR DESCRIPTION
Adjusted the concourse AMI build pipeline to run the verify for workers and web nodes in parallel to speed them up a little bit.