### PR TITLE
fix: add complete OAUTH2_PROVIDER settings to avoid override in mitxonline edX

### DIFF
--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -474,6 +474,25 @@ NOTIFICATIONS_DEFAULT_FROM_EMAIL: {{ key "edxapp/bulk-email-default-from-email" 
 NOTIFICATION_TYPE_ICONS: {} # ADDED
 DEFAULT_NOTIFICATION_ICON_URL: '' # ADDED
 OAUTH2_PROVIDER:
+  OAUTH2_VALIDATOR_CLASS: "openedx.core.djangoapps.oauth_dispatch.dot_overrides.validators.EdxOAuth2Validator"
+  REFRESH_TOKEN_EXPIRE_SECONDS: 7776000
+  SCOPES_BACKEND_CLASS: "openedx.core.djangoapps.oauth_dispatch.scopes.ApplicationModelScopes"
+  SCOPES:
+    read: "Read access"
+    write: "Write access"
+    email: "Know your email address"
+    profile: "Know your name and username"
+    certificates:read: "Retrieve your course certificates"
+    grades:read: "Retrieve your grades for your enrolled courses"
+    tpa:read: "Retrieve your third-party authentication username mapping"
+    user_id: "Know your user identifier"
+  DEFAULT_SCOPES:
+    read: "Read access"
+    write: "Write access"
+    email: "Know your email address"
+    profile: "Know your name and username"
+  REQUEST_APPROVAL_PROMPT: "auto_even_if_expired"
+  ERROR_RESPONSE_WITH_SCOPES: true
   ALLOWED_REDIRECT_URI_SCHEMES:
     - "https"
     - "edu.mit.learn.app"


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7897

### Description (What does it do?)
This PR adds the complete `OAUTH2_PROVIDER` dictionary to fix the OAuth invalid scope issue. The issue arose following the deployment of https://github.com/mitodl/ol-infrastructure/commit/0b459fb85962b53b3af4ff07a3f3a0da96c2a089, which completely overrides the `OAUTH2_PROVIDER` setting.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
