### PR TITLE
Pin named releases to specific envs by stack

### DIFF
--- a/src/bilder/images/edxapp/custom_install.pkr.hcl
+++ b/src/bilder/images/edxapp/custom_install.pkr.hcl
@@ -53,6 +53,7 @@ source "amazon-ebs" "edxapp" {
     OU      = "${var.business_unit}"
     app     = "${local.app_name}"
     purpose = "${local.app_name}-${var.node_type}"
+    edxapp_release = "${var.edx_platform_version}"
   }
   # Base all builds off of the most recent Ubuntu 20.04 image built by the Canonical organization.
   source_ami_filter {
@@ -78,6 +79,7 @@ source "amazon-ebs" "edxapp" {
     app        = "${local.app_name}"
     deployment = "${var.installation_target}"
     purpose    = "${local.app_name}-${var.node_type}"
+    edxapp_release = "${var.edx_platform_version}"
   }
 }
 

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.CI.yaml
@@ -17,6 +17,7 @@ config:
   edxapp:edx_xqueue_secrets:
     secure: v1:yojXnLWnr80P8t0T:sS5KRaJa6JUwEckAjQr0Ln4l/6O1ma69CHF38VhXUfG/pUUqxw1Q8XJBVzlRIVT4yzq7O6UhzRYc2dizDbw5iQsH4/54mdUhfrFreZaZSAO5Ta9uKAmzv4vG1lJ5hI5hwFsg0fm+mUKBq2LFa2tiCVAwoS64BSW1uoO4GBWTUl1hYPXZaouIX0rAd/sgzLq35w==
   edxapp:elb_healthcheck_interval: "30"
+  edxapp:edxapp_release: open-release/nutmeg.master
   edxapp:google_analytics_id: ""
   edxapp:mail_domain: edxapp-mail-staging-ci.mitx.mit.edu
   edxapp:min_web_nodes: "1"

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.Production.yaml
@@ -18,6 +18,7 @@ config:
   edxapp:edx_xqueue_secrets:
     secure: v1:jgBYHCVD4xbM2TGu:P0rmQmQm2SYH/pQh928vZq5C5ZRXWQsKvRijEitpVjsIo5YfzyYGM84GOIQQG2FTINUdINXCGkWXHNUsfYFGq1dKcOsrql9n5nUka8k/4bWcqEuyBy0dI0bCpoEf6Ui0hL1On/Or4/rV7itDycwjIsTe7Eq6pE2oLRw+64RV77e3ho9f1M/63BC00rzYynBkaw==
   edxapp:google_analytics_id: ""
+  edxapp:edxapp_release: open-release/maple.master
   edxapp:mail_domain: edxapp-mail-staging-production.mitx.mit.edu
   edxapp:min_web_nodes: "1"
   edxapp:min_worker_nodes: "1"

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.QA.yaml
@@ -17,6 +17,7 @@ config:
   edxapp:edx_xqueue_secrets:
     secure: v1:qsM/S7Cb8+UOLRdj:Gv5E/h+AjiKQ2HiTNykPh35nw5ApGOVKvwwi6BMBmaHs5g4O8FtzJKe9qxvw2NLdk0wYS80Mftc66tf82Ps//38s/9q2YijplczowzYP3AinvhnFkVy1bQMHDFeiwfWP+owGT0ktv+QIfwT0D4uq1Z4K5S1sdfBQA09Hl7y6RrkxWgYMxYz/C+/w1HlMymkgsw==
   edxapp:elb_healthcheck_interval: "30"
