### PR TITLE
Md/issue 1881

### DIFF
--- a/dockerfiles/dcind/Dockerfile
+++ b/dockerfiles/dcind/Dockerfile
@@ -1,0 +1,36 @@
+# Original : https://raw.githubusercontent.com/taylorsilva/dcind/main/Dockerfile
+
+FROM alpine:3
+
+ARG EARTHLY_VERSION="v0.7.22"
+
+# Install Docker and Docker Compose
+RUN apk --no-cache add \
+    bash \
+    cargo \
+    curl \
+    docker \
+    docker-cli-compose \
+    device-mapper \
+    gcc \
+    git \
+    iptables \
+    libc-dev \
+    libffi-dev \
+    make \
+    openssl-dev \
+    py3-pip \
+    python3-dev \
+    rust \
+    util-linux
+
+# Include functions to start/stop docker daemon
+COPY docker-lib.sh /docker-lib.sh
+COPY entrypoint.sh /entrypoint.sh
+
+RUN wget https://github.com/earthly/earthly/releases/download/${EARTHLY_VERSION}/earthly-linux-amd64 -O /usr/local/bin/earthly && \
+  chmod +x /usr/local/bin/earthly && \
+  /usr/local/bin/earthly bootstrap
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/bin/bash"]

--- a/dockerfiles/dcind/docker-lib.sh
+++ b/dockerfiles/dcind/docker-lib.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# shellcheck disable=all
+# TODO Ardiea: Get this file to pass shellcheck.
+# Based on https://github.com/concourse/docker-image-resource/blob/master/assets/common.sh
+# Credit: https://github.com/taylorsilva/dcind
+
+LOG_FILE=${LOG_FILE:-/tmp/docker.log}
+SKIP_PRIVILEGED=${SKIP_PRIVILEGED:-false}
+STARTUP_TIMEOUT=${STARTUP_TIMEOUT:-20}
+DOCKER_DATA_ROOT=${DOCKER_DATA_ROOT:-/scratch/docker}
+
+sanitize_cgroups() {
+  mkdir -p /sys/fs/cgroup
+  mountpoint -q /sys/fs/cgroup || \
+    mount -t tmpfs -o uid=0,gid=0,mode=0755 cgroup /sys/fs/cgroup
+
+  mount -o remount,rw /sys/fs/cgroup
+
+  sed -e 1d /proc/cgroups | while read sys hierarchy num enabled; do
+    if [ "$enabled" != "1" ]; then
+      # subsystem disabled; skip
+      continue
+    fi
+
+    grouping="$(cat /proc/self/cgroup | cut -d: -f2 | grep "\\<$sys\\>")" || true
+    if [ -z "$grouping" ]; then
+      # subsystem not mounted anywhere; mount it on its own
+      grouping="$sys"
+    fi
+
+    mountpoint="/sys/fs/cgroup/$grouping"
+
+    mkdir -p "$mountpoint"
+
+    # clear out existing mount to make sure new one is read-write
+    if mountpoint -q "$mountpoint"; then
+      umount "$mountpoint"
+    fi
+
+    mount -n -t cgroup -o "$grouping" cgroup "$mountpoint"
+
+    if [ "$grouping" != "$sys" ]; then
+      if [ -L "/sys/fs/cgroup/$sys" ]; then
+        rm "/sys/fs/cgroup/$sys"
+      fi
+
+      ln -s "$mountpoint" "/sys/fs/cgroup/$sys"
+    fi
+  done
+
+  if ! test -e /sys/fs/cgroup/systemd ; then
+    mkdir /sys/fs/cgroup/systemd
+    mount -t cgroup -o none,name=systemd none /sys/fs/cgroup/systemd
+  fi
+}
+
+start_docker() {
+  echo "Starting Docker..."
+
+  if [ -f /tmp/docker.pid ]; then
+    echo "Docker is already running"
+    return
+  fi
+
+  mkdir -p /var/log
+  mkdir -p /var/run
+
+  if [ "$SKIP_PRIVILEGED" = "false" ]; then
+    sanitize_cgroups
+
+    # check for /proc/sys being mounted readonly, as systemd does
+    if grep '/proc/sys\s\+\w\+\s\+ro,' /proc/mounts >/dev/null; then
+      mount -o remount,rw /proc/sys
+    fi
+  fi
+
+  local mtu=$(cat /sys/class/net/$(ip route get 8.8.8.8|awk '{ print $5 }')/mtu)
+  local server_args="--mtu ${mtu}"
+  local registry=""
+
+  for registry in $1; do
+    server_args="${server_args} --insecure-registry ${registry}"
+  done
+
+  if [ -n "$2" ]; then
+    server_args="${server_args} --registry-mirror $2"
+  fi
+
+  export server_args LOG_FILE DOCKER_DATA_ROOT
+  trap stop_docker EXIT
+
+  try_start() {
+    dockerd --data-root $DOCKER_DATA_ROOT ${server_args} >$LOG_FILE 2>&1 &
+    echo $! > /tmp/docker.pid
+
+    sleep 1
+
+    echo waiting for docker to come up...
+    until docker info >/dev/null 2>&1; do
+      sleep 1
+      if ! kill -0 "$(cat /tmp/docker.pid)" 2>/dev/null; then
+        return 1
+      fi
+    done
+  }
+
+  if [ "$(command -v declare)" ]; then
+    declare -fx try_start
+
+    if ! timeout ${STARTUP_TIMEOUT} bash -ce 'while true; do try_start && break; done'; then
+      echo Docker failed to start within ${STARTUP_TIMEOUT} seconds.
+      return 1
+    fi
+  else
+    try_start
+  fi
+}
+
+stop_docker() {
+  echo "Stopping Docker..."
+
+  if [ ! -f /tmp/docker.pid ]; then
+    return 0
+  fi
+
+  local pid=$(cat /tmp/docker.pid)
+  if [ -z "$pid" ]; then
+    return 0
+  fi
+
+  kill -TERM $pid
+  rm /tmp/docker.pid
+}

