### PR TITLE
learn-ai nginx config update 

### DIFF
--- a/src/ol_infrastructure/applications/learn_ai/files/web.conf
+++ b/src/ol_infrastructure/applications/learn_ai/files/web.conf
@@ -19,17 +19,11 @@ server {
       try_files $uri $uri/ /staticfiles/$1 /staticfiles/$1/ =404;
   }
 
-  location /ws {
-      proxy_pass http://127.0.0.1:8073;
-      proxy_http_version 1.1;
-      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-      proxy_set_header Host $host;
-  }
-
   location / {
     proxy_pass http://127.0.0.1:8073;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header Host $host;
     proxy_redirect off;
+    proxy_buffering off;
   }
 }


### PR DESCRIPTION
### Description (What does it do?)
fix: updated nginx config for learn-ai to allow streaming of AI responses.

CC @mbertrand 