### PR TITLE
ocw_studio issue 1874

### DIFF
--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -302,7 +302,7 @@ ocw_starter_webhook = github.RepositoryWebhook(
         url="https://{}/api/starters/site_configs/".format(
             ocw_studio_config.require("app_domain")
         ),
-        content_type="application/json",
+        content_type="json",
         secret=vault_secrets["github_shared_secret"],
     ),
     opts=github_options,


### PR DESCRIPTION
# What are the relevant tickets?
closes : https://github.com/mitodl/ocw-studio/issues/1874

# Description (What does it do?)
Fixing content_type for ocw studio gh webhook definitions.

https://www.pulumi.com/registry/packages/github/api-docs/repositorywebhook/#repositorywebhookconfiguration

> The content type for the payload. Valid values are either `form` or `json`.
