### PR TITLE
config, fix: Added required settings to run daily digest in mitxonline

### DIFF
--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -112,6 +112,7 @@ CONTENTSTORE:
         auth_source: ''
         <<: *mongo_params
 
+ACCOUNT_MICROFRONTEND_URL: null
 ACTIVATION_EMAIL_SUPPORT_LINK: ''
 AFFILIATE_COOKIE_NAME: dev_affiliate_id
 # ANALYTICS_DASHBOARD_NAME: Your Platform Name Here Insights
@@ -207,6 +208,7 @@ CERTIFICATE_TEMPLATE_LANGUAGES:
     es: Español
 CERT_QUEUE: certificates
 CMS_BASE: {{ key "edxapp/studio-domain" }}  # MODIFIED
+CONTACT_MAILING_ADDRESS: SET-ME-PLEASE
 CONTACT_US_ENABLE: false
 ENABLE_CODEJAIL_REST_SERVICE: true
 CODE_JAIL_REST_SERVICE_HOST: http://codejail.service.consul:8000


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4070

### Description (What does it do?)
Some settings were still missing as [this error](https://mit-office-of-digital-learning.sentry.io/issues/6115785112/?project=5939801&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=date&statsPeriod=90d&stream_index=1) was logged on sentry. Strangely, we got the error of missing `LEARNER_HOME_MICROFRONTEND_URL` before this one, but in code flow, this is accessed after `ACCOUNT_MICROFRONTEND_URL` 


### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
