### PR TITLE
Remove disable_compat_19 from consul configs

### DIFF
--- a/src/bilder/components/hashicorp/consul/models.py
+++ b/src/bilder/components/hashicorp/consul/models.py
@@ -59,7 +59,6 @@ class ConsulTelemetry(FlexibleBaseModel):
     dogstatsd_addr: Optional[str]
     disable_hostname: Optional[bool] = True
     prometheus_retention_time: Optional[str] = "60s"
-    disable_compat_19: bool = Field(default=True, alias="disable_compat_1.9")
 
 
 class ConsulConfig(HashicorpConfig):


### PR DESCRIPTION
## Description
Removing the disable_compat_19 field from consul config which has been deprecated.

## Motivation and Context

Consul won't start up anymore with this field set. 
https://www.consul.io/docs/upgrading/upgrade-specific#1-9-telemetry-compatibility

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
