### PR TITLE
feat: First step of adding blue/green nodegroup logic for K8s clusters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "pulumi-eks>=4,<5",
     "pulumi-aws-native>=1.25.0,<2",
     "packaging>=24.2",
+    "kubernetes>=29,<32",
 ]
 
 [project.urls]

--- a/scripts/eks/drain_old_nodegroup.py
+++ b/scripts/eks/drain_old_nodegroup.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+# ruff: noqa: T201
+"""Taint and drain all nodes in an old EKS nodegroup, then optionally delete its ASG.
+
+Prereqs:
+- AWS credentials with permissions to describe/update Auto Scaling Groups and EC2.
+
+- Kubeconfig set to point to the cluster (export KUBECONFIG or run `aws eks
+  update-kubeconfig`).
+
+- Python deps: boto3, kubernetes.
+
+Usage:
+  python scripts/eks/drain_old_nodegroup.py \
+    --asg-name <OLD_ASG_NAME> \
+    [--taint-key ol.mit.edu/decommission] \
+    [--taint-value true] \
+    [--timeout-seconds 1200] \
+    [--scale-to-zero] \
+    [--delete-asg]
+
+Notes:
+- If you pass --delete-asg, the ASG will be deleted in AWS, which will drift from Pulumi
+  state until you remove the old nodegroup from code and run `pulumi up`.
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from collections.abc import Iterable
+
+import boto3
+from botocore.exceptions import ClientError
+from kubernetes import client, config
+from kubernetes.client import V1Pod
+from kubernetes.client.exceptions import ApiException
+
+
+def _get_asg_instance_ids(asg_name: str) -> list[str]:
+    asg = boto3.client("autoscaling")
+    resp = asg.describe_auto_scaling_groups(AutoScalingGroupNames=[asg_name])
+    groups = resp.get("AutoScalingGroups", [])
+    if not groups:
+        msg = f"ASG not found: {asg_name}"
+        raise SystemExit(msg)
+    return [inst["InstanceId"] for inst in groups[0].get("Instances", [])]
+
+
+def _instance_ids_to_node_names(instance_ids: Iterable[str]) -> list[str]:
+    ec2 = boto3.client("ec2")
+    if not instance_ids:
+        return []
+    resp = ec2.describe_instances(InstanceIds=list(instance_ids))
+    names: list[str] = []
+    for r in resp.get("Reservations", []):
+        for i in r.get("Instances", []):
+            # EKS nodes typically use PrivateDnsName as the kube node name
+            if i.get("PrivateDnsName"):
+                names.append(i["PrivateDnsName"])  # noqa: PERF401
+    return names
+
+
+def _cordon_and_taint_node(
+    core: client.CoreV1Api, node_name: str, taint_key: str, taint_value: str
+) -> None:
+    # Cordon
+    core.patch_node(node_name, {"spec": {"unschedulable": True}})
+    # Taint
+    patch = {
+        "spec": {
+            "taints": [
+                {
+                    "key": taint_key,
+                    "value": taint_value,
+                    "effect": "NoSchedule",
+                }
+            ]
+        }
+    }
+    try:
+        core.patch_node(node_name, patch)
+    except ApiException as exc:  # Best-effort (node may already have taints)
+        if exc.status not in (200, 201):
+            raise
+
+
+def _is_daemon_pod(pod: V1Pod) -> bool:
+    if not pod.metadata or not pod.metadata.owner_references:
+        return False
+    return any(owner.kind == "DaemonSet" for owner in pod.metadata.owner_references)
+
+
+def _is_mirror_pod(pod: V1Pod) -> bool:
+    annotations = (pod.metadata and pod.metadata.annotations) or {}
+    return "kubernetes.io/config.mirror" in annotations
+
+
+def _evict_pod(policy_api: client.PolicyV1Api, pod: V1Pod, grace_period_seconds=60):
+    body = client.V1Eviction(
+        delete_options=client.V1DeleteOptions(
+            grace_period_seconds=grace_period_seconds
+        ),
+        metadata=client.V1ObjectMeta(
+            name=pod.metadata.name, namespace=pod.metadata.namespace
+        ),
+    )
+    try:
+        policy_api.create_namespaced_pod_eviction(
+            name=pod.metadata.name, namespace=pod.metadata.namespace, body=body
+        )
+    except ApiException as exc:
+        if exc.status not in (200, 201, 202, 404):
+            raise
+
+
+def _drain_node(
+    core: client.CoreV1Api,
+    policy_api: client.PolicyV1Api,
+    node_name: str,
+    timeout_seconds: int,
+):
+    # Evict all non-daemon, non-mirror pods
+    field_selector = f"spec.nodeName={node_name}"
+    pods = core.list_pod_for_all_namespaces(field_selector=field_selector).items
+    for pod in pods:
+        if _is_daemon_pod(pod) or _is_mirror_pod(pod):
+            continue
+        _evict_pod(policy_api, pod)
+
+    # Wait until pods are gone
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        pods = core.list_pod_for_all_namespaces(field_selector=field_selector).items
+        remaining = [p for p in pods if not (_is_daemon_pod(p) or _is_mirror_pod(p))]
+        if not remaining:
+            return
+        time.sleep(5)
+    msg = f"Timeout draining node {node_name}"
+    raise TimeoutError(msg)
+
+
+def _scale_asg_to_zero(asg_name: str):
+    asg = boto3.client("autoscaling")
+    asg.update_auto_scaling_group(
+        AutoScalingGroupName=asg_name, MinSize=0, MaxSize=0, DesiredCapacity=0
+    )
+
+
+def _delete_asg(asg_name: str):
+    asg = boto3.client("autoscaling")
+    try:
+        asg.delete_auto_scaling_group(AutoScalingGroupName=asg_name, ForceDelete=True)
+    except ClientError as exc:
+        if exc.response.get("Error", {}).get("Code") == "ResourceInUse":
+            # Try scaling to zero and retry delete shortly after
+            _scale_asg_to_zero(asg_name)
+            time.sleep(10)
+            asg.delete_auto_scaling_group(
+                AutoScalingGroupName=asg_name, ForceDelete=True
+            )
+        else:
+            raise
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--asg-name", required=True, help="Old nodegroup ASG name")
+    parser.add_argument(
+        "--taint-key",
+        default="ol.mit.edu/decommission",
+        help="Taint key to apply to old nodes",
+    )
+    parser.add_argument("--taint-value", default="true", help="Taint value")
+    parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=20 * 60,
+        help="Drain timeout per node (seconds)",
+    )
+    parser.add_argument(
+        "--scale-to-zero",
+        action="store_true",
+        help="After drain, scale the old ASG to zero",
+    )
+    parser.add_argument(
+        "--delete-asg",
+        action="store_true",
+        help="After drain, delete the old ASG (will drift from Pulumi state)",
+    )
+    args = parser.parse_args()
+
+    # Build clients
+    config.load_kube_config()
+    core = client.CoreV1Api()
+    policy_api = client.PolicyV1Api()
+
+    instance_ids = _get_asg_instance_ids(args.asg_name)
+    node_names = _instance_ids_to_node_names(instance_ids)
+    if not node_names:
+        print("No instances/nodes found in ASG; nothing to do.")
+        return
+
+    # Cordon/taint and drain nodes
+    for node_name in node_names:
+        print(f"Cordoning and tainting {node_name}…")
+        _cordon_and_taint_node(core, node_name, args.taint_key, args.taint_value)
+    for node_name in node_names:
+        print(f"Draining {node_name}…")
+        _drain_node(core, policy_api, node_name, args.timeout_seconds)
+
+    # Optionally scale to zero or delete
+    if args.delete_asg:
+        print(f"Deleting ASG {args.asg_name}…")
+        _delete_asg(args.asg_name)
+    elif args.scale_to_zero:
+        print(f"Scaling ASG {args.asg_name} to zero…")
+        _scale_asg_to_zero(args.asg_name)
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ol_infrastructure/infrastructure/aws/eks/aws_utils.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/aws_utils.py
@@ -17,7 +17,6 @@ def setup_aws_integrations(
     cluster,
     aws_config,
     k8s_global_labels,
-    k8s_provider,
     operations_tolerations,
     target_vpc,
     node_groups,
@@ -289,7 +288,6 @@ def setup_aws_integrations(
         ),
         automount_service_account_token=True,
         opts=ResourceOptions(
-            provider=k8s_provider,
             parent=cluster,
             depends_on=[
                 cluster,
@@ -354,7 +352,6 @@ def setup_aws_integrations(
             skip_await=False,
         ),
         opts=ResourceOptions(
-            provider=k8s_provider,
             parent=cluster,
             depends_on=[
                 cluster,
@@ -407,7 +404,6 @@ def setup_aws_integrations(
             },
         ),
         opts=ResourceOptions(
-            provider=k8s_provider,
             parent=cluster,
             delete_before_replace=True,
         ),

--- a/src/ol_infrastructure/infrastructure/aws/eks/core_dns.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/core_dns.py
@@ -10,7 +10,6 @@ from pulumi import ResourceOptions
 def create_core_dns_resources(
     cluster_name: str,
     k8s_global_labels: dict[str, str],
-    k8s_provider: kubernetes.Provider,
     cluster: eks.Cluster,
 ):
     """
