### PR TITLE
refactor: Use version info module for edX in MFE pipeline

### DIFF
--- a/src/bilder/images/edxapp/deploy.py
+++ b/src/bilder/images/edxapp/deploy.py
@@ -54,10 +54,8 @@ from bilder.images.edxapp.plugins.git_export_import import git_auto_export
 from bridge.lib.magic_numbers import VAULT_HTTP_PORT
 from bridge.lib.versions import CONSUL_TEMPLATE_VERSION, CONSUL_VERSION, VAULT_VERSION
 from bridge.secrets.sops import set_env_secrets
-from bridge.settings.openedx.version_matrix import (
-    OpenEdxApplication,
-    fetch_application_version,
-)
+from bridge.settings.openedx.accessors import fetch_application_version
+from bridge.settings.openedx.types import OpenEdxApplication
 
 VERSIONS = {  # noqa: WPS407
     "consul": CONSUL_VERSION,

--- a/src/bilder/images/edxapp/prebuild.py
+++ b/src/bilder/images/edxapp/prebuild.py
@@ -5,11 +5,11 @@ from pyinfra.operations import apt, files, git, server
 
 from bilder.components.baseline.steps import install_baseline_packages
 from bilder.images.edxapp.lib import EDX_RELEASE, WEB_NODE_TYPE, node_type
-from bridge.settings.openedx.version_matrix import (
-    OpenEdxApplication,
+from bridge.settings.openedx.accessors import (
     fetch_application_version,
     filter_deployments_by_release,
 )
+from bridge.settings.openedx.types import OpenEdxApplication
 
 EDX_USER = "edxapp"
 

--- a/src/bridge/settings/openedx/accessors.py
+++ b/src/bridge/settings/openedx/accessors.py
@@ -1,0 +1,66 @@
+from functools import partial
+from typing import Optional, Union
+
+from bridge.settings.openedx.types import (
+    DeploymentEnvRelease,
+    OpenEdxApplication,
+    OpenEdxApplicationType,
+    OpenEdxApplicationVersion,
+    OpenEdxDeploymentName,
+    OpenEdxMicroFrontend,
+    OpenEdxSupportedRelease,
+)
+from bridge.settings.openedx.version_matrix import (
+    OpenLearningOpenEdxDeployment,
+    ReleaseMap,
+)
+
+
+def _fetch_application_version(  # noqa: WPS234
+    release_map: dict[  # noqa: WPS320
+        OpenEdxSupportedRelease,
+        dict[OpenEdxDeploymentName, list[OpenEdxApplicationVersion]],
+    ],
+    release_name: OpenEdxSupportedRelease,
+    deployment: OpenEdxDeploymentName,
+    application_name: Union[OpenEdxApplication, OpenEdxMicroFrontend],
+) -> Optional[OpenEdxApplicationVersion]:
+    app_versions = release_map[release_name][deployment]
+    fetched_app_version = None
+    for app_version in app_versions:
+        if app_version.application == application_name:
+            fetched_app_version = app_version
+    return fetched_app_version
+
+
+def _fetch_applications_by_type(  # noqa: WPS234
+    release_map: dict[  # noqa: WPS320
+        OpenEdxSupportedRelease,
+        dict[OpenEdxDeploymentName, list[OpenEdxApplicationVersion]],
+    ],
+    release_name: OpenEdxSupportedRelease,
+    deployment: OpenEdxDeploymentName,
+    application_type: OpenEdxApplicationType,
+) -> list[OpenEdxApplicationVersion]:
+    app_versions = release_map[release_name][deployment]
+    fetched_app_versions = []
+    for app_version in app_versions:
+        if app_version.application_type == application_type:
+            fetched_app_versions.append(app_version)
+    return fetched_app_versions
+
+
+def filter_deployments_by_release(release: str) -> list[DeploymentEnvRelease]:
+    filtered_deployments = []
+    for deployment in OpenLearningOpenEdxDeployment:
+        release_match = False
+        for env_tuple in deployment.value.env_release_map:
+            if release == env_tuple.edx_release:
+                release_match = True
+        if release_match:
+            filtered_deployments.append(deployment.value)
+    return filtered_deployments
+
+
+fetch_application_version = partial(_fetch_application_version, ReleaseMap)
+fetch_applications_by_type = partial(_fetch_applications_by_type, ReleaseMap)

--- a/src/bridge/settings/openedx/version_matrix.py
+++ b/src/bridge/settings/openedx/version_matrix.py
@@ -1,415 +1,348 @@
-from collections import namedtuple
 from enum import Enum
-from typing import Literal, Optional, Union
 
-from pydantic import BaseModel
-
-
-class OpenEdxApplication(Enum):
-    codejail = "codejail"
-    edxapp = "edx-platform"
-    forum = "forum"
-    notes = "notes-api"
-    xqueue = "xqueue"
-    xqueue_watcher = "xqueue-watcher"
-    theme = "edxapp_theme"
-
-
-class OpenEdxMicroFrontend(Enum):
-    course_authoring = "course-authoring"
-    gradebook = "gradebook"
-    learn = "learn"
-    library_authoring = "library-authoring"
-
-
-EnvRelease = namedtuple("EnvRelease", ("environment", "edx_release"))
-EnvName = Literal["CI", "QA", "Production"]
-DeploymentName = Literal["mitx", "mitx-staging", "mitxonline", "xpro"]
-OpenEdxSupportedRelease = Literal["master", "olive", "maple", "nutmeg"]
-OpenEdxBranchMap: dict[OpenEdxSupportedRelease, str] = {
-    "master": "master",
-    "olive": "open-release/olive.master",
-    "nutmeg": "open-release/nutmeg.master",
-    "maple": "open-release/maple.master",
-}
-
-OpenEdxRepoMap: dict[Union[OpenEdxApplication, OpenEdxMicroFrontend], str] = {
-    OpenEdxApplication.edxapp: "https://github.com/openedx/edx-platform",
-    OpenEdxApplication.forum: "https://github.com/openedx/cs_comments_service",
-    OpenEdxApplication.notes: "https://github.com/openedx/edx-notes-api",
-    OpenEdxApplication.xqueue: "https://github.com/openedx/xqueue",
-    OpenEdxMicroFrontend.course_authoring: "https://github.com/openedx/frontend-app-course-authoring",
-    OpenEdxMicroFrontend.gradebook: "https://github.com/openedx/frontend-app-gradebook",
-    OpenEdxMicroFrontend.learn: "https://github.com/openedx/frontend-app-learning",
-    OpenEdxMicroFrontend.library_authoring: "https://github.com/openedx/frontend-app-library-authoring",
-}
-
-
-class DeploymentEnvRelease(BaseModel):
-    deployment_name: DeploymentName
-    env_release_map: list[EnvRelease]
-
-    def envs_by_release(
-        self, release_name: OpenEdxSupportedRelease
-    ) -> list[DeploymentName]:
-        return [
-            env_release.environment
-            for env_release in self.env_release_map
-            if env_release.edx_release == release_name
-        ]
-
-    def release_by_env(self, env_name: EnvName) -> Optional[OpenEdxSupportedRelease]:
-        for env_release in self.env_release_map:
-            if env_release.environment == env_name:
-                return env_release.edx_release
-        return None
-
-    @property
-    def environments(self) -> list[EnvName]:
-        return [env_release.environment for env_release in self.env_release_map]
+from bridge.settings.openedx.types import (
+    DeploymentEnvRelease,
+    EnvRelease,
+    OpenEdxApplicationVersion,
+    OpenEdxDeploymentName,
+    OpenEdxSupportedRelease,
+)
 
 
 class OpenLearningOpenEdxDeployment(Enum):
     mitx = DeploymentEnvRelease(
         deployment_name="mitx",
         env_release_map=[
-            EnvRelease("CI", "olive"),
-            EnvRelease("QA", "nutmeg"),
-            EnvRelease("Production", "nutmeg"),
+            EnvRelease("CI", OpenEdxSupportedRelease["olive"]),
+            EnvRelease("QA", OpenEdxSupportedRelease["nutmeg"]),
+            EnvRelease("Production", OpenEdxSupportedRelease["nutmeg"]),
         ],
     )
     mitx_staging = DeploymentEnvRelease(
         deployment_name="mitx-staging",
         env_release_map=[
-            EnvRelease("CI", "olive"),
-            EnvRelease("QA", "nutmeg"),
-            EnvRelease("Production", "nutmeg"),
+            EnvRelease("CI", OpenEdxSupportedRelease["olive"]),
+            EnvRelease("QA", OpenEdxSupportedRelease["nutmeg"]),
+            EnvRelease("Production", OpenEdxSupportedRelease["nutmeg"]),
         ],
     )
     mitxonline = DeploymentEnvRelease(
         deployment_name="mitxonline",
         env_release_map=[
-            EnvRelease("QA", "master"),
-            EnvRelease("Production", "master"),
+            EnvRelease("QA", OpenEdxSupportedRelease["master"]),
+            EnvRelease("Production", OpenEdxSupportedRelease["master"]),
         ],
     )
     xpro = DeploymentEnvRelease(
         deployment_name="xpro",
         env_release_map=[
-            EnvRelease("CI", "olive"),
-            EnvRelease("QA", "maple"),
-            EnvRelease("Production", "maple"),
+            EnvRelease("CI", OpenEdxSupportedRelease["olive"]),
+            EnvRelease("QA", OpenEdxSupportedRelease["maple"]),
+            EnvRelease("Production", OpenEdxSupportedRelease["maple"]),
         ],
     )
 
-
-class OpenEdxApplicationVersion(BaseModel):
-    application_name: Union[OpenEdxApplication, OpenEdxMicroFrontend]
-    release_name: OpenEdxSupportedRelease
-    # IDA == Independently Deployable Application
-    # MFE == Micro Front-End
-    application_type: Literal["MFE", "IDA"]
-    branch_override: Optional[str]
-    origin_override: Optional[str]
-
-    @property
-    def release_branch(self) -> str:
-        if self.branch_override:
-            return self.branch_override
-        if self.application_name == "edx-platform" and self.release_name == "master":
-            return "release"
-        return OpenEdxBranchMap[self.release_name]
-
-    @property
-    def git_origin(self) -> str:
-        return self.origin_override or OpenEdxRepoMap[self.application_name]
+    @classmethod
+    def get_item(cls, key: OpenEdxDeploymentName) -> DeploymentEnvRelease:
+        deployment_name_map = {
+            "mitx": cls.mitx,
+            "mitx-staging": cls.mitx_staging,
+            "mitxonline": cls.mitxonline,
+            "xpro": cls.xpro,
+        }
+        try:
+            deployment = cls[key]
+        except KeyError:
+            deployment = deployment_name_map[key]
+        return deployment.value
 
 
 ReleaseMap: dict[  # noqa: WPS234
     OpenEdxSupportedRelease,
-    dict[DeploymentName, list[OpenEdxApplicationVersion]],
+    dict[OpenEdxDeploymentName, list[OpenEdxApplicationVersion]],
 ] = {
     "olive": {
         "mitx": [
             OpenEdxApplicationVersion(
-                application_name="edx-platform",  # type: ignore
+                application="edx-platform",  # type: ignore
                 application_type="IDA",
-                release_name="olive",
+                release="olive",
             ),
             OpenEdxApplicationVersion(
-                application_name="edxapp_theme",  # type: ignore
+                application="edxapp_theme",  # type: ignore
                 application_type="IDA",
-                release_name="olive",
+                release="olive",
                 branch_override="olive",
                 origin_override="https://github.com/mitodl/mitx-theme",
             ),
             OpenEdxApplicationVersion(
-                application_name="forum",  # type: ignore
+                application="forum",  # type: ignore
                 application_type="IDA",
-                release_name="olive",
+                release="olive",
             ),
             OpenEdxApplicationVersion(
-                application_name="xqueue",  # type: ignore
+                application="xqueue",  # type: ignore
                 application_type="IDA",
-                release_name="olive",
+                release="olive",
             ),
             OpenEdxApplicationVersion(
-                application_name="learn",  # type: ignore
+                application="learning",  # type: ignore
                 application_type="MFE",
-                release_name="olive",
+                release="olive",
             ),
             OpenEdxApplicationVersion(
-                application_name="gradebook",  # type: ignore
+                application="gradebook",  # type: ignore
                 application_type="MFE",
-                release_name="olive",
+                release="olive",
             ),
             OpenEdxApplicationVersion(
-                application_name="course-authoring",  # type: ignore
+                application="course-authoring",  # type: ignore
                 application_type="MFE",
-                release_name="olive",
+                release="olive",
+            ),
+            OpenEdxApplicationVersion(
+                application="library-authoring",  # type: ignore
+                application_type="MFE",
+                release="olive",
+                branch_override="master",
             ),
         ],
         "mitx-staging": [
             OpenEdxApplicationVersion(
-                application_name="edx-platform",  # type: ignore
+                application="edx-platform",  # type: ignore
                 application_type="IDA",
-                release_name="olive",
+                release="olive",
             ),
             OpenEdxApplicationVersion(
-                application_name="edxapp_theme",  # type: ignore
+                application="edxapp_theme",  # type: ignore
                 application_type="IDA",
-                release_name="olive",
+                release="olive",
                 branch_override="olive",
                 origin_override="https://github.com/mitodl/mitx-theme",
             ),
             OpenEdxApplicationVersion(
-                application_name="forum",  # type: ignore
+                application="forum",  # type: ignore
                 application_type="IDA",
-                release_name="olive",
+                release="olive",
             ),
             OpenEdxApplicationVersion(
-                application_name="xqueue",  # type: ignore
+                application="xqueue",  # type: ignore
                 application_type="IDA",
-                release_name="olive",
+                release="olive",
             ),
             OpenEdxApplicationVersion(
-                application_name="learn",  # type: ignore
+                application="learning",  # type: ignore
                 application_type="MFE",
-                release_name="olive",
+                release="olive",
             ),
             OpenEdxApplicationVersion(
-                application_name="gradebook",  # type: ignore
+                application="gradebook",  # type: ignore
                 application_type="MFE",
-                release_name="olive",
+                release="olive",
             ),
             OpenEdxApplicationVersion(
-                application_name="course-authoring",  # type: ignore
+                application="course-authoring",  # type: ignore
                 application_type="MFE",
-                release_name="olive",
+                release="olive",
+            ),
+            OpenEdxApplicationVersion(
+                application="library-authoring",  # type: ignore
+                application_type="MFE",
+                release="olive",
+                branch_override="master",
             ),
         ],
         "xpro": [
             OpenEdxApplicationVersion(
-                application_name="edx-platform",  # type: ignore
+                application="edx-platform",  # type: ignore
                 application_type="IDA",
-                release_name="olive",
+                release="olive",
             ),
             OpenEdxApplicationVersion(
-                application_name="edxapp_theme",  # type: ignore
+                application="edxapp_theme",  # type: ignore
                 application_type="IDA",
-                release_name="olive",
+                release="olive",
                 branch_override="olive",
                 origin_override="https://github.com/mitodl/mitxpro-theme",
             ),
             OpenEdxApplicationVersion(
-                application_name="forum",  # type: ignore
+                application="forum",  # type: ignore
                 application_type="IDA",
-                release_name="olive",
+                release="olive",
             ),
             OpenEdxApplicationVersion(
-                application_name="learn",  # type: ignore
+                application="learning",  # type: ignore
                 application_type="MFE",
-                release_name="olive",
+                release="olive",
             ),
             OpenEdxApplicationVersion(
-                application_name="gradebook",  # type: ignore
+                application="gradebook",  # type: ignore
                 application_type="MFE",
-                release_name="olive",
+                release="olive",
+            ),
+            OpenEdxApplicationVersion(
+                application="library-authoring",  # type: ignore
+                application_type="MFE",
+                release="olive",
+                branch_override="master",
             ),
         ],
     },
     "nutmeg": {
         "mitx": [
             OpenEdxApplicationVersion(
-                application_name="edx-platform",  # type: ignore
+                application="edx-platform",  # type: ignore
                 application_type="IDA",
-                release_name="nutmeg",
+                release="nutmeg",
                 branch_override="mitx/nutmeg",
                 origin_override="https://github.com/mitodl/edx-platform",
             ),
             OpenEdxApplicationVersion(
-                application_name="edxapp_theme",  # type: ignore
+                application="edxapp_theme",  # type: ignore
                 application_type="IDA",
-                release_name="nutmeg",
+                release="nutmeg",
                 branch_override="nutmeg",
                 origin_override="https://github.com/mitodl/mitx-theme",
             ),
             OpenEdxApplicationVersion(
-                application_name="forum",  # type: ignore
+                application="forum",  # type: ignore
                 application_type="IDA",
-                release_name="nutmeg",
+                release="nutmeg",
             ),
             OpenEdxApplicationVersion(
-                application_name="xqueue",  # type: ignore
+                application="xqueue",  # type: ignore
                 application_type="IDA",
-                release_name="nutmeg",
+                release="nutmeg",
             ),
             OpenEdxApplicationVersion(
-                application_name="learn",  # type: ignore
+                application="learning",  # type: ignore
                 application_type="MFE",
-                release_name="nutmeg",
+                release="nutmeg",
             ),
             OpenEdxApplicationVersion(
-                application_name="gradebook",  # type: ignore
+                application="gradebook",  # type: ignore
                 application_type="MFE",
-                release_name="nutmeg",
+                release="nutmeg",
             ),
             OpenEdxApplicationVersion(
-                application_name="course-authoring",  # type: ignore
+                application="course-authoring",  # type: ignore
                 application_type="MFE",
-                release_name="nutmeg",
+                release="nutmeg",
             ),
         ],
         "mitx-staging": [
             OpenEdxApplicationVersion(
-                application_name="edx-platform",  # type: ignore
+                application="edx-platform",  # type: ignore
                 application_type="IDA",
-                release_name="nutmeg",
+                release="nutmeg",
                 branch_override="mitx/nutmeg",
                 origin_override="https://github.com/mitodl/edx-platform",
             ),
             OpenEdxApplicationVersion(
-                application_name="edxapp_theme",  # type: ignore
+                application="edxapp_theme",  # type: ignore
                 application_type="IDA",
-                release_name="nutmeg",
+                release="nutmeg",
                 branch_override="nutmeg",
                 origin_override="https://github.com/mitodl/mitx-theme",
             ),
             OpenEdxApplicationVersion(
-                application_name="forum",  # type: ignore
+                application="forum",  # type: ignore
                 application_type="IDA",
-                release_name="nutmeg",
+                release="nutmeg",
             ),
             OpenEdxApplicationVersion(
-                application_name="xqueue",  # type: ignore
+                application="xqueue",  # type: ignore
                 application_type="IDA",
-                release_name="nutmeg",
+                release="nutmeg",
             ),
             OpenEdxApplicationVersion(
-                application_name="learn",  # type: ignore
+                application="learning",  # type: ignore
                 application_type="MFE",
-                release_name="nutmeg",
+                release="nutmeg",
             ),
             OpenEdxApplicationVersion(
-                application_name="gradebook",  # type: ignore
+                application="gradebook",  # type: ignore
                 application_type="MFE",
-                release_name="nutmeg",
+                release="nutmeg",
             ),
             OpenEdxApplicationVersion(
-                application_name="course-authoring",  # type: ignore
+                application="course-authoring",  # type: ignore
                 application_type="MFE",
-                release_name="nutmeg",
+                release="nutmeg",
             ),
         ],
     },
     "maple": {
         "xpro": [
             OpenEdxApplicationVersion(
-                application_name="edx-platform",  # type: ignore
+                application="edx-platform",  # type: ignore
                 application_type="IDA",
-                release_name="maple",
+                release="maple",
             ),
             OpenEdxApplicationVersion(
-                application_name="edxapp_theme",  # type: ignore
+                application="edxapp_theme",  # type: ignore
                 application_type="IDA",
-                release_name="maple",
+                release="maple",
                 branch_override="maple",
                 origin_override="https://github.com/mitodl/mitxpro-theme",
             ),
             OpenEdxApplicationVersion(
-                application_name="forum",  # type: ignore
+                application="forum",  # type: ignore
                 application_type="IDA",
-                release_name="maple",
+                release="maple",
             ),
             OpenEdxApplicationVersion(
-                application_name="learn",  # type: ignore
+                application="learning",  # type: ignore
                 application_type="MFE",
-                release_name="maple",
+                release="maple",
+                runtime_version_override="12",
             ),
             OpenEdxApplicationVersion(
-                application_name="gradebook",  # type: ignore
+                application="gradebook",  # type: ignore
                 application_type="MFE",
-                release_name="maple",
+                release="maple",
+                runtime_version_override="12",
             ),
         ],
     },
     "master": {
         "mitxonline": [
             OpenEdxApplicationVersion(
-                application_name="edx-platform",  # type: ignore
+                application="edx-platform",  # type: ignore
                 application_type="IDA",
-                release_name="master",
+                release="master",
                 branch_override="release",
             ),
             OpenEdxApplicationVersion(
-                application_name="edxapp_theme",  # type: ignore
+                application="edxapp_theme",  # type: ignore
                 application_type="IDA",
-                release_name="master",
+                release="master",
                 branch_override="main",
                 origin_override="https://github.com/mitodl/mitxonline-theme",
             ),
             OpenEdxApplicationVersion(
-                application_name="forum",  # type: ignore
+                application="forum",  # type: ignore
                 application_type="IDA",
-                release_name="master",
+                release="master",
             ),
             OpenEdxApplicationVersion(
-                application_name="learn",  # type: ignore
+                application="learning",  # type: ignore
                 application_type="MFE",
-                release_name="master",
+                release="master",
                 branch_override="open-learning",
                 origin_override="https://github.com/mitodl/frontend-app-learning",
             ),
             OpenEdxApplicationVersion(
-                application_name="gradebook",  # type: ignore
+                application="gradebook",  # type: ignore
                 application_type="MFE",
-                release_name="master",
+                release="master",
+            ),
+            OpenEdxApplicationVersion(
+                application="library-authoring",  # type: ignore
+                application_type="MFE",
+                release="olive",
+                branch_override="master",
             ),
         ],
     },
 }
-
-
-def fetch_application_version(
-    release_name: OpenEdxSupportedRelease,
-    deployment: DeploymentName,
-    application_name: Union[OpenEdxApplication, OpenEdxMicroFrontend],
-) -> Optional[OpenEdxApplicationVersion]:
-    app_versions = ReleaseMap[release_name][deployment]
-    fetched_app_version = None
-    for app_version in app_versions:
-        if app_version.application_name == application_name:
-            fetched_app_version = app_version
-    return fetched_app_version
-
-
-def filter_deployments_by_release(release: str) -> list[DeploymentEnvRelease]:
-    filtered_deployments = []
-    for deployment in OpenLearningOpenEdxDeployment:
-        release_match = False
-        for env_tuple in deployment.value.env_release_map:
-            if release == env_tuple.edx_release:
-                release_match = True
-        if release_match:
-            filtered_deployments.append(deployment.value)
-    return filtered_deployments

--- a/src/concourse/lib/models/fragment.py
+++ b/src/concourse/lib/models/fragment.py
@@ -67,3 +67,17 @@ class PipelineFragment(BaseModel):
                 resource_identifiers.add(resource.name)
                 unique_resources.append(resource)
         return unique_resources
+
+    @classmethod
+    def combine_fragments(cls, *fragments: "PipelineFragment") -> "PipelineFragment":
+        return cls(
+            resource_types=[
+                resource_type
+                for fragment in fragments
+                for resource_type in fragment.resource_types
+            ],
+            resources=[
+                resource for fragment in fragments for resource in fragment.resources
+            ],
+            jobs=[job for fragment in fragments for job in fragment.jobs],
+        )

--- a/src/concourse/pipelines/open_edx/edx_platform/meta.py
+++ b/src/concourse/pipelines/open_edx/edx_platform/meta.py
@@ -1,6 +1,6 @@
 import sys
 
-from bridge.settings.openedx.version_matrix import OpenEdxBranchMap
+from bridge.settings.openedx.types import OpenEdxSupportedRelease
 from concourse.lib.models.pipeline import (  # noqa: WPS235
     AnonymousResource,
     Command,
@@ -75,10 +75,8 @@ def build_meta_job(release_name):
     )
 
 
-meta_jobs = [
-    build_meta_job(release_name)
-    for release_name in list(OpenEdxBranchMap.keys()) + ["meta"]
-]
+meta_jobs = [build_meta_job(release_name) for release_name in OpenEdxSupportedRelease]
+meta_jobs.append(build_meta_job("meta"))
 
 meta_pipeline = Pipeline(resources=[pipeline_code], jobs=meta_jobs)
 

--- a/src/concourse/pipelines/open_edx/mfe/values.py
+++ b/src/concourse/pipelines/open_edx/mfe/values.py
@@ -1,37 +1,40 @@
-from concourse.pipelines.open_edx.mfe.pipeline import MFEAppVars, OpenEdxVars
+from concourse.pipelines.open_edx.mfe.pipeline import OpenEdxVars
 
 mitx = [
     OpenEdxVars(
-        marketing_site_domain="lms-ci.mitx.mit.edu",
         environment="mitx-ci",
+        environment_stage="CI",
+        deployment_name="mitx",
         favicon_url="https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/favicon.ico",  # noqa: E501
         lms_domain="lms-ci.mitx.mit.edu",
         logo_url="https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/logo.png",  # noqa: E501
-        release_name="open-release/olive.master",
+        marketing_site_domain="lms-ci.mitx.mit.edu",
         site_name="MITx Residential CI",
         studio_domain="studio-ci.mitx.mit.edu",
         support_url="odl.zendesk.com/hc/en-us/requests/new",
         terms_of_service_url="https://lms-ci.mitx.mit.edu/tos",
     ),
     OpenEdxVars(
-        marketing_site_domain="mitx-qa.mitx.mit.edu",
         environment="mitx-qa",
+        environment_stage="QA",
+        deployment_name="mitx",
         favicon_url="https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/favicon.ico",  # noqa: E501
         lms_domain="mitx-qa.mitx.mit.edu",
         logo_url="https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/logo.png",  # noqa: E501
-        release_name="open-release/nutmeg.master",
+        marketing_site_domain="mitx-qa.mitx.mit.edu",
         site_name="MITx Residential QA",
         studio_domain="studio-mitx-qa.mitx.mit.edu",
         support_url="odl.zendesk.com/hc/en-us/requests/new",
         terms_of_service_url="https://mitx-qa.mitx.mit.edu/tos",
     ),
     OpenEdxVars(
-        marketing_site_domain="lms.mitx.mit.edu",
         environment="mitx-production",
+        environment_stage="Production",
+        deployment_name="mitx",
         favicon_url="https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/favicon.ico",  # noqa: E501
         lms_domain="lms.mitx.mit.edu",
         logo_url="https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/logo.png",  # noqa: E501
-        release_name="open-release/nutmeg.master",
+        marketing_site_domain="lms.mitx.mit.edu",
         site_name="MITx Residential",
         studio_domain="studio.mitx.mit.edu",
         support_url="odl.zendesk.com/hc/en-us/requests/new",
@@ -41,36 +44,39 @@ mitx = [
 
 mitx_staging = [
     OpenEdxVars(
+        deployment_name="mitx-staging",
         environment="mitx-staging-ci",
+        environment_stage="CI",
         favicon_url="https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/favicon.ico",  # noqa: E501
         lms_domain="staging-ci.mitx.mit.edu",
         logo_url="https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/logo.png",  # noqa: E501
         marketing_site_domain="staging-ci.mitx.mit.edu",
-        release_name="open-release/olive.master",
         site_name="MITx Residential Staging CI",
         studio_domain="studio-staging-ci.mitx.mit.edu",
         support_url="odl.zendesk.com/hc/en-us/requests/new",
         terms_of_service_url="https://staging-ci.mitx.mit.edu/tos",
     ),
     OpenEdxVars(
+        deployment_name="mitx-staging",
         environment="mitx-staging-qa",
+        environment_stage="QA",
         favicon_url="https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/favicon.ico",  # noqa: E501
         lms_domain="mitx-qa-draft.mitx.mit.edu",
         logo_url="https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/logo.png",  # noqa: E501
         marketing_site_domain="mitx-qa-draft.mitx.mit.edu",
-        release_name="open-release/nutmeg.master",
         site_name="MITx Residential Staging QA",
         studio_domain="studio-mitx-qa-draft.mitx.mit.edu",
         support_url="odl.zendesk.com/hc/en-us/requests/new",
         terms_of_service_url="https://mitx-qa-draft.mitx.mit.edu/tos",
     ),
     OpenEdxVars(
+        deployment_name="mitx-staging",
         environment="mitx-staging-production",
+        environment_stage="Production",
         favicon_url="https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/favicon.ico",  # noqa: E501
         lms_domain="staging.mitx.mit.edu",
         logo_url="https://raw.githubusercontent.com/mitodl/mitx-theme/master/lms/static/images/logo.png",  # noqa: E501
         marketing_site_domain="staging.mitx.mit.edu",
-        release_name="open-release/nutmeg.master",
         site_name="MITx Residential Staging",
         studio_domain="studio-staging.mitx.mit.edu",
         support_url="odl.zendesk.com/hc/en-us/requests/new",
@@ -81,13 +87,14 @@ mitx_staging = [
 mitxonline = [
     OpenEdxVars(
         contact_url="https://mitxonline.zendesk.com/hc/en-us/requests/new",
+        deployment_name="mitxonline",
         environment="mitxonline-qa",
+        environment_stage="QA",
         favicon_url="https://raw.githubusercontent.com/mitodl/mitxonline-theme/main/lms/static/images/favicon.ico",  # noqa: E501
         honor_code_url="https://rc.mitxonline.mit.edu/honor-code/",
         lms_domain="courses-qa.mitxonline.mit.edu",
         logo_url="https://raw.githubusercontent.com/mitodl/mitxonline-theme/main/lms/static/images/logo.png",  # noqa: E501
         marketing_site_domain="rc.mitxonline.mit.edu",
-        release_name="master",
         site_name="MITx Online QA",
         studio_domain="studio-qa.mitxonline.mit.edu",
         support_url="mitx-micromasters.zendesk.com/hc/",
@@ -96,13 +103,14 @@ mitxonline = [
     ),
     OpenEdxVars(
         contact_url="https://mitxonline.zendesk.com/hc/en-us/requests/new",
+        deployment_name="mitxonline",
         environment="mitxonline-production",
+        environment_stage="Production",
         favicon_url="https://raw.githubusercontent.com/mitodl/mitxonline-theme/main/lms/static/images/favicon.ico",  # noqa: E501
         honor_code_url="https://mitxonline.mit.edu/honor-code/",
         lms_domain="courses.mitxonline.mit.edu",
         logo_url="https://raw.githubusercontent.com/mitodl/mitxonline-theme/main/lms/static/images/logo.png",  # noqa: E501
         marketing_site_domain="mitxonline.mit.edu",
-        release_name="master",
         site_name="MITx Online",
         studio_domain="studio.mitxonline.mit.edu",
         support_url="mitx-micromasters.zendesk.com/hc/",
@@ -113,39 +121,42 @@ mitxonline = [
 
 xpro = [
     OpenEdxVars(
+        deployment_name="xpro",
         environment="xpro-ci",
+        environment_stage="CI",
         favicon_url="https://raw.githubusercontent.com/mitodl/mitxpro-theme/master/lms/static/images/favicon.ico",  # noqa: E501
         honor_code_url="https://ci.xpro.mit.edu/honor-code/",
         lms_domain="courses-ci.xpro.mit.edu",
         logo_url="https://raw.githubusercontent.com/mitodl/mitxpro-theme/master/lms/static/images/logo.png",  # noqa: E501
         marketing_site_domain="ci.xpro.mit.edu",
-        release_name="open-release/olive.master",
         site_name="MIT xPRO CI",
         studio_domain="studio-ci.xpro.mit.edu",
         support_url="xpro.zendesk.com/hc",
         terms_of_service_url="https://ci.xpro.mit.edu/terms-of-service/",
     ),
     OpenEdxVars(
+        deployment_name="xpro",
         environment="xpro-qa",
+        environment_stage="QA",
         favicon_url="https://raw.githubusercontent.com/mitodl/mitxpro-theme/master/lms/static/images/favicon.ico",  # noqa: E501
         honor_code_url="https://rc.xpro.mit.edu/honor-code/",
         lms_domain="courses-rc.xpro.mit.edu",
         logo_url="https://raw.githubusercontent.com/mitodl/mitxpro-theme/master/lms/static/images/logo.png",  # noqa: E501
         marketing_site_domain="rc.xpro.mit.edu",
-        release_name="open-release/maple.master",
         site_name="MIT xPRO RC",
         studio_domain="studio-rc.xpro.mit.edu",
         support_url="xpro.zendesk.com/hc",
         terms_of_service_url="https://rc.xpro.mit.edu/terms-of-service/",
     ),
     OpenEdxVars(
+        deployment_name="xpro",
         environment="xpro-production",
+        environment_stage="Production",
         favicon_url="https://raw.githubusercontent.com/mitodl/mitxpro-theme/master/lms/static/images/favicon.ico",  # noqa: E501
         honor_code_url="https://xpro.mit.edu/honor-code/",
         lms_domain="courses.xpro.mit.edu",
         logo_url="https://raw.githubusercontent.com/mitodl/mitxpro-theme/master/lms/static/images/logo.png",  # noqa: E501
         marketing_site_domain="xpro.mit.edu",
-        release_name="open-release/maple.master",
         site_name="MIT xPRO",
         studio_domain="studio.xpro.mit.edu",
         support_url="xpro.zendesk.com/hc",
@@ -153,34 +164,9 @@ xpro = [
     ),
 ]
 
-gradebook = MFEAppVars(
-    path="gradebook",
-    repository="https://github.com/openedx/frontend-app-gradebook.git",
-    node_major_version=16,  # noqa: WPS432
-)
-
-courseware = MFEAppVars(
-    path="learn",
-    repository="https://github.com/openedx/frontend-app-learning.git",
-    node_major_version=16,  # noqa: WPS432
-)
-
-library_authoring = MFEAppVars(
-    path="authoring",
-    repository="https://github.com/openedx/frontend-app-library-authoring.git",
-    node_major_version=16,  # noqa: WPS432
-)
-
-
 deployments: dict[str, list[OpenEdxVars]] = {
     "mitx": mitx,
     "mitx-staging": mitx_staging,
     "mitxonline": mitxonline,
     "xpro": xpro,
-}
-
-apps: dict[str, MFEAppVars] = {
-    "authoring": library_authoring,
-    "gradebook": gradebook,
-    "learn": courseware,
 }


### PR DESCRIPTION
Refactor the edX MFE pipelines to be easier to evolve and maintain for version upgrades and adding new MFEs

## Description
This refactors the structure to use a single pipeline object for all MFEs used for a given deployment segmented by release. This means that all MITx MFEs running the Olive release are combined in a single pipeline, etc.

In order to ensure that the right versions are used in the right places this refactor also brings in the canonical `version_matrix` module from the `bridge` package. There is also some refactoring of the `version_matrix` into separate modules within the `settings.openedx` namespace that makes it easier to read and reason about.

## Motivation and Context
The MFE pipelines are currently set to use a single version across all environments which is problematic during our upgrade cycles. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
