### PR TITLE
Redirect users to tree view if the specified file is not a Jupyter notebook

### DIFF
--- a/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
+++ b/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
@@ -71,8 +71,12 @@ class QueryStringKubeSpawner(KubeSpawner):
 
                 # If we don't have a notebook, don't muck with default_url
                 # This falls back to the tree view in Jupyterhub if not specified
-                if notebook and notebook.endswith(".ipynb"):
-                    self.default_url = f"/notebooks/{notebook}"
+                if notebook:
+                    if notebook.endswith(".ipynb"):
+                        self.default_url = f"/notebooks/{notebook}"
+                    elif notebook.endswith(".py"):
+                        self.default_url = f"/tree/{notebook}"
+
         return super().start()
 
 


### PR DESCRIPTION
### Description (What does it do?)
For course UAI.0A we've got an open [PR](https://github.mit.edu/ol-notebooks/UAI_SOURCE-UAI.0A-3T2025/pull/2) that uses raw python scripts instead of Jupyter notebooks. At the moment we don't try and put you on the correct page if you specify anything that doesn't end in `ipynb`

Unfortunately, we can't open these in a notebook that's runnable, so this does the next "best" thing and directs you to a the tree file view. That is less than ideal, but at the very least users could download python scripts for local execution.

We don't _have_ to merge this if we'd prefer to have guardrails on how people use this system, but I wanted to get the PR up and tested in case we need it.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
