### PR TITLE
config: enable auto translation language selection feat (MITx Learn-open edX/Prod)

### DIFF
--- a/src/ol_concourse/pipelines/open_edx/mfe/values.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/values.py
@@ -190,7 +190,7 @@ mitxonline = [
         enable_video_upload_page_link_in_content_dropdown="true",
         enable_jumpnav="true",
         appzi_url="https://w.appzi.io/w.js?token=Q2pSI",
-        enable_auto_language_selection="false",
+        enable_auto_language_selection="true",
     ),
 ]
 

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
@@ -89,6 +89,7 @@ config:
   edxapp:backend_lms_domain: courses-backend.learn.mit.edu
   edxapp:backend_studio_domain: studio-backend.learn.mit.edu
   edxapp:backend_preview_domain: preview-backend.learn.mit.edu
+  edxapp:enable_auto_language_selection: true
   edxapp:autoscaling_lms_requests_threshold: "20"
   edxapp:autoscaling_lms_latency_threshold: "2000"
   edxapp:autoscaling_lms_cpu_threshold: "70"


### PR DESCRIPTION
### What are the relevant tickets?
None
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
As we shift our translations feature towards production, we need to enable the flag so that the user language automatically gets selected when a user visits a translated course.
<!--- Describe your changes in detail -->

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
Auto language selection for a user should start working. i.e., If a user opens a French translated course, everything he sees should be in French.
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
