### PR TITLE
vault 1.12.0 hotfix

### DIFF
--- a/src/bilder/images/vault/files/vault_env_script.sh
+++ b/src/bilder/images/vault/files/vault_env_script.sh
@@ -6,4 +6,5 @@ VAULT_CLUSTER_ADDR="https://$PRIVATE_IPV4:8201"
 VAULT_KMS_KEY_ID=$(cat /var/opt/kms_key_id)
 echo "VAULT_CLUSTER_ADDR=$VAULT_CLUSTER_ADDR" | tee /etc/default/vault
 echo "VAULT_AWSKMS_SEAL_KEY_ID=$VAULT_KMS_KEY_ID" | tee -a /etc/default/vault
+echo "VAULT_ALLOW_PENDING_REMOVAL_MOUNTS=True" | tee -a /etc/default/vault
 systemctl restart vault


### PR DESCRIPTION
Setting VAULT_ALLOW_PENDING_REMOVAL_MOUNTS temporarily to allow vault to start up and give us a chance to cleanup old unsupported mountpoints.

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
