### PR TITLE
Change Value class in ol-concourse to a type of Any instead of str

### DIFF
--- a/src/ol_concourse/BUILD
+++ b/src/ol_concourse/BUILD
@@ -11,7 +11,7 @@ python_distribution(
     description="A Pythonic way to manage your Concourse pipelines",
     provides=python_artifact(
         name="ol-concourse",
-        version="0.5.2",
+        version="0.5.3",
     ),
     repositories=["@pypi"]
 )

--- a/src/ol_concourse/lib/models/pipeline.py
+++ b/src/ol_concourse/lib/models/pipeline.py
@@ -56,8 +56,8 @@ class Version(RootModel[dict[str, str]]):
     root: dict[str, str]
 
 
-class Value(RootModel[str]):
-    root: str
+class Value(RootModel[Any]):
+    pass
 
 
 class Duration(RootModel[str]):


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ol-infrastructure/issues/1709

# Description (What does it do?)
This PR changes the type of the `Value` class used in the `value` property of `AcrossStep` to `Any` from `str`, allowing any type of complex variable to be used.

# How can this be tested?
 - Make sure you have `pants` installed
 - `~/bin/pants package src/ol_concourse/:ol-concourse`
 - Install the resulting package in a Python environment
 - Run the following:
```
from ol_concourse.lib.models.pipeline import *

across_var = AcrossVar(
    var="test",
    values=[{"key1": "value1", "key2": {"key3": "value3", "key4": "value4"}}],
)
across_var.model_dump_json()
```
 - In the printed JSON, you should see the var structure that we put in and should not encounter any errors
