### PR TITLE
Reformat some Open key names

### DIFF
--- a/src/bridge/secrets/mitopen/secrets.production.yaml
+++ b/src/bridge/secrets/mitopen/secrets.production.yaml
@@ -3,21 +3,21 @@ ckeditor:
   environment_id: ENC[AES256_GCM,data:fmErnFVYd8PcK173EICR7mRkZPA=,iv:THFC6WCZw+TdLTtoATiXvvNmtmo/ckvym6Dc0yczQ8A=,tag:7aMUOIj5ttKYNbmy+psIFA==,type:str]
   secret_key: ENC[AES256_GCM,data:yk6u/Rc8LeceitnAQb48voShdi2shAYWH/CbbLd4p7ymDarFAvNJrtb+rv1WfL10KMwnu5zYClE1wmAf,iv:C9Si2nOmjqndsXDKMU4+r6yMYm9tR2anRi7RcCn0o4k=,tag:ixDF32IIo1oKB6TlOt66cw==,type:str]
   upload_url: ENC[AES256_GCM,data:e3Uwlt9/8D8vrW9ziBGAquC9NVqM2OXGFqu7fM88dUeKN0aiLLEK2sFm,iv:toJRY8gx7mLL83oqHaJNacE9uyiwM+jc3ykf0iymySM=,tag:bAp4MRdaTUbK9CU43qg3MQ==,type:str]
-edx-api-client:
-  id: ENC[AES256_GCM,data:7mP4mvB+E0ONPSG3NJrmVbCTuEyy+oJvsrMDhNQPLzlgTsknbH05qA==,iv:9iaPXR0cf/YGeP1Eg/fRH7zH79WIId9QVLmELyMHsGA=,tag:cP64hQBAMiee8hfmoGfhIA==,type:str]
-  secret: ENC[AES256_GCM,data:ZtRQ2CsOOvGmpXoWn3Mp+piD9INWvk6ttesLd6tCcs+z7M/jiuTzwZ6Kn+LpvLmD2SyVgJ3nnvhJqx0m/T5mhWEhdYWPf9bhii3++F6mHc3xi6V4iMnZCyU1A3YmM5DmtV6BzGyG7woMbfRfVRrT2/huwQihnjjR+nqB0qyQ9ZA=,iv:0iqpRrxW0pRJILW6tVz8YFCcIrUcZtBwPh88Fjd8t8I=,tag:zvkNhQdZqkYOzeW3LGaGIA==,type:str]
+edx_api_client:
+  id: ENC[AES256_GCM,data:o7ks0/opj3deLLeGzPyIWHGYxiRIV7G5gJDVT4Q/9WiWEPQRHEEjvQ==,iv:d352W7mdVRUE/2HQVs7xq8M4HkG6ExVqK5FdsN13DvM=,tag:Z7mbF5Kdp8oES4PTHNEaUQ==,type:str]
+  secret: ENC[AES256_GCM,data:vG1hnpjNAdPj+cCfLYLqwW6zByX8dZSyKH8U3hqtKk4VeIPw4uSPfJKMv3vRTeEtkeGGcmQGIKMl5yDkha/GFYYsXENQ2gwH/QXQVsP1HSa1Lq4SMN8Gdr3mNji59nKGcThtFwcVr+yJWwaVtwBZ/xRGUvgOS8yMhk0dhqltHiw=,iv:mWQ195MrqCE4aqja6J3HhTX6y5LO09joWPmLWMzX1Bk=,tag:anQ023ABHxKES0TDsVIMfg==,type:str]
 fastly:
   api_key: ENC[AES256_GCM,data:QJ5pAjxCYPRH9f6vTJoaED47EKFlKCxIaCUa0kB0Gm8=,iv:FsZ7goUNeL+1wrfq/hje/MjGNO2IkYm9HQ8XfbtYVko=,tag:GdTsDR3NvZTkryheG1gveg==,type:str]
