### PR TITLE
SAML Pull page fix

### DIFF
--- a/dockerfiles/openedx-edxapp/Dockerfile
+++ b/dockerfiles/openedx-edxapp/Dockerfile
@@ -92,6 +92,8 @@ COPY --chown=app:app settings/cms/i18n.not_py /openedx/edx-platform/cms/envs/mit
 COPY --chown=app:app settings/set_waffle_flags.not_py /openedx/edx-platform/set_waffle_flags.py
 # Copy in special scheduled email script
 COPY --chown=app:app settings/process_scheduled_emails.not_py /openedx/edx-platform/process_scheduled_emails.py
+# Copy in special saml pull script
+COPY --chown=app:app settings/saml_pull.not_py /openedx/edx-platform/saml_pull.py
 
 FROM collected AS build-static-assets
 

--- a/dockerfiles/openedx-edxapp/settings/saml_pull.not_py
+++ b/dockerfiles/openedx-edxapp/settings/saml_pull.not_py
@@ -1,0 +1,14 @@
+from django.core import management
+import lms.startup
+
+from random import uniform
+from time import sleep
+
+lms.startup.run()
+
+while True:
+    # Execute randomly once every 24-48 hours
+    sleep(uniform(86400,172800))
+    management.call_command("saml", ["--pull"])
+
+exit(0)

--- a/src/bilder/images/edxapp_v2/files/docker-compose.yaml.tmpl
+++ b/src/bilder/images/edxapp_v2/files/docker-compose.yaml.tmpl
@@ -176,6 +176,23 @@ services:
       lms-permissions:
         condition: service_completed_successfully
 
+  saml-pull:
+    image: ${DOCKER_REPO_AND_DIGEST}
+    profiles:
+    - worker
+    environment:
+      SERVICE_VARIANT: lms
+      DJANGO_SETTINGS_MODULE: lms.envs.production
+    restart: on-failure
+    volumes:
+    - ./settings/lms.env.yml:/openedx/config/lms.env.yml:ro
+    - /opt/data:/openedx/data
+    - /opt/data/media:/openedx/media
+    command: ["python", "saml_pull.py"]
+    depends_on:
+      lms-permissions:
+        condition: service_completed_successfully
+
   cms-worker:
     image: ${DOCKER_REPO_AND_DIGEST}
     profiles:


### PR DESCRIPTION
# Description (What does it do?)
Created a utility script for running the saml pull management command in edxapp every 24-48h. Should stop the paging every two-ish weeks for residential and residential staging. Doesn't do anything in environments w/o saml providers configured. 
