### PR TITLE
config: set Zendesk contact URLs for MIT xPRO and MITx Online

### DIFF
--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -362,6 +362,7 @@ MKTG_URL_OVERRIDES:
     ABOUT: https://{{ key "edxapp/marketing-domain" }}/about-us/
     HONOR: https://{{ key "edxapp/marketing-domain" }}/honor-code/
     ACCESSIBILITY: https://accessibility.mit.edu/
+    CONTACT: https://mitxonline.zendesk.com/hc/en-us/requests/new/
     TOS_AND_HONOR: ''
 MOBILE_STORE_URLS: {}
 ########################################################################################

--- a/src/bilder/images/edxapp_v2/templates/edxapp/xpro/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/xpro/common_values.yml.tmpl
@@ -387,6 +387,7 @@ MKTG_URL_OVERRIDES:
     ABOUT: https://{{ key "edxapp/marketing-domain" }}/about-us/
     HONOR: https://{{ key "edxapp/marketing-domain" }}/honor-code/
     ACCESSIBILITY: https://accessibility.mit.edu/
+    CONTACT: https://xpro.zendesk.com/hc/en-us/requests/new/
     TOS_AND_HONOR: ''
 MOBILE_STORE_URLS: {}
 ########################################################################################


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/hq/issues/3094 & there is no ticket for MITx Online

# Description (What does it do?)
- Sets the Zendesk new request URL as a contact URL for both xPRO and MITxOnline

# Why add this setting?

When a Marketing site is enabled for an edX instance, The platform uses `MKTG_URLS` dictionary to get the helpful links so that they can point to marketing sites. There are more details on https://github.com/openedx/edx-platform/wiki/Alternate-site-for-marketing-links.

In the case of the `CONTACT` link, it is also picked from `MKTG_URLS` so I created this PR to override the contact value.

# Screenshots (if appropriate):
None

# How can this be tested?
Once deployed, The `Contact Us` links in the 404 and other pages should take the users to our app's new request Zendesk page
