### PR TITLE
Resize edxapp mitxonline prod workers

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
@@ -55,7 +55,7 @@ config:
   edxapp:framework: "earthly"
   edxapp:web_node_capacity: "9"
   edxapp:worker_node_capacity: "5"
-  edxapp:worker_instance_type: "c6a.large"
+  edxapp:worker_instance_type: "r8g.large"
   mongodb:atlas_project_id: 61f0a63f8bc1f86a073a7148
   redis:instance_type: cache.r6g.2xlarge
   vault:address: https://vault-production.odl.mit.edu

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
@@ -55,7 +55,7 @@ config:
   edxapp:framework: "earthly"
   edxapp:web_node_capacity: "9"
   edxapp:worker_node_capacity: "5"
-  edxapp:worker_instance_type: "r8g.large"
+  edxapp:worker_instance_type: "r7a.large"
   mongodb:atlas_project_id: 61f0a63f8bc1f86a073a7148
   redis:instance_type: cache.r6g.2xlarge
   vault:address: https://vault-production.odl.mit.edu


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
MITx Online edxapp worker prod instance seem to constantly reach their memory limits. Currently they're configured as `c6a.large` compute optimized instances which have 2 vCPUs and 4GB of RAM. This would switch them to memory optimized instances with 2 vCPUs and 8GB of RAM
