### PR TITLE
Potentially fix busted secrets for mitxonline

### DIFF
--- a/src/ol_infrastructure/applications/mitxonline/mitxonline_policy.hcl
+++ b/src/ol_infrastructure/applications/mitxonline/mitxonline_policy.hcl
@@ -27,11 +27,11 @@ path "secret-mitxonline/*" {
 }
 
 # MITXOnline needs access to the DID and bearer tokens for authentication with Digital Credentials services
-path "secret-digital-credentials/data/issuer-coordinator" {
+path "secret-digital-credentials/issuer-coordinator" {
   capabilities = ["read"]
 }
 
-path "secret-digital-credentials/data/signing-service" {
+path "secret-digital-credentials/signing-service" {
   capabilities = ["read"]
 }
 


### PR DESCRIPTION
### Description (What does it do?)
Getting the following permission denied error on mitxonline
<img width="1475" height="152" alt="Screenshot 2025-12-22 at 9 02 21 AM" src="https://github.com/user-attachments/assets/fa6d3f68-6e3d-4973-b979-063635b59cae" />

I think it might be because we're using the API path instead of the CLI path?
<img width="1233" height="738" alt="Screenshot 2025-12-22 at 9 06 16 AM" src="https://github.com/user-attachments/assets/b1ecb30f-3115-48a1-8c76-cc3d6649859e" />
