### PR TITLE
update openedx_login_url

### DIFF
--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.CI.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.CI.yaml
@@ -29,7 +29,7 @@ config:
   learn_ai:frontend_vars:
     MIT_LEARN_APP_BASE_URL: https://rc.learn.mit.edu/
     OPENEDX_API_BASE_URL: https://courses-qa.mitxonline.mit.edu/
-    OPENEDX_LOGIN_URL: https://rc.mitxonline.mit.edu/signin/
+    OPENEDX_LOGIN_URL: https://courses-qa.mitxonline.mit.edu/auth/login/ol-oauth2/?auth_entry=login
     NEXT_PUBLIC_MIT_SEARCH_ELASTIC_URL: https://api.learn.mit.edu/api/v1/learning_resources_search/
     NEXT_PUBLIC_MIT_SEARCH_VECTOR_URL: https://api.learn.mit.edu/api/v0/vector_learning_resources_search/
   learn_ai:frontend_domain: "learn-ai-ci.ol.mit.edu"

--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.Production.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.Production.yaml
@@ -37,7 +37,7 @@ config:
   learn_ai:frontend_vars:
     MIT_LEARN_APP_BASE_URL: https://learn.mit.edu/
     OPENEDX_API_BASE_URL: https://courses.mitxonline.mit.edu/
-    OPENEDX_LOGIN_URL: https://mitxonline.mit.edu/signin/
+    OPENEDX_LOGIN_URL: https://courses.mitxonline.mit.edu/auth/login/ol-oauth2/?auth_entry=login
     NEXT_PUBLIC_MIT_SEARCH_ELASTIC_URL: https://api.learn.mit.edu/api/v1/learning_resources_search/
     NEXT_PUBLIC_MIT_SEARCH_VECTOR_URL: https://api.learn.mit.edu/api/v0/vector_learning_resources_search/
   learn_ai:frontend_domain: "learn-ai.ol.mit.edu"

--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.QA.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.QA.yaml
@@ -42,8 +42,7 @@ config:
   learn_ai:frontend_vars:
     MIT_LEARN_APP_BASE_URL: https://rc.learn.mit.edu/
     OPENEDX_API_BASE_URL: https://courses-qa.mitxonline.mit.edu/
-    OPENEDX_LOGIN_URL: https://rc.mitxonline.mit.edu/signin/
-
+    OPENEDX_LOGIN_URL: https://courses-qa.mitxonline.mit.edu/auth/login/ol-oauth2/?auth_entry=login
     NEXT_PUBLIC_MIT_SEARCH_ELASTIC_URL: https://api.learn.mit.edu/api/v1/learning_resources_search/
     NEXT_PUBLIC_MIT_SEARCH_VECTOR_URL: https://api.learn.mit.edu/api/v0/vector_learning_resources_search/
 


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Updates the login URL introduced in https://github.com/mitodl/learn-ai/pull/141

### How can this be tested?
If you want to test this:
1. Log out of RC mitxonline
2. Visit https://learn-ai-qa.ol.mit.edu/?tab=VideoGPT ... You should see an error that you need to log in.
3. Log into https://courses-qa.mitxonline.mit.edu/auth/login/ol-oauth2/?auth_entry=login
4. Visit https://learn-ai-qa.ol.mit.edu/?tab=VideoGPT ... you should NOT see an error.
