### PR TITLE
1775: Add Open Discussions OIDC client to Keycloak in all environments

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.CI.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.CI.yaml
@@ -21,5 +21,6 @@ config:
   - realm_name: olapps
     client_info:
       open-local: "*"
+      open-discusions: https://discussions-ci.odl.mit.edu/
   vault:address: https://vault-ci.odl.mit.edu
   vault_server:env_namespace: operations.ci

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.Production.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.Production.yaml
@@ -20,6 +20,7 @@ config:
   keycloak:openid_clients:
   - client_info:
       open: https://mit-open.odl.mit.edu
+      open-discusions: https://open.mit.edu/
     realm_name: olapps
   - client_info:
       airbyte: https://airbyte.odl.mit.edu

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
@@ -14,6 +14,7 @@ config:
   - realm_name: olapps
     client_info:
       open: https://mit-open-rc.odl.mit.edu
+      open-discusions: https://discussions-qa.odl.mit.edu/
   - realm_name: ol-platform-engineering
     client_info:
       airbyte: https://airbyte-qa.odl.mit.edu


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/ol-infrastructure/issues/1775

# Description (What does it do?)
This adds entries for creating OpenID Connect clients in QA, CI, and Production for Open Discussions in Keycloak.
