### PR TITLE
Add the nextjs domain for CORS and CSRF

### DIFF
--- a/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.QA.yaml
+++ b/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.QA.yaml
@@ -57,13 +57,15 @@ config:
     - "https://api.rc.learn.mit.edu"
     - "https://rc.learn.mit.edu"
     - "https://api.mitopen-rc.odl.mit.edu"  # legacy
-    - "https://mitopen-rc.odl.mit.edu"  # leagcy
+    - "https://mitopen-rc.odl.mit.edu"  # legacy
+    - "https://next.rc.learn.mit.edu" # In use while the https://github.com/mitodl/mit-open/tree/nextjs branch is active TODO remove
     cors_urls:
     - "https://mitopen-rc.odl.mit.edu" # legacy
     - "https://rc.learn.mit.edu"
     - "https://ocw-next.netlify.app"
     - "https://draft-qa.ocw.mit.edu"
     - "https://live-qa.ocw.mit.edu"
+    - "https://next.rc.learn.mit.edu" # In use while the https://github.com/mitodl/mit-open/tree/nextjs branch is active TODO remove
     mailgun_sender_domain: "mail-rc.learn.mit.edu"
     sso_url: "sso-qa.ol.mit.edu"
   mitopen:db_instance_size: db.m7g.xlarge

--- a/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.QA.yaml
+++ b/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.QA.yaml
@@ -58,14 +58,14 @@ config:
     - "https://rc.learn.mit.edu"
     - "https://api.mitopen-rc.odl.mit.edu"  # legacy
     - "https://mitopen-rc.odl.mit.edu"  # legacy
-    - "https://next.rc.learn.mit.edu" # In use while the https://github.com/mitodl/mit-open/tree/nextjs branch is active TODO remove
+    - "https://next.rc.learn.mit.edu"
     cors_urls:
     - "https://mitopen-rc.odl.mit.edu" # legacy
     - "https://rc.learn.mit.edu"
     - "https://ocw-next.netlify.app"
     - "https://draft-qa.ocw.mit.edu"
     - "https://live-qa.ocw.mit.edu"
-    - "https://next.rc.learn.mit.edu" # In use while the https://github.com/mitodl/mit-open/tree/nextjs branch is active TODO remove
+    - "https://next.rc.learn.mit.edu"
     mailgun_sender_domain: "mail-rc.learn.mit.edu"
     sso_url: "sso-qa.ol.mit.edu"
   mitopen:db_instance_size: db.m7g.xlarge


### PR DESCRIPTION
### What are the relevant tickets?

Relates to https://github.com/mitodl/hq/issues/5399

### Description (What does it do?)
<!--- Describe your changes in detail -->

We're deploying changes to our https://github.com/mitodl/mit-open/tree/nextjs feature branch to https://next.rc.learn.mit.edu/, which shares the RC API at https://api.rc.learn.mit.edu/.

This adds the origin URL to the CORS and CSRF whitelist so that the browser allows requests to the API.
