### PR TITLE
fix: redirect to the original page after login in mitxonline learning MFE

### DIFF
--- a/src/bridge/settings/openedx/mfe/slot_config/Footer.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/Footer.jsx
@@ -124,8 +124,8 @@ const ForceLoginRedirect = () => {
       allowedRedirects.some((name) => process.env.DEPLOYMENT_NAME?.includes(name)) &&
       authenticatedUser === null
     ) {
-      const destination = getLoginRedirectUrl(window.location.href);
-      window.location.replace(destination);
+      const destination = getLoginRedirectUrl(global.location.href);
+      global.location.replace(destination);
     }
   }, [config, authenticatedUser]);
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8298

### Description (What does it do?)
Locally, the redirect was working fine, but when on RC, after signing in, it's redirecting back to a search api response instead of the learning MFE page URL from where the redirect initiated. However, when we click the sign-in button, it's working fine and redirecting back to the correct page. Upon debugging, we found that the signin URL is using global.location.href, while we were using window.location.href. This PR updates the code to use global.location.href.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- Verify that the redirect is working fine locally and on RC

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
