### PR TITLE
Check for cookie before presenting login for browser flow.

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/__main__.py
+++ b/src/ol_infrastructure/substructure/keycloak/__main__.py
@@ -479,7 +479,10 @@ ol_browser_flow_forms = keycloak.authentication.Subflow(
     parent_flow_alias=ol_browser_flow.alias,
     provider_id="basic-flow",
     requirement="ALTERNATIVE",
-    opts=resource_options,
+    opts=ResourceOptions(
+        provider=keycloak_provider,
+        depends_on=ol_browser_cookie,
+    ),
 )
 ol_browser_flow_username_form = keycloak.authentication.Execution(
     "auth-username-form",


### PR DESCRIPTION
# What are the relevant tickets?
NA

# Description (What does it do?)
If the cookie exists, we should not present the username screen during login.

This can also be tested by refreshing the page from within the Admin Console.  You will have to log back in when this change is not implemented.

# How can this be tested?
Test this on a local instance.  Without this change, a user coming to keycloak to authenticate from different clients will be required to authenticate rather than reuse their authentication cookie (be automatically logged in).
