### PR TITLE
config: add discussions MFE path, Picked from 2386

### DIFF
--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -70,6 +70,7 @@ def mfe_params(
     open_edx: OpenEdxVars, mfe: OpenEdxApplicationVersion
 ) -> dict[str, Optional[str]]:
     learning_mfe_path = OpenEdxMicroFrontend.learn.path
+    discussion_mfe_path = OpenEdxMicroFrontend.discussion.path
     return {
         "ABOUT_US_URL": open_edx.about_us_url,
         "ACCESSIBILITY_URL": open_edx.accessibility_url,
@@ -81,6 +82,7 @@ def mfe_params(
         "CONTACT_URL": open_edx.contact_url,
         "CSRF_TOKEN_API_PATH": "/csrf/api/v1/token",
         "DISPLAY_FEEDBACK_WIDGET": open_edx.display_feedback_widget,
+        "DISCUSSIONS_MFE_BASE_URL": f"https://{open_edx.lms_domain}/{discussion_mfe_path}",
         "FAVICON_URL": open_edx.favicon_url,
         "HONOR_CODE_URL": open_edx.honor_code_url,
         "LANGUAGE_PREFERENCE_COOKIE_NAME": (


### PR DESCRIPTION
### What are the relevant tickets?
None, We reverted https://github.com/mitodl/ol-infrastructure/pull/2386/ as a whole, But the mfe path needs to be put back.


### Description (What does it do?)
- Adds the path for discussions MFE, More details on https://github.com/mitodl/ol-infrastructure/pull/2386

