### PR TITLE
Very basic PR to get a new ECR repo stood up.

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/ecr/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/ecr/__main__.py
@@ -110,7 +110,7 @@ aws.ecr.PullThroughCacheRule(
 )
 
 ecr_private_repository = aws.ecr.Repository(
-    "aws-ecr-private-repository", name="ol-ecr-private"
+    "aws-ecr-private-repository", name="ol-course-notebooks"
 )
 
 ecr_private_repository_policy = aws.ecr.RepositoryPolicy(


### PR DESCRIPTION
### What are the relevant tickets?
Prerequisite for https://github.com/mitodl/ol-infrastructure/pull/3489

This repo will be used initially to store docker images build off of jupyter notebooks for https://github.com/mitodl/hq/issues/8028.

### Description (What does it do?)
<!--- Describe your changes in detail -->
This provisions an ECR repository the storage of private images using the same policy defined for the pull through cache. We'll be using this intially to store docker containers built off of Jupyter course dependencies and assets.

Below is the output for `pulumi up`
```
╭─cpatti at rocinante in ~/src/mit/ol-infrastructure/src/ol_infrastructure/infrastructure/aws/ecr on dansubak/stand_up_new_ecr✔ 25-08-20 - 10:08:05
╰─(.venv) ⠠⠵ pulumi up -s infrastructure.aws.ecr                                                           <region:us-east-1>
Previewing update (infrastructure.aws.ecr):
     Type                         Name                                          Plan       Info
     pulumi:pulumi:Stack          ol-infrastructure-ecr-infrastructure.aws.ecr             1 warning; 4 messages
 +   ├─ aws:ecr:Repository        aws-ecr-private-repository                    create
 +   └─ aws:ecr:RepositoryPolicy  aws-ecr-private-repository-policy             create

Diagnostics:
  pulumi:pulumi:Stack (ol-infrastructure-ecr-infrastructure.aws.ecr):
    /Users/cpatti/src/mit/ol-infrastructure/.venv/lib/python3.12/site-packages/parliament/__init__.py:13: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
      import pkg_resources
    /Users/cpatti/src/mit/ol-infrastructure/.venv/lib/python3.12/site-packages/pulumi_aws/_utilities.py:317: UserWarning: name is deprecated. Use region instead.
      warnings.warn(message)

    warning: name is deprecated: name is deprecated. Use region instead.

Resources:
    + 2 to create
    7 unchanged

Do you want to perform this update? details
  pulumi:pulumi:Stack: (same)
    [urn=urn:pulumi:infrastructure.aws.ecr::ol-infrastructure-ecr::pulumi:pulumi:Stack::ol-infrastructure-ecr-infrastructure.aws.ecr]
    + aws:ecr/repository:Repository: (create)
        [urn=urn:pulumi:infrastructure.aws.ecr::ol-infrastructure-ecr::aws:ecr/repository:Repository::aws-ecr-private-repository]
        [provider=urn:pulumi:infrastructure.aws.ecr::ol-infrastructure-ecr::pulumi:providers:aws::default_7_4_0::04da6b54-80e4-46f7-96ec-b56ff0331ba9]
        imageTagMutability: "MUTABLE"
        name              : "ol-ecr-private"
        tagsAll           : {}
    + aws:ecr/repositoryPolicy:RepositoryPolicy: (create)
        [urn=urn:pulumi:infrastructure.aws.ecr::ol-infrastructure-ecr::aws:ecr/repositoryPolicy:RepositoryPolicy::aws-ecr-private-repository-policy]
        [provider=urn:pulumi:infrastructure.aws.ecr::ol-infrastructure-ecr::pulumi:providers:aws::default_7_4_0::04da6b54-80e4-46f7-96ec-b56ff0331ba9]
        policy    : (json) {
            Statement: [
                [0]: {
                    Action   : [
                        [0]: "ecr:UploadLayerPart"
                        [1]: "ecr:SetRepositoryPolicy"
                        [2]: "ecr:PutImage"
                        [3]: "ecr:ListTagsForResource"
                        [4]: "ecr:ListImages"
                        [5]: "ecr:InitiateLayerUpload"
                        [6]: "ecr:GetRepositoryPolicy"
                        [7]: "ecr:GetLifecyclePolicyPreview"
                        [8]: "ecr:GetLifecyclePolicy"
                        [9]: "ecr:GetDownloadUrlForLayer"
                        [10]: "ecr:GetAuthorizationToken"
                        [11]: "ecr:DescribeRepositories"
                        [12]: "ecr:DescribeImages"
                        [13]: "ecr:DescribeImageScanFindings"
                        [14]: "ecr:DeleteRepositoryPolicy"
                        [15]: "ecr:DeleteRepository"
                        [16]: "ecr:CompleteLayerUpload"
                        [17]: "ecr:BatchGetImage"
                        [18]: "ecr:BatchDeleteImage"
                        [19]: "ecr:BatchCheckLayerAvailability"
                    ]
                    Effect   : "Allow"
                    Principal: {
                        AWS: "610119931565"
                    }
                    Sid      : "ecr_repository_permissions"
                }
            ]
            Version  : "2012-10-17"
        }

        repository: "ol-ecr-private"

Do you want to perform this update? no
confirmation declined, not proceeding with the update
╭─cpatti at rocinante in ~/src/mit/ol-infrastructure/src/ol_infrastructure/infrastructure/aws/ecr on dansubak/stand_up_new_ecr✔ 25-08-20 - 10:08:53
╰─(.venv) ⠠⠵
```

### How can this be tested?
Changes can be tested by running `pulumi up -s infrastructure.aws.ecr` and observing that it intends to create two new resources, a repository and repository policy.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
