### PR TITLE
Add new course image to build pipeline, recognized courses

### DIFF
--- a/src/ol_concourse/pipelines/container_images/jupyter_courses.py
+++ b/src/ol_concourse/pipelines/container_images/jupyter_courses.py
@@ -24,8 +24,6 @@ class CourseImageInfo:
 # Used to make a parameterized pipeline which builds
 # and publishes the image from GH to ECR
 courses = [
-    # TODO (dsubak) - Remove the first 4 once the rest are tested # noqa: FIX002, TD004
-    # TODO (dsubak) - Derive from course IDs # noqa: FIX002, TD004
     CourseImageInfo(
         course_name="course_deep_learning_foundations_and_applications",
         repo_uri="git@github.mit.edu:ol-notebooks/course_deep_learning_foundations_and_applications.git",
@@ -45,6 +43,11 @@ courses = [
         course_name="clustering_and_descriptive_ai",
         repo_uri="git@github.mit.edu:ol-notebooks/course_clustering_and_descriptive_ai.git",
         image_name="clustering_and_descriptive_ai",
+    ),
+    CourseImageInfo(
+        course_name="uai_source-uai.intro",
+        repo_uri="git@github.mit.edu:ol-notebooks/UAI_SOURCE-UAI.INTRO-2025_C604.git",
+        image_name="uai_source-uai.intro",
     ),
     CourseImageInfo(
         course_name="uai_source-uai.0",

--- a/src/ol_infrastructure/applications/jupyterhub/__main__.py
+++ b/src/ol_infrastructure/applications/jupyterhub/__main__.py
@@ -297,7 +297,10 @@ COURSE_NAMES = [
     "introduction_to_data_analytics_and_machine_learning",
 ]
 COURSE_NAMES.extend(
-    [f"uai_source-uai.{i}" for i in [0, "0a", 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13]]
+    [
+        f"uai_source-uai.{i}"
+        for i in ["intro", 0, "0a", 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13]
+    ]
 )
 EXTRA_IMAGES = {
     course_name.replace(".", "-").replace("_", "-"): {

--- a/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
+++ b/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
@@ -22,7 +22,10 @@ KNOWN_COURSES = [
 ]
 # We have notebooks in UAI courses 6-13, excluding 10
 KNOWN_COURSES.extend(
-    [f"uai_source-uai.{i}" for i in [0, "0a", 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13]]
+    [
+        f"uai_source-uai.{i}"
+        for i in ["intro", 0, "0a", 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13]
+    ]
 )
 # All courses which use the CUDA pytorch base image are below
 GPU_ENABLED_COURSES = {


### PR DESCRIPTION
### Description (What does it do?)
Adds a new course repo to the build pipeline and the recognized courses.

### How can this be tested?

The pipeline is already put into place
<img width="1655" height="921" alt="Screenshot 2025-09-29 at 10 33 04 AM" src="https://github.com/user-attachments/assets/87caf586-fb55-43bb-a2a3-86ab5ae1c48c" />

I'll be testing on CI once the infra changes land before promoting them further!