### PR TITLE
fix: beat prefix added to separate schedules between lms and cms

### DIFF
--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/cms_only.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/cms_only.yml.tmpl
@@ -7,6 +7,7 @@ GIT_EXPORT_DEFAULT_IDENT:
   email: mitx-devops@mit.edu
 
 PARSE_KEYS: {}
+REDBEAT_KEY_PREFIX: cms:  # ADDED - RedBeat key prefix to separate LMS and CMS schedules
 SITE_NAME: {{ key "edxapp/studio-domain" }}  # MODIFIED
 # Configuration for logging into studio via OAuth with LMS
 {{ with secret "secret-mitx-staging/edxapp" }}

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/cms_only.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/cms_only.yml.tmpl
@@ -7,7 +7,7 @@ GIT_EXPORT_DEFAULT_IDENT:
   email: mitx-devops@mit.edu
 
 PARSE_KEYS: {}
-REDBEAT_KEY_PREFIX: cms:  # ADDED - RedBeat key prefix to separate LMS and CMS schedules
+REDBEAT_KEY_PREFIX: redbeat_cms  # ADDED - RedBeat key prefix to separate LMS and CMS schedules
 SITE_NAME: {{ key "edxapp/studio-domain" }}  # MODIFIED
 # Configuration for logging into studio via OAuth with LMS
 {{ with secret "secret-mitx-staging/edxapp" }}

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/lms_only.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/lms_only.yml.tmpl
@@ -93,6 +93,7 @@ THIRD_PARTY_AUTH_BACKENDS:
 - common.djangoapps.third_party_auth.saml.SAMLAuthBackend
 - common.djangoapps.third_party_auth.lti.LTIAuthBackend
 THIRD_PARTY_AUTH_SAML_FETCH_PERIOD_HOURS: 24 # ADDED - Sets the frequency for Celery Beat to refresh the SAML metadata
+REDBEAT_KEY_PREFIX: lms:  # ADDED - RedBeat key prefix to separate LMS and CMS schedules
 TRACKING_SEGMENTIO_WEBHOOK_SECRET: ''
 VERIFY_STUDENT:
     DAYS_GOOD_FOR: 365

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/lms_only.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/lms_only.yml.tmpl
@@ -93,7 +93,7 @@ THIRD_PARTY_AUTH_BACKENDS:
 - common.djangoapps.third_party_auth.saml.SAMLAuthBackend
 - common.djangoapps.third_party_auth.lti.LTIAuthBackend
 THIRD_PARTY_AUTH_SAML_FETCH_PERIOD_HOURS: 24 # ADDED - Sets the frequency for Celery Beat to refresh the SAML metadata
-REDBEAT_KEY_PREFIX: lms:  # ADDED - RedBeat key prefix to separate LMS and CMS schedules
+REDBEAT_KEY_PREFIX: redbeat_lms  # ADDED - RedBeat key prefix to separate LMS and CMS schedules
 TRACKING_SEGMENTIO_WEBHOOK_SECRET: ''
 VERIFY_STUDENT:
     DAYS_GOOD_FOR: 365

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx/cms_only.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx/cms_only.yml.tmpl
@@ -7,6 +7,7 @@ GIT_EXPORT_DEFAULT_IDENT:
   email: mitx-devops@mit.edu
 
 PARSE_KEYS: {}
+REDBEAT_KEY_PREFIX: cms:  # ADDED - RedBeat key prefix to separate LMS and CMS schedules
 SITE_NAME: {{ key "edxapp/studio-domain" }}  # MODIFIED
 # Configuration for logging into studio via OAuth with LMS
 {{ with secret "secret-mitx/edxapp" }}

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx/cms_only.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx/cms_only.yml.tmpl
@@ -7,7 +7,7 @@ GIT_EXPORT_DEFAULT_IDENT:
   email: mitx-devops@mit.edu
 
 PARSE_KEYS: {}
