### PR TITLE
pass GIT_HASH build arg to learn-ai builds

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/learn_ai/docker_pulumi.py
+++ b/src/ol_concourse/pipelines/infrastructure/learn_ai/docker_pulumi.py
@@ -94,10 +94,9 @@ def build_learn_ai_pipeline() -> Pipeline:
                 inputs=[Input(name=learn_ai_main_repo.name)],
                 build_parameters={
                     "CONTEXT": learn_ai_main_repo.name,
+                    "BUILD_ARG_GIT_REF": "((.:git_ref))",
                 },
-                build_args=[
-                    "--build-arg GIT_REF=((.:git_ref))",
-                ],
+                build_args=[],
             ),
             PutStep(
                 put=learn_ai_registry_ci_image.name,
@@ -148,10 +147,9 @@ def build_learn_ai_pipeline() -> Pipeline:
                 inputs=[Input(name=learn_ai_release_candidate_repo.name)],
                 build_parameters={
                     "CONTEXT": learn_ai_release_candidate_repo.name,
+                    "BUILD_ARG_GIT_REF": "((.:git_ref))",
                 },
-                build_args=[
-                    "--build-arg GIT_REF=((.:git_ref))",
-                ],
+                build_args=[],
             ),
             PutStep(
                 put=learn_ai_registry_rc_image.name,

--- a/src/ol_concourse/pipelines/infrastructure/learn_ai/docker_pulumi.py
+++ b/src/ol_concourse/pipelines/infrastructure/learn_ai/docker_pulumi.py
@@ -86,12 +86,18 @@ def build_learn_ai_pipeline() -> Pipeline:
         build_log_retention={"builds": 10},
         plan=[
             GetStep(get=learn_ai_main_repo.name, trigger=True),
+            LoadVarStep(
+                load_var="git_ref",
+                file=f"{learn_ai_main_repo.name}/.git/ref",
+            ),
             container_build_task(
                 inputs=[Input(name=learn_ai_main_repo.name)],
                 build_parameters={
                     "CONTEXT": learn_ai_main_repo.name,
                 },
-                build_args=[],
+                build_args=[
+                    "--build-arg GIT_REF=((.:git_ref))",
+                ],
             ),
             PutStep(
                 put=learn_ai_registry_ci_image.name,
@@ -134,12 +140,18 @@ def build_learn_ai_pipeline() -> Pipeline:
                 file="rc_version/version",
                 reveal=True,
             ),
+            LoadVarStep(
+                load_var="git_ref",
+                file=f"{learn_ai_release_candidate_repo.name}/.git/ref",
+            ),
             container_build_task(
                 inputs=[Input(name=learn_ai_release_candidate_repo.name)],
                 build_parameters={
                     "CONTEXT": learn_ai_release_candidate_repo.name,
                 },
-                build_args=[],
+                build_args=[
+                    "--build-arg GIT_REF=((.:git_ref))",
+                ],
             ),
             PutStep(
                 put=learn_ai_registry_rc_image.name,


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/6880

### Description (What does it do?)
This PR modifies the pipeline for building and deploying the `learn-ai` docker images to pass 

### How can this be tested?
I'm unaware of the testing process here, but I imagine we run the pipeline and then check the docker images to make sure they contain the hash?