### PR TITLE
Caddy configuration update for static files in edxapp

### DIFF
--- a/src/bilder/images/edxapp_v2/files/Caddyfile
+++ b/src/bilder/images/edxapp_v2/files/Caddyfile
@@ -36,6 +36,18 @@
     }
     rewrite @favicon_matcher /theming/asset/images/favicon.ico
 
+    handle_path /static/* {
+        file_server {
+            root /openedx/staticfiles
+        }
+    }
+
+    handle_path /media/* {
+        file_server {
+            root /openedx/media
+        }
+    }
+
     # Limit profile image upload size
     handle_path /api/profile_images/*/*/upload {
         request_body {
@@ -57,6 +69,18 @@
         path_regexp ^/favicon.ico$
     }
     rewrite @favicon_matcher /theming/asset/images/favicon.ico
+
+    handle_path /static/* {
+        file_server {
+            root /openedx/staticfiles
+        }
+    }
+
+    handle_path /media/* {
+        file_server {
+            root /openedx/media
+        }
+    }
 
     import proxy "cms:8000"
 

--- a/src/bilder/images/edxapp_v2/files/docker-compose.yaml.tmpl
+++ b/src/bilder/images/edxapp_v2/files/docker-compose.yaml.tmpl
@@ -47,6 +47,9 @@ services:
     - ./settings/Caddyfile:/etc/caddy/Caddyfile:ro
     - ./tls/certificate:/etc/caddy/certificate:ro
     - ./tls/key:/etc/caddy/key:ro
+    - /opt/data/media:/openedx/media
+    - /opt/staticfiles-${ENVIRONMENT_TIER}:/openedx/staticfiles:ro
+    - /opt/staticfiles-${ENVIRONMENT_TIER}/bundles:/openedx/edx-platform/common/static/bundles:ro
   lms:
     image: 610119931565.dkr.ecr.us-east-1.amazonaws.com/dockerhub/${DOCKER_REPO_AND_DIGEST}
     profiles:

--- a/src/bilder/images/edxapp_v2/files/uwsgi.ini
+++ b/src/bilder/images/edxapp_v2/files/uwsgi.ini
@@ -15,9 +15,6 @@ max-requests = 1000
 max-worker-lifetime = 3600
 reload-on-rss = 2048
 
-static-map = /static=/openedx/staticfiles/
-static-map = /media=/openedx/media/
-
 http = 0.0.0.0:8000
 buffer-size = 65535
 


### PR DESCRIPTION

### Description (What does it do?)
Update edxapp configurations to allow caddy to serve static assets rather than having uwsgi serve them.
