### PR TITLE
Updating forum instance sizing to default to t3a.micro which it fits …

### DIFF
--- a/src/ol_infrastructure/applications/forum/Pulumi.applications.forum.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/forum/Pulumi.applications.forum.mitxonline.Production.yaml
@@ -9,6 +9,7 @@ config:
     max: 10
     min: 3
   forum:business_unit: mitxonline
+  forum:instance_type: t3a.medium
   forum:openedx_version_tag: master
   forum:target_vpc: mitxonline_vpc
   vault:address: https://vault-production.odl.mit.edu

--- a/src/ol_infrastructure/applications/forum/Pulumi.applications.forum.xpro.Production.yaml
+++ b/src/ol_infrastructure/applications/forum/Pulumi.applications.forum.xpro.Production.yaml
@@ -9,6 +9,7 @@ config:
     max: 10
     min: 3
   forum:business_unit: mitxpro
+  forum:instance_type: t3a.medium
   forum:target_vpc: xpro_vpc
   forum:openedx_version_tag: maple.master
   vault:address: https://vault-production.odl.mit.edu

--- a/src/ol_infrastructure/applications/forum/__main__.py
+++ b/src/ol_infrastructure/applications/forum/__main__.py
@@ -160,7 +160,7 @@ forum_server_security_group = ec2.SecurityGroup(
 lt_config = OLLaunchTemplateConfig(
     block_device_mappings=block_device_mappings,
     image_id=forum_server_ami.id,
-    instance_type=forum_config.get("instance_type") or InstanceTypes.burstable_medium,
+    instance_type=forum_config.get("instance_type") or InstanceTypes.burstable_micro,
     instance_profile_arn=forum_server_instance_profile.arn,
     security_groups=[
         forum_server_security_group,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Sets the default instance type to 't3a.micro' for a edx-forum instance. The docker container for a non production forum instance fits very nicely @ ~600MB of memory usage and essentially zero CPU usage. This PR leaves production environments unaltered with t3a.medium nodes but that could probably be reviewed as well. 

This isn't unprecedented, edx-notes runs on t3a.micro instances even in production. 

## Motivation and Context
Chase that paper, yo. 

## How Has This Been Tested?
Untested, low risk. Verified low memory usage on several forum instances. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
