### PR TITLE
Reconciled all waffle flags for edxapp deployments.

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.CI.yaml
@@ -12,7 +12,7 @@ config:
   - ["learner_home_mfe.enabled", "--create", "--superusers", "--everyone"]
   - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
     "--everyone"]
-  - ["new_core_editors.use_new_problem_editor", "--create", "--superusers"]
+  - ["new_core_editors.use_new_problem_editor", "--create", "--everyone"]
   - ["new_core_editors.use_new_text_editor", "--create", "--superusers", "--everyone"]
   - ["new_core_editors.use_new_video_editor", "--create", "--superusers", "--everyone"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.CI.yaml
@@ -4,8 +4,11 @@ encryptedkey: "AQICAHjs8ajWpT7YRhWXwI//wPkHX53RHlo0DjkgQOwCBTUBwQH3lrWmSrfJ6OGoy
 config:
   aws:region: us-east-1
   consul:address: https://consul-mitx-staging-ci.odl.mit.edu
-  edxapp:additional_waffle_flags:
+  edxapp:waffle_flags:
   - ["discussions.pages_and_resources_mfe", "--create", "--superusers", "--everyone"]
+  - ["grades.enforce_freeze_grade_after_course_end", "--create", "--superusers", "--everyone"]
+  - ["grades.rejected_exam_overrides_grade", "--create", "--superusers", "--everyone"]
+  - ["grades.writable_gradebook", "--create", "--superusers", "--everyone"]
   - ["learner_home_mfe.enabled", "--create", "--superusers", "--everyone"]
   - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
     "--everyone"]
@@ -13,6 +16,7 @@ config:
   - ["new_core_editors.use_new_text_editor", "--create", "--superusers", "--everyone"]
   - ["new_core_editors.use_new_video_editor", "--create", "--superusers", "--everyone"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]
+  - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   edxapp:business_unit: residential-staging
   edxapp:db_password:
     secure: "v1:ZB90id7gJ0z4NB/r:S3dGQ6OhdFOl1VdJ8cMOyLTc1L/T36F3ULUBvwMi5XOpyCbRDSyPhxb1DXZQ75DMS8R54Qa8pYE="

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.Production.yaml
@@ -4,6 +4,21 @@ encryptedkey: AQICAHgQalNS7T35ZlcFdhF0QuKeiJAbXMUbm01pjGwHEsjRCgEgvt/Jaq3CayTQkS
 config:
   aws:region: us-east-1
   consul:address: https://consul-mitx-staging-production.odl.mit.edu
+  edxapp:waffle_flags:
+  - ["course_experience.relative_dates", "--create", "--superusers", "--everyone"]
+  - ["discussions.pages_and_resources_mfe", "--create", "--superusers", "--everyone"]
+  - ["grades.bulk_management", "--create", "--superusers", "--everyone"]
+  - ["grades.enforce_freeze_grade_after_course_end", "--create", "--superusers", "--everyone"]
+  - ["grades.rejected_exam_overrides_grade", "--create", "--superusers", "--everyone"]
+  - ["grades.writable_gradebook", "--create", "--superusers", "--everyone"]
+  - ["learner_home_mfe.enabled", "--create", "--superusers", "--everyone"]
+  - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
+    "--everyone"]
+  - ["new_core_editors.use_new_problem_editor", "--create", "--superusers"]
+  - ["new_core_editors.use_new_text_editor", "--create", "--superusers", "--everyone"]
+  - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]
+  - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
+  - ["studio.library_authoring_mfe", "--create", "--superusers", "--everyone"]
   edxapp:business_unit: residential-staging
   edxapp:db_password:
     secure: v1:ZWtTTF60+1g61/XW:K9osJstG/oeHJvYXOUQS6KSIUuTcQFgR1cjECmosVk7BPLCJMPkzlLviW7swdiUhUIPErfyYNqs=

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.Production.yaml
@@ -14,7 +14,7 @@ config:
   - ["learner_home_mfe.enabled", "--create", "--superusers", "--everyone"]
   - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
     "--everyone"]
