### PR TITLE
1855: define user migration plug in configuration for open discussions in qa

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.CI.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.CI.yaml
@@ -22,5 +22,7 @@ config:
     client_info:
       open-local: "*"
       open-discusions: https://discussions-ci.odl.mit.edu
+  keycloak:keycloak_user_migration_open_discussions_bearer_token:
+    secure: v1:
   vault:address: https://vault-ci.odl.mit.edu
   vault_server:env_namespace: operations.ci

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.Production.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.Production.yaml
@@ -29,5 +29,7 @@ config:
   keycloak:url: https://sso-production.odl.mit.edu
   keycloakd:captcha_site_key:
     secure: v1:/iVlq/nwXfZo5cmO:G36x/OuuRgvg6G7sbnLh9l7XKKua00HsHgrNYOv6UrrlBSdetInWQwqmFLo/5bi8RdcfDKRiQ7k=
+  keycloak:keycloak_user_migration_open_discussions_bearer_token:
+    secure: v1:
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
@@ -26,5 +26,7 @@ config:
   keycloak:email_username:
     secure: v1:Uxscw7J8NqxO/NbK:NCGzgYTGRmeIovnjZyXrb6ztDW7levn0
   keycloak:url: https://sso-qa.odl.mit.edu
+  keycloak:keycloak_user_migration_open_discussions_bearer_token:
+    secure: v1:
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa

--- a/src/ol_infrastructure/substructure/keycloak/__main__.py
+++ b/src/ol_infrastructure/substructure/keycloak/__main__.py
@@ -457,3 +457,23 @@ if stack_info.env_suffix != "production":
         ),
     )
     # Okta TEST SAML [END]
+
+keycloak.CustomUserFederation(
+    "ol-open-discussions-qa-user-migration-federation",
+    cache_policy="DEFAULT",
+    config={
+        "API_TOKEN_ENABLED": True,
+        "API_HTTP_BASIC_ENABLED": False,
+        "API_TOKEN": keycloak_config.get("keycloak_user_migration_open_discussions_bearer_token"),
+        "MIGRATE_UNMAPPED_GROUPS": False,
+        "MIGRATE_UNMAPPED_ROLES": False,
+        "URI": "https://discussions-rc.odl.mit.edu/api/v0/auth",
+        "USE_USER_ID_FOR_CREDENTIAL_VERIFICATION": False,
+        "API_HTTP_BASIC_USERNAME": "",
+    },
+    enabled=True,
+    name="Open Discussions",
+    provider_id="User migration using a REST client",
+    realm_id=ol_apps_realm.id,
+    opts=resource_options,
+)


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/ol-infrastructure/issues/1855

# Description (What does it do?)
This defines the Keycloak configuration to support and configure the Keycloak user migration plug-in described here:
https://docs.google.com/document/d/17tJ-C2EwWoSpJWZKjuhMVgsqGtyPH0IN9KakXvSKU0M/edit#heading=h.geba7zl9ukna

The corresponding functionality for this plug-in was added to Open Discussions here https://github.com/mitodl/open-discussions/issues/4227

There are bearer token values that will need to be created in Vault and referenced in the substructure yaml files.

# How can this be tested?
Once this configuration is deployed to QA, Open Discussion users should be able to authenticate with Keycloak using their Open Discussion credentials.
