### PR TITLE
chore: Remove V2 suffix from S3 resources as part of V7 update

### DIFF
--- a/src/ol_infrastructure/applications/airbyte/__main__.py
+++ b/src/ol_infrastructure/applications/airbyte/__main__.py
@@ -109,7 +109,7 @@ VERSIONS = {
 
 # S3 State Storage for Airbyte logs and system state
 airbyte_bucket_name = f"ol-airbyte-{stack_info.env_suffix}"
-s3.BucketV2(
+s3.Bucket(
     "airbyte-state-storage-bucket",
     bucket=airbyte_bucket_name,
     tags=aws_config.tags,

--- a/src/ol_infrastructure/applications/bootcamps/__main__.py
+++ b/src/ol_infrastructure/applications/bootcamps/__main__.py
@@ -51,7 +51,7 @@ aws_config = AWSBase(
 
 # Bucket used to store file uploads from bootcamps app.
 bootcamps_storage_bucket_name = f"ol-bootcamps-app-{stack_info.env_suffix}"
-bootcamps_storage_bucket = s3.BucketV2(
+bootcamps_storage_bucket = s3.Bucket(
     f"ol-bootcamps-app-{stack_info.env_suffix}",
     bucket=bootcamps_storage_bucket_name,
     tags=aws_config.tags,
@@ -63,10 +63,10 @@ bootcamps_storage_bucket_ownership_controls = s3.BucketOwnershipControls(
         object_ownership="BucketOwnerPreferred",
     ),
 )
-s3.BucketVersioningV2(
+s3.BucketVersioning(
     "ol-bootcamps-app-bucket-versioning",
     bucket=bootcamps_storage_bucket.id,
-    versioning_configuration=s3.BucketVersioningV2VersioningConfigurationArgs(
+    versioning_configuration=s3.BucketVersioningVersioningConfigurationArgs(
         status="Enabled"
     ),
 )

--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -190,7 +190,7 @@ mongodb_cluster_uri = mongodb_atlas_stack.require_output("atlas_cluster")[
 ##############
 
 edxapp_mfe_bucket_name = f"{env_name}-edxapp-mfe"
-edxapp_mfe_bucket = s3.BucketV2(
+edxapp_mfe_bucket = s3.Bucket(
     "edxapp-mfe-s3-bucket",
     bucket=edxapp_mfe_bucket_name,
     tags=aws_config.tags,
@@ -202,10 +202,10 @@ edxapp_mfe_bucket_ownership_controls = s3.BucketOwnershipControls(
         object_ownership="BucketOwnerPreferred",
     ),
 )
-s3.BucketVersioningV2(
+s3.BucketVersioning(
     "edxapp-mfe-bucket-versioning",
     bucket=edxapp_mfe_bucket.id,
-    versioning_configuration=s3.BucketVersioningV2VersioningConfigurationArgs(
+    versioning_configuration=s3.BucketVersioningVersioningConfigurationArgs(
         status="Suspended"
     ),
 )
@@ -238,7 +238,7 @@ s3.BucketPolicy(
         ]
     ),
 )
-s3.BucketCorsConfigurationV2(
+s3.BucketCorsConfiguration(
     "edxapp-mfe-bucket-cors-rules",
     bucket=edxapp_mfe_bucket.id,
     cors_rules=[{"allowedMethods": ["GET", "HEAD"], "allowedOrigins": ["*"]}],
@@ -246,7 +246,7 @@ s3.BucketCorsConfigurationV2(
 
 
 storage_bucket_name = f"{env_name}-edxapp-storage"
-edxapp_storage_bucket = s3.BucketV2(
+edxapp_storage_bucket = s3.Bucket(
     "edxapp-storage-s3-bucket",
     bucket=storage_bucket_name,
     tags=aws_config.tags,
@@ -258,10 +258,10 @@ edxapp_storage_bucket_ownership_controls = s3.BucketOwnershipControls(
         object_ownership="BucketOwnerPreferred",
     ),
 )
-s3.BucketVersioningV2(
+s3.BucketVersioning(
     "edxapp-storage-bucket-versioning",
     bucket=edxapp_storage_bucket.id,
-    versioning_configuration=s3.BucketVersioningV2VersioningConfigurationArgs(
+    versioning_configuration=s3.BucketVersioningVersioningConfigurationArgs(
         status="Enabled"
     ),
 )
@@ -296,11 +296,11 @@ s3.BucketPolicy(
         ]
     ),
 )
-s3.BucketCorsConfigurationV2(
+s3.BucketCorsConfiguration(
     "edxapp-storage-bucket-cors-rules",
     bucket=edxapp_mfe_bucket.id,
     cors_rules=[
-        s3.BucketCorsConfigurationV2CorsRuleArgs(
+        s3.BucketCorsConfigurationCorsRuleArgs(
             allowed_headers=["*"],
             allowed_methods=[
                 "GET",
@@ -315,36 +315,36 @@ s3.BucketCorsConfigurationV2(
 )
 
 course_bucket_name = f"{env_name}-edxapp-courses"
-edxapp_course_bucket = s3.BucketV2(
+edxapp_course_bucket = s3.Bucket(
     "edxapp-courses-s3-bucket",
     bucket=course_bucket_name,
     tags=aws_config.tags,
 )
-s3.BucketVersioningV2(
+s3.BucketVersioning(
     "edxapp-course-bucket-versioning",
     bucket=edxapp_course_bucket.id,
-    versioning_configuration=s3.BucketVersioningV2VersioningConfigurationArgs(
+    versioning_configuration=s3.BucketVersioningVersioningConfigurationArgs(
         status="Suspended"
     ),
 )
 
 grades_bucket_name = f"{env_name}-edxapp-grades"
-edxapp_grades_bucket = s3.BucketV2(
+edxapp_grades_bucket = s3.Bucket(
     "edxapp-grades-s3-bucket",
     bucket=grades_bucket_name,
     tags=aws_config.tags,
 )
-s3.BucketVersioningV2(
+s3.BucketVersioning(
     "edxapp-grades-bucket-versioning",
     bucket=edxapp_grades_bucket.id,
-    versioning_configuration=s3.BucketVersioningV2VersioningConfigurationArgs(
+    versioning_configuration=s3.BucketVersioningVersioningConfigurationArgs(
         status="Enabled"
     ),
 )
 
 
 tracking_bucket_name = f"{env_name}-edxapp-tracking"
-edxapp_tracking_bucket = s3.BucketV2(
+edxapp_tracking_bucket = s3.Bucket(
     "edxapp-tracking-logs-s3-bucket",
     bucket=tracking_bucket_name,
     tags=aws_config.tags,
@@ -361,12 +361,12 @@ edxapp_tracking_bucket_public_access = s3.BucketPublicAccessBlock(
     bucket=edxapp_tracking_bucket.id,
     block_public_policy=True,
 )
-edxapp_tracking_bucket_encryption = s3.BucketServerSideEncryptionConfigurationV2(
+edxapp_tracking_bucket_encryption = s3.BucketServerSideEncryptionConfiguration(
     "edxapp-tracking-logs-s3-bucket-encryption",
     bucket=edxapp_tracking_bucket.id,
     rules=[
-        s3.BucketServerSideEncryptionConfigurationV2RuleArgs(
-            apply_server_side_encryption_by_default=s3.BucketServerSideEncryptionConfigurationV2RuleApplyServerSideEncryptionByDefaultArgs(
+        s3.BucketServerSideEncryptionConfigurationRuleArgs(
+            apply_server_side_encryption_by_default=s3.BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs(
                 sse_algorithm="aws:kms",
                 kms_master_key_id=kms_s3_key["id"],
             ),
@@ -374,10 +374,10 @@ edxapp_tracking_bucket_encryption = s3.BucketServerSideEncryptionConfigurationV2
         ),
     ],
 )
-s3.BucketVersioningV2(
+s3.BucketVersioning(
     "edxapp-tracking-logs-bucket-versioning",
     bucket=edxapp_tracking_bucket.id,
-    versioning_configuration=s3.BucketVersioningV2VersioningConfigurationArgs(
+    versioning_configuration=s3.BucketVersioningVersioningConfigurationArgs(
         status="Enabled"
     ),
 )

--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -143,16 +143,16 @@ ol_zone_id = dns_stack.require_output("ol")["id"]
 # Frontend storage bucket
 learn_ai_app_storage_bucket_name = f"ol-mit-learn-ai-{stack_info.env_suffix}"
 
-learn_ai_app_storage_bucket = s3.BucketV2(
+learn_ai_app_storage_bucket = s3.Bucket(
     f"learn-ai-app-storage-bucket-{stack_info.env_suffix}",
     bucket=learn_ai_app_storage_bucket_name,
     tags=aws_config.tags,
 )
 
-s3.BucketVersioningV2(
+s3.BucketVersioning(
     f"learn-ai-app-storage-bucket-versioning-{stack_info.env_suffix}",
     bucket=learn_ai_app_storage_bucket.id,
-    versioning_configuration=s3.BucketVersioningV2VersioningConfigurationArgs(
+    versioning_configuration=s3.BucketVersioningVersioningConfigurationArgs(
         status="Enabled",
     ),
 )

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -140,16 +140,16 @@ cluster_stack.require_output("namespaces").apply(
 # begin legacy block - app bucket config
 #######################################################
 legacy_app_storage_bucket_name = f"ol-mitopen-app-storage-{app_env_suffix}"
-legacy_application_storage_bucket = s3.BucketV2(
+legacy_application_storage_bucket = s3.Bucket(
     f"ol_mitopen_app_storage_bucket_{stack_info.env_suffix}",
     bucket=legacy_app_storage_bucket_name,
     tags=aws_config.tags,
 )
 
-s3.BucketVersioningV2(
+s3.BucketVersioning(
     "ol-mitopen-bucket-versioning",
     bucket=legacy_application_storage_bucket.id,
-    versioning_configuration=s3.BucketVersioningV2VersioningConfigurationArgs(
+    versioning_configuration=s3.BucketVersioningVersioningConfigurationArgs(
         status="Enabled"
     ),
 )
@@ -197,16 +197,16 @@ s3.BucketPolicy(
 #######################################################
 
 mitlearn_app_storage_bucket_name = f"ol-mitlearn-app-storage-{app_env_suffix}"
-mitlearn_application_storage_bucket = s3.BucketV2(
+mitlearn_application_storage_bucket = s3.Bucket(
     f"ol_mitlearn_app_storage_bucket_{stack_info.env_suffix}",
     bucket=mitlearn_app_storage_bucket_name,
     tags=aws_config.tags,
 )
 
-s3.BucketVersioningV2(
+s3.BucketVersioning(
     "ol-mitlearn-bucket-versioning",
     bucket=mitlearn_application_storage_bucket.id,
-    versioning_configuration=s3.BucketVersioningV2VersioningConfigurationArgs(
+    versioning_configuration=s3.BucketVersioningVersioningConfigurationArgs(
         status="Enabled"
     ),
 )

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -106,7 +106,7 @@ cluster_stack.require_output("namespaces").apply(
 
 # Bucket used to store files from MITx Online app.
 mitxonline_bucket_name = f"ol-mitxonline-app-{stack_info.env_suffix}"
-mitxonline_bucket = s3.BucketV2(
+mitxonline_bucket = s3.Bucket(
     f"mitxonline-{stack_info.env_suffix}",
     bucket=mitxonline_bucket_name,
     tags=aws_config.tags,
@@ -118,10 +118,10 @@ mitxonline_bucket_ownership_controls = s3.BucketOwnershipControls(
         object_ownership="BucketOwnerPreferred",
     ),
 )
-mitxonline_bucket_versioning = s3.BucketVersioningV2(
+mitxonline_bucket_versioning = s3.BucketVersioning(
     f"mitxonline-{stack_info.env_suffix}-versioning",
     bucket=mitxonline_bucket.id,
-    versioning_configuration=s3.BucketVersioningV2VersioningConfigurationArgs(
+    versioning_configuration=s3.BucketVersioningVersioningConfigurationArgs(
         status="Enabled",
     ),
 )

--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -87,7 +87,7 @@ test_offline_bucket_name = f"ocw-content-offline-test-{stack_info.env_suffix}"
 test_offline_bucket_arn = f"arn:aws:s3:::{test_offline_bucket_name}"
 
 # Draft bucket
-draft_bucket = s3.BucketV2(
+draft_bucket = s3.Bucket(
     draft_bucket_name,
     bucket=draft_bucket_name,
     tags=aws_config.tags,
@@ -99,19 +99,19 @@ draft_bucket_ownership_controls = s3.BucketOwnershipControls(
         object_ownership="BucketOwnerPreferred",
     ),
 )
-s3.BucketVersioningV2(
+s3.BucketVersioning(
     "ol-draft-bucket-versioning",
     bucket=draft_bucket.id,
-    versioning_configuration=s3.BucketVersioningV2VersioningConfigurationArgs(
+    versioning_configuration=s3.BucketVersioningVersioningConfigurationArgs(
         status="Enabled"
     ),
 )
 
-draft_bucket_cors = s3.BucketCorsConfigurationV2(
+draft_bucket_cors = s3.BucketCorsConfiguration(
     "ol-draft-bucket-cors",
     bucket=draft_bucket_name,
     cors_rules=[
-        s3.BucketCorsConfigurationV2CorsRuleArgs(
+        s3.BucketCorsConfigurationCorsRuleArgs(
             allowed_methods=["GET", "HEAD"],
             allowed_origins=["*"],
         )
@@ -152,16 +152,16 @@ s3.BucketPolicy(
 )
 
 # test bucket
-test_bucket = s3.BucketV2(
+test_bucket = s3.Bucket(
     test_bucket_name,
     bucket=test_bucket_name,
     tags=aws_config.tags,
 )
-test_bucket_cors = s3.BucketCorsConfigurationV2(
+test_bucket_cors = s3.BucketCorsConfiguration(
     "ol-test-bucket-cors",
     bucket=test_bucket_name,
     cors_rules=[
-        s3.BucketCorsConfigurationV2CorsRuleArgs(
+        s3.BucketCorsConfigurationCorsRuleArgs(
             allowed_methods=["GET", "HEAD"],
             allowed_origins=["*"],
         )
@@ -174,10 +174,10 @@ test_bucket_ownership_controls = s3.BucketOwnershipControls(
         object_ownership="BucketOwnerPreferred",
     ),
 )
-s3.BucketVersioningV2(
+s3.BucketVersioning(
     "ol-test-bucket-versioning",
     bucket=test_bucket.id,
-    versioning_configuration=s3.BucketVersioningV2VersioningConfigurationArgs(
+    versioning_configuration=s3.BucketVersioningVersioningConfigurationArgs(
         status="Enabled"
     ),
 )
@@ -215,16 +215,16 @@ s3.BucketPolicy(
 )
 
 # live bucket
-live_bucket = s3.BucketV2(
+live_bucket = s3.Bucket(
     live_bucket_name,
     bucket=live_bucket_name,
     tags=aws_config.tags,
 )
-live_bucket_cors = s3.BucketCorsConfigurationV2(
+live_bucket_cors = s3.BucketCorsConfiguration(
     "ol-live-bucket-cors",
     bucket=live_bucket_name,
     cors_rules=[
-        s3.BucketCorsConfigurationV2CorsRuleArgs(
+        s3.BucketCorsConfigurationCorsRuleArgs(
             allowed_methods=["GET", "HEAD"],
             allowed_origins=["*"],
         )
@@ -237,10 +237,10 @@ live_bucket_ownership_controls = s3.BucketOwnershipControls(
         object_ownership="BucketOwnerPreferred",
     ),
 )
-s3.BucketVersioningV2(
+s3.BucketVersioning(
     "ol-live-bucket-versioning",
     bucket=live_bucket.id,
-    versioning_configuration=s3.BucketVersioningV2VersioningConfigurationArgs(
+    versioning_configuration=s3.BucketVersioningVersioningConfigurationArgs(
         status="Enabled"
     ),
 )
@@ -278,16 +278,16 @@ s3.BucketPolicy(
 )
 
 # draft_backup bucket
-draft_backup_bucket = s3.BucketV2(
+draft_backup_bucket = s3.Bucket(
     draft_backup_bucket_name,
     bucket=draft_backup_bucket_name,
     tags=aws_config.tags,
 )
-draft_backup_bucket_cors = s3.BucketCorsConfigurationV2(
+draft_backup_bucket_cors = s3.BucketCorsConfiguration(
     "ol-draft-backup-bucket-cors",
     bucket=draft_backup_bucket_name,
     cors_rules=[
-        s3.BucketCorsConfigurationV2CorsRuleArgs(
+        s3.BucketCorsConfigurationCorsRuleArgs(
             allowed_methods=["GET", "HEAD"],
             allowed_origins=["*"],
         )
@@ -300,10 +300,10 @@ draft_backup_bucket_ownership_controls = s3.BucketOwnershipControls(
         object_ownership="BucketOwnerPreferred",
     ),
 )
-s3.BucketVersioningV2(
+s3.BucketVersioning(
     "ol-draft-backup-bucket-versioning",
     bucket=draft_backup_bucket.id,
-    versioning_configuration=s3.BucketVersioningV2VersioningConfigurationArgs(
+    versioning_configuration=s3.BucketVersioningVersioningConfigurationArgs(
         status="Enabled"
     ),
 )
@@ -341,16 +341,16 @@ s3.BucketPolicy(
 )
 
 # live_backup bucket
-live_backup_bucket = s3.BucketV2(
+live_backup_bucket = s3.Bucket(
     live_backup_bucket_name,
     bucket=live_backup_bucket_name,
     tags=aws_config.tags,
 )
-live_backup_bucket_cors = s3.BucketCorsConfigurationV2(
+live_backup_bucket_cors = s3.BucketCorsConfiguration(
     "ol-live-backup-bucket-cors",
     bucket=live_backup_bucket_name,
     cors_rules=[
-        s3.BucketCorsConfigurationV2CorsRuleArgs(
+        s3.BucketCorsConfigurationCorsRuleArgs(
             allowed_methods=["GET", "HEAD"],
             allowed_origins=["*"],
         )
@@ -363,10 +363,10 @@ live_backup_bucket_ownership_controls = s3.BucketOwnershipControls(
         object_ownership="BucketOwnerPreferred",
     ),
 )
-s3.BucketVersioningV2(
+s3.BucketVersioning(
     "ol-live-backup-bucket-versioning",
     bucket=live_backup_bucket.id,
-    versioning_configuration=s3.BucketVersioningV2VersioningConfigurationArgs(
+    versioning_configuration=s3.BucketVersioningVersioningConfigurationArgs(
         status="Enabled"
     ),
 )
@@ -404,28 +404,28 @@ s3.BucketPolicy(
 )
 
 # draft_backup bucket
-draft_offline_bucket = s3.BucketV2(
+draft_offline_bucket = s3.Bucket(
     draft_offline_bucket_name,
     bucket=draft_offline_bucket_name,
     tags=aws_config.tags,
 )
-draft_offline_bucket_cors = s3.BucketCorsConfigurationV2(
+draft_offline_bucket_cors = s3.BucketCorsConfiguration(
     "ol-draft-offline-bucket-cors",
     bucket=draft_offline_bucket_name,
     cors_rules=[
-        s3.BucketCorsConfigurationV2CorsRuleArgs(
+        s3.BucketCorsConfigurationCorsRuleArgs(
             allowed_methods=["GET", "HEAD"],
             allowed_origins=["*"],
         )
     ],
 )
-draft_offline_bucket_website = s3.BucketWebsiteConfigurationV2(
+draft_offline_bucket_website = s3.BucketWebsiteConfiguration(
     "draft-offline-website",
     bucket=draft_offline_bucket_name,
-    index_document=s3.BucketWebsiteConfigurationV2IndexDocumentArgs(
+    index_document=s3.BucketWebsiteConfigurationIndexDocumentArgs(
         suffix="index.html",
     ),
-    error_document=s3.BucketWebsiteConfigurationV2ErrorDocumentArgs(
+    error_document=s3.BucketWebsiteConfigurationErrorDocumentArgs(
         key="error.html",
     ),
 )
@@ -437,10 +437,10 @@ draft_offline_bucket_ownership_controls = s3.BucketOwnershipControls(
         object_ownership="BucketOwnerPreferred",
     ),
 )
-s3.BucketVersioningV2(
+s3.BucketVersioning(
     "ol-offline-backup-bucket-versioning",
     bucket=draft_offline_bucket.id,
-    versioning_configuration=s3.BucketVersioningV2VersioningConfigurationArgs(
+    versioning_configuration=s3.BucketVersioningVersioningConfigurationArgs(
         status="Enabled"
     ),
 )
@@ -478,27 +478,27 @@ s3.BucketPolicy(
 )
 
 # live_backup bucket
-live_offline_bucket = s3.BucketV2(
+live_offline_bucket = s3.Bucket(
     live_offline_bucket_name,
     bucket=live_offline_bucket_name,
     tags=aws_config.tags,
 )
-live_offline_bucket_website = s3.BucketWebsiteConfigurationV2(
+live_offline_bucket_website = s3.BucketWebsiteConfiguration(
     "live-offline-website",
     bucket=live_offline_bucket_name,
-    index_document=s3.BucketWebsiteConfigurationV2IndexDocumentArgs(
+    index_document=s3.BucketWebsiteConfigurationIndexDocumentArgs(
         suffix="index.html",
     ),
-    error_document=s3.BucketWebsiteConfigurationV2ErrorDocumentArgs(
+    error_document=s3.BucketWebsiteConfigurationErrorDocumentArgs(
         key="error.html",
     ),
 )
 
-live_offline_bucket_cors = s3.BucketCorsConfigurationV2(
+live_offline_bucket_cors = s3.BucketCorsConfiguration(
     "ol-live-offline-bucket-cors",
     bucket=live_offline_bucket_name,
     cors_rules=[
-        s3.BucketCorsConfigurationV2CorsRuleArgs(
+        s3.BucketCorsConfigurationCorsRuleArgs(
             allowed_methods=["GET", "HEAD"],
             allowed_origins=["*"],
         )
@@ -511,10 +511,10 @@ live_offline_bucket_ownership_controls = s3.BucketOwnershipControls(
         object_ownership="BucketOwnerPreferred",
     ),
 )
-s3.BucketVersioningV2(
+s3.BucketVersioning(
     "ol-live-offline-bucket-versioning",
     bucket=live_offline_bucket.id,
-    versioning_configuration=s3.BucketVersioningV2VersioningConfigurationArgs(
+    versioning_configuration=s3.BucketVersioningVersioningConfigurationArgs(
         status="Enabled"
     ),
 )
@@ -552,16 +552,16 @@ s3.BucketPolicy(
 )
 
 # test_backup bucket
-test_offline_bucket = s3.BucketV2(
+test_offline_bucket = s3.Bucket(
     test_offline_bucket_name,
     bucket=test_offline_bucket_name,
     tags=aws_config.tags,
 )
-test_offline_bucket_cors = s3.BucketCorsConfigurationV2(
+test_offline_bucket_cors = s3.BucketCorsConfiguration(
     "ol-test-offline-bucket-cors",
     bucket=test_offline_bucket_name,
     cors_rules=[
-        s3.BucketCorsConfigurationV2CorsRuleArgs(
+        s3.BucketCorsConfigurationCorsRuleArgs(
             allowed_methods=["GET", "HEAD"],
             allowed_origins=["*"],
         )
@@ -574,10 +574,10 @@ test_offline_bucket_ownership_controls = s3.BucketOwnershipControls(
         object_ownership="BucketOwnerPreferred",
     ),
 )
-s3.BucketVersioningV2(
+s3.BucketVersioning(
     "ol-test-offline-bucket-versioning",
     bucket=test_offline_bucket.id,
-    versioning_configuration=s3.BucketVersioningV2VersioningConfigurationArgs(
+    versioning_configuration=s3.BucketVersioningVersioningConfigurationArgs(
         status="Enabled"
     ),
 )

--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -73,7 +73,7 @@ ocw_studio_legacy_markdown_bucket = s3.Bucket(
 
 # Bucket used to store file uploads from ocw-studio app.
 ocw_storage_bucket_name = f"ol-ocw-studio-app-{stack_info.env_suffix}"
-ocw_storage_bucket = s3.BucketV2(
+ocw_storage_bucket = s3.Bucket(
     f"ol-ocw-studio-app-{stack_info.env_suffix}",
     bucket=ocw_storage_bucket_name,
     tags=aws_config.tags,
@@ -85,10 +85,10 @@ ocw_storage_bucket_ownership_controls = s3.BucketOwnershipControls(
         object_ownership="BucketOwnerPreferred",
     ),
 )
-s3.BucketVersioningV2(
+s3.BucketVersioning(
     "ol-ocw-studio-app-bucket-versioning",
     bucket=ocw_storage_bucket.id,
-    versioning_configuration=s3.BucketVersioningV2VersioningConfigurationArgs(
+    versioning_configuration=s3.BucketVersioningVersioningConfigurationArgs(
         status="Enabled"
     ),
 )

--- a/src/ol_infrastructure/applications/unified_ecommerce/__main__.py
+++ b/src/ol_infrastructure/applications/unified_ecommerce/__main__.py
@@ -128,16 +128,16 @@ ol_zone_id = dns_stack.require_output("ol")["id"]
 unified_ecommerce_app_storage_bucket_name = (
     f"ol-mit-unified-ecommerce-{stack_info.env_suffix}"
 )
-unified_ecommerce_app_storage_bucket = s3.BucketV2(
+unified_ecommerce_app_storage_bucket = s3.Bucket(
     f"unified-ecommerce-app-storage-{stack_info.env_suffix}",
     bucket=unified_ecommerce_app_storage_bucket_name,
     tags=aws_config.tags,
 )
 
-s3.BucketVersioningV2(
+s3.BucketVersioning(
     f"unified-ecommerce-app-storage-versioning-{stack_info.env_suffix}",
     bucket=unified_ecommerce_app_storage_bucket.id,
-    versioning_configuration=s3.BucketVersioningV2VersioningConfigurationArgs(
+    versioning_configuration=s3.BucketVersioningVersioningConfigurationArgs(
         status="Enabled",
     ),
 )

--- a/src/ol_infrastructure/applications/xpro/__main__.py
+++ b/src/ol_infrastructure/applications/xpro/__main__.py
@@ -52,7 +52,7 @@ aws_config = AWSBase(
 
 # Bucket used to store file uploads from xpro app.
 xpro_storage_bucket_name = f"ol-xpro-app-{stack_info.env_suffix}"
-xpro_storage_bucket = s3.BucketV2(
+xpro_storage_bucket = s3.Bucket(
     f"ol-xpro-app-{stack_info.env_suffix}",
     bucket=xpro_storage_bucket_name,
     tags=aws_config.tags,
@@ -64,10 +64,10 @@ xpro_storage_bucket_ownership_controls = s3.BucketOwnershipControls(
         object_ownership="BucketOwnerPreferred",
     ),
 )
-s3.BucketVersioningV2(
+s3.BucketVersioning(
     "ol-xpro-app-bucket-versioning",
     bucket=xpro_storage_bucket.id,
-    versioning_configuration=s3.BucketVersioningV2VersioningConfigurationArgs(
+    versioning_configuration=s3.BucketVersioningVersioningConfigurationArgs(
         status="Enabled"
     ),
 )

--- a/src/ol_infrastructure/components/aws/s3_cloudfront_site.py
+++ b/src/ol_infrastructure/components/aws/s3_cloudfront_site.py
@@ -60,7 +60,7 @@ class S3ServerlessSite(ComponentResource):
         site_bucket_name = f"{site_config.site_name}-bucket"
         site_bucket_arn = f"arn:aws:s3:::{site_bucket_name}"
 
-        self.site_bucket = s3.BucketV2(
+        self.site_bucket = s3.Bucket(
             f"{site_config.site_name}-bucket",
             bucket=site_config.bucket_name,
             tags=site_config.tags,
@@ -114,33 +114,33 @@ class S3ServerlessSite(ComponentResource):
             ),
         )
 
-        s3.BucketWebsiteConfigurationV2(
+        s3.BucketWebsiteConfiguration(
             f"{site_bucket_name}-website",
             bucket=self.site_bucket.id,
-            index_document=s3.BucketWebsiteConfigurationV2IndexDocumentArgs(
+            index_document=s3.BucketWebsiteConfigurationIndexDocumentArgs(
                 suffix=site_config.site_index,
             ),
-            error_document=s3.BucketWebsiteConfigurationV2ErrorDocumentArgs(
+            error_document=s3.BucketWebsiteConfigurationErrorDocumentArgs(
                 key="error.html",
             ),
             opts=generic_resource_opts,
         )
 
-        _ = s3.BucketCorsConfigurationV2(
+        _ = s3.BucketCorsConfiguration(
             f"{site_bucket_name}-cors",
             bucket=self.site_bucket.id,
             cors_rules=[
-                s3.BucketCorsConfigurationV2CorsRuleArgs(
+                s3.BucketCorsConfigurationCorsRuleArgs(
                     allowed_methods=["GET", "HEAD"],
                     allowed_origins=["*"],
                 )
             ],
             opts=generic_resource_opts,
         )
-        s3.BucketVersioningV2(
+        s3.BucketVersioning(
             f"{site_bucket_name}-versioning",
             bucket=self.site_bucket.id,
-            versioning_configuration=s3.BucketVersioningV2VersioningConfigurationArgs(
+            versioning_configuration=s3.BucketVersioningVersioningConfigurationArgs(
                 status="Enabled"
             ),
             opts=generic_resource_opts,

--- a/src/ol_infrastructure/components/aws/sftp.py
+++ b/src/ol_infrastructure/components/aws/sftp.py
@@ -58,7 +58,7 @@ class SFTPServer(ComponentResource):
         generic_resource_opts = ResourceOptions(parent=self).merge(opts)
 
         # Create S3 bucket for SFTP backend
-        self.bucket = s3.BucketV2(
+        self.bucket = s3.Bucket(
             f"{sftp_config.server_name}-sftp-bucket",
             bucket=sftp_config.bucket_name,
             tags=sftp_config.tags,
@@ -66,10 +66,10 @@ class SFTPServer(ComponentResource):
         )
 
         # Enable versioning on the bucket
-        s3.BucketVersioningV2(
+        s3.BucketVersioning(
             f"{sftp_config.server_name}-sftp-bucket-versioning",
             bucket=self.bucket.id,
-            versioning_configuration=s3.BucketVersioningV2VersioningConfigurationArgs(
+            versioning_configuration=s3.BucketVersioningVersioningConfigurationArgs(
                 status="Enabled"
             ),
             opts=generic_resource_opts,

--- a/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
@@ -77,7 +77,7 @@ athena_warehouse_workgroup = athena.Workgroup(
 )
 
 warehouse_buckets = []
-data_landing_zone_bucket = s3.BucketV2(
+data_landing_zone_bucket = s3.Bucket(
     "ol_data_lake_landing_zone_bucket",
     bucket=f"ol-data-lake-landing-zone-{stack_info.env_suffix}",
 )
@@ -88,13 +88,13 @@ data_landing_zone_bucket_ownership_controls = s3.BucketOwnershipControls(
         object_ownership="BucketOwnerPreferred",
     ),
 )
-s3.BucketServerSideEncryptionConfigurationV2(
+s3.BucketServerSideEncryptionConfiguration(
     "encrypt_ol_data_lake_landing_zone_bucket",
     bucket=data_landing_zone_bucket.id,
     rules=[
-        s3.BucketServerSideEncryptionConfigurationV2RuleArgs(
+        s3.BucketServerSideEncryptionConfigurationRuleArgs(
             bucket_key_enabled=True,
-            apply_server_side_encryption_by_default=s3.BucketServerSideEncryptionConfigurationV2RuleApplyServerSideEncryptionByDefaultArgs(
+            apply_server_side_encryption_by_default=s3.BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs(
                 sse_algorithm="aws:kms"
             ),
         )


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
The AWS V7 plugin for Pulumi removed the need to use the V2 suffic fr S3 API V2 resources. This removes those suffixes based on
https://www.pulumi.com/registry/packages/aws/how-to-guides/7-0-migration/

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run a `pulumi up --refresh --run-program` against the affected stacks and verify that there are no material changes.
