### PR TITLE
config: disable new new_core_editors for xPRO

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.CI.yaml
@@ -18,8 +18,8 @@ config:
   - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
     "--everyone"]
   - ["new_core_editors.use_new_problem_editor", "--create", "--deactivate"]
-  - ["new_core_editors.use_new_text_editor", "--create", "--superusers"]
-  - ["new_core_editors.use_new_video_editor", "--create", "--superusers"]
+  - ["new_core_editors.use_new_text_editor", "--create", "--superusers", "--deactivate"]
+  - ["new_core_editors.use_new_video_editor", "--create", "--superusers", "--deactivate"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["studio.library_authoring_mfe", "--deactivate"]


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6269
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
Disable the new authoring MFE for xPRO. These are already disabled for prod, so the changeset in this PR only updates the CI file for xPRO.
<!--- Describe your changes in detail -->

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
Once deployed, Create or edit any problem e.g. use [this link](https://studio-rc.xpro.mit.edu/container/block-v1:RCTEST+SUMACTEST+RC_R0+type@vertical+block@4fd32dcf57784ef991bf72a81695d846#block-v1:RCTEST+SUMACTEST+RC_R0+type@html+block@80d87c952d13455fb101a1860dc9372b) and they should not be opened in the new editor.
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

