### PR TITLE
Update configurations to account for course-authoring MFE rename

### DIFF
--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/cms_only.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/cms_only.yml.tmpl
@@ -2,7 +2,7 @@
 # ALTERNATE_WORKER_QUEUES: lms  # Already has a sane default in the code
 ADDL_INSTALLED_APPS:  # ADDED KEY
   - git_auto_export
-COURSE_AUTHORING_MICROFRONTEND_URL: /course-authoring
+COURSE_AUTHORING_MICROFRONTEND_URL: /authoring
 GIT_REPO_EXPORT_DIR: /openedx/data/export_course_repos
 GIT_EXPORT_DEFAULT_IDENT:
   name: MITx Residential

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx/cms_only.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx/cms_only.yml.tmpl
@@ -2,7 +2,7 @@
 # ALTERNATE_WORKER_QUEUES: lms  # Already has a sane default in the code
 ADDL_INSTALLED_APPS:  # ADDED KEY
   - git_auto_export
-COURSE_AUTHORING_MICROFRONTEND_URL: /course-authoring
+COURSE_AUTHORING_MICROFRONTEND_URL: /authoring
 GIT_REPO_EXPORT_DIR: /openedx/data/export_course_repos
 GIT_EXPORT_DEFAULT_IDENT:
   name: MITx Residential

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/cms_only.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/cms_only.yml.tmpl
@@ -2,7 +2,7 @@
 # ALTERNATE_WORKER_QUEUES: lms  # Already has a sane default in the code
 ADDL_INSTALLED_APPS:  # ADDED KEY
   - git_auto_export
-COURSE_AUTHORING_MICROFRONTEND_URL: /course-authoring
+COURSE_AUTHORING_MICROFRONTEND_URL: /authoring
 GIT_REPO_EXPORT_DIR: /openedx/data/export_course_repos
 GIT_EXPORT_DEFAULT_IDENT:
   name: MITx Online

--- a/src/bilder/images/edxapp_v2/templates/edxapp/xpro/cms_only.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/xpro/cms_only.yml.tmpl
@@ -2,7 +2,7 @@
 # ALTERNATE_WORKER_QUEUES: lms  # Already has a sane default in the code
 ADDL_INSTALLED_APPS:  # ADDED KEY
   - git_auto_export
-COURSE_AUTHORING_MICROFRONTEND_URL: /course-authoring
+COURSE_AUTHORING_MICROFRONTEND_URL: /authoring
 GIT_REPO_EXPORT_DIR: /openedx/data/export_course_repos
 GIT_EXPORT_DEFAULT_IDENT:
   name: MIT xPRO

