### PR TITLE
Updating OPEN_CATALOG_URLS

### DIFF
--- a/src/ol_infrastructure/applications/ocw_studio/Pulumi.applications.ocw_studio.Production.yaml
+++ b/src/ol_infrastructure/applications/ocw_studio/Pulumi.applications.ocw_studio.Production.yaml
@@ -35,7 +35,7 @@ config:
     OCW_STUDIO_LIVE_URL: https://ocw.mit.edu/
     OCW_STUDIO_LOG_LEVEL: INFO
     OCW_STUDIO_SUPPORT_EMAIL: 'ocw-studio-support@mit.edu'
-    OPEN_CATALOG_URLS: 'https://open.mit.edu/api/v0/ocw_next_webhook/,https://mitopen.odl.mit.edu/api/v1/ocw_next_webhook/'
+    OPEN_CATALOG_URLS: 'https://open.mit.edu/api/v0/ocw_next_webhook/,https://api.mitopen.odl.mit.edu/api/v1/ocw_next_webhook/'
     SEARCH_API_URL: 'https://open.mit.edu/api/v0/search/'
     SENTRY_LOG_LEVEL: 'WARN'
     SITEMAP_DOMAIN: 'ocw.mit.edu'

--- a/src/ol_infrastructure/applications/ocw_studio/Pulumi.applications.ocw_studio.QA.yaml
+++ b/src/ol_infrastructure/applications/ocw_studio/Pulumi.applications.ocw_studio.QA.yaml
@@ -35,7 +35,7 @@ config:
     OCW_STUDIO_LIVE_URL: https://live-qa.ocw.mit.edu/
     OCW_STUDIO_LOG_LEVEL: INFO
     OCW_STUDIO_SUPPORT_EMAIL: 'ocw-studio-rc-support@mit.edu'
-    OPEN_CATALOG_URLS: 'https://discussions-rc.odl.mit.edu/api/v0/ocw_next_webhook/,https://mitopen-rc.odl.mit.edu/api/v1/ocw_next_webhook/'
+    OPEN_CATALOG_URLS: 'https://discussions-rc.odl.mit.edu/api/v0/ocw_next_webhook/,https://api.mitopen-rc.odl.mit.edu/api/v1/ocw_next_webhook/'
     SEARCH_API_URL: 'https://discussions-rc.odl.mit.edu/api/v0/search/'
     SENTRY_LOG_LEVEL: 'WARN'
     SITEMAP_DOMAIN: 'live-qa.ocw.mit.edu'


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/ol-infrastructure/issues/2482.

### Description (What does it do?)
This PR updates the `OPEN_CATALOG_URLS` values to the recently-updated URLs for the API.

### How can this be tested?
Verify that the URLs are correct; the deployment can be tested via Pulumi.
