### PR TITLE
fix: add placeholder token for AI chat xBlock

### DIFF
--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/common_values.yml.tmpl
@@ -417,7 +417,7 @@ MIT_LEARN_AI_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai  # Added fo
 MIT_LEARN_API_BASE_URL: https://{{ key "edxapp/learn-api-domain" }}/learn  # Added for ol_openedx_chat
 MIT_LEARN_SUMMARY_FLASHCARD_URL: https://{{ key "edxapp/learn-api-domain" }}/learn/api/v1/contentfiles/  # Added for ol_openedx_chat
 MIT_LEARN_AI_XBLOCK_CHAT_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai/http/syllabus_agent/  # Added for ol_openedx_chat_xblock
-MIT_LEARN_AI_XBLOCK_CHAT_API_TOKEN: ''  # Added for ol_openedx_chat_xblock
+MIT_LEARN_AI_XBLOCK_CHAT_API_TOKEN: 'placeholder'  # Added for ol_openedx_chat_xblock
 MAINTENANCE_BANNER_TEXT: Sample banner message
 MEDIA_ROOT: media/  # MODIFIED - with s3 storage backend this is the path within the bucket. No leading / allowed
 MEDIA_URL: /media/

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx/common_values.yml.tmpl
@@ -421,7 +421,7 @@ MIT_LEARN_AI_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai  # Added fo
 MIT_LEARN_API_BASE_URL: https://{{ key "edxapp/learn-api-domain" }}/learn  # Added for ol_openedx_chat
 MIT_LEARN_SUMMARY_FLASHCARD_URL: https://{{ key "edxapp/learn-api-domain" }}/learn/api/v1/contentfiles/  # Added for ol_openedx_chat
 MIT_LEARN_AI_XBLOCK_CHAT_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai/http/syllabus_agent/  # Added for ol_openedx_chat_xblock
-MIT_LEARN_AI_XBLOCK_CHAT_API_TOKEN: ''  # Added for ol_openedx_chat_xblock
+MIT_LEARN_AI_XBLOCK_CHAT_API_TOKEN: 'placeholder'  # Added for ol_openedx_chat_xblock
 MAINTENANCE_BANNER_TEXT: Sample banner message
 MEDIA_ROOT: media/  # MODIFIED - with s3 storage backend this is the path within the bucket. No leading / allowed
 MEDIA_URL: /media/


### PR DESCRIPTION
### What are the relevant tickets?
None

<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
- Adds placeholder AI chat token instead of empty because empty token is not acceptable.
