### PR TITLE
revert: 'fix: changed the dashboard url for UAI courses to point to mitxonline dashboard'

### DIFF
--- a/src/bridge/settings/openedx/mfe/slot_config/mitxonline/common-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/mitxonline/common-mfe-config.env.jsx
@@ -27,7 +27,7 @@ const logo = <Logo imageUrl={configData.LOGO_URL} destinationUrl={configData.MAR
 
 let userMenu = [
   {
-    url: `${configData.MARKETING_SITE_BASE_URL}/dashboard`,
+    url: `${process.env.MIT_LEARN_BASE_URL}/dashboard`,
     title: linkTitles.dashboard,
   },
   {


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8010

### Description (What does it do?)
This PR reverts the changes in https://github.com/mitodl/ol-infrastructure/pull/3330 to point the dashboard link to mit learn dashboard

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- Visit a UAI course.
- Click the profile dropdown.
- Verify that the dashboard link redirects you to {MIT_LEARN_BASE_URL}/dashboard and not {MARKETING_SITE_BASE_URL}/dashboard.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
