### PR TITLE
config: Add OU tagging to cloudwatch alarms for cost allocation

### DIFF
--- a/src/ol_infrastructure/components/aws/cache.py
+++ b/src/ol_infrastructure/components/aws/cache.py
@@ -220,6 +220,7 @@ class OLAmazonCache(pulumi.ComponentResource):
                     cluster_id=cache_config.cluster_name,
                     node_id=node_id_suffix,
                     name=f"{cache_config.cluster_name}{node_id_suffix}-{alarm_name}-OLCloudWatchAlarmSimpleElastiCacheConfig",
+                    tags=cache_config.tags,
                     **alarm_args,
                 )
                 OLCloudWatchAlarmSimpleElastiCache(alarm_config=alarm_config)

--- a/src/ol_infrastructure/components/aws/cloudwatch.py
+++ b/src/ol_infrastructure/components/aws/cloudwatch.py
@@ -125,6 +125,7 @@ class OLCloudWatchAlarmSimpleElastiCacheConfig(OLCloudWatchAlarmSimpleConfig):
     cluster_id: Union[str, Output[str]]
     node_id: str
     namespace: str = "AWS/ElastiCache"
+    tags: dict[str, str] | None = None
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
 
@@ -163,6 +164,7 @@ class OLCloudWatchAlarmSimpleElastiCache(ComponentResource):
             namespace=alarm_config.namespace,
             period=alarm_config.period,
             statistic=alarm_config.statistic,
+            tags=alarm_config.tags,
             treat_missing_data=alarm_config.treat_missing_data_as,
             threshold=alarm_config.threshold,
             unit=alarm_config.unit,
@@ -175,6 +177,7 @@ class OLCloudWatchAlarmSimpleRDSConfig(OLCloudWatchAlarmSimpleConfig):
 
     database_identifier: str
     namespace: str = "AWS/RDS"
+    tags: dict[str, str] | None = None
 
 
 class OLCloudWatchAlarmSimpleRDS(ComponentResource):
@@ -211,6 +214,7 @@ class OLCloudWatchAlarmSimpleRDS(ComponentResource):
             namespace=alarm_config.namespace,
             period=alarm_config.period,
             statistic=alarm_config.statistic,
+            tags=alarm_config.tags,
             treat_missing_data=alarm_config.treat_missing_data_as,
             threshold=alarm_config.threshold,
             unit=alarm_config.unit,

--- a/src/ol_infrastructure/components/aws/database.py
+++ b/src/ol_infrastructure/components/aws/database.py
@@ -336,6 +336,7 @@ class OLAmazonDB(pulumi.ComponentResource):
                 alarm_config = OLCloudWatchAlarmSimpleRDSConfig(
                     database_identifier=db_config.instance_name,
                     name=f"{db_config.instance_name}-{alarm_name}-OLCloudWatchAlarmSimpleRDSConfig",
+                    tags=db_config.tags,
                     **alarm_args,
                 )
                 OLCloudWatchAlarmSimpleRDS(alarm_config=alarm_config)


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds tagging to Cloudwatch alarms to include OU for cost allocation purposes

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Apply a stack that includes an RDS and/or Elasticache component and verify that the Cloudwatch alarms receive an OU tag
