### PR TITLE
Add Fastly redirects for UAI B2C product pages to MIT Learn

### DIFF
--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -813,8 +813,7 @@ mitxonline_apisix_route_prefix = OLApisixRoute(
 )
 
 ## Fastly Service
-# UAI B2C paths that should redirect to MIT Learn. The last entry (UAI.ENT.1) is
-# intentionally omitted because its source and target are the same.
+# UAI B2C paths that should redirect to MIT Learn.
 uai_b2c_redirects: dict[str, str] = {
     "/programs/program-v1:UAI+B2C/": f"https://{learn_frontend_domain}/programs/program-v1:UAI+B2C",
     "/programs/program-v1:UAI+B2C.1/": f"https://{learn_frontend_domain}/courses/p/program-v1:UAI+B2C.1",
@@ -826,9 +825,10 @@ uai_b2c_redirects: dict[str, str] = {
     "/courses/course-v1:UAI_SOURCE+UAI.MLTL.1/": f"https://{learn_frontend_domain}/courses/course-v1:UAI_SOURCE+UAI.MLTL.1",
     "/courses/course-v1:UAI_SOURCE+UAI.PM.1/": f"https://{learn_frontend_domain}/courses/course-v1:UAI_SOURCE+UAI.PM.1",
     "/courses/course-v1:UAI_SOURCE+UAI.ST.1/": f"https://{learn_frontend_domain}/courses/course-v1:UAI_SOURCE+UAI.ST.1",
+    "/courses/course-v1:UAI_SOURCE+UAI.ENT.1/": f"https://{learn_frontend_domain}/courses/course-v1:UAI_SOURCE+UAI.ENT.1",
 }
 uai_b2c_redirect_vcl = "\n".join(
-    f'if (req.url == "{path}") {{\n'
+    f'if (req.url.path == "{path}") {{\n'
     f'  set req.http.x-redir-location = "{target}";\n'
     f"  error 602;\n"
     f"}}"
@@ -933,6 +933,13 @@ mitxonline_service = fastly.ServiceVcl(
               set obj.status = 301;
               set obj.response = "Moved Permanently";
               set obj.http.Location = req.http.x-redir-location;
+              if (req.url.qs != "") {
+                if (obj.http.Location !~ "\\?") {
+                  set obj.http.Location = obj.http.Location "?" req.url.qs;
+                } else {
+                  set obj.http.Location = obj.http.Location "&" req.url.qs;
+                }
+              }
               return(deliver);
             }"""),
             name="Handle UAI B2C external redirects",


### PR DESCRIPTION
### What are the relevant tickets?
Closes mitodl/hq#10701

### Description (What does it do?)
Adds 301 redirects in the MITx Online Fastly service for UAI B2C product pages, sending them to their counterparts on learn.mit.edu (or rc.learn.mit.edu on RC). When the UAI B2C program launches on 3/31, the mitxonline.mit.edu product pages will silently redirect visitors to the canonical MIT Learn pages.

**Redirects added (10 paths):**
- `/programs/program-v1:UAI+B2C/` → `{learn_domain}/programs/program-v1:UAI+B2C`
- `/programs/program-v1:UAI+B2C.{1-5}/` → `{learn_domain}/courses/p/program-v1:UAI+B2C.{1-5}`
- `/courses/course-v1:UAI_SOURCE+UAI.SE.1/` → `{learn_domain}/courses/course-v1:UAI_SOURCE+UAI.SE.1`
- `/courses/course-v1:UAI_SOURCE+UAI.MLTL.1/` → `{learn_domain}/courses/course-v1:UAI_SOURCE+UAI.MLTL.1`
- `/courses/course-v1:UAI_SOURCE+UAI.PM.1/` → `{learn_domain}/courses/course-v1:UAI_SOURCE+UAI.PM.1`
- `/courses/course-v1:UAI_SOURCE+UAI.ST.1/` → `{learn_domain}/courses/course-v1:UAI_SOURCE+UAI.ST.1`

Note: `UAI.ENT.1` is intentionally excluded — its source and target are the same domain.

**Implementation:**
- Derives `learn_frontend_domain` from the existing `learn_backend_domain` config by stripping the `api.` prefix (e.g. `api.rc.learn.mit.edu` → `rc.learn.mit.edu`)
- Adds a VCL `recv` snippet (priority 100, runs before media routing at 200) that matches each path exactly and stores the target URL in `req.http.x-redir-location`, then triggers `error 602`
- Adds a VCL `error` snippet that intercepts status 602 and delivers a `301 Moved Permanently` response with the correct `Location` header

### How can this be tested?
1. Deploy to RC (`applications.mitxonline.QA` stack)
2. Curl or visit each source URL on `rc.mitxonline.mit.edu` and confirm a 301 redirect to the corresponding `rc.learn.mit.edu` URL
3. Confirm `/courses/course-v1:UAI_SOURCE+UAI.ENT.1/` does **not** redirect
4. Confirm unrelated pages (e.g. `/`, `/courses/`) are unaffected