### PR TITLE
Keycloak metrics

### DIFF
--- a/src/bilder/images/keycloak/files/docker-compose.yaml
+++ b/src/bilder/images/keycloak/files/docker-compose.yaml
@@ -11,6 +11,9 @@ services:
     - --proxy-headers=xforwarded
     - --cache-stack=postgres-jdbc-ping-tcp
     - --cache-config-file=cache-ispn-jdbc-ping.xml
+    - --metrics-enabled=true
+    - --cache-metrics-histograms-enabled=true
+    - --http-metrics-histograms-enabled=true
     env_file:
     - ./.env
     labels:
@@ -23,6 +26,7 @@ services:
     ports:
     - "7800:7800"
     - "8080:8080"
+    - "9000:9000"
     - "57800:57800"
     volumes:
     - /etc/docker/compose/cache-ispn-jdbc-ping.xml:/opt/keycloak/conf/cache-ispn-jdbc-ping.xml:ro

--- a/src/bilder/images/keycloak/templates/vector/keycloak_logs_metrics.yaml
+++ b/src/bilder/images/keycloak/templates/vector/keycloak_logs_metrics.yaml
@@ -3,7 +3,7 @@ sources:
   collect_keycloak_metrics:
     type: prometheus_scrape
     endpoints:
-    - http://localhost:{{ context.keycloak_prometheus_port }}/realms/master/metrics
+    - http://localhost:9000/metrics
     scrape_interval_secs: 60
 
 transforms:

--- a/src/bilder/images/keycloak/templates/vector/keycloak_logs_metrics.yaml
+++ b/src/bilder/images/keycloak/templates/vector/keycloak_logs_metrics.yaml
@@ -16,6 +16,14 @@ transforms:
       .tags.application = "keycloak"
       .tags.service = "keycloak"
 
+      # Drop metrics if:
+      # 1. Name starts with "vendor_statistics_" AND service is "keycloak"
+      # OR
+      # 2. Name is "http_server_requests_seconds_bucket" AND service is "keycloak"
+      if (starts_with(.name, "vendor_statistics_") || .name == "http_server_requests_seconds_bucket") && .tags.service == "keycloak" {
+        abort
+      }
+
   parse_keycloak_logs:
     type: remap
     inputs:

--- a/src/ol_infrastructure/substructure/keycloak/__main__.py
+++ b/src/ol_infrastructure/substructure/keycloak/__main__.py
@@ -127,6 +127,17 @@ ol_platform_engineering_realm = keycloak.Realm(
     opts=resource_options,
 )
 
+ol_platform_engineering_realm_events = keycloak.RealmEvents(
+    "realmEvents",
+    realm_id=ol_platform_engineering_realm.realm,
+    events_enabled=True,
+    events_expiration=SECONDS_IN_ONE_DAY,
+    admin_events_enabled=True,
+    admin_events_details_enabled=True,
+    events_listeners=["jboss-logging"],
+    opts=resource_options,
+)
+
 required_action_configure_otp = keycloak.RequiredAction(
     "configure-totp",
     realm_id=ol_platform_engineering_realm.realm,
@@ -495,6 +506,17 @@ ol_data_platform_realm = keycloak.Realm(
     offline_session_idle_timeout="168h",
     sso_session_idle_timeout="2h",
     sso_session_max_lifespan="24h",
+    opts=resource_options,
+)
+
+ol_data_platform_realm_events = keycloak.RealmEvents(
+    "realmEvents",
+    realm_id=ol_data_platform_realm.realm,
+    events_enabled=True,
+    events_expiration=SECONDS_IN_ONE_DAY,
+    admin_events_enabled=True,
+    admin_events_details_enabled=True,
+    events_listeners=["jboss-logging"],
     opts=resource_options,
 )
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/ol-infrastructure/issues/3119
### Description (What does it do?)
<!--- Describe your changes in detail -->
This enables Keycloak metrics based on https://www.keycloak.org/observability/configuration-metrics. From a keycloak instance, I can load the results from the localhost:9000/metrics endpoint, however after adding the Grafana dashboards - https://www.keycloak.org/observability/grafana-dashboards, I'm not seeing any of the data in Grafana yet. 
