### PR TITLE
chore(deps): upgrade edx-sysadmin to 0.3.1

### DIFF
--- a/dockerfiles/openedx-edxapp/pip_package_lists/master/mitx-staging.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/master/mitx-staging.txt
@@ -2,7 +2,7 @@ celery-redbeat==2.3.2  # Support for using Redis as the lock for Celery schedule
 django-redis==5.4.0
 ol-openedx-git-auto-export==0.3.2
 edx-sga
-edx-sysadmin==0.3.0
+edx-sysadmin==0.3.1
 git+https://github.com/raccoongang/xblock-pdf.git@d8948bf3c7127e23be202d1f8600f1ba293ba978#egg=xblock-pdf
 nodeenv>=1.7.0
 ol-openedx-canvas-integration==0.4.0

--- a/dockerfiles/openedx-edxapp/pip_package_lists/master/mitx.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/master/mitx.txt
@@ -2,7 +2,7 @@ celery-redbeat==2.3.2  # Support for using Redis as the lock for Celery schedule
 django-redis==5.4.0
 ol-openedx-git-auto-export==0.3.2
 edx-sga
-edx-sysadmin==0.3.0
+edx-sysadmin==0.3.1
 git+https://github.com/raccoongang/xblock-pdf.git@d8948bf3c7127e23be202d1f8600f1ba293ba978#egg=xblock-pdf
 nodeenv>=1.7.0
 ol-openedx-canvas-integration==0.4.0

--- a/dockerfiles/openedx-edxapp/pip_package_lists/master/mitxonline.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/master/mitxonline.txt
@@ -1,7 +1,7 @@
 celery-redbeat==2.3.2  # Support for using Redis as the lock for Celery schedules
 django-redis==5.4.0
 ol-openedx-git-auto-export==0.3.2
-edx-sysadmin==0.3.0
+edx-sysadmin==0.3.1
 edx-username-changer==0.3.2
 openedx-companion-auth==1.1.0
 nodeenv>=1.7.0

--- a/dockerfiles/openedx-edxapp/pip_package_lists/teak/mitx-staging.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/teak/mitx-staging.txt
@@ -2,7 +2,7 @@ celery-redbeat==2.3.2  # Support for using Redis as the lock for Celery schedule
 django-redis==5.4.0
 ol-openedx-git-auto-export==0.3.2
 edx-sga
-edx-sysadmin==0.3.0
+edx-sysadmin==0.3.1
 git+https://github.com/raccoongang/xblock-pdf.git@d8948bf3c7127e23be202d1f8600f1ba293ba978#egg=xblock-pdf
 nodeenv>=1.7.0
 ol-openedx-canvas-integration==0.4.0

--- a/dockerfiles/openedx-edxapp/pip_package_lists/teak/mitx.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/teak/mitx.txt
@@ -2,7 +2,7 @@ celery-redbeat==2.3.2  # Support for using Redis as the lock for Celery schedule
 django-redis==5.4.0
 ol-openedx-git-auto-export==0.3.2
 edx-sga
-edx-sysadmin==0.3.0
+edx-sysadmin==0.3.1
 git+https://github.com/raccoongang/xblock-pdf.git@d8948bf3c7127e23be202d1f8600f1ba293ba978#egg=xblock-pdf
 nodeenv>=1.7.0
 ol-openedx-canvas-integration==0.4.0

--- a/dockerfiles/openedx-edxapp/pip_package_lists/teak/xpro.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/teak/xpro.txt
@@ -1,7 +1,7 @@
 celery-redbeat==2.3.2  # Support for using Redis as the lock for Celery schedules
 django-redis==5.4.0
 ol-openedx-git-auto-export==0.3.2
-edx-sysadmin==0.3.0
+edx-sysadmin==0.3.1
 edx-username-changer==0.3.2
 git+https://github.com/ubc/ubcpi.git@1.0.0#egg=ubcpi-xblock
 openedx-companion-auth==1.1.0


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/ol-infrastructure/issues/2891

### Description (What does it do?)
This PR:
1. Upgrades edx-sysadmin to 0.3.1

### How can this be tested?

1. Checkout to this branch
2. Create installable package by following the instructions in [Readme file](https://github.com/mitodl/open-edx-plugins/tree/main/src/edx_sysadmin)
3. Install the package in edX
4. Make sure you have setup the hook for course auto reload
5. Change the default branch setting for this plugin to something different. For example: dummy
6. Publish any course from studio without any change which will invoke the hook for edx_sysadmin > gitreload OR directly push changes to github repo whose hook is configured
7. Verify that there are debug logs like Couldn't reload course for the branch instead of exception