### PR TITLE
fix: disable extracted html blocks to fix notes

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
@@ -50,6 +50,7 @@ config:
     "--authenticated"]
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["teams.enable_teams_app", "--create", "--superusers", "--staff"]
+  edxapp:use_extracted_html_block: false
   edxapp:appzi_url: "https://w.appzi.io/w.js?token=Q2pSI"
   edxapp:business_unit: mitxonline
   edxapp:db_password:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
@@ -50,6 +50,7 @@ config:
     "--authenticated"]
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["teams.enable_teams_app", "--create", "--superusers", "--staff"]
+  edxapp:use_extracted_html_block: false
   edxapp:business_unit: mitxonline
   edxapp:db_password:
     secure: v1:xHUw5WC3aN02zuAj:0BozwDxrtF0OA7wkYuv4R4CCnSHYdgXt+vi6/3eP9zwJgHgQO20+8sQfg7rXPC9SIUobEA==

--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -261,6 +261,9 @@ def _build_interpolated_config_dict(
             {
                 "COURSE_ABOUT_VISIBILITY_PERMISSION": "see_about_page",
                 "MITXONLINE_BASE_URL": f"https://{marketing_domain}/",
+                "USE_EXTRACTED_HTML_BLOCK": edxapp_config.get_bool(
+                    "use_extracted_html_block", False
+                ),
                 "ENABLE_AUTO_LANGUAGE_SELECTION": edxapp_config.get_bool(
                     "enable_auto_language_selection"
                 )


### PR DESCRIPTION
### What are the relevant tickets?
[#9533](https://github.com/mitodl/hq/issues/9533)

### Description (What does it do?)
Adds the `USE_EXTRACTED_HTML_BLOCK=False` edx-platform setting for MITx Online RC and Production, with separate control per environment. This is done to enable notes functionality on HTML Blocks.
