### PR TITLE
feat: Create a deployment pipeline for Dagster images

### DIFF
--- a/src/concourse/lib/jobs/infrastructure.py
+++ b/src/concourse/lib/jobs/infrastructure.py
@@ -151,13 +151,16 @@ def pulumi_jobs_chain(
         if index != 0:
             previous_job = chain_fragment.jobs[-1]
             for dependency in dependencies or []:
+                # These mutations apply globally if the dependencies aren't copied below
                 dependency.trigger = False
+                dependency.passed = [previous_job.name]
         step_fragment = pulumi_job(
             pulumi_code,
             stack_name,
             project_name,
             project_source_path,
-            dependencies,
+            # Need to copy the dependencies because otherwise they are globally mutated
+            [dependency_step.copy() for dependency_step in (dependencies or [])],
             previous_job,
         )
         chain_fragment.resource_types = (

--- a/src/concourse/lib/resources.py
+++ b/src/concourse/lib/resources.py
@@ -1,6 +1,6 @@
-from typing import Union
+from typing import Optional, Union
 
-from concourse.lib.models.pipeline import Identifier, Resource
+from concourse.lib.models.pipeline import Identifier, RegistryImage, Resource
 from concourse.lib.models.resource import Git
 
 
@@ -105,4 +105,14 @@ def schedule(name: Identifier, interval: str) -> Resource:
         type="time",
         icon="clock",
         source={"interval": interval},
+    )
+
+
+def registry_image(
+    name: Identifier, image_repository: str, image_tag: Optional[str] = None
+) -> Resource:
+    return Resource(
+        name=name,
+        type="registry-image",
+        source=RegistryImage(repository=image_repository, tag=image_tag or "latest"),
     )

--- a/src/concourse/pipelines/infrastructure/dagster/packer_pulumi_pipeline.py
+++ b/src/concourse/pipelines/infrastructure/dagster/packer_pulumi_pipeline.py
@@ -1,0 +1,90 @@
+from concourse.lib.constants import PULUMI_CODE_PATH
+from concourse.lib.jobs.infrastructure import packer_jobs, pulumi_jobs_chain
+from concourse.lib.models.fragment import PipelineFragment
+from concourse.lib.models.pipeline import GetStep, Identifier, Pipeline
+from concourse.lib.resources import git_repo, registry_image
+
+dagster_container_resources = [
+    registry_image(
+        name=Identifier("dagit-container"),
+        image_repository="mitodl/data-platform-dagit",
+    ),
+    registry_image(
+        name=Identifier("dagster-daemon-container"),
+        image_repository="mitodl/data-platform-dagster-daemon",
+    ),
+    registry_image(
+        name=Identifier("edx-pipeline-container"),
+        image_repository="mitodl/data-platform-edx-pipeline",
+    ),
+]
+
+dagster_image_code = git_repo(
+    Identifier("ol-infrastructure-packer"),
+    uri="https://github.com/mitodl/ol-infrastructure",
+    paths=[
+        "src/bilder/components/",
+        "src/bilder/images/dagster/",
+    ],
+)
+
+dagster_pulumi_code = git_repo(
+    name=Identifier("ol-infrastructure-pulumi"),
+    uri="https://github.com/mitodl/ol-infrastructure",
+    paths=[
+        "src/ol_infrastructure/applications/dagster/",
+        "pipelines/infrastructure/scripts/",
+    ],
+)
+
+container_dependencies = [
+    GetStep(get=container_resource.name, trigger=True)
+    for container_resource in dagster_container_resources
+]
+
+dagster_ami_fragment = packer_jobs(
+    dependencies=container_dependencies,
+    image_code=dagster_image_code,
+    packer_template_path="src/bilder/images/dagster/dagster.pkr.hcl",
+    env_vars_from_files={"DAGSTER_VERSION": "dagit/tag"},
+)
+
+dagster_pulumi_fragment = pulumi_jobs_chain(
+    dagster_pulumi_code,
+    stack_names=[f"applications.dagster.{stage}" for stage in ("QA", "Production")],
+    project_name="ol-infrastructure-dagster-server",
+    project_source_path=PULUMI_CODE_PATH.joinpath("applications/dagster/"),
+    dependencies=[
+        GetStep(
+            get=dagster_ami_fragment.resources[-1].name,
+            trigger=True,
+            passed=[dagster_ami_fragment.jobs[-1].name],
+        )
+    ],
+)
+
+combined_fragment = PipelineFragment(
+    resource_types=dagster_ami_fragment.resource_types
+    + dagster_pulumi_fragment.resource_types,
+    resources=dagster_ami_fragment.resources
+    + dagster_pulumi_fragment.resources
+    + dagster_container_resources,
+    jobs=dagster_ami_fragment.jobs + dagster_pulumi_fragment.jobs,
+)
+
+
+dagster_pipeline = Pipeline(
+    resource_types=combined_fragment.resource_types,
+    resources=combined_fragment.resources + [dagster_image_code, dagster_pulumi_code],
+    jobs=combined_fragment.jobs,
+)
+
+
+if __name__ == "__main__":
+    import sys
+
+    with open("definition.json", "wt") as definition:
+        definition.write(dagster_pipeline.json(indent=2))
+    sys.stdout.write(dagster_pipeline.json(indent=2))
+    print()
+    print("fly -t pr-inf sp -p packer-pulumi-dagster -c definition.json")

--- a/src/concourse/pipelines/infrastructure/dagster/packer_pulumi_pipeline.py
+++ b/src/concourse/pipelines/infrastructure/dagster/packer_pulumi_pipeline.py
@@ -46,7 +46,7 @@ dagster_ami_fragment = packer_jobs(
     dependencies=container_dependencies,
     image_code=dagster_image_code,
     packer_template_path="src/bilder/images/dagster/dagster.pkr.hcl",
-    env_vars_from_files={"DAGSTER_VERSION": "dagit/tag"},
+    env_vars_from_files={"DAGSTER_VERSION": "dagit-container/tag"},
 )
 
 dagster_pulumi_fragment = pulumi_jobs_chain(


### PR DESCRIPTION
This adds a pipeline definition for building and deploying Dagster AMIs, triggered by our updated Dagster images being published.

## Description
See above

## Motivation and Context
We want to automate deployment of updated versions of Dagster and pipeline code. This handles that process.

## How Has This Been Tested?
The pipeline has been generated and uploaded to the Concourse server. https://cicd.odl.mit.edu/teams/infrastructure/pipelines/packer-pulumi-dagster

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
