### PR TITLE
Upgrade MIT Open OpenSearch clusters to OS 1.3

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.open.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.open.CI.yaml
@@ -10,7 +10,7 @@ config:
   opensearch:cluster_size: "3"
   opensearch:consul_service_name: 'mitopen-search'
   opensearch:disk_size_gb: "60"
-  opensearch:engine_version: "7.10"
+  opensearch:engine_version: "OpenSearch_1.3"
   opensearch:instance_type: t3.medium.elasticsearch
   opensearch:public_web: "true"
   opensearch:secured_cluster: "true"

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.open.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.open.Production.yaml
@@ -10,7 +10,7 @@ config:
   opensearch:cluster_size: "3"
   opensearch:consul_service_name: 'mitopen-search'
   opensearch:disk_size_gb: "120"
-  opensearch:engine_version: "7.10"
+  opensearch:engine_version: "OpenSearch_1.3"
   opensearch:instance_type: m5.large.elasticsearch
   opensearch:public_web: "true"
   opensearch:secured_cluster: "true"

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.open.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.open.QA.yaml
@@ -10,7 +10,7 @@ config:
   opensearch:cluster_size: "3"
   opensearch:consul_service_name: 'mitopen-search'
   opensearch:disk_size_gb: "120"
-  opensearch:engine_version: "7.10"
+  opensearch:engine_version: "OpenSearch_1.3"
   opensearch:instance_type: t3.medium.elasticsearch
   opensearch:public_web: "true"
   opensearch:secured_cluster: "true"


### PR DESCRIPTION
# What are the relevant tickets?

Updates https://github.com/mitodl/open-discussions/issues/3494

# Description (What does it do?)
Upgrades MIT Open OpenSearch clusters to OS 1.3

# Additional Context
Already applied to CI + QA.

No concourse pipeline for OS clusters at the moment, will be applied to production manually. 


