### PR TITLE
add vcl for fastly io

### DIFF
--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -951,6 +951,19 @@ for purpose in ("draft", "live", "test"):
                 name="Strip cookies and authorization.",
                 type="recv",
             ),
+            *(
+                [
+                    fastly.ServiceVclSnippetArgs(
+                        content=snippets_dir.joinpath(
+                            "image_optimization.vcl"
+                        ).read_text(),
+                        name="Image Optimization",
+                        type="recv",
+                    )
+                ]
+                if fastly_image_optimization_enabled
+                else []
+            ),
         ],
         logging_https=[
             fastly.ServiceVclLoggingHttpArgs(

--- a/src/ol_infrastructure/applications/ocw_site/snippets/image_optimization.vcl
+++ b/src/ol_infrastructure/applications/ocw_site/snippets/image_optimization.vcl
@@ -1,0 +1,3 @@
+if (req.url.ext ~ "(?i)^(?:gif|png|jpe?g|webp|avif|jxl|heic)\z") {
+  set req.http.X-Fastly-Imageopto-Api = "fastly";
+}


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10882

### Description (What does it do?)
We enabled fastly io for ocw qa in https://github.com/mitodl/ol-infrastructure/pull/4461 However, it does not appear to be working.

Looking at the fastly docs, enabling IO is not enough. We need to add a recv vcl snippet setting the X-Fastly-Imageopto-Api header for the requests that need optimization. 

Relevant fastly [docs](https://www.fastly.com/documentation/reference/io/#enabling-image-optimization)


### How can this be tested?
After deployment :-)