--- a/dockerfiles/dcind/entrypoint.sh
+++ b/dockerfiles/dcind/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Based on https://github.com/docker/compose/blob/master/docker-compose-entrypoint.sh
+# Credit: https://github.com/taylorsilva/dcind
+
+set -e
+
+# shellcheck disable=SC1091
+source /docker-lib.sh
+start_docker
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- docker-compose "$@"
+fi
+
+# for a valid Docker subcommand, let's invoke it through Docker instead
+# (this allows for "docker run docker ps", etc)
+if docker-compose help "$1" > /dev/null 2>&1; then
+	set -- docker-compose "$@"
+fi
+
+exec "$@"

--- a/dockerfiles/openedx-edxapp/Earthfile
+++ b/dockerfiles/openedx-edxapp/Earthfile
@@ -1,0 +1,173 @@
+VERSION 0.7
+FROM python:3.8.12-buster
+
+apt-base:
+  ENV DEBIAN_FRONTEND=noninteractive
+  COPY ./apt-pkg-list /root/
+  COPY ./pip_package_lists /root/pip_package_lists
+  COPY ./pip_package_lists /root/pip_package_overrides
+  RUN apt update \
+    && apt install -y --no-install-recommends $(cat /root/apt-pkg-list) \
+    && apt autoremove -y \
+    && apt clean \
+    && rm -rf /var/lib/apt/lists/*
+  SAVE ARTIFACT /root/pip_package_lists
+
+locales:
+  FROM +apt-base
+  ARG OPENEDX_I18N_VERSION="open-release/olive.3"
+  WORKDIR /tmp
+  RUN curl -L -o openedx-i18n.tar.gz https://github.com/openedx/openedx-i18n/archive/$OPENEDX_I18N_VERSION.tar.gz \
+    && tar xzf /tmp/openedx-i18n.tar.gz \
+    && mkdir -p /openedx/locale/contrib \
+    && mv openedx-i18n-*/edx-platform/locale /openedx/locale/contrib
+  CACHE /openedx/locale
+  SAVE ARTIFACT /openedx/locale
+
+get-code:
+  FROM +apt-base
+  # Two required vars to specify the git repo and sha ref the build from.
+  ARG EDX_PLATFORM_GIT_REPO="invalid"
+  ARG EDX_PLATFORM_GIT_BRANCH="invalid"
+  GIT CLONE --branch $EDX_PLATFORM_GIT_BRANCH $EDX_PLATFORM_GIT_REPO /openedx/edx-platform
+  RUN cp /openedx/edx-platform/requirements/edx/base.txt /root/pip_package_lists/edx_base.txt
+  SAVE ARTIFACT /openedx/edx-platform
+
+install-deps:
+  FROM +get-code
+  ARG DEPLOYMENT_NAME="invalid"
+  ARG RELEASE_NAME="invalid"
+  RUN pip install --no-warn-script-location --user --no-cache-dir -r /root/pip_package_lists/edx_base.txt -r /root/pip_package_lists/$RELEASE_NAME/$DEPLOYMENT_NAME.txt
+  RUN pip install --no-warn-script-location --user --no-cache-dir -r /root/pip_package_overrides/$RELEASE_NAME/$DEPLOYMENT_NAME.txt
+  IF [ "$DEPLOYMENT_NAME" = "mitxonline" ]
+    RUN pip uninstall --yes "edx-name-affirmation"
+  END
+  WORKDIR /openedx/edx-platform
+  ENV PATH /root/.local/bin:/openedx/nodeenv/bin:${PATH}
+  ENV NPM_REGISTRY "https://registry.npmjs.org/"
+  RUN nodeenv /openedx/nodeenv --node=16.14.0 --prebuilt \
+    && npm clean-install -s --registry=$NPM_REGISTRY
+  SAVE ARTIFACT /openedx/edx-platform
+  SAVE ARTIFACT /openedx/nodeenv
+  SAVE ARTIFACT /root/.local
+
+themes:
+  FROM +apt-base
+  ARG THEME_GIT_REPO="invalid"
+  ARG THEME_GIT_BRANCH="invalid"
+  GIT CLONE --branch $THEME_GIT_BRANCH $THEME_GIT_REPO /openedx/themes/$RELEASE_NAME
+  SAVE ARTIFACT /openedx/themes
+
+tutor-utils:
+  FROM +apt-base
+  ARG TUTOR_REPO="https://github.com/overhangio/tutor.git"
+  ARG TUTOR_VERSION="v15.3.4"
+  GIT CLONE --branch $TUTOR_VERSION $TUTOR_REPO /openedx/tutor
+  SAVE ARTIFACT /openedx/tutor/tutor/templates/build/openedx/bin
+
+dockerize:
+  FROM docker.io/powerman/dockerize@sha256:983fd3e74c93b05f34533aec9ca0457f0748f173cd00acb119ec1983cbf6b62d
+  SAVE ARTIFACT /usr/local/bin/dockerize
+
+collected:
+  FROM +apt-base
+  ARG APP_USER_ID=1000
+  RUN if [ "$APP_USER_ID" = 0 ]; then echo "app user may not be root" && false; fi
+  RUN useradd --home-dir /openedx --create-home --shell /bin/bash/ --uid ${APP_USER_ID} app
+  USER ${APP_USER_ID}
+  COPY +dockerize/dockerize /usr/local/bin/dockerize
+  COPY +install-deps/edx-platform /openedx/edx-platform
+  COPY +install-deps/nodeenv /openedx/nodeenv
+  COPY +install-deps/.local /openedx/.local
+  COPY +themes/themes /openedx/themes
+  COPY +tutor-utils/bin /openedx/bin
+  COPY +locales/locale /openedx/locale
+  RUN chmod a+x /openedx/bin/*
+  ENV PATH /openedx/.local/bin:/openedx/bin:/openedx/edx-platform/node_modules/.bin:/openedx/nodeenv/bin:${PATH}
+  WORKDIR /openedx/edx-platform
+  RUN pip install --no-warn-script-location --user --no-cache-dir -e . \
+    && mkdir -p /openedx/config ./lms/envs/mitol ./cms/envs/mitol
+  COPY settings/lms.env.yml /openedx/config/lms.env.yml
+  COPY settings/cms.env.yml /openedx/config/cms.env.yml
+  COPY settings/lms/assets.not_py /openedx/edx-platform/lms/envs/mitol/assets.py
+  COPY settings/lms/i18n.not_py /openedx/edx-platform/lms/envs/mitol/i18n.py
+  COPY settings/cms/assets.not_py /openedx/edx-platform/cms/envs/mitol/assets.py
+  COPY settings/cms/i18n.not_py /openedx/edx-platform/cms/envs/mitol/i18n.py
+  COPY settings/set_waffle_flags.not_py /openedx/edx-platform/set_waffle_flags.py
+  COPY settings/process_scheduled_emails.not_py /openedx/edx-platform/process_scheduled_emails.py
+  ENV REVISION_CFG /openedx/config/revisions.yml
+  ENV LMS_CFG /openedx/config/lms.env.yml
+  ENV CMS_CFG /openedx/config/cms.env.yml
+  ENV DJANGO_SETTINGS_MODULE lms.envs.production
+  ENV NO_PYTHON_UNINSTALL 1
+  ENV NO_PREREQ_INSTALL 0
+
+build-static-assets-nonprod:
+  FROM +collected
+  ENV JS_ENV_EXTRA_CONFIG '{"PROCTORTRACK_CDN_URL": "\"https://verificientstatic-preprod.storage.googleapis.com/cdn/fb_cjs/edx_preprod_cjs.IQEQWWZ2.js\"", "PROCTORTRACK_CONFIG_KEY": "\"1PKRwFPezxXj3TsD\""}'
+  RUN pip install --no-warn-script-location --user --no-cache-dir -e "git+https://github.com/openedx/codejail.git@babbe784b48bb9888aa159d8b401cbe5e07f0af4#egg=codejail" \
+    && pip install --no-warn-script-location --user --no-cache-dir -e "git+https://github.com/openedx/django-wiki.git@0a1d555a1fa2834cc46367968aad907a5667317b#egg=django_wiki" \
+    && pip install --no-warn-script-location --user --no-cache-dir -e "git+https://github.com/openedx/blockstore.git@9d623bc04f479a1af29204d438fa442ea8380fae#egg=blockstore" \
+    && pip install --no-warn-script-location --user --no-cache-dir -e "git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner"
+  IF [ "$DEPLOYMENT_NAME" = "mitxonline" ]
+    RUN pip install --no-warn-script-location --user --no-cache-dir "edx-proctoring-proctortrack==1.2.1"
+  END
+  ENV NODE_ENV=prod
+  ARG DEPLOYMENT_NAME="invalid"
+  RUN openedx-assets xmodule \
+    && openedx-assets npm \
+    && openedx-assets collect --settings=mitol.assets \
+    && openedx-assets webpack --env=prod 2> /dev/null \
+    && openedx-assets common \
+    && paver compile_sass --theme-dirs /openedx/themes/ --themes $DEPLOYMENT_NAME \
+    && openedx-assets collect --settings=mitol.assets \
+    && rdfind -makesymlinks true -followsymlinks true /openedx/staticfiles/ \
+    && mkdir -p /openedx/data/var/edxapp/course_repos \
+    && mkdir -p /openedx/data/var/log/edx \
+    && ls -ltrah /openedx/staticfiles \
+    && tar czf - /openedx/staticfiles > /openedx/staticfiles-nonprod.tar.gz
+  SAVE ARTIFACT /openedx/staticfiles-nonprod.tar.gz AS LOCAL staticfiles-nonprod.tar.gz
+
+build-static-assets-production:
+  FROM +collected
+  ENV JS_ENV_EXTRA_CONFIG '{"PROCTORTRACK_CDN_URL": "\"https://verificientstatic.storage.googleapis.com/cdn/fb_cjs/edx_us_cjs.IQEQWWZ2.js\"", "PROCTORTRACK_CONFIG_KEY": "\"1PKRwFPezxXj3TsD\""}'
+  RUN pip install --no-warn-script-location --user --no-cache-dir -e "git+https://github.com/openedx/codejail.git@babbe784b48bb9888aa159d8b401cbe5e07f0af4#egg=codejail" \
+    && pip install --no-warn-script-location --user --no-cache-dir -e "git+https://github.com/openedx/django-wiki.git@0a1d555a1fa2834cc46367968aad907a5667317b#egg=django_wiki" \
+    && pip install --no-warn-script-location --user --no-cache-dir -e "git+https://github.com/openedx/blockstore.git@9d623bc04f479a1af29204d438fa442ea8380fae#egg=blockstore" \
+    && pip install --no-warn-script-location --user --no-cache-dir -e "git+https://github.com/openedx/olxcleaner.git@2f0d6c7f126cbd69c9724b7b57a0b2565330a297#egg=olxcleaner"
+  IF [ "$DEPLOYMENT_NAME" = "mitxonline" ]
+    RUN pip install --no-warn-script-location --user --no-cache-dir "edx-proctoring-proctortrack==1.2.1"
+  END
+  ENV NODE_ENV=prod
+  ARG DEPLOYMENT_NAME="invalid"
+  RUN openedx-assets xmodule \
+    && openedx-assets npm \
+    && openedx-assets collect --settings=mitol.assets \
+    && openedx-assets webpack --env=prod 2> /dev/null \
+    && openedx-assets common \
+    && paver compile_sass --theme-dirs /openedx/themes/ --themes $DEPLOYMENT_NAME \
+    && openedx-assets collect --settings=mitol.assets \
+    && rdfind -makesymlinks true -followsymlinks true /openedx/staticfiles/ \
+    && mkdir -p /openedx/data/var/edxapp/course_repos \
+    && mkdir -p /openedx/data/var/log/edx \
+    && ls -ltrah /openedx/staticfiles \
+    && tar czf - /openedx/staticfiles > /openedx/staticfiles-production.tar.gz
+  SAVE ARTIFACT /openedx/staticfiles-production.tar.gz AS LOCAL staticfiles-production.tar.gz
+
+docker-image:
+  FROM +collected
+  ARG DEPLOYMENT_NAME="invalid"
+  ARG RELEASE_NAME="invalid"
+  ENV DJANGO_SETTINGS_MODULE="invalid"
+  RUN mkdir /openedx/.ssh \
+    && chown app:app /openedx/.ssh \
+    && chmod 0700 /openedx/.ssh \
+    && ssh-keyscan 'github.com' 'github.mit.edu' >> /openedx/.ssh/known_hosts \
+    && chmod 0600 /openedx/.ssh/known_hosts
+  CMD uwsgi uwsgi.ini
+  SAVE IMAGE mitodl/edxapp-$DEPLOYMENT_NAME-$RELEASE_NAME:latest
+
+all:
+  FROM +docker-image
+  FROM +build-static-assets-production
+  FROM +build-static-assets-nonprod

--- a/src/bilder/images/edxapp_v2/files/.env.tmpl
+++ b/src/bilder/images/edxapp_v2/files/.env.tmpl
@@ -1,2 +1,8 @@
+# Should be created at AMI creation
 TUTOR_PERMISSIONS_TAG={{ file "/etc/default/tutor_permissions_tag" }}
+
+# Should be created at AMI creation
 DOCKER_REPO_AND_DIGEST={{ file "/etc/default/docker_repo_and_digest" }}
+
+# Should be created at instance startup with user_data
+ENVIRONMENT_TIER={{ file "/etc/default/environment-tier" }}

--- a/src/bilder/images/edxapp_v2/files/docker-compose.yaml.tmpl
+++ b/src/bilder/images/edxapp_v2/files/docker-compose.yaml.tmpl
@@ -14,6 +14,8 @@ services:
     volumes:
     - /opt/data:/openedx/data
     - /opt/data/media:/openedx/media
+    - /opt/staticfiles-${ENVIRONMENT_TIER}:/openedx/staticfiles:ro
+    - /opt/staticfiles-${ENVIRONMENT_TIER}/bundles:/openedx/edx-platform/common/static/bundles:ro
   cms-permissions:
     image: overhangio/openedx-permissions:${TUTOR_PERMISSIONS_TAG}
     profiles:
@@ -26,6 +28,8 @@ services:
     volumes:
     - /opt/data:/openedx/data
     - /opt/data/media:/openedx/media
+    - /opt/staticfiles-${ENVIRONMENT_TIER}:/openedx/staticfiles:ro
+    - /opt/staticfiles-${ENVIRONMENT_TIER}/bundles:/openedx/edx-platform/common/static/bundles:ro
 
 # Webapp definitions
   caddy:
@@ -62,6 +66,8 @@ services:
     - /opt/data:/openedx/data
     - /opt/data/media:/openedx/media
     - ./ssh/id_rsa:/openedx/.ssh/id_rsa:ro
+    - /opt/staticfiles-${ENVIRONMENT_TIER}:/openedx/staticfiles:ro
+    - /opt/staticfiles-${ENVIRONMENT_TIER}/bundles:/openedx/edx-platform/common/static/bundles:ro
   cms:
     image: ${DOCKER_REPO_AND_DIGEST}
     profiles:
@@ -79,6 +85,8 @@ services:
     - /opt/data:/openedx/data
     - /opt/data/media:/openedx/media
     - ./ssh/id_rsa:/openedx/.ssh/id_rsa:ro
+    - /opt/staticfiles-${ENVIRONMENT_TIER}:/openedx/staticfiles:ro
+    - /opt/staticfiles-${ENVIRONMENT_TIER}/bundles:/openedx/edx-platform/common/static/bundles:ro
 
 # Worker definitions
   lms-migrations:
@@ -95,6 +103,8 @@ services:
     - ./settings/lms.env.yml:/openedx/config/lms.env.yml:ro
     - /opt/data:/openedx/data
     - /opt/data/media:/openedx/media
+    - /opt/staticfiles-${ENVIRONMENT_TIER}:/openedx/staticfiles:ro
+    - /opt/staticfiles-${ENVIRONMENT_TIER}/bundles:/openedx/edx-platform/common/static/bundles:ro
     command: ["python", "manage.py", "lms", "migrate", "--noinput"]
     depends_on:
       lms-permissions:
@@ -113,6 +123,8 @@ services:
     - ./settings/cms.env.yml:/openedx/config/cms.env.yml:ro
     - /opt/data:/openedx/data
     - /opt/data/media:/openedx/media
+    - /opt/staticfiles-${ENVIRONMENT_TIER}:/openedx/staticfiles:ro
+    - /opt/staticfiles-${ENVIRONMENT_TIER}/bundles:/openedx/edx-platform/common/static/bundles:ro
     command: ["python", "manage.py", "cms", "migrate", "--noinput"]
     depends_on:
       cms-permissions:
@@ -132,6 +144,8 @@ services:
     - ./settings/waffle_flags.yaml:/openedx/config/waffle_flags.yaml:ro
     - /opt/data:/openedx/data
     - /opt/data/media:/openedx/media
+    - /opt/staticfiles-${ENVIRONMENT_TIER}:/openedx/staticfiles:ro
+    - /opt/staticfiles-${ENVIRONMENT_TIER}/bundles:/openedx/edx-platform/common/static/bundles:ro
     command: ["python", "set_waffle_flags.py", "/openedx/config/waffle_flags.yaml"]
     depends_on:
       lms-permissions:
@@ -153,6 +167,8 @@ services:
     - /opt/data:/openedx/data
     - /opt/data/media:/openedx/media
     - ./ssh/id_rsa:/openedx/.ssh/id_rsa:ro
+    - /opt/staticfiles-${ENVIRONMENT_TIER}:/openedx/staticfiles:ro
+    - /opt/staticfiles-${ENVIRONMENT_TIER}/bundles:/openedx/edx-platform/common/static/bundles:ro
     depends_on:
       lms-migrations:
         condition: service_completed_successfully
@@ -171,6 +187,8 @@ services:
     - ./settings/lms.env.yml:/openedx/config/lms.env.yml:ro
     - /opt/data:/openedx/data
     - /opt/data/media:/openedx/media
+    - /opt/staticfiles-${ENVIRONMENT_TIER}:/openedx/staticfiles:ro
+    - /opt/staticfiles-${ENVIRONMENT_TIER}/bundles:/openedx/edx-platform/common/static/bundles:ro
     command: ["python", "process_scheduled_emails.py"]
     depends_on:
       lms-permissions:
@@ -193,6 +211,8 @@ services:
     - /opt/data:/openedx/data
     - /opt/data/media:/openedx/media
     - ./ssh/id_rsa:/openedx/.ssh/id_rsa:ro
+    - /opt/staticfiles-${ENVIRONMENT_TIER}:/openedx/staticfiles:ro
+    - /opt/staticfiles-${ENVIRONMENT_TIER}/bundles:/openedx/edx-platform/common/static/bundles:ro
     depends_on:
       cms-migrations:
         condition: service_completed_successfully

--- a/src/ol_concourse/lib/models/pipeline.py
+++ b/src/ol_concourse/lib/models/pipeline.py
@@ -414,6 +414,12 @@ class PutStep(Step, StepModifierMixin):
             ' create_files:\n      version.txt: "42"\n```'
         ),
     )
+    no_get: Optional[bool] = Field(
+        None,
+        description=(
+            "Skips the get step that usually follows the completion of the put step."
+        ),
+    )
 
 
 class AnonymousResource(BaseModel):
@@ -1841,12 +1847,6 @@ class Job(BaseModel):
         None,
         description=(
             "The name of the job. This should be short; it will show up in URLs."
-        ),
-    )
-    no_get: Optional[bool] = Field(
-        None,
-        description=(
-            "Skips the get step that usually follows the completion of the put step."
         ),
     )
     old_name: Optional[Identifier] = Field(

--- a/src/ol_concourse/lib/resources.py
+++ b/src/ol_concourse/lib/resources.py
@@ -10,7 +10,7 @@ def git_repo(  # noqa: PLR0913
     branch: str = "main",
     check_every: str = "60s",
     paths: Optional[list[str]] = None,
-    depth: Optional[int] = None,  # noqa: ARG001
+    depth: Optional[int] = None,
     **kwargs,
 ) -> Resource:
     return Resource(
@@ -18,7 +18,9 @@ def git_repo(  # noqa: PLR0913
         type="git",
         icon="git",
         check_every=check_every,
-        source=Git(uri=uri, branch=branch, paths=paths).model_dump(exclude_none=True),
+        source=Git(uri=uri, branch=branch, paths=paths, depth=depth).model_dump(
+            exclude_none=True
+        ),
         **kwargs,
     )
 

--- a/src/ol_concourse/pipelines/container_images/dcind.py
+++ b/src/ol_concourse/pipelines/container_images/dcind.py
@@ -1,0 +1,74 @@
+import sys
+
+from ol_concourse.lib.containers import container_build_task
+from ol_concourse.lib.models.pipeline import (
+    GetStep,
+    Identifier,
+    Input,
+    Job,
+    Pipeline,
+    PutStep,
+    Resource,
+)
+from ol_concourse.lib.resources import git_repo, github_release
+
+ol_inf_repo = git_repo(
+    name=Identifier("ol-infrastructure-repository"),
+    uri="https://github.com/mitodl/ol-infrastructure",
+    branch="md/issue_1881",
+    check_every="24h",
+    paths=["dockerfiles/dcind/"],
+)
+
+earthly_release = github_release(
+    name=Identifier("earthly-release-binary"),
+    owner="earthly",
+    repository="earthly",
+    order_by="time",
+)
+
+dcind_release_image = Resource(
+    name=Identifier("dcind-release-resource-image"),
+    type="registry-image",
+    icon="docker",
+    source={
+        "repository": "mitodl/dcind",
+        "tag": "latest",
+        "password": "((dockerhub.password))",
+        "username": "((dockerhub.username))",
+    },
+)
+
+build_task = container_build_task(
+    inputs=[Input(name=ol_inf_repo.name)],
+    build_parameters={"CONTEXT": f"{ol_inf_repo.name}/dockerfiles/dcind"},
+)
+
+docker_pipeline = Pipeline(
+    resources=[ol_inf_repo, earthly_release, dcind_release_image],
+    jobs=[
+        Job(
+            name=Identifier("build-and-publish-container"),
+            plan=[
+                GetStep(get=ol_inf_repo.name, trigger=True),
+                GetStep(get=earthly_release.name, trigger=True),
+                build_task,
+                PutStep(
+                    put=dcind_release_image.name,
+                    params={
+                        "image": "image/image.tar",
+                        "additional_tags": (f"./{earthly_release.name}/version"),
+                    },
+                ),
+            ],
+        )
+    ],
+)
+
+if __name__ == "__main__":
+    with open("definition.json", "w") as definition:  # noqa: PTH123
+        definition.write(docker_pipeline.model_dump_json(indent=2))
+    sys.stdout.write(docker_pipeline.model_dump_json(indent=2))
+    sys.stdout.write(
+        "\nfly -t pr-inf set-pipeline -p dcind-resource-image -c definition.json"
+    )

--- a/src/ol_concourse/pipelines/open_edx/edx_platform_v2/earthly_packer_pulumi_pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/edx_platform_v2/earthly_packer_pulumi_pipeline.py
@@ -1,0 +1,335 @@
+import sys
+
+from bridge.settings.openedx.accessors import (
+    fetch_application_version,
+    filter_deployments_by_release,
+)
+from bridge.settings.openedx.types import (
+    OpenEdxApplication,
+    OpenEdxSupportedRelease,
+)
+
+from ol_concourse.lib.jobs.infrastructure import packer_jobs, pulumi_jobs_chain
+from ol_concourse.lib.models.fragment import PipelineFragment
+from ol_concourse.lib.models.pipeline import (
+    AnonymousResource,
+    Command,
+    GetStep,
+    GroupConfig,
+    Identifier,
+    InParallelStep,
+    Input,
+    Job,
+    Output,
+    Pipeline,
+    Platform,
+    PutStep,
+    TaskConfig,
+    TaskStep,
+)
+from ol_concourse.lib.resources import git_repo, registry_image
+from ol_concourse.pipelines.constants import PULUMI_CODE_PATH, PULUMI_WATCHED_PATHS
+
+
+def build_edx_pipeline(release_names: list[str]) -> Pipeline:  # noqa: ARG001
+    # This resource will be shared by all releases/deployment combinations
+    earthly_git_resource = git_repo(
+        name=Identifier("ol-infrastructure-docker"),
+        uri="https://github.com/mitodl/ol-infrastructure",
+        branch="main",
+        depth=1,
+        check_every="10m",
+        paths=[
+            "dockerfiles/openedx-edxapp/",
+        ],
+    )
+
+    container_fragments = []
+    packer_fragments = []
+    pulumi_fragments = []
+    group_configs = []
+
+    for release_name in releases:
+        job_names = []
+        for deployment in filter_deployments_by_release(release_name):
+            deployment_name = deployment.deployment_name
+
+            # Theme related resource setup
+            theme_git_resources = []
+            theme_get_steps = []
+            theme = fetch_application_version(
+                release_name, deployment_name, OpenEdxApplication.theme
+            )
+            theme_git_resource = git_repo(
+                name=Identifier(f"{release_name}-{deployment_name}-theme"),
+                uri=theme.git_origin,
+                branch=theme.release_branch,
+                check_every="24h",
+            )
+            theme_git_resources.append(theme_git_resource)
+            theme_get_steps.append(GetStep(get=theme_git_resource.name, trigger=True))
+
+            # edx_platform related resource setup
+            edx_platform_git_resources = []
+            edx_platform_get_steps = []
+            edx_platform = fetch_application_version(
+                release_name, deployment_name, OpenEdxApplication.edxapp
+            )
+            edx_platform_git_resource = git_repo(
+                name=Identifier(f"{release_name}-{deployment_name}-edx-platform"),
+                uri=edx_platform.git_origin,
+                branch=edx_platform.release_branch,
+                depth=1,
+                check_every="24h",
+            )
+            edx_platform_git_resources.append(edx_platform_git_resource)
+            edx_platform_get_steps.append(
+                GetStep(get=edx_platform_git_resource.name, trigger=True)
+            )
+
+            # AMI code related resource setup
+            edx_ami_code = git_repo(
+                name=Identifier(
+                    f"edxapp-custom-image-{deployment_name}-{release_name}"
+                ),
+                uri="https://github.com/mitodl/ol-infrastructure",
+                branch="main",
+                depth=1,
+                check_every="10m",
+                paths=[
+                    "src/bridge/settings/openedx/",
+                    "src/bilder/components/",
+                    "src/bilder/images/edxapp_v2/deploy.py",
+                    "src/bilder/images/edxapp_v2/group_data/",
+                    "src/bilder/images/edxapp_v2/files/",
+                    "src/bilder/images/edxapp_v2/templates/vector/",
+                    f"src/bilder/images/edxapp_v2/templates/edxapp/{deployment_name}/",
+                    "src/bilder/images/edxapp_v2/custom_install.pkr.hcl",
+                    f"src/bilder/images/edxapp_v2/packer_vars/{deployment_name}.pkrvars.hcl",
+                    f"src/bilder/images/edxapp_v2/packer_vars/{release_name}.pkrvars.hcl",
+                ],
+            )
+
+            # Pulumi code related resource setup
+            edx_pulumi_code = git_repo(
+                name=Identifier(f"edxapp-ol-infrastructure-pulumi-{deployment_name}"),
+                uri="https://github.com/mitodl/ol-infrastructure",
+                branch="main",
+                depth=1,
+                check_every="10m",
+                paths=[
+                    *PULUMI_WATCHED_PATHS,
+                    "src/ol_infrastructure/applications/edxapp/",
+                    "src/bridge/secrets/edxapp/",
+                    "src/bridge/settings/openedx/",
+                ],
+            )
+
+            # Docker image related resource setup
+            edx_registry_image_resource = registry_image(
+                name=Identifier(f"edxapp-{release_name}-{deployment_name}-image"),
+                image_repository="mitodl/edxapp",
+                image_tag=f"{release_name}-{deployment_name}",
+                username="((dockerhub.username))",
+                password="((dockerhub.password))",  # noqa: S106
+            )
+
+            # Each earthly build requires several inputs, build that list pre-emptively
+            earthly_build_job = Job(
+                name=f"build-{release_name}-{deployment_name}-edxapp-image",
+                build_log_retention={"builds": 10},
+                max_in_flight=1,
+                plan=[
+                    InParallelStep(
+                        in_parallel=theme_get_steps
+                        + edx_platform_get_steps
+                        + [GetStep(get=earthly_git_resource.name, trigger=True)]
+                    ),
+                    TaskStep(
+                        task=Identifier("build"),
+                        privileged=True,
+                        config=TaskConfig(
+                            platform=Platform.linux,
+                            image_resource=AnonymousResource(
+                                type="registry-image",
+                                source={"repository": "mitodl/dcind", "tag": "latest"},
+                            ),
+                            # Use some cleverness with path to mount resources within
+                            # the earthly git resource so code is where the Earthfile
+                            # expects
+                            inputs=[Input(name=earthly_git_resource.name)],
+                            outputs=[Output(name=Identifier("artifacts"))],
+                            run=Command(
+                                path="bash",
+                                args=[
+                                    "-c",
+                                    f"""source /docker-lib.sh;
+                                    start_docker;
+                                    echo "{release_name}-{deployment_name}-$(cat ol-infrastructure-docker/dockerfiles/openedx-edxapp/edx_platform/.git/short_ref)" > artifacts/tag.txt;
+                                    cd {earthly_git_resource.name}/dockerfiles/openedx-edxapp;
+                                    RELEASE_NAME={release_name};
+                                    DEPLOYMENT_NAME={deployment_name};
+                                    EDX_PLATFORM_GIT_REPO="{edx_platform.git_origin}";
+                                    EDX_PLATFORM_GIT_BRANCH="{edx_platform.release_branch}";
+                                    THEME_GIT_REPO="{theme.git_origin}";
+                                    THEME_GIT_BRANCH="{theme.release_branch}";
+                                    earthly +docker-image --DEPLOYMENT_NAME="$DEPLOYMENT_NAME" --RELEASE_NAME="$RELEASE_NAME" --EDX_PLATFORM_GIT_REPO="$EDX_PLATFORM_GIT_REPO" --EDX_PLATFORM_GIT_BRANCH="$EDX_PLATFORM_GIT_BRANCH" --THEME_GIT_REPO="$THEME_GIT_REPO" --THEME_GIT_BRANCH="$THEME_GIT_BRANCH";
+                                    DIGEST=$(docker inspect --format '{{{{.Id}}}}' mitodl/edxapp-$DEPLOYMENT_NAME-$RELEASE_NAME | cut -d ":" -f2);
+                                    echo "Saving docker image to tar file in the artifacts directory";
+                                    docker save -o ../../../artifacts/image.tar $DIGEST;
+                                    cat ~/.earthly/config.yml
+                                    earthly +build-static-assets-nonprod --DEPLOYMENT_NAME="$DEPLOYMENT_NAME" --RELEASE_NAME="$RELEASE_NAME" --EDX_PLATFORM_GIT_REPO="$EDX_PLATFORM_GIT_REPO" --EDX_PLATFORM_GIT_BRANCH="$EDX_PLATFORM_GIT_BRANCH" --THEME_GIT_REPO="$THEME_GIT_REPO" --THEME_GIT_BRANCH="$THEME_GIT_BRANCH";
+                                    earthly +build-static-assets-production --DEPLOYMENT_NAME="$DEPLOYMENT_NAME" --RELEASE_NAME="$RELEASE_NAME" --EDX_PLATFORM_GIT_REPO="$EDX_PLATFORM_GIT_REPO" --EDX_PLATFORM_GIT_BRANCH="$EDX_PLATFORM_GIT_BRANCH" --THEME_GIT_REPO="$THEME_GIT_REPO" --THEME_GIT_BRANCH="$THEME_GIT_BRANCH";
+                                    echo "Copying staticfiles archives to artifacts directory";
+                                    mv static*.tar.gz ../../../artifacts;""",  # noqa: E501
+                                ],
+                            ),
+                        ),
+                    ),
+                    PutStep(
+                        put=edx_registry_image_resource.name,
+                        inputs=[Identifier("artifacts")],
+                        params={
+                            "image": "artifacts/image.tar",
+                            "additional_tags": "artifacts/tag.txt",
+                        },
+                    ),
+                    TaskStep(
+                        task=Identifier("publish-static-files"),
+                        config=TaskConfig(
+                            platform=Platform.linux,
+                            image_resource=AnonymousResource(
+                                type="registry-image",
+                                source={
+                                    "repository": "amazon/aws-cli",
+                                    "tag": "latest",
+                                },
+                            ),
+                            inputs=[
+                                Input(name="artifacts"),
+                                Input(name=edx_registry_image_resource.name),
+                            ],
+                            outputs=[],
+                            run=Command(
+                                path="sh",
+                                args=[
+                                    "-xc",
+                                    f"""RELEASE_NAME={release_name}
+                                    DEPLOYMENT_NAME={deployment_name}
+                                    DIGEST=$(cat {edx_registry_image_resource.name}/digest)
+                                    aws s3 cp artifacts/staticfiles-production.tar.gz s3://ol-eng-artifacts/edx-staticfiles/$DEPLOYMENT_NAME/$RELEASE_NAME/staticfiles-production-$DIGEST.tar.gz
+                                    aws s3 cp artifacts/staticfiles-nonprod.tar.gz s3://ol-eng-artifacts/edx-staticfiles/$DEPLOYMENT_NAME/$RELEASE_NAME/staticfiles-nonprod-$DIGEST.tar.gz""",  # noqa: E501
+                                ],
+                            ),
+                        ),
+                    ),
+                ],
+            )
+
+            job_names.append(earthly_build_job.name)
+
+            container_fragments.append(
+                PipelineFragment(
+                    resources=[
+                        earthly_git_resource,
+                        edx_registry_image_resource,
+                        edx_ami_code,
+                        edx_pulumi_code,
+                        *theme_git_resources,
+                        *edx_platform_git_resources,
+                    ],
+                    jobs=[earthly_build_job],
+                )
+            )
+
+            packer_fragments.append(
+                packer_jobs(
+                    dependencies=[
+                        GetStep(
+                            get=edx_registry_image_resource.name,
+                            trigger=True,
+                            passed=[earthly_build_job.name],
+                        ),
+                    ],
+                    image_code=edx_ami_code,
+                    packer_template_path=(
+                        "src/bilder/images/edxapp_v2/custom_install.pkr.hcl"
+                    ),
+                    node_types=["web", "worker"],
+                    env_vars_from_files={
+                        "DOCKER_REPO_NAME": (
+                            f"{edx_registry_image_resource.name}/repository"
+                        ),
+                        "DOCKER_IMAGE_DIGEST": (
+                            f"{edx_registry_image_resource.name}/digest"
+                        ),
+                    },
+                    packer_vars={"framework": "earthly"},
+                    extra_packer_params={
+                        "only": ["amazon-ebs.edxapp"],
+                        "var_files": [
+                            f"{edx_ami_code.name}/src/bilder/images/edxapp_v2/packer_vars/{release_name}.pkrvars.hcl",
+                            f"{edx_ami_code.name}/src/bilder/images/edxapp_v2/packer_vars/{deployment.deployment_name}.pkrvars.hcl",
+                        ],
+                    },
+                    job_name_suffix=f"{release_name}-{deployment.deployment_name}",
+                )
+            )
+            job_names.append(packer_fragments[-1].jobs[-1].name)
+            job_names.append(packer_fragments[-1].jobs[-2].name)
+
+            pulumi_fragments.append(
+                pulumi_jobs_chain(
+                    edx_pulumi_code,
+                    stack_names=[
+                        f"applications.edxapp.{deployment.deployment_name}.{stage}"
+                        for stage in deployment.envs_by_release(release_name)
+                    ],
+                    project_name=f"ol-infrastructure-edxapp-application.{deployment.deployment_name}",
+                    project_source_path=PULUMI_CODE_PATH.joinpath(
+                        "applications/edxapp",
+                    ),
+                    dependencies=[
+                        GetStep(
+                            get=packer_fragments[-1].resources[-1].name,
+                            trigger=True,
+                            passed=[packer_fragments[-1].jobs[-1].name],
+                        ),
+                    ],
+                )
+            )
+            job_names.extend([job.name for job in pulumi_fragments[-1].jobs])
+
+        combined_fragments = PipelineFragment.combine_fragments(
+            *container_fragments, *packer_fragments, *pulumi_fragments
+        )
+        group_config = GroupConfig(
+            name=f"{release_name}",
+            jobs=job_names,
+        )
+        group_configs.append(group_config)
+    return Pipeline(
+        resource_types=combined_fragments.resource_types,
+        resources=[
+            *combined_fragments.resources,
+        ],
+        jobs=combined_fragments.jobs,
+        groups=group_configs,
+    )
+
+
+if __name__ == "__main__":
+    releases = [release_name.name for release_name in OpenEdxSupportedRelease]
+    pipeline_json = build_edx_pipeline(releases).json(indent=1)
+    with open("definition.json", "w") as definition:  # noqa: PTH123
+        definition.write(pipeline_json)
+    sys.stdout.write(pipeline_json)
+    sys.stdout.writelines(
+        {
+            "\n",
+            (
+                "fly -t pr-inf set-pipeline -p earthly-packer-pulumi-edxapp-global -c"
+                " definition.json"
+            ),
+        }
+    )

--- a/src/ol_concourse/pipelines/open_edx/edx_platform_v2/grouped_docker_packer_pulumi_pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/edx_platform_v2/grouped_docker_packer_pulumi_pipeline.py
@@ -247,7 +247,7 @@ def build_edx_pipeline(release_names: list[str]) -> Pipeline:  # noqa: ARG001
                             f"{edx_registry_image_resource.name}/digest"
                         ),
                     },
-                    packer_vars={"framework": "docker"},
+                    packer_vars={"framework": "earthly"},
                     extra_packer_params={
                         "only": ["amazon-ebs.edxapp"],
                         "var_files": [

--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -1101,6 +1101,10 @@ def cloud_init_user_data_func(
     grafana_credentials = read_yaml_secrets(
         Path(f"vector/grafana.{stack_info.env_suffix}.yaml")
     )
+    # Used to switch which staticfiles collection to used
+    environment_tier = (
+        "production" if stack_info.env_suffix == "production" else "nonprod"
+    )
     cloud_config_content = {
         "write_files": [
             {
@@ -1147,6 +1151,10 @@ def cloud_init_user_data_func(
             {
                 "path": "/etc/default/consul-template",
                 "content": f"ENVIRONMENT={consul_env_name}",
+            },
+            {
+                "path": "/etc/default/environment-tier",
+                "content": f"{environment_tier}",
             },
         ]
     }


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/ol-infrastructure/issues/1881

# Description (What does it do?)
Does several thing:

1. Converts the edxapp docker file into an [Earthfile](https://docs.earthly.dev/). 
2. Uses said Earthfile to produce two produce two new build artifacts in addition to the largely un-altered original docker image.
  a. `staticfiles-nonprod-{docker image digest}.tar.gz`
  b. `staticfiles-production-{docker image digest}.tar.gz`
  c. **All static content is removed from the docker image now.** So there is no default static content shipped with the container.
3. Creates a new build+deploy pipeline, replacing the `docker build` steps with appropriate `earthly build` steps and adding tasks to ship the staticfiles content to s3. 
4. Makes modifications to the AMI build + docker compose configuration to use this new separated static content.
5. Makes modifications to the pulumi stack to populate a new environment var at runtime `ENVIRONMENT_TIER` to help docker-compose select the right staticfiles directory to mount into the container. 

# Remaining Tasks
1. ~Add this docker file to the repo and create a build and publish pipeline for it. This will replace `source={"repository": "ardiea/earthly", "tag": "v0.3"},` currently in use for the earthly build task in the pipeline. We may want to fork the original Dockerfile for this to ensure we're using a more up-to-date base.~
```
FROM --platform=linux/amd64 taylorsilva/dcind:20.10.8-20211022

RUN wget https://github.com/earthly/earthly/releases/download/v0.7.20/earthly-linux-amd64 -O /usr/local/bin/earthly && \
  chmod +x /usr/local/bin/earthly && \
  /usr/local/bin/earthly bootstrap

RUN apk --no-cache add git
```
2. ~Optimizations. I would say there is at least 10 minutes to save inside the build+deploy pipeline. There is a lot of copying stuff that doesn't always need to be copied that can be cleaned up. Additionally, the new docker image is somehow larger than the current one, despite actually containing fewer things. So we should look at that too.~ Shaved about 20 minutes off and several copies.  
3. ~Cleanup the old pipeline and dockerfile definitions. Cleanup in concoruse as well, once this is verified and working as expected.~
  a. Need to update the metapipeline at some point, as well.   
5. ~Look at moving the collecting of resources away from concourse and making it purely an 'earthly concern'. That is, don't spend so much time copying files from the various inputs -> the one place for earthly, just let earthly go get the stuff it needs. Would want a way to pass something like the commit hash from the concourse resource to earthly + have it default to a branch or whatever. This would make it easier to run the build otuside of concourse (which it very much is not easy at the moment earthly or dockerfile).~ 

# How can this be tested?
The build and deployment pipeline exists currently @ https://cicd.odl.mit.edu/teams/infrastructure/pipelines/earthly-packer-pulumi-edxapp-global but use caution unpausing it / the jobs within it as it will fight with the existing pipeline. 

