### PR TITLE
Provision transitional elasticsearch clusters for MIT OPEN

### DIFF
--- a/src/bridge/secrets/opensearch/opensearch.open.ci.yaml
+++ b/src/bridge/secrets/opensearch/opensearch.open.ci.yaml
@@ -1,0 +1,79 @@
+---
+master_user_password: ENC[AES256_GCM,data:xNE3EpTxonXfcEUycYEeSJE1fCnsiW6e1ls=,iv:XyEbs7brn16xiIjOL/MiN9d+wYRvtXkKA23gEOFNde4=,tag:/rPqudDjbK1BJxd0Z6eo2A==,type:str]
+read_only_user_password: ENC[AES256_GCM,data:Omwb+yrwVgyr5MlFYTuy2QHPk7XIN+1FQRg=,iv:AZLGqCiaVC4p/VDBHF2MlhPaC1jwoji04GSF9sEImMw=,tag:410DDmyUVZiTqsAIqtS4Yg==,type:str]
+read_write_user_password: ENC[AES256_GCM,data:sr82YaxL/fIbL7KH5QONSUvgCh/TzYLGVFS8,iv:zQvTp/ff0xXihv7LmBlwj1gibasj2xtOrP4FUJO+UVs=,tag:7tkeUmq319RmK6U+/kf9Aw==,type:str]
+sops:
+  kms:
+  - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-ci
+    created_at: "2022-08-02T15:02:37Z"
+    enc: AQICAHjs8ajWpT7YRhWXwI//wPkHX53RHlo0DjkgQOwCBTUBwQHvUgZAQKu7n44YHHeW7EdVAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMPZ0PYBTJURko09LFAgEQgDsvgcez6eLTKrWZS+aW6HUOc/8/hYBKWqkaS4b2XckvldtBTKw4SBygMl17Mcdx9cz1o7W8s9oy9H17mA==
+    aws_profile: ""
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: "2022-08-02T15:04:57Z"
+  mac: ENC[AES256_GCM,data:XRDQ2L7wBblFvQ8wxIOsxL6va/NZym7aCuXN2iNsAfnWXLDs/fofXS9S0mC/rJ7NaJXUIBr0L+EuTTJG3PzY9xkASqNdV5s4uz+3s8WTKjCrp0LQkk1XliHX+l9/kbzSJXNDsEznkOS+s/U0Ti+UT04eVJm4XC85eyrDzQUz6U4=,iv:2DSvcYZKn84BQjj2ehpSSoF5LlOY7MD1GYa1l8rc3L4=,tag:VpjTdflr9CEoByCdMEaVew==,type:str]
+  pgp:
+  - created_at: "2022-08-02T15:02:37Z"
+    enc: |
+      -----BEGIN PGP MESSAGE-----
+
+      hQIMA9YmDGFr0PozAQ//W+0gfaMeXYriH8dPlIHiMUjjenhFv1TrL4sy7LyBQg/l
+      5XukeUWnW8eY6w2BvBiT1kNGa7WkuEGXo08/hyqeHkIBlzCK3KIB2qcUOO6CTKeB
+      q0Kwn2MrpWtHJMiaaVz7f2gVWLj8MBmk8CjBXvFxAL2A+uOKyhqTRU2SLngeyKwJ
+      k/cp/nrYdEg85m6qN8DM2SrHTNr6wdqAnAkDg2ZJluaE3dhcLV00SCv0aoPRnNrI
+      FjiXB+8FI9aa5dDnn75m0aDb8Y6uQGgBJwlilSpVAe2vAjDKcA+6mRGOUodNA1wT
+      HL9dJiWRed0IOfIanQvnGPMDc3QLggEQ/Cx6bqUqNoOIbLNLvUIZweGHWQba8D8+
+      H3PmpiZm8yNmiX1QaJLsUx/6pqVUK50fakbv/mqpijmlOz0hTrEigukuTuXvUo8y
+      vTEhDHHJud7pgPs4KbQ80xSnZDT+7tZsyevUjLmaCGz4g5w1nEcTSWld404FwmTU
+      rqHMyTPBbaEtd4vzyaJ0MsNZ2C6wOv9stvzzXOBFwt1B6VyTlrhx4PBFQiaF50+b
+      X19PChHpBUX83vra0+bZ5klG9KhOPGlqz9mlIWHC1BDE6YeJ0e3AiDgqm0ozud0g
+      R5vm0aSSGZ1dCr+qi1ZCvsPPA6HRMswsG9od9pADKoTNvr5N14LvKQ+8NqCX5ZHS
+      XgGMXoLI+x/gdB673G7OxrdZ/q0hfg5RQVbZdaxGlh9udm9K6EUMfqtn+6QVbMph
+      cqMhrokcR51FZVtAKFJlQEd1D2/oXJVrRyDyfq6t+B9phierg0AYv3qBycxdPdk=
+      =UuNt
+      -----END PGP MESSAGE-----
+    fp: dfd1205a98269f34c43c9221d6260c616bd0fa33
+  - created_at: "2022-08-02T15:02:37Z"
+    enc: |
+      -----BEGIN PGP MESSAGE-----
+
+      hQIMA8MO7RiKjktCAQ//XuIM7jcJ/3kFdoSLBDlUcq5Md9HyJk9PF1SZpuPy1y+6
+      S4d0jLBllQ6YCj53qMbbXDDXougxlZGNANF3gVumSBTl5b5kXU4XcT63m4pFMoqs
+      JRIfSsb3zZPPwKmKg+/LrIEfyIUK219UwySaLiz9qKH+MGMzo1MtyxPc3BPm7/uM
+      wpaQRuKQ4SZIBooRLijW9dYsaMpvOoXzE8iAa62zwWIfd8Euotvksmo50E2DbD2y
+      UBw7L3HUsicbV/nhr1psIObL+XZ9gSKsF+uHPI30rQM5c+j+hND7hmIB29n+ay33
+      FjXX2XLffXPm0RYGwXktlD4GDqAZXNyKQckmcA2SSN1KScK8bB42eyVA1oaZHmns
+      rAOkDgFRbyNh3xwGkkqoKirVQkdS3zG419qkY77Sgt+fskPlAMUcgdRyBjqjNE1S
+      4UdKFKwOSjcNMEQHMpI/xmlCcqSzZx3XVt5fRC4IywV6iktUG7bKUbRx7lXMXXfp
+      UTL573a9Co5gXjEnCAM+j/DkkwOB07rAsdX3Wy1Buz97zYgmtKJ9t0DKhXbGHCDw
+      aHdribdTP18B/hYWvd9FWCI917/ev1sOP7wv2fO85UmfFun59rQEKkTdLZIakXYg
+      OdeXhHHonnbE+FSjiZGQOV7EJmalpSzbKglw5jivtUrJMdXG6GHKdcucgODrSWDS
+      UQECw1st4hZb4hWrCLy0Nx2H7LzXE+gYLVp6J7K/7oYsFBXnhreuZDdGxbm1unPp
+      2wbF/07tb2EWZx4jUBhwU7IdPO7s7zU4lXQJwFbWZtRRwg==
+      =Le2D
+      -----END PGP MESSAGE-----
+    fp: B905F0256A801D3F1D15B5126A1D27A4BE75B1C2
+  - created_at: "2022-08-02T15:02:37Z"
+    enc: |-
+      -----BEGIN PGP MESSAGE-----
+
+      wcFMA53hirIFs7uxARAApBQw0Goa02rVOJ7OxORk2lhtjtIUBy2zhlj4KmXXfXxT
+      UAxVDzF9AIpHsBcvug8XMGQ4qk/IXVpWv+KnkiYKC0uc8yYl+Q3skNzHT6o/8HxE
+      xjsPTN4frnFYQZkGvzbq0D4VYSflpXfnlHLNMdQdIZ9qXh8rHv18V1wqW8sJ2gKi
+      gNkBTdE4CKuHga2jSx6BoXCkitvIRiu7HcJyya8BzlWGT6yOFDtIU+Kw3PeL/0oL
+      Oy4hUXL2a7TNjONvHMZuZN85tzalGRQESt3VnDaEyyKTVHBKRP/+5mvTqUZKu8jI
+      BJIYWdE1bVAfvk/xaYHtkMBWIotw734htXBaNm1omta+qX423Z1Xh8qPDTJkmKdN
+      YfKgyFjDxaEPoWH/9yZOrVTyyA9K+iO/LCggHEPPPWT2ZqAQhGvWTEzj/kiRdMd/
+      5e0WSvQ6HPGTk0x81xJ2pI8swl0+K5iy25D+cG7M/8D0TAtZnKZeYdWNlLPL0jP0
+      YYUlFAoaoOizOu9rLlCrWZnsI6tymuaXJ6J0py2T0gTYglV0SwNIBiZrmuj2jTR/
+      sHZKpVOdFebd0XVY5TbUlrpqrYWgo1FdQKaLbb3rET33gRiIYSV23s/TgqbwsTeY
+      KHgfhsl995277EX3lvIyDWSRhwZFi9AcW46gDFD/+0bynuItXyekamMo/+Kh1JPS
+      5gEKn8QsMEowiOO560RRxDxXhsoPR2Gq3669QqQe2QFZ/Ppw5ZnzrEYtVsVKFovp
+      +E33VOhfL8amvLvjy3FW4J/kTljNkW7bJ8LYrgp1cQ2nh+IA/HBBAA==
+      =1KPD
+      -----END PGP MESSAGE-----
+    fp: 07083D36FD5986B0C99700944E9B358045C1B176
+  unencrypted_suffix: _unencrypted
+  version: 3.7.1

