### PR TITLE
87: Add first, last name, and email mappers

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/__main__.py
+++ b/src/ol_infrastructure/substructure/keycloak/__main__.py
@@ -274,3 +274,35 @@ if stack_info.env_suffix != "ci":
         want_assertions_signed=True,
         opts=resource_options,
     )
+    oidc_attribute_importer_identity_provider_mapper = (
+        keycloak.AttributeImporterIdentityProviderMapper(
+            "oidcAttributeImporterIdentityProviderMapper",
+            realm=ol_apps_realm.id,
+            claim_name="email",
+            identity_provider_alias=ol_apps_touchstone_saml_identity_provider.alias,
+            user_attribute="email",
+            extra_config={
+                "syncMode": "INHERIT",
+            },
+        ),
+        keycloak.AttributeImporterIdentityProviderMapper(
+            "oidcAttributeImporterIdentityProviderMapper",
+            realm=ol_apps_realm.id,
+            claim_name="sn",
+            identity_provider_alias=ol_apps_touchstone_saml_identity_provider.alias,
+            user_attribute="lastName",
+            extra_config={
+                "syncMode": "INHERIT",
+            },
+        ),
+        keycloak.AttributeImporterIdentityProviderMapper(
+            "oidcAttributeImporterIdentityProviderMapper",
+            realm=ol_apps_realm.id,
+            claim_name="givenName",
+            identity_provider_alias=ol_apps_touchstone_saml_identity_provider.alias,
+            user_attribute="firstName",
+            extra_config={
+                "syncMode": "INHERIT",
+            },
+        ),
+    )


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/mit-open/issues/87

# Description (What does it do?)
This creates 3 mappers associated with the MIT Touchstone SAML identity provider in Keycloak.  This will populate the fields  (first name, last name, and email) shown on the update profile page when a user authenticates with Touchstone for the first time.

# How can this be tested?
