### PR TITLE
Managing the tika/access-token value in vault

### DIFF
--- a/src/ol_infrastructure/applications/tika/__main__.py
+++ b/src/ol_infrastructure/applications/tika/__main__.py
@@ -173,6 +173,13 @@ x_access_token = read_yaml_secrets(Path(f"tika/tika.{stack_info.env_suffix}.yaml
     "x_access_token"
 ]
 
+# Store the access token in vault
+vault.generic.Secret(
+    "tika-server-x-access-token-vault-secret",
+    path="secret-operations/tika/access-token",
+    data_json=f'{{"value": "{x_access_token}"}}',
+)
+
 block_device_mappings = [BlockDeviceMapping()]
 tag_specs = [
     TagSpecification(

--- a/src/ol_infrastructure/applications/tika/__main__.py
+++ b/src/ol_infrastructure/applications/tika/__main__.py
@@ -177,7 +177,7 @@ x_access_token = read_yaml_secrets(Path(f"tika/tika.{stack_info.env_suffix}.yaml
 vault.generic.Secret(
     "tika-server-x-access-token-vault-secret",
     path="secret-operations/tika/access-token",
-    data_json=f'{{"value": "{x_access_token}"}}',
+    data_json=json.dumps({"value": x_access_token}),
 )
 
 block_device_mappings = [BlockDeviceMapping()]


### PR DESCRIPTION
# What are the relevant tickets?
Addresses an issue reported in slack with MITOpen

# Description (What does it do?)
This will manage the tika access-token in vault automatically. Previously it was manually configured. 
