### PR TITLE
Redirect mitx-courses-on-edx.htm to openlearning URL

### DIFF
--- a/src/ol_infrastructure/applications/ocw_site/redirect_dict.json
+++ b/src/ol_infrastructure/applications/ocw_site/redirect_dict.json
@@ -479,5 +479,6 @@
   "/courses/intro-programming": "307|keep|https://{{AK_HOSTHEADER}}/collections/introductory-programming/",
   "/courses/transportation-courses": "307|keep|https://{{AK_HOSTHEADER}}/collections/transportation/",
   "/courses/ocw-scholar": "307|keep|https://{{AK_HOSTHEADER}}/course-lists/scholar-courses/",
-  "/fairuse": "301|keep|https://mitocw.zendesk.com/hc/en-us/articles/4414756181403-How-is-all-rights-reserved-content-different-from-the-rest-of-OCW-content/"
+  "/fairuse": "301|keep|https://mitocw.zendesk.com/hc/en-us/articles/4414756181403-How-is-all-rights-reserved-content-different-from-the-rest-of-OCW-content/",
+  "/ans7870/featured/mitx-courses-on-edx.htm": "301|discard|https://openlearning.mit.edu/courses-programs/mitx-courses/"
 }


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/3730

### Description (What does it do?)
Redirects https://ocw.mit.edu/ans7870/featured/mitx-courses-on-edx.htm to https://openlearning.mit.edu/courses-programs/mitx-courses

### How can this be tested?
Testing will be done manually once deployed