### PR TITLE
Test adding renew_access_token_on_expiry on logout

### DIFF
--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -1176,6 +1176,7 @@ base_oidc_plugin_config = {
     "bearer_only": False,
     "introspection_endpoint_auth_method": "client_secret_post",
     "ssl_verify": False,
+    "renew_access_token_on_expiry": True,
     "logout_path": "/logout",
     "post_logout_redirect_uri": "/",
 }

--- a/src/ol_infrastructure/applications/mitlearn/__main__.py
+++ b/src/ol_infrastructure/applications/mitlearn/__main__.py
@@ -1103,6 +1103,7 @@ base_oidc_plugin_config = {
     "bearer_only": False,
     "introspection_endpoint_auth_method": "client_secret_basic",
     "ssl_verify": False,
+    "renew_access_token_on_expiry": True,
     "logout_path": "/learn/logout/oidc",
     "post_logout_redirect_uri": f"https://{mitlearn_config.require('api_domain')}/learn/logout/",
 }


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
Change to test whether this resolves `logout` issues that we're encountering when a user logs out after the Keycloak token has expired. The error reported is:
```
Missing parameters: id_token_hint
```

The assumption is that with this change, apisix would make a request to Keycloak to renew the token and thus when a user tries to logout, the request will include the `id_token_hint` in it.