### PR TITLE
Added a basic keyloak/dagster client

### DIFF
--- a/src/ol_infrastructure/applications/keycloak/Pulumi.applications.keycloak.CI.yaml
+++ b/src/ol_infrastructure/applications/keycloak/Pulumi.applications.keycloak.CI.yaml
@@ -9,7 +9,7 @@ config:
     max: 3
     min: 1
   keycloak:db_capacity: "50"
-  keycloak:domain: keycloak-ci.odl.mit.edu
+  keycloak:domain: sso-ci.odl.mit.edu
   keycloak:rds_password:
     secure: v1:PUfBZ4RNoYON7yXj:31owK3ufKfYy24UFKh4pqIGn0ziPM/jpVIuCnMio9xHL5XaBv/02UmpgYe35GgYuiVoOwTfVamP0a+Lb+cLbbNrmRkBfDSoUEKMjFRwe2ps=
   keycloak:target_vpc: operations_vpc

--- a/src/ol_infrastructure/applications/keycloak/Pulumi.applications.keycloak.QA.yaml
+++ b/src/ol_infrastructure/applications/keycloak/Pulumi.applications.keycloak.QA.yaml
@@ -9,7 +9,7 @@ config:
     max: 3
     min: 1
   keycloak:db_capacity: "50"
-  keycloak:domain: keycloak-qa.odl.mit.edu
+  keycloak:domain: sso-qa.odl.mit.edu
   keycloak:rds_password:
     secure: v1:YMizvIx441k8sgrg:bS5HC/DC3vM8GkwzwTXuBPd9A4xznaxN5GjSF3IdSnJ99D1gOI3M4JevsdJTR2ZGdLwnOy0OULBGuPpxy6bsrOsMXZCEqeVEBlu0VAuhibo=
   keycloak:target_vpc: operations_vpc

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
@@ -12,4 +12,4 @@ config:
     secure: v1:D3r4nV78I5WwOPeq:11qN0BLRcgIZimjisckFz9Q2AA8hXdHubDQxjJHqeQ==
   keycloak:email_username:
     secure: v1:Uxscw7J8NqxO/NbK:NCGzgYTGRmeIovnjZyXrb6ztDW7levn0
-  keycloak:url: https://keycloak-qa.odl.mit.edu
+  keycloak:url: https://sso-qa.odl.mit.edu

--- a/src/ol_infrastructure/substructure/keycloak/__main__.py
+++ b/src/ol_infrastructure/substructure/keycloak/__main__.py
@@ -116,3 +116,15 @@ required_action_update_password = keycloak.RequiredAction(
     enabled=True,
     opts=resource_options,
 )
+
+# Create Dagster OIDC client
+keycloak_domain_name = keycloak_config.require("url")
+dagster_openid_client = keycloak.openid.Client(
+    "ol-dagster-client",
+    realm_id=ol_platform_engineering_realm.realm,
+    client_id="ol-dagster-client",
+    enabled=True,
+    access_type="CONFIDENTIAL",
+    valid_redirect_uris=[f"https://{keycloak_domain_name}/*"],
+    login_theme="keycloak",
+)


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
This is somewhat related to https://github.com/mitodl/ol-infrastructure/issues/1473
# Description (What does it do?)
<!--- Describe your changes in detail -->
Does two things:
- Renames keycloak instances to service name as opposed to product name
- Sets up a very basic dagster OIDC client which will be used by the traefik-forward-auth container config to communicate with keycloak
  - Initially, I was adding a bunch of configurable parameters to the client config, but then changed it back to keep it simple for now so that we can test things out and make sure the flow works before tweaking things further.
# Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
I couldn't test the substructure bit as that was looking for the renamed keycloak domain name, however, I tried previewing the minor renaming change and that seems to be working.
# Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
## Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