-REDBEAT_KEY_PREFIX: cms:  # ADDED - RedBeat key prefix to separate LMS and CMS schedules
+REDBEAT_KEY_PREFIX: redbeat_cms  # ADDED - RedBeat key prefix to separate LMS and CMS schedules
 SITE_NAME: {{ key "edxapp/studio-domain" }}  # MODIFIED
 # Configuration for logging into studio via OAuth with LMS
 {{ with secret "secret-mitx/edxapp" }}

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx/lms_only.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx/lms_only.yml.tmpl
@@ -87,7 +87,7 @@ THIRD_PARTY_AUTH_BACKENDS:
 - common.djangoapps.third_party_auth.saml.SAMLAuthBackend
 - common.djangoapps.third_party_auth.lti.LTIAuthBackend
 THIRD_PARTY_AUTH_SAML_FETCH_PERIOD_HOURS: 24 # ADDED - Sets the frequency for Celery Beat to refresh the SAML metadata
-REDBEAT_KEY_PREFIX: lms:  # ADDED - RedBeat key prefix to separate LMS and CMS schedules
+REDBEAT_KEY_PREFIX: redbeat_lms  # ADDED - RedBeat key prefix to separate LMS and CMS schedules
 TRACKING_SEGMENTIO_WEBHOOK_SECRET: ''
 VERIFY_STUDENT:
     DAYS_GOOD_FOR: 365

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx/lms_only.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx/lms_only.yml.tmpl
@@ -87,6 +87,7 @@ THIRD_PARTY_AUTH_BACKENDS:
 - common.djangoapps.third_party_auth.saml.SAMLAuthBackend
 - common.djangoapps.third_party_auth.lti.LTIAuthBackend
 THIRD_PARTY_AUTH_SAML_FETCH_PERIOD_HOURS: 24 # ADDED - Sets the frequency for Celery Beat to refresh the SAML metadata
+REDBEAT_KEY_PREFIX: lms:  # ADDED - RedBeat key prefix to separate LMS and CMS schedules
 TRACKING_SEGMENTIO_WEBHOOK_SECRET: ''
 VERIFY_STUDENT:
     DAYS_GOOD_FOR: 365

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/cms_only.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/cms_only.yml.tmpl
@@ -8,7 +8,7 @@ GIT_EXPORT_DEFAULT_IDENT:
   email: mitx-devops@mit.edu
 
 PARSE_KEYS: {}
-REDBEAT_KEY_PREFIX: cms:  # ADDED - RedBeat key prefix to separate LMS and CMS schedules
+REDBEAT_KEY_PREFIX: redbeat_cms  # ADDED - RedBeat key prefix to separate LMS and CMS schedules
 SITE_NAME: {{ key "edxapp/studio-domain" }}  # MODIFIED
 {{ with secret "secret-mitxonline/edxapp" }}
 SOCIAL_AUTH_EDX_OAUTH2_KEY: {{ .Data.studio_oauth_client.id }}

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/cms_only.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/cms_only.yml.tmpl
@@ -8,6 +8,7 @@ GIT_EXPORT_DEFAULT_IDENT:
   email: mitx-devops@mit.edu
 
 PARSE_KEYS: {}
+REDBEAT_KEY_PREFIX: cms:  # ADDED - RedBeat key prefix to separate LMS and CMS schedules
 SITE_NAME: {{ key "edxapp/studio-domain" }}  # MODIFIED
 {{ with secret "secret-mitxonline/edxapp" }}
 SOCIAL_AUTH_EDX_OAUTH2_KEY: {{ .Data.studio_oauth_client.id }}

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/lms_only.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/lms_only.yml.tmpl
@@ -99,6 +99,7 @@ THIRD_PARTY_AUTH_BACKENDS:
 - common.djangoapps.third_party_auth.identityserver3.IdentityServer3
 - common.djangoapps.third_party_auth.saml.SAMLAuthBackend
 - common.djangoapps.third_party_auth.lti.LTIAuthBackend
+REDBEAT_KEY_PREFIX: lms:  # ADDED - RedBeat key prefix to separate LMS and CMS schedules
 TRACKING_SEGMENTIO_WEBHOOK_SECRET: ''
 VERIFY_STUDENT:
     DAYS_GOOD_FOR: 365

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/lms_only.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/lms_only.yml.tmpl
@@ -99,7 +99,7 @@ THIRD_PARTY_AUTH_BACKENDS:
 - common.djangoapps.third_party_auth.identityserver3.IdentityServer3
 - common.djangoapps.third_party_auth.saml.SAMLAuthBackend
 - common.djangoapps.third_party_auth.lti.LTIAuthBackend
