### PR TITLE
feat: add external course sync email recipients

### DIFF
--- a/src/bridge/secrets/xpro/secrets.production.yaml
+++ b/src/bridge/secrets/xpro/secrets.production.yaml
@@ -18,6 +18,7 @@ emeritus:
   api_key: ENC[AES256_GCM,data:KBxc9jSCWdskRP42e0jIZMhY5+cnQUI7j6OfNVGL6qlK8e/IuoJPtg==,iv:rdhHKQsfipK9ms1hV75pNnS6uCwD7Pwcd9UjMuVvGhU=,tag:QG31QLu4dn75AM1xilTq9g==,type:str]
 external-course-sync:
   api_key: ENC[AES256_GCM,data:1bt5n/ww1kCmjNd269obiY87GRG5Ids/o9JybZZSlbOSoVzB9mneKg==,iv:3ydSRksHNFI/90rkvCi+s43uQtuCV75PVv+BoWsTU2k=,tag:3E8VZBAfm0injNtqjnCgkw==,type:str]
+  email-recipients: ENC[AES256_GCM,data:9vrbC/a/PL7kSvQHjfo=,iv:VchJtbiTpSSfvr6QIeac3wgFoW+Z7is9Iz8E2uVP5+o=,tag:OrpXXvM3yJuFk0fi1T7AKg==,type:str]
 google-sheets:
   admin_emails: ENC[AES256_GCM,data:BzzXBrwBVGT9SK/wQn6LFcFtv92Ez3rnH0t5ex+OjRSswf1UzIhJvb481drf0IK1W5PU/yMxd4wSp2+1QO+IQtS0WoJAjT6TIkk7Q2Nzbs2GmTJ7oKRrp4g9HvZbUZYNvp9Lo2lTwQj1HAGWTZfuP3UGxMSCHJmmDhK9QJLoeS0N/46xD6KPtXbwVSMMlwX14R6f03rlLIJ2x9eRwI3q3kysXSoZ1vwrjLkISRW/Lm52wIrnJOHdjUPLwM6dVnx7vyVh7LbFIvO3ryI2rAASZ4Vpo+lkoVRMId4ilJpbHPBg1amUdeOzPXkTJMKWXvQiBGLWGjdh7Mr34F2WCo+Wvenf,iv:T6+yD4oTKUMeggYI/QgFeKJa6ZcA5aMZ/ZNFdObjjPo=,tag:Ugb0SVVdgc9Yck3SH2M/bA==,type:str]
   deferral_worksheet_id: ENC[AES256_GCM,data:amxvArjdNukohQ==,iv:6s0YO1nBu6ZGz4+SATs25QmxKlzxlaK793skZ674ww4=,tag:sBjL4iXmV6kKasvceB5fIQ==,type:int]
@@ -76,8 +77,8 @@ sops:
     created_at: "2024-01-24T20:22:29Z"
     enc: vault:v1:RPwGIhH3XI6PuKWF10YLU93NnxzMG03C4s8keU3UdKVoxhTnQNfGxSLNGjpl6A3r7J4PpgqouLv1MyJG
   age: []
-  lastmodified: "2025-03-12T19:45:34Z"
-  mac: ENC[AES256_GCM,data:wMAbXXVD6X1/ZVD/qaYDHLt2ka0LTgZv0LVADM0yogCoBS5aSrhxBFnaintovOOdEv99yaLXahF4Noul2nsvuQAQs/BhQ2oWZ9Bg7Spghe5hMJhU3mhRvq8WEqKnh2cBsyeWs++g0ROj1b5lv9qxkdN9SjI5ma74aj71HLxfwWY=,iv:dQjq/MRsOXK4txPwH+oo1wzWQlvQHSs7GqLPYJoEa6Q=,tag:JovMS9RaXc8S9QvRzOGClA==,type:str]
+  lastmodified: "2025-03-28T13:00:08Z"
+  mac: ENC[AES256_GCM,data:QJAueJb8fldnmYyWg9FCOAuGNi7Pw+zD1nQYQbg64gnEoMmi1H22bRGPjlRC1S38zb53QRY5SZCWmQErEWoCXUoA/qq48SWOZb+gO+CtjmFIakEb6iFpAKjUxg4020FZzIJPwkpWqkl86S8WQhoVQ7vLvmQ5Fgp2y4negR3XYHQ=,iv:09PulJWd7cXkfM4cxyqwt1ycEFm97+Ux8SretH38Mng=,tag:86CV5nnj5dF5Vz38IwBNtg==,type:str]
   pgp:
   - created_at: "2024-01-24T20:22:29Z"
     enc: |-

--- a/src/bridge/secrets/xpro/secrets.qa.yaml
+++ b/src/bridge/secrets/xpro/secrets.qa.yaml
@@ -18,6 +18,7 @@ emeritus:
   api_key: ENC[AES256_GCM,data:QSQf+mNwbh4zfYkWEKNHFbZ9CDL80HVHZ3bOL/Vip2yRsnexHePSKA==,iv:0lU8FUrgtDGn+l0E2U0YpM1XJQ0N0qal2gNSVogkYYE=,tag:70Uig4ZxV1oJ3Z1CiFCWpw==,type:str]
 external-course-sync:
   api_key: ENC[AES256_GCM,data:mBhTm7YCHVFsEWi1FrBUS7ROWwafMQYixYS2bkDfeM+4EZFgnNgMOA==,iv:sB0CbFFVquEaQLaJLvSUDRK/zH+k/xyFa3RytDOtLYU=,tag:eJnjw3qaZtld6SQanNzcIw==,type:str]
