### PR TITLE
config: Add database create permission for Trino and dbt workflows

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
@@ -2,7 +2,7 @@ import json
 from typing import Any, Union
 
 from pulumi import Config, StackReference, export
-from pulumi_aws import athena, glue, iam, lakeformation, s3
+from pulumi_aws import athena, glue, iam, s3
 
 from ol_infrastructure.lib.aws.iam_helper import lint_iam_policy
 from ol_infrastructure.lib.ol_types import AWSBase
@@ -93,10 +93,6 @@ for data_stage in data_stages:
         versioning=s3.BucketVersioningArgs(enabled=True),
         tags=aws_config.merged_tags({"OU": "data"}),
     )
-    lakeformation.Resource(
-        f"lakeformation_s3_bucket_{data_stage}",
-        arn=lake_storage_bucket.arn,
-    )
     warehouse_buckets.append(lake_storage_bucket)
     s3.BucketPublicAccessBlock(
         f"ol_data_lake_s3_bucket_{data_stage}_block_public_access",
@@ -109,10 +105,6 @@ for data_stage in data_stages:
         name=f"ol_warehouse_{stack_info.env_suffix}_{data_stage}",
         description=f"Data mart for data in {data_stage} format in the {stack_info.env_suffix} environment.",  # noqa: E501
         location_uri=lake_storage_bucket.bucket.apply(lambda bucket: f"s3://{bucket}/"),
-    )
-    lakeformation.Resource(
-        f"lakeformation_warehouse_db_{data_stage}",
-        arn=warehouse_db.arn,
     )
     warehouse_dbs.append(warehouse_db)
 
@@ -146,6 +138,7 @@ query_engine_permissions: list[dict[str, Union[str, list[str]]]] = [
             "glue:BatchDeletePartition",
             "glue:BatchDeleteTable",
             "glue:BatchGetPartition",
+            "glue:CreateDatabase",
             "glue:CreateTable",
             "glue:CreatePartition",
             "glue:DeletePartition",


### PR DESCRIPTION
As part of the dbt workflow, developers need to be able to generate a namespaced schema that their work can be generated into without affecting other developers and data consumers. This adds permission for Trino to be able to create those database objects in the AWS Glue catalog.

## Description
Grant `glue:CreateDatabase` permissions to the IAM rule used by Trino

## Motivation and Context
Engineers working on dbt code need to be able to work against production data without having to create multiple copies of it. This adds the ability to work from that data.

## How Has This Been Tested?
Manually applied to the QA stack and verified that Trino was able to create a custom database via running dbt with the associated changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
