### PR TITLE
Add HubSpot portal ID to configs and env

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.CI.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.CI.yaml
@@ -38,6 +38,7 @@ config:
   mitlearn:k8s_cutover: "true"
   mitlearn:learn_ai_recommendation_endpoint: "https://api.rc.learn.mit.edu/ai/http/recommendation_agent/"
   mitlearn:learn_ai_syllabus_endpoint: "https://api.rc.learn.mit.edu/ai/http/syllabus_agent/"
+  mitlearn:hubspot_portal_id: "23128026"
   mitlearn:legacy_frontend_domain: "mitopen-ci.odl.mit.edu"
   mitlearn:nextjs_heroku_domain: "next.ci.learn.mit.edu"
   mitlearn:posthog_proxy: "ph.ol.mit.edu"

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.QA.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.QA.yaml
@@ -35,6 +35,7 @@ config:
   mitlearn:k8s_deploy: "true"
   mitlearn:learn_ai_recommendation_endpoint: "https://api.rc.learn.mit.edu/ai/http/recommendation_agent/"
   mitlearn:learn_ai_syllabus_endpoint: "https://api.rc.learn.mit.edu/ai/http/syllabus_agent/"
+  mitlearn:hubspot_portal_id: "23128026"
   mitlearn:legacy_api_domain: "api.mitopen-rc.mit.edu"
   mitlearn:legacy_frontend_domain: "mitopen-rc.odl.mit.edu"
   mit_learn:min_replicas: 4

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.applications.mit_learn_nextjs.CI.yaml
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.applications.mit_learn_nextjs.CI.yaml
@@ -23,4 +23,5 @@ config:
     secure: v1:GISrW09cyDNOopo5:3ubNcN1ZOhKreca0xTuBAQ==
   nextjs:sentry_env: "ci"
   nextjs:syllabus_endpoint: "https://api.ci.learn.mit.edu/ai/http/syllabus_agent/"
+  nextjs:hubspot_portal_id: "23128026"
   nextjs:optimize_images: "true"

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.applications.mit_learn_nextjs.QA.yaml
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.applications.mit_learn_nextjs.QA.yaml
@@ -24,4 +24,5 @@ config:
     secure: v1:FVKlsmjuVBFWXhWG:dxpsTB02SGRWkUfDCpmanVKBOQA6EXh6KnnZ8R+nqHsCF/WOBY/SlZMqikOI6CYlYmhCt8T/BAFn2Ps3xzll68R8UXWBIEhQrfkky4ArOGLRC3xRO6MN7bMS5gjenAhzMIgg3g==
   nextjs:sentry_env: "rc"
   nextjs:syllabus_endpoint: "https://api.rc.learn.mit.edu/ai/http/syllabus_agent/"
+  nextjs:hubspot_portal_id: "23128026"
   nextjs:optimize_images: "true"

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
@@ -142,7 +142,7 @@ raw_env_vars = {
     "NEXT_PUBLIC_LEARN_AI_SYLLABUS_ENDPOINT": nextjs_config.require(
         "syllabus_endpoint"
     ),
-    "NEXT_PUBLIC_HUBSPOT_PORTAL_ID": nextjs_config.require("hubspot_portal_id"),
+    "NEXT_PUBLIC_HUBSPOT_PORTAL_ID": nextjs_config.get("hubspot_portal_id") or "",
     "NEXT_PUBLIC_MITOL_API_BASE_URL": nextjs_config.require("mitlearn_api_base_url"),
     "NEXT_PUBLIC_MITX_ONLINE_CSRF_COOKIE_NAME": "csrf_mitxonline",
     "NEXT_PUBLIC_MITX_ONLINE_BASE_URL": nextjs_config.require("mitxonline_base_url"),

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
@@ -142,6 +142,7 @@ raw_env_vars = {
     "NEXT_PUBLIC_LEARN_AI_SYLLABUS_ENDPOINT": nextjs_config.require(
         "syllabus_endpoint"
     ),
+    "NEXT_PUBLIC_HUBSPOT_PORTAL_ID": nextjs_config.require("hubspot_portal_id"),
     "NEXT_PUBLIC_MITOL_API_BASE_URL": nextjs_config.require("mitlearn_api_base_url"),
     "NEXT_PUBLIC_MITX_ONLINE_CSRF_COOKIE_NAME": "csrf_mitxonline",
     "NEXT_PUBLIC_MITX_ONLINE_BASE_URL": nextjs_config.require("mitxonline_base_url"),


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/mit-learn/pull/3152

### Description (What does it do?)
Add mitlearn:hubspot_portal_id and nextjs:hubspot_portal_id (value 23128026) to CI and QA Pulumi YAML configs for mit_learn and mit_learn_nextjs, and expose it as NEXT_PUBLIC_HUBSPOT_PORTAL_ID in mit_learn_nextjs/__main__.py so the frontend can access the HubSpot portal identifier.

