### PR TITLE
Fix nginx config staticfile serving

### DIFF
--- a/src/ol_infrastructure/applications/learn_ai/files/web.conf
+++ b/src/ol_infrastructure/applications/learn_ai/files/web.conf
@@ -16,7 +16,7 @@ server {
   location ~* /static(.*$) {
       expires max;
       add_header Access-Control-Allow-Origin *;
-      try_files $uri $uri/ /staticfiles/$1 /staticfiles/$1/ =404;
+      try_files $uri $uri/ /src/staticfiles/$1 /src/staticfiles/$1/ =404;
   }
 
   location /ws {

--- a/src/ol_infrastructure/applications/mit_learn/files/web.conf
+++ b/src/ol_infrastructure/applications/mit_learn/files/web.conf
@@ -18,14 +18,7 @@ server {
         expires max;
         add_header Access-Control-Allow-Origin *;
         # Serve static files directly if they exist, otherwise return 404
-        try_files $uri $uri/ /staticfiles/$1 /staticfiles/$1/ =404;
-    }
-
-    location ~* /media/(.*$) {
-        expires max;
-        add_header Access-Control-Allow-Origin *;
-        # Serve media files directly if they exist, otherwise return 404
-        try_files $uri $uri/ /django_media/$1 /django_media/$1/ =404;
+        try_files $uri $uri/ /src/staticfiles/$1 /src/staticfiles/$1/ =404;
     }
 
     # Optional: Add WebSocket location if needed, similar to learn_ai

--- a/src/ol_infrastructure/applications/mitxonline/files/web.conf
+++ b/src/ol_infrastructure/applications/mitxonline/files/web.conf
@@ -23,14 +23,7 @@ server {
         expires max;
         add_header Access-Control-Allow-Origin *;
         # Serve static files directly if they exist, otherwise return 404
-        try_files $uri $uri/ /staticfiles/$1 /staticfiles/$1/ =404;
-    }
-
-    location ~* /media/(.*$) {
-        expires max;
-        add_header Access-Control-Allow-Origin *;
-        # Serve media files directly if they exist, otherwise return 404
-        try_files $uri $uri/ /django_media/$1 /django_media/$1/ =404;
+        try_files $uri $uri/ /src/staticfiles/$1 /src/staticfiles/$1/ =404;
     }
 
     # Optional: Add WebSocket location if needed, similar to learn_ai

--- a/src/ol_infrastructure/applications/unified_ecommerce/files/web.conf
+++ b/src/ol_infrastructure/applications/unified_ecommerce/files/web.conf
@@ -18,13 +18,7 @@ server {
     location ~* /static/(.*$) {
         expires max;
         add_header Access-Control-Allow-Origin *;
-        try_files $uri $uri/ /staticfiles/$1 /staticfiles/$1/ =404;
-    }
-
-    location ~* /media/(.*$) {
-        expires max;
-        add_header Access-Control-Allow-Origin *;
-        try_files $uri $uri/ /django_media/$1 /django_media/$1/ =404;
+        try_files $uri $uri/ /src/staticfiles/$1 /src/staticfiles/$1/ =404;
     }
 
     location / {


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
This updates the filepath where nginx should be looking for staticfiles to the correct directory where it is being mounted [here](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/components/services/k8s.py#L232-L237). I also removed routing for django media files as a) we use S3 for file storage b) even if we didn't, it wouldn't work anyway because django containers would be writing those files to their FS which nginx can't access. Note this touches several applications, but since they all use the same shared code for mounting the volume, the path should be the same on all of them.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Deploy to CI/RC and test