### PR TITLE
config: add MITXPRO_OAUTH_PROVIDER and OPENEDX_SOCIAL_LOGIN_PATH in xpro RC env

### DIFF
--- a/src/ol_infrastructure/applications/xpro/Pulumi.applications.xpro.CI.yaml
+++ b/src/ol_infrastructure/applications/xpro/Pulumi.applications.xpro.CI.yaml
@@ -23,6 +23,8 @@ config:
     MITXPRO_LOG_LEVEL: "INFO"
     MITXPRO_SECURE_SSL_HOST: "xpro-ci.odl.mit.edu"
     OPENEDX_API_BASE_URL: "https://courses-ci.xpro.mit.edu"
+    OPENEDX_OAUTH_PROVIDER: "ol-oauth2"
+    OPENEDX_SOCIAL_LOGIN_PATH: "/auth/login/ol-oauth2/?auth_entry=login"
     SENTRY_LOG_LEVEL: "ERROR"
     SHEETS_DEFERRAL_FIRST_ROW: 184
     SHEETS_MONITORING_FREQUENCY: 86400

--- a/src/ol_infrastructure/applications/xpro/Pulumi.applications.xpro.QA.yaml
+++ b/src/ol_infrastructure/applications/xpro/Pulumi.applications.xpro.QA.yaml
@@ -23,10 +23,10 @@ config:
     MITOL_HUBSPOT_API_ID_PREFIX: "xpro-rc"
     MITXPRO_BASE_URL: "https://rc.xpro.mit.edu"
     MITXPRO_LOG_LEVEL: "INFO"
-    MITXPRO_OAUTH_PROVIDER: "ol-oauth2"
     MITXPRO_SECURE_SSL_HOST: "rc.xpro.mit.edu"
     MITXPRO_USE_S3: "True"
     OPENEDX_API_BASE_URL: "https://courses-rc.xpro.mit.edu"
+    OPENEDX_OAUTH_PROVIDER: "ol-oauth2"
     OPENEDX_SOCIAL_LOGIN_PATH: "/auth/login/ol-oauth2/?auth_entry=login"
     SENTRY_LOG_LEVEL: "ERROR"
     SHEETS_DEFERRAL_FIRST_ROW: 184

--- a/src/ol_infrastructure/applications/xpro/Pulumi.applications.xpro.QA.yaml
+++ b/src/ol_infrastructure/applications/xpro/Pulumi.applications.xpro.QA.yaml
@@ -23,9 +23,11 @@ config:
     MITOL_HUBSPOT_API_ID_PREFIX: "xpro-rc"
     MITXPRO_BASE_URL: "https://rc.xpro.mit.edu"
     MITXPRO_LOG_LEVEL: "INFO"
+    MITXPRO_OAUTH_PROVIDER: "ol-oauth2"
     MITXPRO_SECURE_SSL_HOST: "rc.xpro.mit.edu"
     MITXPRO_USE_S3: "True"
     OPENEDX_API_BASE_URL: "https://courses-rc.xpro.mit.edu"
+    OPENEDX_SOCIAL_LOGIN_PATH: "/auth/login/ol-oauth2/?auth_entry=login"
     SENTRY_LOG_LEVEL: "ERROR"
     SHEETS_DEFERRAL_FIRST_ROW: 184
     SHEETS_MONITORING_FREQUENCY: 43200


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6157#issue-2697314357

### Description (What does it do?)
This PR moves MITXPRO_OAUTH_PROVIDER and OPENEDX_SOCIAL_LOGIN_PATH to env files so that we can test the social auth backend name change on QA without affecting Prod.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
