### PR TITLE
feat: add Vault secrets for OpenMetadata connector credentials

### DIFF
--- a/src/ol_infrastructure/applications/open_metadata/__main__.py
+++ b/src/ol_infrastructure/applications/open_metadata/__main__.py
@@ -285,6 +285,65 @@ oidc_config_secret = OLVaultK8SSecret(
     ),
 )
 
+# Connector credentials for OpenMetadata ingestion pipelines.
+# Each connector's credentials are stored in Vault under
+# secret-operations/open-metadata/connectors/<connector-name>
+# and synced to K8s secrets in the open-metadata namespace.
+# Provision values in Vault before deploying connectors.
+connector_configs: dict[str, dict[str, str]] = {
+    "trino": {
+        "OM_TRINO_HOST_PORT": '{{ get .Secrets "host_port" }}',
+        "OM_TRINO_USERNAME": '{{ get .Secrets "username" }}',
+        "OM_TRINO_PASSWORD": '{{ get .Secrets "password" }}',
+        "OM_TRINO_CATALOG": '{{ get .Secrets "catalog" }}',
+    },
+    "superset": {
+        "OM_SUPERSET_HOST_PORT": '{{ get .Secrets "host_port" }}',
+        "OM_SUPERSET_USERNAME": '{{ get .Secrets "username" }}',
+        "OM_SUPERSET_PASSWORD": '{{ get .Secrets "password" }}',
+    },
+    "redash": {
+        "OM_REDASH_HOST_PORT": '{{ get .Secrets "host_port" }}',
+        "OM_REDASH_API_KEY": '{{ get .Secrets "api_key" }}',
+    },
+    "dagster": {
+        "OM_DAGSTER_HOST": '{{ get .Secrets "host" }}',
+        "OM_DAGSTER_TOKEN": '{{ get .Secrets "token" }}',
+    },
+    "airbyte": {
+        "OM_AIRBYTE_HOST_PORT": '{{ get .Secrets "host_port" }}',
+        "OM_AIRBYTE_USERNAME": '{{ get .Secrets "username" }}',
+        "OM_AIRBYTE_PASSWORD": '{{ get .Secrets "password" }}',
+    },
+}
+
+connector_secrets: list[OLVaultK8SSecret] = []
+connector_secret_names: list[str] = []
+for connector_name, templates in connector_configs.items():
+    secret_name = f"om-connector-{connector_name}"
+    secret_config = OLVaultK8SStaticSecretConfig(
+        name=f"openmetadata-connector-{connector_name}",
+        namespace=open_metadata_namespace,
+        dest_secret_labels=k8s_global_labels,
+        dest_secret_name=secret_name,
+        labels=k8s_global_labels,
+        mount="secret-operations",
+        mount_type="kv-v1",
+        path=f"open-metadata/connectors/{connector_name}",
+        templates=templates,
+        vaultauth=vault_k8s_resources.auth_name,
+    )
+    connector_secret = OLVaultK8SSecret(
+        f"open-metadata-{stack_info.name}-connector-{connector_name}-secret",
+        secret_config,
+        opts=ResourceOptions(
+            delete_before_replace=True,
+            parent=vault_k8s_resources,
+        ),
+    )
+    connector_secrets.append(connector_secret)
+    connector_secret_names.append(secret_name)
+
 # Install the openmetadata helm chart
 # https://github.com/mitodl/ol-infrastructure/issues/2680
 open_metadata_application = kubernetes.helm.v3.Release(
@@ -378,6 +437,7 @@ open_metadata_application = kubernetes.helm.v3.Release(
                         "name": oidc_config_secret_name,
                     },
                 },
+                *[{"secretRef": {"name": name}} for name in connector_secret_names],
             ],
         },
         skip_await=False,
@@ -385,7 +445,12 @@ open_metadata_application = kubernetes.helm.v3.Release(
     opts=ResourceOptions(
         parent=vault_k8s_resources,
         delete_before_replace=True,
-        depends_on=[open_metadata_db, db_creds_secret, oidc_config_secret],
+        depends_on=[
+            open_metadata_db,
+            db_creds_secret,
+            oidc_config_secret,
+            *connector_secrets,
+        ],
     ),
 )
 

--- a/src/ol_infrastructure/applications/open_metadata/open_metadata_policy.hcl
+++ b/src/ol_infrastructure/applications/open_metadata/open_metadata_policy.hcl
@@ -10,6 +10,13 @@ path "secret-operations/sso/open_metadata/*" {
 path "secret-operations/sso/open_metadata" {
   capabilities = ["read"]
 }
+# Connector credentials for OpenMetadata ingestion pipelines
+path "secret-operations/open-metadata/connectors/*" {
+  capabilities = ["read"]
+}
+path "secret-operations/open-metadata/connectors" {
+  capabilities = ["read", "list"]
+}
 # vault-secrets-operator is a little more particular about
 # managing its own leases, give it the permissions it needs
 # for dynamic secret renwals / revocation without giving


### PR DESCRIPTION
## Description

Adds Vault policy paths and K8s static secrets for OpenMetadata connector credentials, supporting Issue mitodl/ol-data-platform#1355.

### Changes

**`open_metadata_policy.hcl`**
- Added Vault policy for `secret-operations/open-metadata/connectors/*` (read + list)

**`__main__.py`**
- Added 5 `OLVaultK8SStaticSecret` resources for connector credentials:
  - **Trino**: host_port, username, password, catalog
  - **Superset**: host_port, username, password
  - **Redash**: host_port, api_key
  - **Dagster**: host, token
  - **Airbyte**: host_port, username, password
- Secrets sync from Vault (`secret-operations/open-metadata/connectors/<name>`) to K8s (`om-connector-<name>`) in the `open-metadata` namespace
- Injected into Helm release `envFrom` and `depends_on`
- S3/Iceberg use IAM roles — no separate credential secrets needed

### Next Steps (operational)
1. Provision credentials in Vault at `secret-operations/open-metadata/connectors/<name>`
2. Configure connectors via OpenMetadata UI
3. Deploy ingestion pipelines as CronOMJob CRDs

### Companion PR
- ol-data-platform: [#2157](https://github.com/mitodl/ol-data-platform/pull/2157) (dbt artifact upload)

### Validation
- All pre-commit hooks pass (ruff format, ruff check, mypy, detect-secrets)

Refs: mitodl/ol-data-platform#1355