### PR TITLE
config: disable COURSES_INVITE_ONLY for MITx (Prod only)

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/config_builder.py
+++ b/src/ol_infrastructure/applications/edxapp/config_builder.py
@@ -423,7 +423,6 @@ def get_deployment_overrides(env_prefix: str) -> ConfigDict:
         "EMAIL_HOST": "outgoing.mit.edu",
         "EMAIL_PORT": 587,
         "EMAIL_USE_TLS": True,
-        "COURSES_INVITE_ONLY": False,
         "COURSE_MODE_DEFAULTS": {
             "name": "Honor",
             "android_sku": None,
@@ -467,6 +466,7 @@ def get_deployment_overrides(env_prefix: str) -> ConfigDict:
     mitx.update(
         {
             "COURSE_CATALOG_VISIBILITY_PERMISSION": "staff",
+            "COURSES_INVITE_ONLY": False,
         }
     )
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9854

<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
Changes https://github.com/mitodl/ol-infrastructure/pull/4133 a little bit. Disables only for Prod as per https://github.com/mitodl/hq/issues/9854#issuecomment-3823889041
<!--- Describe your changes in detail -->

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
