### PR TITLE
fix: enable inbound IPv6 for ALBs and fix Vault security group CIDR

### DIFF
--- a/src/ol_infrastructure/components/aws/olvpc.py
+++ b/src/ol_infrastructure/components/aws/olvpc.py
@@ -235,7 +235,7 @@ class OLVPC(ComponentResource):
             f"{vpc_config.vpc_name}-default-external-ipv6-network-route",
             route_table_id=self.route_table.id,
             destination_ipv6_cidr_block="::/0",
-            egress_only_gateway_id=self.egress_gateway.id,
+            gateway_id=self.gateway.id,
         )
 
         self.olvpc_subnets: list[ec2.Subnet] = []

--- a/src/ol_infrastructure/infrastructure/vault/__main__.py
+++ b/src/ol_infrastructure/infrastructure/vault/__main__.py
@@ -328,7 +328,7 @@ vault_security_group = ec2.SecurityGroup(
             from_port=VAULT_HTTP_PORT,
             to_port=VAULT_HTTP_PORT,
             cidr_blocks=["0.0.0.0/0"],
-            ipv6_cidr_blocks=["0::/0"],
+            ipv6_cidr_blocks=["::/0"],
             description="Allow traffic to Vault server API endpoints",
         ),
     ],


### PR DESCRIPTION
## Problem

Vault (and all other services with dualstack ALBs) times out for clients on IPv6-default networks. IPv4 connections succeed immediately.

## Root Cause

Two bugs were found:

### 1. Egress-Only Internet Gateway on the main VPC route table (`olvpc.py`)

The main route table shared by all public subnets was routing IPv6 (`::/0`) through an **Egress-Only Internet Gateway**. This gateway only permits *outbound* IPv6 — it is the IPv6 equivalent of a NAT gateway. As a result, dualstack ALBs sitting in these subnets could never accept inbound IPv6 connections from the internet, causing the observed timeouts.

**Fix:** Route IPv6 through the regular Internet Gateway on the main route table. The k8s private subnet route tables correctly retain the egress-only gateway (outbound-only is appropriate for private subnets).

### 2. Invalid IPv6 CIDR in Vault security group (`vault/__main__.py`)

The Vault server security group specified `"0::/0"` instead of the standard `"::/0"` for the IPv6 CIDR on port 8200. This non-standard notation is not recognized as "all IPv6 addresses" by AWS.

## Changes

- `src/ol_infrastructure/components/aws/olvpc.py`: Main route table IPv6 route now uses the Internet Gateway (`gateway_id`) instead of the Egress-Only Internet Gateway
- `src/ol_infrastructure/infrastructure/vault/__main__.py`: Fix `"0::/0"` → `"::/0"` in the Vault server security group ingress rule

## Impact

The `olvpc.py` change affects all VPCs and their ALBs. All dualstack ALBs will now be reachable over IPv6. Security groups on EC2 instances continue to control what inbound traffic is allowed at the instance level.

## Testing

Run `pulumi preview` against the `infrastructure.aws.network` stack to review the route table update before deploying.