### PR TITLE
Override logo url

### DIFF
--- a/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
+++ b/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
@@ -85,3 +85,4 @@ c.Authenticator.allow_all = True  # type: ignore[name-defined] # noqa: F821
 c.JupyterHub.db_url = os.environ["DATABASE_URL"]  # type: ignore[name-defined] # noqa: F821
 c.JupyterHub.tornado_settings["cookie_options"] = {"expires_days": 1}  # type: ignore[name-defined] # noqa: F821
 c.JupyterHub.logo_file = "/opt/mit_learn.svg"  # type: ignore[name-defined] # noqa: F821
+c.JupyterHub.template_vars = {"logo_url": "https://learn.mit.edu/dashboard"}  # type: ignore[name-defined] # noqa: F821


### PR DESCRIPTION
### Description (What does it do?)
Just updates the logo_url value for the header on Jupyterhub pages. It relies on using overriding the [template variable used in the relevant template](https://github.com/jupyterhub/jupyterhub/blob/main/share/jupyterhub/templates/page.html#L120-L124) via the [template_vars override](https://jupyterhub.readthedocs.io/en/stable/reference/api/app.html#jupyterhub.app.JupyterHub.template_vars). If we ever override the template itself or upgrade, this variable might change, so we'll need to be aware of that going forward.

### How can this be tested?
This is live on CI so it can be tested by accessing any notebook on that environment. However, under normal circumstances you have to be kinda quick to thread the needle as the only jupyterhub page you're likely to encounter is the spawn page (as opposed to jupyter notebook pages, which are already overridden). Below is a screenshot of the new behavior.
<img width="1722" height="1018" alt="Screenshot 2025-10-21 at 10 22 39 AM" src="https://github.com/user-attachments/assets/cc68a5b1-114a-4da9-990b-4db0d6029b66" />


That said, the behavior can also be seen on the JH 404 page, so simply visiting https://nb.ci.learn.mit.edu/any_fake_url should demonstrate representative behavior as well.