### PR TITLE
config: disable Discussions MFE as a default for discussions

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
@@ -12,7 +12,6 @@ config:
   - ["course_experience.relative_dates", "--create", "--superusers", "--everyone",
     "--staff", "--authenticated"]
   - ["discussions.pages_and_resources_mfe", "--create", "--superusers", "--staff"]
-  - ["discussions.enable_discussions_mfe", "--create", "--everyone"]
   - ["grades.bulk_management", "--create", "--superusers", "--everyone", "--staff",
     "--authenticated"]
   - ["grades.enforce_freeze_grade_after_course_end", "--create", "--superusers", "--everyone"]


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4161#issuecomment-2141466986

### Description (What does it do?)
This flag enables the new Discussions MFE for all the courses with or without legacy discussions. We don't want that. We want to load new Discussions MFE for only those courses where we explicitly want to.

I've already disabled it from the QA environment. More details on https://github.com/mitodl/hq/issues/4161#issuecomment-2141466986