### PR TITLE
Turn on discussions.pages_and_resources_mfe waffle flag for everyone

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
@@ -11,7 +11,8 @@ config:
   - ["content_tagging.disabled", "--create", "--everyone"]
   - ["course_experience.relative_dates", "--create", "--superusers", "--everyone",
     "--staff", "--authenticated"]
-  - ["discussions.pages_and_resources_mfe", "--create", "--superusers", "--everyone", "--staff"]
+  - ["discussions.pages_and_resources_mfe", "--create", "--superusers", "--everyone",
+    "--staff"]
   - ["grades.bulk_management", "--create", "--superusers", "--everyone", "--staff",
     "--authenticated"]
   - ["grades.enforce_freeze_grade_after_course_end", "--create", "--superusers", "--everyone"]

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
@@ -11,7 +11,7 @@ config:
   - ["content_tagging.disabled", "--create", "--everyone"]
   - ["course_experience.relative_dates", "--create", "--superusers", "--everyone",
     "--staff", "--authenticated"]
-  - ["discussions.pages_and_resources_mfe", "--create", "--superusers", "--staff"]
+  - ["discussions.pages_and_resources_mfe", "--create", "--superusers", "--everyone", "--staff"]
   - ["grades.bulk_management", "--create", "--superusers", "--everyone", "--staff",
     "--authenticated"]
   - ["grades.enforce_freeze_grade_after_course_end", "--create", "--superusers", "--everyone"]


### PR DESCRIPTION

### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

closes https://github.com/mitodl/hq/issues/4691 

### Description (What does it do?)
<!--- Describe your changes in detail -->

Before this change, only django staff could see the "Pages and Resources" interface in Studio.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->

before: 

<image src="https://camo.githubusercontent.com/e048175d832464f48be940eb617cf76ab3679b632941bf518348f605be559a6a/68747470733a2f2f6769746875622e6d69742e6564752f73746f726167652f757365722f31393533302f66696c65732f31326666333032652d306338642d346638612d383338612d633665336639623434636638">

after:

![image](https://github.com/user-attachments/assets/60780c99-fdda-4f35-8909-a1cf51228073)

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Take a look at a course in Studio with a user who isn't django staff. 

