### PR TITLE
feat: Update residential CI to Palm with how-to doc

### DIFF
--- a/docs/how_to/openedx/release_upgrades.md
+++ b/docs/how_to/openedx/release_upgrades.md
@@ -8,6 +8,10 @@ their own schedule. MITx Residential upgrades twice per year, roughly aligned wi
 release timing of the upstream Open edX platform, whereas xPro has typically upgraded on
 an annual basis in the December timeframe.
 
+Our MITx Online deployment of Open edX is a special case in that it deploys directly
+from the master branches of the different applications and has a weekly release
+schedule.
+
 ## Open Learning's Open edX Deployments
 At Open Learning we have four distinct installations of Open edX, each with their own
 release cadence and configuration requirements. For each of those deployments we have
@@ -26,9 +30,14 @@ in the QA environment and propagated to Production.
 In addition to the cartesian product of (versions * deployments * env stages) we also
 have to manage these values across the different components of the Open edX
 ecosystem. For example, the core of the platform is called edx-platform, which in turn
-relies on a forum service, the edx-notes API service, a codejail REST API service, and
-myriad MFEs (Micro-FrontEnds). For any of these different components we may need to be
-able to override the repository and/or branch that we are building/deploying from.
+relies on:
+- a forum service
+- the edx-notes API service
+- a codejail REST API service
+- and myriad MFEs (Micro-FrontEnds).
+
+For any of these different components we may need to be able to override the repository
+and/or branch that we are building/deploying from.
 
 ## Versioning of Build and Deploy
 In order to support this sea of complexity we have a module of `bridge.settings.openedx`
@@ -52,9 +61,15 @@ release.
 There are two data structures that control the applications and versions that get
 included in a given deployment and which version to use in the respective environment
 stage. The `OpenLearningOpenEdxDeployment` Enum is the top level that sets the release
-name for the environment stage of a given deployment. The `ReleaseMap` dictionary is
-used to manage any overrides of repository and branch for a given component of the
-platform, as well as which components are included in that deployment.
+name for the environment stage of a given deployment.
+
+There are situations where we need to customize a component that is being deployed. In
+those cases we typically create a fork of the upstream repository where we manage the
+patches that we require. The `ReleaseMap` dictionary is used to manage any overrides of
+repository and branch for a given component of the platform, as well as which components
+are included in that deployment. The `OpenEdxApplicationVersion` structure will map to
+the default repositories and branches for a given component, but supplies a
+`branch_override` and `origin_override` parameter to manage these customizations.
 
 For example, to upgrade our MITx Residential deployments to start testing the Palm
 release we change the `CI` stages of the `mitx` and `mitx-staging` deployments to use

--- a/docs/how_to/openedx/release_upgrades.md
+++ b/docs/how_to/openedx/release_upgrades.md
@@ -1,18 +1,19 @@
 # How To Update The Release Version Of An Open edX Deployment
 
 ## Open edX Releases
-Open edX cuts new named releases approximately every 6 months. Each of our deployments
-needs to be able to independently upgrade the respective version on their own
-schedule. MITx Residential upgrades twice per year, roughly aligned with the release
-timing of the upstream Open edX platform, whereas xPro has typically upgraded on an
-annual basis in the December timeframe.
+Open edX cuts new named releases [approximately every 6
+months](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3613392957/Open+edX+release+schedule). Each
+of our deployments needs to be able to independently upgrade the respective version on
+their own schedule. MITx Residential upgrades twice per year, roughly aligned with the
+release timing of the upstream Open edX platform, whereas xPro has typically upgraded on
+an annual basis in the December timeframe.
 
 ## Open Learning's Open edX Deployments
 At Open Learning we have four distinct installations of Open edX, each with their own
 release cadence and configuration requirements. For each of those deployments we have
 multiple environment stages (e.g. CI, QA, Production). Each of those deployment * stages
 combinations needs to be able to have their versions managed independently, with newer
-versions being progressively toggled to higher environments.
+versions being progressively promoted to higher environments.
 
 This is further complicated by the long testing cycles for new releases in a given
 deployment. We need to be able to deploy a newer release to a lower environment stage,
@@ -55,7 +56,9 @@ name for the environment stage of a given deployment. The `ReleaseMap` dictionar
 used to manage any overrides of repository and branch for a given component of the
 platform, as well as which components are included in that deployment.
 
