### PR TITLE
chore: update the AI chat xBlock URLs and API token key

### DIFF
--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/common_values.yml.tmpl
@@ -417,7 +417,7 @@ MIT_LEARN_AI_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai  # Added fo
 MIT_LEARN_API_BASE_URL: https://{{ key "edxapp/learn-api-domain" }}/learn  # Added for ol_openedx_chat
 MIT_LEARN_SUMMARY_FLASHCARD_URL: https://{{ key "edxapp/learn-api-domain" }}/learn/api/v1/contentfiles/  # Added for ol_openedx_chat
 MIT_LEARN_AI_XBLOCK_CHAT_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai/http/canvas_syllabus_agent/  # Added for ol_openedx_chat_xblock
-MIT_LEARN_AI_XBLOCK_CHAT_API_TOKEN: {{ key "learn_ai_xblock_chat_api_token" }}  # Added for ol_openedx_chat_xblock
+MIT_LEARN_AI_XBLOCK_CHAT_API_TOKEN: {{ key "edxapp/learn_ai_xblock_chat_api_token" }}  # Added for ol_openedx_chat_xblock
 MAINTENANCE_BANNER_TEXT: Sample banner message
 MEDIA_ROOT: media/  # MODIFIED - with s3 storage backend this is the path within the bucket. No leading / allowed
 MEDIA_URL: /media/

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/common_values.yml.tmpl
@@ -67,6 +67,9 @@ XQUEUE_INTERFACE:
 {{ with secret "secret-mitx-staging/edx-forum" }}
 COMMENTS_SERVICE_KEY: {{ .Data.forum_api_key }}
 {{ end }}
+{{ with secret "secret-global/learn_ai" }}
+MIT_LEARN_AI_XBLOCK_CHAT_API_TOKEN: {{ .Data.canvas_syllabus_token }}  # Added for ol_openedx_chat_xblock
+{{ end }}
 
 DATABASES:
   default:
@@ -417,7 +420,6 @@ MIT_LEARN_AI_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai  # Added fo
 MIT_LEARN_API_BASE_URL: https://{{ key "edxapp/learn-api-domain" }}/learn  # Added for ol_openedx_chat
 MIT_LEARN_SUMMARY_FLASHCARD_URL: https://{{ key "edxapp/learn-api-domain" }}/learn/api/v1/contentfiles/  # Added for ol_openedx_chat
 MIT_LEARN_AI_XBLOCK_CHAT_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai/http/canvas_syllabus_agent/  # Added for ol_openedx_chat_xblock
-MIT_LEARN_AI_XBLOCK_CHAT_API_TOKEN: {{ key "edxapp/learn_ai_xblock_chat_api_token" }}  # Added for ol_openedx_chat_xblock
 MAINTENANCE_BANNER_TEXT: Sample banner message
 MEDIA_ROOT: media/  # MODIFIED - with s3 storage backend this is the path within the bucket. No leading / allowed
 MEDIA_URL: /media/

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/common_values.yml.tmpl
@@ -416,8 +416,8 @@ LOGO_TRADEMARK_URL: https://{{ key "edxapp/lms-domain" }}/static/mitx-staging/im
 MIT_LEARN_AI_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai  # Added for ol_openedx_chat
 MIT_LEARN_API_BASE_URL: https://{{ key "edxapp/learn-api-domain" }}/learn  # Added for ol_openedx_chat
 MIT_LEARN_SUMMARY_FLASHCARD_URL: https://{{ key "edxapp/learn-api-domain" }}/learn/api/v1/contentfiles/  # Added for ol_openedx_chat
