### PR TITLE
config: Add new style django-storages configuration

### DIFF
--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx-staging/common_values.yml.tmpl
@@ -132,18 +132,25 @@ AUTH_PASSWORD_VALIDATORS:
 -   NAME: common.djangoapps.util.password_policy_validators.MaximumLengthValidator
     OPTIONS:
         max_length: 75
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 AWS_ACCESS_KEY_ID: "" # MODIFIED - not setting as we will use IAM Instance Profiles
 # AWS_QUERYSTRING_AUTH: false
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 AWS_S3_CUSTOM_DOMAIN: {{ key "edxapp/s3-storage-bucket" }}.s3.amazonaws.com
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 AWS_SECRET_ACCESS_KEY: ""  # MODIFIED - not setting as we will use IAM Instance Profiles
 AWS_SES_CONFIGURATION_SET: {{ key "edxapp/ses-configuration-set" }}  # ADDED KEY
 AWS_SES_REGION_ENDPOINT: email.us-east-1.amazonaws.com
 AWS_SES_REGION_NAME: us-east-1
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 AWS_STORAGE_BUCKET_NAME: {{ key "edxapp/s3-storage-bucket" }}  # MODIFIED
 BASE_COOKIE_DOMAIN: {{ key "edxapp/lms-domain" }} # MODIFIED
 BLOCKSTORE_USE_BLOCKSTORE_APP_API: true
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 BUNDLE_ASSET_STORAGE_SETTINGS:
+  # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
   STORAGE_CLASS: storages.backends.s3boto3.S3Boto3Storage
+  # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
   STORAGE_KWARGS:
     location: blockstore/
 BLOCK_STRUCTURES_SETTINGS:
@@ -151,8 +158,10 @@ BLOCK_STRUCTURES_SETTINGS:
     PRUNING_ACTIVE: true  # MODIFIED
     TASK_DEFAULT_RETRY_DELAY: 30
     TASK_MAX_RETRIES: 5
+    # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
     STORAGE_CLASS: storages.backends.s3boto3.S3Boto3Storage
     DIRECTORY_PREFIX: coursestructure/
+    # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
     STORAGE_KWARGS:
       bucket_name: {{ key "edxapp/s3-storage-bucket" }}
       default_acl: public-read
@@ -244,6 +253,7 @@ COURSE_MODE_DEFAULTS:
     sku: null
     slug: honor
     suggested_prices: ''
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 COURSE_IMPORT_EXPORT_BUCKET: {{ key "edxapp/s3-course-bucket" }}  # MODIFIED
 CREDENTIALS_INTERNAL_SERVICE_URL: http://localhost:8005
 CREDENTIALS_PUBLIC_SERVICE_URL: http://localhost:8005
@@ -257,6 +267,7 @@ DASHBOARD_COURSE_LIMIT: null
 DATA_DIR: /openedx/data  # Filesystem path where edx puts files for course export/import
 DEFAULT_COURSE_VISIBILITY_IN_CATALOG: both
 DEFAULT_FEEDBACK_EMAIL: {{ key "edxapp/sender-email-address" }} # MODIFIED
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 DEFAULT_FILE_STORAGE: storages.backends.s3boto3.S3Boto3Storage  # MODIFIED
 DEFAULT_FROM_EMAIL: {{ key "edxapp/sender-email-address" }} # MODIFIED
 DEFAULT_MOBILE_AVAILABLE: false
@@ -374,7 +385,9 @@ FEATURES:
     SEGMENT_IO: false
     STAFF_EMAIL: mitx-support@mit.edu
 FEEDBACK_SUBMISSION_EMAIL: ''
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 FILE_UPLOAD_STORAGE_BUCKET_NAME: {{ key "edxapp/s3-storage-bucket" }}
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 FILE_UPLOAD_STORAGE_PREFIX: submissions_attachments
 FINANCIAL_REPORTS:
     BUCKET: null
@@ -408,9 +421,12 @@ GOOGLE_ANALYTICS_ACCOUNT: {{ key "edxapp/google-analytics-id" }}
 GRADES_DOWNLOAD:
     BUCKET: {{ key "edxapp/s3-grades-bucket" }}  # MODIFIED
     ROOT_PATH: grades  # MODIFIED
+    # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
     STORAGE_CLASS: django.core.files.storage.S3Storage  # MODIFIED
+    # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
     STORAGE_KWARGS:
         location: grades/
+    # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
     STORAGE_TYPE: S3  # MODIFIED
 HELP_TOKENS_BOOKS:
     course_author: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course
@@ -543,6 +559,28 @@ SOCIAL_SHARING_SETTINGS:
     DASHBOARD_TWITTER: false
 STATIC_URL_BASE: /static/
 STATIC_ROOT_BASE: /openedx/staticfiles/
