### PR TITLE
apisix stability changes.

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.data.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.data.CI.yaml
@@ -2,33 +2,40 @@
 secretsprovider: awskms://alias/infrastructure-secrets-ci
 encryptedkey: AQICAHjnbqe9AmEW1Js10nySybyuAG7Fb5E9EHUgkmqFDv7PxQG7tVQ4cjSd4ZUD7SwqIPuWAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMbK4AIug73P0kVCSmAgEQgDtcf7tVi8RwSaTQ8SSy0Qob2DeSZdWru1j4Pjo4Bo88wQQLgZEWWRAPA9+6hc6IeT6agzB+rn0CeyvXhQ==
 config:
-  environment:business_unit: data
-  environment:target_vpc: data_vpc
   eks:allowed_dns_zones:
   - ".odl.mit.edu"
   - "odl.mit.edu"
   - ".ol.mit.edu"
   - "ol.mit.edu"
-  eks:developer_role_policy_name: "AmazonEKSAdminPolicy"
+  eks:apisix_admin_key:
+    secure: v1:alhS5zTWGpzPC3t3:QxvqqeD7zQ0zWxyKnnGWVRsmQwVx35NmdIaza5rI5re8+frp5OzpQZJR++4cfgzd13VBeNdOB1PM9Q3Z8hUaqGbjAhtclG6HSOg7z7tf3Ak=
+  eks:apisix_domains:
+  - "airbyte-ci-testing.ol.mit.edu"
+  eks:apisix_ingress_enabled: "true"
+  eks:apisix_viewer_key:
+    secure: v1:ZFN4gG/xa7D+1wDe:qwerlKPydX7u54UjHLBvNUCT2Oha5e4EgXs5Uf+8tMOMUtf4yz/5SYy4rfpfls1HDMgroXWwRUY9U21sgKsGF+YJ5lexA+Fo9VSStrw9zPc=
   eks:developer_role_kubernetes_groups: ["admin"]
-  eks:ebs_csi_provisioner: true
-  eks:efs_csi_provisioner: false
+  eks:developer_role_policy_name: "AmazonEKSAdminPolicy"
+  eks:ebs_csi_provisioner: "true"
+  eks:efs_csi_provisioner: "false"
   eks:gateway_release_channel: "experimental"
   eks:namespaces:
-  - "open-metadata"  # Openmetadata testing
+  - "open-metadata"
   - "airbyte"
   eks:nodegroups:
     worker-xlarge:
+      disk_size_gb: 500
       instance_type: "c7a.xlarge"
       labels:
-        ondemand: true
         node_size: c7a.xlarge
-      disk_size_gb: 500
+        ondemand: true
+      node_group_options: {}
       scaling:
         desired: 4
-        min: 2
         max: 5
-      version:
+        min: 2
       tags: {}
       taints: {}
-      node_group_options: {}
+      version:
+  environment:business_unit: data
+  environment:target_vpc: data_vpc

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.data.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.data.Production.yaml
@@ -2,31 +2,36 @@
 secretsprovider: awskms://alias/infrastructure-secrets-production
 encryptedkey: AQICAHjmo6C0sCNz3fdkFlhbu0tdBZxnHmPYSnqtmocvGiuNygGvhXhSXiQ1XmPuxswm2OtcAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMTuh7nmhVuOpDSvyZAgEQgDuh3GDgOQHD2wbrhWUWE2wIUfXQxWNm83tq0ambQmpQqnAr9hajUcnokJAsLf0H8AKhFvUp8SAMbLaHtA==
 config:
-  environment:business_unit: data
-  environment:target_vpc: data_vpc
   eks:allowed_dns_zones:
   - ".odl.mit.edu"
   - "odl.mit.edu"
   - ".ol.mit.edu"
   - "ol.mit.edu"
-  eks:ebs_csi_provisioner: true
-  eks:efs_csi_provisioner: false
+  eks:apisix_admin_key:
+    secure: v1:+4IwDMDzHiVsfnbo:vr+qOCr5SVJhBDoy0N8JL0Mw+1nrcOWNktlN5AKPCCLtAVIJfFWo8m/UJcje8esGgzIql50D/Wj7n8AX3K9zVzh1A6IAws/iZ2GW7B5D0Rw=
+  eks:apisix_ingress_enabled: "true"
+  eks:apisix_viewer_key:
+    secure: v1:j5+aTOfRBG8QiV+V:C6NTWitDBjV4DkOQGApae7GHK9w1wOFAlS7ACNu/s728A5q1zDWv9E13E2hs0IlAtMnP17KJR0HZjxDlg5fckv2nguEVgNA/d90j1XWlFY8=
+  eks:ebs_csi_provisioner: "true"
+  eks:efs_csi_provisioner: "false"
   eks:gateway_release_channel: "experimental"
   eks:namespaces:
-  - "open-metadata"  # Openmetadata testing
+  - "open-metadata"   # Openmetadata testing
   - "airbyte"
   eks:nodegroups:
     worker-xlarge:
+      disk_size_gb: 500
       instance_type: "m7a.4xlarge"
       labels:
