### PR TITLE
Cpatti/ocw site s3 kms fix

### DIFF
--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -82,7 +82,7 @@ audit_log_bucket_config = S3BucketConfig(
     bucket_name=audit_log_bucket_name,
     versioning_enabled=True,
     server_side_encryption_enabled=True,
-    sse_algorithm="aws:kms",
+    sse_algorithm="AES256",
     lifecycle_rules=[
         s3.BucketLifecycleConfigurationRuleArgs(
             id="transition-old-audit-logs",

--- a/src/ol_infrastructure/lib/pulumi_helper.py
+++ b/src/ol_infrastructure/lib/pulumi_helper.py
@@ -1,13 +1,14 @@
 """Helpers for working with Pulumi stack names and stack references."""
 
+import logging
 import os
 from dataclasses import dataclass
 from typing import Any
 
-import pulumi
-import pulumi.log
 from pulumi import StackReference, get_stack
 from pulumi.runtime import sync_await
+
+log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -122,9 +123,13 @@ def get_docker_image_tag(app_prefix: str) -> str:
     sha_var = f"{app_prefix}_DOCKER_SHA"
     tag_value = os.environ.get(tag_var)
     sha_value = os.environ.get(sha_var)
-    pulumi.log.info(
-        f"get_docker_image_tag({app_prefix!r}): "
-        f"{tag_var}={tag_value!r}, {sha_var}={sha_value!r}"
+    log.info(
+        "get_docker_image_tag(%r): %s=%r, %s=%r",
+        app_prefix,
+        tag_var,
+        tag_value,
+        sha_var,
+        sha_value,
     )
 
     if tag_value and sha_value:

--- a/src/ol_infrastructure/lib/pulumi_helper.py
+++ b/src/ol_infrastructure/lib/pulumi_helper.py
@@ -1,14 +1,13 @@
 """Helpers for working with Pulumi stack names and stack references."""
 
-import logging
 import os
 from dataclasses import dataclass
 from typing import Any
 
+import pulumi
+import pulumi.log
 from pulumi import StackReference, get_stack
 from pulumi.runtime import sync_await
-
-log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -123,13 +122,9 @@ def get_docker_image_tag(app_prefix: str) -> str:
     sha_var = f"{app_prefix}_DOCKER_SHA"
     tag_value = os.environ.get(tag_var)
     sha_value = os.environ.get(sha_var)
-    log.info(
-        "get_docker_image_tag(%r): %s=%r, %s=%r",
-        app_prefix,
-        tag_var,
-        tag_value,
-        sha_var,
-        sha_value,
+    pulumi.log.info(
+        f"get_docker_image_tag({app_prefix!r}): "
+        f"{tag_var}={tag_value!r}, {sha_var}={sha_value!r}"
     )
 
     if tag_value and sha_value:


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9680

### Description (What does it do?)
This change removes the errant KMS configuration in the auditing bucket IAM rules. Since it specified no key,
and since KMS is pointless in auditing buckets where SSE at rest encryption is already in play, removing it will
allow us to actually download/access the audit logs.

### How can this be tested?

```
╭─feoh ✔ at loki in ~/src/mit/ol-infrastructure/src/ol_infrastructure/applications/ocw_site on cpatti/ocw-site-s3-kms-fix✔ 26-04-13 - 16:31:46
╰─(.venv) ⠠⠵ pulumi up -s applications.ocw_site.QA                                                                                                                         <region:us-east-1>
Previewing update (applications.ocw_site.QA):
     Type                                                  Name                                                             Plan       Info
     pulumi:pulumi:Stack                                   ol-infrastructure-ocw-site-application-applications.ocw_site.QA
     ├─ ol:aws:s3:OLBucket                                 ocw-site-audit-logs-bucket
 ~   │  └─ aws:s3:BucketServerSideEncryptionConfiguration  ocw-site-audit-logs-bucket-encryption                            update     [diff: ~rules]
     ├─ ol:aws:s3:OLBucket                                 ocw-content-offline-draft-bucket
     │  └─ aws:s3:BucketLogging                            ocw-content-offline-draft-bucket-logging                                    1 warning
     ├─ ol:aws:s3:OLBucket                                 ocw-content-backup-live-bucket
     │  └─ aws:s3:BucketLogging                            ocw-content-backup-live-bucket-logging                                      1 warning
     ├─ ol:aws:s3:OLBucket                                 ocw-content-draft-bucket
     │  └─ aws:s3:BucketLogging                            ocw-content-draft-bucket-logging                                            1 warning
     ├─ ol:aws:s3:OLBucket                                 ocw-content-live-bucket
     │  └─ aws:s3:BucketLogging                            ocw-content-live-bucket-logging                                             1 warning
     ├─ ol:aws:s3:OLBucket                                 ocw-content-test-bucket
     │  └─ aws:s3:BucketLogging                            ocw-content-test-bucket-logging                                             1 warning
     ├─ ol:aws:s3:OLBucket                                 ocw-content-offline-test-bucket
     │  └─ aws:s3:BucketLogging                            ocw-content-offline-test-bucket-logging                                     1 warning
     ├─ ol:aws:s3:OLBucket                                 ocw-content-offline-live-bucket
     │  └─ aws:s3:BucketLogging                            ocw-content-offline-live-bucket-logging                                     1 warning
 ~   └─ fastly:index:TlsSubscription                       fastly-ocw_site-qa-test-tls-subscription                         update     [diff: ~configurationId]

Diagnostics:

Resources:
    ~ 2 to update
    100 unchanged

Do you want to perform this update? details
  pulumi:pulumi:Stack: (same)
    [urn=urn:pulumi:applications.ocw_site.QA::ol-infrastructure-ocw-site-application::pulumi:pulumi:Stack::ol-infrastructure-ocw-site-application-applications.ocw_site.QA]
    > pulumi:pulumi:StackReference: (read)
        [id=infrastructure.monitoring]
        [urn=urn:pulumi:applications.ocw_site.QA::ol-infrastructure-ocw-site-application::pulumi:pulumi:StackReference::infrastructure.monitoring]
        name: "infrastructure.monitoring"
    > pulumi:pulumi:StackReference: (read)
        [id=infrastructure.aws.dns]
        [urn=urn:pulumi:applications.ocw_site.QA::ol-infrastructure-ocw-site-application::pulumi:pulumi:StackReference::infrastructure.aws.dns]
        name: "infrastructure.aws.dns"
    > pulumi:pulumi:StackReference: (read)
        [id=infrastructure.vector_log_proxy.operations.QA]
        [urn=urn:pulumi:applications.ocw_site.QA::ol-infrastructure-ocw-site-application::pulumi:pulumi:StackReference::infrastructure.vector_log_proxy.operations.QA]
        name: "infrastructure.vector_log_proxy.operations.QA"
        ~ aws:s3/bucketServerSideEncryptionConfiguration:BucketServerSideEncryptionConfiguration: (update)
            [id=ocw-site-audit-logs-qa]
            [urn=urn:pulumi:applications.ocw_site.QA::ol-infrastructure-ocw-site-application::ol:aws:s3:OLBucket$aws:s3/bucketServerSideEncryptionConfiguration:BucketServerSideEncryptionConfiguration::ocw-site-audit-logs-bucket-encryption]
            [provider=urn:pulumi:applications.ocw_site.QA::ol-infrastructure-ocw-site-application::pulumi:providers:aws::default_7_25_0::23790c8a-2284-464d-ab71-3b18e154946b]
          ~ rules: [
              ~ [0]: {
                      + __defaults                        : []
                      ~ applyServerSideEncryptionByDefault: {
                          + __defaults    : []
                          - kmsMasterKeyId: ""
                          ~ sseAlgorithm  : "aws:kms" => "AES256"
                        }
                      - blockedEncryptionTypes            : [
                      -     [0]: "NONE"
                        ]
                      - bucketKeyEnabled                  : false
                    }
            ]
    ~ fastly:index/tlsSubscription:TlsSubscription: (update)
        [id=iZ6tuWnaxiQkAgIztJp6wA]
        [urn=urn:pulumi:applications.ocw_site.QA::ol-infrastructure-ocw-site-application::fastly:index/tlsSubscription:TlsSubscription::fastly-ocw_site-qa-test-tls-subscription]
        [provider=urn:pulumi:applications.ocw_site.QA::ol-infrastructure-ocw-site-application::pulumi:providers:fastly::fastly-provider::e40e4ff0-bf5b-4944-bc15-0e4de304104a]
      ~ configurationId: "boVvzkfFAADhAsIxif1NJA" => "suMnBjWyh1mWp9YNm4ZYWg"
```
