### PR TITLE
config: disable new problem editor for MITx Online QA

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
@@ -16,7 +16,6 @@ config:
   - ["grades.enforce_freeze_grade_after_course_end", "--create", "--superusers", "--everyone"]
   - ["grades.rejected_exam_overrides_grade", "--create", "--superusers", "--everyone"]
   - ["grades.writable_gradebook", "--create", "--superusers", "--everyone"]
-  - ["new_core_editors.use_new_problem_editor", "--create", "--everyone"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone",
     "--staff", "--authenticated"]
   - ["seo.enable_anonymous_courseware_access", "--create", "--superusers", "--staff",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/3299 more precisely https://github.com/mitodl/hq/issues/3299#issuecomment-1879262462

### Description (What does it do?)
- Disables the Authoring MFE for problem editors as per https://github.com/mitodl/hq/issues/3299#issuecomment-1879262462

### How can this be tested?
- We should not see https://github.com/mitodl/hq/issues/3299 -- Editing or creating a problem on https://studio-qa.mitxonline.mit.edu/ should work fine.
