### PR TITLE
switch to large text embedding model

### DIFF
--- a/src/ol_infrastructure/applications/mitlearn/__main__.py
+++ b/src/ol_infrastructure/applications/mitlearn/__main__.py
@@ -854,6 +854,7 @@ heroku_vars = {
     "OPENSEARCH_DEFAULT_TIMEOUT": 30,
     "OPENSEARCH_INDEXING_CHUNK_SIZE": 75,
     "QDRANT_COLLECTION_NAME": f"mitlearn-{stack_info.env_suffix}",
+    "QDRANT_DENSE_MODEL": "text-embedding-3-large",
     "QDRANT_ENCODER": "vector_search.encoders.litellm.LiteLLMEncoder",
     "PROLEARN_CATALOG_API_URL": "https://prolearn.mit.edu/graphql",
     "SEE_API_URL": "https://mit-unified-portal-prod-78eeds.43d8q2.usa-e2.cloudhub.io/api/",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Related to https://github.com/mitodl/hq/issues/6271


### Description (What does it do?)
This PR switches us to using open ai's large embedding model (currently we are using small)


### Additional Context
When this is deployed I will need to regenerate the embeddings.

