### PR TITLE
Md/prometheus operator

### DIFF
--- a/src/bridge/lib/versions.py
+++ b/src/bridge/lib/versions.py
@@ -41,3 +41,5 @@ VANTAGE_K8S_AGENT_CHART_VERSION = "1.1.2"
 VAULT_SECRETS_OPERATOR_CHART_VERSION = "0.10.0"
 # renovate: datasource=docker depName=nginx
 NGINX_VERSION = "1.28.0"
+# renovate: datasource=github-releases depName=prometheus-operator packageName=prometheus-operator/prometheus-operator
+PROMETHEUS_OPERATOR_CRD_VERSION = "v0.73.2"

--- a/src/bridge/lib/versions.py
+++ b/src/bridge/lib/versions.py
@@ -42,4 +42,4 @@ VAULT_SECRETS_OPERATOR_CHART_VERSION = "0.10.0"
 # renovate: datasource=docker depName=nginx
 NGINX_VERSION = "1.28.0"
 # renovate: datasource=github-releases depName=prometheus-operator packageName=prometheus-operator/prometheus-operator
-PROMETHEUS_OPERATOR_CRD_VERSION = "v0.73.2"
+PROMETHEUS_OPERATOR_CRD_VERSION = "v0.82.2"

--- a/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
@@ -29,6 +29,7 @@ from bridge.lib.versions import (
     EFS_CSI_DRIVER_VERSION,
     EXTERNAL_DNS_CHART_VERSION,
     GATEWAY_API_VERSION,
+    PROMETHEUS_OPERATOR_CRD_VERSION,
     TRAEFIK_CHART_VERSION,
     VAULT_SECRETS_OPERATOR_CHART_VERSION,
 )
@@ -96,6 +97,9 @@ VERSIONS = {
     ),
     # K8S version is special, retrieve it from the AWS APIs
     "KUBERNETES": os.environ.get("KUBERNETES", get_cluster_version()),
+    "PROMETHEUS_OPERATOR": os.environ.get(
+        "PROMETHEUS_OPERATOR", PROMETHEUS_OPERATOR_CRD_VERSION
+    ),
 }
 
 # A global toleration to allow operators to run on nodes tainted as
@@ -562,11 +566,9 @@ export("namespaces", [*namespaces, "operations"])
 # Install CRDs for Prometheus Operator (ServiceMonitors and PodMonitors)
 # These are typically bundled with kube-prometheus-stack, but we install them separately
 # to allow other tools or lighter-weight Prometheus setups to use them.
-# CRD definitions from Prometheus Operator v0.73.2
 #
 # We install just the four custom resource definitions that alloy supports
