### PR TITLE
Workaround for current bad release of vector

### DIFF
--- a/src/bilder/components/vector/steps.py
+++ b/src/bilder/components/vector/steps.py
@@ -25,9 +25,15 @@ def _install_from_package():
         present=True,
     )
     _debian_pkg_repo()
+    # TODO: MAD 20221102
+    # Temp pin vector to 0.24.2-1 while we wait for a fatal bug in 0.25.0 to be resolved
+    # https://github.com/vectordotdev/vector/issues/15071
+    # Version pinning can be accomplished with server.packages simply by putting =<version> after the package name.
+    # (only validated and tested for apt backend)
+    # https://github.com/Fizzadar/pyinfra/blob/fb5edc89af863677c326bfc5264dd7ec7164f531/pyinfra/operations/apt.py#L409
     server.packages(
         name="Install Vector package",
-        packages=["vector"],
+        packages=["vector=0.24.2-1"],
         present=True,
     )
     files.directory(


### PR DESCRIPTION
Accommodating a for a bad release from vector currently blocking all ODL packer builds.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Temporary work around
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
