### PR TITLE
adding syllabus urls  for syllabyus ai

### DIFF
--- a/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.Production.yaml
+++ b/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.Production.yaml
@@ -56,6 +56,7 @@ config:
     OPENSEARCH_INDEX: "mitlearn"
     OPENSEARCH_SHARD_COUNT: 3
     OPENSEARCH_URL: "https://search-opensearch-mitlearn-producti-qjtnw2dcoampmbtscs3wdfci6y.us-east-1.es.amazonaws.com"
+    AI_MIT_SYLLABUS_URL: "https://api.learn.mit.edu/api/v0/vector_content_files_search/"
     PGBOUNCER_DEFAULT_POOL_SIZE: 50
     PGBOUNER_MAX_CLIENT_CONN: 500
     PGBOUNER_MIN_POOL_SIZE: 20

--- a/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.QA.yaml
+++ b/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.QA.yaml
@@ -32,6 +32,7 @@ config:
     OCW_ITERATOR_CHUNK_SIZE: 300
     OIDC_ENDPOINT: "https://sso-qa.ol.mit.edu/realms/olapps"
     OPENSEARCH_INDEX: "mitlearn-rc"
+    AI_MIT_SYLLABUS_URL: "https://api.rc.learn.mit.edu/api/v0/vector_content_files_search/"
     OPENSEARCH_SHARD_COUNT: 2
     OPENSEARCH_URL: "https://search-opensearch-mitlearn-qa-254ozvoip3e2ywfx5lsch5w2uu.us-east-1.es.amazonaws.com"
     PGBOUNCER_DEFAULT_POOL_SIZE: 50


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/6552


### Description (What does it do?)
Adds the syllabus api urls for the chat ai

### How can this be tested?
Will need a deploy to fully test but I have tried this locally on MIT learn

