### PR TITLE
Update OLL bucket prefix for mitopen

### DIFF
--- a/src/ol_infrastructure/applications/mitopen/__main__.py
+++ b/src/ol_infrastructure/applications/mitopen/__main__.py
@@ -592,7 +592,7 @@ heroku_vars = {
     "OCW_CONTENT_BUCKET_NAME": "ocw-content-storage",
     "OCW_UPLOAD_IMAGE_ONLY": "True",
     "OCW_LIVE_BUCKET": "ocw-content-live-production",
-    "OLL_ALT_URL": "https://openlearninglibrary.mit.edu/courses/",
+    "OLL_ALT_URL": "https://openlearninglibrary.mit.edu/courses",
     "OLL_API_ACCESS_TOKEN_URL": "https://openlearninglibrary.mit.edu/oauth2/access_token/",
     "OLL_API_URL": "https://discovery.openlearninglibrary.mit.edu/api/v1/catalogs/1/courses/",
     "OLL_BASE_URL": "https://openlearninglibrary.mit.edu/course/",


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/mit-open/pull/1008

### Description (What does it do?)
Gets rid of the trailing slash for `OLL_LEARNING_COURSE_BUCKET_PREFIX`

### Screenshots (if appropriate):
N/A

### How can this be tested?
N/A
