### PR TITLE
Fix: Add nubbins for celery monitoring

### DIFF
--- a/src/ol_superset/pythonpath/superset_config.py
+++ b/src/ol_superset/pythonpath/superset_config.py
@@ -224,6 +224,8 @@ class CeleryConfig:  # pylint: disable=too-few-public-methods
     redis_password = REDIS_TOKEN
     worker_prefetch_multiplier = 1
     task_acks_late = True
+    task_track_started = True
+    task_send_sent_event = True
     task_annotations = {  # noqa: RUF012
         "sql_lab.get_sql_results": {
             "rate_limit": "100/s",


### PR DESCRIPTION
This commit adds two Celery client configurables necessary for celery monitoring.

    CELERY_TASK_TRACK_STARTED
    CELERY_TASK_SEND_SENT_EVENT

For: mitodl/ol-infrastructure#2290

### What are the relevant tickets?
mitodl/ol-infrastructure#2290

### Description (What does it do?)
This commit adds two Celery client configurables necessary for [celery monitoring](https://celery-monitoring.odl.mit.edu).

    CELERY_TASK_TRACK_STARTED
    CELERY_TASK_SEND_SENT_EVENT


### How can this be tested?
Surf to [celery monitoring](https://celery-monitoring.odl.mit.edu)

Choose "Superset" under product. Observe task status.

