### PR TITLE
Apisix token lifetime

### DIFF
--- a/src/ol_infrastructure/components/services/apisix.py
+++ b/src/ol_infrastructure/components/services/apisix.py
@@ -235,11 +235,16 @@ class OLApisixOIDCResources(ComponentResource):
             opts=resource_options.merge(ResourceOptions(delete_before_replace=True)),
         )
 
-        cookie_config = {}
+        session_cookie_config: dict[str, Any] = {}
         if oidc_config.oidc_session_cookie_domain:
-            cookie_config["session"] = {
-                "cookie": {"domain": oidc_config.oidc_session_cookie_domain}
-            }
+            session_cookie_config.setdefault("session", {}).setdefault("cookie", {})[
+                "domain"
+            ] = oidc_config.oidc_session_cookie_domain
+
+        if oidc_config.oidc_session_cookie_lifetime:
+            session_cookie_config.setdefault("session", {}).setdefault("cookie", {})[
+                "lifetime"
+            ] = oidc_config.oidc_session_cookie_lifetime
 
         self.base_oidc_config = {
             "scope": oidc_config.oidc_scope,
@@ -249,15 +254,8 @@ class OLApisixOIDCResources(ComponentResource):
             "renew_access_token_on_expiry": oidc_config.oidc_renew_access_token_on_expiry,
             "logout_path": oidc_config.oidc_logout_path,
             "post_logout_redirect_uri": oidc_config.oidc_post_logout_redirect_uri,
-            **cookie_config,
+            **session_cookie_config,
         }
-
-        if oidc_config.oidc_session_cookie_lifetime:
-            self.base_oidc_config["session_cookie_lifetime"] = {
-                "cookie": {
-                    "lifetime": 60 * oidc_config.oidc_session_cookie_lifetime,
-                },
-            }
 
         if oidc_config.oidc_session_contents:
             self.base_oidc_config["session_contents"] = (


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
**Bug: APISIX session cookie lifetime was silently ignored, causing frequent user logouts**

The `oidc_session_cookie_lifetime` value was being written to a top-level key `session_cookie_lifetime` on the APISIX openid-connect plugin config, which is not a valid field and was silently ignored. The correct location is `session.cookie.lifetime` (nested under the `session` object).

As a result, APISIX fell back to the `lua-resty-session` v4 defaults:
- `idling_timeout`: 15 minutes (session expires after 15 min of inactivity)
- `rolling_timeout`: 1 hour

This caused users to be logged out after ~30 minutes of light activity, despite the intended 14-day session lifetime (`oidc_session_cookie_lifetime = 60 * 20160` seconds) configured for MIT Learn.

**Changes:**
- Moved both `session.cookie.domain` and `session.cookie.lifetime` into the correct nested `session.cookie` object so they are merged together cleanly
- Removed an erroneous `* 60` multiplier on the lifetime value — callers already pass the value in seconds, so multiplying again would have resulted in an ~800-day lifetime if the field had ever been read
