### PR TITLE
Add kube_pod_status_reason so I can track evictions

### DIFF
--- a/src/ol_infrastructure/substructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/substructure/aws/eks/__main__.py
@@ -447,7 +447,7 @@ alloy_configmap = kubernetes.core.v1.ConfigMap(
                 // Collapse some labels that include UUIDs and are not useful
                 write_relabel_config {{
                     source_labels = ["__name__"]
-                    regex         = "(kube_pod_container_info|kube_pod_container_status_restarts_total)"
+                    regex         = "(kube_pod_container_info|kube_pod_container_status_restarts_total|kube_pod_status_reason)"
                     action        = "replace"
                     target_label  = "uid"
                     replacement   = ""
@@ -787,7 +787,7 @@ ksm_release = kubernetes.helm.v3.Release(
             },
             "namespaces": "jupyter",
             "extraArgs": {
-                "metric-allowlist": "kube_pod_container_info,kube_pod_container_status_restarts_total",
+                "metric-allowlist": "kube_pod_container_info,kube_pod_container_status_restarts_total,kube_pod_status_reason",
             },
         },
     ),


### PR DESCRIPTION
### Description (What does it do?)
We got reports of a pod eviction resulting in a [pretty bad user experience on Jupyterhub](https://mitodl.slack.com/archives/C09DRCSS9S6/p1760452268013929). I am suspicious about the timing of that issue - while it's certainly possible to have been spawning a notebook server at the time a node was being pulled out of service resulting in the eviction, it appears that it was evicted a few seconds after the pod was created when comparing the logs and the timing for the eviction in the screenshot. Given how few users we have, it seems rather unlikely that this was simply randomly unlucky.

I'd like to track a metric to see how frequently pods are evicted so we can see if this is happening frequently. We basically don't ever expect pods to be evicted and they should have relatively short lifespans, so the presence of any non-trivial volume of evictions would be something we'd want to look into.

### Additional Context
- Should we monitor this across the board?