### PR TITLE
config,fix: Address GitHub rate limit issues with Concourse pipelines

### DIFF
--- a/src/bridge/secrets/concourse/operations.ci.yaml
+++ b/src/bridge/secrets/concourse/operations.ci.yaml
@@ -18,6 +18,8 @@ pipelines:
   main/pypi_creds:
     username: ENC[AES256_GCM,data:Jug65jgSbhoe,iv:RmGglflhUUdH1POy3qpzBWOdDCpotrvHkVPRzaV7Vsk=,tag:MLUt4M8V2l19Y6RCgGscSw==,type:str]
     password: ENC[AES256_GCM,data:ItzNaifwvctqXBPHsrHJ5BKybJoKDOffK7LGy6Sr+YTfBlMQ3wxYfmjqhN2Uv6XJn4JNcUIJbPNpweSyy6m/uMZpdBy09bsy+4AJnmIO1bf7TcKJSqd9i92J81BcJLdogHNjQbWI2/fErj9l90OsTJAuAGnABsNLwnq6MxyOkQYYXq/0vQa/d/5oQoz6Ap9rmWK2tTwl5kIsE1VsoAsp6czZhC5NiKbWNO6HpLOnFCncMT3CMsN4mM0=,iv:55MZ+ijsiPWg2xZtRaCNeNLqpWnkgHDehrJJ5y4PJcc=,tag:pYFK+Np8WehQWUDNgXU8qQ==,type:str]
