### PR TITLE
Add HS256 algorithm for symmetric JWT in edx-platform

### DIFF
--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/common_values.yml.tmpl
@@ -35,6 +35,7 @@ redis_cache_config: &redis_cache_config
     PASSWORD: {{ .Data.redis_auth_token }}
 SECRET_KEY: {{ .Data.django_secret_key }}
 JWT_AUTH:  # NEEDS ATTENTION
+    JWT_ALGORITHM: HS256
     JWT_AUDIENCE: mitx
     JWT_AUTH_COOKIE: {{ env "ENVIRONMENT"}}-edx-jwt-cookie
     JWT_AUTH_COOKIE_HEADER_PAYLOAD: {{ env "ENVIRONMENT" }}-edx-jwt-cookie-header-payload

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx/common_values.yml.tmpl
@@ -35,6 +35,7 @@ redis_cache_config: &redis_cache_config
     PASSWORD: {{ .Data.redis_auth_token }}
 SECRET_KEY: {{ .Data.django_secret_key }}
 JWT_AUTH:  # NEEDS ATTENTION
+    JWT_ALGORITHM: HS256
     JWT_AUDIENCE: mitx
     JWT_AUTH_COOKIE: {{ env "ENVIRONMENT"}}-edx-jwt-cookie
     JWT_AUTH_COOKIE_HEADER_PAYLOAD: {{ env "ENVIRONMENT" }}-edx-jwt-cookie-header-payload

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -32,6 +32,7 @@ redis_cache_config: &redis_cache_config
     PASSWORD: {{ .Data.redis_auth_token }}
 SECRET_KEY: {{ .Data.django_secret_key }}
 JWT_AUTH:  # NEEDS ATTENTION
+    JWT_ALGORITHM: HS256
     JWT_AUDIENCE: mitxonline
     JWT_AUTH_COOKIE: {{ env "ENVIRONMENT"}}-edx-jwt-cookie
     JWT_AUTH_COOKIE_HEADER_PAYLOAD: {{ env "ENVIRONMENT" }}-edx-jwt-cookie-header-payload

--- a/src/bilder/images/edxapp_v2/templates/edxapp/xpro/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/xpro/common_values.yml.tmpl
@@ -34,6 +34,7 @@ redis_cache_config: &redis_cache_config
     PASSWORD: {{ .Data.redis_auth_token }}
 SECRET_KEY: {{ .Data.django_secret_key }}
 JWT_AUTH:  # NEEDS ATTENTION
+    JWT_ALGORITHM: HS256
     JWT_AUDIENCE: xpro
     JWT_AUTH_COOKIE: {{ env "ENVIRONMENT"}}-edx-jwt-cookie
     JWT_AUTH_COOKIE_HEADER_PAYLOAD: {{ env "ENVIRONMENT" }}-edx-jwt-cookie-header-payload


### PR DESCRIPTION
### What are the relevant tickets?
https://mit-office-of-digital-learning.sentry.io/issues/4491572874/?environment=mitxonline-production&project=5939801&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D+exam&referrer=issue-stream&statsPeriod=30d&stream_index=13

### Description (What does it do?)
<!--- Describe your changes in detail -->
The algorithm for symmetric JWT keys as defined by using the Django secret key is being hard-coded to be HS256 in the validation logic from edx-drf-extensions, because the key type is set to `oct` - https://github.com/openedx/edx-drf-extensions/blob/master/edx_rest_framework_extensions/auth/jwt/decoder.py#L410-L413

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
This addresses a handled error, so it will reduce the noise in Sentry but not have any functional change.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
