### PR TITLE
feat: Automatically write Keycloak client credentials to Vault

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.CI.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.CI.yaml
@@ -21,3 +21,5 @@ config:
   - realm_name: olapps
     client_info:
       open-local: "*"
+  vault:address: https://vault-ci.odl.mit.edu
+  vault_server:env_namespace: operations.ci

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.Production.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.Production.yaml
@@ -2,6 +2,10 @@
 secretsprovider: awskms://alias/infrastructure-secrets-production
 encryptedkey: AQICAHiiGjYUolrtj8PCnScLM7oLAdMl8nJrLjQjnqyl1LykYgF6LD3AC9aDhHZ8J3SdTKTrAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM7UqV4xkz6mym2LbAAgEQgDt2BFqcsnYAUr+fyvsAmQKTBuYpEHcraW8xU6+UrD/++MwqrkxANEP5lwmE4EnM+xuIb7KntcacHB9tgw==
 config:
+  keycloak:captcha_secret_key:
+    secure: v1:iSa1sD8v7L2gr7MH:KxpzgPgSDesUW8lZS/cIInzoX9w3zdhmBfIm7aTWRXpzUVDy0stXYfeuj8f5YsEvuzSX4eweKKQ=
+  keycloak:captcha_site_key:
+    secure: v1:4pHYypYEEN6efAjy:f8+bh6EIFVQFvi3tx0R8fwcJ5w8CsUQGlma/JQCwft74UQ15fssCUVLY+K3ol/HiS2y4VjXx50s=
   keycloak:client_id: pulumi
   keycloak:client_secret:
     secure: v1:mbdWdrtlOrf/yMPw:4cu91sZzAKkYUkyxQBEtClJ49/uRp/f9nuW4uDakdRV7RW57Yf1EIqd71ovo0+TZ
@@ -13,12 +17,16 @@ config:
     secure: v1:h2Nlf0N1QtabfvGs:VMm0V5UvkXyjNpJ0gQfcqCVcw35XHF7an1omtVfLqg==
   keycloak:email_username:
     secure: v1:qw0/egOdCOUJi9Vy:CtyFmcodURyRrv9pG9o9wY9J+N2r6IoC
-  keycloak:url: https://sso-production.odl.mit.edu
   keycloak:openid_clients:
-  - realm_name: olapps
-    client_info:
+  - client_info:
       open: https://mit-open.odl.mit.edu
-  - realm_name: ol-platform-engineering
-    client_info:
+    realm_name: olapps
+  - client_info:
       airbyte: https://airbyte.odl.mit.edu
       dagster: https://pipelines.odl.mit.edu
+    realm_name: ol-platform-engineering
+  keycloak:url: https://sso-production.odl.mit.edu
+  keycloakd:captcha_site_key:
+    secure: v1:/iVlq/nwXfZo5cmO:G36x/OuuRgvg6G7sbnLh9l7XKKua00HsHgrNYOv6UrrlBSdetInWQwqmFLo/5bi8RdcfDKRiQ7k=
+  vault:address: https://vault-production.odl.mit.edu
+  vault_server:env_namespace: operations.production

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
@@ -25,3 +25,5 @@ config:
   keycloak:email_username:
     secure: v1:Uxscw7J8NqxO/NbK:NCGzgYTGRmeIovnjZyXrb6ztDW7levn0
   keycloak:url: https://sso-qa.odl.mit.edu
+  vault:address: https://vault-qa.odl.mit.edu
+  vault_server:env_namespace: operations.qa


### PR DESCRIPTION
# What are the relevant tickets?
N/A

# Description (What does it do?)
We are relying on client secrets for Keycloak OIDC clients, and we are retrieving them from Vault. This automatically writes those values to a standard path in Vault when they are generated.

# How can this be tested?
Run the Pulumi stack and verify that the client credentials are persisted to the path in Vault matching the pattern `secret-operations/sso/<client_name>`