### PR TITLE
Enable detailed apisix route metrics

### DIFF
--- a/src/ol_infrastructure/components/services/k8s.py
+++ b/src/ol_infrastructure/components/services/k8s.py
@@ -1332,6 +1332,11 @@ class OLApisixSharedPlugins(ComponentResource):
                     },
                 },
             },
+            {
+                "name": "prometheus",
+                "enable": True,
+                "config": {"prefer_name": True},
+            },
         ]
 
         resource_options = ResourceOptions(parent=self).merge(opts)


### PR DESCRIPTION
### Description (What does it do?)
Adds the prometheus plugin to the default set of plugins used for most (all) routes. 
