### PR TITLE
Show client's public IP in Keycloak

### DIFF
--- a/src/bilder/images/keycloak/deploy.py
+++ b/src/bilder/images/keycloak/deploy.py
@@ -112,7 +112,12 @@ traefik_static_config = traefik_static.TraefikStaticConfig(
                 )
             ),
         ),
-        "https": traefik_static.EntryPoints(address=":443"),
+        "https": traefik_static.EntryPoints(
+            address=":443",
+            forwardedHeaders=traefik_static.ForwardedHeaders(
+                trusted_i_ps=["172.16.0.0/16", "10.0.0.0/8"]
+            ),
+        ),
     },
 )
 traefik_config = TraefikConfig(static_configuration=traefik_static_config)

--- a/src/bilder/images/keycloak/files/docker-compose.yaml
+++ b/src/bilder/images/keycloak/files/docker-compose.yaml
@@ -31,6 +31,8 @@ services:
     - AWS_REGION=us-east-1
     labels:
     - "traefik.http.middlewares.keycloak-ratelimit.ratelimit.average=10"
+    - "traefik.http.services.keycloak.loadbalancer.passHostHeader=true"
+    - "traefik.http.middlewares.forward-headers.headers.customRequestHeaders.X-Forwarded-For=X-Forwarded-For"
     ports:
     - "80:80"
     - "443:443"


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
In the Keycloak UI, under sessions, we were only seeing the ALB's private IP under IP address instead of the client's public IP. This should fix that issue and I tested it on CI and was able to verify that it's working as expected.