### PR TITLE
Add jupyterhub pypi concourse pipeline

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/jupyterhub/build_jupyterhub_extensions.py
+++ b/src/ol_concourse/pipelines/infrastructure/jupyterhub/build_jupyterhub_extensions.py
@@ -61,7 +61,8 @@ for plugin in plugins:
                         args=[
                             "-exc",
                             f"""
-                            cd {plugin_git_repo.name};
+                            apt update && apt install -y nodejs npm;
+                            cd {plugin_git_repo.name}/{plugin};
                             uv build --package {plugin};
                             uvx twine check dist/*
                             uvx twine upload --skip-existing --non-interactive dist/*


### PR DESCRIPTION
### What are the relevant tickets?
Required for https://github.com/mitodl/hq/issues/8395 

### Description (What does it do?)
This adds a pipeline for packaging jupyter extensions to PyPi. https://github.com/mitodl/ol-notebook-extensions/pull/2/files will likely be the first extension we push.

### How can this be tested?
So far, I've verified that running `uv build` in the abovementioned PR does result in an installable wheel that functions with `jupyter notebook`. I have not yet validated that the concourse version will run properly.

### Additional Context
The vast majority of this is lifted from [build_publish_plugins.py](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_concourse/pipelines/open_edx/open_edx_plugins/build_publish_plugins.py) - I've only made minimal changes to point it at the correct repository.

This will not function properly until the ol-notebook-extension PR has landed