### PR TITLE
fix: Split tracking log locations for LMS and CMS

### DIFF
--- a/src/bilder/images/edxapp_v2/deploy.py
+++ b/src/bilder/images/edxapp_v2/deploy.py
@@ -175,9 +175,12 @@ server.shell(
 
 
 # Create skeleton directory structures for docker-compose
-data_directory = Path("/opt/data")
-media_directory = data_directory.joinpath("media")
-tracking_logs_directory = data_directory.joinpath("logs")
+shared_data_directory = Path("/opt/data")
+lms_data_directory = Path("/opt/data/lms")
+cms_data_directory = Path("/opt/data/cms")
+media_directory = shared_data_directory.joinpath("media")
+lms_tracking_logs_directory = lms_data_directory.joinpath("logs")
+cms_tracking_logs_directory = cms_data_directory.joinpath("logs")
 settings_directory = DOCKER_COMPOSE_DIRECTORY.joinpath("settings")
 tls_directory = DOCKER_COMPOSE_DIRECTORY.joinpath("tls")
 ssh_directory = DOCKER_COMPOSE_DIRECTORY.joinpath("ssh")
@@ -191,8 +194,15 @@ files.directory(
 )
 
 files.directory(
-    name="Create data directory",
-    path=data_directory,
+    name="Create LMS data directory",
+    path=lms_data_directory,
+    user="1000",
+    group="1000",
+    present=True,
+)
+files.directory(
+    name="Create CMS data directory",
+    path=cms_data_directory,
     user="1000",
     group="1000",
     present=True,
@@ -227,8 +237,15 @@ files.directory(
     present=True,
 )
 files.directory(
-    name="Create tracking logs directory",
-    path=tracking_logs_directory,
+    name="Create LMS tracking logs directory",
+    path=lms_tracking_logs_directory,
+    user="1000",
+    group="1000",
+    present=True,
+)
+files.directory(
+    name="Create CMS tracking logs directory",
+    path=cms_tracking_logs_directory,
     user="1000",
     group="1000",
     present=True,

--- a/src/bilder/images/edxapp_v2/files/docker-compose.yaml.tmpl
+++ b/src/bilder/images/edxapp_v2/files/docker-compose.yaml.tmpl
@@ -12,7 +12,7 @@ services:
     command: ["1000", "/openedx/data", "/openedx/media"]
     restart: on-failure
     volumes:
-    - /opt/data:/openedx/data
+    - /opt/data/lms:/openedx/data
     - /opt/data/media:/openedx/media
     - /opt/staticfiles-${ENVIRONMENT_TIER}:/openedx/staticfiles:ro
     - /opt/staticfiles-${ENVIRONMENT_TIER}/bundles:/openedx/edx-platform/common/static/bundles:ro
@@ -26,7 +26,7 @@ services:
     command: ["1000", "/openedx/data", "/openedx/media"]
     restart: on-failure
     volumes:
-    - /opt/data:/openedx/data
+    - /opt/data/cms:/openedx/data
     - /opt/data/media:/openedx/media
     - /opt/staticfiles-${ENVIRONMENT_TIER}:/openedx/staticfiles:ro
     - /opt/staticfiles-${ENVIRONMENT_TIER}/bundles:/openedx/edx-platform/common/static/bundles:ro
@@ -63,7 +63,7 @@ services:
     volumes:
     - ./settings/lms.env.yml:/openedx/config/lms.env.yml:ro
     - ./settings/uwsgi.ini:/openedx/edx-platform/uwsgi.ini:ro
-    - /opt/data:/openedx/data
+    - /opt/data/lms:/openedx/data
     - /opt/data/media:/openedx/media
     - ./ssh/id_rsa:/openedx/.ssh/id_rsa:ro
     - /opt/staticfiles-${ENVIRONMENT_TIER}:/openedx/staticfiles:ro
@@ -82,7 +82,7 @@ services:
     volumes:
     - ./settings/cms.env.yml:/openedx/config/cms.env.yml:ro
     - ./settings/uwsgi.ini:/openedx/edx-platform/uwsgi.ini:ro
-    - /opt/data:/openedx/data
+    - /opt/data/cms:/openedx/data
     - /opt/data/media:/openedx/media
     - ./ssh/id_rsa:/openedx/.ssh/id_rsa:ro
     - /opt/staticfiles-${ENVIRONMENT_TIER}:/openedx/staticfiles:ro
@@ -112,7 +112,7 @@ services:
     restart: on-failure
     volumes:
     - ./settings/lms.env.yml:/openedx/config/lms.env.yml:ro
-    - /opt/data:/openedx/data
+    - /opt/data/lms:/openedx/data
     - /opt/data/media:/openedx/media
     - /opt/staticfiles-${ENVIRONMENT_TIER}:/openedx/staticfiles:ro
     - /opt/staticfiles-${ENVIRONMENT_TIER}/bundles:/openedx/edx-platform/common/static/bundles:ro
@@ -153,7 +153,7 @@ services:
     volumes:
     - ./settings/lms.env.yml:/openedx/config/lms.env.yml:ro
     - ./settings/waffle_flags.yaml:/openedx/config/waffle_flags.yaml:ro
-    - /opt/data:/openedx/data
+    - /opt/data/cms:/openedx/data
     - /opt/data/media:/openedx/media
     - /opt/staticfiles-${ENVIRONMENT_TIER}:/openedx/staticfiles:ro
     - /opt/staticfiles-${ENVIRONMENT_TIER}/bundles:/openedx/edx-platform/common/static/bundles:ro
@@ -175,7 +175,7 @@ services:
     restart: unless-stopped
     volumes:
     - ./settings/lms.env.yml:/openedx/config/lms.env.yml:ro
-    - /opt/data:/openedx/data
+    - /opt/data/lms:/openedx/data
     - /opt/data/media:/openedx/media
     - ./ssh/id_rsa:/openedx/.ssh/id_rsa:ro
     - /opt/staticfiles-${ENVIRONMENT_TIER}:/openedx/staticfiles:ro
@@ -197,7 +197,7 @@ services:
     restart: on-failure
     volumes:
     - ./settings/lms.env.yml:/openedx/config/lms.env.yml:ro
-    - /opt/data:/openedx/data
+    - /opt/data/lms:/openedx/data
     - /opt/data/media:/openedx/media
     - /opt/staticfiles-${ENVIRONMENT_TIER}:/openedx/staticfiles:ro
     - /opt/staticfiles-${ENVIRONMENT_TIER}/bundles:/openedx/edx-platform/common/static/bundles:ro
@@ -216,7 +216,7 @@ services:
     restart: on-failure
     volumes:
     - ./settings/lms.env.yml:/openedx/config/lms.env.yml:ro
-    - /opt/data:/openedx/data
+    - /opt/data/lms:/openedx/data
     - /opt/data/media:/openedx/media
     - /opt/staticfiles-${ENVIRONMENT_TIER}:/openedx/staticfiles:ro
     - /opt/staticfiles-${ENVIRONMENT_TIER}/bundles:/openedx/edx-platform/common/static/bundles:ro
@@ -239,7 +239,7 @@ services:
     restart: unless-stopped
     volumes:
     - ./settings/cms.env.yml:/openedx/config/cms.env.yml:ro
-    - /opt/data:/openedx/data
+    - /opt/data/cms:/openedx/data
     - /opt/data/media:/openedx/media
     - ./ssh/id_rsa:/openedx/.ssh/id_rsa:ro
     - /opt/staticfiles-${ENVIRONMENT_TIER}:/openedx/staticfiles:ro

--- a/src/bilder/images/edxapp_v2/templates/vector/edxapp_parsing.yaml.j2
+++ b/src/bilder/images/edxapp_v2/templates/vector/edxapp_parsing.yaml.j2
@@ -7,7 +7,7 @@ transforms:
     source: |
       .application = "edxapp"
       # Drop all logs pertaining to ELB healthchecks
-      abort_match_healthcheck, err = (match_any(.message, [r'GET /heartbeat']))
+      abort_match_healthcheck = (match_any!(.message, [r'GET /heartbeat']))
       if abort_match_healthcheck {
         abort
       }

--- a/src/bilder/images/edxapp_v2/templates/vector/edxapp_tracking_logs.yaml.j2
+++ b/src/bilder/images/edxapp_v2/templates/vector/edxapp_tracking_logs.yaml.j2
@@ -4,7 +4,8 @@ sources:
     file_key: log_file
     type: file
     include:
-    - /opt/data/logs/tracking_logs.log
+    - /opt/data/cms/logs/tracking_logs.log*
+    - /opt/data/lms/logs/tracking_logs.log*
 
 transforms:
   # Maintaining a copy of the logs with nested objects for MIT IRx (TMM 2023-07-05)


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issue/6049

### Description (What does it do?)
<!--- Describe your changes in detail -->
Because there are both LMS and CMS containers running via docker compose, they end up competing for the ability to write to the on-disk location that Vector reads from. This splits their usage of the physical disk to be namespaced by the service type. This also updates the Vector config to watch _all_ of the tracking log files since some logs are being written to a `.1` location simultaneously with logs being written to the primary file.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Build an edxapp instance and deploy to CI to verify that:
- Vector is reading all of the tracking log files
- The tracking log files are being written to both the lms and cms variant directories
- The tracking logs are all making it to S3
