### PR TITLE
peering needed for mitxonline edxapp testing 

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/network/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/network/__main__.py
@@ -526,3 +526,8 @@ operations_to_xpro_peer = OLVPCPeeringConnection(
     operations_vpc,
     xpro_vpc,
 )
+applications_to_mitx_conline_peer = OLVPCPeeringConnection(
+    f"ol-applications-{stack_info.env_suffix}-to-mitx-online-{stack_info.env_suffix}-vpc-peer",
+    applications_vpc,
+    mitx_online_vpc,
+)


### PR DESCRIPTION

### Description (What does it do?)
Adding a peering connection between the apps vpc and the mitxonline vpc.
