### PR TITLE
feat: Add helper for adding new B2B orgs with SAML IDP

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/olapps.py
+++ b/src/ol_infrastructure/substructure/keycloak/olapps.py
@@ -638,57 +638,49 @@ def create_olapps_realm(  # noqa: PLR0913, PLR0915
         hide_on_login_page=True,
     )
 
-    (
-        keycloak.AttributeImporterIdentityProviderMapper(
-            "map-touchstone-saml-email-attribute",
-            realm=ol_apps_realm.id,
-            attribute_friendly_name="mail",
-            identity_provider_alias=ol_apps_touchstone_saml_identity_provider.alias,
-            user_attribute="email",
-            extra_config={
-                "syncMode": "INHERIT",
-            },
-            opts=resource_options,
-        ),
+    keycloak.AttributeImporterIdentityProviderMapper(
+        "map-touchstone-saml-email-attribute",
+        realm=ol_apps_realm.id,
+        attribute_friendly_name="mail",
+        identity_provider_alias=ol_apps_touchstone_saml_identity_provider.alias,
+        user_attribute="email",
+        extra_config={
+            "syncMode": "INHERIT",
+        },
+        opts=resource_options,
     )
-    (
-        keycloak.AttributeImporterIdentityProviderMapper(
-            "map-touchstone-saml-last-name-attribute",
-            realm=ol_apps_realm.id,
-            attribute_friendly_name="sn",
-            identity_provider_alias=ol_apps_touchstone_saml_identity_provider.alias,
-            user_attribute="lastName",
-            extra_config={
-                "syncMode": "INHERIT",
-            },
-            opts=resource_options,
-        ),
+    keycloak.AttributeImporterIdentityProviderMapper(
+        "map-touchstone-saml-last-name-attribute",
+        realm=ol_apps_realm.id,
+        attribute_friendly_name="sn",
+        identity_provider_alias=ol_apps_touchstone_saml_identity_provider.alias,
+        user_attribute="lastName",
+        extra_config={
+            "syncMode": "INHERIT",
+        },
+        opts=resource_options,
     )
-    (
-        keycloak.AttributeImporterIdentityProviderMapper(
-            "map-touchstone-saml-first-name-attribute",
-            realm=ol_apps_realm.id,
-            attribute_friendly_name="givenName",
-            identity_provider_alias=ol_apps_touchstone_saml_identity_provider.alias,
-            user_attribute="firstName",
-            extra_config={
-                "syncMode": "INHERIT",
-            },
-            opts=resource_options,
-        ),
+    keycloak.AttributeImporterIdentityProviderMapper(
+        "map-touchstone-saml-first-name-attribute",
+        realm=ol_apps_realm.id,
+        attribute_friendly_name="givenName",
+        identity_provider_alias=ol_apps_touchstone_saml_identity_provider.alias,
+        user_attribute="firstName",
+        extra_config={
+            "syncMode": "INHERIT",
+        },
+        opts=resource_options,
     )
-    (
-        keycloak.AttributeImporterIdentityProviderMapper(
-            "map-touchstone-saml-full-name-attribute",
-            realm=ol_apps_realm.id,
-            attribute_friendly_name="displayName",
-            identity_provider_alias=ol_apps_touchstone_saml_identity_provider.alias,
-            user_attribute="fullName",
-            extra_config={
-                "syncMode": "INHERIT",
-            },
-            opts=resource_options,
-        ),
+    keycloak.AttributeImporterIdentityProviderMapper(
+        "map-touchstone-saml-full-name-attribute",
+        realm=ol_apps_realm.id,
+        attribute_friendly_name="displayName",
+        identity_provider_alias=ol_apps_touchstone_saml_identity_provider.alias,
+        user_attribute="fullName",
+        extra_config={
+            "syncMode": "INHERIT",
+        },
+        opts=resource_options,
     )
     keycloak.HardcodedAttributeIdentityProviderMapper(
         "map-touchstone-email-opt-in-attribute",

--- a/src/ol_infrastructure/substructure/keycloak/olapps.py
+++ b/src/ol_infrastructure/substructure/keycloak/olapps.py
@@ -13,6 +13,8 @@ from ol_infrastructure.substructure.keycloak.org_flows import (
     create_organization_scope,
 )
 from ol_infrastructure.substructure.keycloak.org_sso_helpers import (
+    OrgConfig,
+    SamlIdpConfig,
     create_org_for_learn,
     onboard_saml_org,
 )
@@ -702,34 +704,42 @@ def create_olapps_realm(  # noqa: PLR0913, PLR0915
     # B2B Organizations [BEGIN]
     if stack_info.env_suffix == "production":
         onboard_saml_org(
-            org_domains=["hhchealth.org"],
-            org_name="Hartford Health Care",
-            org_alias="HHC",
-            org_saml_metadata_url="https://adfs.hhchealth.org/federationmetadata/2007-06/federationmetadata.xml",
-            keycloak_url=keycloak_url,
-            learn_domain=mitlearn_domain,
-            realm_id=ol_apps_realm.id,
-            first_login_flow=ol_first_login_flow,
-            resource_options=resource_options,
+            SamlIdpConfig(
+                org_domains=["hhchealth.org"],
+                org_name="Hartford Health Care",
+                org_alias="HHC",
+                org_saml_metadata_url="https://adfs.hhchealth.org/federationmetadata/2007-06/federationmetadata.xml",
+                keycloak_url=keycloak_url,
+                learn_domain=mitlearn_domain,
+                realm_id=ol_apps_realm.id,
+                first_login_flow=ol_first_login_flow,
+                resource_options=resource_options,
+                principal_type="ATTRIBUTE",
+                principal_attribute="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+            )
         )
         onboard_saml_org(
-            org_domains=["ntua.gr"],
-            org_name="National Technical University of Athens",
-            org_alias="NTUA",
-            org_saml_metadata_url="https://login.ntua.gr/idp/shibboleth",
-            keycloak_url=keycloak_url,
-            learn_domain=mitlearn_domain,
-            realm_id=ol_apps_realm.id,
-            first_login_flow=ol_first_login_flow,
-            resource_options=resource_options,
+            SamlIdpConfig(
+                org_domains=["ntua.gr"],
+                org_name="National Technical University of Athens",
+                org_alias="NTUA",
+                org_saml_metadata_url="https://login.ntua.gr/idp/shibboleth",
+                keycloak_url=keycloak_url,
+                learn_domain=mitlearn_domain,
+                realm_id=ol_apps_realm.id,
+                first_login_flow=ol_first_login_flow,
+                resource_options=resource_options,
+            )
         )
         create_org_for_learn(
-            org_domains=["ttt-example.edu"],
-            org_name="Train the Trainer",
-            org_alias="TTT",
-            learn_domain=mitlearn_domain,
-            realm_id=ol_apps_realm.id,
-            resource_options=resource_options,
+            OrgConfig(
+                org_domains=["ttt-example.edu"],
+                org_name="Train the Trainer",
+                org_alias="TTT",
+                learn_domain=mitlearn_domain,
+                realm_id=ol_apps_realm.id,
+                resource_options=resource_options,
+            )
         )
     # B2B Organizations [END]
 

--- a/src/ol_infrastructure/substructure/keycloak/olapps.py
+++ b/src/ol_infrastructure/substructure/keycloak/olapps.py
@@ -12,7 +12,10 @@ from ol_infrastructure.substructure.keycloak.org_flows import (
     create_organization_first_broker_login_flows,
     create_organization_scope,
 )
-from ol_infrastructure.substructure.keycloak.org_sso_helpers import onboard_saml_org
+from ol_infrastructure.substructure.keycloak.org_sso_helpers import (
+    create_org_for_learn,
+    onboard_saml_org,
+)
 
 
 def create_olapps_realm(  # noqa: PLR0913, PLR0915
@@ -699,7 +702,7 @@ def create_olapps_realm(  # noqa: PLR0913, PLR0915
     # B2B Organizations [BEGIN]
     if stack_info.env_suffix == "production":
         onboard_saml_org(
-            org_domain="hhchealth.org",
+            org_domains=["hhchealth.org"],
             org_name="Hartford Health Care",
             org_alias="HHC",
             org_saml_metadata_url="https://adfs.hhchealth.org/federationmetadata/2007-06/federationmetadata.xml",
@@ -710,7 +713,7 @@ def create_olapps_realm(  # noqa: PLR0913, PLR0915
             resource_options=resource_options,
         )
         onboard_saml_org(
-            org_domain="ntua.gr",
+            org_domains=["ntua.gr"],
             org_name="National Technical University of Athens",
             org_alias="NTUA",
             org_saml_metadata_url="https://login.ntua.gr/idp/shibboleth",
@@ -718,6 +721,14 @@ def create_olapps_realm(  # noqa: PLR0913, PLR0915
             learn_domain=mitlearn_domain,
             realm_id=ol_apps_realm.id,
             first_login_flow=ol_first_login_flow,
+            resource_options=resource_options,
+        )
+        create_org_for_learn(
+            org_domains=["ttt-example.edu"],
+            org_name="Train the Trainer",
+            org_alias="TTT",
+            learn_domain=mitlearn_domain,
+            realm_id=ol_apps_realm.id,
             resource_options=resource_options,
         )
     # B2B Organizations [END]

--- a/src/ol_infrastructure/substructure/keycloak/org_sso_helpers.py
+++ b/src/ol_infrastructure/substructure/keycloak/org_sso_helpers.py
@@ -26,7 +26,7 @@ def onboard_saml_org(  # noqa: PLR0913
         opts=resource_options,
     )
 
-    keycloak.saml.IdentityProvider(
+    org_idp = keycloak.saml.IdentityProvider(
         f"ol-apps-{org_alias}-saml-idp",
         alias=f"{org_alias}",
         display_name=org_name,
@@ -44,4 +44,60 @@ def onboard_saml_org(  # noqa: PLR0913
         trust_email=True,
         validate_signature=True,
         opts=resource_options,
+    )
+    keycloak.AttributeImporterIdentityProviderMapper(
+        f"map-{org_alias}-saml-email-attribute",
+        realm=realm_id,
+        attribute_friendly_name="mail",
+        identity_provider_alias=org_idp.alias,
+        user_attribute="email",
+        extra_config={
+            "syncMode": "INHERIT",
+        },
+        opts=resource_options,
+    )
+    keycloak.AttributeImporterIdentityProviderMapper(
+        f"map-{org_alias}-saml-last-name-attribute",
+        realm=realm_id,
+        attribute_friendly_name="sn",
+        identity_provider_alias=org_idp.alias,
+        user_attribute="lastName",
+        extra_config={
+            "syncMode": "INHERIT",
+        },
+        opts=resource_options,
+    )
+    keycloak.AttributeImporterIdentityProviderMapper(
+        f"map-{org_alias}-saml-first-name-attribute",
+        realm=realm_id,
+        attribute_friendly_name="givenName",
+        identity_provider_alias=org_idp.alias,
+        user_attribute="firstName",
+        extra_config={
+            "syncMode": "INHERIT",
+        },
+        opts=resource_options,
+    )
+    keycloak.AttributeImporterIdentityProviderMapper(
+        f"map-{org_alias}-saml-full-name-attribute",
+        realm=realm_id,
+        attribute_friendly_name="displayName",
+        identity_provider_alias=org_idp.alias,
+        user_attribute="fullName",
+        extra_config={
+            "syncMode": "INHERIT",
+        },
+        opts=resource_options,
+    )
+    keycloak.HardcodedAttributeIdentityProviderMapper(
+        f"map-{org_alias}-email-opt-in-attribute",
+        name="email-opt-in-default",
+        realm=realm_id,
+        identity_provider_alias=org_idp.alias,
+        attribute_name="emailOptIn",
+        attribute_value="1",
+        user_session=False,
+        extra_config={
+            "syncMode": "INHERIT",
+        },
     )

--- a/src/ol_infrastructure/substructure/keycloak/org_sso_helpers.py
+++ b/src/ol_infrastructure/substructure/keycloak/org_sso_helpers.py
@@ -115,6 +115,7 @@ def onboard_saml_org(
             realm=saml_config.realm_id,
             identity_provider_alias=org_idp.alias,
             **args,
+            opts=saml_config.resource_options,
         )
     if not mappers:
         for attr, friendly_names in SAML_FRIENDLY_NAMES.items():

--- a/src/ol_infrastructure/substructure/keycloak/org_sso_helpers.py
+++ b/src/ol_infrastructure/substructure/keycloak/org_sso_helpers.py
@@ -20,9 +20,10 @@ def onboard_saml_org(  # noqa: PLR0913
         ],
         enabled=True,
         name=org_name,
-        alias=org_alias,
-        redirect_url=f"https://{learn_domain}/dashboard/organization/{org_alias}",
+        alias=org_alias.lower(),
+        redirect_url=f"https://{learn_domain}/dashboard/organization/{org_alias.lower()}",
         realm=realm_id,
+        attributes={"slug": org_alias},
         opts=resource_options,
     )
 

--- a/src/ol_infrastructure/substructure/keycloak/org_sso_helpers.py
+++ b/src/ol_infrastructure/substructure/keycloak/org_sso_helpers.py
@@ -1,0 +1,47 @@
+import pulumi
+import pulumi_keycloak as keycloak
+
+
+def onboard_saml_org(  # noqa: PLR0913
+    org_domain: str,
+    org_name: str,
+    org_alias: str,
+    org_saml_metadata_url: str,
+    keycloak_url: str,
+    learn_domain: str,
+    realm_id: str | pulumi.Output[str],
+    first_login_flow: pulumi.Output[keycloak.authentication.Flow],
+    resource_options: pulumi.ResourceOptions,
+):
+    org = keycloak.organization.Organization(
+        f"ol-apps-{org_alias}-organization",
+        domains=[
+            keycloak.organization.OrganizationDomainArgs(name=org_domain, verified=True)
+        ],
+        enabled=True,
+        name=org_name,
+        alias=org_alias,
+        redirect_url=f"https://{learn_domain}/dashboard/organization/{org_alias}",
+        realm=realm_id,
+        opts=resource_options,
+    )
+
+    keycloak.saml.IdentityProvider(
+        f"ol-apps-{org_alias}-saml-idp",
+        alias=f"{org_alias}",
+        display_name=org_name,
+        entity_id=f"{keycloak_url}/realms/olapps",
+        first_broker_login_flow_alias=first_login_flow.alias,
+        hide_on_login_page=True,
+        org_domain=org_domain,
+        org_redirect_mode_email_matches=True,
+        organization_id=org.id,
+        post_binding_authn_request=True,
+        post_binding_response=True,
+        realm=realm_id,
+        single_sign_on_service_url=org_saml_metadata_url,
+        sync_mode="FORCE",
+        trust_email=True,
+        validate_signature=True,
+        opts=resource_options,
+    )

--- a/src/ol_infrastructure/substructure/keycloak/org_sso_helpers.py
+++ b/src/ol_infrastructure/substructure/keycloak/org_sso_helpers.py
@@ -67,7 +67,7 @@ def create_org_for_learn(org_config: OrgConfig) -> keycloak.organization.Organiz
 
 def onboard_saml_org(
     saml_config: SamlIdpConfig,
-):
+) -> None:
     org = create_org_for_learn(saml_config)
 
     saml_args = generate_pulumi_args_dict(

--- a/src/ol_infrastructure/substructure/keycloak/org_sso_helpers.py
+++ b/src/ol_infrastructure/substructure/keycloak/org_sso_helpers.py
@@ -19,12 +19,18 @@ class NameIdFormat(str, Enum):
     persistent = "Persistent"
 
 
+class AttributeFormat(str, Enum):
+    basic = "ATTRIBUTE_FORMAT_BASIC"
+    uri = "ATTRIBUTE_FORMAT_URI"
+
+
 class OrgConfig(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
     org_domains: list[str]
     org_name: str
     org_alias: str
     learn_domain: str
+    attribute_format: AttributeFormat = AttributeFormat.basic
     realm_id: str | pulumi.Output[str]
     resource_options: pulumi.ResourceOptions
 
@@ -36,6 +42,7 @@ class SamlIdpConfig(OrgConfig):
     name_id_format: NameIdFormat = NameIdFormat.unspecified
     principal_type: Literal["SUBJECT", "ATTRIBUTE"] = "SUBJECT"
     principal_attribute: str | None = None
+    mapper_attribute_format: AttributeFormat = AttributeFormat.basic
 
     @model_validator(mode="after")
     def ensure_principal_types(self):
@@ -120,6 +127,7 @@ def onboard_saml_org(
                     user_attribute=attr,
                     extra_config={
                         "syncMode": "INHERIT",
+                        "attribute.name.format": saml_config.mapper_attribute_format,
                     },
                     opts=saml_config.resource_options,
                 )

--- a/src/ol_infrastructure/substructure/keycloak/saml_helpers.py
+++ b/src/ol_infrastructure/substructure/keycloak/saml_helpers.py
@@ -236,19 +236,7 @@ def get_saml_attribute_mappers(  # noqa: C901
             for candidate in saml_attribute_candidates:
                 if (
                     root.find(
-                        f".//saml:AttributeStatement/saml:Attribute[@Name='{candidate}']",
-                        namespaces,
-                    )
-                    is not None
-                    or root.find(
-                        ".//md:AttributeConsumingService/md:RequestedAttribute"
-                        f"[@Name='{candidate}']",
-                        namespaces,
-                    )
-                    is not None
-                    or root.find(
-                        ".//md:AttributeConsumingService/md:RequestedAttribute"
-                        f"[@FriendlyName='{candidate}']",
+                        f".//md:IDPSSODescriptor/saml:Attribute='{candidate}']",
                         namespaces,
                     )
                     is not None

--- a/src/ol_infrastructure/substructure/keycloak/saml_helpers.py
+++ b/src/ol_infrastructure/substructure/keycloak/saml_helpers.py
@@ -1,0 +1,278 @@
+import xml.etree.ElementTree as ET
+from collections.abc import Collection
+from urllib.request import urlopen
+
+SAML_FRIENDLY_NAMES = {
+    "firstName": [
+        "Given Name",
+        "GivenName",
+        "First Name",
+        "first_name",
+        "firstName",  # Sometimes used as FriendlyName
+    ],
+    "lastName": [
+        "Surname",
+        "sn",  # Often the attribute Name, but sometimes FriendlyName
+        "Last Name",
+        "last_name",
+        "lastName",  # Sometimes used as FriendlyName
+    ],
+    "email": [
+        "E-Mail Address",
+        "mail",  # Often the attribute Name, but sometimes FriendlyName
+        "Email",
+        "emailaddress",
+        "Email Address",
+        "user.email",  # {Link: According to Lucid Community
+        # https://community.lucid.co/admin-questions-2/azure-saml-sso-and-first-last-names-in-attributes-claims-not-working-7600}
+    ],
+    "fullName": [
+        "Name",  # Often used in ADFS for the display name or full name
+        "Display Name",
+        "displayName",
+        "cn",  # Common Name (often includes full name)
+        "Common Name or Full Name",
+        "FullName",  # {Link: According to Autodesk
+        # https://help.autodesk.com/view/SSOGUIDE/ENU/?guid=SSOGUIDE_Okta_Guide_About_Single_Sign_on_SSO_Frequently_Asked_Questions_FAQ_What_are_attribute_names_html}
+    ],
+    "username": [
+        "Name ID",
+        "Name Identifier",
+        "User Principal Name",  # ADFS/Azure AD
+        "UserPrincipalName",
+        "NameID",  # Often attribute name, but sometimes friendly name
+        "sAMAccountName",
+        "username",
+        "uid",
+    ],
+}
+
+
+def extract_saml_metadata(metadata_url: str) -> dict[str, str | None]:
+    """
+    Extract relevant information from a SAML IdP metadata XML file.
+
+    Args:
+        metadata_file (str): Path to the SAML IdP metadata XML file.
+
+    Returns:
+        dict: A dictionary containing the extracted metadata attributes,
+              or None if parsing fails.
+    """
+    try:
+        with urlopen(metadata_url) as metadata_file:  # noqa: S310
+            tree = ET.parse(metadata_file)  # noqa: S314
+            root = tree.getroot()
+
+            # Define namespaces
+            namespaces = {
+                "md": "urn:oasis:names:tc:SAML:2.0:metadata",
+                "ds": "http://www.w3.org/2000/09/xmldsig#",
+            }
+
+            # Extract Entity ID
+            entity_id = root.get("entityID")
+
+            # Extract Single Sign-On Service URL
+            sso_service = root.find(".//md:SingleSignOnService", namespaces)
+            sso_url = sso_service.get("Location") if sso_service is not None else None
+
+            # Extract Single Logout Service URL (optional)
+            slo_service = root.find(".//md:SingleLogoutService", namespaces)
+            slo_url = slo_service.get("Location") if slo_service is not None else None
+
+            # Extract X.509 Certificate (signing certificate)
+            x509_cert_element = root.find(
+                ".//md:KeyDescriptor[@use='signing']//ds:X509Certificate", namespaces
+            )
+            x509_certificate = (
+                x509_cert_element.text if x509_cert_element is not None else None
+            )
+
+            return {
+                "entity_id": entity_id,
+                "single_sign_on_service_url": sso_url,
+                "single_logout_service_url": slo_url,
+                "x509_certificate": x509_certificate.strip()
+                if x509_certificate
+                else None,
+            }
+
+    except ET.ParseError:
+        return {}
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+def generate_pulumi_args_dict(metadata: dict[str, str]) -> dict[str, str]:
+    """Generate a dictionary of arguments for the Pulumi IdentityProvider resource.
+
+    Args:
+        metadata (dict): Dictionary containing extracted IdP metadata.
+
+    Returns: dict: A dictionary of arguments suitable for Pulumi, or None if metadata is
+        missing.
+
+    """
+    if not metadata:
+        return {}
+
+    args_dict = {
+        "single_sign_on_service_url": metadata["single_sign_on_service_url"],
+    }
+
+    if metadata["single_logout_service_url"]:
+        args_dict["single_logout_service_url"] = metadata["single_logout_service_url"]
+
+    if metadata["x509_certificate"]:
+        args_dict["signing_certificate"] = metadata["x509_certificate"]
+
+    return args_dict
+
+
+def get_saml_attribute_mappers(  # noqa: C901, PLR0912
+    metadata_url: str, idp_alias: str
+) -> dict[str, dict[str, Collection[str]]]:
+    """Parse SAML metadata to find attributes that can be used for attribute mappers.
+
+    It first attempts to find attributes by their "FriendlyName" and falls back to a
+    list of candidate attribute names.
+
+    Args:
+        metadata_url: The URL to the SAML IdP metadata XML.
+        idp_alias: The alias for the Keycloak identity provider.
+
+    Returns:
+        A dictionary of attribute mapper configurations suitable for Pulumi.
+
+    """
+    try:
+        with urlopen(metadata_url) as metadata_file:  # noqa: S310
+            tree = ET.parse(metadata_file)  # noqa: S314
+            root = tree.getroot()
+            namespaces = {
+                "md": "urn:oasis:names:tc:SAML:2.0:metadata",
+                "saml": "urn:oasis:names:tc:SAML:2.0:assertion",
+            }
+    except ET.ParseError:
+        return {}
+    except Exception:  # noqa: BLE001
+        return {}
+
+    attribute_mapping_candidates = {
+        "email": [
+            "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
+            "urn:oid:0.9.2342.19200300.100.1.3",
+            "email",
+            "mail",
+        ],
+        "firstName": [
+            "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
+            "urn:oid:2.5.4.42",
+            "givenName",
+            "firstName",
+        ],
+        "lastName": [
+            "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname",
+            "urn:oid:2.5.4.4",
+            "lastName",
+            "sn",
+            "surname",
+        ],
+        "fullName": [
+            # ADFS "Name" claim for display name
+            "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name",
+            "displayName",  # Common FriendlyName
+        ],
+        "username": [
+            "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name",
+            "urn:oasis:names:tc:SAML:attribute-def:uid",
+            "sAMAccountName",
+            "NameID",
+            "username",
+        ],
+    }
+
+    common_friendly_names = SAML_FRIENDLY_NAMES
+    mappers = {}
+
+    for (
+        keycloak_user_attribute,
+        saml_attribute_candidates,
+    ) in attribute_mapping_candidates.items():
+        found_attribute_name = None
+
+        # Check for matching Friendly Name first
+        if keycloak_user_attribute in common_friendly_names:
+            friendly_name_candidates = common_friendly_names[keycloak_user_attribute]
+            for candidate in friendly_name_candidates:
+                # Look for any attribute tag with a matching FriendlyName
+                attribute_element = root.find(
+                    f".//*[@FriendlyName='{candidate}']", namespaces
+                )
+                if attribute_element is not None:
+                    found_attribute_name = attribute_element.get("Name")
+                    if (
+                        not found_attribute_name
+                    ):  # Sometimes only FriendlyName is present
+                        found_attribute_name = candidate
+                    break  # Found a match, stop searching friendly names
+
+            if found_attribute_name:
+                mapper_args = {
+                    "name": f"{idp_alias}-{keycloak_user_attribute}-mapper",
+                    "attribute_name": found_attribute_name,
+                    "user_attribute": keycloak_user_attribute,
+                    "extra_config": {
+                        "syncMode": "INHERIT",
+                        "attribute.name.format": "ATTRIBUTE_FORMAT_URI",
+                    },
+                }
+                mappers[found_attribute_name] = mapper_args
+
+        # If not found, try by attribute name from candidates
+        if not found_attribute_name:
+            for candidate in saml_attribute_candidates:
+                if (
+                    root.find(
+                        f".//saml:AttributeStatement/saml:Attribute[@Name='{candidate}']",
+                        namespaces,
+                    )
+                    is not None
+                ):
+                    found_attribute_name = candidate
+                    break
+                if (
+                    root.find(
+                        ".//md:AttributeConsumingService/md:RequestedAttribute"
+                        f"[@Name='{candidate}']",
+                        namespaces,
+                    )
+                    is not None
+                ):
+                    found_attribute_name = candidate
+                    break
+                if (
+                    root.find(
+                        ".//md:AttributeConsumingService/md:RequestedAttribute"
+                        f"[@FriendlyName='{candidate}']",
+                        namespaces,
+                    )
+                    is not None
+                ):
+                    found_attribute_name = candidate
+                    break
+
+            if found_attribute_name:
+                mapper_args = {
+                    "name": f"{idp_alias}-{keycloak_user_attribute}-mapper",
+                    "attribute_name": found_attribute_name,
+                    "user_attribute": keycloak_user_attribute,
+                    "extra_config": {
+                        "syncMode": "INHERIT",
+                        "attribute.name.format": "ATTRIBUTE_FORMAT_URI",
+                    },
+                }
+                mappers[found_attribute_name] = mapper_args
+
+    return mappers

--- a/src/ol_infrastructure/substructure/keycloak/saml_helpers.py
+++ b/src/ol_infrastructure/substructure/keycloak/saml_helpers.py
@@ -53,7 +53,7 @@ def extract_saml_metadata(metadata_url: str) -> dict[str, str | None]:
     Extract relevant information from a SAML IdP metadata XML file.
 
     Args:
-        metadata_file (str): Path to the SAML IdP metadata XML file.
+        metadata_url (str): The URL of the SAML IdP metadata XML file.
 
     Returns:
         dict: A dictionary containing the extracted metadata attributes,

--- a/src/ol_infrastructure/substructure/keycloak/saml_helpers.py
+++ b/src/ol_infrastructure/substructure/keycloak/saml_helpers.py
@@ -110,7 +110,7 @@ def extract_saml_metadata(metadata_url: str) -> dict[str, str | None]:
 
     except ET.ParseError:
         return {}
-    except Exception:  # noqa: BLE001
+    except (ET.ParseError, ValueError):
         return {}
 
 

--- a/src/ol_infrastructure/substructure/keycloak/saml_helpers.py
+++ b/src/ol_infrastructure/substructure/keycloak/saml_helpers.py
@@ -60,7 +60,6 @@ def extract_saml_metadata(metadata_url: str) -> dict[str, str | None]:
               or None if parsing fails.
     """
     try:
-        with urlopen(metadata_url) as metadata_file:  # noqa: S310
         # Validate URL scheme
         parsed_url = urlparse(metadata_url)
         if parsed_url.scheme != "https":

--- a/src/ol_infrastructure/substructure/keycloak/saml_helpers.py
+++ b/src/ol_infrastructure/substructure/keycloak/saml_helpers.py
@@ -166,7 +166,7 @@ def get_saml_attribute_mappers(  # noqa: C901, PLR0912
             }
     except ET.ParseError:
         return {}
-    except Exception:  # noqa: BLE001
+    except ET.ParseError:
         return {}
 
     attribute_mapping_candidates = {


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7805

### Description (What does it do?)
<!--- Describe your changes in detail -->
This creates a helper method for creating organization and SAML IDP configurations for B2B SSO setups. It then uses that helper to initialize the HHC and NTUA organizations.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
I am coordinating time with HHC to test out their integration.
