### PR TITLE
Add configuration for mitxonline scim client

### DIFF
--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.Production.yaml
@@ -34,6 +34,7 @@ config:
     MITOL_HUBSPOT_API_ID_PREFIX: "mitxonline"
     MITOL_PAYMENT_GATEWAY_CYBERSOURCE_REST_API_ENVIRONMENT: "api.cybersource.com"
     MITOL_PAYMENT_GATEWAY_CYBERSOURCE_SECURE_ACCEPTANCE_URL: "https://secureacceptance.cybersource.com/pay"
+    MITOL_SCIM_KEYCLOAK_BASE_URL: "https://sso.ol.mit.edu/realms/olapps/"
     MITXONLINE_NEW_USER_LOGIN_URL: https://mitxonline.mit.edu/create-profile
     MITX_ONLINE_BASE_URL: "https://mitxonline.mit.edu"
     MITX_ONLINE_ENVIRONMENT: "production"

--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.QA.yaml
@@ -28,6 +28,7 @@ config:
     MITOL_HUBSPOT_API_ID_PREFIX: "mitxonline-rc"
     MITOL_PAYMENT_GATEWAY_CYBERSOURCE_REST_API_ENVIRONMENT: "apitest.cybersource.com"
     MITOL_PAYMENT_GATEWAY_CYBERSOURCE_SECURE_ACCEPTANCE_URL: "https://testsecureacceptance.cybersource.com/pay"
+    MITOL_SCIM_KEYCLOAK_BASE_URL: "https://sso-qa.ol.mit.edu/realms/olapps/"
     MITXONLINE_NEW_USER_LOGIN_URL: https://rc.mitxonline.mit.edu/create-profile
     MITX_ONLINE_BASE_URL: "https://rc.mitxonline.mit.edu"
     MITX_ONLINE_ENVIRONMENT: "rc"

--- a/src/ol_infrastructure/applications/mitxonline/k8s_secrets.py
+++ b/src/ol_infrastructure/applications/mitxonline/k8s_secrets.py
@@ -239,8 +239,6 @@ def create_mitxonline_k8s_secrets(
                 "MITOL_PAYMENT_GATEWAY_CYBERSOURCE_MERCHANT_SECRET_KEY_ID": '{{ index .Secrets "cybersource" "merchant-secret-key-id" }}',
                 "MITOL_PAYMENT_GATEWAY_CYBERSOURCE_PROFILE_ID": '{{ index .Secrets "cybersource" "profile-id" }}',
                 "MITOL_PAYMENT_GATEWAY_CYBERSOURCE_SECURITY_KEY": '{{ index .Secrets "cybersource" "security-key" }}',
-                "MITOL_SCIM_KEYCLOAK_CLIENT_ID": '{{ index .Secrets "keycloak-scim" "client-id" }}',
-                "MITOL_SCIM_KEYCLOAK_CLIENT_SECRET": '{{ index .Secrets "keycloak-scim" "client-secret" }}',
                 "MITX_ONLINE_REFINE_OIDC_CONFIG_CLIENT_ID": '{{ index .Secrets "refine-oidc" "client-id" }}',
                 "OIDC_RSA_PRIVATE_KEY": '{{ index .Secrets "refine-oidc" "rsa-private-key" }}',
                 "OPENEDX_API_CLIENT_ID": '{{ index .Secrets "open-edx-api-client" "client-id" }}',
@@ -262,6 +260,14 @@ def create_mitxonline_k8s_secrets(
             "path": f"{openedx_environment}/mitxonline-registration-access-token",
             "templates": {
                 "MITX_ONLINE_REGISTRATION_ACCESS_TOKEN": '{{ get .Secrets "value" }}',
+            },
+        },
+        {
+            "base_name": "mitxonline-keycloak-scim-details",
+            "path": "secret-mitxonline/keycloak-scim",
+            "templates": {
+                "MITOL_SCIM_KEYCLOAK_CLIENT_ID": '{{ get .Secrets "client_id" }}',
+                "MITOL_SCIM_KEYCLOAK_CLIENT_SECRET": '{{ get .Secrets "client_secret" }}',
             },
         },
     ]

--- a/src/ol_infrastructure/applications/mitxonline/k8s_secrets.py
+++ b/src/ol_infrastructure/applications/mitxonline/k8s_secrets.py
@@ -155,9 +155,9 @@ def create_mitxonline_k8s_secrets(
         and a list of the corresponding Pulumi resource objects.
     """
     secret_names: list[str] = []
-    secret_resources: list[Union[OLVaultK8SSecret, kubernetes.core.v1.Secret]] = (
-        []
-    )  # Keep track of resources if needed later
+    secret_resources: list[
+        Union[OLVaultK8SSecret, kubernetes.core.v1.Secret]
+    ] = []  # Keep track of resources if needed later
 
     vaultauth = vault_k8s_resources.auth_name
 

--- a/src/ol_infrastructure/applications/mitxonline/k8s_secrets.py
+++ b/src/ol_infrastructure/applications/mitxonline/k8s_secrets.py
@@ -155,9 +155,9 @@ def create_mitxonline_k8s_secrets(
         and a list of the corresponding Pulumi resource objects.
     """
     secret_names: list[str] = []
-    secret_resources: list[
-        Union[OLVaultK8SSecret, kubernetes.core.v1.Secret]
-    ] = []  # Keep track of resources if needed later
+    secret_resources: list[Union[OLVaultK8SSecret, kubernetes.core.v1.Secret]] = (
+        []
+    )  # Keep track of resources if needed later
 
     vaultauth = vault_k8s_resources.auth_name
 
@@ -239,6 +239,8 @@ def create_mitxonline_k8s_secrets(
                 "MITOL_PAYMENT_GATEWAY_CYBERSOURCE_MERCHANT_SECRET_KEY_ID": '{{ index .Secrets "cybersource" "merchant-secret-key-id" }}',
                 "MITOL_PAYMENT_GATEWAY_CYBERSOURCE_PROFILE_ID": '{{ index .Secrets "cybersource" "profile-id" }}',
                 "MITOL_PAYMENT_GATEWAY_CYBERSOURCE_SECURITY_KEY": '{{ index .Secrets "cybersource" "security-key" }}',
+                "MITOL_SCIM_KEYCLOAK_CLIENT_ID": '{{ index .Secrets "keycloak-scim" "client-id" }}',
+                "MITOL_SCIM_KEYCLOAK_CLIENT_SECRET": '{{ index .Secrets "keycloak-scim" "client-secret" }}',
                 "MITX_ONLINE_REFINE_OIDC_CONFIG_CLIENT_ID": '{{ index .Secrets "refine-oidc" "client-id" }}',
                 "OIDC_RSA_PRIVATE_KEY": '{{ index .Secrets "refine-oidc" "rsa-private-key" }}',
                 "OPENEDX_API_CLIENT_ID": '{{ index .Secrets "open-edx-api-client" "client-id" }}',


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/hq/issues/6585

### Description (What does it do?)
<!--- Describe your changes in detail -->
This adds configuration to MITx Online for a few variables that are necessary for mitxonline to push users to keycloak via scim. The relevant code is in this PR: https://github.com/mitodl/ol-django/pull/250

This requires a client to be created in Keycloak and the client id and secret added to the secrets