### PR TITLE
update config to use path prefixed api

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.applications.mit_learn_nextjs.CI.yaml
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.applications.mit_learn_nextjs.CI.yaml
@@ -10,7 +10,7 @@ config:
     secure: v1:9n/aYdG9CsOgh24r:I1i8lrMAmDCGiGyL6HKXRnz2Mk571vvk0/uiQg5wlte69B2CEQl0cKhMgd9F1Gpq
   nextjs:mitlearn_api_base_url: "https://api.ci.learn.mit.edu"
   nextjs:mitol_noindex: "true"
-  nextjs:mitxonline_base_url: "https://ci.mitxonline.mit.edu"
+  nextjs:mitxonline_base_url: "https://api.ci.learn.mit.edu/mitxonline"
   nextjs:origin: "https://ci.learn.mit.edu"
   nextjs:posthog_api_host: "https://ph.ol.mit.edu"
   nextjs:posthog_api_key:

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.applications.mit_learn_nextjs.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.applications.mit_learn_nextjs.Production.yaml
@@ -10,7 +10,7 @@ config:
     secure: v1:k5VhDKIu3fRgFRZK:uD6fSyGLF3QhKYIbgUJ3/p+3x+fmtQqU4UpuLvJa72UbhDHf1s9t2O2NMQ7492bw
   nextjs:mitlearn_api_base_url: "https://api.learn.mit.edu"
   nextjs:mitol_noindex: "false"
-  nextjs:mitxonline_base_url: "https://mitxonline.mit.edu"
+  nextjs:mitxonline_base_url: "https://api.learn.mit.edu/mitxonline"
   nextjs:origin: "https://learn.mit.edu"
   nextjs:posthog_api_host: "https://ph.ol.mit.edu"
   nextjs:posthog_api_key:

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.applications.mit_learn_nextjs.QA.yaml
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.applications.mit_learn_nextjs.QA.yaml
@@ -10,7 +10,7 @@ config:
     secure: v1:1+Ibvcym7D5UMBPn:kQV6cI3kOhR2uGeeQCQdEvp9gYyfIKv5wInPQzzmnaZhMMAjPBDAJIoyx2zREBGB
   nextjs:mitlearn_api_base_url: "https://api.rc.learn.mit.edu"
   nextjs:mitol_noindex: "true"
-  nextjs:mitxonline_base_url: "https://rc.mitxonline.mit.edu"
+  nextjs:mitxonline_base_url: "https://api.rc.learn.mit.edu/mitxonline"
   nextjs:origin: "https://rc.learn.mit.edu"
   nextjs:posthog_api_host: "https://ph.ol.mit.edu"
   nextjs:posthog_api_key:

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
@@ -55,6 +55,7 @@ raw_env_vars = {
         "syllabus_endpoint"
     ),
     "NEXT_PUBLIC_MITOL_API_BASE_URL": nextjs_config.require("mitlearn_api_base_url"),
+    "NEXT_PUBLIC_MITX_ONLINE_CSRF_COOKIE_NAME": "csrf_mitxonline",
     "NEXT_PUBLIC_MITX_ONLINE_BASE_URL": nextjs_config.require("mitxonline_base_url"),
     "NEXT_PUBLIC_MITOL_AXIOS_WITH_CREDENTIALS": "true",
     "NEXT_PUBLIC_MITOL_SUPPORT_EMAIL": "mitlearn-support@mit.edu",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
This PR updates the `NEXT_PUBLIC_MITX_ONLINE_CSRF_COOKIE_NAME` and `NEXT_PUBLIC_MITX_ONLINE_BASE_URL` in the MIT Learn NextJS build to use the path-prefixed MITx Online base URLs for the Axios client as well as the updated CSRF cookie name.

### How can this be tested?
This needs to be tested in RC