### PR TITLE
fix: fix default xmodule class name

### DIFF
--- a/src/bilder/images/edxapp/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -392,7 +392,7 @@ MODULESTORE:
               DOC_STORE_CONFIG:
                 <<: *docstore_config
               OPTIONS:
-                default_class: xmodule.hidden_module.HiddenDescriptor
+                default_class: xmodule.hidden_block.HiddenBlock
                 fs_root: /edx/var/edxapp/data
                 render_template: common.djangoapps.edxmako.shortcuts.render_to_string
             - ENGINE: xmodule.modulestore.mongo.DraftMongoModuleStore
@@ -400,7 +400,7 @@ MODULESTORE:
               DOC_STORE_CONFIG:
                 <<: *docstore_config
               OPTIONS:
-                default_class: xmodule.hidden_module.HiddenDescriptor
+                default_class: xmodule.hidden_block.HiddenBlock
                 fs_root: /edx/var/edxapp/data
                 render_template: common.djangoapps.edxmako.shortcuts.render_to_string
 ORA2_FILE_PREFIX: mitxonline/ora2  # MODIFIED

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -378,7 +378,7 @@ MODULESTORE:
               DOC_STORE_CONFIG:
                 <<: *docstore_config
               OPTIONS:
-                default_class: xmodule.hidden_module.HiddenDescriptor
+                default_class: xmodule.hidden_block.HiddenBlock
                 fs_root: /openedx/data/var/edxapp/data
                 render_template: common.djangoapps.edxmako.shortcuts.render_to_string
             - ENGINE: xmodule.modulestore.mongo.DraftMongoModuleStore
@@ -386,7 +386,7 @@ MODULESTORE:
               DOC_STORE_CONFIG:
                 <<: *docstore_config
               OPTIONS:
-                default_class: xmodule.hidden_module.HiddenDescriptor
+                default_class: xmodule.hidden_block.HiddenBlock
                 fs_root: /openedx/data/var/edxapp/data
                 render_template: common.djangoapps.edxmako.shortcuts.render_to_string
 ORA2_FILE_PREFIX: mitxonline/ora2  # MODIFIED


### PR DESCRIPTION
# What are the relevant tickets?
Might fix https://github.com/mitodl/hq/issues/2687 & https://github.com/mitodl/hq/issues/2460. Also, this [sentry issue](https://mit-office-of-digital-learning.sentry.io/issues/3825401912/events/57d9dc51546d46eca0cba6a2d451e84d/?project=5939801).

# Description (What does it do?)
edX has renamed one of the module store classes. Also, they have updated the settings in edx-platform. We are using the old name as defined in our configurations. This PR updates the MODULESTORE setting for MITx Online. Here is the edX PR https://github.com/openedx/edx-platform/pull/31113

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
We can test the grading and check sentry.
