### PR TITLE
feat(keycloak): add MIT LDAP federation to ol-mit realm

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.CI.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.CI.yaml
@@ -121,3 +121,5 @@ config:
   - "https://video-ci.odl.mit.edu/"
   keycloak_realm:ol-mit-ovs-web-origins:
   - "https://video-ci.odl.mit.edu"
+  keycloak_realm:ol-mit-ldap-bind-password:
+    secure: v1:l7C+KLXXfHigy4Cj:QjFaZQVvVbAl+spxcIiKn6QJi6uchRT85MIF+3OymX/jqDTU

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.CI.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.CI.yaml
@@ -122,4 +122,4 @@ config:
   keycloak_realm:ol-mit-ovs-web-origins:
   - "https://video-ci.odl.mit.edu"
   keycloak_realm:ol-mit-ldap-bind-password:
-    secure: v1:l7C+KLXXfHigy4Cj:QjFaZQVvVbAl+spxcIiKn6QJi6uchRT85MIF+3OymX/jqDTU
+    secure: v1:dOWj9QsOafyn3p+F:XdKusQqhsxVDx20tFJTdUG3Nc5/FJ4N/ZChyzakYHlXyXpcxRkICJA==

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.Production.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.Production.yaml
@@ -121,3 +121,5 @@ config:
   - "https://video.odl.mit.edu/"
   keycloak_realm:ol-mit-ovs-web-origins:
   - "https://video.odl.mit.edu"
+  keycloak_realm:ol-mit-ldap-bind-password:
+    secure: v1:a64/qH0n0j+vF2Sf:XkJEpFs+ARyby0vmgjNbbM/WHDeM8mLyA2qAevjcGcjXz5om

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.Production.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.Production.yaml
@@ -122,4 +122,4 @@ config:
   keycloak_realm:ol-mit-ovs-web-origins:
   - "https://video.odl.mit.edu"
   keycloak_realm:ol-mit-ldap-bind-password:
-    secure: v1:a64/qH0n0j+vF2Sf:XkJEpFs+ARyby0vmgjNbbM/WHDeM8mLyA2qAevjcGcjXz5om
+    secure: v1:xuY2YgyBZnGNLTMy:ZnmyEmcaAOFd8EsiQX+7uG4rBcyP5QmVbI2HI39kkDllxf2TFRovQA==

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
@@ -135,4 +135,4 @@ config:
   keycloak_realm:ol-mit-ovs-web-origins:
   - "https://video-rc.odl.mit.edu"
   keycloak_realm:ol-mit-ldap-bind-password:
-    secure: v1:ReQKSODS/uYpvaq6:0G5qFul805Kbh/4YXurYnUEE9c9mudi712x1sYqi6Lqrj17T
+    secure: v1:bm9R4ZzTLXsioNmr:BAS1km5mgbC94evdYsX1CqgKyXYxzBmfvMztk9p4ItE+CV0Ri8qt1w==

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.substructure.keycloak.QA.yaml
@@ -134,3 +134,5 @@ config:
   - "https://video-rc.odl.mit.edu/"
   keycloak_realm:ol-mit-ovs-web-origins:
   - "https://video-rc.odl.mit.edu"
+  keycloak_realm:ol-mit-ldap-bind-password:
+    secure: v1:ReQKSODS/uYpvaq6:0G5qFul805Kbh/4YXurYnUEE9c9mudi712x1sYqi6Lqrj17T

--- a/src/ol_infrastructure/substructure/keycloak/__main__.py
+++ b/src/ol_infrastructure/substructure/keycloak/__main__.py
@@ -104,7 +104,9 @@ create_olapps_realm(
     session_secret,
     fetch_realm_public_key_partial,
 )
