### PR TITLE
PG RDS for jupyterhub

### DIFF
--- a/src/ol_infrastructure/applications/jupyterhub/Pulumi.applications.jupyterhub.CI.yaml
+++ b/src/ol_infrastructure/applications/jupyterhub/Pulumi.applications.jupyterhub.CI.yaml
@@ -5,7 +5,7 @@ config:
   binderhub:domain: "binder.ci.learn.mit.edu"
   jupyterhub:target_vpc: "applications_vpc"
   jupyterhub:rds_password: # This MUST be changed, it's reusing the shared PW
-    secure: v1:sKBL3tBJ/EGDkmrt:5sJUBSl6ehXuwdMvMpwILzdsvHkycmXCUt43ru1SsO9sePH9WQNlVy6giJ1Y2wXiYu9dQx9NfGYb+Nnk4t7T90Gjz5Ouc2NKGT05rKuDMjk=
+    secure: v1:ae+uadhbZC0VnnI5:p0QKNNy8xscV8K69VTTcLIca6BfvEoarQ4ZsRsa2pGAGoU3IDDe48fJVCYvVLwDvufpvbLUnR88MJP4=
   jupyterhub:business_unit: "mit-learn"
   jupyterhub:domain: "nb.ci.learn.mit.edu"
   jupyterhub:admin_users:

--- a/src/ol_infrastructure/applications/jupyterhub/Pulumi.applications.jupyterhub.CI.yaml
+++ b/src/ol_infrastructure/applications/jupyterhub/Pulumi.applications.jupyterhub.CI.yaml
@@ -4,7 +4,7 @@ encryptedkey: AQICAHi3MZ/Pjy2dahB1Qm+zKkKDPV1b9MYPGp7k649HPjmOHAFqnCOCAZSgyF1ZWf
 config:
   binderhub:domain: "binder.ci.learn.mit.edu"
   jupyterhub:target_vpc: "applications_vpc"
-  jupyterhub:rds_password: # This MUST be changed, it's reusing the shared PW
+  jupyterhub:rds_password:
     secure: v1:ae+uadhbZC0VnnI5:p0QKNNy8xscV8K69VTTcLIca6BfvEoarQ4ZsRsa2pGAGoU3IDDe48fJVCYvVLwDvufpvbLUnR88MJP4=
   jupyterhub:business_unit: "mit-learn"
   jupyterhub:domain: "nb.ci.learn.mit.edu"

--- a/src/ol_infrastructure/applications/jupyterhub/Pulumi.applications.jupyterhub.CI.yaml
+++ b/src/ol_infrastructure/applications/jupyterhub/Pulumi.applications.jupyterhub.CI.yaml
@@ -4,6 +4,8 @@ encryptedkey: AQICAHi3MZ/Pjy2dahB1Qm+zKkKDPV1b9MYPGp7k649HPjmOHAFqnCOCAZSgyF1ZWf
 config:
   binderhub:domain: "binder.ci.learn.mit.edu"
   jupyterhub:target_vpc: "applications_vpc"
+  jupyterhub:rds_password: # This MUST be changed, it's reusing the shared PW
+    secure: v1:sKBL3tBJ/EGDkmrt:5sJUBSl6ehXuwdMvMpwILzdsvHkycmXCUt43ru1SsO9sePH9WQNlVy6giJ1Y2wXiYu9dQx9NfGYb+Nnk4t7T90Gjz5Ouc2NKGT05rKuDMjk=
   jupyterhub:business_unit: "mit-learn"
   jupyterhub:domain: "nb.ci.learn.mit.edu"
   jupyterhub:admin_users:

--- a/src/ol_infrastructure/applications/jupyterhub/__main__.py
+++ b/src/ol_infrastructure/applications/jupyterhub/__main__.py
@@ -8,7 +8,6 @@ from pulumi import Config, InvokeOptions, ResourceOptions, StackReference
 from pulumi_aws import ec2, get_caller_identity
 
 from bridge.lib.magic_numbers import (
-    AWS_RDS_DEFAULT_DATABASE_CAPACITY,
     DEFAULT_POSTGRES_PORT,
 )
 from ol_infrastructure.components.aws.database import OLAmazonDB, OLPostgresDBConfig
