### PR TITLE
Add UAI SE1 to image pipeline and extra images

### DIFF
--- a/src/ol_concourse/pipelines/container_images/jupyter_courses.py
+++ b/src/ol_concourse/pipelines/container_images/jupyter_courses.py
@@ -142,6 +142,11 @@ courses = [
         s3_object_path="ol-jupyter-courses/7f5202889ff1484188d628ef7f041383/base_authoring_image.tar.gz",
         image_name="base_authoring_image",
     ),
+    CourseImageInfo(
+        course_name="uai_source-uai.se1",
+        repo_uri="git@github.mit.edu:ol-notebooks/UAI_SOURCE-UAI.SE.1-1T2026",
+        image_name="uai_source-uai.se1",
+    ),
 ]
 
 # This infers the ECR url from the AWS account,

--- a/src/ol_infrastructure/applications/jupyterhub/__main__.py
+++ b/src/ol_infrastructure/applications/jupyterhub/__main__.py
@@ -341,6 +341,7 @@ COURSE_NAMES.extend(
             "st1",
             "mltl1",
             "pm1",
+            "se1",
         ]
     ]
 )

--- a/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
+++ b/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
@@ -44,6 +44,7 @@ KNOWN_COURSES.extend(
             "st1",
             "mltl1",
             "pm1",
+            "se1",
         ]
     ]
 )
@@ -62,6 +63,7 @@ GPU_ENABLED_COURSES = {
     "uai_source-uai.13",
     "uai_source-uai.st1",
     "uai_source-uai.mltl1",
+    "uai_source-uai.se1",
 }
 
 


### PR DESCRIPTION
### Description (What does it do?)
Scaffolds out a new image for [UAI SE1](https://github.mit.edu/ol-notebooks/UAI_SOURCE-UAI.SE.1-1T2026).