### PR TITLE
Small OVS pipeline + stack fix

### DIFF
--- a/src/concourse/pipelines/infrastructure/ovs/docker_packer_pulumi_pipeline.py
+++ b/src/concourse/pipelines/infrastructure/ovs/docker_packer_pulumi_pipeline.py
@@ -57,6 +57,7 @@ def build_ovs_pipeline() -> Pipeline:
         paths=PULUMI_WATCHED_PATHS
         + [
             PULUMI_CODE_PATH.joinpath("applications/odl_video_service/"),
+            "src/bridge/secrets/odl_video_service/",
         ],
     )
 

--- a/src/ol_infrastructure/applications/odl_video_service/__main__.py
+++ b/src/ol_infrastructure/applications/odl_video_service/__main__.py
@@ -480,9 +480,11 @@ ovs_server_ami = ec2.get_ami(
 block_device_mappings = [BlockDeviceMapping()]
 
 ovs_lb_config = OLLoadBalancerConfig(
-    subnets=subnets,
-    security_groups=[ovs_server_security_group],
     enable_insecure_http=True,
+    listener_cert_domain="video.odl.mit.edu",
+    listener_use_acm=True,
+    security_groups=[ovs_server_security_group],
+    subnets=subnets,
     tags=instance_tags,
 )
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated the OVS pipeline to include SOPS secrets as monitored resources for pulumi builds.

Also turns out that the primary certificate used by the app is located on the LB, not the servers themselves. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Relates to #1343 

## How Has This Been Tested?
Already running in prod.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
