### PR TITLE
UAI 11 image needs GPU acceleration

### DIFF
--- a/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
+++ b/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
@@ -27,6 +27,7 @@ GPU_ENABLED_COURSES = {
     "deep_learning_foundations_and_applications",
     "uai_source-uai.8",
     "uai_source-uai.9",
+    "uai_source-uai.11",
     "uai_source-uai.12",
     "uai_source-uai.13",
 }


### PR DESCRIPTION
### Description (What does it do?)
UAI 11 loads LLaMA 8B from Huggingface and gets _very_ unhappy without a GPU to use. This tags that image as needing a node w/ a GPU

### How can this be tested?
Changes are currently up on CI and can be seen at https://nb.ci.learn.mit.edu/tmplogin?tag=3fba11a&notebook=Recitation_M14.ipynb&course=uai_source-uai.11

Note that we have the tag there because I needed to rebuild the base image as well, but this isn't necessary long term
