### PR TITLE
Remove run menu, several file menu items, trusted notebook logo

### DIFF
--- a/src/ol_infrastructure/applications/jupyterhub/disabled_extensions.json
+++ b/src/ol_infrastructure/applications/jupyterhub/disabled_extensions.json
@@ -2,6 +2,7 @@
    "disabledExtensions": {
          "@jupyterlab/debugger-extension": true,
          "nbdime-jupyterlab": true,
-         "@jupyter-notebook/application-extension:logo": true
+         "@jupyter-notebook/application-extension:logo": true,
+         "@jupyter-notebook/notebook-extension:trusted": true
    }
 }

--- a/src/ol_infrastructure/applications/jupyterhub/menu_override.json
+++ b/src/ol_infrastructure/applications/jupyterhub/menu_override.json
@@ -12,6 +12,26 @@
           {
             "command": "hub:control-panel",
             "disabled": true
+          },
+          {
+            "command": "application:rename",
+            "disabled": true
+          },
+          {
+            "command": "application:duplicate",
+            "disabled": true
+          },
+          {
+            "command": "docmanager:save-as",
+            "disabled": true
+          },
+          {
+            "command": "docmanager:save-all",
+            "disabled": true
+          },
+          {
+            "command": "notebook:trust",
+            "disabled": true
           }
         ]
       },
@@ -29,39 +49,7 @@
       },
       {
         "id": "jp-mainmenu-run",
-        "disabled": false,
-        "items": [
-          {
-            "command": "runmenu:restart-and-run-all",
-            "disabled": true
-          },
-          {
-            "type": "submenu",
-            "rank": 1010,
-            "disabled": true,
-            "submenu": {
-              "id": "jp-runmenu-change-cell-type",
-              "label": "Cell Type",
-              "items": [
-                {
-                  "command": "notebook:change-cell-to-code",
-                  "rank": 0,
-                  "disabled": true
-                },
-                {
-                  "command": "notebook:change-cell-to-markdown",
-                  "rank": 0,
-                  "disabled": true
-                },
-                {
-                  "command": "notebook:change-cell-to-raw",
-                  "rank": 0,
-                  "disabled": true
-                }
-              ]
-            }
-          }
-        ]
+        "disabled": true
       },
       {
         "id": "jp-mainmenu-kernel",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8530

### Description (What does it do?)
This PR removes several more UI elements:
- The entire run menu
- The Trusted status widget
- "Save Notebook As", "Save All",  "Rename", "Duplicate" and "Trust Notebook" options from the File menu

### Screenshots (if appropriate):
<img width="1218" height="348" alt="Screenshot 2025-09-12 at 12 14 01 PM" src="https://github.com/user-attachments/assets/7cd7e444-859b-4f56-b831-1a0653d8a90b" />
<img width="202" height="151" alt="Screenshot 2025-09-12 at 12 14 10 PM" src="https://github.com/user-attachments/assets/19c485f2-494d-4dd1-a063-fef514637788" />


### How can this be tested?
This is currently up in CI. This can be viewed by visiting `https://nb.ci.learn.mit.edu/tmplogin?course=clustering_and_descriptive_ai&notebook=Recitation.ipynb`

### Additional Context
Discussion at https://mitodl.slack.com/archives/C09DRCSS9S6/p1757687586032699
