### PR TITLE
chore: add super-csv package from the encode fix git

### DIFF
--- a/src/bilder/images/edxapp/group_data/all.py
+++ b/src/bilder/images/edxapp/group_data/all.py
@@ -32,6 +32,7 @@ edx_plugins_added = {
         "ol-openedx-course-export",
         "ol-openedx-checkout-external",
         "social-auth-mitxpro==0.6",
+        "git+https://github.com/openedx/super-csv.git@740b7c76cff72f0bbe6b1f3dde3a1086cf8e1cc3#egg=super-csv",
     ],
     "xpro": [
         "celery-redbeat",  # Support for using Redis as the lock for Celery schedules
@@ -44,6 +45,7 @@ edx_plugins_added = {
         "ol-openedx-course-export",
         "social-auth-mitxpro==0.6",
         "git+https://github.com/ubc/ubcpi.git@1.0.0#egg=ubcpi-xblock",
+        "git+https://github.com/openedx/super-csv.git@740b7c76cff72f0bbe6b1f3dde3a1086cf8e1cc3#egg=super-csv",
     ],
     "mitx": [
         "celery-redbeat",  # Support for using Redis as the lock for Celery schedules
@@ -57,6 +59,7 @@ edx_plugins_added = {
         "rapid-response-xblock==0.6.0",
         "ol-openedx-canvas-integration",
         "ol-openedx-rapid-response-reports",
+        "git+https://github.com/openedx/super-csv.git@740b7c76cff72f0bbe6b1f3dde3a1086cf8e1cc3#egg=super-csv",
     ],
     "mitx-staging": [
         "celery-redbeat",  # Support for using Redis as the lock for Celery schedules
@@ -70,6 +73,7 @@ edx_plugins_added = {
         "rapid-response-xblock",
         "ol-openedx-canvas-integration",
         "ol-openedx-rapid-response-reports",
+        "git+https://github.com/openedx/super-csv.git@740b7c76cff72f0bbe6b1f3dde3a1086cf8e1cc3#egg=super-csv",
     ],
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This commit would set the `super-csv` package to be installed from a git commit that has a fix. More details below

## Motivation and Context
We had a fix for broken Grades Import functionality when we run the gradebook when the default Django storage is set to S3. The AWS/S3 would complain about encoding the data and the import request was failing. Since that [upstream PR](https://github.com/openedx/super-csv/pull/100) has not yet been merged, we will need to install that package from that commit and test it on our servers. 

This PR pins that `super-csv` package to be installed from git. 
The pin has been applied to other apps too. More details on https://github.com/mitodl/mitxonline/issues/415#issuecomment-1145203892

## How Has This Been Tested?
- Setup S3 storage for Django.
- Follow details on https://github.com/mitodl/mitxonline/issues/415

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
