### PR TITLE
Build Jupyter Dockerfiles

### DIFF
--- a/src/ol_concourse/pipelines/container_images/jupyter_courses.py
+++ b/src/ol_concourse/pipelines/container_images/jupyter_courses.py
@@ -53,8 +53,8 @@ course_repository = ssh_git_repo(
     private_key="((github.ol_notebooks_private_ssh_key))",
 )
 
-#This infers the ECR url from the AWS account,
-#the region and the repository name
+# This infers the ECR url from the AWS account,
+# the region and the repository name
 course_image = Resource(
     name=Identifier("course_image"),
     type="registry-image",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Related to https://github.com/mitodl/hq/issues/8028

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds an instance variable pipeline to Concourse to build Jupyter course repos. This will be required for our hosted Jupyterhub to be able to run courses without needing to go use Google Colab.

Note that final testing needs ECR up and running as well as the new secret propagated. Once those are done it'll be put through it's paces, but I would expect this code to be a release candidate.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
Screenshot of running pipelines at https://cicd.odl.mit.edu/?search=team%3A%22infrastructure%22%20group%3A%22jupyter_notebook_docker_image_build%22
<img width="1144" height="716" alt="Screenshot 2025-08-21 at 10 03 05 AM" src="https://github.com/user-attachments/assets/b901231b-3207-4788-aa18-df8023558e41" />



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
At the moment testing is somewhat of a pain. Locally you need to:
- Start up a local concourse (instructions [here](https://concourse-ci.org/quick-start.html#docker-compose-concourse)). Log into the locally running concourse.
- Provision an SSH key for github.mit.edu. Ensure that it has no password
- Pass the contents in as a variable `github_enterprise_ssh_key` in the (or more likely, make a local change to pass it into the `course_repo` private_key argument directly)
- `python jupyter_courses.py`
- Run one or more of the resulting `fly` commands targeting.
At that point you should have a pipeline you can mess with. Provided you've overridden the private key, you should be able to trigger a manual build and get the checkout and build steps to run to completion.

These are also running on https://cicd.odl.mit.edu/ already

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
