### PR TITLE
config: Add Vault role for generating credentials with Dagster role

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/dagster/docker_pulumi_pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/dagster/docker_pulumi_pipeline.py
@@ -194,7 +194,9 @@ def build_dagster_docker_pipeline() -> Pipeline:
 
     pulumi_fragment = pulumi_jobs_chain(
         pulumi_code,
-        stack_names=[f"applications.dagster.{stage}" for stage in ("QA", "Production")],
+        stack_names=[
+            f"applications.dagster.{stage}" for stage in ("CI", "QA", "Production")
+        ],
         project_name="ol-infrastructure-dagster-server",
         project_source_path=PULUMI_CODE_PATH.joinpath("applications/dagster/"),
         dependencies=pulumi_dependencies,

--- a/src/ol_infrastructure/components/applications/eks.py
+++ b/src/ol_infrastructure/components/applications/eks.py
@@ -77,7 +77,7 @@ class OLEKSAuthBinding(ComponentResource):
             opts,
         )
         aws_account = get_caller_identity()
-        iam_policy = iam.Policy(
+        self.iam_policy = iam.Policy(
             f"{config.application_name}-policy-{config.stack_info.env_suffix}",
             name=f"{config.application_name}-policy-{config.stack_info.env_suffix}",
             path=f"/ol-data/{config.application_name}-policy-{config.stack_info.env_suffix}/",
@@ -93,7 +93,7 @@ class OLEKSAuthBinding(ComponentResource):
             opts=ResourceOptions(parent=self),
         )
 
-        trust_role = OLEKSTrustRole(
+        self.trust_role = OLEKSTrustRole(
             f"{config.application_name}-irsa-trust-role-{config.stack_info.env_suffix}",
             role_config=OLEKSTrustRoleConfig(
                 account_id=aws_account.account_id,
@@ -113,11 +113,11 @@ class OLEKSAuthBinding(ComponentResource):
 
         iam.RolePolicyAttachment(
             f"{config.application_name}-irsa-policy-attach-{config.stack_info.env_suffix}",
-            policy_arn=iam_policy.arn,
-            role=trust_role.role.name,
+            policy_arn=self.iam_policy.arn,
+            role=self.trust_role.role.name,
             opts=ResourceOptions(parent=self),
         )
-        self.irsa_role = trust_role.role
+        self.irsa_role = self.trust_role.role
 
         vault_policy = Policy(
             f"{config.application_name}-server-vault-policy",
@@ -163,7 +163,7 @@ class OLEKSAuthBinding(ComponentResource):
 
         self.register_outputs(
             {
-                "iam_policy": iam_policy,
+                "iam_policy": self.iam_policy,
                 "irsa_role": self.irsa_role,
                 "vault_policy": vault_policy,
                 "vault_k8s_auth_role": k8s_auth_backend_role,


### PR DESCRIPTION
### What are the relevant tickets?
Partially addresses https://github.com/mitodl/hq/issues/6800

### Description (What does it do?)
<!--- Describe your changes in detail -->
In order for developers to be able to easily interact with the data platform infrastructure it is useful to have a dynamic credential that can be easily fetched when working on pipeline logic.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run the Pulumi Up and verify that there is a role named `dagster` in https://vault-ci.odl.mit.edu/ui/vault/secrets/aws-mitx/list
