### PR TITLE
fix for getting the beat scheduler working again in ODL edx deployments

### DIFF
--- a/src/bilder/images/edxapp/deploy.py
+++ b/src/bilder/images/edxapp/deploy.py
@@ -128,6 +128,15 @@ files.directory(
     recursive=True,
 )
 
+# Ugly, hopefully short-term, fix for getting the beat scheduler working again in ODL edx deployments.
+files.line(
+    name="Fix beat_scheduler.sh to invoke RedBeat rather than the broken single-beat definition.",
+    path=str(Path("/edx/app/edxapp/beat_scheduler.sh")),
+    line="^exec.*$",
+    replace="exec /edx/app/edxapp/venvs/edxapp/bin/celery beat $@",
+    backup=True,
+)
+
 apt.packages(
     name="Install ACL package for more granular file permissions",
     packages=["acl"],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Closes #836 

## How Has This Been Tested?
Built xpro ami locally with packer, started instance from AMI, checked file, executed file (didn't actually run because it wasn't an instance part of a real env... but celery beat attempted to run, which is all I'm looking for...) 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
