### PR TITLE
Add PROFESSIONAL_EDUCATION_API_URL to mitopen env variables

### DIFF
--- a/src/ol_infrastructure/applications/mitopen/__main__.py
+++ b/src/ol_infrastructure/applications/mitopen/__main__.py
@@ -600,6 +600,7 @@ heroku_vars = {
     "OLL_LEARNING_COURSE_BUCKET_PREFIX": "open-learning-library/courses/",
     "OPENSEARCH_DEFAULT_TIMEOUT": 30,
     "OPENSEARCH_INDEXING_CHUNK_SIZE": 75,
+    "PROFESSIONAL_EDUCATION_API_URL": "https://professional.mit.edu/jsonapi/node/course",
     "PROLEARN_CATALOG_API_URL": "https://prolearn.mit.edu/graphql",
     "SECURE_CROSS_ORIGIN_OPENER_POLICY": "None",
     "SEE_BASE_URL": "https://executive.mit.edu/",


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/4731 and https://github.com/mitodl/mit-open/pull/1210

### Description (What does it do?)
Assigns a value for the PROFESSIONAL_EDUCATION_API_URL mitopen setting


### How can this be tested?
See https://github.com/mitodl/mit-open/pull/1210

