### PR TITLE
update hugo in OCW docker container

### DIFF
--- a/dockerfiles/ocw/node-hugo/Dockerfile
+++ b/dockerfiles/ocw/node-hugo/Dockerfile
@@ -3,9 +3,9 @@ LABEL maintainer="MIT Open Learning (odl-devops@mit.edu)"
 LABEL description="Node and Hugo, used for building OCW website"
 LABEL version="0.1"
 WORKDIR /tmp
-ENV HUGO_VERSION='0.80.0'
+ENV HUGO_VERSION='0.98.0'
 ENV HUGO_NAME="hugo_extended_${HUGO_VERSION}_Linux-64bit"
-ENV GO_FILE_NAME="go1.16.4.linux-amd64.tar.gz"
+ENV GO_FILE_NAME="go1.18.2.linux-amd64.tar.gz"
 ENV GO_URL="https://golang.org/dl/${GO_FILE_NAME}"
 ENV HUGO_URL="https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_NAME}.deb"
 ENV BUILD_DEPS="wget"


### PR DESCRIPTION
## Description
This PR updates the versions of Go and Hugo installed in the OCW `Dockerfile` to 1.18.2 and 0.98.0 respectively.

## Motivation and Context
Closes https://github.com/mitodl/ol-infrastructure/issues/812

Changes coming in https://github.com/mitodl/ocw-hugo-themes/pull/679 necessitate updating to this version.

## How Has This Been Tested?
Hugo 0.98.0 has been tested in https://github.com/mitodl/ocw-hugo-themes/pull/679 but I think the new Docker image will need to be tested after it's deployed?

## Types of changes
- [ ] Enhancement (improves on existing behavior)

## Checklist:
- [ ] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
