### PR TITLE
build: pin packages(rapid-response-reports, canvas-integration) upgraded for Nutmeg

### DIFF
--- a/src/bilder/images/edxapp/group_data/all.py
+++ b/src/bilder/images/edxapp/group_data/all.py
@@ -55,8 +55,8 @@ edx_plugins_added = {
         "ol-openedx-sentry",
         "ol-openedx-course-export",
         "rapid-response-xblock==0.6.0",
-        "ol-openedx-canvas-integration",
-        "ol-openedx-rapid-response-reports",
+        "ol-openedx-canvas-integration==0.1.1",  # TODO: Remove pin when upgrading to nutmeg
+        "ol-openedx-rapid-response-reports==0.1.0",  # TODO: Remove pin when upgrading to nutmeg
     ],
     "mitx-staging": [
         "celery-redbeat",  # Support for using Redis as the lock for Celery schedules
@@ -68,8 +68,8 @@ edx_plugins_added = {
         "ol-openedx-sentry",
         "ol-openedx-course-export",
         "rapid-response-xblock==0.6.0",
-        "ol-openedx-canvas-integration",
-        "ol-openedx-rapid-response-reports",
+        "ol-openedx-canvas-integration==0.1.1",  # TODO: Remove pin when upgrading to nutmeg
+        "ol-openedx-rapid-response-reports==0.1.0",  # TODO:  Remove pin when upgrading to nutmeg
     ],
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This pins the packages for `ol-openedx-rapid-response-reports`, `ol-openedx-canvas-integration` for production and QA. 

## Description
We did some migration with our plugins to support serving assets through the plugins. That change will only work for Nutmeg branch. So, for the instances Prod/QA which are not using Nutmeg release yet so we need to pin the old packages to be used there to keep them from breaking. 
I couldn't see the QA configurations and the staging seems to be the closes to the QA so I changed in that.

## Motivation and Context
Inspired by https://github.com/mitodl/edx-platform/pull/297#issuecomment-1138713468

## How Has This Been Tested?
No testing is needed as such,  since the packages pinned were the ones published when we deployed Prod/QA and were being used already.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