+# Django 4.2+ storage configuration
+STORAGES:
+  default:
+    BACKEND: storages.backends.s3.S3Storage
+    OPTIONS:
+      bucket_name: {{ key "edxapp/s3-storage-bucket" }}
+      custom_domain: {{ key "edxapp/s3-storage-bucket" }}.s3.amazonaws.com
+      file_overwrite: false
+      default_acl: null
+  staticfiles:
+    BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
+  block_structures:
+    BACKEND: storages.backends.s3.S3Storage
+    OPTIONS:
+      bucket_name: {{ key "edxapp/s3-storage-bucket" }}
+      location: coursestructure/
+      default_acl: public-read
+  grades:
+    BACKEND: storages.backends.s3.S3Storage
+    OPTIONS:
+      bucket_name: {{ key "edxapp/s3-grades-bucket" }}
+      location: grades/
 STUDIO_NAME: Studio
 STUDIO_SHORT_NAME: Studio
 SYSTEM_WIDE_ROLE_CLASSES: []
@@ -554,7 +592,9 @@ VIDEO_IMAGE_MAX_AGE: 31536000
 VIDEO_IMAGE_SETTINGS:
     DIRECTORY_PREFIX: video-images/
     BASE_URL: /media/
-    BUCKET: {{ key "edxapp/s3-storage-bucket" }} # MODIFIED
+    # STORAGE_CLASS is required by edx-val and should NOT be removed
+    # Reference: https://github.com/openedx/edx-val/blob/master/edxval/utils.py#L160-L163
+    STORAGE_CLASS: storages.backends.s3boto3.S3Boto3Storage
     STORAGE_KWARGS:
         location: media/  # MODIFIED
     VIDEO_IMAGE_MAX_BYTES: 2097152
@@ -562,8 +602,10 @@ VIDEO_IMAGE_SETTINGS:
 VIDEO_TRANSCRIPTS_MAX_AGE: 31536000
 VIDEO_TRANSCRIPTS_SETTINGS:
     DIRECTORY_PREFIX: video-transcripts/
+    # STORAGE_CLASS is required by edx-val and should NOT be removed
+    # Reference: https://github.com/openedx/edx-val/blob/master/edxval/utils.py#L160-L163
+    STORAGE_CLASS: storages.backends.s3boto3.S3Boto3Storage
     BASE_URL: /media/
-    BUCKET: {{ key "edxapp/s3-storage-bucket" }} # MODIFIED
     STORAGE_KWARGS:
         location: media/  # MODIFIED
     VIDEO_TRANSCRIPTS_MAX_BYTES: 3145728

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitx/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitx/common_values.yml.tmpl
@@ -133,18 +133,25 @@ AUTH_PASSWORD_VALIDATORS:
 -   NAME: common.djangoapps.util.password_policy_validators.MaximumLengthValidator
     OPTIONS:
         max_length: 75
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 AWS_ACCESS_KEY_ID: "" # MODIFIED - not setting as we will use IAM Instance Profiles
 # AWS_QUERYSTRING_AUTH: false
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 AWS_S3_CUSTOM_DOMAIN: {{ key "edxapp/s3-storage-bucket" }}.s3.amazonaws.com  # MODIFIED
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 AWS_SECRET_ACCESS_KEY: ""  # MODIFIED - not setting as we will use IAM Instance Profiles
 AWS_SES_CONFIGURATION_SET: {{ key "edxapp/ses-configuration-set" }}  # ADDED KEY
 AWS_SES_REGION_ENDPOINT: email.us-east-1.amazonaws.com
 AWS_SES_REGION_NAME: us-east-1
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 AWS_STORAGE_BUCKET_NAME: {{ key "edxapp/s3-storage-bucket" }}  # MODIFIED
 BASE_COOKIE_DOMAIN: {{ key "edxapp/lms-domain" }} # MODIFIED
 BLOCKSTORE_USE_BLOCKSTORE_APP_API: true
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 BUNDLE_ASSET_STORAGE_SETTINGS:
+  # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
   STORAGE_CLASS: storages.backends.s3boto3.S3Boto3Storage
+  # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
   STORAGE_KWARGS:
     location: blockstore/
 BLOCK_STRUCTURES_SETTINGS:
@@ -152,8 +159,10 @@ BLOCK_STRUCTURES_SETTINGS:
     PRUNING_ACTIVE: true  # MODIFIED
     TASK_DEFAULT_RETRY_DELAY: 30
     TASK_MAX_RETRIES: 5
+    # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
     STORAGE_CLASS: storages.backends.s3boto3.S3Boto3Storage
     DIRECTORY_PREFIX: coursestructure/
