### PR TITLE
Infrastructure for Open Metadata Production and some Pulumi RDS component fixes

### DIFF
--- a/src/ol_infrastructure/applications/open_metadata/Pulumi.applications.open_metadata.Production.yaml
+++ b/src/ol_infrastructure/applications/open_metadata/Pulumi.applications.open_metadata.Production.yaml
@@ -1,0 +1,11 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-production
+encryptedkey: AQICAHjmo6C0sCNz3fdkFlhbu0tdBZxnHmPYSnqtmocvGiuNygF8fmvvVe5DNkr9Hl4T4PiAAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMfodeXfSUeEPLFSEjAgEQgDt5zX4veOhH9GAV44DHupAS/EzrD1q9rV7s8yk6n8sGXkr6d5MU5NvpKp+D3VcMPQs8s1Rxux9CiLKJhA==
+config:
+  aws:region: us-east-1
+  consul:address: https://consul-data-production.odl.mit.edu
+  open_metadata:db_password:
+    secure: v1:ikO5h3b2i9oa0FSO:8ITKo2xQA8xIdJc93NjsrMZDwh5O3yuGsZ4bA1+uqKFDfX77eEYmaKxhgNmSw+fj/bSoSj1hbeYxGRg=
+  open_metadata:domain: "data.ol.mit.edu"
+  vault:address: https://vault-production.odl.mit.edu
+  vault_server:env_namespace: operations.production

--- a/src/ol_infrastructure/applications/open_metadata/Pulumi.applications.open_metadata.Production.yaml
+++ b/src/ol_infrastructure/applications/open_metadata/Pulumi.applications.open_metadata.Production.yaml
@@ -4,7 +4,7 @@ encryptedkey: AQICAHjmo6C0sCNz3fdkFlhbu0tdBZxnHmPYSnqtmocvGiuNygF8fmvvVe5DNkr9Hl
 config:
   aws:region: us-east-1
   consul:address: https://consul-data-production.odl.mit.edu
-  open_metadata:db_instance_size: db.m7g.2xlarge
+  open_metadata:db_instance_size: db.m7g.large
   open_metadata:db_password:
     secure: v1:VBuj1zz2MEIjzO11:fLVl43FJeZjj22hWk+XAslezaPQDliDPaEOtSbEaI5f8SoyPcBJB7dZcgIIXaWlEn/ucGE7zDSsxxQY=
   open_metadata:domain: "data.ol.mit.edu"

--- a/src/ol_infrastructure/applications/open_metadata/Pulumi.applications.open_metadata.Production.yaml
+++ b/src/ol_infrastructure/applications/open_metadata/Pulumi.applications.open_metadata.Production.yaml
@@ -4,8 +4,9 @@ encryptedkey: AQICAHjmo6C0sCNz3fdkFlhbu0tdBZxnHmPYSnqtmocvGiuNygF8fmvvVe5DNkr9Hl
 config:
   aws:region: us-east-1
   consul:address: https://consul-data-production.odl.mit.edu
+  open_metadata:db_instance_size: db.m7g.2xlarge
   open_metadata:db_password:
-    secure: v1:ikO5h3b2i9oa0FSO:8ITKo2xQA8xIdJc93NjsrMZDwh5O3yuGsZ4bA1+uqKFDfX77eEYmaKxhgNmSw+fj/bSoSj1hbeYxGRg=
+    secure: v1:VBuj1zz2MEIjzO11:fLVl43FJeZjj22hWk+XAslezaPQDliDPaEOtSbEaI5f8SoyPcBJB7dZcgIIXaWlEn/ucGE7zDSsxxQY=
   open_metadata:domain: "data.ol.mit.edu"
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.data.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.data.Production.yaml
@@ -1,6 +1,6 @@
 ---
-secretsprovider: awskms://alias/infrastructure-secrets-qa
-encryptedkey: AQICAHgQW+3bag/cl2fPG3dPdqAPbfcsZuwI7rETXZsx85HRpgFHpqW8dqPwpO+48iRjSPKlAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMT8+E8dJESaABQvpwAgEQgDuViDwWFIt7k1e04QwP3dBW2YCjvz7RUJdyesx59jYHfjXxmnDGziscc9wq1kN3UPp1+uaZf5qBfmA/oQ==
+secretsprovider: awskms://alias/infrastructure-secrets-production
+encryptedkey: AQICAHjmo6C0sCNz3fdkFlhbu0tdBZxnHmPYSnqtmocvGiuNygGvhXhSXiQ1XmPuxswm2OtcAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMTuh7nmhVuOpDSvyZAgEQgDuh3GDgOQHD2wbrhWUWE2wIUfXQxWNm83tq0ambQmpQqnAr9hajUcnokJAsLf0H8AKhFvUp8SAMbLaHtA==
 config:
   environment:business_unit: operations
   environment:target_vpc: data_vpc
@@ -31,5 +31,5 @@ config:
       tags: {}
       taints: {}
       node_group_options: {}
-  vault:address: https://vault-qa.odl.mit.edu
-  vault_server:env_namespace: operations.qa
+  vault:address: https://vault-production.odl.mit.edu
+  vault_server:env_namespace: operations.production

--- a/src/ol_infrastructure/infrastructure/aws/network/Pulumi.infrastructure.aws.network.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/network/Pulumi.infrastructure.aws.network.Production.yaml
@@ -9,7 +9,7 @@ config:
   - 10.3.128.0/21
   - 10.3.136.0/21
   - 10.3.144.0/21
