### PR TITLE
EKS Access overhaul

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/eks/KUBE_CONFIG_SETUP.md
+++ b/src/ol_infrastructure/infrastructure/aws/eks/KUBE_CONFIG_SETUP.md
@@ -11,7 +11,8 @@ Example Stack Output:
         certificate-authority-data: {
             data: "Base64 Encoded CA for the cluster"
         }
-        role_arn                  : "arn:aws:iam::610119931565:role/ol-infrastructure/eks/<cluster_name>/<unique admin role identifier>"
+        admin_role_arn                  : "arn:aws:iam::610119931565:role/ol-infrastructure/eks/<cluster_name>/<unique admin role identifier>"
+        developer_role_arn                  : "arn:aws:iam::610119931565:role/ol-infrastructure/eks/<cluster_name>/<unique admin role identifier>"
         server                    : "https://<unique Kube-API endpoint for the cluster>.gr7.us-east-1.eks.amazonaws.com"
 ```
 It is generally easiest to use the same file-local name for all three blocks and to use the name of the cluster as that name. To use the `operations-ci` environment as an example: the `context`, `cluster`, and `user` would all named `operations-ci`
@@ -44,7 +45,7 @@ It is generally easiest to use the same file-local name for all three blocks and
       - --cluster-name
       - operations-ci
       - --role
-      - "< kube_config_data.role_arn >"
+      - "< kube_config_data.admin_role_arn or kube_config_data.developer_role_arn >"
       command: aws
       env:
       - name: "KUBERNETES_EXEC_INFO"

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.applications.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.applications.CI.yaml
@@ -14,6 +14,8 @@ config:
     secure: v1:IuJlZQCcqboLDz6u:uileS7cOpmHmXYE0Xe+u7pSeJ0QlXNgxq04Zbc4toa010z8GVewuU0WWZsjxcHOI
   eks:apisix_domains:
   - "api-pay-ci.ol.mit.edu"
+  eks:developer_role_policy_name: "AmazonEKSAdminPolicy"
+  eks:developer_role_kubernetes_groups: ["admin"]
   eks:ebs_csi_provisioner: "true"
   eks:efs_csi_provisioner: "false"
   eks:gateway_release_channel: "experimental"

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.applications.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.applications.QA.yaml
@@ -14,6 +14,8 @@ config:
     secure: v1:T9I4WZSeg3lYawlD:d59YkDPqEo372v1ibNCtyYcGjxW0xXC2eXyTADHHZ4QeQ+gD8JuN3pCv78nNVQ/d
   eks:apisix_domains:
   - "api-pay-qa.ol.mit.edu"
+  eks:developer_role_policy_name: "AmazonEKSAdminPolicy"
+  eks:developer_role_kubernetes_groups: ["admin"]
   eks:ebs_csi_provisioner: "true"
   eks:efs_csi_provisioner: "false"
   eks:gateway_release_channel: "experimental"

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.data.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.data.CI.yaml
@@ -9,6 +9,8 @@ config:
   - "odl.mit.edu"
   - ".ol.mit.edu"
   - "ol.mit.edu"
+  eks:developer_role_policy_name: "AmazonEKSAdminPolicy"
+  eks:developer_role_kubernetes_groups: ["admin"]
   eks:ebs_csi_provisioner: true
   eks:efs_csi_provisioner: false
   eks:gateway_release_channel: "experimental"

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.data.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.data.QA.yaml
@@ -9,6 +9,8 @@ config:
   - "odl.mit.edu"
   - ".ol.mit.edu"
   - "ol.mit.edu"
+  eks:developer_role_policy_name: "AmazonEKSAdminPolicy"
+  eks:developer_role_kubernetes_groups: ["admin"]
   eks:ebs_csi_provisioner: true
   eks:efs_csi_provisioner: false
   eks:gateway_release_channel: "experimental"

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.operations.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.operations.CI.yaml
@@ -9,6 +9,8 @@ config:
   - "odl.mit.edu"
   - ".ol.mit.edu"
   - "ol.mit.edu"
+  eks:developer_role_policy_name: "AmazonEKSAdminPolicy"
+  eks:developer_role_kubernetes_groups: ["admin"]
   eks:ebs_csi_provisioner: true
   eks:efs_csi_provisioner: true
   eks:gateway_release_channel: "experimental"

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.operations.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.operations.QA.yaml
@@ -9,6 +9,8 @@ config:
   - "odl.mit.edu"
   - ".ol.mit.edu"
   - "ol.mit.edu"
+  eks:developer_role_policy_name: "AmazonEKSAdminPolicy"
+  eks:developer_role_kubernetes_groups: ["admin"]
   eks:ebs_csi_provisioner: true
   eks:efs_csi_provisioner: true
   eks:gateway_release_channel: "experimental"

--- a/src/ol_infrastructure/lib/aws/iam_helper.py
+++ b/src/ol_infrastructure/lib/aws/iam_helper.py
@@ -26,6 +26,13 @@ EKS_ADMIN_USERNAMES = [
     "tmacey",
 ]
 
+EKS_DEVELOPER_USERNAMES = [
+    "ambady",
+    "abeglova",
+    "jkachel",
+    "rlougee",
+]
+
 
 def _is_parliament_finding_filtered(
     finding: Finding, parliament_config: dict[str, Any]


### PR DESCRIPTION
### Description (What does it do?)
- Gives developers access to EKS clusters in a configurable manner. 
  - Defaults to read-only 
  - Overrides to namespace admins (but not cluster admins!) in CI and QA envs 
- Fixes the console view for the devops team
- Updates the `generate_kube_config.py` script to work for developers or devops with a config flag. 

Developers still won't be able to actually run this script because they can't access the pulumi state but it is a start and we should be able to run it for them and get it to them to use. It isn't something that should change very often. 

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