+  email-recipients: ENC[AES256_GCM,data:j1JaseGedZY8shrpAA4=,iv:41oZolk61j+k8dCUQVfR3Dp+4jK7YCbRzzt//mAWD0Y=,tag:NCEAgUG0jIGQVFFDzQcFhA==,type:str]
 google-sheets:
   admin_emails: ENC[AES256_GCM,data:T4xA9lFS9hYyU2w/cQg+16Eyadi2bwhi4zpd7CiTBg1dXrABm8BcK3HNODcsagsXPQ4R5gZoRg3iCbeh,iv:9o83An92q9r/P+KvQAmVvxM8NJnu09tGTR6OTNkvBgM=,tag:Cr+oZIbQQ6n3xu7JPA7rbA==,type:str]
   deferral_worksheet_id: ENC[AES256_GCM,data:2gjUHM3QiAsO,iv:f2IRy0nNU9/YATiWyIkTpFceECnHEtP/dqyK0VsUdqc=,tag:tH3uALnyTJTU063lh1bPKA==,type:int]
@@ -76,8 +77,8 @@ sops:
     created_at: "2024-01-24T20:20:19Z"
     enc: vault:v1:4YxP4nojlHbL45TdbZ73pGe7XfQrCbwLoN2bDeq5qO6Roj4waUZzrwhAVGAQfuw0T7XUAJbHkeblG01t
   age: []
-  lastmodified: "2025-01-10T17:23:48Z"
-  mac: ENC[AES256_GCM,data:+NPzZA6bKWWij8XNZgkqjCk1edi/g0rMjR7OOP9p3CxW0ahcYRaMYZQ7HMmt0DL/kfg2Jv2If9FjeOpqgeLCkaOSraT0aT9M7/ogRbJiVm/BWNRcHWoQwFqNXxLbShZYYrBX1mO+UdRqxfcuIDtSX8uyX9lykFM7+iSyjhMrWJ4=,iv:538DCyEKyEP4Fd2cq95euO+c62zQHPJiAPkaCihXwpI=,tag:yiXfYXXppc6fVh5kPJr2gQ==,type:str]
+  lastmodified: "2025-03-28T12:59:37Z"
+  mac: ENC[AES256_GCM,data:5fItRcELFHpW1y/xBbHKNskh+rboKnGlXPz/KBYaqtpjVBwvKQdaXUQwJNHly3PHyXb/r1zt53xd4Gl5ruXcmE2slrkzWrrmj+bdDDSQfc1sP9LIum7EENXW7nNcCGGwUBvAx9O8NbMcP+Dg6KvzF26Bh1OLcjvwsUV9N9H89wM=,iv:dYVUBogZIXbZvLNysHUq6g9hu7rQ9jizKNtchmL6FC4=,tag:H7dBxgctKgVRWLq1YGxUiw==,type:str]
   pgp:
   - created_at: "2024-01-24T20:20:19Z"
     enc: |-

--- a/src/ol_infrastructure/applications/xpro/__main__.py
+++ b/src/ol_infrastructure/applications/xpro/__main__.py
@@ -321,6 +321,9 @@ sensitive_heroku_vars = {
     "EXTERNAL_COURSE_SYNC_API_KEY": xpro_vault_secrets["external-course-sync"][
         "api_key"
     ],
+    "EXTERNAL_COURSE_SYNC_EMAIL_RECIPIENTS": xpro_vault_secrets[
+        "external-course-sync"
+    ]["email-recipients"],
     "HIREFIRE_TOKEN": xpro_vault_secrets["hirefire"]["token"],
     "MITOL_DIGITAL_CREDENTIALS_HMAC_SECRET": xpro_vault_secrets["digital-credentials"][
         "hmac_secret"

--- a/src/ol_infrastructure/applications/xpro/__main__.py
+++ b/src/ol_infrastructure/applications/xpro/__main__.py
@@ -321,9 +321,9 @@ sensitive_heroku_vars = {
     "EXTERNAL_COURSE_SYNC_API_KEY": xpro_vault_secrets["external-course-sync"][
         "api_key"
     ],
-    "EXTERNAL_COURSE_SYNC_EMAIL_RECIPIENTS": xpro_vault_secrets[
-        "external-course-sync"
-    ]["email-recipients"],
+    "EXTERNAL_COURSE_SYNC_EMAIL_RECIPIENTS": xpro_vault_secrets["external-course-sync"][
+        "email-recipients"
+    ],
     "HIREFIRE_TOKEN": xpro_vault_secrets["hirefire"]["token"],
     "MITOL_DIGITAL_CREDENTIALS_HMAC_SECRET": xpro_vault_secrets["digital-credentials"][
         "hmac_secret"


### PR DESCRIPTION
### What are the relevant tickets?
[#6769](https://github.com/mitodl/hq/issues/6769)

### Description (What does it do?)
 This PR adds config for enabling stat emails to be sent upon external course sync in xPRO:
     - EXTERNAL_COURSE_SYNC_EMAIL_RECIPIENTS - a list of email addresses to send the stat emails to
     
 Note: these emails are also required to be added into xpro_vault_secrets vault