### PR TITLE
Add hubspot UAI to MITx Online

### DIFF
--- a/src/ol_infrastructure/applications/mitxonline/k8s_secrets.py
+++ b/src/ol_infrastructure/applications/mitxonline/k8s_secrets.py
@@ -233,6 +233,7 @@ def create_mitxonline_k8s_secrets(
                 "MITOL_GOOGLE_SHEETS_DRIVE_CLIENT_SECRET": '{{ index .Secrets "google-sheets" "drive-client-secret" }}',
                 "MITOL_GOOGLE_SHEETS_ENROLLMENT_CHANGE_SHEET_ID": '{{ index .Secrets "google-sheets" "enrollment-change-sheet-id" }}',
                 "MITOL_HUBSPOT_API_PRIVATE_TOKEN": '{{ index .Secrets "hubspot" "private-api-token" }}',
+                "UAI_MITOL_HUBSPOT_API_PRIVATE_TOKEN": '{{ index .Secrets "hubspot" "uai-private-api-token" }}',
                 "MITOL_PAYMENT_GATEWAY_CYBERSOURCE_ACCESS_KEY": '{{ index .Secrets "cybersource" "access-key" }}',
                 "MITOL_PAYMENT_GATEWAY_CYBERSOURCE_MERCHANT_ID": '{{ index .Secrets "cybersource" "merchant-id" }}',
                 "MITOL_PAYMENT_GATEWAY_CYBERSOURCE_MERCHANT_SECRET": '{{ index .Secrets "cybersource" "merchant-secret" }}',


### PR DESCRIPTION
### What are the relevant tickets?
Relates to https://github.com/mitodl/mitxonline/pull/3474

### Description (What does it do?)
Adds a new secret to MITx Online for the UAI Hubspot secret.  I have the value that will need to be added to Vault but I don't think I have permissions to add it in Vault.