### PR TITLE
feat: Add logic updates to allow blue/green updates to run to completion

### DIFF
--- a/src/ol_infrastructure/components/aws/database.py
+++ b/src/ol_infrastructure/components/aws/database.py
@@ -251,7 +251,13 @@ class OLAmazonDB(pulumi.ComponentResource):
                 )
             )
         ):
-            turn_off_deletion_protection(current_db_state.get("DBInstanceIdentifier"))
+            db_instance_identifier = current_db_state.get("DBInstanceIdentifier")
+            if db_instance_identifier is not None:
+                turn_off_deletion_protection(db_instance_identifier)
+            else:
+                pulumi.log.warn(
+                    "Could not turn off deletion protection: DBInstanceIdentifier is None."
+                )
             deletion_protection_for_primary = False
             custom_timeouts = pulumi.CustomTimeouts(
                 create=f"{db_config.blue_green_timeout_minutes}m",

--- a/src/ol_infrastructure/components/aws/database.py
+++ b/src/ol_infrastructure/components/aws/database.py
@@ -256,7 +256,7 @@ class OLAmazonDB(pulumi.ComponentResource):
                 )
             )
         ):
-            turn_off_deletion_protection(current_db_state["DBInstanceIdentifier"])
+            turn_off_deletion_protection(current_db_state.get("DBInstanceIdentifier"))
             deletion_protection_for_primary = False
             custom_timeouts = pulumi.CustomTimeouts(
                 create=f"{db_config.blue_green_timeout_minutes}m",

--- a/src/ol_infrastructure/components/aws/database.py
+++ b/src/ol_infrastructure/components/aws/database.py
@@ -256,7 +256,7 @@ class OLAmazonDB(pulumi.ComponentResource):
                 turn_off_deletion_protection(db_instance_identifier)
             else:
                 pulumi.log.warn(
-                    "Could not turn off deletion protection: DBInstanceIdentifier is None."
+                    "Could not turn off deletion protection: DBInstanceIdentifier is None."  # noqa: E501
                 )
             deletion_protection_for_primary = False
             custom_timeouts = pulumi.CustomTimeouts(

--- a/src/ol_infrastructure/components/aws/database.py
+++ b/src/ol_infrastructure/components/aws/database.py
@@ -252,12 +252,7 @@ class OLAmazonDB(pulumi.ComponentResource):
             )
         ):
             db_instance_identifier = current_db_state.get("DBInstanceIdentifier")
