### PR TITLE
Fix #1945 - add OCW Test Production Fastly service secrets

### DIFF
--- a/src/bridge/secrets/concourse/operations.production.yaml
+++ b/src/bridge/secrets/concourse/operations.production.yaml
@@ -29,6 +29,15 @@ pipelines:
   infrastructure/github:
     public_repo_access_token: ENC[AES256_GCM,data:DoG9tNfM4jr1+RhRBlezAl9KwiyX78vSEKkidF6WvW7jbswwngocJA==,iv:2uB4w6GVqibM4u8gf7vvKdicpWsBaC+pcPe5JbuPJoM=,tag:lVTHbRb70jxFEvR6L/r21w==,type:str]
     issues_resource_access_token: ENC[AES256_GCM,data:DSWwAlx7L4Av0W0Ib3xvRjB7egfQ6JmDJVIn+EThKqIRaShFwWT/eA==,iv:SqWdzDmLBb/uOTKmLgpe7NS8xw8+MQSkkcTz8TO6fhM=,tag:fh/KV0QIdJOSt5lzfc+VrQ==,type:str]
+  ocw/fastly_draft:
+    service_id: ENC[AES256_GCM,data:LuE/upbRZ3NlMFOvrcycTLOtTpYxuA==,iv:ZGOKcXiOxPqRAACcrcBweqp952/wsZohrZmMmGowZuk=,tag:8vJxrFg0S6cdZJnaaTNB5g==,type:str]
+    api_token: ENC[AES256_GCM,data:K+8aAk6RQau3vIJiPuMBFsfSCXiJ+N0rQi4qQcX3lOM=,iv:TFNVFU+/07S205vyaXEn9BQKuswYSnoxA/nEVWRDnhU=,tag:mdnDh0ww8/iv8D5fpmkx6Q==,type:str]
+  ocw/fastly_live:
+    service_id: ENC[AES256_GCM,data:swaUswNFKGPRZ1ZtXTomq1+hqkIoJQ==,iv:qUdp7ortnF1Q6o/JZWeyAUP2YuaJI/bXgvvtn8/Wx1E=,tag:BtO62Bg3FMZkGZOJikk6Xw==,type:str]
+    api_token: ENC[AES256_GCM,data:rfnS5HlkSgkKshCT2vsZk4a/vJ9sPOnEFV3q2zyeqjY=,iv:2cPTbOwnJwvbhoRWKxgDkYP1ScfN84v3HhvWj9dgO38=,tag:lOfRxon+irLEMagjvlnPEQ==,type:str]
+  ocw/fastly_test:
+    service_id: ENC[AES256_GCM,data:Oau/qEa6uTquS3kdMGBpbWBXWnbU4g==,iv:yL2ig9laFyCKeJ9dix1/qrUadZxmM1acwPHBcZOgIQk=,tag:EDMC8FGfKtbBNixbGEF50A==,type:str]
+    api_token: ENC[AES256_GCM,data:kv69aB3+4Vnojlk8XObqTXcCFJ7EIIlEjLrUYBGjYPo=,iv:tIJZggmAPXlKMekOztgE8ypSB3KzVCkdFa6Z62YHoUI=,tag:4bbyLQs1vJCLaRq9j94w6A==,type:str]
   ocw/slack-url:
     value: ENC[AES256_GCM,data:T5NNR+BogjO9xGrscw8z2pTupXflerU8hNyZFTGr++h61I62Tjdkr9UcaQYMVfAB+m9bkeF+tZXCCNhyMpzMH1pGduX6LIfweEuW6bpALg==,iv:vwlb7VTrq+E1SYyC6NsWXXdZst99zLc9vuNo5sg3ywM=,tag:ockMV2kHHcMN/kGirQm5Tw==,type:str]
 sops:
@@ -41,8 +50,8 @@ sops:
   azure_kv: []
   hc_vault: []
   age: []
