### PR TITLE
Increase celery worker memory 

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1446,8 +1446,8 @@ mitlearn_k8s_app = OLApplicationK8s(
                 max_replicas=20,
                 redis_host=redis_cache.address,
                 redis_password=redis_config.require("password"),
-                resource_requests={"cpu": "200m", "memory": "1200Mi"},
-                resource_limits={"memory": "1200Mi"},
+                resource_requests={"cpu": "200m", "memory": "2400Mi"},
+                resource_limits={"memory": "2400Mi"},
             ),
             OLApplicationK8sCeleryWorkerConfig(
                 queue_name="edx_content",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Related to https://github.com/mitodl/mit-learn/pull/2777
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR bumps up the memory for the default queue so we can successfully transcribe pdfs


### How can this be tested?
We would have to deploy this and see that transcription of pdfs succeeds