-For example, to upgrade our MITx Residential deployments to start testing the Palm release we change the `CI` stages of the `mitx` and `mitx-staging` deployments to use the `palm` value for the `OpenEdxSupportedRelease`
+For example, to upgrade our MITx Residential deployments to start testing the Palm
+release we change the `CI` stages of the `mitx` and `mitx-staging` deployments to use
+the `palm` value for the `OpenEdxSupportedRelease`
 
 ```diff
 @@ -13,7 +13,7 @@ class OpenLearningOpenEdxDeployment(Enum):
@@ -115,17 +118,22 @@ deployment.
              OpenEdxApplicationVersion(
 ```
 
-All of the deployment pipelines for these application components are managed by a
-corresponding `meta` pipeline that will automatically update the build and pipeline
-configuration based on the changed version information as soon as it is merged into the
-`master` branch of `ol-infrastructure`.
+All of the [deployment
+pipelines](https://github.com/mitodl/ol-infrastructure/blob/main/src/concourse/pipelines/open_edx/)
+for these application components are managed by a corresponding `meta` pipeline that
+will automatically update the build and pipeline configuration based on the changed
+version information as soon as it is merged into the `master` branch of
+`ol-infrastructure`.
 
 **Note - TMM 2023-04-14**
 
 - The current configuration of our meta pipelines means that before the updates to the
-`bridge.settings.openedx.version_matrix` module can be picked up by the `meta` pipelines
-the `ol-infrastructure` docker image needs to be built and pushed to our registry so
-that it can be loaded. This means that once the [ol-infrastructure image
-pipeline](https://cicd.odl.mit.edu/teams/main/pipelines/ol-infrastructure-docker-container)
-completes it might be necessary to manually trigger the meta pipelines again.
-- Once a new release is deployed to a given environment stage for the first time it may be necessary to manually ensure that all database migrations are run properly. It will be attempted automatically on deployment, but there are often conflicts between the existing database state and the migration logic that require intervention.
+  `bridge.settings.openedx.version_matrix` module can be picked up by the `meta`
+  pipelines the `ol-infrastructure` docker image needs to be built and pushed to our
+  registry so that it can be loaded. This means that once the [ol-infrastructure image
+  pipeline](https://cicd.odl.mit.edu/teams/main/pipelines/ol-infrastructure-docker-container)
+  completes it might be necessary to manually trigger the meta pipelines again.
+- Once a new release is deployed to a given environment stage for the first time it may
+  be necessary to manually ensure that all database migrations are run properly. It will
+  be attempted automatically on deployment, but there are often conflicts between the
+  existing database state and the migration logic that require intervention.

--- a/docs/how_to/openedx/release_upgrades.md
+++ b/docs/how_to/openedx/release_upgrades.md
@@ -140,6 +140,30 @@ will automatically update the build and pipeline configuration based on the chan
 version information as soon as it is merged into the `master` branch of
 `ol-infrastructure`.
 
+## Supporting New Applications
+There are two categories of applications that comprise the overall Open edX
+platform. These are "IDA"s (Independently Deployable Applications), and "MFE"s (Micro
+Front-Ends). An IDA is a Django application that can be deployed as a backend service
+and typically integrates with the edx-platform (LMS and CMS) via OAuth. An MFE is a
+ReactJS application that is deployed as a standalone site which then interacts with LMS
+and/or CMS via REST APIs.
+
+In order to ensure that we have visibility into which of these components we are
+deploying there is an Enum of
+[`OpenEdxApplication`](https://github.com/mitodl/ol-infrastructure/blob/main/src/bridge/settings/openedx/types.py#L7)
+and
+[`OpenEdxMicroFrontend`](https://github.com/mitodl/ol-infrastructure/blob/main/src/bridge/settings/openedx/types.py#L25)
+respectively which captures the details of which elements of the overall edX ecosystem
+we are supporting in our deployments. These Enums are then used as an attribute of the
+[`OpenEdxApplicationVersion`](https://github.com/mitodl/ol-infrastructure/blob/main/src/bridge/settings/openedx/types.py#L121)
+model which captures the details of a specific instance of one of those
+components. These are then used in the `ReleaseMap` dict to show which versions and
+deployments include the given instance of that application and version.
+
+To add support for a new IDA or MFE you need to add a new entry to the appropriate Enum,
+and then include an instance of an `OpenEdxApplicationVersion` that points to that
+application in the `ReleaseMap` at the appropriate location.
+
 **Note - TMM 2023-04-14**
 
 - The current configuration of our meta pipelines means that before the updates to the

--- a/src/bridge/settings/openedx/types.py
+++ b/src/bridge/settings/openedx/types.py
@@ -33,6 +33,11 @@ class OpenEdxMicroFrontend(str, Enum):
         enum_element.path = path
         return enum_element
 
+    communications = (
+        "communications",
+        "https://github.com/openedx/frontend-app-communications",
+        "communications",
+    )
     course_authoring = (
         "course-authoring",
         "https://github.com/openedx/frontend-app-course-authoring",
@@ -44,6 +49,11 @@ class OpenEdxMicroFrontend(str, Enum):
         "gradebook",
     )
     learn = ("learning", "https://github.com/openedx/frontend-app-learning", "learn")
+    learner_dashboard = (
+        "learner-dashboard",
+        "https://github.com/openedx/frontend-app-learner-dashboard",
+        "dashboard",
+    )
     library_authoring = (
         "library-authoring",
         "https://github.com/openedx/frontend-app-library-authoring",
@@ -51,7 +61,7 @@ class OpenEdxMicroFrontend(str, Enum):
     )
     ora_grading = (
         "ora-grading",
-        "https://github.com/edx/frontend-app-ora-grading",
+        "https://github.com/openedx/frontend-app-ora-grading",
         "ora-grading",
     )
 

--- a/src/bridge/settings/openedx/types.py
+++ b/src/bridge/settings/openedx/types.py
@@ -74,6 +74,7 @@ class OpenEdxSupportedRelease(str, Enum):
 
     master = ("master", "master")
     olive = ("olive", "open-release/olive.master")
+    palm = ("palm", "open-release/palm.master")
 
 
 class EnvRelease(NamedTuple):

--- a/src/bridge/settings/openedx/version_matrix.py
+++ b/src/bridge/settings/openedx/version_matrix.py
@@ -13,7 +13,7 @@ class OpenLearningOpenEdxDeployment(Enum):
     mitx = DeploymentEnvRelease(
         deployment_name="mitx",
         env_release_map=[
-            EnvRelease("CI", OpenEdxSupportedRelease["olive"]),
+            EnvRelease("CI", OpenEdxSupportedRelease["palm"]),
             EnvRelease("QA", OpenEdxSupportedRelease["olive"]),
             EnvRelease("Production", OpenEdxSupportedRelease["olive"]),
         ],
@@ -21,7 +21,7 @@ class OpenLearningOpenEdxDeployment(Enum):
     mitx_staging = DeploymentEnvRelease(
         deployment_name="mitx-staging",
         env_release_map=[
-            EnvRelease("CI", OpenEdxSupportedRelease["olive"]),
+            EnvRelease("CI", OpenEdxSupportedRelease["palm"]),
             EnvRelease("QA", OpenEdxSupportedRelease["olive"]),
             EnvRelease("Production", OpenEdxSupportedRelease["olive"]),
         ],
@@ -61,6 +61,122 @@ ReleaseMap: dict[
     OpenEdxSupportedRelease,
     dict[OpenEdxDeploymentName, list[OpenEdxApplicationVersion]],
 ] = {
+    "palm": {
+        "mitx": [
+            OpenEdxApplicationVersion(
+                application="edx-platform",  # type: ignore
+                application_type="IDA",
+                release="palm",
+                branch_override="mitx/palm",
+                origin_override="https://github.com/mitodl/edx-platform",
+            ),
+            OpenEdxApplicationVersion(
+                application="edxapp_theme",  # type: ignore
+                application_type="IDA",
+                release="palm",
+                branch_override="palm",
+                origin_override="https://github.com/mitodl/mitx-theme",
+            ),
+            OpenEdxApplicationVersion(
+                application="forum",  # type: ignore
+                application_type="IDA",
+                release="palm",
+            ),
+            OpenEdxApplicationVersion(
+                application="xqueue",  # type: ignore
+                application_type="IDA",
+                release="palm",
+            ),
+            OpenEdxApplicationVersion(
+                application="notes-api",  # type: ignore
+                application_type="IDA",
+                release="palm",
+            ),
+            OpenEdxApplicationVersion(
+                application="learning",  # type: ignore
+                application_type="MFE",
+                release="palm",
+            ),
+            OpenEdxApplicationVersion(
+                application="gradebook",  # type: ignore
+                application_type="MFE",
+                release="palm",
+            ),
+            OpenEdxApplicationVersion(
+                application="course-authoring",  # type: ignore
+                application_type="MFE",
+                release="palm",
+            ),
+            OpenEdxApplicationVersion(
+                application="library-authoring",  # type: ignore
+                application_type="MFE",
+                release="palm",
+                branch_override="master",
+            ),
+            OpenEdxApplicationVersion(
+                application="ora-grading",  # type: ignore
+                application_type="MFE",
+                release="palm",
+            ),
+        ],
+        "mitx-staging": [
+            OpenEdxApplicationVersion(
+                application="edx-platform",  # type: ignore
+                application_type="IDA",
+                release="palm",
+                branch_override="mitx/palm",
+                origin_override="https://github.com/mitodl/edx-platform",
+            ),
+            OpenEdxApplicationVersion(
+                application="edxapp_theme",  # type: ignore
+                application_type="IDA",
+                release="palm",
+                branch_override="palm",
+                origin_override="https://github.com/mitodl/mitx-theme",
+            ),
+            OpenEdxApplicationVersion(
+                application="forum",  # type: ignore
+                application_type="IDA",
+                release="palm",
+            ),
+            OpenEdxApplicationVersion(
+                application="xqueue",  # type: ignore
+                application_type="IDA",
+                release="palm",
+            ),
+            OpenEdxApplicationVersion(
+                application="notes-api",  # type: ignore
+                application_type="IDA",
+                release="palm",
+            ),
+            OpenEdxApplicationVersion(
+                application="learning",  # type: ignore
+                application_type="MFE",
+                release="palm",
+            ),
+            OpenEdxApplicationVersion(
+                application="gradebook",  # type: ignore
+                application_type="MFE",
+                release="palm",
+            ),
+            OpenEdxApplicationVersion(
+                application="course-authoring",  # type: ignore
+                application_type="MFE",
+                release="palm",
+            ),
+            OpenEdxApplicationVersion(
+                application="library-authoring",  # type: ignore
+                application_type="MFE",
+                release="palm",
+                branch_override="master",
+            ),
+            OpenEdxApplicationVersion(
+                application="ora-grading",  # type: ignore
+                application_type="MFE",
+                release="palm",
+            ),
+        ],
+    },
     "olive": {
         "mitx": [
             OpenEdxApplicationVersion(

--- a/src/bridge/settings/openedx/version_matrix.py
+++ b/src/bridge/settings/openedx/version_matrix.py
@@ -64,6 +64,11 @@ ReleaseMap: dict[
     "palm": {
         "mitx": [
             OpenEdxApplicationVersion(
+                application="course-authoring",  # type: ignore
+                application_type="MFE",
+                release="palm",
+            ),
+            OpenEdxApplicationVersion(
                 application="edx-platform",  # type: ignore
                 application_type="IDA",
                 release="palm",
@@ -83,13 +88,8 @@ ReleaseMap: dict[
                 release="palm",
             ),
             OpenEdxApplicationVersion(
-                application="xqueue",  # type: ignore
-                application_type="IDA",
-                release="palm",
-            ),
-            OpenEdxApplicationVersion(
-                application="notes-api",  # type: ignore
-                application_type="IDA",
+                application="gradebook",  # type: ignore
+                application_type="MFE",
                 release="palm",
             ),
             OpenEdxApplicationVersion(
@@ -98,12 +98,7 @@ ReleaseMap: dict[
                 release="palm",
             ),
             OpenEdxApplicationVersion(
-                application="gradebook",  # type: ignore
-                application_type="MFE",
-                release="palm",
-            ),
-            OpenEdxApplicationVersion(
-                application="course-authoring",  # type: ignore
+                application="learner-dashboard",  # type: ignore
                 application_type="MFE",
                 release="palm",
             ),
@@ -114,13 +109,28 @@ ReleaseMap: dict[
                 branch_override="master",
             ),
             OpenEdxApplicationVersion(
+                application="notes-api",  # type: ignore
+                application_type="IDA",
+                release="palm",
+            ),
+            OpenEdxApplicationVersion(
                 application="ora-grading",  # type: ignore
                 application_type="MFE",
+                release="palm",
+            ),
+            OpenEdxApplicationVersion(
+                application="xqueue",  # type: ignore
+                application_type="IDA",
                 release="palm",
             ),
         ],
         "mitx-staging": [
             OpenEdxApplicationVersion(
+                application="course-authoring",  # type: ignore
+                application_type="MFE",
+                release="palm",
+            ),
+            OpenEdxApplicationVersion(
                 application="edx-platform",  # type: ignore
                 application_type="IDA",
                 release="palm",
@@ -140,27 +150,12 @@ ReleaseMap: dict[
                 release="palm",
             ),
             OpenEdxApplicationVersion(
-                application="xqueue",  # type: ignore
-                application_type="IDA",
-                release="palm",
-            ),
-            OpenEdxApplicationVersion(
-                application="notes-api",  # type: ignore
-                application_type="IDA",
-                release="palm",
-            ),
-            OpenEdxApplicationVersion(
-                application="learning",  # type: ignore
-                application_type="MFE",
-                release="palm",
-            ),
-            OpenEdxApplicationVersion(
                 application="gradebook",  # type: ignore
                 application_type="MFE",
                 release="palm",
             ),
             OpenEdxApplicationVersion(
-                application="course-authoring",  # type: ignore
+                application="learning",  # type: ignore
                 application_type="MFE",
                 release="palm",
             ),
@@ -171,8 +166,18 @@ ReleaseMap: dict[
                 branch_override="master",
             ),
             OpenEdxApplicationVersion(
+                application="notes-api",  # type: ignore
+                application_type="IDA",
+                release="palm",
+            ),
+            OpenEdxApplicationVersion(
                 application="ora-grading",  # type: ignore
                 application_type="MFE",
+                release="palm",
+            ),
+            OpenEdxApplicationVersion(
+                application="xqueue",  # type: ignore
+                application_type="IDA",
                 release="palm",
             ),
         ],
@@ -180,6 +185,11 @@ ReleaseMap: dict[
     "olive": {
         "mitx": [
             OpenEdxApplicationVersion(
+                application="course-authoring",  # type: ignore
+                application_type="MFE",
+                release="olive",
+            ),
+            OpenEdxApplicationVersion(
                 application="edx-platform",  # type: ignore
                 application_type="IDA",
                 release="olive",
@@ -199,13 +209,8 @@ ReleaseMap: dict[
                 release="olive",
             ),
             OpenEdxApplicationVersion(
-                application="xqueue",  # type: ignore
-                application_type="IDA",
-                release="olive",
-            ),
-            OpenEdxApplicationVersion(
-                application="notes-api",  # type: ignore
-                application_type="IDA",
+                application="gradebook",  # type: ignore
+                application_type="MFE",
                 release="olive",
             ),
             OpenEdxApplicationVersion(
@@ -214,12 +219,7 @@ ReleaseMap: dict[
                 release="olive",
             ),
             OpenEdxApplicationVersion(
-                application="gradebook",  # type: ignore
-                application_type="MFE",
-                release="olive",
-            ),
-            OpenEdxApplicationVersion(
-                application="course-authoring",  # type: ignore
+                application="learner-dashboard",  # type: ignore
                 application_type="MFE",
                 release="olive",
             ),
@@ -230,13 +230,28 @@ ReleaseMap: dict[
                 branch_override="master",
             ),
             OpenEdxApplicationVersion(
+                application="notes-api",  # type: ignore
+                application_type="IDA",
+                release="olive",
+            ),
+            OpenEdxApplicationVersion(
                 application="ora-grading",  # type: ignore
                 application_type="MFE",
+                release="olive",
+            ),
+            OpenEdxApplicationVersion(
+                application="xqueue",  # type: ignore
+                application_type="IDA",
                 release="olive",
             ),
         ],
         "mitx-staging": [
             OpenEdxApplicationVersion(
+                application="course-authoring",  # type: ignore
+                application_type="MFE",
+                release="olive",
+            ),
+            OpenEdxApplicationVersion(
                 application="edx-platform",  # type: ignore
                 application_type="IDA",
                 release="olive",
@@ -256,27 +271,12 @@ ReleaseMap: dict[
                 release="olive",
             ),
             OpenEdxApplicationVersion(
-                application="xqueue",  # type: ignore
-                application_type="IDA",
-                release="olive",
-            ),
-            OpenEdxApplicationVersion(
-                application="notes-api",  # type: ignore
-                application_type="IDA",
-                release="olive",
-            ),
-            OpenEdxApplicationVersion(
-                application="learning",  # type: ignore
-                application_type="MFE",
-                release="olive",
-            ),
-            OpenEdxApplicationVersion(
                 application="gradebook",  # type: ignore
                 application_type="MFE",
                 release="olive",
             ),
             OpenEdxApplicationVersion(
-                application="course-authoring",  # type: ignore
+                application="learning",  # type: ignore
                 application_type="MFE",
                 release="olive",
             ),
@@ -287,12 +287,28 @@ ReleaseMap: dict[
                 branch_override="master",
             ),
             OpenEdxApplicationVersion(
+                application="notes-api",  # type: ignore
+                application_type="IDA",
+                release="olive",
+            ),
+            OpenEdxApplicationVersion(
                 application="ora-grading",  # type: ignore
                 application_type="MFE",
                 release="olive",
             ),
+            OpenEdxApplicationVersion(
+                application="xqueue",  # type: ignore
+                application_type="IDA",
+                release="olive",
+            ),
         ],
         "xpro": [
+            OpenEdxApplicationVersion(
+                application="course-authoring",  # type: ignore
+                application_type="MFE",
+                release="olive",
+                branch_override="master",
+            ),
             OpenEdxApplicationVersion(
                 application="edx-platform",  # type: ignore
                 application_type="IDA",
@@ -311,17 +327,12 @@ ReleaseMap: dict[
                 release="olive",
             ),
             OpenEdxApplicationVersion(
-                application="notes-api",  # type: ignore
-                application_type="IDA",
-                release="olive",
-            ),
-            OpenEdxApplicationVersion(
-                application="learning",  # type: ignore
+                application="gradebook",  # type: ignore
                 application_type="MFE",
                 release="olive",
             ),
             OpenEdxApplicationVersion(
-                application="gradebook",  # type: ignore
+                application="learning",  # type: ignore
                 application_type="MFE",
                 release="olive",
             ),
@@ -332,10 +343,9 @@ ReleaseMap: dict[
                 branch_override="master",
             ),
             OpenEdxApplicationVersion(
-                application="course-authoring",  # type: ignore
-                application_type="MFE",
+                application="notes-api",  # type: ignore
+                application_type="IDA",
                 release="olive",
-                branch_override="master",
             ),
             OpenEdxApplicationVersion(
                 application="ora-grading",  # type: ignore
@@ -346,6 +356,16 @@ ReleaseMap: dict[
     },
     "master": {
         "mitxonline": [
+            OpenEdxApplicationVersion(
+                application="communications",  # type: ignore
+                application_type="MFE",
+                release="master",
+            ),
+            OpenEdxApplicationVersion(
+                application="course-authoring",  # type: ignore
+                application_type="MFE",
+                release="master",
+            ),
             OpenEdxApplicationVersion(
                 application="edx-platform",  # type: ignore
                 application_type="IDA",
@@ -365,6 +385,11 @@ ReleaseMap: dict[
                 release="master",
             ),
             OpenEdxApplicationVersion(
+                application="gradebook",  # type: ignore
+                application_type="MFE",
+                release="master",
+            ),
+            OpenEdxApplicationVersion(
                 application="learning",  # type: ignore
                 application_type="MFE",
                 release="master",
@@ -372,17 +397,12 @@ ReleaseMap: dict[
                 origin_override="https://github.com/mitodl/frontend-app-learning",
             ),
             OpenEdxApplicationVersion(
-                application="gradebook",  # type: ignore
-                application_type="MFE",
-                release="master",
-            ),
-            OpenEdxApplicationVersion(
                 application="library-authoring",  # type: ignore
                 application_type="MFE",
                 release="master",
             ),
             OpenEdxApplicationVersion(
-                application="course-authoring",  # type: ignore
+                application="ora-grading",  # type: ignore
                 application_type="MFE",
                 release="master",
             ),


### PR DESCRIPTION
## Description
This updates the version configuration to set the CI stage of the residential MITx deployments to use the new Palm release. This also adds a corresponding `how-to` document that explains how to do this in the future with the aim of making it easier for anyone to manage the process.

## Motivation and Context
We want to be able to start testing the Palm release for residential environments. I also want to enable other people to manage this process.

## How Has This Been Tested?
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
