### PR TITLE
Add helper method for InstanceTypes enum

### DIFF
--- a/src/ol_infrastructure/applications/concourse/__main__.py
+++ b/src/ol_infrastructure/applications/concourse/__main__.py
@@ -637,11 +637,7 @@ for worker_def in concourse_config.get_object("workers") or []:
     worker_instance_type_name = worker_def.get(
         "instance_type", InstanceTypes.burstable_large.name
     )
-    try:
-        worker_instance_type = InstanceTypes[worker_instance_type_name].value
-    except KeyError:
-        # The instance type specified is a direct specifier (e.g. t3a.large)
-        worker_instance_type = worker_instance_type_name
+    worker_instance_type = InstanceTypes.dereference(worker_instance_type_name)
     worker_launch_config = ec2.LaunchTemplate(
         f"concourse-worker-{worker_class_name}-launch-template",
         name_prefix=f"concourse-worker-{worker_class_name}-{stack_info.env_suffix}-",

--- a/src/ol_infrastructure/applications/keycloak/__main__.py
+++ b/src/ol_infrastructure/applications/keycloak/__main__.py
@@ -240,10 +240,10 @@ keycloak_db_consul_service = Service(
 )
 
 # Provision EC2 resources
-instance_type_name = (
-    keycloak_config.get("instance_type") or InstanceTypes.burstable_medium.name
+instance_type_name = keycloak_config.get(
+    "instance_type", InstanceTypes.burstable_medium.name
 )
-instance_type = InstanceTypes[instance_type_name].value
+instance_type = InstanceTypes.dereference(instance_type_name)
 
 subnets = target_vpc["subnet_ids"]
 subnet_id = subnets.apply(chain)


### PR DESCRIPTION
# What are the relevant tickets?
N/A

# Description (What does it do?)
The instance types enum is intended as a means of managing evolution of instance types deployed without having to find/replace across the whole repo. Sometimes we want to use an instance type that is not commonly applied, so we have to route around the `InstanceTypes` enum. This adds a `dereference` method to the enum to allow for using it as a common pass-through, while also ensuring that we are using valid instance types.

# How can this be tested?
This was tested by factoring it into the Concourse and Keycloak code and ensuring that it ran without error. Concourse in particular has a mix of enumerated and non-enumerated instance types.