### PR TITLE
feat: enable pod restarts on Vault dynamic credential rotation

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/k8s_resources.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_resources.py
@@ -94,6 +94,16 @@ def create_k8s_resources(  # noqa: C901
     lms_celery_deployment_name = f"{env_name}-edxapp-lms-celery"
     cms_celery_deployment_name = f"{env_name}-edxapp-cms-celery"
 
+    # All deployments that consume MariaDB credentials and need to restart on rotation.
+    # Includes both OLApplicationK8s-managed webapps and hand-rolled celery/batch deployments.
+    edxapp_db_restart_deployment_names = [
+        "lms-edxapp-app",  # LMS webapp (OLApplicationK8s application_name="lms-edxapp")
+        "cms-edxapp-app",  # CMS webapp (OLApplicationK8s application_name="cms-edxapp")
+        lms_celery_deployment_name,
+        cms_celery_deployment_name,
+        f"{env_name}-edxapp-lms-process-scheduled-emails",
+    ]
+
     aws_account = aws.get_caller_identity()
 
     replicas_dict = edxapp_config.require_object("k8s_replicas")
@@ -257,6 +267,7 @@ def create_k8s_resources(  # noqa: C901
         namespace=namespace,
         stack_info=stack_info,
         vault_k8s_resources=vault_k8s_resources,
+        restart_deployment_names=edxapp_db_restart_deployment_names,
     )
     configmaps = create_k8s_configmaps(
         stack_info=stack_info,

--- a/src/ol_infrastructure/applications/edxapp/k8s_secrets.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_secrets.py
@@ -29,6 +29,7 @@ from ol_infrastructure.components.services.vault import (
     OLVaultK8SResources,
     OLVaultK8SSecret,
     OLVaultK8SStaticSecretConfig,
+    OLVaultRestartTarget,
 )
 from ol_infrastructure.lib.pulumi_helper import StackInfo
 
@@ -77,6 +78,7 @@ def create_k8s_secrets(
     namespace: str,
     stack_info: StackInfo,
     vault_k8s_resources: OLVaultK8SResources,
+    restart_deployment_names: list[str] | None = None,
 ) -> EdxappSecrets:
     """Create all Kubernetes secrets for edxapp using registry pattern.
 
@@ -92,6 +94,8 @@ def create_k8s_secrets(
         namespace: Kubernetes namespace for secrets
         stack_info: Stack information (env_prefix, env_suffix)
         vault_k8s_resources: Vault Kubernetes authentication resources
+        restart_deployment_names: Deployment names to restart when DB
+            credentials are rotated by Vault (dynamic secrets only).
 
     Returns:
         EdxappSecrets dataclass with all created secrets
@@ -131,6 +135,14 @@ def create_k8s_secrets(
     typesense_secret_name = "16-typesense-yaml"  # pragma: allowlist secret
 
     # Database credentials secret (dynamic - depends on DB outputs)
+    _db_restart_targets = (
+        [
+            OLVaultRestartTarget(kind="Deployment", name=n)
+            for n in restart_deployment_names
+        ]
+        if restart_deployment_names
+        else None
+    )
     db_creds_secret = Output.all(
         address=edxapp_db.db_instance.address,
         port=edxapp_db.db_instance.port,
@@ -151,6 +163,7 @@ def create_k8s_secrets(
                     )[0],
                 },
                 vaultauth=vault_k8s_resources.auth_name,
+                restart_targets=_db_restart_targets,
             ),
             opts=builder.get_common_options(),
         )
@@ -177,6 +190,7 @@ def create_k8s_secrets(
                     )[0],
                 },
                 vaultauth=vault_k8s_resources.auth_name,
+                restart_targets=_db_restart_targets,
             ),
             opts=builder.get_common_options(),
         )

--- a/src/ol_infrastructure/components/services/vault.py
+++ b/src/ol_infrastructure/components/services/vault.py
@@ -688,7 +688,11 @@ class OLVaultK8SSecretConfig(BaseModel):
     @model_validator(mode="after")
     def validate_restart_targets(self) -> "OLVaultK8SSecretConfig":
         has_legacy = bool(self.restart_target_kind or self.restart_target_name)
-        has_new = self.restart_targets is not None
+        has_new = bool(self.restart_targets)
+
+        if self.restart_targets is not None and not self.restart_targets:
+            msg = "restart_targets must be non-empty when provided."
+            raise ValueError(msg)
 
         if has_legacy and has_new:
             msg = (


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
When Vault dynamic credentials (e.g. database credentials) expire and are re-created by the Vault Secrets Operator (VSO), pods consuming those credentials via `envFrom` do not automatically restart. This leaves applications using stale/expired credentials until the next manual rollout restart.

This PR wires in the VSO `rolloutRestartTargets` mechanism end-to-end:

**`components/services/vault.py`**
- Adds `OLVaultRestartTarget(kind, name)` — a typed Pydantic model replacing the previously ad-hoc single-target approach
- Adds `restart_targets: list[OLVaultRestartTarget] | None` to `OLVaultK8SSecretConfig`, which maps directly to the VSO `rolloutRestartTargets` spec field and supports multiple deployments in one config (needed for apps that have celery workers + beat alongside the webapp)
- Deprecates the single-target `restart_target_kind`/`restart_target_name` fields with full backward compatibility — all existing callers continue to work unchanged
- Adds a model validator that prevents mixing old and new fields
- Updates `OLVaultK8SSecret.__init__` to use `restart_targets` when set, falling back to legacy fields

**`components/services/k8s.py`**
- Exposes `webapp_deployment_name`, `celery_deployment_names`, and `beat_deployment_name` as public attributes on `OLApplicationK8s` so callers have a stable, computed reference to the K8s names (rather than hardcoding them)
- Adds `all_deployment_names` property returning all managed deployment names in a single list

**Usage in an app stack:**
```python
from ol_infrastructure.components.services.vault import (
    OLVaultRestartTarget,
    OLVaultK8SDynamicSecretConfig,
    OLVaultK8SSecret,
)

app = OLApplicationK8s(config)

OLVaultK8SSecret(
    "my-app-db-creds",
    OLVaultK8SDynamicSecretConfig(
        ...
        restart_targets=[
            OLVaultRestartTarget(kind="Deployment", name=name)
            for name in app.all_deployment_names
        ],
    ),
)
```
When VSO refreshes the dynamic secret, it will trigger a rolling restart of the webapp, all celery worker deployments, and the beat deployment.

### How can this be tested?
- All 130 existing unit tests pass (`uv run pytest tests/`)
- Pre-commit hooks (ruff format, ruff check, mypy) pass clean
- To validate end-to-end: deploy a stack that uses `OLVaultK8SDynamicSecretConfig` with `restart_targets` set to `app.all_deployment_names`, then force a VSO secret refresh (`kubectl annotate vaultdynamicsecret <name> force-sync=true`) and confirm all deployments roll over