### PR TITLE
feat: Add config for deploying course authoring MFE

### DIFF
--- a/src/bilder/images/edxapp/templates/edxapp/mitx-staging/studio_only.yml.tmpl
+++ b/src/bilder/images/edxapp/templates/edxapp/mitx-staging/studio_only.yml.tmpl
@@ -1,7 +1,7 @@
 # ALTERNATE_WORKER_QUEUES: lms  # Already has a sane default in the code
 ADDL_INSTALLED_APPS:  # ADDED KEY
   - git_auto_export
-COURSE_AUTHORING_MICROFRONTEND_URL:
+COURSE_AUTHORING_MICROFRONTEND_URL: /course-authoring/
 GIT_REPO_EXPORT_DIR: /edx/var/edxapp/export_course_repos
 GIT_EXPORT_DEFAULT_IDENT:
   name: MITx Residential

--- a/src/bilder/images/edxapp/templates/edxapp/mitx/studio_only.yml.tmpl
+++ b/src/bilder/images/edxapp/templates/edxapp/mitx/studio_only.yml.tmpl
@@ -1,7 +1,7 @@
 # ALTERNATE_WORKER_QUEUES: lms  # Already has a sane default in the code
 ADDL_INSTALLED_APPS:  # ADDED KEY
   - git_auto_export
-COURSE_AUTHORING_MICROFRONTEND_URL:
+COURSE_AUTHORING_MICROFRONTEND_URL: /course-authoring/
 GIT_REPO_EXPORT_DIR: /edx/var/edxapp/export_course_repos
 GIT_EXPORT_DEFAULT_IDENT:
   name: MITx Residential

--- a/src/bilder/images/edxapp/templates/edxapp/mitxonline/studio_only.yml.tmpl
+++ b/src/bilder/images/edxapp/templates/edxapp/mitxonline/studio_only.yml.tmpl
@@ -1,7 +1,7 @@
 # ALTERNATE_WORKER_QUEUES: lms  # Already has a sane default in the code
 ADDL_INSTALLED_APPS:  # ADDED KEY
   - git_auto_export
-COURSE_AUTHORING_MICROFRONTEND_URL:
+COURSE_AUTHORING_MICROFRONTEND_URL: /course-authoring/
 GIT_REPO_EXPORT_DIR: /edx/var/edxapp/export_course_repos
 GIT_EXPORT_DEFAULT_IDENT:
   name: MITx Online

--- a/src/bilder/images/edxapp/templates/edxapp/xpro/studio_only.yml.tmpl
+++ b/src/bilder/images/edxapp/templates/edxapp/xpro/studio_only.yml.tmpl
@@ -1,7 +1,7 @@
 # ALTERNATE_WORKER_QUEUES: lms  # Already has a sane default in the code
 ADDL_INSTALLED_APPS:  # ADDED KEY
   - git_auto_export
-COURSE_AUTHORING_MICROFRONTEND_URL:
+COURSE_AUTHORING_MICROFRONTEND_URL: /course-authoring/
 GIT_REPO_EXPORT_DIR: /edx/var/edxapp/export_course_repos
 GIT_EXPORT_DEFAULT_IDENT:
   name: MIT xPRO

--- a/src/bridge/settings/openedx/version_matrix.py
+++ b/src/bridge/settings/openedx/version_matrix.py
@@ -346,8 +346,12 @@ ReleaseMap: dict[  # noqa: WPS234
             OpenEdxApplicationVersion(
                 application="library-authoring",  # type: ignore
                 application_type="MFE",
-                release="olive",
-                branch_override="master",
+                release="master",
+            ),
+            OpenEdxApplicationVersion(
+                application="course-authoring",  # type: ignore
+                application_type="MFE",
+                release="master",
             ),
         ],
     },

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.CI.yaml
@@ -19,9 +19,10 @@ config:
   edxapp:edxapp_release: open-release/olive.master
   edxapp:elb_healthcheck_interval: "30"
   edxapp:enabled_mfes:
+    course_authoring: course-authoring
     gradebook: gradebook
     learning: learn
-    library_authoring: authoring
+    library_authoring: library-authoring
   edxapp:google_analytics_id: ""
   edxapp:mail_domain: edxapp-mail-staging-ci.mitx.mit.edu
   edxapp:min_web_nodes: "1"

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.QA.yaml
@@ -19,6 +19,7 @@ config:
   edxapp:edxapp_release: open-release/nutmeg.master
   edxapp:elb_healthcheck_interval: "30"
   edxapp:enabled_mfes:
+    course_authoring: course-authoring
     gradebook: gradebook
     learning: learn
     library_authoring: authoring

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.CI.yaml
@@ -19,9 +19,10 @@ config:
   edxapp:edxapp_release: open-release/olive.master
   edxapp:elb_healthcheck_interval: "30"
   edxapp:enabled_mfes:
+    course_authoring: course-authoring
     gradebook: gradebook
     learning: learn
-    library_authoring: authoring
+    library_authoring: library-authoring
   edxapp:google_analytics_id: ""
   edxapp:mail_domain: edxapp-mail-ci.mitx.mit.edu
   edxapp:min_web_nodes: "1"

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.QA.yaml
@@ -20,6 +20,7 @@ config:
   edxapp:edxapp_release: open-release/nutmeg.master
   edxapp:elb_healthcheck_interval: "30"
   edxapp:enabled_mfes:
+    course_authoring: course-authoring
     gradebook: gradebook
     learning: learn
     library_authoring: authoring

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
@@ -20,6 +20,7 @@ config:
   edxapp:edxapp_release: release
   edxapp:elb_healthcheck_interval: "30"
   edxapp:enabled_mfes:
+    course_authoring: course-authoring
     gradebook: gradebook
     learning: learn
   edxapp:google_analytics_id: UA-5145472-46

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.CI.yaml
@@ -17,8 +17,10 @@ config:
   edxapp:edxapp_release: open-release/olive.master
   edxapp:elb_healthcheck_interval: "30"
   edxapp:enabled_mfes:
+    course_authoring: course-authoring
     gradebook: gradebook
     learning: learn
+    library_authoring: library-authoring
   edxapp:google_analytics_id: ""
   edxapp:mail_domain: edxapp-mail-ci.xpro.mit.edu
   edxapp:min_web_nodes: "1"


### PR DESCRIPTION
The course authoring experience in studio is getting factored into an MFE. This adds configuration for deploying that MFE in the MITx Online deployment of Open edX since it is tracking the upstream release branch.

## Description
- Add configuration to create pipelines to build and publish the course authoring MFE across our deployments
- Add configuration for MITx Online to use the course authoring MFE and update the Fastly configuration to route requests appropriately

## Motivation and Context
https://github.mit.edu/mitxonline/mitxonline-issues/issues/162

## How Has This Been Tested?
This will be tested in QA once it is merged

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
