### PR TITLE
fix: use black logo for authoring

### DIFF
--- a/src/bridge/settings/openedx/mfe/slot_config/mitxonline/common-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/mitxonline/common-mfe-config.env.jsx
@@ -471,6 +471,12 @@ const addSecondaryMenuSlotOverride = (config) => {
 }
 
 const addEnvOverrides = (config) => {
+  if (CURRENT_MFE_APP_ID === AUTHORING_APP_ID) {
+    config = {
+      ...config,
+      LOGO_URL: process.env.LOGO_URL.replace(/logo\.svg$/, 'old-logo.svg'),
+    }
+  }
   if (isLearnCourse()) {
     return {
       ...config,


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
None

### Description (What does it do?)
<!--- Describe your changes in detail -->
Replaces the logo with a black logo for the authoring header.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Copy the config to the authoring MFE and see that the logo is black.