### PR TITLE
config: Migrate Bootcamps S3 bucket to component resource

### DIFF
--- a/src/ol_infrastructure/components/aws/s3.py
+++ b/src/ol_infrastructure/components/aws/s3.py
@@ -213,7 +213,9 @@ class OLBucket(pulumi.ComponentResource):
         """
         super().__init__("ol:aws:s3:OLBucket", name, {}, opts)
 
-        child_opts = pulumi.ResourceOptions(parent=self)
+        child_opts = (opts or pulumi.ResourceOptions()).merge(
+            pulumi.ResourceOptions(parent=self)
+        )
 
         # Apply merged tags from config and component name
         # Use config.bucket_name if provided, otherwise default to the Pulumi
@@ -229,8 +231,6 @@ class OLBucket(pulumi.ComponentResource):
             tags=merged_tags,
             opts=child_opts,
         )
-        # Ensure subsequent resources depend on the main bucket
-        child_opts = pulumi.ResourceOptions(parent=self, depends_on=[self.bucket_v2])
 
         # Conditionally create BucketVersioning
         if config.versioning_enabled:


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
This migrates the Bootcamps S3 bucket to use the new component resource for simpler code and cost efficiencies through a default intelligent tiering setup.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
This has been manually applied to CI. Applying to QA or Production should not try to delete/re-create the bucket.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
S3 intelligent tiering is an easy option to save a decent amount of cloud spend without any manual effort.
