### PR TITLE
chore: logo config for prod

### DIFF
--- a/src/ol_concourse/pipelines/open_edx/mfe/values.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/values.py
@@ -128,7 +128,7 @@ mitxonline = [
         favicon_url="https://courses.mitxonline.mit.edu/static/mitxonline/images/favicon.ico",
         honor_code_url="https://mitxonline.mit.edu/honor-code/",
         lms_domain="courses.mitxonline.mit.edu",
-        logo_url="https://courses.mitxonline.mit.edu/static/mitxonline/images/logo.png",
+        logo_url="https://courses.mitxonline.mit.edu/static/mitxonline/images/logo.svg",
         marketing_site_domain="mitxonline.mit.edu",
         privacy_policy_url="https://mitxonline.mit.edu/privacy-policy/",
         schedule_email_section="true",  # Because the communication MFE treats this boolean as string  # noqa: E501
@@ -137,6 +137,7 @@ mitxonline = [
         support_url="mitxonline.zendesk.com/hc/",
         terms_of_service_url="https://mitxonline.mit.edu/terms-of-service/",
         trademark_text="© MITx Online. All rights reserved except where noted.",
+        logo_trademark_url="https://courses.mitxonline.mit.edu/static/mitxonline/images/mit-ol-logo.svg",
     ),
 ]
 


### PR DESCRIPTION
### What are the relevant tickets?
[#43](https://github.com/mitodl/mitxonline-theme/pull/43) and [#2507](https://github.com/mitodl/ol-infrastructure/pull/2507)

### Description (What does it do?)
This PR updates config for mitxonline logo updates for Prod.



### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
How can this be tested?

- Check the updated logos in the legacy theme and the MFEs, or can follow the testing instructions in this ticket https://github.com/mitodl/mitxonline-theme/pull/43

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
