### PR TITLE
change OCW redirect response to 301 instead of 302

### DIFF
--- a/src/ol_infrastructure/applications/ocw_site/snippets/reroute_redirects.vcl
+++ b/src/ol_infrastructure/applications/ocw_site/snippets/reroute_redirects.vcl
@@ -1,36 +1,36 @@
 if (obj.status == 601 && obj.response == "redirect") {
-  set obj.status = 302;
+  set obj.status = 301;
   set obj.http.Location = req.protocol + "://" + req.http.host + req.http.header_sans_department;
   return (deliver);
 }
 
 if (obj.status == 602 && obj.response == "redirect" && !req.http.redirected) {
-  set obj.status = 302;
+  set obj.status = 301;
   set obj.http.Location = req.protocol + "://" + req.http.host + req.http.pages_header;
   set req.http.redirected = "1";
   return (deliver);
 }
 
 if (obj.status == 604 && obj.response == "redirect") {
-  set obj.status = 302;
+  set obj.status = 301;
   set obj.http.location = req.http.courses_instead_resources;
   return(deliver);
 }
 
 if (obj.status == 605 && obj.response == "redirect") {
-  set obj.status = 302;
+  set obj.status = 301;
   set obj.http.location = req.http.remove_index_htm;
   return(deliver);
 }
 
 if (obj.status == 606 && obj.response == "redirect") {
-  set obj.status = 302;
+  set obj.status = 301;
   set obj.http.location = req.http.high_school_to_article;
   return(deliver);
 }
 
 if (obj.status == 301) {
-  set obj.status = 302;
+  set obj.status = 301;
   set obj.http.Location = req.protocol + "://" + req.http.host + req.http.slash_header;
   return (deliver);
 }


### PR DESCRIPTION
## Description
In https://github.com/mitodl/ol-infrastructure/pull/867, `reroute_redirects.vcl` was added to configure redirects for OCW.  The status code of the redirects was set to 302, which is a temporary redirect.  This PR sets them to 301, making the redirects permanent.

## Motivation and Context
Since the launch of the new OCW site, the Google search rankings have gone down significantly and we are making efforts to correct that.  Some of those include defining a proper sitemap index and making sure meta descriptions are set for every page.  One of the biggest remaining categories of errors / unindexed pages are redirect issues.  According to [this page](https://developers.google.com/search/docs/advanced/crawling/301-redirects#:~:text=Redirecting%20URLs%20is%20the%20practice,page%20has%20a%20new%20location.), Google interprets 302 redirects as a "weak" signal that the target page should be canonical.  In order for the Google indexer to get a "strong" signal that the target of the redirect is canonical, the redirect needs to be 301; permanent.

## How Has This Been Tested?
There isn't really a way to test this, we need to set it up in Fastly and configure the redirects to be 301 and watch Google over time and see if starts considering the redirect targets as canonical.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