-  - ["new_core_editors.use_new_problem_editor", "--create", "--superusers"]
+  - ["new_core_editors.use_new_problem_editor", "--create", "--everyone"]
   - ["new_core_editors.use_new_text_editor", "--create", "--superusers", "--everyone"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.QA.yaml
@@ -14,7 +14,7 @@ config:
   - ["learner_home_mfe.enabled", "--create", "--superusers", "--everyone"]
   - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
     "--everyone"]
-  - ["new_core_editors.use_new_problem_editor", "--create", "--superusers"]
+  - ["new_core_editors.use_new_problem_editor", "--create", "--everyone"]
   - ["new_core_editors.use_new_text_editor", "--create", "--superusers", "--everyone"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.QA.yaml
@@ -4,16 +4,20 @@ encryptedkey: AQICAHijXuVxVlAL6bY9xCOrzO3YYhFlQBPt6jNyJGkhYu+q4QF1vipPwcs5DYUCID
 config:
   aws:region: us-east-1
   consul:address: https://consul-mitx-staging-qa.odl.mit.edu
-  edxapp:additional_waffle_flags:
+  edxapp:waffle_flags:
   - ["course_experience.relative_dates", "--create", "--superusers", "--everyone"]
   - ["discussions.pages_and_resources_mfe", "--create", "--superusers", "--everyone"]
   - ["grades.bulk_management", "--create", "--superusers", "--everyone"]
+  - ["grades.enforce_freeze_grade_after_course_end", "--create", "--superusers", "--everyone"]
+  - ["grades.rejected_exam_overrides_grade", "--create", "--superusers", "--everyone"]
+  - ["grades.writable_gradebook", "--create", "--superusers", "--everyone"]
   - ["learner_home_mfe.enabled", "--create", "--superusers", "--everyone"]
   - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
     "--everyone"]
   - ["new_core_editors.use_new_problem_editor", "--create", "--superusers"]
   - ["new_core_editors.use_new_text_editor", "--create", "--superusers", "--everyone"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]
+  - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["studio.library_authoring_mfe", "--create", "--superusers", "--everyone"]
   edxapp:business_unit: residential-staging
   edxapp:db_password:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.CI.yaml
@@ -12,7 +12,7 @@ config:
   - ["learner_home_mfe.enabled", "--create", "--superusers", "--everyone"]
   - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
     "--everyone"]
-  - ["new_core_editors.use_new_problem_editor", "--create", "--superusers"]
+  - ["new_core_editors.use_new_problem_editor", "--create", "--everyone"]
   - ["new_core_editors.use_new_text_editor", "--create", "--superusers", "--everyone"]
   - ["new_core_editors.use_new_video_editor", "--create", "--superusers", "--everyone"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.CI.yaml
@@ -4,6 +4,20 @@ encryptedkey: AQICAHjs8ajWpT7YRhWXwI//wPkHX53RHlo0DjkgQOwCBTUBwQFx9m+5C+NdLferEI
 config:
   aws:region: us-east-1
   consul:address: https://consul-mitx-ci.odl.mit.edu
+  edxapp:waffle_flags:
+  - ["discussions.pages_and_resources_mfe", "--create", "--superusers", "--everyone"]
+  - ["grades.enforce_freeze_grade_after_course_end", "--create", "--superusers", "--everyone"]
+  - ["grades.rejected_exam_overrides_grade", "--create", "--superusers", "--everyone"]
+  - ["grades.writable_gradebook", "--create", "--superusers", "--everyone"]
+  - ["learner_home_mfe.enabled", "--create", "--superusers", "--everyone"]
+  - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
+    "--everyone"]
+  - ["new_core_editors.use_new_problem_editor", "--create", "--superusers"]
+  - ["new_core_editors.use_new_text_editor", "--create", "--superusers", "--everyone"]
+  - ["new_core_editors.use_new_video_editor", "--create", "--superusers", "--everyone"]
+  - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]
+  - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
+  - ["studio.library_authoring_mfe", "--create", "--superusers", "--everyone"]
   edxapp:business_unit: residential
   edxapp:db_password:
     secure: v1:Q1uI9EWaIrq2z2sY:pTBVK/vatuCQXgO3Z2ItArDb4P1QLpN/lP/jT9690boozaKjjJudoQZOyWjkbCFwGLieh+L9auw=

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.Production.yaml
@@ -15,7 +15,7 @@ config:
   - ["learner_home_mfe.enabled", "--create", "--superusers", "--everyone"]
   - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
     "--everyone"]
