### PR TITLE
Concourse publishing pipeline for open-api-clients

### DIFF
--- a/src/ol_concourse/pipelines/libraries/open_api_clients.py
+++ b/src/ol_concourse/pipelines/libraries/open_api_clients.py
@@ -1,0 +1,232 @@
+import sys
+from pathlib import Path
+
+from ol_concourse.lib.models.pipeline import (
+    Command,
+    GetStep,
+    Identifier,
+    InParallelStep,
+    Input,
+    Job,
+    Output,
+    Pipeline,
+    PutStep,
+    Resource,
+    TaskConfig,
+    TaskStep,
+)
+from ol_concourse.lib.resources import git_repo, ssh_git_repo
+
+
+def _read_script(script_name: str) -> str:
+    return (Path(__file__).parent / "scripts" / script_name).read_text()
+
+
+git_image = Resource(
+    name=Identifier("git-image"),
+    type="docker-image",
+    source={
+        "repository": "concourse/buildroot",
+        "tag": "git",
+    },
+)
+openapi_generator_image = Resource(
+    name=Identifier("openapi-generator-image"),
+    type="registry-image",
+    icon="docker",
+    source={
+        "repository": "openapitools/openapi-generator-cli",
+        "tag": "v7.2.0",
+    },
+)
+python_image = Resource(
+    name=Identifier("python-image"),
+    type="registry-image",
+    icon="docker",
+    source={
+        "repository": "python",
+        "tag": "3.11-slim",
+    },
+)
+node_image = Resource(
+    name=Identifier("node-image"),
+    type="registry-image",
+    icon="docker",
+    source={
+        "repository": "node",
+        "tag": "18-slim",
+    },
+)
+
+mit_open_repository = git_repo(
+    name=Identifier("mit-open"),
+    uri="https://github.com/mitodl/mit-open",
+    branch="release",
+    paths=["openapi/specs/*.yaml"],
+)
+mit_open_api_clients_repository = ssh_git_repo(
+    name=Identifier("mit-open-api-clients"),
+    uri="git@github.com/mitodl/open-api-clients.git",
+    branch="main",
+    private_key="((git-private-key))",
+)
+
+generate_clients_job = Job(
+    name=Identifier("generate-clients"),
+    plan=[
+        InParallelStep(
+            in_parallel=[
+                GetStep(get=git_image.name),
+                GetStep(get=openapi_generator_image.name),
+                GetStep(get=mit_open_repository.name, trigger=True),
+                GetStep(get=mit_open_api_clients_repository.name, trigger=True),
+            ]
+        ),
+        TaskStep(
+            task=Identifier("generate-apis"),
+            image=openapi_generator_image.name,
+            config=TaskConfig(
+                platform="linux",
+                inputs=[
+                    Input(name=mit_open_repository.name),
+                    Input(name=mit_open_api_clients_repository.name),
+                ],
+                outputs=[Output(name=mit_open_api_clients_repository.name)],
+                run=Command(
+                    path="/bin/bash",
+                    args=["open-api-clients/scripts/generate-inner.sh"],
+                ),
+            ),
+        ),
+        TaskStep(
+            task="git-commit",
+            image=git_image.name,
+            config=TaskConfig(
+                platform="linux",
+                inputs=[
+                    Input(name=mit_open_repository.name),
+                    Input(name=mit_open_api_clients_repository.name),
+                ],
+                outputs=[Output(name=mit_open_api_clients_repository.name)],
+                run=Command(
+                    path="/bin/bash",
+                    args=[
+                        "-exc",
+                        _read_script("open-api-clients-commit-changes.sh"),
+                    ],
+                ),
+            ),
+        ),
+        PutStep(
+            put=mit_open_api_clients_repository.name,
+            params={"repository": mit_open_api_clients_repository.name},
+        ),
+    ],
+)
+
+create_release_job = Job(
+    name="create-release",
+    plan=[
+        InParallelStep(
+            in_parallel=[
+                GetStep(get=git_image.name),
+                GetStep(get=python_image.name),
+                GetStep(
+                    get=mit_open_api_clients_repository.name,
+                    passed=[generate_clients_job.name],
+                    trigger=True,
+                ),
+            ]
+        ),
+        TaskStep(
+            task="bump-version",
+            image=python_image.name,
+            config=TaskConfig(
+                platform="linux",
+                inputs=[Input(name=mit_open_api_clients_repository.name)],
+                outputs=[Output(name=mit_open_api_clients_repository.name)],
+                run=Command(
+                    path="/bin/bash",
+                    args=["-exc", _read_script("open-api-clients-bumpver.sh")],
+                ),
+            ),
+        ),
+        TaskStep(
+            task="git-commit-and-tag",
+            image=git_image.name,
+            config=TaskConfig(
+                platform="linux",
+                inputs=[
+                    Input(name=mit_open_repository.name),
+                    Input(name=mit_open_api_clients_repository.name),
+                ],
+                outputs=[Output(name=mit_open_api_clients_repository.name)],
+                run=Command(
+                    path="/bin/bash",
+                    args=[
+                        "-exc",
+                        _read_script("open-api-clients-tag-release.sh"),
+                    ],
+                ),
+            ),
+        ),
+        PutStep(
+            put=mit_open_api_clients_repository.name,
+            params={"repository": mit_open_api_clients_repository.name},
+        ),
+    ],
+)
+
+publish_job = Job(
+    name="publish",
+    plan=[
+        InParallelStep(
+            in_parallel=[
+                GetStep(get=node_image.name),
+                GetStep(
+                    get=mit_open_api_clients_repository.name,
+                    passed=[create_release_job.name],
+                    trigger=True,
+                ),
+            ]
+        ),
+        TaskStep(
+            task="publish-node",
+            image=node_image.name,
+            config=TaskConfig(
+                platform="linux",
+                inputs=[Input(name=mit_open_api_clients_repository.name)],
+                params={"NPM_TOKEN": "((npm.auth_token))"},
+                run=Command(
+                    path="/bin/bash",
+                    dir="open-api-clients/src/typescript/mit-open-api-axios",
+                    args=["-exc", _read_script("open-api-clients-publish-node.sh")],
+                ),
+            ),
+        ),
+    ],
+)
+
+build_pipeline = Pipeline(
+    resources=[
+        git_image,
+        openapi_generator_image,
+        python_image,
+        node_image,
+        mit_open_repository,
+        mit_open_api_clients_repository,
+    ],
+    jobs=[
+        generate_clients_job,
+        create_release_job,
+        publish_job,
+    ],
+)
+
+if __name__ == "__main__":
+    with open("definition.json", "w") as definition:  # noqa: PTH123
+        definition.write(build_pipeline.model_dump_json(indent=2))
+    sys.stdout.write(build_pipeline.model_dump_json(indent=2))
+    sys.stdout.write(
+        "fly -t <prod_target> set-pipeline -p open-api-clients -c definition.json"
+    )

