### PR TITLE
UE API Client: more fixes for the publishing workflow

### DIFF
--- a/src/ol_concourse/pipelines/libraries/scripts/unified-ecommerce-api-clients-publish-node.sh
+++ b/src/ol_concourse/pipelines/libraries/scripts/unified-ecommerce-api-clients-publish-node.sh
@@ -1,11 +1,11 @@
 #!/bin/bash -x
 # publish the npm package to npmjs.org
 
-echo "//registry.npmjs.org/:_authToken=((npm_publish.npmjs_token))" > .npmrc
-COREPACK_ENABLE_DOWNLOAD_PROMPT=0
-export COREPACK_ENABLE_DOWNLOAD_PROMPT
+#echo "//registry.npmjs.org/:_authToken=((npm_publish.npmjs_token))" > .npmrc
+echo "npmPublishRegistry: https://registry.npmjs.org/" > .yarnrc.yml
+echo "npmAuthToken: ((npm_publish.npmjs_token))" >> .yarnrc.yml
 corepack enable
-yarn install --immutable
+COREPACK_ENABLE_DOWNLOAD_PROMPT=0 yarn install --immutable
 yarn build
 # OK so this is vaguely gross but it will do :)
 new_version=$(cat ../../../VERSION)


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/5723


### Description (What does it do?)

After https://github.com/mitodl/ol-infrastructure/pull/2851 got merged, I realized some more changes were needed. This should be the last round (I hope).

- As configured previously, running `yarn` after `corepack enable` stalled out because Corepack asks if you really want to go get yarn. Moved the env var to disable that prompt inline with the first call to `yarn` so it won't do that anymore.
- Update the ephemeral credentials store so the npmjs token gets put somewhere where yarn will actually see it.

### How can this be tested?

I tested this by running the `unified-ecommerce-api-clients-publish-node.sh` script in a temporary container. The gist of it was I cloned the UE API client repo intto a folder, threw this script in the folder, and ran a `node:18-slim` container. Then I ran the script. I _manually_ modified the script to take my personal npmjs token and then also futzed with the API client code a bit to make it publish to a scope that my personal account had access to (you get `@<your username>` as a scope by default). That all worked so I figure this will too. (I then deleted the pacakge I'd published.) 

### Notes

I'm not set up to run `fly` commands (at least for now) so someone will need to do that.