-open-learning-library-client:
-  client-id: ENC[AES256_GCM,data:0JLWYT7/184leYbyYGCdzr96RjNXni2BCKGNDKZ8UzBIbY59qnK3yg==,iv:PFcAPZkESRkpMyzuwsgRCMSyLGUxsu2QtlEiIGzbAfs=,tag:Bt7a3X/FmLRBIbgBuOmbOA==,type:str]
-  client-secret: ENC[AES256_GCM,data:tZL5lS2/txyJItbBice/6vopuofDYKUgfM/2Ho5RX1w4mOe/Am3h2NGCHNufgxipUQ7TdM+zx2s/Vas2bF3KbF9C3el9w7rJdlNUJ00UDtavgESVpm+mVUl92Al7u22S2jHfGEB5TYtr+J9pP9XHKXxNQPLqmow2gsc17V7dpkg=,iv:OGKyJmKLL243/2sJ4ZvkkBkiTkAcHXbjM9pncNo/3rA=,tag:sqTSw+y1OJJHPWDjwCo7/Q==,type:str]
+open_learning_library_client:
+  client_id: ENC[AES256_GCM,data:lDy2ObFjkKmhTB7nl8Vw1DVj/FEajt923e4R72rBMXIizWsOkqoKTA==,iv:f+Lqy9nXMPLBpB48kvR761RxYQ6dlDwu3hISinD03pE=,tag:2yMqipE0XEx07V080bmVrg==,type:str]
+  client_secret: ENC[AES256_GCM,data:ZCszNQfRWuRUX8xgRwQluOmYnqZDzgIR31uDQs7S3Mp5YPw9dlbw42y9HRmlYRvtSvqNyGGsdw4tEPEGpM6p0IpzkmGD48Kuq0VryVCylbMQ5W5YqlaomvkvaDW94M7TqrSns6itCGVdJBtLfPik+pHC7HbmKE9sHjS/MKE5OCg=,iv:t2Dra/OAFgNlkoYzSRQOyNRTpFwqSdAccf3M7cz3vPk=,tag:rUdRs7JSlG0hSA+FJR/g4Q==,type:str]
 jwt_secret: ENC[AES256_GCM,data:nZwEzfPyPyaec8PATCsnIWfUZ6qCBsVnixumThDDj3CKArKODOH/mJVl5IIZGgNWgr43Mgv2Sg==,iv:cS/4XH6f8Anzco4s4bu9ZTE5ysIz5Y/B4I02b5Cj57g=,tag:tIR/foAw0YYo5MIqP6mljQ==,type:str]
 opensearch:
   http_auth: ENC[AES256_GCM,data:4kTYmtC6O+7YLYj4rYQ27z4Q2h8KcOOycF145Fu37wGVve1qUvEYX/iwsk0Bj/rYbsn3wA==,iv:iBt6OzQ49khm2NJRVdenCYMQRAX+5usDpBzW4l+ucZk=,tag:GkiSd3OGSsq2wKolkgEFzA==,type:str]
