### PR TITLE
feat: enable asktim waffle flag for prod

### DIFF
--- a/src/ol_concourse/pipelines/open_edx/mfe/values.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/values.py
@@ -189,6 +189,7 @@ mitxonline = [
         logo_trademark_url="https://courses.learn.mit.edu/static/mitxonline/images/mit-logo.svg",
         enable_video_upload_page_link_in_content_dropdown="true",
         enable_jumpnav="true",
+        enable_ai_drawer_slot="true",
         appzi_url="https://w.appzi.io/w.js?token=Q2pSI",
         enable_auto_language_selection="true",
     ),


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9143

### Description (What does it do?)
Enables the enable_ai_drawer_slot feature flag for the prod environment to enable AI drawer slot functionality introduced in https://github.com/mitodl/ol-infrastructure/pull/3884.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
