### PR TITLE
MIT Open Application routing paths

### DIFF
--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
@@ -47,8 +47,20 @@ config:
     sso_url: "sso-qa.ol.mit.edu"
   mitopen:api_paths:
   - "api"
-  - "search"
+  - "login"
+  - "complete/ol-oidc"
+  - "logout"
   - "admin"
+  - "static/admin"
+  - "static/rest_framework"
+  - "static/hijack"
+  - "_/features/"
+  - "scim/|o/|disconnect/"
+  - "podcasts/rss_feed"
+  - "__debug__/"
+  - "media/"
+  - "profile/"
+  - "program_letter/([0-9]+)/"
   mitopen:db_instance_size: "db.t4g.medium"
   mitopen:db_password:
     secure: v1:Xk9oxNvxSQAJUAHE:8CdeLN2SlyhyU0iZpqEX5rnHSJ3PClleDJi2UpzoCsVZ4UjNkr7vCOAKY7CvCuB/7CBKJKM=


### PR DESCRIPTION


### What are the relevant tickets?
https://github.com/mitodl/mit-open/issues/629

### Description (What does it do?)
Adding the rest of the paths to route to the application rather than to s3 based on feedback from Chris and Shankar. 

This should recreate the [nginx regex](https://github.com/mitodl/mit-open/blob/main/config/nginx.conf#L35C18-L35C210) from the MITOpen repo. 
