### PR TITLE
feat: update ol_openedx_chat settings & @mitodl/smoot-design version for learning MFE

### DIFF
--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -385,7 +385,8 @@ JWT_EXPIRATION: 30
 LANGUAGE_CODE: en
 LANGUAGE_COOKIE: {{ env "ENVIRONMENT" }}-openedx-language-preference
 MIT_LEARN_AI_API_URL: https://{{ key "edxapp/learn-ai-api-domain" }}  # Added for ol_openedx_chat
-MIT_LEARN_API_URL: https://{{ key "edxapp/mit-learn-api-domain" }}  # Added for ol_openedx_chat
+MIT_LEARN_API_BASE_URL: https://{{ key "edxapp/mit-learn-api-domain" }}  # Added for ol_openedx_chat
+MIT_LEARN_SUMMARY_FLASHCARD_URL: https://{{ key "edxapp/mit-learn-api-domain" }}/api/v1/contentfiles/  # Added for ol_openedx_chat
 LEARNER_PORTAL_URL_ROOT: https://learner-portal-localhost:18000
 LEARNER_HOME_MICROFRONTEND_URL: '/dashboard/'
 LEARNING_MICROFRONTEND_URL: https://{{ key "edxapp/lms-domain" }}/learn

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -384,8 +384,8 @@ INTEGRATED_CHANNELS_API_CHUNK_TRANSMISSION_LIMIT:
 JWT_EXPIRATION: 30
 LANGUAGE_CODE: en
 LANGUAGE_COOKIE: {{ env "ENVIRONMENT" }}-openedx-language-preference
-MIT_LEARN_AI_API_URL: https://{{ key "edxapp/learn-ai-api-domain" }}  # Added for ol_openedx_chat
-MIT_LEARN_API_BASE_URL: https://{{ key "edxapp/mit-learn-api-domain" }}  # Added for ol_openedx_chat
+MIT_LEARN_AI_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai  # Added for ol_openedx_chat
+MIT_LEARN_API_BASE_URL: https://{{ key "edxapp/learn-api-domain" }}/learn  # Added for ol_openedx_chat
 MIT_LEARN_SUMMARY_FLASHCARD_URL: https://{{ key "edxapp/mit-learn-api-domain" }}/api/v1/contentfiles/  # Added for ol_openedx_chat
 LEARNER_PORTAL_URL_ROOT: https://learner-portal-localhost:18000
 LEARNER_HOME_MICROFRONTEND_URL: '/dashboard/'

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -384,7 +384,8 @@ INTEGRATED_CHANNELS_API_CHUNK_TRANSMISSION_LIMIT:
 JWT_EXPIRATION: 30
 LANGUAGE_CODE: en
 LANGUAGE_COOKIE: {{ env "ENVIRONMENT" }}-openedx-language-preference
-LEARN_AI_API_URL: https://{{ key "edxapp/learn-ai-api-domain" }}  # Added for ol_openedx_chat
+MIT_LEARN_AI_API_URL: https://{{ key "edxapp/learn-ai-api-domain" }}  # Added for ol_openedx_chat
+MIT_LEARN_API_URL: https://{{ key "edxapp/mit-learn-api-domain" }}  # Added for ol_openedx_chat
 LEARNER_PORTAL_URL_ROOT: https://learner-portal-localhost:18000
 LEARNER_HOME_MICROFRONTEND_URL: '/dashboard/'
 LEARNING_MICROFRONTEND_URL: https://{{ key "edxapp/lms-domain" }}/learn

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -386,7 +386,7 @@ LANGUAGE_CODE: en
 LANGUAGE_COOKIE: {{ env "ENVIRONMENT" }}-openedx-language-preference
 MIT_LEARN_AI_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai  # Added for ol_openedx_chat
 MIT_LEARN_API_BASE_URL: https://{{ key "edxapp/learn-api-domain" }}/learn  # Added for ol_openedx_chat
-MIT_LEARN_SUMMARY_FLASHCARD_URL: https://{{ key "edxapp/mit-learn-api-domain" }}/api/v1/contentfiles/  # Added for ol_openedx_chat
+MIT_LEARN_SUMMARY_FLASHCARD_URL: https://{{ key "edxapp/learn-api-domain" }}/learn/api/v1/contentfiles/  # Added for ol_openedx_chat
 LEARNER_PORTAL_URL_ROOT: https://learner-portal-localhost:18000
 LEARNER_HOME_MICROFRONTEND_URL: '/dashboard/'
 LEARNING_MICROFRONTEND_URL: https://{{ key "edxapp/lms-domain" }}/learn

