### PR TITLE
feat: Add Fastly management to MITx Online project

### DIFF
--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.CI.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.CI.yaml
@@ -6,7 +6,8 @@ config:
   mitxonline:apisix_ingress_class: apache-apisix
   mitxonline:db_password:
     secure: v1:vEeGgZVBjWBklqb3:FWrkz0af0N+bAW/Faye1raC5aSL7fJwcJgBk3DtWmQCZ95k1v8pRzMyGmPG6FQ10Q2VWNMS0yBO4PMZVp7bSIRz18OiCPwmfVv5wa347Fms=
-  mitxonline:domain: "api.ci.mitxonline.mit.edu"
+  mitxonline:backend_domain: "api.ci.mitxonline.mit.edu"
+  mitxonline:frontend_domain: "ci.mitxonline.mit.edu"
   mitxonline:k8s_deploy: "true"
   mitxonline:learn_backend_domain: "api.ci.learn.mit.edu"
   mitxonline:use_granian: true

--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.Production.yaml
@@ -10,7 +10,8 @@ config:
   mitxonline:apisix_ingress_class: apache-apisix
   mitxonline:db_password:
     secure: v1:1SGxkH66kKNXMVc0:P9FztYdyzfxIrapGHU3pD5gz9ZkW6Of/zTqhaZf4O+L+Y8yAbcissYxogKfyDMxSJYSSUxI12K0=
-  mitxonline:domain: "api.mitxonline.mit.edu"
+  mitxonline:backend_domain: "api.mitxonline.mit.edu"
+  mitxonline:frontend_domain: "mitxonline.mit.edu"
   mitxonline:k8s_deploy: "true"
   mitxonline:learn_backend_domain: "api.learn.mit.edu"
   mitxonline:min_replicas: 4

--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.QA.yaml
@@ -10,7 +10,8 @@ config:
   mitxonline:apisix_ingress_class: apache-apisix
   mitxonline:db_password:
     secure: v1:72AVczMFP7U0adTg:qiVKioH1VjNf38HfLkNIZsCdc8RqKs0bkaou+fU6SSRK9W4kbS1do2PwdD3JWYlc37eojd+sdAL8npp+tyEeQ66q5mHmWDQK3WlqgdWbf8G41fizyMwoy2AQdZmtZtJe40IoeqaSX3ntfJvhI0uP7YWmpge4G9e6KMNBmhZ0wl0T6qHU4z180aId1ZpjCM4=
-  mitxonline:domain: "api.rc.mitxonline.mit.edu"
+  mitxonline:backend_domain: "api.rc.mitxonline.mit.edu"
+  mitxonline:frontend_domain: "rc.mitxonline.mit.edu"
   mitxonline:k8s_deploy: "true"
   mitxonline:learn_backend_domain: "api.rc.learn.mit.edu"
   mitxonline:min_replicas: 4
@@ -42,7 +43,7 @@ config:
     MITX_ONLINE_BASE_URL: "https://rc.mitxonline.mit.edu"
     MITX_ONLINE_ENVIRONMENT: "rc"
     MITX_ONLINE_LOG_LEVEL: "INFO"
-    MITX_ONLINE_SECURE_SSL_HOST: "api.rc.mitxonline.mit.edu"
+    MITX_ONLINE_SECURE_SSL_HOST: "rc.mitxonline.mit.edu"
     OPENEDX_API_BASE_URL: "https://courses.rc.learn.mit.edu"
     OPENEDX_COURSE_BASE_URL: "https://courses.rc.learn.mit.edu/learn/course/"
     OPENEDX_OAUTH_PROVIDER: "ol-oauth2"


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9133

### Description (What does it do?)
<!--- Describe your changes in detail -->
The login flow was landing on the API domain instead of the frontend domain when going through fastly. This was because of the host name override being set which caused the login link to point at the API domain instead of the frontend domain. This brings the Fastly management under Pulumi control, as well as setting up APISix to handle the frontend domain for routing as well so that there isn't a need to route directly to the API domain for login/logout.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
This has been deployed to RC and validated working
