### PR TITLE
refactor: Tie Python and node versions to releases

### DIFF
--- a/dockerfiles/openedx-codejail/Dockerfile
+++ b/dockerfiles/openedx-codejail/Dockerfile
@@ -1,19 +1,20 @@
-FROM ubuntu:focal
+ARG PYTHON_VERSION=3.8
+FROM python:${PYTHON_VERSION}-slim-bookworm
 SHELL ["/bin/bash", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true
-RUN apt-get update && apt-get install --no-install-recommends -y vim python3-virtualenv python3-pip git sudo libxslt-dev && apt-get clean
+RUN apt-get update && apt-get install --no-install-recommends -y python3-virtualenv python3-pip git sudo libxslt-dev && apt-get clean
 
 # Define Environment Variables
 ENV CODEJAIL_GROUP=sandbox
-ENV CODEJAIL_SANDBOX_CALLER=ubuntu
+ENV CODEJAIL_SANDBOX_CALLER=debian
 ENV CODEJAIL_USER=sandbox
 ENV CODEJAIL_VENV=/sandbox/venv/
 ARG OPENEDX_BRANCH=master
 ENV OPEN_EDX_BRANCH=$OPENEDX_BRANCH
 
-RUN virtualenv -p python3.8 --always-copy $CODEJAIL_VENV
+RUN virtualenv -p python${PYTHON_VERSION} --always-copy $CODEJAIL_VENV
 ENV PATH="$CODEJAIL_VENV/bin:$PATH"
 
 # Create Sandbox user & group
@@ -21,8 +22,8 @@ RUN addgroup $CODEJAIL_GROUP
 RUN adduser --disabled-login --disabled-password $CODEJAIL_USER --ingroup $CODEJAIL_GROUP
 
 # Switch to non root user inside Docker container
-RUN addgroup ubuntu
-RUN adduser --disabled-login --disabled-password ubuntu --ingroup ubuntu
+RUN addgroup debian
+RUN adduser --disabled-login --disabled-password debian --ingroup debian
 
 # Give Ownership of sandbox env to sandbox group and user
 RUN chown -R $CODEJAIL_USER:$CODEJAIL_GROUP $CODEJAIL_VENV
@@ -44,8 +45,8 @@ COPY sudoers-file/01-sandbox /etc/sudoers.d/01-sandbox
 RUN chmod 0440 /etc/sudoers.d/01-sandbox
 
 # Change Repo ownership
-RUN chown -R ubuntu:ubuntu ../codejail
+RUN chown -R debian:debian ../codejail
 
-# Switch to ubuntu user
-USER ubuntu
+# Switch to debian user
+USER debian
 CMD gunicorn -b 0.0.0.0:8000 --workers 2 --max-requests=1000 wsgi

--- a/src/bridge/settings/openedx/types.py
+++ b/src/bridge/settings/openedx/types.py
@@ -80,16 +80,26 @@ OpenEdxDeploymentName = Literal["mitx", "mitx-staging", "mitxonline", "xpro"]
 
 class OpenEdxSupportedRelease(str, Enum):
     branch: str
+    python_version: str
+    node_version: str
 
-    def __new__(cls, release_name: str, release_branch: str):
+    def __new__(
+        cls,
+        release_name: str,
+        release_branch: str,
+        python_version: str,
+        node_version: str,
+    ):
         enum_element = str.__new__(cls, release_name)
         enum_element._value_ = release_name
         enum_element.branch = release_branch
+        enum_element.python_version = python_version
+        enum_element.node_version = node_version
         return enum_element
 
-    master = ("master", "master")
-    quince = ("quince", "open-release/quince.master")
-    redwood = ("redwood", "open-release/redwood.master")
+    master = ("master", "master", "3.11", "18")
+    quince = ("quince", "open-release/quince.master", "3.8", "18")
+    redwood = ("redwood", "open-release/redwood.master", "3.11", "18")
 
     def __str__(self):
         return self.value
@@ -139,7 +149,11 @@ class OpenEdxApplicationVersion(BaseModel):
     @property
     def runtime_version(self) -> str:
         # Default to Python 3.8 for IDAs and Node 16 for MFEs
-        app_type_runtime = "3.8" if self.application_type == "IDA" else "18"
+        app_type_runtime = (
+            self.release.python_version
+            if self.application_type == "IDA"
+            else self.release.node_version
+        )
         return self.runtime_version_override or app_type_runtime
 
     @property

--- a/src/ol_concourse/pipelines/open_edx/codejail/docker_packer_pulumi_pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/codejail/docker_packer_pulumi_pipeline.py
@@ -23,7 +23,8 @@ def build_codejail_pipeline(
     release_name: str,
     edx_deployments: list[DeploymentEnvRelease],  # noqa: ARG001
 ):
-    openedx_branch = OpenEdxSupportedRelease[release_name].branch
+    openedx_release = OpenEdxSupportedRelease[release_name]
+    openedx_branch = openedx_release.branch
     codejail_repo = git_repo(
         name=Identifier("openedx-codejail-code"),
         uri="https://github.com/eduNEXT/codejailservice",
@@ -80,6 +81,7 @@ def build_codejail_pipeline(
                         f"{codejail_dockerfile_repo.name}/dockerfiles/openedx-codejail/"
                     ),
                     "BUILD_ARG_OPENEDX_BRANCH": openedx_branch,
+                    "BUILD_ARG_PYTHON_VERSION": openedx_release.python_version,
                 },
                 build_args=[
                     "-t $(cat ./codejail-release/commit_sha)",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
- Update the codejail docker image to use upstream Python image as source
- Tie the Python and node versions to release channels

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Generate the pipeline and ensure that the proper Python version is used for codejail
Build the docker image and ensure that it completes successfully
Deploy to CI and verify that edX courses load properly.

