### PR TITLE
Allow NAT gateway public IPs to access mongodb instances over the internet 

### DIFF
--- a/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitxonline.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/mongodb_atlas/Pulumi.infrastructure.mongodb_atlas.mitxonline.CI.yaml
@@ -7,6 +7,7 @@ config:
   consul:scheme: https
   environment:business_unit: mitxonline
   environment:target_vpc: mitxonline_vpc
+  environment:target_k8s_vpc: applications_vpc
   mongodb_atlas:disk_autoscale_max_gb: "100"
   mongodb_atlas:enable_cloud_backup: "false"
   mongodb_atlas:enable_point_in_time_recovery: "false"


### PR DESCRIPTION
### What are the relevant tickets?
Supports #3310 

### Description (What does it do?)
Network stacks now include these outputs:
```
              + k8s_nat_gateway_ids       : [
              +     [0]: "nat-04e6c0627e831964e"
                ]
              + k8s_nat_gateway_public_ips: [
              +     [0]: "13.216.56.8"
                ]
```

In monogo atlas stacks we will take these IP addresses and allow them to access the mongodb cluster from over the internet. 