+    # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
     STORAGE_KWARGS:
       bucket_name: {{ key "edxapp/s3-storage-bucket" }}
       default_acl: public-read
@@ -244,6 +253,7 @@ COURSE_MODE_DEFAULTS:
     sku: null
     slug: honor
     suggested_prices: ''
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 COURSE_IMPORT_EXPORT_BUCKET: {{ key "edxapp/s3-course-bucket" }}  # MODIFIED
 CREDENTIALS_INTERNAL_SERVICE_URL: http://localhost:8005
 CREDENTIALS_PUBLIC_SERVICE_URL: http://localhost:8005
@@ -259,6 +269,7 @@ DASHBOARD_COURSE_LIMIT: null
 DATA_DIR: /openedx/data  # Filesystem path where edx puts files for course export/import
 DEFAULT_COURSE_VISIBILITY_IN_CATALOG: both
 DEFAULT_FEEDBACK_EMAIL: {{ key "edxapp/sender-email-address" }} # MODIFIED
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 DEFAULT_FILE_STORAGE: storages.backends.s3boto3.S3Boto3Storage  # MODIFIED
 DEFAULT_FROM_EMAIL: {{ key "edxapp/sender-email-address" }} # MODIFIED
 DEFAULT_MOBILE_AVAILABLE: false
@@ -378,7 +389,9 @@ FEATURES:
     RESTRICT_ENROLL_SOCIAL_PROVIDERS:
       - mit-kerberos
 FEEDBACK_SUBMISSION_EMAIL: ''
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 FILE_UPLOAD_STORAGE_BUCKET_NAME: {{ key "edxapp/s3-storage-bucket" }}
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 FILE_UPLOAD_STORAGE_PREFIX: submissions_attachments
 FINANCIAL_REPORTS:
     BUCKET: null
@@ -410,9 +423,12 @@ GOOGLE_ANALYTICS_ACCOUNT: {{ key "edxapp/google-analytics-id" }}
 GRADES_DOWNLOAD:
     BUCKET: {{ key "edxapp/s3-grades-bucket" }}  # MODIFIED
     ROOT_PATH: grades  # MODIFIED
+    # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
     STORAGE_CLASS: django.core.files.storage.S3Storage  # MODIFIED
+    # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
     STORAGE_KWARGS:
         location: grades/
+    # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
     STORAGE_TYPE: S3  # MODIFIED
 HELP_TOKENS_BOOKS:
     course_author: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course
@@ -548,6 +564,28 @@ SOCIAL_SHARING_SETTINGS:
     DASHBOARD_TWITTER: false
 STATIC_URL_BASE: /static/
 STATIC_ROOT_BASE: /openedx/staticfiles/
+# Django 4.2+ storage configuration
+STORAGES:
+  default:
+    BACKEND: storages.backends.s3.S3Storage
+    OPTIONS:
+      bucket_name: {{ key "edxapp/s3-storage-bucket" }}
+      custom_domain: {{ key "edxapp/s3-storage-bucket" }}.s3.amazonaws.com
+      file_overwrite: false
+      default_acl: null
+  staticfiles:
+    BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
+  block_structures:
+    BACKEND: storages.backends.s3.S3Storage
+    OPTIONS:
+      bucket_name: {{ key "edxapp/s3-storage-bucket" }}
+      location: coursestructure/
+      default_acl: public-read
+  grades:
+    BACKEND: storages.backends.s3.S3Storage
+    OPTIONS:
+      bucket_name: {{ key "edxapp/s3-grades-bucket" }}
+      location: grades/
 STUDIO_NAME: Studio
 STUDIO_SHORT_NAME: Studio
 SYSTEM_WIDE_ROLE_CLASSES: []
@@ -559,7 +597,9 @@ VIDEO_IMAGE_MAX_AGE: 31536000
 VIDEO_IMAGE_SETTINGS:
     DIRECTORY_PREFIX: video-images/
     BASE_URL: /media/
-    BUCKET: {{ key "edxapp/s3-storage-bucket" }} # MODIFIED
+    # STORAGE_CLASS is required by edx-val and should NOT be removed
+    # Reference: https://github.com/openedx/edx-val/blob/master/edxval/utils.py#L160-L163
+    STORAGE_CLASS: storages.backends.s3boto3.S3Boto3Storage
     STORAGE_KWARGS:
         location: media/  # MODIFIED
     VIDEO_IMAGE_MAX_BYTES: 2097152
@@ -567,8 +607,11 @@ VIDEO_IMAGE_SETTINGS:
 VIDEO_TRANSCRIPTS_MAX_AGE: 31536000
 VIDEO_TRANSCRIPTS_SETTINGS:
     DIRECTORY_PREFIX: video-transcripts/
