### PR TITLE
EKS configuration tweaks 

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.applications.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.applications.Production.yaml
@@ -21,6 +21,8 @@ config:
   - "api-learn-ai.ol.mit.edu"
   - "api.learn.mit.edu"
   - "api.mitxonline.mit.edu"
+  eks:apisix_min_replicas: "5"
+  eks:apisix_max_replicas: "10"
   eks:developer_role_policy_name: "AmazonEKSClusterAdminPolicy"
   eks:developer_role_kubernetes_groups: ["admin"]
   eks:developer_role_scope: "cluster"
@@ -51,5 +53,7 @@ config:
       tags: {}
       taints: {}
       version:
+  eks:traefik_min_replicas: 5
+  eks:treafik_max_replicas: 10
   environment:business_unit: operations
   environment:target_vpc: applications_vpc

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.applications.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.applications.Production.yaml
@@ -54,6 +54,6 @@ config:
       taints: {}
       version:
   eks:traefik_min_replicas: 5
-  eks:treafik_max_replicas: 10
+  eks:traefik_max_replicas: 10
   environment:business_unit: operations
   environment:target_vpc: applications_vpc

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.data.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.data.Production.yaml
@@ -12,6 +12,8 @@ config:
   eks:apisix_domains:
   - "airbyte.ol.mit.edu"
   eks:apisix_ingress_enabled: "true"
+  eks:apisix_min_replicas: "5"
+  eks:apisix_max_replicas: "10"
   eks:apisix_viewer_key:
     secure: v1:j5+aTOfRBG8QiV+V:C6NTWitDBjV4DkOQGApae7GHK9w1wOFAlS7ACNu/s728A5q1zDWv9E13E2hs0IlAtMnP17KJR0HZjxDlg5fckv2nguEVgNA/d90j1XWlFY8=
   eks:ebs_csi_provisioner: "true"
@@ -35,5 +37,7 @@ config:
       tags: {}
       taints: {}
       version:
+  eks:traefik_min_replicas: 5
+  eks:traefik_max_replicas: 10
   environment:business_unit: data
   environment:target_vpc: data_vpc

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.operations.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.operations.Production.yaml
@@ -9,6 +9,8 @@ config:
   - "odl.mit.edu"
   - ".ol.mit.edu"
   - "ol.mit.edu"
+  eks:apisix_min_replicas: "5"
+  eks:apisix_max_replicas: "10"
   eks:ebs_csi_provisioner: true
   eks:efs_csi_provisioner: true
   eks:gateway_release_channel: "experimental"
@@ -30,3 +32,5 @@ config:
       tags: {}
       taints: {}
       node_group_options: {}
+  eks:traefik_min_replicas: 5
+  eks:traefik_max_replicas: 10

--- a/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
@@ -1013,8 +1013,8 @@ traefik_helm_release = kubernetes.helm.v3.Release(
             },
             "autoscaling": {
                 "enabled": True,
-                "minReplicas": 2,
-                "maxReplicas": 5,
+                "minReplicas": eks_config.get("traefik_min_replicas") or 2,
+                "maxReplicas": eks_config.get("traefik_max_replicas") or 5,
                 "metrics": [
                     {
                         "resource": {
@@ -1208,8 +1208,8 @@ if eks_config.get_bool("apisix_ingress_enabled"):
                     "autoscaling": {
                         "hpa": {
                             "enabled": True,
-                            "minReplicas": "2",
-                            "maxReplicas": "5",
+                            "minReplicas": eks_config.get("apisix_min_replicas") or "2",
+                            "maxReplicas": eks_config.get("apisix_max_replicas") or "5",
                             "targetCPU": "50",
                         },
                     },

--- a/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
@@ -1002,8 +1002,6 @@ traefik_helm_release = kubernetes.helm.v3.Release(
             },
             "commonLabels": k8s_global_labels,
             "tolerations": operations_tolerations,
-            # Debug the traefik by turning off "DaemonSet"
-            # and setting "replcias": 1
             "deployment": {
                 "kind": "Deployment",
                 "podLabels": {


### PR DESCRIPTION
### Description (What does it do?)
config: tweaks to EKS configs for stability and resource usage

- Changes APISIX from a daemonset to a deployment
  - Sets up a HPA for APISIX with 2/5 min max based on cpu usage (50% triggers scaling)
- Changes traefik from a daemonset to a deployment
  - Sets up a HPA for traefik with 2/5 min max based on cpu usage (50% triggers scaling)
- Gives APISIX ingress controller pods a bit more memory limits. 
- Gives APISIX etcd pods more time to startup / replay their WAL.
- Gives APISIX etcd pods a bit more memory limits. 