### PR TITLE
config: add Learn AI Feedback API URL for chat xBlock

### DIFF
--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/common_values.yml.tmpl
@@ -446,6 +446,7 @@ MIT_LEARN_SUMMARY_FLASHCARD_URL: https://{{ key "edxapp/learn-api-domain" }}/lea
 MIT_LEARN_AI_XBLOCK_CHAT_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai/http/canvas_syllabus_agent/  # Added for ol_openedx_chat_xblock
 MIT_LEARN_AI_XBLOCK_TUTOR_CHAT_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai/http/canvas_tutor_agent/  # Added for ol_openedx_chat_xblock
 MIT_LEARN_AI_XBLOCK_PROBLEM_SET_LIST_URL: https://{{ key "edxapp/learn-api-domain" }}/ai/api/v0/problem_set_list  # Added for ol_openedx_chat_xblock
+MIT_LEARN_AI_XBLOCK_CHAT_RATING_URL: https://{{ key "edxapp/learn-api-domain" }}/ai/api/v0/chat_sessions/  # Added for ol_openedx_chat_xblock
 MAINTENANCE_BANNER_TEXT: Sample banner message
 MEDIA_ROOT: media/  # MODIFIED - with s3 storage backend this is the path within the bucket. No leading / allowed
 MEDIA_URL: /media/

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx/common_values.yml.tmpl
@@ -448,6 +448,7 @@ MIT_LEARN_SUMMARY_FLASHCARD_URL: https://{{ key "edxapp/learn-api-domain" }}/lea
 MIT_LEARN_AI_XBLOCK_CHAT_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai/http/canvas_syllabus_agent/  # Added for ol_openedx_chat_xblock
 MIT_LEARN_AI_XBLOCK_TUTOR_CHAT_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai/http/canvas_tutor_agent/  # Added for ol_openedx_chat_xblock
 MIT_LEARN_AI_XBLOCK_PROBLEM_SET_LIST_URL: https://{{ key "edxapp/learn-api-domain" }}/ai/api/v0/problem_set_list  # Added for ol_openedx_chat_xblock
+MIT_LEARN_AI_XBLOCK_CHAT_RATING_URL: https://{{ key "edxapp/learn-api-domain" }}/ai/api/v0/chat_sessions/  # Added for ol_openedx_chat_xblock
 MAINTENANCE_BANNER_TEXT: Sample banner message
 MEDIA_ROOT: media/  # MODIFIED - with s3 storage backend this is the path within the bucket. No leading / allowed
 MEDIA_URL: /media/

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -399,6 +399,7 @@ MIT_LEARN_BASE_URL: https://{{ key "edxapp/learn-frontend-domain" }}
 MIT_LEARN_AI_XBLOCK_CHAT_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai/http/canvas_syllabus_agent/  # Added for ol_openedx_chat_xblock
 MIT_LEARN_AI_XBLOCK_TUTOR_CHAT_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai/http/canvas_tutor_agent/  # Added for ol_openedx_chat_xblock
 MIT_LEARN_AI_XBLOCK_PROBLEM_SET_LIST_URL: https://{{ key "edxapp/learn-api-domain" }}/ai/api/v0/problem_set_list  # Added for ol_openedx_chat_xblock
+MIT_LEARN_AI_XBLOCK_CHAT_RATING_URL: https://{{ key "edxapp/learn-api-domain" }}/ai/api/v0/chat_sessions/  # Added for ol_openedx_chat_xblock
 UAI_COURSE_KEY_FORMATS:
   - course-v1:uai_
 MIT_LEARN_LOGO: https://{{ key "edxapp/lms-domain" }}/static/mitxonline/images/mit-learn-logo.svg"

--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -156,6 +156,7 @@ def create_k8s_configmaps(
                     MIT_LEARN_AI_XBLOCK_CHAT_API_URL: https://{edxapp_config.require("mit_learn_api_domain")}/ai/http/canvas_syllabus_agent/
                     MIT_LEARN_AI_XBLOCK_TUTOR_CHAT_API_URL:  https://{edxapp_config.require("mit_learn_api_domain")}/ai/http/canvas_tutor_agent/
                     MIT_LEARN_AI_XBLOCK_PROBLEM_SET_LIST_URL: https://{edxapp_config.require("mit_learn_api_domain")}/ai/api/v0/problem_set_list  # Added for ol_openedx_chat_xblock
+                    MIT_LEARN_AI_XBLOCK_CHAT_RATING_URL: https://{edxapp_config.require("mit_learn_api_domain")}/ai/api/v0/chat_sessions/  # Added for ol_openedx_chat_xblock
                     MIT_LEARN_LOGO: https://{edxapp_config.require_object("domains")["lms"]}/static/mitxonline/images/mit-learn-logo.svg
                     LEARNING_MICROFRONTEND_URL: https://{edxapp_config.require_object("domains")["lms"]}/learn
                     LMS_BASE: {edxapp_config.require_object("domains")["lms"]}


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8796
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
- Adds the URL for the rating API for Learn AI chat xblocks
<!--- Describe your changes in detail -->

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
Once the latest chat xblock https://github.com/mitodl/hq/issues/8796#issuecomment-3409653871 is installed in our edX instance, we should see the thumbs (Up/Down) buttons on the chat and clicking them should work without issues in the netwrork/console.
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
