### PR TITLE
Md/dagster disruptions

### DIFF
--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -584,6 +584,7 @@ for location in code_locations:
         "annotations": dagster_auth_binding.irsa_role.arn.apply(
             lambda arn: {
                 "eks.amazonaws.com/role-arn": arn,
+                "karpenter.sh/do-not-disrupt": "true",
             }
         ),
         "resources": {


### PR DESCRIPTION


### Description (What does it do?)
Add the karpenter.sh/do-not-disrupt annotation to dagster workload pods.