-  - ["new_core_editors.use_new_problem_editor", "--create", "--superusers"]
+  - ["new_core_editors.use_new_problem_editor", "--create", "--everyone"]
   - ["new_core_editors.use_new_text_editor", "--create", "--superusers", "--everyone"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.Production.yaml
@@ -4,6 +4,22 @@ encryptedkey: AQICAHgQalNS7T35ZlcFdhF0QuKeiJAbXMUbm01pjGwHEsjRCgFwrf3LY2FAJ/ptzj
 config:
   aws:region: us-east-1
   consul:address: https://consul-mitx-production.odl.mit.edu
+  edxapp:waffle_flags:
+  - ["blockstore.use_blockstore_app_api", "--create", "--superusers", "--everyone"]
+  - ["course_experience.relative_dates", "--create", "--superusers", "--everyone"]
+  - ["discussions.pages_and_resources_mfe", "--create", "--superusers", "--everyone"]
+  - ["grades.bulk_management", "--create", "--superusers", "--everyone"]
+  - ["grades.enforce_freeze_grade_after_course_end", "--create", "--superusers", "--everyone"]
+  - ["grades.rejected_exam_overrides_grade", "--create", "--superusers", "--everyone"]
+  - ["grades.writable_gradebook", "--create", "--superusers", "--everyone"]
+  - ["learner_home_mfe.enabled", "--create", "--superusers", "--everyone"]
+  - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
+    "--everyone"]
+  - ["new_core_editors.use_new_problem_editor", "--create", "--superusers"]
+  - ["new_core_editors.use_new_text_editor", "--create", "--superusers", "--everyone"]
+  - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]
+  - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
+  - ["studio.library_authoring_mfe", "--create", "--superusers", "--everyone"]
   edxapp:business_unit: residential
   edxapp:db_max_storage_gb: "1000"
   edxapp:db_password:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.QA.yaml
@@ -4,16 +4,20 @@ encryptedkey: AQICAHijXuVxVlAL6bY9xCOrzO3YYhFlQBPt6jNyJGkhYu+q4QHu2G/FW4u/U5Mp8a
 config:
   aws:region: us-east-1
   consul:address: https://consul-mitx-qa.odl.mit.edu
-  edxapp:additional_waffle_flags:
+  edxapp:waffle_flags:
   - ["course_experience.relative_dates", "--create", "--superusers", "--everyone"]
   - ["discussions.pages_and_resources_mfe", "--create", "--superusers", "--everyone"]
   - ["grades.bulk_management", "--create", "--superusers", "--everyone", "--staff"]
+  - ["grades.enforce_freeze_grade_after_course_end", "--create", "--superusers", "--everyone"]
+  - ["grades.rejected_exam_overrides_grade", "--create", "--superusers", "--everyone"]
+  - ["grades.writable_gradebook", "--create", "--superusers", "--everyone"]
   - ["learner_home_mfe.enabled", "--create", "--superusers", "--everyone"]
   - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
     "--everyone"]
   - ["new_core_editors.use_new_problem_editor", "--create", "--superusers"]
   - ["new_core_editors.use_new_text_editor", "--create", "--superusers", "--everyone"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]
+  - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["studio.library_authoring_mfe", "--create", "--superusers", "--everyone"]
   edxapp:business_unit: residential
   edxapp:db_password:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.QA.yaml
