### PR TITLE
Minor tweak to xpro permissions

### DIFF
--- a/src/ol_infrastructure/substructure/vault/policies/github/software_engineer.hcl
+++ b/src/ol_infrastructure/substructure/vault/policies/github/software_engineer.hcl
@@ -37,7 +37,7 @@ path "secret-mitxonline/*" {
   capabilities = ["read", "list"]
 }
 
-path "secret-mitxpro/*" {
+path "secret-xpro/*" {
   capabilities = ["read", "list"]
 }
 


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
Was doing some vault QA cleanup on the `secret-mitxpro` but after checking the code, it appears that we moved away from using `secret-mitxpro` vault mount to `secret-xpro` one. This just changes permissions to use the active mount.