### PR TITLE
Make the course certificate generation task run more frequently

### DIFF
--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.Production.yaml
@@ -20,7 +20,7 @@ config:
     CSRF_TRUSTED_ORIGINS: "https://mitxonline.mit.edu,https://learn.mit.edu"
     CSRF_COOKIE_DOMAIN: "mitxonline.mit.edu"
     CSRF_COOKIE_NAME: csrf_mitxonline
-    CRON_COURSE_CERTIFICATES_HOURS: "18"
+    CRON_COURSE_CERTIFICATES_HOURS: "*/6"
     CRON_PROCESS_REFUND_REQUESTS_MINUTES: "*/5"
     FEATURE_ENABLE_ADDL_PROFILE_FIELDS: "true"
     FEATURE_ENABLE_UPGRADE_DIALOG: "true"

--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.QA.yaml
@@ -20,7 +20,7 @@ config:
     CSRF_TRUSTED_ORIGINS: "https://rc.mitxonline.mit.edu,https://rc.learn.mit.edu"
     CSRF_COOKIE_DOMAIN: ".rc.mitxonline.mit.edu"
     CSRF_COOKIE_NAME: csrf_mitxonline
-    CRON_COURSE_CERTIFICATES_HOURS: "18"
+    CRON_COURSE_CERTIFICATES_HOURS: "*/6"
     GA_TRACKING_ID: "UA-5145472-46"
     GTM_TRACKING_ID: "GTM-TW97MNR"
     KEYCLOAK_BASE_URL: "https://sso-qa.ol.mit.edu"


### PR DESCRIPTION
### What are the relevant tickets?

Related to https://github.com/mitodl/hq/issues/8956

### Description (What does it do?)

[Peter mentioned](https://github.com/mitodl/hq/issues/8956#issuecomment-3456204668) making the certificate task run more frequently. So, this changes the schedule to run every 6 hours. It was set to run at 18:00 UTC daily.

### Additional Context

[This](https://github.com/mitodl/mitxonline/pull/3027) changes the default schedule to be on the hour. That's probably too often for it to run in production; it took about 12 minutes to run when I triggered it manually. 