### PR TITLE
Use a get with a default of blank so we don't fail if not found.

### DIFF
--- a/src/ol_infrastructure/applications/xpro/__main__.py
+++ b/src/ol_infrastructure/applications/xpro/__main__.py
@@ -353,7 +353,7 @@ sensitive_heroku_vars = {
     "OPENEDX_SERVICE_WORKER_API_TOKEN": xpro_vault_secrets["openedx"][
         "service_worker_api_token"
     ],
-    "POSTHOG_PROJECT_API_KEY": xpro_vault_secrets["posthog"]["project_api_key"],
+    "POSTHOG_PROJECT_API_KEY": xpro_vault_secrets["posthog"].get("project_api_key", ""),
     "RECAPTCHA_SECRET_KEY": xpro_vault_secrets["recaptcha"]["secret_key"],
     "RECAPTCHA_SITE_KEY": xpro_vault_secrets["recaptcha"]["site_key"],
     "REFUND_REQUEST_WORKSHEET_ID": xpro_vault_secrets["google-sheets"][


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/6376

### Description (What does it do?)
Makes it so the xpro Pulumi project doesn't fail when it can't find a posthog project API key, as we only have one in RC.

### How can this be tested?

Watch pipeline. Green? Great! Red. Sad.