### PR TITLE
Add more images to build pipeline, kubespawner, extra images

### DIFF
--- a/src/ol_concourse/pipelines/container_images/jupyter_courses.py
+++ b/src/ol_concourse/pipelines/container_images/jupyter_courses.py
@@ -72,6 +72,16 @@ courses = [
         image_name="uai_source-uai.3",
     ),
     CourseImageInfo(
+        course_name="uai_source-uai.4",
+        repo_uri="git@github.mit.edu:ol-notebooks/UAI_SOURCE-UAI.4-2025_C604.git",
+        image_name="uai_source-uai.4",
+    ),
+    CourseImageInfo(
+        course_name="uai_source-uai.5",
+        repo_uri="git@github.mit.edu:ol-notebooks/UAI_SOURCE-UAI.3-2025_C604.git",
+        image_name="uai_source-uai.5",
+    ),
+    CourseImageInfo(
         course_name="uai_source-uai.6",
         repo_uri="git@github.mit.edu:ol-notebooks/UAI_SOURCE-UAI.6-3T2025.git",
         image_name="uai_source-uai.6",

--- a/src/ol_infrastructure/applications/jupyterhub/__main__.py
+++ b/src/ol_infrastructure/applications/jupyterhub/__main__.py
@@ -297,7 +297,7 @@ COURSE_NAMES = [
     "introduction_to_data_analytics_and_machine_learning",
 ]
 COURSE_NAMES.extend(
-    [f"uai_source-uai.{i}" for i in [0, "0a", 1, 2, 3, 6, 7, 8, 9, 11, 12, 13]]
+    [f"uai_source-uai.{i}" for i in [0, "0a", 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13]]
 )
 EXTRA_IMAGES = {
     course_name.replace(".", "-").replace("_", "-"): {

--- a/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
+++ b/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
@@ -22,7 +22,7 @@ KNOWN_COURSES = [
 ]
 # We have notebooks in UAI courses 6-13, excluding 10
 KNOWN_COURSES.extend(
-    [f"uai_source-uai.{i}" for i in [0, "0a", 1, 2, 3, 6, 7, 8, 9, 11, 12, 13]]
+    [f"uai_source-uai.{i}" for i in [0, "0a", 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13]]
 )
 # All courses which use the CUDA pytorch base image are below
 GPU_ENABLED_COURSES = {
@@ -30,6 +30,8 @@ GPU_ENABLED_COURSES = {
     "uai_source-uai.1",
     "uai_source-uai.2",
     "uai_source-uai.3",
+    "uai_source-uai.4",
+    "uai_source-uai.5",
     "uai_source-uai.8",
     "uai_source-uai.9",
     "uai_source-uai.11",


### PR DESCRIPTION
### Description (What does it do?)
The notebook saga continues. This adds 2 more notebooks which currently correspond to modules 6 and 8.