### PR TITLE
Md/vault secrets operator transit encryption

### DIFF
--- a/src/ol_infrastructure/applications/open_metadata/open_metadata_policy.hcl
+++ b/src/ol_infrastructure/applications/open_metadata/open_metadata_policy.hcl
@@ -20,7 +20,7 @@ path "sys/leases/renew" {
     lease_id = ["postgres-open-metadata/creds/app/*"]
   }
 }
-path "sys/leases/renew" {
+path "sys/leases/revoke" {
   capabilities = ["update"]
   allowed_parameters = {
     lease_id = ["postgres-open-metadata/creds/app/*"]

--- a/src/ol_infrastructure/applications/open_metadata/open_metadata_policy.hcl
+++ b/src/ol_infrastructure/applications/open_metadata/open_metadata_policy.hcl
@@ -10,6 +10,19 @@ path "secret-operations/sso/open_metadata/*" {
 path "secret-operations/sso/open_metadata" {
   capabilities = ["read"]
 }
+# vault-secrets-operator is a little more particular about
+# managing its own leases, give it the permissions it needs
+# for dynamic secret renwals / revocation without giving
+# it the power to revoke or renew anything
 path "sys/leases/renew" {
   capabilities = ["update"]
+  allowed_parameters = {
+    lease_id = ["postgres-open-metadata/creds/app/*"]
+  }
+}
+path "sys/leases/renew" {
+  capabilities = ["update"]
+  allowed_parameters = {
+    lease_id = ["postgres-open-metadata/creds/app/*"]
+  }
 }

--- a/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
@@ -4,6 +4,7 @@
 
 import base64
 import json
+from pathlib import Path
 
 import pulumi_aws as aws
 import pulumi_eks as eks
@@ -587,6 +588,31 @@ vault_k8s_auth_backend_config = vault.kubernetes.AuthBackendConfig(
 )
 export("vault_auth_endpoint", vault_auth_endpoint_name)
 
+# This role allows the vault secrets operator to use a transit mount for
+# maintaining a cache of open leases. Makes operator restarts less painful
+# on applications
+# Ref: https://developer.hashicorp.com/vault/tutorials/kubernetes/vault-secrets-operator#transit-encryption
+transit_policy_name = f"{stack_info.env_prefix}-eks-vso-transit"
+transit_policy = vault.Policy(
+    f"{cluster_name}-eks-vault-secrets-operator-transit-policy",
+    name=transit_policy_name,
+    policy=Path(__file__).parent.joinpath("vso_transit_policy.hcl").read_text(),
+    opts=ResourceOptions(parent=vault_k8s_auth),
+)
+transit_role_name = "vso-transit"
+vault_secrets_operator_service_account_name = (
+    "vault-secrets-operator-controller-manager"
+)
+vault_secret_operator_transit_role = vault.kubernetes.AuthBackendRole(
+    f"{cluster_name}-eks-vault-secrets-operator-transit-role",
+    role_name=transit_role_name,
+    backend=vault_auth_endpoint_name,
+    bound_service_account_names=[vault_secrets_operator_service_account_name],
+    bound_service_account_namespaces=["operations"],
+    token_policies=[transit_policy_name],
+    opts=ResourceOptions(parent=vault_k8s_auth),
+)
+
 # Install the vault-secrets-operator directly from the public chart
 vault_secrets_operator = kubernetes.helm.v3.Release(
     f"{cluster_name}-vault-secrets-operator-helm-release",
@@ -612,6 +638,22 @@ vault_secrets_operator = kubernetes.helm.v3.Release(
             "controller": {
                 "replicas": 1,
                 "tolerations": operations_tolerations,
+                "manager": {
+                    "clientCache": {
+                        "persistenceModel": "direct-encrypted",
+                        "storageEncryption": {
+                            "enabled": True,
+                            "mount": vault_auth_endpoint_name,
+                            "keyName": "vault-secrets-operator",
+                            "transitMount": "infrastructure",
+                            "kubernetes": {
+                                "role": transit_role_name,
+                                "serviceAccount": "vault-secrets-operator-controller-manager",
+                                "tokenAudiences": [],
+                            },
+                        },
+                    },
+                },
             },
         },
         skip_await=False,
@@ -619,7 +661,7 @@ vault_secrets_operator = kubernetes.helm.v3.Release(
     opts=ResourceOptions(
         provider=k8s_provider,
         parent=operations_namespace,
-        depends_on=[cluster, node_groups[0]],
+        depends_on=[cluster, node_groups[0], vault_secret_operator_transit_role],
         delete_before_replace=True,
     ),
 )

--- a/src/ol_infrastructure/infrastructure/aws/eks/vso_transit_policy.hcl
+++ b/src/ol_infrastructure/infrastructure/aws/eks/vso_transit_policy.hcl
@@ -1,0 +1,6 @@
+path "infrastructure/encrypt/vault-secrets-operator" {
+   capabilities = ["create", "update"]
+}
+path "infrastructure/decrypt/vault-secrets-operator" {
+   capabilities = ["create", "update"]
+}

--- a/src/ol_infrastructure/substructure/vault/encryption_mounts/__main__.py
+++ b/src/ol_infrastructure/substructure/vault/encryption_mounts/__main__.py
@@ -19,3 +19,11 @@ vault_sops_infrastructure_key = vault.transit.SecretBackendKey(
     type="aes256-gcm96",
     deletion_allowed=True,
 )
+
+vault_secrets_operator_key = vault.transit.SecretBackendKey(
+    "vault-secrets-operator-key",
+    name="vault-secrets-operator",
+    backend=vault_infrastructure_transit.path,
+    type="aes256-gcm96",
+    deletion_allowed=True,
+)


### PR DESCRIPTION


### Description (What does it do?)
Added a transit encryption key for the vault-secrets-operator + enabled the secret cache for the vault-secrets-operator and tweaked the policy for open-metadata to play more nicely with what VSO wants.

This makes the vault-secrets-operator better at its job and less disruptive to applications. 
