### PR TITLE
Install cron on vault servers with Debian 12.1

### DIFF
--- a/src/bilder/images/vault/deploy.py
+++ b/src/bilder/images/vault/deploy.py
@@ -53,7 +53,7 @@ VERSIONS = {
 TEMPLATES_DIRECTORY = Path(__file__).parent.joinpath("templates")
 FILES_DIRECTORY = Path(__file__).parent.joinpath("files")
 
-install_baseline_packages(packages=["curl", "gnupg", "jq"])
+install_baseline_packages(packages=["curl", "gnupg", "jq", "cron"])
 # Set up configuration objects
 set_env_secrets(Path("consul/consul.env"))
 # Install Traefik


### PR DESCRIPTION
# What are the relevant tickets?
Closes #1664

# Description (What does it do?)
Explicitly install cron on vault servers which is needed for raft backups. 
