### PR TITLE
md/202512_tika_2

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.CI.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.CI.yaml
@@ -99,7 +99,7 @@ config:
     SENTRY_TRACES_SAMPLE_RATE: "0"
     SESSION_COOKIE_NAME: "session_mitlearn_ci"
     SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT:
-    TIKA_SERVER_ENDPOINT: "https://tika-ci.odl.mit.edu"
+    TIKA_SERVER_ENDPOINT: "https://tika-ci.ol.mit.edu"
     UWSGI_THREADS: 15
     UWSGI_WORKERS: 3
   redis:password:

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.Production.yaml
@@ -101,7 +101,7 @@ config:
     SENTRY_TRACES_SAMPLE_RATE: "0.25"
     SESSION_COOKIE_NAME: "session_mitlearn"
     SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT: "https://sso.ol.mit.edu/realms/olapps"
-    TIKA_SERVER_ENDPOINT: "https://tika-production.odl.mit.edu"
+    TIKA_SERVER_ENDPOINT: "https://tika-production.ol.mit.edu"
     UWSGI_THREADS: 15
     UWSGI_WORKERS: 3
   redis:password:

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.QA.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.QA.yaml
@@ -98,7 +98,7 @@ config:
     SENTRY_TRACES_SAMPLE_RATE: "0.25"
     SESSION_COOKIE_NAME: "session_mitlearn_rc"
     SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT:
-    TIKA_SERVER_ENDPOINT: "https://tika-qa.odl.mit.edu"
+    TIKA_SERVER_ENDPOINT: "https://tika-qa.ol.mit.edu"
     UWSGI_THREADS: 15
     UWSGI_WORKERS: 3
   redis:password:

--- a/src/ol_infrastructure/applications/open_discussions/Pulumi.applications.open_discussions.CI.yaml
+++ b/src/ol_infrastructure/applications/open_discussions/Pulumi.applications.open_discussions.CI.yaml
@@ -55,7 +55,7 @@ config:
     SOCIAL_AUTH_MICROMASTERS_LOGIN_URL: "https://micromasters-ci.odl.mit.edu/login/edxorg/?next=/discussions/"
     SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT: "https://sso-ci.ol.mit.edu/realms/olapps"
     SOCIAL_AUTH_SAML_SP_ENTITY_ID: "https://discussions-ci.odl.mit.edu/saml/metadata"
-    TIKA_SERVER_ENDPOINT: "https://tika-ci.odl.mit.edu"
+    TIKA_SERVER_ENDPOINT: "https://tika-ci.ol.mit.edu"
     USERINFO_URL: "https://sso-ci.ol.mit.edu/realms/olapps/protocol/openid-connect/userinfo"
   vault:address: https://vault-ci.odl.mit.edu
   vault_server:env_namespace: operations.ci

--- a/src/ol_infrastructure/applications/open_discussions/Pulumi.applications.open_discussions.Production.yaml
+++ b/src/ol_infrastructure/applications/open_discussions/Pulumi.applications.open_discussions.Production.yaml
@@ -59,7 +59,7 @@ config:
     SOCIAL_AUTH_MICROMASTERS_LOGIN_URL: "https://micromasters.mit.edu/login/edxorg/?next=/discussions/"
     SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT: "https://sso.ol.mit.edu/realms/olapps"
     SOCIAL_AUTH_SAML_SP_ENTITY_ID: "https://discussions.odl.mit.edu/saml/metadata"
-    TIKA_SERVER_ENDPOINT: "https://tika-production.odl.mit.edu"
+    TIKA_SERVER_ENDPOINT: "https://tika-production.ol.mit.edu"
     USERINFO_URL: "https://sso.ol.mit.edu/realms/olapps/protocol/openid-connect/userinfo"
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production

--- a/src/ol_infrastructure/applications/open_discussions/Pulumi.applications.open_discussions.QA.yaml
+++ b/src/ol_infrastructure/applications/open_discussions/Pulumi.applications.open_discussions.QA.yaml
@@ -57,7 +57,7 @@ config:
     SOCIAL_AUTH_MICROMASTERS_LOGIN_URL: "https://micromasters-rc.odl.mit.edu/login/edxorg/?next=/discussions/"
     SOCIAL_AUTH_OL_OIDC_OIDC_ENDPOINT: "https://sso-qa.ol.mit.edu/realms/olapps"
     SOCIAL_AUTH_SAML_SP_ENTITY_ID: "https://discussions-rc.odl.mit.edu/saml/metadata"
-    TIKA_SERVER_ENDPOINT: "https://tika-qa.odl.mit.edu"
+    TIKA_SERVER_ENDPOINT: "https://tika-qa.ol.mit.edu"
     USERINFO_URL: "https://sso-qa.ol.mit.edu/realms/olapps/protocol/openid-connect/userinfo"
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa


### PR DESCRIPTION
### What are the relevant tickets?
Updated opendiscussions and mitlearn to point to the new Tika envs  which have been verified and are up and running in k8s. 
