### PR TITLE
reset staleness and incompleteness defaults

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -978,8 +978,6 @@ env_vars = {
     "CORS_ALLOWED_ORIGIN_REGEXES": "['^.+ocw-next.netlify.app$']",
     "CSAIL_BASE_URL": "https://cap.csail.mit.edu/",
     "CSRF_COOKIE_DOMAIN": f".{mitlearn_config.get('frontend_domain')}",
-    "DEFAULT_SEARCH_MAX_INCOMPLETENESS_PENALTY": 0,
-    "DEFAULT_SEARCH_STALENESS_PENALTY": 0,
     "EDX_API_ACCESS_TOKEN_URL": "https://api.edx.org/oauth2/v1/access_token",
     "EDX_API_URL": "https://api.edx.org/catalog/v1/catalogs/10/courses",
     "EDX_PROGRAMS_API_URL": "https://discovery.edx.org/api/v1/programs/",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9243

### Description (What does it do?)
https://github.com/mitodl/mit-learn/pull/2688 fixed the bug that was causing the staleness/incompleteness adjustments to break search. this resets the defaults to the defaults from learn https://github.com/mitodl/mit-learn/blob/0156f9164ad9045f9829bc8debc2e39839fb33ba/main/settings.py#L779

