### PR TITLE
Added stabliziation periods to scaleup actions on celery worker hpas.

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/k8s_resources.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_resources.py
@@ -904,6 +904,13 @@ def create_k8s_resources(  # noqa: C901
             "cooldownPeriod": 10,
             "minReplicaCount": replicas_dict["celery"]["lms"]["min"],
             "maxReplicaCount": replicas_dict["celery"]["lms"]["max"],
+            "advanced": {
+                "horizontalPodAutoscalerConfig": {
+                    "behavior": {
+                        "scaleUp": {"stabilizationWindowSeconds": 300},
+                    }
+                }
+            },
             "triggers": [
                 {
                     "type": "redis",

--- a/src/ol_infrastructure/components/services/k8s.py
+++ b/src/ol_infrastructure/components/services/k8s.py
@@ -942,9 +942,6 @@ class OLApplicationK8s(ComponentResource):
                                     "scaleUp": {
                                         "stabilizationWindowSeconds": 300,
                                     },
-                                    "scaleDown": {
-                                        "stabilizationWindowSeconds": 300,
-                                    },
                                 }
                             }
                         },


### PR DESCRIPTION
### Description (What does it do?)
The HPA will wait 5 minutes and observe the metric recommendations during that window before acting, preventing rapid flapping between scaling decisions.
