### PR TITLE
config: enable posthog for xPRO (CI/RC) and add API key

### DIFF
--- a/src/ol_infrastructure/applications/xpro/Pulumi.applications.xpro.CI.yaml
+++ b/src/ol_infrastructure/applications/xpro/Pulumi.applications.xpro.CI.yaml
@@ -25,6 +25,7 @@ config:
     OPENEDX_API_BASE_URL: "https://courses-ci.xpro.mit.edu"
     OPENEDX_OAUTH_PROVIDER: "ol-oauth2"
     OPENEDX_SOCIAL_LOGIN_PATH: "/auth/login/ol-oauth2/?auth_entry=login"
+    POSTHOG_ENABLED: "True"
     SENTRY_LOG_LEVEL: "ERROR"
     SHEETS_DEFERRAL_FIRST_ROW: 184
     SHEETS_MONITORING_FREQUENCY: 86400

--- a/src/ol_infrastructure/applications/xpro/Pulumi.applications.xpro.QA.yaml
+++ b/src/ol_infrastructure/applications/xpro/Pulumi.applications.xpro.QA.yaml
@@ -28,6 +28,7 @@ config:
     OPENEDX_API_BASE_URL: "https://courses-rc.xpro.mit.edu"
     OPENEDX_OAUTH_PROVIDER: "ol-oauth2"
     OPENEDX_SOCIAL_LOGIN_PATH: "/auth/login/ol-oauth2/?auth_entry=login"
+    POSTHOG_ENABLED: "True"
     SENTRY_LOG_LEVEL: "ERROR"
     SHEETS_DEFERRAL_FIRST_ROW: 184
     SHEETS_MONITORING_FREQUENCY: 43200

--- a/src/ol_infrastructure/applications/xpro/__main__.py
+++ b/src/ol_infrastructure/applications/xpro/__main__.py
@@ -259,6 +259,7 @@ heroku_vars = {
     "MITXPRO_USE_S3": "True",
     "NODE_MODULES_CACHE": "False",
     "OAUTH2_PROVIDER_ALLOWED_REDIRECT_URI_SCHEMES": "http,https,dccrequest",
+    "POSTHOG_API_HOST": "https://app.posthog.com",
     # This can be removed once PR#1314 is in production,
     "OPENEDX_OAUTH_APP_NAME": "edx-oauth-app",
     # This replaces OPENEDX_GRADES_API_TOKEN and is
@@ -352,6 +353,7 @@ sensitive_heroku_vars = {
     "OPENEDX_SERVICE_WORKER_API_TOKEN": xpro_vault_secrets["openedx"][
         "service_worker_api_token"
     ],
+    "POSTHOG_PROJECT_API_KEY": xpro_vault_secrets["posthog"]["project_api_key"],
     "RECAPTCHA_SECRET_KEY": xpro_vault_secrets["recaptcha"]["secret_key"],
     "RECAPTCHA_SITE_KEY": xpro_vault_secrets["recaptcha"]["site_key"],
     "REFUND_REQUEST_WORKSHEET_ID": xpro_vault_secrets["google-sheets"][


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/6376

### Description (What does it do?)
<!--- Describe your changes in detail -->
- Enables posthog for xPRO (CI/RC) only, I don't want to spill it to production unintentionally
- Adds the config for posthog API key. However, the actual key would be loaded from the vault

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Initially, there is nothing to test unless we start moving our feature flags to RC Posthog, We might still be able to use analytics

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
