### PR TITLE
config: add logo_url and trademark_logo_url for platform (xPRO)

### DIFF
--- a/src/bilder/images/edxapp_v2/templates/edxapp/xpro/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/xpro/common_values.yml.tmpl
@@ -371,6 +371,8 @@ LOGIN_REDIRECT_WHITELIST:  # MODIFIED
   - {{ key "edxapp/preview-domain" }}
   - {{ key "edxapp/marketing-domain" }}
 LOG_DIR: /openedx/data/var/log/edx
+LOGO_URL: https://raw.githubusercontent.com/mitodl/mitxpro-theme/master/lms/static/images/logo.svg
+LOGO_TRADEMARK_URL: https://raw.githubusercontent.com/mitodl/mitxpro-theme/master/lms/static/images/mit-ol-logo.svg
 MAINTENANCE_BANNER_TEXT: Sample banner message
 MARKETING_SITE_BASE_URL: https://{{ key "edxapp/marketing-domain" }}/ # ADDED - to support xpro-theme
 XPRO_BASE_URL: https://{{ key "edxapp/marketing-domain" }}/ # ADDED - to support xpro-theme


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/3409

### Description (What does it do?)
- We recently added logo URLs in https://github.com/mitodl/ol-infrastructure/pull/2135. But these were only added and reflected in MFEs, We need these in edx-platform(legacy) as well. And that's why we couldn't verify the trademark footer logo as per [this Figma Link](https://www.figma.com/file/a8CIg9kGp9jEmkA0BmOFOv/MIT-xPRO-Logo-Update?node-id=73%3A504&mode=dev)

### Screenshots (if appropriate):

### How can this be tested?
Once deployed:
1. We should see the Open Learning Logo in the footer of (e.g. Progress page)
2. We should see the header logo is loaded from the added `LOGO_URL`

