### PR TITLE
Add full pipeline for deploying edX codejail service

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
+  rev: v4.4.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer
@@ -32,14 +32,14 @@ repos:
   - id: yamllint
     args: [--format, parsable, -d, relaxed]
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.2.2
+  rev: v3.3.0
   hooks:
   - id: pyupgrade
     args:
     - --py39-plus
     - --keep-runtime-typing
 - repo: https://github.com/PyCQA/autoflake
-  rev: v1.7.7
+  rev: v2.0.0
   hooks:
   - id: autoflake
     args:

--- a/dockerfiles/openedx-codejail/Dockerfile
+++ b/dockerfiles/openedx-codejail/Dockerfile
@@ -11,6 +11,7 @@ ENV CODEJAIL_GROUP=sandbox
 ENV CODEJAIL_SANDBOX_CALLER=ubuntu
 ENV CODEJAIL_USER=sandbox
 ENV CODEJAIL_VENV=/sandbox/venv/
+ARG OPEN_EDX_BRANCH=master
 
 RUN virtualenv -p python3.8 --always-copy $CODEJAIL_VENV
 ENV PATH="$CODEJAIL_VENV/bin:$PATH"
@@ -32,7 +33,7 @@ ADD requirements.txt requirements.txt
 
 # Install dependencies
 RUN source $CODEJAIL_VENV/bin/activate && pip install --no-cache-dir --no-cache-dir -r requirements/base.txt  && \
-    pip install --no-cache-dir -r  https://github.com/openedx/edx-platform/blob/master/requirements/edx-sandbox/py38.txt && deactivate
+    pip install --no-cache-dir -r  https://github.com/openedx/edx-platform/blob/$OPEN_EDX_BRANCH/requirements/edx-sandbox/py38.txt && deactivate
 
 # Setup sudoers file
 ADD sudoers-file/01-sandbox /etc/sudoers.d/01-sandbox

--- a/src/bilder/images/codejail/codejail.pkr.hcl
+++ b/src/bilder/images/codejail/codejail.pkr.hcl
@@ -4,13 +4,17 @@ locals {
 }
 
 variable "build_environment" {
-  type        = string
-  default     = "operations-ci"
+  type    = string
+  default = "operations-ci"
 }
 
 variable "business_unit" {
-  type        = string
-  default     = "operations"
+  type    = string
+  default = "operations"
+}
+
+variable "openedx_release" {
+  type = string
 }
 
 # Available options are "web" or "worker". Used to determine which type of node to build an image for.
@@ -20,7 +24,11 @@ variable "node_type" {
 }
 
 variable "deployment" {
-  type    = string
+  type = string
+}
+
+variable "openedx_release" {
+  type = string
 }
 
 source "amazon-ebs" "codejail" {
@@ -46,10 +54,10 @@ source "amazon-ebs" "codejail" {
     purpose = "${local.app_name}-${var.node_type}"
   }
   snapshot_tags = {
-    Name           = "${local.app_name}-${var.node_type}-ami"
-    OU             = "${var.business_unit}"
-    app            = "${local.app_name}"
-    purpose        = "${local.app_name}-${var.node_type}"
+    Name    = "${local.app_name}-${var.node_type}-ami"
+    OU      = "${var.business_unit}"
+    app     = "${local.app_name}"
+    purpose = "${local.app_name}-${var.node_type}"
   }
   # Base all builds off of the most recent docker_baseline_ami built by us, based of Debian 11
   source_ami_filter {
@@ -70,10 +78,10 @@ source "amazon-ebs" "codejail" {
     random = true
   }
   tags = {
-    Name    = "${local.app_name}-${var.node_type}"
-    OU      = var.business_unit
-    app     = local.app_name
-    purpose = "${local.app_name}-${var.node_type}"
+    Name       = "${local.app_name}-${var.node_type}"
+    OU         = var.business_unit
+    app        = local.app_name
+    purpose    = "${local.app_name}-${var.node_type}"
     deployment = "${var.deployment}"
   }
 }
@@ -91,7 +99,11 @@ build {
   }
 
   provisioner "shell-local" {
-    environment_vars = ["NODE_TYPE=${var.node_type}", "DEPLOYMENT=${var.deployment}"]
-    inline           = ["pyinfra --data ssh_strict_host_key_checking=off --sudo --user ${build.User} --port ${build.Port} --key /tmp/packer-session-${build.ID}.pem ${build.Host} --chdir ${path.root} deploy.py"]
+    environment_vars = [
+      "NODE_TYPE=${var.node_type}",
+      "DEPLOYMENT=${var.deployment}",
+      "OPENEDX_RELEASE=${var.openedx_release}"
+    ]
+    inline = ["pyinfra --data ssh_strict_host_key_checking=off --sudo --user ${build.User} --port ${build.Port} --key /tmp/packer-session-${build.ID}.pem ${build.Host} --chdir ${path.root} deploy.py"]
   }
 }

