### PR TITLE
Add APISix gateway to MIT Learn

### DIFF
--- a/src/ol_infrastructure/applications/mitlearn/__main__.py
+++ b/src/ol_infrastructure/applications/mitlearn/__main__.py
@@ -954,28 +954,6 @@ learn_external_service_apisix_pluginconfig = kubernetes.apiextensions.CustomReso
 learn_external_service_name = "learn-at-heroku"
 learn_external_service_port_name = "https"
 
-learn_external_service = kubernetes.core.v1.Service(
-    f"ol-mitlearn-external-service-{stack_info.env_suffix}",
-    metadata=kubernetes.meta.v1.ObjectMetaArgs(
-        name=learn_external_service_name,
-        namespace=learn_namespace,
-        labels=application_labels,
-    ),
-    spec=kubernetes.core.v1.ServiceSpecArgs(
-        external_name=mitlearn_config.require("heroku_domain"),
-        ports=[
-            kubernetes.core.v1.ServicePortArgs(
-                name=learn_external_service_port_name,
-                port=DEFAULT_HTTPS_PORT,
-                target_port=DEFAULT_HTTPS_PORT,
-                protocol="TCP",
-            ),
-        ],
-        type="ExternalName",  # Special!
-    ),
-    opts=ResourceOptions(delete_before_replace=True),
-)
-
 learn_external_service_apisix_upstream = kubernetes.apiextensions.CustomResource(
     f"ol-mitlearn-external-service-apisix-upstream-{stack_info.env_suffix}",
     api_version="apisix.apache.org/v2",
@@ -994,9 +972,7 @@ learn_external_service_apisix_upstream = kubernetes.apiextensions.CustomResource
             },
         ],
     },
-    opts=ResourceOptions(
-        delete_before_replace=True, depends_on=[learn_external_service]
-    ),
+    opts=ResourceOptions(delete_before_replace=True),
 )
 
 
@@ -1098,7 +1074,6 @@ learn_external_service_apisix_route = kubernetes.apiextensions.CustomResource(
     opts=ResourceOptions(
         delete_before_replace=True,
         depends_on=[
-            learn_external_service,
             learn_external_service_apisix_upstream,
             learn_external_service_apisix_pluginconfig,
         ],

--- a/src/ol_infrastructure/applications/mitlearn/mitlearn_policy.hcl
+++ b/src/ol_infrastructure/applications/mitlearn/mitlearn_policy.hcl
@@ -1,0 +1,33 @@
+path "postgres-mitopen/creds/app/*" {
+  capabilities = ["read"]
+}
+path "postgres-mitopen/creds/app" {
+  capabilities = ["read"]
+}
+
+path "secret-operations/sso/mitlearn/*" {
+  capabilities = ["read"]
+}
+path "secret-operations/sso/mitlearn" {
+  capabilities = ["read"]
+}
+
+path "secret-mitopen/*" {
+  capabilities = ["read"]
+}
+# vault-secrets-operator is a little more particular about
+# managing its own leases, give it the permissions it needs
+# for dynamic secret renwals / revocation without giving
+# it the power to revoke or renew anything
+path "sys/leases/renew" {
+  capabilities = ["update"]
+  allowed_parameters = {
+    lease_id = ["postgres-mitopen/creds/app/*"]
+  }
+}
+path "sys/leases/revoke" {
+  capabilities = ["update"]
+  allowed_parameters = {
+    lease_id = ["postgres-mitopen/creds/app/*"]
+  }
+}

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.applications.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.applications.Production.yaml
@@ -7,6 +7,8 @@ config:
   - "odl.mit.edu"
   - ".ol.mit.edu"
   - "ol.mit.edu"
+  - "learn.mit.edu"
+  - ".learn.mit.edu"
   eks:apisix_admin_key:
     secure: v1:PafPE9cAPNoOSOrU:8V16zZH9OGc1jgfZffXRDLvb6ROksZLULaYJvdjHgPCG/zmB/8nA8EMZb8X2/O74
   eks:apisix_ingress_enabled: "true"
@@ -15,6 +17,7 @@ config:
   eks:apisix_domains:
   - "api-pay.ol.mit.edu"
   - "api-learn-ai.ol.mit.edu"
+  - "api.learn.mit.edu"
   eks:ebs_csi_provisioner: "true"
   eks:efs_csi_provisioner: "false"
   eks:gateway_release_channel: "experimental"

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.applications.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.applications.QA.yaml
@@ -7,6 +7,8 @@ config:
   - "odl.mit.edu"
   - ".ol.mit.edu"
   - "ol.mit.edu"
+  - "learn.mit.edu"
+  - ".learn.mit.edu"
   eks:apisix_admin_key:
     secure: v1:AndQEZrEKm/Q3QyP:60BdyhdeUbx2ds+YdP3vN5+Q0nIA0AyqLjtUo0XSj0f4vQQc6f5PsLJOKwZj1/4T
   eks:apisix_ingress_enabled: "true"
@@ -15,6 +17,7 @@ config:
   eks:apisix_domains:
   - "api-pay-qa.ol.mit.edu"
   - "api-learn-ai-qa.ol.mit.edu"
+  - "api.rc.learn.mit.edu"
   eks:developer_role_policy_name: "AmazonEKSAdminPolicy"
   eks:developer_role_kubernetes_groups: ["admin"]
   eks:ebs_csi_provisioner: "true"


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds APISix configuration and routing that will proxy to the MIT Learn application running in Heroku.


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Deploy it to RC
