### PR TITLE
Fix Trino to Redash permissions

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
@@ -162,6 +162,7 @@ query_engine_permissions: list[dict[str, Union[str, list[str]]]] = [  # noqa: WP
         ],
         "Resource": [
             "arn:aws:glue:*:*:catalog",
+            "arn:aws:glue:*:*:database/information_schema",
             f"arn:aws:glue:*:*:database/*{stack_info.env_suffix}*",
             f"arn:aws:glue:*:*:table/*{stack_info.env_suffix}*/*",
         ],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When trying to connect Redash to Starburst/Trino, ran into a [timeout issue](https://github.com/mitodl/ol-infrastructure/issues/1149) which one of problems behind it is not enough permissions for the query engine role. This minor fix resolves that problem.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Modified permissions in the AWS console to try it out and things went through.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
