### PR TITLE
issue 2074 - mitxonline

### DIFF
--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.Production.yaml
@@ -7,6 +7,28 @@ config:
   consul:http_auth:
     secure: v1:RNlPmxc0q/5pq3c8:pXsI73JRWV2rdfxwCJGDunjn6a3qOEmhJzSJ+Y0sIRe3DyRYcAGIkwtlCdkeS1+pY8YFsZlSSUJbzKC03ZwZXkSwcOqsnEcIjTkJ4xLCfHYQx0eXF9SvWXshLMHpDRK1yQ==
   consul:scheme: https
+  heroku:app_id:
+    secure: v1:pR0Rve/LoKSnrjSl:KTPyUma7Q6HO2ZEv/n7cqwwBtjXviC+xTEL2EYAGIxZ/72itycpuOKhemhvfpb83E0/O5w==
+  heroku_app:vars:
+    AWS_STORAGE_BUCKET_NAME: "ol-mitxonline-app-production"
+    CRON_COURSE_CERTIFICATES_HOURS: "18"
+    GA_TRACKING_ID: "UA-5145472-48"
+    GTM_TRACKING_ID: "GTM-M47BLXN"
+    LOGOUT_REDIRECT_URL: "https://courses.mitxonline.mit.edu/logout"
+    MAILGUN_FROM_EMAIL: "MITx Online <no-reply@mail.mitxonline.mit.edu>"
+    MAILGUN_SENDER_DOMAIN: "mail.mitxonline.mit.edu"
+    MITOL_GOOGLE_SHEETS_PROCESSOR_APP_NAME: "MITx Online (production)"
+    MITOL_GOOGLE_SHEETS_REFUNDS_FIRST_ROW: "4"
+    MITOL_GOOGLE_SHEETS_REFUNDS_REQUEST_WORKSHEET_ID: "0"
+    MITOL_HUBSPOT_API_ID_PREFIX: "mitxonline"
+    MITOL_PAYMENT_GATEWAY_CYBERSOURCE_REST_API_ENVIRONMENT: "api.cybersource.com"
+    MITOL_PAYMENT_GATEWAY_CYBERSOURCE_SECURE_ACCEPTANCE_URL: "https://secureacceptance.cybersource.com/pay"
+    MITX_ONLINE_BASE_URL: "https://mitxonline.mit.edu"
+    MITX_ONLINE_ENVIRONMENT: "production"
+    MITX_ONLINE_LOG_LEVEL: "INFO"
+    MITX_ONLINE_SECURE_SSL_HOST: "mitxonline.mit.edu"
+    OPENEDX_API_BASE_URL: "https://courses.mitxonline.mit.edu"
+    SENTRY_LOG_LEVEL: "ERROR"
   mitxonline:db_password:
     secure: v1:1SGxkH66kKNXMVc0:P9FztYdyzfxIrapGHU3pD5gz9ZkW6Of/zTqhaZf4O+L+Y8yAbcissYxogKfyDMxSJYSSUxI12K0=
   vault:address: https://vault-production.odl.mit.edu

--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.QA.yaml
@@ -7,6 +7,28 @@ config:
   consul:http_auth:
     secure: v1:cFN5rfbLYKJOLKko:EbolfR0aA+3QNuLKU4ixNwZVdSuSB5UIl0gAPICG4mrprmQSDFabC/VkxrJGDgaAbELMxpskbvN0qj2y9SMX0IlKJYD2JHUZsfYqd8FX1QcxAxeSL00jJ5Zkks+mP8c=
   consul:scheme: https
