### PR TITLE
config: update logo URLs for xPRO

### DIFF
--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -55,6 +55,7 @@ class OpenEdxVars(BaseModel):
     support_url: str
     terms_of_service_url: str
     trademark_text: Optional[str] = None
+    logo_trademark_url: Optional[str] = None
 
     @property
     def release_name(self) -> OpenEdxSupportedRelease:
@@ -86,7 +87,7 @@ def mfe_params(
         "LOGIN_URL": f"https://{open_edx.lms_domain}/login",
         "LOGOUT_URL": f"https://{open_edx.lms_domain}/logout",
         "LOGO_ALT_TEXT": None,
-        "LOGO_TRADEMARK_URL": open_edx.logo_url,
+        "LOGO_TRADEMARK_URL": open_edx.logo_trademark_url or open_edx.logo_url,
         "LOGO_URL": open_edx.logo_url,
         "LOGO_WHITE_URL": open_edx.logo_url,
         "MARKETING_SITE_BASE_URL": f"https://{open_edx.marketing_site_domain}",

--- a/src/ol_concourse/pipelines/open_edx/mfe/values.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/values.py
@@ -144,7 +144,7 @@ xpro = [
         favicon_url="https://raw.githubusercontent.com/mitodl/mitxpro-theme/master/lms/static/images/favicon.ico",
         honor_code_url="https://ci.xpro.mit.edu/honor-code/",
         lms_domain="courses-ci.xpro.mit.edu",
-        logo_url="https://raw.githubusercontent.com/mitodl/mitxpro-theme/master/lms/static/images/logo.png",
+        logo_url="https://raw.githubusercontent.com/mitodl/mitxpro-theme/master/lms/static/images/logo.svg",
         marketing_site_domain="ci.xpro.mit.edu",
         privacy_policy_url="https://ci.xpro.mit.edu/privacy-policy/",
         site_name="MIT xPRO CI",
@@ -152,6 +152,7 @@ xpro = [
         support_url="xpro.zendesk.com/hc",
         terms_of_service_url="https://ci.xpro.mit.edu/terms-of-service/",
         trademark_text="© MIT xPRO. All rights reserved except where noted.",
+        logo_trademark_url="https://raw.githubusercontent.com/mitodl/mitxpro-theme/master/lms/static/images/mit-ol-logo.svg",
     ),
     OpenEdxVars(
         about_us_url="https://rc.xpro.mit.edu/about-us/",
@@ -163,7 +164,7 @@ xpro = [
         favicon_url="https://raw.githubusercontent.com/mitodl/mitxpro-theme/master/lms/static/images/favicon.ico",
         honor_code_url="https://rc.xpro.mit.edu/honor-code/",
         lms_domain="courses-rc.xpro.mit.edu",
-        logo_url="https://raw.githubusercontent.com/mitodl/mitxpro-theme/master/lms/static/images/logo.png",
+        logo_url="https://raw.githubusercontent.com/mitodl/mitxpro-theme/master/lms/static/images/logo.svg",
         marketing_site_domain="rc.xpro.mit.edu",
         privacy_policy_url="https://rc.xpro.mit.edu/privacy-policy/",
         site_name="MIT xPRO RC",
@@ -171,6 +172,7 @@ xpro = [
         support_url="xpro.zendesk.com/hc",
         terms_of_service_url="https://rc.xpro.mit.edu/terms-of-service/",
         trademark_text="© MIT xPRO. All rights reserved except where noted.",
+        logo_trademark_url="https://raw.githubusercontent.com/mitodl/mitxpro-theme/master/lms/static/images/mit-ol-logo.svg",
     ),
     OpenEdxVars(
         about_us_url="https://xpro.mit.edu/about-us/",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/3209

### Description (What does it do?)
- Updates the Logo URL config for xPRO CI and RC
- Added a new config variable for the footer logo


### Screenshots (if appropriate):
- Check the logos on https://github.com/mitodl/mitxpro-theme/pull/58

### How can this be tested?

**Reviewer Note:**

**This is how I'm expecting this to work:**
- After the deployment of this on the QA instance we see the latest xPRO logo on the Instructor Dashboard and other legacy pages
- Latest logo on MFEs
- Updated `Open Learning` logo on the footer


**NOTE 2:**
This will be deployed along with the theme update https://github.com/mitodl/mitxpro-theme/pull/58