+  edxapp:edxapp_release: open-release/maple.master
   edxapp:google_analytics_id: ""
   edxapp:mail_domain: edxapp-mail-staging-qa.mitx.mit.edu
   edxapp:min_web_nodes: "1"

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.CI.yaml
@@ -18,6 +18,7 @@ config:
     secure: v1:ovK3uwt1RjhV81YB:Uw63YPpyTVNXV4jX9LnlMf/TqtnNjk+Ro0rynUf+ulEaZzot+bOCAqMlDyn5Xu7/nUx3iGwJEHVTrOnrMNlXiHCqOiYFpfFv8NIqc/x6+Q8+eJFGjcLxhqYidyQkUAZIfz9mRVCVgEjC423yfAMi+tMee05xKI6ylAy4aO7AjjfE0s8RMt1/toGhW6DF1MIDZw==
   edxapp:elb_healthcheck_interval: "30"
   edxapp:google_analytics_id: ""
+  edxapp:edxapp_release: open-release/nutmeg.master
   edxapp:gradebook_url: /gradebook
   edxapp:mail_domain: edxapp-mail-ci.mitx.mit.edu
   edxapp:min_web_nodes: "1"

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.Production.yaml
@@ -18,6 +18,7 @@ config:
   edxapp:edx_xqueue_secrets:
     secure: v1:MSer6cBbKNVi/Pas:v5XAeVblUaT5pyxdhhk9wn9cVjadZcHscOWhN1nlPHBsCD8/HgEtsvAjtTOWnW/yVMYaMzlIjOxoKvEw0/qNESQj0M7bFKC7/dtfU+qlrWyI0PJEVVmiz9QPLAOvl4rA8In2hJTAmN+BAREDqSRFM9YiOKmdOuoDssTGv+fD1+oC5EcFz4BKPUnbZDQ1
   edxapp:google_analytics_id: UA-5145472-4
+  edxapp:edxapp_release: open-release/maple.master
   edxapp:mail_domain: edxapp-mail-production.mitx.mit.edu
   edxapp:min_web_nodes: "5"
   edxapp:min_worker_nodes: "2"

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.QA.yaml
@@ -18,6 +18,7 @@ config:
   edxapp:edx_xqueue_secrets:
     secure: v1:8gxklYODxX1veWAk:hMnDmIkA5pDq3fdkWCKpNUdF/XDhbjoGKtcffutGdgWfjZVGrRrcpIEZoDvxI/YWPB3oL12c8mpYsE75yJupx3tijTYU33Ym5+++ZauQGBlxnsbgEA4SmWHm1bPmKjQieAWt+lKcLvvkAYMS5qTalYHpTrdf9ud9CYMd8bFgT3za/RDaAEGEaw9qOqUbdJQDWA==
   edxapp:elb_healthcheck_interval: "30"
+  edxapp:edxapp_release: open-release/maple.master
   edxapp:google_analytics_id: ""
   edxapp:gradebook_url: /gradebook
   edxapp:mail_domain: edxapp-mail-qa.mitx.mit.edu

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
@@ -18,6 +18,7 @@ config:
   edxapp:edx_forum_secrets:
     secure: v1:qzfe99Jb8n0TnEQS:Y6fSOS8lksj7WvED+V7kCtV7arDtwx7184Fw330Mwh9JDHW72rVd8y7Nm0fF8ANCcFCwDV5EwSU2Fcc+X47NHDOLCOQv16lyB6jWOF2mTr/veRax6MbXY9NlLmsfp9EBQesDCitULbkz9hyHcHT3GPI=
   edxapp:google_analytics_id: UA-5145472-48
+  edxapp:edxapp_release: release
   edxapp:mail_domain: edxapp-mail.mitxonline.mit.edu
   edxapp:sender_email_address: mitxonline-support@mit.edu
   edxapp:web_node_capacity: "9"

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
@@ -18,6 +18,7 @@ config:
   edxapp:edx_forum_secrets:
     secure: v1:IqXRArQveCV+9lkE:cRaraFuN2dDmI29PD4QifOU7MrRFdszOoaUb7o3pDJordt4TSjw8fIxldWfMzNhZRLC+NS291DorO1IuN6ASdCbt5d53aMvHVt+3hA6wyuI11OFjk7U=
   edxapp:elb_healthcheck_interval: "30"
