### PR TITLE
chore(deps): bump edx-username-changer version

### DIFF
--- a/dockerfiles/openedx-edxapp/pip_package_lists/master/mitxonline.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/master/mitxonline.txt
@@ -2,7 +2,7 @@ celery-redbeat==2.2.0  # Support for using Redis as the lock for Celery schedule
 django-redis==5.4.0
 edx-git-auto-export==0.3
 edx-sysadmin==0.3.0
-edx-username-changer==0.3.1
+edx-username-changer==0.3.2
 openedx-companion-auth
 nodeenv>=1.7.0
 ol-openedx-checkout-external

--- a/dockerfiles/openedx-edxapp/pip_package_lists/quince/xpro.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/quince/xpro.txt
@@ -2,7 +2,7 @@ celery-redbeat==2.2.0  # Support for using Redis as the lock for Celery schedule
 django-redis==5.4.0
 edx-git-auto-export==0.3
 edx-sysadmin==0.3.0
-edx-username-changer==0.3.1
+edx-username-changer==0.3.2
 git+https://github.com/ubc/ubcpi.git@1.0.0#egg=ubcpi-xblock
 mitxpro-openedx-extensions==1.1.0
 nodeenv>=1.7.0

--- a/dockerfiles/openedx-edxapp/pip_package_lists/sumac/xpro.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/sumac/xpro.txt
@@ -2,7 +2,7 @@ celery-redbeat==2.2.0  # Support for using Redis as the lock for Celery schedule
 django-redis==5.4.0
 edx-git-auto-export==0.3
 edx-sysadmin==0.3.0
-edx-username-changer==0.3.1
+edx-username-changer==0.3.2
 git+https://github.com/ubc/ubcpi.git@1.0.0#egg=ubcpi-xblock
 openedx-companion-auth
 nodeenv>=1.7.0


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/5584

### Description (What does it do?)
Bump `edx-username-changer` package version from 0.3.1 to 0.3.2