### PR TITLE
config,defaults: Set RDS changes to apply immediately

### DIFF
--- a/src/ol_infrastructure/components/aws/database.py
+++ b/src/ol_infrastructure/components/aws/database.py
@@ -221,6 +221,7 @@ class OLAmazonDB(pulumi.ComponentResource):
             f"{db_config.instance_name}-{db_config.engine}-instance",
             allocated_storage=db_config.storage,
             allow_major_version_upgrade=True,
+            apply_immediately=True,
             backup_retention_period=db_config.backup_days,
             copy_tags_to_snapshot=True,
             db_name=db_config.db_name,


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
By default major changes to an RDS instance such as version upgrades are placed into a queue for the next maintenance window. Unfortunately, this breaks the behavior of our component resource because of our use of custom parameter groups. By setting the `apply_immediately` parameter to `True`, those version changes succeed.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
First, try applying a version upgrade to a DB without this change. For instance, change the `major_version` in the Dagster project from `13` to `14` and apply to the QA stack. It will error out. Then apply this change and run again and it will succeed.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
The purpose of using the maintenance window approach is to try to schedule changes to off-peak hours. Unfortunately, that also means that if anything goes wrong then we will get paged in off-peak hours. By applying changes immediately it means that we are watching the system at the time of the change so that we can more rapidly take action as necessary and we are more aware of what and when things are changing.