### PR TITLE
Configure grafana oauth client

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.CI.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.CI.yaml
@@ -55,6 +55,8 @@ config:
   keycloak_realm:ol-platform-engineering-leek-client-secret:
     secure: v1:xf9mFeIyIWLQbIYk:IY+XjdVmc6Va8WGTwrEN+t3jsyuJJ2b1fD83n2MiDSfUBNxeBoP1Xwd+KGskOLOX
   keycloak_realm:ol-platform-engineering-leek-redirect-uris: ["https://celery-monitoring-ci.odl.mit.edu/*"]
+  keycloak_realm:ol-platform-engineering-grafana-redirect-uris: ["https://mitolci.grafana.net/login/generic_oauth"]
+  keycloak_realm:ol-platform-engineering-grafana-web-origins: ["https://mitolci.grafana.net"]
   keycloak_realm:ol-platform-engineering-vault-redirect-uris: ["https://vault-ci.odl.mit.edu/ui/vault/auth/oidc/oidc/callback",
     "http://localhost:8250/oidc/callback"]
   keycloak_realm:ol-platform-engineering-jupyterhub-redirect-uris:
@@ -106,3 +108,5 @@ config:
   vault_server:env_namespace: operations.ci
   keycloak_realm:session_secret:
     secure: v1:SKlByHIh5fj/2MlA:1hzqRgIoqGowunYEVMMhdzPPBPUGucSUjlcOUDuuPL7JIg+Mpp2nGu8sHGfSMtfeAFOKNlQ6bmMF2oQ=
+  keycloak_realm:ol-platform-engineering-grafana-client-secret:
+    secure: v1:rAIQutctJKUBe/rV:VV0DhdOXs5U+zCqXE/bOTjqe98nBvo/Kkdfnf0JJjzFwI9gxOIBXwSmwoyP2XsIi7+VVVLVzfCHVcvay

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.Production.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.Production.yaml
@@ -98,6 +98,10 @@ config:
     secure: v1:r4drRDC08ppZP7oF:LIYIGuIWCRKyCAG0mcaVU4Te1LpN/MtylDiO2FYfYR1Iq8OcahRcoT2hU5CzvO8Y
   keycloak_realm:ol-platform-engineering-leek-client-secret:
     secure: v1:q+CCXORqwpNWS3PZ:7JaJVv9GrEnLVR+dnRg1Y7RGJtVTKz1Q5zWNAZ5x44012mdmZm0C4Lr+P2a4mcxT
+  keycloak_realm:ol-platform-engineering-grafana-client-secret:
+    secure: v1:kErvIIMewm7v72cy:cmFt1ef2WtHj0cGlcCVK/NcayMscYiowTPIUuudj3eWNfnVFECXy2A5ff2vNbdlKsqwqGKmHx9x3UHiD0aTLFaD4mlzzax98wnlIPWknkL0=
+  keycloak_realm:ol-platform-engineering-grafana-redirect-uris: ["https://mitolproduction.grafana.net/login/generic_oauth"]
+  keycloak_realm:ol-platform-engineering-grafana-web-origins: ["https://mitolproduction.grafana.net"]
   keycloak_realm:ol-data-platform-superset-client-secret:
     secure: v1:LTpB1a4pNAAm04uf:1IqPnuHcO78FzzwhML/wLgP2IzoW2GEvmjipQtm5fXGW2qV9Snw9CUYP9qFGfdMZ
   keycloak_realm:ol-data-platform-openmetadata-client-secret:

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
@@ -101,6 +101,10 @@ config:
     secure: v1:1fMzXwbZ0vUU1lLG:xfQvxCldwuHT1SKt622uz62qVAZsuHNnq+/C8WTkd0p4ntC4IDr0s5BDA8CwK6Tp
   keycloak_realm:ol-platform-engineering-leek-client-secret:
     secure: v1:Ork7nqqaLiH7LtjR:sXrent5knH9tHsdW91HAQLKOYct6xZNzwmLB32L9dRNeoCaSC6bXdQIjV40+BEMp
+  keycloak_realm:ol-platform-engineering-grafana-client-secret:
+    secure: v1:ZTyNlZjdB/k/qMns:QNw5/PzevRDbZr71k3uCITuh6iWHztdWlZ78r372mPTZf+s+3CyTCgumLkbyRBYRDjIATthTXMXm+1fivwqeoYQFUd4AWDh3SUzZtepTScI=
+  keycloak_realm:ol-platform-engineering-grafana-redirect-uris: ["https://mitolqa.grafana.net/login/generic_oauth"]
+  keycloak_realm:ol-platform-engineering-grafana-web-origins: ["https://mitolqa.grafana.net"]
   keycloak_realm:ol-platform-engineering-vault-client-secret:
     secure: v1:1G2J8kD4DrOtBOEO:K1wWu8mjGE0QUS4npZxvHc3O7bZPH8GdXBmnPhEMhW67HvjQq20TmWK3lrtsYFaN
   keycloak_realm:ol-data-platform-superset-client-secret:


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
This configures the Grafana OAuth client so that we can use Keycloak when logging in to grafana along with setting up the pre-defined client rules. There's a manual piece that needs to be configured on the grafana side and I currently have it configured on CI.


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
I'd like to hold-off on merging this until we hear back from Grafana support about whether there's a better way to handle account setup on the org level vs the stack level.
