### PR TITLE
minor redash image bug fix

### DIFF
--- a/src/bilder/images/redash/deploy.py
+++ b/src/bilder/images/redash/deploy.py
@@ -71,7 +71,7 @@ def place_jinja_template_file(
         context=context,
         mode="0664",
     )
-    watched_files.append(Path(DOCKER_COMPOSE_DIRECTORY).joinpath("docker-compose.yaml"))
+    watched_files.append(destination_path.joinpath(name))
 
 
 def place_consul_template_file(


### PR DESCRIPTION
Fixing a bug with the helper functions for laying down jinja2 templates in the redash image deployment code.

<!--- Provide a general summary of your changes in the Title above -->

## Description
The jinja2 helper function in bilder/images/redash/deploy.py had hard coded paths specified in the append to `watched_files`, so it would just append the same values every time the function was called and not actually produce a useful list of files to watch. 

## Motivation and Context
Bugfix

## How Has This Been Tested?
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