+  infrastructure/github:
+    public_repo_access_token: ENC[AES256_GCM,data:/61QL8mtNXHlQUvJK1Pc4YxdI/fwDtVWvP9ABuHOCc2G7XYUQWU+pg==,iv:p2QMO5e2vvZpOHnYka+rNLJv04Wg51bMAgUi5L/sSaw=,tag:eCtX+aEpk7cIigZmR2OIXg==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-ci
@@ -28,8 +30,8 @@ sops:
   azure_kv: []
   hc_vault: []
   age: []
-  lastmodified: "2023-02-02T19:09:55Z"
-  mac: ENC[AES256_GCM,data:6XFrEgyZ6CpRx4kWagEHK8f7OYN8YdbH724n/OLIdgII5DgavnEIgsWyYq4/qh9g89Exlu8OgI2JTMnZ3Ff1mxRhaLXM5OQhJXrq1KnhuP839BMYLdv93LAurROTy23m1Domgy4+mrTmJcSyiZycpOLaDJ2xjKmeA42aUgxwvJc=,iv:bCvpRYx7oldMesY3T2WT8AfkPGzFXYUbpcuwNPkmgII=,tag:Dq/KqH5mvmI4zoWpZozLgw==,type:str]
+  lastmodified: "2023-10-05T21:02:25Z"
+  mac: ENC[AES256_GCM,data:jbp2iCNby6I+DkSaCqkUliL3j6wv4iaufE4u0iBgfkH8upB0sxeinfnPJzZziLBpkArwIb74Nu3ssDFoDtB0hYjiCKfOTVJbTmomsXB4MIVhhL5VNXabNz1wEYHRiwd2QEY3g4Bmch3o8cTwfCz27PP85+uiQyTzaacmjgQNE44=,iv:YonoD+e1Hx2kOcfU1EgQa8E+DkNvQCkBcKy89zNpnx4=,tag:t0tykW9iytGeKAYLlhHzZQ==,type:str]
   pgp:
   - created_at: "2022-01-11T16:16:44Z"
     enc: |
@@ -89,4 +91,4 @@ sops:
       -----END PGP MESSAGE-----
     fp: 07083D36FD5986B0C99700944E9B358045C1B176
   unencrypted_suffix: _unencrypted
-  version: 3.7.3
+  version: 3.8.0

--- a/src/bridge/secrets/concourse/operations.production.yaml
+++ b/src/bridge/secrets/concourse/operations.production.yaml
@@ -26,6 +26,8 @@ pipelines:
     id: ENC[AES256_GCM,data:hrUu/8xl8DQsWVOxxLtdqQbdDPj6pQbU5XM2fow2ZPtS64mbZ7yenQ==,iv:4nbs5lllyKQcHr6K3o0aF37v9yjd7Q7iR4gccwUFNK8=,tag:uPCbQgGCjlsHAl+sc9abcA==,type:str]
     secret: ENC[AES256_GCM,data:Lww/QtE9mbKx0RbSzu+G5hgy3rAuAg/8ylRxXhZf+K7+4FRxz3dQjoe5BUWYY/wD0hb9hzs7arxZ60gMO7b7COfisuylqG9RsWPJxt1KAEZBKQEEq/vMJCB4MRhHgig7kwLBXZi/f/16BOjIZLWgKgPWdzdx6TERtaL6yu3uaE4=,iv:fpjgH/eIksRR+qGCB4oPREBnfRpBLy9flBfiIQ1635Q=,tag:yR87AtDjq4ddxQOMCKGQ8A==,type:str]
     host: ENC[AES256_GCM,data:JF2fFxvGV7o3DeyltbEArOPSPWY1SrHqCeCLQ/8=,iv:MU0hOewaHX5XKALZbkmoufFgaEbR4PWSFhhkWdhGf5g=,tag:qDPGja7Zkd7U0XHsJ0YGCg==,type:str]
+  infrastructure/github:
+    public_repo_access_token: ENC[AES256_GCM,data:DoG9tNfM4jr1+RhRBlezAl9KwiyX78vSEKkidF6WvW7jbswwngocJA==,iv:2uB4w6GVqibM4u8gf7vvKdicpWsBaC+pcPe5JbuPJoM=,tag:lVTHbRb70jxFEvR6L/r21w==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
@@ -36,8 +38,8 @@ sops:
   azure_kv: []
   hc_vault: []
   age: []
-  lastmodified: "2023-06-07T20:44:32Z"
-  mac: ENC[AES256_GCM,data:0o7Fy2IlOBfTGYqPK34ofYNlr0WF1ootpVjkimFov6BAuVV6HL8sKfxwNs4C1kZAI40pZLVZXcg7ySRqx5xQEIHUGSc4u1K0wxjqSwnsvQoMVBrUixTSzbVaQTIOgRWoPK/jPb4GFCUvj9pg9I5zpUllSae5//eDkeSNg6r6Y4s=,iv:R+W0/SLPbF6JyTtv823OgmbTTv2suabuSREPsn+DoVU=,tag:l73s+l6JucgtHvMzTsIvWw==,type:str]
+  lastmodified: "2023-10-05T21:02:55Z"
+  mac: ENC[AES256_GCM,data:Cg3Le8WMUHLMZ9qx6hvElx3I4xbtmFVhuV0qI1raQFsbHAvC1qIAK6/HwIBZ12S7ZEZmISzmM9USV6aLjER/2mRAQYiZyl+b6KgNHxiBvT9DU8lyzzZFTOmiVht5mLwASn+139F9GXVFwri06I+ICElL5mxf8d4FdwU2drR9F8g=,iv:RkVZOOXumf9VinSMMYaFldjE0GP4LPlx76RkZr+TxNQ=,tag:auf4q10TSDwijJH0Bi1nSQ==,type:str]
   pgp:
   - created_at: "2021-11-23T19:02:59Z"
     enc: |
@@ -100,4 +102,4 @@ sops:
       -----END PGP MESSAGE-----
     fp: 51BB820DC5F14FE9
   unencrypted_suffix: _unencrypted
-  version: 3.7.3
+  version: 3.8.0

--- a/src/bridge/secrets/concourse/operations.qa.yaml
+++ b/src/bridge/secrets/concourse/operations.qa.yaml
@@ -22,6 +22,8 @@ pipelines:
     id: ENC[AES256_GCM,data:y9PHMdP3yraktbpj1TYyquTlKZsEbrn8Bd802BcqzPIa6CXV3jKASg==,iv:QvtHty2PLOXEoVkFvklq5J5deIdfH4995azPTd3QSUw=,tag:8scZ4eV6TayaBIHhvlBjjw==,type:str]
     secret: ENC[AES256_GCM,data:5Wl3V5CXufQiPVarSX/wfo+94AB74G2qDR6G0yAZ68irmyadKrC868wuLpz9rXqCA/fzI2CgcQMVqKRJ267UJZYDxX5Fzv6F+afCInKzUmuxlxx+boTAOU0RQtlgxiy+hWrd5DntIYUMjFWcR4SWyQFYjJ82VWk2jgIc2Lb0DU8=,iv:NZdv6VTn6wz1igDaRfjMeloAgFjXVF+3tiAoNdcRRng=,tag:7+U0wy/Q7wa2ZlXmt+L2Eg==,type:str]
     host: ENC[AES256_GCM,data:DqfvWWc3+UrA2urkgZF6U0gJwweYi/ov8E3RWj3MFJ2v3HcDdQ==,iv:6fDWXeF86zT3uqCzYAuTHMSFakTemrgHywPnBFZV0yQ=,tag:KHGnClH80r7FpnkVjHD9Gw==,type:str]
+  infrastructure/github:
+    public_repo_access_token: ENC[AES256_GCM,data:qjNEm0oddKvPlijcDgW2KLGtc3oC/ZZ14Ew0CWQ3kIMznnFKpHtD4w==,iv:0lXsKYufetLyLkfNXat8ssRZbL5XzlsR05Ty4IrqXD0=,tag:tNWxBvhUjMwPObObWFskag==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-qa
@@ -32,8 +34,8 @@ sops:
   azure_kv: []
   hc_vault: []
   age: []
-  lastmodified: "2023-05-17T19:08:59Z"
-  mac: ENC[AES256_GCM,data:Ey7dmMfGrWB2SJory0Fr2zFR3A0a2nGzHgLv4fxz4JbRvN5MyGg49BqJOjjwoi+nI95kchKBJAFASMyjBKcK7Z0vSSP3zHLKrW2uaqOCK0D+pd1N4Rj9U98QyVP2qZkTlpx8KZczaSCozEiAbya/CKNer4T6NFHy1xrwjV+4H+s=,iv:e00hJiTgQMIwo22WIPyYoKUenCvJTSQdgmILVIXt3JI=,tag:a3SmLm9SuRqE1xwTIj/vVw==,type:str]
+  lastmodified: "2023-10-05T21:02:33Z"
+  mac: ENC[AES256_GCM,data:U1RSrhBfMhRtRZpWXO+v7yUUy+NnJNUgDIhS4lnZF60GOwbXm1dV8OHIj9J746LgkgnhfdNtCRU1u9iNrz9xX8YOt6jjccAPN/GOItkqtVRQv/6FZjlwyOUcoqAe72DCEPCuF2apAsS8vRJ4y34sv3tpk6GWEm09PV4a540dqiM=,iv:xMuyVhSSc5YSmfpczYqW8y86jUeUTfMM9J727uAUX54=,tag:8x88Ymu7Xfst/B114hg1EQ==,type:str]
   pgp:
   - created_at: "2021-11-23T18:57:37Z"
     enc: |
@@ -96,4 +98,4 @@ sops:
       -----END PGP MESSAGE-----
     fp: 51BB820DC5F14FE9
   unencrypted_suffix: _unencrypted
-  version: 3.7.3
+  version: 3.8.0

--- a/src/ol_concourse/lib/resources.py
+++ b/src/ol_concourse/lib/resources.py
@@ -40,17 +40,23 @@ def ssh_git_repo(
     )
 
 
-def github_release(name: Identifier, owner: str, repository: str) -> Resource:
+def github_release(
+    name: Identifier,
+    owner: str,
+    repository: str,
+    github_token: str = "((github.public_repo_access_token))",  # noqa: S107
+) -> Resource:
     """Generate a github-release resource for the given owner/repository.
 
-    :param name: The name of the resource. This will get used across subsequent
+    :param name: The name of the resource.  This will get used across subsequent
         pipeline steps that reference this resource.
-    :type name: Identifier
     :param owner: The owner of the repository (e.g. the GitHub user or organization)
-    :type owner: str
     :param repository: The name of the repository as it appears in GitHub
-    :type repository: str
+    :param github_token: A personal access token with `public_repo` scope to increase
+        the rate limit for checking versions.
+
     :returns: A configured Concourse resource object that can be used in a pipeline.
+
     :rtype: Resource
     """
     return Resource(
@@ -58,7 +64,12 @@ def github_release(name: Identifier, owner: str, repository: str) -> Resource:
         type="github-release",
         icon="github",
         check_every="24h",
-        source={"repository": repository, "owner": owner, "release": True},
+        source={
+            "repository": repository,
+            "owner": owner,
+            "release": True,
+            "access_token": github_token,
+        },
     )
 
 


### PR DESCRIPTION
# What are the relevant tickets?
N/A

# Description (What does it do?)
<!--- Describe your changes in detail -->
Concourse pipelines that use the github release resource are often rate limited due to accessing the API anonymously. As we continue to build and manage pipelines we will hit this more frequently. This adds a default argument of the access token to allow for authenticated requests with a higher rate limit.

# How can this be tested?
Compile and update a pipeline using the GitHub issue resource and ensure that it continues to operate. To ensure the higher rate limit you can trigger multiple checks of a GH release to trigger the ratelimit, update the resource with this code, and then trigger the checks again.