### PR TITLE
chore: Move OVS S3 buckets under Pulumi management

### DIFF
--- a/src/ol_infrastructure/applications/odl_video_service/Pulumi.applications.odl_video_service.CI.yaml
+++ b/src/ol_infrastructure/applications/odl_video_service/Pulumi.applications.odl_video_service.CI.yaml
@@ -19,9 +19,9 @@ config:
   - video-ci.odl.mit.edu
   ovs:s3_bucket_name: odl-video-service-ci
   ovs:s3_subtitle_bucket_name: odl-video-service-subtitles-ci
-  ovs:s3_thumbnail_bucket_name: odl-video-service-thumbnail-ci
-  ovs:s3_transcode_bucket_name: odl-video-service-transcode-ci
-  ovs:s3_watch_bucket_name: odl-video-service-watch-ci
+  ovs:s3_thumbnail_bucket_name: odl-video-service-thumbnails-ci
+  ovs:s3_transcode_bucket_name: odl-video-service-transcoded-ci
+  ovs:s3_watch_bucket_name: odl-video-service-uploaded-ci
   ovs:target_vpc: applications_vpc
   ovs:use_shibboleth: "False"
   redis:max_connections: "30"


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/ol-infrastructure/issues/2018

### Description (What does it do?)
<!--- Describe your changes in detail -->
The OVS application and its associated buckets all pre-date our use of Pulumi. This moves those resources under management of Pulumi using the S3 component resource. That resource automatically assigns intelligent-tiering as a lifecycle policy for cost savings.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
All existing buckets have been imported into the stack state for the corresponding environment tier. Running a `pulumi up --refresh` for the stacks will show the intended changes.
