### PR TITLE
POC: Instance Refresh jobs in concourse --  

### DIFF
--- a/src/concourse/lib/tasks.py
+++ b/src/concourse/lib/tasks.py
@@ -1,0 +1,31 @@
+from concourse.lib.constants import REGISTRY_IMAGE
+from concourse.lib.models.pipeline import Command, Identifier, TaskConfig, TaskStep
+
+
+# Generates a TaskStep to perform an instance refresh from a given set of filters and queires.
+# The combination of filters and queries should be trusted to return one, and only one,
+# autoscale group name.
+def instance_refresh_task(
+    filters: str,
+    queries: str,
+) -> TaskStep:
+    return TaskStep(
+        task=Identifier("instance-refresh"),
+        privileged=False,
+        config=TaskConfig(
+            platform="linux",
+            image_resource={
+                "type": REGISTRY_IMAGE,
+                "source": {"repository": "amazon/aws-cli"},
+            },
+            params={},
+            run=Command(
+                path="sh",
+                args=[
+                    "-exc",
+                    f""" ASG_NAME=$(aws autoscaling describe-auto-scaling-groups --color on --no-cli-auto-prompt --no-cli-pager --filters {filters} --query "{queries}" --output text);
+                    aws autoscaling start-instance-refresh --color on  --no-cli-auto-prompt --no-cli-pager --auto-scaling-group-name $ASG_NAME --preferences MinHealthyPercentage=50,InstanceWarmup=120""",  # noqa: WPS318
+                ],
+            ),
+        ),
+    )

--- a/src/concourse/pipelines/infrastructure/concourse/instance_refresh.py
+++ b/src/concourse/pipelines/infrastructure/concourse/instance_refresh.py
@@ -1,0 +1,52 @@
+import sys
+
+from concourse.lib.instance_refresh import instance_refresh_task
+from concourse.lib.models.fragment import PipelineFragment
+from concourse.lib.models.pipeline import GroupConfig, Job, Pipeline
+
+environments = ["ci", "qa", "production"]
+node_classes = ["worker-infra", "worker-ocw", "worker-generic", "web"]
+
+jobs = []
+group_configs = []
+for env in environments:
+    job_names = []
+    for node_class in node_classes:
+        filter_template = f"Name=tag:concourse_type,Values={node_class} Name=tag:Environment,Values=operations-{env}"
+        query = "AutoScalingGroups[*].AutoScalingGroupName"
+        refresh_job = Job(
+            name=f"{env}-{node_class}-instance-refresh",
+            plan=[
+                instance_refresh_task(filters=filter_template, queries=query),
+            ],
+        )
+        jobs.append(refresh_job)
+        job_names.append(refresh_job.name)
+    env_group_config = GroupConfig(
+        name=env,
+        jobs=job_names,
+    )
+    group_configs.append(env_group_config)
+
+
+instance_refresh_pipeline_fragment = PipelineFragment(
+    resource_types=[],
+    resources=[],
+    jobs=jobs,
+)
+
+instance_refresh_pipeline = Pipeline(
+    resource_types=instance_refresh_pipeline_fragment.resource_types,
+    resources=instance_refresh_pipeline_fragment.resources,
+    jobs=instance_refresh_pipeline_fragment.jobs,
+    groups=group_configs,
+)
+
+if __name__ == "__main__":
+    with open("definition.json", "w") as definition:
+        definition.write(instance_refresh_pipeline.json(indent=2))
+    sys.stdout.write(instance_refresh_pipeline.json(indent=2))
+    print()  # noqa: WPS421
+    print(  # noqa: WPS421
+        "fly -t pr-inf sp -p instance-refresh-concourse -c definition.json"  # noqa: C813
+    )

--- a/src/ol_infrastructure/applications/concourse/Pulumi.applications.concourse.CI.yaml
+++ b/src/ol_infrastructure/applications/concourse/Pulumi.applications.concourse.CI.yaml
@@ -50,7 +50,7 @@ config:
     - cloud_custodian
     - infra
     instance_type: t3a.medium
-    name: infrastructure
+    name: infra
   - auto_scale:
       desired: 1
       max: 2

--- a/src/ol_infrastructure/applications/concourse/__main__.py
+++ b/src/ol_infrastructure/applications/concourse/__main__.py
@@ -599,7 +599,7 @@ web_asg = autoscaling.Group(
             propagate_at_launch=True,
         )
         for key_name, key_value in aws_config.merged_tags(
-            {"ami_id": concourse_web_ami.id}
+            {"ami_id": concourse_web_ami.id, "concourse_type": "web"}
         ).items()
     ],
 )
@@ -784,7 +784,10 @@ for worker_def in concourse_config.get_object("workers") or []:  # noqa: WPS440
                 propagate_at_launch=True,
             )
             for key_name, key_value in aws_config.merged_tags(
-                {"ami_id": concourse_worker_ami.id}
+                {
+                    "ami_id": concourse_worker_ami.id,
+                    "concourse_type": f"worker-{worker_class_name}",
+                },
             ).items()
         ],
         target_group_arns=[worker_target_group.arn],

--- a/src/ol_infrastructure/applications/concourse/iam_policies/cloud_custodian.py
+++ b/src/ol_infrastructure/applications/concourse/iam_policies/cloud_custodian.py
@@ -1,9 +1,5 @@
 from ol_infrastructure.lib.aws.iam_helper import IAM_POLICY_VERSION
 
-## TODO: MAD 2022-01-21  # noqa: E266
-## There is something wrong with this one at the moment.  # noqa: E266
-## Pulumi throws an error if you try to use it.  # noqa: E266
-
 # AWS Permissions Document
 # Allow infrastructure workers elevated permissions needed for running packer
 policy_definition = {

--- a/src/ol_infrastructure/applications/concourse/iam_policies/infra.py
+++ b/src/ol_infrastructure/applications/concourse/iam_policies/infra.py
@@ -1,9 +1,5 @@
 from ol_infrastructure.lib.aws.iam_helper import IAM_POLICY_VERSION
 
-## TODO: MAD 2022-01-21  # noqa: E266
-## There is something wrong with this one at the moment.  # noqa: E266
-## Pulumi throws an error if you try to use it.  # noqa: E266
-
 # AWS Permissions Document
 # Allow infrastructure workers elevated permissions needed for running packer
 policy_definition = {
@@ -48,6 +44,20 @@ policy_definition = {
                 "ec2:TerminateInstances",
             ],
             "Resource": "*",
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "autoscaling:StartInstanceRefresh",
+            ],
+            "Resource": "arn:aws:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/concourse-*",
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "autoscaling:DescribeAutoScalingGroups",
+            ],
+            "Resource": "arn:aws:autoscaling:*:*:*:*:*",
         },
         {
             "Effect": "Allow",


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
- Added tags to concourse autoscale groups to add in identifiying them.
- Added permissions to infra concourse workers to allow them to trigger an asg instance refresh. Cleaned up some old comments.
- Fixed concourse worker group names in CI to make consistent with other envs.
- Updated the IAM policy for infra workers to allow them to describe all autoscale groups.
- Created a shared function for generating an instance refresh task component. Created a simple pipeline for running instances refreshes against concourse autoscale groups.

## Motivation and Context
This makes an easy-mode trigger for instance refreshes against concourse environments. Mostly a proof of concept that could be expanded to other applications easily. 

Sort of closes #692 ... Didn't set up the workers / teams to allow them to do their own instance refreshes. Just seems excessive. 

## How Has This Been Tested?
Tested in CI. The Stack changes (for the tagging) need to be applied to higher envs before they can be tested there. No reason to think there will be issues. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
