### PR TITLE
set CREATE_OCW_LEARNING_MATERIALS true on rc

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.QA.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.QA.yaml
@@ -51,6 +51,7 @@ config:
     CANVAS_COURSE_BUCKET_NAME: "ol-data-lake-landing-zone-production"
     COURSE_ARCHIVE_BUCKET_NAME: "ol-data-lake-landing-zone-qa"
     CELERY_WORKER_CONCURRENCY: 1
+    CREATE_OCW_LEARNING_MATERIALS: "true"
     CSRF_COOKIE_NAME: "learn_rc_csrftoken"
     DEBUG: "false"
     EDX_LEARNING_COURSE_BUCKET_NAME: "edxorg-production-edxapp-courses"


### PR DESCRIPTION
### What are the relevant tickets?
learn pr https://github.com/mitodl/mit-learn/pull/3103
learn ticket https://github.com/mitodl/hq/issues/10657

### Description (What does it do?)
this pr adds a flag to learn. The default is False so it just needs to be set to true on RC

