### PR TITLE
Allow use of locally cloned edX and theme repos in Concourse

### DIFF
--- a/dockerfiles/openedx-edxapp/Earthfile
+++ b/dockerfiles/openedx-edxapp/Earthfile
@@ -25,18 +25,26 @@ locales:
   SAVE ARTIFACT /openedx/locale
 
 get-code:
-  FROM +apt-base
+  ARG EDX_PLATFORM_DIR
+  LOCALLY
+  IF [ -d $EDX_PLATFORM_DIR ]
   # Two required vars to specify the git repo and sha ref the build from.
-  ARG --required EDX_PLATFORM_GIT_REPO
-  ARG --required EDX_PLATFORM_GIT_BRANCH
-  GIT CLONE --branch $EDX_PLATFORM_GIT_BRANCH $EDX_PLATFORM_GIT_REPO /openedx/edx-platform
-  RUN cp /openedx/edx-platform/requirements/edx/base.txt /root/pip_package_lists/edx_base.txt
-  SAVE ARTIFACT /openedx/edx-platform
+    SAVE ARTIFACT $EDX_PLATFORM_DIR /openedx/edx-platform
+  ELSE
+    FROM +apt-base
+    ARG --required EDX_PLATFORM_GIT_REPO
+    ARG --required EDX_PLATFORM_GIT_BRANCH
+    GIT CLONE --branch $EDX_PLATFORM_GIT_BRANCH $EDX_PLATFORM_GIT_REPO /openedx/edx-platform
+    SAVE ARTIFACT /openedx/edx-platform
+  END
 
 install-deps:
-  FROM +get-code
+  FROM +apt-base
   ARG --required DEPLOYMENT_NAME
   ARG --required RELEASE_NAME
+  COPY +get-code/openedx/edx-platform /openedx/edx-platform
+  RUN cp /openedx/edx-platform/requirements/edx/base.txt /root/pip_package_lists/edx_base.txt
+  RUN ls -l /root/pip_package_lists/
   RUN pip install --no-warn-script-location --user --no-cache-dir -r /root/pip_package_lists/edx_base.txt -r /root/pip_package_lists/$RELEASE_NAME/$DEPLOYMENT_NAME.txt
   RUN pip install --no-warn-script-location --user --no-cache-dir -r /root/pip_package_overrides/$RELEASE_NAME/$DEPLOYMENT_NAME.txt
   IF [ "$DEPLOYMENT_NAME" = "mitxonline" ]
@@ -52,12 +60,18 @@ install-deps:
   SAVE ARTIFACT /root/.local
 
 themes:
-  FROM +apt-base
-  ARG --required THEME_GIT_REPO
-  ARG --required THEME_GIT_BRANCH
+  ARG THEME_DIR
   ARG --required DEPLOYMENT_NAME
-  GIT CLONE --branch $THEME_GIT_BRANCH $THEME_GIT_REPO /openedx/themes/$DEPLOYMENT_NAME
-  SAVE ARTIFACT /openedx/themes
+  LOCALLY
+  IF [ -d $THEME_DIR ]
+    SAVE ARTIFACT $THEME_DIR /openedx/themes/$DEPLOYMENT_NAME
+  ELSE
+    FROM +apt-base
+    ARG --required THEME_GIT_REPO
+    ARG --required THEME_GIT_BRANCH
+    GIT CLONE --branch $THEME_GIT_BRANCH $THEME_GIT_REPO /openedx/themes/$DEPLOYMENT_NAME
+    SAVE ARTIFACT /openedx/themes/$DEPLOYMENT_NAME
+  END
 
 tutor-utils:
   FROM +apt-base
@@ -80,7 +94,7 @@ collected:
   COPY +install-deps/edx-platform /openedx/edx-platform
   COPY +install-deps/nodeenv /openedx/nodeenv
   COPY +install-deps/.local /openedx/.local
-  COPY +themes/themes /openedx/themes
+  COPY +themes/openedx/themes /openedx/themes
   COPY +tutor-utils/bin /openedx/bin
   COPY +locales/locale /openedx/locale
   RUN chmod a+x /openedx/bin/*

--- a/src/ol_concourse/pipelines/open_edx/edx_platform_v2/earthly_packer_pulumi_pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/edx_platform_v2/earthly_packer_pulumi_pipeline.py
@@ -157,7 +157,11 @@ def build_edx_pipeline(release_names: list[str]) -> Pipeline:  # noqa: ARG001
                             # Use some cleverness with path to mount resources within
                             # the earthly git resource so code is where the Earthfile
                             # expects
-                            inputs=[Input(name=earthly_git_resource.name)],
+                            inputs=[
+                                Input(name=earthly_git_resource.name),
+                                Input(name=edx_platform_git_resource.name),
+                                Input(name=theme_git_resource.name),
+                            ],
                             outputs=[Output(name=Identifier("artifacts"))],
                             run=Command(
                                 path="bash",
@@ -169,11 +173,9 @@ def build_edx_pipeline(release_names: list[str]) -> Pipeline:  # noqa: ARG001
                                     cd {earthly_git_resource.name}/dockerfiles/openedx-edxapp;
                                     RELEASE_NAME={release_name};
                                     DEPLOYMENT_NAME={deployment_name};
-                                    EDX_PLATFORM_GIT_REPO="{edx_platform.git_origin}";
-                                    EDX_PLATFORM_GIT_BRANCH="{edx_platform.release_branch}";
-                                    THEME_GIT_REPO="{theme.git_origin}";
-                                    THEME_GIT_BRANCH="{theme.release_branch}";
-                                    earthly +docker-image --DEPLOYMENT_NAME="$DEPLOYMENT_NAME" --RELEASE_NAME="$RELEASE_NAME" --EDX_PLATFORM_GIT_REPO="$EDX_PLATFORM_GIT_REPO" --EDX_PLATFORM_GIT_BRANCH="$EDX_PLATFORM_GIT_BRANCH" --THEME_GIT_REPO="$THEME_GIT_REPO" --THEME_GIT_BRANCH="$THEME_GIT_BRANCH";
+                                    EDX_PLATFORM_DIR="../../../{edx_platform_git_resource.name}"
+                                    THEME_DIR="../../../{theme_git_resource.name}"
+                                    earthly +docker-image --DEPLOYMENT_NAME="$DEPLOYMENT_NAME" --RELEASE_NAME="$RELEASE_NAME" --EDX_PLATFORM_DIR="$EDX_PLATFORM_DIR" --THEME_DIR="$THEME_DIR";
                                     DIGEST=$(docker inspect --format '{{{{.Id}}}}' mitodl/edxapp-$DEPLOYMENT_NAME-$RELEASE_NAME | cut -d ":" -f2);
                                     echo "Saving docker image to tar file in the artifacts directory";
                                     docker save -o ../../../artifacts/image.tar $DIGEST;


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
When trying to pin a commit for an edx-platfom build it is ignored because of cloning from the target branch as part of the Earthly steps. This allows for passing the locally cloned repo so that pinned commits in the pipeline are properly handled.

### How can this be tested?
Try running the earthly build using the newly added args and see if the cloned repos are used

### Additional Context
This is to address a bug introduced in the master branch of edx-platform that is currently blocking testing of MITx online

