### PR TITLE
chore(deps): bump git-auto-export version for mitxonline

### DIFF
--- a/dockerfiles/openedx-edxapp/pip_package_lists/master/mitxonline.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_lists/master/mitxonline.txt
@@ -1,7 +1,7 @@
 celery-redbeat==2.3.3  # Support for using Redis as the lock for Celery schedules
 granian==2.6.0
 django-redis==6.0.0
-ol-openedx-git-auto-export==0.7.0
+ol-openedx-git-auto-export==0.7.1
 edx-sysadmin==0.4.0
 edx-username-changer==0.5.0
 openedx-companion-auth==1.2.0


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9488

### Description (What does it do?)
This PR just bumps the version of `git-auto-export`
