### PR TITLE
Correct OCW links to RC environment

### DIFF
--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
@@ -36,13 +36,12 @@ config:
     TIKA_SERVER_ENDPOINT: "https://tika-qa.odl.mit.edu"
   heroku_app:interpolation_vars:
     auth_allowed_redirect_hosts:
-    - "ocwnext-rc.odl.mit.edu"
+    - "live-qa.ocw.mit.edu"
     cors_urls:
-    - "https://ocwnext-rc.odl.mit.edu"
+    - "https://live-qa.ocw.mit.edu"
     - "https://ocw-next.netlify.app"
     - "https://ol-devops-ci.odl.mit.edu"
     - "https://draft-qa.ocw.mit.edu"
-    - "https://live-qa.ocw.mit.edu"
     etl_micromasters_host: "micromasters-rc.odl.mit.edu"
     etl_xpro_host: "rc.xpro.mit.edu"
     mailgun_sender_domain: "discussions-mail.odl.mit.edu"

--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
@@ -38,10 +38,10 @@ config:
     auth_allowed_redirect_hosts:
     - "live-qa.ocw.mit.edu"
     cors_urls:
-    - "https://live-qa.ocw.mit.edu"
     - "https://ocw-next.netlify.app"
     - "https://ol-devops-ci.odl.mit.edu"
     - "https://draft-qa.ocw.mit.edu"
+    - "https://live-qa.ocw.mit.edu"
     etl_micromasters_host: "micromasters-rc.odl.mit.edu"
     etl_xpro_host: "rc.xpro.mit.edu"
     mailgun_sender_domain: "discussions-mail.odl.mit.edu"

--- a/src/ol_infrastructure/applications/ocw_site/Pulumi.applications.ocw_site.QA.yaml
+++ b/src/ol_infrastructure/applications/ocw_site/Pulumi.applications.ocw_site.QA.yaml
@@ -8,6 +8,5 @@ config:
     - draft-qa.ocw.mit.edu
     live:
     - live-qa.ocw.mit.edu
-    - ocwnext-rc.odl.mit.edu
     test:
     - test-qa.ocw.mit.edu


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/ol-infrastructure/issues/2242

### Description (What does it do?)
This PR updates references to `https://ocwnext-rc.odl.mit.edu/` to `https://live-qa.ocw.mit.edu/`

### How can this be tested?
Deploy the new vars to `mit-open` RC and test the login button demo at https://live-qa.ocw.mit.edu/login-button/courses/24-964-topics-in-phonology-phonetic-realization-fall-2006/
