### PR TITLE
refactor: Rename variables and resources to reduce confusion

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/k8s_secrets.py
+++ b/src/ol_infrastructure/applications/mit_learn/k8s_secrets.py
@@ -146,7 +146,7 @@ def create_mitlearn_k8s_secrets(
         mitlearn_namespace: The Kubernetes namespace for mitlearn resources.
         k8s_global_labels: Standard labels to apply to all Kubernetes resources.
         vault_k8s_resources: Vault Kubernetes auth backend resources.
-        mitlearn_vault_mount: The Vault mount resource for mitopen secrets.
+        mitlearn_vault_mount: The Vault mount resource for mitlearn secrets.
         db_config: Configuration for the Vault dynamic PostgreSQL database backend.
 
     Returns:
@@ -157,10 +157,10 @@ def create_mitlearn_k8s_secrets(
         Union[OLVaultK8SSecret, kubernetes.core.v1.Secret]
     ] = []  # Keep track of resources if needed later
 
-    # 1. Static secrets from the mitopen KV-v2 mount
+    # 1. Static secrets from the mitlearn KV-v2 mount
     # These secrets are specific to the mitlearn application environment.
     # Static secrets derived from mitopen/secrets.*.yaml, fetched via Vault agent
-    mitopen_static_secret_name, mitopen_static_secret = _create_static_secret(
+    mitlearn_static_secret_name, mitlearn_static_secret = _create_static_secret(
         stack_info=stack_info,
         secret_base_name="mitopen",  # Base name for the K8s secret resource  # pragma: allowlist secret  # noqa: S106
         namespace=mitlearn_namespace,
@@ -194,8 +194,8 @@ def create_mitlearn_k8s_secrets(
         },
         vaultauth=vault_k8s_resources.auth_name,
     )
-    secret_names.append(mitopen_static_secret_name)
-    secret_resources.append(mitopen_static_secret)
+    secret_names.append(mitlearn_static_secret_name)
+    secret_resources.append(mitlearn_static_secret)
 
     # 2. Static secrets from the shared 'secret-operations' KV-v1 mount
     # These secrets are shared across multiple applications or services.
@@ -279,7 +279,7 @@ def create_mitlearn_k8s_secrets(
         namespace=mitlearn_namespace,
         labels=k8s_global_labels,
         mount="aws-mitx",
-        path="creds/ol-mitopen-application",
+        path="creds/ol-mitlearn-application",
         templates={
             "AWS_ACCESS_KEY_ID": '{{ get .Secrets "access_key" }}',
             "AWS_SECRET_ACCESS_KEY": '{{ get .Secrets "secret_key" }}',  # Corrected key name

--- a/src/ol_infrastructure/applications/mit_learn/mitlearn_policy.hcl
+++ b/src/ol_infrastructure/applications/mit_learn/mitlearn_policy.hcl
@@ -1,14 +1,14 @@
-path "aws-mitx/creds/ol-mitopen-application" {
+path "aws-mitx/creds/ol-mitlearn-application" {
   capabilities = ["read"]
 }
-path "aws-mitx/creds/ol-mitopen-application/*" {
+path "aws-mitx/creds/ol-mitlearn-application/*" {
   capabilities = ["read"]
 }
 
-path "postgres-mitopen/creds/app" {
+path "postgres-mitlearn/creds/app" {
   capabilities = ["read"]
 }
-path "postgres-mitopen/creds/app/*" {
+path "postgres-mitlearn/creds/app/*" {
   capabilities = ["read"]
 }
 
@@ -41,9 +41,6 @@ path "secret-global/data/mailgun" {
   capabilities = ["read"]
 }
 
-path "secret-mitopen/*" {
-  capabilities = ["read"]
-}
 path "secret-mitlearn/*" {
   capabilities = ["read"]
 }
@@ -54,12 +51,12 @@ path "secret-mitlearn/*" {
 path "sys/leases/renew" {
   capabilities = ["update"]
   allowed_parameters = {
-    lease_id = ["postgres-mitopen/creds/app/*"]
+    lease_id = ["postgres-mitlearn/creds/app/*"]
   }
 }
 path "sys/leases/revoke" {
   capabilities = ["update"]
   allowed_parameters = {
-    lease_id = ["postgres-mitopen/creds/app/*"]
+    lease_id = ["postgres-mitlearn/creds/app/*"]
   }
 }


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Renames variables and safe-to-change resources to `mitlearn` instead of `mitopen`

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
This has been applied in CI already. Verify that the app still operates.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
There are still remainders of artifacts that reference the old `mitopen` name which is no longer in use. This causes confusion when trying to perform tasks related to infrastructure that supports the MIT Learn application.

