### PR TITLE
config: Add Heroku app configs to Leek for monitoring

### DIFF
--- a/src/ol_infrastructure/applications/celery_monitoring/Pulumi.applications.celery_monitoring.CI.yaml
+++ b/src/ol_infrastructure/applications/celery_monitoring/Pulumi.applications.celery_monitoring.CI.yaml
@@ -2,18 +2,26 @@
 secretsprovider: awskms://alias/infrastructure-secrets-ci
 encryptedkey: AQICAHjnbqe9AmEW1Js10nySybyuAG7Fb5E9EHUgkmqFDv7PxQGJ3TnWvhlQQrGyE2EnakrrAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMLHRA6TjX63WMbvebAgEQgDvYwi1/1THyTliMz0gtC5QFMM5n3CEegQjUf4ex2KMBS2cfl45cyxYnMRC30v/+rl+oTap57E0YNCks7A==
 config:
-  consul:address: https://consul-operations-ci.odl.mit.edu
-  consul:scheme: https
-  opensearch:consul_service_name: 'celery-monitoring-opensearch'
-  environment:business_unit: operations
-  environment:target_vpc: operations_vpc
-  opensearch:domain_name: "celeryc"
-  celery_monitoring:sender_email_address: ol-devops@mit.edu
   aws:region: us-east-1
   celery_monitoring:auto_scale:
     desired: 1
     max: 2
     min: 1
-  celery_monitorng:business_unit: operations
-  celery_monitoring:target_vpc: operations_vpc
   celery_monitoring:domain: celery-monitoring-ci.odl.mit.edu
+  celery_monitoring:sender_email_address: ol-devops@mit.edu
+  celery_monitoring:target_vpc: operations_vpc
+  celery_monitorng:business_unit: operations
+  consul:address: https://consul-operations-ci.odl.mit.edu
+  consul:scheme: https
+  environment:business_unit: operations
+  environment:target_vpc: operations_vpc
+  opensearch:consul_service_name: 'celery-monitoring-opensearch'
+  opensearch:domain_name: "celeryc"
+  celery_monitoring:heroku_map:
+    mitx-devops:
+    - bootcamp-ecommerce-ci
+    - micromasters-ci
+    - ocw-studio-ci
+    - xpro-ci
+    odl-devops:
+    - odl-open-discussions-ci

--- a/src/ol_infrastructure/applications/celery_monitoring/Pulumi.applications.celery_monitoring.Production.yaml
+++ b/src/ol_infrastructure/applications/celery_monitoring/Pulumi.applications.celery_monitoring.Production.yaml
@@ -2,11 +2,22 @@
 secretsprovider: awskms://alias/infrastructure-secrets-production
 encryptedkey: AQICAHiiGjYUolrtj8PCnScLM7oLAdMl8nJrLjQjnqyl1LykYgEdGy9xAEuhd2us5xqrOlxoAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMXK6sZZn1tdLfTZF4AgEQgDuzHB/a0s/gLtTCImB7e/shVdAOnQ/PbHwrAz1nhI6M8pc3O8GO+0o4xZwRxIIQA81Ynw6+tuR57IIW1A==
 config:
+  celery_monitoring:domain: celery-monitoring.odl.mit.edu
+  celery_monitoring:sender_email_address: ol-devops@mit.edu
   consul:address: https://consul-operations-production.odl.mit.edu
   consul:scheme: https
-  opensearch:consul_service_name: 'celery-monitoring-opensearch'
   environment:business_unit: operations
   environment:target_vpc: operations_vpc
+  opensearch:consul_service_name: 'celery-monitoring-opensearch'
   opensearch:domain_name: "celeryp"
-  celery_monitoring:sender_email_address: ol-devops@mit.edu
-  celery_monitoring:domain: celery-monitoring.odl.mit.edu
+  celery_monitoring:heroku_map:
+    mitx-devops:
+    - bootcamp-ecommerce
+    - micromasters
+    - ocw-studio
+    - xpro-production
+    odl-devops:
+    - mitxonline-production
+    - odl-open-discussions
+    ol-engineering-finance:
+    - mitopen-production

--- a/src/ol_infrastructure/applications/celery_monitoring/Pulumi.applications.celery_monitoring.QA.yaml
+++ b/src/ol_infrastructure/applications/celery_monitoring/Pulumi.applications.celery_monitoring.QA.yaml
@@ -2,11 +2,22 @@
 secretsprovider: awskms://alias/infrastructure-secrets-qa
 encryptedkey: AQICAHg42pDDDGBhpaX14TdtzcK1hbiMYTHsYRH4k5GL5RFpIwF2/DtEoBk3QwV16pe6zwFoAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM3iu2yMHQBIuj93iqAgEQgDuF+IIz5NYwrJRmNl9HU9+js6+Ma/bRa02O0UpiL+WJit629gHgFBqhOthl9kfxW0dWS3OTe45zebAqFg==
 config:
+  celery_monitoring:domain: celery-monitoring-qa.odl.mit.edu
+  celery_monitoring:sender_email_address: ol-devops@mit.edu
   consul:address: https://consul-operations-qa.odl.mit.edu
   consul:scheme: https
-  opensearch:consul_service_name: 'celery-monitoring-opensearch'
   environment:business_unit: operations
   environment:target_vpc: operations_vpc
+  opensearch:consul_service_name: 'celery-monitoring-opensearch'
   opensearch:domain_name: "celeryq"
-  celery_monitoring:sender_email_address: ol-devops@mit.edu
-  celery_monitoring:domain: celery-monitoring-qa.odl.mit.edu
+  celery_monitoring:heroku_map:
+    mitx-devops:
+    - bootcamp-ecommerce-rc
+    - micromasters-rc
+    - ocw-studio-rc
+    - xpro-rc
+    odl-devops:
+    - mitxonline-rc
+    - odl-open-discussions-rc
+    ol-engineering-finance:
+    - mitopen-rc


### PR DESCRIPTION
### What are the relevant tickets?
Fixes #2473 

### Description (What does it do?)
<!--- Describe your changes in detail -->
This adds configuration of Celery brokers for Heroku apps as part of the Leek deployment by fetching the `REDISCLOUD_URL` from the application configuration.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Apply the Pulumi stack to one of the environments and verify that the broker configs are included in the Vault data.