-django-secret-key: ENC[AES256_GCM,data:h/ORPizv7rgV2oXIKy8zkGqErD5Vdf7wDwiJmOYKxLivcdYkaNR1cYyQNsoI8XSBviQr0AdF3jpLvegzfOTnIw==,iv:8+OhnkZX47vkm1Ccz1WR9PBeHrHoXPqI32rYR2QxVjo=,tag:dQIafPiwTSZCy4tBW/qzlA==,type:str]
-django-status-token: ENC[AES256_GCM,data:IxlCvCdSzS4n4NiHJ5ZmWQ+gwy4JQ3C/EQEuoYqHKHa/pxbLFiKAjjHAyqopLYFYDdk5oxMifCbAYU3dtHe/WA==,iv:2B0vVnf29VdEgKvl0LH5dP2j5ZpugOXmfVmB8EfC/fQ=,tag:Nyz6TiFxzGs8Oay2klqJMg==,type:str]
-youtube-developer-key: ENC[AES256_GCM,data:5kp+5D4xwYDeJj93ZU/1urrmdXX3qoxbVMrY/JiU5hTHq/2MVAwp,iv:l76XU9DzhkdlAqsgzN4/UhTI+Ejlkd+/uuhJvNY7K7s=,tag:dS5/JdXjj20Zauo4dsUwmQ==,type:str]
-sentry-dsn: ENC[AES256_GCM,data:p4hJIzYIsOrTa2HXAEgw1IlUb6ZpgPINi5RHIpDSWx7JEcLtmuijpa2iU4MEKHe9/zHXKBebTV7e271OMsHvVq1oOlzAstaRALU2FAQnznRAexqY,iv:P9O4CKcAY+eV50n35BVEO0XiU2aT1mPtig6/MKbtzXI=,tag:MgxL7riLeOiJRAP2FkxTlw==,type:str]
+django_secret_key: ENC[AES256_GCM,data:bSusOcrIlIJXr2Y4JlKPtdCTU8ahaiwk1KLBygODZeZB+JUdSe+1AhALpEBqMsF08r71cXISNpeMfWIDyrsCGQ==,iv:W8Er1JXAVfVX/CitHYxuqDsP2IGqbALVUmWNdyvaNug=,tag:DKqEgAMXmArDoU5TwaQrcA==,type:str]
+django_status_token: ENC[AES256_GCM,data:ciwPJcc+VCxO/6u0AmEXKQ+9/fr8IulJhv7Yw2Vc70dU4Ip7Xwrug4jpuFekO1qc9pWKnItQRpoxFLcvduPUJA==,iv:1DapvheQFAZC0TMe08VisTlh2105422P/ZrKS8mxfDo=,tag:c00gnVVB7CZMh24PbGq6FA==,type:str]
+youtube_developer_key: ENC[AES256_GCM,data:FAc3Tki5ZUtPySIBKwtBYDj+TvuCgEne8cdhvOEiUg2wUh/BKHuo,iv:Qi4QcSgjhhOKOPTxIyyMzC+9aBCb1HlRPZX+EL/N5JU=,tag:iHZFRn3gRItbu+4VGEQQMw==,type:str]
+sentry_dsn: ENC[AES256_GCM,data:VbiI0aFg0dwwf/eDS3woKixeJf9g9tt5AK8n0DosteH44vNHx62qM/U6Bk0/wjL+dWkeEVxzHeAK3s/uDN0pXuakXQF/o3T6P22fGIrKVRakbmrr,iv:9TV4rjD23wLJVnxdSrTHS8JwvmSIcBJ6qxmY8VMIcog=,tag:eKIQ6X189YBwQHwyI5zDlg==,type:str]
 posthog:
   project_api_key: ENC[AES256_GCM,data:i2Mq++jx+tdXC7l33HA31E8645cGh6STZhBO11BfzDQoRIUdngBwwrnooaJ7zOM=,iv:XhasJJVR3vqLcG5VoJe7W8dZfatIXDLwIKuQEV74Ltg=,tag:LRzhYPg+eZ9dSOQDAV2iVQ==,type:str]
   personal_api_key: ENC[AES256_GCM,data:S8jJkQE5CpAFvYmL+iWqLnHIve9nAZ2KOfNPum3LqEptRs8BokB0dn0wpP7C01E=,iv:BiBJDS0djg17heMXnv0/ThaAtE74hZuiyGmwD71iB/Y=,tag:a/O/8tj6SEopr/qNdxcOvQ==,type:str]
@@ -36,8 +36,8 @@ sops:
     created_at: "2024-01-24T20:22:49Z"
     enc: vault:v1:fiuTgvlXSuwTy2UJRkMcAU9JM9Iwoyu/emfX/Ce1C1QSw/OZpZIylaa8Ldc/8IEqh+vskrolkEW5mkEO
   age: []
-  lastmodified: "2024-06-05T21:17:04Z"
-  mac: ENC[AES256_GCM,data:bt5V/nq15quFP5rN/TlJ+PwQupM7LChtgAVApNH/wkkL8/olma4M/gJhkyt2rkIQPWWq+iY2AVBkhzOAtR/z07S6ELxOBd52kGlOB/yc4HOhstG6cRtepbXYVsPv2/c8Mvstyk/AXQPR5uIPPuAFRDJP2diRM4e9Jtr8z385liI=,iv:LzOea10JDIZ7Q0J9voe7SuzaNW+a7ayEv2aXpe9cexs=,tag:cZjbZP5xySCU9m3RseJooA==,type:str]
+  lastmodified: "2024-06-11T15:42:10Z"
+  mac: ENC[AES256_GCM,data:Iynf558SyLUygtUdEQhhnRADeQ7qHeufRmeRRF4Hbml091Vb+sjtX9QUzUY/NaHyYHvM94bgMiGwXl8SoaQyCKxVTd27z+oQ+coZnGt6bdW4D+VPUAfv1s8N51SlMw73nEG3plOC7NRN/RxdYvnx+hhqT2hFc6QJ6dMeKkREoHY=,iv:NzbnT4jzWKcnPgU+ivqUG60YSVE5MI/1skZrSHXGz4M=,tag:k3AhyH/e/XMUVFf2TVthvg==,type:str]
   pgp:
   - created_at: "2024-01-24T20:22:49Z"
     enc: |-

