### PR TITLE
Add EDX_PROGRAMS_API_URL setting for mit learn

### DIFF
--- a/src/ol_infrastructure/applications/mitlearn/__main__.py
+++ b/src/ol_infrastructure/applications/mitlearn/__main__.py
@@ -884,6 +884,7 @@ heroku_vars = {
     "CSRF_COOKIE_DOMAIN": f".{mitopen_config.get('frontend_domain')}",
     "EDX_API_ACCESS_TOKEN_URL": "https://api.edx.org/oauth2/v1/access_token",
     "EDX_API_URL": "https://api.edx.org/catalog/v1/catalogs/10/courses",
+    "EDX_PROGRAMS_API_URL": "https://discovery.edx.org/api/v1/programs/",
     "MICROMASTERS_CATALOG_API_URL": "https://micromasters.mit.edu/api/v0/catalog/",
     "MICROMASTERS_CMS_API_URL": "https://micromasters.mit.edu/api/v0/wagtail/",
     "MITOL_ADMIN_EMAIL": "cuddle-bunnies@mit.edu",


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/mit-open/pull/1536

### Description (What does it do?)
Adds the EDX_PROGRAMS_API_URL setting value for prod and rc both (same value)


### How can this be tested?
N/A

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