@@ -38,7 +37,7 @@ def create_core_dns_resources(
                 }
             ),
         ),
-        opts=ResourceOptions(provider=k8s_provider, parent=cluster),
+        opts=ResourceOptions(parent=cluster),
     )
 
     # Modifying the coredns plugin is a huge pain, so we just patch the existing
@@ -61,5 +60,5 @@ def create_core_dns_resources(
                 },
             },
         },
-        opts=ResourceOptions(provider=k8s_provider, parent=cluster),
+        opts=ResourceOptions(parent=cluster),
     )

--- a/src/ol_infrastructure/infrastructure/aws/eks/nodegroups.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/nodegroups.py
@@ -1,0 +1,213 @@
+import hashlib
+import json
+from typing import Any
+
+import pulumi_aws as aws
+import pulumi_eks as eks
+import pulumi_kubernetes as kubernetes
+from pulumi import Config, Output, ResourceOptions, export
+
+from ol_infrastructure.lib.aws.eks_helper import get_cluster_version
+from ol_infrastructure.lib.ol_types import AWSBase
+from ol_infrastructure.lib.pulumi_helper import parse_stack
+
+
+def create_and_update_nodegroup(  # noqa: PLR0913
+    ng_name: str,
+    ng_config: dict[str, Any],
+    cluster: eks.Cluster,
+    cluster_role: aws.iam.Role,
+    node_role: aws.iam.Role,
+    node_instance_profile: aws.iam.InstanceProfile,
+    target_vpc: Output[dict[str, Any]],
+    aws_config: AWSBase,
+    k8s_provider: kubernetes.Provider,
+):
+    node_groups = []
+    stack_info = parse_stack()
+    cluster_name = f"{stack_info.env_prefix}-{stack_info.env_suffix}"
+    eks_config = Config("eks")
+    pod_ip_blocks = target_vpc["k8s_pod_subnet_cidrs"]
+    taint_list = {}
+    for taint_name, taint_config in ng_config["taints"].items() or {}:
+        taint_list[taint_name] = eks.TaintArgs(
+            value=taint_config["value"],
+            effect=taint_config["effect"],
+        )
+
+    # New hash-based blue/green logic:
+    # 1. Always have exactly one active nodegroup hash recorded in SSM (active_hash).
+    # 2. When desired hash differs, create candidate nodegroup alongside active; keep
+    # active untouched.
+    # 3. Exports expose active & candidate ASG names for drain operations.
+    # 4. When promotion flag set and candidate hash matches desired, only create new
+    # active and remove old.
+    architecture = ng_config.get("architecture") or "x86_64"
+    ami_type = "nvidia" if ng_config.get("gpu") else "standard"
+    ami_param = f"/aws/service/eks/optimized-ami/{get_cluster_version()}/amazon-linux-2023/{architecture}/{ami_type}/recommended/image_id"  # noqa: E501
+    resolved_ami = aws.ssm.get_parameter(name=ami_param).value
+    desired_bytes = json.dumps(
+        {
+            "cluster_version": get_cluster_version(),
+            "instance_type": ng_config["instance_type"],
+            "gpu": ng_config.get("gpu") or False,
+            "disk": ng_config["disk_size_gb"] or 250,
+            "labels": ng_config["labels"] or {},
+            "taints": ng_config.get("taints") or {},
+            "ami_id": resolved_ami,
+        },
+        sort_keys=True,
+    ).encode()
+    desired_hash = hashlib.sha1(desired_bytes, usedforsecurity=False).hexdigest()[:8]
+
+    active_param_name = (
+        f"/ol-infrastructure/eks/{cluster_name}/nodegroups/{ng_name}/active_hash"
+    )
+    candidate_param_name = (
+        f"/ol-infrastructure/eks/{cluster_name}/nodegroups/{ng_name}/candidate_hash"
+    )
+
+    def _ssm_get(name: str) -> str | None:
+        try:
+            return aws.ssm.get_parameter(name=name).value
+        except Exception:  # noqa: BLE001
+            return None
+
+    active_hash = _ssm_get(active_param_name)
+    candidate_hash = _ssm_get(candidate_param_name)
+    promote = eks_config.get_bool("promote_nodegroups") or False
+
+    # Bootstrap active hash if absent
+    if not active_hash:
+        active_hash = desired_hash
+        aws.ssm.Parameter(
+            f"{cluster_name}-eks-nodegroup-{ng_name}-active-hash-param",
+            name=active_param_name,
+            type="String",
+            value=active_hash,
+            overwrite=True,
+            tags=aws_config.tags,
+        )
+
+    need_candidate = desired_hash not in [active_hash, candidate_hash]
+    promoting = promote and candidate_hash and candidate_hash == desired_hash
+
+    if need_candidate:
+        candidate_hash = desired_hash
+        aws.ssm.Parameter(
+            f"{cluster_name}-eks-nodegroup-{ng_name}-candidate-hash-param",
+            name=candidate_param_name,
+            type="String",
+            value=candidate_hash,
+            overwrite=True,
+            tags=aws_config.tags,
+        )
+
+    if promoting:
+        # Update active hash to candidate and do not recreate candidate
+        aws.ssm.Parameter(
+            f"{cluster_name}-eks-nodegroup-{ng_name}-active-hash-promote",
+            name=active_param_name,
+            type="String",
+            value=candidate_hash,
+            overwrite=True,
+            tags=aws_config.tags,
+        )
+        active_hash = candidate_hash
+        candidate_hash = None  # stop defining candidate resource
+
+    # Helper for nodegroup creation
+    def _create_ng(hash_value: str, export_key: str, *, is_active: bool = True):
+        resource_options = ResourceOptions(parent=cluster, depends_on=cluster)
+        if is_active:
+            resource_options.merge(
+                ResourceOptions(ignore_changes=["instance_type", "image_id"])
+            )
+        sec = eks.NodeGroupSecurityGroup(
+            f"{cluster_name}-eks-nodegroup-{ng_name}-{hash_value}-secgroup",
+            cluster_security_group=cluster.cluster_security_group,
+            eks_cluster=cluster.eks_cluster,
+            vpc_id=target_vpc["id"],
+            tags=aws_config.tags,
+        )
+        ng_res = eks.NodeGroupV2(
+            f"{cluster_name}-eks-nodegroup-{ng_name}-{hash_value}",
+            cluster=eks.CoreDataArgs(
+                cluster=cluster.eks_cluster,
+                cluster_iam_role=cluster_role,
+                endpoint=cluster.eks_cluster.endpoint,
+                instance_roles=[node_role],
+                node_group_options=eks.ClusterNodeGroupOptionsArgs(
+                    node_associate_public_ip_address=False,
+                ),
+                subnet_ids=target_vpc["k8s_pod_subnet_ids"],
+                vpc_id=target_vpc["id"],
+                provider=k8s_provider,
+            ),
+            launch_template_tag_specifications=[
+                aws.ec2.LaunchTemplateTagSpecificationArgs(
+                    resource_type="instance",
+                    tags=aws_config.merged_tags(ng_config.get("tags") or {}),
+                ),
+                aws.ec2.LaunchTemplateTagSpecificationArgs(
+                    resource_type="volume",
+                    tags=aws_config.merged_tags(ng_config.get("tags") or {}),
+                ),
+            ],
+            gpu=ng_config.get("gpu") or False,
+            min_refresh_percentage=eks_config.get_int("min_refresh_percentage") or 90,
+            instance_type=ng_config["instance_type"],
+            instance_profile=node_instance_profile,
+            labels=ng_config.get("labels", {}),
+            node_security_group=sec.security_group,
+            node_root_volume_size=ng_config["disk_size_gb"] or 250,
+            node_root_volume_delete_on_termination=True,
+            node_root_volume_type="gp3",
+            cluster_ingress_rule=sec.security_group_rule,
+            desired_capacity=ng_config["scaling"]["desired"] or 3,
+            max_size=ng_config["scaling"]["max"] or 5,
+            min_size=ng_config["scaling"]["min"] or 2,
+            taints=taint_list,
+            opts=resource_options,
+        )
+        aws.ec2.SecurityGroupRule(
+            f"{cluster_name}-eks-nodegroup-{ng_name}-{hash_value}-podcidr",
+            type="ingress",
+            description="Allow all traffic from pod CIDRs",
+            security_group_id=sec.security_group.id,
+            protocol="-1",
+            from_port=0,
+            to_port=0,
+            cidr_blocks=pod_ip_blocks,
+        )
+        export(export_key, ng_res.auto_scaling_group.name)
+        return ng_res
+
+    # active_hash guaranteed non-None after bootstrap above
+    active_ng = _create_ng(active_hash, f"{ng_name}_active_asg_name", is_active=True)  # type: ignore[arg-type]
+    node_groups.append(active_ng)
+    if candidate_hash:
+        candidate_ng = _create_ng(
+            candidate_hash, f"{ng_name}_candidate_asg_name", is_active=False
+        )
+        node_groups.append(candidate_ng)
+        # Bi-directional SG rules
+        aws.ec2.SecurityGroupRule(
+            f"{cluster_name}-eks-nodegroup-{ng_name}-{active_hash}-to-{candidate_hash}",
+            type="ingress",
+            security_group_id=active_ng.node_security_group_id,
+            source_security_group_id=candidate_ng.node_security_group_id,
+            protocol="-1",
+            from_port=0,
+            to_port=0,
+        )
+        aws.ec2.SecurityGroupRule(
+            f"{cluster_name}-eks-nodegroup-{ng_name}-{candidate_hash}-to-{active_hash}",
+            type="ingress",
+            security_group_id=candidate_ng.node_security_group_id,
+            source_security_group_id=active_ng.node_security_group_id,
+            protocol="-1",
+            from_port=0,
+            to_port=0,
+        )
+    return node_groups

