### PR TITLE
Adding * to allowed CORS headers for OCW.

### DIFF
--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -405,6 +405,13 @@ for purpose in ("draft", "live"):
         headers=[
             fastly.ServiceVclHeaderArgs(
                 action="set",
+                destination="http.Access-Control-Allow-Origin",
+                name="CORS Allow Star",
+                source="*",
+                type="cache",
+            ),
+            fastly.ServiceVclHeaderArgs(
+                action="set",
                 destination="http.Surrogate-Key",
                 name="S3 Cache Surrogate Keys",
                 priority=10,


### PR DESCRIPTION
# What are the relevant tickets?
Slack Discussion: https://mitodl.slack.com/archives/GQ89D0Z5M/p1700599234247129

# Description (What does it do?)
Allows any origin to request OCW content via fastly. 

