### PR TITLE
Increase superset HTTP request timeout

### DIFF
--- a/src/ol_superset/pythonpath/superset_config.py
+++ b/src/ol_superset/pythonpath/superset_config.py
@@ -232,6 +232,9 @@ SQLALCHEMY_POOL_TIMEOUT = 30  # Seconds to wait for a connection from the pool
 SQLALCHEMY_POOL_RECYCLE = 43200  # 12 hours
 SQLALCHEMY_POOL_PRE_PING = True  # Enable connection validation
 
+
+SUPERSET_WEBSERVER_TIMEOUT = 300  # 5 minutes timeout for HTTP requests
+
 # Caching Settings
 cache_base = {
     "CACHE_TYPE": "RedisCache",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
NA

### Description (What does it do?)
<!--- Describe your changes in detail -->
https://pipelines.odl.mit.edu/runs/5e8d7b60-1d5a-47dd-a66b-434af2bc36c1
We are still hitting `Server error '504 Gateway Time-out'` error when calling our Superset API, even after setting timeout=300 on the `httpx` client. It looks like that SUPERSET_WEBSERVER_TIMEOUT is default to 60 seconds, this PR is to increase it to 300 seconds to allow for longer-running HTTP requests (such as dataset refreshes for large tables) on the server side.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

