### PR TITLE
refactor: remove usages of EDX_API_KEY

### DIFF
--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/lms_only.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/lms_only.yml.tmpl
@@ -2,7 +2,6 @@
 {{ with secret "secret-mitxonline/edxapp" }}
 SOCIAL_AUTH_OAUTH_SECRETS:
   mitxpro-oauth2: {{ .Data.mitxonline_oauth_secret }}
-EDX_API_KEY: {{ .Data.edxapp_api_key }}  # DEPRECATED SETTING
 {{ end }}
 
 ACCOUNT_MICROFRONTEND_URL: null

--- a/src/bilder/images/edxapp_v2/templates/edxapp/xpro/lms_only.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/xpro/lms_only.yml.tmpl
@@ -2,7 +2,6 @@
 {{ with secret "secret-xpro/edxapp" }}
 SOCIAL_AUTH_OAUTH_SECRETS:
   mitxpro-oauth2: {{ .Data.xpro_oauth_secret }}
-EDX_API_KEY: {{ .Data.edxapp_api_key }}  # DEPRECATED SETTING
 {{ end }}
 
 ACCOUNT_MICROFRONTEND_URL: null

--- a/src/bridge/secrets/edxapp/mitxonline.production.yaml
+++ b/src/bridge/secrets/edxapp/mitxonline.production.yaml
@@ -1,6 +1,5 @@
 ---
 django_secret_key: ENC[AES256_GCM,data:TSccKTwc5z0n7+88RhsoaYs6zOc3+ZChNZP8uVEFIYe996CqOOQ2GQqXB1Humk8TTRhEKKqnDyQOisvZW8ydKBElJW+R2fYXUkM=,iv:MbeEDUb3rqK9/aCtSRrFmfPBbsonpstpu50kdy0R+po=,tag:juvmuoyUefm3uq1+6DBhGA==,type:str]
-edxapp_api_key: ENC[AES256_GCM,data:rAw+wahIF+nqhsCaC7kNm2pcHd0G1hwU9q1/hlhMi228TKhJy6g=,iv:28tztvSYZrXZRxlYH2RRnk0beyr48plMs59t/cMrkXg=,tag:kykXpf+BdXF+OfHUdJk+0A==,type:str]
 fernet_keys:
 - ENC[AES256_GCM,data:6I69FIFsMhFmpk3knoLBaUSpDfKqm7iMsWdDYOCIcg3mimFKtwrNnJxhZv8=,iv:slfWuZ4T2GSYf5w2kYAvSR6nSnOv6soXLh2Lb/AXPyA=,tag:j3ukHy0aM41mkYGmgMY3AA==,type:str]
 mitxonline_oauth_secret: ENC[AES256_GCM,data:ze+8hNS2vnSzIbOsFARFXAiDJ1s4y1DfnyggHkmBAWYWb/l8UhkOT+yLIBF5RqPBfjHhdIMsgaKvD2PPK4+aU/XrjKtyjKP4ps3/GjNRQMoAe44NVPJz0nxXH6PSmJe3XJ3rAQ0sq3FjhyTn9Q+j/SWF017U4j6hHylKX3FloJQ=,iv:lKzWhvW9SDuKN2Gsr+6+FWAs3FN8m00NfnJk9mdplhU=,tag:OjUrSMpmNc4HOjP3wmVRLQ==,type:str]
@@ -31,8 +30,8 @@ sops:
     created_at: "2024-01-24T20:22:34Z"
     enc: vault:v1:byPRBF6A/8V2ih1u4mcYKp/DzvLqIN/qMwepOaR/v65OFh4xp31M6Z9GlzMgruW0o93GTuk4uOsyo/Nm
   age: []
-  lastmodified: "2023-10-18T15:30:38Z"
-  mac: ENC[AES256_GCM,data:SImOaLCdTUn8LnWhxNQUhroJ6RBL5oMkJn9ShyTJhmlJAQ2SHX/HKNa/5p7e4+wl35vpogMWybVbK61czgBkgceFcga13iOMkYZsQ5PoYo7hrsp0vRAFnX5bhKzpnqiLbhcC2Q+WlN5BaUz2iNClBz8HE7KYLvsZffP6GJoLr9Q=,iv:7jw0rNw1FxVhIQqEDwr4QPC2tMUYi41GXBfb2+QD1n8=,tag:C8+HJ/4oh/cIDBcnCcYl+Q==,type:str]
+  lastmodified: "2024-05-28T15:57:44Z"
+  mac: ENC[AES256_GCM,data:s2VBTPuvAS2j/yUDqlNjx0y64hyFAv/kFOEicGqtYxnRJRwA7+8Y1c5IC71KzScxt0da1ritYoueNzebyaT1IEbveGZcRX6Dx0o43SFJIsUV/3iIpbbs7uMNYUrW/4svpVNyVSnYKWTl/o9VnOahNNMtKrMghVL/wcY+QgFbr9Q=,iv:UahK397Uhltzr+xCzfaz+EGKLIFy2KtUJ895GzPQSrE=,tag:u9nUS99ZIy/ccf/NnprB2g==,type:str]
   pgp:
   - created_at: "2024-01-24T20:22:34Z"
     enc: |-
