### PR TITLE
Provision k8s compatible vpc in CI

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/network/Pulumi.infrastructure.aws.network.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/network/Pulumi.infrastructure.aws.network.CI.yaml
@@ -5,6 +5,8 @@ config:
   apps_vpc:cidr_block: 172.18.0.0/16
   aws:region: us-east-1
   data_vpc:cidr_block: 172.17.0.0/16
+  k8s_vpc:cidr_block: 172.30.0.0/16
+  k8s_vpc:k8s_service_subnet: 172.30.48.0/20
   mitx_online_vpc:cidr_block: 10.20.0.0/16
   ocw_vpc:cidr_block: 172.21.0.0/16
   operations_vpc:cidr_block: 172.16.0.0/16

--- a/src/ol_infrastructure/infrastructure/aws/network/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/network/__main__.py
@@ -37,7 +37,7 @@ def vpc_exports(vpc: OLVPC, peers: Optional[List[str]] = None) -> Dict[str, Any]
 
     :rtype: Dict[Text, Any]
     """
-    return {
+    return_value = {
         "cidr": vpc.olvpc.cidr_block,
         "cidr_v6": vpc.olvpc.ipv6_cidr_block,
         "id": vpc.olvpc.id,
@@ -50,6 +50,9 @@ def vpc_exports(vpc: OLVPC, peers: Optional[List[str]] = None) -> Dict[str, Any]
         "subnet_zones": [subnet.availability_zone for subnet in vpc.olvpc_subnets],
         "route_table_id": vpc.route_table.id,
     }
+    if vpc.k8s_service_subnet:
+        return_value["k8s_service_subnet"] = vpc.k8s_service_subnet.cidr_block
+    return return_value
 
 
 stack_info = parse_stack()

--- a/src/ol_infrastructure/infrastructure/aws/network/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/network/__main__.py
@@ -54,6 +54,21 @@ def vpc_exports(vpc: OLVPC, peers: Optional[List[str]] = None) -> Dict[str, Any]
 
 stack_info = parse_stack()
 
+k8s_config = Config("k8s_vpc")
+k8s_vpc_config = OLVPCConfig(
+    vpc_name=f"k8s-{stack_info.env_suffix}",
+    cidr_block=k8s_config.require("cidr_block"),
+    k8s_service_subnet=k8s_config.require("k8s_service_subnet"),
+    num_subnets=16,
+    tags={
+        "OU": "operations",
+        "Environment": f"k8s-{stack_info.env_suffix}",
+        "business_unit": "operations",
+        "Name": f"OL K8S {stack_info.name}",
+    },
+)
+k8svpc = OLVPC(k8s_vpc_config)
+
 apps_config = Config("apps_vpc")
 applications_vpc_config = OLVPCConfig(
     vpc_name=f"applications-{stack_info.env_suffix}",

--- a/src/ol_infrastructure/infrastructure/aws/network/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/network/__main__.py
@@ -67,7 +67,7 @@ k8s_vpc_config = OLVPCConfig(
         "Name": f"OL K8S {stack_info.name}",
     },
 )
-k8svpc = OLVPC(k8s_vpc_config)
+k8s_vpc = OLVPC(k8s_vpc_config)
 
 apps_config = Config("apps_vpc")
 applications_vpc_config = OLVPCConfig(
@@ -358,6 +358,11 @@ xpro_vpc_exports.update(
     }
 )
 export("xpro_vpc", xpro_vpc_exports)
+
+# TODO: MD 2022-05-13 This probably needs to be expanded upon once the k8s network is peered to others
+# when it gains some security groups.
+k8s_vpc_exports = vpc_exports(k8s_vpc)
+export("k8s_vpc", k8s_vpc_exports)
 
 applications_vpc_exports = vpc_exports(applications_vpc, ["data_vpc", "operations_vpc"])
 applications_vpc_exports.update(


### PR DESCRIPTION
Created a mechanism to provision k8s specific VPCs that is backwards compatible with ec2 VPCs.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
K8S is IP address hungry and we should keep it seperated from other VPCs, probably. 

## How Has This Been Tested?
Provisioned all resources in CI successfully.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
