### PR TITLE
fix: Make git operation for edxapp use directory owner

### DIFF
--- a/src/bilder/images/edxapp/deploy.py
+++ b/src/bilder/images/edxapp/deploy.py
@@ -3,6 +3,7 @@ import tempfile
 from pathlib import Path
 
 from pyinfra import host
+from pyinfra.facts.files import Directory
 from pyinfra.operations import apt, files, git, pip, server
 
 from bilder.components.baseline.steps import service_configuration_watches
@@ -79,6 +80,7 @@ apt.packages(
 git_remote = host.data.edx_platform_repository[EDX_INSTALLATION_NAME]["origin"]
 git_branch = host.data.edx_platform_repository[EDX_INSTALLATION_NAME]["branch"]
 edx_platform_path = "/edx/app/edxapp/edx-platform/"
+edx_repo_fact = host.get_fact(Directory, edx_platform_path)
 server.shell(
     name="Fix git",
     commands=["git config --global --add safe.directory /edx/app/edxapp/edx-platform"],
@@ -96,8 +98,8 @@ git.repo(
     dest=edx_platform_path,
     branch=git_branch,
     pull=False,
-    user=EDX_USER,
-    group=EDX_USER,
+    user=edx_repo_fact["user"],
+    group=edx_repo_fact["group"],
 )
 
 git_auto_export()


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The latest git release restricts git operations to being executed by the repository
owner based on file permissions. This updates the git operation to use whatever user
owns the edx repository on disk based on facts fetched at execution time.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The edX AMI build is currently blocked due to security errors being thrown by git that cause the PyInfra execution to fail. This prevents us from releasing any changes to edX until this issue is resolved.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It has been tested by manually running an AMI build with the code changes present on disk.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
