### PR TITLE
Upgrading the QA dagster instance resource to a m7a.xlarge.

### DIFF
--- a/src/ol_infrastructure/applications/dagster/Pulumi.applications.dagster.QA.yaml
+++ b/src/ol_infrastructure/applications/dagster/Pulumi.applications.dagster.QA.yaml
@@ -22,6 +22,6 @@ config:
   dagster:edx_pipeline_xpro_edx_bucket_name: dagster-data-qa
   dagster:edx_pipeline_xpro_edx_course_bucket_name: xpro-qa-edxapp-courses
   dagster:edx_pipeline_xpro_edx_xpro_purpose: mitx-etl-xpro-qa
-  dagster:instance_type: m7a.medium
+  dagster:instance_type: m7a.xlarge
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa


### PR DESCRIPTION
# What are the relevant tickets?
Bumping into resource limitations when testing changes from [PR #876](https://github.com/mitodl/ol-data-platform/pull/876) which was work done for Ticket [#1309](https://github.com/mitodl/hq/issues/1309).

# Description (What does it do?)
Upgrades the Dagster instance to an m7a.xlarge (16.0 GiB | 4 vCPUs) to be able to handle the increased load on QA for testing. Currently, our [Dagster QA Instance](https://pipelines-qa.odl.mit.edu/overview/timeline) is unresponsive after kicking off a pipeline run.

# How can this be tested?
This is a change to our QA infrastructure.