### PR TITLE
Follow instructions printed by a ruff format fail

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,6 @@ select = [
     "ICN",  # flake8-import-conventions
     "INP",  # flake8-no-pep420
     "INT",  # flake8-gettext
-    "ISC",  # flake8-implicit-str-concat
     "N",  # pep8-naming
     # "NPY",  # NumPy-specific rules
     # "PD",  # pandas-vet


### PR DESCRIPTION
# Description (What does it do?)
<!--- Describe your changes in detail -->

Trying to run ruff format on some changes to ocw_studio, I get:

```
# cpatti @ rocinante in ~/src/mit/ol-infrastructure/src/ol_infrastructure/applications/ocw_studio on git:cpatti_ocw_test_pipeline x [17:59:24]
$ pr ruff format __main__.py
warning: Selection `CPY` has no effect because the `--preview` flag was not included.
warning: Selection `CPY` has no effect because the `--preview` flag was not included.
warning: The following rules may cause conflicts when used with the formatter: `ISC001`. To avoid unexpected behavior, we recommend disabling these rules, either by removing them from the `select` or `extend-select` configuration, or adding them to the `ignore` configuration.
1 file left unchanged
```

I don't personally feel like single line string concatenation is the biggest problem we need to watch out for, so I'm willing to go with what ruff wants and remove it.