### PR TITLE
Point to new keycloak customization repo

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/keycloak/docker_packer_pulumi_pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/keycloak/docker_packer_pulumi_pipeline.py
@@ -32,12 +32,9 @@ def build_keycloak_pipeline() -> Pipeline:
         image_repository="quay.io/keycloak/keycloak",
         image_tag="22.0",
     )
-    # When the ol-keycloak-customization repo is ready for it and has doof implemented,
-    # this should be split into two resources, one for `release` and another for
-    # `release-canidate` branch. Then refs should be updated. See OVS pipeline.
     keycloak_customization_repo = git_repo(
         Identifier("ol-keycloak-customization"),
-        uri="https://github.com/mitodl/ol-keycloak-customization",
+        uri="https://github.com/mitodl/ol-keycloak",
         branch="main",
     )
 


### PR DESCRIPTION
# Description (What does it do?)
<!--- Describe your changes in detail -->
We moved theme assets and a mod to the login form to a new repo and this is a minor change to point to that new repo