--- a/src/bridge/secrets/opensearch/opensearch.open.production.yaml
+++ b/src/bridge/secrets/opensearch/opensearch.open.production.yaml
@@ -1,0 +1,79 @@
+---
+master_user_password: ENC[AES256_GCM,data:ujhU4oVDYXrCqzST+8G9372aunY7SpxZywU=,iv:DjC16gfW5p8GL4GDF9oAEZyPoITMtoyKxLfKG8+AWSE=,tag:QfU1tox4/0Hte/6jSSxTOw==,type:str]
+read_only_user_password: ENC[AES256_GCM,data:mVr8VmZk1p9c8Je5ozM2m0YFoonxTDJ9ng==,iv:6/YY2cQ9mNTiSLBRv12bgOO116UqKYXYY4FWR//z8bQ=,tag:FpXkHUt9BSqvRuoZIeqTgw==,type:str]
+read_write_user_password: ENC[AES256_GCM,data:scbMOiCrXx90mtyWE2PEOPO1gjj5xjWVI0A=,iv:NncaZz1r9M+jZiUSpJXTbFd6bE5XsTS8Alc5poxDcc0=,tag:CFOoM+enFnPGBszsM/7KIA==,type:str]
+sops:
+  kms:
+  - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
+    created_at: "2022-08-02T17:57:32Z"
+    enc: AQICAHg/+QzF9hGIaoayDitgnEVHEhuaANONVQQOnqpkIsol1gF20Ugf3X4FkOBiOsY6RBzHAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMJIHJl0GP4OKYMmGOAgEQgDvzK5fPRDMhgaDxys9ooqezvu85zcLxCLKuwrntWmWaUbVCKWNM4ZgzqXRZTLyamei6nPaDYnWjA+k7ow==
+    aws_profile: ""
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: "2022-08-02T17:58:29Z"
+  mac: ENC[AES256_GCM,data:ojGAOw97g0C0TTjIFpbOpMOBIKF9x4g/Qvtw/JwwEqscfufhVyzhGr0VHK1r7z8H2xS1KmJSo4GDP/yuRY0Z2l0nRYUmqjK1Q8tfdQD1G0GqCECEoV2GmLvsACI+ICzg64g2iJNkzSFzpVb8a5ATtKYqWGzkHfwopc7s5CkxcMc=,iv:mxJUYUchtJeVJFAE4TeROPuAlDiGhtIci4O/Zv6cFpQ=,tag:125gAlI2V+FVkhQgmlQNdg==,type:str]
+  pgp:
+  - created_at: "2022-08-02T17:57:32Z"
+    enc: |
+      -----BEGIN PGP MESSAGE-----
+
+      hQIMA9YmDGFr0PozAQ//dOJvWtxMV8VXXagOU2fdJdLG795Qit0tJ2kHjJBvD7Xr
+      Xvv6Y8KMTiwaCRnN1MMnQVR7+iWsCopIAEYOuR+RVc/Lq+QM7ClLGwNyBiV0FDH/
+      lsKCVyrf+20oqozQ6Z+ftXqYdhZhRpmkL5Nvyt2RR++5vDHlbpjbTFyk1uICTz2Z
+      Xqom3kqNKjA8cS+E/R04gkIbBNsbQVRTFgsPGyUQ9lGelBVZ6DPY39ir+Rplt2Wx
+      9RyD4zV6qbSbT+oiCCBGognKeBlANBeyX7iE6WLZ9od4NuaRDv5UYijziIk6nPD5
+      Y1gQkFid5eCz4LNIJsE9gZ3sLSA5o2SQQQTCk5pgsG/86HxN14tLpkE+inSDv8FU
+      6UQQfpbr485ew2Gth4Bc79sH5dAzw5Vy7XPZ3jxhqyWkeB1H6FmaN6nFLPH7D7tm
+      m5p2hXDjBIodmrG2Z6yMh9Rwpyul8ddsOUIrOP/cCVYwi3O4Cxl+9gftFN1P7Sya
+      wWrTRX++VagN6zft93CqjH+Yx4+OxVTfoyWC54r+vnhVJXcUxQpVIPBLQuv8RSje
+      8eds1qPC/5lxV4CWwwCwQ9LXj8BPA/cuGyhH1GQGvLbgjO09gsQMFuUsNHhMwI4Q
+      YNaf4e2iGLDLM8NlPpLZgiGysEhrzUYudhbumaWl2e0xJ88bITPxoDfNpWJKLFTS
+      XAFWfkJqxUKVW4MGAa7Vi5sRMGVaXhLMHLxAm7m11CrSIdNzMI8Ohjc40GPvd9zW
+      Mm12I2KLKKqJWbgm7OfXz3bFUxIv6m5J50ujUtO9lxcLgYTvwiViu8TbG8KF
+      =P/Rt
+      -----END PGP MESSAGE-----
+    fp: dfd1205a98269f34c43c9221d6260c616bd0fa33
+  - created_at: "2022-08-02T17:57:32Z"
+    enc: |
+      -----BEGIN PGP MESSAGE-----
+
+      hQIMA8MO7RiKjktCARAAhml8HWZTqr90R3wXI4mw3q4eugeK5A8M+boOq3agyNvC
+      RmXWr00To1zvFjTlFlH+XC8mb4ibIfmsxd5XzR5748XTBnYJb+RBXRBNsD9pOAdO
+      kWfTdQEGl61vDR5kMo7b08yJgmOYZeNHRsvQpOcvYug8pJ5PtfTbxvfz+t0ifzSF
+      vVASuU4Fyz60AVQ8vPprk+lyGt7UoKFF2Ga+bB1UReuOqJ79C0pH/NGeNWebCU+7
+      oeUniI68u6MJ2GRGsrf2IyI1jRtlFue2ql1hZ4tnnYikPkoRQJwIx9kMhAPpQ4Ke
+      ZYBhK56RDM+3cirJwjCSI/lVqjm/Tf7RdxYpHlfSFG32nhAykVPC0WzTnLOH0Lw9
+      0kocQ48/sv03sNNrJD1FhydnpN/c4Pn4nwvFyNfPvJaYGlvdkz2SsXhK4ntPXB/a
+      yIOflGhqFKhf12xESnkXhNUqSJ8UwUlAbo4lJdcG6aRnYkSWQN3gkVU1SbRKP3SB
+      6E8PcVrURNxiu7rHtz53Dw87oZbW+or5CnDKc4UW4k6kFIuOpKjUmRvKLehXh6ka
+      3k/4Rj2i3+XNBsrc3p+iZJg3xKF5KmIvD7xL+dW4jRhem7IMNRFsPexZ2Ls21eHa
+      //3oBLA9AOiwiubZwuuYuyAyJp+R4b6IGyv77gVLK2q/LYqaIt8pTgiRGsyExj7S
+      UQE6uamS6LH8U7xQSQFcNxdar4t28aNFwDZdpNhOUUQ1old128YxHBtdptQJy/CQ
+      LpV9UURYyRnUkZhmDh91+Nm91Vx8Yp+QftVdweDi/V04xw==
+      =vEIv
+      -----END PGP MESSAGE-----
+    fp: B905F0256A801D3F1D15B5126A1D27A4BE75B1C2
+  - created_at: "2022-08-02T17:57:32Z"
+    enc: |-
+      -----BEGIN PGP MESSAGE-----
+
+      wcFMA53hirIFs7uxARAAbVu3M91HqTXUCyevoWDtojbLK8/rQKCjj9YfIUNm9s8V
+      y+DfVl4cSWWe3XHRTHZJ7fWBEK6kOlB7CpcNEnGFWh79lwwbYuSGpxY6JVhkhJT3
+      0bT0K8pcMxhsNziprZ48rhMwgUPEJvKhIFoTidANb2r/063o83hXwR1n5nkuMtlW
+      b/D92gXqby93XVyavoxqOKBdt4VTmZKz+KQv2edrnS2lTgFbMXpkoijowdFaOO9z
+      C8h3hcbP8Smob+bmURUhCAkkslVMsXJMkqSuziqfOl7+rrqObMkE3fbBjIXWhweS
+      TpyVuMkx4Xj3t5FDeAeAHoqPpvawcvZbRX3r+rXDRBvy8MH3wqY/MfjgfqmcCLRC
+      nF9twYeFNDHsWd4zCJGbuaD4PfJyeXfm24xQZXGZkZXqtjBVJ1fJYZ8qUo3fTk8w
+      O2Ryfb2UrSWLDfBcA45yOodmRQ13mE1OTF4ZXh8xVQP7131cgC3cFTzCgZPQ+CRE
+      bOOPKfe7gbL7yG9IpJS+oDTDDsYWraoxhUel6eiZETdiHlR/mRo3qtjxJ4JSMtlK
+      pjNhN09JlJeMM2RpjjqK3GFDHsmFZAwCCxvbKfGQlZZcF7ESMZe5DcnQF82bRBxx
+      rTIEGiXpaQAWuxws4hkcrFfS6JyVGTDhFx5bsxyWAvMqdluNsJtTJyeBmzRwloLS
+      5gFYBnhzCGikopP8MQZLpt+YELrIrNGHmzgyPubV0sspBYsM/r0cww9BrFR5ybMp
+      vWcIYBDjZSH0uG3mXqIvYRLkUllBKDLGM0LdWutrfgYGd+KYiib5AA==
+      =KnDJ
+      -----END PGP MESSAGE-----
+    fp: 07083D36FD5986B0C99700944E9B358045C1B176
+  unencrypted_suffix: _unencrypted
+  version: 3.7.1

--- a/src/bridge/secrets/opensearch/opensearch.open.qa.yaml
+++ b/src/bridge/secrets/opensearch/opensearch.open.qa.yaml
@@ -1,0 +1,79 @@
+---
+master_user_password: ENC[AES256_GCM,data:MdVIVARnHRXfUAOjnDUZJbTrQ0A4pTNL25yT,iv:U7BnlAq9qq3LJHiaimRccILpxwypzIyJlTUXpMfsplc=,tag:F3CxDYsYPKB6sdL49XkDKA==,type:str]
+read_only_user_password: ENC[AES256_GCM,data:7F7l9D8te494Es/jgvrWepdCgRorSRtmjwY=,iv:gW+cqLPG9a9NSUdoDh+846JI8qB6W98Gc3T2j6mvVg0=,tag:wXhEyjwTKwbVEfxb3U3RWg==,type:str]
+read_write_user_password: ENC[AES256_GCM,data:0swTeyH1SqjfPPW00+e2phpsTonrPoP5+Nk=,iv:EYI3ry5ulekCxHLB/mCK1kkOw4aNz8PpKMvKHysiTqw=,tag:t+kOcaNjy2J6pI6bAgmKNw==,type:str]
+sops:
+  kms:
+  - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-qa
+    created_at: "2022-08-02T17:55:35Z"
+    enc: AQICAHi7xhTkB8tf1ObyPMxDhODJja4Mn4jyIo32zZVlOiZPFgHwQHtZXj49RBoCcvsSnsotAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMqHAawWvMGxjUgemHAgEQgDuHMLD835gyHxAtBPmrpe5YKuNCcuBSrDvuCsBkXc+GkXCR0Ai7+b1maIMNF3R06feKqYZYgYbcKj2S5Q==
+    aws_profile: ""
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: "2022-08-02T17:57:07Z"
+  mac: ENC[AES256_GCM,data:Cqkp6BsyKotuW5fLnyPp/dkLKuFzchM3G5CgiUliNRgUeD9g4srghRn7/CPAoSObE98V7quLf3U/+eDELQAbkrTMlx3XWSKod3aOpC0OJEn72g8kK4pIEbCIv4p3EvJL0a9vgHBVESqHbM2wfyKFCXdZ2FLMQofiM7JTMu+A808=,iv:PI9e7o9J3+SkK3s4vtq9OHTKgftJQcSnoPJzVXtqHJU=,tag:Uw3QvBZB7hdJp86gcgPGSg==,type:str]
+  pgp:
+  - created_at: "2022-08-02T17:55:35Z"
+    enc: |
+      -----BEGIN PGP MESSAGE-----
+
+      hQIMA9YmDGFr0PozAQ//eRckBxnMX0JXn43HKrWAjYr7vU72Yz9o+M6VSh0u+xDO
+      qnvePJfY5RvAAYfdUXIwG1mQ5KWtACSeIqW7SkEb5rwxz5HlFnLtGoECnAFLqu+Y
+      ynk6s5rSN9vq3RIpEOFRiSNCAM1cVd36C1q+s9vSsfU9rB88PYtHU7vdLE9peyis
+      Eqr4DmRaihSOlsO8u0K3US70nZhtjclhwlbb7nZDj8Gb2DlJFLIRNbNNzBsysuW9
+      u5fPZ2rlQoFRfwUI+QsESa5NlGwkvk+GMeEPkq4RSNzpwd+RUfxVdxUcNgrYWx1o
+      a4mLvQdg8Nr1+DJfY0tlsa6+WLH4vTiKI9K+2EXM5wp46Stum8WjFebgL7woEAuD
+      V652D8ohgxpR+TyP27J8dcYzcT4vRC1qtfOFeEI/C7QFbu7Y8jNEUNZ7spob9nXW
+      x8CJahnzBPTFX6y/euTH1bQCiXPUvZqoK+V9fITYcACWhxrRCPYJ9BiTseRmWEaX
+      uZ3ZuyMz94ZyQ40R/M+bmp6HRiCKMX/GDR0Wp0z+YMY9+/2jt2FacMK63JUay7Xq
+      gPQYuWoKspI7YrvBuy8DsyvlLy7uq9bD2xLnM5+XXQCEOBvZilbLcppyn/prZJeQ
+      gGNonGK7jk2jC25r2ujEElhNBAW8lYPEqg3PQLaDzfjGUQrgPoTxRF5jOdx7xkLS
+      XgHYaxEjNMfpDNz42AyGksCGePyi1RI+PHcFKieKQha3ADk8hrwTNTEWSeoVE5jG
+      q05XqiIJbQaF2GFreeo02N62jC9rmgmom9BERZBrpl3Dhd9FIp1r+1IX6jdSrHE=
+      =7SJJ
+      -----END PGP MESSAGE-----
+    fp: dfd1205a98269f34c43c9221d6260c616bd0fa33
+  - created_at: "2022-08-02T17:55:35Z"
+    enc: |
+      -----BEGIN PGP MESSAGE-----
+
+      hQIMA8MO7RiKjktCARAAnQYy4RAsFKBF7EBpd8ThT5nzciVdjTd8sFfvYQZfIMOX
+      NKLIfZY7Bx7VmqtPeZ5oMldSw3IDapsVogNARWuHsnMZBJ8ErJfz2IWG5YEticfp
+      V/3jc/9koSrrEbEnaLO2gO5OO6XpqlbQt86V3L0CUiixbPEyEWvfhsB3T/vXObYt
+      dFrGDZRZDemiRbyGgKvN4st5JLuXrqTIKks8RrfuCVuIo04/9Q8M9aO459VlsU+Y
+      UY2iAWaNN+q/fTFQPLfOgG6XNGXqXtG1Oif9i0/8DwYE4gT33ZDSpTpMHkvxQbnW
+      sKnSsmK2ZVrYH7nFu7irs0ijsMRVcBzbm+9FsPmngcNLvw2FUvMGlOAD6Ry6QZkY
+      uaCUD9AgLGEHZ27RtKfnsKXxUcqtAv5y2rzi6HxZp2c7flpJvu2QuePc81gMsszq
+      OGkRIx819jm2CeK4f8zzRswCW475piq52KdA6l4pNlpeW9+1B4ggFkt82AJ0djpR
+      n1OvOx7CYwpg8XPmGWKHWMuQB3hogxYwvZHvjew9uIueGs0L7GIMkBkOtkoV023Z
+      gyzquBoxvvrNZXNn10ajXfJWDvUkqCZ24wPLUkaXc9LoiCCrvH/HGFSIbId5qUVl
+      4kMQS3p5LAxSoi1qiE6/1OH52U4BJQjuPPpWs1hF/OVaFo4i6ZU3m8UJ9zH4Gf7S
+      UQGVrAPFL2usUXb4mUT8im/cFX487U2bi6MAjmBfLgSNvFxLiDcOei9bLcBN+zmN
+      ttaqboEwrdsJ5OOrOqFRJ/Kri2/Omb9w7wFhYlxB4zbNQg==
+      =33oI
+      -----END PGP MESSAGE-----
+    fp: B905F0256A801D3F1D15B5126A1D27A4BE75B1C2
+  - created_at: "2022-08-02T17:55:35Z"
+    enc: |-
+      -----BEGIN PGP MESSAGE-----
+
+      wcFMA53hirIFs7uxARAAt5LQ6iNOvb/n6s7gsi2QymdWWG2csMhyE9TaQ5X7VsdE
+      ZO4A7nvGOAlrvNMtiWS+39PRqKeLI+5qEfNThtEf2ovfLZJRLYz8cznYVlCCQdeM
+      wxSVv74Ukp7pdeFYSlsvXx5TGBtMj0+HAjkf0JXJKRnMiRnIE7r4f5jPbpmEShN4
+      8SmTYPP6+4iuLhNgr1rysj/tmDCyEwTpbUQQvKef8F3ftLbP2yyPc/HIbSs7TM8L
+      jXLlGguXLFM6VY47YcIAVpi1lDNNnX593i4X5XDAIBakTxiGq4dS5o5uZ8ppP+kD
+      TK7h739NlycbQVQZ0mTHvpU5pc2OAF+rh0OjKNZbSU7wBchlXVKEX45rCcm4ptMb
+      Z4xO5J0hnxOF6fSw3ln15lgMWu2mhcb12sozOcR6VLlOsUgPt/yW2aUMj0+36Pnm
+      3ssJgA9MlKDxnzAveLVjzCji0KF4BwwMKJgnfiDD+/dHOWv2U2EKfAE1V6jyDVF4
+      wcN65zHnJPbzrHwaqnGNqA0qDU34sVGLK1owtL5TTin0bUCEg4GlKRsw0+1wOc5W
+      2W5qb9IsKTUZYLr2lZW2llrdWtzvkH/c6mAiR8nU9x70d2Imd+1QMastc2Grr2Mk
+      TCItFm20Pp9WvBCjjIg8nBvB3PnohfioQKHxcrtnk8Sp4uAoygUifc/wRtPtKpDS
+      5gHh3zYFcMh9oDcpnlbVI51HeLVXaX/DZLbSMu+57fQkcHeSo41vJFZLaMF7QRfd
+      dzx6VzyMYOh+641/wpyqOfnkOo7bAI0dXt7FOPryP5bGWeJOTsCjAA==
+      =ORUA
+      -----END PGP MESSAGE-----
+    fp: 07083D36FD5986B0C99700944E9B358045C1B176
+  unencrypted_suffix: _unencrypted
+  version: 3.7.1

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.open.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.open.CI.yaml
@@ -1,0 +1,16 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-ci
+encryptedkey: AQICAHjs8ajWpT7YRhWXwI//wPkHX53RHlo0DjkgQOwCBTUBwQGxHicvhYUkUI1tZY6z5KO1AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMKGV1jmWSqevJowLOAgEQgDtqpoHZ/9pM6v5phUMKeRFtsoKDS8J+M2/ysvlik23cJfDpefcuzm3ouwn0zzKhbijpx7JTC+xoCljJ2Q==
+config:
+  aws:region: us-east-1
+  consul:address: https://consul-apps-ci.odl.mit.edu
+  consul:scheme: https
+  environment:business_unit: operations
+  environment:target_vpc: applications_vpc
+  opensearch:cluster_size: "3"
+  opensearch:consul_service_name: opensearch-open
+  opensearch:disk_size_gb: "60"
+  opensearch:engine_version: "6.8"
+  opensearch:instance_type: t3.medium.elasticsearch
+  opensearch:public_web: "true"
+  opensearch:secured_cluster: "true"

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.open.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.open.CI.yaml
@@ -5,10 +5,10 @@ config:
   aws:region: us-east-1
   consul:address: https://consul-apps-ci.odl.mit.edu
   consul:scheme: https
-  environment:business_unit: operations
+  environment:business_unit: 'mit-open'
   environment:target_vpc: applications_vpc
   opensearch:cluster_size: "3"
-  opensearch:consul_service_name: opensearch-open
+  opensearch:consul_service_name: 'mitopen-search'
   opensearch:disk_size_gb: "60"
   opensearch:engine_version: "6.8"
   opensearch:instance_type: t3.medium.elasticsearch

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.open.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.open.Production.yaml
@@ -1,0 +1,16 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-production
+encryptedkey: AQICAHg/+QzF9hGIaoayDitgnEVHEhuaANONVQQOnqpkIsol1gGf009lpMSC+4jP11unPPA4AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMwPQGAPfyz2E9Zy9GAgEQgDumhOdyFPbxMVvLtOfDhwYoD6JMek6+GZFwR+e6W0FxZ5Eqq9XD+redMsOWtwcVX4PMwPjNdS+6mnhMAA==
+config:
+  aws:region: us-east-1
+  consul:address: https://consul-apps-production.odl.mit.edu
+  consul:scheme: https
+  environment:business_unit: operations
+  environment:target_vpc: applications_vpc
+  opensearch:cluster_size: "3"
+  opensearch:consul_service_name: opensearch-open
+  opensearch:disk_size_gb: "60"
+  opensearch:engine_version: "6.8"
+  opensearch:instance_type: t3.medium.elasticsearch
+  opensearch:public_web: "true"
+  opensearch:secured_cluster: "true"

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.open.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.open.Production.yaml
@@ -5,10 +5,10 @@ config:
   aws:region: us-east-1
   consul:address: https://consul-apps-production.odl.mit.edu
   consul:scheme: https
-  environment:business_unit: operations
+  environment:business_unit: 'mit-open'
   environment:target_vpc: applications_vpc
   opensearch:cluster_size: "3"
-  opensearch:consul_service_name: opensearch-open
+  opensearch:consul_service_name: 'mitopen-search'
   opensearch:disk_size_gb: "60"
   opensearch:engine_version: "6.8"
   opensearch:instance_type: t3.medium.elasticsearch

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.open.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.open.QA.yaml
@@ -1,0 +1,16 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-qa
+encryptedkey: AQICAHi7xhTkB8tf1ObyPMxDhODJja4Mn4jyIo32zZVlOiZPFgGsVW18c9PB7xqo2BKFDd9AAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM+Awcm9py2OW88XmXAgEQgDseCRRmYkdmCFvg/Urh/VdZMgo6a4eIG8DCf+rW/TJ6wsOijCV/u3130nI013loiHCWeF5ouy7SVvFMlw==
+config:
+  aws:region: us-east-1
+  consul:address: https://consul-apps-qa.odl.mit.edu
+  consul:scheme: https
+  environment:business_unit: operations
+  environment:target_vpc: applications_vpc
+  opensearch:cluster_size: "3"
+  opensearch:consul_service_name: opensearch-open
+  opensearch:disk_size_gb: "60"
+  opensearch:engine_version: "6.8"
+  opensearch:instance_type: t3.medium.elasticsearch
+  opensearch:public_web: "true"
+  opensearch:secured_cluster: "true"

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.open.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.open.QA.yaml
@@ -5,10 +5,10 @@ config:
   aws:region: us-east-1
   consul:address: https://consul-apps-qa.odl.mit.edu
   consul:scheme: https
-  environment:business_unit: operations
+  environment:business_unit: 'mit-open'
   environment:target_vpc: applications_vpc
   opensearch:cluster_size: "3"
-  opensearch:consul_service_name: opensearch-open
+  opensearch:consul_service_name: 'mitopen-search'
   opensearch:disk_size_gb: "60"
   opensearch:engine_version: "6.8"
   opensearch:instance_type: t3.medium.elasticsearch

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/README.md
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/README.md
@@ -7,3 +7,5 @@ poetry run python3 ./bootstrap_security_config.py -s <same stack name as the pul
 It is dirty, but it gets the job done. The script is idempotent and you can run it mutliple times if need-be. It is useful for resetting the passwords of the basic auth users if that is needed.
 
 It expects to find the passwords in the sops file for environment. So, same place you defined the `master_user_password` in order to build the environment.
+
+If you need an older cluster ( < ES 7.X ), use the `bootstrap_security_config_6.8.py` script instead. Some of the API interfaces are different.

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/__main__.py
@@ -19,10 +19,16 @@ SEARCH_DOMAIN_NAME_MAX_LENGTH = 28
 search_config = pulumi.Config("opensearch")
 env_config = pulumi.Config("environment")
 stack_info = parse_stack()
+
+if stack_info.env_prefix == "open":
+    consul_stack = pulumi.StackReference(
+        f"infrastructure.consul.apps.{stack_info.name}"
+    )
+else:
+    consul_stack = pulumi.StackReference(
+        f"infrastructure.consul.{stack_info.env_prefix}.{stack_info.name}"
+    )
 network_stack = pulumi.StackReference(f"infrastructure.aws.network.{stack_info.name}")
-consul_stack = pulumi.StackReference(
-    f"infrastructure.consul.{stack_info.env_prefix}.{stack_info.name}"
-)
 vault_stack = pulumi.StackReference(
     f"infrastructure.vault.operations.{stack_info.name}"
 )

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/bootstrap_security_config_6.8.py
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/bootstrap_security_config_6.8.py
@@ -1,0 +1,112 @@
+import argparse
+import json
+import os
+from pathlib import Path
+
+import requests
+
+from bridge.secrets.sops import read_yaml_secrets
+
+# Documentation on request formats:
+# https://opendistro.github.io/for-elasticsearch-docs/old/0.9.0/docs/security/api/#create-role
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-s", "--stack", help="pulumi stack name", required=True)
+args = vars(parser.parse_args())
+
+env_prefix = args["stack"].split(".")[-2]
+env_suffix = args["stack"].split(".")[-1]
+
+master_username = "opensearch"
+master_password = read_yaml_secrets(
+    Path(f"opensearch/opensearch.{env_prefix}.{env_suffix}.yaml")
+)["master_user_password"]
+
+stream = os.popen(f"pulumi stack output -s {args['stack']} 'cluster'")
+cluster_output = stream.read()
+cluster = json.loads(cluster_output)
+
+read_only_role = {
+    "cluster": ["cluster_composite_ops_ro"],
+    "indices": {
+        "*": {
+            "*": ["READ"],
+        }
+    },
+    "tenants": {},
+}
+
+read_write_role = {
+    "cluster": [
+        "cluster_composite_ops",
+        "indices:data/read/scroll",
+        "indices:data/read/scroll/clear",
+    ],
+    "indices": {
+        "*": {
+            "*": [
+                "crud",
+                "create_index",
+                "indices_all",
+                "indices:data/read/scroll",
+                "indices:data/read/scroll/clear",
+                "indices:data/read/scroll*",
+                "indices:data/read/scroll/clear*",
+            ],
+        }
+    },
+}
+
+read_only_user = {
+    "password": read_yaml_secrets(
+        Path(f"opensearch/opensearch.{env_prefix}.{env_suffix}.yaml")
+    )["read_only_user_password"],
+    "roles": ["read_only_role"],
+}
+read_write_user = {
+    "password": read_yaml_secrets(
+        Path(f"opensearch/opensearch.{env_prefix}.{env_suffix}.yaml")
+    )["read_write_user_password"],
+    "roles": ["read_write_role"],
+}
+
+# headers = {"Content-Type": "application/json", "Connection": "close"}
+headers = {"Content-Type": "application/json"}
+auth = requests.auth.HTTPBasicAuth(master_username, master_password)
+
+roles = {
+    "read_only_role": read_only_role,
+    "read_write_role": read_write_role,
+}
+users = {
+    "read_only_user": read_only_user,
+    "read_write_user": read_write_user,
+}
+
+role_mappings = {
+    "read_only_role": {
+        "hosts": [],
+        "users": ["read_only_user"],
+    },
+    "read_write_role": {
+        "hosts": [],
+        "users": ["read_write_user"],
+    },
+}
+
+for r_name, r_def in roles.items():
+    url = f"https://{cluster['endpoint']}/_opendistro/_security/api/roles/{r_name}"
+    response = requests.put(url, headers=headers, auth=auth, data=json.dumps(r_def))
+    print(response.text)
+
+for u_name, u_def in users.items():
+    url = f"https://{cluster['endpoint']}/_opendistro/_security/api/internalusers/{u_name}"
+    response = requests.put(url, headers=headers, auth=auth, data=json.dumps(u_def))
+    print(response.text)
+
+for r_name, rm in role_mappings.items():
+    url = (
+        f"https://{cluster['endpoint']}/_opendistro/_security/api/rolesmapping/{r_name}"
+    )
+    response = requests.put(url, headers=headers, auth=auth, data=json.dumps(rm))
+    print(response.text)

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/bootstrap_security_config_6.8.py
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/bootstrap_security_config_6.8.py
@@ -27,7 +27,7 @@ cluster_output = stream.read()
 cluster = json.loads(cluster_output)
 
 read_only_role = {
-    "cluster": ["cluster_composite_ops_ro"],
+    "cluster": ["CLUSTER_COMPOSITE_OPS_RO"],
     "indices": {
         "*": {
             "*": ["READ"],
@@ -38,20 +38,23 @@ read_only_role = {
 
 read_write_role = {
     "cluster": [
-        "cluster_composite_ops",
+        "CLUSTER_COMPOSITE_OPS",
         "indices:data/read/scroll",
         "indices:data/read/scroll/clear",
+        "indices:data/write/bulk",
+        "indices:admin/get",
+        "indices:admin/exists",
+        "indices:admin/refresh*",
     ],
     "indices": {
         "*": {
             "*": [
-                "crud",
-                "create_index",
-                "indices_all",
-                "indices:data/read/scroll",
-                "indices:data/read/scroll/clear",
-                "indices:data/read/scroll*",
-                "indices:data/read/scroll/clear*",
+                "CRUD",
+                "GET",
+                "CREATE_INDEX",
+                "SEARCH",
+                "MANAGE_ALIASES",
+                "indices:*",
             ],
         }
     },

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/migrate_data.sh
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/migrate_data.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+# A dirty script to reindex data from the old, manually created elasticsearch
+# cluster for open to a new, managed service cluster
+
+# Prereqs
+#
+# On EVERY NODE in the source cluster make the following updates
+#
+# 0. Backup the existing config
+#    `cp /etc/elasticsearch/readonlyrest.yml ~`
+#    `cp /etc/nginx/sites-available/elasticsearch ~`
+#
+# 1. /etc/elasticsearch/readonlyrest.yml add the following permission block
+#
+#  - actions:
+#    - '*'
+#    auth_key: $SOURCE_USER:$SOURCE_PW
+#    indices:
+#    - '*'
+#    type: allow
+#    name: reindex_user
+#
+#   Where $SOURCE_USER and $SOURCE_PW are the username and password you intend
+#   create on the source environment for copying data.
+#
+# 2. restart elasticsearch, one node at a time `systemctl restart elasticsearch`
+#    make sure the cluster is green between each restart
+#
+# 3. /etc/nginx/sites-available/elasticsearch add the following block after the first
+#    location directive (the one with all the paths specified)
+#
+#   location ~ ^/$ {
+#        proxy_pass http://127.0.0.1:9200$request_uri;
+#        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#        proxy_pass_header X-Api-Key;
+#        client_max_body_size 75m;
+#   }
+#
+#   The reindex process running on the destination environment wants to be able to
+#   verify that the source is actually an ES cluster and what it supports, which
+#   requires the / endpoint respond. That endpoint doesn't respond with our current
+#   config.
+#
+# 4. Restart nginx `systemctl restart nginx`
+#
+# 5. WHen you're done restore the original configs on each node
+#    `cp ~/readonlyrest.yml /etc/elasticsearch/readonlyrest.yml;`
+#    `cp ~/elasticsearch /etc/nginx/sites-available/elasticsearch`
+#    `systemctl restart elasticsearch`  # ONE NODE AT A TIME, Verify green status between each!
+#    `systemctl restart nginx`
+
+# addresses MacOS curl + openssl oddity
+export CURL_SSL_BACKEND="secure-transport"
+
+# Fill these in
+export SOURCE=""
+export SOURCE_PW=""  # Possibly not actually required
+export SOURCE_USER="" # Possibly not actually required
+export DEST=""
+export DEST_PW=""
+export DEST_USER=""
+# Can be easily populated with this:
+# curl $SOURCE/_cat/indices | awk '{print"\"" $3 "\""}'
+index_names=()
+
+
+if [ -z "$SOURCE" ]; then
+  echo "ERROR: source address not provided."
+  exit 1
+fi
+if [ -z "$SOURCE_PW" ]; then
+  echo "ERROR: source password not provided."
+  exit 1
+fi
+if [ -z "$SOURCE_USER" ]; then
+  echo "ERROR: source username not provided."
+  exit 1
+fi
+if [ -z "$DEST" ]; then
+  echo "ERROR: destination not provided."
+  exit 1
+fi
+if [ -z "$DEST_PW" ]; then
+  echo "ERROR: destination password not provided."
+  exit 1
+fi
+if [ -z "$DEST_USER" ]; then
+  echo "ERROR: destination username not provided."
+  exit 1
+fi
+
+for index in "${index_names[@]}"; do
+  echo "Processing $index"
+  index_def=$(curl -s -X GET "$SOURCE/$index/" |  jq -r --arg index "$index" '."\($index)" | del(.settings.index.creation_date, .settings.index.provided_name, .settings.index.uuid, .settings.index.version)')
+  echo "Creating $index at $DEST"
+  curl -X PUT -H 'Content-Type: application/json' -u "$DEST_USER:$DEST_PW" "$DEST/$index" -d "$index_def"
+  echo ""
+  echo "Starting reindex of $index from $SOURCE to $DEST."
+  echo ""
+  read -r -d '' data_body <<EOF
+{
+  "source": {
+    "size": 500,
+    "remote": {
+      "host": "${SOURCE}",
+      "username": "${SOURCE_USER}",
+      "password": "${SOURCE_PW}",
+      "socket_timeout": "5m",
+      "connect_timeout": "60s",
+      "external": true
+    },
+    "index": "${index}"
+  },
+  "dest": {
+    "index": "${index}"
+  }
+}
+EOF
+  curl -X POST -H 'Content-Type: application/json' -u "$DEST_USER:$DEST_PW" "$DEST/_reindex?wait_for_completion=false" -d "$data_body"
+done


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Adjusted opensearch pulumi code to allow provisioning of 6.8 ES clusters, created a special bootstrapping security security script for 6.8 clusters and created prod, qa, and CI stacks for 'open'.

## Motivation and Context
Salt-stack deprecation. 

## How Has This Been Tested?
Provisioned environments and interacted with them by Kibana + cURL.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
