### PR TITLE
Readd the hub control panel button

### DIFF
--- a/src/ol_infrastructure/applications/jupyterhub/menu_override.json
+++ b/src/ol_infrastructure/applications/jupyterhub/menu_override.json
@@ -11,7 +11,7 @@
           },
           {
             "command": "hub:control-panel",
-            "disabled": true
+            "disabled": false
           },
           {
             "command": "application:rename",


### PR DESCRIPTION
### Description (What does it do?)
This just adds the Hub Control Panel back into the file menu. We want to expose access to it so folks can provision tokens, which they'll use to try and integrate with VS Code for accessibility purposes.

### Screenshots (if appropriate):
<img width="402" height="391" alt="Screenshot 2025-09-23 at 1 29 45 PM" src="https://github.com/user-attachments/assets/68bcedbd-7c01-4448-a767-165d11bb9b4e" />


### How can this be tested?
This is up on https://nb.ci.learn.mit.edu/
