### PR TITLE
Configure olapps to use the ol email theme

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/__main__.py
+++ b/src/ol_infrastructure/substructure/keycloak/__main__.py
@@ -156,9 +156,10 @@ ol_apps_realm = keycloak.Realm(
     attributes={
         "business_unit": f"operations-{env_name}",
     },
-    display_name="OL Apps",
-    display_name_html="<b>MIT Open Learning Applications</b>",
+    display_name="MIT Open",
+    display_name_html="<b>MIT Open</b>",
     enabled=True,
+    email_theme="ol",
     login_theme="ol",
     duplicate_emails_allowed=False,
     otp_policy=keycloak.RealmOtpPolicyArgs(


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Related to https://github.com/mitodl/ol-keycloak/issues/48

### Description (What does it do?)
<!--- Describe your changes in detail -->
A [recent PR](https://github.com/mitodl/ol-keycloak/pull/49) to `ol-keycloak` introduced a new email theme for keycloak emails to be used for the `olapps` realm. This PR adds the configuration to use it.

Docs: https://www.pulumi.com/registry/packages/keycloak/api-docs/realm/#email_theme_python
