### PR TITLE
Add APISIX route for cart endpoints

### DIFF
--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -792,6 +792,7 @@ mitxonline_apisix_route_prefix = OLApisixRoute(
             paths=[
                 f"/{api_path_prefix}/cart/",
                 f"/{api_path_prefix}/cart",
+                f"/{api_path_prefix}/cart/*",
             ],
             plugins=[
                 proxy_rewrite_plugin_config,


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10558

### Description (What does it do?)
Add OLApisixRouteConfig for cart endpoints to mitxonline APISIX routes

