### PR TITLE
config: update default mitxonline/learn header links

### DIFF
--- a/src/bridge/settings/openedx/mfe/slot_config/mitxonline/common-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/mitxonline/common-mfe-config.env.jsx
@@ -70,7 +70,7 @@ const addFooterSubSlotsOverride = (config) => {
     },
   ]
 
-  if (isMitxonlineCourse()) {
+  if (isMITxOnlineCourse()) {
     footerLegalLinks.push(
       {
         url: supportURL,
@@ -195,7 +195,7 @@ const safeDecodeURIComponent = (value) => {
   }
 };
 
-const isMitxonlineCourse = () => {
+const isMITxOnlineCourse = () => {
   const href = (window.location?.href || document.URL || '').toLowerCase();
   const decodedHref = safeDecodeURIComponent(href);
   const isCourseKeyInPath = new RegExp(COURSE_KEY_REGEX, 'i').test(decodedHref);
@@ -221,11 +221,11 @@ const getUserMenu = ({ includeDashboard = false } = {}) => {
 
   // Build dashboard URL consistently with SecondaryMenu logic
   let dashboardURL = process.env.MIT_LEARN_BASE_URL ? `${process.env.MIT_LEARN_BASE_URL}/dashboard` : 'https://learn.mit.edu/dashboard';
-  if (isMitxonlineCourse()) {
+  if (isMITxOnlineCourse()) {
     dashboardURL = configData.MARKETING_SITE_BASE_URL ? `${configData.MARKETING_SITE_BASE_URL}/dashboard/` : 'https://mitxonline.mit.edu/dashboard/';
   }
 
-  if (!isMitxonlineCourse()) {
+  if (!isMITxOnlineCourse()) {
     const baseMenu = [
       {
         url: `${configData.LMS_BASE_URL}/logout`,
@@ -407,7 +407,7 @@ const addUserMenuSlotOverride = (config) => {
 }
 
 const addLearningCourseInfoSlotOverride = (config) => {
-  if (!isMitxonlineCourse()) {
+  if (!isMITxOnlineCourse()) {
   // Hiding the course org and number from the learning header in the UAI courses
     config.pluginSlots = {
       ...config.pluginSlots,
@@ -434,7 +434,7 @@ const addLearningCourseInfoSlotOverride = (config) => {
 }
 
 const modifyLogoHref = ( widget ) => {
-  if (isMitxonlineCourse()) {
+  if (isMITxOnlineCourse()) {
     widget.content.href = `${configData.MARKETING_SITE_BASE_URL}/dashboard/` || "https://mitxonline.mit.edu/dashboard/";
   } else {
     widget.content.href = `${process.env.MIT_LEARN_BASE_URL}/dashboard` || "https://learn.mit.edu/dashboard";
@@ -463,7 +463,7 @@ const addLogoSlotOverride = (config) => {
 
 const SecondaryMenu = () => {
   let dashboardURL = process.env.MIT_LEARN_BASE_URL ? `${process.env.MIT_LEARN_BASE_URL}/dashboard` : 'https://learn.mit.edu/dashboard';
-  if (isMitxonlineCourse()) {
+  if (isMITxOnlineCourse()) {
     dashboardURL = configData.MARKETING_SITE_BASE_URL ? `${configData.MARKETING_SITE_BASE_URL}/dashboard/` : 'https://mitxonline.mit.edu/dashboard/';
   }
 
@@ -544,7 +544,7 @@ const addEnvOverrides = (config) => {
       LOGO_URL: process.env.LOGO_URL.replace(/logo\.svg$/, 'old-logo.svg'),
     }
   }
-  if (!isMitxonlineCourse()) {
+  if (!isMITxOnlineCourse()) {
     return {
       ...config,
       SUPPORT_URL: process.env.CONTACT_URL || 'mailto:mitlearn-support@mit.edu',


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9834

### Description (What does it do?)
This PR updates the logic to use learn links by default in the MITxOnline/Learn MFEs header

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
- Visit an MFE page of a UAI course and verify the links in the header point to learn
- Visit an MFE page of a non-UAI course and verify the links in the header point to mitxonline
- Visit any page without a course key in the URL. Verify that the links in the header point to learn

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
