### PR TITLE
issue 2343 - grafana health issues 

### DIFF
--- a/src/bilder/components/vector/templates/host_metrics.yaml
+++ b/src/bilder/components/vector/templates/host_metrics.yaml
@@ -43,6 +43,11 @@ transforms:
     source: |
       # Remove the 'host' label because it is just a duplicate of 'instance'
       del(.tags.host)
+      # Concourse creates lots of mount points for the same filesystem underneath
+      abort_name_match, err = match_any(mountpoint, [r'^\/var\/concourse\/worker\/volumes\/.*$'])
+      if abort_name_match {
+        abort
+      }
 
   add_labels_to_host_metrics:
     type: remap

--- a/src/bilder/images/consul/templates/vector/consul_metrics.yaml
+++ b/src/bilder/images/consul/templates/vector/consul_metrics.yaml
@@ -14,7 +14,7 @@ transforms:
     - 'collect_consul_metrics'
     source: |
       ## Any metrics that match these prefixes or names will be dropped entirely
-      abort_name_match, err = match_any(.name, [r'^consul_raft_replication_heartbeat_.*', r'^consul_raft_replication_appendEntries_rpc_.*', r'^consul_raft_replication_appendEntries_logs_.*', r'^consul_raft_replication_installSnapshot_.*'])
+      abort_name_match, err = match_any(.name, [r'^consul_raft_replication_heartbeat_.*', r'^consul_raft_replication_appendEntries_rpc_.*', r'^consul_raft_replication_appendEntries_logs_.*', r'^consul_raft_replication_installSnapshot_.*', r'^consul_api_http$', r'^consul_api_http_count$', r'^consul_api_http_sum$'])
       if abort_name_match {
         abort
       }


### PR DESCRIPTION
Slight modifications to our host metric collection and consul metric collection to keep our cardinality in check.

Remove sprawling concourse mountpoint metrics. 
Remove three different consul metrics that are not very useful and generate lots of series. 