### PR TITLE
fix: fixed the port messiness of edx-notes.

### DIFF
--- a/src/ol_infrastructure/applications/edx_notes/__main__.py
+++ b/src/ol_infrastructure/applications/edx_notes/__main__.py
@@ -241,7 +241,7 @@ if deploy_to_k8s:
 
     # Application configuration (non-sensitive, static values only)
     application_config = {
-        "APP_PORT": APP_PORT,
+        "APP_PORT": str(APP_PORT),
         "ELASTICSEARCH_DSL_PORT": "443",
         "ELASTICSEARCH_DSL_USE_SSL": "true",
         "ELASTICSEARCH_DSL_VERIFY_CERTS": "false",


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/9766

### Description (What does it do?)
Makes the ports being uses by edx-notes consistent and locked on 8073. We are using the OLApplicationK8sConfig pattern for edx-notes but that expects NGINX sidecar which we don't have. So it required a little finagling. 
