### PR TITLE
edx database migrations on boot 

### DIFF
--- a/src/bilder/images/edxapp/deploy.py
+++ b/src/bilder/images/edxapp/deploy.py
@@ -137,6 +137,12 @@ files.line(
     backup=True,
 )
 
+files.put(
+    name="Setup the database migrations service definition",
+    src=str(Path(__file__).resolve().parent.joinpath("files", "migrations.service")),
+    dest=str(Path("/usr/lib/systemd/system/migrations.service")),
+)
+
 apt.packages(
     name="Install ACL package for more granular file permissions",
     packages=["acl"],
@@ -156,6 +162,9 @@ vector_config.configuration_templates[
 ] = {"edx_installation": EDX_INSTALLATION_NAME}
 vector_config.configuration_templates[
     TEMPLATES_DIRECTORY.joinpath("vector", "edxapp_metrics.yaml.j2")
+] = {"edx_installation": EDX_INSTALLATION_NAME}
+vector_config.configuration_templates[
+    TEMPLATES_DIRECTORY.joinpath("vector", "edxapp_migrations_logs.yaml.j2")
 ] = {"edx_installation": EDX_INSTALLATION_NAME}
 consul_configuration = {Path("00-default.json"): ConsulConfig()}
 
@@ -391,6 +400,11 @@ if host.get_fact(HasSystemd):
             # Restart the forum process to reload the configuration file
             "/edx/bin/supervisorctl restart forum'"
         ),
+    )
+    service_configuration_watches(
+        service_name="migrations",
+        watched_files=[lms_config_path, studio_config_path],
+        start_now=False,
     )
 
 if "mitodl" in git_remote and node_type == WEB_NODE_TYPE:

--- a/src/bilder/images/edxapp/files/migrations.service
+++ b/src/bilder/images/edxapp/files/migrations.service
@@ -1,0 +1,17 @@
+[Unit]
+Description="Obtain an exclusive lock and run database migrations at startup."
+Requires=network-online.target
+After=consul-template.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/consul lock -timeout=1h -verbose lsm_migrations /edx/bin/edxapp-migrate-lms
+ExecStart=/usr/local/bin/consul lock -timeout=1h -verbose cms_migrations /edx/bin/edxapp-migrate-cms
+RemainAfterExit=True
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=migrations
+Restart=no
+
+[Install]
+WantedBy=multi-user.target

--- a/src/bilder/images/edxapp/files/migrations.service
+++ b/src/bilder/images/edxapp/files/migrations.service
@@ -5,8 +5,8 @@ After=consul-template.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/local/bin/consul lock -timeout=1h -verbose lsm_migrations /edx/bin/edxapp-migrate-lms
-ExecStart=/usr/local/bin/consul lock -timeout=1h -verbose cms_migrations /edx/bin/edxapp-migrate-cms
+ExecStart=/usr/local/bin/consul lock -timeout=6h -verbose lms_migrations /edx/bin/edxapp-migrate-lms
+ExecStart=/usr/local/bin/consul lock -timeout=6h -verbose cms_migrations /edx/bin/edxapp-migrate-cms
 RemainAfterExit=True
 StandardOutput=journal
 StandardError=journal

--- a/src/bilder/images/edxapp/templates/vector/edxapp_migrations_logs.yaml.j2
+++ b/src/bilder/images/edxapp/templates/vector/edxapp_migrations_logs.yaml.j2
@@ -1,0 +1,50 @@
+---
+log_schema:
+  timestamp_key: vector_timestamp
+  host_key: log_host
+
+sources:
+  collect_edxapp_migrations_logs:
+    type: journald
+    current_boot_only: true
+    include_units:
+    - migrations
+
+transforms:
+
+  parse_edxapp_migrations_logs:
+    inputs:
+    - 'collect_edxapp_migrations_logs'
+    type: remap
+    source: |
+      event, err = parse_json(.message)
+      if event != null {
+        . = merge!(., event)
+        .log_process = "edxapp"
+        .environment = "${ENVIRONMENT}"
+      }
+
+  enrich_edxapp_migrations_logs:
+    type: aws_ec2_metadata
+    inputs:
+    - 'parse_edxapp_migrations_logs'
+    namespace: ec2
+
+sinks:
+  ship_edxapp_migraitons_logs_to_grafana_cloud:
+    inputs:
+    - 'enrich_edxapp_migrations_logs'
+    type: loki
+    auth:
+      strategy: basic
+      password: ${GRAFANA_CLOUD_API_KEY}
+      user: "${GRAFANA_CLOUD_LOKI_API_USER}"
+    endpoint: https://logs-prod-us-central1.grafana.net
+    encoding:
+      codec: json
+    labels:
+      environment: ${ENVIRONMENT}
+      application: edxapp
+      service: {{context.edx_installation}}
+      hostname: ${HOSTNAME}
+    out_of_order_action: rewrite_timestamp


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Setup a one shot systemd service to run database migrations on boot. Will use a consul lock to ensure that only one database migration runs at a time. Closes #420 

## Motivation and Context
https://github.com/mitodl/ol-infrastructure/issues/420 

## How Has This Been Tested?
Built a new AMI, updated the XPro CI environment, verified that the migration service ran on both workers and web nodes. 

Trusting the `consul lock` functionality to work as advertised but can verify no overlapping timestamps in grafana (aside from the messages saying it couldn't acquire the lock and blocking).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
