### PR TITLE
Adding a new oauth group to manage users of the superset alpha role.

### DIFF
--- a/src/ol_superset/pythonpath/superset_config.py
+++ b/src/ol_superset/pythonpath/superset_config.py
@@ -71,7 +71,8 @@ OAUTH_PROVIDERS = [
 # Testing out Keycloak role mapping to Superset
 # https://superset.apache.org/docs/installation/configuring-superset#mapping-ldap-or-oauth-groups-to-superset-roles
 AUTH_ROLES_MAPPING = {
-    "superset_admin": ["Admin"], "superset_alpha": ["Alpha"],
+    "superset_admin": ["Admin"],
+    "superset_alpha": ["Alpha"],
 }
 
 # if we should replace ALL the user's roles each login, or only on registration

--- a/src/ol_superset/pythonpath/superset_config.py
+++ b/src/ol_superset/pythonpath/superset_config.py
@@ -71,7 +71,7 @@ OAUTH_PROVIDERS = [
 # Testing out Keycloak role mapping to Superset
 # https://superset.apache.org/docs/installation/configuring-superset#mapping-ldap-or-oauth-groups-to-superset-roles
 AUTH_ROLES_MAPPING = {
-    "superset_admin": ["Admin"],
+    "superset_admin": ["Admin"], "superset_alpha": ["Alpha"],
 }
 
 # if we should replace ALL the user's roles each login, or only on registration


### PR DESCRIPTION
### What are the relevant tickets?
Unblocks https://github.com/mitodl/ol-infrastructure/issues/1968

### Description (What does it do?)
We would like to give some users access to Superset along with a few dashboards and need to give these users the Alpha role. This change will map the "superset_alpha" keycloak oauth group to the "Alpha" role in Superset.

### How can this be tested?
Checking the roles in Superset after Keycloak and Superset Config changes have been deployed.

### Checklist:
- [ ] Add superset_alpha role mapping to superset_config
- [ ] Add new superset_alpha group to the Pulumi/Keycloak/Touchstone configuration
- [ ] Ask Shelly and Shira to test after changes have been deployed