### PR TITLE
Md/apisix stab and misc eks stuff

### DIFF
--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -743,6 +743,8 @@ learn_ai_app_k8s = OLApplicationK8s(
             OLApplicationK8sCeleryWorkerConfig(
                 worker_name="default",
                 queues=["default", "edx_content"],
+                resource_requests={"cpu": "500m", "memory": "1000Mi"},
+                resource_limits={"cpu": "1000m", "memory": "2000Mi"},
             )
         ],
     ),

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.applications.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.applications.CI.yaml
@@ -25,7 +25,7 @@ config:
   eks:developer_role_kubernetes_groups: ["admin"]
   eks:developer_role_scope: "cluster"
   eks:ebs_csi_provisioner: "true"
-  eks:efs_csi_provisioner: "false"
+  eks:efs_csi_provisioner: "true"
   eks:gateway_release_channel: "experimental"
   eks:namespaces:
   - "ecommerce"

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.applications.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.applications.Production.yaml
@@ -21,7 +21,7 @@ config:
   - "api-learn-ai.ol.mit.edu"
   - "api.learn.mit.edu"
   eks:ebs_csi_provisioner: "true"
-  eks:efs_csi_provisioner: "false"
+  eks:efs_csi_provisioner: "true"
   eks:gateway_release_channel: "experimental"
   eks:namespaces:
   - "ecommerce"

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.applications.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.applications.QA.yaml
@@ -24,7 +24,7 @@ config:
   eks:developer_role_kubernetes_groups: ["admin"]
   eks:developer_role_scope: "cluster"
   eks:ebs_csi_provisioner: "true"
-  eks:efs_csi_provisioner: "false"
+  eks:efs_csi_provisioner: "true"
   eks:gateway_release_channel: "experimental"
   eks:namespaces:
   - "ecommerce"

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.data.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.data.CI.yaml
@@ -17,7 +17,7 @@ config:
   eks:developer_role_kubernetes_groups: ["admin"]
   eks:developer_role_policy_name: "AmazonEKSAdminPolicy"
   eks:ebs_csi_provisioner: "true"
-  eks:efs_csi_provisioner: "false"
+  eks:efs_csi_provisioner: "true"
   eks:gateway_release_channel: "experimental"
   eks:namespaces:
   - "open-metadata"

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.data.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.data.Production.yaml
@@ -15,7 +15,7 @@ config:
   eks:apisix_viewer_key:
     secure: v1:j5+aTOfRBG8QiV+V:C6NTWitDBjV4DkOQGApae7GHK9w1wOFAlS7ACNu/s728A5q1zDWv9E13E2hs0IlAtMnP17KJR0HZjxDlg5fckv2nguEVgNA/d90j1XWlFY8=
   eks:ebs_csi_provisioner: "true"
-  eks:efs_csi_provisioner: "false"
+  eks:efs_csi_provisioner: "true"
   eks:gateway_release_channel: "experimental"
   eks:namespaces:
   - "open-metadata"   # Openmetadata testing

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.data.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.data.QA.yaml
@@ -17,7 +17,7 @@ config:
   eks:developer_role_kubernetes_groups: ["admin"]
   eks:developer_role_policy_name: "AmazonEKSAdminPolicy"
   eks:ebs_csi_provisioner: "true"
-  eks:efs_csi_provisioner: "false"
+  eks:efs_csi_provisioner: "true"
   eks:gateway_release_channel: "experimental"
   eks:namespaces:
   - "open-metadata"   # Openmetadata testing


### PR DESCRIPTION
### Description (What does it do?)
- Enable EFS storage provider on all clusters.
- Set reasonable requests and limits for learn-ai celery containers
- Setup more aggressive liveness and readiness probes for apisix's etcd instances. 
- Setup pull through cache images for apisix resources. 
- Changed persistence to use EFS rather than EBS for apisix's etcd instances. 
- Added OU and other tags to core EC2 nodes in each cluster.

I believe the liveness and readiness probes will address some of our stability issues when combined with the storage change.

Basically what I saw happening: 
- AWS instance refresh on the ASG behind the core nodes takes place for whatever reason, doesn't matter.
- By default the instance refresh wants to see 50% of nodes remaining online. Which would be fine if there were 3 nodes in the cluster, it would restart one at a time. But if their are 4, it can restart two at a time...
  - If those two happen to have etcd running on them, the cluster has dropped below N/2+1 instances and ETCD locks up and refuses to work anymore even IF things come back up. 
  - This SHOULDN'T be an issue though because AWS isn't going to actually remove the two nodes until the replacements are online BUT.
  - The default long liveness and readiness probes cause the replacement etcd containers to come online too late to take over for their already terminated ancestors. 
- So, we tell k8s to be more aggressive with keeping an eye on etcd and restart it sooner if there is an issue. 
- Bonus issue:
  - Peristence for etcd was using EBS storage and sometimes when the AZ changes on where the replacement etcd instance came online vs the original, it will struggle to reattach the EBS volume. We can fix this by using EFS which isn't so persnickity about AZ foolishness. We can fallback further by turning persistence off entirely and using emptyDir volumes (ram / local empheral disk to the nodes) but I'm not sure how that will play with ApisixIngressController (does it update the state entirely each time it does something?).  