### PR TITLE
First attempt at changing OIDC realm to use olapps

### DIFF
--- a/src/ol_infrastructure/applications/jupyterhub/__main__.py
+++ b/src/ol_infrastructure/applications/jupyterhub/__main__.py
@@ -239,7 +239,7 @@ oidc_resources = OLApisixOIDCResources(
         oidc_use_session_secret=True,
         oidc_scope="openid email",
         vault_mount="secret-operations",
-        vault_path="sso/jupyterhub",
+        vault_path="sso/mitlearn",
         vaultauth=vault_k8s_resources.auth_name,
     ),
 )

--- a/src/ol_infrastructure/applications/jupyterhub/jupyterhub_policy.hcl
+++ b/src/ol_infrastructure/applications/jupyterhub/jupyterhub_policy.hcl
@@ -1,7 +1,7 @@
-path "secret-operations/sso/jupyterhub/*" {
+path "secret-operations/sso/mitlearn/*" {
   capabilities = ["read"]
 }
-path "secret-operations/sso/jupyterhub" {
+path "secret-operations/sso/mitlearn" {
   capabilities = ["read"]
 }
 

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.CI.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.CI.yaml
@@ -55,8 +55,8 @@ config:
   keycloak_realm:ol-platform-engineering-leek-redirect-uris: ["https://celery-monitoring-ci.odl.mit.edu/*"]
   keycloak_realm:ol-platform-engineering-vault-redirect-uris: ["https://vault-ci.odl.mit.edu/ui/vault/auth/oidc/oidc/callback"]
   keycloak_realm:ol-platform-engineering-jupyterhub-redirect-uris:
-  - "https://nb.ci.learn.mit.edu/*"
-  - "https://binder.ci.learn.mit.edu/*"
+  - "https://nb.ci.ol.mit.edu/*"
+  - "https://binder.ci.ol.mit.edu/*"
   keycloak_realm:olapps-learn-ai-client-roles: ["https://api-learn-ai-ci.ol.mit.edu/*"]
   keycloak_realm:olapps-learn-ai-client-secret:
     secure: v1:hJQd4Gnpww6vFMI8:ScX791cNeXk1iWO0j/4uXMzfFivtTkhFWPCXkhJIbwIC/Jb5zaiFO591c25Ri64+
@@ -68,6 +68,8 @@ config:
   - "https://learn-ai-ci.ol.mit.edu/*"
   - "https://pay-ci.ol.mit.edu/*"
   - "https://ci.mitxonline.mit.edu/*"
+  - "https://nb.ci.learn.mit.edu/*"
+  - "https://binder.ci.learn.mit.edu/*"
   keycloak_realm:olapps-mitlearn-client-redirect-uris:
   - "https://api.ci.learn.mit.edu/*"
   - "https://ci.learn.mit.edu/*"
@@ -77,6 +79,8 @@ config:
   - "https://pay-ci.ol.mit.edu/*"
   - "https://ci.mitxonline.mit.edu/*"
   - "https://api.ci.mitxonline.mit.edu/*"
+  - "https://nb.ci.learn.mit.edu/*"
+  - "https://binder.ci.learn.mit.edu/*"
   keycloak_realm:olapps-mitlearn-client-secret:
     secure: v1:sJuWLKHeep4Qz9cr:YbZNIQoy3Bn1nbpKsCUPNUeEtZJgd+tA5LAU8pDfSKWr2fzvjfMy0XcmO4CR7a3q
   keycloak_realm:olapps-mitxonline-client-redirect-uris:

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.Production.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.Production.yaml
@@ -47,11 +47,15 @@ config:
   - "https://pay.ol.mit.edu/*"
   - "https://mitxonline.mit.edu/*"
   - "https://api.mitxonline.mit.edu/*"
+  - "https://nb.learn.mit.edu/*"
+  - "https://binder.learn.mit.edu/*"
   keycloak_realm:olapps-mitlearn-client-roles:
   - "https://learn.mit.edu/*"
   - "https://learn-ai.ol.mit.edu/*"
   - "https://pay.ol.mit.edu/*"
   - "https://mitxonline.mit.edu/*"
+  - "https://nb.learn.mit.edu/*"
+  - "https://binder.learn.mit.edu/*"
   keycloak_realm:olapps-mitxonline-client-redirect-uris:
   - "https://mitxonline.mit.edu/account/action/complete*"
   keycloak_realm:olapps-open-discussions-client-redirect-uris: ["https://open.mit.edu/*"]
@@ -62,8 +66,8 @@ config:
   - "https://vault-production.odl.mit.edu/ui/vault/auth/oidc/oidc/callback"
   - "http://localhost:8250/oidc/callback"
   keycloak_realm:ol-platform-engineering-jupyterhub-redirect-uris:
-  - "https://nb.learn.mit.edu/*"
-  - "https://binder.learn.mit.edu/*"
+  - "https://nb.ol.mit.edu/*"
+  - "https://binder.ol.mit.edu/*"
   keycloak_realm:ol-data-platform-superset-redirect-uris: ["https://bi.ol.mit.edu/*"]
   keycloak_realm:ol-data-platform-superset-client-roles:
   - "superset_admin"

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
@@ -50,11 +50,15 @@ config:
   - "https://pay-qa.ol.mit.edu/*"
   - "https://rc.mitxonline.mit.edu/*"
   - "https://api.rc.mitxonline.mit.edu/*"
+  - "https://nb.rc.learn.mit.edu/*"
+  - "https://binder.rc.learn.mit.edu/*"
   keycloak_realm:olapps-mitlearn-client-roles:
   - "https://rc.learn.mit.edu/*"
   - "https://learn-ai.ol.mit.edu/*"
   - "https://pay-qa.ol.mit.edu/*"
   - "https://rc.mitxonline.mit.edu/*"
+  - "https://nb.rc.learn.mit.edu/*"
+  - "https://binder.rc.learn.mit.edu/*"
   keycloak_realm:olapps-mitxonline-client-redirect-uris:
   - "https://rc.mitxonline.mit.edu/account/action/complete*"
   keycloak_realm:olapps-open-discussions-client-redirect-uris: ["https://discussions-rc.odl.mit.edu/*"]
@@ -65,8 +69,8 @@ config:
   - "https://vault-qa.odl.mit.edu/ui/vault/auth/oidc/oidc/callback"
   - "http://localhost:8250/oidc/callback"
   keycloak_realm:ol-platform-engineering-jupyterhub-redirect-uris:
-  - "https://nb.rc.learn.mit.edu/*"
-  - "https://binder.rc.learn.mit.edu/*"
+  - "https://nb.qa.ol.mit.edu/*"
+  - "https://binder.qa.ol.mit.edu/*"
   keycloak_realm:ol-data-platform-superset-redirect-uris: ["https://bi-qa.ol.mit.edu/*"]
   keycloak_realm:ol-data-platform-superset-client-roles:
   - "superset_admin"


### PR DESCRIPTION
### Description (What does it do?)
After some brief discussion [here](https://mitodl.slack.com/archives/G1VJQHQHK/p1756835317176429?thread_ts=1756835110.397759&cid=G1VJQHQHK) I took a swing at getting the realm and client switched over to use the existing SSO values in vault.

Two main blockers:
- ~Unsure if this is the right approach. Rather than explicitly trying to reuse a vault secret by specifying it's path, folks might prefer if I just copy the relevant values into `sso/jupyterhub` - not sure what is preferred!~
- ~It's not actually working. Even after `pulumi up` it's giving me old values. I've tried rolling the jupyter namespaced pods, but I kinda didn't expect that to change things - do I need to kick apisix pods in some way/shape/form?~ Tobias rolled some state and corrected a few missing redirect urls, works in CI now!

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
