### PR TITLE
Md/202604 hubspot token update

### DIFF
--- a/src/bridge/secrets/mitxonline/secrets.ci.yaml
+++ b/src/bridge/secrets/mitxonline/secrets.ci.yaml
@@ -18,7 +18,7 @@ google-sheets:
 hubspot:
   formId: ENC[AES256_GCM,data:oiojRMT7Ff+mtU8=,iv:opmrOFszYlZ8h8tARc/yIUSRQRDujHgakL3TvHCtcko=,tag:wRJMZKki7gxADDA5aSMr+Q==,type:str]
   portalId: ENC[AES256_GCM,data:4vgrIVEPVWKIAjs=,iv:f1GagchEXw0Lo/t7lHBks/0e4W3f7dA/y1yHSGA+zoo=,tag:tZSQRKjeJEyi0yLQMCKeKQ==,type:str]
-  private-api-token: ENC[AES256_GCM,data:6SqvVaUz0doOy9Q=,iv:mmo5ATKqL+vDTByUt9CD+gCLqO3ViSLpU8aFEcv5KjY=,tag:JaAe6BzznGqKKWdiIKjIFA==,type:str]
+  private-api-token: ENC[AES256_GCM,data:i1VgYBl0liRWoreqvljcTqtWrhyQVHiEjAbpRjBFy+LHS+1EUkHk0DhqsyY=,iv:Qs0ZvrBG+cZXXzfmGznWFt5EAE6TM8ZwmboMNWjPMvg=,tag:HR0Vi4wwJYT8q5xFJs6KDA==,type:str]
   uai-private-api-token: ENC[AES256_GCM,data:3OHdOIoOagYaTd7oby17XLYP68kQ9m5QUQioKhSW+/UtxWcC2QPxUa3WwXY=,iv:ohh3dIc1XNcuXqQ8YwQUje7lnQ/Fi1ktVbGtDfHY22w=,tag:VMi0gfsqUZAKA5l8BGJTWw==,type:str]
 open-edx-service-worker:
   api-token: ENC[AES256_GCM,data:/PMGKOsguPVgBw7p6jyKiZQMyltbzHbOsH6BlT8Vy5vSxaxkP7ZxTOP7zXB5bYqCWMwVQ7QNu6u1v/+KZw8NFw==,iv:1VqzzC4ynMTjQP0hgvp/iRH1xjDk3stiXT3o9osUJ40=,tag:/RetmtOPrBle/tAzQqvvlQ==,type:str]
@@ -52,13 +52,17 @@ sops:
     created_at: "2025-09-29T20:51:01Z"
     enc: AQICAHi3MZ/Pjy2dahB1Qm+zKkKDPV1b9MYPGp7k649HPjmOHAF2zZLq2xGkUy9ABZ9y/fvDAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMD/b7t9+bezAonH8mAgEQgDtkQ2Q/N74r7cNm0gsQiFAqHcPn+kcH9LSWZkakBix81IEJ56PuSc/QQPYfNFAWpDJFVxo0aZXYKrzgSQ==
     aws_profile: ""
+  gcp_kms: []
+  azure_kv: []
   hc_vault:
   - vault_address: https://vault-ci.odl.mit.edu
     engine_path: infrastructure
     key_name: sops
     created_at: "2025-09-29T20:51:01Z"
     enc: vault:v1:RRmHUxUh3yhdXY+w0oVO573VCHyMru8LLbCgo6sJ+pmJdBFJ0GAJCN1tcrIbazSwN+N1AV38+E4dOQWr
