### PR TITLE
Md/hq issue 6892 2

### DIFF
--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.CI.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.CI.yaml
@@ -4,6 +4,7 @@ encryptedkey: AQICAHi3MZ/Pjy2dahB1Qm+zKkKDPV1b9MYPGp7k649HPjmOHAGzwYvKdv8btlpNoW
 config:
   aws:region: us-east-1
   learn_ai:backend_domain: "api-learn-ai-ci.ol.mit.edu"
+  learn_ai:learn_backend_domain: "api.ci.learn.mit.edu"
   learn_ai:env_vars:
     AI_DEFAULT_SYLLABUS_MODEL: "bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0"
     AI_MIT_SEARCH_URL: "https://api.rc.learn.mit.edu/api/v1/learning_resources_search/"

--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.Production.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.Production.yaml
@@ -4,6 +4,7 @@ encryptedkey: AQICAHjmo6C0sCNz3fdkFlhbu0tdBZxnHmPYSnqtmocvGiuNygH4WWFJR+Plwkjoif
 config:
   aws:region: us-east-1
   learn_ai:backend_domain: "api-learn-ai.ol.mit.edu"
+  learn_ai:learn_backend_domain: "api.learn.mit.edu"
   learn_ai:db_password:
     secure: v1:DIaoiP0dVXpI2w72:zcSTWgD6DInTMOdD1oH1FTdlUJCney7MLeAfL5Q5hcL9lDfW7AjVGynLDeDtpL3DQIZvFBUvcbjIHVaBYQf8Ikf8tdjWamNBv+4Ymwe2
   learn_ai:env_vars:

--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.Production.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.Production.yaml
@@ -10,8 +10,10 @@ config:
   learn_ai:env_vars:
     AI_DEFAULT_SYLLABUS_MODEL: "bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0"
     CELERY_TASK_ALWAYS_EAGER: "false"
-    CSRF_ALLOWED_ORIGINS: '["https://learn-ai.ol.mit.edu", "https://api-learn-ai.ol.mit.edu"]'
-    CSRF_TRUSTED_ORIGINS: '["https://learn-ai.ol.mit.edu", "https://api-learn-ai.ol.mit.edu"]'
+    CSRF_ALLOWED_ORIGINS: '["https://learn-ai.ol.mit.edu", "https://api-learn-ai.ol.mit.edu",
+      "https://learn.mit.edu", "https://api.learn.mit.edu"]'
+    CSRF_TRUSTED_ORIGINS: '["https://learn-ai.ol.mit.edu", "https://api-learn-ai.ol.mit.edu",
+      "https://learn.mit.edu", "https://api.learn.mit.edu"]'
     DEBUG: "false"
     DEV_ENV: "false"
     ENVIRONMENT: "production"

--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.QA.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.QA.yaml
@@ -14,8 +14,10 @@ config:
     AI_MIT_SYLLABUS_URL: "https://api.rc.learn.mit.edu/api/v0/vector_content_files_search/"
     AI_MIT_VIDEO_TRANSCRIPT_URL: "https://api.rc.learn.mit.edu/api/v0/vector_content_files_search/"
     CELERY_TASK_ALWAYS_EAGER: "false"
-    CSRF_ALLOWED_ORIGINS: '["https://learn-ai-qa.ol.mit.edu", "https://api-learn-ai-qa.ol.mit.edu"]'
-    CSRF_TRUSTED_ORIGINS: '["https://learn-ai-qa.ol.mit.edu", "https://api-learn-ai-qa.ol.mit.edu"]'
+    CSRF_ALLOWED_ORIGINS: '["https://learn-ai-qa.ol.mit.edu", "https://api-learn-ai-qa.ol.mit.edu",
+      "https://rc.learn.mit.edu", "https://api.rc.learn.mit.edu"]'
+    CSRF_TRUSTED_ORIGINS: '["https://learn-ai-qa.ol.mit.edu", "https://api-learn-ai-qa.ol.mit.edu",
+      "https://rc.learn.mit.edu", "https://api.rc.learn.mit.edu"]'
     DEBUG: "false"
     DEV_ENV: "false"
     ENVIRONMENT: "production"

--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.QA.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.QA.yaml
@@ -4,6 +4,7 @@ encryptedkey: AQICAHgQW+3bag/cl2fPG3dPdqAPbfcsZuwI7rETXZsx85HRpgF0G1SpXqAgEVHrcC
 config:
   aws:region: us-east-1
   learn_ai:backend_domain: "api-learn-ai-qa.ol.mit.edu"
+  learn_ai:learn_backend_domain: "api.rc.learn.mit.edu"
   learn_ai:db_password:
     secure: v1:moKYAbHsHOnTUrEk:4OgRBNFXT0WKrz1KaKZDhQxT09dA36jN4+q/SO0IIAemTSiwGqrXbXn+r5dFlGrr24S+VGtiyNXSVKts+j/TgKS33FTo86OX2saBDrL4dFo=
   learn_ai:env_vars:

