### PR TITLE
config: add DATAPLATFORM_BASE_URL in mitxonline configurations

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.CI.yaml
@@ -66,6 +66,7 @@ config:
   edxapp:backend_studio_domain: studio-backend.ci.learn.mit.edu
   edxapp:backend_preview_domain: preview-backend.ci.learn.mit.edu
   edxapp:mitxonline_domain: ci.mitxonline.mit.edu
+  edxapp:data_platform_domain: bi-ci.ol.mit.edu
   edxapp:edx_forum_secrets:
     secure: v1:+8kgTH+x98kC+Lxc:bW03E5mk8wRB+FxZYtj06FPx/MEJuEiKO5ekaDTZKmqmfklisVhidp0fhX+So2Eygf/Aiyqp5L03RCzA8k7I4ZmlNss19//pdGgBDwa3HAbw
   edxapp:enable_notes: "True"

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
@@ -67,6 +67,7 @@ config:
   edxapp:mit_learn_api_domain: api.learn.mit.edu
   edxapp:learn_ai_frontend_domain: "learn-ai.ol.mit.edu"
   edxapp:mitxonline_domain: mitxonline.mit.edu
+  edxapp:data_platform_domain: bi.ol.mit.edu
   edxapp:edx_forum_secrets:
     secure: v1:qzfe99Jb8n0TnEQS:Y6fSOS8lksj7WvED+V7kCtV7arDtwx7184Fw330Mwh9JDHW72rVd8y7Nm0fF8ANCcFCwDV5EwSU2Fcc+X47NHDOLCOQv16lyB6jWOF2mTr/veRax6MbXY9NlLmsfp9EBQesDCitULbkz9hyHcHT3GPI=
   edxapp:enable_notes: "True"

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
@@ -67,6 +67,7 @@ config:
   edxapp:backend_studio_domain: studio-backend.rc.learn.mit.edu
   edxapp:backend_preview_domain: preview-backend.rc.learn.mit.edu
   edxapp:mitxonline_domain: rc.mitxonline.mit.edu
+  edxapp:data_platform_domain: bi-qa.ol.mit.edu
   edxapp:edx_forum_secrets:
     secure: v1:IqXRArQveCV+9lkE:cRaraFuN2dDmI29PD4QifOU7MrRFdszOoaUb7o3pDJordt4TSjw8fIxldWfMzNhZRLC+NS291DorO1IuN6ASdCbt5d53aMvHVt+3hA6wyuI11OFjk7U=
   edxapp:elb_healthcheck_interval: "30"

--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -59,7 +59,7 @@ def _build_interpolated_config_dict(
         if stack_info.env_prefix == "mitxonline"
         else edxapp_config.get("marketing_domain")
     )
-
+    data_platform_domain = edxapp_config.get("data_platform_domain")
     # Build base interpolated config shared across deployments
     config: dict[str, Any] = {
         "ALLOWED_HOSTS": [
@@ -264,6 +264,7 @@ def _build_interpolated_config_dict(
                 "USE_EXTRACTED_HTML_BLOCK": edxapp_config.get_bool(
                     "use_extracted_html_block", False
                 ),
+                "DATAPLATFORM_CERTIFICATE_BASE_URL": f"https://{data_platform_domain}/superset/dashboard/da9e03d3-e1bb-45b8-981f-208deca90e7a/",
                 "ENABLE_AUTO_LANGUAGE_SELECTION": edxapp_config.get_bool(
                     "enable_auto_language_selection"
                 )


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9759

### Description (What does it do?)
This PR adds `DATAPLATFORM_CERTIFICATE_BASE_URL` in mitxonline configurations as requested [here](https://github.com/mitodl/mitxonline-theme/pull/79#discussion_r2820662151)

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
