### PR TITLE
Fix: Bump memory sizes on redis cache for mitx and mitxonline production

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.Production.yaml
@@ -40,5 +40,6 @@ config:
   edxapp:worker_instance_type: "c6a.large"
   edxapp:framework: "docker"
   mongodb:atlas_project_id: 61b728704656cb4747e589a0
+  redis:instance_type: cache.r6g.2xlarge
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
@@ -35,6 +35,6 @@ config:
   edxapp:worker_node_capacity: "5"
   edxapp:worker_instance_type: "c6a.large"
   mongodb:atlas_project_id: 61f0a63f8bc1f86a073a7148
-  redis:instance_type: cache.r6g.xlarge
+  redis:instance_type: cache.r6g.2xlarge
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production


### PR DESCRIPTION
# What are the relevant tickets?

https://opsg.in/a/i/mitodl/099f1d0e-f165-461e-8bf2-a8245625fbc0-1702920017120


# Description (What does it do?)
Doubles memory size for mitx and mitxonline production redis cache.

