### PR TITLE
fix: disable new email experience for xpro

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -584,6 +584,12 @@ def create_k8s_configmaps(  # noqa: PLR0915
             "common.djangoapps.third_party_auth.lti.LTIAuthBackend",
         ]
         lms_general_config_content["LEARNER_HOME_MICROFRONTEND_URL"] = "/dashboard/"
+        deployment_features.update(
+            {
+                "ENABLE_NEW_BULK_EMAIL_EXPERIENCE": False,
+            }
+        )
+
     elif stack_info.env_prefix == "mitxonline":
         lms_general_config_content["THIRD_PARTY_AUTH_BACKENDS"] = [
             "ol_social_auth.backends.OLOAuth2",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9767
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
Looks like the k8s migration enabled the new bulk experience in xPRO as well. 
- Disables the new email experience for xPRO 
<!--- Describe your changes in detail -->

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
Once deployed, the email tab in the instructor dashboard should show the legacy view.
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
