### PR TITLE
feat: allow bulk retirement API url

### DIFF
--- a/src/bilder/images/edxapp/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -358,7 +358,7 @@ MEDIA_ROOT: media/  # MODIFIED - with s3 storage backend this is the path within
 MEDIA_URL: /media/
 MICROSITE_CONFIGURATION: {}
 MICROSITE_ROOT_DIR: /edx/app/edxapp/edx-microsite
-MITXPRO_CORE_REDIRECT_ALLOW_RE_LIST: ["^/(admin|auth|logout|register|api|oauth2|user_api|heartbeat|login_refresh)", "^/courses/.*/xblock/.*/handler_noauth/outcome_service_handler"]  # ADDED VALUE
+MITXPRO_CORE_REDIRECT_ALLOW_RE_LIST: ["^/(admin|auth|logout|register|api|oauth2|user_api|heartbeat|login_refresh)", "^/courses/.*/xblock/.*/handler_noauth/outcome_service_handler", "^/v1/accounts/bulk_retire_users"]  # ADDED VALUE
 MKTG_URLS:
     ROOT: https://{{ key "edxapp/marketing-domain" }}/
 MKTG_URL_LINK_MAP:

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -344,7 +344,7 @@ MARKETING_SITE_CHECKOUT_URL: https://{{ key "edxapp/marketing-domain" }}/cart/ad
 MEDIA_ROOT: media/  # MODIFIED - with s3 storage backend this is the path within the bucket. No leading / allowed
 MEDIA_URL: /media/
 MICROSITE_CONFIGURATION: {}
-MITXPRO_CORE_REDIRECT_ALLOW_RE_LIST: ["^/(admin|auth|logout|register|api|oauth2|user_api|heartbeat|login_refresh)", "^/courses/.*/xblock/.*/handler_noauth/outcome_service_handler"]  # ADDED VALUE
+MITXPRO_CORE_REDIRECT_ALLOW_RE_LIST: ["^/(admin|auth|logout|register|api|oauth2|user_api|heartbeat|login_refresh)", "^/courses/.*/xblock/.*/handler_noauth/outcome_service_handler", "^/v1/accounts/bulk_retire_users"]  # ADDED VALUE
 MKTG_URLS:
     ROOT: https://{{ key "edxapp/marketing-domain" }}/
 MKTG_URL_LINK_MAP:


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes https://github.com/mitodl/mitxonline/issues/697

# Description (What does it do?)
<!--- Describe your changes in detail -->
Updates the redirect allow list to allow the bulk retirement API URL.

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Can be tested by following the steps mentioned in this [PR](https://github.com/mitodl/mitxonline/pull/1785#issue-1824315167)

<!--- Uncomment and add steps to be completed before merging this PR if necessary
## Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
