### PR TITLE
feat: Close AskTim on vertical navigation

### DIFF
--- a/src/bridge/settings/openedx/mfe/slot_config/SidebarAIDrawerCoordinator.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/SidebarAIDrawerCoordinator.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState, useCallback, useMemo } from 'react';
+import React, { useContext, useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { getConfig } from '@edx/frontend-platform';
 import { useModel } from '@src/generic/model-store';
@@ -25,8 +25,11 @@ const SidebarAIDrawerCoordinator = ({ courseId }) => {
     const currentSidebar = contextValue?.currentSidebar ?? null;
     const toggleSidebar = contextValue?.toggleSidebar ?? (() => {});
     const shouldDisplayFullScreen = contextValue?.shouldDisplayFullScreen ?? false;
+    const unitId = contextValue?.unitId ?? null;
 
     const [showAIDrawer, setShowAIDrawer] = useState(false);
+    const prevUnitIdRef = useRef(unitId);
+    const showAIDrawerRef = useRef(false);
 
     const messageOrigin = useMemo(() => {
         const lmsBaseUrl = getConfig().LMS_BASE_URL;
@@ -65,6 +68,26 @@ const SidebarAIDrawerCoordinator = ({ courseId }) => {
             setShowAIDrawer(false);
         }
     }, [currentSidebar]);
+
+    useEffect(() => {
+        showAIDrawerRef.current = showAIDrawer;
+    }, [showAIDrawer]);
+
+    useEffect(() => {
+        if (prevUnitIdRef.current && prevUnitIdRef.current !== unitId && unitId !== null) {
+            // Only send close message if drawer is actually open
+            if (showAIDrawerRef.current) {
+                window.postMessage(
+                    {
+                        type: 'smoot-design::ai-drawer-close',
+                    },
+                    messageOrigin
+                );
+            }
+            setShowAIDrawer(false);
+        }
+        prevUnitIdRef.current = unitId;
+    }, [unitId, messageOrigin]);
 
     return (
         <>


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9573

### Description (What does it do?)

This PR handles the work when AskTim Chat is opened inside the Slot and learner moves to next vertical, the AskTim chat left open inside the slot. We need a mechanism to close the AskTim chat when user moved to next vertical.

#### Added
A post message is sent on unit change to close the AskTim Chat inside the slot.


### Video:
https://www.loom.com/share/50377aacfd6346c19d8c34015c8923e2

### How can this be tested?
To test this feature locally:

1. **Set up Tutor instance locally** as described in [this guide](https://docs.google.com/document/d/1kt_8VspC_SSU5zpmw8kyRQPWQaPtEbzTcDJeKYNBOfE/edit?tab=t.0)

2. **Mount frontend-app-learning locally**

3. **Enable AI Chatbot** by following the configuration steps in the [ol_openedx_chat plugin documentation](https://github.com/mitodl/open-edx-plugins/tree/main/src/ol_openedx_chat)

4. **Build the branch** [[zafzal/9573-vertical-navigation](https://github.com/mitodl/smoot-design/pull/209)](https://github.com/mitodl/smoot-design/pull/209) in the smoot-design repo by running:

The paths assume both directories are at the same level. If they're not siblings, adjust ../ as needed to navigate to the correct parent directory.

   ```bash
   cd smoot-design && yarn install && npm run build && npm pack && cp mitodl-smoot-design-*.tgz ../frontend-app-learning/ && cd ../frontend-app-learning && rm -rf package && tar -xvzf mitodl-smoot-design-*.tgz && mkdir -p public/static/smoot-design && cp package/dist/bundles/* public/static/smoot-design/
   ```
   ```bash
    cd ../frontend-app-learning && npm start
   ```

5. **Add AIDrawerManagerSidebar component and SidebarAIDrawerCoordinator**: Copy `AiDrawerManagerSidebar.jsx`  and `SidebarAIDrawerCoordinator` to the root of your local `frontend-app-learning` repository (alongside the `.env` file)

6. **Update configuration**: Update `env.config.jsx` with the content from `learning-mfe-config.env.jsx` of this repo.
7. Add ENABLE_AI_DRAWER_SLOT = 'true'  in .env.development file.
8. Update Bundle path with const BUNDLE_PATH =  '/static/smoot-design/aiDrawerManager.es.js';
9. Update your mitxonline-styles.scss file with the scss of the file in this pr. src/bridge/settings/openedx/mfe/slot_config/mitxonline-styles.scss

Now, on clicking the AskTim Button, it will open the AskTim Chat inside the Notifications/Discussions sidebar slot and when move to next Vertical, AskTim chat will close automatically. 