### PR TITLE
Render ol_concourse pipelines by alias

### DIFF
--- a/src/bilder/components/hashicorp/consul/models.py
+++ b/src/bilder/components/hashicorp/consul/models.py
@@ -116,8 +116,12 @@ class Consul(HashicorpProduct):
 
     @property
     def data_directory(self) -> Path:
-        data_dir = next(iter(filter(
-                None,
-                map(lambda config: config.data_dir, self.configuration.values()),
-            )))
+        data_dir = next(
+            iter(
+                filter(
+                    None,
+                    map(lambda config: config.data_dir, self.configuration.values()),
+                )
+            )
+        )
         return data_dir or Path("/var/lib/consul/")

--- a/src/ol_concourse/lib/models/pipeline.py
+++ b/src/ol_concourse/lib/models/pipeline.py
@@ -11,7 +11,7 @@ from typing import Any, Literal, Optional, Union
 from pydantic import BaseModel, ConstrainedStr, Extra, Field, PositiveInt
 
 
-class Identifier(ConstrainedStr):
+class Identifier(ConstrainedStr):  # type: ignore
     regex = re.compile(r"^[a-z][\w\d\-_.]*$")
 
 
@@ -1920,6 +1920,7 @@ class Pipeline(BaseModel):
 
     def json(self, *args, **kwargs):
         kwargs["exclude_none"] = True
+        kwargs["by_alias"] = True
         return super().json(*args, **kwargs)
 
     jobs: Optional[list[Job]] = Field(


### PR DESCRIPTION
# What are the relevant tickets?
closes #1637 

# Description (What does it do?)
Render pipelines by_alias to ensure that try steps come out as `try` and not `try_`


# How can this be tested?
Wrap any pipeline step in `TryStep(try_=<previous step here>)`

```diff
--- a/src/ol_concourse/pipelines/infrastructure/grafana_cloud/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/grafana_cloud/pipeline.py
@@ -11,6 +11,7 @@ from ol_concourse.lib.models.pipeline import (
     Pipeline,
     Platform,
     PutStep,
+    TryStep,
     RegistryImage,
     TaskConfig,
     TaskStep,
@@ -79,7 +80,7 @@ commit_managed_dashboards_job = Job(
     name="commit-managed-dashboards-from-ci",
     build_log_retention={"days": 2},
     plan=[
-        GetStep(get=build_schedule.name, trigger=True),
+        TryStep(try_=GetStep(get=build_schedule.name, trigger=True)),
         GetStep(get=grafana_dashboards.name, trigger=True),
         TaskStep(
             task=Identifier("get-managed-dashboards-from-ci"),
```
```
 ~/code/2ol-inf/src/ol_concourse/pipelines/infrastructure/grafana_cloud$  (md/issue_1637)| pr python ./pipeline.py | grep try
          "try_": {
```
```
 ~/code/2ol-inf/src/ol_concourse/pipelines/infrastructure/grafana_cloud$  (md/issue_1637)| pr python ./pipeline.py | grep try
          "try": {
...
```



