### PR TITLE
Airbyte vault kvv2

### DIFF
--- a/src/bilder/components/pomerium/files/config.yaml.tmpl
+++ b/src/bilder/components/pomerium/files/config.yaml.tmpl
@@ -3,7 +3,7 @@
 
 # this is the domain the identity provider will callback after a user authenticates
 # form: https://< whatever >
-authenticate_service_url: "https://{{ .Data.authenticate_server_address }}"
+authenticate_service_url: "https://{{ .Data.data.authenticate_server_address }}"
 
 # certificate settings:  https://www.pomerium.com/docs/reference/certificates.html
 # These paths are within the docker container, not the host machine
@@ -17,19 +17,19 @@ certificate_key_file: /pomerium/privkey.pem
 ##################################################################################
 # https://www.pomerium.com/docs/identity-providers/github.html
 idp_provider: github
-idp_client_id: "{{ .Data.idp_client_id }}"
-idp_client_secret: "{{ .Data.idp_client_secret }}"
-idp_service_account: "{{ .Data.idp_service_account }}"
+idp_client_id: "{{ .Data.data.idp_client_id }}"
+idp_client_secret: "{{ .Data.data.idp_client_secret }}"
+idp_service_account: "{{ .Data.data.idp_service_account }}"
 
 # https://github.com/pomerium/pomerium/blob/main/scripts/generate_self_signed_signing_key.sh
 # base64 encoded, no newlines
-signing_key: "{{ .Data.signing_key }}"
+signing_key: "{{ .Data.data.signing_key }}"
 
 # Generate 256 bit random keys  e.g. `head -c32 /dev/urandom | base64`
-cookie_secret: "{{ .Data.cookie_secret }}"
+cookie_secret: "{{ .Data.data.cookie_secret }}"
 
 routes:
-- from: "https://{{ .Data.application_address }}/"
+- from: "https://{{ .Data.data.application_address }}/"
   ## TODO: MAD 20220606 Need to come up with a way to paramartize this or making it more generic
   ## OR, perhaps this becomes the standard. If were going to expose an app frontend, it shall be named 'webapp'
   to: http://webapp:80
@@ -38,5 +38,5 @@ routes:
   - allow:
       or:
       - groups:
-          has: '{{ .Data.allowed_group }}'
+          has: '{{ .Data.data.allowed_group }}'
 {{end}}

--- a/src/bilder/images/airbyte/files/nginx_htpasswd.tmpl
+++ b/src/bilder/images/airbyte/files/nginx_htpasswd.tmpl
@@ -1,3 +1,3 @@
 {{ with secret "secret-airbyte/pomerium" -}}
-dagster:{{ .Data.dagster_hashed_password }}
+dagster:{{ .Data.data.dagster_hashed_password }}
 {{- end }}

