### PR TITLE
refactor: Align data warehouses around data lifecycle

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
@@ -2,7 +2,7 @@ import json
 from typing import Any, Union
 
 from pulumi import Config, StackReference, export
-from pulumi_aws import athena, glue, iam, s3
+from pulumi_aws import athena, glue, iam, lakeformation, s3
 
 from ol_infrastructure.lib.aws.iam_helper import lint_iam_policy
 from ol_infrastructure.lib.ol_types import AWSBase, BusinessUnit
@@ -21,6 +21,8 @@ aws_config = AWSBase(
     },
 )
 s3_kms_key = kms_stack.require_output("kms_s3_data_analytics_key")
+
+data_stages = ("raw", "cleaned", "modeled")
 
 results_bucket = s3.Bucket(
     f"ol_warehouse_results_bucket_{stack_info.env_suffix}",
@@ -110,6 +112,46 @@ for unit in BusinessUnit:
         )
     )
 
+for data_stage in data_stages:
+    lake_storage_bucket = s3.Bucket(
+        f"ol_data_lake_s3_bucket_{data_stage}",
+        bucket=f"ol-data-lake-{data_stage}-{stack_info.env_suffix}",
+        acl="private",
+        server_side_encryption_configuration=s3.BucketServerSideEncryptionConfigurationArgs(  # noqa: E501
+            rule=s3.BucketServerSideEncryptionConfigurationRuleArgs(
+                apply_server_side_encryption_by_default=s3.BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs(  # noqa: E501
+                    sse_algorithm="aws:kms",
+                    kms_master_key_id=s3_kms_key["id"],
+                ),
+                bucket_key_enabled=True,
+            )
+        ),
+        versioning=s3.BucketVersioningArgs(enabled=True),
+        tags=aws_config.merged_tags({"OU": "data"}),
+    )
+    lakeformation.Resource(
+        f"lakeformation_s3_bucket_{data_stage}",
+        arn=lake_storage_bucket.arn,
+    )
+    warehouse_buckets.append(lake_storage_bucket)
+    s3.BucketPublicAccessBlock(
+        f"ol_data_lake_s3_bucket_{data_stage}_block_public_access",
+        bucket=lake_storage_bucket.bucket,
+        block_public_acls=True,
+        block_public_policy=True,
+    )
+    warehouse_db = glue.CatalogDatabase(
+        f"ol_warehouse_database_{data_stage}",
+        name=f"ol_warehouse_{data_stage}_{stack_info.env_suffix}",
+        description=f"Data mart for data in {data_stage} format in the {stack_info.env_suffix} environment.",  # noqa: E501
+        location_uri=lake_storage_bucket.bucket.apply(lambda bucket: f"s3://{bucket}/"),
+    )
+    lakeformation.Resource(
+        f"lakeformation_warehouse_db_{data_stage}",
+        arn=warehouse_db.arn,
+    )
+    warehouse_dbs.append(warehouse_db)
+
 export(
     "athena_data_warehouse",
     {
@@ -172,8 +214,12 @@ query_engine_permissions: list[dict[str, Union[str, list[str]]]] = [
             "s3:GetObjectVersion",
         ],
         "Resource": [
-            f"arn:aws:s3:::ol-data-lake-data-{stack_info.env_suffix}",
-            f"arn:aws:s3:::ol-data-lake-data-{stack_info.env_suffix}/*",
+            f"arn:aws:s3:::ol-data-lake-{stage}-{stack_info.env_suffix}"
+            for stage in data_stages
+        ]
+        + [
+            f"arn:aws:s3:::ol-data-lake-{stage}-{stack_info.env_suffix}/*"
+            for stage in data_stages
         ],
     },
 ]

--- a/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
@@ -22,7 +22,7 @@ aws_config = AWSBase(
 )
 s3_kms_key = kms_stack.require_output("kms_s3_data_analytics_key")
 
-data_stages = ("raw", "cleaned", "modeled")
+data_stages = ("raw", "staging", "intermediate", "mart")
 
 results_bucket = s3.Bucket(
     f"ol_warehouse_results_bucket_{stack_info.env_suffix}",
@@ -220,6 +220,10 @@ query_engine_permissions: list[dict[str, Union[str, list[str]]]] = [
         + [
             f"arn:aws:s3:::ol-data-lake-{stage}-{stack_info.env_suffix}/*"
             for stage in data_stages
+        ]
+        + [
+            f"arn:aws:s3:::ol-data-lake-data-{stack_info.env_suffix}",
+            f"arn:aws:s3:::ol-data-lake-data-{stack_info.env_suffix}/*",
         ],
     },
 ]


### PR DESCRIPTION
The warehouse definitions and S3 buckets in the data lake make more sense to be modeled around the stages of the data lifecycle than to arbitrarily segment them by business units. The original motivation was for cost allocation purposes but it introduces unnecessary complexity. This _adds_ the new definitions so that we can migrate to them first, and a subsequent commit will _remove_ the old ones.

## Description
This condenses the warehouse and data lake bucket definitions to align with data lifecycle stages, rather than business units.

## Motivation and Context
The alignment with business units was intended for cost allocation purposes, but it introduces substantial overhead without any real gain. By aligning on lifecycle stages it makes it clearer what the purpose of each segmentation is, as well as simplifying access control definitions so that e.g. we don't grant access to raw data for anyone who is only supposed to view fully processed information.

## How Has This Been Tested?
The new warehouse/bucket definitions have been deployed and the corresponding dbt project in ol-data-platform was updated and executed against the new targets.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
