### PR TITLE
config: remove Open discussion from MM CI/Prod

### DIFF
--- a/src/ol_infrastructure/applications/micromasters/Pulumi.applications.micromasters.CI.yaml
+++ b/src/ol_infrastructure/applications/micromasters/Pulumi.applications.micromasters.CI.yaml
@@ -22,18 +22,13 @@ config:
     MAILGUN_FROM_EMAIL: "no-reply@micromasters-rc-mail.odl.mit.edu"
     MAILGUN_URL: "https://api.mailgun.net/v3/micromasters-rc-mail.odl.mit.edu"
     MICROMASTERS_BASE_URL: "https://micromasters-ci.odl.mit.edu"
-    MICROMASTERS_CORS_ORIGIN_WHITELIST: "['discussions-ci.odl.mit.edu']"
+    MICROMASTERS_CORS_ORIGIN_WHITELIST: "[]"
     MICROMASTERS_ENVIRONMENT: "ci"
     MICROMASTERS_LOG_LEVEL: "DEBUG"
     MIDDLEWARE_FEATURE_FLAG_QS_PREFIX: ""
     MITXONLINE_BASE_URL: ""
     MITXONLINE_CALLBACK_URL: ""
     MITXONLINE_URL: ""
-    OPEN_DISCUSSIONS_API_USERNAME: "od_mm_ci_api"
-    OPEN_DISCUSSIONS_BASE_URL: "https://discussions-ci.odl.mit.edu/"
-    OPEN_DISCUSSIONS_COOKIE_DOMAIN: "odl.mit.edu"
-    OPEN_DISCUSSIONS_COOKIE_NAME: "discussionsci"
-    OPEN_DISCUSSIONS_REDIRECT_URL: "https://discussions-ci.odl.mit.edu/"
     PGBOUNCER_DEFAULT_POOL_SIZE: 50
     PGBOUNCER_MAX_CLIENT_CONN: 1000
   micromasters:db_password:

--- a/src/ol_infrastructure/applications/micromasters/Pulumi.applications.micromasters.Production.yaml
+++ b/src/ol_infrastructure/applications/micromasters/Pulumi.applications.micromasters.Production.yaml
@@ -24,18 +24,13 @@ config:
     MAILGUN_FROM_EMAIL: "no-reply@micromasters.odl.mit.edu"
     MAILGUN_URL: "https://api.mailgun.net/v3/micromasters.odl.mit.edu"
     MICROMASTERS_BASE_URL: "https://micromasters.mit.edu"
-    MICROMASTERS_CORS_ORIGIN_WHITELIST: '["open.mit.edu"]'
+    MICROMASTERS_CORS_ORIGIN_WHITELIST: '[]'
     MICROMASTERS_ENVIRONMENT: "production"
     MICROMASTERS_LOG_LEVEL: "INFO"
     MIDDLEWARE_FEATURE_FLAG_QS_PREFIX: "XIQ"
     MITXONLINE_BASE_URL: "https://courses.learn.mit.edu"
     MITXONLINE_CALLBACK_URL: "https://courses.learn.mit.edu"
     MITXONLINE_URL: "https://mitxonline.mit.edu/"
-    OPEN_DISCUSSIONS_API_USERNAME: "od_mm_prod_api"
-    OPEN_DISCUSSIONS_BASE_URL: "https://open.mit.edu"
-    OPEN_DISCUSSIONS_COOKIE_DOMAIN: "mit.edu"
-    OPEN_DISCUSSIONS_COOKIE_NAME: "discussionsprod"
-    OPEN_DISCUSSIONS_REDIRECT_URL: "https://open.mit.edu/"
     PGBOUNCER_DEFAULT_POOL_SIZE: 20
     PGBOUNCER_MAX_CLIENT_CONN: 500
   micromasters:db_password:


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/micromasters/issues/5441

### Description (What does it do?)
This PR removes the Open Discussion settings from Micromasters RC and Prod

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
