### PR TITLE
config: Add configuration for managing user retirement in MITxOnline

### DIFF
--- a/src/bilder/images/edxapp/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -21,6 +21,7 @@ mysql_creds: &mysql_creds
 
 {{ with secret "secret-mitxonline/edxapp" }}
 CELERY_BROKER_PASSWORD: {{ .Data.redis_auth_token }}
+FERNET_KEYS: {{ .Data.fernet_keys }}
 redis_cache_config: &redis_cache_config
   BACKEND: django_redis.cache.RedisCache
   LOCATION: rediss://default@edxapp-redis.service.consul:6379/0
@@ -45,6 +46,8 @@ JWT_AUTH:  # NEEDS ATTENTION
       - ISSUER: https://{{ key "edxapp/lms-domain" }}/oauth2
         AUDIENCE: mitxonline
         SECRET_KEY: {{ .Data.django_secret_key }}
+RETIRED_USER_SALTS: {{ .Data.user_retirement_salts }}
+SENTRY_DSN: {{ .Data.sentry_dsn }}
 XQUEUE_INTERFACE:
     basic_auth:
     - edx
@@ -53,7 +56,6 @@ XQUEUE_INTERFACE:
         password: {{ .Data.xqueue_edxapp_password }}
         username: edxapp
     url: http://xqueue.service.consul:8040  # MODIFIED
-SENTRY_DSN: {{ .Data.sentry_dsn }}
 {{ end }}
 
 {{ with secret "secret-mitxonline/edx-forum" }}
@@ -259,6 +261,7 @@ FEATURES:
     CUSTOM_COURSES_EDX: false
     EMBARGO: true  # ADDED KEY
     ENABLE_BULK_ENROLLMENT_VIEW: false
+    ENABLE_BULK_USER_RETIREMENT: true
     ENABLE_COMBINED_LOGIN_REGISTRATION: true
     ENABLE_CORS_HEADERS: true  # MODIFIED
     ENABLE_COUNTRY_ACCESS: false
@@ -291,8 +294,6 @@ FEATURES:
     SHOW_HEADER_LANGUAGE_SELECTOR: false
     SKIP_EMAIL_VALIDATION: true # ADDED KEY
 FEEDBACK_SUBMISSION_EMAIL: ''
-FERNET_KEYS:
-- DUMMY KEY CHANGE BEFORE GOING TO PRODUCTION
 FILE_UPLOAD_STORAGE_BUCKET_NAME: {{ key "edxapp/s3-storage-bucket" }}
 FILE_UPLOAD_STORAGE_PREFIX: submissions_attachments
 FINANCIAL_REPORTS:
@@ -409,17 +410,24 @@ REGISTRATION_EXTRA_FIELDS:
     terms_of_service: hidden
     year_of_birth: optional
 RETIRED_EMAIL_DOMAIN: retired.invalid
-RETIRED_EMAIL_PREFIX: retired__user_
-RETIRED_USERNAME_PREFIX: retired__user_
-RETIRED_USER_SALTS:
-- OVERRIDE ME WITH A RANDOM VALUE
-- ROTATE SALTS BY APPENDING NEW VALUES
+RETIRED_EMAIL_PREFIX: retired__user__
+RETIRED_USERNAME_PREFIX: retired__user__
 RETIREMENT_SERVICE_WORKER_USERNAME: retirement_worker
 RETIREMENT_STATES:
-- PENDING
-- ERRORED
-- ABORTED
-- COMPLETE
+    - PENDING
+    - LOCKING_ACCOUNT
+    - LOCKING_COMPLETE
+    - RETIRING_FORUMS
+    - FORUMS_COMPLETE
+    - RETIRING_EMAIL_LISTS
+    - EMAIL_LISTS_COMPLETE
+    - RETIRING_ENROLLMENTS
+    - ENROLLMENTS_COMPLETE
+    - RETIRING_LMS
+    - LMS_COMPLETE
+    - ERRORED
+    - ABORTED
+    - COMPLETE
 SEGMENT_KEY: null
 SENTRY_ENVIRONMENT: {{ env "ENVIRONMENT" }}
 SERVER_EMAIL: odl-devops@mit.edu # MODIFIED

