### PR TITLE
chore: bump ol-openedx-canvas-integration to 0.4.0

### DIFF
--- a/dockerfiles/openedx-edxapp/pip_package_lists/sumac/mitx-staging.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/sumac/mitx-staging.txt
@@ -5,7 +5,7 @@ edx-sga
 edx-sysadmin==0.3.0
 git+https://github.com/raccoongang/xblock-pdf.git@d8948bf3c7127e23be202d1f8600f1ba293ba978#egg=xblock-pdf
 nodeenv>=1.7.0
-ol-openedx-canvas-integration==0.3.0
+ol-openedx-canvas-integration==0.4.0
 ol-openedx-course-export==0.1.2
 ol-openedx-course-structure-api
 ol-openedx-logging==0.2.0

--- a/dockerfiles/openedx-edxapp/pip_package_lists/sumac/mitx.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/sumac/mitx.txt
@@ -5,7 +5,7 @@ edx-sga
 edx-sysadmin==0.3.0
 git+https://github.com/raccoongang/xblock-pdf.git@d8948bf3c7127e23be202d1f8600f1ba293ba978#egg=xblock-pdf
 nodeenv>=1.7.0
-ol-openedx-canvas-integration==0.3.0
+ol-openedx-canvas-integration==0.4.0
 ol-openedx-course-export==0.1.2
 ol-openedx-course-structure-api
 ol-openedx-logging==0.2.0


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/6104

### Description (What does it do?)
Bumps the canvas integration plugin version

### How can this be tested?
Once installed correctly, we should see a `Canvas` tab on the `Instructor Dashboard`

### Additional Context
You can check the conversation on https://github.com/mitodl/hq/issues/6104
