### PR TITLE
mitlearn/mitxonline nginx hotfix

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/files/web.conf
+++ b/src/ol_infrastructure/applications/mit_learn/files/web.conf
@@ -40,7 +40,7 @@ server {
 
     location / {
         include uwsgi_params;
-        uwsgi_pass localhost:8073;  # DEFAULT_UWSGI_PORT
+        uwsgi_pass 127.0.0.1:8073;  # DEFAULT_UWSGI_PORT
         uwsgi_pass_request_headers on;
         uwsgi_pass_request_body on;
         client_max_body_size 25M;

--- a/src/ol_infrastructure/applications/mitxonline/files/web.conf
+++ b/src/ol_infrastructure/applications/mitxonline/files/web.conf
@@ -28,7 +28,7 @@ server {
 
     location / {
         include uwsgi_params;
-        uwsgi_pass localhost:8073;  # DEFAULT_UWSGI_PORT
+        uwsgi_pass 127.0.0.1:8073;  # DEFAULT_UWSGI_PORT
         uwsgi_pass_request_headers on;
         uwsgi_pass_request_body on;
         uwsgi_ignore_client_abort on;


### PR DESCRIPTION
### What are the relevant tickets?
cc @rhysyngsun 

### Description (What does it do?)
Hotfix for mitxonline and mitlearn to not attempt connections on ipv6