-  lastmodified: "2026-04-15T14:16:19Z"
-  mac: ENC[AES256_GCM,data:0qvKnJ24jdJH1wcTzYCgQjdbq31H54N8jtJFP2mnGM23l4dNN7xbskD15rw+non8Z6gFYpDvIyn8qDdGdWWGxBQhHR4znkx/SahZNnPo/S7itCmJ67JxVMnU4YPaTgKk/vHAP8kejx61heSk9P6O39FdX92yPN2OHjlvjG95Xlw=,iv:d4HeVOrEOJoNPQBMweFJaQsnSIE/ACcUGb3nTbAT6GQ=,tag:PpiF0N0aIOYm7zLYuJHYXQ==,type:str]
+  age: []
+  lastmodified: "2026-04-21T18:35:28Z"
+  mac: ENC[AES256_GCM,data:1kZvDgf5TgdN3RlrvhJ3KkD1lNB56EMApHSFvRMJGi7+/PR84lRWvQLed3sQ3HiCMKSvXcGKucQJS75fC1U7+JMFwz+NMLAjFC87pkK04zKz6a+vTdtUBYxMv72SjeQVKowgChjkjlEwgeklebTfDMLHnADN22QhG7BF7rCZ8SI=,iv:UnvpYswvCDuEXYnPjtNjwMMJdXLSGFAIZJgrELJov9c=,tag:4C6JxCKS4Nkm8AioPifqng==,type:str]
+  pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.12.2

--- a/src/bridge/secrets/mitxonline/secrets.qa.yaml
+++ b/src/bridge/secrets/mitxonline/secrets.qa.yaml
@@ -18,7 +18,7 @@ google-sheets:
 hubspot:
   formId: ENC[AES256_GCM,data:l8jtCoBMFXKBWIKe0NQxCKmGvhil6G4GvrMG6PhcECjanYmZ,iv:kp5muyTBTIp0/X/Wff0h2yYtT/j2oizaIqVJx05fyB8=,tag:++qWZ2eTyIg9WhqGgmJLcg==,type:str]
   portalId: ENC[AES256_GCM,data:dbDyqlxu2Ow=,iv:mUQVMgtHlCwGiU58MHAm6kwd+NSwJkAlxp5CqkR+Odw=,tag:NFHBf7ZRfh82+D1wB2godg==,type:int]
-  private-api-token: ENC[AES256_GCM,data:pPlzre38q0ABvYSVsvf7fkstNpYMlgW7yIky8hrfCRoGjJgLH/79/8bHghU=,iv:1/igLL5qbIaIfxK/ZF8kCUCbZMPfecKTmjwIZOeqsyc=,tag:B8CkbUjnix0fs0aZ7Iiftg==,type:str]
+  private-api-token: ENC[AES256_GCM,data:d8QxWLHPHkGzf74ngSuO/MKmKpdI+2ViYjwuZdxNL895/2Q8k2g9FehouKg=,iv:aaUUOGNGltY6POb0vbXgO/kgkZ9YpF9W4lJJV2QgT70=,tag:f7Cyva8PYwC76q0mqwWD8g==,type:str]
   uai-private-api-token: ENC[AES256_GCM,data:jrtIApvXVQrZBqwFMarxTFt8K+aKYGMXbTO3FQ5Xqkybt2M04DxeZ4DWMG0=,iv:tqzzQHC25aY1bVIUxeZwAKlUawi7HGGY0bho6OGbfeg=,tag:Yzr+532Etc/9oYoe/0dRgQ==,type:str]
 open-edx-service-worker:
   api-token: ENC[AES256_GCM,data:Duf2ItD1c/ALxhopM/U+/zdkWepn7AKyfBumfcPoWpQWYWIR1+3+wkKuHGtagRlZUqKCZxQMMauTJjT0R4MNOA==,iv:hBA7lU8z65I7fhU6RwGy1b/pFO1wgHB9dC8BNQOlBVs=,tag:nsormOFFH0hn4hsSf9V4hA==,type:str]
@@ -54,13 +54,17 @@ sops:
     created_at: "2026-02-02T17:11:45Z"
     enc: AQICAHjZAY5LtmRWGljev0oiDGn0jR5cRwD4IVXCn50TW5i0qQHqmN8pFGX+2qcY5XXiY0kRAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMyhTtxzfD/gU5HUZNAgEQgDtvzRLa7AL13nl12d+v8Oc1Oenj4qF25AbX3SwGtVWH4LA75IUBGVA4H0DqqU4KBFFLe33xO7EIKLhOJQ==
     aws_profile: ""
+  gcp_kms: []
+  azure_kv: []
   hc_vault:
   - vault_address: https://vault-qa.odl.mit.edu
     engine_path: infrastructure
     key_name: sops
     created_at: "2026-02-02T17:11:45Z"
     enc: vault:v1:0y+YFRqZIXMxr0jX7vzFtCRy4cCDz261a3BOcLKq7gtYmbUJNdJV7PHabO7/1tJMhEYshQpIxGXEqiNh
