### PR TITLE
Fix: Add celery monitoring sg to superset's redis.

### DIFF
--- a/src/ol_infrastructure/applications/celery_monitoring/__main__.py
+++ b/src/ol_infrastructure/applications/celery_monitoring/__main__.py
@@ -7,7 +7,7 @@ import pulumi_consul as consul
 import pulumi_vault as vault
 import yaml
 from bridge.secrets.sops import read_yaml_secrets
-from pulumi import Config, Output, ResourceOptions, StackReference, export
+from pulumi import Config, Output, ResourceOptions, StackReference
 from pulumi_aws import acm, ec2, get_caller_identity, iam, route53
 
 from ol_infrastructure.components.aws.auto_scale_group import (
@@ -367,9 +367,4 @@ route53.Record(
     records=[celery_monitoring_web_asg.load_balancer.dns_name],
     zone_id=mitodl_zone_id,
     opts=ResourceOptions(delete_before_replace=True),
-)
-
-export(
-    "celery_monitoring",
-    {"security_group": celery_monitoring_security_group.id},
 )

--- a/src/ol_infrastructure/applications/celery_monitoring/__main__.py
+++ b/src/ol_infrastructure/applications/celery_monitoring/__main__.py
@@ -7,7 +7,7 @@ import pulumi_consul as consul
 import pulumi_vault as vault
 import yaml
 from bridge.secrets.sops import read_yaml_secrets
-from pulumi import Config, Output, ResourceOptions, StackReference
+from pulumi import Config, Output, ResourceOptions, StackReference, export
 from pulumi_aws import acm, ec2, get_caller_identity, iam, route53
 
 from ol_infrastructure.components.aws.auto_scale_group import (
@@ -367,4 +367,9 @@ route53.Record(
     records=[celery_monitoring_web_asg.load_balancer.dns_name],
     zone_id=mitodl_zone_id,
     opts=ResourceOptions(delete_before_replace=True),
+)
+
+export(
+    "celery_monitoring",
+    {"security_group": celery_monitoring_security_group.id},
 )

--- a/src/ol_infrastructure/applications/superset/__main__.py
+++ b/src/ol_infrastructure/applications/superset/__main__.py
@@ -52,6 +52,9 @@ vault_mount_stack = StackReference(
     f"substructure.vault.static_mounts.operations.{stack_info.name}"
 )
 policy_stack = StackReference("infrastructure.aws.policies")
+celery_monitoring_stack = StackReference(
+    f"applications.celery_monitoring.{stack_info.name}"
+)
 
 mitol_zone_id = dns_stack.require_output("ol")["id"]
 data_vpc = network_stack.require_output("data_vpc")
@@ -393,8 +396,14 @@ redis_cluster_security_group = ec2.SecurityGroup(
             from_port=DEFAULT_REDIS_PORT,
             to_port=DEFAULT_REDIS_PORT,
             protocol="tcp",
-            security_groups=[superset_security_group.id],
-            description="Allow access from edX to Redis for caching and queueing",
+            security_groups=[
+                superset_security_group.id,
+                celery_monitoring_stack.require_output("celery_monitoring")[
+                    "security_group"
+                ],
+            ],
+            description="Allow access from edX & celery monitoring to Redis for"
+            "caching and queueing",
         )
     ],
     tags=aws_config.merged_tags({"Name": f"superset-redis-{superset_env}"}),

--- a/src/ol_infrastructure/applications/superset/__main__.py
+++ b/src/ol_infrastructure/applications/superset/__main__.py
@@ -52,11 +52,8 @@ vault_mount_stack = StackReference(
     f"substructure.vault.static_mounts.operations.{stack_info.name}"
 )
 policy_stack = StackReference("infrastructure.aws.policies")
-celery_monitoring_stack = StackReference(
-    f"applications.celery_monitoring.{stack_info.name}"
-)
-
 mitol_zone_id = dns_stack.require_output("ol")["id"]
+operations_vpc = network_stack.require_output("operations_vpc")
 data_vpc = network_stack.require_output("data_vpc")
 superset_env = f"data-{stack_info.env_suffix}"
 superset_vault_kv_path = vault_mount_stack.require_output("superset_kv")["path"]
@@ -398,9 +395,7 @@ redis_cluster_security_group = ec2.SecurityGroup(
             protocol="tcp",
             security_groups=[
                 superset_security_group.id,
-                celery_monitoring_stack.require_output("celery_monitoring")[
-                    "security_group"
-                ],
+                operations_vpc["security_groups"]["celery_monitoring"],
             ],
             description="Allow access from edX & celery monitoring to Redis for"
             "caching and queueing",


### PR DESCRIPTION
Fix: Add celery monitoring sg to superset's redis.

### What are the relevant tickets?
Related to #2290

### Description (What does it do?)
Adds celery monitoring sg to superset's redis cache's sg inbound egress rules.


### How can this be tested?

Surf to https://celery-monitoring.odl.mit.edu - choose the 'superset" product. Click on Workers and Tasks and observe them being populated.