### PR TITLE
Use the "standard" enforcing mode for EKS pod security groups

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
@@ -225,6 +225,7 @@ cluster = eks.Cluster(
     # Ref: https://docs.aws.amazon.com/eks/latest/userguide/security-groups-pods-deployment.html
     # Ref: https://docs.aws.amazon.com/eks/latest/userguide/sg-pods-example-deployment.html
     vpc_cni_options=eks.cluster.VpcCniOptionsArgs(
+        configurationValues={"POD_SECURITY_GROUP_ENFORCING_MODE": "standard"},
         enable_pod_eni=eks_config.get_bool("pod_security_groups"),
         enable_prefix_delegation=eks_config.get_bool("pod_security_groups"),
         disable_tcp_early_demux=eks_config.get_bool("pod_security_groups"),


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Add configuration for the VPC CNI that uses the "standard" enforcing mode of security groups to allow in-cluster traffic between pods.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Apply the change to an EKS cluster, add a security group CRD definition for Airbyte and test configuring one of the edX source databases.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
The lack of security group pod assignment is currently blocking use of Airbyte with non-public database instances.
