### PR TITLE
chore: Configure Renovate to maintain versions in versions.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,3 +172,4 @@ inline-quotes = "double"
 "test_*.py" = ["S101"]
 "src/ol_infrastructure/substructure/vault/pki/__main__.py" = ["E501"]
 "src/ol_infrastructure/lib/fastly.py" = ["E501"]
+"src/bridge/lib/versions.py" = ["E501"]

--- a/renovate.json
+++ b/renovate.json
@@ -13,5 +13,16 @@
   ],
   "pip_requirements": {
     "fileMatch": "dockerfiles/openedx-edxapp/pip_package_lists/.*?/.*.txt"
-  }
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "src/bridge/lib/versions.py"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?) packageName=(?<packageName>.*)\s+.*?\s*=\s*\"v?(?<currentVersion>.*?)\""
+      ]
+    }
+  ]
 }

--- a/src/bridge/lib/versions.py
+++ b/src/bridge/lib/versions.py
@@ -1,26 +1,37 @@
-AIRBYTE_VERSION = "1.3.0"
-APISIX_CLOUD_CLI_VERSION = "0.30.2"
-APISIX_VERSION = "2.15.3"
+# renovate: datasource=github-releases depName=concourse packageName=concourse/concourse
 CONCOURSE_VERSION = "7.8.3"
+# renovate: datasource=github-releases depName=consul-template packageName=hashicorp/consul-template
 CONSUL_TEMPLATE_VERSION = "0.29.5"
+# renovate: datasource=github-releases depName=consul packageName=hashicorp/consul
 CONSUL_VERSION = "1.14.0"
-DAGSTER_VERSION = "1.0.17"
+# renovate: datasource=github-releases depName=keycloak packageName=keycloak/keycloak
 KEYCLOAK_VERSION = "26.1"
+# renovate: datasource=helm depName=open-metadata packageName=open-metadata/openmetadata
 OPEN_METADATA_VERSION = "1.6.3"
 OVS_VERSION = "v0.65.1-3-g2630021"
 REDASH_VERSION = "9d273e4"
+# renovate: datasource=github-releases depName=traefik packageName=traefik/traefik
 TRAEFIK_VERSION = "2.10.3"
 TUTOR_PERMISSIONS_VERSION = "15.3.4"
+# renovate: datasource=github-releases depName=vault packageName=hashicorp/vault
 VAULT_VERSION = "1.12.1"
 
 # EKS Specific Versions
+# renovate: datasource=helm depName=airbyte packageName=airbyte/airbyte
 AIRBYTE_CHART_VERSION = "1.3.0"
+# renovate: datasource=helm depName=apisix packageName=apisix/apisix
 APISIX_CHART_VERSION = "2.10.0"
+# renovate: datasource=helm depName=cert-manager packageName=cert-manager/cert-manager
 CERT_MANAGER_CHART_VERSION = "v1.16.1"
 EBS_CSI_DRIVER_VERSION = "v1.36.0-eksbuild.1"
 EFS_CSI_DRIVER_VERSION = "v2.0.8-eksbuild.1"
+# renovate: datasource=helm depName=external-dns packageName=external-dns/external-dns
 EXTERNAL_DNS_CHART_VERSION = "1.15.0"
+# renovate: datasource=github-releases depName=gateway-api packageName=kubernetes-sigs/gateway-api
 GATEWAY_API_VERSION = "v1.2.1"
+# renovate: datasource=helm depName=traefik packageName=traefik/traefik
 TRAEFIK_CHART_VERSION = "v34.2.0"
+# renovate: datasource=helm depName=vantage-kubernetes-agent packageName=vantage-kubernetes-agent/vantage-kubernetes-agent
 VANTAGE_K8S_AGENT_CHART_VERSION = "1.0.36"
+# renovate: datasource=helm depName=vault-secrets-operator packageName=vault-secrets-operator/vault-secrets-operator
 VAULT_SECRETS_OPERATOR_CHART_VERSION = "0.9.0"


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Allows Renovate to manage versions of dependencies that are used multiple places in Pulumi code and are otherwise unmanaged via package managers.

### How can this be tested?
Unfortunately this likely requires merging to see if Renovate picks up the changes to verify that it works properly.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
The versions.py file is a useful source of truth for what versions are running. Unfortunately it frequently falls out of date as we pull versions dynamically into the build pipelines. This adds information to the versions.py file that Renovate can use to keep that file up to date as upstream versions change. https://docs.renovatebot.com/modules/manager/regex/