-  lastmodified: "2023-12-01T18:03:03Z"
-  mac: ENC[AES256_GCM,data:eU7fP6APvlnJNi3HsiQa1zrRmpBsNVsD+3gho3nALKdC3jgriUBPgKOqHQfkA3ojDjBZBVDZKM775cBh4Wqc19rYNiy5Rnf/OTCllXkW/v0cX7kjVthI3+xuqHwrK4mTNA5Y3334THCwzaZhapjls8NtOCR27FAgIUeachAcJBE=,iv:C0SusaxYFLad62zUmirFhTpKrF1dMZNS1FTPxtj6cHo=,tag:DFInD3K+jL05ps82QKjsjQ==,type:str]
+  lastmodified: "2024-01-05T20:07:40Z"
+  mac: ENC[AES256_GCM,data:q7Y3yGH12eOh+xiZGqa7nCU2WrVzOf5YwwHRwEPJ7eWN/Dccw3KcyMQxVNe2/UeNGMlOFLQoYpbgeP9Utpadojt2r1npfk3HfPZG3TGsTWKZwtPyy+r9aOuGX44asVlDP4vaLFdyS6eK+ffqmMPRR4gim0OCj9jFpvCvHiyUDPM=,iv:XWPvSsG7LeZMEWYb56doSot6tXThl5UzfMbk7S2gfmQ=,tag:VED4VVVDk1p46ZHZBh+Z/Q==,type:str]
   pgp:
   - created_at: "2021-11-23T19:02:59Z"
     enc: |
@@ -105,4 +114,4 @@ sops:
       -----END PGP MESSAGE-----
     fp: 51BB820DC5F14FE9
   unencrypted_suffix: _unencrypted
-  version: 3.8.0
+  version: 3.8.1

--- a/src/bridge/secrets/concourse/operations.production.yaml
+++ b/src/bridge/secrets/concourse/operations.production.yaml
@@ -29,17 +29,17 @@ pipelines:
   infrastructure/github:
     public_repo_access_token: ENC[AES256_GCM,data:DoG9tNfM4jr1+RhRBlezAl9KwiyX78vSEKkidF6WvW7jbswwngocJA==,iv:2uB4w6GVqibM4u8gf7vvKdicpWsBaC+pcPe5JbuPJoM=,tag:lVTHbRb70jxFEvR6L/r21w==,type:str]
     issues_resource_access_token: ENC[AES256_GCM,data:DSWwAlx7L4Av0W0Ib3xvRjB7egfQ6JmDJVIn+EThKqIRaShFwWT/eA==,iv:SqWdzDmLBb/uOTKmLgpe7NS8xw8+MQSkkcTz8TO6fhM=,tag:fh/KV0QIdJOSt5lzfc+VrQ==,type:str]
-  ocw/fastly_draft:
-    service_id: ENC[AES256_GCM,data:LuE/upbRZ3NlMFOvrcycTLOtTpYxuA==,iv:ZGOKcXiOxPqRAACcrcBweqp952/wsZohrZmMmGowZuk=,tag:8vJxrFg0S6cdZJnaaTNB5g==,type:str]
-    api_token: ENC[AES256_GCM,data:K+8aAk6RQau3vIJiPuMBFsfSCXiJ+N0rQi4qQcX3lOM=,iv:TFNVFU+/07S205vyaXEn9BQKuswYSnoxA/nEVWRDnhU=,tag:mdnDh0ww8/iv8D5fpmkx6Q==,type:str]
-  ocw/fastly_live:
-    service_id: ENC[AES256_GCM,data:swaUswNFKGPRZ1ZtXTomq1+hqkIoJQ==,iv:qUdp7ortnF1Q6o/JZWeyAUP2YuaJI/bXgvvtn8/Wx1E=,tag:BtO62Bg3FMZkGZOJikk6Xw==,type:str]
-    api_token: ENC[AES256_GCM,data:rfnS5HlkSgkKshCT2vsZk4a/vJ9sPOnEFV3q2zyeqjY=,iv:2cPTbOwnJwvbhoRWKxgDkYP1ScfN84v3HhvWj9dgO38=,tag:lOfRxon+irLEMagjvlnPEQ==,type:str]
-  ocw/fastly_test:
-    service_id: ENC[AES256_GCM,data:Oau/qEa6uTquS3kdMGBpbWBXWnbU4g==,iv:yL2ig9laFyCKeJ9dix1/qrUadZxmM1acwPHBcZOgIQk=,tag:EDMC8FGfKtbBNixbGEF50A==,type:str]
-    api_token: ENC[AES256_GCM,data:kv69aB3+4Vnojlk8XObqTXcCFJ7EIIlEjLrUYBGjYPo=,iv:tIJZggmAPXlKMekOztgE8ypSB3KzVCkdFa6Z62YHoUI=,tag:4bbyLQs1vJCLaRq9j94w6A==,type:str]
   ocw/slack-url:
     value: ENC[AES256_GCM,data:T5NNR+BogjO9xGrscw8z2pTupXflerU8hNyZFTGr++h61I62Tjdkr9UcaQYMVfAB+m9bkeF+tZXCCNhyMpzMH1pGduX6LIfweEuW6bpALg==,iv:vwlb7VTrq+E1SYyC6NsWXXdZst99zLc9vuNo5sg3ywM=,tag:ockMV2kHHcMN/kGirQm5Tw==,type:str]
