### PR TITLE
Growing worker filesystem size for edxapp 

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -1213,7 +1213,7 @@ worker_launch_config = ec2.LaunchTemplate(
         ec2.LaunchTemplateBlockDeviceMappingArgs(
             device_name=edxapp_worker_ami.root_device_name,
             ebs=ec2.LaunchTemplateBlockDeviceMappingEbsArgs(
-                volume_size=edxapp_config.get_int("worker_disk_size") or 25,
+                volume_size=edxapp_config.get_int("worker_disk_size") or 50,
                 volume_type=DiskTypes.ssd,
                 delete_on_termination=True,
                 encrypted=True,


### PR DESCRIPTION
Growing worker filesystem size on all edx workers to account for course export processes.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Sets the default worker disk size to 50GB rather than 25GB

## Motivation and Context
Stop paging me. 

## How Has This Been Tested?
Will apply the stack to the unhappy environments

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
