### PR TITLE
Strip MITOpen cookies from requests routed to s3

### DIFF
--- a/src/ol_infrastructure/applications/mitopen/__main__.py
+++ b/src/ol_infrastructure/applications/mitopen/__main__.py
@@ -506,6 +506,7 @@ mitopen_fastly_service = fastly.ServiceVcl(
                 set req.http.orig-req-url = req.url;
                 declare local var.org_qs STRING;
                 set var.org_qs = req.url.qs;
+                unset req.http.Cookie;
 
                 # If the request does not end in a slash and does not contain a period, error to redirect
                 if (req.url.path !~ "\/$" && req.url.basename !~ "\." ) {


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4840

### Description (What does it do?)
Unset cookies for all mitopen requests going to s3.

Will test when deployed to QA

<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
