### PR TITLE
Test PT change

### DIFF
--- a/dockerfiles/openedx-edxapp/Dockerfile
+++ b/dockerfiles/openedx-edxapp/Dockerfile
@@ -111,6 +111,7 @@ RUN pip install --no-warn-script-location --user --no-cache-dir -e "git+https://
     && pip install --no-warn-script-location --user --no-cache-dir -e "git+https://github.com/openedx/blockstore.git@9d623bc04f479a1af29204d438fa442ea8380fae#egg=blockstore" \
     && pip install --no-warn-script-location --user --no-cache-dir -e "git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner"
 RUN if [ "$DEPLOYMENT_NAME" = "mitxonline" ]; then pip install --no-warn-script-location --user --no-cache-dir "edx-proctoring-proctortrack==1.2.1"; fi
+RUN echo '{"status":"done","chunks":{"edx-proctoring-proctortrack":[{"name":"edx-proctoring-proctortrack.js","path":"/openedx/edx-platform/common/static/bundles/edx-proctoring-proctortrack.js"}]}}' > /openedx/staticfiles/webpack-worker-stats.json
 
 RUN openedx-assets xmodule \
     && openedx-assets npm \


### PR DESCRIPTION
# Description (What does it do?)
Just testing to see if having the /openedx/staticfiles/webpack-worker-stats.json in place ends up creating the PT JS bundle

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Let concourse do its thing and check the container to see if the JS bundle is created here - /openedx/edx-platform/common/static/bundles/edx-proctoring-proctortrack.js


<!--- Uncomment and add steps to be completed before merging this PR if necessary
## Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
