### PR TITLE
config: Add aggressive scale-up for edxapp LMS

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/k8s_autoscaling.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_autoscaling.py
@@ -156,6 +156,32 @@ def create_autoscaling_resources(
             "maxReplicaCount": replicas_dict["webapp"]["lms"]["max"],
             "pollingInterval": 60,  # check triggers every minute
             "cooldownPeriod": 300,  # wait 5 minutes before scaling down again
+            "advanced": {
+                "horizontalPodAutoscalerConfig": {
+                    "behavior": {
+                        "scaleUp": {
+                            "stabilizationWindowSeconds": 60,
+                            "policies": [
+                                {
+                                    "type": "Percent",
+                                    "value": 50,  # Aggressive: 50% capacity increase
+                                    "periodSeconds": 15,
+                                }
+                            ],
+                        },
+                        "scaleDown": {
+                            "stabilizationWindowSeconds": 300,
+                            "policies": [
+                                {
+                                    "type": "Percent",
+                                    "value": 10,  # Conservative: 10% decrease
+                                    "periodSeconds": 60,
+                                }
+                            ],
+                        },
+                    }
+                }
+            },
             "triggers": [
                 # The primary trigger is based on requests per pod
                 {


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds an aggressive scale-up policy of 50% of capacity with a one minute stabilization for edxapp LMS pods. This is to prevent being stuck in a scale-up period with not enough capacity online during traffic peaks.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Apply to CI or QA and create traffic to scale beyond the request rate threshold and verify that the capacity increases by 50% instead of just by 1 or 2 pods.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
LMS pods take a non-trivial amount of time to launch, especially if they are waiting on Karpenter nodes to come online. This ensures that we have capacity for traffic spikes without having to wait and to avoid sub-optimal user experience.
