### PR TITLE
config: add MITXPRO_OAUTH_PROVIDER and OPENEDX_SOCIAL_LOGIN_PATH in xpro prod env

### DIFF
--- a/src/ol_infrastructure/applications/xpro/Pulumi.applications.xpro.Production.yaml
+++ b/src/ol_infrastructure/applications/xpro/Pulumi.applications.xpro.Production.yaml
@@ -31,6 +31,8 @@ config:
     MITXPRO_SECURE_SSL_HOST: "xpro.mit.edu"
     MITXPRO_USE_S3: "True"
     OPENEDX_API_BASE_URL: "https://courses.xpro.mit.edu"
+    OPENEDX_OAUTH_PROVIDER: "ol-oauth2"
+    OPENEDX_SOCIAL_LOGIN_PATH: "/auth/login/ol-oauth2/?auth_entry=login"
     SENTRY_LOG_LEVEL: "WARN"
     SHEETS_DEFERRAL_FIRST_ROW: 234
     SHEETS_MONITORING_FREQUENCY: 3600


### PR DESCRIPTION
### What are the relevant tickets?
2nd step of https://github.com/mitodl/hq/issues/6157 for prod

### Description (What does it do?)
This PR sets ol-social-auth provider in xpro marketing app prod instance

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
