### PR TITLE
Created a basic framework for attaching slack notifications to any concourse job.

### DIFF
--- a/src/concourse/lib/notifications.md
+++ b/src/concourse/lib/notifications.md
@@ -1,0 +1,10 @@
+
+# Sending Slack Notifications from Concourse Jobs.
+
+## Slack API Setup
+
+1. Navigate to api.slack.com and login with touchstone.
+2. Find the app named 'concourse-notifications'. You will need to be a collaborator on this app so talk to Mike or Tobias if you're not on the list.
+3. Under 'Basic Information' for the app expand 'Add features and functionality` and then select 'Incoming Web Hooks`.
+4. Then you can select 'Add New Webhook to Workspace'. Specify the channel you want it to send notification to. Each channel needs its own webhook.
+   - **Important:** Don't commit the webhook URL to git. There is no authentication besides simply knowing the URL, so if it were public anyone could send us notifications in slack. Treat the webhook URL like a secret and put it in Vault.

--- a/src/concourse/lib/notifications.py
+++ b/src/concourse/lib/notifications.py
@@ -1,0 +1,20 @@
+from typing import Optional
+from concourse.lib.models.pipeline import (
+    Resource,
+    PutStep
+)
+def notification(
+    resource: Resource, 
+    title: str,
+    body: str,
+    alert_type: Optional[str] = "default",
+) -> PutStep: 
+    params = {
+        "alert_type": alert_type,
+        "message": title,
+        "text": body
+    }
+    return PutStep(
+                put=resource.name,
+                params=params,
+            )

--- a/src/concourse/lib/notifications.py
+++ b/src/concourse/lib/notifications.py
@@ -9,7 +9,21 @@ def notification(
     body: str,
     alert_type: Optional[str] = "default",
 ) -> PutStep:
-    params = {"alert_type": alert_type, "message": title, "text": body}
+    """Generate a PutStep for sending notifications (to just slack, for now).
+
+    :param resource: The slack_notification_resource object for the pipeline.
+        See src/concourse/lib/resources.py
+    :param title: The text to send to slack as the 'title' of the notification. The bold
+        main line.
+    :param body: The text to send to slack as the 'body' of the notification. Additional
+        details that are hidden when the alert is collapsed.
+    :param alert_type: The type of alert to send. Determined the color of the alert
+        in slack. See: https://github.com/arbourd/concourse-slack-alert-resource#alert-types.
+        At this time we don't support 'started' notifications.
+
+    :returns: A `PutStep` object that can be executed as an 'on_success', 'on_failure', etc
+    """
+    params = {"alert_type": alert_type, "message": title, "text": body}  # noqa: WPS110
     return PutStep(
         put=resource.name,
         params=params,

--- a/src/concourse/lib/notifications.py
+++ b/src/concourse/lib/notifications.py
@@ -1,20 +1,16 @@
 from typing import Optional
-from concourse.lib.models.pipeline import (
-    Resource,
-    PutStep
-)
+
+from concourse.lib.models.pipeline import PutStep, Resource
+
+
 def notification(
-    resource: Resource, 
+    resource: Resource,
     title: str,
     body: str,
     alert_type: Optional[str] = "default",
-) -> PutStep: 
-    params = {
-        "alert_type": alert_type,
-        "message": title,
-        "text": body
-    }
+) -> PutStep:
+    params = {"alert_type": alert_type, "message": title, "text": body}
     return PutStep(
-                put=resource.name,
-                params=params,
-            )
+        put=resource.name,
+        params=params,
+    )

--- a/src/concourse/lib/resource_types.py
+++ b/src/concourse/lib/resource_types.py
@@ -56,3 +56,12 @@ def pulumi_provisioner_resource() -> ResourceType:
         type=REGISTRY_IMAGE,
         source=RegistryImage(repository="mitodl/concourse-pulumi-resource-provisioner"),
     )
+
+# https://github.com/arbourd/concourse-slack-alert-resource
+# We use only a very basic implementation of this notification framework
+def slack_notification_resource() -> ResourceType:
+    return ResourceType(
+        name=Identifier("slack-notification"),
+        type=REGISTRY_IMAGE,
+        source=RegistryImage(repository="arbourd/concourse-slack-alert-resource", tag="v0.15.0")
+    )

--- a/src/concourse/lib/resource_types.py
+++ b/src/concourse/lib/resource_types.py
@@ -57,11 +57,14 @@ def pulumi_provisioner_resource() -> ResourceType:
         source=RegistryImage(repository="mitodl/concourse-pulumi-resource-provisioner"),
     )
 
+
 # https://github.com/arbourd/concourse-slack-alert-resource
 # We use only a very basic implementation of this notification framework
 def slack_notification_resource() -> ResourceType:
     return ResourceType(
         name=Identifier("slack-notification"),
         type=REGISTRY_IMAGE,
-        source=RegistryImage(repository="arbourd/concourse-slack-alert-resource", tag="v0.15.0")
+        source=RegistryImage(
+            repository="arbourd/concourse-slack-alert-resource", tag="v0.15.0"
+        ),
     )

--- a/src/concourse/lib/resources.py
+++ b/src/concourse/lib/resources.py
@@ -124,12 +124,10 @@ def registry_image(
         source=RegistryImage(repository=image_repository, tag=image_tag or "latest"),
     )
 
+
 # https://github.com/arbourd/concourse-slack-alert-resource
 # We use only a very basic implementation of this notification framework
-def slack_notification(
-    name: Identifier, url: str) -> Resource:
+def slack_notification(name: Identifier, url: str) -> Resource:
     return Resource(
-        name=name,
-        type="slack-notification",
-        source={"url": url, "disabled": False} 
+        name=name, type="slack-notification", source={"url": url, "disabled": False}
     )

--- a/src/concourse/lib/resources.py
+++ b/src/concourse/lib/resources.py
@@ -123,3 +123,13 @@ def registry_image(
         type="registry-image",
         source=RegistryImage(repository=image_repository, tag=image_tag or "latest"),
     )
+
+# https://github.com/arbourd/concourse-slack-alert-resource
+# We use only a very basic implementation of this notification framework
+def slack_notification(
+    name: Identifier, url: str) -> Resource:
+    return Resource(
+        name=name,
+        type="slack-notification",
+        source={"url": url, "disabled": False} 
+    )

--- a/src/concourse/pipelines/infrastructure/grafana_cloud/pipeline.py
+++ b/src/concourse/pipelines/infrastructure/grafana_cloud/pipeline.py
@@ -15,9 +15,9 @@ from concourse.lib.models.pipeline import (  # noqa: WPS235
     TaskConfig,
     TaskStep,
 )
-from concourse.lib.resource_types import slack_notification_resource as snr_type
-from concourse.lib.resources import schedule, ssh_git_repo, slack_notification
 from concourse.lib.notifications import notification
+from concourse.lib.resource_types import slack_notification_resource as snr_type
+from concourse.lib.resources import schedule, slack_notification, ssh_git_repo
 
 build_schedule = schedule(Identifier("build-schedule"), "1h")
 
@@ -37,7 +37,9 @@ loki_alert_rules = ssh_git_repo(
     ],
 )
 
-slack_notification_resource = slack_notification(Identifier("slack-notification"), url="(( grizzly.slack_url ))")
+slack_notification_resource = slack_notification(
+    Identifier("slack-notification"), url="(( grizzly.slack_url ))"
+)
 
 cortex_alert_rules = ssh_git_repo(
     Identifier("cortex-alert-rules"),
@@ -133,10 +135,30 @@ commit_managed_dashboards_job = Job(
             put=grafana_dashboards.name, params={"repository": grafana_dashboards.name}
         ),
     ],
-    on_error=notification(slack_notification_resource, "Grafana Pipeline Error", "Error commiting managed dashboards to GitHub", alert_type="errored"),
-    on_failure=notification(slack_notification_resource, "Grafana Pipeline Failure", "Failure commiting managed dashboards to GitHub", alert_type="failed"),
-    on_abort=notification(slack_notification_resource, "Grafana Pipeline Aborted", "User Aborted Pipeline during commiting managed dashboards to GitHub", alert_type="aborted"),
-    on_success=notification(slack_notification_resource, "Grafana Pipeline Activity", "Managed dashboards successfully committed to GitHub.", alert_type="success"),
+    on_error=notification(
+        slack_notification_resource,
+        "Grafana Pipeline Error",
+        "Error commiting managed dashboards to GitHub",
+        alert_type="errored",
+    ),
+    on_failure=notification(
+        slack_notification_resource,
+        "Grafana Pipeline Failure",
+        "Failure commiting managed dashboards to GitHub",
+        alert_type="failed",
+    ),
+    on_abort=notification(
+        slack_notification_resource,
+        "Grafana Pipeline Aborted",
+        "User Aborted Pipeline during commiting managed dashboards to GitHub",
+        alert_type="aborted",
+    ),
+    on_success=notification(
+        slack_notification_resource,
+        "Grafana Pipeline Activity",
+        "Managed dashboards successfully committed to GitHub.",
+        alert_type="success",
+    ),
 )
 
 apply_dashboards_to_qa_job = Job(
@@ -166,10 +188,30 @@ apply_dashboards_to_qa_job = Job(
             ),
         ),
     ],
-    on_error=notification(slack_notification_resource, "Grafana Pipeline Error", "Error applying managed dashboards to QA", alert_type="errored"),
-    on_failure=notification(slack_notification_resource, "Grafana Pipeline Failure", "Failure applying managed dashboards to QA", alert_type="failed"),
-    on_abort=notification(slack_notification_resource, "Grafana Pipeline Aborted", "User Aborted Pipeline during applying managed dashboards to QA", alert_type="aborted"),
-    on_success=notification(slack_notification_resource, "Grafana Pipeline Activity", "Managed dashboards successfully applied to QA", alert_type="success"),
+    on_error=notification(
+        slack_notification_resource,
+        "Grafana Pipeline Error",
+        "Error applying managed dashboards to QA",
+        alert_type="errored",
+    ),
+    on_failure=notification(
+        slack_notification_resource,
+        "Grafana Pipeline Failure",
+        "Failure applying managed dashboards to QA",
+        alert_type="failed",
+    ),
+    on_abort=notification(
+        slack_notification_resource,
+        "Grafana Pipeline Aborted",
+        "User Aborted Pipeline during applying managed dashboards to QA",
+        alert_type="aborted",
+    ),
+    on_success=notification(
+        slack_notification_resource,
+        "Grafana Pipeline Activity",
+        "Managed dashboards successfully applied to QA",
+        alert_type="success",
+    ),
 )
 
 apply_dashboards_to_production_job = Job(
@@ -199,10 +241,30 @@ apply_dashboards_to_production_job = Job(
             ),
         ),
     ],
-    on_error=notification(slack_notification_resource, "Grafana Pipeline Error", "Error applying managed dashboards to Production", alert_type="errored"),
-    on_failure=notification(slack_notification_resource, "Grafana Pipeline Failure", "Failure applying managed dashboards to Production", alert_type="failed"),
-    on_abort=notification(slack_notification_resource, "Grafana Pipeline Aborted", "User Aborted Pipeline during applying managed dashboards to Production", alert_type="aborted"),
-    on_success=notification(slack_notification_resource, "Grafana Pipeline Activity", "Managed dashboards successfully applied to Production", alert_type="success"),
+    on_error=notification(
+        slack_notification_resource,
+        "Grafana Pipeline Error",
+        "Error applying managed dashboards to Production",
+        alert_type="errored",
+    ),
+    on_failure=notification(
+        slack_notification_resource,
+        "Grafana Pipeline Failure",
+        "Failure applying managed dashboards to Production",
+        alert_type="failed",
+    ),
+    on_abort=notification(
+        slack_notification_resource,
+        "Grafana Pipeline Aborted",
+        "User Aborted Pipeline during applying managed dashboards to Production",
+        alert_type="aborted",
+    ),
+    on_success=notification(
+        slack_notification_resource,
+        "Grafana Pipeline Activity",
+        "Managed dashboards successfully applied to Production",
+        alert_type="success",
+    ),
 )
 
 dashboards_combined_fragment = PipelineFragment(
@@ -270,9 +332,24 @@ for tool in ["loki", "cortex", "alertmanager"]:  # noqa: WPS335
                     ),
                 ),
             ],
-            on_error=notification(slack_notification_resource, "Grafana Pipeline Error", f"Error linting {tool} configs", alert_type="errored"),
-            on_failure=notification(slack_notification_resource, "Grafana Pipeline Failure", f"Failure linting {tool} configs", alert_type="failed"),
-            on_abort=notification(slack_notification_resource, "Grafana Pipeline Aborted", f"User Aborted Pipeline during linting {tool} configs", alert_type="aborted"),
+            on_error=notification(
+                slack_notification_resource,
+                "Grafana Pipeline Error",
+                f"Error linting {tool} configs",
+                alert_type="errored",
+            ),
+            on_failure=notification(
+                slack_notification_resource,
+                "Grafana Pipeline Failure",
+                f"Failure linting {tool} configs",
+                alert_type="failed",
+            ),
+            on_abort=notification(
+                slack_notification_resource,
+                "Grafana Pipeline Aborted",
+                f"User Aborted Pipeline during linting {tool} configs",
+                alert_type="aborted",
+            ),
         )
         alerting_jobs.append(linter_job)
     else:
@@ -336,15 +413,35 @@ for tool in ["loki", "cortex", "alertmanager"]:  # noqa: WPS335
                     ),
                 ),
             ],
-            on_error=notification(slack_notification_resource, "Grafana Pipeline Error", f"Error syncing {tool} configs in {stage}", alert_type="errored"),
-            on_failure=notification(slack_notification_resource, "Grafana Pipeline Failure", f"Failure syncing {tool} configs {stage}", alert_type="failed"),
-            on_abort=notification(slack_notification_resource, "Grafana Pipeline Aborted", f"User Aborted Pipeline during syncing {tool} configs in {stage}", alert_type="aborted"),
+            on_error=notification(
+                slack_notification_resource,
+                "Grafana Pipeline Error",
+                f"Error syncing {tool} configs in {stage}",
+                alert_type="errored",
+            ),
+            on_failure=notification(
+                slack_notification_resource,
+                "Grafana Pipeline Failure",
+                f"Failure syncing {tool} configs {stage}",
+                alert_type="failed",
+            ),
+            on_abort=notification(
+                slack_notification_resource,
+                "Grafana Pipeline Aborted",
+                f"User Aborted Pipeline during syncing {tool} configs in {stage}",
+                alert_type="aborted",
+            ),
         )
         alerting_jobs.append(sync_job)
 
 alerting_combined_fragment = PipelineFragment(
     resource_types=[snr_type()],
-    resources=[cortex_alert_rules, loki_alert_rules, alertmanager_config, slack_notification_resource],
+    resources=[
+        cortex_alert_rules,
+        loki_alert_rules,
+        alertmanager_config,
+        slack_notification_resource,
+    ],
     jobs=alerting_jobs,
 )
 

--- a/src/concourse/pipelines/infrastructure/grafana_cloud/pipeline.py
+++ b/src/concourse/pipelines/infrastructure/grafana_cloud/pipeline.py
@@ -115,10 +115,10 @@ commit_managed_dashboards_job = Job(
                 run=Command(
                     path="bash",
                     args=[
-                        "-exc",  # noqa: WPS462
+                        "-xc",  # noqa: WPS462
                         """  cd changed_repo;
                                 git config user.name "concourse";
-                                git config user.email "odl-devops@mit.edu":
+                                git config user.email "odl-devops@mit.edu";
                                 UNTRACKED_FILES=`git ls-files --other --exclude-standard --directory`;  # noqa: E501
                                 git diff --exit-code;
                                 if [ $? != 0 ] || [ "$UNTRACKED_FILES" != "" ]; then
@@ -131,9 +131,7 @@ commit_managed_dashboards_job = Job(
                 ),
             ),
         ),
-        PutStep(
-            put=grafana_dashboards.name, params={"repository": grafana_dashboards.name}
-        ),
+        PutStep(put=grafana_dashboards.name, params={"repository": "changed_repo"}),
     ],
     on_error=notification(
         slack_notification_resource,
@@ -176,7 +174,7 @@ apply_dashboards_to_qa_job = Job(
                         "-exc",
                         f""" export GRAFANA_TOKEN="((grizzly.qa_token))";  # noqa: WPS237, F541
                               export GRAFANA_URL="((grizzly.qa_url))";
-                              grr apply -d {{grafana_dashboards.name}}/managed -t '*';""",  # noqa: E501
+                              grr apply -d {grafana_dashboards.name}/managed -t '*';""",  # noqa: E501
                     ],
                 ),
             ),
@@ -229,7 +227,7 @@ apply_dashboards_to_production_job = Job(
                         "-exc",
                         f""" export GRAFANA_TOKEN="((grizzly.production_token))";  # noqa: WPS237, F541
                               export GRAFANA_URL="((grizzly.production_url))";
-                              grr apply -d {{grafana_dashboards.name}}/managed -t '*';""",  # noqa: E501
+                              grr apply -d {grafana_dashboards.name}/managed -t '*';""",  # noqa: E501
                     ],
                 ),
             ),

--- a/src/concourse/pipelines/infrastructure/grafana_cloud/pipeline.py
+++ b/src/concourse/pipelines/infrastructure/grafana_cloud/pipeline.py
@@ -15,7 +15,9 @@ from concourse.lib.models.pipeline import (  # noqa: WPS235
     TaskConfig,
     TaskStep,
 )
-from concourse.lib.resources import schedule, ssh_git_repo
+from concourse.lib.resource_types import slack_notification_resource as snr_type
+from concourse.lib.resources import schedule, ssh_git_repo, slack_notification
+from concourse.lib.notifications import notification
 
 build_schedule = schedule(Identifier("build-schedule"), "1h")
 
@@ -34,6 +36,8 @@ loki_alert_rules = ssh_git_repo(
         "loki-rules/*",
     ],
 )
+
+slack_notification_resource = slack_notification(Identifier("slack-notification"), url="(( grizzly.slack_url ))")
 
 cortex_alert_rules = ssh_git_repo(
     Identifier("cortex-alert-rules"),
@@ -129,6 +133,10 @@ commit_managed_dashboards_job = Job(
             put=grafana_dashboards.name, params={"repository": grafana_dashboards.name}
         ),
     ],
+    on_error=notification(slack_notification_resource, "Grafana Pipeline Error", "Error commiting managed dashboards to GitHub", alert_type="errored"),
+    on_failure=notification(slack_notification_resource, "Grafana Pipeline Failure", "Failure commiting managed dashboards to GitHub", alert_type="failed"),
+    on_abort=notification(slack_notification_resource, "Grafana Pipeline Aborted", "User Aborted Pipeline during commiting managed dashboards to GitHub", alert_type="aborted"),
+    on_success=notification(slack_notification_resource, "Grafana Pipeline Activity", "Managed dashboards successfully committed to GitHub.", alert_type="success"),
 )
 
 apply_dashboards_to_qa_job = Job(
@@ -158,6 +166,10 @@ apply_dashboards_to_qa_job = Job(
             ),
         ),
     ],
+    on_error=notification(slack_notification_resource, "Grafana Pipeline Error", "Error applying managed dashboards to QA", alert_type="errored"),
+    on_failure=notification(slack_notification_resource, "Grafana Pipeline Failure", "Failure applying managed dashboards to QA", alert_type="failed"),
+    on_abort=notification(slack_notification_resource, "Grafana Pipeline Aborted", "User Aborted Pipeline during applying managed dashboards to QA", alert_type="aborted"),
+    on_success=notification(slack_notification_resource, "Grafana Pipeline Activity", "Managed dashboards successfully applied to QA", alert_type="success"),
 )
 
 apply_dashboards_to_production_job = Job(
@@ -187,6 +199,10 @@ apply_dashboards_to_production_job = Job(
             ),
         ),
     ],
+    on_error=notification(slack_notification_resource, "Grafana Pipeline Error", "Error applying managed dashboards to Production", alert_type="errored"),
+    on_failure=notification(slack_notification_resource, "Grafana Pipeline Failure", "Failure applying managed dashboards to Production", alert_type="failed"),
+    on_abort=notification(slack_notification_resource, "Grafana Pipeline Aborted", "User Aborted Pipeline during applying managed dashboards to Production", alert_type="aborted"),
+    on_success=notification(slack_notification_resource, "Grafana Pipeline Activity", "Managed dashboards successfully applied to Production", alert_type="success"),
 )
 
 dashboards_combined_fragment = PipelineFragment(
@@ -254,6 +270,9 @@ for tool in ["loki", "cortex", "alertmanager"]:  # noqa: WPS335
                     ),
                 ),
             ],
+            on_error=notification(slack_notification_resource, "Grafana Pipeline Error", f"Error linting {tool} configs", alert_type="errored"),
+            on_failure=notification(slack_notification_resource, "Grafana Pipeline Failure", f"Failure linting {tool} configs", alert_type="failed"),
+            on_abort=notification(slack_notification_resource, "Grafana Pipeline Aborted", f"User Aborted Pipeline during linting {tool} configs", alert_type="aborted"),
         )
         alerting_jobs.append(linter_job)
     else:
@@ -317,11 +336,15 @@ for tool in ["loki", "cortex", "alertmanager"]:  # noqa: WPS335
                     ),
                 ),
             ],
+            on_error=notification(slack_notification_resource, "Grafana Pipeline Error", f"Error syncing {tool} configs in {stage}", alert_type="errored"),
+            on_failure=notification(slack_notification_resource, "Grafana Pipeline Failure", f"Failure syncing {tool} configs {stage}", alert_type="failed"),
+            on_abort=notification(slack_notification_resource, "Grafana Pipeline Aborted", f"User Aborted Pipeline during syncing {tool} configs in {stage}", alert_type="aborted"),
         )
         alerting_jobs.append(sync_job)
 
 alerting_combined_fragment = PipelineFragment(
-    resources=[cortex_alert_rules, loki_alert_rules, alertmanager_config],
+    resource_types=[snr_type()],
+    resources=[cortex_alert_rules, loki_alert_rules, alertmanager_config, slack_notification_resource],
     jobs=alerting_jobs,
 )
 

--- a/src/concourse/pipelines/infrastructure/grafana_cloud/pipeline.py
+++ b/src/concourse/pipelines/infrastructure/grafana_cloud/pipeline.py
@@ -38,7 +38,7 @@ loki_alert_rules = ssh_git_repo(
 )
 
 slack_notification_resource = slack_notification(
-    Identifier("slack-notification"), url="(( grizzly.slack_url ))"
+    Identifier("slack-notification"), url="((grizzly.slack_url))"
 )
 
 cortex_alert_rules = ssh_git_repo(
@@ -152,12 +152,6 @@ commit_managed_dashboards_job = Job(
         "Grafana Pipeline Aborted",
         "User Aborted Pipeline during commiting managed dashboards to GitHub",
         alert_type="aborted",
-    ),
-    on_success=notification(
-        slack_notification_resource,
-        "Grafana Pipeline Activity",
-        "Managed dashboards successfully committed to GitHub.",
-        alert_type="success",
     ),
 )
 
@@ -430,6 +424,12 @@ for tool in ["loki", "cortex", "alertmanager"]:  # noqa: WPS335
                 "Grafana Pipeline Aborted",
                 f"User Aborted Pipeline during syncing {tool} configs in {stage}",
                 alert_type="aborted",
+            ),
+            on_success=notification(
+                slack_notification_resource,
+                "Grafana Pipeline Activity",
+                f"Sync complete for {tool} configs to {stage}.",
+                alert_type="success",
             ),
         )
         alerting_jobs.append(sync_job)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This provides a straightforwards method for attaching slack notifications as 'on_error', 'on_success', 'on_abort', 'on_failure' clauses to any job. 


## Motivation and Context
Sometimes alerting is good. 

## How Has This Been Tested?
There is a demo implementation on the grafana management pipeline that updates a slack channel when grafana events take place. 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
