### PR TITLE
chore: Migrated Leek deployment to Kubernetes

### DIFF
--- a/src/ol_infrastructure/applications/celery_monitoring/Pulumi.applications.celery_monitoring.CI.yaml
+++ b/src/ol_infrastructure/applications/celery_monitoring/Pulumi.applications.celery_monitoring.CI.yaml
@@ -3,10 +3,6 @@ secretsprovider: awskms://alias/infrastructure-secrets-ci
 encryptedkey: AQICAHjnbqe9AmEW1Js10nySybyuAG7Fb5E9EHUgkmqFDv7PxQGJ3TnWvhlQQrGyE2EnakrrAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMLHRA6TjX63WMbvebAgEQgDvYwi1/1THyTliMz0gtC5QFMM5n3CEegQjUf4ex2KMBS2cfl45cyxYnMRC30v/+rl+oTap57E0YNCks7A==
 config:
   aws:region: us-east-1
-  celery_monitoring:auto_scale:
-    desired: 1
-    max: 2
-    min: 1
   celery_monitoring:domain: celery-monitoring-ci.odl.mit.edu
   celery_monitoring:sender_email_address: ol-devops@mit.edu
   celery_monitoring:target_vpc: operations_vpc

--- a/src/ol_infrastructure/applications/celery_monitoring/__main__.py
+++ b/src/ol_infrastructure/applications/celery_monitoring/__main__.py
@@ -1,49 +1,62 @@
-import base64
 import json
 import re
-import textwrap
 from pathlib import Path
 
-import pulumi_consul as consul
+import pulumi_kubernetes as kubernetes
 import pulumi_vault as vault
 import pulumiverse_heroku as heroku
-import yaml
-from pulumi import Config, InvokeOptions, Output, ResourceOptions, StackReference
-from pulumi_aws import acm, ec2, get_caller_identity, iam, route53
+from pulumi import Config, InvokeOptions, Output, StackReference
 
