### PR TITLE
Use external prod urls wherever feasible

### DIFF
--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.Production.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.Production.yaml
@@ -16,8 +16,6 @@ config:
     - "https://ocw.mit.edu"
     - "https://live.ocw.mit.edu"
     - "https://live-qa.ocw.mit.edu"
-    etl_micromasters_host: "micromasters.mit.edu"
-    etl_xpro_host: "xpro.mit.edu"
     mailgun_sender_domain: "discussions-mail.odl.mit.edu"
     sso_url: "sso.ol.mit.edu"
   heroku_app:vars:
@@ -48,7 +46,6 @@ config:
     PGBOUNER_MIN_POOL_SIZE: 20
     SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT: "https://sso.ol.mit.edu/realms/olapps"
     TIKA_SERVER_ENDPOINT: "https://tika-production.odl.mit.edu"
-    MICROMASTERS_CMS_API_URL: "https://micromasters.mit.edu/api/v0/wagtail/"
   mitopen:db_password:
     secure: v1:siGmu4+ZCOqekx7l:4Pdgv4fKZIjWJPAcZDBdpvZ0mUW10SUcX/9ZatsnZbR/euYoklo8dTTFu4i/5kTnJHHYot1QK3xS+gk++lHZfneBoC9qBR+l2qzlvvNBoN8=
   vault:address: https://vault-production.odl.mit.edu

--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.Production.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.Production.yaml
@@ -33,8 +33,6 @@ config:
     MITOPEN_COOKIE_NAME: "mitopen"
     MITOPEN_LOG_LEVEL: "INFO"
     MITOPEN_SUPPORT_EMAIL: "mitopen-support@mit.edu"
-    OCW_BASE_URL: "https://ocw.mit.edu/"
-    OCW_CONTENT_BUCKET_NAME: "ocw-content-storage"
     OCW_ITERATOR_CHUNK_SIZE: 300
     OIDC_ENDPOINT: "https://sso.ol.mit.edu/realms/olapps"
     OPENSEARCH_INDEX: "mitopen"

--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.Production.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.Production.yaml
@@ -36,7 +36,6 @@ config:
     OCW_BASE_URL: "https://ocw.mit.edu/"
     OCW_CONTENT_BUCKET_NAME: "ocw-content-storage"
     OCW_ITERATOR_CHUNK_SIZE: 300
-    OCW_LIVE_BUCKET: "ocw-content-live-production"
     OIDC_ENDPOINT: "https://sso.ol.mit.edu/realms/olapps"
     OPENSEARCH_INDEX: "mitopen"
     OPENSEARCH_SHARD_COUNT: 3

--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
@@ -24,7 +24,6 @@ config:
     OCW_BASE_URL: "https://live-qa.ocw.mit.edu/"
     OCW_CONTENT_BUCKET_NAME: "ocw-content-storage"
     OCW_ITERATOR_CHUNK_SIZE: 300
-    OCW_LIVE_BUCKET: "ocw-content-live-qa"
     OIDC_ENDPOINT: "https://sso-qa.ol.mit.edu/realms/olapps"
     OPENSEARCH_INDEX: "mitopen-rc"
     OPENSEARCH_SHARD_COUNT: 2

--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
@@ -21,8 +21,6 @@ config:
     MITOPEN_COOKIE_NAME: "mitopen-rc"
     MITOPEN_LOG_LEVEL: "INFO"
     MITOPEN_SUPPORT_EMAIL: "odl-mitopen-rc-support@mit.edu"
-    OCW_BASE_URL: "https://live-qa.ocw.mit.edu/"
-    OCW_CONTENT_BUCKET_NAME: "ocw-content-storage"
     OCW_ITERATOR_CHUNK_SIZE: 300
     OIDC_ENDPOINT: "https://sso-qa.ol.mit.edu/realms/olapps"
     OPENSEARCH_INDEX: "mitopen-rc"

--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
@@ -34,7 +34,6 @@ config:
     PGBOUNER_MIN_POOL_SIZE: 20
     SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT:
     TIKA_SERVER_ENDPOINT: "https://tika-qa.odl.mit.edu"
-    MICROMASTERS_CMS_API_URL: "https://micromasters-rc.odl.mit.edu/api/v0/wagtail/"
   heroku_app:interpolation_vars:
     auth_allowed_redirect_hosts:
     - "live-qa.ocw.mit.edu"
@@ -43,8 +42,6 @@ config:
     - "https://ol-devops-ci.odl.mit.edu"
     - "https://draft-qa.ocw.mit.edu"
     - "https://live-qa.ocw.mit.edu"
-    etl_micromasters_host: "micromasters-rc.odl.mit.edu"
-    etl_xpro_host: "rc.xpro.mit.edu"
     mailgun_sender_domain: "discussions-mail.odl.mit.edu"
     sso_url: "sso-qa.ol.mit.edu"
   mitopen:db_instance_size: "db.t4g.small"

