### PR TITLE
Removing concourse_jobs_schedulingDuration.* metrics from collection

### DIFF
--- a/src/bilder/images/concourse/templates/vector/concourse_metrics.yaml
+++ b/src/bilder/images/concourse/templates/vector/concourse_metrics.yaml
@@ -22,7 +22,7 @@ transforms:
     - 'add_hostname_to_concourse_metrics'
     source: |
       ## Any metrics that match these prefixes or names will be dropped entirely
-      abort_name_match, err = match_any(.name, [r'^prom.*', r'^process.*', r'go_.*', r'concourse_builds_duration_seconds', r'concourse_http_responses_duration_seconds', r'concourse_steps_wait_duration'])
+      abort_name_match, err = match_any(.name, [r'^prom.*', r'^process.*', r'go_.*', r'concourse_builds_duration_seconds', r'concourse_http_responses_duration_seconds', r'concourse_steps_wait_duration', r'concourse_jobs_schedulingDuration.*'])
       if abort_name_match {
         abort
       }


### PR DESCRIPTION

## Description
This is a new metric with the most recent version of Concourse that has exploded our cardinality in GrafanaCloud. 

## Motivation and Context
Save $$$

## How Has This Been Tested?
No, not tested. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
