### PR TITLE
fix: auto select package name

### DIFF
--- a/dockerfiles/openedx-edxapp/pip_package_overrides/master/mitxonline.txt
+++ b/dockerfiles/openedx-edxapp/pip_package_overrides/master/mitxonline.txt
@@ -10,4 +10,4 @@ openai==2.15.0
 # Experimental Plugins for Translations feature
 # install at the end to override any dependency issues
 ol-openedx-course-translations
-ol-openedx-auto-language-select
+ol-openedx-auto-select-language


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
None

### Description (What does it do?)
<!--- Describe your changes in detail -->
Fixes the name of the auto select language plugin
