### PR TITLE
Change Vault OIDC user claim

### DIFF
--- a/src/ol_infrastructure/substructure/vault/auth/__main__.py
+++ b/src/ol_infrastructure/substructure/vault/auth/__main__.py
@@ -118,7 +118,7 @@ developer_role = jwt.AuthBackendRole(
         f"{vault_config.get('address')}/ui/vault/auth/oidc/oidc/callback",
     ],
     bound_audiences=[keycloak_config.get("client_id")],
-    user_claim="sub",
+    user_claim="email",
     role_type="oidc",
 )
 
@@ -133,7 +133,7 @@ admin_role = jwt.AuthBackendRole(
         f"{vault_config.get('address')}/ui/vault/auth/oidc/oidc/callback",
     ],
     bound_audiences=[keycloak_config.get("client_id")],
-    user_claim="sub",
+    user_claim="email",
     role_type="oidc",
     bound_claims={"roles": "admin, vault-admins"},
 )


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
Minor change to make the Vault identity entity alias in OIDC be the user's email as opposed to a random string - https://support.hashicorp.com/hc/en-us/articles/22230971274131-Configure-OIDC-user-claim-parameter-for-user-friendly-output
