### PR TITLE
config: Unscope userneames coming from Touchstone in data platform realm

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/__main__.py
+++ b/src/ol_infrastructure/substructure/keycloak/__main__.py
@@ -460,6 +460,13 @@ ol_data_oidc_attribute_importer_identity_provider_mapper = (
         },
         opts=resource_options,
     ),
+    keycloak.UserTemplateImporterIdentityProviderMapper(
+        "ol-data-map-touchstone-saml-username-attribute",
+        name="username-formatter",
+        realm=ol_data_platform_realm.id,
+        identity_provider_alias=ol_data_platform_touchstone_saml_identity_provider.alias,
+        template="${ATTRIBUTE.mail | localpart}",
+    ),
     # Map Moira group membership to superset role
     # ol-eng-data -> superset_admin
     keycloak.AttributeToRoleIdentityMapper(


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
For users created via Touchstone in the ol-data platform realm, convert their username to the unscoped value (remove the `@mit.edu` part)

