### PR TITLE
Fix Keycloak metrics

### DIFF
--- a/src/ol_infrastructure/applications/keycloak/__main__.py
+++ b/src/ol_infrastructure/applications/keycloak/__main__.py
@@ -507,7 +507,7 @@ keycloak_service_monitor = kubernetes.apiextensions.CustomResource(
         "selector": {
             "matchLabels": {
                 "app": "keycloak",
-                "keycloak": keycloak_resource_name,
+                "app.kubernetes.io/instance": keycloak_resource_name,
             }
         },
         "endpoints": [


### PR DESCRIPTION
Fix Keycloak ServiceMonitor selector to match operator-generated Service labels

## Problem

Keycloak metrics (sessions, logins, JVM stats, etc.) have never appeared in
Grafana/Mimir despite `metrics-enabled: true` being set in the Keycloak operator
spec. The ServiceMonitor was silently matching zero Services, so Alloy never
scraped anything.

The root cause is a label mismatch. The ServiceMonitor selector required:

    matchLabels:
      app: keycloak
      keycloak: keycloak-production

But the Keycloak Operator creates its Service with standard Kubernetes labels:

    labels:
      app: keycloak
      app.kubernetes.io/instance: keycloak-production
      app.kubernetes.io/managed-by: keycloak-operator

The label `keycloak: keycloak-production` does not exist on any Service in the
cluster. Because selector.matchLabels requires all labels to match, the selector
returned zero results and Alloy had nothing to scrape.

## Fix

Replace the incorrect `keycloak:` label with `app.kubernetes.io/instance:` in
the ServiceMonitor selector, matching the label the Keycloak Operator actually
applies to its generated Service.

## Impact

After deploying this change, Alloy will correctly target the
`keycloak-production-service` Service and scrape the Keycloak management port
(`/metrics` on port 9000) every 30 seconds. Keycloak metrics will begin flowing
into Mimir within ~1 minute of rollout.

## Testing

After `pulumi up` on the `applications.keycloak.Production` stack, verify the
scrape target is live:

    kubectl port-forward -n grafana svc/grafana-k8s-monitoring-alloy-metrics 12345:12345
    # Open http://localhost:12345/targets
    # keycloak namespace entries should appear with status UP

Then confirm metrics are flowing in Grafana Explore:

    keycloak_active_sessions