### PR TITLE
Revert cc03f41805ab97bf579901185ef3778cefbfeb2a

### DIFF
--- a/src/ol_infrastructure/applications/mit_open/__main__.py
+++ b/src/ol_infrastructure/applications/mit_open/__main__.py
@@ -1,4 +1,4 @@
-from pulumi import Config, StackReference, export
+from pulumi import Config, export
 from pulumi.output import Output
 from pulumi_aws import iam, s3
 from pulumi_vault import aws
@@ -11,11 +11,6 @@ from ol_infrastructure.lib.vault import setup_vault_provider
 setup_vault_provider()
 mit_open_config = Config("mit_open")
 stack_info = parse_stack()
-opensearch_stack = StackReference(
-    f"infrastructure.aws.opensearch.apps.{stack_info.name}"
-)
-opensearch_iam_policies = opensearch_stack.require_output("iam_policies")
-
 aws_config = AWSBase(
     tags={
         "OU": "mit-open",
@@ -204,15 +199,13 @@ mit_open_iam_policy = iam.Policy(
     ),
 )
 
-policy_arns = [mit_open_iam_policy.arn, opensearch_iam_policies["read_only_policy_arn"]]
-
 mit_open_vault_iam_role = aws.SecretBackendRole(
     f"mit-open-iam-permissions-vault-policy-{stack_info.env_suffix}",
     name=f"mit-open-application-{stack_info.env_suffix}",
     # TODO: Make this configurable to support multiple AWS backends. TMM 2021-03-04
     backend="aws-mitx",
     credential_type="iam_user",
-    policy_arns=policy_arns,
+    policy_arns=[mit_open_iam_policy.arn],
 )
 
 export(


### PR DESCRIPTION
Revert "Initial commit of hooking the OpenSearch IAM policy ARN to the IAM role that the MIT-Open application uses."

This reverts commit cc03f41805ab97bf579901185ef3778cefbfeb2a.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Reverts changes to the MIT Open stack definition that depends on aspects of the opensearch stack that no longer exist. 

## Motivation and Context
Bugfix

## How Has This Been Tested?
Deployed to all mit open stacks already. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
