### PR TITLE
Fix: Add --strict-env-vars to vector

### DIFF
--- a/src/bilder/components/vector/files/vector.service
+++ b/src/bilder/components/vector/files/vector.service
@@ -15,9 +15,9 @@ After=network-online.target
 [Service]
 User=vector
 Group=vector
-ExecStartPre=/usr/bin/vector validate
-ExecStart=/usr/bin/vector
-ExecReload=/usr/bin/vector validate
+ExecStartPre=/usr/bin/vector validate ---strict-env-vars
+ExecStart=/usr/bin/vector --strict-env-vars
+ExecReload=/usr/bin/vector validate --strict-env-vars
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 AmbientCapabilities=CAP_NET_BIND_SERVICE

--- a/src/bilder/components/vector/steps.py
+++ b/src/bilder/components/vector/steps.py
@@ -138,7 +138,7 @@ def configure_vector(vector_config: VectorConfig):
     # this entirely. Vector now offers unit tests so perhaps we can use that.
     server.shell(
         name="Run vector validate",
-        commands=["/usr/bin/vector validate --no-environment"],
+        commands=["/usr/bin/vector validate --no-environment --strict-env-vars"],
         _env={
             "VECTOR_CONFIG_DIR": "/etc/vector",
             "AWS_REGION": "us-east-1",


### PR DESCRIPTION
### What are the relevant failed builds?

https://cicd.odl.mit.edu/teams/infrastructure/pipelines/docker-packer-pulumi-edxapp-global/jobs/build-packer-template-master-mitxonline/builds/667


### Description (What does it do?)

Adds --strict-env-vars to each vector invocation in our build as a result of https://vector.dev/highlights/2023-03-26-0-37-0-upgrade-guide/#breaking-changes

