### PR TITLE
Add keycloak ratelimit though traefik

### DIFF
--- a/src/bilder/images/keycloak/files/docker-compose.yaml
+++ b/src/bilder/images/keycloak/files/docker-compose.yaml
@@ -23,6 +23,8 @@ services:
     image: traefik:v2.10
     command:
     - "--configFile=/etc/traefik/traefik.yaml"
+    labels:
+    - "traefik.http.middlewares.keycloak-ratelimit.ratelimit.average=10"
     ports:
     - "80:80"
     - "443:443"


### PR DESCRIPTION
# Description (What does it do?)
<!--- Describe your changes in detail -->
Our Open login form allows one to type a username and prior to typing a password, routes a user to the identity provider. This presents a risk of automated user enumeration. Keycloak does have mitigation strategies, however those only apply after a user tries to authenticate and thus don't work in this particular case. This PR adds a rate limit at the traefik layer to only allow 10 requests/second. There are additional settings that can be [leveraged](https://doc.traefik.io/traefik/middlewares/http/ratelimit/) but this should be a good start.

# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Deploy to CI and test exceeding the rate limit.
