### PR TITLE
Added renew_access_token_on_expiry

### DIFF
--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -1177,6 +1177,7 @@ base_oidc_plugin_config = {
     "introspection_endpoint_auth_method": "client_secret_post",
     "ssl_verify": False,
     "renew_access_token_on_expiry": True,
+    "refresh_session_interval": 1800,
     "logout_path": "/logout",
     "post_logout_redirect_uri": "/",
 }

--- a/src/ol_infrastructure/applications/mitlearn/__main__.py
+++ b/src/ol_infrastructure/applications/mitlearn/__main__.py
@@ -1104,6 +1104,7 @@ base_oidc_plugin_config = {
     "introspection_endpoint_auth_method": "client_secret_basic",
     "ssl_verify": False,
     "renew_access_token_on_expiry": True,
+    "refresh_session_interval": 1800,
     "logout_path": "/learn/logout/oidc",
     "post_logout_redirect_uri": f"https://{mitlearn_config.require('api_domain')}/learn/logout/",
 }


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
Change to test whether this resolves `logout` issues that we're encountering when a user logs out after the Keycloak token has expired. The error reported is:
```
Missing parameters: id_token_hint
```

The assumption is that with this change, apisix would make a request to Keycloak to renew the token and thus when a user tries to logout, the request will include the `id_token_hint` in it.