### PR TITLE
Fix mediaconvert component resource for use with OVS and OCW Studio

### DIFF
--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -124,7 +124,7 @@ s3.BucketPolicy(
 # Get the standard MediaConvert policy statements
 mediaconvert_policy_statements = OLMediaConvert.get_standard_policy_statements(
     stack_info.env_suffix,
-    aws_account.id,
+    service_name="ocw-studio",
 )
 
 ocw_studio_iam_policy = iam.Policy(
@@ -318,6 +318,7 @@ ocw_starter_webhook = github.RepositoryWebhook(
 
 # Setup AWS MediaConvert Queue
 ocw_studio_mediaconvert_config = MediaConvertConfig(
+    service_name="ocw-studio",
     env_suffix=stack_info.env_suffix,
     tags=aws_config.tags,
     policy_arn=ocw_studio_iam_policy.arn,

--- a/src/ol_infrastructure/components/aws/mediaconvert.py
+++ b/src/ol_infrastructure/components/aws/mediaconvert.py
@@ -194,7 +194,6 @@ class OLMediaConvert(ComponentResource):
 
         Args:
             stack_info: Stack information including environment details
-            account_id: AWS account ID where the role exists
             service_name: Name of the service using MediaConvert
                 (e.g., 'ovs', 'ocw-studio')
 


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
The initial pass of the mediaconvert component resource threw errors and wouldn't execute. This addresses those failures.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
The changes have been applied manually in OVS CI and mediaconvert functionality can be tested there.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
We will want to be careful applying this to OCW Studio because it will delete and re-create the mediaconvert resources. Presumably that won't cause any errors, but I'm not certain of how that service works and whether continuity of the resource is required.

<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
