### PR TITLE
fix: Wire up Celery monitoring for apps that are in Kubernetes

### DIFF
--- a/src/ol_infrastructure/applications/celery_monitoring/Pulumi.applications.celery_monitoring.Production.yaml
+++ b/src/ol_infrastructure/applications/celery_monitoring/Pulumi.applications.celery_monitoring.Production.yaml
@@ -17,7 +17,4 @@ config:
     - ocw-studio
     - xpro-production
     odl-devops:
-    - mitxonline-production
     - odl-open-discussions
-    ol-engineering-finance:
-    - mitopen-production

--- a/src/ol_infrastructure/applications/celery_monitoring/Pulumi.applications.celery_monitoring.QA.yaml
+++ b/src/ol_infrastructure/applications/celery_monitoring/Pulumi.applications.celery_monitoring.QA.yaml
@@ -17,7 +17,4 @@ config:
     - ocw-studio-rc
     - xpro-rc
     odl-devops:
-    - mitxonline-rc
     - odl-open-discussions-rc
-    ol-engineering-finance:
-    - mitopen-rc

--- a/src/ol_infrastructure/applications/celery_monitoring/__main__.py
+++ b/src/ol_infrastructure/applications/celery_monitoring/__main__.py
@@ -101,6 +101,9 @@ stacks = [
     f"applications.edxapp.mitx.{stack_info.name}",
     f"applications.edxapp.mitx-staging.{stack_info.name}",
     f"applications.superset.{stack_info.name}",
+    f"applications.mitxonline.{stack_info.name}",
+    f"applications.mit_learn.{stack_info.name}",
+    f"applications.learn_ai.{stack_info.name}",
 ]
 # mitxonline CI is not up at the moment.
 if stack_info.name != "CI":

--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -19,6 +19,7 @@ from pulumi import (
     Output,
     ResourceOptions,
     StackReference,
+    export,
 )
 from pulumi_aws import ec2, get_caller_identity, iam, route53, s3
 
@@ -1213,3 +1214,12 @@ if stack_info.env_suffix != "ci":
         plaintext_value=mitlearn_posthog_secrets["personal_api_key"],
         opts=ResourceOptions(provider=github_provider, delete_before_replace=True),
     )