@@ -14,7 +14,7 @@ config:
   - ["learner_home_mfe.enabled", "--create", "--superusers", "--everyone"]
   - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
     "--everyone"]
-  - ["new_core_editors.use_new_problem_editor", "--create", "--superusers"]
+  - ["new_core_editors.use_new_problem_editor", "--create", "--everyone"]
   - ["new_core_editors.use_new_text_editor", "--create", "--superusers", "--everyone"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
@@ -7,6 +7,17 @@ config:
   consul:http_auth:
     secure: v1:aOXMA7B3yJEu1Csf:rdNjtg5pbPnVrlDdbkAdwAE3Cw2vzAoY0uh/yu/yqgNX/bRySO53cv+LFgYRm26JUu3Eu7/i7qny8Sd5F9DFxOowNCkzUS9YOCuDeA+TnSp9R626c47iMlklo5dNrhGlFw==
   consul:scheme: https
+  edxapp:waffle_flags:
+  - ["course_experience.relative_dates", "--create", "--everyone"]
+  - ["grades.bulk_management", "--create", "--superusers", "--everyone", "--staff"]
+  - ["grades.enforce_freeze_grade_after_course_end", "--create", "--superusers", "--everyone"]
+  - ["grades.rejected_exam_overrides_grade", "--create", "--superusers", "--everyone"]
+  - ["grades.writable_gradebook", "--create", "--superusers", "--everyone"]
+  - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone",
+    "--staff", "--authenticated"]
+  - ["seo.enable_anonymous_courseware_access", "--create", "--superusers", "--staff",
+    "--authenticated"]
+  - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   edxapp:business_unit: mitxonline
   edxapp:db_password:
     secure: v1:Za4LI6RKfAW7jLJh:hlthF86wmGH6VSiBHgehE8mY11hDfOUK/uYZADbodhCVuS8RSXoCoHtrRrBDNMXunQmHLABw4SM=

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
@@ -7,6 +7,20 @@ config:
   consul:http_auth:
     secure: v1:Fa4X7VjchQQhRf6+:LxDvDXBPZUPOgMpcqvo9PxwjMK2lDKrnmJGbaJA7e0i5sVsUyQXTLYpa7lDmC5d1QddyLLkjyQjK5Hi/fEeoJle5986uRKVHXNyjRpcJqx8sN2SbFPHrCDpWQfrsz38=
   consul:scheme: https
+  edxapp:waffle_flags:
+  - ["course_experience.relative_dates", "--create", "--superusers", "--everyone",
+    "--staff", "--authenticated"]
+  - ["discussions.pages_andResources_mfe", "--create", "--superusers", "--staff"]
+  - ["grades.bulk_management", "--create", "--superusers", "--everyone", "--staff",
+    "--authenticated"]
+  - ["grades.enforce_freeze_grade_after_course_end", "--create", "--superusers", "--everyone"]
+  - ["grades.rejected_exam_overrides_grade", "--create", "--superusers", "--everyone"]
+  - ["grades.writable_gradebook", "--create", "--superusers", "--everyone"]
+  - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone",
+    "--staff", "--authenticated"]
+  - ["seo.enable_anonymous_courseware_access", "--create", "--superusers", "--staff",
+    "--authenticated"]
+  - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   edxapp:business_unit: mitxonline
   edxapp:db_password:
     secure: v1:xHUw5WC3aN02zuAj:0BozwDxrtF0OA7wkYuv4R4CCnSHYdgXt+vi6/3eP9zwJgHgQO20+8sQfg7rXPC9SIUobEA==

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
@@ -16,6 +16,7 @@ config:
   - ["grades.enforce_freeze_grade_after_course_end", "--create", "--superusers", "--everyone"]
   - ["grades.rejected_exam_overrides_grade", "--create", "--superusers", "--everyone"]
   - ["grades.writable_gradebook", "--create", "--superusers", "--everyone"]