--- a/src/ol_infrastructure/applications/mitopen/__main__.py
+++ b/src/ol_infrastructure/applications/mitopen/__main__.py
@@ -326,6 +326,8 @@ heroku_vars = {
     "MITX_ONLINE_PROGRAMS_API_URL": "https://mitxonline.mit.edu/api/programs/",
     "NEW_RELIC_LOG": "stdout",
     "NODE_MODULES_CACHE": "False",
+    "OCW_BASE_URL": "https://ocw.mit.edu/",
+    "OCW_CONTENT_BUCKET_NAME": "ocw-content-storage",
     "OCW_UPLOAD_IMAGE_ONLY": "True",
     "OCW_LIVE_BUCKET": "ocw-content-live-production",
     "OLL_ALT_URL": "https://openlearninglibrary.mit.edu/courses/",

--- a/src/ol_infrastructure/applications/mitopen/__main__.py
+++ b/src/ol_infrastructure/applications/mitopen/__main__.py
@@ -327,6 +327,7 @@ heroku_vars = {
     "NEW_RELIC_LOG": "stdout",
     "NODE_MODULES_CACHE": "False",
     "OCW_UPLOAD_IMAGE_ONLY": "True",
+    "OCW_LIVE_BUCKET": "ocw-content-live-production",
     "OLL_ALT_URL": "https://openlearninglibrary.mit.edu/courses/",
     "OLL_API_ACCESS_TOKEN_URL": "https://openlearninglibrary.mit.edu/oauth2/access_token/",
     "OLL_API_URL": "https://discovery.openlearninglibrary.mit.edu/api/v1/catalogs/1/courses/",

--- a/src/ol_infrastructure/applications/mitopen/__main__.py
+++ b/src/ol_infrastructure/applications/mitopen/__main__.py
@@ -307,6 +307,8 @@ heroku_vars = {
     "DUPLICATE_COURSES_URL": "https://raw.githubusercontent.com/mitodl/open-resource-blacklists/master/duplicate_courses.yml",
     "EDX_API_ACCESS_TOKEN_URL": "https://api.edx.org/oauth2/v1/access_token",
     "EDX_API_URL": "https://api.edx.org/catalog/v1/catalogs/10/courses",
+    "MICROMASTERS_CATALOG_API_URL": "https://micromasters.mit.edu/api/v0/catalog/",
+    "MICROMASTERS_CMS_API_URL": "https://micromasters.mit.edu/api/v0/wagtail/",
     "MITOPEN_ADMIN_EMAIL": "cuddle-bunnies@mit.edu",
     "MITOPEN_DB_CONN_MAX_AGE": 0,
     "MITOPEN_DB_DISABLE_SSL": "True",
@@ -336,6 +338,8 @@ heroku_vars = {
     "SOCIAL_AUTH_OL_OIDC_KEY": "ol-open-client",
     "USE_X_FORWARDED_HOST": "True",
     "USE_X_FORWARDED_PORT": "True",
+    "XPRO_CATALOG_API_URL": "https://xpro.mit.edu/api/programs/",
+    "XPRO_COURSES_API_URL": "https://xpro.mit.edu/api/courses/",
     "XPRO_LEARNING_COURSE_BUCKET_NAME": "mitx-etl-xpro-production-mitxpro-production",
     "YOUTUBE_FETCH_TRANSCRIPT_SCHEDULE_SECONDS": 21600,
     "YOUTUBE_CONFIG_URL": "https://raw.githubusercontent.com/mitodl/open-video-data/mitopen/youtube/channels.yaml",
@@ -359,14 +363,11 @@ heroku_interpolated_vars = {
     "MAILGUN_FROM_EMAIL": f"MIT Open <no-reply@{interpolation_vars['mailgun_sender_domain']}",
     "MAILGUN_SENDER_DOMAIN": interpolation_vars["mailgun_sender_domain"],
     "MAILGUN_URL": f"https://api.mailgun.net/v3/{interpolation_vars['mailgun_sender_domain']}",
-    "MICROMASTERS_CATALOG_API_URL": f"https://{interpolation_vars['etl_micromasters_host']}/api/v0/catalog/",
     "MITOPEN_CORS_ORIGIN_WHITELIST": cors_urls_json,
     "OIDC_ENDPOINT": f"https://{interpolation_vars['sso_url']}/realms/olapps",
     "SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS": auth_allowed_redirect_hosts_json,
     "SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT": f"https://{interpolation_vars['sso_url']}/realms/olapps",
     "USERINFO_URL": f"https://{interpolation_vars['sso_url']}/realms/olapps/protocol/openid-connect/userinfo",
-    "XPRO_CATALOG_API_URL": f"https://{interpolation_vars['etl_xpro_host']}/api/programs/",
-    "XPRO_COURSES_API_URL": f"https://{interpolation_vars['etl_xpro_host']}/api/courses/",
 }
 
 # Combine two var sources above with values explictly defined in pulumi configuration


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/3948

### Description (What does it do?)
Uses production urls for all external source urls where feasible.


### How can this be tested?
In mitopen, delete existing resources for xpro and micromasters, then rerun the ETL pipelines.
