### PR TITLE
Add an API token requirement for Canvas Tutor

### DIFF
--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -912,6 +912,23 @@ mit_learn_learn_ai_https_apisix_route = OLApisixRoute(
             backend_service_port=learn_ai_app_k8s.application_lb_service_port_name,
             backend_resolve_granularity="service",
         ),
+        OLApisixRouteConfig(
+            route_name="canvas_tutor_agent",
+            priority=20,
+            plugins=[
+                OLApisixPluginConfig(
+                    name="key-auth",
+                    config={
+                        "header": "canvas_token",
+                    },
+                ),
+            ],
+            hosts=[learn_api_domain],
+            paths=["/ai/http/canvas_tutor_agent/*"],
+            backend_service_name=learn_ai_app_k8s.application_lb_service_name,
+            backend_service_port=learn_ai_app_k8s.application_lb_service_port_name,
+            backend_resolve_granularity="service",
+        ),
         # Wildcard route that can use auth but doesn't require it
         OLApisixRouteConfig(
             route_name="passauth",


### PR DESCRIPTION
### Description (What does it do?)
Adds an API token requirement for Canvas Tutor

### How can this be tested?
```
 curl -X POST https://api-learn-ai-qa.ol.mit.edu/http/canvas_tutor_agent/ \
    -H "Content-Type: application/json" \
    -d '{"message": "What do i do first", "run_readable_id": "14566-kaleba:20211202+canvas", "problem_set_title": "Deliverable 6 - 15.060"}'
```

should not work and should require an API token.