### PR TITLE
Adjust Keycloak pipeline for new SCIM client

### DIFF
--- a/src/bilder/images/keycloak/files/.env.tmpl
+++ b/src/bilder/images/keycloak/files/.env.tmpl
@@ -24,9 +24,3 @@ KEYCLOAK_ADMIN_PASSWORD="{{ .Data.data.admin_password }}"
 
 # Disable external access to metrics
 DISABLE_EXTERNAL_ACCESS=True
-
-# SCIM Config
-KC_SPI_THEME_WELCOME_THEME=scim
-{{ with secret "secret-keycloak/data/keycloak-secrets" -}}
-KC_SPI_REALM_RESTAPI_EXTENSION_SCIM_LICENSE_KEY="{{ .Data.data.scim_license_key }}"
-{{- end }}

--- a/src/bridge/secrets/keycloak/data.ci.yaml
+++ b/src/bridge/secrets/keycloak/data.ci.yaml
@@ -1,7 +1,6 @@
 ---
 admin_username: ENC[AES256_GCM,data:Q/jW4js=,iv:pd/qnJZEqpxK2yXQ/+4iKynTFaA8SOCAuKl/383f0uY=,tag:KKjfajlq5wH3ds+rtzRBtA==,type:str]
 admin_password: ENC[AES256_GCM,data:9GklLRf8BZmZFzFygow6GdHxgRnLkTsk0snQ0Ds0edrw+Wtb1UbYVvUf4V3HQ7xvM3+gFeRPzD5vcrBz0vxhjw==,iv:V+9qUxQpb5zcZ7bH6hnIEFmAl1jv5+wT8nGU/zwHCBk=,tag:gL8x7zHYAPW8yPjdFEVzPw==,type:str]
-scim_license_key: ENC[AES256_GCM,data:0wrQ2htiTiJu5HOWXr098jZuBNfW1SxIIn3JOjv3pYjRgxG9FxmvRRHtxOXscoeTFqm6c3YYenKa3qk4PvWB+mKy4S7SXNvLbs/GwLBIFh5dPgB39hr9+X11lVHPkArRHgEdLfdHg1NsIdxynuj8tOOcwM1gdBbjNBmaZVE+awjzZ0fchfGaceDy4Mx1BZKqlw3VfG1b1bA3TdANPyt3KjD/xqb5lM7XzBP8siaiE/jJPW/p4MsrXtQENDna1aaB/7AEk+/aMBkoBWYzeddIqZjSlPX5UylHMO+AryC11d7RI76oUGmHuM7oYer1T8RI2qRVq4K2xZSZ3K4u7SoSAl93BmbyjfuhLN0PNw13NWI0JfEOsTJ2eaclMmP86Q==,iv:VQtw8A2+YfDcA4ePONA6h3wt5/U8fS1mFlo04LK9jxY=,tag:wNGhNkkRvNx0ZQJ2mQ744A==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-ci
@@ -17,8 +16,8 @@ sops:
     created_at: "2024-01-24T19:58:43Z"
     enc: vault:v1:idhz1/U0p0K2DgJR6rJMx0fMMCAsEMaPkbvKfXKtV0SF9Qu5hO21O6Bz9tUPGXpoH9PbczIcs0iYZ0K7
   age: []
-  lastmodified: "2024-10-21T15:01:01Z"
-  mac: ENC[AES256_GCM,data:yScnPzi/qy5+nlwyFd5n3s0TbntRF0gm90IPU5PaqgXGWTUlxepjKSxfH56hKPpYPjkcGojghYIY4w2T/diYgrTWk6kiJyf6Q4e8//7yRKk4pT9CiwX8vwiTTfLw/sRnV3MZjKKDiizS5Q+8ShBCkZhdsZX+rCJNjZDX1OAzMuM=,iv:scpAh8uBCaDOIOfk3sOjtMbh8z6bdeLF4b1uQh6IXk0=,tag:c2iuZ32lcMtrqf35ABjoCA==,type:str]
+  lastmodified: "2024-10-24T15:04:11Z"
+  mac: ENC[AES256_GCM,data:2ZAgmD7mEOFOc9Zz7tccLbvOxU/jTc7ASEXj1O0dBFxSY8ovIBo3D+xxT6SDZOygkowbjHYocLFlCxK+IQPB38UOt+J5r/aVTgOyfXn1gAApTgyPP7wdkVBRBuVZSNqehu4yrCOSvavlR/5tO+fZv+Si9gSsMu3JVnWJ5bX1iQE=,iv:+CZz+ecCXBOlqqxPNhCf2te1LFmyvtf7xHubmQtSk40=,tag:rPTKDOa0L8XeQ7eRe4/VgQ==,type:str]
   pgp:
   - created_at: "2024-01-24T19:58:43Z"
     enc: |-

--- a/src/ol_concourse/pipelines/infrastructure/keycloak/docker_packer_pulumi_pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/keycloak/docker_packer_pulumi_pipeline.py
@@ -146,7 +146,7 @@ def build_keycloak_infrastructure_pipeline() -> PipelineFragment:
                         args=[
                             "-xc",
                             """
-                            aws s3 cp s3://ol-eng-artifacts/keycloak/scim-client/scim_client_file.jar scim_client_file.jar""",  # noqa: E501
+                            aws s3 cp s3://ol-eng-artifacts/keycloak/scim-client/scim-for-keycloak-kc-24-2.3.3-enterprise.jar scim-for-keycloak-kc-24-2.3.3-enterprise.jar """,  # noqa: E501
                         ],
                     ),
                 ),

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.Production.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.Production.yaml
@@ -20,9 +20,6 @@ config:
     secure: v1:j07wuh/TTLkO473J:NZ/98PovITQ5SjTXJV2gF7L4J8FMMNKlk+aboNb64u46GgBZ09wtrHeRUuU=
   keycloak_realm:mailgun_reply_to_address:
     secure: v1:k6AjXnlCnWLqwVhx:NHhS0Yt9Flc/vc0hcLJmfuE/CNCe92U8WbllT/KyyeouZ8UO8bAJSCTLp5Q=