-PROMETHEUS_OPERATOR_CRD_VERSION = "v0.73.2"
-PROMETHEUS_OPERATOR_CRD_BASE_URL = f"https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/{PROMETHEUS_OPERATOR_CRD_VERSION}/example/prometheus-operator-crd"
+PROMETHEUS_OPERATOR_CRD_BASE_URL = f"https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/{VERSIONS['PROMETHEUS_OPERATOR']}/example/prometheus-operator-crd"
 
 prometheus_operator_crds = kubernetes.yaml.v2.ConfigGroup(
     f"{cluster_name}-prometheus-operator-crds",

--- a/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
@@ -1136,11 +1136,23 @@ if eks_config.get_bool("apisix_ingress_enabled"):
                 # Disabled for traditional mode
                 "dataPlane": {
                     "enabled": False,
+                    "metrics": {
+                        "enabled": True,
+                        "serviceMonitor": {
+                            "enabled": True,
+                        },
+                    },
                 },
                 # --- Control Plane (Admin API) ---
                 # In traditional mode, this also handles gateway traffic
                 "controlPlane": {
                     "enabled": True,
+                    "metrics": {
+                        "enabled": True,
+                        "serviceMonitor": {
+                            "enabled": True,
+                        },
+                    },
                     "useDaemonSet": True,
                     "pdb": {
                         "create": False

--- a/src/ol_infrastructure/substructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/substructure/aws/eks/__main__.py
@@ -423,6 +423,20 @@ alloy_configmap = kubernetes.core.v1.ConfigMap(
 
             prometheus.operator.servicemonitors "servicemonitors" {{
               forward_to = [prometheus.remote_write.publish_to_grafana.receiver]
+              // Drop metrics that start with go_
+              // These are usually metrics about the exporter itself rather than
+              // the application / service we are interested in.
+              rule {{
+                source_labels = ["__name__"]
+                regex         = "go_.*"
+                action        = "drop"
+              }}
+              // Add cluster label
+              rule {{
+                target_label = "cluster"
+                replacement  = "{cluster_name}"
+                action       = "replace"
+              }}
             }}
 
             // ----------------------------------------------------------

--- a/src/ol_infrastructure/substructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/substructure/aws/eks/__main__.py
@@ -368,6 +368,9 @@ alloy_env_vars_static_secret_config = OLVaultK8SStaticSecretConfig(
         "GRAFANA_CLOUD_LOKI_URL": '{{ get .Secrets "loki_endpoint" }}',
         "GRAFANA_CLOUD_LOKI_PASSWORD": '{{ get .Secrets "loki_api_key" }}',
         "GRAFANA_CLOUD_LOKI_USERNAME": '{{ get .Secrets "loki_user_id" }}',
+        "GRAFANA_CLOUD_PROMETHEUS_URL": '{{ get .Secrets "prometheus_endpoint" }}',
+        "GRAFANA_CLOUD_PROMETHEUS_PASSWORD": '{{ get .Secrets "prometheus_api_key" }}',
+        "GRAFANA_CLOUD_PROMETHEUS_USERNAME": '{{ get .Secrets "prometheus_user_id" }}',
         "GRAFANA_CLOUD_TEMPO_URL": '{{ get .Secrets "tempo_endpoint" }}',
         "GRAFANA_CLOUD_TEMPO_PASSWORD": '{{ get .Secrets "tempo_api_key" }}',
         "GRAFANA_CLOUD_TEMPO_USERNAME": '{{ get .Secrets "tempo_user_id" }}',
@@ -398,13 +401,36 @@ alloy_configmap = kubernetes.core.v1.ConfigMap(
     data={
         "config.alloy": textwrap.dedent(
             f"""
+            // ----------------------------------------------------------
+            // General configuration of loki
             logging {{
               level = "info"
               format = "logfmt"
             }}
 
-            // Collect all pod logs
-discovery.kubernetes "pods" {{
+            // ----------------------------------------------------------
+            // Discover servicemonitor and podmonitor resources in the
+            // cluster and ship their metrics to prometheus @ grafana cloud
+            prometheus.remote_write "publish_to_grafana" {{
+              endpoint {{
+                url = env("GRAFANA_CLOUD_PROMETHEUS_URL")
+                basic_auth {{
+                  username = env("GRAFANA_CLOUD_PROMETHEUS_USERNAME")
+                  password = env("GRAFANA_CLOUD_PROMETHEUS_PASSWORD")
+                }}
+              }}
+            }}
+
+            prometheus.operator.servicemonitors "servicemonitors" {{
+              forward_to = [prometheus.remote_write.publish_to_grafana.receiver]
+            }}
+
+            // ----------------------------------------------------------
+            // Collect all pod logs and cluster events and ship to loki
+            // @ grafana cloud
+
+
+            discovery.kubernetes "pods" {{
               role = "pod"
             }}
 
@@ -550,6 +576,7 @@ discovery.kubernetes "pods" {{
               }}
             }}
 
+            // ----------------------------------------------------------
             // OpenTelemetry trace collection
             otelcol.receiver.otlp "kubernetes_traces" {{
               grpc {{

--- a/src/ol_infrastructure/substructure/aws/eks/karpenter.py
+++ b/src/ol_infrastructure/substructure/aws/eks/karpenter.py
@@ -203,6 +203,9 @@ def setup_karpenter(  # noqa: PLR0913
                         "eks.amazonaws.com/role-arn": karpenter_trust_role.role.arn,
                     },
                 },
+                "serviceMonitor": {  # TODO: doesn't seem to work  # noqa: TD002, TD003, FIX002
+                    "enabled": True,
+                },
                 "controller": {
                     "resources": {
                         "requests": {


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/ol-infrastructure/issues/3204
### Description (What does it do?)
This sets up grafana alloy to act as a prometheus operator within the cluster and additionally creates service monitors for APISIX and traefik.

I tried to add karpenter as a service monitor as well but for some reason it doesn't seem to work and I'd rather move on than spend a bunch of time figuring it out and taking apart the helm chart to see why. 

Service Monitors are CRDs that tell the prometheus operator "go here and look for metrics to scrape". 
