### PR TITLE
refactor: Consolidate IAM and Vault setup into a component resource

### DIFF
--- a/src/ol_infrastructure/applications/superset/__main__.py
+++ b/src/ol_infrastructure/applications/superset/__main__.py
@@ -16,8 +16,8 @@ from bridge.lib.magic_numbers import (
 from bridge.lib.versions import SUPERSET_CHART_VERSION
 from bridge.secrets.sops import read_yaml_secrets
 from ol_infrastructure.components.applications.eks import (
-    OLEKSApplication,
-    OLEKSApplicationConfig,
+    OLEKSAuthBinding,
+    OLEKSAuthBindingConfig,
 )
 from ol_infrastructure.components.aws.cache import OLAmazonCache, OLAmazonRedisConfig
 from ol_infrastructure.components.aws.database import OLAmazonDB, OLPostgresDBConfig
@@ -128,8 +128,8 @@ superset_policy_document = {
     ],
 }
 
-superset_app = OLEKSApplication(
-    OLEKSApplicationConfig(
+superset_app = OLEKSAuthBinding(
+    OLEKSAuthBindingConfig(
         application_name="superset",
         namespace=superset_namespace,
         stack_info=stack_info,

--- a/src/ol_infrastructure/components/applications/eks.py
+++ b/src/ol_infrastructure/components/applications/eks.py
@@ -19,7 +19,7 @@ from ol_infrastructure.lib.ol_types import AWSBase, K8sGlobalLabels
 from ol_infrastructure.lib.pulumi_helper import StackInfo
 
 
-class OLEKSApplicationConfig(BaseModel):
+class OLEKSAuthBindingConfig(BaseModel):
     """Configuration for EKS application services.
 
     This component is intended to simplify the deployment of applications on EKS that
@@ -50,12 +50,15 @@ class OLEKSApplicationConfig(BaseModel):
         arbitrary_types_allowed = True
 
 
-class OLEKSApplication(ComponentResource):
+class OLEKSAuthBinding(ComponentResource):
     """A component for deploying applications to EKS."""
+
+    irsa_role: iam.Role
+    vault_k8s_resources: OLVaultK8SResources
 
     def __init__(
         self,
-        config: OLEKSApplicationConfig,
+        config: OLEKSAuthBindingConfig,
         opts: ResourceOptions | None = None,
     ):
         """Initialize the EKS application component.

--- a/src/ol_infrastructure/components/applications/eks.py
+++ b/src/ol_infrastructure/components/applications/eks.py
@@ -1,0 +1,154 @@
+"""Common components for deploying applications to EKS."""
+
+from pathlib import Path
+from typing import Any
+
+from pulumi import ComponentResource, Config, Output, ResourceOptions
+from pulumi_aws import get_caller_identity, iam
+from pulumi_vault import Policy
+from pulumi_vault import kubernetes as vault_kubernetes
+from pydantic import BaseModel
+
+from ol_infrastructure.components.aws.eks import OLEKSTrustRole, OLEKSTrustRoleConfig
+from ol_infrastructure.components.services.vault import (
+    OLVaultK8SResources,
+    OLVaultK8SResourcesConfig,
+)
+from ol_infrastructure.lib.aws.iam_helper import lint_iam_policy
+from ol_infrastructure.lib.ol_types import AWSBase, K8sGlobalLabels
+from ol_infrastructure.lib.pulumi_helper import StackInfo
+
+
+class OLEKSApplicationConfig(BaseModel):
+    """Configuration for EKS application services.
+
+    This component is intended to simplify the deployment of applications on EKS that
+    interact with AWS services and Vault. It will provision the required IAM and Vault
+    policies and roles to allow the application to authenticate with both AWS (via IRSA)
+    and Vault (via Kubernetes service account).
+    """
+
+    application_name: str
+    namespace: str
+    stack_info: StackInfo
+    aws_config: AWSBase
+    iam_policy_document: dict[str, Any]
+    vault_policy_path: Path
+    # From cluster stack reference
+    cluster_identities: Output[Any]
+    vault_auth_endpoint: Output[str]
+    # Name of the k8s service account that will be used for IRSA
+    irsa_service_account_name: str
+    # Name of the k8s service account used for vault secret sync
+    vault_sync_service_account_name: str = "vault-secrets"
+    # Labels to apply to k8s resources created by the component
+    k8s_labels: K8sGlobalLabels
+
+    class Config:
+        """Pydantic model configuration."""
+
+        arbitrary_types_allowed = True
+
+
+class OLEKSApplication(ComponentResource):
+    """A component for deploying applications to EKS."""
+
+    def __init__(
+        self,
+        config: OLEKSApplicationConfig,
+        opts: ResourceOptions | None = None,
+    ):
+        """Initialize the EKS application component.
+
+        :param config: The configuration for the application.
+        :param opts: The Pulumi resource options.
+        """
+        super().__init__(
+            "ol:infrastructure:aws:eks:OLEKSApplication",
+            config.application_name,
+            {},
+            opts,
+        )
+        aws_account = get_caller_identity()
+        iam_policy = iam.Policy(
+            f"{config.application_name}-policy-{config.stack_info.env_suffix}",
+            name=f"{config.application_name}-policy-{config.stack_info.env_suffix}",
+            path=f"/ol-data/{config.application_name}-policy-{config.stack_info.env_suffix}/",
+            policy=lint_iam_policy(config.iam_policy_document, stringify=True),
+            description=(
+                f"Policy for granting access for {config.application_name} to AWS"
+                " resources"
+            ),
+            opts=ResourceOptions(parent=self),
+        )
+
+        trust_role = OLEKSTrustRole(
+            f"{config.application_name}-irsa-trust-role-{config.stack_info.env_suffix}",
+            role_config=OLEKSTrustRoleConfig(
+                account_id=aws_account.account_id,
+                cluster_name=f"data-{config.stack_info.name}",
+                cluster_identities=config.cluster_identities,
+                description=(
+                    f"Trust role for {config.application_name} k8s service account"
+                ),
+                policy_operator="StringEquals",
+                role_name=config.application_name,
+                service_account_name=config.irsa_service_account_name,
+                service_account_namespace=config.namespace,
+                tags=config.aws_config.tags,
+            ),
+            opts=ResourceOptions(parent=self),
+        )
+
+        iam.RolePolicyAttachment(
+            f"{config.application_name}-irsa-policy-attach-{config.stack_info.env_suffix}",
+            policy_arn=iam_policy.arn,
+            role=trust_role.role.name,
+            opts=ResourceOptions(parent=self),
+        )
+        self.irsa_role = trust_role.role
+
+        vault_policy = Policy(
+            f"{config.application_name}-server-vault-policy",
+            name=f"{config.application_name}-server",
+            policy=config.vault_policy_path.read_text(),
+            opts=ResourceOptions(parent=self),
+        )
+
+        k8s_auth_backend_role = vault_kubernetes.AuthBackendRole(
+            f"{config.application_name}-k8s-vault-auth-backend-role-{config.stack_info.env_suffix}",
+            role_name=config.application_name,
+            backend=config.vault_auth_endpoint,
+            bound_service_account_names=[config.vault_sync_service_account_name],
+            bound_service_account_namespaces=[config.namespace],
+            token_policies=[vault_policy.name],
+            opts=ResourceOptions(parent=self),
+        )
+
+        vault_k8s_resources_config = OLVaultK8SResourcesConfig(
+            application_name=config.application_name,
+            namespace=config.namespace,
+            labels=config.k8s_labels.model_dump(),
+            vault_address=Config("vault").require("address"),
+            vault_auth_endpoint=config.vault_auth_endpoint,
+            vault_auth_role_name=k8s_auth_backend_role.role_name,
+            service_account_name=config.vault_sync_service_account_name,
+        )
+        self.vault_k8s_resources = OLVaultK8SResources(
+            resource_config=vault_k8s_resources_config,
+            opts=ResourceOptions(
+                delete_before_replace=True,
+                depends_on=[k8s_auth_backend_role],
+                parent=self,
+            ),
+        )
+
+        self.register_outputs(
+            {
+                "iam_policy": iam_policy,
+                "irsa_role": self.irsa_role,
+                "vault_policy": vault_policy,
+                "vault_k8s_auth_role": k8s_auth_backend_role,
+                "vault_k8s_resources": self.vault_k8s_resources,
+            }
+        )


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Consolidates IAM/IRSA and Vault setup into a component to cut down on boilerplate. It also integrates that component with the Superset deployment as a POC

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
This has been applied to the Superset stack in CI for validation.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
Setting up the IAM/IRSA and Vault auth elements are cumbersome and introduce friction in setting up new K8s services. This moves that boilerplate into a single place to make it easier to improve on across our infrastructure.