-  lastmodified: "2026-04-15T14:19:41Z"
-  mac: ENC[AES256_GCM,data:Q+dtpFhw1927c073nEyZw9Nt2izNkzMPr1je6/pHxAzJQBUm9FdJ8FKewE+kjnmHnK5LmCGcnYYMzP3+OP8JBE4ZiM+14zJYXNm4cW08BOfkA6Sz7vzOIiFyWq6MHY6W0To9qlpXFDeRPeTQaDX/SFF9JiJwVOVEvFs9AGYpclw=,iv:LHqJKAXEsAApAVqmWHhJWyfpnkQdvPaAtNOeUsUYZ5Q=,tag:kphDNrmi7Gx3GSS7iWHiGg==,type:str]
+  age: []
+  lastmodified: "2026-04-21T18:35:56Z"
+  mac: ENC[AES256_GCM,data:pV1DAQzpiTqQazT2GepCVKbB/SLAE2N9dS460MBfOpoWmdqu+5NWv2dcB0CtUA7ZrnUaM1PGbeNBzrgnw/HDFURIyxp0QPksDcJso3h7qy9+YDrB0JWthU06RdVclAji4KUNljVXh+M8hBsVUkzjCWnz2NbtRhjwoGNDuxeubmM=,iv:2pc5r9kOhoAfVY7E7XQelnpNSm94K/6ztlo3gxCB5l8=,tag:124EredcCXH8kp1y5x2J/Q==,type:str]
+  pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.12.2

--- a/src/bridge/secrets/xpro/secrets.ci.yaml
+++ b/src/bridge/secrets/xpro/secrets.ci.yaml
@@ -31,7 +31,7 @@ google-sheets:
 hirefire:
   token:
 hubspot:
-  api_private_token: ENC[AES256_GCM,data:wv7k5zcQMXYYVPY8JgVcbhM0zS+p67Tn3e4DdLiQIB8jLlDYrQO1CCOSIHo=,iv:hxKGO8FMOTy8PwANrX0+FW9BLb2R4mcqDbOBl8+8Q9Q=,tag:gfOQnE0nQ+13vJ4gQJ1quA==,type:str]
+  api_private_token: ENC[AES256_GCM,data:IWp3y6s0ruZ7AbWUywk8/g4jMB6WddoPYcwCAkUilA1IDqBWEAvNWHAOcBY=,iv:UXzFiY2IXeMCl5paKHBde9clxcfgNYKOYSStyjsYDf0=,tag:9B+TJgQdNEDWKiFeyOM20g==,type:str]
 openedx-api-client:
   client_id: ENC[AES256_GCM,data:6f7C9jxKxEJyQnX37Vs/kQLUeLAnIaUpr1tcO9PPZ1Mu07TN6yC1RQ==,iv:NMtUmSgKJMTS4U7366JJJxKks4Grwcpm2qVmSMreycE=,tag:IQ9ft86Yl87Pn4WFCTsNdA==,type:str]
   client_secret: ENC[AES256_GCM,data:GPmBi8Z+zUy6q2GrNEXGurBPzY+gqOz3U08ADBFocNts+USAfQpw8TdLVQqAW88l85JZE8s5xWaNofWg0QsQ1+rGUUq41fd7idDpi5kPt1So+XzsFgI9eYnOD1jqOn3p0tApb5CXlhI3CHC8lpQEajnT80D1AZprBkY019SLtMc=,iv:WSTm/QTtLVGo8Y4yBbVYb51jjwwmQ73SCOYJ8K1Xt5U=,tag:6A0NTfHifTpAZJ1zYpws1A==,type:str]
@@ -69,13 +69,17 @@ sops:
     created_at: "2025-12-15T18:06:53Z"
     enc: AQICAHhMkpkBpCvmFjhyfy75ENALRrbg42uOs9cUsFNLXqPnagH92PAz0KrjatIcGHnBoJXfAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMOnZP3G3lPN1rV/J6AgEQgDvtiwIXhBxD1ox+DUnp+wss+Nbh1JkWfAS2XoKn5KdMCFyFk5yV2y4RGCUhhYDRIb8h3SN+//IWdnCXRw==
     aws_profile: ""
