### PR TITLE
Rightsizing codejail environments to t3a.micro

### DIFF
--- a/src/ol_infrastructure/applications/codejail/Pulumi.applications.codejail.mitx-staging.CI.yaml
+++ b/src/ol_infrastructure/applications/codejail/Pulumi.applications.codejail.mitx-staging.CI.yaml
@@ -5,7 +5,7 @@ config:
   aws:region: us-east-1
   codejail:auto_scale:
     desired: 1
-    max: 2
+    max: 3
     min: 1
   codejail:business_unit: residential-staging
   codejail:target_vpc: residential_mitx_staging_vpc

--- a/src/ol_infrastructure/applications/codejail/Pulumi.applications.codejail.mitx-staging.Production.yaml
+++ b/src/ol_infrastructure/applications/codejail/Pulumi.applications.codejail.mitx-staging.Production.yaml
@@ -4,8 +4,8 @@ encryptedkey: AQICAHg/+QzF9hGIaoayDitgnEVHEhuaANONVQQOnqpkIsol1gGPs5BM4bM02RE7ZR
 config:
   aws:region: us-east-1
   codejail:auto_scale:
-    desired: 3
-    max: 4
+    desired: 2
+    max: 3
     min: 2
   codejail:business_unit: residential-staging
   codejail:target_vpc: residential_mitx_staging_vpc

--- a/src/ol_infrastructure/applications/codejail/Pulumi.applications.codejail.mitx-staging.QA.yaml
+++ b/src/ol_infrastructure/applications/codejail/Pulumi.applications.codejail.mitx-staging.QA.yaml
@@ -5,7 +5,7 @@ config:
   aws:region: us-east-1
   codejail:auto_scale:
     desired: 1
-    max: 2
+    max: 3
     min: 1
   codejail:business_unit: residential-staging
   codejail:target_vpc: residential_mitx_staging_vpc

--- a/src/ol_infrastructure/applications/codejail/Pulumi.applications.codejail.mitx.CI.yaml
+++ b/src/ol_infrastructure/applications/codejail/Pulumi.applications.codejail.mitx.CI.yaml
@@ -5,7 +5,7 @@ config:
   aws:region: us-east-1
   codejail:auto_scale:
     desired: 1
-    max: 2
+    max: 3
     min: 1
   codejail:business_unit: residential
   codejail:target_vpc: residential_mitx_vpc

--- a/src/ol_infrastructure/applications/codejail/Pulumi.applications.codejail.mitx.Production.yaml
+++ b/src/ol_infrastructure/applications/codejail/Pulumi.applications.codejail.mitx.Production.yaml
@@ -4,8 +4,8 @@ encryptedkey: AQICAHg/+QzF9hGIaoayDitgnEVHEhuaANONVQQOnqpkIsol1gFmLVxyy2hwwSaJxQ
 config:
   aws:region: us-east-1
   codejail:auto_scale:
-    desired: 2
-    max: 3
+    desired: 3
+    max: 5
     min: 2
   codejail:business_unit: residential
   codejail:target_vpc: residential_mitx_vpc

--- a/src/ol_infrastructure/applications/codejail/Pulumi.applications.codejail.mitx.Production.yaml
+++ b/src/ol_infrastructure/applications/codejail/Pulumi.applications.codejail.mitx.Production.yaml
@@ -4,8 +4,8 @@ encryptedkey: AQICAHg/+QzF9hGIaoayDitgnEVHEhuaANONVQQOnqpkIsol1gFmLVxyy2hwwSaJxQ
 config:
   aws:region: us-east-1
   codejail:auto_scale:
-    desired: 5
-    max: 10
+    desired: 2
+    max: 3
     min: 2
   codejail:business_unit: residential
   codejail:target_vpc: residential_mitx_vpc

--- a/src/ol_infrastructure/applications/codejail/Pulumi.applications.codejail.mitx.QA.yaml
+++ b/src/ol_infrastructure/applications/codejail/Pulumi.applications.codejail.mitx.QA.yaml
@@ -5,7 +5,7 @@ config:
   aws:region: us-east-1
   codejail:auto_scale:
     desired: 1
