### PR TITLE
Add api/app urls to mit open env vars

### DIFF
--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.Production.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.Production.yaml
@@ -34,6 +34,8 @@ config:
     INDEXING_API_USERNAME: "od_mm_prod_api"
     KEYCLOAK_BASE_URL: "https://sso.ol.mit.edu"
     KEYCLOAK_REALM_NAME: "olapps"
+    MITOPEN_API_URL: "https://api.mitopen.odl.mit.edu"
+    MITOPEN_APP_URL: "https://mitopen.odl.mit.edu"
     MITOPEN_BASE_URL: "https://mitopen.odl.mit.edu"
     MITOPEN_COOKIE_DOMAIN: "mit.edu"
     MITOPEN_COOKIE_NAME: "mitopen"

--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitopen.QA.yaml
@@ -16,6 +16,8 @@ config:
     INDEXING_API_USERNAME: "od_mm_rc_api"
     KEYCLOAK_BASE_URL: "https://sso-qa.ol.mit.edu"
     KEYCLOAK_REALM_NAME: "olapps"
+    MITOPEN_API_URL: "https://api.mitopen-rc.odl.mit.edu"
+    MITOPEN_APP_URL: "https://mitopen-rc.odl.mit.edu"
     MITOPEN_BASE_URL: "https://mitopen-rc.odl.mit.edu"
     MITOPEN_COOKIE_DOMAIN: "odl.mit.edu"
     MITOPEN_COOKIE_NAME: "mitopen-rc"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Related to https://github.com/mitodl/mit-open/pull/1179

### Description (What does it do?)
<!--- Describe your changes in detail -->
This adds 2 environment variables that were added in the PR linked above. I'm keeping `MITOPEN_BASE_URL` for a bit so I don't break deployments in the meantime and I'll follow up with a PR to remove that (and a few other unused vars I removed in the PR) later once the code is deployed.
