### PR TITLE
RC login fix

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/config_builder.py
+++ b/src/ol_infrastructure/applications/edxapp/config_builder.py
@@ -134,6 +134,7 @@ def build_base_general_config() -> ConfigDict:
         "COURSES_WITH_UNSAFE_CODE": [],
         "COURSES_INVITE_ONLY": True,
         "COURSE_ABOUT_VISIBILITY_PERMISSION": "see_exists",
+        "COURSE_AUTHORING_MICROFRONTEND_URL": "/authoring",
         "COURSE_CATALOG_API_URL": "http://localhost:8008/api/v1",
         "COURSE_CATALOG_URL_ROOT": "http://localhost:8008",
         "COURSE_CATALOG_VISIBILITY_PERMISSION": "staff",

--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -394,7 +394,6 @@ def create_k8s_configmaps(  # noqa: PLR0915
     # CMS general configuration
     cms_general_config_name = "71-cms-general-config-yaml"
     cms_general_config_content: dict[str, Any] = {
-        "COURSE_AUTHORING_MICROFRONTEND_URL": "/authoring",
         "DISCUSSIONS_INCONTEXT_LEARNMORE_URL": "https://openedx.atlassian.net/wiki/spaces/COMM/pages/3470655498/Discussions+upgrade+Sidebar+and+new+topic+structure",
         "GIT_REPO_EXPORT_DIR": "/openedx/data/export_course_repos",
         "GIT_EXPORT_DEFAULT_IDENT": {


### PR DESCRIPTION


### Description (What does it do?)
fix: moved COURSE_AUTHORING_MICROFRONTEND_URL to general config and out to CMS config.
