### PR TITLE
update smoot to v6

### DIFF
--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -159,7 +159,7 @@ def mfe_job(
         and OpenEdxMicroFrontend[mfe_name].value == OpenEdxMicroFrontend.learn.value
     ):
         mfe_smoot_design_overrides = """
-        npm pack @mitodl/smoot-design@^5.0.0
+        npm pack @mitodl/smoot-design@^6.0.0
         tar -xvzf mitodl-smoot-design*.tgz
         mv package mitodl-smoot-design
         """


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6985

### Description (What does it do?)
Updates smoot to v6.

The fix to drawer title was technically a breaking change, so smoot updated to v6 from (very recent) v5. Probably should group these changes better, but in the meantime, here's v6.

### How can this be tested?
Not really sure for the deployment, but v6 can be tested as described in https://github.com/mitodl/hq/issues/6985 
