### PR TITLE
feat: add cookie header telemetry to APISix and Alloy

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
@@ -255,7 +255,8 @@ def setup_apisix(
                             "cookie_bytes=$cookie_bytes "
                             "cookie_count=$cookie_count "
                             "oidc_session_bytes=$oidc_session_bytes "
-                            "cookie_names=$cookie_names",
+                            "cookie_names=$cookie_names "
+                            "cookie_sizes=$cookie_sizes",
                             "accessLogFormatEscape": "default",
                             "errorLog": "/dev/stderr",
                             "errorLogLevel": "warn",
@@ -280,8 +281,13 @@ def setup_apisix(
                                 set_by_lua_block $cookie_count {{
                                     local cookie = ngx.var.http_cookie or ""
                                     if cookie == "" then return "0" end
-                                    local count = 1
-                                    for _ in cookie:gmatch(";") do count = count + 1 end
+                                    local count = 0
+                                    for pair in (cookie .. ";"):gmatch("([^;]*);") do
+                                        local name = pair:match("^%s*([^=]+)=")
+                                        if name and name:match("%S") then
+                                            count = count + 1
+                                        end
+                                    end
                                     return tostring(count)
                                 }}
                                 set_by_lua_block $oidc_session_bytes {{
@@ -290,8 +296,11 @@ def setup_apisix(
                                     local all = ngx.var.http_cookie or ""
                                     for pair in (all .. ";"):gmatch("([^;]+);") do
                                         local name, val = pair:match("^%s*([^=]+)=(.*)")
-                                        if name and name:match("^%s*" .. session_name .. "%s*$") then
-                                            return tostring(#pair)
+                                        if name then
+                                            local trimmed_name = name:match("^%s*(.-)%s*$")
+                                            if trimmed_name == session_name then
+                                                return tostring(#(trimmed_name .. "=" .. val))
+                                            end
                                         end
                                     end
                                     return "0"
@@ -307,6 +316,23 @@ def setup_apisix(
                                         end
                                     end
                                     return table.concat(names, ",")
+                                }}
+                                -- cookie_sizes logs each cookie name with its byte count as name:BYTES
+                                -- pairs (e.g. _csrf:64,session_id:4096).  Cookie request headers do
+                                -- NOT carry the domain/path the cookie was set on; use host= in the
+                                -- surrounding log line to correlate which destination received them.
+                                set_by_lua_block $cookie_sizes {{
+                                    local cookie = ngx.var.http_cookie or ""
+                                    local parts = {{}}
+                                    for pair in (cookie .. ";"):gmatch("([^;]+);") do
+                                        local name = pair:match("^%s*([^=]+)=")
+                                        if name then
+                                            local trimmed_name = name:match("^%s*(.-)%s*$")
+                                            local trimmed_pair = pair:match("^%s*(.-)%s*$")
+                                            table.insert(parts, trimmed_name .. ":" .. tostring(#trimmed_pair))
+                                        end
+                                    end
+                                    return table.concat(parts, ",")
                                 }}
 
                                 # Serve a branded error page for gateway-level errors (HTTP 400/431

--- a/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
@@ -251,7 +251,11 @@ def setup_apisix(
                             'http_referer="$http_referer" '
                             'http_user_agent="$http_user_agent" '
                             "method=$request_method "
-                            'request="$request"',
+                            'request="$request" '
+                            "cookie_bytes=$cookie_bytes "
+                            "cookie_count=$cookie_count "
+                            "oidc_session_bytes=$oidc_session_bytes "
+                            "cookie_names=$cookie_names",
                             "accessLogFormatEscape": "default",
                             "errorLog": "/dev/stderr",
                             "errorLogLevel": "warn",
@@ -269,6 +273,41 @@ def setup_apisix(
                                 f"""\
                                 set $session_compressor zlib;
                                 set $session_name {session_cookie_name};
+
+                                set_by_lua_block $cookie_bytes {{
+                                    return #(ngx.var.http_cookie or "")
+                                }}
+                                set_by_lua_block $cookie_count {{
+                                    local cookie = ngx.var.http_cookie or ""
+                                    if cookie == "" then return "0" end
+                                    local count = 1
+                                    for _ in cookie:gmatch(";") do count = count + 1 end
+                                    return tostring(count)
+                                }}
+                                set_by_lua_block $oidc_session_bytes {{
+                                    local session_name = ngx.var.session_name or ""
+                                    if session_name == "" then return "0" end
+                                    local all = ngx.var.http_cookie or ""
+                                    for pair in (all .. ";"):gmatch("([^;]+);") do
+                                        local name, val = pair:match("^%s*([^=]+)=(.*)")
+                                        if name and name:match("^%s*" .. session_name .. "%s*$") then
+                                            return tostring(#pair)
+                                        end
+                                    end
+                                    return "0"
+                                }}
+                                set_by_lua_block $cookie_names {{
+                                    local cookie = ngx.var.http_cookie or ""
+                                    local names = {{}}
+                                    for pair in (cookie .. ";"):gmatch("([^;]+);") do
+                                        local name = pair:match("^%s*([^=]+)=")
+                                        if name then
+                                            name = name:match("^%s*(.-)%s*$")
+                                            table.insert(names, name)
+                                        end
+                                    end
+                                    return table.concat(names, ",")
+                                }}
 
                                 # Serve a branded error page for gateway-level errors (HTTP 400/431
                                 # from oversized request headers, HTTP 500 from OIDC plugin failures,

--- a/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
@@ -255,8 +255,8 @@ def setup_apisix(
                             "cookie_bytes=$cookie_bytes "
                             "cookie_count=$cookie_count "
                             "oidc_session_bytes=$oidc_session_bytes "
-                            "cookie_names=$cookie_names "
-                            "cookie_sizes=$cookie_sizes",
+                            'cookie_names="$cookie_names" '
+                            'cookie_sizes="$cookie_sizes"',
                             "accessLogFormatEscape": "default",
                             "errorLog": "/dev/stderr",
                             "errorLogLevel": "warn",
@@ -275,64 +275,43 @@ def setup_apisix(
                                 set $session_compressor zlib;
                                 set $session_name {session_cookie_name};
 
-                                set_by_lua_block $cookie_bytes {{
-                                    return #(ngx.var.http_cookie or "")
-                                }}
-                                set_by_lua_block $cookie_count {{
-                                    local cookie = ngx.var.http_cookie or ""
-                                    if cookie == "" then return "0" end
-                                    local count = 0
-                                    for pair in (cookie .. ";"):gmatch("([^;]*);") do
-                                        local name = pair:match("^%s*([^=]+)=")
-                                        if name and name:match("%S") then
-                                            count = count + 1
-                                        end
-                                    end
-                                    return tostring(count)
-                                }}
-                                set_by_lua_block $oidc_session_bytes {{
+                                set $cookie_bytes 0;
+                                set $cookie_count 0;
+                                set $oidc_session_bytes 0;
+                                set $cookie_names "";
+                                set $cookie_sizes "";
+
+                                -- Parse the Cookie request header exactly once per request and
+                                -- populate all telemetry variables.  APISix does not use
+                                -- rewrite_by_lua_block in its server block so this is safe.
+                                rewrite_by_lua_block {{
+                                    local raw = ngx.var.http_cookie or ""
+                                    ngx.var.cookie_bytes = tostring(#raw)
+                                    if raw == "" then return end
                                     local session_name = ngx.var.session_name or ""
-                                    if session_name == "" then return "0" end
-                                    local all = ngx.var.http_cookie or ""
-                                    for pair in (all .. ";"):gmatch("([^;]+);") do
+                                    local count = 0
+                                    local names = {{}}
+                                    local sizes = {{}}
+                                    local oidc_bytes = 0
+                                    for pair in (raw .. ";"):gmatch("([^;]+);") do
                                         local name, val = pair:match("^%s*([^=]+)=(.*)")
                                         if name then
                                             local trimmed_name = name:match("^%s*(.-)%s*$")
-                                            if trimmed_name == session_name then
-                                                return tostring(#(trimmed_name .. "=" .. val))
+                                            if trimmed_name ~= "" then
+                                                count = count + 1
+                                                local trimmed_pair = pair:match("^%s*(.-)%s*$")
+                                                table.insert(names, trimmed_name)
+                                                table.insert(sizes, trimmed_name .. ":" .. tostring(#trimmed_pair))
+                                                if trimmed_name == session_name then
+                                                    oidc_bytes = #(trimmed_name .. "=" .. val)
+                                                end
                                             end
                                         end
                                     end
-                                    return "0"
-                                }}
-                                set_by_lua_block $cookie_names {{
-                                    local cookie = ngx.var.http_cookie or ""
-                                    local names = {{}}
-                                    for pair in (cookie .. ";"):gmatch("([^;]+);") do
-                                        local name = pair:match("^%s*([^=]+)=")
-                                        if name then
-                                            name = name:match("^%s*(.-)%s*$")
-                                            table.insert(names, name)
-                                        end
-                                    end
-                                    return table.concat(names, ",")
-                                }}
-                                -- cookie_sizes logs each cookie name with its byte count as name:BYTES
-                                -- pairs (e.g. _csrf:64,session_id:4096).  Cookie request headers do
-                                -- NOT carry the domain/path the cookie was set on; use host= in the
-                                -- surrounding log line to correlate which destination received them.
-                                set_by_lua_block $cookie_sizes {{
-                                    local cookie = ngx.var.http_cookie or ""
-                                    local parts = {{}}
-                                    for pair in (cookie .. ";"):gmatch("([^;]+);") do
-                                        local name = pair:match("^%s*([^=]+)=")
-                                        if name then
-                                            local trimmed_name = name:match("^%s*(.-)%s*$")
-                                            local trimmed_pair = pair:match("^%s*(.-)%s*$")
-                                            table.insert(parts, trimmed_name .. ":" .. tostring(#trimmed_pair))
-                                        end
-                                    end
-                                    return table.concat(parts, ",")
+                                    ngx.var.cookie_count = tostring(count)
+                                    ngx.var.oidc_session_bytes = tostring(oidc_bytes)
+                                    ngx.var.cookie_names = table.concat(names, ",")
+                                    ngx.var.cookie_sizes = table.concat(sizes, ",")
                                 }}
 
                                 # Serve a branded error page for gateway-level errors (HTTP 400/431

--- a/src/ol_infrastructure/substructure/aws/eks/grafana.py
+++ b/src/ol_infrastructure/substructure/aws/eks/grafana.py
@@ -9,6 +9,67 @@ from bridge.secrets.sops import read_yaml_secrets
 from ol_infrastructure.lib.pulumi_helper import StackInfo
 
 
+def _apisix_cookie_metrics_alloy_config() -> str:
+    """
+    Alloy River stage blocks that extract cookie header telemetry from APISix
+    access logs and emit Prometheus histograms.
+
+    This string is injected into the loki.process "pod_logs" component by the
+    k8s-monitoring chart via podLogsViaLoki.extraLogProcessingStages. It runs
+    after the standard relabeling stages so stream labels (e.g.
+    app_kubernetes_io_name) are already available.
+
+    The APISix access log format appends these fields at the end of each line:
+      cookie_bytes=NNN cookie_count=N oidc_session_bytes=NNN cookie_names=name1,name2
+
+    The stage.metrics blocks emit Prometheus histograms that Alloy exposes on
+    its own metrics endpoint (:12345/metrics), from where they are scraped and
+    forwarded to Grafana Cloud Prometheus.
+
+    Privacy: only byte counts and cookie name keys are captured; cookie values
+    are never logged or extracted.
+    """
+    return r"""
+stage.match {
+  selector = "{app_kubernetes_io_name=\"apisix\"} |= \"cookie_bytes=\""
+  pipeline_name = "apisix_cookie_metrics"
+
+  // Extract host, status, and the four cookie fields appended at the end of
+  // each APISix access log line. host and status appear early in the line;
+  // the cookie fields are always at the tail after request="...".
+  stage.regex {
+    expression = `.*\bhost=(?P<host>\S+).*\bstatus=(?P<status>\d+).*\bcookie_bytes=(?P<cookie_bytes>\d+)\s+cookie_count=(?P<cookie_count>\d+)\s+oidc_session_bytes=(?P<oidc_session_bytes>\d+)`
+  }
+
+  stage.metrics {
+    metric.histogram "apisix_cookie_header_bytes" {
+      description = "Size in bytes of the Cookie request header at the APISix ingress, per virtual host"
+      source      = "cookie_bytes"
+      config {
+        buckets = [256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536]
+      }
+    }
+
+    metric.histogram "apisix_cookie_count" {
+      description = "Number of cookies in the Cookie request header at APISix ingress"
+      source      = "cookie_count"
+      config {
+        buckets = [1, 2, 3, 5, 8, 12, 20, 30, 50]
+      }
+    }
+
+    metric.histogram "apisix_oidc_session_cookie_bytes" {
+      description = "Size in bytes of the APISix OIDC session cookie only"
+      source      = "oidc_session_bytes"
+      config {
+        buckets = [0, 256, 1024, 2048, 4096, 6144, 8192]
+      }
+    }
+  }
+}
+"""
+
+
 def setup_grafana(
     cluster_name: str,
     stack_info: StackInfo,
@@ -191,6 +252,7 @@ def setup_grafana(
                 "podLogsViaLoki": {
                     "enabled": True,
                     "collector": "alloy-logs",
+                    "extraLogProcessingStages": _apisix_cookie_metrics_alloy_config(),
                 },
                 "applicationObservability": {
                     "enabled": True,

--- a/src/ol_infrastructure/substructure/aws/eks/grafana.py
+++ b/src/ol_infrastructure/substructure/aws/eks/grafana.py
@@ -16,27 +16,28 @@ def _apisix_cookie_metrics_alloy_config() -> str:
 
     This string is injected into the loki.process "pod_logs" component by the
     k8s-monitoring chart via podLogsViaLoki.extraLogProcessingStages. It runs
-    after the standard relabeling stages so stream labels (e.g.
-    app_kubernetes_io_name) are already available.
+    after the standard relabeling stages so retained stream labels (e.g.
+    service, namespace, and container) are already available.
 
-    The APISix access log format appends these fields at the end of each line:
-      cookie_bytes=NNN cookie_count=N oidc_session_bytes=NNN cookie_names=name1,name2
+    The APISix access log format appends cookie telemetry at the end of each
+    line. This pipeline extracts the three numeric fields:
+      cookie_bytes=NNN cookie_count=N oidc_session_bytes=NNN
 
     The stage.metrics blocks emit Prometheus histograms that Alloy exposes on
     its own metrics endpoint (:12345/metrics), from where they are scraped and
     forwarded to Grafana Cloud Prometheus.
 
-    Privacy: only byte counts and cookie name keys are captured; cookie values
-    are never logged or extracted.
+    Privacy: only numeric cookie metrics are extracted; cookie values are never
+    logged or extracted.
     """
     return r"""
 stage.match {
   selector = "{service=\"apisix\"} |= \"cookie_bytes=\""
   pipeline_name = "apisix_cookie_metrics"
 
-  // Extract host, status, and the four cookie fields appended at the end of
-  // each APISix access log line. host and status appear early in the line;
-  // the cookie fields are always at the tail after request="...".
+  // Extract host, status, and the three numeric cookie fields appended at the
+  // end of each APISix access log line. host and status appear early in the
+  // line; the cookie fields are always at the tail after request="...".
   stage.regex {
     expression = `.*\bhost=(?P<host>\S+).*\bstatus=(?P<status>\d+).*\bcookie_bytes=(?P<cookie_bytes>\d+)\s+cookie_count=(?P<cookie_count>\d+)\s+oidc_session_bytes=(?P<oidc_session_bytes>\d+)`
   }

--- a/src/ol_infrastructure/substructure/aws/eks/grafana.py
+++ b/src/ol_infrastructure/substructure/aws/eks/grafana.py
@@ -31,7 +31,7 @@ def _apisix_cookie_metrics_alloy_config() -> str:
     """
     return r"""
 stage.match {
-  selector = "{app_kubernetes_io_name=\"apisix\"} |= \"cookie_bytes=\""
+  selector = "{service=\"apisix\"} |= \"cookie_bytes=\""
   pipeline_name = "apisix_cookie_metrics"
 
   // Extract host, status, and the four cookie fields appended at the end of


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Instruments cookie header metrics flowing through the APISix gateway to help diagnose HTTP 431 "Request Header Fields Too Large" errors. Cookies set by unrelated MIT properties on `.mit.edu` accumulate in browsers and are sent to every `*.mit.edu` request; APISix also contributes ~4–8 KB of its own OIDC session cookie per authenticated request.

**Phase 1 — APISix Nginx (`apisix_official.py`)**

Adds four `set_by_lua_block` directives to `configurationSnippet.httpSrv` (server block context — required for `set_by_lua_block`):
- `$cookie_bytes` — total byte length of the incoming `Cookie` header
- `$cookie_count` — number of distinct `name=value` pairs
- `$oidc_session_bytes` — byte length of just the APISix OIDC session cookie (keyed off the existing `$session_name` variable)
- `$cookie_names` — comma-delimited list of cookie name keys only (values never logged)

Appends `cookie_bytes`, `cookie_count`, `oidc_session_bytes`, `cookie_names` to the Nginx `accessLogFormat` string.

**Phase 2 — Alloy metric extraction (`grafana.py`)**

Adds `_apisix_cookie_metrics_alloy_config()` returning Alloy River stage blocks, injected into the existing `loki.process "pod_logs"` pipeline via `podLogsViaLoki.extraLogProcessingStages` (the correct k8s-monitoring v4 extension point — not `alloy.extraConfig`):
- `stage.match` filters to APISix pod log lines containing `cookie_bytes=`
- `stage.regex` extracts `host`, `status`, and the three numeric cookie fields in the order they appear in the log line
- `stage.metrics` emits three Prometheus histograms exposed on Alloy's own metrics endpoint and scraped to Grafana Cloud:
  - `apisix_cookie_header_bytes` — total cookie header size distribution
  - `apisix_cookie_count` — number of cookies per request
  - `apisix_oidc_session_cookie_bytes` — our own OIDC session cookie size (baseline ~4–8 KB before Redis session migration; expected ~32 bytes after)

### How can this be tested?
After deploying to QA:

1. **Verify log enrichment:**
   ```bash
   kubectl logs -n operations -l app.kubernetes.io/name=apisix --tail=20 | grep cookie_bytes
   ```
   Each access log line should contain `cookie_bytes=NNN cookie_count=N oidc_session_bytes=NNN cookie_names=...`

2. **Verify Loki ingestion:**
   Run in Grafana Cloud Loki:
   ```logql
   {app_kubernetes_io_name="apisix"} | logfmt | cookie_bytes > 0
   ```

3. **Verify Prometheus metrics:**
   After a few minutes of traffic, query Grafana Cloud Prometheus:
   ```promql
   histogram_quantile(0.99, sum(rate(apisix_cookie_header_bytes_bucket[5m])) by (le))
   ```

4. **Privacy check:** Confirm `cookie_names` contains only key names (no `=value` portions) and that raw cookie values do not appear anywhere in the logs.

### Additional Context
- Cookie values are never logged — only byte counts and cookie name keys.
- The `$oidc_session_bytes` Lua block will undercount if the session library chunks large cookies across `${session_name}-0`, `${session_name}-1`, etc. suffixes. This is acceptable for the initial baseline measurement.
- Dashboard and alert rule creation (Phases 3–4 in the implementation plan) are out of scope for this PR and can be done via the Grafana Cloud UI once metrics are flowing.