### PR TITLE
Enable PKCE for OIDC clients

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/__main__.py
+++ b/src/ol_infrastructure/substructure/keycloak/__main__.py
@@ -690,6 +690,7 @@ for openid_clients in keycloak_realm_config.get_object("openid_clients"):
             access_type="CONFIDENTIAL",
             standard_flow_enabled=openid_clients.get("standard_flow_enabled") or True,
             implicit_flow_enabled=openid_clients.get("implicit_flow_enabled") or False,
+            pkce_code_challenge_method="S256",
             service_accounts_enabled=openid_clients.get("service_accounts_enabled")
             or False,
             valid_redirect_uris=urls,


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
This enables [PKCE](https://oauth.net/2/pkce/) (Proof Key for Code Exchange) to the OIDC clients to prevent CSRF and authorization code injection attacks. It is now a recommended best practice and additionally we have a [use case](https://github.com/mitodl/mit-learn/pull/1868#discussion_r1869827203) where we will be dealing with dynamic hostnames which could expose us to open redirects when using wildcards. This should help mitigate that, even though ideally we wouldn't want to rely on the use of wildcards and should explore dynamic hostname registrations.