### PR TITLE
refactor: Move postgres role creation statements inline

### DIFF
--- a/src/ol_infrastructure/lib/vault.py
+++ b/src/ol_infrastructure/lib/vault.py
@@ -61,7 +61,7 @@ postgres_role_statements = {
         "renew": [],
         "rollback": [],
     },
-    "approle": {
+    "app": {
         "create": [
             # Check if the role exists and create it if not
             Template(
@@ -113,15 +113,6 @@ postgres_role_statements = {
                 """
             ),
             Template("""RESET ROLE;"""),
-        ],
-        # Don't provide a revoke statement so that Vault won't accidentally remove the
-        # role
-        "revoke": [],
-        "renew": [],
-        "rollback": [],
-    },
-    "app": {
-        "create": [
             # Create the user in ${app_name}
             Template(
                 """
@@ -155,7 +146,7 @@ postgres_role_statements = {
         "renew": [],
         "rollback": [],
     },
-    "readonly_role": {
+    "readonly": {
         "create": [
             # Check if the role exists and create it if not
             Template(
@@ -204,13 +195,6 @@ postgres_role_statements = {
                 """
             ),
             Template("""RESET ROLE;"""),
-        ],
-        "revoke": [],
-        "renew": [],
-        "rollback": [],
-    },
-    "readonly": {
-        "create": [
             # Create the read-only user and put it into the read-only-role
             Template(
                 """


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Having the role creation statements as a separate vault role definition causes confusion and impedes our ability to cleanly set up new apps and environments without manual intervention. The previous motivation for splitting the statements into separate blocks was due to an unrelated issue with excessive readonly users being granted direct access to tables and other objects. That is no longer the case so the role definitions can be moved back in-line.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Apply the change to a stack with a postgres database and ensure that generation of app or readonly credentials still functions properly.

