### PR TITLE
config: disable feedback widget

### DIFF
--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -37,6 +37,7 @@ from ol_concourse.lib.resources import git_repo
 class OpenEdxVars(BaseModel):
     contact_url: Optional[str] = None
     deployment_name: OpenEdxDeploymentName
+    display_feedback_widget: Optional[str] = None
     environment: str
     environment_stage: EnvStage
     favicon_url: str
@@ -71,6 +72,7 @@ def mfe_params(
         "BASE_URL": f"https://{open_edx.lms_domain}",
         "CSRF_TOKEN_API_PATH": "/csrf/api/v1/token",
         "CONTACT_URL": open_edx.contact_url,
+        "DISPLAY_FEEDBACK_WIDGET": open_edx.display_feedback_widget,
         "FAVICON_URL": open_edx.favicon_url,
         "LANGUAGE_PREFERENCE_COOKIE_NAME": (
             f"{open_edx.environment}-open-edx-language-preference"

--- a/src/ol_concourse/pipelines/open_edx/mfe/values.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/values.py
@@ -90,6 +90,7 @@ mitxonline = [
     OpenEdxVars(
         contact_url="https://mitxonline.zendesk.com/hc/en-us/requests/new",
         deployment_name="mitxonline",
+        display_feedback_widget="false",
         environment="mitxonline-qa",
         environment_stage="QA",
         favicon_url="https://raw.githubusercontent.com/mitodl/mitxonline-theme/main/lms/static/images/favicon.ico",
@@ -110,6 +111,7 @@ mitxonline = [
     OpenEdxVars(
         contact_url="https://mitxonline.zendesk.com/hc/en-us/requests/new",
         deployment_name="mitxonline",
+        display_feedback_widget="false",
         environment="mitxonline-production",
         environment_stage="Production",
         favicon_url="https://raw.githubusercontent.com/mitodl/mitxonline-theme/main/lms/static/images/favicon.ico",


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/hq/issues/2935

# Description (What does it do?)
Disables the display widget in the gradebook and any other MFEs if it ever comes to that. (See ticket for more details)

# Screenshots (if appropriate):
There is a screenshot on https://github.com/mitodl/hq/issues/2935

# How can this be tested?
Once deployed, We should not see the feedback button anymore.
