### PR TITLE
Fix: Add a 3AM start time to instance refresh.

### DIFF
--- a/src/ol_concourse/lib/resources.py
+++ b/src/ol_concourse/lib/resources.py
@@ -216,12 +216,17 @@ def pypi(
     )
 
 
-def schedule(name: Identifier, interval: str, start: Optional[str] = None) -> Resource:
+def schedule(
+    name: Identifier,
+    interval: str,
+    start: Optional[str] = None,
+    stop: Optional[str] = None,
+) -> Resource:
     return Resource(
         name=name,
         type="time",
         icon="clock",
-        source={"interval": interval, "start": start},
+        source={"interval": interval, "start": start, "stop": stop},
     )
 
 

--- a/src/ol_concourse/lib/resources.py
+++ b/src/ol_concourse/lib/resources.py
@@ -216,12 +216,12 @@ def pypi(
     )
 
 
-def schedule(name: Identifier, interval: str) -> Resource:
+def schedule(name: Identifier, interval: str, start: Optional[str] = None) -> Resource:
     return Resource(
         name=name,
         type="time",
         icon="clock",
-        source={"interval": interval},
+        source={"interval": interval, "start": start},
     )
 
 

--- a/src/ol_concourse/pipelines/infrastructure/concourse/instance_refresh.py
+++ b/src/ol_concourse/pipelines/infrastructure/concourse/instance_refresh.py
@@ -17,7 +17,8 @@ from ol_concourse.lib.tasks import (
 environments = ["ci", "qa", "production"]
 node_classes = ["worker-infra", "worker-ocw", "worker-generic", "web"]
 
-build_schedule = schedule(Identifier("build-schedule"), "24h")
+# According to Google 08:00 UTC = 03:00 EST.
+build_schedule = schedule(Identifier("build-schedule"), interval="24h", start="08:00")
 
 jobs = []
 group_configs = []

--- a/src/ol_concourse/pipelines/infrastructure/concourse/instance_refresh.py
+++ b/src/ol_concourse/pipelines/infrastructure/concourse/instance_refresh.py
@@ -18,7 +18,9 @@ environments = ["ci", "qa", "production"]
 node_classes = ["worker-infra", "worker-ocw", "worker-generic", "web"]
 
 # According to Google 08:00 UTC = 03:00 EST.
-build_schedule = schedule(Identifier("build-schedule"), interval="24h", start="08:00")
+build_schedule = schedule(
+    Identifier("build-schedule"), interval="24h", start="08:00", stop="11:00"
+)
 
 jobs = []
 group_configs = []


### PR DESCRIPTION
### What are the relevant tickets?
Fixes #2164 

### Description (What does it do?)
Adds a 3AM start time to the instance refresh task.