### PR TITLE
fix: set DISABLE_START_DATES to False for MITx

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/config_builder.py
+++ b/src/ol_infrastructure/applications/edxapp/config_builder.py
@@ -443,7 +443,7 @@ def get_deployment_overrides(env_prefix: str) -> ConfigDict:
             "COMPLETE",
         ],
         # Module-level settings overrides for residential
-        "DISABLE_START_DATES": True,
+        "DISABLE_START_DATES": False,
         "ENABLE_MKTG_SITE": False,  # Extracted to module-level
         # FEATURES overrides for residential (only non-module-level flags)
         "FEATURES": {


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9703

### Description (What does it do?)
This flag let's user see the content which is schedules for future release -- Disabled it