+  ocw/fastly_draft:
+    service_id: ENC[AES256_GCM,data:E/G+v8u4W438yRTATiByqDzrAhsgQw==,iv:Ukab8eadgwDzTSw51bMyn9QiUSwlVkI7fMJRff9ZVcY=,tag:UJcPCf6+5oJP8yKnSIljyw==,type:str]
+    api_token: ENC[AES256_GCM,data:D3gh9dGmYxrr8MX0BYCjUEm7cIzpNytv3ffZy/JmzOA=,iv:FEqYtFk/SQyePAKEhVvKD9rGz8Eh6eFcTgAW/HBjc/s=,tag:U/dfeD5+a7lVyyF0c4YpzA==,type:str]
+  ocw/fastly_live:
+    service_id: ENC[AES256_GCM,data:cINNvhP1Zwic5tmN+j1RpCMIOI6c5Q==,iv:qmG8mpJhwSqyjpqw4WbBsagun5/YDt4Is8VtJdGCqog=,tag:nPy3cUZk1rIyGclsihE3yg==,type:str]
+    api_token: ENC[AES256_GCM,data:DZSB6szxslhZfV+P9F+3cwEVUKcTg7t+FE/6Ay7XSlY=,iv:1ZiIlYneOPx8N+t2ebSHSaHKynCGSvMNAnNmrgnrmX8=,tag:J+w3BftFztltUVsQm+l4Nw==,type:str]
+  ocw/fastly_test:
+    service_id: ENC[AES256_GCM,data:dRiYb70cRg8N71KbQI86BIeJ8nNTUw==,iv:1nhZW1taQ1jn9FaOjJiI1SPvUou/jfs2tTYhWQRmh1w=,tag:8JvCvJPdtF7aF4+yxTsNaw==,type:str]
+    api_token: ENC[AES256_GCM,data:XH7E07YgY8friFcFrG6eltj4dJ7i/8Dk88tQFp7VGvU=,iv:gB+BBjpeg+/w43UeiaQdEeigkLkr3ynAq89l2unLwMM=,tag:QRnq9ZEUhOSZ3+cqUFT4UA==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
@@ -50,8 +50,8 @@ sops:
   azure_kv: []
   hc_vault: []
   age: []
-  lastmodified: "2024-01-05T20:07:40Z"
-  mac: ENC[AES256_GCM,data:q7Y3yGH12eOh+xiZGqa7nCU2WrVzOf5YwwHRwEPJ7eWN/Dccw3KcyMQxVNe2/UeNGMlOFLQoYpbgeP9Utpadojt2r1npfk3HfPZG3TGsTWKZwtPyy+r9aOuGX44asVlDP4vaLFdyS6eK+ffqmMPRR4gim0OCj9jFpvCvHiyUDPM=,iv:XWPvSsG7LeZMEWYb56doSot6tXThl5UzfMbk7S2gfmQ=,tag:VED4VVVDk1p46ZHZBh+Z/Q==,type:str]
+  lastmodified: "2024-01-05T20:34:13Z"
+  mac: ENC[AES256_GCM,data:oblsd9FZ6TJJueYqTJI4mVZfRWmRlEEhLO3txt2qsExgPel1qSPi1AC+Nlrf06Qz+z7TzgFmGSauUR7qvYbn1DLbAuBp/CIGgRGBMPfxPSIPqQ50KwmybBEaiS+uLyAMdixcfH7mP6wZ4v43cTQl7CNrwWIRKWL8W8s6bN22kCs=,iv:IWXuscmge/hSdAkdk30Mny9Pw5fR8HwNFC4Z4V864rM=,tag:sqEE66RKv6M+zNqRqjEEyw==,type:str]
   pgp:
   - created_at: "2021-11-23T19:02:59Z"
     enc: |


### PR DESCRIPTION
# What are the relevant tickets?
Fixes #1945


# Description (What does it do?)
Add Fastly "OCW Test Production" service for OCW end to end pipeline.
