### PR TITLE
fix: remove cross-origin-opener policy from nginx conf

### DIFF
--- a/src/bilder/images/odl_video_service/files/nginx_with_shib.conf.tmpl
+++ b/src/bilder/images/odl_video_service/files/nginx_with_shib.conf.tmpl
@@ -27,8 +27,6 @@ server {
     ssl_prefer_server_ciphers on;
     resolver 1.1.1.1;
 
-    add_header Cross-Origin-Opener-Policy same-origin-allow-popups;
-
     location /shibauthorizer {
         internal ;
         include fastcgi_params;

--- a/src/bilder/images/odl_video_service/files/nginx_wo_shib.conf.tmpl
+++ b/src/bilder/images/odl_video_service/files/nginx_wo_shib.conf.tmpl
@@ -27,7 +27,6 @@ server {
     ssl_prefer_server_ciphers on;
     resolver 1.1.1.1;
 
-    add_header Cross-Origin-Opener-Policy same-origin-allow-popups;
 
     location /status {
         include uwsgi_params;


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7110#issuecomment-2801529301

### Description (What does it do?)
This PR:
1. Removes cross-origin-opener policy from nginx config


### Additional Context
We are moving this value from nginx conf to Django settings, configureable via environment