### PR TITLE
Add resource and resource types to pipeline

### DIFF
--- a/src/ol_concourse/pipelines/applications/google_ads_optimization/ad_optimization_pipeline.py
+++ b/src/ol_concourse/pipelines/applications/google_ads_optimization/ad_optimization_pipeline.py
@@ -14,6 +14,9 @@ from ol_concourse.lib.models.pipeline import (
     TaskStep,
 )
 from ol_concourse.lib.notifications import notification
+from ol_concourse.lib.resource_types import (
+    slack_notification_resource as slack_notification_resource_type,
+)
 from ol_concourse.lib.resources import slack_notification
 
 COURSES = ["ml", "gen_ai", "sys_think", "sys_eng"]
@@ -77,7 +80,11 @@ def ad_optimization_pipeline() -> Pipeline:
             alert_type="aborted",
         ),
     )
-    return Pipeline(jobs=[ad_optimization_object])
+    return Pipeline(
+        jobs=[ad_optimization_object],
+        resources=[slack_notification_resource],
+        resource_types=[slack_notification_resource_type()],
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description (What does it do?)
Just hooks up the missing resources for slack notifications.

### How can this be tested?
I applied this to [this pipeline](https://cicd.odl.mit.edu/teams/main/pipelines/google-ads-optimization/jobs/ad-optimization/builds/2?vars.course_name=%22ml%22) and induced a failure by having the script cat a non-existent file. Got a notification [as expected](https://mitodl.slack.com/archives/C0APP7G9P0W/p1774969865939629)