### PR TITLE
Use the secret-global/mailgun path for all access to API key

### DIFF
--- a/src/ol_infrastructure/applications/micromasters/__main__.py
+++ b/src/ol_infrastructure/applications/micromasters/__main__.py
@@ -248,7 +248,7 @@ secret_micromasters_cybersource = vault.generic.get_secret_output(
     path="secret-micromasters/cybersource",
     opts=InvokeOptions(parent=micromasters_vault_backend_role),
 )
-secret_operations_mailgun = vault.generic.get_secret_output(
+secret_mailgun = vault.generic.get_secret_output(
     path="secret-operations/mailgun",
     opts=InvokeOptions(parent=micromasters_vault_backend_role),
 )
@@ -278,9 +278,7 @@ sensitive_heroku_vars = {
             data["username"], data["password"], stack_info.env_suffix.lower()
         )
     ),
-    "MAILGUN_KEY": secret_operations_mailgun.data.apply(
-        lambda data: "{}".format(data["api_key"])
-    ),
+    "MAILGUN_KEY": secret_mailgun.data.apply(lambda data: "{}".format(data["api_key"])),
     "MICROMASTERS_EMAIL_HOST": secret_operations_mit_smtp.data.apply(
         lambda data: "{}".format(data["relay_host"])
     ),

--- a/src/ol_infrastructure/applications/mitopen/__main__.py
+++ b/src/ol_infrastructure/applications/mitopen/__main__.py
@@ -653,8 +653,8 @@ secret_operations_global_odlbot_github_access_token = vault.generic.get_secret_o
     path="secret-operations/global/odlbot-github-access-token",
     opts=InvokeOptions(parent=mitopen_vault_mount),
 )
