### PR TITLE
adding rc api urls for xpro

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.QA.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.QA.yaml
@@ -73,6 +73,8 @@ config:
     MITX_ONLINE_BASE_URL: "https://rc.mitxonline.mit.edu/"
     MITX_ONLINE_COURSES_API_URL: "https://rc.mitxonline.mit.edu/api/v2/courses/"
     MITX_ONLINE_PROGRAMS_API_URL: "https://rc.mitxonline.mit.edu/api/v2/programs/"
+    XPRO_CATALOG_API_URL: "https://rc.xpro.mit.edu/api/programs/"
+    XPRO_COURSES_API_URL: "https://rc.xpro.mit.edu/api/courses/"
     MITPE_API_ENABLED: "true"
     OCW_ITERATOR_CHUNK_SIZE: 300
     OIDC_ENDPOINT: "https://sso-qa.ol.mit.edu/realms/olapps"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/10288
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR sets the RC xpro url to the RC xpro api instead of production.

### How can this be tested?
N/A - I have tested this locally with the correct setting and RC credentials to verify contentfiles load