@@ -130,8 +129,6 @@ jupyterhub_db_security_group = ec2.SecurityGroup(
 jupyterhub_db_config = OLPostgresDBConfig(
     instance_name=f"jupyterhub-db-{stack_info.env_suffix}",
     password=rds_password,
-    storage=jupyterhub_config.get("db_capacity")
-    or str(AWS_RDS_DEFAULT_DATABASE_CAPACITY),
     subnet_group_name=target_vpc["rds_subnet"],
     security_groups=[jupyterhub_db_security_group],
     tags=aws_config.tags,

--- a/src/ol_infrastructure/applications/jupyterhub/__main__.py
+++ b/src/ol_infrastructure/applications/jupyterhub/__main__.py
@@ -93,7 +93,6 @@ cluster_stack.require_output("namespaces").apply(
 
 
 rds_defaults = defaults(stack_info)["rds"]
-print(rds_defaults)
 rds_defaults["instance_size"] = (
     jupyterhub_config.get("db_instance_size") or rds_defaults["instance_size"]
 )

--- a/src/ol_infrastructure/applications/jupyterhub/__main__.py
+++ b/src/ol_infrastructure/applications/jupyterhub/__main__.py
@@ -389,7 +389,7 @@ binderhub_application = kubernetes.helm.v3.Release(
                             "authenticator_class": "tmp",
                         },
                     },
-                    "db": {"type": "postgresql"},
+                    "db": {"type": "postgres", "url": "$(DATABASE_URL)"},
                     "resources": {
                         "requests": {
                             "cpu": "100m",
@@ -461,17 +461,22 @@ binderhub_application = kubernetes.helm.v3.Release(
                 },
             },
             "imageBuilderType": "dind",
-            "envFrom": [
+            "extraEnv": [
                 {
-                    "secretRef": {
-                        "name": jupyterhub_creds_secret_name,
-                    },
+                    "DATABASE_URL": {
+                        "valueFrom": {
+                            "secretRef": {
+                                "name": jupyterhub_creds_secret_name,
+                                "key": "DATABASE_URL",
+                            }
+                        }
+                    }
                 }
             ],
         },
         skip_await=False,
     ),
     opts=ResourceOptions(
-        delete_before_replace=True,
+        delete_before_replace=True, depends_on=[app_db_creds_dynamic_secret]
     ),
 )

--- a/src/ol_infrastructure/applications/jupyterhub/__main__.py
+++ b/src/ol_infrastructure/applications/jupyterhub/__main__.py
@@ -132,10 +132,8 @@ jupyterhub_db_config = OLPostgresDBConfig(
     password=rds_password,
     storage=jupyterhub_config.get("db_capacity")
     or str(AWS_RDS_DEFAULT_DATABASE_CAPACITY),
-    subnet_group_name=apps_vpc["rds_subnet"],
+    subnet_group_name=target_vpc["rds_subnet"],
     security_groups=[jupyterhub_db_security_group],
-    parameter_overrides=[{"name": "rds.force_ssl", "value": 0}],
-    engine_major_version="16",
     tags=aws_config.tags,
     db_name="jupyterhub",
     **rds_defaults,

--- a/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
+++ b/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
@@ -1,3 +1,5 @@
+import os
+
 from kubespawner import KubeSpawner
 
 
@@ -33,3 +35,4 @@ class QueryStringKubeSpawner(KubeSpawner):
 
 c.JupyterHub.spawner_class = QueryStringKubeSpawner  # type: ignore[name-defined] # noqa: F821
 c.Authenticator.allow_all = True  # type: ignore[name-defined] # noqa: F821
+c.JupyterHub.db_url = os.environ["DATABASE_URL"]  # type: ignore[name-defined] # noqa: F821

--- a/src/ol_infrastructure/applications/jupyterhub/jupyterhub_policy.hcl
+++ b/src/ol_infrastructure/applications/jupyterhub/jupyterhub_policy.hcl
@@ -8,3 +8,20 @@ path "secret-operations/sso/jupyterhub" {
 path "postgres-jupyterhub/creds/app" {
   capabilities = ["read"]
 }
+
+# vault-secrets-operator is a little more particular about
+# managing its own leases, give it the permissions it needs
+# for dynamic secret renwals / revocation without giving
+# it the power to revoke or renew anything
+path "sys/leases/renew" {
+  capabilities = ["update"]
+  allowed_parameters = {
+    lease_id = ["postgres-jupyterhub/creds/app/*"]
+  }
+}
+path "sys/leases/revoke" {
+  capabilities = ["update"]
+  allowed_parameters = {
+    lease_id = ["postgres-jupyterhub/creds/app/*"]
+  }
+}

--- a/src/ol_infrastructure/applications/jupyterhub/jupyterhub_policy.hcl
+++ b/src/ol_infrastructure/applications/jupyterhub/jupyterhub_policy.hcl
@@ -4,3 +4,7 @@ path "secret-operations/sso/jupyterhub/*" {
 path "secret-operations/sso/jupyterhub" {
   capabilities = ["read"]
 }
+
+path "postgres-jupyterhub/creds/app" {
+  capabilities = ["read"]
+}


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/8028

### Description (What does it do?)
Adds a new PG RDS for Jupyterhub. Sets up Jupyterhub to use a dynamic secret by piping it in through `extraConfig`

NOTE:
- ~This has not been applied yet. There may be forthcoming changes as the result of networking or RDS user misconfiguration~
- ~I've stubbed out a secret for the RDS admin user and reused the jupyterhub `shared_password`, so this PR should absolutely not land until that is resolved and has it's own vaulted secret.~
- ~While networking is up and appears to be correctly wired up (see https://github.com/mitodl/ol-infrastructure/pull/3517#issuecomment-3237787951) I have not been able to get the dynamic credentials to work yet.~


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
This is up and running at https://nb.ci.learn.mit.edu/. I verified it was using the database by running python on the hub pod to connect via the dynamic secret and queried the users table after instantiating a notebook. Observe that it has records
```
>>> import psycopg2
>>> import os

>>> conn = psycopg2.connect(os.environ['DATABASE_URL'])
>>> cursor = conn.cursor()
>>> cursor.execute('SELECT * FROM users;')
>>> for user in cursor.fetchall():
...     print(user)
... 
(1, 'admin', True, datetime.datetime(2025, 9, 2, 15, 11, 44, 899551), None, '<snipped>', None, None)
(2, 'c7cecef0-779c-48ea-a88d-68d32e70fe76', False, datetime.datetime(2025, 9, 2, 15, 13, 53, 415614), datetime.datetime(2025, 9, 2, 15, 24, 32, 666000), '<snipped>', '{}', None)
```

### Additional Context
Below is the summary of the `pulumi up command`
```
Previewing update (applications.jupyterhub.CI):
     Type                                                                  Name                                          
     pulumi:pulumi:Stack                                                   ol-infrastructure-jupyterhub-application-appli
     ├─ ol:infrastructure:services:k8s:OLApisixOIDCResources               ol-k8s-apisix-olapisixoidcresources-ci        
     │  ├─ kubernetes:yaml/v2:ConfigGroup                                  OLVaultK8SSecret-jupyter-ol-apisix-jupyterhub-
     │  │  └─ kubernetes:secrets.hashicorp.com/v1beta1:VaultStaticSecret   OLVaultK8SSecret-jupyter-ol-apisix-jupyterhub-
     │  └─ ol:services:Vault:K8S:VaultStaticSecret                         jupyterhub-oidc-secrets                       
     ├─ ol:services:Vault:K8S:ResourcesConfig                              jupyterhub                                    
     │  ├─ kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding      jupyterhub-vault-cluster-role-binding         
     │  ├─ kubernetes:yaml/v2:ConfigGroup                                  jupyterhub-vso-resources                      
     │  │  ├─ kubernetes:secrets.hashicorp.com/v1beta1:VaultAuth           jupyterhub-vso-resources:jupyter/jupyterhub-au
     │  │  └─ kubernetes:secrets.hashicorp.com/v1beta1:VaultConnection     jupyterhub-vso-resources:jupyter/jupyterhub-va
     │  └─ kubernetes:core/v1:ServiceAccount                               jupyterhub-vault-service-account              
     ├─ ol:services:Vault:DatabaseBackend:postgresql                       jupyterhub                                    
     │  └─ vault:index:Mount                                               jupyterhub-mount-point                        
     │     └─ vault:database:SecretBackendConnection                       jupyterhub-database-connection                
     │        ├─ vault:database:SecretBackendRole                          jupyterhub-database-role-admin                
     │        ├─ vault:database:SecretBackendRole                          jupyterhub-database-role-readonly             
     │        └─ vault:database:SecretBackendRole                          jupyterhub-database-role-app                  
 ~   ├─ kubernetes:helm.sh/v3:Release                                      binderhub-CI-application-helm-release         
     ├─ ol:infrastructure.aws.cloudwatch.OLCloudWatchAlarmRDS              jupyterhub-db-ci-ReadLatency-OLCloudWatchAlarm
     │  └─ aws:cloudwatch:MetricAlarm                                      jupyterhub-db-ci-ReadLatency-simple-rds-alarm 
     ├─ ol:services:Vault:K8S:VaultDynamicSecret                           jupyterhub-app-db-creds-vaultdynamicsecret    
     │  └─ kubernetes:yaml/v2:ConfigGroup                                  OLVaultK8SSecret-jupyter-jupyterhub-app-db-cre
     │     └─ kubernetes:secrets.hashicorp.com/v1beta1:VaultDynamicSecret  OLVaultK8SSecret-jupyter-jupyterhub-app-db-cre
     ├─ ol:infrastructure.aws.cloudwatch.OLCloudWatchAlarmRDS              jupyterhub-db-ci-FreeStorageSpace-OLCloudWatch
     │  └─ aws:cloudwatch:MetricAlarm                                      jupyterhub-db-ci-FreeStorageSpace-simple-rds-a
     ├─ ol:infrastructure:aws:database:OLAmazonDB                          jupyterhub-db-ci                              
     │  ├─ aws:rds:Instance                                                jupyterhub-db-ci-postgres-instance            
     │  └─ aws:rds:ParameterGroup                                          jupyterhub-db-ci-postgres-parameter-group     
 ~   ├─ pulumi:pulumi:StackReference                                       infrastructure.vault.operations.CI            
     ├─ ol:infrastructure.services.cert_manager:OLCertManagerCert          ol-jupyterhub-binderhub-cert-manager-certifica
     │  ├─ kubernetes:cert-manager.io/v1:Certificate                       ol-cert-manager-certificate-jupyterhub-cert   
     │  └─ kubernetes:apisix.apache.org/v2:ApisixTls                       ol-cert-manager-apisix-tls-jupyterhub-cert    
 ~   ├─ pulumi:pulumi:StackReference                                       infrastructure.aws.network.CI                 
     ├─ ol:infrastructure:services:k8s:OLApisixSharedPlugin                ol-jupyterhub-external-service-apisix-plugins 
     │  └─ kubernetes:apisix.apache.org/v2:ApisixPluginConfig              OLApisixSharedPlugin-jupyterhub-ol-shared-plug
 ~   ├─ pulumi:pulumi:StackReference                                       implicit.infrastructure.monitoring            
 ~   ├─ vault:index:Policy                                                 ol-jupyterhub-vault-policy-ci                 
 ~   ├─ pulumi:pulumi:StackReference                                       infrastructure.consul.operations.CI           
     ├─ ol:infrastructure.aws.cloudwatch.OLCloudWatchAlarmRDS              jupyterhub-db-ci-CPUUtilization-OLCloudWatchAl
     │  └─ aws:cloudwatch:MetricAlarm                                      jupyterhub-db-ci-CPUUtilization-simple-rds-ala
     ├─ pulumi:providers:vault                                             vault-provider                                
     ├─ aws:ec2:SecurityGroup                                              jupyterhub-db-security-group-jupyterhub-ci    
 ~   ├─ pulumi:pulumi:StackReference                                       infrastructure.aws.policies                   
 ~   ├─ pulumi:pulumi:StackReference                                       infrastructure.aws.eks.applications.CI        
     ├─ vault:kubernetes:AuthBackendRole                                   ol-jupyterhub-vault-k8s-auth-backend-role-ci  
     ├─ ol:infrastructure.aws.cloudwatch.OLCloudWatchAlarmRDS              jupyterhub-db-ci-WriteLatency-OLCloudWatchAlar
     │  └─ aws:cloudwatch:MetricAlarm                                      jupyterhub-db-ci-WriteLatency-simple-rds-alarm
 ~   ├─ pulumi:pulumi:StackReference                                       infrastructure.aws.dns                        
     ├─ ol:infrastructure:services:k8s:OLApisixRoute                       ol-jupyterhub-k8s-apisix-route-ci             
     │  └─ kubernetes:apisix.apache.org/v2:ApisixRoute                     OLApisixRoute-ol-jupyterhub-k8s-apisix-route-c
     └─ pulumi:providers:kubernetes                                        k8s-provider   
 ```


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
