### PR TITLE
feat: Add pipeline definition for deploying xqueue service

### DIFF
--- a/src/bridge/settings/openedx/accessors.py
+++ b/src/bridge/settings/openedx/accessors.py
@@ -62,5 +62,30 @@ def filter_deployments_by_release(release: str) -> list[DeploymentEnvRelease]:
     return filtered_deployments
 
 
+def _filter_deployments_by_application(  # noqa: WPS231, WPS234
+    release_map: dict[  # noqa: WPS320
+        OpenEdxSupportedRelease,
+        dict[OpenEdxDeploymentName, list[OpenEdxApplicationVersion]],
+    ],
+    release_name: OpenEdxSupportedRelease,
+    application_name: OpenEdxApplication,
+) -> list[DeploymentEnvRelease]:
+    filtered_deployments = []
+    for deployment in OpenLearningOpenEdxDeployment:
+        release_match = False
+        for env_tuple in deployment.value.env_release_map:
+            if release_name == env_tuple.edx_release:
+                release_match = True
+        if release_match:
+            app_versions = release_map[release_name][deployment]
+            for app_version in app_versions:
+                if app_version.application == application_name:
+                    filtered_deployments.append(deployment.value)
+    return filtered_deployments
+
+
 fetch_application_version = partial(_fetch_application_version, ReleaseMap)
 fetch_applications_by_type = partial(_fetch_applications_by_type, ReleaseMap)
+filter_deployments_by_application = partial(
+    _filter_deployments_by_application, ReleaseMap
+)

