### PR TITLE
config: change the social auth backend name in mitxonline

### DIFF
--- a/dockerfiles/openedx-edxapp/pip_package_lists/master/mitxonline.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/master/mitxonline.txt
@@ -11,7 +11,7 @@ ol-openedx-course-structure-api
 ol-openedx-logging
 ol-openedx-sentry
 openedx-scorm-xblock
-social-auth-mitxpro==0.7.1
+ol-social-auth==0.1.0
 uwsgi==2.0.28
 wheel==0.45.1
 

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/lms_only.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/lms_only.yml.tmpl
@@ -1,7 +1,7 @@
 # -*- mode: yaml -*-
 {{ with secret "secret-mitxonline/edxapp" }}
 SOCIAL_AUTH_OAUTH_SECRETS:
-  mitxpro-oauth2: {{ .Data.mitxonline_oauth_secret }}
+  ol-oauth2: {{ .Data.mitxonline_oauth_secret }}
 {{ end }}
 
 ACCOUNT_MICROFRONTEND_URL: null
@@ -90,7 +90,7 @@ RECALCULATE_GRADES_ROUTING_KEY: edx.lms.core.default
 SITE_NAME: {{ key "edxapp/lms-domain" }}  # MODIFIED
 SESSION_COOKIE_NAME: {{ env "ENVIRONMENT" }}-edx-lms-sessionid  # MODIFIED
 THIRD_PARTY_AUTH_BACKENDS:
-- social_auth_mitxpro.backends.MITxProOAuth2
+- ol_social_auth.backends.OLOAuth2
 - social_core.backends.google.GoogleOAuth2
 - social_core.backends.linkedin.LinkedinOAuth2
 - social_core.backends.facebook.FacebookOAuth2


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6158

### Description (What does it do?)
This PR changes the replaces social-auth-mitxpro with ol-social-auth in MITxOnline

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
