### PR TITLE
Remove onbeforeunload extension

### DIFF
--- a/src/ol_infrastructure/applications/jupyterhub/disabled_extensions.json
+++ b/src/ol_infrastructure/applications/jupyterhub/disabled_extensions.json
@@ -3,6 +3,7 @@
          "@jupyterlab/debugger-extension": true,
          "nbdime-jupyterlab": true,
          "@jupyter-notebook/application-extension:logo": true,
-         "@jupyter-notebook/notebook-extension:trusted": true
+         "@jupyter-notebook/notebook-extension:trusted": true,
+         "@jupyter-notebook/application-extension:dirty": true
    }
 }


### PR DESCRIPTION
### Description (What does it do?)
At the moment, if you make a change to a notebook cell and attempt to close your tab or browser, you get a pop up asking you to confirm you want to leave. This might be confusing to some users, and we got a request to disable it if possible.
<img width="1420" height="879" alt="Screenshot 2025-10-03 at 11 00 22 AM" src="https://github.com/user-attachments/assets/380a6dba-287f-4e3d-ba32-212a5061feef" />

This is due to an extension that sets a `beforeunload` event which this PR disables. The result is that when you attempt to exit the window, it closes immediately.


### How can this be tested?
This can be safely applied to CI to verify functionality. Apply this branch's changes, grab a notebook link for nb.ci.learn.mit.edu and make any local edits. Attempt to close the tab and you should no longer see any message.