### PR TITLE
OTEL sample rates + tail sampling 

### DIFF
--- a/src/ol_infrastructure/applications/keycloak/__main__.py
+++ b/src/ol_infrastructure/applications/keycloak/__main__.py
@@ -483,7 +483,7 @@ keycloak_resource = kubernetes.apiextensions.CustomResource(
         "tracing": {
             "enabled": True,
             "endpoint": "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4317",
-            "samplerRatio": 0.2,
+            "samplerRatio": 1.0,
         },
         "hostname": {
             "hostname": keycloak_domain,

--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.Production.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.Production.yaml
@@ -40,7 +40,7 @@ config:
     OPENTELEMETRY_SERVICE_NAME: "learn-ai-webapp"
     OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=production,service.namespace=learn-ai,service.version=${GIT_SHA:-unknown},service.instance.id=${HOSTNAME}"
     OTEL_TRACES_SAMPLER: "parentbased_traceidratio"
-    OTEL_TRACES_SAMPLER_ARG: "0.2"
+    OTEL_TRACES_SAMPLER_ARG: "1.0"
     OTEL_PROPAGATORS: "tracecontext,baggage"
     OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
     OTEL_LOGS_EXPORTER: "otlp"

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.Production.yaml
@@ -80,7 +80,7 @@ config:
     OPENTELEMETRY_SERVICE_NAME: "learn-webapp"
     OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=production,service.namespace=learn,service.version=${GIT_SHA:-unknown},service.instance.id=${HOSTNAME}"
     OTEL_TRACES_SAMPLER: "parentbased_traceidratio"
-    OTEL_TRACES_SAMPLER_ARG: "0.2"
+    OTEL_TRACES_SAMPLER_ARG: "1.0"
     OTEL_PROPAGATORS: "tracecontext,baggage"
     OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
     OTEL_LOGS_EXPORTER: "otlp"

--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.applications.mitxonline.Production.yaml
@@ -60,7 +60,7 @@ config:
     OPENTELEMETRY_SERVICE_NAME: "mitxonline-webapp"
     OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=production,service.namespace=mitxonline,service.version=${GIT_SHA:-unknown},service.instance.id=${HOSTNAME}"
     OTEL_TRACES_SAMPLER: "parentbased_traceidratio"
-    OTEL_TRACES_SAMPLER_ARG: "0.2"
+    OTEL_TRACES_SAMPLER_ARG: "1.0"
     OTEL_PROPAGATORS: "tracecontext,baggage"
     OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
     OTEL_LOGS_EXPORTER: "otlp"


### PR DESCRIPTION

### Description (What does it do?)
Set OTEL sampling rates to 100 percent because we now use tail sampling at the alloy layer to pick and choose which traces get sent to grafana cloud. 
