### PR TITLE
adding wagtail api urls for mit-open

### DIFF
--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.Production.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.Production.yaml
@@ -48,6 +48,7 @@ config:
     PGBOUNER_MIN_POOL_SIZE: 20
     SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT: "https://sso.ol.mit.edu/realms/olapps"
     TIKA_SERVER_ENDPOINT: "https://tika-production.odl.mit.edu"
+    MICROMASTERS_CMS_API_URL: "https://micromasters.mit.edu/api/v0/wagtail/"
   mitopen:db_password:
     secure: v1:siGmu4+ZCOqekx7l:4Pdgv4fKZIjWJPAcZDBdpvZ0mUW10SUcX/9ZatsnZbR/euYoklo8dTTFu4i/5kTnJHHYot1QK3xS+gk++lHZfneBoC9qBR+l2qzlvvNBoN8=
   vault:address: https://vault-production.odl.mit.edu

--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
@@ -34,6 +34,7 @@ config:
     PGBOUNER_MIN_POOL_SIZE: 20
     SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT:
     TIKA_SERVER_ENDPOINT: "https://tika-qa.odl.mit.edu"
+    MICROMASTERS_CMS_API_URL: "https://micromasters-rc.odl.mit.edu/api/v0/wagtail/"
   heroku_app:interpolation_vars:
     auth_allowed_redirect_hosts:
     - "live-qa.ocw.mit.edu"


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/mit-open/pull/608

### Description (What does it do?)
This sets the cms api url that mit-open uses to fetch program letter template data

### How can this be tested?
Once deployed to rc, the following should properly render a program certificate:
https://mitopen-rc.odl.mit.edu/program_letter/04940fc2-e011-4483-bae3-89f103a41e82/view

