### PR TITLE
Redirecting RES.TLL-008 to permanent URL

### DIFF
--- a/src/ol_infrastructure/applications/ocw_site/redirect_dict.json
+++ b/src/ol_infrastructure/applications/ocw_site/redirect_dict.json
@@ -447,6 +447,7 @@
   "/courses/physics/8-13-14-experimental-physics-i-ii-junior-lab-fall-2007-spring-2008/labs/lab22": "307|discard|https://{{AK_HOSTHEADER}}/courses/physics/8-13-14-experimental-physics-i-ii-junior-lab-fall-2016-spring-2017/",
   "/courses/physics/8-13-14-experimental-physics-i-ii-junior-lab-fall-2007-spring-2008/labs/lab6": "307|discard|https://{{AK_HOSTHEADER}}/courses/physics/8-13-14-experimental-physics-i-ii-junior-lab-fall-2016-spring-2017/",
   "/courses/political-science": "307|discard|https://{{AK_HOSTHEADER}}/search/?d=Political%20Science&s=department_course_numbers.sort_coursenum",
+  "/courses/res-tll-008-social-and-ethical-responsibilities-of-computing-serc-fall-2021": "301|keep|https://{{AK_HOSTHEADER}}/courses/res-tll-008-social-and-ethical-responsibilities-of-computing-serc/",
   "/courses/science-technology-and-society": "307|discard|https://{{AK_HOSTHEADER}}/search/?d=Science%2C%20Technology%2C%20and%20Society&s=department_course_numbers.sort_coursenum",
   "/courses/special-programs/sp-272-culture-tech-spring-2003": "307|discard|https://{{AK_HOSTHEADER}}/courses/experimental-study-group/es-272-culture-tech-spring-2003/",
   "/courses/special-programs/sp-287-kitchen-chemistry-spring-2009": "307|discard|https://{{AK_HOSTHEADER}}/courses/experimental-study-group/es-287-kitchen-chemistry-spring-2009/",


### PR DESCRIPTION
This PR closes https://github.com/mitodl/ocw-studio/issues/1613. The course site has been republished at a new URL, and this adds a redirect https://ocw.mit.edu/courses/res-tll-008-social-and-ethical-responsibilities-of-computing-serc-fall-2021 -> https://ocw.mit.edu/courses/res-tll-008-social-and-ethical-responsibilities-of-computing-serc.