### PR TITLE
set default retirement salts for residential envs

### DIFF
--- a/src/bridge/secrets/edxapp/mitx-staging.ci.yaml
+++ b/src/bridge/secrets/edxapp/mitx-staging.ci.yaml
@@ -16,6 +16,9 @@ studio_oauth_client:
 sysadmin_git_webhook_secret: ENC[AES256_GCM,data:/YK7+N9f7C6n++WIlaFHmgeheUXiT+9rJy0YuaSbHxURnxgIG/bv9/vDYhm2LNR9NVSXxd5YC+WTHcymMNeGVMUQq0NyvkqQ,iv:ohpAeTYt9N9iQyjCOWTP1fRnQ7YCH5WVpH/h1RP/aEM=,tag:F25H7xSz62z1rmcgaY+PlQ==,type:str]
 youtube_api_key: ENC[AES256_GCM,data:yCnpo/q4VOuoZX/V0n/ByhCZC3pncojwynZRD5mst37eAJZa0JUK,iv:pgvBxQogqsSOKf6wPnc/tfm1AlQ99Dne7UtkfudGaCg=,tag:FX2jwuHNEpI5X5iE0DsUgg==,type:str]
 github_access_token: ENC[AES256_GCM,data:+7wa+8Tsr2sUnv8ZYeeajPBCd2Yfal2betgLas3UK9KTOIJGnYfVgA==,iv:B710MwpY6Zxa1c4j4wt1PGxJ+7yldC5BIulAKwL/j54=,tag:8ANRFvkN9u/A8k8WFD8/Bw==,type:str]
