### PR TITLE
Add some explicit depends_on links between resources for Jupyterhub

### DIFF
--- a/src/ol_infrastructure/applications/jupyterhub/__main__.py
+++ b/src/ol_infrastructure/applications/jupyterhub/__main__.py
@@ -145,7 +145,9 @@ jupyterhub_db_vault_backend_config = OLVaultPostgresDatabaseConfig(
     db_host=jupyterhub_db.db_instance.address,
     role_statements=postgres_role_statements,
 )
-jupyterhub_db_vault_backend = OLVaultDatabaseBackend(jupyterhub_db_vault_backend_config)
+jupyterhub_db_vault_backend = OLVaultDatabaseBackend(
+    jupyterhub_db_vault_backend_config, opts=ResourceOptions(depends_on=[jupyterhub_db])
+)
 jupyterhub_creds_secret_name = "jupyterhub-db-creds"  # noqa: S105  # pragma: allowlist secret
 
 # Create vault_k8s_resources to allow jupyter hub to access secrets in vault
@@ -196,6 +198,7 @@ app_db_creds_dynamic_secret_config = OLVaultK8SDynamicSecretConfig(
 app_db_creds_dynamic_secret = OLVaultK8SSecret(
     "jupyterhub-app-db-creds-vaultdynamicsecret",
     resource_config=app_db_creds_dynamic_secret_config,
+    opts=ResourceOptions(depends_on=jupyterhub_db_vault_backend),
 )
 
 


### PR DESCRIPTION
### Description (What does it do?)
Small changes to enable a fresh jupyterhub stack to come up clean.

### How can this be tested?
It's a fairly slow process, but I ran repeated `pulumi destroy`s followed by `pulumi up`s to test this. With both depends_on options set, I got a fresh stack in about 12 minutes:
```
Do you want to perform this update? yes
Updating (applications.jupyterhub.QA):
     Type                                                                  Name                                                                                                  Status              
 +   pulumi:pulumi:Stack                                                   ol-infrastructure-jupyterhub-application-applications.jupyterhub.QA                                   created (709s)      
 +   ├─ ol:infrastructure.aws.cloudwatch.OLCloudWatchAlarmRDS              jupyterhub-db-qa-WriteLatency-OLCloudWatchAlarmSimpleRDSConfig                                        created             
 +   │  └─ aws:cloudwatch:MetricAlarm                                      jupyterhub-db-qa-WriteLatency-simple-rds-alarm                                                        created (2s)        
 +   ├─ ol:infrastructure:services:k8s:OLApisixSharedPlugin                ol-jupyterhub-external-service-apisix-plugins                                                         created             
 +   │  └─ kubernetes:apisix.apache.org/v2:ApisixPluginConfig              OLApisixSharedPlugin-jupyterhub-ol-shared-plugins                                                     created (2s)        
 +   ├─ ol:infrastructure:services:k8s:OLApisixOIDCResources               ol-k8s-apisix-olapisixoidcresources-qa                                                                created             
 +   │  ├─ ol:services:Vault:K8S:VaultStaticSecret                         jupyterhub-oidc-secrets                                                                               created             
 +   │  └─ kubernetes:yaml/v2:ConfigGroup                                  OLVaultK8SSecret-jupyter-ol-apisix-jupyterhub-oidc-secrets                                            created             
 +   │     └─ kubernetes:secrets.hashicorp.com/v1beta1:VaultStaticSecret   OLVaultK8SSecret-jupyter-ol-apisix-jupyterhub-oidc-secrets:jupyter/ol-apisix-jupyterhub-oidc-secrets  created (0.74s)     
 +   ├─ ol:infrastructure:aws:database:OLAmazonDB                          jupyterhub-db-qa                                                                                      created (664s)      
 +   │  ├─ aws:rds:ParameterGroup                                          jupyterhub-db-qa-postgres-parameter-group                                                             created (4s)        
 +   │  └─ aws:rds:Instance                                                jupyterhub-db-qa-postgres-instance                                                                    created (653s)      
 +   ├─ ol:infrastructure.aws.cloudwatch.OLCloudWatchAlarmRDS              jupyterhub-db-qa-CPUUtilization-OLCloudWatchAlarmSimpleRDSConfig                                      created             
 +   │  └─ aws:cloudwatch:MetricAlarm                                      jupyterhub-db-qa-CPUUtilization-simple-rds-alarm                                                      created (2s)        
 +   ├─ ol:infrastructure:services:k8s:OLApisixRoute                       ol-jupyterhub-k8s-apisix-route-qa                                                                     created             
 +   │  └─ kubernetes:apisix.apache.org/v2:ApisixRoute                     OLApisixRoute-ol-jupyterhub-k8s-apisix-route-qa                                                       created (2s)        
 +   ├─ ol:infrastructure.aws.cloudwatch.OLCloudWatchAlarmRDS              jupyterhub-db-qa-FreeStorageSpace-OLCloudWatchAlarmSimpleRDSConfig                                    created             
 +   │  └─ aws:cloudwatch:MetricAlarm                                      jupyterhub-db-qa-FreeStorageSpace-simple-rds-alarm                                                    created (2s)        
 +   ├─ ol:infrastructure.services.cert_manager:OLCertManagerCert          ol-jupyterhub-binderhub-cert-manager-certificate-qa                                                   created             
 +   │  ├─ kubernetes:apisix.apache.org/v2:ApisixTls                       ol-cert-manager-apisix-tls-jupyterhub-cert                                                            created (2s)        
 +   │  └─ kubernetes:cert-manager.io/v1:Certificate                       ol-cert-manager-certificate-jupyterhub-cert                                                           created (3s)        
 +   ├─ ol:infrastructure.aws.cloudwatch.OLCloudWatchAlarmRDS              jupyterhub-db-qa-ReadLatency-OLCloudWatchAlarmSimpleRDSConfig                                         created             
 +   │  └─ aws:cloudwatch:MetricAlarm                                      jupyterhub-db-qa-ReadLatency-simple-rds-alarm                                                         created (2s)        
 +   ├─ aws:ec2:SecurityGroup                                              jupyterhub-db-security-group-jupyterhub-qa                                                            created (4s)        
 +   ├─ pulumi:providers:vault                                             vault-provider                                                                                        created (2s)        
 +   ├─ pulumi:providers:kubernetes                                        k8s-provider                                                                                          created (3s)        
 +   ├─ vault:index:Policy                                                 ol-jupyterhub-vault-policy-qa                                                                         created (2s)        
 +   ├─ vault:kubernetes:AuthBackendRole                                   ol-jupyterhub-vault-k8s-auth-backend-role-qa                                                          created (2s)        
 +   ├─ ol:services:Vault:K8S:ResourcesConfig                              jupyterhub                                                                                            created             
 +   │  ├─ kubernetes:yaml/v2:ConfigGroup                                  jupyterhub-vso-resources                                                                              created             
 +   │  │  ├─ kubernetes:secrets.hashicorp.com/v1beta1:VaultAuth           jupyterhub-vso-resources:jupyter/jupyterhub-auth                                                      created (0.71s)     
 +   │  │  └─ kubernetes:secrets.hashicorp.com/v1beta1:VaultConnection     jupyterhub-vso-resources:jupyter/jupyterhub-vault-connection                                          created (0.42s)     
 +   │  ├─ kubernetes:core/v1:ServiceAccount                               jupyterhub-vault-service-account                                                                      created (0.25s)     
 +   │  └─ kubernetes:rbac.authorization.k8s.io/v1:ClusterRoleBinding      jupyterhub-vault-cluster-role-binding                                                                 created (0.65s)     
 +   ├─ ol:services:Vault:DatabaseBackend:postgresql                       jupyterhub                                                                                            created (0.57s)     
 +   │  └─ vault:index:Mount                                               jupyterhub-mount-point                                                                                created (0.47s)     
 +   │     └─ vault:database:SecretBackendConnection                       jupyterhub-database-connection                                                                        created (0.59s)     
 +   │        ├─ vault:database:SecretBackendRole                          jupyterhub-database-role-app                                                                          created (1s)        
 +   │        ├─ vault:database:SecretBackendRole                          jupyterhub-database-role-readonly                                                                     created (1s)        
 +   │        └─ vault:database:SecretBackendRole                          jupyterhub-database-role-admin                                                                        created (0.69s)     
 +   ├─ ol:services:Vault:K8S:VaultDynamicSecret                           jupyterhub-app-db-creds-vaultdynamicsecret                                                            created             
 +   │  └─ kubernetes:yaml/v2:ConfigGroup                                  OLVaultK8SSecret-jupyter-jupyterhub-app-db-creds                                                      created             
 +   │     └─ kubernetes:secrets.hashicorp.com/v1beta1:VaultDynamicSecret  OLVaultK8SSecret-jupyter-jupyterhub-app-db-creds:jupyter/jupyterhub-app-db-creds                      created (1s)        
 +   └─ kubernetes:helm.sh/v3:Release                                      binderhub-QA-application-helm-release                                                                 created (28s)       

Resources:
    + 44 created

Duration: 11m52s
``` 

