### PR TITLE
Giving mitxonline edxapp workers dedicated CPU

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
@@ -33,6 +33,7 @@ config:
   edxapp:use_docker: true
   edxapp:web_node_capacity: "9"
   edxapp:worker_node_capacity: "5"
+  edxapp:worker_instance_type: "c6a.large"
   mongodb:atlas_project_id: 61f0a63f8bc1f86a073a7148
   redis:instance_type: cache.r6g.xlarge
   vault:address: https://vault-production.odl.mit.edu

--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -1312,7 +1312,7 @@ web_alb_metric_alarm = cloudwatch.MetricAlarm(
 )
 
 worker_instance_type = (
-    edxapp_config.get("worker_instance_type") or InstanceTypes.burstable_large.name
+    edxapp_config.get("worker_instance_type") or InstanceTypes.burstable_medium.name
 )
 worker_launch_config = ec2.LaunchTemplate(
     "edxapp-worker-launch-template",


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/hq/issues/2879

# Description (What does it do?)
This switches edxapp workers in the mitxonline production env to c6a.large which has two dedicated vCPU rather than burstable instances that the stacks default to. This does reduce the amount of memory available but after confirming in grafana, the workers only ever utulize about 2.2GB of memory so we are still well within the resources. 

Costs about 0.003/h * 5 more. 