+  heroku:app_id:
+    secure: v1:KIux67Zl3+hwHcoO:nHVugTj5RoBKpU1ZM2QHzRj1mKQqVz2dXhRKdJ51ZZTUA4/aK+iapqhEYVpKIFq8itMeMA==
+  heroku_app:vars:
+    AWS_STORAGE_BUCKET_NAME: "ol-mitxonline-app-qa"
+    CRON_COURSE_CERTIFICATES_HOURS: "18"
+    GA_TRACKING_ID: "UA-5145472-46"
+    GTM_TRACKING_ID: "GTM-TW97MNR"
+    LOGOUT_REDIRECT_URL: "https://courses-qa.mitxonline.mit.edu/logout"
+    MAILGUN_FROM_EMAIL: "MITx Online <no-reply@mitxonline-rc-mail.mitxonline.mit.edu>"
+    MAILGUN_SENDER_DOMAIN: "mitxonline-rc-mail.mitxonline.mit.edu"
+    MITOL_GOOGLE_SHEETS_PROCESSOR_APP_NAME: "MITx Online (rc)"
+    MITOL_GOOGLE_SHEETS_REFUNDS_FIRST_ROW: "4"
+    MITOL_GOOGLE_SHEETS_REFUNDS_REQUEST_WORKSHEET_ID: "0"
+    MITOL_HUBSPOT_API_ID_PREFIX: "mitxonline-rc"
+    MITOL_PAYMENT_GATEWAY_CYBERSOURCE_REST_API_ENVIRONMENT: "apitest.cybersource.com"
+    MITOL_PAYMENT_GATEWAY_CYBERSOURCE_SECURE_ACCEPTANCE_URL: "https://testsecureacceptance.cybersource.com/pay"
+    MITX_ONLINE_ENVIRONMENT: "rc"
+    MITX_ONLINE_LOG_LEVEL: "INFO"
+    MITX_ONLINE_SECURE_SSL_HOST: "mitxonline-rc.mitxonline.mit.edu"
+    MITX_ONLINE_BASE_URL: "https://rc.mitxonline.mit.edu"
+    OPENEDX_API_BASE_URL: "https://courses-qa.mitxonline.mit.edu"
+    SENTRY_LOG_LEVEL: "ERROR"
   mitxonline:db_password:
     secure: v1:72AVczMFP7U0adTg:qiVKioH1VjNf38HfLkNIZsCdc8RqKs0bkaou+fU6SSRK9W4kbS1do2PwdD3JWYlc37eojd+sdAL8npp+tyEeQ66q5mHmWDQK3WlqgdWbf8G41fizyMwoy2AQdZmtZtJe40IoeqaSX3ntfJvhI0uP7YWmpge4G9e6KMNBmhZ0wl0T6qHU4z180aId1ZpjCM4=
   vault:address: https://vault-qa.odl.mit.edu

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -1,3 +1,5 @@
+# ruff: noqa: E501
+
 """Create the infrastructure and services needed to support the MITx Online application.
 
 - Create a PostgreSQL database in AWS RDS for production environments
@@ -7,8 +9,9 @@
 import json
 
 import pulumi_vault as vault
+import pulumiverse_heroku as heroku
 from bridge.lib.magic_numbers import DEFAULT_POSTGRES_PORT
-from pulumi import Config, StackReference, export
+from pulumi import Config, InvokeOptions, StackReference, export
 from pulumi_aws import ec2, iam, s3
 
 from ol_infrastructure.components.aws.database import OLAmazonDB, OLPostgresDBConfig
@@ -17,13 +20,19 @@ from ol_infrastructure.components.services.vault import (
     OLVaultPostgresDatabaseConfig,
 )
 from ol_infrastructure.lib.aws.iam_helper import lint_iam_policy
+from ol_infrastructure.lib.heroku import setup_heroku_provider
 from ol_infrastructure.lib.ol_types import AWSBase
 from ol_infrastructure.lib.pulumi_helper import parse_stack
 from ol_infrastructure.lib.stack_defaults import defaults
 from ol_infrastructure.lib.vault import setup_vault_provider
 
-setup_vault_provider()
+setup_vault_provider(skip_child_token=True)
+setup_heroku_provider()
+
 mitxonline_config = Config("mitxonline")
+heroku_config = Config("heroku")
+heroku_app_config = Config("heroku_app")
+
 stack_info = parse_stack()
 network_stack = StackReference(f"infrastructure.aws.network.{stack_info.name}")
 mitxonline_vpc = network_stack.require_output("mitxonline_vpc")
@@ -68,7 +77,7 @@ mitxonline_bucket = s3.Bucket(
 
 
 mitxonline_iam_policy = iam.Policy(
-    f"mitxonline-{stack_info.env_suffix}-policy",
+    f"yymitxonline-{stack_info.env_suffix}-policy",
     description=(
         "AWS access controls for the MITx Online application in the "
         f"{stack_info.name} environment"
@@ -166,5 +175,253 @@ mitxonline_vault_backend_config = OLVaultPostgresDatabaseConfig(
     db_host=mitxonline_db.db_instance.address,
 )
 mitxonline_vault_backend = OLVaultDatabaseBackend(mitxonline_vault_backend_config)
+
+heroku_vars = {
+    "CRON_COURSERUN_SYNC_HOURS": "*",
+    "MITX_ONLINE_SUPPORT_EMAIL": "mitxonline-support@mit.edu",
+    "FEATURE_SYNC_ON_DASHBOARD_LOAD": "True",
+    "FEATURE_IGNORE_EDX_FAILURES": "True",
+    "HUBSPOT_PIPELINE_ID": "19817792",
+    "MITOL_GOOGLE_SHEETS_REFUNDS_COMPLETED_DATE_COL": "12",
+    "MITOL_GOOGLE_SHEETS_REFUNDS_ERROR_COL": "13",
+    "MITOL_GOOGLE_SHEETS_REFUNDS_SKIP_ROW_COL": "14",
+    "MITX_ONLINE_ADMIN_EMAIL": "cuddle-bunnies@mit.edu",
+    "MITX_ONLINE_DB_CONN_MAX_AGE": "0",
+    "MITX_ONLINE_DB_DISABLE_SSL": "True",  # pgbouncer buildpack uses stunnel to handle encryption"
+    "MITX_ONLINE_FROM_EMAIL": "MITx Online <support@mitxonline.mit.edu>",
+    "MITX_ONLINE_OAUTH_PROVIDER": "mitxonline-oauth2",
+    "MITX_ONLINE_REPLY_TO_ADDRESS": "MITx Online <support@mitxonline.mit.edu>",
+    "MITX_ONLINE_SECURE_SSL_REDIRECT": "True",
+    "MITX_ONLINE_USE_S3": "True",
+    "NODE_MODULES_CACHE": "False",
+    "OPEN_EXCHANGE_RATES_URL": "https://openexchangerates.org/api/",
+    "OPENEDX_SERVICE_WORKER_USERNAME": "login_service_user",
+    "PGBOUNCER_DEFAULT_POOL_SIZE": "50",
+    "PGBOUNCER_MIN_POOL_SIZE": "5",
+    "SITE_NAME": "MITx Online",
+    "USE_X_FORWARDED_HOST": "True",
+    "ZENDESK_HELP_WIDGET_ENABLED": "True",
+    "POSTHOG_API_HOST": "https://app.posthog.com",
+}
+
+# All of the secrets for this app must be obtained with async incantations
+
+env_name = (
+    stack_info.env_suffix.lower() if stack_info.env_suffix.lower() != "qa" else "rc"
+)
+openedx_environment = f"mitxonline-{stack_info.env_suffix.lower()}"
+
+rds_endpoint = f"mitxonline-{stack_info.env_suffix.lower()}-app-db.cbnm7ajau6mi.us-east-1.rds.amazonaws.com:5432"
+
+auth_aws_mitx_creds_mitxonline = vault.generic.get_secret_output(
+    path="aws-mitx/creds/mitxonline",
+    with_lease_start_time=False,
+    opts=InvokeOptions(parent=mitxonline_vault_backend_role),
+)
+
+auth_postgres_mitxonline_creds_app = vault.generic.get_secret_output(
+    path="postgres-mitxonline/creds/app",
+    with_lease_start_time=False,
+    opts=InvokeOptions(parent=mitxonline_vault_backend_role),
+)
+
+secret_mitxonline_google_sheets_refunds = vault.generic.get_secret_output(
+    path="secret-mitxonline/google-sheets-refunds",
+    opts=InvokeOptions(parent=mitxonline_vault_backend_role),
+)
+
+secret_mitxonline_refine_oidc = vault.generic.get_secret_output(
+    path="secret-mitxonline/refine-oidc",
+    opts=InvokeOptions(parent=mitxonline_vault_backend_role),
+)
+
+secret_mitxonline_open_exchange_rates = vault.generic.get_secret_output(
+    path="secret-mitxonline/open-exchange-rates",
+    opts=InvokeOptions(parent=mitxonline_vault_backend_role),
+)
+
+secret_mitxonline_recaptcha_keys = vault.generic.get_secret_output(
+    path="secret-mitxonline/recaptcha-keys",
+    opts=InvokeOptions(parent=mitxonline_vault_backend_role),
+)
+
+secret_mitxonline_openedx_retirement_service_worker = vault.generic.get_secret_output(
+    path="secret-mitxonline/openedx-retirement-service-worker",
+    opts=InvokeOptions(parent=mitxonline_vault_backend_role),
+)
+
+secret_mitxonline_env_cybersource_credentials = vault.generic.get_secret_output(
+    path=f"secret-mitxonline/{env_name}/cybersource-credentials",
+    opts=InvokeOptions(parent=mitxonline_vault_backend_role),
+)
+
+secret_mitxonline_hubspot_api_private_token = vault.generic.get_secret_output(
+    path="secret-mitxonline/hubspot-api-private-token",
+    opts=InvokeOptions(parent=mitxonline_vault_backend_role),
+)
+
+secret_mitxonline_openedx_env_mitxonline_registration_access_token = vault.generic.get_secret_output(
+    path=f"secret-mitxonline/{openedx_environment}/mitxonline-registration-access-token",
+    opts=InvokeOptions(parent=mitxonline_vault_backend_role),
+)
+
+secret_mitxonline_env_openedx_api_client = vault.generic.get_secret_output(
+    path=f"secret-mitxonline/{env_name}/openedx-api-client",
+    opts=InvokeOptions(parent=mitxonline_vault_backend_role),
+)
+
+secret_mitxonline_openedx_env_edx_api_key = vault.generic.get_secret_output(
+    path=f"secret-mitxonline/{openedx_environment}/edx-api-key",
+    opts=InvokeOptions(parent=mitxonline_vault_backend_role),
+)
+
+secret_mitxonline_env_openedx_service_worker_api_token = (
+    vault.generic.get_secret_output(
+        path=f"secret-mitxonline/{env_name}/openedx-service-worker-api-token",
+        opts=InvokeOptions(parent=mitxonline_vault_backend_role),
+    )
+)
+
+secret_mitxonline_env_django_secret_key = vault.generic.get_secret_output(
+    path=f"secret-mitxonline/{env_name}/django-secret-key",
+    opts=InvokeOptions(parent=mitxonline_vault_backend_role),
+)
+
+secret_mitxonline_env_django_status_token = vault.generic.get_secret_output(
+    path=f"secret-mitxonline/{env_name}/django-status-token",
+    opts=InvokeOptions(parent=mitxonline_vault_backend_role),
+)
+
+secret_mitxonline_posthog_credentials = vault.generic.get_secret_output(
+    path="secret-mitxonline/posthog-credentials",
+    opts=InvokeOptions(parent=mitxonline_vault_backend_role),
+)
+
+secret_mitxonline_hubspot = vault.generic.get_secret_output(
+    path="secret-mitxonline/hubspot",
+    opts=InvokeOptions(parent=mitxonline_vault_backend_role),
+)
+secret_operations_global_mailgun_api_key = vault.generic.get_secret_output(
+    path="secret-operations/global/mailgun-api-key",
+    opts=InvokeOptions(parent=mitxonline_vault_backend_role),
+)
+secret_operations_global_mitxonline_sentry_dsn = vault.generic.get_secret_output(
+    path="secret-operations/global/mitxonline/sentry-dsn",
+    opts=InvokeOptions(parent=mitxonline_vault_backend_role),
+)
+
+sensitive_heroku_vars = {
+    "AWS_ACCESS_KEY_ID": auth_aws_mitx_creds_mitxonline.data.apply(
+        lambda data: "{}".format(data["access_key"])
+    ),
+    "AWS_SECRET_ACCESS_KEY": auth_aws_mitx_creds_mitxonline.data.apply(
+        lambda data: "{}".format(data["secret_key"])
+    ),
+    "DATABASE_URL": auth_postgres_mitxonline_creds_app.data.apply(
+        lambda data: "postgres://{}:{}@{}/mitxonline".format(
+            data["username"], data["password"], rds_endpoint
+        )
+    ),
+    "HUBSPOT_HOME_PAGE_FORM_GUID": secret_mitxonline_hubspot.data.apply(
+        lambda data: "{}".format(data["formId"])
+    ),
+    "HUBSPOT_PORTAL_ID": secret_mitxonline_hubspot.data.apply(
+        lambda data: "{}".format(data["portalId"])
+    ),
+    "MAILGUN_KEY": secret_operations_global_mailgun_api_key.data.apply(
+        lambda data: "{}".format(data["value"])
+    ),
+    "MITOL_GOOGLE_SHEETS_DRIVE_API_PROJECT_ID": secret_mitxonline_google_sheets_refunds.data.apply(
+        lambda data: "{}".format(data["drive-api-project-id"])
+    ),
+    "MITOL_GOOGLE_SHEETS_DRIVE_CLIENT_ID": secret_mitxonline_google_sheets_refunds.data.apply(
+        lambda data: "{}".format(data["drive-client-id"])
+    ),
+    "MITOL_GOOGLE_SHEETS_DRIVE_CLIENT_SECRET": secret_mitxonline_google_sheets_refunds.data.apply(
+        lambda data: "{}".format(data["drive-client-secret"])
+    ),
+    "MITOL_GOOGLE_SHEETS_ENROLLMENT_CHANGE_SHEET_ID": secret_mitxonline_google_sheets_refunds.data.apply(
+        lambda data: "{}".format(data["enrollment-change-sheet-id"])
+    ),
+    "MITOL_HUBSPOT_API_PRIVATE_TOKEN": secret_mitxonline_hubspot_api_private_token.data.apply(
+        lambda data: "{}".format(data["value"])
+    ),
+    "MITOL_PAYMENT_GATEWAY_CYBERSOURCE_ACCESS_KEY": secret_mitxonline_env_cybersource_credentials.data.apply(
+        lambda data: "{}".format(data["access-key"])
+    ),
+    "MITOL_PAYMENT_GATEWAY_CYBERSOURCE_MERCHANT_ID": secret_mitxonline_env_cybersource_credentials.data.apply(
+        lambda data: "{}".format(data["merchant-id"])
+    ),
+    "MITOL_PAYMENT_GATEWAY_CYBERSOURCE_MERCHANT_SECRET": secret_mitxonline_env_cybersource_credentials.data.apply(
+        lambda data: "{}".format(data["merchant-secret"])
+    ),
+    "MITOL_PAYMENT_GATEWAY_CYBERSOURCE_MERCHANT_SECRET_KEY_ID": secret_mitxonline_env_cybersource_credentials.data.apply(
+        lambda data: "{}".format(data["merchant-secret-key-id"])
+    ),
+    "MITOL_PAYMENT_GATEWAY_CYBERSOURCE_PROFILE_ID": secret_mitxonline_env_cybersource_credentials.data.apply(
+        lambda data: "{}".format(data["profile-id"])
+    ),
+    "MITOL_PAYMENT_GATEWAY_CYBERSOURCE_SECURITY_KEY": secret_mitxonline_env_cybersource_credentials.data.apply(
+        lambda data: "{}".format(data["security-key"])
+    ),
+    "MITX_ONLINE_REFINE_OIDC_CONFIG_CLIENT_ID": secret_mitxonline_refine_oidc.data.apply(
+        lambda data: "{}".format(data["client-id"])
+    ),
+    "MITX_ONLINE_REGISTRATION_ACCESS_TOKEN": secret_mitxonline_openedx_env_mitxonline_registration_access_token.data.apply(
+        lambda data: "{}".format(data["value"])
+    ),
+    "OIDC_RSA_PRIVATE_KEY": secret_mitxonline_refine_oidc.data.apply(
+        lambda data: "{}".format(data["rsa-private-key"])
+    ),
+    "OPENEDX_API_CLIENT_ID": secret_mitxonline_env_openedx_api_client.data.apply(
+        lambda data: "{}".format(data["client-id"])
+    ),
+    "OPENEDX_API_CLIENT_SECRET": secret_mitxonline_env_openedx_api_client.data.apply(
+        lambda data: "{}".format(data["client-secret"])
+    ),
+    "OPENEDX_API_KEY": secret_mitxonline_openedx_env_edx_api_key.data.apply(
+        lambda data: "{}".format(data["value"])
+    ),
+    "OPENEDX_RETIREMENT_SERVICE_WORKER_CLIENT_ID": secret_mitxonline_openedx_retirement_service_worker.data.apply(
+        lambda data: "{}".format(data["client_id"])
+    ),
+    "OPENEDX_RETIREMENT_SERVICE_WORKER_CLIENT_SECRET": secret_mitxonline_openedx_retirement_service_worker.data.apply(
+        lambda data: "{}".format(data["client_secret"])
+    ),
+    "OPENEDX_SERVICE_WORKER_API_TOKEN": secret_mitxonline_env_openedx_service_worker_api_token.data.apply(
+        lambda data: "{}".format(data["value"])
+    ),
+    "OPEN_EXCHANGE_RATES_APP_ID": secret_mitxonline_open_exchange_rates.data.apply(
+        lambda data: "{}".format(data["app_id"])
+    ),
+    "POSTHOG_API_TOKEN": secret_mitxonline_posthog_credentials.data.apply(
+        lambda data: "{}".format(data["api-token"])
+    ),
+    "RECAPTCHA_SECRET_KEY": secret_mitxonline_recaptcha_keys.data.apply(
+        lambda data: "{}".format(data["secret_key"])
+    ),
+    "RECAPTCHA_SITE_KEY": secret_mitxonline_recaptcha_keys.data.apply(
+        lambda data: "{}".format(data["site_key"])
+    ),
+    "SECRET_KEY": secret_mitxonline_env_django_secret_key.data.apply(
+        lambda data: "{}".format(data["value"])
+    ),
+    "SENTRY_DSN": secret_operations_global_mitxonline_sentry_dsn.data.apply(
+        lambda data: "{}".format(data["value"])
+    ),
+    "STATUS_TOKEN": secret_mitxonline_env_django_status_token.data.apply(
+        lambda data: "{}".format(data["value"])
+    ),
+}
+
+heroku_vars.update(**heroku_app_config.get_object("vars"))
+
+heroku_app_id = heroku_config.require("app_id")
+mitxonline_heroku_configassociation = heroku.app.ConfigAssociation(
+    f"mitxonline-{stack_info.env_suffix}-heroku-configassociation",
+    app_id=heroku_app_id,
+    sensitive_vars=sensitive_heroku_vars,
+    vars=heroku_vars,
+)
 
 export("mitxonline_app", {"rds_host": mitxonline_db.db_instance.address})


### PR DESCRIPTION
### What are the relevant tickets?
#2074 

### Description (What does it do?)
Migrating mitxonline heroku config var management from salt -> pulumi.

Final diffs for production:
```
< AWS_ACCESS_KEY_ID:              <<<< Expected
< AWS_SECRET_ACCESS_KEY:             <<<< Expected
---
> AWS_ACCESS_KEY_ID:              <<<< Expected
> AWS_SECRET_ACCESS_KEY:              <<<< Expected
6,9c6
< DATABASE_URL: 
< EMAIL_SUPPORT: "mitxonline-support@mit.edu"            <<<< Isn't managed by salt.
< FEATURE_ENABLE_ADDL_PROFILE_FIELDS: "True"            <<<< Isn't managed by salt.
< FEATURE_ENABLE_UPGRADE_DIALOG: "True"            <<<< Isn't managed by salt.
---
> DATABASE_URL:             <<<< Expected
15d11
< HUBSPOT_MAX_CONCURRENT_TASKS: "2"            <<<< Isn't managed by salt.
22d17
< MITOL_GOOGLE_SHEETS_DEFERRALS_REQUEST_WORKSHEET_ID: "268521316"            <<<< Isn't managed by salt.
33d27
< MITOL_GOOGLE_SHEET_PROCESSOR_APP_NAME: "MITx Online (production)"                <<<< Typo: 'SHEET' vs 'SHEETS'
59,60d52
< NEW_RELIC_LICENSE_KEY:              <<<< Expected
< NEW_RELIC_LOG: "stdout"             <<<< Expected
78d70
< REDISCLOUD_URL:              <<<< Expected
85,86d76
< UWSGI_THREADS: "25"            <<<< Isn't managed by salt.
< UWSGI_WORKERS: "3"            <<<< Isn't managed by salt.
```

