### PR TITLE
update open catalog urls for ocw-studio

### DIFF
--- a/src/ol_infrastructure/applications/ocw_studio/Pulumi.applications.ocw_studio.Production.yaml
+++ b/src/ol_infrastructure/applications/ocw_studio/Pulumi.applications.ocw_studio.Production.yaml
@@ -35,7 +35,7 @@ config:
     OCW_STUDIO_LIVE_URL: https://ocw.mit.edu/
     OCW_STUDIO_LOG_LEVEL: INFO
     OCW_STUDIO_SUPPORT_EMAIL: 'ocw-studio-support@mit.edu'
-    OPEN_CATALOG_URLS: 'https://open.mit.edu/api/v0/ocw_next_webhook/,https://api.mitopen.odl.mit.edu/api/v1/ocw_next_webhook/'
+    OPEN_CATALOG_URLS: 'https://open.mit.edu/api/v0/ocw_next_webhook/,https://api.learn.mit.edu/api/v1/ocw_next_webhook/'
     SEARCH_API_URL: 'https://open.mit.edu/api/v0/search/'
     SENTRY_LOG_LEVEL: 'WARN'
     SITEMAP_DOMAIN: 'ocw.mit.edu'

--- a/src/ol_infrastructure/applications/ocw_studio/Pulumi.applications.ocw_studio.QA.yaml
+++ b/src/ol_infrastructure/applications/ocw_studio/Pulumi.applications.ocw_studio.QA.yaml
@@ -35,7 +35,7 @@ config:
     OCW_STUDIO_LIVE_URL: https://live-qa.ocw.mit.edu/
     OCW_STUDIO_LOG_LEVEL: INFO
     OCW_STUDIO_SUPPORT_EMAIL: 'ocw-studio-rc-support@mit.edu'
-    OPEN_CATALOG_URLS: 'https://discussions-rc.odl.mit.edu/api/v0/ocw_next_webhook/,https://api.mitopen-rc.odl.mit.edu/api/v1/ocw_next_webhook/'
+    OPEN_CATALOG_URLS: 'https://discussions-rc.odl.mit.edu/api/v0/ocw_next_webhook/,https://api.rc.learn.mit.edu/api/v1/ocw_next_webhook/'
     SEARCH_API_URL: 'https://discussions-rc.odl.mit.edu/api/v0/search/'
     SENTRY_LOG_LEVEL: 'WARN'
     SITEMAP_DOMAIN: 'live-qa.ocw.mit.edu'


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/2272

### Description (What does it do?)
This PR updates the `OPEN_CATALOG_URLS` setting for `ocw-studio` environments to reflect the rename of `mit-open` to `mit-learn`

### How can this be tested?
Deploy this change, redeploy `ocw-studio` with these settings and try to publish a course