--- a/src/bridge/settings/openedx/types.py
+++ b/src/bridge/settings/openedx/types.py
@@ -39,9 +39,9 @@ class OpenEdxMicroFrontend(str, Enum):
         "communications",
     )
     course_authoring = (
-        "course-authoring",
-        "https://github.com/openedx/frontend-app-course-authoring",
-        "course-authoring",
+        "authoring",
+        "https://github.com/openedx/frontend-app-authoring",
+        "authoring",
     )
     discussion = (
         "discussions",

--- a/src/bridge/settings/openedx/version_matrix.py
+++ b/src/bridge/settings/openedx/version_matrix.py
@@ -94,7 +94,7 @@ ReleaseMap: dict[
                 branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
-                application="course-authoring",
+                application="authoring",
                 application_type="MFE",
                 release="redwood",
                 branding_overrides=default_branding_overrides,
@@ -183,7 +183,7 @@ ReleaseMap: dict[
                 branding_overrides=default_branding_overrides,
             ),
             OpenEdxApplicationVersion(
-                application="course-authoring",
+                application="authoring",
                 application_type="MFE",
                 release="redwood",
                 branding_overrides=default_branding_overrides,
@@ -268,7 +268,7 @@ ReleaseMap: dict[
                 release="quince",
             ),
             OpenEdxApplicationVersion(
-                application="course-authoring",
+                application="authoring",
                 application_type="MFE",
                 release="quince",
                 branding_overrides=pinned_branding_overrides,
@@ -336,7 +336,7 @@ ReleaseMap: dict[
                 release="master",
             ),
             OpenEdxApplicationVersion(
-                application="course-authoring",
+                application="authoring",
                 application_type="MFE",
                 release="master",
                 branding_overrides=default_branding_overrides,

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.CI.yaml
@@ -48,7 +48,7 @@ config:
   edxapp:enable_notes: "True"
   edxapp:enabled_mfes:
     communications: communications
-    course_authoring: course-authoring
+    authoring: authoring
     gradebook: gradebook
     learner_dashboard: dashboard
     learning: learn

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.Production.yaml
@@ -50,7 +50,7 @@ config:
   edxapp:enable_notes: "True"
   edxapp:enabled_mfes:
     communications: communications
-    course_authoring: course-authoring
+    authoring: authoring
     gradebook: gradebook
     learner_dashboard: dashboard
     learning: learn

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.QA.yaml
@@ -49,7 +49,7 @@ config:
   edxapp:enable_notes: "True"
   edxapp:enabled_mfes:
     communications: communications
-    course_authoring: course-authoring
+    authoring: authoring
     gradebook: gradebook
     learner_dashboard: dashboard
     learning: learn

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.CI.yaml
@@ -50,7 +50,7 @@ config:
   edxapp:enable_notes: "True"
   edxapp:enabled_mfes:
     communications: communications
-    course_authoring: course-authoring
+    authoring: authoring
     gradebook: gradebook
     learner_dashboard: dashboard
     learning: learn

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.Production.yaml
@@ -53,7 +53,7 @@ config:
   edxapp:enable_notes: "True"
   edxapp:enabled_mfes:
     communications: communications
-    course_authoring: course-authoring
+    authoring: authoring
     gradebook: gradebook
     learner_dashboard: dashboard
     learning: learn

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.QA.yaml
@@ -51,7 +51,7 @@ config:
   edxapp:enable_notes: "True"
   edxapp:enabled_mfes:
     communications: communications
-    course_authoring: course-authoring
+    authoring: authoring
     gradebook: gradebook
     learner_dashboard: dashboard
     learning: learn

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
@@ -41,7 +41,7 @@ config:
   edxapp:enable_notes: "True"
   edxapp:enabled_mfes:
     communications: communications
-    course_authoring: course-authoring
+    authoring: authoring
     discussions: discuss
     gradebook: gradebook
     learning: learn

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
@@ -41,7 +41,7 @@ config:
   edxapp:enable_notes: "True"
   edxapp:enabled_mfes:
     communications: communications
-    course_authoring: course-authoring
+    authoring: authoring
     discussions: discuss
     gradebook: gradebook
     learning: learn

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.CI.yaml
@@ -38,7 +38,7 @@ config:
   edxapp:web_instance_type: m6a.large
   edxapp:enable_notes: "True"
   edxapp:enabled_mfes:
-    course_authoring: course-authoring
+    authoring: authoring
     gradebook: gradebook
     learning: learn
     ora_grading: ora-grading

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.Production.yaml
@@ -37,7 +37,7 @@ config:
     secure: v1:YHqAWSdn7TNUn7d+:IBgiGsl4r8vymID8NV43rnfJy+qsJSXm/jXaWWALUfF9zXqRO4zJZhLS0d+etijGVwaZnF8v5zXlo+EczFrCe7ICHpS85zHgifbfDcw=
   edxapp:enable_notes: "True"
   edxapp:enabled_mfes:
-    course_authoring: course-authoring
+    authoring: authoring
     gradebook: gradebook
     learning: learn
     ora_grading: ora-grading

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.QA.yaml
@@ -38,7 +38,7 @@ config:
   edxapp:elb_healthcheck_interval: "30"
   edxapp:enable_notes: "True"
   edxapp:enabled_mfes:
-    course_authoring: course-authoring
+    authoring: authoring
     gradebook: gradebook
     learning: learn
     ora_grading: ora-grading


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
The `frontend-app-course-authoring` MFE was recently renamed to `frontend-app-authoring` since it now encompasses all authoring UX. This updates our settings to reflect that change by pointing to the updated repo URL, and changing the MFE URL prefix to be `/authoring`.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
All `pulumi up` steps on edX environments should include a modification to MFE paths from `course-authoring` to `authoring` and MFE pipelines generated with this change will point to the new github URL and S3 path prefix

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
https://github.com/openedx/frontend-app-authoring/issues/1250

