### PR TITLE
fix: celery beat schedule name in edx

### DIFF
--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -178,7 +178,7 @@ CACHES:  # MODIFIED
     staticfiles:
       <<: *redis_cache_config
       KEY_PREFIX: staticfiles
-CELERY_BEAT_SCHEDULE:
+CELERYBEAT_SCHEDULE:
     send-email-digest:
       task: openedx.core.djangoapps.notifications.emails.tasks.send_digest_email_to_all_users
       schedule:


### PR DESCRIPTION
### What are the relevant tickets?
Fixes the celery beat schedule name

### Description (What does it do?)
While viewing the logs on MITx Online QA edX to test https://github.com/mitodl/hq/issues/4070, I found that the Celery task didn’t run. Upon further investigation, I discovered that the Celery beat schedule attribute is named `CELERYBEAT_SCHEDULE` in edX ([reference](https://github.com/openedx/edx-platform/blob/42febb62ce9fae115a07a03676731ac749ad670b/lms/envs/common.py#L2908)). This might be the reason why the job was not run by Celery.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
