### PR TITLE
Md/issue 2326

### DIFF
--- a/src/bilder/components/hashicorp/steps.py
+++ b/src/bilder/components/hashicorp/steps.py
@@ -128,3 +128,9 @@ def configure_hashicorp_product(product: HashicorpProduct):
             )
         )
         temp_src.close()
+
+
+# Helper function to allow configuring to follow the same pattern as installing
+def configure_hashicorp_products(hashicorp_products: list[HashicorpProduct]):
+    for product in hashicorp_products:
+        configure_hashicorp_product(product)

--- a/src/bilder/images/xqwatcher/deploy.py
+++ b/src/bilder/images/xqwatcher/deploy.py
@@ -1,0 +1,263 @@
+import os
+from io import StringIO
+from pathlib import Path
+
+from bridge.lib.magic_numbers import VAULT_HTTP_PORT
+from bridge.lib.versions import CONSUL_TEMPLATE_VERSION, CONSUL_VERSION, VAULT_VERSION
+from bridge.secrets.sops import set_env_secrets
+from pyinfra import host
+from pyinfra.operations import files, server, apt, git
+
+from bilder.components.hashicorp.consul.models import (
+    Consul,
+    ConsulAddresses,
+    ConsulConfig,
+    ConsulService,
+    ConsulServiceTCPCheck,
+)
+from bilder.components.hashicorp.consul.steps import proxy_consul_dns
+from bilder.components.hashicorp.consul_template.models import (
+    ConsulTemplate,
+    ConsulTemplateConfig,
+    ConsulTemplateTemplate,
+    ConsulTemplateVaultConfig,
+)
+from bilder.components.hashicorp.consul_template.steps import (
+    consul_template_permissions,
+)
+from bilder.components.hashicorp.steps import (
+    configure_hashicorp_product,
+    install_hashicorp_products,
+    register_services,
+)
+from bilder.components.hashicorp.vault.models import (
+    Vault,
+    VaultAgentCache,
+    VaultAgentConfig,
+    VaultAutoAuthAWS,
+    VaultAutoAuthConfig,
+    VaultAutoAuthFileSink,
+    VaultAutoAuthMethod,
+    VaultAutoAuthSink,
+    VaultConnectionConfig,
+    VaultListener,
+    VaultTCPListener,
+)
+from bilder.components.vector.models import VectorConfig
+from bilder.components.vector.steps import install_and_configure_vector
+from bilder.facts.has_systemd import HasSystemd
+from bilder.lib.linux_helpers import DOCKER_COMPOSE_DIRECTORY
+
+from bilder.components.baseline.steps import install_baseline_packages
+
+VERSIONS = {
+    "consul": os.environ.get("CONSUL_VERSION", CONSUL_VERSION),
+    "consul-template": os.environ.get("CONSUL_TEMPLATE_VERSION", CONSUL_TEMPLATE_VERSION),
+    "vault": os.environ.get("VAULT_VERSION", VAULT_VERSION),
+}
+
+set_env_secrets(Path("consul/consul.env"))
+
+FILES_DIRECTORY = Path(__file__).resolve().parent.joinpath("files")
+TEMPLATES_DIRECTORY = Path(__file__).resolve().parent.joinpath("templates")
+
+install_baseline_packages(
+    packages=[
+        "curl",
+        "git",
+        "python3",
+        "python3-dev",
+        "python3-pip",
+        "python3-virtualenv",
+        "libmariadb-dev",
+        "libmariadb-dev-compat",
+        "libssl-dev",
+        "libopenblas-dev",
+        "liblapack-dev",
+    ],
+    upgrade_system=True,
+)
+
+server.shell(
+    name="Disable git safe directory checking on immutable machines",
+    commands=["git config --system safe.directory *"],
+)
+
+apt.packages(
+    name="Remove unattended-upgrades to prevent race conditions during build",
+    packages=["unattended-upgrades"],
+    present=False,
+)
+
+XQWATCHER_HOME = Path("/home/xqwatcher")
+XQWATCHER_INSTALL_DIR = XQWATCHER_HOME.joinpath("xqwatcher")
+XQWATCHER_VENV_DIR = XQWATCHER_INSTALL_DIR.joinpath(".venv")
+XQWATCHER_CONF_DIR = XQWATCHER_INSTALL_DIR.joinpath("conf.d")
+XQWATCHER_LOG_DIR = XQWATCHER_INSTALL_DIR.joinpath("log")
+XQWATCHER_GRADER_DIR = XQWATCHER_INSTALL_DIR.joinpath("graders")
+XQWATCHER_GRADER_VENVS_DIR = XQWATCHER_INSTALL_DIR.joinpath("grader_venvs")
+XQWATCHER_LOGGING_CONFIG_FILE = XQWATCHER_INSTALL_DIR.joinpath("logging.json")
+XQWATCHER_SSH_DIR = XQWATCHER_INSTALL_DIR.joinpath(".ssh")
+XQWATCHER_BRANCH = "master"
+XQWATCHER_GIT_REPO = "https://github.com/mitodl/xqueue-watcher.git"
+XQWATCHER_USER = "xqwatcher"
+
+shared_template_context = {
+    "XQWATCHER_LOG_DIR": str(XQWATCHER_LOG_DIR),
+    "XQWATCHER_GRADER_VENVS_DIR": str(XQWATCHER_GRADER_VENVS_DIR),
+}
+
+server.user(
+    name="Create xqwatcher user and home directory",
+    create_home=True,
+    ensure_home=True,
+    home=str(XQWATCHER_HOME),
+    present=True,
+    shell="/bin/bash",
+    user=XQWATCHER_USER,
+)
+
+git.repo(
+    name="Clone xqwatcher repository from github",
+    branch=XQWATCHER_BRANCH,
+    dest=str(XQWATCHER_INSTALL_DIR),
+    group="xqwatcher",
+    pull=True,
+    src=XQWATCHER_GIT_REPO,
+    user="xqwatcher",
+)
+
+server.shell(
+    name="Create virtual environment for xqwatcher",
+    commands=[f"/usr/bin/virtualenv {XQWATCHER_VENV_DIR}"],
+)
+
+server.shell(
+    name="Install xqwatcher requirements into the virtual environment",
+    commands=[f"{XQWATCHER_VENV_DIR.joinpath('bin/pip3')} install -r {XQWATCHER_INSTALL_DIR.joinpath('requirements/production.txt')} --exists-action w"],
+)
+
+files.directory(
+    name="Create the conf.d directory for xqwatcher configurations",
+    path=str(XQWATCHER_CONF_DIR),
+    user=XQWATCHER_USER,
+    group=XQWATCHER_USER,
+    present=True,
+    mode="0750",
+)
+
+files.directory(
+    name="Create a directory for logs",
+    path=str(XQWATCHER_LOG_DIR),
+    user=XQWATCHER_USER,
+    group=XQWATCHER_USER,
+    mode="0750",
+)
+
+files.template(
+    name="Create logging configuration file",
+    src=FILES_DIRECTORY.joinpath("logging.json.j2"),
+    dest=str(XQWATCHER_LOGGING_CONFIG_FILE),
+    user=XQWATCHER_USER,
+    group=XQWATCHER_USER,
+    mode="0664",
+    shared_context=shared_template_context,
+)
+
+files.directory(
+    name="Create grader directory",
+    path=str(XQWATCHER_GRADER_DIR),
+    user=XQWATCHER_USER,
+    group=XQWATCHER_USER,
+    mode="0750",
+)
+
+files.directory(
+    name="Create grader venvs directory",
+    path=str(XQWATCHER_GRADER_VENV_DIR),
+    user=XQWATCHER_USER,
+    group=XQWATCHER_USER,
+    mode="0750",
+)
+
+files.directory(
+    name="Create ~xqwatcher/.ssh directory",
+    path=str(XQWATCHER_SSH_DIR),
+    user=XQWATCHER_USER,
+    group=XQWATCHER_USER,
+    mode="0700",
+)
+
+consul_configuration = {
+    Path("00-default.json"): ConsulConfig(
+        addresses=ConsulAddresses(dns="127.0.0.1", http="127.0.0.1"),
+        advertise_addr='{{ GetInterfaceIP "ens5" }}',
+        services=[]
+    ),
+}
+consul = Consul(version=VERSIONS["consul"], configuration=consul_configuration)
+
+consul_template_configuration = {
+    Path("00-graders.json"): ConsulTemplateConfig(
+        vault=ConsulTemplateVaultConfig(),
+        template=[
+            # https://github.com/mitodl/xqueue-watcher?tab=readme-ov-file#running-xqueue-watcher
+            ConsulTemplateTemplate(
+                contents=(
+                    '{{ with secret "secret-xqwatcher/grader-config" }}'
+                    '{{ printf .Data.data.confd_json }}{{ end }}'
+                ),
+                destination=XQWATCHER_CONF_DIR.joinpath("grader_config.json"),
+            ),
+            ConsulTemplateTemplate(
+                contents=(
+                    '{{ with secret "secret-xqwatcher/grader-config" }}'
+                    '{{ printf .Data.data.xqwatcher-grader-code-ssh-identity }}{{ end }}'
+                ),
+                destination=XQWATCHER_SSH_DIR.joinpath("xqwatcher-grader-code-ssh-identity"),
+            ),
+            ConsulTemplateTemplate(
+            ),
+        ]
+    ),
+}
+consul_template = ConsulTemplate(
+    version=VERSIONS["consul-template"],
+    configuration=consul_template_configuration,
+)
+
+vault_configuration = {
+    Path("agent.json"): VaultAgentConfig(
+        cache=VaultAgentCache(use_auto_auth_token="force"),
+        listener=[
+            VaultListener(
+                tcp=VaultTCPListener(
+                    address=f"127.0.0.1:{VAULT_HTTP_PORT}", tls_disable=True
+                ),
+            ),
+        ],
+        vault=VaultConnectionConfig(
+            address=f"https://vault.query.consul:{VAULT_HTTP_PORT}",
+            tls_skip_verify=True,
+        ),
+        auto_auth=VaultAutoAuthConfig(
+            method=VaultAutoAuthMethod(
+                type="aws",
+                mount_path="auth/aws",
+                config=VaultAutoAuthAWS(role="xqwatcher-server"),
+            ),
+            sink=[VaultAutoAuthSink(type="file", config=[VaultAutoAuthFileSink()])],
+        ),
+    ),
+}
+vault = Vault(version=VERSIONS["vault"], configuration=vault_configuration)
+
+hashicorp_products = [consul, consul_template, vault]
+install_hashicorp_products(hashicorp_products)
+configure_hashicorp_product(hashicorp_products)
+
+consul_template_permissions(consul_template.configuration)
+
+if host.get_fact(HasSystemd):
+    register_services(hashicorp_products, start_services_immediately=False)
+    proxy_consul_dns()

