### PR TITLE
config: Add a pod disruption budget to web application deployments

### DIFF
--- a/src/ol_infrastructure/components/services/k8s.py
+++ b/src/ol_infrastructure/components/services/k8s.py
@@ -515,7 +515,7 @@ class OLApplicationK8s(ComponentResource):
             opts=deployment_options,
         )
 
-        # Pod Disruption Budget to ensure at least one web application pod is available
+        # Pod Disruption Budget to ensure at least one web application pod is available.
         _application_pdb = kubernetes.policy.v1.PodDisruptionBudget(
             f"{ol_app_k8s_config.application_name}-application-{stack_info.env_suffix}-pdb",
             metadata=kubernetes.meta.v1.ObjectMetaArgs(
@@ -524,7 +524,7 @@ class OLApplicationK8s(ComponentResource):
                 labels=application_labels,
             ),
             spec=kubernetes.policy.v1.PodDisruptionBudgetSpecArgs(
-                min_available=ol_app_k8s_config.web_pdb_minimum,  # Ensure minimum number of pods are available
+                min_available=ol_app_k8s_config.web_pdb_minimum,
                 selector=kubernetes.meta.v1.LabelSelectorArgs(
                     match_labels=application_labels,
                 ),


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Add a pod disruption budget to web application pods

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Apply the changes and try to terminate web app pods

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
In order to ensure that we don't have downtime as a result of node pressure we want to have pod disruption budget in place that prevents us from ever not having a pod ready to serve traffic.
