### PR TITLE
Fix: Roll mitx and mitx staging QA to Quince

### DIFF
--- a/src/bridge/settings/openedx/version_matrix.py
+++ b/src/bridge/settings/openedx/version_matrix.py
@@ -14,7 +14,7 @@ class OpenLearningOpenEdxDeployment(Enum):
         deployment_name="mitx",
         env_release_map=[
             EnvRelease("CI", OpenEdxSupportedRelease["quince"]),
-            EnvRelease("QA", OpenEdxSupportedRelease["palm"]),
+            EnvRelease("QA", OpenEdxSupportedRelease["quince"]),
             EnvRelease("Production", OpenEdxSupportedRelease["palm"]),
         ],
     )
@@ -22,7 +22,7 @@ class OpenLearningOpenEdxDeployment(Enum):
         deployment_name="mitx-staging",
         env_release_map=[
             EnvRelease("CI", OpenEdxSupportedRelease["quince"]),
-            EnvRelease("QA", OpenEdxSupportedRelease["palm"]),
+            EnvRelease("QA", OpenEdxSupportedRelease["quince"]),
             EnvRelease("Production", OpenEdxSupportedRelease["palm"]),
         ],
     )


### PR DESCRIPTION
# Description (What does it do?)

Bump MITx and MITx staging QA to OpenEdX Quince

# How can this be tested?

Appropriate pipeline should trigger