--- a/uv.lock
+++ b/uv.lock
@@ -155,6 +155,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cachetools"
+version = "5.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/81/3747dad6b14fa2cf53fcf10548cf5aea6913e96fab41a3c198676f8948a5/cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4", size = 28380, upload-time = "2025-02-20T21:01:19.524Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/76/20fa66124dbe6be5cafeb312ece67de6b61dd91a0247d1ea13db4ebb33c2/cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a", size = 10080, upload-time = "2025-02-20T21:01:16.647Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.8.3"
 source = { registry = "https://pypi.org/simple" }
@@ -419,6 +428,15 @@ wheels = [
 ]
 
 [[package]]
+name = "durationpy"
+version = "0.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335, upload-time = "2025-05-17T13:52:37.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -481,6 +499,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/91/fd53ec0617c869df78cb7bb9a85741483df56288b23ac1fc4a3b5f165b34/gevent-25.8.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3535a699771f35b460026077dec946e73e4744afb5661b4e05a78eea74c120ce", size = 1831945, upload-time = "2025-08-29T17:21:29.356Z" },
     { url = "https://files.pythonhosted.org/packages/92/7d/46b4d5a8c9b37d66f16d7cd4f52e60e026a58b3a9cdedb4f93581082fb2b/gevent-25.8.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:23383d4e50718750f44cabdf1f8d4905108da0ffc6a8bf85448fb0a68f0e1b4d", size = 2174857, upload-time = "2025-08-29T16:51:08.342Z" },
     { url = "https://files.pythonhosted.org/packages/37/ce/18ff1db74d5654318a3a3176fda984317d3d9856a91ef0c1da56324e7104/gevent-25.8.2-cp314-cp314-win_amd64.whl", hash = "sha256:28a60e5f1174ac568639ab3bd12be9d620478a35acf0ad3156ef117918b4f551", size = 1686254, upload-time = "2025-08-29T18:23:41.138Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.40.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachetools" },
