### PR TITLE
fix: 21L-705S14 ocw redirect

### DIFF
--- a/src/ol_infrastructure/applications/ocw_site/redirect_dict.json
+++ b/src/ol_infrastructure/applications/ocw_site/redirect_dict.json
@@ -109,7 +109,7 @@
   "/21L-432S03": "307|keep|https://{{AK_HOSTHEADER}}/courses/literature/21l-432-understanding-television-spring-2003/",
   "/21L-432S08": "307|keep|https://{{AK_HOSTHEADER}}/courses/literature/21l-432-understanding-television-spring-2003/",
   "/21L-448JF10": "307|keep|https://{{AK_HOSTHEADER}}/courses/literature/21l-448j-darwin-and-design-fall-2010/",
-  "/21L-705S14": "307|keep|https://{{AK_HOSTHEADER}}/courses/literature/21l-705-major-authors-old-english-and-beowulf-spring-2014/",
+  "/21L-705S14": "301|keep|https://{{AK_HOSTHEADER}}/courses/21l-601j-old-english-and-beowulf-spring-2023/",
   "/21M-235F14": "307|discard|https://{{AK_HOSTHEADER}}/courses/music-and-theater-arts/21m-235-monteverdi-to-mozart-1600-1800-fall-2013/",
   "/21M-250S14": "307|keep|https://{{AK_HOSTHEADER}}/courses/music-and-theater-arts/21m-250-beethoven-to-mahler-spring-2014/",
   "/21M-303S09": "307|keep|https://{{AK_HOSTHEADER}}/courses/music-and-theater-arts/21m-303-writing-in-tonal-forms-i-spring-2009/",


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/3434

### Description (What does it do?)

This PR updates the redirect for resource `/21L-705S14` according to the specifications in https://github.com/mitodl/hq/issues/3434.


### How can this be tested?

This will be tested on RC.

1. Open [https://live-qa.ocw.mit.edu/21L-705S14](https://live-qa.ocw.mit.edu/21L-705S14).
2. Expect to be redirected to [https://live-qa.ocw.mit.edu/courses/21l-601j-old-english-and-beowulf-spring-2023/](https://ocw.mit.edu/courses/21l-601j-old-english-and-beowulf-spring-2023/)

