### PR TITLE
Ami cleanup revisit pt1

### DIFF
--- a/cloud_custodian/sync_ec2_tags.yaml
+++ b/cloud_custodian/sync_ec2_tags.yaml
@@ -5,11 +5,12 @@ policies:
   description: |
     Find all the running ec2 instances that were spawned by an asg, belong of mitodl, and do not belong to ike. Take no action. Output used for next filter.
   filters:
-  - State.Name: running
-  - "tag:OU": present
-  - "tag:aws:autoscaling:groupName": present
-  - not:
-    - "tag:OU": "ike"
+  - and:
+    - State.Name: running
+    - "tag:OU": present
+    - "tag:aws:autoscaling:groupName": present
+    - not:
+      - "tag:OU": "ike"
 
 - name: find-and-propagate-tags-mitodl-ebs-volumes
   resource: aws.ebs

--- a/cloud_custodian/tag_ebs_resources_for_cleanup.yaml
+++ b/cloud_custodian/tag_ebs_resources_for_cleanup.yaml
@@ -43,6 +43,7 @@ policies:
       days: 30
     - type: unused
       value: true
+    - "tag:custodian_cleanup": absent
   actions:
   - type: mark-for-op
     tag: custodian_cleanup
@@ -66,6 +67,7 @@ policies:
       key: Description
       op: regex-case
       value: '^.*CreateImage.*$'
+    - "tag:custodian_cleanup": absent
   actions:
   - type: mark-for-op
     tag: custodian_cleanup
@@ -86,6 +88,7 @@ policies:
         url: file:find-and-mark-mitodl-ami-snapshots/resources.json
         format: json
         expr: "[].VolumeId"
+    - "tag:custodian_cleanup": absent
   actions:
   - type: mark-for-op
     tag: custodian_cleanup

--- a/cloud_custodian/tag_ebs_resources_for_cleanup.yaml
+++ b/cloud_custodian/tag_ebs_resources_for_cleanup.yaml
@@ -5,41 +5,44 @@ policies:
   description: |
     Find all MIT ODL autoscale groups and take no action. Linked launch templates are used in the next policy.
   filters:
-  - "tag:pulumi_managed": present
-  - not:
-    - "tag:OU": "ike"
+  - and:
+    - "tag:pulumi_managed": present
+    - not:
+      - "tag:OU": "ike"
 
 - name: find-mitodl-ltv
   resource: aws.launch-template-version
   description: |
     Find all inactive MIT ODL launch template version and take no action. Will used the linked AMI in the next policy.
   filters:
-  - type: value
-    key: LaunchTemplateId
-    op: in
-    value_from:
-      url: file:find-mitodl-asg/resources.json
-      format: json
-      expr: "[].Instances[].LaunchTemplate.LaunchTemplateId"
-  - DefaultVersion: false
+  - and:
+    - type: value
+      key: LaunchTemplateId
+      op: in
+      value_from:
+        url: file:find-mitodl-asg/resources.json
+        format: json
+        expr: "[].Instances[].LaunchTemplate.LaunchTemplateId"
+    - DefaultVersion: false
 
 - name: find-and-mark-mitodl-ami
   resource: aws.ami
   description: |
     Find all MIT ODL AMI IDs that go with the inactive launch template versions and tag them for cleanup.
   filters:
-  - type: value
-    key: ImageId
-    op: in
-    value_from:
-      url: file:find-mitodl-ltv/resources.json
-      format: json
-      expr: "[].LaunchTemplateData.ImageId"
-  - type: image-age
-    op: gt
-    days: 30
-  - type: unused
-    value: true
+  - and:
+    - type: value
+      key: ImageId
+      op: in
+      value_from:
+        url: file:find-mitodl-ltv/resources.json
+        format: json
+        expr: "[].LaunchTemplateData.ImageId"
+    - type: image-age
+      op: gt
+      days: 30
+    - type: unused
+      value: true
   actions:
   - type: mark-for-op
     tag: custodian_cleanup
@@ -51,17 +54,18 @@ policies:
   description: |
     Find the snapshots associated with the unused AMIs from the previous policy. Tag them for deletion. Found snapshots will be used in the next policy to tmark the volumes for cleanup as well.
   filters:
