### PR TITLE
feat: Add AWS import bucket name

### DIFF
--- a/src/ol_infrastructure/applications/ocw_studio/Pulumi.applications.ocw_studio.QA.yaml
+++ b/src/ol_infrastructure/applications/ocw_studio/Pulumi.applications.ocw_studio.QA.yaml
@@ -6,6 +6,8 @@ config:
   heroku:app_id:
     secure: v1:E4q9VpR9KB5D3KAt:VVTgctKXg3tucJ2TzGVIlq+6EilZ7dMGThGt82yZvWFJnosXeYxnKtRsVuG2/TpNq0UzBQ==
   heroku_app:vars:
+    # Only want this in RC. Should be left blank in production.
+    AWS_IMPORT_STORAGE_BUCKET_NAME: ol-ocw-studio-app-production
     CONCOURSE_URL: https://cicd-qa.odl.mit.edu
     CONTENT_FILE_SEARCH_API_URL: 'https://mitopen.odl.mit.edu/api/v1/content_file_search/'
     COURSE_SEARCH_API_URL: 'https://mitopen.odl.mit.edu/api/v1/learning_resources_search/'


### PR DESCRIPTION
For OCW Studio S3 sync pipeline.

### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/8703

### Description (What does it do?)
Adds the needed AWS import bucket override in RC only.

### How can this be tested?
Ensure the OCW studio S3 Sync pipeline upserts? @gumaerc can offer more detail if needed.