### PR TITLE
config: add/enable ol-openedx-chat-xblock on MITx QA/Staging

### DIFF
--- a/dockerfiles/openedx-edxapp/pip_package_lists/master/mitx-staging.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/master/mitx-staging.txt
@@ -20,3 +20,4 @@ wheel==0.45.1
 
 # Experimental Plugins for AI features
 ol-openedx-chat
+ol-openedx-chat-xblock

--- a/dockerfiles/openedx-edxapp/pip_package_lists/master/mitx.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/master/mitx.txt
@@ -20,3 +20,4 @@ wheel==0.45.1
 
 # Experimental Plugins for AI features
 ol-openedx-chat
+ol-openedx-chat-xblock

--- a/dockerfiles/openedx-edxapp/pip_package_lists/teak/mitx-staging.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/teak/mitx-staging.txt
@@ -20,3 +20,4 @@ wheel==0.45.1
 
 # Experimental Plugins for AI features
 ol-openedx-chat
+ol-openedx-chat-xblock

--- a/dockerfiles/openedx-edxapp/pip_package_lists/teak/mitx.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/teak/mitx.txt
@@ -20,3 +20,4 @@ wheel==0.45.1
 
 # Experimental Plugins for AI features
 ol-openedx-chat
+ol-openedx-chat-xblock

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/common_values.yml.tmpl
@@ -416,6 +416,8 @@ LOGO_TRADEMARK_URL: https://{{ key "edxapp/lms-domain" }}/static/mitx-staging/im
 MIT_LEARN_AI_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai  # Added for ol_openedx_chat
 MIT_LEARN_API_BASE_URL: https://{{ key "edxapp/learn-api-domain" }}/learn  # Added for ol_openedx_chat
 MIT_LEARN_SUMMARY_FLASHCARD_URL: https://{{ key "edxapp/learn-api-domain" }}/learn/api/v1/contentfiles/  # Added for ol_openedx_chat
+MIT_LEARN_AI_XBLOCK_CHAT_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai/http/syllabus_agent/  # Added for ol_openedx_chat_xblock
+MIT_LEARN_AI_XBLOCK_CHAT_API_TOKEN: ''  # Added for ol_openedx_chat_xblock
 MAINTENANCE_BANNER_TEXT: Sample banner message
 MEDIA_ROOT: media/  # MODIFIED - with s3 storage backend this is the path within the bucket. No leading / allowed
 MEDIA_URL: /media/

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx/common_values.yml.tmpl
@@ -418,6 +418,8 @@ LOGO_TRADEMARK_URL: https://{{ key "edxapp/lms-domain" }}/static/mitx/images/mit
 MIT_LEARN_AI_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai  # Added for ol_openedx_chat
 MIT_LEARN_API_BASE_URL: https://{{ key "edxapp/learn-api-domain" }}/learn  # Added for ol_openedx_chat
 MIT_LEARN_SUMMARY_FLASHCARD_URL: https://{{ key "edxapp/learn-api-domain" }}/learn/api/v1/contentfiles/  # Added for ol_openedx_chat
+MIT_LEARN_AI_XBLOCK_CHAT_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai/http/syllabus_agent/  # Added for ol_openedx_chat_xblock
+MIT_LEARN_AI_XBLOCK_CHAT_API_TOKEN: ''  # Added for ol_openedx_chat_xblock
 MAINTENANCE_BANNER_TEXT: Sample banner message
 MEDIA_ROOT: media/  # MODIFIED - with s3 storage backend this is the path within the bucket. No leading / allowed
 MEDIA_URL: /media/


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7781
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
- Adds the newly created ol-openedx-chat-xblock in MITx Staging/QA
<!--- Describe your changes in detail -->

### Screenshots (if appropriate):

<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
Once done, We should be able to add the newly created ol-openedx-chat-xblock in the course outline
