### PR TITLE
export npm config to env instead of overwriting yarn config

### DIFF
--- a/src/ol_concourse/pipelines/libraries/scripts/api-clients-publish-node.sh
+++ b/src/ol_concourse/pipelines/libraries/scripts/api-clients-publish-node.sh
@@ -2,7 +2,9 @@
 # publish the npm package to npmjs.org
 
 export YARN_NPM_PUBLISH_REGISTRY=https://registry.npmjs.org/
-export YARN_NPM_AUTH_TOKEN=$NPM_TOKEN
+set +x
+export YARN_NPM_AUTH_TOKEN="${NPM_TOKEN}"
+set -x
 corepack enable
 COREPACK_ENABLE_DOWNLOAD_PROMPT=0 yarn install --immutable
 yarn build

--- a/src/ol_concourse/pipelines/libraries/scripts/api-clients-publish-node.sh
+++ b/src/ol_concourse/pipelines/libraries/scripts/api-clients-publish-node.sh
@@ -1,9 +1,8 @@
 #!/bin/bash -x
 # publish the npm package to npmjs.org
 
-#echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
-echo "npmPublishRegistry: https://registry.npmjs.org/" > .yarnrc.yml
-echo "npmAuthToken: $NPM_TOKEN" >> .yarnrc.yml
+export YARN_NPM_PUBLISH_REGISTRY=https://registry.npmjs.org/
+export YARN_NPM_AUTH_TOKEN=$NPM_TOKEN
 corepack enable
 COREPACK_ENABLE_DOWNLOAD_PROMPT=0 yarn install --immutable
 yarn build


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/11017

### Description (What does it do?)
Recently I merged https://github.com/mitodl/mitxonline-api-clients/pull/67 which fixes this issue with Node in our API client builds: https://github.com/nodejs/node/issues/62012. The problem is, the build script here that the pipeline uses overwrites the `.yarnrc.yml` file with the repo's Yarn config to store the credentials for pushing to NPM. This PR changes the strategy to export those to the env instead.

### How can this be tested?
The pipeline needs to be pushed up and run to see if this works.