### PR TITLE
Enable Professional Education API ETL pipeline on production

### DIFF
--- a/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.Production.yaml
+++ b/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.Production.yaml
@@ -50,6 +50,7 @@ config:
     MITOL_NEW_USER_LOGIN_URL: "https://learn.mit.edu/onboarding"
     MITOL_NOINDEX: "false"
     MITOL_SUPPORT_EMAIL: "learn-support@mit.edu"  # Need to verify
+    MITPE_API_ENABLED: "true"
     OCW_ITERATOR_CHUNK_SIZE: 300
     OIDC_ENDPOINT: "https://sso.ol.mit.edu/realms/olapps"
     OPENSEARCH_INDEX: "mitlearn"


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/4731

### Description (What does it do?)
Enables use of the Professional Education ETL pipeline on production (eventually this flag will be removed altogether, once some additional code changes are made for mit-learn).

### How can this be tested?
N/A
