### PR TITLE
chore: add rapid response xblock package publish pipeline

### DIFF
--- a/src/ol_concourse/pipelines/open_edx/open_edx_plugins/build_publish_plugins.py
+++ b/src/ol_concourse/pipelines/open_edx/open_edx_plugins/build_publish_plugins.py
@@ -37,6 +37,7 @@ plugins = [
     "ol_openedx_sentry",
     "ol_social_auth",
     "openedx_companion_auth",
+    "rapid_response_xblock",
 ]
 
 fragments = []


### PR DESCRIPTION
### What are the relevant tickets?
None, Noticed that [rapid response xblock](https://github.com/mitodl/open-edx-plugins/tree/main/src/rapid_response_xblock) pipeline was missing.
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
- Adds `rapid_response_xbock` entry in package auto publish
<!--- Describe your changes in detail -->

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
Once deployed, the rapid response should start auto publishing.
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
