### PR TITLE
Redirect OCW FAQs to About OCW page

### DIFF
--- a/src/ol_infrastructure/applications/ocw_site/redirect_dict.json
+++ b/src/ol_infrastructure/applications/ocw_site/redirect_dict.json
@@ -358,6 +358,7 @@
   "/about/contactus": "301|keep|https://{{AK_HOSTHEADER}}/contact/",
   "/ans7870/21f/21f.027/home/index.html": "307|discard|https://visualizingcultures.mit.edu/",
   "/ans7870/featured/mitx-courses-on-edx.htm": "301|discard|https://openlearning.mit.edu/courses-programs/mitx-courses/",
+  "/ans7870/global/MIT_OpenCourseWare_FAQs.pdf": "301|discard|https://{{AK_HOSTHEADER}}/about/",
   "/ans7870/resources/Strang/Edited/Calculus/Calculus.pdf": "301|discard|https://{{AK_HOSTHEADER}}/courses/res-18-001-calculus-fall-2023/pages/textbook/",
   "/comments": "307|discard|https://mitocw.zendesk.com/hc/en-us/articles/6636015233051-Comments-Policy-for-YouTube-and-Social-Media",
   "/courses": "307|keep|https://{{AK_HOSTHEADER}}/search/?s=department_course_numbers.sort_coursenum",


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7578.

### Description (What does it do?)

This PR adds a redirect from `https://ocw.mit.edu/ans7870/global/MIT_OpenCourseWare_FAQs.pdf` (the actual PDF has now been deleted since it is outdated) to `https://ocw.mit.edu/about`.

### How can this be tested?
This PR can be tested once it's deployed to RC. However, the URL in the issue can be verified and compared with the URL in this PR.