### PR TITLE
Added media config to learn prod

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.Production.yaml
@@ -49,6 +49,8 @@ config:
     AI_MIT_SYLLABUS_URL: "https://api.learn.mit.edu/api/v0/vector_content_files_search/"
     AI_MIT_VIDEO_TRANSCRIPT_URL: "https://api.learn.mit.edu/api/v0/vector_content_files_search/"
     APPZI_URL: "https://w.appzi.io/w.js?token=Q2pSI"
+    AWS_S3_CUSTOM_DOMAIN: "learn.mit.edu"
+    AWS_S3_PREFIX: "media"
     CANVAS_COURSE_BUCKET_NAME: "ol-data-lake-landing-zone-production"
     CELERY_WORKER_CONCURRENCY: 1
     CSRF_COOKIE_NAME: "learn_csrftoken"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/hq/issues/9376
### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds required config for AWS S3 which has been tested/verified on QA. Prod and QA S3 assets have already been copied to the `media` folder so that should be all set.
