### PR TITLE
config,fix: Add missing setting for daily digest emails in MITx Online

### DIFF
--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -354,6 +354,7 @@ JWT_EXPIRATION: 30
 LANGUAGE_CODE: en
 LANGUAGE_COOKIE: {{ env "ENVIRONMENT" }}-openedx-language-preference
 LEARNER_PORTAL_URL_ROOT: https://learner-portal-localhost:18000
+LEARNER_HOME_MICROFRONTEND_URL: ''
 LEARNING_MICROFRONTEND_URL: https://{{ key "edxapp/lms-domain" }}/learn
 LMS_BASE: {{ key "edxapp/lms-domain" }}  # MODIFIED
 LMS_INTERNAL_ROOT_URL: https://{{ key "edxapp/lms-domain" }}  # MODIFIED


### PR DESCRIPTION
### What are the relevant tickets?
https://celery-monitoring.odl.mit.edu/task/?app=mitxonline&env=production&uuid=4da53f19-5c1f-4eba-a2c2-6cdc69501628

### Description (What does it do?)
This PR adds `LEARNER_HOME_MICROFRONTEND_URL` setting for daily digest emails in MITx Online

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
