### PR TITLE
Correct open-discussions redirect URIs

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.CI.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.CI.yaml
@@ -21,6 +21,6 @@ config:
   - realm_name: olapps
     client_info:
       open-local: "*"
-      open-discusions: https://discussions-ci.odl.mit.edu/
+      open-discusions: https://discussions-ci.odl.mit.edu
   vault:address: https://vault-ci.odl.mit.edu
   vault_server:env_namespace: operations.ci

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.Production.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.Production.yaml
@@ -20,7 +20,7 @@ config:
   keycloak:openid_clients:
   - client_info:
       open: https://mit-open.odl.mit.edu
-      open-discusions: https://open.mit.edu/
+      open-discusions: https://open.mit.edu
     realm_name: olapps
   - client_info:
       airbyte: https://airbyte.odl.mit.edu

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
@@ -14,7 +14,7 @@ config:
   - realm_name: olapps
     client_info:
       open: https://mit-open-rc.odl.mit.edu
-      open-discusions: https://discussions-qa.odl.mit.edu/
+      open-discusions: https://discussions-rc.odl.mit.edu
   - realm_name: ol-platform-engineering
     client_info:
       airbyte: https://airbyte-qa.odl.mit.edu


### PR DESCRIPTION
# Description (What does it do?)
The redirect URI's in Keycloak for Open Discussions had two issues:

1. They referenced `https://discussions-qa.odl.mit.edu` (wrong) instead of `https://discussions-rc.odl.mit.edu` (correct).
2. They had "/" appended to them which caused issues when generating the redirect URL.

The values in this PR have been manually updated in Keycloak and successfully tested