### PR TITLE
feat: add Iceberg connector credentials for OpenMetadata

### DIFF
--- a/src/ol_infrastructure/applications/open_metadata/__main__.py
+++ b/src/ol_infrastructure/applications/open_metadata/__main__.py
@@ -297,6 +297,11 @@ connector_configs: dict[str, dict[str, str]] = {
         "OM_TRINO_PASSWORD": '{{ get .Secrets "password" }}',
         "OM_TRINO_CATALOG": '{{ get .Secrets "catalog" }}',
     },
+    "iceberg": {
+        "OM_ICEBERG_CATALOG_NAME": '{{ get .Secrets "catalog_name" }}',
+        "OM_ICEBERG_WAREHOUSE": '{{ get .Secrets "warehouse" }}',
+        "OM_ICEBERG_CATALOG_URI": '{{ get .Secrets "catalog_uri" }}',
+    },
 }
 
 connector_secrets: list[OLVaultK8SSecret] = []


### PR DESCRIPTION
## Description

Adds Vault-synced K8s secret for Iceberg connector credentials, providing dedicated Iceberg catalog metadata (table snapshots, partitions, manifests) beyond what the Trino connector surfaces.

### Vault Secret
- **Path**: `secret-operations/open-metadata/connectors/iceberg`
- **K8s Secret**: `om-connector-iceberg` in `open-metadata` namespace

### Secret Fields
| Vault Key | Env Var | Purpose |
|-----------|---------|---------|
| `catalog_name` | `OM_ICEBERG_CATALOG_NAME` | Iceberg catalog identifier |
| `warehouse` | `OM_ICEBERG_WAREHOUSE` | S3 warehouse path |
| `catalog_uri` | `OM_ICEBERG_CATALOG_URI` | REST/Glue catalog endpoint |

### OpenMetadata Capabilities
- ✅ Iceberg-specific metadata (snapshots, partitions, manifest files)
- ✅ Profiling & data quality
- Uses IAM roles for S3 data access (no separate AWS creds needed)

### Dependencies
- Depends on Trino connector PR (#4493) — Iceberg tables also accessible via Trino SQL

Refs: mitodl/ol-data-platform#1355