--- a/src/ol_concourse/pipelines/libraries/scripts/open-api-clients-bumpver.sh
+++ b/src/ol_concourse/pipelines/libraries/scripts/open-api-clients-bumpver.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+pip install bumpver
+
+bumpver update

--- a/src/ol_concourse/pipelines/libraries/scripts/open-api-clients-commit-changes.sh
+++ b/src/ol_concourse/pipelines/libraries/scripts/open-api-clients-commit-changes.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Commmit the updated clients w/ a commit message referencing
+# the mit-open commit we generated it from.
+
+pushd mit-open || return 1
+
+OPEN_REV="$(git rev-parse --short HEAD)"
+
+popd || return 2
+pushd open-api-clients || return 3
+
+# only src/ files are expected to be modified
+git add src/
+
+git status
+
+git config --global user.name "MIT Open Learning Engineering"
+git config --global user.email "oldevops@mit.edu"
+
+git commit -m "Generated clients from rev: $OPEN_REV"

--- a/src/ol_concourse/pipelines/libraries/scripts/open-api-clients-publish-node.sh
+++ b/src/ol_concourse/pipelines/libraries/scripts/open-api-clients-publish-node.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# publish the npm package to npmjs.org
+
+yarn build
+yarn npm publish

--- a/src/ol_concourse/pipelines/libraries/scripts/open-api-clients-tag-release.sh
+++ b/src/ol_concourse/pipelines/libraries/scripts/open-api-clients-tag-release.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Commit the updated version and tag it
+
+VERSION=$(cat VERSION)
+
+git add .
+git status
+
+git config --global user.name "MIT Open Learning Engineering"
+git config --global user.email "oldevops@mit.edu"
+
+git commit -m "Release: $VERSION"
+
+git tag "v$VERSION"


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/mit-open/issues/269

### Description (What does it do?)
<!--- Describe your changes in detail -->
This implements a Concourse pipeline that generates new versions of API clients of MIT Open and publishes them.

- Triggers only when a change occurs:
  - In the OpenAPI specs in the mit-open repo's `release` (production) branch.
  - In the open-api-clients repo itself.
- The version gets bumped automatically using [bumpver](https://pypi.org/project/bumpver/) and a date-based versioning scheme.
- We're only currently generating a release to npm

I'm less than sure about how I setup the credentials, but it's an educated attempt based on what else I see in the repo. I'm also unsure if there's other work that has to be done to get values into concourse itself.

### Screenshots (if appropriate):
![Screenshot 2024-02-12 at 16-01-32 api-clients-release - Concourse](https://github.com/mitodl/ol-infrastructure/assets/28598/4ad75a97-dc40-41bd-89d5-2dae9bc65f52)
(ignore that these are all failing at the time of screenshot)

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
You can run this locally, although I haven't tested this personally with the credentials parts as I'm unsure how to set that up locally.
