### PR TITLE
Create GIT_REPO_EXPORT_DIR for the final docker image - edxapp

### DIFF
--- a/dockerfiles/openedx-edxapp/Earthfile
+++ b/dockerfiles/openedx-edxapp/Earthfile
@@ -207,7 +207,8 @@ docker-image:
     && chown app:app /openedx/.ssh \
     && chmod 0700 /openedx/.ssh \
     && ssh-keyscan 'github.com' 'github.mit.edu' >> /openedx/.ssh/known_hosts \
-    && chmod 0600 /openedx/.ssh/known_hosts
+    && chmod 0600 /openedx/.ssh/known_hosts \
+    && mkdir -p /openedx/data/export_course_repos
   CMD uwsgi uwsgi.ini
   SAVE IMAGE mitodl/edxapp-$DEPLOYMENT_NAME-$RELEASE_NAME:latest
 


### PR DESCRIPTION
### What are the relevant tickets?
Closes #2372 

### Description (What does it do?)
Resolves an error message that appears every time a node is created and the migrations run / the app starts.
