### PR TITLE
Add gpt5-nano as ocr model

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1024,6 +1024,7 @@ env_vars = {
     "QDRANT_DENSE_MODEL": "text-embedding-3-large",
     "QDRANT_ENABLE_INDEXING_PLUGIN_HOOKS": True,
     "QDRANT_ENCODER": "vector_search.encoders.litellm.LiteLLMEncoder",
+    "OCR_MODEL": "gpt-5-nano-2025-08-07",
     "SECURE_CROSS_ORIGIN_OPENER_POLICY": "None",
     "SEE_API_ACCESS_TOKEN_URL": "https://mit-unified-portal-prod-78eeds.43d8q2.usa-e2.cloudhub.io/oauth/token",
     "SEE_API_URL": "https://mit-unified-portal-prod-78eeds.43d8q2.usa-e2.cloudhub.io/api/",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Related to https://github.com/mitodl/hq/issues/9288

### Description (What does it do?)
This PR adds gpt5 nano as the default ocr model for transcribing pdfs.

related PR in MIT Learn: https://github.com/mitodl/mit-learn/pull/2777