+
+export(
+    "learn_ai",
+    {
+        "rds_host": learn_ai_db.app_db.db_instance.address,
+        "redis": redis_cache.address,
+        "redis_token": redis_cache.cache_cluster.auth_token,
+    },
+)

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1610,8 +1610,10 @@ learn_external_service_apisix_route = OLApisixRoute(
 
 
 export(
-    "mitopen",
+    "mit_learn",
     {
+        "redis": redis_cache.address,
+        "redis_token": redis_cache.cache_cluster.auth_token,
         "iam_policy": mitopen_iam_policy.arn,
         "vault_iam_role": Output.all(
             mitlearn_vault_iam_role.backend, mitlearn_vault_iam_role.name

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -11,8 +11,7 @@ import os
 from pathlib import Path
 
 import pulumi_vault as vault
-import pulumiverse_heroku as heroku
-from pulumi import Alias, Config, InvokeOptions, ResourceOptions, StackReference, export
+from pulumi import Alias, Config, ResourceOptions, StackReference, export
 from pulumi_aws import ec2, iam, s3
 
 from bridge.lib.magic_numbers import DEFAULT_POSTGRES_PORT, DEFAULT_REDIS_PORT
@@ -50,7 +49,6 @@ from ol_infrastructure.lib.aws.eks_helper import (
 )
 from ol_infrastructure.lib.aws.iam_helper import lint_iam_policy
 from ol_infrastructure.lib.aws.rds_helper import DBInstanceTypes
-from ol_infrastructure.lib.heroku import setup_heroku_provider
 from ol_infrastructure.lib.ol_types import (
     AWSBase,
     BusinessUnit,
@@ -62,10 +60,8 @@ from ol_infrastructure.lib.stack_defaults import defaults
 from ol_infrastructure.lib.vault import setup_vault_provider
 
 setup_vault_provider(skip_child_token=True)
-setup_heroku_provider()
 
 mitxonline_config = Config("mitxonline")
-heroku_config = Config("heroku")
 vault_config = Config("vault")
 
 stack_info = parse_stack()
@@ -208,6 +204,15 @@ mitxonline_vault_backend_role = vault.aws.SecretBackendRole(
     policy_arns=[mitxonline_iam_policy.arn],
 )
 
+mitxonline_app_security_group = ec2.SecurityGroup(
+    f"mitxonline-app-access-{stack_info.env_suffix}",
+    description=f"Access control for the MITx Online App in {stack_info.name}",
+    egress=default_psg_egress_args,
+    ingress=get_default_psg_ingress_args(k8s_pod_subnet_cidrs=k8s_pod_subnet_cidrs),
+    tags=aws_config.tags,
+    vpc_id=apps_vpc["id"],
+)
+
 # Create RDS instance
 mitxonline_db_security_group = ec2.SecurityGroup(
     f"mitxonline-db-access-{stack_info.env_suffix}",
@@ -217,8 +222,7 @@ mitxonline_db_security_group = ec2.SecurityGroup(
             protocol="tcp",
             from_port=DEFAULT_POSTGRES_PORT,
             to_port=DEFAULT_POSTGRES_PORT,
-            cidr_blocks=["0.0.0.0/0"],
-            ipv6_cidr_blocks=["::/0"],
+            security_groups=[mitxonline_app_security_group.id],
             description="Allow access over the public internet from Heroku",
         )
     ],
@@ -257,7 +261,6 @@ mitxonline_db_config.parameter_overrides.append(
     {"name": "password_encryption", "value": "md5"}
 )
 mitxonline_db = OLAmazonDB(mitxonline_db_config)
-export("mitxonline_app", {"rds_host": mitxonline_db.db_instance.address})
 
 mitxonline_vault_backend_config = OLVaultPostgresDatabaseConfig(
     db_name=mitxonline_db_config.db_name,
@@ -308,402 +311,190 @@ openedx_environment = f"mitxonline-{stack_info.env_suffix.lower()}"
 # Construct the RDS endpoint string used by both Heroku and K8s secret generation
 rds_endpoint = f"{db_instance_name}.cbnm7ajau6mi.us-east-1.rds.amazonaws.com:{DEFAULT_POSTGRES_PORT}"
 
-# Vault secrets needed specifically for Heroku deployment
-# These are fetched directly during Pulumi execution.
-if not mitxonline_config.get_bool("k8s_deploy"):
-    auth_aws_mitx_creds_mitxonline = vault.generic.get_secret_output(
-        path="aws-mitx/creds/mitxonline",
-        with_lease_start_time=False,
-        opts=InvokeOptions(parent=mitxonline_vault_backend_role),
-    )
-
-    auth_postgres_mitxonline_creds_app = vault.generic.get_secret_output(
-        path="postgres-mitxonline/creds/app",
-        with_lease_start_time=False,
-        opts=InvokeOptions(parent=mitxonline_vault_backend_role),
-    )
-
-    secret_mitxonline_google_sheets_refunds = vault.generic.get_secret_output(
-        path="secret-mitxonline/google-sheets-refunds",
-        opts=InvokeOptions(parent=mitxonline_vault_backend_role),
-    )
-
-    secret_mitxonline_refine_oidc = vault.generic.get_secret_output(
-        path="secret-mitxonline/refine-oidc",
-        opts=InvokeOptions(parent=mitxonline_vault_backend_role),
-    )
-
-    secret_mitxonline_open_exchange_rates = vault.generic.get_secret_output(
-        path="secret-mitxonline/open-exchange-rates",
-        opts=InvokeOptions(parent=mitxonline_vault_backend_role),
-    )
-
-    secret_mitxonline_recaptcha_keys = vault.generic.get_secret_output(
-        path="secret-mitxonline/recaptcha-keys",
-        opts=InvokeOptions(parent=mitxonline_vault_backend_role),
-    )
-
-    secret_mitxonline_openedx_retirement_service_worker = (
-        vault.generic.get_secret_output(
-            path="secret-mitxonline/openedx-retirement-service-worker",
-            opts=InvokeOptions(parent=mitxonline_vault_backend_role),
-        )
-    )
-
-    secret_mitxonline_env_cybersource_credentials = vault.generic.get_secret_output(
-        path=f"secret-mitxonline/{env_name}/cybersource-credentials",
-        opts=InvokeOptions(parent=mitxonline_vault_backend_role),
-    )
-
-    secret_mitxonline_hubspot_api_private_token = vault.generic.get_secret_output(
-        path="secret-mitxonline/hubspot-api-private-token",
-        opts=InvokeOptions(parent=mitxonline_vault_backend_role),
-    )
-
-    secret_mitxonline_openedx_env_mitxonline_registration_access_token = vault.generic.get_secret_output(
-        path=f"secret-mitxonline/{openedx_environment}/mitxonline-registration-access-token",
-        opts=InvokeOptions(parent=mitxonline_vault_backend_role),
-    )
-
-    secret_mitxonline_env_openedx_api_client = vault.generic.get_secret_output(
-        path=f"secret-mitxonline/{env_name}/openedx-api-client",
-        opts=InvokeOptions(parent=mitxonline_vault_backend_role),
-    )
-
-    secret_mitxonline_env_openedx_service_worker_api_token = (
-        vault.generic.get_secret_output(
-            path=f"secret-mitxonline/{env_name}/openedx-service-worker-api-token",
-            opts=InvokeOptions(parent=mitxonline_vault_backend_role),
-        )
-    )
-
-    secret_mitxonline_env_django_secret_key = vault.generic.get_secret_output(
-        path=f"secret-mitxonline/{env_name}/django-secret-key",
-        opts=InvokeOptions(parent=mitxonline_vault_backend_role),
-    )
-
-    secret_mitxonline_env_django_status_token = vault.generic.get_secret_output(
-        path=f"secret-mitxonline/{env_name}/django-status-token",
-        opts=InvokeOptions(parent=mitxonline_vault_backend_role),
-    )
-
-    secret_mitxonline_posthog_credentials = vault.generic.get_secret_output(
-        path="secret-mitxonline/posthog-credentials",
-        opts=InvokeOptions(parent=mitxonline_vault_backend_role),
-    )
-
-    secret_mitxonline_hubspot = vault.generic.get_secret_output(
-        path="secret-mitxonline/hubspot",
-        opts=InvokeOptions(parent=mitxonline_vault_backend_role),
-    )
-    secret_global_mailgun_api_key = vault.generic.get_secret_output(
-        path="secret-global/mailgun",
-        opts=InvokeOptions(parent=mitxonline_vault_backend_role),
-    )
-    secret_operations_global_mitxonline_sentry_dsn = vault.generic.get_secret_output(
-        path="secret-operations/global/mitxonline/sentry-dsn",
-        opts=InvokeOptions(parent=mitxonline_vault_backend_role),
-    )
-
-    # Combine fetched secrets into the sensitive_env_vars dict for Heroku
-    sensitive_env_vars = {
-        "AWS_ACCESS_KEY_ID": auth_aws_mitx_creds_mitxonline.data.apply(
-            lambda data: "{}".format(data["access_key"])
-        ),
-        "AWS_SECRET_ACCESS_KEY": auth_aws_mitx_creds_mitxonline.data.apply(
-            lambda data: "{}".format(data["secret_key"])
-        ),
-        "DATABASE_URL": auth_postgres_mitxonline_creds_app.data.apply(
-            lambda data: "postgres://{}:{}@{}/mitxonline".format(
-                data["username"], data["password"], rds_endpoint
-            )
-        ),
-        "HUBSPOT_HOME_PAGE_FORM_GUID": secret_mitxonline_hubspot.data.apply(
-            lambda data: "{}".format(data["formId"])
-        ),
-        "HUBSPOT_PORTAL_ID": secret_mitxonline_hubspot.data.apply(
-            lambda data: "{}".format(data["portalId"])
-        ),
-        "MAILGUN_KEY": secret_global_mailgun_api_key.data.apply(
-            lambda data: "{}".format(data["api_key"])
-        ),
-        "MITOL_GOOGLE_SHEETS_DRIVE_API_PROJECT_ID": secret_mitxonline_google_sheets_refunds.data.apply(
-            lambda data: "{}".format(data["drive-api-project-id"])
-        ),
-        "MITOL_GOOGLE_SHEETS_DRIVE_CLIENT_ID": secret_mitxonline_google_sheets_refunds.data.apply(
-            lambda data: "{}".format(data["drive-client-id"])
-        ),
-        "MITOL_GOOGLE_SHEETS_DRIVE_CLIENT_SECRET": secret_mitxonline_google_sheets_refunds.data.apply(
-            lambda data: "{}".format(data["drive-client-secret"])
-        ),
-        "MITOL_GOOGLE_SHEETS_ENROLLMENT_CHANGE_SHEET_ID": secret_mitxonline_google_sheets_refunds.data.apply(
-            lambda data: "{}".format(data["enrollment-change-sheet-id"])
-        ),
-        "MITOL_HUBSPOT_API_PRIVATE_TOKEN": secret_mitxonline_hubspot_api_private_token.data.apply(
-            lambda data: "{}".format(data["value"])
-        ),
-        "MITOL_PAYMENT_GATEWAY_CYBERSOURCE_ACCESS_KEY": secret_mitxonline_env_cybersource_credentials.data.apply(
-            lambda data: "{}".format(data["access-key"])
-        ),
-        "MITOL_PAYMENT_GATEWAY_CYBERSOURCE_MERCHANT_ID": secret_mitxonline_env_cybersource_credentials.data.apply(
-            lambda data: "{}".format(data["merchant-id"])
-        ),
-        "MITOL_PAYMENT_GATEWAY_CYBERSOURCE_MERCHANT_SECRET": secret_mitxonline_env_cybersource_credentials.data.apply(
-            lambda data: "{}".format(data["merchant-secret"])
-        ),
-        "MITOL_PAYMENT_GATEWAY_CYBERSOURCE_MERCHANT_SECRET_KEY_ID": secret_mitxonline_env_cybersource_credentials.data.apply(
-            lambda data: "{}".format(data["merchant-secret-key-id"])
-        ),
-        "MITOL_PAYMENT_GATEWAY_CYBERSOURCE_PROFILE_ID": secret_mitxonline_env_cybersource_credentials.data.apply(
-            lambda data: "{}".format(data["profile-id"])
-        ),
-        "MITOL_PAYMENT_GATEWAY_CYBERSOURCE_SECURITY_KEY": secret_mitxonline_env_cybersource_credentials.data.apply(
-            lambda data: "{}".format(data["security-key"])
-        ),
-        "MITX_ONLINE_REFINE_OIDC_CONFIG_CLIENT_ID": secret_mitxonline_refine_oidc.data.apply(
-            lambda data: "{}".format(data["client-id"])
-        ),
-        "MITX_ONLINE_REGISTRATION_ACCESS_TOKEN": secret_mitxonline_openedx_env_mitxonline_registration_access_token.data.apply(
-            lambda data: "{}".format(data["value"])  # This one stays where it is
-        ),
-        "OIDC_RSA_PRIVATE_KEY": secret_mitxonline_refine_oidc.data.apply(
-            lambda data: "{}".format(data["rsa-private-key"])
-        ),
-        "OPENEDX_API_CLIENT_ID": secret_mitxonline_env_openedx_api_client.data.apply(
-            lambda data: "{}".format(data["client-id"])
-        ),
-        "OPENEDX_API_CLIENT_SECRET": secret_mitxonline_env_openedx_api_client.data.apply(
-            lambda data: "{}".format(data["client-secret"])
-        ),
-        "OPENEDX_RETIREMENT_SERVICE_WORKER_CLIENT_ID": secret_mitxonline_openedx_retirement_service_worker.data.apply(
-            lambda data: "{}".format(data["client_id"])  # this one stays
-        ),
-        "OPENEDX_RETIREMENT_SERVICE_WORKER_CLIENT_SECRET": secret_mitxonline_openedx_retirement_service_worker.data.apply(
-            lambda data: "{}".format(data["client_secret"])  # this one stays
-        ),
-        "OPENEDX_SERVICE_WORKER_API_TOKEN": secret_mitxonline_env_openedx_service_worker_api_token.data.apply(
-            lambda data: "{}".format(data["value"])  # this one stays
-        ),
-        "OPEN_EXCHANGE_RATES_APP_ID": secret_mitxonline_open_exchange_rates.data.apply(
-            lambda data: "{}".format(data["app_id"])
-        ),
-        "POSTHOG_PROJECT_API_KEY": secret_mitxonline_posthog_credentials.data.apply(
-            lambda data: "{}".format(data["api-token"])
-        ),
-        "POSTHOG_API_TOKEN": secret_mitxonline_posthog_credentials.data.apply(
-            lambda data: "{}".format(data["api-token"])
-        ),  # This one stays where it is
-        "RECAPTCHA_SECRET_KEY": secret_mitxonline_recaptcha_keys.data.apply(
-            lambda data: "{}".format(data["secret_key"])
-        ),
-        "RECAPTCHA_SITE_KEY": secret_mitxonline_recaptcha_keys.data.apply(
-            lambda data: "{}".format(data["site_key"])
-        ),
-        "SECRET_KEY": secret_mitxonline_env_django_secret_key.data.apply(
-            lambda data: "{}".format(data["value"])
-        ),
-        "SENTRY_DSN": secret_operations_global_mitxonline_sentry_dsn.data.apply(
-            lambda data: "{}".format(data["value"])
-        ),
-        "STATUS_TOKEN": secret_mitxonline_env_django_status_token.data.apply(
-            lambda data: "{}".format(data["value"])
-        ),
-    }
-
-    # Configure Heroku app with the fetched secrets
-    heroku_app_id = heroku_config.require("app_id")
-    mitxonline_heroku_configassociation = heroku.app.ConfigAssociation(
-        f"mitxonline-{stack_info.env_suffix}-heroku-configassociation",
-        app_id=heroku_app_id,
-        sensitive_vars=sensitive_env_vars,
-        vars=env_vars,
-    )
-
 # Begin k8s resources
-if mitxonline_config.get_bool("k8s_deploy"):
-    # TODO (TMM 2025-05-06): The vault mount is also # noqa: TD003, FIX002
-    # created/managed as part of the edxapp project. This needs to be factored out into
-    # a substructure project or referenced from one stack to the other via stack
-    # references. There is some ambiguity about the properl directionality of ownership.
-    mitxonline_vault_mount = vault.Mount(
-        f"mitxonline-vault-mount-{stack_info.env_suffix}",
-        description="Static secrets storage for Open edX {stack_info.env_prefix} applications and services",
-        path="secret-mitxonline",
-        type="kv",
-    )
-    mitxonline_collected_secrets = read_yaml_secrets(
-        Path(f"mitxonline/secrets.{stack_info.env_suffix}.yaml")
-    )
-    mitxonline_vault_collected_static_secrets = vault.generic.Secret(
-        f"mitxonline-collected-static-secrets-{stack_info.env_suffix}",
-        path="secret-mitxonline/collected-static-secrets",
-        data_json=json.dumps(mitxonline_collected_secrets),
-        opts=ResourceOptions(depends_on=[mitxonline_vault_mount]),
-    )
+# TODO (TMM 2025-05-06): The vault mount is also # noqa: TD003, FIX002
+# created/managed as part of the edxapp project. This needs to be factored out into
+# a substructure project or referenced from one stack to the other via stack
+# references. There is some ambiguity about the properl directionality of ownership.
+mitxonline_vault_mount = vault.Mount(
+    f"mitxonline-vault-mount-{stack_info.env_suffix}",
+    description="Static secrets storage for Open edX {stack_info.env_prefix} applications and services",
+    path="secret-mitxonline",
+    type="kv",
+)
+mitxonline_collected_secrets = read_yaml_secrets(
+    Path(f"mitxonline/secrets.{stack_info.env_suffix}.yaml")
+)
+mitxonline_vault_collected_static_secrets = vault.generic.Secret(
+    f"mitxonline-collected-static-secrets-{stack_info.env_suffix}",
+    path="secret-mitxonline/collected-static-secrets",
+    data_json=json.dumps(mitxonline_collected_secrets),
+    opts=ResourceOptions(depends_on=[mitxonline_vault_mount]),
+)
 
-    mitxonline_app_security_group = ec2.SecurityGroup(
-        f"mitxonline-app-access-{stack_info.env_suffix}",
-        description=f"Access control for the MITx Online App in {stack_info.name}",
-        egress=default_psg_egress_args,
-        ingress=get_default_psg_ingress_args(k8s_pod_subnet_cidrs=k8s_pod_subnet_cidrs),
-        tags=aws_config.tags,
-        vpc_id=apps_vpc["id"],
-    )
+mitxonline_vault_policy = vault.Policy(
+    f"mitxonline-vault-policy-{stack_info.env_suffix}",
+    name="mitxonline",
+    policy=Path(__file__).parent.joinpath("mitxonline_policy.hcl").read_text(),
+)
 
-    mitxonline_vault_policy = vault.Policy(
-        f"mitxonline-vault-policy-{stack_info.env_suffix}",
-        name="mitxonline",
-        policy=Path(__file__).parent.joinpath("mitxonline_policy.hcl").read_text(),
-    )
+mitxonline_vault_k8s_auth_backend_role = vault.kubernetes.AuthBackendRole(
+    f"mitxonline-vault-k8s-auth-backend-role-{stack_info.env_suffix}",
+    role_name=Services.mitxonline,
+    backend=cluster_stack.require_output("vault_auth_endpoint"),
+    bound_service_account_names=["*"],
+    bound_service_account_namespaces=[mitxonline_namespace],
+    token_policies=[mitxonline_vault_policy.name],
+)
 
-    mitxonline_vault_k8s_auth_backend_role = vault.kubernetes.AuthBackendRole(
-        f"mitxonline-vault-k8s-auth-backend-role-{stack_info.env_suffix}",
-        role_name=Services.mitxonline,
-        backend=cluster_stack.require_output("vault_auth_endpoint"),
-        bound_service_account_names=["*"],
-        bound_service_account_namespaces=[mitxonline_namespace],
-        token_policies=[mitxonline_vault_policy.name],
-    )
+vault_k8s_resources = OLVaultK8SResources(
+    resource_config=OLVaultK8SResourcesConfig(
+        application_name=Services.mitxonline,
+        namespace=mitxonline_namespace,
+        labels=k8s_global_labels,
+        vault_address=vault_config.require("address"),
+        vault_auth_endpoint=cluster_stack.require_output("vault_auth_endpoint"),
+        vault_auth_role_name=mitxonline_vault_k8s_auth_backend_role.role_name,
+    ),
+    opts=ResourceOptions(
+        delete_before_replace=True,
+    ),
+)
 
-    vault_k8s_resources = OLVaultK8SResources(
-        resource_config=OLVaultK8SResourcesConfig(
-            application_name=Services.mitxonline,
-            namespace=mitxonline_namespace,
-            labels=k8s_global_labels,
-            vault_address=vault_config.require("address"),
-            vault_auth_endpoint=cluster_stack.require_output("vault_auth_endpoint"),
-            vault_auth_role_name=mitxonline_vault_k8s_auth_backend_role.role_name,
+# Redis / Elasticache
+# only for applications deployed in k8s
+redis_config = Config("redis")
+redis_cluster_security_group = ec2.SecurityGroup(
+    f"mitxonline-redis-cluster-security-group-{stack_info.env_suffix}",
+    name_prefix=f"mitxonline-redis-cluster-security-group-{stack_info.env_suffix}",
+    description="Access control for the mitxonline redis cluster.",
+    ingress=[
+        ec2.SecurityGroupIngressArgs(
+            security_groups=[mitxonline_app_security_group.id],
+            protocol="tcp",
+            from_port=DEFAULT_REDIS_PORT,
+            to_port=DEFAULT_REDIS_PORT,
+            description="Allow application pods to talk to Redis",
         ),
-        opts=ResourceOptions(
-            delete_before_replace=True,
-        ),
-    )
+    ],
+    vpc_id=apps_vpc["id"],
+    tags=aws_config.tags,
+)
+redis_cache_config = OLAmazonRedisConfig(
+    encrypt_transit=True,
+    auth_token=redis_config.require("password"),
+    cluster_mode_enabled=False,
+    encrypted=True,
+    engine_version="7.1",
+    num_instances=3,
+    shard_count=1,
+    auto_upgrade=True,
+    cluster_description="Redis cluster for MITxonline",
+    cluster_name=f"mitxonline-app-redis-{stack_info.env_suffix}",
+    subnet_group=apps_vpc["elasticache_subnet"],
+    security_groups=[redis_cluster_security_group.id],
+    tags=aws_config.tags,
+    **defaults(stack_info)["redis"],
+)
+redis_cache = OLAmazonCache(redis_cache_config)
 
-    # Redis / Elasticache
-    # only for applications deployed in k8s
-    redis_config = Config("redis")
-    redis_cluster_security_group = ec2.SecurityGroup(
-        f"mitxonline-redis-cluster-security-group-{stack_info.env_suffix}",
-        name_prefix=f"mitxonline-redis-cluster-security-group-{stack_info.env_suffix}",
-        description="Access control for the mitxonline redis cluster.",
-        ingress=[
-            ec2.SecurityGroupIngressArgs(
-                security_groups=[mitxonline_app_security_group.id],
-                protocol="tcp",
-                from_port=DEFAULT_REDIS_PORT,
-                to_port=DEFAULT_REDIS_PORT,
-                description="Allow application pods to talk to Redis",
+# Create Kubernetes secrets using the dedicated function
+# The function returns the names of the secrets and the Pulumi resource objects
+secret_names, secret_resources = create_mitxonline_k8s_secrets(
+    stack_info=stack_info,
+    mitxonline_namespace=mitxonline_namespace,
+    k8s_global_labels=k8s_global_labels,
+    vault_k8s_resources=vault_k8s_resources,
+    db_config=mitxonline_vault_backend,  # Pass the Vault DB backend config
+    rds_endpoint=rds_endpoint,
+    openedx_environment=openedx_environment,
+    redis_password=redis_config.require("password"),
+    redis_cache=redis_cache,
+)
+
+if "MITXONLINE_DOCKER_TAG" not in os.environ:
+    msg = "MITXONLINE_DOCKER_TAG must be set."
+    raise OSError(msg)
+MITXONLINE_DOCKER_TAG = os.environ["MITXONLINE_DOCKER_TAG"]
+
+mitxonline_k8s_app = OLApplicationK8s(
+    ol_app_k8s_config=OLApplicationK8sConfig(
+        project_root=Path(__file__).parent,
+        application_config=env_vars,
+        application_name=Services.mitxonline,
+        application_namespace=mitxonline_namespace,
+        application_lb_service_name="mitxonline-webapp",
+        application_lb_service_port_name="http",
+        k8s_global_labels=k8s_global_labels,
+        # Use the secret names returned by create_mitxonline_k8s_secrets
+        env_from_secret_names=secret_names,
+        application_security_group_id=mitxonline_app_security_group.id,
+        application_security_group_name=mitxonline_app_security_group.name,
+        application_image_repository="mitodl/mitxonline-app",
+        application_docker_tag=MITXONLINE_DOCKER_TAG,
+        application_cmd_array=[
+            "uwsgi",
+            "/tmp/uwsgi.ini",  # noqa: S108
+        ],
+        vault_k8s_resource_auth_name=vault_k8s_resources.auth_name,
+        import_nginx_config=True,
+        import_uwsgi_config=True,
+        resource_requests={"cpu": "500m", "memory": "512Mi"},
+        resource_limits={"cpu": "1000m", "memory": "1024Mi"},
+        init_migrations=True,
+        init_collectstatic=True,
+        celery_worker_configs=[
+            OLApplicationK8sCeleryWorkerConfig(
+                worker_name="default",
+                queues=["default", "hubspot_sync"],
+                resource_requests={"cpu": "500m", "memory": "1024Mi"},
+                resource_limits={"cpu": "1000m", "memory": "2048Mi"},
             ),
         ],
-        vpc_id=apps_vpc["id"],
-        tags=aws_config.tags,
-    )
-    redis_cache_config = OLAmazonRedisConfig(
-        encrypt_transit=True,
-        auth_token=redis_config.require("password"),
-        cluster_mode_enabled=False,
-        encrypted=True,
-        engine_version="7.1",
-        num_instances=3,
-        shard_count=1,
-        auto_upgrade=True,
-        cluster_description="Redis cluster for MITxonline",
-        cluster_name=f"mitxonline-app-redis-{stack_info.env_suffix}",
-        subnet_group=apps_vpc["elasticache_subnet"],
-        security_groups=[redis_cluster_security_group.id],
-        tags=aws_config.tags,
-        **defaults(stack_info)["redis"],
-    )
-    redis_cache = OLAmazonCache(redis_cache_config)
+    ),
+    opts=ResourceOptions(
+        # Ensure secrets are created before the application deployment
+        depends_on=[mitxonline_app_security_group, *secret_resources]
+    ),
+)
 
-    # Create Kubernetes secrets using the dedicated function
-    # The function returns the names of the secrets and the Pulumi resource objects
-    secret_names, secret_resources = create_mitxonline_k8s_secrets(
-        stack_info=stack_info,
-        mitxonline_namespace=mitxonline_namespace,
-        k8s_global_labels=k8s_global_labels,
-        vault_k8s_resources=vault_k8s_resources,
-        db_config=mitxonline_vault_backend,  # Pass the Vault DB backend config
-        rds_endpoint=rds_endpoint,
-        openedx_environment=openedx_environment,
-        redis_password=redis_config.require("password"),
-        redis_cache=redis_cache,
-    )
-
-    if "MITXONLINE_DOCKER_TAG" not in os.environ:
-        msg = "MITXONLINE_DOCKER_TAG must be set."
-        raise OSError(msg)
-    MITXONLINE_DOCKER_TAG = os.environ["MITXONLINE_DOCKER_TAG"]
-
-    mitxonline_k8s_app = OLApplicationK8s(
-        ol_app_k8s_config=OLApplicationK8sConfig(
-            project_root=Path(__file__).parent,
-            application_config=env_vars,
-            application_name=Services.mitxonline,
-            application_namespace=mitxonline_namespace,
-            application_lb_service_name="mitxonline-webapp",
-            application_lb_service_port_name="http",
-            k8s_global_labels=k8s_global_labels,
-            # Use the secret names returned by create_mitxonline_k8s_secrets
-            env_from_secret_names=secret_names,
-            application_security_group_id=mitxonline_app_security_group.id,
-            application_security_group_name=mitxonline_app_security_group.name,
-            application_image_repository="mitodl/mitxonline-app",
-            application_docker_tag=MITXONLINE_DOCKER_TAG,
-            application_cmd_array=[
-                "uwsgi",
-                "/tmp/uwsgi.ini",  # noqa: S108
-            ],
-            vault_k8s_resource_auth_name=vault_k8s_resources.auth_name,
-            import_nginx_config=True,
-            import_uwsgi_config=True,
-            resource_requests={"cpu": "500m", "memory": "512Mi"},
-            resource_limits={"cpu": "1000m", "memory": "1024Mi"},
-            init_migrations=True,
-            init_collectstatic=True,
-            celery_worker_configs=[
-                OLApplicationK8sCeleryWorkerConfig(
-                    worker_name="default",
-                    queues=["celery", "hubspot_sync"],
-                    resource_requests={"cpu": "500m", "memory": "1024Mi"},
-                    resource_limits={"cpu": "1000m", "memory": "2048Mi"},
-                ),
-            ],
-        ),
-        opts=ResourceOptions(
-            # Ensure secrets are created before the application deployment
-            depends_on=[mitxonline_app_security_group, *secret_resources]
-        ),
-    )
-
-    frontend_tls_secret_name = "mitxonline-tls-pair"  # noqa: S105  # pragma: allowlist secret
-    cert_manager_certificate = OLCertManagerCert(
-        f"mitxonline-cert-manager-certificate-{stack_info.env_suffix}",
-        cert_config=OLCertManagerCertConfig(
-            application_name="mitxonline",
-            k8s_namespace=mitxonline_namespace,
-            k8s_labels=k8s_global_labels,
-            create_apisixtls_resource=True,
-            dest_secret_name=frontend_tls_secret_name,
-            dns_names=[mitxonline_config.require("domain")],
-        ),
-    )
-    mitxonline_apisix_route_prefix = OLApisixRoute(
-        name=f"mitxonline-apisix-route-{stack_info.env_suffix}",
+frontend_tls_secret_name = "mitxonline-tls-pair"  # noqa: S105  # pragma: allowlist secret
+cert_manager_certificate = OLCertManagerCert(
+    f"mitxonline-cert-manager-certificate-{stack_info.env_suffix}",
+    cert_config=OLCertManagerCertConfig(
+        application_name="mitxonline",
         k8s_namespace=mitxonline_namespace,
         k8s_labels=k8s_global_labels,
-        route_configs=[
-            OLApisixRouteConfig(
-                route_name="app-wildcard",
-                priority=10,
-                hosts=[mitxonline_config.require("domain")],
-                paths=["/*"],
-                plugins=[],
-                backend_service_name=mitxonline_k8s_app.application_lb_service_name,
-                backend_service_port=mitxonline_k8s_app.application_lb_service_port_name,
-            ),
-        ],
-        opts=ResourceOptions(
-            delete_before_replace=True,
+        create_apisixtls_resource=True,
+        dest_secret_name=frontend_tls_secret_name,
+        dns_names=[mitxonline_config.require("domain")],
+    ),
+)
+mitxonline_apisix_route_prefix = OLApisixRoute(
+    name=f"mitxonline-apisix-route-{stack_info.env_suffix}",
+    k8s_namespace=mitxonline_namespace,
+    k8s_labels=k8s_global_labels,
+    route_configs=[
+        OLApisixRouteConfig(
+            route_name="app-wildcard",
+            priority=10,
+            hosts=[mitxonline_config.require("domain")],
+            paths=["/*"],
+            plugins=[],
+            backend_service_name=mitxonline_k8s_app.application_lb_service_name,
+            backend_service_port=mitxonline_k8s_app.application_lb_service_port_name,
         ),
-    )
+    ],
+    opts=ResourceOptions(
+        delete_before_replace=True,
+    ),
+)
+
+export(
+    "mitxonline",
+    {
+        "rds_host": mitxonline_db.db_instance.address,
+        "redis": redis_cache.address,
+        "redis_token": redis_cache.cache_cluster.auth_token,
+    },
+)


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Gets celery monitoring wired back up for apps that moved to Kubernetes

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Deploy it and make sure that the apps show up in the celery monitoring stack.
