### PR TITLE
config: Add settings to pre-emptively scale notebooks for users

### DIFF
--- a/src/ol_infrastructure/applications/jupyterhub/__main__.py
+++ b/src/ol_infrastructure/applications/jupyterhub/__main__.py
@@ -350,7 +350,16 @@ binderhub_application = kubernetes.helm.v3.Release(
                     },
                 },
                 "scheduling": {
+                    "podPriority": {"enabled": True},
+                    "userPlaceholder": {
+                        "enabled": True,
+                        "replicas": jupyterhub_config.get_int(
+                            "user_placeholder_replicas"
+                        )
+                        or 4,
+                    },
                     "userScheduler": {
+                        "enabled": True,
                         "resources": {
                             "requests": {
                                 "cpu": "100m",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8024

### Description (What does it do?)
<!--- Describe your changes in detail -->
In order to avoid having users wait for new Karpenter nodes to be provisioned if there is a ramp-up of usage, this pre-emptively schedules a certain number of pods to warm up the infrastructure. Based on docs at https://z2jh.jupyter.org/en/latest/administrator/optimization.html

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Deploy and see if Karpenter scales nodes based on pre-emptive usage
