### PR TITLE
feat: Added code to dynamically add node selector based on the course name.

### DIFF
--- a/src/ol_infrastructure/applications/jupyterhub/__main__.py
+++ b/src/ol_infrastructure/applications/jupyterhub/__main__.py
@@ -459,21 +459,9 @@ binderhub_application = kubernetes.helm.v3.Release(
                     },
                 },
                 "singleuser": {
-                    # This is where we would do our own notebook image
-                    # ref: https://z2jh.jupyter.org/en/stable/jupyterhub/customizing/user-environment.html#customize-an-existing-docker-image
-                    # "image": {
-                    #     "name": "mitodl/some-special-image"
-                    #     "tag": "some-tag",
-                    # },
-                    # Below is similar but not the same as k8s resource declarations.
-                    # These are on a PER-USER-BASIS, so they can quickly grow with lots of
-                    # users. Numbers are conservative to start with.
                     "image": {
                         "name": "610119931565.dkr.ecr.us-east-1.amazonaws.com/ol-course-notebooks",
                         "tag": "clustering_and_descriptive_ai",
-                    },
-                    "nodeSelector": {
-                        "ol.mit.edu/gpu_node": "true",
                     },
                     "extraTolerations": [
                         {

--- a/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
+++ b/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
@@ -2,6 +2,18 @@ import os
 
 from kubespawner import KubeSpawner
 
+GPU_NODE_AFFINITY_LIST = [
+    {
+        "matchExpressions": [
+            {
+                "key": "ol.mit.edu/gpu_node",
+                "operator": "In",
+                "values": ["true"],
+            }
+        ]
+    }
+]
+
 
 class QueryStringKubeSpawner(KubeSpawner):
     def start(self):
@@ -14,6 +26,7 @@ class QueryStringKubeSpawner(KubeSpawner):
             "supervised_learning_fundamentals",
             "introduction_to_data_analytics_and_machine_learning",
         ]
+        GPU_ENABLED_COURSES = ["deep_learning_foundations_and_applications"]
         self.image = (
             "610119931565.dkr.ecr.us-east-1.amazonaws.com/"
             "ol-course-notebooks:clustering_and_descriptive_ai"
@@ -32,20 +45,12 @@ class QueryStringKubeSpawner(KubeSpawner):
                 self.image = (
                     image_base.format(tag) if tag else image_base.format(course)
                 )
-                if course == "deep_learning_foundations_and_applications":
+
+                if course in GPU_ENABLED_COURSES:
                     # This course requires a GPU, so we are adding a node affinity
                     # rule to schedule the pod on a node with a GPU.
-                    self.node_affinity_required = [
-                        {
-                            "matchExpressions": [
-                                {
-                                    "key": "ol.mit.edu/gpu_node",
-                                    "operator": "In",
-                                    "values": ["true"],
-                                }
-                            ]
-                        }
-                    ]
+                    self.node_affinity_required = GPU_NODE_AFFINITY_LIST
+
                 # If we don't have a notebook, don't muck with default_url
                 # This falls back to the tree view in Jupyterhub if not specified
                 if notebook and notebook.endswith(".ipynb"):

--- a/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
+++ b/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
@@ -32,6 +32,20 @@ class QueryStringKubeSpawner(KubeSpawner):
                 self.image = (
                     image_base.format(tag) if tag else image_base.format(course)
                 )
+                if course == "deep_learning_foundations_and_applications":
+                    # This course requires a GPU, so we are adding a node affinity
+                    # rule to schedule the pod on a node with a GPU.
+                    self.node_affinity_required = [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "ol.mit.edu/gpu_node",
+                                    "operator": "In",
+                                    "values": ["true"],
+                                }
+                            ]
+                        }
+                    ]
                 # If we don't have a notebook, don't muck with default_url
                 # This falls back to the tree view in Jupyterhub if not specified
                 if notebook and notebook.endswith(".ipynb"):

--- a/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
+++ b/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
@@ -26,7 +26,7 @@ class QueryStringKubeSpawner(KubeSpawner):
             "supervised_learning_fundamentals",
             "introduction_to_data_analytics_and_machine_learning",
         ]
-        GPU_ENABLED_COURSES = ["deep_learning_foundations_and_applications"]
+        GPU_ENABLED_COURSES = {"deep_learning_foundations_and_applications"}
         self.image = (
             "610119931565.dkr.ecr.us-east-1.amazonaws.com/"
             "ol-course-notebooks:clustering_and_descriptive_ai"


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
Picking up Mike's work and taking it across the line - this lets us specify on a per-course basis whether or not to use a GPU enabled node for a given course or not.

### Additional Context
For now we're choosing to tie course to GPU affinity directly, but we might decouple this a bit in the future (for example, if a course has multiple notebooks, only some of which need a GPU) - this would probably take the form of an explicit GPU query param or determining the affinity from a combination of course + notebook.
