### PR TITLE
fix: fixed the discussion sidebar issue

### DIFF
--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -4,6 +4,8 @@ from collections import defaultdict
 from itertools import chain, product
 from typing import Optional
 
+from pydantic import BaseModel
+
 from bridge.settings.openedx.accessors import fetch_applications_by_type
 from bridge.settings.openedx.types import (
     EnvStage,
@@ -13,8 +15,6 @@ from bridge.settings.openedx.types import (
     OpenEdxSupportedRelease,
 )
 from bridge.settings.openedx.version_matrix import OpenLearningOpenEdxDeployment
-from pydantic import BaseModel
-
 from ol_concourse.lib.models.fragment import PipelineFragment
 from ol_concourse.lib.models.pipeline import (
     AnonymousResource,
@@ -70,6 +70,7 @@ def mfe_params(
     open_edx: OpenEdxVars, mfe: OpenEdxApplicationVersion
 ) -> dict[str, Optional[str]]:
     learning_mfe_path = OpenEdxMicroFrontend.learn.path
+    discussion_mfe_path = OpenEdxMicroFrontend.discussion.path
     return {
         "ABOUT_US_URL": open_edx.about_us_url,
         "ACCESSIBILITY_URL": open_edx.accessibility_url,
@@ -81,6 +82,7 @@ def mfe_params(
         "CONTACT_URL": open_edx.contact_url,
         "CSRF_TOKEN_API_PATH": "/csrf/api/v1/token",
         "DISPLAY_FEEDBACK_WIDGET": open_edx.display_feedback_widget,
+        "DISCUSSIONS_MFE_BASE_URL": f"https://{open_edx.lms_domain}/{discussion_mfe_path}",
         "FAVICON_URL": open_edx.favicon_url,
         "HONOR_CODE_URL": open_edx.honor_code_url,
         "LANGUAGE_PREFERENCE_COOKIE_NAME": (

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -4,8 +4,6 @@ from collections import defaultdict
 from itertools import chain, product
 from typing import Optional
 
-from pydantic import BaseModel
-
 from bridge.settings.openedx.accessors import fetch_applications_by_type
 from bridge.settings.openedx.types import (
     EnvStage,
@@ -15,6 +13,8 @@ from bridge.settings.openedx.types import (
     OpenEdxSupportedRelease,
 )
 from bridge.settings.openedx.version_matrix import OpenLearningOpenEdxDeployment
+from pydantic import BaseModel
+
 from ol_concourse.lib.models.fragment import PipelineFragment
 from ol_concourse.lib.models.pipeline import (
     AnonymousResource,

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
@@ -12,6 +12,7 @@ config:
     "--staff", "--authenticated"]
   - ["discussions.pages_and_resources_mfe", "--create", "--superusers", "--staff"]
   - ["discussions.enable_discussions_mfe", "--create", "--everyone"]
+  - ["discussions.enable_new_structure_discussions", "--create", "--everyone"]
   - ["grades.bulk_management", "--create", "--superusers", "--everyone", "--staff",
     "--authenticated"]
   - ["grades.enforce_freeze_grade_after_course_end", "--create", "--superusers", "--everyone"]


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4081

### Description (What does it do?)
This PR adds the `discussions.enable_new_structure_discussions` waffle flag in the lms and `DISCUSSIONS_MFE_BASE_URL` in the learning MFE. The waffle flag ensures that all the new courses are created with the new edx provider which along with the `DISCUSSIONS_MFE_BASE_URL` is required to enable the discussion sidebar

### Screenshots (if appropriate):
<img width="1436" alt="Screenshot 2024-04-30 at 8 28 28 PM" src="https://github.com/mitodl/ol-infrastructure/assets/88967643/4dece21b-5c94-405c-9980-5799797d9f83">


### How can this be tested?
- In studio, create a new course.
- In the course, create a unit.
- Publish the unit and click the `View live Version` button which will redirect you to the learning MFE.
- Ensure that the discussion sidebar is displayed on the learning MFE.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
