### PR TITLE
config: Enable Keycloak auth via APISIX for MITx Online

### DIFF
--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.CI.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.CI.yaml
@@ -15,6 +15,7 @@ config:
     LOGOUT_REDIRECT_URL: "https://courses-qa.mitxonline.mit.edu/logout" # Points to RC
     MAILGUN_FROM_EMAIL: "MITx Online <no-reply@mitxonline-rc-mail.mitxonline.mit.edu>"
     MAILGUN_SENDER_DOMAIN: "mitxonline-rc-mail.mitxonline.mit.edu"
+    MITOL_APIGATEWAY_DISABLE_MIDDLEWARE: "false"
     MITOL_GOOGLE_SHEETS_PROCESSOR_APP_NAME: "MITx Online (ci)"
     MITOL_GOOGLE_SHEETS_REFUNDS_FIRST_ROW: "4"
     MITOL_GOOGLE_SHEETS_REFUNDS_REQUEST_WORKSHEET_ID: "0"

--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.Production.yaml
@@ -25,6 +25,7 @@ config:
     LOGOUT_REDIRECT_URL: "https://courses.mitxonline.mit.edu/logout"
     MAILGUN_FROM_EMAIL: "MITx Online <no-reply@mail.mitxonline.mit.edu>"
     MAILGUN_SENDER_DOMAIN: "mail.mitxonline.mit.edu"
+    MITOL_APIGATEWAY_DISABLE_MIDDLEWARE: "true"
     MITOL_GOOGLE_SHEETS_DEFERRALS_REQUEST_WORKSHEET_ID: "268521316"
     MITOL_GOOGLE_SHEETS_PROCESSOR_APP_NAME: "MITx Online (production)"
     MITOL_GOOGLE_SHEETS_PROCESS_ONLY_LAST_ROWS_NUM: "30"

--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.QA.yaml
@@ -21,6 +21,7 @@ config:
     LOGOUT_REDIRECT_URL: "https://courses-qa.mitxonline.mit.edu/logout"
     MAILGUN_FROM_EMAIL: "MITx Online <no-reply@mitxonline-rc-mail.mitxonline.mit.edu>"
     MAILGUN_SENDER_DOMAIN: "mitxonline-rc-mail.mitxonline.mit.edu"
+    MITOL_APIGATEWAY_DISABLE_MIDDLEWARE: "false"
     MITOL_GOOGLE_SHEETS_PROCESSOR_APP_NAME: "MITx Online (rc)"
     MITOL_GOOGLE_SHEETS_REFUNDS_FIRST_ROW: "4"
     MITOL_GOOGLE_SHEETS_REFUNDS_REQUEST_WORKSHEET_ID: "0"

--- a/src/ol_infrastructure/applications/mitxonline/mitxonline_policy.hcl
+++ b/src/ol_infrastructure/applications/mitxonline/mitxonline_policy.hcl
@@ -41,3 +41,7 @@ path "sys/leases/revoke" {
     lease_id = ["postgres-mitopen/creds/app/*"]
   }
 }
+
+path "secret-operations/sso/mitlearn" {
+  capabilities = ["read"]
+}

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.CI.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.CI.yaml
@@ -57,6 +57,7 @@ config:
   - "https://ci.learn.mit.edu/*"
   - "https://learn-ai-ci.ol.mit.edu/*"
   - "https://pay-ci.ol.mit.edu/*"
+  - "https://ci.mitxonline.mit.edu/*"
   keycloak_realm:olapps-mitlearn-client-redirect-uris:
   - "https://api.ci.learn.mit.edu/*"
   - "https://ci.learn.mit.edu/*"
@@ -64,6 +65,8 @@ config:
   - "https://learn-ai-ci.ol.mit.edu/*"
   - "https://api-pay-ci.ol.mit.edu/*"
   - "https://pay-ci.ol.mit.edu/*"
+  - "https://ci.mitxonline.mit.edu/*"
+  - "https://api.ci.mitxonline.mit.edu/*"
   keycloak_realm:olapps-mitlearn-client-secret:
     secure: v1:sJuWLKHeep4Qz9cr:YbZNIQoy3Bn1nbpKsCUPNUeEtZJgd+tA5LAU8pDfSKWr2fzvjfMy0XcmO4CR7a3q
   keycloak_realm:olapps-open-discussions-client-redirect-uris: ["https://discussions-ci.odl.mit.edu/*"]

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.Production.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.Production.yaml
@@ -41,10 +41,13 @@ config:
   - "https://learn-ai.ol.mit.edu/*"
   - "https://api-pay.ol.mit.edu/*"
   - "https://pay.ol.mit.edu/*"
+  - "https://mitxonline.mit.edu/*"
+  - "https://api.mitxonline.mit.edu/*"
   keycloak_realm:olapps-mitlearn-client-roles:
   - "https://learn.mit.edu/*"
   - "https://learn-ai.ol.mit.edu/*"
   - "https://pay.ol.mit.edu/*"
+  - "https://mitxonline.mit.edu/*"
   keycloak_realm:olapps-open-discussions-client-redirect-uris: ["https://open.mit.edu/*"]
   keycloak_realm:ol-platform-engineering-airbyte-redirect-uris: ["https://airbyte.odl.mit.edu/*"]
   keycloak_realm:ol-platform-engineering-dagster-redirect-uris: ["https://pipelines.odl.mit.edu/*"]

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
@@ -44,10 +44,13 @@ config:
   - "https://learn-ai.ol.mit.edu/*"
   - "https://api-pay-qa.ol.mit.edu/*"
   - "https://pay-qa.ol.mit.edu/*"
+  - "https://rc.mitxonline.mit.edu/*"
+  - "https://api.rc.mitxonline.mit.edu/*"
   keycloak_realm:olapps-mitlearn-client-roles:
   - "https://rc.learn.mit.edu/*"
   - "https://learn-ai.ol.mit.edu/*"
   - "https://pay-qa.ol.mit.edu/*"
+  - "https://rc.mitxonline.mit.edu/*"
   keycloak_realm:olapps-open-discussions-client-redirect-uris: ["https://discussions-rc.odl.mit.edu/*"]
   keycloak_realm:ol-platform-engineering-airbyte-redirect-uris: ["https://airbyte-qa.odl.mit.edu/*"]
   keycloak_realm:ol-platform-engineering-dagster-redirect-uris: ["https://pipelines-qa.odl.mit.edu/*"]


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds Keycloak OIDC config for MITx Online


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Try to trigger a Keycloak login by hitting api.rc.mitxonline.mit.edu/login, and then logout 
