### PR TITLE
Change Keycloak domains to be rooted at ol.mit.edu

### DIFF
--- a/src/ol_infrastructure/applications/keycloak/Pulumi.applications.keycloak.CI.yaml
+++ b/src/ol_infrastructure/applications/keycloak/Pulumi.applications.keycloak.CI.yaml
@@ -9,7 +9,7 @@ config:
     max: 3
     min: 1
   keycloak:db_capacity: "50"
-  keycloak:domain: sso-ci.odl.mit.edu
+  keycloak:domain: sso-ci.ol.mit.edu
   keycloak:rds_password:
     secure: v1:PUfBZ4RNoYON7yXj:31owK3ufKfYy24UFKh4pqIGn0ziPM/jpVIuCnMio9xHL5XaBv/02UmpgYe35GgYuiVoOwTfVamP0a+Lb+cLbbNrmRkBfDSoUEKMjFRwe2ps=
   keycloak:target_vpc: operations_vpc

--- a/src/ol_infrastructure/applications/keycloak/Pulumi.applications.keycloak.Production.yaml
+++ b/src/ol_infrastructure/applications/keycloak/Pulumi.applications.keycloak.Production.yaml
@@ -9,7 +9,7 @@ config:
     max: 3
     min: 1
   keycloak:db_capacity: "100"
-  keycloak:domain: sso.odl.mit.edu
+  keycloak:domain: sso.ol.mit.edu
   keycloak:rds_password:
     secure: v1:Mm/fdzMRwsMVpw69:MX1c8FwEDhUeFDg5yImmYhxDrl3gi1PK9pZTbStEXiVpRWEGS3gwGELy+Ut33JpVVwvbTaY2l9A=
   keycloak:target_vpc: operations_vpc

--- a/src/ol_infrastructure/applications/keycloak/Pulumi.applications.keycloak.QA.yaml
+++ b/src/ol_infrastructure/applications/keycloak/Pulumi.applications.keycloak.QA.yaml
@@ -9,7 +9,7 @@ config:
     max: 3
     min: 1
   keycloak:db_capacity: "50"
-  keycloak:domain: sso-qa.odl.mit.edu
+  keycloak:domain: sso-qa.ol.mit.edu
   keycloak:rds_password:
     secure: v1:YMizvIx441k8sgrg:bS5HC/DC3vM8GkwzwTXuBPd9A4xznaxN5GjSF3IdSnJ99D1gOI3M4JevsdJTR2ZGdLwnOy0OULBGuPpxy6bsrOsMXZCEqeVEBlu0VAuhibo=
   keycloak:target_vpc: operations_vpc

--- a/src/ol_infrastructure/applications/keycloak/__main__.py
+++ b/src/ol_infrastructure/applications/keycloak/__main__.py
@@ -65,7 +65,7 @@ target_vpc_id = target_vpc["id"]
 
 data_vpc = network_stack.require_output("data_vpc")
 
-mitodl_zone_id = dns_stack.require_output("odl_zone_id")
+mitol_zone_id = dns_stack.require_output("ol")["id"]
 
 # TODO MD 20230206  # noqa: FIX002, TD002, TD003, TD004
 # This might be needed in the future but right now it just causes errors
@@ -469,7 +469,7 @@ route53.Record(
     type="CNAME",
     ttl=five_minutes,
     records=[autoscale_setup.load_balancer.dns_name],
-    zone_id=mitodl_zone_id,
+    zone_id=mitol_zone_id,
 )
 
 # TODO MD 20230206 revisit this, probably need to export more things  # noqa: E501, FIX002, TD002, TD003, TD004


### PR DESCRIPTION
# What are the relevant tickets?
N/A

# Description (What does it do?)
The odl subdomain doesn't have any real bearing on the current organization. The ol subdomain is what we want to use for exposing services to end users.
