### PR TITLE
Md/fix concourse web build

### DIFF
--- a/src/bilder/components/caddy/models.py
+++ b/src/bilder/components/caddy/models.py
@@ -27,6 +27,9 @@ class CaddyConfig(OLBaseSettings):
     plugins: Optional[List[CaddyPlugin]]
     template_context: Optional[Dict[str, Any]]
     upstream_address: Optional[str]
+    tls_cert_path: Path = Path("/etc/caddy/odl_wildcard.cert")
+    tls_key_path: Path = Path("/etc/caddy/odl_wildcard.key")
+    caddy_user: Optional[str] = "caddy"
 
     class Config:
         env_prefix = "caddy_"

--- a/src/bilder/components/caddy/steps.py
+++ b/src/bilder/components/caddy/steps.py
@@ -9,11 +9,10 @@ from bilder.lib.linux_helpers import DEFAULT_DIRECTORY_MODE
 
 @deploy("Install Caddy")
 def install_caddy(caddy_config: CaddyConfig):
-    caddy_user = "caddy"
     if caddy_config.plugins:
         server.user(
             name="Create system user for Caddy",
-            user=caddy_user,
+            user=caddy_config.caddy_user,
             system=True,
             ensure_home=False,
         )
@@ -26,16 +25,16 @@ def install_caddy(caddy_config: CaddyConfig):
         files.directory(
             name="Create Caddy configuration directory",
             path="/etc/caddy/",
-            user=caddy_user,
-            group=caddy_user,
+            user=caddy_config.caddy_user,
+            group=caddy_config.caddy_user,
             present=True,
             recursive=True,
         )
         files.directory(
             name="Create Caddy data directory",
             path=str(caddy_config.data_directory),
-            user=caddy_user,
-            group=caddy_user,
+            user=caddy_config.caddy_user,
+            group=caddy_config.caddy_user,
             present=True,
             recursive=True,
         )
@@ -83,7 +82,7 @@ def install_caddy(caddy_config: CaddyConfig):
         files.directory(
             name="Crate Caddy log directory",
             path=str(caddy_config.log_file.parent),
-            user=caddy_user,
+            user=caddy_config.caddy_user,
             present=True,
         )
     return caddy_install.changed
@@ -105,6 +104,43 @@ def configure_caddy(caddy_config: CaddyConfig):
             dest="/etc/caddy/Caddyfile",
         )
     return caddy_file.changed
+
+
+@deploy("Create placeholder TLS key and cert.")
+def create_placeholder_tls_config(caddy_config: CaddyConfig):
+    apt.packages(
+        name="Install ACL package for more granular file permissions",
+        packages=["acl"],
+    )
+    server.shell(
+        name=f"Generate TLS certificate + key",
+        commands=[
+            f'openssl req -newkey rsa:4098 -x509 -sha256 -days 365 -nodes -out {caddy_config.tls_cert_path} -keyout {caddy_config.tls_key_path} -subj "/C=US/ST=Massachusetts/L=Cambridge/O=MIT/OU=ODL/CN=this.is.not.a.valid.certificate.odl.mit.edu"',
+        ],
+    )
+    # This is a workaround for a bahavior quirk of vault-template when it is running as a non-root user.
+    # A simple chown caddy:caddy /etc/caddy/odl* will not suffice here.
+    #
+    # vault-template doesn't actually modify the existing file, but rather creates a new one and attempts to
+    # overwrite the existing file and then restore the ownerships. When it runs as non-root, it cannot chown
+    # so it fails. The new cert files end up with vault:vault and 660 permissions so caddy cannot open them.
+    #
+    # After much futzing about with setfacl, chmod, chgrp, etc ... the easiest thing is to just add vault
+    # as a secondary group to the caddy user and set the ownership on the TLS files to vault:vault
+    server.shell(
+        name=f"Set ownership of the TLS cert and key",
+        commands=[
+            f"chown caddy:vault {caddy_config.tls_cert_path}",
+            f"chown caddy:vault {caddy_config.tls_key_path}",
+            f"chmod 0660 {caddy_config.tls_cert_path} {caddy_config.tls_key_path}",
+        ],
+    )
+    server.shell(
+        name=f"Add vault group to caddy user",
+        commands=[
+            f"usermod -a -G vault {caddy_config.caddy_user}",
+        ],
+    )
 
 
 @deploy("Manage Caddy Service")


### PR DESCRIPTION
Fixing the failing concourse webnode ami build.

## Description
Something (not sure what, some change in behavior with a version upgrade) is causing the installation of caddy to fail when building an AMI. Specifically, it is complaining about the absence of the odl wildcard key and cert (which previously were not there and it was perfectly fine with...).

This PR will create a dummy self-signed TLS key and cert and place them where caddy expects them so that the service can be initialized. To ensure that the dummy file works nicely with both caddy + vault, we do some jankyness with ownerships/mode/group memberships. To make that jankyness work, I needed to rearrange what steps were done in what order. 

The primary fix comes cherry picked from https://github.com/mitodl/ol-infrastructure/pull/802. 

Additionally, this PR also addresses a deprecated feature with the get_template function from pyinfra. 

It is a bit clunky but it gets it done until I can spend more dedicated time to decouple vault + caddy a bit. 

## Motivation and Context
Fix all the broken things. 

## How Has This Been Tested?
Locally running the AMI build. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
