### PR TITLE
Online-1182 Add marketing configs and URLs

### DIFF
--- a/src/bilder/images/edxapp/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -349,7 +349,12 @@ MICROSITE_CONFIGURATION: {}
 MICROSITE_ROOT_DIR: /edx/app/edxapp/edx-microsite
 MITXPRO_CORE_REDIRECT_ALLOW_RE_LIST: ["^/(admin|auth|logout|register|api|oauth2|user_api|heartbeat|login_refresh)", "^/courses/.*/xblock/.*/handler_noauth/outcome_service_handler"]  # ADDED VALUE
 MKTG_URLS: {}
-MKTG_URL_LINK_MAP: {}
+MKTG_URL_LINK_MAP:
+    TOS: tos
+    HONOR: honor
+MKTG_URL_OVERRIDES:
+    TOS: https://{{ key "edxapp/marketing-domain" }}/terms-of-service/
+    HONOR: https://{{ key "edxapp/marketing-domain" }}/honor-code/
 MOBILE_STORE_URLS: {}
 ########################################################################################
 # Previously assumed to be unnecessary config as it duplicates code from               #


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
We want to make the footer identical to the learning MFE, Learning MFE has separate TOS and Honor links. Currently, TOS & Honor link is not working on the legacy site. Also, as mentioned in the ticket, we want to disable all other links like About, Blog, Contact, Donate, etc.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/mitodl/mitxonline/issues/1182

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested this locally by changing the settings.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
