### PR TITLE
Rename SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS to ALLOWED_REDIRECT_HOSTS (mit-learn)

### DIFF
--- a/src/ol_infrastructure/applications/mitlearn/__main__.py
+++ b/src/ol_infrastructure/applications/mitlearn/__main__.py
@@ -1357,7 +1357,7 @@ heroku_interpolated_vars = {
     "MITOL_CORS_ORIGIN_WHITELIST": cors_urls_json,
     "OIDC_ENDPOINT": f"https://{interpolation_vars['sso_url']}/realms/olapps",
     "SESSION_COOKIE_DOMAIN": session_cookie_domain,
-    "SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS": auth_allowed_redirect_hosts_json,
+    "ALLOWED_REDIRECT_HOSTS": auth_allowed_redirect_hosts_json,
     "SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT": f"https://{interpolation_vars['sso_url']}/realms/olapps",
     "USERINFO_URL": f"https://{interpolation_vars['sso_url']}/realms/olapps/protocol/openid-connect/userinfo",
 }


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/6923 and https://github.com/mitodl/hq/issues/6885

### Description (What does it do?)
Renames SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS to ALLOWED_REDIRECT_HOSTS (mit-learn)


### How can this be tested?
N/A
