### PR TITLE
Disable Renovate automerge in ocw-course-publisher Dockerfile

### DIFF
--- a/dockerfiles/ocw/node-hugo/Dockerfile
+++ b/dockerfiles/ocw/node-hugo/Dockerfile
@@ -5,7 +5,7 @@ LABEL version="0.8"
 WORKDIR /tmp
 
 # renovate: datasource=github-releases depName=hugo packageName=gohugoio/hugo
-ENV HUGO_VERSION="0.145.0"
+ENV HUGO_VERSION="0.142.0"
 ENV HUGO_NAME="hugo_extended_${HUGO_VERSION}_linux-amd64"
 
 # renovate: datasource=github-tags depName=go packageName=golang/go versioning=go

--- a/renovate.json5
+++ b/renovate.json5
@@ -6,7 +6,7 @@
   "packageRules": [
     {
       "matchManagers": ["regex"],
-      "matchPaths": ["dockerfiles/ocw/node-hugo/Dockerfile"],
+      "matchFileNames": ["dockerfiles/ocw/node-hugo/Dockerfile"],
       "automerge": false
     },
     {

--- a/renovate.json5
+++ b/renovate.json5
@@ -5,6 +5,11 @@
   ],
   "packageRules": [
     {
+      "matchManagers": ["regex"],
+      "matchPaths": ["dockerfiles/ocw/node-hugo/Dockerfile"],
+      "automerge": false
+    },
+    {
       "groupName": "pulumi-plugins",
       "matchPackageNames": [
         "pulumi{/,}**"


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
We recently added Renovate configuration for ocw-course-publisher in `renovate.json5` and `dockerfiles/ocw/node-hugo/Dockerfile` in https://github.com/mitodl/ol-infrastructure/pull/2993

But Renovate automerged Hugo upgrade from `0.142.0` to `0.145.0` in https://github.com/mitodl/ol-infrastructure/pull/3002 causing pipeline failures: https://mitodl.slack.com/archives/GQ89D0Z5M/p1741148914186019?thread_ts=1741128216.873919&cid=GQ89D0Z5M

We need to disable Hugo upgrade auto-merges because it should be always updated in development first in `ocw-hugo-themes` (`hugo-bin-extended`) and only afterwards in `ocw-course-publisher` -- and after a review.

This PR also reverts Hugo upgrade from `0.145.0` back to `0.142.0`.
