### PR TITLE
fix(open-metadata): use logical path for vault.generic.Secret KV v2 write

### DIFF
--- a/src/ol_infrastructure/applications/open_metadata/__main__.py
+++ b/src/ol_infrastructure/applications/open_metadata/__main__.py
@@ -333,7 +333,7 @@ connector_secret_names: list[str] = []
 if open_metadata_connector_secrets:
     open_metadata_connector_vault_secret = vault.generic.Secret(
         f"open-metadata-connector-vault-secret-{stack_info.env_suffix}",
-        path="secret-openmetadata/data/connectors",
+        path="secret-openmetadata/connectors",
         data_json=Output.secret(json.dumps(open_metadata_connector_secrets)),
         opts=ResourceOptions(
             depends_on=[open_metadata_connector_vault_mount],


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Fixes a bug introduced during the KV v2 migration for the OpenMetadata connector secrets mount.

`vault.generic.Secret` handles the `/data/` API path prefix internally for KV v2 mounts — the `path` argument should be the logical secret path (`secret-openmetadata/connectors`), not the raw KV v2 API path (`secret-openmetadata/data/connectors`).

Using the API path directly causes the write and read to target different locations, preventing connector credentials from being synced to K8s secrets via vault-secrets-operator. The pattern used here now matches the existing convention in this repo (e.g. `concourse/__main__.py`).

The Vault HCL policy paths are unaffected — policies correctly use the KV v2 API path (`secret-openmetadata/data/connectors`).

### How can this be tested?
Run `pulumi preview` against the QA stack after the SOPS secrets file for OpenMetadata is in place. Confirm that `vault.generic.Secret` targets `secret-openmetadata/connectors` and that the VSO `VaultStaticSecret` resource syncs correctly to the K8s secret.

### Additional Context
Caught during post-merge code review of PRs #4493 and #4497.