### PR TITLE
Enable Opensearch auto_tune by default

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitopen.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/Pulumi.infrastructure.aws.opensearch.mitopen.Production.yaml
@@ -11,6 +11,6 @@ config:
   opensearch:disable_consul_components: true
   opensearch:disk_size_gb: "120"
   opensearch:engine_version: "OpenSearch_2.11"
-  opensearch:instance_type: m5.large.search
+  opensearch:instance_type: r6g.large.search
   opensearch:public_web: "true"
   opensearch:secured_cluster: "true"

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/__main__.py
@@ -139,6 +139,9 @@ search_domain = aws.opensearch.Domain(
     "opensearch-v2-domain-cluster",
     domain_name=domain_name,
     engine_version=search_config.get("engine_version") or "Elasticsearch_7.10",
+    auto_tune_options=aws.opensearch.DomainAutoTuneOptionsArgs(
+        desired_state="ENABLED", use_off_peak_window=True
+    ),
     cluster_config=aws.opensearch.DomainClusterConfigArgs(
         zone_awareness_enabled=True,
         zone_awareness_config=aws.opensearch.DomainClusterConfigZoneAwarenessConfigArgs(

--- a/src/ol_infrastructure/infrastructure/aws/opensearch/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/opensearch/__main__.py
@@ -8,7 +8,7 @@ import pulumi_consul as consul
 from bridge.lib.magic_numbers import DEFAULT_HTTPS_PORT
 from bridge.secrets.sops import read_yaml_secrets
 
-from ol_infrastructure.lib.aws.ec2_helper import default_egress_args
+from ol_infrastructure.lib.aws.ec2_helper import DiskTypes, default_egress_args
 from ol_infrastructure.lib.aws.iam_helper import IAM_POLICY_VERSION, lint_iam_policy
 from ol_infrastructure.lib.ol_types import AWSBase
 from ol_infrastructure.lib.pulumi_helper import parse_stack
@@ -152,7 +152,7 @@ search_domain = aws.opensearch.Domain(
     ),
     ebs_options=aws.opensearch.DomainEbsOptionsArgs(
         ebs_enabled=True,
-        volume_type="gp2",
+        volume_type=DiskTypes.ssd,
         volume_size=disk_size,
     ),
     tags=aws_config.merged_tags({"Name": f"{environment_name}-opensearch-cluster"}),


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/5101

### Description (What does it do?)
<!--- Describe your changes in detail -->
The auto-tune feature will update JVM parameters in Opensearch clusters based on search usage with the intent of optimizing performance.

https://docs.aws.amazon.com/opensearch-service/latest/developerguide/auto-tune.html