### PR TITLE
feat: Add pipeline configs for deploying edxapp

### DIFF
--- a/pipelines/infrastructure/ami_builds/edxapp/edx_custom_ami.yaml
+++ b/pipelines/infrastructure/ami_builds/edxapp/edx_custom_ami.yaml
@@ -40,6 +40,32 @@ resources:
       is-public: false
       state: available
       name: edxapp-web-((edx_release))-*
+
+- name: edxapp-worker-custom-ami
+  type: ami
+  check_every: 30m
+  source:
+    region: us-east-1
+    filters:
+      owner-id: 610119931565
+      is-public: false
+      state: available
+      name: edxapp-worker-*
+      tag:deployment: ((edx_installation))
+      tag:edxapp_release: ((edx_release))
+- name: edxapp-web-custom-ami
+  type: ami
+  check_every: 30m
+  source:
+    region: us-east-1
+    filters:
+      owner-id: 610119931565
+      is-public: false
+      state: available
+      name: edxapp-web-*
+      tag:deployment: ((edx_installation))
+      tag:edxapp_release: ((edx_release))
+
 - icon: github
   name: packer_templates
   source:
@@ -49,6 +75,19 @@ resources:
     - src/bilder/images/edxapp/
     uri: https://github.com/mitodl/ol-infrastructure
   type: git
+
+- icon: github
+  name: pulumi_code
+  source:
+    branch: main
+    paths:
+    - src/ol_infrastructure/applications/edxapp/
+    uri: https://github.com/mitodl/ol-infrastructure
+  type: git
+
+- name: deploy-edxapp
+  source:
+  type: pulumi
 - name: packer-validate
   type: packer
 - name: packer-build
@@ -85,7 +124,7 @@ jobs:
         vars:
           node_type: worker
 
-- name: build-custom-packer-template
+- name: build-custom-edxapp-amis
   plan:
   - get: edxapp-worker-base-ami
     trigger: true
@@ -98,7 +137,8 @@ jobs:
   - get: packer_templates
     trigger: true
   - in_parallel:
-    - put: packer-build
+    - put: custom-edxapp-web-ami
+      resource: packer-build
       params:
         env_vars:
           AWS_REGION: us-east-1
@@ -111,7 +151,8 @@ jobs:
         - packer_templates/src/bilder/images/edxapp/packer_vars/((edx_installation)).pkrvars.hcl
         vars:
           node_type: web
-    - put: packer-build
+    - put: custom-edxapp-worker-ami
+      resource: packer-build
       params:
         env_vars:
           AWS_REGION: us-east-1
@@ -124,3 +165,123 @@ jobs:
         - packer_templates/src/bilder/images/edxapp/packer_vars/((edx_installation)).pkrvars.hcl
         vars:
           node_type: worker
