### PR TITLE
Remove MITPE_BASE_API_URL setting, add MITPE_API_ENABLED=True for RC (mit-learn)

### DIFF
--- a/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.QA.yaml
+++ b/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.QA.yaml
@@ -28,6 +28,7 @@ config:
     MITOL_NEW_USER_LOGIN_URL: "https://rc.learn.mit.edu/onboarding"
     MITOL_NOINDEX: "true"
     MITOL_SUPPORT_EMAIL: "odl-learn-rc-support@mit.edu"   # Need to verify
+    MITPE_API_ENABLED: "true"
     OCW_ITERATOR_CHUNK_SIZE: 300
     OIDC_ENDPOINT: "https://sso-qa.ol.mit.edu/realms/olapps"
     OPENSEARCH_INDEX: "mitlearn-rc"

--- a/src/ol_infrastructure/applications/mitlearn/__main__.py
+++ b/src/ol_infrastructure/applications/mitlearn/__main__.py
@@ -834,7 +834,6 @@ heroku_vars = {
     "MITOL_USE_S3": "True",
     "MITOL_NOTIFICATION_EMAIL_BACKEND": "anymail.backends.mailgun.EmailBackend",
     "MITPE_BASE_URL": "https://professional.mit.edu/",
-    "MITPE_BASE_API_URL": "https://professional.mit.edu/",
     "MITX_ONLINE_BASE_URL": "https://mitxonline.mit.edu/",
     "MITX_ONLINE_COURSES_API_URL": "https://mitxonline.mit.edu/api/v2/courses/",
     "MITX_ONLINE_LEARNING_COURSE_BUCKET_NAME": "mitx-etl-mitxonline-production",


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/mit-learn/pull/1210

### Description (What does it do?)
- Gets rid of a redundant setting (MITPE_BASE_API_URL)
- Sets a flag on RC only (for now) to use the new professional education pipeline instead of prolearn.

### How can this be tested?
N/A
