### PR TITLE
add some mongodb host string outputs 

### DIFF
--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/__main__.py
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/__main__.py
@@ -364,7 +364,9 @@ pulumi.export(
     "atlas_cluster",
     {
         "id": atlas_cluster.cluster_id,
+        # Retain 'host_string' for compatibility with existing stacks that reference it
         "host_string": privatized_mongo_uri.apply(lambda uri: urlparse(uri).netloc),
+        # Same as legacy 'host_string'
         "private_host_string": privatized_mongo_uri.apply(
             lambda uri: urlparse(uri).netloc
         ),

--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/__main__.py
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/__main__.py
@@ -365,6 +365,12 @@ pulumi.export(
     {
         "id": atlas_cluster.cluster_id,
         "host_string": privatized_mongo_uri.apply(lambda uri: urlparse(uri).netloc),
+        "private_host_string": privatized_mongo_uri.apply(
+            lambda uri: urlparse(uri).netloc
+        ),
+        "public_host_string": atlas_cluster.mongo_uri.apply(
+            lambda uri: urlparse(uri).netloc
+        ),
         "mongo_uri": atlas_cluster.mongo_uri,
         "mongo_uri_with_options": atlas_cluster.mongo_uri_with_options,
         "connection_strings": atlas_cluster.connection_strings,


### PR DESCRIPTION


### What are the relevant tickets?
Supports https://github.com/mitodl/ol-infrastructure/issues/3310

### Description (What does it do?)
Added public and private host strings to the output of mongodb atlas stacks.
