### PR TITLE
Revert "chore(deps): update dependency sentry-sdk to v2"

### DIFF
--- a/dockerfiles/openedx-edxapp/pip_package_lists/master/mitxonline.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/master/mitxonline.txt
@@ -12,7 +12,7 @@ ol-openedx-logging==0.2.0
 ol-openedx-sentry==0.1.2
 openedx-scorm-xblock
 pip==24.0
-sentry-sdk==2.1.1  # Fix RecursionError
+sentry-sdk==1.45.0  # Fix RecursionError
 social-auth-mitxpro==0.6.3
 uwsgi==2.0.25.1
 wheel==0.43.0


### PR DESCRIPTION
Reverts mitodl/ol-infrastructure#2379

Open edX is still exhibiting a behavior that is not compatible with newer versions of Sentry yet.