### PR TITLE
Start indexing learn.mit.edu

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.CI.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.CI.yaml
@@ -66,7 +66,6 @@ config:
     MITOL_COOKIE_NAME: "learn-ci"
     MITOL_LOG_LEVEL: "INFO"
     MITOL_NEW_USER_LOGIN_URL: "https://ci.learn.mit.edu/onboarding"
-    MITOL_NOINDEX: "true"
     OPENTELEMETRY_ENABLED: "true"
     OPENTELEMETRY_ENDPOINT: "http://grafana-alloy.operations.svc.cluster.local:4318/v1/traces"
     MITOL_SUPPORT_EMAIL: "odl-learn-ci-support@mit.edu" # Need to verify

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.Production.yaml
@@ -63,7 +63,6 @@ config:
     MITOL_COOKIE_NAME: "learn"
     MITOL_LOG_LEVEL: "INFO"
     MITOL_NEW_USER_LOGIN_URL: "https://learn.mit.edu/onboarding"
-    MITOL_NOINDEX: "false"
     MITOL_SUPPORT_EMAIL: "learn-support@mit.edu" # Need to verify
     MITPE_API_ENABLED: "true"
     OCW_ITERATOR_CHUNK_SIZE: 300

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.QA.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.QA.yaml
@@ -62,7 +62,6 @@ config:
     MITOL_COOKIE_NAME: "learn-rc"
     MITOL_LOG_LEVEL: "INFO"
     MITOL_NEW_USER_LOGIN_URL: "https://rc.learn.mit.edu/onboarding"
-    MITOL_NOINDEX: "true"
     MITOL_SUPPORT_EMAIL: "odl-learn-rc-support@mit.edu" # Need to verify
     MITPE_API_ENABLED: "true"
     OCW_ITERATOR_CHUNK_SIZE: 300

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.applications.mit_learn_nextjs.CI.yaml
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.applications.mit_learn_nextjs.CI.yaml
@@ -9,6 +9,7 @@ config:
   nextjs:embedly_key:
     secure: v1:9n/aYdG9CsOgh24r:I1i8lrMAmDCGiGyL6HKXRnz2Mk571vvk0/uiQg5wlte69B2CEQl0cKhMgd9F1Gpq
   nextjs:mitlearn_api_base_url: "https://api.ci.learn.mit.edu"
+  nextjs:mitol_noindex: "true"
   nextjs:mitxonline_base_url: "https://ci.mitxonline.mit.edu"
   nextjs:origin: "https://ci.learn.mit.edu"
   nextjs:posthog_api_host: "https://ph.ol.mit.edu"

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.applications.mit_learn_nextjs.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.applications.mit_learn_nextjs.Production.yaml
@@ -9,6 +9,7 @@ config:
   nextjs:embedly_key:
     secure: v1:k5VhDKIu3fRgFRZK:uD6fSyGLF3QhKYIbgUJ3/p+3x+fmtQqU4UpuLvJa72UbhDHf1s9t2O2NMQ7492bw
   nextjs:mitlearn_api_base_url: "https://api.learn.mit.edu"
+  nextjs:mitol_noindex: "false"
   nextjs:mitxonline_base_url: "https://mitxonline.mit.edu"
   nextjs:origin: "https://learn.mit.edu"
   nextjs:posthog_api_host: "https://ph.ol.mit.edu"

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.applications.mit_learn_nextjs.QA.yaml
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.applications.mit_learn_nextjs.QA.yaml
@@ -9,6 +9,7 @@ config:
   nextjs:embedly_key:
     secure: v1:1+Ibvcym7D5UMBPn:kQV6cI3kOhR2uGeeQCQdEvp9gYyfIKv5wInPQzzmnaZhMMAjPBDAJIoyx2zREBGB
   nextjs:mitlearn_api_base_url: "https://api.rc.learn.mit.edu"
+  nextjs:mitol_noindex: "true"
   nextjs:mitxonline_base_url: "https://rc.mitxonline.mit.edu"
   nextjs:origin: "https://rc.learn.mit.edu"
   nextjs:posthog_api_host: "https://ph.ol.mit.edu"

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
@@ -42,6 +42,9 @@ cluster_stack.require_output("namespaces").apply(
 nextjs_config = Config("nextjs")
 
 raw_env_vars = {
+    # Env vars available only on server
+    "MITOL_NOINDEX": nextjs_config.get("mitol_noindex"),
+    # Env vars available on client and server
     "NEXT_PUBLIC_APPZI_URL": nextjs_config.require("appzi_url"),
     "NEXT_PUBLIC_CSRF_COOKIE_NAME": nextjs_config.require("csrf_cookie_name"),
     "NEXT_PUBLIC_EMBEDLY_KEY": nextjs_config.require("embedly_key"),


### PR DESCRIPTION
### What are the relevant tickets?
Followup to https://github.com/mitodl/hq/issues/7696 and https://github.com/mitodl/hq/issues/7426

### Description (What does it do?)
- Removes MITOL_NOINDEX env var from the backend stack. It is unused.
- Set MITOL_NOINDEX on the nextjs app. Only production should be indexed.

### How can this be tested?
Deploy and check vars.