### PR TITLE
config: override brand for learner dashboard MFE in MITxOnline QA

### DIFF
--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -119,7 +119,10 @@ def mfe_job(
         npm install @edx/frontend-component-footer@npm:@mitodl/frontend-component-footer-mitol@latest --legacy-peer-deps
         npm install @edx/frontend-component-header@npm:@mitodl/frontend-component-header-mitol@latest --legacy-peer-deps"""  # noqa: E501
     )
-    if open_edx.environment == "mitx-ci" and mfe_name == "frontend-app-learner-dashboard":
+    if (
+        open_edx.environment == "mitx-ci"
+        and mfe_name == "frontend-app-learner-dashboard"
+    ):
         branding_overrides += textwrap.dedent(
             """\
 

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -123,7 +123,7 @@ def mfe_job(
         branding_overrides += textwrap.dedent(
             """\
 
-            npm install @edx/brand@git+https://git@github.com/mitodl/brand-mitol-residential#master --legacy-peer-deps"""  # noqa: E501
+            npm install @edx/brand@npm:@mitodl/brand-mitol-residential@latest --legacy-peer-deps"""  # noqa: E501
         )
     if previous_job and mfe_repo.name == previous_job.plan[0].get:
         clone_git_repo.passed = [previous_job.name]

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -119,6 +119,12 @@ def mfe_job(
         npm install @edx/frontend-component-footer@npm:@mitodl/frontend-component-footer-mitol@latest --legacy-peer-deps
         npm install @edx/frontend-component-header@npm:@mitodl/frontend-component-header-mitol@latest --legacy-peer-deps"""  # noqa: E501
     )
+    if open_edx.environment == "mitx-ci" and mfe_name == "frontend-app-learner-dashboard":
+        branding_overrides += textwrap.dedent(
+            """\
+
+            npm install @edx/brand@git+https://git@github.com/mitodl/brand-mitol-residential#master --legacy-peer-deps"""  # noqa: E501
+        )
     if previous_job and mfe_repo.name == previous_job.plan[0].get:
         clone_git_repo.passed = [previous_job.name]
     mfe_job_definition = Job(


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/hq/issues/1499, Specifically https://github.com/mitodl/brand-mitol-residential/pull/1#issuecomment-1584648648

# Description (What does it do?)
- Adds an override for `brand-edx.org` and uses our own custom brand
- The override should only affect the learner dashboard MFE and Residential MITx-CI for now.

<!--- Describe your changes in detail -->
- There are a lot of details mentioned in https://github.com/mitodl/hq/issues/1499

# Screenshots (if appropriate):
Screenshots can be seen in https://github.com/mitodl/hq/issues/1499

# How can this be tested?
- Once deployed, We should not see any `Upgrade` button or `Looking for New Challange` card


# Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
## Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
