### PR TITLE
can-kick-fix: lease duration for pulumi-heroku-configvars

### DIFF
--- a/src/ol_infrastructure/applications/mitopen/__main__.py
+++ b/src/ol_infrastructure/applications/mitopen/__main__.py
@@ -23,7 +23,7 @@ from ol_infrastructure.lib.pulumi_helper import parse_stack
 from ol_infrastructure.lib.stack_defaults import defaults
 from ol_infrastructure.lib.vault import setup_vault_provider
 
-setup_vault_provider()
+setup_vault_provider(skip_child_token=True)
 setup_heroku_provider()
 
 mitopen_config = Config("mitopen")


### PR DESCRIPTION


### What are the relevant tickets?
Relates #2074 
Relates #2117 

### Description (What does it do?)
Added a flag to enable  when creating the vault provider for a pulumi stack.

Verified that leases don't expire after 20 minutes now and credentials hang around as expected. 