--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -1558,8 +1558,7 @@ gh_workflow_api_base_env_var = github.ActionsVariable(
     f"learn-ai-gh-workflow-api-base-env-variablet-{stack_info.env_suffix}",
     repository=gh_repo.name,
     variable_name=f"API_BASE_{env_var_suffix}",  # pragma: allowlist secret
-    # SWITCHOVER : Update to learn_api_domain
-    value=f"https://{learn_ai_api_domain}",
+    value=f"https://{learn_api_domain}/ai",
     opts=ResourceOptions(provider=github_provider, delete_before_replace=True),
 )
 

--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -1062,6 +1062,7 @@ learn_ai_pod_security_group_policy = (
 # Ref: https://apisix.apache.org/docs/ingress-controller/concepts/apisix_plugin_config/
 # Ref: https://apisix.apache.org/docs/ingress-controller/references/apisix_pluginconfig_v2/
 
+# LEGACY RETIREMENT : goes away
 # Load open-id-connect secrets into a k8s secret via VSO
 oidc_secret_name = "oidc-secrets"  # pragma: allowlist secret  # noqa: S105
 oidc_secret = OLVaultK8SSecret(
@@ -1090,8 +1091,38 @@ oidc_secret = OLVaultK8SSecret(
     ),
     opts=ResourceOptions(
         delete_before_replace=True,
-        parent=vault_k8s_resources,
-        depends_on=[learn_ai_static_vault_secrets],
+    ),
+)
+
+mit_learn_oidc_secret_name = (
+    "mit-learn-oidc-secrets"  # pragma: allowlist secret # noqa: S105
+)
+mit_learn_oidc_secret = OLVaultK8SSecret(
+    f"ol-mitlearn-oidc-secrets-{stack_info.env_suffix}",
+    resource_config=OLVaultK8SStaticSecretConfig(
+        name="mit-learn-oidc-static-secrets",
+        namespace=learn_ai_namespace,
+        labels=application_labels,
+        dest_secret_name=mit_learn_oidc_secret_name,
+        dest_secret_labels=application_labels,
+        mount="secret-operations",
+        mount_type="kv-v1",
+        path="sso/mitlearn",
+        excludes=[".*"],
+        exclude_raw=True,
+        # Refresh frequently because substructure keycloak stack could change some of these
+        refresh_after="1m",
+        templates={
+            "client_id": '{{ get .Secrets "client_id" }}',
+            "client_secret": '{{ get .Secrets "client_secret" }}',
+            "realm": '{{ get .Secrets "realm_name" }}',
+            "discovery": '{{ get .Secrets "url" }}/.well-known/openid-configuration',
+            "session.secret": '{{ get .Secrets "secret" }}',
+        },
+        vaultauth=vault_k8s_resources.auth_name,
+    ),
+    opts=ResourceOptions(
+        delete_before_replace=True,
     ),
 )
 
@@ -1150,6 +1181,7 @@ base_oidc_plugin_config = {
 }
 
 learn_ai_api_domain = learn_ai_config.require("backend_domain")
+learn_api_domain = learn_ai_config.require("learn_backend_domain")
 
 if stack_info.env_suffix != "ci":
     consul_opts = get_consul_provider(stack_info)
@@ -1159,6 +1191,7 @@ if stack_info.env_suffix != "ci":
             consul.KeysKeyArgs(
                 path="edxapp/learn-ai-api-domain",
                 delete=True,
+                # SWITCHOVER : Update to learn_api_domain
                 value=learn_ai_api_domain,
             )
         ],
@@ -1171,6 +1204,7 @@ if stack_info.env_suffix != "ci":
 
 # Ref: https://apisix.apache.org/docs/ingress-controller/references/apisix_route_v2/
 # Ref: https://apisix.apache.org/docs/ingress-controller/concepts/apisix_route/
