### PR TITLE
config: add MIT learn support URL

### DIFF
--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -416,6 +416,7 @@ MIT_LEARN_AI_XBLOCK_CHAT_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai
 MIT_LEARN_AI_XBLOCK_TUTOR_CHAT_API_URL: https://{{ key "edxapp/learn-api-domain" }}/ai/http/canvas_tutor_agent/  # Added for ol_openedx_chat_xblock
 MIT_LEARN_AI_XBLOCK_PROBLEM_SET_LIST_URL: https://{{ key "edxapp/learn-api-domain" }}/ai/api/v0/problem_set_list  # Added for ol_openedx_chat_xblock
 MIT_LEARN_AI_XBLOCK_CHAT_RATING_URL: https://{{ key "edxapp/learn-api-domain" }}/ai/api/v0/chat_sessions/  # Added for ol_openedx_chat_xblock
+MIT_LEARN_SUPPORT_SITE_LINK: mailto:mitlearn-support@mit.edu
 UAI_COURSE_KEY_FORMATS:
   - course-v1:uai_
 MIT_LEARN_LOGO: https://{{ key "edxapp/lms-domain" }}/static/mitxonline/images/mit-learn-logo.svg"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Related to https://github.com/mitodl/mitxonline-theme/pull/64

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds a new setting for the MIT Learn support Email.

