### PR TITLE
Md/issue 2370

### DIFF
--- a/src/bilder/components/hashicorp/templates/consul-template.service.j2
+++ b/src/bilder/components/hashicorp/templates/consul-template.service.j2
@@ -9,6 +9,10 @@ Restart=on-failure
 ExecStart=/usr/local/bin/consul-template -config={{ context.configuration_directory }}
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGTERM
+{% if context.mode == "agent" and context.restart_period %}
+RuntimeMaxSec={{ context.restart_period }}
+RuntimeRandomizedExtraSec={{ context.restart_jitter }}
+{% endif %}
 User=consul-template
 Group=consul-template
 AmbientCapabilities=CAP_CHOWN CAP_FOWNER CAP_DAC_OVERRIDE CAP_KILL

--- a/src/bilder/components/hashicorp/templates/vault.service.j2
+++ b/src/bilder/components/hashicorp/templates/vault.service.j2
@@ -25,6 +25,10 @@ KillMode=process
 KillSignal=SIGINT
 Restart=on-failure
 RestartSec=5
+{% if context.mode == "agent" and context.restart_period %}
+RuntimeMaxSec={{ context.restart_period }}
+RuntimeRandomizedExtraSec={{ context.restart_jitter }}
+{% endif %}
 TimeoutStopSec=30
 StartLimitInterval=60
 StartLimitBurst=3

--- a/src/bilder/images/airbyte/deploy.py
+++ b/src/bilder/images/airbyte/deploy.py
@@ -254,6 +254,8 @@ vault_config = VaultAgentConfig(
         ),
         sink=[VaultAutoAuthSink(type="file", config=[VaultAutoAuthFileSink()])],
     ),
+    restart_period="5d",
+    restart_jitter="12h",
 )
 vault = Vault(
     version=VERSIONS["vault"],
@@ -283,6 +285,8 @@ consul_template = ConsulTemplate(
         Path("00-default.json"): ConsulTemplateConfig(
             vault=ConsulTemplateVaultConfig(),
             template=consul_templates,
+            restart_period="7d",
+            restart_jitter="12h",
         )
     },
 )

--- a/src/bilder/images/celery_monitoring/deploy.py
+++ b/src/bilder/images/celery_monitoring/deploy.py
@@ -160,6 +160,8 @@ consul_template = ConsulTemplate(
         Path("00-default.json"): ConsulTemplateConfig(
             vault=ConsulTemplateVaultConfig(),
             template=consul_templates,
+            restart_period="7d",
+            restart_jitter="12h",
         )
     },
 )

--- a/src/bilder/images/dagster/deploy.py
+++ b/src/bilder/images/dagster/deploy.py
@@ -261,6 +261,8 @@ consul_template = ConsulTemplate(
         Path("00-default.json"): ConsulTemplateConfig(
             vault=ConsulTemplateVaultConfig(),
             template=consul_templates,
+            restart_period="7d",
+            restart_jitter="12h",
         )
     },
 )

--- a/src/bilder/images/docker_baseline_ami/deploy.py
+++ b/src/bilder/images/docker_baseline_ami/deploy.py
@@ -54,6 +54,8 @@ vault_config = VaultAgentConfig(
         address=f"https://active.vault.service.consul:{VAULT_HTTP_PORT}",
         tls_skip_verify=True,
     ),
+    restart_period="5d",
+    restart_jitter="12h",
 )
 vault = Vault(
     version=VERSIONS["vault"],

--- a/src/bilder/images/edx_notes/deploy.py
+++ b/src/bilder/images/edx_notes/deploy.py
@@ -184,6 +184,8 @@ consul_template = ConsulTemplate(
         Path("00-default.json"): ConsulTemplateConfig(
             vault=ConsulTemplateVaultConfig(),
             template=consul_templates,
+            restart_period="7d",
+            restart_jitter="12h",
         )
     },
 )

--- a/src/bilder/images/edxapp_v2/deploy.py
+++ b/src/bilder/images/edxapp_v2/deploy.py
@@ -444,6 +444,8 @@ consul_template = ConsulTemplate(
         Path("00-default.json"): ConsulTemplateConfig(
             vault=ConsulTemplateVaultConfig(),
             template=consul_templates,
+            restart_period="7d",
+            restart_jitter="12h",
         )
     },
 )

