### PR TITLE
ocw-content backup adjustments

### DIFF
--- a/pipelines/ocw/backup-ocw-content/backup-ocw-content.yaml
+++ b/pipelines/ocw/backup-ocw-content/backup-ocw-content.yaml
@@ -4,9 +4,7 @@ resources:
   type: time
   icon: clock
   source:
-    interval: 24h
-    start: 12:00 AM
-    stop: 1:00 AM
+    interval: 6h
     initial_version: true
 
 jobs:

--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -73,6 +73,15 @@ draft_backup_bucket = s3.Bucket(
         }
     ),
     cors_rules=[{"allowedMethods": ["GET", "HEAD"], "allowedOrigins": ["*"]}],
+    versioning=s3.BucketVersioningArgs(enabled=True),
+    lifecycle_rules=[
+        s3.BucketLifecycleRuleArgs(
+            enabled=True,
+            noncurrent_version_expiration=s3.BucketLifecycleRuleNoncurrentVersionExpirationArgs(
+                days=90,
+            ),
+        )
+    ],
 )
 
 live_bucket = s3.Bucket(
@@ -116,6 +125,15 @@ live_backup_bucket = s3.Bucket(
         }
     ),
     cors_rules=[{"allowedMethods": ["GET", "HEAD"], "allowedOrigins": ["*"]}],
+    versioning=s3.BucketVersioningArgs(enabled=True),
+    lifecycle_rules=[
+        s3.BucketLifecycleRuleArgs(
+            enabled=True,
+            noncurrent_version_expiration=s3.BucketLifecycleRuleNoncurrentVersionExpirationArgs(
+                days=90,
+            ),
+        )
+    ],
 )
 
 policy_description = (


### PR DESCRIPTION
Updated the ocw-content-backup-* buckets to use versioning with a 90 day version expiration policy. Updated the backup jobs to run every 6 hours.