### PR TITLE
put back rc OCW_LIVE_BUCKET

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.QA.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.QA.yaml
@@ -79,7 +79,7 @@ config:
     XPRO_COURSES_API_URL: "https://rc.xpro.mit.edu/api/courses/"
     MITPE_API_ENABLED: "true"
     OCW_ITERATOR_CHUNK_SIZE: 300
-    OCW_LIVE_BUCKET: "ocw-content-live-qa"
+    OCW_LIVE_BUCKET: "ocw-content-live-production"
     OIDC_ENDPOINT: "https://sso-qa.ol.mit.edu/realms/olapps"
     OPENTELEMETRY_ENABLED: "true"
     OPENTELEMETRY_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/traces"


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
https://github.com/mitodl/ol-infrastructure/pull/4523 set OCW_LIVE_BUCKET="ocw-content-live-qa" on learn rc for testing a pr
Now that that pr is released to prod we can set OCW_LIVE_BUCKET="ocw-content-live-production" on learn rc again


