### PR TITLE
Vector_log_proxy hotfix

### DIFF
--- a/src/bilder/images/vector_log_proxy/files/traefik/dynamic_config.yaml
+++ b/src/bilder/images/vector_log_proxy/files/traefik/dynamic_config.yaml
@@ -2,7 +2,7 @@
 http:
   routers:
     s3-hash-file-router:
-      rule: 'Host("{{ env "DOMAIN" }}") && Path("/.well-known/fastly/logging/challenge")'
+      rule: 'Path("/.well-known/fastly/logging/challenge")'
       service: s3-hash-file-service
       middlewares:
       - "remove-auth"

--- a/src/ol_infrastructure/infrastructure/vector_log_proxy/__main__.py
+++ b/src/ol_infrastructure/infrastructure/vector_log_proxy/__main__.py
@@ -326,7 +326,7 @@ heroku_log_proxy_lb_target_group = lb.TargetGroup(
         path="/events",
         port=str(HEROKU_LOG_PROXY_PORT),
         protocol="HTTPS",
-        matcher="405",
+        matcher="200",
     ),
     name=("heroku-" + vector_log_proxy_tag)[:TARGET_GROUP_NAME_MAX_LENGTH].rstrip("-"),
     tags=aws_config.tags,
@@ -340,7 +340,7 @@ fastly_log_proxy_lb_target_group = lb.TargetGroup(
     health_check=lb.TargetGroupHealthCheckArgs(
         healthy_threshold=2,
         interval=120,
-        path="/",
+        path="/.well-known/fastly/logging/challenge",
         port=str(FASTLY_LOG_PROXY_PORT),
         protocol="HTTPS",
         matcher="405",


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Addressing an issue with autoscalling groups refusing to accept vector log servers as they are.

## Motivation and Context
Does two things.
1. Removes the domain check from the .well-known URL router so any request to that path will be routed there, not just those to `vector-log-proxy-<whatever>.odl.mit.edu`. This will allow us to send the health checks from the next part on to the s3 bucket.
2. Updates the target group configuration to check for the .well-known path instead of just `/`. This will get routed to s3, which is technically an indicator that vector is up but it will work now because it will indicate that traefik is up. Also changes the valid check codes to `200`. 

Will need to circle back and create some kind of default router that will listen for just `/` but not demand that the DOMAIN be set to `vector-log-proxy-<whatever>.odl.mit.edu`. Doing that is more complicated fix and involves changing more the the config file than I want to do on a Thursday at 6PM. I feel good enough about this PR to push it out w/o testing. 

## How Has This Been Tested?
We will do it live! 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
