### PR TITLE
fix: missing aws region for post-processor calls to aws-cli

### DIFF
--- a/docs/how_to/tagging_amis_with_installed_software_metadata.md
+++ b/docs/how_to/tagging_amis_with_installed_software_metadata.md
@@ -60,6 +60,7 @@ Finally, we will take the AMI ID out of the `packer manifest` and combined with 
 ```
 post-processor "shell-local" {
   inline = ["AMI_ID=$(jq -r '.builds[-1].artifact_id' /tmp/packer-build-manifest-${build.ID}.json | cut -d \":\" -f2)",
+            "export AWS_DEFAULT_REGION=us-east-1",
             "aws ec2 create-tags --resource $AMI_ID --cli-input-json \"$(cat /tmp/ami_tags-${build.ID}.json)\"",
             "aws --no-cli-pager ec2 describe-images --image-ids $AMI_ID"]
 }

--- a/src/bilder/images/edxapp_v2/custom_install.pkr.hcl
+++ b/src/bilder/images/edxapp_v2/custom_install.pkr.hcl
@@ -135,6 +135,7 @@ build {
 
   post-processor "shell-local" {
     inline = ["AMI_ID=$(jq -r '.builds[-1].artifact_id' /tmp/packer-build-manifest-${build.ID}.json | cut -d \":\" -f2)",
+      "export AWS_DEFAULT_REGION=us-east-1",
       "aws ec2 create-tags --resource $AMI_ID --cli-input-json \"$(cat /tmp/ami_tags-${build.ID}.json)\"",
     "aws --no-cli-pager ec2 describe-images --image-ids $AMI_ID"]
   }

--- a/src/bilder/images/tika/tika.pkr.hcl
+++ b/src/bilder/images/tika/tika.pkr.hcl
@@ -106,6 +106,7 @@ build {
   post-processor "shell-local" {
     inline = ["AMI_ID=$(jq -r '.builds[-1].artifact_id' /tmp/packer-build-manifest-${build.ID}.json | cut -d \":\" -f2)",
       "aws ec2 create-tags --resource $AMI_ID --cli-input-json \"$(cat /tmp/ami_tags-${build.ID}.json)\"",
+      "export AWS_DEFAULT_REGION=us-east-1",
     "aws --no-cli-pager ec2 describe-images --image-ids $AMI_ID"]
   }
 }


### PR DESCRIPTION


# What are the relevant tickets?
#1979 

# Description (What does it do?)
Adding AWS_DEFAULT_REGION env var to post-processor calls to the aws-cli

