### PR TITLE
config: update external checkout redirect url to cart/add

### DIFF
--- a/src/bilder/images/edxapp/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -334,7 +334,7 @@ LOGIN_REDIRECT_WHITELIST:  # MODIFIED
 LOG_DIR: /edx/var/log/edx
 MAINTENANCE_BANNER_TEXT: Sample banner message
 MARKETING_SITE_BASE_URL: https://{{ key "edxapp/marketing-domain" }}/ # ADDED - to support mitxonline-theme
-MARKETING_SITE_CHECKOUT_URL: https://{{ key "edxapp/marketing-domain" }}/cart/ # ADDED - to support mitxonline checkout
+MARKETING_SITE_CHECKOUT_URL: https://{{ key "edxapp/marketing-domain" }}/cart/add/ # ADDED - to support mitxonline checkout
 MEDIA_ROOT: media/  # MODIFIED - with s3 storage backend this is the path within the bucket. No leading / allowed
 MEDIA_URL: /media/
 MICROSITE_CONFIGURATION: {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- The redirect URL currently redirects to `/cart` of the marketing application, Specifically for MITxOnline it should instead go to `/cart/add` which is the right URL to add a product inside cart

## Motivation and Context
- Associated with https://github.com/mitodl/mitxonline/issues/610
- Some counter implementation is being done in the MITxOnline to handle the checkout course URL and convert it to the product.

## How Has This Been Tested?
- Install the external-checkout plugin
- Set the values for `MARKETING_SITE_CHECKOUT_URL, MARKETING_SITE_BASE_URL, ECOMMERCE_PUBLIC_URL_ROOT` accordingly as mentioned in [ECOMMERCE_PUBLIC_URL_ROOT](https://github.com/mitodl/ol-infrastructure/pull/823)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
