### PR TITLE
fix: add ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN feature flag

### DIFF
--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -62,7 +62,9 @@ class OpenEdxVars(BaseModel):
     terms_of_service_url: str
     trademark_text: Optional[str] = None
     logo_trademark_url: Optional[str] = None
-    enable_video_upload_page_link_in_content_dropdown: Optional[Literal["true", "false"]] = None
+    enable_video_upload_page_link_in_content_dropdown: Optional[
+        Literal["true", "false"]
+    ] = None
 
     @property
     def release_name(self) -> OpenEdxSupportedRelease:
@@ -118,7 +120,7 @@ def mfe_params(
         "TERMS_OF_SERVICE_URL": open_edx.terms_of_service_url,
         "TRADEMARK_TEXT": open_edx.trademark_text,
         "USER_INFO_COOKIE_NAME": f"{open_edx.environment}-edx-user-info",
-        "ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN": open_edx.enable_video_upload_page_link_in_content_dropdown,
+        "ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN": open_edx.enable_video_upload_page_link_in_content_dropdown,  # noqa: E501
     }
 
 

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -62,6 +62,7 @@ class OpenEdxVars(BaseModel):
     terms_of_service_url: str
     trademark_text: Optional[str] = None
     logo_trademark_url: Optional[str] = None
+    enable_video_upload_page_link_in_content_dropdown: Optional[Literal["true", "false"]] = None
 
     @property
     def release_name(self) -> OpenEdxSupportedRelease:
@@ -117,6 +118,7 @@ def mfe_params(
         "TERMS_OF_SERVICE_URL": open_edx.terms_of_service_url,
         "TRADEMARK_TEXT": open_edx.trademark_text,
         "USER_INFO_COOKIE_NAME": f"{open_edx.environment}-edx-user-info",
+        "ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN": open_edx.enable_video_upload_page_link_in_content_dropdown,
     }
 
 

--- a/src/ol_concourse/pipelines/open_edx/mfe/values.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/values.py
@@ -120,6 +120,7 @@ mitxonline = [
         terms_of_service_url="https://ci.mitxonline.mit.edu/terms-of-service/",
         trademark_text="© MITx Online. All rights reserved except where noted.",
         logo_trademark_url="https://courses-ci.mitxonline.mit.edu/static/mitxonline/images/mit-logo.svg",
+        enable_video_upload_page_link_in_content_dropdown="true",
     ),
     OpenEdxVars(
         about_us_url="https://rc.mitxonline.mit.edu/about-us/",
@@ -145,6 +146,7 @@ mitxonline = [
         terms_of_service_url="https://rc.mitxonline.mit.edu/terms-of-service/",
         trademark_text="© MITx Online. All rights reserved except where noted.",
         logo_trademark_url="https://courses-qa.mitxonline.mit.edu/static/mitxonline/images/mit-logo.svg",
+        enable_video_upload_page_link_in_content_dropdown="true",
     ),
     OpenEdxVars(
         about_us_url="https://mitxonline.mit.edu/about-us/",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/3607

### Description (What does it do?)
This PR:
1. adds `ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN` feature flag in env

### How can this be tested?
1. MFE video page should work now. Example course video page: https://studio-qa.mitxonline.mit.edu/authoring/course/course-v1:MITx+MATH.002x+1T2025/videos