### PR TITLE
defaults: Enable the gradebook MFE for all environments

### DIFF
--- a/src/bilder/images/edxapp/templates/edxapp/mitx/lms_only.yml.tmpl
+++ b/src/bilder/images/edxapp/templates/edxapp/mitx/lms_only.yml.tmpl
@@ -89,7 +89,7 @@ VERIFY_STUDENT:
     EXPIRING_SOON_WINDOW: 28
 VIDEO_CDN_URL:
     EXAMPLE_COUNTRY_CODE: http://example.com/edx/video?s3_url=
-WRITABLE_GRADEBOOK_URL: {{ keyOrDefault "edxapp/gradebook-url" "" }} # MODIFIED for use with Gradeook MFE
+WRITABLE_GRADEBOOK_URL: "/gradebook" # MODIFIED for use with Gradeook MFE
 
 ########################################################
 # We are not using any of the enterprise functionality #

--- a/src/bilder/images/edxapp/templates/edxapp/mitxonline/lms_only.yml.tmpl
+++ b/src/bilder/images/edxapp/templates/edxapp/mitxonline/lms_only.yml.tmpl
@@ -102,7 +102,7 @@ VERIFY_STUDENT:
     EXPIRING_SOON_WINDOW: 28
 VIDEO_CDN_URL:
     EXAMPLE_COUNTRY_CODE: http://example.com/edx/video?s3_url=
-WRITABLE_GRADEBOOK_URL: {{ keyOrDefault "edxapp/gradebook-url" "" }}  # MODIFIED for use with Gradeook MFE
+WRITABLE_GRADEBOOK_URL: "/gradebook"  # MODIFIED for use with Gradeook MFE
 
 ########################################################
 # We are not using any of the enterprise functionality #

--- a/src/bilder/images/edxapp/templates/edxapp/xpro/lms_only.yml.tmpl
+++ b/src/bilder/images/edxapp/templates/edxapp/xpro/lms_only.yml.tmpl
@@ -102,7 +102,7 @@ VERIFY_STUDENT:
     EXPIRING_SOON_WINDOW: 28
 VIDEO_CDN_URL:
     EXAMPLE_COUNTRY_CODE: http://example.com/edx/video?s3_url=
-WRITABLE_GRADEBOOK_URL: {{ keyOrDefault "edxapp/gradebook-url" "" }} # MODIFIED for use with Gradeook MFE
+WRITABLE_GRADEBOOK_URL: "/gradebook" # MODIFIED for use with Gradeook MFE
 
 ########################################################
 # We are not using any of the enterprise functionality #

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.CI.yaml
@@ -19,7 +19,6 @@ config:
   edxapp:edxapp_release: open-release/nutmeg.master
   edxapp:elb_healthcheck_interval: "30"
   edxapp:google_analytics_id: ""
-  edxapp:gradebook_url: /gradebook
   edxapp:mail_domain: edxapp-mail-ci.mitx.mit.edu
   edxapp:min_web_nodes: "1"
   edxapp:min_worker_nodes: "1"

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.QA.yaml
@@ -20,7 +20,6 @@ config:
   edxapp:edxapp_release: open-release/nutmeg.master
   edxapp:elb_healthcheck_interval: "30"
   edxapp:google_analytics_id: ""
-  edxapp:gradebook_url: /gradebook
   edxapp:mail_domain: edxapp-mail-qa.mitx.mit.edu
   edxapp:min_web_nodes: "1"
   edxapp:min_worker_nodes: "1"

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
@@ -23,8 +23,6 @@ config:
   edxapp:sender_email_address: mitxonline-support@mit.edu
   edxapp:web_node_capacity: "9"
   edxapp:worker_node_capacity: "5"
-  mongodb:admin_password:
-    secure: v1:Z57JZ5RX59bVTb2j:zIERkkj7Vs1e7J+qZNhaPOo3H6owlQn3Ovj9VpikQaXbWa4uBV4B7Lf6I9KWoDMohXYJoId1Dn5waiSlmOBp19NhoPQNilteLJDmjyl5T2N6zNxsLi8T3u7C
   mongodb:atlas_project_id: 61f0a63f8bc1f86a073a7148
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
@@ -20,7 +20,6 @@ config:
   edxapp:edxapp_release: release
   edxapp:elb_healthcheck_interval: "30"
   edxapp:google_analytics_id: UA-5145472-46
-  edxapp:gradebook_url: /gradebook
   edxapp:mail_domain: edxapp-mail-qa.mitxonline.mit.edu
   edxapp:sender_email_address: support@edxapp-mail-qa.mitxonline.mit.edu
   mongodb:atlas_project_id: 61a8fd80284fd30a660f2699

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.CI.yaml
@@ -17,7 +17,6 @@ config:
   edxapp:edxapp_release: open-release/maple.master
   edxapp:elb_healthcheck_interval: "30"
   edxapp:google_analytics_id: ""
-  edxapp:gradebook_url: /gradebook
   edxapp:mail_domain: edxapp-mail-ci.xpro.mit.edu
   edxapp:min_web_nodes: "1"
   edxapp:min_worker_nodes: "1"

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.QA.yaml
@@ -17,7 +17,6 @@ config:
   edxapp:elb_healthcheck_interval: "30"
   edxapp:edxapp_release: open-release/maple.master
   edxapp:google_analytics_id: ""
-  edxapp:gradebook_url: /gradebook
   edxapp:mail_domain: edxapp-mail-qa.xpro.mit.edu
   edxapp:min_web_nodes: "1"
   edxapp:min_worker_nodes: "1"

--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -834,8 +834,6 @@ consul_kv_data = {
     "session-cookie-domain": ".{}".format(edxapp_domains["lms"].split(".", 1)[-1]),
     "studio-domain": edxapp_domains["studio"],
 }
-if gradebook_url := edxapp_config.get("gradebook_url"):
-    consul_kv_data["gradebook-url"] = gradebook_url
 consul.Keys(
     "edxapp-consul-template-data",
     keys=[


### PR DESCRIPTION
Enable the edxapp gradebook MFE for all environments
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This updates the configuration to turn on the gradebook for all environments on all
deployments that we are using it. It also removes the placeholder approach that allowed
us to toggle the gradebook per environment via Consul values.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#833 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
