### PR TITLE
Rightsizing xqueue instances to t3a.micro in all environments.

### DIFF
--- a/src/ol_infrastructure/applications/xqueue/__main__.py
+++ b/src/ol_infrastructure/applications/xqueue/__main__.py
@@ -164,7 +164,7 @@ xqueue_server_security_group = ec2.SecurityGroup(
 lt_config = OLLaunchTemplateConfig(
     block_device_mappings=block_device_mappings,
     image_id=xqueue_server_ami.id,
-    instance_type=xqueue_config.get("instance_type") or InstanceTypes.burstable_medium,
+    instance_type=xqueue_config.get("instance_type") or InstanceTypes.burstable_micro,
     instance_profile_arn=xqueue_server_instance_profile.arn,
     security_groups=[
         xqueue_server_security_group,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Sets the default instance type to 't3a.micro' for a xqueue instance. The docker container for a non production forum instance fits very nicely @ ~440MB of memory usage and essentially zero CPU usage. 

## Motivation and Context
Save money $$$ 

## How Has This Been Tested?
Untested, low risk. Verified memory + CPU usage across several tiers and environments. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
