### PR TITLE
fix: Bump write latency alert to 50ms to help curb frequent alarms

### DIFF
--- a/src/ol_infrastructure/components/aws/database.py
+++ b/src/ol_infrastructure/components/aws/database.py
@@ -296,7 +296,7 @@ class OLAmazonDB(pulumi.ComponentResource):
                 "period": 300,  # 5 minutes
                 "evaluation_periods": 6,  # 30 minutes
                 "metric_name": "WriteLatency",
-                "threshold": 0.020,  # 20 milliseconds
+                "threshold": 0.050,  # 20 milliseconds
             },
             "ReadLatency": {
                 "comparison_operator": "GreaterThanThreshold",

--- a/src/ol_infrastructure/components/aws/database.py
+++ b/src/ol_infrastructure/components/aws/database.py
@@ -296,7 +296,7 @@ class OLAmazonDB(pulumi.ComponentResource):
                 "period": 300,  # 5 minutes
                 "evaluation_periods": 6,  # 30 minutes
                 "metric_name": "WriteLatency",
-                "threshold": 0.050,  # 20 milliseconds
+                "threshold": 0.050,  # 50 milliseconds
             },
             "ReadLatency": {
                 "comparison_operator": "GreaterThanThreshold",


### PR DESCRIPTION
# What are the relevant tickets?

https://opsg.in/a/i/mitodl/67856f2c-cbea-4955-8dd6-818299b28134-1702931508799


# Description (What does it do?)

Increases WriteLatency threshold to 50ms. 20ms is very agressive and likely to cause unhelpful alerts.
