### PR TITLE
feat: Phase 2a — add missing project constants and remove dead STARROCKS_INFRA

### DIFF
--- a/src/ol_infrastructure/lib/pulumi_projects.py
+++ b/src/ol_infrastructure/lib/pulumi_projects.py
@@ -43,7 +43,6 @@ QDRANT_CLOUD = "ol-infrastructure-qdrant-cloud"
 GRAFANA_CLOUD = "ol-infrastructure-grafana-cloud"
 SFTP = "ol-infrastructure-aws-sftp"
 S3_SITES = "ol-infrastructure-aws-s3"
-STARROCKS_INFRA = "ol-infrastructure-starrocks"
 GEMINI_API = "ol-infrastructure-gemini-api"
 
 # ---------------------------------------------------------------------------
@@ -99,6 +98,12 @@ KEYCLOAK_APP = "ol-application-keycloak"
 MAILGUN = "ol-application-mailgun"
 MITX = "ol-application-mitx"
 ODL_VIDEO_SERVICE = "ol-application-odl-video-service"
+OPEN_DISCUSSIONS = "ol-application-open-discussions"
+STARROCKS_APP = "ol-application-starrocks"
+TIKA = "ol-application-tika"
+XPRO = "ol-application-xpro"
+XQUEUE = "ol-application-xqueue"
+XQWATCHER = "ol-application-xqwatcher"
 
 # ---------------------------------------------------------------------------
 # LEGACY_PROJECT_PREFIXES — migration shim
@@ -136,7 +141,6 @@ LEGACY_PROJECT_PREFIXES: dict[str, str] = {
     GRAFANA_CLOUD: "infrastructure.grafana_cloud",
     SFTP: "infrastructure.aws.sftp_servers",
     S3_SITES: "infrastructure.aws.s3_sites",
-    STARROCKS_INFRA: "infrastructure.starrocks",
     # substructure/
     EKS_SUB: "substructure.aws.eks",
     VAULT_AUTH: "substructure.vault.auth",
@@ -182,4 +186,10 @@ LEGACY_PROJECT_PREFIXES: dict[str, str] = {
     MAILGUN: "applications.mailgun",
     MITX: "applications.mitx",
     ODL_VIDEO_SERVICE: "applications.odl_video_service",
+    OPEN_DISCUSSIONS: "applications.open_discussions",
+    STARROCKS_APP: "applications.starrocks",
+    TIKA: "applications.tika",
+    XPRO: "applications.xpro",
+    XQUEUE: "applications.xqueue",
+    XQWATCHER: "applications.xqwatcher",
 }


### PR DESCRIPTION
## Summary

Phase 2a of the [project-scoped stacks migration](docs/project-scoped-stacks-migration.md). Completes the `pulumi_projects.py` constant inventory so every Pulumi project has a named constant and, where applicable, a `LEGACY_PROJECT_PREFIXES` shim entry.

Follows Phase 1 code preparation (PR #4559). Prerequisites for Phase 3 (`pulumi state upgrade`).

## Changes

### `src/ol_infrastructure/lib/pulumi_projects.py`

**Added 6 new project constants + `LEGACY_PROJECT_PREFIXES` entries:**

| Constant | Project name | Legacy prefix |
|----------|-------------|---------------|
| `OPEN_DISCUSSIONS` | `ol-application-open-discussions` | `applications.open_discussions` |
| `STARROCKS_APP` | `ol-application-starrocks` | `applications.starrocks` |
| `TIKA` | `ol-application-tika` | `applications.tika` |
| `XPRO` | `ol-application-xpro` | `applications.xpro` |
| `XQUEUE` | `ol-application-xqueue` | `applications.xqueue` |
| `XQWATCHER` | `ol-application-xqwatcher` | `applications.xqwatcher` |

**Removed:**
- `STARROCKS_INFRA` constant and its `LEGACY_PROJECT_PREFIXES` entry — the `infrastructure/starrocks` Pulumi project was deleted and no longer exists

## Intentional omissions

- `ECS_TEST` — no LEGACY entry because its single stack is already named `dev` (not a dotted legacy name); `stack_ref(ECS_TEST, "dev")` will emit the correct project-scoped format after Phase 3
- `GEMINI_API` — no LEGACY entry because the project has zero active stacks and cannot be referenced by other projects