### PR TITLE
setup a cronjob for "process scheduled instructor tasks"

### DIFF
--- a/src/bilder/images/edxapp/deploy.py
+++ b/src/bilder/images/edxapp/deploy.py
@@ -144,6 +144,18 @@ files.line(
 )
 
 files.put(
+    name="Setup process_scheduled_instructor_tasks cron task.",
+    src=str(
+        Path(__file__)
+        .resolve()
+        .parent.joinpath("files", "process_scheduled_instructor_tasks")
+    ),
+    dest=str(Path("/etc/cron.d/process_scheduled_instructor_tasks")),
+    user="root",
+    group="root",
+)
+
+files.put(
     name="Setup the database migrations service definition",
     src=str(Path(__file__).resolve().parent.joinpath("files", "migrations.service")),
     dest=str(Path("/usr/lib/systemd/system/migrations.service")),

--- a/src/bilder/images/edxapp/files/process_scheduled_instructor_tasks
+++ b/src/bilder/images/edxapp/files/process_scheduled_instructor_tasks
@@ -1,0 +1,3 @@
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+*/10 * * * * edxapp source /edx/app/edxapp/edxapp_env; python edx-platform/manage.py lms process_scheduled_instructor_tasks


### PR DESCRIPTION


# What are the relevant tickets?
https://github.com/mitodl/hq/issues/1503

# Description (What does it do?)
Adding a cron task to legacy edxapp nodes to execute process_scheduled_instructor_tasks management command every 10 minutes.

# Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

# How can this be tested?
Tested by building a mitxonline AMI locally and deploying to RC. Then setup a scheduled email to myself on a test course and waited for the. scheduled time to pass. Got the email at the :10 minute mark following the scheduled time as expected. 

# Additional Context
@pdpinch FYI

