### PR TITLE
fix: Bump our always on worker ASG to 4 instances

### DIFF
--- a/src/ol_infrastructure/applications/concourse/Pulumi.applications.concourse.Production.yaml
+++ b/src/ol_infrastructure/applications/concourse/Pulumi.applications.concourse.Production.yaml
@@ -57,8 +57,8 @@ config:
     instance_type: m7a.4xlarge
     name: infra
   - auto_scale:
-      desired: 2
-      max: 3
+      desired: 4
+      max: 6
       min: 2
       max_instance_lifetime_seconds: 86400
     aws_tags:


### PR DESCRIPTION
### Description (What does it do?)

MFE builds were crushing our workers. This bumps the minimum and desired numbers to suit to task.