### PR TITLE
chore: add missing email settings for QA/MITx for Canvas package

### DIFF
--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx/common_values.yml.tmpl
@@ -159,6 +159,8 @@ BUGS_EMAIL: odl-devops@mit.edu  # MODIFIED
 BULK_EMAIL_EMAILS_PER_TASK: 500
 BULK_EMAIL_LOG_SENT_EMAILS: false
 BULK_EMAIL_DEFAULT_FROM_EMAIL: {{ key "edxapp/sender-email-address" }} # ADDED
+BULK_EMAIL_MAX_RETRIES: 5  # ADDED
+BULK_EMAIL_DEFAULT_RETRY_DELAY: 30  # ADDED
 CACHES:  # MODIFIED
     celery:
       <<: *redis_cache_config


### PR DESCRIPTION
### What are the relevant tickets?
Doing similar changes as https://github.com/mitodl/ol-infrastructure/pull/3320 but for QA, [Related Sentry Error](https://mit-office-of-digital-learning.sentry.io/issues/6703840060/?environment=mitx-qa&project=1757731&query=is%3Aunresolved&referrer=issue-stream&stream_index=0)

### Description (What does it do?)
These keys are breaking on QA environment, Celery is probably breaking on startup so that might be the reason out outline generation is also failing on QA> 

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
