### PR TITLE
Adding setting for mit-open SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS

### DIFF
--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.Production.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.Production.yaml
@@ -7,6 +7,8 @@ config:
     secure: v1:mdVwWs7IkyH7o5j7:49eMfOoVshilsOCouixsxdQSGehSeqRHF3DhPWp2UIiE1clEoyoKqOodkpBQ27rik/MIDg==
   heroku:user: "odl-devops"
   heroku_app:interpolation_vars:
+    auth_allowed_redirect_hosts:
+    - "ocw.mit.edu"
     cors_urls:
     - "https://ocw-preview.odl.mit.edu"
     - "https://draft.ocw.mit.edu"

--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
@@ -35,6 +35,8 @@ config:
     SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT:
     TIKA_SERVER_ENDPOINT: "https://tika-qa.odl.mit.edu"
   heroku_app:interpolation_vars:
+    auth_allowed_redirect_hosts:
+    - "ocwnext-rc.odl.mit.edu"
     cors_urls:
     - "https://ocwnext-rc.odl.mit.edu"
     - "https://ocw-next.netlify.app"

--- a/src/ol_infrastructure/applications/mitopen/__main__.py
+++ b/src/ol_infrastructure/applications/mitopen/__main__.py
@@ -262,6 +262,10 @@ interpolation_vars = heroku_app_config.get_object("interpolation_vars")
 
 cors_urls_list = interpolation_vars["cors_urls"] or []
 cors_urls_json = json.dumps(cors_urls_list)
+auth_allowed_redirect_hosts_list = (
+    interpolation_vars["auth_allowed_redirect_hosts"] or []
+)
+auth_allowed_redirect_hosts_json = json.dumps(auth_allowed_redirect_hosts_list)
 
 heroku_interpolated_vars = {
     "ACCESS_TOKEN_URL": f"https://{interpolation_vars['sso_url']}/realms/olapps/protocol/openid-connect/token",
@@ -274,6 +278,7 @@ heroku_interpolated_vars = {
     "MICROMASTERS_CATALOG_API_URL": f"https://{interpolation_vars['etl_micromasters_host']}/api/v0/catalog/",
     "MITOPEN_CORS_ORIGIN_WHITELIST": cors_urls_json,
     "OIDC_ENDPOINT": f"https://{interpolation_vars['sso_url']}/realms/olapps",
+    "SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS": auth_allowed_redirect_hosts_json,
     "SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT": f"https://{interpolation_vars['sso_url']}/realms/olapps",
     "USERINFO_URL": f"https://{interpolation_vars['sso_url']}/realms/olapps/protocol/openid-connect/userinfo",
     "XPRO_CATALOG_API_URL": f"https://{interpolation_vars['etl_xpro_host']}/api/programs/",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/mit-open/issues/420

### Description (What does it do?)
<!--- Describe your changes in detail -->
This adds configuration to set `SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS` on mit-open. We'll want to set this to have the corresponding OCW hostname for each environment (e.g. `['ocw.mit.edu']` for production).