### PR TITLE
Feature flag `ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN` added for MITxOnline Production

### DIFF
--- a/src/ol_concourse/pipelines/open_edx/mfe/values.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/values.py
@@ -172,6 +172,7 @@ mitxonline = [
         terms_of_service_url="https://mitxonline.mit.edu/terms-of-service/",
         trademark_text="© MITx Online. All rights reserved except where noted.",
         logo_trademark_url="https://courses.mitxonline.mit.edu/static/mitxonline/images/mit-logo.svg",
+        enable_video_upload_page_link_in_content_dropdown="true",
     ),
 ]
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/3607

### Description (What does it do?)
This PR:
1. Adds `ENABLE_VIDEO_UPLOAD_PAGE_LINK_IN_CONTENT_DROPDOWN` flag for MITxOnline production

### Screenshots (if appropriate):
<img width="1266" alt="image" src="https://github.com/user-attachments/assets/5cb086c9-e312-4089-abb3-c90357d5da7f" />