-MIT_LEARN_AI_XBLOCK_CHAT_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai/http/syllabus_agent/  # Added for ol_openedx_chat_xblock
-MIT_LEARN_AI_XBLOCK_CHAT_API_TOKEN: 'placeholder'  # Added for ol_openedx_chat_xblock
+MIT_LEARN_AI_XBLOCK_CHAT_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai/http/canvas_syllabus_agent/  # Added for ol_openedx_chat_xblock
+MIT_LEARN_AI_XBLOCK_CHAT_API_TOKEN: {{ key "learn_ai_xblock_chat_api_token" }}  # Added for ol_openedx_chat_xblock
 MAINTENANCE_BANNER_TEXT: Sample banner message
 MEDIA_ROOT: media/  # MODIFIED - with s3 storage backend this is the path within the bucket. No leading / allowed
 MEDIA_URL: /media/

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx/common_values.yml.tmpl
@@ -67,6 +67,9 @@ XQUEUE_INTERFACE:
 {{ with secret "secret-mitx/edx-forum" }}
 COMMENTS_SERVICE_KEY: {{ .Data.forum_api_key }}
 {{ end }}
+{{ with secret "secret-global/learn_ai" }}
+MIT_LEARN_AI_XBLOCK_CHAT_API_TOKEN: {{ .Data.canvas_syllabus_token }}  # Added for ol_openedx_chat_xblock
+{{ end }}
 
 DATABASES:
   default:
@@ -421,7 +424,6 @@ MIT_LEARN_AI_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai  # Added fo
 MIT_LEARN_API_BASE_URL: https://{{ key "edxapp/learn-api-domain" }}/learn  # Added for ol_openedx_chat
 MIT_LEARN_SUMMARY_FLASHCARD_URL: https://{{ key "edxapp/learn-api-domain" }}/learn/api/v1/contentfiles/  # Added for ol_openedx_chat
 MIT_LEARN_AI_XBLOCK_CHAT_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai/http/canvas_syllabus_agent/  # Added for ol_openedx_chat_xblock
-MIT_LEARN_AI_XBLOCK_CHAT_API_TOKEN: {{ key "edxapp/learn_ai_xblock_chat_api_token" }}  # Added for ol_openedx_chat_xblock
 MAINTENANCE_BANNER_TEXT: Sample banner message
 MEDIA_ROOT: media/  # MODIFIED - with s3 storage backend this is the path within the bucket. No leading / allowed
 MEDIA_URL: /media/

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx/common_values.yml.tmpl
@@ -420,8 +420,8 @@ LOGO_TRADEMARK_URL: https://{{ key "edxapp/lms-domain" }}/static/mitx/images/mit
 MIT_LEARN_AI_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai  # Added for ol_openedx_chat
 MIT_LEARN_API_BASE_URL: https://{{ key "edxapp/learn-api-domain" }}/learn  # Added for ol_openedx_chat
 MIT_LEARN_SUMMARY_FLASHCARD_URL: https://{{ key "edxapp/learn-api-domain" }}/learn/api/v1/contentfiles/  # Added for ol_openedx_chat
-MIT_LEARN_AI_XBLOCK_CHAT_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai/http/syllabus_agent/  # Added for ol_openedx_chat_xblock
-MIT_LEARN_AI_XBLOCK_CHAT_API_TOKEN: 'placeholder'  # Added for ol_openedx_chat_xblock
+MIT_LEARN_AI_XBLOCK_CHAT_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai/http/canvas_syllabus_agent/  # Added for ol_openedx_chat_xblock
+MIT_LEARN_AI_XBLOCK_CHAT_API_TOKEN: {{ key "learn_ai_xblock_chat_api_token" }}  # Added for ol_openedx_chat_xblock
 MAINTENANCE_BANNER_TEXT: Sample banner message
 MEDIA_ROOT: media/  # MODIFIED - with s3 storage backend this is the path within the bucket. No leading / allowed
 MEDIA_URL: /media/

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx/common_values.yml.tmpl
@@ -421,7 +421,7 @@ MIT_LEARN_AI_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai  # Added fo
 MIT_LEARN_API_BASE_URL: https://{{ key "edxapp/learn-api-domain" }}/learn  # Added for ol_openedx_chat
 MIT_LEARN_SUMMARY_FLASHCARD_URL: https://{{ key "edxapp/learn-api-domain" }}/learn/api/v1/contentfiles/  # Added for ol_openedx_chat
 MIT_LEARN_AI_XBLOCK_CHAT_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai/http/canvas_syllabus_agent/  # Added for ol_openedx_chat_xblock
