### PR TITLE
update node and python, update publish script syntax

### DIFF
--- a/src/ol_concourse/pipelines/libraries/open_api_clients.py
+++ b/src/ol_concourse/pipelines/libraries/open_api_clients.py
@@ -49,7 +49,7 @@ python_image = Resource(
     icon="docker",
     source={
         "repository": "python",
-        "tag": "3.11-slim",
+        "tag": "3.12-slim",
     },
 )
 node_image = Resource(
@@ -58,7 +58,7 @@ node_image = Resource(
     icon="docker",
     source={
         "repository": "node",
-        "tag": "18-slim",
+        "tag": "22-slim",
     },
 )
 

--- a/src/ol_concourse/pipelines/libraries/scripts/open-api-clients-publish-node.sh
+++ b/src/ol_concourse/pipelines/libraries/scripts/open-api-clients-publish-node.sh
@@ -2,9 +2,13 @@
 # publish the npm package to npmjs.org
 
 echo "//registry.npmjs.org/:_authToken=((open_api_clients.npmjs_token))" > .npmrc
+export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+corepack enable
+mkdir yarn-global
+yarn config set globalFolder ./yarn-global
 yarn install --immutable
 yarn build
 # OK so this is vaguely gross but it will do :)
 new_version=$(cat ../../../VERSION)
 echo "Publishing version $new_version"
-yarn publish --access public --new-version "$new_version"
+npm publish --dry-run --access public


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/ol-infrastructure/issues/3005

### Description (What does it do?)
This PR upgrades the versions of Node and Python used in the build and publish jobs of the `open-api-clients` pipeline. The syntax of the publishing script was also updated to match the newer version of yarn used with the newer version of Node.

### How can this be tested?
If you have locally running Concourse, you can generate the pipeline with:

`python src/ol_concourse/pipelines/libraries/open_api_clients.py`

Then, edit the pipeline definition so that the `git commit` and `npm publish` lines have `--dry-run` after them. You will also have to replace `((open_api_clients.odlbot_private_ssh_key))` with a valid SSH key that can pull the https://github.com/mitodl/open-api-clients repository, and also has rights to push. Even though it won't be doing so with `--dry-run` enabled, it seems necessary for the command to even run. You may also need to replace `((open_api_clients.npmjs_token))` with a valid NPM access token for publishing to the `@mitodl` organization. After setting these values and pushing the pipeline up to Concourse, it should run without issue.