--- a/src/bridge/secrets/mitopen/secrets.qa.yaml
+++ b/src/bridge/secrets/mitopen/secrets.qa.yaml
@@ -3,22 +3,22 @@ ckeditor:
   environment_id: ENC[AES256_GCM,data:FdUizcS7xpM/dpOcjQZBfaOm4R0=,iv:/VZZISKYwqW/A9dRUlUvRChZ9OE1+jiiojz0ABVsv2k=,tag:aZ1oYyptoIj7hI0FtRWQdg==,type:str]
   secret_key: ENC[AES256_GCM,data:JklRuOIOmUDWFG63EU9Zv4Vada7SGwd69MVuGtOgyCC2caBiQME2sOtWfNFVM/6AXkiUVahzLgCF4PuR,iv:uzcwRycKaAYx++kd6BJZcK4WbnQEL+wbmdSCO+LV0Bk=,tag:hojtIjnzhHDW+JmDsQkO5A==,type:str]
   upload_url: ENC[AES256_GCM,data:e3Uwlt9/8D8vrW9ziBGAquC9NVqM2OXGFqu7fM88dUeKN0aiLLEK2sFm,iv:toJRY8gx7mLL83oqHaJNacE9uyiwM+jc3ykf0iymySM=,tag:bAp4MRdaTUbK9CU43qg3MQ==,type:str]
-edx-api-client:
-  id: ENC[AES256_GCM,data:7mP4mvB+E0ONPSG3NJrmVbCTuEyy+oJvsrMDhNQPLzlgTsknbH05qA==,iv:9iaPXR0cf/YGeP1Eg/fRH7zH79WIId9QVLmELyMHsGA=,tag:cP64hQBAMiee8hfmoGfhIA==,type:str]
-  secret: ENC[AES256_GCM,data:ZtRQ2CsOOvGmpXoWn3Mp+piD9INWvk6ttesLd6tCcs+z7M/jiuTzwZ6Kn+LpvLmD2SyVgJ3nnvhJqx0m/T5mhWEhdYWPf9bhii3++F6mHc3xi6V4iMnZCyU1A3YmM5DmtV6BzGyG7woMbfRfVRrT2/huwQihnjjR+nqB0qyQ9ZA=,iv:0iqpRrxW0pRJILW6tVz8YFCcIrUcZtBwPh88Fjd8t8I=,tag:zvkNhQdZqkYOzeW3LGaGIA==,type:str]
+edx_api_client:
+  id: ENC[AES256_GCM,data:APLHYbwzYAtBv6dTFubbRHkkh7JpWdU83apMr1hmLFZFT+J9Esd13g==,iv:A9y6ZMi+6yT55MMBJHbi+7erFVKfYZTVeOUCBuq9IPE=,tag:VghhyscWTCEFFGfARyxvrw==,type:str]
+  secret: ENC[AES256_GCM,data:wRwrr7GCEtWtCUTHWMhK8zqqoYTOjh8ZkDTpG66HvKcvgRwuLRXeFlmTkiUSZrZ5+Sq+OUjJEt2739p9SRwF5btbA0HJRQImgYVqDAzRf2uWhTNvi0bjwlUF9qCIzkAN1150OphiIj4qMWnSKL5kQaisSrNJekFNkI5DMlU7wlY=,iv:4t795dZRav9JQ3i9UMpN++cw3syb+gzbcps5Q4m/PFE=,tag:wf0QgMtwzu3uTsNvdmWAJQ==,type:str]
 fastly:
   api_key: ENC[AES256_GCM,data:bGbB+uLsHoNKwajWhYuJWWPLWNHSEaL7nN1ff982vA8=,iv:vQbab9r+nA9TmGrsgnFoDrhwlKfD4CX9cvzB2JMWYWs=,tag:JEw6U+Tq19lUSyUZC2YZ2w==,type:str]
