### PR TITLE
Rds version management

### DIFF
--- a/src/ol_infrastructure/applications/airbyte/__main__.py
+++ b/src/ol_infrastructure/applications/airbyte/__main__.py
@@ -439,6 +439,7 @@ airbyte_db_config = OLPostgresDBConfig(
     subnet_group_name=target_vpc["rds_subnet"],
     security_groups=[airbyte_db_security_group],
     parameter_overrides=[{"name": "rds.force_ssl", "value": 0}],
+    engine_major_version="15",
     tags=aws_config.tags,
     db_name="airbyte",
     **rds_defaults,

--- a/src/ol_infrastructure/applications/bootcamps/__main__.py
+++ b/src/ol_infrastructure/applications/bootcamps/__main__.py
@@ -186,6 +186,7 @@ bootcamps_db_config = OLPostgresDBConfig(
     password=bootcamps_config.require("db_password"),
     subnet_group_name=apps_vpc["rds_subnet"],
     security_groups=[bootcamps_db_security_group],
+    engine_major_version="13",
     tags=aws_config.tags,
     db_name="bootcamps",
     public_access=True,

--- a/src/ol_infrastructure/applications/concourse/__main__.py
+++ b/src/ol_infrastructure/applications/concourse/__main__.py
@@ -389,6 +389,7 @@ concourse_db_config = OLPostgresDBConfig(
     storage=concourse_config.get("db_capacity"),
     subnet_group_name=target_vpc["rds_subnet"],
     security_groups=[concourse_db_security_group],
+    engine_major_version="15",
     tags=aws_config.tags,
     db_name="concourse",
     **rds_defaults,

--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -321,6 +321,7 @@ dagster_db_config = OLPostgresDBConfig(
     password=get_config("dagster:db_password"),
     subnet_group_name=data_vpc["rds_subnet"],
     security_groups=[dagster_db_security_group],
+    engine_major_version="15",
     tags=aws_config.tags,
     db_name="dagster",
     **rds_defaults,

--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -544,6 +544,7 @@ edxapp_db_config = OLMariaDBConfig(
     password=edxapp_config.require("db_password"),
     subnet_group_name=edxapp_vpc["rds_subnet"],
     security_groups=[edxapp_db_security_group],
+    engine_major_version="10",
     tags=aws_config.tags,
     db_name="edxapp",
     storage=edxapp_config.get_int("db_storage_gb") or 50,

--- a/src/ol_infrastructure/applications/keycloak/__main__.py
+++ b/src/ol_infrastructure/applications/keycloak/__main__.py
@@ -195,6 +195,7 @@ keycloak_db_config = OLPostgresDBConfig(
     or str(AWS_RDS_DEFAULT_DATABASE_CAPACITY),
     subnet_group_name=target_vpc["rds_subnet"],
     security_groups=[keycloak_database_security_group],
+    engine_major_version="15",
     db_name="keycloak",
     tags=aws_config.tags,
     **rds_defaults,

--- a/src/ol_infrastructure/applications/micromasters/__main__.py
+++ b/src/ol_infrastructure/applications/micromasters/__main__.py
@@ -147,7 +147,7 @@ micromasters_db_config = OLPostgresDBConfig(
     security_groups=[micromasters_db_security_group],
     tags=aws_config.tags,
     db_name="micromasters",
-    engine_version="13.13",
+    engine_major_version="13",
     public_access=True,
     **defaults(stack_info)["rds"],
 )

--- a/src/ol_infrastructure/applications/mitopen/__main__.py
+++ b/src/ol_infrastructure/applications/mitopen/__main__.py
@@ -235,6 +235,7 @@ mitopen_db_config = OLPostgresDBConfig(
     password=rds_password,
     subnet_group_name=apps_vpc["rds_subnet"],
     security_groups=[mitopen_db_security_group],
+    engine_major_version="15",
     tags=aws_config.tags,
     db_name="mitopen",
     public_access=True,

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -160,6 +160,7 @@ mitxonline_db_config = OLPostgresDBConfig(
     password=mitxonline_config.require("db_password"),
     subnet_group_name=mitxonline_vpc["rds_subnet"],
     security_groups=[mitxonline_db_security_group],
+    engine_major_version="12",
     tags=aws_config.tags,
     db_name="mitxonline",
     public_access=True,

--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -286,6 +286,7 @@ ocw_studio_db_config = OLPostgresDBConfig(
     password=ocw_studio_config.require("db_password"),
     subnet_group_name=apps_vpc["rds_subnet"],
     security_groups=[ocw_studio_db_security_group],
+    engine_major_version="12",
     tags=aws_config.tags,
     db_name="ocw_studio",
     public_access=True,

--- a/src/ol_infrastructure/applications/odl_video_service/__main__.py
+++ b/src/ol_infrastructure/applications/odl_video_service/__main__.py
@@ -383,6 +383,7 @@ ovs_db_config = OLPostgresDBConfig(
     storage=ovs_config.get("db_capacity") or str(AWS_RDS_DEFAULT_DATABASE_CAPACITY),
     subnet_group_name=target_vpc["rds_subnet"],
     security_groups=[ovs_database_security_group],
+    engine_major_version="12",
     parameter_overrides=[],
     db_name="odlvideo",
     tags=aws_config.tags,

--- a/src/ol_infrastructure/applications/redash/__main__.py
+++ b/src/ol_infrastructure/applications/redash/__main__.py
@@ -190,6 +190,7 @@ redash_db_config = OLPostgresDBConfig(
     password=redash_config.require("db_password"),
     subnet_group_name=data_vpc["rds_subnet"],
     security_groups=[redash_db_security_group],
+    engine_major_version="13",
     tags=aws_config.tags,
     db_name="redash",
     **defaults(stack_info)["rds"],

--- a/src/ol_infrastructure/applications/semantic/__main__.py
+++ b/src/ol_infrastructure/applications/semantic/__main__.py
@@ -139,6 +139,7 @@ semantic_db_config = OLPostgresDBConfig(
     security_groups=[semantic_database_security_group],
     storage=semantic_config.get("db_capacity")
     or str(AWS_RDS_DEFAULT_DATABASE_CAPACITY),
+    engine_major_version="15",
     tags=aws_config.tags,
     db_name="semantic",
     **defaults(stack_info)["rds"],

--- a/src/ol_infrastructure/applications/superset/__main__.py
+++ b/src/ol_infrastructure/applications/superset/__main__.py
@@ -335,6 +335,7 @@ superset_db_config = OLPostgresDBConfig(
     password=superset_config.require("db_password"),
     subnet_group_name=data_vpc["rds_subnet"],
     security_groups=[superset_db_security_group],
+    engine_major_version="15",
     tags=aws_config.tags,
     db_name="superset",
     **defaults(stack_info)["rds"],

--- a/src/ol_infrastructure/applications/xpro/__main__.py
+++ b/src/ol_infrastructure/applications/xpro/__main__.py
@@ -180,6 +180,7 @@ xpro_db_config = OLPostgresDBConfig(
     password=xpro_config.require("db_password"),
     subnet_group_name=apps_vpc["rds_subnet"],
     security_groups=[xpro_db_security_group],
+    engine_major_version="15",
     tags=aws_config.tags,
     db_name="xpro",
     public_access=True,

--- a/src/ol_infrastructure/components/aws/database.py
+++ b/src/ol_infrastructure/components/aws/database.py
@@ -64,7 +64,7 @@ class OLDBConfig(AWSBase):
 
     engine: str
     engine_full_version: Optional[str] = None
-    engine_major_version: Optional[str] = None
+    engine_major_version: Optional[str | int] = None
     instance_name: str  # The name of the RDS instance
     password: SecretStr
     parameter_overrides: list[dict[str, Union[str, bool, int, float]]]
@@ -148,7 +148,7 @@ class OLPostgresDBConfig(OLDBConfig):
     """Configuration container to specify settings specific to Postgres."""
 
     engine: str = "postgres"
-    engine_major_version: str = "15"
+    engine_major_version: str | int = "15"
     port: PositiveInt = PositiveInt(5432)
     parameter_overrides: list[dict[str, Union[str, bool, int, float]]] = [  # noqa: RUF012
         {"name": "client_encoding", "value": "UTF-8"},
@@ -162,7 +162,7 @@ class OLMariaDBConfig(OLDBConfig):
     """Configuration container to specify settings specific to MariaDB."""
 
     engine: str = "mariadb"
-    engine_major_version: str = "10"
+    engine_major_version: str | int = "10"
     port: PositiveInt = PositiveInt(3306)
     parameter_overrides: list[dict[str, Union[str, bool, int, float]]] = [  # noqa: RUF012
         {"name": "character_set_client", "value": "utf8mb4"},
@@ -222,7 +222,7 @@ class OLAmazonDB(pulumi.ComponentResource):
         self.db_instance = rds.Instance(
             f"{db_config.instance_name}-{db_config.engine}-instance",
             allocated_storage=db_config.storage,
-            allow_major_version_upgrades=True,
+            allow_major_version_upgrade=True,
             backup_retention_period=db_config.backup_days,
             copy_tags_to_snapshot=True,
             db_name=db_config.db_name,

--- a/src/ol_infrastructure/components/aws/database.py
+++ b/src/ol_infrastructure/components/aws/database.py
@@ -148,7 +148,7 @@ class OLPostgresDBConfig(OLDBConfig):
     """Configuration container to specify settings specific to Postgres."""
 
     engine: str = "postgres"
-    engine_major_version: str | int = "15"
+    engine_major_version: str | int = "16"
     port: PositiveInt = PositiveInt(5432)
     parameter_overrides: list[dict[str, Union[str, bool, int, float]]] = [  # noqa: RUF012
         {"name": "client_encoding", "value": "UTF-8"},
@@ -162,7 +162,7 @@ class OLMariaDBConfig(OLDBConfig):
     """Configuration container to specify settings specific to MariaDB."""
 
     engine: str = "mariadb"
-    engine_major_version: str | int = "10"
+    engine_major_version: str | int = "11"
     port: PositiveInt = PositiveInt(3306)
     parameter_overrides: list[dict[str, Union[str, bool, int, float]]] = [  # noqa: RUF012
         {"name": "character_set_client", "value": "utf8mb4"},

--- a/src/ol_infrastructure/components/aws/database.py
+++ b/src/ol_infrastructure/components/aws/database.py
@@ -20,9 +20,10 @@ from pydantic import (
     ConfigDict,
     PositiveInt,
     SecretStr,
-    ValidationInfo,
+    computed_field,
     conint,
     field_validator,
+    model_validator,
 )
 
 from ol_infrastructure.components.aws.cloudwatch import (
@@ -32,6 +33,7 @@ from ol_infrastructure.components.aws.cloudwatch import (
 from ol_infrastructure.lib.aws.rds_helper import (
     DBInstanceTypes,
     db_engines,
+    max_minor_version,
     parameter_group_family,
 )
 from ol_infrastructure.lib.ol_types import AWSBase
@@ -61,7 +63,8 @@ class OLDBConfig(AWSBase):
     """Configuration object for defining the interface to create an RDS instance with sane defaults."""  # noqa: E501
 
     engine: str
-    engine_version: str
+    engine_full_version: Optional[str] = None
+    engine_major_version: Optional[str] = None
     instance_name: str  # The name of the RDS instance
     password: SecretStr
     parameter_overrides: list[dict[str, Union[str, bool, int, float]]]
@@ -92,10 +95,29 @@ class OLDBConfig(AWSBase):
             raise ValueError(msg)
         return engine
 
-    @field_validator("engine_version")
-    @classmethod
-    def is_valid_version(cls, engine_version: str, info: ValidationInfo) -> str:
-        engine = info.data["engine"]
+    @model_validator(mode="after")
+    def engine_version_is_set(self):
+        if all((self.engine_full_version, self.engine_major_version)):
+            msg = (
+                "Only one of 'engine_full_version' and 'engine_major-version' can "
+                "be set at the same time. Please set one or the other depending on "
+                "your preferred behavior."
+            )
+            raise ValueError(msg)
+        if self.engine_full_version is None and self.engine_major_version is None:
+            msg = (
+                "You must specify either the major version or the full version of the "
+                "database engine."
+            )
+            raise ValueError(msg)
+        return self
+
+    # @field_validator("engine_version")
+    # @classmethod
+    def is_valid_version(
+        self, engine_version: str
+    ) -> str:  # , info: ValidationInfo) -> str:
+        engine = self.engine
         engines_map = db_engines()
         if engine_version not in engines_map.get(engine, []):
             msg = (
@@ -113,12 +135,20 @@ class OLDBConfig(AWSBase):
             raise ValueError(msg)
         return monitoring_profile_name
 
+    @computed_field  # type: ignore[misc]
+    @property
+    def engine_version(self) -> str:
+        return self.is_valid_version(
+            self.engine_full_version
+            or max_minor_version(self.engine, self.engine_major_version)
+        )
+
 
 class OLPostgresDBConfig(OLDBConfig):
     """Configuration container to specify settings specific to Postgres."""
 
     engine: str = "postgres"
-    engine_version: str = "15.6"
+    engine_major_version: str = "15"
     port: PositiveInt = PositiveInt(5432)
     parameter_overrides: list[dict[str, Union[str, bool, int, float]]] = [  # noqa: RUF012
         {"name": "client_encoding", "value": "UTF-8"},
@@ -132,7 +162,7 @@ class OLMariaDBConfig(OLDBConfig):
     """Configuration container to specify settings specific to MariaDB."""
 
     engine: str = "mariadb"
-    engine_version: str = "10.6.12"
+    engine_major_version: str = "10"
     port: PositiveInt = PositiveInt(3306)
     parameter_overrides: list[dict[str, Union[str, bool, int, float]]] = [  # noqa: RUF012
         {"name": "character_set_client", "value": "utf8mb4"},
@@ -192,7 +222,7 @@ class OLAmazonDB(pulumi.ComponentResource):
         self.db_instance = rds.Instance(
             f"{db_config.instance_name}-{db_config.engine}-instance",
             allocated_storage=db_config.storage,
-            auto_minor_version_upgrade=True,
+            allow_major_version_upgrades=True,
             backup_retention_period=db_config.backup_days,
             copy_tags_to_snapshot=True,
             db_name=db_config.db_name,
@@ -207,9 +237,7 @@ class OLAmazonDB(pulumi.ComponentResource):
             instance_class=db_config.instance_size,
             max_allocated_storage=db_config.max_storage,
             multi_az=db_config.multi_az,
-            opts=resource_options.merge(
-                pulumi.ResourceOptions(ignore_changes=["engine_version"])
-            ),
+            opts=resource_options,
             parameter_group_name=self.parameter_group.name,
             password=db_config.password.get_secret_value(),
             port=db_config.port,

--- a/src/ol_infrastructure/lib/aws/rds_helper.py
+++ b/src/ol_infrastructure/lib/aws/rds_helper.py
@@ -54,7 +54,7 @@ def max_minor_version(engine: str, major_version: int | str) -> str:
     for version in versions:
         major, minor_and_patch = version.split(".", maxsplit=1)
         major_versions[major].append(minor_and_patch)
-    highest_minor = sorted(major_versions[str(major_version)])[-1]
+    highest_minor = sorted(major_versions[str(major_version)], key=float)[-1]
     return f"{major_version}.{highest_minor}"
 
 


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Change the behavior of the RDS component resource to allow managing the major version of the database and automatically update the minor version as the stack gets executed. The previous behavior was to set the version at initial creation time and allow for minor version upgrades, but then whenever setting he version to a new value in the code it would be ignored. This allows us to more explicitly and clearly manage the database version without requiring us to manage the minutiae of patch releases.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run the `pulumi up` command on the affected projects/stacks and verify that the major version of the databsae is not slated to change but that the patch version will be set to the newest available.
