### PR TITLE
Added configuration for keycloak client scopes

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
@@ -37,6 +37,7 @@ config:
       mitlearn: ["https://api.rc.learn.mit.edu/*", "https://rc.learn.mit.edu/*"]
       open: ["https://api.mitopen-rc.odl.mit.edu/*", "https://mitopen-rc.odl.mit.edu/*"]
       open-discussions: ["https://discussions-rc.odl.mit.edu/*"]
+    extra_default_scopes: ["ol-profile"]
     realm_name: olapps
   - client_info:
       airbyte: ["https://airbyte-qa.odl.mit.edu/*"]

--- a/src/ol_infrastructure/substructure/keycloak/__main__.py
+++ b/src/ol_infrastructure/substructure/keycloak/__main__.py
@@ -707,7 +707,7 @@ for openid_clients in keycloak_realm_config.get_object("openid_clients"):
                     "role_list",
                     "roles",
                     "web-origins",
-                    *openid_clients.get("extra_default_scopes")
+                    *openid_clients.get("extra_default_scopes"),
                 ],
             )
 

--- a/src/ol_infrastructure/substructure/keycloak/__main__.py
+++ b/src/ol_infrastructure/substructure/keycloak/__main__.py
@@ -380,7 +380,9 @@ ol_apps_user_profile = keycloak.RealmUserProfile(
 )
 
 ol_apps_profile_client_scope = keycloak.openid.ClientScope(
-    "profile", realm_id=ol_apps_realm.id
+    "ol-profile-client-scope",
+    name="ol-profile",
+    realm_id=ol_apps_realm.id,
 )
 
 ol_apps_user_email_optin_attribute_mapper = keycloak.openid.UserAttributeProtocolMapper(
@@ -693,6 +695,22 @@ for openid_clients in keycloak_realm_config.get_object("openid_clients"):
                 realm_id=realm_name,
                 opts=resource_options,
             )
+        if "extra_default_scopes" in openid_clients:
+            keycloak.openid.ClientDefaultScopes(
+                f"{realm_name}-{client_name}-default-scopes",
+                realm_id=realm_name,
+                client_id=openid_client.id,
+                default_scopes=[
+                    "acr",
+                    "email",
+                    "profile",
+                    "role_list",
+                    "roles",
+                    "web-origins",
+                    *openid_clients.get("extra_default_scopes")
+                ],
+            )
+
 
 # OL - First login flow [START]
 # Does not require email verification or confirmation to connect with existing account.


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/hq/issues/5559

### Description (What does it do?)
<!--- Describe your changes in detail -->
The configuration that's currently in the code ends up causing Pulumi to create a secondary "profile" scope with a generated name (e.g. `profile-abf8e`) rather than modifying the current one. These changes:

- Give the scope a well-known name that doesn't collide with `profile`.
- Add this scope to the defaults for clients in the `olapps` realm.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
I think we can test this in CI and verify on manual inspection the configuration comes out correct.

The `ol-profile` scope should show up for the app clients as a default scope.

It should look like this (we're only concerned about the `ol-profile` scope, namely that it is default and has the two attribute mappers:

![Screenshot 2024-10-28 at 13-54-26 Keycloak Administration UI](https://github.com/user-attachments/assets/8d2e4429-c43e-4ecb-aa61-5cf54ed574fe)

![Screenshot 2024-10-28 at 13-54-44 Keycloak Administration UI](https://github.com/user-attachments/assets/0c33b778-7331-40bf-97ca-8b7c474d3b6c)