### PR TITLE
config: enable learning MFE redirect for CI and RC only

### DIFF
--- a/src/bridge/settings/openedx/mfe/slot_config/Footer.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/Footer.jsx
@@ -121,6 +121,7 @@ const ForceLoginRedirect = () => {
   useEffect(() => {
     const allowedRedirects = ["mitxonline", "xpro"];
     if (
+      process.env.ENVIRONMENT_STAGE.toLowerCase() !== "production" &&
       config.APP_ID === "learning" &&
       allowedRedirects.some((name) => process.env.DEPLOYMENT_NAME?.includes(name)) &&
       authenticatedUser === null

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -101,6 +101,7 @@ def mfe_params(
         "CSRF_TOKEN_API_PATH": "/csrf/api/v1/token",
         "DISPLAY_FEEDBACK_WIDGET": open_edx.display_feedback_widget,
         "ENABLE_CERTIFICATE_PAGE": open_edx.enable_certificate_page,
+        "ENVIRONMENT_STAGE": open_edx.environment_stage,
         "DEPLOYMENT_NAME": open_edx.deployment_name,
         "DISCUSSIONS_MFE_BASE_URL": (
             f"https://{open_edx.lms_domain}/{discussion_mfe_path}"


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8298

### Description (What does it do?)
This PR prevents the learning MFE redirect logic to production

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
