### PR TITLE
feat: Add exclusions for Sentry collector to exclude spammy already handled exceptions

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/config_builder.py
+++ b/src/ol_infrastructure/applications/edxapp/config_builder.py
@@ -618,12 +618,8 @@ def get_deployment_overrides(env_prefix: str) -> ConfigDict:
                     "A label was requested for language code `ht` but",
                     "the code is completely unknown",
                 ),
-                (
-                    "Failed async course content export to git",
-                ),
-                (
-                    "Failed to pull git repository",
-                ),
+                ("Failed async course content export to git",),
+                ("Failed to pull git repository",),
             ],
         },
     }


### PR DESCRIPTION
### What are the relevant tickets?
Work towards #3986



### Description (What does it do?)
Excludes super spammy exceptions in mitxonline openedx from being collected by Sentry.

Candidate Sentry issues:

https://mit-office-of-digital-learning.sentry.io/issues/6011906340/?project=5939801
https://mit-office-of-digital-learning.sentry.io/issues/6693435061/?project=5939801
https://mit-office-of-digital-learning.sentry.io/issues/6531712941/?project=5939801
https://mit-office-of-digital-learning.sentry.io/issues/6658720102/?project=5939801
https://mit-office-of-digital-learning.sentry.io/issues/5827787531/?project=5939801


### How can this be tested?
Deploy this and ensure these excep;tions aren't collected in QA?