### PR TITLE
Md/2358 pt2

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.apps.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.apps.CI.yaml
@@ -8,7 +8,7 @@ config:
   environment:business_unit: operations
   environment:target_vpc: applications_vpc
   opensearch:cluster_size: "3"
-  opensearch:consul_service_name: opensearch
+  opensearch:disable_consul_components: true
   opensearch:disk_size_gb: "60"
   opensearch:engine_version: OpenSearch_1.1
   opensearch:instance_type: t3.medium.search

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.apps.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.apps.CI.yaml
@@ -11,6 +11,6 @@ config:
   opensearch:consul_service_name: opensearch
   opensearch:disk_size_gb: "60"
   opensearch:engine_version: OpenSearch_1.1
-  opensearch:instance_type: t3.medium.elasticsearch
+  opensearch:instance_type: t3.medium.search
   opensearch:public_web: "true"
   opensearch:secured_cluster: "true"

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.apps.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.apps.Production.yaml
@@ -8,9 +8,9 @@ config:
   environment:business_unit: operations
   environment:target_vpc: applications_vpc
   opensearch:cluster_size: "3"
-  opensearch:consul_service_name: opensearch
+  opensearch:disable_consul_components: true
   opensearch:disk_size_gb: "60"
   opensearch:engine_version: OpenSearch_1.1
-  opensearch:instance_type: t3.medium.elasticsearch
+  opensearch:instance_type: t3.medium.search
   opensearch:public_web: "true"
   opensearch:secured_cluster: "true"

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.apps.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.apps.QA.yaml
@@ -8,9 +8,9 @@ config:
   environment:business_unit: operations
   environment:target_vpc: applications_vpc
   opensearch:cluster_size: "3"
-  opensearch:consul_service_name: opensearch
+  opensearch:disable_consul_components: true
   opensearch:disk_size_gb: "60"
   opensearch:engine_version: OpenSearch_1.1
-  opensearch:instance_type: t3.medium.elasticsearch
+  opensearch:instance_type: t3.medium.search
   opensearch:public_web: "true"
   opensearch:secured_cluster: "true"

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.celery_monitoring.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.celery_monitoring.CI.yaml
@@ -12,6 +12,6 @@ config:
   opensearch:cluster_size: "3"
   opensearch:disk_size_gb: "60"
   opensearch:engine_version: "OpenSearch_2.11"
-  opensearch:instance_type: t3.medium.elasticsearch
+  opensearch:instance_type: t3.medium.search
   opensearch:public_web: "false"
   opensearch:secured_cluster: "true"

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.celery_monitoring.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.celery_monitoring.Production.yaml
@@ -12,6 +12,6 @@ config:
   opensearch:cluster_size: "3"
   opensearch:disk_size_gb: "60"
   opensearch:engine_version: "OpenSearch_2.11"
-  opensearch:instance_type: t3.medium.elasticsearch
+  opensearch:instance_type: t3.medium.search
   opensearch:public_web: "false"
   opensearch:secured_cluster: "true"

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.celery_monitoring.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.celery_monitoring.QA.yaml
@@ -12,6 +12,6 @@ config:
   opensearch:cluster_size: "3"
   opensearch:disk_size_gb: "60"
   opensearch:engine_version: "OpenSearch_2.11"
-  opensearch:instance_type: t3.medium.elasticsearch
+  opensearch:instance_type: t3.medium.search
   opensearch:public_web: "false"
   opensearch:secured_cluster: "true"

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitopen.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitopen.Production.yaml
@@ -8,9 +8,9 @@ config:
   environment:business_unit: 'mit-open'
   environment:target_vpc: applications_vpc
   opensearch:cluster_size: "3"
-  opensearch:consul_service_name: 'mitopen-opensearch'
+  opensearch:disable_consul_components: true
   opensearch:disk_size_gb: "120"
   opensearch:engine_version: "OpenSearch_2.11"
-  opensearch:instance_type: m5.large.elasticsearch
+  opensearch:instance_type: m5.large.search
   opensearch:public_web: "true"
   opensearch:secured_cluster: "true"

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitopen.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitopen.QA.yaml
@@ -8,9 +8,9 @@ config:
   environment:business_unit: 'mit-open'
   environment:target_vpc: applications_vpc
   opensearch:cluster_size: "3"