--- a/src/bilder/images/xqwatcher/deploy.py
+++ b/src/bilder/images/xqwatcher/deploy.py
@@ -75,6 +75,7 @@ install_baseline_packages(
         "libmariadb-dev",
         "libopenblas-dev",
         "libssl-dev",
+        "logrotate",
         "pkg-config",
         "python3",
         "python3-dev",
@@ -124,6 +125,7 @@ shared_template_context = {
     "XQWATCHER_GRADERS_VENVS_DIR": str(XQWATCHER_GRADERS_VENVS_DIR),
     "XQWATCHER_INSTALL_DIR": str(XQWATCHER_INSTALL_DIR),
     "XQWATCHER_LOG_DIR": str(XQWATCHER_LOG_DIR),
+    "XQWATCHER_USER": str(XQWATCHER_USER),
     "XQWATCHER_VENV_DIR": str(XQWATCHER_VENV_DIR),
 }
 
@@ -200,6 +202,16 @@ files.template(
     user=XQWATCHER_USER,
     group=XQWATCHER_USER,
     mode="0664",
+    shared_context=shared_template_context,
+)
+
+files.template(
+    name="Create logrotate.d configuration",
+    src=str(TEMPLATES_DIRECTORY.joinpath("logrotate.xqwatcher.j2")),
+    dest="/etc/logrotate.d/xqwatcher",
+    user="root",
+    group="root",
+    mode="0644",
     shared_context=shared_template_context,
 )
 

--- a/src/bilder/images/xqwatcher/deploy.py
+++ b/src/bilder/images/xqwatcher/deploy.py
@@ -9,7 +9,10 @@ from bridge.secrets.sops import set_env_secrets
 from pyinfra import host
 from pyinfra.operations import apt, files, git, server
 
-from bilder.components.baseline.steps import install_baseline_packages
+from bilder.components.baseline.steps import (
+    install_baseline_packages,
+    service_configuration_watches,
+)
 from bilder.components.hashicorp.consul.models import (
     Consul,
     ConsulAddresses,
@@ -61,6 +64,7 @@ TEMPLATES_DIRECTORY = Path(__file__).resolve().parent.joinpath("templates")
 install_baseline_packages(
     packages=[
         "build-essential",
+        "cron",
         "curl",
         "gfortran",
         "git",
@@ -91,25 +95,36 @@ apt.packages(
     present=False,
 )
 
+APP_ARMOR_DIR = Path("/etc/apparmor.d")
+
 XQWATCHER_HOME = Path("/home/xqwatcher")
+XQWATCHER_SSH_DIR = XQWATCHER_HOME.joinpath(".ssh")
 XQWATCHER_INSTALL_DIR = XQWATCHER_HOME.joinpath("xqwatcher")
+
 XQWATCHER_VENV_DIR = XQWATCHER_INSTALL_DIR.joinpath(".venv")
 XQWATCHER_CONF_DIR = XQWATCHER_INSTALL_DIR.joinpath("conf.d")
 XQWATCHER_LOG_DIR = XQWATCHER_INSTALL_DIR.joinpath("log")
-XQWATCHER_GRADER_DIR = XQWATCHER_INSTALL_DIR.joinpath("graders")
-XQWATCHER_GRADER_VENVS_DIR = XQWATCHER_INSTALL_DIR.joinpath("grader_venvs")
-XQWATCHER_GRADER_CONFIG_FILE = XQWATCHER_INSTALL_DIR.joinpath("grader_config.yaml")
+XQWATCHER_GRADERS_DIR = XQWATCHER_INSTALL_DIR.joinpath("graders")
+XQWATCHER_GRADERS_VENVS_DIR = XQWATCHER_INSTALL_DIR.joinpath("grader_venvs")
+XQWATCHER_GRADERS_CONFIG_FILE = XQWATCHER_CONF_DIR.joinpath("grader_config.json")
+XQWATCHER_FETCH_GRADERS_CONFIG_FILE = XQWATCHER_INSTALL_DIR.joinpath(
+    "fetch_graders.yaml"
+)
+XQWATCHER_FETCH_GRADERS_SCRIPT_FILE = XQWATCHER_INSTALL_DIR.joinpath("fetch_graders.py")
 XQWATCHER_LOGGING_CONFIG_FILE = XQWATCHER_INSTALL_DIR.joinpath("logging.json")
-XQWATCHER_SSH_DIR = XQWATCHER_HOME.joinpath(".ssh")
+
+XQWATCHER_SERVICE_FILE = Path("/usr/lib/systemd/system/xqwatcher.service")
 XQWATCHER_BRANCH = "master"
 XQWATCHER_GIT_REPO = "https://github.com/mitodl/xqueue-watcher.git"
 XQWATCHER_USER = "xqwatcher"
 
 shared_template_context = {
+    "XQWATCHER_FETCH_GRADERS_CONFIG_FILE": str(XQWATCHER_FETCH_GRADERS_CONFIG_FILE),
+    "XQWATCHER_GRADERS_DIR": str(XQWATCHER_GRADERS_DIR),
+    "XQWATCHER_GRADERS_VENVS_DIR": str(XQWATCHER_GRADERS_VENVS_DIR),
+    "XQWATCHER_INSTALL_DIR": str(XQWATCHER_INSTALL_DIR),
     "XQWATCHER_LOG_DIR": str(XQWATCHER_LOG_DIR),
-    "XQWATCHER_GRADER_VENVS_DIR": str(XQWATCHER_GRADER_VENVS_DIR),
-    "XQWATCHER_GRADER_DIR": str(XQWATCHER_GRADER_DIR),
-    "XQWATCHER_GRADER_CONFIG_FILE": str(XQWATCHER_GRADER_CONFIG_FILE),
+    "XQWATCHER_VENV_DIR": str(XQWATCHER_VENV_DIR),
 }
 
 server.user(
@@ -126,10 +141,18 @@ git.repo(
     name="Clone xqwatcher repository from github",
     branch=XQWATCHER_BRANCH,
     dest=str(XQWATCHER_INSTALL_DIR),
-    group="xqwatcher",
+    group=XQWATCHER_USER,
     pull=True,
     src=XQWATCHER_GIT_REPO,
-    user="xqwatcher",
+    user=XQWATCHER_USER,
+)
+
+files.directory(
+    name="Remove the existing conf.d directory for xqwatcher configurations",
+    path=str(XQWATCHER_CONF_DIR),
+    force=True,
+    assume_present=True,
+    present=False,
 )
 
 server.shell(
@@ -142,20 +165,15 @@ files.put(
     src=str(FILES_DIRECTORY.joinpath("requirements.txt")),
     dest=str(XQWATCHER_INSTALL_DIR.joinpath("requirements.txt")),
     mode="0664",
-    user="xqwatcher",
-    group="xqwatcher",
+    user=XQWATCHER_USER,
+    group=XQWATCHER_USER,
 )
 
 server.shell(
     name="Install xqwatcher requirements into the virtual environment",
     commands=[
-        f"{XQWATCHER_VENV_DIR.joinpath('bin/pip3')} install -r {XQWATCHER_INSTALL_DIR.joinpath('requirements.txt')} --no-cache-dir --exists-action w"
+        f"{XQWATCHER_VENV_DIR.joinpath('bin/pip3')!s} install -r {XQWATCHER_INSTALL_DIR.joinpath('requirements.txt')!s} --no-cache-dir --exists-action w"
     ],
-)
-files.directory(
-    name="Remove the existing conf.d directory for xqwatcher configurations",
-    path=str(XQWATCHER_CONF_DIR),
-    present=False,
 )
 
 files.directory(
@@ -188,16 +206,24 @@ files.template(
 files.template(
     name="Create grader fetch script",
     src=TEMPLATES_DIRECTORY.joinpath("fetch_graders.py.j2"),
-    dest=str(XQWATCHER_INSTALL_DIR.joinpath("fetch_graders.py")),
+    dest=str(XQWATCHER_FETCH_GRADERS_SCRIPT_FILE),
     user=XQWATCHER_USER,
     group=XQWATCHER_USER,
     mode="0754",
     shared_context=shared_template_context,
 )
 
+server.crontab(
+    name="Schedule fetch_graders.py to run every hour.",
+    command=f"{XQWATCHER_VENV_DIR}/bin/python3 {XQWATCHER_FETCH_GRADERS_SCRIPT_FILE}",
+    user=XQWATCHER_USER,
+    cron_name="fetch_graders",
+    minute="10",
+)
+
 files.directory(
     name="Create grader directory",
-    path=str(XQWATCHER_GRADER_DIR),
+    path=str(XQWATCHER_GRADERS_DIR),
     user=XQWATCHER_USER,
     group=XQWATCHER_USER,
     mode="0750",
@@ -205,7 +231,7 @@ files.directory(
 
 files.directory(
     name="Create grader venvs directory",
-    path=str(XQWATCHER_GRADER_VENVS_DIR),
+    path=str(XQWATCHER_GRADERS_VENVS_DIR),
     user=XQWATCHER_USER,
     group=XQWATCHER_USER,
     mode="0750",
@@ -219,10 +245,29 @@ files.directory(
     mode="0700",
 )
 
+files.template(
+    name="Create systemd service definition for xqwatcher.",
+    src=TEMPLATES_DIRECTORY.joinpath("xqwatcher.service.j2"),
+    dest=str(XQWATCHER_SERVICE_FILE),
+    user="root",
+    group="root",
+    mode="0644",
+    shared_context=shared_template_context,
+)
+
+files.put(
+    name="Create xqwatcher.json",
+    src=str(FILES_DIRECTORY.joinpath("xqwatcher.json")),
+    dest=str(XQWATCHER_INSTALL_DIR.joinpath("xqwatcher.json")),
+    user=XQWATCHER_USER,
+    group=XQWATCHER_USER,
+    mode="0644",
+)
+
 # Grader virtual environment setup
 grader_venvs = ["mit-600x", "mit-686x-mooc", "mit-686x", "mit-6S082", "mit-940"]
 for grader_venv in grader_venvs:
-    GRADER_VENV_DIR = XQWATCHER_GRADER_VENVS_DIR.joinpath(grader_venv)
+    GRADER_VENV_DIR = XQWATCHER_GRADERS_VENVS_DIR.joinpath(grader_venv)
     GRADER_REQS_FILE = GRADER_VENV_DIR.joinpath("requirements.txt")
     server.shell(
         name=f"Install grader {grader_venv} : Create virtual environment",
@@ -233,8 +278,17 @@ for grader_venv in grader_venvs:
         src=str(FILES_DIRECTORY.joinpath(f"grader_reqs/{grader_venv}.txt")),
         dest=str(GRADER_REQS_FILE),
         mode="0664",
-        user="xqwatcher",
-        group="xqwatcher",
+        user=XQWATCHER_USER,
+        group=XQWATCHER_USER,
+    )
+    files.template(
+        name=f"Install grader {grader_venv} : create app-armor profile",
+        src=str(TEMPLATES_DIRECTORY.joinpath("app_armor_profile.j2")),
+        dest=str(APP_ARMOR_DIR.joinpath(f"xqwatcher.{grader_venv}")),
+        user="root",
+        group="root",
+        mode="0644",
+        context={"GRADER_VENV_DIR": str(GRADER_VENV_DIR)},
     )
     server.shell(
         name=f"Install grader {grader_venv} : install requirements",
@@ -284,7 +338,7 @@ consul_template_configuration = {
                     '{{ with secret "secret-xqwatcher/grader-config" }}'
                     "{{ .Data.data.graders_yaml | toYAML }}{{ end }}"
                 ),
-                destination=XQWATCHER_GRADER_CONFIG_FILE,
+                destination=XQWATCHER_FETCH_GRADERS_CONFIG_FILE,
                 user=XQWATCHER_USER,
                 group=XQWATCHER_USER,
                 perms="0600",
@@ -332,3 +386,18 @@ consul_template_permissions(consul_template.configuration)
 if host.get_fact(HasSystemd):
     register_services(hashicorp_products, start_services_immediately=False)
     proxy_consul_dns()
+
+    server.service(
+        name="Ensure that the xqwatcher service is enabled",
+        service="xqwatcher",
+        running=False,
+        enabled=True,
+    )
+    watched_xqwatcher_files = [
+        XQWATCHER_LOGGING_CONFIG_FILE,
+        XQWATCHER_GRADERS_CONFIG_FILE,
+        XQWATCHER_FETCH_GRADERS_CONFIG_FILE,
+    ]
+    service_configuration_watches(
+        service_name="xqwatcher.service", watched_files=watched_xqwatcher_files
+    )

--- a/src/bilder/images/xqwatcher/files/grader_reqs/mit-600x.txt
+++ b/src/bilder/images/xqwatcher/files/grader_reqs/mit-600x.txt
@@ -1,0 +1,5 @@
+joblib==1.4.0
+numpy==1.26.4
+scikit-learn==1.4.2
+scipy==1.13.0
+threadpoolctl==3.4.0

--- a/src/bilder/images/xqwatcher/files/grader_reqs/mit-686x-mooc.txt
+++ b/src/bilder/images/xqwatcher/files/grader_reqs/mit-686x-mooc.txt
@@ -1,0 +1,15 @@
+numpy==1.26.4
+pandas==2.2.2
+scikit-image==0.23.1
+scikit-learn==1.4.2
+scipy==1.13.0
+matplotlib==3.8.4
+pytz==2024.1
+networkx==3.3
+cycler==0.12.1
+decorator==5.1.1
+pillow==10.3.0
+pyparsing==3.1.2
+PyWavelets==1.6.0
+six==1.16.0
+torch==2.2.2

--- a/src/bilder/images/xqwatcher/files/grader_reqs/mit-686x.txt
+++ b/src/bilder/images/xqwatcher/files/grader_reqs/mit-686x.txt
@@ -1,0 +1,15 @@
+numpy==1.26.4
+pandas==2.2.2
+scikit-image==0.23.1
+scikit-learn==1.4.2
+scipy==1.13.0
+matplotlib==3.8.4
+pytz==2024.1
+networkx==3.3
+cycler==0.12.1
+decorator==5.1.1
+pillow==10.3.0
+pyparsing==3.1.2
+PyWavelets==1.6.0
+six==1.16.0
+torch==2.2.2

--- a/src/bilder/images/xqwatcher/files/grader_reqs/mit-6S082.txt
+++ b/src/bilder/images/xqwatcher/files/grader_reqs/mit-6S082.txt
@@ -1,0 +1,5 @@
+joblib==1.4.0
+numpy==1.26.4
+scikit-learn==1.4.2
+scipy==1.13.0
+threadpoolctl==3.4.0

--- a/src/bilder/images/xqwatcher/files/grader_reqs/mit-940.txt
+++ b/src/bilder/images/xqwatcher/files/grader_reqs/mit-940.txt
@@ -1,0 +1,16 @@
+contourpy==1.2.1
+cycler==0.12.1
+fonttools==4.51.0
+kiwisolver==1.4.5
+matplotlib==3.8.4
+numpy==1.26.4
+packaging==24.0
+pandas==2.2.2
+pillow==10.3.0
+pyparsing==3.1.2
+python-dateutil==2.9.0.post0
+pytz==2024.1
+scipy==1.13.0
+seaborn==0.13.2
+six==1.16.0
+tzdata==2024.1

--- a/src/bilder/images/xqwatcher/files/requirements.txt
+++ b/src/bilder/images/xqwatcher/files/requirements.txt
@@ -6,6 +6,7 @@ gitdb==4.0.11
 GitPython==3.1.43
 idna==3.4
 newrelic==8.7.0
+numpy==1.26.4
 path==16.6.0
 path.py==12.5.0
 PyYAML==6.0.1

--- a/src/bilder/images/xqwatcher/files/requirements.txt
+++ b/src/bilder/images/xqwatcher/files/requirements.txt
@@ -1,0 +1,15 @@
+certifi==2022.12.7
+charset-normalizer==3.1.0
+-e git+https://github.com/openedx/codejail.git@4127fc4bd5775cc72aee8d7f0a70e31405e22439#egg=codejail
+dogstatsd-python==0.5.6
+gitdb==4.0.11
+GitPython==3.1.43
+idna==3.4
+newrelic==8.7.0
+path==16.6.0
+path.py==12.5.0
+PyYAML==6.0.1
+requests==2.28.2
+six==1.16.0
+smmap==5.0.1
+urllib3==1.26.15

--- a/src/bilder/images/xqwatcher/files/xqwatcher.json
+++ b/src/bilder/images/xqwatcher/files/xqwatcher.json
@@ -1,0 +1,6 @@
+{
+    "FOLLOW_CLIENT_REDIRECTS": true,
+    "POLL_INTERVAL": 10,
+    "POLL_TIME": 10,
+    "REQUESTS_TIMEOUT": 10
+}

--- a/src/bilder/images/xqwatcher/files/xqwatcher.service
+++ b/src/bilder/images/xqwatcher/files/xqwatcher.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=xqwatcher process that executes student code via course author defined graders.
+After=multi-user.target
+
+[Service]
+type=simple
+Restart=always
+ExecStart=/home/xqwatcher/xqwatcher/.venv/bin/python3 -m xqueue_watcher -d /home/xqwatcher/xqwatcher

--- a/src/bilder/images/xqwatcher/files/xqwatcher.service
+++ b/src/bilder/images/xqwatcher/files/xqwatcher.service
@@ -1,8 +1,0 @@
-[Unit]
-Description=xqwatcher process that executes student code via course author defined graders.
-After=multi-user.target
-
-[Service]
-type=simple
-Restart=always
-ExecStart=/home/xqwatcher/xqwatcher/.venv/bin/python3 -m xqueue_watcher -d /home/xqwatcher/xqwatcher

--- a/src/bilder/images/xqwatcher/templates/99-xqwatcher-grader.j2
+++ b/src/bilder/images/xqwatcher/templates/99-xqwatcher-grader.j2
@@ -1,1 +1,4 @@
-xqwatcher ALL=({{ shared_context.XQWATCHER_USER }}) SETENV:NOPASSWD:{{ grader_context.GRADER_VENV_DIR }}/bin/python
+xqwatcher ALL=({{ grader_context.GRADER_USER }}) SETENV:NOPASSWD:{{ grader_context.GRADER_VENV_DIR }}/bin/python
+xqwatcher ALL=({{ grader_context.GRADER_USER }}) NOPASSWD:/usr/bin/find
+xqwatcher ALL=({{ grader_context.GRADER_USER }}) NOPASSWD:/bin/kill
+xqwatcher ALL=({{ grader_context.GRADER_USER }}) NOPASSWD:/usr/bin/pkill

--- a/src/bilder/images/xqwatcher/templates/99-xqwatcher-grader.j2
+++ b/src/bilder/images/xqwatcher/templates/99-xqwatcher-grader.j2
@@ -1,0 +1,1 @@
+xqwatcher ALL=({{ shared_context.XQWATCHER_USER }}) SETENV:NOPASSWD:{{ grader_context.GRADER_VENV_DIR }}/bin/python

--- a/src/bilder/images/xqwatcher/templates/99-xqwatcher-shared.j2
+++ b/src/bilder/images/xqwatcher/templates/99-xqwatcher-shared.j2
@@ -1,3 +1,0 @@
-xqwatcher ALL=({{ shared_context.XQWATCHER_USER }}) NOPASSWD:/usr/bin/find
-xqwatcher ALL=({{ shared_context.XQWATCHER_USER }}) NOPASSWD:/bin/kill
-xqwatcher ALL=({{ shared_context.XQWATCHER_USER }}) NOPASSWD:/usr/bin/pkill

--- a/src/bilder/images/xqwatcher/templates/99-xqwatcher-shared.j2
+++ b/src/bilder/images/xqwatcher/templates/99-xqwatcher-shared.j2
@@ -1,0 +1,3 @@
+xqwatcher ALL=({{ shared_context.XQWATCHER_USER }}) NOPASSWD:/usr/bin/find
+xqwatcher ALL=({{ shared_context.XQWATCHER_USER }}) NOPASSWD:/bin/kill
+xqwatcher ALL=({{ shared_context.XQWATCHER_USER }}) NOPASSWD:/usr/bin/pkill

--- a/src/bilder/images/xqwatcher/templates/app_armor_profile.j2
+++ b/src/bilder/images/xqwatcher/templates/app_armor_profile.j2
@@ -3,6 +3,7 @@
 {{ grader_context.GRADER_VENV_DIR }}/bin/python {
     #include <abstractions/base>
     {{ grader_context.GRADER_VENV_DIR }}/** mr,
+    /usr/local/lib/python3.11/dist-packages/** mr,
     /tmp/codejail-*/ rix,
     /tmp/codejail-*/** wrix,
     /proc/*/mounts r,

--- a/src/bilder/images/xqwatcher/templates/app_armor_profile.j2
+++ b/src/bilder/images/xqwatcher/templates/app_armor_profile.j2
@@ -1,0 +1,9 @@
+#include <tunables/global>
+
+{{ shared_context.XQWATCHER_GRADER_VENVS_DIR }}/{{ grader_context.grader_short_name }}/bin/python {
+    #include <abstractions/base>
+    {{ shared_context.XQWATCHER_GRADER_VENVS_DIR }}/{{ grader_context.grader_short_name }}/** mr,
+    /tmp/codejail-*/ rix,
+    /tmp/codejail-*/** wrix,
+    /proc/*/mounts r,
+}

--- a/src/bilder/images/xqwatcher/templates/app_armor_profile.j2
+++ b/src/bilder/images/xqwatcher/templates/app_armor_profile.j2
@@ -1,8 +1,8 @@
 #include <tunables/global>
 
-{{ shared_context.XQWATCHER_GRADER_VENVS_DIR }}/{{ grader_context.grader_short_name }}/bin/python {
+{{ context.GRADER_VENV_DIR }}/bin/python {
     #include <abstractions/base>
-    {{ shared_context.XQWATCHER_GRADER_VENVS_DIR }}/{{ grader_context.grader_short_name }}/** mr,
+    {{ context.GRADER_VENV_DIR }}/** mr,
     /tmp/codejail-*/ rix,
     /tmp/codejail-*/** wrix,
     /proc/*/mounts r,

--- a/src/bilder/images/xqwatcher/templates/app_armor_profile.j2
+++ b/src/bilder/images/xqwatcher/templates/app_armor_profile.j2
@@ -1,8 +1,8 @@
 #include <tunables/global>
 
-{{ context.GRADER_VENV_DIR }}/bin/python {
+{{ grader_context.GRADER_VENV_DIR }}/bin/python {
     #include <abstractions/base>
-    {{ context.GRADER_VENV_DIR }}/** mr,
+    {{ grader_context.GRADER_VENV_DIR }}/** mr,
     /tmp/codejail-*/ rix,
     /tmp/codejail-*/** wrix,
     /proc/*/mounts r,

--- a/src/bilder/images/xqwatcher/templates/fetch_graders.py.j2
+++ b/src/bilder/images/xqwatcher/templates/fetch_graders.py.j2
@@ -1,0 +1,35 @@
+from git import NoSuchPathError, Repo
+from pathlib import Path
+from yaml import safe_load
+
+# Expects a yaml file containing configuration used to retrieve grader code
+# from git repositories
+#
+# Format:
+# graders:
+# - name: <directory name within XQWATCHER_GRADER_DIR for this grader>
+#   git_ref: <the brnach or tag to checkout>
+#   address: <address of the git repo>
+#   env:
+#     <dict containing env var names+vals to pass to the git command(s)>
+#
+# The env dict is primary used for passing a custom `GIT_SSH_COMMAND` value
+# which can be used to specify a specific identity file / other SSH options.
+
+with open("{{ shared_context.XQWATCHER_GRADER_CONFIG_FILE }}", 'r') as config_file:
+    grader_configs = safe_load(config_file)
+
+graders_root = Path("{{ shared_context.XQWATCHER_GRADER_DIR }}")
+
+for grader_config in grader_configs["graders"]:
+
+    grader_path = graders_root.joinpath(grader_config["name"])
+    git_env = grader_config["env"]  or {}
+
+    # Check if a local copy of the repo already exists
+    try:
+        repo = Repo(grader_path)
+    except NoSuchPathError:
+        repo = Repo.clone_from(url=grader_config["address"],to_path=str(grader_path),env=git_env)
+    repo.git.checkout(grader_config["git_ref"])
+    repo.remotes.origin.pull(grader_config["git_ref"], env=git_env)

--- a/src/bilder/images/xqwatcher/templates/fetch_graders.py.j2
+++ b/src/bilder/images/xqwatcher/templates/fetch_graders.py.j2
@@ -7,7 +7,7 @@ from yaml import safe_load
 #
 # Format:
 # graders:
-# - name: <directory name within XQWATCHER_GRADER_DIR for this grader>
+# - name: <directory name within XQWATCHER_GRADERS_DIR for this grader>
 #   git_ref: <the brnach or tag to checkout>
 #   address: <address of the git repo>
 #   env:
@@ -16,10 +16,10 @@ from yaml import safe_load
 # The env dict is primary used for passing a custom `GIT_SSH_COMMAND` value
 # which can be used to specify a specific identity file / other SSH options.
 
-with open("{{ shared_context.XQWATCHER_GRADER_CONFIG_FILE }}", 'r') as config_file:
+with open("{{ shared_context.XQWATCHER_FETCH_GRADERS_CONFIG_FILE }}", 'r') as config_file:
     grader_configs = safe_load(config_file)
 
-graders_root = Path("{{ shared_context.XQWATCHER_GRADER_DIR }}")
+graders_root = Path("{{ shared_context.XQWATCHER_GRADERS_DIR }}")
 
 for grader_config in grader_configs["graders"]:
 

--- a/src/bilder/images/xqwatcher/templates/logging.json.j2
+++ b/src/bilder/images/xqwatcher/templates/logging.json.j2
@@ -13,7 +13,7 @@
     },
     "rotatingfile": {
       "class": "logging.handlers.RotatingFileHandler",
-      "filename": "{{ context.XQWATCHER_LOG_DIR }}/xqwatcher.log",
+      "filename": "{{ shared_context.XQWATCHER_LOG_DIR }}/xqwatcher.log",
       "formatter": "default",
       "level": "DEBUG",
       "maxBytes": 10485760

--- a/src/bilder/images/xqwatcher/templates/logging.json.j2
+++ b/src/bilder/images/xqwatcher/templates/logging.json.j2
@@ -1,0 +1,32 @@
+{
+  "disable_existing_loggers": false,
+  "formatters": {
+    "default": {
+      "format": "%(asctime)s - %(filename)s:%(lineno)d -- %(funcName)s [%(levelname)s]: %(message)s"
+    }
+  },
+  "handlers": {
+    "console": {
+      "class": "logging.StreamHandler",
+      "formatter": "default",
+      "level": "DEBUG"
+    },
+    "rotatingfile": {
+      "class": "logging.handlers.RotatingFileHandler",
+      "filename": "{{ context.XQWATCHER_LOG_DIR }}/xqwatcher.log",
+      "formatter": "default",
+      "level": "DEBUG",
+      "maxBytes": 10485760
+    }
+  },
+  "loggers": {
+    "": {
+      "handlers": [
+        "rotatingfile",
+        "console"
+      ],
+      "level": "DEBUG"
+    }
+  },
+  "version": 1
+}

--- a/src/bilder/images/xqwatcher/templates/logrotate.xqwatcher.j2
+++ b/src/bilder/images/xqwatcher/templates/logrotate.xqwatcher.j2
@@ -1,0 +1,11 @@
+{{ shared_context.XQWATCHER_LOG_DIR }}/xqwatcher.log
+{
+	compress
+	copytruncate
+	daily
+	delaycompress
+	missingok
+	notifempty
+	rotate 90
+	su {{ shared_context.XQWATCHER_USER }} {{ shared_context.XQWATCHER_USER }}
+}

--- a/src/bilder/images/xqwatcher/templates/vector/xqwatcher-logs.yaml.j2
+++ b/src/bilder/images/xqwatcher/templates/vector/xqwatcher-logs.yaml.j2
@@ -1,0 +1,43 @@
+---
+sources:
+  collect_xqwatcher_logs:
+    type: journald
+    include_units:
+    - python3
+    current_boot_only: true
+
+transforms:
+  parse_xqwatcher_logs:
+    type: remap
+    inputs:
+    - 'collect_xqwatcher_logs'
+    source: |
+      event, err = parse_json(.message)
+      if event != null {
+        .,err = merge(., event)
+        .environment = "${ENVIRONMENT}"
+      }
+
+  enrich_xqwatcher_logs:
+    type: aws_ec2_metadata
+    inputs:
+    - 'parse_xqwatcher_logs'
+    namespace: ec2
+
+sinks:
+  ship_xqwatcher_logs_to_grafana_cloud:
+    inputs:
+    - 'enrich_xqwatcher_logs'
+    type: loki
+    auth:
+      strategy: basic
+      password: ${GRAFANA_CLOUD_API_KEY}
+      user: "${GRAFANA_CLOUD_LOKI_API_USER}"
+    endpoint: https://logs-prod-us-central1.grafana.net
+    encoding:
+      codec: json
+    labels:
+      environment: ${ENVIRONMENT}
+      application: xqwatcher
+      service: xqwatcher
+    out_of_order_action: rewrite_timestamp

--- a/src/bilder/images/xqwatcher/templates/xqwatcher.service.j2
+++ b/src/bilder/images/xqwatcher/templates/xqwatcher.service.j2
@@ -1,0 +1,23 @@
+[Unit]
+Description=xqwatcher process that executes student code via course author defined graders.
+Documentation=https://github.com/mitodl/xqueue-watcher
+After=multi-user.target
+Wants=vault.service
+After=vault.service
+Wants=consul.service
+After=consul.service
+Wants=consul-template.service
+After=consul-template.service
+
+[Service]
+Type=exec
+Restart=always
+User=xqwatcher
+Group=xqwatcher
+WorkingDirectory={{ shared_context.XQWATCHER_INSTALL_DIR }}
+ExecStartPre=/usr/bin/sleep 5
+ExecStartPre={{ shared_context.XQWATCHER_VENV_DIR }}/bin/python3 {{ shared_context.XQWATCHER_INSTALL_DIR }}/fetch_graders.py
+ExecStart={{ shared_context.XQWATCHER_VENV_DIR }}/bin/python3 -m xqueue_watcher -d /home/xqwatcher/xqwatcher
+
+[Install]
+WantedBy=multi-user.target

--- a/src/bilder/images/xqwatcher/xqwatcher.pkr.hcl
+++ b/src/bilder/images/xqwatcher/xqwatcher.pkr.hcl
@@ -1,0 +1,111 @@
+packer {
+  required_plugins {
+    ansible = {
+      source  = "github.com/hashicorp/ansible"
+      version = "~> 1"
+    }
+    amazon = {
+      source  = "github.com/hashicorp/amazon"
+      version = "~> 1"
+    }
+  }
+}
+
+locals {
+  timestamp = regex_replace(timestamp(), "[- TZ:]", "")
+  app_name  = "open-edx-xqwatcher-server"
+}
+
+variable "build_environment" {
+  type    = string
+  default = "operations-ci"
+}
+
+variable "business_unit" {
+  type    = string
+  default = "operations"
+}
+
+variable "node_type" {
+  type    = string
+  default = "server"
+}
+
+variable "ol_ansible_branch" {
+  type    = string
+  default = "md/issue_2326"
+}
+
+source "amazon-ebs" "xqwatcher" {
+  ami_description         = "Deployment image for xqwatcher server generated at ${local.timestamp}"
+  ami_name                = "open-edx-xqwatcher-${var.node_type}-${local.timestamp}"
+  ami_virtualization_type = "hvm"
+  instance_type           = "t3a.medium"
+  launch_block_device_mappings {
+    device_name           = "/dev/xvda"
+    volume_size           = 25
+    delete_on_termination = true
+  }
+  run_tags = {
+    Name    = "${local.app_name}-packer-builder"
+    OU      = "${var.business_unit}"
+    app     = "${local.app_name}"
+    purpose = "${local.app_name}"
+  }
+  run_volume_tags = {
+    Name    = "${local.app_name}-packer-builder"
+    OU      = "${var.business_unit}"
+    app     = "${local.app_name}"
+    purpose = "${local.app_name}"
+  }
+  snapshot_tags = {
+    Name            = "${local.app_name}-ami"
+    OU              = "${var.business_unit}"
+    app             = "${local.app_name}"
+    purpose         = "${local.app_name}"
+  }
+  
+  # Base all builds off of the most recent Debian 12 image built by the Debian organization.
+  source_ami_filter {
+    filters = {
+      name                = "debian-12-amd64*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    most_recent = true
+    owners      = ["136693071363"]
+  }
+  ssh_username  = "admin"
+  ssh_interface = "public_ip"
+  subnet_filter {
+    filters = {
+      "tag:Environment" : var.build_environment
+    }
+    random = true
+  }
+  tags = {
+    Name            = "${local.app_name}"
+    OU              = var.business_unit
+    app             = local.app_name
+    purpose         = "${local.app_name}"
+    framework       = "native"
+  }
+}
+
+build {
+  sources = [
+    "source.amazon-ebs.xqwatcher",
+  ]
+
+  provisioner "shell-local" {
+    inline = [
+      "echo '${build.SSHPrivateKey}' > /tmp/packer-session-${build.ID}.pem",
+      "chmod 600 /tmp/packer-session-${build.ID}.pem"
+    ]
+  }
+
+  # Run the pre-ansible configuration / setup via py-infra
+  provisioner "shell-local" {
+    inline = ["pyinfra --data ssh_strict_host_key_checking=off --sudo --user ${build.User} --port ${build.Port} --key /tmp/packer-session-${build.ID}.pem ${build.Host} --chdir ${path.root} deploy.py"]
+  }
+}

--- a/src/bilder/images/xqwatcher/xqwatcher.pkr.hcl
+++ b/src/bilder/images/xqwatcher/xqwatcher.pkr.hcl
@@ -40,10 +40,10 @@ source "amazon-ebs" "xqwatcher" {
   ami_description         = "Deployment image for xqwatcher server generated at ${local.timestamp}"
   ami_name                = "open-edx-xqwatcher-${var.node_type}-${local.timestamp}"
   ami_virtualization_type = "hvm"
-  instance_type           = "t3a.medium"
+  instance_type           = "c6a.large"  # AMI build does a lot of compling from source, so dedicated CPU is needed
   launch_block_device_mappings {
     device_name           = "/dev/xvda"
-    volume_size           = 25
+    volume_size           = 50
     delete_on_termination = true
   }
   run_tags = {

--- a/src/bilder/images/xqwatcher/xqwatcher.pkr.hcl
+++ b/src/bilder/images/xqwatcher/xqwatcher.pkr.hcl
@@ -64,7 +64,7 @@ source "amazon-ebs" "xqwatcher" {
     app             = "${local.app_name}"
     purpose         = "${local.app_name}"
   }
-  
+
   # Base all builds off of the most recent Debian 12 image built by the Debian organization.
   source_ami_filter {
     filters = {

--- a/src/bilder/images/xqwatcher/xqwatcher.pkr.hcl
+++ b/src/bilder/images/xqwatcher/xqwatcher.pkr.hcl
@@ -43,7 +43,7 @@ source "amazon-ebs" "xqwatcher" {
   instance_type           = "c6a.large"  # AMI build does a lot of compling from source, so dedicated CPU is needed
   launch_block_device_mappings {
     device_name           = "/dev/xvda"
-    volume_size           = 50
+    volume_size           = 25
     delete_on_termination = true
   }
   run_tags = {

--- a/src/bridge/secrets/xqwatcher/secrets.ci.yaml
+++ b/src/bridge/secrets/xqwatcher/secrets.ci.yaml
@@ -1,4 +1,16 @@
 ---
+graders_yaml:
+  graders:
+  - name: ENC[AES256_GCM,data:p5T9MPzwVzB2SmsbB7kFcEuBlR9HJGbyPVZw,iv:iFC4JC+oyLBtKH06ZGKOLdZDEleN2f9j4iXJxQpwWt8=,tag:588sITOlP+vcF66ohqyRLw==,type:str]
+    address: ENC[AES256_GCM,data:0ZoJISrNH1Y/fcbioWNDlvNpPzELSdN+jZolfqYOkWlYOnzufqUMlQ==,iv:OTS2obQKZd/yJray6BxhpOKEaOamXQf2RdsZibHklSc=,tag:Jusz+4i6wysepofR9M0mQA==,type:str]
+    git_ref: ENC[AES256_GCM,data:M5tIe1zv,iv:yB5QnVIDuBmYauTQzx6rzLwQNd6V+t15DUcAirIDySI=,tag:SsgXOI1nmtqfkhmCgVJbrg==,type:str]
+    env:
+      GIT_SSH_COMMAND: ENC[AES256_GCM,data:coG50L+hkKRgs2WVWfe/6QscmwcPfDcp4+6+j7T7ClIhw62jHFODAv2vassHrvmUxIR2Xy7+8bs8aFhxp4dGhSUmcwaF9vEXkVP1GcxenZaVI9pz0s9yPHdeUixUmeqxKocNreLAY5eeKXWMZ/lsrI4SYVhapA5JAnJP/xELbJnJATXghIvLgnZvO3Q72zpE,iv:B+5FjVCCUP7WAK4tBJBZoLjFip3fFUTeDVOqI0G9jIc=,tag:1tTdqrY2Lr1H+rljN6Bk0w==,type:str]
+  - name: ENC[AES256_GCM,data:guJV2vkSNpqaWWnlQgOoZhGXzLpPekf+GZABiO4=,iv:IJIIE0cFWPEhwcWKBQtcPGnv5XF4vy8ENEjETpIrnWc=,tag:lc82HaHmcJSy7Waxv7WN2Q==,type:str]
+    address: ENC[AES256_GCM,data:0ZoJISrNH1Y/fcbioWNDlvNpPzELSdN+jZolfqYOkWlYOnzufqUMlQ==,iv:OTS2obQKZd/yJray6BxhpOKEaOamXQf2RdsZibHklSc=,tag:Jusz+4i6wysepofR9M0mQA==,type:str]
+    git_ref: ENC[AES256_GCM,data:M5tIe1zv,iv:yB5QnVIDuBmYauTQzx6rzLwQNd6V+t15DUcAirIDySI=,tag:SsgXOI1nmtqfkhmCgVJbrg==,type:str]
+    env:
+      GIT_SSH_COMMAND: ENC[AES256_GCM,data:/tHzs53lMHrUmndEgR0jOhOPW0ned4A1USAZ2j9jLM+4KYjPKlicXEeWnOKL7wAwNZnlpN7O+iD0tE3UjkfkCrF9+MMMjzeh6Cxi7HjaX8B7yNVGXpt3CMBbVIduza0Qta6bqo0Ixao1xID4jhq2Hx/K0XTGHr8sq1WDo5RWjhgNni0HrYfQ7LCAT4/h8pNR,iv:3JZxMQWw95j4KGAL/bMqTo+irhdtlDEpVJjPrkK/IWQ=,tag:Uh0vwfZzZVN8nkxz0V6lDw==,type:str]
 confd_json:
   Watcher-MITx-6.00x:
     AUTH:
@@ -46,8 +58,8 @@ sops:
     created_at: "2024-04-16T18:44:13Z"
     enc: vault:v1:DFw1gsayFWeGxTCrU0HCQzWk4YBPHQdKHpValoIHi4bO/jHn+eZv+Nr2d4FubYiq8jKrKREm/UgsizDS
   age: []
-  lastmodified: "2024-04-17T15:34:21Z"
-  mac: ENC[AES256_GCM,data:P3gaeVFhsvOoPoGQzN5rgQct7/XB3eDPmBbgh8MtBrW5HB5P6DKspgUBA/LfPYaVMcI6Lm5jGtygj7gNiSlraHaP6Tq/1usfcDLj30apRakUB0uFxF6TqnYfUGNoLqq2mI9eSzZE6lpmnzkyRoWWzp4dbdRPPOWsBM5gBTJZSxE=,iv:8JbyZGkms6/t61zLh/c5G+DEeSRYcMCI84vdkUs2CrE=,tag:2RjStjvuQ+4T7kglYK9suA==,type:str]
+  lastmodified: "2024-04-19T19:07:39Z"
+  mac: ENC[AES256_GCM,data:qTvPprG3QfomjsCAP4JGA1fSbweyCB17WxqQOZrWixrSWS00EFXv6rbUfOCdX/Vech7j0EEsatk0Hl7kIDrHFHMVPyGSTsimHL4Ts0R3tJi1AKsGXp2B+6rJXw0JpE13YwnMLrh/Kc46DVqFHgFUdLaBxejNGJcdQo+V7B9Y0Gk=,iv:g/0zpL8t8Wl8tfZno3L6puM4jf4WGw2Q+STOle5NV/8=,tag:P4riAhXbqqlMm2scyDhykg==,type:str]
   pgp:
   - created_at: "2024-04-16T18:44:13Z"
     enc: |-

--- a/src/bridge/secrets/xqwatcher/secrets.ci.yaml
+++ b/src/bridge/secrets/xqwatcher/secrets.ci.yaml
@@ -5,7 +5,7 @@ graders_yaml:
     address: ENC[AES256_GCM,data:0ZoJISrNH1Y/fcbioWNDlvNpPzELSdN+jZolfqYOkWlYOnzufqUMlQ==,iv:OTS2obQKZd/yJray6BxhpOKEaOamXQf2RdsZibHklSc=,tag:Jusz+4i6wysepofR9M0mQA==,type:str]
     git_ref: ENC[AES256_GCM,data:M5tIe1zv,iv:yB5QnVIDuBmYauTQzx6rzLwQNd6V+t15DUcAirIDySI=,tag:SsgXOI1nmtqfkhmCgVJbrg==,type:str]
     env:
-      GIT_SSH_COMMAND: ENC[AES256_GCM,data:coG50L+hkKRgs2WVWfe/6QscmwcPfDcp4+6+j7T7ClIhw62jHFODAv2vassHrvmUxIR2Xy7+8bs8aFhxp4dGhSUmcwaF9vEXkVP1GcxenZaVI9pz0s9yPHdeUixUmeqxKocNreLAY5eeKXWMZ/lsrI4SYVhapA5JAnJP/xELbJnJATXghIvLgnZvO3Q72zpE,iv:B+5FjVCCUP7WAK4tBJBZoLjFip3fFUTeDVOqI0G9jIc=,tag:1tTdqrY2Lr1H+rljN6Bk0w==,type:str]
+      GIT_SSH_COMMAND: ENC[AES256_GCM,data:/tHzs53lMHrUmndEgR0jOhOPW0ned4A1USAZ2j9jLM+4KYjPKlicXEeWnOKL7wAwNZnlpN7O+iD0tE3UjkfkCrF9+MMMjzeh6Cxi7HjaX8B7yNVGXpt3CMBbVIduza0Qta6bqo0Ixao1xID4jhq2Hx/K0XTGHr8sq1WDo5RWjhgNni0HrYfQ7LCAT4/h8pNR,iv:3JZxMQWw95j4KGAL/bMqTo+irhdtlDEpVJjPrkK/IWQ=,tag:Uh0vwfZzZVN8nkxz0V6lDw==,type:str]
   - name: ENC[AES256_GCM,data:guJV2vkSNpqaWWnlQgOoZhGXzLpPekf+GZABiO4=,iv:IJIIE0cFWPEhwcWKBQtcPGnv5XF4vy8ENEjETpIrnWc=,tag:lc82HaHmcJSy7Waxv7WN2Q==,type:str]
     address: ENC[AES256_GCM,data:0ZoJISrNH1Y/fcbioWNDlvNpPzELSdN+jZolfqYOkWlYOnzufqUMlQ==,iv:OTS2obQKZd/yJray6BxhpOKEaOamXQf2RdsZibHklSc=,tag:Jusz+4i6wysepofR9M0mQA==,type:str]
     git_ref: ENC[AES256_GCM,data:M5tIe1zv,iv:yB5QnVIDuBmYauTQzx6rzLwQNd6V+t15DUcAirIDySI=,tag:SsgXOI1nmtqfkhmCgVJbrg==,type:str]
@@ -26,7 +26,7 @@ confd_json:
       HANDLER: ENC[AES256_GCM,data:xKNmClln1J5leWUOsHXo6d0XMm+tNAN9bek4soM5b49o6zLbv3s8TQ==,iv:kZ7jGM5B4n2RsOCppRTt0Cn8TDH2sSnAOuYbQl95dY4=,tag:OTw+Y0uhByeYXY8eP13dqw==,type:str]
       KWARGS:
         grader_root: ENC[AES256_GCM,data:A+hHIVLX0mTz1DHc7MMmVAf60hQ/EJjgzG5h9lnZppBLZIscVvhyryczyTS+RKimzqWQQYTT32FAsqYqvtI=,iv:dIMitVcAwebHlO3LRKoD13dVkMkuL2z6rX/gJbuGxKc=,tag:HDCOyEUMMK1/ErgXk6q7Kw==,type:str]
-    SERVER: ENC[AES256_GCM,data:fdG1PqCwq2+9zRf/qrIUkXjN9/cM9a0j25WogRKJWaQE,iv:C/NiAICRcO938Q5UUncVR7/6873zxE78FVtq0PQI4aM=,tag:oCYKQ2VOkBzrHdXhIYgyqg==,type:str]
+    SERVER: ENC[AES256_GCM,data:fgyBM4dTnNCyUgb0O/nruyu5WgsGEZaYGHP+oV/Qi7llIUkOFDN9sQY=,iv:7GIz4gNKMqINA+i1WzGfEvptip3vLo6XnA/EScQbEy4=,tag:tjyrPKIx9dONJMgb6vyIPQ==,type:str]
   Watcher-MITx-6.0001r:
     AUTH:
     - ENC[AES256_GCM,data:GeoKMl2An+NT,iv:4bpjXM5pBTGk43L4aFffe/i7Xuiqqma4x1bjwqr2vZc=,tag:cRJlbd1X9ScKyIMXc56Mng==,type:str]
@@ -41,7 +41,7 @@ confd_json:
       HANDLER: ENC[AES256_GCM,data:ptWfCuhtmp1XaCxZsxoyFryVbS82cJkYLOgeTfI883Abtal/nUK58g==,iv:Y2vuOaLH94pc9iY0V6qUfmlj9m3ijK/vxnyljFhBC4w=,tag:dBe2y1yG4y/MDqKeUlobow==,type:str]
       KWARGS:
         grader_root: ENC[AES256_GCM,data:6UFR02eSi21NXOU6SQcZyRm3SbFqgMXV4yJiMTW8+lMiVRfRVyz0cFnQjFEAlwflHxgWgXNymHNTkxYFzSUpUw==,iv:AiEGSD68isqsL0Ften6dn+/DTpHfdbUGwBN5vdBd1w8=,tag:lCXfJNrV9hkrSRxFVesPsQ==,type:str]
-    SERVER: ENC[AES256_GCM,data:4lmNq9PPq6N2O0JP5w0gXndDV5XwdPs9LvdjKtWMkTIW,iv:MN+mcnrkC1zz/l7I68O7azhrJTcq6mFBa95eWtB1Uhc=,tag:fm4CAE6YyhheVjnrsJxPrQ==,type:str]
+    SERVER: ENC[AES256_GCM,data:FHHp0nXRKUsYrfccjmv0TF1Qb6ms7sCRnvA/V2Pm0snJznW/YA66LRo=,iv:7l7VZyh2wyVT7q1j43fIWdDBsODzK9IGGZt9+D+Z55I=,tag:8zW+XIdqJjuuN2QY3ndSgg==,type:str]
 xqwatcher_grader_code_ssh_identity: ENC[AES256_GCM,data:2ogEHew5oYkdHOhn/Td92T0tLF59cC0ts6kQddqEgUu/7/cSadFoGvb9RfS4TUOzhAARnMdMRT5JclXlp4Oi8T0X2nenAM/zZkokd5GMmC0J2mESCm2bbdXcG2qat9Rjga7d+1bLyP1+1heIHPb5uRsGJYkA87d1bvv8vlmwtEQN3VeBrD/0I+jwTUcLamVg4T602RxWMnEm9nXw0NTDUp4TsOMtIrzdBvs9IsNEqdDT7hwSkHpmC69dulUJzJGOSFYmkYFHcDAK8qTRdc8qp5vvMTz4k7X8JF8yp7LfEGuE5w==,iv:c2o8vAGEB8DFq9VtW8Zhm5Xat4s49x+oQf7212ZeFFk=,tag:9gI1u/SBMIjLDfY3b1X8+w==,type:str]
 sops:
   kms:
@@ -58,8 +58,8 @@ sops:
     created_at: "2024-04-16T18:44:13Z"
     enc: vault:v1:DFw1gsayFWeGxTCrU0HCQzWk4YBPHQdKHpValoIHi4bO/jHn+eZv+Nr2d4FubYiq8jKrKREm/UgsizDS
   age: []
-  lastmodified: "2024-04-19T19:07:39Z"
-  mac: ENC[AES256_GCM,data:qTvPprG3QfomjsCAP4JGA1fSbweyCB17WxqQOZrWixrSWS00EFXv6rbUfOCdX/Vech7j0EEsatk0Hl7kIDrHFHMVPyGSTsimHL4Ts0R3tJi1AKsGXp2B+6rJXw0JpE13YwnMLrh/Kc46DVqFHgFUdLaBxejNGJcdQo+V7B9Y0Gk=,iv:g/0zpL8t8Wl8tfZno3L6puM4jf4WGw2Q+STOle5NV/8=,tag:P4riAhXbqqlMm2scyDhykg==,type:str]
+  lastmodified: "2024-04-25T18:35:23Z"
+  mac: ENC[AES256_GCM,data:X4CfjxG/ps13sYRd2PzeXl0MLz0pxkSKky23dIN/PmsH1xyhPnVXQ8wMV85vjN55LrGcSHs9GWAlJjqna43apnoggHfdqO/bYUeHhUjUJ8RiqXTFCi9NfRkCq5x1upmiXTR95fKdZUrykFZTGx+8JvTWLjs+2HfgHWL0kDk1HDU=,iv:RVkdd8V9rHgFbMP7ZqormU7TYXF2uwe46QCKHpmhi8E=,tag:xEdvYfirIpM/rwhKDAouHw==,type:str]
   pgp:
   - created_at: "2024-04-16T18:44:13Z"
     enc: |-

--- a/src/bridge/secrets/xqwatcher/secrets.ci.yaml
+++ b/src/bridge/secrets/xqwatcher/secrets.ci.yaml
@@ -1,5 +1,35 @@
 ---
-confd_json: ENC[AES256_GCM,data:ERE=,iv:oh2uLN30sxPn3Rn80Tpc/ATBC8ivDwEZsbfrfYEGZEU=,tag:JNeq80a8BLhEMN8Fl7tVMQ==,type:str]
+confd_json:
+  Watcher-MITx-6.00x:
+    AUTH:
+    - ENC[AES256_GCM,data:SCKbOmao2Gpl,iv:Hb7ZVtcobrj2E6hFBrmqVpq1oNnJ+j2YOQMcfLFN6Dc=,tag:3rvoooddYT3G04AQOsKxEA==,type:str]
+    - ENC[AES256_GCM,data:/FqGfC4XbHZ2AIaJiUHJA+hebqDA4eag+qwjiG2lywpzOOMJIwblQw==,iv:dmDX989O8vyVtgfcCcSG1IPoX/+Vy/CHifk+4omnwV8=,tag:QFkUcAaojGs/+c+5h3r5lg==,type:str]
+    CONNECTIONS: ENC[AES256_GCM,data:Gg==,iv:d7E2fNOoSSflC2UNEnIUg9bBCHI3rlbn8pgmHCnxX68=,tag:5V0iQ94DuAdt0+zxQXV39A==,type:int]
+    HANDLERS:
+    - CODEJAIL:
+        bin_path: ENC[AES256_GCM,data:kXgOjRNdv5RNXL2JcleS3u/W2FUelW/OWS6u9Dd3ASC2mOxHMAjxQK0VoivVPj0ZqSzlqhxFPg21sg==,iv:jtm/LiMJapsXJEIZGgOzknJ/Nmd9zFofyNtQG4jJLHs=,tag:gIBJjPWkIydCIzoan9V6kw==,type:str]
+        lang: ENC[AES256_GCM,data:vxjPnbN7oQ==,iv:m25r3jtmoUjIWYDKyKUX82awfO98K9UdFPzUGlmdcF4=,tag:8yMYlavG9/pPCzIl5prLcg==,type:str]
+        name: ENC[AES256_GCM,data:1ISqevS5v+s=,iv:pX1qlTFPdlrgqP16/Vm9OGJ/hKnuMScGwjJ3M+YWeA4=,tag:d88eMeekFkpm0mRbNy741A==,type:str]
+        user: ENC[AES256_GCM,data:jiWGB4mhGX4=,iv:WOiO7BPAsvjl9tQz8NwLLTYcCi/XwcixYei6ybWiDYg=,tag:yGfU4XhPE0hkkVFM3c3Hcg==,type:str]
+      HANDLER: ENC[AES256_GCM,data:xKNmClln1J5leWUOsHXo6d0XMm+tNAN9bek4soM5b49o6zLbv3s8TQ==,iv:kZ7jGM5B4n2RsOCppRTt0Cn8TDH2sSnAOuYbQl95dY4=,tag:OTw+Y0uhByeYXY8eP13dqw==,type:str]
+      KWARGS:
+        grader_root: ENC[AES256_GCM,data:A+hHIVLX0mTz1DHc7MMmVAf60hQ/EJjgzG5h9lnZppBLZIscVvhyryczyTS+RKimzqWQQYTT32FAsqYqvtI=,iv:dIMitVcAwebHlO3LRKoD13dVkMkuL2z6rX/gJbuGxKc=,tag:HDCOyEUMMK1/ErgXk6q7Kw==,type:str]
+    SERVER: ENC[AES256_GCM,data:fdG1PqCwq2+9zRf/qrIUkXjN9/cM9a0j25WogRKJWaQE,iv:C/NiAICRcO938Q5UUncVR7/6873zxE78FVtq0PQI4aM=,tag:oCYKQ2VOkBzrHdXhIYgyqg==,type:str]
+  Watcher-MITx-6.0001r:
+    AUTH:
+    - ENC[AES256_GCM,data:GeoKMl2An+NT,iv:4bpjXM5pBTGk43L4aFffe/i7Xuiqqma4x1bjwqr2vZc=,tag:cRJlbd1X9ScKyIMXc56Mng==,type:str]
+    - ENC[AES256_GCM,data:2IRNwrwVNeQ/N5B3Ka0E8JKa2rMoY+g1h078CWy82O0EYrsfUAEIxw==,iv:sl5rkCOZxVIM2xkgAHvsg9wPl4arEOm7NTq4B67Dz5s=,tag:dpxlezEbjFndERvvvGQSkQ==,type:str]
+    CONNECTIONS: ENC[AES256_GCM,data:0g==,iv:6tyg9WvnRhnpLm0vKGefnd70VfpmEFy0ErgwnNiFSAU=,tag:fl01agv/QL6uosiMu0rDzA==,type:int]
+    HANDLERS:
+    - CODEJAIL:
+        bin_path: ENC[AES256_GCM,data:lsEJDjU3WT6woU5bptLcYR1wXqWdWUfTg95Rsi+KBHbJgB2WCSApOL4NokZErBfF9b2Gp6Oo8lbTnw==,iv:A2I+IE3Sb2sMMt3jzwQahVeHVVSKFegWe4lOYq7d+kA=,tag:fcR1QNOhmBa60VW62XcEwg==,type:str]
+        lang: ENC[AES256_GCM,data:UkMtJmLV7w==,iv:pbuB6D7FVuwpjJU8Aq/94McxvrADBG6q9NK1dInRaWA=,tag:keZqRH/pnb7hJGK/5IB6Dw==,type:str]
+        name: ENC[AES256_GCM,data:FNj9NpiNTLA=,iv:/NO4SppIdQ2sk4b4v0yFy5uhUA6xJe3Ln4CcbNOwoYQ=,tag:kPIcKyFzwlXawgYNuEFGQg==,type:str]
+        user: ENC[AES256_GCM,data:AgacvZvMofI=,iv:M8eB7g7NIieNs+WeQjemUfcyYiPxRSsxdQhKCHcehLg=,tag:kEFkDWkdhqWhrkSVnpPjRg==,type:str]
+      HANDLER: ENC[AES256_GCM,data:ptWfCuhtmp1XaCxZsxoyFryVbS82cJkYLOgeTfI883Abtal/nUK58g==,iv:Y2vuOaLH94pc9iY0V6qUfmlj9m3ijK/vxnyljFhBC4w=,tag:dBe2y1yG4y/MDqKeUlobow==,type:str]
+      KWARGS:
+        grader_root: ENC[AES256_GCM,data:6UFR02eSi21NXOU6SQcZyRm3SbFqgMXV4yJiMTW8+lMiVRfRVyz0cFnQjFEAlwflHxgWgXNymHNTkxYFzSUpUw==,iv:AiEGSD68isqsL0Ften6dn+/DTpHfdbUGwBN5vdBd1w8=,tag:lCXfJNrV9hkrSRxFVesPsQ==,type:str]
+    SERVER: ENC[AES256_GCM,data:4lmNq9PPq6N2O0JP5w0gXndDV5XwdPs9LvdjKtWMkTIW,iv:MN+mcnrkC1zz/l7I68O7azhrJTcq6mFBa95eWtB1Uhc=,tag:fm4CAE6YyhheVjnrsJxPrQ==,type:str]
 xqwatcher_grader_code_ssh_identity: ENC[AES256_GCM,data:2ogEHew5oYkdHOhn/Td92T0tLF59cC0ts6kQddqEgUu/7/cSadFoGvb9RfS4TUOzhAARnMdMRT5JclXlp4Oi8T0X2nenAM/zZkokd5GMmC0J2mESCm2bbdXcG2qat9Rjga7d+1bLyP1+1heIHPb5uRsGJYkA87d1bvv8vlmwtEQN3VeBrD/0I+jwTUcLamVg4T602RxWMnEm9nXw0NTDUp4TsOMtIrzdBvs9IsNEqdDT7hwSkHpmC69dulUJzJGOSFYmkYFHcDAK8qTRdc8qp5vvMTz4k7X8JF8yp7LfEGuE5w==,iv:c2o8vAGEB8DFq9VtW8Zhm5Xat4s49x+oQf7212ZeFFk=,tag:9gI1u/SBMIjLDfY3b1X8+w==,type:str]
 sops:
   kms:
@@ -16,8 +46,8 @@ sops:
     created_at: "2024-04-16T18:44:13Z"
     enc: vault:v1:DFw1gsayFWeGxTCrU0HCQzWk4YBPHQdKHpValoIHi4bO/jHn+eZv+Nr2d4FubYiq8jKrKREm/UgsizDS
   age: []
-  lastmodified: "2024-04-16T18:46:13Z"
-  mac: ENC[AES256_GCM,data:Lq39cY9aiGE9x0UaXtfox3g2sx23eSLrTGGC8Qe7T+4Xf+HnldnSCC12thUQwSAAjqA44AedsJIYon8ZAzWhMjHXJfyyZScgQYSQpyabVpJJaTynJ02HvPQx/eS///S1NCbmRNOWWD6akmxTP9V9Oo4LBcYfJbNI4TxJaLNEnBU=,iv:MwVzs4VMXHhymO7qbV4VF7UGJkG+NnVxXX8Hn3229fo=,tag:nQb8OSSu8AcNuGyi7gr8iw==,type:str]
+  lastmodified: "2024-04-17T15:34:21Z"
+  mac: ENC[AES256_GCM,data:P3gaeVFhsvOoPoGQzN5rgQct7/XB3eDPmBbgh8MtBrW5HB5P6DKspgUBA/LfPYaVMcI6Lm5jGtygj7gNiSlraHaP6Tq/1usfcDLj30apRakUB0uFxF6TqnYfUGNoLqq2mI9eSzZE6lpmnzkyRoWWzp4dbdRPPOWsBM5gBTJZSxE=,iv:8JbyZGkms6/t61zLh/c5G+DEeSRYcMCI84vdkUs2CrE=,tag:2RjStjvuQ+4T7kglYK9suA==,type:str]
   pgp:
   - created_at: "2024-04-16T18:44:13Z"
     enc: |-

--- a/src/bridge/secrets/xqwatcher/secrets.ci.yaml
+++ b/src/bridge/secrets/xqwatcher/secrets.ci.yaml
@@ -1,0 +1,103 @@
+---
+confd_json: ENC[AES256_GCM,data:ERE=,iv:oh2uLN30sxPn3Rn80Tpc/ATBC8ivDwEZsbfrfYEGZEU=,tag:JNeq80a8BLhEMN8Fl7tVMQ==,type:str]
+xqwatcher_grader_code_ssh_identity: ENC[AES256_GCM,data:2ogEHew5oYkdHOhn/Td92T0tLF59cC0ts6kQddqEgUu/7/cSadFoGvb9RfS4TUOzhAARnMdMRT5JclXlp4Oi8T0X2nenAM/zZkokd5GMmC0J2mESCm2bbdXcG2qat9Rjga7d+1bLyP1+1heIHPb5uRsGJYkA87d1bvv8vlmwtEQN3VeBrD/0I+jwTUcLamVg4T602RxWMnEm9nXw0NTDUp4TsOMtIrzdBvs9IsNEqdDT7hwSkHpmC69dulUJzJGOSFYmkYFHcDAK8qTRdc8qp5vvMTz4k7X8JF8yp7LfEGuE5w==,iv:c2o8vAGEB8DFq9VtW8Zhm5Xat4s49x+oQf7212ZeFFk=,tag:9gI1u/SBMIjLDfY3b1X8+w==,type:str]
+sops:
+  kms:
+  - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-ci
+    created_at: "2024-04-16T18:44:13Z"
+    enc: AQICAHjnbqe9AmEW1Js10nySybyuAG7Fb5E9EHUgkmqFDv7PxQGybcfmnUvB5N3pkXc+9ch5AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM/4CSiwztDCKuyN3oAgEQgDvUtEGftvJN4EzTdnZS00yMzsZhgmq3lCXovEvM6fFJFBZYZjGAeKZYnhW69ITlOIUi8K4iZmlUy9eQFw==
+    aws_profile: ""
+  gcp_kms: []
+  azure_kv: []
+  hc_vault:
+  - vault_address: https://vault-ci.odl.mit.edu
+    engine_path: infrastructure
+    key_name: sops
+    created_at: "2024-04-16T18:44:13Z"
+    enc: vault:v1:DFw1gsayFWeGxTCrU0HCQzWk4YBPHQdKHpValoIHi4bO/jHn+eZv+Nr2d4FubYiq8jKrKREm/UgsizDS
+  age: []
+  lastmodified: "2024-04-16T18:46:13Z"
+  mac: ENC[AES256_GCM,data:Lq39cY9aiGE9x0UaXtfox3g2sx23eSLrTGGC8Qe7T+4Xf+HnldnSCC12thUQwSAAjqA44AedsJIYon8ZAzWhMjHXJfyyZScgQYSQpyabVpJJaTynJ02HvPQx/eS///S1NCbmRNOWWD6akmxTP9V9Oo4LBcYfJbNI4TxJaLNEnBU=,iv:MwVzs4VMXHhymO7qbV4VF7UGJkG+NnVxXX8Hn3229fo=,tag:nQb8OSSu8AcNuGyi7gr8iw==,type:str]
+  pgp:
+  - created_at: "2024-04-16T18:44:13Z"
+    enc: |-
+      -----BEGIN PGP MESSAGE-----
+
+      hQIMA9YmDGFr0PozARAAmD57uXQ/pdcvfLIq7zfX+60zR7pPeVgcPa3ZUplbdkkj
+      pGl1X9NFlyImC405EZRlVzUXkkmFt0/+vP++FKQGhyFtHihiZ9u43+Frpi8LIOhe
+      UYOq+ZwnWVY9F5lPRdwe2ilVPauNDh9ncbZ54chd9+9sSG2YkHg3OyvwT1ZynTBl
+      ap2e3uvu1PAoFtxCW0q7S6PpMKD2PQgwuHB0zhVTogTQl8gLaXCbEoHLsWRLJq4s
+      o0FzYhcc2FGDnhuBfinElrCPAaPAheTakVrDudwnQ0duLbZ3Z7zZ5fXyqB40jjKy
+      mVVwv8vmM6vV6dOVFtX8dU3sxwcC3K/Kf5+7PwUca/gw0yc12gjmcbbwa04W0OgD
+      ftjJ1iJiPuL/pSAzWDXTsl6RZ9a/irSuqT0W9RSkQ5MI8+YCqkEg79OhxL2QDfQT
+      VAD8ZEs5+SLGljqkigBj0Z4MSgaoqE94gyqFG3/FdHsXDkkNsEw47RL0LyqtR4kJ
+      ZZL056Gml6+e6DHT4MjLJgmrjZhQqX/J0KqITBWy9C0/op04nzCt9rbhdsGYTRMZ
+      P1DVv9De9zb+4u7X1cnRnAbvk4+JX49zmeev2pFjtcdD4HNrjmlf53gE0gkGRSF6
+      vc1nPVxVfHP5UUxxia+Jy4oKJ1PuyH6Pw362fnUlnrJ6x4aZF0SAqoi4zzHEGbjS
+      XgHMEoLdUOXKCz6o20mX+WsaUq98O1S3tmV+0Ttum22bJh4xfZYrgYJwWblrhKiV
+      ppsUcIN6wIKtDn1QmKdODO6vo6BiGIZsHL1XOjkKie3qdsm5kPJXi41fFeuw2WU=
+      =teBF
+      -----END PGP MESSAGE-----
+    fp: dfd1205a98269f34c43c9221d6260c616bd0fa33
+  - created_at: "2024-04-16T18:44:13Z"
+    enc: |-
+      -----BEGIN PGP MESSAGE-----
+
+      hQIMA8MO7RiKjktCARAAz1oSLQGpAfIQrn2waOie5Z2pAl0/cc+ASPM1Cd7BkppB
+      tZbKPlJjpMbfeTWCpX5QOsHFoAsft4AAnlKQRPPtNT6l1ulKLAi46rrdW4HRebV+
+      TX8Iv6PV3HyVhfMJdfUPC5/mR1B5528dgjtZ9ry+A2IsbK9VN+CZGu4+0vpswmV8
+      XzVEsIWWfhJhYHImkvXXI0ZZmqYtj1HYvhO3xXCfCAj+GmHkPwRnzgJVOTaRvBeQ
+      dNaixGVGtGjOST1X2/lhlJoJt3OyKqhYsktgt9MXuOlKjYFs7ki9Qh8Q2gRS0OiT
+      AU83i+yjDwId3G5Lor1trW3OcY+9AYAMGf/TWXD9Tb2qXRxG2Sz9MlJsRqQDdstS
+      lgmqN4FMRjTfiCeES4TrCn4jxyYTZFOVlxnQio/JdPWFWBQr8gOtf4ZiUod148GT
+      x79D0PEowqEmuzlz/oszrmUcEUrBgD9jKMW8qhtzucilr5btzDtBB38TnY0pRIl6
+      0DOOcjMUgb/ODkgBBBZyo8z7cJEgwwM+1sH/zUsY6ene0AYSSJtivd9JW3Kyd3DR
+      0x8E/PM4qc60/sTa5o9lJq6WgesXmxxXBu5BFHc0YQjjM0vpso4rn9CQxq6pgE3L
+      l2FyE7gAn0fpNGFi/PVTEoe/ePlzwz7kQh7YGdf7sJFN/HXc88s8SwZNxmtxyXDS
+      UQHpK5DDi2z5v9i0y+a+jSJkqC7v0EyY4fGWZ1IBvGz/rLMEL8WvGQxk8StwEtjm
+      /NgpkD9BN1VxcypvZ/NSxyU8bH51tn9NBRwmMvirGKk2IQ==
+      =ZLl+
+      -----END PGP MESSAGE-----
+    fp: B905F0256A801D3F1D15B5126A1D27A4BE75B1C2
+  - created_at: "2024-04-16T18:44:13Z"
+    enc: |-
+      -----BEGIN PGP MESSAGE-----
+
+      hQIMA53hirIFs7uxAQ/+MPuBdHRxbO3qNVZ5cBk8USRYEJ6VO38zHGX9YLfyx2iU
+      0IMw1VAGRSBxzHyHh9SyvFTxzDEmdcqD6p3ZrRO8hFXQXl/AANL8P8YmOToiS+S/
+      a1EQQigS4r6QkEvbIeb17n5xN9X9hbSMqBfynRa8J6bBmKYHA2G4N5FSAKq5RdID
+      98+U/Am41u9ayjikC4JMx6HVKHStTyHuZjF6yYGT9496yYi1ooljIMWux/zi3xaV
+      w3OFr8v8S7e45KfxQpCLXAnkBzklqk8UM9gbPmXvj47j7fUjmjuD95GthpDJNHws
+      k1kJ3gKtOlg8eRFQd3GwxvaxLQ7vnY/Pwq2njR0fw274l4qO9Mr6xVd5OfujJM7A
+      IOzThoRp/trj0mTMUCmYgHu6FUPp/1aT+FAOyzb/0ErLU2vbMIO8PShDLRTXmt/9
+      o1Y4SUbxGTnPri0yvnpabM3khgpk1SHB/nzqO8OlV00nJRPh4WILq7w6EUycNdJX
+      qVi7CWshN3KI5F6SNIUZ6BtHb//Zsj9EHVi89cWuCKUEtEx7MoYvOwoSuRsvl3xD
+      +sLf1dk+Ns8umPqKIhbe/MvJLvzMHzwqc0+/N9kEfDOp7GX1CqEVptkTz+zPbTi6
+      gc6ePc9Y+hsheMqc+lqwWWsmS/sqtqwQ+vSMoY8EYFbPM5kQEaz189VFIrNHDIfS
+      XgHwaMVngT5OxRXJ0KU5bPgwka2kE3dS66nhynyVWhuCI1G5JDBwaZZQ8XNgptbv
+      uWSfuFLaK9WO0usbMF3s9mFv+ncTCk7d6q6yHxInYq3nEUB/Qk03LCZh0xm7Pao=
+      =K2FX
+      -----END PGP MESSAGE-----
+    fp: 07083D36FD5986B0C99700944E9B358045C1B176
+  - created_at: "2024-04-16T18:44:13Z"
+    enc: |-
+      -----BEGIN PGP MESSAGE-----
+
+      hQIMA8YdB40JfEZzAQ//T05WpvKaOPzJbZYaqydhqskr9M7CrzrTzYJJsjK00LBA
+      MvTjOjtZDukmNUCKAs+h9dl+X520ko80MjuSR/F5Oxy6VQqZ/FK7e9hu5WQEwBBh
+      3ZQsdzumr3WCRYyJEq19nJNMqKSujQDrBqRiiue5AAWi0tQRa2LEmwP1tw5pPP0J
+      P2uc6XJzcK4rGWmwEZWdnQsWRxccQW2BLyR4rtM4JugkQ9a6Fy4YzJuRULMJWZA2
+      RqB5yPN82TBOrsBoWL99BpB77CqR/Qoi9lxrrWg5+8TkdinXk20ky9o6Zwdi7eSj
+      WnygEXfzL04smkqt6rW5tpZ6/bs7aYnkYCzA55/l/gKSHdA9LdiU8jig7mBMJvVO
+      jNvkLpZtA/QP14QJXoZMELq9pwNZYiNNemNuZ0fnfaBDrwWO4vT5U7HkXcs24iA2
+      LrK81bRngXiibvcZtYnzQntWD1pTud3RiBIOhVVH+uKVp8WIENwqXdZcoJ1J77RE
+      vxU0SzGFWsNGOteqhc9T/6FOVSsL88r3vIVc2TKmraliRj+gsx8aWu+HWLQFr8Y5
+      nBzZdoLLLFDGPg8r3NfjFlRbBlaSP1VoveRjtQCS9CzQT+WzyyXShJoEahrF/ylq
+      RqZ2+MpSkHyoW/QO4z74krOjaB3k3yWoWOj2tRjEDwGU9WcP0njkashI5/65uAvS
+      XgF5ir5Ro8833kPYzn0nCzyo4osSXsWBq0C8ardltxdY8txmMaTrj8jWY5+tSCv5
+      B3CjtRRofnyLjuY9MOQfNla6FKjx/8Hvf2cuG9Vh+MigJ65jIVjLrUATVfsSL7c=
+      =qUiA
+      -----END PGP MESSAGE-----
+    fp: 3582AE9F12CE295BDAF545ED17A5F53F11681446
+  unencrypted_suffix: _unencrypted
+  version: 3.8.1

--- a/src/bridge/secrets/xqwatcher/secrets.production.yaml
+++ b/src/bridge/secrets/xqwatcher/secrets.production.yaml
@@ -1,0 +1,216 @@
+---
+graders_yaml:
+  graders:
+  - name: ENC[AES256_GCM,data:CJEFoJq2E2Q=,iv:/svfF2BhTRufD4HUY4/e3U4C1uoZg93i59mdkd0NTqg=,tag:gpeMihlWF3szCMlFnhtk+w==,type:str]
+    address: ENC[AES256_GCM,data:GnVPPRFinmGb/CdTHNitpfqXShU3mgghcFmDoY2QqZGTaI8Tm75z6A==,iv:U2MmVWQjrflNpLKMGb5+DgnL2bk99M0DpSu/7APpjsU=,tag:jCZs5mMBrYqOs9nyU7wxcg==,type:str]
+    git_ref: ENC[AES256_GCM,data:ApikKUP4,iv:pzXBymJP1SigUEr8NlZ+AxKwIR9U1slQ9sEn4o+irvA=,tag:TMBO7ieC6UbwrslPO7Yykw==,type:str]
+    env:
+      GIT_SSH_COMMAND: ENC[AES256_GCM,data:o4Oa350wI2XBVH22Pjjfxz00Z7lReVKzZyMR6GMLk4tygT37uFF5IERkgVixcr79g9eh/LGual5qsYd56eOYEZ5CFszqH+Mv/J1itdq4mUtqwWQQJffRLpnLFBTrVVWVU4aNNVZqVh6ryaMQ5O2/buXF40nNoMt/53hIsaId+bPpk6n5eUcY1wTM+gnXtVXS,iv:dk5jIq0UampOECWDF8DjFQZl9zY4qlIaAKU2FZR6G/Y=,tag:LDj5kZjp1W/4+PaXkxiXrg==,type:str]
+  - name: ENC[AES256_GCM,data:DLt8PlQaX2MIN/DLIuhKNzpEhhFf7Zl47/Ws,iv:ncr/JZy2IZWTd3yfgDPuNK3RwdL3jfnoRNc9dnt8KNM=,tag:NRs3ypuFIZVHbTVqjdbAjw==,type:str]
+    address: ENC[AES256_GCM,data:IwoxMAM45HLHeVdtu/0HfEVdLbTttmy8OkRfvOjaO1INL1Km75kAHg==,iv:aXl8B/JKnXBYrf6qQ6X+43xv4/bwZebS1axX4bX8OaQ=,tag:vTb5ZPDe+7RMDvGauNxDWw==,type:str]
+    git_ref: ENC[AES256_GCM,data:5s/Hz4YY,iv:xJr+WClo9O3V7+4zsKf1YM/6PGfmwj/AWR6CdPOjLss=,tag:fPkwOXQcR19H8WcUXYTHGw==,type:str]
+    env:
+      GIT_SSH_COMMAND: ENC[AES256_GCM,data:jcdCzn0idn+hOOoX6ZvLX0OYyzM1W/36geNdAcgmTJL80UiD9DRDQLQ57g2WNnOiXmsuStPv0D48qsNJhQms/iLnjkP5T0HirF4ApGFR4uELA2l3SueOsfjyKx4KIwJ5d8qsFGCGy8icbi/SBOlGAUGuoWg6K7wpnrSZ0MKRHIYLofy2i54Vuk1UAL5WzTZs,iv:4CpOr79vAtdrkfWCMH9IuYclHRX2sjWpYzyWL6VNNN0=,tag:IaN8MFq9Qe0Vl9mL3BaxEg==,type:str]
+  - name: ENC[AES256_GCM,data:uG8/tj5RahV+YfHXPKGOf/d/ijB8iZyyi+ciD2A=,iv:IcynShcGc0jqRjgDNq5OsmiBFC5GhEzmz6cV6r6Z4wQ=,tag:qDE12piJpNsqMUBkRiZjvg==,type:str]
+    address: ENC[AES256_GCM,data:NeN+2es1ka14Ei0V61sL0KjJ2wHLJF3779YPOHptvPM+XBCRwFF/+g==,iv:X19Kq3GJlGhi3Ph4xOUKx0Kh3peTm/nJOQHryfb5bo0=,tag:U9D6iZsjK3K02Ry5I9+WKw==,type:str]
+    git_ref: ENC[AES256_GCM,data:RNxgY5Rv,iv:hILWee8Dj5/C5YBWQh8v1icKpIgZcZSS3ZeqEuFeZns=,tag:IWM2eydyNjS0GV5f1MEg/Q==,type:str]
+    env:
+      GIT_SSH_COMMAND: ENC[AES256_GCM,data:VXlhmOm/sq6i2Po2lbqOY0NIiie40yLuMqe8VrfIlUgVUk5zlFOY1pa0BkMZGzVDP8nT2BwaM8zyeqSnOtdkX4moi5lQYP86FuD1wkZiPx4APgIY0pgiJMuvSparZKw/D/uIu8kPxXeUsCAdde/7gN9Nxe99FOz+mOQEYIpG66Zjyj7l0XpqrAcza3fBwMDn,iv:Li4i2qmdGqBeCsTd2zsoccS4wZ4yFize4zm4TfRHr+Y=,tag:fqt6NvzloFvLuEZ8AdFo8g==,type:str]
+confd_json:
+  residential-6.00x:
+    AUTH:
+    - ENC[AES256_GCM,data:M67oKzglXtXh,iv:Nhnhd0Z6MVB0JeTUIRD5vQvdnB575Y2YMiIGqgm65eo=,tag:O7mKSFI2ExxPeXL3+pZUBQ==,type:str]
+    - ENC[AES256_GCM,data:IZCDoI14t4rqUb+VbwA/LlBiB8lk6RSLSDOPSQKdXE5oda6b,iv:FHHycpRisQzcu+E7og80HKpco1F+z9Z0R1h/wlD5xTo=,tag:tzUddhvyngwD1F5uT7m0rw==,type:str]
+    CONNECTIONS: ENC[AES256_GCM,data:wg==,iv:0ily9UP3xEOXwTPS1mQFctgaI9QusPX3gpxci/m6zBI=,tag:T55b+SZpypz+sgE9InsXIQ==,type:int]
+    HANDLERS:
+    - CODEJAIL:
+        bin_path: ENC[AES256_GCM,data:YasiEiU6shaMIyqB320VsU9QEhU3h0A8KzD3n9NgtjbaqPVo+/6suAsSBLq3TMLDIMBc5bkKjh4AFw==,iv:iRuTrDaxdbAo3oV85xejockI3hsc1DISmyIfQq3BcU4=,tag:7lq5g+D/MG6fWgINJmRDNg==,type:str]
+        lang: ENC[AES256_GCM,data:T8nWkWbg7Q==,iv:cfV2eBK9alL48tDT2eXFPHsx7z0kPgRPFwZsNRLEOq0=,tag:zYLfveg9PaSHVapPEwAC2w==,type:str]
+        name: ENC[AES256_GCM,data:YKNRxeZSZTw=,iv:3FzVRqpcQOlLt5Lsr8be6D5Q6LmVv/5VYgm5MiESD+4=,tag:Vj55NfUy58dwAN0IWVpSkQ==,type:str]
+        user: ENC[AES256_GCM,data:RFx3kcRGlGI=,iv:CyJ2sk8tzM5MM3GIh4zMEHguUU1WOF3r8W+kw6medQo=,tag:5/1DdCER6wQBtFEPtMOiqw==,type:str]
+      HANDLER: ENC[AES256_GCM,data:leuG3bGgdHRhcwjwoZx9cKzo2FTskdGu7JT4+yHXFbuGCf9UPs22Rg==,iv:nYr2peXxYI/6plQ/CvFXnYsEwnvzF5aXD1L0FdXzX94=,tag:oIsTZdWXH8kZkMYx+fk+5g==,type:str]
+      KWARGS:
+        grader_root: ENC[AES256_GCM,data:JpRjAZrkwpoj6GHTRtCbdJNTyA37GDCo/l2bzuWqqg/tubMLUhbjmKjRzp1BnNbeKH+iXYbnBikcaTiJCYdnjxYwv4KWT2Br,iv:ztgPo3v7intXIJyq0QZ3k0sOLuJcxZS2lPTjIJHxOdI=,tag:e7tt0boBPdXNSMZnWE3+8g==,type:str]
+    NAME_OVERRIDE: ENC[AES256_GCM,data:42zLkUwUITGO7CCIxYxXe0PU,iv:FVs6QK3rh8zP9VntHwvmSWKAqU36tJfytxU5CJscjE0=,tag:bT/QMx1sE4JMQay12aZ7jw==,type:str]
+    SERVER: ENC[AES256_GCM,data:GRrO+sxP9w8lHQ48gn9vMkka69Y55670hTU+g7oJvQXTSuAGZrg=,iv:8XBzgcf69F+jiWgTnSwCDvU4oedWqWLB46j8htQD5Tc=,tag:/IyJR9jl1t2ndjeE/KkVMw==,type:str]
+  residential-6.0001r:
+    AUTH:
+    - ENC[AES256_GCM,data:IFUDD92Ralrh,iv:bpAy1JC84fO3larAbmWx0rNpt/Kzj4Izux1HSXsRwe4=,tag:+ttZplx6YyeOKmxqf7HYfQ==,type:str]
+    - ENC[AES256_GCM,data:7IU53OkMecRX3BDjfIxXa4evJncFW7StSzL7wWOukzhZcyD4,iv:+oahCtO2bSkrfuojA/VqKlsNfdAIR8xqYr3YqGhFQ4g=,tag:5F5nCADGJ/yKsigyY3wBBQ==,type:str]
+    CONNECTIONS: ENC[AES256_GCM,data:xw==,iv:rCDXV+BB2VJU48qDxNrDSjfNmcMEPWHjc/07XD7zqfk=,tag:88foquuqrnqMPY1V2bMmdA==,type:int]
+    HANDLERS:
+    - CODEJAIL:
+        bin_path: ENC[AES256_GCM,data:wl5U3kFeWOcFn4evuMwbbLAaQUfNbmi2zXUpQdm7EN1AyHcqgcG60GNGTrP3X/9t78RGHpAua/6Duw==,iv:2HAxo1cKd1UHyU8gCaoMMQpgRPoXx6ircPI57DdLLbs=,tag:N/b5WofoVCBoEGFd27Ji7A==,type:str]
+        lang: ENC[AES256_GCM,data:su6CH0xdQA==,iv:AyJPUpYkgT/jwNc4M5IjPfc6NRrspNRAY/1pnk0x6Sg=,tag:h1LFHMsa8CCVzD9MnmzPKA==,type:str]
+        name: ENC[AES256_GCM,data:M1IwXSNp5sk=,iv:i/VuR7CkpKNPFMUKED58Ebt9rn5HLeVdP2UK0spzmFs=,tag:OxqTWj72n2j3DD1+sxyuSg==,type:str]
+        user: ENC[AES256_GCM,data:tfl7wW27RQg=,iv:risY5SPcEGKR3yl5Zz8VtWc4x2gU9UxX2koV3R3SYSM=,tag:lNwdxbo1Ueuflxs5v4opfA==,type:str]
+      HANDLER: ENC[AES256_GCM,data:0NpvGG3WLq2yjo4t4hYdHfJ1b5lrKEFCbI7Wb3TPNNQGA9MRRIAuSg==,iv:lMxsIZEmYbnVNWvrxgsnhT3mFKmQxzDGljwYGyohncI=,tag:u8ScAqVgSpS4goxd7kyPSQ==,type:str]
+      KWARGS:
+        grader_root: ENC[AES256_GCM,data:Y6QBmRh2iItVlQLIUbDE9JKFzRDv4CNzh/DE/Q/t6pjvdRmmcGNoY/6TkALfyeiAZK2I4cyB3wGIqUfTwfcMTuWlD3TEctymBo0=,iv:sgX+hJP3MQDFkNUY4Oasvr2RbDHJ5cmwNZHByOEPouc=,tag:8SqKPdMchP2QMz1mC4v/Gg==,type:str]
+    NAME_OVERRIDE: ENC[AES256_GCM,data:gRuI4FEQ1IKyl7n+XV6kxt8d2xo=,iv:6yyI8/QfAjZLGL7Sbd+A5f7xj3yTwTMO9ezYndSMpk8=,tag:6E2rlMGUENP6lEvbWQlFDw==,type:str]
+    SERVER: ENC[AES256_GCM,data:+KaHpMs+vrZ8Ham8skaeC7edlU1LqNrvhReRO4OwbiyffS0pQps=,iv:vtYFNTKmefw8Te7MkrH+VoYckU/Rx2FKFXEFHxl3tzQ=,tag:P5fqNW5yBlk6S6rOBOOcrQ==,type:str]
+  residential-staging-6.00x:
+    AUTH:
+    - ENC[AES256_GCM,data:0ebE9q1FXXAB,iv:pZDmXnGGXV1LlscidRRLc3iP61neEiwoEXQrnBGP9w8=,tag:IYw6kyAyiOwBsoeU2I7oDA==,type:str]
+    - ENC[AES256_GCM,data:ryPvzdXxw+sGYcMK+0NcapKM/THW8jd+jgDNLMF7ixvGrwjVT3xMMw==,iv:hv7FtqmTpaLU8vY+3AYd5HzL1wUP1QpwDl5wIVdsw28=,tag:yTotpcu07lUFWmGspf7E/Q==,type:str]
+    CONNECTIONS: ENC[AES256_GCM,data:OA==,iv:XMZWlMuMhroeYn+7EX2pjpmQQEGm2eZsvcekkHJEX8g=,tag:oFaeew+suPAMmvTxeyDOFg==,type:int]
+    HANDLERS:
+    - CODEJAIL:
+        bin_path: ENC[AES256_GCM,data:Y1OrCRmsOITIocvfC1LCx01he/f5jghyVAgC/sFeHWPBqQXo38qrg7FxzoEQh8TxhCBWtE3D6woZDQ==,iv:qAIu6UJgQyeem+wVhQdcaTH4Xc5Ba33hwCE9ceZrp18=,tag:jdbomkEGO/gAZFGVAMr2FQ==,type:str]
+        lang: ENC[AES256_GCM,data:9oPPNrcFSQ==,iv:6J0wmts5muxoLpBMSaCfsdmHGL/xkCN4Zhl+fj4Is44=,tag:pBRrAZUgmn2ACBGGrbpkug==,type:str]
+        name: ENC[AES256_GCM,data:SwD0Vsr1F/4=,iv:zVrS8u8XAfnDjbhZsq1+v33BUwCP257CgCPvQv2jsvE=,tag:HMxkVCRfLqXdlZs4RLB/tg==,type:str]
+        user: ENC[AES256_GCM,data:WaVfAUvf268=,iv:P8+lV91CXklkyXiNwC7Iv0vpAVIbi5Hp9CCht0do5BU=,tag:SZUdO5vPS1l92XWsJ3Sshw==,type:str]
+      HANDLER: ENC[AES256_GCM,data:X1i3kWzvqEFh1oe56jhtz6g8Kno3e2wkYXiVpAufYhqYZZIFBzYm1Q==,iv:80PwD/MpLeKyrODHCOyemsNoU2+YBjqjrnNU7aXiO74=,tag:y2t8EvB3+qUY3OLDeWrAgA==,type:str]
+      KWARGS:
+        grader_root: ENC[AES256_GCM,data:mLizLMYXQG0cbKsC2ujnIZUAPxN8fAgxgPMBLVllRNMEisKBE36qRazPOu+/GWxXN271zyqIyojsSXKntfCLzxHbtkZrhvjc,iv:qoX07KMeVFElCaI6+nWuCWQEYMrMBikVl/DhECWc6Eo=,tag:l/giJYXMMRUrpS1TXtTTqg==,type:str]
+    NAME_OVERRIDE: ENC[AES256_GCM,data:eRsdqaMIwhqGPmGUAs20allX,iv:vu2XWnZBR+m3pNgsqp9LzS4esf5mUytNP7FXfIS3CsI=,tag:/wtFA8fesqtQzkdQwMnGnQ==,type:str]
+    SERVER: ENC[AES256_GCM,data:Ddr/5kN+9iz0mi9kGadiOD+/7xN1CMTDyq71s4Lw7otIU2IXdnXyNfjXdbPWvA==,iv:E1uH/KjYb30O5mdcRmjhU4lTAiGOPLz831KfyIpQv1w=,tag:m7Hi3VeH6KlXJ6lojS9XVA==,type:str]
+  residential-staging-6.0001r:
+    AUTH:
+    - ENC[AES256_GCM,data:pPKF5R8TbUrW,iv:Z22228AvuXCGJONCRnzoHEuRqYPbhG347okIuvYL1h4=,tag:FS6ruofA8bgOBZTQz+dAEQ==,type:str]
+    - ENC[AES256_GCM,data:C9AbOAGcSMkiR5hzV5kWLrJ6W8PrIuPIjINAD0XMqJCfSqmzDlt6Vw==,iv:EK5H1mPoBA3NExTbHxMe6PYvVhWWfteOlLNf+2vqdRk=,tag:PvLt7Id/WbMeoWYfGoMELQ==,type:str]
+    CONNECTIONS: ENC[AES256_GCM,data:8w==,iv:opldpYaJdqSmgGS0B7QygxR52dZO9lDySZ5gVxOyOlQ=,tag:tAu4Bj91ncyDeF2xfUTNGA==,type:int]
+    HANDLERS:
+    - CODEJAIL:
+        bin_path: ENC[AES256_GCM,data:CZ7IEyvkcZM6ruOu+hN/61jW33MNVoCHLvqi1FjX8AVW8ewvR9NrIPTieMaDvUdix8546tOBsyMlZQ==,iv:sFJ7fOPaVAE8ozNxTkNrn7Eg7Z3P4OXsDdAv7Zn1kiQ=,tag:douQdPW5d6dbA98GD7eNLw==,type:str]
+        lang: ENC[AES256_GCM,data:9NmOPMJeEQ==,iv:N6FWr67Ntk2IUMnFxqZ5F2pDMRw1zgbOHH1xktcaxUY=,tag:txQ1UXqPSm8GlK7ElIqf7w==,type:str]
+        name: ENC[AES256_GCM,data:gh4Y3zIdhEU=,iv:3UnKRV8vSJeTaxcnOpEKyomzIfyL8IHFSBSpdgJqPpI=,tag:DWLocHKW3msmD4lowLJbXw==,type:str]
+        user: ENC[AES256_GCM,data:ZyEXf/zBips=,iv:zvvl+d8bEnrBEuiR3DZ2M9/GPV5BXzhDyRE4w8l11tE=,tag:+Jw900C3YaotFEJN9kPZIA==,type:str]
+      HANDLER: ENC[AES256_GCM,data:JzFVwY5kA06X9f/X00S1oToxB9/gn6uHns4LTKVM2Nkwmg7hoiGtIQ==,iv:84OvATZeijQEI1GbzczBXomucffgU6nZvLcyKKazoMg=,tag:Yh3KOWiddJiFUXwL/kQFtw==,type:str]
+      KWARGS:
+        grader_root: ENC[AES256_GCM,data:37he9hy2tI36/PNzMbD4T8qeC5IYOBCG4PaDk0uhhHiisqf+yII0TgVPPn3efBCLhXlgYavZh8zIYM5vaEHcwGIjgbN4rl2Px+k=,iv:UZhHgU0HsLkYE6ssZBktzMPqO4fNA+1l6yIbdwRRNek=,tag:hcBKt/JgX8FuO0V0x1T7yA==,type:str]
+    NAME_OVERRIDE: ENC[AES256_GCM,data:v/TlqJx7VSPF3XqgOn+vhyShOvY=,iv:dnBAHIQredCqqZvHqZhlifeo+FhQzZukIRIKYivoKdM=,tag:kykSLQXt2p1+9PS3QHEk0A==,type:str]
+    SERVER: ENC[AES256_GCM,data:y/ChrGSTfsqwUBZ+cO6c3cQAXcdfq116M7A5Zpf1VrZC3Z86nJXrlvhGA5HlTA==,iv:A8Kywv9bOs7NwIOh+m+Xq9OJ/9X3npeIWSr/4bAgPzA=,tag:eROck83n3+X1/8rDxC2nHA==,type:str]
+  residential-686x:
+    AUTH:
+    - ENC[AES256_GCM,data:k99ot3nAwRaB,iv:bEb5PNHoDWyfNezaaFiZzece71bD8lCGvlWPR2ch0g8=,tag:ee4wCHf5IYgE7Re4OTOMHg==,type:str]
+    - ENC[AES256_GCM,data:+OF3M6iL30Uxlm3HlSKUCp38YIu8AXabB405qOETu0pJd2HR,iv:sfZrFSFafcUTMol9Vt9oGkeSCFvMSCVEgOWCT8juKeQ=,tag:WKwV4rMLQ7NLGwjYC/9Kqw==,type:str]
+    CONNECTIONS: ENC[AES256_GCM,data:cA==,iv:hvkkidj/RWklKtpgNynOscmd5TjmY5n6BFptqxHKiF8=,tag:gDyucK3S/1m4dBjssIuzgg==,type:int]
+    HANDLERS:
+    - CODEJAIL:
+        bin_path: ENC[AES256_GCM,data:hOUT6hzEkVPXaMje5gkH/V4IzJKBMHAR6Gcop75Y1EMsBH4z0CuMTDETTUPdKGbjvFbR2g0ldOzDrg==,iv:Oh/zgbmaC7ZaNNhyLusla8+a2ltyO/5MCGmdPomfMQo=,tag:ddiBVD+rIAkWizC2u3RQHA==,type:str]
+        lang: ENC[AES256_GCM,data:LENIZxRy5g==,iv:pe4NHMFzWeZaftOoRuOQd2+Olxqk/93oZgnhjtsZNQU=,tag:9A1s1xyOipXP/+3YndFPGg==,type:str]
+        name: ENC[AES256_GCM,data:WKTT3aqPSd4=,iv:fW05tKdQXYZBPL3OKIguuHHgMMjifBOA4HUP5ziKd5o=,tag:+aaGRqP/sWMeVpSoO1ac6A==,type:str]
+        user: ENC[AES256_GCM,data:Ft1Koeafyuk=,iv:7ekGZAokKGfX0Uvt9tHbvjdBVKUXk5jDX1O3WpDFtEI=,tag:8GyvODOqf5LNbnd2wcVmaA==,type:str]
+      HANDLER: ENC[AES256_GCM,data:Rx2UGZe53QGTcuzezRjkmCkfTmA+NQ0pIoWpQMTqbfZ/ctVWEMhVjQ==,iv:lBJNUOWt+dKPgyR28oYZRgUnWR/t2CqaLvBqaGSOX00=,tag:RY/GlQHDFI9b2CExWuVVsw==,type:str]
+      KWARGS:
+        grader_root: ENC[AES256_GCM,data:qLiT7p9jNttF1ebIzq2OabjofqHXKpOoCry6KB/JbHdszg4vhlY=,iv:qAZ5AiO5Dr4Emhukd+gr/7VUnjHb4zVx4UBV81kC78E=,tag:vPi8U1PasR+FNvMKjCPrVg==,type:str]
+    NAME_OVERRIDE: ENC[AES256_GCM,data:TpoRWAd07mMOmZxqLu8h,iv:+1JL9GXFt4INMBymId8b9YxnsJS8Um6gc5vZrL6tqK4=,tag:js4RfVzF3qaNUmU8na1KIQ==,type:str]
+    SERVER: ENC[AES256_GCM,data:vNHLwNiwPFPoeuPeO8QxudRQh0tZLzs0glzO46aIpp9dNmYTzbrwulZuyCosgA==,iv:mxYHU1zLhlQvRHl4PNPtLXr/cmn17kY8NkdbOsPg/UU=,tag:oZSvQTIevj6ZJriKvXxHuw==,type:str]
+  edxorg-686x:
+    AUTH:
+    - ENC[AES256_GCM,data:jglE+70bfWLosuxVKJA4,iv:1F0NZY3/MBp1erFmK0/CgT4QtxKif6o8xokwTp1Kzs4=,tag:78Rbe9gIA5r2sTshcmpMmQ==,type:str]
+    - ENC[AES256_GCM,data:8uvIgA3CGaGT83ktbdbINg==,iv:J6FbufFroKYrTKUqRXwDWNI9BlGi92wWVOKzpBlGo0U=,tag:qcQnizgGJ1zaVS8npXacFQ==,type:str]
+    CONNECTIONS: ENC[AES256_GCM,data:7w==,iv:0IDDxWDK7OrEJc/Z5bzC3AudO/FfQPG9ci1c4VNX+BA=,tag:ybkCW6Budu+lNsegmXbgNA==,type:int]
+    HANDLERS:
+    - CODEJAIL:
+        bin_path: ENC[AES256_GCM,data:DPgTPSsBjsk2C67Qn0KP3Blz1jzkHgRia4EEqYCd9Cfd4amvFokw1JINSx5CdHTiAo3UVq/BFOX1KRvCHNxB,iv:hshEnIJIC++PsL+Rh59ucjDHmkgsraFmwGIPyqkmNYc=,tag:MrdLZSTWcs6EGG/HqRKiNA==,type:str]
+        lang: ENC[AES256_GCM,data:lj+DhS247w==,iv:7knwGBh67z6YHhvN5aE3h/niqxROSpS1jknZt/ZJ7WU=,tag:7TEbFIDiX4NdNRJYR2KRfg==,type:str]
+        name: ENC[AES256_GCM,data:aLB6K9As07CEZN5GVw==,iv:yAQZVvdboOek44Rku+/COBFPImZsJTjyqMZsJshALiI=,tag:qiWzZ89oiCqJGEojaRuICw==,type:str]
+        user: ENC[AES256_GCM,data:ghHFgg4VcPtouLj8UQ==,iv:dwnWx7UztbYDe01q99K1ci9PNwQKFG2SNBhFk/O6hrQ=,tag:YjauQHD8wNBsbPktq/238g==,type:str]
+      HANDLER: ENC[AES256_GCM,data:I+itLOStkcQlgrvKegbjBvGvpdNSESHOzDVI8QjCaEf8MCUGNgdrRA==,iv:AOBsBfFQaqFlGpcyEiyD1C+tmXBetIf60OukqtM+KHo=,tag:dTsPlY38SuKQI2l11ttwyA==,type:str]
+      KWARGS:
+        grader_root: ENC[AES256_GCM,data:8RlB7XtFOHuHSAponHQrtWD2ifTa9acyXATSQhP2v50+fe7zoAY=,iv:73NqWymaqDwDlZKftSWasIz7NS4Ero2YPJBpurPV2bo=,tag:EeW2p0zSisKH3DgmH8Zi4g==,type:str]
+    NAME_OVERRIDE: ENC[AES256_GCM,data:LiFz39Bm8SJU4ozmtNl6,iv:f9/dim7mqQtOyYfsk467don+RaeFlOlcOtY6XExx+A4=,tag:O12FCm+RDAvvcUtriHc7GA==,type:str]
+    SERVER: ENC[AES256_GCM,data:7o/f6xMFdTKwHB94AEfufyLh0K8GMg==,iv:FwNJ/ARo0Vj6Z9w96I3TJxdZ5ZpYSQ7oRYytnuriqe4=,tag:SeE0bAs9z/iTWCBcwuXOvw==,type:str]
+xqwatcher_grader_code_ssh_identity: ENC[AES256_GCM,data:SVF/HMkQIrqhbH2eIGBaevuhtCSxuPVtY4A3TJJrFA9HhcYP7PlCKljRRP/xBJOSYFhoEirfdO5RXg00mN3VsGoqgcp5dS5SWQDOmf6OLmxU9tjDYre4fvFkXqq+ar86N7M+IoapstMsVd1WlwC4DINKok/t2V0uflEYxq4jP9YLMluUoCT6PNvj7R0t8VlTbN7YLpXrpKMjKFytPiS8YL2bR5Y3kYb9DgOs9unDwW062y3Q0jPBQLfeDFYP97pcts16xUs6rS967/fKdlvIqZ3w+V5JNQXO1FcwqwcbeaIhew==,iv:uSRu1f/9SM+8tzlFYaPQAMDvSbE8T4AoGvj8WMM7YUw=,tag:jw+mY2V5ZROCcWc5vbyYNQ==,type:str]
+sops:
+  kms:
+  - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
+    created_at: "2024-05-06T14:13:58Z"
+    enc: AQICAHjmo6C0sCNz3fdkFlhbu0tdBZxnHmPYSnqtmocvGiuNygGvpBQwo4JrHkyisSRZB8eeAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMeR9ril2SKtaeohDYAgEQgDvZoWQ6jEjpwa9gq6vb25ma5eBbb9nCBHucsX4Itwv4CoPboSUDV12y5SvC12O3goermj0Ili3SqAzImA==
+    aws_profile: ""
+  gcp_kms: []
+  azure_kv: []
+  hc_vault:
+  - vault_address: https://vault-production.odl.mit.edu
+    engine_path: infrastructure
+    key_name: sops
+    created_at: "2024-05-06T14:13:58Z"
+    enc: vault:v1:aWyCjjLMlMraiZLA33tBOhaVm56Ykg3fVPAxgiwiVAbFlPJHwiviNH9O6T9zvm41mkrZfJLoKes3Lbkh
+  age: []
+  lastmodified: "2024-05-06T14:22:19Z"
+  mac: ENC[AES256_GCM,data:fDxdi3S7aVbgAwMLTJmF51U2d3ux13bMfCCZ93y5J8fjmNKLukVj9Vxu7Shx+myoJYp1kLXrnp+itVmnq31jIoWbXxX1acoUEIS3llgZ7QsMzznGmRuVYWDEPsCZCWokfnCUWipCNA0szPq7FEEyLEPW8mCy5SuqmX0D5nclYvQ=,iv:mMaFe6hVNUErgja7N7Nc3JIA4mT2wY96qCwn4kSWmT0=,tag:QjBTdFY2k143uub7I4tgCg==,type:str]
+  pgp:
+  - created_at: "2024-05-06T14:13:58Z"
+    enc: |-
+      -----BEGIN PGP MESSAGE-----
+
+      hQIMA9YmDGFr0PozAQ/+KIAHjZpxu+aLyH5HeOv9Kh23QIMa0RXHafflUAeGdtso
+      rwoTr/NWtwJFuIGjk7zt/8krrzN1toS7g/HyZ6+0VAsolOsyBLoEkz6mWLhnCXKp
+      ty8f3HXWkBeDJnWM4X9+9vU4LGjovd45IIxLWjmc1AVbb6WmfE6RfetxEmInhuOr
+      aVV3p3nh6FiaM8ihEzChCzK+P6mI/BYP+Icm3p0dDsanYzgFOxk+s+TNN4GP3Rif
+      rm5liyqOLtapvfjAPCeEJGbLmX7dd5ej6yDzCLdufldCzZ+WtPezpAovpdJgaYKa
+      TsyLQWeMQnOUsZht06THe0glSyTHX3CArGkS/r10n7V4d4l9ixF8BJjCWo/y+PkU
+      ggpcT5mSvvtDaPAt8+Zd/nX0mN9xU3hKKuStwXR4PLgMFJ7xZ3WzLEDhFE4aU1Ge
+      MlBMpFuLWtNrUE1oJWwp37wPkNf97G4Au5RoRo6ZYh9amF3WFOcy929o0bnsn+M/
+      oUj1vJjtQ8VowTHRcLKQRB2b8UnKR7rIFQ0KVIN5+0OxXTgoMdcpsn3sWcZ9/1WP
+      o9FLmOOY8leoaeefrNZCqryV4izUgzpn75UMb9KS4Dvs8vXZWov62zN0s/vslVgN
+      Fs48vyKbg13U9yR4JaMkyon/ksR+tYAmgU2eVR9qwxipigumt4RQcdG7QoE1vI/S
+      XgFNvVQIT/yeMKHQH5UvWOu3GS42WyI9r3MyQOLENf4oWqYsQlqIHJvBLvdU2bcs
+      z0AUItiavFi+rIcZxpmHSiGX/5w0G3tMtzkf/r64gQoB5eEpe9VOJzUsPrvWKsw=
+      =2oAg
+      -----END PGP MESSAGE-----
+    fp: dfd1205a98269f34c43c9221d6260c616bd0fa33
+  - created_at: "2024-05-06T14:13:58Z"
+    enc: |-
+      -----BEGIN PGP MESSAGE-----
+
+      hQIMA8MO7RiKjktCARAAytx0E44otYpt2mmqmGEg15+rFDdMqXGgKoifpb4NmBF1
+      f8e3Y0mR2sbH2tsFoYOZby93kXNwStDa5U77rwwSyRW8paP2inecCBicKBY/dWKA
+      sOvro6xskeADjwxlsSi3Fzb5mwBmTtcaUfVIXfVzhUnci/4U+KvjYEBPaIyai5rr
+      ZB3FF4euieghJNhMUZbL+ENDgp9uTeUnlOvMLiVdeSZ6D+VX/JDPW7hbG6GMC+A0
+      nAxAjGhbnwHqABfKEtCOmwa+UO8Hv/nfu7iS2VFtn7K88QoS7JNd+F5dkpc1OdsW
+      tkwrhqPKhJu79rpsHf62ymgUIBJAvBw3i1B4dK8Uhg3+2kJrX/rKfNW2g/J7wqZB
+      YGObKSZ6Io3ajYv63C6ypxpPdfKOLXO9Jvl9jDke1AvHm8ioXNl8a18WQrPXArCf
+      n1N/6/FROJiAqm6LTC8Wjxy8+gqqsd5viThwYJjDWE6heZ036nQFG38wjq9b0cOb
+      NUa3w4H6UTZ8HMndfkym1D03uGQLFY6Tk5izg+pgK7cP6bms16auNTDwMWht6DjS
+      HiaEbFbLaU5xOj8Ceqe5tydWUxS3v6MwwF4j9uVQvwwwSJD5JBVjhBGXGGwSK40A
+      vvuqJA+ZX2g/BkRWISEG/XwRlnr7ruw+Z2SdSyDtMpXqHwAFlkapXvdIZwjcO5jS
+      UQH90cDtP2lcLmN2HY6zlvuZHoB7T+J0jbZvJRdJd5svI2Z/FeQ4G92PEMXF8qId
+      R61galqifflRr0hd5ATXCinExj2PEOKFFb8k4cuu2oV3Fg==
+      =DVGd
+      -----END PGP MESSAGE-----
+    fp: B905F0256A801D3F1D15B5126A1D27A4BE75B1C2
+  - created_at: "2024-05-06T14:13:58Z"
+    enc: |-
+      -----BEGIN PGP MESSAGE-----
+
+      hQIMA53hirIFs7uxARAArAy46vFBnacGfl5iZOX9g45EMMXM3DSnoPXJ7pf8h9E+
+      uXvVjkL/MUZFGd4wLimS56otU9LG+36+y5DLEOxBnJelx3YU30cHo3SDz+74LxSI
+      LUbAuxCVQs1fCQMjKyr2Ifd9J2SEVWhMkRVrdjO30wplEoeYBg16B/qQdI4JEsxd
+      r6ZV1iih8wwL5qqIzYNIssDktqucOyKAQULxpRI/ie7yQQzFANS//9BbkrO9wHJ2
+      jaF/GKdh08EC6odpiCJkCxRPQk2SLwa5B489G3sXKAlGi+6ML/VB/JvUdZ5ayHKV
+      1qXpdA17RwkYS2eft13UM/jAyphxV40ixCvgVC+laKsyYHRbhBaZg3zXl53zNa9Z
+      k5vXWUfVfKZgLyEtiyImIffBjqYAbXIkjnlOSEjZ5YGjCnoRfUDDhGXvQ2iQ4bYX
+      J96LzCJqnD7HfnbWqUrnjPfgTv0lfHSxh/DNbQGGF5eUJOxJj88h6OkQeVUnyZ73
+      9Jkbyf/0oODiMqrsyoUlQiowhgmizRL7iiw2pwj9JIagqYaX/qNRtEVylzJmpnBs
+      tjVGkYzEisK9OGFMKjeU6qTPRyC0nA1HZNfl6WmXHGq9RDApPqxTiXeCSGIR8BWB
+      1qV0+UkseZw9JjbW4yziHHAFikq3YGiG8PrTlCtXKuesKDN2dEbd5LlbDbBNc1zS
+      XgHUhlAqq7qWTRnloKM1c/MoWwu/SJpRKKIdw8qlb/Ve1fHBYKlRIo1VJM50HsQ5
+      iLY4iQRrcQTG9i3ejeMJ935Pwkzmr7rSSwxJAcGYTFi4EWvf12CizJRS0Vp9560=
+      =cvFj
+      -----END PGP MESSAGE-----
+    fp: 07083D36FD5986B0C99700944E9B358045C1B176
+  - created_at: "2024-05-06T14:13:58Z"
+    enc: |-
+      -----BEGIN PGP MESSAGE-----
+
+      hQIMA8YdB40JfEZzAQ//bsq9MNCHuqXm09l+nbXko/+S5Zl+G5V+3gmgUkBEuy4e
+      Mnnvsq3VrJ4N5toCdRa9mu0gzDnG13ZCn8t9lBBw0KKm/vsMWvQpG8YPHIqq0h0o
+      piZ4L0NIFM/SDd15+NukqD+w8nJZTXCm7lQR/qiyVtbpz/IouCHyHcB/dLjF8ZxC
+      6jos06aHrlOBULXvXOu00iKwP6w48QgvNG3zA0mmQqje0ZSW9nurvOf1/8diP3V/
+      qH69IkYu4oDL8LC9BcM7j9FnfZgZEEhvX4BBFekLuV1FXXRib/D+z89eJtyQ0HuQ
+      t0gwFmjqsNCoMZKgX3DXzWMNzqytBgRYwposhNcZ3X17HkbWT2Zn97BJbZobTL5H
+      xi0rddieI7Gjm8ojNM3pX5RIQ2EB9mSQLIl7erldJv1I2+5esIxGrZQCy/UkZfpb
+      z3NqPUF2JuFSfg1U/I1402MgNqPDGmtLOp2QdO6tLUSIAdocnVvGr+4DcSKs/ySL
+      s4Qxn4dkVvoaj0yy4+a3wcM2bJ99WuKx13MdQD0J7i11lCoYGDt5RZZMSplfABCR
+      ActqWn/VJ4I1OLI4uWopRf2HHiLSfC4Q3EKYqzQ5T8R/wJRBYuhDHM6TQYMuVHgA
+      0OCcGrATya1Roc2XCqrqjEvye0UhYj8kJtE/WUu309wmPEfX+2UsoR9qQXAIaCvS
+      XgEGLijMDXS6M2RLjJKs0omQWqRkeLxfvQpGNj3YlY0RUipeY7cRzQLjN9+0t8qv
+      tFaP4HRmrjC+uHI7tc2tFJiDKFz8qrqOHe8RW6/tHbaGLcu20PjRmO+U+Ok2UCY=
+      =bvvN
+      -----END PGP MESSAGE-----
+    fp: 3582AE9F12CE295BDAF545ED17A5F53F11681446
+  unencrypted_suffix: _unencrypted
+  version: 3.8.1

--- a/src/bridge/secrets/xqwatcher/secrets.qa.yaml
+++ b/src/bridge/secrets/xqwatcher/secrets.qa.yaml
@@ -1,6 +1,11 @@
 ---
 graders_yaml:
   graders:
+  - name: ENC[AES256_GCM,data:tSb1tAESxqE=,iv:mamhQy4CnWK8k0CMUJYQEdO9OsRDT9ZgwKt4VS4p4Lc=,tag:YgfUn41hA8qFjej+dPQdMw==,type:str]
+    address: ENC[AES256_GCM,data:oD8NTl5YOE4S9z7FDt2VJn/pHeB/2B8h5rI22HXjgqx+ABklZtDWyg==,iv:EGRDC2P3cQsuj27zdwvppfdl1f+cRQpscd4Qs10wjP8=,tag:sGHYD8645GwLcBfgFr2+yw==,type:str]
+    git_ref: ENC[AES256_GCM,data:VrCSjxRb,iv:ZiOuUrUU5FZHaM16iE8FgEjh4iX20QgYim/h8yXi7Qg=,tag:SMB9hgvcySbp8F0MOyC5jg==,type:str]
+    env:
+      GIT_SSH_COMMAND: ENC[AES256_GCM,data:LDPg2HHhJXIwB4N6wwS/C2/Cn06fng34eFtZhiTKIuSQfvkOLO3jUxV5Almuv4FOD9pOuXWkjeX+Qz/z1dNc53CrzXtST9i+NYWGNXCgzdPXJk4ur7j2Km+tApqY2pp37fGypq90GutRAUhwjJPuyZqiFDGwBK5sWGviSeWIgDqeER7nD0oOFM+mp3jNp6hB,iv:MOkeUtJaSY4WnuQdU0q+7o6vlCMpiiSy99igPfbf1xg=,tag:AYc2B5rkrEBMCxkYVN4V+g==,type:str]
   - name: ENC[AES256_GCM,data:KaXUqIsxyjGYcOkLVp74o6GN4JhKTr+ROeql,iv:mD4/JQ4k1fwZAx8mU58NO1tMn/Oc1lIfdOb3Qh3ibWM=,tag:/WqP+KPHx7ooRnIQoOwezA==,type:str]
     address: ENC[AES256_GCM,data:TB1LcqYkiClD8FOiWB99otqUFAYmKEAF6VY8tK/ElBoJgt/7SNxHsQ==,iv:T/He3/UbODgrkO4RZyBLD6ZsCLtcmFRnXDVifIcMBS0=,tag:L9qkOKxlNZGNah3XF4c68g==,type:str]
     git_ref: ENC[AES256_GCM,data:VrCSjxRb,iv:ZiOuUrUU5FZHaM16iE8FgEjh4iX20QgYim/h8yXi7Qg=,tag:SMB9hgvcySbp8F0MOyC5jg==,type:str]
@@ -25,7 +30,7 @@ confd_json:
         user: ENC[AES256_GCM,data:IX1SAN1VJTw5,iv:VWKB8Qww97rsowEglBhAs2CMtyJy2JU05j/oJSlSKXo=,tag:WHZ0EwrUcZ/by3Toq813vg==,type:str]
       HANDLER: ENC[AES256_GCM,data:XZTysIiia2Div+6kSzJWW0zFb7cFx0SP/YDh0Y9ZLt2vKaZytzgOAw==,iv:mt9s1hTESSxMhJ3S+PUgLrNLAggB1qgOrlK5/2yUiWY=,tag:tZlbjAJ/q/1yGKU0mZfqoQ==,type:str]
       KWARGS:
-        grader_root: ENC[AES256_GCM,data:Tb7J7byAZXp8TASXkd8+aNlR1EYnQJEqzEzw3FKiIsa3GCLCrxhV0cX1X2oMoWg7HNVu2YN+CdteblNkLig=,iv:5PpsIeA4VQMtD4GDnKo89UkXORxDZ/VgI1ExD1IJg3A=,tag:f9LtFfbTmYTktaeLcJ9A6w==,type:str]
+        grader_root: ENC[AES256_GCM,data:BiHmEDc1mTof9tGtYedwPi507mfhgluwPZFSxUl79gX7GzHacp1uVeD1I096tHqijtu5CsO0hyQ7f8srtfU08M12XYQPJ0ax,iv:SkMuBmSJfbpuQxpk/xB9h/FocFaRTm6Xj6yB3k+b92c=,tag:FZbQWVexumGakpBgrfHh8g==,type:str]
     NAME_OVERRIDE: ENC[AES256_GCM,data:QXoUpKAq0JppJDllDWGyZJcj,iv:C2wOxvTaPFcECYhRJqSuEYdyrk5hCX8jWWA4vqPVAKc=,tag:6e5TQ46DlFntAPQoqsxTug==,type:str]
     SERVER: ENC[AES256_GCM,data:FLhMOkAkg0wwOpDzkGAJs9pwDSGj4GUTlUaQ8mKyxiaQGBiINxjpr0A=,iv:vCPnQUa+Bcpgb5EpWTEyKiPbxLhLQ3+DReqHtaWGgmo=,tag:3YpUkFm3AjoZr8XNmktq0w==,type:str]
   Watcher-MITx-6.0001r:
@@ -57,7 +62,7 @@ confd_json:
         user: ENC[AES256_GCM,data:H0w3pGMTrIWq,iv:FrJkV9mTfA0+TtRiXqPY3GsBHKtZ1WVl4CiNpxD4GxY=,tag:lo/iRP5l4hW8JDn+hWAmRA==,type:str]
       HANDLER: ENC[AES256_GCM,data:H5+hNRyFaCmnGnoY4HKDTXlCnh/A+xcmzpyxj6qJVE6WIiomoVyUrA==,iv:XFv0UYC05LEvpe+/Lzeqi/huP+mdpWGoYCl1PjgILA0=,tag:6uIwL9L433ZgZVF2hAs21Q==,type:str]
       KWARGS:
-        grader_root: ENC[AES256_GCM,data:lwlvWcXWElOuIJ3Kzy02Cw53xinXcsCmygmQEhJ1PTy14WiGGkot9Eg51sZI4HqV3aUqhkIMB/GCH1LpYXM=,iv:dRIaNZCNbzc6gSC5eH3uz8LyuWNAAT4aMAGIPRYjl9g=,tag:wbLorIGABlJyzfkywICi9Q==,type:str]
+        grader_root: ENC[AES256_GCM,data:2BkaBckpvV6Lq5QUC+AoRVjh/9I67oForBhAO4PIcl/C9bcilhXOmv/3CjucDGb+LcUAO2RN6dFOiC6Xn6nQK5oig/phkSa3,iv:2uno7gFhEUUeWVBUuJnt/HNBifgck9ynPYm3kBC2tic=,tag:7bwiwNWCfhGPAmTLQbdM0Q==,type:str]
     NAME_OVERRIDE: ENC[AES256_GCM,data:tHgWQeJhSGvQxGj442Sys3fp,iv:vW9xzmjJJJEi2GkNIaAdcunX7D7PDyR8RskxVL/QhC0=,tag:99sNlqJW6oMss0cXWKu28Q==,type:str]
     SERVER: ENC[AES256_GCM,data:URnsn7MBb9Z8/JGFqcMQ/QGA0TY6B6uTDZc/R+WIyyiXv5e2zsQnAml0skFSfxmJeQ==,iv:vTs87C72Pb6NCmPqIi/lsHIfeVIyxqgDVJGxOyf8/DQ=,tag:x0Tjiifh322kWJLPwxzOGA==,type:str]
   Watcher-MITx-staging-6.0001r:
@@ -76,6 +81,22 @@ confd_json:
         grader_root: ENC[AES256_GCM,data:1BhyZs2Oyy14j2IWnJ6bVofhXT76E49eysEo0/QVEGN+oFVk4HF4/KEAo9M42Skkhy4mp27mb4gXc4E4HUr6VXaoTyCabMOC/rI=,iv:uPJIjHYY1FqQdb8NYHar1x8OAkfm4LVkMv4JkFC3wgk=,tag:clx6b8DnVS6jiGCKwFoVMA==,type:str]
     NAME_OVERRIDE: ENC[AES256_GCM,data:/Of9T3dF3MEpDloP0Yrjhxi98Dw=,iv:9QLqLLE53YLeNC5acNFPLufBEi9rOTWY5sN26AcvC0c=,tag:xQU0/3BIHug5LiXk9kODgw==,type:str]
     SERVER: ENC[AES256_GCM,data:VIQfQGFSQaEXWppXQFv5zovLIXoLk7WYfLvQ66c/oz1DBoO5nRU7o0l2Oa3jnmF3EQ==,iv:DszapcN75MIVvukiimU+A8oQKeRH5PK6L6hxhPfDXug=,tag:YTfvi6QbVVVsF+Df7hA3XA==,type:str]
+  mitx-staging-686xgrader:
+    AUTH:
+    - ENC[AES256_GCM,data:2Zl8vPmSCAy5,iv:Cl8Yk+7XiP4q5F43aeWPhrocsmKzLfFKjbILYy0LZWQ=,tag:6oihqLZ80RYziWGiGP7bfQ==,type:str]
+    - ENC[AES256_GCM,data:AiYc+osV60J4n+AS6MP9/TEmJflcsjkBu5moGJHp+qTiI/fMuPA63g==,iv:30uv3chQQaBWwn+R94COzz+xi1qIE14jkKN8PFNLI08=,tag:uwlPGclB6rNfOAqJH7KXnw==,type:str]
+    CONNECTIONS: ENC[AES256_GCM,data:TQ==,iv:cn6p30ECUeh3QV/iWaAoVDJHMhKRwETYoV4K2ygLU9M=,tag:1ipyHdb51qzLoiDdYeql5g==,type:int]
+    HANDLERS:
+    - CODEJAIL:
+        bin_path: ENC[AES256_GCM,data:lm+qwo1r/Iss2eEybNsuwsvjDZtQ7jbRcCukyKvvDrhhCj6VA0C4f9rxh6VHMXSv7KXZTft98Tc7lA==,iv:j3r4neRgYb1VmE/vHYxf9LxSVg31Dv6t64xf2mB5cNU=,tag:OWyVrAPPRjbdx9IiHp+ZQA==,type:str]
+        lang: ENC[AES256_GCM,data:8lXbMNLx2w==,iv:eOGzXyTMEHDEeplqvmPGaz6HDAPqy5qQuiFgF/SkriA=,tag:CRQFCANwsOpUecuSjura/Q==,type:str]
+        name: ENC[AES256_GCM,data:EmlN/s5JnCc=,iv:KMirAMEZda//L2EZ5/cvYdhcWtVtIjVzUu82og0xw7E=,tag:+sFOEgTkYmeoWyyfGaJbTA==,type:str]
+        user: ENC[AES256_GCM,data:FP27LebeA0L4,iv:wktifxeJgvCXm9G7nrvjLqa3HLFrIz4nOUK1LWMXj4w=,tag:v77IoY6PZ37ir+445+mMHg==,type:str]
+      HANDLER: ENC[AES256_GCM,data:6TOMoOwPQY9WdAKKq3QRjtoLx6H66l8vW3fPWgOzDaI3jOAbNW2yWg==,iv:+dxCn7lzW+LQRXgBqSFZEHDhbwRnpn7HMKlc1RZexeo=,tag:tKUd5yYfVrEDE9u1M31AWg==,type:str]
+      KWARGS:
+        grader_root: ENC[AES256_GCM,data:TEm0Nrkl/f/UqIEEb8Hh1ROShKZT3Le3VU/I9jsHhUbNPuAcunE=,iv:WFOeghb9S8+Z0al3m7GCDz2jsgp6kOI6/AXCLCcfdCo=,tag:FYfRitcC1W9Uzn3YP4+y7g==,type:str]
+    NAME_OVERRIDE: ENC[AES256_GCM,data:I4XudASAQ5g8saWj/O3j,iv:tgKNm0hisixm506UiFowNX9Pq2ZecQy8BzKflUynCPQ=,tag:8psibgnyE/iz23MbGtIxnA==,type:str]
+    SERVER: ENC[AES256_GCM,data:yFmxp1Srpemykt8aQYTlJbtpeJ8TH/VGQnbCjCdadStdKHfO6mZJZrQDSN8KxoF34A==,iv:ZRQ2ciWwAfRPZ+az7PZHLiN8zw9kj9ExdF9jMcI5l/c=,tag:6MOzf/sK5L6ZUpQLt9vrlg==,type:str]
 xqwatcher_grader_code_ssh_identity: ENC[AES256_GCM,data:OKKNzLBwKNJSClei6ONDhENy9nQ1C5EPthf3vGBABtpJwi53pjr9KEHMMshnCKrMFNCLyPH2vXvj595nsWaXkU1EYdF3JHhmfddZyPYRs21lM/x+2H+O9ptoS0w6J7rC93/lmrWsV/qVIq5AWgoUsxWzxF7O35/RarAywRAZeEZ6qylvkpK7+5z3xJk9abTQ9dBminLRZfFALUXS9CCwNy7IkRsJWnL38hSGVLsbq/He4YraaF6+Cvcp657TuXlJd8N74zARbO3LFIQOfl119ibDdY7g1h+/fwbygGJEivgYZQ==,iv:h4qvnCfk3Cp3UhgdHypQbtpTPOAOrmvI4SZxYidj9X0=,tag:eLgJWJM/fVg0H6SbBoBN8A==,type:str]
 sops:
   kms:
@@ -92,8 +113,8 @@ sops:
     created_at: "2024-04-25T18:36:13Z"
     enc: vault:v1:g7mhUqKHlNcwvcj2abywWi5LPantyajOlFaIYJjJSmZNY1EGqBmUNtSKK3kutcgneXo2KpoNffN5uuxI
   age: []
-  lastmodified: "2024-04-29T17:02:21Z"
-  mac: ENC[AES256_GCM,data:dLxTYKxxSRyjEazG+5CDfAkvb3w7cq2XAL2mPi9likTBR7AO/teQunsoD6hhVc0DUAIC0qLFGDq12YxtBuAl9DWOENTU9vEyd3J6oni34XBTDaumBXyZOjHCd6t+8BEkRLlBjrzoh/RR3KXxoZ4bpfFQlf2xwmP+p+wEp09qq+c=,iv:eMp+aCZBxL67wNiibuusRcRaqudKsbI9IhbdJQnP/Pw=,tag:vramBZl/ICQzwlCHIZ1Zbw==,type:str]
+  lastmodified: "2024-05-02T14:54:45Z"
+  mac: ENC[AES256_GCM,data:bXfKcSMMlJyKKgZLg0I5562g1gr3TEReWSgJWJ2M5BTJtWlHEU1ljoxm6fPXEKw/D/Q0IfXVxqvXWSsrZWMGHKbj/IzzbDDvqsmGMPQphKqhHvtKlJ2V2i/wxFoGy7FS82itcM97qe/ELf48AZutrRk/MQ4+FusAvb+s+XMAwV4=,iv:5pCcnZalmXgPhv4NV1nW83W9r49/0FUR3TdrRJgcARI=,tag:52F81c+1s5OLFfIeEimfBA==,type:str]
   pgp:
   - created_at: "2024-04-25T18:36:13Z"
     enc: |-

--- a/src/bridge/secrets/xqwatcher/secrets.qa.yaml
+++ b/src/bridge/secrets/xqwatcher/secrets.qa.yaml
@@ -27,7 +27,7 @@ confd_json:
         bin_path: ENC[AES256_GCM,data:18Iwzd3OM5rDCkagV5lX7gYsj9Exk5hr/6YY+16LSgneDK5/Fwiv238UY8rVWEjVbeFMJAyEKROD1g==,iv:LK2S1XaNPkXw+XnEBexNEhpGleMW2LdZB+QJMqWKzPg=,tag:uR+JHZjluKv5bwi4mV9gGA==,type:str]
         lang: ENC[AES256_GCM,data:o1bp2jETFQ==,iv:pz1WNgFtCLki+o8hyeMYVyei/jmH9CTJpGcwqiS8A9c=,tag:fEHPmnfSx2ZPRODe4gK3AA==,type:str]
         name: ENC[AES256_GCM,data:C14JtLirrlc=,iv:YREgi8mo4PU66sLs3ybYvPLryzMlUMonjEH5kv9EZ98=,tag:aAWcSaJmwE5BRDH1jWmV6Q==,type:str]
-        user: ENC[AES256_GCM,data:IX1SAN1VJTw5,iv:VWKB8Qww97rsowEglBhAs2CMtyJy2JU05j/oJSlSKXo=,tag:WHZ0EwrUcZ/by3Toq813vg==,type:str]
+        user: ENC[AES256_GCM,data:QdgC57w8tA0=,iv:SXbTQS+1MKQ9/+Dg+akBt9DW7E7L0tBw/7AtFxKs9KI=,tag:7w45Paoo/aljI3yiOSOg3Q==,type:str]
       HANDLER: ENC[AES256_GCM,data:XZTysIiia2Div+6kSzJWW0zFb7cFx0SP/YDh0Y9ZLt2vKaZytzgOAw==,iv:mt9s1hTESSxMhJ3S+PUgLrNLAggB1qgOrlK5/2yUiWY=,tag:tZlbjAJ/q/1yGKU0mZfqoQ==,type:str]
       KWARGS:
         grader_root: ENC[AES256_GCM,data:BiHmEDc1mTof9tGtYedwPi507mfhgluwPZFSxUl79gX7GzHacp1uVeD1I096tHqijtu5CsO0hyQ7f8srtfU08M12XYQPJ0ax,iv:SkMuBmSJfbpuQxpk/xB9h/FocFaRTm6Xj6yB3k+b92c=,tag:FZbQWVexumGakpBgrfHh8g==,type:str]
@@ -43,7 +43,7 @@ confd_json:
         bin_path: ENC[AES256_GCM,data:bon91L3gja5a2sUx90GDUaSnijgn+cgDT21uIJ503Xx5MP7H24edv2HpEwISKrtX+PoKOAhGJcTi1g==,iv:HkTEtzz/2nw/7UCfiQq5NyUKy9uSOeiyzDr2x6+oOJQ=,tag:8x5oGml4tWLvdWHDmr0Y7Q==,type:str]
         lang: ENC[AES256_GCM,data:bf8we2WTng==,iv:uC9KkzmA+FLGDFitk09tLv4JugTuwy2oji7UYIvL/IY=,tag:/lwA1eg/DpowvVfLeP94wA==,type:str]
         name: ENC[AES256_GCM,data:WfR5/uHjfxs=,iv:rArs1snYabjZ0tcvoS2GlXmWp0OTjEOqhpgSvDpkNXw=,tag:UFIvXZujOk9Swbz7C0Pcpw==,type:str]
-        user: ENC[AES256_GCM,data:atnu3DnrPkSn,iv:e5mB6KzPohmnrZAIEj+0RU41SFI0adEqu/ATAatJR4s=,tag:4LMVnpa67v1eV9A82SfnZQ==,type:str]
+        user: ENC[AES256_GCM,data:ikEMnkFSZdA=,iv:iltRvvbN908ZhIvwefxfCAWzDBWp+cgdHpUCJEUFYFI=,tag:6JUTZIlcRkqFClnnYgEQOg==,type:str]
       HANDLER: ENC[AES256_GCM,data:RH26Iuu66uafWoluF43xdVkgci/SuSU1po7coLDbJK3zIIMioNzqSw==,iv:L6cxBwFYreErANENdX/5v/ixJ9uAC/LI90/js/OaISc=,tag:L5sBomNWh7h840VMKEdqXQ==,type:str]
       KWARGS:
         grader_root: ENC[AES256_GCM,data:UxnLP8pTKC/lYeyqp4q8demkIz1ZkHnpUImUpFUPvb8qt9U5ctL0jf8oWjDrmT7X6Lc+4oxGMfanPa32W0WWcVuqrL5ZELUgcig=,iv:t5EHNxgRMQYUnJq8RMANJ4gBwEoA/5SYxRE5y6x+U6U=,tag:w9f8wknetVu8PagCLhiZAQ==,type:str]
@@ -59,7 +59,7 @@ confd_json:
         bin_path: ENC[AES256_GCM,data:4APOMzF3XjPYhQR8AEzAvllTBiwMURrNunFy3xNgC3GBOhWKjbHBwiSrKMQqiN1qXoYBKCjUtFVD6w==,iv:z/zsIwOe5Wq9L+YQBKO2RA0LfKQkpT8KT+FpTwQFS2M=,tag:wEF6H/dlK6WXoOSjsroTNA==,type:str]
         lang: ENC[AES256_GCM,data:vdUU5TC9nA==,iv:E4xG0jPRw8Vm59pXRhRY6E9bSEQjcTs4TkXSHEXrxnY=,tag:oZByqrDG8Bl8Yu7Q4ujafg==,type:str]
         name: ENC[AES256_GCM,data:2AyOaZZG86U=,iv:V+xSuPArLWPF4c0UAFJG5HaVKfwTC0ldqteY1HY6Ucw=,tag:kSp1d6ceheioKwUXoyvuCA==,type:str]
-        user: ENC[AES256_GCM,data:H0w3pGMTrIWq,iv:FrJkV9mTfA0+TtRiXqPY3GsBHKtZ1WVl4CiNpxD4GxY=,tag:lo/iRP5l4hW8JDn+hWAmRA==,type:str]
+        user: ENC[AES256_GCM,data:41h1ev8mhqE=,iv:Avd2xJQ3OHmnNWvbEeLPIxNU9vOMqVI3fawob0xfRJY=,tag:6k8OdHp61utVybfUO7R44A==,type:str]
       HANDLER: ENC[AES256_GCM,data:H5+hNRyFaCmnGnoY4HKDTXlCnh/A+xcmzpyxj6qJVE6WIiomoVyUrA==,iv:XFv0UYC05LEvpe+/Lzeqi/huP+mdpWGoYCl1PjgILA0=,tag:6uIwL9L433ZgZVF2hAs21Q==,type:str]
       KWARGS:
         grader_root: ENC[AES256_GCM,data:2BkaBckpvV6Lq5QUC+AoRVjh/9I67oForBhAO4PIcl/C9bcilhXOmv/3CjucDGb+LcUAO2RN6dFOiC6Xn6nQK5oig/phkSa3,iv:2uno7gFhEUUeWVBUuJnt/HNBifgck9ynPYm3kBC2tic=,tag:7bwiwNWCfhGPAmTLQbdM0Q==,type:str]
@@ -75,7 +75,7 @@ confd_json:
         bin_path: ENC[AES256_GCM,data:2TjjrKn+bexHbtLDWjCvJLW+Ero80iraVgwfjk/25b5k9jWE5i1ePOfpBW5Z3ISAHu0C2qOf2fEZ2w==,iv:2u6kS9rE7i0CLqhyqVTdyRN3KI2tBD4fAiNLtxcERQM=,tag:qnwVs3qjWyvIz6gzwkPzbA==,type:str]
         lang: ENC[AES256_GCM,data:HC0EWYti4A==,iv:LEuZvhVjpVtNVpmG4JRp1i/cTvY+JqOPJquN3rMziZY=,tag:Kke9Y7qrlzvFQdCravFTjQ==,type:str]
         name: ENC[AES256_GCM,data:T8Ww/L+hvpY=,iv:y0/kqqgc30sz2r3Ch8KWdJksIchszIW7Sh+1EsAtvDQ=,tag:IzdtALknTd5RO5EqNwJLPg==,type:str]
-        user: ENC[AES256_GCM,data:n4il1NiScKoL,iv:MUoVaLpWkXPXOjsIdtR6I+EgzcfDCK/fI/l18WfJDPw=,tag:jhLEv2SnX3Gc4bz3UmVyow==,type:str]
+        user: ENC[AES256_GCM,data:aX3MtZcMoHY=,iv:SY5FPBVwxQHEsW9r+Ve6BA4P9XKtaHiSuh77aHIfOiU=,tag:HxUahPGqcKQl1q+q0K8LOQ==,type:str]
       HANDLER: ENC[AES256_GCM,data:z+FPpoXI6uwY1C+j7YWo6Rb4jE7jGK245T7EV140yDPLVISho9YbcQ==,iv:i7Y3Ofy7pqykvMiXJlV1g6lerx6M6c/1Gc1pQnf+3yw=,tag:Ne29K/80tiUejK1Sqa0iiA==,type:str]
       KWARGS:
         grader_root: ENC[AES256_GCM,data:1BhyZs2Oyy14j2IWnJ6bVofhXT76E49eysEo0/QVEGN+oFVk4HF4/KEAo9M42Skkhy4mp27mb4gXc4E4HUr6VXaoTyCabMOC/rI=,iv:uPJIjHYY1FqQdb8NYHar1x8OAkfm4LVkMv4JkFC3wgk=,tag:clx6b8DnVS6jiGCKwFoVMA==,type:str]
@@ -91,7 +91,7 @@ confd_json:
         bin_path: ENC[AES256_GCM,data:lm+qwo1r/Iss2eEybNsuwsvjDZtQ7jbRcCukyKvvDrhhCj6VA0C4f9rxh6VHMXSv7KXZTft98Tc7lA==,iv:j3r4neRgYb1VmE/vHYxf9LxSVg31Dv6t64xf2mB5cNU=,tag:OWyVrAPPRjbdx9IiHp+ZQA==,type:str]
         lang: ENC[AES256_GCM,data:8lXbMNLx2w==,iv:eOGzXyTMEHDEeplqvmPGaz6HDAPqy5qQuiFgF/SkriA=,tag:CRQFCANwsOpUecuSjura/Q==,type:str]
         name: ENC[AES256_GCM,data:EmlN/s5JnCc=,iv:KMirAMEZda//L2EZ5/cvYdhcWtVtIjVzUu82og0xw7E=,tag:+sFOEgTkYmeoWyyfGaJbTA==,type:str]
-        user: ENC[AES256_GCM,data:FP27LebeA0L4,iv:wktifxeJgvCXm9G7nrvjLqa3HLFrIz4nOUK1LWMXj4w=,tag:v77IoY6PZ37ir+445+mMHg==,type:str]
+        user: ENC[AES256_GCM,data:Z1G/R9ho7UE=,iv:LXC9uIIItlWMBdiDPxpxRGq2Tzo+N/p85YprqiO7hf4=,tag:MMBMdyXlmRnFqpUCgzIMZQ==,type:str]
       HANDLER: ENC[AES256_GCM,data:6TOMoOwPQY9WdAKKq3QRjtoLx6H66l8vW3fPWgOzDaI3jOAbNW2yWg==,iv:+dxCn7lzW+LQRXgBqSFZEHDhbwRnpn7HMKlc1RZexeo=,tag:tKUd5yYfVrEDE9u1M31AWg==,type:str]
       KWARGS:
         grader_root: ENC[AES256_GCM,data:TEm0Nrkl/f/UqIEEb8Hh1ROShKZT3Le3VU/I9jsHhUbNPuAcunE=,iv:WFOeghb9S8+Z0al3m7GCDz2jsgp6kOI6/AXCLCcfdCo=,tag:FYfRitcC1W9Uzn3YP4+y7g==,type:str]
@@ -113,8 +113,8 @@ sops:
     created_at: "2024-04-25T18:36:13Z"
     enc: vault:v1:g7mhUqKHlNcwvcj2abywWi5LPantyajOlFaIYJjJSmZNY1EGqBmUNtSKK3kutcgneXo2KpoNffN5uuxI
   age: []
-  lastmodified: "2024-05-02T14:54:45Z"
-  mac: ENC[AES256_GCM,data:bXfKcSMMlJyKKgZLg0I5562g1gr3TEReWSgJWJ2M5BTJtWlHEU1ljoxm6fPXEKw/D/Q0IfXVxqvXWSsrZWMGHKbj/IzzbDDvqsmGMPQphKqhHvtKlJ2V2i/wxFoGy7FS82itcM97qe/ELf48AZutrRk/MQ4+FusAvb+s+XMAwV4=,iv:5pCcnZalmXgPhv4NV1nW83W9r49/0FUR3TdrRJgcARI=,tag:52F81c+1s5OLFfIeEimfBA==,type:str]
+  lastmodified: "2024-05-02T18:34:37Z"
+  mac: ENC[AES256_GCM,data:jfAI1GKS8pwo870lyGfX+6DzLBk6JH+yLsRfVoe5iHt6fdoKpt3N2yucGXwgAtThkncWzXVY79h1hUuGYP2dXf7TTacG14fv7l+DNyyaFAvMWbKkEL1iFYLc3FVbijBdwuuuztp5xjyB70FJT9aWUjxkpco1uEs0xlCVu+Dt7oc=,iv:Ex5hi2sjt3g3F1p7FKI8bw1lX46MoDoSEiXxE3POUeE=,tag:IQda+XWRC284MLRVqCA/kQ==,type:str]
   pgp:
   - created_at: "2024-04-25T18:36:13Z"
     enc: |-

--- a/src/bridge/secrets/xqwatcher/secrets.qa.yaml
+++ b/src/bridge/secrets/xqwatcher/secrets.qa.yaml
@@ -1,0 +1,179 @@
+---
+graders_yaml:
+  graders:
+  - name: ENC[AES256_GCM,data:KaXUqIsxyjGYcOkLVp74o6GN4JhKTr+ROeql,iv:mD4/JQ4k1fwZAx8mU58NO1tMn/Oc1lIfdOb3Qh3ibWM=,tag:/WqP+KPHx7ooRnIQoOwezA==,type:str]
+    address: ENC[AES256_GCM,data:TB1LcqYkiClD8FOiWB99otqUFAYmKEAF6VY8tK/ElBoJgt/7SNxHsQ==,iv:T/He3/UbODgrkO4RZyBLD6ZsCLtcmFRnXDVifIcMBS0=,tag:L9qkOKxlNZGNah3XF4c68g==,type:str]
+    git_ref: ENC[AES256_GCM,data:VrCSjxRb,iv:ZiOuUrUU5FZHaM16iE8FgEjh4iX20QgYim/h8yXi7Qg=,tag:SMB9hgvcySbp8F0MOyC5jg==,type:str]
+    env:
+      GIT_SSH_COMMAND: ENC[AES256_GCM,data:LDPg2HHhJXIwB4N6wwS/C2/Cn06fng34eFtZhiTKIuSQfvkOLO3jUxV5Almuv4FOD9pOuXWkjeX+Qz/z1dNc53CrzXtST9i+NYWGNXCgzdPXJk4ur7j2Km+tApqY2pp37fGypq90GutRAUhwjJPuyZqiFDGwBK5sWGviSeWIgDqeER7nD0oOFM+mp3jNp6hB,iv:MOkeUtJaSY4WnuQdU0q+7o6vlCMpiiSy99igPfbf1xg=,tag:AYc2B5rkrEBMCxkYVN4V+g==,type:str]
+  - name: ENC[AES256_GCM,data:Sqd9giVECpubmDGIvsGPdALAqHMrw52bcbg1MHk=,iv:pSBdxUEXYSYFJO3T5tWgpBldzv5cjpCOneXOeIfbS5g=,tag:3bbhm89XV4Hf8MWxr8i/Eg==,type:str]
+    address: ENC[AES256_GCM,data:TB1LcqYkiClD8FOiWB99otqUFAYmKEAF6VY8tK/ElBoJgt/7SNxHsQ==,iv:T/He3/UbODgrkO4RZyBLD6ZsCLtcmFRnXDVifIcMBS0=,tag:L9qkOKxlNZGNah3XF4c68g==,type:str]
+    git_ref: ENC[AES256_GCM,data:VrCSjxRb,iv:ZiOuUrUU5FZHaM16iE8FgEjh4iX20QgYim/h8yXi7Qg=,tag:SMB9hgvcySbp8F0MOyC5jg==,type:str]
+    env:
+      GIT_SSH_COMMAND: ENC[AES256_GCM,data:LDPg2HHhJXIwB4N6wwS/C2/Cn06fng34eFtZhiTKIuSQfvkOLO3jUxV5Almuv4FOD9pOuXWkjeX+Qz/z1dNc53CrzXtST9i+NYWGNXCgzdPXJk4ur7j2Km+tApqY2pp37fGypq90GutRAUhwjJPuyZqiFDGwBK5sWGviSeWIgDqeER7nD0oOFM+mp3jNp6hB,iv:MOkeUtJaSY4WnuQdU0q+7o6vlCMpiiSy99igPfbf1xg=,tag:AYc2B5rkrEBMCxkYVN4V+g==,type:str]
+confd_json:
+  Watcher-MITx-6.00x:
+    AUTH:
+    - ENC[AES256_GCM,data:ajQtwjOmxQy9,iv:r52guR2fdJ88HFjvC5RnWrdILFE+UytfwcAU3uyG2Go=,tag:OBrI3i/q4KPMeIYqalfUYg==,type:str]
+    - ENC[AES256_GCM,data:VAxwDt8ztQ50n8qmLwX35xRJRYAsrhScURMF/R8eUofEyADSvJcbaQ==,iv:xnnG3Q3NEYf2ZljNJmiStZEf+2ZjucFMA939tM8hOoQ=,tag:5chV6zU6Ol8G1krfijv8pQ==,type:str]
+    CONNECTIONS: ENC[AES256_GCM,data:fA==,iv:C7l0LqC3V6Jjmeem9yk/UkaBR2UonHkj9GEs84LVrHw=,tag:Ln5XnjFnctnahk2mVisIkw==,type:int]
+    HANDLERS:
+    - CODEJAIL:
+        bin_path: ENC[AES256_GCM,data:18Iwzd3OM5rDCkagV5lX7gYsj9Exk5hr/6YY+16LSgneDK5/Fwiv238UY8rVWEjVbeFMJAyEKROD1g==,iv:LK2S1XaNPkXw+XnEBexNEhpGleMW2LdZB+QJMqWKzPg=,tag:uR+JHZjluKv5bwi4mV9gGA==,type:str]
+        lang: ENC[AES256_GCM,data:o1bp2jETFQ==,iv:pz1WNgFtCLki+o8hyeMYVyei/jmH9CTJpGcwqiS8A9c=,tag:fEHPmnfSx2ZPRODe4gK3AA==,type:str]
+        name: ENC[AES256_GCM,data:C14JtLirrlc=,iv:YREgi8mo4PU66sLs3ybYvPLryzMlUMonjEH5kv9EZ98=,tag:aAWcSaJmwE5BRDH1jWmV6Q==,type:str]
+        user: ENC[AES256_GCM,data:IX1SAN1VJTw5,iv:VWKB8Qww97rsowEglBhAs2CMtyJy2JU05j/oJSlSKXo=,tag:WHZ0EwrUcZ/by3Toq813vg==,type:str]
+      HANDLER: ENC[AES256_GCM,data:XZTysIiia2Div+6kSzJWW0zFb7cFx0SP/YDh0Y9ZLt2vKaZytzgOAw==,iv:mt9s1hTESSxMhJ3S+PUgLrNLAggB1qgOrlK5/2yUiWY=,tag:tZlbjAJ/q/1yGKU0mZfqoQ==,type:str]
+      KWARGS:
+        grader_root: ENC[AES256_GCM,data:Tb7J7byAZXp8TASXkd8+aNlR1EYnQJEqzEzw3FKiIsa3GCLCrxhV0cX1X2oMoWg7HNVu2YN+CdteblNkLig=,iv:5PpsIeA4VQMtD4GDnKo89UkXORxDZ/VgI1ExD1IJg3A=,tag:f9LtFfbTmYTktaeLcJ9A6w==,type:str]
+    NAME_OVERRIDE: ENC[AES256_GCM,data:QXoUpKAq0JppJDllDWGyZJcj,iv:C2wOxvTaPFcECYhRJqSuEYdyrk5hCX8jWWA4vqPVAKc=,tag:6e5TQ46DlFntAPQoqsxTug==,type:str]
+    SERVER: ENC[AES256_GCM,data:FLhMOkAkg0wwOpDzkGAJs9pwDSGj4GUTlUaQ8mKyxiaQGBiINxjpr0A=,iv:vCPnQUa+Bcpgb5EpWTEyKiPbxLhLQ3+DReqHtaWGgmo=,tag:3YpUkFm3AjoZr8XNmktq0w==,type:str]
+  Watcher-MITx-6.0001r:
+    AUTH:
+    - ENC[AES256_GCM,data:/VRXo6nwZJB2,iv:YoP1MNR+T0XOtJd4qC+WXdpp9+cAQsEwnnJI/YMiyic=,tag:KF3zzOqI8bPuw1Kj07fgnw==,type:str]
+    - ENC[AES256_GCM,data:tt9VSa63zrOhNeCH+WxuSJYVdCHjxkV1JTrzBUy45RJSix0CvStxUg==,iv:OyympEzEmM1d58gyeevMO3xo/TSkyoLKGQ9xYO1tsTI=,tag:F8U/N3LQredQjCcP2EG3hQ==,type:str]
+    CONNECTIONS: ENC[AES256_GCM,data:kQ==,iv:Uq2vyq/X3DdVUQ2GBrI9nR8e4XbCPP/vODfrLIBTVrk=,tag:ikUfZ1WuGKG6JDtM72oMOw==,type:int]
+    HANDLERS:
+    - CODEJAIL:
+        bin_path: ENC[AES256_GCM,data:bon91L3gja5a2sUx90GDUaSnijgn+cgDT21uIJ503Xx5MP7H24edv2HpEwISKrtX+PoKOAhGJcTi1g==,iv:HkTEtzz/2nw/7UCfiQq5NyUKy9uSOeiyzDr2x6+oOJQ=,tag:8x5oGml4tWLvdWHDmr0Y7Q==,type:str]
+        lang: ENC[AES256_GCM,data:bf8we2WTng==,iv:uC9KkzmA+FLGDFitk09tLv4JugTuwy2oji7UYIvL/IY=,tag:/lwA1eg/DpowvVfLeP94wA==,type:str]
+        name: ENC[AES256_GCM,data:WfR5/uHjfxs=,iv:rArs1snYabjZ0tcvoS2GlXmWp0OTjEOqhpgSvDpkNXw=,tag:UFIvXZujOk9Swbz7C0Pcpw==,type:str]
+        user: ENC[AES256_GCM,data:atnu3DnrPkSn,iv:e5mB6KzPohmnrZAIEj+0RU41SFI0adEqu/ATAatJR4s=,tag:4LMVnpa67v1eV9A82SfnZQ==,type:str]
+      HANDLER: ENC[AES256_GCM,data:RH26Iuu66uafWoluF43xdVkgci/SuSU1po7coLDbJK3zIIMioNzqSw==,iv:L6cxBwFYreErANENdX/5v/ixJ9uAC/LI90/js/OaISc=,tag:L5sBomNWh7h840VMKEdqXQ==,type:str]
+      KWARGS:
+        grader_root: ENC[AES256_GCM,data:UxnLP8pTKC/lYeyqp4q8demkIz1ZkHnpUImUpFUPvb8qt9U5ctL0jf8oWjDrmT7X6Lc+4oxGMfanPa32W0WWcVuqrL5ZELUgcig=,iv:t5EHNxgRMQYUnJq8RMANJ4gBwEoA/5SYxRE5y6x+U6U=,tag:w9f8wknetVu8PagCLhiZAQ==,type:str]
+    NAME_OVERRIDE: ENC[AES256_GCM,data:3noCR19Mzjltf2OaZ6TO9sHWXzU=,iv:tmpNOVo5XS+joc4zmWB49C934WtYEp3fhh+a/47/UJ4=,tag:W6s7kRw2WHkgxrc+NESK+g==,type:str]
+    SERVER: ENC[AES256_GCM,data:YrcYqDpGVv1Gw3Cq0lj9vYCeHsI8DTsPKW/1y35EaOQSvVWxG9+KdqM=,iv:bBCvLd/j66ddInSjs2SnuRR5TuZ1xv3tWMOwPWP5IsM=,tag:fJAg+Fxg8AAAFhhLOUpsQw==,type:str]
+  Watcher-MITx-staging-6.00x:
+    AUTH:
+    - ENC[AES256_GCM,data:RooDZn5EBfNo,iv:3nrrZ/ZxKKSUtmFkip+PdCsEFkkwoGSLM+TnV4T3l+k=,tag:j1Giqn10yrTioVmR151sHQ==,type:str]
+    - ENC[AES256_GCM,data:62P4eas8+p1VIx4TYhw426AiMHkjF31zYVssUy+XfHLUphRNFz3G1Q==,iv:kppknuq8Bo0QWqfdDFO4qrL53SG8cEmo0BVbq/DuPE0=,tag:Gd+JhL/Tj95LxgFugVSvQA==,type:str]
+    CONNECTIONS: ENC[AES256_GCM,data:rg==,iv:a6QNGU50SFZGZm0U/DBdsUe256xmG2Eet8dR0dnnypo=,tag:ioUBmwXzuvRemCJDfAky5Q==,type:int]
+    HANDLERS:
+    - CODEJAIL:
+        bin_path: ENC[AES256_GCM,data:4APOMzF3XjPYhQR8AEzAvllTBiwMURrNunFy3xNgC3GBOhWKjbHBwiSrKMQqiN1qXoYBKCjUtFVD6w==,iv:z/zsIwOe5Wq9L+YQBKO2RA0LfKQkpT8KT+FpTwQFS2M=,tag:wEF6H/dlK6WXoOSjsroTNA==,type:str]
+        lang: ENC[AES256_GCM,data:vdUU5TC9nA==,iv:E4xG0jPRw8Vm59pXRhRY6E9bSEQjcTs4TkXSHEXrxnY=,tag:oZByqrDG8Bl8Yu7Q4ujafg==,type:str]
+        name: ENC[AES256_GCM,data:2AyOaZZG86U=,iv:V+xSuPArLWPF4c0UAFJG5HaVKfwTC0ldqteY1HY6Ucw=,tag:kSp1d6ceheioKwUXoyvuCA==,type:str]
+        user: ENC[AES256_GCM,data:H0w3pGMTrIWq,iv:FrJkV9mTfA0+TtRiXqPY3GsBHKtZ1WVl4CiNpxD4GxY=,tag:lo/iRP5l4hW8JDn+hWAmRA==,type:str]
+      HANDLER: ENC[AES256_GCM,data:H5+hNRyFaCmnGnoY4HKDTXlCnh/A+xcmzpyxj6qJVE6WIiomoVyUrA==,iv:XFv0UYC05LEvpe+/Lzeqi/huP+mdpWGoYCl1PjgILA0=,tag:6uIwL9L433ZgZVF2hAs21Q==,type:str]
+      KWARGS:
+        grader_root: ENC[AES256_GCM,data:lwlvWcXWElOuIJ3Kzy02Cw53xinXcsCmygmQEhJ1PTy14WiGGkot9Eg51sZI4HqV3aUqhkIMB/GCH1LpYXM=,iv:dRIaNZCNbzc6gSC5eH3uz8LyuWNAAT4aMAGIPRYjl9g=,tag:wbLorIGABlJyzfkywICi9Q==,type:str]
+    NAME_OVERRIDE: ENC[AES256_GCM,data:tHgWQeJhSGvQxGj442Sys3fp,iv:vW9xzmjJJJEi2GkNIaAdcunX7D7PDyR8RskxVL/QhC0=,tag:99sNlqJW6oMss0cXWKu28Q==,type:str]
+    SERVER: ENC[AES256_GCM,data:URnsn7MBb9Z8/JGFqcMQ/QGA0TY6B6uTDZc/R+WIyyiXv5e2zsQnAml0skFSfxmJeQ==,iv:vTs87C72Pb6NCmPqIi/lsHIfeVIyxqgDVJGxOyf8/DQ=,tag:x0Tjiifh322kWJLPwxzOGA==,type:str]
+  Watcher-MITx-staging-6.0001r:
+    AUTH:
+    - ENC[AES256_GCM,data:vfrhfb3hp8wY,iv:5LvYmSxIgWw0/M/rYcfupmZ8L7aba5+E4lv1h8XXEZk=,tag:Xwx/cPY2Y7ziS18G/WCCEQ==,type:str]
+    - ENC[AES256_GCM,data:iMeeDj/iQyYFR0bBP+uS9I/tnGNs38TLWQktSPXOjq7LL224/3BEDQ==,iv:HOtqMaB/XLV15aKKqcXryKu0EECxtv6Tq3BHw6XtbOU=,tag:pKEzYt0oULWNLTAN2h2IGQ==,type:str]
+    CONNECTIONS: ENC[AES256_GCM,data:aQ==,iv:nIC7i/WPVjs+uUDsO9nzdIqRZazobJakwReipq6ItHs=,tag:3B852wmx8klCDlMIWZlH2A==,type:int]
+    HANDLERS:
+    - CODEJAIL:
+        bin_path: ENC[AES256_GCM,data:2TjjrKn+bexHbtLDWjCvJLW+Ero80iraVgwfjk/25b5k9jWE5i1ePOfpBW5Z3ISAHu0C2qOf2fEZ2w==,iv:2u6kS9rE7i0CLqhyqVTdyRN3KI2tBD4fAiNLtxcERQM=,tag:qnwVs3qjWyvIz6gzwkPzbA==,type:str]
+        lang: ENC[AES256_GCM,data:HC0EWYti4A==,iv:LEuZvhVjpVtNVpmG4JRp1i/cTvY+JqOPJquN3rMziZY=,tag:Kke9Y7qrlzvFQdCravFTjQ==,type:str]
+        name: ENC[AES256_GCM,data:T8Ww/L+hvpY=,iv:y0/kqqgc30sz2r3Ch8KWdJksIchszIW7Sh+1EsAtvDQ=,tag:IzdtALknTd5RO5EqNwJLPg==,type:str]
+        user: ENC[AES256_GCM,data:n4il1NiScKoL,iv:MUoVaLpWkXPXOjsIdtR6I+EgzcfDCK/fI/l18WfJDPw=,tag:jhLEv2SnX3Gc4bz3UmVyow==,type:str]
+      HANDLER: ENC[AES256_GCM,data:z+FPpoXI6uwY1C+j7YWo6Rb4jE7jGK245T7EV140yDPLVISho9YbcQ==,iv:i7Y3Ofy7pqykvMiXJlV1g6lerx6M6c/1Gc1pQnf+3yw=,tag:Ne29K/80tiUejK1Sqa0iiA==,type:str]
+      KWARGS:
+        grader_root: ENC[AES256_GCM,data:1BhyZs2Oyy14j2IWnJ6bVofhXT76E49eysEo0/QVEGN+oFVk4HF4/KEAo9M42Skkhy4mp27mb4gXc4E4HUr6VXaoTyCabMOC/rI=,iv:uPJIjHYY1FqQdb8NYHar1x8OAkfm4LVkMv4JkFC3wgk=,tag:clx6b8DnVS6jiGCKwFoVMA==,type:str]
+    NAME_OVERRIDE: ENC[AES256_GCM,data:/Of9T3dF3MEpDloP0Yrjhxi98Dw=,iv:9QLqLLE53YLeNC5acNFPLufBEi9rOTWY5sN26AcvC0c=,tag:xQU0/3BIHug5LiXk9kODgw==,type:str]
+    SERVER: ENC[AES256_GCM,data:VIQfQGFSQaEXWppXQFv5zovLIXoLk7WYfLvQ66c/oz1DBoO5nRU7o0l2Oa3jnmF3EQ==,iv:DszapcN75MIVvukiimU+A8oQKeRH5PK6L6hxhPfDXug=,tag:YTfvi6QbVVVsF+Df7hA3XA==,type:str]
+xqwatcher_grader_code_ssh_identity: ENC[AES256_GCM,data:OKKNzLBwKNJSClei6ONDhENy9nQ1C5EPthf3vGBABtpJwi53pjr9KEHMMshnCKrMFNCLyPH2vXvj595nsWaXkU1EYdF3JHhmfddZyPYRs21lM/x+2H+O9ptoS0w6J7rC93/lmrWsV/qVIq5AWgoUsxWzxF7O35/RarAywRAZeEZ6qylvkpK7+5z3xJk9abTQ9dBminLRZfFALUXS9CCwNy7IkRsJWnL38hSGVLsbq/He4YraaF6+Cvcp657TuXlJd8N74zARbO3LFIQOfl119ibDdY7g1h+/fwbygGJEivgYZQ==,iv:h4qvnCfk3Cp3UhgdHypQbtpTPOAOrmvI4SZxYidj9X0=,tag:eLgJWJM/fVg0H6SbBoBN8A==,type:str]
+sops:
+  kms:
+  - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-qa
+    created_at: "2024-04-25T18:36:13Z"
+    enc: AQICAHgQW+3bag/cl2fPG3dPdqAPbfcsZuwI7rETXZsx85HRpgFWZ1clLPvtGzXirK3/8c4oAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM9VYKV03n0jFDf5/2AgEQgDsvdg1XS6Pne/8sdwZtkZpVD9Wdcgp1Xx0zLGfYCe7m7HUd6e8eXi/1cUtiDPuSVJoz5vyk5UY9/zC7gg==
+    aws_profile: ""
+  gcp_kms: []
+  azure_kv: []
+  hc_vault:
+  - vault_address: https://vault-qa.odl.mit.edu
+    engine_path: infrastructure
+    key_name: sops
+    created_at: "2024-04-25T18:36:13Z"
+    enc: vault:v1:g7mhUqKHlNcwvcj2abywWi5LPantyajOlFaIYJjJSmZNY1EGqBmUNtSKK3kutcgneXo2KpoNffN5uuxI
+  age: []
+  lastmodified: "2024-04-29T17:02:21Z"
+  mac: ENC[AES256_GCM,data:dLxTYKxxSRyjEazG+5CDfAkvb3w7cq2XAL2mPi9likTBR7AO/teQunsoD6hhVc0DUAIC0qLFGDq12YxtBuAl9DWOENTU9vEyd3J6oni34XBTDaumBXyZOjHCd6t+8BEkRLlBjrzoh/RR3KXxoZ4bpfFQlf2xwmP+p+wEp09qq+c=,iv:eMp+aCZBxL67wNiibuusRcRaqudKsbI9IhbdJQnP/Pw=,tag:vramBZl/ICQzwlCHIZ1Zbw==,type:str]
+  pgp:
+  - created_at: "2024-04-25T18:36:13Z"
+    enc: |-
+      -----BEGIN PGP MESSAGE-----
+
+      hQIMA9YmDGFr0PozAQ/+Ka2DkBaUX6gCkvET1dlsKmsZrrpkXG5vbPSegDVSlzhw
+      sa/wKIS2BNbHPLo3w6cDZZeR1zt6rS34e0pjiA0rwc1Xpkx6QvXRMp0ZngZnIbeO
+      IuEjRoiFrqpVrT0MfnusIY7AA393lOTUI5uhTJB1Vj2hUcsA8D0fTYK40y/g2Ldb
+      ng4Ul6vIFp7yhl+uc+K7N1lNvQOH7d/kwmeDX0UCVrg3Jo47VzOZsUFIHWTvhEcY
+      W7eYEeeyzRW5LGDELJjvlM7++sfN0v0rjx540aj+Ct8RZEQXKe9LPsJH53jMbnXn
+      YHdJtoQ8bTF+ENlsjQ77QMAQOSit+ihirT18JOKMUSzJ1cXv5WaTsptlX1HPipdb
+      ojKmq6mrnLc+hp1I0Cllov+GLV0RWEfaaveqXsXmmF0Z16ibTZUoglfXVSFVx3hF
+      BCao/ZfCI70yaM8nFUGoexdFrBQuqHC0ePdzbk/tJfYDG65YdtW94QJ4DZh+LHXP
+      f5AXX7G/Hv3cHu5idkVvvcTWGvU6hrvXalr+Zo1JgUmOHjRDgR7jd96hhsi6D+FN
+      mLaepTdpSGFHIY2d7KuXgRPoWabfJ6nhaTATDJggNde884w47PlubdjUU4jaKQ+j
+      eP0rZaCVQVpzNVZNLIw9YQYIsrJeCFU468AqBGq1ozCyrMf4cKautPEpW9oRZ2PS
+      XgHGFznDzjiupwXBPbCc6ZvvW60lWOwF7VYkUrXJXyB/6CpPidwosclehXFkFEh+
+      GcUkG/nVS/1FdjZPbag3T4kIvuvyHJYYK1yE0DZxZFnF7WqkBHRDpaG4ZxQYhGo=
+      =3wqN
+      -----END PGP MESSAGE-----
+    fp: dfd1205a98269f34c43c9221d6260c616bd0fa33
+  - created_at: "2024-04-25T18:36:13Z"
+    enc: |-
+      -----BEGIN PGP MESSAGE-----
+
+      hQIMA8MO7RiKjktCARAAzDf20G7xUYXMH6pBQTSQyRkPNtagOglxNIO/lA3/lCqx
+      9iiX6mquF2p0DcrX/tEZ5pNVGrDlU126O2DNPwi+kaH7neoq06uV3u91yBseAffk
+      wGeG/FJCSG2vYmgTlx667vvzCpkqYj1O/AJNrmiOQj9dCw6iDlx7ln3dWMDKTBIC
+      nwOiFBkwC33jPKsE4TED9DNyhGfeSgAIUtWF2mPuV08mHOOGnYp+cYNDH0CnUvOt
+      jS62XPCUGAN+1q9uRmkOkRqlh0VbpmjUqEDOJiSSFvDCqvHC80dQlF6JV7inxXjn
+      TESSsQ33I/C7hXrstASvFts9+K8wiaTf7ODWCs3MDmYDt6XgDLL3sEBgWqD9GsHq
+      6rpcTMqBl0IZDCBWvwQ/45ACNL5yP6YvVHpSufwFc//cpKAhaJOJJJs7tL00VLio
+      eLajxw+HQ4w2XimS68DKcfW5aB2pOaJuV8AQlibz18nPKpoVO+tZ6cPY5bOcVVKv
+      nKESE3aKpKsy4j4jq/Xlj5mT8Jpg4x9AwycSwnfHqaoGzvj6Iyr7V4grhRnuMeFK
+      fArDTqQKWe75H2enLj/bGCnJkwERM3Whr7juJrUEQrQYr9LcWCon7oIDnDUApIDP
+      2KfiEkps1cFuhz70ODhvXnnLsF1g0O683JLT7UWBQzH/Nq+rWqbEwp7ix/Te6TPS
+      UQEfnFtwk+ps4n0MLKmYbHgdBzy9Cubbfqux9CDP/vqI1Tg0HDVwGsdB8VA2ejwV
+      UWSeUNseJmM5rurXLTsLQgvn0UFHjp3B6DLK2dYv4qrp8w==
+      =kABa
+      -----END PGP MESSAGE-----
+    fp: B905F0256A801D3F1D15B5126A1D27A4BE75B1C2
+  - created_at: "2024-04-25T18:36:13Z"
+    enc: |-
+      -----BEGIN PGP MESSAGE-----
+
+      hQIMA53hirIFs7uxAQ/9G5LwkInmII8Fbfx9iuU4jCzx6aVnbt+YfGg/E/gxCmhk
+      vdnuWxc68Fa8x7D+FKZ6pEoD04zL809yTk40mIHFGr6GtF8NzMz+0NV/84wvjZWt
+      v06GhJa9xoPwtNMwGjUDNQM4Ht9kanJ2AehFDLn7nM9CtBbkeAtaJ3rAaZmtMp3I
+      9G5mpekYZueqQVJCWX3lsLkbs1AaQDD1mKr3YIZT2d2bX4QP8WRkYk5/5tUAQmOZ
+      N2n9ZkgUzmsL9I4yO6mEqZKJpHfeVFrXBwmqsuTkDydBHAbjPvZLDvOCuPT1iV42
+      10CU4QDV/e7aXAoJ2aFYch0nxMlQ9/U+fD3FPcfwakiHUkpVNLdmWvJqhSYc0GCL
+      ZONQ3aYC0UdH4y7g0eh3sdlLwGMmzDA3Zyud9E3IE90t2wII8jwwW5fT6VMndFG1
+      jX/89UJ3XZvwQQyGaaSE4F0YzwHSfbTlNWVeXnJaP67yIbJ3m27zzC4qC8e9V1WN
+      CFvqjGH2AQmf1I/tO/uDQlbFWSDHbSFPHP78QkK0ro5VvhIEMPycE8KlOFq9SQ3i
+      FmeaL2tsNzfUEWhoDYPc8MkoePhajNEJ2sjm0BvBJHkJuUY1MoAjRw8mmq/F/pQn
+      l9YZ4K35jneNK4bGxJdVEYsh7vBujRKHoYq3pYKqvb7tGxhEnmhymIOjse9iO2bS
+      XgHPeBmBZtSwJXCFLEjvCMQCiY+abgZE/6f/oNzIEpUZO/e+1tRAvHYtDypNuryQ
+      ixv10MOwUkxDYpb0jrUL7LucX+an3cEbTmcnBNHetq7msq3c4ebF+ZgDM9LOfEE=
+      =6eoY
+      -----END PGP MESSAGE-----
+    fp: 07083D36FD5986B0C99700944E9B358045C1B176
+  - created_at: "2024-04-25T18:36:13Z"
+    enc: |-
+      -----BEGIN PGP MESSAGE-----
+
+      hQIMA8YdB40JfEZzAQ//YeGYvRc+hcj3983BVQgZOeMH2gt7dw3KihhgQWkoeJrM
+      zQagTRa2Xx7yQrR9YKIbaB4eZMu4KyLh1Y1YcJKalSOwnS91hel48BW19TdFLvDY
+      WqMbwa4tfssudWAuzie4yVuFfdU9ci6flp58B5RVwhBOmQyL5ZzFKfX5WUeQiU35
+      U4VaDzy82lUfvEN2fIF0tZfn8enBadiz8MS0SQ0ZD/ywoNZpJrYJYMwb0QbZip/B
+      VHYDBYFc2s9BXNB192/PEQNAFlXj4jVsRpmw4xFv6P6Rt7G6VXUlNOoTdoj2Ro39
+      4hEKvKpXqa/WN0rGGA90SyJmlhtJz0mDJbQY8EW0+3eojtRgFUkeKvvM+DaArWto
+      B534nBOJ9SqNuW8HpfyMOb3Rrq/3gW93tghllb9Aed4s6XxgVLrwcWHWa7tCRTRs
+      ZQx08o/m/LUcXVBtoMbOXAdLe8qgDBa6blc1YcDJu3dTF1kdjtXo/nXgn7Vh5QoK
+      iFMk05eKg1aGX4ebrfNxTllz7pC4k+7ob4PsfxWnKueQZ5quhYQlQI/3TTkjc1fF
+      11z3Kp8ww+HsPhaj5UOkTtaJPFUWRimXBXzpTG44gdO8dGzAqNs9wOEbRpjUl3IT
+      ldXEsRReDHkSPfkd6wi6vTlU6B+D4I+k6JojrQGtaCScKSnmjl6kerqSVsKVVQjS
+      XgHcSYDMJDYltyEwmETD7YXHiTKWYkrOSGT+n5ZjaIrvquGuqSkvjGXD3URuOodT
+      rtU2qkcTwuGu57vm3HN75yD6vyvYwQFjzsOB8SEvid0Jbaykkun5SGzNMk40omU=
+      =Zd7k
+      -----END PGP MESSAGE-----
+    fp: 3582AE9F12CE295BDAF545ED17A5F53F11681446
+  unencrypted_suffix: _unencrypted
+  version: 3.8.1

--- a/src/ol_concourse/pipelines/infrastructure/xqwatcher/packer_pulumi_pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/xqwatcher/packer_pulumi_pipeline.py
@@ -1,0 +1,81 @@
+from ol_concourse.lib.jobs.infrastructure import packer_jobs, pulumi_jobs_chain
+from ol_concourse.lib.models.fragment import PipelineFragment
+from ol_concourse.lib.models.pipeline import GetStep, Identifier, Pipeline
+from ol_concourse.lib.resources import git_repo
+from ol_concourse.pipelines.constants import (
+    PACKER_WATCHED_PATHS,
+    PULUMI_CODE_PATH,
+    PULUMI_WATCHED_PATHS,
+)
+
+xqwatcher_image_code = git_repo(
+    Identifier("ol-infrastructure-packer"),
+    uri="https://github.com/mitodl/ol-infrastructure",
+    paths=[
+        "src/bilder/components/",
+        "src/bilder/images/xqwatcher/",
+        "src/bridge/lib/versions.py",
+        *PACKER_WATCHED_PATHS,
+    ],
+)
+
+xqwatcher_pulumi_code = git_repo(
+    name=Identifier("ol-infrastructure-pulumi"),
+    uri="https://github.com/mitodl/ol-infrastructure",
+    paths=[
+        *PULUMI_WATCHED_PATHS,
+        PULUMI_CODE_PATH.joinpath("applications/xqwatcher/"),
+    ],
+)
+
+xqwatcher_ami_fragment = packer_jobs(
+    dependencies=[],
+    image_code=xqwatcher_image_code,
+    packer_template_path="src/bilder/images/xqwatcher/xqwatcher.pkr.hcl",
+    node_types=["server"],
+    extra_packer_params={"only": ["amazon-ebs.xqwatcher"]},
+)
+
+xqwatcher_pulumi_fragment = pulumi_jobs_chain(
+    xqwatcher_pulumi_code,
+    project_name="ol-infrastructure-xqwatcher-server",
+    stack_names=[
+        f"applications.xqwatcher.{stage}" for stage in ("CI", "QA", "Production")
+    ],
+    project_source_path=PULUMI_CODE_PATH.joinpath("applications/xqwatcher/"),
+    dependencies=[
+        GetStep(
+            get=xqwatcher_ami_fragment.resources[-1].name,
+            trigger=True,
+            passed=[xqwatcher_ami_fragment.jobs[-1].name],
+        )
+    ],
+)
+
+combined_fragment = PipelineFragment(
+    resource_types=xqwatcher_ami_fragment.resource_types
+    + xqwatcher_pulumi_fragment.resource_types,
+    resources=xqwatcher_ami_fragment.resources + xqwatcher_pulumi_fragment.resources,
+    jobs=xqwatcher_ami_fragment.jobs + xqwatcher_pulumi_fragment.jobs,
+)
+
+
+xqwatcher_pipeline = Pipeline(
+    resource_types=combined_fragment.resource_types,
+    resources=[
+        *combined_fragment.resources,
+        xqwatcher_image_code,
+        xqwatcher_pulumi_code,
+    ],
+    jobs=combined_fragment.jobs,
+)
+
+
+if __name__ == "__main__":
+    import sys
+
+    with open("definition.json", "w") as definition:  # noqa: PTH123
+        definition.write(xqwatcher_pipeline.model_dump_json(indent=2))
+    sys.stdout.write(xqwatcher_pipeline.model_dump_json(indent=2))
+    print()  # noqa: T201
+    print("fly -t pr-inf sp -p packer-pulumi-xqwatcher -c definition.json")  # noqa: T201

--- a/src/ol_infrastructure/applications/xqueue/__main__.py
+++ b/src/ol_infrastructure/applications/xqueue/__main__.py
@@ -35,12 +35,13 @@ openedx_version_tag = xqueue_config.get("openedx_version_tag")
 network_stack = StackReference(f"infrastructure.aws.network.{stack_info.name}")
 policy_stack = StackReference("infrastructure.aws.policies")
 dns_stack = StackReference("infrastructure.aws.dns")
+xqwatcher_stack = StackReference(f"applications.xqwatcher.operations.{stack_info.name}")
 consul_stack = StackReference(
     f"infrastructure.consul.{stack_info.env_prefix}.{stack_info.name}"
 )
 
 vault_stack = StackReference(f"infrastructure.vault.operations.{stack_info.name}")
-edxapp = StackReference(
+edxapp_stack = StackReference(
     f"applications.edxapp.{stack_info.env_prefix}.{stack_info.name}"
 )
 
@@ -153,7 +154,10 @@ xqueue_server_security_group = ec2.SecurityGroup(
             protocol="tcp",
             from_port=XQUEUE_SERVICE_PORT,
             to_port=XQUEUE_SERVICE_PORT,
-            security_groups=[edxapp.get_output("edxapp_security_group")],
+            security_groups=[
+                edxapp_stack.get_output("edxapp_security_group"),
+                xqwatcher_stack.get_output("xqwatcher_security_group"),
+            ],
             cidr_blocks=[target_vpc["cidr"]],
             description=(
                 f"Allow traffic to the xqueue server on port {XQUEUE_SERVICE_PORT}"

--- a/src/ol_infrastructure/applications/xqwatcher/Pulumi.applications.xqwatcher.mitx.CI.yaml
+++ b/src/ol_infrastructure/applications/xqwatcher/Pulumi.applications.xqwatcher.mitx.CI.yaml
@@ -1,0 +1,15 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-ci
+encryptedkey: AQICAHjnbqe9AmEW1Js10nySybyuAG7Fb5E9EHUgkmqFDv7PxQEzqA1t1iNXRXJnQ8u5DHxfAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMh4FAQiYMf30gSJMfAgEQgDsNcPRFPO6hWaZb3I3JrbyvU8yR3kit9AUZRENn0NF6IL8GTeo/VKN9kvdXSzN6Z9tXEB6RfvUeuCP+uw==
+config:
+  aws:region: us-east-1
+  consul:address: https://consul-mitx-ci.odl.mit.edu
+  xqwatcher:auto_scale:
+    desired: 1
+    max: 2
+    min: 1
+  xqwatcher:instance_type: t3a.small
+  xqwatcher:business_unit: residential
+  xqwatcher:target_vpc: residential_mitx_vpc
+  vault:address: https://vault-ci.odl.mit.edu
+  vault_server:env_namespace: operations.ci

--- a/src/ol_infrastructure/applications/xqwatcher/Pulumi.applications.xqwatcher.operations.CI.yaml
+++ b/src/ol_infrastructure/applications/xqwatcher/Pulumi.applications.xqwatcher.operations.CI.yaml
@@ -3,13 +3,13 @@ secretsprovider: awskms://alias/infrastructure-secrets-ci
 encryptedkey: AQICAHjnbqe9AmEW1Js10nySybyuAG7Fb5E9EHUgkmqFDv7PxQEzqA1t1iNXRXJnQ8u5DHxfAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMh4FAQiYMf30gSJMfAgEQgDsNcPRFPO6hWaZb3I3JrbyvU8yR3kit9AUZRENn0NF6IL8GTeo/VKN9kvdXSzN6Z9tXEB6RfvUeuCP+uw==
 config:
   aws:region: us-east-1
-  consul:address: https://consul-mitx-ci.odl.mit.edu
+  consul:address: https://consul-operations-ci.odl.mit.edu
   xqwatcher:auto_scale:
     desired: 1
     max: 2
     min: 1
   xqwatcher:instance_type: t3a.small
   xqwatcher:business_unit: residential
-  xqwatcher:target_vpc: residential_mitx_vpc
+  xqwatcher:target_vpc: operations_vpc
   vault:address: https://vault-ci.odl.mit.edu
   vault_server:env_namespace: operations.ci

--- a/src/ol_infrastructure/applications/xqwatcher/Pulumi.applications.xqwatcher.operations.Production.yaml
+++ b/src/ol_infrastructure/applications/xqwatcher/Pulumi.applications.xqwatcher.operations.Production.yaml
@@ -1,0 +1,15 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-production
+encryptedkey: AQICAHjmo6C0sCNz3fdkFlhbu0tdBZxnHmPYSnqtmocvGiuNygHiJv9aOMGV5kKSqPFCi6yPAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMTgVqNgpzU7d/7SDFAgEQgDvdxsHdgrYYLLtaz+88M6rhf2PJGqoM97RmC7b9y+wXtS+l6l19ihayut1T0iFs1ui9UVIcmrkEFph4/Q==
+config:
+  aws:region: us-east-1
+  consul:address: https://consul-operations-production.odl.mit.edu
+  xqwatcher:auto_scale:
+    desired: 1
+    max: 2
+    min: 1
+  xqwatcher:instance_type: t3a.small
+  xqwatcher:business_unit: residential
+  xqwatcher:target_vpc: operations_vpc
+  vault:address: https://vault-production.odl.mit.edu
+  vault_server:env_namespace: operations.production

--- a/src/ol_infrastructure/applications/xqwatcher/Pulumi.applications.xqwatcher.operations.QA.yaml
+++ b/src/ol_infrastructure/applications/xqwatcher/Pulumi.applications.xqwatcher.operations.QA.yaml
@@ -1,0 +1,15 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-qa
+encryptedkey: AQICAHgQW+3bag/cl2fPG3dPdqAPbfcsZuwI7rETXZsx85HRpgH8fGMAtaS8TQEdIDVlSOWTAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMUp4ls6yMxwTlAFkcAgEQgDvypDOhiXE0KKn+rXaWFMSvrM8IqJCVJYtfe+Pve7u+mxl9tkzWPNIiMV8sL79BLvkGpmwhjK60lzSZSg==
+config:
+  aws:region: us-east-1
+  consul:address: https://consul-operations-qa.odl.mit.edu
+  xqwatcher:auto_scale:
+    desired: 1
+    max: 2
+    min: 1
+  xqwatcher:instance_type: t3a.small
+  xqwatcher:business_unit: residential
+  xqwatcher:target_vpc: operations_vpc
+  vault:address: https://vault-qa.odl.mit.edu
+  vault_server:env_namespace: operations.qa

--- a/src/ol_infrastructure/applications/xqwatcher/Pulumi.yaml
+++ b/src/ol_infrastructure/applications/xqwatcher/Pulumi.yaml
@@ -1,0 +1,6 @@
+---
+name: ol-infrastructure-xqwatcher-server
+runtime: python
+description: Manage deployment of a xqwatcher server
+backend:
+  url: s3://mitol-pulumi-state/

--- a/src/ol_infrastructure/applications/xqwatcher/__main__.py
+++ b/src/ol_infrastructure/applications/xqwatcher/__main__.py
@@ -1,5 +1,8 @@
 """Create the resources needed to run a xqwatcher server.  # noqa: D200"""
 
+# Note: This stack has a silent dependency on an peering connection between the VPC
+# that it is installed in and the VPC(s) that contain the xqueue instances.
+
 import base64
 import json
 import textwrap

--- a/src/ol_infrastructure/applications/xqwatcher/__main__.py
+++ b/src/ol_infrastructure/applications/xqwatcher/__main__.py
@@ -159,7 +159,7 @@ vault.kv.SecretV2(
     data_json=json.dumps(vault_secrets),
 )
 
-block_device_mappings = [BlockDeviceMapping()]
+block_device_mappings = [BlockDeviceMapping(volume_size=50)]
 tag_specs = [
     TagSpecification(
         resource_type="instance",

--- a/src/ol_infrastructure/applications/xqwatcher/__main__.py
+++ b/src/ol_infrastructure/applications/xqwatcher/__main__.py
@@ -159,7 +159,7 @@ vault.kv.SecretV2(
     data_json=json.dumps(vault_secrets),
 )
 
-block_device_mappings = [BlockDeviceMapping(volume_size=50)]
+block_device_mappings = [BlockDeviceMapping(volume_size=25)]
 tag_specs = [
     TagSpecification(
         resource_type="instance",

--- a/src/ol_infrastructure/applications/xqwatcher/__main__.py
+++ b/src/ol_infrastructure/applications/xqwatcher/__main__.py
@@ -1,0 +1,250 @@
+"""Create the resources needed to run a xqwatcher server.  # noqa: D200"""
+
+import base64
+import json
+import textwrap
+from pathlib import Path
+
+import pulumi_vault as vault
+import yaml
+from bridge.secrets.sops import read_yaml_secrets
+from pulumi import Config, StackReference, export
+from pulumi_aws import ec2, get_caller_identity, iam
+
+from ol_infrastructure.components.aws.auto_scale_group import (
+    BlockDeviceMapping,
+    OLAutoScaleGroupConfig,
+    OLAutoScaling,
+    OLLaunchTemplateConfig,
+    TagSpecification,
+)
+from ol_infrastructure.lib.aws.ec2_helper import InstanceTypes, default_egress_args
+from ol_infrastructure.lib.consul import get_consul_provider
+from ol_infrastructure.lib.ol_types import AWSBase
+from ol_infrastructure.lib.pulumi_helper import parse_stack
+from ol_infrastructure.lib.vault import setup_vault_provider
+
+##################################
+##    Setup + Config Retrival   ##
+##################################
+
+if Config("vault_server").get("env_namespace"):
+    setup_vault_provider()
+stack_info = parse_stack()
+xqwatcher_config = Config("xqwatcher")
+network_stack = StackReference(f"infrastructure.aws.network.{stack_info.name}")
+policy_stack = StackReference("infrastructure.aws.policies")
+dns_stack = StackReference("infrastructure.aws.dns")
+consul_stack = StackReference(
+    f"infrastructure.consul.{stack_info.env_prefix}.{stack_info.name}"
+)
+
+env_name = f"{stack_info.env_prefix}-{stack_info.env_suffix}"
+
+target_vpc_name = xqwatcher_config.get("target_vpc")
+target_vpc = network_stack.require_output(target_vpc_name)
+vpc_id = target_vpc["id"]
+
+consul_security_groups = consul_stack.require_output("security_groups")
+consul_provider = get_consul_provider(stack_info)
+
+vault_mount_stack = StackReference(
+    f"substructure.vault.static_mounts.operations.{stack_info.name}"
+)
+
+aws_account = get_caller_identity()
+
+aws_config = AWSBase(
+    tags={
+        "OU": xqwatcher_config.get("business_unit"),
+        "Environment": env_name,
+        "Application": "open-edx-xqwatcher",
+        "Owner": "platform-engineering",
+    }
+)
+xqwatcher_server_tag = f"open-edx-xqwatcher-server-{env_name}"
+
+xqwatcher_server_ami = ec2.get_ami(
+    filters=[
+        ec2.GetAmiFilterArgs(name="name", values=["open-edx-xqwatcher-server-*"]),
+        ec2.GetAmiFilterArgs(name="virtualization-type", values=["hvm"]),
+        ec2.GetAmiFilterArgs(name="root-device-type", values=["ebs"]),
+    ],
+    most_recent=True,
+    owners=[aws_account.account_id],
+)
+
+###############################
+##     General Resources     ##
+###############################
+
+# IAM and instance profile
+xqwatcher_server_instance_role = iam.Role(
+    f"xqwatcher-server-instance-role-{env_name}",
+    assume_role_policy=json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": {
+                "Effect": "Allow",
+                "Action": "sts:AssumeRole",
+                "Principal": {"Service": "ec2.amazonaws.com"},
+            },
+        }
+    ),
+    path="/ol-infrastructure/xqwatcher-server/role/",
+    tags=aws_config.tags,
+)
+iam.RolePolicyAttachment(
+    f"xqwatcher-server-describe-instance-role-policy-{env_name}",
+    policy_arn=policy_stack.require_output("iam_policies")["describe_instances"],
+    role=xqwatcher_server_instance_role.name,
+)
+xqwatcher_server_instance_profile = iam.InstanceProfile(
+    f"xqwatcher-server-instance-profile-{env_name}",
+    role=xqwatcher_server_instance_role.name,
+    path="/ol-infrastructure/xqwatcher-server/profile/",
+)
+
+# Vault policy definition
+xqwatcher_server_vault_policy = vault.Policy(
+    "xqwatcher-server-vault-policy",
+    name="xqwatcher-server",
+    policy=Path(__file__).parent.joinpath("xqwatcher_server_policy.hcl").read_text(),
+)
+# Register xqwatcher AMI for Vault AWS auth
+vault.aws.AuthBackendRole(
+    "xqwatcher-server-ami-ec2-vault-auth",
+    backend="aws",
+    auth_type="iam",
+    role="xqwatcher-server",
+    inferred_entity_type="ec2_instance",
+    inferred_aws_region=aws_config.region,
+    bound_iam_instance_profile_arns=[xqwatcher_server_instance_profile.arn],
+    bound_ami_ids=[xqwatcher_server_ami.id],
+    bound_account_ids=[aws_account.account_id],
+    bound_vpc_ids=[vpc_id],
+    token_policies=[xqwatcher_server_vault_policy.name],
+)
+
+##################################
+#     Network Access Control     #
+##################################
+# Create security group
+xqwatcher_server_security_group = ec2.SecurityGroup(
+    f"xqwatcher-server-security-group-{env_name}",
+    name=f"xqwatcher-server-operations-{env_name}",
+    description="Access control for xqwatcher servers",
+    ingress=[],  # no listeners on xqwatcher nodes
+    egress=default_egress_args,
+    vpc_id=vpc_id,
+)
+
+###################################
+#     Web Node EC2 Deployment     #
+###################################
+
+consul_datacenter = consul_stack.require_output("datacenter")
+grafana_credentials = read_yaml_secrets(
+    Path(f"vector/grafana.{stack_info.env_suffix}.yaml")
+)
+
+vault_secrets = read_yaml_secrets(
+    Path(f"xqwatcher/secrets.{stack_info.env_suffix}.yaml")
+)
+xqwatcher_vault_mount_name = vault_mount_stack.require_output("xqwatcher_kv")["path"]
+vault.kv.SecretV2(
+    "xqwatcher-grader-static-secrets",
+    mount=xqwatcher_vault_mount_name,
+    name="grader-config",
+    data_json=json.dumps(vault_secrets),
+)
+
+block_device_mappings = [BlockDeviceMapping()]
+tag_specs = [
+    TagSpecification(
+        resource_type="instance",
+        tags=aws_config.merged_tags({"Name": xqwatcher_server_tag}),
+    ),
+    TagSpecification(
+        resource_type="volume",
+        tags=aws_config.merged_tags({"Name": xqwatcher_server_tag}),
+    ),
+]
+
+lt_config = OLLaunchTemplateConfig(
+    block_device_mappings=block_device_mappings,
+    image_id=xqwatcher_server_ami.id,
+    instance_type=xqwatcher_config.get("instance_type")
+    or InstanceTypes.burstable_small,
+    instance_profile_arn=xqwatcher_server_instance_profile.arn,
+    security_groups=[
+        xqwatcher_server_security_group,
+        consul_security_groups["consul_agent"],
+    ],
+    tags=aws_config.merged_tags({"Name": xqwatcher_server_tag}),
+    tag_specifications=tag_specs,
+    user_data=consul_datacenter.apply(
+        lambda consul_dc: base64.b64encode(
+            "#cloud-config\n{}".format(
+                yaml.dump(
+                    {
+                        "write_files": [
+                            {
+                                "path": "/etc/consul.d/02-autojoin.json",
+                                "content": json.dumps(
+                                    {
+                                        "retry_join": [
+                                            "provider=aws tag_key=consul_env "
+                                            f"tag_value={consul_dc}"
+                                        ],
+                                        "datacenter": consul_dc,
+                                    }
+                                ),
+                                "owner": "consul:consul",
+                            },
+                            {
+                                "path": "/etc/default/vector",
+                                "content": textwrap.dedent(
+                                    f"""\
+                            ENVIRONMENT={consul_dc}
+                            APPLICATION=xqwatcher
+                            VECTOR_CONFIG_DIR=/etc/vector/
+                            VECTOR_STRICT_ENV_VARS=false
+                            AWS_REGION={aws_config.region}
+                            GRAFANA_CLOUD_API_KEY={grafana_credentials['api_key']}
+                            GRAFANA_CLOUD_PROMETHEUS_API_USER={grafana_credentials['prometheus_user_id']}
+                            GRAFANA_CLOUD_LOKI_API_USER={grafana_credentials['loki_user_id']}
+                            """
+                                ),
+                                "owner": "root:root",
+                            },
+                        ]
+                    },
+                    sort_keys=True,
+                )
+            ).encode("utf8")
+        ).decode("utf8")
+    ),
+)
+
+auto_scale_config = xqwatcher_config.get_object("auto_scale") or {
+    "desired": 2,
+    "min": 1,
+    "max": 3,
+}
+asg_config = OLAutoScaleGroupConfig(
+    asg_name=f"xqwatcher-server-{env_name}",
+    aws_config=aws_config,
+    desired_size=auto_scale_config["desired"] or 2,
+    min_size=auto_scale_config["min"] or 1,
+    max_size=auto_scale_config["max"] or 3,
+    vpc_zone_identifiers=target_vpc["subnet_ids"],
+    tags=aws_config.merged_tags({"Name": xqwatcher_server_tag}),
+)
+
+as_setup = OLAutoScaling(
+    asg_config=asg_config,
+    lt_config=lt_config,
+)
+
+export("xqwatcher_security_group", xqwatcher_server_security_group.id)

--- a/src/ol_infrastructure/applications/xqwatcher/xqwatcher_server_policy.hcl
+++ b/src/ol_infrastructure/applications/xqwatcher/xqwatcher_server_policy.hcl
@@ -1,0 +1,7 @@
+path "sys/leases/renew" {
+  capabilities = [ "update" ]
+}
+
+path "secret-xqwatcher/*" {
+  capabilities = [ "read" ]
+}

--- a/src/ol_infrastructure/substructure/vault/static_mounts/__main__.py
+++ b/src/ol_infrastructure/substructure/vault/static_mounts/__main__.py
@@ -29,6 +29,17 @@ celery_monitoring_vault_kv_mount = vault.Mount(
     opts=ResourceOptions(delete_before_replace=True),
 )
 
+xqwatcher_vault_kv_mount = vault.Mount(
+    "xqwatcher-vault-kv-secrets-mount",
+    path="secret-xqwatcher",
+    description=("Static secrets storage for xqwatcher"),
+    type="kv-v2",
+    options={
+        "version": 2,
+    },
+    opts=ResourceOptions(delete_before_replace=True),
+)
+
 export(
     "superset_kv",
     {
@@ -42,5 +53,13 @@ export(
     {
         "path": celery_monitoring_vault_kv_mount.path,
         "type": celery_monitoring_vault_kv_mount.type,
+    },
+)
+
+export(
+    "xqwatcher_kv",
+    {
+        "path": xqwatcher_vault_kv_mount.path,
+        "type": xqwatcher_vault_kv_mount.type,
     },
 )


### PR DESCRIPTION
### What are the relevant tickets?
#2326 

### Description (What does it do?)
This PR implements [xqwatcher](https://github.com/mitodl/xqueue-watcher/tree/master/xqueue_watcher) + [codejail](https://github.com/openedx/codejail) following our standard practices using our PPP stack. This re-implementation completely removes the dependency on the salt-stack from xqwatcher. Additionally, it discontinues use of Ansible for installing xqwatcher. 

Key Elements / Changes:
- `src/bilder/xqwatcer`
  - Packer Config and PyInfra code for building the AMI.
  - Installs a virtual environment for xqwatcher itself
  - Installs logrotate configuration for keep xqwatcher logs under control. 
  - Installs `xqwatcher.json` and `logging.json` configuration files. 
  - Sets up (but does not configure) a new script `fetch_graders.py`. See below. 
  - Consul-templates for the following:
    - SSH key for fetching grader code from github.com / github.mit.edu 
    - `fetch_graders.py` configuration file `fetch_graders.yaml`
    - `conf.d/grader_config.json` configuration file xqwatcher
  - Additional virtual environment + configs for each course grader as needed. 
    - Includes requirements files for all grader venvs. 
    - Sets up a unix user for each grader and fixes permissions. 
    - Sets up an app-armor profile for each grader.
    - Sets up sudoers entries for each grader.
- `src/bridge/secrets/xqwatcher`
  - Contents of the files for the consul-templates outlined above. Templates are simplistic and mostly consist of rendering these secrets directly to the filesystem as-is (converting to JSON or YAML as needed). 
- `src/ol_infrastructure/xqwatcher`
  - Pretty standard Pulumi code for creating an xqwatcher stack in AWS. 
  - xqwatchers are deployed into the `operations-vpc` to facilitate connecting to more than one xqueue stack. Additional, complicated, peerings would be required if xqwatcher is deployed elsewhere. 
  - Populates values out of `src/bridge/secrets/xqwatcher` and into vault for use by consul-template.
  - Exports a security group.
- `src/ol_infrastructure/xqueue`
  - Adds the security group exported by the xqwatcher stacks to the ingress rules for xqueue.  
- Special note about `SERVER` directives in the conf.d config:
  - Because we are deploying into the `operations-vpc`, we need to further qualify the addresses of the various xqueue instances to include the consul-datacenter.
    - Previously: `http://xqueue.service.consul:8040`
    - Going forward: `http://xqueue.service.mitx-staging-qa.consul:8040`  
- `fetch_graders.py` and `fetch_graders.yaml` 
  - This script runs on startup and every hour to pull down an integrate any changes made to the grader code.  
  - The script loads the configuration yaml and clones / fetches as necessary for a given branch of a given repo and installs it into the specified directory inside of `graders`. 
  - `FETCH_GRADERS_README.md` to follow. 


### Additional Items to be done
- [x] ~`FETCH_GRADERS_README.md`~ documented in the script itself.
- [x] Build + deployment pipeline for concourse
- [ ] Non-ephemeral documentation around the `conf.d/grader_config.yaml` setup. 

### Other thoughts
- We can probably remove the graders / other elements that pretain to anything beside mit-600 and mit-686. I couldn't find any active xqwatcher instances in our environment for courses besides these two. That would clean things up a bit and shorted the build time on the AMI (potentially substantially...) 

### How can this be tested?
It is tricky. In mitx-staging-qa I have created two courses, one for 600x and one for 686x that will interact with staging's already deployed xqueue environment and submit problems. From there, you can observe the xqwatcher instance reach out to the xqueue instance, pickup a problem to grade, grade it, and return the result to xqueue, which in turn returns the result to edxapp. 