### PR TITLE
feat: add MITx branding with slots

### DIFF
--- a/src/bridge/settings/openedx/mfe/slot_config/mitx-staging/common-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/mitx-staging/common-mfe-config.env.jsx
@@ -1,6 +1,7 @@
 import { PLUGIN_OPERATIONS, DIRECT_PLUGIN } from '@openedx/frontend-plugin-framework';
 import { getConfig } from '@edx/frontend-platform';
 import Footer, { Logo, MenuLinks, CopyrightNotice } from './Footer.jsx';
+import style from './mitx-styles.scss';
 
 const configData = getConfig();
 const currentYear = new Date().getFullYear();
@@ -168,6 +169,10 @@ if (learningApps.includes(edxMfeAppName)) {
       },
     ],
   };
+}
+
+config.pluginSlots.widget_sidebar_slot = {
+  plugins: [{ op: PLUGIN_OPERATIONS.Hide, widgetId: 'default_contents' }]
 }
 
 export default config;

--- a/src/bridge/settings/openedx/mfe/slot_config/mitx-staging/common-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/mitx-staging/common-mfe-config.env.jsx
@@ -1,7 +1,7 @@
 import { PLUGIN_OPERATIONS, DIRECT_PLUGIN } from '@openedx/frontend-plugin-framework';
 import { getConfig } from '@edx/frontend-platform';
 import Footer, { Logo, MenuLinks, CopyrightNotice } from './Footer.jsx';
-import style from './mitx-styles.scss';
+import styles from './mitx-styles.scss';
 
 const configData = getConfig();
 const currentYear = new Date().getFullYear();
@@ -171,6 +171,7 @@ if (learningApps.includes(edxMfeAppName)) {
   };
 }
 
+// Removes the looking for a new challenge banner from the Learner Dashboard MFE sidebar
 config.pluginSlots.widget_sidebar_slot = {
   plugins: [{ op: PLUGIN_OPERATIONS.Hide, widgetId: 'default_contents' }]
 }

--- a/src/bridge/settings/openedx/mfe/slot_config/mitx-styles.scss
+++ b/src/bridge/settings/openedx/mfe/slot_config/mitx-styles.scss
@@ -1,0 +1,9 @@
+// This file provides an alternative to using brand overrides for MITx Micro Frontends (MFEs).
+
+// Hide the informational banner displayed on course cards in the Learner Dashboard MFE.
+.course-card-banners {
+    div[role=alert] {
+      display: none;
+    }
+}
+

--- a/src/bridge/settings/openedx/mfe/slot_config/mitx-styles.scss
+++ b/src/bridge/settings/openedx/mfe/slot_config/mitx-styles.scss
@@ -1,6 +1,6 @@
 // This file provides an alternative to using brand overrides for MITx Micro Frontends (MFEs).
 
-// Hide the informational banner displayed on course cards in the Learner Dashboard MFE.
+// Hide the informational banner displayed at the bottom of the course cards in the Learner Dashboard MFE.
 .course-card-banners {
     div[role=alert] {
       display: none;

--- a/src/bridge/settings/openedx/mfe/slot_config/mitx-styles.scss
+++ b/src/bridge/settings/openedx/mfe/slot_config/mitx-styles.scss
@@ -6,4 +6,3 @@
       display: none;
     }
 }
-

--- a/src/bridge/settings/openedx/mfe/slot_config/mitx/common-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/mitx/common-mfe-config.env.jsx
@@ -1,6 +1,7 @@
 import { PLUGIN_OPERATIONS, DIRECT_PLUGIN } from '@openedx/frontend-plugin-framework';
 import { getConfig } from '@edx/frontend-platform';
 import Footer, { Logo, MenuLinks, CopyrightNotice } from './Footer.jsx';
+import style from './mitx-styles.scss';
 
 const configData = getConfig();
 const currentYear = new Date().getFullYear();
@@ -168,6 +169,10 @@ if (learningApps.includes(edxMfeAppName)) {
       },
     ],
   };
+}
+
+config.pluginSlots.widget_sidebar_slot = {
+  plugins: [{ op: PLUGIN_OPERATIONS.Hide, widgetId: 'default_contents' }]
 }
 
 export default config;

--- a/src/bridge/settings/openedx/mfe/slot_config/mitx/common-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/mitx/common-mfe-config.env.jsx
@@ -1,7 +1,7 @@
 import { PLUGIN_OPERATIONS, DIRECT_PLUGIN } from '@openedx/frontend-plugin-framework';
 import { getConfig } from '@edx/frontend-platform';
 import Footer, { Logo, MenuLinks, CopyrightNotice } from './Footer.jsx';
