### PR TITLE
Retry ad optimization pipeline a few times

### DIFF
--- a/src/ol_concourse/pipelines/applications/google_ads_optimization/ad_optimization_pipeline.py
+++ b/src/ol_concourse/pipelines/applications/google_ads_optimization/ad_optimization_pipeline.py
@@ -43,6 +43,7 @@ def ad_optimization_pipeline() -> Pipeline:
         plan=[
             GetStep(get=ad_optimization_schedule.name, trigger=True),
             TaskStep(
+                attempts=3,
                 task=Identifier("ad-optimization-pipeline"),
                 config=TaskConfig(
                     platform=Platform.linux,


### PR DESCRIPTION
### Description (What does it do?)
Just retries the ad optimization pipeline if it fails. This should improve situations where we hit network errors or other intermittent failures in concourse such as [the one we saw Sunday](https://mitodl.slack.com/archives/C0AG4SN9XRP/p1777898664224029)