### PR TITLE
config: Add bucket permissions for OCW Studio to sync videos

### DIFF
--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -156,6 +156,23 @@ ocw_studio_iam_policy = iam.Policy(
                     "Action": "iam:PassRole",
                     "Resource": f"arn:aws:iam::610119931565:role/service-role-mediaconvert-ocw-studio-{stack_info.env_suffix}",  # noqa: E501
                 },
+                # Temporary permissions until video archives are synced via management
+                # command. TMM 2023-04-19
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "s3:*MultiPartUpload*",
+                        "s3:DeleteObject",
+                        "s3:GetObject*",
+                        "s3:ListBucket*",
+                        "s3:PutObject",
+                        "s3:PutObjectTagging",
+                    ],
+                    "Resource": [
+                        f"arn:aws:s3:::ocw-content*{stack_info.env_suffix}",
+                        f"arn:aws:s3:::ocw-content*{stack_info.env_suffix}/*",
+                    ],
+                },
             ],
         },
         stringify=True,


### PR DESCRIPTION
## Description
Add permissions for writing to OCW content buckets by the studio app (including multi-part)

## Motivation and Context
There are a number of videos in our legacy offline site mirror that we would like to propagate to our new offline site configuration. This adds the IAM permissions to the OCW Studio application to manage that process. Once we have moved all of the videos we will likely want to remove these permissions.

## How Has This Been Tested?
Preview the Pulumi apply changes