### PR TITLE
k8s networking for the ci operations_vpc 

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/heroku_dyno_reset/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/heroku_dyno_reset/pipeline.py
@@ -3,7 +3,6 @@ import textwrap
 from pathlib import Path
 
 from bridge.secrets.sops import read_yaml_secrets
-
 from ol_concourse.lib.constants import REGISTRY_IMAGE
 from ol_concourse.lib.models.fragment import PipelineFragment
 from ol_concourse.lib.models.pipeline import (

--- a/src/ol_infrastructure/infrastructure/aws/network/Pulumi.infrastructure.aws.network.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/network/Pulumi.infrastructure.aws.network.CI.yaml
@@ -15,6 +15,12 @@ config:
   ocw_vpc:cidr_block: 172.21.0.0/16
   operations_vpc:cidr_block: 172.16.0.0/16
   operations_vpc:name: operations-ci
+  operations_vpc:k8s_pod_subnets:
+  - 172.16.128.0/21
+  - 172.16.136.0/21
+  - 172.16.144.0/21
+  - 172.16.152.0/21
+  operations_vpc:k8s_service_subnet: 10.110.24.0/23
   residential_staging_vpc:cidr_block: 172.22.0.0/16
   residential_vpc:cidr_block: 172.19.0.0/16
   xpro_vpc:cidr_block: 172.20.0.0/16

--- a/src/ol_infrastructure/infrastructure/aws/network/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/network/__main__.py
@@ -107,6 +107,8 @@ operations_vpc_config = OLVPCConfig(
         "business_unit": "operations",
         "Name": f"Operations {stack_info.name}",
     },
+    k8s_pod_subnets=ops_config.require_object("k8s_pod_subnets") or None,
+    k8s_service_subnet=ops_config.require("k8s_service_subnet") or None,
 )
 operations_vpc = OLVPC(operations_vpc_config)
 


### PR DESCRIPTION
### Description (What does it do?)
Added k8s networks in the ci operations_vpc. So I can make a second CI eks cluster and not interfer with Tobias' work with the data platform. 