-mit_ldap_bind_password = keycloak_realm_config.require("ol-mit-ldap-bind-password")
+mit_ldap_bind_password = keycloak_realm_config.require_secret(
+    "ol-mit-ldap-bind-password"
+)
 create_ol_mit_realm(
     keycloak_provider,
     keycloak_url,

--- a/src/ol_infrastructure/substructure/keycloak/__main__.py
+++ b/src/ol_infrastructure/substructure/keycloak/__main__.py
@@ -104,6 +104,7 @@ create_olapps_realm(
     session_secret,
     fetch_realm_public_key_partial,
 )
+mit_ldap_bind_password = keycloak_realm_config.require("ol-mit-ldap-bind-password")
 create_ol_mit_realm(
     keycloak_provider,
     keycloak_url,
@@ -112,6 +113,7 @@ create_ol_mit_realm(
     mit_email_password,
     mit_email_username,
     mit_email_host,
+    mit_ldap_bind_password,
     session_secret,
     fetch_realm_public_key_partial,
 )

--- a/src/ol_infrastructure/substructure/keycloak/ol_mit.py
+++ b/src/ol_infrastructure/substructure/keycloak/ol_mit.py
@@ -31,6 +31,7 @@ def create_ol_mit_realm(  # noqa: PLR0913
     mit_email_password: str,
     mit_email_username: str,
     mit_email_host: str,
+    mit_ldap_bind_password: str,
     session_secret: str,
     fetch_realm_public_key_partial,
 ):
@@ -428,6 +429,119 @@ def create_ol_mit_realm(  # noqa: PLR0913
         add_to_access_token=True,
         opts=resource_options,
     )
+
+    # MIT LDAP FEDERATION [START]
+    # Read-only federation against MIT's Okta LDAP interface to enrich users
+    # already created via Touchstone SAML and to assign group memberships.
+    #
+    # The Okta LDAP interface only exposes ou=users at the base DN; groups are
+    # surfaced via the virtual memberOf attribute on each user entry.  The
+    # GET_GROUPS_FROM_USER_MEMBEROF_ATTRIBUTE strategy on the group mapper
+    # therefore avoids needing to walk group entries and is more efficient for
+    # this interface.
+    #
+    # Username linkage: Touchstone sends kerberos@mit.edu as the SAML NameID
+    # (SUBJECT principal); the LDAP uid attribute is also kerberos@mit.edu, so
+    # users created on first Touchstone login are automatically linked to their
+    # LDAP counterpart on the next sync / login.
+    #
+    # PREREQUISITE: The oleng service account must have "Read Groups" scope
+    # enabled in Okta Admin → Security → API → LDAP Interface before the group
+    # mapper can populate memberships.  The user-attribute sync works without
+    # that permission.
+    ol_mit_ldap = keycloak.ldap.UserFederation(
+        "ol-mit-ldap",
+        name="mit-ldap",
+        realm_id=ol_mit_realm.id,
+        connection_url="ldaps://mitprod.ldap.okta.com",
+        bind_dn="uid=oleng,dc=mitprod,dc=okta,dc=com",
+        bind_credential=mit_ldap_bind_password,
+        users_dn="ou=users,dc=mitprod,dc=okta,dc=com",
+        username_ldap_attribute="uid",
+        rdn_ldap_attribute="uid",
+        # uniqueIdentifier is the Okta-assigned immutable GUID for each user and
+        # is the correct stable identifier across renames / email changes.
+        uuid_ldap_attribute="uniqueIdentifier",
+        user_object_classes=["inetOrgPerson"],
+        edit_mode="READ_ONLY",
+        vendor="OTHER",
+        search_scope="ONE_LEVEL",
+        # MIT emails are validated by Touchstone; no re-verification needed.
+        trust_email=True,
+        sync_registrations=False,
+        import_enabled=True,
+        connection_pooling=True,
+        pagination=True,
+        use_truststore_spi="ONLY_FOR_LDAPS",
+        # Hourly delta sync picks up group-membership changes for users who have
+        # already logged in.  Full sync is disabled to avoid bulk-importing every
+        # MIT affiliate into Keycloak; users are provisioned on-demand via the
+        # Touchstone SAML first-login flow.
+        changed_sync_period=3600,
+        opts=resource_options,
+    )
+
+    # MIT-specific attribute mappers.  Standard attributes (username, email,
+    # firstName, lastName) are handled by the default mappers that Keycloak
+    # creates automatically when delete_default_mappers is not set.
+    for resource_name, mapper_name, ldap_attr, model_attr in [
+        (
+            "ol-mit-ldap-edu-person-principal-name-mapper",
+            "eduPersonPrincipalName",
+            "eduPersonPrincipalName",
+            "eduPersonPrincipalName",
+        ),
+        (
+            "ol-mit-ldap-display-name-mapper",
+            "displayName",
+            "displayName",
+            "displayName",
+        ),
+        (
+            "ol-mit-ldap-edu-person-primary-affiliation-mapper",
+            "eduPersonPrimaryAffiliation",
+            "eduPersonPrimaryAffiliation",
+            "eduPersonPrimaryAffiliation",
+        ),
+    ]:
+        keycloak.ldap.UserAttributeMapper(
+            resource_name,
+            realm_id=ol_mit_realm.id,
+            ldap_user_federation_id=ol_mit_ldap.id,
+            name=mapper_name,
+            ldap_attribute=ldap_attr,
+            user_model_attribute=model_attr,
+            read_only=True,
+            always_read_value_from_ldap=True,
+            is_mandatory_in_ldap=False,
+            opts=resource_options,
+        )
+
+    # Group mapper — resolves memberships from the virtual memberOf attribute
+    # rather than scanning group entries.  Groups in the Okta LDAP interface are
+    # exposed as groupOfUniqueNames under ou=groups once the oleng account has
+    # "Read Groups" permission; the mapper is registered now so no Pulumi change
+    # is required after that permission is granted.
+    keycloak.ldap.GroupMapper(
+        "ol-mit-ldap-group-mapper",
+        realm_id=ol_mit_realm.id,
+        ldap_user_federation_id=ol_mit_ldap.id,
+        name="group-mapper",
+        ldap_groups_dn="ou=groups,dc=mitprod,dc=okta,dc=com",
+        group_name_ldap_attribute="cn",
+        group_object_classes=["groupOfUniqueNames"],
+        membership_ldap_attribute="uniqueMember",
+        membership_user_ldap_attribute="uid",
+        membership_attribute_type="DN",
+        user_roles_retrieve_strategy="GET_GROUPS_FROM_USER_MEMBEROF_ATTRIBUTE",
+        memberof_ldap_attribute="memberOf",
+        mode="READ_ONLY",
+        preserve_group_inheritance=False,
+        drop_non_existing_groups_during_sync=True,
+        ignore_missing_groups=True,
+        opts=resource_options,
+    )
+    # MIT LDAP FEDERATION [END]
 
     vault.generic.Secret(
         "ol-mit-ovs-client-vault-oidc-credentials",

--- a/src/ol_infrastructure/substructure/keycloak/ol_mit.py
+++ b/src/ol_infrastructure/substructure/keycloak/ol_mit.py
@@ -434,27 +434,26 @@ def create_ol_mit_realm(  # noqa: PLR0913
     # Read-only federation against MIT's Okta LDAP interface to enrich users
     # already created via Touchstone SAML and to assign group memberships.
     #
-    # The Okta LDAP interface only exposes ou=users at the base DN; groups are
-    # surfaced via the virtual memberOf attribute on each user entry.  The
-    # GET_GROUPS_FROM_USER_MEMBEROF_ATTRIBUTE strategy on the group mapper
-    # therefore avoids needing to walk group entries and is more efficient for
-    # this interface.
+    # The Okta LDAP interface exposes users under ou=users and groups under
+    # ou=groups.  User entries do NOT carry a virtual memberOf attribute, so the
+    # group mapper uses LOAD_GROUPS_BY_MEMBER_ATTRIBUTE to look up memberships
+    # by querying group entries directly.
     #
     # Username linkage: Touchstone sends kerberos@mit.edu as the SAML NameID
     # (SUBJECT principal); the LDAP uid attribute is also kerberos@mit.edu, so
     # users created on first Touchstone login are automatically linked to their
     # LDAP counterpart on the next sync / login.
     #
-    # PREREQUISITE: The oleng service account must have "Read Groups" scope
-    # enabled in Okta Admin → Security → API → LDAP Interface before the group
-    # mapper can populate memberships.  The user-attribute sync works without
-    # that permission.
+    # PREREQUISITE: The open-learning-ldap.service account must have "Read
+    # Groups" scope enabled in Okta Admin → Security → API → LDAP Interface
+    # before the group mapper can populate memberships.  The user-attribute
+    # sync works without that permission.
     ol_mit_ldap = keycloak.ldap.UserFederation(
         "ol-mit-ldap",
         name="mit-ldap",
         realm_id=ol_mit_realm.id,
         connection_url="ldaps://mitprod.ldap.okta.com",
-        bind_dn="uid=oleng,dc=mitprod,dc=okta,dc=com",
+        bind_dn="uid=open-learning-ldap.service,dc=mitprod,dc=okta,dc=com",
         bind_credential=mit_ldap_bind_password,
         users_dn="ou=users,dc=mitprod,dc=okta,dc=com",
         username_ldap_attribute="uid",
@@ -466,6 +465,9 @@ def create_ol_mit_realm(  # noqa: PLR0913
         edit_mode="READ_ONLY",
         vendor="OTHER",
         search_scope="ONE_LEVEL",
+        # Restrict to active accounts only; deprovisioned users have
+        # organizationalStatus set to a value other than ACTIVE.
+        custom_user_search_filter="(organizationalStatus=ACTIVE)",
         # MIT emails are validated by Touchstone; no re-verification needed.
         trust_email=True,
         sync_registrations=False,
@@ -517,11 +519,13 @@ def create_ol_mit_realm(  # noqa: PLR0913
             opts=resource_options,
         )
 
-    # Group mapper — resolves memberships from the virtual memberOf attribute
-    # rather than scanning group entries.  Groups in the Okta LDAP interface are
-    # exposed as groupOfUniqueNames under ou=groups once the oleng account has
-    # "Read Groups" permission; the mapper is registered now so no Pulumi change
-    # is required after that permission is granted.
+    # Group mapper — resolves memberships by querying group entries directly.
+    # The Okta LDAP interface does NOT expose a virtual memberOf attribute on
+    # user entries, so GET_GROUPS_FROM_USER_MEMBEROF_ATTRIBUTE cannot be used.
+    # Instead, LOAD_GROUPS_BY_MEMBER_ATTRIBUTE issues a search for
+    # groupOfUniqueNames objects whose uniqueMember value equals the user's DN
+    # (e.g. uid=tmacey@mit.edu,ou=users,dc=mitprod,dc=okta,dc=com), which is
+    # how membership is actually stored in the Okta LDAP interface.
     keycloak.ldap.GroupMapper(
         "ol-mit-ldap-group-mapper",
         realm_id=ol_mit_realm.id,
@@ -533,8 +537,7 @@ def create_ol_mit_realm(  # noqa: PLR0913
         membership_ldap_attribute="uniqueMember",
         membership_user_ldap_attribute="uid",
         membership_attribute_type="DN",
-        user_roles_retrieve_strategy="GET_GROUPS_FROM_USER_MEMBEROF_ATTRIBUTE",
-        memberof_ldap_attribute="memberOf",
+        user_roles_retrieve_strategy="LOAD_GROUPS_BY_MEMBER_ATTRIBUTE",
         mode="READ_ONLY",
         preserve_group_inheritance=False,
         drop_non_existing_groups_during_sync=True,

--- a/src/ol_infrastructure/substructure/keycloak/ol_mit.py
+++ b/src/ol_infrastructure/substructure/keycloak/ol_mit.py
@@ -519,6 +519,15 @@ def create_ol_mit_realm(  # noqa: PLR0913
             opts=resource_options,
         )
 
+    # Parent group for all LDAP-sourced groups.  The groups_path parameter on
+    # the group mapper requires this group to exist before the first sync runs.
+    ol_mit_moira_group = keycloak.Group(
+        "ol-mit-moira-group",
+        realm_id=ol_mit_realm.id,
+        name="moira",
+        opts=resource_options,
+    )
+
     # Group mapper — resolves memberships by querying group entries directly.
     # The Okta LDAP interface does NOT expose a virtual memberOf attribute on
     # user entries, so GET_GROUPS_FROM_USER_MEMBEROF_ATTRIBUTE cannot be used.
@@ -526,6 +535,9 @@ def create_ol_mit_realm(  # noqa: PLR0913
     # groupOfUniqueNames objects whose uniqueMember value equals the user's DN
     # (e.g. uid=tmacey@mit.edu,ou=users,dc=mitprod,dc=okta,dc=com), which is
     # how membership is actually stored in the Okta LDAP interface.
+    #
+    # All synced groups land under /moira to distinguish them from groups
+    # managed directly in Keycloak.
     keycloak.ldap.GroupMapper(
         "ol-mit-ldap-group-mapper",
         realm_id=ol_mit_realm.id,
@@ -538,11 +550,15 @@ def create_ol_mit_realm(  # noqa: PLR0913
         membership_user_ldap_attribute="uid",
         membership_attribute_type="DN",
         user_roles_retrieve_strategy="LOAD_GROUPS_BY_MEMBER_ATTRIBUTE",
+        groups_path="/moira",
         mode="READ_ONLY",
         preserve_group_inheritance=False,
         drop_non_existing_groups_during_sync=True,
         ignore_missing_groups=True,
-        opts=resource_options,
+        opts=ResourceOptions.merge(
+            resource_options,
+            ResourceOptions(depends_on=[ol_mit_moira_group]),
+        ),
     )
     # MIT LDAP FEDERATION [END]
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6821

### Description (What does it do?)
Adds a read-only LDAP user federation to the `ol-mit` Keycloak realm against MIT's Okta LDAP interface (`ldaps://mitprod.ldap.okta.com`). This implements the group-membership sync path that was noted as "eventual" in the realm docstring.

**What's configured:**
- `UserFederation` — read-only, import-on-demand; no full sync (avoids bulk-importing all MIT affiliates); hourly delta sync (`changed_sync_period=3600`) refreshes attributes for users who have already logged in via Touchstone. A `custom_user_search_filter=(organizationalStatus=ACTIVE)` ensures deprovisioned accounts are excluded.
- Three MIT-specific `UserAttributeMapper` resources: `eduPersonPrincipalName`, `displayName`, `eduPersonPrimaryAffiliation` (standard username/email/name mappers are auto-created by Keycloak)
- `GroupMapper` using `LOAD_GROUPS_BY_MEMBER_ATTRIBUTE` — queries `groupOfUniqueNames` entries under `ou=groups` directly, searching for entries whose `uniqueMember` DN matches the user. This is the correct strategy because user entries in the Okta LDAP interface do **not** expose a virtual `memberOf` attribute (confirmed via ldapsearch).
- A top-level `moira` Keycloak group that acts as the parent for all LDAP-synced groups (`groups_path=/moira`), making them easy to distinguish from groups managed directly in Keycloak.

**Username linkage:** Touchstone sends `kerberos@mit.edu` as the SAML NameID (SUBJECT principal). The LDAP `uid` attribute is also `kerberos@mit.edu`. Users created on first Touchstone login are automatically linked to their LDAP counterpart, so group memberships flow in on the next login without any manual federation step.

**Investigation notes:** Exploration of the Okta LDAP interface confirmed:
- Users are under `ou=users,dc=mitprod,dc=okta,dc=com`; user entries have standard attributes (`uid`, `mail`, `cn`, `eduPersonPrimaryAffiliation`, etc.) but **no** `memberOf` virtual attribute
- Groups are accessible under `ou=groups,dc=mitprod,dc=okta,dc=com` as `groupOfUniqueNames` objects with `uniqueMember` DN values
- The `open-learning-ldap.service` account is used as the bind DN; it must have "Read Groups" scope enabled in Okta for group queries to succeed

**Group sync trigger:** Groups are resolved per-login via `LOAD_GROUPS_BY_MEMBER_ATTRIBUTE` (live LDAP search at login time). No periodic full-group-sync is configured; a manual sync can be triggered via the Keycloak Admin UI or REST API if needed.

### How can this be tested?
Run `pulumi preview` against the `substructure.keycloak.CI` stack after setting the bind-password config secret. Verify the LDAP user federation, three attribute mappers, group mapper, and `moira` parent group appear in the planned resource additions with no errors.

Log in as a user who is a member of an LDAP group (e.g. `ol-eng-developer`) and confirm the group appears under `/moira/ol-eng-developer` in the Keycloak Admin UI.

### Checklist:
- [x] Set `keycloak_realm:ol-mit-ldap-bind-password` as a Pulumi secret in CI, QA, and Production stacks before deploying:
  ```bash
  pulumi config set --secret keycloak_realm:ol-mit-ldap-bind-password  -s substructure.keycloak.CI
  pulumi config set --secret keycloak_realm:ol-mit-ldap-bind-password  -s substructure.keycloak.QA
  pulumi config set --secret keycloak_realm:ol-mit-ldap-bind-password  -s substructure.keycloak.Production
  ```
- [x] Enable "Read Groups" scope on the `open-learning-ldap.service` account in Okta Admin → Security → API → LDAP Interface (group memberships will not populate until this is done; attribute sync works without it)