### PR TITLE
create static mounts in vault for xqwatcher secrets 

### DIFF
--- a/src/ol_infrastructure/substructure/vault/static_mounts/__main__.py
+++ b/src/ol_infrastructure/substructure/vault/static_mounts/__main__.py
@@ -29,6 +29,17 @@ celery_monitoring_vault_kv_mount = vault.Mount(
     opts=ResourceOptions(delete_before_replace=True),
 )
 
+xqwatcher_vault_kv_mount = vault.Mount(
+    "xqwatcher-vault-kv-secrets-mount",
+    path="secret-xqwatcher",
+    description=("Static secrets storage for xqwatcher"),
+    type="kv-v2",
+    options={
+        "version": 2,
+    },
+    opts=ResourceOptions(delete_before_replace=True),
+)
+
 export(
     "superset_kv",
     {
@@ -42,5 +53,13 @@ export(
     {
         "path": celery_monitoring_vault_kv_mount.path,
         "type": celery_monitoring_vault_kv_mount.type,
+    },
+)
+
+export(
+    "xqwatcher_kv",
+    {
+        "path": xqwatcher_vault_kv_mount.path,
+        "type": xqwatcher_vault_kv_mount.type,
     },
 )


### PR DESCRIPTION
### What are the relevant tickets?
#2326 

### Description (What does it do?)
Added static mounts to all stacks for xqwatcher. Merging this in before other changes because these mounts are required for stack testing to take place and it would be good if pulumi wouldn't delete them out from under me every day. 
