### PR TITLE
fix: discussion MFE course title in header

### DIFF
--- a/src/bridge/settings/openedx/mfe/slot_config/mitxonline-styles.scss
+++ b/src/bridge/settings/openedx/mfe/slot_config/mitxonline-styles.scss
@@ -25,6 +25,10 @@
     font-weight: 400 !important;
   }
 
+  .flex-grow-1.course-title-lockup {
+    font-size: 14px !important;
+  }
+
   .course-title-lockup {
     margin-left: 10px !important;
   }


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
This PR fixes the font size of the course title in the discussion MFE header, which was being overridden by another default CSS rule.

### Screenshots (if appropriate):

Before
<img width="1792" height="954" alt="Screenshot 2025-12-03 at 11 17 24 PM" src="https://github.com/user-attachments/assets/72e8c19d-9ef0-4f3c-b044-93a5a6175b0f" />

After
<img width="1792" height="954" alt="Screenshot 2025-12-03 at 11 16 50 PM" src="https://github.com/user-attachments/assets/34902f78-3f1c-4aa1-8793-a9d45bb505d0" />


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
