### PR TITLE
Keycloak: remove the custom username/password form from the browser flow

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/__main__.py
+++ b/src/ol_infrastructure/substructure/keycloak/__main__.py
@@ -496,7 +496,7 @@ ol_browser_flow_ol_auth_username_password_form = keycloak.authentication.Executi
     "ol-auth-username-password-form",
     realm_id=ol_apps_realm.id,
     parent_flow_alias=ol_browser_flow_forms.alias,
-    authenticator="ol-auth-username-password-form",
+    authenticator="auth-username-password-form",
     requirement="REQUIRED",
     opts=resource_options,
 )


### PR DESCRIPTION
# What are the relevant tickets?
Relates to https://github.com/mitodl/mit-open/issues/91

# Description (What does it do?)
The custom username and password form, which provided templates with a variable indicating which SAML providers a user was not linked with, is no longer needed.  This PR updates the ol-browser flow to use the OOTB username/password form instead of the custom one.
