### PR TITLE
Md/issue 2326 permfix

### DIFF
--- a/src/bilder/images/xqwatcher/deploy.py
+++ b/src/bilder/images/xqwatcher/deploy.py
@@ -293,6 +293,7 @@ for grader_venv in grader_venvs:
         present=True,
         shell="/bin/false",  # noqa: S604
         user=grader_venv,
+        groups=[XQWATCHER_USER],
     )
     server.shell(
         name=f"Install grader {grader_venv} : Create virtual environment",

--- a/src/bilder/images/xqwatcher/deploy.py
+++ b/src/bilder/images/xqwatcher/deploy.py
@@ -281,6 +281,16 @@ files.put(
     mode="0644",
 )
 
+files.template(
+    name="Install xqwatcher-pkill sudoer entry",
+    src=str(TEMPLATES_DIRECTORY.joinpath("98-xqwatcher-pkill.j2")),
+    dest="/etc/sudoers.d/98-xqwatcher-pkill",
+    user="root",
+    group="root",
+    mode="0600",
+    shared_context=shared_template_context,
+)
+
 grader_venvs = ["mit-600x", "mit-686x-mooc", "mit-686x", "mit-6S082", "mit-940"]
 for grader_venv in grader_venvs:
     GRADER_VENV_DIR = XQWATCHER_GRADERS_VENVS_DIR.joinpath(grader_venv)
@@ -323,6 +333,7 @@ for grader_venv in grader_venvs:
         user="root",
         group="root",
         mode="0600",
+        shared_context=shared_template_context,
         grader_context={
             "GRADER_VENV_DIR": str(GRADER_VENV_DIR),
             "GRADER_USER": grader_venv,

--- a/src/bilder/images/xqwatcher/templates/98-xqwatcher-pkill.j2
+++ b/src/bilder/images/xqwatcher/templates/98-xqwatcher-pkill.j2
@@ -1,0 +1,1 @@
+{{ shared_context.XQWATCHER_USER }} ALL=(ALL) NOPASSWD:/usr/bin/pkill

--- a/src/bilder/images/xqwatcher/templates/99-xqwatcher-grader.j2
+++ b/src/bilder/images/xqwatcher/templates/99-xqwatcher-grader.j2
@@ -1,4 +1,2 @@
-xqwatcher ALL=({{ grader_context.GRADER_USER }}) SETENV:NOPASSWD:{{ grader_context.GRADER_VENV_DIR }}/bin/python
-xqwatcher ALL=({{ grader_context.GRADER_USER }}) NOPASSWD:/usr/bin/find
-xqwatcher ALL=({{ grader_context.GRADER_USER }}) NOPASSWD:/bin/kill
-xqwatcher ALL=({{ grader_context.GRADER_USER }}) NOPASSWD:/usr/bin/pkill
+{{ shared_context.XQWATCHER_USER }} ALL=({{ grader_context.GRADER_USER }}) SETENV:NOPASSWD:{{ grader_context.GRADER_VENV_DIR }}/bin/python
+{{ shared_context.XQWATCHER_USER }} ALL=({{ grader_context.GRADER_USER }}) NOPASSWD:/usr/bin/find

--- a/src/bridge/secrets/xqwatcher/secrets.production.yaml
+++ b/src/bridge/secrets/xqwatcher/secrets.production.yaml
@@ -3,14 +3,14 @@ graders_yaml:
   graders:
   - name: ENC[AES256_GCM,data:CJEFoJq2E2Q=,iv:/svfF2BhTRufD4HUY4/e3U4C1uoZg93i59mdkd0NTqg=,tag:gpeMihlWF3szCMlFnhtk+w==,type:str]
     address: ENC[AES256_GCM,data:GnVPPRFinmGb/CdTHNitpfqXShU3mgghcFmDoY2QqZGTaI8Tm75z6A==,iv:U2MmVWQjrflNpLKMGb5+DgnL2bk99M0DpSu/7APpjsU=,tag:jCZs5mMBrYqOs9nyU7wxcg==,type:str]
-    git_ref: ENC[AES256_GCM,data:ApikKUP4,iv:pzXBymJP1SigUEr8NlZ+AxKwIR9U1slQ9sEn4o+irvA=,tag:TMBO7ieC6UbwrslPO7Yykw==,type:str]
+    git_ref: ENC[AES256_GCM,data:RNxgY5Rv,iv:hILWee8Dj5/C5YBWQh8v1icKpIgZcZSS3ZeqEuFeZns=,tag:IWM2eydyNjS0GV5f1MEg/Q==,type:str]
     env:
-      GIT_SSH_COMMAND: ENC[AES256_GCM,data:o4Oa350wI2XBVH22Pjjfxz00Z7lReVKzZyMR6GMLk4tygT37uFF5IERkgVixcr79g9eh/LGual5qsYd56eOYEZ5CFszqH+Mv/J1itdq4mUtqwWQQJffRLpnLFBTrVVWVU4aNNVZqVh6ryaMQ5O2/buXF40nNoMt/53hIsaId+bPpk6n5eUcY1wTM+gnXtVXS,iv:dk5jIq0UampOECWDF8DjFQZl9zY4qlIaAKU2FZR6G/Y=,tag:LDj5kZjp1W/4+PaXkxiXrg==,type:str]
+      GIT_SSH_COMMAND: ENC[AES256_GCM,data:VXlhmOm/sq6i2Po2lbqOY0NIiie40yLuMqe8VrfIlUgVUk5zlFOY1pa0BkMZGzVDP8nT2BwaM8zyeqSnOtdkX4moi5lQYP86FuD1wkZiPx4APgIY0pgiJMuvSparZKw/D/uIu8kPxXeUsCAdde/7gN9Nxe99FOz+mOQEYIpG66Zjyj7l0XpqrAcza3fBwMDn,iv:Li4i2qmdGqBeCsTd2zsoccS4wZ4yFize4zm4TfRHr+Y=,tag:fqt6NvzloFvLuEZ8AdFo8g==,type:str]
   - name: ENC[AES256_GCM,data:DLt8PlQaX2MIN/DLIuhKNzpEhhFf7Zl47/Ws,iv:ncr/JZy2IZWTd3yfgDPuNK3RwdL3jfnoRNc9dnt8KNM=,tag:NRs3ypuFIZVHbTVqjdbAjw==,type:str]
-    address: ENC[AES256_GCM,data:IwoxMAM45HLHeVdtu/0HfEVdLbTttmy8OkRfvOjaO1INL1Km75kAHg==,iv:aXl8B/JKnXBYrf6qQ6X+43xv4/bwZebS1axX4bX8OaQ=,tag:vTb5ZPDe+7RMDvGauNxDWw==,type:str]
-    git_ref: ENC[AES256_GCM,data:5s/Hz4YY,iv:xJr+WClo9O3V7+4zsKf1YM/6PGfmwj/AWR6CdPOjLss=,tag:fPkwOXQcR19H8WcUXYTHGw==,type:str]
+    address: ENC[AES256_GCM,data:NeN+2es1ka14Ei0V61sL0KjJ2wHLJF3779YPOHptvPM+XBCRwFF/+g==,iv:X19Kq3GJlGhi3Ph4xOUKx0Kh3peTm/nJOQHryfb5bo0=,tag:U9D6iZsjK3K02Ry5I9+WKw==,type:str]
+    git_ref: ENC[AES256_GCM,data:RNxgY5Rv,iv:hILWee8Dj5/C5YBWQh8v1icKpIgZcZSS3ZeqEuFeZns=,tag:IWM2eydyNjS0GV5f1MEg/Q==,type:str]
     env:
-      GIT_SSH_COMMAND: ENC[AES256_GCM,data:jcdCzn0idn+hOOoX6ZvLX0OYyzM1W/36geNdAcgmTJL80UiD9DRDQLQ57g2WNnOiXmsuStPv0D48qsNJhQms/iLnjkP5T0HirF4ApGFR4uELA2l3SueOsfjyKx4KIwJ5d8qsFGCGy8icbi/SBOlGAUGuoWg6K7wpnrSZ0MKRHIYLofy2i54Vuk1UAL5WzTZs,iv:4CpOr79vAtdrkfWCMH9IuYclHRX2sjWpYzyWL6VNNN0=,tag:IaN8MFq9Qe0Vl9mL3BaxEg==,type:str]
+      GIT_SSH_COMMAND: ENC[AES256_GCM,data:VXlhmOm/sq6i2Po2lbqOY0NIiie40yLuMqe8VrfIlUgVUk5zlFOY1pa0BkMZGzVDP8nT2BwaM8zyeqSnOtdkX4moi5lQYP86FuD1wkZiPx4APgIY0pgiJMuvSparZKw/D/uIu8kPxXeUsCAdde/7gN9Nxe99FOz+mOQEYIpG66Zjyj7l0XpqrAcza3fBwMDn,iv:Li4i2qmdGqBeCsTd2zsoccS4wZ4yFize4zm4TfRHr+Y=,tag:fqt6NvzloFvLuEZ8AdFo8g==,type:str]
   - name: ENC[AES256_GCM,data:uG8/tj5RahV+YfHXPKGOf/d/ijB8iZyyi+ciD2A=,iv:IcynShcGc0jqRjgDNq5OsmiBFC5GhEzmz6cV6r6Z4wQ=,tag:qDE12piJpNsqMUBkRiZjvg==,type:str]
     address: ENC[AES256_GCM,data:NeN+2es1ka14Ei0V61sL0KjJ2wHLJF3779YPOHptvPM+XBCRwFF/+g==,iv:X19Kq3GJlGhi3Ph4xOUKx0Kh3peTm/nJOQHryfb5bo0=,tag:U9D6iZsjK3K02Ry5I9+WKw==,type:str]
     git_ref: ENC[AES256_GCM,data:RNxgY5Rv,iv:hILWee8Dj5/C5YBWQh8v1icKpIgZcZSS3ZeqEuFeZns=,tag:IWM2eydyNjS0GV5f1MEg/Q==,type:str]
@@ -28,6 +28,12 @@ confd_json:
         lang: ENC[AES256_GCM,data:T8nWkWbg7Q==,iv:cfV2eBK9alL48tDT2eXFPHsx7z0kPgRPFwZsNRLEOq0=,tag:zYLfveg9PaSHVapPEwAC2w==,type:str]
         name: ENC[AES256_GCM,data:YKNRxeZSZTw=,iv:3FzVRqpcQOlLt5Lsr8be6D5Q6LmVv/5VYgm5MiESD+4=,tag:Vj55NfUy58dwAN0IWVpSkQ==,type:str]
         user: ENC[AES256_GCM,data:RFx3kcRGlGI=,iv:CyJ2sk8tzM5MM3GIh4zMEHguUU1WOF3r8W+kw6medQo=,tag:5/1DdCER6wQBtFEPtMOiqw==,type:str]
+        limits:
+          CPU: ENC[AES256_GCM,data:UA==,iv:tjJTzi+wV8M7P9HrqN/p4fBYmRuENIH9FI742JG2l0g=,tag:LyLbUtKl2rqn+Ji1ciFzvA==,type:int]
+          FSIZE: ENC[AES256_GCM,data:xzdJdKoFSw==,iv:30+5Hp/LPZ6BHhlkiE0aZy3Kg8+0i8SdiTRaEWcOx28=,tag:qAMJN3lMdEilg31NSzYPpA==,type:int]
+          NPROC: ENC[AES256_GCM,data:2tc=,iv:JXPaBqp52/Mv5Y/uROrx2+vOzlFTucRyxqcs/FSZdlw=,tag:YRxRjuEP6xvFlrpJfawr7w==,type:int]
+          PROXY: ENC[AES256_GCM,data:QA==,iv:Q5oQboMlse1WSC1cpeS8RKQTDN9fV8DSlZ3JBaQSZEs=,tag:Ph+owGe7a7sc94ZBz0YepQ==,type:int]
+          REALTIME: ENC[AES256_GCM,data:GQ==,iv:2MAjQjsWOSF4xF1/IrrBIxYoHQLAkCg0Cf5xCLMfo1w=,tag:JJgNb+Vt2nRxXc6Vrc4VLA==,type:int]
       HANDLER: ENC[AES256_GCM,data:leuG3bGgdHRhcwjwoZx9cKzo2FTskdGu7JT4+yHXFbuGCf9UPs22Rg==,iv:nYr2peXxYI/6plQ/CvFXnYsEwnvzF5aXD1L0FdXzX94=,tag:oIsTZdWXH8kZkMYx+fk+5g==,type:str]
       KWARGS:
         grader_root: ENC[AES256_GCM,data:JpRjAZrkwpoj6GHTRtCbdJNTyA37GDCo/l2bzuWqqg/tubMLUhbjmKjRzp1BnNbeKH+iXYbnBikcaTiJCYdnjxYwv4KWT2Br,iv:ztgPo3v7intXIJyq0QZ3k0sOLuJcxZS2lPTjIJHxOdI=,tag:e7tt0boBPdXNSMZnWE3+8g==,type:str]
@@ -44,6 +50,12 @@ confd_json:
         lang: ENC[AES256_GCM,data:su6CH0xdQA==,iv:AyJPUpYkgT/jwNc4M5IjPfc6NRrspNRAY/1pnk0x6Sg=,tag:h1LFHMsa8CCVzD9MnmzPKA==,type:str]
         name: ENC[AES256_GCM,data:M1IwXSNp5sk=,iv:i/VuR7CkpKNPFMUKED58Ebt9rn5HLeVdP2UK0spzmFs=,tag:OxqTWj72n2j3DD1+sxyuSg==,type:str]
         user: ENC[AES256_GCM,data:tfl7wW27RQg=,iv:risY5SPcEGKR3yl5Zz8VtWc4x2gU9UxX2koV3R3SYSM=,tag:lNwdxbo1Ueuflxs5v4opfA==,type:str]
+        limits:
+          CPU: ENC[AES256_GCM,data:VQ==,iv:axNkKbgBSRdAabWhZ0KJ9M5JyLao5rRSXjkj6MHZtA0=,tag:nb1oXM8dGgpC6NGhUWNT7Q==,type:int]
+          FSIZE: ENC[AES256_GCM,data:kTcK4+tOTg==,iv:vvzlgmBOHGa9YrikCN0jSQpMHUUFpAG7j+8Yv6NkWXg=,tag:PzOZ7HzOX8kIaIlRuL9y7Q==,type:int]
+          NPROC: ENC[AES256_GCM,data:Jaw=,iv:y4hnBWu9Fjf/CuoqWGovS5cWVsrfftkPUh/AWxcA3E0=,tag:fusAvqhLHtbRiK8lpqTEzw==,type:int]
+          PROXY: ENC[AES256_GCM,data:iw==,iv:44Qch23HFMbVw7N0wslQZI3srfVaFJCFxD3mmnzZZi8=,tag:J1Rys3t99yBy3/t24yME7A==,type:int]
+          REALTIME: ENC[AES256_GCM,data:hA==,iv:h0PQCzdZdzZKvlGZm2tfofimIpeOfzZLm6gIXGrRSzQ=,tag:vgUlbaxd1SOKI30eNZuRMQ==,type:int]
       HANDLER: ENC[AES256_GCM,data:0NpvGG3WLq2yjo4t4hYdHfJ1b5lrKEFCbI7Wb3TPNNQGA9MRRIAuSg==,iv:lMxsIZEmYbnVNWvrxgsnhT3mFKmQxzDGljwYGyohncI=,tag:u8ScAqVgSpS4goxd7kyPSQ==,type:str]
       KWARGS:
         grader_root: ENC[AES256_GCM,data:Y6QBmRh2iItVlQLIUbDE9JKFzRDv4CNzh/DE/Q/t6pjvdRmmcGNoY/6TkALfyeiAZK2I4cyB3wGIqUfTwfcMTuWlD3TEctymBo0=,iv:sgX+hJP3MQDFkNUY4Oasvr2RbDHJ5cmwNZHByOEPouc=,tag:8SqKPdMchP2QMz1mC4v/Gg==,type:str]
@@ -60,6 +72,12 @@ confd_json:
         lang: ENC[AES256_GCM,data:9oPPNrcFSQ==,iv:6J0wmts5muxoLpBMSaCfsdmHGL/xkCN4Zhl+fj4Is44=,tag:pBRrAZUgmn2ACBGGrbpkug==,type:str]
         name: ENC[AES256_GCM,data:SwD0Vsr1F/4=,iv:zVrS8u8XAfnDjbhZsq1+v33BUwCP257CgCPvQv2jsvE=,tag:HMxkVCRfLqXdlZs4RLB/tg==,type:str]
         user: ENC[AES256_GCM,data:WaVfAUvf268=,iv:P8+lV91CXklkyXiNwC7Iv0vpAVIbi5Hp9CCht0do5BU=,tag:SZUdO5vPS1l92XWsJ3Sshw==,type:str]
+        limits:
+          CPU: ENC[AES256_GCM,data:gg==,iv:8caEIPy/FxLOCKTWewAsQ4VRJPaFjLgfbXG183pfFQw=,tag:iwW0mf68tSiyUUKEnGQAYA==,type:int]
+          FSIZE: ENC[AES256_GCM,data:qONe0zKY5g==,iv:i8YcbM1H3z544EGZMTRModClOIurMcP8MZ4cGgAByTw=,tag:Kz76Z4U/yCRXdSFo6SeP/g==,type:int]
+          NPROC: ENC[AES256_GCM,data:hHE=,iv:T4Hm4pEt6VC6qDyYipNWHehQIc0bGRFcpqs1oaKUhwg=,tag:MMjF4AB0a5Xa8PYoTVCY6A==,type:int]
+          PROXY: ENC[AES256_GCM,data:1w==,iv:nU8cKl2VMu+3jZV/2hiM6v/uDnk7b22IM4UUlUP09gU=,tag:Bo8TphPfbWetBLIeK1l8Qg==,type:int]
+          REALTIME: ENC[AES256_GCM,data:Zw==,iv:3iK6BjrxyQdKrzrQ9lR7sgNN+tXbHIdoTpdZD8qp2d0=,tag:Erjd8ZY9K/e+tz92xb4GFw==,type:int]
       HANDLER: ENC[AES256_GCM,data:X1i3kWzvqEFh1oe56jhtz6g8Kno3e2wkYXiVpAufYhqYZZIFBzYm1Q==,iv:80PwD/MpLeKyrODHCOyemsNoU2+YBjqjrnNU7aXiO74=,tag:y2t8EvB3+qUY3OLDeWrAgA==,type:str]
       KWARGS:
         grader_root: ENC[AES256_GCM,data:mLizLMYXQG0cbKsC2ujnIZUAPxN8fAgxgPMBLVllRNMEisKBE36qRazPOu+/GWxXN271zyqIyojsSXKntfCLzxHbtkZrhvjc,iv:qoX07KMeVFElCaI6+nWuCWQEYMrMBikVl/DhECWc6Eo=,tag:l/giJYXMMRUrpS1TXtTTqg==,type:str]
@@ -76,6 +94,12 @@ confd_json:
         lang: ENC[AES256_GCM,data:9NmOPMJeEQ==,iv:N6FWr67Ntk2IUMnFxqZ5F2pDMRw1zgbOHH1xktcaxUY=,tag:txQ1UXqPSm8GlK7ElIqf7w==,type:str]
         name: ENC[AES256_GCM,data:gh4Y3zIdhEU=,iv:3UnKRV8vSJeTaxcnOpEKyomzIfyL8IHFSBSpdgJqPpI=,tag:DWLocHKW3msmD4lowLJbXw==,type:str]
         user: ENC[AES256_GCM,data:ZyEXf/zBips=,iv:zvvl+d8bEnrBEuiR3DZ2M9/GPV5BXzhDyRE4w8l11tE=,tag:+Jw900C3YaotFEJN9kPZIA==,type:str]
+        limits:
+          CPU: ENC[AES256_GCM,data:hQ==,iv:vZEhH2KTzuXVVYmfIpnqlrZXDLNizu+dVlSjtvmClzc=,tag:usbzubo4P5BL0SqrHOYB8w==,type:int]
+          FSIZE: ENC[AES256_GCM,data:d5MCvMXOoA==,iv:hs3NE6CL5pgjdNZPPBKLhXDlVUy/QUGYU8HZbLunwb0=,tag:6Gwn/eNSxEh5E3uOigOOiw==,type:int]
+          NPROC: ENC[AES256_GCM,data:h0Y=,iv:XasMdip0pipQdFehXbQ9H10fjg5eu75bzN6InBl8GKM=,tag:ZOHx6t0/lvjl8dVb/5Kuhw==,type:int]
+          PROXY: ENC[AES256_GCM,data:PA==,iv:CCt9P1TweOI+0o6FPR86TFGf65PkKVdf6F4xyZ9uBwc=,tag:pFGY1L8IhWuHWKK2m9gdjA==,type:int]
+          REALTIME: ENC[AES256_GCM,data:CQ==,iv:HJRs7uTZLhXbNKyTD5mGg0lBvHw8l48fJ6/NSoYkls4=,tag:LsQavhVn5r8t7kN9jmm9oA==,type:int]
       HANDLER: ENC[AES256_GCM,data:JzFVwY5kA06X9f/X00S1oToxB9/gn6uHns4LTKVM2Nkwmg7hoiGtIQ==,iv:84OvATZeijQEI1GbzczBXomucffgU6nZvLcyKKazoMg=,tag:Yh3KOWiddJiFUXwL/kQFtw==,type:str]
       KWARGS:
         grader_root: ENC[AES256_GCM,data:37he9hy2tI36/PNzMbD4T8qeC5IYOBCG4PaDk0uhhHiisqf+yII0TgVPPn3efBCLhXlgYavZh8zIYM5vaEHcwGIjgbN4rl2Px+k=,iv:UZhHgU0HsLkYE6ssZBktzMPqO4fNA+1l6yIbdwRRNek=,tag:hcBKt/JgX8FuO0V0x1T7yA==,type:str]
@@ -92,6 +116,12 @@ confd_json:
         lang: ENC[AES256_GCM,data:LENIZxRy5g==,iv:pe4NHMFzWeZaftOoRuOQd2+Olxqk/93oZgnhjtsZNQU=,tag:9A1s1xyOipXP/+3YndFPGg==,type:str]
         name: ENC[AES256_GCM,data:WKTT3aqPSd4=,iv:fW05tKdQXYZBPL3OKIguuHHgMMjifBOA4HUP5ziKd5o=,tag:+aaGRqP/sWMeVpSoO1ac6A==,type:str]
         user: ENC[AES256_GCM,data:Ft1Koeafyuk=,iv:7ekGZAokKGfX0Uvt9tHbvjdBVKUXk5jDX1O3WpDFtEI=,tag:8GyvODOqf5LNbnd2wcVmaA==,type:str]
+        limits:
+          CPU: ENC[AES256_GCM,data:xw==,iv:qIVmu+Sfyegs94Oje9E3f4zbHeSAoP+UzZmlFGe8aVA=,tag:1d/7z0g5JOFQn9lrJmEnVg==,type:int]
+          FSIZE: ENC[AES256_GCM,data:BVgHj2b9eA==,iv:WsKYTRPaAO6QLs1ZgQpDf72Nmchh4Vvt55//PkINbro=,tag:ZbNCEMEel88sUEhIJLZHcA==,type:int]
+          NPROC: ENC[AES256_GCM,data:Zjw=,iv:49APgMnoerLIEVmWc6lJUysLZDbnL2gkZI6oNazFHuM=,tag:yRDA3Xclv2vigHAlYREnyg==,type:int]
+          PROXY: ENC[AES256_GCM,data:jg==,iv:CbXa5rflI/QomQFKLdeC2fMNCwM2U2bIpTz5AXHdcDI=,tag:/xUGri3UgBR4969D4WfXGQ==,type:int]
+          REALTIME: ENC[AES256_GCM,data:qg==,iv:mOp4mPCgnk+DvegD96pxAMCUgY3G6rA2X10rKQcL4nw=,tag:72Xb1pgXKflg1BpXYCdReQ==,type:int]
       HANDLER: ENC[AES256_GCM,data:Rx2UGZe53QGTcuzezRjkmCkfTmA+NQ0pIoWpQMTqbfZ/ctVWEMhVjQ==,iv:lBJNUOWt+dKPgyR28oYZRgUnWR/t2CqaLvBqaGSOX00=,tag:RY/GlQHDFI9b2CExWuVVsw==,type:str]
       KWARGS:
         grader_root: ENC[AES256_GCM,data:qLiT7p9jNttF1ebIzq2OabjofqHXKpOoCry6KB/JbHdszg4vhlY=,iv:qAZ5AiO5Dr4Emhukd+gr/7VUnjHb4zVx4UBV81kC78E=,tag:vPi8U1PasR+FNvMKjCPrVg==,type:str]
@@ -108,6 +138,12 @@ confd_json:
         lang: ENC[AES256_GCM,data:lj+DhS247w==,iv:7knwGBh67z6YHhvN5aE3h/niqxROSpS1jknZt/ZJ7WU=,tag:7TEbFIDiX4NdNRJYR2KRfg==,type:str]
         name: ENC[AES256_GCM,data:aLB6K9As07CEZN5GVw==,iv:yAQZVvdboOek44Rku+/COBFPImZsJTjyqMZsJshALiI=,tag:qiWzZ89oiCqJGEojaRuICw==,type:str]
         user: ENC[AES256_GCM,data:ghHFgg4VcPtouLj8UQ==,iv:dwnWx7UztbYDe01q99K1ci9PNwQKFG2SNBhFk/O6hrQ=,tag:YjauQHD8wNBsbPktq/238g==,type:str]
+        limits:
+          CPU: ENC[AES256_GCM,data:Cg==,iv:xfmbSTuKlZJeSJlpzbNJDtxTMuCaSpA0v8GdXaGsqkY=,tag:sxUlquDwup14yawMvKPmOg==,type:int]
+          FSIZE: ENC[AES256_GCM,data:MLHYpzMPbg==,iv:r6sDqNCOmOV13bXy+ER/NStLcCA2cUIjQ1WAmnuos7c=,tag:GlFG0bBGo3Jk70g1/UZdlw==,type:int]
+          NPROC: ENC[AES256_GCM,data:Mew=,iv:CZnilm61lVzGvJXB1SLSM+ZfgBC4mbZuGBDzNc0KlOU=,tag:Z5i/E+4fMDgJFCgd0NajPQ==,type:int]
+          PROXY: ENC[AES256_GCM,data:kQ==,iv:FoivxZEhbtmil0n+GKPVfmVVjqcYSPKVRL/CKjOkDRk=,tag:LD4jN0j9bHmOA3NuLSKCWw==,type:int]
+          REALTIME: ENC[AES256_GCM,data:iA==,iv:tHARJIZkxXLXbtYaiYSBzXDxov2qYwrAMlV1KW6MECc=,tag:pWjMUvY7KTKceXFOYQOFPg==,type:int]
       HANDLER: ENC[AES256_GCM,data:I+itLOStkcQlgrvKegbjBvGvpdNSESHOzDVI8QjCaEf8MCUGNgdrRA==,iv:AOBsBfFQaqFlGpcyEiyD1C+tmXBetIf60OukqtM+KHo=,tag:dTsPlY38SuKQI2l11ttwyA==,type:str]
       KWARGS:
         grader_root: ENC[AES256_GCM,data:8RlB7XtFOHuHSAponHQrtWD2ifTa9acyXATSQhP2v50+fe7zoAY=,iv:73NqWymaqDwDlZKftSWasIz7NS4Ero2YPJBpurPV2bo=,tag:EeW2p0zSisKH3DgmH8Zi4g==,type:str]
@@ -129,8 +165,8 @@ sops:
     created_at: "2024-05-06T14:13:58Z"
     enc: vault:v1:aWyCjjLMlMraiZLA33tBOhaVm56Ykg3fVPAxgiwiVAbFlPJHwiviNH9O6T9zvm41mkrZfJLoKes3Lbkh
   age: []
-  lastmodified: "2024-05-06T14:22:19Z"
-  mac: ENC[AES256_GCM,data:fDxdi3S7aVbgAwMLTJmF51U2d3ux13bMfCCZ93y5J8fjmNKLukVj9Vxu7Shx+myoJYp1kLXrnp+itVmnq31jIoWbXxX1acoUEIS3llgZ7QsMzznGmRuVYWDEPsCZCWokfnCUWipCNA0szPq7FEEyLEPW8mCy5SuqmX0D5nclYvQ=,iv:mMaFe6hVNUErgja7N7Nc3JIA4mT2wY96qCwn4kSWmT0=,tag:QjBTdFY2k143uub7I4tgCg==,type:str]
+  lastmodified: "2024-05-10T17:52:23Z"
+  mac: ENC[AES256_GCM,data:DUOa59XLFokUZzLREWaW9Pr3pXWaZNECGHVjespz3FPh0NfiUhG3QwMm0B0XHZvJvZMZuexmnNN3W8niYb7Rq+bC2xmuVmJV+Xya+QVkGBv+Mgfh2vGVXwffNuJ9WyUYO3idSsqT6S22If+cAwEm8KFOcPzqPCYclaBIfOkc1Jg=,iv:/4ocuQlXaZaljHUqmN0wxQE6RW497poCaDnjabesfuk=,tag:Zg/hrJ8s2OFj8T/tAttA1A==,type:str]
   pgp:
   - created_at: "2024-05-06T14:13:58Z"
     enc: |-

--- a/src/bridge/secrets/xqwatcher/secrets.qa.yaml
+++ b/src/bridge/secrets/xqwatcher/secrets.qa.yaml
@@ -28,6 +28,12 @@ confd_json:
         lang: ENC[AES256_GCM,data:o1bp2jETFQ==,iv:pz1WNgFtCLki+o8hyeMYVyei/jmH9CTJpGcwqiS8A9c=,tag:fEHPmnfSx2ZPRODe4gK3AA==,type:str]
         name: ENC[AES256_GCM,data:C14JtLirrlc=,iv:YREgi8mo4PU66sLs3ybYvPLryzMlUMonjEH5kv9EZ98=,tag:aAWcSaJmwE5BRDH1jWmV6Q==,type:str]
         user: ENC[AES256_GCM,data:QdgC57w8tA0=,iv:SXbTQS+1MKQ9/+Dg+akBt9DW7E7L0tBw/7AtFxKs9KI=,tag:7w45Paoo/aljI3yiOSOg3Q==,type:str]
+        limits:
+          CPU: ENC[AES256_GCM,data:ZA==,iv:Ln106vfSIO1MyUInf7E6gG+HVkCuz/UoSBAG5vypO0Y=,tag:dv+LKFUAOXbR7t+3mFwQyw==,type:int]
+          FSIZE: ENC[AES256_GCM,data:Mf3/VO3NBg==,iv:UI94kponUwIVRcJqLtb8UZx0qlbt6jfPlpEUY40q8tw=,tag:gWCuViqWo3dOUMZjYRWUTw==,type:int]
+          NPROC: ENC[AES256_GCM,data:feQ=,iv:Q6XT9iC33/5wK//aU16atebKI/dFykq4JcK9gypeCAA=,tag:lAlLcgIK8cMWDWKSkBECkw==,type:int]
+          PROXY: ENC[AES256_GCM,data:DQ==,iv:1yOMIiX+aFNYqIJKtDZgpsLWgbxIpt5IdB2nEg4rUJ0=,tag:Zcy2I6IRC4gwcOyCPuheQg==,type:int]
+          REALTIME: ENC[AES256_GCM,data:qA==,iv:JJG0hkohxYABdSJF5FSOVG7Xl0XermMu38qATGqTTt0=,tag:K0Cf/4bCwGzvv2de3ojpOA==,type:int]
       HANDLER: ENC[AES256_GCM,data:XZTysIiia2Div+6kSzJWW0zFb7cFx0SP/YDh0Y9ZLt2vKaZytzgOAw==,iv:mt9s1hTESSxMhJ3S+PUgLrNLAggB1qgOrlK5/2yUiWY=,tag:tZlbjAJ/q/1yGKU0mZfqoQ==,type:str]
       KWARGS:
         grader_root: ENC[AES256_GCM,data:BiHmEDc1mTof9tGtYedwPi507mfhgluwPZFSxUl79gX7GzHacp1uVeD1I096tHqijtu5CsO0hyQ7f8srtfU08M12XYQPJ0ax,iv:SkMuBmSJfbpuQxpk/xB9h/FocFaRTm6Xj6yB3k+b92c=,tag:FZbQWVexumGakpBgrfHh8g==,type:str]
@@ -44,6 +50,12 @@ confd_json:
         lang: ENC[AES256_GCM,data:bf8we2WTng==,iv:uC9KkzmA+FLGDFitk09tLv4JugTuwy2oji7UYIvL/IY=,tag:/lwA1eg/DpowvVfLeP94wA==,type:str]
         name: ENC[AES256_GCM,data:WfR5/uHjfxs=,iv:rArs1snYabjZ0tcvoS2GlXmWp0OTjEOqhpgSvDpkNXw=,tag:UFIvXZujOk9Swbz7C0Pcpw==,type:str]
         user: ENC[AES256_GCM,data:ikEMnkFSZdA=,iv:iltRvvbN908ZhIvwefxfCAWzDBWp+cgdHpUCJEUFYFI=,tag:6JUTZIlcRkqFClnnYgEQOg==,type:str]
+        limits:
+          CPU: ENC[AES256_GCM,data:1A==,iv:Zh6fdLbGkoYL20lWNtEKc3WXKz0Ahq9s1C71Cx7i6L8=,tag:8ELhG/6j/mm3Ck6FcRuY8w==,type:int]
+          FSIZE: ENC[AES256_GCM,data:zGJii3y8GQ==,iv:EDfYaHIopSTc60qHE4/Y+89GRxqrYWnRO4RrYlU7c7M=,tag:KfP20+mnD1JviF3CoSNAYg==,type:int]
+          NPROC: ENC[AES256_GCM,data:9Iw=,iv:nYOzIEqte1ij3TIHU61uW5/uLfpxDd/z8qC5+ha9Dgc=,tag:nmCIbHZhEwHEeh2fsz01lw==,type:int]
+          PROXY: ENC[AES256_GCM,data:LQ==,iv:NzNDFQm7bwXgA3WNIwGqLkqrk4I7cQFW6lNzKgkwBS0=,tag:QG2sN5LKfzFofVANYZchXg==,type:int]
+          REALTIME: ENC[AES256_GCM,data:kA==,iv:SlHBCUi7W9RpQh4kATbmhsVwdX9jzXdW7f3pwVwhcno=,tag:AXQnIbY6V7i/OfsK5Mt6Zw==,type:int]
       HANDLER: ENC[AES256_GCM,data:RH26Iuu66uafWoluF43xdVkgci/SuSU1po7coLDbJK3zIIMioNzqSw==,iv:L6cxBwFYreErANENdX/5v/ixJ9uAC/LI90/js/OaISc=,tag:L5sBomNWh7h840VMKEdqXQ==,type:str]
       KWARGS:
         grader_root: ENC[AES256_GCM,data:UxnLP8pTKC/lYeyqp4q8demkIz1ZkHnpUImUpFUPvb8qt9U5ctL0jf8oWjDrmT7X6Lc+4oxGMfanPa32W0WWcVuqrL5ZELUgcig=,iv:t5EHNxgRMQYUnJq8RMANJ4gBwEoA/5SYxRE5y6x+U6U=,tag:w9f8wknetVu8PagCLhiZAQ==,type:str]
@@ -60,6 +72,12 @@ confd_json:
         lang: ENC[AES256_GCM,data:vdUU5TC9nA==,iv:E4xG0jPRw8Vm59pXRhRY6E9bSEQjcTs4TkXSHEXrxnY=,tag:oZByqrDG8Bl8Yu7Q4ujafg==,type:str]
         name: ENC[AES256_GCM,data:2AyOaZZG86U=,iv:V+xSuPArLWPF4c0UAFJG5HaVKfwTC0ldqteY1HY6Ucw=,tag:kSp1d6ceheioKwUXoyvuCA==,type:str]
         user: ENC[AES256_GCM,data:41h1ev8mhqE=,iv:Avd2xJQ3OHmnNWvbEeLPIxNU9vOMqVI3fawob0xfRJY=,tag:6k8OdHp61utVybfUO7R44A==,type:str]
+        limits:
+          CPU: ENC[AES256_GCM,data:kQ==,iv:tOLIuZntkQv4bAnmbofXGUm2clSnLGR/SxNRYU0MISo=,tag:X1BlY5ba0gFJP0p0hpiesw==,type:int]
+          FSIZE: ENC[AES256_GCM,data:WWI/JAkq9A==,iv:aL/GUDCbvq9AeYr1+qstLzCJ0kUrgSfK/JzD6HCx6h8=,tag:WY1CQ58MN+FjSqEz7yTdBQ==,type:int]
+          NPROC: ENC[AES256_GCM,data:HCs=,iv:J4aAjAUs590/8M6mfNR+UBVIuRykRZhZhCqU8Q3TEeo=,tag:PzQTtGMbxQ9Pxsc4nuYESA==,type:int]
+          PROXY: ENC[AES256_GCM,data:HQ==,iv:LVnun+6yVVrBQaBHIkbw1aJXVpZMH8//6mJpEsa4vao=,tag:QuCQFnvBDKkSAP6trI1Juw==,type:int]
+          REALTIME: ENC[AES256_GCM,data:2w==,iv:3Q/tqdh7+gx/iQ6MbHRBI9mCDHRTTLONAjGLeF3f86s=,tag:yL5bd6bvd73zCqxmkDtUew==,type:int]
       HANDLER: ENC[AES256_GCM,data:H5+hNRyFaCmnGnoY4HKDTXlCnh/A+xcmzpyxj6qJVE6WIiomoVyUrA==,iv:XFv0UYC05LEvpe+/Lzeqi/huP+mdpWGoYCl1PjgILA0=,tag:6uIwL9L433ZgZVF2hAs21Q==,type:str]
       KWARGS:
         grader_root: ENC[AES256_GCM,data:2BkaBckpvV6Lq5QUC+AoRVjh/9I67oForBhAO4PIcl/C9bcilhXOmv/3CjucDGb+LcUAO2RN6dFOiC6Xn6nQK5oig/phkSa3,iv:2uno7gFhEUUeWVBUuJnt/HNBifgck9ynPYm3kBC2tic=,tag:7bwiwNWCfhGPAmTLQbdM0Q==,type:str]
@@ -76,6 +94,12 @@ confd_json:
         lang: ENC[AES256_GCM,data:HC0EWYti4A==,iv:LEuZvhVjpVtNVpmG4JRp1i/cTvY+JqOPJquN3rMziZY=,tag:Kke9Y7qrlzvFQdCravFTjQ==,type:str]
         name: ENC[AES256_GCM,data:T8Ww/L+hvpY=,iv:y0/kqqgc30sz2r3Ch8KWdJksIchszIW7Sh+1EsAtvDQ=,tag:IzdtALknTd5RO5EqNwJLPg==,type:str]
         user: ENC[AES256_GCM,data:aX3MtZcMoHY=,iv:SY5FPBVwxQHEsW9r+Ve6BA4P9XKtaHiSuh77aHIfOiU=,tag:HxUahPGqcKQl1q+q0K8LOQ==,type:str]
+        limits:
+          CPU: ENC[AES256_GCM,data:Ug==,iv:5KJQlXdTyVJKbxPHkow16WjTgPFF6Q7Lf/oUJwjdJmY=,tag:U5x4qSNg57gFEBpNP7SFSQ==,type:int]
+          FSIZE: ENC[AES256_GCM,data:xsYCAtnKjw==,iv:w1Y5V+ADdOuGtbl1Lm+Rr15910dfNtFmxjQhjLdyiU8=,tag:G/6qZiooZWnfPkO56ytf9Q==,type:int]
+          NPROC: ENC[AES256_GCM,data:obs=,iv:v0CCcgAj6236PxNgrv8PV8rAPiOhsYsK47LlyhCjULU=,tag:6+2VUtL5WxQNt645P2Pcrw==,type:int]
+          PROXY: ENC[AES256_GCM,data:3Q==,iv:ep8KZXleMFd7xCdCNyq7LQn61cmibVA2buI3S2ocFA8=,tag:8RIL+nT15KUSioes8wrm+A==,type:int]
+          REALTIME: ENC[AES256_GCM,data:9g==,iv:coWzuBT87tPcMo072azYS8ZCftBC86irIxAsbuJgGW8=,tag:lgmqJROi2lDRS3S1MJSGMw==,type:int]
       HANDLER: ENC[AES256_GCM,data:z+FPpoXI6uwY1C+j7YWo6Rb4jE7jGK245T7EV140yDPLVISho9YbcQ==,iv:i7Y3Ofy7pqykvMiXJlV1g6lerx6M6c/1Gc1pQnf+3yw=,tag:Ne29K/80tiUejK1Sqa0iiA==,type:str]
       KWARGS:
         grader_root: ENC[AES256_GCM,data:1BhyZs2Oyy14j2IWnJ6bVofhXT76E49eysEo0/QVEGN+oFVk4HF4/KEAo9M42Skkhy4mp27mb4gXc4E4HUr6VXaoTyCabMOC/rI=,iv:uPJIjHYY1FqQdb8NYHar1x8OAkfm4LVkMv4JkFC3wgk=,tag:clx6b8DnVS6jiGCKwFoVMA==,type:str]
@@ -92,6 +116,12 @@ confd_json:
         lang: ENC[AES256_GCM,data:8lXbMNLx2w==,iv:eOGzXyTMEHDEeplqvmPGaz6HDAPqy5qQuiFgF/SkriA=,tag:CRQFCANwsOpUecuSjura/Q==,type:str]
         name: ENC[AES256_GCM,data:EmlN/s5JnCc=,iv:KMirAMEZda//L2EZ5/cvYdhcWtVtIjVzUu82og0xw7E=,tag:+sFOEgTkYmeoWyyfGaJbTA==,type:str]
         user: ENC[AES256_GCM,data:Z1G/R9ho7UE=,iv:LXC9uIIItlWMBdiDPxpxRGq2Tzo+N/p85YprqiO7hf4=,tag:MMBMdyXlmRnFqpUCgzIMZQ==,type:str]
+        limits:
+          CPU: ENC[AES256_GCM,data:Nw==,iv:PQPWlXK1kLD8mT7wE0kNxTcssnC786le2mg/09HfQ6A=,tag:dxU7XFj8VAkuin31nZCiTQ==,type:int]
+          FSIZE: ENC[AES256_GCM,data:YeeT/8WMdw==,iv:KNQpUt4BxeEB9iK3C0zKsq5vAz6Wa3IYHVZ76HVPEyg=,tag:rHBblf3PfzQ0uWPuYQck8A==,type:int]
+          NPROC: ENC[AES256_GCM,data:lr4=,iv:pvTLC9gEI48xg8C7DCDW26p+W/jyhe4hh+lQ4uEURRQ=,tag:/1bo6w5Rl+ap3L+6FkUSbw==,type:int]
+          PROXY: ENC[AES256_GCM,data:1A==,iv:ZziurSdgyaZd4Fwb8YvKFodJZaTpTFqaI5IIQg0sz0g=,tag:qruiGCUt5YR3RoeirPYcog==,type:int]
+          REALTIME: ENC[AES256_GCM,data:Nw==,iv:ARsZAjvaV1lTvuOBmGWiv41M/pz1rpJlxvEMZlvIT8I=,tag:Nq+p7DkjlSYKxKuZkZrTEA==,type:int]
       HANDLER: ENC[AES256_GCM,data:6TOMoOwPQY9WdAKKq3QRjtoLx6H66l8vW3fPWgOzDaI3jOAbNW2yWg==,iv:+dxCn7lzW+LQRXgBqSFZEHDhbwRnpn7HMKlc1RZexeo=,tag:tKUd5yYfVrEDE9u1M31AWg==,type:str]
       KWARGS:
         grader_root: ENC[AES256_GCM,data:TEm0Nrkl/f/UqIEEb8Hh1ROShKZT3Le3VU/I9jsHhUbNPuAcunE=,iv:WFOeghb9S8+Z0al3m7GCDz2jsgp6kOI6/AXCLCcfdCo=,tag:FYfRitcC1W9Uzn3YP4+y7g==,type:str]
@@ -113,8 +143,8 @@ sops:
     created_at: "2024-04-25T18:36:13Z"
     enc: vault:v1:g7mhUqKHlNcwvcj2abywWi5LPantyajOlFaIYJjJSmZNY1EGqBmUNtSKK3kutcgneXo2KpoNffN5uuxI
   age: []
-  lastmodified: "2024-05-02T18:34:37Z"
-  mac: ENC[AES256_GCM,data:jfAI1GKS8pwo870lyGfX+6DzLBk6JH+yLsRfVoe5iHt6fdoKpt3N2yucGXwgAtThkncWzXVY79h1hUuGYP2dXf7TTacG14fv7l+DNyyaFAvMWbKkEL1iFYLc3FVbijBdwuuuztp5xjyB70FJT9aWUjxkpco1uEs0xlCVu+Dt7oc=,iv:Ex5hi2sjt3g3F1p7FKI8bw1lX46MoDoSEiXxE3POUeE=,tag:IQda+XWRC284MLRVqCA/kQ==,type:str]
+  lastmodified: "2024-05-10T15:40:04Z"
+  mac: ENC[AES256_GCM,data:CbXM8YwOcOUlgf7B+JeRZJMcONZeHxkq/zbtldIepArthEJVbML/qOdG4U6gt6TbGV8WADZ6n6fiIGfD9WP/PsFBlI/DnrRz7tmgE4mSKUhy4/UVIvf0Nsr3K9QtXprgyRizoibzlvcb8k2s+wJ3Cj94Rj0IsgAVG0xbaDEgbvs=,iv:RfDsXA1WpJAniXrkfH0lZhiFZ1qAM84Xf+AUXg3MjGA=,tag:9iiI+N+giNDaFomFRY7eEg==,type:str]
   pgp:
   - created_at: "2024-04-25T18:36:13Z"
     enc: |-


### PR DESCRIPTION
### What are the relevant tickets?
#2326 

### Description (What does it do?)
- Adds xqwatcher grader unix accounts to 'xqwatcher' as secondary unix groups. Added codejail limits clauses to all QA + prod workers.
- Fixed sudoers file for pkill operations.