+
+- name: deploy-edxapp-ci
+  plan:
+  - get: packer-build
+    passed: [build-custom-edxapp-amis]
+    trigger: true
+  - get: edxapp-web-custom-ami
+  - get: edxapp-worker-custom-ami
+  - get: pulumi_code
+    trigger: true
+  - task: set-aws-creds
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: amazon/aws-cli
+          tag: 'latest'
+      inputs:
+      - name: pulumi_code
+      outputs:
+      - name: aws_creds
+      run:
+        path: pulumi_code/pipelines/infrastructure/scripts/generate_aws_config_from_instance_profile.sh
+  - put: deploy-edxapp
+    inputs:
+    - aws_creds
+    - pulumi_code
+    get_params:
+      skip_implicit_get: true
+    params:
+      env_pulumi:
+        AWS_SHARED_CREDENTIALS_FILE: aws_creds/credentials
+      action: update
+      env_os:
+        AWS_DEFAULT_REGION: us-east-1
+        PYTHONPATH: /usr/lib/:/tmp/build/put/pulumi_code/src/
+      project_name: ol-infrastructure-edxapp-application
+      source_dir: pulumi_code/src/ol_infrastructure/applications/edxapp
+      stack_name: applications.edxapp.((edx_installation)).CI
+
+- name: deploy-edxapp-qa
+  plan:
+  - get: edxapp-web-custom-ami
+    passed: [deploy-edxapp-ci]
+  - get: edxapp-worker-custom-ami
+    passed: [deploy-edxapp-ci]
+  - get: pulumi_code
+    passed: [deploy-edxapp-ci]
+    trigger: false
+  - task: set-aws-creds
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: amazon/aws-cli
+          tag: 'latest'
+      inputs:
+      - name: pulumi_code
+      outputs:
+      - name: aws_creds
+      run:
+        path: pulumi_code/pipelines/infrastructure/scripts/generate_aws_config_from_instance_profile.sh
+  - put: deploy-edxapp
+    inputs:
+    - aws_creds
+    - pulumi_code
+    get_params:
+      skip_implicit_get: true
+    params:
+      env_pulumi:
+        AWS_SHARED_CREDENTIALS_FILE: aws_creds/credentials
+      action: update
+      env_os:
+        AWS_DEFAULT_REGION: us-east-1
+        PYTHONPATH: /usr/lib/:/tmp/build/put/pulumi_code/src/
+      project_name: ol-infrastructure-edxapp-application
+      source_dir: pulumi_code/src/ol_infrastructure/applications/edxapp
+      stack_name: applications.edxapp.((edx_installation)).QA
+
+- name: deploy-edxapp-production
+  plan:
+  - get: edxapp-web-custom-ami
+    passed: [deploy-edxapp-qa]
+  - get: edxapp-worker-custom-ami
+    passed: [deploy-edxapp-qa]
+  - get: pulumi_code
+    passed: [deploy-edxapp-qa]
+    trigger: false
+  - task: set-aws-creds
+    config:
+      platform: linux
+      image_resource:
+        type: registry-image
+        source:
+          repository: amazon/aws-cli
+          tag: 'latest'
+      inputs:
+      - name: pulumi_code
+      outputs:
+      - name: aws_creds
+      run:
+        path: pulumi_code/pipelines/infrastructure/scripts/generate_aws_config_from_instance_profile.sh
+  - put: deploy-edxapp
+    inputs:
+    - aws_creds
+    - pulumi_code
+    get_params:
+      skip_implicit_get: true
+    params:
+      env_pulumi:
+        AWS_SHARED_CREDENTIALS_FILE: aws_creds/credentials
+      action: update
+      env_os:
+        AWS_DEFAULT_REGION: us-east-1
+        PYTHONPATH: /usr/lib/:/tmp/build/put/pulumi_code/src/
+      project_name: ol-infrastructure-edxapp-application
+      source_dir: pulumi_code/src/ol_infrastructure/applications/edxapp
+      stack_name: applications.edxapp.((edx_installation)).Production

--- a/pipelines/infrastructure/ami_builds/edxapp/edx_custom_ami_vars/mitx-staging.yaml
+++ b/pipelines/infrastructure/ami_builds/edxapp/edx_custom_ami_vars/mitx-staging.yaml
@@ -1,3 +1,3 @@
 ---
-edx_release: open-release/maple.master
+edx_release: open-release/nutmeg.master
 edx_installation: mitx-staging

--- a/pipelines/infrastructure/ami_builds/edxapp/edx_custom_ami_vars/mitx.yaml
+++ b/pipelines/infrastructure/ami_builds/edxapp/edx_custom_ami_vars/mitx.yaml
@@ -1,3 +1,3 @@
 ---
-edx_release: open-release/maple.master
+edx_release: open-release/nutmeg.master
 edx_installation: mitx


### PR DESCRIPTION
In order to improve the ergonomics and visibility of edX deployments we want to run them
via Concourse. This extends the pipeline template for building the second stage AMIs to
then run the Pulumi deployments once the AMIs are built.

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Add Pulumi steps for relevant environments to deploy built AMIs
- Only trigger the earliest stage Pulumi step so that subsequent environments are manual triggers

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Running edX deployments gets bottlenecked with DevOps and is hard to keep track of what has been deployed where and when. This addresses that problem. Fixes #904 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Pushed pipeline to Concourse CI to ensure it renders properly, deployed pipelines to Concourse Production and unpaused residential pipelines to build Nutmeg image

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
