### PR TITLE
Edxorg program credentials

### DIFF
--- a/src/bilder/images/dagster/deploy.py
+++ b/src/bilder/images/dagster/deploy.py
@@ -75,6 +75,14 @@ server.user(
     system=True,
     ensure_home=False,
 )
+
+files.put(
+    name="Set AWS config file for use with STS assume role credentials",
+    src=FILES_DIRECTORY.joinpath("aws_config.ini"),
+    dest="/etc/aws/config",
+    create_remote_dir=True,
+)
+
 watched_docker_compose_files = []
 
 consul_templates_directory = Path("/etc/consul-template")

--- a/src/bilder/images/dagster/files/.env.tmpl
+++ b/src/bilder/images/dagster/files/.env.tmpl
@@ -1,3 +1,4 @@
+AWS_CONFIG_FILE=/etc/aws/config
 {{- with secret "postgres-dagster/creds/app" -}}
 DAGSTER_PG_USERNAME="{{ .Data.username }}"
 DAGSTER_PG_PASSWORD="{{ .Data.password }}"

--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -198,13 +198,24 @@ athena_permissions: list[dict[str, Union[str, list[str]]]] = [
     },
 ]
 
+edxorg_program_credentials_role_assumption = {
+    "Effect": "Allow",
+    "Action": ["sts:AssumeRole"],
+    "Resource": "arn:aws:iam::708756755355:role/mit-s3-edx-program-reports-access",
+}
+
 dagster_iam_permissions = {
     "Version": "2012-10-17",
-    "Statement": dagster_s3_permissions + athena_permissions,
+    "Statement": [
+        *dagster_s3_permissions,
+        *athena_permissions,
+        edxorg_program_credentials_role_assumption,
+    ],
 }
 
 parliament_config: dict[str, Any] = {
-    "RESOURCE_EFFECTIVELY_STAR": {"ignore_locations": []}
+    "RESOURCE_EFFECTIVELY_STAR": {"ignore_locations": []},
+    "CREDENTIALS_EXPOSURE": {"ignore_locations": [{"actions": "sts:assumeRole"}]},
 }
 
 dagster_runtime_bucket = s3.Bucket(


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/hq/issues/1592

# Description (What does it do?)
- Creates an S3 bucket for staging data copied from edx.org (and eventually other sources) so that it can be loaded into the data lake via Airbyte
- Adds an AWS configuration for Dagster to be able to assume the cross-account role provided by edx.org to access the program credential reports S3 bucket

# How can this be tested?
The Pulumi changes have been applied manually and the corresponding Dagster pipeline defined in https://github.com/mitodl/ol-data-platform/pull/849 has been run locally.

# Additional Context
The data pipeline changes that this is supporting are in https://github.com/mitodl/ol-data-platform/pull/849