--- a/src/bilder/images/codejail/deploy.py
+++ b/src/bilder/images/codejail/deploy.py
@@ -26,6 +26,7 @@ from bilder.components.hashicorp.vault.models import (
 )
 from bilder.facts.has_systemd import HasSystemd
 from bilder.lib.linux_helpers import DOCKER_COMPOSE_DIRECTORY
+from bilder.lib.openedx_helpers import set_openedx_release_env
 from bridge.lib.magic_numbers import VAULT_HTTP_PORT
 from bridge.lib.versions import CONSUL_TEMPLATE_VERSION, CONSUL_VERSION, VAULT_VERSION
 from bridge.secrets.sops import set_env_secrets
@@ -51,6 +52,7 @@ files.put(
 
 # Acceptable values mitxonline, mitx, xpro, mitx-staging
 DEPLOYMENT = os.environ["DEPLOYMENT"]
+set_openedx_release_env()
 if DEPLOYMENT not in ["mitxonline", "mitx", "xpro", "mitx-staging"]:  # noqa: WPS510
     raise ValueError(
         "DEPLOYMENT should be on these values 'mitxonline', 'mitx', 'xpro', 'mitx-staging' "  # noqa: E501

--- a/src/bilder/images/codejail/files/docker-compose.yaml
+++ b/src/bilder/images/codejail/files/docker-compose.yaml
@@ -3,9 +3,11 @@ version: "3.7"
 services:
   codejail:
     container_name: codejail
-    image: mitodl/codejail:latest
+    image: mitodl/codejail:${OPENEDX_RELEASE}
     environment:
       FLASK_CODEJAILSERVICE_HOST: "0.0.0.0"
       FLASK_CODEJAILSERVICE_PORT: "8000"
     ports:
     - 8000:8000
+    env_file:
+    - /etc/defaults/openedx

--- a/src/concourse/pipelines/open_edx/codejail/docker_packer_pulumi_pipeline.py
+++ b/src/concourse/pipelines/open_edx/codejail/docker_packer_pulumi_pipeline.py
@@ -1,0 +1,165 @@
+import sys
+
+from bridge.settings.openedx.accessors import filter_deployments_by_release
+from bridge.settings.openedx.types import DeploymentEnvRelease, OpenEdxSupportedRelease
+from bridge.settings.openedx.version_matrix import OpenLearningOpenEdxDeployment
+from concourse.lib.constants import PULUMI_CODE_PATH, PULUMI_WATCHED_PATHS
+from concourse.lib.containers import container_build_task
+from concourse.lib.jobs.infrastructure import packer_jobs, pulumi_jobs_chain
+from concourse.lib.models.fragment import PipelineFragment
+from concourse.lib.models.pipeline import (
+    GetStep,
+    Identifier,
+    Input,
+    Job,
+    Pipeline,
+    PutStep,
+)
+from concourse.lib.resources import git_repo, registry_image
+
+
+def build_codejail_pipeline(
+    release_name: str, edx_deployments: list[DeploymentEnvRelease]
+):
+    openedx_branch = OpenEdxSupportedRelease[release_name].branch
+    codejail_repo = git_repo(
+        name=Identifier("openedx-codejail-code"),
+        uri="https://github.com/eduNEXT/codejailservice",
+        branch="main",
+    )
+
+    codejail_registry_image = registry_image(  # noqa: S106
+        name=Identifier("openedx-codejail-container"),
+        image_repository="mitodl/codejail",
+        image_tag=release_name,
+        username="((dockerhub.username))",
+        password="((dockerhub.password))",
+    )
+
+    codejail_dockerfile_repo = git_repo(
+        name=Identifier("codejail-dockerfile"),
+        uri="https://github.com/mitodl/ol-infrastructure",
+        branch="main",
+        paths=["dockerfiles/openedx-codejail/Dockerfile"],
+    )
+
+    codejail_packer_code = git_repo(
+        name=Identifier("ol-infrastructure-build"),
+        uri="https://github.com/mitodl/ol-infrastructure",
+        paths=[
+            "src/bridge/settings/openedx/",
+            "src/bilder/images/codejail/",
+        ],
+    )
+
+    codejail_pulumi_code = git_repo(
+        name=Identifier("ol-infrastructure-deploy"),
+        uri="https://github.com/mitodl/ol-infrastructure",
+        branch="main",
+        paths=PULUMI_WATCHED_PATHS
+        + [PULUMI_CODE_PATH.joinpath("applications/codejail/")],
+    )
+
+    image_build_job = Job(
+        name=Identifier("build-codejail-image"),
+        plan=[
+            GetStep(get=codejail_repo.name, trigger=True),
+            GetStep(get=codejail_dockerfile_repo.name, trigger=True),
+            container_build_task(
+                inputs=[
+                    Input(name=codejail_repo.name),
+                    Input(name=codejail_dockerfile_repo.name),
+                ],
+                build_parameters={
+                    "CONTEXT": f"{codejail_dockerfile_repo.name}/dockerfiles/openedx-codejail",
+                    "BUILD_ARG_OPENEDX_COMMON_VERSION": openedx_branch,
+                },
+                build_args=[
+                    "-t $(cat ./codejail-release/commit_sha)",
+                    f"-t {openedx_branch}",
+                ],
+            ),
+            PutStep(
+                put=codejail_registry_image.name,
+                params={
+                    "image": "image/image.tar",
+                    "additional_tags": f"./{codejail_repo.name}/.git/describe_ref",
+                },
+            ),
+        ],
+    )
+
+    container_fragment = PipelineFragment(
+        resources=[codejail_repo, codejail_registry_image, codejail_dockerfile_repo],
+        jobs=[image_build_job],
+    )
+
+    loop_fragments = []
+    for deployment in filter_deployments_by_release(release_name):
+        ami_fragment = packer_jobs(
+            dependencies=[
+                GetStep(
+                    get=codejail_registry_image.name,
+                    trigger=True,
+                    passed=[image_build_job.name],
+                )
+            ],
+            image_code=codejail_packer_code,
+            packer_template_path="src/bilder/images/codejail/codejail.pkr.hcl",
+            packer_vars={
+                "deployment": deployment.deployment_name,
+                "openedx_release": release_name,
+            },
+            job_name_suffix=deployment.deployment_name,
+        )
+        loop_fragments.append(ami_fragment)
+
+        pulumi_fragment = pulumi_jobs_chain(
+            codejail_pulumi_code,
+            stack_names=[
+                f"applications.codejail.{deployment.deployment_name}.{stage}"
+                for stage in deployment.envs_by_release(release_name)
+            ],
+            project_name="ol-infrastructure-codejail-server",
+            project_source_path=PULUMI_CODE_PATH.joinpath("applications/codejail/"),
+            dependencies=[
+                GetStep(
+                    get=ami_fragment.resources[-1].name,
+                    trigger=True,
+                    passed=[ami_fragment.jobs[-1].name],
+                ),
+            ],
+        )
+        loop_fragments.append(pulumi_fragment)
+
+    combined_fragments = PipelineFragment.combine_fragments(
+        container_fragment,
+        *loop_fragments,
+    )
+
+    return Pipeline(
+        resource_types=combined_fragments.resource_types,
+        resources=combined_fragments.resources
+        + [
+            codejail_pulumi_code,
+            codejail_packer_code,
+        ],
+        jobs=combined_fragments.jobs,
+    )
+
+
+if __name__ == "__main__":
+    release_name = sys.argv[1]
+    pipeline_json = build_codejail_pipeline(
+        release_name,
+        OpenLearningOpenEdxDeployment,
+    ).json(indent=2)
+    with open("definition.json", "w") as definition:
+        definition.write(pipeline_json)
+    sys.stdout.write(pipeline_json)
+    sys.stdout.writelines(
+        (
+            "\n",
+            f"fly -t <target> set-pipeline -p docker-packer-pulumi-codejail-{release_name} -c definition.json",  # noqa: E501
+        )
+    )

--- a/src/concourse/pipelines/open_edx/codejail/meta.py
+++ b/src/concourse/pipelines/open_edx/codejail/meta.py
@@ -1,0 +1,88 @@
+import sys
+
+from bridge.settings.openedx.types import OpenEdxSupportedRelease
+from concourse.lib.models.pipeline import (  # noqa: WPS235
+    AnonymousResource,
+    Command,
+    GetStep,
+    Identifier,
+    Input,
+    Job,
+    Output,
+    Pipeline,
+    Platform,
+    SetPipelineStep,
+    TaskConfig,
+    TaskStep,
+)
+from concourse.lib.resources import git_repo
+
+pipeline_code = git_repo(
+    name=Identifier("edxapp-pipeline-code"),
+    uri="https://github.com/mitodl/ol-infrastructure",
+    paths=[
+        "src/concourse/lib/",
+        "src/concourse/pipelines/open_edx/edx_platform",
+    ],
+)
+
+
+def build_meta_job(release_name):
+    if release_name == "meta":
+        pipeline_definition_path = "src/concourse/pipelines/open_edx/codejail/meta.py"
+        pipeline_team = "main"
+        pipeline_id = "self"
+    else:
+        pipeline_definition_path = "src/concourse/pipelines/open_edx/codejail/docker_packer_pulumi_pipeline.py"  # noqa: E501
+        pipeline_team = "infrastructure"
+        pipeline_id = f"docker-packer-pulumi-edxapp-{release_name}"
+    return Job(
+        name=Identifier(f"create-codejail-{release_name}-pipeline"),
+        plan=[
+            GetStep(get=pipeline_code.name, trigger=True),
+            TaskStep(
+                task=Identifier(f"generate-{release_name}-pipeline-definition"),
+                config=TaskConfig(
+                    platform=Platform.linux,
+                    image_resource=AnonymousResource(
+                        type="registry-image",
+                        source={
+                            "repository": "mitodl/ol-infrastructure",
+                            "tag": "latest",
+                        },
+                    ),
+                    inputs=[Input(name=Identifier(pipeline_code.name))],
+                    outputs=[Output(name=Identifier("pipeline"))],
+                    run=Command(
+                        path="python",
+                        dir="pipeline",
+                        user="root",
+                        args=[
+                            f"../{pipeline_code.name}/{pipeline_definition_path}",
+                            release_name,
+                        ],
+                    ),
+                ),
+            ),
+            SetPipelineStep(
+                team=pipeline_team,
+                set_pipeline=Identifier(pipeline_id),
+                file="pipeline/definition.json",
+            ),
+        ],
+    )
+
+
+meta_jobs = [build_meta_job(release_name) for release_name in OpenEdxSupportedRelease]
+meta_jobs.append(build_meta_job("meta"))
+
+meta_pipeline = Pipeline(resources=[pipeline_code], jobs=meta_jobs)
+
+
+if __name__ == "__main__":
+    with open("definition.json", "w") as definition:
+        definition.write(meta_pipeline.json(indent=2))
+    sys.stdout.write(meta_pipeline.json(indent=2))
+    sys.stdout.write(
+        "\nfly -t <target> set-pipeline -p docker-packer-pulumi-codejail-meta -c definition.json"
+    )


### PR DESCRIPTION
## Description
This refactors the Codejail container image to use the sandbox requirements based on the corresponding edx-platform release version that the image is being built for. It also adds a pipeline definition for building the container, creating the AMI, and deploying to the target environments.

## Motivation and Context
We need to be able to run the codejail service alongside our various edx-platform installations. Each release has a slightly different set of sandbox requirements, so this will build and deploy an image that matches those requirements.

## How Has This Been Tested?
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
