### PR TITLE
refactor: Use DockerHub image as upstream for Superset

### DIFF
--- a/src/ol_superset/Dockerfile
+++ b/src/ol_superset/Dockerfile
@@ -1,4 +1,4 @@
-FROM apachesuperset.docker.scarf.sh/apache/superset:${SUPERSET_TAG:-latest}
+FROM apache/superset:${SUPERSET_TAG:-latest}
 COPY --link requirements.in requirements.txt
 COPY --link pythonpath /app/pythonpath
 COPY static/assets/images/ol-data-platform-logo.svg /app/superset/static/assets/images/ol-data-platform-logo.svg

--- a/src/ol_superset/requirements.in
+++ b/src/ol_superset/requirements.in
@@ -1,9 +1,0 @@
-apache-superset[cors,thumbnails,prophet,trino]
-authlib
-celery-redbeat
-duckdb
-flask-openid
-flask-oidc
-hvac
-psycopg2
-redis

--- a/src/ol_superset/requirements.txt
+++ b/src/ol_superset/requirements.txt
@@ -1,0 +1,9 @@
+apache-superset[cors,thumbnails,prophet,trino]>=4.0,<5
+authlib
+celery-redbeat
+duckdb
+flask-openid
+flask-oidc
+hvac
+psycopg2
+redis


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Superset is now on verion 4.x, and has started publishing Dcker images to DockerHub. This fixes our upstream target, as well as using the GitHub release tags for identifying which image tag to use for our builds. This should also help to resolve the errors that we were experiencing with invalid database migrations during deployments.
