### PR TITLE
set Posthog env vars for published OCW sites

### DIFF
--- a/src/ol_infrastructure/applications/ocw_studio/Pulumi.applications.ocw_studio.Production.yaml
+++ b/src/ol_infrastructure/applications/ocw_studio/Pulumi.applications.ocw_studio.Production.yaml
@@ -38,6 +38,7 @@ config:
     OCW_STUDIO_LOG_LEVEL: INFO
     OCW_STUDIO_SUPPORT_EMAIL: 'ocw-studio-support@mit.edu'
     OPEN_CATALOG_URLS: 'https://open.mit.edu/api/v0/ocw_next_webhook/,https://api.learn.mit.edu/api/v1/ocw_next_webhook/'
+    PUBLISH_POSTHOG_ENABLED: 'false'
     SEARCH_API_URL: 'https://open.mit.edu/api/v0/search/'
     SENTRY_LOG_LEVEL: 'WARN'
     SITEMAP_DOMAIN: 'ocw.mit.edu'

--- a/src/ol_infrastructure/applications/ocw_studio/Pulumi.applications.ocw_studio.QA.yaml
+++ b/src/ol_infrastructure/applications/ocw_studio/Pulumi.applications.ocw_studio.QA.yaml
@@ -38,6 +38,9 @@ config:
     OCW_STUDIO_LOG_LEVEL: INFO
     OCW_STUDIO_SUPPORT_EMAIL: 'ocw-studio-rc-support@mit.edu'
     OPEN_CATALOG_URLS: 'https://discussions-rc.odl.mit.edu/api/v0/ocw_next_webhook/,https://api.rc.learn.mit.edu/api/v1/ocw_next_webhook/'
+    PUBLISH_POSTHOG_ENABLED: 'true'
+    PUBLISH_POSTHOG_HOST: https://ph.rc.learn.mit.edu
+    PUBLISH_POSTHOG_PROJECT_API_KEY: 'phc_Ci6X3XFSc1mj8chO0BO0qfSnJ5cJEVUGT0cyQ5CIE6x'  # pragma: allowlist secret
     SEARCH_API_URL: 'https://discussions-rc.odl.mit.edu/api/v0/search/'
     SENTRY_LOG_LEVEL: 'WARN'
     SITEMAP_DOMAIN: 'live-qa.ocw.mit.edu'

--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -378,6 +378,13 @@ heroku_vars = {
     "VIDEO_TRANSCODE_QUEUE": ocw_studio_mediaconvert.queue.name,
 }
 
+if stack_info.env_suffix.lower() != "production":
+    heroku_vars["PUBLISH_POSTHOG_ENABLED"] = "True"
+    heroku_vars["PUBLISH_POSTHOG_API_HOST"] = "https://ph.rc.learn.mit.edu"
+    heroku_vars["PUBLISH_POSTHOG_PROJECT_API_KEY"] = (
+        "phc_Ci6X3XFSc1mj8chO0BO0qfSnJ5cJEVUGT0cyQ5CIE6x"  # pragma: allowlist secret
+    )
+
 heroku_vars.update(**heroku_app_config.get_object("vars"))
 
 auth_aws_mitx_creds_ocw_studio_app_env = vault.generic.get_secret_output(

--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -378,7 +378,6 @@ heroku_vars = {
     "VIDEO_TRANSCODE_QUEUE": ocw_studio_mediaconvert.queue.name,
 }
 
-
 heroku_vars.update(**heroku_app_config.get_object("vars"))
 
 auth_aws_mitx_creds_ocw_studio_app_env = vault.generic.get_secret_output(

--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -378,12 +378,6 @@ heroku_vars = {
     "VIDEO_TRANSCODE_QUEUE": ocw_studio_mediaconvert.queue.name,
 }
 
-if stack_info.env_suffix.lower() != "production":
-    heroku_vars["PUBLISH_POSTHOG_ENABLED"] = "True"
-    heroku_vars["PUBLISH_POSTHOG_API_HOST"] = "https://ph.rc.learn.mit.edu"
-    heroku_vars["PUBLISH_POSTHOG_PROJECT_API_KEY"] = (
-        "phc_Ci6X3XFSc1mj8chO0BO0qfSnJ5cJEVUGT0cyQ5CIE6x"  # pragma: allowlist secret
-    )
 
 heroku_vars.update(**heroku_app_config.get_object("vars"))
 


### PR DESCRIPTION
### What are the relevant tickets?
Prerequisite for https://github.com/mitodl/hq/issues/7017

### Description (What does it do?)
This PR sets some env vars to have a separate Posthog project for the published OCW site vs `ocw-studio` itself. 

### How can this be tested?
- Make sure the env vars are properly set
- Not sure how else to test, probably has to get into RC / QA first