### PR TITLE
increase ocw concourse worker disk size to 1TB

### DIFF
--- a/src/ol_infrastructure/applications/concourse/Pulumi.applications.concourse.QA.yaml
+++ b/src/ol_infrastructure/applications/concourse/Pulumi.applications.concourse.QA.yaml
@@ -28,7 +28,7 @@ config:
     aws_tags:
       OU: open-courseware
     concourse_team: ocw
-    disk_size_gb: 200
+    disk_size_gb: 1000
     disk_throughput: 600
     disk_iops: 3000
     iam_policies:


### PR DESCRIPTION
# What are the relevant tickets?
Related to https://github.com/mitodl/ocw-studio/issues/1966

# Description (What does it do?)
This PR increases the OCW worker's disk size to 1TB. This is being done to asses how much disk space is needed in production environments to run the new mass build pipeline in offline mode, which copies in archive videos for every site.

# How can this be tested?
Deploy to QA so that the OCW offline mass build pipeline can be run, watch Grafana to see how much disk space is used and then adjust based on what we find.
