### PR TITLE
Change default models and search url for learn-ai

### DIFF
--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.CI.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.CI.yaml
@@ -6,8 +6,11 @@ config:
   learn_ai:backend_domain: "api-learn-ai-ci.ol.mit.edu"
   learn_ai:learn_backend_domain: "api.ci.learn.mit.edu"
   learn_ai:env_vars:
-    AI_DEFAULT_SYLLABUS_MODEL: "bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0"
-    AI_MIT_SEARCH_URL: "https://api.rc.learn.mit.edu/api/v1/learning_resources_search/"
+    AI_DEFAULT_RECOMMENDATION_MODEL: "openai/gpt-4o-mini"
+    AI_DEFAULT_SYLLABUS_MODEL: "openai/gpt-4o-mini"
+    AI_DEFAULT_VIDEO_GPT_MODEL: "openai/gpt-4o-mini"
+    AI_DEFAULT_TUTOR_MODEL: "openai/gpt-4o"
+    AI_MIT_SEARCH_URL: "https://api.rc.learn.mit.edu/api/v0/vector_learning_resources_search/"
     AI_MIT_SYLLABUS_URL: "https://api.rc.learn.mit.edu/api/v0/vector_content_files_search/"
     AI_MIT_VIDEO_TRANSCRIPT_URL: "https://api.rc.learn.mit.edu/api/v0/vector_content_files_search/"
     AI_PROMPT_CACHE_FUNCTION: "ai_chatbots.utils.get_django_cache"

--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.Production.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.Production.yaml
@@ -8,7 +8,11 @@ config:
   learn_ai:db_password:
     secure: v1:DIaoiP0dVXpI2w72:zcSTWgD6DInTMOdD1oH1FTdlUJCney7MLeAfL5Q5hcL9lDfW7AjVGynLDeDtpL3DQIZvFBUvcbjIHVaBYQf8Ikf8tdjWamNBv+4Ymwe2
   learn_ai:env_vars:
-    AI_DEFAULT_SYLLABUS_MODEL: "bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+    AI_DEFAULT_RECOMMENDATION_MODEL: "openai/gpt-4o-mini"
+    AI_DEFAULT_SYLLABUS_MODEL: "openai/gpt-4o-mini"
+    AI_DEFAULT_VIDEO_GPT_MODEL: "openai/gpt-4o-mini"
+    AI_DEFAULT_TUTOR_MODEL: "openai/gpt-4o"
+    AI_MIT_SEARCH_URL: "https://api.rc.learn.mit.edu/api/v0/vector_learning_resources_search/"
     AI_PROMPT_CACHE_FUNCTION: "ai_chatbots.utils.get_django_cache"
     CELERY_TASK_ALWAYS_EAGER: "false"
     CSRF_ALLOWED_ORIGINS: '["https://learn-ai.ol.mit.edu", "https://api-learn-ai.ol.mit.edu",

--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.QA.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.QA.yaml
@@ -9,8 +9,11 @@ config:
     secure: v1:moKYAbHsHOnTUrEk:4OgRBNFXT0WKrz1KaKZDhQxT09dA36jN4+q/SO0IIAemTSiwGqrXbXn+r5dFlGrr24S+VGtiyNXSVKts+j/TgKS33FTo86OX2saBDrL4dFo=
   learn_ai:env_vars:
     AI_DEBUG: "true"
-    AI_DEFAULT_SYLLABUS_MODEL: "bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0"
-    AI_MIT_SEARCH_URL: "https://api.rc.learn.mit.edu/api/v1/learning_resources_search/"
+    AI_DEFAULT_RECOMMENDATION_MODEL: "openai/gpt-4o-mini"
+    AI_DEFAULT_SYLLABUS_MODEL: "openai/gpt-4o-mini"
+    AI_DEFAULT_VIDEO_GPT_MODEL: "openai/gpt-4o-mini"
+    AI_DEFAULT_TUTOR_MODEL: "openai/gpt-4o"
+    AI_MIT_SEARCH_URL: "https://api.rc.learn.mit.edu/api/v0/vector_learning_resources_search/"
     AI_MIT_SEARCH_DETAIL_URL: "https://rc.learn.mit.edu/?resource="
     AI_MIT_SYLLABUS_URL: "https://api.rc.learn.mit.edu/api/v0/vector_content_files_search/"
     AI_MIT_VIDEO_TRANSCRIPT_URL: "https://api.rc.learn.mit.edu/api/v0/vector_content_files_search/"


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7477

### Description (What does it do?)
- Changes the default recommendation bot search url to the vector api endpoint
- Sets default model to "gpt-4o-mini" for all but the tutor bot (which is "gpt-4o")



### How can this be tested?
N/A


