### PR TITLE
feat: add learn urls for MIT_ET courses

### DIFF
--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -390,7 +390,9 @@ MIT_LEARN_AI_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai  # Added fo
 MIT_LEARN_API_BASE_URL: https://{{ key "edxapp/learn-api-domain" }}/learn  # Added for ol_openedx_chat
 MIT_LEARN_SUMMARY_FLASHCARD_URL: https://{{ key "edxapp/learn-api-domain" }}/learn/api/v1/contentfiles/  # Added for ol_openedx_chat
 MIT_LEARN_BASE_URL: "https://{{ key edxapp/learn-frontend-domain}}"
-UAI_COURSE_KEY_FORMAT: course-v1:uai_
+UAI_COURSE_KEY_FORMATS:
+  - course-v1:uai_
+  - course-v1:mit_et
 MIT_LEARN_LOGO: https://{{ key "edxapp/lms-domain" }}/static/mitxonline/images/mit-learn-logo.svg"
 LEARNER_PORTAL_URL_ROOT: https://learner-portal-localhost:18000
 LEARNER_HOME_MICROFRONTEND_URL: '/dashboard/'

--- a/src/bridge/settings/openedx/mfe/slot_config/mitxonline/common-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/mitxonline/common-mfe-config.env.jsx
@@ -6,8 +6,8 @@ const configData = getConfig();
 const currentYear = new Date().getFullYear();
 const edxMfeAppName = configData.APP_ID;
 const authoringAppID = "authoring";
-const learnCourseKeyFormat = "course-v1:uai_";
-const isLearnCourse = window.location.href.toLowerCase().includes(learnCourseKeyFormat);
+const href = window.location.href.toLowerCase();
+const isLearnCourse = ["course-v1:uai_", "course-v1:mit_et"].some(key => href.includes(key));
 const accessibilityURL = process.env.ACCESSIBILITY_URL || 'https://accessibility.mit.edu/';
 const linkTitles = {
   dashboard: "Dashboard",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7355

### Description (What does it do?)
This PR changes the header menu URLs of the MFE dashboard to the learn website for MIT_ET courses.

### Screenshots (if appropriate):


### How can this be tested?
Copy paste `common-mfe-config.env.jsx` file into MFE `config.jsx` and verify that the URLs are shown as per https://github.com/mitodl/hq/issues/7355

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
