### PR TITLE
revert new Studio MFE waffle flags in production

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.Production.yaml
@@ -11,20 +11,16 @@ config:
   - ["course_home.course_home_mfe_progress_tab", "--create", "--everyone"]
   - ["contentstore.new_studio_mfe.use_new_advanced_settings_page", "--create", "--superusers",
     "--everyone"]
-  - ["contentstore.new_studio_mfe.use_new_course_outline_page", "--create", "--superusers",
-    "--everyone"]
-  - ["contentstore.new_studio_mfe.use_new_course_team_page", "--create", "--superusers",
-    "--everyone"]
+  - ["contentstore.new_studio_mfe.use_new_course_outline_page", "--deactivate"]
+  - ["contentstore.new_studio_mfe.use_new_course_team_page", "--deactivate"]
   - ["contentstore.new_studio_mfe.use_new_export_page", "--create", "--superusers",
     "--everyone"]
   - ["contentstore.new_studio_mfe.use_new_files_uploads_page", "--create", "--superusers",
     "--everyone"]
-  - ["contentstore.new_studio_mfe.use_new_grading_page", "--create", "--superusers",
-    "--everyone"]
+  - ["contentstore.new_studio_mfe.use_new_grading_page", "--deactivate"]
   - ["contentstore.new_studio_mfe.use_new_import_page", "--create", "--superusers",
     "--everyone"]
-  - ["contentstore.new_studio_mfe.use_new_schedule_details_page", "--create", "--superusers",
-    "--everyone"]
+  - ["contentstore.new_studio_mfe.use_new_schedule_details_page", "--deactivate"]
   - ["contentstore.new_studio_mfe.use_new_updates_page", "--create", "--superusers",
     "--everyone"]
   - ["discussions.pages_and_resources_mfe", "--create", "--superusers", "--everyone"]
@@ -38,7 +34,7 @@ config:
   - ["new_core_editors.use_new_problem_editor", "--create", "--everyone"]
   - ["new_core_editors.use_new_text_editor", "--create", "--superusers", "--everyone"]
   - ["new_core_editors.use_new_video_editor", "--create", "--superusers", "--everyone"]
-  - ["new_studio_mfe.use_new_home_page", "--create", "--superusers", "--everyone"]
+  - ["new_studio_mfe.use_new_home_page", "--deactivate"]
   - ["new_studio_mfe.use_tagging_taxonomy_list_page", "--create", "--superusers",
     "--everyone"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

partially reverts https://github.com/mitodl/ol-infrastructure/pull/2863
closes https://github.com/mitodl/hq/issues/6387 

### Description (What does it do?)
<!--- Describe your changes in detail -->

We released the new Studio MFE without testing to production. I already turned off the flags manually. This PR turns them off in the repo so it doesn't go out to production again by mistake. 

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

I would appreciate it if you could double-check my work to see that this turns off all and only the waffle flags that were turned on in https://github.com/mitodl/ol-infrastructure/pull/2863

