### PR TITLE
config: remove course outline sidebar trigger btn from mitxonline learning mfe

### DIFF
--- a/src/bridge/settings/openedx/mfe/slot_config/learning-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/learning-mfe-config.env.jsx
@@ -115,6 +115,24 @@ if (process.env.DEPLOYMENT_NAME?.includes("mitxonline")) {
             },
           },
         ]
+      },
+      'org.openedx.frontend.learning.course_outline_sidebar_trigger.v1': {
+        keepDefault: false,
+        plugins: [
+          {
+            op: PLUGIN_OPERATIONS.Hide,
+            widgetId: 'default_trigger',
+          },
+        ]
+      },
+      'org.openedx.frontend.learning.course_outline_mobile_sidebar_trigger.v1': {
+        keepDefault: false,
+        plugins: [
+          {
+            op: PLUGIN_OPERATIONS.Hide,
+            widgetId: 'default_trigger',
+          },
+        ]
       }
   };
 }


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8293

### Description (What does it do?)
This PR hides the course outline sidebar trigger button from mitxonline learning mfe. 

### Screenshots (if appropriate):
- [ ] Desktop screenshots
**Before**

<img width="1792" height="877" alt="Screenshot 2025-08-27 at 2 47 48 PM" src="https://github.com/user-attachments/assets/597344cf-d8e6-41f0-872d-3b996dc9f7bf" />

**After**

<img width="1792" height="877" alt="Screenshot 2025-08-27 at 2 46 43 PM" src="https://github.com/user-attachments/assets/5c1cfd8c-dfca-4ffc-825c-c0fe5bfbbf57" />

- [ ] Mobile width screenshots

**Before**

<img width="375" height="820" alt="Screenshot 2025-08-27 at 2 49 55 PM" src="https://github.com/user-attachments/assets/9da695f5-020a-4fba-b2a7-f331fa12123c" />

**After**
<img width="375" height="820" alt="Screenshot 2025-08-27 at 2 53 54 PM" src="https://github.com/user-attachments/assets/b5d6c9d7-898c-4474-bc19-d7007d5114c1" />


### How can this be tested?
- Set your deployment name to mitxonline in the `.env.development` file
- Copy-paste the configuration from `src/bridge/settings/openedx/mfe/slot_config/learning-mfe-config.env.jsx` in your `env.config.jsx` file.
- Verify that the course outline sidebar trigger button doesn't appear in both the Desktop and the Mobile view when the notification/discussion panel is opened.
