### PR TITLE
fix: pass TRAEFIK_VERSION to TraefikConfig in AMI build scripts

### DIFF
--- a/src/bilder/images/concourse/deploy.py
+++ b/src/bilder/images/concourse/deploy.py
@@ -313,6 +313,7 @@ if concourse_config._node_type == CONCOURSE_WEB_NODE_TYPE:  # noqa: SLF001
     )
 
     traefik_config = TraefikConfig(
+        version=VERSIONS["traefik"],
         static_configuration=traefik_static.TraefikStaticConfig.model_validate(
             yaml.safe_load(
                 FILES_DIRECTORY.joinpath("traefik", "static_config.yaml").read_text()

--- a/src/bilder/images/consul/deploy.py
+++ b/src/bilder/images/consul/deploy.py
@@ -56,6 +56,7 @@ consul_configuration = {
 
 # Install Traefik
 traefik_config = TraefikConfig(
+    version=VERSIONS["traefik"],
     static_configuration=traefik_static.TraefikStaticConfig.model_validate(
         yaml.safe_load(
             FILES_DIRECTORY.joinpath("traefik", "static_config.yaml").read_text()

--- a/src/bilder/images/vault/deploy.py
+++ b/src/bilder/images/vault/deploy.py
@@ -63,6 +63,7 @@ install_baseline_packages(packages=["curl", "gnupg", "jq", "cron"])
 set_env_secrets(Path("consul/consul.env"))
 # Install Traefik
 traefik_config = TraefikConfig(
+    version=VERSIONS["traefik"],
     static_configuration=traefik_static.TraefikStaticConfig.model_validate(
         yaml.safe_load(
             FILES_DIRECTORY.joinpath("traefik", "static_config.yaml").read_text()


### PR DESCRIPTION
### Description (What does it do?)

Fixes a bug where `TraefikConfig` was being instantiated without a `version` argument in all three AMI build scripts, causing the hardcoded default version (`2.9.1`) in `TraefikConfig` to be used instead of the centrally managed `TRAEFIK_VERSION` from `bridge/lib/versions.py` (currently `3.6.13`).

**Root cause:** `TraefikConfig.version` defaults to `"2.9.1"` in the model definition. Each deploy script correctly imports `TRAEFIK_VERSION` and stores it in a `VERSIONS` dict, but none of them passed `version=VERSIONS["traefik"]` when constructing the `TraefikConfig` object.

**Impact:** Every AMI bake for concourse, consul, and vault instances has been silently installing Traefik 2.9.1 (built October 2022), which bundles `golang.org/x/net v0.0.0-20220927171203` — a version vulnerable to CVE-2023-44487 (HTTP/2 Rapid Reset DoS). This was confirmed by inspecting the running Traefik binary on a concourse-web-qa instance:

```
traefik version
Version:      2.9.1
Built:        2022-10-03T14:22:13Z

strings /usr/local/bin/traefik | grep "dep.*golang.org/x/net"
dep	golang.org/x/net	v0.0.0-20220927171203-f486391704dc
```

The fix adds `version=VERSIONS["traefik"]` to `TraefikConfig(...)` in all three affected files. After rebuilding AMIs, Traefik 3.6.13 will be installed, which bundles a patched version of `golang.org/x/net`.

**Files changed:**
- `src/bilder/images/concourse/deploy.py`
- `src/bilder/images/consul/deploy.py`
- `src/bilder/images/vault/deploy.py`

### How can this be tested?

1. Trigger an AMI bake for any of the three image types (concourse, consul, vault)
2. Launch an instance from the new AMI and verify:
   ```bash
   traefik version
   # Should show Version: 3.6.13

   strings /usr/local/bin/traefik | grep "dep.*golang.org/x/net"
   # Should show v0.52.x or higher (>= v0.17.0 is patched)
   ```

### Additional Context

All three AMI types (concourse, consul, vault) need to be rebuilt and instances redeployed to remediate CVE-2023-44487 on running infrastructure. The `TraefikConfig` model default of `"2.9.1"` should ideally be updated or removed to prevent this class of silent version regression in the future.