-  - type: value
-    key: SnapshotId
-    op: in
-    value_from:
-      url: file:find-and-mark-mitodl-ami/resources.json
-      format: json
-      expr: "[].BlockDeviceMappings[].Ebs.SnapshotId"
-  - type: value
-    key: Description
-    op: regex-case
-    value: '^.*CreateImage.*$'
+  - and:
+    - type: value
+      key: SnapshotId
+      op: in
+      value_from:
+        url: file:find-and-mark-mitodl-ami/resources.json
+        format: json
+        expr: "[].BlockDeviceMappings[].Ebs.SnapshotId"
+    - type: value
+      key: Description
+      op: regex-case
+      value: '^.*CreateImage.*$'
   actions:
   - type: mark-for-op
     tag: custodian_cleanup


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Revisiting the AMI cleanup stuff because it wasn't working how I had intended. It STILL isn't actually deleting anything, but it will properly tag things now. 

Also adding explicit logical AND operations. They are implied before. I think explicit might be better and more consistent since there was one explicit in the config prior. 

## Motivation and Context
Before: It was updating all the `mark-for-op` dates to be 30 days out, every single day. So no items were ever going to pass a `marked-for-op` check. Perpetually 30 days out. Now it won't consider items that have the `cloud_custodian` tag.

## How Has This Been Tested?
Bad behavior:
```
2022-04-27 17:29:33,732: custodian.policy:INFO policy:find-mitodl-asg resource:aws.asg region:us-east-1 count:60 time:2.27
2022-04-27 17:29:39,551: custodian.policy:INFO policy:find-mitodl-ltv resource:aws.launch-template-version region:us-east-1 count:902 time:5.78
2022-04-27 17:29:49,506: custodian.policy:INFO policy:find-and-mark-mitodl-ami resource:aws.ami region:us-east-1 count:356 time:9.58
2022-04-27 17:29:49,596: custodian.actions:INFO Tagging 356 resources for deregister on 2022/05/27
2022-04-27 17:29:53,145: custodian.policy:INFO policy:find-and-mark-mitodl-ami action:tagdelayedaction resources:356 execution_time:3.55
2022-04-27 17:29:58,665: custodian.policy:INFO policy:find-and-mark-mitodl-ami-snapshots resource:aws.ebs-snapshot region:us-east-1 count:356 time:5.51
2022-04-27 17:29:58,702: custodian.actions:INFO Tagging 356 resources for delete on 2022/05/27
2022-04-27 17:30:02,405: custodian.policy:INFO policy:find-and-mark-mitodl-ami-snapshots action:tagdelayedaction resources:356 execution_time:3.70
2022-04-27 17:30:06,909: custodian.policy:INFO policy:find-and-mark-mitodl-ami-volumes resource:aws.ebs region:us-east-1 count:256 time:4.49
2022-04-27 17:30:06,927: custodian.actions:INFO Tagging 256 resources for delete on 2022/05/27
2022-04-27 17:30:09,818: custodian.policy:INFO policy:find-and-mark-mitodl-ami-volumes action:tagdelayedaction resources:256 execution_time:2.89
```

Good behavior (nothing new to update, no adding +1 to the `cloud_custodian` field. 
```
2022-04-28 10:27:16,249: custodian.policy:INFO policy:find-mitodl-asg resource:aws.asg region:us-east-1 count:60 time:1.01
2022-04-28 10:27:23,655: custodian.policy:INFO policy:find-mitodl-ltv resource:aws.launch-template-version region:us-east-1 count:902 time:7.40
2022-04-28 10:27:38,855: custodian.policy:INFO policy:find-and-mark-mitodl-ami resource:aws.ami region:us-east-1 count:0 time:15.14
2022-04-28 10:27:50,901: custodian.policy:INFO policy:find-and-mark-mitodl-ami-snapshots resource:aws.ebs-snapshot region:us-east-1 count:0 time:12.04
2022-04-28 10:27:55,122: custodian.policy:INFO policy:find-and-mark-mitodl-ami-volumes resource:aws.ebs region:us-east-1 count:0 time:4.22
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