-        ondemand: true
         node_size: m7a.4xlarge
-      disk_size_gb: 500
+        ondemand: true
+      node_group_options: {}
       scaling:
         desired: 4
-        min: 2
         max: 8
-      version:
+        min: 2
       tags: {}
       taints: {}
-      node_group_options: {}
+      version:
+  environment:business_unit: data
+  environment:target_vpc: data_vpc

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.data.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.data.QA.yaml
@@ -2,33 +2,38 @@
 secretsprovider: awskms://alias/infrastructure-secrets-qa
 encryptedkey: AQICAHgQW+3bag/cl2fPG3dPdqAPbfcsZuwI7rETXZsx85HRpgFHpqW8dqPwpO+48iRjSPKlAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMT8+E8dJESaABQvpwAgEQgDuViDwWFIt7k1e04QwP3dBW2YCjvz7RUJdyesx59jYHfjXxmnDGziscc9wq1kN3UPp1+uaZf5qBfmA/oQ==
 config:
-  environment:business_unit: data
-  environment:target_vpc: data_vpc
   eks:allowed_dns_zones:
   - ".odl.mit.edu"
   - "odl.mit.edu"
   - ".ol.mit.edu"
   - "ol.mit.edu"
-  eks:developer_role_policy_name: "AmazonEKSAdminPolicy"
+  eks:apisix_admin_key:
+    secure: v1:7MeUlqKSTbqRovyg:d+PtadLdy5md0WQvYWbW3rBF5WHO4mvN69eXpegY72UNos0qGAoWBT/o6eSGxKsjZDllxfFpFEUvKUuOTpjQDl14cDW9khKyaTQFrpJq3WI=
+  eks:apisix_ingress_enabled: "true"
+  eks:apisix_viewer_key:
+    secure: v1:FXn/5LA92VaA0LDu:+M5NNNgprjafZJTssawGZoRrI9ZEoiGKbRa3oVh4YjtZO4B5MLwXgfRvfWyY1zSbT0LJxxMJT90KQtWN3MsWobIseTYXLrdnPcpcYXY9lmg=
   eks:developer_role_kubernetes_groups: ["admin"]
-  eks:ebs_csi_provisioner: true
-  eks:efs_csi_provisioner: false
+  eks:developer_role_policy_name: "AmazonEKSAdminPolicy"
+  eks:ebs_csi_provisioner: "true"
+  eks:efs_csi_provisioner: "false"
   eks:gateway_release_channel: "experimental"
   eks:namespaces:
-  - "open-metadata"  # Openmetadata testing
+  - "open-metadata"   # Openmetadata testing
   - "airbyte"
   eks:nodegroups:
     worker-xlarge:
+      disk_size_gb: 500
       instance_type: "m7a.4xlarge"
       labels:
-        ondemand: true
         node_size: m7a.4xlarge
-      disk_size_gb: 500
+        ondemand: true
+      node_group_options: {}
       scaling:
         desired: 3
-        min: 2
         max: 5
-      version:
+        min: 2
       tags: {}
       taints: {}
-      node_group_options: {}
+      version:
+  environment:business_unit: data
+  environment:target_vpc: data_vpc

--- a/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
@@ -1040,13 +1040,23 @@ if eks_config.get_bool("apisix_ingress_enabled"):
                     },
                 },
                 "apisix": {
+                    "deployment": {
+                        "mode": "traditional",
+                        "role": "traditional",
+                    },
                     "ssl": {
                         "enabled": True,
                     },
                     "admin": {
+                        "enabled": True,
                         "credentials": {
                             "admin": eks_config.require("apisix_admin_key"),
                             "viewer": eks_config.require("apisix_viewer_key"),
+                        },
+                        "allow": {
+                            "ipList": Output.all(pods=pod_ip_blocks).apply(
+                                lambda args: [*args["pods"]]
+                            )
                         },
                     },
                 },
@@ -1066,6 +1076,8 @@ if eks_config.get_bool("apisix_ingress_enabled"):
                 },
                 "ingress-controller": {
                     "enabled": True,
+                    "replicaCount": 2,
+                    "tolerations": operations_tolerations,
                     "gateway": {
                         "type": "ClusterIP",
                         "resources": {
@@ -1088,7 +1100,7 @@ if eks_config.get_bool("apisix_ingress_enabled"):
                         },
                         "kubernetes": {
                             # Requires using apisix CRs
-                            "enableGatewayAPI": False,  # Not first-class support
+                            "enableGatewayAPI": False,  # Not first-class support 20250304
                             "resyncInterval": "1m",
                         },
                     },


### PR DESCRIPTION


### What are the relevant tickets?
Closes #2972  (?) 

### Description (What does it do?)
Tweaks to apisix to maybe help stability but cannot get rid of etcd (yet!)

This also turns on apisix for the data EKS clusters. 

I can't find a way to run apisix in "standalone" mode using the official helm chart. Refer to this poor soul on stack overflow who has our exact issue: https://stackoverflow.com/questions/78518535/apisix-on-kubernetes-is-it-possible-to-deploy-apisix-without-the-database-suppo