--- a/src/bilder/images/airbyte/files/nginx_pomerium.conf.tmpl
+++ b/src/bilder/images/airbyte/files/nginx_pomerium.conf.tmpl
@@ -2,7 +2,7 @@
 # Pomerium endpoint
 server {
     listen 443 ssl;
-    server_name  {{ .Data.authenticate_server_address }} {{ .Data.application_address }};
+    server_name  {{ .Data.data.authenticate_server_address }} {{ .Data.data.application_address }};
     ssl_certificate /etc/nginx/nginx.pem;
     ssl_certificate_key /etc/nginx/nginx-key.pem;
 

--- a/src/bilder/images/airbyte/templates/.env.tmpl
+++ b/src/bilder/images/airbyte/templates/.env.tmpl
@@ -68,7 +68,7 @@ LOG_LEVEL=INFO
 # https://docs.airbyte.com/integrations/sources/sentry/
 # Default is the one that shipped with airbyte, looked up value from vault is our's
 {{ with secret "secret-airbyte/sentry-dsn" }}
-SENTRY_DSN="{{ .Data.value }}"
+SENTRY_DSN="{{ .Data.data.value }}"
 {{ end }}
 
 ### APPLICATIONS ###

--- a/src/bridge/secrets/airbyte/data.production.yaml
+++ b/src/bridge/secrets/airbyte/data.production.yaml
@@ -1,0 +1,89 @@
+---
+pomerium:
+  allowed_group: ENC[AES256_GCM,data:7j+qFCzLG1D4bI5WYaVj,iv:j8vXbmPcPFHewkqxdQaJZ2qA3kBhfi+lrO6FukQMX7s=,tag:O0pL4jg7IvuxGTObRwaQAw==,type:str]
+  application_address: ENC[AES256_GCM,data:LvqxohFKjZtZQ6Yy2L+p9HeJHQ==,iv:YudW/JIqg/AAfam/wj58YhMGxSkHZoTRCIufG0185b4=,tag:aan54fZYySXk43MfWyReAA==,type:str]
+  authenticate_server_address: ENC[AES256_GCM,data:3Pbej1r6Dp9cQ6SR0EbjWXfPVBl8nGQG,iv:tSTuWyvO16eqDI3ih6cfgOUGFLg3SJ1H6Ys9JgF9sVI=,tag:CRmf8KdRNeOVVUU5cT6AIg==,type:str]
+  cookie_secret: ENC[AES256_GCM,data:msO/ovgEJeEvIbznzL6tsuE+LYFvSwHIAem7wdjzda9OcNwEMPpUmK5pyMc=,iv:mFR97I5auEXsYLzf65vCs575lJvbpT85WLuy/CoZlSY=,tag:Lpc/vb2x+BPFgl3HH3oI2Q==,type:str]
+  dagster_hashed_password: ENC[AES256_GCM,data:U6EBXEUl25DROT+yaiCQq5XLiBiXOxj5pDseb76BRDWdrVpCbg==,iv:WRg0GDtPlBwwyKjb7wqwIOO3vtKd7tQtGe2RcbYSp2o=,tag:yOv35ISvUE1732v+y/C48g==,type:str]
+  dagster_password: ENC[AES256_GCM,data:ahoHuy8VmAZiLrnwAdS8QBe3MrRAX4EsZ05U1QexGHI=,iv:HZVp0ACIziwpVjKUvn+CevDm/8H0vasF8fum8PXTScw=,tag:6XnTGzjGJWvdro0BD+l7ZA==,type:str]
+  idp_client_id: ENC[AES256_GCM,data:mXzSVgLUjMLXo56bsTbfLrZ6q2c=,iv:UUKaDIFGzCBBZsmJq2tbBEOIrTGWooCc4LujQQjT6Rs=,tag:TxWVlRl7ydwu4zJobwUZig==,type:str]
+  idp_client_secret: ENC[AES256_GCM,data:/v9IAmsQRLw2JAuRzsEYx4OBNwp+tlcq0/5ZXA8gUnp0QPtlYOj6AA==,iv:EqROnD1FHNRDvNeif5Z8cB50fCKvJKrkPzeFt52Amio=,tag:hhSQQVHMi8eJBqmgKQDXrA==,type:str]
+  idp_service_account: ENC[AES256_GCM,data:fp+JZxkU09K+46oU5N1lZoYee29h4a7oqUKD/fUrFKRW3m0ppK1/4RkbW3/kJ9CIc6W4r+RUXcK4/2YVGoM71mj5eqvjCK62WypuJZLMZFo2NQUM9UFcH/7NU1NObIXJy/Y//2nOV6L5LWD+NbOjZ90zlpxStYwom2JuSQ==,iv:FM2X7gdDGWqDZKvBMi44FogJykQakhgjeAS3ay7nfmo=,tag:/qLefBTNxhq8kIWYaVaudw==,type:str]
+  signing_key: ENC[AES256_GCM,data:dftiYHiSrdq8fQs0C1do/aH/gC03dfc2h3ULuaON8PF6yzRdUkNLYk9TPjyyv7zzDI7BKt4esyqnfo3aXOzMpTBcIGzoJenkfsu+pponTRco7DPIoRjkDJQDvZtu8+9jo/Ae6SnKO5V78iffCdK3XZDYCVi4yiWex2lgvkXn60mYwf4AX7YTcRw0tGguy0DPUDE4R3D1qducn+g6Aq9O2x52Jd+GWpYH0InIizCsfGwS4IPANMm80KbFcZLg4TbJ+FGaDVadhc+0uyUPHp7NeyiTisONaJnPLbDZ/IfBT1RaMLh6z2tc6FPFU2UkVZFtk0xh/P0jgCZB/Ls2yL0TN29ljXLVvGPh7mJGZt/TGZx+s4XcTJy7JFFmwDu46iPQ26vv3myCkmac8BEsKrS63w==,iv:JdbWcjux0f1v9XELQlxmvsLhyC2su2f8HmAe/4Pa+44=,tag:/hpHMftX64ugp8BK1abSJA==,type:str]
+sentry-dsn:
+  value: ENC[AES256_GCM,data:TZcyNcq4mK9+rrCmU/cGJO7wcPI4NnxJ7TISY/pe0fZ7y+RaSyOg4xpEXvNDSCA0fde3TsiMQCk5vWugkIndqejLkfwvdy8F,iv:FfzdxF8mIj2/t88qzNCvogYcoFJbzjABnAwoNc74WSk=,tag:D/vWVj3gO55L9BPGPhxU4Q==,type:str]
+sops:
+  kms:
+  - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
+    created_at: "2022-09-07T20:09:26Z"
+    enc: AQICAHg/+QzF9hGIaoayDitgnEVHEhuaANONVQQOnqpkIsol1gHEXWc9znZaTqf7wtd4AOkNAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM47IxeVH3tR9TaL+jAgEQgDs7zOjS6AT1AK2vgHHlnHDNKiXeIVwfk9bByFKV+D8uYczKlSlYhQBasc5MK+JkcCSUM9PZHazl2HkZ5w==
+    aws_profile: ""
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: "2022-09-07T20:10:29Z"
+  mac: ENC[AES256_GCM,data:5pMyfFOsX36kFURB16/L0WpoZbvy/6fSIlmRv7RnRFUrmQW9KJS+ktHthrqCicUuO99AKoQ/usFhLXWYqclRKLYyuv67XYuzx3n3RX68VhMvETTPrEQgYc7pD+X08qP4+NPhMKdUukexkzXqZrN7CSz34MdQJoyrYkmFeZ4lm7A=,iv:j7kwa7+ZNs5sBdwTmNH+zJ/ITUqZG97CXT9QkUwpCuA=,tag:JB+UYP/zXe7nwwUOEmHqEA==,type:str]
+  pgp:
+  - created_at: "2022-09-07T20:09:26Z"
+    enc: |
+      -----BEGIN PGP MESSAGE-----
+
+      hQIMA9YmDGFr0PozAQ/+PzLE+MA1wsKf8w+2aFpOu91ayWQYDYWoup6LxpLU0KBu
+      P3mKWAQnjuDCMreVBY2BCJXMNkhlBS7Xw83MuAlCb3Ct1yMkIdY7ZY90pwAMzNA7
+      95DXCt07mmESlta5R1uLDQhaWC7gNKnYBdF97U3EfvjnAenNx7feXbb9lD9rdBHt
+      eDHuXNeZPqfLgsu6tTMAR2G0ChtsmInhw1bsDk9cj6z5AFGS+lENA0nHGu/z/PX5
+      Qc6Sd7If3qmtrVrNiyRYJVnNW/nq2A67vCKQ68iYhouRPs3wME2hxIwkQGw/XMDL
+      aNJyjsM6JW0txEwL6YTiGTGtrX9eTMdshC/Xr8B+D6bY/GUMhkTQhcIzuL6F/m/Z
+      JzNzoZA5G0ZCzFII4clxTVvcYFYqOQgVGZMEiMhLG1CsyXnpIIp/bQGwdMJNw3rI
+      Y8kxbLU2togStn0h8BrT0VuaI8pjeL6U54ccj8NvHcEExolA2fqWuG6iw31WE5qk
+      1M2c2YTSg3GvGXlvqTstyRAI1uSbkGCE9RXmQHn4OLucepRJkCk++nee2sTRGfCW
+      UfC7Ll96ioWUw5SHWp0d/4J24m2sl08wgxaRCpDuCjAKjhOOIkwodmYBMI3fvtrH
+      G6qfOoz4kGsGOMFzmKNcq80ywo+Qf7i2bdD6dAsHMX1lvE3JuS41Otj0SKnAsYzS
+      XgEhJFBDRUBEhuGsMW91Zm5skyokYmpeCoHY0yaj7KaIthpKgyjRAH0QpVng+xWJ
+      R7CaHcCmCkXXq6/1MsYZCndRsf2HYh1mFR4C1vmk6gFCUkNeDM4mFY57XSTeMes=
+      =5Jgd
+      -----END PGP MESSAGE-----
+    fp: dfd1205a98269f34c43c9221d6260c616bd0fa33
+  - created_at: "2022-09-07T20:09:26Z"
+    enc: |
+      -----BEGIN PGP MESSAGE-----
+
+      hQIMA8MO7RiKjktCARAAsgJ3CxYMWG0qJ2EcUjWsJndnbptEjMfPxTgAu/zCoNyN
+      TPxZUn87B85rMXNd0GiWzXqG72M9b7wScXoZ9nmrEBuMmRFXCdHalYZOwt/S5hZK
+      hUXaDgZi5+Cs0vS6rU2J9LC9ADnNUggnJxeXtGR7bYWolindBTMIzKDiMFFfnVBh
+      7n7NfcuPkuK9Fwfm3M3izxyiu7VtlwTvY8aBi0piZcZc/qU5gvRvnvWkz7iElrnn
+      jvUtxsJ3RF1pn+7t1ENrbEPuN0OLZk0bGyQ5f8pPWJFKwWcpp2yGlvjpyaaD6/Ek
+      sPjBnWouFfLgroEFgpCp4BYDC+T6P8SZTf/Qra86Y5CmpIAdJNmO6tlTsSSw3/1X
+      CHkConHh7aUz57k3SSWEU05QnA3w3b/+mQuFX0ApocURXlvlNRXRauiTzFNlzgXY
+      RCcnVAeJHzHywgKYimOHHAEqibHNx1afDF73jD4rvv7F3gV+9SP/0+X/H7AeHurh
+      dy32uujnaWOZ5a8uXhd1/BmKk7sE8MaIV+qbgj1+t6j4Ifa6BcVkVG0oG8IrjxXe
+      U4H+dno8Gtqj5gWRNcIm8/7QKVIPAANJiw6dj8v8HkXDGIlDiaCyQM0ugOwC5ijH
+      BvOjl/2+sSKfq63EXGabfkA5dXOsOjW3Pk6oRSNwCC6oZfwJeClXXqyDyLtiC63S
+      UQH0Kym43XjNCeQS18kX2M7hfQHmzQxRECCuvP3Zb2wO0ZoYdSnXD01o9627rcF9
+      clV031eM0YmaWnzGMwoOZ8Zqys/jzOyW/4zSHpfu3EYtaQ==
+      =0ZJC
+      -----END PGP MESSAGE-----
+    fp: B905F0256A801D3F1D15B5126A1D27A4BE75B1C2
+  - created_at: "2022-09-07T20:09:26Z"
+    enc: |-
+      -----BEGIN PGP MESSAGE-----
+
+      wcFMA53hirIFs7uxARAAm1UQTghwspPui8qH7ZfhIgoG/HKVuOU3KZE6FjN8FxTK
+      E1FPVl1snBy7i16Mzu6NMVCWdPCG9KPCBLOaxlTiBj5oELsC+urjKc295LNkn5et
+      HCMrL3WgpeQD9SCwx+ri5wSASQ7QehZkh3mSgc+3NmCKaA22e3o9g5gA3/KXBmN2
+      mWbOEYKC0npS85eJxjMT23D8FTG1E34gOuNVtmtTT4Rc0opzdiPzuV3KzQUs52F9
+      W0YQ/JqtBG1nUbS4qbu+Kxo+r9eFR36VQRV50XtxiCBMkdxGZSgZdYF8w87pCH2g
+      ggq8FG17B26sWT2QRsVOYQagDTC4E8WjxJ4WX72HDk5wb5EfhwJJn9nxHBVXmsse
+      oPmVFPjmW49Gk0hrVrsB5W2lilBto6PlkGkvNFR7D+RwIAkRrkzz2eXnQM/VPb9U
+      xhuIUjd3RQflWes9ZbJM8zJu68iCZA/8Zw2C9iU9y2VQ/yMMbtfUlfom0aDGnVJG
+      DwOP8itAAU7KSNmhQtEFsgfAiC0g/0oNgxQ3xC2mF/qXZDnu8mEESzBfMNNeAAY/
+      GaaAZ6itSNK8zuQb81+HWVxMrxgSFEyWnd5qbN7AT90yE3QlXtu2TIJSeZsY2lcb
+      Pu+WVGKQslFMZmFJ8fgx9MjjUA71ulmV5YkzCzlyByxgaIH4fbC7Lzg020OkxcDS
+      UQFKDOLbOAgpT2vyHm8YjgYvMG8OhpG8aM2gvYjkbjMX8nG8ts8Exx/z7inp0Znl
+      L+T25vCb9uR5rUs1Y+WxvNOIUZCU7rr6CmD3bRxy7stRtw==
+      =TEXu
+      -----END PGP MESSAGE-----
+    fp: 07083D36FD5986B0C99700944E9B358045C1B176
+  unencrypted_suffix: _unencrypted
+  version: 3.7.3

--- a/src/bridge/secrets/airbyte/data.qa.yaml
+++ b/src/bridge/secrets/airbyte/data.qa.yaml
@@ -1,0 +1,89 @@
+---
+pomerium:
+  allowed_group: ENC[AES256_GCM,data:TLcI24nQZFvmHqbAXeJk,iv:mwTdQR0UZRI4fL8FusKdN+WrT1PTaxoUvLwuoBPCqNY=,tag:gXLPTonzo/ziuMZjFF+Tyg==,type:str]
+  application_address: ENC[AES256_GCM,data:BBAvB/KYeRPiyyTidyVaQPu7hNDRDg==,iv:hBInCgEuFEzFVbiWh4n3ziitFVE5SuM5TPrrW+gutlM=,tag:sIrR/zVkBkdbGQzLA1xJ1w==,type:str]
+  authenticate_server_address: ENC[AES256_GCM,data:O570kSmSiip2BMMkLigPqEaECObZqdyUFk/S,iv:Ii9Q9wGZKRJF/emPBpAH28ixaY0AaTJXQvycuKAqfrw=,tag:YgAkCzwwM3U3JSXwBJLtdw==,type:str]
+  cookie_secret: ENC[AES256_GCM,data:m+aqUTeW0xbzdUCDLOMwfVwmV9ZXo84Pt5qNQKnCY84zJp/TMg/tytZiH9w=,iv:N4E0/6PS1EJie+9fPz7RXc67pGcQwy2S0+Eg7Tca7Xw=,tag:v4YHj3X8D6RO20enK82ZZQ==,type:str]
+  dagster_hashed_password: ENC[AES256_GCM,data:/q4HHzDSfa0/P8HY1j4sL5ndnAfSTo4YdWrsbyvVDfO6G46WVQ==,iv:Fm7P/FM3tviABBn6isXXrrKp/i8cLlCfNwRHBIIVqVM=,tag:hStrZDfI3VBcynB5MZfUgQ==,type:str]
+  dagster_password: ENC[AES256_GCM,data:FaNieSApPOAlJBpav0i4+QH2VNF1g3Yf0BmhAoY1prA=,iv:qp/6zt93yVNfi3gSn2hbxmsaWr1ngYTgktEZDJd0V5Y=,tag:rjgJf+WP229q7eoME2/bTw==,type:str]
+  idp_client_id: ENC[AES256_GCM,data:qUiRzt2C3wll8AcDN42j+W0PDfU=,iv:SKaSRB+CrOP1tk4CNvhTUbBPQOTyGysV62IlfWU9A+U=,tag:1RcA5GVbpECfhObDn/1wDw==,type:str]
+  idp_client_secret: ENC[AES256_GCM,data:dv3p0w/x0bFr2nzhEoT2PSSC7Q/r9Hc6/DkwDU0YyyE6Uibvdre05A==,iv:k5KrBifsNGY4GjSeZw3JRFFL96cJfTaHY6UCgMt4qlE=,tag:LBpS1AEJyGesVrAQnl7cXw==,type:str]
+  idp_service_account: ENC[AES256_GCM,data:p9yIRFsZ926ET/xI85tjj4+RJg29TnXIDMI0cSgIoLTUMmHU5y4U4iqoXUe6zTWKdCdWMRYAB4lRB0BWRupjc69xSp/SD6GLOsyhkiVG82RhCAgCf7ZubbQENnEcXWvJoAaiEGVy/b7Fv8/odVgpIZuqyWWMIvSHWq0y6A==,iv:DNnYRevVxU4WfZFq6WDNpSD3BET0PtGT79VjzN7tcRQ=,tag:cbZJWpzMp2jVtKpgANf6Ig==,type:str]
+  signing_key: ENC[AES256_GCM,data:gl0drmj5qkJq7TvAa1A0F3yoQxomvbFJsClqCaGXlVdGHkShVnaE5nuMaAeWZt//QQW7eDU/FcwpsuK4crBH1pRmumZIY+ITVspJ9al0lG5kUZ2Ssus1VbOpZ8eHiC4w6h/gJ9WqfKdr4qpUwY4xMor0NSSTvwOwpiRrGHXPYHzCblOFzz3JBgsJACEz/JEaY8VWaBYnBbOAHEbD8JW9RHHPfb3ZNnmO/u1A4gSLc9O8mubPVjToiiQ8UMLmMye/nT5sr+DLsv3L+Y0CKlkRsRDGlh6U0zMCieAIM4X6JQMUs4qLnFZBdKJJCWhQ2EKt6Zlx/mkiG3S5wctMJwQoAooH/RtZI4nNp43HSHj+KdeUsgatQKj4Y3IDG/XJDeQQTxqqwv3/fgv1Ew1lxC8wQw==,iv:Ql38bpeG8Jj5M97swnPxBsk19j9MbI2epBAfHhiQxpA=,tag:uuwERPxGO9oMfaO1RtCtGA==,type:str]
+sentry-dsn:
+  value: ENC[AES256_GCM,data:Tt1jlqeaor4AJswuOEIWfs3FuOwYhsVJIviB0xalRamiuNuJU6kxTS60pm8qREu2Yjg36l+VzZOxqS+82KkFM6tJkmsN29KS,iv:O+Cfc//um0Es6+mjn6WZP+LHz3QGs4szGKj0L/EaRCo=,tag:JH8HCngWPeuC+l2GiZCGbg==,type:str]
+sops:
+  kms:
+  - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-qa
+    created_at: "2022-09-07T20:06:40Z"
+    enc: AQICAHi7xhTkB8tf1ObyPMxDhODJja4Mn4jyIo32zZVlOiZPFgEJui5blxFQqVj8ApQprFKqAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMeTxA6v3dOCekRZ22AgEQgDu1++srn1RQM8w9gq8+7SJOsKD2gDoXBi82BlfDMjWs963qPQ2IDe2gYQc5WJqUyh7H3efLVnLOW6sNsQ==
+    aws_profile: ""
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: "2022-09-07T20:08:44Z"
+  mac: ENC[AES256_GCM,data:ZweRr5y2Vn53chIPL7noXufULXEqVoMUuG/0N5ZLBae+Q0i1ZX/geP1GRObH3rbuGaIMF9DglyJuAJP+aDzPUjxYMKNSZ7GYNBMMVhmZbBtabvQ8mx/kvjh8CrAeTvv5RRHdPkJ7I0ESVKRcuHF5PvN6y3A4TBTrErqFRNOJ0+M=,iv:qnIUwgihHgE4+zIUpJFxSD6RtnDYZ7jy8B4xvFzzTzo=,tag:e2fkbAafBjlPcBkJkhq7PA==,type:str]
+  pgp:
+  - created_at: "2022-09-07T20:06:40Z"
+    enc: |
+      -----BEGIN PGP MESSAGE-----
+
+      hQIMA9YmDGFr0PozAQ//ZRkfvFqZbIQ9MrjO/FPXVE/EfLcn/pLVD2cDQqSaNRwS
+      q0xgIVGdorEgG2miBDEmF0p2z3FeTMmDXMEGrEyqULwsh8slnTJ98Nh7zzmRw+aL
+      eIEvM0dU8GbzZ9ynQ2C1ufXiCtfTBmx6lbEbjaDbCWk++lkqp0Djx8QOvG55/vLn
+      aoPU8Y7olKOJ7H0f/wnNe+GSpknfB3zHPlg6mfn1IXxzXb4H6CL8oU1GptpL5qbl
+      AEggM3Y0UmVms7WyzP5jrzz4eH/ASBw7Js1F1ccxA9Q2BUIDv9qY+KGEG3QiBTES
+      DVgviMLojX35rodY+rQWIioLTYr2b2+BxhlpX9BcQOZVAbMgAiVM4xPxvBJ+gw6h
+      WXINePhYgjZnfX1qIY2IxO+brkOa7ns1dfD6aQBlBJtjwlEysDiLZTCqrXCXLtNu
+      ywjNO88z1ZxOZK8sEYqjWeQJ2c+hCoesHqvhW8ThfZ47OVLwGk4UA4/xHMoq+//t
+      x+JdUFDZk8JF869Opyv7dUXYs4CQtrmNBQ/suGIVHS5nkZrbRA3SDs7YuDkEkbJa
+      ozCqLhw3qCkLon/L5HFRBpJvCHIjZSuqQi192hgyhbuMSkbpr3tiR2x9u43Sbw1m
+      F7vMNhJETmQ97uaMdVjvarjRGC/i9ekv5FeaogNo+rkSOqPFork6lLNeOb64IpHS
+      XgEgI/cKzCdf8CSAJgtFDYJqBW2akFHL0JeUZtV4ylOWMcWXeLJMCCASyjuBaiO9
+      Af3+gngZq+LrwJLNr35OErvgqSI9hM8cWouXWzWxVBLtEA3jPH0uemQFssbk8kI=
+      =U7Kb
+      -----END PGP MESSAGE-----
+    fp: dfd1205a98269f34c43c9221d6260c616bd0fa33
+  - created_at: "2022-09-07T20:06:40Z"
+    enc: |
+      -----BEGIN PGP MESSAGE-----
+
+      hQIMA8MO7RiKjktCARAAnKk/+8fdIJfTwFIn76vw8nGjCHyJZwWk7l/jqaxaMhZ4
+      uP1FHfDemIEsVVSiiR6IKPmEN5ZHUZLseZNUKjC3kMOiuc+GXj+9bMePKUitRRbi
+      XIRRAeuTlsEjrUhtEWjUsgkX6eRWYgos2YDvrJtHWylzP/tZ8sUODcZv0uc6+W62
+      wCoG9BBv52GJepZmYjeKdJfZHor8boSSBgPPaMDWk71e6CpboN1G3Do5syawJ1Jo
+      rbhHKw4enVdvC7zmC3PN61UZxxgyIhihZqNk+k+btmwCtieQ4jhiXIR6kBUERG+0
+      uRhIyB7Sz+omnU/h8TLLIN1Dpddk9YwfbUXKJPjybq4Rrijm6K6xFTqfmqaHVozG
+      AcUI8dfx737nuLlseUkzVBbWPnKmN0BVd0iEzzPPvyoP5m7RHzqs5uhVhbJXsya1
+      QY+iu9ZwyT25WpGLmqrcM/mqRRj1t6Fz4Oz58Jz9QStYEoS15YLPcz7+I7qoNVG+
+      0nntAMfJgd17XBs0JpnTHCR+Ot6C9kSJSwdV0iNpZdB7npJgF0VgHTyfxytIZx7U
+      wyInbk48yZD8QsdV2KN6sveDDYwXjH5zu+yyeLvg6Q3dCOeag2CxC/xw/gcgGe7W
+      ng9+NCZ/QokbX9EeIJy6+ZPtKY57SohIL6JPKKn30Lk5Bu6Wm/8iklxlnB3VfqrS
+      UQGhGJ3ZUESM+LRNetX63Km9RoDAg7/BGziOj/YgGu+K8zqwWGh+7BlEuLMac9Uh
+      bg8AqlSI7Bs+jzYjUmdN+EU6S8QBJEJ9VhgjMqrmCPSN2A==
+      =b2Nw
+      -----END PGP MESSAGE-----
+    fp: B905F0256A801D3F1D15B5126A1D27A4BE75B1C2
+  - created_at: "2022-09-07T20:06:40Z"
+    enc: |-
+      -----BEGIN PGP MESSAGE-----
+
+      wcFMA53hirIFs7uxARAAmAVySZs5Q0qXCVbabWil0z2PYBNUM4goC+K/T1QfYjoQ
+      zOayZ0wnNGHDSz7uz07UAOHC98iu+RhmSr79IQkgXh+PcfgxXOWeuI8B4qdQ9LOE
+      35CfMZDuidoBoMy6oZyUVOeaf5ufK0pmdI87LzhoKd2zgSRjON8TtBajgwK5jIJt
+      lwowhZel8P2HzUwh3uVL7sKAeSbfk9DJcNHIvc/+VKEtji/TQACkQaGKcV0oT3Wl
+      psjXMvO2V9t2X9Nx8NMPuZy83oLeSPzfMFjM3S9xpqeA4LHufgP74tDSyIfq58wb
+      yObQXriaEAd+e8QE4wpYwD4pEkyfn/rm1I6iTqInxSFhsyttTK0zlwDgEnv0VjeZ
+      PDHsWyUQLsIwe76fU2zMDI5rTq0HXiSO/XULaCeq0pgvWQcqdcBvIBaRDfpgNF8u
+      CMEa+73sJqCUI+WJ8fJlHYLr/kHg3/K9fnIRlB5jImRhmcJ6e+EdxlSW36vEHvwR
+      ckSyFRfYJMa0/lbxQ1bHd2c5BPYBJHydvvTTiFP/ucXFw9VskJNMlelKb1GwT88Z
+      kIF+4GkpT4hZfmokRVEdJv/O3mAa4Z1qWgajKZLxmotxe3/EFPiODMuQ91Du+nrX
+      KUBsqBIFDM7kNR/pEQ8n1pBPjX7dMCGhPuPhjEvSMcwfSAAwn7rmS7XNuYruHwLS
+      UQGBerctwnjaMGuDJvEya73f5OAtxdHMiB/JVHCNs7pY6axBq+EM05XpHTOtT5+1
+      H/sKzgqyRSmwgetQSYmJ3r1WprBNPtdddUjXB0PpJjbUuA==
+      =RNaX
+      -----END PGP MESSAGE-----
+    fp: 07083D36FD5986B0C99700944E9B358045C1B176
+  unencrypted_suffix: _unencrypted
+  version: 3.7.3


### PR DESCRIPTION
Update Airbyte Vault storage to use KV V2

## Description
The Airbyte integration with Vault defaults to assuming a version 2 KV mount for storing configuration secrets. This updates the code to use that mount type. This also moves the secrets required to configure the server runtime into SOPS to make it easier to rebuild/redeploy.

## Motivation and Context
This was found while working on adding additional data sources to Airbyte for work related to the data platform.

## How Has This Been Tested?
This has been tested by applying the Pulumi code and ensuring that Airbyte is able to write and read secrets from the updated mount.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
