### PR TITLE
Treat lock files as binary for git merge purposes.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+poetry.lock binary
+yarn.lock binary
+black.lockfile binary
+build-support-bin.lockfile binary
+flake8.lockfile binary
+ipython.lockfile binary
+isort.lockfile binary
+mypy.lockfile binary
+pytest.lockfile binary
+python-default.lockfile binary
+testing.lockfile binary


### PR DESCRIPTION
# What are the relevant tickets?
N/A

# Description (What does it do?)

This .gitattributes file tells git to treat all the various lock files we know about as binary, because hand merging things like yarn.lock is an error prone operation.

# How can this be tested?

Ran git check-attributes binary poetry.lock

```
# cpatti @ rocinante in ~/src/mit/ol-infrastructure on git:main x [10:10:07] 
$ git check-attr binary poetry.lock
poetry.lock: binary: set
```

