### PR TITLE
Enable storage autoscaling up to 1TB by default for RDS

### DIFF
--- a/src/ol_infrastructure/components/aws/database.py
+++ b/src/ol_infrastructure/components/aws/database.py
@@ -75,7 +75,8 @@ class OLDBConfig(AWSBase):
     backup_days: conint(ge=0, le=MAX_BACKUP_DAYS, strict=True) = 30  # type: ignore  # noqa: PGH003
     db_name: Optional[str] = None  # The name of the database schema to create
     instance_size: str = DBInstanceTypes.general_purpose_large.value
-    max_storage: Optional[PositiveInt] = None  # Set to allow for storage autoscaling
+    # Set to allow for storage autoscaling. Default to 1 TB
+    max_storage: Optional[PositiveInt] = 1000
     multi_az: bool = True
     prevent_delete: bool = True
     public_access: bool = False


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
The current default configuration is that storage autoscaling of our RDS instances is disabled. This will lead to failures if the storage capacity is exhausted. This changes that to a default of up to 1TB autoscaled storage capacity in the event that the starting allocation starts to fill up.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run a `pulumi up` on a stack that uses an RDS instance and verify that the `maxAllocatedCapacity` will be modified if it is not otherwise set explicitly.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
This can lead to increased AWS costs, but it raises the threshold under which we are likely to experience errors due to storage capacity being exhausted. Currently, the largest database that we have in operation is ~400GB so 1TB is a substantial ceiling that we are unlikely to hit.

<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
