### PR TITLE
Add cookie tombstone env var to correct app

### DIFF
--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.Production.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.Production.yaml
@@ -20,7 +20,6 @@ config:
     CANVAS_SYLLABUS_DEMO_READABLE_IDS: ["14566-kaleba:20211202", "34642-15.095_FA25"]
     CANVAS_TUTOR_DEMO_RUN_READABLE_IDS: ["14566-kaleba:20211202+canvas", "34642-15.095_FA25+canvas"]
     CELERY_TASK_ALWAYS_EAGER: "false"
-    COOKIE_TOMBSTONES: '[{"name":"csrftoken","domain":"learn.mit.edu","path":"/"}]'
     CSRF_COOKIE_NAME: learn_ai_csrftoken
     CSRF_COOKIE_DOMAIN: "learn.mit.edu"
     CSRF_ALLOWED_ORIGINS: '["https://learn-ai.ol.mit.edu", "https://api-learn-ai.ol.mit.edu",

--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.QA.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.applications.learn_ai.QA.yaml
@@ -23,7 +23,6 @@ config:
     CELERY_TASK_ALWAYS_EAGER: "false"
     CANVAS_SYLLABUS_DEMO_READABLE_IDS: ["14566-kaleba:20211202", "34642-15.095_FA25"]
     CANVAS_TUTOR_DEMO_RUN_READABLE_IDS: ["14566-kaleba:20211202+canvas", "34642-15.095_FA25+canvas"]
-    COOKIE_TOMBSTONES: '[{"name":"csrftoken","domain":"rc.learn.mit.edu","path":"/"}]'
     CSRF_COOKIE_NAME: learn_ai_qa_csrftoken
     CSRF_COOKIE_DOMAIN: "rc.learn.mit.edu"
     CSRF_ALLOWED_ORIGINS: '["https://learn-ai-qa.ol.mit.edu", "https://api-learn-ai-qa.ol.mit.edu",

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.Production.yaml
@@ -54,6 +54,7 @@ config:
     AWS_S3_PREFIX: "media"
     CANVAS_COURSE_BUCKET_NAME: "ol-data-lake-landing-zone-production"
     CELERY_WORKER_CONCURRENCY: 1
+    COOKIE_TOMBSTONES: '[{"name":"csrftoken","domain":"learn.mit.edu","path":"/"}]'
     CSRF_COOKIE_NAME: "learn_csrftoken"
     DEBUG: "false"
     EDX_LEARNING_COURSE_BUCKET_NAME: "edxorg-production-edxapp-courses"

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.QA.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.applications.mit_learn.QA.yaml
@@ -53,6 +53,7 @@ config:
     COURSE_ARCHIVE_BUCKET_NAME: "ol-data-lake-landing-zone-qa"
     CELERY_WORKER_CONCURRENCY: 1
     CREATE_OCW_LEARNING_MATERIALS: "true"
+    COOKIE_TOMBSTONES: '[{"name":"csrftoken","domain":"rc.learn.mit.edu","path":"/"}]'
     CSRF_COOKIE_NAME: "learn_rc_csrftoken"
     DEBUG: "false"
     EDX_LEARNING_COURSE_BUCKET_NAME: "edxorg-production-edxapp-courses"


### PR DESCRIPTION
### What are the relevant tickets?
- For. https://github.com/mitodl/hq/issues/11013
- Related to https://github.com/mitodl/mit-learn/pull/3234

### Description (What does it do?)
So.... #4534 added this env var, but to the wrong app. Oops.


Tells MIT learn to unset old `csrftoken` cookies that had domain `learn.mit.edu`, which conflicted with an openedx cookie set on `courses.learn.mit.edu`

For `rc.learn.mit.edu` we set the same value; on RC, the cookie tombstone middleware should not delete the production cookie.

