### PR TITLE
fix: application stability 

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1389,8 +1389,8 @@ mitlearn_k8s_app = OLApplicationK8s(
                 redis_password=redis_config.require("password"),
             ),
         ],
-        resource_requests={"cpu": "500m", "memory": "1800Mi"},
-        resource_limits={"cpu": "1000m", "memory": "1800Mi"},
+        resource_requests={"cpu": "500m", "memory": "1600Mi"},
+        resource_limits={"cpu": "1000m", "memory": "2000Mi"},
         hpa_scaling_metrics=[
             kubernetes.autoscaling.v2.MetricSpecArgs(
                 type="Resource",


### PR DESCRIPTION
- Tweaked memory requests and limits for mitlearn. 
- Changed the default app PDB to use maxUnavailable rather than minAvailable. 
- Changed the rolling deployment max surge to 100%. 
- Adjusted the startup probe to give the pod 1 minute to startup rather than five. 
- Added pod anti-affinity to application deployments by default.
