### PR TITLE
Enable the Sloan API ETL on production

### DIFF
--- a/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.Production.yaml
+++ b/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.Production.yaml
@@ -61,7 +61,7 @@ config:
     POSTHOG_ENABLED: "true"
     POSTHOG_PROJECT_ID: "63497"
     POSTHOG_TIMEOUT_MS: 1000
-    SEE_API_ENABLED: "false"
+    SEE_API_ENABLED: "true"
     SESSION_COOKIE_NAME: "learn-session"
     SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT: "https://sso.ol.mit.edu/realms/olapps"
     TIKA_SERVER_ENDPOINT: "https://tika-production.odl.mit.edu"


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/ol-infrastructure/pull/2625

### Description (What does it do?)
Enables the Sloan API ETL on production

Would appreciate a heads-up when this is deployed so I can run some management commands.

### How can this be tested?
N/A
