### PR TITLE
Functionality to build jupyter notebooks from S3

### DIFF
--- a/src/ol_concourse/pipelines/container_images/jupyter_courses.py
+++ b/src/ol_concourse/pipelines/container_images/jupyter_courses.py
@@ -131,14 +131,6 @@ courses = [
         repo_uri="git@github.mit.edu:ol-notebooks/UAI_SOURCE-UAI.MLTL.1-1T2026",
         image_name="uai_source-uai.mltl1",
     ),
-    CourseImageInfo(
-        course_name="base_notebook_image",
-        # This needs to be provisioned as a versioned bucket.
-        # Alternatively, we need to encode versioning into the object path.
-        s3_bucket="ol-infrastructure-artifacts",
-        s3_object_path="jupyterhub/base_notebook_image/base_image.tar.gz",
-        image_name="base_notebook_image",
-    ),
 ]
 
 # This infers the ECR url from the AWS account,


### PR DESCRIPTION
### Description (What does it do?)
Reasonably quick and dirty first cut at scaffolding the Jupyter course build pipeline to support both github-sourced builds and s3 sourced builds.

This will rely on IAM credentials provisioned on Concourse runners in order to access the S3 bucket. Code to provision an S3 bucket and add the first S3 course will come in a subsequent PR - for now this is a no-op.

### How can this be tested?
It's not extremely straightforward. I ended up using my local installation of concourse, manually editing the pipeline definition to pipe in a valid access key pair and using a course archive stored in ol-devops-sandbox. YMMV and I frankly don't recommend doing much testing of this until:
- The S3 bucket is provisioned
- I've got a course stored in S3 to even build