### PR TITLE
Only enable mitxonline dashboard sync in prod

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.Production.yaml
@@ -55,6 +55,7 @@ config:
     DEBUG: "false"
     EDX_LEARNING_COURSE_BUCKET_NAME: "edxorg-production-edxapp-courses"
     ENABLE_INFINITE_CORRIDOR: "true"
+    FEATURE_SYNC_ON_DASHBOARD_LOAD: "True"
     GA_G_TRACKING_ID: "" # Missing?
     GA_TRACKING_ID: "" # Missing?
     INDEXING_API_USERNAME: "od_mm_prod_api"

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -317,7 +317,6 @@ mitxonline_vault_backend = OLVaultDatabaseBackend(mitxonline_vault_backend_confi
 env_vars = {
     "CRON_COURSERUN_SYNC_HOURS": "*",
     "FEATURE_IGNORE_EDX_FAILURES": "True",
-    "FEATURE_SYNC_ON_DASHBOARD_LOAD": "True",
     "HUBSPOT_PIPELINE_ID": "19817792",
     "MITOL_GOOGLE_SHEETS_REFUNDS_COMPLETED_DATE_COL": "12",
     "MITOL_GOOGLE_SHEETS_REFUNDS_ERROR_COL": "13",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Updates the configuration to only enable this setting in production

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
It should get disabled in RC