### PR TITLE
fix: enable the breadcrump slot only for MITxOnline

### DIFF
--- a/src/bridge/settings/openedx/mfe/slot_config/learning-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/learning-mfe-config.env.jsx
@@ -24,97 +24,100 @@ import(
    })
 })
 
-// Configure the MFE plugin slots for the Learning MFE
 let learningMFEConfig = {
-  ...config,
-  pluginSlots: {
-    ...config.pluginSlots,
-    // Render the CourseBreadcrumbs component in the course_breadcrumbs slot
-    'org.openedx.frontend.learning.course_breadcrumbs.v1': {
-      keepDefault: false,
-      plugins: [
-        {
-          op: PLUGIN_OPERATIONS.Insert,
-          widget: {
-            id: 'default_breadcrumbs_component',
-            type: DIRECT_PLUGIN,
-            RenderWidget: ({ courseId, sectionId, sequenceId, isStaff, unitId }) => (
-              <CourseBreadcrumbs
-                courseId={courseId}
-                sectionId={sectionId}
-                sequenceId={sequenceId}
-                isStaff={isStaff}
-                unitId={unitId}
-              />
-            ),
-          },
-        },
-      ]
-    },
-    // Render the SequenceNavigation component in the sequence_navigation slot
-    'org.openedx.frontend.learning.sequence_navigation.v1': {
-      keepDefault: false,
-      plugins: [
-        {
-          op: PLUGIN_OPERATIONS.Insert,
-          widget: {
-            id: 'custom_sequence_navigation',
-            type: DIRECT_PLUGIN,
-            RenderWidget: ({ sequenceId, unitId, nextHandler, onNavigate, previousHandler }) => (
-              <SequenceNavigation
-                sequenceId={sequenceId}
-                unitId={unitId}
-                nextHandler={nextHandler}
-                onNavigate={onNavigate}
-                previousHandler={previousHandler}
-              />
-            ),
-          },
-        },
-      ],
-    },
-    // Hide the default course outline sidebar
-    'org.openedx.frontend.learning.course_outline_sidebar.v1': {
-      keepDefault: false,
-      plugins: [
-        {
-          op: PLUGIN_OPERATIONS.Hide,
-          widgetId: 'default_contents',
-        },
-      ]
-    },
-    // The unit title slot includes navigation arrow buttons that aren’t needed,
-    // so we render a custom unit title component instead.
-    'org.openedx.frontend.learning.unit_title.v1': {
-      plugins: [
-        {
-          op: PLUGIN_OPERATIONS.Insert,
-          widget: {
-            id: 'custom_unit_title_content',
-            type: DIRECT_PLUGIN,
-            RenderWidget: ({ unit }) => {
-            const isProcessing = unit.bookmarkedUpdateState === 'loading';
-            const {formatMessage} = useIntl();
-             return <>
-             <div className="d-flex justify-content-between">
-                <div className="mb-0">
-                  <h3 className="h3">{unit.title}</h3>
-                </div>
-              </div>
-              <p className="sr-only">{formatMessage(messages.headerPlaceholder)}</p>
-              <BookmarkButton
-                unitId={unit.id}
-                isBookmarked={unit.bookmarked}
-                isProcessing={isProcessing}
-              />
-             </>
+    ...config
+}
+
+// Configure the Breadcrumbs old behaviour in MITx Online Learning MFE
+if (getConfig().SITE_NAME.includes("MITx Online")) {
+  learningMFEConfig.pluginSlots = {
+      ...config.pluginSlots,
+      // Render the CourseBreadcrumbs component in the course_breadcrumbs slot
+      'org.openedx.frontend.learning.course_breadcrumbs.v1': {
+        keepDefault: false,
+        plugins: [
+          {
+            op: PLUGIN_OPERATIONS.Insert,
+            widget: {
+              id: 'default_breadcrumbs_component',
+              type: DIRECT_PLUGIN,
+              RenderWidget: ({ courseId, sectionId, sequenceId, isStaff, unitId }) => (
+                <CourseBreadcrumbs
+                  courseId={courseId}
+                  sectionId={sectionId}
+                  sequenceId={sequenceId}
+                  isStaff={isStaff}
+                  unitId={unitId}
+                />
+              ),
             },
           },
-        },
-      ]
-    }
-  },
+        ]
+      },
+      // Render the SequenceNavigation component in the sequence_navigation slot
+      'org.openedx.frontend.learning.sequence_navigation.v1': {
+        keepDefault: false,
+        plugins: [
+          {
+            op: PLUGIN_OPERATIONS.Insert,
+            widget: {
+              id: 'custom_sequence_navigation',
+              type: DIRECT_PLUGIN,
+              RenderWidget: ({ sequenceId, unitId, nextHandler, onNavigate, previousHandler }) => (
+                <SequenceNavigation
+                  sequenceId={sequenceId}
+                  unitId={unitId}
+                  nextHandler={nextHandler}
+                  onNavigate={onNavigate}
+                  previousHandler={previousHandler}
+                />
+              ),
+            },
+          },
+        ],
+      },
+      // Hide the default course outline sidebar
+      'org.openedx.frontend.learning.course_outline_sidebar.v1': {
+        keepDefault: false,
+        plugins: [
+          {
+            op: PLUGIN_OPERATIONS.Hide,
+            widgetId: 'default_contents',
+          },
+        ]
+      },
+      // The unit title slot includes navigation arrow buttons that aren’t needed,
+      // so we render a custom unit title component instead.
+      'org.openedx.frontend.learning.unit_title.v1': {
+        plugins: [
+          {
+            op: PLUGIN_OPERATIONS.Insert,
+            widget: {
+              id: 'custom_unit_title_content',
+              type: DIRECT_PLUGIN,
+              RenderWidget: ({ unit }) => {
+              const isProcessing = unit.bookmarkedUpdateState === 'loading';
+              const {formatMessage} = useIntl();
+              return <>
+              <div className="d-flex justify-content-between">
+                  <div className="mb-0">
+                    <h3 className="h3">{unit.title}</h3>
+                  </div>
+                </div>
+                <p className="sr-only">{formatMessage(messages.headerPlaceholder)}</p>
+                <BookmarkButton
+                  unitId={unit.id}
+                  isBookmarked={unit.bookmarked}
+                  isProcessing={isProcessing}
+                />
+              </>
+              },
+            },
+          },
+        ]
+      }
+  };
+}
 
-};
 
 export default learningMFEConfig;

--- a/src/bridge/settings/openedx/mfe/slot_config/learning-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/learning-mfe-config.env.jsx
@@ -29,7 +29,7 @@ let learningMFEConfig = {
 }
 
 // Configure the Breadcrumbs old behaviour in MITx Online Learning MFE
-if (getConfig().SITE_NAME.includes("MITx Online")) {
+if (process.env.DEPLOYMENT_NAME.includes("mitxonline")) {
   learningMFEConfig.pluginSlots = {
       ...config.pluginSlots,
       // Render the CourseBreadcrumbs component in the course_breadcrumbs slot

--- a/src/bridge/settings/openedx/mfe/slot_config/learning-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/learning-mfe-config.env.jsx
@@ -29,7 +29,7 @@ let learningMFEConfig = {
 }
 
 // Configure the Breadcrumbs old behaviour in MITx Online Learning MFE
-if (process.env.DEPLOYMENT_NAME.includes("mitxonline")) {
+if (process.env.DEPLOYMENT_NAME?.includes("mitxonline")) {
   learningMFEConfig.pluginSlots = {
       ...config.pluginSlots,
       // Render the CourseBreadcrumbs component in the course_breadcrumbs slot

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -100,6 +100,7 @@ def mfe_params(
         "CSRF_TOKEN_API_PATH": "/csrf/api/v1/token",
         "DISPLAY_FEEDBACK_WIDGET": open_edx.display_feedback_widget,
         "ENABLE_CERTIFICATE_PAGE": open_edx.enable_certificate_page,
+        "DEPLOYMENT_NAME": open_edx.deployment_name,
         "DISCUSSIONS_MFE_BASE_URL": (
             f"https://{open_edx.lms_domain}/{discussion_mfe_path}"
         ),


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8204, https://github.com/mitodl/hq/issues/8205

### Description (What does it do?)
We recently added the breadcrumb slots for MITxOnline in [this PR](https://github.com/mitodl/ol-infrastructure/pull/3462) to replicate the old behavior. Since the learning MFE uses a shared config across all applications, this change was also rolled out to MITxPRO and MITx. However, in the [teak release](https://github.com/openedx/frontend-app-learning/blob/release/teak/src/plugin-slots/CourseBreadcrumbsSlot/index.tsx#L1-L33), the CourseBreadcrumbsSlot component is missing the pluginProps attribute. As a result, the props passed to the Slot by our config are null, which is causing this issue.

To address this, this PR updates the logic so that the slot is only added for MITxOnline and not for other applications.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- Checkout to Teak release in your learning MFE
- In your `.env.development` file, set the `SITE_ID` which doesn't contain `MITx Online`. 
- The unit page should load correctly without any issues
- Checkout to master branch and set the `SITE_ID` which contains `MITx Online`.
- Verify that the breadcrumb component loads correctly on the unit page.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
