### PR TITLE
Adding redirect for Highlights of Calculus course

### DIFF
--- a/src/ol_infrastructure/applications/ocw_site/redirect_dict
+++ b/src/ol_infrastructure/applications/ocw_site/redirect_dict
@@ -292,6 +292,7 @@
   "/ESD-290S05": "307|keep|https://{{AK_HOSTHEADER}}/courses/engineering-systems-division/esd-290-special-topics-in-supply-chain-management-spring-2005/",
   "/ESD-932S06": "307|keep|https://{{AK_HOSTHEADER}}/courses/engineering-systems-division/esd-932-engineering-ethics-spring-2006/",
   "/ESD-S43S14": "307|keep|https://{{AK_HOSTHEADER}}/courses/engineering-systems-division/esd-s43-green-supply-chain-management-spring-2014/",
+  "/highlights-of-calculus": "307|keep|https://{{AK_HOSTHEADER}}/courses/res-18-005-highlights-of-calculus-spring-2010/",
   "/HST-725S04": "307|keep|https://{{AK_HOSTHEADER}}/courses/health-sciences-and-technology/hst-725-music-perception-and-cognition-spring-2009/",
   "/HST-931S09": "302|keep|https://{{AK_HOSTHEADER}}/courses/health-sciences-and-technology/hst-921-information-technology-in-the-health-care-system-of-the-future-spring-2009/",
   "/HST-S14S12": "307|keep|https://{{AK_HOSTHEADER}}/courses/health-sciences-and-technology/hst-s14-health-information-systems-to-improve-quality-of-care-in-resource-poor-settings-spring-2012/",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Redirects https://ocw.mit.edu/highlights-of-calculus -> https://ocw.mit.edu/courses/res-18-005-highlights-of-calculus-spring-2010/. This will make it easier for YouTube channel viewers to find the course, since that is the link in the YouTube channel description (https://www.youtube.com/playlist?list=PLBE9407EA64E2C318).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/ol-infrastructure/issues/1156.