### PR TITLE
Add framework tagging to edxapp AMI builds and deploys 

### DIFF
--- a/src/bilder/images/edxapp/custom_install.pkr.hcl
+++ b/src/bilder/images/edxapp/custom_install.pkr.hcl
@@ -83,6 +83,7 @@ source "amazon-ebs" "edxapp" {
     OU              = var.business_unit
     app             = local.app_name
     deployment      = var.installation_target
+    framework       = "ansible"
     purpose         = "${local.app_name}-${var.node_type}"
     openedx_release = var.openedx_release
   }

--- a/src/bilder/images/edxapp/edxapp_base.pkr.hcl
+++ b/src/bilder/images/edxapp/edxapp_base.pkr.hcl
@@ -79,6 +79,7 @@ source "amazon-ebs" "edxapp" {
     Name            = "${local.app_name}-${var.node_type}"
     OU              = "${local.business_unit}"
     app             = "${local.app_name}"
+    framework       = "ansible"
     purpose         = "${local.app_name}-${var.node_type}"
     openedx_release = var.openedx_release
   }

--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -120,11 +120,14 @@ edxapp_vpc = network_stack.require_output(target_vpc)
 edxapp_vpc_id = edxapp_vpc["id"]
 data_vpc = network_stack.require_output("data_vpc")
 data_integrator_secgroup = data_vpc["security_groups"]["integrator"]
+
+framework = "docker" if edxapp_config.get("use_docker") else "ansible"
 ami_filters = [
     ec2.GetAmiFilterArgs(name="virtualization-type", values=["hvm"]),
     ec2.GetAmiFilterArgs(name="root-device-type", values=["ebs"]),
     ec2.GetAmiFilterArgs(name="tag:deployment", values=[stack_info.env_prefix]),
     ec2.GetAmiFilterArgs(name="tag:openedx_release", values=[openedx_release]),
+    ec2.GetAmiFilterArgs(name="tag:framework", values=[framework]),
 ]
 edxapp_web_ami = ec2.get_ami(
     filters=[ec2.GetAmiFilterArgs(name="name", values=["edxapp-web-*"]), *ami_filters],
@@ -139,6 +142,7 @@ edxapp_worker_ami = ec2.get_ami(
     most_recent=True,
     owners=[aws_account.account_id],
 )
+
 edxapp_zone = dns_stack.require_output(edxapp_config.require("dns_zone"))
 edxapp_zone_id = edxapp_zone["id"]
 kms_ebs = kms_stack.require_output("kms_ec2_ebs_key")

--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -121,7 +121,7 @@ edxapp_vpc_id = edxapp_vpc["id"]
 data_vpc = network_stack.require_output("data_vpc")
 data_integrator_secgroup = data_vpc["security_groups"]["integrator"]
 
-framework = "docker" if edxapp_config.get("use_docker") else "ansible"
+framework = "docker" if edxapp_config.get_bool("use_docker") else "ansible"
 ami_filters = [
     ec2.GetAmiFilterArgs(name="virtualization-type", values=["hvm"]),
     ec2.GetAmiFilterArgs(name="root-device-type", values=["ebs"]),


### PR DESCRIPTION
Adding a framework tag to edxapp images to differentiate between old ansible AMIs and new docker AMIs. Practice safe deployments.

# What are the relevant tickets?
N/A

# Description (What does it do?)
While we work on moving edxapp into docker, it is possible for an AMI built around docker to sneak its way through into environments where it is not welcome should a `pulumi up` be run against an env without a corresponding `packer build` for the same env. This is pretty unlikely to happen since we mostly depend on the concourse pipeliens to do the needful at the moment but it is still a possibility. 

This PR does two things: 

1. Adds a tag to the legacy AMIs 'framework: ansible`
2. Adds an AMI filter to the pulumi stacks that defaults to requiring `framework: ansible` unless a configuration option of `edxapp:use_docker: True` is set for an environment. 
