### PR TITLE
use qa bucket for ocw rc

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.CI.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.CI.yaml
@@ -75,6 +75,7 @@ config:
     MITOL_SUPPORT_EMAIL: "odl-learn-ci-support@mit.edu" # Need to verify
     MITPE_API_ENABLED: "true"
     OCW_ITERATOR_CHUNK_SIZE: 300
+    OCW_LIVE_BUCKET: "ocw-content-live-production"
     OIDC_ENDPOINT: "https://sso-ci.ol.mit.edu/realms/olapps"
     OVS_API_BASE_URL: "https://video-rc.odl.mit.edu"
     OPENSEARCH_INDEX: "mitlearn-ci"

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.Production.yaml
@@ -78,6 +78,7 @@ config:
     MITX_ONLINE_PROGRAMS_API_URL: "https://mitxonline.mit.edu/api/v2/programs/"
     MITPE_API_ENABLED: "true"
     OCW_ITERATOR_CHUNK_SIZE: 300
+    OCW_LIVE_BUCKET: "ocw-content-live-production"
     OIDC_ENDPOINT: "https://sso.ol.mit.edu/realms/olapps"
     OPENTELEMETRY_ENABLED: "true"
     OPENTELEMETRY_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/traces"

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.QA.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.QA.yaml
@@ -79,6 +79,7 @@ config:
     XPRO_COURSES_API_URL: "https://rc.xpro.mit.edu/api/courses/"
     MITPE_API_ENABLED: "true"
     OCW_ITERATOR_CHUNK_SIZE: 300
+    OCW_LIVE_BUCKET: "ocw-content-live-qa"
     OIDC_ENDPOINT: "https://sso-qa.ol.mit.edu/realms/olapps"
     OPENTELEMETRY_ENABLED: "true"
     OPENTELEMETRY_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/traces"

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1151,7 +1151,6 @@ env_vars = {
     "NODE_MODULES_CACHE": "False",
     "OCW_BASE_URL": "https://ocw.mit.edu/",
     "OCW_CONTENT_BUCKET_NAME": "ocw-content-storage",
-    "OCW_LIVE_BUCKET": "ocw-content-live-production",
     "OCW_UPLOAD_IMAGE_ONLY": "True",
     "OLL_ALT_URL": "https://openlearninglibrary.mit.edu/courses",
     "OLL_API_ACCESS_TOKEN_URL": "https://openlearninglibrary.mit.edu/oauth2/access_token/",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10880

### Description (What does it do?)
In order to test https://github.com/mitodl/mit-learn/pull/3202 OCW_LIVE_BUCKE should be "ocw-content-live-qa" on rc
