### PR TITLE
add mitxonline_legacy_base_url

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.applications.mit_learn_nextjs.CI.yaml
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.applications.mit_learn_nextjs.CI.yaml
@@ -11,6 +11,7 @@ config:
   nextjs:mitlearn_api_base_url: "https://api.ci.learn.mit.edu"
   nextjs:mitol_noindex: "true"
   nextjs:mitxonline_base_url: "https://api.ci.learn.mit.edu/mitxonline"
+  nextjs:mitxonline_legacy_base_url: "https://ci.mitxonline.mit.edu"
   nextjs:origin: "https://ci.learn.mit.edu"
   nextjs:posthog_api_host: "https://ph.ol.mit.edu"
   nextjs:posthog_api_key:

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.applications.mit_learn_nextjs.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.applications.mit_learn_nextjs.Production.yaml
@@ -11,6 +11,7 @@ config:
   nextjs:mitlearn_api_base_url: "https://api.learn.mit.edu"
   nextjs:mitol_noindex: "false"
   nextjs:mitxonline_base_url: "https://api.learn.mit.edu/mitxonline"
+  nextjs:mitxonline_legacy_base_url: "https://mitxonline.mit.edu"
   nextjs:origin: "https://learn.mit.edu"
   nextjs:pod_count: 5
   nextjs:posthog_api_host: "https://ph.ol.mit.edu"

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.applications.mit_learn_nextjs.QA.yaml
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.applications.mit_learn_nextjs.QA.yaml
@@ -11,6 +11,7 @@ config:
   nextjs:mitlearn_api_base_url: "https://api.rc.learn.mit.edu"
   nextjs:mitol_noindex: "true"
   nextjs:mitxonline_base_url: "https://api.rc.learn.mit.edu/mitxonline"
+  nextjs:mitxonline_legacy_base_url: "https://rc.mitxonline.mit.edu"
   nextjs:origin: "https://rc.learn.mit.edu"
   nextjs:pod_count: 4
   nextjs:posthog_api_host: "https://ph.ol.mit.edu"

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
@@ -130,6 +130,9 @@ raw_env_vars = {
     "NEXT_PUBLIC_MITOL_API_BASE_URL": nextjs_config.require("mitlearn_api_base_url"),
     "NEXT_PUBLIC_MITX_ONLINE_CSRF_COOKIE_NAME": "csrf_mitxonline",
     "NEXT_PUBLIC_MITX_ONLINE_BASE_URL": nextjs_config.require("mitxonline_base_url"),
+    "NEXT_PUBLIC_MITX_ONLINE_LEGACY_BASE_URL": nextjs_config.require(
+        "mitxonline_legacy_base_url"
+    ),
     "NEXT_PUBLIC_MITOL_AXIOS_WITH_CREDENTIALS": "true",
     "NEXT_PUBLIC_MITOL_SUPPORT_EMAIL": "mitlearn-support@mit.edu",
     "NEXT_PUBLIC_ORIGIN": nextjs_config.require("origin"),


### PR DESCRIPTION
### What are the relevant tickets?

For https://github.com/mitodl/mit-learn/pull/2797

### Description (What does it do?)
Some (feature-flagged) flows in MIT Learn (currently) redirect users to the legacy MITxOnline frontend. (For example: upgrading enrollments to certificate track). This new env var supports that case.

Why two env vars for this:

- `NEXT_PUBLIC_MITX_ONLINE_BASE_URL` = base url used for API calls, e.g., things with CSRF tokens that need to be on the same site. (`api.learn.mit.edu/mitxonline` is same-site as `learn.mit.edu`)
    - I don't think apisix is set up to forward non-api routes... I.e., https://api.learn.mit.edu/mitxonline/dashboard does not go to your dashboard
    - Even if it were set up that way—which is easy in our local stacks—it doesn't work well with current mitxonline URLs. For example, much of MITxOnline site uses root-relative links like `<a href="/catalog">Catalog</a>` which would link from https://api.learn.mit.edu/mitxonline/dashboard to https://api.learn.mit.edu/catalog w/o the mitxonline prefix.
    - Plus we don't want to send people to the `api.learn.mit.edu` url anyway. 
- `NEXT_PUBLIC_MITX_ONLINE_LEGACY_BASE_URL` = The actual MITxOnline frontend; not appropriate if we need a CSRF token, but good if we are actually redirecting users to the mitxonline site.