### PR TITLE
edxapp elasticache instance enhancements

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
@@ -27,5 +27,6 @@ config:
   edxapp:web_node_capacity: "9"
   edxapp:worker_node_capacity: "5"
   mongodb:atlas_project_id: 61f0a63f8bc1f86a073a7148
+  redis:instance_type: cache.r6g.large
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production

--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -707,6 +707,9 @@ redis_cluster_security_group = ec2.SecurityGroup(
     vpc_id=edxapp_vpc_id,
 )
 
+redis_instance_type = (
+    redis_config.get("instance_type") or defaults(stack_info)["redis"]["instance_type"]
+)
 redis_cache_config = OLAmazonRedisConfig(
     encrypt_transit=True,
     auth_token=read_yaml_secrets(
@@ -715,6 +718,7 @@ redis_cache_config = OLAmazonRedisConfig(
     cluster_mode_enabled=False,
     encrypted=True,
     engine_version="6.2",
+    instance_type=redis_instance_type,
     num_instances=3,
     shard_count=1,
     auto_upgrade=True,
@@ -725,7 +729,6 @@ redis_cache_config = OLAmazonRedisConfig(
         "elasticache_subnet"
     ],  # the name of the subnet group created in the OLVPC component resource
     tags=aws_config.tags,
-    **defaults(stack_info)["redis"],
 )
 edxapp_redis_cache = OLAmazonCache(redis_cache_config)
 edxapp_redis_consul_node = Node(

--- a/src/ol_infrastructure/lib/aws/cache_helper.py
+++ b/src/ol_infrastructure/lib/aws/cache_helper.py
@@ -1,0 +1,11 @@
+from enum import Enum, unique
+
+
+@unique
+class CacheInstanceTypes(str, Enum):  # noqa: WPS600
+    small = "cache.t3.small"
+    medium = "cache.t2.medium"
+    large = "cache.m6g.large"
+    xlarge = "cache.m6g.xlarge"
+    high_mem_large = "cache.r6g.large"
+    high_mem_xlarge = "cache.r6g.xlarge"

--- a/src/ol_infrastructure/lib/stack_defaults.py
+++ b/src/ol_infrastructure/lib/stack_defaults.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from ol_infrastructure.components.aws.database import OLReplicaDBConfig
+from ol_infrastructure.lib.aws.cache_helper import CacheInstanceTypes
 from ol_infrastructure.lib.aws.rds_helper import DBInstanceTypes
 from ol_infrastructure.lib.pulumi_helper import StackInfo
 
@@ -10,7 +11,7 @@ production_defaults = {
         "instance_size": DBInstanceTypes.general_purpose_large.value,
         "read_replica": OLReplicaDBConfig(),
     },
-    "redis": {"instance_type": "cache.m6g.large"},
+    "redis": {"instance_type": CacheInstanceTypes.large},
 }
 
 qa_defaults = {
@@ -21,7 +22,7 @@ qa_defaults = {
         "take_final_snapshot": False,
         "backup_days": 7,
     },
-    "redis": {"instance_type": "cache.t3.small"},
+    "redis": {"instance_type": CacheInstanceTypes.small},
 }
 
 ci_defaults = {
@@ -32,7 +33,7 @@ ci_defaults = {
         "take_final_snapshot": False,
         "backup_days": 1,
     },
-    "redis": {"instance_type": "cache.t3.small"},
+    "redis": {"instance_type": CacheInstanceTypes.small},
 }
 
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

- Created a means to specify an redis instance size in edxapp pulumi stacks. 
- Created a cache_helper module for holding the basic enumerated instance types for elasticache. 
- Changed the default stack parameters to reference the new enum for CacheInstanceTypes rather than straight strings.

## Motivation and Context
mitxonline production redis cluster is out of memory. No easy way existed to change the instance type for the one node. 

## How Has This Been Tested?
previewed vs mitxonline QA and production to verify expected instance type changes were present or not present as applicable.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