-MIT_LEARN_AI_XBLOCK_CHAT_API_TOKEN: {{ key "learn_ai_xblock_chat_api_token" }}  # Added for ol_openedx_chat_xblock
+MIT_LEARN_AI_XBLOCK_CHAT_API_TOKEN: {{ key "edxapp/learn_ai_xblock_chat_api_token" }}  # Added for ol_openedx_chat_xblock
 MAINTENANCE_BANNER_TEXT: Sample banner message
 MEDIA_ROOT: media/  # MODIFIED - with s3 storage backend this is the path within the bucket. No leading / allowed
 MEDIA_URL: /media/

--- a/src/bridge/secrets/vault/secrets.ci.yaml
+++ b/src/bridge/secrets/vault/secrets.ci.yaml
@@ -31,6 +31,8 @@ odl-wildcard:
 heroku:
   mitx_devops_api_key: ENC[AES256_GCM,data:aLXulBvQlLTuyRS35yn/Ifo0vsbR1+IJO0o7/TsGZQeSY/6A,iv:8JROrXVF15zZxH5VVWt4bAe3boxJ2RUVO/ChTqbIWa8=,tag:+uhPEa3LzDBUemOabhJXjg==,type:str]
   odl_devops_api_key: ENC[AES256_GCM,data:CUJeCE6YaRHHMqrezUuW4nJ4Gfe4VzD2Gm1+vgyjMid2BWX/,iv:zJqwANnlXJ54s2YLxy/cRPP4ZV9uK1Ou2BLHozwVC2k=,tag:kuHJ785PRd8HnHECXC6I1Q==,type:str]