@@ -115,4 +114,4 @@ sops:
       -----END PGP MESSAGE-----
     fp: 3582AE9F12CE295BDAF545ED17A5F53F11681446
   unencrypted_suffix: _unencrypted
-  version: 3.8.0
+  version: 3.8.1

--- a/src/bridge/secrets/edxapp/mitxonline.qa.yaml
+++ b/src/bridge/secrets/edxapp/mitxonline.qa.yaml
@@ -1,6 +1,5 @@
 ---
 django_secret_key: ENC[AES256_GCM,data:/TJ5IPewi6sTJx/jfUgOetVqLW9PgAjkWUK6JLEls95S15YJ7cn5hpn/2g==,iv:GyXW6CR2g/5YxK6RD4IfBEuetDp3kUGdO5LU2lZJ3go=,tag:p+xL45eHKSKy5+kIi0sJow==,type:str]
-edxapp_api_key: ENC[AES256_GCM,data:vUq3VWTXWFkh0h9ai5r7kwrebuFkgaY8HKT+AyiJsryH5WqiYPE=,iv:9rrvXBPvKOtYn0sJl6wdZmQd20itG7E9JMXdKQ7ZQk4=,tag:kQYOxD+ZVEpJ/teC0h/kQg==,type:str]
 fernet_keys:
 - ENC[AES256_GCM,data:kbn+eZnz2qkiuJNPXuNufANaltoW/ZjkPOIktuBL9nhiAMt45dL6S131l8U=,iv:0vfqEFccLxBQ73LwtdPbP2/XI3PAOPCpD5ESPBqL0Z0=,tag:tSuRCLFuoTgJ1Vnd6bdHHA==,type:str]
 mitxonline_oauth_secret: ENC[AES256_GCM,data:dSvvn13YbDlxU481jJJ8eul/Xd3pZM4a/EGJ6cWH1WuEx0XwW2lc/lYdVlqyfg3ytleIoVIxDnuM2vt/K2go0Uaku6xi/bFfFhnpHdzUC8LhI2eLCKn0dmBrfWlbzs3you0hLobCMJnZl+o/DpQ3TuSDtNAk6GvPE3O6Ysq0MqE=,iv:483uzJ2DCp6VMigXhB9CHfy8B8uIW+mN2sNEqG8Ibxg=,tag:UkwB2sxCwulVB8RzCNSJeA==,type:str]
@@ -31,8 +30,8 @@ sops:
     created_at: "2024-01-24T20:20:45Z"
     enc: vault:v1:Se7VK51tjpcwBeK5uIFfhzwFjk3eRiB5wqcPDkENhttBD+6gHlpvJxzQIWzeVI1OeRDntvsiEHigDixU
   age: []
