### PR TITLE
Issue 1571 , ocw-preview.odl.mit.edu -> live

### DIFF
--- a/src/ol_infrastructure/applications/ocw_site/Pulumi.applications.ocw_site.Production.yaml
+++ b/src/ol_infrastructure/applications/ocw_site/Pulumi.applications.ocw_site.Production.yaml
@@ -6,8 +6,8 @@ config:
   ocw_site:domains:
     draft:
     - draft.ocw.mit.edu
-    - ocw-preview.odl.mit.edu
     live:
     - live.ocw.mit.edu
     - ocw.mit.edu
     - www.ocw.mit.edu
+    - ocw-preview.odl.mit.edu


### PR DESCRIPTION
# What are the relevant tickets?
Closes #1571 

CC @pdpinch 

# Description (What does it do?)
Moving ocw-preview.odl.mit.edu from pointing to draft to pointing to live.

# Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

# How can this be tested?
N/A

# Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
## Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
