### PR TITLE
fix ocw redirect urls

### DIFF
--- a/src/ol_infrastructure/applications/ocw_site/redirect_dict.json
+++ b/src/ol_infrastructure/applications/ocw_site/redirect_dict.json
@@ -354,7 +354,7 @@
   "/ans7870/21f/21f.027/home/index.html": "307|discard|https://visualizingcultures.mit.edu/",
   "/comments": "307|discard|https://mitocw.zendesk.com/hc/en-us/articles/6636015233051-Comments-Policy-for-YouTube-and-Social-Media",
   "/courses": "307|keep|https://{{AK_HOSTHEADER}}/search/?s=department_course_numbers.sort_coursenum",
-  "/courses/12-003-atmosphere-ocean-and-climate-dynamics-fall-2008/resources/lab11/experiment-xi-baroclinic-instability-of-the-thermal-wind/": "301|discard|https://ocw.mit.edu/courses/12-003-atmosphere-ocean-and-climate-dynamics-fall-2008/resources/experiment-xi-baroclinic-instability-of-the-thermal-wind/",
+  "/courses/12-003-atmosphere-ocean-and-climate-dynamics-fall-2008/resources/lab11/experiment-xi-baroclinic-instability-of-the-thermal-wind": "301|discard|https://ocw.mit.edu/courses/12-003-atmosphere-ocean-and-climate-dynamics-fall-2008/resources/experiment-xi-baroclinic-instability-of-the-thermal-wind/",
   "/courses/6-002x-related-curriculum": "307|keep|https://{{AK_HOSTHEADER}}/courses/mitx-related-courseware/index.htm",
   "/courses/aeronautics-and-astronautics": "307|discard|https://{{AK_HOSTHEADER}}/search/?d=Aeronautics%20and%20Astronautics&s=department_course_numbers.sort_coursenum",
   "/courses/anthropology": "307|discard|https://{{AK_HOSTHEADER}}/search/?d=Anthropology&s=department_course_numbers.sort_coursenum",
@@ -472,6 +472,6 @@
   "/courses/environment-courses": "307|keep|https://{{AK_HOSTHEADER}}/collections/environment/",
   "/courses/intro-programming": "307|keep|https://{{AK_HOSTHEADER}}/collections/introductory-programming/",
   "/courses/transportation-courses": "307|keep|https://{{AK_HOSTHEADER}}/collections/transportation/",
-  "/courses/ocw-scholar/": "307|keep|https://{{AK_HOSTHEADER}}/course-lists/scholar-courses/",
+  "/courses/ocw-scholar": "307|keep|https://{{AK_HOSTHEADER}}/course-lists/scholar-courses/",
   "/fairuse": "301|keep|https://mitocw.zendesk.com/hc/en-us/articles/4414756181403-How-is-all-rights-reserved-content-different-from-the-rest-of-OCW-content/"
 }


### PR DESCRIPTION
# What are the relevant tickets?
Fixes https://github.com/mitodl/ol-infrastructure/issues/1369

# Description (What does it do?)
It appears that redirected URLs in `redirect_dict.json` do not need a trailing`/`. Adding a trailing `/` makes it a different URL.  This PR removes the unnecessary `/`s.

> This is a quick fix for these particular URLs, I do acknowledge that we might need a better long-term solution.

# How can this be tested?
I think would be difficult for me to test it locally, so I intend to do the first test on RC. If there is a way for me to set the entire thing up locally, please let me know.

To test these changes:

On RC, the following URLs should work:
- https://live-qa.ocw.mit.edu/courses/ocw-scholar/
- https://live-qa.ocw.mit.edu/courses/12-003-atmosphere-ocean-and-climate-dynamics-fall-2008/resources/lab11/experiment-xi-baroclinic-instability-of-the-thermal-wind/

And on Prod, the following URLs should work:
- https://ocw.mit.edu/courses/ocw-scholar/
- https://ocw.mit.edu/courses/12-003-atmosphere-ocean-and-climate-dynamics-fall-2008/resources/lab11/experiment-xi-baroclinic-instability-of-the-thermal-wind/