### PR TITLE
Create S3 / CloudFront backed OCW Legacy site

### DIFF
--- a/src/ol_infrastructure/components/aws/s3_cloudfront_site.py
+++ b/src/ol_infrastructure/components/aws/s3_cloudfront_site.py
@@ -89,9 +89,9 @@ class S3ServerlessSite(ComponentResource):
                 }
             ),
             tags=site_config.tags,
-            versioning=versioning_args,
+            versionings=[versioning_args],
             cors_rules=[cors_args],
-            website=[website_args],
+            websites=[website_args],
             opts=resource_opts,
         )
 

--- a/src/ol_infrastructure/components/aws/s3_cloudfront_site.py
+++ b/src/ol_infrastructure/components/aws/s3_cloudfront_site.py
@@ -57,6 +57,19 @@ class S3ServerlessSite(ComponentResource):
 
         resource_opts = ResourceOptions(parent=self).merge(opts)
 
+        website_args = s3.BucketV2WebsiteArgs(
+            index_document=site_config.site_index,
+            error_document="error.html",
+        )
+
+        cors_args = s3.BucketV2CorsRuleArgs(
+            allowed_methods=["GET", "HEAD"],
+            allowed_origins=["*"],
+            max_age_seconds=3000,
+        )
+
+        versioning_args = s3.BucketV2VersioningArgs(enabled=True)
+
         self.site_bucket = s3.BucketV2(
             f"{site_config.site_name}-bucket",
             bucket=site_config.bucket_name,
@@ -76,11 +89,9 @@ class S3ServerlessSite(ComponentResource):
                 }
             ),
             tags=site_config.tags,
-            # We need separate aws.s3.BucketVersioningV2 object instead.
-            # Same for Cors, website. -CAP
-            # versioning={"enabled": True},
-            # cors_rules=[{"allowedMethods": ["GET", "HEAD"], "allowedOrigins": ["*"]}],
-            # website={"indexDocument": site_config.site_index},
+            versioning=versioning_args,
+            cors_rules=[cors_args],
+            website=[website_args],
             opts=resource_opts,
         )
 

--- a/src/ol_infrastructure/components/aws/s3_cloudfront_site.py
+++ b/src/ol_infrastructure/components/aws/s3_cloudfront_site.py
@@ -2,7 +2,6 @@
 
 import json
 from enum import Enum
-from typing import Optional
 
 from pulumi import ComponentResource, ResourceOptions
 from pulumi_aws import acm, cloudfront, s3
@@ -39,9 +38,7 @@ class S3ServerlessSite(ComponentResource):
     """
 
     def __init__(
-        self,
-        site_config: S3ServerlessSiteConfig,
-        opts: Optional[ResourceOptions] = None,
+        self, site_config: S3ServerlessSiteConfig, opts: ResourceOptions | None
     ):
         """Create an S3 bucket, ACM certificate, and Cloudfront distribution for
             hosting a static site.
@@ -50,7 +47,7 @@ class S3ServerlessSite(ComponentResource):
         :type site_config: S3ServerlessSiteConfig
 
         :param opts: Pulumi resource options
