### PR TITLE
Slightly alter mit-learn CSRF cookie names to see if it fixes 400 errors for some users

### DIFF
--- a/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.Production.yaml
+++ b/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.Production.yaml
@@ -31,7 +31,7 @@ config:
   heroku_app:vars:
     APPZI_URL: "https://w.appzi.io/w.js?token=Q2pSI"
     CELERY_WORKER_MAX_MEMORY_PER_CHILD: 250000
-    CSRF_COOKIE_NAME: "learn-csrftoken"
+    CSRF_COOKIE_NAME: "learn_csrftoken"
     DEBUG: "false"
     EDX_LEARNING_COURSE_BUCKET_NAME: "edxorg-production-edxapp-courses"
     ENABLE_INFINITE_CORRIDOR: "true"

--- a/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.QA.yaml
+++ b/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.QA.yaml
@@ -9,7 +9,7 @@ config:
   heroku_app:vars:
     APPZI_URL: ""
     CELERY_WORKER_MAX_MEMORY_PER_CHILD: 125000
-    CSRF_COOKIE_NAME: "learn-rc-csrftoken"
+    CSRF_COOKIE_NAME: "learn_rc_csrftoken"
     DEBUG: "false"
     EDX_LEARNING_COURSE_BUCKET_NAME: "edxorg-qa-edxapp-courses"
     ENABLE_INFINITE_CORRIDOR: "true"


### PR DESCRIPTION

### What are the relevant tickets?
Potentially related to https://github.com/mitodl/hq/issues/6960

### Description (What does it do?)
<!--- Describe your changes in detail -->
Slightly alters the CSRF cookie names for mit-learn (rc and prod)



### How can this be tested?
Once the changes are in RC, users who are still experiencing 400 errors on login should try again.

