### PR TITLE
feat: Turn on max instance lifetime for our ec2 instances

### DIFF
--- a/src/ol_infrastructure/components/aws/auto_scale_group.py
+++ b/src/ol_infrastructure/components/aws/auto_scale_group.py
@@ -83,6 +83,7 @@ class OLTargetGroupConfig(AWSBase):
     health_check_protocol: str = "HTTPS"
     health_check_timeout: PositiveInt = PositiveInt(5)
     health_check_unhealthy_threshold: PositiveInt = PositiveInt(3)
+    max_instance_lifetime: Optional[PositiveInt] = 2592000  # 30 days
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @field_validator("stickiness")


### PR DESCRIPTION
This is set to 30 days as expressed in seconds.

### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
Fixes #2652
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This change sets the [max instance lifetime attribute](https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-max-instance-lifetime.html) on all of our AWS auto scaling groups to 30 days. It is currently unset.

This would mean that instances would refresh automatically every 30 days, likely curtailing many of the stale creds issues we now have.
 
### How can this be tested?

Run `pulumi up` on an application in CI. Note that the resource changes as expected. Monitor application health to ensure this isn't a destabilizing change.