### PR TITLE
config: enable DATES COURSE APP in the Pages and Resources page

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/config_builder.py
+++ b/src/ol_infrastructure/applications/edxapp/config_builder.py
@@ -538,6 +538,7 @@ def get_deployment_overrides(env_prefix: str) -> ConfigDict:
             "PLATFORM_NAME": "MIT Learn",
             "PLATFORM_DESCRIPTION": "MIT Learn",
             "PRESS_EMAIL": "support@mitxonline.mit.edu",
+            "ENABLE_DATES_COURSE_APP": True,
             "MITX_REDIRECT_ENABLED": True,
             "MITX_REDIRECT_ALLOW_RE_LIST": [
                 "^/(admin|auth|logout|register|api|oauth2|user_api|heartbeat|login_refresh|c4x|asset-v1:|assets/courseware/|lti_provider)",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8988

### Description (What does it do?)
This PR enables `ENABLE_DATES_COURSE_APP` to display the dates card in the Pages and Resources page.

### Screenshots (if appropriate):
<img width="1512" height="841" alt="Screenshot 2026-03-12 at 12 47 42 PM" src="https://github.com/user-attachments/assets/1ddf6104-fd31-405a-8383-ec8c7a42670a" />


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
