### PR TITLE
Adding a custom macro to get the current user email.

### DIFF
--- a/src/ol_superset/pythonpath/superset_config.py
+++ b/src/ol_superset/pythonpath/superset_config.py
@@ -263,9 +263,9 @@ SLACK_API_TOKEN = vault_client.secrets.kv.v2.read_secret(
     path="app-config", mount_point="secret-superset"
 )["data"]["data"]["slack_token"]
 
-#############################
-# Custom Template Processors #
-############################
+#######################
+# Custom Jinja Macros #
+#######################
 # Enable usage of current_user_email() macro until Superset releases that feature
 
 

--- a/src/ol_superset/pythonpath/superset_config.py
+++ b/src/ol_superset/pythonpath/superset_config.py
@@ -266,9 +266,8 @@ SLACK_API_TOKEN = vault_client.secrets.kv.v2.read_secret(
 #######################
 # Custom Jinja Macros #
 #######################
-# Enable usage of current_user_email() macro until Superset releases that feature
-
-
+# Temporarily add a current_user_email() macro until Superset releases that feature
+# Macro function that returns the current user's email
 def current_user_email() -> Optional[str]:
     """
     Get the email (if defined) associated with the current user.
@@ -281,5 +280,5 @@ def current_user_email() -> Optional[str]:
     except Exception:  # pylint: disable=broad-except
         return None
 
-
+# Adding macros to enable usage in the jinja_context for Superset
 JINJA_CONTEXT_ADDONS = {"current_user_email": current_user_email}

--- a/src/ol_superset/pythonpath/superset_config.py
+++ b/src/ol_superset/pythonpath/superset_config.py
@@ -1,8 +1,10 @@
 import logging
 import os
+from typing import Optional
 
 from celery.schedules import crontab
 from flask_appbuilder.security.manager import AUTH_OAUTH
+from flask import g
 from superset.security import SupersetSecurityManager
 from superset.utils.encrypt import SQLAlchemyUtilsAdapter
 from vault.aws_auth import get_vault_client
@@ -260,3 +262,25 @@ ENABLE_CHUNK_ENCODING = False
 SLACK_API_TOKEN = vault_client.secrets.kv.v2.read_secret(
     path="app-config", mount_point="secret-superset"
 )["data"]["data"]["slack_token"]
+
+#############################
+# Custom Template Processors #
+############################
+# Enable usage of current_user_email() macro until Superset releases that feature
+
+
+def current_user_email() -> Optional[str]:
+    """
+    Get the email (if defined) associated with the current user.
+
+    :returns: The email
+    """
+
+    try:
+        return g.user.email
+    except Exception:  # pylint: disable=broad-except
+        return None
+
+JINJA_CONTEXT_ADDONS = {
+    'current_user_email': current_user_email()
+}

--- a/src/ol_superset/pythonpath/superset_config.py
+++ b/src/ol_superset/pythonpath/superset_config.py
@@ -3,8 +3,8 @@ import os
 from typing import Optional
 
 from celery.schedules import crontab
-from flask_appbuilder.security.manager import AUTH_OAUTH
 from flask import g
+from flask_appbuilder.security.manager import AUTH_OAUTH
 from superset.security import SupersetSecurityManager
 from superset.utils.encrypt import SQLAlchemyUtilsAdapter
 from vault.aws_auth import get_vault_client
@@ -281,6 +281,5 @@ def current_user_email() -> Optional[str]:
     except Exception:  # pylint: disable=broad-except
         return None
 
-JINJA_CONTEXT_ADDONS = {
-    'current_user_email': current_user_email()
-}
+
+JINJA_CONTEXT_ADDONS = {"current_user_email": current_user_email()}

--- a/src/ol_superset/pythonpath/superset_config.py
+++ b/src/ol_superset/pythonpath/superset_config.py
@@ -278,7 +278,7 @@ def current_user_email() -> Optional[str]:
 
     try:
         return g.user.email
-    except Exception:  # noqa: BLE001 
+    except Exception:  # noqa: BLE001
         logging.debug("Could not get email for : %s", g.user)
         return None
 

--- a/src/ol_superset/pythonpath/superset_config.py
+++ b/src/ol_superset/pythonpath/superset_config.py
@@ -279,6 +279,7 @@ def current_user_email() -> Optional[str]:
     try:
         return g.user.email
     except Exception:  # pylint: disable=broad-except
+        logging.debug("Could not get email for : %s", g.user)
         return None
 
 

--- a/src/ol_superset/pythonpath/superset_config.py
+++ b/src/ol_superset/pythonpath/superset_config.py
@@ -278,7 +278,7 @@ def current_user_email() -> Optional[str]:
 
     try:
         return g.user.email
-    except Exception:  # pylint: disable=broad-except
+    except Exception:  # noqa: BLE001 
         logging.debug("Could not get email for : %s", g.user)
         return None
 

--- a/src/ol_superset/pythonpath/superset_config.py
+++ b/src/ol_superset/pythonpath/superset_config.py
@@ -282,4 +282,4 @@ def current_user_email() -> Optional[str]:
         return None
 
 
-JINJA_CONTEXT_ADDONS = {"current_user_email": current_user_email()}
+JINJA_CONTEXT_ADDONS = {"current_user_email": current_user_email}

--- a/src/ol_superset/pythonpath/superset_config.py
+++ b/src/ol_superset/pythonpath/superset_config.py
@@ -263,6 +263,7 @@ SLACK_API_TOKEN = vault_client.secrets.kv.v2.read_secret(
     path="app-config", mount_point="secret-superset"
 )["data"]["data"]["slack_token"]
 
+
 #######################
 # Custom Jinja Macros #
 #######################
@@ -279,6 +280,7 @@ def current_user_email() -> Optional[str]:
         return g.user.email
     except Exception:  # pylint: disable=broad-except
         return None
+
 
 # Adding macros to enable usage in the jinja_context for Superset
 JINJA_CONTEXT_ADDONS = {"current_user_email": current_user_email}


### PR DESCRIPTION
### What are the relevant tickets?
Unblocks https://github.com/mitodl/ol-infrastructure/issues/1968

### Description (What does it do?)
Defined a new macro to return user email from the flask app in our superset config.

Superset's function hasn't been released yet and so isn't available in our instance.
See Superset's own code here:
[Jinja_context](https://github.com/apache/superset/blob/master/superset/jinja_context.py#L136-L148)
[Superset Utils](https://github.com/Vitor-Avila/superset/blob/40b0c78dd1e0b003e34361ec6920bdc36c279d5b/superset/utils/core.py#L1387-L1397)
[Superset Docs on Jinja Templating and adding custom macros](https://superset.apache.org/docs/installation/sql-templating/)

### How can this be tested?
Try running `SELECT {{ current_user_email() }}` in the SQL Lab on our Superset instance.