### PR TITLE
fix: docker-baseline-ami consul-template version specification missing

### DIFF
--- a/src/bilder/images/docker_baseline_ami/deploy.py
+++ b/src/bilder/images/docker_baseline_ami/deploy.py
@@ -54,9 +54,9 @@ vault = Vault(
     configuration={Path("vault.json"): vault_config},
 )
 consul = Consul(version=VERSIONS["consul"], configuration=consul_configuration)
-consul_template_config = ConsulTemplate()
+consul_template = ConsulTemplate(version=VERSIONS["consul-template"])
 
-hashicorp_products = [vault, consul, consul_template_config]
+hashicorp_products = [vault, consul, consul_template]
 install_hashicorp_products(hashicorp_products)
 
 docker_config = {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixing a missed version specification allowing a very old version of consul-template to get installed in some circumstances.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
