### PR TITLE
UE API clients: Fix the GitHub repo name in the pipeline definition

### DIFF
--- a/src/ol_concourse/pipelines/libraries/unified_ecommerce_api_clients.py
+++ b/src/ol_concourse/pipelines/libraries/unified_ecommerce_api_clients.py
@@ -71,7 +71,7 @@ unified_ecommerce_repository = git_repo(
 
 unified_ecommerce_api_clients_repository = ssh_git_repo(
     name=Identifier("unified-ecommerce-api-clients"),
-    uri="git@github.com:mitodl/open-api-clients.git",
+    uri="git@github.com:mitodl/unified-ecommerce-api-clients.git",
     branch="main",
     private_key="((npm_publish.odlbot_private_ssh_key))",
 )


### PR DESCRIPTION
There was one outlier ref to the Learn repo that should have been changed.

### What are the relevant tickets?

n/a

### Description (What does it do?)

The pipeline was originally done here and was basically a cut and paste of the existing `open-api-clients` pipeline; there was a spot where it was still referencing an `open` GitHub repo that needed to be changed, so this changes it.

### How can this be tested?

The pipeline should run successfully.