### PR TITLE
Change base_authoring_image location

### DIFF
--- a/src/ol_concourse/pipelines/container_images/jupyter_courses.py
+++ b/src/ol_concourse/pipelines/container_images/jupyter_courses.py
@@ -139,7 +139,7 @@ courses = [
     CourseImageInfo(
         course_name="base_authoring_image",
         s3_bucket="jupyter-courses-ci",
-        s3_object_path="ol-jupyter-courses/7f5202889ff1484188d628ef7f041383/base_authoring_image.tar.gz",
+        s3_object_path="ol-jupyter-courses/admin/base_authoring_image.tar.gz",
         image_name="base_authoring_image",
     ),
     CourseImageInfo(


### PR DESCRIPTION
### Description (What does it do?)
Previously used a random uuid as the username because that's what tmpauthenticator does. Now I've got match grade hardware and a consistent login for `admin` so we can use that instead.