### PR TITLE
Provision s3 bucket for course images

### DIFF
--- a/src/ol_infrastructure/applications/jupyterhub/__main__.py
+++ b/src/ol_infrastructure/applications/jupyterhub/__main__.py
@@ -112,7 +112,7 @@ jupyter_bucket_public_access = s3.BucketPublicAccessBlock(
     block_public_acls=True,
     block_public_policy=True,
     ignore_public_acls=True,
-    restrict_public_access=True,
+    restrict_public_buckets=True,
 )
 
 # Allow full access to the bucket from the account root user.


### PR DESCRIPTION
N.B. This will _probably_ be superseded by https://github.com/mitodl/ol-infrastructure/pull/3821/files. I'll close whichever of the two that we don't go w/ but these are functionally identical at the moment (excluding intelligent tiering)

### Description (What does it do?)
Provisions an S3 bucket per environment for the Jupyterhub "save to S3" functionality. Each is set up as versioned and accessible from within the AWS account

Below is the relevant Pulumi plan:
```
    + aws:s3/bucket:Bucket: (create)
        [urn=urn:pulumi:applications.jupyterhub.CI::ol-infrastructure-jupyterhub-application::aws:s3/bucket:Bucket::jupyter-course-bucket]
        [provider=urn:pulumi:applications.jupyterhub.CI::ol-infrastructure-jupyterhub-application::pulumi:providers:aws::default_7_11_0::e3220dc5-6ab5-437e-9c02-1ab4b5396902]
        bucket      : "jupyter-courses-ci"
        forceDestroy: false
        region      : "us-east-1"
        tags        : {
            Environment   : "ci"
            OU            : "mit-learn"
            pulumi_managed: "true"
        }
        tagsAll     : {
            Environment   : "ci"
            OU            : "mit-learn"
            pulumi_managed: "true"
        }
    > pulumi:pulumi:StackReference: (read)
        [id=infrastructure.monitoring]
        [urn=urn:pulumi:applications.jupyterhub.CI::ol-infrastructure-jupyterhub-application::pulumi:pulumi:StackReference::implicit.infrastructure.monitoring]
        name: "infrastructure.monitoring"
    + aws:s3/bucketPolicy:BucketPolicy: (create)
        [urn=urn:pulumi:applications.jupyterhub.CI::ol-infrastructure-jupyterhub-application::aws:s3/bucketPolicy:BucketPolicy::jupyter-course-bucket-policy]
        [provider=urn:pulumi:applications.jupyterhub.CI::ol-infrastructure-jupyterhub-application::pulumi:providers:aws::default_7_11_0::e3220dc5-6ab5-437e-9c02-1ab4b5396902]
        bucket    : [unknown]
        policy    : (json) {
            Statement: [
                [0]: {
                    Action   : "s3:*"
                    Effect   : "Allow"
                    Principal: {
                        AWS: "arn:aws:iam::610119931565:root"
                    }
                    Resource : "arn:aws:s3:::[jupyter-courses-ci]/*"
                }
            ]
            Version  : "2012-10-17"
        }

        region    : "us-east-1"
    + aws:s3/bucketVersioning:BucketVersioning: (create)
        [urn=urn:pulumi:applications.jupyterhub.CI::ol-infrastructure-jupyterhub-application::aws:s3/bucketVersioning:BucketVersioning::jupyter-course-bucket-versioning]
        [provider=urn:pulumi:applications.jupyterhub.CI::ol-infrastructure-jupyterhub-application::pulumi:providers:aws::default_7_11_0::e3220dc5-6ab5-437e-9c02-1ab4b5396902]
        bucket                 : [unknown]
        region                 : "us-east-1"
        versioningConfiguration: {
            status    : "Enabled"
        }
    + aws:s3/bucketPublicAccessBlock:BucketPublicAccessBlock: (create)
        [urn=urn:pulumi:applications.jupyterhub.CI::ol-infrastructure-jupyterhub-application::aws:s3/bucketPublicAccessBlock:BucketPublicAccessBlock::jupyter-course-bucket-public-access]
        [provider=urn:pulumi:applications.jupyterhub.CI::ol-infrastructure-jupyterhub-application::pulumi:providers:aws::default_7_11_0::e3220dc5-6ab5-437e-9c02-1ab4b5396902]
        blockPublicAcls      : true
        blockPublicPolicy    : true
        bucket               : [unknown]
        ignorePublicAcls     : true
        region               : "us-east-1"
        restrictPublicBuckets: true
```

### Open Questions
- ~Do we want one bucket per environment? While Jupyterhub itself has multiple environments, the image build pipeline doesn't, and any built images in ECR are accessible to any JH environment. We could keep everything in a single cross-env bucket if we wanted to adhere more closely to that behavior - if we go w/ that, we'll probably want to pull it out of the main Jupyterhub provisioning code since it wouldn't be 1:1 w/ the stacks.~ See comments - we're going to provision one bucket per env for now and we can always revisit it if it ends up being a direction we don't want to proceed in.