### PR TITLE
Switch to using ol-mitlearn-client

### DIFF
--- a/src/ol_infrastructure/applications/mitlearn/__main__.py
+++ b/src/ol_infrastructure/applications/mitlearn/__main__.py
@@ -924,7 +924,7 @@ heroku_vars = {
     "SEE_API_ACCESS_TOKEN_URL": "https://mit-unified-portal-prod-78eeds.43d8q2.usa-e2.cloudhub.io/oauth/token",
     "SECURE_CROSS_ORIGIN_OPENER_POLICY": "None",
     "SEE_BASE_URL": "https://executive.mit.edu/",
-    "SOCIAL_AUTH_OL_OIDC_KEY": "ol-open-client",
+    "SOCIAL_AUTH_OL_OIDC_KEY": "ol-mitlearn-client",
     "USE_X_FORWARDED_HOST": "True",
     "USE_X_FORWARDED_PORT": "True",
     "XPRO_CATALOG_API_URL": "https://xpro.mit.edu/api/programs/",

--- a/src/ol_infrastructure/substructure/keycloak/__main__.py
+++ b/src/ol_infrastructure/substructure/keycloak/__main__.py
@@ -514,9 +514,7 @@ for openid_clients in keycloak_realm_config.get_object("openid_clients"):
     realm_name = openid_clients.get("realm_name")
     client_details = openid_clients.get("client_info")
     for client_name, client_detail in client_details.items():
-        urls = [client_detail[0]]
-        if len(client_detail) > 1 and client_detail[1].startswith("https"):
-            urls.append(client_detail[1])
+        urls = [url for url in client_detail if url.startswith("https")]
 
         openid_client = keycloak.openid.Client(
             f"{realm_name}-{client_name}-client",

--- a/src/ol_infrastructure/substructure/keycloak/__main__.py
+++ b/src/ol_infrastructure/substructure/keycloak/__main__.py
@@ -514,7 +514,10 @@ for openid_clients in keycloak_realm_config.get_object("openid_clients"):
     realm_name = openid_clients.get("realm_name")
     client_details = openid_clients.get("client_info")
     for client_name, client_detail in client_details.items():
-        url = client_detail[0]
+        urls = [client_detail[0]]
+        if len(client_detail) > 1 and client_detail[1].startswith("https"):
+            urls.append(client_detail[1])
+
         openid_client = keycloak.openid.Client(
             f"{realm_name}-{client_name}-client",
             name=f"ol-{client_name}-client",
@@ -523,7 +526,7 @@ for openid_clients in keycloak_realm_config.get_object("openid_clients"):
             enabled=True,
             access_type="CONFIDENTIAL",
             standard_flow_enabled=True,
-            valid_redirect_uris=[f"{url}"],
+            valid_redirect_uris=urls,
             opts=resource_options.merge(ResourceOptions(delete_before_replace=True)),
         )
         vault.generic.Secret(


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
Ran into an issue yesterday where the Learn app was still using the `ol-open-client` Keycloak client. This switches it to using the existing `ol-mitlearn-client`. Additionally, noticed that we were only adding the first url in the list for the redirect_uri, and this fixes it to where it checks all items in list.
### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Tested it by running it locally and saw the needed changes.
### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
