### PR TITLE
use_docker: true for mitxonline-production

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
@@ -28,6 +28,7 @@ config:
   edxapp:google_analytics_id: UA-5145472-48
   edxapp:mail_domain: edxapp-mail.mitxonline.mit.edu
   edxapp:sender_email_address: mitxonline-support@mit.edu
+  edxapp:use_docker: true
   edxapp:web_node_capacity: "9"
   edxapp:worker_node_capacity: "5"
   mongodb:atlas_project_id: 61f0a63f8bc1f86a073a7148


### PR DESCRIPTION

# Description (What does it do?)
Setting the mitxonline production env to use docker.