-import style from './mitx-styles.scss';
+import styles from './mitx-styles.scss';
 
 const configData = getConfig();
 const currentYear = new Date().getFullYear();
@@ -171,6 +171,7 @@ if (learningApps.includes(edxMfeAppName)) {
   };
 }
 
+// Removes the looking for a new challenge banner from the Learner Dashboard MFE sidebar
 config.pluginSlots.widget_sidebar_slot = {
   plugins: [{ op: PLUGIN_OPERATIONS.Hide, widgetId: 'default_contents' }]
 }

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -177,23 +177,31 @@ def mfe_job(
 
     mfe_setup_lines = [
         f"cp -r {mfe_repo.name}/* {mfe_build_dir.name}",
-        f"cp {mfe_configs.name}/src/bridge/settings/openedx/mfe/slot_config/Footer.jsx {mfe_build_dir.name}/Footer.jsx",
-        f"cp {mfe_configs.name}/src/bridge/settings/openedx/mfe/slot_config/{open_edx_deployment.deployment_name}/{slot_config_file}.env.jsx {mfe_build_dir.name}/env.config.jsx",
+        (
+            f"cp {mfe_configs.name}/src/bridge/settings/openedx/mfe/slot_config/"
+            f"Footer.jsx {mfe_build_dir.name}/Footer.jsx"
+        ),
+        (
+            f"cp {mfe_configs.name}/src/bridge/settings/openedx/mfe/slot_config/"
+            f"{open_edx_deployment.deployment_name}/{slot_config_file}.env.jsx "
+            f"{mfe_build_dir.name}/env.config.jsx"
+        ),
         copy_common_config,
     ]
 
     # Add styles.scss copy for Residential deployments
     if (
         open_edx_deployment.deployment_name in ["mitx", "mitx-staging"]
-        and OpenEdxMicroFrontend[mfe_name].value == OpenEdxMicroFrontend.learner_dashboard.value
+        and OpenEdxMicroFrontend[mfe_name].value
+        == OpenEdxMicroFrontend.learner_dashboard.value
     ):
         mfe_setup_lines.append(
-            f"cp {mfe_configs.name}/src/bridge/settings/openedx/mfe/slot_config/mitx-styles.scss {mfe_build_dir.name}/mitx-styles.scss"
+            f"cp {mfe_configs.name}/src/bridge/settings/openedx/mfe/slot_config/"
+            f"mitx-styles.scss {mfe_build_dir.name}/mitx-styles.scss"
         )
 
     # Join all commands with newlines
     mfe_setup_command = textwrap.dedent("\n".join(mfe_setup_lines))
-
 
     mfe_setup_plan += [
         clone_mfe_configs,

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -175,14 +175,6 @@ def mfe_job(
         slot_config_file = "learning-mfe-config"
         copy_common_config = f"cp {mfe_configs.name}/src/bridge/settings/openedx/mfe/slot_config/{open_edx_deployment.deployment_name}/common-mfe-config.env.jsx {mfe_build_dir.name}/common-mfe-config.env.jsx"  # noqa: E501
 
-    # mfe_setup_command = textwrap.dedent(
-    #     f"""\
-    #     cp -r {mfe_repo.name}/* {mfe_build_dir.name}
-    #     cp {mfe_configs.name}/src/bridge/settings/openedx/mfe/slot_config/Footer.jsx {mfe_build_dir.name}/Footer.jsx
-    #     cp {mfe_configs.name}/src/bridge/settings/openedx/mfe/slot_config/{open_edx_deployment.deployment_name}/{slot_config_file}.env.jsx {mfe_build_dir.name}/env.config.jsx
-    #     {copy_common_config}
-    #     """  # noqa: E501
-    # )
     mfe_setup_lines = [
         f"cp -r {mfe_repo.name}/* {mfe_build_dir.name}",
         f"cp {mfe_configs.name}/src/bridge/settings/openedx/mfe/slot_config/Footer.jsx {mfe_build_dir.name}/Footer.jsx",

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -175,14 +175,33 @@ def mfe_job(
         slot_config_file = "learning-mfe-config"
         copy_common_config = f"cp {mfe_configs.name}/src/bridge/settings/openedx/mfe/slot_config/{open_edx_deployment.deployment_name}/common-mfe-config.env.jsx {mfe_build_dir.name}/common-mfe-config.env.jsx"  # noqa: E501
 
-    mfe_setup_command = textwrap.dedent(
-        f"""\
-        cp -r {mfe_repo.name}/* {mfe_build_dir.name}
-        cp {mfe_configs.name}/src/bridge/settings/openedx/mfe/slot_config/Footer.jsx {mfe_build_dir.name}/Footer.jsx
-        cp {mfe_configs.name}/src/bridge/settings/openedx/mfe/slot_config/{open_edx_deployment.deployment_name}/{slot_config_file}.env.jsx {mfe_build_dir.name}/env.config.jsx
-        {copy_common_config}
-        """  # noqa: E501
-    )
+    # mfe_setup_command = textwrap.dedent(
+    #     f"""\
+    #     cp -r {mfe_repo.name}/* {mfe_build_dir.name}
+    #     cp {mfe_configs.name}/src/bridge/settings/openedx/mfe/slot_config/Footer.jsx {mfe_build_dir.name}/Footer.jsx
+    #     cp {mfe_configs.name}/src/bridge/settings/openedx/mfe/slot_config/{open_edx_deployment.deployment_name}/{slot_config_file}.env.jsx {mfe_build_dir.name}/env.config.jsx
+    #     {copy_common_config}
+    #     """  # noqa: E501
+    # )
+    mfe_setup_lines = [
+        f"cp -r {mfe_repo.name}/* {mfe_build_dir.name}",
+        f"cp {mfe_configs.name}/src/bridge/settings/openedx/mfe/slot_config/Footer.jsx {mfe_build_dir.name}/Footer.jsx",
+        f"cp {mfe_configs.name}/src/bridge/settings/openedx/mfe/slot_config/{open_edx_deployment.deployment_name}/{slot_config_file}.env.jsx {mfe_build_dir.name}/env.config.jsx",
+        copy_common_config,
+    ]
+
+    # Add styles.scss copy for Residential deployments
+    if (
+        open_edx_deployment.deployment_name in ["mitx", "mitx-staging"]
+        and OpenEdxMicroFrontend[mfe_name].value == OpenEdxMicroFrontend.learner_dashboard.value
+    ):
+        mfe_setup_lines.append(
+            f"cp {mfe_configs.name}/src/bridge/settings/openedx/mfe/slot_config/mitx-styles.scss {mfe_build_dir.name}/mitx-styles.scss"
+        )
+
+    # Join all commands with newlines
+    mfe_setup_command = textwrap.dedent("\n".join(mfe_setup_lines))
+
 
     mfe_setup_plan += [
         clone_mfe_configs,

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -175,7 +175,7 @@ def mfe_job(
         slot_config_file = "learning-mfe-config"
         copy_common_config = f"cp {mfe_configs.name}/src/bridge/settings/openedx/mfe/slot_config/{open_edx_deployment.deployment_name}/common-mfe-config.env.jsx {mfe_build_dir.name}/common-mfe-config.env.jsx"  # noqa: E501
 
-    mfe_setup_lines = [
+    mfe_setup_steps = [
         f"cp -r {mfe_repo.name}/* {mfe_build_dir.name}",
         (
             f"cp {mfe_configs.name}/src/bridge/settings/openedx/mfe/slot_config/"
@@ -195,13 +195,13 @@ def mfe_job(
         and OpenEdxMicroFrontend[mfe_name].value
         == OpenEdxMicroFrontend.learner_dashboard.value
     ):
-        mfe_setup_lines.append(
+        mfe_setup_steps.append(
             f"cp {mfe_configs.name}/src/bridge/settings/openedx/mfe/slot_config/"
             f"mitx-styles.scss {mfe_build_dir.name}/mitx-styles.scss"
         )
 
     # Join all commands with newlines
-    mfe_setup_command = textwrap.dedent("\n".join(mfe_setup_lines))
+    mfe_setup_command = textwrap.dedent("\n".join(mfe_setup_steps))
 
     mfe_setup_plan += [
         clone_mfe_configs,


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7417

### Description (What does it do?)
MFE brand overrides are being deprecated. This PR uses plugin slots to replicate the behavior of https://github.com/mitodl/brand-mitol-residential. More details are available on the [issue](https://github.com/mitodl/hq/issues/7417).

### Screenshots (if appropriate):
![Screenshot](https://github.com/user-attachments/assets/a24eb7df-df28-4957-bf93-85de1ed211bc)

### How can this be tested?
- Set up learner-dashboard locally and copy and paste the MFE config files of MITx in the `env.config.jsx`
- Create a `mitx-styles.scss` file in your MFE and copy and paste the contents from `src/bridge/settings/openedx/mfe/slot_config/mitx-styles.scss`
- Verify that the learner's dashboard page looks as in https://github.com/mitodl/hq/issues/7417#issuecomment-2934431676

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
