### PR TITLE
adding new canvas demo ids to setting

### DIFF
--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.CI.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.CI.yaml
@@ -16,7 +16,7 @@ config:
     AI_MIT_SYLLABUS_URL: "https://api.rc.learn.mit.edu/api/v0/vector_content_files_search/"
     AI_MIT_VIDEO_TRANSCRIPT_URL: "https://api.rc.learn.mit.edu/api/v0/vector_content_files_search/"
     AI_PROMPT_CACHE_FUNCTION: "ai_chatbots.utils.get_django_cache"
-    CANVAS_TUTOR_DEMO_RUN_READABLE_IDS: ["14566-kaleba:20211202+canvas"]
+    CANVAS_TUTOR_DEMO_RUN_READABLE_IDS: ["14566-kaleba:20211202+canvas", "34642-15.095_FA25+canvas"]
     CELERY_TASK_ALWAYS_EAGER: "false"
     CSRF_ALLOWED_ORIGINS: '["https://learn-ai-ci.ol.mit.edu", "https://api-learn-ai-ci.ol.mit.edu"]'
     CSRF_TRUSTED_ORIGINS: '["https://learn-ai-ci.ol.mit.edu", "https://api-learn-ai-ci.ol.mit.edu"]'

--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.Production.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.Production.yaml
@@ -14,7 +14,7 @@ config:
     AI_MIT_CONTENTFILE_URL: "https://api.learn.mit.edu/api/v1/contentfiles/"
     AI_MIT_SEARCH_URL: "https://api.learn.mit.edu/api/v0/vector_learning_resources_search/"
     AI_PROMPT_CACHE_FUNCTION: "ai_chatbots.utils.get_django_cache"
-    CANVAS_TUTOR_DEMO_RUN_READABLE_IDS: ["14566-kaleba:20211202+canvas"]
+    CANVAS_TUTOR_DEMO_RUN_READABLE_IDS: ["14566-kaleba:20211202+canvas", "34642-15.095_FA25+canvas"]
     CELERY_TASK_ALWAYS_EAGER: "false"
     CSRF_ALLOWED_ORIGINS: '["https://learn-ai.ol.mit.edu", "https://api-learn-ai.ol.mit.edu",
       "https://learn.mit.edu", "https://api.learn.mit.edu"]'

--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.QA.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.QA.yaml
@@ -19,7 +19,7 @@ config:
     AI_MIT_VIDEO_TRANSCRIPT_URL: "https://api.rc.learn.mit.edu/api/v0/vector_content_files_search/"
     AI_PROMPT_CACHE_FUNCTION: "ai_chatbots.utils.get_django_cache"
     CELERY_TASK_ALWAYS_EAGER: "false"
-    CANVAS_TUTOR_DEMO_RUN_READABLE_IDS: ["14566-kaleba:20211202+canvas"]
+    CANVAS_TUTOR_DEMO_RUN_READABLE_IDS: ["14566-kaleba:20211202+canvas", "34642-15.095_FA25+canvas"]
     CSRF_ALLOWED_ORIGINS: '["https://learn-ai-qa.ol.mit.edu", "https://api-learn-ai-qa.ol.mit.edu",
       "https://rc.learn.mit.edu", "https://api.rc.learn.mit.edu"]'
     CSRF_TRUSTED_ORIGINS: '["https://learn-ai-qa.ol.mit.edu", "https://api-learn-ai-qa.ol.mit.edu",


### PR DESCRIPTION

### Description (What does it do?)
This PR adds a new canvas course so we can test it in the sandbox

### How can this be tested?
Can be tested once deployed. currently we cannot use canvas course 34642-15.095_FA25+canvas in the sandbox
