### PR TITLE
Adding a missing export to the DNS stack

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/dns/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/dns/__main__.py
@@ -114,6 +114,7 @@ podcast_dns_zone = route53.Zone(
 
 export("mitxpro_legacy_zone_id", mitxpro_legacy_dns_zone.id)
 export("odl_zone_id", odl_dns_zone.id)
+export("odl", {"id": odl_dns_zone.id, "domain": odl_dns_zone.name})
 export("mitxonline", {"id": mitxonline_dns_zone.id, "domain": mitxonline_dns_zone.name})
 export("xpro", {"id": xpro_dns_zone.id, "domain": xpro_dns_zone.name})
 export("mitx", {"id": mitx_dns_zone.id, "domain": mitx_dns_zone.name})


### PR DESCRIPTION


### Description (What does it do?)
Adding a normalized export for the odl zone in the dns stack.
