### PR TITLE
remove contentstore.new_studio_mfe.use_new_video_uploads_page waffle flag on mitxonline production

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
@@ -9,7 +9,6 @@ config:
   consul:scheme: https
   edxapp:waffle_flags:
   - ["content_tagging.disabled", "--create", "--everyone"]
-  - ["contentstore.new_studio_mfe.use_new_video_uploads_page", "--create", "--everyone"]
   - ["course_experience.relative_dates", "--create", "--superusers", "--everyone",
     "--staff", "--authenticated"]
   - ["course_experience.relative_dates_disable_reset", "--create", "--everyone"]

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
@@ -9,7 +9,7 @@ config:
   consul:scheme: https
   edxapp:waffle_flags:
   - ["content_tagging.disabled", "--create", "--everyone"]
-  - ["contentstore.new_studio_mfe.use_new_video_uploads_page", "--create", "--disabled"]
+  - ["contentstore.new_studio_mfe.use_new_video_uploads_page", "--create", "--deactivate"]
   - ["course_experience.relative_dates", "--create", "--superusers", "--everyone",
     "--staff", "--authenticated"]
   - ["course_experience.relative_dates_disable_reset", "--create", "--everyone"]

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
@@ -9,6 +9,7 @@ config:
   consul:scheme: https
   edxapp:waffle_flags:
   - ["content_tagging.disabled", "--create", "--everyone"]
+  - ["contentstore.new_studio_mfe.use_new_video_uploads_page", "--create", "--disabled"]
   - ["course_experience.relative_dates", "--create", "--superusers", "--everyone",
     "--staff", "--authenticated"]
   - ["course_experience.relative_dates_disable_reset", "--create", "--everyone"]


### PR DESCRIPTION
We're in the process of testing and debugging the new video uploads page. It would be best to not have the flag set by pulumi at this time.

### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
<!--- Describe your changes in detail -->

https://github.com/mitodl/hq/issues/7503
https://github.com/mitodl/hq/issues/3607

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Go to a course outline in open edX Studio. Click on the content menu. The last item should be "Video Uploads" and not "Video"

Selecting "Video Uploads" should successfully load a page for editing video metadata. 

