### PR TITLE
chore(deps): rename and upgarde dependency ol-openedx-git-auto-export to 0.3.2

### DIFF
--- a/dockerfiles/openedx-edxapp/pip_package_lists/master/mitx-staging.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/master/mitx-staging.txt
@@ -1,6 +1,6 @@
 celery-redbeat==2.3.2  # Support for using Redis as the lock for Celery schedules
 django-redis==5.4.0
-edx-git-auto-export==0.3
+ol-openedx-git-auto-export==0.3.2
 edx-sga
 edx-sysadmin==0.3.0
 git+https://github.com/raccoongang/xblock-pdf.git@d8948bf3c7127e23be202d1f8600f1ba293ba978#egg=xblock-pdf

--- a/dockerfiles/openedx-edxapp/pip_package_lists/master/mitx.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/master/mitx.txt
@@ -1,6 +1,6 @@
 celery-redbeat==2.3.2  # Support for using Redis as the lock for Celery schedules
 django-redis==5.4.0
-edx-git-auto-export==0.3
+ol-openedx-git-auto-export==0.3.2
 edx-sga
 edx-sysadmin==0.3.0
 git+https://github.com/raccoongang/xblock-pdf.git@d8948bf3c7127e23be202d1f8600f1ba293ba978#egg=xblock-pdf

--- a/dockerfiles/openedx-edxapp/pip_package_lists/master/mitxonline.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/master/mitxonline.txt
@@ -1,6 +1,6 @@
 celery-redbeat==2.3.2  # Support for using Redis as the lock for Celery schedules
 django-redis==5.4.0
-edx-git-auto-export==0.3
+ol-openedx-git-auto-export==0.3.2
 edx-sysadmin==0.3.0
 edx-username-changer==0.3.2
 openedx-companion-auth==1.1.0

--- a/dockerfiles/openedx-edxapp/pip_package_lists/teak/mitx-staging.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/teak/mitx-staging.txt
@@ -1,6 +1,6 @@
 celery-redbeat==2.3.2  # Support for using Redis as the lock for Celery schedules
 django-redis==5.4.0
-edx-git-auto-export==0.3
+ol-openedx-git-auto-export==0.3.2
 edx-sga
 edx-sysadmin==0.3.0
 git+https://github.com/raccoongang/xblock-pdf.git@d8948bf3c7127e23be202d1f8600f1ba293ba978#egg=xblock-pdf

--- a/dockerfiles/openedx-edxapp/pip_package_lists/teak/mitx.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/teak/mitx.txt
@@ -1,6 +1,6 @@
 celery-redbeat==2.3.2  # Support for using Redis as the lock for Celery schedules
 django-redis==5.4.0
-edx-git-auto-export==0.3
+ol-openedx-git-auto-export==0.3.2
 edx-sga
 edx-sysadmin==0.3.0
 git+https://github.com/raccoongang/xblock-pdf.git@d8948bf3c7127e23be202d1f8600f1ba293ba978#egg=xblock-pdf

--- a/dockerfiles/openedx-edxapp/pip_package_lists/teak/xpro.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/teak/xpro.txt
@@ -1,6 +1,6 @@
 celery-redbeat==2.3.2  # Support for using Redis as the lock for Celery schedules
 django-redis==5.4.0
-edx-git-auto-export==0.3
+ol-openedx-git-auto-export==0.3.2
 edx-sysadmin==0.3.0
 edx-username-changer==0.3.2
 git+https://github.com/ubc/ubcpi.git@1.0.0#egg=ubcpi-xblock


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6803

### Description (What does it do?)
This PR:
1. Rename `edx-git-auto-export` to `ol-openedx-git-auto-export`
2. And upgrades ol-openedx-git-auto-export to 0.3.2

### How can this be tested?
1. Install and configure the package following [the instructions](https://github.com/mitodl/open-edx-plugins/tree/main/src/ol_openedx_git_auto_export)
2. Publish a course without setting its `giturl` in advance_settings
3. You should see a log message `Course {course_key} does not have a GIT URL set in course advance settings, skipping export.` instead of `GitExportError` error