--- a/src/bridge/secrets/edxapp/mitxonline.production.yaml
+++ b/src/bridge/secrets/edxapp/mitxonline.production.yaml
@@ -1,6 +1,8 @@
 ---
 django_secret_key: ENC[AES256_GCM,data:TSccKTwc5z0n7+88RhsoaYs6zOc3+ZChNZP8uVEFIYe996CqOOQ2GQqXB1Humk8TTRhEKKqnDyQOisvZW8ydKBElJW+R2fYXUkM=,iv:MbeEDUb3rqK9/aCtSRrFmfPBbsonpstpu50kdy0R+po=,tag:juvmuoyUefm3uq1+6DBhGA==,type:str]
 edxapp_api_key: ENC[AES256_GCM,data:rAw+wahIF+nqhsCaC7kNm2pcHd0G1hwU9q1/hlhMi228TKhJy6g=,iv:28tztvSYZrXZRxlYH2RRnk0beyr48plMs59t/cMrkXg=,tag:kykXpf+BdXF+OfHUdJk+0A==,type:str]
+fernet_keys:
+- ENC[AES256_GCM,data:6I69FIFsMhFmpk3knoLBaUSpDfKqm7iMsWdDYOCIcg3mimFKtwrNnJxhZv8=,iv:slfWuZ4T2GSYf5w2kYAvSR6nSnOv6soXLh2Lb/AXPyA=,tag:j3ukHy0aM41mkYGmgMY3AA==,type:str]
 mitxonline_oauth_secret: ENC[AES256_GCM,data:ze+8hNS2vnSzIbOsFARFXAiDJ1s4y1DfnyggHkmBAWYWb/l8UhkOT+yLIBF5RqPBfjHhdIMsgaKvD2PPK4+aU/XrjKtyjKP4ps3/GjNRQMoAe44NVPJz0nxXH6PSmJe3XJ3rAQ0sq3FjhyTn9Q+j/SWF017U4j6hHylKX3FloJQ=,iv:lKzWhvW9SDuKN2Gsr+6+FWAs3FN8m00NfnJk9mdplhU=,tag:OjUrSMpmNc4HOjP3wmVRLQ==,type:str]
 private_signing_jwk: ENC[AES256_GCM,data:qiB8I0KPxioFs99SRrWSwZgEUyeMeOKCjzQBYF1EJMz7yMXfR4phaZwMFtzXU0Ki6rTB1xpYt35NB9GwY/5pLboVWp79eV2E3WBnPVdvRIAIbqfffcVJbd4X8cjCULsQ+WKw4vccuKkcY2F6Ol+BfzlW4yNVlf4/U/Z4DN9lmNcxKUdhZGgmYzZ9Yktn0HVJKQKDk6rSkCFfz1qA9842+BD9VQotVO1uFHr6IwA4rC5FRtOQX9Gf4Kh8r0Dnj3ayosi+1xwd8D/iih2wgHuFOxAkxAJWWrhVYtCMSXTMKiFUvs+65jXa+4nIGKYJ8OP/KN5P0eZq3t03a59cSXlTAtjo97JHiMqLFEjd+rvpV4BG2uuTAhH5o0SpR8H+xxAoxOLdKbirVdktJnaIMG73K0d22CFvqcNvYpFtmVdjhsg1JH5niagZwngEtstPqFQ2d8rMb8/XC+gmuLwBXWMJichaBf8fATN/dUdHbSdThwgvDFwlgf07vXr/F1jK3xe+oL0ISI8Z23MEfCBEOOTzGJ0iBZ4HDvQXav0A8g/kI8p83WRU2j5M5aNIRyn/HonT/V9JzjofH4SGJGyG5/AicmV4WkUX55t3bcMJ1vMJ4IChVgNeNBhnhBauYPsrqFoShFKbnsT69kFrqZhAbeUgPl19y7t9i+G3ic2pQYTGMw20L/dRRnTjLE81ai3rXYjYn48zYwtKqHdzgddGhxgPdFg6mOgl3KfnlCyko2QbmC3Zgc7/m3iHuYUgcbYJeq4ajp/d979ImyoDxrtAVCg5EoGgB5JXbZwrDT3ZgnsQ5zm39gFSR/2pGvOhsETDAv2ceVJPIC/aFk+UcRhK/AChNBsdRWLXhnHL/ybevobtQnCXtsQjPwu+dxYDqeuAn6Ux/WBX9tVPPOnPBd7AlihG3Q2soy3atSZpCZZn7WKABEVyucegMCoAcevP+jP9Q7nWKYPZB/55j9Jejzwfsy9XB7P76T63KesvUCfXArJSeWhFGz937ql/3VVabQ+/olwfiFUKRzJVtV6dHmaBEH/K7x+xsAnDsBFvWHwDK3cl0YfTatJHHuts5ygFnZYCI61+BnlGECfZSmajcmDSXoW6sjsQclR9JnKNrQZqh02S8wcLK5cWxMQrixRJTB1Fz+DbpmW53u2hpRhNBUXnAQdEVfgpa1sW3XwtBuAiMmd/aBk9mTZ17gDhquGp/cTCLhmt5eg3UyWgnhYgYgGzDM85NiLfZusXMjWEUaI6THk1ps7l9uXo6vB6pkK+iR99jtfH0NOLnRdIbQrtlJmlpbCdLJgNtHkEHwCOB15lkwfFDgZLhqff/r0I9xzy/ERs7xauf3pnZPDypdDqazG/iX9d+BSXmV5v+nQZJqpUz1ENOb81Wfnsl348HftcV4YbpnrdPWZtqWPkVFWLhmTTNGFkieQk9eG/CGnw9OANn0WV1oJ+gD4Im8pmz/rmmlDZHkyr9Z0rIw==,iv:xgq7+1Qb4d1suwmgNMpytAziV+prLdDEPQ5WPEGBlGY=,tag:7HAx2/geGYPl9BxkxTYJCw==,type:str]
 proctortrack_client_id: ENC[AES256_GCM,data:EGmHb1Gid2ZuwCPseHjrYoP8HXjX0+IeAK2mAL2R7Ypy8Amk0kOlLw==,iv:ZFfcOqEV2q+R0sy3kLPqyyMLAuW27Xceonrw+85x+u4=,tag:DAbmT1/x7qIjn7Txa3reMw==,type:str]
