### PR TITLE
Add a k8s_global_labels Pydantic model so we can enforce validations for expense tracking

### DIFF
--- a/src/ol_infrastructure/applications/airbyte/__main__.py
+++ b/src/ol_infrastructure/applications/airbyte/__main__.py
@@ -1,4 +1,5 @@
 """Create the resources needed to run a airbyte server.  # noqa: D200"""
+# ruff: noqa: UP042, CPY001, D100, ERA001, D102
 
 import json
 import os
@@ -82,10 +83,10 @@ aws_config = AWSBase(
 )
 
 k8s_global_labels = K8sGlobalLabels(
-    app=Apps.airbyte,
+    service=Apps.airbyte,
     ou=BusinessUnit.data,
-    stack_info=stack_info,
-)
+    stack=stack_info.full_name,
+).model_dump()
 setup_k8s_provider(kubeconfig=cluster_stack.require_output("kube_config"))
 airbyte_namespace = "airbyte"
 

--- a/src/ol_infrastructure/applications/airbyte/__main__.py
+++ b/src/ol_infrastructure/applications/airbyte/__main__.py
@@ -44,7 +44,7 @@ from ol_infrastructure.lib.aws.iam_helper import (
     lint_iam_policy,
 )
 from ol_infrastructure.lib.consul import get_consul_provider
-from ol_infrastructure.lib.ol_types import AWSBase
+from ol_infrastructure.lib.ol_types import Apps, AWSBase, BusinessUnit, K8sGlobalLabels
 from ol_infrastructure.lib.pulumi_helper import parse_stack
 from ol_infrastructure.lib.stack_defaults import defaults
 from ol_infrastructure.lib.vault import postgres_role_statements, setup_vault_provider
@@ -81,10 +81,11 @@ aws_config = AWSBase(
     }
 )
 
-k8s_global_labels = {
-    "pulumi_managed": "true",
-    "pulumi_stack": stack_info.full_name,
-}
+k8s_global_labels = K8sGlobalLabels(
+    app=Apps.airbyte,
+    ou=BusinessUnit.data,
+    stack_info=stack_info,
+)
 setup_k8s_provider(kubeconfig=cluster_stack.require_output("kube_config"))
 airbyte_namespace = "airbyte"
 

--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -99,11 +99,15 @@ github_provider = github.Provider(
     token=read_yaml_secrets(Path("pulumi/github_provider.yaml"))["token"],
 )
 
+# k8s_global_labels = K8sGlobalLabels(
+#     app=Apps.mit_learn,
+#     ou=BusinessUnit.mit_learn,
+#     stack_info=stack_info,
+# )
+
 k8s_global_labels = K8sGlobalLabels(
-    app=Apps.mit_learn,
-    ou=BusinessUnit.mit_learn,
-    stack_info=stack_info,
-)
+    ou=BusinessUnit.mit_learn, service=Apps.mit_learn, stack=stack_info.full_name
+).model_dump()
 setup_k8s_provider(kubeconfig=cluster_stack.require_output("kube_config"))
 
 # Fail hard if LEARN_AI_DOCKER_TAG is not set

--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -99,12 +99,6 @@ github_provider = github.Provider(
     token=read_yaml_secrets(Path("pulumi/github_provider.yaml"))["token"],
 )
 
-# k8s_global_labels = K8sGlobalLabels(
-#     app=Apps.mit_learn,
-#     ou=BusinessUnit.mit_learn,
-#     stack_info=stack_info,
-# )
-
 k8s_global_labels = K8sGlobalLabels(
     ou=BusinessUnit.mit_learn, service=Apps.mit_learn, stack=stack_info.full_name
 ).model_dump()

--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -62,7 +62,7 @@ from ol_infrastructure.lib.fastly import (
     build_fastly_log_format_string,
     get_fastly_provider,
 )
-from ol_infrastructure.lib.ol_types import AWSBase
+from ol_infrastructure.lib.ol_types import Apps, AWSBase, BusinessUnit, K8sGlobalLabels
 from ol_infrastructure.lib.pulumi_helper import parse_stack
 from ol_infrastructure.lib.stack_defaults import defaults
 from ol_infrastructure.lib.vault import setup_vault_provider
@@ -99,10 +99,11 @@ github_provider = github.Provider(
     token=read_yaml_secrets(Path("pulumi/github_provider.yaml"))["token"],
 )
 
