### PR TITLE
fix: git-auto-export configs added for xPro and MITx production

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.Production.yaml
@@ -60,7 +60,7 @@ config:
     learner_dashboard: dashboard
     learning: learn
     ora_grading: ora-grading
-  edxapp:github_org_api_url: https://github.mit.edu/api/v3/orgs/{actual_org}
+  edxapp:github_org_api_url: https://github.mit.edu/api/v3/orgs/mitx-staging
   edxapp:google_analytics_id: ""
   edxapp:move_db: true
   edxapp:mail_domain: edxapp-mail-staging-production.mitx.mit.edu

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.Production.yaml
@@ -72,7 +72,7 @@ config:
     learner_dashboard: dashboard
     learning: learn
     ora_grading: ora-grading
-  edxapp:github_org_api_url: https://github.mit.edu/api/v3/orgs/{actual_org}
+  edxapp:github_org_api_url: https://github.mit.edu/api/v3/orgs/MITx-Studio2LMS
   edxapp:google_analytics_id: UA-5145472-4
   edxapp:move_db: true
   edxapp:mail_domain: edxapp-mail-production.mitx.mit.edu

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.Production.yaml
@@ -51,7 +51,7 @@ config:
     gradebook: gradebook
     learning: learn
     ora_grading: ora-grading
-  edxapp:github_org_api_url: https://github.mit.edu/api/v3/orgs/{actual_org}
+  edxapp:github_org_api_url: https://github.mit.edu/api/v3/orgs/xpro
   edxapp:google_analytics_id: UA-5145472-38
   edxapp:product: xpro
   edxapp:enable_xqueue: false


### PR DESCRIPTION
NEED TO GO AFTER https://github.com/mitodl/ol-infrastructure/pull/4186

### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10161#issuecomment-3879324760

### Description (What does it do?)
These are production environment configuration for `git-auto-export`

### Additional Context
It requires https://github.com/mitodl/ol-infrastructure/pull/4186 and need to go after that.

After merging/deployment need to run the management command on Production env. 
```python
python manage.py migrate_giturl --all
```