### PR TITLE
chore: remove xpro zendesk widget variables

### DIFF
--- a/src/ol_infrastructure/applications/xpro/Pulumi.applications.xpro.CI.yaml
+++ b/src/ol_infrastructure/applications/xpro/Pulumi.applications.xpro.CI.yaml
@@ -36,7 +36,6 @@ config:
     SHEETS_REFUND_SKIP_ROW_COL: 14
     VOUCHER_COMPANY_ID: 1
     ZENDESK_DOMAIN_VERIFICATION_TAG_VALUE: "o0itxdfh369m1bw4cuz9"
-    ZENDESK_HELP_WIDGET_KEY: "4bde85d7-9202-4a71-9a35-d9295e7a5b3d"
   vault:address: https://vault-ci.odl.mit.edu
   vault_server:env_namespace: operations.ci
   xpro:db_password:

--- a/src/ol_infrastructure/applications/xpro/Pulumi.applications.xpro.Production.yaml
+++ b/src/ol_infrastructure/applications/xpro/Pulumi.applications.xpro.Production.yaml
@@ -50,8 +50,6 @@ config:
     #WAGTAIL_CACHE_MAX_ENTRIES: 500
     #YOUTUBE_FETCH_SCHEDULE_SECONDS: 7200
     ZENDESK_DOMAIN_VERIFICATION_TAG_VALUE: "o0itxdfh369m1bw4cuz9"
-    ZENDESK_HELP_WIDGET_ENABLED: "True"
-    ZENDESK_HELP_WIDGET_KEY: "8ef9ef96-3317-40a9-8ef6-de0737503caa"
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production
   xpro:db_password:

--- a/src/ol_infrastructure/applications/xpro/Pulumi.applications.xpro.QA.yaml
+++ b/src/ol_infrastructure/applications/xpro/Pulumi.applications.xpro.QA.yaml
@@ -48,8 +48,6 @@ config:
     WAGTAIL_CACHE_MAX_ENTRIES: 500
     YOUTUBE_FETCH_SCHEDULE_SECONDS: 7200
     ZENDESK_DOMAIN_VERIFICATION_TAG_VALUE: "o0itxdfh369m1bw4cuz9"
-    ZENDESK_HELP_WIDGET_ENABLED: "True"
-    ZENDESK_HELP_WIDGET_KEY: "4bde85d7-9202-4a71-9a35-d9295e7a5b3d"
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa
   xpro:db_password:


### PR DESCRIPTION
### What are the relevant tickets?
[#7504](https://github.com/mitodl/hq/issues/7504)

### Description (What does it do?)
This PR removes the `ZENDESK_HELP_WIDGET_KEY` and `ZENDESK_HELP_WIDGET_ENABLED` variables from all xPRO Pulumi configuration files (Production, QA, CI). These variables are no longer required for xPRO deployments as the bot has been removed in [#3537](https://github.com/mitodl/mitxpro/pull/3537)