### PR TITLE
Keycloak changes for MIT Learn

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.Production.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.Production.yaml
@@ -28,7 +28,8 @@ config:
     secure: v1:ixrI5oZwMK2WCpQr:NaqM67NVCRDfOCsTlyrnN4tNmrPXcSOs
   keycloak_realm:openid_clients:
   - client_info:
-      open: ["https://api.mitopen.odl.mit.edu/*", "https://mitopen.odl.mit.edu/*"]
+      open: ["https://api.mitopen.odl.mit.edu/*", "https://mitopen.odl.mit.edu/*",
+        "https://api.learn.mit.edu/*", "https://learn.mit.edu/*"]
       open-discussions: ["https://open.mit.edu/*"]
     realm_name: olapps
   - client_info:

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
@@ -21,8 +21,8 @@ config:
     secure: v1:TfpaJKet+1dR7zPW:uH/rZTfcHuW/+DmQNzeowgCQk8uw3Fi31ZN+UZkUBXnBYbUCZZGjYxYxMuSvuY4=
   keycloak_realm:mailgun_reply_to_address:
     secure: v1:uRDOLOjIW6qFgbcO:kyGfXZcMIUw0IQ36MEL0ujQoYDJdNCAaljl9j7uI1k5LCWVQm/cz5S7mOkz/+68=
-  keycloak_realm:mit-open-qa-scim-password:
-    secure: v1:pazNjt2BTYSGutic:YPKUHNDADTLHjqu9S20KrDM6T6d7Wc69243Sy8dGAsFAzvVbxYVJDzixtHRVuA==
+  keycloak_realm:mit-learn-qa-scim-password:
+    secure: v1:Bm9tUPq+YhRFUtiI:gWI6wZeDQvYO1P7JbizBqQtRgFfjXkZ5aSIGyFwncJGj9wBqUZek+jmLhkoFVg==
   keycloak_realm:mit_email_host:
     secure: v1:NJ2W839vX2H5EmR7:xZ1XFFS1Lj+zYG7REfJUUYmoBrItsSUCmtDoYCzhDa4=
   keycloak_realm:mit_email_password:
@@ -33,7 +33,8 @@ config:
   keycloak_realm:okta_single_sign_on_service_url: https://dev-66940844.okta.com/app/dev-66940844_collintestlogin_1/exk8gfblmeePE5uUQ5d7/sso/saml
   keycloak_realm:openid_clients:
   - client_info:
-      open: ["https://api.mitopen-rc.odl.mit.edu/*", "https://mitopen-rc.odl.mit.edu/*"]
+      open: ["https://api.mitopen-rc.odl.mit.edu/*", "https://mitopen-rc.odl.mit.edu/*",
+        "https://api.rc.learn.mit.edu/*", "https://rc.learn.mit.edu/*"]
       open-discussions: ["https://discussions-rc.odl.mit.edu/*"]
     realm_name: olapps
   - client_info:

--- a/src/ol_infrastructure/substructure/keycloak/__main__.py
+++ b/src/ol_infrastructure/substructure/keycloak/__main__.py
@@ -159,8 +159,8 @@ ol_apps_realm = keycloak.Realm(
     attributes={
         "business_unit": f"operations-{env_name}",
     },
-    display_name="MIT Open",
-    display_name_html="<b>MIT Open</b>",
+    display_name="MIT Learn",
+    display_name_html="<b>MIT Learn</b>",
     enabled=True,
     email_theme="ol",
     login_theme="ol",
@@ -210,7 +210,7 @@ ol_apps_realm = keycloak.Realm(
             username=mailgun_email_username,
         ),
         from_=mailgun_email_username,
-        from_display_name="MIT Open",
+        from_display_name="MIT Learn",
         host=mailgun_email_host,
         port="465",
         ssl=True,
@@ -941,26 +941,26 @@ if stack_info.env_suffix in ["ci", "qa"]:
     # OKTA-DEV [END] # noqa: ERA001
 
 if stack_info.env_suffix == "qa":
-    # SCIM for MIT-Open in RC.
+    # SCIM for MIT-Learn in RC.
     keycloak.CustomUserFederation(
-        "ol-mit-open-qa-scim",
+        "ol-mit-learn-qa-scim",
         config={
             "user-patchOp": "false",
             "fullSyncPeriod": "-1",
-            "auth-pass": keycloak_realm_config.get("mit-open-qa-scim-password"),
+            "auth-pass": keycloak_realm_config.get("mit-learn-qa-scim-password"),
             "auth-mode": "BEARER",
             "cachePolicy": "DEFAULT",
             "sync-import-action": "CREATE_LOCAL",
             "propagation-user": "true",
             "enabled": "true",
             "changedSyncPeriod": "-1",
-            "endpoint": "https://mitopen-rc.odl.mit.edu/scim/v2/",
+            "endpoint": "https://rc.learn.mit.edu/scim/v2/",
             "propagation-group": "true",
             "content-type": "application/scim+json",
             "group-patchOp": "false",
         },
         enabled=True,
-        name="MIT Open",
+        name="MIT Learn",
         provider_id="scim",
         realm_id=ol_apps_realm.id,
         opts=resource_options,


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/hq/issues/5154

### Description (What does it do?)
<!--- Describe your changes in detail -->
This adds the new domain (old entries should be removed after we switch over) and renames references from `Open` to `Learn`
