### PR TITLE
Enable flag EMAIL_USE_COURSE_ID_FROM_FOR_BULK for QA instance only

### DIFF
--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -139,7 +139,8 @@ BLOCK_STRUCTURES_SETTINGS:
     TASK_MAX_RETRIES: 5
 BRANCH_IO_KEY: ''
 BUGS_EMAIL: odl-devops@mit.edu  # MODIFIED
-EMAIL_USE_DEFAULT_FROM_FOR_BULK: true
+EMAIL_USE_DEFAULT_FROM_FOR_BULK: true # Can be removed. It's renamed https://github.com/openedx/edx-platform/pull/29001
+EMAIL_USE_COURSE_ID_FROM_FOR_BULK: {{ keyOrDefault "edxapp/email-use-course-id-from-for-bulk" "false" }}
 BULK_EMAIL_EMAILS_PER_TASK: 500
 BULK_EMAIL_LOG_SENT_EMAILS: false
 BULK_EMAIL_DEFAULT_FROM_EMAIL: {{ key "edxapp/sender-email-address" }} # ADDED

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
@@ -46,6 +46,7 @@ config:
   edxapp:mail_domain: edxapp-mail-qa.mitxonline.mit.edu
   edxapp:proctortrack_url: https://preproduction.verificient.com
   edxapp:sender_email_address: support@edxapp-mail-qa.mitxonline.mit.edu
+  edxapp:email_use_course_id_from_for_bulk: "True"
   edxapp:framework: "earthly"
   edxapp:web_node_capacity: "3"
   edxapp:worker_node_capacity: "5"

--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -912,6 +912,9 @@ consul_kv_data = {
     "s3-grades-bucket": grades_bucket_name,
     "s3-storage-bucket": storage_bucket_name,
     "sender-email-address": edxapp_config.require("sender_email_address"),
+    "email-use-course-id-from-for-bulk":  (
+        "true" if edxapp_config.get_bool("email_use_course_id_from_for_bulk") else "false"
+    ),
     "ses-configuration-set": f"edxapp-{env_name}",
     "ses-mail-domain": edxapp_mail_domain,
     "session-cookie-domain": ".{}".format(edxapp_domains["lms"].split(".", 1)[-1]),

--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -912,8 +912,10 @@ consul_kv_data = {
     "s3-grades-bucket": grades_bucket_name,
     "s3-storage-bucket": storage_bucket_name,
     "sender-email-address": edxapp_config.require("sender_email_address"),
-    "email-use-course-id-from-for-bulk":  (
-        "true" if edxapp_config.get_bool("email_use_course_id_from_for_bulk") else "false"
+    "email-use-course-id-from-for-bulk": (
+        "true"
+        if edxapp_config.get_bool("email_use_course_id_from_for_bulk")
+        else "false"
     ),
     "ses-configuration-set": f"edxapp-{env_name}",
     "ses-mail-domain": edxapp_mail_domain,


### PR DESCRIPTION
### What are the relevant tickets?
[#669](https://github.com/mitodl/hq/issues/669)

### Description (What does it do?)
Enable flag `EMAIL_USE_COURSE_ID_FROM_FOR_BULK` for QA instance only to test the use of the email from address in the CourseEmail, if it is present, otherwise compute it.
**Note: Do not enable this flag for any other instances besides QA.**

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
