### PR TITLE
Keycloak upgrade fix

### DIFF
--- a/src/bilder/images/keycloak/files/.env.tmpl
+++ b/src/bilder/images/keycloak/files/.env.tmpl
@@ -1,5 +1,6 @@
 VERSION={{ file "/etc/default/keycloak-version" }}
 KC_HOSTNAME="{{ keyOrDefault "keycloak/keycloak_host" "missing_keycloak_host" }}"
+KC_URL="https://{{ keyOrDefault "keycloak/keycloak_host" "missing_keycloak_host" }}"
 KC_PROXY="edge"
 KC_CACHE="ispn"
 KC_CACHE_CONFIG_FILE="cache-ispn-jdbc-ping.xml"

--- a/src/bilder/images/keycloak/files/docker-compose.yaml
+++ b/src/bilder/images/keycloak/files/docker-compose.yaml
@@ -6,6 +6,8 @@ services:
     - start
     - --spi-sticky-session-encoder-infinispan-should-attach-route=false
     - --spi-login-provider=ol-freemarker
+    - --http-enabled=true
+    - --hostname=${KC_URL}
     env_file:
     - ./.env
     labels:


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
Change should resolve our issue of running into the `somethingWenWrong` Keycloak error when upgrading to version 26.0.5
