### PR TITLE
Add access_logs to Keycloak traefik

### DIFF
--- a/src/bilder/images/keycloak/deploy.py
+++ b/src/bilder/images/keycloak/deploy.py
@@ -88,6 +88,7 @@ consul_templates: list[ConsulTemplateTemplate] = []
 # Configure and install traefik
 traefik_static_config = traefik_static.TraefikStaticConfig(
     log=traefik_static.Log(format="json"),
+    accessLog=traefik_static.AccessLog(format="json"),
     providers=traefik_static.Providers(docker=traefik_static.Docker()),
     certificates_resolvers={
         "letsencrypt_resolver": traefik_static.CertificatesResolvers(

--- a/src/bilder/images/keycloak/files/docker-compose.yaml
+++ b/src/bilder/images/keycloak/files/docker-compose.yaml
@@ -26,6 +26,8 @@ services:
     image: traefik:v3.2
     command:
     - "--configFile=/etc/traefik/traefik.yaml"
+    environment:
+    - AWS_REGION=us-east-1
     labels:
     - "traefik.http.middlewares.keycloak-ratelimit.ratelimit.average=10"
     ports:


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds access_logs to Keycloak traefik as that information can be handy. There are some [filtering](https://doc.traefik.io/traefik/observability/access-logs/#filtering) options that we can apply if it gets too noisy, but think it's good for now. The second change is an issue I see in the logs when messing around with the Keycloak upgrade. Appears that in the traefik letsencrypt config, [AWS Region is no longer optional](https://github.com/traefik/traefik/issues/10195). This add it to keycloak, but we might want to add that to the other configs too.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
I tried it manually on Keycloak CI
