### PR TITLE
Add uai images to known courses and gpu enabled courses, switch repo uris to no longer have -qa suffix in preparation of rename

### DIFF
--- a/src/ol_concourse/pipelines/container_images/jupyter_courses.py
+++ b/src/ol_concourse/pipelines/container_images/jupyter_courses.py
@@ -28,57 +28,57 @@ courses = [
     # TODO (dsubak) - Derive from course IDs # noqa: FIX002, TD004
     CourseImageInfo(
         course_name="course_deep_learning_foundations_and_applications",
-        repo_uri="git@github.mit.edu:ol-notebooks-qa/course_deep_learning_foundations_and_applications.git",
+        repo_uri="git@github.mit.edu:ol-notebooks/course_deep_learning_foundations_and_applications.git",
         image_name="deep_learning_foundations_and_applications",
     ),
     CourseImageInfo(
         course_name="supervised_learning_fundamentals",
-        repo_uri="git@github.mit.edu:ol-notebooks-qa/course_supervised_learning_fundamentals.git",
+        repo_uri="git@github.mit.edu:ol-notebooks/course_supervised_learning_fundamentals.git",
         image_name="supervised_learning_fundamentals",
     ),
     CourseImageInfo(
         course_name="introduction_to_data_analytics_and_machine_learning",
-        repo_uri="git@github.mit.edu:ol-notebooks-qa/course_introduction_to_data_analytics_and_machine_learning.git",
+        repo_uri="git@github.mit.edu:ol-notebooks/course_introduction_to_data_analytics_and_machine_learning.git",
         image_name="introduction_to_data_analytics_and_machine_learning",
     ),
     CourseImageInfo(
         course_name="clustering_and_descriptive_ai",
-        repo_uri="git@github.mit.edu:ol-notebooks-qa/course_clustering_and_descriptive_ai.git",
+        repo_uri="git@github.mit.edu:ol-notebooks/course_clustering_and_descriptive_ai.git",
         image_name="clustering_and_descriptive_ai",
     ),
     CourseImageInfo(
         course_name="uai_source-uai.6",
-        repo_uri="git@github.mit.edu:ol-notebooks-qa/UAI_SOURCE-UAI.6-3T2025.git",
+        repo_uri="git@github.mit.edu:ol-notebooks/UAI_SOURCE-UAI.6-3T2025.git",
         image_name="uai_source-uai.6",
     ),
     CourseImageInfo(
         course_name="uai_source-uai.7",
-        repo_uri="git@github.mit.edu:ol-notebooks-qa/UAI_SOURCE-UAI.7-3T2025.git",
+        repo_uri="git@github.mit.edu:ol-notebooks/UAI_SOURCE-UAI.7-3T2025.git",
         image_name="uai_source-uai.7",
     ),
     CourseImageInfo(
         course_name="uai_source-uai.8",
-        repo_uri="git@github.mit.edu:ol-notebooks-qa/UAI_SOURCE-UAI.8-3T2025.git",
+        repo_uri="git@github.mit.edu:ol-notebooks/UAI_SOURCE-UAI.8-3T2025.git",
         image_name="uai_source-uai.8",
     ),
     CourseImageInfo(
         course_name="uai_source-uai.9",
-        repo_uri="git@github.mit.edu:ol-notebooks-qa/UAI_SOURCE-UAI.9-3T2025.git",
+        repo_uri="git@github.mit.edu:ol-notebooks/UAI_SOURCE-UAI.9-3T2025.git",
         image_name="uai_source-uai.9",
     ),
     CourseImageInfo(
         course_name="uai_source-uai.11",
-        repo_uri="git@github.mit.edu:ol-notebooks-qa/UAI_SOURCE-UAI.11-3T2025.git",
+        repo_uri="git@github.mit.edu:ol-notebooks/UAI_SOURCE-UAI.11-3T2025.git",
         image_name="uai_source-uai.11",
     ),
     CourseImageInfo(
         course_name="uai_source-uai.12",
-        repo_uri="git@github.mit.edu:ol-notebooks-qa/UAI_SOURCE-UAI.12-3T2025.git",
+        repo_uri="git@github.mit.edu:ol-notebooks/UAI_SOURCE-UAI.12-3T2025.git",
         image_name="uai_source-uai.12",
     ),
     CourseImageInfo(
         course_name="uai_source-uai.13",
-        repo_uri="git@github.mit.edu:ol-notebooks-qa/UAI_SOURCE-UAI.13-3T2025.git",
+        repo_uri="git@github.mit.edu:ol-notebooks/UAI_SOURCE-UAI.13-3T2025.git",
         image_name="uai_source-uai.13",
     ),
 ]

--- a/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
+++ b/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
@@ -14,19 +14,29 @@ GPU_NODE_AFFINITY_LIST = [
     }
 ]
 
