### PR TITLE
UE API Client pipeline: install yarn explicitly

### DIFF
--- a/src/ol_concourse/pipelines/libraries/scripts/unified-ecommerce-api-clients-publish-node.sh
+++ b/src/ol_concourse/pipelines/libraries/scripts/unified-ecommerce-api-clients-publish-node.sh
@@ -2,9 +2,11 @@
 # publish the npm package to npmjs.org
 
 echo "//registry.npmjs.org/:_authToken=((npm_publish.npmjs_token))" > .npmrc
+COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+corepack enable
 yarn install --immutable
 yarn build
 # OK so this is vaguely gross but it will do :)
 new_version=$(cat ../../../VERSION)
 echo "Publishing version $new_version"
-yarn publish --access public --new-version "$new_version"
+yarn npm publish --access public


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/5723

### Description (What does it do?)

We're getting some errors in the publish step of the pipeline, mostly relating to the yarn version that comes with Node. Node ships with yarn 1.2 (yarn classic) and the client specifies yarn 4.2 (berry). So, this updates the publish step script to enable Corepack, which then enables using the yarn version specified in the `package.json`. 

This also updates the publish command since it's changed in yarn berry.

### How can this be tested?

dunno but this seemed to work just running it manually outside the pipeline (other than publishing, because I didn't want to publish it for real). 

### Additional Context

`yarn npm publish` doesn't give you a way to specify the version, so I think it comes out of the package manifest. It will also default to setting the tag to `latest`. 