-k8s_global_labels = {
-    "ol.mit.edu/stack": stack_info.full_name,
-    "ol.mit.edu/application": "learn-ai",
-}
+k8s_global_labels = K8sGlobalLabels(
+    app=Apps.mit_learn,
+    ou=BusinessUnit.mit_learn,
+    stack_info=stack_info,
+)
 setup_k8s_provider(kubeconfig=cluster_stack.require_output("kube_config"))
 
 # Fail hard if LEARN_AI_DOCKER_TAG is not set

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -131,7 +131,7 @@ k8s_global_labels = K8s8sGlobalLabels(
     app=Apps.mit_learn,
     ou=BusinessUnit.mit_learn,
     stack_info=stack_info,
-)
+).model_dump()
 
 setup_k8s_provider(kubeconfig=cluster_stack.require_output("kube_config"))
 learn_namespace = "mitlearn"

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -72,7 +72,12 @@ from ol_infrastructure.lib.fastly import (
     get_fastly_provider,
 )
 from ol_infrastructure.lib.heroku import setup_heroku_provider
-from ol_infrastructure.lib.ol_types import AWSBase
+from ol_infrastructure.lib.ol_types import (
+    Apps,
+    AWSBase,
+    BusinessUnit,
+    K8s8sGlobalLabels,
+)
 from ol_infrastructure.lib.pulumi_helper import parse_stack
 from ol_infrastructure.lib.stack_defaults import defaults
 from ol_infrastructure.lib.vault import postgres_role_statements, setup_vault_provider
@@ -122,10 +127,12 @@ app_env_suffix = {"ci": "ci", "qa": "rc", "production": "production"}[
     stack_info.env_suffix
 ]
 
-k8s_global_labels = {
-    "ol.mit.edu/stack": stack_info.full_name,
-    "ol.mit.edu/service": "mit-learn",  # What should this actually be?
-}
+k8s_global_labels = K8s8sGlobalLabels(
+    app=Apps.mit_learn,
+    ou=BusinessUnit.mit_learn,
+    stack_info=stack_info,
+)
+
 setup_k8s_provider(kubeconfig=cluster_stack.require_output("kube_config"))
 learn_namespace = "mitlearn"
 cluster_stack.require_output("namespaces").apply(

--- a/src/ol_infrastructure/applications/open_metadata/__main__.py
+++ b/src/ol_infrastructure/applications/open_metadata/__main__.py
@@ -1,3 +1,4 @@
+# ruff: noqa: UP042, CPY001, D100, ERA001, D102
 from pathlib import Path
 from string import Template
 
@@ -69,10 +70,10 @@ consul_provider = get_consul_provider(stack_info)
 setup_vault_provider(stack_info)
 
 k8s_global_labels = K8sGlobalLabels(
-    app=Apps.open_metadata,
+    service=Apps.open_metadata,
     ou=BusinessUnit.data,
-    stack_info=stack_info,
-)
+    stack=stack_info.full_name,
+).model_dump()
 
 setup_k8s_provider(kubeconfig=cluster_stack.require_output("kube_config"))
 

--- a/src/ol_infrastructure/applications/open_metadata/__main__.py
+++ b/src/ol_infrastructure/applications/open_metadata/__main__.py
@@ -35,7 +35,7 @@ from ol_infrastructure.lib.aws.eks_helper import (
 )
 from ol_infrastructure.lib.aws.rds_helper import DBInstanceTypes
 from ol_infrastructure.lib.consul import get_consul_provider
-from ol_infrastructure.lib.ol_types import AWSBase
+from ol_infrastructure.lib.ol_types import Apps, AWSBase, BusinessUnit, K8sGlobalLabels
 from ol_infrastructure.lib.pulumi_helper import parse_stack
 from ol_infrastructure.lib.stack_defaults import defaults
 from ol_infrastructure.lib.vault import postgres_role_statements, setup_vault_provider
@@ -67,10 +67,12 @@ vault_config = Config("vault")
 
 consul_provider = get_consul_provider(stack_info)
 setup_vault_provider(stack_info)
-k8s_global_labels = {
-    "ol.mit.edu/stack": stack_info.full_name,
-    "ol.mit.edu/service": "open-metadata",
-}
+
+k8s_global_labels = K8sGlobalLabels(
+    app=Apps.open_metadata,
+    ou=BusinessUnit.data,
+    stack_info=stack_info,
+)
 
 setup_k8s_provider(kubeconfig=cluster_stack.require_output("kube_config"))
 