-        :type opts: Optional[ResourceOptions]
+        :type opts: ResourceOptions
 
         :rtype: S3ServerlessSite
         """
@@ -60,7 +57,7 @@ class S3ServerlessSite(ComponentResource):
 
         resource_opts = ResourceOptions(parent=self).merge(opts)
 
-        self.site_bucket = s3.Bucket(
+        self.site_bucket = s3.BucketV2(
             f"{site_config.site_name}-bucket",
             bucket=site_config.bucket_name,
             acl="public-read",
@@ -79,9 +76,11 @@ class S3ServerlessSite(ComponentResource):
                 }
             ),
             tags=site_config.tags,
-            versioning={"enabled": True},
-            cors_rules=[{"allowedMethods": ["GET", "HEAD"], "allowedOrigins": ["*"]}],
-            website={"indexDocument": site_config.site_index},
+            # We need separate aws.s3.BucketVersioningV2 object instead.
+            # Same for Cors, website. -CAP
+            # versioning={"enabled": True},
+            # cors_rules=[{"allowedMethods": ["GET", "HEAD"], "allowedOrigins": ["*"]}],
+            # website={"indexDocument": site_config.site_index},
             opts=resource_opts,
         )
 

--- a/src/ol_infrastructure/infrastructure/aws/dns/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/dns/__main__.py
@@ -14,6 +14,16 @@ mitxpro_legacy_dns_zone = route53.Zone(
     opts=mitxpro_legacy_opts,
 )
 
+ocw_legacy_dns_name = "ocw-legacy.ocw.mit.edu"
+ocw_legacy_opts = zone_opts(ocw_legacy_dns_name)
+ocw_legacy_dns_zone = route53.Zone(
+    "ocw_legacy_subdomain",
+    name=ocw_legacy_dns_name,
+    comment="DNS Zone for legacy OCW resources",
+    tags=AWSBase(tags={"OU": "open-courseware", "Environment": "applications"}).tags,
+    opts=ocw_legacy_opts,
+)
+
 odl_dns_name = "odl.mit.edu"
 odl_opts = zone_opts(odl_dns_name)
 odl_dns_zone = route53.Zone(
@@ -113,6 +123,7 @@ podcast_dns_zone = route53.Zone(
 )
 
 export("mitxpro_legacy_zone_id", mitxpro_legacy_dns_zone.id)
+export("ocw_legacy_zone_id", ocw_legacy_dns_zone.id)
 export("odl_zone_id", odl_dns_zone.id)
 export("mitxonline", {"id": mitxonline_dns_zone.id, "domain": mitxonline_dns_zone.name})
 export("xpro", {"id": xpro_dns_zone.id, "domain": xpro_dns_zone.name})

--- a/src/ol_infrastructure/infrastructure/aws/s3_sites/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/s3_sites/__main__.py
@@ -22,7 +22,7 @@ if stack_info.env_suffix == "production":
         bucket_name="mitxpro-legacy-certificates",
         tags={"OU": "mitxpro", "Environment": "operations"},
     )
-    xpro_legacy_certs_site = S3ServerlessSite(xpro_legacy_certs_site_config)
+    xpro_legacy_certs_site = S3ServerlessSite(xpro_legacy_certs_site_config, opts=None)
     xpro_legacy_certs_domain = route53.Record(
         "xpro-legacy-certificates-domain",
         name=xpro_legacy_certs_site_config.domains[0],
@@ -36,3 +36,23 @@ if stack_info.env_suffix == "production":
         "xpro_certs_distribution_id", xpro_legacy_certs_site.cloudfront_distribution.id
     )
     export("xpro_certs_acm_cname", xpro_legacy_certs_site.site_tls.domain_name)
+    # Static site for hosting legacy OCW
+    ocw_legacy_zone_id = dns_stack.get_output("ocw_legacy_zone_id")
+    ocw_legacy_site_config = S3ServerlessSiteConfig(
+        site_name="ocw-legacy",
+        domains=["ocw-legacy.ocw.mit.edu"],
+        bucket_name="ocw-legacy",
+        tags={"OU": "open-courseware", "Environment": "applications"},
+    )
+    ocw_legacy_site = S3ServerlessSite(ocw_legacy_site_config, opts=None)
+    ocw_legacy_domain = route53.Record(
+        "ocw-legacy-domain",
+        name=ocw_legacy_site_config.domains[0],
+        type="CNAME",
+        ttl=fifteen_minutes,
+        records=[ocw_legacy_site.cloudfront_distribution.domain_name],
+        zone_id=ocw_legacy_zone_id,
+    )
+    export("ocw_legacy_bucket", ocw_legacy_site.site_bucket.bucket)
+    export("ocw_legacy_distribution_id", ocw_legacy_site.cloudfront_distribution.id)
+    export("ocw_legacy_acm_cname", ocw_legacy_site.site_tls.domain_name)


### PR DESCRIPTION
### What are the relevant tickets?
#2528 

### Description (What does it do?)
- Updates the s3_cloudfront_site service to use s3.BucketV2
- Add a new ocw-legacy site to s3_sites using the new service.

### How can this be tested?

Run:
```
pr pulumi up -s infrastructure.aws.s3_sites.Production
```

and spot check built resources for correctness.