--- a/src/bilder/images/forum/deploy.py
+++ b/src/bilder/images/forum/deploy.py
@@ -164,6 +164,8 @@ consul_template = ConsulTemplate(
         Path("00-default.json"): ConsulTemplateConfig(
             vault=ConsulTemplateVaultConfig(),
             template=consul_templates,
+            restart_period="7d",
+            restart_jitter="12h",
         )
     },
 )

--- a/src/bilder/images/keycloak/deploy.py
+++ b/src/bilder/images/keycloak/deploy.py
@@ -184,6 +184,8 @@ consul_template = ConsulTemplate(
         Path("00-default.json"): ConsulTemplateConfig(
             vault=ConsulTemplateVaultConfig(),
             template=consul_templates,
+            restart_period="7d",
+            restart_jitter="12h",
         )
     },
 )

--- a/src/bilder/images/odl_video_service/deploy.py
+++ b/src/bilder/images/odl_video_service/deploy.py
@@ -252,6 +252,8 @@ consul_template = ConsulTemplate(
         Path("00-default.json"): ConsulTemplateConfig(
             vault=ConsulTemplateVaultConfig(),
             template=consul_templates,
+            restart_period="7d",
+            restart_jitter="12h",
         )
     },
 )

--- a/src/bilder/images/redash/deploy.py
+++ b/src/bilder/images/redash/deploy.py
@@ -321,6 +321,8 @@ vault_config = VaultAgentConfig(
         ),
         sink=[VaultAutoAuthSink(type="file", config=[VaultAutoAuthFileSink()])],
     ),
+    restart_period="7h",
+    restart_jitter="12h",
 )
 vault = Vault(
     version=VERSIONS["vault"],
@@ -334,6 +336,8 @@ consul_template = ConsulTemplate(
         Path("00-default.json"): ConsulTemplateConfig(
             vault=ConsulTemplateVaultConfig(),
             template=consul_templates,
+            restart_period="5d",
+            restart_jitter="12d",
         )
     },
 )

--- a/src/bilder/images/semantic/deploy.py
+++ b/src/bilder/images/semantic/deploy.py
@@ -122,6 +122,8 @@ consul_template = ConsulTemplate(
         Path("00-default.json"): ConsulTemplateConfig(
             vault=ConsulTemplateVaultConfig(),
             template=consul_templates,
+            restart_period="7d",
+            restart_jitter="12h",
         )
     },
 )

--- a/src/bilder/images/xqueue/deploy.py
+++ b/src/bilder/images/xqueue/deploy.py
@@ -162,6 +162,8 @@ consul_template = ConsulTemplate(
         Path("00-default.json"): ConsulTemplateConfig(
             vault=ConsulTemplateVaultConfig(),
             template=consul_templates,
+            restart_period="7d",
+            restart_jitter="12h",
         )
     },
 )

--- a/src/bilder/images/xqwatcher/deploy.py
+++ b/src/bilder/images/xqwatcher/deploy.py
@@ -401,6 +401,8 @@ consul_template_configuration = {
                 perms="0600",
             ),
         ],
+        restart_period="7d",
+        restart_jitter="12h",
     ),
 }
 consul_template = ConsulTemplate(

--- a/src/bilder/lib/model_helpers.py
+++ b/src/bilder/lib/model_helpers.py
@@ -1,5 +1,12 @@
+import re
+from typing import Any, Union
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class OLBaseSettings(BaseSettings):
     model_config = SettingsConfigDict(case_sensitive=False)
+
+
+def parse_simple_duration_string(dur: str) -> Union[re.Match[Any], None]:
+    return re.match(r"^([1-9])\d*(m|h|d)$", dur)


### PR DESCRIPTION
### What are the relevant tickets?
#2370 

### Description (What does it do?)
This PR adds a periodic restart option to vault-agent and consul-template installations via systemd sorcery. It is configurable to include a `restart_period` + and additional amount of time `restart_jitter` so that all instances are not restarting vault-agent + consul-template at the same time. 

Additionally, this configures vault to restart slightly more often than consul-template, which is the key to getting new credentials when consul-template restarts. 


