### PR TITLE
fix: fix learning mfe base url

### DIFF
--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -66,7 +66,11 @@ class OpenEdxVars(BaseModel):
 def mfe_params(
     open_edx: OpenEdxVars, mfe: OpenEdxApplicationVersion
 ) -> dict[str, Optional[str]]:
-    mfe_base_url = f"https://{open_edx.lms_domain}" if mfe.application.path != "learn" else f"https://{open_edx.lms_domain}/learn"
+
+    mfe_base_url = f"https://{open_edx.lms_domain}"
+    if mfe.application.path == "learn":
+        mfe_base_url = f"https://{open_edx.lms_domain}/learn"
+
     return {
         "ABOUT_US_URL": open_edx.about_us_url,
         "ACCESSIBILITY_URL": open_edx.accessibility_url,

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -66,11 +66,6 @@ class OpenEdxVars(BaseModel):
 def mfe_params(
     open_edx: OpenEdxVars, mfe: OpenEdxApplicationVersion
 ) -> dict[str, Optional[str]]:
-
-    mfe_base_url = f"https://{open_edx.lms_domain}"
-    if mfe.application.path == "learn":
-        mfe_base_url = f"https://{open_edx.lms_domain}/learn"
-
     return {
         "ABOUT_US_URL": open_edx.about_us_url,
         "ACCESSIBILITY_URL": open_edx.accessibility_url,
@@ -78,7 +73,7 @@ def mfe_params(
             f"{open_edx.environment}-edx-jwt-cookie-header-payload"
         ),
         "ACCOUNT_SETTINGS_URL": open_edx.account_settings_url,
-        "BASE_URL": mfe_base_url,
+        "BASE_URL": f"https://{open_edx.lms_domain}/{mfe.application.path}",
         "CONTACT_URL": open_edx.contact_url,
         "CSRF_TOKEN_API_PATH": "/csrf/api/v1/token",
         "DISPLAY_FEEDBACK_WIDGET": open_edx.display_feedback_widget,

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -66,6 +66,7 @@ class OpenEdxVars(BaseModel):
 def mfe_params(
     open_edx: OpenEdxVars, mfe: OpenEdxApplicationVersion
 ) -> dict[str, Optional[str]]:
+    mfe_base_url = f"https://{open_edx.lms_domain}" if mfe.application.path != "learn" else f"https://{open_edx.lms_domain}/learn"
     return {
         "ABOUT_US_URL": open_edx.about_us_url,
         "ACCESSIBILITY_URL": open_edx.accessibility_url,
@@ -73,7 +74,7 @@ def mfe_params(
             f"{open_edx.environment}-edx-jwt-cookie-header-payload"
         ),
         "ACCOUNT_SETTINGS_URL": open_edx.account_settings_url,
-        "BASE_URL": f"https://{open_edx.lms_domain}",
+        "BASE_URL": mfe_base_url,
         "CONTACT_URL": open_edx.contact_url,
         "CSRF_TOKEN_API_PATH": "/csrf/api/v1/token",
         "DISPLAY_FEEDBACK_WIDGET": open_edx.display_feedback_widget,


### PR DESCRIPTION
# What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes https://github.com/mitodl/hq/issues/3087

# Description (What does it do?)
<!--- Describe your changes in detail -->
Updates the BASE_URL environment config for the learning MFE as we serve the learning MFE at `/learn`


# How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Can be tested by accessing the CSS file that's been causing the issue? https://courses-rc.xpro.mit.edu/learn/static/LmsHtmlFragment.css

