### PR TITLE
Create AWS PrivateLinks between Mongo and DataVPC

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/mongodb_atlas/pulumi_pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/mongodb_atlas/pulumi_pipeline.py
@@ -1,0 +1,66 @@
+from ol_concourse.lib.jobs.infrastructure import pulumi_jobs_chain
+from ol_concourse.lib.models.fragment import PipelineFragment
+from ol_concourse.lib.models.pipeline import Identifier, Pipeline
+from ol_concourse.lib.resources import git_repo
+from ol_concourse.pipelines.constants import PULUMI_CODE_PATH, PULUMI_WATCHED_PATHS
+
+simple_resource_types = []
+simple_resources = []
+simple_jobs = []
+
+for service in ["mitx", "mitx-staging", "mitxonline", "xpro"]:
+    simple_pulumi_code = git_repo(
+        name=Identifier(f"ol-infrastructure-pulumi-{service}"),
+        uri="https://github.com/mitodl/ol-infrastructure",
+        paths=[
+            *PULUMI_WATCHED_PATHS,
+            "src/ol-infrastructure/infrastructure/mongodb_atlas/",
+        ],
+    )
+
+    if service == "mitxonline":
+        stage_list = ["QA", "Production"]
+    else:
+        stage_list = ["CI", "QA", "Production"]
+    simple_pulumi_chain = pulumi_jobs_chain(
+        simple_pulumi_code,
+        project_name=f"ol-infrastructure-mongodb_atlas-{service}",
+        stack_names=[
+            f"infrastructure.mongodb_atlas.{service}.{stage}" for stage in stage_list
+        ],
+        project_source_path=PULUMI_CODE_PATH.joinpath("infrastructure/mongodb_atlas/"),
+        dependencies=[],
+    )
+
+    simple_service_fragment = PipelineFragment(
+        resource_types=simple_pulumi_chain.resource_types,
+        resources=[simple_pulumi_code, *simple_pulumi_chain.resources],
+        jobs=simple_pulumi_chain.jobs,
+    )
+    simple_resource_types.extend(simple_service_fragment.resource_types)
+    simple_resources.extend([simple_pulumi_code, *simple_service_fragment.resources])
+    simple_jobs.extend(simple_service_fragment.jobs)
+
+
+simple_services_combined_fragment = PipelineFragment(
+    resource_types=simple_resource_types,
+    resources=simple_resources,
+    jobs=simple_jobs,
+)
+
+
+mongodb_atlas_pipeline = Pipeline(
+    resource_types=simple_services_combined_fragment.resource_types,
+    resources=simple_services_combined_fragment.resources,
+    jobs=simple_services_combined_fragment.jobs,
+)
+
+
+if __name__ == "__main__":
+    import sys
+
+    with open("definition.json", "w") as definition:  # noqa: PTH123
+        definition.write(mongodb_atlas_pipeline.model_dump_json(indent=2))
+    sys.stdout.write(mongodb_atlas_pipeline.model_dump_json(indent=2))
+    print()  # noqa: T201
+    print("fly -t pr-inf sp -p pulumi-mongodb-atlas -c definition.json")  # noqa: T201

--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitx.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitx.Production.yaml
@@ -15,3 +15,4 @@ config:
   mongodb_atlas:organization_id: 611ab793e07f5965c7b9e4f6
   mongodb_atlas:ready_for_traffic: "true"
   mongodb_atlas:version: "4.4"
+  data_vpc_access:create_privatelink_to_datavpc: "true"

--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitx.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitx.QA.yaml
@@ -13,3 +13,4 @@ config:
   mongodb_atlas:organization_id: 611ab793e07f5965c7b9e4f6
   mongodb_atlas:ready_for_traffic: "true"
   mongodb_atlas:version: "4.4"
+  data_vpc_access:create_privatelink_to_datavpc: "true"

--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitxonline.Production.yaml
@@ -15,3 +15,4 @@ config:
   mongodb_atlas:organization_id: 611ab793e07f5965c7b9e4f6
   mongodb_atlas:ready_for_traffic: "true"
   mongodb_atlas:version: "4.4"
+  data_vpc_access:create_privatelink_to_datavpc: "true"

--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitxonline.QA.yaml
@@ -14,3 +14,4 @@ config:
   mongodb_atlas:organization_id: 611ab793e07f5965c7b9e4f6
   mongodb_atlas:ready_for_traffic: "true"
   mongodb_atlas:version: "4.4"
+  data_vpc_access:create_privatelink_to_datavpc: "true"

--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.xpro.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.xpro.Production.yaml
@@ -15,3 +15,4 @@ config:
   mongodb_atlas:organization_id: 611ab793e07f5965c7b9e4f6
   mongodb_atlas:ready_for_traffic: "true"
   mongodb_atlas:version: "4.4"
+  data_vpc_access:create_privatelink_to_datavpc: "true"

--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.xpro.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.xpro.QA.yaml
@@ -12,3 +12,4 @@ config:
   mongodb_atlas:organization_id: 611ab793e07f5965c7b9e4f6
   mongodb_atlas:ready_for_traffic: "true"
   mongodb_atlas:version: "4.4"
