### PR TITLE
Adds PostHog-specific settings to the MIT Open config

### DIFF
--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.Production.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.Production.yaml
@@ -43,6 +43,10 @@ config:
     PGBOUNER_MIN_POOL_SIZE: 20
     SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT: "https://sso.ol.mit.edu/realms/olapps"
     TIKA_SERVER_ENDPOINT: "https://tika-production.odl.mit.edu"
+    POSTHOG_ENABLED: "true"
+    POSTHOG_API_HOST: "https://app.posthog.com"
+    POSTHOG_TIMEOUT_MS: 1000
+    POSTHOG_PROJECT_ID: "63497"
   mitopen:db_password:
     secure: v1:siGmu4+ZCOqekx7l:4Pdgv4fKZIjWJPAcZDBdpvZ0mUW10SUcX/9ZatsnZbR/euYoklo8dTTFu4i/5kTnJHHYot1QK3xS+gk++lHZfneBoC9qBR+l2qzlvvNBoN8=
   vault:address: https://vault-production.odl.mit.edu

--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
@@ -31,6 +31,10 @@ config:
     PGBOUNER_MIN_POOL_SIZE: 20
     SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT:
     TIKA_SERVER_ENDPOINT: "https://tika-qa.odl.mit.edu"
+    POSTHOG_ENABLED: "true"
+    POSTHOG_API_HOST: "https://app.posthog.com"
+    POSTHOG_TIMEOUT_MS: 1000
+    POSTHOG_PROJECT_ID: "63497"
   heroku_app:interpolation_vars:
     auth_allowed_redirect_hosts:
     - "live-qa.ocw.mit.edu"

--- a/src/ol_infrastructure/applications/mitopen/__main__.py
+++ b/src/ol_infrastructure/applications/mitopen/__main__.py
@@ -346,6 +346,10 @@ heroku_vars = {
     "XPRO_LEARNING_COURSE_BUCKET_NAME": "mitx-etl-xpro-production-mitxpro-production",
     "YOUTUBE_FETCH_TRANSCRIPT_SCHEDULE_SECONDS": 21600,
     "YOUTUBE_CONFIG_URL": "https://raw.githubusercontent.com/mitodl/open-video-data/mitopen/youtube/channels.yaml",
+    "POSTHOG_ENABLED": "True",
+    "POSTHOG_TIMEOUT_MS": 1000,
+    "POSTHOG_API_HOST": "https://app.posthog.com",
+    "POSTHOG_PROJECT_ID": 63497,
 }
 
 # Values that require interpolation or other special considerations
@@ -445,6 +449,8 @@ sensitive_heroku_vars = {
     "SENTRY_DSN": mitopen_vault_secrets["sentry-dsn"],
     "STATUS_TOKEN": mitopen_vault_secrets["django-status-token"],
     "YOUTUBE_DEVELOPER_KEY": mitopen_vault_secrets["youtube-developer-key"],
+    "POSTHOG_PROJECT_API_KEY": mitopen_vault_secrets["posthog-project-api-key"],
+    "POSTHOG_PERSONAL_API_KEY": mitopen_vault_secrets["posthog-personal-api-key"],
     # Vars that require more
     "AWS_ACCESS_KEY_ID": auth_aws_mitx_creds_ol_mitopen_application.data.apply(
         lambda data: "{}".format(data["access_key"])


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#4009

### Description (What does it do?)

This adds a couple non-secret settings:
- `POSTHOG_ENABLED` - boolean to toggle integration on/off
- `POSTHOG_TIMEOUT_MS` - int, timeout for hitting the PostHog API
- `POSTHOG_API_HOST` - string, the URL for the PostHog API (this generally doesn't change but it can, esp. if we opt to self-host)
- `POSTHOG_PROJECT_ID` - string, the project ID for use with the private PostHog API

And a couple of secrets:
- `POSTHOG_PROJECT_API_KEY` - the API key for the project itself (this is not _strictly_ a secret but it looks like an API key so lumping it in here to keep things from flagging it as such)
- `POSTHOG_PERSONAL_API_KEY` - the API key we'll use for querying the PostHog private API - this is different from the _project_ key, which we use to collect analytics, and _is_ secret since it supports UD operations

### Additional Context

We don't use the personal API key or project ID yet (though the project ID has a reasonable default - it is set to the [PostHog project for Open](https://us.posthog.com/project/63497/)). But, [that's coming pretty soon.](https://github.com/mitodl/hq/issues/4008)

As noted, the project API key is used for POSTing to the public API; the key is an identifier and does not convey any permissions to do anything (and is available in clear text in the app) so this can be put in the regular config rather than the vault if that's preferred. 

I haven't had to do this yet so I'm expecting some of this to be wrong.
