### PR TITLE
config: enable zendesk help widget (xPRO Production)

### DIFF
--- a/src/ol_infrastructure/applications/xpro/Pulumi.applications.xpro.Production.yaml
+++ b/src/ol_infrastructure/applications/xpro/Pulumi.applications.xpro.Production.yaml
@@ -46,7 +46,7 @@ config:
     #WAGTAIL_CACHE_MAX_ENTRIES: 500
     #YOUTUBE_FETCH_SCHEDULE_SECONDS: 7200
     ZENDESK_DOMAIN_VERIFICATION_TAG_VALUE: "o0itxdfh369m1bw4cuz9"
-    ZENDESK_HELP_WIDGET_ENABLED: "False"
+    ZENDESK_HELP_WIDGET_ENABLED: "True"
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production
   xpro:db_password:


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Re-enabling the widget, We've tested it in RC.

### How can this be tested?
We should see a help widget button on the bottom right of https://xpro.mit.edu/
