### PR TITLE
upgrade ocw worker disk size to 1TB

### DIFF
--- a/src/ol_infrastructure/applications/concourse/Pulumi.applications.concourse.Production.yaml
+++ b/src/ol_infrastructure/applications/concourse/Pulumi.applications.concourse.Production.yaml
@@ -28,7 +28,7 @@ config:
     aws_tags:
       OU: open-courseware
     concourse_team: ocw
-    disk_size_gb: 200
+    disk_size_gb: 1000
     disk_throughput: 600
     disk_iops: 3000
     iam_policies:


### PR DESCRIPTION
# What are the relevant tickets?
Related to https://github.com/mitodl/ocw-studio/issues/1928

# Description (What does it do?)
This PR upgrades the production OCW Concourse workers with 1TB of storage, required for the offline mass build that now handles archive videos.

# How can this be tested?
Merge the PR, deploy changes to production Concourse and run the offline mass build