-REDBEAT_KEY_PREFIX: lms:  # ADDED - RedBeat key prefix to separate LMS and CMS schedules
+REDBEAT_KEY_PREFIX: redbeat_lms  # ADDED - RedBeat key prefix to separate LMS and CMS schedules
 TRACKING_SEGMENTIO_WEBHOOK_SECRET: ''
 VERIFY_STUDENT:
     DAYS_GOOD_FOR: 365

--- a/src/bilder/images/edxapp_v2/templates/edxapp/xpro/cms_only.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/xpro/cms_only.yml.tmpl
@@ -7,6 +7,7 @@ GIT_EXPORT_DEFAULT_IDENT:
   email: odl-devops@mit.edu
 
 PARSE_KEYS: {}
+REDBEAT_KEY_PREFIX: cms:  # ADDED - RedBeat key prefix to separate LMS and CMS schedules
 SITE_NAME: {{ key "edxapp/studio-domain" }}  # MODIFIED
 {{ with secret "secret-xpro/edxapp" }}
 SOCIAL_AUTH_EDX_OAUTH2_KEY: {{ .Data.studio_oauth_client.id }}

--- a/src/bilder/images/edxapp_v2/templates/edxapp/xpro/cms_only.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/xpro/cms_only.yml.tmpl
@@ -7,7 +7,7 @@ GIT_EXPORT_DEFAULT_IDENT:
   email: odl-devops@mit.edu
 
 PARSE_KEYS: {}
-REDBEAT_KEY_PREFIX: cms:  # ADDED - RedBeat key prefix to separate LMS and CMS schedules
+REDBEAT_KEY_PREFIX: redbeat_cms  # ADDED - RedBeat key prefix to separate LMS and CMS schedules
 SITE_NAME: {{ key "edxapp/studio-domain" }}  # MODIFIED
 {{ with secret "secret-xpro/edxapp" }}
 SOCIAL_AUTH_EDX_OAUTH2_KEY: {{ .Data.studio_oauth_client.id }}

--- a/src/bilder/images/edxapp_v2/templates/edxapp/xpro/lms_only.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/xpro/lms_only.yml.tmpl
@@ -98,7 +98,7 @@ THIRD_PARTY_AUTH_BACKENDS:
 - common.djangoapps.third_party_auth.identityserver3.IdentityServer3
 - common.djangoapps.third_party_auth.saml.SAMLAuthBackend
 - common.djangoapps.third_party_auth.lti.LTIAuthBackend
-REDBEAT_KEY_PREFIX: lms:  # ADDED - RedBeat key prefix to separate LMS and CMS schedules
+REDBEAT_KEY_PREFIX: redbeat_lms  # ADDED - RedBeat key prefix to separate LMS and CMS schedules
 TRACKING_SEGMENTIO_WEBHOOK_SECRET: ''
 VERIFY_STUDENT:
     DAYS_GOOD_FOR: 365

--- a/src/bilder/images/edxapp_v2/templates/edxapp/xpro/lms_only.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/xpro/lms_only.yml.tmpl
@@ -98,6 +98,7 @@ THIRD_PARTY_AUTH_BACKENDS:
 - common.djangoapps.third_party_auth.identityserver3.IdentityServer3
 - common.djangoapps.third_party_auth.saml.SAMLAuthBackend
 - common.djangoapps.third_party_auth.lti.LTIAuthBackend
+REDBEAT_KEY_PREFIX: lms:  # ADDED - RedBeat key prefix to separate LMS and CMS schedules
 TRACKING_SEGMENTIO_WEBHOOK_SECRET: ''
 VERIFY_STUDENT:
     DAYS_GOOD_FOR: 365


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6702

### Description (What does it do?)
This PR:
1. Adds `REDBEAT_KEY_PREFIX` to separate out the schedules for both LMS and CMS apps
