### PR TITLE
Md/issue 2074 - MITOpen QA

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1119,16 +1119,6 @@ files = [
     {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
@@ -1565,6 +1555,21 @@ pulumi = ">=3.0.0,<4.0.0"
 semver = ">=2.8.1"
 
 [[package]]
+name = "pulumiverse-heroku"
+version = "1.0.3"
+description = "A Pulumi package for creating and managing heroku cloud resources."
+optional = false
+python-versions = "*"
+files = [
+    {file = "pulumiverse_heroku-1.0.3.tar.gz", hash = "sha256:6fa4b6bc86f30e4f24fd04e1bb68c9f2f3804a95e5793dce79532edc8ed31e14"},
+]
+
+[package.dependencies]
+parver = ">=0.2.1"
+pulumi = ">=3.0.0,<4.0.0"
+semver = ">=2.8.1"
+
+[[package]]
 name = "pycparser"
 version = "2.21"
 description = "C parser in Python"
@@ -1951,7 +1956,6 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
-    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -1959,15 +1963,8 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
-    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
-    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
-    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
-    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -1984,7 +1981,6 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
-    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -1992,7 +1988,6 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
-    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -2391,4 +2386,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "e17a80ccba659d41a28b1924f1690cb9e0a5c8ce3b00f50df42df71e2616e8de"
+content-hash = "57178d83aed8aa2a6087d1fa160f3ec4e8a9137f73f5349969f60f16fc92a9cf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ pulumi-mongodbatlas = "^3.3.0"
 bcrypt = "^4.0.0"
 pulumi-keycloak = "^5.1.0"
 pydantic-settings = "^2.0.1"
+pulumiverse-heroku = "^1.0.3"
 
 [tool.poetry.group.dev.dependencies]
 copier = "*"

--- a/src/bridge/secrets/heroku/secrets.mitx-devops.yaml
+++ b/src/bridge/secrets/heroku/secrets.mitx-devops.yaml
@@ -1,0 +1,97 @@
+---
+apiKey: ENC[AES256_GCM,data:zB78I8Uz70DzSi466/Zvh2HwOMbbu0pKKzHXNxZozuR84n2l,iv:nsC8zC0L0fDbGtdM0Fw7Y3Tc/9yH/7NsN2INc08VlRU=,tag:PmXmkCNmOrQcATya+RnDHg==,type:str]
+sops:
+  kms:
+  - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
+    created_at: "2024-01-10T16:39:53Z"
+    enc: AQICAHiiGjYUolrtj8PCnScLM7oLAdMl8nJrLjQjnqyl1LykYgF8yltEAct3JQzu75FN0euaAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMn5+5RMYfwLb9lczaAgEQgDuQEE2A3/k6CsxSnWBI9H0wMByz62JJjHOP5LcHxSRQiactIixJKlR6zEsY6tpQhPeCjQADE5GA5XILmA==
+    aws_profile: ""
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: "2024-01-10T16:40:09Z"
+  mac: ENC[AES256_GCM,data:HXMFMH9fhATA/xW2pRX6F3k78gUYh3afBfY5r0keHa/JctOnNWAcpSW5gGfJmYkPxbXztzci9PrniyETjPmz8tEcmqpka2aeSYgTt+agbV1CtzEJNPFVVN+SiEJ7lv4YwGXThW9Tar+1x7rUdIabX4D/y79tbR1wGw0JwegdQgQ=,iv:y6DivWzJIZ31DLk5zpcH1hUhUd3JpgeZtvEcXhWC4ZY=,tag:4JFoWRU2fhHgCzRjmLRilg==,type:str]
+  pgp:
+  - created_at: "2024-01-10T16:39:53Z"
+    enc: |
+      -----BEGIN PGP MESSAGE-----
+
+      hQIMA9YmDGFr0PozARAAqIX5nH8O/FHNK9b5CGxrb104YMZh4ik2i7FlnpD1DDtO
+      wbSgkYeyL7LTjJEtOqftNdU8A//j3lSNa4u59DZ99gPQ0UR0xVc2W/lsBnoigKL4
+      Fxej+IzVRSfnHiD/hXSPfuynSPVqGWTTcYPeKU52SSjsIIqTSkq8p+qsj53SJJ4D
+      AfagVNEEqGT2kn5jXwcTSGBoi1E/16XD55iIqz9BVcEZHIrB8eL19PP/QWkyLWw9
+      jDDWUCjlT0QyL5VTM5twi90jgSVbLrygyYJYJN+i7i9+XZHXihj/AMnNHrdk+HlS
+      5a3Rg/U7f/covZFYis6iO05rycVAHm86/p34KrkASAvrokMWwTpTAM+TvJOzaaSj
+      u3ogn/t1/Yy8vJISVSZqmPjpIR3f8pjJuqLtNbwnSsq1qUNuBzMeE1+Xp7F7NBiV
+      prbmnzdqWF2nchWeZYkEKCI5jpSfjwGnBoIsWtnhLSp1IGZc0QE1o9+tp/QZA0+S
+      Zfk3dyR6T89LJ7Yc8VA1rT9R+7ZtZj6/u0n+ZhSuuVcHToHq+E5Lfr8pNrEJg9iR
+      gsUSHeUKOSFSTpOve4YyDQa0KoU28YlJKFBjTkUrSTGjUwHw43O7WF6tjosBAxvk
+      iAKSyFNEB34sxlBe9YEnjrtt8Bc+PnvpZsGfjGQQYmesCLoyNFMZUoJwYrpRPXTS
+      XgGGJSRfiK1N9kE4LTcuBa1v6q6ku2Su2kNnxgtEV2cTCIzshNCBg4kSaDgbMFpJ
+      yUxIyHXAQCtjszXkxXVzbx/Q5IOCnwqeVxsxJsTHwxpPrgOaEQD2jh8d51PHEnM=
+      =dERb
+      -----END PGP MESSAGE-----
+    fp: dfd1205a98269f34c43c9221d6260c616bd0fa33
+  - created_at: "2024-01-10T16:39:53Z"
+    enc: |
+      -----BEGIN PGP MESSAGE-----
+
+      hQIMA8MO7RiKjktCARAAzZ2ipycAW4aIHzy+5XZz1vqyavyg4J/WicUy/h+4jozp
+      Op9FJjU0uMgV80mvDcBXUib9Tj/OCdkRP2r1VJNS/WNRicqqOjtTMyDmNt96YKIY
+      UXKhac3maIQVLuaGmQ82opNJ/aD5I2xehuZw40EpNf76LGjUjc7C8tIy06d17vVI
+      Snv+TTy8nRSAfRAMW9FIyE74WHCnapG5LBh0k6WutBDu+hscjE20K1cIRpLFQMp2
+      MKiGXk9SVJN6PIot+c0h59FDLa4WPZuOlUdlhwMlK07qC+USZBd2b2aQgNyy3cVy
+      VXN+4L2JSfkZOenBxD7ahVvRtnQzDV+I+Z95UXkFx9EcXICh8DxVl1n5mks/ihNg
+      HsQeIWLiUatddsXSVsX+q2HrjyFiCp22sBvpAvct6L4vF5VNbrYWfWNxPjK5fhnT
+      K9vG6tlDioCbngORCqH4gLJmlwvirDLlMEhq5ZY4joUD5oqr6sakOVnKxOLIAqKr
+      w7cMxPzcar3g9LkzhHv5btVomv33/EqpuIn9CYqN+FUVA+o6l1yXkTEFpvFJUQ4/
+      y7fVBtQGFv87AS9yFLJ+SCLEYWbFC2o4THIsS9prHlLQJdVJtw1S+K/jOWu1FdAI
+      OMqjN84su+h23X/CzngHakw2y7vUP9KKusKfcS5TIfEsvvnXDwUuBH5yb4igXsvS
+      UQF8qQ/7CorzeuhOt1hHS4szGxAmNED4AcU4nwq4Uap9ZBIxQ3QCWXIgznN82eK4
+      N43+hHk38BqkL29JRQNMxRem4l84imev08DbpJpMx67tag==
+      =qtyb
+      -----END PGP MESSAGE-----
+    fp: B905F0256A801D3F1D15B5126A1D27A4BE75B1C2
+  - created_at: "2024-01-10T16:39:53Z"
+    enc: |-
+      -----BEGIN PGP MESSAGE-----
+
+      wcFMA53hirIFs7uxARAAmoHiF8CEZumbJ5jC8XMUVob/RS6pIl6Iyioxy5/0B6/D
+      zrdotycO3R+Knd6pjKgQLLtcLe5uvgWbDevNvJtB0ieg9z4T4Gec0VwV15ALNg1E
+      JJLVHxIeonNCG2QddKbQF5+3QeXMcnk3K+X1CMTgbtALwr7wfm+wIUOIJfLNj4aY
+      1Bh1bIGo3hQngTDqusrJiRViZiUHAnf1arp6XhpB3pahPVcnbIUoRInjRwBWKt6s
+      7Rl/U0zvfqUmjlLQAAmFDTmSBBXNukQrCird/DbkZFKVJMvVwaqAE0qOZGeKpaey
+      36JBzaSfCoLVDkSBjzSCexcnqsX+vSv2dmLFK2XVE7oUUG47JpHFFlPCMp97z5R4
+      Vu63R5ClNpm07zuPjQargqQrfFxENLOcle0IkVJC0X76bPnpB7EN2oSNZ7seZbg3
+      1vj5D/YhJDczR7bYsgJR+tJoVBUVIFjot5dqWLNo7tojdPOl17Z0c0+nwZ/iaeuv
+      ZfVvWeA/yv3OujJ5Zvp3Pl26QmthDWbOiN3mVTllkjGb95+VUU7c+IoWSK/5dRNQ
+      EACyop3MMSw9QzuGFiaNo4ttAzQ3gbQmaU6swQJxGyJnEfJsEfMXj0ausq9f8RYV
+      tPedq2RQddQM8PJV9UbT2kPMdjlrddGKRVWj5774BhtxQUsHbyX92T1h8MwjvRPS
+      5gGIntz4skOjbVNsmMVM58Cnizvf/qYBSw23Z94ZQ1sLAUFauQ48I3gyLjJjgGOV
+      qnoTmJ6/v/IigCQ/OkV6kg7khnxmOsGRUSB9W4weXq+m/uJys2DrAA==
+      =HURZ
+      -----END PGP MESSAGE-----
+    fp: 07083D36FD5986B0C99700944E9B358045C1B176
+  - created_at: "2024-01-10T16:39:53Z"
+    enc: |
+      -----BEGIN PGP MESSAGE-----
+
+      hQIMA8YdB40JfEZzAQ//Q6nYxubxcdQA+M6CKn+kqkFtb55nwWprk/gTVHdyJzaW
+      ePjDqeKZoo3wmkEhMHVA9b2cKxd7fT21seMISaG8mkLErwYzUfMaXfQY9u/FKHvQ
+      eqwmfVi7iMG7MNaUFlFv/C1GhDnVzbLITc9d5skILX2IKsr1uHuLiqdHBGezsfBL
+      jtARBlzuReiFjGsHBXmB+IYh5/aDkCyzactoW2rUwqiZijH1Y4OmQLRcwnnGG4K4
+      TtgGjzWwVf6i7GXq7HDwjNgJZRGbAfWzNzMOZmI0mc+RtZqLLs/L9Lli+ORUgBf5
+      1y/L8fOTL9x096aqqRUU9ZT12JwVVOSL9vCTlHExmQKZ3jFOv8OiY2++ihfeeQSG
+      uL06oD4rLr8dqZTUYPhg2XBWU0FfTeQvN/lGImOBcLvspl3/6FfqzTT8MLGq3z6+
+      ShV3/xbPEpv0Owv/ophl/LcTMa4i0GnMgK481Bf6FE3smv+1D7juDEw/Wu3FCziU
+      7OhpTG2ZpoTZae1Jz2vbeNa/uJER4EBm1GYcjLppzAMJt2OUhO7W2GIfYgPEpZCz
+      Pj7b15afhSBgS7YeAyQaWrdatkHBajHbTS/67jBiXVTXhpq0vN+QUBumkLcFzphW
+      ph7wjaDYT8ARunNMJaoZ4Mm763ZOxUZnIaBCSoXHW12/jpnk7CR5bJ9ABnFb1ZnS
+      XgEoe3XEHKrNqSVZOj8y8yF4apGeN0mWiVFEB7CF8bsqpM9fu7SdPiF8D3jWT9US
+      qIFYzN5ylhwIg4sSbbDdqu1qwRVpNJmYDG2kVFGPDtrYu1P/4xqcU1kAxumb8vo=
+      =Qpe/
+      -----END PGP MESSAGE-----
+    fp: 3582AE9F12CE295BDAF545ED17A5F53F11681446
+  unencrypted_suffix: _unencrypted
+  version: 3.7.1

--- a/src/bridge/secrets/heroku/secrets.odl-devops.yaml
+++ b/src/bridge/secrets/heroku/secrets.odl-devops.yaml
@@ -1,0 +1,97 @@
+---
+apiKey: ENC[AES256_GCM,data:qXL54BHwvaQc1vld80m0oMxgi84p8hXJ1WFT0kzKt9azQL0f,iv:UH2jfERrEzb0y5BHaVhMK7Uea9+T0NhalX3fxQsydR0=,tag:Tf3GNbnPlfp4xRp6Otgyqw==,type:str]
+sops:
+  kms:
+  - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
+    created_at: "2024-01-10T16:36:49Z"
+    enc: AQICAHiiGjYUolrtj8PCnScLM7oLAdMl8nJrLjQjnqyl1LykYgGqcMO9ftYS3r8iicjWDtN1AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMo1fpVaRzVnA0o3v6AgEQgDu8KLJ2aRB8NaKbXTSgv5iTBrJWE1mrlcDXA5IUiGHv7PaHCtjDaFINPN94BCsLMA5mbDqKyJP9ppo2ug==
+    aws_profile: ""
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: "2024-01-10T16:38:59Z"
+  mac: ENC[AES256_GCM,data:BDWyI5GH8m+YYSBB1xvV3rfjpld70TNolMgPnox+KsmULnmzQ7qm0KcS3LoBS12bJ1JFq6J0ScCl0xlPVLRenfIAwrgn1tpjndpA5lFUri61cpEB3QNMYnpSiyVAEIA02bkeSVf+0BxJhKRUaZTEx1gUDeIh7NPc4D1E5zpRKdw=,iv:9dt16Wa9Zd/srnXvQys37bRH3K3lmz/mYNTEc3932ms=,tag:WXJ6hfCDcqnFOrX8JCwwlg==,type:str]
+  pgp:
+  - created_at: "2024-01-10T16:36:49Z"
+    enc: |
+      -----BEGIN PGP MESSAGE-----
+
+      hQIMA9YmDGFr0PozARAAy2q/fTYh+CzDypacYaacuj2fChmb1REokCIsOilQxcSO
+      oPaKmqeqJrY39ibEc4uRRQcGa/u04ad0FNEuZPjdMclvL/XMxAZz+vZ/+8mEiIn5
+      2jBnzPv21m9KOULJnLQG4iC3N03z4c4G+ih7vEMWolmJEDMazHV1+WqKc3XHOwvM
+      W03zJ5ESnsk1tImBIDRU1mlqYxT89+Z2dORQW9Ff+w7Yxviie/KUfyMEKXMWIiE2
+      Usl2eFIaZ9lyZfvYfi12J45OPC9GWtHfNNdyY7NviRSgO2htFImQ/fpegSvJbYoG
+      bqnnBGLM4TtQuGE2H6iAmm0RjdOaqAFMwq+vlXY+7v7rhAweutVMhPDJ6XGFMT6P
+      SN5WyEcea5crF96w70j4dL2J47eOcF6oJauG9K89NddlCPQhmiX3JG7TGSknP4JG
+      avkhrPIcCoK5Y72Xj/6H97L2DIi31o10gaLpu3nUm2lHuw+3a7vfujXxjVepjdGE
+      MjYDVhyOH8oDGaM97jYjXQLpVaY7ds0oYaCbvFzG9g7u1hrzRsbOyT4ow5RRpURs
+      rf/LLG93mCh5OemEh8dN+HIBL/+E+Uo9Gtk+UQNMiWwbvohkC90CV+vzW0AcZErs
+      SQ+wsj3/fA0pCt6Ch1Dt0UEaP0MAWOuidTzPT8gKCx7BnUixcemxuSPybCy/6vfS
+      XgGk2y5Sybw5JW5hZaXquj6rset1VZ+u5LsO2yw5PjRxTCJgdsMo5auwBvaSAeZO
+      R0uaHUMBokv5f02zp/+s3W9769+D+mI/SQLac43ZddNppfNW+dv8W6OnH/i+Ga4=
+      =wcyK
+      -----END PGP MESSAGE-----
+    fp: dfd1205a98269f34c43c9221d6260c616bd0fa33
+  - created_at: "2024-01-10T16:36:49Z"
+    enc: |
+      -----BEGIN PGP MESSAGE-----
+
+      hQIMA8MO7RiKjktCAQ//WcFHVJX7gFkVHvsV0EjT7n0u9D+xosOKxT4OxRtvetuR
+      Hc/ZGqcw8da2OmlThCyDV4IkpNk9leTw7rQaX8Dc0h9iy5cQ1DWWyL938+4CtIVH
+      gqGAuSpRoxOWcbYNDivZ1rmvavgPE1t57fZzD0qF+43pnisdKSxMQN33XPFy3THy
+      b+kDi6f+CwVwlo4YGQ/HkhQSgnKs23N347x6hQwo5rVQ0Nv4Q0aQaFsoLfJZopSp
+      4ZdOXscbEWUJlWc99yUeUl6zyJooQy+J/hvJQuHS+bT+cMILFAnYKhTqQbX6eHIX
+      VWkhqJxkbAi50zwHiwkJUJ+Oos8uw1+Z+v4v1pldMKicrFqNiLDdLfK8Y009VC+7
+      RanQB1lHk+MdwWQYn3TIof5i4NeibHp7+X1+GQhND+BY7bQF9fsPB0K+z5tlpPYF
+      50oepxStZ/SYo8Mdpl1WspZ7GrTPavqBNQJKpoDbWMO/8TAupEmMCXcQCkNGNfVg
+      nAp3/X6Q+s0FxGlQSYpKWzHBr41ntPUHSzDL6RfKcLs72QVmjpvxJ+aW9UDaOa/G
+      7Yg8f38llhO5UDaEhrzciTdivzftFW+lMa8foe5+WLEv5SDb1jUFvRtBOLVICVQI
+      AeI3wHi7Bwxs7HJHi71IKslabKfn49ZLmUYkKJSc0cWxN4fUKfVrP8riyntdd/rS
+      UQEjjYV0/VfSf77/Gzr569vBbWjI4/HqhsKcDRsC+heugPsuDiiEbOZI4JvnLoDS
+      F6dex8itfTe7wvEqJH2cEP5upKX2eQRkcrGIeRBdlWXLkg==
+      =0FR5
+      -----END PGP MESSAGE-----
+    fp: B905F0256A801D3F1D15B5126A1D27A4BE75B1C2
+  - created_at: "2024-01-10T16:36:49Z"
+    enc: |-
+      -----BEGIN PGP MESSAGE-----
+
+      wcFMA53hirIFs7uxARAAlhfy0mOkhgjDBQb479jJ5CN0HmN6DkpB/71OkNqhx6pJ
+      J6SzFh8BRt+M2yG4DIPCwQjbRwj+P5JkuDBgK5fd/YAOCPsjHndIFGBsWajFn+8y
+      noHgEwWawd42L/IxWSpbWBUG0frlMugW9kLgjvy4hMJunw1zSCEzEDsN4yAaW3MC
+      6kb8rknOkFfzy8KVYaOxuZVAcGUUGY8pPPy6/cj0tugJf+ZdylB7GKRxVXsuhaNt
+      gx7060w2DEccdqjOeXefnpKszIrQOnGJSFga++gFzqD+7INyd0BUGP2lnTBfSj1w
+      2WJq6oNs4gii99w1ZxtUrYSO4U0GdibNSo5vdNQqZ9XRgtefrVzwXcwujPg1oeZE
+      bUVhY8TglENhcHfP8rdeqqDtgpGUMUgoAhXLTTjEQyPjpX6evjEXjufyE3QuQz7T
+      /P3S8Y34W1kjduhnie7tC2/VlZVEncfAcaFDUANMRcsnRuA8Kb/vy4VwSmXjSvWt
+      D4NWYMPjsxO7g0Bgj1N4tAUt7UOeVBGAFApqY3wimZb9dvWuzwfZsmODYuqmDgC4
+      EOdgooXeyDeVniX8iAW6tqhPKMg8e5Ertth6+dUDu+pfEd9GkuorjgP9e37Nxnz8
+      p2g5UnqyU7SHPJtVdvWNWNovSh+OPjCfke8fyPBesw22HAjjPN5dAYT3+zn4dHXS
+      5gGxmKEfPgyo/tDVOEuKMR7uCP79g+U61HA3uGvkdyOonP4t4i15uDs0EBRX6P/I
+      Cin82393Gtr14o3qqgdnWX3kqUG9leq+OwHn76bTEYk+F+IRxJ3uAA==
+      =YbXf
+      -----END PGP MESSAGE-----
+    fp: 07083D36FD5986B0C99700944E9B358045C1B176
+  - created_at: "2024-01-10T16:36:49Z"
+    enc: |
+      -----BEGIN PGP MESSAGE-----
+
+      hQILA8YdB40JfEZzAQ/4yBuNOF+xhUGqHOf7shHeB8qvowP5atJj6ZFwcWeXhv7d
+      Du5zW4KlTVzeHidyY8PKhaUen8wtGbA1dXnlcvQPCjMVDg2iFVrgmfh1rXd6ty9D
+      tm4N6BthqlSVHMlQOxcElxSoUt9pKsVBqG01Cx9amTPxFFuPDcslsa0k3yI0G+wi
+      0hCTUfdHRB9KrKjn9XJJqN+ufcMG5lx45BfaFn/HpwauYEspz1CxGXfm5EV6sxZp
+      5pQFrajaLpq7gJfrD4Xz2RJVSmStgUxMlOQzXy0+Stm84i1QEUMFrS5hrrvBzAG4
+      FXH9WuHaEmlr42XLF2vddP+xPPJOXRohYe9cUkkntFmuDHPUonKhYy/WDqVtB1wZ
+      qkp1Rth2Y64k9bgASwldd6PBV4feHP4U4FHkwXZBskivZKoszS5THWkSG++QsSFB
+      JkhqKALS2OQvvyd+PLljbedp+ETxpM9bIyJw7MBPSiFXP6P8hTBYQ5yH2WByA6Xe
+      362WfqhbZjeGtMi74f3AxszrOyGw7oJaxFhFt07xXXUG1oZ+32clbgxhlxMcsFZN
+      33jT7Wy1Uub4z+eSP6oAOdrLrBYcmNnvumKM28nhA8TSFxZzR6R/NOwKfKdwtqf1
+      4b+qqtGjCPXPtVZuu+h7nOLLjcoglRyEmN8lXKZba2r8y3vU4Bq7CTFGZ/iABtJe
+      AQk7W6a89YdGtFj6/kPx00KHvwIJefN+cPLRx7BBmCCEMShn4N/ckR2gbDLx8mKt
+      oRxk5Eol0dJYil3RIbeOVmCkrZYNtK5NEFyiM+A60Q5Y0CZUxCigkokmXhko8w==
+      =Nz/k
+      -----END PGP MESSAGE-----
+    fp: 3582AE9F12CE295BDAF545ED17A5F53F11681446
+  unencrypted_suffix: _unencrypted
+  version: 3.7.1

--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
@@ -3,6 +3,9 @@ secretsprovider: awskms://alias/infrastructure-secrets-qa
 encryptedkey: AQICAHg42pDDDGBhpaX14TdtzcK1hbiMYTHsYRH4k5GL5RFpIwEi8MniqKSK7PJ7AIbp17REAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMbWm9PEFY6H+jKGYHAgEQgDtAZs04prjkVBGB8O8+C6kjqzMhazPYOAanmLoWdx4WArJXNKxZkv72c6my81/qnCg0xWYdmw6fJxV0dg==
 config:
   consul:address: https://consul-apps-qa.odl.mit.edu
+  heroku:user: "odl-devops"
+  heroku:app_id:
+    secure: v1:eSvnqne7KQRkHJlu:wTyl9W3aivfxlANqBML2wy4GEHe85VuKll60R5HmGUu1hJTcQBEfzK1cJOyvjlbLgBtXLw==
   mitopen:db_instance_size: "db.t4g.small"
   mitopen:db_password:
     secure: v1:Xk9oxNvxSQAJUAHE:8CdeLN2SlyhyU0iZpqEX5rnHSJ3PClleDJi2UpzoCsVZ4UjNkr7vCOAKY7CvCuB/7CBKJKM=

--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
@@ -30,6 +30,7 @@ config:
   heroku_var:mitopen_cookie_name: "mitopen-rc"
   heroku_var:mitopen_support_email: "odl-mitopen-rc-support@mit.edu"
   heroku_var:ocw_base_url: "https://live-qa.ocw.mit.edu/"
+  heroku_var:ocw_content_bucket_name: "ocw-content-storage"
   heroku_var:ocw_iterator_chunk_size: 300
   heroku_var:ocw_live_bucket: "ocw-content-live-qa"
   heroku_var:opensearch_index: "mitxopen-rc"

--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
@@ -6,6 +6,38 @@ config:
   heroku:user: "odl-devops"
   heroku:app_id:
     secure: v1:eSvnqne7KQRkHJlu:wTyl9W3aivfxlANqBML2wy4GEHe85VuKll60R5HmGUu1hJTcQBEfzK1cJOyvjlbLgBtXLw==
+  heroku_var:cors_urls:
+  - "https://ocwnext-rc.odl.mit.edu"
+  - "https://ocw-next.netlify.app"
+  - "https://ol-devops-ci.odl.mit.edu"
+  - "https://draft-qa.ocw.mit.edu"
+  - "https://live-qa.ocw.mit.edu"
+  heroku_var:debug: false
+  heroku_var:enable_infitite_corridor: true
+  heroku_var:edx_learning_course_bucket_name: "edxorg-qa-edxapp-courses"
+  heroku_var:ga_g_tracking_id: ""
+  heroku_var:ga_tracking_id: ""
+  heroku_var:indexing_api_username: "od_mm_rc_api"
+  heroku_var:keycloak_base_url: "https://sso-qa.ol.mit.edu"
+  heroku_var:keycloak_realm_name: "olapps"
+  heroku_var:mailgun_sender_domain: "discussions-mail.odl.mit.edu"
+  heroku_var:mitopen_base_url: "https://mit-open-rc.odl.mit.edu"
+  heroku_var:mitopen_cookie_domain: "odl.mit.edu"
+  heroku_var:mitopen_cookie_name: "mitopen-rc"
+  heroku_var:log_level: "INFO"
+  heroku_var:mitopen_support_email: "odl-mitopen-rc-support@mit.edu"
+  heroku_var:ocw_base_url: "https://live-qa.ocw.mit.edu/"
+  heroku_var:ocw_iterator_chunk_size: 300
+  heroku_var:ocw_live_bucket: "ocw-content-live-qa"
+  heroku_var:sso_url: "sso-qa.ol.mit.edu"
+  heroku_var:opensearch_index: "mitxopen-rc"
+  heroku_var:opensearch_shard_count: 2
+  heroku_var:opensearch_url: "https://search-opensearch-mitopen-qa-nvwau2pbr2nek5dgx2o5w3xju4.us-east-1.es.amazonaws.com"
+  heroku_var:pgbouncer_default_pool_size: 50
+  heroku_var:pgbouncer_max_client_conn: 500
+  heroku_var:pgbouncer_min_pool_size: 20
+  heroku_var:tika_server_endpoint: "https://tika-qa.odl.mit.edu"
+  heroku_var:celery_worker_max_memory_per_child: 125000
   mitopen:db_instance_size: "db.t4g.small"
   mitopen:db_password:
     secure: v1:Xk9oxNvxSQAJUAHE:8CdeLN2SlyhyU0iZpqEX5rnHSJ3PClleDJi2UpzoCsVZ4UjNkr7vCOAKY7CvCuB/7CBKJKM=

--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
@@ -6,42 +6,47 @@ config:
   heroku:user: "odl-devops"
   heroku:app_id:
     secure: v1:eSvnqne7KQRkHJlu:wTyl9W3aivfxlANqBML2wy4GEHe85VuKll60R5HmGUu1hJTcQBEfzK1cJOyvjlbLgBtXLw==
-  heroku_var:celery_worker_max_memory_per_child: 125000
-  heroku_var:cors_urls:
-  - "https://ocwnext-rc.odl.mit.edu"
-  - "https://ocw-next.netlify.app"
-  - "https://ol-devops-ci.odl.mit.edu"
-  - "https://draft-qa.ocw.mit.edu"
-  - "https://live-qa.ocw.mit.edu"
-  heroku_var:debug: false
-  heroku_var:edx_learning_course_bucket_name: "edxorg-qa-edxapp-courses"
-  heroku_var:enable_infitite_corridor: true
-  heroku_var:etl_micromasters_host: "micromasters-rc.odl.mit.edu"
-  heroku_var:etl_xpro_host: "rc.xpro.mit.edu"
-  heroku_var:ga_g_tracking_id: ""
-  heroku_var:ga_tracking_id: ""
-  heroku_var:indexing_api_username: "od_mm_rc_api"
-  heroku_var:keycloak_base_url: "https://sso-qa.ol.mit.edu"
-  heroku_var:keycloak_realm_name: "olapps"
-  heroku_var:log_level: "INFO"
-  heroku_var:mailgun_sender_domain: "discussions-mail.odl.mit.edu"
-  heroku_var:mitopen_base_url: "https://mit-open-rc.odl.mit.edu"
-  heroku_var:mitopen_cookie_domain: "odl.mit.edu"
-  heroku_var:mitopen_cookie_name: "mitopen-rc"
-  heroku_var:mitopen_support_email: "odl-mitopen-rc-support@mit.edu"
-  heroku_var:ocw_base_url: "https://live-qa.ocw.mit.edu/"
-  heroku_var:ocw_content_bucket_name: "ocw-content-storage"
-  heroku_var:ocw_iterator_chunk_size: 300
-  heroku_var:ocw_live_bucket: "ocw-content-live-qa"
-  heroku_var:ocw_next_aws_storage_bucket_name: "ol-ocw-studio-app-qa"
-  heroku_var:opensearch_index: "mitxopen-rc"
-  heroku_var:opensearch_shard_count: 2
-  heroku_var:opensearch_url: "https://search-opensearch-mitopen-qa-nvwau2pbr2nek5dgx2o5w3xju4.us-east-1.es.amazonaws.com"
-  heroku_var:pgbouncer_default_pool_size: 50
-  heroku_var:pgbouncer_max_client_conn: 500
-  heroku_var:pgbouncer_min_pool_size: 20
-  heroku_var:sso_url: "sso-qa.ol.mit.edu"
-  heroku_var:tika_server_endpoint: "https://tika-qa.odl.mit.edu"
+  heroku_app:vars:
+    CELERY_WORKER_MAX_MEMORY_PER_CHILD: 125000
+    DEBUG: false
+    EDX_LEARNING_COURSE_BUCKET_NAME: "edxorg-qa-edxapp-courses"
+    ENABLE_INFINITE_CORRIDOR: true
+    GA_G_TRACKING_ID: ""
+    GA_TRACKING_ID: ""
+    INDEXING_API_USERNAME: "od_mm_rc_api"
+    KEYCLOAK_BASE_URL: "https://sso-qa.ol.mit.edu"
+    KEYCLOAK_REALM_NAME: "olapps"
+    MITOPEN_BASE_URL: "https://mit-open-rc.odl.mit.edu"
+    MITOPEN_COOKIE_DOMAIN: "odl.mit.edu"
+    MITOPEN_COOKIE_NAME: "mitopen-rc"
+    MITOPEN_LOG_LEVEL: "INFO"
+    MITOPEN_SUPPORT_EMAIL: "odl-mitopen-rc-support@mit.edu"
+    OCW_BASE_URL: "https://live-qa.ocw.mit.edu/"
+    OCW_CONTENT_BUCKET_NAME: "ocw-content-storage"
+    OCW_ITERATOR_CHUNK_SIZE: 300
+    OCW_LIVE_BUCKET: "ocw-content-live-qa"
+    OCW_NEXT_AWS_STORAGE_BUCKET_NAME: "ol-ocw-studio-app-qa"
+    OCW_NEXT_BASE_URL: "https://live-qa.ocw.mit.edu"
+    ODIC_ENDPOINT: "https://sso-qa.ol.mit.edu/realms/olapps"
+    OPENSEARCH_INDEX: "mitopen-rc"
+    OPENSEARCH_SHARD_COUNT: 2
+    OPENSEARCH_URL: "https://search-opensearch-mitopen-qa-nvwau2pbr2nek5dgx2o5w3xju4.us-east-1.es.amazonaws.com"
+    PGBOUNCER_DEFAULT_POOL_SIZE: 50
+    PGBOUNER_MAX_CLIENT_CONN: 500
+    PGBOUNER_MIN_POOL_SIZE: 20
+    SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT:
+    TIKA_SERVER_ENDPOING: "https://tika-qa.odl.mit.edu"
+  heroku_app:interpolation_vars:
+    cors_urls:
+    - "https://ocwnext-rc.odl.mit.edu"
+    - "https://ocw-next.netlify.app"
+    - "https://ol-devops-ci.odl.mit.edu"
+    - "https://draft-qa.ocw.mit.edu"
+    - "https://live-qa.ocw.mit.edu"
+    etl_micromasters_host: "micromasters-rc.odl.mit.edu"
+    etl_xpro_host: "rc.xpro.mit.edu"
+    mailgun_sender_domain: "discussions-mail.odl.mit.edu"
+    sso_url: "sso-qa.ol.mit.edu"
   mitopen:db_instance_size: "db.t4g.small"
   mitopen:db_password:
     secure: v1:Xk9oxNvxSQAJUAHE:8CdeLN2SlyhyU0iZpqEX5rnHSJ3PClleDJi2UpzoCsVZ4UjNkr7vCOAKY7CvCuB/7CBKJKM=

--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
@@ -6,6 +6,7 @@ config:
   heroku:user: "odl-devops"
   heroku:app_id:
     secure: v1:eSvnqne7KQRkHJlu:wTyl9W3aivfxlANqBML2wy4GEHe85VuKll60R5HmGUu1hJTcQBEfzK1cJOyvjlbLgBtXLw==
+  heroku_var:celery_worker_max_memory_per_child: 125000
   heroku_var:cors_urls:
   - "https://ocwnext-rc.odl.mit.edu"
   - "https://ocw-next.netlify.app"
@@ -13,31 +14,32 @@ config:
   - "https://draft-qa.ocw.mit.edu"
   - "https://live-qa.ocw.mit.edu"
   heroku_var:debug: false
-  heroku_var:enable_infitite_corridor: true
   heroku_var:edx_learning_course_bucket_name: "edxorg-qa-edxapp-courses"
+  heroku_var:enable_infitite_corridor: true
+  heroku_var:etl_micromasters_host: "micromasters-rc.odl.mit.edu"
+  heroku_var:etl_xpro_host: "rc.xpro.mit.edu"
   heroku_var:ga_g_tracking_id: ""
   heroku_var:ga_tracking_id: ""
   heroku_var:indexing_api_username: "od_mm_rc_api"
   heroku_var:keycloak_base_url: "https://sso-qa.ol.mit.edu"
   heroku_var:keycloak_realm_name: "olapps"
+  heroku_var:log_level: "INFO"
   heroku_var:mailgun_sender_domain: "discussions-mail.odl.mit.edu"
   heroku_var:mitopen_base_url: "https://mit-open-rc.odl.mit.edu"
   heroku_var:mitopen_cookie_domain: "odl.mit.edu"
   heroku_var:mitopen_cookie_name: "mitopen-rc"
-  heroku_var:log_level: "INFO"
   heroku_var:mitopen_support_email: "odl-mitopen-rc-support@mit.edu"
   heroku_var:ocw_base_url: "https://live-qa.ocw.mit.edu/"
   heroku_var:ocw_iterator_chunk_size: 300
   heroku_var:ocw_live_bucket: "ocw-content-live-qa"
-  heroku_var:sso_url: "sso-qa.ol.mit.edu"
   heroku_var:opensearch_index: "mitxopen-rc"
   heroku_var:opensearch_shard_count: 2
   heroku_var:opensearch_url: "https://search-opensearch-mitopen-qa-nvwau2pbr2nek5dgx2o5w3xju4.us-east-1.es.amazonaws.com"
   heroku_var:pgbouncer_default_pool_size: 50
   heroku_var:pgbouncer_max_client_conn: 500
   heroku_var:pgbouncer_min_pool_size: 20
+  heroku_var:sso_url: "sso-qa.ol.mit.edu"
   heroku_var:tika_server_endpoint: "https://tika-qa.odl.mit.edu"
-  heroku_var:celery_worker_max_memory_per_child: 125000
   mitopen:db_instance_size: "db.t4g.small"
   mitopen:db_password:
     secure: v1:Xk9oxNvxSQAJUAHE:8CdeLN2SlyhyU0iZpqEX5rnHSJ3PClleDJi2UpzoCsVZ4UjNkr7vCOAKY7CvCuB/7CBKJKM=

--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
@@ -33,6 +33,7 @@ config:
   heroku_var:ocw_content_bucket_name: "ocw-content-storage"
   heroku_var:ocw_iterator_chunk_size: 300
   heroku_var:ocw_live_bucket: "ocw-content-live-qa"
+  heroku_var:ocw_next_aws_storage_bucket_name: "ol-ocw-studio-app-qa"
   heroku_var:opensearch_index: "mitxopen-rc"
   heroku_var:opensearch_shard_count: 2
   heroku_var:opensearch_url: "https://search-opensearch-mitopen-qa-nvwau2pbr2nek5dgx2o5w3xju4.us-east-1.es.amazonaws.com"

--- a/src/ol_infrastructure/applications/mitopen/__main__.py
+++ b/src/ol_infrastructure/applications/mitopen/__main__.py
@@ -263,7 +263,7 @@ interpolation_vars = heroku_app_config.get_object("interpolation_vars")
 cors_urls_list = interpolation_vars["cors_urls"] or []
 cors_urls_json = json.dumps(cors_urls_list)
 
-heroku_interoplate_vars = {
+heroku_interpolated_vars = {
     "ACCESS_TOKEN_URL": f"https://{interpolation_vars['sso_url']}/realms/olapps/protocol/openid-connect/token",
     "AUTHORIZATION_URL": f"https://{interpolation_vars['sso_url']}/realms/olapps/protocol/openid-connect/auth",
     "CORS_ALLOWED_ORIGINS": cors_urls_json,

--- a/src/ol_infrastructure/applications/mitopen/__main__.py
+++ b/src/ol_infrastructure/applications/mitopen/__main__.py
@@ -273,6 +273,11 @@ heroku_vars = {
     "OCW_CONTENT_BUCKET_NAME": heroku_var_config.require("ocw_content_bucket_name"),
     "OCW_ITERATOR_CHUNK_SIZE": heroku_var_config.require_int("ocw_iterator_chunk_size"),
     "OCW_LIVE_BUCKET": heroku_var_config.require("ocw_live_bucket"),
+    "OCW_NEXT_AWS_STORAGE_BUCKET_NAME": heroku_var_config.require(
+        "ocw_next_aws_storage_bucket_name"
+    ),
+    "OCW_NEXT_BASE_URL": heroku_var_config.require("ocw_base_url"),
+    "OCW_UPLOAD_IMAGE_ONLY": True,
     "OIDC_ENDPOINT": f"https://{heroku_var_config.require('sso_url')}/realms/olapps",
     "OLL_ALT_URL": "https://openlearninglibrary.mit.edu/courses/",
     "OLL_API_ACCESS_TOKEN_URL": "https://openlearninglibrary.mit.edu/oauth2/access_token/",
@@ -404,6 +409,9 @@ sensitive_heroku_vars = {
     ),
     "MITOPEN_EMAIL_USER": secret_operations_global_mit_smtp.data.apply(
         lambda data: "{}".format(data["relay_username"])
+    ),
+    "OCW_NEXT_SEARCH_WEBHOOK_KEY": secret_operations_global_update_search_data_webhook_key.data.apply(
+        lambda data: "{}".format(data["value"])
     ),
     "OCW_WEBHOOK_KEY": secret_operations_global_update_search_data_webhook_key.data.apply(
         lambda data: "{}".format(data["value"])

--- a/src/ol_infrastructure/applications/mitopen/__main__.py
+++ b/src/ol_infrastructure/applications/mitopen/__main__.py
@@ -213,11 +213,6 @@ mitopen_vault_backend = OLVaultDatabaseBackend(mitopen_vault_backend_config)
 # ci, rc, or production
 env_name = stack_info.name.lower() if stack_info.name != "QA" else "rc"
 
-opensearch_stack = StackReference(
-    f"infrastructure.aws.opensearch.mitopen.{stack_info.name}"
-)
-opensearch_endpoint = opensearch_stack.require_output("cluster")["endpoint"]
-
 cors_urls_list = heroku_var_config.get_object("cors_urls") or []
 cors_urls_json = json.dumps(cors_urls_list)
 
@@ -234,7 +229,7 @@ heroku_vars = {
     "CORS_ALLOWED_ORIGIN_REGEXES": "['^.+ocw-next.netlify.app$']",
     "CSAIL_BASE_URL": "https://cap.csail.mit.edu/",
     "DEBUG": heroku_var_config.get_bool("debug") or False,
-    "DUPLICATE_COURSES_URL": "https://raw.githubusercontent.com/mitodl/open-resource-blacklists/master/duplicate_course",
+    "DUPLICATE_COURSES_URL": "https://raw.githubusercontent.com/mitodl/open-resource-blacklists/master/duplicate_courses.yml",
     "EDX_API_ACCESS_TOKEN_URL": "https://api.edx.org/oauth2/v1/access_token",
     "EDX_API_URL": "https://api.edx.org/catalog/v1/catalogs/10/courses",
     "EDX_LEARNING_COURSE_BUCKET_NAME": heroku_var_config.require(
@@ -247,34 +242,35 @@ heroku_vars = {
     "INDEXING_API_USERNAME": heroku_var_config.require("indexing_api_username"),
     "KEYCLOAK_BASE_URL": heroku_var_config.require("keycloak_base_url"),
     "KEYCLOAK_REALM_NAME": heroku_var_config.require("keycloak_realm_name"),
-    "MAILGUN_FROM_EMAIL": f"'MIT Open <no-reply@{heroku_var_config.require('mailgun_sender_domain')}'",
+    "MAILGUN_FROM_EMAIL": f"MIT Open <no-reply@{heroku_var_config.require('mailgun_sender_domain')}",
     "MAILGUN_SENDER_DOMAIN": heroku_var_config.require("mailgun_sender_domain"),
-    "MAILGUN_URL": "https://api.mailgun.net/v3/{heroku_var_config.require('mailgun_sender_domain')}",
-    "MICROMASTERS_CATALOG_API_URL": "https://{{ etl_micromasters_host }}/api/v0/catalog/",
+    "MAILGUN_URL": f"https://api.mailgun.net/v3/{heroku_var_config.require('mailgun_sender_domain')}",
+    "MICROMASTERS_CATALOG_API_URL": f"https://{heroku_var_config.require('etl_micromasters_host')}/api/v0/catalog/",
     "MITOPEN_ADMIN_EMAIL": "cuddle-bunnies@mit.edu",
     "MITOPEN_BASE_URL": heroku_var_config.require("mitopen_base_url"),
     "MITOPEN_COOKIE_DOMAIN": heroku_var_config.require("mitopen_cookie_domain"),
     "MITOPEN_COOKIE_NAME": heroku_var_config.require("mitopen_cookie_name"),
     "MITOPEN_CORS_ORIGIN_WHITELIST": cors_urls_json,
     "MITOPEN_DB_CONN_MAX_AGE": 0,
-    "MITOPEN_DB_DISABLE_SSL": "True",
+    "MITOPEN_DB_DISABLE_SSL": True,
     "MITOPEN_DEFAULT_SITE_KEY": "micromasters",
     "MITOPEN_EMAIL_PORT": 587,
-    "MITOPEN_EMAIL_TLS": "True",
+    "MITOPEN_EMAIL_TLS": True,
     "MITOPEN_ENVIRONMENT": env_name,
     "MITOPEN_FROM_EMAIL": "MITOpen <mitopen-support@mit.edu>",
     "MITOPEN_FRONTPAGE_DIGEST_MAX_POSTS": 10,
     "MITOPEN_LOG_LEVEL": heroku_var_config.get("log_level") or "INFO",
     "MITOPEN_SUPPORT_EMAIL": heroku_var_config.require("mitopen_support_email"),
-    "MITOPEN_USE_S3": "True",
+    "MITOPEN_USE_S3": True,
     "MITPE_BASE_URL": "https://professional.mit.edu/",
     "MITX_ONLINE_BASE_URL": "https://mitxonline.mit.edu/",
     "MITX_ONLINE_COURSES_API_URL": "https://mitxonline.mit.edu/api/courses/",
     "MITX_ONLINE_LEARNING_COURSE_BUCKET_NAME": "mitx-etl-mitxonline-production",
     "MITX_ONLINE_PROGRAMS_API_URL": "https://mitxonline.mit.edu/api/programs/",
     "NEW_RELIC_LOG": "stdout",
-    "NODE_MODULES_CACHE": "False",
+    "NODE_MODULES_CACHE": False,
     "OCW_BASE_URL": heroku_var_config.require("ocw_base_url"),
+    "OCW_CONTENT_BUCKET_NAME": heroku_var_config.require("ocw_content_bucket_name"),
     "OCW_ITERATOR_CHUNK_SIZE": heroku_var_config.require_int("ocw_iterator_chunk_size"),
     "OCW_LIVE_BUCKET": heroku_var_config.require("ocw_live_bucket"),
     "OIDC_ENDPOINT": f"https://{heroku_var_config.require('sso_url')}/realms/olapps",
@@ -286,7 +282,7 @@ heroku_vars = {
     "OPENSEARCH_INDEX": heroku_var_config.require("opensearch_index"),
     "OPENSEARCH_INDEXING_CHUNK_SIZE": 75,
     "OPENSEARCH_SHARD_COUNT": heroku_var_config.get_int("opensearch_shard_count") or 2,
-    "OPENSEARCH_URL": f"https://{opensearch_endpoint}",
+    "OPENSEARCH_URL": heroku_var_config.require("opensearch_url"),
     "PGBOUNCER_DEFAULT_POOL_SIZE": heroku_var_config.get_int(
         "pgbouncer_default_pool_size"
     )
@@ -301,8 +297,8 @@ heroku_vars = {
     "SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT": f"https://{heroku_var_config.require('sso_url')}/realms/olapps",
     "TIKA_SERVER_ENDPOINT": heroku_var_config.require("tika_server_endpoint"),
     "USERINFO_URL": f"https://{heroku_var_config.require('sso_url')}/realms/olapps/protocol/openid-connect/userinfo",
-    "USE_X_FORWARDED_HOST": "True",
-    "USE_X_FORWARDED_PORT": "True",
+    "USE_X_FORWARDED_HOST": True,
+    "USE_X_FORWARDED_PORT": True,
     "XPRO_CATALOG_API_URL": f"https://{heroku_var_config.require('etl_xpro_host')}/api/programs/",
     "XPRO_COURSES_API_URL": f"https://{heroku_var_config.require('etl_xpro_host')}/api/courses/",
     "XPRO_LEARNING_COURSE_BUCKET_NAME": "mitx-etl-xpro-production-mitxpro-production",

--- a/src/ol_infrastructure/applications/mitopen/__main__.py
+++ b/src/ol_infrastructure/applications/mitopen/__main__.py
@@ -281,7 +281,7 @@ heroku_interoplate_vars = {
 }
 
 # Combine two var sources above with values explictly defined in pulumi configuration
-heroku_vars.update(**heroku_interoplate_vars)
+heroku_vars.update(**heroku_interpolated_vars)
 heroku_vars.update(**heroku_app_config.get_object("vars"))
 
 # Making these `get_secret_*()` calls children of the seemigly un-related vault mount `secret-mitopen/` tricks

--- a/src/ol_infrastructure/lib/heroku.py
+++ b/src/ol_infrastructure/lib/heroku.py
@@ -1,0 +1,35 @@
+from functools import lru_cache, partial
+from pathlib import Path
+
+import pulumi
+import pulumiverse_heroku
+from bridge.secrets.sops import read_yaml_secrets
+
+
+@lru_cache
+def get_heroku_provider(heroku_user: str) -> pulumi.ResourceTransformationResult:
+    heroku_api_key = read_yaml_secrets(
+        Path().joinpath("heroku", f"secrets.{heroku_user}.yaml")
+    )["apiKey"]
+    return pulumiverse_heroku.Provider(
+        resource_name=f"ol-heroku-provider-{heroku_user}",
+        api_key=heroku_api_key,
+    )
+
+
+def set_heroku_provider(
+    heroku_user: str, resource_args: pulumi.ResourceTransformationArgs
+) -> pulumi.ResourceTransformationResult:
+    if resource_args.type_.split(":")[0] == "heroku":
+        resource_args.opts.provider = get_heroku_provider(heroku_user)
+    return pulumi.ResourceTransformationResult(
+        props=resource_args.props,
+        opts=resource_args.opts,
+    )
+
+
+def setup_heroku_provider():
+    heroku_user = pulumi.Config("heroku").get("user") or "odl-devops"
+    pulumi.runtime.register_stack_transformation(
+        partial(set_heroku_provider, heroku_user)
+    )


### PR DESCRIPTION
### What are the relevant tickets?
Partially addresses #2074 

### Description (What does it do?)
This implements management of all configuration vars in heroku for MITOpen-QA with Pulumi rather than SaltStac 

### How can this be tested?
`pr pulumi up --refresh -s applications.mitopen.QA` 

