### PR TITLE
Update 18.217 redirect

### DIFF
--- a/src/ol_infrastructure/applications/ocw_site/redirect_dict.json
+++ b/src/ol_infrastructure/applications/ocw_site/redirect_dict.json
@@ -63,7 +63,7 @@
   "/18-085F07": "307|keep|https://{{AK_HOSTHEADER}}/courses/mathematics/18-085-computational-science-and-engineering-i-fall-2008/",
   "/18-085F08": "307|keep|https://{{AK_HOSTHEADER}}/courses/mathematics/18-085-computational-science-and-engineering-i-fall-2008/",
   "/18-086S06": "307|keep|https://{{AK_HOSTHEADER}}/courses/mathematics/18-086-mathematical-methods-for-engineers-ii-spring-2006/",
-  "/18-217F19": "307|keep|https://{{AK_HOSTHEADER}}/courses/mathematics/18-217-graph-theory-and-additive-combinatorics-fall-2019/",
+  "/18-217F19": "307|keep|https://{{AK_HOSTHEADER}}/courses/mathematics/18-225-graph-theory-and-additive-combinatorics-fall-2023/",
   "/18-404JF20": "307|discard|https://{{AK_HOSTHEADER}}/courses/mathematics/18-404j-theory-of-computation-fall-2020/",
   "/18-650F16": "307|discard|https://{{AK_HOSTHEADER}}/courses/mathematics/18-650-statistics-for-applications-fall-2016/",
   "/18-821S13": "307|keep|https://{{AK_HOSTHEADER}}/courses/mathematics/18-821-project-laboratory-in-mathematics-spring-2013/",


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4918.

### Description (What does it do?)
This PR updates the redirect for `https://ocw.mit.edu/18-217F19` to `https://ocw.mit.edu/courses/18-225-graph-theory-and-additive-combinatorics-fall-2023`, a newer version of the same course.