### PR TITLE
Updating superset_config to enable iframe embedding

### DIFF
--- a/src/ol_superset/pythonpath/superset_config.py
+++ b/src/ol_superset/pythonpath/superset_config.py
@@ -255,7 +255,7 @@ MAPBOX_API_KEY = os.environ.get("MAPBOX_API_KEY", "")
 
 # Adding http headers to allow iframe embedding
 ENABLE_CORS = True
-HTTP_HEADERS={"X-Frame-Options":"ALLOWALL"}
+HTTP_HEADERS = {"X-Frame-Options": "ALLOWALL"}
 
 
 class CeleryConfig:  # pylint: disable=too-few-public-methods

--- a/src/ol_superset/pythonpath/superset_config.py
+++ b/src/ol_superset/pythonpath/superset_config.py
@@ -253,6 +253,10 @@ DATA_CACHE_CONFIG = {"CACHE_KEY_PREFIX": "superset_chart_cache", **cache_base}
 # Set this API key to enable Mapbox visualizations
 MAPBOX_API_KEY = os.environ.get("MAPBOX_API_KEY", "")
 
+# Adding http headers to allow iframe embedding
+ENABLE_CORS = True
+HTTP_HEADERS={"X-Frame-Options":"ALLOWALL"}
+
 
 class CeleryConfig:  # pylint: disable=too-few-public-methods
     broker_url = "rediss://superset-redis.service.consul:6379/1"


### PR DESCRIPTION
### What are the relevant tickets?
?

### Description (What does it do?)
Added variables to enable CORS and allow us to embed superset charts into frames.

### How can this be tested?
Once deployed to QA:
- Confirm that you are able to share/embed the chart by navigating to a dashboard, then to a chart, and then to the additional options menu (meatballs) on the right hand side > Share > Embed code
- Generate the iframe embed code from the cart
- Use a html / script tester to attempt embedding the cart and confirm it is visible
<img width="1700" alt="Screenshot 2024-08-14 at 2 34 25 PM" src="https://github.com/user-attachments/assets/9064ad4b-4673-4a3f-99a4-5b3b898f8885">

### Additional Context
- Do we need to configure or define CORS_OPTIONS in superset_config.py?
- Do we need to add any additional dependencies? (apache-superset[cors] is already included)
https://superset.apache.org/docs/configuration/networking-settings/