### PR TITLE
Add Learn AI endpoints for GitHub Actions

### DIFF
--- a/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.Production.yaml
+++ b/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.Production.yaml
@@ -85,3 +85,6 @@ config:
   mitlearn:nextjs_heroku_domain: "mitopen-production-nextjs-6b0d663f9110.herokuapp.com"
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production
+  mitlearn:learn_ai_recommendation_endpoint: "https://api-learn-ai.ol.mit.edu/http/recommendation_agent/"
+  mitlearn:learn_ai_syllabus_endpoint: "https://api-learn-ai.ol.mit.edu/http/syllabus_agent/"
+

--- a/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.Production.yaml
+++ b/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.Production.yaml
@@ -87,4 +87,3 @@ config:
   vault_server:env_namespace: operations.production
   mitlearn:learn_ai_recommendation_endpoint: "https://api-learn-ai.ol.mit.edu/http/recommendation_agent/"
   mitlearn:learn_ai_syllabus_endpoint: "https://api-learn-ai.ol.mit.edu/http/syllabus_agent/"
-

--- a/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.QA.yaml
+++ b/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.QA.yaml
@@ -81,3 +81,5 @@ config:
   mitlearn:heroku_domain: "shrouded-brook-krg88s8bvcdg6kgrdjrsrmbq.herokudns.com"
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa
+  mitlearn:learn_ai_recommendation_endpoint: "https://api-learn-ai-qa.ol.mit.edu/http/recommendation_agent/"
+  mitlearn:learn_ai_syllabus_endpoint: "https://api-learn-ai-qa.ol.mit.edu/http/syllabus_agent/"

--- a/src/ol_infrastructure/applications/mitlearn/__main__.py
+++ b/src/ol_infrastructure/applications/mitlearn/__main__.py
@@ -1139,6 +1139,20 @@ gh_workflow_sentry_profiles_sample_rate = github.ActionsSecret(
     plaintext_value=heroku_vars["SENTRY_PROFILES_SAMPLE_RATE"],
     opts=ResourceOptions(provider=github_provider, delete_before_replace=True),
 )
+gh_workflow_learn_ai_recommendation_endpoint_env_secret = github.ActionsSecret(
+    f"ol_mitopen_gh_workflow_learn_ai_recommendation_endpoint-{stack_info.env_suffix}",
+    repository=gh_repo.name,
+    secret_name=f"LEARN_AI_RECOMMENDATION_ENDPOINT_{env_var_suffix}",
+    plaintext_value=f"{mitlearn_config.get('learn_ai_recommendation_endpoint')}",
+    opts=ResourceOptions(provider=github_provider, delete_before_replace=True),
+)
+gh_workflow_learn_ai_syllabus_endpoint_env_secret = github.ActionsSecret(
+    f"ol_mitopen_gh_workflow_learn_ai_syllabus_endpoint-{stack_info.env_suffix}",
+    repository=gh_repo.name,
+    secret_name=f"LEARN_AI_SYLLABUS_ENDPOINT_{env_var_suffix}",
+    plaintext_value=f"{mitlearn_config.get('learn_ai_syllabus_endpoint')}",
+    opts=ResourceOptions(provider=github_provider, delete_before_replace=True),
+)
 
 
 export(


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

https://github.com/mitodl/hq/issues/6735

### Description (What does it do?)
<!--- Describe your changes in detail -->

Sets the following in plain text config for the Learn project GitHub Actions workflows:

```env
LEARN_AI_RECOMMENDATION_ENDPOINT_RC=https://api-learn-ai-qa.ol.mit.edu/http/recommendation_agent/
LEARN_AI_SYLLABUS_ENDPOINT_RC=https://api-learn-ai-qa.ol.mit.edu/http/syllabus_agent/
LEARN_AI_RECOMMENDATION_ENDPOINT_PROD=https://api-learn-ai.ol.mit.edu/http/recommendation_agent/
LEARN_AI_SYLLABUS_ENDPOINT_PROD=https://api-learn-ai.ol.mit.edu/http/syllabus_agent/
```
