### PR TITLE
feat: enable taxonomy flag for the learn openedx authoring MFE ci

### DIFF
--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -77,6 +77,7 @@ class OpenEdxVars(BaseModel):
     enable_ai_drawer_slot: Literal["true", "false"] | None = None
     appzi_url: str | None = None
     enable_auto_language_selection: Literal["true", "false"] | None = None
+    enable_tagging_taxonomy_pages: Literal["true", "false"] | None = None
 
     @property
     def release_name(self) -> OpenEdxSupportedRelease:
@@ -144,6 +145,7 @@ def mfe_params(
             open_edx.enable_video_upload_page_link_in_content_dropdown
         ),
         "ENABLE_AUTO_LANGUAGE_SELECTION": (open_edx.enable_auto_language_selection),
+        "ENABLE_TAGGING_TAXONOMY_PAGES": (open_edx.enable_tagging_taxonomy_pages),
         "PARAGON_THEME_URLS": "{}",
         "ENABLE_JUMPNAV": open_edx.enable_jumpnav,
         "ENABLE_AI_DRAWER_SLOT": open_edx.enable_ai_drawer_slot,

--- a/src/ol_concourse/pipelines/open_edx/mfe/values.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/values.py
@@ -131,6 +131,7 @@ mitxonline = [
         enable_jumpnav="true",
         enable_ai_drawer_slot="true",
         enable_auto_language_selection="true",
+        enable_tagging_taxonomy_pages="true",
     ),
     OpenEdxVars(
         about_us_url="https://rc.mitxonline.mit.edu/about-us/",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Closes https://github.com/mitodl/hq/issues/10654

### Description (What does it do?)
<!--- Describe your changes in detail -->
Enables ENABLE_TAGGING_TAXONOMY_PAGES for Authoring MFE Learn OpenedX CI


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

- Enable this locally and verify that you see a taxonomy tab in authoring homepage