### PR TITLE
Use CIDR block permissions instead of SG for Airbyte connections

### DIFF
--- a/src/ol_infrastructure/applications/airbyte/__main__.py
+++ b/src/ol_infrastructure/applications/airbyte/__main__.py
@@ -1020,33 +1020,6 @@ forward_auth_middleware = kubernetes.apiextensions.CustomResource(
     ),
 )
 
-airbyte_security_group_attachment = kubernetes.apiextensions.CustomResource(
-    "airbyte-data-integration-pod-security-group-attachment",
-    api_version="vpcresources.k8s.aws/v1beta1",
-    kind="SecurityGroupPolicy",
-    metadata=kubernetes.meta.v1.ObjectMetaArgs(
-        name="airbyte-data-ingest-security-group",
-        namespace=airbyte_namespace,
-        labels=k8s_global_labels,
-    ),
-    spec={
-        # a lot of guides and tutorials only use the service name,
-        # omitting the rest of the k8s domain. That works fine
-        # if you're doing *everything* in the default namespace.
-        # We are not, so we need to use the whole thing.
-        "podSelector": {
-            "matchLabels": {"airbyte": "job-pod"},
-        },
-        "securityGroups": {"groupIds": [target_vpc["security_groups"]["integrator"]]},
-    },
-    opts=ResourceOptions(
-        provider=k8s_provider,
-        parent=gateway,
-        depends_on=[airbyte_helm_release],
-        delete_before_replace=True,
-    ),
-)
-
 forward_auth_secret_config = OLVaultK8SStaticSecretConfig(
     name="airbyte-forward-auth-oidc-config",
     namespace=airbyte_namespace,

--- a/src/ol_infrastructure/applications/bootcamps/__main__.py
+++ b/src/ol_infrastructure/applications/bootcamps/__main__.py
@@ -173,6 +173,7 @@ bootcamps_db_security_group = ec2.SecurityGroup(
             from_port=DEFAULT_POSTGRES_PORT,
             to_port=DEFAULT_POSTGRES_PORT,
             security_groups=[data_vpc["security_groups"]["integrator"]],
+            cidr_blocks=data_vpc["k8s_pod_subnet_cidrs"],
         ),
     ],
     tags=aws_config.merged_tags(

--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -163,7 +163,6 @@ edxapp_zone_id = edxapp_zone["id"]
 kms_ebs = kms_stack.require_output("kms_ec2_ebs_key")
 kms_s3_key = kms_stack.require_output("kms_s3_data_analytics_key")
 operations_vpc = network_stack.require_output("operations_vpc")
-data_vpc = network_stack.require_output("data_vpc")
 mongodb_cluster_uri = mongodb_atlas_stack.require_output("atlas_cluster")[
     "connection_strings"
 ][0]
@@ -421,9 +420,9 @@ edxapp_db_security_group = ec2.SecurityGroup(
             ],
             # TODO: Create Vault security group to act as source of allowed  # noqa: FIX002, TD002, TD003
             # traffic. (TMM 2021-05-04)
-            cidr_blocks=[
-                edxapp_vpc["cidr"],
-            ],
+            cidr_blocks=data_vpc["k8s_pod_subnet_cidrs"].apply(
+                lambda pod_cidrs: [*pod_cidrs, edxapp_vpc["cidr"]]
+            ),
             protocol="tcp",
             from_port=DEFAULT_MYSQL_PORT,
             to_port=DEFAULT_MYSQL_PORT,

--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -264,6 +264,7 @@ ocw_studio_db_security_group = ec2.SecurityGroup(
             from_port=DEFAULT_POSTGRES_PORT,
             to_port=DEFAULT_POSTGRES_PORT,
             security_groups=[data_vpc["security_groups"]["integrator"]],
+            cidr_blocks=data_vpc["k8s_pod_subnet_cidrs"],
         ),
     ],
     egress=[

--- a/src/ol_infrastructure/applications/odl_video_service/__main__.py
+++ b/src/ol_infrastructure/applications/odl_video_service/__main__.py
@@ -338,7 +338,9 @@ ovs_database_security_group = ec2.SecurityGroup(
                 vault_stack.require_output("vault_server")["security_group"],
                 data_vpc["security_groups"]["integrator"],
             ],
-            cidr_blocks=[target_vpc["cidr"]],
+            cidr_blocks=data_vpc["k8s_pod_subnet_cidrs"].apply(
+                lambda pod_cidrs: [*pod_cidrs, target_vpc["cidr"]]
+            ),
             protocol="tcp",
             from_port=DEFAULT_POSTGRES_PORT,
             to_port=DEFAULT_POSTGRES_PORT,

--- a/src/ol_infrastructure/applications/xpro/__main__.py
+++ b/src/ol_infrastructure/applications/xpro/__main__.py
@@ -167,6 +167,7 @@ xpro_db_security_group = ec2.SecurityGroup(
             from_port=DEFAULT_POSTGRES_PORT,
             to_port=DEFAULT_POSTGRES_PORT,
             security_groups=[data_vpc["security_groups"]["integrator"]],
+            cidr_blocks=data_vpc["k8s_pod_subnet_cidrs"],
         ),
     ],
     tags=aws_config.merged_tags(

--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/__main__.py
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/__main__.py
@@ -147,6 +147,7 @@ if data_vpc_access_config.get_bool("create_privatelink_to_datavpc"):
                 from_port=1024,
                 to_port=1026,
                 security_groups=[data_vpc["security_groups"]["integrator"]],
+                cidr_blocks=data_vpc["k8s_pod_subnet_cidrs"],
             ),
         ],
         egress=[],


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
This opens up traffic from the Data K8s cluster to allow for Airbyte to communicate with the RDS instances that are scoped only to VPC traffic


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Apply the changes and verify that Airbyte is able to communicate with the DB

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
With the migration to K8s for Airbyte the application of security groups becomes a bit more challenging at the per-pod level. This is a short-term workaround to unblock data ingest.

<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
