### PR TITLE
set MITOL_NOINDEX var in mit-learn environments

### DIFF
--- a/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.Production.yaml
+++ b/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.Production.yaml
@@ -48,6 +48,7 @@ config:
     MITOL_COOKIE_NAME: "learn"
     MITOL_LOG_LEVEL: "INFO"
     MITOL_NEW_USER_LOGIN_URL: "https://learn.mit.edu/onboarding"
+    MITOL_NOINDEX: "false"
     MITOL_SUPPORT_EMAIL: "learn-support@mit.edu"  # Need to verify
     OCW_ITERATOR_CHUNK_SIZE: 300
     OIDC_ENDPOINT: "https://sso.ol.mit.edu/realms/olapps"

--- a/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.QA.yaml
+++ b/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.QA.yaml
@@ -26,6 +26,7 @@ config:
     MITOL_COOKIE_NAME: "learn-rc"
     MITOL_LOG_LEVEL: "INFO"
     MITOL_NEW_USER_LOGIN_URL: "https://rc.learn.mit.edu/onboarding"
+    MITOL_NOINDEX: "true"
     MITOL_SUPPORT_EMAIL: "odl-learn-rc-support@mit.edu"   # Need to verify
     OCW_ITERATOR_CHUNK_SIZE: 300
     OIDC_ENDPOINT: "https://sso-qa.ol.mit.edu/realms/olapps"


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/5393

### Description (What does it do?)
This PR adds the new `MITOL_NOINDEX` setting to the `mit-learn` Pulumi configuration, setting it to true in QA and false in Production. This setting is being added to the environment ahead of https://github.com/mitodl/mit-open/pull/1559 to have configuration in place prior to the PR merging.

### How can this be tested?
This can only be tested after it has been merged and deployed, but should have no impact until the above PR is also merged and deployed.