-    BUCKET: {{ key "edxapp/s3-storage-bucket" }} # MODIFIED
+    # STORAGE_CLASS is required by edx-val and should NOT be removed
+    # Reference: https://github.com/openedx/edx-val/blob/master/edxval/utils.py#L160-L163
+    STORAGE_CLASS: storages.backends.s3boto3.S3Boto3Storage
     BASE_URL: /media/
+    # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
     STORAGE_KWARGS:
         location: media/  # MODIFIED
     VIDEO_TRANSCRIPTS_MAX_BYTES: 3145728

--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -136,18 +136,25 @@ AUTH_PASSWORD_VALIDATORS:
 -   NAME: common.djangoapps.util.password_policy_validators.MaximumLengthValidator
     OPTIONS:
         max_length: 75
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 AWS_ACCESS_KEY_ID: "" # MODIFIED - not setting as we will use IAM Instance Profiles
 # AWS_QUERYSTRING_AUTH: false
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 AWS_S3_CUSTOM_DOMAIN: {{ key "edxapp/s3-storage-bucket" }}.s3.amazonaws.com
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 AWS_SECRET_ACCESS_KEY: ""  # MODIFIED - not setting as we will use IAM Instance Profiles
 AWS_SES_CONFIGURATION_SET: {{ key "edxapp/ses-configuration-set" }}  # ADDED KEY
 AWS_SES_REGION_ENDPOINT: email.us-east-1.amazonaws.com
 AWS_SES_REGION_NAME: us-east-1
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 AWS_STORAGE_BUCKET_NAME: {{ key "edxapp/s3-storage-bucket" }}  # MODIFIED
 BASE_COOKIE_DOMAIN: {{ key "edxapp/lms-domain" }} # MODIFIED
 BLOCKSTORE_USE_BLOCKSTORE_APP_API: true
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 BUNDLE_ASSET_STORAGE_SETTINGS:
+  # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
   STORAGE_CLASS: storages.backends.s3boto3.S3Boto3Storage
+  # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
   STORAGE_KWARGS:
     location: blockstore/
 BLOCK_STRUCTURES_SETTINGS:
@@ -155,8 +162,10 @@ BLOCK_STRUCTURES_SETTINGS:
     PRUNING_ACTIVE: true  # MODIFIED
     TASK_DEFAULT_RETRY_DELAY: 30
     TASK_MAX_RETRIES: 5
+    # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
     STORAGE_CLASS: storages.backends.s3boto3.S3Boto3Storage
     DIRECTORY_PREFIX: coursestructure/
+    # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
     STORAGE_KWARGS:
       bucket_name: {{ key "edxapp/s3-storage-bucket" }}
       default_acl: public-read
@@ -242,6 +251,7 @@ COURSE_ABOUT_VISIBILITY_PERMISSION: see_exists
 COURSE_CATALOG_API_URL: http://localhost:8008/api/v1
 COURSE_CATALOG_URL_ROOT: http://localhost:8008
 COURSE_CATALOG_VISIBILITY_PERMISSION: staff
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 COURSE_IMPORT_EXPORT_BUCKET: {{ key "edxapp/s3-course-bucket" }}  # MODIFIED
 CREDENTIALS_INTERNAL_SERVICE_URL: http://localhost:8005
 CREDENTIALS_PUBLIC_SERVICE_URL: http://localhost:8005
@@ -256,6 +266,7 @@ DASHBOARD_COURSE_LIMIT: null
 DATA_DIR: /openedx/data  # Filesystem path where edx puts files for course export/import
 DEFAULT_COURSE_VISIBILITY_IN_CATALOG: both
 DEFAULT_FEEDBACK_EMAIL: {{ key "edxapp/sender-email-address" }} # MODIFIED
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 DEFAULT_FILE_STORAGE: storages.backends.s3boto3.S3Boto3Storage  # MODIFIED
 DEFAULT_FROM_EMAIL: {{ key "edxapp/sender-email-address" }} # MODIFIED
 DEFAULT_MOBILE_AVAILABLE: false
@@ -341,7 +352,9 @@ FEATURES:
     SHOW_HEADER_LANGUAGE_SELECTOR: false
     SKIP_EMAIL_VALIDATION: true # ADDED KEY
 FEEDBACK_SUBMISSION_EMAIL: ''
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 FILE_UPLOAD_STORAGE_BUCKET_NAME: {{ key "edxapp/s3-storage-bucket" }}
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 FILE_UPLOAD_STORAGE_PREFIX: submissions_attachments
 FINANCIAL_REPORTS:
     BUCKET: null
@@ -373,9 +386,12 @@ GOOGLE_ANALYTICS_ACCOUNT: {{ key "edxapp/google-analytics-id" }}
 GRADES_DOWNLOAD:
     BUCKET: {{ key "edxapp/s3-grades-bucket" }}  # MODIFIED
     ROOT_PATH: grades  # MODIFIED
