### PR TITLE
config: Enable LTI provider functionality in Learn edX

### DIFF
--- a/dockerfiles/openedx-edxapp/pip_package_lists/master/mitxonline.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/master/mitxonline.txt
@@ -18,6 +18,7 @@ wheel==0.45.1
 
 # Experimental Plugins for AI features
 ol-openedx-chat
+ol-openedx-chat-xblock
 
 # Allow for copying courses to children to support UAI
 ol-openedx-course-sync

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -67,6 +67,10 @@ XQUEUE_INTERFACE:
 COMMENTS_SERVICE_KEY: {{ .Data.forum_api_key }}
 {{ end }}
 
+{{ with secret "secret-global/learn_ai" }}
+MIT_LEARN_AI_XBLOCK_CHAT_API_TOKEN: {{ .Data.data.canvas_syllabus_token }}  # Added for ol_openedx_chat_xblock
+{{ end }}
+
 DATABASES:
   default:
     ATOMIC_REQUESTS: true
@@ -244,6 +248,7 @@ CREDIT_PROVIDER_SECRET_KEYS: {}
 CROSS_DOMAIN_CSRF_COOKIE_DOMAIN: {{ key "edxapp/lms-domain" }}  # MODIFIED
 CROSS_DOMAIN_CSRF_COOKIE_NAME: {{ env "ENVIRONMENT" }}-edxapp-csrftoken  # MODIFIED
 CSRF_COOKIE_SECURE: true  # MODIFIED
+CSRF_COOKIE_SAMESITE: 'None'
 CSRF_TRUSTED_ORIGINS:  # MODIFIED
   - https://{{ key "edxapp/lms-domain" }}
 DASHBOARD_COURSE_LIMIT: null
@@ -316,7 +321,7 @@ FEATURES:
     ENABLE_GIT_AUTO_EXPORT: true  # ADDED KEY
     ENABLE_GRADE_DOWNLOADS: true
     ENABLE_INSTRUCTOR_ANALYTICS: false
-    ENABLE_LTI_PROVIDER: false
+    ENABLE_LTI_PROVIDER: true  # modified
     ENABLE_MKTG_SITE: true
     ENABLE_MOBILE_REST_API: true
     ENABLE_NEW_BULK_EMAIL_EXPERIENCE: true  # ADDED KEY
@@ -551,6 +556,11 @@ SERVER_EMAIL: odl-devops@mit.edu # MODIFIED
 # between LMS and Studio (TMM 2021-10-22)
 # UPDATE: The session cookie domain appears to still be required for enabling the
 # preview subdomain to share authentication with LMS (TMM 2021-12-20)
+
+# Adding session cookie settings for LTI config
+# https://docs.openedx.org/en/latest/site_ops/install_configure_run_guide/configuration/lti/configure_lti.html#configure-the-tool-consumer
+SESSION_COOKIE_SAMESITE: 'None'
+SESSION_COOKIE_SAMESITE_FORCE_ALL: true
 SESSION_COOKIE_DOMAIN: {{ key "edxapp/session-cookie-domain" }}  # MODIFIED
 SESSION_COOKIE_SECURE: true # MODIFIED
 SESSION_SAVE_EVERY_REQUEST: false
@@ -596,7 +606,8 @@ WIKI_ENABLED: true
 XBLOCK_FS_STORAGE_BUCKET: null
 XBLOCK_FS_STORAGE_PREFIX: null
 XBLOCK_SETTINGS: {}
-X_FRAME_OPTIONS: DENY
+# Needed for showing pages in Canvas via LTI
+X_FRAME_OPTIONS: "ALLOW-FROM canvas.mit.edu"
 YOUTUBE_API_KEY: null
 ZENDESK_API_KEY: ''
 ZENDESK_CUSTOM_FIELDS: {}

--- a/src/bridge/secrets/edxapp/mitxonline.ci.yaml
+++ b/src/bridge/secrets/edxapp/mitxonline.ci.yaml
@@ -1,116 +1,36 @@
 ---
-django_secret_key: ENC[AES256_GCM,data:m5GsJxdx/IGkH27WYB7pzlA2thjt8z3a+kBY3hQf8UyFWClV6P4lFtEi/w==,iv:mgcbgXy6HJbZ1BwW0s1I6Eq33ZS+ytrDqoncdD8Fm6g=,tag:SGHKDBC3hYNMZWOViqvHfQ==,type:str]
+canvas_access_token: ENC[AES256_GCM,data:Nmyf9HsWKLDMwoRYdEqWp+Dw1CHXdjT1roa1kTjTogvPlm2Ll3p+PIb0gxQKjHslm80DI4RyZZuDOxxWKKzxj37ZbB7e,iv:RruRtTuMhaSJ0fYkSMYP+FwWK9p1THqBrNUI2Bk2olA=,tag:SF8ws12Q6DpVdU8sjxJf9g==,type:str]
+django_secret_key: ENC[AES256_GCM,data:mXabzfo0s3euIi31AfSt1fVesOhlDu3firdqKVnAQZhT4TMNeEdpFEwRTw==,iv:9wyOtcW3b0YYN+f6+nsBCUzjfDBOL4cqqUf/RcccgmY=,tag:+QAfwQe1HgrinQDOlLN/7Q==,type:str]
 fernet_keys:
