### PR TITLE
feat: Add maintenance override for edxapp DNS

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.Production.yaml
@@ -20,6 +20,7 @@ config:
   edxapp:google_analytics_id: ""
   edxapp:edxapp_release: open-release/nutmeg.master
   edxapp:mail_domain: edxapp-mail-staging-production.mitx.mit.edu
+  edxapp:maintenance_page_dns: d18vms1k4mfvhk.cloudfront.net
   edxapp:min_web_nodes: "1"
   edxapp:min_worker_nodes: "1"
   edxapp:sender_email_address: support@edxapp-mail-staging-production.mitx.mit.edu

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.Production.yaml
@@ -20,6 +20,7 @@ config:
   edxapp:edxapp_release: open-release/nutmeg.master
   edxapp:google_analytics_id: UA-5145472-4
   edxapp:mail_domain: edxapp-mail-production.mitx.mit.edu
+  edxapp:maintenance_page_dns: d18vms1k4mfvhk.cloudfront.net
   edxapp:min_web_nodes: "5"
   edxapp:min_worker_nodes: "2"
   edxapp:sender_email_address: mitx-support@mit.edu

--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -1273,13 +1273,14 @@ worker_asg = autoscaling.Group(
 
 # Create Route53 DNS records for Edxapp web nodes
 for domain_key, domain_value in edxapp_domains.items():
+    dns_override = edxapp_config.get("maintenance_page_dns")
     if domain_key == "lms":
         route53.Record(
             f"edxapp-web-{domain_key}-dns-record",
             name=domain_value,
             type="CNAME",
             ttl=FIVE_MINUTES,
-            records=["j.sni.global.fastly.net"],
+            records=[dns_override or "j.sni.global.fastly.net"],
             zone_id=edxapp_zone_id,
         )
     else:
@@ -1288,7 +1289,7 @@ for domain_key, domain_value in edxapp_domains.items():
             name=domain_value,
             type="CNAME",
             ttl=FIVE_MINUTES,
-            records=[web_lb.dns_name],
+            records=[dns_override or web_lb.dns_name],
             zone_id=edxapp_zone_id,
         )
 


### PR DESCRIPTION
During scheduled upgrades of Open edX we like to route site visitors to a static maintenance page.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In order to support easily toggling maintenance mode on on and off this adds a stack setting for a maintenance page DNS value that will be set in Route53 when it is present and then toggle back to the proper value when it is removed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We would like to prevent users from using the Open edX site during upgrades

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Validated the functionality of the conditional logic in a Python REPL

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
