### PR TITLE
feat: enable mktg site

### DIFF
--- a/src/bilder/images/edxapp/templates/edxapp/xpro/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp/templates/edxapp/xpro/common_values.yml.tmpl
@@ -276,6 +276,7 @@ FEATURES:
     ENABLE_COMBINED_LOGIN_REGISTRATION: true
     ENABLE_CORS_HEADERS: true  # MODIFIED
     ENABLE_COUNTRY_ACCESS: false
+    ENABLE_COURSE_HOME_REDIRECT: true
     ENABLE_COURSEWARE_INDEX: true
     ENABLE_COURSEWARE_SEARCH: true
     ENABLE_CONTENT_LIBRARY_INDEX: true
@@ -295,7 +296,7 @@ FEATURES:
     ENABLE_GRADE_DOWNLOADS: true
     ENABLE_INSTRUCTOR_ANALYTICS: false
     ENABLE_LTI_PROVIDER: false
-    ENABLE_MKTG_SITE: false
+    ENABLE_MKTG_SITE: true
     ENABLE_MOBILE_REST_API: true
     ENABLE_OAUTH2_PROVIDER: true
     ENABLE_ORA_USERNAMES_ON_DATA_EXPORT: true
@@ -384,13 +385,22 @@ MEDIA_URL: /media/
 MICROSITE_CONFIGURATION: {}
 MICROSITE_ROOT_DIR: /edx/app/edxapp/edx-microsite
 MITXPRO_CORE_REDIRECT_ALLOW_RE_LIST: ["^/(admin|auth|logout|register|api|oauth2|user_api|heartbeat|login_refresh)", "^/courses/.*/xblock/.*/handler_noauth/outcome_service_handler"]  # ADDED VALUE
-MKTG_URLS: {}
+MKTG_URLS:
+    ROOT: https://{{ key "edxapp/marketing-domain" }}/
 MKTG_URL_LINK_MAP:
     TOS: tos
     HONOR: honor
     ABOUT: about
     PRIVACY: privacy
     ACCESSIBILITY: accessibility
+MKTG_URL_OVERRIDES:
+    COURSES: https://{{ key "edxapp/marketing-domain" }}/
+    PRIVACY: https://{{ key "edxapp/marketing-domain" }}/privacy-policy/
+    TOS: https://{{ key "edxapp/marketing-domain" }}/terms-of-service/
+    ABOUT: https://{{ key "edxapp/marketing-domain" }}/about-us/
+    HONOR: https://{{ key "edxapp/marketing-domain" }}/honor-code/
+    ACCESSIBILITY: https://accessibility.mit.edu/
+    TOS_AND_HONOR: ''
 MOBILE_STORE_URLS: {}
 ########################################################################################
 # Previously assumed to be unnecessary config as it duplicates code from               #

--- a/src/bilder/images/edxapp_v2/templates/edxapp/xpro/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/xpro/common_values.yml.tmpl
@@ -263,6 +263,7 @@ FEATURES:
     ENABLE_COMBINED_LOGIN_REGISTRATION: true
     ENABLE_CORS_HEADERS: true  # MODIFIED
     ENABLE_COUNTRY_ACCESS: false
+    ENABLE_COURSE_HOME_REDIRECT: true
     ENABLE_COURSEWARE_INDEX: true
     ENABLE_COURSEWARE_SEARCH: true
     ENABLE_CONTENT_LIBRARY_INDEX: true
@@ -282,7 +283,7 @@ FEATURES:
     ENABLE_GRADE_DOWNLOADS: true
     ENABLE_INSTRUCTOR_ANALYTICS: false
     ENABLE_LTI_PROVIDER: false
-    ENABLE_MKTG_SITE: false
+    ENABLE_MKTG_SITE: true
     ENABLE_MOBILE_REST_API: true
     ENABLE_OAUTH2_PROVIDER: true
     ENABLE_ORA_USERNAMES_ON_DATA_EXPORT: true
@@ -370,13 +371,22 @@ MEDIA_ROOT: media/  # MODIFIED - with s3 storage backend this is the path within
 MEDIA_URL: /media/
 MICROSITE_CONFIGURATION: {}
 MITXPRO_CORE_REDIRECT_ALLOW_RE_LIST: ["^/(admin|auth|logout|register|api|oauth2|user_api|heartbeat|login_refresh)", "^/courses/.*/xblock/.*/handler_noauth/outcome_service_handler"]  # ADDED VALUE
-MKTG_URLS: {}
+MKTG_URLS:
+    ROOT: https://{{ key "edxapp/marketing-domain" }}/
 MKTG_URL_LINK_MAP:
     TOS: tos
     HONOR: honor
     ABOUT: about
     PRIVACY: privacy
     ACCESSIBILITY: accessibility
+MKTG_URL_OVERRIDES:
+    COURSES: https://{{ key "edxapp/marketing-domain" }}/catalog/
+    PRIVACY: https://{{ key "edxapp/marketing-domain" }}/privacy-policy/
+    TOS: https://{{ key "edxapp/marketing-domain" }}/terms-of-service/
+    ABOUT: https://{{ key "edxapp/marketing-domain" }}/about-us/
+    HONOR: https://{{ key "edxapp/marketing-domain" }}/honor-code/
+    ACCESSIBILITY: https://accessibility.mit.edu/
+    TOS_AND_HONOR: ''
 MOBILE_STORE_URLS: {}
 ########################################################################################
 # Previously assumed to be unnecessary config as it duplicates code from               #


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes https://github.com/mitodl/hq/issues/2379

# Description (What does it do?)
<!--- Describe your changes in detail -->
- Enables marketing site for MITxOnline Open edX.
- Redirects course about page to course home.
- Redirects `/courses/` in Open edX to the MITxOnline homepage.
- Adds MKTG_URL_OVERRIDES, previously added through site configs in Django Admin.

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Update settings locally and verify that:

- Course about redirects to course home in the Learning MFE.
- `/courses/` redirects to the marketing site URL.
- Footer URLs match configs MKTG_URL_LINK_MAP & MKTG_URL_OVERRIDES