+  gcp_kms: []
+  azure_kv: []
   hc_vault:
   - vault_address: https://vault-ci.odl.mit.edu
     engine_path: infrastructure
     key_name: sops
     created_at: "2025-12-15T18:06:53Z"
     enc: vault:v1:YUHVVxmZJi1Zj8oSZT5wPhp9+VXEt3tuNoL1EH6eVyVG1niTBA0ZmOXdJXhYcdsHsCXoyhReqIoVHFVF
-  lastmodified: "2025-12-15T18:06:54Z"
-  mac: ENC[AES256_GCM,data:cG7HxjDDOmRn2dQG96Imm8rGBT+R9VjvyBiueYkA10XZ+rz8GhvmmEHM50LQNpoE34n/PFzhsjTm69XQLHP4yTaayrF2Dy+Rtz5EEryYMY9AcQtQZxhPyHP3SppsrEtBLA+V94Mc2JKDwdNfqqILt7jHWi0/HMIIp6Y5TODHr9Y=,iv:UO9GHF7qIcUm9fgeqRz1tyksnvO39ccLMhxzSoEyO1Y=,tag:yrRB9JvaC0ixl6E23zAStA==,type:str]
+  age: []
+  lastmodified: "2026-04-21T18:31:29Z"
+  mac: ENC[AES256_GCM,data:olilZWXOtUsVEVJznfLSmZsNGqnoe5lwjot9cYtuLg5U+Vo5TmRnnD0goatTNJ5mrPuAk5p+vwwZXmGfeCv866UwFAWA9dF6R2ZByVgUoVWi9l0EGqiEkisc2GbTW9ke8CfDnO78x+3d/K7Iz4t5mfWpNFljciB0abvhRmJx6SU=,iv:QLqw4Y7MQbgYlEIR8ayBMTl07JxMBIOYRTr8xzSyXWY=,tag:gRBZU6pr5K4ekRYYkxJQ0w==,type:str]
+  pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.11.0

--- a/src/bridge/secrets/xpro/secrets.qa.yaml
+++ b/src/bridge/secrets/xpro/secrets.qa.yaml
@@ -31,7 +31,7 @@ google-sheets:
 hirefire:
   token:
 hubspot:
