### PR TITLE
Fix DummyVarSource in ol-concourse

### DIFF
--- a/src/ol_concourse/lib/models/pipeline.py
+++ b/src/ol_concourse/lib/models/pipeline.py
@@ -225,7 +225,7 @@ class Number(RootModel[float]):
 class DummyConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    vars: Optional[Vars] = Field(
+    vars: Optional[dict[str, Any]] = Field(
         None, description="A mapping of var name to var value."
     )
 

--- a/src/ol_concourse/lib/models/pipeline.py
+++ b/src/ol_concourse/lib/models/pipeline.py
@@ -1981,7 +1981,7 @@ class Pipeline(BaseModel):
             " pipeline to use."
         ),
     )
-    var_sources: Optional[list[VarSource]] = Field(
+    var_sources: Optional[list[SerializeAsAny[VarSource]]] = Field(
         None, description="A set of  var-sources  for the pipeline to use."
     )
     display: Optional[DisplayConfig] = Field(

--- a/src/ol_concourse/lib/models/pipeline.py
+++ b/src/ol_concourse/lib/models/pipeline.py
@@ -591,7 +591,7 @@ class DummyVarSource(VarSource):
         ),
     )
     type: Optional[Literal["dummy"]] = Field(
-        None,
+        "dummy",
         description=(
             "The `dummy` type supports configuring a static map of vars to values.   "
             " This is really only useful if you have no better alternative for"

--- a/src/ol_concourse/lib/models/pipeline.py
+++ b/src/ol_concourse/lib/models/pipeline.py
@@ -581,7 +581,7 @@ class AcrossVar(BaseModel):
     )
 
 
-class DummyVarSource(BaseModel):
+class DummyVarSource(VarSource):
     model_config = ConfigDict(extra="forbid")
 
     config: Optional[DummyConfig] = Field(


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ol-infrastructure/issues/1686

# Description (What does it do?)
This PR updates the Pydantic models in `src/ol_concourse/lib/models/pipeline.py` to reflect the [schema](https://concourse-ci.org/vars.html#schema.var_source) that a `dummy` type var source should have:

 - `DummyVarSource` now extends `VarSource` instead of `BaseModel`
 - `var_sources` on the `Pipeline` model now has the list of `VarSource` it takes wrapped in `SerializeAsAny` to make sure that the extended properties are also serialized
 - The default on the `type` field in `DummyVarSource` was changed to `"dummy"` because that's what it's supposed to be
 - The type of the `vars` property on `DummyConfig` was changed to `dict[str, Any]` to reflect that the value is supposed to be an arbitrary dictionary of string var names to values

# How can this be tested?
 - Set up `ol-infrastructure` and make sure you have `pants` installed
 - Build `ol-concourse` with `~/bin/pants package src/ol_concourse/:ol-concourse`
 - Install it into your Python environment with `poetry run pip install dist/ol-concourse-0.5.1.tar.gz`
 - In a Python shell, run the following:
```python
from ol_concourse.lib.models.pipeline import *

dummy_vars = {"test_1": "value_1", "test_2": {"test_3": "value_3", "test_4": "value_4"}}
dummy_config = DummyConfig(vars=dummy_vars)
dummy_var_source = DummyVarSource(name="test_dummy", config=dummy_config)
test_pipeline = Pipeline(var_sources=[dummy_var_source])
test_pipeline.model_dump_json(indent=2)
```
 - You should see output that looks like this, although in the shell output it may look ugly with `\n` everywhere:
```json
{
  "var_sources": [
    {
      "name": "test_dummy",
      "config": {
        "vars": {
          "test_1": "value_1",
          "test_2": {
            "test_3": "value_3",
            "test_4": "value_4"
          }
        }
      },
      "type": "dummy"
    }
  ]
}
```
