### PR TITLE
md5 passwords for mit open database users

### DIFF
--- a/src/ol_infrastructure/applications/mitopen/__main__.py
+++ b/src/ol_infrastructure/applications/mitopen/__main__.py
@@ -187,6 +187,7 @@ mitopen_db_config = OLPostgresDBConfig(
     security_groups=[mitopen_db_security_group],
     tags=aws_config.tags,
     db_name="mitopen",
+    parameter_overrides=[{"name": "password_encryption", "value": "md5"}],
     public_access=True,
     **rds_defaults,
 )


### PR DESCRIPTION
# What are the relevant tickets?
#1657 

# Description (What does it do?)
Setting default password encryption to md5 for mitopen rds instance.

# Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

# Additional Context
pgbouncer is a complication with scram-sha-256 + heroku in the mix makes it a big complication.


<!--- Uncomment and add steps to be completed before merging this PR if necessary
## Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
