### PR TITLE
Add BULK_EMAIL_RETRY_DELAY_BETWEEN_SENDS

### DIFF
--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/lms_only.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/lms_only.yml.tmpl
@@ -21,6 +21,7 @@ API_DOCUMENTATION_URL: http://course-catalog-api-guide.readthedocs.io/en/latest/
 AUDIT_CERT_CUTOFF_DATE: null
 AUTH_DOCUMENTATION_URL: http://course-catalog-api-guide.readthedocs.io/en/latest/authentication/index.html
 BULK_EMAIL_ROUTING_KEY_SMALL_JOBS: edx.lms.core.default
+BULK_EMAIL_RETRY_DELAY_BETWEEN_SENDS: 1
 COMMUNICATIONS_MICROFRONTEND_URL: /communications  # ADDED
 CONTACT_MAILING_ADDRESS: SET-ME-PLEASE
 CREDIT_HELP_LINK_URL: ''


### PR DESCRIPTION
This should resolve SES timeouts that we're seeing since it currently configured at 19 email per second based on this https://github.com/openedx/edx-platform/blob/32a1820360e8c0908ee5c68031b44bdc599ab80f/lms/envs/common.py#L2941
