### PR TITLE
destroy old csrftoken cookies ☠️

### DIFF
--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.Production.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.Production.yaml
@@ -20,6 +20,7 @@ config:
     CANVAS_SYLLABUS_DEMO_READABLE_IDS: ["14566-kaleba:20211202", "34642-15.095_FA25"]
     CANVAS_TUTOR_DEMO_RUN_READABLE_IDS: ["14566-kaleba:20211202+canvas", "34642-15.095_FA25+canvas"]
     CELERY_TASK_ALWAYS_EAGER: "false"
+    COOKIE_TOMBSTONES: '[{"name":"csrftoken","domain":"learn.mit.edu","path":"/"}]'
     CSRF_COOKIE_NAME: learn_ai_csrftoken
     CSRF_COOKIE_DOMAIN: "learn.mit.edu"
     CSRF_ALLOWED_ORIGINS: '["https://learn-ai.ol.mit.edu", "https://api-learn-ai.ol.mit.edu",

--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.QA.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.QA.yaml
@@ -23,6 +23,7 @@ config:
     CELERY_TASK_ALWAYS_EAGER: "false"
     CANVAS_SYLLABUS_DEMO_READABLE_IDS: ["14566-kaleba:20211202", "34642-15.095_FA25"]
     CANVAS_TUTOR_DEMO_RUN_READABLE_IDS: ["14566-kaleba:20211202+canvas", "34642-15.095_FA25+canvas"]
+    COOKIE_TOMBSTONES: '[{"name":"csrftoken","domain":"rc.learn.mit.edu","path":"/"}]'
     CSRF_COOKIE_NAME: learn_ai_qa_csrftoken
     CSRF_COOKIE_DOMAIN: "rc.learn.mit.edu"
     CSRF_ALLOWED_ORIGINS: '["https://learn-ai-qa.ol.mit.edu", "https://api-learn-ai-qa.ol.mit.edu",


### PR DESCRIPTION
### What are the relevant tickets?
- For. https://github.com/mitodl/hq/issues/11013
- Related to https://github.com/mitodl/mit-learn/pull/3234

### Description (What does it do?)
Tells MIT learn to unset old `csrftoken` cookies that had domain `learn.mit.edu`, which conflicted with an openedx cookie set on `courses.learn.mit.edu`

