### PR TITLE
feat: Add container image build task helper and edx tubular pipeline

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ per-file-ignores =
     # Allow deployments to have a large number of imports
     deploy.py:WPS201,WPS203,WPS235
     # Allow lib modules to have more module members
+    **/lib/*.py:WPS201,WPS202
     **/lib/**/*.py:WPS201,WPS202
     # Allow Pulumi projects to have a large number of imports
     src/ol_infrastructure/**/__main__.py:WPS201,WPS203

--- a/src/concourse/lib/containers.py
+++ b/src/concourse/lib/containers.py
@@ -1,0 +1,37 @@
+from typing import Optional
+
+from concourse.lib.jobs.infrastructure import Output
+from concourse.lib.models.pipeline import (
+    Command,
+    Identifier,
+    Input,
+    TaskConfig,
+    TaskStep,
+)
+
+
+def container_build_task(
+    inputs: list[Input],
+    build_parameters: Optional[dict[str, str]],
+    build_args: Optional[list[str]] = None,
+) -> TaskStep:
+    return TaskStep(
+        task=Identifier("build-container-image"),
+        privileged=True,
+        config=TaskConfig(
+            platform="linux",
+            image_resource={
+                "type": "registry-image",
+                "source": {"repository": "concourse/oci-build-task"},
+            },
+            params=build_parameters,
+            run=Command(
+                path="build",
+                args=build_args or [],
+            ),
+            inputs=inputs,
+            # This output needs to be named exactly "image" or it won't actually export
+            # the built image.
+            outputs=[Output(name=Identifier("image"))],
+        ),
+    )

--- a/src/concourse/lib/resources.py
+++ b/src/concourse/lib/resources.py
@@ -5,13 +5,18 @@ from concourse.lib.models.resource import Git
 
 
 def git_repo(
-    name: Identifier, uri: str, branch: str = "main", paths: list[str] = None
+    name: Identifier,
+    uri: str,
+    branch: str = "main",
+    paths: list[str] = None,
+    **kwargs,
 ) -> Resource:
     return Resource(
         name=name,
         type="git",
         icon="git",
         source=Git(uri=uri, branch=branch, paths=paths),
+        **kwargs,
     )
 
 

--- a/src/concourse/pipelines/container_images/openedx_tubular.py
+++ b/src/concourse/pipelines/container_images/openedx_tubular.py
@@ -1,0 +1,65 @@
+import sys
+
+from concourse.lib.containers import container_build_task
+from concourse.lib.models.pipeline import (
+    GetStep,
+    Identifier,
+    Input,
+    Job,
+    Pipeline,
+    PutStep,
+    Resource,
+)
+from concourse.lib.resources import git_repo
+
+tubular_repository = git_repo(
+    name=Identifier("openedx-tubular"),
+    uri="https://github.com/openedx/tubular",
+    branch="master",
+    check_every="24h",
+)
+
+tubular_image = Resource(
+    name=Identifier("openedx-tubular-image"),
+    type="registry-image",
+    icon="docker",
+    source={
+        "repository": "mitodl/openedx-tubular",
+        "tag": "latest",
+        "password": "((dockerhub.password))",
+        "username": "((dockerhub.username))",
+    },
+)
+
+build_task = container_build_task(
+    inputs=[Input(name=tubular_repository.name)],
+    build_parameters={"CONTEXT": tubular_repository.name},
+)
+
+docker_pipeline = Pipeline(
+    resources=[tubular_repository, tubular_image],
+    jobs=[
+        Job(
+            name=Identifier("build-and-publish-container"),
+            plan=[
+                GetStep(get=tubular_repository.name, trigger=True),
+                build_task,
+                PutStep(
+                    put=tubular_image.name,
+                    params={
+                        "image": "image/image.tar",
+                        "additional_tags": f"./{tubular_repository.name}/.git/describe_ref",
+                    },
+                ),
+            ],
+        )
+    ],
+)
+
+if __name__ == "__main__":
+    with open("definition.json", "wt") as definition:
+        definition.write(docker_pipeline.json(indent=2))
+    sys.stdout.write(docker_pipeline.json(indent=2))
+    sys.stdout.write(
+        "fly -t <prod_target> set-pipeline -p docker-openedx-tubular-image -c definition.json"
+    )


### PR DESCRIPTION
- We have a number of images that we need to build and keep up to date. This adds a helper function to simplify the work of defining a container build task in Concourse to standardize that step.
- This creates a pipeline for the Open edX Tubular container image and uses that as the first example of the container task helper function.

## Description
This adds a helper function for reducing the amount of code needed to write a container build pipeline in Concourse

## Motivation and Context
We have a number of container images that we need to maintain for various purposes, as well as more that we will be adding. In order to be able to make that maintainable we need to make it easy and low-friction to write pipelines that keep those containers up to date.

## How Has This Been Tested?
The helper function was used to create a pipeline that builds the container for Open edX Tubular https://cicd.odl.mit.edu/teams/main/pipelines/docker-openedx-tubular-image

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
