### PR TITLE
Create new S3 buckets for OCW Pipeline End to End Test

### DIFF
--- a/src/ol_infrastructure/applications/ocw_site/Pulumi.applications.ocw_site.Production.yaml
+++ b/src/ol_infrastructure/applications/ocw_site/Pulumi.applications.ocw_site.Production.yaml
@@ -11,3 +11,5 @@ config:
     - ocw.mit.edu
     - www.ocw.mit.edu
     - ocw-preview.odl.mit.edu
+    test:
+    - test.ocw.mit.edu

--- a/src/ol_infrastructure/applications/ocw_site/Pulumi.applications.ocw_site.QA.yaml
+++ b/src/ol_infrastructure/applications/ocw_site/Pulumi.applications.ocw_site.QA.yaml
@@ -9,3 +9,5 @@ config:
     live:
     - live-qa.ocw.mit.edu
     - ocwnext-rc.odl.mit.edu
+    test:
+    - test-qa.ocw.mit.edu

--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -175,11 +175,10 @@ s3.BucketPolicy(
             "Statement": [
                 {
                     "Effect": "Allow",
-                    "Principal": {"AWS": "*"},
+                    "Principal": "*",
                     "Action": "s3:GetObject",
                     "Resource": [
-                        f"arn:aws:s3:::{test_bucket_name}/images/*",
-                        f"arn:aws:s3:::{test_bucket_name}/resumes/*",
+                        f"{test_bucket_arn}/*",
                     ],
                 }
             ],

--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -122,11 +122,10 @@ s3.BucketPolicy(
             "Statement": [
                 {
                     "Effect": "Allow",
-                    "Principal": {"AWS": "*"},
+                    "Principal": "*",
                     "Action": "s3:GetObject",
                     "Resource": [
-                        f"arn:aws:s3:::{draft_bucket_name}/images/*",
-                        f"arn:aws:s3:::{draft_bucket_name}/resumes/*",
+                        f"{draft_bucket_arn}/*",
                     ],
                 }
             ],

--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -197,28 +197,28 @@ draft_backup_bucket = s3.BucketV2(
     tags=aws_config.tags,
 )
 draft_backup_bucket_ownership_controls = s3.BucketOwnershipControls(
-    "ol-draft_backup-bucket-ownership-controls",
+    "ol-draft-backup-bucket-ownership-controls",
     bucket=draft_backup_bucket.id,
     rule=s3.BucketOwnershipControlsRuleArgs(
         object_ownership="BucketOwnerPreferred",
     ),
 )
 s3.BucketVersioningV2(
-    "ol-draft_backup-bucket-versioning",
+    "ol-draft-backup-bucket-versioning",
     bucket=draft_backup_bucket.id,
     versioning_configuration=s3.BucketVersioningV2VersioningConfigurationArgs(
         status="Enabled"
     ),
 )
 draft_backup_bucket_public_access = s3.BucketPublicAccessBlock(
-    "ol-draft_backup-bucket-public-access",
+    "ol-draft-backup-bucket-public-access",
     bucket=draft_backup_bucket.id,
     block_public_acls=False,
     block_public_policy=False,
     ignore_public_acls=False,
 )
 s3.BucketPolicy(
-    "ol-draft_backup-bucket-policy",
+    "ol-draft-backup-bucket-policy",
     bucket=draft_backup_bucket.id,
     policy=json.dumps(
         {
@@ -251,28 +251,28 @@ live_backup_bucket = s3.BucketV2(
     tags=aws_config.tags,
 )
 live_backup_bucket_ownership_controls = s3.BucketOwnershipControls(
-    "ol-live_backup-bucket-ownership-controls",
+    "ol-live-backup-bucket-ownership-controls",
     bucket=live_backup_bucket.id,
     rule=s3.BucketOwnershipControlsRuleArgs(
         object_ownership="BucketOwnerPreferred",
     ),
 )
 s3.BucketVersioningV2(
-    "ol-live_backup-bucket-versioning",
+    "ol-live-backup-bucket-versioning",
     bucket=live_backup_bucket.id,
     versioning_configuration=s3.BucketVersioningV2VersioningConfigurationArgs(
         status="Enabled"
     ),
 )
 live_backup_bucket_public_access = s3.BucketPublicAccessBlock(
-    "ol-live_backup-bucket-public-access",
+    "ol-live-backup-bucket-public-access",
     bucket=live_backup_bucket.id,
     block_public_acls=False,
     block_public_policy=False,
     ignore_public_acls=False,
 )
 s3.BucketPolicy(
-    "ol-live_backup-bucket-policy",
+    "ol-live-backup-bucket-policy",
     bucket=live_backup_bucket.id,
     policy=json.dumps(
         {
@@ -305,28 +305,28 @@ draft_offline_bucket = s3.BucketV2(
     tags=aws_config.tags,
 )
 draft_offline_bucket_ownership_controls = s3.BucketOwnershipControls(
-    "ol-draft_backup-bucket-ownership-controls",
+    "ol-offline-backup-bucket-ownership-controls",
     bucket=draft_offline_bucket.id,
     rule=s3.BucketOwnershipControlsRuleArgs(
         object_ownership="BucketOwnerPreferred",
     ),
 )
 s3.BucketVersioningV2(
-    "ol-draft_backup-bucket-versioning",
+    "ol-offline-backup-bucket-versioning",
     bucket=draft_offline_bucket.id,
     versioning_configuration=s3.BucketVersioningV2VersioningConfigurationArgs(
         status="Enabled"
     ),
 )
 draft_offline_bucket_public_access = s3.BucketPublicAccessBlock(
-    "ol-draft_backup-bucket-public-access",
+    "ol-offline-backup-bucket-public-access",
     bucket=draft_offline_bucket.id,
     block_public_acls=False,
     block_public_policy=False,
     ignore_public_acls=False,
 )
 s3.BucketPolicy(
-    "ol-draft_backup-bucket-policy",
+    "ol-offline-backup-bucket-policy",
     bucket=draft_offline_bucket.id,
     policy=json.dumps(
         {
@@ -359,28 +359,28 @@ live_offline_bucket = s3.BucketV2(
     tags=aws_config.tags,
 )
 live_offline_bucket_ownership_controls = s3.BucketOwnershipControls(
-    "ol-live_backup-bucket-ownership-controls",
+    "ol-live-offline-bucket-ownership-controls",
     bucket=live_offline_bucket.id,
     rule=s3.BucketOwnershipControlsRuleArgs(
         object_ownership="BucketOwnerPreferred",
     ),
 )
 s3.BucketVersioningV2(
-    "ol-live_backup-bucket-versioning",
+    "ol-live-offline-bucket-versioning",
     bucket=live_offline_bucket.id,
     versioning_configuration=s3.BucketVersioningV2VersioningConfigurationArgs(
         status="Enabled"
     ),
 )
 live_offline_bucket_public_access = s3.BucketPublicAccessBlock(
-    "ol-live_backup-bucket-public-access",
+    "ol-live-offline-bucket-public-access",
     bucket=live_offline_bucket.id,
     block_public_acls=False,
     block_public_policy=False,
     ignore_public_acls=False,
 )
 s3.BucketPolicy(
-    "ol-live_backup-bucket-policy",
+    "ol-live-offline-bucket-policy",
     bucket=live_offline_bucket.id,
     policy=json.dumps(
         {

--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -323,11 +323,10 @@ s3.BucketPolicy(
             "Statement": [
                 {
                     "Effect": "Allow",
-                    "Principal": {"AWS": "*"},
+                    "Principal": "*",
                     "Action": "s3:GetObject",
                     "Resource": [
-                        f"arn:aws:s3:::{draft_backup_bucket_name}/images/*",
-                        f"arn:aws:s3:::{draft_backup_bucket_name}/resumes/*",
+                        f"{draft_backup_bucket_arn}/*",
                     ],
                 }
             ],

--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -228,11 +228,10 @@ s3.BucketPolicy(
             "Statement": [
                 {
                     "Effect": "Allow",
-                    "Principal": {"AWS": "*"},
+                    "Principal": "*",
                     "Action": "s3:GetObject",
                     "Resource": [
-                        f"arn:aws:s3:::{live_bucket_name}/images/*",
-                        f"arn:aws:s3:::{live_bucket_name}/resumes/*",
+                        f"{live_bucket_arn}/*",
                     ],
                 }
             ],

--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -106,6 +106,28 @@ s3.BucketVersioningV2(
         status="Enabled"
     ),
 )
+
+draft_bucket_cors = s3.BucketCorsConfigurationV2(
+    "ol-draft-bucket-cors",
+    bucket=draft_bucket_name,
+    cors_rules=[
+        s3.BucketCorsConfigurationV2CorsRuleArgs(
+            allowed_methods=["GET", "HEAD"],
+            allowed_origins=["*"],
+        )
+    ],
+)
+draft_bucket_website = s3.BucketWebsiteConfigurationV2(
+    "draft_website",
+    bucket=draft_bucket_name,
+    index_document=s3.BucketWebsiteConfigurationV2IndexDocumentArgs(
+        suffix="index.html",
+    ),
+    error_document=s3.BucketWebsiteConfigurationV2ErrorDocumentArgs(
+        key="error.html",
+    ),
+)
+
 draft_bucket_public_access = s3.BucketPublicAccessBlock(
     "ol-draft-bucket-public-access",
     bucket=draft_bucket.id,
@@ -118,9 +140,10 @@ s3.BucketPolicy(
     bucket=draft_bucket.id,
     policy=json.dumps(
         {
-            "Version": IAM_POLICY_VERSION,
+            "Version": "2012-10-17",
             "Statement": [
                 {
+                    "Sid": "PublicRead",
                     "Effect": "Allow",
                     "Principal": "*",
                     "Action": "s3:GetObject",

--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -386,11 +386,10 @@ s3.BucketPolicy(
             "Statement": [
                 {
                     "Effect": "Allow",
-                    "Principal": {"AWS": "*"},
+                    "Principal": "*",
                     "Action": "s3:GetObject",
                     "Resource": [
-                        f"arn:aws:s3:::{live_backup_bucket_name}/images/*",
-                        f"arn:aws:s3:::{live_backup_bucket_name}/resumes/*",
+                        f"{live_backup_bucket_arn}/*",
                     ],
                 }
             ],

--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -497,11 +497,10 @@ s3.BucketPolicy(
             "Statement": [
                 {
                     "Effect": "Allow",
-                    "Principal": {"AWS": "*"},
+                    "Principal": "*",
                     "Action": "s3:GetObject",
                     "Resource": [
-                        f"arn:aws:s3:::{test_offline_bucket_name}/images/*",
-                        f"arn:aws:s3:::{test_offline_bucket_name}/resumes/*",
+                        f"{test_offline_bucket_arn}/*",
                     ],
                 }
             ],

--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -117,17 +117,6 @@ draft_bucket_cors = s3.BucketCorsConfigurationV2(
         )
     ],
 )
-draft_bucket_website = s3.BucketWebsiteConfigurationV2(
-    "draft_website",
-    bucket=draft_bucket_name,
-    index_document=s3.BucketWebsiteConfigurationV2IndexDocumentArgs(
-        suffix="index.html",
-    ),
-    error_document=s3.BucketWebsiteConfigurationV2ErrorDocumentArgs(
-        key="error.html",
-    ),
-)
-
 draft_bucket_public_access = s3.BucketPublicAccessBlock(
     "ol-draft-bucket-public-access",
     bucket=draft_bucket.id,
@@ -167,6 +156,16 @@ test_bucket = s3.BucketV2(
     test_bucket_name,
     bucket=test_bucket_name,
     tags=aws_config.tags,
+)
+test_bucket_cors = s3.BucketCorsConfigurationV2(
+    "ol-test-bucket-cors",
+    bucket=test_bucket_name,
+    cors_rules=[
+        s3.BucketCorsConfigurationV2CorsRuleArgs(
+            allowed_methods=["GET", "HEAD"],
+            allowed_origins=["*"],
+        )
+    ],
 )
 test_bucket_ownership_controls = s3.BucketOwnershipControls(
     "ol-test-bucket-ownership-controls",
@@ -221,6 +220,16 @@ live_bucket = s3.BucketV2(
     bucket=live_bucket_name,
     tags=aws_config.tags,
 )
+live_bucket_cors = s3.BucketCorsConfigurationV2(
+    "ol-live-bucket-cors",
+    bucket=live_bucket_name,
+    cors_rules=[
+        s3.BucketCorsConfigurationV2CorsRuleArgs(
+            allowed_methods=["GET", "HEAD"],
+            allowed_origins=["*"],
+        )
+    ],
+)
 live_bucket_ownership_controls = s3.BucketOwnershipControls(
     "ol-live-bucket-ownership-controls",
     bucket=live_bucket.id,
@@ -273,6 +282,16 @@ draft_backup_bucket = s3.BucketV2(
     draft_backup_bucket_name,
     bucket=draft_backup_bucket_name,
     tags=aws_config.tags,
+)
+draft_backup_bucket_cors = s3.BucketCorsConfigurationV2(
+    "ol-draft-backup-bucket-cors",
+    bucket=draft_backup_bucket_name,
+    cors_rules=[
+        s3.BucketCorsConfigurationV2CorsRuleArgs(
+            allowed_methods=["GET", "HEAD"],
+            allowed_origins=["*"],
+        )
+    ],
 )
 draft_backup_bucket_ownership_controls = s3.BucketOwnershipControls(
     "ol-draft-backup-bucket-ownership-controls",
@@ -328,6 +347,16 @@ live_backup_bucket = s3.BucketV2(
     bucket=live_backup_bucket_name,
     tags=aws_config.tags,
 )
+live_backup_bucket_cors = s3.BucketCorsConfigurationV2(
+    "ol-live-backup-bucket-cors",
+    bucket=live_backup_bucket_name,
+    cors_rules=[
+        s3.BucketCorsConfigurationV2CorsRuleArgs(
+            allowed_methods=["GET", "HEAD"],
+            allowed_origins=["*"],
+        )
+    ],
+)
 live_backup_bucket_ownership_controls = s3.BucketOwnershipControls(
     "ol-live-backup-bucket-ownership-controls",
     bucket=live_backup_bucket.id,
@@ -382,6 +411,27 @@ draft_offline_bucket = s3.BucketV2(
     bucket=draft_offline_bucket_name,
     tags=aws_config.tags,
 )
+draft_offline_bucket_cors = s3.BucketCorsConfigurationV2(
+    "ol-draft-offline-bucket-cors",
+    bucket=draft_offline_bucket_name,
+    cors_rules=[
+        s3.BucketCorsConfigurationV2CorsRuleArgs(
+            allowed_methods=["GET", "HEAD"],
+            allowed_origins=["*"],
+        )
+    ],
+)
+draft_offline_bucket_website = s3.BucketWebsiteConfigurationV2(
+    "draft-offline-website",
+    bucket=draft_offline_bucket_name,
+    index_document=s3.BucketWebsiteConfigurationV2IndexDocumentArgs(
+        suffix="index.html",
+    ),
+    error_document=s3.BucketWebsiteConfigurationV2ErrorDocumentArgs(
+        key="error.html",
+    ),
+)
+
 draft_offline_bucket_ownership_controls = s3.BucketOwnershipControls(
     "ol-offline-backup-bucket-ownership-controls",
     bucket=draft_offline_bucket.id,
@@ -435,6 +485,27 @@ live_offline_bucket = s3.BucketV2(
     bucket=live_offline_bucket_name,
     tags=aws_config.tags,
 )
+live_offline_bucket_website = s3.BucketWebsiteConfigurationV2(
+    "live-offline-website",
+    bucket=live_offline_bucket_name,
+    index_document=s3.BucketWebsiteConfigurationV2IndexDocumentArgs(
+        suffix="index.html",
+    ),
+    error_document=s3.BucketWebsiteConfigurationV2ErrorDocumentArgs(
+        key="error.html",
+    ),
+)
+
+live_offline_bucket_cors = s3.BucketCorsConfigurationV2(
+    "ol-live-offline-bucket-cors",
+    bucket=live_offline_bucket_name,
+    cors_rules=[
+        s3.BucketCorsConfigurationV2CorsRuleArgs(
+            allowed_methods=["GET", "HEAD"],
+            allowed_origins=["*"],
+        )
+    ],
+)
 live_offline_bucket_ownership_controls = s3.BucketOwnershipControls(
     "ol-live-offline-bucket-ownership-controls",
     bucket=live_offline_bucket.id,
@@ -487,6 +558,16 @@ test_offline_bucket = s3.BucketV2(
     test_offline_bucket_name,
     bucket=test_offline_bucket_name,
     tags=aws_config.tags,
+)
+test_offline_bucket_cors = s3.BucketCorsConfigurationV2(
+    "ol-test-offline-bucket-cors",
+    bucket=test_offline_bucket_name,
+    cors_rules=[
+        s3.BucketCorsConfigurationV2CorsRuleArgs(
+            allowed_methods=["GET", "HEAD"],
+            allowed_origins=["*"],
+        )
+    ],
 )
 test_offline_bucket_ownership_controls = s3.BucketOwnershipControls(
     "ol-test-offline-bucket-ownership-controls",

--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -390,11 +390,10 @@ s3.BucketPolicy(
             "Statement": [
                 {
                     "Effect": "Allow",
-                    "Principal": {"AWS": "*"},
+                    "Principal": "*",
                     "Action": "s3:GetObject",
                     "Resource": [
-                        f"arn:aws:s3:::{draft_offline_bucket_name}/images/*",
-                        f"arn:aws:s3:::{draft_offline_bucket_name}/resumes/*",
+                        f"{draft_offline_bucket_arn}/*",
                     ],
                 }
             ],

--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -443,11 +443,10 @@ s3.BucketPolicy(
             "Statement": [
                 {
                     "Effect": "Allow",
-                    "Principal": {"AWS": "*"},
+                    "Principal": "*",
                     "Action": "s3:GetObject",
                     "Resource": [
-                        f"arn:aws:s3:::{live_offline_bucket_name}/images/*",
-                        f"arn:aws:s3:::{live_offline_bucket_name}/resumes/*",
+                        f"{live_offline_bucket_arn}/*",
                     ],
                 }
             ],


### PR DESCRIPTION
# What are the relevant tickets?

Fixes #1945

# Description (What does it do?)

Adds end to end ocw testing buckets and Fastly nubbins to match.

Also updates Pulumi code for all S3 bucket creation to the new god awful BucketV2 API.

