### PR TITLE
add zip and unzip packages to ocw-course-publisher

### DIFF
--- a/dockerfiles/ocw/node-hugo/Dockerfile
+++ b/dockerfiles/ocw/node-hugo/Dockerfile
@@ -8,7 +8,7 @@ ENV HUGO_NAME="hugo_extended_${HUGO_VERSION}_Linux-64bit"
 ENV GO_FILE_NAME="go1.18.2.linux-amd64.tar.gz"
 ENV GO_URL="https://golang.org/dl/${GO_FILE_NAME}"
 ENV HUGO_URL="https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/${HUGO_NAME}.deb"
-ENV BUILD_DEPS="wget"
+ENV BUILD_DEPS="wget zip unzip"
 RUN apt update && \
     apt install -y curl awscli jq git "${BUILD_DEPS}" && \
     wget "${HUGO_URL}" && \


### PR DESCRIPTION
## Description
This PR was added as a prerequisite to the work being done for https://github.com/mitodl/ocw-studio/issues/1476.

## Motivation and Context
A step will be added to the `mass-build-sites` Concourse pipeline for deploying OCW sites to create ZIP archives if the pipeline is being run in offline mode. The `ocw-course-publisher` Docker image is used to build the sites, and therefore will need the `zip` package to do so. The `unzip` package was also added, as when you install `zip` it is installed anyway as a dependency anyway.

## How Has This Been Tested?
I did some initial testing by adding the `zip` package manually to the `ocw-course-publisher` image manually while using it in a pipeline. The packages are available and install without issue.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
