### PR TITLE
feat: scheduling daily digest command to run every midnight UTC

### DIFF
--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -178,6 +178,17 @@ CACHES:  # MODIFIED
     staticfiles:
       <<: *redis_cache_config
       KEY_PREFIX: staticfiles
+CELERY_BEAT_SCHEDULE:
+    send-email-digest:
+      task: openedx.core.djangoapps.notifications.emails.tasks.send_digest_email_to_all_users
+      schedule:
+        minute: 0
+        hour: 0
+        day_of_week: "*"
+        day_of_month: "*"
+        month_of_year: "*"
+      args:
+        - "Daily"
 CELERYBEAT_SCHEDULER: redbeat.RedBeatScheduler  # MODIFIED
 CELERY_BROKER_HOSTNAME: edxapp-redis.service.consul:6379  # MODIFIED
 CELERY_BROKER_TRANSPORT: rediss  # MODIFIED - second "s" indicates "secure"


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4070

### Description (What does it do?)
This PR adds the `CELERY_BEAT_SCHEDULE`  in [src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl](https://github.com/mitodl/ol-infrastructure/blob/614f5302b7ac417320640665957c944bf31f3525/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl) to send the daily email digest every midnight UTC.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
