### PR TITLE
Increase Keycloak olapps email verification link lifetime to 24h

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/olapps.py
+++ b/src/ol_infrastructure/substructure/keycloak/olapps.py
@@ -44,6 +44,7 @@ def create_olapps_realm(  # noqa: PLR0913, PLR0915
         access_code_lifespan="30m",
         access_code_lifespan_user_action="15m",
         attributes={
+            "actionTokenGeneratedByUserLifespan.verify-email": "86400",
             "business_unit": f"operations-{env_name}",
         },
         display_name="MIT Learn",


### PR DESCRIPTION
## Summary

Extends `access_code_lifespan_user_action` from `15m` to `24h` in the `olapps` Keycloak realm so that email verification links remain valid for 24 hours instead of expiring after 15 minutes.

Closes mitodl/hq#8669