### PR TITLE
setting embedding schedule to be every 2 hours

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1020,6 +1020,7 @@ env_vars = {
     "QDRANT_ENCODER": "vector_search.encoders.litellm.LiteLLMEncoder",
     "CONTENT_FILE_EMBEDDING_CHUNK_OVERLAP": 51,
     "CONTENT_FILE_EMBEDDING_CHUNK_SIZE": 512,
+    "EMBEDDING_SCHEDULE_MINUTES": 120,
     "PROLEARN_CATALOG_API_URL": "https://prolearn.mit.edu/graphql",
     "SEE_API_URL": "https://mit-unified-portal-prod-78eeds.43d8q2.usa-e2.cloudhub.io/api/",
     "SEE_API_ACCESS_TOKEN_URL": "https://mit-unified-portal-prod-78eeds.43d8q2.usa-e2.cloudhub.io/oauth/token",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
Related to https://github.com/mitodl/hq/issues/8885
<!--- N/A --->

### Description (What does it do?)
This PR spaces out the schedule (from default 60 mins -> 120 mins) for the backup celery tasks that embed all new content and resources that have not been embedded via regular means. This is to account for some delay in records showing up in qdrant as we are now processing tasks much more efficiently. Also there is a change to set QDRANT_CHUNK_SIZE to be something smaller as it previously was which I think will have some effect.


### Additional Context
We will have to deploy this and keep an eye on the openai embeddings cost to see if this results in reduced cost.
