### PR TITLE
Fix RecursionError

### DIFF
--- a/src/bilder/images/edxapp/group_data/all.py
+++ b/src/bilder/images/edxapp/group_data/all.py
@@ -12,7 +12,7 @@ edx_plugins_added = {
         "ol-openedx-sentry",
         "ol-openedx-course-export",
         "ol-openedx-checkout-external",
-        "sentry-sdk==1.2.1", # Fix RecursionError
+        "sentry-sdk==1.2.1",  # Fix RecursionError
         "social-auth-mitxpro==0.6.1",
     ],
     "xpro": [
@@ -54,7 +54,7 @@ edx_plugins_added = {
         # msg=self signed certificate (TMM 2022-12-01)
         # Downgrade to version used in Nutmeg due to conflicts with SAML implementation
         "lxml==4.5.0",
-        "sentry-sdk==1.2.1", # Fix RecursionError
+        "sentry-sdk==1.2.1",  # Fix RecursionError
     ],
     "mitx-staging": [
         "celery-redbeat",  # Support for using Redis as the lock for Celery schedules
@@ -83,7 +83,7 @@ edx_plugins_added = {
         # msg=self signed certificate (TMM 2022-12-01)
         # Downgrade to version used in Nutmeg due to conflicts with SAML implementation
         "lxml==4.5.0",
-        "sentry-sdk==1.2.1", # Fix RecursionError
+        "sentry-sdk==1.2.1",  # Fix RecursionError
     ],
 }
 

--- a/src/bilder/images/edxapp/group_data/all.py
+++ b/src/bilder/images/edxapp/group_data/all.py
@@ -12,6 +12,7 @@ edx_plugins_added = {
         "ol-openedx-sentry",
         "ol-openedx-course-export",
         "ol-openedx-checkout-external",
+        "sentry-sdk==1.2.1", # Fix RecursionError
         "social-auth-mitxpro==0.6.1",
     ],
     "xpro": [
@@ -53,6 +54,7 @@ edx_plugins_added = {
         # msg=self signed certificate (TMM 2022-12-01)
         # Downgrade to version used in Nutmeg due to conflicts with SAML implementation
         "lxml==4.5.0",
+        "sentry-sdk==1.2.1", # Fix RecursionError
     ],
     "mitx-staging": [
         "celery-redbeat",  # Support for using Redis as the lock for Celery schedules
@@ -81,6 +83,7 @@ edx_plugins_added = {
         # msg=self signed certificate (TMM 2022-12-01)
         # Downgrade to version used in Nutmeg due to conflicts with SAML implementation
         "lxml==4.5.0",
+        "sentry-sdk==1.2.1", # Fix RecursionError
     ],
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Sentry is instrumenting the call to redis, as part of that instrumentation it's calling str() on the return value, which is an instance of BulkEmailFlag . BulkEmailFlag._str_ calls BulkEmailFlag.current, which then gets us into the recursion.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Downgrading Sentry to a version prior to this commit - https://github.com/getsentry/sentry-python/commit/efa55d32c75c90f6bf4afab5d7c8032797821430 until we submit an upstream PR to address it in Open edX
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested downgrading sentry-sdk on one edxapp mitxonline-qa instance and ran `BulkEmailFlag.current()` in the django shell and it didn't throw the RecursionError that it was before.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Enhancement (improves on existing behavior)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (Did you install and run the pre-commit hooks?)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
