### PR TITLE
refactor: Add a means of overriding branding components in MFEs

### DIFF
--- a/src/bridge/settings/openedx/types.py
+++ b/src/bridge/settings/openedx/types.py
@@ -128,6 +128,7 @@ class OpenEdxApplicationVersion(BaseModel):
     branch_override: Optional[str]
     origin_override: Optional[str]
     runtime_version_override: Optional[str]
+    branding_overrides: Optional[dict[str, str]]
 
     @property
     def runtime_version(self) -> str:

--- a/src/bridge/settings/openedx/version_matrix.py
+++ b/src/bridge/settings/openedx/version_matrix.py
@@ -57,6 +57,12 @@ class OpenLearningOpenEdxDeployment(Enum):
         return deployment.value
 
 
+default_branding_overrides = {
+    "@edx/frontend-component-footer@npm": "@mitodl/frontend-component-footer-mitol@latest",  # noqa: E501
+    "@edx/frontend-component-header@npm": "@mitodl/frontend-component-header-mitol@latest",  # noqa: E501
+}
+
+
 ReleaseMap: dict[
     OpenEdxSupportedRelease,
     dict[OpenEdxDeploymentName, list[OpenEdxApplicationVersion]],
@@ -67,11 +73,13 @@ ReleaseMap: dict[
                 application="communications",  # type: ignore
                 application_type="MFE",
                 release="palm",
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="course-authoring",  # type: ignore
                 application_type="MFE",
                 release="palm",
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="edx-platform",  # type: ignore
@@ -96,22 +104,29 @@ ReleaseMap: dict[
                 application="gradebook",  # type: ignore
                 application_type="MFE",
                 release="palm",
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="learner-dashboard",  # type: ignore
                 application_type="MFE",
                 release="palm",
+                branding_overrides={
+                    "@edx/brand@npm": "@mitodl/brand-mitol-residential@latest",
+                    **default_branding_overrides,
+                },
             ),
             OpenEdxApplicationVersion(
                 application="learning",  # type: ignore
                 application_type="MFE",
                 release="palm",
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="library-authoring",  # type: ignore
                 application_type="MFE",
                 release="palm",
                 branch_override="master",
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="notes-api",  # type: ignore
@@ -122,6 +137,7 @@ ReleaseMap: dict[
                 application="ora-grading",  # type: ignore
                 application_type="MFE",
                 release="palm",
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="xqueue",  # type: ignore
@@ -134,11 +150,13 @@ ReleaseMap: dict[
                 application="communications",  # type: ignore
                 application_type="MFE",
                 release="palm",
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="course-authoring",  # type: ignore
                 application_type="MFE",
                 release="palm",
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="edx-platform",  # type: ignore
@@ -163,22 +181,29 @@ ReleaseMap: dict[
                 application="gradebook",  # type: ignore
                 application_type="MFE",
                 release="palm",
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="learning",  # type: ignore
                 application_type="MFE",
                 release="palm",
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="learner-dashboard",  # type: ignore
                 application_type="MFE",
                 release="palm",
+                branding_overrides={
+                    "@edx/brand@npm": "@mitodl/brand-mitol-residential@latest",
+                    **default_branding_overrides,
+                },
             ),
             OpenEdxApplicationVersion(
                 application="library-authoring",  # type: ignore
                 application_type="MFE",
                 release="palm",
                 branch_override="master",
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="notes-api",  # type: ignore
@@ -189,6 +214,7 @@ ReleaseMap: dict[
                 application="ora-grading",  # type: ignore
                 application_type="MFE",
                 release="palm",
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="xqueue",  # type: ignore
@@ -205,6 +231,7 @@ ReleaseMap: dict[
                 release="olive",
                 branch_override="master",
                 runtime_version_override="16",
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="edx-platform",  # type: ignore
@@ -228,12 +255,14 @@ ReleaseMap: dict[
                 application_type="MFE",
                 release="olive",
                 runtime_version_override="16",
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="learning",  # type: ignore
                 application_type="MFE",
                 release="olive",
                 runtime_version_override="16",
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="library-authoring",  # type: ignore
@@ -241,6 +270,7 @@ ReleaseMap: dict[
                 release="olive",
                 branch_override="master",
                 runtime_version_override="16",
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="notes-api",  # type: ignore
@@ -252,6 +282,7 @@ ReleaseMap: dict[
                 application_type="MFE",
                 release="olive",
                 runtime_version_override="16",
+                branding_overrides=default_branding_overrides,
             ),
         ],
     },
@@ -261,12 +292,13 @@ ReleaseMap: dict[
                 application="communications",  # type: ignore
                 application_type="MFE",
                 release="master",
-                origin_override="https://github.com/mitodl/frontend-app-communications",
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="course-authoring",  # type: ignore
                 application_type="MFE",
                 release="master",
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="edx-platform",  # type: ignore
@@ -290,6 +322,7 @@ ReleaseMap: dict[
                 application="gradebook",  # type: ignore
                 application_type="MFE",
                 release="master",
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="learning",  # type: ignore
@@ -297,16 +330,19 @@ ReleaseMap: dict[
                 release="master",
                 branch_override="open-learning",
                 origin_override="https://github.com/mitodl/frontend-app-learning",
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="library-authoring",  # type: ignore
                 application_type="MFE",
                 release="master",
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="ora-grading",  # type: ignore
                 application_type="MFE",
                 release="master",
+                branding_overrides=default_branding_overrides,
             ),
         ],
     },

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -114,20 +114,12 @@ def mfe_job(
         get=mfe_repo.name,
         trigger=previous_job is None and open_edx.environment_stage != "production",
     )
-    branding_overrides = textwrap.dedent(
-        """\
-        npm install @edx/frontend-component-footer@npm:@mitodl/frontend-component-footer-mitol@latest --legacy-peer-deps
-        npm install @edx/frontend-component-header@npm:@mitodl/frontend-component-header-mitol@latest --legacy-peer-deps"""  # noqa: E501
-    )
-    if (
-        open_edx.environment == "mitx-ci"
-        and mfe_name == "frontend-app-learner-dashboard"
-    ):
-        branding_overrides += textwrap.dedent(
-            """\
-
-            npm install @edx/brand@npm:@mitodl/brand-mitol-residential@latest --legacy-peer-deps"""  # noqa: E501
+    branding_overrides = "\n".join(
+        (
+            f"npm install {component}:{override} --legacy-peer-deps"
+            for component, override in mfe.branding_overrides.items()
         )
+    )
     if previous_job and mfe_repo.name == previous_job.plan[0].get:
         clone_git_repo.passed = [previous_job.name]
     mfe_job_definition = Job(


### PR DESCRIPTION
# What are the relevant tickets?
N/A

# Description (What does it do?)
This adds a common mechanism for specifying which MFE components to override with which plugins.

# How can this be tested?
This has been manually applied to the mitx-staging MFE pipeline