### PR TITLE
feat: update mitxonline edx logos to learn

### DIFF
--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -405,7 +405,7 @@ LOGIN_REDIRECT_WHITELIST:  # MODIFIED
 LOG_DIR: /openedx/data/var/log/ed/openedx/data/var/log/edx
 LOGO_URL: https://{{ key "edxapp/lms-domain" }}/static/mitxonline/images/logo.svg
 LOGO_URL_PNG_FOR_EMAIL: https://{{ key "edxapp/lms-domain" }}/static/mitxonline/images/logo.png
-LOGO_TRADEMARK_URL: https://{{ key "edxapp/lms-domain" }}/static/mitxonline/images/mit-ol-logo.svg
+LOGO_TRADEMARK_URL: https://{{ key "edxapp/lms-domain" }}/static/mitxonline/images/mit-logo.svg
 MAINTENANCE_BANNER_TEXT: Sample banner message
 MARKETING_SITE_BASE_URL: https://{{ key "edxapp/marketing-domain" }}/ # ADDED - to support mitxonline-theme
 MARKETING_SITE_CHECKOUT_URL: https://{{ key "edxapp/marketing-domain" }}/cart/add/ # ADDED - to support mitxonline checkout

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -412,6 +412,7 @@ MARKETING_SITE_CHECKOUT_URL: https://{{ key "edxapp/marketing-domain" }}/cart/ad
 MEDIA_ROOT: media/  # MODIFIED - with s3 storage backend this is the path within the bucket. No leading / allowed
 MEDIA_URL: /media/
 MICROSITE_CONFIGURATION: {}
+MIT_BASE_URL: https://mit.edu # Keeping it hardcoded till we change MARKETING_SITE_BASE_URL
 MITX_REDIRECT_ENABLED: True
 MITX_REDIRECT_ALLOW_RE_LIST: ["^/(admin|auth|logout|register|api|oauth2|user_api|heartbeat|login_refresh|c4x|asset-v1:|assets/courseware/)", "^/courses/.*/xblock/.*/handler_noauth/outcome_service_handler", "^/v1/accounts/bulk_retire_users"]  # ADDED VALUE
 MKTG_URLS:

--- a/src/bridge/settings/openedx/mfe/slot_config/mitxonline/common-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/mitxonline/common-mfe-config.env.jsx
@@ -86,7 +86,7 @@ const footerSubSlotsConfig = {
           id: 'custom_logo',
           type: DIRECT_PLUGIN,
           RenderWidget: () => (
-            <Logo imageUrl={configData.LOGO_URL} destinationUrl={configData.MARKETING_SITE_BASE_URL} />
+            <Logo imageUrl={configData.LOGO_TRADEMARK_URL} destinationUrl={process.env.MIT_BASE_URL} />
           ),
         },
       },

--- a/src/ol_concourse/pipelines/open_edx/mfe/values.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/values.py
@@ -110,6 +110,7 @@ mitxonline = [
         lms_domain="courses-ci.mitxonline.mit.edu",
         logo_url="https://courses-ci.mitxonline.mit.edu/static/mitxonline/images/logo.svg",
         marketing_site_domain="ci.mitxonline.mit.edu",
+        mit_base_url="https://mit.edu",
         privacy_policy_url="https://ci.mitxonline.mit.edu/privacy-policy/",
         schedule_email_section="true",  # Because the communication MFE treats this boolean as string  # noqa: E501
         site_name="MITx Online CI",
@@ -117,7 +118,7 @@ mitxonline = [
         support_url="mitxonline.zendesk.com/hc/",
         terms_of_service_url="https://ci.mitxonline.mit.edu/terms-of-service/",
         trademark_text="© MITx Online. All rights reserved except where noted.",
-        logo_trademark_url="https://courses-ci.mitxonline.mit.edu/static/mitxonline/images/mit-ol-logo.svg",
+        logo_trademark_url="https://courses-ci.mitxonline.mit.edu/static/mitxonline/images/mit-logo.svg",
     ),
     OpenEdxVars(
         about_us_url="https://rc.mitxonline.mit.edu/about-us/",
@@ -133,6 +134,7 @@ mitxonline = [
         lms_domain="courses-qa.mitxonline.mit.edu",
         logo_url="https://courses-qa.mitxonline.mit.edu/static/mitxonline/images/logo.svg",
         marketing_site_domain="rc.mitxonline.mit.edu",
+        mit_base_url="https://mit.edu",
         privacy_policy_url="https://rc.mitxonline.mit.edu/privacy-policy/",
         schedule_email_section="true",  # Because the communication MFE treats this boolean as string  # noqa: E501
         site_name="MITx Online QA",
@@ -140,7 +142,7 @@ mitxonline = [
         support_url="mitxonline.zendesk.com/hc/",
         terms_of_service_url="https://rc.mitxonline.mit.edu/terms-of-service/",
         trademark_text="© MITx Online. All rights reserved except where noted.",
-        logo_trademark_url="https://courses-qa.mitxonline.mit.edu/static/mitxonline/images/mit-ol-logo.svg",
+        logo_trademark_url="https://courses-qa.mitxonline.mit.edu/static/mitxonline/images/mit-logo.svg",
     ),
     OpenEdxVars(
         about_us_url="https://mitxonline.mit.edu/about-us/",
@@ -156,6 +158,7 @@ mitxonline = [
         lms_domain="courses.mitxonline.mit.edu",
         logo_url="https://courses.mitxonline.mit.edu/static/mitxonline/images/logo.svg",
         marketing_site_domain="mitxonline.mit.edu",
+        mit_base_url="https://mit.edu",
         privacy_policy_url="https://mitxonline.mit.edu/privacy-policy/",
         schedule_email_section="true",  # Because the communication MFE treats this boolean as string  # noqa: E501
         site_name="MITx Online",
@@ -163,7 +166,7 @@ mitxonline = [
         support_url="mitxonline.zendesk.com/hc/",
         terms_of_service_url="https://mitxonline.mit.edu/terms-of-service/",
         trademark_text="© MITx Online. All rights reserved except where noted.",
-        logo_trademark_url="https://courses.mitxonline.mit.edu/static/mitxonline/images/mit-ol-logo.svg",
+        logo_trademark_url="https://courses.mitxonline.mit.edu/static/mitxonline/images/mit-logo.svg",
     ),
 ]
 


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
First part of https://github.com/mitodl/hq/issues/7233 to update logos

### Description (What does it do?)
<!--- Describe your changes in detail -->
Updates the MITx Online logo to MIT Learn and trademark logo to MIT logo.
