### PR TITLE
feat: Automatically create a read replica for production DBs

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -605,6 +605,30 @@ edxapp_db_consul_service = Service(
     ],
     opts=consul_provider,
 )
+if edxapp_db_config.read_replica:
+    edxapp_db_replica_consul_service = Service(
+        "edxapp-instance-db-replica-service",
+        node=edxapp_db_consul_node.name,
+        name="edxapp-db-replica",
+        port=edxapp_db_config.port,
+        meta={
+            "external-node": True,
+            "external-probe": True,
+        },
+        checks=[
+            ServiceCheckArgs(
+                check_id="edxapp-db",
+                interval="10s",
+                name="edxapp-db",
+                timeout="1m0s",
+                status="passing",
+                tcp=Output.all(
+                    address=edxapp_db.db_replica.address, port=edxapp_db_config.port
+                ).apply(lambda db: "{address}:{port}".format(**db)),
+            )
+        ],
+        opts=consul_provider,
+    )
 
 #######################
 # MongoDB Vault Setup #

--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -113,6 +113,8 @@ edxapp_mfe_paths = list(edxapp_mfes.values())
 edxapp_mail_domain = edxapp_config.require("mail_domain")
 edxapp_vpc = network_stack.require_output(target_vpc)
 edxapp_vpc_id = edxapp_vpc["id"]
+data_vpc = network_stack.require_output("data_vpc")
+data_integrator_secgroup = data_vpc["security_groups"]["integrator"]
 ami_filters = [
     ec2.GetAmiFilterArgs(name="virtualization-type", values=["hvm"]),
     ec2.GetAmiFilterArgs(name="root-device-type", values=["ebs"]),
@@ -1396,8 +1398,8 @@ edxapp_fastly_service = fastly.ServiceVcl(
                   set var.mfe_path = regsub(req.url.path, "{mfe_regex}.*", "\\1");
                   set req.url = "/" + var.mfe_path + "/index.html";
                   restart;
-                }}"""
-            ),  # noqa: WPS355
+                }}"""  # noqa: WPS342
+            ),
             name="Fetch site index for MFE custom error",
             priority=120,  # noqa: WPS432
             type="error",
@@ -1455,3 +1457,6 @@ export(
 )
 
 export("edxapp_security_group", edxapp_security_group.id)
+
+if edxapp_db_config.read_replica:
+    export("edxapp_read_replica", edxapp_db.db_replica.address)

--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -251,6 +251,7 @@ ocw_studio_vault_backend_config = OLVaultPostgresDatabaseConfig(
     db_admin_username=ocw_studio_db_config.username,
     db_admin_password=ocw_studio_db_config.password.get_secret_value(),
     db_host=ocw_studio_db.db_instance.address,
+    **defaults(stack_info)["rds"],
 )
 ocw_studio_vault_backend = OLVaultDatabaseBackend(ocw_studio_vault_backend_config)
 

--- a/src/ol_infrastructure/lib/stack_defaults.py
+++ b/src/ol_infrastructure/lib/stack_defaults.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from ol_infrastructure.components.aws.database import OLReplicaDBConfig
 from ol_infrastructure.lib.aws.rds_helper import DBInstanceTypes
 from ol_infrastructure.lib.pulumi_helper import StackInfo
 
@@ -7,6 +8,7 @@ production_defaults = {
     "rds": {
         "multi_az": True,
         "instance_size": DBInstanceTypes.general_purpose_large.value,
+        "read_replica": OLReplicaDBConfig(),
     },
     "redis": {"instance_type": "cache.m6g.large"},
 }


### PR DESCRIPTION
For production environments we want to create a read replica to absorb the load from data replication workflows into our data lake. This adds that as s default configuration.

<!--- Provide a general summary of your changes in the Title above -->

## Description
We don't want to add strain to production databases so this makes the creation of a read replica the default setup for production environments.

## Motivation and Context
https://github.com/mitodl/ol-infrastructure/issues/1089

## How Has This Been Tested?
The Pulumi preview command was run on a sampling of production stacks to verify that the read replica will be created with the proper settings.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
