### PR TITLE
Issue 1629 - Log shipping for edxapp fastly distributions 

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -1534,14 +1534,13 @@ edxapp_fastly_service = fastly.ServiceVcl(
             ),
             name=f"fastly-{env_name}-https-logging-args",
             content_type="application/json",
-            format=build_fastly_log_format_string(
-                additional_static_fields={
-                    "application": "edxapp",
-                    "environment": consul_stack.require_output("datacenter").apply(
-                        lambda consul_dc: f"{consul_dc}"
-                    ),
-                    # service will be applied by the vector-log-proxy
-                }
+            format=consul_stack.require_output("datacenter").apply(
+                lambda dc: build_fastly_log_format_string(
+                    additional_static_fields={
+                        "application": "edxapp",
+                        "environment": dc,
+                    }
+                )
             ),
             format_version=2,
             header_name="Authorization",

--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -40,7 +40,9 @@ ocw_zone = dns_stack.require_output("ocw")
 vector_log_proxy_stack = StackReference(
     f"infrastructure.vector_log_proxy.operations.{stack_info.name}"
 )
-vector_log_proxy_fqdn = vector_log_proxy_stack.require_output("vector_log_proxy")
+vector_log_proxy_fqdn = vector_log_proxy_stack.require_output("vector_log_proxy")[
+    "fqdn"
+]
 
 vector_log_proxy_secrets = read_yaml_secrets(
     Path(f"vector/vector_log_proxy.{stack_info.env_suffix}.yaml")
@@ -499,7 +501,7 @@ for purpose in ("draft", "live"):
         ],
         logging_https=[
             fastly.ServiceVclLoggingHttpArgs(
-                url=Output.all(fqdn=vector_log_proxy_fqdn["fqdn"]).apply(
+                url=Output.all(fqdn=vector_log_proxy_fqdn).apply(
                     lambda fqdn: "https://{fqdn}".format(**fqdn)
                 ),
                 name=f"ocw-{purpose}-{stack_info.env_suffix}-https-logging-args",
@@ -508,6 +510,7 @@ for purpose in ("draft", "live"):
                     additional_static_fields={
                         "application": "open-courseware",
                         "environment": f"ocw-{stack_info.env_suffix}",
+                        # service will be applied by the vector-log-proxy
                     }
                 ),
                 format_version=2,

--- a/src/ol_infrastructure/lib/aws/monitoring_helper.py
+++ b/src/ol_infrastructure/lib/aws/monitoring_helper.py
@@ -1,11 +1,20 @@
 from functools import lru_cache
 from typing import Literal
 
-from pulumi import Output, StackReference
+from pulumi import Output, ResourceOptions, StackReference
 
 
 @lru_cache
 def get_monitoring_sns_arn(level: Literal["warning", "critical"]) -> Output[str]:
-    return StackReference("infrastructure.monitoring").require_output(
-        "opsgenie_sns_topics"
-    )[f"{level}_sns_topic_arn"]
+    # This ends up creating a StackReference resource via a component resource which is
+    # not great and can lead to conflicts / duplicate resources.
+    #
+    # We work around this by naming this stack resource `implicit` because it is a
+    # side-effect of finding the sns_topic_arn for a given environment. This way
+    # we can continue to explicitly create a StackReference("infrastructure.monitoring")
+    # when we need it without getting duplicate resources.
+    return StackReference(
+        "implicit.infrastructure.monitoring",
+        stack_name="infrastructure.monitoring",
+        opts=ResourceOptions(delete_before_replace=True),
+    ).require_output("opsgenie_sns_topics")[f"{level}_sns_topic_arn"]


### PR DESCRIPTION

# What are the relevant tickets?
Partially addresses #1628 

# Description (What does it do?)
This enables log shipping from fastly to Grafana and S3 following the same pattern we use for OCW.

Additionally it makes a few things more consistent with how the log shipping is setup with both edxapp and ocw. 

It also addresses a bug introduced by the `get_monitoring_sns_arn` helper function which silently creates stack references in stacks that did not explicitly ask for it. The helper function will continue to create that stack reference, but it is now given a special `implicit` name that will prevent collisions when stacks later explicitly ask for references to the `infrastructure.monitoring` stack. Also documented this behavior. 
