### PR TITLE
config: update proctoring info panel instruction link in mitxonline

### DIFF
--- a/src/bridge/settings/openedx/mfe/slot_config/mitxonline/common-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/mitxonline/common-mfe-config.env.jsx
@@ -172,6 +172,10 @@ const footerSlotConfig = {
 let config = {
   ...process.env,
   pluginSlots: footerSubSlotsConfig,
+  // Override the proctoring info panel 'Review instructions and system requirements' link
+  externalLinkUrlOverrides : {
+    "https://support.edx.org/hc/en-us/sections/115004169247-Taking-Timed-and-Proctored-Exams": "https://mitxonline.zendesk.com/hc/en-us/articles/4418223178651-What-is-the-Proctortrack-Onboarding-Exam",
+  },
 };
 
 // Additional plugin config based on MFE
@@ -219,14 +223,6 @@ if (learningApps.includes(edxMfeAppName)) {
       },
     ],
   };
-}
-
-// Override the proctoring info panel 'Review instructions and system requirements' link
-config = {
-  ...config,
-  externalLinkUrlOverrides : {
-    "https://support.edx.org/hc/en-us/sections/115004169247-Taking-Timed-and-Proctored-Exams": "https://mitxonline.zendesk.com/hc/en-us/articles/4418223178651-What-is-the-Proctortrack-Onboarding-Exam",
-  },
 }
 
 export default config;


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7658

### Description (What does it do?)
This PR overrides the default Procotoring info panel instruction link in MITxOnline. More details in this comment: https://github.com/mitodl/hq/issues/7658#issuecomment-3151197233

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- Verify that the updated config works fine with all MFEs
- Verify that the proctoring info panel instruction link in learning MFE is updated to https://mitxonline.zendesk.com/hc/en-us/articles/4418223178651-What-is-the-Proctortrack-Onboarding-Exam
    - To test this, you would need to show the proctoring panel on the course page. An easy way to do this is by updating the [showInfoPanel](https://github.com/openedx/frontend-app-learning/blob/master/src/course-home/outline-tab/widgets/ProctoringInfoPanel.jsx#L178) to true directly.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
