### PR TITLE
Set YOUTUBE_FETCH_SCHEDULE_SECONDS to 4 hours on both rc and prod mitopen

### DIFF
--- a/src/ol_infrastructure/applications/mitopen/__main__.py
+++ b/src/ol_infrastructure/applications/mitopen/__main__.py
@@ -609,6 +609,7 @@ heroku_vars = {
     "XPRO_CATALOG_API_URL": "https://xpro.mit.edu/api/programs/",
     "XPRO_COURSES_API_URL": "https://xpro.mit.edu/api/courses/",
     "XPRO_LEARNING_COURSE_BUCKET_NAME": "mitx-etl-xpro-production-mitxpro-production",
+    "YOUTUBE_FETCH_SCHEDULE_SECONDS": 14400,
     "YOUTUBE_FETCH_TRANSCRIPT_SCHEDULE_SECONDS": 21600,
     "YOUTUBE_CONFIG_URL": "https://raw.githubusercontent.com/mitodl/open-video-data/mitopen/youtube/channels.yaml",
     "POSTHOG_ENABLED": "True",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Sets YOUTUBE_FETCH_SCHEDULE_SECONDS to 14400 seconds (4 hours) for MIT Open RC and production.

