### PR TITLE
Add component resource for ACM certificates and use it for edx-notes

### DIFF
--- a/src/ol_infrastructure/applications/edx_notes/Pulumi.applications.edxnotes.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edx_notes/Pulumi.applications.edxnotes.mitxonline.Production.yaml
@@ -4,7 +4,7 @@ encryptedkey: AQICAHi7xhTkB8tf1ObyPMxDhODJja4Mn4jyIo32zZVlOiZPFgHMxGt/KjhBHNA7kH
 config:
   aws:region: us-east-1
   consul:address: https://consul-mitxonline-production.odl.mit.edu
-  edxnotes:acm_cert_domain: '*.mitxonline.mit.edu'
+  edxnotes:acm_cert_domain: 'notes.mitxonline.mit.edu'
   edxnotes:auto_scale:
     desired: 2
     max: 3

--- a/src/ol_infrastructure/applications/edx_notes/Pulumi.applications.edxnotes.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edx_notes/Pulumi.applications.edxnotes.mitxonline.QA.yaml
@@ -4,7 +4,7 @@ encryptedkey: AQICAHi7xhTkB8tf1ObyPMxDhODJja4Mn4jyIo32zZVlOiZPFgHMxGt/KjhBHNA7kH
 config:
   aws:region: us-east-1
   consul:address: https://consul-mitxonline-qa.odl.mit.edu
-  edxnotes:acm_cert_domain: '*.mitxonline.mit.edu'
+  edxnotes:acm_cert_domain: 'notes-qa.mitxonline.mit.edu'
   edxnotes:auto_scale:
     desired: 1
     max: 2

