### PR TITLE
fix: add learning MFE branding overrides

### DIFF
--- a/src/bridge/settings/openedx/version_matrix.py
+++ b/src/bridge/settings/openedx/version_matrix.py
@@ -520,6 +520,7 @@ ReleaseMap: dict[
                 application="learning",
                 application_type="MFE",
                 release="master",
+                branding_overrides=default_branding_overrides,
                 translation_overrides=[
                     "atlas pull -r mitodl/mitxonline-translations -n main translations/frontend-app-learning/src/i18n/messages:src/i18n/messages/frontend-app-learning",  # noqa: E501
                     "node_modules/@edx/frontend-platform/i18n/scripts/intl-imports.js frontend-app-learning",  # noqa: E501


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
A part of https://github.com/mitodl/hq/issues/4889

### Description (What does it do?)
<!--- Describe your changes in detail -->
Branding overrides were removed accidentally as part of https://github.com/mitodl/ol-infrastructure/pull/2389. This PR adds them back.

Default edX footer is enabled for the learning MFE:
https://courses-qa.mitxonline.mit.edu/learn/course/course-v1:MITxT+14.750x+3T2023/home

<img width="1515" alt="Screenshot 2024-07-15 at 3 58 11 PM" src="https://github.com/user-attachments/assets/9117f543-43b9-4383-bb59-fe33550e3aeb">


### Checklist:
- [x] Release latest footer on npm https://github.com/mitodl/frontend-component-footer-mitol
