### PR TITLE
Adding handling of OCW site domains to Pulumi

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,9 +52,12 @@ repos:
   hooks:
   - id: detect-secrets
     args:
-    - --exclude-lines (^encryptedkey:|^secure:|^secretsprovider:)
-    - --exclude-files src/bridge/secrets/
-    - --exclude-files poetry.lock
+    - --exclude-lines
+    - '(^encryptedkey:|^secure:|^secretsprovider:)'
+    - --exclude-files
+    - src/bridge/secrets/
+    - --exclude-files
+    - poetry.lock
 - repo: https://github.com/PyCQA/isort
   rev: 5.10.1
   hooks:

--- a/src/ol_infrastructure/applications/ocw_site/Pulumi.applications.ocw_site.Production.yaml
+++ b/src/ol_infrastructure/applications/ocw_site/Pulumi.applications.ocw_site.Production.yaml
@@ -3,3 +3,7 @@ secretsprovider: awskms://alias/infrastructure-secrets-production  # pragma: all
 encryptedkey: AQICAHgQalNS7T35ZlcFdhF0QuKeiJAbXMUbm01pjGwHEsjRCgGPbSz7qllaLKSxEZcmDRxmAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMiW0X4xHd5cZ68j1uAgEQgDtqOisD1vkDetSKsy4Q4aHqZt4ZoWiScmYMkFGsRXTOCpzP2bU1U20TVIiN+hQrSWe60lqWycNfePaPtA==  # pragma: allowlist-secret
 config:
   aws:region: us-east-1
+  ocw_site:domains:
+  - draft.ocw.mit.edu
+  - live.ocw.mit.edu
+  - ocw.mit.edu

--- a/src/ol_infrastructure/applications/ocw_site/Pulumi.applications.ocw_site.QA.yaml
+++ b/src/ol_infrastructure/applications/ocw_site/Pulumi.applications.ocw_site.QA.yaml
@@ -3,3 +3,6 @@ secretsprovider: awskms://alias/infrastructure-secrets-qa
 encryptedkey: AQICAHijXuVxVlAL6bY9xCOrzO3YYhFlQBPt6jNyJGkhYu+q4QHhXlvPfNhuE+oHmMQQseu9AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMPLfTZMrnTgwBA2kfAgEQgDupw9ff+ck3TY6C9Z9MJ3nBjVRZGqljmBh4OmWLRPsR6iBm59Z1RTIcgaxHjChEkMM0Y9+GGF6j3nM6Qw==
 config:
   aws:region: us-east-1
+  ocw_site:domains:
+  - draft-qa.ocw.mit.edu
+  - live-qa.ocw.mit.edu

--- a/src/ol_infrastructure/lib/aws/iam_helper.py
+++ b/src/ol_infrastructure/lib/aws/iam_helper.py
@@ -27,7 +27,7 @@ def _is_parliament_finding_filtered(
             )
             action_matches.append(any(matches))
     else:
-        action_matches.append("all")
+        action_matches.append("all")  # type: ignore[arg-type]
     return any(action_matches)
 
 


### PR DESCRIPTION
Creates DNS records in Route53 for the draft and live OCW sites that point to the
appropriate record types that are powered by Fastly distributions.