-  data_vpc:k8s_service_subnet: 10.110.83.0/23 - 10.3.153.0/21
+  data_vpc:k8s_service_subnet: 10.110.83.0/23
   mitx_online_vpc:cidr_block: 10.22.0.0/16
   operations_vpc:cidr_block: 10.0.0.0/16
   operations_vpc:name: operations

--- a/src/ol_infrastructure/infrastructure/aws/network/Pulumi.infrastructure.aws.network.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/network/Pulumi.infrastructure.aws.network.Production.yaml
@@ -5,6 +5,11 @@ config:
   apps_vpc:cidr_block: 10.13.0.0/16
   aws:region: us-east-1
   data_vpc:cidr_block: 10.3.0.0/16
+  data_vpc:k8s_pod_subnets:
+  - 10.3.128.0/21
+  - 10.3.136.0/21
+  - 10.3.144.0/21
+  data_vpc:k8s_service_subnet: 10.110.83.0/23 - 10.3.153.0/21
   mitx_online_vpc:cidr_block: 10.22.0.0/16
   operations_vpc:cidr_block: 10.0.0.0/16
   operations_vpc:name: operations

--- a/src/ol_infrastructure/infrastructure/aws/network/Pulumi.infrastructure.aws.network.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/network/Pulumi.infrastructure.aws.network.Production.yaml
@@ -9,7 +9,7 @@ config:
   - 10.3.128.0/21
   - 10.3.136.0/21
   - 10.3.144.0/21
-  data_vpc:k8s_service_subnet: 10.110.83.0/23
+  data_vpc:k8s_service_subnet: 10.110.142.0/23
   mitx_online_vpc:cidr_block: 10.22.0.0/16
   operations_vpc:cidr_block: 10.0.0.0/16
   operations_vpc:name: operations

--- a/src/ol_infrastructure/infrastructure/aws/network/Pulumi.infrastructure.aws.network.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/network/Pulumi.infrastructure.aws.network.Production.yaml
@@ -9,9 +9,16 @@ config:
   - 10.3.128.0/21
   - 10.3.136.0/21
   - 10.3.144.0/21
+  - 10.3.152.0/21
   data_vpc:k8s_service_subnet: 10.110.142.0/23
   mitx_online_vpc:cidr_block: 10.22.0.0/16
   operations_vpc:cidr_block: 10.0.0.0/16
+  operations_vpc:k8s_pod_subnets:
+  - 10.0.128.0/21
+  - 10.0.136.0/21
+  - 10.0.144.0/21
+  - 10.0.152.0/21
+  operations_vpc:k8s_service_subnet: 10.110.140.0/23
   operations_vpc:name: operations
   residential_staging_vpc:cidr_block: 10.31.0.0/16
   residential_vpc:cidr_block: 10.7.0.0/16

--- a/src/ol_infrastructure/infrastructure/aws/network/Pulumi.infrastructure.aws.network.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/network/Pulumi.infrastructure.aws.network.QA.yaml
@@ -19,7 +19,7 @@ config:
   - 10.1.136.0/21
   - 10.1.144.0/21
   - 10.1.152.0/21
-  operations_vpc:k8s_service_subnet: 10.110.84.0/23
+  operations_vpc:k8s_service_subnet: 10.110.80.0/23
   operations_vpc:name: operations-qa
   residential_staging_vpc:cidr_block: 10.30.0.0/16
   residential_vpc:cidr_block: 10.5.0.0/16

--- a/src/ol_infrastructure/lib/aws/rds_helper.py
+++ b/src/ol_infrastructure/lib/aws/rds_helper.py
@@ -81,3 +81,21 @@ def parameter_group_family(engine: str, engine_version: str) -> str:
         Engine=engine, EngineVersion=engine_version
     )
     return engine_details["DBEngineVersions"][0]["DBParameterGroupFamily"]
+
+
+def get_rds_instance(instance_name: str) -> dict[str, str]:
+    try:
+        db_instances = rds_client.describe_db_instances(
+            DBInstanceIdentifier=instance_name,
+        )
+        db_instances = db_instances.pop("DBInstances")
+        if len(db_instances) > 1:
+            msg = (
+                "More than one database instance was found. "
+                "Please provide a more specific instance name."
+            )
+            raise ValueError(msg)
+        db_instance = db_instances[0]
+    except rds_client.exceptions.DBInstanceNotFoundFault:
+        db_instance = {}
+    return db_instance

--- a/src/ol_infrastructure/substructure/aws/eks/Pulumi.substructure.aws.eks.data.Production.yaml
+++ b/src/ol_infrastructure/substructure/aws/eks/Pulumi.substructure.aws.eks.data.Production.yaml
@@ -1,0 +1,7 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-production
+encryptedkey: AQICAHjmo6C0sCNz3fdkFlhbu0tdBZxnHmPYSnqtmocvGiuNygHMwER9MKPw3/xJQzKW46FqAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMu7h9Fra5DeQPwF+3AgEQgDsoRQi6Xc0wnv70ldAwsTjskugZkGgD+53Zvru2Xsf8akHEvQrf9Ew7PLey+LJPxBlVRyroU4P9t1IBwg==
+config:
+  environment:business_unit: operations
+  vault:address: https://vault-production.odl.mit.edu
+  vault_server:env_namespace: operations.production


### PR DESCRIPTION
### What are the relevant tickets?
#2731

### Description (What does it do?)
- Adds all the necessary infrastructure for Open Metadata in Production.
- Al;so adds a fix to the RDS component that was preventing new database instances from being created in production.

### How can this be tested?
Surf to https://data.ol.mit.edu and make all the appropriate "OOH!" and "Aah!" noises :)

