### PR TITLE
turn on video and news by default

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
@@ -158,6 +158,8 @@ raw_env_vars = {
     "NEXT_PUBLIC_SITE_NAME": "MIT Learn",
     "NEXT_PUBLIC_VERSION": MIT_LEARN_NEXTJS_DOCKER_TAG,
     "NEXT_PUBLIC_FEATURE_product_page_courses": "false",
+    "NEXT_PUBLIC_FEATURE_article_viewer": "true",
+    "NEXT_PUBLIC_FEATURE_video_shorts": "true",
     "NEXT_PUBLIC_FEATURE_enrollment_dashboard": "false",  # pragma: allowlist secret
     "NEXT_PUBLIC_FEATURE_lr_drawer_chatbot": "true",
     "NEXT_PUBLIC_FEATURE_home_page_recommendation_bot": "true",  # pragma: allowlist secret  # noqa: E501


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Sets some feature flag defaults for Learn

### How can this be tested?
Set these flags locally in Learn and block posthog in network devtools. News/video shorts should still show up.