### PR TITLE
Got the invocation for limiting the cookie length to a day

### DIFF
--- a/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
+++ b/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
@@ -79,3 +79,4 @@ class QueryStringKubeSpawner(KubeSpawner):
 c.JupyterHub.spawner_class = QueryStringKubeSpawner  # type: ignore[name-defined] # noqa: F821
 c.Authenticator.allow_all = True  # type: ignore[name-defined] # noqa: F821
 c.JupyterHub.db_url = os.environ["DATABASE_URL"]  # type: ignore[name-defined] # noqa: F821
+c.JupyterHub.tornado_settings["cookie_options"] = {"expires_days": 1}  # type: ignore[name-defined] # noqa: F821


### PR DESCRIPTION
### Description (What does it do?)
By default, the hub login cookie and jupyter single user server cookies are set to 30 days via Tornado's default behavior. That's not so much of an issue for typical authentication schemes, but because we treat everyone as a temporary user you can pretty rapidly stack up auth cookies simply by accessing notebook links. 

It's not exactly clear _where_ this causes problems in the stack, but the end user result is that clicking on a link that should work bounces you through auth only to give a 404 from Jupyterhub. If you know about the error, clearing cookies lets you get moving again, but it's a pretty confusing end user experience.
<img width="960" height="245" alt="thumbnail_Screenshot 2025-09-24 at 7 39 46 AM" src="https://github.com/user-attachments/assets/d01d8fad-8c38-406c-854a-2782cc51fc1f" />

This PR attempts to mitigate this behavior by significantly shortening the cookie expiration time to 1 day. It's still possible to hit this issue (particularly in cases where you're testing a lot of them in rapid succession, as I currently am) but I'm hoping this should make it much less likely to crop up for authors and learners in their workflows.

### Screenshots (if appropriate):
<img width="1681" height="824" alt="Screenshot 2025-09-24 at 3 22 18 PM" src="https://github.com/user-attachments/assets/79774525-13c0-4b80-81f4-4dc4f62ae2e8" />


### How can this be tested?
It's currently up in CI, simply visit any working notebook link on nb.ci.learn.mit.edu and check cookie expiration. You should find that they're set with an expiration of 1 day.

### Additional Context
You might reasonably think we could `JupyterHub.cookie_max_age_days` but as far as I can tell this only ever used as an arg to Tornado's [get_signed_cooke](https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.get_signed_cookie) and just controls whether the application considers a cookie expired. It doesn't actually change the expiration set on the cookie. Operating on the assumption that we're tripping over a payload size threshold, we need the cookie to actually expire at the browser level so it isn't sent.