### PR TITLE
Enable tail sampling of OTEL metrics.

### DIFF
--- a/src/ol_infrastructure/substructure/aws/eks/grafana.py
+++ b/src/ol_infrastructure/substructure/aws/eks/grafana.py
@@ -127,6 +127,35 @@ def setup_grafana(
                         "traces": {
                             "enabled": True,
                         },
+                        "processors": {
+                            "tailSampling": {
+                                "enabled": True,
+                                "decisionWait": "5s",
+                                "numTraces": 100,
+                                "expectedNewTracesPerSecond": 10,
+                                "decisionCache": {
+                                    "sampledCacheSize": 1000,
+                                    "nonSampledCacheSize": 10000,
+                                },
+                                "policies": [
+                                    {
+                                        "name": "keep-errors",
+                                        "type": "status_code",
+                                        "status_codes": ["ERROR", "UNSET"],
+                                    },
+                                    {
+                                        "name": "sample-slow-traces",
+                                        "type": "latency",
+                                        "threshold_ms": 5000,
+                                    },
+                                    {
+                                        "name": "sample-15pct-traces",
+                                        "type": "probabilistic",
+                                        "sampling_percentage": 15,
+                                    },
+                                ],
+                            },
+                        },
                     },
                 ],
                 "clusterMetrics": {


### PR DESCRIPTION

### Description (What does it do?)
Enable tail sampling of OTEL metrics.

- Added a processors block to the Grafana OTLP destination configuration.
 - Enabled Tail Sampling with specific tuning (decisionWait: "5s", numTraces: 100).
 - Defined three sampling policies:
   - keep-errors: Retains all traces with status ERROR or UNSET.
   - sample-slow-traces: Retains traces taking longer than 5000ms.
   - sample-15pct-traces: Retains 15% of all other traces (Probabilistic sampling).
