### PR TITLE
fix: new discussion banner link value

### DIFF
--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/cms_only.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/cms_only.yml.tmpl
@@ -3,6 +3,7 @@
 ADDL_INSTALLED_APPS:  # ADDED KEY
   - git_auto_export
 COURSE_AUTHORING_MICROFRONTEND_URL: /authoring
+DISCUSSIONS_INCONTEXT_LEARNMORE_URL: https://openedx.atlassian.net/wiki/spaces/COMM/pages/3470655498/Discussions+upgrade+Sidebar+and+new+topic+structure
 GIT_REPO_EXPORT_DIR: /openedx/data/export_course_repos
 GIT_EXPORT_DEFAULT_IDENT:
   name: MITx Online


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/5341#event-14873621866

### Description (What does it do?)
This PR changes the discussion banner link value in mitxonline studio from default to https://openedx.atlassian.net/wiki/spaces/COMM/pages/3470655498/Discussions+upgrade+Sidebar+and+new+topic+structure

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
