### PR TITLE
Add email optin attribute and protocol mappers to ol apps keycloak config

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/__main__.py
+++ b/src/ol_infrastructure/substructure/keycloak/__main__.py
@@ -356,6 +356,14 @@ ol_apps_user_profile = keycloak.RealmUserProfile(
                 views=["admin", "user"], edits=["admin", "user"]
             ),
         ),
+        keycloak.RealmUserProfileAttributeArgs(
+            name="emailOptIn",
+            display_name="${emailOptIn}",
+            required_for_roles=[],
+            permissions=keycloak.RealmUserProfileAttributePermissionsArgs(
+                views=["admin", "user"], edits=["admin", "user"]
+            ),
+        ),
     ],
     groups=[
         keycloak.RealmUserProfileGroupArgs(
@@ -369,6 +377,27 @@ ol_apps_user_profile = keycloak.RealmUserProfile(
             display_description="User's legal address",
         ),
     ],
+)
+
+ol_apps_profile_client_scope = keycloak.openid.ClientScope(
+    "profile", realm_id=ol_apps_realm.id
+)
+
+ol_apps_user_email_optin_attribute_mapper = keycloak.openid.UserAttributeProtocolMapper(
+    "email-optin-mapper",
+    realm_id=ol_apps_realm.id,
+    client_scope_id=ol_apps_profile_client_scope.id,
+    name="email-optin-mapper",
+    user_attribute="emailOptIn",
+    claim_name="email_optin",
+)
+ol_apps_user_fullname_attribute_mapper = keycloak.openid.UserAttributeProtocolMapper(
+    "fullname-mapper",
+    realm_id=ol_apps_realm.id,
+    client_scope_id=ol_apps_profile_client_scope.id,
+    name="fullname-mapper",
+    user_attribute="fullName",
+    claim_name="name",
 )
 
 """ # noqa: ERA001


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/5559#issuecomment-2392330230

### Description (What does it do?)
<!--- Describe your changes in detail -->
This adds the email opt in field to the user profile attributes and also adds protocol mappers for this and the last name field so that those can come back on the `openid-connect/userinfo` API response.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
I'm not aware of how to test this locally, I think we need to test it in a deployed test environment first.
