### PR TITLE
feat: Add k8s labels to OTEL traces

### DIFF
--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -852,6 +852,39 @@ learn_ai_app_k8s = OLApplicationK8s(
     ),
 )
 
+# Reconstruct variables needed for Celery deployment
+application_image_repository_and_tag = f"mitodl/learn-ai-app:{LEARN_AI_DOCKER_TAG}"
+
+learn_ai_deployment_env_vars = []
+for k, v in (learn_ai_config.require_object("env_vars") or {}).items():
+    learn_ai_deployment_env_vars.append(
+        kubernetes.core.v1.EnvVarArgs(
+            name=k,
+            value=v,
+        )
+    )
+
+# Build a list of sensitive env vars for the deployment config via envFrom
+learn_ai_deployment_envfrom = [
+    # Database creds
+    kubernetes.core.v1.EnvFromSourceArgs(
+        secret_ref=kubernetes.core.v1.SecretEnvSourceArgs(
+            name=db_creds_secret_name,
+        ),
+    ),
+    # Redis Configuration
+    kubernetes.core.v1.EnvFromSourceArgs(
+        secret_ref=kubernetes.core.v1.SecretEnvSourceArgs(
+            name=redis_creds_secret_name,
+        ),
+    ),
+    # static secrets from secrets-learn-ai/secrets
+    kubernetes.core.v1.EnvFromSourceArgs(
+        secret_ref=kubernetes.core.v1.SecretEnvSourceArgs(
+            name=static_secrets_name,
+        ),
+    ),
+]
 
 # Create the apisix custom resources since it doesn't support gateway-api yet
 


### PR DESCRIPTION
Adds the OTEL_ENTITITES variable to the learn_ai runtime set to appropriately format key/value pairs.

### What are the relevant tickets?
Part of #4310

### Description (What does it do?)
Adds Pulumi code to set OTEL_ENTITIES environment variable at application runtime to contain the Kubernetes labels we're using for the app.

### How can this be tested?

Pulumi up details:
```
            [provider=urn:pulumi:applications.learn_ai.QA::ol-infrastructure-learn_ai-application::pulumi:providers:kubernetes::k8s-provider::f40d776f-1bb9-4e9c-a44b-a21bb986fc62]
          ~ spec: {
              ~ template: {
                  ~ spec: {
                      ~ containers    : [
                          ~ [1]: {
                                  ~ env            : [
                                      ~ [52]: {
                                              ~ name : "PORT" => "OTEL_ENTITIES"
                                              ~ value: "8073" => "mitol.deployment{ol.mit.edu/stack=applications.learn_ai.QA}[ol.mit.edu/ou=mit-learn,ol.mit.edu/service=mit-learn,ol.mit.edu/environment=qa]"
```