-open-learning-library-client:
-  client-id: ENC[AES256_GCM,data:0JLWYT7/184leYbyYGCdzr96RjNXni2BCKGNDKZ8UzBIbY59qnK3yg==,iv:PFcAPZkESRkpMyzuwsgRCMSyLGUxsu2QtlEiIGzbAfs=,tag:Bt7a3X/FmLRBIbgBuOmbOA==,type:str]
-  client-secret: ENC[AES256_GCM,data:ihXRlkH7VelFLLGNOz22g221R3+5giK5ykfLVm7K4RH+nH/81P79Wl4A9E7rK/ABA1aQD7ea+Te0rvOMu0tJXR924zl7PFIG2iuoZEIaf+254Wn8fKu0LLNcBMS+AP+L/SV8+9KDiJy6b+yalYfQNnrzQ6xydbfoXLRikJEMHGo=,iv:YEbWf/fnCc8tIo7tz+IAb3AMhMYAKuHmMpoJq4q5b2A=,tag:kB9egwbSDHc54SHEOckYqQ==,type:str]
-oidc-secret-key: ENC[AES256_GCM,data:IrEX2TO79HwVwFvKK64gnmUxLbFhgg6GX4JKbgBJ5lc=,iv:OB6w6goNfu5a1huWf1OswNAlr1IC1Uxec05L+UwXyY0=,tag:SY/BOXL49OWyC08PpxNLiA==,type:str]
+open_learning_library_client:
+  client_id: ENC[AES256_GCM,data:R3LxOgxBqEq41JgwgyMr7Zi7dMADSwN4AOQijc+4xDp9rgozT0SzuA==,iv:ech9Q6z/TxAIjwJFnf87vyyxUEiBslLUK42C9i4IM6U=,tag:hgER0NpzOl5p2zwBnpfoig==,type:str]
+  client_secret: ENC[AES256_GCM,data:zxQc9QCyr2MUPMUUH8lr1V3vaK7u4t7Om6mhDb/jePVWEQvikabhcll4tbxKhOjbnpEaqpr/YkF+PGmd9mjBiXv2XH/vEDTKBO91JqGX2brPpfCibm26DLuT4x6ArRrWzxXRqfXwL10OYDqxlcKPsXZ8vehCQMRe94hPJgdEEYA=,iv:Nj6ZX32b4yn29/Lw1LmlKlBDvR86w8n9ct2MaM+YCOg=,tag:v7HFtaM1Ydj/evMhl5FDkg==,type:str]
+oidc_secret_key: ENC[AES256_GCM,data:QWdeGug5hUUF0WRpaVOkqZQYUjte91TW6ym05bbUVIo=,iv:owGl7uac5cx1L29XD5Ls22qJrftd6i4GEP9eRGcwkIM=,tag:ftobz6E3WXRlEbgUj+u49Q==,type:str]
 jwt_secret: ENC[AES256_GCM,data:sU7R/ks9gJB0Me6+cVp4vFzXTBrfQcfnT+XzYRrxZ+zAIX/NquCNd6IXZqAzD19yZgdYWBUSyA==,iv:rQEwVZxZ/3yXXVAXscb/xz2OWjCWDw2gwqH5smRolY0=,tag:alyk9JYqv0Neui9M/3jLCQ==,type:str]
 opensearch:
   http_auth: ENC[AES256_GCM,data:QiJpzdCxDFctflpnT+DzI+o1n2OZttrq4rj0bHrxE9+l99V2UmFFPuhmc9MSj4Jsj1HSXvU=,iv:gT37cRdyjN4KLpmVilnL/ZfuihfxTXo9PhADJ9yZNms=,tag:kgulSMeZ6oGiJQ3wTmu3Kw==,type:str]
