### PR TITLE
Tweaks for vault/keycloak OIDC work

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/__main__.py
+++ b/src/ol_infrastructure/substructure/keycloak/__main__.py
@@ -679,7 +679,7 @@ for openid_clients in keycloak_realm_config.get_object("openid_clients"):
     realm_name = openid_clients.get("realm_name")
     client_details = openid_clients.get("client_info")
     for client_name, client_detail in client_details.items():
-        urls = [url for url in client_detail if url.startswith("https")]
+        urls = [url for url in client_detail if url.startswith("http")]
 
         openid_client = keycloak.openid.Client(
             f"{realm_name}-{client_name}-client",

--- a/src/ol_infrastructure/substructure/vault/secrets/Pulumi.substructure.vault.secrets.operations.QA.yaml
+++ b/src/ol_infrastructure/substructure/vault/secrets/Pulumi.substructure.vault.secrets.operations.QA.yaml
@@ -8,4 +8,4 @@ config:
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa
   keycloak:client-secret:
-    secure: v1:O6bloRgoHCRsGakb:QZ5JfiWqpzCeO5VqKZHRtcRkIkDEVO3RgUTQEWvAbnAZuphA7XaSZO3DiW/hpwad
+    secure: v1:iAm9e/nnnZ4GdOdo:NC7vy2WTCJcSZSI/zyLVJQiWEU8DmpGcmqTl85FkFcpl/Niv3ecATGz1b76tII/8


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
Does the following:
- Allows the use of `http` for the vault redirect URL since that's need for vault CLI
- Updates the vault client secret generated by Keycloak when the client was created.

