### PR TITLE
add CSRF_COOKIE_NAME values for rc and prod

### DIFF
--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitlearn.Production.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitlearn.Production.yaml
@@ -30,6 +30,7 @@ config:
     sso_url: "sso.ol.mit.edu"
   heroku_app:vars:
     CELERY_WORKER_MAX_MEMORY_PER_CHILD: 250000
+    CSFRF_COOKIE_NAME: "learn-csrftoken"
     DEBUG: "false"
     EDX_LEARNING_COURSE_BUCKET_NAME: "edxorg-production-edxapp-courses"
     ENABLE_INFINITE_CORRIDOR: "true"

--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitlearn.Production.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitlearn.Production.yaml
@@ -30,7 +30,7 @@ config:
     sso_url: "sso.ol.mit.edu"
   heroku_app:vars:
     CELERY_WORKER_MAX_MEMORY_PER_CHILD: 250000
-    CSFRF_COOKIE_NAME: "learn-csrftoken"
+    CSRF_COOKIE_NAME: "learn-csrftoken"
     DEBUG: "false"
     EDX_LEARNING_COURSE_BUCKET_NAME: "edxorg-production-edxapp-courses"
     ENABLE_INFINITE_CORRIDOR: "true"

--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitlearn.QA.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitlearn.QA.yaml
@@ -8,6 +8,7 @@ config:
     secure: v1:eSvnqne7KQRkHJlu:wTyl9W3aivfxlANqBML2wy4GEHe85VuKll60R5HmGUu1hJTcQBEfzK1cJOyvjlbLgBtXLw==
   heroku_app:vars:
     CELERY_WORKER_MAX_MEMORY_PER_CHILD: 125000
+    CSFRF_COOKIE_NAME: "learn-rc-csrftoken"
     DEBUG: "false"
     EDX_LEARNING_COURSE_BUCKET_NAME: "edxorg-qa-edxapp-courses"
     ENABLE_INFINITE_CORRIDOR: "true"

--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitlearn.QA.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitlearn.QA.yaml
@@ -8,7 +8,7 @@ config:
     secure: v1:eSvnqne7KQRkHJlu:wTyl9W3aivfxlANqBML2wy4GEHe85VuKll60R5HmGUu1hJTcQBEfzK1cJOyvjlbLgBtXLw==
   heroku_app:vars:
     CELERY_WORKER_MAX_MEMORY_PER_CHILD: 125000
-    CSFRF_COOKIE_NAME: "learn-rc-csrftoken"
+    CSRF_COOKIE_NAME: "learn-rc-csrftoken"
     DEBUG: "false"
     EDX_LEARNING_COURSE_BUCKET_NAME: "edxorg-qa-edxapp-courses"
     ENABLE_INFINITE_CORRIDOR: "true"

--- a/src/ol_infrastructure/applications/mitopen/__main__.py
+++ b/src/ol_infrastructure/applications/mitopen/__main__.py
@@ -965,6 +965,13 @@ gh_workflow_environment_env_secret = github.ActionsSecret(
     plaintext_value=stack_info.env_suffix,
     opts=ResourceOptions(provider=github_provider),
 )
+gh_workflow_csrf_cookie_name_env_secret = github.ActionsSecret(
+    f"ol_mitopen_csrf_cookie_name-{stack_info.env_suffix}",
+    repository=gh_repo.name,
+    secret_name=f"CSRF_COOKIE_NAME_{env_var_suffix}",
+    plaintext_value=heroku_vars["CSRF_COOKIE_NAME"],
+    opts=ResourceOptions(provider=github_provider),
+)
 
 
 export(


### PR DESCRIPTION
### What are the relevant tickets?
Sets the env vars for https://github.com/mitodl/mit-open/pull/1420

### Description (What does it do?)
Sets CSRF_COOKIE_NAME for RC and production

