### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/project_automation.yaml
+++ b/.github/workflows/project_automation.yaml
@@ -9,6 +9,9 @@ on:
 jobs:
   add-to-project:
     name: Add issue to project
+    permissions:
+      contents: read
+      issues: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2


### PR DESCRIPTION
Potential fix for [https://github.com/mitodl/ol-infrastructure/security/code-scanning/6](https://github.com/mitodl/ol-infrastructure/security/code-scanning/6)

To fix this problem, we should explicitly set the `permissions` block for the workflow/job so that only the minimal access needed by the workflow is granted to the GITHUB_TOKEN. In this workflow, the only operation conducted is opening issues and adding them to a GitHub Project via the `actions/add-to-project` action. According to the documentation for that action and common best practice, the workflow at a minimum requires `contents: read` and `issues: write` permissions (since it operates on issues, not pull requests). The preferred location for the `permissions` block is either at the top level (to apply to all jobs), or just inside the specific job if other jobs may need differing permissions. Here, since there's only one job, it's most straightforward to add the block right under `add-to-project:` in the job definition. The block should look like:
```yaml
permissions:
  contents: read
  issues: write
```
No external libraries or packages are required; only the workflow YAML needs updating.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
