### PR TITLE
Add theme pipeline variables to Heroku config

### DIFF
--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -350,6 +350,8 @@ heroku_vars = {
     "MITOL_MAIL_FROM_EMAIL": "ocw-prod-support@mit.edu",
     "MITOL_MAIL_REPLY_TO_ADDRESS": "ocw-prod-support@mit.edu",
     "OCW_COURSE_TEST_SLUG": "ocw-ci-test-course",
+    "OCW_DEFAULT_COURSE_THEME": "ocw-course-v2",
+    "OCW_EXTRA_COURSE_THEMES": "ocw-course-v3",
     "OCW_STUDIO_ADMIN_EMAIL": "cuddle-bunnies@mit.edu",
     "OCW_STUDIO_DB_CONN_MAX_AGE": 0,
     "OCW_STUDIO_DB_DISABLE_SSL": "True",


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/9358.

### Description (What does it do?)
This PR adds the relevant theme variables to Heroku for OCW Studio, allowing for multiple themes to be built, with the `course-v2` theme as default and `course-v3` as secondary.

### How can this be tested?
This can be tested on the OCW Studio RC server by confirming that the Heroku variables are being correctly read, analogously to the testing instructions for https://github.com/mitodl/ocw-studio/pull/2826.

