### PR TITLE
Add an automatic daily run to the Concourse instance refresh pipeline

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/concourse/instance_refresh.py
+++ b/src/ol_concourse/pipelines/infrastructure/concourse/instance_refresh.py
@@ -1,7 +1,14 @@
 import sys
 
 from ol_concourse.lib.models.fragment import PipelineFragment
-from ol_concourse.lib.models.pipeline import GroupConfig, Job, Pipeline
+from ol_concourse.lib.models.pipeline import (
+    GetStep,
+    GroupConfig,
+    Identifier,
+    Job,
+    Pipeline,
+)
+from ol_concourse.lib.resources import schedule
 from ol_concourse.lib.tasks import (
     block_for_instance_refresh_task,
     instance_refresh_task,
@@ -9,6 +16,8 @@ from ol_concourse.lib.tasks import (
 
 environments = ["ci", "qa", "production"]
 node_classes = ["worker-infra", "worker-ocw", "worker-generic", "web"]
+
+build_schedule = schedule(Identifier("build-schedule"), "24h")
 
 jobs = []
 group_configs = []
@@ -20,6 +29,7 @@ for env in environments:
         refresh_job = Job(
             name=f"{env}-{node_class}-instance-refresh",
             plan=[
+                GetStep(get=build_schedule.name, trigger=True),
                 instance_refresh_task(filters=filter_template, queries=query),
                 block_for_instance_refresh_task(
                     filters=filter_template, queries=query, check_freq=10
@@ -47,6 +57,7 @@ instance_refresh_pipeline = Pipeline(
     jobs=instance_refresh_pipeline_fragment.jobs,
     groups=group_configs,
 )
+
 
 if __name__ == "__main__":
     with open("definition.json", "w") as definition:  # noqa: PTH123

--- a/src/ol_concourse/pipelines/infrastructure/concourse/instance_refresh.py
+++ b/src/ol_concourse/pipelines/infrastructure/concourse/instance_refresh.py
@@ -58,7 +58,6 @@ instance_refresh_pipeline = Pipeline(
     groups=group_configs,
 )
 
-
 if __name__ == "__main__":
     with open("definition.json", "w") as definition:  # noqa: PTH123
         definition.write(instance_refresh_pipeline.model_dump_json(indent=2))


### PR DESCRIPTION
Add daily automatic instance refresh run for concourse workers.

### What are the relevant tickets?
#2164 

### Description (What does it do?)
<!--- Describe your changes in detail -->
What it says on the tin :) Makes the Concourse worker instance refresh happen daily automatically.

### How can this be tested?
Build the pipeline from this definition and wait a day.
