### PR TITLE
chore: bump ol-openedx-canvas-integration version to 0.5.0 (Staging only)

### DIFF
--- a/dockerfiles/openedx-edxapp/pip_package_lists/teak/mitx-staging.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/teak/mitx-staging.txt
@@ -5,7 +5,7 @@ edx-sga
 edx-sysadmin==0.3.1
 git+https://github.com/raccoongang/xblock-pdf.git@d8948bf3c7127e23be202d1f8600f1ba293ba978#egg=xblock-pdf
 nodeenv>=1.7.0
-ol-openedx-canvas-integration==0.4.0
+ol-openedx-canvas-integration==0.5.0
 ol-openedx-course-export==0.1.2
 ol-openedx-course-structure-api
 ol-openedx-logging==0.2.0

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/common_values.yml.tmpl
@@ -158,6 +158,8 @@ BUGS_EMAIL: odl-devops@mit.edu  # MODIFIED
 BULK_EMAIL_EMAILS_PER_TASK: 500
 BULK_EMAIL_LOG_SENT_EMAILS: false
 BULK_EMAIL_DEFAULT_FROM_EMAIL: {{ key "edxapp/sender-email-address" }} # ADDED
+BULK_EMAIL_MAX_RETRIES: 5  # ADDED
+BULK_EMAIL_DEFAULT_RETRY_DELAY: 30  # ADDED
 CACHES:  # MODIFIED
     celery:
       <<: *redis_cache_config


### PR DESCRIPTION
### What are the relevant tickets?

Related to this PR https://github.com/mitodl/open-edx-plugins/pull/519 (We don't have access to ticket)


<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
- Bumps the ol-openedx-canvas-integration version to 0.5.0 to contains the changes from open-craft
- Adds required settings to be available in CMS

### How can this be tested?

Once deployment is done, the plugins should be upgraded. 


### Reviewer Note

A question here https://github.com/mitodl/ol-infrastructure/pull/3320#discussion_r2159209298
