### PR TITLE
Add pod details back

### DIFF
--- a/src/ol_infrastructure/substructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/substructure/aws/eks/__main__.py
@@ -461,13 +461,6 @@ alloy_configmap = kubernetes.core.v1.ConfigMap(
                 }}
                 write_relabel_config {{
                     source_labels = ["__name__"]
-                    regex         = "(kube_pod_container_info|kube_pod_container_status_restarts_total)"
-                    action        = "replace"
-                    target_label  = "exported_pod"
-                    replacement   = ""
-                }}
-                write_relabel_config {{
-                    source_labels = ["__name__"]
                     regex         = "kube_pod_container_info"
                     action        = "replace"
                     target_label  = "image_id"


### PR DESCRIPTION
### Description (What does it do?)
Made a slight mistake and was a tad overzealous in removing labels. Since these metrics are scraped from ksm, pod and instance both refer to the KSM pod, so if I fire up two of the same notebook, we end up with two identical metrics being persisted. We could probably get away with that for `kube_pod_container_status_restarts_total` - since it's a counter, we'd still be able to pull out OOMKills on a per-image basis by summing over a time window.
For `kube_pod_container_info`, however, we sorta need the different label in there. As it's a gauge with a constant value of 1, we can't meaningfully back the number of running notebook servers out of the collapsed metric.

I think that if we add `exported_pod`, which is the name of the notebook pod itself, back into the label set, we can then `sum by (image)` and get the number of notebooks running a specific image at a given point in time. This PR just adds that value back in.
