### PR TITLE
add rc ocw to open next prod cors

### DIFF
--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.Production.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.Production.yaml
@@ -15,6 +15,7 @@ config:
     - "https://www.ocw.mit.edu"
     - "https://ocw.mit.edu"
     - "https://live.ocw.mit.edu"
+    - "https://live-qa.ocw.mit.edu"
     etl_micromasters_host: "micromasters.mit.edu"
     etl_xpro_host: "xpro.mit.edu"
     mailgun_sender_domain: "discussions-mail.odl.mit.edu"


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/ocw-hugo-themes/issues/1294

### Description (What does it do?)
Since we are using the new ocw search on rc to test the data in the new open prod search index,  we need to update the CORS values in mitopen prod to allow this