### PR TITLE
disable ENABLE_TAGGING_TAXONOMY_PAGES flag by default

### DIFF
--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -41,6 +41,7 @@ class OpenEdxVars(BaseModel):
     account_settings_url: Optional[str] = None
     contact_url: Optional[str] = None
     enable_certificate_page: Optional[Literal["true", "false"]] = None
+    enable_tagging_taxonomy_pages: Optional[Literal["true", "false"]] = "false"
     deployment_name: OpenEdxDeploymentName
     display_feedback_widget: Optional[str] = None
     environment: str
@@ -84,6 +85,7 @@ def mfe_params(
         "CSRF_TOKEN_API_PATH": "/csrf/api/v1/token",
         "DISPLAY_FEEDBACK_WIDGET": open_edx.display_feedback_widget,
         "ENABLE_CERTIFICATE_PAGE": open_edx.enable_certificate_page,
+        "ENABLE_TAGGING_TAXONOMY_PAGES": open_edx.enable_tagging_taxonomy_pages,
         "DISCUSSIONS_MFE_BASE_URL": f"https://{open_edx.lms_domain}/{discussion_mfe_path}",
         "FAVICON_URL": open_edx.favicon_url,
         "HONOR_CODE_URL": open_edx.honor_code_url,


### PR DESCRIPTION
### What are the relevant tickets?
fixes https://github.com/mitodl/hq/issues/5629

### Description (What does it do?)
It will disable `ENABLE_TAGGING_TAXONOMY_PAGES` flag's value to `"false"` by default


### How can this be tested?
1. Login to studio
2. Go to any course
3. Click on tools dropdown
4. see if `Export Tag` option is removed

### Additional Context
It will also remove Taxonomies from the studio home page
![Screenshot 2024-10-21 at 4 20 30 PM](https://github.com/user-attachments/assets/b3b992fc-dbe9-44f4-b1e1-d28576e98924)


### Checklist:
- [x] Add mfe_config flag `ENABLE_TAGGING_TAXONOMY_PAGES` and set its value to `"false"` by default