+    # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
     STORAGE_CLASS: django.core.files.storage.S3Storage  # MODIFIED
+    # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
     STORAGE_KWARGS:
         location: grades/
+    # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
     STORAGE_TYPE: S3  # MODIFIED
 HELP_TOKENS_BOOKS:
     course_author: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course
@@ -582,6 +598,28 @@ SOCIAL_SHARING_SETTINGS:
     DASHBOARD_TWITTER: false
 STATIC_URL_BASE: /static/
 STATIC_ROOT_BASE: /openedx/staticfiles/
+# Django 4.2+ storage configuration
+STORAGES:
+  default:
+    BACKEND: storages.backends.s3.S3Storage
+    OPTIONS:
+      bucket_name: {{ key "edxapp/s3-storage-bucket" }}
+      custom_domain: {{ key "edxapp/s3-storage-bucket" }}.s3.amazonaws.com
+      file_overwrite: false
+      default_acl: null
+  staticfiles:
+    BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
+  block_structures:
+    BACKEND: storages.backends.s3.S3Storage
+    OPTIONS:
+      bucket_name: {{ key "edxapp/s3-storage-bucket" }}
+      location: coursestructure/
+      default_acl: public-read
+  grades:
+    BACKEND: storages.backends.s3.S3Storage
+    OPTIONS:
+      bucket_name: {{ key "edxapp/s3-grades-bucket" }}
+      location: grades/
 STUDIO_NAME: Studio
 STUDIO_SHORT_NAME: Studio
 SUPPORT_SITE_LINK: https://mitxonline.zendesk.com/hc/
@@ -594,6 +632,9 @@ USERNAME_REPLACEMENT_WORKER: OVERRIDE THIS WITH A VALID USERNAME
 VIDEO_IMAGE_MAX_AGE: 31536000
 VIDEO_IMAGE_SETTINGS:
     DIRECTORY_PREFIX: video-images/
+    # STORAGE_CLASS is required by edx-val and should NOT be removed
+    # Reference: https://github.com/openedx/edx-val/blob/master/edxval/utils.py#L160-L163
+    STORAGE_CLASS: storages.backends.s3boto3.S3Boto3Storage
     STORAGE_KWARGS:
         location: media/  # MODIFIED
     VIDEO_IMAGE_MAX_BYTES: 2097152
@@ -602,6 +643,9 @@ VIDEO_IMAGE_SETTINGS:
 VIDEO_TRANSCRIPTS_MAX_AGE: 31536000
 VIDEO_TRANSCRIPTS_SETTINGS:
     DIRECTORY_PREFIX: video-transcripts/
+    # STORAGE_CLASS is required by edx-val and should NOT be removed
+    # Reference: https://github.com/openedx/edx-val/blob/master/edxval/utils.py#L160-L163
+    STORAGE_CLASS: storages.backends.s3boto3.S3Boto3Storage
     STORAGE_KWARGS:
         location: media/  # MODIFIED
     VIDEO_TRANSCRIPTS_MAX_BYTES: 3145728

--- a/src/bilder/images/edxapp_v2/templates/edxapp/xpro/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/xpro/common_values.yml.tmpl
@@ -127,18 +127,25 @@ AUTH_PASSWORD_VALIDATORS:
 -   NAME: common.djangoapps.util.password_policy_validators.MaximumLengthValidator
     OPTIONS:
         max_length: 75
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 AWS_ACCESS_KEY_ID: "" # MODIFIED - not setting as we will use IAM Instance Profiles
 # AWS_QUERYSTRING_AUTH: false
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 AWS_S3_CUSTOM_DOMAIN: {{ key "edxapp/s3-storage-bucket" }}.s3.amazonaws.com
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 AWS_SECRET_ACCESS_KEY: ""  # MODIFIED - not setting as we will use IAM Instance Profiles
 AWS_SES_CONFIGURATION_SET: {{ key "edxapp/ses-configuration-set" }}  # ADDED KEY
 AWS_SES_REGION_ENDPOINT: email.us-east-1.amazonaws.com
 AWS_SES_REGION_NAME: us-east-1
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 AWS_STORAGE_BUCKET_NAME: {{ key "edxapp/s3-storage-bucket" }}  # MODIFIED
 BASE_COOKIE_DOMAIN: {{ key "edxapp/lms-domain" }} # MODIFIED
 BLOCKSTORE_USE_BLOCKSTORE_APP_API: true
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 BUNDLE_ASSET_STORAGE_SETTINGS:
+  # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
   STORAGE_CLASS: storages.backends.s3boto3.S3Boto3Storage
