### PR TITLE
Add K8s labels into OTEL spans

### DIFF
--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -79,7 +79,10 @@ from ol_infrastructure.lib.ol_types import (
     KubernetesServiceAppProtocol,
     Services,
 )
-from ol_infrastructure.lib.pulumi_helper import parse_stack
+from ol_infrastructure.lib.pulumi_helper import (
+    merge_otel_resource_attributes,
+    parse_stack,
+)
 from ol_infrastructure.lib.stack_defaults import defaults
 from ol_infrastructure.lib.vault import setup_vault_provider
 
@@ -734,11 +737,7 @@ env_vars = dict(learn_ai_config.require_object("env_vars") or {})
 
 # Unconditionally append k8s labels to OTEL_RESOURCE_ATTRIBUTES so all metrics
 # carry organizational metadata regardless of stack environment.
-k8s_label_attrs = ",".join(f"{k}={v}" for k, v in k8s_global_labels.items())
-base_otel = env_vars.get("OTEL_RESOURCE_ATTRIBUTES")
-env_vars["OTEL_RESOURCE_ATTRIBUTES"] = (
-    f"{base_otel},{k8s_label_attrs}" if base_otel else k8s_label_attrs
-)
+merge_otel_resource_attributes(env_vars, k8s_global_labels)
 
 # Instantiate the OLApplicationK8s component
 learn_ai_app_k8s = OLApplicationK8s(

--- a/src/ol_infrastructure/applications/micromasters/__main__.py
+++ b/src/ol_infrastructure/applications/micromasters/__main__.py
@@ -82,7 +82,10 @@ from ol_infrastructure.lib.ol_types import (
     K8sGlobalLabels,
     Services,
 )
-from ol_infrastructure.lib.pulumi_helper import parse_stack
+from ol_infrastructure.lib.pulumi_helper import (
+    merge_otel_resource_attributes,
+    parse_stack,
+)
 from ol_infrastructure.lib.stack_defaults import defaults
 from ol_infrastructure.lib.vault import setup_vault_provider
 
@@ -1008,11 +1011,7 @@ if micromasters_config.get_bool("deploy_k8s"):
 
     # Unconditionally append k8s labels to OTEL_RESOURCE_ATTRIBUTES so all metrics
     # carry organizational metadata regardless of stack environment.
-    k8s_label_attrs = ",".join(f"{k}={v}" for k, v in k8s_global_labels.items())
-    base_otel = k8s_env_vars.get("OTEL_RESOURCE_ATTRIBUTES")
-    k8s_env_vars["OTEL_RESOURCE_ATTRIBUTES"] = (
-        f"{base_otel},{k8s_label_attrs}" if base_otel else k8s_label_attrs
-    )
+    merge_otel_resource_attributes(k8s_env_vars, k8s_global_labels)
 
     micromasters_k8s_app = OLApplicationK8s(
         ol_app_k8s_config=OLApplicationK8sConfig(

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -85,7 +85,10 @@ from ol_infrastructure.lib.ol_types import (
     Product,
     Services,
 )
-from ol_infrastructure.lib.pulumi_helper import parse_stack
+from ol_infrastructure.lib.pulumi_helper import (
+    merge_otel_resource_attributes,
+    parse_stack,
+)
 from ol_infrastructure.lib.stack_defaults import defaults
 from ol_infrastructure.lib.vault import postgres_role_statements, setup_vault_provider
 
@@ -1218,11 +1221,7 @@ env_vars.update(**mitlearn_config.get_object("vars"))
 
 # Unconditionally append k8s labels to OTEL_RESOURCE_ATTRIBUTES so all metrics
 # carry organizational metadata regardless of stack environment.
-k8s_label_attrs = ",".join(f"{k}={v}" for k, v in k8s_app_labels.items())
-base_otel = env_vars.get("OTEL_RESOURCE_ATTRIBUTES")
-env_vars["OTEL_RESOURCE_ATTRIBUTES"] = (
-    f"{base_otel},{k8s_label_attrs}" if base_otel else k8s_label_attrs
-)
+merge_otel_resource_attributes(env_vars, k8s_app_labels)
 
 # Making these `get_secret_*()` calls children of the seemigly un-related vault mount `secret-mitopen/` tricks
 # them into inheriting the correct vault provider rather than attempting to create their own (which won't work and / or

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -85,7 +85,10 @@ from ol_infrastructure.lib.ol_types import (
     Product,
     Services,
 )
-from ol_infrastructure.lib.pulumi_helper import parse_stack
+from ol_infrastructure.lib.pulumi_helper import (
+    merge_otel_resource_attributes,
+    parse_stack,
+)
 from ol_infrastructure.lib.stack_defaults import defaults
 from ol_infrastructure.lib.vault import setup_vault_provider
 
@@ -365,11 +368,7 @@ env_vars.update(**mitxonline_config.get_object("vars"))
 
 # Unconditionally append k8s labels to OTEL_RESOURCE_ATTRIBUTES so all metrics
 # carry organizational metadata regardless of stack environment.
-k8s_label_attrs = ",".join(f"{k}={v}" for k, v in k8s_app_labels.items())
-base_otel = env_vars.get("OTEL_RESOURCE_ATTRIBUTES")
-env_vars["OTEL_RESOURCE_ATTRIBUTES"] = (
-    f"{base_otel},{k8s_label_attrs}" if base_otel else k8s_label_attrs
-)
+merge_otel_resource_attributes(env_vars, k8s_app_labels)
 
 # All of the secrets for this app must be obtained with async incantations
 

--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -75,7 +75,10 @@ from ol_infrastructure.lib.ol_types import (
     Product,
     Services,
 )
-from ol_infrastructure.lib.pulumi_helper import parse_stack
+from ol_infrastructure.lib.pulumi_helper import (
+    merge_otel_resource_attributes,
+    parse_stack,
+)
 from ol_infrastructure.lib.stack_defaults import defaults
 from ol_infrastructure.lib.vault import setup_vault_provider
 
@@ -565,11 +568,7 @@ app_env_vars["POSTHOG_API_HOST"] = app_env_vars.pop(
 
 # Unconditionally append k8s labels to OTEL_RESOURCE_ATTRIBUTES so all metrics
 # carry organizational metadata regardless of stack environment.
-k8s_label_attrs = ",".join(f"{k}={v}" for k, v in k8s_app_labels.items())
-base_otel = app_env_vars.get("OTEL_RESOURCE_ATTRIBUTES")
-app_env_vars["OTEL_RESOURCE_ATTRIBUTES"] = (
-    f"{base_otel},{k8s_label_attrs}" if base_otel else k8s_label_attrs
-)
+merge_otel_resource_attributes(app_env_vars, k8s_app_labels)
 
 if "OCW_STUDIO_DOCKER_TAG" not in os.environ:
     msg = "OCW_STUDIO_DOCKER_TAG must be set."

--- a/src/ol_infrastructure/applications/odl_video_service/__main__.py
+++ b/src/ol_infrastructure/applications/odl_video_service/__main__.py
@@ -72,7 +72,10 @@ from ol_infrastructure.lib.ol_types import (
     Product,
     Services,
 )
-from ol_infrastructure.lib.pulumi_helper import parse_stack
+from ol_infrastructure.lib.pulumi_helper import (
+    merge_otel_resource_attributes,
+    parse_stack,
+)
 from ol_infrastructure.lib.stack_defaults import defaults
 from ol_infrastructure.lib.vault import setup_vault_provider
 
@@ -781,11 +784,7 @@ app_env_vars.update(k8s_extra_vars)
 
 # Unconditionally append k8s labels to OTEL_RESOURCE_ATTRIBUTES so all metrics
 # carry organizational metadata regardless of stack environment.
-k8s_label_attrs = ",".join(f"{k}={v}" for k, v in k8s_app_labels.items())
-base_otel = app_env_vars.get("OTEL_RESOURCE_ATTRIBUTES")
-app_env_vars["OTEL_RESOURCE_ATTRIBUTES"] = (
-    f"{base_otel},{k8s_label_attrs}" if base_otel else k8s_label_attrs
-)
+merge_otel_resource_attributes(app_env_vars, k8s_app_labels)
 
 if "ODL_VIDEO_SERVICE_DOCKER_TAG" not in os.environ:
     msg = "ODL_VIDEO_SERVICE_DOCKER_TAG must be set."

--- a/src/ol_infrastructure/applications/xpro/__main__.py
+++ b/src/ol_infrastructure/applications/xpro/__main__.py
@@ -79,7 +79,10 @@ from ol_infrastructure.lib.ol_types import (
     Product,
     Services,
 )
-from ol_infrastructure.lib.pulumi_helper import parse_stack
+from ol_infrastructure.lib.pulumi_helper import (
+    merge_otel_resource_attributes,
+    parse_stack,
+)
 from ol_infrastructure.lib.stack_defaults import defaults
 from ol_infrastructure.lib.vault import setup_vault_provider
 
@@ -500,11 +503,7 @@ if k8s_deploy:
 
     # Unconditionally append k8s labels to OTEL_RESOURCE_ATTRIBUTES so all metrics
     # carry organizational metadata regardless of stack environment.
-    k8s_label_attrs = ",".join(f"{k}={v}" for k, v in k8s_app_labels.items())
-    base_otel = app_env_vars.get("OTEL_RESOURCE_ATTRIBUTES")
-    app_env_vars["OTEL_RESOURCE_ATTRIBUTES"] = (
-        f"{base_otel},{k8s_label_attrs}" if base_otel else k8s_label_attrs
-    )
+    merge_otel_resource_attributes(app_env_vars, k8s_app_labels)
 
     if "XPRO_DOCKER_TAG" not in os.environ:
         msg = "XPRO_DOCKER_TAG must be set."

--- a/src/ol_infrastructure/lib/pulumi_helper.py
+++ b/src/ol_infrastructure/lib/pulumi_helper.py
@@ -74,3 +74,23 @@ def require_stack_output_value(
 
     msg = f"Missing required stack output: {output_name}"
     raise ValueError(msg)
+
+
+def merge_otel_resource_attributes(
+    env_vars: dict[str, Any],
+    k8s_labels: dict[str, str],
+) -> None:
+    """Append k8s label key/value pairs to OTEL_RESOURCE_ATTRIBUTES in-place.
+
+    If OTEL_RESOURCE_ATTRIBUTES already exists in ``env_vars`` its existing value is
+    preserved and the label attributes are appended with a comma separator.  When the
+    key is absent it is created with only the label attributes.
+
+    :param env_vars: Mutable dict of environment variables to update.
+    :param k8s_labels: Kubernetes label key/value pairs to encode as OTEL attributes.
+    """
+    k8s_label_attrs = ",".join(f"{k}={v}" for k, v in k8s_labels.items())
+    base_otel = env_vars.get("OTEL_RESOURCE_ATTRIBUTES")
+    env_vars["OTEL_RESOURCE_ATTRIBUTES"] = (
+        f"{base_otel},{k8s_label_attrs}" if base_otel else k8s_label_attrs
+    )


### PR DESCRIPTION
### What are the relevant tickets?

#4310 

### Description (What does it do?)
Adds k8s labels into our OTEL telemetry spans.

### How can this be tested?
pulumi up shows the proper environment variable creation in details:
```
                        ~ [1]: {
                                  ~ env: [
                                      ~ [77]: {
                                              ~ name : "PORT" => "OTEL_RESOURCE_ATTRIBUTES"
                                              ~ value: "8073" => "ol.mit.edu/ou=open-courseware,ol.mit.edu/service=ocw-studio,ol.mit.edu/stack=applications.ocw_studio.CI,ol.mit.edu/product=infrastructure,ol.mit.edu/application=ocw-studio,ol.mit.edu/source_repository=github.com_mitodl_ocw-studio,ol.mit.edu/environment=ci"
                                            }
                                      + [78]: {
                                              + name : "PORT"
                                              + value: "8073"
                                            }
                                    ]
                                }
```