### PR TITLE
fix: Set Traefik filter link to HTTP route

### DIFF
--- a/src/ol_infrastructure/applications/keycloak/__main__.py
+++ b/src/ol_infrastructure/applications/keycloak/__main__.py
@@ -610,12 +610,7 @@ gateway_config = OLEKSGatewayConfig(
             name="keycloak-https",
             listener_name="https",
             port=8443,
-            middlewares=[
-                {
-                    "name": KEYCLOAK_COOKIE_FILTER_NAME,
-                    "namespace": "keycloak",
-                }
-            ],
+            filters=[keycloak_cookie_filter.gateway_filter],
         )
     ],
 )

--- a/src/ol_infrastructure/components/aws/eks.py
+++ b/src/ol_infrastructure/components/aws/eks.py
@@ -21,7 +21,6 @@ class OLEKSGatewayRouteConfig(BaseModel):
     backend_service_port: int | None
     filters: list[dict[str, Any]] | None = []
     matches: list[dict[str, Any]] | None = None
-    middlewares: list[dict[str, Any]] | None = None
     listener_name: str
     hostnames: list[str]
     name: str

--- a/src/ol_infrastructure/components/services/k8s.py
+++ b/src/ol_infrastructure/components/services/k8s.py
@@ -1111,3 +1111,7 @@ class OLTraefikMiddleware(pulumi.ComponentResource):
             spec=spec,
             opts=resource_options,
         )
+        self.gateway_filter = {
+            "type": "ExtensionRef",
+            "extensionRef": {"group": "traefik.io", "kind": "Middleware", "name": name},
+        }


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
The K8s gateway API has a concept of filters which get mapped in the Traefik implementation to the middlewares. This updates the code to properly handle that linkage.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Apply the code change to the Keycloak Pulumi project and validate that the middleware takes effect

