### PR TITLE
Change logout redirect url for mit-learn

### DIFF
--- a/src/ol_infrastructure/applications/mitlearn/__main__.py
+++ b/src/ol_infrastructure/applications/mitlearn/__main__.py
@@ -915,8 +915,8 @@ base_oidc_plugin_config = {
     "bearer_only": False,
     "introspection_endpoint_auth_method": "client_secret_basic",
     "ssl_verify": False,
-    "logout_path": "/logout/oidc",
-    "post_logout_redirect_uri": "/",
+    "logout_path": "/logout/",
+    "post_logout_redirect_uri": "/django_logout/",
 }
 
 shared_plugin_config_name = "shared-plugin-config"


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/mit-learn/pull/2119

### Description (What does it do?)
Changes the apisix logout and logout_redirect_url values for mit-learn


### How can this be tested?
N/A

### Additional Context
This is meant to reflect the changes made [here ](https://github.com/mitodl/mit-learn/pull/2119/files#diff-d87c38aaeae096a18f954f1eecfd2a8fe134f08fb2924e4dc2a2315875b7ab7d) to the local dev apisix container, with APISIX_LOGOUT_URL now equal to `/django_logout/` instead of `/logout/`



