### PR TITLE
Redis memory usage issues 

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.Production.yaml
@@ -5,10 +5,10 @@ config:
   aws:region: us-east-1
   consul:address: https://consul-mitx-production.odl.mit.edu
   edxapp:business_unit: residential
+  edxapp:db_max_storage_gb: "1000"
   edxapp:db_password:
     secure: v1:vkG4n/X+C+SBaMf7:W/zi1Bxqkab0Hx1HAAiVhZuj/8WOJ7v94lxfERa5YIF5dD037uuULgPxIt+3zzHVur26pBcVIk4=
-  edxapp:db_storage_gb: 500
-  edxapp:db_max_storage_gb: 1000
+  edxapp:db_storage_gb: "500"
   edxapp:dns_zone: mitx
   edxapp:domains:
     lms: lms.mitx.mit.edu
@@ -33,7 +33,7 @@ config:
   edxapp:web_instance_type: general_purpose_xlarge
   edxapp:web_node_capacity: "5"
   edxapp:worker_disk_size: "50"
-  edxapp:worker_node_capacity: "2"
+  edxapp:worker_node_capacity: "5"
   mongodb:atlas_project_id: 61b728704656cb4747e589a0
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production

--- a/src/ol_infrastructure/components/aws/cache.py
+++ b/src/ol_infrastructure/components/aws/cache.py
@@ -340,7 +340,17 @@ class OLAmazonCache(pulumi.ComponentResource):
                 "metric_name": "EngineCPUUtilization",
                 "threshold": 50,  # percent
                 "unit": "Percent",
-            }
+            },
+            "DatabaseMemoryUsagePercentage": {
+                "comparison_operator": "GreaterThanThreshold",
+                "description": "ElastiCache - High memory utilization by the Redis engine.",  # noqa: E501
+                "datapoints_to_alarm": 2,
+                "level": "warning",
+                "period": 300,  # 5 minutes
+                "evaluation_periods": 2,  # 10 Minutes
+                "metric_name": "DatabaseMemoryUsagePercentage",
+                "threshold": 90,  # percent
+            },
         }
 
         monitoring_profiles: dict[str, dict] = {

--- a/src/ol_infrastructure/lib/stack_defaults.py
+++ b/src/ol_infrastructure/lib/stack_defaults.py
@@ -12,7 +12,7 @@ production_defaults = {
         "read_replica": OLReplicaDBConfig(),
         "monitoring_profile_name": "production",
     },
-    "redis": {"instance_type": CacheInstanceTypes.large},
+    "redis": {"instance_type": CacheInstanceTypes.high_mem_large},
 }
 
 qa_defaults = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Set the default elasticache instance size in production to high_mem_large.
- Create an elasticache alert that will page out when memory goes over 90% utilization. 
- Set the desired residential edxapp worker count to five nodes. 

Also spent some time looking into a few other discrepancies but determined they are okay to revert when stack is applied. 

## Motivation and Context
Redis is sad in multiple production envs. 😢


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
