### PR TITLE
Add YOUTUBE_CONFIG_URL setting for mitopen

### DIFF
--- a/src/ol_infrastructure/applications/mitopen/__main__.py
+++ b/src/ol_infrastructure/applications/mitopen/__main__.py
@@ -254,7 +254,7 @@ heroku_vars = {
     "USE_X_FORWARDED_PORT": "True",
     "XPRO_LEARNING_COURSE_BUCKET_NAME": "mitx-etl-xpro-production-mitxpro-production",
     "YOUTUBE_FETCH_TRANSCRIPT_SCHEDULE_SECONDS": 21600,
-    "YOUTUBE_FETCH_TRANSCRIPT_SLEEP_SECONDS": 20,
+    "YOUTUBE_CONFIG_URL": "https://raw.githubusercontent.com/mitodl/open-video-data/mitopen/youtube/channels.yaml",
 }
 
 # Values that require interpolation or other special considerations


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/mit-open/pull/558

### Description (What does it do?)
Adds a new setting for mitopen `YOUTUBE_CONFIG_URL` which should be a url to a yaml file dpecifying which youtube channels and playlists to import.

### How can this be tested?
As part of the PR linked above.