### PR TITLE
Adjust apisix login, post_logout_redirect-uri for mit-learn

### DIFF
--- a/src/ol_infrastructure/applications/mitlearn/__main__.py
+++ b/src/ol_infrastructure/applications/mitlearn/__main__.py
@@ -916,7 +916,7 @@ base_oidc_plugin_config = {
     "introspection_endpoint_auth_method": "client_secret_basic",
     "ssl_verify": False,
     "logout_path": "/logout/oidc",
-    "post_logout_redirect_uri": "/logout/",
+    "post_logout_redirect_uri": f"{mitlearn_config.require('api_domain')}/logout/",
 }
 
 shared_plugin_config_name = "shared-plugin-config"
@@ -1061,6 +1061,7 @@ learn_external_service_apisix_route = kubernetes.apiextensions.CustomResource(
                     ],
                     "paths": [
                         "/admin/login/*",
+                        "/login",
                         "/login/*",
                     ],
                 },

--- a/src/ol_infrastructure/applications/mitlearn/__main__.py
+++ b/src/ol_infrastructure/applications/mitlearn/__main__.py
@@ -916,7 +916,7 @@ base_oidc_plugin_config = {
     "introspection_endpoint_auth_method": "client_secret_basic",
     "ssl_verify": False,
     "logout_path": "/logout/oidc",
-    "post_logout_redirect_uri": f"{mitlearn_config.require('api_domain')}/logout/",
+    "post_logout_redirect_uri": f"https://{mitlearn_config.require('api_domain')}/logout/",
 }
 
 shared_plugin_config_name = "shared-plugin-config"


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Tweaks apisix login and post-logout settings for mit-learn

### How can this be tested?
Login and logout should hopefully work for mit-learn on rc and prod

