### PR TITLE
Adding OCW PostHog variables to Heroku config

### DIFF
--- a/.gitguardian.yml
+++ b/.gitguardian.yml
@@ -1,7 +1,0 @@
----
-version: 2
-
-secret:
-  ignored_matches:
-  - name: "PostHog API Key (public)"
-    match: "phc_XDgBzghi6cHYiBbiTsL91Fw03j073dXNSxtG7MWfeS0" #pragma: allowlist secret


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-studio/issues/2275.

### Description (What does it do?)
This PR adds the relevant PostHog environment variables to Heroku for OCW Studio, allowing for PostHog to control feature flags in the application.

### How can this be tested?
This can be tested on the OCW Studio RC server by confirming that the Heroku variables are being correctly read, analogously to the testing instructions for https://github.com/mitodl/ocw-studio/pull/2291.

