### PR TITLE
config: Remove K8s provider as explicit parent

### DIFF
--- a/src/ol_infrastructure/applications/open_metadata/__main__.py
+++ b/src/ol_infrastructure/applications/open_metadata/__main__.py
@@ -229,7 +229,6 @@ vault_k8s_resources_config = OLVaultK8SResourcesConfig(
 vault_k8s_resources = OLVaultK8SResources(
     resource_config=vault_k8s_resources_config,
     opts=ResourceOptions(
-        parent=k8s_provider,
         delete_before_replace=True,
         depends_on=[open_metadata_vault_auth_backend_role],
     ),

--- a/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
@@ -339,8 +339,6 @@ operations_namespace = kubernetes.core.v1.Namespace(
     ),
     opts=ResourceOptions(
         provider=k8s_provider,
-        parent=k8s_provider,
-        depends_on=k8s_provider,
         protect=True,
     ),
 )
@@ -357,8 +355,6 @@ for namespace in namespaces:
         ),
         opts=ResourceOptions(
             provider=k8s_provider,
-            parent=k8s_provider,
-            depends_on=k8s_provider,
             protect=True,
         ),
     )
@@ -468,8 +464,7 @@ if eks_config.get_bool("ebs_csi_provisioner"):
         },
         opts=ResourceOptions(
             provider=k8s_provider,
-            parent=k8s_provider,
-            depends_on=[k8s_provider, ebs_csi_driver_role],
+            depends_on=[ebs_csi_driver_role],
         ),
     )
     aws_ebs_cni_driver_addon = eks.Addon(
@@ -567,8 +562,7 @@ if eks_config.get_bool("efs_csi_provisioner"):
         },
         opts=ResourceOptions(
             provider=k8s_provider,
-            parent=k8s_provider,
-            depends_on=[k8s_provider, efs_csi_driver_role],
+            depends_on=[efs_csi_driver_role],
         ),
     )
     aws_efs_cni_driver_addon = eks.Addon(

--- a/src/ol_infrastructure/substructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/substructure/aws/eks/__main__.py
@@ -80,7 +80,6 @@ vault_traefik_service_account = kubernetes.core.v1.ServiceAccount(
     automount_service_account_token=False,
     opts=ResourceOptions(
         provider=k8s_provider,
-        parent=k8s_provider,
         delete_before_replace=True,
     ),
 )
@@ -280,7 +279,6 @@ cert_manager_clusterissuer_resources = kubernetes.yaml.v2.ConfigGroup(
     ],
     opts=ResourceOptions(
         provider=k8s_provider,
-        parent=k8s_provider,
         delete_before_replace=True,
     ),
 )


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Setting the Kubernetes provider as an explicit parent is unnecessary from a dependency management perspective, and can pose a risk if the provider is modified or replaced that it will cascade to all child resources.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Up the Pulumi stacks that are affected and verify that the k8s resources are not children of the provider.