### PR TITLE
fix: changed the dashboard url for UAI courses to point to mitxonline dashboard

### DIFF
--- a/src/bridge/settings/openedx/mfe/slot_config/mitxonline/common-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/mitxonline/common-mfe-config.env.jsx
@@ -25,29 +25,39 @@ const copyRightText = `${configData.SITE_NAME.replace(/\b(CI|QA|Staging)\b/g, ""
 
 const logo = <Logo imageUrl={configData.LOGO_URL} destinationUrl={configData.MARKETING_SITE_BASE_URL} />;
 
-const userMenu = [
+let userMenu = [
   {
     url: `${configData.MARKETING_SITE_BASE_URL}/dashboard`,
     title: linkTitles.dashboard,
   },
-  ...(!isLearnCourse
-    ? [
-        {
-          url: `${configData.MARKETING_SITE_BASE_URL}/profile/`,
-          title: linkTitles.profile,
-        },
-        {
-          url: `${configData.MARKETING_SITE_BASE_URL}/account-settings/`,
-          title: linkTitles.account,
-        },
-      ]
-    : []),
   {
     url: `${configData.LMS_BASE_URL}/logout`,
     title: linkTitles.logout,
   },
 ];
 
+if (!isLearnCourse) {
+
+  userMenu = [
+    {
+      url: `${configData.MARKETING_SITE_BASE_URL}/dashboard`,
+      title: linkTitles.dashboard,
+    },
+    {
+      url: `${configData.MARKETING_SITE_BASE_URL}/profile/`,
+      title: linkTitles.profile,
+    },
+    {
+      url: `${configData.MARKETING_SITE_BASE_URL}/account-settings/`,
+      title: linkTitles.account,
+    },
+    {
+      url: `${configData.LMS_BASE_URL}/logout`,
+      title: linkTitles.logout,
+    },
+  ];
+
+}
 
 const footerLegalLinks = [
     {


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7672

### Description (What does it do?)
This PR changes back the dashboard url of UAI courses to mitxonline dashboard

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- Visit a UAI course.
- Click the profile dropdown.
- Verify that the dashboard link redirects you to {MARKETING_SITE_BASE_URL}/dashboard and not {MIT_LEARN_BASE_URL}/dashboard


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
