### PR TITLE
feat: added waffle flag to hide taxonomies in residential

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.CI.yaml
@@ -5,6 +5,7 @@ config:
   aws:region: us-east-1
   consul:address: https://consul-mitx-ci.odl.mit.edu
   edxapp:waffle_flags:
+  - ["content_tagging.disabled", "--create", "--everyone"]
   - ["contentstore.new_studio_mfe.use_new_advanced_settings_page", "--create", "--superusers",
     "--everyone"]
   - ["contentstore.new_studio_mfe.use_new_export_page", "--create", "--superusers",

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.Production.yaml
@@ -5,6 +5,7 @@ config:
   aws:region: us-east-1
   consul:address: https://consul-mitx-production.odl.mit.edu
   edxapp:waffle_flags:
+  - ["content_tagging.disabled", "--create", "--everyone"]
   - ["blockstore.use_blockstore_app_api", "--create", "--superusers", "--everyone"]
   - ["course_experience.relative_dates", "--create", "--superusers", "--everyone"]
   - ["contentstore.new_studio_mfe.use_new_advanced_settings_page", "--create", "--superusers",

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.QA.yaml
@@ -5,6 +5,7 @@ config:
   aws:region: us-east-1
   consul:address: https://consul-mitx-qa.odl.mit.edu
   edxapp:waffle_flags:
+  - ["content_tagging.disabled", "--create", "--everyone"]
   - ["course_experience.relative_dates", "--create", "--superusers", "--everyone"]
   - ["contentstore.new_studio_mfe.use_new_advanced_settings_page", "--create", "--superusers",
     "--everyone"]


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4721#issuecomment-2192010379

### Description (What does it do?)
This PR adds a waffle flag to disable content tagging on residential MITx deployments

### How can this be tested?

- Add "content_tagging.disabled" waffle flag in your local edx-platform
- Visit studio: http://localhost:18010/home/
- Validate that there's no "taxonomies" button