-  lastmodified: "2023-10-18T15:31:30Z"
-  mac: ENC[AES256_GCM,data:8/w3rAds0Ky+r030rI/UXigz9J5lXULy2NBYftJou0DOqWLJNiyvWpoP9TAsOiqrTuXVK3aScUAnyAS+WOp1O2nv5ZqEh/yzrFj8VXtnu+rbXJ2+aPVKf7xXsVpK8Ega/NHxyXG3DyxZSzpv+MCvI03VW/nyia04O0OhzeehO4w=,iv:oA7L9RKxprYw0dHO7RqxABazuX9Gt/VE1ZGkI+JzmwE=,tag:r1bE3SKXBjdx6HAi+Ms0cQ==,type:str]
+  lastmodified: "2024-05-28T15:57:37Z"
+  mac: ENC[AES256_GCM,data:HJly2g/z6BuvX4bFaK4yEzdqRZh1B0p5zwC63FIyULoEt73Ib+AsDV/JZkGK+MP31wn8pqEaZQSFidoJm6xICa+8Ms5jFOzKXnbTwndM3NFL//hJpa8OpaoqoxmN3n2c6NHE54F4LYh0f26Z2Uo/57ppNULSqkRDe5zL4hg1DLw=,iv:QoFT9vOOIr9Ae+1f35UMTv8zOnZzJVw/z7ORbso3mLg=,tag:rnUX6Zf4JZZ5FgFN6WoYPg==,type:str]
   pgp:
   - created_at: "2024-01-24T20:20:45Z"
     enc: |-
@@ -115,4 +114,4 @@ sops:
       -----END PGP MESSAGE-----
     fp: 3582AE9F12CE295BDAF545ED17A5F53F11681446
   unencrypted_suffix: _unencrypted
-  version: 3.8.0
+  version: 3.8.1

--- a/src/bridge/secrets/edxapp/xpro.ci.yaml
+++ b/src/bridge/secrets/edxapp/xpro.ci.yaml
@@ -1,6 +1,5 @@
 ---
 django_secret_key: ENC[AES256_GCM,data:xsLYKfT+Y8NLZcint8BnkE41BaGt/fBrCsLuX2p0PjW/zTpi/fuhVspJ49wueUjcgKbkdIiiB2JVVFrQojXW56gftwItkUGZqAU=,iv:N6Pxqf8HuMJbNJW0fF6PNKpQ1+fGi6Dq7x389MYRdFk=,tag:959FNK3YuJGlppGOVKiyPQ==,type:str]
-edxapp_api_key: ENC[AES256_GCM,data:lRuA7aaifQLfVEI9iAgZRgYRKh63i5JC856hinAGUIMCUBHC3xc=,iv:rSTU8l6f/lG1T/8ZPVmMA5ylE6A4zbp9VxS2rJYW6OU=,tag:UOGEpg41V88bvG48Plh7MQ==,type:str]
 email_username: ENC[AES256_GCM,data:xMv7a5R03KsLzlm0DODg2GaRAnbhhfCBe4WWcFJ81XlWpNM=,iv:bL9MysnRqgagPn8nuztHGdlOkBVdTT/qa8Dk1mEhl1o=,tag:+CreMok6pmOl193g3t/fjg==,type:str]
 email_password: ENC[AES256_GCM,data:GGOm8trLpjJtN4uyMYQX14ow1VFQdwbh8JewFX6PHfd8upepC3Ns07MqIJk+lbweejA=,iv:xPNUuQfC/8/mEg6ANOaM3NPvu1v6M2ozLB0DX3/MlUk=,tag:I6LgM0UdO/kvpwes/BZNPQ==,type:str]
 fernet_keys:
@@ -28,8 +27,8 @@ sops:
     created_at: "2024-01-24T19:58:56Z"
     enc: vault:v1:gNmbSqZKfMu3Wllyvby83SIInqWQ6cZp4WWfPo3ybgDQAKQMcc8A/coDv8eXYXduYSPyZjONyHKtVgw7
   age: []
-  lastmodified: "2021-12-21T17:28:18Z"
-  mac: ENC[AES256_GCM,data:ryJ2t5N4Dl3BozKQ3SlkakrPqeIBGu7NrN8XK7FB2eBLDbLobqU/8l7q8r2+59IgB9AYdzBdeXmVxahXvCrlA2QukMg83X/DYqzhDzw/JSEDdV0ws2Lqs7Upwmx6rrdn0McMBDAUy0C+LBMJbH2nwEWJi/8ABnObVmRGiJDMndQ=,iv:l0TbvIUGCEfQFfIfT7KmehSflL4kKG3ck2X/uT2VnG8=,tag:rjzNejod/7XHy8Kqzz9+UQ==,type:str]
+  lastmodified: "2024-05-28T15:56:45Z"
+  mac: ENC[AES256_GCM,data:e1ibASuBUazcq+QiUut4FfN1i+NpHKVXiR5JkdLFNrq8Hp9GnMITmFurLS+fbYn1P3dozIfxlFG4FKNTOhft2lW5ZFcoaKULi2Y4vNS60AOmG/OqxS9zaCxfoOr4bnSciq5PO4rr5DNO9nqnDx30LLMQtyCNaBFOCYQT9i4V8CM=,iv:VSnir7fWOVJUpdlzjRWLHHDYEDfLuxrO8IikhH1YVwU=,tag:5gy83oy48m3qzyB39Bhd5A==,type:str]
   pgp:
   - created_at: "2024-01-24T19:58:56Z"
     enc: |-
@@ -112,4 +111,4 @@ sops:
       -----END PGP MESSAGE-----
     fp: 3582AE9F12CE295BDAF545ED17A5F53F11681446
   unencrypted_suffix: _unencrypted
-  version: 3.7.1
+  version: 3.8.1

--- a/src/bridge/secrets/edxapp/xpro.production.yaml
+++ b/src/bridge/secrets/edxapp/xpro.production.yaml
@@ -1,6 +1,5 @@
 ---
 django_secret_key: ENC[AES256_GCM,data:y0I7WrjeEYGSE7d35MBo1QkoKwdR3ONE+Xol3QBuuCGtCq0/G8kKUeZn,iv:dg4AK4P8DiWcEISTEEN+46GWV7YogXkuU1Pxwp6qrBk=,tag:BSsTaPOmDkuLy8+l6STmMQ==,type:str]
-edxapp_api_key: ENC[AES256_GCM,data:3+b24nidsJy/NX0UXn3nr6+MocPsAgNi8ujbp7eoFxrhHfJSCc9Mk/e3,iv:2V0xJGuCYyojO3KZyqlmbkk6W2ltmg4xz5BdJplsX8g=,tag:88LbXH8SUAuTKGlqADO5yA==,type:str]
 email_username: ENC[AES256_GCM,data:LvasWaWm02L+tkvQ4xd7qt/so4PqADQ=,iv:Sn/atfToIUIFeVYINHPM8+/0vjYYgaCcuKp55FFxjgI=,tag:ZH65h2aFD+p/I6PnLSnYZQ==,type:str]
 email_password: ENC[AES256_GCM,data:LuIY2AjBRBQqRhuzrqZaRWLD7ARdAd23I/4Vk7Xcv/yUmqYpURkWRXrF1qrgNawvKc0=,iv:xDIksWwABl8/SfDiu2Cw2c/b30DxPHqjYfGrQrj6PhQ=,tag:7BtzJLzQUZx4RsSIes/WKA==,type:str]
 fernet_keys:
@@ -28,8 +27,8 @@ sops:
     created_at: "2024-01-24T20:22:36Z"
     enc: vault:v1:Cfpacsnzar6PQdnySkw0o659TJ5Y1voD8w3BbrxUyEF7IEjzRdnr75RxDOTwdSFcC3WnAgEk4Y5R78mF
   age: []
-  lastmodified: "2021-12-21T17:22:34Z"
-  mac: ENC[AES256_GCM,data:14PpP8SFCzh72xSlqmU0yANS+ziyJkHtML2MWOsaVtQrE9e3GeTyLLe5ko5aB226MCFGf0WmigszBbD2lm+K2tMieh2xat0kSwMm4zNHR9Wv5TVUE2nmQIbfdX98OpmLspMHdB6v3rCfK5OmSww2sZ6qON/kxZpzXNKBLaL6XkA=,iv:TW052UpwSHfCE9K/EWw8RY+zMQ7rTXfj82JqI7gQrwc=,tag:BJM/QsM77wNuj0kXdPUjPA==,type:str]
+  lastmodified: "2024-05-28T15:57:06Z"
+  mac: ENC[AES256_GCM,data:QJw1j7DwcPQbKI6LiC5vizD192OYgXgPsJG4AjZO7Vx1utASvZ4k05IGhdfPcCm/iXBHGmw9RAkVg0yyAcNi5KWhR5nVlBev7Bkn3OhNvZunncf2yYXRRn08HK+W0SiVaGxgBpN35khU1flGPVo029rA2F5M3uggFMOk+4mxHuQ=,iv:HGVOsH1YCeWi1l3l+oJWyPODO8sbBLeJw82PZ3mwdPY=,tag:7XZkfvx3TjqDvsdlZeGxIA==,type:str]
   pgp:
   - created_at: "2024-01-24T20:22:36Z"
     enc: |-
@@ -112,4 +111,4 @@ sops:
       -----END PGP MESSAGE-----
     fp: 3582AE9F12CE295BDAF545ED17A5F53F11681446
   unencrypted_suffix: _unencrypted
-  version: 3.7.1
+  version: 3.8.1

--- a/src/bridge/secrets/edxapp/xpro.qa.yaml
+++ b/src/bridge/secrets/edxapp/xpro.qa.yaml
@@ -1,6 +1,5 @@
 ---
 django_secret_key: ENC[AES256_GCM,data:+JAv4bC8cqau1cxImIu6G6/A0YCJQSBjdG4YMfEdEMOK/8UE2xUlRcpM,iv:bW+RuC7L+jsvBlKKl2unvz/7LOwd/p0cNgLdjhZ6Gaw=,tag:vv6uwWontr1geY8H1E2edA==,type:str]
-edxapp_api_key: ENC[AES256_GCM,data:7LHZ2tGnCxeLWBrbXlUIISyYeuTuIYXtdgO4R/yihNrsyp2BzNiPl31G,iv:qm05tKtwlQ7DBtStliGXlxyBxr4mATLQ5YCh6ggocIQ=,tag:RosUWTgMdDUdlxL1qGreQw==,type:str]
 email_username: ENC[AES256_GCM,data:EiDodwz75DMbZIKEPupj9KGGJUhh6XpHqpyKygQlrmt4sow=,iv:mPd3jtchLc1QvX9xbzcsg5NqqaT3IB/woSUw1UnacUA=,tag:BEwxcy+y2uc/b2XZTcR2aw==,type:str]
 email_password: ENC[AES256_GCM,data:YW4LFnJ/FIo7pbOOZ2twwrNbuCfSi5GF3Q+Heq4Miodxl5JwkETf3dF7P3T0CqWq+IY=,iv:u96LoC8Y4pCPndBf4KuIBZTHdFgNV7n2ejO7Io4zAtU=,tag:1T8lPcAsKtCJL1kRAQhqaQ==,type:str]
 fernet_keys:
@@ -28,8 +27,8 @@ sops:
     created_at: "2024-01-24T20:20:46Z"
     enc: vault:v1:aVmaUwwhksjOmD2ievgiTBT8J8Ra7sQhquWs82r0ABGqBaiSFXUE/gMB2zBGAfGJb/3sK0E6vzDr37QQ
   age: []
-  lastmodified: "2021-12-21T17:23:16Z"
-  mac: ENC[AES256_GCM,data:J6GJP1j2B5zgvZV4A8lHsTfWYvOx/89nvG23Qzpd+bJIMLEviXjContON6Z3RxkabaQMnYR553oxe6nE3YvsJyeatIQu2w6sKOeNYH0ocCLhfk07BC2TI17p0A5dq6plBdDcr2oBtZn70YWIBTnjqMBNHF/v626Gr1XyEd/BSHA=,iv:Lt+6UF4nrtpi4SXkzpQSsXyqMVWRpzFW9gHNL+hdsPo=,tag:3twGMIaZ80QcDegJVKMN9A==,type:str]
+  lastmodified: "2024-05-28T15:56:53Z"
+  mac: ENC[AES256_GCM,data:1kvLh0A+JVRXX0S5ZyvR4uwBDd1djmACC2sSN9Eh4FOges4a0bUfvFnjoi1GrJOLlsU8K4EehaejDEwnwCVpA5N+tC23ScKpiOwIKQysrUQYW3tAI/3YSsnr1sDY51fMOSPCcTupJGoCBGor5YYE9pv6G33k16RbI0L+qRo1RJM=,iv:85sw0l7euXfGlNJSmLddb7X0SNG4XsBLs/XAmnnm8tw=,tag:I6UwZoWdkhr6+steBd5h3g==,type:str]
   pgp:
   - created_at: "2024-01-24T20:20:46Z"
     enc: |-
@@ -112,4 +111,4 @@ sops:
       -----END PGP MESSAGE-----
     fp: 3582AE9F12CE295BDAF545ED17A5F53F11681446
   unencrypted_suffix: _unencrypted
-  version: 3.7.1
+  version: 3.8.1

--- a/src/bridge/secrets/xpro/secrets.ci.yaml
+++ b/src/bridge/secrets/xpro/secrets.ci.yaml
@@ -31,7 +31,6 @@ openedx-api-client:
   client_id: ENC[AES256_GCM,data:hnt3275thdE0gw84LTxBShVnExRseuQE4ZvYxCTPp+5cbLj9scIndQ==,iv:0G9m6BQNpzuwxqcKLgdfU1BIzlRTI3BWvqsF9n7XYJE=,tag:evj0wbDIsUcHLbslQr/DDg==,type:str]
   client_secret: ENC[AES256_GCM,data:xLFoy1D2A5swZ/lV0muOm7XjO+P0c8ehxndpDBKLACfiqQDHaKAruZ75BCBrwYb4DacvDrZUgxSOPQ6BVHeoCZosmE6PL6wdy/HhrKTuziK3dhLfFe3+yUcqwG4//1mCZd8BsArqJNXkLOaMcYho293Zdqybk9uWN+WmM1HHDf8=,iv:Ski+RmLhmKMJxfGTJKajVxlsw+s5tst/GRLxXcwXnKU=,tag:GkB/V5ck+13ODLAMtS6S8w==,type:str]
 openedx:
-  edxapp_api_key: ENC[AES256_GCM,data:QM5vVtte8bymi7K0iGA8NE+EFif95/vCtsxz0gWGlzMwk+f66IbrDU9R,iv:rQYmHZs1WmXlZr+AWfKRJLqmBU7XDzzOj/lcB4DKebY=,tag:oP6j1WCEXH7UnyjA8BJpKw==,type:str]
   grades_api_token: ENC[AES256_GCM,data:eX3tzrQ7jCrGpTyrKjSgFtj9yy/Av2Q5NN/68pfMbESCOK72QRqG9g==,iv:4nvLUbPk9Tzm9JIAA/26JPqcnl2j/WrhsxiBE8p/ie0=,tag:0Hvcayo1WGJhEGviNAgauA==,type:str]
   registration_access_token: ENC[AES256_GCM,data:PCoRnpICNQkkFNX2QhGgLoiTQDBBMv8vENsWYwxvyE+47axecZdwROcQ,iv:QQ3TPRpjEdsQ6PONWaPOIKl0x1NfBJyWJQ4tgIgxWT8=,tag:/Duii/pOIBqi68INpWjyVA==,type:str]
   service_worker_api_token: ENC[AES256_GCM,data:FLlwhyEQKv3p1M26zyr+YRJAj4g2NQ2ZvoHEsNhu3v0LR41ntGz9Aw==,iv:t6yG/qSO0D+zqpWHej1UkII3DjqHtLBwhS1Xgl2N9ic=,tag:wsgTJMIsTGV4A9fmJWahqw==,type:str]
@@ -71,8 +70,8 @@ sops:
     created_at: "2024-01-24T19:58:50Z"
     enc: vault:v1:eqLTbBnjlosTlLhitEaYfHOchh7o8OmbMOOtXWnQ7aOBeoI3dZri5XxotBFe+8J97mDuWsP+p0a3tCiN
   age: []
-  lastmodified: "2024-01-25T16:21:01Z"
-  mac: ENC[AES256_GCM,data:JT+3IqzJpJXqZxmLF7eKkaZK/CroN8YzKFnIfeOGIvXSRGR9fO4eDpAjn/BxxbfecoSWlWRdKgE1oTQJElHX362cpGMgVYjjKzgd4mHwj8Ovie4Uhg7rq1iHa9t/ZHnILpC1Ddr9CLemayMIOxTN5cdhu3+bg4O1RAKLkL7zT4s=,iv:DJRvL7KHKl7jEzubRoh3y6JeXn05kK8se9PWKQ8iaeg=,tag:ZibUAITBxC1589Wbbd/aSg==,type:str]
+  lastmodified: "2024-05-28T16:01:04Z"
+  mac: ENC[AES256_GCM,data:YoLF4FKMWx3aU3fGuucfm3o4WCyRX+Ii3qkBjObO7BYwIYQ/bQxRwYTgrj/j48PifVlKE/3/uUVmxlUEmYs26tpwMCuXacApKog9Nh1DthXZ1XXihgGqM0T3/RJWoy99mhNwbEBW97L+ED8bAS4FEnggTLUwyXaqzLFYucBd0HA=,iv:EIdsd8vVTjSbAiUEd4nsg7o8ZgVw00hrGZatZT7CKAc=,tag:hQ79aFN706zVtENwX5aI+Q==,type:str]
   pgp:
   - created_at: "2024-01-24T19:58:50Z"
     enc: |-

--- a/src/bridge/secrets/xpro/secrets.production.yaml
+++ b/src/bridge/secrets/xpro/secrets.production.yaml
@@ -31,7 +31,6 @@ openedx-api-client:
   client_id: ENC[AES256_GCM,data:Hb45ooHrprktE6fEJJ6OOs0Bs1m1/CydvEIDD5GwSg+IseAgP+0kEQ==,iv:JfUWTxp5QGcrKE5yBKWOaNWLRZgBWdSqB80MNRZR8q4=,tag:W++TxDf/3qXn45rU5+O8lA==,type:str]
   client_secret: ENC[AES256_GCM,data:QqKi9nZ6xo6l8VaT+VnKVHJNH8MgHfb+OiXJ51NIo2mJECyNCqYRASxypU9cY0vfJfm1mYWGFCDWuV0rQjeGDjFhFKk04l3YULnIDn/DCeRlrdgRLezDVpQas2oAed3BkEK15mi06fND32BKVcsUAhZMxrhHC2/lkRABTbfdEc8=,iv:1j3NtvOTvKtYwm9OnwuOQPTAC5T50tEU2eWCnivCLoY=,tag:kl3vUtoSh3ueEvbeyJgP/A==,type:str]
 openedx:
-  edxapp_api_key: ENC[AES256_GCM,data:ycSdWlgLRZtksid68ja9i3wTKnPWCJO1KgG3rZVuoL9zOEJNZRfgWFlz,iv:oLcyNBphj1coJutEKjz+S7AkgTYDTPO4ApQFLOO/JRs=,tag:tcP+XgQzYq/AHcgzt/AZXg==,type:str]
   grades_api_token: ENC[AES256_GCM,data:Rc8ql7HST+ZE1hphoLvF98RQhAepfmYpPgxyJczh3OGzBJShKqnqJQ==,iv:0dCR2y1fXX9a19kKR1XBoPYUdKnxErBqD+YR/Ds3oOM=,tag:R7n1Te0Rv7r+AFgvDJK8Dw==,type:str]
   registration_access_token: ENC[AES256_GCM,data:BrFc0Uj6f4XXERZuk5qXQEY0tCdD/sYANTM+lfvc6coHjDJviJHl0hbK,iv:Vpadvp0Gzoj1yUp/Gp0Lv9ELoA5OY/OYH/8XkU9coz0=,tag:ODhtK6Bnh4igp7UK4rrSog==,type:str]
   service_worker_api_token: ENC[AES256_GCM,data:0AKqBEW/Zue+McBoQMSSyAcy6UkLcF67ePtaehEBMc8=,iv:F/8PWq+IpiramQBL1bOcf07dpP3li4B5VbSA0JlW6UA=,tag:1EBb1ZRVSFen52UcB8ASRQ==,type:str]
@@ -71,8 +70,8 @@ sops:
     created_at: "2024-01-24T20:22:29Z"
     enc: vault:v1:RPwGIhH3XI6PuKWF10YLU93NnxzMG03C4s8keU3UdKVoxhTnQNfGxSLNGjpl6A3r7J4PpgqouLv1MyJG
   age: []
-  lastmodified: "2024-05-07T15:13:19Z"
-  mac: ENC[AES256_GCM,data:TVnsmTSc1c9qRaTEAOaEdZ/llXRRRCQw6NMkISHT59EYq0/3yvsxY1aamae9GIugC8whsQO5bpnLHyWk9yjdth++Ty92xaSDfRzi5ZHWjXzMLjglJw0e5yoy7lDZ44BEXjexZXxGIGpx1TpdYhj+bJzVtEBRPMjHHFIOqx9nBSE=,iv:kRQd6DAEozCNufam6YorjMtdFGr/3AM8PyFaavDA3Ck=,tag:tqVRcHqHiXjQzl3F+KitIw==,type:str]
+  lastmodified: "2024-05-28T16:01:17Z"
+  mac: ENC[AES256_GCM,data:szIgQ4oGT57+mj1MK3o9M1LGV4SSPy+1p42A/0T+mkSKUoV4+beiVoA4WZxONxDB7HNvwpEGy5I8z8eaI8Z4QoPa0srQpx0H/BMrcTtsVvWCEih5rCfOM58OXM9EI865Rnesmxi9+fQlznpQjfljyr0VOuABDvBVbgKrKPztbxg=,iv:w38+vG667IvOUWOMqlt4MtiIXzT/brJ+94WCybJCrCk=,tag:hkY8QTqvyoR0lf5Mcv4tQA==,type:str]
   pgp:
   - created_at: "2024-01-24T20:22:29Z"
     enc: |-

--- a/src/bridge/secrets/xpro/secrets.qa.yaml
+++ b/src/bridge/secrets/xpro/secrets.qa.yaml
@@ -31,7 +31,6 @@ openedx-api-client:
   client_id: ENC[AES256_GCM,data:8xSM5VhnSLVVIPNPtdJj2lGuu5NtLpZl0woBUX6W8iCT5WSzj4yAOQ==,iv:w93qLGpxVdzA7IYa5fT6ekSX/Yoy6tCCO6o9Y8WCD0Y=,tag:1isfObiPf83f8KzfTBtAzg==,type:str]
   client_secret: ENC[AES256_GCM,data:BRjsdlHE9/jIhqhO4Dvu0aJhbFfeDcw28KAUAdYlxth9QabqQLnPkyy3337P/rw7VTxe2S/Ff9/jm3mrwWfGryk4CQ9NdVlzPGTwqc0PHaIrjOY/CTKGdrTV2YFx3CQYSRlwK9ZRCGOZuXmCywSD3KLm4DAB+rwJXPFSpgK3kYY=,iv:1ct31yLJNzL3qbKWhAWjNMR3gn6g1bzcCej0u1t1lKA=,tag:CQqLdLB92U6CTK+dOnp9pQ==,type:str]
 openedx:
-  edxapp_api_key: ENC[AES256_GCM,data:gckVO6mvSDqnFgQmCIsfXVMtgEoBxHacbn2ZNLeBahjQuEega1JTM3bw,iv:pKweyUgIgs8v0JIVce5Zg1pOhcip49c4R0hG6Wa/DIg=,tag:Yip078frebpGJSrNUkrQdA==,type:str]
   grades_api_token: ENC[AES256_GCM,data:R5PRT5sBCZrl5WjCYZohVsIfSBxIVuVrmY6HtxjegePGwsIWNJAHqQ==,iv:Vcd9Qk0wsj9rwTW3HJUUPhBANSR/dAbzd+LfP8/B/S0=,tag:iOol/ovN5txIepiTgz+Gyg==,type:str]
   registration_access_token: ENC[AES256_GCM,data:UVbef3la9lkIJhkI/b6R+2RT73tJRaVFNOeyanaQ9imd1zHcV5lttmIf,iv:gZBEcGm12TBNRDhq4k3YdIf0FZwwCIX13ZxZpFXWEvY=,tag:sR8rM60GBiPI44LTHYUVGw==,type:str]
   service_worker_api_token: ENC[AES256_GCM,data:ga/Y+qjqA1kdBisihUZa7Xq3VE1O9JCLLOHVtN/wDn/sweXPoANvQg==,iv:Q/cwpIkhve1xEvgL9WzDN7Pkf1z84xXl9ZJBYESKYW0=,tag:IX7zBQRu8LxXwkK8Xiov/w==,type:str]
@@ -71,8 +70,8 @@ sops:
     created_at: "2024-01-24T20:20:19Z"
     enc: vault:v1:4YxP4nojlHbL45TdbZ73pGe7XfQrCbwLoN2bDeq5qO6Roj4waUZzrwhAVGAQfuw0T7XUAJbHkeblG01t
   age: []
-  lastmodified: "2024-01-25T16:21:28Z"
-  mac: ENC[AES256_GCM,data:eVLV+tt6s+0mncXBwwmrhKckOLeR+0htLhDj2KPItbnQ8XASp4Bez4HIX/fTYVbC1q7L4BpKbrxWwTwpHJri5n8pXhK6YfJdjjEYfCQW2koxFL7f1B16Gi5KZ59o87dpf2UA0MWt64jouZatgPJWhLm+3uuvykKZFGG/H4rHFK0=,iv:aQdxsVr0Bc9/LpudsVPmg7VVJrfe/TMTE52Xdbe8QMg=,tag:7crlTPfz1KCOkyCVQmavog==,type:str]
+  lastmodified: "2024-05-28T16:01:10Z"
+  mac: ENC[AES256_GCM,data:rq7FDmQPoxG1g3xu+nyy8BbFfsTMsrXZnXxEUZidNra7SJtSDYgwbg885RogB7J7REHYaXYHIQkxzSl77S+X730kB2j/D3VZzSQd8I/0JvGVQuE/WXEj6cJHMbT5dv+H+ry3WXxZZ5IcQI99q5YLqiPz4F4HoAXa5kku9F/0sHo=,iv:nUrLOeryJPkTxMnYjsIww6qjKp4CrWg9AcSlKAcVO0o=,tag:ScgqCMLO3gDN1t4M+iAKYQ==,type:str]
   pgp:
   - created_at: "2024-01-24T20:20:19Z"
     enc: |-

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -275,11 +275,6 @@ secret_mitxonline_env_openedx_api_client = vault.generic.get_secret_output(
     opts=InvokeOptions(parent=mitxonline_vault_backend_role),
 )
 
-secret_mitxonline_openedx_env_edx_api_key = vault.generic.get_secret_output(
-    path=f"secret-mitxonline/{openedx_environment}/edx-api-key",
-    opts=InvokeOptions(parent=mitxonline_vault_backend_role),
-)
-
 secret_mitxonline_env_openedx_service_worker_api_token = (
     vault.generic.get_secret_output(
         path=f"secret-mitxonline/{env_name}/openedx-service-worker-api-token",
@@ -383,9 +378,6 @@ sensitive_heroku_vars = {
     ),
     "OPENEDX_API_CLIENT_SECRET": secret_mitxonline_env_openedx_api_client.data.apply(
         lambda data: "{}".format(data["client-secret"])
-    ),
-    "OPENEDX_API_KEY": secret_mitxonline_openedx_env_edx_api_key.data.apply(
-        lambda data: "{}".format(data["value"])
     ),
     "OPENEDX_RETIREMENT_SERVICE_WORKER_CLIENT_ID": secret_mitxonline_openedx_retirement_service_worker.data.apply(
         lambda data: "{}".format(data["client_id"])

--- a/src/ol_infrastructure/applications/xpro/__main__.py
+++ b/src/ol_infrastructure/applications/xpro/__main__.py
@@ -342,7 +342,6 @@ sensitive_heroku_vars = {
     "OPENEDX_API_CLIENT_SECRET": xpro_vault_secrets["openedx-api-client"][
         "client_secret"
     ],
-    "OPENEDX_API_KEY": xpro_vault_secrets["openedx"]["edxapp_api_key"],
     "OPENEDX_GRADES_API_TOKEN": xpro_vault_secrets["openedx"]["grades_api_token"],
     "OPENEDX_SERVICE_WORKER_API_TOKEN": xpro_vault_secrets["openedx"][
         "service_worker_api_token"


### PR DESCRIPTION
### What are the relevant tickets?
Follow up on https://github.com/mitodl/mitxpro/issues/2872 and https://github.com/mitodl/mitxonline/issues/2102

Related tickets: [#2872](https://github.com/mitodl/mitxpro/issues/2872) and [#2102](https://github.com/mitodl/mitxonline/issues/2102)

### Description (What does it do?)
This PR removes the EDX_API_KEY for xPRO and MITxOnline in light of related tickets: [#2872](https://github.com/mitodl/mitxpro/issues/2872) and [#2102](https://github.com/mitodl/mitxonline/issues/2102).

**Note: Since this PR removes EDX_API_KEY usage for all environments (xPRO and MITxOnline), it should not be merged or deployed until the related PRs ([mitxpro#2982](https://github.com/mitodl/mitxpro/pull/2982) and [mitxonline#2217](https://github.com/mitodl/mitxonline/pull/2217)) are deployed to their production instances. Reviewers should ensure that no EDX_API_KEY references remain for xPRO and MITxOnline.**


### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
