### PR TITLE
feat(superset): add allowed_schemas to governance roles

### DIFF
--- a/src/ol_infrastructure/applications/superset/ol_governance_roles.json
+++ b/src/ol_infrastructure/applications/superset/ol_governance_roles.json
@@ -226,6 +226,10 @@
           "name": "Charts"
         }
       }
+    ],
+    "allowed_schemas": [
+      "ol_warehouse_production_dimensional",
+      "ol_warehouse_production_mart"
     ]
   },
   {
@@ -535,6 +539,12 @@
           "name": "Datasets"
         }
       }
+    ],
+    "allowed_schemas": [
+      "ol_warehouse_production_intermediate",
+      "ol_warehouse_production_dimensional",
+      "ol_warehouse_production_mart",
+      "ol_warehouse_production_reporting"
     ]
   },
   {
@@ -844,6 +854,12 @@
           "name": "Datasets"
         }
       }
+    ],
+    "allowed_schemas": [
+      "ol_warehouse_production_intermediate",
+      "ol_warehouse_production_dimensional",
+      "ol_warehouse_production_mart",
+      "ol_warehouse_production_reporting"
     ]
   },
   {
@@ -1257,6 +1273,12 @@
           "name": "SQL Editor"
         }
       }
+    ],
+    "allowed_schemas": [
+      "ol_warehouse_production_intermediate",
+      "ol_warehouse_production_dimensional",
+      "ol_warehouse_production_mart",
+      "ol_warehouse_production_reporting"
     ]
   },
   {
@@ -2046,6 +2068,13 @@
           "name": "Manage"
         }
       }
+    ],
+    "allowed_schemas": [
+      "ol_warehouse_production_raw",
+      "ol_warehouse_production_intermediate",
+      "ol_warehouse_production_dimensional",
+      "ol_warehouse_production_mart",
+      "ol_warehouse_production_reporting"
     ]
   }
 ]


### PR DESCRIPTION
## Summary

Adds `allowed_schemas` to each role in `ol_governance_roles.json`, mapping Superset governance roles to the warehouse schemas (= data tiers) they are permitted to access, as defined in `ol_data_governance.md`.

| Role | Allowed schemas |
|------|----------------|
| `ol_instructor` | `dimensional`, `mart` (Gold tier only) |
| `ol_data_analyst` | `intermediate`, `dimensional`, `mart`, `reporting` |
| `ol_business_analyst` | `intermediate`, `dimensional`, `mart`, `reporting` |
| `ol_researcher` | `intermediate`, `dimensional`, `mart`, `reporting` |
| `ol_data_engineer` | `raw` + all of the above (all tiers) |

Schema = data tier, so any dataset added to a covered schema is automatically in scope for the correct roles on the next `ol-superset roles sync` — no per-dataset enumeration needed.

## Related PR

Companion CLI implementation: https://github.com/mitodl/ol-data-platform/pull/1980