-  api_private_token: ENC[AES256_GCM,data:CXMYOPrMNQ/zsL2wpWIwF5WaOSJVc2OeDtBe366Bq36+hq4f2jmwQwPyWqk=,iv:3DuqohjtNewjsWUBz7t5aUWJxnAyy2FUTuuif8FXo5o=,tag:Y1l/jW7Dii6tOMVjyDjYSw==,type:str]
+  api_private_token: ENC[AES256_GCM,data:7RKmn0HRzXSriNTYWPipu/Xdk0UkzhlLdxp7a09FpYpuh+cW3kMOfHnVJys=,iv:VRqynS8Km9L0CU8szXlJIsMnBT2I3UJWkpj6zA+TBa4=,tag:DLhCEm+cHSIxWUImhtmAHQ==,type:str]
 openedx-api-client:
   client_id: ENC[AES256_GCM,data:LFfY0x8YYHkdzQoIOp/AxLsYp1NTQngiGqPq2pCv1Be8wQgS8ec7XQ==,iv:ua8GRAhndXMNONkyDauCgsdGZSbmLaYOs8D8VKpnOm8=,tag:y+9+qHBPxDoEmHGW/aKbmw==,type:str]
   client_secret: ENC[AES256_GCM,data://XElBPnjUYn/FS8CKqnS91C9L0OUJtBQ4Ddt1JzoyFiAXjXK67pu0yuziBeOhM9m2+oFf5uRZWV3cjt5XbREYwHkH2sqdamyDlFTVukNLXZYRVDftdIVdytAdnTFZx7A0ZV1wUOJHMF1dNr7iv0J8NfarL4kbvIPqwwOfDWD0U=,iv:BM+XaM2hEO7Wpp1LgIabFdnfr5DjvMSmGn8iCiSiG7s=,tag:Q4EVFuGwZSGXMM/JbnfZvw==,type:str]
@@ -69,13 +69,17 @@ sops:
     created_at: "2025-12-15T18:00:54Z"
     enc: AQICAHjZAY5LtmRWGljev0oiDGn0jR5cRwD4IVXCn50TW5i0qQF4jX18YajaV/gETb7LR27dAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMCH1qperhuJI0hcaVAgEQgDvYoOM6JLoXDj+pdWEoYcN/Pls6OpZlvgZRZqj/7X2MTgoaaAKgE0zxy7WqqO6QRhXz5kAdPaDii2fnWA==
     aws_profile: ""
+  gcp_kms: []
+  azure_kv: []
   hc_vault:
   - vault_address: https://vault-qa.odl.mit.edu
     engine_path: infrastructure
     key_name: sops
     created_at: "2025-12-15T18:00:54Z"
     enc: vault:v1:p+K4+MTpPFJvFoN8KcIBO+PWy2IxlXkBG/TPliY4CixpxjxskHkxcDIgR90B+VBKaEZzPR7/LwR/cfvN
-  lastmodified: "2025-12-15T18:00:54Z"
-  mac: ENC[AES256_GCM,data:14a6TboNSEzyOR2FdnunvDD/PevLkzFF3hEZLiHRfZuf4DoOSLh+Fz1Wl8BiH6krke1rbcm2WkfPzH0xehaczVQDYCU5xuCVsckAGJ2jV4nTQxKlGISdt04u8UeSGR1xaiBZzw5YXy2Qfo8bzJDtKWENFkwZEkwJpZ//CwCrETw=,iv:3PrIDdsfjqp/7VfsdDbjfANwRgUSu08tgb17dNcFKqg=,tag:kdCtLo7gp+L/IRJoeZwNGg==,type:str]
+  age: []
+  lastmodified: "2026-04-21T18:31:43Z"
+  mac: ENC[AES256_GCM,data:VRrH72APKJFct/jXVhG5QpIc5KVa4UMfYdV0zK0ciWPUzT/RMY56VAYMfSXY0zk9fZ3KOTatp5AbJJhwbt1xeg6lSPtjLAtKLlvyjqI31f1ymGkckdoMzPVHtuQwMWW+6Ib+QI/SDz/RD+ZAIMnMCBnjbdZ6b0T1LrVkEwlDtGU=,iv:DYvNwIH9/COAqjmnFXm+sVI/8sKgdqx+l+6uJ0frMKw=,tag:B84kTlBTUoach1NwnN4lcQ==,type:str]
+  pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.11.0

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
@@ -129,8 +129,8 @@ active_color = colors.apply(lambda c: c["active_color"])
 last_active_resolved = colors.apply(lambda c: c["last_active"])
 
 stay_updated_hubspot_form_ids = {
-    "ci": "4f423dc7-5b08-430b-a9fb-920b7f9597ed",
-    "qa": "4f423dc7-5b08-430b-a9fb-920b7f9597ed",
+    "ci": "f201f3af-c2c0-4b7d-b297-ddbb75912cc1",
+    "qa": "f201f3af-c2c0-4b7d-b297-ddbb75912cc1",
     "production": "a5d18493-dcdb-4482-ad10-16ab66a35526",
 }
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10985

### Description (What does it do?)
Updates two SOPS encrypted values for CI/QA:

`src/bridge/secrets/mitxonline/secrets.ci.yaml` ---  `hubspot:private-api-token`
`src/bridge/secrets/mitxonline/secrets.qa.yaml` ---  `hubspot:private-api-token`
This renders to `MITOL_HUBSPOT_API_PRIVATE_TOKEN` for mitxonline


`src/bridge/secrets/xpro/secrets.ci.yaml` ---  `hubspot:api_private_token`
`src/bridge/secrets/xpro/secrets.qa.yaml` ---  `hubspot:api_private_token`
THis renders to `MITOL_HUBSPOT_API_PRIVATE_TOKEN` for xpro and `MITOL_HUBSPOT_API_PRIVATE_TOKEN` for mit_learn. 