### PR TITLE
Md/202504 typesense operator install

### DIFF
--- a/src/bridge/secrets/edxapp/mitx-staging.ci.yaml
+++ b/src/bridge/secrets/edxapp/mitx-staging.ci.yaml
@@ -21,6 +21,7 @@ user_retirement_salts:
 - ENC[AES256_GCM,data:paTHr8iqnGOrOcXWHYK4voIQQciAjiSKwmWl5NVeIoXcwJ6Y,iv:KXS+uNs4C/+O82/ydCtrMSpZ6A2F63v0RjijHYUT0Rw=,tag:sXymJWORqf8DhrD9v6h0Qg==,type:str]
 meilisearch_master_key: ENC[AES256_GCM,data:ijGWjx7KVW5VW9ldwmR0pYAGIlc3YRLtUW+HB5JKa4ItpWE8aNwpOgXy3OUwcyGCmHBlvnLeMaA4iSf1aMXnAw==,iv:HV4ktBRS9KwPJG0YMwEpB4NQTXAmgJXjcuCMQ49Upsg=,tag:Z6hQs6PjvF4p860nDJ3nOQ==,type:str]
 meilisearch_api_key: ENC[AES256_GCM,data:h6PxYBWkmQ1PCo3QCjW9gNdioYUysSvZQLaCfhkwzTpoA/eVoIf1+2j8pz5vtaGTxUYVIcvLqWCoD7cz2+MWfQ==,iv:jSugC28ffyUn5nSPyMSEfdePtHxXhsVHAn5rV6dvKCI=,tag:1HE4fudxxmMaJVG/QWNrZQ==,type:str]
