### PR TITLE
config: remove mit_et from UAI_COURSE_KEY_FORMATS

### DIFF
--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -392,7 +392,6 @@ MIT_LEARN_SUMMARY_FLASHCARD_URL: https://{{ key "edxapp/learn-api-domain" }}/lea
 MIT_LEARN_BASE_URL: https://{{ key "edxapp/learn-frontend-domain" }}
 UAI_COURSE_KEY_FORMATS:
   - course-v1:uai_
-  - course-v1:mit_et
 MIT_LEARN_LOGO: https://{{ key "edxapp/lms-domain" }}/static/mitxonline/images/mit-learn-logo.svg"
 LEARNER_PORTAL_URL_ROOT: https://learner-portal-localhost:18000
 LEARNER_HOME_MICROFRONTEND_URL: '/dashboard/'

--- a/src/bridge/settings/openedx/mfe/slot_config/mitxonline/common-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/mitxonline/common-mfe-config.env.jsx
@@ -7,7 +7,7 @@ const currentYear = new Date().getFullYear();
 const edxMfeAppName = configData.APP_ID;
 const authoringAppID = "authoring";
 const href = window.location.href.toLowerCase();
-const isLearnCourse = ["course-v1:uai_", "course-v1:mit_et"].some(key => href.includes(key));
+const isLearnCourse = ["course-v1:uai_"].some(key => href.includes(key));
 const accessibilityURL = process.env.ACCESSIBILITY_URL || 'https://accessibility.mit.edu/';
 const linkTitles = {
   dashboard: "Dashboard",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8010

### Description (What does it do?)
This PR removes the `MIT_ET` prefix from `UAI_COURSE_KEY_FORMATS`, since the correct prefix is `UAI_ET`. The `UAI_ET` case is already covered by the `UAI_` prefix.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
