### PR TITLE
Expire Vault backups out of S3 after 1 year

### DIFF
--- a/src/bridge/settings/openedx/types.py
+++ b/src/bridge/settings/openedx/types.py
@@ -8,7 +8,7 @@ class OpenEdxApplication(str, Enum):  # noqa: WPS600
     repository: str
 
     def __new__(cls, app: str, repository: str):
-        enum_element = str.__new__(cls, app)  # noqa: WPS609
+        enum_element = str.__new__(cls, app)
         enum_element._value_ = app  # noqa: WPS437
         enum_element.repository = repository
         return enum_element
@@ -27,7 +27,7 @@ class OpenEdxMicroFrontend(str, Enum):  # noqa: WPS600
     path: str
 
     def __new__(cls, app: str, repository: str, path: str):
-        enum_element = str.__new__(cls, app)  # noqa: WPS609
+        enum_element = str.__new__(cls, app)
         enum_element._value_ = app  # noqa: WPS437
         enum_element.repository = repository
         enum_element.path = path
@@ -67,7 +67,7 @@ class OpenEdxSupportedRelease(str, Enum):  # noqa: WPS600
     branch: str
 
     def __new__(cls, release_name: str, release_branch: str):
-        enum_element = str.__new__(cls, release_name)  # noqa: WPS609
+        enum_element = str.__new__(cls, release_name)
         enum_element._value_ = release_name  # noqa: WPS437
         enum_element.branch = release_branch
         return enum_element

--- a/src/ol_infrastructure/infrastructure/vault/__main__.py
+++ b/src/ol_infrastructure/infrastructure/vault/__main__.py
@@ -259,6 +259,13 @@ backup_bucket = s3.Bucket(
                 ),
             ],
         ),
+        s3.BucketLifecycleRuleArgs(
+            enabled=True,
+            id="delete_older_than_one_year",
+            expiration=s3.BucketLifecycleRuleExpirationArgs(
+                days=365,  # noqa: WPS432
+            ),
+        ),
     ],
     versioning=s3.BucketVersioningArgs(enabled=False),
     server_side_encryption_configuration=s3.BucketServerSideEncryptionConfigurationArgs(


### PR DESCRIPTION


## Description
Expire vault backups after 1 calendar year. 

When used in conjunction with an alert to detect when vault backups are failing, this should close #1040 

## Motivation and Context
There shouldn't really be a need to keep vault backups for more than 1 calendar year. This PR adds an expiration policy to objects in the vault-raft-backup-* buckets that will remove the objects after a year. 

"For version-enabled buckets, Amazon S3 adds a delete marker and the current version of an object is retained as a noncurrent version. **For non-versioned buckets, Amazon S3 permanently removes the object**."

## How Has This Been Tested?
Verified the policy in CI.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
