### PR TITLE
fix: Allow multiple hops for IMDSv2 API access

### DIFF
--- a/src/ol_infrastructure/applications/concourse/__main__.py
+++ b/src/ol_infrastructure/applications/concourse/__main__.py
@@ -684,6 +684,12 @@ for worker_def in concourse_config.get_object("workers") or []:
         ],
         instance_type=worker_instance_type,
         key_name="oldevops",
+        metadata_options=ec2.LaunchTemplateMetadataOptionsArgs(
+            http_endpoint="enabled",
+            http_tokens="optional",
+            http_put_response_hop_limit=5,
+            instance_metadata_tags="enabled",
+        ),
         tag_specifications=[
             ec2.LaunchTemplateTagSpecificationArgs(
                 resource_type="instance",

--- a/src/ol_infrastructure/components/aws/auto_scale_group.py
+++ b/src/ol_infrastructure/components/aws/auto_scale_group.py
@@ -14,6 +14,7 @@ from pulumi_aws.ec2 import (
     LaunchTemplateBlockDeviceMappingArgs,
     LaunchTemplateBlockDeviceMappingEbsArgs,
     LaunchTemplateIamInstanceProfileArgs,
+    LaunchTemplateMetadataOptionsArgs,
     LaunchTemplateTagSpecificationArgs,
     SecurityGroup,
 )
@@ -308,7 +309,7 @@ class OLAutoScaling(pulumi.ComponentResource):
 
         # Construct the launch template
         self.launch_template = LaunchTemplate(
-            resource_name_prefix + "launch-template",
+            f"{resource_name_prefix}-launch-template",
             name_prefix=resource_name_prefix,
             block_device_mappings=block_device_mappings,
             iam_instance_profile=LaunchTemplateIamInstanceProfileArgs(
@@ -321,6 +322,12 @@ class OLAutoScaling(pulumi.ComponentResource):
             tags=lt_config.tags,
             user_data=lt_config.user_data,
             vpc_security_group_ids=lt_config.security_groups,
+            metadata_options=LaunchTemplateMetadataOptionsArgs(
+                http_endpoint="enabled",
+                http_tokens="optional",
+                http_put_response_hop_limit=5,
+                instance_metadata_tags="enabled",
+            ),
             opts=resource_options,
         )
 


### PR DESCRIPTION
The AWS metadata service has a V2 API that uses authentication tokens for requests. In
order to allow for using that API from containers running on EC2 hosts we need to
increase the maximum number of allowed network hops.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds metadata configuration details for autoscaling group launch templates to allow for multiple network hops when communicating with the IMDSv2 metadata API on EC2 instances that run docker containers which need to interact with that API.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We would like to start using the IMDSv2 metadata service to improve overall instance security

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually applied changes and verified ability to use v2 metadata API

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