-  opensearch:consul_service_name: 'mitopen-opensearch'
+  opensearch:disable_consul_components: true
   opensearch:disk_size_gb: "60"
   opensearch:engine_version: "OpenSearch_2.11"
-  opensearch:instance_type: t3.medium.elasticsearch
+  opensearch:instance_type: t3.medium.search
   opensearch:public_web: "true"
   opensearch:secured_cluster: "true"

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitx-staging.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitx-staging.CI.yaml
@@ -5,5 +5,6 @@ config:
   aws:region: us-east-1
   consul:address: https://consul-mitx-staging-ci.odl.mit.edu
   consul:scheme: https
+  opensearch:instance_type: t3.medium.search
   environment:business_unit: residential-staging
   environment:target_vpc: residential_mitx_staging_vpc

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitx-staging.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitx-staging.Production.yaml
@@ -7,3 +7,4 @@ config:
   consul:scheme: https
   environment:business_unit: residential-staging
   environment:target_vpc: residential_mitx_staging_vpc
+  opensearch:instance_type: t3.medium.search

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitx-staging.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitx-staging.QA.yaml
@@ -5,5 +5,6 @@ config:
   aws:region: us-east-1
   consul:address: https://consul-mitx-staging-qa.odl.mit.edu
   consul:scheme: https
+  opensearch:instance_type: t3.medium.search
   environment:business_unit: residential-staging
   environment:target_vpc: residential_mitx_staging_vpc

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitx.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitx.CI.yaml
@@ -5,5 +5,6 @@ config:
   aws:region: us-east-1
   consul:address: https://consul-mitx-ci.odl.mit.edu
   consul:scheme: https
+  opensearch:instance_type: t3.medium.search
   environment:business_unit: residential
   environment:target_vpc: residential_mitx_vpc

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitx.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitx.Production.yaml
@@ -7,3 +7,4 @@ config:
   consul:scheme: https
   environment:business_unit: residential
   environment:target_vpc: residential_mitx_vpc
+  opensearch:instance_type: t3.medium.search

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitx.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitx.QA.yaml
@@ -5,5 +5,6 @@ config:
   aws:region: us-east-1
   consul:address: https://consul-mitx-qa.odl.mit.edu
   consul:scheme: https
+  opensearch:instance_type: t3.medium.search
   environment:business_unit: residential
   environment:target_vpc: residential_mitx_vpc

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitxonline.Production.yaml
@@ -5,5 +5,6 @@ config:
   aws:region: us-east-1
   consul:address: https://consul-mitxonline-production.odl.mit.edu
   consul:scheme: https
+  opensearch:instance_type: t3.medium.search
   environment:business_unit: mitxonline
   environment:target_vpc: mitxonline_vpc

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitxonline.QA.yaml
@@ -7,3 +7,4 @@ config:
   consul:scheme: https
   environment:business_unit: mitxonline
   environment:target_vpc: mitxonline_vpc
+  opensearch:instance_type: t3.medium.search

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.open.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.open.CI.yaml
@@ -11,6 +11,6 @@ config:
   opensearch:consul_service_name: 'mitopen-search'
   opensearch:disk_size_gb: "60"
   opensearch:engine_version: "OpenSearch_1.3"
-  opensearch:instance_type: t3.medium.elasticsearch
+  opensearch:instance_type: t3.medium.search
   opensearch:public_web: "true"
   opensearch:secured_cluster: "true"

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.open.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.open.Production.yaml
@@ -8,9 +8,9 @@ config:
   environment:business_unit: 'mit-open'
   environment:target_vpc: applications_vpc
   opensearch:cluster_size: "3"
-  opensearch:consul_service_name: 'mitopen-search'
+  opensearch:disable_consul_components: true
   opensearch:disk_size_gb: "120"
   opensearch:engine_version: "OpenSearch_1.3"
-  opensearch:instance_type: m5.large.elasticsearch
+  opensearch:instance_type: m5.large.search
   opensearch:public_web: "true"
   opensearch:secured_cluster: "true"

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.open.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.open.QA.yaml
@@ -8,9 +8,9 @@ config:
   environment:business_unit: 'mit-open'
   environment:target_vpc: applications_vpc
   opensearch:cluster_size: "3"