+  # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
   STORAGE_KWARGS:
     location: blockstore/
 BLOCK_STRUCTURES_SETTINGS:
@@ -146,8 +153,10 @@ BLOCK_STRUCTURES_SETTINGS:
     PRUNING_ACTIVE: true  # MODIFIED
     TASK_DEFAULT_RETRY_DELAY: 30
     TASK_MAX_RETRIES: 5
+    # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
     STORAGE_CLASS: storages.backends.s3boto3.S3Boto3Storage
     DIRECTORY_PREFIX: coursestructure/
+    # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
     STORAGE_KWARGS:
       bucket_name: {{ key "edxapp/s3-storage-bucket" }}
       default_acl: public-read
@@ -226,6 +235,7 @@ COURSE_ABOUT_VISIBILITY_PERMISSION: see_exists
 COURSE_CATALOG_API_URL: http://localhost:8008/api/v1
 COURSE_CATALOG_URL_ROOT: http://localhost:8008
 COURSE_CATALOG_VISIBILITY_PERMISSION: staff
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 COURSE_IMPORT_EXPORT_BUCKET: {{ key "edxapp/s3-course-bucket" }}  # MODIFIED
 CREDENTIALS_INTERNAL_SERVICE_URL: http://localhost:8005
 CREDENTIALS_PUBLIC_SERVICE_URL: http://localhost:8005
@@ -239,6 +249,7 @@ DASHBOARD_COURSE_LIMIT: null
 DATA_DIR: /openedx/data # Filesystem path where edx puts files for course export/import
 DEFAULT_COURSE_VISIBILITY_IN_CATALOG: both
 DEFAULT_FEEDBACK_EMAIL: {{ key "edxapp/sender-email-address" }} # MODIFIED
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 DEFAULT_FILE_STORAGE: storages.backends.s3boto3.S3Boto3Storage  # MODIFIED
 DEFAULT_FROM_EMAIL: {{ key "edxapp/sender-email-address" }} # MODIFIED
 DEFAULT_MOBILE_AVAILABLE: false
@@ -345,7 +356,9 @@ FEATURES:
     RESTRICT_ENROLL_BY_REG_METHOD: false
     SESSION_COOKIE_SECURE: true
 FEEDBACK_SUBMISSION_EMAIL: ''
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 FILE_UPLOAD_STORAGE_BUCKET_NAME: {{ key "edxapp/s3-storage-bucket" }}
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 FILE_UPLOAD_STORAGE_PREFIX: submissions_attachments
 FINANCIAL_REPORTS:
     BUCKET: null
@@ -357,9 +370,12 @@ GOOGLE_ANALYTICS_ACCOUNT: {{ key "edxapp/google-analytics-id" }}
 GRADES_DOWNLOAD:
     BUCKET: {{ key "edxapp/s3-grades-bucket" }}  # MODIFIED
     ROOT_PATH: grades  # MODIFIED
+    # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
     STORAGE_CLASS: django.core.files.storage.S3Storage  # MODIFIED
+    # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
     STORAGE_KWARGS:
         location: grades/
+    # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
     STORAGE_TYPE: S3  # MODIFIED
 HELP_TOKENS_BOOKS:
     course_author: http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course
@@ -522,6 +538,28 @@ SOCIAL_SHARING_SETTINGS:
     DASHBOARD_TWITTER: false
 STATIC_URL_BASE: /static/
 STATIC_ROOT_BASE: /openedx/staticfiles/
+# Django 4.2+ storage configuration
+STORAGES:
+  default:
+    BACKEND: storages.backends.s3.S3Storage
+    OPTIONS:
+      bucket_name: {{ key "edxapp/s3-storage-bucket" }}
+      custom_domain: {{ key "edxapp/s3-storage-bucket" }}.s3.amazonaws.com
+      file_overwrite: false
+      default_acl: null
+  staticfiles:
+    BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
+  block_structures:
+    BACKEND: storages.backends.s3.S3Storage
+    OPTIONS:
+      bucket_name: {{ key "edxapp/s3-storage-bucket" }}
+      location: coursestructure/
+      default_acl: public-read
+  grades:
+    BACKEND: storages.backends.s3.S3Storage
+    OPTIONS:
+      bucket_name: {{ key "edxapp/s3-grades-bucket" }}
+      location: grades/
 STUDIO_NAME: Studio
 STUDIO_SHORT_NAME: Studio
 SUPPORT_SITE_LINK: https://xpro.zendesk.com/hc
@@ -533,8 +571,10 @@ USERNAME_REPLACEMENT_WORKER: OVERRIDE THIS WITH A VALID USERNAME
 VIDEO_IMAGE_MAX_AGE: 31536000
 VIDEO_IMAGE_SETTINGS:
     DIRECTORY_PREFIX: video-images/
