### PR TITLE
Tweak NTUA saml config

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/olapps.py
+++ b/src/ol_infrastructure/substructure/keycloak/olapps.py
@@ -827,6 +827,8 @@ def create_olapps_realm(  # noqa: PLR0913, PLR0915
                     "lastName": "sn",
                     "fullName": "cn",
                 },
+                want_assertions_encrypted=True,
+                want_assertions_signed=True,
             )
         )
         onboard_saml_org(


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
Enables assertion encryption and signature to one of the partner SAML configs in Keycloak
