### PR TITLE
Concourse infrastructure worker scale up

### DIFF
--- a/src/ol_infrastructure/applications/concourse/Pulumi.applications.concourse.Production.yaml
+++ b/src/ol_infrastructure/applications/concourse/Pulumi.applications.concourse.Production.yaml
@@ -47,7 +47,7 @@ config:
     - infra
     - operations
     - cloud_custodian
-    instance_type: t3a.medium
+    instance_type: c6a.large
     name: infra
   - auto_scale:
       desired: 3


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Sizing up concourse infrastructure workers to the least expensive instance that doesn't have burstable CPU.

## Motivation and Context
These workers are heavily CPU bound at the moment fully utilize all CPU credits 100% of the time meaning they are slow as deathhhhhh. New instance is same CPU count + memory but not restricted by credit usage. Costs approx 2x as much as a t3a.medium. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
