### PR TITLE
ocw-studio replication pipeline

### DIFF
--- a/src/concourse/pipelines/infrastructure/ocw_studio_db_replication/BUILD
+++ b/src/concourse/pipelines/infrastructure/ocw_studio_db_replication/BUILD
@@ -1,0 +1,4 @@
+pex_binary(
+    name="pipeline",
+    entry_point="pipeline.py",
+)

--- a/src/concourse/pipelines/infrastructure/ocw_studio_db_replication/pipeline.py
+++ b/src/concourse/pipelines/infrastructure/ocw_studio_db_replication/pipeline.py
@@ -1,0 +1,121 @@
+from calendar import timegm
+from datetime import datetime
+
+from concourse.lib.constants import REGISTRY_IMAGE
+from concourse.lib.models.pipeline import (
+    AnonymousResource,
+    Command,
+    GetStep,
+    Identifier,
+    Input,
+    Job,
+    Output,
+    Pipeline,
+    Platform,
+    RegistryImage,
+    TaskConfig,
+    TaskStep,
+)
+from concourse.lib.resources import git_repo
+
+ocw_studio = git_repo(
+    Identifier("ocw-studio"),
+    uri="https://github.com/mitodl/ocw-studio",
+    branch="cg/replibyte-config",
+    check_every="60m",
+)
+
+alpine_resource = AnonymousResource(
+    type=REGISTRY_IMAGE,
+    source=RegistryImage(repository="marsblockchain/curl-git-jq-wget"),
+)
+
+postgres_resource = AnonymousResource(
+    type=REGISTRY_IMAGE, source=RegistryImage(repository="postgres", tag="latest")
+)
+
+
+def db_replication_pipeline() -> Pipeline:
+    db_replication_job = Job(
+        name="ocw-studio-db-replication",
+        build_log_retention={"builds": 10},
+        plan=[
+            GetStep(get=ocw_studio.name, trigger=False),
+            TaskStep(
+                task=Identifier("install-replibyte"),
+                privileged=False,
+                config=TaskConfig(
+                    platform=Platform.linux,
+                    image_resource=alpine_resource,
+                    inputs=[Input(name=ocw_studio.name)],
+                    outputs=[Output(name=ocw_studio.name)],
+                    run=Command(
+                        path="/bin/sh",
+                        dir="./ocw-studio/replibyte",
+                        args=["./install.sh"],
+                    ),
+                ),
+            ),
+            TaskStep(
+                task=Identifier("replibyte-dump-create"),
+                privileged=False,
+                config=TaskConfig(
+                    platform=Platform.linux,
+                    image_resource=postgres_resource,
+                    inputs=[Input(name=ocw_studio.name)],
+                    outputs=[Output(name="dump")],
+                    params={
+                        "SOURCE_DB_URI": "((ocw-studio-production-database-uri))",
+                        "DESTINATION_DB_URI": "((ocw-studio-qa-database-uri))",
+                    },
+                    run=Command(
+                        path="./ocw-studio/replibyte/replibyte",
+                        args=[
+                            "--config",
+                            "./ocw-studio/replibyte/replibyte.config",
+                            "dump",
+                            "create",
+                        ],
+                    ),
+                ),
+            ),
+            TaskStep(
+                task=Identifier("replibyte-dump-restore"),
+                privileged=False,
+                config=TaskConfig(
+                    platform=Platform.linux,
+                    image_resource=postgres_resource,
+                    inputs=[Input(name=ocw_studio.name), Input(name="dump")],
+                    params={
+                        "SOURCE_DB_URI": "((ocw-studio-production-database-uri))",
+                        "DESTINATION_DB_URI": "((ocw-studio-qa-database-uri))",
+                    },
+                    run=Command(
+                        path="./ocw-studio/replibyte/replibyte",
+                        args=[
+                            "--config",
+                            "./ocw-studio/replibyte/replibyte.config",
+                            "dump",
+                            "restore",
+                            "remote",
+                            "-v",
+                            "latest",
+                        ],
+                    ),
+                ),
+            ),
+        ],
+    )
+    return Pipeline(resources=[ocw_studio], jobs=[db_replication_job])
+
+
+if __name__ == "__main__":
+    import sys  # noqa: WPS433
+
+    with open("definition.json", "w") as definition:
+        definition.write(db_replication_pipeline().json(indent=2))
+    sys.stdout.write(db_replication_pipeline().json(indent=2))
+    sys.stdout.write("\n")
+    sys.stdout.write(
+        "fly -t local set-pipeline -p ocw-studio-db-replication -c definition.json"
+    )

--- a/src/concourse/pipelines/infrastructure/ocw_studio_db_replication/pipeline.py
+++ b/src/concourse/pipelines/infrastructure/ocw_studio_db_replication/pipeline.py
@@ -40,7 +40,7 @@ def db_replication_pipeline() -> Pipeline:
                         path="/bin/sh",
                         args=[
                             "-c",
-                            "pg_dump -Fc -d ((source.database)) > ./dump/db.dump",
+                            "pg_dump -v -Fc -d ((source.database)) > ./dump/db.dump",
                         ],
                     ),
                 ),
@@ -62,7 +62,7 @@ def db_replication_pipeline() -> Pipeline:
                         path="/bin/sh",
                         args=[
                             "-c",
-                            "pg_restore --clean --no-privileges --no-owner -d ((destination.database)) ./dump/db.dump",
+                            "pg_restore -v --clean --no-privileges --no-owner -d ((destination.database)) ./dump/db.dump",
                         ],
                     ),
                 ),

--- a/src/concourse/pipelines/infrastructure/ocw_studio_db_replication/pipeline.py
+++ b/src/concourse/pipelines/infrastructure/ocw_studio_db_replication/pipeline.py
@@ -1,6 +1,3 @@
-from calendar import timegm
-from datetime import datetime
-
 from concourse.lib.constants import REGISTRY_IMAGE
 from concourse.lib.models.pipeline import (
     AnonymousResource,

--- a/src/concourse/pipelines/infrastructure/ocw_studio_db_replication/pipeline.py
+++ b/src/concourse/pipelines/infrastructure/ocw_studio_db_replication/pipeline.py
@@ -80,5 +80,5 @@ if __name__ == "__main__":
     sys.stdout.write(db_replication_pipeline().json(indent=2))
     sys.stdout.write("\n")
     sys.stdout.write(
-        "fly -t local set-pipeline -p ocw-studio-db-replication -c definition.json\n"
+        "fly -t qa-ocw set-pipeline -p ocw-studio-db-replication -c definition.json\n"
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Closes https://github.com/mitodl/ol-infrastructure/issues/1044

This PR adds a Python based pipeline definition to the repo for performing a Postgres DB replication on the `ocw-studio` database, based on a source and destination.

## Motivation and Context
The primary motivation behind this work is to be able to push a pipeline up into QA Concourse to perform a replication from production to QA for `ocw-studio`. This pipeline can also be used with the local Concourse instance spun up by `ocw-studio` to perform a restore of either QA or production to your local database. Initially [Replibyte](https://github.com/Qovery/Replibyte) was trialed for this work, but a number of issues were run into that prevented its use:

 - Multiple issues with escape characters in markdown causing the Replibyte dump creation to fail
 - Even with those "corrected," I encountered the worst memory leak issue I have ever seen

## How Has This Been Tested?
The pipeline generation code has been tested locally using the `poetry` setup, and the pipeline itself has been tested against a locally running version of `ocw-studio` with its own Concourse instance.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
