### PR TITLE
Keycloak Clustering / Cache configuration 

### DIFF
--- a/src/bilder/images/keycloak/deploy.py
+++ b/src/bilder/images/keycloak/deploy.py
@@ -119,6 +119,13 @@ files.put(
     mode="0664",
 )
 
+files.put(
+    name="Upload cache configuration xml",
+    src=str(FILES_DIRECTORY.joinpath("cache-ispn-jdbc-ping.xml")),
+    dest=str(DOCKER_COMPOSE_DIRECTORY.joinpath("cache-ispn-jdbc-ping.xml")),
+    mode="0664",
+)
+
 # Install vault, consul, consul-template
 vault_config = VaultAgentConfig(
     cache=VaultAgentCache(use_auto_auth_token="force"),  # noqa: S106

--- a/src/bilder/images/keycloak/files/.env.tmpl
+++ b/src/bilder/images/keycloak/files/.env.tmpl
@@ -9,6 +9,8 @@ KC_DB_URL_HOST="{{ keyOrDefault "keycloak/rds_host" "missing_rds_host" }}"
 KC_DB_URL_PORT="5432"
 KC_DB_URL_DATABASE="keycloak"
 
+HOST_ADDR="{{ with node }}{{ .Node.Address }}{{ end }}"
+
 {{ with secret "postgres-keycloak/creds/app" -}}
 KC_DB_USERNAME="{{ .Data.username }}"
 KC_DB_PASSWORD="{{ .Data.password }}"

--- a/src/bilder/images/keycloak/files/.env.tmpl
+++ b/src/bilder/images/keycloak/files/.env.tmpl
@@ -9,7 +9,7 @@ KC_DB_URL_HOST="{{ keyOrDefault "keycloak/rds_host" "missing_rds_host" }}"
 KC_DB_URL_PORT="5432"
 KC_DB_URL_DATABASE="keycloak"
 
-HOST_ADDR="{{ with node }}{{ .Node.Address }}{{ end }}"
+JGROUPS_DISCOVERY_EXTERNAL_IP="{{ with node }}{{ .Node.Address }}{{ end }}"
 
 {{ with secret "postgres-keycloak/creds/app" -}}
 KC_DB_USERNAME="{{ .Data.username }}"

--- a/src/bilder/images/keycloak/files/.env.tmpl
+++ b/src/bilder/images/keycloak/files/.env.tmpl
@@ -1,6 +1,8 @@
 VERSION={{ file "/etc/default/keycloak-version" }}
 KC_HOSTNAME="{{ keyOrDefault "keycloak/keycloak_host" "missing_keycloak_host" }}"
 KC_PROXY="edge"
+KC_CACHE="ispn"
+KC_CACHE_STACK="ec2"
 
 KC_DB="postgres"
 KC_DB_URL_HOST="{{ keyOrDefault "keycloak/rds_host" "missing_rds_host" }}"

--- a/src/bilder/images/keycloak/files/.env.tmpl
+++ b/src/bilder/images/keycloak/files/.env.tmpl
@@ -2,7 +2,7 @@ VERSION={{ file "/etc/default/keycloak-version" }}
 KC_HOSTNAME="{{ keyOrDefault "keycloak/keycloak_host" "missing_keycloak_host" }}"
 KC_PROXY="edge"
 KC_CACHE="ispn"
-KC_CACHE_STACK="ec2"
+KC_CACHE_CONFIG_FILE="cache-ispn-jdbc-ping.xml"
 
 KC_DB="postgres"
 KC_DB_URL_HOST="{{ keyOrDefault "keycloak/rds_host" "missing_rds_host" }}"

--- a/src/bilder/images/keycloak/files/cache-ispn-jdbc-ping.xml
+++ b/src/bilder/images/keycloak/files/cache-ispn-jdbc-ping.xml
@@ -29,7 +29,7 @@
       connection_username="${env.KC_DB_USERNAME}" connection_password="${env.KC_DB_PASSWORD}"
       connection_url="jdbc:postgresql://${env.KC_DB_URL_HOST}:${env.KC_DB_URL_PORT}/${env.KC_DB_URL_DATABASE}"
       initialize_sql="CREATE TABLE IF NOT EXISTS JGROUPSPING (own_addr varchar(200) NOT NULL, bind_addr VARCHAR(200) NOT NULL, created timestamp NOT NULL, cluster_name varchar(200) NOT NULL, ping_data BYTEA, constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name));"
-      insert_single_sql="INSERT INTO JGROUPSPING (own_addr, bind_addr, created, cluster_name, ping_data) values (?,'${jboss.bind.address:127.0.0.1}',NOW(), ?, ?);"
+      insert_single_sql="INSERT INTO JGROUPSPING (own_addr, bind_addr, created, cluster_name, ping_data) values (?,'${env.HOST_ADDR:127.0.0.1}',NOW(), ?, ?);"
       delete_single_sql="DELETE FROM JGROUPSPING WHERE own_addr=? AND cluster_name=?;"
       select_all_pingdata_sql="SELECT ping_data FROM JGROUPSPING WHERE cluster_name=?;"
       info_writer_sleep_time="500"

--- a/src/bilder/images/keycloak/files/cache-ispn-jdbc-ping.xml
+++ b/src/bilder/images/keycloak/files/cache-ispn-jdbc-ping.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Copyright 2019 Red Hat, Inc. and/or its affiliates
+~ and other contributors as indicated by the @author tags.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~ http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+
+<infinispan
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="urn:infinispan:config:11.0 http://www.infinispan.org/schemas/infinispan-config-11.0.xsd"
+  xmlns="urn:infinispan:config:11.0">
+
+<jgroups>
+  <stack name="jdbc-ping-tcp" extends="tcp">
+
+    <!-- https://keycloak.discourse.group/t/use-of-jdbc-ping-with-keycloak-17-quarkus-distro/13571/4 -->
+    <JDBC_PING connection_driver="org.postgresql.Driver"
+      connection_username="${env.KC_DB_USERNAME}" connection_password="${env.KC_DB_PASSWORD}"
+      connection_url="jdbc:postgresql://${env.KC_DB_URL_HOST}:${env.KC_DB_URL_PORT}/${env.KC_DB_URL_DATABASE}"
+      initialize_sql="CREATE TABLE IF NOT EXISTS JGROUPSPING (own_addr varchar(200) NOT NULL, bind_addr VARCHAR(200) NOT NULL, created timestamp NOT NULL, cluster_name varchar(200) NOT NULL, ping_data BYTEA, constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name));"
+      insert_single_sql="INSERT INTO JGROUPSPING (own_addr, bind_addr, created, cluster_name, ping_data) values (?,'${jboss.bind.address:127.0.0.1}',NOW(), ?, ?);"
+      delete_single_sql="DELETE FROM JGROUPSPING WHERE own_addr=? AND cluster_name=?;"
+      select_all_pingdata_sql="SELECT ping_data FROM JGROUPSPING WHERE cluster_name=?;"
+      info_writer_sleep_time="500"
+      remove_all_data_on_view_change="true"
+      stack.combine="REPLACE"
+      stack.position="MPING"/>
+  </stack>
+</jgroups>
+
+<cache-container name="keycloak">
+  <!-- custom stack must be referenced by name in the stack attribute of the transport element -->
+  <transport lock-timeout="60000" stack="jdbc-ping-tcp"/>
+  <local-cache name="realms">
+    <encoding>
+      <key media-type="application/x-java-object"/>
+      <value media-type="application/x-java-object"/>
+    </encoding>
+    <memory max-count="10000"/>
+  </local-cache>
+  <local-cache name="users">
+    <encoding>
+      <key media-type="application/x-java-object"/>
+      <value media-type="application/x-java-object"/>
+    </encoding>
+    <memory max-count="10000"/>
+  </local-cache>
+  <distributed-cache name="sessions" owners="2">
+    <expiration lifespan="-1"/>
+  </distributed-cache>
+  <distributed-cache name="authenticationSessions" owners="2">
+    <expiration lifespan="-1"/>
+  </distributed-cache>
+  <distributed-cache name="offlineSessions" owners="2">
+    <expiration lifespan="-1"/>
+  </distributed-cache>
+  <distributed-cache name="clientSessions" owners="2">
+    <expiration lifespan="-1"/>
+  </distributed-cache>
+  <distributed-cache name="offlineClientSessions" owners="2">
+    <expiration lifespan="-1"/>
+  </distributed-cache>
+  <distributed-cache name="loginFailures" owners="2">
+    <expiration lifespan="-1"/>
+  </distributed-cache>
+  <local-cache name="authorization">
+    <encoding>
+      <key media-type="application/x-java-object"/>
+      <value media-type="application/x-java-object"/>
+    </encoding>
+    <memory max-count="10000"/>
+  </local-cache>
+  <replicated-cache name="work">
+    <expiration lifespan="-1"/>
+  </replicated-cache>
+  <local-cache name="keys">
+    <encoding>
+      <key media-type="application/x-java-object"/>
+      <value media-type="application/x-java-object"/>
+    </encoding>
+    <expiration max-idle="3600000"/>
+    <memory max-count="1000"/>
+  </local-cache>
+  <distributed-cache name="actionTokens" owners="2">
+    <encoding>
+      <key media-type="application/x-java-object"/>
+      <value media-type="application/x-java-object"/>
+    </encoding>
+    <expiration max-idle="-1" lifespan="-1" interval="300000"/>
+    <memory max-count="-1"/>
+  </distributed-cache>
+</cache-container>
+</infinispan>

--- a/src/bilder/images/keycloak/files/cache-ispn-jdbc-ping.xml
+++ b/src/bilder/images/keycloak/files/cache-ispn-jdbc-ping.xml
@@ -15,33 +15,75 @@
 ~ See the License for the specific language governing permissions and
 ~ limitations under the License.
 -->
+<!--
+~ Sourced from: https://github.com/ivangfr/keycloak-clustered
+-->
 
 <infinispan
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="urn:infinispan:config:11.0 http://www.infinispan.org/schemas/infinispan-config-11.0.xsd"
   xmlns="urn:infinispan:config:11.0">
-
 <jgroups>
-  <stack name="jdbc-ping-tcp" extends="tcp">
-
-    <!-- https://keycloak.discourse.group/t/use-of-jdbc-ping-with-keycloak-17-quarkus-distro/13571/4 -->
-    <JDBC_PING connection_driver="org.postgresql.Driver"
+  <stack name="mysql-jdbc-ping-tcp" extends="tcp">
+    <TCP external_addr="${env.JGROUPS_DISCOVERY_EXTERNAL_IP:127.0.0.1}" />
+    <JDBC_PING connection_driver="com.mysql.jdbc.Driver"
       connection_username="${env.KC_DB_USERNAME}" connection_password="${env.KC_DB_PASSWORD}"
-      connection_url="jdbc:postgresql://${env.KC_DB_URL_HOST}:${env.KC_DB_URL_PORT}/${env.KC_DB_URL_DATABASE}"
-      initialize_sql="CREATE TABLE IF NOT EXISTS JGROUPSPING (own_addr varchar(200) NOT NULL, bind_addr VARCHAR(200) NOT NULL, created timestamp NOT NULL, cluster_name varchar(200) NOT NULL, ping_data BYTEA, constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name));"
-      insert_single_sql="INSERT INTO JGROUPSPING (own_addr, bind_addr, created, cluster_name, ping_data) values (?,'${env.HOST_ADDR:127.0.0.1}',NOW(), ?, ?);"
+      connection_url="jdbc:mysql://${env.KC_DB_URL_HOST}/${env.KC_DB_URL_DATABASE}"
+      initialize_sql="CREATE TABLE IF NOT EXISTS JGROUPSPING (own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, bind_addr varchar(200) NOT NULL, updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, ping_data varbinary(5000) DEFAULT NULL, PRIMARY KEY (own_addr, cluster_name)) ENGINE=InnoDB DEFAULT CHARSET=utf8;"
+      insert_single_sql="INSERT INTO JGROUPSPING (own_addr, cluster_name, bind_addr, updated, ping_data) values (?, ?, '${env.JGROUPS_DISCOVERY_EXTERNAL_IP:127.0.0.1}', NOW(), ?);"
       delete_single_sql="DELETE FROM JGROUPSPING WHERE own_addr=? AND cluster_name=?;"
-      select_all_pingdata_sql="SELECT ping_data FROM JGROUPSPING WHERE cluster_name=?;"
+      select_all_pingdata_sql="SELECT ping_data, own_addr, cluster_name FROM JGROUPSPING WHERE cluster_name=?;"
       info_writer_sleep_time="500"
       remove_all_data_on_view_change="true"
       stack.combine="REPLACE"
-      stack.position="MPING"/>
+      stack.position="MPING" />
+  </stack>
+  <stack name="mariadb-jdbc-ping-tcp" extends="tcp">
+    <TCP external_addr="${env.JGROUPS_DISCOVERY_EXTERNAL_IP:127.0.0.1}" />
+    <JDBC_PING connection_driver="com.mysql.jdbc.Driver"
+      connection_username="${env.KC_DB_USERNAME}" connection_password="${env.KC_DB_PASSWORD}"
+      connection_url="jdbc:mysql://${env.KC_DB_URL_HOST}/${env.KC_DB_URL_DATABASE}"
+      initialize_sql="CREATE TABLE IF NOT EXISTS JGROUPSPING (own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, bind_addr varchar(200) NOT NULL, updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP, ping_data varbinary(5000) DEFAULT NULL, PRIMARY KEY (own_addr, cluster_name)) ENGINE=InnoDB DEFAULT CHARSET=utf8;"
+      insert_single_sql="INSERT INTO JGROUPSPING (own_addr, cluster_name, bind_addr, updated, ping_data) values (?, ?, '${env.JGROUPS_DISCOVERY_EXTERNAL_IP:127.0.0.1}', NOW(), ?);"
+      delete_single_sql="DELETE FROM JGROUPSPING WHERE own_addr=? AND cluster_name=?;"
+      select_all_pingdata_sql="SELECT ping_data, own_addr, cluster_name FROM JGROUPSPING WHERE cluster_name=?;"
+      info_writer_sleep_time="500"
+      remove_all_data_on_view_change="true"
+      stack.combine="REPLACE"
+      stack.position="MPING" />
+  </stack>
+  <stack name="postgres-jdbc-ping-tcp" extends="tcp">
+    <TCP external_addr="${env.JGROUPS_DISCOVERY_EXTERNAL_IP:127.0.0.1}" />
+    <JDBC_PING connection_driver="org.postgresql.Driver"
+      connection_username="${env.KC_DB_USERNAME}" connection_password="${env.KC_DB_PASSWORD}"
+      connection_url="jdbc:postgresql://${env.KC_DB_URL_HOST}/${env.KC_DB_URL_DATABASE}"
+      initialize_sql="CREATE SCHEMA IF NOT EXISTS ${env.KC_DB_SCHEMA:public}; CREATE TABLE IF NOT EXISTS ${env.KC_DB_SCHEMA:public}.JGROUPSPING (own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, bind_addr varchar(200) NOT NULL, updated timestamp default current_timestamp, ping_data BYTEA, constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name));"
+      insert_single_sql="INSERT INTO ${env.KC_DB_SCHEMA:public}.JGROUPSPING (own_addr, cluster_name, bind_addr, updated, ping_data) values (?, ?, '${env.JGROUPS_DISCOVERY_EXTERNAL_IP:127.0.0.1}', NOW(), ?);"
+      delete_single_sql="DELETE FROM ${env.KC_DB_SCHEMA:public}.JGROUPSPING WHERE own_addr=? AND cluster_name=?;"
+      select_all_pingdata_sql="SELECT ping_data, own_addr, cluster_name FROM ${env.KC_DB_SCHEMA:public}.JGROUPSPING WHERE cluster_name=?"
+      info_writer_sleep_time="500"
+      remove_all_data_on_view_change="true"
+      stack.combine="REPLACE"
+      stack.position="MPING" />
+  </stack>
+  <stack name="mssql-jdbc-ping-tcp" extends="tcp">
+    <TCP external_addr="${env.JGROUPS_DISCOVERY_EXTERNAL_IP:127.0.0.1}" />
+    <JDBC_PING connection_driver="com.microsoft.sqlserver.jdbc.SQLServerDriver"
+      connection_username="${env.KC_DB_USERNAME}" connection_password="${env.KC_DB_PASSWORD}"
+      connection_url="jdbc:sqlserver://${env.KC_DB_URL_HOST};databaseName=${env.KC_DB_URL_DATABASE}"
+      initialize_sql="IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = '${env.KC_DB_SCHEMA:dbo}') BEGIN EXEC ('CREATE SCHEMA [${env.KC_DB_SCHEMA:dbo}] AUTHORIZATION [dbo]') END; IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE='BASE TABLE' AND TABLE_NAME='JGROUPSPING' AND TABLE_SCHEMA='${env.KC_DB_SCHEMA:dbo}') CREATE TABLE ${env.KC_DB_SCHEMA:dbo}.JGROUPSPING (own_addr varchar(200) NOT NULL, cluster_name varchar(200) NOT NULL, bind_addr varchar(200) NOT NULL, updated datetime2 default getdate(), ping_data varbinary(5000), constraint PK_JGROUPSPING PRIMARY KEY (own_addr, cluster_name));"
+      insert_single_sql="INSERT INTO ${env.KC_DB_SCHEMA:dbo}.JGROUPSPING (own_addr, cluster_name, bind_addr, updated, ping_data) values (?, ?, '${env.JGROUPS_DISCOVERY_EXTERNAL_IP:127.0.0.1}', GETDATE(), ?);"
+      delete_single_sql="DELETE FROM ${env.KC_DB_SCHEMA:dbo}.JGROUPSPING WHERE own_addr=? AND cluster_name=?;"
+      select_all_pingdata_sql="SELECT ping_data, own_addr, cluster_name FROM ${env.KC_DB_SCHEMA:dbo}.JGROUPSPING WHERE cluster_name=?;"
+      info_writer_sleep_time="500"
+      remove_all_data_on_view_change="true"
+      stack.combine="REPLACE"
+      stack.position="MPING" />
   </stack>
 </jgroups>
 
 <cache-container name="keycloak">
-  <!-- custom stack must be referenced by name in the stack attribute of the transport element -->
-  <transport lock-timeout="60000" stack="jdbc-ping-tcp"/>
+  <transport lock-timeout="60000" stack="${env.KC_DB}-jdbc-ping-tcp"/>
   <local-cache name="realms">
     <encoding>
       <key media-type="application/x-java-object"/>

--- a/src/bilder/images/keycloak/files/docker-compose.yaml
+++ b/src/bilder/images/keycloak/files/docker-compose.yaml
@@ -4,14 +4,18 @@ services:
     image: mitodl/keycloak:${VERSION}
     command:
     - "start --features=preview -Dkeycloak.profile.feature.upload_scripts=enabled\
-      \ --spi-connections-jpa-default-migration-strategy=update"
+      \ --spi-sticky-session-encoder-infinispan-should-attach-route=false"
     env_file:
     - ./.env
     labels:
     - "traefik.enable=true"
     - "traefik.http.routers.keycloak.rule=Host(`${KC_HOSTNAME}`)"
     - "traefik.http.routers.keycloak.tls.certresolver=letsencrypt_resolver"
+    - "traefik.http.routers.keycloak.service=keycloak"
     - "traefik.http.routers.keycloak.entrypoints=https"
+    - "traefik.http.services.keycloak.loadbalancer.server.port=8080"
+    ports:
+    - "7800:7800"
     volumes:
     - /etc/docker/compose/cache-ispn-jdbc-ping.xml:/opt/keycloak/conf/cache-ispn-jdbc-ping.xml:ro
   traefik:

--- a/src/bilder/images/keycloak/files/docker-compose.yaml
+++ b/src/bilder/images/keycloak/files/docker-compose.yaml
@@ -3,7 +3,8 @@ services:
   keycloak:
     image: mitodl/keycloak:${VERSION}
     command:
-    - "start --features=preview -Dkeycloak.profile.feature.upload_scripts=enabled"
+    - "start --features=preview -Dkeycloak.profile.feature.upload_scripts=enabled\
+      \ --spi-connections-jpa-default-migration-strategy=update"
     env_file:
     - ./.env
     labels:
@@ -11,8 +12,8 @@ services:
     - "traefik.http.routers.keycloak.rule=Host(`${KC_HOSTNAME}`)"
     - "traefik.http.routers.keycloak.tls.certresolver=letsencrypt_resolver"
     - "traefik.http.routers.keycloak.entrypoints=https"
-    # Probably need to mount a keycloak.conf file
-    volumes: []
+    volumes:
+    - /etc/docker/compose/cache-ispn-jdbc-ping.xml:/opt/keycloak/conf/cache-ispn-jdbc-ping.xml:ro
   traefik:
     image: traefik:v2.9
     command:

--- a/src/ol_infrastructure/applications/keycloak/__main__.py
+++ b/src/ol_infrastructure/applications/keycloak/__main__.py
@@ -123,6 +123,21 @@ keycloak_server_security_group = ec2.SecurityGroup(
             cidr_blocks=["0.0.0.0/0"],
             description=f"Allow traffic to the keycloak server on port {DEFAULT_HTTPS_PORT}",  # noqa: E501
         ),
+        # https://infinispan.org/docs/stable/titles/security/security.html#ports_protocols
+        ec2.SecurityGroupIngressArgs(
+            self=True,
+            from_port=7800,
+            to_port=7800,
+            protocol="tcp",
+            description="Allow all keycloak servers to talk to all other keycloak servers on port 7800 tcp for IPSN clustering.",  # noqa: E501
+        ),
+        ec2.SecurityGroupIngressArgs(
+            self=True,
+            from_port=7800,
+            to_port=7800,
+            protocol="udp",
+            description="Allow all keycloak servers to talk to all other keycloak servers on port 7800 udp for IPSN clustering.",  # noqa: E501
+        ),
     ],
     egress=default_egress_args,
     vpc_id=target_vpc_id,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request makes our keycloak environments highly available by enabling the infinispan cache between all keycloak instances. Rather than using one of the built in cache discovery mechanisms, we use JDBC_PING, a good guide for which is found [here](https://github.com/ivangfr/keycloak-clustered).

## Motivation and Context
HA services are good services. 

## How Has This Been Tested?
By hand. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
