### PR TITLE
feat: Phase 5 cleanup — remove legacy shim, update Concourse pipelines for project-scoped stacks

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/aws/pulumi_pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/aws/pulumi_pipeline.py
@@ -5,6 +5,12 @@ from ol_concourse.lib.resources import git_repo
 from ol_concourse.pipelines.constants import PULUMI_CODE_PATH, PULUMI_WATCHED_PATHS
 from ol_concourse.pipelines.jobs import pulumi_jobs_chain
 
+# Project names differ from the service names for kms/network, so use explicit mapping.
+_SIMPLE_SERVICE_PROJECT_NAMES = {
+    "kms": "ol-infrastructure-aws-kms",
+    "network": "ol-infrastructure-networking",
+}
+
 # Simple services that follow well defined patterns (CI -> QA -> Production)
 simple_resource_types = []
 simple_resources = []
@@ -21,11 +27,8 @@ for service in ["kms", "network"]:
 
     simple_pulumi_chain = pulumi_jobs_chain(
         simple_pulumi_code,
-        project_name=f"ol-infrastructure-aws-{service}",
-        stack_names=[
-            f"infrastructure.aws.{service}.{stage}"
-            for stage in ("CI", "QA", "Production")
-        ],
+        project_name=_SIMPLE_SERVICE_PROJECT_NAMES[service],
+        stack_names=["CI", "QA", "Production"],
         project_source_path=PULUMI_CODE_PATH.joinpath(f"infrastructure/aws/{service}/"),
         dependencies=[],
     )
@@ -63,7 +66,7 @@ for service in ["dns", "policies", "iam"]:
     oneoff_pulumi_chain = pulumi_jobs_chain(
         oneoff_pulumi_code,
         project_name=f"ol-infrastructure-aws-{service}",
-        stack_names=[f"infrastructure.aws.{service}"],
+        stack_names=["default"],
         project_source_path=PULUMI_CODE_PATH.joinpath(f"infrastructure/aws/{service}/"),
         dependencies=[],
     )

