### PR TITLE
OCW / MIT Learn integration env vars

### DIFF
--- a/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.Production.yaml
+++ b/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.Production.yaml
@@ -8,24 +8,25 @@ config:
   heroku:user: "odl-devops"
   heroku_app:interpolation_vars:
     auth_allowed_redirect_hosts:
+    - "draft.ocw.mit.edu"
     - "ocw.mit.edu"
     - ".mitopen.odl.mit.edu"  # legacy
     - ".learn.mit.edu"
     session_cookie_domain: ".learn.mit.edu"
     csrf_domains:
     - "https://api.learn.mit.edu"
+    - "https://learn.mit.edu"
     - "https://api.mitopen.odl.mit.edu"  # legacy
-    - "https://learn.mit.edu"
     - "https://mitopen.odl.mit.edu"  # legacy
-    cors_urls:
     - "https://draft.ocw.mit.edu"
-    - "https://live-qa.ocw.mit.edu"  # Why?
-    - "https://live.ocw.mit.edu"
-    - "https://learn.mit.edu"
-    - "https://mitopen.odl.mit.edu"  # legacy
-    - "https://ocw-preview.odl.mit.edu"
     - "https://ocw.mit.edu"
-    - "https://www.ocw.mit.edu"
+    cors_urls:
+    - "https://api.learn.mit.edu"
+    - "https://learn.mit.edu"
+    - "https://api.mitopen.odl.mit.edu"  # legacy
+    - "https://mitopen.odl.mit.edu"  # legacy
+    - "https://draft.ocw.mit.edu"
+    - "https://ocw.mit.edu"
     mailgun_sender_domain: "mail.learn.mit.edu"  # Need to verify
     sso_url: "sso.ol.mit.edu"
   heroku_app:vars:

--- a/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.QA.yaml
+++ b/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.QA.yaml
@@ -54,6 +54,7 @@ config:
     UWSGI_THREADS: 15
   heroku_app:interpolation_vars:
     auth_allowed_redirect_hosts:
+    - "draft-qa.ocw.mit.edu"
     - "live-qa.ocw.mit.edu"
     - "rc.learn.mit.edu"
     session_cookie_domain: ".rc.learn.mit.edu"
@@ -62,6 +63,8 @@ config:
     - "https://rc.learn.mit.edu"
     - "https://api.mitopen-rc.odl.mit.edu"  # legacy
     - "https://mitopen-rc.odl.mit.edu"  # legacy
+    - "https://draft-qa.ocw.mit.edu"
+    - "https://live-qa.ocw.mit.edu"
     cors_urls:
     - "https://mitopen-rc.odl.mit.edu" # legacy
     - "https://rc.learn.mit.edu"

--- a/src/ol_infrastructure/applications/ocw_studio/Pulumi.applications.ocw_studio.Production.yaml
+++ b/src/ol_infrastructure/applications/ocw_studio/Pulumi.applications.ocw_studio.Production.yaml
@@ -24,6 +24,8 @@ config:
     MAILGUN_FROM_EMAIL: 'MIT OCW <no-reply@ocw.mail.odl.mit.edu'
     MAILGUN_SENDER_DOMAIN: 'ocw.mail.odl.mit.edu'
     MAILGUN_URL: https://api.mailgun.net/v3/ocw.mail.odl.mit.edu
+    MIT_LEARN_BASE_URL: https://learn.mit.edu
+    MIT_LEARN_API_BASE_URL: https://api.learn.mit.edu
     OCW_COURSE_STARTER_SLUG: ocw-course-v2
     OCW_GTM_ACCOUNT_ID: GTM-NMQZ25T
     OCW_HUGO_THEMES_SENTRY_DSN: 'https://eee58f41dda54d2b814296e12dced4b7@o48788.ingest.sentry.io/5304953'

--- a/src/ol_infrastructure/applications/ocw_studio/Pulumi.applications.ocw_studio.QA.yaml
+++ b/src/ol_infrastructure/applications/ocw_studio/Pulumi.applications.ocw_studio.QA.yaml
@@ -24,6 +24,8 @@ config:
     MAILGUN_FROM_EMAIL: 'MIT OCW <no-reply@ocw-rc.mail.odl.mit.edu'
     MAILGUN_SENDER_DOMAIN: 'ocw-rc.mail.odl.mit.edu'
     MAILGUN_URL: https://api.mailgun.net/v3/ocw-rc.mail.odl.mit.edu
+    MIT_LEARN_BASE_URL: https://rc.learn.mit.edu
+    MIT_LEARN_API_BASE_URL: https://api.rc.learn.mit.edu
     OCW_COURSE_STARTER_SLUG: ocw-course-v2
     OCW_GTM_ACCOUNT_ID: GTM-PJMJGF6
     OCW_HUGO_THEMES_SENTRY_DSN: 'https://eee58f41dda54d2b814296e12dced4b7@o48788.ingest.sentry.io/5304953'


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/ol-infrastructure/issues/3058

### Description (What does it do?)
This PR adds two new env variables (`MIT_LEARN_BASE_URL` and `MIT_LEARN_API_BASE_URL`) to the `ocw-studio` Pulumi configuration. It also modifies the `auth_allowed_redirect_hosts`, `csrf_domains` and `cors_urls` properties on the MIT Learn Pulumi configurations to reflect what the current expected OCW URLs should be in all environments.

### How can this be tested?
 - Look at the changes and ensure that the URLs specified makes sense
 - Get this PR into RC and ensure that CORS still works everywhere it should