### PR TITLE
refactor: Use edx version matrix for Pulumi deploys

### DIFF
--- a/src/bilder/images/edxapp/custom_install.pkr.hcl
+++ b/src/bilder/images/edxapp/custom_install.pkr.hcl
@@ -13,11 +13,9 @@ variable "build_environment" {
   default = "mitxonline-qa"
 }
 
-variable "edx_release_name" {
-  type    = string
-  default = "master"
+variable "openedx_release" {
+  type = string
 }
-
 variable "edx_platform_version" {
   type    = string
   default = "release"
@@ -61,11 +59,11 @@ source "amazon-ebs" "edxapp" {
     OU             = "${var.business_unit}"
     app            = "${local.app_name}"
     purpose        = "${local.app_name}-${var.node_type}"
-    edxapp_release = "${var.edx_platform_version}"
+    openedx_release = "${var.edx_platform_version}"
   }
   source_ami_filter {
     filters = {
-      name                = "edxapp-${var.node_type}-${var.edx_platform_version}-*"
+      name                = "edxapp-${var.node_type}-${var.openedx_release}-*"
       root-device-type    = "ebs"
       virtualization-type = "hvm"
     }
@@ -81,12 +79,12 @@ source "amazon-ebs" "edxapp" {
     random = true
   }
   tags = {
-    Name           = "${local.app_name}-${var.node_type}-${var.edx_platform_version}"
+    Name           = "${local.app_name}-${var.node_type}-${var.openedx_release}"
     OU             = "${var.business_unit}"
     app            = "${local.app_name}"
     deployment     = "${var.installation_target}"
     purpose        = "${local.app_name}-${var.node_type}"
-    edxapp_release = "${var.edx_platform_version}"
+    openedx_release = "${var.edx_platform_version}"
   }
 }
 
@@ -136,7 +134,7 @@ build {
   provisioner "shell-local" {
     environment_vars = [
       "NODE_TYPE=${var.node_type}",
-      "EDX_RELEASE_NAME=${var.edx_release_name}",
+      "OPENEDX_RELEASE=${var.openedx_release}",
       "EDX_INSTALLATION=${var.installation_target}",
     ]
     inline = [

--- a/src/bilder/images/edxapp/deploy.py
+++ b/src/bilder/images/edxapp/deploy.py
@@ -49,7 +49,7 @@ from bilder.components.vector.steps import (
     vector_service,
 )
 from bilder.facts.has_systemd import HasSystemd
-from bilder.images.edxapp.lib import EDX_RELEASE, WEB_NODE_TYPE, node_type
+from bilder.images.edxapp.lib import OPENEDX_RELEASE, WEB_NODE_TYPE, node_type
 from bilder.images.edxapp.plugins.git_export_import import git_auto_export
 from bridge.lib.magic_numbers import VAULT_HTTP_PORT
 from bridge.lib.versions import CONSUL_TEMPLATE_VERSION, CONSUL_VERSION, VAULT_VERSION
@@ -79,7 +79,7 @@ apt.packages(
 # Check out desired repository and branch for edx-platform. This lets us manage our
 # custom code without having to bake it into the base image.
 edx_version = fetch_application_version(
-    EDX_RELEASE, EDX_INSTALLATION_NAME, OpenEdxApplication.edxapp
+    OPENEDX_RELEASE, EDX_INSTALLATION_NAME, OpenEdxApplication.edxapp
 )
 edx_platform_path = "/edx/app/edxapp/edx-platform/"
 server.shell(

--- a/src/bilder/images/edxapp/edxapp_base.pkr.hcl
+++ b/src/bilder/images/edxapp/edxapp_base.pkr.hcl
@@ -14,12 +14,11 @@ variable "edx_platform_version" {
   default = "release"
 }
 
-variable "edx_ansible_branch" {
-  type    = string
-  default = "master"
+variable "openedx_release" {
+  type = string
 }
 
-variable "edx_release_name" {
+variable "edx_ansible_branch" {
   type    = string
   default = "master"
 }
@@ -56,6 +55,7 @@ source "amazon-ebs" "edxapp" {
     OU      = "${local.business_unit}"
     app     = "${local.app_name}"
     purpose = "${local.app_name}-${var.node_type}"
+    openedx_release = var.openedx_release
   }
   # Base all builds off of the most recent Ubuntu 20.04 image built by the Canonical organization.
   source_ami_filter {
@@ -80,6 +80,7 @@ source "amazon-ebs" "edxapp" {
     OU      = "${local.business_unit}"
     app     = "${local.app_name}"
     purpose = "${local.app_name}-${var.node_type}"
+    openedx_release = var.openedx_release
   }
 }
 
@@ -97,7 +98,7 @@ build {
   provisioner "shell-local" {
     environment_vars = [
       "DEBIAN_FRONTEND=noninteractive",
-      "EDX_RELEASE_NAME=${var.edx_release_name}"
+      "OPENEDX_RELEASE=${var.openedx_release}"
     ]
     inline = [
       "sleep 15",

--- a/src/bilder/images/edxapp/lib.py
+++ b/src/bilder/images/edxapp/lib.py
@@ -5,4 +5,4 @@ from bridge.settings.openedx.version_matrix import OpenEdxSupportedRelease
 WEB_NODE_TYPE = "web"
 WORKER_NODE_TYPE = "worker"
 node_type = os.environ.get("NODE_TYPE", WEB_NODE_TYPE)
-EDX_RELEASE: OpenEdxSupportedRelease = os.environ.get("EDX_RELEASE_NAME", "master")
+OPENEDX_RELEASE: OpenEdxSupportedRelease = os.environ.get("OPENEDX_RELEASE", "master")

--- a/src/bilder/images/edxapp/packer_vars/maple.pkrvars.hcl
+++ b/src/bilder/images/edxapp/packer_vars/maple.pkrvars.hcl
@@ -1,4 +1,4 @@
 build_environment    = "mitxpro-ci"
 edx_platform_version = "open-release/maple.master"
 edx_ansible_branch   = "open-release/maple.master"
-edx_release_name     = "maple"
+openedx_release     = "maple"

--- a/src/bilder/images/edxapp/packer_vars/master.pkrvars.hcl
+++ b/src/bilder/images/edxapp/packer_vars/master.pkrvars.hcl
@@ -1,4 +1,4 @@
 build_environment    = "mitxonline-ci"
 edx_platform_version = "release"
 edx_ansible_branch   = "master"
-edx_release_name     = "master"
+openedx_release     = "master"

--- a/src/bilder/images/edxapp/packer_vars/nutmeg.pkrvars.hcl
+++ b/src/bilder/images/edxapp/packer_vars/nutmeg.pkrvars.hcl
@@ -1,4 +1,4 @@
 build_environment    = "mitx-ci"
 edx_platform_version = "open-release/nutmeg.master"
 edx_ansible_branch   = "open-release/nutmeg.master"
-edx_release_name     = "nutmeg"
+openedx_release     = "nutmeg"

--- a/src/bilder/images/edxapp/packer_vars/olive.pkrvars.hcl
+++ b/src/bilder/images/edxapp/packer_vars/olive.pkrvars.hcl
@@ -1,4 +1,4 @@
 build_environment    = "mitx-ci"
 edx_platform_version = "open-release/olive.master"
 edx_ansible_branch   = "open-release/olive.master"
-edx_release_name     = "olive"
+openedx_release      = "olive"

--- a/src/bilder/images/edxapp/prebuild.py
+++ b/src/bilder/images/edxapp/prebuild.py
@@ -4,7 +4,7 @@ import tempfile
 from pyinfra.operations import apt, files, git, server
 
 from bilder.components.baseline.steps import install_baseline_packages
-from bilder.images.edxapp.lib import EDX_RELEASE, WEB_NODE_TYPE, node_type
+from bilder.images.edxapp.lib import OPENEDX_RELEASE, WEB_NODE_TYPE, node_type
 from bridge.settings.openedx.accessors import (
     fetch_application_version,
     filter_deployments_by_release,
@@ -52,9 +52,9 @@ if node_type == WEB_NODE_TYPE:
         group=EDX_USER,
         present=True,
     )
-    for deployment in filter_deployments_by_release(EDX_RELEASE):
+    for deployment in filter_deployments_by_release(OPENEDX_RELEASE):
         theme = fetch_application_version(
-            EDX_RELEASE, deployment.deployment_name, OpenEdxApplication.theme
+            OPENEDX_RELEASE, deployment.deployment_name, OpenEdxApplication.theme
         )
         git.repo(
             name="Load theme repository",

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.CI.yaml
@@ -16,7 +16,6 @@ config:
     secure: v1:TMUUvuM6tlFYbT3r:Zmp7UuIteRPHVNghhms3+xqHZT+1DZjoJU1tEjsZiny0XCTIJJXY4E+OKNEDMoblo3FR4FtQEFdU719imPMdR9zk+Kb7oh3rZzf74QmMcMlSL2P743T98MchMvM3Fa1RyBf4PgebMSNZJ9GdDg==
   edxapp:edx_xqueue_secrets:
     secure: v1:yojXnLWnr80P8t0T:sS5KRaJa6JUwEckAjQr0Ln4l/6O1ma69CHF38VhXUfG/pUUqxw1Q8XJBVzlRIVT4yzq7O6UhzRYc2dizDbw5iQsH4/54mdUhfrFreZaZSAO5Ta9uKAmzv4vG1lJ5hI5hwFsg0fm+mUKBq2LFa2tiCVAwoS64BSW1uoO4GBWTUl1hYPXZaouIX0rAd/sgzLq35w==
-  edxapp:edxapp_release: open-release/olive.master
   edxapp:elb_healthcheck_interval: "30"
   edxapp:enabled_mfes:
     course_authoring: course-authoring

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.Production.yaml
@@ -17,7 +17,6 @@ config:
     secure: v1:Yh0hsiSt2TTi7gX0:ZIMrOO7lw+EhZ6d+x5UP/Lk/41TOJ/AS2EiQQOQB0SqmR8n3F28uthxe933kplAoSnisJBwiTu3kWztLWCyc7LJqNK7KDMAGlhQY6Ow=
   edxapp:edx_xqueue_secrets:
     secure: v1:jgBYHCVD4xbM2TGu:P0rmQmQm2SYH/pQh928vZq5C5ZRXWQsKvRijEitpVjsIo5YfzyYGM84GOIQQG2FTINUdINXCGkWXHNUsfYFGq1dKcOsrql9n5nUka8k/4bWcqEuyBy0dI0bCpoEf6Ui0hL1On/Or4/rV7itDycwjIsTe7Eq6pE2oLRw+64RV77e3ho9f1M/63BC00rzYynBkaw==
-  edxapp:edxapp_release: open-release/nutmeg.master
   edxapp:enabled_mfes:
     gradebook: gradebook
     learning: learn

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.QA.yaml
@@ -16,7 +16,6 @@ config:
     secure: v1:KMWZXKBsEvC8Uaue:1Q6pU2/TB/Y6yzu1f/tjCSeA0Qmy7csbV5JxlbhyB0CBlE3fO6+hJJEnzeKJxmNIlpPMUtptddiQsgV4wl2XEFIvDAEflMWjqV51VGA=
   edxapp:edx_xqueue_secrets:
     secure: v1:qsM/S7Cb8+UOLRdj:Gv5E/h+AjiKQ2HiTNykPh35nw5ApGOVKvwwi6BMBmaHs5g4O8FtzJKe9qxvw2NLdk0wYS80Mftc66tf82Ps//38s/9q2YijplczowzYP3AinvhnFkVy1bQMHDFeiwfWP+owGT0ktv+QIfwT0D4uq1Z4K5S1sdfBQA09Hl7y6RrkxWgYMxYz/C+/w1HlMymkgsw==
-  edxapp:edxapp_release: open-release/nutmeg.master
   edxapp:elb_healthcheck_interval: "30"
   edxapp:enabled_mfes:
     course_authoring: course-authoring

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.CI.yaml
@@ -16,7 +16,6 @@ config:
     secure: v1:Cv6WRoXTzc4X0Mt/:JfUayMiJ3oXbRcmhCWfCLJqVvMAx3c8M0z4e5fXVj9L2fLMHfRVUhhQEn1O5lrbwnewNkzGIci1ArchaMiC9BpbVRYqfihQhT5/KH2UkaoVS6kvbgbL/M489Wa7AYpLxK47F/BPaBGLGkIZMesuo
   edxapp:edx_xqueue_secrets:
     secure: v1:ovK3uwt1RjhV81YB:Uw63YPpyTVNXV4jX9LnlMf/TqtnNjk+Ro0rynUf+ulEaZzot+bOCAqMlDyn5Xu7/nUx3iGwJEHVTrOnrMNlXiHCqOiYFpfFv8NIqc/x6+Q8+eJFGjcLxhqYidyQkUAZIfz9mRVCVgEjC423yfAMi+tMee05xKI6ylAy4aO7AjjfE0s8RMt1/toGhW6DF1MIDZw==
-  edxapp:edxapp_release: open-release/olive.master
   edxapp:elb_healthcheck_interval: "30"
   edxapp:enabled_mfes:
     course_authoring: course-authoring

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.Production.yaml
@@ -18,7 +18,6 @@ config:
     secure: v1:abC4Zew/4Q9nzIm8:ntKKmUgT7z8jIEgKV2EkTbSJ6zcckEH2YHHInsBo8WOGqPNydNkxidhKYZ/bXy8y8E3iBOFF0uRROTyuHhrmzcbGygu01zYGFIBe+v8=
   edxapp:edx_xqueue_secrets:
     secure: v1:MSer6cBbKNVi/Pas:v5XAeVblUaT5pyxdhhk9wn9cVjadZcHscOWhN1nlPHBsCD8/HgEtsvAjtTOWnW/yVMYaMzlIjOxoKvEw0/qNESQj0M7bFKC7/dtfU+qlrWyI0PJEVVmiz9QPLAOvl4rA8In2hJTAmN+BAREDqSRFM9YiOKmdOuoDssTGv+fD1+oC5EcFz4BKPUnbZDQ1
-  edxapp:edxapp_release: open-release/nutmeg.master
   edxapp:enabled_mfes:
     gradebook: gradebook
     learning: learn

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.QA.yaml
@@ -17,7 +17,6 @@ config:
     secure: v1:0/vZ/fZAoI9JRgrT:spK/nul4YYGNS+fn3dgRpOewZPmN5X6esiAJaJqgRY4CTjLrjSBC6VMZsXjJoDCIgVSAOoY3ClPFge6kYy02EAJMORtlHhuuBxxl2wY=
   edxapp:edx_xqueue_secrets:
     secure: v1:8gxklYODxX1veWAk:hMnDmIkA5pDq3fdkWCKpNUdF/XDhbjoGKtcffutGdgWfjZVGrRrcpIEZoDvxI/YWPB3oL12c8mpYsE75yJupx3tijTYU33Ym5+++ZauQGBlxnsbgEA4SmWHm1bPmKjQieAWt+lKcLvvkAYMS5qTalYHpTrdf9ud9CYMd8bFgT3za/RDaAEGEaw9qOqUbdJQDWA==
-  edxapp:edxapp_release: open-release/nutmeg.master
   edxapp:elb_healthcheck_interval: "30"
   edxapp:enabled_mfes:
     course_authoring: course-authoring

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
@@ -17,7 +17,6 @@ config:
     studio: studio.mitxonline.mit.edu
   edxapp:edx_forum_secrets:
     secure: v1:qzfe99Jb8n0TnEQS:Y6fSOS8lksj7WvED+V7kCtV7arDtwx7184Fw330Mwh9JDHW72rVd8y7Nm0fF8ANCcFCwDV5EwSU2Fcc+X47NHDOLCOQv16lyB6jWOF2mTr/veRax6MbXY9NlLmsfp9EBQesDCitULbkz9hyHcHT3GPI=
-  edxapp:edxapp_release: release
   edxapp:enabled_mfes:
     gradebook: gradebook
     learning: learn

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
@@ -17,7 +17,6 @@ config:
     studio: studio-qa.mitxonline.mit.edu
   edxapp:edx_forum_secrets:
     secure: v1:IqXRArQveCV+9lkE:cRaraFuN2dDmI29PD4QifOU7MrRFdszOoaUb7o3pDJordt4TSjw8fIxldWfMzNhZRLC+NS291DorO1IuN6ASdCbt5d53aMvHVt+3hA6wyuI11OFjk7U=
-  edxapp:edxapp_release: release
   edxapp:elb_healthcheck_interval: "30"
   edxapp:enabled_mfes:
     course_authoring: course-authoring

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.CI.yaml
@@ -14,7 +14,6 @@ config:
     studio: studio-ci.xpro.mit.edu
   edxapp:edx_forum_secrets:
     secure: v1:QSW6gq7cQ6t65Glo:OGJ5X4YYEi2ZdyrpnML25p10mQrodNNLaF5zyV1242ZcQz1TkRsTdpmv9HghIhgHxykYd2NK7kyRkvphd5pfI56xAg/de/8PuHNuPx5kg3IZCrFktYuE2Nyzjxhg7aGHNhA6JQEf95925WPwAG3V
-  edxapp:edxapp_release: open-release/olive.master
   edxapp:elb_healthcheck_interval: "30"
   edxapp:enabled_mfes:
     course_authoring: course-authoring

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.Production.yaml
@@ -14,7 +14,6 @@ config:
     studio: studio.xpro.mit.edu
   edxapp:edx_forum_secrets:
     secure: v1:YHqAWSdn7TNUn7d+:IBgiGsl4r8vymID8NV43rnfJy+qsJSXm/jXaWWALUfF9zXqRO4zJZhLS0d+etijGVwaZnF8v5zXlo+EczFrCe7ICHpS85zHgifbfDcw=
-  edxapp:edxapp_release: open-release/maple.master
   edxapp:enabled_mfes:
     gradebook: gradebook
     learning: learn

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.QA.yaml
@@ -14,7 +14,6 @@ config:
     studio: studio-rc.xpro.mit.edu
   edxapp:edx_forum_secrets:
     secure: v1:Tpg1BEYCoSw2D6HQ:yGnhmeKYzo+EetdiUpY/7VzE9vq+OtX/O02d6ugQwMI3D57r3yvxtsY3u+lRYwr0R2yvvVr/Lhm9xXQ3EfycxNtpOUxviHCFsL5wXLA=
-  edxapp:edxapp_release: open-release/maple.master
   edxapp:elb_healthcheck_interval: "30"
   edxapp:enabled_mfes:
     gradebook: gradebook

--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -43,6 +43,7 @@ from bridge.lib.magic_numbers import (
     IAM_ROLE_NAME_PREFIX_MAX_LENGTH,
 )
 from bridge.secrets.sops import read_yaml_secrets
+from bridge.settings.openedx.version_matrix import OpenLearningOpenEdxDeployment
 from ol_infrastructure.components.aws.cache import OLAmazonCache, OLAmazonRedisConfig
 from ol_infrastructure.components.aws.database import OLAmazonDB, OLMariaDBConfig
 from ol_infrastructure.components.services.vault import (
@@ -106,7 +107,11 @@ aws_config = AWSBase(
 consul_security_groups = consul_stack.require_output("security_groups")
 consul_provider = get_consul_provider(stack_info)
 fastly_provider = get_fastly_provider()
-edxapp_release = edxapp_config.require("edxapp_release")
+openedx_release = (
+    OpenLearningOpenEdxDeployment.get_item(stack_info.env_prefix)
+    .release_by_env(stack_info.name)
+    .value
+)
 edxapp_domains = edxapp_config.require_object("domains")
 edxapp_mfes = edxapp_config.require_object("enabled_mfes")
 edxapp_mfe_paths = list(edxapp_mfes.values())
@@ -119,7 +124,7 @@ ami_filters = [
     ec2.GetAmiFilterArgs(name="virtualization-type", values=["hvm"]),
     ec2.GetAmiFilterArgs(name="root-device-type", values=["ebs"]),
     ec2.GetAmiFilterArgs(name="tag:deployment", values=[stack_info.env_prefix]),
-    ec2.GetAmiFilterArgs(name="tag:edxapp_release", values=[edxapp_release]),
+    ec2.GetAmiFilterArgs(name="tag:openedx_release", values=[openedx_release]),
 ]
 edxapp_web_ami = ec2.get_ami(
     filters=[


### PR DESCRIPTION
## Description
This refactors the Pulumi deploys to use the values from the Open edX version matrix module that is driving our other logic. It also standardizes on `openedx_release` as the reference name for the release names (e.g. "olive", "maple", "master", etc.)

## Motivation and Context
The purpose of the `version_matrix` module is to be a single location to update version information. The Pulumi code was the last remaining place where the versions were specified in a separate location. This reconciles that to use the canonical source of truth.

## How Has This Been Tested?
It will be tested in CI once merged, but the Pulumi logic was validated manually to ensure that the version retrieved matches what's in the matrix.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