-  opensearch:consul_service_name: 'mitopen-search'
+  opensearch:disable_consul_components: true
   opensearch:disk_size_gb: "120"
   opensearch:engine_version: "OpenSearch_1.3"
-  opensearch:instance_type: t3.medium.elasticsearch
+  opensearch:instance_type: t3.medium.search
   opensearch:public_web: "true"
   opensearch:secured_cluster: "true"

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.xpro.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.xpro.CI.yaml
@@ -7,3 +7,4 @@ config:
   consul:scheme: https
   environment:business_unit: mitxpro
   environment:target_vpc: xpro_vpc
+  opensearch:instance_type: t3.medium.search

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.xpro.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.xpro.Production.yaml
@@ -7,3 +7,4 @@ config:
   consul:scheme: https
   environment:business_unit: mitxpro
   environment:target_vpc: xpro_vpc
+  opensearch:instance_type: t3.medium.search

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.xpro.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.xpro.QA.yaml
@@ -7,3 +7,4 @@ config:
   consul:scheme: https
   environment:business_unit: mitxpro
   environment:target_vpc: xpro_vpc
+  opensearch:instance_type: t3.medium.search

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/__main__.py
@@ -1,4 +1,4 @@
-# ruff: noqa: ERA001, E501
+# ruff: noqa: E501
 
 from pathlib import Path
 
@@ -47,7 +47,7 @@ target_vpc = network_stack.require_output(env_config.require("target_vpc"))
 business_unit = env_config.get("business_unit") or "operations"
 aws_config = AWSBase(tags={"OU": business_unit, "Environment": environment_name})
 cluster_size = search_config.get_int("cluster_size") or 3
-cluster_instance_type = search_config.get("instance_type") or "t3.medium.elasticsearch"
+cluster_instance_type = search_config.get("instance_type") or "t3.medium.search"
 disk_size = search_config.get_int("disk_size_gb") or 30
 is_public_web = search_config.get_bool("public_web") or False
 is_secured_cluster = search_config.get_bool("secured_cluster") or False
