### PR TITLE
Update env.config.js to avoid double-bundling smoot-design

### DIFF
--- a/src/bridge/settings/openedx/mfe/slot_config/mitxonline/learning-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/mitxonline/learning-mfe-config.env.jsx
@@ -1,3 +1,4 @@
+import { getConfig } from '@edx/frontend-platform';
 import config from './common-mfe-config.env.jsx';
 
 import(
@@ -10,7 +11,7 @@ import(
   /* webpackIgnore: true */
  "/static/smoot-design/remoteTutorDrawer.es.js").then(module => {
    module.init({
-     messageOrigin: "http://local.openedx.io:8000",
+     messageOrigin: getConfig().LMS_BASE_URL,
      transformBody: messages => ({ message: messages[messages.length - 1].content }),
    })
 })

--- a/src/bridge/settings/openedx/mfe/slot_config/mitxonline/learning-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/mitxonline/learning-mfe-config.env.jsx
@@ -1,11 +1,18 @@
-import { getConfig } from '@edx/frontend-platform';
 import config from './common-mfe-config.env.jsx';
-import * as remoteTutorDrawer from "./mitodl-smoot-design/dist/bundles/remoteTutorDrawer.umd.js"
 
-
-remoteTutorDrawer.init({
-  messageOrigin: getConfig().LMS_BASE_URL,
-  transformBody: messages => ({ message: messages[messages.length - 1].content }),
+import(
+  /**
+   * remoteTutorDrawer is already bundled to include its own version
+   * of React and ReactDOM.
+   *
+   * Add webpackIgnore to avoid bundling it again.
+   */
+  /* webpackIgnore: true */
+ "/static/smoot-design/remoteTutorDrawer.es.js").then(module => {
+   module.init({
+     messageOrigin: "http://local.openedx.io:8000",
+     transformBody: messages => ({ message: messages[messages.length - 1].content }),
+   })
 })
 
 export default config;

--- a/src/bridge/settings/openedx/mfe/slot_config/xpro/learning-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/xpro/learning-mfe-config.env.jsx
@@ -1,11 +1,18 @@
-import { getConfig } from '@edx/frontend-platform';
 import config from './common-mfe-config.env.jsx';
-import * as remoteTutorDrawer from "./mitodl-smoot-design/dist/bundles/remoteTutorDrawer.umd.js"
 
-
-remoteTutorDrawer.init({
-  messageOrigin: getConfig().LMS_BASE_URL,
-  transformBody: messages => ({ message: messages[messages.length - 1].content }),
+import(
+  /**
+   * remoteTutorDrawer is already bundled to include its own version
+   * of React and ReactDOM.
+   *
+   * Add webpackIgnore to avoid bundling it again.
+   */
+  /* webpackIgnore: true */
+ "/static/remoteTutorDrawer.es.js").then(module => {
+   module.init({
+     messageOrigin: "http://local.openedx.io:8000",
+     transformBody: messages => ({ message: messages[messages.length - 1].content }),
+   })
 })
 
 export default config;

--- a/src/bridge/settings/openedx/mfe/slot_config/xpro/learning-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/xpro/learning-mfe-config.env.jsx
@@ -1,3 +1,4 @@
+import { getConfig } from '@edx/frontend-platform';
 import config from './common-mfe-config.env.jsx';
 
 import(
@@ -10,8 +11,8 @@ import(
   /* webpackIgnore: true */
  "/static/remoteTutorDrawer.es.js").then(module => {
    module.init({
-     messageOrigin: "http://local.openedx.io:8000",
-     transformBody: messages => ({ message: messages[messages.length - 1].content }),
+      messageOrigin: getConfig().LMS_BASE_URL,
+      transformBody: messages => ({ message: messages[messages.length - 1].content }),
    })
 })
 

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -165,9 +165,10 @@ def mfe_job(
         and OpenEdxMicroFrontend[mfe_name].value == OpenEdxMicroFrontend.learn.value
     ):
         mfe_smoot_design_overrides = """
-        npm pack @mitodl/smoot-design@6.2.2
+        npm pack @mitodl/smoot-design@^6.4.0
         tar -xvzf mitodl-smoot-design*.tgz
-        mv package mitodl-smoot-design
+        mkdir -p public/static/smoot-design
+        cp package/dist/bundles/* public/static/smoot-design
         """
         slot_config_file = "learning-mfe-config"
         copy_common_config = f"cp {mfe_configs.name}/src/bridge/settings/openedx/mfe/slot_config/{open_edx_deployment.deployment_name}/common-mfe-config.env.jsx {mfe_build_dir.name}/common-mfe-config.env.jsx"  # noqa: E501


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7259

### Description (What does it do?)
Loads the remote tutor drawer code from the static directory to avoid re-bundling (via webpack) the already-bundled code.

### Screenshots (if appropriate):
It works again!

<img width="600" alt="Screenshot 2025-05-06 at 2 08 16 PM" src="https://github.com/user-attachments/assets/c5ad8f8b-72c3-40b8-84bb-e7cb211e51bc" />

### How can this be tested?

Follow the steps outlined in https://github.com/mitodl/open-edx-plugins/tree/cc/update-readme/src/ol_openedx_chat. In particular, steps 3 and 4 have changed slightly. You can see the diff here: https://github.com/mitodl/open-edx-plugins/pull/494

