### PR TITLE
fix: add studio as CSRF_TRUSTED_ORIGINS for MIT Learn Open edX

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -256,7 +256,10 @@ def _build_interpolated_config_dict(
 
     # MITx Online-specific configuration
     elif stack_info.env_prefix == "mitxonline":
-        config["CSRF_TRUSTED_ORIGINS"] = [f"https://{domains['lms']}"]
+        config["CSRF_TRUSTED_ORIGINS"] = [
+            f"https://{domains['lms']}",
+            f"https://{domains['studio']}",
+        ]
         config.update(
             {
                 "COURSE_ABOUT_VISIBILITY_PERMISSION": "see_about_page",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/hq/issues/10580

### Description (What does it do?)
<!--- Describe your changes in detail -->
Adds studio domain in CORS_ALLOWED_ORIGINS for MIT Learn Open edX

