### PR TITLE
renaming mitopen->mitlearn rds instance

### DIFF
--- a/src/ol_infrastructure/applications/mitlearn/__main__.py
+++ b/src/ol_infrastructure/applications/mitlearn/__main__.py
@@ -320,7 +320,7 @@ rds_defaults["instance_size"] = (
     mitopen_config.get("db_instance_size") or rds_defaults["instance_size"]
 )
 mitopen_db_config = OLPostgresDBConfig(
-    instance_name=f"ol-mitopen-db-{stack_info.env_suffix}",
+    instance_name=f"ol-mitlearn-db-{stack_info.env_suffix}",
     password=rds_password,
     subnet_group_name=apps_vpc["rds_subnet"],
     security_groups=[mitopen_db_security_group],
@@ -334,7 +334,10 @@ mitopen_db_config.parameter_overrides.append(
     {"name": "password_encryption", "value": "md5"}
 )
 
-mitopen_db = OLAmazonDB(mitopen_db_config)
+mitopen_db = OLAmazonDB(
+    db_config=mitopen_db_config,
+    opts=ResourceOptions(aliases=[Alias(f"ol-mitopen-db-{stack_info.env_suffix}")]),
+)
 
 mitopen_role_statements = postgres_role_statements.copy()
 mitopen_role_statements.pop("app")

--- a/src/ol_infrastructure/applications/mitlearn/__main__.py
+++ b/src/ol_infrastructure/applications/mitlearn/__main__.py
@@ -994,7 +994,7 @@ sensitive_heroku_vars = {
         lambda data: "{}".format(data["secret_key"])
     ),
     "DATABASE_URL": auth_postgres_mitopen_creds_app.data.apply(
-        lambda data: "postgres://{}:{}@ol-mitopen-db-{}.cbnm7ajau6mi.us-east-1.rds.amazonaws.com:5432/mitopen".format(
+        lambda data: "postgres://{}:{}@ol-mitlearn-db-{}.cbnm7ajau6mi.us-east-1.rds.amazonaws.com:5432/mitopen".format(
             data["username"], data["password"], stack_info.name.lower()
         )
     ),  # TODO @Ardiea: This changes every run / preview and creates a mess in the DB.


### PR DESCRIPTION

### Description (What does it do?)
renaming mitopen->mitlearn rds instance


@blarghmatey Can you review the change set for this? As far as I can tell it is okay. It wants to recreate almost everything that RDS related EXCEPT the rds instance itself. I believe this okay?