### PR TITLE
feat: Add AWS LB Controller to clusters

### DIFF
--- a/src/bridge/lib/versions.py
+++ b/src/bridge/lib/versions.py
@@ -21,6 +21,8 @@ VAULT_VERSION = "1.20.1"
 AIRBYTE_CHART_VERSION = "1.7.2"
 # renovate: datasource=docker depName=apisix packageName=registry-1.docker.io/bitnamicharts/apisix
 APISIX_CHART_VERSION = "5.1.0"
+# renovate: datasource=helm depName=aws-load-balancer-controller packageName=eks/aws-load-balancer-controller registryUrl=https://aws.github.io/eks-charts
+AWS_LOAD_BALANCER_CONTROLLER_CHART_VERSION = "1.13.4"
 # renovate: datasource=helm depName=botkube packageName=botkube
 BOTKUBE_CHART_VERSION = "v1.14.0"
 # renovate: datasource=helm depName=cert-manager packageName=cert-manager

--- a/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
@@ -1925,22 +1925,6 @@ aws_load_balancer_controller_policy_document = {
     ],
 }
 
-aws_load_balancer_controller_parliament_config = {
-    "UNKNOWN_FEDERATION_SOURCE": {"ignore_locations": [{"principal": "federated"}]},
-    "PERMISSIONS_MANAGEMENT_ACTIONS": {"ignore_locations": []},
-    "MALFORMED": {"ignore_locations": []},
-    "RESOURCE_STAR": {"ignore_locations": []},
-    "CREDENTIALS_EXPOSURE": {
-        "ignore_locations": [{"action": "cognito-idp:describeuserpoolclient"}]
-    },
-    "RESOURCE_MISMATCH": {
-        "ignore_locations": [
-            {"action": "elasticloadbalancing:AddTags"},
-            {"action": "elasticloadbalancing:RemoveTags"},
-        ]
-    },
-}
-
 aws_lb_controller_service_account_name = "aws-load-balancer-controller"
 
 aws_load_balancer_controller_role_config = OLEKSTrustRoleConfig(

--- a/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
@@ -1928,7 +1928,7 @@ aws_load_balancer_controller_policy_document = {
 aws_load_balancer_controller_parliament_config = {
     "UNKNOWN_FEDERATION_SOURCE": {"ignore_locations": [{"principal": "federated"}]},
     "PERMISSIONS_MANAGEMENT_ACTIONS": {"ignore_locations": []},
-    "MALFORMED": {"ignore_lcoations": []},
+    "MALFORMED": {"ignore_locations": []},
     "RESOURCE_STAR": {"ignore_locations": []},
     "CREDENTIALS_EXPOSURE": {
         "ignore_locations": [{"action": "cognito-idp:describeuserpoolclient"}]

--- a/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
@@ -2006,9 +2006,7 @@ aws_load_balancer_controller_release = kubernetes.helm.v3.Release(
                 "create": False,
                 "name": aws_lb_controller_service_account_name,
                 "annotations": {
-                    "eks.amazonaws.com/role-arn": aws_load_balancer_controller_role.role.arn.apply(
-                        lambda arn: f"{arn}"
-                    ),
+                    "eks.amazonaws.com/role-arn": aws_load_balancer_controller_role.role.arn,
                 },
             },
             "vpcId": target_vpc["id"],


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
For more nuanced usage of NLBs we want to use the AWS LB controller instead of just the built-in cloud controller in Kubernetes. This installs the LB controller and updates the annotations for the APISix and Traefik gateways to use it.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
This has been manually deployed and verified in applications CI
