### PR TITLE
Update OCW 404 page text

### DIFF
--- a/src/ol_infrastructure/applications/ocw_site/404.html
+++ b/src/ol_infrastructure/applications/ocw_site/404.html
@@ -138,8 +138,15 @@
           <h3>Sorry, the page you requested was not found.</h3>
           <br />
           <p>
-            You might want to try <a href="/search/">searching</a> for another
-            page, or you can <a href="/contact/">contact us</a> and let us know.
+            If you are trying to access OCW content from a saved bookmark or from a link from another website:
+            <ul>
+              <li>The OCW content may have been updated to a new version, which you can find by
+                <a href="/search/">searching</a> for the course number or title.</li>
+              <li>The OCW content may have been retired by request of MIT departments and faculty.
+                Retired and prior versions no longer on the live OCW website can be found in our
+                <a href="https://dspace.mit.edu/handle/1721.1/33971">DSpace archive</a>.</li>
+            </ul>
+            If you still can't find what you're seeking, please <a href="/contact/">contact us</a> for help.
           </p>
         </div>
       </div>


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/2800.

# Description (What does it do?)
Updates the text of the OCW 404 page to be more informative.

# How can this be tested?
Open the updated page `/src/ol_infrastructure/applications/ocw_site/404.html` in a web browser, and verify that everything looks correct. The relative links won't work until this is deployed.
