### PR TITLE
config: update xPRO RC domain

### DIFF
--- a/src/ol_infrastructure/applications/xpro/Pulumi.applications.xpro.QA.yaml
+++ b/src/ol_infrastructure/applications/xpro/Pulumi.applications.xpro.QA.yaml
@@ -51,7 +51,7 @@ config:
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa
   xpro:app_domain: rc.xpro.mit.edu
-  xpro:backend_domain: "rc.xpro.mit.edu"
+  xpro:backend_domain: "xpro-rc.odl.mit.edu"
   xpro:frontend_domain: "rc.xpro.mit.edu"
   xpro:db_password:
     secure: v1:W6DusspG9IcM4g6H:HvfOZra3mL7KU/JYUFzcDUj0YrFD7EQJTAwkceVjI1ajCVmLUlj8kiTNYL5IOcW7KK0gmAcnkJHzzCE=


### PR DESCRIPTION
### What are the relevant tickets?
None, noticed it while testing https://github.com/mitodl/mitxpro/pull/3859
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
The verify account link in the email points to the `xpro-rc` domain instead of `rc.xpro`. 

As a reference, when you visit https://rc.xpro.mit.edu/ and sign up for a new account, the verify account email has a link with `xpro-rc` instead of `rc.xpro`. What happens in this case is that the user gets registered on RC, but when they visit dashboard, they are linked back to the login because the session is not created for `rc.xpro` instead it had been created for xpro-rc.
<!--- Describe your changes in detail -->

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