+  - ["new_core_editors.use_new_problem_editor", "--create", "--everyone"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone",
     "--staff", "--authenticated"]
   - ["seo.enable_anonymous_courseware_access", "--create", "--superusers", "--staff",

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
@@ -10,7 +10,7 @@ config:
   edxapp:waffle_flags:
   - ["course_experience.relative_dates", "--create", "--superusers", "--everyone",
     "--staff", "--authenticated"]
-  - ["discussions.pages_andResources_mfe", "--create", "--superusers", "--staff"]
+  - ["discussions.pages_and_resources_mfe", "--create", "--superusers", "--staff"]
   - ["grades.bulk_management", "--create", "--superusers", "--everyone", "--staff",
     "--authenticated"]
   - ["grades.enforce_freeze_grade_after_course_end", "--create", "--superusers", "--everyone"]

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.CI.yaml
@@ -4,11 +4,14 @@ encryptedkey: AQICAHjs8ajWpT7YRhWXwI//wPkHX53RHlo0DjkgQOwCBTUBwQEGbYgV2EePyiT5w7
 config:
   aws:region: us-east-1
   consul:address: https://consul-xpro-ci.odl.mit.edu
-  edxapp:additional_waffle_flags:
+  edxapp:waffle_flags:
   - ["completion.enable_completion_tracking", "--create", "--superusers", "--everyone"]
   - ["course_experience.relative_dates", "--create", "--superusers", "--everyone"]
   - ["course_home.course_home_mfe_progress_tab", "--create", "--everyone"]
   - ["discussions.pages_and_resources_mfe", "--create", "--superusers", "--everyone"]
+  - ["grades.enforce_freeze_grade_after_course_end", "--create", "--superusers", "--everyone"]
+  - ["grades.rejected_exam_overrides_grade", "--create", "--superusers", "--everyone"]
+  - ["grades.writable_gradebook", "--create", "--superusers", "--everyone"]
   - ["learner_home_mfe.enabled", "--create", "--superusers", "--everyone"]
   - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
     "--everyone"]
@@ -16,6 +19,7 @@ config:
   - ["new_core_editors.use_new_text_editor", "--create", "--superusers"]
   - ["new_core_editors.use_new_video_editor", "--create", "--superusers"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]
+  - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["studio.library_authoring_mfe", "--create", "--superusers", "--everyone"]
   edxapp:business_unit: mitxpro
   edxapp:db_password:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.CI.yaml
@@ -15,7 +15,7 @@ config:
   - ["learner_home_mfe.enabled", "--create", "--superusers", "--everyone"]
   - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
     "--everyone"]
-  - ["new_core_editors.use_new_problem_editor", "--create"]
+  - ["new_core_editors.use_new_problem_editor", "--create", "--everyone"]
   - ["new_core_editors.use_new_text_editor", "--create", "--superusers"]
   - ["new_core_editors.use_new_video_editor", "--create", "--superusers"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.Production.yaml
@@ -10,6 +10,9 @@ config:
   - ["course_home.course_home_mfe_progress_tab", "--create", "--everyone"]
   - ["courseware.courseware_mfe", "--create", "--superusers", "--everyone"]
   - ["discussions.pages_and_resources_mfe", "--create", "--superusers", "--everyone"]
+  - ["grades.enforce_freeze_grade_after_course_end", "--create", "--superusers", "--everyone"]
+  - ["grades.rejected_exam_overrides_grade", "--create", "--superusers", "--everyone"]
+  - ["grades.writable_gradebook", "--create", "--superusers", "--everyone"]
   - ["learner_home_mfe.enabled", "--create", "--superusers", "--everyone"]
   - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
     "--everyone"]
@@ -17,11 +20,8 @@ config:
   - ["new_core_editors.use_new_text_editor", "--create", "--superusers"]
   - ["new_core_editors.use_new_video_editor", "--create", "--superusers"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]
