### PR TITLE
fix: header login buttons in learning MFE before redirecting to login page

### DIFF
--- a/src/bridge/settings/openedx/mfe/slot_config/mitxonline-styles.scss
+++ b/src/bridge/settings/openedx/mfe/slot_config/mitxonline-styles.scss
@@ -144,6 +144,7 @@
     border: 1px solid var(--Light-Gray-2, #DDE1E6) !important;
     background: var(--Light-Gray-2, #DDE1E6) !important;
     color: #212326 !important;
+    font-size: 12px !important;
     margin-left: 10px !important;
     &:hover {
       text-decoration: none !important;


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9142

### Description (What does it do?)
This PR fixes the text styling of header login buttons in learning MFE  before redirecting to the login page

### Screenshots (if appropriate):
Before
<img width="1792" height="910" alt="Screenshot 2025-12-02 at 12 44 25 PM" src="https://github.com/user-attachments/assets/fecfb395-71d0-4adc-8a91-a7cc0174c7c2" />

After
<img width="1792" height="910" alt="Screenshot 2025-12-02 at 12 43 34 PM" src="https://github.com/user-attachments/assets/c6e727e9-22e3-4b9d-a1a1-d1a343cedf1b" />


### How can this be tested?
- Comment out the login redirect code from the footer
- Visit a learning MFE page in incognito mode. Verify the text styling as shown in the above screenshot

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
