### PR TITLE
Set OCW_EXTRA_COURSE_THEMES to v3 for prod

### DIFF
--- a/src/ol_infrastructure/applications/ocw_studio/Pulumi.applications.ocw_studio.Production.yaml
+++ b/src/ol_infrastructure/applications/ocw_studio/Pulumi.applications.ocw_studio.Production.yaml
@@ -25,6 +25,7 @@ config:
     MIT_LEARN_API_BASE_URL: https://api.learn.mit.edu
     MIT_LEARN_BASE_URL: https://learn.mit.edu
     OCW_COURSE_STARTER_SLUG: ocw-course-v2
+    OCW_EXTRA_COURSE_THEMES: ocw-course-v3
     OCW_GTM_ACCOUNT_ID: GTM-NMQZ25T
     OCW_HUGO_THEMES_SENTRY_DSN: 'https://eee58f41dda54d2b814296e12dced4b7@o48788.ingest.sentry.io/5304953'
     OCW_IMPORT_STARTER_SLUG: ocw-course


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/10579.

### Description (What does it do?)
This PR sets the variable `OCW_EXTRA_COURSE_THEMES` to `ocw-course-v3` for production, allowing for the v3 theme courses to be published in production alongside the v2 theme courses.

### How can this be tested?
This can be tested by verifying that the variables for production are being set correctly; once pipelines are backpopulated in production, the relevant v3 pipelines will appear.

### Additional Context
Previous PR setting this value to empty: https://github.com/mitodl/ol-infrastructure/pull/4130.