### PR TITLE
Removing no longer needed migration plugin

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/keycloak/docker_packer_pulumi_pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/keycloak/docker_packer_pulumi_pipeline.py
@@ -125,14 +125,6 @@ def build_keycloak_infrastructure_pipeline() -> PipelineFragment:
         repository="keycloak-scim",
     )
 
-    # Repo: https://github.com/daniel-frak/keycloak-user-migration
-    # Use: Migrating users from open discussions
-    user_migration_spi = github_release(
-        name=Identifier("user-migration-spi"),
-        owner="daniel-frak",
-        repository="keycloak-user-migration",
-    )
-
     #############################################
     image_build_context = Output(name=Identifier("image-build-context"))
 
@@ -146,7 +138,6 @@ def build_keycloak_infrastructure_pipeline() -> PipelineFragment:
             GetStep(get=metrics_spi.name, trigger=True),
             GetStep(get=ol_spi.name, trigger=True),
             GetStep(get=scim_spi.name, trigger=True),
-            GetStep(get=user_migration_spi.name, trigger=True),
             TaskStep(
                 task=Identifier("collect-artifacts-for-build-context"),
                 config=TaskConfig(
@@ -158,7 +149,6 @@ def build_keycloak_infrastructure_pipeline() -> PipelineFragment:
                         Input(name=metrics_spi.name),
                         Input(name=ol_spi.name),
                         Input(name=scim_spi.name),
-                        Input(name=user_migration_spi.name),
                     ],
                     image_resource=AnonymousResource(
                         type=REGISTRY_IMAGE,
@@ -176,7 +166,6 @@ def build_keycloak_infrastructure_pipeline() -> PipelineFragment:
                         cp -r {metrics_spi.name}/* {image_build_context.name}/plugins/
                         cp -r {ol_spi.name}/* {image_build_context.name}/plugins/
                         cp -r {scim_spi.name}/* {image_build_context.name}/plugins/
-                        cp -r {user_migration_spi.name}/* {image_build_context.name}/plugins/
                         """  # noqa: E501
                             ),
                         ],
@@ -217,7 +206,6 @@ def build_keycloak_infrastructure_pipeline() -> PipelineFragment:
             metrics_spi,
             ol_spi,
             scim_spi,
-            user_migration_spi,
         ],
         jobs=[docker_build_job],
     )

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
@@ -36,7 +36,5 @@ config:
       superset: ["https://bi-qa.ol.mit.edu/*", "superset_admin", "superset_alpha"]
     realm_name: ol-data-platform
   keycloak:url: https://sso-qa.ol.mit.edu
-  keycloak:user_migration_open_discussions_bearer_token:
-    secure: v1:JlslYpQlva2/fWrn:2sYWwNCeNRNERF4wYmxpnw1+YF1sHp3hBNg6F9upUVH+el+XWc0XrgZ6NEVU8dC4SLc2Hd1r8gg=
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa

--- a/src/ol_infrastructure/substructure/keycloak/__main__.py
+++ b/src/ol_infrastructure/substructure/keycloak/__main__.py
@@ -918,28 +918,6 @@ if stack_info.env_suffix in ["ci", "qa"]:
     # OKTA-DEV [END] # noqa: ERA001
 
 if stack_info.env_suffix == "qa":
-    # User migration plug-in for Open Discussions in RC.
-    keycloak.CustomUserFederation(
-        "ol-open-discussions-qa-user-migration-federation",
-        cache_policy="DEFAULT",
-        config={
-            "API_TOKEN_ENABLED": True,
-            "API_HTTP_BASIC_ENABLED": False,
-            "API_TOKEN": keycloak_config.get(
-                "keycloak_user_migration_open_discussions_bearer_token"
-            ),
-            "MIGRATE_UNMAPPED_GROUPS": False,
-            "MIGRATE_UNMAPPED_ROLES": False,
-            "URI": "https://discussions-rc.odl.mit.edu/api/v0/auth",
-            "USE_USER_ID_FOR_CREDENTIAL_VERIFICATION": False,
-            "API_HTTP_BASIC_USERNAME": "",
-        },
-        enabled=True,
-        name="Open Discussions",
-        provider_id="User migration using a REST client",
-        realm_id=ol_apps_realm.id,
-        opts=resource_options,
-    )
     # SCIM for MIT-Open in RC.
     keycloak.CustomUserFederation(
         "ol-mit-open-qa-scim",


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
Remove the Keycloak user migration plugin that we were testing with and potentially were gonna use for migrating users from Discussions. However, appears that we won't be going that route and thus the plugin is no longer necessary.