### PR TITLE
Disable service monitor

### DIFF
--- a/src/ol_infrastructure/substructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/substructure/aws/eks/__main__.py
@@ -786,7 +786,7 @@ ksm_release = kubernetes.helm.v3.Release(
         skip_await=True,
         values={
             "serviceMonitor": {
-                "enabled": True,
+                "enabled": False,
             },
             "image": {
                 "repository": "bitnamilegacy/kube-state-metrics",


### PR DESCRIPTION
### Description (What does it do?)
https://mitodl.slack.com/archives/G1VJQHQHK/p1759780510871189 - since we're updating the filtering and enabling the service monitor at the same time, there's a brief period where we get a ton of metrics piped into prometheus before it gets filtered properly.

This just disables the service monitor while allowing us to get the filtering in place. Once the filtering is fully out, we can flip this setting again and I _think_ we won't get that massive cardinality blip