### PR TITLE
Superset role mapping

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.CI.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.CI.yaml
@@ -22,14 +22,14 @@ config:
   keycloak:okta_single_sign_on_service_url: https://dev-66940844.okta.com/app/dev-66940844_mitci_1/exkcshk0uw4gnJILX5d7/sso/saml
   keycloak:openid_clients:
   - client_info:
-      open-discusions: https://discussions-ci.odl.mit.edu
+      open-discusions: ["https://discussions-ci.odl.mit.edu"]
       open-local: "*"
     realm_name: olapps
   - client_info:
-      superset: https://bi-ci.ol.mit.edu
+      superset: ["https://bi-ci.ol.mit.edu", superset_admin, superset_alpha]
     realm_name: ol-data-platform
   - client_info:
-      leek: https://celery-monitoring-ci.odl.mit.edu
+      leek: ["https://celery-monitoring-ci.odl.mit.edu"]
     realm_name: ol-platform-engineering
   keycloak:url: https://sso-ci.ol.mit.edu
   vault:address: https://vault-ci.odl.mit.edu

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.CI.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.CI.yaml
@@ -26,7 +26,7 @@ config:
       open-local: "*"
     realm_name: olapps
   - client_info:
-      superset: ["https://bi-ci.ol.mit.edu", superset_admin, superset_alpha]
+      superset: ["https://bi-ci.ol.mit.edu", "superset_admin", "superset_alpha"]
     realm_name: ol-data-platform
   - client_info:
       leek: ["https://celery-monitoring-ci.odl.mit.edu"]

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.CI.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.CI.yaml
@@ -22,14 +22,14 @@ config:
   keycloak:okta_single_sign_on_service_url: https://dev-66940844.okta.com/app/dev-66940844_mitci_1/exkcshk0uw4gnJILX5d7/sso/saml
   keycloak:openid_clients:
   - client_info:
-      open-discusions: ["https://discussions-ci.odl.mit.edu"]
+      open-discusions: ["https://discussions-ci.odl.mit.edu/*"]
       open-local: "*"
     realm_name: olapps
   - client_info:
-      superset: ["https://bi-ci.ol.mit.edu", "superset_admin", "superset_alpha"]
+      superset: ["https://bi-ci.ol.mit.edu/*", "superset_admin", "superset_alpha"]
     realm_name: ol-data-platform
   - client_info:
-      leek: ["https://celery-monitoring-ci.odl.mit.edu"]
+      leek: ["https://celery-monitoring-ci.odl.mit.edu/*"]
     realm_name: ol-platform-engineering
   keycloak:url: https://sso-ci.ol.mit.edu
   vault:address: https://vault-ci.odl.mit.edu

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.Production.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.Production.yaml
@@ -19,16 +19,16 @@ config:
     secure: v1:qw0/egOdCOUJi9Vy:CtyFmcodURyRrv9pG9o9wY9J+N2r6IoC
   keycloak:openid_clients:
   - client_info:
-      open: https://mitopen.odl.mit.edu
-      open-discussions: https://open.mit.edu
+      open: ["https://mitopen.odl.mit.edu/*"]
+      open-discussions: ["https://open.mit.edu/*"]
     realm_name: olapps
   - client_info:
-      airbyte: https://airbyte.odl.mit.edu
-      dagster: https://pipelines.odl.mit.edu
-      leek: https://celery-monitoring.odl.mit.edu
+      airbyte: ["https://airbyte.odl.mit.edu/*"]
+      dagster: ["https://pipelines.odl.mit.edu/*"]
+      leek: ["https://celery-monitoring.odl.mit.edu/*"]
     realm_name: ol-platform-engineering
   - client_info:
-      superset: https://bi.ol.mit.edu
+      superset: ["https://bi.ol.mit.edu/*", "superset_admin", "superset_alpha"]
     realm_name: ol-data-platform
   keycloak:url: https://sso.ol.mit.edu
   vault:address: https://vault-production.odl.mit.edu

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
@@ -24,16 +24,16 @@ config:
   keycloak:okta_single_sign_on_service_url: https://dev-66940844.okta.com/app/dev-66940844_collintestlogin_1/exk8gfblmeePE5uUQ5d7/sso/saml
   keycloak:openid_clients:
   - client_info:
-      open: https://mitopen-rc.odl.mit.edu
-      open-discussions: https://discussions-rc.odl.mit.edu
+      open: ["https://mitopen-rc.odl.mit.edu/*"]
+      open-discussions: ["https://discussions-rc.odl.mit.edu/*"]
     realm_name: olapps
   - client_info:
-      airbyte: https://airbyte-qa.odl.mit.edu
-      dagster: https://pipelines-qa.odl.mit.edu
-      leek: https://celery-monitoring-qa.odl.mit.edu
+      airbyte: ["https://airbyte-qa.odl.mit.edu/*"]
+      dagster: ["https://pipelines-qa.odl.mit.edu/*"]
+      leek: ["https://celery-monitoring-qa.odl.mit.edu/*"]
     realm_name: ol-platform-engineering
   - client_info:
-      superset: https://bi-qa.ol.mit.edu
+      superset: ["https://bi-qa.ol.mit.edu/*", "superset_admin", "superset_alpha"]
     realm_name: ol-data-platform
   keycloak:url: https://sso-qa.ol.mit.edu
   keycloak:user_migration_open_discussions_bearer_token:

--- a/src/ol_infrastructure/substructure/keycloak/__main__.py
+++ b/src/ol_infrastructure/substructure/keycloak/__main__.py
@@ -499,7 +499,7 @@ for openid_clients in keycloak_config.get_object("openid_clients"):
             enabled=True,
             access_type="CONFIDENTIAL",
             standard_flow_enabled=True,
-            valid_redirect_uris=[f"{url}/*"],
+            valid_redirect_uris=[f"{url}"],
             opts=resource_options.merge(ResourceOptions(delete_before_replace=True)),
         )
         vault.generic.Secret(
@@ -519,15 +519,14 @@ for openid_clients in keycloak_config.get_object("openid_clients"):
                 realm_name=realm_name,
             ).apply(json.dumps),
         )
-        if len(client_detail) > 1:
-            for role in client_detail[1:]:
-                openid_client_role = keycloak.Role(
-                    role,
-                    name=role,
-                    client_id=openid_client.id,
-                    realm_id=realm_name,
-                    opts=resource_options,
-                )
+        for role in client_detail[1:]:
+            openid_client_role = keycloak.Role(
+                role,
+                name=role,
+                client_id=openid_client.id,
+                realm_id=realm_name,
+                opts=resource_options,
+            )
 
 # OL - First login flow [START]
 # Does not require email verification or confirmation to connect with existing account.


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/ol-infrastructure/issues/1968

### Description (What does it do?)
<!--- Describe your changes in detail -->
This creates the two superset roles along with the mappings required to Moira groups. The Moira groups need to be created still. This should automatically map superset roles to Moira groups so that a person who is a member of the `ol-eng-data` group will automatically be a `superset_admin` when logged in through Touchstone via Keycloak.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
I ran it on CI and it appears to do what's expected.
### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
Not the idea way to code this, but went down the route of setting up a helper method and got somewhat lost in the details. Will need at some point to circle back and refactor some of the code, but this should do what is required for now. 
