### PR TITLE
Add basic scope to superset client

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/__main__.py
+++ b/src/ol_infrastructure/substructure/keycloak/__main__.py
@@ -1102,6 +1102,7 @@ ol_data_platform_superset_client_scope = keycloak.openid.ClientDefaultScopes(
     client_id=ol_data_platform_superset_client.id,
     default_scopes=[
         "acr",
+        "basic",
         "email",
         "profile",
         "ol_roles",


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
This add the `basic` claim to the Keycloak superset client as it's required for the service account to work as without it we get the following error:
`"msg": "Missing claim: sub"`
