### PR TITLE
For mit-learn, hardcode S3 bucket for mit_edx to production

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -348,8 +348,8 @@ application_s3_bucket_permissions = [
         "Action": ["s3:GetObject*", "s3:ListBucket*"],
         "Effect": "Allow",
         "Resource": [
-            f"arn:aws:s3:::edxorg-{stack_info.env_suffix}-edxapp-courses",
-            f"arn:aws:s3:::edxorg-{stack_info.env_suffix}-edxapp-courses/*",
+            "arn:aws:s3:::edxorg-production-edxapp-courses",
+            "arn:aws:s3:::edxorg-production-edxapp-courses/*",
             "arn:aws:s3:::mitx-etl-xpro-production-mitxpro-production",
             "arn:aws:s3:::mitx-etl-xpro-production-mitxpro-production/*",
             "arn:aws:s3:::mitx-etl-mitxonline-production",


### PR DESCRIPTION
There is no qa bucket for this so always use the production bucket

### What are the relevant tickets?
N/A

### Description (What does it do?)
Always uses the production S3 bucket for mit-learn's edx contentfile ingestion


### How can this be tested?
N/A

