### PR TITLE
Fix - add pipeline-workflow label to concourse github-issues resource…

### DIFF
--- a/src/ol_concourse/lib/jobs/infrastructure.py
+++ b/src/ol_concourse/lib/jobs/infrastructure.py
@@ -239,7 +239,11 @@ def pulumi_jobs_chain(  # noqa: PLR0913, C901
             local_dependencies,
             previous_job,
         )
-        default_github_issue_labels = ["product:infrastructure", "DevOps"]
+        default_github_issue_labels = [
+            "product:infrastructure",
+            "DevOps",
+            "pipeline-workflow",
+        ]
         if ci_stack:
             default_github_issue_labels.append("promotion-to-qa")
         elif qa_stack:


### PR DESCRIPTION
… label defaults for issue creation

# What are the relevant tickets?
#1858 


# Description (What does it do?)
<!--- Describe your changes in detail -->
Adds a 'pipeline-workflow' label by default to issues created by the concourse github issues resource.


# How can this be tested?
Re-generate pipeline with this updated code.