+  edxapp:edxapp_release: release
   edxapp:google_analytics_id: UA-5145472-46
   edxapp:gradebook_url: /gradebook
   edxapp:mail_domain: edxapp-mail-qa.mitxonline.mit.edu

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.CI.yaml
@@ -15,6 +15,7 @@ config:
   edxapp:edx_forum_secrets:
     secure: v1:QSW6gq7cQ6t65Glo:OGJ5X4YYEi2ZdyrpnML25p10mQrodNNLaF5zyV1242ZcQz1TkRsTdpmv9HghIhgHxykYd2NK7kyRkvphd5pfI56xAg/de/8PuHNuPx5kg3IZCrFktYuE2Nyzjxhg7aGHNhA6JQEf95925WPwAG3V
   edxapp:elb_healthcheck_interval: "30"
+  edxapp:edxapp_release: open-release/maple.master
   edxapp:google_analytics_id: ""
   edxapp:gradebook_url: /gradebook
   edxapp:mail_domain: edxapp-mail-ci.xpro.mit.edu

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.Production.yaml
@@ -15,6 +15,7 @@ config:
   edxapp:edx_forum_secrets:
     secure: v1:YHqAWSdn7TNUn7d+:IBgiGsl4r8vymID8NV43rnfJy+qsJSXm/jXaWWALUfF9zXqRO4zJZhLS0d+etijGVwaZnF8v5zXlo+EczFrCe7ICHpS85zHgifbfDcw=
   edxapp:google_analytics_id: UA-5145472-38
+  edxapp:edxapp_release: open-release/maple.master
   edxapp:mail_domain: edxapp-mail-production.xpro.mit.edu
   edxapp:min_web_nodes: "3"
   edxapp:min_worker_nodes: "2"

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.QA.yaml
@@ -15,6 +15,7 @@ config:
   edxapp:edx_forum_secrets:
     secure: v1:Tpg1BEYCoSw2D6HQ:yGnhmeKYzo+EetdiUpY/7VzE9vq+OtX/O02d6ugQwMI3D57r3yvxtsY3u+lRYwr0R2yvvVr/Lhm9xXQ3EfycxNtpOUxviHCFsL5wXLA=
   edxapp:elb_healthcheck_interval: "30"
+  edxapp:edxapp_release: open-release/maple.master
   edxapp:google_analytics_id: ""
   edxapp:gradebook_url: /gradebook
   edxapp:mail_domain: edxapp-mail-qa.xpro.mit.edu

--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -102,6 +102,7 @@ aws_config = AWSBase(
 )
 consul_security_groups = consul_stack.require_output("security_groups")
 consul_provider = get_consul_provider(stack_info)
+edxapp_release = edxapp_config.require("edxapp_release")
 edxapp_domains = edxapp_config.require_object("domains")
 edxapp_mail_domain = edxapp_config.require("mail_domain")
 edxapp_vpc = network_stack.require_output(target_vpc)
@@ -112,6 +113,7 @@ edxapp_web_ami = ec2.get_ami(
         ec2.GetAmiFilterArgs(name="virtualization-type", values=["hvm"]),
         ec2.GetAmiFilterArgs(name="root-device-type", values=["ebs"]),
         ec2.GetAmiFilterArgs(name="tag:deployment", values=[stack_info.env_prefix]),
+        ec2.GetAmiFilterArgs(name="tag:edxapp_release", values=[edxapp_release]),
     ],
     most_recent=True,
     owners=[aws_account.account_id],


### PR DESCRIPTION
## Description
As we test out new named releases we need to maintain a way for deploying the previous
release to QA and production environments in the event of a security patch or
bugfix. This adds an AMI tag and associated stack configuration to filter the AMI that
is deployed per environment/stack. This lets us build e.g. Nutmeg AMIs to deploy to
residential CI while preventing accidental deployment to QA and production.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is necessary to allow us to flexibly propagate a given named release to different
environment levels without blocking us from deploying prior releases to production while
we are still in testing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This will be tested in the CI environment once new AMIs have been built with the
requisite tags.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.