### PR TITLE
config: enable teams app in course authoring MFE (MITx Online)

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
@@ -18,6 +18,7 @@ config:
   - ["seo.enable_anonymous_courseware_access", "--create", "--superusers", "--staff",
     "--authenticated"]
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
+  - ["teams.enable_teams_app", "--create", "--superusers", "--staff"]
   edxapp:business_unit: mitxonline
   edxapp:db_password:
     secure: v1:Za4LI6RKfAW7jLJh:hlthF86wmGH6VSiBHgehE8mY11hDfOUK/uYZADbodhCVuS8RSXoCoHtrRrBDNMXunQmHLABw4SM=

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
@@ -21,6 +21,7 @@ config:
   - ["seo.enable_anonymous_courseware_access", "--create", "--superusers", "--staff",
     "--authenticated"]
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
+  - ["teams.enable_teams_app", "--create", "--superusers", "--staff"]
   edxapp:business_unit: mitxonline
   edxapp:db_password:
     secure: v1:xHUw5WC3aN02zuAj:0BozwDxrtF0OA7wkYuv4R4CCnSHYdgXt+vi6/3eP9zwJgHgQO20+8sQfg7rXPC9SIUobEA==


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/3469 & comment https://github.com/mitodl/hq/issues/3469#issuecomment-1930115629

### Description (What does it do?)
- This flag enables the `Teams` app in course authoring MFE - `Pages & resources`


### Screenshots (if appropriate):
We should see a Teams settings tab in `Resouces and Pages`. It should look like:
<img width="1120" alt="image" src="https://github.com/mitodl/ol-infrastructure/assets/34372316/2ca3516d-d2d5-43f3-b443-6a13e9e2f413">

### How can this be tested?
- Once deployed, Open any course in https://studio-qa.mitxonline.mit.edu/.
- Click `Content`-> `Pages & Resources`
- Confirm that you see the `Teams` settings tab
