### PR TITLE
chore: remove HubSpot footer form keys(Bootcamp)

### DIFF
--- a/src/ol_infrastructure/applications/bootcamps/Pulumi.applications.bootcamps.Production.yaml
+++ b/src/ol_infrastructure/applications/bootcamps/Pulumi.applications.bootcamps.Production.yaml
@@ -25,8 +25,6 @@ config:
     GTM_TRACKING_ID: "GTM-TFSZHVB"
     HUBSPOT_API_ID_PREFIX: "bootcamp"
     HUBSPOT_ID_PREFIX: "bootcamp"
-    HUBSPOT_FOOTER_FORM_GUID: "2d798908-c195-4c0c-b075-a10b0c1b08f3"
-    HUBSPOT_PORTAL_ID: "6119748"
     JOBMA_BASE_URL: "https://www.jobma.com"
     MAILGUN_FROM_EMAIL: "MIT Bootcamps <no-reply@mail.bootcamp.odl.mit.edu>"
     MAILGUN_SENDER_DOMAIN: "mail.bootcamp.odl.mit.edu"

--- a/src/ol_infrastructure/applications/bootcamps/Pulumi.applications.bootcamps.QA.yaml
+++ b/src/ol_infrastructure/applications/bootcamps/Pulumi.applications.bootcamps.QA.yaml
@@ -22,8 +22,6 @@ config:
     GA_TRACKING_ID: "UA-5145472-19"
     GTM_TRACKING_ID: "GTM-NZT8SRC"
     HUBSPOT_API_ID_PREFIX: "bootcamp-rc"
-    HUBSPOT_FOOTER_FORM_GUID: "be317df4-ed94-4d42-bfb9-01adec557d8f"
-    HUBSPOT_PORTAL_ID: "23263862"
     JOBMA_BASE_URL: "https://dev.jobma.com"
     MAILGUN_FROM_EMAIL: "MIT Bootcamps <no-reply@mail-rc.bootcamp.odl.mit.edu>"
     MAILGUN_SENDER_DOMAIN: "mail-rc.bootcamp.odl.mit.edu"


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7404

<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
Removed the keys that are used to display and configure Sign up for updates Hubspot from in the footer.
<!--- Describe your changes in detail -->

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
