### PR TITLE
Properly tag and retrieve Learn AI docker images for RC/Production

### DIFF
--- a/src/ol_concourse/lib/resources.py
+++ b/src/ol_concourse/lib/resources.py
@@ -1,6 +1,6 @@
-from typing import Literal, Optional, Union
+from typing import Any, Literal, Optional, Union
 
-from ol_concourse.lib.models.pipeline import Identifier, RegistryImage, Resource
+from ol_concourse.lib.models.pipeline import Identifier, Resource
 from ol_concourse.lib.models.resource import Git
 
 
@@ -249,22 +249,26 @@ def schedule(
 def registry_image(  # noqa: PLR0913
     name: Identifier,
     image_repository: str,
-    image_tag: Optional[str] = None,
+    image_tag: Optional[str] = "latest",
     variant: Optional[str] = None,
     tag_regex: Optional[str] = None,
+    sort_by_creation: bool | None = None,
     username=None,
     password=None,
+    check_every: str | None = None,
 ) -> Resource:
-    image_source = RegistryImage(
-        repository=image_repository, tag=image_tag or "latest"
-    ).model_dump()
+    image_source: dict[str, Any] = {"repository": image_repository, "tag": image_tag}
     if username and password:
         image_source["username"] = username
         image_source["password"] = password
     if variant:
         image_source["variant"] = variant
-    if tag_regex:
+    if tag_regex is not None:
         image_source["tag_regex"] = tag_regex
+    if sort_by_creation is not None:
+        image_source["created_at_sort"] = sort_by_creation
+    if check_every:
+        image_source["check_every"] = check_every
     return Resource(
         name=name,
         type="registry-image",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Fix deployment logic for Learn AI so that versions are properly propagated to RC/Production


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
These changes have been applied to the existing pipeline and verified.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
The git tag does not get set on the release-candidate branch, so it is necessary to retrieve the version details from the code for tagging the image. This udpates the RC git resource to not filter on tags that don't exist yet, and instead fetch the version via bash command. Also update the registry-image resource to properly filter on the tagged versions to propagate to the Pulumi code
