### PR TITLE
fix,refactor: Unpack CNI plugins to proper target on Concourse

### DIFF
--- a/src/bilder/components/alloy/steps.py
+++ b/src/bilder/components/alloy/steps.py
@@ -42,7 +42,6 @@ def _install_from_package(alloy_config: AlloyConfig):
         files.directory(
             name="Remove example configurations",
             path=f"{alloy_config.configuration_directory}/config.alloy",
-            assume_present=True,
             present=False,
         )
 

--- a/src/bilder/components/concourse/sample_deploy.py
+++ b/src/bilder/components/concourse/sample_deploy.py
@@ -14,7 +14,7 @@ from bilder.components.concourse.steps import (
 from bilder.facts.has_systemd import HasSystemd
 
 concourse_config = ConcourseBaseConfig()
-web_config = ConcourseWebConfig()
+web_config = ConcourseWebConfig(admin_password="foobar", database_password="foobar")  # noqa: S106
 worker_config = ConcourseWorkerConfig()
 install_baseline_packages()
 install_changed = install_concourse(concourse_config)

--- a/src/bilder/components/concourse/steps.py
+++ b/src/bilder/components/concourse/steps.py
@@ -79,8 +79,7 @@ def install_concourse(concourse_config: ConcourseBaseConfig):
         server.shell(
             name="Extract the cni release archive.",
             commands=[
-                f"cd {installation_directory}/bin",
-                f"tar -xvzf {cni_archive_path}",
+                f"tar -xvzf {cni_archive_path} --directory {installation_directory}/bin/",  # noqa: E501
             ],
         )
         # Verify ownership of Concourse directory
@@ -129,13 +128,12 @@ def _manage_web_node_keys(
             src=host_key_file.name,
             state=state,
         )
-    elif not host.get_fact(File, concourse_config.tsa_host_key_path):
+    elif not host.get_fact(File, str(concourse_config.tsa_host_key_path)):
         server.shell(
             name="Generate a tsa host key",
             commands=[
                 f"{concourse_config.deploy_directory}/bin/concourse generate-key -t ssh -f {concourse_config.tsa_host_key_path}"  # noqa: E501
             ],
-            state=state,
         )
     if concourse_config.session_signing_key:
         session_signing_key_file = tempfile.NamedTemporaryFile(delete=False)
@@ -150,13 +148,12 @@ def _manage_web_node_keys(
             src=session_signing_key_file.name,
             state=state,
         )
-    elif not host.get_fact(File, concourse_config.session_signing_key_path):
+    elif not host.get_fact(File, str(concourse_config.session_signing_key_path)):
         server.shell(
             name="Generate a session signing key",
             commands=[
                 f"{concourse_config.deploy_directory}/bin/concourse generate-key -t rsa -f {concourse_config.session_signing_key_path}"  # noqa: E501
             ],
-            state=state,
         )
 
 

--- a/src/bilder/components/hashicorp/steps.py
+++ b/src/bilder/components/hashicorp/steps.py
@@ -47,7 +47,7 @@ def install_hashicorp_products(hashicorp_products: list[HashicorpProduct]):
         }
         download_destination = f"/tmp/{product.name}.zip"  # noqa: S108
         target_directory = product.install_directory or "/usr/local/bin/"
-        download_binary = files.download(
+        files.download(
             name=f"Download {product.name} archive",
             src=f"https://releases.hashicorp.com/{product.name}/{product.version}/{file_download}",
             dest=download_destination,
@@ -60,7 +60,6 @@ def install_hashicorp_products(hashicorp_products: list[HashicorpProduct]):
         files.file(
             name=f"Ensure {product.name} binary is executable",
             path=str(Path(target_directory).joinpath(product.name)),
-            assume_present=download_binary.changed,
             user=product.name,
             group=product.name,
             mode="755",

--- a/src/bilder/components/traefik/steps.py
+++ b/src/bilder/components/traefik/steps.py
@@ -47,7 +47,7 @@ def install_traefik_binary(traefik_config: TraefikConfig):
     }
     download_destination = "/tmp/traefik.tar.gz"  # noqa: S108
     target_directory = "/usr/local/bin/"
-    download_binary = files.download(
+    files.download(
         name="Download Traefik archive",
         src=f"https://github.com/traefik/traefik/releases/download/v{traefik_config.version}/{file_download}",
         dest=download_destination,
@@ -60,7 +60,6 @@ def install_traefik_binary(traefik_config: TraefikConfig):
     files.file(
         name="Ensure Traefik binary is executable",
         path=str(Path(target_directory).joinpath("traefik")),
-        assume_present=download_binary.changed,
         user=traefik_config.user,
         group=traefik_config.group,
         mode="755",

--- a/src/bilder/components/vector/steps.py
+++ b/src/bilder/components/vector/steps.py
@@ -38,13 +38,11 @@ def _install_from_package():
     files.directory(
         name="Remove example configurations",
         path="/etc/vector/examples/",
-        assume_present=True,
         present=False,
     )
     files.file(
         name="Remove example vector.toml",
         path="/etc/vector/vector.toml",
-        assume_present=True,
         present=False,
     )
 

--- a/src/bilder/images/xqwatcher/deploy.py
+++ b/src/bilder/images/xqwatcher/deploy.py
@@ -162,7 +162,6 @@ files.directory(
     name="Remove the existing conf.d directory for xqwatcher configurations",
     path=str(XQWATCHER_CONF_DIR),
     force=True,
-    assume_present=True,
     present=False,
 )
 


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
- Added an explicit target directory for tar unpacking of CNI plugins in Concourse install
- Updated syntax to address changes in PyInfra 3.x releases

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
From the root of the repo run `pyinfra @docker/debian:bullseye src/bilder/components/concourse/sample_deploy.py`, verify that it runs successfully and then verify that the CNI plugins have been unpacked to the target directory of `/usr/local/concourse/bin`
