### PR TITLE
fix: external-dns default behavior change

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/eks/external_dns.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/external_dns.py
@@ -147,11 +147,6 @@ def setup_external_dns(
                 ],
                 # Create a txt record to indicate provenance of the record(s)
                 "txtOwnerId": cluster_name,
-                # Need to explicitly turn off support for legacy traefik ingress services
-                # to avoid an annoying bug
-                "extraArgs": [
-                    "--traefik-disable-legacy",
-                ],
                 # Limit the dns zones that external dns knows about
                 "domainFilters": eks_config.require_object("allowed_dns_zones"),
                 "resources": {


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
Fixes a break introduced by commit https://github.com/mitodl/ol-infrastructure/commit/6220e1aa6c4c6581ed7869adfd1654320a7a6388 

Breaking change introduced in 0.19.0 https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.19.0

Default behavior is now to disable legacy traefik configs. 