### PR TITLE
Add step to pull translation files at build time via edX Atlas

### DIFF
--- a/dockerfiles/openedx-edxapp/Earthfile
+++ b/dockerfiles/openedx-edxapp/Earthfile
@@ -1,5 +1,5 @@
-VERSION 0.7
-FROM python:3.8.12-buster
+VERSION 0.8
+FROM python:3.8-bookworm
 
 apt-base:
   ENV DEBIAN_FRONTEND=noninteractive
@@ -119,8 +119,33 @@ collected:
   ENV NO_PYTHON_UNINSTALL 1
   ENV NO_PREREQ_INSTALL 0
 
-build-static-assets-nonprod:
+
+fetch-translations:
   FROM +collected
+  ARG OPENEDX_TRANSLATIONS_REPOSITORY=openedx/openedx-translations
+  ARG OPENEDX_TRANSLATIONS_BRANCH=main
+  ARG OPENEDX_ATLAS_OPTIONS="--repository $OPENEDX_TRANSLATIONS_REPOSITORY --revision $OPENEDX_TRANSLATIONS_BRANCH"
+   ## Pull translations for edx_django_utils.plugins for both lms and cms
+  ENV DJANGO_SETTINGS_MODULE lms.envs.mitol.i18n
+  WORKDIR /openedx/edx-platform
+  RUN python manage.py lms pull_plugin_translations $OPENEDX_ATLAS_OPTIONS && \
+    python manage.py lms compile_plugin_translations && \
+    ## pull xblock translations via atlas
+    python manage.py lms pull_xblock_translations $OPENEDX_ATLAS_OPTIONS && \
+    python manage.py lms compile_xblock_translations && \
+    python manage.py cms compile_xblock_translations && \
+    ## pull translations via atlas
+    atlas pull $OPENEDX_ATLAS_OPTIONS \
+      translations/edx-platform/conf/locale:conf/locale \
+      translations/studio-frontend/src/i18n/messages:conf/plugins-locale/studio-frontend && \
+    python manage.py lms compilemessages && \
+    python manage.py lms compilejsi18n && \
+    python manage.py cms compilejsi18n
+  ENV DJANGO_SETTINGS_MODULE lms.envs.production
+  SAVE ARTIFACT /openedx/edx-platform /edx-platform
+
+build-static-assets-nonprod:
+  FROM +fetch-translations
   # ENV JS_ENV_EXTRA_CONFIG '{"PROCTORTRACK_CDN_URL": "\"https://verificientstatic-preprod.storage.googleapis.com/cdn/fb_cjs/edx_preprod_cjs.IQEQWWZ2.js\"", "PROCTORTRACK_CONFIG_KEY": "\"1PKRwFPezxXj3TsD\""}'
   ENV JS_ENV_EXTRA_CONFIG='{"PROCTORTRACK_CDN_URL":"\"\"","PROCTORTRACK_CONFIG_KEY":"\"\""}'
   RUN pip install --no-warn-script-location --user --no-cache-dir -e "git+https://github.com/openedx/codejail.git@babbe784b48bb9888aa159d8b401cbe5e07f0af4#egg=codejail" \
@@ -147,7 +172,7 @@ build-static-assets-nonprod:
   SAVE ARTIFACT /openedx/staticfiles-nonprod.tar.gz AS LOCAL staticfiles-nonprod.tar.gz
 
 build-static-assets-production:
-  FROM +collected
+  FROM +fetch-translations
   # ENV JS_ENV_EXTRA_CONFIG '{"PROCTORTRACK_CDN_URL": "\"https://verificientstatic.storage.googleapis.com/cdn/fb_cjs/edx_us_cjs.IQEQWWZ2.js\"", "PROCTORTRACK_CONFIG_KEY": "\"1PKRwFPezxXj3TsD\""}'
   ENV JS_ENV_EXTRA_CONFIG='{"PROCTORTRACK_CDN_URL":"\"\"","PROCTORTRACK_CONFIG_KEY":"\"\""}'
   RUN pip install --no-warn-script-location --user --no-cache-dir -e "git+https://github.com/openedx/codejail.git@babbe784b48bb9888aa159d8b401cbe5e07f0af4#egg=codejail" \
@@ -174,7 +199,7 @@ build-static-assets-production:
   SAVE ARTIFACT /openedx/staticfiles-production.tar.gz AS LOCAL staticfiles-production.tar.gz
 
 docker-image:
-  FROM +collected
+  FROM +fetch-translations
   ARG --required DEPLOYMENT_NAME
   ARG --required RELEASE_NAME
   ENV DJANGO_SETTINGS_MODULE="invalid"


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/3851

### Description (What does it do?)
https://github.com/openedx/edx-platform/commit/a10fce33794e9c527d3f651408b16f1ad5b7fec9 removed all of the djangojs.js files from the edx-platform repository, making it necessary to pull all translation related assets from the centralized translations repository. This adds a build step to use the atlas utility for fetching those translation files for inclusion in the final asset build.

### How can this be tested?
Download the most recent static asset build from S3 (e.g. `s3://ol-eng-artifacts/edx-staticfiles/mitxonline/master/staticfiles-nonprod-sha256:34a6002f1d7f4f8c37463328fba60cef0a920773f1e4b094a20ad94ee321643c.tar.gz`), unpack it, and run `find . -regex '.*djangojs.*.js.*' -type f`. This will yield zero results. After building the assets with this updated Earthfile running the find command will yield results again.

### Additional Context
This is all part of a long-running effort to re-architect how translation data is managed across the edX suite of repositories. 
- https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html
- https://docs.google.com/document/d/11dFBCnbdHiCEdZp3pZeHdeH8m7Glla-XbIin7cnIOzU/edit#