### PR TITLE
Helper script for developer EKS access

### DIFF
--- a/scripts/eks/KUBE_ACCESS.md
+++ b/scripts/eks/KUBE_ACCESS.md
@@ -9,5 +9,5 @@ for regenerating AWS creds, creating/overwriting your `~/.kube/config` file,
 setting a context (default is "applications-qa") and optionally listing the
 pods available in a namespace.
 
-You should run `source eks.env` after the script finishes to ensure the 
+You should run `source eks.env` after the script finishes to ensure the
 environment values are applied to your shell.

--- a/scripts/eks/KUBE_ACCESS.md
+++ b/scripts/eks/KUBE_ACCESS.md
@@ -1,0 +1,10 @@
+# Developer EKS Access
+
+See https://pe.ol.mit.edu/how_to/developer_eks_access/ for instructions on
+how to initially set up developer access to EKS and learn about the available
+commands.
+
+Once that is complete, you can use the helper bash script `eks.sh` as a shortcut
+for regenerating AWS creds, creating/overwriting your `~/.kube/config` file,
+setting a context (default is "applications-qa") and optionally listing the
+pods available in a namespace.

--- a/scripts/eks/KUBE_ACCESS.md
+++ b/scripts/eks/KUBE_ACCESS.md
@@ -8,3 +8,6 @@ Once that is complete, you can use the helper bash script `eks.sh` as a shortcut
 for regenerating AWS creds, creating/overwriting your `~/.kube/config` file,
 setting a context (default is "applications-qa") and optionally listing the
 pods available in a namespace.
+
+You should run `source eks.env` after the script finishes to ensure the 
+environment values are applied to your shell.

--- a/scripts/eks/eks.sh
+++ b/scripts/eks/eks.sh
@@ -8,6 +8,9 @@ set -euo pipefail
 # -d <duration>  The duration in minutes for which the AWS credentials are valid
 # -g Set AWS creds globally (default: false)
 #
+# After the command completes, run `source eks.env` to set the environment vars
+# in your current shell session.
+#
 # Usage: bash ./eks.sh -c <context> -n <namespace>
 # Example: bash ./eks.sh -c applications-qa -n learn-ai
 #
@@ -22,10 +25,9 @@ KUBE_NAMESPACE=""
 AWS_EXPIRES_IN="60"
 AWS_GLOBAL_CREDS=false
 EKS_PATH="../../src/ol_infrastructure/infrastructure/aws/eks"
-START_LENS=false
 
 # Parse command-line options
-while getopts ":c:n:d:gl" opt; do
+while getopts ":c:n:d:g" opt; do
   case $opt in
     c)
       KUBE_CONTEXT="$OPTARG"
@@ -38,8 +40,6 @@ while getopts ":c:n:d:gl" opt; do
       ;;
     g)
       AWS_GLOBAL_CREDS=true
-      ;;
-    l) START_LENS=true
       ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
@@ -82,12 +82,4 @@ if [ -n "$KUBE_CONTEXT" ]; then
 fi
 if [ -n "$KUBE_NAMESPACE" ]; then
   kubectl get pods -n "$KUBE_NAMESPACE"
-fi
-if [ "$START_LENS" == true ]; then
-  echo "Starting Lens..."
-  if command -v lens-desktop &> /dev/null; then
-    lens-desktop > /dev/null 2>&1 &
-  else
-    echo "Lens is not installed. Please install Lens to manage your Kubernetes clusters."
-  fi
 fi

--- a/scripts/eks/eks.sh
+++ b/scripts/eks/eks.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -euo pipefail
+###############################################################################
+# Helper script to login to an EKS cluster. It accepts the following options:
+#
+# -c <context>   The Kubernetes context to use (default: applications-qa)
+# -n <namespace> The Kubernetes namespace to use (default: none)
+# -d <duration>  The duration in minutes for which the AWS credentials are valid
+#
+# Usage: bash ./eks.sh -c <context> -n <namespace>
+# Example: bash ./eks.sh -c applications-qa -n learn-ai
+#
+# You must first create a github.env file & add your github token value to it.
+# You must also have already installed the required dependencies specified
+# at https://pe.ol.mit.edu/how_to/developer_eks_access/
+###############################################################################
+
+# Initialize variables for context and namespace
+KUBE_CONTEXT="applications-qa"
+KUBE_NAMESPACE=""
+AWS_EXPIRES_IN="60"
+EKS_PATH="../../src/ol_infrastructure/infrastructure/aws/eks"
+
+# Parse command-line options
+while getopts ":c:n:d:" opt; do
+  case $opt in
+    c)
+      KUBE_CONTEXT="$OPTARG"
+      ;;
+    n)
+      KUBE_NAMESPACE="$OPTARG"
+      ;;
+    d)
+      AWS_EXPIRES_IN="$OPTARG"
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+  esac
+done
+
+shift $((OPTIND -1))
+
+
+if [ -n "$KUBE_CONTEXT" ]; then
+  echo "Using context: $KUBE_CONTEXT"
+fi
+if [ -n "$KUBE_NAMESPACE" ]; then
+  echo "Using namespace: $KUBE_NAMESPACE"
+fi
+
+# shellcheck source=/dev/null
+source github.env
+python "$EKS_PATH/login_helper.py" aws_creds -d "$AWS_EXPIRES_IN" | grep '^export' > eks.env
+# shellcheck source=/dev/null
+source eks.env
+python "$EKS_PATH/login_helper.py" kubeconfig > ~/.kube/config
+
+if [ -n "$KUBE_CONTEXT" ]; then
+    kubectl config use-context "$KUBE_CONTEXT"
+fi
+if [ -n "$KUBE_NAMESPACE" ]; then
+  kubectl get pods -n "$KUBE_NAMESPACE"
+fi

--- a/scripts/eks/github.example.env
+++ b/scripts/eks/github.example.env
@@ -1,0 +1,2 @@
+# Enter your personal github token here, copy to github.env
+export GITHUB_TOKEN=


### PR DESCRIPTION
### What are the relevant tickets?
- Makes EKS access a little easier via a helper script

### Description (What does it do?)
- Adds a helper script that automates a few preliminary steps needed before kubernetes pods can be accessed:
  - Getting AWS credentials and saving to an env file
  - Creating/saving kube configuration 
  - Setting a context (default is "applications-qa"
  - Optionally displaying a list of pods if a namespace is provided as an input arg


### How can this be tested?
Follow the instructions in KUBE_ACCESS.md and make sure that they are easy to follow and the script does what it's supposed to.

PS - look at the 1st commit to see the relevant changes, pre-commit is responsible for the 2nd one.
