### PR TITLE
config: add mitxonline domain for theme templates

### DIFF
--- a/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
+++ b/src/bilder/images/edxapp_v2/templates/edxapp/mitxonline/common_values.yml.tmpl
@@ -453,6 +453,7 @@ MITX_REDIRECT_ALLOW_RE_LIST:  # ADDED VALUE
   - "^/courses/course-v1:.*?/xqueue/.*$"  # TODO (TMM 2025-07-22): Remove this once the xqueue -> submissions migration is complete
   - "^/courses/.*/courseware-navigation-sidebar/toggles/?$"
   - "^/courses/.*/courseware-search/enabled/?$"
+MITXONLINE_BASE_URL: https://{{ key "edxapp/mitxonline-domain" }}/ # ADDED - to support mitxonline-theme
 MKTG_URLS:
     ROOT: https://{{ key "edxapp/marketing-domain" }}/
 MKTG_URL_LINK_MAP:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.CI.yaml
@@ -65,6 +65,7 @@ config:
   edxapp:backend_studio_domain: studio-backend.ci.learn.mit.edu
   edxapp:backend_preview_domain: preview-backend.ci.learn.mit.edu
   edxapp:marketing_domain: ci.mitxonline.mit.edu
+  edxapp:mitxonline_domain: ci.mitxonline.mit.edu
   edxapp:edx_forum_secrets:
     secure: v1:+8kgTH+x98kC+Lxc:bW03E5mk8wRB+FxZYtj06FPx/MEJuEiKO5ekaDTZKmqmfklisVhidp0fhX+So2Eygf/Aiyqp5L03RCzA8k7I4ZmlNss19//pdGgBDwa3HAbw
   edxapp:enable_notes: "True"

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
@@ -65,6 +65,7 @@ config:
   edxapp:mit_learn_api_domain: api.learn.mit.edu
   edxapp:learn_ai_frontend_domain: "learn-ai.ol.mit.edu"
   edxapp:marketing_domain: learn.mit.edu
+  edxapp:mitxonline_domain: mitxonline.mit.edu
   edxapp:edx_forum_secrets:
     secure: v1:qzfe99Jb8n0TnEQS:Y6fSOS8lksj7WvED+V7kCtV7arDtwx7184Fw330Mwh9JDHW72rVd8y7Nm0fF8ANCcFCwDV5EwSU2Fcc+X47NHDOLCOQv16lyB6jWOF2mTr/veRax6MbXY9NlLmsfp9EBQesDCitULbkz9hyHcHT3GPI=
   edxapp:enable_notes: "True"

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
@@ -65,6 +65,7 @@ config:
   edxapp:backend_studio_domain: studio-backend.rc.learn.mit.edu
   edxapp:backend_preview_domain: preview-backend.rc.learn.mit.edu
   edxapp:marketing_domain: rc.mitxonline.mit.edu
+  edxapp:mitxonline_domain: rc.mitxonline.mit.edu
   edxapp:edx_forum_secrets:
     secure: v1:IqXRArQveCV+9lkE:cRaraFuN2dDmI29PD4QifOU7MrRFdszOoaUb7o3pDJordt4TSjw8fIxldWfMzNhZRLC+NS291DorO1IuN6ASdCbt5d53aMvHVt+3hA6wyuI11OFjk7U=
   edxapp:elb_healthcheck_interval: "30"

--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -1173,6 +1173,7 @@ consul_kv_data = {
     "google-analytics-id": edxapp_config.require("google_analytics_id"),
     "lms-domain": edxapp_domains["lms"],
     "marketing-domain": edxapp_config.get("marketing_domain") or "",
+    "mitxonline-domain": edxapp_config.get("mitxonline_domain") or "",
     "preview-domain": edxapp_domains["preview"],
     "rds-host": edxapp_db.db_instance.address,
     "proctortrack-base-url": edxapp_config.get("proctortrack_url") or "",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8964

### Description (What does it do?)
In [this commit](https://github.com/mitodl/ol-infrastructure/commit/99960a7a2ec8eeb6c99af79186f68a489d3492c2), Mike updated the mitxonline marketing domain value to point to the MIT Learn domain. We were using this value in our legacy templates to direct non-UAI courses to the mitxonline site.

To keep things consistent, this PR introduces a new variable, `MITXONLINE_BASE_URL`, similar to the existing `MIT_LEARN_BASE_URL`. This variable will be used in our themes to direct the non UAI courses to mitxonline instead of learn

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