--- a/src/concourse/pipelines/open_edx/xqueue/docker_packer_pulumi_pipeline.py
+++ b/src/concourse/pipelines/open_edx/xqueue/docker_packer_pulumi_pipeline.py
@@ -1,0 +1,161 @@
+import sys
+
+from bridge.settings.openedx.accessors import filter_deployments_by_release
+from bridge.settings.openedx.types import OpenEdxSupportedRelease
+from concourse.lib.constants import PULUMI_CODE_PATH, PULUMI_WATCHED_PATHS
+from concourse.lib.containers import container_build_task
+from concourse.lib.jobs.infrastructure import packer_jobs, pulumi_jobs_chain
+from concourse.lib.models.fragment import PipelineFragment
+from concourse.lib.models.pipeline import (
+    GetStep,
+    Identifier,
+    Input,
+    Job,
+    Pipeline,
+    PutStep,
+)
+from concourse.lib.resources import git_repo, registry_image
+
+
+def build_xqueue_pipeline(release_name: str):
+    xqueue_branch = OpenEdxSupportedRelease[release_name].branch
+    xqueue_repo = git_repo(
+        name=Identifier("openedx-xqueue-code"),
+        uri="https://github.com/openedx/xqueue",
+        branch=xqueue_branch,
+    )
+
+    xqueue_registry_image = registry_image(  # noqa: S106
+        name=Identifier("openedx-xqueue-container"),
+        image_repository="mitodl/xqueue",
+        image_tag=release_name,
+        username="((dockerhub.username))",
+        password="((dockerhub.password))",
+    )
+
+    xqueue_dockerfile_repo = git_repo(
+        name=Identifier("xqueue-dockerfile"),
+        uri="https://github.com/mitodl/ol-infrastructure",
+        branch="main",
+        paths=["dockerfiles/openedx-xqueue/Dockerfile"],
+    )
+
+    xqueue_packer_code = git_repo(
+        name=Identifier("ol-infrastructure-build"),
+        uri="https://github.com/mitodl/ol-infrastructure",
+        paths=[
+            "src/bridge/settings/openedx/",
+            "src/bilder/images/xqueue/",
+        ],
+    )
+
+    xqueue_pulumi_code = git_repo(
+        name=Identifier("ol-infrastructure-deploy"),
+        uri="https://github.com/mitodl/ol-infrastructure",
+        branch="main",
+        paths=PULUMI_WATCHED_PATHS
+        + [PULUMI_CODE_PATH.joinpath("applications/xqueue/")],
+    )
+
+    image_build_job = Job(
+        name=Identifier("build-xqueue-image"),
+        plan=[
+            GetStep(get=xqueue_repo.name, trigger=True),
+            GetStep(get=xqueue_dockerfile_repo.name, trigger=True),
+            container_build_task(
+                inputs=[
+                    Input(name=xqueue_repo.name),
+                    Input(name=xqueue_dockerfile_repo.name),
+                ],
+                build_parameters={
+                    "CONTEXT": f"{xqueue_dockerfile_repo.name}/dockerfiles/openedx-xqueue",
+                    "BUILD_ARG_OPENEDX_COMMON_VERSION": xqueue_branch,
+                },
+                build_args=[
+                    "-t $(cat ./xqueue-release/commit_sha)",
+                    f"-t {xqueue_branch}",
+                ],
+            ),
+            PutStep(
+                put=xqueue_registry_image.name,
+                params={
+                    "image": "image/image.tar",
+                    "additional_tags": f"./{xqueue_repo.name}/.git/describe_ref",
+                },
+            ),
+        ],
+    )
+
+    container_fragment = PipelineFragment(
+        resources=[xqueue_repo, xqueue_registry_image, xqueue_dockerfile_repo],
+        jobs=[image_build_job],
+    )
+
+    loop_fragments = []
+    for deployment in filter_deployments_by_release(release_name):
+        ami_fragment = packer_jobs(
+            dependencies=[
+                GetStep(
+                    get=xqueue_registry_image.name,
+                    trigger=True,
+                    passed=[image_build_job.name],
+                )
+            ],
+            image_code=xqueue_packer_code,
+            packer_template_path="src/bilder/images/xqueue/xqueue.pkr.hcl",
+            packer_vars={
+                "deployment": deployment.deployment_name,
+                "openedx_release": release_name,
+            },
+            job_name_suffix=deployment.deployment_name,
+        )
+        loop_fragments.append(ami_fragment)
+
+        pulumi_fragment = pulumi_jobs_chain(
+            xqueue_pulumi_code,
+            stack_names=[
+                f"applications.xqueue.{deployment.deployment_name}.{stage}"
+                for stage in deployment.envs_by_release(release_name)
+            ],
+            project_name="ol-infrastructure-xqueue-server",
+            project_source_path=PULUMI_CODE_PATH.joinpath("applications/xqueue/"),
+            dependencies=[
+                GetStep(
+                    get=ami_fragment.resources[-1].name,
+                    trigger=True,
+                    passed=[ami_fragment.jobs[-1].name],
+                ),
+            ],
+        )
+        loop_fragments.append(pulumi_fragment)
+
+    combined_fragments = PipelineFragment.combine_fragments(
+        container_fragment,
+        *loop_fragments,
+    )
+
+    return Pipeline(
+        resource_types=combined_fragments.resource_types,
+        resources=combined_fragments.resources
+        + [
+            xqueue_pulumi_code,
+            xqueue_packer_code,
+        ],
+        jobs=combined_fragments.jobs,
+    )
+
+
+if __name__ == "__main__":
+    release_name = sys.argv[1]
+    pipeline_json = build_xqueue_pipeline(
+        release_name,
+    ).json(indent=2)
+    with open("definition.json", "w") as definition:
+        definition.write(pipeline_json)
+    sys.stdout.write(pipeline_json)
+    sys.stdout.writelines(
+        (
+            "\n",
+            f"fly -t <target> set-pipeline -p docker-packer-pulumi-xqueue-{release_name} -c definition.json",  # noqa: E501
+        )
+    )

--- a/src/concourse/pipelines/open_edx/xqueue/docker_packer_pulumi_pipeline.py
+++ b/src/concourse/pipelines/open_edx/xqueue/docker_packer_pulumi_pipeline.py
@@ -1,6 +1,6 @@
 import sys
 
-from bridge.settings.openedx.accessors import filter_deployments_by_release
+from bridge.settings.openedx.accessors import filter_deployments_by_application
 from bridge.settings.openedx.types import OpenEdxSupportedRelease
 from concourse.lib.constants import PULUMI_CODE_PATH, PULUMI_WATCHED_PATHS
 from concourse.lib.containers import container_build_task
