### PR TITLE
Duplicate open-api-clients build pipeline for Unified Ecommerce

### DIFF
--- a/src/ol_concourse/pipelines/libraries/scripts/unified-ecommerce-api-clients-bumpver.sh
+++ b/src/ol_concourse/pipelines/libraries/scripts/unified-ecommerce-api-clients-bumpver.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+pip install bumpver
+
+bumpver update

--- a/src/ol_concourse/pipelines/libraries/scripts/unified-ecommerce-api-clients-commit-changes.sh
+++ b/src/ol_concourse/pipelines/libraries/scripts/unified-ecommerce-api-clients-commit-changes.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Commmit the updated clients w/ a commit message referencing
+# the unified-ecommerce commit we generated it from.
+
+# only src/ files are expected to be modified
+git add -u
+
+git status
+
+git config --global user.name "MIT Open Learning Engineering"
+git config --global user.email "odl-devops@mit.edu"
+
+git commit -m "Generated clients from rev: $OPEN_REV"

--- a/src/ol_concourse/pipelines/libraries/scripts/unified-ecommerce-api-clients-publish-node.sh
+++ b/src/ol_concourse/pipelines/libraries/scripts/unified-ecommerce-api-clients-publish-node.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -x
+# publish the npm package to npmjs.org
+
+echo "//registry.npmjs.org/:_authToken=((unified_ecommerce_api_clients.npmjs_token))" > .npmrc
+yarn install --immutable
+yarn build
+# OK so this is vaguely gross but it will do :)
+new_version=$(cat ../../../VERSION)
+echo "Publishing version $new_version"
+yarn publish --access public --new-version "$new_version"

--- a/src/ol_concourse/pipelines/libraries/scripts/unified-ecommerce-api-clients-tag-release.sh
+++ b/src/ol_concourse/pipelines/libraries/scripts/unified-ecommerce-api-clients-tag-release.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Commit the updated version and tag it
+
+VERSION=$(cat VERSION)
+
+git add .
+git status
+
+git config --global user.name "MIT Open Learning Engineering"
+git config --global user.email "oldevops@mit.edu"
+
+git commit -m "Release: $VERSION"
+
+git tag "v$VERSION"

--- a/src/ol_concourse/pipelines/libraries/unified_ecommerce_api_clients.py
+++ b/src/ol_concourse/pipelines/libraries/unified_ecommerce_api_clients.py
@@ -135,7 +135,10 @@ generate_clients_job = Job(
                 run=Command(
                     path="sh",
                     dir=unified_ecommerce_api_clients_repository.name,
-                    args=["-xc", _read_script("unified-ecommerce-api-clients-commit-changes.sh")],
+                    args=[
+                        "-xc",
+                        _read_script("unified-ecommerce-api-clients-commit-changes.sh"),
+                    ],
                 ),
             ),
         ),
@@ -168,7 +171,10 @@ publish_job = Job(
                 run=Command(
                     path="sh",
                     dir="unified-ecommerce-api-clients/src/typescript/unified-ecommerce-api-axios",
-                    args=["-xc", _read_script("unified-ecommerce-api-clients-publish-node.sh")],
+                    args=[
+                        "-xc",
+                        _read_script("unified-ecommerce-api-clients-publish-node.sh"),
+                    ],
                 ),
             ),
         ),

