### PR TITLE
feat: add ol_openedx_chat configs

### DIFF
--- a/dockerfiles/openedx-edxapp/pip_package_lists/master/mitxonline.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/master/mitxonline.txt
@@ -16,6 +16,4 @@ uwsgi==2.0.28
 wheel==0.45.1
 
 # Experimental Plugins for AI features
-ai-coach-xblock
-learning-assistant
-ai-aside
+ol-openedx-chat

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -382,7 +382,7 @@ INTEGRATED_CHANNELS_API_CHUNK_TRANSMISSION_LIMIT:
 JWT_EXPIRATION: 30
 LANGUAGE_CODE: en
 LANGUAGE_COOKIE: {{ env "ENVIRONMENT" }}-openedx-language-preference
-LEARN_AI_API_URL: {{ key "edxapp/learn-ai-domain" }}  # Added for ol_openedx_chat
+LEARN_AI_API_URL: https://{{ key "edxapp/learn-ai-api-domain" }}/http/recommendation_agent/  # Added for ol_openedx_chat
 LEARNER_PORTAL_URL_ROOT: https://learner-portal-localhost:18000
 LEARNER_HOME_MICROFRONTEND_URL: '/dashboard/'
 LEARNING_MICROFRONTEND_URL: https://{{ key "edxapp/lms-domain" }}/learn

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -382,6 +382,7 @@ INTEGRATED_CHANNELS_API_CHUNK_TRANSMISSION_LIMIT:
 JWT_EXPIRATION: 30
 LANGUAGE_CODE: en
 LANGUAGE_COOKIE: {{ env "ENVIRONMENT" }}-openedx-language-preference
+LEARN_AI_API_URL: {{ key "edxapp/learn-ai-domain" }}  # Added for ol_openedx_chat
 LEARNER_PORTAL_URL_ROOT: https://learner-portal-localhost:18000
 LEARNER_HOME_MICROFRONTEND_URL: '/dashboard/'
 LEARNING_MICROFRONTEND_URL: https://{{ key "edxapp/lms-domain" }}/learn
