### PR TITLE
chore: add UAI Email settings

### DIFF
--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.CI.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.CI.yaml
@@ -44,6 +44,8 @@ config:
     OPENTELEMETRY_ENDPOINT: "http://grafana-alloy.operations.svc.cluster.local:4318/v1/traces"
     SENTRY_LOG_LEVEL: "ERROR"
     SESSION_COOKIE_NAME: "session_mitxonline_ci"
+    MIT_LEARN_FROM_EMAIL: "MIT Learn <mitlearn-support@mit.edu>"
+    MIT_LEARN_DASHBOARD_URL: "https://learn.mit.edu/dashboard"
   redis:password:
     secure: v1:N1ZyKKPiMa/DaKYH:Y8NIcmgFnBBjTIUkT6PeefRnINIjVI/MMmX8IXKfxF5bLfMjRT/6dG8eYwMtHFSRMn+Kb1ZEJod3oqiSeMdeidttL4LPKK0=
   vault:address: https://vault-ci.odl.mit.edu

--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.Production.yaml
@@ -60,6 +60,8 @@ config:
     SESSION_COOKIE_NAME: "session_mitxonline"
     UWSGI_ENABLE_THREADS: "1"
     UWSGI_THREADS: "25"
+    MIT_LEARN_FROM_EMAIL: "MIT Learn <mitlearn-support@mit.edu>"
+    MIT_LEARN_DASHBOARD_URL: "https://learn.mit.edu/dashboard"
   redis:password:
     secure: v1:yvRUeBECxXQn0EuQ:CzfHq2P7kQGgULkRI7EFThTAnZyxq4uLvCTAdCYWpgvKl6Hwir6Gfk6UgU//ceOEKXrLVw6mRf34oWU=
   vault:address: https://vault-production.odl.mit.edu

--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.QA.yaml
@@ -51,6 +51,8 @@ config:
     SENTRY_PROFILES_SAMPLE_RATE: "0.25"
     SENTRY_TRACES_SAMPLE_RATE: "0.25"
     SESSION_COOKIE_NAME: "session_mitxonline_rc"
+    MIT_LEARN_FROM_EMAIL: "MIT Learn <mitlearn-support@mit.edu>"
+    MIT_LEARN_DASHBOARD_URL: "https://learn.mit.edu/dashboard"
   redis:password:
     secure: v1:rFyMZ8hojMNVgkJb:YmQuqHaePqYVtbE4nJXFupDfowZvdjH6AXsKOPJpGgWCdXFrOy9zzNDu2zCiMFkXPVRc1iobr/au9viSl7GZX4f7lw==
   vault:address: https://vault-qa.odl.mit.edu


### PR DESCRIPTION
### What are the relevant tickets?
[#7834](https://github.com/mitodl/hq/issues/7834)

### Description (What does it do?)
This PR adds the environment variables to support UAI email branding functionality in MITxOnline. The changes include adding MIT_LEARN_FROM_EMAIL and MIT_LEARN_DASHBOARD_URL environment variables to the QA, Production, and CI environment configurations.

These variables enable UAI enrollment emails to be sent from the MIT Learn email address and direct users to the appropriate MIT Learn dashboard.