### PR TITLE
Update redirect for http://ocw.mit.edu/6-042JS15

### DIFF
--- a/src/ol_infrastructure/applications/ocw_site/redirect_dict.json
+++ b/src/ol_infrastructure/applications/ocw_site/redirect_dict.json
@@ -194,7 +194,7 @@
   "/6-041F10": "307|keep|https://{{AK_HOSTHEADER}}/courses/electrical-engineering-and-computer-science/6-041-probabilistic-systems-analysis-and-applied-probability-fall-2010/",
   "/6-041SCF13": "307|discard|https://{{AK_HOSTHEADER}}/courses/electrical-engineering-and-computer-science/6-041sc-probabilistic-systems-analysis-and-applied-probability-fall-2013/",
   "/6-042JF10": "307|keep|https://{{AK_HOSTHEADER}}/courses/electrical-engineering-and-computer-science/6-042j-mathematics-for-computer-science-fall-2010/",
-  "/6-042JS15": "307|discard|https://{{AK_HOSTHEADER}}/courses/mathematics-for-computer-science/",
+  "/6-042JS15": "307|discard|https://{{AK_HOSTHEADER}}/courses/6-042j-mathematics-for-computer-science-spring-2015/",
   "/6-046JF05": "307|keep|https://{{AK_HOSTHEADER}}/courses/electrical-engineering-and-computer-science/6-046j-introduction-to-algorithms-sma-5503-fall-2005/",
   "/6-046JS15": "307|keep|https://{{AK_HOSTHEADER}}/courses/electrical-engineering-and-computer-science/6-046j-design-and-analysis-of-algorithms-spring-2015/",
   "/6-050js08": "307|keep|https://{{AK_HOSTHEADER}}/courses/electrical-engineering-and-computer-science/6-050j-information-and-entropy-spring-2008/",


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5760.

### Description (What does it do?)

This PR updates the redirect for `http://ocw.mit.edu/6-042JS15` to `https://ocw.mit.edu/courses/6-042j-mathematics-for-computer-science-spring-2015/`. 

### How can this be tested?
This PR can be tested once it's deployed to RC. However, the URL in the issue can be verified and compared with the URL in this PR.