+    # STORAGE_CLASS is required by edx-val and should NOT be removed
+    # Reference: https://github.com/openedx/edx-val/blob/master/edxval/utils.py#L160-L163
+    STORAGE_CLASS: storages.backends.s3boto3.S3Boto3Storage
     BASE_URL: /media/
-    BUCKET: {{ key "edxapp/s3-storage-bucket" }} # MODIFIED
     STORAGE_KWARGS:
         location: media/  # MODIFIED
     VIDEO_IMAGE_MAX_BYTES: 2097152
@@ -542,8 +582,10 @@ VIDEO_IMAGE_SETTINGS:
 VIDEO_TRANSCRIPTS_MAX_AGE: 31536000
 VIDEO_TRANSCRIPTS_SETTINGS:
     DIRECTORY_PREFIX: video-transcripts/
+    # STORAGE_CLASS is required by edx-val and should NOT be removed
+    # Reference: https://github.com/openedx/edx-val/blob/master/edxval/utils.py#L160-L163
+    STORAGE_CLASS: storages.backends.s3boto3.S3Boto3Storage
     BASE_URL: /media/
-    BUCKET: {{ key "edxapp/s3-storage-bucket" }} # MODIFIED
     STORAGE_KWARGS:
         location: media/  # MODIFIED
     VIDEO_TRANSCRIPTS_MAX_BYTES: 3145728

--- a/src/ol_infrastructure/applications/edxapp/files/edxapp/mitxonline/50-general-config.yaml
+++ b/src/ol_infrastructure/applications/edxapp/files/edxapp/mitxonline/50-general-config.yaml
@@ -30,14 +30,19 @@ AUTH_PASSWORD_VALIDATORS:
 - NAME: common.djangoapps.util.password_policy_validators.MaximumLengthValidator
   OPTIONS:
     max_length: 75
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 AWS_ACCESS_KEY_ID: "" # MODIFIED - not setting as we will use IAM Instance Profiles
 # AWS_QUERYSTRING_AUTH: false
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 AWS_SECRET_ACCESS_KEY: ""  # MODIFIED - not setting as we will use IAM Instance Profiles
 AWS_SES_REGION_ENDPOINT: email.us-east-1.amazonaws.com
 AWS_SES_REGION_NAME: us-east-1
 BLOCKSTORE_USE_BLOCKSTORE_APP_API: true
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 BUNDLE_ASSET_STORAGE_SETTINGS:
+  # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
   STORAGE_CLASS: storages.backends.s3boto3.S3Boto3Storage
+  # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
   STORAGE_KWARGS:
     location: blockstore/
 BRANCH_IO_KEY: ''
@@ -118,6 +123,7 @@ CSRF_COOKIE_SAMESITE: 'None'
 DASHBOARD_COURSE_LIMIT: null
 DATA_DIR: /openedx/data  # Filesystem path where edx puts files for course export/import
 DEFAULT_COURSE_VISIBILITY_IN_CATALOG: both
+# TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
 DEFAULT_FILE_STORAGE: storages.backends.s3boto3.S3Boto3Storage  # MODIFIED
 DEFAULT_MOBILE_AVAILABLE: false
 DEFAULT_SITE_THEME: mitxonline  # MODIFIED
@@ -357,6 +363,7 @@ SOCIAL_SHARING_SETTINGS:
   DASHBOARD_TWITTER: false
 STATIC_URL_BASE: /static/
 STATIC_ROOT_BASE: /openedx/staticfiles/
+# Django 4.2+ storage configuration
 STUDIO_NAME: Studio
 STUDIO_SHORT_NAME: Studio
 SUPPORT_SITE_LINK: https://mitxonline.zendesk.com/hc/
@@ -369,6 +376,9 @@ USE_X_FORWARDED_HOST: false  # MODIFIED
 VIDEO_IMAGE_MAX_AGE: 31536000
 VIDEO_IMAGE_SETTINGS:
   DIRECTORY_PREFIX: video-images/
+  # STORAGE_CLASS is required by edx-val and should NOT be removed
+  # Reference: https://github.com/openedx/edx-val/blob/master/edxval/utils.py#L160-L163
+  STORAGE_CLASS: storages.backends.s3boto3.S3Boto3Storage
   STORAGE_KWARGS:
     location: media/  # MODIFIED
   VIDEO_IMAGE_MAX_BYTES: 2097152
@@ -377,6 +387,9 @@ VIDEO_IMAGE_SETTINGS:
 VIDEO_TRANSCRIPTS_MAX_AGE: 31536000
 VIDEO_TRANSCRIPTS_SETTINGS:
   DIRECTORY_PREFIX: video-transcripts/
