### PR TITLE
Add cache control headers for OCW

### DIFF
--- a/src/ol_infrastructure/applications/ocw_site/snippets/ttl_setup.vcl
+++ b/src/ol_infrastructure/applications/ocw_site/snippets/ttl_setup.vcl
@@ -5,11 +5,11 @@ if (beresp.status == 404) {
 }
 # One month cache is for hashed static assets (first three cases). We use a long cache because the hashes should be updated whenever the files are updated.
 # One week cache is for unhashed assets (last three cases). We use a shorter cache here to ensure those assets remain fresh.
-if (bereq.url.path ~ ".*(main|common|www|course_v2|instructor_insights|fields)\.[0-9a-f]+\.(css|js)\z") || (bereq.url.path ~ ".*[0-9a-f]+\.[0-9a-f]+\.(css|js)\z") {
+if (bereq.url.path ~ ".*(main|common|www|course_v2|instructor_insights|fields)\.[0-9a-f]+\.(css|js)\z" || bereq.url.path ~ ".*[0-9a-f]+\.[0-9a-f]+\.(css|js)\z") {
   # Hashed static theme assets and dynamic imports
   set beresp.ttl = 2629743s;
   set beresp.http.Cache-Control = "max-age=2629743";
-} elsif (bereq.url.path ~ ".*/static_shared/images/.*\.[0-9a-f]+\.(png|jpg|jpeg|svg|gif)\z") || (bereq.url.path ~ ".*/static_shared/fonts/.*\.subset\.[0-9a-f]+\.(ttf|woff|woff2)\z") {
+} elsif (bereq.url.path ~ ".*/static_shared/images/.*\.[0-9a-f]+\.(png|jpg|jpeg|svg|gif)\z" || bereq.url.path ~ ".*/static_shared/fonts/.*\.subset\.[0-9a-f]+\.(ttf|woff|woff2)\z") {
   # Hashed static images and fonts
   set beresp.ttl = 2629743s;
   set beresp.http.Cache-Control = "max-age=2629743";
@@ -25,7 +25,7 @@ if (bereq.url.path ~ ".*(main|common|www|course_v2|instructor_insights|fields)\.
   # Any other images
   set beresp.ttl = 604800s;
   set beresp.http.Cache-Control = "max-age=604800";
-} elsif (bereq.http.Host ~ "www.ocw-openmatters.org") && (bereq.url.path ~ "^/wp-content/uploads/.*\.(png|jpg|jpeg|svg|gif)\z") {
+} elsif (bereq.http.Host ~ "www.ocw-openmatters.org" && bereq.url.path ~ "^/wp-content/uploads/.*\.(png|jpg|jpeg|svg|gif)\z") {
   # Uploaded images in openmatters
   set beresp.ttl = 604800s;
   set beresp.http.Cache-Control = "max-age=604800";

--- a/src/ol_infrastructure/applications/ocw_site/snippets/ttl_setup.vcl
+++ b/src/ol_infrastructure/applications/ocw_site/snippets/ttl_setup.vcl
@@ -2,18 +2,17 @@ if (beresp.status == 404) {
   set beresp.ttl = 5m;
   set beresp.http.Cache-Control = "max-age=300";
   return(deliver);
- }
+}
 
 if (bereq.url.path ~ "^.*(main|common|www|course_v2|instructor_insights|fields|[0-9a-f]+)\.[0-9a-f]+\.(css|js)") {
   set beresp.ttl = 2629743s;  // one month
   set beresp.http.Cache-Control = "max-age=2629743";
- }
+}
 
 if (bereq.url.path ~ "^.*\/static_shared\/(images|fonts)\/[a-zA-Z0-9|-]+(\.subset)?\.[0-9a-f]+\.(png|svg|ttf|woff|woff2)") {
   set beresp.ttl = 2629743s;  // one month
   set beresp.http.Cache-Control = "max-age=2629743";
-}
-else if (bereq.url.path ~ "^.*\/static_shared\/(images|fonts)\/.*\.(png|svg|ttf|woff|woff2)") {
+} elsif (bereq.url.path ~ "^.*\/static_shared\/(images|fonts)\/.*\.(png|svg|ttf|woff|woff2)") {
   set beresp.ttl = 604800s;  // one week
   set beresp.http.Cache-Control = "max-age=604800";
 }

--- a/src/ol_infrastructure/applications/ocw_site/snippets/ttl_setup.vcl
+++ b/src/ol_infrastructure/applications/ocw_site/snippets/ttl_setup.vcl
@@ -3,13 +3,17 @@ if (beresp.status == 404) {
   set beresp.http.Cache-Control = "max-age=300";
   return(deliver);
 }
-# One month cache is for hashed static assets (first two cases), while one week is for unhashed assets (last three cases)
+# One month cache is for hashed static assets (first three cases), while one week is for unhashed assets (last three cases)
 if (bereq.url.path ~ ".*(main|common|www|course_v2|instructor_insights|fields)\.[0-9a-f]+\.(css|js)\z") || (bereq.url.path ~ ".*[0-9a-f]+\.[0-9a-f]+\.(css|js)\z") {
   # Hashed static theme assets and dynamic imports
   set beresp.ttl = 2629743s;
   set beresp.http.Cache-Control = "max-age=2629743";
 } elsif (bereq.url.path ~ ".*/static_shared/images/.*\.[0-9a-f]+\.(png|jpg|jpeg|svg|gif)\z") || (bereq.url.path ~ ".*/static_shared/fonts/.*\.subset\.[0-9a-f]+\.(ttf|woff|woff2)\z") {
   # Hashed static images and fonts
+  set beresp.ttl = 2629743s;
+  set beresp.http.Cache-Control = "max-age=2629743";
+} elsif (bereq.url.path ~ ".*/static_shared/mathjax/.*\.[0-9a-f]+.*\z") {
+  # Hashed static mathjax assets
   set beresp.ttl = 2629743s;
   set beresp.http.Cache-Control = "max-age=2629743";
 } elsif (bereq.url.path ~ ".*/static_shared/(images|fonts)/.*\.(png|jpg|jpeg|svg|gif|ttf|woff|woff2)\z") {

--- a/src/ol_infrastructure/applications/ocw_site/snippets/ttl_setup.vcl
+++ b/src/ol_infrastructure/applications/ocw_site/snippets/ttl_setup.vcl
@@ -4,15 +4,15 @@ if (beresp.status == 404) {
   return(deliver);
 }
 
-if (bereq.url.path ~ "^.*(main|common|www|course_v2|instructor_insights|fields|[0-9a-f]+)\.[0-9a-f]+\.(css|js)") {
+if (bereq.url.path ~ ".*(main|common|www|course_v2|instructor_insights|fields|[0-9a-f]+)\.[0-9a-f]+\.(css|js)") {
   set beresp.ttl = 2629743s;  // one month
   set beresp.http.Cache-Control = "max-age=2629743";
 }
 
-if (bereq.url.path ~ "^.*\/static_shared\/(images|fonts)\/[a-zA-Z0-9|-]+(\.subset)?\.[0-9a-f]+\.(png|svg|ttf|woff|woff2)") {
+if (bereq.url.path ~ ".*\/static_shared\/(images|fonts)\/[a-zA-Z0-9|-]+(\.subset)?\.[0-9a-f]+\.(png|svg|ttf|woff|woff2)") {
   set beresp.ttl = 2629743s;  // one month
   set beresp.http.Cache-Control = "max-age=2629743";
-} elsif (bereq.url.path ~ "^.*\/static_shared\/(images|fonts)\/.*\.(png|svg|ttf|woff|woff2)") {
+} elsif (bereq.url.path ~ ".*\/static_shared\/(images|fonts)\/.*\.(png|svg|ttf|woff|woff2)") {
   set beresp.ttl = 604800s;  // one week
   set beresp.http.Cache-Control = "max-age=604800";
 }

--- a/src/ol_infrastructure/applications/ocw_site/snippets/ttl_setup.vcl
+++ b/src/ol_infrastructure/applications/ocw_site/snippets/ttl_setup.vcl
@@ -9,11 +9,11 @@ if (bereq.url.path ~ "^.*(main|common|www|course_v2|instructor_insights|fields|[
   set beresp.http.Cache-Control = "max-age=2629743";
  }
 
-if (bereq.urlpath ~ "^.*\/static_shared\/(images|fonts)\/[a-zA-Z0-9|-]+(\.subset)?\.[0-9a-f]+\.(png|svg|ttf|woff|woff2)") {
+if (bereq.url.path ~ "^.*\/static_shared\/(images|fonts)\/[a-zA-Z0-9|-]+(\.subset)?\.[0-9a-f]+\.(png|svg|ttf|woff|woff2)") {
   set beresp.ttl = 2629743s;  // one month
   set beresp.http.Cache-Control = "max-age=2629743";
 }
-else if (bereq.urlpath ~ "^.*\/static_shared\/(images|fonts)\/.*\.(png|svg|ttf|woff|woff2)") {
+else if (bereq.url.path ~ "^.*\/static_shared\/(images|fonts)\/.*\.(png|svg|ttf|woff|woff2)") {
   set beresp.ttl = 604800s;  // one week
   set beresp.http.Cache-Control = "max-age=604800";
 }

--- a/src/ol_infrastructure/applications/ocw_site/snippets/ttl_setup.vcl
+++ b/src/ol_infrastructure/applications/ocw_site/snippets/ttl_setup.vcl
@@ -3,7 +3,6 @@ if (beresp.status == 404) {
   set beresp.http.Cache-Control = "max-age=300";
   return(deliver);
 }
-
 # One month cache is for hashed static assets (first two cases), while one week is for unhashed assets (last three cases)
 if (bereq.url.path ~ ".*(main|common|www|course_v2|instructor_insights|fields)\.[0-9a-f]+\.(css|js)\z") || (bereq.url.path ~ ".*[0-9a-f]+\.[0-9a-f]+\.(css|js)\z") {
   # Hashed static theme assets and dynamic imports

--- a/src/ol_infrastructure/applications/ocw_site/snippets/ttl_setup.vcl
+++ b/src/ol_infrastructure/applications/ocw_site/snippets/ttl_setup.vcl
@@ -4,7 +4,16 @@ if (beresp.status == 404) {
   return(deliver);
  }
 
-if (bereq.url.path ~ "^/main\.[0-9a-f]+\.(css|js)") {
+if (bereq.url.path ~ "^.*(main|common|www|course_v2|instructor_insights|fields|[0-9a-f]+)\.[0-9a-f]+\.(css|js)") {
   set beresp.ttl = 2629743s;  // one month
   set beresp.http.Cache-Control = "max-age=2629743";
  }
+
+if (bereq.urlpath ~ "^.*\/static_shared\/(images|fonts)\/[a-zA-Z0-9|-]+(\.subset)?\.[0-9a-f]+\.(png|svg|ttf|woff|woff2)") {
+  set beresp.ttl = 2629743s;  // one month
+  set beresp.http.Cache-Control = "max-age=2629743";
+}
+else if (bereq.urlpath ~ "^.*\/static_shared\/(images|fonts)\/.*\.(png|svg|ttf|woff|woff2)") {
+  set beresp.ttl = 604800s;  // one week
+  set beresp.http.Cache-Control = "max-age=604800";
+}

--- a/src/ol_infrastructure/applications/ocw_site/snippets/ttl_setup.vcl
+++ b/src/ol_infrastructure/applications/ocw_site/snippets/ttl_setup.vcl
@@ -9,20 +9,20 @@ if (bereq.url.path ~ ".*(main|common|www|course_v2|instructor_insights|fields)\.
   # Hashed static theme assets and dynamic imports
   set beresp.ttl = 2629743s; 
   set beresp.http.Cache-Control = "max-age=2629743";
-} elsif (bereq.url.path ~ ".*/static_shared/images/.*\.[0-9a-f]+\.(png|jpg|jpeg|svg)\z") || (bereq.url.path ~ ".*/static_shared/fonts/.*\.subset\.[0-9a-f]+\.(ttf|woff|woff2)\z") {
+} elsif (bereq.url.path ~ ".*/static_shared/images/.*\.[0-9a-f]+\.(png|jpg|jpeg|svg|gif)\z") || (bereq.url.path ~ ".*/static_shared/fonts/.*\.subset\.[0-9a-f]+\.(ttf|woff|woff2)\z") {
   # Hashed static images and fonts
   set beresp.ttl = 2629743s;
   set beresp.http.Cache-Control = "max-age=2629743";
-} elsif (bereq.url.path ~ ".*/static_shared/(images|fonts)/.*\.(png|jpg|jpeg|svg|ttf|woff|woff2)\z") {
+} elsif (bereq.url.path ~ ".*/static_shared/(images|fonts)/.*\.(png|jpg|jpeg|svg|gif|ttf|woff|woff2)\z") {
   # Non-hashed static images and fonts (if any)
   set beresp.ttl = 604800s;  
   set beresp.http.Cache-Control = "max-age=604800";
-} elsif (bereq.url.path ~ ".*/(ocw-www|courses|images)/.*\.(png|jpg|jpeg|svg)\z"){
+} elsif (bereq.url.path ~ ".*/(ocw-www|courses|images)/.*\.(png|jpg|jpeg|svg|gif)\z") {
   # Any other images
   set beresp.ttl = 604800s;
   set beresp.http.Cache-Control = "max-age=604800";
-} elsif (bereq.http.Host ~ "www.ocw-openmatters.org") && (bereq.url.path ~ "^/wp-content/uploads/.*) {
-  # Uploaded images from openmatters
+} elsif (bereq.http.Host ~ "www.ocw-openmatters.org") && (bereq.url.path ~ "^/wp-content/uploads/.*\.(png|jpg|jpeg|svg|gif)\z") {
+  # Uploaded images in openmatters
   set beresp.ttl = 604800s;
   set beresp.http.Cache-Control = "max-age=604800";
 }

--- a/src/ol_infrastructure/applications/ocw_site/snippets/ttl_setup.vcl
+++ b/src/ol_infrastructure/applications/ocw_site/snippets/ttl_setup.vcl
@@ -9,10 +9,10 @@ if (bereq.url.path ~ ".*(main|common|www|course_v2|instructor_insights|fields|[0
   set beresp.http.Cache-Control = "max-age=2629743";
 }
 
-if (bereq.url.path ~ ".*\/static_shared\/(images|fonts)\/[a-zA-Z0-9|-]+(\.subset)?\.[0-9a-f]+\.(png|svg|ttf|woff|woff2)") {
+if (bereq.url.path ~ ".*\/static_shared\/(images|fonts)\/[a-zA-Z0-9|-|_]+(\.subset)?\.[0-9a-f]+\.(png|jpg|jpeg|svg|ttf|woff|woff2)") {
   set beresp.ttl = 2629743s;  // one month
   set beresp.http.Cache-Control = "max-age=2629743";
-} elsif (bereq.url.path ~ ".*\/static_shared\/(images|fonts)\/.*\.(png|svg|ttf|woff|woff2)") {
+} elsif (bereq.url.path ~ ".*\/static_shared\/(images|fonts)\/.*\.(png|jpg|jpeg|svg|ttf|woff|woff2)") {
   set beresp.ttl = 604800s;  // one week
   set beresp.http.Cache-Control = "max-age=604800";
 }

--- a/src/ol_infrastructure/applications/ocw_site/snippets/ttl_setup.vcl
+++ b/src/ol_infrastructure/applications/ocw_site/snippets/ttl_setup.vcl
@@ -3,7 +3,8 @@ if (beresp.status == 404) {
   set beresp.http.Cache-Control = "max-age=300";
   return(deliver);
 }
-# One month cache is for hashed static assets (first three cases), while one week is for unhashed assets (last three cases)
+# One month cache is for hashed static assets (first three cases). We use a long cache because the hashes should be updated whenever the files are updated.
+# One week cache is for unhashed assets (last three cases). We use a shorter cache here to ensure those assets remain fresh.
 if (bereq.url.path ~ ".*(main|common|www|course_v2|instructor_insights|fields)\.[0-9a-f]+\.(css|js)\z") || (bereq.url.path ~ ".*[0-9a-f]+\.[0-9a-f]+\.(css|js)\z") {
   # Hashed static theme assets and dynamic imports
   set beresp.ttl = 2629743s;

--- a/src/ol_infrastructure/applications/ocw_site/snippets/ttl_setup.vcl
+++ b/src/ol_infrastructure/applications/ocw_site/snippets/ttl_setup.vcl
@@ -7,7 +7,7 @@ if (beresp.status == 404) {
 # One month cache is for hashed static assets (first two cases), while one week is for unhashed assets (last three cases)
 if (bereq.url.path ~ ".*(main|common|www|course_v2|instructor_insights|fields)\.[0-9a-f]+\.(css|js)\z") || (bereq.url.path ~ ".*[0-9a-f]+\.[0-9a-f]+\.(css|js)\z") {
   # Hashed static theme assets and dynamic imports
-  set beresp.ttl = 2629743s; 
+  set beresp.ttl = 2629743s;
   set beresp.http.Cache-Control = "max-age=2629743";
 } elsif (bereq.url.path ~ ".*/static_shared/images/.*\.[0-9a-f]+\.(png|jpg|jpeg|svg|gif)\z") || (bereq.url.path ~ ".*/static_shared/fonts/.*\.subset\.[0-9a-f]+\.(ttf|woff|woff2)\z") {
   # Hashed static images and fonts
@@ -15,7 +15,7 @@ if (bereq.url.path ~ ".*(main|common|www|course_v2|instructor_insights|fields)\.
   set beresp.http.Cache-Control = "max-age=2629743";
 } elsif (bereq.url.path ~ ".*/static_shared/(images|fonts)/.*\.(png|jpg|jpeg|svg|gif|ttf|woff|woff2)\z") {
   # Non-hashed static images and fonts (if any)
-  set beresp.ttl = 604800s;  
+  set beresp.ttl = 604800s;
   set beresp.http.Cache-Control = "max-age=604800";
 } elsif (bereq.url.path ~ ".*/(ocw-www|courses|images)/.*\.(png|jpg|jpeg|svg|gif)\z") {
   # Any other images


### PR DESCRIPTION
# What are the relevant tickets?
Partial solution to https://github.com/mitodl/ocw-hugo-themes/issues/1212

# Description (What does it do?)
Adds cache-control headers for OCW resources.

### The pattern:
`(bereq.url.path ~ ".*(main|common|www|course_v2|instructor_insights|fields)\.[0-9a-f]+\.(css|js)\z") || (bereq.url.path ~ ".*[0-9a-f]+\.[0-9a-f]+\.(css|js)\z")`
The first part of the pattern corresponds to hashed themes related `js` or `css` files.
The second part of the pattern corresponds to dynamic imports using webpack (videojs and nanogallery2).
Eg. 
`https://ocw.mit.edu/static_shared/js/common.904c3.js (1st part)
`
`https://ocw.mit.edu/static_shared/js/abc354.904c3.js (1st part)
`
`https://ocw.mit.edu/static_shared/js/354.904c3.js (2nd part)
`
You can notice the dynamic imports here:
https://ocw.mit.edu/courses/16-885j-aircraft-systems-engineering-fall-2005/pages/related-resources/
<img width="1263" alt="image" src="https://github.com/mitodl/ol-infrastructure/assets/109785089/70c62265-c6bc-4bd7-a8e3-8e09b64aa580">
The code for them is given here:
https://github.com/mitodl/ocw-hugo-themes/blob/main/course-v2/assets/course-v2.ts

### The pattern
`(bereq.url.path ~ ".*/static_shared/images/.*\.[0-9a-f]+\.(png|jpg|jpeg|svg|gif)\z") || (bereq.url.path ~ ".*/static_shared/fonts/.*\.subset\.[0-9a-f]+\.(ttf|woff|woff2)\z")`
Corresponds to hashed static assets (images and fonts).
Eg.
`http://localhost:3000/static_shared/images/ocw_logo_white_v2.1a5cf4568192c88b5efab45063b86d8a.svg
`
`http://localhost:3000/static_shared/fonts/MaterialIcons-Regular.subset.0ec6028d1bb7a2675394e0512f8ceee4.woff2 
`

### The pattern
`(bereq.url.path ~ ".*/static_shared/mathjax/.*\.[0-9a-f]+.*\z")`
Corresponds to static mathjax files. There are many different files with different extensions produced by webpack, so we are not limiting the extensions here in the pattern.

### The pattern
`(bereq.url.path ~ ".*/static_shared/(images|fonts)/.*\.(png|jpg|jpeg|svg|gif|ttf|woff|woff2)\z")`
Corresponds to unhashed static images and fonts. Currently I do not think we have any such case, as we have hashed all the static images and fonts by webpack. But if we did, it would fall here.

### The pattern
`(bereq.url.path ~ ".*/(ocw-www|courses|images)/.*\.(png|jpg|jpeg|svg|gif)\z")`
Corresponds to any other images present in `ocw-www` or `course-v2` theme.
Eg. 
https://ocw.mit.edu/images/homepage_hero.jpg
https://ocw.mit.edu/courses/6-033-computer-system-engineering-spring-2018/a79fa5
https://ocw.mit.edu/ocw-www/chansa_20230113.jpg

### The pattern
`(bereq.http.Host ~ "www.ocw-openmatters.org") && (bereq.url.path ~ "^/wp-content/uploads/.*\.(png|jpg|jpeg|svg|gif)\z")`
`

Corresponds to any OpenMatters images we use. We use them in `ocw-www` theme, eg. this image:
https://www.ocw-openmatters.org/wp-content/uploads/2020/01/Placeholder_2.png

# How can this be tested?
I will be testing this in RC as I do not have the setup of `ol-infrastructure`.
What you need to do is, make sure the code works as intended (take the given examples for help). 

# Additional Context
More details can be found here:
https://github.com/mitodl/ocw-hugo-themes/issues/1212
https://github.com/mitodl/ocw-hugo-themes/pull/1272
https://mitodl.slack.com/archives/GQ89D0Z5M/p1696431334601819

<!--- Uncomment and add steps to be completed before merging this PR if necessary
## Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
