### PR TITLE
fix: Override upgrade button link for MITx Online production

### DIFF
--- a/src/bilder/images/edxapp/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -337,7 +337,7 @@ LOGIN_REDIRECT_WHITELIST:  # MODIFIED
 LOG_DIR: /edx/var/log/edx
 MAINTENANCE_BANNER_TEXT: Sample banner message
 MARKETING_SITE_BASE_URL: https://{{ key "edxapp/marketing-domain" }}/ # ADDED - to support mitxonline-theme
-MARKETING_SITE_CHECKOUT_URL: https://{{ key "edxapp/marketing-domain" }}/cart/add/ # ADDED - to support mitxonline checkout
+MARKETING_SITE_CHECKOUT_URL: https://{{ if env "ENVIRONMENT" | contains "production" }}micromasters.mit.edu/dashboard{{ else }}{{ key "edxapp/marketing-domain" }}/cart/add/{{ end}} # ADDED - to support mitxonline checkout
 MEDIA_ROOT: media/  # MODIFIED - with s3 storage backend this is the path within the bucket. No leading / allowed
 MEDIA_URL: /media/
 MICROSITE_CONFIGURATION: {}


### PR DESCRIPTION
The ecommerce functionality has not been turned on in production for MITx Online. Until it goes live the `upgrade` button should direct the user to the MITx Online dashboard.

<!--- Provide a general summary of your changes in the Title above -->

## Description
This adds a conditional link text for MITx Online production

## Motivation and Context
https://github.com/mitodl/mitxonline/issues/953#issuecomment-1243130429

## How Has This Been Tested?
I created a minimal consul-template template with just this change and verified that the output is rendered based on the value in the `ENVIRONMENT` env var.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