-    max: 2
+    max: 3
     min: 1
   codejail:business_unit: residential
   codejail:target_vpc: residential_mitx_vpc

--- a/src/ol_infrastructure/applications/codejail/Pulumi.applications.codejail.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/codejail/Pulumi.applications.codejail.mitxonline.Production.yaml
@@ -4,8 +4,8 @@ encryptedkey: AQICAHg/+QzF9hGIaoayDitgnEVHEhuaANONVQQOnqpkIsol1gFMzAtzjNTziE5CH3
 config:
   aws:region: us-east-1
   codejail:auto_scale:
-    desired: 2
-    max: 3
+    desired: 3
+    max: 5
     min: 2
   codejail:business_unit: mitxonline
   codejail:target_vpc: mitxonline_vpc

--- a/src/ol_infrastructure/applications/codejail/Pulumi.applications.codejail.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/codejail/Pulumi.applications.codejail.mitxonline.Production.yaml
@@ -4,8 +4,8 @@ encryptedkey: AQICAHg/+QzF9hGIaoayDitgnEVHEhuaANONVQQOnqpkIsol1gFMzAtzjNTziE5CH3
 config:
   aws:region: us-east-1
   codejail:auto_scale:
-    desired: 3
-    max: 10
+    desired: 2
+    max: 3
     min: 2
   codejail:business_unit: mitxonline
   codejail:target_vpc: mitxonline_vpc

--- a/src/ol_infrastructure/applications/codejail/Pulumi.applications.codejail.xpro.Production.yaml
+++ b/src/ol_infrastructure/applications/codejail/Pulumi.applications.codejail.xpro.Production.yaml
@@ -4,8 +4,8 @@ encryptedkey: AQICAHg/+QzF9hGIaoayDitgnEVHEhuaANONVQQOnqpkIsol1gFIp45VyYwQaGk+qW
 config:
   aws:region: us-east-1
   codejail:auto_scale:
-    desired: 5
-    max: 10
+    desired: 2
+    max: 3
     min: 2
   codejail:business_unit: mitxpro
   codejail:target_vpc: xpro_vpc

--- a/src/ol_infrastructure/applications/codejail/Pulumi.applications.codejail.xpro.Production.yaml
+++ b/src/ol_infrastructure/applications/codejail/Pulumi.applications.codejail.xpro.Production.yaml
@@ -4,8 +4,8 @@ encryptedkey: AQICAHg/+QzF9hGIaoayDitgnEVHEhuaANONVQQOnqpkIsol1gFIp45VyYwQaGk+qW
 config:
   aws:region: us-east-1
   codejail:auto_scale:
-    desired: 2
-    max: 3
+    desired: 3
+    max: 5
     min: 2
   codejail:business_unit: mitxpro
   codejail:target_vpc: xpro_vpc

--- a/src/ol_infrastructure/applications/codejail/__main__.py
+++ b/src/ol_infrastructure/applications/codejail/__main__.py
@@ -133,8 +133,7 @@ codejail_server_security_group = ec2.SecurityGroup(
 lt_config = OLLaunchTemplateConfig(
     block_device_mappings=block_device_mappings,
     image_id=codejail_server_ami.id,
-    instance_type=codejail_config.get("instance_type")
-    or InstanceTypes.burstable_medium,
+    instance_type=codejail_config.get("instance_type") or InstanceTypes.burstable_micro,
     instance_profile_arn=codejail_server_instance_profile.arn,
     security_groups=[
         codejail_server_security_group,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Sets the default instance type to 't3a.micro' for a codejail instance. The docker container for a non production codejail instance fits nicely @ ~330MB of memory usage and essentially zero CPU usage. Honestly these maybe even could be t3a.nano but lets come back to that another time... 

Also sets the min/max/desired consistently across tiers and environments. Lots of codejail servers doing a whole lot of nothing out there at the moment. 

## Motivation and Context
Save money. 

## How Has This Been Tested?
Untested, low risk. Verified memory + CPU usage across several tiers and environments.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
