### PR TITLE
chore(deps): pin openai for ol-openedx-course-translations

### DIFF
--- a/dockerfiles/openedx-edxapp/pip_package_overrides/master/mitxonline.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_overrides/master/mitxonline.txt
@@ -9,4 +9,5 @@ xmlsec==1.3.14 --no-binary xmlsec
 celery==5.6.0
 
 # Fix dependencies for ol-openedx-course-translations package
+# https://github.com/openedx/edx-platform/issues/35268
 openai==2.15.0


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/9913

### Description (What does it do?)
<!--- Describe your changes in detail -->
Pins openai dependency as it is not used in edx-platform and causing troubles with course translations plugin. Here is the edx-platform issue to remove the dependency https://github.com/openedx/edx-platform/issues/35268

