### PR TITLE
Added query engine permissions and role

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
@@ -184,7 +184,7 @@ query_engine_iam_permissions = {
 
 # Create instance profile for granting access to S3 buckets
 query_engine_iam_policy = iam.Policy(
-    f"query-engine-policy-{stack_info.env_suffix}",
+    f"data-lake-query-engine-policy-{stack_info.env_suffix}",
     name=f"query-engine-policy-{stack_info.env_suffix}",
     path=f"/ol-data/etl-policy-{stack_info.env_suffix}/",
     policy=lint_iam_policy(
@@ -207,7 +207,7 @@ query_engine_role = iam.Role(
             },
         }
     ),
-    name=f"query-engine-role-{stack_info.env_suffix}",
+    name=f"data-lake-query-engine-policy-{stack_info.env_suffix}",
     path="/ol-data/etl-role/",
     tags=aws_config.tags,
 )

--- a/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
@@ -207,7 +207,7 @@ query_engine_role = iam.Role(
             },
         }
     ),
-    name=f"data-lake-query-engine-policy-{stack_info.env_suffix}",
+    name=f"data-lake-query-engine-role-{stack_info.env_suffix}",
     path="/ol-data/etl-role/",
     tags=aws_config.tags,
 )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Starburst Galaxy requires a cross-account IAM role with permissions to access Glue and the data lake. This PR defines the necessary permissions and creates a role with said permissions.

## How Has This Been Tested?
Ran pulumi preview/up locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
