### PR TITLE
Enabling jinja templating in superset.

### DIFF
--- a/src/ol_superset/pythonpath/superset_config.py
+++ b/src/ol_superset/pythonpath/superset_config.py
@@ -153,6 +153,8 @@ FEATURE_FLAGS: dict[str, bool] = {
     # Unlike Selenium, Playwright reports support deck.gl visualizations
     # Enabling this feature flag requires installing "playwright" pip package
     "PLAYWRIGHT_REPORTS_AND_THUMBNAILS": False,
+    # Set to True to enable Jinja templating in queries in SQL Lab and Explore
+    "ENABLE_TEMPLATE_PROCESSING": True,
 }
 
 # Default configurator will consume the LOG_* settings below


### PR DESCRIPTION
### What are the relevant tickets?


### Description (What does it do?)
Enables the feature flag for template processing in superset.

### How can this be tested?
Try adding Jinja templating blocks in Superset UI.

Try creating a new dataset in Superset that uses the current_user_email() built in function in Superset.
`SELECT * FROM [TABLE]
WHERE courserun_readable_id in 
(SELECT courserun_readable_id 
FROM "ol_data_lake_production"."ol_warehouse_production_intermediate"."int__combined__user_course_roles" 
WHERE [LOOKUP TABLE] in ('staff', 'instructor') AND user_email = {{ current_user_email() }})
`