### PR TITLE
remove paver steps from edxapp builds 

### DIFF
--- a/dockerfiles/openedx-edxapp/Earthfile
+++ b/dockerfiles/openedx-edxapp/Earthfile
@@ -162,15 +162,14 @@ build-static-assets-nonprod:
   IF [ "$DEPLOYMENT_NAME" = "mitxonline" ]
     RUN pip install --no-warn-script-location --user --no-cache-dir "edx-proctoring-proctortrack==1.2.1"
   END
+  ENV STATIC_ROOT_LMS="/openedx/staticfiles"
   ENV NODE_ENV=prod
   ARG --required DEPLOYMENT_NAME
-  RUN openedx-assets xmodule \
-    && openedx-assets npm \
-    && openedx-assets collect --settings=mitol.assets \
-    && openedx-assets webpack --env=prod 2> /dev/null \
-    && openedx-assets common \
-    && paver compile_sass --theme-dirs /openedx/themes/ --themes $DEPLOYMENT_NAME \
-    && openedx-assets collect --settings=mitol.assets \
+  RUN npm run postinstall \
+    && npm run webpack 2> /dev/null \
+    && npm run compile-sass -- --theme-dir /openedx/themes/ --theme $DEPLOYMENT_NAME \
+    && python manage.py lms collectstatic --noinput --settings=mitol.assets \
+    && python manage.py cms collectstatic --noinput --settings=mitol.assets \
     && rdfind -makesymlinks true -followsymlinks true /openedx/staticfiles/ \
     && mkdir -p /openedx/data/export_course_repos \
     && mkdir -p /openedx/data/var/log/edx \
@@ -188,15 +187,14 @@ build-static-assets-production:
   IF [ "$DEPLOYMENT_NAME" = "mitxonline" ]
     RUN pip install --no-warn-script-location --user --no-cache-dir "edx-proctoring-proctortrack==1.2.1"
   END
+  ENV STATIC_ROOT_LMS="/openedx/staticfiles"
   ENV NODE_ENV=prod
   ARG --required DEPLOYMENT_NAME
-  RUN openedx-assets xmodule \
-    && openedx-assets npm \
-    && openedx-assets collect --settings=mitol.assets \
-    && openedx-assets webpack --env=prod 2> /dev/null \
-    && openedx-assets common \
-    && paver compile_sass --theme-dirs /openedx/themes/ --themes $DEPLOYMENT_NAME \
-    && openedx-assets collect --settings=mitol.assets \
+  RUN npm run postinstall \
+    && npm run webpack 2> /dev/null \
+    && npm run compile-sass -- --theme-dir /openedx/themes/ --theme $DEPLOYMENT_NAME \
+    && python manage.py lms collectstatic --noinput --settings=mitol.assets \
+    && python manage.py cms collectstatic --noinput --settings=mitol.assets \
     && rdfind -makesymlinks true -followsymlinks true /openedx/staticfiles/ \
     && mkdir -p /openedx/data/export_course_repos \
     && mkdir -p /openedx/data/var/log/edx \


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/ol-infrastructure/issues/2504

### Description (What does it do?)
Removes paver steps from our custom edxapp docker + static asset compliation steps. 

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
I have a test pipeline that is coded against this branch for the earthly steps:  https://cicd.odl.mit.edu/teams/infrastructure/pipelines/testing-earthly-packer-pulumi-edxapp-global

 Can be used to deploy a modified docker image to a CI environment. Make sure the real pipeline doesn't stomp your work behind your back, though.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
