### PR TITLE
fix: typo in xPro certificate status slot

### DIFF
--- a/src/bridge/settings/openedx/mfe/slot_config/xpro/common-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/xpro/common-mfe-config.env.jsx
@@ -225,7 +225,7 @@ const CustomCertificateStatus = (widget) => {
       const newSecondChild = React.cloneElement(
         secondChild,
         secondChild.props,
-        `Final grades and any earned certificates are scheduled to be available 3 busines s days after ${endDate}`
+        `Final grades and any earned certificates are scheduled to be available 3 business days after ${endDate}`
       );
       const newChildren = [childArray[0], newSecondChild, childArray[2]];
       widget.RenderWidget = React.cloneElement(


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8250

### Description (What does it do?)
This PR:
1. fixes typo in xPro learning MFE Certificate Status Slot

### How can this be tested?
Follow https://github.com/mitodl/ol-infrastructure/pull/3516