### PR TITLE
Add explicit MIT Learn Fastly log labels

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1029,7 +1029,7 @@ mitlearn_fastly_service = fastly.ServiceVcl(
             content_type="application/json",
             format=build_fastly_log_format_string(
                 additional_static_fields={
-                    "application": stack_info.env_prefix,
+                    "application": Application.mit_learn,
                     "environment": stack_info.env_suffix,
                 }
             ),

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1027,7 +1027,12 @@ mitlearn_fastly_service = fastly.ServiceVcl(
             ),
             name=f"fastly-{stack_info.env_prefix}-{stack_info.env_suffix}-https-logging-args",
             content_type="application/json",
-            format=build_fastly_log_format_string(additional_static_fields={}),
+            format=build_fastly_log_format_string(
+                additional_static_fields={
+                    "application": "mit-learn",
+                    "environment": stack_info.env_suffix,
+                }
+            ),
             format_version=2,
             header_name="Authorization",
             header_value=f"Basic {encoded_fastly_proxy_credentials}",

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1029,7 +1029,7 @@ mitlearn_fastly_service = fastly.ServiceVcl(
             content_type="application/json",
             format=build_fastly_log_format_string(
                 additional_static_fields={
-                    "application": "mit-learn",
+                    "application": stack_info.env_prefix,
                     "environment": stack_info.env_suffix,
                 }
             ),


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/ol-infrastructure/pull/4482

### Description (What does it do?)
This PR adds application and environment labels to the MIT Learn fastly logs for more explicit / easier filtering

### How can this be tested?
Deploy it, I guess

### Additional Info
This is how we label fastly for [OCW]( https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/applications/ocw_site/__main__.py#L975-L980) and [xPro](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/applications/xpro/__main__.py#L901-L905)