--- a/src/ol_concourse/pipelines/infrastructure/consul/packer_pulumi_pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/consul/packer_pulumi_pipeline.py
@@ -64,8 +64,8 @@ for network in [
         stages.insert(0, "CI")
     consul_pulumi_infrastructure_fragment = pulumi_jobs_chain(
         consul_pulumi_infrastructure_code,
-        project_name="ol-infrastructure-consul-server",
-        stack_names=[f"infrastructure.consul.{network}.{stage}" for stage in stages],
+        project_name="ol-infrastructure-consul",
+        stack_names=[f"{network}.{stage}" for stage in stages],
         project_source_path=PULUMI_CODE_PATH.joinpath("infrastructure/consul/"),
         dependencies=[
             GetStep(
@@ -85,8 +85,8 @@ for network in [
         stages.insert(0, "CI")
     consul_pulumi_substructure_fragment = pulumi_jobs_chain(
         consul_pulumi_substructure_code,
-        project_name="ol-infrastructure-substructure-consul",
-        stack_names=[f"substructure.consul.{network}.{stage}" for stage in stages],
+        project_name="ol-substructure-consul",
+        stack_names=[f"{network}.{stage}" for stage in stages],
         project_source_path=PULUMI_CODE_PATH.joinpath("substructure/consul/"),
     )
     consul_pulumi_substructure_fragments.append(consul_pulumi_substructure_fragment)

--- a/src/ol_concourse/pipelines/infrastructure/eks_clusters/pulumi_pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/eks_clusters/pulumi_pipeline.py
@@ -34,7 +34,7 @@ for cluster in ["data", "operations", "applications", "residential"]:
         eks_infrastructure_code,
         project_name="ol-infrastructure-eks",
         project_source_path=PULUMI_CODE_PATH.joinpath("infrastructure/aws/eks"),
-        stack_names=[f"infrastructure.aws.eks.{cluster}.{stage}" for stage in stages],
+        stack_names=[f"{cluster}.{stage}" for stage in stages],
     )
     pipeline_fragments.append(infra_chain)
 
@@ -42,7 +42,7 @@ for cluster in ["data", "operations", "applications", "residential"]:
         eks_substructure_code,
         project_name="ol-substructure-eks",
         project_source_path=PULUMI_CODE_PATH.joinpath("substructure/aws/eks"),
-        stack_names=[f"substructure.aws.eks.{cluster}.{stage}" for stage in stages],
+        stack_names=[f"{cluster}.{stage}" for stage in stages],
     )
     pipeline_fragments.append(substructure_chain)
 

--- a/src/ol_concourse/pipelines/infrastructure/k8s_apps/docker_pulumi.py
+++ b/src/ol_concourse/pipelines/infrastructure/k8s_apps/docker_pulumi.py
@@ -211,8 +211,8 @@ def _define_pulumi_resources(
     """Define the Pulumi resource type and resource."""
     pulumi_resource_type = pulumi_provisioner_resource()
     pulumi_resource = pulumi_provisioner(
-        name=Identifier(f"pulumi-ol-infrastructure-{app_name}-application"),
-        project_name=f"ol-infrastructure-{app_name}-application",
+        name=Identifier(f"pulumi-ol-application-{app_name}"),
+        project_name=f"ol-application-{app_name}",
         project_path=(
             f"{ol_infra_repo_name}/src/ol_infrastructure/applications/"
             f"{app_name.replace('-', '_')}"
@@ -405,8 +405,8 @@ def build_app_pipeline(app_name: str) -> Pipeline:
     # CI Deployment
     ci_fragment = pulumi_job(
         pulumi_code=ol_infra_repo,
-        stack_name=f"applications.{app_name.replace('-', '_')}.CI",
-        project_name=f"ol-infrastructure-{app_name}-application",
+        stack_name="CI",
+        project_name=f"ol-application-{app_name}",
         project_source_path=(
             f"src/ol_infrastructure/applications/{app_name.replace('-', '_')}"
         ),
@@ -496,11 +496,8 @@ def build_app_pipeline(app_name: str) -> Pipeline:
     # QA and Production Deployments
     qa_and_production_fragment = pulumi_jobs_chain(
         pulumi_code=ol_infra_repo,
-        stack_names=[
-            f"applications.{app_name.replace('-', '_')}.QA",
-            f"applications.{app_name.replace('-', '_')}.Production",
-        ],
-        project_name=f"ol-infrastructure-{app_name}-application",
+        stack_names=["QA", "Production"],
+        project_name=f"ol-application-{app_name}",
         project_source_path=(
             f"src/ol_infrastructure/applications/{app_name.replace('-', '_')}"
         ),

--- a/src/ol_concourse/pipelines/infrastructure/keycloak/docker_pulumi_pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/keycloak/docker_pulumi_pipeline.py
@@ -43,10 +43,8 @@ def build_keycloak_substructure_pipeline() -> PipelineFragment:
     )
     substructure_fragment = pulumi_jobs_chain(
         pulumi_code=keycloak_pulumi_code,
-        stack_names=[
-            f"substructure.keycloak.{env}" for env in ("CI", "QA", "Production")
-        ],
-        project_name="ol-infrastructure-substructure-keycloak",
+        stack_names=["CI", "QA", "Production"],
+        project_name="ol-substructure-keycloak",
         project_source_path=PULUMI_CODE_PATH.joinpath("substructure/keycloak/"),
     )
     substructure_fragment.resources.append(keycloak_pulumi_code)
@@ -216,15 +214,8 @@ def build_keycloak_infrastructure_pipeline() -> PipelineFragment:
 
     pulumi_fragment = pulumi_jobs_chain(
         keycloak_pulumi_code,
-        stack_names=[
-            f"applications.keycloak.{stage}"
-            for stage in [
-                "CI",
-                "QA",
-                "Production",
-            ]
-        ],
-        project_name="ol-infrastructure-keycloak",
+        stack_names=["CI", "QA", "Production"],
+        project_name="ol-application-keycloak",
         project_source_path=PULUMI_CODE_PATH.joinpath(
             "applications/keycloak",
         ),

--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/simple_pulumi_pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/simple_pulumi_pipeline.py
@@ -48,11 +48,10 @@ class SimplePulumiParams(BaseModel):
     Attributes:
         app_name: The name of the application/service.
         pulumi_project_path: Path to Pulumi project relative to src/ol_infrastructure/.
-        stack_prefix: Prefix for Pulumi stack names (e.g., "applications.tika").
-        pulumi_project_name: Name of the Pulumi project.
+        pulumi_project_name: Name of the Pulumi project (e.g. "ol-application-tika").
         stages: List of deployment stages (default: ["CI", "QA", "Production"]).
         deployment_groups: List of deployment group names for multi-group deployments
-                          (e.g., ["mitx", "mitxonline", "xpro"] for mongodb_atlas).
+                          (e.g. ["mitx", "mitxonline", "xpro"] for mongodb_atlas).
                           If specified, auto_discover_stacks will be used.
         auto_discover_stacks: If True, automatically discover stacks from repo
                              (default: False unless deployment_groups is set).
@@ -60,19 +59,18 @@ class SimplePulumiParams(BaseModel):
         branch: Git branch to watch (default: "main").
         docker_image: Optional Docker image configuration for apps that depend on
                      external Docker images.
-        prior_stage_stack: Full stack name of the preceding stage that runs in a
-                          different Concourse environment (e.g. QA stack when this
-                          pipeline only runs the Production stage in prod Concourse).
-                          When set, a GitHub issues trigger resource is added so this
-                          pipeline gates on the prior stage's deployment issue being
-                          closed, preserving the same promotion workflow used within a
-                          single chained pipeline.
+        prior_stage_stack: Short stack name of the preceding stage that runs in a
+                          different Concourse environment (e.g. "lakehouse.QA" when
+                          this pipeline only runs the Production stage in prod
+                          Concourse). When set, a GitHub issues trigger resource is
+                          added so this pipeline gates on the prior stage's deployment
+                          issue being closed, preserving the same promotion workflow
+                          used within a single chained pipeline.
     """
 
     app_name: str
     pulumi_project_path: str
-    stack_prefix: str
-    pulumi_project_name: str | None = None
+    pulumi_project_name: str
     stages: list[str] = ["CI", "QA", "Production"]
     deployment_groups: list[str] | None = None
     auto_discover_stacks: bool = False
@@ -85,8 +83,6 @@ class SimplePulumiParams(BaseModel):
     @classmethod
     def set_defaults(cls, data: dict[str, Any]) -> dict[str, Any]:
         """Set default values for optional fields."""
-        if not data.get("pulumi_project_name"):
-            data["pulumi_project_name"] = f"ol-infrastructure-{data['app_name']}"
         # Auto-enable stack discovery if deployment_groups is specified
         if data.get("deployment_groups") and not data.get("auto_discover_stacks"):
             data["auto_discover_stacks"] = True
@@ -94,13 +90,12 @@ class SimplePulumiParams(BaseModel):
 
 
 def discover_pulumi_stacks(
-    project_path: Path, stack_prefix: str, deployment_groups: list[str] | None = None
+    project_path: Path, deployment_groups: list[str] | None = None
 ) -> dict[str, list[str]] | list[str]:
     """Discover Pulumi stacks from the filesystem.
 
     Args:
         project_path: Path to the Pulumi project directory.
-        stack_prefix: Stack prefix to match (e.g., "infrastructure.mongodb_atlas").
         deployment_groups: Optional list of deployment groups to discover.
 
     Returns:
@@ -108,7 +103,7 @@ def discover_pulumi_stacks(
         stack names for that group (sorted by stage: CI → QA → Production).
         If deployment_groups is None: List of stack names sorted by stage.
     """
-    stack_files = list(project_path.glob(f"Pulumi.{stack_prefix}.*.yaml"))
+    stack_files = list(project_path.glob("Pulumi.*.yaml"))
 
     stacks = []
     for stack_file in stack_files:
@@ -130,11 +125,7 @@ def discover_pulumi_stacks(
     if deployment_groups:
         grouped_stacks: dict[str, list[str]] = {}
         for group in deployment_groups:
-            group_stacks = [
-                stack
-                for stack in stacks
-                if stack.startswith(f"{stack_prefix}.{group}.")
-            ]
+            group_stacks = [stack for stack in stacks if stack.startswith(f"{group}.")]
             # Sort by stage priority within group
             group_stacks.sort(key=get_stage_priority)
             if group_stacks:
@@ -146,13 +137,11 @@ def discover_pulumi_stacks(
         return stacks
 
 
-# Pipeline parameter configurations for each app
 pipeline_params: dict[str, SimplePulumiParams] = {
     "airbyte": SimplePulumiParams(
         app_name="airbyte",
         pulumi_project_path="applications/airbyte/",
-        pulumi_project_name="ol-infrastructure-airbyte-server",
-        stack_prefix="applications.airbyte",
+        pulumi_project_name="ol-application-airbyte",
         additional_watched_paths=[
             "src/bridge/secrets/airbyte/",
             "src/bridge/lib/versions.py",
@@ -161,8 +150,7 @@ pipeline_params: dict[str, SimplePulumiParams] = {
     "celery-monitoring": SimplePulumiParams(
         app_name="celery-monitoring",
         pulumi_project_path="applications/celery_monitoring/",
-        stack_prefix="applications.celery_monitoring",
-        pulumi_project_name="ol-infrastructure-celery-monitoring-server",
+        pulumi_project_name="ol-application-celery-monitoring",
         docker_image=DockerImageConfig(
             image_repository="kodhive/leek",
             image_tag="0.7.5",  # Must match LEEK_VERSION in bridge.lib.versions
@@ -171,47 +159,42 @@ pipeline_params: dict[str, SimplePulumiParams] = {
     "clickhouse": SimplePulumiParams(
         app_name="clickhouse",
         pulumi_project_path="applications/clickhouse/",
-        stack_prefix="applications.clickhouse",
-        pulumi_project_name="ol-infrastructure-clickhouse-application",
+        pulumi_project_name="ol-application-clickhouse",
         stages=["CI", "QA", "Production"],
     ),
     "data_warehouse": SimplePulumiParams(
         app_name="data_warehouse",
         pulumi_project_path="infrastructure/aws/data_warehouse/",
-        stack_prefix="infrastructure.aws.data_warehouse",
-        pulumi_project_name="ol-infrastructure-data_warehouse",
+        pulumi_project_name="ol-infrastructure-data-warehouse",
         stages=["QA", "Production"],
     ),
     "digital-credentials": SimplePulumiParams(
         app_name="digital-credentials",
         pulumi_project_path="applications/digital_credentials/",
-        stack_prefix="applications.digital_credentials",
+        pulumi_project_name="ol-application-digital-credentials",
         additional_watched_paths=["src/bridge/secrets/digital_credentials/"],
     ),
     "fastly-redirector": SimplePulumiParams(
         app_name="fastly-redirector",
         pulumi_project_path="applications/fastly_redirector/",
-        stack_prefix="applications.fastly_redirector",
-        pulumi_project_name="ol-infrastructure-fastly-redirector",
+        pulumi_project_name="ol-application-fastly-redirector",
     ),
     "mongodb-atlas": SimplePulumiParams(
         app_name="mongodb-atlas",
         pulumi_project_path="infrastructure/mongodb_atlas/",
-        stack_prefix="infrastructure.mongodb_atlas",
+        pulumi_project_name="ol-infrastructure-mongodb-atlas",
         deployment_groups=["mitx", "mitx-staging", "mitxonline", "xpro"],
     ),
     "open-discussions": SimplePulumiParams(
         app_name="open-discussions",
         pulumi_project_path="applications/open_discussions/",
-        stack_prefix="applications.open_discussions",
-        pulumi_project_name="ol-infrastructure-open_discussions-application",
+        pulumi_project_name="ol-application-open-discussions",
         stages=["QA", "Production"],
     ),
     "open-metadata": SimplePulumiParams(
         app_name="open-metadata",
         pulumi_project_path="applications/open_metadata/",
-        pulumi_project_name="ol-infrastructure-open_metadata-application",
-        stack_prefix="applications.open_metadata",
+        pulumi_project_name="ol-application-open-metadata",
         additional_watched_paths=[
             "src/bridge/secrets/open_metadata/",
             "src/bridge/lib/versions.py",
@@ -220,7 +203,6 @@ pipeline_params: dict[str, SimplePulumiParams] = {
     "opensearch": SimplePulumiParams(
         app_name="opensearch",
         pulumi_project_path="infrastructure/aws/opensearch/",
-        stack_prefix="infrastructure.aws.opensearch",
         pulumi_project_name="ol-infrastructure-opensearch",
         deployment_groups=[
             "apps",
@@ -237,7 +219,6 @@ pipeline_params: dict[str, SimplePulumiParams] = {
     "qdrant-cloud": SimplePulumiParams(
         app_name="qdrant-cloud",
         pulumi_project_path="infrastructure/qdrant_cloud/",
-        stack_prefix="infrastructure.qdrant_cloud.mitlearn",
         pulumi_project_name="ol-infrastructure-qdrant-cloud",
         additional_watched_paths=[
             "src/bridge/secrets/qdrant_cloud/",
@@ -247,8 +228,7 @@ pipeline_params: dict[str, SimplePulumiParams] = {
     "starrocks": SimplePulumiParams(
         app_name="starrocks",
         pulumi_project_path="applications/starrocks/",
-        stack_prefix="applications.starrocks",
-        pulumi_project_name="ol-infrastructure-starrocks-application",
+        pulumi_project_name="ol-application-starrocks",
         deployment_groups=[
             "lakehouse",
         ],
@@ -261,19 +241,17 @@ pipeline_params: dict[str, SimplePulumiParams] = {
     "starrocks-substructure": SimplePulumiParams(
         app_name="starrocks_substructure",
         pulumi_project_path="substructure/starrocks/",
-        stack_prefix="substructure.starrocks",
-        pulumi_project_name="ol-infrastructure-substructure-starrocks",
+        pulumi_project_name="ol-substructure-starrocks",
         deployment_groups=[
             "lakehouse",
         ],
         stages=["Production"],
-        prior_stage_stack="substructure.starrocks.lakehouse.QA",
+        prior_stage_stack="lakehouse.QA",
     ),
     "starrocks-substructure-qa": SimplePulumiParams(
         app_name="starrocks_substructure",
         pulumi_project_path="substructure/starrocks/",
-        stack_prefix="substructure.starrocks",
-        pulumi_project_name="ol-infrastructure-substructure-starrocks",
+        pulumi_project_name="ol-substructure-starrocks",
         deployment_groups=[
             "lakehouse",
         ],
@@ -282,21 +260,18 @@ pipeline_params: dict[str, SimplePulumiParams] = {
     "tika": SimplePulumiParams(
         app_name="tika",
         pulumi_project_path="applications/tika/",
-        stack_prefix="applications.tika",
-        pulumi_project_name="ol-infrastructure-tika-server",
+        pulumi_project_name="ol-application-tika",
     ),
     "vector-log-proxy": SimplePulumiParams(
         app_name="vector-log-proxy",
         pulumi_project_path="infrastructure/vector_log_proxy/",
-        stack_prefix="infrastructure.vector_log_proxy.operations",
-        pulumi_project_name="ol-infrastructure-vector-log-proxy-server",
+        pulumi_project_name="ol-infrastructure-vector-log-proxy",
     ),
     "xpro-partner-dns": SimplePulumiParams(
         app_name="xpro-partner-dns",
         pulumi_project_path="substructure/xpro_partner_dns/",
-        stack_prefix="substructure.xpro_partner_dns",
-        pulumi_project_name="ol-infrastructure-substructure-xpro-partner-dns",
-        stages=[""],
+        pulumi_project_name="ol-substructure-xpro-partner-dns",
+        stages=["default"],
     ),
 }
 
@@ -402,13 +377,10 @@ def build_simple_pulumi_pipeline(app_name: str) -> Pipeline:
             repo_root / "src/ol_infrastructure" / params.pulumi_project_path
         )
         discovered_stacks = discover_pulumi_stacks(
-            project_full_path, params.stack_prefix, params.deployment_groups
+            project_full_path, params.deployment_groups
         )
         if not discovered_stacks:
-            msg = (
-                f"No stacks discovered for {app_name} at {project_full_path} "
-                f"with prefix {params.stack_prefix}"
-            )
+            msg = f"No stacks discovered for {app_name} at {project_full_path}"
             raise ValueError(msg)
 
         # Filter discovered stacks to only the configured stages.  This ensures
@@ -439,8 +411,7 @@ def build_simple_pulumi_pipeline(app_name: str) -> Pipeline:
         if not discovered_stacks:
             msg = (
                 f"No stacks discovered for {app_name} at {project_full_path} "
-                f"with prefix {params.stack_prefix} after filtering for "
-                f"stages {params.stages}"
+                f"after filtering for stages {params.stages}"
             )
             raise ValueError(msg)
 
@@ -510,8 +481,7 @@ def build_simple_pulumi_pipeline(app_name: str) -> Pipeline:
     else:
         # Use explicitly configured stages - single chain
         stack_names = [
-            params.stack_prefix if stage == "" else f"{params.stack_prefix}.{stage}"
-            for stage in params.stages
+            "default" if stage == "default" else stage for stage in params.stages
         ]
 
         pulumi_fragment = pulumi_jobs_chain(

--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/simple_pulumi_pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/simple_pulumi_pipeline.py
@@ -49,6 +49,12 @@ class SimplePulumiParams(BaseModel):
         app_name: The name of the application/service.
         pulumi_project_path: Path to Pulumi project relative to src/ol_infrastructure/.
         pulumi_project_name: Name of the Pulumi project (e.g. "ol-application-tika").
+        stack_prefix: Short deployment-scope discriminator that appears before the
+                      stage in the stack name (e.g. "mitlearn" for qdrant-cloud →
+                      stack name "mitlearn.QA", "operations" for vector-log-proxy →
+                      "operations.QA"). Leave empty for single-tenant projects whose
+                      stack names are just the stage (e.g. "QA", "Production").
+                      Not used when deployment_groups is set.
         stages: List of deployment stages (default: ["CI", "QA", "Production"]).
         deployment_groups: List of deployment group names for multi-group deployments
                           (e.g. ["mitx", "mitxonline", "xpro"] for mongodb_atlas).
@@ -71,6 +77,7 @@ class SimplePulumiParams(BaseModel):
     app_name: str
     pulumi_project_path: str
     pulumi_project_name: str
+    stack_prefix: str = ""
     stages: list[str] = ["CI", "QA", "Production"]
     deployment_groups: list[str] | None = None
     auto_discover_stacks: bool = False
@@ -220,6 +227,7 @@ pipeline_params: dict[str, SimplePulumiParams] = {
         app_name="qdrant-cloud",
         pulumi_project_path="infrastructure/qdrant_cloud/",
         pulumi_project_name="ol-infrastructure-qdrant-cloud",
+        stack_prefix="mitlearn",
         additional_watched_paths=[
             "src/bridge/secrets/qdrant_cloud/",
             "src/bridge/lib/versions.py",
@@ -266,6 +274,7 @@ pipeline_params: dict[str, SimplePulumiParams] = {
         app_name="vector-log-proxy",
         pulumi_project_path="infrastructure/vector_log_proxy/",
         pulumi_project_name="ol-infrastructure-vector-log-proxy",
+        stack_prefix="operations",
     ),
     "xpro-partner-dns": SimplePulumiParams(
         app_name="xpro-partner-dns",
@@ -479,9 +488,12 @@ def build_simple_pulumi_pipeline(app_name: str) -> Pipeline:
                 jobs=pulumi_fragment.jobs,
             )
     else:
-        # Use explicitly configured stages - single chain
+        # Use explicitly configured stages - single chain.
+        # When stack_prefix is set (e.g. "mitlearn", "operations"), the stack
+        # name is "{prefix}.{stage}"; otherwise it is just the stage.
         stack_names = [
-            "default" if stage == "default" else stage for stage in params.stages
+            f"{params.stack_prefix}.{stage}" if params.stack_prefix else stage
+            for stage in params.stages
         ]
 
         pulumi_fragment = pulumi_jobs_chain(

--- a/src/ol_concourse/pipelines/infrastructure/vault/packer_pulumi_pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/vault/packer_pulumi_pipeline.py
@@ -51,10 +51,7 @@ vault_ami_fragment = packer_jobs(
 vault_pulumi_fragment = pulumi_jobs_chain(
     vault_pulumi_code,
     project_name="ol-infrastructure-vault-server",
-    stack_names=[
-        f"infrastructure.vault.operations.{stage}"
-        for stage in ("CI", "QA", "Production")
-    ],
+    stack_names=[f"operations.{stage}" for stage in ("CI", "QA", "Production")],
     project_source_path=PULUMI_CODE_PATH.joinpath("infrastructure/vault/"),
     dependencies=[
         GetStep(
@@ -78,11 +75,8 @@ for substructure in [
     substructure_fragments.append(  # noqa: PERF401
         pulumi_jobs_chain(
             vault_pulumi_substructure_code,
-            project_name=f"ol-infrastructure-vault-{substructure}",
-            stack_names=[
-                f"substructure.vault.{substructure}.operations.{stage}"
-                for stage in ("CI", "QA", "Production")
-            ],
+            project_name=f"ol-substructure-vault-{substructure}",
+            stack_names=[f"operations.{stage}" for stage in ("CI", "QA", "Production")],
             project_source_path=PULUMI_CODE_PATH.joinpath(
                 f"substructure/vault/{substructure}/"
             ),

--- a/src/ol_infrastructure/lib/pulumi_helper.py
+++ b/src/ol_infrastructure/lib/pulumi_helper.py
@@ -16,8 +16,11 @@ class StackInfo:
 
     After the project-scoped stack migration the fields carry these values:
 
-    * ``name``         — the short stack name, e.g. ``"QA"``, ``"mitx.QA"``,
-                         or ``"operations.QA"``.
+    * ``name``         — the trailing stack stage segment, e.g. ``"QA"``
+                         or ``"Production"``.  For the full short stack name
+                         (including any tenant prefix) use ``get_stack()``
+                         directly, or inspect ``namespace`` and combine:
+                         ``f"{namespace}.{name}" if namespace else name``.
     * ``project_name`` — Pulumi project name from ``Pulumi.yaml``, e.g.
                          ``"ol-infrastructure-networking"``.
     * ``namespace``    — the tenant/cluster token before the env segment

--- a/src/ol_infrastructure/lib/pulumi_helper.py
+++ b/src/ol_infrastructure/lib/pulumi_helper.py
@@ -9,14 +9,6 @@ import pulumi.log
 from pulumi import StackReference, get_stack
 from pulumi.runtime import sync_await
 
-# Top-level prefixes used in legacy flat-namespace stack names.
-# A stack whose name starts with one of these is still in the old format.
-_LEGACY_PREFIXES: tuple[str, ...] = (
-    "infrastructure.",
-    "applications.",
-    "substructure.",
-)
-
 
 @dataclass
 class StackInfo:
@@ -24,21 +16,19 @@ class StackInfo:
 
     After the project-scoped stack migration the fields carry these values:
 
-    * ``name``         — the environment segment, e.g. ``"QA"`` or ``"Production"``.
+    * ``name``         — the short stack name, e.g. ``"QA"``, ``"mitx.QA"``,
+                         or ``"operations.QA"``.
     * ``project_name`` — Pulumi project name from ``Pulumi.yaml``, e.g.
                          ``"ol-infrastructure-networking"``.
-    * ``namespace``    — for legacy stacks: the full dotted prefix before the env
-                         segment (e.g. ``"infrastructure.aws.network"``); for
-                         project-scoped stacks: the tenant/cluster token before
-                         the env segment (e.g. ``"mitx"``), or an empty string
-                         for single-tenant stacks.
-    * ``env_suffix``   — lowercase ``name``, e.g. ``"qa"``.
-    * ``env_prefix``   — tenant or cluster discriminator for multi-tenant projects
-                         (e.g. ``"mitx"``, ``"operations"``).  Empty string for
+    * ``namespace``    — the tenant/cluster token before the env segment
+                         (e.g. ``"mitx"``), or an empty string for
                          single-tenant stacks (stack name has no dot prefix).
+    * ``env_suffix``   — lowercase trailing stage, e.g. ``"qa"``.
+    * ``env_prefix``   — tenant or cluster discriminator for multi-tenant
+                         projects (e.g. ``"mitx"``, ``"operations"``).
+                         Empty string for single-tenant stacks.
     * ``full_name``    — fully-qualified stack reference:
-                         ``"organization/{project}/{stack}"`` for project-scoped
-                         stacks; the bare dotted name for legacy stacks.
+                         ``"organization/{project}/{stack}"``.
     """
 
     name: str
@@ -52,10 +42,8 @@ class StackInfo:
 def parse_stack() -> StackInfo:
     """Standardized method for extracting stack information.
 
-    Supports both the legacy flat-namespace format
-    (``infrastructure.aws.network.QA``) used before the project-scoped stack
-    migration and the new short format (``QA`` for single-tenant stacks,
-    ``mitx.QA`` for multi-tenant stacks).
+    Expects the project-scoped short stack name format: ``"QA"`` for
+    single-tenant stacks, ``"mitx.QA"`` for multi-tenant stacks.
 
     :returns: Parsed stack information for use in business logic.
     :rtype: StackInfo
@@ -64,40 +52,24 @@ def parse_stack() -> StackInfo:
     project = pulumi.get_project()
 
     stack_name = stack.split(".")[-1]
-    # For project-scoped single-tenant stacks (e.g. "QA") there is no dot, so
-    # namespace is empty.  For legacy or multi-tenant stacks (e.g.
-    # "infrastructure.aws.network.QA" or "mitx.QA") namespace is everything
-    # before the trailing env segment.
+    # For single-tenant stacks (e.g. "QA") there is no dot, so namespace is
+    # empty.  For multi-tenant stacks (e.g. "mitx.QA") namespace is the token
+    # before the trailing stage segment.
     namespace = stack.rsplit(".", 1)[0] if "." in stack else ""
     env_prefix = namespace.rsplit(".", 1)[-1] if namespace else ""
-
-    # Preserve the bare dotted name for legacy stacks so that existing
-    # StackReference strings and resource tags continue to work unchanged
-    # during the migration.  New-format stacks get the fully-qualified
-    # project-scoped reference as their full_name.
-    is_legacy = any(stack.startswith(p) for p in _LEGACY_PREFIXES)
-    full_name = stack if is_legacy else f"organization/{project}/{stack}"
 
     return StackInfo(
         name=stack_name,
         namespace=namespace,
         env_suffix=stack_name.lower(),
         env_prefix=env_prefix,
-        full_name=full_name,
+        full_name=f"organization/{project}/{stack}",
         project_name=project,
     )
 
 
 def stack_ref(project_name: str, stack_name: str) -> str:
-    """Build a stack reference string that works both before and after migration.
-
-    During Phase 1 this returns the legacy flat-namespace dotted format (e.g.
-    ``"infrastructure.aws.network.QA"``) for all projects that haven't been
-    renamed yet, so that existing stacks in the S3 backend continue to resolve.
-    Once a project's stacks are renamed (Phase 4) and its entry is removed from
-    :data:`ol_infrastructure.lib.pulumi_projects.LEGACY_PROJECT_PREFIXES`,
-    the helper switches to the project-scoped format
-    ``"organization/{project_name}/{stack_name}"``.
+    """Build a project-scoped stack reference string.
 
     :param project_name: Pulumi project name constant from
         :mod:`ol_infrastructure.lib.pulumi_projects`.
@@ -106,13 +78,6 @@ def stack_ref(project_name: str, stack_name: str) -> str:
         projects (DNS, IAM, POLICIES …).
     :returns: Reference string suitable for :class:`pulumi.StackReference`.
     """
-    from ol_infrastructure.lib.pulumi_projects import (  # noqa: PLC0415
-        LEGACY_PROJECT_PREFIXES,
-    )
-
-    if project_name in LEGACY_PROJECT_PREFIXES:
-        prefix = LEGACY_PROJECT_PREFIXES[project_name]
-        return prefix if stack_name == "default" else f"{prefix}.{stack_name}"
     return f"organization/{project_name}/{stack_name}"
 
 

--- a/src/ol_infrastructure/lib/pulumi_projects.py
+++ b/src/ol_infrastructure/lib/pulumi_projects.py
@@ -12,12 +12,6 @@ to build stack reference strings:
     eks_stack = StackReference(
         stack_ref(projects.EKS_SUB, f"{stack_info.env_prefix}.{stack_info.name}")
     )
-
-**Migration note:** The string values here are the *target* project names that
-will be set in each project's ``Pulumi.yaml`` after Phase 2 of the migration.
-Until then, :data:`LEGACY_PROJECT_PREFIXES` maps every constant to its current
-legacy dotted stack prefix so that :func:`stack_ref` continues to resolve
-stacks in the existing S3 backend without any stack renames being required.
 """
 
 # ---------------------------------------------------------------------------
@@ -104,92 +98,3 @@ TIKA = "ol-application-tika"
 XPRO = "ol-application-xpro"
 XQUEUE = "ol-application-xqueue"
 XQWATCHER = "ol-application-xqwatcher"
-
-# ---------------------------------------------------------------------------
-# LEGACY_PROJECT_PREFIXES — migration shim
-#
-# Maps each future project name constant (value of the constants above) to the
-# dotted prefix used in the current flat-namespace S3 backend.
-#
-# stack_ref() uses this table to emit the correct legacy format while stacks
-# have not yet been renamed.  Remove an entry from this dict once that
-# project's stacks have been renamed (Phase 4); remove the dict entirely after
-# all projects are migrated (Phase 5).
-#
-# For single-stack "global" projects (DNS, IAM, POLICIES, …) the legacy stack
-# name IS the prefix and stack_ref() is called with stack_name="default".
-# ---------------------------------------------------------------------------
-
-LEGACY_PROJECT_PREFIXES: dict[str, str] = {
-    # infrastructure/
-    NETWORKING: "infrastructure.aws.network",
-    KMS: "infrastructure.aws.kms",
-    DNS: "infrastructure.aws.dns",
-    IAM: "infrastructure.aws.iam",
-    ECR: "infrastructure.aws.ecr",
-    PRIVATE_CA: "infrastructure.aws.private_ca",
-    POLICIES: "infrastructure.aws.policies",
-    EKS: "infrastructure.aws.eks",
-    OPENSEARCH: "infrastructure.aws.opensearch",
-    VAULT_SERVER: "infrastructure.vault",
-    CONSUL_INFRA: "infrastructure.consul",
-    MONITORING: "infrastructure.monitoring",
-    VECTOR_LOG_PROXY: "infrastructure.vector_log_proxy",
-    DATA_WAREHOUSE: "infrastructure.aws.data_warehouse",
-    MONGODB_ATLAS: "infrastructure.mongodb_atlas",
-    QDRANT_CLOUD: "infrastructure.qdrant_cloud",
-    GRAFANA_CLOUD: "infrastructure.grafana_cloud",
-    SFTP: "infrastructure.aws.sftp_servers",
-    S3_SITES: "infrastructure.aws.s3_sites",
-    # substructure/
-    EKS_SUB: "substructure.aws.eks",
-    VAULT_AUTH: "substructure.vault.auth",
-    VAULT_SETUP: "substructure.vault.setup",
-    VAULT_STATIC_MOUNTS: "substructure.vault.static_mounts",
-    VAULT_ENCRYPTION_MOUNTS: "substructure.vault.encryption_mounts",
-    VAULT_PKI: "substructure.vault.pki",
-    VAULT_APPROLES: "substructure.vault.approles",
-    VAULT_SECRETS: "substructure.vault.secrets",  # pragma: allowlist secret
-    CONSUL_SUB: "substructure.consul",
-    KEYCLOAK_SUB: "substructure.keycloak",
-    STARROCKS_SUB: "substructure.starrocks",
-    TLS_CERTS: "substructure.tls_certificates",
-    XPRO_PARTNER_DNS: "substructure.xpro_partner_dns",
-    # applications/
-    MIT_LEARN: "applications.mit_learn",
-    EDXAPP: "applications.edxapp",
-    EDX_NOTES: "applications.edxnotes",
-    CODEJAIL: "applications.codejail",
-    CONCOURSE: "applications.concourse",
-    AIRBYTE: "applications.airbyte",
-    DAGSTER: "applications.dagster",
-    OCW_STUDIO: "applications.ocw_studio",
-    JUPYTERHUB: "applications.jupyterhub",
-    SUPERSET: "applications.superset",
-    OPEN_METADATA: "applications.open_metadata",
-    KUBEWATCH: "applications.kubewatch",
-    KUBEWATCH_WEBHOOK: "applications.kubewatch_webhook_handler",
-    FASTLY_REDIRECTOR: "applications.fastly_redirector",
-    CELERY_MONITORING: "applications.celery_monitoring",
-    REDASH: "applications.redash",
-    LEARN_AI: "applications.learn_ai",
-    MICROMASTERS: "applications.micromasters",
-    MITXONLINE: "applications.mitxonline",
-    B2B_STORAGE: "applications.b2b_partners_storage",
-    DIGITAL_CREDENTIALS: "applications.digital_credentials",
-    STARBURST: "applications.starburst",
-    BOOTCAMPS: "applications.bootcamps",
-    OCW_SITE: "applications.ocw_site",
-    MIT_LEARN_NEXTJS: "applications.mit_learn_nextjs",
-    CLICKHOUSE: "applications.clickhouse",
-    KEYCLOAK_APP: "applications.keycloak",
-    MAILGUN: "applications.mailgun",
-    MITX: "applications.mitx",
-    ODL_VIDEO_SERVICE: "applications.odl_video_service",
-    OPEN_DISCUSSIONS: "applications.open_discussions",
-    STARROCKS_APP: "applications.starrocks",
-    TIKA: "applications.tika",
-    XPRO: "applications.xpro",
-    XQUEUE: "applications.xqueue",
-    XQWATCHER: "applications.xqwatcher",
-}


### PR DESCRIPTION
## Overview

This is the **Phase 5 (final cleanup) PR** for the project-scoped stacks migration. It should only be merged **after Phase 3 (state upgrade) and Phase 4 (all stack renames) are complete**.

See `docs/project-scoped-stacks-migration.md` (PR #4565) for the full migration guide.

## Changes

### `src/ol_infrastructure/lib/pulumi_helper.py`
- Remove `_LEGACY_PREFIXES` tuple (no longer needed after all stacks renamed)
- `parse_stack()`: remove dual-mode legacy detection; `full_name` always `organization/{project}/{stack}`
- `stack_ref()`: simplified to always return `organization/{project_name}/{stack_name}`

### `src/ol_infrastructure/lib/pulumi_projects.py`
- Remove `LEGACY_PROJECT_PREFIXES` dict (no longer needed after all stacks renamed)
- Update module docstring

### Concourse Pipelines (all in `src/ol_concourse/pipelines/infrastructure/`)
Updated to use new project-scoped stack names after migration:

- **`aws/pulumi_pipeline.py`**: project names corrected; stack names are bare stages (`QA`, `Production`) or `default`
- **`eks_clusters/pulumi_pipeline.py`**: stack names `{cluster}.{stage}`
- **`vault/packer_pulumi_pipeline.py`**: stack names `operations.{stage}`; substructure project names `ol-substructure-vault-*`
- **`consul/packer_pulumi_pipeline.py`**: project names corrected; stack names `{network}.{stage}`
- **`keycloak/docker_pulumi_pipeline.py`**: project names corrected; stack names are bare stages
- **`k8s_apps/docker_pulumi.py`**: project name formula `ol-application-{app}`; stack names bare stages
- **`simple_pulumi/simple_pulumi_pipeline.py`**:
  - All `pulumi_project_name` values updated to new names
  - `stack_prefix` retained as short deployment discriminator (e.g. `mitlearn` for qdrant-cloud, `operations` for vector-log-proxy)
  - Stack name generation: `f"{prefix}.{stage}"` when prefix is set, otherwise bare stage
  - Prior-stage stack references updated to new short names

## ⚠️ Do Not Merge Until

- [x] Phase 3 complete: `pulumi state upgrade` run against `s3://mitol-pulumi-state`
- [x] Phase 4 complete: ALL 274 stacks renamed, ALL `Pulumi.yaml` project names updated
- [ ] All `pulumi preview` runs show zero diff after renames

## Testing

Pre-commit hooks pass: ruff format ✓, ruff check ✓, mypy ✓