### PR TITLE
adding favorites plugin to OL authentication plugins setting

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -976,7 +976,7 @@ env_vars = {
     "SEE_BASE_URL": "https://executive.mit.edu/",
     "SOCIAL_AUTH_OL_OIDC_KEY": "ol-mitlearn-client",
     "USE_X_FORWARDED_HOST": "True",
-    "MITOL_AUTHENTICATION_PLUGINS": "learning_resources.plugins.FavoritesListPlugin,learning_resources.plugins.FavoritesListPlugin,profiles.plugins.CreateProfilePlugin",
+    "MITOL_AUTHENTICATION_PLUGINS": "learning_resources.plugins.FavoritesListPlugin,profiles.plugins.CreateProfilePlugin",
     "USE_X_FORWARDED_PORT": "True",
     "XPRO_CATALOG_API_URL": "https://xpro.mit.edu/api/programs/",
     "XPRO_COURSES_API_URL": "https://xpro.mit.edu/api/courses/",


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7544

### Description (What does it do?)
This PR re-instates the plugin that automatically creates a default favorites list for users in MIT Learn via environment variable


### How can this be tested?
as per the [ticket](https://github.com/mitodl/hq/issues/7544) this is something that already works locally due to the plugin being enabled by default in local environments.

You can validate this is missing on our deployed envs by ssh'ing in and running the following in django shell:
```python
from django.conf import settings

print(settings.MITOL_AUTHENTICATION_PLUGINS)

 'learning_resources.plugins.FavoritesListPlugin,profiles.plugins.CreateProfilePlugin' # note the missing favorites plugin

```