+    { name = "pyasn1-modules" },
+    { name = "rsa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/9b/e92ef23b84fa10a64ce4831390b7a4c2e53c0132568d99d4ae61d04c8855/google_auth-2.40.3.tar.gz", hash = "sha256:500c3a29adedeb36ea9cf24b8d10858e152f2412e3ca37829b3fa18e33d63b77", size = 281029, upload-time = "2025-06-04T18:04:57.577Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/63/b19553b658a1692443c62bd07e5868adaa0ad746a0751ba62c59568cd45b/google_auth-2.40.3-py2.py3-none-any.whl", hash = "sha256:1370d4593e86213563547f97a92752fc658456fe4514c809544f330fed45a7ca", size = 216137, upload-time = "2025-06-04T18:04:55.573Z" },
 ]
 
 [[package]]
@@ -703,6 +735,28 @@ wheels = [
 ]
 
 [[package]]
+name = "kubernetes"
+version = "31.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "durationpy" },
+    { name = "google-auth" },
+    { name = "oauthlib" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "requests-oauthlib" },
+    { name = "six" },
+    { name = "urllib3" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/bd/ffcd3104155b467347cd9b3a64eb24182e459579845196b3a200569c8912/kubernetes-31.0.0.tar.gz", hash = "sha256:28945de906c8c259c1ebe62703b56a03b714049372196f854105afe4e6d014c0", size = 916096, upload-time = "2024-09-20T03:16:08.089Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/a8/17f5e28cecdbd6d48127c22abdb794740803491f422a11905c4569d8e139/kubernetes-31.0.0-py2.py3-none-any.whl", hash = "sha256:bf141e2d380c8520eada8b351f4e319ffee9636328c137aa432bc486ca1200e1", size = 1857013, upload-time = "2024-09-20T03:16:06.05Z" },
+]
+
+[[package]]
 name = "kwonly-args"
 version = "1.0.10"
 source = { registry = "https://pypi.org/simple" }
