### PR TITLE
config: remove Open Discussion settings from Micromasters

### DIFF
--- a/src/ol_infrastructure/applications/micromasters/Pulumi.applications.micromasters.QA.yaml
+++ b/src/ol_infrastructure/applications/micromasters/Pulumi.applications.micromasters.QA.yaml
@@ -24,18 +24,13 @@ config:
     MAILGUN_FROM_EMAIL: "no-reply@micromasters-rc-mail.odl.mit.edu"
     MAILGUN_URL: "https://api.mailgun.net/v3/micromasters-rc-mail.odl.mit.edu"
     MICROMASTERS_BASE_URL: "https://micromasters-rc.odl.mit.edu"
-    MICROMASTERS_CORS_ORIGIN_WHITELIST: '["discussions-rc.odl.mit.edu"]'
+    MICROMASTERS_CORS_ORIGIN_WHITELIST: '[]'
     MICROMASTERS_ENVIRONMENT: "rc"
     MICROMASTERS_LOG_LEVEL: "DEBUG"
     MIDDLEWARE_FEATURE_FLAG_QS_PREFIX: "BGA"
     MITXONLINE_BASE_URL: "https://courses.rc.learn.mit.edu/"
     MITXONLINE_CALLBACK_URL: "https://courses.rc.learn.mit.edu/"
     MITXONLINE_URL: "https://rc.mitxonline.mit.edu/"
-    OPEN_DISCUSSIONS_API_USERNAME: "od_mm_rc_api"
-    OPEN_DISCUSSIONS_BASE_URL: "https://discussions-rc.odl.mit.edu/"
-    OPEN_DISCUSSIONS_COOKIE_DOMAIN: "odl.mit.edu"
-    OPEN_DISCUSSIONS_COOKIE_NAME: "discussionsrc"
-    OPEN_DISCUSSIONS_REDIRECT_URL: "https://discussions-rc.odl.mit.edu/"
     PGBOUNCER_DEFAULT_POOL_SIZE: 50
     PGBOUNCER_MAX_CLIENT_CONN: 1000
   micromasters:db_password:


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/micromasters/issues/5441

### Description (What does it do?)
This PR removes the Open Discussion settings from Micromasters

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
