### PR TITLE
Revert "Merge pull request #717 from mitodl/renovate/node-17.x"

### DIFF
--- a/dockerfiles/ocw/node-hugo/Dockerfile
+++ b/dockerfiles/ocw/node-hugo/Dockerfile
@@ -1,4 +1,4 @@
-FROM  node:17-buster-slim
+FROM  node:14-buster-slim
 LABEL maintainer="MIT Open Learning (odl-devops@mit.edu)"
 LABEL description="Node and Hugo, used for building OCW website"
 LABEL version="0.1"


### PR DESCRIPTION
This reverts commit b250502d06bb7b5859d8227a1eb440c47dfa2a8f, reversing
changes made to 0db18e3d01bea70927d0856707437436ae69f2c6.

Node 17 does not seem to be compatible with webpack 4:
https://itsmycode.com/error-digital-envelope-routines-unsupported/
https://cicd-qa.odl.mit.edu/teams/ocw/pipelines/ocw-theme-assets/jobs/build-theme-assets/builds/57?vars.branch=%22release-candidate%22