+# LEGACY RETIREMENT : goes away
 learn_ai_https_apisix_route = kubernetes.apiextensions.CustomResource(
     f"learn-ai-{stack_info.env_suffix}-https-apisix-route",
     api_version="apisix.apache.org/v2",
@@ -1249,7 +1283,7 @@ learn_ai_https_apisix_route = kubernetes.apiextensions.CustomResource(
                 ],
                 "match": {
                     "hosts": [
-                        learn_ai_config.require("backend_domain"),
+                        learn_ai_api_domain,
                     ],
                     "paths": [
                         "/admin/login/*",
@@ -1279,7 +1313,7 @@ learn_ai_https_apisix_route = kubernetes.apiextensions.CustomResource(
                 ],
                 "match": {
                     "hosts": [
-                        learn_ai_config.require("backend_domain"),
+                        learn_ai_api_domain,
                     ],
                     "paths": [
                         "/ws/*",
@@ -1299,9 +1333,144 @@ learn_ai_https_apisix_route = kubernetes.apiextensions.CustomResource(
         depends_on=[learn_ai_service, oidc_secret],
     ),
 )
+# New ApisixRoute object for the learn.mit.edu address
+# All paths prefixed with /ai
+# Host match is only the mit-learn domain
+mit_learn_learn_ai_https_apisix_route = kubernetes.apiextensions.CustomResource(
+    f"learn-ai-{stack_info.env_suffix}-https-apisix-route",
+    api_version="apisix.apache.org/v2",
+    kind="ApisixRoute",
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        name="mit-learn-learn-ai-https",
+        namespace=learn_ai_namespace,
+        labels=k8s_global_labels,
+    ),
+    spec={
+        "http": [
+            {
+                # Wildcard route that can use auth but doesn't require it
+                "name": "passauth",
+                "priority": 2,
+                "plugin_config_name": shared_plugin_config_name,
+                "plugins": [
+                    {
+                        "name": "openid-connect",
+                        "enable": True,
+                        "secretRef": mit_learn_oidc_secret_name,
+                        "config": base_oidc_plugin_config | {"unauth_action": "pass"},
+                    }
+                ],
+                "match": {
+                    "hosts": [learn_ai_api_domain],
+                    "paths": [
+                        "/ai/*",
+                    ],
+                },
+                "backends": [
+                    {
+                        "serviceName": learn_ai_service_name,
+                        "servicePort": learn_ai_service_port_name,
+                    },
+                ],
+            },
+            {
+                # Strip trailing slash from logout redirect
+                "name": "logout-redirect",
+                "priority": 10,
+                "plugins": [
+                    {
+                        "name": "redirect",
+                        "enable": True,
+                        "config": {
+                            "uri": "/logout",
+                        },
+                    },
+                ],
+                "match": {
+                    "hosts": [
+                        learn_api_domain,
+                    ],
+                    "paths": [
+                        "/ai/logout/*",
+                    ],
+                },
+                "backends": [
+                    {
+                        "serviceName": learn_ai_service_name,
+                        "servicePort": learn_ai_service_port_name,
+                    },
+                ],
+            },
+            {
+                # Routes that require authentication
+                "name": "reqauth",
+                "priority": 10,
+                "plugin_config_name": shared_plugin_config_name,
+                "plugins": [
+                    {
+                        "name": "openid-connect",
+                        "enable": True,
+                        "secretRef": mit_learn_oidc_secret_name,
+                        "config": base_oidc_plugin_config | {"unauth_action": "auth"},
+                    }
+                ],
+                "match": {
+                    "hosts": [
+                        learn_api_domain,
+                    ],
+                    "paths": [
+                        "/ai/admin/login/*",
+                        "/ai/http/login/",
+                    ],
+                },
+                "backends": [
+                    {
+                        "serviceName": learn_ai_service_name,
+                        "servicePort": learn_ai_service_port_name,
+                    },
+                ],
+            },
+            {
+                # Sepcial handling for websocket URLS.
+                "name": "websocket",
+                "priority": 1,
+                "websocket": True,
+                "plugin_config_name": shared_plugin_config_name,
+                "plugins": [
+                    {
+                        "name": "openid-connect",
+                        "enable": True,
+                        "secretRef": mit_learn_oidc_secret_name,
+                        "config": base_oidc_plugin_config | {"unauth_action": "pass"},
+                    }
+                ],
+                "match": {
+                    "hosts": [
+                        learn_api_domain,
+                    ],
+                    "paths": [
+                        "/ai/ws/*",
+                    ],
+                },
+                "backends": [
+                    {
+                        "serviceName": learn_ai_service_name,
+                        "servicePort": learn_ai_service_port_name,
+                    },
+                ],
+            },
+        ],
+    },
+    opts=ResourceOptions(
+        delete_before_replace=True,
+        depends_on=[learn_ai_service, mit_learn_oidc_secret],
+    ),
+)
 
 # Ref: https://apisix.apache.org/docs/ingress-controller/references/apisix_tls_v2/
 # Ref: https://apisix.apache.org/docs/ingress-controller/concepts/apisix_tls/
+# LEGACY RETIREMENT : goes away
+# Won't need this because it will exist from the mit-learn namespace
 learn_ai_https_apisix_tls = kubernetes.apiextensions.CustomResource(
     f"learn-ai-{stack_info.env_suffix}-https-apisix-tls",
     api_version="apisix.apache.org/v2",
@@ -1312,7 +1481,7 @@ learn_ai_https_apisix_tls = kubernetes.apiextensions.CustomResource(
         labels=k8s_global_labels,
     ),
     spec={
-        "hosts": [learn_ai_config.require("backend_domain")],
+        "hosts": [learn_ai_api_domain],
         # Use the shared ol-wildcard cert loaded into every cluster
         "secret": {
             "name": "ol-wildcard-cert",
@@ -1374,7 +1543,8 @@ gh_workflow_api_base_env_var = github.ActionsVariable(
     f"learn-ai-gh-workflow-api-base-env-variablet-{stack_info.env_suffix}",
     repository=gh_repo.name,
     variable_name=f"API_BASE_{env_var_suffix}",  # pragma: allowlist secret
-    value=f"https://{learn_ai_config.require('backend_domain')}",
+    # SWITCHOVER : Update to learn_api_domain
+    value=f"https://{learn_ai_api_domain}",
     opts=ResourceOptions(provider=github_provider, delete_before_replace=True),
 )
 

--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -1333,6 +1333,17 @@ learn_ai_https_apisix_route = kubernetes.apiextensions.CustomResource(
         depends_on=[learn_ai_service, oidc_secret],
     ),
 )
+
+proxy_rewrite_plugin_config = {
+    "name": "proxy-rewrite",
+    "enable": True,
+    "config": {
+        "regex_uri": [
+            "/ai/(.*)",
+            "/$1",
+        ],
+    },
+}
 # New ApisixRoute object for the learn.mit.edu address
 # All paths prefixed with /ai
 # Host match is only the mit-learn domain
@@ -1353,12 +1364,13 @@ mit_learn_learn_ai_https_apisix_route = kubernetes.apiextensions.CustomResource(
                 "priority": 2,
                 "plugin_config_name": shared_plugin_config_name,
                 "plugins": [
+                    proxy_rewrite_plugin_config,
                     {
                         "name": "openid-connect",
                         "enable": True,
                         "secretRef": mit_learn_oidc_secret_name,
                         "config": base_oidc_plugin_config | {"unauth_action": "pass"},
-                    }
+                    },
                 ],
                 "match": {
                     "hosts": [learn_ai_api_domain],
@@ -1378,6 +1390,7 @@ mit_learn_learn_ai_https_apisix_route = kubernetes.apiextensions.CustomResource(
                 "name": "logout-redirect",
                 "priority": 10,
                 "plugins": [
+                    proxy_rewrite_plugin_config,
                     {
                         "name": "redirect",
                         "enable": True,
@@ -1407,12 +1420,13 @@ mit_learn_learn_ai_https_apisix_route = kubernetes.apiextensions.CustomResource(
                 "priority": 10,
                 "plugin_config_name": shared_plugin_config_name,
                 "plugins": [
+                    proxy_rewrite_plugin_config,
                     {
                         "name": "openid-connect",
                         "enable": True,
                         "secretRef": mit_learn_oidc_secret_name,
                         "config": base_oidc_plugin_config | {"unauth_action": "auth"},
-                    }
+                    },
                 ],
                 "match": {
                     "hosts": [
@@ -1437,12 +1451,13 @@ mit_learn_learn_ai_https_apisix_route = kubernetes.apiextensions.CustomResource(
                 "websocket": True,
                 "plugin_config_name": shared_plugin_config_name,
                 "plugins": [
+                    proxy_rewrite_plugin_config,
                     {
                         "name": "openid-connect",
                         "enable": True,
                         "secretRef": mit_learn_oidc_secret_name,
                         "config": base_oidc_plugin_config | {"unauth_action": "pass"},
-                    }
+                    },
                 ],
                 "match": {
                     "hosts": [

--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -1348,7 +1348,7 @@ proxy_rewrite_plugin_config = {
 # All paths prefixed with /ai
 # Host match is only the mit-learn domain
 mit_learn_learn_ai_https_apisix_route = kubernetes.apiextensions.CustomResource(
-    f"learn-ai-{stack_info.env_suffix}-https-apisix-route",
+    f"mit-learn-learn-ai-{stack_info.env_suffix}-https-apisix-route",
     api_version="apisix.apache.org/v2",
     kind="ApisixRoute",
     metadata=kubernetes.meta.v1.ObjectMetaArgs(
@@ -1373,7 +1373,7 @@ mit_learn_learn_ai_https_apisix_route = kubernetes.apiextensions.CustomResource(
                     },
                 ],
                 "match": {
-                    "hosts": [learn_ai_api_domain],
+                    "hosts": [learn_api_domain],
                     "paths": [
                         "/ai/*",
                     ],

--- a/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.Production.yaml
+++ b/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.Production.yaml
@@ -87,5 +87,5 @@ config:
   mitlearn:nextjs_heroku_domain: "mitopen-production-nextjs-6b0d663f9110.herokuapp.com"
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production
-  mitlearn:learn_ai_recommendation_endpoint: "https://api-learn-ai.ol.mit.edu/http/recommendation_agent/"
-  mitlearn:learn_ai_syllabus_endpoint: "https://api-learn-ai.ol.mit.edu/http/syllabus_agent/"
+  mitlearn:learn_ai_recommendation_endpoint: "https://api.learn.mit.edu/ai/http/recommendation_agent/"
+  mitlearn:learn_ai_syllabus_endpoint: "https://api.learn.mit.edu/ai/http/syllabus_agent/"

--- a/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.QA.yaml
+++ b/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.QA.yaml
@@ -83,5 +83,5 @@ config:
   mitlearn:heroku_domain: "shrouded-brook-krg88s8bvcdg6kgrdjrsrmbq.herokudns.com"
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa
-  mitlearn:learn_ai_recommendation_endpoint: "https://api-learn-ai-qa.ol.mit.edu/http/recommendation_agent/"
-  mitlearn:learn_ai_syllabus_endpoint: "https://api-learn-ai-qa.ol.mit.edu/http/syllabus_agent/"
+  mitlearn:learn_ai_recommendation_endpoint: "https://api.rc.learn.mit.edu/ai/http/recommendation_agent/"
+  mitlearn:learn_ai_syllabus_endpoint: "https://api.rc.learn.mit.edu/ai/http/syllabus_agent/"

--- a/src/ol_infrastructure/applications/mitlearn/__main__.py
+++ b/src/ol_infrastructure/applications/mitlearn/__main__.py
@@ -1088,11 +1088,11 @@ learn_external_service_apisix_route = kubernetes.apiextensions.CustomResource(
 # All paths prefixed with /learn
 mit_learn_api_domain = mitlearn_config.require("api_domain")
 learn_external_service_apisix_route = kubernetes.apiextensions.CustomResource(
-    f"ol-mitlearn-external-service-apisix-route-{stack_info.env_suffix}",
+    f"ol-mitlearn-external-service-apisix-route-{stack_info.env_suffix}-new",
     api_version="apisix.apache.org/v2",
     kind="ApisixRoute",
     metadata=kubernetes.meta.v1.ObjectMetaArgs(
-        name=learn_external_service_name,
+        name=f"{learn_external_service_name}-new",
         namespace=learn_namespace,
         labels=application_labels,
     ),

--- a/src/ol_infrastructure/applications/mitlearn/__main__.py
+++ b/src/ol_infrastructure/applications/mitlearn/__main__.py
@@ -1103,8 +1103,8 @@ base_oidc_plugin_config = {
     "bearer_only": False,
     "introspection_endpoint_auth_method": "client_secret_basic",
     "ssl_verify": False,
-    "logout_path": "/learn/logout/",
-    "post_logout_redirect_uri": "/learn/django_logout/",
+    "logout_path": "/learn/logout/oidc",
+    "post_logout_redirect_uri": f"https://{mitlearn_config.require('api_domain')}/learn/logout/",
 }
 # New ApisixRoute object
 # All paths prefixed with /learn

--- a/src/ol_infrastructure/applications/mitlearn/__main__.py
+++ b/src/ol_infrastructure/applications/mitlearn/__main__.py
@@ -1084,6 +1084,17 @@ learn_external_service_apisix_route = kubernetes.apiextensions.CustomResource(
     ),
 )
 
+
+proxy_rewrite_plugin_config = {
+    "name": "proxy-rewrite",
+    "enable": True,
+    "config": {
+        "regex_uri": [
+            "/learn/(.*)",
+            "/$1",
+        ],
+    },
+}
 # New ApisixRoute object
 # All paths prefixed with /learn
 mit_learn_api_domain = mitlearn_config.require("api_domain")
@@ -1104,6 +1115,7 @@ learn_external_service_apisix_route = kubernetes.apiextensions.CustomResource(
                 "priority": 0,
                 "plugin_config_name": shared_plugin_config_name,
                 "plugins": [
+                    proxy_rewrite_plugin_config,
                     {
                         "name": "openid-connect",
                         "enable": True,
@@ -1158,6 +1170,7 @@ learn_external_service_apisix_route = kubernetes.apiextensions.CustomResource(
                 "priority": 10,
                 "plugin_config_name": shared_plugin_config_name,
                 "plugins": [
+                    proxy_rewrite_plugin_config,
                     {
                         "name": "openid-connect",
                         "enable": True,

--- a/src/ol_infrastructure/applications/mitlearn/__main__.py
+++ b/src/ol_infrastructure/applications/mitlearn/__main__.py
@@ -1108,7 +1108,6 @@ base_oidc_plugin_config = {
 }
 # New ApisixRoute object
 # All paths prefixed with /learn
-mit_learn_api_domain = mitlearn_config.require("api_domain")
 learn_external_service_apisix_route = kubernetes.apiextensions.CustomResource(
     f"ol-mitlearn-external-service-apisix-route-{stack_info.env_suffix}-new",
     api_version="apisix.apache.org/v2",
@@ -1495,6 +1494,13 @@ env_var_suffix = "RC" if stack_info.env_suffix == "qa" else "PROD"
 
 gh_repo = github.get_repository(
     full_name="mitodl/mit-learn", opts=InvokeOptions(provider=github_provider)
+)
+gh_workflow_api_base_env_var = github.ActionsVariable(
+    f"ol_mitopen_gh_workflow_api_base_env_var-{stack_info.env_suffix}",
+    repository=gh_repo.name,
+    variable_name=f"API_BASE_{env_var_suffix}",
+    value=f"https://{mit_learn_api_domain}/learn",
+    opts=ResourceOptions(provider=github_provider, delete_before_replace=True),
 )
 gh_workflow_accesskey_id_env_secret = github.ActionsSecret(
     f"ol_mitopen_gh_workflow_accesskey_id_env_secret-{stack_info.env_suffix}",

--- a/src/ol_infrastructure/applications/mitlearn/__main__.py
+++ b/src/ol_infrastructure/applications/mitlearn/__main__.py
@@ -910,7 +910,7 @@ mitlearn_https_apisix_tls = kubernetes.apiextensions.CustomResource(
 
 # We need to be able to change `unauth_action` depending on the route but otherwise
 # the settings for the oidc plugin will be unchanged
-base_oidc_plugin_config = {
+legacy_base_oidc_plugin_config = {
     "scope": "openid profile email",
     "bearer_only": False,
     "introspection_endpoint_auth_method": "client_secret_basic",
@@ -1000,7 +1000,8 @@ learn_external_service_apisix_route = kubernetes.apiextensions.CustomResource(
                         "name": "openid-connect",
                         "enable": True,
                         "secretRef": oidc_secret_name,
-                        "config": base_oidc_plugin_config | {"unauth_action": "pass"},
+                        "config": legacy_base_oidc_plugin_config
+                        | {"unauth_action": "pass"},
                     },
                 ],
                 "match": {
@@ -1054,7 +1055,8 @@ learn_external_service_apisix_route = kubernetes.apiextensions.CustomResource(
                         "name": "openid-connect",
                         "enable": True,
                         "secretRef": oidc_secret_name,
-                        "config": base_oidc_plugin_config | {"unauth_action": "auth"},
+                        "config": legacy_base_oidc_plugin_config
+                        | {"unauth_action": "auth"},
                     },
                 ],
                 "match": {
@@ -1094,6 +1096,15 @@ proxy_rewrite_plugin_config = {
             "/$1",
         ],
     },
+}
+
+base_oidc_plugin_config = {
+    "scope": "openid profile email",
+    "bearer_only": False,
+    "introspection_endpoint_auth_method": "client_secret_basic",
+    "ssl_verify": False,
+    "logout_path": "/learn/logout/",
+    "post_logout_redirect_uri": "/learn/django_logout/",
 }
 # New ApisixRoute object
 # All paths prefixed with /learn

--- a/src/ol_infrastructure/applications/unified_ecommerce/Pulumi.applications.unified_ecommerce.CI.yaml
+++ b/src/ol_infrastructure/applications/unified_ecommerce/Pulumi.applications.unified_ecommerce.CI.yaml
@@ -5,6 +5,7 @@ config:
   aws:region: us-east-1
   consul:address: https://consul-apps-ci.odl.mit.edu
   ecommerce:backend_domain: "api-pay-ci.ol.mit.edu"
+  ecommerce:learn_backend_domain: "api.ci.learn.mit.edu"
   ecommerce:db_password:
     secure: v1:rkeSh1S69nUNqVvu:cSeK5sUm8Q3RiFjCLwVcte3JGTR9cLSSiekj3YEcdcxYQWNih3h4YjuTAOgLed4C6wjBo5LL+aRUsUKR3mX96bOx3bTAgUxxIYhg/btcKMU=
   ecommerce:env_vars:

--- a/src/ol_infrastructure/applications/unified_ecommerce/Pulumi.applications.unified_ecommerce.Production.yaml
+++ b/src/ol_infrastructure/applications/unified_ecommerce/Pulumi.applications.unified_ecommerce.Production.yaml
@@ -5,6 +5,7 @@ config:
   aws:region: us-east-1
   consul:address: https://consul-apps-production.odl.mit.edu
   ecommerce:backend_domain: "api-pay.ol.mit.edu"
+  ecommerce:learn_backend_domain: "api.learn.mit.edu"
   ecommerce:env_vars:
     CELERY_TASK_ALWAYS_EAGER: "False"
     CSRF_ALLOWED_ORIGINS: '["https://pay.ol.mit.edu", "https://api-pay.ol.mit.edu"]'

--- a/src/ol_infrastructure/applications/unified_ecommerce/Pulumi.applications.unified_ecommerce.QA.yaml
+++ b/src/ol_infrastructure/applications/unified_ecommerce/Pulumi.applications.unified_ecommerce.QA.yaml
@@ -5,7 +5,7 @@ config:
   aws:region: us-east-1
   consul:address: https://consul-apps-qa.odl.mit.edu
   ecommerce:backend_domain: "api-pay-qa.ol.mit.edu"
-  ecommerce:learn_backend_domain: "api.rc.learn.ol.mit.edu"
+  ecommerce:learn_backend_domain: "api.rc.learn.mit.edu"
   ecommerce:db_password:
     secure: v1:OIaEfSH/Zi+Cx4xN:gxfyu42ieyWreccgmnbPDCBxnM5MAZbeDKJnIRlvp8Wvu87QhI+fFeEUtr+T3cPJVSvGiBipllOsETbkijSShL1TcTu+WDPmXtrRsSSBhWk=
   ecommerce:env_vars:

--- a/src/ol_infrastructure/applications/unified_ecommerce/Pulumi.applications.unified_ecommerce.QA.yaml
+++ b/src/ol_infrastructure/applications/unified_ecommerce/Pulumi.applications.unified_ecommerce.QA.yaml
@@ -5,6 +5,7 @@ config:
   aws:region: us-east-1
   consul:address: https://consul-apps-qa.odl.mit.edu
   ecommerce:backend_domain: "api-pay-qa.ol.mit.edu"
+  ecommerce:learn_backend_domain: "api.rc.learn.ol.mit.edu"
   ecommerce:db_password:
     secure: v1:OIaEfSH/Zi+Cx4xN:gxfyu42ieyWreccgmnbPDCBxnM5MAZbeDKJnIRlvp8Wvu87QhI+fFeEUtr+T3cPJVSvGiBipllOsETbkijSShL1TcTu+WDPmXtrRsSSBhWk=
   ecommerce:env_vars:

--- a/src/ol_infrastructure/applications/unified_ecommerce/Pulumi.applications.unified_ecommerce.QA.yaml
+++ b/src/ol_infrastructure/applications/unified_ecommerce/Pulumi.applications.unified_ecommerce.QA.yaml
@@ -10,8 +10,10 @@ config:
     secure: v1:OIaEfSH/Zi+Cx4xN:gxfyu42ieyWreccgmnbPDCBxnM5MAZbeDKJnIRlvp8Wvu87QhI+fFeEUtr+T3cPJVSvGiBipllOsETbkijSShL1TcTu+WDPmXtrRsSSBhWk=
   ecommerce:env_vars:
     CELERY_TASK_ALWAYS_EAGER: "False"
-    CSRF_ALLOWED_ORIGINS: '["https://pay-qa.ol.mit.edu", "https://api-pay-qa.ol.mit.edu"]'
-    CSRF_TRUSTED_ORIGINS: '["https://pay-qa.ol.mit.edu", "https://api-pay-qa.ol.mit.edu"]'
+    CSRF_ALLOWED_ORIGINS: '["https://pay-qa.ol.mit.edu", "https://api-pay-qa.ol.mit.edu",
+      "https://api.rc.learn.mit.edu", "https://rc.learn.mit.edu"]'
+    CSRF_TRUSTED_ORIGINS: '["https://pay-qa.ol.mit.edu", "https://api-pay-qa.ol.mit.edu",
+      "https://api.rc.learn.mit.edu", "https://rc.learn.mit.edu"]'
     DEBUG: "true"
     DEV_ENV: "true"
     ENVIRONMENT: "dev"

--- a/src/ol_infrastructure/applications/unified_ecommerce/__main__.py
+++ b/src/ol_infrastructure/applications/unified_ecommerce/__main__.py
@@ -1133,8 +1133,7 @@ gh_workflow_api_base_env_var = github.ActionsVariable(
     f"unified-ecommerce-gh-workflow-api-base-env-variable-{stack_info.env_suffix}",
     repository=gh_repo.name,
     variable_name=f"API_BASE_{env_var_suffix}",  # pragma: allowlist secret
-    # SWITCHOVER : Update to learn_api_domain
-    value=f"https://{ecommerce_api_domain}",
+    value=f"https://{learn_api_domain}/commerce",
     opts=ResourceOptions(provider=github_provider, delete_before_replace=True),
 )
 

--- a/src/ol_infrastructure/applications/unified_ecommerce/__main__.py
+++ b/src/ol_infrastructure/applications/unified_ecommerce/__main__.py
@@ -981,7 +981,7 @@ mit_learn_ecommerce_https_apisix_route = kubernetes.apiextensions.CustomResource
             {
                 # wildcard route for the rest of the system - auth required
                 "name": "ue-default",
-                "priority": 0,
+                "priority": 100,
                 "plugins": [
                     proxy_rewrite_plugin_config,
                     # Ref: https://apisix.apache.org/docs/apisix/plugins/openid-connect/
@@ -1022,7 +1022,7 @@ mit_learn_ecommerce_https_apisix_route = kubernetes.apiextensions.CustomResource
             # Strip trailing slack from logout redirect
             {
                 "name": "ue-logout-redirect",
-                "priority": 0,
+                "priority": 100,
                 "plugins": [
                     proxy_rewrite_plugin_config,
                     {

--- a/src/ol_infrastructure/applications/unified_ecommerce/__main__.py
+++ b/src/ol_infrastructure/applications/unified_ecommerce/__main__.py
@@ -926,6 +926,17 @@ ecommerce_https_apisix_route = kubernetes.apiextensions.CustomResource(
     ),
 )
 
+proxy_rewrite_plugin_config = {
+    "name": "proxy-rewrite",
+    "enable": True,
+    "config": {
+        "regex_uri": [
+            "/commerce/(.*)",
+            "/$1",
+        ],
+    },
+}
+
 # New ApisixRoute object for the learn.mit.edu address
 # All paths prefixed with /commerce
 # Host match is only the mit-learn domain
@@ -943,7 +954,8 @@ mit_learn_ecommerce_https_apisix_route = kubernetes.apiextensions.CustomResource
             {
                 # unauthenticated routes, including assests and checkout callback API
                 "name": "ue-unauth",
-                "priority": 1,
+                "priority": 100,
+                "plugins": [proxy_rewrite_plugin_config],
                 "match": {
                     "hosts": [
                         learn_api_domain,
@@ -971,6 +983,7 @@ mit_learn_ecommerce_https_apisix_route = kubernetes.apiextensions.CustomResource
                 "name": "ue-default",
                 "priority": 0,
                 "plugins": [
+                    proxy_rewrite_plugin_config,
                     # Ref: https://apisix.apache.org/docs/apisix/plugins/openid-connect/
                     {
                         "name": "openid-connect",
@@ -1011,11 +1024,12 @@ mit_learn_ecommerce_https_apisix_route = kubernetes.apiextensions.CustomResource
                 "name": "ue-logout-redirect",
                 "priority": 0,
                 "plugins": [
+                    proxy_rewrite_plugin_config,
                     {
                         "name": "redirect",
                         "enable": True,
                         "config": {
-                            "uri": "/logout",
+                            "uri": "/commerce/logout",
                         },
                     },
                 ],

--- a/src/ol_infrastructure/applications/unified_ecommerce/__main__.py
+++ b/src/ol_infrastructure/applications/unified_ecommerce/__main__.py
@@ -779,9 +779,9 @@ mit_learn_oidc_secret = OLVaultK8SSecret(
     resource_config=OLVaultK8SStaticSecretConfig(
         name="mit-learn-oidc-static-secrets",
         namespace=ecommerce_namespace,
-        labels=application_labels,
+        labels=k8s_global_labels,
         dest_secret_name=mit_learn_oidc_secret_name,
-        dest_secret_labels=application_labels,
+        dest_secret_labels=k8s_global_labels,
         mount="secret-operations",
         mount_type="kv-v1",
         path="sso/mitlearn",
@@ -973,8 +973,8 @@ mit_learn_ecommerce_https_apisix_route = kubernetes.apiextensions.CustomResource
                 "plugin_config_name": shared_plugin_config_name,
                 "backends": [
                     {
-                        "serviceName": ecommerce_service_name,
-                        "servicePort": ecommerce_service_port_name,
+                        "serviceName": ol_k8s_application.application_lb_service_name,
+                        "servicePort": ol_k8s_application.application_lb_service_port_name,  # noqa: E501
                     }
                 ],
             },
@@ -1014,8 +1014,8 @@ mit_learn_ecommerce_https_apisix_route = kubernetes.apiextensions.CustomResource
                 },
                 "backends": [
                     {
-                        "serviceName": ecommerce_service_name,
-                        "servicePort": ecommerce_service_port_name,
+                        "serviceName": ol_k8s_application.application_lb_service_name,
+                        "servicePort": ol_k8s_application.application_lb_service_port_name,  # noqa: E501
                     }
                 ],
             },
@@ -1043,8 +1043,8 @@ mit_learn_ecommerce_https_apisix_route = kubernetes.apiextensions.CustomResource
                 },
                 "backends": [
                     {
-                        "serviceName": ecommerce_service_name,
-                        "servicePort": ecommerce_service_port_name,
+                        "serviceName": ol_k8s_application.application_lb_service_name,
+                        "servicePort": ol_k8s_application.application_lb_service_port_name,  # noqa: E501
                     }
                 ],
             },
@@ -1052,7 +1052,7 @@ mit_learn_ecommerce_https_apisix_route = kubernetes.apiextensions.CustomResource
     },
     opts=ResourceOptions(
         delete_before_replace=True,
-        depends_on=[ecommerce_service],
+        depends_on=[ol_k8s_application],
     ),
 )
 


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6892

### Description (What does it do?)
Adds ApisixRoutes for consolidating API endpoints at api.learn.mit.edu or api.rc.learn.mit.edu and adds prefixes. Additionally this should not disrupt an existing URLs and endpoints but does mark them as legacy and for removal. 

