### PR TITLE
Allow specifying image to launch in authoring env

### DIFF
--- a/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
+++ b/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
@@ -113,6 +113,8 @@ class QueryStringKubeSpawner(KubeSpawner):
                     self.default_url = f"/notebooks/{notebook}"
         return super().start()
 
+    # It's safe to put this in as TmpAuthenticator doesn't render a login form
+    # As a result, this only affects login on authoring subdomains
     def _options_form_default(self):
         return """
         <div class="form-group">


### PR DESCRIPTION
### Description (What does it do?)
This renders a freetext form after initial login for the authoring environment which lets you specify a course tag for launch.

This is in service of allowing edits to existing courses. In order to allow a course to be edited in this way, we'll need to make the following changes in it's course repo:
1) Add ol-jupyter-authoring to it's `requirements.txt` file
2) Change Dockerfile to ensure it copies `requirements.txt` and `Dockerfile` into the root of the workspace
3) Change Concourse job definition to look for filepath in S3 instead of using Github for subsequent builds.

### Screenshots (if appropriate):
Step after initial login
<img width="1300" height="546" alt="Screenshot 2025-12-09 at 2 18 14 PM" src="https://github.com/user-attachments/assets/3adc138a-dcfd-4ef9-b59c-321927af1393" />


### How can this be tested?
This is currently on nb.ci.learn.mit.edu and authoring.nb.ci.learn.mit.edu. If you log in to admin using the shared password from the pulumi stack on the authoring subdomain, you'll see the above screencap after logging in. The regular notebook domain should remain unchanged, allowing you to anonymously access courses given a correctly structured course link (i.e. `https://nb.ci.learn.mit.edu/tmplogin?course=uai_source-uai.intro&notebook=intro_notebooks%2Fintro_colab%2Fmod0_introcolab.ipynb`)