### PR TITLE
Adds a notebook query param

### DIFF
--- a/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
+++ b/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
@@ -26,7 +26,7 @@ class QueryStringKubeSpawner(KubeSpawner):
                 self.image = image_base.format(course)
                 # If we don't have a notebook, don't muck with default_url
                 # This falls back to the tree view in Jupyterhub if not specified
-                if notebook:
+                if notebook and notebook.endswith(".ipynb"):
                     self.default_url = f"/notebooks/{notebook}"
         return super().start()
 

--- a/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
+++ b/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
@@ -24,7 +24,10 @@ class QueryStringKubeSpawner(KubeSpawner):
             notebook = self.handler.get_query_argument("notebook", "")
             if course in KNOWN_COURSES:
                 self.image = image_base.format(course)
-                self.default_url = f"/notebooks/{notebook}"
+                # If we don't have a notebook, don't muck with default_url
+                # This falls back to the tree view in Jupyterhub if not specified
+                if notebook:
+                    self.default_url = f"/notebooks/{notebook}"
         return super().start()
 
 

--- a/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
+++ b/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
@@ -18,8 +18,13 @@ class QueryStringKubeSpawner(KubeSpawner):
         )
         if self.handler:
             course = self.handler.get_query_argument("course", "").lower()
+            # Notebook is case sensitive, and special characters
+            # with query string meaning must be URL encoded i.e.
+            # notebook=Assignment_2_Prediction_with_LogReg_%26_CART_%26_XGBoost.ipynb
+            notebook = self.handler.get_query_argument("notebook", "")
             if course in KNOWN_COURSES:
                 self.image = image_base.format(course)
+                self.default_url = f"/notebooks/{notebook}"
         return super().start()
 
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8028

### Description (What does it do?)
This PR adds a notebook query param. When a string ending in `.ipynb` is passed to a spawn link, we set this as a default URL, which allows us to drop the user directly into a notebook (provided it exists in the image). Filenames with characters that are meaningful to query params (i.e. `=`, `&`, `+`, `?`) need to be urlencoded.

If it does not exist, it'll 404, but there's not a straightforward way for us to check that the notebook exists within the image. If it doesn't end in `.ipynb`, we let Jupyter use its defaults (which will drop users into the tree view).


The result of this change is that if we build urls with query params off the [TmpAuthenticator provided `/tmplogin` endpoint](https://github.com/jupyterhub/tmpauthenticator/blob/main/tmpauthenticator/__init__.py#L9-L17) we will get freshly spawned container every time we hit the link for the corresponding course and users will be dropped directly into the notebook UI. See below for a few examples
```
https://nb.ci.learn.mit.edu/tmplogin?course=supervised_learning_fundamentals&notebook=Recitation_1.ipynb
https://nb.ci.learn.mit.edu/tmplogin?course=supervised_learning_fundamentals&notebook=Assignment_2_Prediction_with_LogReg_%26_CART_%26_XGBoost.ipynb
https://nb.ci.learn.mit.edu/tmplogin?course=clustering_and_descriptive_ai&notebook=Recitation.ipynb
```

### Screenshots (if appropriate):

https://github.com/user-attachments/assets/14e84215-f89c-484a-b769-fb16b21c3f43



### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
When applied, simply visiting `https://nb.ci.learn.mit.edu/tmplogin` with a valid course query param and notebook filename should spawn you directly into the corresponding course container and notebook.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