-django-secret-key: ENC[AES256_GCM,data:Q0Z22Dr2oF0Te8nycpc5kaeWEh27Mctw7mIFbqpdqfTDZha6PVzQfBKZvi87gqp/uH77xgAz1y7qkDVqDyPiLQ==,iv:n744BChkDYe4yJRhpgnRQa6LvQ4bxL0P326QG6j+iPA=,tag:7HuROxzr0flAZzmTyuhGXQ==,type:str]
-django-status-token: ENC[AES256_GCM,data:b0cwhG9KGkqHqQTm3mdE9sM6EgSMgLwoEbNR0VMcUBH8VeSqh31ewU3Swfim4rfFF8YDRSBFBm0SY4p7T3hmeg==,iv:VFrOgqMWGvfWvL5GrD011tL0ybGfQIqxvQDgujyHIQY=,tag:KwhzkeMEa9YZnTRv0KHBHg==,type:str]
-youtube-developer-key: ENC[AES256_GCM,data:5kp+5D4xwYDeJj93ZU/1urrmdXX3qoxbVMrY/JiU5hTHq/2MVAwp,iv:l76XU9DzhkdlAqsgzN4/UhTI+Ejlkd+/uuhJvNY7K7s=,tag:dS5/JdXjj20Zauo4dsUwmQ==,type:str]
-sentry-dsn: ENC[AES256_GCM,data:tN074XDC4h/kejS6Fe4c1RWUR8be3yirk6j1iBSDHIgY2g9lx+DTM5JOllhNOkekTl+8ZAUxz9Nhg6jXulB3+bkrQwvvwu5HLPFKTXviflQN4f1v,iv:3l+MSYNV/g9tapr3rX2q8LQG+iNEPEe7qU3CX4e3LGo=,tag:W06u7dRs2GFb6CLo0y9AVQ==,type:str]
+django_secret_key: ENC[AES256_GCM,data:2JWprsQmPYvYYCouqxMwOQN8skt+K/iihYXkVDOsycILZb0rDtKJJI2WQbUcNdxnLQ9wYLD09Y4EgWdKHcfXww==,iv:Iw9pE+J2ESanzOrrnK+4o+kt4HNTWmpDUquQNaV/iXE=,tag:sZpd+8ethz9u04bXZqzHOg==,type:str]
+django_status_token: ENC[AES256_GCM,data:PyMuKhs5ReS2ZPDa2edzTh5GNBqN0RTBuOv7QmRiZ5NzSfWpCfLD6hEGym9V+5w8q4MI7OGj1e0yz7Lbr4VX4A==,iv:qd+GsJ8I3Ezmyiep4yPmRapM2G3zsWWedUufFLM0BPQ=,tag:KvfpKEC6slJvE3SU6QDQTw==,type:str]
+youtube_developer_key: ENC[AES256_GCM,data:kFJOsxjVmCBXX3xy5fMJl1P6y6HoOowOEBcnXkld6Bmp3uHcZ5Yc,iv:LobZJjeCCbcsyQWuEfOreCCJMR7YsH2YGGdzd2pLybk=,tag:HYY6b+Swlq/ivl2ADHYwGg==,type:str]
+sentry_dsn: ENC[AES256_GCM,data:Efobi0O0ni5vnTp5B/lt48hn67E7vNX0ii+Kbn9uvlAtfE+X2v8UNVL8oSToHTwU1Z79LztJ0o/qT7GVEy43rNDj9kLRTSNO25VD9Shd71S6/jAY,iv:sVM02Ol4nXTySDfJGQLFD8jeupW+Pcm5l0nGqNGVJcA=,tag:i5sEYFWiTr6MKxMk/DU+uA==,type:str]
 posthog:
   project_api_key: ENC[AES256_GCM,data:w9ZKltonqKd8WzJ7Drx2JPw4WPbw5Acm64NNha8mijUbfYCTofCqNdwBaaFjupI=,iv:CxSdoxoxbWKXTGnE9NljyzYZGS27dmo1QwL0jdrm2/o=,tag:mH6+Wj35PeKbBbZfmUQhtA==,type:str]
   personal_api_key: ENC[AES256_GCM,data:1Z1s+KBvZ8OkvYvdvLNip+IkFwNhO8E2kfTqmoUwJaGav2WgqlUm9CQvVJVwE2g=,iv:1XH4EH72MSzGdPUfQkGhqpmaWEfrOTCg4rQV6GBIBsY=,tag:VUsF4DFLeMT1p/nCGaUONg==,type:str]
@@ -37,8 +37,8 @@ sops:
     created_at: "2024-01-24T20:21:18Z"
     enc: vault:v1:eDAp5xqP31vCqxaHCXojM4jwtr7GBYFZ3hghLFMk71NRu5jjanIIr1ZgZ+Vb2sJLV7qFmgWYO6GVPxy+
   age: []