-            if db_instance_identifier is not None:
-                turn_off_deletion_protection(db_instance_identifier)
-            else:
-                pulumi.log.warn(
-                    "Could not turn off deletion protection: DBInstanceIdentifier is None."  # noqa: E501
-                )
+            turn_off_deletion_protection(db_instance_identifier)
             deletion_protection_for_primary = False
             custom_timeouts = pulumi.CustomTimeouts(
                 create=f"{db_config.blue_green_timeout_minutes}m",

--- a/src/ol_infrastructure/components/aws/database.py
+++ b/src/ol_infrastructure/components/aws/database.py
@@ -244,7 +244,16 @@ class OLAmazonDB(pulumi.ComponentResource):
                 db_config.engine_version != current_db_state["EngineVersion"],
                 db_config.multi_az != current_db_state["MultiAZ"],
                 db_config.storage_type != current_db_state["StorageType"],
-                db_config.instance_size != current_db_state["DBInstanceClass"],
+        if (
+            db_config.use_blue_green
+            and current_db_state
+            and any(
+                (
+                    db_config.engine_version != current_db_state.get("EngineVersion"),
+                    db_config.multi_az != current_db_state.get("MultiAZ"),
+                    db_config.storage_type != current_db_state.get("StorageType"),
+                    db_config.instance_size != current_db_state.get("DBInstanceClass"),
+                )
             )
         ):
             turn_off_deletion_protection(current_db_state["DBInstanceIdentifier"])

--- a/src/ol_infrastructure/components/aws/database.py
+++ b/src/ol_infrastructure/components/aws/database.py
@@ -239,11 +239,6 @@ class OLAmazonDB(pulumi.ComponentResource):
         # for successful completion of the blue/green update process. Currently it is
         # timing out at 1 hour, so we should likely allow for up to at least 3 hours
         # before timing out, with a configurable parameter for the maximum timeout.
-        if db_config.use_blue_green and any(
-            (
-                db_config.engine_version != current_db_state["EngineVersion"],
-                db_config.multi_az != current_db_state["MultiAZ"],
-                db_config.storage_type != current_db_state["StorageType"],
         if (
             db_config.use_blue_green
             and current_db_state

--- a/src/ol_infrastructure/lib/aws/rds_helper.py
+++ b/src/ol_infrastructure/lib/aws/rds_helper.py
@@ -106,4 +106,13 @@ def turn_off_deletion_protection(db_identifier: str):
         DBInstanceIdentifier=db_identifier,
         ApplyImmediately=True,
         DeletionProtection=False,
-    )
+    try:
+        rds_client.modify_db_instance(
+            DBInstanceIdentifier=db_identifier,
+            ApplyImmediately=True,
+            DeletionProtection=False,
+        )
+    except rds_client.exceptions.DBInstanceNotFoundFault:
+        raise ValueError(f"DB instance '{db_identifier}' not found.")
+    except rds_client.exceptions.InvalidDBInstanceStateFault:
+        raise RuntimeError(f"DB instance '{db_identifier}' is in an invalid state for modification.")

--- a/src/ol_infrastructure/lib/aws/rds_helper.py
+++ b/src/ol_infrastructure/lib/aws/rds_helper.py
@@ -102,25 +102,23 @@ def get_rds_instance(instance_name: str) -> dict[str, str]:
 
 
 def turn_off_deletion_protection(db_identifier: str):
-    """
-    Disable deletion protection for the specified RDS database instance.
+    """Disable deletion protection for the specified RDS database instance.
 
     :param db_identifier: The identifier of the RDS database instance.
     :type db_identifier: str
 
-    :raises botocore.exceptions.ClientError: If the AWS API call fails or the instance does not exist.
+    :raises botocore.exceptions.ClientError: If the AWS API call fails or the instance
+    does not exist.
     """
-    rds_client.modify_db_instance(
-        DBInstanceIdentifier=db_identifier,
-        ApplyImmediately=True,
-        DeletionProtection=False,
     try:
         rds_client.modify_db_instance(
             DBInstanceIdentifier=db_identifier,
             ApplyImmediately=True,
             DeletionProtection=False,
         )
-    except rds_client.exceptions.DBInstanceNotFoundFault:
-        raise ValueError(f"DB instance '{db_identifier}' not found.")
-    except rds_client.exceptions.InvalidDBInstanceStateFault:
-        raise RuntimeError(f"DB instance '{db_identifier}' is in an invalid state for modification.")
+    except rds_client.exceptions.DBInstanceNotFoundFault as e:
+        msg = f"DB instance '{db_identifier}' not found."
+        raise ValueError(msg) from e
+    except rds_client.exceptions.InvalidDBInstanceStateFault as e:
+        msg = f"DB instance '{db_identifier}' is in an invalid state for modification."
+        raise RuntimeError(msg) from e

--- a/src/ol_infrastructure/lib/aws/rds_helper.py
+++ b/src/ol_infrastructure/lib/aws/rds_helper.py
@@ -99,3 +99,11 @@ def get_rds_instance(instance_name: str) -> dict[str, str]:
     except rds_client.exceptions.DBInstanceNotFoundFault:
         db_instance = {}
     return db_instance
+
+
+def turn_off_deletion_protection(db_identifier: str):
+    rds_client.modify_db_instance(
+        DBInstanceIdentifier=db_identifier,
+        ApplyImmediately=True,
+        DeletionProtection=False,
+    )

--- a/src/ol_infrastructure/lib/aws/rds_helper.py
+++ b/src/ol_infrastructure/lib/aws/rds_helper.py
@@ -102,6 +102,14 @@ def get_rds_instance(instance_name: str) -> dict[str, str]:
 
 
 def turn_off_deletion_protection(db_identifier: str):
+    """
+    Disable deletion protection for the specified RDS database instance.
+
+    :param db_identifier: The identifier of the RDS database instance.
+    :type db_identifier: str
+
+    :raises botocore.exceptions.ClientError: If the AWS API call fails or the instance does not exist.
+    """
     rds_client.modify_db_instance(
         DBInstanceIdentifier=db_identifier,
         ApplyImmediately=True,


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds fixes for allowing Pulumi to manage blue/green upgrades of RDS databases successfully.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Apply the changes to a database with deletion protection enabled and a change-set that will trigger a blue/green deploy to verify that it runs to completion and cleans up after itself.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
The default timeout limit is 1 hour which isn't always long enough to complete the blue/green update. Pulumi is also supposed to clean up the blue/green deployment when it is complete, but can't do that if deletion protection is enabled.
