### PR TITLE
fix: use learn DNS zone, not mitodl

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -971,7 +971,7 @@ route53.Record(
     type="CNAME",
     ttl=five_minutes,
     records=[mitlearn_config.require("zendesk_help_url")],
-    zone_id=mitodl_zone_id,
+    zone_id=learn_zone_id,
     opts=ResourceOptions(delete_before_replace=True),
 )
 


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/9878


### Description (What does it do?)
Use the learn zone, not the mitodl one.

### How can this be tested?
````
╭─feoh at loki in ~/src/mit/ol-infrastructure/src/ol_infrastructure/applications/mit_learn on cpatti/fix_learn_zendesk✔ 26-01-21 - 12:00:37
╰─(.venv) ⠠⠵ dig in CNAME support.ci.learn.mit.edu                                                                                                                         <region:us-east-1>

; <<>> DiG 9.20.17 <<>> in CNAME support.ci.learn.mit.edu
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 1259
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 65494
;; QUESTION SECTION:
;support.ci.learn.mit.edu.      IN      CNAME

;; ANSWER SECTION:
support.ci.learn.mit.edu. 300   IN      CNAME   mitlearn.zendesk.com.

;; Query time: 13 msec
;; SERVER: 127.0.0.53#53(127.0.0.53) (UDP)
;; WHEN: Wed Jan 21 12:02:49 EST 2026
;; MSG SIZE  rcvd: 87
```