### PR TITLE
Feat: Enable OpenEdX Redwood for mitx/staging in CI

### DIFF
--- a/src/bridge/settings/openedx/types.py
+++ b/src/bridge/settings/openedx/types.py
@@ -89,6 +89,7 @@ class OpenEdxSupportedRelease(str, Enum):
 
     master = ("master", "master")
     quince = ("quince", "open-release/quince.master")
+    redwood = ("redwood", "open-release/redwood.master")
 
     def __str__(self):
         return self.value

--- a/src/bridge/settings/openedx/version_matrix.py
+++ b/src/bridge/settings/openedx/version_matrix.py
@@ -169,19 +169,19 @@ ReleaseMap: dict[
                 application="communications",
                 application_type="MFE",
                 release="redwood",
-                branding_overrides=pinned_branding_overrides,
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="course-authoring",
                 application_type="MFE",
                 release="redwood",
-                branding_overrides=pinned_branding_overrides,
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="discussions",
                 application_type="MFE",
                 release="redwood",
-                branding_overrides=pinned_branding_overrides,
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="edx-platform",

--- a/src/bridge/settings/openedx/version_matrix.py
+++ b/src/bridge/settings/openedx/version_matrix.py
@@ -13,7 +13,7 @@ class OpenLearningOpenEdxDeployment(Enum):
     mitx = DeploymentEnvRelease(
         deployment_name="mitx",
         env_release_map=[
-            EnvRelease("CI", OpenEdxSupportedRelease["quince"]),
+            EnvRelease("CI", OpenEdxSupportedRelease["redwood"]),
             EnvRelease("QA", OpenEdxSupportedRelease["quince"]),
             EnvRelease("Production", OpenEdxSupportedRelease["quince"]),
         ],
@@ -21,7 +21,7 @@ class OpenLearningOpenEdxDeployment(Enum):
     mitx_staging = DeploymentEnvRelease(
         deployment_name="mitx-staging",
         env_release_map=[
-            EnvRelease("CI", OpenEdxSupportedRelease["quince"]),
+            EnvRelease("CI", OpenEdxSupportedRelease["redwood"]),
             EnvRelease("QA", OpenEdxSupportedRelease["quince"]),
             EnvRelease("Production", OpenEdxSupportedRelease["quince"]),
         ],
@@ -80,6 +80,174 @@ ReleaseMap: dict[
     OpenEdxSupportedRelease,
     dict[OpenEdxDeploymentName, list[OpenEdxApplicationVersion]],
 ] = {
+    "redwood": {
+        "mitx": [
+            OpenEdxApplicationVersion(
+                application="communications",
+                application_type="MFE",
+                release="redwood",
+                branding_overrides=pinned_branding_overrides,
+            ),
+            OpenEdxApplicationVersion(
+                application="course-authoring",
+                application_type="MFE",
+                release="redwood",
+                branding_overrides=pinned_branding_overrides,
+            ),
+            OpenEdxApplicationVersion(
+                application="discussions",
+                application_type="MFE",
+                release="redwood",
+                branding_overrides=pinned_branding_overrides,
+            ),
+            OpenEdxApplicationVersion(
+                application="edx-platform",
+                application_type="IDA",
+                release="redwood",
+                branch_override="mitx/redwood",
+                origin_override="https://github.com/mitodl/edx-platform",
+            ),
+            OpenEdxApplicationVersion(
+                application="edxapp_theme",
+                application_type="IDA",
+                release="redwood",
+                branch_override="redwood",
+                origin_override="https://github.com/mitodl/mitx-theme",
+            ),
+            OpenEdxApplicationVersion(
+                application="forum",
+                application_type="IDA",
+                release="redwood",
+            ),
+            OpenEdxApplicationVersion(
+                application="gradebook",
+                application_type="MFE",
+                release="redwood",
+                branding_overrides=pinned_branding_overrides,
+            ),
+            OpenEdxApplicationVersion(
+                application="learner-dashboard",
+                application_type="MFE",
+                release="redwood",
+                branding_overrides={
+                    "@edx/brand@npm": "@mitodl/brand-mitol-residential@latest",
+                    **pinned_branding_overrides,
+                },
+            ),
+            OpenEdxApplicationVersion(
+                application="learning",
+                application_type="MFE",
+                release="redwood",
+                branding_overrides=pinned_branding_overrides,
+            ),
+            OpenEdxApplicationVersion(
+                application="library-authoring",
+                application_type="MFE",
+                release="redwood",
+                branch_override="master",
+                branding_overrides=default_branding_overrides,
+            ),
+            OpenEdxApplicationVersion(
+                application="notes-api",
+                application_type="IDA",
+                release="redwood",
+            ),
+            OpenEdxApplicationVersion(
+                application="ora-grading",
+                application_type="MFE",
+                release="redwood",
+                branding_overrides=pinned_branding_overrides,
+            ),
+            OpenEdxApplicationVersion(
+                application="xqueue",
+                application_type="IDA",
+                release="redwood",
+            ),
+        ],
+        "mitx-staging": [
+            OpenEdxApplicationVersion(
+                application="communications",
+                application_type="MFE",
+                release="redwood",
+                branding_overrides=pinned_branding_overrides,
+            ),
+            OpenEdxApplicationVersion(
+                application="course-authoring",
+                application_type="MFE",
+                release="redwood",
+                branding_overrides=pinned_branding_overrides,
+            ),
+            OpenEdxApplicationVersion(
+                application="discussions",
+                application_type="MFE",
+                release="redwood",
+                branding_overrides=pinned_branding_overrides,
+            ),
+            OpenEdxApplicationVersion(
+                application="edx-platform",
+                application_type="IDA",
+                release="redwood",
+                branch_override="mitx/redwood",
+                origin_override="https://github.com/mitodl/edx-platform",
+            ),
+            OpenEdxApplicationVersion(
+                application="edxapp_theme",
+                application_type="IDA",
+                release="redwood",
+                branch_override="redwood",
+                origin_override="https://github.com/mitodl/mitx-theme",
+            ),
+            OpenEdxApplicationVersion(
+                application="forum",
+                application_type="IDA",
+                release="redwood",
+            ),
+            OpenEdxApplicationVersion(
+                application="gradebook",
+                application_type="MFE",
+                release="redwood",
+                branding_overrides=pinned_branding_overrides,
+            ),
+            OpenEdxApplicationVersion(
+                application="learning",
+                application_type="MFE",
+                release="redwood",
+                branding_overrides=pinned_branding_overrides,
+            ),
+            OpenEdxApplicationVersion(
+                application="learner-dashboard",
+                application_type="MFE",
+                release="redwood",
+                branding_overrides={
+                    "@edx/brand@npm": "@mitodl/brand-mitol-residential@latest",
+                    **pinned_branding_overrides,
+                },
+            ),
+            OpenEdxApplicationVersion(
+                application="library-authoring",
+                application_type="MFE",
+                release="redwood",
+                branch_override="master",
+                branding_overrides=pinned_branding_overrides,
+            ),
+            OpenEdxApplicationVersion(
+                application="notes-api",
+                application_type="IDA",
+                release="redwood",
+            ),
+            OpenEdxApplicationVersion(
+                application="ora-grading",
+                application_type="MFE",
+                release="redwood",
+                branding_overrides=pinned_branding_overrides,
+            ),
+            OpenEdxApplicationVersion(
+                application="xqueue",
+                application_type="IDA",
+                release="redwood",
+            ),
+        ],
+    },
     "quince": {
         "mitx": [
             OpenEdxApplicationVersion(

--- a/src/bridge/settings/openedx/version_matrix.py
+++ b/src/bridge/settings/openedx/version_matrix.py
@@ -86,19 +86,19 @@ ReleaseMap: dict[
                 application="communications",
                 application_type="MFE",
                 release="redwood",
-                branding_overrides=pinned_branding_overrides,
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="course-authoring",
                 application_type="MFE",
                 release="redwood",
-                branding_overrides=pinned_branding_overrides,
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="discussions",
                 application_type="MFE",
                 release="redwood",
-                branding_overrides=pinned_branding_overrides,
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="edx-platform",
@@ -123,7 +123,7 @@ ReleaseMap: dict[
                 application="gradebook",
                 application_type="MFE",
                 release="redwood",
-                branding_overrides=pinned_branding_overrides,
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="learner-dashboard",
@@ -131,14 +131,14 @@ ReleaseMap: dict[
                 release="redwood",
                 branding_overrides={
                     "@edx/brand@npm": "@mitodl/brand-mitol-residential@latest",
-                    **pinned_branding_overrides,
+                    **default_branding_overrides,
                 },
             ),
             OpenEdxApplicationVersion(
                 application="learning",
                 application_type="MFE",
                 release="redwood",
-                branding_overrides=pinned_branding_overrides,
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="library-authoring",
@@ -156,7 +156,7 @@ ReleaseMap: dict[
                 application="ora-grading",
                 application_type="MFE",
                 release="redwood",
-                branding_overrides=pinned_branding_overrides,
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="xqueue",
@@ -206,13 +206,13 @@ ReleaseMap: dict[
                 application="gradebook",
                 application_type="MFE",
                 release="redwood",
-                branding_overrides=pinned_branding_overrides,
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="learning",
                 application_type="MFE",
                 release="redwood",
-                branding_overrides=pinned_branding_overrides,
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="learner-dashboard",
@@ -220,7 +220,7 @@ ReleaseMap: dict[
                 release="redwood",
                 branding_overrides={
                     "@edx/brand@npm": "@mitodl/brand-mitol-residential@latest",
-                    **pinned_branding_overrides,
+                    **default_branding_overrides,
                 },
             ),
             OpenEdxApplicationVersion(
@@ -239,7 +239,7 @@ ReleaseMap: dict[
                 application="ora-grading",
                 application_type="MFE",
                 release="redwood",
-                branding_overrides=pinned_branding_overrides,
+                branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
                 application="xqueue",


### PR DESCRIPTION
### Description (What does it do?)
Sets mitx/staging up for redwood in CI.

### How can this be tested?
Watch the edx-platform-global pipeline.