### PR TITLE
config: remove the course org and number from edx header

### DIFF
--- a/src/bridge/settings/openedx/mfe/slot_config/mitxonline/common-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/mitxonline/common-mfe-config.env.jsx
@@ -221,4 +221,26 @@ if (learningApps.includes(edxMfeAppName)) {
   };
 }
 
+// Hiding the course org and number from course header
+config.pluginSlots = {
+  ...config.pluginSlots,
+  "org.openedx.frontend.layout.header_learning_course_info.v1": {
+    plugins: [
+      { op: PLUGIN_OPERATIONS.Hide, widgetId: 'default_contents' },
+      {
+        op: PLUGIN_OPERATIONS.Insert,
+        widget: {
+          id: 'custom_footer',
+          type: DIRECT_PLUGIN,
+          RenderWidget: ({ courseTitle }) => (
+            <div style={{ minWidth: 0 }}>
+              <span className="d-block m-0 font-weight-bold course-title">{courseTitle}</span>
+            </div>
+          ),
+        },
+      },
+    ],
+  },
+};
+
 export default config;

--- a/src/bridge/settings/openedx/mfe/slot_config/mitxonline/common-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/mitxonline/common-mfe-config.env.jsx
@@ -221,26 +221,28 @@ if (learningApps.includes(edxMfeAppName)) {
   };
 }
 
-// Hiding the course org and number from course header
-config.pluginSlots = {
-  ...config.pluginSlots,
-  "org.openedx.frontend.layout.header_learning_course_info.v1": {
-    plugins: [
-      { op: PLUGIN_OPERATIONS.Hide, widgetId: 'default_contents' },
-      {
-        op: PLUGIN_OPERATIONS.Insert,
-        widget: {
-          id: 'custom_footer',
-          type: DIRECT_PLUGIN,
-          RenderWidget: ({ courseTitle }) => (
-            <div style={{ minWidth: 0 }}>
-              <span className="d-block m-0 font-weight-bold course-title">{courseTitle}</span>
-            </div>
-          ),
+if (isLearnCourse) {
+  // Hiding the course org and number from the learning header in the UAI courses
+  config.pluginSlots = {
+    ...config.pluginSlots,
+    "org.openedx.frontend.layout.header_learning_course_info.v1": {
+      plugins: [
+        { op: PLUGIN_OPERATIONS.Hide, widgetId: 'default_contents' },
+        {
+          op: PLUGIN_OPERATIONS.Insert,
+          widget: {
+            id: 'custom_header_learning_course_info',
+            type: DIRECT_PLUGIN,
+            RenderWidget: ({ courseTitle }) => (
+              <div style={{ paddingTop: '14px', minWidth: 0 }}>
+                <span className="d-block m-0 font-weight-bold course-title">{courseTitle}</span>
+              </div>
+            ),
+          },
         },
-      },
-    ],
-  },
-};
+      ],
+    },
+  };
+}
 
 export default config;


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8624

### Description (What does it do?)
This PR hides the course number and org from the header in MITxOnline.

### Screenshots (if appropriate):

**Before**

<img width="1158" height="70" alt="Screenshot 2025-09-19 at 3 49 55 PM" src="https://github.com/user-attachments/assets/95001cc6-506e-4fc6-bf41-524b010937d3" />

**After**

<img width="1158" height="70" alt="Screenshot 2025-09-19 at 3 47 40 PM" src="https://github.com/user-attachments/assets/2c633eb9-d2f1-4bf2-af1e-3e1e6d35f5a6" />

### How can this be tested?

- Copy-paste the config in your local MFEs env.config.jsx files that use the learning header
- Verify that the course number and org are hidden from the header


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
