### PR TITLE
add appzi url

### DIFF
--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitlearn.Production.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitlearn.Production.yaml
@@ -29,6 +29,7 @@ config:
     mailgun_sender_domain: "mail.learn.mit.edu"  # Need to verify
     sso_url: "sso.ol.mit.edu"
   heroku_app:vars:
+    APPZI_URL: "https://w.appzi.io/w.js?token=Q2pSI"
     CELERY_WORKER_MAX_MEMORY_PER_CHILD: 250000
     CSRF_COOKIE_NAME: "learn-csrftoken"
     DEBUG: "false"

--- a/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitlearn.QA.yaml
+++ b/src/ol_infrastructure/applications/mitopen/Pulumi.applications.mitlearn.QA.yaml
@@ -7,6 +7,7 @@ config:
   heroku:app_id:
     secure: v1:eSvnqne7KQRkHJlu:wTyl9W3aivfxlANqBML2wy4GEHe85VuKll60R5HmGUu1hJTcQBEfzK1cJOyvjlbLgBtXLw==
   heroku_app:vars:
+    APPZI_URL: ""
     CELERY_WORKER_MAX_MEMORY_PER_CHILD: 125000
     CSRF_COOKIE_NAME: "learn-rc-csrftoken"
     DEBUG: "false"

--- a/src/ol_infrastructure/applications/mitopen/__main__.py
+++ b/src/ol_infrastructure/applications/mitopen/__main__.py
@@ -1116,7 +1116,7 @@ gh_workflow_csrf_cookie_name_env_secret = github.ActionsSecret(
 gh_workflow_appzi_url_env_secret = github.ActionsSecret(
     f"ol_mitopen_appzi_url-{stack_info.env_suffix}",
     repository=gh_repo.name,
-    secret_name=f"APPZI_URL{env_var_suffix}",
+    secret_name=f"APPZI_URL_{env_var_suffix}",
     plaintext_value=heroku_vars["APPZI_URL"],
     opts=ResourceOptions(provider=github_provider),
 )

--- a/src/ol_infrastructure/applications/mitopen/__main__.py
+++ b/src/ol_infrastructure/applications/mitopen/__main__.py
@@ -1113,7 +1113,7 @@ gh_workflow_csrf_cookie_name_env_secret = github.ActionsSecret(
     plaintext_value=heroku_vars["CSRF_COOKIE_NAME"],
     opts=ResourceOptions(provider=github_provider),
 )
-gh_workflow_csrf_cookie_name_env_secret = github.ActionsSecret(
+gh_workflow_appzi_url_env_secret = github.ActionsSecret(
     f"ol_mitopen_appzi_url-{stack_info.env_suffix}",
     repository=gh_repo.name,
     secret_name=f"APPZI_URL{env_var_suffix}",

--- a/src/ol_infrastructure/applications/mitopen/__main__.py
+++ b/src/ol_infrastructure/applications/mitopen/__main__.py
@@ -1113,6 +1113,13 @@ gh_workflow_csrf_cookie_name_env_secret = github.ActionsSecret(
     plaintext_value=heroku_vars["CSRF_COOKIE_NAME"],
     opts=ResourceOptions(provider=github_provider),
 )
+gh_workflow_csrf_cookie_name_env_secret = github.ActionsSecret(
+    f"ol_mitopen_appzi_url-{stack_info.env_suffix}",
+    repository=gh_repo.name,
+    secret_name=f"APPZI_URL{env_var_suffix}",
+    plaintext_value=heroku_vars["APPZI_URL"],
+    opts=ResourceOptions(provider=github_provider),
+)
 
 
 export(


### PR DESCRIPTION
### What are the relevant tickets?
For PR https://github.com/mitodl/ol-infrastructure/compare/cc/appzi?expand=1

### Description (What does it do?)
Adds `APPZI_URL` for MIT Learn Production only, used by frontend.