--- a/src/ol_infrastructure/applications/unified_ecommerce/__main__.py
+++ b/src/ol_infrastructure/applications/unified_ecommerce/__main__.py
@@ -56,7 +56,7 @@ from ol_infrastructure.lib.fastly import (
     build_fastly_log_format_string,
     get_fastly_provider,
 )
-from ol_infrastructure.lib.ol_types import Apps, AWSBase
+from ol_infrastructure.lib.ol_types import Apps, AWSBase, BusinessUnit, K8sGlobalLabels
 from ol_infrastructure.lib.pulumi_helper import parse_stack
 from ol_infrastructure.lib.vault import setup_vault_provider
 
@@ -90,10 +90,12 @@ vault_config = Config("vault")
 
 consul_provider = get_consul_provider(stack_info)
 setup_vault_provider(stack_info)
-k8s_global_labels = {
-    "ol.mit.edu/stack": stack_info.full_name,
-    "ol.mit.edu/service": Apps.ecommerce,
-}
+
+k8s_global_labels = K8sGlobalLabels(
+    app=Apps.ecommerce,
+    ou=BusinessUnit.ecommerce,
+    stack_info=stack_info,
+)
 setup_k8s_provider(kubeconfig=cluster_stack.require_output("kube_config"))
 
 if not (UNIFIED_ECOMMERCE_DOCKER_TAG := os.getenv("UNIFIED_ECOMMERCE_DOCKER_TAG")):

--- a/src/ol_infrastructure/applications/unified_ecommerce/__main__.py
+++ b/src/ol_infrastructure/applications/unified_ecommerce/__main__.py
@@ -1,4 +1,4 @@
-# ruff: noqa: ERA001, C416, D100
+# ruff: noqa: ERA001, C416, D100, CPY001
 
 import base64
 import json
@@ -92,10 +92,9 @@ consul_provider = get_consul_provider(stack_info)
 setup_vault_provider(stack_info)
 
 k8s_global_labels = K8sGlobalLabels(
-    app=Apps.ecommerce,
-    ou=BusinessUnit.ecommerce,
-    stack_info=stack_info,
-)
+    ou=BusinessUnit.ecommerce, service=Apps.ecommerce, stack=stack_info.full_name
+).model_dump()
+
 setup_k8s_provider(kubeconfig=cluster_stack.require_output("kube_config"))
 
 if not (UNIFIED_ECOMMERCE_DOCKER_TAG := os.getenv("UNIFIED_ECOMMERCE_DOCKER_TAG")):

--- a/src/ol_infrastructure/lib/ol_types.py
+++ b/src/ol_infrastructure/lib/ol_types.py
@@ -52,7 +52,7 @@ class Environment(str, Enum):
 class Apps(str, Enum):
     """Canonical source of truth for defining apps."""
 
-    airbyte = "airbytte"
+    airbyte = "airbyte"
     bootcamps = "bootcamps"
     dagster = "dagster"
     edxapp = "edxapp"

--- a/src/ol_infrastructure/lib/ol_types.py
+++ b/src/ol_infrastructure/lib/ol_types.py
@@ -19,6 +19,7 @@ class BusinessUnit(str, Enum):
     bootcamps = "bootcamps"
     data = "data"
     digital_credentials = "digital-credentials"
+    mit_learn = "mit-learn"
     micromasters = "micromasters"
     mit_open = "mit-open"
     mitx = "mitx"
@@ -29,6 +30,7 @@ class BusinessUnit(str, Enum):
     residential = "residential"
     residential_staging = "residential-staging"
     xpro = "mitxpro"
+    ecommerce = "unified-ecommerce"
 
 
 @unique
@@ -48,6 +50,7 @@ class Environment(str, Enum):
 class Apps(str, Enum):
     """Canonical source of truth for defining apps."""
 
+    airbyte = "airbytte"
     bootcamps = "bootcamps"
     dagster = "dagster"
     edxapp = "edxapp"
@@ -63,18 +66,23 @@ class Apps(str, Enum):
     xpro = "xpro"
     ecommerce = "unified-ecommerce"
     mit_learn = "mit-learn"
