### PR TITLE
pin smoot to 6.2.2

### DIFF
--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -165,7 +165,7 @@ def mfe_job(
         and OpenEdxMicroFrontend[mfe_name].value == OpenEdxMicroFrontend.learn.value
     ):
         mfe_smoot_design_overrides = """
-        npm pack @mitodl/smoot-design@^6.0.0
+        npm pack @mitodl/smoot-design@6.2.2
         tar -xvzf mitodl-smoot-design*.tgz
         mv package mitodl-smoot-design
         """


### PR DESCRIPTION
### What are the relevant tickets?
Temporary remediation to https://github.com/mitodl/hq/issues/7259

### Description (What does it do?)
Based on local testing, v6.2.2 is the last version of `remoteTutorDrawer` that renders the video drawer correctly.