+  # STORAGE_CLASS is required by edx-val and should NOT be removed
+  # Reference: https://github.com/openedx/edx-val/blob/master/edxval/utils.py#L160-L163
+  STORAGE_CLASS: storages.backends.s3boto3.S3Boto3Storage
   STORAGE_KWARGS:
     location: media/  # MODIFIED
   VIDEO_TRANSCRIPTS_MAX_BYTES: 3145728

--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -84,7 +84,9 @@ def create_k8s_configmaps(
                     - {edxapp_config.require_object("domains")["lms"]}
                     - {edxapp_config.require_object("domains")["preview"]}
                     - {edxapp_config.require_object("domains")["studio"]}
+                    # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
                     AWS_S3_CUSTOM_DOMAIN: {storage_bucket_name}.s3.amazonaws.com
+                    # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
                     AWS_STORAGE_BUCKET_NAME: {storage_bucket_name}
                     AWS_SES_CONFIGURATION_SET: {ses_configuration_set}
                     BASE_COOKIE_DOMAIN: {edxapp_config.require_object("domains")["lms"]}
@@ -93,8 +95,10 @@ def create_k8s_configmaps(
                       PRUNING_ACTIVE: true  # MODIFIED
                       TASK_DEFAULT_RETRY_DELAY: 30
                       TASK_MAX_RETRIES: 5
+                      # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
                       STORAGE_CLASS: storages.backends.s3boto3.S3Boto3Storage
                       DIRECTORY_PREFIX: coursestructure/
+                      # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
                       STORAGE_KWARGS:
                         bucket_name: {storage_bucket_name}
                         default_acl: public-read
@@ -129,6 +133,7 @@ def create_k8s_configmaps(
                     - host: {runtime_config["opensearch_hostname"]}
                       port: 443
                       use_ssl: true
+                    # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
                     FILE_UPLOAD_STORAGE_BUCKET_NAME: {storage_bucket_name}
                     FORUM_ELASTIC_SEARCH_CONFIG:
                     - host: {runtime_config["opensearch_hostname"]}
@@ -140,9 +145,12 @@ def create_k8s_configmaps(
                     GRADES_DOWNLOAD:
                       BUCKET: {grades_bucket_name}  # MODIFIED
                       ROOT_PATH: grades  # MODIFIED
+                      # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
                       STORAGE_CLASS: django.core.files.storage.S3Storage  # MODIFIED
+                      # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
                       STORAGE_KWARGS:
                         location: grades/
+                      # TODO: Remove after Django 5.2 migration - replaced by STORAGES configuration
                       STORAGE_TYPE: S3  # MODIFIED
                     IDA_LOGOUT_URI_LIST:
                     - https://{edxapp_config.require("marketing_domain")}/logout
@@ -194,6 +202,28 @@ def create_k8s_configmaps(
                     SESSION_COOKIE_DOMAIN: {".{}".format(edxapp_config.require_object("domains")["lms"].split(".", 1)[-1])}
                     UNIVERSITY_EMAIL: {edxapp_config.require("sender_email_address")}
                     ECOMMERCE_PUBLIC_URL_ROOT: {edxapp_config.require_object("domains")["lms"]}
+                    # Django 4.2+ storage configuration
+                    STORAGES:
+                      default:
+                        BACKEND: storages.backends.s3.S3Storage
+                        OPTIONS:
+                          bucket_name: {storage_bucket_name}
+                          custom_domain: {storage_bucket_name}.s3.amazonaws.com
+                          file_overwrite: false
+                          default_acl: null
+                      staticfiles:
+                        BACKEND: django.contrib.staticfiles.storage.StaticFilesStorage
+                      block_structures:
+                        BACKEND: storages.backends.s3.S3Storage
+                        OPTIONS:
+                          bucket_name: {storage_bucket_name}
+                          location: coursestructure/
+                          default_acl: public-read
+                      grades:
+                        BACKEND: storages.backends.s3.S3Storage
+                        OPTIONS:
+                          bucket_name: {grades_bucket_name}
+                          location: grades/
             """),
             },
             opts=ResourceOptions(delete_before_replace=True),


### PR DESCRIPTION
### What are the relevant tickets?
https://github.mit.edu/mitxonline/mitxonline-issues/issues/896

### Description (What does it do?)
<!--- Describe your changes in detail -->
The django-storages package has changed its configuration structure. This manifests most visibly in video transcript files related to edx-val. This adds the necessary settings structures to verify that things are working properly.

The relevant bit of code that pointed to the solution was https://github.com/openedx/edx-val/blob/master/edxval/utils.py#L160-L163

We didn't have the `STORAGE_CLASS` set in the `VIDEO_TRANSCRIPTS_SETTINGS` and image settings blocks so it fell through to the else clause which ignored our settings.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
This has been deployed and validated on Learn edX RC
