### PR TITLE
Revert "Remove the protocol mapper for emailOptIn (#2805)"

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/__main__.py
+++ b/src/ol_infrastructure/substructure/keycloak/__main__.py
@@ -403,7 +403,7 @@ ol_apps_profile_client_scope = keycloak.openid.ClientScope(
     name="ol-profile",
     realm_id=ol_apps_realm.id,
 )
-"""
+
 ol_apps_user_email_optin_attribute_mapper = keycloak.openid.UserAttributeProtocolMapper(
     "email-optin-mapper",
     realm_id=ol_apps_realm.id,
@@ -412,7 +412,6 @@ ol_apps_user_email_optin_attribute_mapper = keycloak.openid.UserAttributeProtoco
     user_attribute="emailOptIn",
     claim_name="email_optin",
 )
-"""
 ol_apps_user_fullname_attribute_mapper = keycloak.openid.UserAttributeProtocolMapper(
     "fullname-mapper",
     realm_id=ol_apps_realm.id,


### PR DESCRIPTION
This reverts commit 3c16e1c2de8d2cde062ed78a98beb2798744de00.

### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/6136

### Description (What does it do?)
<!--- Describe your changes in detail -->
This reverts a previous change that removed this protocol mapper do to there being bad data in the field. Fixes are now in place to prevent the bad data and existing bad data has been fixed.