@@ -809,6 +863,15 @@ wheels = [
 ]
 
 [[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
 name = "ol-infrastructure"
 version = "0.1.0"
 source = { editable = "." }
@@ -817,6 +880,7 @@ dependencies = [
     { name = "boto3" },
     { name = "httpx" },
     { name = "hvac", extra = ["parser"] },
+    { name = "kubernetes" },
     { name = "packaging" },
     { name = "parliament" },
     { name = "pulumi" },
@@ -855,6 +919,7 @@ requires-dist = [
     { name = "boto3", specifier = "~=1.24" },
     { name = "httpx", specifier = ">=0.28.0,<0.29" },
     { name = "hvac", extras = ["parser"], specifier = ">=2.0.0,<3" },
+    { name = "kubernetes", specifier = ">=29,<32" },
     { name = "packaging", specifier = ">=24.2" },
     { name = "parliament", specifier = "!=1.6.4" },
     { name = "pulumi", specifier = ">=3.39.1,<4" },
@@ -1228,6 +1293,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f6/eb/1ab9951beee42cb1af9b7164b5d9c60c9348d838c6f229dc49eb62656f86/pulumiverse_heroku-1.0.4.tar.gz", hash = "sha256:6ecc7ea57238e4ec9f9373401a8464a6d712a4f1cebb963c5e65c9ce6c89c501", size = 55873, upload-time = "2025-04-08T10:55:58.355Z" }
 
 [[package]]
+name = "pyasn1"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034", size = 145322, upload-time = "2024-09-10T22:41:42.55Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629", size = 83135, upload-time = "2024-09-11T16:00:36.122Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "2.22"
 source = { registry = "https://pypi.org/simple" }
@@ -1525,6 +1611,31 @@ wheels = [
 ]
 
 [[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
+name = "rsa"
+version = "4.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.12.11"
 source = { registry = "https://pypi.org/simple" }
@@ -1678,6 +1789,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301, upload-time = "2024-01-06T02:10:57.829Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166, upload-time = "2024-01-06T02:10:55.763Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/30/fba0d96b4b5fbf5948ed3f4681f7da2f9f64512e1d303f94b4cc174c24a5/websocket_client-1.8.0.tar.gz", hash = "sha256:3239df9f44da632f96012472805d40a23281a991027ce11d2f45a6f24ac4c3da", size = 54648, upload-time = "2024-04-23T22:16:16.976Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/84/44687a29792a70e111c5c477230a72c4b957d88d16141199bf9acb7537a3/websocket_client-1.8.0-py3-none-any.whl", hash = "sha256:17b44cc997f5c498e809b22cdf2d9c7a9e71c02c8cc2b6c56e7c2d1239bfa526", size = 58826, upload-time = "2024-04-23T22:16:14.422Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
This is an attempt at automating blue/green deployments of EKS nodegroups to reduce churn in the running pods when cycling a nodegroup.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
TBD

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
When a NodeGroupV2 object is updated, it creates an instance refresh, which proceeds more quickly than the scheduler can keep up with when rebalancing pods to nodes.
