### PR TITLE
Safely migrate to appdb component

### DIFF
--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -11,15 +11,21 @@ import pulumi_fastly as fastly
 import pulumi_github as github
 import pulumi_kubernetes as kubernetes
 import pulumi_vault as vault
-from pulumi import Config, InvokeOptions, Output, ResourceOptions, StackReference
+from pulumi import (
+    ROOT_STACK_RESOURCE,
+    Alias,
+    Config,
+    InvokeOptions,
+    Output,
+    ResourceOptions,
+    StackReference,
+)
 from pulumi_aws import ec2, get_caller_identity, iam, route53, s3
 
 from bridge.lib.constants import FASTLY_A_TLS_1_3
 from bridge.lib.magic_numbers import (
-    AWS_RDS_DEFAULT_DATABASE_CAPACITY,
     DEFAULT_HTTPS_PORT,
     DEFAULT_NGINX_PORT,
-    DEFAULT_POSTGRES_PORT,
     DEFAULT_REDIS_PORT,
     DEFAULT_UWSGI_PORT,
     ONE_MEGABYTE_BYTE,
@@ -27,16 +33,14 @@ from bridge.lib.magic_numbers import (
 from bridge.secrets.sops import read_yaml_secrets
 from bridge.settings.github.team_members import DEVOPS_MIT
 from ol_infrastructure.components.aws.cache import OLAmazonCache, OLAmazonRedisConfig
-from ol_infrastructure.components.aws.database import OLAmazonDB, OLPostgresDBConfig
 from ol_infrastructure.components.aws.eks import OLEKSTrustRole, OLEKSTrustRoleConfig
+from ol_infrastructure.components.services import appdb
 from ol_infrastructure.components.services.vault import (
-    OLVaultDatabaseBackend,
     OLVaultK8SDynamicSecretConfig,
     OLVaultK8SResources,
     OLVaultK8SResourcesConfig,
     OLVaultK8SSecret,
     OLVaultK8SStaticSecretConfig,
-    OLVaultPostgresDatabaseConfig,
 )
 from ol_infrastructure.lib.aws.cache_helper import CacheInstanceTypes
 from ol_infrastructure.lib.aws.eks_helper import (
@@ -46,7 +50,6 @@ from ol_infrastructure.lib.aws.eks_helper import (
     setup_k8s_provider,
 )
 from ol_infrastructure.lib.aws.iam_helper import IAM_POLICY_VERSION, lint_iam_policy
-from ol_infrastructure.lib.aws.rds_helper import DBInstanceTypes
 from ol_infrastructure.lib.consul import get_consul_provider
 from ol_infrastructure.lib.fastly import (
     build_fastly_log_format_string,
@@ -54,7 +57,6 @@ from ol_infrastructure.lib.fastly import (
 )
 from ol_infrastructure.lib.ol_types import AWSBase
 from ol_infrastructure.lib.pulumi_helper import parse_stack
-from ol_infrastructure.lib.stack_defaults import defaults
 from ol_infrastructure.lib.vault import setup_vault_provider
 
 aws_account = get_caller_identity()
@@ -521,62 +523,20 @@ learn_ai_application_security_group = ec2.SecurityGroup(
 
 ################################################
 # RDS configuration and networking setup
-learn_ai_database_security_group = ec2.SecurityGroup(
-    f"learn-ai-db-security-group-{stack_info.env_suffix}",
-    name=f"learn-ai-db-security-group-{stack_info.env_suffix}",
-    description="Access control for the learn-ai database.",
-    ingress=[
-        ec2.SecurityGroupIngressArgs(
-            security_groups=[
-                vault_stack.require_output("vault_server")["security_group"],
-            ],
-            protocol="tcp",
-            from_port=DEFAULT_POSTGRES_PORT,
-            to_port=DEFAULT_POSTGRES_PORT,
-            description="Access to postgres from consul and vault.",
-        ),
-        ec2.SecurityGroupIngressArgs(
-            security_groups=[learn_ai_application_security_group.id],
-            protocol="tcp",
-            from_port=DEFAULT_POSTGRES_PORT,
-            to_port=DEFAULT_POSTGRES_PORT,
-            description="Allow application pods to talk to DB",
-        ),
-    ],
-    vpc_id=apps_vpc["id"],
-    tags=aws_config.tags,
-)
 
-rds_defaults = defaults(stack_info)["rds"]
-rds_defaults["instance_size"] = (
-    learn_ai_config.get("db_instance_size") or DBInstanceTypes.small.value
+learn_ai_db_config = appdb.OLAppDatabaseConfig(
+    app_name="learn-ai",
+    app_security_group=learn_ai_application_security_group,
+    app_db_name="learnai",
+    aws_config=aws_config,
+    app_vpc=apps_vpc,
+    app_db_password=learn_ai_config.get("db_password"),
+    alias_map={
+        appdb.AliasKey.secgroup: [Alias(parent=ROOT_STACK_RESOURCE)],
+        appdb.AliasKey.db: [Alias(parent=ROOT_STACK_RESOURCE)],
+    },
 )
-
-learn_ai_db_config = OLPostgresDBConfig(
-    instance_name=f"learn-ai-db-{stack_info.env_suffix}",
-    password=learn_ai_config.get("db_password"),
-    subnet_group_name=apps_vpc["rds_subnet"],
-    security_groups=[learn_ai_database_security_group],
-    storage=learn_ai_config.get("db_capacity")
-    or str(AWS_RDS_DEFAULT_DATABASE_CAPACITY),
-    engine_major_version="16",
-    tags=aws_config.tags,
-    db_name="learnai",
-    **defaults(stack_info)["rds"],
-)
-learn_ai_db = OLAmazonDB(learn_ai_db_config)
-
-learn_ai_db_vault_backend_config = OLVaultPostgresDatabaseConfig(
-    db_name=learn_ai_db_config.db_name,
-    mount_point=f"{learn_ai_db_config.engine}-learn-ai",
-    db_admin_username=learn_ai_db_config.username,
-    db_admin_password=learn_ai_config.get("db_password"),
-    db_host=learn_ai_db.db_instance.address,
-)
-learn_ai_db_vault_backend = OLVaultDatabaseBackend(
-    learn_ai_db_vault_backend_config,
-    opts=ResourceOptions(delete_before_replace=True, parent=learn_ai_db),
-)
+learn_ai_db = appdb.OLAppDatabase(learn_ai_db_config)
 
 # Redis Cluster configuration and networking setup
 redis_config = Config("redis")
@@ -656,7 +616,11 @@ vault_k8s_resources = OLVaultK8SResources(
 
 # Load the database creds into a k8s secret via VSO
 db_creds_secret_name = "pgsql-db-creds"  # noqa: S105  # pragma: allowlist secret
-db_creds_secret = Output.all(address=learn_ai_db.db_instance.address).apply(
+db_creds_secret = Output.all(
+    address=learn_ai_db.app_db.db_instance.address,
+    port=learn_ai_db.app_db.db_instance.port,
+    db_name=learn_ai_db.app_db.db_instance.db_name,
+).apply(
     lambda db: OLVaultK8SSecret(
         f"learn-ai-{stack_info.env_suffix}-db-creds-secret",
         OLVaultK8SDynamicSecretConfig(
@@ -665,19 +629,19 @@ db_creds_secret = Output.all(address=learn_ai_db.db_instance.address).apply(
             dest_secret_labels=k8s_global_labels,
             dest_secret_name=db_creds_secret_name,
             labels=k8s_global_labels,
-            mount=learn_ai_db_vault_backend_config.mount_point,
+            mount=learn_ai_db.app_db_vault_backend.db_mount.path,
             path="creds/app",
             restart_target_kind="Deployment",
             restart_target_name="learn-ai-app",
             templates={
-                "DATABASE_URL": f'postgres://{{{{ get .Secrets "username"}}}}:{{{{ get .Secrets "password" }}}}@{db["address"]}:{learn_ai_db_config.port}/{learn_ai_db_config.db_name}',
+                "DATABASE_URL": f'postgres://{{{{ get .Secrets "username"}}}}:{{{{ get .Secrets "password" }}}}@{db["address"]}:{db["port"]}/{db["db_name"]}',
             },
             vaultauth=vault_k8s_resources.auth_name,
         ),
         opts=ResourceOptions(
             delete_before_replace=True,
             parent=vault_k8s_resources,
-            depends_on=[learn_ai_db_vault_backend],
+            depends_on=[learn_ai_db],
         ),
     )
 )

--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -916,7 +916,7 @@ learn_ai_webapp_deployment_resource = kubernetes.apps.v1.Deployment(
     ),
     opts=ResourceOptions(
         delete_before_replace=True,
-        depends_on=[db_creds_secret, redis_creds],
+        depends_on=[learn_ai_db, db_creds_secret, redis_creds],
     ),
 )
 
@@ -968,7 +968,7 @@ learn_ai_celery_deployment_resource = kubernetes.apps.v1.Deployment(
     ),
     opts=ResourceOptions(
         delete_before_replace=True,
-        depends_on=[db_creds_secret, redis_creds],
+        depends_on=[learn_ai_db, db_creds_secret, redis_creds],
     ),
 )
 

--- a/src/ol_infrastructure/applications/unified_ecommerce/__main__.py
+++ b/src/ol_infrastructure/applications/unified_ecommerce/__main__.py
@@ -435,15 +435,12 @@ ecommerce_db_config: appdb.OLAppDatabaseConfig = appdb.OLAppDatabaseConfig(
     app_name="unified-ecommerce",
     app_security_group=ecommerce_application_security_group,
     app_db_name="ecommerce",
-    app_ou=aws_config.tags["OU"],
-    app_vpc_id=apps_vpc["id"],
-    target_vpc_name="applications",
+    app_vpc=apps_vpc,
     aws_config=aws_config,
     app_db_password=ecommerce_config.get("db_password"),
     alias_map={
         appdb.AliasKey.secgroup: [Alias(parent=ROOT_STACK_RESOURCE)],
         appdb.AliasKey.db: [Alias(parent=ROOT_STACK_RESOURCE)],
-        # appdb.AliasKey.vault: [Alias(parent=ROOT_STACK_RESOURCE)],
     },
 )
 
@@ -582,7 +579,7 @@ db_creds_secret = Output.all(
         opts=ResourceOptions(
             delete_before_replace=True,
             parent=vault_k8s_resources,
-            depends_on=[ecommerce_db.app_db_vault_backend],
+            depends_on=[ecommerce_db],
         ),
     )
 )

--- a/src/ol_infrastructure/applications/unified_ecommerce/__main__.py
+++ b/src/ol_infrastructure/applications/unified_ecommerce/__main__.py
@@ -653,6 +653,7 @@ ecommerce_k8s_config: OLApplicationK8sConfiguration = OLApplicationK8sConfigurat
 
 ol_k8s_application = OLApplicationK8s(
     ol_app_k8s_config=ecommerce_k8s_config,
+    opts=ResourceOptions(depends_on=ecommerce_db),
 )
 
 

--- a/src/ol_infrastructure/components/aws/database.py
+++ b/src/ol_infrastructure/components/aws/database.py
@@ -202,7 +202,7 @@ class OLAmazonDB(pulumi.ComponentResource):
             opts,
         )
 
-        resource_options = pulumi.ResourceOptions(parent=self).merge(opts)
+        resource_options = pulumi.ResourceOptions(parent=self)
 
         # In order to update the minor versions of an RDS instance with a read replica,
         # the replica has to be upgraded prior to the primary. This block of logic

--- a/src/ol_infrastructure/components/services/k8s.py
+++ b/src/ol_infrastructure/components/services/k8s.py
@@ -90,7 +90,7 @@ class OLApplicationK8s(ComponentResource):
             None,
             opts=opts,
         )
-        resource_options = ResourceOptions(parent=self).merge(opts)
+        resource_options = ResourceOptions(parent=self)
         self.application_lb_service_name: str = (
             ol_app_k8s_config.application_lb_service_name
         )

--- a/src/ol_infrastructure/components/services/vault.py
+++ b/src/ol_infrastructure/components/services/vault.py
@@ -124,7 +124,7 @@ class OLVaultDatabaseBackend(ComponentResource):
             opts,
         )
 
-        resource_opts = ResourceOptions.merge(ResourceOptions(parent=self), opts)
+        resource_opts = ResourceOptions(parent=self)
 
         self.db_mount = Mount(
             f"{db_config.db_name}-mount-point",
@@ -638,7 +638,7 @@ class OLVaultK8SSecretConfig(BaseModel):
     includes: Optional[list[str]] = []
     kind: str
     labels: Optional[dict[str, str]] = None
-    mount: str
+    mount: str | Output[str]
     mount_type: Optional[Literal["kv-v1", "kv-v2"]] = None
     name: str
     refresh_after: Optional[str] = None

--- a/src/ol_infrastructure/lib/stack_defaults.py
+++ b/src/ol_infrastructure/lib/stack_defaults.py
@@ -29,7 +29,7 @@ qa_defaults = {
 
 ci_defaults = {
     "rds": {
-        "instance_size": DBInstanceTypes.medium.value,
+        "instance_size": DBInstanceTypes.small.value,
         "multi_az": False,
         "prevent_delete": False,
         "take_final_snapshot": False,


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Allows for safely migrating to the higher level OLAppDatabase component for stacks that are already using the OLAmazonDB and OLVaultDatabaseBackend.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run a `pulumi up` against the learn-ai CI stack and see that the only changes are for the Vault mount. The database and security group resources are safely maintained.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
I wasn't able to cleanly get the Vault component to be re-parented because it was already a child of the OLAmazonDB. I think it's possible, but it's not a big deal if we let it get recreated.

The Unified Ecommerce diff will be noisier because it was trying to build against the wrong Consul cluster to begin with, so that will actually destroy/replace the DB resource, but that app isn't a production dependency so it's ok to make that change.

<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