+user_retirement_salts:
+- ENC[AES256_GCM,data:FST4YF8MyqswEgFIpAuaiFQBW/u7wHYpPFcXlBt7Uw==,iv:AvZxPGRHPtUiYKCkCmcvV0dpht7A8jBmr11Ah2cliuw=,tag:FRx/CEvnXQx7eb+AcNOuCg==,type:str]
+- ENC[AES256_GCM,data:paTHr8iqnGOrOcXWHYK4voIQQciAjiSKwmWl5NVeIoXcwJ6Y,iv:KXS+uNs4C/+O82/ydCtrMSpZ6A2F63v0RjijHYUT0Rw=,tag:sXymJWORqf8DhrD9v6h0Qg==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-ci
@@ -31,8 +34,8 @@ sops:
     created_at: "2024-01-24T19:58:55Z"
     enc: vault:v1:NkR3Q8K1eG5ndrJI8YJj/kdlHh8hPLDnItNliLFvYO5RWTyY/435l81LB/pzYLEdQa2Muytt9CnC01yy
   age: []
-  lastmodified: "2025-12-19T15:58:15Z"
-  mac: ENC[AES256_GCM,data:XVGMLrRG9USJXcRvOSXqjP1ZEgQ+GPKgGHOFIJXUZOeNccH5fP+DHBhgBnoTaroAGL79IJ+O7wHTiCA4APm5reMNdLfthm2Bw2HHgpIkX8iVDnD9obgBFH59u2tx9nTvkGe4pdW9z4De3RII45U4kIWLczORKIWpBghC3uCr7L4=,iv:0c2yMFVakvud+YqwuKOBXP6I9TKGc0U8VJFETlebwwY=,tag:kr7LPZRHCRGpZQ3iouehqg==,type:str]
+  lastmodified: "2025-12-30T15:20:52Z"
+  mac: ENC[AES256_GCM,data:xCoh45jUUZKaDtPGUI8lpJl9Wzf3p0YOWxZ+c3Q/ETZVwh7F3jiZdvrqqSFukk1KD2V31BU0UkDua2wp+X4TbNtBIM0ucnn5aosKygotjKksVSP3PUkf+kTHILp0fNWpqFfmO+OHC6l/iyFDTJcdv1GFbISqb6a7Gh7ZlSAol58=,iv:wVRKrly5G2VCk6DWSI4DZ8j8KRcCKje3pRsUAci5HCE=,tag:tB5xCbfOqJUNZSGZeCW0ig==,type:str]
   pgp:
   - created_at: "2024-01-24T19:58:55Z"
     enc: |-

--- a/src/bridge/secrets/edxapp/mitx-staging.production.yaml
+++ b/src/bridge/secrets/edxapp/mitx-staging.production.yaml
@@ -17,6 +17,9 @@ studio_oauth_client:
 sysadmin_git_webhook_secret: ENC[AES256_GCM,data:8KrxK6ft+ipe1rTpFs3AzW520TOYBFvNH+Xz6fAVdfR4GR/zZ4c=,iv:xUCuEVdwzU3VQFNBvI16BgZC01MUQoKdLFArRdg3/Lo=,tag:C55ryUEmKQwuftWrYMcWpQ==,type:str]
 youtube_api_key: ENC[AES256_GCM,data:SUz/PRelZVZ9ijukYp4PZ41oabkVWcjzVmCZvie+WvM/M120s0hr,iv:tlE/oeEXnILZqy1yijp8/Wa4Yy7pZ0k7H2n5c4mp4w4=,tag:BDve0C2SXfZ9M13Q3NBxWA==,type:str]
 github_access_token: ENC[AES256_GCM,data:78hRjtj+aypCptplxdtBnv100bLQ5BNRQFDIE+6IQdxImXT0GH0PLQ==,iv:UBP3HH/4hceyx0aZe4hWiQZa5PQBVWSOCSuuYjJ4YbE=,tag:UMifRal8HcnrZuRR53JtIw==,type:str]
+user_retirement_salts:
+- ENC[AES256_GCM,data:ijuDEh7HxHGTO12mMOxUXISCma024tAQp/F15Qfe3w==,iv:qaeTX4ofY11m0/dfv9Tp9xEnbrEteSqJz44TELK+sSA=,tag:mUc6DjCSn4RpHf6pzbahQA==,type:str]
+- ENC[AES256_GCM,data:fmoFmCp1h5XVgtigp2Q2rSjnWm5WMS2SK1zYkbD/0yBJjBWN,iv:DqWduZGSI/foZr9g7Ri7lHa5NBc+ol8z6pr2157hXbA=,tag:pfpgR9mV8f46wh5wAZbY3w==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
@@ -32,8 +35,8 @@ sops:
     created_at: "2024-01-24T20:22:35Z"
     enc: vault:v1:ZEmqaxdMKI9bIlJcx1bwvyT1o/V+4JYdnQWoRggJEhof9A1vUVneHk3cwS7gNidRf1HTLv5b8Be6btb+
   age: []
-  lastmodified: "2025-12-19T15:58:27Z"
-  mac: ENC[AES256_GCM,data:M5Edt89C/rSY769RR/QtKM0YLgjMSfc1gaHwIEF1V5JMXBuMGaGaO8p9/I0q4YVzjpvTf9bGpYFZko73sx35FJnJhgd7lafSJWV9PG6XQw/cSm76BCdT8fLKp24xhPkHDR7G25A0cmbaxboOVlF/HVmqOR+AUdLC/sp1XHaF2Fo=,iv:D2LBXHDdHKa8cMH+C0QbP2qgkrY0ANbVouYYF17J0G8=,tag:2jAuD8T4V1CitlgRmSo0CA==,type:str]
+  lastmodified: "2025-12-30T15:21:03Z"
+  mac: ENC[AES256_GCM,data:XjtTLvib5AVIt3uityta3wWui4VffzvPp5p4hme7I5aqJ/XqmnXujxZJ59JXvbfXwLDfB/M/uYnXhI4iiwzsWGa2/wkthzj1TdeI2IZOTxKQNg8I3jZ+72Wm9zpVgje6ln43sH6wQmXQa+Wc0Gooi5XBJJHZw36ssLjmeHfgWxY=,iv:8LcQi6WwO3gjy7OMFfHFFys9mHNuP13M5UoFzy+FPEg=,tag:iFDCTqDCUIZ9o5sTKmsNHQ==,type:str]
   pgp:
   - created_at: "2024-01-24T20:22:35Z"
     enc: |-

--- a/src/bridge/secrets/edxapp/mitx-staging.qa.yaml
+++ b/src/bridge/secrets/edxapp/mitx-staging.qa.yaml
@@ -17,6 +17,9 @@ studio_oauth_client:
 sysadmin_git_webhook_secret: ENC[AES256_GCM,data:Oc7bI7okLc0UHqp+pI/0oaf4ae64GMcUwo8rrI4GsrsNLsP2BEBt9Bgr93FepcoRFnU=,iv:r41GrJ3Hlh3WzDIfKNk8wR9uhYiYfePWK1qOHb9HxYE=,tag:UbwZTjQhB3ie3OsRDJ6RFA==,type:str]
 youtube_api_key: ENC[AES256_GCM,data:kyFTxrhOEq6q1t6n7VBfiVWFFuEceadCznltshjKpNAgMUT+5phO,iv:ypiQfmqyLkP+eNolOFjmuhs34WrIbi32O4SuBKZ+a5c=,tag:+OVMBq2i9PSblbixjLa8IQ==,type:str]
 github_access_token: ENC[AES256_GCM,data:RFvFQJYiPDMBgzNHS5Q+NSY53oaNykAxX2VQcURjV4OIXuz2VG5hiw==,iv:OLVrFbJEr3Ohx3+DoUcd3o4e1+8jDDwIL518JS8iNR8=,tag:MUCGBzYCavla8jwYXuI1Dg==,type:str]
+user_retirement_salts:
+- ENC[AES256_GCM,data:1DeDwlbvSfSumRPD+S28tHDYmMmrHWj01v1d79bPDg==,iv:7nCpnNz0nTRt+WzEBs1l/t/4/LixkhXnOcKZtLKgIBU=,tag:FyxR5SesDyYCdHa/Y+RWWQ==,type:str]
+- ENC[AES256_GCM,data:46sVID0S/m7iqZr+fJfkCEWGwg6FED9WlXL1+YxqC2vQOUmj,iv:H5iF/jR02Rwp/jv30Y4rt9y+RK16ZJHqveVOqMjJRo8=,tag:HyC1QDPkVbBQ0gDaspme8Q==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-qa
@@ -32,8 +35,8 @@ sops:
     created_at: "2024-01-24T20:20:41Z"
     enc: vault:v1:ryD3PSZ0sUpniheec2bYEDduhjOWMvdQHBx1HGIUh+Tc1RkU+i11dSQIuDheIFqwh+FlDItuwstSBWSl
   age: []
-  lastmodified: "2025-12-19T15:58:21Z"
-  mac: ENC[AES256_GCM,data:0yfGbk3oAOOCqGtznq6xLmiZRYbMMZMgQTj/fZpnd1b8+oEt6fWJIs8I7HGvWJKHmR2BMNetAIMAIwx161BweHZ5KhY3oopHdDHy69rSWt5u/Ya3WGuHXORm2xv0TeNXeQkr8LnAQ2VJI/jK/2blbpQcolo0w8OVpvty2PXYl4g=,iv:vG6gLrLW00dv+J85hcs4uUzqJjw/XE/tNqA2935kVwg=,tag:zvNgQENg8C9iHpmggwg2MQ==,type:str]
+  lastmodified: "2025-12-30T15:20:57Z"
+  mac: ENC[AES256_GCM,data:Q35QBO0kBqIkQmY5C/LiPpMORHtqy5NVt6v03b8u3j5G2GqQKmumnftSDydO5HJ5zrp3W0T2/CFZLvC8XCULYSGP7zXN4VZMlCenreuVEvcGrHlrK7x9Usz1fAYAJrWw8ZXSiTy4m9+xoszMd9+1PntiSmIUCjKPdNaV9viP95w=,iv:RCBPYXhDa8e7C+74zcPtI2v/pSOwYPJhNm25MkSHtkc=,tag:1gdUAhnmU42WqvTJin8hsg==,type:str]
   pgp:
   - created_at: "2024-01-24T20:20:41Z"
     enc: |-

--- a/src/bridge/secrets/edxapp/mitx.ci.yaml
+++ b/src/bridge/secrets/edxapp/mitx.ci.yaml
@@ -17,6 +17,9 @@ studio_oauth_client:
 sysadmin_git_webhook_secret: ENC[AES256_GCM,data:jFo3AcuE9yfzphevwQWSDr8SoWPzQhzccw/23YTeqKi0Ia+XX6J17JAfcmw74x1YWC9uZ6pWLt7t5i5fQ0ClDyegOF4M+UgR,iv:EtbS9g8VH30F7CUvF/DAMoQmNyeyj3/FUD5c3cD6y6Y=,tag:OShX7dO6ttLm1aNjjPmdqA==,type:str]
 youtube_api_key: ENC[AES256_GCM,data:gqI/YXldsrNXBSSES0g+aXhmR6NWXtFIRPsR49CbKYp+FUyTDf5J,iv:5eHVMvdtmoEfxX3VH44GwhnuYyyeLvgVCRDEl3+XV3o=,tag:qNsT5I5pM/zeBMzZfl92mw==,type:str]
 github_access_token: ENC[AES256_GCM,data:AruI8ZPQaxc+SEpJnipK7jYn4al4/al2V8W+b13CbevDs6/fzYVOIg==,iv:0QmJl7AtmdqDGW+kv0YiRp9oYzZ+Vj1Fm0tUCjOKpSs=,tag:cf3jlhzagHFTPsDIvhF/YA==,type:str]
+user_retirement_salts:
+- ENC[AES256_GCM,data:kBFC7hnjt91EKPNvoE2UNDmyo6xPRJNOOUjf4QBlfA==,iv:f/R6GoiA5lnJQaJVO9b7gpbMyZ50ojpHnfWvvkUbpsM=,tag:Og2Xy1PhyqNemfp2zMPOoA==,type:str]
+- ENC[AES256_GCM,data:Q0DYjd6GHNtg19vLMjsJo1iabXbeUgjt4uxF8ofYrff1ZKjW,iv:AOtsr2SjlQL7DUubAFX01boGI33D16WBX790HHxlMUA=,tag:np84jzHl2WCqi24lrN7WwA==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-ci
@@ -32,8 +35,8 @@ sops:
     created_at: "2024-01-24T19:58:53Z"
     enc: vault:v1:geqMdaaYkEB/BOyQAllgH+AdInYMUlSc4ylgBca2jH3BX0Re/k7y09sKoNH5+FXC4AmIrgnR+FE45ocl
   age: []
-  lastmodified: "2025-12-19T15:57:54Z"
-  mac: ENC[AES256_GCM,data:0sHs78GHYiqecNJqI8vcb7l59xzOX9qtIbrPQckrYNspJJvHaEohLBOfz4Jvw/FVtDwvj8lIcoApMh/zKM5nLUYWwh49o41biazkq9x/i1ue2vDjnc7gdSkoYaH8U8AJDtgBbvIGEhEH/i6WY4ACIq+/AJq57B3xtLAMH0O55Jc=,iv:s9lu3gLZ+pzBqWL4ysEIognPNRnAqOyBWLqpnz9T5Wg=,tag:2ukQYYxoKhzCGGOo7yAq4g==,type:str]
+  lastmodified: "2025-12-30T15:20:43Z"
+  mac: ENC[AES256_GCM,data:GdNyYi979o5ieYUPQ2de3sT6/kFnTM1PvypTrwH4lXfZbn/7k1xiuEjZOco0PMERYFS52Hzo5GckNQNpDDeCwYTzndKzX4MEqXrw4tR8aJdEa3b7uh5k1TYg76TakOANAhO5aGrnM1u7pljCOT4Rkn+3idC7qw+yvJt9YXC8NZs=,iv:kECd8aM91r80qqRgAq0nSRtuudYr6riVaekj/zkc4C4=,tag:U2l5nhSr8yf+1uLSLGi7Lg==,type:str]
   pgp:
   - created_at: "2024-01-24T19:58:53Z"
     enc: |-

--- a/src/bridge/secrets/edxapp/mitx.production.yaml
+++ b/src/bridge/secrets/edxapp/mitx.production.yaml
@@ -17,6 +17,9 @@ studio_oauth_client:
 sysadmin_git_webhook_secret: ENC[AES256_GCM,data:FVJK4RPfykeuBbmeodRSNN9+QxXsYFYKxJW65EY4gO1QwdxQtC0=,iv:t75PFRDJp5b594ZcqPlj/dS7ZFXj09lbDWRNCwjU7jg=,tag:7FttxNVc36UKDnuGtcVePw==,type:str]
 youtube_api_key: ENC[AES256_GCM,data:D9snB9tTnWUri95ZUPxvPykO3/PyF9SfJyyup4PqJLPk3rLJLrHv,iv:Q88mgk+SvpQyrm8GRuW2M/t0OpSQEaNeZtSDRLdciEE=,tag:LM4Ag9n38tS5DuTlHBlpcQ==,type:str]
 github_access_token: ENC[AES256_GCM,data:APX/ZWvrhNBCK5TBKBq8kN9DK5mpau2Bo+zX3Em/Bjzg2QA5o50rhg==,iv:ovFTyE1m6OSVyPbFzvvPHvH/TMe2QDNxc/vVSV8MiaA=,tag:dl8U5JDzNwBmKz/j2CYPbA==,type:str]
+user_retirement_salts:
+- ENC[AES256_GCM,data:KVY9qns9tTB44dWuJq9uvyZOhQOAl6DoeW1T5AHDYQ==,iv:qxmpe0UzRaENWv/bKAeN4XbccFGzVerqH/5DJ5ZvN84=,tag:5WNjDgTvXhaDfO3r8IvzBw==,type:str]
+- ENC[AES256_GCM,data:oplce6GXk7A1OAZ1iKVJ8FNd+kMz7Xrsiqs2f2gL2A4jUFx1,iv:r3E3mSJi5LEO32qV77rARjOEvCrRs/19DOlOOXFSTLs=,tag:zYe/pNsSVMqK0sCkc+jFGw==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
@@ -32,8 +35,8 @@ sops:
     created_at: "2024-01-24T20:22:38Z"
     enc: vault:v1:HQ3eAys/YP//Fl5ExD/0O4idzF7Posb21kIyJcfCOpl7beksw6MLqE89lH/Z3lfrJ966fju+yNHpEqcH
   age: []
-  lastmodified: "2025-12-19T15:58:07Z"
-  mac: ENC[AES256_GCM,data:nkLpC1yuyICc2NmHLax8v6wWDveTo5a2qSOrU2PO3ewSxMCABWoWyI4JmqKJ44wXdGKS74P5wXbFVOSJBd599Nmd/P83O5hnnJjIpq8MwfkzjlDmV+LLFYfG2A8HunJWx6ALn41DJEDsqjwTfksCF/DFE/qtTt4R7PzXIZ2nyss=,iv:ufVaxcMjMa++WNvxAYSi2NbO09SGKIWda9As3SePlYs=,tag:f9UOv0mDTTXZ0Nxhw+YUcA==,type:str]
+  lastmodified: "2025-12-30T15:20:28Z"
+  mac: ENC[AES256_GCM,data:RxbZA6fa3n8rxc9hd5DKKSuKoAttRe1CTUL+8l04tW1Xj59WIcJi59FdDnTawheJWrVuTicyv+FmTO0BV+1xj7IGQPbMWHx/e9ebiuG8B2Je2vTj9m7KqM7MZ4ZffQbrOKBs5h0HOSUOgwsrIs3N9qmGLIpboVfn43f4qczJEr0=,iv:AfvpH+dva/t4LjnKcKUhDUDOG69nCGXZe1P4ViKHEIE=,tag:IluvZn7sxFU7j1R9hfSizw==,type:str]
   pgp:
   - created_at: "2024-01-24T20:22:38Z"
     enc: |-

--- a/src/bridge/secrets/edxapp/mitx.qa.yaml
+++ b/src/bridge/secrets/edxapp/mitx.qa.yaml
@@ -17,6 +17,9 @@ studio_oauth_client:
 sysadmin_git_webhook_secret: ENC[AES256_GCM,data:nbb6t935KLlWZRMhyI4BuyvpTwpt0vg/xSZy9LmWFYkoHnucQQjvhpGm0h1Pe04VYDY=,iv:vSfAgRfZXaaaveV6MiAhb5s0ng2HpgUfyg/bK7t1nGY=,tag:9Na1pm26qIq9v2g2gx0r4A==,type:str]
 youtube_api_key: ENC[AES256_GCM,data:PkoMIBybAKEwdTTCjK6PBhnaviK0e0KDz6AKzYfNTjC2Y8oHgV0P,iv:sUXzmkFEkFaRZ7ks+laFxBL4ocOC62woUMB/626JK34=,tag:YrJ/OnOsKEKxY2pZFZUPgg==,type:str]
 github_access_token: ENC[AES256_GCM,data:uS5kb9dPQJEx4DW9AGQpr/QgHcmt5QgT4/ZmkNr5Z4mrKeCXo8ptDg==,iv:3bhp3HyWyPk0l9PY0J+qgM90sELptgd5xJnjN7cK3nU=,tag:kw3+Cux+LiTsEXYhGB5glw==,type:str]
+user_retirement_salts:
+- ENC[AES256_GCM,data:N1IT4EwsTkF5rVBZMkQDcQwN+qUCIjNAZscDSYvrBA==,iv:7+oUCHf1CsUGhqUFwZzV+eIrGMxSzY+bi/qVs72Okdk=,tag:JyaOXCjgH3Ou1ocdNcbpLw==,type:str]
+- ENC[AES256_GCM,data:FctNYF79bRiYPKYcUvLxvabkpoXqwAFv3Q3qKIIiGYXV2oLx,iv:pBakxJfR9MfKXhYvymYz698NqphEbLJ70byoW0OBhxM=,tag:ef0YiuakaWeWhjB4nbqzDw==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-qa
@@ -32,8 +35,8 @@ sops:
     created_at: "2024-01-24T20:20:39Z"
     enc: vault:v1:MWW3ZTm2rKEZ20FOMyhtNmKgT8bqGRw0kT8OzlcvA1Blma1saJ/0ng+oQnMPk+GvcVnW5mcPWojoBRhA
   age: []
-  lastmodified: "2025-12-19T15:58:01Z"
-  mac: ENC[AES256_GCM,data:TMC3wn03/wCbbPdtQhZnakssYKskD1dBQ2eJ3kFL1j8xDfaYqvHNouJx+oZa2IyLvpvcVTxsKIXvReaZ79hKVNsoAR1DqXqDGbl16MoccfveYaz3tNMDyYlX2W2s39p23O2oh83KTKWqdB4GdNu80ymdvBBmDILrNR/I06yn2l0=,iv:Vk7hoydZ/Lpq3KcBvKjFjBXehVeVefj4qndtYdSC5n8=,tag:iIobkI31eGxfinVAXmK1bg==,type:str]
+  lastmodified: "2025-12-30T15:20:37Z"
+  mac: ENC[AES256_GCM,data:TcHrNNhVAlpj8P+v+MGuWAuuwrsnyVOZGolo87vun4DZGUkM88IFuIA798+ckhYmup34VfHjn9WqXx00qBC44DCP9mlbctL/4RcAjAkL9Gsyr+DhGgBlp1kVm0ONIGJ5oI2/S5h57g3v8i9S2D1ExeZMui+4/tC4AKS3TjseirA=,iv:bHO3xGHTGGDI9KPNw1CzeAHpRc5QEzvip92ALO2GatM=,tag:o2AWl569GxaZu2UZfVVmaw==,type:str]
   pgp:
   - created_at: "2024-01-24T20:20:39Z"
     enc: |-


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9727
https://github.com/mitodl/hq/issues/9726

### Description (What does it do?)
fix: set default retirement salts for residential envs

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
