### PR TITLE
Revert "fix: Override upgrade button link for MITx Online production"

### DIFF
--- a/src/bilder/images/edxapp/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -337,7 +337,7 @@ LOGIN_REDIRECT_WHITELIST:  # MODIFIED
 LOG_DIR: /edx/var/log/edx
 MAINTENANCE_BANNER_TEXT: Sample banner message
 MARKETING_SITE_BASE_URL: https://{{ key "edxapp/marketing-domain" }}/ # ADDED - to support mitxonline-theme
-MARKETING_SITE_CHECKOUT_URL: https://{{ if env "ENVIRONMENT" | contains "production" }}micromasters.mit.edu/dashboard{{ else }}{{ key "edxapp/marketing-domain" }}/cart/add/{{ end}} # ADDED - to support mitxonline checkout
+MARKETING_SITE_CHECKOUT_URL: https://{{ key "edxapp/marketing-domain" }}/cart/add/ # ADDED - to support mitxonline checkout
 MEDIA_ROOT: media/  # MODIFIED - with s3 storage backend this is the path within the bucket. No leading / allowed
 MEDIA_URL: /media/
 MICROSITE_CONFIGURATION: {}


### PR DESCRIPTION
⚠️ This PR doesn't need to be merged right away, We'd want to merge this when we [launch MITx Online ](https://github.com/mitodl/hq/discussions/227).

This revert PR is associated with https://github.com/mitodl/mitxonline/issues/953, in response to https://github.com/mitodl/mitxonline/issues/953#issuecomment-1262603741. We'd want to change the redirect back to MITx Online.


Reverts mitodl/ol-infrastructure#1067

