### PR TITLE
Revert "fix: fixed the discussion sidebar issue"

### DIFF
--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -70,7 +70,6 @@ def mfe_params(
     open_edx: OpenEdxVars, mfe: OpenEdxApplicationVersion
 ) -> dict[str, Optional[str]]:
     learning_mfe_path = OpenEdxMicroFrontend.learn.path
-    discussion_mfe_path = OpenEdxMicroFrontend.discussion.path
     return {
         "ABOUT_US_URL": open_edx.about_us_url,
         "ACCESSIBILITY_URL": open_edx.accessibility_url,
@@ -82,7 +81,6 @@ def mfe_params(
         "CONTACT_URL": open_edx.contact_url,
         "CSRF_TOKEN_API_PATH": "/csrf/api/v1/token",
         "DISPLAY_FEEDBACK_WIDGET": open_edx.display_feedback_widget,
-        "DISCUSSIONS_MFE_BASE_URL": f"https://{open_edx.lms_domain}/{discussion_mfe_path}",
         "FAVICON_URL": open_edx.favicon_url,
         "HONOR_CODE_URL": open_edx.honor_code_url,
         "LANGUAGE_PREFERENCE_COOKIE_NAME": (

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
@@ -12,7 +12,6 @@ config:
     "--staff", "--authenticated"]
   - ["discussions.pages_and_resources_mfe", "--create", "--superusers", "--staff"]
   - ["discussions.enable_discussions_mfe", "--create", "--everyone"]
-  - ["discussions.enable_new_structure_discussions", "--create", "--everyone"]
   - ["grades.bulk_management", "--create", "--superusers", "--everyone", "--staff",
     "--authenticated"]
   - ["grades.enforce_freeze_grade_after_course_end", "--create", "--superusers", "--everyone"]


### PR DESCRIPTION
Reverts mitodl/ol-infrastructure#2386

This was discussed in https://github.com/mitodl/hq/issues/4161#issuecomment-2124863515  & https://github.com/mitodl/hq/issues/4161#issuecomment-2125102047

We are reverting this because we don't want to turn on the new discussions on all the courses. We'll instead manually enable the new discussions sidebar for the courses which need It.