### PR TITLE
alloy k8s helm chart updates

### DIFF
--- a/src/ol_infrastructure/substructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/substructure/aws/eks/__main__.py
@@ -620,10 +620,11 @@ alloy_release = kubernetes.helm.v3.Release(
                         "name": "otlp",
                         "port": 4317,
                         "targetPort": 4317,
+                        "appProtocol": "grpc",
                     },
                     {
                         "name": "otlp-http",
-                        "port": 4317,
+                        "port": 4318,
                         "targetPort": 4318,
                     },
                 ],

--- a/src/ol_infrastructure/substructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/substructure/aws/eks/__main__.py
@@ -615,6 +615,18 @@ alloy_release = kubernetes.helm.v3.Release(
                         },
                     },
                 ],
+                "extraPorts": [
+                    {
+                        "name": "otlp",
+                        "port": 4317,
+                        "targetPort": 4317,
+                    },
+                    {
+                        "name": "otlp-http",
+                        "port": 4317,
+                        "targetPort": 4318,
+                    },
+                ],
             },
             "serviceAccount": {
                 "create": True,


### PR DESCRIPTION
### Description (What does it do?)
Updated grafana alloy config to listen for OTEL metrics.

You can send metrics to `grafana-alloy.operations.svc.cluster.local` 

ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#services