### PR TITLE
Use aws imdsv2 in scripts

### DIFF
--- a/pipelines/infrastructure/scripts/generate_aws_config_from_instance_profile.sh
+++ b/pipelines/infrastructure/scripts/generate_aws_config_from_instance_profile.sh
@@ -2,10 +2,11 @@
 
 set -e
 
-AWS_ROLE=$(curl -s http://169.254.169.254/latest/meta-data/iam/security-credentials/)
-AWS_ACCESS_KEY_ID="$(curl http://169.254.169.254/latest/meta-data/iam/security-credentials/"$AWS_ROLE" | awk '/AccessKeyId/ {print $3}' | sed 's/[",]//g')"
-AWS_SECRET_ACCESS_KEY="$(curl http://169.254.169.254/latest/meta-data/iam/security-credentials/"$AWS_ROLE" | awk '/SecretAccessKey/ {print $3}' | sed 's/[",]//g')"
-AWS_SESSION_TOKEN="$(curl http://169.254.169.254/latest/meta-data/iam/security-credentials/"$AWS_ROLE" | awk '/Token/ {print $3}' | sed 's/[",]//g')"
+TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+AWS_ROLE=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/meta-data/iam/security-credentials/)
+AWS_ACCESS_KEY_ID="$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/iam/security-credentials/"$AWS_ROLE" | awk '/AccessKeyId/ {print $3}' | sed 's/[",]//g')"
+AWS_SECRET_ACCESS_KEY="$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/iam/security-credentials/"$AWS_ROLE" | awk '/SecretAccessKey/ {print $3}' | sed 's/[",]//g')"
+AWS_SESSION_TOKEN="$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/iam/security-credentials/"$AWS_ROLE" | awk '/Token/ {print $3}' | sed 's/[",]//g')"
 export AWS_ACCESS_KEY_ID
 export AWS_SECRET_ACCESS_KEY
 export AWS_SESSION_TOKEN

--- a/src/bilder/images/vault/files/vault_env_script.sh
+++ b/src/bilder/images/vault/files/vault_env_script.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-PRIVATE_IPV4=$(curl http://169.254.169.254/latest/meta-data/local-ipv4)
+TOKEN=$(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+PRIVATE_IPV4=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/local-ipv4)
 VAULT_CLUSTER_ADDR="https://$PRIVATE_IPV4:8201"
 VAULT_KMS_KEY_ID=$(cat /var/opt/kms_key_id)
 echo "VAULT_CLUSTER_ADDR=$VAULT_CLUSTER_ADDR" | tee /etc/default/vault


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There are two versions of the AWS Instance Metadata Service (imds). V2 adds a secure layer to where a token is required to query the service and both are enabled by default. The goal is to move towards using v2 and turning off v1. This PR is an initial one to upgrade the two scripts to using V2.

## Motivation and Context
This was motivated by the findings in this [article](https://www.mandiant.com/resources/cloud-metadata-abuse-unc2903)

## How Has This Been Tested?
Just ran the script on an EC2 instance

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
