### PR TITLE
Revert "chore(deps): update docker.io/ruby docker tag to v3.3"

### DIFF
--- a/dockerfiles/openedx-forum/Dockerfile
+++ b/dockerfiles/openedx-forum/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/ruby:3.3-slim-bullseye
+FROM docker.io/ruby:3.0-slim-bullseye
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && \
   apt upgrade -y && \


### PR DESCRIPTION
Reverts mitodl/ol-infrastructure#2104

This version of Ruby isn't supported yet by the edX forum application.