### PR TITLE
Add authoring extension scaffold to build pipeline

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/jupyterhub/build_jupyterhub_extensions.py
+++ b/src/ol_concourse/pipelines/infrastructure/jupyterhub/build_jupyterhub_extensions.py
@@ -22,6 +22,7 @@ pypi_type = pypi_resource()
 # repository. The build happens via uv package manager (https://docs.astral.sh/uv/)
 plugins = [
     "ol-themed-jupyter",
+    "ol-jupyter-authoring",
 ]
 
 fragments = []


### PR DESCRIPTION
### Description (What does it do?)
Once https://github.com/mitodl/ol-notebook-extensions/pull/5 is merged, this should build and publish the authoring extension scaffold to PyPi. Once that's done, we'll be able to create a base image for docker authors which includes an installation of this package, so we can build additional authoring functionality into a notebook server.