### PR TITLE
add `global-languages` to list of departments

### DIFF
--- a/src/ol_infrastructure/applications/ocw_site/snippets/departments_table.vcl
+++ b/src/ol_infrastructure/applications/ocw_site/snippets/departments_table.vcl
@@ -3,6 +3,7 @@ table departments BOOL {
   "biological-engineering": true,
   "aeronautics-and-astronautics": true,
   "global-studies-and-languages": true,
+  "global-languages": true,
   "mathematics": true,
   "health-sciences-and-technology": true,
   "edgerton-center": true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

in May 2020 department 21a `global-studies-and-languages` was renamed `global-languages`. The department name should be removed when redirecting legacy URLs.

## Motivation and Context

There are still legacy URLs with the department name on the internet, including in the Google searc index. 

## How Has This Been Tested?

It hasn't been tested. We should test it on QA. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
