### PR TITLE
feat(mit-learn): add Fastly shielding toggle and increase first_byte_timeout to 30s

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.CI.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.CI.yaml
@@ -42,6 +42,7 @@ config:
   mitlearn:nextjs_heroku_domain: "next.ci.learn.mit.edu"
   mitlearn:posthog_proxy: "ph.ol.mit.edu"
   mitlearn:support_url: "support.ci.learn.mit.edu"
+  mitlearn:enable_fastly_shielding: true
   mitlearn:use_granian: true
   mitlearn:vars:
     AI_MIT_SYLLABUS_URL: "https://api.ci.learn.mit.edu/api/v0/vector_content_files_search/"

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.QA.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.QA.yaml
@@ -41,6 +41,7 @@ config:
   mitlearn:nextjs_heroku_domain: "next.rc.learn.mit.edu"
   mitlearn:posthog_proxy: "ph.ol.mit.edu"
   mitlearn:support_url: "support.qa.learn.mit.edu"
+  mitlearn:enable_fastly_shielding: true
   mitlearn:use_granian: true
   mitlearn:vars:
     AI_MIT_SYLLABUS_URL: "https://api.rc.learn.mit.edu/api/v0/vector_content_files_search/"

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -849,6 +849,7 @@ for k, v in mimetypes.types_map.items():
     ):
         gzip_settings["extensions"].add(k.strip("."))
         gzip_settings["content_types"].add(v)
+fastly_shielding_enabled = mitlearn_config.get_bool("enable_fastly_shielding") or False
 bucket_backend_name = "MIT Learn S3 Media Storage"
 mitlearn_fastly_service = fastly.ServiceVcl(
     f"fastly-{stack_info.env_prefix}-{stack_info.env_suffix}",
@@ -858,8 +859,10 @@ mitlearn_fastly_service = fastly.ServiceVcl(
         fastly.ServiceVclBackendArgs(
             address=nextjs_heroku_domain,
             name="NextJS_Frontend",
+            first_byte_timeout=30000,
             override_host=nextjs_heroku_domain,
             port=DEFAULT_HTTPS_PORT,
+            shield="iad-va-us" if fastly_shielding_enabled else None,
             ssl_cert_hostname=nextjs_heroku_domain,
             ssl_sni_hostname=nextjs_heroku_domain,
             use_ssl=True,
@@ -867,9 +870,11 @@ mitlearn_fastly_service = fastly.ServiceVcl(
         fastly.ServiceVclBackendArgs(
             address=f"{mitlearn_app_storage_bucket_name}.s3.us-east-1.amazonaws.com",
             name=bucket_backend_name,
+            first_byte_timeout=30000,
             override_host=f"{mitlearn_app_storage_bucket_name}.s3.us-east-1.amazonaws.com",
             port=443,
             request_condition="Media asset requests",
+            shield="iad-va-us" if fastly_shielding_enabled else None,
             ssl_cert_hostname=f"{mitlearn_app_storage_bucket_name}.s3.us-east-1.amazonaws.com",
             ssl_sni_hostname=f"{mitlearn_app_storage_bucket_name}.s3.us-east-1.amazonaws.com",
             use_ssl=True,


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Improves the MIT Learn Fastly distribution in two ways:

1. **Fastly shielding**: Adds a `mitlearn:enable_fastly_shielding` stack config flag. When `true`, both the `NextJS_Frontend` and `MIT Learn S3 Media Storage` backends route through the `iad-va-us` shield POP (IAD/Dulles, VA — consistent with the OCW and xpro services). Enabled by default for CI and QA; Production remains off until validated.

2. **First-byte timeout**: Increases `first_byte_timeout` from the Fastly default (15 000 ms) to 30 000 ms on both backends, giving the NextJS app and S3 more headroom for slow responses.

No VCL changes were required — all existing snippets are idempotent (cookie unsetting, boolean flags, path redirects via `error 601`), and both backends already use `override_host`, so there are no host-header or double-execution gotchas with shielding enabled.

To enable on Production: `pulumi config set mitlearn:enable_fastly_shielding true`

### How can this be tested?
- Run `pulumi preview` against the CI or QA stack and confirm the two backends gain a `shield = iad-va-us` property and `first_byte_timeout = 30000`.
- Deploy to CI/QA and verify the Fastly service activates without errors; check that cache hit ratio and origin request counts improve over time.