### PR TITLE
Disable mitxonline dashboard sync

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.Production.yaml
@@ -57,7 +57,6 @@ config:
     DEBUG: "false"
     EDX_LEARNING_COURSE_BUCKET_NAME: "edxorg-production-edxapp-courses"
     ENABLE_INFINITE_CORRIDOR: "true"
-    FEATURE_SYNC_ON_DASHBOARD_LOAD: "True"
     GA_G_TRACKING_ID: "" # Missing?
     GA_TRACKING_ID: "" # Missing?
     INDEXING_API_USERNAME: "od_mm_prod_api"

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -338,6 +338,7 @@ mitxonline_vault_backend = OLVaultDatabaseBackend(mitxonline_vault_backend_confi
 env_vars = {
     "CRON_COURSERUN_SYNC_HOURS": "*",
     "FEATURE_IGNORE_EDX_FAILURES": "True",
+    "FEATURE_SYNC_ON_DASHBOARD_LOAD": "False",
     "HUBSPOT_PIPELINE_ID": "19817792",
     "MITOL_GOOGLE_SHEETS_REFUNDS_COMPLETED_DATE_COL": "12",
     "MITOL_GOOGLE_SHEETS_REFUNDS_ERROR_COL": "13",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Possibly related to one of the issues seen in https://github.com/mitodl/hq/issues/10443

### Description (What does it do?)
<!--- Describe your changes in detail -->
Disables a feature flag that causes the `/api/v1/enrollments/` API to synchronously synchronize enrollment data from openedx on what should be a simple `GET`.
