### PR TITLE
Point to RC search from CI/RC learn-ai

### DIFF
--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.CI.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.CI.yaml
@@ -7,7 +7,7 @@ config:
   learn_ai:env_vars:
     AI_DEFAULT_SYLLABUS_MODEL: "bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0"
     AI_MIT_SYLLABUS_URL: "https://api.rc.learn.mit.edu/api/v0/vector_content_files_search/"
-    AI_MIT_SEARCH_URL: "https://api.rc.learn.mit.edu/api/v1/learning_resources_search/"    
+    AI_MIT_SEARCH_URL: "https://api.rc.learn.mit.edu/api/v1/learning_resources_search/"
     CELERY_TASK_ALWAYS_EAGER: "false"
     CSRF_ALLOWED_ORIGINS: '["https://learn-ai-ci.ol.mit.edu", "https://api-learn-ai-ci.ol.mit.edu"]'
     CSRF_TRUSTED_ORIGINS: '["https://learn-ai-ci.ol.mit.edu", "https://api-learn-ai-ci.ol.mit.edu"]'

--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.CI.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.CI.yaml
@@ -6,6 +6,8 @@ config:
   learn_ai:backend_domain: "api-learn-ai-ci.ol.mit.edu"
   learn_ai:env_vars:
     AI_DEFAULT_SYLLABUS_MODEL: "bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+    AI_MIT_SYLLABUS_URL: "https://api.rc.learn.mit.edu/api/v0/vector_content_files_search/"
+    AI_MIT_SEARCH_URL: "https://api.rc.learn.mit.edu/api/v1/learning_resources_search/"    
     CELERY_TASK_ALWAYS_EAGER: "false"
     CSRF_ALLOWED_ORIGINS: '["https://learn-ai-ci.ol.mit.edu", "https://api-learn-ai-ci.ol.mit.edu"]'
     CSRF_TRUSTED_ORIGINS: '["https://learn-ai-ci.ol.mit.edu", "https://api-learn-ai-ci.ol.mit.edu"]'

--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.QA.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.QA.yaml
@@ -8,6 +8,8 @@ config:
     secure: v1:moKYAbHsHOnTUrEk:4OgRBNFXT0WKrz1KaKZDhQxT09dA36jN4+q/SO0IIAemTSiwGqrXbXn+r5dFlGrr24S+VGtiyNXSVKts+j/TgKS33FTo86OX2saBDrL4dFo=
   learn_ai:env_vars:
     AI_DEFAULT_SYLLABUS_MODEL: "bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+    AI_MIT_SYLLABUS_URL: "https://api.rc.learn.mit.edu/api/v0/vector_content_files_search/"
+    AI_MIT_SEARCH_URL: "https://api.rc.learn.mit.edu/api/v1/learning_resources_search/"
     CELERY_TASK_ALWAYS_EAGER: "false"
     CSRF_ALLOWED_ORIGINS: '["https://learn-ai-qa.ol.mit.edu", "https://api-learn-ai-qa.ol.mit.edu"]'
     CSRF_TRUSTED_ORIGINS: '["https://learn-ai-qa.ol.mit.edu", "https://api-learn-ai-qa.ol.mit.edu"]'


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Sets env variables so that learn-ai RC uses the mit-learn RC search endpoints instead of production.


### How can this be tested?
N/A

