### PR TITLE
config: Disable caching of api routes on open edx

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -1359,12 +1359,22 @@ edxapp_fastly_service = fastly.ServiceVcl(
             action="pass",
             cache_condition="Django Admin Route",
             name="Django Admin Route",
-        )
+        ),
+        fastly.ServiceVclCacheSettingArgs(
+            action="pass",
+            cache_condition="Django API Route",
+            name="Django API Route",
+        ),
     ],
     conditions=[
         fastly.ServiceVclConditionArgs(
             name="Django Admin Route",
             statement='req.url ~ "^/admin"',
+            type="CACHE",
+        ),
+        fastly.ServiceVclConditionArgs(
+            name="Django API Route",
+            statement='req.url ~ "^/api/"',
             type="CACHE",
         ),
         fastly.ServiceVclConditionArgs(


### PR DESCRIPTION
## Description
Ensure that we aren't caching API responses for open edX instances in the Fastly layer.

## Motivation and Context
Cached API responses can lead to weird error situations. The endpoints should properly set the cache-control but this makes a blanket config to avoid edge cases.