-  lastmodified: "2024-06-05T21:16:45Z"
-  mac: ENC[AES256_GCM,data:7blxymkwoQGwo2NYQudgg7/k+E8oR+RA1CTuoC/0fYHD5Bz7j8/vjQFzOs67xpuDLEfGX4WdoSLM2+mXd+bbgvoIESo2V1BHwlpZ5QF8Pqpxnfsykial0Ptde7yWkZhxT2RGRI4qntnKy11dYUAxa79tknUH+k8kF3XVapL/GzU=,iv:AtVTfOSVzOcCgQU1Juyl0AnoO6i9+eQhqMW15QFwv38=,tag:9KqclDkFH2SJDV7rAewPLQ==,type:str]
+  lastmodified: "2024-06-11T15:41:18Z"
+  mac: ENC[AES256_GCM,data:3NQqqkiDv9rn6TKzhlkMpXxYVrkV/6wjq8XvmRksGNmwgG6VHVBHXPFdREawcoDYNy8br9z4r5OQe7qkMj2Q1qpA8OVGwaiBg8tFBgM+tZH3C/4l7RRWBI3ZZTajPjsdtE/WA3HKI5aKQMaet1MAe3KfVinsA2ihMxhqtwA/IVo=,iv:sE8kV3MLBV0Am0lVXr5FEufRLZCl8i/6DZUbI133xiw=,tag:B+ov39qCju8LP1YEEmiwbw==,type:str]
   pgp:
   - created_at: "2024-01-24T20:21:18Z"
     enc: |-

--- a/src/ol_infrastructure/applications/mitopen/__main__.py
+++ b/src/ol_infrastructure/applications/mitopen/__main__.py
@@ -703,20 +703,20 @@ sensitive_heroku_vars = {
     "CKEDITOR_ENVIRONMENT_ID": mitopen_vault_secrets["ckeditor"]["environment_id"],
     "CKEDITOR_SECRET_KEY": mitopen_vault_secrets["ckeditor"]["secret_key"],
     "CKEDITOR_UPLOAD_URL": mitopen_vault_secrets["ckeditor"]["upload_url"],
-    "EDX_API_CLIENT_ID": mitopen_vault_secrets["edx-api-client"]["id"],
-    "EDX_API_CLIENT_SECRET": mitopen_vault_secrets["edx-api-client"]["secret"],
+    "EDX_API_CLIENT_ID": mitopen_vault_secrets["edx_api_client"]["id"],
+    "EDX_API_CLIENT_SECRET": mitopen_vault_secrets["edx_api_client"]["secret"],
     "MITOPEN_JWT_SECRET": mitopen_vault_secrets["jwt_secret"],
-    "OLL_API_CLIENT_ID": mitopen_vault_secrets["open-learning-library-client"][
-        "client-id"
+    "OLL_API_CLIENT_ID": mitopen_vault_secrets["open_learning_library_client"][
+        "client_id"
     ],
-    "OLL_API_CLIENT_SECRET": mitopen_vault_secrets["open-learning-library-client"][
-        "client-secret"
+    "OLL_API_CLIENT_SECRET": mitopen_vault_secrets["open_learning_library_client"][
+        "client_secret"
     ],
     "OPENSEARCH_HTTP_AUTH": mitopen_vault_secrets["opensearch"]["http_auth"],
-    "SECRET_KEY": mitopen_vault_secrets["django-secret-key"],
-    "SENTRY_DSN": mitopen_vault_secrets["sentry-dsn"],
-    "STATUS_TOKEN": mitopen_vault_secrets["django-status-token"],
-    "YOUTUBE_DEVELOPER_KEY": mitopen_vault_secrets["youtube-developer-key"],
+    "SECRET_KEY": mitopen_vault_secrets["django_secret_key"],
+    "SENTRY_DSN": mitopen_vault_secrets["sentry_dsn"],
+    "STATUS_TOKEN": mitopen_vault_secrets["django_status_token"],
+    "YOUTUBE_DEVELOPER_KEY": mitopen_vault_secrets["youtube_developer_key"],
     "POSTHOG_PROJECT_API_KEY": mitopen_vault_secrets["posthog"]["project_api_key"],
     "POSTHOG_PERSONAL_API_KEY": mitopen_vault_secrets["posthog"]["personal_api_key"],
     # Vars that require more


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Related to work on https://github.com/mitodl/ol-infrastructure/issues/2454

### Description (What does it do?)
<!--- Describe your changes in detail -->
Some of the key names have dashes instead of underscores and when trying to use the vault agent templating, that was throwing errors. It's a known [issue](https://support.hashicorp.com/hc/en-us/articles/15667022913299-Vault-Agent-throws-bad-character-U-002D) and the recommendation is to use underscores, otherwise we would need to do a few workarounds which would be confusing down the line, so better to fix it now.

