### PR TITLE
CI should use smaller embedding model

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.CI.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.CI.yaml
@@ -71,6 +71,7 @@ config:
     OIDC_ENDPOINT: "https://sso-ci.ol.mit.edu/realms/olapps"
     OPENSEARCH_INDEX: "mitlearn-ci"
     OPENSEARCH_SHARD_COUNT: 2
+    QDRANT_DENSE_MODEL: "text-embedding-3-small"
     OPENSEARCH_URL: "https://search-opensearch-mitlearn-ci-q7fuxrc2j26me44ymcftz3ahba.us-east-1.es.amazonaws.com"
     POSTHOG_API_HOST: "https://ph.ol.mit.edu"
     POSTHOG_ENABLED: "true"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/8825
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR switches the CI instance to use the smaller and cheaper embedding model




### Checklist:
- [ ] Ping me once merged and deployed so I can delete the existing CI collections from qdrant so they get re-created with the small model

