### PR TITLE
config: Use Atlas for managing translation overrides in learning MFE

### DIFF
--- a/src/bridge/settings/openedx/types.py
+++ b/src/bridge/settings/openedx/types.py
@@ -133,6 +133,7 @@ class OpenEdxApplicationVersion(BaseModel):
     origin_override: Optional[str] = None
     runtime_version_override: Optional[str] = None
     branding_overrides: Optional[dict[str, str]] = None
+    translation_overrides: Optional[list[str]] = None
 
     @property
     def runtime_version(self) -> str:

--- a/src/bridge/settings/openedx/version_matrix.py
+++ b/src/bridge/settings/openedx/version_matrix.py
@@ -355,9 +355,9 @@ ReleaseMap: dict[
                 application="learning",
                 application_type="MFE",
                 release="master",
-                branch_override="open-learning",
-                origin_override="https://github.com/mitodl/frontend-app-learning",
-                branding_overrides=pinned_branding_overrides,
+                translation_overrides=[
+                    "atlas pull -r mitodl/mitxonline-translations -n main translations/frontend-app-learning/src/i18n/messages:src/i18n/messages/",  # noqa: E501
+                ],
             ),
             OpenEdxApplicationVersion(
                 application="library-authoring",

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -135,6 +135,7 @@ def mfe_job(
             for component, override in (mfe.branding_overrides or {}).items()
         )
     )
+    translation_overrides = "\n".join(cmd for cmd in mfe.translation_overrides or [])
     if previous_job and mfe_repo.name == previous_job.plan[0].get:
         clone_git_repo.passed = [previous_job.name]
     mfe_job_definition = Job(
@@ -169,9 +170,11 @@ def mfe_job(
                             textwrap.dedent(
                                 f"""\
                                 apt-get update
-                                apt-get install -q -y python3 python-is-python3 build-essential
+                                apt-get install -q -y python3 python-is-python3 build-essential git
                                 npm install
+                                npm install -g @edx/openedx-atlas
                                 {branding_overrides}
+                                {translation_overrides}
                                 npm install webpack
                                 NODE_ENV=production npm run build
                                 """  # noqa: E501


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/3917

### Description (What does it do?)
<!--- Describe your changes in detail -->
We have been maintaining a fork of the learning MFE for MITx Online to allow for customizing the messaging. This updates the MFE build to use the atlas utility for pulling customized translations during build time to avoid the need to maintain the separate fork.

### How can this be tested?
Run the MFE pipeline with the changes. A build with the changes found here was run at https://cicd.odl.mit.edu/teams/mitxonline/pipelines/mitxonline-master-mfe-pipeline/jobs/compile-and-deploy-mfe-learning-to-mitxonline-qa/builds/62
