### PR TITLE
fix: fix default xmodule class name

### DIFF
--- a/src/bilder/images/edxapp_v2/templates/edxapp/xpro/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/xpro/common_values.yml.tmpl
@@ -413,7 +413,7 @@ MODULESTORE:
               DOC_STORE_CONFIG:
                 <<: *docstore_config
               OPTIONS:
-                default_class: {{ keyOrDefault "edxapp/default-module-class" "xmodule.hidden_module.HiddenDescriptor"}}
+                default_class: {{ keyOrDefault "edxapp/default-module-class" "xmodule.hidden_block.HiddenBlock"}}
                 fs_root: /openedx/data/var/edxapp/data
                 render_template: common.djangoapps.edxmako.shortcuts.render_to_string
             - ENGINE: xmodule.modulestore.mongo.DraftMongoModuleStore
@@ -421,7 +421,7 @@ MODULESTORE:
               DOC_STORE_CONFIG:
                 <<: *docstore_config
               OPTIONS:
-                default_class: {{ keyOrDefault "edxapp/default-module-class" "xmodule.hidden_module.HiddenDescriptor"}}
+                default_class: {{ keyOrDefault "edxapp/default-module-class" "xmodule.hidden_block.HiddenBlock"}}
                 fs_root: /openedx/data/var/edxapp/data
                 render_template: common.djangoapps.edxmako.shortcuts.render_to_string
 ORA2_FILE_PREFIX: ora2  # MODIFIED

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.CI.yaml
@@ -33,7 +33,7 @@ config:
   edxapp:edx_forum_secrets:
     secure: v1:QSW6gq7cQ6t65Glo:OGJ5X4YYEi2ZdyrpnML25p10mQrodNNLaF5zyV1242ZcQz1TkRsTdpmv9HghIhgHxykYd2NK7kyRkvphd5pfI56xAg/de/8PuHNuPx5kg3IZCrFktYuE2Nyzjxhg7aGHNhA6JQEf95925WPwAG3V
   edxapp:elb_healthcheck_interval: "30"
-  edxapp:default_module_class: xmodule.hidden_module.HiddenDescriptor
+  edxapp:default_module_class: xmodule.hidden_block.HiddenBlock
   edxapp:web_instance_type: m6a.large
   edxapp:enable_notes: "True"
   edxapp:enabled_mfes:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.Production.yaml
@@ -26,7 +26,7 @@ config:
   edxapp:db_password:
     secure: v1:U83x0i6WAndxuOLK:XsAILALTGbtjCqGJllcqg3EaOM0FF/SNmuiMAK2r3E9X5joW26kjOQzYUcKr0slkHBv8RUEr3xA=
   edxapp:dns_zone: xpro
-  edxapp:default_module_class: xmodule.hidden_module.HiddenDescriptor
+  edxapp:default_module_class: xmodule.hidden_block.HiddenBlock
   edxapp:domains:
     lms: courses.xpro.mit.edu
     preview: preview.xpro.mit.edu

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.QA.yaml
@@ -26,7 +26,7 @@ config:
   edxapp:db_password:
     secure: v1:+Bcw4dSZUPqWY2cL:g/KKgzrmRlgx2SOuOOB4grCveVaNv5mZVuuFrpGgAGwKEussIqUWTBnFJknEdJ4Hjf5Jw/1W560=
   edxapp:dns_zone: xpro
-  edxapp:default_module_class: xmodule.hidden_module.HiddenDescriptor
+  edxapp:default_module_class: xmodule.hidden_block.HiddenBlock
   edxapp:domains:
     lms: courses-rc.xpro.mit.edu
     preview: preview-rc.xpro.mit.edu


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Fixes Sentry issue https://mit-office-of-digital-learning.sentry.io/issues/4545924864/?project=1730882&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=2

### Description (What does it do?)
<!--- Describe your changes in detail -->
edX has renamed one of the module store classes. Also, they have updated the settings in edx-platform. We are using the old name as defined in our configurations. This PR updates the MODULESTORE setting for MITx Online. Here is the edX PR https://github.com/openedx/edx-platform/pull/31113

We made similar changes for the MITx Online at https://github.com/mitodl/ol-infrastructure/pull/1840. This PR updates the settings for the xPro instances.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Track sentry issues maybe?