+    open_metadata = " open-metadata"
 
 
-class K8sLabels(BaseModel):
+class K8sGlobalLabels(BaseModel):
     """Base class for Kubernetes resource labels."""
 
     labels: dict[str, str]
 
-    def __init__(self, stack_info, app: Apps, **kwargs):
+    def __init__(self, stack_info, app: Apps, ou: BusinessUnit, **kwargs):
         """Add MIT OL standard labels for app and stack info."""
         super().__init__(**kwargs)
         self.labels.update(
-            {"ol.mit.edu/stack": stack_info.name, "ol.mit.edu/service": app}
+            {
+                "ol.mit.edu/stack": stack_info.name,
+                "ol.mit.edu/service": app,
+                "ol.mit.edu/ou": ou,
+            }
         )
 
 

--- a/src/ol_infrastructure/lib/ol_types.py
+++ b/src/ol_infrastructure/lib/ol_types.py
@@ -68,7 +68,7 @@ class Apps(str, Enum):
     xpro = "xpro"
     ecommerce = "unified-ecommerce"
     mit_learn = "mit-learn"
-    open_metadata = " open-metadata"
+    open_metadata = "open-metadata"
 
 
 class K8sGlobalLabels(BaseModel):

--- a/src/ol_infrastructure/lib/ol_types.py
+++ b/src/ol_infrastructure/lib/ol_types.py
@@ -65,6 +65,19 @@ class Apps(str, Enum):
     mit_learn = "mit-learn"
 
 
+class K8sLabels(BaseModel):
+    """Base class for Kubernetes resource labels."""
+
+    labels: dict[str, str]
+
+    def __init__(self, stack_info, app: Apps, **kwargs):
+        """Add MIT OL standard labels for app and stack info."""
+        super().__init__(**kwargs)
+        self.labels.update(
+            {"ol.mit.edu/stack": stack_info.name, "ol.mit.edu/service": app}
+        )
+
+
 class AWSBase(BaseModel):
     """Base class for configuration objects to pass to AWS component resources."""
 

--- a/src/ol_infrastructure/lib/ol_types.py
+++ b/src/ol_infrastructure/lib/ol_types.py
@@ -7,7 +7,6 @@ from ol_infrastructure.lib.aws.ec2_helper import aws_regions
 
 REQUIRED_TAGS = {"OU", "Environment"}
 RECOMMENDED_TAGS = {"Application", "Owner"}
-REQUIRED_LABELS = {"ol.mit.edu/ou", "ol.mit.edu/service"}
 
 
 @unique


### PR DESCRIPTION
### What are the relevant tickets?
Fixes #2946

### Description (What does it do?)
Adds a k8s_global_labels Pydantic model so we can enforce validations for expense tracking

### How can this be tested?
Run Pulumi up in one of the modified projects. Validate k8s labels are correct.

I ran pulumi up successfully on all the apps save Airbyte, and the new labels look awesome :)
```
        }
    ~ kubernetes:vpcresources.k8s.aws/v1beta1:SecurityGroupPolicy: (update)
        [id=ecommerce/unified-ecommerce-application-security-group-ci]
        [urn=urn:pulumi:applications.unified_ecommerce.CI::ol-infrastructure-unified_ecommerce-application::kubernetes:vpcresources.k8s.aws/v1beta1:SecurityGroupPolicy::unified-ecommerce-application-ci-application-pod-security-group-policy]
        [provider=urn:pulumi:applications.unified_ecommerce.CI::ol-infrastructure-unified_ecommerce-application::pulumi:providers:kubernetes::k8s-provider::126d39f8-52dc-41f1-898c-c72fc1198e4d]
      ~ metadata: {
          ~ labels: {
              + ol.mit.edu/ou: "unified-ecommerce"
            }
        }
    ~ kubernetes:core/v1:Secret: (update)
        [id=ecommerce/redis-creds]
        [urn=urn:pulumi:applications.unified_ecommerce.CI::ol-infrastructure-unified_ecommerce-application::kubernetes:core/v1:Secret::unified-ecommerce-ci-redis-creds]
        [provider=urn:pulumi:applications.unified_ecommerce.CI::ol-infrastructure-unified_ecommerce-application::pulumi:providers:kubernetes::k8s-provider::126d39f8-52dc-41f1-898c-c72fc1198e4d]
      ~ metadata: {
          ~ labels: {
              + ol.mit.edu/ou: "unified-ecommerce"
            }
        }
```
