### PR TITLE
fix: add MIT canvas URL in CORS_ORIGIN_WHITELIST

### DIFF
--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/common_values.yml.tmpl
@@ -208,6 +208,7 @@ CORS_ORIGIN_WHITELIST:
   - https://{{ key "edxapp/lms-domain" }}
   - https://{{ key "edxapp/studio-domain" }}
   - https://idp.mit.edu
+  - https://canvas.mit.edu
 COURSES_WITH_UNSAFE_CODE: []
 COURSES_INVITE_ONLY: true
 COURSE_ABOUT_VISIBILITY_PERMISSION: see_exists

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx/common_values.yml.tmpl
@@ -208,6 +208,7 @@ CORS_ORIGIN_WHITELIST:
   - https://{{ key "edxapp/lms-domain" }}
   - https://{{ key "edxapp/studio-domain" }}
   - https://idp.mit.edu
+  - https://canvas.mit.edu
 COURSES_WITH_UNSAFE_CODE: []
 COURSE_ABOUT_VISIBILITY_PERMISSION: see_exists
 COURSE_CATALOG_API_URL: http://localhost:8008/api/v1


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/hq/issues/3128

# Description (What does it do?)
The LTI calls from MIT canvas are rejected by our edX instance because the canvas is not in our `CORS_ORIGIN_WHITELIST`. 

For more details check this comment: https://github.com/mitodl/hq/issues/3128#issuecomment-1867519607


# How can this be tested?
Once deployed, The LTI calls from MIT canvas should start working.