-from bridge.secrets.sops import read_yaml_secrets
-from ol_infrastructure.components.aws.auto_scale_group import (
-    BlockDeviceMapping,
-    OLAutoScaleGroupConfig,
-    OLAutoScaling,
-    OLLaunchTemplateConfig,
-    OLLoadBalancerConfig,
-    OLTargetGroupConfig,
-    TagSpecification,
+from ol_infrastructure.components.applications.eks import (
+    OLEKSAuthBinding,
+    OLEKSAuthBindingConfig,
 )
-from ol_infrastructure.lib.aws.ec2_helper import InstanceTypes
-from ol_infrastructure.lib.consul import get_consul_provider
+from ol_infrastructure.components.services.cert_manager import (
+    OLCertManagerCert,
+    OLCertManagerCertConfig,
+)
+from ol_infrastructure.components.services.k8s import (
+    OLApisixOIDCConfig,
+    OLApisixOIDCResources,
+    OLApisixPluginConfig,
+    OLApisixRoute,
+    OLApisixRouteConfig,
+)
+from ol_infrastructure.components.services.vault import (
+    OLVaultK8SSecret,
+    OLVaultK8SStaticSecretConfig,
+)
+from ol_infrastructure.lib.aws.eks_helper import (
+    cached_image_uri,
+    check_cluster_namespace,
+    setup_k8s_provider,
+)
 from ol_infrastructure.lib.heroku import get_heroku_provider
-from ol_infrastructure.lib.ol_types import AWSBase
+from ol_infrastructure.lib.ol_types import (
+    AWSBase,
+    BusinessUnit,
+    K8sGlobalLabels,
+    Services,
+)
 from ol_infrastructure.lib.pulumi_helper import parse_stack
 from ol_infrastructure.lib.vault import setup_vault_provider
 
 stack_info = parse_stack()
 setup_vault_provider(stack_info)
 celery_monitoring_config = Config("celery_monitoring")
-consul_provider = get_consul_provider(stack_info)
-network_stack = StackReference(f"infrastructure.aws.network.{stack_info.name}")
-dns_stack = StackReference("infrastructure.aws.dns")
-consul_stack = StackReference(f"infrastructure.consul.operations.{stack_info.name}")
 opensearch_stack = StackReference(
     f"infrastructure.aws.opensearch.celery_monitoring.{stack_info.name}"
 )
-vault_infra_stack = StackReference(f"infrastructure.vault.operations.{stack_info.name}")
 vault_mount_stack = StackReference(
     f"substructure.vault.static_mounts.operations.{stack_info.name}"
 )
 
-policy_stack = StackReference("infrastructure.aws.policies")
+# K8s stack references
+cluster_stack = StackReference(f"infrastructure.aws.eks.operations.{stack_info.name}")
+cluster_substructure_stack = StackReference(
+    f"substructure.aws.eks.operations.{stack_info.name}"
+)
+setup_k8s_provider(kubeconfig=cluster_stack.require_output("kube_config"))
 
 
 def build_broker_subscriptions(
@@ -125,266 +138,305 @@ vault.kv.SecretV2(
     data_json=redis_broker_subscriptions,
 )
 
-mitodl_zone_id = dns_stack.require_output("odl_zone_id")
-operations_vpc = network_stack.require_output("operations_vpc")
-celery_monitoring_env = f"operations-{stack_info.env_suffix}"
-aws_config = AWSBase(tags={"OU": "operations", "Environment": celery_monitoring_env})
-consul_security_groups = consul_stack.require_output("security_groups")
-
-aws_account = get_caller_identity()
-
-
-celery_monitoring_domain = celery_monitoring_config.get("domain")
-
-consul.Keys(
-    "celery-monitoring-consul-template-data",
-    keys=[
-        consul.KeysKeyArgs(
-            path="celery-monitoring/domain",
-            value=celery_monitoring_domain,
-        ),
-    ],
-    opts=consul_provider,
+aws_config = AWSBase(
+    tags={"OU": "operations", "Environment": f"operations-{stack_info.env_suffix}"}
 )
 
-celery_monitoring_instance_role = iam.Role(
-    "celery-monitoring-instance-role",
-    assume_role_policy=json.dumps(
-        {
-            "Version": "2012-10-17",
-            "Statement": {
-                "Effect": "Allow",
-                "Action": "sts:AssumeRole",
-                "Principal": {"Service": "ec2.amazonaws.com"},
-            },
-        }
-    ),
-    name=f"celery-monitoring-instance-role-{stack_info.env_suffix}",
-    path="/ol-operations/celery-monitoring-role/",
-    tags=aws_config.tags,
+celery_monitoring_domain = celery_monitoring_config.require("domain")
+
+# Kubernetes deployment
+celery_monitoring_namespace = "operations"
+
+# Verify namespace exists in cluster
+cluster_stack.require_output("namespaces").apply(
+    lambda ns: check_cluster_namespace(celery_monitoring_namespace, ns)
 )
 
-iam.RolePolicyAttachment(
-    f"celery-monitoring-describe-instance-role-policy-{stack_info.env_suffix}",
-    policy_arn=policy_stack.require_output("iam_policies")["describe_instances"],
-    role=celery_monitoring_instance_role.name,
+k8s_global_labels = K8sGlobalLabels(
+    service=Services.celery_monitoring,
+    ou=BusinessUnit.operations,
+    stack=stack_info,
 )
 
-iam.RolePolicyAttachment(
-    f"concourse-route53-role-policy-{stack_info.env_suffix}",
-    policy_arn=policy_stack.require_output("iam_policies")["route53_ol_zone_records"],
-    role=celery_monitoring_instance_role.name,
-)
-
-celery_monitoring_profile = iam.InstanceProfile(
-    f"celery-monitoring-instance-profile-{stack_info.env_suffix}",
-    role=celery_monitoring_instance_role.name,
-    name=f"celery-monitoring-instance-profile-{stack_info.env_suffix}",
-    path="/ol-operations/celery-monitoring-profile/",
-)
-
-celery_monitoring_security_group = ec2.SecurityGroup(
-    "celery-monitoring-security-group",
-    name_prefix=f"celery-monitoring-{celery_monitoring_env}-",
-    description="Allow celery_monitoring to connect to Elasticache",
-    vpc_id=operations_vpc["id"],
-    ingress=[],
-    egress=[],
-    tags=aws_config.merged_tags(
-        {"Name": f"celery-monitoring-{celery_monitoring_env}"},
-    ),
-)
-
-# Get the AMI ID for the celery_monitoring/docker-compose image
-celery_monitoring_ami = ec2.get_ami(
-    filters=[
-        ec2.GetAmiFilterArgs(name="name", values=["celery-monitoring-server-*"]),
-        ec2.GetAmiFilterArgs(name="virtualization-type", values=["hvm"]),
-        ec2.GetAmiFilterArgs(name="root-device-type", values=["ebs"]),
-    ],
-    most_recent=True,
-    owners=[aws_account.account_id],
-)
-
-# Create a vault policy to allow celery_monitoring to get to the secrets it needs
-celery_monitoring_server_vault_policy = vault.Policy(
-    "celery-monitoring-server-vault-policy",
-    name="celery-monitoring-server",
-    policy=Path(__file__)
-    .parent.joinpath("celery_monitoring_server_policy.hcl")
-    .read_text(),
-)
-# Register celery_monitoring AMI for Vault AWS auth
-vault.aws.AuthBackendRole(
-    "celery-monitoring-server-ami-ec2-vault-auth",
-    backend="aws",
-    auth_type="iam",
-    role="celery_monitoring",
-    inferred_entity_type="ec2_instance",
-    inferred_aws_region=aws_config.region,
-    bound_iam_instance_profile_arns=[celery_monitoring_profile.arn],
-    bound_ami_ids=[celery_monitoring_ami.id],
-    bound_account_ids=[aws_account.account_id],
-    bound_vpc_ids=[operations_vpc["id"]],
-    token_policies=[celery_monitoring_server_vault_policy.name],
-    opts=ResourceOptions(delete_before_replace=True),
-)
-
-
-# ACM lookup of ODL's wildcardcert
-celery_monitoring_web_acm_cert = acm.get_certificate(
-    domain="*.odl.mit.edu", most_recent=True, statuses=["ISSUED"]
-)
-celery_monitoring_lb_config = OLLoadBalancerConfig(
-    subnets=operations_vpc["subnet_ids"],
-    security_groups=[operations_vpc["security_groups"]["web"]],
-    tags=aws_config.merged_tags(
-        {"Name": f"celery-monitoring-lb-{stack_info.env_suffix}"}
-    ),
-    listener_cert_domain=celery_monitoring_domain,
-    listener_cert_arn=celery_monitoring_web_acm_cert.arn,
-)
-
-celery_monitoring_tg_config = OLTargetGroupConfig(
-    vpc_id=operations_vpc["id"],
-    health_check_interval=60,
-    health_check_matcher="200-399",
-    health_check_path="/api/v1/manage/hc",
-    # give extra time for celery_monitoring to start up
-    health_check_unhealthy_threshold=3,
-    tags=aws_config.merged_tags(
-        {"Name": f"celery-monitoring-tg-{stack_info.env_suffix}"}
-    ),
-)
-
-consul_datacenter = consul_stack.require_output("datacenter")
-grafana_credentials = read_yaml_secrets(
-    Path(f"vector/grafana.{stack_info.env_suffix}.yaml")
-)
-
-celery_monitoring_web_block_device_mappings = [BlockDeviceMapping(volume_size=50)]
-celery_monitoring_web_tag_specs = [
-    TagSpecification(
-        resource_type="instance",
-        tags=aws_config.merged_tags(
-            {"Name": f"celery-monitoring-web-{stack_info.env_suffix}"}
-        ),
-    ),
-    TagSpecification(
-        resource_type="volume",
-        tags=aws_config.merged_tags(
-            {"Name": f"celery-monitoring-web-{stack_info.env_suffix}"}
-        ),
-    ),
-]
-
-celery_monitoring_web_lt_config = OLLaunchTemplateConfig(
-    block_device_mappings=celery_monitoring_web_block_device_mappings,
-    image_id=celery_monitoring_ami.id,
-    instance_type=celery_monitoring_config.get("instance_type")
-    or InstanceTypes.burstable_medium,
-    instance_profile_arn=celery_monitoring_profile.arn,
-    security_groups=[
-        celery_monitoring_security_group.id,
-        consul_security_groups["consul_agent"],
-        operations_vpc["security_groups"]["web"],
-        operations_vpc["security_groups"]["celery_monitoring"],
-    ],
-    tags=aws_config.merged_tags(
-        {"Name": f"celery-monitoring-web-{stack_info.env_suffix}"}
-    ),
-    tag_specifications=celery_monitoring_web_tag_specs,
-    user_data=consul_datacenter.apply(
-        lambda consul_dc: base64.b64encode(
-            "#cloud-config\n{}".format(
-                yaml.dump(
-                    {
-                        "write_files": [
-                            {
-                                "path": "/etc/consul.d/02-autojoin.json",
-                                "content": json.dumps(
-                                    {
-                                        "retry_join": [
-                                            "provider=aws tag_key=consul_env "
-                                            f"tag_value={consul_dc}"
-                                        ],
-                                        "datacenter": consul_dc,
-                                    }
-                                ),
-                                "owner": "consul:consul",
-                            },
-                            {
-                                "path": "/etc/default/vector",
-                                "content": textwrap.dedent(
-                                    f"""\
-                            ENVIRONMENT={consul_dc}
-                            APPLICATION=celery_monitoring
-                            SERVICE=celery-monitoring
-                            VECTOR_CONFIG_DIR=/etc/vector/
-                            VECTOR_STRICT_ENV_VARS=false
-                            AWS_REGION={aws_config.region}
-                            GRAFANA_CLOUD_API_KEY={grafana_credentials["api_key"]}
-                            GRAFANA_CLOUD_PROMETHEUS_API_USER={grafana_credentials["prometheus_user_id"]}
-                            GRAFANA_CLOUD_LOKI_API_USER={grafana_credentials["loki_user_id"]}
-                            """
-                                ),
-                                "owner": "root:root",
-                            },
-                            {
-                                "path": "/etc/default/docker-compose",
-                                "content": "COMPOSE_PROFILES=web",
-                            },
-                            {
-                                "path": "/etc/profile",
-                                "content": "export COMPOSE_PROFILES=web",
-                                "append": True,
-                            },
-                        ]
-                    },
-                    sort_keys=True,
-                )
-            ).encode("utf8")
-        ).decode("utf8")
-    ),
-)
-
-celery_monitoring_web_auto_scale_config = celery_monitoring_config.get_object(
-    "web_auto_scale"
-) or {
-    "desired": 1,
-    "min": 1,
-    "max": 2,
+application_labels = {
+    **k8s_global_labels.model_dump(),
+    "app": "celery-monitoring",
 }
-celery_monitoring_web_asg_config = OLAutoScaleGroupConfig(
-    asg_name=f"leek-web-{celery_monitoring_env}",
-    aws_config=aws_config,
-    health_check_grace_period=120,
-    instance_refresh_warmup=120,
-    desired_size=celery_monitoring_web_auto_scale_config["desired"],
-    min_size=celery_monitoring_web_auto_scale_config["min"],
-    max_size=celery_monitoring_web_auto_scale_config["max"],
-    vpc_zone_identifiers=operations_vpc["subnet_ids"],
-    tags=aws_config.merged_tags(
-        {"Name": f"celery-monitoring-web-{celery_monitoring_env}"}
+
+# Get OpenSearch endpoint for Leek configuration
+opensearch_endpoint = opensearch_stack.require_output("cluster")["endpoint"]
+
+# IAM policy for IRSA (if needed for AWS service access)
+celery_monitoring_iam_policy_document = {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeInstances",
+                "ec2:DescribeTags",
+            ],
+            "Resource": "*",
+        }
+    ],
+}
+
+# OLEKSAuthBinding for IRSA and Vault K8s auth
+celery_monitoring_auth_binding = OLEKSAuthBinding(
+    OLEKSAuthBindingConfig(
+        application_name="celery-monitoring",
+        namespace=celery_monitoring_namespace,
+        stack_info=stack_info,
+        aws_config=aws_config,
+        iam_policy_document=celery_monitoring_iam_policy_document,
+        vault_policy_path=Path(__file__).parent.joinpath(
+            "celery_monitoring_server_policy.hcl"
+        ),
+        cluster_identities=cluster_stack.require_output("cluster_identities"),
+        vault_auth_endpoint=cluster_stack.require_output("vault_auth_endpoint"),
+        irsa_service_account_name="celery-monitoring",
+        vault_sync_service_account_names=["celery-monitoring-vault"],
+        k8s_labels=k8s_global_labels,
+    )
+)
+
+# Create broker subscriptions secret via Vault Secrets Operator
+leek_broker_subscriptions_secret = OLVaultK8SSecret(
+    f"celery-monitoring-broker-subscriptions-{stack_info.env_suffix}",
+    resource_config=OLVaultK8SStaticSecretConfig(
+        dest_secret_labels=application_labels,
+        dest_secret_name="leek-broker-subscriptions",  # pragma: allowlist-secret # noqa: S106, E501
+        exclude_raw=True,
+        excludes=[".*"],
+        labels=application_labels,
+        mount=celery_monitoring_vault_kv_path,
+        mount_type="kv-v2",
+        name="leek-broker-subscriptions",
+        namespace=celery_monitoring_namespace,
+        path="redis_brokers",
+        refresh_after="1m",
+        templates={
+            "LEEK_AGENT_SUBSCRIPTIONS": '{{ get .Secrets "broker_subscriptions" | toJson }}',  # noqa: E501
+        },
+        vaultauth=celery_monitoring_auth_binding.vault_k8s_resources.auth_name,
     ),
 )
 
-celery_monitoring_web_asg = OLAutoScaling(
-    asg_config=celery_monitoring_web_asg_config,
-    lt_config=celery_monitoring_web_lt_config,
-    tg_config=celery_monitoring_tg_config,
-    lb_config=celery_monitoring_lb_config,
+cert_manager_certificate = OLCertManagerCert(
+    f"celery-monitoring-cert-manager-certificate-{stack_info.env_suffix}",
+    cert_config=OLCertManagerCertConfig(
+        application_name="celery-monitoring",
+        k8s_namespace=celery_monitoring_namespace,
+        k8s_labels=application_labels,
+        create_apisixtls_resource=True,
+        dest_secret_name="celery-monitoring-tls",  # pragma: allowlist-secret  # noqa: E501, S106
+        dns_names=[celery_monitoring_domain],
+    ),
 )
 
 
-# Create Route53 DNS records for celery_monitoring
-five_minutes = 60 * 5
-route53.Record(
-    "celery-monitoring-server-dns-record",
-    name=celery_monitoring_domain,
-    type="CNAME",
-    ttl=five_minutes,
-    records=[celery_monitoring_web_asg.load_balancer.dns_name],
-    zone_id=mitodl_zone_id,
-    opts=ResourceOptions(delete_before_replace=True),
+# OIDC authentication resources (using existing secret-operations/sso/leek)
+celery_monitoring_oidc_resources = OLApisixOIDCResources(
+    f"celery-monitoring-oidc-resources-{stack_info.env_suffix}",
+    oidc_config=OLApisixOIDCConfig(
+        application_name="celery-monitoring",
+        k8s_labels=application_labels,
+        k8s_namespace=celery_monitoring_namespace,
+        oidc_logout_path="/logout/oidc",
+        oidc_post_logout_redirect_uri=f"https://{celery_monitoring_domain}/",
+        oidc_session_cookie_lifetime=60 * 20160,  # 2 weeks
+        oidc_use_session_secret=True,
+        vault_mount="secret-operations",
+        vault_mount_type="kv-v1",
+        vault_path="sso/leek",
+        vaultauth=celery_monitoring_auth_binding.vault_k8s_resources.auth_name,
+    ),
 )
+
+# Leek container image from ECR mirror
+leek_image = cached_image_uri("kodhive/leek")
+
+# Kubernetes Deployment for Leek
+leek_deployment = kubernetes.apps.v1.Deployment(
+    f"celery-monitoring-deployment-{stack_info.env_suffix}",
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        name="celery-monitoring",
+        namespace=celery_monitoring_namespace,
+        labels=application_labels,
+    ),
+    spec=kubernetes.apps.v1.DeploymentSpecArgs(
+        replicas=celery_monitoring_config.get_int("replicas") or 1,
+        selector=kubernetes.meta.v1.LabelSelectorArgs(
+            match_labels={"app": "celery-monitoring"},
+        ),
+        template=kubernetes.core.v1.PodTemplateSpecArgs(
+            metadata=kubernetes.meta.v1.ObjectMetaArgs(
+                labels=application_labels,
+            ),
+            spec=kubernetes.core.v1.PodSpecArgs(
+                service_account_name=celery_monitoring_auth_binding.vault_k8s_resources.service_account_name,
+                containers=[
+                    kubernetes.core.v1.ContainerArgs(
+                        name="leek",
+                        image=leek_image,
+                        ports=[
+                            kubernetes.core.v1.ContainerPortArgs(
+                                container_port=5000,
+                                name="http",
+                            ),
+                        ],
+                        env=[
+                            kubernetes.core.v1.EnvVarArgs(
+                                name="LEEK_API_LOG_LEVEL",
+                                value=celery_monitoring_config.get("log_level")
+                                or "INFO",
+                            ),
+                            kubernetes.core.v1.EnvVarArgs(
+                                name="LEEK_API_ENABLE_AUTH",
+                                value="false",
+                            ),
+                            kubernetes.core.v1.EnvVarArgs(
+                                name="LEEK_WEB_URL",
+                                value=f"https://{celery_monitoring_domain}",
+                            ),
+                            kubernetes.core.v1.EnvVarArgs(
+                                name="LEEK_API_URL",
+                                value=f"https://{celery_monitoring_domain}/v1",
+                            ),
+                            kubernetes.core.v1.EnvVarArgs(
+                                name="LEEK_AGENT_API_SECRET",
+                                value="not-secret",
+                            ),
+                            kubernetes.core.v1.EnvVarArgs(
+                                name="LEEK_AGENT_LOG_LEVEL",
+                                value="INFO",
+                            ),
+                            kubernetes.core.v1.EnvVarArgs(
+                                name="LEEK_ENABLE_API", value="true"
+                            ),
+                            kubernetes.core.v1.EnvVarArgs(
+                                name="LEEK_ENABLE_AGENT", value="true"
+                            ),
+                            kubernetes.core.v1.EnvVarArgs(
+                                name="LEEK_ENABLE_WEB", value="true"
+                            ),
+                            kubernetes.core.v1.EnvVarArgs(
+                                name="LEEK_ES_URL",
+                                value=opensearch_endpoint.apply(
+                                    lambda ep: f"https://{ep}"
+                                ),
+                            ),
+                        ],
+                        env_from=[
+                            kubernetes.core.v1.EnvFromSourceArgs(
+                                secret_ref=kubernetes.core.v1.SecretEnvSourceArgs(
+                                    name="leek-broker-subscriptions",
+                                ),
+                            ),
+                        ],
+                        resources=kubernetes.core.v1.ResourceRequirementsArgs(
+                            requests={
+                                "cpu": celery_monitoring_config.get("cpu_request")
+                                or "500m",
+                                "memory": celery_monitoring_config.get("memory_request")
+                                or "512Mi",
+                            },
+                            limits={
+                                "cpu": celery_monitoring_config.get("cpu_limit")
+                                or "1000m",
+                                "memory": celery_monitoring_config.get("memory_limit")
+                                or "1Gi",
+                            },
+                        ),
+                        liveness_probe=kubernetes.core.v1.ProbeArgs(
+                            http_get=kubernetes.core.v1.HTTPGetActionArgs(
+                                path="/v1/manage/hc",
+                                port=5000,
+                            ),
+                            initial_delay_seconds=30,
+                            period_seconds=10,
+                        ),
+                        readiness_probe=kubernetes.core.v1.ProbeArgs(
+                            http_get=kubernetes.core.v1.HTTPGetActionArgs(
+                                path="/v1/manage/hc",
+                                port=5000,
+                            ),
+                            initial_delay_seconds=10,
+                            period_seconds=5,
+                        ),
+                        startup_probe=kubernetes.core.v1.ProbeArgs(
+                            http_get=kubernetes.core.v1.HTTPGetActionArgs(
+                                path="/v1/manage/hc",
+                                port=5000,
+                            ),
+                            initial_delay_seconds=10,
+                            period_seconds=10,
+                            failure_threshold=6,
+                            success_threshold=1,
+                            timeout_seconds=5,
+                        ),
+                    ),
+                ],
+            ),
+        ),
+    ),
+)
+
+# Kubernetes Service for Leek
+leek_service = kubernetes.core.v1.Service(
+    f"celery-monitoring-service-{stack_info.env_suffix}",
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        name="celery-monitoring",
+        namespace=celery_monitoring_namespace,
+        labels=application_labels,
+    ),
+    spec=kubernetes.core.v1.ServiceSpecArgs(
+        type="ClusterIP",
+        selector={"app": "celery-monitoring"},
+        ports=[
+            kubernetes.core.v1.ServicePortArgs(
+                port=5000,
+                target_port=5000,
+                name="api",
+            ),
+            kubernetes.core.v1.ServicePortArgs(
+                port=8000,
+                target_port=8000,
+                name="web",
+            ),
+        ],
+    ),
+)
+
+# APISIX Routes for Leek (API and Web UI with OIDC)
+apisix_ingress_class = celery_monitoring_config.get("apisix_ingress_class") or "apisix"
+
+# Get OIDC plugin config as dict and wrap in OLApisixPluginConfig
+oidc_plugin = OLApisixPluginConfig(
+    **celery_monitoring_oidc_resources.get_full_oidc_plugin_config(unauth_action="deny")
+)
+
+leek_apisix_route = OLApisixRoute(
+    name=f"celery-monitoring-apisix-route-{stack_info.env_suffix}",
+    k8s_namespace=celery_monitoring_namespace,
+    k8s_labels=application_labels,
+    ingress_class_name=apisix_ingress_class,
+    route_configs=[
+        OLApisixRouteConfig(
+            route_name="web",
+            priority=0,
+            plugins=[
+                oidc_plugin,
+            ],
+            hosts=[celery_monitoring_domain],
+            paths=["/*"],
+            backend_service_name="celery-monitoring",
+            backend_service_port=5000,
+        ),
+    ],
+)
+
+
+# DNS is managed by external-dns via annotations on the APISIX service
+# Domain must be added to eks:apisix_domains in the EKS stack configuration
+# (infrastructure.aws.eks.operations.{env})

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.operations.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.operations.CI.yaml
@@ -13,8 +13,8 @@ config:
   - "celery-monitoring-ci.odl.mit.edu"
   eks:developer_role_policy_name: "AmazonEKSAdminPolicy"
   eks:developer_role_kubernetes_groups: ["admin"]
-  eks:ebs_csi_provisioner: "true"
-  eks:efs_csi_provisioner: "true"
+  eks:ebs_csi_provisioner: true
+  eks:efs_csi_provisioner: true
   eks:gateway_release_channel: "experimental"
   eks:namespaces:
   - "keycloak"

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.operations.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.operations.Production.yaml
@@ -13,8 +13,8 @@ config:
   - "celery-monitoring.odl.mit.edu"
   eks:apisix_min_replicas: "3"
   eks:apisix_max_replicas: "10"
-  eks:ebs_csi_provisioner: "true"
-  eks:efs_csi_provisioner: "true"
+  eks:ebs_csi_provisioner: true
+  eks:efs_csi_provisioner: true
   eks:gateway_release_channel: "experimental"
   eks:namespaces:
   - "keycloak"

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.operations.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.infrastructure.aws.eks.operations.QA.yaml
@@ -13,8 +13,8 @@ config:
   - "celery-monitoring-qa.odl.mit.edu"
   eks:developer_role_policy_name: "AmazonEKSAdminPolicy"
   eks:developer_role_kubernetes_groups: ["admin"]
-  eks:ebs_csi_provisioner: "true"
-  eks:efs_csi_provisioner: "true"
+  eks:ebs_csi_provisioner: true
+  eks:efs_csi_provisioner: true
   eks:gateway_release_channel: "experimental"
   eks:namespaces:
   - "keycloak"

--- a/src/ol_infrastructure/lib/ol_types.py
+++ b/src/ol_infrastructure/lib/ol_types.py
@@ -55,6 +55,7 @@ class Services(str, Enum):
     superset = "superset"
     bootcamps = "bootcamps"
     botkube = "botkube"
+    celery_monitoring = "celery-monitoring"
     codejail = "codejail"
     dagster = "dagster"
     ecommerce = "unified-ecommerce"


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
This migrates deployment of the Leek celery monitoring service from EC2 to Kubernetes

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Run a `pulumi up` on the CI or QA stacks and verify that everything runs. This requires first deploying the APISix chart configs to the operations cluster.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
In order to cut down on excess EC2 spend we want to continue with migrating ASG based services to Kubernetes
