### PR TITLE
Moves proctortrack consul configs to edxapp

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
@@ -13,6 +13,7 @@ config:
   edxapp:dns_zone: mitxonline
   edxapp:domains:
     lms: courses.mitxonline.mit.edu
+    marketing: mitxonline.mit.edu
     preview: preview.mitxonline.mit.edu
     studio: studio.mitxonline.mit.edu
   edxapp:edx_forum_secrets:
@@ -27,6 +28,7 @@ config:
     ora_grading: ora-grading
   edxapp:google_analytics_id: UA-5145472-48
   edxapp:mail_domain: edxapp-mail.mitxonline.mit.edu
+  edxapp:proctortrack_url: https://production.verificient.com
   edxapp:sender_email_address: mitxonline-support@mit.edu
   edxapp:use_docker: true
   edxapp:web_node_capacity: "9"

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
@@ -13,6 +13,7 @@ config:
   edxapp:dns_zone: mitxonline
   edxapp:domains:
     lms: courses-qa.mitxonline.mit.edu
+    marketing: rc.mitxonline.mit.edu
     preview: preview-qa.mitxonline.mit.edu
     studio: studio-qa.mitxonline.mit.edu
   edxapp:edx_forum_secrets:
@@ -28,6 +29,7 @@ config:
     ora_grading: ora-grading
   edxapp:google_analytics_id: UA-5145472-46
   edxapp:mail_domain: edxapp-mail-qa.mitxonline.mit.edu
+  edxapp:proctortrack_url: https://preproduction.verificient.com
   edxapp:sender_email_address: support@edxapp-mail-qa.mitxonline.mit.edu
   edxapp:use_docker: true
   edxapp:web_node_capacity: "3"

--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -885,8 +885,10 @@ consul_kv_data = {
     else "false",  # intended quoted boolean
     "google-analytics-id": edxapp_config.require("google_analytics_id"),
     "lms-domain": edxapp_domains["lms"],
+    "marketing-domain": edxapp_domains["marketing"],
     "preview-domain": edxapp_domains["preview"],
     "rds-host": edxapp_db.db_instance.address,
+    "proctortrack-base-url": edxapp_config.get("proctortrack_url") or "",
     "s3-course-bucket": course_bucket_name,
     "s3-grades-bucket": grades_bucket_name,
     "s3-storage-bucket": storage_bucket_name,

--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.Production.yaml
@@ -9,7 +9,5 @@ config:
   consul:scheme: https
   mitxonline:db_password:
     secure: v1:1SGxkH66kKNXMVc0:P9FztYdyzfxIrapGHU3pD5gz9ZkW6Of/zTqhaZf4O+L+Y8yAbcissYxogKfyDMxSJYSSUxI12K0=
-  mitxonline:domain: mitxonline.mit.edu
-  mitxonline:proctortrack_url: https://testing.verificient.com
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production

--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.QA.yaml
@@ -9,7 +9,5 @@ config:
   consul:scheme: https
   mitxonline:db_password:
     secure: v1:72AVczMFP7U0adTg:qiVKioH1VjNf38HfLkNIZsCdc8RqKs0bkaou+fU6SSRK9W4kbS1do2PwdD3JWYlc37eojd+sdAL8npp+tyEeQ66q5mHmWDQK3WlqgdWbf8G41fizyMwoy2AQdZmtZtJe40IoeqaSX3ntfJvhI0uP7YWmpge4G9e6KMNBmhZ0wl0T6qHU4z180aId1ZpjCM4=
-  mitxonline:domain: rc.mitxonline.mit.edu
-  mitxonline:proctortrack_url: https://preproduction.verificient.com
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -6,7 +6,6 @@
 
 import json
 
-import pulumi_consul as consul
 import pulumi_vault as vault
 from bridge.lib.magic_numbers import DEFAULT_POSTGRES_PORT
 from pulumi import Config, StackReference, export
@@ -165,20 +164,5 @@ mitxonline_vault_backend_config = OLVaultPostgresDatabaseConfig(
     db_host=mitxonline_db.db_instance.address,
 )
 mitxonline_vault_backend = OLVaultDatabaseBackend(mitxonline_vault_backend_config)
-
-# Set Consul key for use in edxapp configuration template
-consul.Keys(
-    "mitxonline-app-domain-for-edxapp",
-    keys=[
-        consul.KeysKeyArgs(
-            path="edxapp/marketing-domain",
-            value=mitxonline_config.require("domain"),
-        ),
-        consul.KeysKeyArgs(
-            path="edxapp/proctortrack-base-url",
-            value=mitxonline_config.require("proctortrack_url"),
-        ),
-    ],
-)
 
 export("mitxonline_app", {"rds_host": mitxonline_db.db_instance.address})


### PR DESCRIPTION
# Description (What does it do?)
<!--- Describe your changes in detail -->
This is a continuation of our Proctortrack issues. After switching the CDN to point to PT's QA CDN, noticed that the PT url in the lms config is still pointing to `testing.verificient.com` which isn't the correct url for their QA stack. Changed it here https://github.com/mitodl/ol-infrastructure/commit/343e7e9c3c6bd6c7b035b4bcda34139f5cd56f39 and deployed new edxapp instances, however the value did not change. Then realized that the reason is because the change I made sets it on the mitxonline app side https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.QA.yaml which is then written to consul https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/applications/mitxonline/__main__.py#L179 and then the edxapp reads the value here - https://github.com/mitodl/ol-infrastructure/blob/main/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl#L410. The issue is that we have the change set on the mitxonline app and not on the edxapp. This PR refactors the code to add the PT change and the marketing url to the edxapp.

**Note**: We need to verify that the url for production is the correct one. I looked through my email to see if I can find a reference to it, however I didn't come across any reference. Assuming that's the correct one, but surely worth verifying.

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Deploy to QA and verify. 