--- a/src/bridge/settings/openedx/mfe/slot_config/mitxonline/learning-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/mitxonline/learning-mfe-config.env.jsx
@@ -1,7 +1,7 @@
 import { PLUGIN_OPERATIONS } from '@openedx/frontend-plugin-framework';
 import { getConfig } from '@edx/frontend-platform';
 
-import * as remoteAiChatDrawer from "./mitodl-smoot-design/dist/bundles/remoteAiChatDrawer.umd.js"
+import * as remoteTutorDrawer from "./mitodl-smoot-design/dist/bundles/remoteTutorDrawer.umd.js"
 
 
 const modifyUserMenu = (widget) => {
@@ -26,7 +26,7 @@ const modifyUserMenu = (widget) => {
   return widget;
 };
 
-remoteAiChatDrawer.init({
+remoteTutorDrawer.init({
   messageOrigin: getConfig().LMS_BASE_URL,
   transformBody: messages => ({ message: messages[messages.length - 1].content }),
 })

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -159,7 +159,7 @@ def mfe_job(
         and OpenEdxMicroFrontend[mfe_name].value == OpenEdxMicroFrontend.learn.value
     ):
         mfe_smoot_design_overrides = """
-        npm pack @mitodl/smoot-design@^3.4.0
+        npm pack @mitodl/smoot-design@^5.0.0
         tar -xvzf mitodl-smoot-design*.tgz
         mv package mitodl-smoot-design
         """

--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.Production.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.Production.yaml
@@ -39,8 +39,3 @@ config:
     secure: v1:txrMWRvWLuyLZ9jG:RANFRu7iGA96qnc47SdQjrwTOS5Lz96n4Vdt6CK9vyb6FreKon4+qyLlk7P+dBS+T0lN7H6bvC1F38zIOA==
   vault:address: "https://vault-production.odl.mit.edu"
   vault_server:env_namespace: "operations.production"
-  # This is a hack. We need to write a Consul key for use by MITx Online and the apps
-  # and MITx Online VPCs aren't peered, so the Consul clusters aren't peered. We don't
-  # actually use Consul for anything else in this project so this is okay (so far) (TMM
-  # 2025-02-21)
-  consul:address: https://consul-mitxonline-production.odl.mit.edu

--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.QA.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.QA.yaml
@@ -43,8 +43,3 @@ config:
     secure: v1:j1q4KgePVUsaaySb:EhUqxWBezBKe6Ck1o/gqlX68GBnrZZQdmUCscl5aPok1j6jJWKSRO89XfV+6dWJaCMhqHA==
   vault:address: "https://vault-qa.odl.mit.edu"
   vault_server:env_namespace: "operations.qa"
-  # This is a hack. We need to write a Consul key for use by MITx Online and the apps
-  # and MITx Online VPCs aren't peered, so the Consul clusters aren't peered. We don't
-  # actually use Consul for anything else in this project so this is okay (so far) (TMM
-  # 2025-02-21)
-  consul:address: https://consul-mitxonline-qa.odl.mit.edu

--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -6,7 +6,6 @@ import os
 import textwrap
 from pathlib import Path
 
-import pulumi_consul as consul
 import pulumi_fastly as fastly
 import pulumi_github as github
 import pulumi_kubernetes as kubernetes
@@ -57,7 +56,6 @@ from ol_infrastructure.lib.aws.eks_helper import (
     setup_k8s_provider,
 )
 from ol_infrastructure.lib.aws.iam_helper import IAM_POLICY_VERSION, lint_iam_policy
-from ol_infrastructure.lib.consul import get_consul_provider
 from ol_infrastructure.lib.fastly import (
     build_fastly_log_format_string,
     get_fastly_provider,
@@ -1130,21 +1128,6 @@ base_oidc_plugin_config = {
 
 learn_ai_api_domain = learn_ai_config.require("backend_domain")
 learn_api_domain = learn_ai_config.require("learn_backend_domain")
-
-if stack_info.env_suffix != "ci":
-    consul_opts = get_consul_provider(stack_info)
-    consul.Keys(
-        "learn-ai-domain-consul-key-for-mitxonline-openedx",
-        keys=[
-            consul.KeysKeyArgs(
-                path="edxapp/learn-ai-api-domain",
-                delete=True,
-                # SWITCHOVER : Update to learn_api_domain
-                value=learn_ai_api_domain,
-            )
-        ],
-        opts=consul_opts,
-    )
 
 # ApisixUpstream resources don't seem to work but we don't really need them?
 # Ref: https://github.com/apache/apisix-ingress-controller/issues/1655

--- a/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.Production.yaml
+++ b/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.Production.yaml
@@ -2,7 +2,6 @@
 secretsprovider: awskms://alias/infrastructure-secrets-production
 encryptedkey: AQICAHiiGjYUolrtj8PCnScLM7oLAdMl8nJrLjQjnqyl1LykYgGq710cJf4taf7FUfw+iIGNAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM2JcEQu/tozu3tO8TAgEQgDvnl65jF/6aC66eb97jIrt3/CIL6a5XcVwv9E8EWgWlrX3cJadv9f2X0bcVLKiGPImjG4qTL6m5sDN7Ig==
 config:
-  consul:address: https://consul-apps-production.odl.mit.edu
   heroku:app_id:
     secure: v1:mdVwWs7IkyH7o5j7:49eMfOoVshilsOCouixsxdQSGehSeqRHF3DhPWp2UIiE1clEoyoKqOodkpBQ27rik/MIDg==
   heroku:user: "odl-devops"
@@ -90,3 +89,8 @@ config:
   vault_server:env_namespace: operations.production
   mitlearn:learn_ai_recommendation_endpoint: "https://api.learn.mit.edu/ai/http/recommendation_agent/"
   mitlearn:learn_ai_syllabus_endpoint: "https://api.learn.mit.edu/ai/http/syllabus_agent/"
+  # This is a hack. We need to write a Consul key for use by MITx Online and the apps
+  # and MITx Online VPCs aren't peered, so the Consul clusters aren't peered. We don't
+  # actually use Consul for anything else in this project so this is okay (so far) (TMM
+  # 2025-02-21)
+  consul:address: https://consul-mitxonline-production.odl.mit.edu

--- a/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.QA.yaml
+++ b/src/ol_infrastructure/applications/mitlearn/Pulumi.applications.mitlearn.QA.yaml
@@ -2,7 +2,6 @@
 secretsprovider: awskms://alias/infrastructure-secrets-qa
 encryptedkey: AQICAHg42pDDDGBhpaX14TdtzcK1hbiMYTHsYRH4k5GL5RFpIwEi8MniqKSK7PJ7AIbp17REAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMbWm9PEFY6H+jKGYHAgEQgDtAZs04prjkVBGB8O8+C6kjqzMhazPYOAanmLoWdx4WArJXNKxZkv72c6my81/qnCg0xWYdmw6fJxV0dg==
 config:
-  consul:address: https://consul-apps-qa.odl.mit.edu
   heroku:user: "odl-devops"
   heroku:app_id:
     secure: v1:eSvnqne7KQRkHJlu:wTyl9W3aivfxlANqBML2wy4GEHe85VuKll60R5HmGUu1hJTcQBEfzK1cJOyvjlbLgBtXLw==
@@ -88,3 +87,8 @@ config:
   vault_server:env_namespace: operations.qa
   mitlearn:learn_ai_recommendation_endpoint: "https://api.rc.learn.mit.edu/ai/http/recommendation_agent/"
   mitlearn:learn_ai_syllabus_endpoint: "https://api.rc.learn.mit.edu/ai/http/syllabus_agent/"
+  # This is a hack. We need to write a Consul key for use by MITx Online and the apps
+  # and MITx Online VPCs aren't peered, so the Consul clusters aren't peered. We don't
+  # actually use Consul for anything else in this project so this is okay (so far) (TMM
+  # 2025-02-21)
+  consul:address: https://consul-mitxonline-qa.odl.mit.edu


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
A part of https://github.com/mitodl/hq/issues/6985

### Description (What does it do?)
<!--- Describe your changes in detail -->

- Renames `LEARN_AI_API_URL` to `MIT_ LEARN_AI_API_URL`
- Adds new setting `MIT_LEARN_API_BASE_URL ` that SHOULD point to the LEARN API (Not Learn AI)
- Adds new setting `MIT_LEARN_SUMMARY_FLASHCARD_URL` for video summary and flashcards.
- Updates the minimum required version of smoot-design for Learning MFE build.
- updates the learning MFE config.