-  - ["studio.library_authoring_mfe", "--create", "--superusers", "--everyone"]
-  - ["grades.enforce_freeze_grade_after_course_end", "--create", "--superusers", "--everyone"]
-  - ["grades.rejected_exam_overrides_grade", "--create", "--superusers", "--everyone"]
-  - ["grades.writable_gradebook", "--create", "--superusers", "--everyone"]
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
+  - ["studio.library_authoring_mfe", "--create", "--superusers", "--everyone"]
   edxapp:business_unit: mitxpro
   edxapp:db_password:
     secure: v1:U83x0i6WAndxuOLK:XsAILALTGbtjCqGJllcqg3EaOM0FF/SNmuiMAK2r3E9X5joW26kjOQzYUcKr0slkHBv8RUEr3xA=

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.Production.yaml
@@ -16,7 +16,7 @@ config:
   - ["learner_home_mfe.enabled", "--create", "--superusers", "--everyone"]
   - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
     "--everyone"]
-  - ["new_core_editors.use_new_problem_editor", "--create"]
+  - ["new_core_editors.use_new_problem_editor", "--create", "--everyone"]
   - ["new_core_editors.use_new_text_editor", "--create", "--superusers"]
   - ["new_core_editors.use_new_video_editor", "--create", "--superusers"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.Production.yaml
@@ -18,6 +18,10 @@ config:
   - ["new_core_editors.use_new_video_editor", "--create", "--superusers"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]
   - ["studio.library_authoring_mfe", "--create", "--superusers", "--everyone"]
+  - ["grades.enforce_freeze_grade_after_course_end", "--create", "--superusers", "--everyone"]
+  - ["grades.rejected_exam_overrides_grade", "--create", "--superusers", "--everyone"]
+  - ["grades.writable_gradebook", "--create", "--superusers", "--everyone"]
+  - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   edxapp:business_unit: mitxpro
   edxapp:db_password:
     secure: v1:U83x0i6WAndxuOLK:XsAILALTGbtjCqGJllcqg3EaOM0FF/SNmuiMAK2r3E9X5joW26kjOQzYUcKr0slkHBv8RUEr3xA=

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.QA.yaml
@@ -4,8 +4,7 @@ encryptedkey: AQICAHijXuVxVlAL6bY9xCOrzO3YYhFlQBPt6jNyJGkhYu+q4QHxoDDVZ4kHnQtnul
 config:
   aws:region: us-east-1
   consul:address: https://consul-xpro-qa.odl.mit.edu
-  edxapp:additional_waffle_flags:
-  - ["completion.enable_completion_tracking", "--create", "--superusers", "--everyone"]
+  edxapp:waffle_flags:
   - ["course_experience.relative_dates", "--create", "--superusers", "--everyone"]
   - ["course_home.course_home_mfe_progress_tab", "--create", "--everyone"]
   - ["courseware.courseware_mfe", "--create", "--superusers", "--everyone"]
@@ -18,6 +17,10 @@ config:
   - ["new_core_editors.use_new_video_editor", "--create", "--superusers"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]
   - ["studio.library_authoring_mfe", "--create", "--superusers", "--everyone"]
+  - ["grades.enforce_freeze_grade_after_course_end", "--create", "--superusers", "--everyone"]
+  - ["grades.rejected_exam_overrides_grade", "--create", "--superusers", "--everyone"]
+  - ["grades.writable_gradebook", "--create", "--superusers", "--everyone"]
+  - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   edxapp:business_unit: mitxpro
   edxapp:db_password:
     secure: v1:+Bcw4dSZUPqWY2cL:g/KKgzrmRlgx2SOuOOB4grCveVaNv5mZVuuFrpGgAGwKEussIqUWTBnFJknEdJ4Hjf5Jw/1W560=

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.QA.yaml
@@ -16,7 +16,7 @@ config:
   - ["learner_home_mfe.enabled", "--create", "--superusers", "--everyone"]
   - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
     "--everyone"]