+  data_vpc_access:create_privatelink_to_datavpc: "true"

--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/__main__.py
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/__main__.py
@@ -30,15 +30,13 @@ def privatize_mongo_uri(mongo_uri):
 ###############
 atlas_config = pulumi.Config("mongodb_atlas")
 env_config = pulumi.Config("environment")
+data_vpc_access_config = pulumi.Config("data_vpc_access")
 stack_info = parse_stack()
 dagster_env_name = stack_info.name
 if stack_info.name == "CI":
     dagster_env_name = "QA"
 network_stack = pulumi.StackReference(f"infrastructure.aws.network.{stack_info.name}")
 dagster_stack = pulumi.StackReference(f"applications.dagster.{dagster_env_name}")
-consul_stack = pulumi.StackReference(
-    f"infrastructure.consul.{stack_info.env_prefix}.{stack_info.name}"
-)
 
 #############
 # VARIABLES #
@@ -119,6 +117,88 @@ atlas_security_group = aws.ec2.SecurityGroup(
     ],
     egress=default_egress_args,
 )
+
+# Because all networks @ atlas have the same address space, we need to
+# create privatelinke in the datavpc for airbyte/dagster rather than peering.
+# This costs a little bit of $$$ but is better than going over the internet.
+if data_vpc_access_config.get_bool("create_privatelink_to_datavpc") or False:
+    data_vpc = network_stack.require_output("data_vpc")
+
+    privatelink_endpoint = atlas.PrivateLinkEndpoint(
+        f"mongodb-atlas-privatelink-endpoint-{environment_name}",
+        project_id=atlas_project.id,
+        provider_name="AWS",
+        region=atlas_config.get("cloud_region") or "US_EAST_1",
+        opts=atlas_provider,
+    )
+
+    # It might not be safe to assume ports 1024-1026 here according to mongo docs
+    # https://www.mongodb.com/docs/atlas/security-private-endpoint/#port-ranges-used-for-private-endpoints
+    data_vpc_endpoint_security_group = aws.ec2.SecurityGroup(
+        f"monogdb-atlas-privatelink-endpoint-security-group-{environment_name}",
+        name=f"mongodb-atlas-privatelink-{environment_name}",
+        tags=aws_config.merged_tags(
+            {"Names": f"mongodb-atlas-privatelink-{environment_name}"}
+        ),
+        vpc_id=data_vpc["id"],
+        ingress=[
+            aws.ec2.SecurityGroupIngressArgs(
+                protocol="tcp",
+                from_port=1024,
+                to_port=1026,
+                security_groups=[data_vpc["security_groups"]["integrator"]],
+            ),
+        ],
+        egress=[],
+    )
+
+    data_vpc_endpoint = aws.ec2.VpcEndpoint(
+        f"mongodb-atlas-privatelink-vpcendpoint-{environment_name}",
+        service_name=privatelink_endpoint.endpoint_service_name,
+        subnet_ids=data_vpc["subnet_ids"],
+        vpc_id=data_vpc["id"],
+        vpc_endpoint_type="Interface",
+        security_group_ids=[data_vpc_endpoint_security_group.id],
+    )
+
+    privatelink_endpoint_service = atlas.PrivateLinkEndpointService(
+        f"mongodb-atlas-privatelink-endpoint-service-{environment_name}",
+        project_id=atlas_project.id,
+        provider_name="AWS",
+        private_link_id=privatelink_endpoint.id,
+        endpoint_service_id=data_vpc_endpoint.id,
+        opts=atlas_provider,
+    )
+
+    data_vpc_consul_address = (
+        data_vpc_access_config.get("consul_address")
+        or f"https://consul-data-{stack_info.name}.odl.mit.edu"
+    )
+
+    consul.Keys(
+        "set-mongo-connection-info-in-data-vpc-consul",
+        keys=[
+            consul.KeysKeyArgs(
+                path=f"mongodb/{environment_name}/private-link-connection-string",
+                delete=True,
+                value=atlas_cluster.connection_strings[0]["private_endpoints"][0][
+                    "connection_string"
+                ],
+            ),
+        ],
+        opts=pulumi.ResourceOptions(
+            provider=consul.Provider(
+                "consul-provider-data-vpc",
+                address=data_vpc_consul_address,
+                scheme="https",
+                http_auth="pulumi:{}".format(
+                    read_yaml_secrets(
+                        Path(f"pulumi/consul.{stack_info.env_suffix}.yaml")
+                    )["basic_auth_password"]
+                ),
+            )
+        ),
+    )
 
 # It is necessary to manually go to the Mongo Atlas UI and fetch the IP CIDR for adding
 # to the VPC route table


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/ol-data-platform/issues/786

# Description (What does it do?)

This update automates the creation of privatelinks between mongo-atlas and our datavpcs. These are needed due to the fact that the networks on each mongo-atlas project overlap in address space. Due to this overlap, we cannot peer more than one of them to the dataVPC. To get around this, privatelink interfaces are created in the datavpc that will allow airbyte/dagster to interact with more than one mongodb instance.  

Will eventually close: https://github.com/mitodl/ol-data-platform/issues/786

# How can this be tested?
Tested and verified in QA. 