### PR TITLE
config,fix: Enable segmented caching for large files in OCW Fastly

### DIFF
--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -475,6 +475,13 @@ for purpose in ("draft", "live"):
                 name="Reroute Redirects",
                 type="error",
             ),
+            fastly.ServiceVclSnippetArgs(
+                content=snippets_dir.joinpath(
+                    "large_object_segmented_caching.vcl"
+                ).read_text(),
+                name="Segmented Caching",
+                type="recv",
+            ),
         ],
         logging_https=[
             fastly.ServiceVclLoggingHttpArgs(

--- a/src/ol_infrastructure/applications/ocw_site/snippets/large_object_segmented_caching.vcl
+++ b/src/ol_infrastructure/applications/ocw_site/snippets/large_object_segmented_caching.vcl
@@ -1,0 +1,6 @@
+# Enabled segmented caching on files that tend to be large
+# Where "large" means > 2GB in size
+
+if (req.url.ext ~ "(zip|ova)") {
+   set req.enable_segmented_caching = true;
+}


### PR DESCRIPTION
# What are the relevant tickets?
N/A

# Description (What does it do?)
Requests for files that are larger than 2GB will result in a 503 error. This enables segmented caching on zip files and OVA VM images since those are the most likely to exceed that 2GB threshold.

# How can this be tested?
This change has been applied to the QA environment and the functionality is validated by visiting the URL https://live-qa.ocw.mit.edu/courses/16-412j-cognitive-robotics-spring-2016/16.412j-spring-2016.zip