### PR TITLE
feat: custom certificate status slot added for custom message

### DIFF
--- a/src/bridge/settings/openedx/mfe/slot_config/xpro/common-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/xpro/common-mfe-config.env.jsx
@@ -216,7 +216,7 @@ const CustomCertificateStatus = (widget) => {
     const newSecondChild = React.cloneElement(
       RenderWidget.props.children[1],
       RenderWidget.props.children[1].props,
-      `Final grades and any earned certificates are scheduled to be available 3 business days after ${endDate}.`
+      `Final grades and any earned certificates are scheduled to be available 3 business days after ${endDate}`
     );
 
     const newChildren = [

--- a/src/bridge/settings/openedx/mfe/slot_config/xpro/common-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/xpro/common-mfe-config.env.jsx
@@ -1,6 +1,10 @@
-import { PLUGIN_OPERATIONS, DIRECT_PLUGIN } from '@openedx/frontend-plugin-framework';
-import { getConfig } from '@edx/frontend-platform';
-import Footer, { Logo, MenuLinks, CopyrightNotice } from './Footer.jsx';
+import React from "react";
+import {
+  PLUGIN_OPERATIONS,
+  DIRECT_PLUGIN,
+} from "@openedx/frontend-plugin-framework";
+import { getConfig } from "@edx/frontend-platform";
+import Footer, { Logo, MenuLinks, CopyrightNotice } from "./Footer.jsx";
 
 const configData = getConfig();
 const currentYear = new Date().getFullYear();
@@ -8,19 +12,19 @@ const currentYear = new Date().getFullYear();
 const userMenu = [
   {
     url: `${configData.MARKETING_SITE_BASE_URL}/dashboard`,
-    title: 'Dashboard',
+    title: "Dashboard",
   },
   {
     url: `${configData.MARKETING_SITE_BASE_URL}/profile/`,
-    title: 'Profile',
+    title: "Profile",
   },
   {
     url: `${configData.MARKETING_SITE_BASE_URL}/account-settings/`,
-    title: 'Settings',
+    title: "Settings",
   },
   {
     url: `${configData.LMS_BASE_URL}/logout`,
-    title: 'Sign Out',
+    title: "Sign Out",
   },
 ];
 
@@ -28,7 +32,7 @@ const DesktopHeaderUserMenu = (widget) => {
   widget.content.menu = [
     {
       items: userMenu.map((item) => ({
-        type: 'item',
+        type: "item",
         href: item.url,
         content: item.title,
       })),
@@ -41,44 +45,47 @@ const LearningHeaderUserMenu = (widget) => {
   widget.content.items = userMenu.map((item) => ({
     href: item.url,
     message: item.title,
-  }))
+  }));
   return widget;
 };
 
 const footerLegalLinks = [
   {
     url: `${configData.MARKETING_SITE_BASE_URL}/about-us/`,
-    title: 'About Us',
+    title: "About Us",
   },
   {
     url: `${configData.MARKETING_SITE_BASE_URL}/privacy-policy/`,
-    title: 'Privacy Policy',
+    title: "Privacy Policy",
   },
   {
     url: `${configData.MARKETING_SITE_BASE_URL}/honor-code/`,
-    title: 'Honor Code',
+    title: "Honor Code",
   },
   {
     url: `${configData.MARKETING_SITE_BASE_URL}/terms-of-service/`,
-    title: 'Terms of Service',
+    title: "Terms of Service",
   },
   {
-    url: 'https://accessibility.mit.edu/',
-    title: 'Accessibility',
+    url: "https://accessibility.mit.edu/",
+    title: "Accessibility",
   },
 ];
 
 const footerSubSlotsConfig = {
   "frontend.shell.footer.desktop.leftLinks.ui": {
     plugins: [
-      { op: PLUGIN_OPERATIONS.Hide, widgetId: 'default_contents' },
+      { op: PLUGIN_OPERATIONS.Hide, widgetId: "default_contents" },
       {
         op: PLUGIN_OPERATIONS.Insert,
         widget: {
-          id: 'custom_logo',
+          id: "custom_logo",
           type: DIRECT_PLUGIN,
           RenderWidget: () => (
-            <Logo imageUrl={configData.LOGO_URL} destinationUrl={configData.MARKETING_SITE_BASE_URL} />
+            <Logo
+              imageUrl={configData.LOGO_URL}
+              destinationUrl={configData.MARKETING_SITE_BASE_URL}
+            />
           ),
         },
       },
@@ -86,49 +93,52 @@ const footerSubSlotsConfig = {
   },
   "frontend.shell.footer.desktop.centerLinks.ui": {
     plugins: [
-      { op: PLUGIN_OPERATIONS.Hide, widgetId: 'default_contents' },
+      { op: PLUGIN_OPERATIONS.Hide, widgetId: "default_contents" },
       {
         op: PLUGIN_OPERATIONS.Insert,
         widget: {
-          id: 'custom_menu_links',
+          id: "custom_menu_links",
           type: DIRECT_PLUGIN,
-          RenderWidget: () => (
-            <MenuLinks menuItems={footerLegalLinks} />
-          ),
+          RenderWidget: () => <MenuLinks menuItems={footerLegalLinks} />,
         },
       },
     ],
   },
   "frontend.shell.footer.desktop.legalNotices.ui": {
     plugins: [
-      { op: PLUGIN_OPERATIONS.Hide, widgetId: 'default_contents' },
+      { op: PLUGIN_OPERATIONS.Hide, widgetId: "default_contents" },
       {
         op: PLUGIN_OPERATIONS.Insert,
         widget: {
-          id: 'custom_legal_notice',
+          id: "custom_legal_notice",
           type: DIRECT_PLUGIN,
           RenderWidget: () => (
-            <CopyrightNotice copyrightText={`© ${currentYear} ${configData.SITE_NAME.replace(/\b(CI|QA|Staging)\b/g, "").trim()}. All rights reserved.`} />
+            <CopyrightNotice
+              copyrightText={`© ${currentYear} ${configData.SITE_NAME.replace(
+                /\b(CI|QA|Staging)\b/g,
+                ""
+              ).trim()}. All rights reserved.`}
+            />
           ),
         },
       },
     ],
   },
   "frontend.shell.footer.desktop.top.ui": {
-    plugins: [{ op: PLUGIN_OPERATIONS.Hide, widgetId: 'default_contents' }],
+    plugins: [{ op: PLUGIN_OPERATIONS.Hide, widgetId: "default_contents" }],
   },
   "frontend.shell.footer.desktop.rightLinks.ui": {
-    plugins: [{ op: PLUGIN_OPERATIONS.Hide, widgetId: 'default_contents' }],
+    plugins: [{ op: PLUGIN_OPERATIONS.Hide, widgetId: "default_contents" }],
   },
 };
 
 const footerSlotConfig = {
   plugins: [
-    { op: PLUGIN_OPERATIONS.Hide, widgetId: 'default_contents' },
+    { op: PLUGIN_OPERATIONS.Hide, widgetId: "default_contents" },
     {
       op: PLUGIN_OPERATIONS.Insert,
       widget: {
-        id: 'custom_footer',
+        id: "custom_footer",
         type: DIRECT_PLUGIN,
         RenderWidget: () => <Footer />,
       },
@@ -163,7 +173,12 @@ if (edxMfeAppName === "authoring") {
 }
 
 // Dynamic header menu slot overrides
-const learningApps = ["learning", "discussions", "ora-grading", "communications"];
+const learningApps = [
+  "learning",
+  "discussions",
+  "ora-grading",
+  "communications",
+];
 const dashboardApps = ["gradebook", "learner-dashboard"];
 
 if (learningApps.includes(edxMfeAppName)) {
@@ -172,7 +187,7 @@ if (learningApps.includes(edxMfeAppName)) {
     plugins: [
       {
         op: PLUGIN_OPERATIONS.Modify,
-        widgetId: 'default_contents',
+        widgetId: "default_contents",
         fn: LearningHeaderUserMenu,
       },
     ],
@@ -183,8 +198,51 @@ if (learningApps.includes(edxMfeAppName)) {
     plugins: [
       {
         op: PLUGIN_OPERATIONS.Modify,
-        widgetId: 'default_contents',
+        widgetId: "default_contents",
         fn: DesktopHeaderUserMenu,
+      },
+    ],
+  };
+}
+
+const CustomcertificateStatus = (widget) => {
+  const { RenderWidget } = widget;
+
+  // Only modify widgets for "notAvailable_certificate_status"
+  if (RenderWidget.props.id.includes("notAvailable_")) {
+    const old_body = RenderWidget.props.children[1].props.children;
+    let endDate = old_body.split("available after")[1];
+
+    const newSecondChild = React.cloneElement(
+      RenderWidget.props.children[1],
+      RenderWidget.props.children[1].props,
+      `Final grades and any earned certificates are scheduled to be available 3 business days after ${endDate}.`
+    );
+
+    const newChildren = [
+      RenderWidget.props.children[0],
+      newSecondChild,
+      ...RenderWidget.props.children.slice(2),
+    ];
+
+    const newWidgetRender = React.cloneElement(
+      RenderWidget,
+      RenderWidget.props,
+      ...newChildren
+    );
+    widget.RenderWidget = newWidgetRender;
+  }
+  return widget;
+};
+
+if (edxMfeAppName === "learning") {
+  config.pluginSlots.progress_certificate_status_slot = {
+    keepDefault: true,
+    plugins: [
+      {
+        op: PLUGIN_OPERATIONS.Modify,
+        widgetId: "default_contents",
+        fn: CustomcertificateStatus,
       },
     ],
   };

--- a/src/bridge/settings/openedx/mfe/slot_config/xpro/common-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/xpro/common-mfe-config.env.jsx
@@ -206,37 +206,34 @@ if (learningApps.includes(edxMfeAppName)) {
 }
 
 const CustomCertificateStatus = (widget) => {
-  const { RenderWidget } = widget;
-
   // Modify only "notAvailable_certificate_status" with exactly 3 children.
   // If the structure changes (children count ≠ 3), fall back to the original widget for safety.
   // Original code reference:
   // https://github.com/openedx/frontend-app-learning/blob/release/teak/src/course-home/progress-tab/certificate-status/CertificateStatus.jsx#L245
-  const renderProps = RenderWidget.props;
-  if (
-    renderProps.id.includes("notAvailable_") &&
-    renderProps.children.length == 3
-  ) {
-    const old_body = renderProps.children[1].props.children;
-    const endDate = old_body.split("available after")[1];
 
-    const newSecondChild = React.cloneElement(
-      renderProps.children[1],
-      renderProps.children[1].props,
-      `Final grades and any earned certificates are scheduled to be available 3 business days after ${endDate}`
-    );
-
-    const newChildren = [
-      renderProps.children[0],
-      newSecondChild,
-      ...renderProps.children.slice(2),
-    ];
-
-    widget.RenderWidget = React.cloneElement(
-      RenderWidget,
-      RenderWidget.props,
-      ...newChildren
-    );
+  const { RenderWidget } = widget;
+  const { id, children } = RenderWidget.props;
+  const childArray = React.Children.toArray(children);
+  if (id?.includes("notAvailable_") && childArray.length === 3) {
+    const secondChild = childArray[1];
+    let oldBody = secondChild?.props?.children;
+    let endDate = null;
+    if (typeof oldBody === "string" && oldBody.includes("available after")) {
+      endDate = oldBody.split("available after")[1].trim();
+    }
+    if (endDate) {
+      const newSecondChild = React.cloneElement(
+        secondChild,
+        secondChild.props,
+        `Final grades and any earned certificates are scheduled to be available 3 busines s days after ${endDate}`
+      );
+      const newChildren = [childArray[0], newSecondChild, childArray[2]];
+      widget.RenderWidget = React.cloneElement(
+        RenderWidget,
+        RenderWidget.props,
+        newChildren
+      );
+    }
   }
   return widget;
 };

--- a/src/bridge/settings/openedx/mfe/slot_config/xpro/common-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/xpro/common-mfe-config.env.jsx
@@ -205,7 +205,7 @@ if (learningApps.includes(edxMfeAppName)) {
   };
 }
 
-const CustomcertificateStatus = (widget) => {
+const CustomCertificateStatus = (widget) => {
   const { RenderWidget } = widget;
 
   // Only modify widgets for "notAvailable_certificate_status"
@@ -225,12 +225,11 @@ const CustomcertificateStatus = (widget) => {
       ...RenderWidget.props.children.slice(2),
     ];
 
-    const newWidgetRender = React.cloneElement(
+    widget.RenderWidget = React.cloneElement(
       RenderWidget,
       RenderWidget.props,
       ...newChildren
     );
-    widget.RenderWidget = newWidgetRender;
   }
   return widget;
 };
@@ -242,7 +241,7 @@ if (edxMfeAppName === "learning") {
       {
         op: PLUGIN_OPERATIONS.Modify,
         widgetId: "default_contents",
-        fn: CustomcertificateStatus,
+        fn: CustomCertificateStatus,
       },
     ],
   };

--- a/src/bridge/settings/openedx/mfe/slot_config/xpro/common-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/xpro/common-mfe-config.env.jsx
@@ -208,21 +208,28 @@ if (learningApps.includes(edxMfeAppName)) {
 const CustomCertificateStatus = (widget) => {
   const { RenderWidget } = widget;
 
-  // Only modify widgets for "notAvailable_certificate_status"
-  if (RenderWidget.props.id.includes("notAvailable_")) {
-    const old_body = RenderWidget.props.children[1].props.children;
-    let endDate = old_body.split("available after")[1];
+  // Modify only "notAvailable_certificate_status" with exactly 3 children.
+  // If the structure changes (children count ≠ 3), fall back to the original widget for safety.
+  // Original code reference:
+  // https://github.com/openedx/frontend-app-learning/blob/release/teak/src/course-home/progress-tab/certificate-status/CertificateStatus.jsx#L245
+  const renderProps = RenderWidget.props;
+  if (
+    renderProps.id.includes("notAvailable_") &&
+    renderProps.children.length == 3
+  ) {
+    const old_body = renderProps.children[1].props.children;
+    const endDate = old_body.split("available after")[1];
 
     const newSecondChild = React.cloneElement(
-      RenderWidget.props.children[1],
-      RenderWidget.props.children[1].props,
+      renderProps.children[1],
+      renderProps.children[1].props,
       `Final grades and any earned certificates are scheduled to be available 3 business days after ${endDate}`
     );
 
     const newChildren = [
-      RenderWidget.props.children[0],
+      renderProps.children[0],
       newSecondChild,
-      ...RenderWidget.props.children.slice(2),
+      ...renderProps.children.slice(2),
     ];
 
     widget.RenderWidget = React.cloneElement(


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8250#issuecomment-3226286424

### Description (What does it do?)
This PR:
1. Adds slot for `progress_certificate_status_slot`
2. Only updates message in case of certificate case is `notAvailable`
3. Override the [message](https://github.com/mitodl/hq/issues/8250#issuecomment-3220620548) to "Final grades and any earned certificates are scheduled to be available 3 business days after [END DATE OF COURSE]"

### Screenshots (if appropriate):
<img width="1680" height="658" alt="image" src="https://github.com/user-attachments/assets/f6936fc6-f191-480c-9e6d-5701597c6f77" />

### How can this be tested?
1. Make sure you have running Tutor setup with locally mounted `frontend-app-learning`
2. Use existing or create a new course with certificate to complete on Studio
3. After complete the course go the progress page: `/learning/course/{course_key}/progress`
4. You should see Text mentioned in the screenshot from [description of the original ticket](https://github.com/mitodl/hq/issues/8250#issue-3343624967) -- "Final grades and any earned certificates are scheduled to be available after {endDate}."
5. Follow the instructions mentioned [here](https://github.com/openedx/frontend-app-learning/blob/9bf5d01c41b4c770da20415fd92dcf90a1589da8/src/plugin-slots/ProgressCertificateStatusSlot/README.md) to add certificate status slot
6. Replace the `modifyWidget` function with the [CustomCertificateStatus](https://github.com/mitodl/ol-infrastructure/pull/3516/files#diff-342c3e298d7dbdad7d521d1d86fca53e84b989dc1e4fe12d2a941700d9ef6486R207) from this PR
7. Now check the message again and you should see "Final grades and any earned certificates are scheduled to be available 3 business days after ${endDate}."

