### PR TITLE
Add SEE_API_ENABLED env setting with different values for RC, prod

### DIFF
--- a/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.Production.yaml
+++ b/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.Production.yaml
@@ -61,6 +61,7 @@ config:
     POSTHOG_ENABLED: "true"
     POSTHOG_PROJECT_ID: "63497"
     POSTHOG_TIMEOUT_MS: 1000
+    SEE_API_ENABLED: "false"
     SESSION_COOKIE_NAME: "learn-session"
     SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT: "https://sso.ol.mit.edu/realms/olapps"
     TIKA_SERVER_ENDPOINT: "https://tika-production.odl.mit.edu"

--- a/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.QA.yaml
+++ b/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.QA.yaml
@@ -39,6 +39,7 @@ config:
     POSTHOG_ENABLED: "true"
     POSTHOG_PROJECT_ID: "86325"
     POSTHOG_TIMEOUT_MS: 1000
+    SEE_API_ENABLED: "true"
     SESSION_COOKIE_NAME: "learn-rc-session"
     SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT:
     TIKA_SERVER_ENDPOINT: "https://tika-qa.odl.mit.edu"


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/mit-open/pull/1394

### Description (What does it do?)
Adds an env setting that will enable the new Sloan API on RC but disable it on production (for now)


### How can this be tested?
see https://github.com/mitodl/mit-open/pull/1394