--- a/src/ol_concourse/pipelines/libraries/unified_ecommerce_api_clients.py
+++ b/src/ol_concourse/pipelines/libraries/unified_ecommerce_api_clients.py
@@ -1,0 +1,198 @@
+import sys
+from pathlib import Path
+
+from ol_concourse.lib.models.pipeline import (
+    AnonymousResource,
+    Command,
+    GetStep,
+    Identifier,
+    Input,
+    Job,
+    LoadVarStep,
+    Output,
+    Pipeline,
+    PutStep,
+    RegistryImage,
+    Resource,
+    TaskConfig,
+    TaskStep,
+)
+from ol_concourse.lib.resources import git_repo, ssh_git_repo
+
+unified_ecommerce_repository_uri = "https://github.com/mitodl/unified-ecommerce"
+
+
+def _read_script(script_name: str) -> str:
+    return (Path(__file__).parent / "scripts" / script_name).read_text()
+
+
+git_image = Resource(
+    name=Identifier("git-image"),
+    type="docker-image",
+    source={
+        "repository": "concourse/buildroot",
+        "tag": "git",
+    },
+)
+openapi_generator_image = Resource(
+    name=Identifier("openapi-generator-image"),
+    type="registry-image",
+    icon="docker",
+    source={
+        "repository": "openapitools/openapi-generator-cli",
+        "tag": "v7.2.0",
+    },
+)
+python_image = Resource(
+    name=Identifier("python-image"),
+    type="registry-image",
+    icon="docker",
+    source={
+        "repository": "python",
+        "tag": "3.11-slim",
+    },
+)
+node_image = Resource(
+    name=Identifier("node-image"),
+    type="registry-image",
+    icon="docker",
+    source={
+        "repository": "node",
+        "tag": "18-slim",
+    },
+)
+
+unified_ecommerce_repository = git_repo(
+    name=Identifier("unified-ecommerce"),
+    uri=unified_ecommerce_repository_uri,
+    branch="release",
+    paths=["openapi/specs/*.yaml"],
+)
+
+unified_ecommerce_api_clients_repository = ssh_git_repo(
+    name=Identifier("unified-ecommerce-api-clients"),
+    uri="git@github.com:mitodl/open-api-clients.git",
+    branch="main",
+    private_key="((unified_ecommerce_api_clients.odlbot_private_ssh_key))",
+)
+
+generate_clients_job = Job(
+    name=Identifier("generate-clients"),
+    plan=[
+        GetStep(get=python_image.name),
+        GetStep(get=unified_ecommerce_repository.name, trigger=True),
+        GetStep(get=unified_ecommerce_api_clients_repository.name, trigger=False),
+        GetStep(get=openapi_generator_image.name),
+        TaskStep(
+            task=Identifier("generate-apis"),
+            image=openapi_generator_image.name,
+            config=TaskConfig(
+                platform="linux",
+                inputs=[
+                    Input(name=unified_ecommerce_repository.name),
+                    Input(name=unified_ecommerce_api_clients_repository.name),
+                ],
+                outputs=[Output(name=unified_ecommerce_api_clients_repository.name)],
+                run=Command(
+                    path="/bin/bash",
+                    args=["unified-ecommerce-api-clients/scripts/generate-inner.sh"],
+                ),
+            ),
+        ),
+        LoadVarStep(
+            load_var=Identifier("unified-ecommerce-git-rev"),
+            file=f"{unified_ecommerce_repository.name}/.git/refs/heads/{unified_ecommerce_repository.source['branch']}",
+            reveal=True,
+        ),
+        TaskStep(
+            task="bump-version",
+            image=python_image.name,
+            config=TaskConfig(
+                platform="linux",
+                inputs=[Input(name=unified_ecommerce_api_clients_repository.name)],
+                outputs=[Output(name=unified_ecommerce_api_clients_repository.name)],
+                run=Command(
+                    path="sh",
+                    dir=unified_ecommerce_api_clients_repository.name,
+                    args=[
+                        "-xc",
+                        _read_script("unified-ecommerce-api-clients-bumpver.sh"),
+                    ],
+                ),
+            ),
+        ),
+        TaskStep(
+            task="commit-changes",
+            config=TaskConfig(
+                inputs=[Input(name=unified_ecommerce_api_clients_repository.name)],
+                outputs=[Output(name=unified_ecommerce_api_clients_repository.name)],
+                image_resource=AnonymousResource(
+                    source=RegistryImage(repository="concourse/buildroot", tag="git"),
+                    type="registry-image",
+                ),
+                platform="linux",
+                params={"OPEN_REV": "((.:unified-ecommerce-git-rev))"},
+                run=Command(
+                    path="sh",
+                    dir=unified_ecommerce_api_clients_repository.name,
+                    args=["-xc", _read_script("unified-ecommerce-api-clients-commit-changes.sh")],
+                ),
+            ),
+        ),
+        PutStep(
+            put=unified_ecommerce_api_clients_repository.name,
+            params={
+                "repository": unified_ecommerce_api_clients_repository.name,
+                "tag": "unified-ecommerce-api-clients/VERSION",
+            },
+        ),
+    ],
+)
+
+publish_job = Job(
+    name="publish",
+    plan=[
+        GetStep(get=node_image.name, trigger=True),
+        GetStep(
+            get=unified_ecommerce_api_clients_repository.name,
+            passed=[generate_clients_job.name],
+            trigger=True,
+        ),
+        TaskStep(
+            task="publish-node",
+            image=node_image.name,
+            config=TaskConfig(
+                platform="linux",
+                inputs=[Input(name=unified_ecommerce_api_clients_repository.name)],
+                params={"NPM_TOKEN": "((unified_ecommerce_api_clients.npmjs_token))"},
+                run=Command(
+                    path="sh",
+                    dir="unified-ecommerce-api-clients/src/typescript/unified-ecommerce-api-axios",
+                    args=["-xc", _read_script("unified-ecommerce-api-clients-publish-node.sh")],
+                ),
+            ),
+        ),
+    ],
+)
+
+build_pipeline = Pipeline(
+    resources=[
+        unified_ecommerce_repository,
+        unified_ecommerce_api_clients_repository,
+        openapi_generator_image,
+        python_image,
+        node_image,
+    ],
+    jobs=[
+        generate_clients_job,
+        publish_job,
+    ],
+)
+
+if __name__ == "__main__":
+    with open("definition.json", "w") as definition:  # noqa: PTH123
+        definition.write(build_pipeline.model_dump_json(indent=2))
+    sys.stdout.write(build_pipeline.model_dump_json(indent=2))
+    sys.stdout.write(
+        "fly -t <prod_target> set-pipeline -p open-api-clients -c definition.json"
+    )


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/5723

### Description (What does it do?)

We need a pipeline to build the Unified Ecommerce API clients and publish them to NPM. This should work just about the same way that the MIT Learn clients are built, so this adds basically the same stuff that was there for Learn but updates it for UE.

We have a repo set up with the same infrastructure as open-api-clients here: https://github.com/mitodl/unified-ecommerce-api-clients

### How can this be tested?

Not real sure - I'm not totally up on how Concourse works. It will need keys added for pushing to the repo and publishing to npm. 
