### PR TITLE
IAM adjustments for EKS clusters

### DIFF
--- a/src/ol_infrastructure/applications/concourse/__main__.py
+++ b/src/ol_infrastructure/applications/concourse/__main__.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import pulumi_vault as vault
 import yaml
-from pulumi import Config, Output, StackReference
+from pulumi import Config, Output, StackReference, export
 from pulumi_aws import ec2, get_caller_identity, iam, route53
 from pulumi_consul import Node, Service, ServiceCheckArgs
 
@@ -615,6 +615,8 @@ for worker_def in concourse_config.get_object("workers") or []:
         path="/ol-applications/concourse/role/",
         tags=aws_config.tags,  # We will leave all the IAM resources with default tags.
     )
+
+    export(f"{worker_class_name}-instance-role-arn", concourse_worker_instance_role.arn)
 
     for iam_policy_name in worker_def["iam_policies"] or []:
         iam_policy_object = iam_policy_objects[iam_policy_name]

--- a/src/ol_infrastructure/infrastructure/aws/iam/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/iam/__main__.py
@@ -1,7 +1,13 @@
-from pulumi import export
-from pulumi_aws import iam
+import json
 
-from ol_infrastructure.lib.aws.iam_helper import ADMIN_USERNAMES, EKS_ADMIN_USERNAMES
+from pulumi import StackReference, export
+from pulumi_aws import get_caller_identity, iam
+
+from ol_infrastructure.lib.aws.iam_helper import (
+    ADMIN_USERNAMES,
+    EKS_ADMIN_USERNAMES,
+    IAM_POLICY_VERSION,
+)
 
 administrator_iam_group = iam.Group(
     "administrators-iam-group",
@@ -37,3 +43,38 @@ eks_administrator_export_dict = {
 }
 
 export("eks_administrators", eks_administrator_export_dict)
+
+account_id = get_caller_identity().account_id
+concourse_production_stack = StackReference("applications.concourse.Production")
+
+# The people or nodes assuming this role already have admin powers
+eks_cluster_creator_role = iam.Role(
+    "eks-cluster-creator-role",
+    assume_role_policy=concourse_production_stack.require_output(
+        "infra-instance-role-arn"
+    ).apply(
+        lambda concourse_arn: json.dumps(
+            {
+                "Version": IAM_POLICY_VERSION,
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": "sts:AssumeRole",
+                        "Principal": {
+                            "Service": "ec2.amazonaws.com",
+                            "AWS": [
+                                f"arn:aws:iam::{account_id}:user/{username}"
+                                for username in EKS_ADMIN_USERNAMES
+                            ]
+                            + [concourse_arn],
+                        },
+                    }
+                ],
+            }
+        )
+    ),
+    path="/ol-infrastructure/eks/shared/",
+    managed_policy_arns=["arn:aws:iam::aws:policy/AdministratorAccess"],
+)
+
+export("eks_cluster_creator_role_arn", eks_cluster_creator_role.arn)


### PR DESCRIPTION
### Description (What does it do?)
- Adds a version specifier for K8S Clusters 
- Creates an IAM role that DevOps and Production Concourse instances can assume which will be used to build EKS clusters. This role will 'own' the clusters that it makes, and keeps any one person's credentials / IAM from becoming associated with an EKS cluster. 
- Changed the kube_config file that the EKS stacks export to include the AssumeRole arguments that we use on the command line. This keeps us from having to have an access entry for every devops user (or concourse instance role) on the cluster. 
