### PR TITLE
Correct release name derivation

### DIFF
--- a/src/ol_infrastructure/applications/jupyterhub/deployment.py
+++ b/src/ol_infrastructure/applications/jupyterhub/deployment.py
@@ -53,7 +53,7 @@ def provision_jupyterhub_deployment(  # noqa: PLR0913
     base_name = jupyterhub_deployment_config["name"]
     domain_name = jupyterhub_deployment_config["domain"]
     namespace = jupyterhub_deployment_config["namespace"]
-    env_name = f"{stack_info.env_suffix}"
+    env_name = f"{stack_info.name}"
     db_name_normalized = base_name.replace("-", "_")
     proxy_port = jupyterhub_deployment_config["proxy_port"]
 
@@ -240,7 +240,7 @@ def provision_jupyterhub_deployment(  # noqa: PLR0913
     admin_users_list = jupyterhub_deployment_config.get("admin_users", [])
     allowed_users_list = jupyterhub_deployment_config.get("allowed_users", [])
     return kubernetes.helm.v3.Release(
-        f"{base_name}-{env_name.upper()}-application-helm-release",
+        f"{base_name}-{env_name}-application-helm-release",
         kubernetes.helm.v3.ReleaseArgs(
             chart="jupyterhub",
             cleanup_on_fail=True,


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
https://cicd.odl.mit.edu/teams/infrastructure/pipelines/pulumi-jupyterhub/jobs/deploy-ol-infrastructure-jupyterhub-applications.jupyterhub.production/builds/53 failed when applying https://github.com/mitodl/ol-infrastructure/pull/3793/files to production, but went through CI and QA just fine. 

This is because we were incorrectly deriving the name of the existing jupyter deployment and uppercasing the environment portion of the name. That matched in CI and QA simply because they're already fully uppercased, but when it hit prod, it attempted to teardown and replace the release instead of editing it in place


I've verified that running a `pulumi up` in CI results in no changes, and production results in the following, much more reasonable plan
<img width="1722" height="636" alt="Screenshot 2025-12-04 at 3 53 46 PM" src="https://github.com/user-attachments/assets/552b2c2c-7cbd-4085-9f65-867f615544bf" />
