### PR TITLE
config: enable AI drawer slot for QA and CI environment

### DIFF
--- a/src/ol_concourse/pipelines/open_edx/mfe/values.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/values.py
@@ -129,6 +129,7 @@ mitxonline = [
         logo_trademark_url="https://courses.ci.learn.mit.edu/static/mitxonline/images/mit-logo.svg",
         enable_video_upload_page_link_in_content_dropdown="true",
         enable_jumpnav="true",
+        enable_ai_drawer_slot="true",
     ),
     OpenEdxVars(
         about_us_url="https://rc.mitxonline.mit.edu/about-us/",
@@ -157,6 +158,7 @@ mitxonline = [
         logo_trademark_url="https://courses.rc.learn.mit.edu/static/mitxonline/images/mit-logo.svg",
         enable_video_upload_page_link_in_content_dropdown="true",
         enable_jumpnav="true",
+        enable_ai_drawer_slot="true",
     ),
     OpenEdxVars(
         about_us_url="https://mitxonline.mit.edu/about-us/",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9143

### Description (What does it do?)
Enables the `enable_ai_drawer_slot` feature flag for the QA environment to test the AI drawer slot functionality introduced in [#3884](https://github.com/mitodl/ol-infrastructure/pull/3884).