### PR TITLE
KEDA networking changes 

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
@@ -71,7 +71,6 @@ target_vpc = network_stack.require_output(env_config.require("target_vpc"))
 pod_ip_blocks = target_vpc["k8s_pod_subnet_cidrs"]
 public_ip_blocks = target_vpc["k8s_public_subnet_cidrs"]
 pod_subnet_ids = target_vpc["k8s_pod_subnet_ids"]
-pod_ip_blocks = target_vpc["k8s_pod_subnet_cidrs"]
 service_ip_block = target_vpc["k8s_service_subnet_cidr"]
 
 cluster_name = f"{stack_info.env_prefix}-{stack_info.env_suffix}"

--- a/src/ol_infrastructure/infrastructure/aws/network/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/network/__main__.py
@@ -16,12 +16,16 @@ from pulumi import Config, export
 from pulumi_aws import ec2
 from security_groups import default_group, public_ssh, public_web, salt_minion
 
+from bridge.lib.magic_numbers import DEFAULT_REDIS_PORT
 from ol_infrastructure.components.aws.olvpc import (
     OLVPC,
     OLVPCConfig,
     OLVPCPeeringConnection,
 )
 from ol_infrastructure.lib.aws.ec2_helper import default_egress_args
+from ol_infrastructure.lib.aws.eks_helper import (
+    default_psg_egress_args,
+)
 from ol_infrastructure.lib.pulumi_helper import parse_stack
 
 
@@ -200,6 +204,23 @@ data_vpc_exports.update(
     {
         "security_groups": {
             "default": data_vpc.olvpc.id.apply(default_group).id,
+            "keda": ec2.SecurityGroup(
+                f"{data_vpc_config.vpc_name}-keda",
+                description="Security group KEDA pods running EKS to access redis clusters.",  # noqa: E501
+                vpc_id=data_vpc.olvpc.id,
+                ingress=[
+                    ec2.SecurityGroupIngressArgs(
+                        self=True,
+                        from_port=DEFAULT_REDIS_PORT,
+                        to_port=DEFAULT_REDIS_PORT,
+                        protocol="tcp",
+                    ),
+                ],
+                egress=default_psg_egress_args,
+                tags=data_vpc_config.merged_tags(
+                    {"Name": f"data-{stack_info.env_suffix}-keda"}
+                ),
+            ).id,
             "ssh": public_ssh(data_vpc_config.vpc_name, data_vpc.olvpc)(
                 tags=data_vpc_config.merged_tags(
                     {"Name": f"ol-data-{stack_info.env_suffix}-public-ssh"}
@@ -392,6 +413,23 @@ applications_vpc_exports.update(
     {
         "security_groups": {
             "default": applications_vpc.olvpc.id.apply(default_group).id,
+            "keda": ec2.SecurityGroup(
+                f"{applications_vpc_config.vpc_name}-keda",
+                description="Security group KEDA pods running EKS to access redis clusters.",  # noqa: E501
+                vpc_id=applications_vpc.olvpc.id,
+                ingress=[
+                    ec2.SecurityGroupIngressArgs(
+                        self=True,
+                        from_port=DEFAULT_REDIS_PORT,
+                        to_port=DEFAULT_REDIS_PORT,
+                        protocol="tcp",
+                    ),
+                ],
+                egress=default_psg_egress_args,
+                tags=applications_vpc_config.merged_tags(
+                    {"Name": f"applications-{stack_info.env_suffix}-keda"}
+                ),
+            ).id,
             "web": public_web(applications_vpc_config.vpc_name, applications_vpc.olvpc)(
                 tags=applications_vpc_config.merged_tags(
                     {"Name": f"applications-{stack_info.env_suffix}-public-web"}
@@ -441,6 +479,23 @@ operations_vpc_exports.update(
                 egress=[],
                 tags=operations_vpc_config.merged_tags(
                     {"Name": f"operations-{stack_info.env_suffix}-celery-monitoring"}
+                ),
+            ).id,
+            "keda": ec2.SecurityGroup(
+                f"{operations_vpc_config.vpc_name}-keda",
+                description="Security group KEDA pods running EKS to access redis clusters.",  # noqa: E501
+                vpc_id=operations_vpc.olvpc.id,
+                ingress=[
+                    ec2.SecurityGroupIngressArgs(
+                        self=True,
+                        from_port=DEFAULT_REDIS_PORT,
+                        to_port=DEFAULT_REDIS_PORT,
+                        protocol="tcp",
+                    ),
+                ],
+                egress=default_psg_egress_args,
+                tags=operations_vpc_config.merged_tags(
+                    {"Name": f"operations-{stack_info.env_suffix}-keda"}
                 ),
             ).id,
             "default": operations_vpc.olvpc.id.apply(default_group).id,


### PR DESCRIPTION
### Description (What does it do?)
Networking changes needed to enable KEDA in our EKS clusters.

Adds pod_cidr to api-server rules to every EKS cluster.
Adds a new security group to applications, data, and operations VPCs for KEDA + Redis to talk to each other. 