### PR TITLE
Fix - change instance type to general purpose-large

### DIFF
--- a/src/ol_infrastructure/applications/tika/Pulumi.applications.tika.QA.yaml
+++ b/src/ol_infrastructure/applications/tika/Pulumi.applications.tika.QA.yaml
@@ -4,7 +4,6 @@ encryptedkey: AQICAHi7xhTkB8tf1ObyPMxDhODJja4Mn4jyIo32zZVlOiZPFgFHfBkhf0VwBzMaAl
 config:
   aws:region: us-east-1
   consul:address: https://consul-apps-qa.odl.mit.edu
-  tika:instance_type: m4.large
   tika:auto_scale:
     desired: 2
     max: 3

--- a/src/ol_infrastructure/applications/tika/__main__.py
+++ b/src/ol_infrastructure/applications/tika/__main__.py
@@ -185,7 +185,8 @@ tag_specs = [
 lt_config = OLLaunchTemplateConfig(
     block_device_mappings=block_device_mappings,
     image_id=tika_server_ami.id,
-    instance_type=tika_config.get("instance_type") or InstanceTypes.burstable_medium,
+    instance_type=tika_config.get("instance_type")
+    or InstanceTypes.general_purpose_large,
     instance_profile_arn=tika_server_instance_profile.arn,
     security_groups=[
         tika_server_security_group,


### PR DESCRIPTION
Tika is not suited to bust instances. Change instance type to general purpose large

# What are the relevant tickets?

#1798 

# Description (What does it do?)

Rather than fussing about with configuration values that aren't working, change the hard coded instance type/category.

# How can this be tested?

Observe new m6 instance type after deployment completes.