### PR TITLE
Add uai_source-uai.st1 to build pipeline, known images, gpu enabled courses

### DIFF
--- a/src/ol_concourse/pipelines/container_images/jupyter_courses.py
+++ b/src/ol_concourse/pipelines/container_images/jupyter_courses.py
@@ -60,6 +60,11 @@ courses = [
         image_name="uai_source-uai.0a",
     ),
     CourseImageInfo(
+        course_name="uai_source-uai.st1",
+        repo_uri="git@github.mit.edu:ol-notebooks/UAI_SOURCE-UAI.ST.1-1T2026.git",
+        image_name="uai_source-uai.st1",
+    ),
+    CourseImageInfo(
         course_name="uai_source-uai.1",
         repo_uri="git@github.mit.edu:ol-notebooks/UAI_SOURCE-UAI.1-2T2025.git",
         image_name="uai_source-uai.1",

--- a/src/ol_infrastructure/applications/jupyterhub/__main__.py
+++ b/src/ol_infrastructure/applications/jupyterhub/__main__.py
@@ -299,7 +299,7 @@ COURSE_NAMES = [
 COURSE_NAMES.extend(
     [
         f"uai_source-uai.{i}"
-        for i in ["intro", 0, "0a", 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13]
+        for i in ["intro", 0, "0a", 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, "st1"]
     ]
 )
 EXTRA_IMAGES = {

--- a/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
+++ b/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
@@ -24,10 +24,10 @@ KNOWN_COURSES = [
 KNOWN_COURSES.extend(
     [
         f"uai_source-uai.{i}"
-        for i in ["intro", 0, "0a", 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13]
+        for i in ["intro", 0, "0a", 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, "st1"]
     ]
 )
-# All courses which use the CUDA pytorch base image are below
+# All courses which use the CUDA pytorch or tensorflow base image are below
 GPU_ENABLED_COURSES = {
     "deep_learning_foundations_and_applications",
     "uai_source-uai.1",
@@ -40,6 +40,7 @@ GPU_ENABLED_COURSES = {
     "uai_source-uai.11",
     "uai_source-uai.12",
     "uai_source-uai.13",
+    "uai_source-uai.st1",
 }
 
 


### PR DESCRIPTION
### Description (What does it do?)
Adds a new course repo and image for building. Specifies it as GPU enabled.

### How can this be tested?
Relevant Pulumi output looks as expected when run locally:
```
    ~ kubernetes:helm.sh/v3:Release: (update)
        [id=jupyter/binderhub]
        [urn=urn:pulumi:applications.jupyterhub.CI::ol-infrastructure-jupyterhub-application::kubernetes:helm.sh/v3:Release::binderhub-CI-application-helm-release]
        [provider=urn:pulumi:applications.jupyterhub.CI::ol-infrastructure-jupyterhub-application::pulumi:providers:kubernetes::k8s-provider::5f3a8ac8-372e-491d-b910-ae7a4854e30c]
      ~ values: {
          ~ jupyterhub: {
              ~ hub      : {
                  ~ extraConfig: {
                      ~ dynamicImageConfig.py: 
                            ...
                                [
                                    f"uai_source-uai.{i}"
                          -         for i in ["intro", 0, "0a", 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13]
                          +         for i in ["intro", 0, "0a", 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 13, "st1"]
                                ]
                            )
                          - # All courses which use the CUDA pytorch base image are below
                          + # All courses which use the CUDA pytorch or tensorflow base image are below
                            GPU_ENABLED_COURSES = {
                                "deep_learning_foundations_and_applications",
                            ...
                                "uai_source-uai.12",
                                "uai_source-uai.13",
                          +     "uai_source-uai.st1",
                            }
                            class QueryStringKubeSpawner(KubeSpawner):
                            ...
                    }
                }
              ~ prePuller: {
                  ~ extraImages: {
                      + uai-source-uai-st1: {
                          + name      : "610119931565.dkr.ecr.us-east-1.amazonaws.com/ol-course-notebooks"
                          + pullPolicy: "Always"
                          + tag       : "uai_source-uai.st1"
                        }
                    }
                }
            }
        }
```