### PR TITLE
fix(traefik): configure trusted IPs for passing  X-Forwarded headers to Keycloak

### DIFF
--- a/src/bilder/components/traefik/models/traefik_static.py
+++ b/src/bilder/components/traefik/models/traefik_static.py
@@ -108,7 +108,7 @@ class ProxyProtocol(FieldModel):
 
 class ForwardedHeaders(FieldModel):
     insecure: Optional[bool] = None
-    trusted_i_ps: Optional[list[str]] = Field(None, alias="trustedIPs")
+    trusted_ips: Optional[list[str]] = Field(None, alias="trustedIPs")
 
 
 class EntryPoint(FieldModel):
@@ -156,7 +156,14 @@ class EntryPoints(FieldModel):
     transport: Optional[Transport] = None
     proxy_protocol: Optional[ProxyProtocol] = Field(None, alias="proxyProtocol")
     forwarded_headers: Optional[ForwardedHeaders] = Field(
-        None, alias="forwardedHeaders"
+        ForwardedHeaders(
+            trusted_ips=[
+                "10.0.0.0/8",
+                "172.16.0.0/12",
+                "192.168.0.0/16",
+            ]
+        ),
+        alias="forwardedHeaders",
     )
     http: Optional[Http] = None
     http2: Optional[Http2] = None

--- a/src/bilder/images/keycloak/deploy.py
+++ b/src/bilder/images/keycloak/deploy.py
@@ -111,8 +111,24 @@ traefik_static_config = traefik_static.TraefikStaticConfig(
                     )
                 )
             ),
+            forwarded_headers=traefik_static.ForwardedHeaders(
+                trusted_ips=[
+                    "10.0.0.0/8",
+                    "172.16.0.0/12",
+                    "192.168.0.0/16",
+                ]
+            ),
         ),
-        "https": traefik_static.EntryPoints(address=":443"),
+        "https": traefik_static.EntryPoints(
+            address=":443",
+            forwarded_headers=traefik_static.ForwardedHeaders(
+                trusted_ips=[
+                    "10.0.0.0/8",
+                    "172.16.0.0/12",
+                    "192.168.0.0/16",
+                ]
+            ),
+        ),
     },
 )
 traefik_config = TraefikConfig(static_configuration=traefik_static_config)

--- a/src/ol_infrastructure/substructure/keycloak/__main__.py
+++ b/src/ol_infrastructure/substructure/keycloak/__main__.py
@@ -821,6 +821,7 @@ if keycloak_realm_config.get("olapps-mitlearn-client-secret"):
         valid_redirect_uris=keycloak_realm_config.get_object(
             "olapps-mitlearn-client-redirect-uris"
         ),
+        web_origins="+",
         opts=resource_options.merge(ResourceOptions(delete_before_replace=True)),
     )
     olapps_mitlearn_client_scope = keycloak.openid.ClientDefaultScopes(


### PR DESCRIPTION
### What are the relevant tickets?
Related to MITLearn auth issues

### Description (What does it do?)
<!--- Describe your changes in detail -->
This fixes a typo in the field name (trusted_i_ps -> trusted_ips) and adds proper configuration for trusted IP ranges in forwarded headers for both HTTP and HTTPS entrypoints. This allows `X-Forwarded-*` headers to be passed along to Keycloak for determining when to send CORS responses.

Also adds web origins configuration for the mitlearn client.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Apply the changes in CI and verify that an OPTIONS request from an appropriate origin includes `Access-Control-Allowed-*` headers in the response.
