### PR TITLE
Giving dagster production 1TB.

### DIFF
--- a/src/ol_infrastructure/applications/dagster/Pulumi.applications.dagster.Production.yaml
+++ b/src/ol_infrastructure/applications/dagster/Pulumi.applications.dagster.Production.yaml
@@ -23,6 +23,6 @@ config:
   dagster:edx_pipeline_xpro_edx_course_bucket_name: xpro-production-edxapp-courses
   dagster:edx_pipeline_xpro_edx_xpro_purpose: mitx-etl-xpro-production
   dagster:instance_type: m6a.xlarge
-  dagster:disk_size_gb: 300
+  dagster:disk_size_gb: 1000
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production


### PR DESCRIPTION
# Description (What does it do?)
Gives dagster production 1TB of disk space to work with. 
