### PR TITLE
Fix static url path

### DIFF
--- a/src/bridge/settings/openedx/mfe/slot_config/mitxonline/learning-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/mitxonline/learning-mfe-config.env.jsx
@@ -9,7 +9,7 @@ import(
    * Add webpackIgnore to avoid bundling it again.
    */
   /* webpackIgnore: true */
- "/static/smoot-design/remoteTutorDrawer.es.js").then(module => {
+ "/learn/static/smoot-design/remoteTutorDrawer.es.js").then(module => {
    module.init({
      messageOrigin: getConfig().LMS_BASE_URL,
      transformBody: messages => ({ message: messages[messages.length - 1].content }),

--- a/src/bridge/settings/openedx/mfe/slot_config/xpro/learning-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/xpro/learning-mfe-config.env.jsx
@@ -9,7 +9,7 @@ import(
    * Add webpackIgnore to avoid bundling it again.
    */
   /* webpackIgnore: true */
- "/static/remoteTutorDrawer.es.js").then(module => {
+ "/learn/static/remoteTutorDrawer.es.js").then(module => {
    module.init({
       messageOrigin: getConfig().LMS_BASE_URL,
       transformBody: messages => ({ message: messages[messages.length - 1].content }),


### PR DESCRIPTION
### What are the relevant tickets?
Followup for https://github.com/mitodl/hq/issues/7259

### Description (What does it do?)
<!--- Describe your changes in detail -->

### How can this be tested?
Observe that MITxOnline:
- currently tries to hit https://courses-qa.mitxonline.mit.edu/static/smoot-design/remoteTutorDrawer.es.js
- ...but the file is actually at https://courses-qa.mitxonline.mit.edu/learn/static/smoot-design/remoteTutorDrawer.es.js

I made the analogous change to xpro based on the existence of https://courses-rc.xpro.mit.edu/learn/static/LmsHtmlFragment.css file.
