### PR TITLE
Add new courses to image build pipeline, known courses

### DIFF
--- a/src/ol_concourse/pipelines/container_images/jupyter_courses.py
+++ b/src/ol_concourse/pipelines/container_images/jupyter_courses.py
@@ -47,6 +47,31 @@ courses = [
         image_name="clustering_and_descriptive_ai",
     ),
     CourseImageInfo(
+        course_name="uai_source-uai.0",
+        repo_uri="git@github.mit.edu:ol-notebooks/UAI_SOURCE-UAI.0-3T2025.git",
+        image_name="uai_source-uai.0",
+    ),
+    CourseImageInfo(
+        course_name="uai_source-uai.0a",
+        repo_uri="git@github.mit.edu:ol-notebooks/UAI_SOURCE-UAI.0A-3T2025.git",
+        image_name="uai_source-uai.0a",
+    ),
+    CourseImageInfo(
+        course_name="uai_source-uai.1",
+        repo_uri="git@github.mit.edu:ol-notebooks/UAI_SOURCE-UAI.1-2T2025.git",
+        image_name="uai_source-uai.1",
+    ),
+    CourseImageInfo(
+        course_name="uai_source-uai.2",
+        repo_uri="git@github.mit.edu:ol-notebooks/UAI_SOURCE-UAI.2-2T2025.git",
+        image_name="uai_source-uai.2",
+    ),
+    CourseImageInfo(
+        course_name="uai_source-uai.3",
+        repo_uri="git@github.mit.edu:ol-notebooks/UAI_SOURCE-UAI.3-3T2025.git",
+        image_name="uai_source-uai.3",
+    ),
+    CourseImageInfo(
         course_name="uai_source-uai.6",
         repo_uri="git@github.mit.edu:ol-notebooks/UAI_SOURCE-UAI.6-3T2025.git",
         image_name="uai_source-uai.6",

--- a/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
+++ b/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
@@ -21,10 +21,15 @@ KNOWN_COURSES = [
     "introduction_to_data_analytics_and_machine_learning",
 ]
 # We have notebooks in UAI courses 6-13, excluding 10
-KNOWN_COURSES.extend([f"uai_source-uai.{i}" for i in [6, 7, 8, 9, 11, 12, 13]])
+KNOWN_COURSES.extend(
+    [f"uai_source-uai.{i}" for i in [0, "0a", 2, 3, 6, 7, 8, 9, 11, 12, 13]]
+)
 # All courses which use the CUDA pytorch base image are below
 GPU_ENABLED_COURSES = {
     "deep_learning_foundations_and_applications",
+    "uai_source-uai.1",
+    "uai_source-uai.2",
+    "uai_source-uai.3",
     "uai_source-uai.8",
     "uai_source-uai.9",
     "uai_source-uai.11",


### PR DESCRIPTION
### Description (What does it do?)
Adds a few new course repos and images.

At the moment, this is designed to be fully additive because it's the only safe thing we can do acknowledging that the courses themselves are in flux. We previously missed some colab links when introspecting github exports due to [visibility settings inconsistencies for repos](https://mitodl.slack.com/archives/C09DRCSS9S6/p1758136296064099?thread_ts=1758124065.941679&cid=C09DRCSS9S6).

### Additional Context
This is getting a bit challenging to keep track of, but this follows the audit of all UAI courses as seen in learn by manually flagging every single notebook link. The last tab in the spreadsheet has the findings.
https://docs.google.com/spreadsheets/d/18nYsqucd9WiXNfiFf3J2ce7P14K9D0Kz3K8WyUDcugY/edit?gid=834282836#gid=834282836

Courses currently link to a mixture of colab links, new-style images (built according to the course identifier) and old style ones (the original 4 human readable ones) - for example, UAI 3 references https://nb.learn.mit.edu/tmplogin?course=deep_learning_foundations_and_applications&notebook=Recitation_1.ipynb as well as a few colab links. In the future we should try and ensure that courses do not link "across" course images until we can programmatically generate mappings of courses to the course images they reference.
