### PR TITLE
Use extraimages to prepull images

### DIFF
--- a/src/ol_infrastructure/applications/jupyterhub/__main__.py
+++ b/src/ol_infrastructure/applications/jupyterhub/__main__.py
@@ -416,6 +416,30 @@ binderhub_application = kubernetes.helm.v3.Release(
                     },
                 },
                 "prePuller": {
+                    "continuous": {
+                        "enabled": True,
+                    },
+                    "hook": {
+                        "enabled": True,
+                    },
+                    "extraImages": {
+                        "clustering-and-descriptive-ai": {
+                            "name": "610119931565.dkr.ecr.us-east-1.amazonaws.com/ol-course-notebooks",
+                            "tag": "clustering_and_descriptive_ai",
+                        },
+                        "deep-learning-foundations-and-applications": {
+                            "name": "610119931565.dkr.ecr.us-east-1.amazonaws.com/ol-course-notebooks",
+                            "tag": "deep_learning_foundations_and_applications",
+                        },
+                        "introduction-to-data-analytics-and-machine-learning": {
+                            "name": "610119931565.dkr.ecr.us-east-1.amazonaws.com/ol-course-notebooks",
+                            "tag": "introduction_to_data_analytics_and_machine_learning",
+                        },
+                        "supervised-learning-fundamentals": {
+                            "name": "610119931565.dkr.ecr.us-east-1.amazonaws.com/ol-course-notebooks",
+                            "tag": "supervised_learning_fundamentals",
+                        },
+                    },
                     "resources": {
                         "requests": {
                             "cpu": "10m",
@@ -425,7 +449,7 @@ binderhub_application = kubernetes.helm.v3.Release(
                             "cpu": "10m",
                             "memory": "10Mi",
                         },
-                    }
+                    },
                 },
                 "singleuser": {
                     # This is where we would do our own notebook image


### PR DESCRIPTION
### Description (What does it do?)
Uses continuous and hook prePuller to snag all currently built images

### How can this be tested?
Visiting any of the following links should no longer result in delays due to image pulling once pre-puller daemonsets have completed post apply:
```
https://nb.rc.learn.mit.edu/tmplogin?course=deep_learning_foundations_and_applications&notebook=Recitation_2.ipynb
https://nb.rc.learn.mit.edu/tmplogin?course=introduction_to_data_analytics_and_machine_learning&notebook=Recitation_1.ipynb
https://nb.rc.learn.mit.edu/tmplogin?course=supervised_learning_fundamentals&notebook=Recitation_1.ipynb
https://nb.rc.learn.mit.edu/tmplogin?course=supervised_learning_fundamentals&notebook=Assignment_2_Prediction_with_LogReg_%26_CART_%26_XGBoost.ipynb
https://nb.rc.learn.mit.edu/tmplogin?course=clustering_and_descriptive_ai&notebook=Recitation.ipynb
```

Additionally, looking at `hook-image-puller` daemonsets should reflect each of the four images being either pulled or found on boxes:
<img width="1466" height="877" alt="Screenshot 2025-09-03 at 3 39 16 PM" src="https://github.com/user-attachments/assets/c7f1fa10-cf8a-4be4-8cce-0e15d48171fe" />


### Additional Context
This is probably tractable at the moment because we only have 4 images, but they range in size from 2.5GB to a bit north of 5GB. That said, if we see broader adoption (particularly using programmatic authoring flows to speed things up) we may need to revisit this - I've got no idea how much capacity it'll take to run these pulls in practice or how much we'll end up paying for in increased storage.

Also, because they're so big, a `pulumi up` command now is likely to timeout:
```
Diagnostics:
  pulumi:pulumi:Stack (ol-infrastructure-jupyterhub-application-applications.jupyterhub.QA):
    error: update failed

  kubernetes:helm.sh/v3:Release (binderhub-QA-application-helm-release):
    error: 1 error occurred:
    	* Helm release "jupyter/binderhub" failed to initialize completely. Use Helm CLI to investigate: failed to become available within allocated timeout. Error: Helm Release jupyter/binderhub: pre-upgrade hooks failed: 1 error occurred:
    	* timed out waiting for the condition
```

Right now, practically, this doesn't hurt anything and just letting it finish doing its thing and rerunning pulumi to ensure everything looks good works. It does, however, suck and will only get worse if we add more images, so we may need to either run with a gratuitously long timeout.


### Checklist:
- [ ] Run on CI environment without impeding Mike's work.