@@ -92,7 +92,7 @@ def build_xqueue_pipeline(release_name: str):
     )
 
     loop_fragments = []
-    for deployment in filter_deployments_by_release(release_name):
+    for deployment in filter_deployments_by_application(release_name, "xqueue"):
         ami_fragment = packer_jobs(
             dependencies=[
                 GetStep(

--- a/src/concourse/pipelines/open_edx/xqueue/meta.py
+++ b/src/concourse/pipelines/open_edx/xqueue/meta.py
@@ -1,0 +1,88 @@
+import sys
+
+from bridge.settings.openedx.types import OpenEdxSupportedRelease
+from concourse.lib.models.pipeline import (  # noqa: WPS235
+    AnonymousResource,
+    Command,
+    GetStep,
+    Identifier,
+    Input,
+    Job,
+    Output,
+    Pipeline,
+    Platform,
+    SetPipelineStep,
+    TaskConfig,
+    TaskStep,
+)
+from concourse.lib.resources import git_repo
+
+pipeline_code = git_repo(
+    name=Identifier("xqueue-pipeline-code"),
+    uri="https://github.com/mitodl/ol-infrastructure",
+    paths=[
+        "src/concourse/lib/",
+        "src/concourse/pipelines/open_edx/xqueue/",
+    ],
+)
+
+
+def build_meta_job(release_name):
+    if release_name == "meta":
+        pipeline_definition_path = "src/concourse/pipelines/open_edx/xqueue/meta.py"
+        pipeline_team = "main"
+        pipeline_id = "self"
+    else:
+        pipeline_definition_path = "src/concourse/pipelines/open_edx/xqueue/docker_packer_pulumi_pipeline.py"  # noqa: E501
+        pipeline_team = "infrastructure"
+        pipeline_id = f"docker-packer-pulumi-xqueue-{release_name}"
+    return Job(
+        name=Identifier(f"create-xqueue-{release_name}-pipeline"),
+        plan=[
+            GetStep(get=pipeline_code.name, trigger=True),
+            TaskStep(
+                task=Identifier(f"generate-{release_name}-pipeline-definition"),
+                config=TaskConfig(
+                    platform=Platform.linux,
+                    image_resource=AnonymousResource(
+                        type="registry-image",
+                        source={
+                            "repository": "mitodl/ol-infrastructure",
+                            "tag": "latest",
+                        },
+                    ),
+                    inputs=[Input(name=Identifier(pipeline_code.name))],
+                    outputs=[Output(name=Identifier("pipeline"))],
+                    run=Command(
+                        path="python",
+                        dir="pipeline",
+                        user="root",
+                        args=[
+                            f"../{pipeline_code.name}/{pipeline_definition_path}",
+                            release_name,
+                        ],
+                    ),
+                ),
+            ),
+            SetPipelineStep(
+                team=pipeline_team,
+                set_pipeline=Identifier(pipeline_id),
+                file="pipeline/definition.json",
+            ),
+        ],
+    )
+
+
+meta_jobs = [build_meta_job(release_name) for release_name in OpenEdxSupportedRelease]
+meta_jobs.append(build_meta_job("meta"))
+
+meta_pipeline = Pipeline(resources=[pipeline_code], jobs=meta_jobs)
+
+
+if __name__ == "__main__":
+    with open("definition.json", "w") as definition:
+        definition.write(meta_pipeline.json(indent=2))
+    sys.stdout.write(meta_pipeline.json(indent=2))
+    sys.stdout.write(
+        "\nfly -t <target> set-pipeline -p docker-packer-pulumi-xqueue-meta -c definition.json"
+    )


### PR DESCRIPTION
This adds a pipeline for building and deploying the xqueue service to run as a standalone server apart from the edx-platform AMI.

## Description
- Add a pipeline and meta pipeline for managing deployments of the xqueue service
- Ensure that the proper version AMI gets launched with the proper environment and stage

## Motivation and Context
We need to ensure that the xqueue service is built and deployed in a consistent and automated fashion

## How Has This Been Tested?
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
