### PR TITLE
Revert "chore(deps): update ubuntu docker tag to v24"

### DIFF
--- a/dockerfiles/openedx-codejail/Dockerfile
+++ b/dockerfiles/openedx-codejail/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:noble
+FROM ubuntu:focal
 SHELL ["/bin/bash", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/dockerfiles/openedx-xqueue/Dockerfile
+++ b/dockerfiles/openedx-xqueue/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:noble
+FROM ubuntu:focal
 
 RUN apt update && \
   apt-get install -y software-properties-common && \


### PR DESCRIPTION
Reverts mitodl/ol-infrastructure#2380

The codejail and xqueue applications have not yet been updated to be compatible with Ubuntu 24