### PR TITLE
fix: Keep the Dockerfile at Python 3.9 for Pants

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim as build
+FROM python:3.9-slim as build
 RUN apt-get update -yqq && apt-get install -yqq curl  && useradd -m app
 USER app
 RUN mkdir /home/app/workspace && chown app:app /home/app/workspace
@@ -14,7 +14,7 @@ RUN poetry export --without-hashes -o requirements.txt &&\
     pip install --force-reinstall dist/*.whl &&\
     pip install --no-cache-dir -r requirements.txt
 
-FROM python:3.11-slim
+FROM python:3.9-slim
 RUN useradd -m app
 USER app
 COPY --from=build /home/app/.local/ /usr/local/


### PR DESCRIPTION
The latest version of Python supported by Pants is still locked at 3.9 so we need to keep that version for the ol-infrastructure dockerfile.