@@ -12,20 +14,22 @@ sentry_dsn: ENC[AES256_GCM,data:aDh5g6N8DnpqKvdo1Jf0EN8RUyCIIWWFKCMVIs36hdIX0ZP2
 studio_oauth_client:
   id: ENC[AES256_GCM,data:R+J/Amlzfl/zcvfYieDnU2akDL/2v9tiBkJ5PdGg2zM3EGJNA38Xsw==,iv:JQKxZsJIEZYWNlOJPX64Sbu6JoJjktZh1PC/B3EdI9Y=,tag:89lSNpablxotqDU9fQ4/og==,type:str]
   secret: ENC[AES256_GCM,data:9lQSQ96LMlsZhvfp0G3SbROG+EOB4Sb9XCBV9lPF8sk/hvLaryHivJ2NG6OMy424waoTkZPtI+QHtkrshqsL2EW3wtmwB7JTNoHm8td3p5hct0KYlxuzNbe8khEY9H05VDKVK8GrvhVBh9ZHjsaV+ZODQ01X+XGElBGNd05TIO4=,iv:cngGmXPg/FQTF07734w9v6ic0DKycebFAxUpzkUXpdo=,tag:uIjuF0g/LeiJDrM2Z0SF9w==,type:str]
+user_retirement_salts:
+- ENC[AES256_GCM,data:1S30UMmeD9En4HJdtaHDuLI9XyLanJYcXjvTVgsaedguEPObGYV9y3COEw==,iv:B2H6dZc4Aby/1einxkpN/Tb1gIEWPFzjf9UTFt+QDv8=,tag:+5l9SK5L7tj0nqvOSa2pRQ==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
-    created_at: '2021-10-15T18:33:31Z'
+    created_at: "2021-10-15T18:33:31Z"
     enc: AQICAHgQalNS7T35ZlcFdhF0QuKeiJAbXMUbm01pjGwHEsjRCgHPgBq+bdNeB7aieSVT5JsNAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM3BdoFh+6VYGxQdeLAgEQgDu2cWs07JcpSUcgvF3H3VaSVdKQwD1Bkkki5slmhGJk1ZIPzwDoCm+2BJO3ZCFRTQ+yZyZnp4L/K+3RxA==
-    aws_profile: ''
+    aws_profile: ""
   gcp_kms: []
   azure_kv: []
   hc_vault: []
   age: []
-  lastmodified: '2021-12-21T17:27:23Z'
-  mac: ENC[AES256_GCM,data:yavfiAIpPy0wLxseHndzY1hKUZV/5JyKxVASQHuSkC0Nm9/lsV+GFe4H4w+PGQLqLOrEuW7Tcobf9CBX5PuzuJomn2uKvwGPjzQDmfk0hKuf9OVhwx+R3M2bBDjG1ozrcVsrUBhkkkLUIHeXxoqykavMA+ZUYemUU7jHNFlW2Fg=,iv:KvJii+Gh0jvTWAVzGuoh1H7OaMseYe3GXrSjgO8evo8=,tag:uopo4VOhpn3xgXsmJAVJCQ==,type:str]
+  lastmodified: "2022-09-23T15:01:44Z"
+  mac: ENC[AES256_GCM,data:NsDdr/RW2cXz9ZRwieDuxWGIqTkD8SQE4N1eYSD8AryfiPkhMT4RFP1TWPPmwxD2SmCEUAM2AF8O+Q4bLPzMaH3EcNPqcAG6pT5Trnm8Jz1i2qSFQyFT48/5356kRR/HpKxG1zAR/esmvrad/Z5qyiXi6aTq5FCHhH5IQiMcQEI=,iv:gSL3B/YJDdX3DXSWxlHLBcBtjCh1fgZiY4cnNvG6OBg=,tag:b+4u/A14ckwymQfhX2wPlQ==,type:str]
   pgp:
-  - created_at: '2021-10-15T18:33:31Z'
+  - created_at: "2021-10-15T18:33:31Z"
     enc: |
       -----BEGIN PGP MESSAGE-----
 
@@ -45,7 +49,7 @@ sops:
       =FFCD
       -----END PGP MESSAGE-----
     fp: dfd1205a98269f34c43c9221d6260c616bd0fa33
-  - created_at: '2021-10-15T18:33:31Z'
+  - created_at: "2021-10-15T18:33:31Z"
     enc: |
       -----BEGIN PGP MESSAGE-----
 
@@ -65,7 +69,7 @@ sops:
       =u5Sp
       -----END PGP MESSAGE-----
     fp: B905F0256A801D3F1D15B5126A1D27A4BE75B1C2
-  - created_at: '2021-10-15T18:33:31Z'
+  - created_at: "2021-10-15T18:33:31Z"
     enc: |
       -----BEGIN PGP MESSAGE-----
 
@@ -86,4 +90,4 @@ sops:
       -----END PGP MESSAGE-----
     fp: 51BB820DC5F14FE9
   unencrypted_suffix: _unencrypted
-  version: 3.7.1
+  version: 3.7.3

--- a/src/bridge/secrets/edxapp/mitxonline.qa.yaml
+++ b/src/bridge/secrets/edxapp/mitxonline.qa.yaml
@@ -1,6 +1,8 @@
 ---
 django_secret_key: ENC[AES256_GCM,data:/TJ5IPewi6sTJx/jfUgOetVqLW9PgAjkWUK6JLEls95S15YJ7cn5hpn/2g==,iv:GyXW6CR2g/5YxK6RD4IfBEuetDp3kUGdO5LU2lZJ3go=,tag:p+xL45eHKSKy5+kIi0sJow==,type:str]
 edxapp_api_key: ENC[AES256_GCM,data:vUq3VWTXWFkh0h9ai5r7kwrebuFkgaY8HKT+AyiJsryH5WqiYPE=,iv:9rrvXBPvKOtYn0sJl6wdZmQd20itG7E9JMXdKQ7ZQk4=,tag:kQYOxD+ZVEpJ/teC0h/kQg==,type:str]
+fernet_keys:
+- ENC[AES256_GCM,data:kbn+eZnz2qkiuJNPXuNufANaltoW/ZjkPOIktuBL9nhiAMt45dL6S131l8U=,iv:0vfqEFccLxBQ73LwtdPbP2/XI3PAOPCpD5ESPBqL0Z0=,tag:tSuRCLFuoTgJ1Vnd6bdHHA==,type:str]
 mitxonline_oauth_secret: ENC[AES256_GCM,data:dSvvn13YbDlxU481jJJ8eul/Xd3pZM4a/EGJ6cWH1WuEx0XwW2lc/lYdVlqyfg3ytleIoVIxDnuM2vt/K2go0Uaku6xi/bFfFhnpHdzUC8LhI2eLCKn0dmBrfWlbzs3you0hLobCMJnZl+o/DpQ3TuSDtNAk6GvPE3O6Ysq0MqE=,iv:483uzJ2DCp6VMigXhB9CHfy8B8uIW+mN2sNEqG8Ibxg=,tag:UkwB2sxCwulVB8RzCNSJeA==,type:str]
 private_signing_jwk: ENC[AES256_GCM,data:ViAG2fERIOG9lsbqRyspGvScg3kWbirLndYjmJKd+iWLPQMa/5fAHz4RlnetSEz75ue+6Nzpykw0dR+ivz57Qv92UAQ59ZU39O95v1qMgpOyPUwzToO8gV45x5+Dh0nk0g4L4eOylOG0IMbsj0sjIttoohvjcdfXVDm6u/qCHieYQpNBLVAnHWBjhRNeGklYUjRBwZHLYK/Z4FZq5AjcbeIxirjMko2EuFrngNRuB7thbW+V3AUqlJ21SY+bDHLpl1OGbHYp6yiNXXTuiIGqVsHrFqd9BIuQ1QpGF7Jn2EbuarPnNU2cTRcyKuW/8rY/QR6A6ms+9awzTyMPTPFNa5o2vdBLqqetXSbMJTVSqJdGZ+f28fqEWe9KvgJBko4mNzg/asA5y6sRw8uSmK5ITqLW7CiPF7ckivMe/yzfaFpSb1jzOrYk+wmAvWP9Dk9ggv/DePTTnNTByX4fUkSwLFvMl8B75B57cyMZmf9dJr8/c3XbY7jYhy2e3P+ODU70DmjOFy1x4d6mPPtOoQ13zSRoAfX3heWaA/pDIy6rf6X5rFEv8c4MwL2NCq3gJsasZupPib89KYthCYdOAutGgtfcsKpcfHShxyJpetqqwLWuJEHEavWA89sj67jtkWyZjJrvw3jCjQoy/7VMnFmc5h3Gf4BFdf4ub3ATWJQLYTxbNL+Ca9gQ/oBov6Suyl6gCDHsfROdqOvyUuMdhq/nvSEmNw45OOODw/bFvihZlARdynruzgrfRiiazT7A1xr6VgBlu4qPXaUqQT4DWxl/tnZp4OsfxiqJV4lOrKuhTeC+Qu2zuXXe3TQpMkrgbifiEcyATOK0aEbFsGMByAY4MPjsvPTqMsm63m+kcMBZfqGIHaMciqh3OG9TlGMsHJ1Vfd6kjfpOnaD3YLWYbhufwh7et8UtJGkcWDrY3JCt+P4+wOzGEOpT/+Qzilsx1WMhoYZ+o+PAm3kbQ7IrmhArfGdEMXuWfe/7hKCSXCdikTwkY/rogtC6hVoHrSQ9OcKyJjpevU/s81h1Il4AbqpDwF5LnAyRErEI3nTMAUJy34Ci4iHIHjIdIlYDOPZMt64eOJLhKU/K1t9BrbG+VH0DErI8kdc7MFejlxCz87ceHbef8rmFg5EY3l/vuPfiD3r1ovWGhuZWNiO5NYbWCJkmaLFnm5sywx7UodV59CwGDHcQYMGoykpH8+XZ4NnbBH0UK4bdUS0il8L9P/BsVX35V1g/b48QYvCi/GGkKJJ+Us/ippHy1viy+DLt7gGvxHrv1GG2P4+Ms3hDkPGFU2kylGsJ0VU2JXM56Lc4hWlvhE1EDMffu+6LRBy0HCHQzDupHPx1RycRWNGwJuKX7b/8RQV5CE3uyfX1e3MUuxaNMjDsgihza8YXsP7J8uemQFzpFrVEzwhYKrO1P0jPi8V3nAwMIoGVyO7h1H0ttWlMCuNisLgDsCPF3sU2OYLsKwnN1f/DLg==,iv:klpmhtZmlsM27TDAX6TqFfAWqyHOem1NTLI3aYpv8Kg=,tag:lpWq4tQFOww31XYP0J/aPw==,type:str]
 public_signing_jwk: ENC[AES256_GCM,data:b+FehmhZqgGl9nf5CvHNvYoNDApAkzK1zMGXveBNTKfgxLGJZGsKJOsnzHqz7Uu8JUIGH61D2G6PZXP2vBZ9GwXPUd250y+yExR8b4SJI8/cDwoZMLzvkokHIq/cpQACHOjAAHewo1tEp/g+lB1g2AzrcfvWYSOZDCfILRhliuHfFS+3rZRvWx8yA46AcpNoHslhu/gWFyK0lEHNPD+tNLfdi9gKRWyBRbVkj2TuNPDlkxkbnTxFvqSsEfYW9QDMyXwTMxDAPTJal9ffRr2+9q5dNyzEMNg8bCJ0hfcNna+pc21lESn2eyDUlEVQdHqMdcTwmRijlWr4u9q/8gkuldLB+wu2MPYiSRg1BttF/tBOTmAzmByi8DCoj4LMWcWQPvfwQhZzgaga17phAeLf1OzF6B3AlWo/P4y8LGsZCIqba216ISPH0h/suT90djPRN5YOsMnWFjdIm6CpFS/PWC/Iw7wMsxdX5yU9YiY0t1P+60xvRI3aFK3zEVvTfVB+JxM/QYOqmvnA4yiW6cU/3I9J8BBspbTK6w==,iv:rPhcz6n0qGv6FHh94HwKdgpOE6dTtvCL1uCHIqvmrec=,tag:1Flx7UUDgzv85qj3kv8TIA==,type:str]
@@ -12,20 +14,22 @@ sentry_dsn: ENC[AES256_GCM,data:ffrJUtMBXOPdvMcoiF83ktVnVQ1M91mYPsRDH6ejPPTkNyXz
 studio_oauth_client:
   id: ENC[AES256_GCM,data:sRPZu3KUl4XD3sCIwthMqE0PCbrHtHBB/A4cytoH2H3DFcAzipH7Aw==,iv:bOTZZT1reRhdXOiIaQYpjMBr8hbe12ne4wTVwuntmXU=,tag:TBTv/xTytfwXvgfalR9hKQ==,type:str]
   secret: ENC[AES256_GCM,data:4Ce7WgnUfVtw5T0Vms9DrjFLkcTZEVf8VyjrnpCTEqrmRttig2SOrSYn5cYRpbtNommBk5IucunzdDR6vkCtInv5nYShrAxBmahVOL+qoOHToKLTX7k4+j6u+/962fdZTPX8Fu44P3Ehl6sYYYBLQM3jYBTN0w25TLg/o7DW6aQ=,iv:aHEghcJ4aEL2YxQ5I2dbqifDOdYtKZVyMuuSEFd+U7c=,tag:N7zTbcZMBBvywJ5AQ4Aamw==,type:str]
+user_retirement_salts:
+- ENC[AES256_GCM,data:OEErinnXRju8/9Tjt3xF3e7PJ7oaH+lbuJu/TauncTLxeLM83KryT+2Cjw==,iv:CRUBkkU+TT3TpSVXA9SeKZ8qnxN6uWYTMC8FmQINNNE=,tag:HMP42S06BBaniyfANKyhlA==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-qa
-    created_at: '2021-07-16T20:26:59Z'
+    created_at: "2021-07-16T20:26:59Z"
     enc: AQICAHijXuVxVlAL6bY9xCOrzO3YYhFlQBPt6jNyJGkhYu+q4QHcIH+LYX8aM/rKxipncPJGAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMg5/prKkbzTs6KGr0AgEQgDsC9RIfPf0JOVdR3/DVPL+IGJFtrOgXIc0/UAYoFO/Y4QP7v4nmNtIpjgdOPuaExM/Qi9Yrzi0mCWO+yw==
-    aws_profile: ''
+    aws_profile: ""
   gcp_kms: []
   azure_kv: []
   hc_vault: []
   age: []
-  lastmodified: '2021-12-21T17:27:09Z'
-  mac: ENC[AES256_GCM,data:pRaYEodOv7uM5e0wpeKe3RqeTukbO85mIWa9YlRPr5bwfjelX8ksFECQF41sm4hWpn/tEouIWbLgmbKl0t2Vd6Ctsf8YD3M+nHVr59oLXWjFadzm1Co1bo4+hJUA+xFUoqaWoJiEVmKpK+TXYcy1hwaay43OBCXOeJzxX5F+9zE=,iv:AlmYMwhdn0b6GF51NU+YMc+Y+U+MCYHtLnAZNpbNrN0=,tag:4fQNOIUeLLqt/YnQhN38nw==,type:str]
+  lastmodified: "2022-09-23T15:00:35Z"
+  mac: ENC[AES256_GCM,data:AFbuBUhFegQ+owKBr31TNSbRMBPv0Wpaevww2zhiH6WcI55jc8q3BdESovQhMtHABUR+THJumiSAVpLgTDQNWzuo8heDVWgfE+9fLdc/ZAJKnQA8P6dClnH+AJAXjtKRXXh6kWRkmNywEibS3iWF+/OBGcNyDcFhK8FtItQTAQM=,iv:UFATZQBHpe0yCkj1YKokZ4GNFBeqQpU7WRV3E4P0Sks=,tag:j/DSNyIy5X40H/3dQlYxIw==,type:str]
   pgp:
-  - created_at: '2021-07-16T20:26:59Z'
+  - created_at: "2021-07-16T20:26:59Z"
     enc: |
       -----BEGIN PGP MESSAGE-----
 
@@ -45,7 +49,7 @@ sops:
       =RKmD
       -----END PGP MESSAGE-----
     fp: dfd1205a98269f34c43c9221d6260c616bd0fa33
-  - created_at: '2021-07-16T20:26:59Z'
+  - created_at: "2021-07-16T20:26:59Z"
     enc: |
       -----BEGIN PGP MESSAGE-----
 
@@ -65,7 +69,7 @@ sops:
       =NPIb
       -----END PGP MESSAGE-----
     fp: B905F0256A801D3F1D15B5126A1D27A4BE75B1C2
-  - created_at: '2021-07-16T20:26:59Z'
+  - created_at: "2021-07-16T20:26:59Z"
     enc: |
       -----BEGIN PGP MESSAGE-----
 
@@ -86,4 +90,4 @@ sops:
       -----END PGP MESSAGE-----
     fp: 51BB820DC5F14FE9
   unencrypted_suffix: _unencrypted
-  version: 3.7.1
+  version: 3.7.3


### PR DESCRIPTION
We have a need to retire user accounts in the MITx Online service. This adds configuration to the Open edX service to allow for managing the provided retirement workflows.

## Description
Add configuration for user retirement pipelines, as well as populating secrets needed for hashing the user information during retirement.

## Motivation and Context
https://github.com/mitodl/mitxonline/issues/697

## How Has This Been Tested?
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
