### PR TITLE
Rightsize consul envs to nano / micro instances.

### DIFF
--- a/src/concourse/pipelines/infrastructure/consul/packer_pulumi_pipeline.py
+++ b/src/concourse/pipelines/infrastructure/consul/packer_pulumi_pipeline.py
@@ -53,7 +53,7 @@ for network in [
     "xpro",
 ]:
     # Missing a few stacks for some apps
-    if network in ["apps", "data"]:
+    if network in ["data"]:
         stages = ("QA", "Production")
     else:
         stages = ("CI", "QA", "Production")  # type: ignore

--- a/src/ol_infrastructure/infrastructure/consul/Pulumi.infrastructure.consul.apps.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/consul/Pulumi.infrastructure.consul.apps.CI.yaml
@@ -3,5 +3,6 @@ secretsprovider: awskms://alias/infrastructure-secrets-ci
 encryptedkey: AQICAHjs8ajWpT7YRhWXwI//wPkHX53RHlo0DjkgQOwCBTUBwQGFBeNksqO95z6Ao/qJQZ7WAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMAXWy9IRFaBBES+Q4AgEQgDt+dtb92tzc5rQQSmuWYzzQIjiyPmod+SZ61YIi5rn7m0cicnv9YJgH8eIQNsZ6OP+fDSBHTk00Bty6vA==
 config:
   aws:region: us-east-1
+  consul:instance_type: burstable_nano
   environment:business_unit: operations
   environment:vpc_reference: applications_vpc

--- a/src/ol_infrastructure/infrastructure/consul/Pulumi.infrastructure.consul.mitx-staging.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/consul/Pulumi.infrastructure.consul.mitx-staging.CI.yaml
@@ -5,3 +5,4 @@ config:
   aws:region: us-east-1
   environment:business_unit: residential-staging
   environment:vpc_reference: residential_mitx_staging_vpc
+  consul:instance_type: "t3a.nano"

--- a/src/ol_infrastructure/infrastructure/consul/Pulumi.infrastructure.consul.mitx.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/consul/Pulumi.infrastructure.consul.mitx.CI.yaml
@@ -5,3 +5,4 @@ config:
   aws:region: us-east-1
   environment:business_unit: residential
   environment:vpc_reference: residential_mitx_vpc
+  consul:instance_type: "t3a.nano"

--- a/src/ol_infrastructure/infrastructure/consul/Pulumi.infrastructure.consul.mitxonline.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/consul/Pulumi.infrastructure.consul.mitxonline.CI.yaml
@@ -5,3 +5,4 @@ config:
   aws:region: us-east-1
   environment:business_unit: mitxonline
   environment:vpc_reference: mitxonline_vpc
+  consul:instance_type: "t3a.nano"

--- a/src/ol_infrastructure/infrastructure/consul/Pulumi.infrastructure.consul.operations.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/consul/Pulumi.infrastructure.consul.operations.CI.yaml
@@ -5,3 +5,4 @@ config:
   aws:region: us-east-1
   environment:business_unit: operations
   environment:vpc_reference: operations_vpc
+  consul:instance_type: "t3a.nano"

--- a/src/ol_infrastructure/infrastructure/consul/Pulumi.infrastructure.consul.xpro.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/consul/Pulumi.infrastructure.consul.xpro.CI.yaml
@@ -5,3 +5,4 @@ config:
   aws:region: us-east-1
   environment:business_unit: mitxpro
   environment:vpc_reference: xpro_vpc
+  consul:instance_type: "t3a.nano"

--- a/src/ol_infrastructure/infrastructure/consul/__main__.py
+++ b/src/ol_infrastructure/infrastructure/consul/__main__.py
@@ -285,7 +285,7 @@ consul_ami = ec2.get_ami(
 
 # Select instance type
 instance_type_name = (
-    consul_config.get("instance_type") or InstanceTypes.burstable_medium.name
+    consul_config.get("instance_type") or InstanceTypes.burstable_micro.name
 )
 instance_type = InstanceTypes[instance_type_name].value
 

--- a/src/ol_infrastructure/lib/aws/ec2_helper.py
+++ b/src/ol_infrastructure/lib/aws/ec2_helper.py
@@ -25,6 +25,7 @@ default_egress_args = [
 
 @unique
 class InstanceTypes(str, Enum):
+    burstable_nano = "t3a.nano"
     burstable_micro = "t3a.micro"
     burstable_small = "t3a.small"
     burstable_medium = "t3a.medium"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR right-sizes our consul environments to nano / micro instances. 

CI envs : Medium -> Nano instances
QA envs : Medium -> Micro instances 

Also fixed a bug with the consul concourse pipelines (missing an environment) 

## Motivation and Context

Napkin math for estimated savings with this PR
```
CI envs (med -> nano):
$27.4480 monthly * 3 = 82.344
$3.4310 monthly * 3 = 10.293
Save 72.05 / month / env 
6 envs -> Save 432.30 / month

QA envs (med -> micro):
$27.4480 monthly * 3 = 82.344
$6.8620 monthly * 3 = 20.586
Save 61.76 / month / env 
7 envs -> Save 432.30 / month

Production envs (med -> micro):
$27.4480 monthly * 5 = 137.24
$6.8620 monthly * 5 = 34.31
Save 102.93 / month / env 
7 envs -> Save 720.51 / month

Total estimated savings / month: $1585.11
```

## How Has This Been Tested?
Verified that consul still works with the infrastructure.consul.apps.* environments. Checked memory and CPU usage across a selection of environments. Confirmed that CPU usage is minimal and CPU credit balances are 100% on all consul instances and continues to acrue of resized envs. Memory usage is universally below 512MB as far as I can see. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
