### PR TITLE
Keycloak - Touchstone IDp mapper email -> mail

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/__main__.py
+++ b/src/ol_infrastructure/substructure/keycloak/__main__.py
@@ -391,7 +391,7 @@ oidc_attribute_importer_identity_provider_mapper = (
     keycloak.AttributeImporterIdentityProviderMapper(
         "map-touchstone-saml-email-attribute",
         realm=ol_apps_realm.id,
-        attribute_name="email",
+        attribute_name="mail",
         identity_provider_alias=ol_apps_touchstone_saml_identity_provider.alias,
         user_attribute="email",
         extra_config={


### PR DESCRIPTION
# What are the relevant tickets?
NA

# Description (What does it do?)
Renames the mapped assertion attribute from "email" to "mail" which matches what Touchstone's documentation says: http://kb.mit.edu/confluence/display/istcontrib/Touchstone+FAQ;jsessionid=E7F782EB2624A99DE1988A587B151E2B