### PR TITLE
Run the ad optimization pipeline once a day, append all log output to file, push output data to the google ads

### DIFF
--- a/src/ol_concourse/pipelines/applications/google_ads_optimization/ad_optimization_pipeline.py
+++ b/src/ol_concourse/pipelines/applications/google_ads_optimization/ad_optimization_pipeline.py
@@ -5,6 +5,7 @@ from ol_concourse.lib.constants import REGISTRY_IMAGE
 from ol_concourse.lib.models.pipeline import (
     AnonymousResource,
     Command,
+    GetStep,
     Identifier,
     Input,
     Job,
@@ -19,7 +20,7 @@ from ol_concourse.lib.notifications import notification
 from ol_concourse.lib.resource_types import (
     slack_notification_resource as slack_notification_resource_type,
 )
-from ol_concourse.lib.resources import slack_notification
+from ol_concourse.lib.resources import schedule, slack_notification
 
 COURSES = ["ml", "gen_ai", "sys_think", "sys_eng"]
 
@@ -33,11 +34,14 @@ slack_notification_resource = slack_notification(
     Identifier("slack-notification"), url="((google_ads_optimization.slack_url))"
 )
 
+ad_optimization_schedule = schedule(Identifier("optimization-schedule"), interval="24h")
+
 
 def ad_optimization_pipeline() -> Pipeline:
     ad_optimization_object = Job(
         name=Identifier("ad-optimization"),
         plan=[
+            GetStep(get=ad_optimization_schedule.name, trigger=True),
             TaskStep(
                 task=Identifier("ad-optimization-pipeline"),
                 config=TaskConfig(

--- a/src/ol_concourse/pipelines/applications/google_ads_optimization/ad_optimization_pipeline.py
+++ b/src/ol_concourse/pipelines/applications/google_ads_optimization/ad_optimization_pipeline.py
@@ -115,7 +115,7 @@ def ad_optimization_pipeline() -> Pipeline:
     )
     return Pipeline(
         jobs=[ad_optimization_object],
-        resources=[slack_notification_resource],
+        resources=[slack_notification_resource, ad_optimization_schedule],
         resource_types=[slack_notification_resource_type()],
     )
 

--- a/src/ol_concourse/pipelines/applications/google_ads_optimization/run_optimization_pipeline.sh
+++ b/src/ol_concourse/pipelines/applications/google_ads_optimization/run_optimization_pipeline.sh
@@ -32,7 +32,10 @@ CUSTOMER_ID_FOR_COURSE=$(echo "${CUSTOMER_ID_FOR_COURSES}" | uv run python -c "i
 uv run python scripts/pull_input_data.py --google-ads-yaml=google-ads.yaml --customer-id=${CUSTOMER_ID_FOR_COURSE} --output-course=${COURSE_NAME} --datasets=ads_reports
 
 # shellcheck disable=SC2086
-uv run python scripts/run_pipeline.py --course ${COURSE_NAME} --time-limit="1800.0" 2>&1 | tee "optimization_pipeline.log"
+uv run python scripts/run_pipeline.py --course ${COURSE_NAME} --time-limit="1800.0" 2>&1 | tee -a "optimization_pipeline.log"
+
+# shellcheck disable=SC2086
+uv run python scripts/push_output_data.py --google-ads-yaml=google-ads.yaml --customer-id=${CUSTOMER_ID_FOR_COURSE} --output-course=${COURSE_NAME} --datasets=budget,cpc,bid_adj --execute 2>&1 | tee -a "optimization_pipeline.log"
 
 echo "Pipeline finished. Checking for warnings in the log..."
 


### PR DESCRIPTION
Adjust the concourse google ads optimization pipeline to run once a day, put everything in one file, and push the budget, cpc and bid adjustments generated by the pipeline

```
resources:
  resource optimization-schedule has been added:
+ icon: clock
+ name: optimization-schedule
+ source:
+   days: null
+   interval: 24h
+   start: null
+   stop: null
+ type: time
  
jobs:
  job ad-optimization has changed:
  name: ad-optimization
  plan:
+ - get: optimization-schedule
+   trigger: true
  - config:
      image_resource:
        name: ""
        source:
          repository: mitodl/ad-opt
          tag: latest
        type: registry-image
      outputs:
      - name: optimization_pipeline_output
      params:
        COURSE_NAME: sys_think
        CUSTOMER_ID_FOR_COURSES: ((google_ads_optimization.customer_id_for_courses))
        GOOGLE_ADS_JSON: ((google_ads_optimization.google_ads_json))
        GOOGLE_DEVELOPER_TOKEN: ((google_ads_optimization.google_developer_token))
        GOOGLE_MANAGER_ACCOUNT: ((google_ads_optimization.google_manager_account))
        GRAFANA_TOKEN: ((grafana.metrics_write_token))
        GRAFANA_URL: ((grafana.metrics_url))
        GRAFANA_USERNAME: ((grafana.metrics_write_user))
        LICENSEID: ((google_ads_optimization.gurobi_wls_license_id))
        SEMRUSH_API_KEY: ((google_ads_optimization.semrush_api_key))
        WLSACCESSID: ((google_ads_optimization.gurobi_wls_access_id))
        WLSSECRET: ((google_ads_optimization.gurobi_wls_secret))
      platform: linux
      run:
        args:
        - -c
        - |
          #!/bin/bash
          set -euo pipefail
  
          working_dir=$(pwd)
  
          # TODO: Change this to just pass in env vars instead of writing out the json and yaml files.
          # This will require some small tweaks to the pull_input_data.py script to read from env vars instead of requiring files.
          mkdir /opt/gurobi
          cat > "/opt/gurobi/gurobi.lic" <<EOF
          LICENSEID=${LICENSEID}
          WLSACCESSID=${WLSACCESSID}
          WLSSECRET=${WLSSECRET}
          EOF
  
  
          cd /app
          cat > "google-ads.json" <<EOF
          ${GOOGLE_ADS_JSON}
          EOF
          cat > "google-ads.yaml" <<EOF
          json_key_file_path: google-ads.json
          developer_token: ${GOOGLE_DEVELOPER_TOKEN}
          use_proto_plus: True
          login_customer_id: ${GOOGLE_MANAGER_ACCOUNT}
          EOF
  
          # Kind of gnarly, but this lets us store the customer ID in vault since it's a semi-sensitive value.
          # shellcheck disable=SC2153
          CUSTOMER_ID_FOR_COURSE=$(echo "${CUSTOMER_ID_FOR_COURSES}" | uv run python -c "import json,sys; d=json.load(sys.stdin); print(d['${COURSE_NAME}'])")
  
          # shellcheck disable=SC2086
          uv run python scripts/pull_input_data.py --google-ads-yaml=google-ads.yaml --customer-id=${CUSTOMER_ID_FOR_COURSE} --output-course=${COURSE_NAME} --datasets=ads_reports
+ 
+         # shellcheck disable=SC2086
+         uv run python scripts/run_pipeline.py --course ${COURSE_NAME} --time-limit="1800.0" 2>&1 | tee -a "optimization_pipeline.log"
  
          # shellcheck disable=SC2086
-         uv run python scripts/run_pipeline.py --course ${COURSE_NAME} --time-limit="1800.0" 2>&1 | tee "optimization_pipeline.log"
+         uv run python scripts/push_output_data.py --google-ads-yaml=google-ads.yaml --customer-id=${CUSTOMER_ID_FOR_COURSE} --output-course=${COURSE_NAME} --datasets=budget,cpc,bid_adj --execute 2>&1 | tee -a "optimization_pipeline.log"
  
          echo "Pipeline finished. Checking for warnings in the log..."
  
          # Pipe warnings to an output. If that output exists, we want to emit a slack message about it.
          # Messages emitted by our push script use "WARNING" over stdout.
          warning_result=$(grep -A 3 "WARNING" optimization_pipeline.log || true)
          echo "Warnings check complete."
          if [ -n "$warning_result" ]; then
            echo "Warnings found in the log"
            echo "$warning_result" > "$working_dir"/optimization_pipeline_output/warnings.txt
          fi
          echo "Pipeline execution complete."
        path: bash
    on_abort:
      params:
        alert_type: aborted
        message: Google Ads Optimization Pipeline Abort
        text: Google Ads Optimization Pipeline aborted for sys_think. Check the pipeline
          logs for details.
      put: slack-notification
    on_error:
      params:
        alert_type: errored
        message: Google Ads Optimization Pipeline Error
        text: Google Ads Optimization Pipeline errored for sys_think. Check the pipeline
          logs for details.
      put: slack-notification
    on_failure:
      params:
        alert_type: failed
        message: Google Ads Optimization Pipeline Failure
        text: Google Ads Optimization Pipeline failed for sys_think. Check the pipeline
          logs for details.
      put: slack-notification
    task: ad-optimization-pipeline
  - config:
      image_resource:
        name: ""
        source:
          repository: debian
          tag: 12-slim
        type: registry-image
      inputs:
      - name: optimization_pipeline_output
      platform: linux
      run:
        args:
        - -c
        - |
          #!/bin/bash
          set -euo pipefail
  
  
          if [ -s optimization_pipeline_output/warnings.txt ]; then
            exit 1
          else
            exit 0
          fi
        path: bash
    on_failure:
      params:
        alert_type: failed
        message: Google Ads Optimization Warnings detected
        text: Google Ads Optimization Pipeline emitted warnings for sys_think. Check
          the pipeline logs for details.
      put: slack-notification
    task: ad-optimization-pipeline-emit-warnings
  
pipeline name: google-ads-optimization
pipeline instance vars:
  course_name: sys_think```
