### PR TITLE
chore: bump rapid response version for mitx residential

### DIFF
--- a/dockerfiles/openedx-edxapp/pip_package_lists/quince/mitx-staging.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/quince/mitx-staging.txt
@@ -13,6 +13,6 @@ ol-openedx-rapid-response-reports==0.3.0
 ol-openedx-sentry==0.1.2
 openedx-scorm-xblock>=16.0.0,<18.0.0
 pip==23.3.2
-rapid-response-xblock==0.9.0
+rapid-response-xblock==0.9.1
 uwsgi==2.0.23
 wheel==0.42.0

--- a/dockerfiles/openedx-edxapp/pip_package_lists/quince/mitx.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/quince/mitx.txt
@@ -13,6 +13,6 @@ ol-openedx-rapid-response-reports==0.3.0
 ol-openedx-sentry==0.1.2
 openedx-scorm-xblock>=16.0.0,<18.0.0
 pip==23.3.2
-rapid-response-xblock==0.9.0
+rapid-response-xblock==0.9.1
 uwsgi==2.0.23
 wheel==0.42.0


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/hq/issues/3186


# Description (What does it do?)
- The new versions fixes the problem where the rapid response wasn't able to find the problem's options text when created through Authoring MFE.


# How can this be tested?
- Once deployed, We should not see https://github.com/mitodl/hq/issues/3186 anymore.