--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -1021,6 +1021,7 @@ edxapp_acm_cert_validation_records = (
     edxapp_web_acm_cert.domain_validation_options.apply(
         partial(
             acm_certificate_validation_records,
+            cert_name="edx-platform",
             zone_id=edxapp_zone_id,
             stack_info=stack_info,
         )

--- a/src/ol_infrastructure/applications/keycloak/__main__.py
+++ b/src/ol_infrastructure/applications/keycloak/__main__.py
@@ -291,6 +291,7 @@ keycloak_acm_cert_validation_records = (
     keycloak_web_acm_cert.domain_validation_options.apply(
         partial(
             acm_certificate_validation_records,
+            cert_name="keycloak",
             zone_id=mitol_zone_id,
             stack_info=stack_info,
         )

--- a/src/ol_infrastructure/applications/superset/__main__.py
+++ b/src/ol_infrastructure/applications/superset/__main__.py
@@ -473,6 +473,7 @@ superset_acm_cert_validation_records = (
     superset_web_acm_cert.domain_validation_options.apply(
         partial(
             acm_certificate_validation_records,
+            cert_name="superset",
             zone_id=mitol_zone_id,
             stack_info=stack_info,
         )

--- a/src/ol_infrastructure/components/aws/acm.py
+++ b/src/ol_infrastructure/components/aws/acm.py
@@ -1,0 +1,70 @@
+from functools import partial
+from typing import Optional
+
+from pulumi import ComponentResource, Output, ResourceOptions
+from pulumi_aws import acm
+from pydantic import BaseModel, ConfigDict
+
+from ol_infrastructure.lib.aws.route53_helper import acm_certificate_validation_records
+from ol_infrastructure.lib.pulumi_helper import parse_stack
+
+
+class ACMCertificateConfig(BaseModel):
+    certificate_domain: str
+    alternative_names: Optional[list[str]] = None
+    certificate_zone_id: Optional[Output[str] | str] = None
+    certificate_tags: dict[str, str]
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class ACMCertificate(ComponentResource):
+    def __init__(
+        self,
+        name: str,
+        cert_config: ACMCertificateConfig,
+        opts: Optional[ResourceOptions] = None,
+    ):
+        super().__init__(
+            "ol:infrastructure:aws:acm:ACMCertificate",
+            name,
+            None,
+            opts,
+        )
+
+        cert_opts = ResourceOptions(parent=self).merge(opts)
+
+        stack_info = parse_stack()
+
+        acm_cert = acm.Certificate(
+            f"{name}-acm-certificate",
+            domain_name=cert_config.certificate_domain,
+            subject_alternative_names=cert_config.alternative_names,
+            validation_method="DNS",
+            tags=cert_config.certificate_tags,
+            opts=cert_opts,
+        )
+
+        acm_cert_validation_records = acm_cert.domain_validation_options.apply(
+            partial(
+                acm_certificate_validation_records,
+                cert_name=name,
+                zone_id=cert_config.certificate_zone_id,
+                stack_info=stack_info,
+                opts=cert_opts,
+            )
+        )
+
+        acm_validated_cert = acm.CertificateValidation(
+            f"wait-for-{name}-acm-cert-validation",
+            certificate_arn=acm_cert.arn,
+            validation_record_fqdns=acm_cert_validation_records.apply(
+                lambda validation_records: [
+                    validation_record.fqdn for validation_record in validation_records
+                ]
+            ),
+            opts=cert_opts,
+        )
+
+        self.certificate = acm_cert
+        self.validated_certificate = acm_validated_cert

--- a/src/ol_infrastructure/lib/aws/route53_helper.py
+++ b/src/ol_infrastructure/lib/aws/route53_helper.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import boto3
 import pulumi
 from pulumi_aws import route53
@@ -47,20 +49,23 @@ def zone_opts(domain: str) -> pulumi.ResourceOptions:
 
 def acm_certificate_validation_records(
     validation_options: list[CertificateDomainValidationOption],
+    cert_name: str,
     zone_id: str,
     stack_info: StackInfo,
+    opts: Optional[pulumi.ResourceOptions] = None,
 ) -> list[route53.Record]:
     records_array = []
     for index, validation in enumerate(validation_options):
         records_array.append(
             route53.Record(
-                f"{stack_info.env_prefix}-acm-cert-validation-route53-record-{index}",
+                f"{cert_name}{stack_info.env_prefix}-acm-cert-validation-route53-record-{index}",
                 name=validation.resource_record_name,
                 zone_id=zone_id,
                 type=validation.resource_record_type,
                 records=[validation.resource_record_value],
                 ttl=FIVE_MINUTES,
                 allow_overwrite=True,
+                opts=opts,
             )
         )
     return records_array

--- a/src/ol_infrastructure/substructure/consul/__main__.py
+++ b/src/ol_infrastructure/substructure/consul/__main__.py
@@ -1,12 +1,11 @@
+from ol_infrastructure.lib.consul import get_consul_provider
+from ol_infrastructure.lib.pulumi_helper import parse_stack
 from pulumi import ResourceOptions, StackReference
 from pulumi_consul import (
     PreparedQuery,
     PreparedQueryFailoverArgs,
     PreparedQueryTemplateArgs,
 )
-
-from ol_infrastructure.lib.consul import get_consul_provider
-from ol_infrastructure.lib.pulumi_helper import parse_stack
 
 stack_info = parse_stack()
 network_stack = StackReference(f"infrastructure.aws.network.{stack_info.name}")

--- a/src/ol_infrastructure/substructure/keycloak/__main__.py
+++ b/src/ol_infrastructure/substructure/keycloak/__main__.py
@@ -4,10 +4,9 @@ import secrets
 import pulumi_keycloak as keycloak
 import pulumi_vault as vault
 from bridge.lib.magic_numbers import SECONDS_IN_ONE_DAY
-from pulumi import Config, Output, ResourceOptions
-
 from ol_infrastructure.lib.pulumi_helper import parse_stack
 from ol_infrastructure.lib.vault import setup_vault_provider
+from pulumi import Config, Output, ResourceOptions
 
 env_config = Config("environment")
 stack_info = parse_stack()

--- a/src/ol_infrastructure/substructure/xpro_partner_dns/__main__.py
+++ b/src/ol_infrastructure/substructure/xpro_partner_dns/__main__.py
@@ -1,10 +1,9 @@
 from typing import Literal, Union
 
-from pulumi import Config, StackReference
-from pulumi_aws import route53
-
 from ol_infrastructure.lib.ol_types import AWSBase, BusinessUnit
 from ol_infrastructure.lib.pulumi_helper import parse_stack
+from pulumi import Config, StackReference
+from pulumi_aws import route53
 
 xpro_dns_config = Config("xpro_dns")
 stack_info = parse_stack()


### PR DESCRIPTION
### What are the relevant tickets?
Fixes https://mit-office-of-digital-learning.sentry.io/issues/5535811137/?referrer=slack

### Description (What does it do?)
<!--- Describe your changes in detail -->
The edx-notes service is having issues in MITx Online due to edx-platform lacking the validation chain for the intermediate cert in the Internet2 trust chain. This creates a component resource for ACM certificates and uses it to generate an ACM cert for edx-notes

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Deploy the changes to edx-notes.mitxonline.QA and verify that the notes feature is working on MITx Online courses QA