### PR TITLE
Change emailOptIn default to '1'

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/__main__.py
+++ b/src/ol_infrastructure/substructure/keycloak/__main__.py
@@ -1018,7 +1018,7 @@ oidc_attribute_importer_identity_provider_mapper = (
         realm=ol_data_platform_realm.id,
         identity_provider_alias=ol_apps_touchstone_saml_identity_provider.alias,
         attribute_name="emailOptIn",
-        attribute_value="true",
+        attribute_value="1",
         user_session=False,
         extra_config={
             "syncMode": "INHERIT",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
The default I gave Sar (`"true"`) was incorrect, the code in Learn [expects it to be a parseable int of 0 or 1](https://github.com/mitodl/mit-learn/blob/main/authentication/backends/ol_open_id_connect.py#L22-L24) , so I'm updating the default here to reflect that.
