### PR TITLE
feat: remove certificate link from resedential course authoring mfe

### DIFF
--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -40,6 +40,7 @@ class OpenEdxVars(BaseModel):
     accessibility_url: Optional[str] = None
     account_settings_url: Optional[str] = None
     contact_url: Optional[str] = None
+    certificate: Optional[str] = None
     deployment_name: OpenEdxDeploymentName
     display_feedback_widget: Optional[str] = None
     environment: str
@@ -82,6 +83,7 @@ def mfe_params(
         "CONTACT_URL": open_edx.contact_url,
         "CSRF_TOKEN_API_PATH": "/csrf/api/v1/token",
         "DISPLAY_FEEDBACK_WIDGET": open_edx.display_feedback_widget,
+        "ENABLE_CERTIFICATE_PAGE":open_edx.certificate,
         "DISCUSSIONS_MFE_BASE_URL": f"https://{open_edx.lms_domain}/{discussion_mfe_path}",
         "FAVICON_URL": open_edx.favicon_url,
         "HONOR_CODE_URL": open_edx.honor_code_url,

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -40,7 +40,7 @@ class OpenEdxVars(BaseModel):
     accessibility_url: Optional[str] = None
     account_settings_url: Optional[str] = None
     contact_url: Optional[str] = None
-    certificate: Optional[str] = None
+    enable_certificate_page: Optional[bool] = None
     deployment_name: OpenEdxDeploymentName
     display_feedback_widget: Optional[str] = None
     environment: str
@@ -83,7 +83,7 @@ def mfe_params(
         "CONTACT_URL": open_edx.contact_url,
         "CSRF_TOKEN_API_PATH": "/csrf/api/v1/token",
         "DISPLAY_FEEDBACK_WIDGET": open_edx.display_feedback_widget,
-        "ENABLE_CERTIFICATE_PAGE":open_edx.certificate,
+        "ENABLE_CERTIFICATE_PAGE":open_edx.enable_certificate_page,
         "DISCUSSIONS_MFE_BASE_URL": f"https://{open_edx.lms_domain}/{discussion_mfe_path}",
         "FAVICON_URL": open_edx.favicon_url,
         "HONOR_CODE_URL": open_edx.honor_code_url,

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -2,7 +2,7 @@ import sys
 import textwrap
 from collections import defaultdict
 from itertools import chain, product
-from typing import Optional, Union
+from typing import Literal, Optional
 
 from pydantic import BaseModel
 
@@ -40,7 +40,7 @@ class OpenEdxVars(BaseModel):
     accessibility_url: Optional[str] = None
     account_settings_url: Optional[str] = None
     contact_url: Optional[str] = None
-    enable_certificate_page: Optional[bool] = None
+    enable_certificate_page: Optional[Literal["true","false"]] = None
     deployment_name: OpenEdxDeploymentName
     display_feedback_widget: Optional[str] = None
     environment: str
@@ -69,7 +69,7 @@ class OpenEdxVars(BaseModel):
 
 def mfe_params(
     open_edx: OpenEdxVars, mfe: OpenEdxApplicationVersion
-) -> dict[str, Optional[Union[str,bool]]]:
+) -> dict[str, Optional[str]]:
     learning_mfe_path = OpenEdxMicroFrontend.learn.path
     discussion_mfe_path = OpenEdxMicroFrontend.discussion.path
     return {

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -40,7 +40,7 @@ class OpenEdxVars(BaseModel):
     accessibility_url: Optional[str] = None
     account_settings_url: Optional[str] = None
     contact_url: Optional[str] = None
-    enable_certificate_page: Optional[Literal["true","false"]] = None
+    enable_certificate_page: Optional[Literal["true", "false"]] = None
     deployment_name: OpenEdxDeploymentName
     display_feedback_widget: Optional[str] = None
     environment: str
@@ -83,7 +83,7 @@ def mfe_params(
         "CONTACT_URL": open_edx.contact_url,
         "CSRF_TOKEN_API_PATH": "/csrf/api/v1/token",
         "DISPLAY_FEEDBACK_WIDGET": open_edx.display_feedback_widget,
-        "ENABLE_CERTIFICATE_PAGE":open_edx.enable_certificate_page,
+        "ENABLE_CERTIFICATE_PAGE": open_edx.enable_certificate_page,
         "DISCUSSIONS_MFE_BASE_URL": f"https://{open_edx.lms_domain}/{discussion_mfe_path}",
         "FAVICON_URL": open_edx.favicon_url,
         "HONOR_CODE_URL": open_edx.honor_code_url,

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -2,7 +2,7 @@ import sys
 import textwrap
 from collections import defaultdict
 from itertools import chain, product
-from typing import Optional
+from typing import Optional, Union
 
 from pydantic import BaseModel
 
@@ -69,7 +69,7 @@ class OpenEdxVars(BaseModel):
 
 def mfe_params(
     open_edx: OpenEdxVars, mfe: OpenEdxApplicationVersion
-) -> dict[str, Optional[str]]:
+) -> dict[str, Optional[Union[str,bool]]]:
     learning_mfe_path = OpenEdxMicroFrontend.learn.path
     discussion_mfe_path = OpenEdxMicroFrontend.discussion.path
     return {

--- a/src/ol_concourse/pipelines/open_edx/mfe/values.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/values.py
@@ -4,7 +4,7 @@ mitx = [
     OpenEdxVars(
         environment="mitx-ci",
         environment_stage="CI",
-        certificates="false",
+        certificate="false",
         deployment_name="mitx",
         favicon_url="https://lms-ci.mitx.mit.edu/static/mitx/images/favicon.ico",
         lms_domain="lms-ci.mitx.mit.edu",
@@ -20,7 +20,7 @@ mitx = [
     OpenEdxVars(
         environment="mitx-qa",
         environment_stage="QA",
-        certificates="false",
+        certificate="false",
         deployment_name="mitx",
         favicon_url="https://mitx-qa.mitx.mit.edu/static/mitx/images/favicon.ico",
         lms_domain="mitx-qa.mitx.mit.edu",
@@ -35,7 +35,7 @@ mitx = [
     OpenEdxVars(
         environment="mitx-production",
         environment_stage="Production",
-        certificates="false",
+        certificate="false",
         deployment_name="mitx",
         favicon_url="https://lms.mitx.mit.edu/static/mitx/images/favicon.ico",
         lms_domain="lms.mitx.mit.edu",

--- a/src/ol_concourse/pipelines/open_edx/mfe/values.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/values.py
@@ -4,6 +4,7 @@ mitx = [
     OpenEdxVars(
         environment="mitx-ci",
         environment_stage="CI",
+        certificates="false",
         deployment_name="mitx",
         favicon_url="https://lms-ci.mitx.mit.edu/static/mitx/images/favicon.ico",
         lms_domain="lms-ci.mitx.mit.edu",
@@ -19,6 +20,7 @@ mitx = [
     OpenEdxVars(
         environment="mitx-qa",
         environment_stage="QA",
+        certificates="false",
         deployment_name="mitx",
         favicon_url="https://mitx-qa.mitx.mit.edu/static/mitx/images/favicon.ico",
         lms_domain="mitx-qa.mitx.mit.edu",
@@ -33,6 +35,7 @@ mitx = [
     OpenEdxVars(
         environment="mitx-production",
         environment_stage="Production",
+        certificates="false",
         deployment_name="mitx",
         favicon_url="https://lms.mitx.mit.edu/static/mitx/images/favicon.ico",
         lms_domain="lms.mitx.mit.edu",

--- a/src/ol_concourse/pipelines/open_edx/mfe/values.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/values.py
@@ -4,7 +4,7 @@ mitx = [
     OpenEdxVars(
         environment="mitx-ci",
         environment_stage="CI",
-        enable_certificate_page=False,
+        enable_certificate_page="false",
         deployment_name="mitx",
         favicon_url="https://lms-ci.mitx.mit.edu/static/mitx/images/favicon.ico",
         lms_domain="lms-ci.mitx.mit.edu",
@@ -20,7 +20,7 @@ mitx = [
     OpenEdxVars(
         environment="mitx-qa",
         environment_stage="QA",
-        enable_certificate_page=False,
+        enable_certificate_page="false",
         deployment_name="mitx",
         favicon_url="https://mitx-qa.mitx.mit.edu/static/mitx/images/favicon.ico",
         lms_domain="mitx-qa.mitx.mit.edu",
@@ -35,7 +35,7 @@ mitx = [
     OpenEdxVars(
         environment="mitx-production",
         environment_stage="Production",
-        enable_certificate_page=False,
+        enable_certificate_page="false",
         deployment_name="mitx",
         favicon_url="https://lms.mitx.mit.edu/static/mitx/images/favicon.ico",
         lms_domain="lms.mitx.mit.edu",

--- a/src/ol_concourse/pipelines/open_edx/mfe/values.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/values.py
@@ -4,7 +4,7 @@ mitx = [
     OpenEdxVars(
         environment="mitx-ci",
         environment_stage="CI",
-        certificate="false",
+        enable_certificate_page=False,
         deployment_name="mitx",
         favicon_url="https://lms-ci.mitx.mit.edu/static/mitx/images/favicon.ico",
         lms_domain="lms-ci.mitx.mit.edu",
@@ -20,7 +20,7 @@ mitx = [
     OpenEdxVars(
         environment="mitx-qa",
         environment_stage="QA",
-        certificate="false",
+        enable_certificate_page=False,
         deployment_name="mitx",
         favicon_url="https://mitx-qa.mitx.mit.edu/static/mitx/images/favicon.ico",
         lms_domain="mitx-qa.mitx.mit.edu",
@@ -35,7 +35,7 @@ mitx = [
     OpenEdxVars(
         environment="mitx-production",
         environment_stage="Production",
-        certificate="false",
+        enable_certificate_page=False,
         deployment_name="mitx",
         favicon_url="https://lms.mitx.mit.edu/static/mitx/images/favicon.ico",
         lms_domain="lms.mitx.mit.edu",


### PR DESCRIPTION
Note: This PR should be merged after the merge of https://github.com/openedx/frontend-app-course-authoring/pull/1223

### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4658

### Description (What does it do?)
This PR removes the certificate link from course authoring header settiings tab.

### Screenshots (if appropriate):
Before
<img width="432" alt="Screenshot 2024-08-21 at 4 00 37 PM" src="https://github.com/user-attachments/assets/ca3c989d-95b9-47c1-a711-94a817a52b36">

After
<img width="432" alt="Screenshot 2024-08-21 at 3 48 30 PM" src="https://github.com/user-attachments/assets/c1f5ea47-8b01-4b6e-9269-4c839fbd704d">

### How can this be tested?
Note: Make sure you enable the contentstore.new_studio_mfe.use_new_course_outline_page waffle flag so that the authoring MFE will be used for displaying the course outline.

- In Studio, visit any course outline and click the Settings tab. You should see a certificate link there.
- In the .env.development file, set ENABLE_CERTIFICATE_PAGE=false.
- Restart the MFE container. Now, repeat the first step. There should be no certificate link.


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
