### PR TITLE
Correct MITX_ONLINE_ENVIRONMENT for CI

### DIFF
--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.CI.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.CI.yaml
@@ -32,7 +32,7 @@ config:
     MITOL_PAYMENT_GATEWAY_CYBERSOURCE_SECURE_ACCEPTANCE_URL: "https://testsecureacceptance.cybersource.com/pay"
     MITXONLINE_NEW_USER_LOGIN_URL: https://ci.mitxonline.mit.edu/create-profile
     MITX_ONLINE_BASE_URL: "https://ci.mitxonline.mit.edu"
-    MITX_ONLINE_ENVIRONMENT: "rc"
+    MITX_ONLINE_ENVIRONMENT: "ci"
     MITX_ONLINE_LOG_LEVEL: "INFO"
     MITX_ONLINE_SECURE_SSL_HOST: "ci.mitxonline.mit.edu"
     OPENEDX_API_BASE_URL: "https://courses.ci.learn.mit.edu"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Sets the environment for CI to be `ci` so that it gets reported to the correct environment in sentry and possibly other places
