### PR TITLE
fix: in CI use DOCKER_SHA rather than DOCKER_TAG

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/k8s_apps/docker_pulumi.py
+++ b/src/ol_concourse/pipelines/infrastructure/k8s_apps/docker_pulumi.py
@@ -414,7 +414,9 @@ def build_app_pipeline(app_name: str) -> Pipeline:
                 params={"skip_download": True},
             ),
             LoadVarStep(
-                load_var="image_tag", file=f"{app_ci_image.name}/tag", reveal=True
+                load_var="image_digest",
+                file=f"{app_ci_image.name}/digest",
+                reveal=True,
             ),
         ],
         additional_post_steps=[
@@ -439,7 +441,7 @@ def build_app_pipeline(app_name: str) -> Pipeline:
         if pipeline_parameters.purge_fastly_cache
         else [],
         additional_env_vars={
-            f"{app_name.replace('-', '_').upper()}_DOCKER_TAG": "((.:image_tag))",
+            f"{app_name.replace('-', '_').upper()}_DOCKER_SHA": "((.:image_digest))",
         },
         slack_url_path="eks.slack_url",
     )


### PR DESCRIPTION
### What are the relevant tickets?
Fixes #4454 

### Description (What does it do?)
Modifies the meta pipeline so each K8s app's CI stage uses the latest SHA digest from the image builder rather than the latest tag.

### How can this be tested?
I have no idea. I still don't understand meta-pipelines. Maybe I need to run fly?

Magic?

Cosmic rays?

Contrails? :)