@@ -457,6 +458,7 @@ NOTIFICATIONS_DEFAULT_FROM_EMAIL: {{ key "edxapp/bulk-email-default-from-email" 
 NOTIFICATION_TYPE_ICONS: {} # ADDED
 DEFAULT_NOTIFICATION_ICON_URL: '' # ADDED
 ORA2_FILE_PREFIX: mitxonline/ora2  # MODIFIED
+OL_CHAT_SETTINGS: {}  # Added for ol_openedx_chat
 PARTNER_SUPPORT_EMAIL: ''
 PASSWORD_POLICY_COMPLIANCE_ROLLOUT_CONFIG:
     ENFORCE_COMPLIANCE_ON_LOGIN: false

--- a/src/bridge/settings/openedx/mfe/slot_config/mitx/learning.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/mitx/learning.env.jsx
@@ -1,6 +1,9 @@
 import { PLUGIN_OPERATIONS } from '@openedx/frontend-plugin-framework';
 import { getConfig } from '@edx/frontend-platform';
 
+import * as remoteAiChatDrawer from "./mitodl-smoot-design/dist/bundles/remoteAiChatDrawer.umd.js"
+
+
 const modifyUserMenu = (widget) => {
   widget.content.items = [
     {
@@ -14,6 +17,13 @@ const modifyUserMenu = (widget) => {
   ];
   return widget;
 };
+
+if (getConfig().APP_ID === 'learning') {
+  remoteAiChatDrawer.init({
+    messageOrigin: getConfig().LMS_BASE_URL,
+    transformBody: messages => ({ message: messages[messages.length - 1].content }),
+  })
+}
 
 const config = {
   pluginSlots: {

--- a/src/bridge/settings/openedx/mfe/slot_config/mitxonline/learning-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/mitxonline/learning-mfe-config.env.jsx
@@ -1,11 +1,22 @@
 import { PLUGIN_OPERATIONS } from '@openedx/frontend-plugin-framework';
 import { getConfig } from '@edx/frontend-platform';
 
+import * as remoteAiChatDrawer from "./mitodl-smoot-design/dist/bundles/remoteAiChatDrawer.umd.js"
+
+
 const modifyUserMenu = (widget) => {
   widget.content.items = [
     {
       href: `${getConfig().LMS_BASE_URL}/dashboard`,
       message: 'Dashboard',
+    },
+    {
+      href: `${getConfig().MARKETING_SITE_BASE_URL}/profile/`,
+      message: 'Profile',
+    },
+    {
+      href: `${getConfig().MARKETING_SITE_BASE_URL}/account-settings/`,
+      message: 'Settings',
     },
     {
       href: `${getConfig().LMS_BASE_URL}/logout`,
@@ -14,6 +25,12 @@ const modifyUserMenu = (widget) => {
   ];
   return widget;
 };
+
+remoteAiChatDrawer.init({
+  messageOrigin: getConfig().LMS_BASE_URL,
+  transformBody: messages => ({ message: messages[messages.length - 1].content }),
+})
+
 
 const config = {
   pluginSlots: {

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -154,7 +154,7 @@ def mfe_job(
         )
     )
 
-    if OpenEdxMicroFrontend[mfe_name].value == OpenEdxMicroFrontend.learn.value:
+    if open_edx_deployment.deployment_name == "mitxonline" and OpenEdxMicroFrontend[mfe_name].value == OpenEdxMicroFrontend.learn.value:
         mfe_smoot_design_overrides = """
         npm pack @mitodl/smoot-design^3.4
         tar -xvzf mitodl-smoot-design*.tgz

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -154,6 +154,12 @@ def mfe_job(
         )
     )
 
+    mfe_smoot_design_overrides = """
+    npm pack @mitodl/smoot-design
+    tar -xvzf mitodl-smoot-design*.tgz
+    mv package mitodl-smoot-design
+    """ if OpenEdxMicroFrontend[mfe_name].value == OpenEdxMicroFrontend.learn.value else ""
+
     translation_overrides = "\n".join(cmd for cmd in mfe.translation_overrides or [])
     if previous_job and mfe_repo.name == previous_job.plan[0].get:
         clone_mfe_repo.passed = [previous_job.name]
@@ -236,6 +242,7 @@ def mfe_job(
                                 npm install -g @edx/openedx-atlas
                                 {branding_overrides}
                                 {translation_overrides}
+                                {mfe_smoot_design_overrides}
                                 npm install webpack
                                 NODE_ENV=production npm run build
                                 """  # noqa: E501

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -154,7 +154,10 @@ def mfe_job(
         )
     )
 
-    if open_edx_deployment.deployment_name == "mitxonline" and OpenEdxMicroFrontend[mfe_name].value == OpenEdxMicroFrontend.learn.value:
+    if (
+        open_edx_deployment.deployment_name == "mitxonline"
+        and OpenEdxMicroFrontend[mfe_name].value == OpenEdxMicroFrontend.learn.value
+    ):
         mfe_smoot_design_overrides = """
         npm pack @mitodl/smoot-design^3.4
         tar -xvzf mitodl-smoot-design*.tgz

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -154,11 +154,15 @@ def mfe_job(
         )
     )
 
-    mfe_smoot_design_overrides = """
+    mfe_smoot_design_overrides = (
+        """
     npm pack @mitodl/smoot-design
     tar -xvzf mitodl-smoot-design*.tgz
     mv package mitodl-smoot-design
-    """ if OpenEdxMicroFrontend[mfe_name].value == OpenEdxMicroFrontend.learn.value else ""
+    """
+        if OpenEdxMicroFrontend[mfe_name].value == OpenEdxMicroFrontend.learn.value
+        else ""
+    )
 
     translation_overrides = "\n".join(cmd for cmd in mfe.translation_overrides or [])
     if previous_job and mfe_repo.name == previous_job.plan[0].get:

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -154,15 +154,16 @@ def mfe_job(
         )
     )
 
-    mfe_smoot_design_overrides = (
+    if OpenEdxMicroFrontend[mfe_name].value == OpenEdxMicroFrontend.learn.value:
+        mfe_smoot_design_overrides = """
+        npm pack @mitodl/smoot-design^3.4
+        tar -xvzf mitodl-smoot-design*.tgz
+        mv package mitodl-smoot-design
         """
-    npm pack @mitodl/smoot-design
-    tar -xvzf mitodl-smoot-design*.tgz
-    mv package mitodl-smoot-design
-    """
-        if OpenEdxMicroFrontend[mfe_name].value == OpenEdxMicroFrontend.learn.value
-        else ""
-    )
+        learning_mfe_slot_config_file = "learning-mfe-config"
+    else:
+        mfe_smoot_design_overrides = ""
+        learning_mfe_slot_config_file = "learning"
 
     translation_overrides = "\n".join(cmd for cmd in mfe.translation_overrides or [])
     if previous_job and mfe_repo.name == previous_job.plan[0].get:
@@ -173,7 +174,7 @@ def mfe_job(
     mfe_setup_plan = [clone_mfe_repo]
 
     mfe_plugin_type_map = {
-        "learning": "learning",
+        "learning": learning_mfe_slot_config_file,
         "discussions": "learning",
         "ora-grading": "learning",
         "communications": "learning",

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -159,7 +159,7 @@ def mfe_job(
         and OpenEdxMicroFrontend[mfe_name].value == OpenEdxMicroFrontend.learn.value
     ):
         mfe_smoot_design_overrides = """
-        npm pack @mitodl/smoot-design^3.4
+        npm pack @mitodl/smoot-design@^3.4.0
         tar -xvzf mitodl-smoot-design*.tgz
         mv package mitodl-smoot-design
         """

--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.Production.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.Production.yaml
@@ -25,3 +25,8 @@ config:
     secure: v1:txrMWRvWLuyLZ9jG:RANFRu7iGA96qnc47SdQjrwTOS5Lz96n4Vdt6CK9vyb6FreKon4+qyLlk7P+dBS+T0lN7H6bvC1F38zIOA==
   vault:address: "https://vault-production.odl.mit.edu"
   vault_server:env_namespace: "operations.production"
+  # This is a hack. We need to write a Consul key for use by MITx Online and the apps
+  # and MITx Online VPCs aren't peered, so the Consul clusters aren't peered. We don't
+  # actually use Consul for anything else in this project so this is okay (so far) (TMM
+  # 2025-02-21)
+  consul:address: https://consul-mitxonline-production.odl.mit.edu

--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.QA.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.QA.yaml
@@ -25,3 +25,8 @@ config:
     secure: v1:j1q4KgePVUsaaySb:EhUqxWBezBKe6Ck1o/gqlX68GBnrZZQdmUCscl5aPok1j6jJWKSRO89XfV+6dWJaCMhqHA==
   vault:address: "https://vault-qa.odl.mit.edu"
   vault_server:env_namespace: "operations.qa"
+  # This is a hack. We need to write a Consul key for use by MITx Online and the apps
+  # and MITx Online VPCs aren't peered, so the Consul clusters aren't peered. We don't
+  # actually use Consul for anything else in this project so this is okay (so far) (TMM
+  # 2025-02-21)
+  consul:address: https://consul-mitxonline-qa.odl.mit.edu


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
A bit of https://github.com/mitodl/ol-infrastructure/issues/2981 + None

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds the required configs for ol_openedx_chat, it includes:

-  Settings `LEARN_AI_API_URL` and `OL_CHAT_SETTINGS`.
- Modifies the learning.env.jsx for MITx Online to initiate the chat drawer. 
- Adds build steps to add the smoot-design bundle in the learning MFE.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Can be tested on QA?