### PR TITLE
fix(k8s): improve OLApplicationK8s deployment reliability

### DIFF
--- a/src/ol_infrastructure/components/services/k8s.py
+++ b/src/ol_infrastructure/components/services/k8s.py
@@ -323,12 +323,13 @@ class OLApplicationK8sConfig(BaseModel):
     )
     resource_requests: dict[str, str] = Field(default={"cpu": "250m", "memory": "1Gi"})
     resource_limits: dict[str, str] = Field(default={"memory": "1Gi"})
-    deployment_timeout_minutes: int = Field(
+    deployment_timeout_minutes: PositiveInt = Field(
         default=15,
         description=(
-            "Minutes Pulumi will wait for the Deployment and Service to become ready "
-            "before marking the update as failed. Increase for applications with known "
-            "slow rollouts. Pulumi's built-in default is 10 minutes."
+            "Minutes Pulumi will wait for the webapp Deployment and its Service to "
+            "become ready before marking the update as failed. Does not affect celery "
+            "worker or beat Deployments. Increase for applications with known slow "
+            "rollouts. Pulumi's built-in default is 10 minutes."
         ),
     )
     init_migrations: bool = Field(default=True)


### PR DESCRIPTION
## Problem

Intermittent `kubernetes:core/v1:Service timed out waiting to be Ready` errors during Pulumi deployments, e.g.:

```
kubernetes:core/v1:Service (mitxonline-application-ci-service): error: 1 error occurred:
  * the Kubernetes API server reported that "mitxonline/mitxonline-webapp" failed to
    fully initialize or become live: 'mitxonline-webapp' timed out waiting to be Ready
```

## Root Cause

The `pulumi-kubernetes` provider waits for **all Service endpoint pods to be Ready** before marking a Service resource as done (10-minute default timeout). The `_application_service` and `_application_deployment` were created **in parallel** — so the Service's 10-minute clock started ticking at the same moment as the rolling update. On slow runs (image pull cache miss, heavy DB migration, resource contention) the Service timer expired before pods became Ready, causing an intermittent failure.

## Changes

### 1. `depends_on=[_application_deployment]` on Service *(primary fix)*

Serializes the readiness check: the Service's endpoint health check only starts *after* the Deployment has fully rolled out. By that point all pods are already Ready, so the check passes immediately.

**Before:**
```
Pre-Deploy Job → Deployment ‖ Service   ← parallel, Service timer racing rollout ❌
```

**After:**
```
Pre-Deploy Job → Deployment → Service   ← Service check starts after all pods Ready ✅
```

### 2. `CustomTimeouts(create/update=15m)` on Deployment and Service

Raises Pulumi's hard ceiling from 10 min to 15 min as a safety net for legitimately slow deployments.

### 3. New `deployment_timeout_minutes: int = Field(default=15)` on `OLApplicationK8sConfig`

Allows per-application tuning without touching the component.

### 4. Startup probe `failure_threshold` 6 → 12 (60 s → 120 s)

The original 60-second startup window was too tight for complex Django apps. A pod restart due to a missed startup probe extends the rollout and compounds the timeout problem. Doubling the window reduces unnecessary restarts. The full `probe_configs` field remains overridable for apps that need a different value.

## Testing

- All 118 existing tests pass
- All pre-commit hooks pass (ruff format, ruff check, mypy)