### PR TITLE
feat: added waffle flag to hide taxonomies

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
@@ -8,6 +8,7 @@ config:
     secure: v1:Fa4X7VjchQQhRf6+:LxDvDXBPZUPOgMpcqvo9PxwjMK2lDKrnmJGbaJA7e0i5sVsUyQXTLYpa7lDmC5d1QddyLLkjyQjK5Hi/fEeoJle5986uRKVHXNyjRpcJqx8sN2SbFPHrCDpWQfrsz38=
   consul:scheme: https
   edxapp:waffle_flags:
+  - ["content_tagging.disabled", "--create", "--everyone"]
   - ["course_experience.relative_dates", "--create", "--superusers", "--everyone",
     "--staff", "--authenticated"]
   - ["discussions.pages_and_resources_mfe", "--create", "--superusers", "--staff"]


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4419

### Description (What does it do?)
Disable "taxonomies" on mitxonline QA

### Screenshots (if appropriate):
<img width="1025" alt="Screenshot 2024-05-30 at 8 32 25 PM" src="https://github.com/mitodl/ol-infrastructure/assets/88967643/6b9de0a6-a6cd-494a-bdba-29513966a40d">


### How can this be tested?
- Add "content_tagging.disabled" waffle flag in your local edx-platform
- Visit studio: http://localhost:18010/home/
- Validate that there's no "taxonomies" button