### PR TITLE
chore: remove cybersource access key for bootcamps to remove payment steps

### DIFF
--- a/src/ol_infrastructure/applications/bootcamps/__main__.py
+++ b/src/ol_infrastructure/applications/bootcamps/__main__.py
@@ -257,7 +257,7 @@ heroku_vars = {
 }
 
 sensitive_heroku_vars = {
-    "CYBERSOURCE_ACCESS_KEY": bootcamps_vault_secrets["cybersource"]["access_key"],
+    "CYBERSOURCE_ACCESS_KEY": "",
     "CYBERSOURCE_INQUIRY_LOG_NACL_ENCRYPTION_KEY": bootcamps_vault_secrets[
         "cybersource"
     ]["inquiry_public_encryption_key"],


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/8005


### Description (What does it do?)
<!--- Describe your changes in detail -->
We made some changes in https://github.com/mitodl/bootcamp-ecommerce/pull/1619 to hide the payment step from bootcamp applications. We need to remove the Cybersource access key so it does not get added to follow-up releases.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Remove CYBERSOURCE_ACCESS_KEY and make sure the app works as expected.