### PR TITLE
Lower the passauth mitxonline route priority to 0

### DIFF
--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -617,7 +617,7 @@ mitxonline_apisix_route_direct = OLApisixRoute(
     route_configs=[
         OLApisixRouteConfig(
             route_name="passauth",
-            priority=10,
+            priority=0,
             hosts=[api_domain],
             paths=["/*"],
             shared_plugin_config_name=mitxonline_shared_plugins.resource_name,
@@ -673,7 +673,7 @@ mitxonline_apisix_route_prefix = OLApisixRoute(
     route_configs=[
         OLApisixRouteConfig(
             route_name="passauth",
-            priority=10,
+            priority=0,
             hosts=[learn_api_domain],
             paths=[f"/{api_path_prefix}/*"],
             shared_plugin_config_name=mitxonline_shared_plugins.resource_name,


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->

Lowers the priority of the default route so that login and logout will have higher priority.
