### PR TITLE
Fixing units on RDS latency monitors to enable data collection.

### DIFF
--- a/src/ol_infrastructure/components/aws/cloudwatch.py
+++ b/src/ol_infrastructure/components/aws/cloudwatch.py
@@ -24,7 +24,7 @@ class OLCloudWatchAlarmSimpleConfig(BaseModel):
     namespace: str
     period: PositiveInt = 300  # Five minutes
     statistic: str = "Average"
-    threshold: int
+    threshold: Union[int, float]
     treat_missing_data_as: str = "missing"
     unit: Optional[str] = None
 

--- a/src/ol_infrastructure/components/aws/database.py
+++ b/src/ol_infrastructure/components/aws/database.py
@@ -297,8 +297,7 @@ class OLAmazonDB(pulumi.ComponentResource):
                 "period": 300,  # 5 minutes
                 "evaluation_periods": 2,  # 10 minutes
                 "metric_name": "WriteLatency",
-                "threshold": 20,
-                "unit": "Milliseconds",
+                "threshold": 0.020,  # 20 milliseconds
             },
             "ReadLatency": {
                 "comparison_operator": "GreaterThanThreshold",
@@ -308,8 +307,7 @@ class OLAmazonDB(pulumi.ComponentResource):
                 "period": 300,  # 5 minutes
                 "evaluation_periods": 2,  # 10 minutes
                 "metric_name": "ReadLatency",
-                "threshold": 10,
-                "unit": "Milliseconds",
+                "threshold": 0.010,  # 10 milliseconds
             },
         }
 


### PR DESCRIPTION
# Description (What does it do?)
Fixing units on RDS latency monitors to enable data collection.