@@ -97,34 +97,34 @@ if is_public_web:
         )
     )["master_user_password"]
     conditional_kwargs["advanced_security_options"] = (
-        aws.elasticsearch.DomainAdvancedSecurityOptionsArgs(
+        aws.opensearch.DomainAdvancedSecurityOptionsArgs(
             enabled=True,
             internal_user_database_enabled=True,
-            master_user_options=aws.elasticsearch.DomainAdvancedSecurityOptionsMasterUserOptionsArgs(
+            master_user_options=aws.opensearch.DomainAdvancedSecurityOptionsMasterUserOptionsArgs(
                 master_user_name="opensearch",
                 master_user_password=master_user_password,
             ),
         )
     )
 else:
-    conditional_kwargs["vpc_options"] = aws.elasticsearch.DomainVpcOptionsArgs(
+    conditional_kwargs["vpc_options"] = aws.opensearch.DomainVpcOptionsArgs(
         subnet_ids=target_vpc["subnet_ids"][:3],
         security_group_ids=[search_security_group.id],
     )
 
 if is_secured_cluster:
     conditional_kwargs["domain_endpoint_options"] = (
-        aws.elasticsearch.DomainDomainEndpointOptionsArgs(
+        aws.opensearch.DomainDomainEndpointOptionsArgs(
             enforce_https=True,
             tls_security_policy="Policy-Min-TLS-1-2-2019-07",
         )
     )
     conditional_kwargs["node_to_node_encryption"] = (
-        aws.elasticsearch.DomainNodeToNodeEncryptionArgs(
+        aws.opensearch.DomainNodeToNodeEncryptionArgs(
             enabled=True,
         )
     )
-    conditional_kwargs["encrypt_at_rest"] = aws.elasticsearch.DomainEncryptAtRestArgs(
+    conditional_kwargs["encrypt_at_rest"] = aws.opensearch.DomainEncryptAtRestArgs(
         enabled=True,
     )
 
@@ -134,29 +134,6 @@ if search_config.get("domain_name"):
     ]
 else:
     domain_name = f"opensearch-{environment_name}"[:SEARCH_DOMAIN_NAME_MAX_LENGTH]
-
-
-# search_domain = aws.elasticsearch.Domain(
-#    "opensearch-domain-cluster",
-#    domain_name=domain_name,
-#    elasticsearch_version=search_config.get("engine_version") or "7.10",
-#    cluster_config=aws.elasticsearch.DomainClusterConfigArgs(
-#        zone_awareness_enabled=True,
-#        zone_awareness_config=aws.elasticsearch.DomainClusterConfigZoneAwarenessConfigArgs(
-#            availability_zone_count=3
-#        ),
-#        instance_count=cluster_size,
-#        instance_type=cluster_instance_type,
-#    ),
-#    ebs_options=aws.elasticsearch.DomainEbsOptionsArgs(
-#        ebs_enabled=True,
-#        volume_type="gp2",
-#        volume_size=disk_size,
-#    ),
-#    tags=aws_config.merged_tags({"Name": f"{environment_name}-opensearch-cluster"}),
-#    opts=pulumi.ResourceOptions(delete_before_replace=True, retain_on_delete=True),
-#    **conditional_kwargs,
-# )
 
 search_domain = aws.opensearch.Domain(
     "opensearch-v2-domain-cluster",
@@ -177,32 +154,11 @@ search_domain = aws.opensearch.Domain(
     ),
     tags=aws_config.merged_tags({"Name": f"{environment_name}-opensearch-cluster"}),
     opts=pulumi.ResourceOptions(
-        delete_before_replace=True, retain_on_delete=True, import_=domain_name
+        delete_before_replace=True,
     ),
     **conditional_kwargs,
 )
 
-# search_domain_policy = aws.elasticsearch.DomainPolicy(
-#    "opensearch-domain-cluster-access-policy",
-#    domain_name=search_domain.domain_name,
-#    access_policies=search_domain.arn.apply(
-#        lambda arn: lint_iam_policy(
-#            {
-#                "Version": IAM_POLICY_VERSION,
-#                "Statement": [
-#                    {
-#                        "Effect": "Allow",
-#                        "Principal": {"AWS": "*"},
-#                        "Action": "es:ESHttp*",
-#                        "Resource": f"{arn}/*",
-#                    }
-#                ],
-#            },
-#            stringify=True,
-#        )
-#    ),
-#    opts=pulumi.ResourceOptions(retain_on_delete=True),
-# )
 
 search_domain_policy = aws.opensearch.DomainPolicy(
     "opensearch-domain-cluster-access-policy",
@@ -225,59 +181,59 @@ search_domain_policy = aws.opensearch.DomainPolicy(
     ),
 )
 
-# Consul Service
-consul_config = pulumi.Config("consul")
-consul_provider = consul.Provider(
-    "consul-provider",
-    address=consul_config.require("address"),
-    scheme="https",
-    http_auth="pulumi:{}".format(
-        read_yaml_secrets(Path(f"pulumi/consul.{stack_info.env_suffix}.yaml"))[
-            "basic_auth_password"
-        ]
-    ),
-)
-opensearch_node = consul.Node(
-    "aws-opensearch-consul-node",
-    address=search_domain.endpoint,
-    name=consul_service_name,
-    opts=pulumi.ResourceOptions(provider=consul_provider),
-)
-opensearch_service = consul.Service(
-    "aws-opensearch-consul-service",
-    node=opensearch_node.name,
-    name=consul_service_name,
-    port=DEFAULT_HTTPS_PORT,
-    meta={
-        "external-node": True,
-        "external-probe": True,
-    },
-    checks=[
-        consul.ServiceCheckArgs(
-            check_id=consul_service_name,
-            interval="10s",
-            name=consul_service_name,
-            timeout="1m0s",
-            status="passing",
-            tcp=pulumi.Output.all(
-                address=search_domain.endpoint, port=DEFAULT_HTTPS_PORT
-            ).apply(lambda es: "{address}:{port}".format(**es)),
-        )
-    ],
-    opts=pulumi.ResourceOptions(provider=consul_provider),
-)
-
-consul.Keys(
-    "elasticsearch",
-    keys=[
-        consul.KeysKeyArgs(
-            path="elasticsearch/host",
-            delete=True,
-            value=search_domain.endpoint,
+if not search_config.get("disable_consul_components"):
+    consul_config = pulumi.Config("consul")
+    consul_provider = consul.Provider(
+        "consul-provider",
+        address=consul_config.require("address"),
+        scheme="https",
+        http_auth="pulumi:{}".format(
+            read_yaml_secrets(Path(f"pulumi/consul.{stack_info.env_suffix}.yaml"))[
+                "basic_auth_password"
+            ]
         ),
-    ],
-    opts=pulumi.ResourceOptions(provider=consul_provider),
-)
+    )
+    opensearch_node = consul.Node(
+        "aws-opensearch-consul-node",
+        address=search_domain.endpoint,
+        name=consul_service_name,
+        opts=pulumi.ResourceOptions(provider=consul_provider),
+    )
+    opensearch_service = consul.Service(
+        "aws-opensearch-consul-service",
+        node=opensearch_node.name,
+        name=consul_service_name,
+        port=DEFAULT_HTTPS_PORT,
+        meta={
+            "external-node": True,
+            "external-probe": True,
+        },
+        checks=[
+            consul.ServiceCheckArgs(
+                check_id=consul_service_name,
+                interval="10s",
+                name=consul_service_name,
+                timeout="1m0s",
+                status="passing",
+                tcp=pulumi.Output.all(
+                    address=search_domain.endpoint, port=DEFAULT_HTTPS_PORT
+                ).apply(lambda es: "{address}:{port}".format(**es)),
+            )
+        ],
+        opts=pulumi.ResourceOptions(provider=consul_provider),
+    )
+
+    consul.Keys(
+        "elasticsearch",
+        keys=[
+            consul.KeysKeyArgs(
+                path="elasticsearch/host",
+                delete=True,
+                value=search_domain.endpoint,
+            ),
+        ],
+        opts=pulumi.ResourceOptions(provider=consul_provider),
+    )
 
 
 # Export Resources for shared use

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/__main__.py
@@ -136,51 +136,75 @@ else:
     domain_name = f"opensearch-{environment_name}"[:SEARCH_DOMAIN_NAME_MAX_LENGTH]
 
 
-search_domain = aws.elasticsearch.Domain(
-    "opensearch-domain-cluster",
-    domain_name=domain_name,
-    elasticsearch_version=search_config.get("engine_version") or "7.10",
-    cluster_config=aws.elasticsearch.DomainClusterConfigArgs(
-        zone_awareness_enabled=True,
-        zone_awareness_config=aws.elasticsearch.DomainClusterConfigZoneAwarenessConfigArgs(
-            availability_zone_count=3
-        ),
-        instance_count=cluster_size,
-        instance_type=cluster_instance_type,
-    ),
-    ebs_options=aws.elasticsearch.DomainEbsOptionsArgs(
-        ebs_enabled=True,
-        volume_type="gp2",
-        volume_size=disk_size,
-    ),
-    tags=aws_config.merged_tags({"Name": f"{environment_name}-opensearch-cluster"}),
-    opts=pulumi.ResourceOptions(delete_before_replace=True, retain_on_delete=True),
-    **conditional_kwargs,
-)
-
-# search_domain = aws.opensearch.Domain(
-#    "opensearch-v2-domain-cluster",
+# search_domain = aws.elasticsearch.Domain(
+#    "opensearch-domain-cluster",
 #    domain_name=domain_name,
-#    engine_version=search_config.get("engine_version") or "7.10",
-#    cluster_config=aws.opensearch.DomainClusterConfigArgs(
+#    elasticsearch_version=search_config.get("engine_version") or "7.10",
+#    cluster_config=aws.elasticsearch.DomainClusterConfigArgs(
 #        zone_awareness_enabled=True,
-#        zone_awareness_config=aws.opensearch.DomainClusterConfigZoneAwarenessConfigArgs(
+#        zone_awareness_config=aws.elasticsearch.DomainClusterConfigZoneAwarenessConfigArgs(
 #            availability_zone_count=3
 #        ),
 #        instance_count=cluster_size,
 #        instance_type=cluster_instance_type,
 #    ),
-#    ebs_options=aws.opensearch.DomainEbsOptionsArgs(
+#    ebs_options=aws.elasticsearch.DomainEbsOptionsArgs(
 #        ebs_enabled=True,
 #        volume_type="gp2",
 #        volume_size=disk_size,
 #    ),
 #    tags=aws_config.merged_tags({"Name": f"{environment_name}-opensearch-cluster"}),
-#    opts=pulumi.ResourceOptions(delete_before_replace=True, retain_on_delete=True, import_=domain_name),
+#    opts=pulumi.ResourceOptions(delete_before_replace=True, retain_on_delete=True),
 #    **conditional_kwargs,
 # )
 
-search_domain_policy = aws.elasticsearch.DomainPolicy(
+search_domain = aws.opensearch.Domain(
+    "opensearch-v2-domain-cluster",
+    domain_name=domain_name,
+    engine_version=search_config.get("engine_version") or "Elasticsearch_7.10",
+    cluster_config=aws.opensearch.DomainClusterConfigArgs(
+        zone_awareness_enabled=True,
+        zone_awareness_config=aws.opensearch.DomainClusterConfigZoneAwarenessConfigArgs(
+            availability_zone_count=3
+        ),
+        instance_count=cluster_size,
+        instance_type=cluster_instance_type,
+    ),
+    ebs_options=aws.opensearch.DomainEbsOptionsArgs(
+        ebs_enabled=True,
+        volume_type="gp2",
+        volume_size=disk_size,
+    ),
+    tags=aws_config.merged_tags({"Name": f"{environment_name}-opensearch-cluster"}),
+    opts=pulumi.ResourceOptions(
+        delete_before_replace=True, retain_on_delete=True, import_=domain_name
+    ),
+    **conditional_kwargs,
+)
+
+# search_domain_policy = aws.elasticsearch.DomainPolicy(
+#    "opensearch-domain-cluster-access-policy",
+#    domain_name=search_domain.domain_name,
+#    access_policies=search_domain.arn.apply(
+#        lambda arn: lint_iam_policy(
+#            {
+#                "Version": IAM_POLICY_VERSION,
+#                "Statement": [
+#                    {
+#                        "Effect": "Allow",
+#                        "Principal": {"AWS": "*"},
+#                        "Action": "es:ESHttp*",
+#                        "Resource": f"{arn}/*",
+#                    }
+#                ],
+#            },
+#            stringify=True,
+#        )
+#    ),
+#    opts=pulumi.ResourceOptions(retain_on_delete=True),
+# )
+
+search_domain_policy = aws.opensearch.DomainPolicy(
     "opensearch-domain-cluster-access-policy",
     domain_name=search_domain.domain_name,
     access_policies=search_domain.arn.apply(
@@ -200,27 +224,6 @@ search_domain_policy = aws.elasticsearch.DomainPolicy(
         )
     ),
 )
-
-# search_domain_policy = aws.opensearch.DomainPolicy(
-#    "opensearch-domain-cluster-access-policy",
-#    domain_name=search_domain.domain_name,
-#    access_policies=search_domain.arn.apply(
-#        lambda arn: lint_iam_policy(
-#            {
-#                "Version": IAM_POLICY_VERSION,
-#                "Statement": [
-#                    {
-#                        "Effect": "Allow",
-#                        "Principal": {"AWS": "*"},
-#                        "Action": "es:ESHttp*",
-#                        "Resource": f"{arn}/*",
-#                    }
-#                ],
-#            },
-#            stringify=True,
-#        )
-#    ),
-# )
 
 # Consul Service
 consul_config = pulumi.Config("consul")


### PR DESCRIPTION
### What are the relevant tickets?
Closes #2358 

### Description (What does it do?)
Second batch of changes that were required to move from `aws.elasticsearch` to `aws.opensearch`. 

I added a conditional to simply disable all the consul components for an environment which is what makes sense for the public clusters (at the moment). The stacks that "share a VPC" have been smashing each-other's consul resources for who knows how long. This seemed like the easiest solution since these stacks don't _actually_ get deployed into their affiliated VPC and there is nothing that is looking for an `elasticsearch.service.consul` address that points to them. 

### How can this be tested?
Already running everywhere. 