-secret_operations_global_mailgun_api_key = vault.generic.get_secret_output(
-    path="secret-operations/global/mailgun-api-key",
+secret_global_mailgun_api_key = vault.generic.get_secret_output(
+    path="secret-global/mailgun",
     opts=InvokeOptions(parent=mitopen_vault_mount),
 )
 secret_operations_global_mit_smtp = vault.generic.get_secret_output(
@@ -715,8 +715,8 @@ sensitive_heroku_vars = {
     "GITHUB_ACCESS_TOKEN": secret_operations_global_odlbot_github_access_token.data.apply(
         lambda data: "{}".format(data["value"])
     ),
-    "MAILGUN_KEY": secret_operations_global_mailgun_api_key.data.apply(
-        lambda data: "{}".format(data["value"])
+    "MAILGUN_KEY": secret_global_mailgun_api_key.data.apply(
+        lambda data: "{}".format(data["api_key"])
     ),
     "MITOPEN_EMAIL_HOST": secret_operations_global_mit_smtp.data.apply(
         lambda data: "{}".format(data["relay_host"])

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -305,8 +305,8 @@ secret_mitxonline_hubspot = vault.generic.get_secret_output(
     path="secret-mitxonline/hubspot",
     opts=InvokeOptions(parent=mitxonline_vault_backend_role),
 )
-secret_operations_global_mailgun_api_key = vault.generic.get_secret_output(
-    path="secret-operations/global/mailgun-api-key",
+secret_global_mailgun_api_key = vault.generic.get_secret_output(
+    path="secret-global/mailgun",
     opts=InvokeOptions(parent=mitxonline_vault_backend_role),
 )
 secret_operations_global_mitxonline_sentry_dsn = vault.generic.get_secret_output(
@@ -332,8 +332,8 @@ sensitive_heroku_vars = {
     "HUBSPOT_PORTAL_ID": secret_mitxonline_hubspot.data.apply(
         lambda data: "{}".format(data["portalId"])
     ),
-    "MAILGUN_KEY": secret_operations_global_mailgun_api_key.data.apply(
-        lambda data: "{}".format(data["value"])
+    "MAILGUN_KEY": secret_global_mailgun_api_key.data.apply(
+        lambda data: "{}".format(data["api_key"])
     ),
     "MITOL_GOOGLE_SHEETS_DRIVE_API_PROJECT_ID": secret_mitxonline_google_sheets_refunds.data.apply(
         lambda data: "{}".format(data["drive-api-project-id"])

--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -449,8 +449,8 @@ auth_aws_mitx_creds_ocw_studio_app_env = vault.generic.get_secret_output(
 )
 
 
-secret_operations_global_mailgun_api_key = vault.generic.get_secret_output(
-    path="secret-operations/global/mailgun-api-key",
+secret_global_mailgun_api_key = vault.generic.get_secret_output(
+    path="secret-global/mailgun",
     opts=InvokeOptions(parent=ocw_studio_secrets),
 )
 
@@ -470,8 +470,8 @@ sensitive_heroku_vars = {
     "AWS_SECRET_ACCESS_KEY": auth_aws_mitx_creds_ocw_studio_app_env.data.apply(
         lambda data: "{}".format(data["secret_key"])
     ),
-    "MAILGUN_KEY": secret_operations_global_mailgun_api_key.data.apply(
-        lambda data: "{}".format(data["value"])
+    "MAILGUN_KEY": secret_global_mailgun_api_key.data.apply(
+        lambda data: "{}".format(data["api_key"])
     ),
     "API_BEARER_TOKEN": secret_concourse_ocw_api_bearer_token.data.apply(
         lambda data: "{}".format(data["value"])

--- a/src/ol_infrastructure/applications/open_discussions/__main__.py
+++ b/src/ol_infrastructure/applications/open_discussions/__main__.py
@@ -303,8 +303,8 @@ auth_aws_mitx_creds_mit_open_application_env = vault.generic.get_secret_output(
 )
 
 # secret-operations
-secret_operations_global_mailgun_api_key = vault.generic.get_secret_output(
-    path="secret-operations/global/mailgun-api-key",
+secret_global_mailgun_api_key = vault.generic.get_secret_output(
+    path="secret-global/mailgun",
     opts=InvokeOptions(parent=mit_open_vault_iam_role),
 )
 secret_operations_global_mit_smtp = vault.generic.get_secret_output(
@@ -435,8 +435,8 @@ sensitive_heroku_vars = {
     "GITHUB_ACCESS_TOKEN": secret_mit_open_global_odlbot_github_access_token.data.apply(
         lambda data: "{}".format(data["value"])
     ),
-    "MAILGUN_KEY": secret_operations_global_mailgun_api_key.data.apply(
-        lambda data: "{}".format(data["value"])
+    "MAILGUN_KEY": secret_global_mailgun_api_key.data.apply(
+        lambda data: "{}".format(data["api_key"])
     ),
     "MIT_WS_CERTIFICATE": secret_mit_open_global_mit_application_certificate.data.apply(
         lambda data: "{}".format(data["certificate"])

--- a/src/ol_infrastructure/applications/xpro/__main__.py
+++ b/src/ol_infrastructure/applications/xpro/__main__.py
@@ -285,8 +285,8 @@ auth_postgres_xpro_creds_app = vault.generic.get_secret_output(
     with_lease_start_time=False,
     opts=InvokeOptions(parent=xpro_vault_backend_role),
 )
-secret_operations_global_mailgun_api_key = vault.generic.get_secret_output(
-    path="secret-operations/global/mailgun-api-key",
+secret_global_mailgun_api_key = vault.generic.get_secret_output(
+    path="secret-global/mailgun",
     opts=InvokeOptions(parent=xpro_vault_backend_role),
 )
 
@@ -382,8 +382,8 @@ sensitive_heroku_vars = {
         )
     ),
     # Static secrets that require something more involved
-    "MAILGUN_KEY": secret_operations_global_mailgun_api_key.data.apply(
-        lambda data: "{}".format(data["value"])
+    "MAILGUN_KEY": secret_global_mailgun_api_key.data.apply(
+        lambda data: "{}".format(data["api_key"])
     ),
 }
 


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Refactor the Pulumi code to use a single reference to the Mailgun API key
