### PR TITLE
Adds the nextjs subdomain for CORS and CSRF

### DIFF
--- a/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.QA.yaml
+++ b/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.QA.yaml
@@ -59,6 +59,7 @@ config:
     - "https://api.mitopen-rc.odl.mit.edu"  # legacy
     - "https://mitopen-rc.odl.mit.edu"  # legacy
     - "https://next.rc.learn.mit.edu"
+    - "https://nextjs-rc.learn.mit.edu"
     cors_urls:
     - "https://mitopen-rc.odl.mit.edu" # legacy
     - "https://rc.learn.mit.edu"
@@ -66,6 +67,7 @@ config:
     - "https://draft-qa.ocw.mit.edu"
     - "https://live-qa.ocw.mit.edu"
     - "https://next.rc.learn.mit.edu"
+    - "https://nextjs-rc.learn.mit.edu"
     mailgun_sender_domain: "mail-rc.learn.mit.edu"
     sso_url: "sso-qa.ol.mit.edu"
   mitopen:db_instance_size: db.m7g.xlarge


### PR DESCRIPTION
### What are the relevant tickets?

Relates to https://github.com/mitodl/hq/issues/5399

### Description (What does it do?)
<!--- Describe your changes in detail -->

We have a new subdomain for the Next.js service's CDN at nextjs-rc.learn.mit.edu

This adds the origin URL to the CORS and CSRF whitelist so that the browser allows requests to the API.
