### PR TITLE
Adds iam tag to vault users created in AWS

### DIFF
--- a/src/ol_infrastructure/components/services/vault.py
+++ b/src/ol_infrastructure/components/services/vault.py
@@ -235,7 +235,7 @@ class OLVaultAWSSecretsEngineConfig(BaseModel):
     vault_backend_path: str
     policy_documents: dict[str, str]
     credential_type: str = "iam_user"
-    iam_tags: list[str] = ["operations"]
+    iam_tags: list[str] = ["OU=operations"]
 
     @field_validator("vault_backend_path")
     @classmethod

--- a/src/ol_infrastructure/components/services/vault.py
+++ b/src/ol_infrastructure/components/services/vault.py
@@ -235,6 +235,7 @@ class OLVaultAWSSecretsEngineConfig(BaseModel):
     vault_backend_path: str
     policy_documents: dict[str, str]
     credential_type: str = "iam_user"
+    iam_tags: list[str] = ["operations"]
 
     @field_validator("vault_backend_path")
     @classmethod

--- a/src/ol_infrastructure/components/services/vault.py
+++ b/src/ol_infrastructure/components/services/vault.py
@@ -235,7 +235,7 @@ class OLVaultAWSSecretsEngineConfig(BaseModel):
     vault_backend_path: str
     policy_documents: dict[str, str]
     credential_type: str = "iam_user"
-    iam_tags: list[str] = ["OU=operations"]
+    iam_tags: list[str] = ["OU=operations", "vault_managed=True"]
 
     @field_validator("vault_backend_path")
     @classmethod


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
Noticed that Vault created users in AWS IAM are not tagged. This should add tags to newly created accounts by vault based on [vault documentation](https://developer.hashicorp.com/vault/api-docs/secret/aws#parameters-3)