-  - ["new_core_editors.use_new_problem_editor", "--create"]
+  - ["new_core_editors.use_new_problem_editor", "--create", "--everyone"]
   - ["new_core_editors.use_new_text_editor", "--create", "--superusers"]
   - ["new_core_editors.use_new_video_editor", "--create", "--superusers"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.QA.yaml
@@ -5,10 +5,14 @@ config:
   aws:region: us-east-1
   consul:address: https://consul-xpro-qa.odl.mit.edu
   edxapp:waffle_flags:
+  - ["completion.enable_completion_tracking", "--create", "--superusers", "--everyone"]
   - ["course_experience.relative_dates", "--create", "--superusers", "--everyone"]
   - ["course_home.course_home_mfe_progress_tab", "--create", "--everyone"]
   - ["courseware.courseware_mfe", "--create", "--superusers", "--everyone"]
   - ["discussions.pages_and_resources_mfe", "--create", "--superusers", "--everyone"]
+  - ["grades.enforce_freeze_grade_after_course_end", "--create", "--superusers", "--everyone"]
+  - ["grades.rejected_exam_overrides_grade", "--create", "--superusers", "--everyone"]
+  - ["grades.writable_gradebook", "--create", "--superusers", "--everyone"]
   - ["learner_home_mfe.enabled", "--create", "--superusers", "--everyone"]
   - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
     "--everyone"]
@@ -16,11 +20,8 @@ config:
   - ["new_core_editors.use_new_text_editor", "--create", "--superusers"]
   - ["new_core_editors.use_new_video_editor", "--create", "--superusers"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]
-  - ["studio.library_authoring_mfe", "--create", "--superusers", "--everyone"]
-  - ["grades.enforce_freeze_grade_after_course_end", "--create", "--superusers", "--everyone"]
-  - ["grades.rejected_exam_overrides_grade", "--create", "--superusers", "--everyone"]
-  - ["grades.writable_gradebook", "--create", "--superusers", "--everyone"]
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
+  - ["studio.library_authoring_mfe", "--create", "--superusers", "--everyone"]
   edxapp:business_unit: mitxpro
   edxapp:db_password:
     secure: v1:+Bcw4dSZUPqWY2cL:g/KKgzrmRlgx2SOuOOB4grCveVaNv5mZVuuFrpGgAGwKEussIqUWTBnFJknEdJ4Hjf5Jw/1W560=

--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -888,21 +888,8 @@ edxapp_ses_event_destintations = ses.EventDestination(
 ######################
 # Build waffle flags
 ######################
-default_waffle_list = [
-    [
-        "grades.enforce_freeze_grade_after_course_end",
-        "--create",
-        "--superusers",
-        "--everyone",
-    ],
-    ["grades.rejected_exam_overrides_grade", "--create", "--superusers", "--everyone"],
-    ["grades.writable_gradebook", "--create", "--superusers", "--everyone"],
-    ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"],
-]
-additional_waffle_list = edxapp_config.get_object("additional_waffle_flags", default=[])
-waffle_flags_yaml_content = yaml.safe_dump(
-    {"waffles": default_waffle_list + additional_waffle_list}
-)
+waffle_list = edxapp_config.get_object("waffle_flags", default=[])
+waffle_flags_yaml_content = yaml.safe_dump({"waffles": waffle_list})
 
 ######################
 # Manage Consul Data #


### PR DESCRIPTION
# What are the relevant tickets?
Closes #1935 

# Description (What does it do?)
This will set up the consul keys for managing waffle flags in our edxapp environments. Once these keys are in place, an automated process at the startup of any new web instance of edxapp will run a script that sets the flags as specified in this config. 

Additionally, I got rid of the idea of 'additional tags' and 'default tags'. It made the reconciliation process to unwieldy and difficult. Now there is just the one set of tags for any environment found in the config file. No secret defaults hiding in the python code. 

# How can this be tested?
Should be carefully verified vs existing flags. 

# Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
## Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
