### PR TITLE
Use a different suffix for logout url when apisix is enabled on mit-learn

### DIFF
--- a/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.Production.yaml
+++ b/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.Production.yaml
@@ -40,6 +40,7 @@ config:
     INDEXING_API_USERNAME: "od_mm_prod_api"
     KEYCLOAK_BASE_URL: "https://sso.ol.mit.edu"
     KEYCLOAK_REALM_NAME: "olapps"
+    MITOL_API_LOGOUT_SUFFIX: "logout"
     MITOL_API_URL: "https://api.learn.mit.edu"
     MITOL_APP_URL: "https://learn.mit.edu"
     MITOL_APP_BASE_URL: "https://learn.mit.edu"

--- a/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.QA.yaml
+++ b/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.QA.yaml
@@ -18,6 +18,7 @@ config:
     INDEXING_API_USERNAME: "od_mm_rc_api"
     KEYCLOAK_BASE_URL: "https://sso-qa.ol.mit.edu"
     KEYCLOAK_REALM_NAME: "olapps"
+    MITOL_API_LOGOUT_SUFFIX: "logout"
     MITOL_API_URL: "https://api.rc.learn.mit.edu"
     MITOL_APP_URL: "https://rc.learn.mit.edu"
     MITOL_APP_BASE_URL: "https://rc.learn.mit.edu"

--- a/src/ol_infrastructure/applications/mitlearn/__main__.py
+++ b/src/ol_infrastructure/applications/mitlearn/__main__.py
@@ -823,6 +823,7 @@ heroku_vars = {
     "MICROMASTERS_CATALOG_API_URL": "https://micromasters.mit.edu/api/v0/catalog/",
     "MICROMASTERS_CMS_API_URL": "https://micromasters.mit.edu/api/v0/wagtail/",
     "MITOL_ADMIN_EMAIL": "cuddle-bunnies@mit.edu",
+    "MITOL_API_LOGOUT_SUFFIX": "logout/oidc",
     "MITOL_AXIOS_BASE_PATH": f"https://{mitlearn_config.get('frontend_domain')}",
     "MITOL_DB_CONN_MAX_AGE": 0,
     "MITOL_DB_DISABLE_SSL": "True",

--- a/src/ol_infrastructure/applications/mitlearn/__main__.py
+++ b/src/ol_infrastructure/applications/mitlearn/__main__.py
@@ -823,7 +823,6 @@ heroku_vars = {
     "MICROMASTERS_CATALOG_API_URL": "https://micromasters.mit.edu/api/v0/catalog/",
     "MICROMASTERS_CMS_API_URL": "https://micromasters.mit.edu/api/v0/wagtail/",
     "MITOL_ADMIN_EMAIL": "cuddle-bunnies@mit.edu",
-    "MITOL_API_LOGOUT_SUFFIX": "logout/oidc",
     "MITOL_AXIOS_BASE_PATH": f"https://{mitlearn_config.get('frontend_domain')}",
     "MITOL_DB_CONN_MAX_AGE": 0,
     "MITOL_DB_DISABLE_SSL": "True",

--- a/src/ol_infrastructure/applications/mitlearn/__main__.py
+++ b/src/ol_infrastructure/applications/mitlearn/__main__.py
@@ -1160,7 +1160,13 @@ gh_workflow_learn_ai_syllabus_endpoint_env_secret = github.ActionsSecret(
     plaintext_value=f"{mitlearn_config.get('learn_ai_syllabus_endpoint')}",
     opts=ResourceOptions(provider=github_provider, delete_before_replace=True),
 )
-
+gh_workflow_learn_ai_syllabus_endpoint_env_secret = github.ActionsSecret(
+    f"ol_mitopen_gh_workflow_mitol_api_logout_suffix-{stack_info.env_suffix}",
+    repository=gh_repo.name,
+    secret_name=f"MITOL_API_LOGOUT_SUFFIX_{env_var_suffix}",
+    plaintext_value=f"{heroku_vars['MITOL_API_LOGOUT_SUFFIX']}",
+    opts=ResourceOptions(provider=github_provider, delete_before_replace=True),
+)
 
 export(
     "mitopen",


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/mit-learn/pull/2061

### Description (What does it do?)
Adds ` MITOL_API_LOGOUT_SUFFIX: "logout/oidc"` so the frontend will send the user there (apisix) first to log out, which should then redirect the user back to the url specified by `APISIX_LOGOUT_URL`.

Assumption is that APISIX will be configured with the [same login/logout urls as defined in this file](https://github.com/mitodl/mit-learn/blob/3bb5d4ffe8dfea45eb80678158b7049f5997356b/config/apisix/apisix.yaml) - is that correct, @blarghmatey ?

### How can this be tested?
N/A
