### PR TITLE
Remove upgrad domain in org

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/olapps.py
+++ b/src/ol_infrastructure/substructure/keycloak/olapps.py
@@ -978,7 +978,7 @@ def create_olapps_realm(  # noqa: PLR0913, PLR0915
         )
         onboard_oidc_org(
             OIDCIdpConfig(
-                org_domains=["upgrad.com"],
+                org_domains=[""],
                 org_name="upGrad",
                 org_alias="UPGRAD",
                 learn_domain=mitlearn_domain,


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
Remove upgrad domain in org given that upgrad users mostly use their personal emails.