### PR TITLE
Adding missing period on 404 page

### DIFF
--- a/src/ol_infrastructure/applications/ocw_site/404.html
+++ b/src/ol_infrastructure/applications/ocw_site/404.html
@@ -139,7 +139,7 @@
           <br />
           <p>
             You might want to try <a href="/search/">searching</a> for another
-            page, or you can <a href="/contact/">contact us</a> and let us know
+            page, or you can <a href="/contact/">contact us</a> and let us know.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Description
There is a missing period on the custom 404 page for OCW; this PR fixes that.