### PR TITLE
config: disable authoring MFE for xPRO Production

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.Production.yaml
@@ -17,8 +17,8 @@ config:
   - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
     "--everyone"]
   - ["new_core_editors.use_new_problem_editor", "--create", "--deactivate"]
-  - ["new_core_editors.use_new_text_editor", "--create", "--superusers"]
-  - ["new_core_editors.use_new_video_editor", "--create", "--superusers"]
+  - ["new_core_editors.use_new_text_editor", "--create", "--superusers", "--deactivate"]
+  - ["new_core_editors.use_new_video_editor", "--create", "--superusers", "--deactivate"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["studio.library_authoring_mfe", "--create", "--superusers", "--everyone"]


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/3654#issuecomment-1964534504

### Description (What does it do?)
- We don't intend to enable the new authoring MFE experience in xPRO production yet. But the current configuration enables it for staff users on production. This PR disables them for everyone.


### How can this be tested?
We should see the authoring MFE upon editing any unit in e.g. https://studio.xpro.mit.edu/container/block-v1:xPRO+MLx1_IND+SPOC_R1+type@vertical+block@8ad6326456c94930aba3e0b91cffa1b6



<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
