### PR TITLE
refactor: Pass through Python version for xqueue and notes

### DIFF
--- a/dockerfiles/openedx-notes/Dockerfile
+++ b/dockerfiles/openedx-notes/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.8-slim
+ARG PYTHON_VERSION=3.8
+FROM python:${PYTHON_VERSION}-slim
 
 ARG APP_USER_ID=1000
 RUN apt update && \

--- a/dockerfiles/openedx-xqueue/Dockerfile
+++ b/dockerfiles/openedx-xqueue/Dockerfile
@@ -1,16 +1,13 @@
-FROM ubuntu:focal
+ARG PYTHON_VERSION=3.8
+FROM python:${PYTHON_VERSION}-slim-bookworm
 
 RUN apt update && \
   apt-get install -y software-properties-common && \
-  apt-add-repository -y ppa:deadsnakes/ppa && apt-get update && \
-  apt-get install git-core language-pack-en python3-pip libmysqlclient-dev ntp libssl-dev python3.8-dev python3.8-venv pkg-config -qy && \
+  apt-get install git-core language-pack-en libmysqlclient-dev ntp libssl-dev pkg-config -qy && \
   rm -rf /var/lib/apt/lists/*
 
-ARG OPENEDX_COMMON_VERSION=open-release/olive.master
-ENV VIRTUAL_ENV=/venv
+ARG OPENEDX_COMMON_VERSION=open-release/quince.master
 ENV DJANGO_SETTINGS_MODULE=xqueue.production
-RUN python3.8 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8

--- a/src/ol_concourse/pipelines/open_edx/edx_notes/docker_packer_pulumi_pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/edx_notes/docker_packer_pulumi_pipeline.py
@@ -27,7 +27,8 @@ def build_notes_pipeline(
     release_name: str,
     edx_deployments: list[DeploymentEnvRelease],  # noqa: ARG001
 ):
-    notes_branch = OpenEdxSupportedRelease[release_name].branch
+    openedx_release = OpenEdxSupportedRelease[release_name]
+    notes_branch = openedx_release.branch
     notes_repo = git_repo(
         name=Identifier("openedx-notes-code"),
         uri="https://github.com/openedx/edx-notes-api",
@@ -86,6 +87,7 @@ def build_notes_pipeline(
                         f"{notes_dockerfile_repo.name}/dockerfiles/openedx-notes/"
                     ),
                     "BUILD_ARG_OPENEDX_COMMON_VERSION": notes_branch,
+                    "BUILD_ARG_PYTHON_VERSION": openedx_release.python_version,
                 },
                 build_args=[
                     "-t $(cat ./notes-release/commit_sha)",

--- a/src/ol_concourse/pipelines/open_edx/xqueue/docker_packer_pulumi_pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/xqueue/docker_packer_pulumi_pipeline.py
@@ -19,7 +19,8 @@ from ol_concourse.pipelines.constants import PULUMI_CODE_PATH, PULUMI_WATCHED_PA
 
 
 def build_xqueue_pipeline(release_name: str):
-    xqueue_branch = OpenEdxSupportedRelease[release_name].branch
+    openedx_release = OpenEdxSupportedRelease[release_name]
+    xqueue_branch = openedx_release.branch
     xqueue_repo = git_repo(
         name=Identifier("openedx-xqueue-code"),
         uri="https://github.com/openedx/xqueue",
@@ -76,6 +77,7 @@ def build_xqueue_pipeline(release_name: str):
                         f"{xqueue_dockerfile_repo.name}/dockerfiles/openedx-xqueue"
                     ),
                     "BUILD_ARG_OPENEDX_COMMON_VERSION": xqueue_branch,
+                    "BUILD_ARG_PYTHON_VERSION": openedx_release.python_version,
                 },
                 build_args=[
                     "-t $(cat ./xqueue-release/commit_sha)",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Update the Dockerfiles and pipelines for xqueue and edx-notes to use the version of Python specified for the target release.
