### PR TITLE
Remove hook prepulling behavior

### DIFF
--- a/src/ol_infrastructure/applications/jupyterhub/__main__.py
+++ b/src/ol_infrastructure/applications/jupyterhub/__main__.py
@@ -419,9 +419,6 @@ binderhub_application = kubernetes.helm.v3.Release(
                     "continuous": {
                         "enabled": True,
                     },
-                    "hook": {
-                        "enabled": True,
-                    },
                     "extraImages": {
                         # The object keys here are used for RFC 1123 names of init containers.
                         # No underscores are allowed


### PR DESCRIPTION
### Description (What does it do?)
Missed a file in https://github.com/mitodl/ol-infrastructure/pull/3539 - this removes the prepulling behavior on helm upgrades in favor of relying solely on the continuous prepuller
