### PR TITLE
issue 1354

### DIFF
--- a/src/bilder/images/redash/deploy.py
+++ b/src/bilder/images/redash/deploy.py
@@ -230,7 +230,6 @@ consul_templates.append(
         command_timeout="120s",
     )
 )
-watched_files.append(redash_conf_directory.joinpath("datasources.yaml"))
 
 # Add consul template confgs for files that are just populated straight from vault.
 consul_templates.extend(

--- a/src/bilder/images/redash/deploy.py
+++ b/src/bilder/images/redash/deploy.py
@@ -232,7 +232,6 @@ consul_templates.append(
 )
 watched_files.append(redash_conf_directory.joinpath("datasources.yaml"))
 
-
 # Add consul template confgs for files that are just populated straight from vault.
 consul_templates.extend(
     [
@@ -329,6 +328,13 @@ consul_template = ConsulTemplate(
 
 # Consul and vault were installed in the docker-baseline-ami, consul-template is missing
 install_hashicorp_products([consul_template])
+
+# Only on redash server do we need to give user: consul-template permission to
+# interact with the docker system daemon
+server.shell(
+    name="Add the docker group as a supplemental to user: consul-template",
+    commands=["usermod -aG docker consul-template"],
+)
 
 hashicorp_products = [vault, consul, consul_template]
 

--- a/src/bilder/images/redash/files/update_datasources.py
+++ b/src/bilder/images/redash/files/update_datasources.py
@@ -4,6 +4,11 @@ import subprocess
 import sys
 
 import yaml
+import time
+
+# Pause for 15 seconds to give docker-compose time to
+# restart containers if that is triggered
+time.sleep(15)
 
 with open("/etc/redash/datasources.yaml") as yamlfile:
     config = yaml.safe_load(yamlfile)
@@ -31,6 +36,7 @@ for datasource in config["managed_datasources"]:
         [
             "/usr/bin/docker",
             "exec",
+            "-t",
             container_id,
             "python3",
             "manage.py",

--- a/src/bilder/images/redash/files/update_datasources.py
+++ b/src/bilder/images/redash/files/update_datasources.py
@@ -44,6 +44,6 @@ for datasource in config["managed_datasources"]:
         capture_output=True,
     )
     if update_output.returncode != 0:
-        return_code = update_output.returncode
+        returncode = update_output.returncode
 
 sys.exit(returncode)

--- a/src/bilder/images/redash/files/update_datasources.py
+++ b/src/bilder/images/redash/files/update_datasources.py
@@ -31,7 +31,6 @@ for datasource in config["managed_datasources"]:
         [
             "/usr/bin/docker",
             "exec",
-            "-it",
             container_id,
             "python3",
             "manage.py",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Giving consul-template permission to interact with the docker daemon on redash servers.

## Motivation and Context
Closes #1354 (which impacts more than just edx_notes, and edx_notes had its own problems of a similar nature. 

Turns out consul-template was silently failing to run the `command` it was told to run after rendering /etc/redash/datasources.py. 

2 reasons for that:

1. Didn't have permission to interact with docker.
2. Logic error in `update_datasources.py` that caused the script to always return `0`. 

## How Has This Been Tested?
Tested in QA and in production like the madman I am. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