-- ENC[AES256_GCM,data:ukhOF1XdL3ZC4NaZj4iMGBnb6bun0YgtlRtoo1YAmrZ3qFZC+hiKSxkF1Q==,iv:Q0tPUhvKErsoQunRtny+YpJ/bvTPvCcegMhS68pq6Dk=,tag:KM9jYdCIpkvStpPk267X2w==,type:str]
-mitxonline_oauth_secret: ENC[AES256_GCM,data:QNcOCAWwB/BrJ7yNLvNCbbXtaKkwaOIK4BEL02qLhSD9y8qmL9OLON8cFcClcM38sMkuhdaqeJ2UjPXR8v8RSIWYXiQWHL3SjQbTmbtV1hGxLpc7LdVq2v2+qvaXvJYsJi1O9aTc3+PcOnZOQUJma+A1RoOb9TAXJ4BYlTd7Wr0=,iv:We+sJPBQFHk45ZyADe+NzJb1ivc0/TMZ2PWGIjcaFPU=,tag:nNeLazOH/m6uDF1KnoDYIg==,type:str]
-openai_api_key: ENC[AES256_GCM,data:2EWJfTfxJtNSk5oyesSiNh0amH5gG/IXkkgFrPPdmkCHdRDW3VbyDY2l0T0BqMY6+85yaxBzt8+D5F3aB+YB17X8fnaz2wQ3P0sYvqbhufn7WkHsPTEvVGCYDJdBXF8l4Bw/qVoWRwapurBXhpJjGMpRAtqjbIr7qcAt504EmIhuNhMCPgdRT3LVJFld0ruBmNxxhuGgydJ0f2tkHj1b,iv:6ZN92RiqYQZUng1IupAeu6KtW2eJ/CVS72OOPxh8ty8=,tag:evtdGG4Y+eyaeYnwgSNaqg==,type:str]
-private_signing_jwk: ENC[AES256_GCM,data:rhMLW3PWUdNNc8zMp6eUYDZOG0jTI5Fuuz938aoEK/LXy3hFHKTEzSaUSdtDxeRj4QhGHTWxmsBTPQcb7jNvM/oa6VN1IVgp+jBMscuCMXnI31D2rQDgbzpg71jjvLPEJiui5zpphU3FzbiB4oEjlIYsxsKd2NJK+dsCW3xH7iv0i/bQIvE1QbmOCdQGKV/ZtTGBuy/WCXnALR+jKIpHBRb3WfN/GkKur2iS4LE5dPgzBUDJcLporVt1SaD5NZ2gnnjb07M5AGhdku7r98OTwwhMAFNFFsKISiATEMKHL/2J6qBbwby/A4NclBvZlmcmF+/U3A2ALCZO78Y5PluyToXJ+OeP/YHTZpScooG60tbz+yh6D3d9kzOf6Sh88UCFGQRHOJtLZgQ9p/vQubP1tiw6SccqhWKLRAa+DOiKN9R95/BwPTZJXhiaEqVcFL46C34ycF5rq00Fre17Gd5cZXAULc4OptnKfbOgxCWciv0aE3vWohsFAio7m/EXyG2jFTbwDtI+f/KjNpHUUS34jXe4gmEzpG2u3OJTybfo++JISb2mDdEqiRy9XF/3fS1GtK0ObmALefd1rlL4+otnkpnAOyuSQkZh8fbh6mH6Ckwweop8Ur8YlXvqbylta4bNduGt7YpID4MsrQw49sMAbbii+RafXY1PV2v/nlCaFtrq0lwMyi1cybfiLp4tV1UE753UjkkA89/TUf1kqL6BDFfF8c7wnIDFrhoGIZkwUeVUXeOKtg0QirLZXbIWPKSw2Wt+QOWWwq/hhWUzd5SuwZ6aOS4tl4F1b8TpTq+/MUokoByTOM1hNr/KPA9ydy90qp3dARF1JlBs7X8cYR/A5Hnhpj/rI1q+4HJ62aOHr5qGPljtY+jr5kkjRHhkHRAoRT9Z5+kC/U2dsglNrRuaXY/vmobsh4m7dGHPPiUdVs2z+92lctTYyAFleZ9tCRod2Bpi3wzKsJcxuIA/kw5FdsO9qOaQPxro83aV77BZwveRTjaX5sZlKu8BrKSdjqCGldEmK+RUm5sCEmKYOG7YPZ8nMR3vtzuT+5Co5yP97RsDkL4v1kq18p5cqEOw2hYrYUiCdLh5Xjt8268fptccyKpMFZUgKeZw8tNRp3glzS4T4m/CkESdHSY2t9bCrLZa7Snm0GsZpQLpb70oMFv/UpRbSm7Uj99ee9fRe96R9KU2nUfx/VKZzNYDoygGnJyt+YxljZFSLI7zhHhXT49LxN6D2/mHWhuIIfWFtoFegdrirwYjbJCEWa57+X9itiFHvh9d72hCOIyuouWY0y0gh+sQdmPEK7YpxtA6coa2OK/+MiqlGviqFZP3A5ijo6vZtOgDJy3/pRoJaXGszQXo2a0uyk2VeVZNojEIH15JmfBEoWeQTaI48FIppWWLny8YKZymgFTBx9V3SxU6EvklmYijwqhjI+DzT//2MfukWCfK30v7ltiq531C9o0lwS1Mu+9tm11kU8CkBt/QpsoKEDIAn6yW3IKacXSa9pSBa/CuTJSDIE4SACT8rFnG6E645kP69u0nubr1872JsWC47cBp1VZQxKUw+Ze8njIUP9qK37CYLz50K83+puSXNf7PFgGJ6/8AFKREfg8H9LpGJkCbMzgTpEhy96OerfaRiILiCNrfyAYS2JDXuhhu5LuB+vHhJHmi4fSsNZk69svMK3OdxYXvPSa0CGBV5B2bNjONgo6XNlM/j2wfYgwrFmwWkMkjMaHLce1atkrBpkwPllQN6cuWm+tYrysZ/dFdyiGl9zlxKZcGbrjpdsmvADms/bEcezRcBxWXfC+x3suCQVMyu2ZGlTex1Wx7Vc1QvljV50HGTSYxMPL3U/gEzZT3UL0/hKq+Lh+tUbDQXJOs7vIotC+QtAKZaxeUG7HjSN//AO7+IaCn5R4r6EuvjOX0HSC8nZFOV5J0dliWhFbrpeJQLoXDRNoF74ghvqKANVdeLNfJLlyYUQfqN87FgB73bzS2z0+4h0txu0GcPhefkGs+uPjzu7zW0/L30W3L7Qv2XFjq7NLJVq8NQ+9qJLYgXarpMQ1IL/f2zR/iC9e9SkYgy+x+uzMAvNvhJ0NhgSJhhYmfuR48XhapXK+UioIuAX5SY/u+PvnZ2OQeBUb2Q8rqAa2G3Q1vYUFWhtckYglh9/7TcjIJbHTgyEncJkNuuAQSRoNRlPl6xQ6kUJzWvBqqW4pRIRVyVOoGvfw+xo7kOpBYkkhsmQ==,iv:e+1Cc0JN247vEF6RvmXkmlyx2moDbOEAeYXQ3gdtYYY=,tag:Y4mbjgg4Xd4KUH4bhaFUfg==,type:str]
-public_signing_jwk: ENC[AES256_GCM,data:HKuKdXbUO8Rt9fh35MzTTisy6dKn0oSsUI1VAZE9OZv2oNJdPTh1R0jfhDSaZi9kRkdhzTr7gYBHoJdUx7Ha+1JpUYV3AFlBw6t7ODS/vfQiKGHeVixY9s820pH6+jeDKc15MQEpoJWLmaRVTb88hwhxaxETJp4agZhq2lfM7sW+YSsH/8duyl6e1BlFyeyRm0YznFjEWxOKqCLab2Nw3IvEqQzJd8WRzZ+zDhd9XU5NcDNhVGSXuvSRwSV/iwrhfcEZ/eNGz5PaOt5Vsdudng3rb0j5dp/vYrtC9/IlbdlQdCRGXuzqImsPksB83H3RHAU0GR2x3wjt9G2TdzoREtizuEr3BedkiyC0BxFwmucE6IerovwgVPbH3K/q7QC1WrXgTF4eEI40PJBBPFzFB8MZTpLWo+77IaLbXn/Ad6doY0MtF36iOoAE73ndY1macn8V0gFC/4yS5vvr/PQkpgnCs7yE/1nDQP9iQJ0Hgg6gTAuWcXxjEJz9tNAle1BPwmeQanO65yrysF6eWmlPgH/19uRWLZO3xff5Mb0taN2KxltfKPA7aOeZqD1Fkjgh,iv:C5XWqjegPNZS1Opt5yP7inZSfiDqQ/AK+eN11tEltYc=,tag:1dLhN0OnuDTRLdQovWYjCQ==,type:str]
-proctortrack_client_id: ENC[AES256_GCM,data:Vo8Ww/vhoRjwwHd+Z/U5SjZ0xeXVgM8DOUHW3YFfnGj0n8BOZl3lIA==,iv:yO5/pnt2JZUe3nKn8rPRMmetDf8JqySc7aLdh+dFavA=,tag:5d+Pta6zn5oP7dCPNL9wRw==,type:str]
-proctortrack_client_secret: ENC[AES256_GCM,data:Pe3lUOOkhSWlzC1Zme/6XtevIx/Mvay0qw0MOakIWGUyDJFq/ZX83w4C7AEuEOk3m4fj+xu/f/Uqk42kJSaF2Ir+NjVlLs6dHv+Kiexvbh9Bu0feC2G5rpRlzTi4Iy2FPsL83fHIauShDCJl/F2sUDZYxW2oU63QhvltIZHLV68=,iv:/YniGddQfTx94Ah06/mU2xoZMdgWQF7I3g3+RantLCw=,tag:PPfDg7br8+ekRyh2T7G+fw==,type:str]
-proctortrack_user_obfuscation_key: ENC[AES256_GCM,data:Fw10zus3JmoEYBzfYWXsu9+FUP3y9wFidIbXmq5SQbUBO6nSzyPrXIJgO6kfTUZ62klE5AzcYXd2qg9wrSCGQA==,iv:HzCht3OXan1YT3Tz3fy44mPLfZLNnLe2FZFIwNZy/m0=,tag:O0LNmjV4iz3LXZ7CAm/c0g==,type:str]
-redis_auth_token: ENC[AES256_GCM,data:u1QfnkQXA9RIcJAmktds82Nc9Jl68DEpTQa1sAbRvbNZ/WRUSiQ6cz2ujw==,iv:YVs+tmVif1I/n3tOeLmZQfb88AkN0QAtzf4AA5fcVKU=,tag:Acj+MYcsIk/6xpUVe51JaQ==,type:str]
-sentry_dsn: ENC[AES256_GCM,data:v8ezI7XOIzjG6w53pnSjIaE//Qawyu6y81m0A/sR8l8IR7olNdnsAuMH8idwGS2b2k37wX24PM8k5MmwB24Yzjz2gNs33mel,iv:p8lsczSvYA1y7rQhlcZiYicuoQtXpuj1aE2ZI7JwxT8=,tag:Vba4nUscxC0/Jh2fK5Wyaw==,type:str]
+- ENC[AES256_GCM,data:WeBz56FmaizBoXiEQo7+gvPxwWrEuc6sFiLpgjVLQUcbZ0dfGrh+jEVoXQ==,iv:u1OA+RWHSgJU1Wbl1Ez2KsqRxxmNtC+Kmh3DU0cu+NY=,tag:j3wMtVCkJQkNxSQCvEL8fg==,type:str]
+mitxonline_oauth_secret: ENC[AES256_GCM,data:x3KJKR/Wi/Eb+mCLi55+hklOD6mCYmfR8kVTkpWVuq/RqMNSInwktN68UA5VlbRH31BnpTliA+Imt+SPEFjRsj/qBdLkaTbkGFXl9YppQDBWe1VDc6usX2dLdbp0WzFvfiZAemExRi75i9HodmEVnawODVTAoBrXqUOo0slaq3w=,iv:JWGtOZVnNMD969lEwnQZZYn/wa5XbAmp80Lro8LXxAg=,tag:ln9WsPe/42rqpjAFJNkhFA==,type:str]
+openai_api_key: ENC[AES256_GCM,data:nM28QNvskZZw7Ftrj/YuecrktPQ1qzgupcL2cuRnlr0OoSyP+Wu6ET0fQezhsaEZ9zZo0y27PrSFI0DpbG1fbid7oMxfWpUfq3JMhimi/DfUrF1yodo389ROsG99CVuOrLKNFnivmEZ6nH8yjb+kwxoJP4r7cbtxipB72/nVl89lgQAtjNvnzLDSF9vMa85RZRk/iC3yj40G0HNNBv1S,iv:Sd56D9Lb+PYnAGM3oiLn8QC5X5ZDEw3wyMHvbXRNh4U=,tag:ptfSM8CbbQjpaYrLX1H0kQ==,type:str]
+private_signing_jwk: ENC[AES256_GCM,data:/nK0FBFkGZAlwzrgJvNQSrhd1PFYuEU+o4aybVhGfvFNGQuxXFr90aIyIK/VXuwFXOXljE8M06OabfaUvmf9Z8qLH974Et6gTAFWoZ6IIyBJDJTh14kIuQyB38CQo2B5KM9mdXFbaSoOLdun+BoQFbEBMXLHzzQkkG5d7P9JHB+osJMUEN1mcu6TWgnXreQiiRTz5vEKkfXyGoilJlN5iWSiRjaYpYHLruzhkiZ53y/UXLfCm+ZRI4CFwzPoKNQM/BlQeVaft3k/dRAOxrEZriV57XNgRz6S7Pxs/Bqb3J2gPllCQBfxbHiZj0J2EC7XJs1DqI4WX9TSVOwKuT7aOo+T7Yhl3Dt6vNNd8zKsVfW3iRpLMAPjfamT85+/aB65yfTWOREZqzWh+YN+eukhUyix8y3MLz6Afsi6bA7OHaQrl+wG170MWujok4fS6H1V5+O0a2PuQrgGOSQObn2qBR6ZMxA1xTclagi5CcBDYQga3PTshqvJV3VH8HIn/X8eCDanprP0X0riKp2Fhn3VRh70tehKnjx9c92LVVKB5V+sFFVRVn2d2kf2zSp2WmEZQLlCofb0zLPqLK8NTVKgcuh0w78pJt9awyiZDl2kdM7VKwsFafhPqB5asB/3+knckJB2arneJ4rn+iLLzYlmUcRwwuV/fHadiGwSOzjCvUNO49SIb8To4SX2JRtzmu+9mbaMFzwwhaOEn+oE5mCaM9V1q0Ea3NyQGalvouV6UsIaGumRM+S0fzX1sn/FUI+rWcyZ1dSHNdRltJupbZ3n3G4aiq/4M/bmFv3tyjWSGBO/HC7PoqNWl8xNp0ep3BPCuAGNSVq2xv0URTQ5Zl81WAKQv3QHL3YC+0tpIo+djLI7Up+Prjm59ki1rPR1iHAASJ6+MxgRPFPXcf9MW4OVrHIhXS6LDULV92gn/8PGhiSzM3diWNh6QOMM2rD7dYbtTZuER8dAdZERNjCAPWyYCQb5w1lwyKTuOkEdRmdf7M2vR22JtekD2w5ROHvvuew173KLZZ+p33kVQWQFojDFnn6TKRfI7xEBt/neSXPbxsYJx2t5/SawaqPmKd1oyevjXiGKZHa4QHizd8mFftpQFDfFmRbvVzIoc/D2AG2aJTJ/anfq7JGiTuUSv2blUdgMQYqJKJ6J3CWVywy3ClK3wB3KJsJK+3Hndu9PPtnpYpIHECIafenpLaSKy/6uGdzFa8OcUmqi3krVh1Ap0C9hcIhlF5L3FNSgUlwt80PTbhtfQoIo+OHEUujcpR1MTV6f5KjC3S4ZO1JgRwYJUbLLW1FfJOF+lxNvXXx+vcgmiwXDCNcGMk+dtGvist6eJV4bV15FZtrqxQJh3WQPk4Oe/7NsME8vG6vuMoXI4ahLs+KVRyHW3nGmfftDhZPjAR1io0iLOaP4qKKZ6Y6MmlvKuHcRKU8cvsqEqvA8KaRXktz9ILBu2VngZvJqrRgVq/yN4BT2Jg4+Sh6LVph+K+vVe35w4b6L5u6vK2AEgoZBY9yLCWV4vCOiOMJWkW5+xVYXembc5IxqasZDqL+SF/uzJquMfrp5KIn/DkR1kjHa0xlPHk7F/V0pRLvPOBGh1vVv1+hJ+7nbcCOwR41R5ryNNLvJxBUj7QvD0UMVp703HvDhOGbE+vV9YQZAZ0butLfhHYZtYJ28fxqpxvbIZihKAc+dXmNcyOuU1Vqnv1oq1jdewso+8BPh/0l1CGElbaSuAikjiaXIJxmGQ4TY4+uMElpq6MglMtRovvK/bbPP+lkbrtSoNMPfy6Apv5rqPqcFRNw65qy8hhacjCrN3cKOic+nWiYoQ0CFZiZq3UfVwv4TZd7+kRW26yjiSx3EFfBDBRrCUfR8vLwuuYTz1sG7FezQu6zzeJA/nyercfRRcDFiXqkDkynop2LgeaVyOKIsjzuX2FXm4ESrMlsDYgJ9Q8W9XMIVp/Y/7EaH17eI3IiofIGK+w9L4urD+xltcBro4ZWMjMuUCLJpUiv9okphZT4hgX9y4clITTplpBhN1GO4XJxBoYZYi8W8dMgvwx/uC0vNUYGt5IGps+AJOgojxfUt5Gb+Fze+RqZgoOeK29cEHillYrBiCrNcrpzyGI8xdnACyCuqqQhAYcifK/8nNu/nbwiKHz7y0g7bpTEyjcP1R1Wbki+mLIT8mSFUJkYOUkuJO56k0UYOKuM5QU6jnXB4de7bTo9jFD2XFSApHuZ/AX8x2yeTSQ==,iv:8TOoPOkrusCpt3sI62NmulNTEvCU8NlRzr1weyB/KBE=,tag:AfMF9b+1t/hkeV5xg+6NsA==,type:str]
+public_signing_jwk: ENC[AES256_GCM,data:8EKEplYyJuE99P9+tcjL5jjz2OjUP/90EpWfqiacuA1Tpwx4GLyUs7hOtWfyG/0cbYRIHyR4aZrGO4OHRXECDrNPbwhZxbw/NtYA/LA1UCBIOHobZJ57SWXFokxgZdkoQzfunFzkxSPzzDzyETbRsQ7GyUftJbrY1n9Y8ZcJBRUw+BHGDoX0fy9VV1J9NosrP5iqLqOMB+xdtDOCq5fQfffHGPYq/zQ99ZBYPMjKq9PlJIz8bJbArfMRO5/pmZjmUpBK4opHCrysygUVCDHvBR16ID8v9HxKP9jBEhk0U1uvp/mQ6koHjrLKlaN2L4vlD7fIBCctec9grXO4SSm2dbK0gHqJoNW4A9TZzaYNlCd4BpHNc/5dUK2TIm37MjatIakfIAj+C7f5YkTvn8hAJX9JrVDxF0r/dvs8bfx+Tj2UhUoWO8mfXBL7LiQRPF+PilDpI0DBLOtg9FU/ZTDet/xQkpV4hMkwy2nnlhrMzAiTb6WYDX/SDqdydeu7Ak23e5Ko+OdAkGtfwL/nSwThyxwlm1+OBzY66jp1ZnqYRNZ8Eg/Y5WU0DRFEBiGn3WLR,iv:hsagGk/S1BMaR7dFe0Eh6Vi5xofCK6qxouByRFXaIfk=,tag:KEQv6slusR9/3ZYjXHa1OQ==,type:str]
+proctortrack_client_id: ENC[AES256_GCM,data:yQi/CLAckwYe8GI+aaZWydEmwW1s9Rf5h2T5LN2YgSRxcoJlYslJWw==,iv:MDa/IP09gN20F55bKDYuU57n9QHG9tVGI69enukKFM4=,tag:AAYJqcaWBNm+Nex3xD0mWA==,type:str]
+proctortrack_client_secret: ENC[AES256_GCM,data:oIrZhFsRfDrD0x4a/Amm4fOAq9X0AcQWSs0wV4ViEk3roXcgvlGaKvAQTPTladBpvd3GE4cl7qsvkqVyS6giLD2FuGqr6VSzMpTYUrHGIB1ZMbFRXIByNWaI+c5j/ysZf220/vbSZz7H0ziwiStru4VBC++KkGSYFdHb6xCE78A=,iv:S4eZLBY9WWCZ/wj1REg6Jqy93Nq1a7C1sw1oDJXVPbk=,tag:QCakJf105xqgciE7S29jXA==,type:str]
+proctortrack_user_obfuscation_key: ENC[AES256_GCM,data:kI3rLqYtlpBkiyXfTLjuV7wB7QxwPPqO4juYfpmYvqYYFksVDukCBjRYXVIdaDPqp9In3CqHE0HeXaXIgTdR0g==,iv:z4KBsDls6kb/Ib/6t3DfPO4ZM2vPhMjXTxqVzFFQeb0=,tag:Zs+UPeTycDMiJTh8SjdV1g==,type:str]
+redis_auth_token: ENC[AES256_GCM,data:YtRhZEnHqeeA3u+I62vDTMhmz4jpixiBZwInoZ7hJwmpVWJLnz9DI/0glw==,iv:CFtllkPCPCjOuwJ2uRa1p0i6XZ3G223ZrB+cyt1YcJQ=,tag:wwIIFzLUaRQG27oIBxqySg==,type:str]
+sentry_dsn: ENC[AES256_GCM,data:DjGv8+M9KnjhsG4vr1C6kHP8sQr9fd+avZGAiVnOLg832dWWv4Mf3Lj/7izh5GN1EOVkJRejU4F1WdfxD0t4GTIATuN8a8Dd,iv:FrFiNEj3O3MIlhhtaoUqAN+n2C0dt5kdeKdX+zWGQJA=,tag:XKqYt/OJZhcBV5LYt0YR8g==,type:str]
 studio_oauth_client:
-  id: ENC[AES256_GCM,data:6kHQJXXpinYMce60Ycm/OGdE2KqFjGWi5D3uUNFtaF57qI0DWUebjw==,iv:luTIoezfN0LSDAstjHIYhepphqbMSGcrTOatcFIgMMk=,tag:GZel+RPIZoUImpcqT9he2A==,type:str]
-  secret: ENC[AES256_GCM,data:ALQHu+ttr5pT/Wsks8g2Vz/JyLj/oUb8tFn0CakiKzAPKmoAIMQ9l56T8U5465DvxtHFd52viaroMPMNv5ZTV335pl1KVUIqOzyM1AUTAtNYW6FPOQ4neRgwBBdXjDXqy9RHHe61d8yBnimh+1M1Fj1UfRQpjhZSX3/JvLCsVSI=,iv:sbnyQn+o/KxCKEM9jFdIvGXP+UW16Es/cVsCCNpymXM=,tag:An2IJxZcCPqJgpnM19xJcg==,type:str]
+  id: ENC[AES256_GCM,data:4XkM20L+SgNGVLJNfZIT3MaVKY050jshoEhvOUbp2/CHdJCpuGQ/8A==,iv:evfsmfpUtSRNrlsuh+Ba8eL6/0L0MOAH6OqHkIe3cz8=,tag:IgtrDi7TPnkbYgAI171VGw==,type:str]
+  secret: ENC[AES256_GCM,data:7lYrrTspiYJngLO4HrSfsA1uCUzkz56MWWVr+XHN2O6Bi6fa/py4IdOWS55RCGfs5NIeO9RPsRoTtyKSVXKWwQKw/+LqV2WvF2uoFK6mvkOzaEDsgv6+wu0iDU/pIk8n42P1VI+yTmuAZV4q6WNlD7qEqqSd9EHC1Z9qvY02VLU=,iv:RYyrdhZ2QcBbPlzPMjNxgPJE2E8iZlBXIwKYLqXzEAg=,tag:tgg6V+Y0ynYie6q78faZ9Q==,type:str]
 user_retirement_salts:
-- ENC[AES256_GCM,data:CElwgc/FsYue97pCfNkx47KTuTCUX4VwqTHdTmNDv+AhyxlAMbFU7XyYdw==,iv:+YunABfzL2qIkqq5jrIR3ShcHKOAZ3gH554VuNQK7q4=,tag:mZQJtSDr1s40xz5g95cmhw==,type:str]
-sysadmin_git_webhook_secret: ENC[AES256_GCM,data:4kXM4cSucPvmlfOWZe2pVYuikWzGDRPm5biuhRuRIP9QRK93VbBN+Mvg5A==,iv:Et4GKv8B8SN0VPwNuaScly4PksHtpnosFvR3QLaUEr0=,tag:QbL1WSWLe050M+GBl3efoA==,type:str]
+- ENC[AES256_GCM,data:hQcHuunoj2NaLjFbKcITgziJHzRpgf9b43T5D44uudZk08d957ZkiFLI7g==,iv:/lsiiZYXvJN+HTO9cDm1UTXmpRet2nM2E2OXG/xScMc=,tag:CRIoAnBGf4skrqm5PBKlYA==,type:str]
+sysadmin_git_webhook_secret: ENC[AES256_GCM,data:3faJ7pjORmlsGSqn4oYmzN/TznQSzduotNmYgHlQLwJpYY6Z21Zx6OQvsw==,iv:vYrfFB2dG1jK1UaJDn8BF+tST3IFCoyn6houoF5v/6Q=,tag:I1jEniI6SEvexcmtIlF44Q==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-ci
-    created_at: "2025-05-09T20:52:13Z"
-    enc: AQICAHi3MZ/Pjy2dahB1Qm+zKkKDPV1b9MYPGp7k649HPjmOHAEIYFOrXSG/rVd+xvmgx6OxAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMOEHRoRuo/KM1d34sAgEQgDt+InGnbvHp1Uxqcrpq/60dmIWKTHuVw22DMAGgOxfpYHZrfAJjp0FeFCyO62Ydm39RDQLB8NUQQ4C9AA==
+    created_at: "2025-08-28T20:35:02Z"
+    enc: AQICAHi3MZ/Pjy2dahB1Qm+zKkKDPV1b9MYPGp7k649HPjmOHAHlqCRlxIfgpLm8bF77GeFQAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM+8/juNZp/oUFKTgaAgEQgDuDSA4KTjEQVCLPa8Txo55rBIDSCzCvas0Kca8QUvtVGQ6IlPtKGiftrQ5UD/VxX56lOqJd04shL814HA==
     aws_profile: ""
   hc_vault:
   - vault_address: https://vault-ci.odl.mit.edu
     engine_path: infrastructure
     key_name: sops
-    created_at: "2025-05-09T20:52:13Z"
-    enc: vault:v1:yp2MNPTiKWdiCTzWQQbGEnTUXTs566LzUlki7as0jeJd8NvEUPxxRZY0TYpU35DHarp4UKh5mVu/QwVw
-  lastmodified: "2025-05-12T20:47:06Z"
-  mac: ENC[AES256_GCM,data:oyW3ErFdZAGftXjsT2pVr6RUQvCzKRRkYzJc57eZGZ5tML1B+SM924WmwU0nxUjw/6zInIZvFAlasi8nrmPUWI3psPSnWW1OQO1QeapBPINBRfZEW5EaEVN2RYptkfluZ2z6CEIRaOSzXimp+oGUQOBiPLKaMjFWQp1zDkVkv6E=,iv:OKSiBefV1H7mgXjvEFDzzsx3o+lcquHXSIKqCyqkQcE=,tag:UCPaRwhZRoPjVRAK9g+sjw==,type:str]
-  pgp:
-  - created_at: "2025-05-09T20:52:13Z"
-    enc: |-
-      -----BEGIN PGP MESSAGE-----
-
-      hQIMA9YmDGFr0PozAQ//cPkM7Kg9/PRqFBOA8VZnQV22wwN7JhUOSjMut791IxLV
-      RytvRZn3g0YNftr3AfBxsNGpH9cjVj4UQ54PziSybbhd11fijrKYEdb6TZ9pxTKW
-      GQ/qnxr2/nIzxUQZtCgJgWw8WPPlfDhu7vvpgxdiTgm+PUIRSNhftEcC0VZYomSp
-      2H1pgBCZWrgNTqX/IKMh9WiJbD76qVvQtgFw7Qivgsl/7YGNWzagLl35Y05q+iUE
-      B6x1RjiNO+1myXoQrK1GNI+M7GDxDFEh6YwHWVpMO2tdBEe4Kadw4vPg1zRi80f1
-      YBlkqyEB/QhKdNihymdeQKvciL3mSyNMCNZe4dYhxMAScsep4LZKV/Qgpq++3iyi
-      qsMJa0p18DXNov+y0nRtJ7Gdlt1wC2jXJSmtSRt/py7km4pm6t2xqywImr47s02v
-      SUX+7t+B5Pfq/VjlHl7TAHuwpy4uLWFP6rdn5c2EYHlgdh+cl6wqGFCVd3QcR50y
-      0CY/CA4LzpL/6o3NBpZ4ockP/uFTdYoAxSW3A1zj7JRPAGL9qV/Kl3sNyfOlftSr
-      az+9Kq3jjTCDJjNqPR8AfDSCRjquy9mngx+GM2ccWv4fFBKZXujr0qoRHLY7C67n
-      orF0dnW1jtFAKOxWbPinSQlO+vx/hpfW+RLVRGNGoTJychzyFGx6nhr05W4VAWbS
-      XgHX6UVKujYqihKD83Jqx/E9pZ4NN4dq5QESGAOO6M3v5pz6um3NuvutQXEFRgl7
-      Sm/gMPvzdBjh24G3Xv1pbHQSoP2E5i5ieplNDGt5Rwwc31ZyAEwnHXfJ0iEzFI4=
-      =zu1K
-      -----END PGP MESSAGE-----
-    fp: dfd1205a98269f34c43c9221d6260c616bd0fa33
-  - created_at: "2025-05-09T20:52:13Z"
-    enc: |-
-      -----BEGIN PGP MESSAGE-----
-
-      hQIMA8MO7RiKjktCARAAqJs3Qtvq0TNtB1RJ8pQgG66dSNN9gTkH7NFXxiGRlGyd
-      p8yKas6K1dpWuho25QeMGy/Sa8d95tpg5GTiQ6YWxtPc2zNU0RC7cnzuYUxIsZ/T
-      DcANzCQchGRxCaSzTbmVSCrAy+p8XCVY9BCRq0hKEq4fATTCmagYLD+nd6DjXdDD
-      aDlKZR0/P+8D2Y8ip1T2znxm4dRtRxKXVm9yEEtyCgy2axNZaqL9FOvHn2YUtSM4
-      cSe1eD6T75Qu+hhUd2laeeRpsUG7m26/vvLP8x4tuirYIUB4TQ/FLwqD5DM6T5Nt
-      nxw9q9H/3Qwnq4VBh9D7D4OIQGSC/pBStqxxLZtodxVQZDYpkNAAlA2GBN5W9wRQ
-      bPKYHXrGjoRGpz8mXPKUK3HAKn1YURXjXF1qucreZzRYxJF7eO4HwkvWPuXNsiJG
-      KDBZCDB0SMYL5UUTN14bpRfaQvuGKO6X3kOe98sWfDYDeaAon9GBA2M6yXewb3Cd
-      MAo9Adq+AEM1A0TH1IBW63O/d8TBm84O9oH+/msII2lkbQEIMF+oDgX1JrfGvgpL
-      EaMDvmlkQEPJHHVCC+Dt3ZFkqtkg8opdYQFw7lUIUeRk2Rideqf5dM1yA3xlhnN7
-      MLXNIi/E0FLX3q6HXNjA4pKFUaEEossfp3qQDtza74eabMaeJ31+C6Aee+EGiHfS
-      UQEztA2rEoKnEEjvit0i47ke76MzhZ77ViM4fRR508kX7tag8x9cLNorzm897zE4
-      u3aXcC+4DRGMvhf+cAE1AQajOcLKkLaYAlyhUS63myjKBw==
-      =m3Ur
-      -----END PGP MESSAGE-----
-    fp: B905F0256A801D3F1D15B5126A1D27A4BE75B1C2
-  - created_at: "2025-05-09T20:52:13Z"
-    enc: |-
-      -----BEGIN PGP MESSAGE-----
-
-      hQIMA53hirIFs7uxAQ//XF/c9gfN5ZzE8+Jhv3QeN2DBtpvFQdpvdamqYIXvJx/+
-      YAKFD9yrxSofKIOzK5YugISOobmV+GpG8PlGVkafZoxlvBDp+0mDOXZDEpviV308
-      zGHP16QdFXW1Xr6zxVExRciCtEXXr1OaHyknfvuNT87zlafpNNyctPkYGT3jV35e
-      SKiLA01o+YdiKthVxaIQ/sWPh3QUDh3JPwgrt/rLI0PtXZIowF2dpHhcmNHXZlwI
-      c1gvDbTi3AWlwEFC1QOX+3BRsxNVQkIH5wt4d161Kp+SVvWaD15bkXeGVb0WYg2S
-      A1YqGnvSXlCnMTovrD+0RZ9zEfKLWZxt/GcW4cUknv2VKWBPbbNfOnZM0vJ++hYQ
-      bh6RyKY/TwroNXmfoVy6P3jGkNduHZz8JElLPuy1tFT3HRjUApKws11/OHSCgEMG
-      Nnxu7ql3LDfciUQb+Npax4TODbJY/UlO5xtSCrllsdEGnYPwR9/HIU+ZCARjYiQm
-      IOPiwFrRjrs2u1DajHhlNgiu9cGid6Ozfq6Mo9/dT4WTRauZX9gh/xaZ1XkvGWVD
-      031okUJVFKEJnMiXyjo7MnDoPFG3OuRHeWzQBM0FEerD4m8hxzyBJFSSbXtYHbm7
-      CCgrYLMfl+G8V2nRnZHPECH7PRHiOi7uf4+7Gh03X2gMWavpRWe093IXqdcpEi3S
-      XgHbNzl7ljxmK5ya4XoH9sMfIbjY3VnSs6zxjAcp1ne1l5LB1xcrfQNZg3seS+7H
-      HVJjIOb5qV6PKePL0/LIDY+CbGU81REYjaHTEZOdrpkOG90pHj2k/WTLe+VU2gE=
-      =GzAt
-      -----END PGP MESSAGE-----
-    fp: 07083D36FD5986B0C99700944E9B358045C1B176
-  - created_at: "2025-05-09T20:52:13Z"
-    enc: |-
-      -----BEGIN PGP MESSAGE-----
-
-      hQIMA8YdB40JfEZzARAAkElDa5achR0ex243tzSzl0lGdGq4Vjtpnand8DKfesQW
-      I89rAoslcqh1+7W5iaFeW4qGJ3GnqnJ+v6vlmN4ukSo/58COfIqgZJ+v9FVJgsWI
-      ahZES07pLR8k6K7IvQ8MwhQQ9UMMFhZCzfmWOjCXwZsl6IaDr/j9YL5HbiFsoEB/
-      BF6iFyPBBflmXtG1oGzhVL2XYR/4hhhd0Ws8a+QryhA2yX6gzaATSt1aaha55DnH
-      FhUu09U/ok66wkuWWr6Smun9+R8wwFdgzZS443MzZXpZWA/YsfxiFVu+eFwHugrF
-      Ts4R+D+2BEpl9eUfTRTpO+BunltPjobOZb0zxCfvYBHlBXnfb7UQaiN9Vsaj6uCB
-      KKBiqoaQX75pwsM+b3++Ji32YDjzH2SMGVJMSl8/DNeUQUlbU6qYKeoUoHlGaiG9
-      qmr3BacbZEfKMAgTTwH+ulrErJfN4lEbN4WxbyV0gak1/RybS9HUPnlAp6OmWY62
-      RdHTwG70cc3eqMmTdDRTUeZ/J/BG2oLndEgWNomylF+srynlntf49sxGycP91Vx0
-      9SucGbvK1l3imoCeEU6mtSMjzv5T0flYXfwXq26C1Htk6HsCHOjAsIvtlNc/vj2C
-      KYtIxR2DLiSjdjAgU3ukIfgqOegbQtNp8hwGMfMVNjQ2GVvrDkX9hcx1B19aeozS
-      XgHtQeebXqKmq6jxbl+GhSHGV7CcUvdqbgpcruYxX38lmjbpyIQoEO1BslVLRnO4
-      tFDuhblwf4eqOK2pkv1iwCV6KC11+roRHMtkB7mcfckDNldPaPh1auTASeLM8sc=
-      =2FCW
-      -----END PGP MESSAGE-----
-    fp: 3582AE9F12CE295BDAF545ED17A5F53F11681446
+    created_at: "2025-08-28T20:35:02Z"
+    enc: vault:v1:hLtAum4sTZQgTXdhB78kGsXPj2m02TYFy2pu8dVo/akd0tPpmEzN8/ax0iypvf7anxbrMTCXAMNEm2Uv
+  lastmodified: "2025-08-28T20:35:02Z"
+  mac: ENC[AES256_GCM,data:jEkqi+ujvIcQOsmXmPURBqWtWhp5KAFbErPWXikLGiyJ2vrfEVFpCYFU9NwIJ4iXB40//u8gK/3TKV7MbWs9GS0FZ8D2dG45LozMQnkGSDJ4HvM4lt1lO3djhXOPDJWu5/LCzu6NjbW+EPQh3ESzkqVILJLCweKLltHus9Hbhbs=,iv:2UILOyoBPduoPFPKjeEKXuUlmioBRKc5f8iFzskCAxk=,tag:ysKjIN+CLRTals2Fq+PXsg==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.10.2

--- a/src/bridge/secrets/edxapp/mitxonline.production.yaml
+++ b/src/bridge/secrets/edxapp/mitxonline.production.yaml
@@ -1,119 +1,36 @@
 ---
-django_secret_key: ENC[AES256_GCM,data:D+UL/yaPa7UF1M/2PbV+NTm66OXqLob53/rev5/emmQTQUz2+gSGPAaszL0oFwI4ZYZt40bEQ/9oU+jWcobnhEd5PuJRgYH2WQ8=,iv:lgH4oIeXh+EAhVAGMKls5JWBvkxQ53mnCUkLUPMbvc4=,tag:70hblO3a5iF4oVacRLbOvg==,type:str]
+canvas_access_token: ENC[AES256_GCM,data:IlkTOrACyKgVfp/1x2upB5DXwGVQqIJfbmsVYCKk2I9VDZenYL20hIOJi8043Nr6wRTs2fmHeoczets/Ll9uDwIH5XgA,iv:1U4pM5EmRtEaXRyP79GK/cjJWNxctTjP8dZLzGLynUQ=,tag:6EeLQO0DCxJUpdHJaCUkag==,type:str]
+django_secret_key: ENC[AES256_GCM,data:W+MBjzmYluHiw/++R4Rq3+ud0le6oON586R2oYRXlFyOT7oTHkMiYDG0A1MuyUxWA1xfS7dP5XFGfj5JJkafnheWS4rZLFX28v0=,iv:paayLYfMDD22/u3nUD11eztQw0wStMmWZrg/hUYtrJ0=,tag:lY7004q3IjwdvG5yX+PtDA==,type:str]
 fernet_keys:
-- ENC[AES256_GCM,data:GiguadB+EKdoEGK/BAuYMeSo98I7MoyR11/XFpVb67R9fuoKqemO5aVyz8s=,iv:QTnPIETZk6JLF1bKSSjVaCykzx1nRw7A+Ym0ue9k8UQ=,tag:s6g1SabhV1+lMRK03dyw1A==,type:str]
-mitxonline_oauth_secret: ENC[AES256_GCM,data:0ltR1yUIz0Uu9mhGKiSGY+RLad67y9rhSqrnHMK481VeZUlPF+ZdvwvBuf4/O68L7MqIAK7FM5EQ5xU88WHJrJP6EwWvtlkIJTLglnktHUtJly+2Cs6ew0kpZzxsEfy5mnyVBFF1UJSm7TstSWJC7d/xfEol8QR4ilHyi9EY2AM=,iv:LzuSdkmbYNef0oESiofp7dNtW5Z0OZ+2NvwEj7H+UK4=,tag:1Z1ZkB4mACkPEEOYtQbEUw==,type:str]
-openai_api_key: ENC[AES256_GCM,data:LPHXWtcs+GVLBFtp24kAcrmB8sp2w4HNmVT1wIwQGwGwDiFkdgLNMxmUd2mCNjNMuukCtWL3vhOjJFB2LJtk/mqDQRXl3t7pVPWOsRVN8VVOeOpPLIFleaom7F3dHFmzmMHAdkKI8Jql/JD+H60qslB40yvaG2WbDbI13I3Roo/m/wMyaBUXnCKhEMaoO8CSEVl80hYGF5KKxbFOVqEYIg==,iv:QJNmEDzZxDnTTPg1F75NAqcao8haYY3pCmgdniFULf8=,tag:s9HtihHInXarF7zerzhrpg==,type:str]
-private_signing_jwk: ENC[AES256_GCM,data:FCQO+w54QDG0BdnTCVX17gpNJ0fsaadPmNoZ+iv2Ib0irzNcs9lvcJPisBlc5SH55eBVeC6FxFTDpGzDyfDofyOhkzxIipqLeEsop+kJYyBSgb3dqbYKj2sH/pRfom3nYsSn2a9t2qh+ttM1cSdMrdBzXK7J7S+JZ2jspr6JMoAnWke1M035J3Ito+ah5ERnQy2w1aCYsvaN1yStRHSEedOzodZ/97QVlQtVQzsU0wf65qQboMVP4VnKBZSCmmUUURR30GvYH+dIMXQZ6zLdXGUzi3uwGfX4HQOfKLIC2eeuXOdmyEI8Gel0gZ9Vr13mgusJiS0fbwElDTQEdiHgkgX5hhPEmrxkxUMVMvEQnUdvftaa67O2ZKvoUeXPuLzk5NbDuRpktyyJzoyk9QC5R1mHtkWTYedqv6422MkJZPyroZ1xz+D4Qrib2UVnwde3/IhZMAdOD0OIkSG/mMJ88iv4imThpRbD+qs0CtQK8ILzRXXa6yMh5ZJhibXZSEffJ4hk+JjJB7iJ6Gr6lw1QlcZBy2qTbEg/PnokRRrdp5IK4rir5fNoulP/c6ua1nQJkT3yuKsGDePLsbl6qug8AocsIv06xpEC9l5fKoJ/39tscfwQH33C2e54+jBA8LscELQ9wTOkDr+QIyMQvyY6pw1+VcnhqKPY9OBLYj8UPh0FXDTLeVDC7S52APMYqmQ8wQNJ7uWenvJB6FbKOwyI2fZM76ITXS3XW0P35odFOMi51knK8F5nzi2Mpvh4K0jP6yek7j47WWylWT3uDxP0XizHqZyMJ1sjwxss2q2m1c/AVY/b6ZvNEPEeRQd6tj3j6LNH73CS/CaDOqKiGiWclueyqHqYJX1XXIvgzJgfYCxZ/zHf/zOVD0x+6IcJDcP4vrk71MznXete5+8zDAxvTyhNvulkyYgd57jBFWP6A8u9cBvz3XWXwQ+faYd5vLU8Cm0Gs9OYPBnPVJUa+Dy0pzcRNc5GVMrUQXBnpt45K1wSASP4KqUdq212RZPX6k8mfdnqhywqB9QUK8uEFeamBSJRRs4w2bM9Q5UN8EOF1eWDo8Fb8jhYKz9dicTk83s4qaAAHkXvjia2zGsri25mMly4fvAdEWGyWY0p61oIKlqQjMEZyjrP/4XugGplHaRLmpvvxkddTxc1FSNSS55ruzuX7jtM/NnKgKPnjujjOj5gL7689arsJmpQBSMmuYgJOlq3KL8wYDUHmBslruzQ8bJmNbFXdwZaB0I9L5X8zIx9xBKIy8/DqpCtRKo6XQS4kwPgRP+i7X9+ilgbroR/LGPG5EAtVEOCOr4IETfY5ZSRtMmcfQfS3t4K2BpCwTicuEwvjRo6NjwpXJGj4AIegVAuthQEpOXUINs6wm8/wRdrMnhV42UVn5UUDsGP1yxcp4CRaVFJZuHZ53YWNtORuSpE/QIJLQbpvRDSRkFk9S5ndKbn5Dn3qEDCbsoq0TqKgY265VNw0fHe9Q1XtHKRZVVEnMls4W+p9UTdOon3230reZWgsTEIO3NOxnnP4Hk3ZtqQFk0TNjfnQEKXZn8QfHyqd00gndqSvD3dnntFJL3tgdUMtg3CYv3sucfYZcrNBV+ozEPXL55fCZWRRhaguetf/CjgpjetHTfpcxKHgbvygLyhgeD+ZK9kmsK+asOlRGG4yhdkOHPRI741e+BUGq0mPqObpN+tgmg8eGEPWOpCr3IAV2obsFybxkBwDU36nUKDNf8kEJL5+GTdALXkpB74X0kw1PBtakurniE5n8nGJkdlOlJq98rjVN2PXT4d8ukXPL/VbnuiCQbF0vu52ToixreiL7S+fT4wuu3/UGaaaGRNHYfd+bLE6Sj1Td/b2VV9N0A7ZvFT9vjxd0K8yZU3DvzNvfr4FeIJ3lGIBNgweX3hSFCNKNWPWzrqr9bUqiZX8Yxp1544xHjBe5IDZMmT8w5mv8/dNRCykxIsreMknUO6XbH91o2G1JK2qRg6peDyOZwp5zgEzXgAqNGz4i/ZXhZFwrE7GB03dINBl8Q17F3UJfhbNHnGSuPq1Vd5POxUzHIoJ6i7s/4t9c6xkaMEI7qbyGR135j4YfFbsze1GGe3YVUbegUhpwraBC5CxnFcGffETagfKD7JVUV7LBVVkRttfS71pxoOG/NIIifs+5orqniF19p9kNpZGQGeWJluqcYZsk4fQojHzsWGAw0s/q9TK7B779oWhJh09NUeVn05IFe8VA==,iv:mysAKPhMhfFerMAmzP2eB2G3HFQTx6/lFLfTkReJPaM=,tag:e+dD7YWDUVdBHaQgcQgEUg==,type:str]
-proctortrack_client_id: ENC[AES256_GCM,data:33k7left875pSBMJMqbUcULP1qrf7c91NvX7kWiMvqSIHU62+X71rQ==,iv:jS2x6cjkd29WJWJ4MjkamFcU+sV97SkGpuxgDNtsFZw=,tag:Z6vgFYfS+b5jEbbshxAZlQ==,type:str]
-proctortrack_client_secret: ENC[AES256_GCM,data:b8QDqg1uMOcU0JqXOkGKgyDNRT/mEFLNZ68MsOsoCLyaXGucE5XnvXnR1S10tb86HwpFZKSQnVQLeqpEz2HOwDVkYvzEPLJsKM7PpYBDBdJSvFgBeLtTFoMzkyNbMX0IlhEanfTaapeSgH4+lLeJtYW+MmZmawWwPcoVNUMjMeo=,iv:LM+4pwtv0jMRcm86MVw0TDLasJWzwZ3Uk+lBZdIOzio=,tag:JJhVM6IBF+SUQqG6x5s74w==,type:str]
-proctortrack_user_obfuscation_key: ENC[AES256_GCM,data:aGj/QEVOfZ4jtd5dieW4s96o2JaDzaG10Bdt/dJFg1C0DgsWJ7gARWmo3PvMAuDL+Oy6fpRJs6Rucjh/hNx6Mw==,iv:CzfF2pQuHLdmFloRZd36mstfZWstjn294FhgHIM5YCE=,tag:aHam4TXb9/AwBOnvL3tX1g==,type:str]
-public_signing_jwk: ENC[AES256_GCM,data:4FHZVekSXs1VEFHqJrFG7547FXTojKreyt48pymKadTOYi5KUgG6INBVMwAnm6HkK1B4rVsouTGXeeCbW0qLv2tuAGgWbGJjN9anhKpcVz+BsJ0Wv4yVOtKYsYayicqJ2L7racMJn+KLfFZaMzMDPr4CoZRooDnC3eukwHAg8P6YWcURXZBDeSEbnnSnVK3GSZgPvtKh18VDqimgnmJs/TzosUQJuovDp/6pDEkfRsZ+ZKI8hlVZAPfNePR+bwsPDr6NidmVh+Csu9Kc33Q3qHleNzbJu4548mZYck/k9gMfCi+LIGoocUjheHf8JHKBcS2+ouPBl2IqiRmpXD2wXifZ4welYHFXf41/XVV0QAEZ3XAcMaY+RzpA35boJK5gheKARIEoXc4D1B3sRNnDSh4PZNjh2MsOTsVCI6pwlhN7cG+ucqxAGPWFs+VIhuzgsLTrQUm58MmGuFzCjXudyy9Qs9JicAetO9Au3sdcoxFPJEQk4CV4tAHpe9PWaf0esn3kPP0dgEGI1qjcmO2dBb5V7eO2+EY5SONgQ9SC/+HBWyjjdS/s3EKcAD3qf3kWDOD87cn4Yp1rXMB76pIWGNpYXgWnC4Y9SKY3Xa21ZCgbX0ZZbdCTZvfmzQEfRZjW4rEyRxhg1B1m3P+xhBhcasmFhngr1KjMBJafDHIvqhjfsHFbD1f3g9VVza2YwYblE1hnQFrERNtiRr8Jc0STsqSknNhqPz1SrSwrJFFYuW2XKwWufAmd6OtBjoz/O4eZo3IMQm1j+JnKVDDUBEwyvGeTfnGqlqrtd9WZbjcPOycHlAdBS7MTXQ8mUk75zCCixDRJK7pGkdAPxJcIxgbpYmHPszktsd1gDtLqKJvVJaibvibUNH00YSDxeCYuZ+oht5JxgDc7WeZcnzkoEZonKfebmcGudC/2rt2bf5TOaEFDYkfcHzLKtCMQ2nLvFzs+XrPxMWKTUdtLi75XUss9EChCU9m+jBRtq2WaJoIeFBY7dSfrRCsGS6amSOzQu1n2Z37J9reOfFub+ZD4eqU56UPh01PDzGpOIbvAKrNpeaWU4V92HfNPnZ3+tQorMCvE8Nr0mFbk5TlLyF89XG0How3sVFtVOgFHXDYiL74EikcZEz5tcY1sonPtS8hH/JcVL1f3sAoItbjKsW/F4HSavTatnUk4DepiWd3on8chBON7/81GizSfgTZc4886UZChKRfkPWFeNVFcDTD6m+ZcSd9BvMJHXb982+h1qXzVCokV6mvI9tqpPyUg82WkHIximV2B+yPLsoPC/AVYxDY8Cx8TTrLYzJsHJlZXYFyAabMUrjYAEkxtTtpHozDCNa2hA+J3833BUagS7IJ6gZMO4uMpA57a/QkKp7aWC10mY0gmVcdjRfaeRb510D+nOci/ISfU/LgniXSB4IKJEdFijTrlWq3Fx54X85kWd4Z3qiN88HqoTxOuIQXFnpvWPZm8r3XKTvLqJ5yH6olMusEsFcIA6aBs5MYqV98q0dVQMFUkzLT6HbwgScD6KOSKPJ2SAfalIxDhC2x2WfaK/5CBGqnpXldm/hivb0phdLl+1znBXV6xD5sqUzOUCPKuhqpGcti2IF9IDaPH8bl7r79zITM8JPAO1EqSeOK7CGDf,iv:IIqgRbzvhELEQ/+dUzgsRHkVvLN77KBJrg7+FBKWwIM=,tag:3u1gBQyz13/xOMdntLmy1A==,type:str]
-redis_auth_token: ENC[AES256_GCM,data:da4gmQMltv4Hv/eYRPfQumYbEGwHS4JSef+7KqVc0UTLcmgWLiA=,iv:STP1WuOJJWPsVdlQwsdsOdNuCKQ4DjNrRnTB9eX+Ucs=,tag:rBdEUL6RlkWJSx3+RHiKeQ==,type:str]
-sentry_dsn: ENC[AES256_GCM,data:R/pExjS4i5zR4KjuBD8idKZo6+/1tOYb/VM2FmqLrztABsyjKKRVzpgcmYuLVEOuLjFbvpqf5gPnl3PJwqn0HujmP+/cw/Zs,iv:N0VG4tJhGq5VTf7qEV49frGNmzFT3C+C9TKuiEqNmt0=,tag:8RxvPEziHV+evAcmhozFVw==,type:str]
+- ENC[AES256_GCM,data:77mgi/35x6zn8hb6uSCHmZjVxaUZSq0SOrIYycBWqVuR4sOpzpdeVPNEG9Q=,iv:ET93vrEjZvWHOOSKvqwTexjd1lAPQHf3C31I01ZnCXk=,tag:j8Oho+6MYIlgTEH/rSEYjw==,type:str]
+mitxonline_oauth_secret: ENC[AES256_GCM,data:bApVG2hJ3nFh/i+mslyi1dAWTGTKvWH3aUy6G/RhlMWtrBONa8ZOCmWyK08riWCCPm7/sPgAsmTIfWX1JQPmWYbBCMHwiaO+4/NpxJrhZiq79XGJ7aBNXuQ6Q4R652cwIaQync1IjpazijZrNk3bgFA57PSxDEXxQWVqVE9Bh2E=,iv:ktabTzE7Ahz2740hQtsHtBLfKxgnEAkLkDRSZv6IPbQ=,tag:6bpSJuA2RGr8gxlxpywFZQ==,type:str]
+openai_api_key: ENC[AES256_GCM,data:KbQO+G6fl0VEPIszIkA4V4JruX7IivkpQoPYu+TKt0ApAa+xNJ8HIIElZfXE/BothFg7oSKB/Bwf/BJHEaksF+q9cmDSHRX8d6pMCRorroVqvkcRjWoWEwTD/qNOLuzc3ef0A5VtWcY/GOOkrCkI99n9jo3HoJBSD0hC5QOV+Ayb/ZJyAdAC8aOc4RXykVR9XvUeSZKEeFIzgqp0yukK1A==,iv:DeX3u7YmtmLxZCLzZxf4TwyAJsqVsbI8865Wcm34ZSY=,tag:PQn1qV4M0l2yvx04OaXESg==,type:str]
+private_signing_jwk: ENC[AES256_GCM,data:srJrxL0tFQILkye6SW9zBqMtcq13Ff5D1Wvjf0DwYRiSIOASJbhPBZfsIptcgMHIjK6mqioC6FF76f7K18evzEdm/4hHiVtnXI80IdURIv3D4DxexdbAQD9xvomChBHsIrqqhxC6SsyzlsvQLgFw4W7BknpCBDkdxPmF3cbiCwrouF2WLzBQb+dp9clz9b1xYLe4xeBPjkpoy7qdCQTEWNLq1NXeuhKhXXRQj/83wwIz8bfAsBMUdyA6yFmYnrsGHkQ+duDb98Q+nwCSWHMkFth2BoXjDG1e+MtUCdOx8AtEEzn4WHe/5f6Z6IrYAfSXFtRCLu5kkmzJL4GvYdjLC74uvKVtS+b8iCfGBdzFRtjqy1yTryPeMExpYcB882H6AZhgFcsyOrFohGxzw2EPfvlOJcjsui+Z6Hnvkg9q0SVd5VKMYi3o6XhMdBIqIlNl6JAU3LOIUqhRcgB5rL+XeF400vA9RbxfcMRGFn6mguIMWNvuE9/HYSxkE2Wt7ZahK1XmdBzKEz+KOYfGgYZ48bP/Xud93apsZCatl5iFhPKxtVmlkxJlHvvisIpAHkZJVdIh4/aZvjadQMrvEW2jg6WZA+fqEkFsq+oEjWNLn6GjS1yjJJM3R8jr3uEF1f4480Ac9Cm2hmU/OAGlJATzNcM5geuR4kLD+UdEFoiONfidGd57S9p3lItH4ZTOWtbY80MUtVfCd2SzdWj/e53tMol3KTk8LgOOpA25nXboBUgez8WamVMIoGhlqjRnCNclBRVy6uqKMEZqX/qPJiB0q8zCpjjA2bz6ZUDJtTNJhzmvOIK4hYia5Pt0bmZIQteQ7mBg3J8NXP38DjkptYg4IX4TXNqP/GcyruQ6uLVCWAW664XuGmpEIUGyk8+8S3uBhHQqeQDAO3Wor80xYxKE1RHse9nfdE5fTUD/48T/sWuh1Ruxx6ezio+dn6IhPf1+VrO0+t5/ecnGJ6szdCZa+J/k5wvXEFpTvTZneUM9Y+0Ueoq+0ZKb5Z/3eYDYAJUofEve5C6PFcLXu3D+2UOl3CgRfsokiK/6fRpqkwuR8wwKma2CHxIare1cl5jZdFmwZz12bTlxN/vmJD69IbweAZBj3Vc5qpuS7feXGvnJ94wuGwxToLAmYbzwj+oAgSeKofTSxlAjB+ukX6UgnmHF01lP7e6M7SmVowvsccqVhqbEfvAbYGfsMTDK96fwgHBJwLsTVQdGtSfFXMN7WcSH6GqllvWFkk4TNKgLjMQfcsXlrfZq8xpFiS6vMyvOveD8pvgIwriWL2dFZCmwjb/4yqAQoPeOVLDF08LlxFCsG6jsoYBUo9VAC4gi19XQGGqN59HxKG8zN442hwPXmlcA7b20rMGGZrZ8MKBdg+HzYiw6wgKyHt4p5QoVuH1GYcHhor3zjvT6pEC5EwecsL7/BgAwDs8i/I94IQoYdYm3O8YcqgoWdkGR3onYZlp/HMX51mwy5ALHnX+lURaFoofPH1fqDO9vzlpxO7VB7l174pLk2AgS27EMt+SYpL3DfX33vTItBwC2/LJ5MPVSvLpbeQDwJP5xc0WmUBXi6pV0KzzKMDYvyRn6G1HBBhnnNYkxeBTdYZL900r3tpiSwqbptgqz/MvZYiwoeS+vQvN9phI85zpIPlg35QznDYuGuWGr9eyG1aH/ORN6FQMtzmsQRWsJArhhXKyYC7g3QaBBkfVrMS2qVgfXJe65ZI6CYle+Q0lUnB/NgE0qoNEPVazVBQhDF80mPp+qHxXhDYDpJXtxHzHw02kq0256UK/VXt0JCIBlhCJFHwil8JU27gjlIrc7nK2hUTFQbOv9SvhRD/fquEyOp49VMi2XqII/nqwNmSw8ljx05385qQPPipL2h68v7faaYLQ2D/pm7D56eZs0X/yekz3e3IMzyOpAlQzQa0PQYzHH8sj+cen2W8rMYTfw1Rxh1qinvN1b5BaH4saK3WddGbTM4EBprpOQ62LbC5yzAL+Jyb1+PaR5BM5vIZ22G1GVwkvVd1ColoxZDnWda9wwATvMRBSjKaQVdpDQVq5golFj+Nh/vNcMyiLN27P2Rug1oy45XAfnme7SfMhOBRqDa8A3febokYHp0ZEs2H2QaZD3KX+UHaghdY942cE++Zk/U9WWt0abjtnKCeex/MdarLOnmgLgrDetb3O4b5nKPuB+iIC1A/ECeh+nJ9oAN9BnAv9XP7sPotrTlCtX6WL5Y2mpdQ==,iv:AaASn3BHqj8ge4AHi0OGWLtn+klAtl/cb+zfFaD6wW8=,tag:FrtjRIc4VVNYvIfxtFlzVg==,type:str]
+proctortrack_client_id: ENC[AES256_GCM,data:b95K2+1z91EBO7GOLLW/02N48eicOIG8TGbiaDW8h+Mrp5uwqM9XNA==,iv:UCySkBH6xAnl6zy5hGk8ND3oB66Tf5LVRIUaDpjnrGM=,tag:VXQfwsgfAecTxOYvDIMooQ==,type:str]
+proctortrack_client_secret: ENC[AES256_GCM,data:t7n+wB8MHvAZ9uC8jRbhPuslZ0d56vTNAqjaHbLp2vnSmT3Utt0mi4SwQGUXpWCqt3AyhTEwZsQpAjGBXgyM0NUyY//GRVwwF8CnbQhiqvmbmPnvBIc6sZe95W03XcXKODjEsi8e6TScZEjO9+txsE1xW3A2Fh5L691+xCR7o9Q=,iv:nlVGtPjhhm05lpnx04EnMFsKrjBRILlwVDgjl8MSIxs=,tag:Sr+rh7n7JFWGo2GtFNLNxQ==,type:str]
+proctortrack_user_obfuscation_key: ENC[AES256_GCM,data:dhR7LarGmz0ccPniIRRSET9MXu9L7AWBC6txYbzWTf5D4jHTyTBFRUK2ULQ2I1TKO+mHDyrFcj+RWl3cmTBr3w==,iv:5HAK0NFhFz7rh7Hj7kIH3E0KmhEfecd0OYZV8MSYYuM=,tag:oCvF4u0hmGPWVf3fGAqUyg==,type:str]
+public_signing_jwk: ENC[AES256_GCM,data:jlF1sMGrwk/tBF5GnxrLNHsYEvuXaDuXviPr/v61QXOumzYGaiV5JcEyuv85c0c4Yw/pw065LgM3srD4o+R3qzOWwgqE9Metl95qJ++8el26jnyuov3EK8DtOwytqo6DhKZvienVfzxIwD0pihhr0RVvoyqIbY3bDV70PmtccxAz2fSP3NeVFs6fy+mxkYjzUkGGgXq0i1/C4XazgzR9N0fkwVN6lxshOnErmmuW8zoa3wErEhyLPRtkbu3QMnUWmCdKL9oGWnfwVrh//h6I5CcDn+EyzGGUCVdyw3Rku6ShrzBeTUdfEvqiTVI+vOMkF+VVnCLS+igmr2Exbwo9xeaWCY2ixifG/es0mzqrGasNhj7QwHdIWf2RfVBbIqZqUgFdfpTt1BfsY2zZEGGbL+iW8xo4IQzFC+DRbY17fdothOGA8ZrvZNHrxvnhvIn15AHwZI+JM2wQJh8KfQtUvjdcCaKolaLAhOVI2yzi87AJ7YRkXPkZHrUwoGwdqjgZvCOO564WrdoXzWvIklCo5L8VlVRkS1RwzE9+tJAR9urilPHqBn+bOFb/ssNryRDOu9hQLgicpNVA0QmVRRzeno/+wVAGxhMES+VTxTcoF9vXZY6wGrPeXskctVQs8Ap0eK6p/ANPQnEDQfoEGengqikMHBbTaUu8sIDzCGqyzdjH4rJSYSAeIC+Y4YmU08+l43m5Efu3sb0GOSTa2pOA8lY1NlMYJu0cznr6n0xRnfzOD0p3LD7NyPwdO9NSGO5DzKobEqmVbPmr+o358ywZHrMv9JVt1a0RirvbHjCJ4pQiKbP+eBNRvlUXaQtzTxUwzgE8BPFeWEGcNLItcprJcEDj4f6f1wfa5Tv/b0MeOl7EYrwMN16cHW7KQb1iEME9Pm6Y/9/eVvvkwDtLwFFz+q4JfcC31ul83rgMpplUQ5XLqN4ggswAPO+6oobTAfgerKs65IinyNuPrDKbVROc9gzEgey2LxNjELNFDivnyK9EKRX+g92lftJ0WzcUXSJvuNnRV+aq+/y5uDGlHVFoQNG3SOd9XqISTZMV6q9rQWOVlCmf5RZBZUpehKmu68Y9npNaLQ6EytCW0c538zf/JBuc3VXh+g5NR6ksAYuiuIHmEMey7OZVErliPikr4a7DOOLZNk+AX0Ndq6NJEUET+R26hSrdZBkuMrTVxMeF2xAlPe5HDf8WwZTBD56YwjO2PIeqpmATn4tyc7m75G/rDKHtVDN51/ge2L/Iu5meX9i0fOD1bB4IdG+ioZNZbRHZB23BKHkZnGoK+jA2dEiAxT8T2ooB/tQo99XU0I+ZU1x1IjVXXUvGD4rn1TWccmA6SYzrYojDjkfIDxZuiSi3TcI5tFknN0W9OuOohDPL+0PFmWb9OB0DeFIuZXrwzkhUY0SK74SivU1eF3qizDWza85rXR8tGj0qDiKgykPkE9eRraMWCExeRzNqjSH+svOLI/qZDMlZjVeD6RbXAMBzB5ht4EK03MyodsxyzffbMGzilmtipiB21X9mOX4ZumTlkjxPq4ZwOTqd/7xLZ0XYizQFwo2wRuTOQiZKlcBAN/sKDc9bPE51rru27cZkuAlzrlRnnuVXKdtKZ2xZNN6pMRNZwoJW5+sW5ymx82m1,iv:yGJebwoHtoxOKwtdWLz2F/ODdbY5/J3RvvERXf0DhPI=,tag:rvA/lsisH0lWVXDajk7I/g==,type:str]
+redis_auth_token: ENC[AES256_GCM,data:m9tdnp1IOkH7HASmWZl2hWKQHiEEuQvV3VSCp7qucOjqCVG2GsA=,iv:L98qJ2dpzkMUc4Opn4ry0IOA2GyIO0WduqfBSOaSzWk=,tag:qgQeJCXKJRtgJdGTYnLiuQ==,type:str]
+sentry_dsn: ENC[AES256_GCM,data:KaerFZMEVPMOR/Zw77jq9pk6O1xDFDfkU+3YFdHkgtKNiGatYQdyVHHdzc2YBp9ijwxUH82p/f+tAhXVdmBHM9WIYhIUuPEA,iv:2Hng5AR8gY1bjUdZfDZGQBt/rMF6xylvLfWdJDbmwrQ=,tag:jk9HZGt8avEgcDDvMy/u8g==,type:str]
 studio_oauth_client:
-  id: ENC[AES256_GCM,data:B53me4P1yrVzowCBRQ7klmlb4Av8JFFzUr43Wuhmux2Fx3Nnx0f/Vg==,iv:CScPFOJihClNXAWOs2pj/NFdu1eJudJuy7pBL9edxKY=,tag:mcMwnEOdgvJgnKa1wqTo4A==,type:str]
-  secret: ENC[AES256_GCM,data:TJ0sEK2WBNzneQKAu3dXTMM59SXM3q7y1pO5HgX370VHTguh2lDsE/R+eIQfuU6KDpQCrbRaAUjAuhrYdetFiZY2gS2Ln7Wa6U4zVMOFOT+IIv5d6ujxkD+6Ju8LsxrrnfFrfUFeUk53gP01LbqELOMESjsMGqfhAbygxwooGyE=,iv:QWjW7aGbTUVqrjUWkle3iW01RtaN/wI2CEoVey6yOJo=,tag:Het5ZfKKgP6aQPoFpZXwrA==,type:str]
+  id: ENC[AES256_GCM,data:xzkx+1Pgx6e/4O7H+2h40IF9l/TTTi5dotFrmbINt1817KJGq69qSw==,iv:dHaleX7e94O6fYIDq+V/QYH5JdqqD7PIoW3hMrRK2bU=,tag:9+CVqGYreoVTCppr2D8fvA==,type:str]
+  secret: ENC[AES256_GCM,data:85hj4bWIaDLXvlUMapT1P/d4Gj/CdDCvEqvA/NneReDQ4ruNATYhfDEVstJR05uHa+aB9VQl5xThWyAHF5IAkeyiufggArUfy1zGcHDtpplwhvWYnFjAj+LE2WSBxePGKxQce/27a/e0WjGPdEgtq2fbq2q8iGW1UKChAoxQPlo=,iv:n9jWyr2mdrQME+IxpAG+3De16Sna5ie4yyWTXf4D9os=,tag:MO0DEvfapCCIyPSKz06G4A==,type:str]
 user_retirement_salts:
-- ENC[AES256_GCM,data:nxLK611AEQGK9Y1/MIHUxYaCTzOWN7K2ng3jhr6MGvCbfOIkJUuZGcnamA==,iv:9E7Ognljww5yptJ4+3/d2pOUElHwQ8alBd1UZf4MYJI=,tag:JorsHyTmMtnvpMfKUxb81A==,type:str]
-sysadmin_git_webhook_secret: ENC[AES256_GCM,data:9uNKX97c1rT1MPjVcVDKINWt9juqCoB2XS3H/ztgND8H69m+aoBDRfpBBQ==,iv:ywiJqhriKQqyc5DfyZ+AYFKBGP+EPd43ZQDDQZptpzg=,tag:tAsjKC7llloBJm8nMDHAGw==,type:str]
+- ENC[AES256_GCM,data:5ls/ESoE0X+ZL3L6w0ujhXMN/8GziE83Xws9x5ColWbA4MtyYwJOLFdpjw==,iv:xFrLPgEM/0/I/6lcypBh01uK3qsaHMJexxgfnPdYZlA=,tag:5CyOpBkGdD7BcEqBIROJeg==,type:str]
+sysadmin_git_webhook_secret: ENC[AES256_GCM,data:Fuyd/DtfUKciAxnnnblaOFShf2QtLdR52GAV+NJPKTvXA0+Hp7AbtYPG4Q==,iv:TCF/wa3oL8CDUjIJCKlxUDlUjZBCIq9zHKoZN7Clf/Q=,tag:tMp3H/Z0Vm1Nv2CkruMjBQ==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
-    created_at: "2025-03-07T16:39:35Z"
-    enc: AQICAHjmo6C0sCNz3fdkFlhbu0tdBZxnHmPYSnqtmocvGiuNygEZWxmvBJgLAeczocqbn/wcAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM9U70GM7HZAYxZczdAgEQgDujwYeNiIDg0ryFQ1h4Tx0hC3ZDMriuYJrRWQUU3ZJ8X6H9hyoEUXRHLhwSkZDKlPi5RIrYRDgRRLA+2w==
+    created_at: "2025-08-28T20:36:45Z"
+    enc: AQICAHi3FG4qowC3UzOLWOAA4Y9/RTwqKjovG3wyVVYDxkR+zAESwreODlY1Cryss8WrDyzIAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM54M+6yqf1cGrG8IZAgEQgDutGvIcCiKFmSfgfHds+ul53Z/f6ZCI75bM0txOvD36tG4uyK7aaQMwNX4cb20vRGl3qom06po1FFShWA==
     aws_profile: ""
-  gcp_kms: []
-  azure_kv: []
   hc_vault:
   - vault_address: https://vault-production.odl.mit.edu
     engine_path: infrastructure
     key_name: sops
-    created_at: "2025-03-07T16:39:35Z"
-    enc: vault:v1:BnxZ42NZeamaGZE6NMNqVAfgy52lf+0rMTmctgtpwg0NpkCD3zz/31M+AneqYp39T5S6gLiIKOTmN0vF
-  age: []
-  lastmodified: "2025-03-07T16:39:36Z"
-  mac: ENC[AES256_GCM,data:WtM7iM+aTfduW2dG0SsMEFSbnJ1fvoBkK8wAtn0v4YpZ0M0Kl4hKeFcf2NcNN7xwc2pkndUJCRtVA0fcN+MjNPiS1b7lEID4cKhnpQHCMPQ/XeogLFxxP5wEmXERZ9VUxfdwNlIo/Bd/++jQ+WY2v/oyi0Lmygni83MnF3gR8/g=,iv:6H0PXkdQdgHJKsJ/WFEA5xCpeZVj24gVZ8pezoZvXTg=,tag:y4Gjk73xTiqCmHjpVkIZBQ==,type:str]
-  pgp:
-  - created_at: "2025-03-07T16:39:35Z"
-    enc: |-
-      -----BEGIN PGP MESSAGE-----
-
-      hQIMA9YmDGFr0PozAQ/7BnsQuInsi14lZLB/PkTviZTeokGunUW8O814LQvZc3g7
-      IPfSbm6jpICdqsKXlWLWC5ayO6uPjMroTnNVzvTyyrl1CVv5+J80P4Cvvs7W66YV
-      RvJZu3i+5aBpYuPB5oPA18OirHFbCoHLKrU8Cy8/4hqaE7pNwyq3x2H72AkNg3ee
-      OzGQdBFKfvGNjbX0e8kCKy5rtwYW8LG/4deHUqaTWr/DmeDDWdB8zWAcHq8FD0sK
-      G4kw+LnkYT7u9B9i3tKBH0YRCePEz86Uk4uMusBETTpB8I2J6Lg6amR0PPsFs/Kk
-      O5+RqayfL5sA03dEV6pSo+TbOJ/D5HrAr4vqoncD9qyBfO4jPVTlOZcfDnKs1T5K
-      AiqMm1U/WW4jzyGZtASjp0l9LAVpblP6nmloRDMqQ4A40f+/YDjXdN9PTXNTlfPJ
-      COdzDn9jNJwdVb9TAxoSvYJRU2Lspl6ZslyQXvWsJdMxGO/JQ8Dm2v9UGBkZBKlT
-      eeOCRo7MK/ZnhITHg/Y4KvGfR2cUCkgLjKX0Id4UFOjsBWLidQrma5o9NDU1ZmSj
-      VCePX5aqSPyYdOAJzKNcmw0KWcmH0CioIX64msjlYjsLEcVc+frkbSfsoJPaAdFz
-      rNVPv2E5NWwDsC9aRcwxCHSmaMzA3dW/JPoEms2t7I++x4qbkdc8d/ueiqYnsnzS
-      XAERGoKpeI5to0T4JnnPZ/1RXa5GlOuCZW41wboymRP8j0FLY7MqYUoXokQsdNU+
-      DgHkTjl8Kq/OJ5p9XDP0Y1raTFIsY2Alm+K3ugAvlLd2268Wca4Z7sXDRtuv
-      =EAbX
-      -----END PGP MESSAGE-----
-    fp: dfd1205a98269f34c43c9221d6260c616bd0fa33
-  - created_at: "2025-03-07T16:39:35Z"
-    enc: |-
-      -----BEGIN PGP MESSAGE-----
-
-      hQIMA8MO7RiKjktCAQ/+NoZzyH9r1FLsw0iP6C0ZzCva1h3sPllsTzNbcqmKuiTB
-      l4x6YdRNhkz6KJ/CMNqyj2EYvMDZYbAFsvYYeGu/QxRI1Yspe6QsLg/XSS5Xe2eJ
-      u2Rd5n6Zb8iiG92C5m7Tc5HhKQSB8vJ/5adJlDAho565nRObuWfm+qw8OhJ9RQDm
-      5VPntiOOglnpzoE65QvYoAb8nSN5Pi7c4mZILYp1iMM22d2P5aMxSI9MNf2/cI3M
-      f+zIeadLbPJynrnHR7aC/i50Vu9pnnYpEziQE9Wi2/CrYgq8u3zbmI2bID+/qS0T
-      P+dkVPCQP6LM0knjuPyM+rkAjV2PqXMtKDoiuHHdWIan19HPkhlJCCCMBbA6jGgF
-      PmCkDeTqHVrwv65kM3HtpCw7l89iXZbgqB+Kp1HAkcrJ09OiuqqNeLLF5a6J5/A7
-      NkQ1qAe4lMmfjxBPoVE50VkZiKnlGqfzYYE7rG7+LNOtva7My9Y3cTBxSgYzswqs
-      6WtWXVTmejCZJd/s+nJ/NKbl/zS7MB2OvfS5Lal6VnvsjM9eR0RM753sB0SsYxib
-      eKVMA3VAHfCpqgEpPAewbagAAvUa3NqWQT4No7z/JjmdDZMFR9r3d3zS0YEy0nAM
-      0yhlEqIR140xrb/y7niXUz1YMXaKhv/soUwqLuMGLS+BWD5kyJgAoWCEPaFvR57S
-      UQFqhz3U3UhG98nubVozyhgwzZN+SpVLW1idJbpZZQRj6Pf7q2TUZcih6hp6Dj8w
-      cMovLI0MexVcid9DZgudKt0bzWyhC2O6/VUWfjFUKTjEsA==
-      =44Q+
-      -----END PGP MESSAGE-----
-    fp: B905F0256A801D3F1D15B5126A1D27A4BE75B1C2
-  - created_at: "2025-03-07T16:39:35Z"
-    enc: |-
-      -----BEGIN PGP MESSAGE-----
-
-      hQIMA53hirIFs7uxARAAkxtwAK7owjRfSNkQw7g0jUGsIaKNA4tFbb1AkaY2AZJG
-      a/PW9TB7XL3A7HAlyvHohCz8wG9oHJ4O2nvOpERoMXf84mntEB3n1moBmW7W3T+B
-      k469MEbzlpdlavbTwprsL3cOgWHdD25d1kGisT5t6B590/Bb2TY/gjidsnyjRP6I
-      yQFQqw2zTmPrDVMaThipJP+zxleGRVSFRytH8RvGQbuQEvFpOMLGS0TY10+ZOB9B
-      EV/lgEbbZAF+M9GnEhYP9Pxl+TZBw8+6E69U8bMj2KjxBeWcdcMTftRf6lnFxaJm
-      JNxeXnVBY82wIyqY9B/qWPIh6ifqEiKhwsm+JBUvDb2XbcukZZuOE5HcLo1lhQYR
-      Ccba23IQaYfXT0DrG81cYtve7y/IAAmeVqUQ7oQQsJoc4NxVIhfYYuT0EeJ5US/O
-      cprO2zPV00w3FGfi7XgkD/t2O6c/bpLfgVV0m2c/MYYb/TXojDjLi6BbP276Jc40
-      Dketo3rgA7R2fWY2ojXh+i/V0npBGn7ZpoKzFbxOuM79ol8ZKqzx0MnvMEr2yZ42
-      uAq/yoMcMux3M7E6npwF/GfvTm+HD8dL4oSjjbYpIEmYBysknTgVy7U37nUhG7Od
-      sN/g/94kZFheed0JbER46uSmv0Kh/FvZhm6FR8cDNL2hXKUaNxThrk0tdL6e3UvS
-      XAGOUDUivy8x9uZvXFhnaQ0yQdGObAWVZi/IfMJVlrvKW3U4g3FMDoFS97za6/bh
-      A3OAQ0b3dT0u/OC+6MbtOEvaIIxLgHpa42XitRWOiB/3rvVZI65U8d0geI3h
-      =cg1b
-      -----END PGP MESSAGE-----
-    fp: 07083D36FD5986B0C99700944E9B358045C1B176
-  - created_at: "2025-03-07T16:39:35Z"
-    enc: |-
-      -----BEGIN PGP MESSAGE-----
-
-      hQIMA8YdB40JfEZzAQ//fmhWK4cD9oDW2SJwAK3Fct54lt97Kte7F5g6GwqF51Yg
-      R4q7dYbhpM7mxwTXPbE3KC0TtVwfUXOYXiyTyFjFB5RWJf1Hc5/n8etzg0Tf+BVw
-      D3pIdBkseaeQpvfjp7ZfMxP8ccex/0jt/2opuy544aiWau1rmbezAIUOnATK/jXl
-      wUTfXoRM6Na/cx6XEJG8Tj7oGOVb0K/8N4979dibc2nt+3RDf99zS1nPmLcbs+HR
-      im6ARD/PYBaDzaLoapdqII4lhzHrCnaLSSnpdPLv+tYa3/LVKcslaI4chJD0dqwx
-      F6ERvY7/BC2LzfwOVB/ARW60m/soajE13ybnCvsK7KkS9yVoOfd6KT/VR7HiTrD+
-      0Vm3s4e7V8+QtlpwGSNTxxQRFYsPURDrLWfN1iHhFY+rY2NqXDe847dtpt9MqJo7
-      xLHT0YamHvBJVn/pOOkcUYM2LD/T3Qq9CR/o5VMhZPk5217ZjMaTq4l1NTIsIz2T
-      w0H8bk0XmDS9dPUh1u0MvHPSThT+qmhd0/yTCbAiUCXKJfh5KKrp2oyXPw54Y12W
-      M3Zx3cMMz1Hm0aGJqVLBc2WTO/KOcxipMB3vxMwbXIXu/y57tKWhuKfpKUMO9jed
-      ydsKHR0MCVrq9jqNyCJDwnCfmcp/WfypwHGpa5Lg+nkYeTFeARBa5lGU5bhRrujS
-      XAHDZOg0suqxpM/jKuYB8HWXlIpxCAt3WfyMBENz0zmS8zSPTnPk3dWGCy8SLMC5
-      MG/H1p+DFao84Ms8myL1Ez362Mm7DlHYoqu/RU71wQ/lkQhyf2JxuKqeYxDK
-      =I3pd
-      -----END PGP MESSAGE-----
-    fp: 3582AE9F12CE295BDAF545ED17A5F53F11681446
+    created_at: "2025-08-28T20:36:45Z"
+    enc: vault:v1:wySAGYErO7ejAr61t8fYz2kui0WTaV8k5RixzlexIp4qrcwA4Z2Dn0lbLGxS9/ot8LuX+cOZJdw1K3dH
+  lastmodified: "2025-08-28T20:36:45Z"
+  mac: ENC[AES256_GCM,data:Dk3/SEd22b7TEX8B9u8x+84B5KPf68JTMuBMDGq41rNrWSKYB9D1f3FAybk3OUTy+l5LobU7x6mUZnX93I6wYDwIwjyAtA4v94qTOPmAwGFZb9YtWoviRdmYun5nUxDmQgz9haImppdmNptXthjncf3h18H+eAtkXuMB4OsHZDw=,iv:O1vJeWrpgtqQFxsHUZ/WlTUlh4KCOs0YZkZonwK+fWo=,tag:6DyXt0Ge+fudn+vs6aQ1IQ==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.4
+  version: 3.10.2

--- a/src/bridge/secrets/edxapp/mitxonline.qa.yaml
+++ b/src/bridge/secrets/edxapp/mitxonline.qa.yaml
@@ -1,119 +1,36 @@
 ---
-django_secret_key: ENC[AES256_GCM,data:ivLoggMi4gWGlVC7Hs2mNzb2UH3mJTlxHjHnxu/pyB11cuHdLrb3XFH3kw==,iv:KGviPMrtc+DbX3P7pagf7pIq3Nu7Pbz5CjLCXfqVVnw=,tag:jwX99/9zXerz+OD6zBvdrQ==,type:str]
+canvas_access_token: ENC[AES256_GCM,data:52ZXNyuHOlyvNco/k1BGqp/zOQDbHUtGziqvV67TlRWhlSrX6o16X9fmzdD15pjeP2t9yUWRzlRvrwx5F5SrIOadKm+d,iv:qF2iINaS0tinDONzJ8Ggpui4QD2JUbxoevCsLUOftao=,tag:2lkeeCQrbfOLOUeNc9p7xg==,type:str]
+django_secret_key: ENC[AES256_GCM,data:tzvMTZYQd9h4+pbknjjw00hH69HOiRrjqJ50cnm+ypTBgirQJASL/oM6gg==,iv:41iEih8V2UYnIUcAUycvrwY/nSlxqpLQMxBkqPczJUU=,tag:/az4GFM013T260PzgUsSBw==,type:str]
 fernet_keys:
-- ENC[AES256_GCM,data:SfnVaT+ViHTXXWEbVXyb3sf+SLXgpgOzyViO5Xc+wnixipO9AiyG4MMDhkA=,iv:QUfoyoIGURsxfIBdInNAhbJdOZvdQB0zvel4Q59dy8U=,tag:9ZbAJiU2UpaFmJ9sbZtntA==,type:str]
-mitxonline_oauth_secret: ENC[AES256_GCM,data:vERfFatN+q0Bi4xJr4JYDwwd5Aqg/08EZFlYLDrVZiM6xZbuP1INM1VX5fRprVXtPO+yKSdmbZ4pqoOCAbrg0VvnqMTlNBKdTmGnC5LSzM4KgFbqioJS3AY+WH3/KaBKA3x1XkmM3p4FRHyejB0YFxtMd1cVYSAX7FSB/Ihq0nE=,iv:ZHLf0cNfG53Ay04meFn4oU4i/mJ3BcaXMErMNc0bEH4=,tag:bb6MaEYKr5BbMIPhQhTc9w==,type:str]
-openai_api_key: ENC[AES256_GCM,data:arJDJO1vyDxEJJo5EBdOFjvdak23VX8/35oec9YBnwL1YNfsEUh9OSDg1tMw0ScirmSwNUvHLPDk9OAmZG2pt0HDOrtySuMEBkUFPSdflYnwLlLPiupSThqmaBhuckzA8gPgi/LO9+kj0oM7FWYCKMIMps7ZJKz6DE+i7kvxdZWYjzKptrtwvD2YdcL24PIEJBjScsYR3waQ6vp4FhCl,iv:tjpil+fg8+APadHrTFb4mcIxtSX8zCZays3ahBlxNow=,tag:+CdxBaIolCqJB3iGfOtx0g==,type:str]
-private_signing_jwk: ENC[AES256_GCM,data:IWOtKBbstWn8o9cuV3NIVC8AvJNtcQd48zXaLjgL/r44ZkpPQ/RKRm2hy6t3+tXWX2xiA1/sTh3pcZu0dqa/MsVi0f5B8hunUp7+YzpzuQXB+1lpyWq0Ip27FJGHcfpLLEiQcPUtPxxHmnzs2G8Wb0ZKS5duwejIWQUocWofs/7HUMLNt+0I2xGSvzUNKmxE2ZiJiH8u+UQr/YF+PvFEwqQzl++AtAXCuAMnjgdhqqSxDy+P2CXsqIXXVupCDBCpPW3iJOuAiFkCI134XZ+5JPdUNYIJkTGPJ4tYLfWcnlVXj9DvauPNcLVPr4WKT94IM22oXu6i+YxjuLiQi+zW6f4PnVFodyEWwmXDlD8aUcYNY2qgcuShOH1b+Y0Vs2yXveRV6THsNqSRQRRDZyka+4L9Q1+gnhswRWWe3LvK1CgxDtwc3p4V2kdoRH5oLnnjlfeDM4+dYMYif7KZ44WdmDNU6HUK5JFTK7RJJfpZXIRkgb/nVmoiN9CfGP3HJYg4ItB/72jLE+DvXDLo57qH0pka+0ZrPDOBLXOEvRMw430CHAF7XIryap4HMwbtfhaisv3XOEURpfTvuZLDMtotae2ymoOlA1xhWxQ/JTYZKQOSOxBWMuDVyLrJOKmvfghbI7pBhtperITL5U0azYKvJtnXhTPmLHHDEGvaiKRJUycpUorqfq8Xj2LdodQCaZOphf/aAMwkkAG3h4eUHqQSh7PD5FfYUvEY90PKG5nwha5j6ucs06OOTBokRl5yumy3BciNHXkTEoAX7FAB4zQWVXe86kPOyqf7nWwK5RWQdvEa+1Tdjha+mQRIC/Ady8qJWI2lbwl0VSUrzUb1H5HVcmdH53ekcPZ6UuCFyT1VCjJ+1EgZJGaNFmWk3yd6qpDk6mhMRFubAzeCjpNCgV3a8KiYYOr9eZXqPz0y2nStFZAXumD7DgAU9Z/YGGij9yW58hRoJrRPwgGUrJDNhSaLejRIw5bEbKNywnZAzguXUZtZCwggPS2pwb7w+3I2j+187o0MFK5ojX8TE2AxDchQ7SU1++jlL+C2SQ4lajLzz3KKer7fV77X9ZkGijBescUgMPSIncL8lX+XJ0R1aN555H/BPTWVOLIiR5tiCDbHrnPfO6pIfECJwlqPFH5bTzO2c0VHrJTBoa12ykjGxPCtOEMDA5VI6zbIU8WxxtkT1BkXsI6Oi8TLrd5l17itR9ynbjuL8hQqnmhlax42Rybm916n+JukDbM2emr4E21poEHnIpE0JQoYOMCish69PrN1LnUaE14D3WOrIovLHeSX/bMXN3wOAlmim9/sbWJEAFFD8H4r4XGE3Qa/a4w1UelebZ77zdBYxWgJ9pXSKHcKWCafs31deqJNY7sHXpnlNQMSzMxeFcfVuYaAFOL+5ZQfbn7nImOlhXxxDNAM24XohQiolekzRn0Sowe66UYdxpuJM5c6Ej41H90Y0cu1awUIYlBFXsjWnW9rrfIJ+GGgoiPFCNJk1UpppV/T/8XPb7ZcP9YY+VpF6gdOb73mXsh3dEBxnI9905iXbYIXa2KswH76s0v0U+OYgQoG9JQtoCQbHonBK3eKAxsLdDGUneNKLrID224RrvRaCsq43y88aS7m5KBELQ/JiG2uKB6Rt7vEMlFpd8GtNB7f3ida5UUPlHmdAL0vWdVsxwFRQrxy8DALw4gsJxCFGhyJ9M0n733w6KLRlwxAumJkLt+iJPnQBgofp32XSfpT80O1QHHUFsiddACSjBEnVNIYn7Qmufn7vQtqUhyK+iHYIEwu+mNR58EyE4sNWr4ycmZIYEdlyS8Bcq/6zx7EFHKLIXSmzXJ7qVBl4DG3mT2mt5W3sP/1mN8BH6S4fGz3+yWokZ9f7ML1nIyqML8fAWk84pomZKPv2cG+Oto2cfH7y2x5VYmNzSdju4sWV/1hJziZ7LVUhkfOToJibinJBTesek7vuPS+ZkGOks7TR0oia4BrXGAP9wX1X7zxp27XX50wZk/fdm+6bJIHuQFanc+d1Np8EJtQTNCdQiXJA90FbHHsiXPnm7zKpuPdeYQ9+e8c6ZOYdEjYs8rhZBrEYySaLPaTL/WB28hhJA1d7Y6jwE8ZmJukQDiOpptSLLP0iJ8jnGqCUR/miAA+l92UWvSk14YsyKypsXhh/g5GNIRhBulmmTI/JDU0j3Fdl/4mgRo6xSSyvhHZmmka1fJfG/dhG1bhaxQ0mzy1p1/6Og==,iv:g/X4hZTYUlzOvZNM3yDAG6CtcWJE6TbqBtO2SXUkabE=,tag:NYKa13vo0KV1OVr8AK2r5Q==,type:str]
-public_signing_jwk: ENC[AES256_GCM,data:Ycz/JNQFa2v8YbIbpPke5rGdfYT8bn2zPLXPe5C9XkvAlYWafma8novRyJ6W+PXXUg3wz7r+M83OQvCwUkHdtVEqweFg3MaAyqmKNYQMVWtx51lkZetaRUw1vToLbWHemZr/OWtyOR3R5aEr0u6MCh0mDh4kBnJ8WjR6dnkh4b4rH2XCGe2iBw9Vk+rTUqAcez1B1DVCR96PIM0Rl6cjeK4+zi9IpoHuEwm69E3qYx17+Pu7wRIlFgAiogb2UQmT+GNMOnEDQJ8xSs0vZsQEF6FY7uDjj1KWL1bb5oFftxsIDuiIc/WngCheiTRvPlq9r2Kq9c+reM6KvoB4wxnP3CTJl4iZh+m7MbW97/jJaubNx5ScQuYCjrCl+vXinfxXYf2smYgzLUaDIJuZdiQHphQd5YvJEK1UXVJPVJJdvhybekhBwmN5aWWnKTirRWfoHkBG6uXASZe4aCx06fR9ub9mvuk7qMYsEWJ388n0xnGHTHDL88Dml5UukrYRXzZIUWpvnEkcNVjOAfdobrEb/bwCJ/dSlvPRtbHLe/j10tB+92WT1OlR3TnRHdQ6JyZ7rpZfIro7p74FyC+VIl53y8qDOB3poXs8bn1SgUAEznkHlZNMXeXBWjYgpquxj7Pa3/NJtDbXOPbHHfXmcqXuIH2P7AuXU5T7ViZrzkve5oL6QwbbHYej1F0pY3NT26lJ3F2/KBg7wjppNGv4ZB2ucITCt0ylv3I0VoUzsmQ5dDnaiJ8JabLFbVtblGJoBklgcmhkziqUuYjfjM5uBeTBS3mqaUmbr2nYHBoIQxSspw1yePVBfcYdOCGJjcW7RMlJQYPORcOKOu+pXkuWQcLJv2Q7A5+YtolhoIENIyw8/aKWuIdPLyxQViPfkI2eIM4REjzZJ+jU85A4s3Lwpm1BKRbZ0pJ/1NPzwSDDiRBIAFuaFMXjhCQWDU3xrnFExBWsFMfzrmOgZEUVOZccAu8yjm9L8fcWXwu+L+d3T/mArlb1fX8WVjqCqxc8MRCR+0CppOYABYaCJRFJR5Xnm2dmuooDEgMHTDM+4/3/+Fbm16EMTmFXnu6g1Uzzu1jLcTcklwWrqDGqjhgUkfFM8Ayf,iv:IXOYJGOJ4vNuDS97gFpXaO03c5eRRZNx11O/CTVszyk=,tag:sw1QHu0Tz0+E61i6MzPreg==,type:str]
-proctortrack_client_id: ENC[AES256_GCM,data:b+vQqZclff/MHnoDU9My3vcu10u2r4venyny819sH3hD0Qu8zBE4Hw==,iv:W1sPyXSckaSfGnsOtJ6S8neOauHg/ZtvdTwJ3JxLTkk=,tag:kAQIcs24HLwJbem2oH4R+A==,type:str]
-proctortrack_client_secret: ENC[AES256_GCM,data:TyQ+HMN2dXrKH5AuyfVCtkzqan/3bqZFq5nMjhEucdbqqGs16l7HI3poRu+4r2042oOsqsgUu/LY8GwE3rox9tYDYTWIE3el4slnzVlxL4kM/6hAS6gDc+6DaxRDCwwNSfmEHZhuJHYF7kBP+lkthNud1XBEi7m+5ugoHcIwSiM=,iv:+ubFg0y43Kzm9kiPjBgN2Z8Fxs6tRXeL/Rkrkd6ISx8=,tag:inI+ycsTjClPqaKc7MNxcg==,type:str]
-proctortrack_user_obfuscation_key: ENC[AES256_GCM,data:kVIXHoOC0b1jHUB6TpYlePMxmFhsT1ZU5QQ4KAPB7sYuhGqDuEmiqcfYlmYievKiJQQXbHWWuodbUWsEI7JLNA==,iv:ps9txYwTSo6UXnUuvrBSw6t1cRh3/PaceRm4Rfh3F7A=,tag:RwMwRyyxWplT9AGl/GVHFw==,type:str]
-redis_auth_token: ENC[AES256_GCM,data:7UbmcnCXCw7Cjg9DKiBlzMhqMuIUcumtX5acaAiLUCODs+WsOAY=,iv:CJKYzmAU9gNDhV9TamPMavd2HW+aYd3pvYlemC3EUs8=,tag:VfF6TKz13u1v6yl6Njehdw==,type:str]
-sentry_dsn: ENC[AES256_GCM,data:Pv8Obfwvsv94JkPrgTHXzppcFx6+FC2A2JL5YfmihBKFbIewV78OGLyGmdcgWOjX5YQ5RlTyNB/3lx+rzylVabhzjXzR4lbZ,iv:52Gqk6DFLg5vDG+upZekCCmv3FZyhGrAfftbndUW9c4=,tag:920yc8ZOWSkDQRrEioSFxQ==,type:str]
+- ENC[AES256_GCM,data:15Pm1NSgKZE6EJcdNDxtNh9Ag2QFYg+C20/DHuK+Wo0WYj7eQioPs1d5nFs=,iv:r1r6SCCBmOJeTwQYaMcPHCYCX0UJ8lmXgfnAG+IydFM=,tag:kdYpJlDJ+DWkVB19aewKog==,type:str]
+mitxonline_oauth_secret: ENC[AES256_GCM,data:n/X+Vz5F38nkg5VvvbDQ9kCbhDjpDmDfCixxlKcVYZjbTbOB3RZQYhfiIAJLY8ujTq4t48Ry6d+1PXgu8/M36XZlUR0oH4jYSPUnZWwLLTGRc7w+KiacSwC8zImFGVyBJHpzcD7prVkKz/fXOuFWTD7Wdvfl8qSlouqkalavdgg=,iv:05lmq0+tvyqI5RvnmGkyTggafYXD2AbW/cr9+oq+5Hk=,tag:ZI0d14QTQ79zeHWj8biK/Q==,type:str]
+openai_api_key: ENC[AES256_GCM,data:ZOIVYBemsAW9urjsV5D5rTY+GA/MPJdJyvxvApLKnCJBhszdLM8QymOJ/QEAb4CI7Ljtm2epZYLigdD8ODCjyafoL0+SYccjD0H+cjdoWgEPa4we5E++oLZ9oewQcGPBWEkw311MSfO1flvTVkINhhH9u0LMS6BWtVrulqFtZDSvoqI2PnH4Uo4veaRS9tE0IcxXDdAaSLSQq8oJoSqW,iv:j3ccOZu1gAzrDDq/P0x9/JxuHnUp5vwAnelk4j9rd+A=,tag:Ua+2BnaHoX39hMSOdx1XDA==,type:str]
+private_signing_jwk: ENC[AES256_GCM,data:kDSQwHoK7MirTfoDSyNJ8nf56Gv/aieZphN/5DiXIsX7jrYKpXsVIKHch/LLdYtZFo2K4yx+C9PzRnjSEYdIuhBG9MHWjVOXUTFVWSuZcplowosY/cz65HIMSYuVzHK9u0nm6M0ZvZLwwZLriIzJJ9vOI9gDy9ZJjntrKGrsgW+/B5+E9kCXQNbBito3kZAb4c//nDTZGSh5FxIOSLB4tHivAaKcxRuqam9J3tnJFc5KJiR3nkNvaaUu9nRRZwB8/rEuWVe3x6/B7N6HTrgp1/Vs8nx2pz/wrEfAE3vKNz5gm0aS96nwEP3EPXn8s/Uj4oHWSL/9uBjcpCeXTNmf2rrvUJ+B2IbqrPMWTXhkNoPRqTJQhWpkH627Tmq5GXjql6lp2/SClm0LPLvWWLjnx3Oprbs53nyEK7K6KRekcCpPugxeslidnyJNPw1AFMPOp1Rr3Hwy/njtF5zQ63Ob4k/oEW9W1HPubepgJaHMIHBl0/5l6g2ABYn4sPM7E7779C46xWBZQM8bfFo32RmyJoauggYLJyf0RRdfnv1c4ULNKZ4PtN8I9C7a8ypgSBQOE5nMnNaOwWobvy9KDb4Ks/3mS6gjwynwaSCPlgcwD5DFVyNVixkJpnNkD3ar/OJXxNhPrQsmBW79bZKBKVtzuZ5BOAUFPfn9wTlrlG2ene5dsbFdzGJX0oKxQidA51F0mXXKuX26Cv6r+NJGdJZZi7uI4ApPmHX8HJBqAhYNELMJeN/tvRtwezqYD5DmDpE7eCoI8EZ239nQza7vgghyF+xsYEb9nPSN7TV9FszLII1OBxgy59XdUHtYj5Wbw4rc38sDEGAp8aJfSIrqiyTSv3M1b6UDT9QF2hC2PiiC+mi4GZdhXy29kl0mYMaD6aKSmfv15GV1M+8bv6n3eijmAN5nJFZaopnaERyr4CF+1Ur8d4xo92RvQD4DkuvO1L56Y7ypiwDdOdFFOknxiNXjVgwaU+DaUQMo+J4CKi1h+AkQKEsSL1fpe/5AWdI71C/qxruV9f2nGuuBL4Z2YJtIPgXdkjLKn/p6TdABDjiL82VQiscGpjA6AwrJVRs+CAEqN91vIRLCh+AKTjhetXU3d0Ob9Ulqwn7jVXM+QHlHvy5eK5GhLUntP8QWYQkIDhtf2PFreXU7+X8PlgaT3HVjxFHXttoEZmV2IjkEYOvtQZPWaRAzYqCTM40hs6VFxdQVXYPtyF3nMCOS2EWEIYNBhQXMb7ozVkhvnXFpZplDyIhKCKciDBf5JZHnDhOYYXnCuITlI3u5Ddr4N+fADQdKRlNTCJvZLY//Zd9fmX+fGR8BgdG2waP0QvMfijhKtEXHdR/wAKRb4lx5qjKEot7j9VKTUCg1IA79HMhxB5fA/zR96gamI/UB3MuovqpRQ0JW6pQhWu2lwLSmAt9XqWxRmGe7vvw/o1ltoGJoj4svLth0MFmsBOOwBR9+8htKFQtbFF8HAnjAi/amGm/elMDcd3NaOesd1c2G44SahzLaddAGsUQ5peepWa4IQmeWbKdTOMGFhmSkJLXvPpqsJ0huEhKTvJiWz1RJSvFXBiaMW4ptCFn8jiqQ6sHT7SlS0jXN4PzVeattO46JFX5QivMzlN2e3tVgwrtbzNZbc5ZkHi2xnHQBByyRmXBNDnOGftUAZxMVS32jb8OKBJzBDOlZVmW6JAsayon5/taAeDAYmlVd8OUzSXQAJWy9MkSm6BVaXo0vCJ7V3q1Sa7AUizrZe++9SWeCI6mp5YdYxkvO8AVSGgf8x08BdAX3+l2CT3WaxbF7qDGX7BJ2Br4eXZJeQ3JeKFbsZfGrS6UskyvvcDCO+3EeAYl0eZCxJLFizAICDHBtm1mQvf/K+8KyB4e4cDFrdvFH6zM2l5OcIOQDTiObX3eSYtVnuGRp20N4h02/R4aMLGmElZsYqDDLgiBQR58R9ZcBOp8ydrtQH14Zq56ZG78gjN9CFZqGtFSjohUOfDYZ28n038lJzg/BPh7C+/mrSZtEqrOhZOob8vb9Trm+3G18v+HEHt8lSMm91YlewDjLRDY+4+aX7C64wbMYFbcoVFpQhKaTojF3vRUBbLkppvbUvlzvcfEJy5KFfMnEiQJ4wlYhBrHQqqrcy9iNpA5LjV4O9ORW0ryIHmW5YQSWdQ8uloDmemofPvUCaEMkO9ho1RPEhvgZvBYUuoiFKApKNv1ik6vc8NxtQQQEd8zZos8U9a1BZA==,iv:paPDskKO1yV+xdTwawLVBOmUpC0tRmLXFv8FLHim1EQ=,tag:PwqMJkU9wjC4WFTsF/RzKg==,type:str]
+public_signing_jwk: ENC[AES256_GCM,data:KMdcwiQAmX/otmT3F6zqhA5V4OCjJcZdais3z4nt/681xU9N1xLtDwk9GuCqFLgVwQFm9eM9mRC6psHRL8FcvQO1LaYPNIqRci+buoPjCcq9gpZpQ8hNfi1I08+LiLSSLqq0QZyvdZdS0yBtrPiNHpLmLVoZPipigDFzzcEM10tJxZgedHVGmzwBPXhZWbxLY8ht9rm4AJOrGbl5nTZiwbz78UWn5NKGi5rL1L7ipE1MY5fvy2eCngTUuS9l/smb4rfjPO4uFK1mJR8KzTpq0x/pRmdnPkoys1aeUaF74XqEhIo56jAJl9OSsYviDVWxC0U/TtHLssWTfaStXLPsmsSUigzSkDlheKKciHcyEW66v8wXrmx7HoWAfTEM3W8HC7F+VgknTOTbq+G58hhnMIoqRriyOzay6i4xtyZoMV266jTdnBYlsujGA88heteeb6P+wn9lKPkienBu+BAOpGTAHsRoyM8do/0Q57gxoP5YJ5aGDWQ3wavJTfVc5KUUupMtkAma8H6FMXFX+4vN9S+eF8/PqquUK3CGzuYqXM6hfKrz+x6txr+AbVWeuBw0tyQEuwN2TzLhZrPgeGqhQUBBWI3scuD67Tuu6Cgegn7+k/BWuyO82gHQlqlLkFegJxhzk6xVg1ZZGHJUJdt8+zcjjzhTTLcB2Yy7Ac5qPFpineMG3rcXzZ6Cp9EwojCIAM3x03lPFmKCHgyJgInitEP3Vl7j+eEden+5qm0OzbJrSZ/SbU+4Ubv7jTGPMgI6znDjydJSPqNOD9C9uN9M0HgXusD7W1DrCZ+1ZUZKI6/oq9XNQMB/ynyorphH7LF1rwWcmzpa0Vb1Tx4/7dET2U4JnRomkruXQnH8UlosCX+28hCbk7u67Y0zQMqY/TQNhrle3bII04G2nUuK4mX3RuTsLKgTj5g17LQCGsp1B6zREEvo7m8hp+1gRopM9MXWxIEk9o1vHlWstB4QQDly3h17ZFcKjqexezVmrUg3oaa1IKdLpm7rze68TsKGPj+vXFh4Cy++kb7EbpdeF4vI+7yUgC4Ibfb0d9OpzlATP0vDCjIOjYE1o7GsxtXbO8vE68ARv7yuFA5P9DNZAUj0,iv:u5TBKX7APDghFKv+sBAUSNs78DzKABhvjY1zx9fEnJE=,tag:B/7XB3y86lOkFSIOP/RBeQ==,type:str]
+proctortrack_client_id: ENC[AES256_GCM,data:aVSofDYccgT+2Xe17NJ1OYwhdeZjIESoCDxQNN6NIUQfenUzIUGwlA==,iv:UEOCGnfYoqBPIuQuEnUUWJ5nPw7GeTfEXdDkelqvYfY=,tag:0QGZoDVufN2/l+XwrARUnA==,type:str]
+proctortrack_client_secret: ENC[AES256_GCM,data:rsQUnfsPS5egBaIF6Y67RIn8Mep8tmGe1Qwiutk+3qnxYccnsmZA/BlujrKqCeZwozo42ySXQ//Xj198+q2JqbS2+Eh3oiqFD0jt6gTeGxxgeNDdGUlTTE1T/nTP9ZYfe61zFMkg0iIsl39+Nf/oXnZmxcP5ehGLv3IAM53cwuc=,iv:18VdJj1um9paq2xqVzBy6pLlAHiz/d6vPfmWLyLA6Qo=,tag:6CDMGVQTaQu+XsFVZAC3dQ==,type:str]
+proctortrack_user_obfuscation_key: ENC[AES256_GCM,data:xijtifH+j80ta0Fl5ObujZSjRUI06wv2kxR6397kC46YzmFw434+Ba6xX17FG9TLJRM28xzRINjjsKXPWBYntQ==,iv:e2NBPJodV8C21VFjV/sEkao2dUhkfmisK0MXUilS4bQ=,tag:gIbFsFmz1Uvx7cZm8xViDw==,type:str]
+redis_auth_token: ENC[AES256_GCM,data:uyP7RO3SSnax/FAxSsbBKrr/sh9G8wUq9aAxZa++tk9CpnkWmw8=,iv:zrOThx1XNjJ17O0V/7KtvVU9ZHEUD/f5SnJXYhxa7Pw=,tag:dfGVjjVd+FoNWQXqnN1akQ==,type:str]
+sentry_dsn: ENC[AES256_GCM,data:6+lgqofXxpeZ2wC4YHYKcDM0pNTyoG16euQxiZu+ExXWG+FVKtfQA5ba8ZtThNSCKnhCjQxpLgvPrl+8ZVtSoXAjg91gz7Xw,iv:EaukmbDRlScCDidQPt+3fl+EPeXoEDdeWg94yJDRXqw=,tag:zIIEz/SHx+wmR4ragqY1xQ==,type:str]
 studio_oauth_client:
-  id: ENC[AES256_GCM,data:VfqR96cfZSGd2I1/kNyzhgronyC+1oL9lpC69lU2cbDSFTWFPCNy0Q==,iv:rnCXhQdd93IMDiIHr1mBzH48SGo34pM5kAfEBHoCkQA=,tag:2r5NpUu4RSKcY+o8ryUf9g==,type:str]
-  secret: ENC[AES256_GCM,data:aYpHXSe8PfijkmD4nqUPKLXZfmhnlP1fpJM4VOhckpqKJHYHgkzAmhgGNo125FPlUG2hiVYSTZOIKBGsoe/bLDcyy+kmd4n0WDu2EUgiHXe0KbwlfITJOp555WoSghYW/d7DQ+Y2bib4F/iePwqPIkfoBTl4Z7J1PXrzpP+s3kI=,iv:6h0cLJIba+5tS2hoGbF1lp24mhS5jkycpZ+BLAU28lw=,tag:mdK7Kp9vJSlcV22bTjEM/g==,type:str]
+  id: ENC[AES256_GCM,data:8ZJLxD1/z+dMAHa4BMuKtyaxgkOnr+TcU9V6ly08uK0SJT75odNtLw==,iv:Lz4PjnOX1W/Bj7re5/klgVFctYo3j+s1T73/DpMvgQA=,tag:B/JeLcGM4GgodaH7q3dFuQ==,type:str]
+  secret: ENC[AES256_GCM,data:RbqZsLqFRj+AYzh7Ytf0yUkpTMNErX8ty+OmLNIohg77EfoUScqFf0e48BjvGuG5UzKhtVBHxcIYl7DomOAXVDKUZX8UoqjOvfwOlRpO0+aZcLoGcpV7/Cq0lu60k2FPWvOR9u0RFiJLI97c0iH7F6Qm81qoAtUw6yw699TqRR8=,iv:3GLfEG2Sb2Zn8+TTc3Z/Xn5Gy+AzAlCN4sylp4rNa3M=,tag:QoqUlACaoFh2WBx1A4TzUw==,type:str]
 user_retirement_salts:
-- ENC[AES256_GCM,data:dt+xzsLerdEfR8AKA6FSxOTMp5KgR3kkD7BAYTAoF/h0w6fKNAB1QokX3A==,iv:BIrYxLjAecvEc6vShH72fl2CLnvdCsFHHTfdBkvXA2Q=,tag:QtMAP3k0yEh9weSmh3MA9g==,type:str]
-sysadmin_git_webhook_secret: ENC[AES256_GCM,data:3FxATvjqRt4VdBan07L0xzx9knhwSvWeCTAXxcYDopJYMR9NP1u48s/UTTg=,iv:A9NhvoKtnovk1bpJt2lDH+zZgY4Nem35RdwwullFbjI=,tag:RGD5UYSi2zZyqZRnQFhR2Q==,type:str]
+- ENC[AES256_GCM,data:h44hRp6zDRSlsmM4F0vstHQiBDHZPNPr2kkX8Wc1q4hK9W2bnF1o0194Mw==,iv:aDgMhQYIUDECB+WUXA3VQgCfoggtaf53yN+POC6SHds=,tag:+1aZJmUSJCAX+LeNjgzang==,type:str]
+sysadmin_git_webhook_secret: ENC[AES256_GCM,data:PhMN34W7Qo2gOqn6dv+/Ub9js0qkU2md3Xc8nNHMw20av2oASZ9q9pMVT9I=,iv:XNHKK6GBBQAPS9Dvs4IpGKQnITAZsYV6YurI6Gm8bLU=,tag:eT/rGRE5MGfcA8C9QxvG6Q==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-qa
-    created_at: "2025-03-07T16:37:35Z"
-    enc: AQICAHgQW+3bag/cl2fPG3dPdqAPbfcsZuwI7rETXZsx85HRpgFVTs3bkiaaJ6S4RYVttsS2AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMt5d/8Cv5TTKVrnD2AgEQgDvl/Rc9LFAoQdCVMaZ68uyg70gG/NlqdVxjpc10jZoM8pyiL5JwlYS5eZDjPyx5vj9NwioXuyq/nxoeKg==
+    created_at: "2025-08-28T20:37:22Z"
+    enc: AQICAHjZAY5LtmRWGljev0oiDGn0jR5cRwD4IVXCn50TW5i0qQECb3uGmATbrEE+B6xsVQT+AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMft5GBa2P5vK52JQsAgEQgDvS/SL4r/yZtgkDuhb90XnqDrfgpAP1+5FnqhTiVLv9fZ9ifhtSMw5GdHQgv1iyiMyBnofkQejlJQkJ6Q==
     aws_profile: ""
-  gcp_kms: []
-  azure_kv: []
   hc_vault:
   - vault_address: https://vault-qa.odl.mit.edu
     engine_path: infrastructure
     key_name: sops
-    created_at: "2025-03-07T16:37:35Z"
-    enc: vault:v1:HqCEtQKzSbYbT4GLO+HA0gY8t4gDh3rEWi4LLuem44It+Z5nofxXPf4GGQuKlpYX7cIyn6fR8AWJSb/R
-  age: []
-  lastmodified: "2025-03-07T16:37:35Z"
-  mac: ENC[AES256_GCM,data:bV7WoyxbzTBpyAKtP6VRvvCKpv7uX4LdOSWlAzzr/SJzKnR/5qq18UooYxcZTz7WEj0Yw0WAKoWU1gnnCxC6mwqhQu7MVEiGT3Hyk2Da0wevFwLelcvnP1W5/LvqXkKvGGx843oDJMqBmauSYuMJ8+StLas3cQKwq9cozmnE2d4=,iv:ntgXPpMsJK0OWsRnnBNlWWZJba0E/FfTHmHOpeafkD4=,tag:KU9e2wIequjXoSaJq3vEhA==,type:str]
-  pgp:
-  - created_at: "2025-03-07T16:37:35Z"
-    enc: |-
-      -----BEGIN PGP MESSAGE-----
-
-      hQIMA9YmDGFr0PozAQ//TTuCEBAkmXrFqMa2++nahINsZDN71Jhd6lON9gskIlie
-      VTFLxxSUyziRoUJQwlJGXdfsbjAaHcmwRHipWbsbYRhtXitFlh/aoLLwgbG3sHHX
-      HweboOXH0mbFVPOqcXm/7sn4YRRB5HDieeuXA6QjZV12rf8aFKO7+Qv+z7lEJoD9
-      +9MV9awvOBRWYRPOyrRSVC7snIGtQgqpp9bYTVPfl7mFuS4R0mZOLj6yrbYtLI7q
-      I4HlcGRCCiDErzWncchQktFrTai1xrangpDsu20lYb/vcMfD31Uc5K73tw83cioc
-      JfJ6TRvOdpNNDdCyMcxpxfgi0AIVuQRhwCrmNEncljbAHm2P6b6fGYPQK76fngBH
-      0bv0gdSR5x2K5G4GYmzIe7sopdvstJ29ELTgKKpmCHd5GqLm13a4hAzNbhZPXg+S
-      XHNUwbD3QQNnThEqKbjw74dMgGmGdZX8lOO2mURmN1AGTLScPNJoycLr93nrfIKr
-      SFHYbsUa7LiJ5rSMMPtmW/DJJdMlUlaSCyQvD93l8zQoZFitEHxBzYQao9JlKBti
-      kfvZ4Jt/Z/pL2kIOd8KeSKMhWNvoLhrBCikyifoXyFJVJvoau7L02dahTKpwiluz
-      ICmb861EkpSckktRzp5DbAVeZIiBYw76RUQ0hF8qFNDpMFg9ILPvzSoyNXmClmfS
-      XgGb/KEx/fWL3STPGCN3iZTIbWDaFJC3jgszfVJ5YizcpXoi16fBNJGgZNK6J4Lj
-      jloVP7zGDpQi2+tOhN67OJnPhO0akt7hqAzcMzbkDYcvyWqgIniPoqJfUzHYidA=
-      =4KGE
-      -----END PGP MESSAGE-----
-    fp: dfd1205a98269f34c43c9221d6260c616bd0fa33
-  - created_at: "2025-03-07T16:37:35Z"
-    enc: |-
-      -----BEGIN PGP MESSAGE-----
-
-      hQIMA8MO7RiKjktCAQ/7BGsDTuXqCZEsGdQkkVcAq00p4qQme7ZPTtMm/i/gHFRL
-      CMwa6QeF9lGl9UfxhOWu4UE1s2gZmEPyhY5ycWM+JitCV3Fej+j1W2mbxR04C9aQ
-      riyP/cNMkbwut3IHlXn80ZfCbmugoy6iP9O0WAZWlwg8ihFBxBXB0G9rxFlNF09v
-      k6nzMZ0mULhI/Q+c/p7SHW1HZKeuv3bfuDixt9jQGSkdzlsRrpObNO7tis7Gftbg
-      R12OA7Taeq1XzUYL9i5H4X6e9vLoPYbl3BXxR6whSwIAycbm+IpLpPF1njwQWrQP
-      MjayRk0Ds4NrwXLgb7/SUfZiFlhJhQFi+L3Y2xZg+r26T5RvtzWFv7oQotFFbAag
-      fs6lhgNWACb+OQnavsbP2p2VwI+Ky0dMPsCFB/Juc5VitG9OWJmvy9x41fqho40n
-      a4jMOjqWHhXDO36+c+YEMtnjIjHV/TdsppMB4jTHcATzIBC8MjGu9rO+Cae/sboO
-      shb7qdMdbCCTynyCAcg+graLuJxRdMbXnt8nLqGnqGh9X1jsHiweWZ87T20mm0Ei
-      5W/HQyrg33UFSMGQ1FEJ2lUSDB/ODu8lFeihif578Cmv/d2V6NkU2WReGsbLK9R6
-      WRZIM2tGYsYLPPSHKb8Q0oIc++3a2iaYv+SvJByYKGAGyGjeiROpzSs8WC2MUC/S
-      UQF66RruQ9fvYeD3sjrEklg7DP1bX4xh30v0hrX1tAPwvUy++0AVJX0WbvvGKAlr
-      xc5yjIZEX+vGrgRgMFUJPOY2xklIenhYipqNakUZdjFAew==
-      =eOHo
-      -----END PGP MESSAGE-----
-    fp: B905F0256A801D3F1D15B5126A1D27A4BE75B1C2
-  - created_at: "2025-03-07T16:37:35Z"
-    enc: |-
-      -----BEGIN PGP MESSAGE-----
-
-      hQIMA53hirIFs7uxAQ//X2y7wL07c3wC76BkStldm8f30Z8YMcUfnNPiDJBOsN2Y
-      KNGmox/d2ro99N2HmrU4BE2BVsmf1t53UosyPDFckvXqVY8JcrFLm8D31wpmR4Xz
-      /HdVWt14DV1c+7wfOTp8r2T1ZbF+TgU1zZcw8ZSwF8nOo4vHz2HiRgDCHq0KbXD9
-      +oIa0vQqbcnIF2XNhmRGvS/oHTDjCuhJOHHxJZYfKPHIwlKdNBIDYslAqa99FBmW
-      fnkqn8HVICuNeIJ6DL3OIOtOfuoKlrtqqzjfe7QFp8X8O5OaxsaTWRAhbZNypard
-      Ps2lsjqQ5a6cwdA17HdsE+JXcXJ/ud3sgf61AhTHJpqxinVmF0DCXEAgHP9kzUb8
-      FUn17DUECnEjjW+f+WAYmLcWTkwOv+d/qqE/btCCTzvdGJzAaYN8x/kCljIVdAfR
-      kuzCqYQ/JWmbr9adjWKyTyuXDEypytjC5jUwMrWQmmF4CYWMJnRcELK6HhkI/jwt
-      /ZK7PdOL0JEvvZXVJ5LO3iK05xKwdB3XVojJbunpOqHIPXrdUWkPtBI1BwBSzknH
-      1C9qvt1r2qQw5ki8wONpRhgQPFMCD6Tr+c6jPhe+p2mvqpPe668cKh1gGblcC1zg
-      xVGtoikTSP2rQM/lioVi/grqzt/7UiGM2g+STfkqtJ8bkcEzL5IwbBUR+1uxfRzS
-      XgFH0XosccTBxUrHwufo98jw/ph5VjvnH1e9dqFu+wEXAtEDXc3AfVsGz2SBgdlp
-      5XVhql/Eu9POem5eLu/QNyOKUzNrm8YULMDDswCQO0Xg/dF4xioC3h0avcBsFiE=
-      =yakE
-      -----END PGP MESSAGE-----
-    fp: 07083D36FD5986B0C99700944E9B358045C1B176
-  - created_at: "2025-03-07T16:37:35Z"
-    enc: |-
-      -----BEGIN PGP MESSAGE-----
-
-      hQIMA8YdB40JfEZzARAAiCM4EkUoQgNCJQtvlXKQ5xWXQWGqCvBjFr4JFUa+Tjde
-      WSb1xP6sSd4TVPU/z9yZw+JlXxLLJNUm+gvtWUy7vgveYkudfuEdfY3+cyTBoqcQ
-      YIeMWo+jSlMLB+9dU/5O2Myv0ftwFKWPxsasK42l89Jfo4OLL8X9FSFlZHb1xeJy
-      P3pAYsLFo2TJ0y2qciR7hehSDC8RPiCukwSH6wpMd/Hu9Lsb4OmQUTy8nP+1LHrP
-      kI9/5WRasOT6SFP0THkVzCRKkM7rhrltVyffg9Cv/dxr85n1qwTC4YQ7y9ncaiJl
-      oUMY69Q5L3Bcb4mkYb+43alXKu37C/5J2JTMIxup5n2FO24/+gd18M8K2l5c1KNx
-      eAD/74H3WEEVUKTjQO80ZW9WRnRNfLtMYtYfRpFcXPXzr61TiON2ly9aCBGU2Rb3
-      0rlN/HFmw67MKj4r68KvC/AJfW24zEpbJxKs2ey3vOMSE+F7NDU5u9O4vNPPmr55
-      XlxFoPH2FvN0YD5MDYu9lWZTVkZlLuAaPG/XE2uzvmpPwoe3DCYHAHsKwT92a1oo
-      cz6DT82YzQCGIC3uHsuZcP46DQdQ2vUPgfLUZKQ8eZxq5o/tQYAMAFEG9m1UxSQH
-      O3ISJOhQa3+SBbhxoYfhcH3HWTOeGTL3S9102Fw/kLk3jvCODGBoBaN24S1P98nS
-      XgGF43cDEumGQzXHLVZKLqcrq+zMUjVEXYPtkl8n+xeJBNP4BG/4aQPAEREXXkiy
-      rAz+3zYCzqlmsceFoaPw+A5VHr8qxFWMOElnCs8kloMDlEndfPMHSfML4I/zdHU=
-      =hxne
-      -----END PGP MESSAGE-----
-    fp: 3582AE9F12CE295BDAF545ED17A5F53F11681446
+    created_at: "2025-08-28T20:37:22Z"
+    enc: vault:v1:myA322x4V71XWIYseRNjdHuJMe9sPAKQ3rQrPF95bzQ34WselInLQ4nVNGeBy7HY+4wVTg2vUBnAce4Z
+  lastmodified: "2025-08-28T20:37:22Z"
+  mac: ENC[AES256_GCM,data:CKPVduldwZ1rJBm+gPl+W+xYC4KJQymRWER/4w03pBNgiCN/YRfO/D8D59M+IbtPvDZnz34c7yH/l62OyLBmH291b2tMkzH94/xdhiIXdsbykK5Vm03WoOQVoiz+VAVhRJRX6lB8jJU0uGgLL4v+3fFeGdrTLpbm8KPKNFwLjWE=,iv:2U8ZHXuwfASbk1ffvhO0JKBIgtV4s9E+nYeWZxS8GEM=,tag:FQHtwo7znyIoKDW/podV1g==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.9.4
+  version: 3.10.2


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Sets up Learn edX as an LTI tool provider

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Deploy to CI/RC and set up the LTI provider configuration to Canvas

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
In order to more smoothly manage the Canvas bot functionality we want to allow the Learn edX to be an LTI provider so that it doesn't conflict with Canvas usage that is dependent residential MITx. In the Canvas case we don't need to associate the user accounts with their Kerberos, so there's not real benefit from the MITx residential edX being the provider. This allows us to have an LTI provider setup that is customized for the Canvas bot use case without conflicting with the residential use case.


