### PR TITLE
Fix hash.txt serving in ocw-studio deployment

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/k8s_apps/docker_pulumi.py
+++ b/src/ol_concourse/pipelines/infrastructure/k8s_apps/docker_pulumi.py
@@ -95,7 +95,11 @@ pipeline_params = {
         build_target="production",
         settings_dir="mitxpro",
     ),
-    "ocw-studio": AppPipelineParams(app_name="ocw-studio", repo_main_branch="master"),
+    "ocw-studio": AppPipelineParams(
+        app_name="ocw-studio",
+        repo_main_branch="master",
+        build_target="production",
+    ),
     "odl-video-service": AppPipelineParams(
         app_name="odl-video-service",
         repo_main_branch="master",

--- a/src/ol_infrastructure/applications/ocw_studio/files/web.conf
+++ b/src/ol_infrastructure/applications/ocw_studio/files/web.conf
@@ -25,6 +25,7 @@ server {
     location ~* /static/hash.txt {
         expires -1;
         add_header Cache-Control private;
+        try_files /staticfiles/hash.txt =404;
     }
 
     location ~* /static/(.*$) {


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up to https://github.com/mitodl/ocw-studio/pull/2888 and https://github.com/mitodl/ocw-studio/pull/2926.

### Description (What does it do?)
`/static/hash.txt` was returning 404 on the deployed site despite the file existing in the K8 container at `/src/staticfiles/hash.txt`.

The nginx `location ~* /static/hash.txt` block in `web.conf` was missing a `try_files` directive. Without it, nginx had no instruction to serve the file from the shared `staticfiles` emptyDir volume and fell through to its own filesystem, which does not have the `hash.txt` file.

This PR fixes that issue by adding `try_files /staticfiles/hash.txt =404;` to the location block, consistent with how all other static assets are served in the block below it.

The PR also adds `build_target="production"` to the ocw-studio entry in `docker_pulumi.py` for consistency with all other multi-stage apps in the pipeline (`mitxonline`, `xpro`, `micromasters`, `odl-video-service`), making the intended build target explicit rather than relying on `oci-build-task` defaulting to the last stage.

### How can this be tested?
Verify that everything looks correct. This can be tested in the RC deployment by navigating to `https://ocw-studio-rc.odl.mit.edu/static/hash.txt`.