### PR TITLE
fix: remove OCW_EXTRA_COURSE_THEMES from prod

### DIFF
--- a/src/ol_infrastructure/applications/ocw_studio/Pulumi.applications.ocw_studio.Production.yaml
+++ b/src/ol_infrastructure/applications/ocw_studio/Pulumi.applications.ocw_studio.Production.yaml
@@ -27,7 +27,6 @@ config:
     MIT_LEARN_API_BASE_URL: https://api.learn.mit.edu
     MIT_LEARN_BASE_URL: https://learn.mit.edu
     OCW_COURSE_STARTER_SLUG: ocw-course-v2
-    OCW_EXTRA_COURSE_THEMES: ''
     OCW_GTM_ACCOUNT_ID: GTM-NMQZ25T
     OCW_HUGO_THEMES_SENTRY_DSN: 'https://eee58f41dda54d2b814296e12dced4b7@o48788.ingest.sentry.io/5304953'
     OCW_IMPORT_STARTER_SLUG: ocw-course

--- a/src/ol_infrastructure/applications/ocw_studio/Pulumi.applications.ocw_studio.QA.yaml
+++ b/src/ol_infrastructure/applications/ocw_studio/Pulumi.applications.ocw_studio.QA.yaml
@@ -27,6 +27,7 @@ config:
     MIT_LEARN_BASE_URL: https://rc.learn.mit.edu
     MIT_LEARN_API_BASE_URL: https://api.rc.learn.mit.edu
     OCW_COURSE_STARTER_SLUG: ocw-course-v2
+    OCW_EXTRA_COURSE_THEMES: ocw-course-v3
     OCW_GTM_ACCOUNT_ID: GTM-PJMJGF6
     OCW_HUGO_THEMES_SENTRY_DSN: 'https://eee58f41dda54d2b814296e12dced4b7@o48788.ingest.sentry.io/5304953'
     OCW_IMPORT_STARTER_SLUG: ocw-course

--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -351,7 +351,6 @@ heroku_vars = {
     "MITOL_MAIL_REPLY_TO_ADDRESS": "ocw-prod-support@mit.edu",
     "OCW_COURSE_TEST_SLUG": "ocw-ci-test-course",
     "OCW_DEFAULT_COURSE_THEME": "ocw-course-v2",
-    "OCW_EXTRA_COURSE_THEMES": "ocw-course-v3",
     "OCW_STUDIO_ADMIN_EMAIL": "cuddle-bunnies@mit.edu",
     "OCW_STUDIO_DB_CONN_MAX_AGE": 0,
     "OCW_STUDIO_DB_DISABLE_SSL": "True",


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/9941

### Description (What does it do?)
This PR unsets the variable `OCW_EXTRA_COURSE_THEMES` for production, so that it is properly [interpreted](https://github.com/mitodl/ocw-studio/blob/master/main/settings.py#L1271-L1276) as an empty list.

Setting an env var to an empty string and then interpreting it as a list using `get_delimited_list` will end up setting it to a list with an empty string `['']` whereas the original intention is more likely to be to set it to an empty list `[]`. This is a somewhat unintuitive behavior of the `get_delimited_list` function but may not be easy to fix due to compatibility concerns with other apps.

### How can this be tested?
After this is merged, verify the values of OCW_EXTRA_COURSE_THEMES from RC and prod django shell. On prod, it should be `[]`. On RC `['ocw-course-v3']`