### PR TITLE
Remove the wildcard /login/* route in favor of more scoped ones

### DIFF
--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -577,7 +577,7 @@ mitxonline_apisix_route_direct = OLApisixRoute(
             route_name="reqauth",
             priority=10,
             hosts=[api_domain],
-            paths=["/login/*", "/admin/login/*", "/login"],
+            paths=["/login/", "/admin/login/*", "/login", "/login/oidc*"],
             plugins=[
                 mitxonline_direct_oidc.get_full_oidc_plugin_config(unauth_action="auth")
             ],
@@ -628,7 +628,8 @@ mitxonline_apisix_route_prefix = OLApisixRoute(
             priority=10,
             hosts=[api_domain],
             paths=[
-                f"/{api_path_prefix}/login/*",
+                f"/{api_path_prefix}/login/",
+                f"/{api_path_prefix}/login/oidc*",
                 f"/{api_path_prefix}/admin/login/*",
                 f"/{api_path_prefix}/login",
             ],


### PR DESCRIPTION
### What are the relevant tickets?

n/a

Relevant Sentry error: https://mit-office-of-digital-learning.sentry.io/issues/6636358394/?project=5864687&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=1

### Description (What does it do?)

The edX integration needs /login/_private/complete to work (which is an OAuth2 route) - since we have /login/* APISIX eats this and some scheduled tasks fail, notably the repair faulty users one.

I added /login/oidc because we were using it on the frontend so not 100% sure it's strictly necessary.

### How can this be tested?

Not real sure, but the APISIX redirect into Keycloak should still work and the `repair_missing_courseware_records` management command should also start working again.