+learn_ai:
+  canvas_syllabus_token: ENC[AES256_GCM,data:5UYI54Fhf6BCIlW/CLJdkC8lX9cLDKA41dHnycym0JOAg0kBHusHXpBprA==,iv:tZDVELOBdkFk1ll5AHXjShCN4Mo+1YbSUSU38z/O1VE=,tag:inHPoCFIbEvidip9Gj86xw==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-ci
@@ -43,8 +45,8 @@ sops:
     key_name: sops
     created_at: "2024-01-24T19:59:10Z"
     enc: vault:v1:J5sxEsIe+qD777/RgQw5uxTX5zTTOQ9mgVrQgIXT+UB9YTE+DpXUdlR9ueM0AEDCwi5PWdzEmVjZ5Rdm
-  lastmodified: "2025-06-23T16:26:18Z"
-  mac: ENC[AES256_GCM,data:Rwggz36xe8RJfgHLyehoiHRAfRPvuC2v4nN+wbxjA+k6jbIa/mz2QMg5BRVW8+98AtKK0cSUFXg8Noyc7ANTM/j/dDASElxSMU7p2hGNIBWrsmtfpeCjB6mv3hJ+UGaH3rGV3Hpq9+xwYyWzbk3u2yE0gdg28gDa0gUzISyGB8k=,iv:GhFe/u72DNXAUnYmIIyqskRybBrgzs1sU6VHqvAjUGo=,tag:khdI8z2SO2kuB88c+CI3xg==,type:str]
+  lastmodified: "2025-07-16T13:49:36Z"
+  mac: ENC[AES256_GCM,data:6ovGfSX+ShivMcDbLRCQXMm0CbWwZ1JXufiiu7Alv4SrqjKz99uVtmUf5kTzHdwMmmqBs2c5KLzWyg8iQgiY5NXpS7PBKchDai8L2azJcBoME+wJIx5VpNPDHfamumvS+oF4hdNLvL/NdOFyufJNWOpCqjRHy4FjTMFJ3VqPOtA=,iv:Xi9COhOrgLlABpoipguu56d1gLouepekgqPQYEa7Rno=,tag:ELEiTQ6ZytrvQMGPyvP8Ig==,type:str]
   pgp:
   - created_at: "2024-01-24T19:59:10Z"
     enc: |-

--- a/src/bridge/secrets/vault/secrets.production.yaml
+++ b/src/bridge/secrets/vault/secrets.production.yaml
@@ -31,6 +31,8 @@ odl-wildcard:
 heroku:
   mitx_devops_api_key: ENC[AES256_GCM,data:aLXulBvQlLTuyRS35yn/Ifo0vsbR1+IJO0o7/TsGZQeSY/6A,iv:8JROrXVF15zZxH5VVWt4bAe3boxJ2RUVO/ChTqbIWa8=,tag:+uhPEa3LzDBUemOabhJXjg==,type:str]
   odl_devops_api_key: ENC[AES256_GCM,data:CUJeCE6YaRHHMqrezUuW4nJ4Gfe4VzD2Gm1+vgyjMid2BWX/,iv:zJqwANnlXJ54s2YLxy/cRPP4ZV9uK1Ou2BLHozwVC2k=,tag:kuHJ785PRd8HnHECXC6I1Q==,type:str]
+learn_ai:
+  canvas_syllabus_token: ENC[AES256_GCM,data:d0WC1N2mP35vQUEoHOFCpyD1V0LcLVmoL354w/zbCVslM9F8aY43mgrHnA==,iv:oLCC98zej0C1yvoQW1dcWJCDRVdeg8PrBnSpEt3XU6Y=,tag:WRHgO6smiXRMbqmrIvP1QQ==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
@@ -43,8 +45,8 @@ sops:
     key_name: sops
     created_at: "2024-01-24T20:23:02Z"
     enc: vault:v1:wFpDUWRU95eZWvdkzMYn98bDFkyFdG6MO+HhEEUEEkerK/yrBOOHgnoF/u65kkh7l0q3ZDZpOBv7X9rJ
-  lastmodified: "2025-06-23T16:26:57Z"
-  mac: ENC[AES256_GCM,data:pv2q4ILIM7CDM+wugIbuiuF5cPIwrVKq3ts7XAh66VzuzBWBwfYTERyfqaR+RfMg3fhldw1wtgh901kRIZ8F6LFENPy+5U/wsuigrb4X/356kYwdbOdXtGfuA7nZOSBscXiVWezNe50qhvvEcnDfNXEcNdIEetc41SkqtiCpHWE=,iv:q3iue+CnunhN22dQMwOoAjnEKAnNH0KpWqbl4s8f2l0=,tag:EmG4Ra4vJo3qj4jIzoziYw==,type:str]
+  lastmodified: "2025-07-16T13:50:14Z"
+  mac: ENC[AES256_GCM,data:IINcmw0jbXqGeScf0wiYHIMEj+x3OiUpJ1ihUgsVtUU4aCm3VAcsOggz8euF/q8UamJ73wloFoHimw2PcqhIgLLWMBVs5JZ+0D7qIoHpzmUuYToECU5znhd+l0HinVygnLY9lon9XJS3ZKM5rXBr+eRGRRUZ6Y5istcfgrXXCH0=,iv:cBBmdlXc5Q5xr277DKn5HipLU12QxJa4g2HZpxnGpAQ=,tag:Dg7RX30LouvcZdg9UQmWAA==,type:str]
   pgp:
   - created_at: "2024-01-24T20:23:02Z"
     enc: |-

--- a/src/bridge/secrets/vault/secrets.qa.yaml
+++ b/src/bridge/secrets/vault/secrets.qa.yaml
@@ -31,6 +31,8 @@ odl-wildcard:
 heroku:
   mitx_devops_api_key: ENC[AES256_GCM,data:aLXulBvQlLTuyRS35yn/Ifo0vsbR1+IJO0o7/TsGZQeSY/6A,iv:8JROrXVF15zZxH5VVWt4bAe3boxJ2RUVO/ChTqbIWa8=,tag:+uhPEa3LzDBUemOabhJXjg==,type:str]
   odl_devops_api_key: ENC[AES256_GCM,data:CUJeCE6YaRHHMqrezUuW4nJ4Gfe4VzD2Gm1+vgyjMid2BWX/,iv:zJqwANnlXJ54s2YLxy/cRPP4ZV9uK1Ou2BLHozwVC2k=,tag:kuHJ785PRd8HnHECXC6I1Q==,type:str]
+learn_ai:
+  canvas_syllabus_token: ENC[AES256_GCM,data:zhov1VeYBkkV6oFMecHzKYVEYoAhpvJ9QsZQxDUl0QXGy2tyDLlSGndMtg==,iv:1fZUMnqyeUMQ75ltbOuD6QnIfVQHjysG0iLz2FlE/nM=,tag:y59uZWJkgzv1m2AC3r/Qaw==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-qa
@@ -43,8 +45,8 @@ sops:
     key_name: sops
     created_at: "2024-01-24T20:21:47Z"
     enc: vault:v1:1p6NmnfmZs1pSLy+G5clxb22Qt8YHGIWmpH3j2eA8X1lbPIDdsjZ+wgJWnqtrZrfa4tlKlUbAXGMD5u2
-  lastmodified: "2025-06-23T16:26:40Z"
-  mac: ENC[AES256_GCM,data:mJrtvG4GtImn2RniUSoTWk/1pmy1hegMSeXujdvXK5OYShwjdt97LejT5XFobV9vwB+bSCD/Z38YVqiQaZFM5ANBeFch7yFxefcPm+2kwluIk7m6uB7PQne3QHXbVvZtpSSzLEDtW7iafi//xDqJrSCh24RTVFnhtF4PVhPDJsc=,iv:X4OtZ9Q99BzK8i+RHDXJsrlayYA+a/i5Zfp77HpTlp8=,tag:wQndMjjWrR4pDt1sr1WuzQ==,type:str]
+  lastmodified: "2025-07-16T13:49:57Z"
+  mac: ENC[AES256_GCM,data:+LW3ef67F5gQvGkBHzdOoywO3t9l7++K+p1Cr+bL9nuVnizX1pqpU2FrGMCmLGH1B5HKvTwTwULds816RIOYo8Pz/AFoUDFLLLT+Mg73HvC5SNmIMOpUE+6QtR2jcVeuq9jTooQcX8VB67HopsrDO4PBGZ4qCN+rjR5T6upTES4=,iv:n/yGF3+361c3ErQqTntbq4x4tx5P4E5pxvjS9/nHnag=,tag:AFMTuuycIJsLa+vH6TXiPA==,type:str]
   pgp:
   - created_at: "2024-01-24T20:21:47Z"
     enc: |-

--- a/src/ol_infrastructure/applications/edxapp/edxapp_mitx-staging_policy.hcl
+++ b/src/ol_infrastructure/applications/edxapp/edxapp_mitx-staging_policy.hcl
@@ -41,3 +41,7 @@ path "secret-operations/global/github-enterprise-ssh" {
 path "secret-mitx-staging/mitx-staging-wildcard-certificate" {
   capabilities = ["read"]
 }
+
+path "secret-global/learn_ai" {
+  capabiliities = ["read"]
+}

--- a/src/ol_infrastructure/applications/edxapp/edxapp_mitx_policy.hcl
+++ b/src/ol_infrastructure/applications/edxapp/edxapp_mitx_policy.hcl
@@ -41,3 +41,7 @@ path "secret-operations/global/github-enterprise-ssh" {
 path "secret-mitx/mitx-wildcard-certificate" {
   capabilities = ["read"]
 }
+
+path "secret-global/learn_ai" {
+  capabiliities = ["read"]
+}

--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.CI.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.CI.yaml
@@ -4,8 +4,6 @@ encryptedkey: AQICAHi3MZ/Pjy2dahB1Qm+zKkKDPV1b9MYPGp7k649HPjmOHAGzwYvKdv8btlpNoW
 config:
   aws:region: us-east-1
   learn_ai:backend_domain: "api-learn-ai-ci.ol.mit.edu"
-  learn_ai:canvas_syllabus_token:
-    secure: v1:gTO7eJWYLyP62wAE:Ha2Tt/EZ+ITP4qrxWJ+IdMvaB77L2EGxCw8tl5qDezhcXZkaslzUKHHDaKwDfLQ2YsHcm/otJyRUWxqCNRwA4wy9aRFrz3EJKzXxOmNnE1c=
   learn_ai:db_password:
     secure: v1:LPQWUf68siLqkk30:JHBZ8gREGp0fRcAWH4ER7ExID5d3LVbn8BoFZ8o7tOBj43Jf+Jqh2c9acA/im/p9+W4c15appQNpC1hMHo4+hrIks3UIhC8a8+SV6GzO908=
   learn_ai:env_vars:

--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.Production.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.Production.yaml
@@ -4,8 +4,6 @@ encryptedkey: AQICAHjmo6C0sCNz3fdkFlhbu0tdBZxnHmPYSnqtmocvGiuNygH4WWFJR+Plwkjoif
 config:
   aws:region: us-east-1
   learn_ai:backend_domain: "api-learn-ai.ol.mit.edu"
-  learn_ai:canvas_syllabus_token:
-    secure: v1:MTdC2Oe5z5huSj/b:KQ+4s7uMAeULWARnceUj9oxed0MOxKXqciAcut2oSNK6YKDcyiq4a7Okii1Rrqm2OgETG8oEo4w0K1CoR/uqlP1IA9TNzf9tl5/Cf6Mg3Ao=
   learn_ai:db_password:
     secure: v1:DIaoiP0dVXpI2w72:zcSTWgD6DInTMOdD1oH1FTdlUJCney7MLeAfL5Q5hcL9lDfW7AjVGynLDeDtpL3DQIZvFBUvcbjIHVaBYQf8Ikf8tdjWamNBv+4Ymwe2
   learn_ai:env_vars:

--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.QA.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.QA.yaml
@@ -4,8 +4,6 @@ encryptedkey: AQICAHgQW+3bag/cl2fPG3dPdqAPbfcsZuwI7rETXZsx85HRpgF0G1SpXqAgEVHrcC
 config:
   aws:region: us-east-1
   learn_ai:backend_domain: "api-learn-ai-qa.ol.mit.edu"
-  learn_ai:canvas_syllabus_token:
-    secure: v1:5AqE+hzKclLRCJI1:sPNmw08x6t+MngBcAT3TQnWmLnRnGvVaX37Xaw7fzEUTLLQ17Njgisq2Fv5AbzpfbSIQvZ9tJ28qcgQEnjD9noH+7kWQ9f/SRI+r5zsFZcw=
   learn_ai:db_password:
     secure: v1:moKYAbHsHOnTUrEk:4OgRBNFXT0WKrz1KaKZDhQxT09dA36jN4+q/SO0IIAemTSiwGqrXbXn+r5dFlGrr24S+VGtiyNXSVKts+j/TgKS33FTo86OX2saBDrL4dFo=
   learn_ai:env_vars:

--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -1134,7 +1134,11 @@ learn_ai_https_apisix_consumer = kubernetes.apiextensions.CustomResource(
         "authParameter": {
             "keyAuth": {
                 "value": {
-                    "key": learn_ai_config.require("canvas_syllabus_token"),
+                    "key": Output.secret(
+                        read_yaml_secrets(
+                            Path(f"vault/secrets.{stack_info.env_suffix}.yaml"),
+                        )["learn_ai"]["canvas_syllabus_token"]
+                    ),
                 },
             },
         },

--- a/src/ol_infrastructure/applications/learn_ai/learn_ai_policy.hcl
+++ b/src/ol_infrastructure/applications/learn_ai/learn_ai_policy.hcl
@@ -34,3 +34,7 @@ path "sys/leases/revoke" {
     lease_id = ["postgres-learn-ai/creds/app/*"]
   }
 }
+
+path "secret-global/learn_ai" {
+  capabiliities = ["read"]
+}


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/7781#issuecomment-3073528784


### Description (What does it do?)
- Updated the Learn AI API URL for canvas xBlock AI chat
- Also, Adds a new key instead of the placeholder for the Learn AI API token so that the token is loaded from vault or other secure location
<!--- Describe your changes in detail -->

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
