### PR TITLE
fix OCW Posthog env var name

### DIFF
--- a/src/ol_infrastructure/applications/ocw_studio/Pulumi.applications.ocw_studio.QA.yaml
+++ b/src/ol_infrastructure/applications/ocw_studio/Pulumi.applications.ocw_studio.QA.yaml
@@ -39,7 +39,7 @@ config:
     OCW_STUDIO_SUPPORT_EMAIL: 'ocw-studio-rc-support@mit.edu'
     OPEN_CATALOG_URLS: 'https://discussions-rc.odl.mit.edu/api/v0/ocw_next_webhook/,https://api.rc.learn.mit.edu/api/v1/ocw_next_webhook/'
     PUBLISH_POSTHOG_ENABLED: 'true'
-    PUBLISH_POSTHOG_HOST: https://ph.rc.learn.mit.edu
+    PUBLISH_POSTHOG_API_HOST: https://ph.rc.learn.mit.edu
     PUBLISH_POSTHOG_PROJECT_API_KEY: 'phc_Ci6X3XFSc1mj8chO0BO0qfSnJ5cJEVUGT0cyQ5CIE6x'  # pragma: allowlist secret
     SEARCH_API_URL: 'https://discussions-rc.odl.mit.edu/api/v0/search/'
     SENTRY_LOG_LEVEL: 'WARN'


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up to https://github.com/mitodl/ol-infrastructure/pull/3079

### Description (What does it do?)
In the above PR, a typo was made in the env var name for the API host. `PUBLISH_POSTHOG_HOST` was changed to `PUBLISH_POSTHOG_API_HOST`

### How can this be tested?
Deploy in RC and ensure that the proper API host value is being used.