### PR TITLE
feat: enable mktg site

### DIFF
--- a/src/bilder/images/edxapp/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -275,6 +275,7 @@ FEATURES:
     ENABLE_COMBINED_LOGIN_REGISTRATION: true
     ENABLE_CORS_HEADERS: true  # MODIFIED
     ENABLE_COUNTRY_ACCESS: false
+    ENABLE_COURSE_HOME_REDIRECT: true
     ENABLE_CREDIT_API: false
     ENABLE_CREDIT_ELIGIBILITY: false
     ENABLE_CROSS_DOMAIN_CSRF_COOKIE: true  # MODIFIED
@@ -289,7 +290,7 @@ FEATURES:
     ENABLE_GRADE_DOWNLOADS: true
     ENABLE_INSTRUCTOR_ANALYTICS: false
     ENABLE_LTI_PROVIDER: false
-    ENABLE_MKTG_SITE: false
+    ENABLE_MKTG_SITE: true
     ENABLE_MOBILE_REST_API: true
     ENABLE_NEW_BULK_EMAIL_EXPERIENCE: true  # ADDED KEY
     ENABLE_OAUTH2_PROVIDER: true
@@ -356,7 +357,8 @@ MEDIA_URL: /media/
 MICROSITE_CONFIGURATION: {}
 MICROSITE_ROOT_DIR: /edx/app/edxapp/edx-microsite
 MITXPRO_CORE_REDIRECT_ALLOW_RE_LIST: ["^/(admin|auth|logout|register|api|oauth2|user_api|heartbeat|login_refresh)", "^/courses/.*/xblock/.*/handler_noauth/outcome_service_handler"]  # ADDED VALUE
-MKTG_URLS: {}
+MKTG_URLS:
+    ROOT: https://{{ key "edxapp/marketing-domain" }}/
 MKTG_URL_LINK_MAP:
     TOS: tos
     HONOR: honor
@@ -364,7 +366,14 @@ MKTG_URL_LINK_MAP:
     PRIVACY: privacy
     ACCESSIBILITY: accessibility
     HELP_CENTER: help-center
-MKTG_URL_OVERRIDES: {}
+MKTG_URL_OVERRIDES:
+    COURSES: https://{{ key "edxapp/marketing-domain" }}/
+    PRIVACY: https://{{ key "edxapp/marketing-domain" }}/privacy-policy/
+    TOS: https://{{ key "edxapp/marketing-domain" }}/terms-of-service/
+    ABOUT: https://{{ key "edxapp/marketing-domain" }}/about-us/
+    HONOR: https://{{ key "edxapp/marketing-domain" }}/honor-code/
+    ACCESSIBILITY: https://accessibility.mit.edu/
+    TOS_AND_HONOR: ''
 MOBILE_STORE_URLS: {}
 ########################################################################################
 # Previously assumed to be unnecessary config as it duplicates code from               #


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
fixes https://github.com/mitodl/hq/issues/1725

# Description (What does it do?)
<!--- Describe your changes in detail -->

- Enables marketing site for MITxOnline Open edX.
- Redirects course about page to course home.
- Redirects `/courses/` in Open edX to the MITxOnline homepage.
- Adds MKTG_URL_OVERRIDES, previously added through site configs in Django Admin.


# Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Update settings locally and verify that:

- Course about redirects to course home in the Learning MFE.
- `/courses/` redirects to the marketing site URL.
- Footer URLs match configs MKTG_URL_LINK_MAP & MKTG_URL_OVERRIDES

# Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
## Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
