### PR TITLE
fix: Removes incidental overwrite of "service" label

### DIFF
--- a/src/ol_infrastructure/components/services/k8s.py
+++ b/src/ol_infrastructure/components/services/k8s.py
@@ -386,7 +386,7 @@ class OLApplicationK8s(ComponentResource):
 
         # Create a deployment resource to manage the application pods
         application_labels = ol_app_k8s_config.k8s_global_labels | {
-            "ol.mit.edu/service": "webapp",
+            "ol.mit.edu/process": "webapp",
             "ol.mit.edu/application": f"{ol_app_k8s_config.application_name}",
             "ol.mit.edu/pod-security-group": ol_app_k8s_config.application_security_group_name.apply(
                 truncate_k8s_metanames
@@ -627,7 +627,7 @@ class OLApplicationK8s(ComponentResource):
 
         for celery_worker_config in ol_app_k8s_config.celery_worker_configs:
             celery_labels = ol_app_k8s_config.k8s_global_labels | {
-                "ol.mit.edu/service": "celery",
+                "ol.mit.edu/process": "celery",
                 "ol.mit.edu/application": f"{ol_app_k8s_config.application_name}",
                 "ol.mit.edu/pod-security-group": ol_app_k8s_config.application_security_group_name.apply(
                     truncate_k8s_metanames


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
The "service" label is used to identify the overarching service that the pod is contributing to. This was being overwritten with "webapp" and "celery" which I renamed to be "process" for more accurate semantics.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Manually deploy to CI for any affected applications.
