### PR TITLE
config: pin openedx-companion-auth version to 1.1.0 in mitxonline

### DIFF
--- a/dockerfiles/openedx-edxapp/pip_package_lists/master/mitxonline.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/master/mitxonline.txt
@@ -3,7 +3,7 @@ django-redis==5.4.0
 edx-git-auto-export==0.3
 edx-sysadmin==0.3.0
 edx-username-changer==0.3.2
-openedx-companion-auth==1.0.0
+openedx-companion-auth==1.1.0
 nodeenv>=1.7.0
 ol-openedx-checkout-external
 ol-openedx-course-export==0.1.2


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6158

### Description (What does it do?)
This PR pins openedx-companion-auth version to v1.1.0 to make it compatible with ol-social-auth

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
