### PR TITLE
Task to block a job for an aws instance refresh

### DIFF
--- a/src/concourse/lib/tasks.py
+++ b/src/concourse/lib/tasks.py
@@ -20,11 +20,48 @@ def instance_refresh_task(
             },
             params={},
             run=Command(
-                path="sh",
+                path="bash",
                 args=[
-                    "-exc",
+                    "-ec",
+                    f"""ASG_NAME=$(aws autoscaling describe-auto-scaling-groups --color on --no-cli-auto-prompt --no-cli-pager --filters {filters} --query "{queries}" --output text);
+                    aws autoscaling start-instance-refresh --color on --no-cli-auto-prompt --no-cli-pager --auto-scaling-group-name $ASG_NAME --preferences MinHealthyPercentage=50,InstanceWarmup=120""",  # noqa: WPS318
+                ],
+            ),
+        ),
+    )
+
+
+# Generates a TaskStep that can be used to block a job from completing until the most recent
+# instance refresh is completed. If no instance refresh is found, the task finishes
+# immediately. The combination filters + queries is expected to return one and only one
+# autoscale group name.
+def block_for_instance_refresh_task(
+    filters: str,
+    queries: str,
+    check_freq: int = 10,
+) -> TaskStep:
+    return TaskStep(
+        task=Identifier("block-for-instance-refresh"),
+        privileged=False,
+        config=TaskConfig(
+            platform="linux",
+            image_resource={
+                "type": REGISTRY_IMAGE,
+                "source": {"repository": "amazon/aws-cli"},
+            },
+            params={},
+            run=Command(
+                path="bash",
+                args=[
+                    "-ec",
                     f""" ASG_NAME=$(aws autoscaling describe-auto-scaling-groups --color on --no-cli-auto-prompt --no-cli-pager --filters {filters} --query "{queries}" --output text);
-                    aws autoscaling start-instance-refresh --color on  --no-cli-auto-prompt --no-cli-pager --auto-scaling-group-name $ASG_NAME --preferences MinHealthyPercentage=50,InstanceWarmup=120""",  # noqa: WPS318
+                    status="InProgress"
+                    while [ "$status" = "InProgress" ] || [ "$status" == "Pending" ] || [ "$status" == "Canceling" ]
+                    do
+                        sleep {check_freq}
+                        status=$(aws autoscaling describe-instance-refreshes --color on --no-cli-auto-prompt --no-cli-pager --auto-scaling-group-name $ASG_NAME --query "sort_by(InstanceRefreshes, &StartTime)[].{{Status: Status}}" --output text | tail -n 1)
+                        aws autoscaling describe-instance-refreshes --color on --no-cli-auto-prompt --no-cli-pager --auto-scaling-group-name $ASG_NAME --query "sort_by(InstanceRefreshes, &StartTime)[].{{InstanceRefreshId: InstanceRefreshId, StartTime: StartTime, Status: Status}}" --output text | tail -n 1
+                    done""",
                 ],
             ),
         ),

--- a/src/concourse/pipelines/infrastructure/concourse/instance_refresh.py
+++ b/src/concourse/pipelines/infrastructure/concourse/instance_refresh.py
@@ -1,8 +1,8 @@
 import sys
 
-from concourse.lib.instance_refresh import instance_refresh_task
 from concourse.lib.models.fragment import PipelineFragment
 from concourse.lib.models.pipeline import GroupConfig, Job, Pipeline
+from concourse.lib.tasks import block_for_instance_refresh_task, instance_refresh_task
 
 environments = ["ci", "qa", "production"]
 node_classes = ["worker-infra", "worker-ocw", "worker-generic", "web"]
@@ -18,6 +18,9 @@ for env in environments:
             name=f"{env}-{node_class}-instance-refresh",
             plan=[
                 instance_refresh_task(filters=filter_template, queries=query),
+                block_for_instance_refresh_task(
+                    filters=filter_template, queries=query, check_freq=10
+                ),
             ],
         )
         jobs.append(refresh_job)


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Created a re-usable concourse task that can be used to block a job from completing pending on an InstanceRefresh completing (successfully or otherwise).

Closes #1303 

## Motivation and Context
Eventually we can incorporate this in the the pulumi_jobs_chain() function and it will allow us to block a pulumi up job step until any associated instance refreshes are complete. 

## How Has This Been Tested?
For now it is only tested with the explicit instance refresh jobs that exist only for the concourse autoscale groups. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
