### PR TITLE
Fix error deleting read_replica

### DIFF
--- a/src/ol_infrastructure/components/aws/database.py
+++ b/src/ol_infrastructure/components/aws/database.py
@@ -223,6 +223,7 @@ class OLAmazonDB(pulumi.ComponentResource):
         if db_config.read_replica:
             self.db_replica = rds.Instance(
                 f"{db_config.instance_name}-{db_config.engine}-replica",
+                final_snapshot_identifier=f"{db_config.instance_name}-{db_config.engine}-final-snapshot",  # noqa: E501
                 identifier=f"{db_config.instance_name}-replica",
                 instance_class=db_config.read_replica.instance_size,
                 kms_key_id=self.db_instance.kms_key_id,

--- a/src/ol_infrastructure/components/aws/database.py
+++ b/src/ol_infrastructure/components/aws/database.py
@@ -223,13 +223,13 @@ class OLAmazonDB(pulumi.ComponentResource):
         if db_config.read_replica:
             self.db_replica = rds.Instance(
                 f"{db_config.instance_name}-{db_config.engine}-replica",
-                final_snapshot_identifier=f"{db_config.instance_name}-{db_config.engine}-final-snapshot",  # noqa: E501
                 identifier=f"{db_config.instance_name}-replica",
                 instance_class=db_config.read_replica.instance_size,
                 kms_key_id=self.db_instance.kms_key_id,
                 opts=resource_options,
                 publicly_accessible=db_config.read_replica.public_access,
                 replicate_source_db=self.db_instance.id,
+                skip_final_snapshot=True,
                 storage_type=db_config.read_replica.storage_type.value,
                 storage_encrypted=True,
                 tags=db_config.tags,


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A
# Description (What does it do?)
<!--- Describe your changes in detail -->
Ran into the following error when running a pulumi destroy on the Keycloak production deployment:
```
 error: deleting urn:pulumi:applications.keycloak.Production::ol-infrastructure-keycloak-application::ol:infrastructure:aws:database:OLAmazonDB$aws:rds/instance:Instance::keycloak-production-postgres-replica: 1 error occurred:
    	* final_snapshot_identifier is required when skip_final_snapshot is false
```

Looking at the docs, appears that `skip_final_snapshot` is set to `false` by default. PR simply adds a `final_snapshot_identifier` in line with the other snapshot identifiers.

# Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

# Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
## Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
