### PR TITLE
Move cart route to direct APISIX route

### DIFF
--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -732,8 +732,7 @@ mitxonline_apisix_route_direct = OLApisixRoute(
                 "/cart/*",
             ],
             plugins=[
-                proxy_rewrite_plugin_config,
-                mitxonline_prefixed_oidc_resources.get_full_oidc_plugin_config(
+                mitxonline_direct_oidc.get_full_oidc_plugin_config(
                     unauth_action="auth"
                 ),
                 response_rewrite_plugin_config,


### PR DESCRIPTION
Add a 'cart' OLApisixRouteConfig to the mitxonline_apisix_route_direct config (hosts: api_domain, frontend_domain; paths: /cart, /cart/*; priority 20) with the same plugins and backend settings, and remove the corresponding prefixed cart route from mitxonline_apisix_route_prefix (the /{api_path_prefix}/cart entries). This shifts the cart endpoints from the prefixed learn domain to the unprefixed API/frontend domains to avoid the duplicated/prefixed route.

### What are the relevant tickets?
https://github.com/mitodl/ol-infrastructure/pull/4324

### Description (What does it do?)
This PR should fix the prior PR that attempted to add auth to the cart page in mitxonline.

