### PR TITLE
config,version: Fix master and Quince edxapp node builds

### DIFF
--- a/dockerfiles/openedx-edxapp/Earthfile
+++ b/dockerfiles/openedx-edxapp/Earthfile
@@ -1,5 +1,6 @@
 VERSION 0.7
-FROM python:3.8-bookworm
+ARG PYTHON_VERSION="3.8"
+FROM python:$PYTHON_VERSION"-bookworm"
 
 apt-base:
   ENV DEBIAN_FRONTEND=noninteractive
@@ -42,6 +43,7 @@ install-deps:
   FROM +apt-base
   ARG --required DEPLOYMENT_NAME
   ARG --required RELEASE_NAME
+  ARG NODE_VERSION="16.14.0"
   COPY +get-code/edx-platform /openedx/edx-platform
   RUN cp /openedx/edx-platform/requirements/edx/base.txt /root/pip_package_lists/edx_base.txt
   RUN ls -l /root/pip_package_lists/
@@ -53,7 +55,7 @@ install-deps:
   WORKDIR /openedx/edx-platform
   ENV PATH /root/.local/bin:/openedx/nodeenv/bin:${PATH}
   ENV NPM_REGISTRY "https://registry.npmjs.org/"
-  RUN nodeenv /openedx/nodeenv --node=16.20.2 --prebuilt \
+  RUN nodeenv /openedx/nodeenv --node=$NODE_VERSION --prebuilt \
     && npm clean-install -s --registry=$NPM_REGISTRY
   SAVE ARTIFACT /openedx/edx-platform
   SAVE ARTIFACT /openedx/nodeenv

--- a/src/ol_concourse/pipelines/open_edx/edx_platform_v2/earthly_packer_pulumi_pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/edx_platform_v2/earthly_packer_pulumi_pipeline.py
@@ -175,7 +175,9 @@ def build_edx_pipeline(release_names: list[str]) -> Pipeline:  # noqa: ARG001
                                     DEPLOYMENT_NAME={deployment_name};
                                     EDX_PLATFORM_DIR="../../../{edx_platform_git_resource.name}"
                                     THEME_DIR="../../../{theme_git_resource.name}"
-                                    earthly +all --DEPLOYMENT_NAME="$DEPLOYMENT_NAME" --RELEASE_NAME="$RELEASE_NAME" --EDX_PLATFORM_DIR="$EDX_PLATFORM_DIR" --THEME_DIR="$THEME_DIR";
+                                    PYTHON_VERSION="{edx_platform.runtime_version}"
+                                    NODE_VERSION="{'16.14.0' if release_name == 'quince' else '18.20.2'}"
+                                    earthly +all --DEPLOYMENT_NAME="$DEPLOYMENT_NAME" --RELEASE_NAME="$RELEASE_NAME" --EDX_PLATFORM_DIR="$EDX_PLATFORM_DIR" --THEME_DIR="$THEME_DIR" --PYTHON_VERSION="$PYTHON_VERSION" --NODE_VERSION="$NODE_VERSION"";
                                     DIGEST=$(docker inspect --format '{{{{.Id}}}}' mitodl/edxapp-$DEPLOYMENT_NAME-$RELEASE_NAME | cut -d ":" -f2);
                                     echo "Saving docker image to tar file in the artifacts directory";
                                     docker save -o ../../../artifacts/image.tar $DIGEST;


### PR DESCRIPTION
### What are the relevant tickets?
Addresses failed builds for edx-platform (e.g. https://cicd.odl.mit.edu/teams/infrastructure/pipelines/docker-packer-pulumi-edxapp-global/jobs/build-quince-mitx-edxapp-image/builds/117)

### Description (What does it do?)
<!--- Describe your changes in detail -->
- Allow master branch to run on Python 3.11 and Quince to stay on 3.8
- Allow Node build to use 16.x for Quince and 18.x for master

### How can this be tested?
Run the Earthly build for Quince and Master and verify that they both complete
`earthly +all --DEPLOYMENT_NAME=mitxonline --RELEASE_NAME=master --EDX_PLATFORM_GIT_REPO=https://github.com/openedx/edx-platform --EDX_PLATFORM_GIT_BRANCH=master --THEME_GIT_REPO=https://github.com/mitodl/mitxonline-theme --THEME_GIT_BRANCH=main --OPENEDX_TRANSLATIONS_BRANCH=main --PYTHON_VERSION=3.8 --NODE_VERSION=18.20.2`
`earthly +all --DEPLOYMENT_NAME=xpro --RELEASE_NAME=quince --EDX_PLATFORM_GIT_REPO=https://github.com/openedx/edx-platform --EDX_PLATFORM_GIT_BRANCH=open-release/quince.master --THEME_GIT_REPO=https://github.com/mitodl/mitxpro-theme --THEME_GIT_BRANCH=quince --OPENEDX_TRANSLATIONS_BRANCH=main`