### PR TITLE
adding correct prefix

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -935,7 +935,7 @@ env_vars = {
     "MITOL_DB_CONN_MAX_AGE": 0,
     "MITOL_DB_DISABLE_SSL": "True",
     "QDRANT_ENABLE_INDEXING_PLUGIN_HOOKS": True,
-    "CANVAS_COURSE_BUCKET_PREFIX": "canvas/canvas_export",
+    "CANVAS_COURSE_BUCKET_PREFIX": "canvas/canvas_content",
     "MITOL_DEFAULT_SITE_KEY": "micromasters",
     "MITOL_EMAIL_PORT": 587,
     "MITOL_EMAIL_TLS": "True",

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -935,6 +935,7 @@ env_vars = {
     "MITOL_DB_CONN_MAX_AGE": 0,
     "MITOL_DB_DISABLE_SSL": "True",
     "QDRANT_ENABLE_INDEXING_PLUGIN_HOOKS": True,
+    "CANVAS_COURSE_BUCKET_PREFIX": "canvas_export",
     "MITOL_DEFAULT_SITE_KEY": "micromasters",
     "MITOL_EMAIL_PORT": 587,
     "MITOL_EMAIL_TLS": "True",

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -935,7 +935,7 @@ env_vars = {
     "MITOL_DB_CONN_MAX_AGE": 0,
     "MITOL_DB_DISABLE_SSL": "True",
     "QDRANT_ENABLE_INDEXING_PLUGIN_HOOKS": True,
-    "CANVAS_COURSE_BUCKET_PREFIX": "canvas_export",
+    "CANVAS_COURSE_BUCKET_PREFIX": "canvas/canvas_export",
     "MITOL_DEFAULT_SITE_KEY": "micromasters",
     "MITOL_EMAIL_PORT": 587,
     "MITOL_EMAIL_TLS": "True",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Related to https://github.com/mitodl/hq/issues/7514
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This updates the canvas course bucket prefix to what it is supposed to be for both rc and production assuming the course exports will be dumped in s3://ol-data-lake-landing-zone-production/canvas/canvas_export/{course folder}/{course archives}

