### PR TITLE
Revert "chore(deps): update python docker tag"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim as build
+FROM python:3.11-slim as build
 RUN apt-get update -yqq && apt-get install -yqq curl  && useradd -m app
 USER app
 RUN mkdir /home/app/workspace && chown app:app /home/app/workspace
@@ -15,7 +15,7 @@ RUN scripts/get-pants.sh -d bin &&\
     poetry export --without-hashes -o requirements.txt &&\
     pip install --no-cache-dir -r requirements.txt
 
-FROM python:3.12-slim
+FROM python:3.11-slim
 RUN useradd -m app
 USER app
 COPY --from=build /home/app/.local/ /usr/local/

--- a/dockerfiles/openedx-edxapp/Dockerfile
+++ b/dockerfiles/openedx-edxapp/Dockerfile
@@ -6,7 +6,7 @@
 # This dockerfile is not expected to work locally. Only executes correctly within the context
 # of its concourse pipeline.
 
-FROM --platform=linux/amd64 python:3.11.4-buster as base
+FROM --platform=linux/amd64 python:3.8.12-buster as base
 
 ENV DEBIAN_FRONTEND=noninteractive
 COPY ./apt-pkg-list /root/

--- a/dockerfiles/openedx-notes/Dockerfile
+++ b/dockerfiles/openedx-notes/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.8-slim
 
 ARG APP_USER_ID=1000
 RUN apt update && \


### PR DESCRIPTION
Reverts mitodl/ol-infrastructure#2105

The Python versions set in these dockerfiles are not currently supported by the affected applications.