### PR TITLE
Use working image for ksm

### DIFF
--- a/src/ol_infrastructure/substructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/substructure/aws/eks/__main__.py
@@ -745,6 +745,10 @@ ksm_release = kubernetes.helm.v3.Release(
             "serviceMonitor": {
                 "enabled": False,
             },
+            "image": {
+                "repository": "bitnamilegacy/kube-state-metrics",
+                "tag": "2.16.0-debian-12-r5",
+            },
         },
     ),
     opts=ResourceOptions(


### PR DESCRIPTION
### Description (What does it do?)
While trying to get KSM to spit out a few metrics for jupyterhub related infra Mike and I ran into an issue where bitnami shuffled their old images. This just specifies one that we saw working in testing.