+typesense_bootstrap_key: ENC[AES256_GCM,data:oGAbwdfomjBYhGiBeIT0I1VYp3HUNd707l3oXi+YL9BtE/QLE+HLKOqN3jSPl5hr2KXupOKWJ5jRCNC1zjrn/Q==,iv:PjA8nefkYn9hK09C63B7rkAbiXcilIf0crN8sPM+hl8=,tag:NOKPfLGr76JiQFpB2eh6kQ==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-ci
@@ -36,8 +37,8 @@ sops:
     created_at: "2024-01-24T19:58:55Z"
     enc: vault:v1:NkR3Q8K1eG5ndrJI8YJj/kdlHh8hPLDnItNliLFvYO5RWTyY/435l81LB/pzYLEdQa2Muytt9CnC01yy
   age: []
-  lastmodified: "2026-01-29T19:27:15Z"
-  mac: ENC[AES256_GCM,data:p4afEPrDHKKFqEQjtGqv5Je2m0mY02lYrVA6qQvHJl0gcrsVoG68wYdI2eGZzO0ab6ArnY/dBME/0RbHrf7H1rhNcXVY+NR6e+poMU0DYq+zFqjogPo+75ezvRQ6AWvHvJtah4kybnaF2O5PjpeVAUupeWXOoSQRI8klQOqSGvQ=,iv:2lG0h6G/Yh09mtdIFnlJkMkVcU0NyIx3VGmEgTL6E6o=,tag:HlnZObz+84Aioe9vrTKXfw==,type:str]
+  lastmodified: "2026-04-08T17:49:17Z"
+  mac: ENC[AES256_GCM,data:Evd5hqk3e73ofqGRQ2oMmxZOpOAtP3L/59pC67+6ZZRlHp8IGwW3Q5D4VG4cA1+PUWQggM4TfDaBCzI5QpVnaf3gJ7frNwrujWGLxkffjHoRhTt8Nc/sVAUKz6dtXsN6IdCg/d9fTgAaZY3C3nXhhBkzvmnIvnTBnYM5NrsqHl0=,iv:SzL9GzH+KgUhUTZvch8Z6YP5RubuP8HlXuArgALkj3Y=,tag:A1tahsEPJ7mW9Zx8OUCHUQ==,type:str]
   pgp:
   - created_at: "2024-01-24T19:58:55Z"
     enc: |-

--- a/src/bridge/secrets/edxapp/mitx-staging.production.yaml
+++ b/src/bridge/secrets/edxapp/mitx-staging.production.yaml
@@ -23,19 +23,24 @@ user_retirement_salts:
 - ENC[AES256_GCM,data:VDpUXiHWlUioZ75o7DYwCK+3pbCAk8UupSDticrlIhhBqPhS,iv:vjBpxz7Ki5SzL6jTmfzSSmlJGs4DFYy+JgCDzHAMB8c=,tag:EzxSXk9TRRj9Bew8VKY3Mw==,type:str]
 meilisearch_master_key: ENC[AES256_GCM,data:dRyp5feciXINalNtPkJ8cn+KKZEWGhLlpwondttR3+7UIBlrUmDcfEFzVvn4lYkqCcsC+kyAtPyHFr6s7djwKw==,iv:AfA5Ohclz+VPviFukOleYVpfX3GXKsWLJuTRcD/LHOo=,tag:ECQdb67fFqd9woG8jTISjg==,type:str]
 meilisearch_api_key: ENC[AES256_GCM,data:uZJwSafOww==,iv:x48QLSHrZEYhszNrjjXK0Vhkqnyk7AWzIQgjf4fXh8E=,tag:qMg60xj95awQBljY38XVUA==,type:str]
+typesense_bootstrap_key: ENC[AES256_GCM,data:6Fz1RsyBVNOQDOF288rDPyqdwME9yXYzgGwKN2oh9n3PwQHPxsLtuZRCnUpN5CrVmo6NlrkHtWe+7huohI6vGw==,iv:IOuShp6YJfQzNZa2Mnqvc1/kDsygMTlNon6T6pBfqRM=,tag:CQlGKoZ93EJPJo5yuUWcMw==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
     created_at: "2026-02-23T16:23:57Z"
     enc: AQICAHi3FG4qowC3UzOLWOAA4Y9/RTwqKjovG3wyVVYDxkR+zAHQLtHXR1G+H9d/5tF8oczUAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMpn/whDYtH2roA5S/AgEQgDsSwR5LqrjJu5/3JlQWz78niLLeY5TeqLNyBnuHPDVlsDfBly9Q8rCG2IT8OGCxUyg7d2WfLPhzyXVGuQ==
     aws_profile: ""
+  gcp_kms: []
+  azure_kv: []
   hc_vault:
   - vault_address: https://vault-production.odl.mit.edu
     engine_path: infrastructure
     key_name: sops
     created_at: "2026-02-23T16:23:57Z"
     enc: vault:v1:ALCZnRPyFjAiZ6q/bbadcVCeYweVkfDPZelYes0T/SbQVpIZ/o/wrKq4vi43UuXjNxclAyMgIE/hhzTL
-  lastmodified: "2026-02-23T16:23:58Z"
-  mac: ENC[AES256_GCM,data:/6xvhlaiKDv04MpgJeW3Mvkrzc7CdrHqCieQko27B5NCPA354P+UQ3+l1lMtc/DdGCk75WTfPLOY7aKJIHsmhaSKVU2/M8Z1EIDXw5gfeIAMFytQkhgkWY58Ep4ldQdGeilxE5IEmFf87LYq5O4Ik3XliRCKsG+KFv81L1LyGRo=,iv:h7CXIKVtoYbMs/f5RBQPecFqWQoWmkdB+lgcmr/R2kQ=,tag:lrUibfHTb6WRztQooXyJBg==,type:str]
+  age: []
+  lastmodified: "2026-04-08T17:50:47Z"
+  mac: ENC[AES256_GCM,data:TvfHHJ/XbvbgLiMyNd5GSXRCXg99+zhs++438S7OUsM66LMSA1hZXlw5oQbzFFKYfglNkWhijQ6zspylzLXGgR+ipXEK1+TFwnaoKlYa4lDTO7CX8wmOPGU3JNIglARk/uoCQHlMskTSmeitHTw97s7Einlf9UdL9m7U5EiquO8=,iv:v74IKK6rif8OkHGRxM22SmTgS1cPsbIFB/aZBWMfSVQ=,tag:GpSPh9d6XH9R4QAiEvGcqw==,type:str]
+  pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/src/bridge/secrets/edxapp/mitx-staging.qa.yaml
+++ b/src/bridge/secrets/edxapp/mitx-staging.qa.yaml
@@ -22,6 +22,7 @@ user_retirement_salts:
 - ENC[AES256_GCM,data:46sVID0S/m7iqZr+fJfkCEWGwg6FED9WlXL1+YxqC2vQOUmj,iv:H5iF/jR02Rwp/jv30Y4rt9y+RK16ZJHqveVOqMjJRo8=,tag:HyC1QDPkVbBQ0gDaspme8Q==,type:str]
 meilisearch_master_key: ENC[AES256_GCM,data:uiKO0/0Sxa9oTbbD624oWCSAjZJAi8r36EjGIRSPfXWKSzQd91i73mQPHwQuWpXJxe1IIu+sqbC4GpXMOR/wGQ==,iv:rkjosZEJyPSNhQgQlVgAysO47Hlj0/efnRBOpuaV3Sc=,tag:HPqehfAWiCW9NTU+hRa5VQ==,type:str]
 meilisearch_api_key: ENC[AES256_GCM,data:E2k0i8XmzTQTnPs3w3PJqHMh1ATm2lCZUPiHcGOj05CWlBLCOxaVeHx8ob0Cfce243okvLh281PaesGPh8eMxQ==,iv:rHTskJ82LoBb11p76RU4yLzyWJFsCVBqkL65UCboT68=,tag:9cEQjQFMA9Ix372r7w9ugQ==,type:str]
+typesense_bootstrap_key: ENC[AES256_GCM,data:BRCH/lGWrMjov71vtUwltMC5zEgF+CMX6fpFcqZnJcb67iEpfxqo3+x7TS50rjoO+HnGOoWqqUMZrDYrcQc3Bw==,iv:MUI3YNHG14rqdBLEo8616XvapJgo1EyW3dlPtZrKT8Q=,tag:hCxQI7eRuKVarIktemPlKg==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-qa
@@ -37,8 +38,8 @@ sops:
     created_at: "2024-01-24T20:20:41Z"
     enc: vault:v1:ryD3PSZ0sUpniheec2bYEDduhjOWMvdQHBx1HGIUh+Tc1RkU+i11dSQIuDheIFqwh+FlDItuwstSBWSl
   age: []
-  lastmodified: "2026-01-29T19:34:28Z"
-  mac: ENC[AES256_GCM,data:UhTi72rfSO39J184+/WiLrcl7JrabSIvUYq3VECb6VAwyCYcE4l8whBoHrhSIjJWUHmfG4eJoyt1NFOV7FSmOdLfUBK4BQm1dk+rlxPZ9WKRRWTbnVTIi6BWiTJBUQfYTIN23Lk2cyxt+TW+2HsoF/0KFcom/pfG/a/Pl5N3VYg=,iv:PXb0EbQQ/LbsrLDRkAAlRIq00jlz+yt14rdtD18kmNs=,tag:nERvzeXo19KSzuF27B9EQA==,type:str]
+  lastmodified: "2026-04-08T17:49:44Z"
+  mac: ENC[AES256_GCM,data:5bNDn2o76oWtraCZYH8LTH2YSWYGDXl8q4ru+ohvXjM3Jl2Ha5PgCxEbxHJe07HCHPzeW3SwufqfOqMgM5s3/iXZ0j9qWQvAWe6jtdVXgtZRXtONRfHer9VZp8zbDQVst3eCr8E8s65ZBn5loJsknQhU7bkqv80qfhIwQrZdc6c=,iv:7cNATbBqCbecLmajuBOk1+O1qtSqKq93CEIYnqsK5fc=,tag:SqqU3ZomqTTyLCqv9l98xQ==,type:str]
   pgp:
   - created_at: "2024-01-24T20:20:41Z"
     enc: |-

--- a/src/bridge/secrets/edxapp/mitx.ci.yaml
+++ b/src/bridge/secrets/edxapp/mitx.ci.yaml
@@ -22,6 +22,7 @@ user_retirement_salts:
 - ENC[AES256_GCM,data:Q0DYjd6GHNtg19vLMjsJo1iabXbeUgjt4uxF8ofYrff1ZKjW,iv:AOtsr2SjlQL7DUubAFX01boGI33D16WBX790HHxlMUA=,tag:np84jzHl2WCqi24lrN7WwA==,type:str]
 meilisearch_master_key: ENC[AES256_GCM,data:6x0iOFqrRDNzCfez+dv7lpXdNynD04TPCEuHRhPdfMNYIFcrnJ5GdBuO9oLeGPdR3Ect1CN+TWgpvixUv6c6cg==,iv:E7fgLdPLIjNZDl/7ozSt2u2UNXb0gOs7RzFrHLkkntY=,tag:QWvZnOiwtmJS6LzUZ/jbjg==,type:str]
 meilisearch_api_key: ENC[AES256_GCM,data:ZYXoEiE9Ld9TK/FIcdMmjwO6G/rt61msiQZtrwiduvFj+L28qUqWCCAZ8Gjl5FZsweasJXQxTqUMf8aMdeo5gg==,iv:Twrh4TiDwez/L/Woo/bMqnENyxRvO5RWviZHWZXR5fU=,tag:jXWeWqHwuuAYAm5T8PPIcw==,type:str]
+typesense_bootstrap_key: ENC[AES256_GCM,data:Q2Fcvw0SHhcZpD5j08emVJ23NMQaRdW0ZFgU/gjMBrV+yIi92MUgQJiG8RhDFnx3rhwIUJCHqWaMX7UDuN6M4A==,iv:1oqRJUH+CrKecbDu6eCF1TF/yW98ArZ6gNjldDbWO+c=,tag:WZ39QP+gz/mSl7Vb398Lng==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-ci
@@ -37,8 +38,8 @@ sops:
     created_at: "2024-01-24T19:58:53Z"
     enc: vault:v1:geqMdaaYkEB/BOyQAllgH+AdInYMUlSc4ylgBca2jH3BX0Re/k7y09sKoNH5+FXC4AmIrgnR+FE45ocl
   age: []
-  lastmodified: "2026-01-29T19:26:16Z"
-  mac: ENC[AES256_GCM,data:ujrdD+WTxSD4c1EiUVAUS7LhZiutAPMUkb+xr0dt2wxDmhnaUTcmsb9KBUbG8uS8cB9zdt9iIkvsFDssVoc+oH6uEtjLHWKd06v69laseYKltR0EB1FUPHNEV0fFYhACrKIMhS21iKwJkbcKe/ltl2CyTzn4TXO32qPb7hBEo9s=,iv:cLko6daxkUOOxDuExo+4z6WObG0w5CpWAKzOJYEcnt4=,tag:r4x3iBmPcEAi2GqfgMUHPQ==,type:str]
+  lastmodified: "2026-04-08T17:47:56Z"
+  mac: ENC[AES256_GCM,data:ovx/4QN/0CSqIInHYqCyPe5AgcCOp1d3skaawa2MgrGLJyoDrMcFxPHVZK0/wsdNuMvjrkUoQ5e99EdGMnBpMm+ZsfhmhbbGVtoFdfPDypBLsV6J6jsH2nUy0tMJkPpePeBqXKeo2yIYm6kiLG5LO6oicnztNKft8mpZqKbgAhs=,iv:S4pd5Mn3kee3HbkMJhxwCpiFy3G2YCSkk/TF1Alu9Xk=,tag:3WlrEsPTeksgOKM7vrT3iw==,type:str]
   pgp:
   - created_at: "2024-01-24T19:58:53Z"
     enc: |-

--- a/src/bridge/secrets/edxapp/mitx.production.yaml
+++ b/src/bridge/secrets/edxapp/mitx.production.yaml
@@ -23,19 +23,24 @@ user_retirement_salts:
 - ENC[AES256_GCM,data:E4+baDSA+i8X0HNdXJ3k1NtOu0UnviJaeWfRve3XulkLzBsl,iv:WgeGcLhiWrjQDQvzvrWukp9yOAxRXn4/0REeLRIr7/g=,tag:8BEeNzphUcfqabDzyN0wqQ==,type:str]
 meilisearch_master_key: ENC[AES256_GCM,data:oyiXVuo3gb7Ku9x1uO4yuk1abjcGXU8HscPVGEVs0o8dxWvo6NJM5XMTZiW7CzaESTegeZrvXjeiFU0amuvWBw==,iv:Qh7uLrAtknBMWTHfulPAfaxHPaS/w67p73HpLJiRKJM=,tag:1dqzjKXxeN/xmExjueqWNQ==,type:str]
 meilisearch_api_key: ENC[AES256_GCM,data:b5slqHad9g==,iv:WT34HXg/0xGaXvSzDgxlR3I2mzpoUcyXSBrJVQ9ciYI=,tag:fR74rqrEan8YOfuAy92tiQ==,type:str]
+typesense_bootstrap_key: ENC[AES256_GCM,data:3DZyM5Igl1XZlIAidEMk1gNvSvdKUz+BAwqfxK4mEQQkZTP3Ep4p62MceiaHD387VyDXcA3TuXs3B2xqlEVzqQ==,iv:fsa7IvbzLm22UhpMjeIXA0Cc7fkaKnbBU1+pNELr9s0=,tag:Tx25A6cCwJO85hyvG5/Hrg==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
     created_at: "2026-02-23T16:23:47Z"
     enc: AQICAHi3FG4qowC3UzOLWOAA4Y9/RTwqKjovG3wyVVYDxkR+zAFJohZ7h5pQkbIGQVPSd3/TAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMq1u5P6BlwLtzX1xwAgEQgDugw32S89uP8WkOSdgVwTv1mCxgbqO54g32XRenGOY6vIpCtygrEvD+lzXDYigLhZgYsTQBSNiFPT+zIg==
     aws_profile: ""
+  gcp_kms: []
+  azure_kv: []
   hc_vault:
   - vault_address: https://vault-production.odl.mit.edu
     engine_path: infrastructure
     key_name: sops
     created_at: "2026-02-23T16:23:47Z"
     enc: vault:v1:VZCwFALEIGTzpVAzyjHMawkFwdu9HZLdUeaKoC50DpeejlC9HdH8R5CprYkB2GU8euHru/bDTvs4k0Jc
-  lastmodified: "2026-02-23T16:23:47Z"
-  mac: ENC[AES256_GCM,data:iaDNgIWfoFBUa5l2DY+kpXt4h+z5h/txFSFTcfDpV95dXd1V2DxmIEg81xqwvtJfIzoxuAG1RIrQJ1+0G8U0IODtKsMyMtB+lDSqcdRMkevCnnWL++bLRxLrdbMGVgUT6RLuC3/UTGLQJGoiubNUPLymIni1goCnj4YszoTTWVg=,iv:51HiZ2K+TDqMdvP6p+Ld7ipyLX4j1frJgU+WQ9UxUMk=,tag:CaNBf1QuCi1vey8swY/GuA==,type:str]
+  age: []
+  lastmodified: "2026-04-08T17:48:49Z"
+  mac: ENC[AES256_GCM,data:VKid1d9SUU8wFqZQBPlsLqsuiBBbwdVoOfxWjEgGTF14cXb7k73kAEM9ad9bKaeJnoUOWsIstorxEUF1MSMXo95kdjEm5ARicbyfJrz2xg194ercttnihMMHrCQBfJpns1Pk6EElT9CFbTcEhC7wEt/d9RWvfW1WcSXqpzBrrUo=,iv:NjYjQN99Pgya0whyjqp9iazw0UwV/PUqNID5lcShWuY=,tag:1zAxrn6EM4qbq48bpzfaJQ==,type:str]
+  pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/src/bridge/secrets/edxapp/mitx.qa.yaml
+++ b/src/bridge/secrets/edxapp/mitx.qa.yaml
@@ -22,6 +22,7 @@ user_retirement_salts:
 - ENC[AES256_GCM,data:FctNYF79bRiYPKYcUvLxvabkpoXqwAFv3Q3qKIIiGYXV2oLx,iv:pBakxJfR9MfKXhYvymYz698NqphEbLJ70byoW0OBhxM=,tag:ef0YiuakaWeWhjB4nbqzDw==,type:str]
 meilisearch_master_key: ENC[AES256_GCM,data:5F0rrkonBD1OocV5FmjYJU3WL6cJdZ+Lfp9CT0nuRsCC0RUr+BAABsSqV4hFCDa/OZM/KLnQNlXtXrn6L5YB0w==,iv:2dKt2BfHdiKswGFG3iWRrn4pCSK/oG6EZwPtl8xjmRg=,tag:pOUWO2Nygl/51bh4dp0q1g==,type:str]
 meilisearch_api_key: ENC[AES256_GCM,data:k+fqoNQ6LdmTfm/TrnjQQG1L3nwHODkIT4tv4xu9bAGm5VnXgIwGTL+QGen0Sa/DhOrU9zoxHu0UFUC+yy9Wrg==,iv:p0u01B93w3jTa5KQX+D8bD10PU68a4DsNUXd02+Zjy4=,tag:xYKGv1RFDx8mDRG2VvDpnQ==,type:str]
+typesense_bootstrap_key: ENC[AES256_GCM,data:Ay1cSq17oKLO2Zt1mhdqWUyczBpgTD5wMU+FdV2xmdSx3nbjONQHmY5cE472sm3dq+pdfhA2+EL+YRydRbL6sg==,iv:m1noREanMkkrkqdWvJIESYFRDXdA34uKh2ewth2SGKw=,tag:1VrCtevG3MyxwP2ndUqnWQ==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-qa
@@ -37,8 +38,8 @@ sops:
     created_at: "2024-01-24T20:20:39Z"
     enc: vault:v1:MWW3ZTm2rKEZ20FOMyhtNmKgT8bqGRw0kT8OzlcvA1Blma1saJ/0ng+oQnMPk+GvcVnW5mcPWojoBRhA
   age: []
-  lastmodified: "2026-01-29T19:33:26Z"
-  mac: ENC[AES256_GCM,data:JVhm7DqZ2BE1jx9Q7511g09nGRK7YPlvkib98Fc5yU14p/ux7HE8hs/klZE7RoYXgWriFGtHKUf02L7XtXzy4jCNd3UolUrnejcIVH4cuxhnEeskXbjnJYwezMHroS4HKw/T41NFdrAUUcmdDbXclk2s8VKFCPtyLaIZAohWFDQ=,iv:/hyXF4lyBS4nmIEotupki5qSbDtaKhvcTU2HGqwiNyk=,tag:8Raz/FrkP5Kpgb4k/apOVQ==,type:str]
+  lastmodified: "2026-04-08T17:48:16Z"
+  mac: ENC[AES256_GCM,data:K2XXoWsOqTwrIw7HG7/c32D7xyXF8BVLT804k/L2Uw1G65+n9vWM/fXRm9+/k9TI8tZfz/wqwOUni5ubf1EC7sTmE+Rv69jK0R+u7RugnVkC3YAyTQiD7AlO7pQCVOHyD36abMXm5YXLG3kDp5Cz6J1XAh6DIG4h3yu/QsF5AnQ=,iv:z0bngalNseWNzP4kJ1BvANa1Zg7k82Kf6LEacScyc8Q=,tag:96jowxyHqqd1lsaGrYC2qQ==,type:str]
   pgp:
   - created_at: "2024-01-24T20:20:39Z"
     enc: |-

--- a/src/bridge/secrets/edxapp/mitxonline.ci.yaml
+++ b/src/bridge/secrets/edxapp/mitxonline.ci.yaml
@@ -25,6 +25,7 @@ sysadmin_git_webhook_secret: ENC[AES256_GCM,data:3faJ7pjORmlsGSqn4oYmzN/TznQSzdu
 github_access_token: ENC[AES256_GCM,data:A7ba+oo3mUgDfVtYu0jm9hor3vaPgNvprHX8/X8Idszbz3iqiAY8bA==,iv:VqtqKGtCSwx9y6Ijx/BJrLTLlIpaQo8mCoq9onizAVg=,tag:bpJQexJFJq07+rQG+En7KQ==,type:str]
 meilisearch_master_key: ENC[AES256_GCM,data:36e4lYgbPAGSxTQDC5VYjEcXnyQ7rKRdInkTuLfYL6jdFwBfMeF6g1WVORnEdllYMDf7Ixo9Ty6JcBOdp/Txbw==,iv:gxM4u3F6oeXHCK1pDCjrInrXF6ZmP32mhzbK2iyo7n8=,tag:5l8q5lUp7xBEjE2K5e3fJg==,type:str]
 meilisearch_api_key: ENC[AES256_GCM,data:H1emHo5/df6MBXpsUNAISxlU+vFTiUzytQ2UPyGjiALVU8jJ9Mlg/feH7JSab8kSZEr4Dl/UyaqkCTVXJtmhKw==,iv:oIwgYgv7YDI0CA0Em3btB0+E6NUCe2w7ZEmfxVasR0k=,tag:d/PgI0UvYdm85rE88EDyeA==,type:str]
+typesense_bootstrap_key: ENC[AES256_GCM,data:UrYqYLW+GfeMxaPpAi7EfMz8r5enWVrSqiQfWGeKLz9tF9iHD+cpRihzQsDDeGbX29JFfnkexBq3L5vhvG7dBg==,iv:EDoCy6tic8She2LNFh4uh37JRj0ALpmC1MkfxUpFJxY=,tag:FpRUhCFVVOcZtnDkF23u2g==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-ci
@@ -40,8 +41,8 @@ sops:
     created_at: "2025-08-28T20:35:02Z"
     enc: vault:v1:hLtAum4sTZQgTXdhB78kGsXPj2m02TYFy2pu8dVo/akd0tPpmEzN8/ax0iypvf7anxbrMTCXAMNEm2Uv
   age: []
-  lastmodified: "2026-04-06T16:16:54Z"
-  mac: ENC[AES256_GCM,data:LIiqOrNkknkvi+36e3pmQqC0/WTMH69ot+az8qBZ5eyD++pmuxgzS6Oc4XLJLzU+5uqUAr2MPzFuVNaagUQLuCq3AyXxBG+oAHn3fw2gK78LR+2hNOIg9kUCJM1ayAjjiusPffLVTqSWWJy0JGdIR8hA3m/N0NUeoxPMI4UHk2Y=,iv:YyvY7SX809mPhC9jlYi96NVw3pNcqqQb6IWBujXvtW4=,tag:HroeHfV7ntJ3A1s4yz27cQ==,type:str]
+  lastmodified: "2026-04-08T17:46:28Z"
+  mac: ENC[AES256_GCM,data:7fBi1ohrI2Ldqjwax19jWUa9Xef49LdJbjoUoR39pMih8ruwa7hb5Lo+WezEhWpuwoVAOHha2vDy66bcNg67JspBA8c/KRrWAzP57lESUdmIgg/FX9TBbYwIP3xqeewzZOQCL61pBXX9vuE8iTOtcfQh6xEMg8HOsGJZrF2SqZU=,iv:yvocTVujlD94Ywf/L5iDWmzLy7xch7XaSxdhbbB6vkE=,tag:XauJBFeKbQmewsJE1iCDLA==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.10.2

--- a/src/bridge/secrets/edxapp/mitxonline.production.yaml
+++ b/src/bridge/secrets/edxapp/mitxonline.production.yaml
@@ -26,19 +26,24 @@ sysadmin_git_webhook_secret: ENC[AES256_GCM,data:zqVSczdMIr5uSucovW2Ruu5S/rdiXSK
 github_access_token: ENC[AES256_GCM,data:hg67iYujwEJsKBIdg6DL+E+xFS9wQn0mCUuf922NRmp1Q7b3odW0xw==,iv:coMJP+MiSe/cBWX1zzS/k9qf9jUOMcmIPA0xrcWRHgE=,tag:12kn3ECwqwFhhKVJCnSpng==,type:str]
 meilisearch_master_key: ENC[AES256_GCM,data:/3dHEF7G8qLExISc8d2QTLb38QSrHJhPEvUID7zqg7dS99m7ZDI0HSuCNlXh+AHA2ye899LxLutNpoyl5Z08JQ==,iv:2Z+FoYp/qYxHSU/fciR5p0Pkl0RMKJTFa3bZgLp0ZGQ=,tag:pBCnqjnx9P+0NmMDoXI7vA==,type:str]
 meilisearch_api_key: ENC[AES256_GCM,data:l5RBU6uhMukaij08MVRNGTDX3poTyQ2MCkwsEtRfmS3wpOihbtK03zHWq0fDV4gPRCSIIcV/JAULTQ4ieuYI5Q==,iv:FMbGjqNO6wes4WwAAfMY2njUajKPt9bcf9FWgnTBa54=,tag:vUS14fxXWK9f/BZAzGxn4w==,type:str]
+typesense_bootstrap_key: ENC[AES256_GCM,data:ZvaZh5CFQxxt/fvRLS22Tk5iB88EuBPk03YBOp0b/Msw+n2bdeE9vpMn+2SiKTp9RVc0/jie3ewnXvZwdgNR6w==,iv:XEbPsyfvAws9qgjTla0ay5nPIDqbFaZ1vzv88Hd2qKE=,tag:ZZADeCeFGidnyo1AqNFn7A==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
     created_at: "2026-02-23T16:23:32Z"
     enc: AQICAHi3FG4qowC3UzOLWOAA4Y9/RTwqKjovG3wyVVYDxkR+zAGQRhidTTSRdqHrmAw6VSuhAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMKKLTPX27vQVm6+QfAgEQgDuvVEh5I4Z00IEVT9bS9viXvGsITixK4xLE0h187Lsu9cZ0uZIXq8NwJHk9IwrDJ68iM8sWCjXBsd5N/w==
     aws_profile: ""
+  gcp_kms: []
+  azure_kv: []
   hc_vault:
   - vault_address: https://vault-production.odl.mit.edu
     engine_path: infrastructure
     key_name: sops
     created_at: "2026-02-23T16:23:32Z"
     enc: vault:v1:dENz887tU/JbibzTNM6uvzdGc/61Q6p+5uMZkgLO9Ql5Myx5ka2T9JnDxH5xQdblVrH7bZ0hf8WO0TDx
-  lastmodified: "2026-02-23T16:23:32Z"
-  mac: ENC[AES256_GCM,data:GPlcM1lTz0Px3PdPUW3rqGbTC4q7o3/SRd1IacHZjQqDHW0TdYdM0eje9coymXSvmys4h4uA6KHFceTkoUc0sLYYfNrLdjCBRMyrot9ZPy0rT2tc1MuzMet7eOakgMf10oTMr6BgOqTj6KZ+Y2/5Sf4p6knWRQwRz3hV5eoJvxc=,iv:F/Bs44Fy6eEZ8tp6+y9ouFBOvyT3da5NJpPMTT62eO8=,tag:Kfv3FOTK7SKsdMYoeJ/1Yw==,type:str]
+  age: []
+  lastmodified: "2026-04-08T17:47:26Z"
+  mac: ENC[AES256_GCM,data:XVHqjKAD4gWJXQMyrD77vdtpsZAnvQWmcaH4sid+P5M1UdIhFjNvVaFP7wGb1Ve9r6moxaE1rsQ/lX2iYabTEu690y0fnU75ZCZ+wO6WqvBCAakpyHdc15JGa4y0NvNeM6Cint9f250iUnFcVprtmJ7X6yYj61/cae0eGF8/st4=,iv:6IIwZ5rdbIQHjqraYEgPsuwsYF06zif7KGZxQoM36fg=,tag:Ws5SOvxvLdVNF3NpvJ2Lfg==,type:str]
+  pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/src/bridge/secrets/edxapp/mitxonline.qa.yaml
+++ b/src/bridge/secrets/edxapp/mitxonline.qa.yaml
@@ -25,6 +25,7 @@ sysadmin_git_webhook_secret: ENC[AES256_GCM,data:PhMN34W7Qo2gOqn6dv+/Ub9js0qkU2m
 github_access_token: ENC[AES256_GCM,data:CSsR6fFcKrz6T9Q7XXZ/wOzsEUXMJTXno8OW5WgdrlQG2Ty68yPI+Q==,iv:xIHgoE6OlXLkroy/Lg/Btum/BHLveQPHmcEAUZc6Awo=,tag:TaINbR/XGZR3ov6uj7ahMw==,type:str]
 meilisearch_master_key: ENC[AES256_GCM,data:AruMFclrbpvG30v6aCYvtP6F3mcAGerA2hB/3UqMNypoJGIITwUcKP0YJSsBSAFqoEiPQ3BiyyI/oJM0zI42Iw==,iv:iwxf1Y6DME9Iq9bENhhulYeZyPEJESr+Wz/4fY3aBY0=,tag:K2Y8ZwoLbk7y9+WoOh/jJQ==,type:str]
 meilisearch_api_key: ENC[AES256_GCM,data:KgOLFKuVlzhmvAnSgewqLOjXzWFeUGPQ8aJ4NpljIKPKm3zu33w+XA8Lry+0+DI2yQW+auxhC7LHQS/eAIlH3A==,iv:MUgfZfWXgYpjjCPpeYQ1KD3uuC56fvSya+KRgPEzee4=,tag:HDytyH56dJcRcIYZMDi+lQ==,type:str]
+typesense_bootstrap_key: ENC[AES256_GCM,data:6uNFa7No/8hLrgzoKqUhTPUWGoM3URrcW5E+Zye0fFRgZ/9idtwgvi1J6aJCsq1b2pyukfSNQJcWYOurju1rWw==,iv:hMHBo3QIiiWy1FQ4GVuW/jHdrqXgrZ1ESKTQwaOcbsQ=,tag:UeAbCRp60i+FCkvIDA+k4A==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-qa
@@ -40,8 +41,8 @@ sops:
     created_at: "2025-08-28T20:37:22Z"
     enc: vault:v1:myA322x4V71XWIYseRNjdHuJMe9sPAKQ3rQrPF95bzQ34WselInLQ4nVNGeBy7HY+4wVTg2vUBnAce4Z
   age: []
-  lastmodified: "2026-01-29T16:19:16Z"
-  mac: ENC[AES256_GCM,data:727wB55N4S7xpBt5TNuu2mGAtLq17FMqIa+oJtI7hqJBo92d/UW4leogoXiUjSyCyiNUgI7UJiCRAyQ7igSxxrXpnELOl5HnFPrgFUuS81MVjD+6pB5AVQhBpFtUzZ2/1Btd+/1sgF0XSTlxPOKvPBRFpCSGj0g3KgpW54y3k/g=,iv:BORTm5wIcghPJnjwqCHn/FWs9wN+Xk0Ovd7wrLnPbqY=,tag:icfOSgWf35TrkLWxTZFR1g==,type:str]
+  lastmodified: "2026-04-08T17:47:02Z"
+  mac: ENC[AES256_GCM,data:6Bxx35H8KyZNqGeSFWDOI3ocQ+otS7nDybcOy6d38qCcsIs/ShijkPksTwP3X/2JCD8jLdjZz+nwCrQLAfsTQskCAMtxutAIpL4EmG1C/u6A33VTuFlwVYEMG5a4bUU9x3tXahDJmJTuae70UKI6ji+eX/akGVmqNR65doZ6bHE=,iv:Z+MOkZoXL70+bHJeTpvZzjZd9fEU2EJRTs+Fn//co8s=,tag:9ec/h3Qc0iom5kDAEkxCaA==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.10.2

--- a/src/bridge/secrets/edxapp/xpro.ci.yaml
+++ b/src/bridge/secrets/edxapp/xpro.ci.yaml
@@ -17,6 +17,7 @@ user_retirement_salts:
 github_access_token: ENC[AES256_GCM,data:O3CyS0IMYTecnsVtr3V7MtNthHk7/n1QGwvb0HUPzxjDytXRYE3LKA==,iv:t0aBoo954dRqTS8y5J3IzLZPMlhMNUig4O8mpr0eyTk=,tag:bxOUWYUKHrNARMFtk7TzSA==,type:str]
 meilisearch_master_key: ENC[AES256_GCM,data:MeMFcHUJGjCkkVPKLLu4ncHS9krg4fJXnFGEdo///nXRKstA/AD51+izFLmdh4BWZ300bXNlRFoePpAOtNZJYw==,iv:UVaQFxvurRomL+U8a85D1gvoBcvYoLFAhwkouDVVppE=,tag:l73W44WDIUF6EzBKUbTWqw==,type:str]
 meilisearch_api_key: ENC[AES256_GCM,data:H3/44WXGRUi0yi9H5ksxqd3Ak9K4tQ6jPZ2N3uCQcZpnHJbff907ggnKNvdqPddWewM8uqiCkp0jzski3llc4A==,iv:NW85WfwFBOm4HHtS2ks/uk12i2XXK31UuGedyZRGlqA=,tag:6zahEFEwq7knKAJUhZikzQ==,type:str]
+typesense_bootstrap_key: ENC[AES256_GCM,data:SA80HsdiZC/XDj8reBHOoy0zqSqN9X8Chsv33fxQv/QK+EHD4aMopprlPdWahQuMtZvri9t3z3KcKm0lgiYc4Q==,iv:PpJpD4nbEP6ffTJNPdW5D74jsJ5TkCFPBfxDSFsak8I=,tag:FXuyKwd/B+/Bv9rxrJEcpQ==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-ci
@@ -32,8 +33,8 @@ sops:
     created_at: "2024-01-24T19:58:56Z"
     enc: vault:v1:gNmbSqZKfMu3Wllyvby83SIInqWQ6cZp4WWfPo3ybgDQAKQMcc8A/coDv8eXYXduYSPyZjONyHKtVgw7
   age: []
-  lastmodified: "2026-01-29T19:25:49Z"
-  mac: ENC[AES256_GCM,data:PJv9AWZI95gkChA3ZljNUpTi8jylfMa0dYETUSlRQn0IrMylwvm53K4hxl5ysbB7+hViq4WHBLjszw2zWWNUTKQeOero9PnehAAPqLVoMjk64DcGfDDE2qcl0+C18Z7+YA9rSdQsJ9IikeuEQBBNDU/AxBIZykKVfZgHL674UW0=,iv:VPQJW59s3jIXbqSBjE2C58CLHnUWvJI7Wj1XrrhUO4k=,tag:aprb5clXNHpTyL/UAT1pMA==,type:str]
+  lastmodified: "2026-04-08T17:51:29Z"
+  mac: ENC[AES256_GCM,data:fLYg/aUtzmAn4v122smcDrycaJpXhR2tgGmPj+Oyy6j3DqjO2NWtVHa0/NolWPcvPBrA34hxbKZL0iQYjgvMZcpN80JXQIRYN4ztVuw/hViqKXfJegyxbquQrI66OoECIjuwy0Nfdq3r6EY72GwSH/Yu0y/QUk5COfQbyHNw3IM=,iv:ye3iGuJDevKNeAHqeFZO+3HCrQibBoZVu6nUytVoimo=,tag:8djDExzEoUeE2dNznp/6lg==,type:str]
   pgp:
   - created_at: "2024-01-24T19:58:56Z"
     enc: |-

--- a/src/bridge/secrets/edxapp/xpro.production.yaml
+++ b/src/bridge/secrets/edxapp/xpro.production.yaml
@@ -18,19 +18,24 @@ user_retirement_salts:
 github_access_token: ENC[AES256_GCM,data:AR61V0Ik58bO4p1rWQeBoYvht81Z5l4a08nx0lCh5PxN30ROK02NvQ==,iv:tLc+hObrxu7zfuS9yPJPfJx+VTx6DW0CklcA7h7/b/w=,tag:z7phMLo2VA5VnQA7s0th2A==,type:str]
 meilisearch_master_key: ENC[AES256_GCM,data:h3pbLNIiCTBTT5Y3w4WaYE5zkPmnf+4xtatY8zfh0RQAKm4ejWqgn9YUlTpkaDnqQFmYXONJMJgth+Eu0dHP3Q==,iv:cfuOn2WoXEn19l9RBHBS96kf73P8ZUFFjdC1Fyi9HXo=,tag:Q8oHJAJZOmYqL0qZvNAbjw==,type:str]
 meilisearch_api_key: ENC[AES256_GCM,data:gXxSycQbJUSrxb89hHw69/LN9uoYA1JBRFBj2C/MvnCI+2E6aW2Ii6+pzYOaCTARib4/q4MhrdnGz2gouzA1Sw==,iv:tX4LSTBne809iLGVdhrFbxW+L8mo0Pyd1nEtB01REBQ=,tag:lzv2bJpGCd6VnPeALmcyYw==,type:str]
+typesense_bootstrap_key: ENC[AES256_GCM,data:8NXxG3OAgdH1EGS8ftZotxEMy4Ub+2IdjlqNJ7UmBwdT4acyQzlJUwYQX84Z/1R51+hddwAK5I6X9wmC3B9www==,iv:0oRD50pHzKnSAmZGCNlbU9bL1fxawi7tdxvHQWj9hAo=,tag:oyw5BRWIDkBPk/mbZlrOuw==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
     created_at: "2026-02-23T16:23:20Z"
     enc: AQICAHi3FG4qowC3UzOLWOAA4Y9/RTwqKjovG3wyVVYDxkR+zAEqyz+kbxdWwlyDFszxvgrKAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMRGKYl3WzBn3MvBA9AgEQgDv4fTPcuvXfBiaf09C7uG+WuY+FCQ56rQR9lrAUwWB7DLLQs32BfToW8IQKinPy19JlP/yeE44aePfCjQ==
     aws_profile: ""
+  gcp_kms: []
+  azure_kv: []
   hc_vault:
   - vault_address: https://vault-production.odl.mit.edu
     engine_path: infrastructure
     key_name: sops
     created_at: "2026-02-23T16:23:20Z"
     enc: vault:v1:Sw47evhFtP89HMz9jVKn95j6RFF+T0KxAXjb11Brcjf98F8ekFU3gYJ18xuzU7DfIYD7loudidMJMgYf
-  lastmodified: "2026-02-23T16:23:20Z"
-  mac: ENC[AES256_GCM,data:TUBSzc5j8JtACjneIZHrmOIIsTGfEIgZCoZqXe5D7tkpDvMqANXOXH1/natLK9t/BhKP9vESiKV3/sJO6jDCiyMN+88tVoYMSlgplz8OC6gtY2UzQXNAiiitVKQgb+Jnn2dbe2cJyvFljD5NDA7VQJ/+4im3kIxDKlPCTqLEUsI=,iv:Ue1GRtkranR9v/fQBjprgQgvhBPx6Ooa2PiLvtgdoM8=,tag:iyD1bfDVscYE0L3BclLlfQ==,type:str]
+  age: []
+  lastmodified: "2026-04-08T17:52:15Z"
+  mac: ENC[AES256_GCM,data:41EI58QYOMqzBAUVuQhbgG+xfWnkgs19IIR/S7Xjd/Olj8eKDrEFLfRaDGUc1Q+iLBOT5GCQvZ4PZRLjVV9iDAPM6s0zU8WUmqnusXu0dbUgnLpsoQEpFuqjDFEQIaQ1vrPa66Y11xDFJs55Faqbws9w7SnlKFz90JdUISZhI+s=,iv:btQB07KF0fEwiK3R7ueaCfdfRQ2v9gZyeWJzWPKbl8U=,tag:mm6NoV8NBXDpayxeVnNwMg==,type:str]
+  pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/src/bridge/secrets/edxapp/xpro.qa.yaml
+++ b/src/bridge/secrets/edxapp/xpro.qa.yaml
@@ -17,6 +17,7 @@ user_retirement_salts:
 github_access_token: ENC[AES256_GCM,data:rLKvw9Uq5dUz3x8HRxB4nb5BUcHzCx31ppg3FSJP8fEuKpZZky6Giw==,iv:h79CN9A5zLDH77eijAaTF8fGo9wJ/iNthyKNj2/HK7c=,tag:VrXGaOfelz6UY1jG5r8s4g==,type:str]
 meilisearch_master_key: ENC[AES256_GCM,data:fd6YCBfyJgR6yrg870UbYqYl05SH0LcZPaRqyBIpemN8A5R1KtymaQwdqnwY0J3Pmv5Uwx+vmLH4am6P8/hU6g==,iv:OWyoZs8MzBL9kTD0pxIZPKxWf9qopmtM5FgbBFspm6Y=,tag:qFsdkGlOT2Gjb8njTSJGfQ==,type:str]
 meilisearch_api_key: ENC[AES256_GCM,data:k8Z4UVXVzFwPlNk/ma8LWxSXYkHxEKiU+Ou0Rya4Xfuo4VAnwTvbytc3RcAHmhMRiLhvx/8nETEloJCziZ37ow==,iv:o8S5EucKQvF2WRKthmJfPSf8YU5scqWlLt6nC92J/4g=,tag:YvBLPMl0U0Ga0snjzYAv7g==,type:str]
+typesense_bootstrap_key: ENC[AES256_GCM,data:e+N2tMZlrKg4Tw8ZfkwsAREarxawwmiVnyOp8SS5vxqMo3gkhaiuW+GuqOsLjRLp94QbNLPAAntcypsaEZSR4A==,iv:ZYWTLZI6YuSg0VC8K2eU0bqeOCGrx3VLUiI7mbt7fao=,tag:exDaK05YijRAkajACkpPTQ==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-qa
@@ -32,8 +33,8 @@ sops:
     created_at: "2024-01-24T20:20:46Z"
     enc: vault:v1:aVmaUwwhksjOmD2ievgiTBT8J8Ra7sQhquWs82r0ABGqBaiSFXUE/gMB2zBGAfGJb/3sK0E6vzDr37QQ
   age: []
-  lastmodified: "2026-01-29T19:35:25Z"
-  mac: ENC[AES256_GCM,data:nYYtWi2J6r46CKFgJkNoQ8ozGG43DJahQ6M4nAt7Ay4Uqf2e7KjkVK2J2/oxkhpcWaHsGKlyKJ5a6yc5lm40ZrrAIYClSfw4cE+4zNtSQbaUB407toEOoHSXJshJV04T+fU0jjMO7+tfFyUuwp977qobIUMr9kctAje2q6at75M=,iv:LS+2j/CF3UiiguYYd1Gp71LzZFkDoUIaTLyPnSWuIWo=,tag:votZ3o9S5v4XUOxPN/xcfw==,type:str]
+  lastmodified: "2026-04-08T17:51:56Z"
+  mac: ENC[AES256_GCM,data:1igorcwe/NUWlBCGPvAIcU9Ik/O8CV1ByeQmXrgQeT0QOJJkzo7iAPUy3I5YDCnB5Tr5IXrn1AVNwGKPF9XbqYrvD0C3VleX4hlqiLw4HWXI44/Z0gU89Ffclix+rEmm0Oei9Oe77QBWhlP6WlHIAhDjmeysM7BTm+0tvWxcdKY=,iv:6C23/cyZfUE+U5fCEF66AU0i1PQPizln2c/ouN+Zg8g=,tag:cCteAKeyNtn8IwiHQ8Gd3A==,type:str]
   pgp:
   - created_at: "2024-01-24T20:20:46Z"
     enc: |-

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.CI.yaml
@@ -124,5 +124,3 @@ config:
   meilisearch:memory_limit: "1Gi"
   typesense:deploy: "true"
   typesense:enabled: "false"
-  typesense:bootstrap_key:
-    secure: v1:y04vN0z80H+bcJIs:l6LS1eJrokgNnyWpCbV/7G0yzG72mv1dtGOWvWljZUdUUTA5oEd7pZj/8OeOWDPqUxnnWvM5lRi+AhA8TmZxvvx73fhzu02tgraOilYsuBU=

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.Production.yaml
@@ -127,5 +127,3 @@ config:
   meilisearch:memory_limit: "4Gi"
   typesense:deploy: "true"
   typesense:enabled: "false"
-  typesense:bootstrap_key:
-    secure: v1:Wpp+qWm4Ln5toRHy:qHBx1Th7dWTghihKa88fUzu6xr5z5DkQYyb8v3pjqFTK4Yd6EIs5xCK6xk9We3WBnCEmxElnxyT8w3SyQprqLTpzerj4C3Kd1xY4OO7glMI=

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx-staging.QA.yaml
@@ -125,5 +125,3 @@ config:
   meilisearch:memory_limit: "1Gi"
   typesense:deploy: "true"
   typesense:enabled: "false"
-  typesense:bootstrap_key:
-    secure: v1:yiNQEJ+5tqmqzT0n:dtzJ/I/8a1Laag/ozwuGC2qoNUI+wMQWsTgTZ56t4YFF/AUjn/Inv8RIdCPc9c03mIZixIG8jete360saGXfiJ3hm/JHCOSz1xeEef20l7w=

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.CI.yaml
@@ -135,5 +135,3 @@ config:
   meilisearch:memory_limit: "1Gi"
   typesense:deploy: "true"
   typesense:enabled: "false"
-  typesense:bootstrap_key:
-    secure: v1:z0HcchgIyTOU/9e1:VVxPqu4YxYmnTbJVmwRe3UQgGV9dWUjDVNb665loD89WWtqBlT9PrQZhQW6hTmtVSio6CbI/4sFBEjYUEFzf8yH8caC/wabpOR5Gbypp1h0=

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.Production.yaml
@@ -141,5 +141,3 @@ config:
   meilisearch:memory_limit: "4Gi"
   typesense:deploy: "true"
   typesense:enabled: "false"
-  typesense:bootstrap_key:
-    secure: v1:ZdFbrn54MEh6LMsK:jeq3S8pizyZM4cVeH90k66OEavcNxTq14w6vJj+c4UcU6MhQSHhFKy2rr1Yze9zYnWQjKFPmasmSJ53ljOd564bB680z/NSN5SNO8jNV0KI=

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitx.QA.yaml
@@ -136,5 +136,3 @@ config:
   meilisearch:memory_limit: "1Gi"
   typesense:deploy: "true"
   typesense:enabled: "false"
-  typesense:bootstrap_key:
-    secure: v1:9mjLSEadatYpmU9K:TTiq9gAtOyKOoex43LD7gj/FlCIUomsETCRrt1XQkJgANLkbynjlSj64KDB7J5pZsaIX9FwvTudb/NAv6mbQ2tcrYhoa+zCwgz4+xTq3eYQ=

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.CI.yaml
@@ -150,4 +150,6 @@ config:
   meilisearch:memory_request: "1Gi"
   meilisearch:memory_limit: "1Gi"
   typesense:deploy: "true"
-  typesense:enabled: "false"
+  typesense:enabled: "true"
+  typesense:course_search_enabled: "true"
+  typesense:forum_search_enabled: "true"

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.CI.yaml
@@ -151,5 +151,3 @@ config:
   meilisearch:memory_limit: "1Gi"
   typesense:deploy: "true"
   typesense:enabled: "false"
-  typesense:bootstrap_key:
-    secure: v1:9n3O89ID5lZ1AQJC:oNMWFAClYYNjULnDE6NOR5+Pj6anL+qrJ1ZijGE1DGljrYmY8xBsWBNrPOmBOjI0ej1uHIr3+cPRlEVyaR83aoEH8vWWEBprkbr3TbLHGkA=

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.Production.yaml
@@ -150,5 +150,3 @@ config:
   meilisearch:memory_limit: "4Gi"
   typesense:deploy: "true"
   typesense:enabled: "false"
-  typesense:bootstrap_key:
-    secure: v1:WHEQs3w8gXDymViw:AjjoxqoCmm6TCsO+X8J8Euhi57AjbpiLjwV0KpL2EnTSlQSjUoqv4VPz8dMgx5kKTiXHwuDZWmKv9fwNuPQPGocpI3/zqn6XIJdpg+YucQk=

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.mitxonline.QA.yaml
@@ -152,5 +152,3 @@ config:
   meilisearch:memory_limit: "4Gi"
   typesense:deploy: "true"
   typesense:enabled: "false"
-  typesense:bootstrap_key:
-    secure: v1:Vc3NR0Nwh4t5F4yQ:4xcl9T5cuxUM8qVaj+l7upvIiGuupp9NR7QC+ZPQTa5txMWMCeyC6MUIzhGgtw9Wh4tKRGEwkebDhBG46i2SfC24r1T4BrrmpSTxJTaCf0o=

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.CI.yaml
@@ -115,5 +115,3 @@ config:
   meilisearch:memory_limit: "1Gi"
   typesense:deploy: "true"
   typesense:enabled: "false"
-  typesense:bootstrap_key:
-    secure: v1:hcjVLbhLxeouRxCw:OBqqga8VHRf0SwBng2rWWGd4GqQV7q6Wpl9WbDcGOH8dyfoFGNHvSyIdvYABM2leeC4xkyYN+A3nAREyArq6mr2IHKy3nHHcKAWn/2adQ40=

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.Production.yaml
@@ -112,5 +112,3 @@ config:
   meilisearch:memory_limit: "4Gi"
   typesense:deploy: "true"
   typesense:enabled: "false"
-  typesense:bootstrap_key:
-    secure: v1:tCCP9DtDKgEJfll5:zTkEhO/k0UrKTX9vGNtf7mzzN7cgPqUDqL+Zkj/UkSsgGI1SCuHwcM5mKgMxbn1105WSiEwZx1TlckpqdKTOhoqHURBbLl4dgnlYNiixePI=

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.applications.edxapp.xpro.QA.yaml
@@ -112,5 +112,3 @@ config:
   meilisearch:memory_limit: "1Gi"
   typesense:deploy: "true"
   typesense:enabled: "false"
-  typesense:bootstrap_key:
-    secure: v1:A8WvY7o//RDKohX7:tXV9NlMbjAkzLuQykqQomNxvZ1ZSWQlnkwk6Bcsw0fg0ig4sVNiHanUtkrovJaxKyun5XjuqM0bPBRiJvQrxkfbf1wsqxCvsypnKVEvrQ/U=

--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -193,6 +193,26 @@ def _build_interpolated_config_dict(
         "ECOMMERCE_PUBLIC_URL_ROOT": domains["lms"],
     }
 
+    # Ref: https://docs.openedx.org/en/latest/site_ops/how-tos/use_typesense_search_backend.html
+    typesense_config = Config("typesense")
+    if typesense_config.get_bool("enabled"):
+        config["TYPESENSE_ENABLED"] = True
+        # Typical URL:
+        # mitxonline-ts-sts-0.mitxonline-ts-sts-svc:8108
+        # Ref: https://docs.openedx.org/en/latest/site_ops/how-tos/use_typesense_search_backend.html#clustered-typesense
+        # "For clustered Typesense, it is best to provide urls to all the
+        # nodes to TYPESENSE_URLS, rather than putting it behind a load balancer.
+        # This allows the Typesense client to manage load balancing and fallbacks itself."
+        config["TYPESENSE_URLS"] = [
+            f"http://{stack_info.env_prefix}-ts-sts-{i}.{stack_info.env_prefix}-ts-sts-svc:8108"
+            for i in range(typesense_config.get_int("replicas", 3))
+        ]
+        config["TYPESENSE_COLLECTION_PREFIX"] = "openedx_"
+        if typesense_config.get_bool("forum_search_enabled", False):
+            config["FOURM_SEARCH_BACKEND"] = "forum.search.typesense.TypesenseBackend"
+        if typesense_config.get_bool("course_search_enabled", False):
+            config["SEARCH_ENGINE"] = "search.typesense.TypesenseEngine"
+
     # Residential-specific configuration (mitx, mitx-staging)
     if stack_info.env_prefix in ["mitx", "mitx-staging"]:
         # Add Canvas and MIT IDP to CORS whitelist for residential deployments

--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -209,7 +209,7 @@ def _build_interpolated_config_dict(
         ]
         config["TYPESENSE_COLLECTION_PREFIX"] = "openedx_"
         if typesense_config.get_bool("forum_search_enabled", False):
-            config["FOURM_SEARCH_BACKEND"] = "forum.search.typesense.TypesenseBackend"
+            config["FORUM_SEARCH_BACKEND"] = "forum.search.typesense.TypesenseBackend"
         if typesense_config.get_bool("course_search_enabled", False):
             config["SEARCH_ENGINE"] = "search.typesense.TypesenseEngine"
 

--- a/src/ol_infrastructure/applications/edxapp/k8s_resources.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_resources.py
@@ -440,6 +440,8 @@ def create_k8s_resources(  # noqa: C901
         lms_edxapp_config_sources[secrets.translations_providers_secret_name] = (
             secrets.translations_providers
         )
+    if secrets.typesense:
+        lms_edxapp_config_sources[secrets.typesense_secret_name] = secrets.typesense
     lms_edxapp_secret_names = [
         secrets.db_creds_secret_name,
         secrets.db_connections_secret_name,
@@ -456,6 +458,8 @@ def create_k8s_resources(  # noqa: C901
         lms_edxapp_secret_names.append(secrets.lms_oauth_secret_name)
     if secrets.translations_providers:
         lms_edxapp_secret_names.append(secrets.translations_providers_secret_name)
+    if secrets.typesense:
+        lms_edxapp_secret_names.append(secrets.typesense_secret_name)
     lms_edxapp_configmap_names = [
         configmaps.general_config_name,
         configmaps.interpolated_config_name,
@@ -724,6 +728,8 @@ def create_k8s_resources(  # noqa: C901
         )
     if secrets.meilisearch:
         cms_edxapp_config_sources[secrets.meilisearch_secret_name] = secrets.meilisearch
+    if secrets.typesense:
+        cms_edxapp_config_sources[secrets.typesense_secret_name] = secrets.typesense
     cms_edxapp_secret_names = [
         secrets.db_creds_secret_name,
         secrets.db_connections_secret_name,
@@ -741,6 +747,8 @@ def create_k8s_resources(  # noqa: C901
         cms_edxapp_secret_names.append(secrets.translations_providers_secret_name)
     if secrets.meilisearch:
         cms_edxapp_secret_names.append(secrets.meilisearch_secret_name)
+    if secrets.typesense:
+        cms_edxapp_secret_names.append(secrets.typesense_secret_name)
     cms_edxapp_configmap_names = [
         configmaps.general_config_name,
         configmaps.interpolated_config_name,

--- a/src/ol_infrastructure/applications/edxapp/k8s_secrets.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_secrets.py
@@ -50,6 +50,7 @@ class EdxappSecrets:
     git_export_ssh_key: OLVaultK8SSecret
     translations_providers: OLVaultK8SSecret | None
     meilisearch: OLVaultK8SSecret | None
+    typesense: OLVaultK8SSecret | None
 
     db_creds_secret_name: str
     db_connections_secret_name: str
@@ -64,6 +65,7 @@ class EdxappSecrets:
     git_export_ssh_key_secret_name: str
     translations_providers_secret_name: str | None
     meilisearch_secret_name: str | None
+    typesense_secret_name: str | None
 
 
 def create_k8s_secrets(
@@ -126,6 +128,7 @@ def create_k8s_secrets(
         "14-translations-providers-yaml"  # pragma: allowlist secret
     )
     meilisearch_secret_name = "15-meilisearch-yaml"  # pragma: allowlist secret
+    typesense_secret_name = "16-typesense-yaml"  # pragma: allowlist secret
 
     # Database credentials secret (dynamic - depends on DB outputs)
     db_creds_secret = Output.all(
@@ -411,6 +414,23 @@ def create_k8s_secrets(
     else:
         meilisearch_secret = None
 
+    typesense_config = Config("typesense")
+    if typesense_config.get_bool("enabled"):
+        typesense_secret = builder.create_static(
+            name="typesense",
+            resource_name="typesense-secret",
+            secret_name=typesense_secret_name,
+            mount=f"secret-{stack_info.env_prefix}",
+            path="edxapp",
+            templates={
+                "16-typesense-secrets.yaml": textwrap.dedent("""
+                    TYPESENSE_API_KEY: {{ get .Secrets "typesense_bootstrap_key" }}
+                """),
+            },
+        )
+    else:
+        typesense_secret = None
+
     # Return dataclass with all secrets
     return EdxappSecrets(
         db_creds=db_creds_secret,
@@ -426,6 +446,7 @@ def create_k8s_secrets(
         git_export_ssh_key=git_export_ssh_key_secret,
         translations_providers=translations_providers_secret,
         meilisearch=meilisearch_secret,
+        typesense=typesense_secret,
         db_creds_secret_name=db_creds_secret_name,
         db_connections_secret_name=db_connections_secret_name,
         mongo_db_creds_secret_name=mongo_db_creds_secret_name,
@@ -441,4 +462,5 @@ def create_k8s_secrets(
         if stack_info.env_prefix == "mitxonline"
         else None,
         meilisearch_secret_name=meilisearch_secret_name,
+        typesense_secret_name=typesense_secret_name,
     )

--- a/src/ol_infrastructure/applications/edxapp/typesense.py
+++ b/src/ol_infrastructure/applications/edxapp/typesense.py
@@ -1,7 +1,12 @@
+"""Typesense custom resource definition"""
+
+from pathlib import Path
+
 import pulumi_kubernetes as kubernetes
 from pulumi import Config, ResourceOptions
 
 from bridge.lib.versions import TYPESENSE_VERSION
+from bridge.secrets.sops import read_yaml_secrets
 from ol_infrastructure.lib.pulumi_helper import StackInfo
 
 
@@ -27,6 +32,10 @@ def create_typesense_resources(
     if not typesense_config.get_bool("deploy"):
         return None
 
+    secrets = read_yaml_secrets(
+        Path(f"edxapp/{stack_info.env_prefix}.{stack_info.env_suffix}.yaml")
+    )
+
     typesense_bootstrap_key_name = "typesense-bootstrap-key"
     typesense_bootstrap_key = kubernetes.core.v1.Secret(
         f"ol-{stack_info.env_prefix}-edxapp-typesense-bootstrap-key-{stack_info.env_suffix}",
@@ -36,7 +45,7 @@ def create_typesense_resources(
             labels=k8s_global_labels,
         ),
         string_data={
-            "typesense-api-key": typesense_config.require("bootstrap_key"),
+            "typesense-api-key": secrets["typesense_bootstrap_key"],
         },
         opts=ResourceOptions(),
     )


### PR DESCRIPTION
### Description (What does it do?)
Adds secrets and configmap entries for installing using typesense as the search backend for edxapp installations. Only enables it for mitxonline-ci. Disabled for all other envs. 