-  keycloak_realm:mit-learn-scim-endpoint: https://api.learn.mit.edu/scim/v2/
-  keycloak_realm:mit-learn-scim-password:
-    secure: v1:uyMnfYLapB6nFCsW:Sgd6cnNMHByd80Y6iQrbJQ8frFluiJuUSQPAlZKV4M+XjH4SdTeBFHrECVsIcc5h
   keycloak_realm:mit_email_host:
     secure: v1:1gyJ6yq3akZxkYYu:EEHQNf1bF5ScW9XFFDcW932EQZOK2wWm48OBftAr1SE=
   keycloak_realm:mit_email_password:

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
@@ -21,9 +21,6 @@ config:
     secure: v1:TfpaJKet+1dR7zPW:uH/rZTfcHuW/+DmQNzeowgCQk8uw3Fi31ZN+UZkUBXnBYbUCZZGjYxYxMuSvuY4=
   keycloak_realm:mailgun_reply_to_address:
     secure: v1:uRDOLOjIW6qFgbcO:kyGfXZcMIUw0IQ36MEL0ujQoYDJdNCAaljl9j7uI1k5LCWVQm/cz5S7mOkz/+68=
-  keycloak_realm:mit-learn-scim-endpoint: https://api.rc.learn.mit.edu/scim/v2/
-  keycloak_realm:mit-learn-scim-password:
-    secure: v1:GzkoKrnvuhwYC9uT:IfBrZtoR/5YFZRe2OSixF9kyZqdsBWKppn4X3/V8icHPG1CFy06WM1DVCqqOow==
   keycloak_realm:mit_email_host:
     secure: v1:NJ2W839vX2H5EmR7:xZ1XFFS1Lj+zYG7REfJUUYmoBrItsSUCmtDoYCzhDa4=
   keycloak_realm:mit_email_password:

--- a/src/ol_infrastructure/substructure/keycloak/__main__.py
+++ b/src/ol_infrastructure/substructure/keycloak/__main__.py
@@ -231,7 +231,7 @@ olapps_realm_events = keycloak.RealmEvents(
     events_expiration=SECONDS_IN_ONE_DAY,
     admin_events_enabled=True,
     admin_events_details_enabled=True,
-    events_listeners=["metrics-listener", "scim"],
+    events_listeners=["metrics-listener"],
     opts=resource_options,
 )
 
@@ -1053,28 +1053,3 @@ if stack_info.env_suffix in ["ci", "qa"]:
         ),
     )
     # OKTA-DEV [END] # noqa: ERA001
-
-# SCIM for MIT-Learn
-if stack_info.env_suffix != "CI":
-    keycloak.CustomUserFederation(
-        "ol-mit-learn-scim",
-        config={
-            "user-patchOp": "false",
-            "auth-pass": keycloak_realm_config.get("mit-learn-scim-password"),
-            "auth-mode": "BEARER",
-            "sync-import-action": "NOTHING",
-            "propagation-user": "true",
-            "endpoint": keycloak_realm_config.get("mit-learn-scim-endpoint"),
-            "propagation-group": "true",
-            "content-type": "application/scim+json",
-            "group-patchOp": "false",
-        },
-        cache_policy="DEFAULT",
-        changed_sync_period=60,
-        enabled=True,
-        full_sync_period=86400,
-        name="MIT Learn",
-        provider_id="scim",
-        realm_id=ol_apps_realm.id,
-        opts=resource_options,
-    )


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
The new licensed Keycloak SCIM client will need to be download from our `ol-eng-artifacts` S3 bucket and then copied over to the plugin folder in Keycloak. This adjusts the pipeline to handle that.
