### PR TITLE
Adding a PATH env var to the cron job executing raft_backup.sh

### DIFF
--- a/src/ol_infrastructure/infrastructure/vault/__main__.py
+++ b/src/ol_infrastructure/infrastructure/vault/__main__.py
@@ -427,7 +427,7 @@ def cloud_init_user_data(
             {
                 "path": "/etc/cron.d/raft_backup",
                 "content": (
-                    f"{vault_backup_cron} root HEALTH_CHECK_ID={vault_backup_healthcheck_id} BUCKET_NAME={vault_backup_bucket} /usr/sbin/raft_backup.sh\n"
+                    f"{vault_backup_cron} root PATH=/usr/local/bin:/usr/bin HEALTH_CHECK_ID={vault_backup_healthcheck_id} BUCKET_NAME={vault_backup_bucket} /usr/sbin/raft_backup.sh\n"
                 ),
             },
             {


### PR DESCRIPTION
Just a quick bugfix. 