+KNOWN_COURSES = [
+    "clustering_and_descriptive_ai",
+    "deep_learning_foundations_and_applications",
+    "supervised_learning_fundamentals",
+    "introduction_to_data_analytics_and_machine_learning",
+]
+# We have notebooks in UAI courses 6-13, excluding 10
+KNOWN_COURSES.extend([f"uai_source-uai.{i}" for i in [6, 7, 8, 9, 11, 12, 13]])
+# All courses which use the CUDA pytorch base image are below
+GPU_ENABLED_COURSES = {
+    "deep_learning_foundations_and_applications",
+    "uai_source-uai.8",
+    "uai_source-uai.9",
+    "uai_source-uai.12",
+    "uai_source-uai.13",
+}
+
 
 class QueryStringKubeSpawner(KubeSpawner):
     def start(self):
         image_base = (
             "610119931565.dkr.ecr.us-east-1.amazonaws.com/ol-course-notebooks:{}"
         )
-        KNOWN_COURSES = [
-            "clustering_and_descriptive_ai",
-            "deep_learning_foundations_and_applications",
-            "supervised_learning_fundamentals",
-            "introduction_to_data_analytics_and_machine_learning",
-        ]
-        GPU_ENABLED_COURSES = {"deep_learning_foundations_and_applications"}
         self.image = (
             "610119931565.dkr.ecr.us-east-1.amazonaws.com/"
             "ol-course-notebooks:clustering_and_descriptive_ai"


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8533

### Description (What does it do?)
Accomplishes three things:
- Adds the newly constructed course images to the list of known and gpu enabled courses in the Kubespawner class. This will allow us to actually launch the images from a link.
- Adds those course images to the extraImages configuration, which will allow the prepuller to cache the new images locally so that spawning times remain fast
- Changes the repo URIs in the concourse job ahead of the ol-notebooks-qa rename to remove the `-qa` suffix

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
These changes are up in CI and the following example links should work as a result:
TODO

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
The relevant Pulumi changes are as follows:
```
~ values: {
          ~ jupyterhub: {
              ~ hub      : {
                  ~ extraConfig: {
                      ~ dynamicImageConfig.py: 
                            ...
                                }
                            ]
                          + KNOWN_COURSES = [
                          +     "clustering_and_descriptive_ai",
                          +     "deep_learning_foundations_and_applications",
                          +     "supervised_learning_fundamentals",
                          +     "introduction_to_data_analytics_and_machine_learning",
                          + ]
                          + # We have notebooks in UAI courses 6-13, excluding 10
                          + KNOWN_COURSES.extend([f"uai_source-uai.{i}" for i in [6, 7, 8, 9, 11, 12, 13]])
                          + # All courses which use the CUDA pytorch base image are below
                          + GPU_ENABLED_COURSES = {
                          +     "deep_learning_foundations_and_applications",
                          +     "uai_source-uai.8",
                          +     "uai_source-uai.9",
                          +     "uai_source-uai.12",
                          +     "uai_source-uai.13",
                          + }
                            class QueryStringKubeSpawner(KubeSpawner):
                                def start(self):
                                    image_base = (
                                        "610119931565.dkr.ecr.us-east-1.amazonaws.com/ol-course-notebooks:{}"
                                    )
                          -         KNOWN_COURSES = [
                          -             "clustering_and_descriptive_ai",
                          -             "deep_learning_foundations_and_applications",
                          -             "supervised_learning_fundamentals",
                          -             "introduction_to_data_analytics_and_machine_learning",
                          -         ]
                          -         GPU_ENABLED_COURSES = {"deep_learning_foundations_and_applications"}
                                    self.image = (
                                        "610119931565.dkr.ecr.us-east-1.amazonaws.com/"
                            ...
                    }
                }
              ~ prePuller: {
                  ~ extraImages: {
                      + uai-source-uai-11: {
                          + name: "610119931565.dkr.ecr.us-east-1.amazonaws.com/ol-course-notebooks"
                          + tag : "uai_source-uai.11"
                        }
                      + uai-source-uai-12: {
                          + name: "610119931565.dkr.ecr.us-east-1.amazonaws.com/ol-course-notebooks"
                          + tag : "uai_source-uai.12"
                        }
                      + uai-source-uai-13: {
                          + name: "610119931565.dkr.ecr.us-east-1.amazonaws.com/ol-course-notebooks"
                          + tag : "uai_source-uai.13"
                        }
                      + uai-source-uai-6 : {
                          + name: "610119931565.dkr.ecr.us-east-1.amazonaws.com/ol-course-notebooks"
                          + tag : "uai_source-uai.6"
                        }
                      + uai-source-uai-7 : {
                          + name: "610119931565.dkr.ecr.us-east-1.amazonaws.com/ol-course-notebooks"
                          + tag : "uai_source-uai.7"
                        }
                      + uai-source-uai-8 : {
                          + name: "610119931565.dkr.ecr.us-east-1.amazonaws.com/ol-course-notebooks"
                          + tag : "uai_source-uai.8"
                        }
                      + uai-source-uai-9 : {
                          + name: "610119931565.dkr.ecr.us-east-1.amazonaws.com/ol-course-notebooks"
                          + tag : "uai_source-uai.9"
                        }
                    }
                }
            }
        }
```

<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
