### PR TITLE
preserve query params for optimized image requests

### DIFF
--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -946,9 +946,9 @@ for purpose in ("draft", "live", "test"):
             ),
             fastly.ServiceVclSnippetArgs(
                 content=snippets_dir.joinpath(
-                    "strip_cookies_and_authorization.vcl"
+                    "strip_cookies_and_authorization_and_user_io.vcl"
                 ).read_text(),
-                name="Strip cookies and authorization.",
+                name="Strip cookies and authorization and user provided io header.",
                 type="recv",
             ),
             *(
@@ -959,6 +959,7 @@ for purpose in ("draft", "live", "test"):
                         ).read_text(),
                         name="Image Optimization",
                         type="recv",
+                        priority=1000
                     )
                 ]
                 if fastly_image_optimization_enabled

--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -959,7 +959,7 @@ for purpose in ("draft", "live", "test"):
                         ).read_text(),
                         name="Image Optimization",
                         type="recv",
-                        priority=1000
+                        priority=1000,
                     )
                 ]
                 if fastly_image_optimization_enabled

--- a/src/ol_infrastructure/applications/ocw_site/snippets/s3_bucket_proxying.vcl
+++ b/src/ol_infrastructure/applications/ocw_site/snippets/s3_bucket_proxying.vcl
@@ -1,4 +1,6 @@
-set bereq.url = querystring.remove(bereq.url);
+if (!req.http.X-Fastly-Imageopto-Api) {
+  set bereq.url = querystring.remove(bereq.url);
+}
 set bereq.url = regsub(bereq.url, "/$", "/index.html");
 set bereq.url = regsub(bereq.url, "^/ans7870", "/largefiles");
 set bereq.url = regsub(bereq.url, "^/ans15436", "/zipfiles");

--- a/src/ol_infrastructure/applications/ocw_site/snippets/strip_cookies_and_authorization.vcl
+++ b/src/ol_infrastructure/applications/ocw_site/snippets/strip_cookies_and_authorization.vcl
@@ -1,2 +1,0 @@
-unset req.http.Cookie;
-unset req.http.Authorization;

--- a/src/ol_infrastructure/applications/ocw_site/snippets/strip_cookies_and_authorization_and_user_io.vcl
+++ b/src/ol_infrastructure/applications/ocw_site/snippets/strip_cookies_and_authorization_and_user_io.vcl
@@ -1,0 +1,4 @@
+unset req.http.Cookie;
+unset req.http.Authorization;
+# Disallow user provided X-Fastly-Imageopto-Api
+unset req.http.X-Fastly-Imageopto-Api;


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10882

### Description (What does it do?)
Currently, fastly image optimization in ocw does not respect query params used to customize the response i.e `/image.jepg?width=200` does not set the width to 200pixels. This is due to the query params being stripped in the vcl miss phase. 

As a fix, we only strip query params for non-io requests. For io requests, fastly strips query params ([docs](https://www.fastly.com/documentation/reference/io/#query-string-removal)) before sending the request to the backend itself so the change shouldn't impact requests to s3 in any way.,


### How can this be tested?
I have tested it on https://fiddle.fastly.dev/fiddle/a563e117 but that is not a complete replication of our environment. However, I believe it is good enough for the change here.