### PR TITLE
Explicitly reduce the TTL for instructor uploaded files

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -1536,6 +1536,18 @@ edxapp_fastly_service = fastly.ServiceVcl(
         ),
         fastly.ServiceVclSnippetArgs(
             content=textwrap.dedent(
+                """\
+                if (req.url.path ~ "^/asset-v1:") {
+                  set beresp.ttl = 30;
+                  return (deliver)
+                }
+                """
+            ),
+            name="Shorten the TTL for assets uploaded in studio",
+            type="fetch",
+        ),
+        fastly.ServiceVclSnippetArgs(
+            content=textwrap.dedent(
                 f"""\
                 if (beresp.status == 404 && req.url.path ~ "{mfe_regex}") {{
                   error 600 "### Custom Response";


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/2466

### Description (What does it do?)
<!--- Describe your changes in detail -->
Files uploaded by instructors in edX do not get explicitly expired from the cache when they are updated. This explicitly limits the TTL for those files to 30 seconds to avoid problems with stale content getting served when a file is updated.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
This has been applied to the QA environment of MITx Online. Upload a file to a course, load that file, then upload a different file with the same name and verify that the new file is displayed after no more than 30 seconds.
