### PR TITLE
chore: version matrix updates for verawood.

### DIFF
--- a/src/bridge/settings/openedx/types.py
+++ b/src/bridge/settings/openedx/types.py
@@ -108,6 +108,7 @@ class OpenEdxSupportedRelease(StrEnum):
 
     master = ("master", "master", "3.12", "24")
     ulmo = ("ulmo", "release/ulmo", "3.11", "24")
+    verawood = ("verawood", "release/verawood", "3.12", "24")
 
     def __str__(self):
         return self.value

--- a/src/bridge/settings/openedx/version_matrix.py
+++ b/src/bridge/settings/openedx/version_matrix.py
@@ -298,7 +298,6 @@ ReleaseMap: dict[
                 release="verawood",
                 branch_override="mitx/verawood",
                 origin_override="https://github.com/mitodl/edx-platform",
-                runtime_version_override="3.11",
             ),
             OpenEdxApplicationVersion(
                 application="edxapp_theme",

--- a/src/bridge/settings/openedx/version_matrix.py
+++ b/src/bridge/settings/openedx/version_matrix.py
@@ -16,7 +16,7 @@ class OpenLearningOpenEdxDeployment(Enum):
             # Residential environments want to track master in CI for testing new
             # features as they land. (TMM 2025-05-20)
             EnvRelease("CI", OpenEdxSupportedRelease["master"]),
-            EnvRelease("QA", OpenEdxSupportedRelease["ulmo"]),
+            EnvRelease("QA", OpenEdxSupportedRelease["verawood"]),
             EnvRelease("Production", OpenEdxSupportedRelease["ulmo"]),
         ],
     )
@@ -26,7 +26,7 @@ class OpenLearningOpenEdxDeployment(Enum):
             # Residential environments want to track master in CI for testing new
             # features as they land. (TMM 2025-05-20)
             EnvRelease("CI", OpenEdxSupportedRelease["master"]),
-            EnvRelease("QA", OpenEdxSupportedRelease["ulmo"]),
+            EnvRelease("QA", OpenEdxSupportedRelease["verawood"]),
             EnvRelease("Production", OpenEdxSupportedRelease["ulmo"]),
         ],
     )
@@ -41,7 +41,7 @@ class OpenLearningOpenEdxDeployment(Enum):
     xpro = DeploymentEnvRelease(
         deployment_name="xpro",
         env_release_map=[
-            EnvRelease("CI", OpenEdxSupportedRelease["ulmo"]),
+            EnvRelease("CI", OpenEdxSupportedRelease["verawood"]),
             EnvRelease("QA", OpenEdxSupportedRelease["ulmo"]),
             EnvRelease("Production", OpenEdxSupportedRelease["ulmo"]),
         ],
@@ -267,6 +267,210 @@ ReleaseMap: dict[
                 application="ora-grading",
                 application_type="MFE",
                 release="ulmo",
+            ),
+        ],
+    },
+    "verawood": {
+        "mitx": [
+            OpenEdxApplicationVersion(
+                application="codejail",
+                application_type="IDA",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="communications",
+                application_type="MFE",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="authoring",
+                application_type="MFE",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="discussions",
+                application_type="MFE",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="edx-platform",
+                application_type="IDA",
+                release="verawood",
+                branch_override="mitx/verawood",
+                origin_override="https://github.com/mitodl/edx-platform",
+                runtime_version_override="3.11",
+            ),
+            OpenEdxApplicationVersion(
+                application="edxapp_theme",
+                application_type="IDA",
+                release="verawood",
+                branch_override="verawood",
+                origin_override="https://github.com/mitodl/mitx-theme",
+            ),
+            OpenEdxApplicationVersion(
+                application="gradebook",
+                application_type="MFE",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="learner-dashboard",
+                application_type="MFE",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="learning",
+                application_type="MFE",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="notes-api",
+                application_type="IDA",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="ora-grading",
+                application_type="MFE",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="xqueue",
+                application_type="IDA",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="xqwatcher",
+                application_type="IDA",
+                branch_override="master",
+                origin_override="https://github.com/mitodl/xqueue-watcher",
+                release="verawood",
+            ),
+        ],
+        "mitx-staging": [
+            OpenEdxApplicationVersion(
+                application="codejail",
+                application_type="IDA",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="communications",
+                application_type="MFE",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="authoring",
+                application_type="MFE",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="discussions",
+                application_type="MFE",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="edx-platform",
+                application_type="IDA",
+                release="verawood",
+                branch_override="mitx/verawood",
+                origin_override="https://github.com/mitodl/edx-platform",
+                runtime_version_override="3.11",
+            ),
+            OpenEdxApplicationVersion(
+                application="edxapp_theme",
+                application_type="IDA",
+                release="verawood",
+                branch_override="verawood",
+                origin_override="https://github.com/mitodl/mitx-theme",
+            ),
+            OpenEdxApplicationVersion(
+                application="gradebook",
+                application_type="MFE",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="learning",
+                application_type="MFE",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="learner-dashboard",
+                application_type="MFE",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="notes-api",
+                application_type="IDA",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="ora-grading",
+                application_type="MFE",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="xqueue",
+                application_type="IDA",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="xqwatcher",
+                application_type="IDA",
+                branch_override="master",
+                origin_override="https://github.com/mitodl/xqueue-watcher",
+                release="verawood",
+            ),
+        ],
+        "xpro": [
+            OpenEdxApplicationVersion(
+                application="codejail",
+                application_type="IDA",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="authoring",
+                application_type="MFE",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="communications",
+                application_type="MFE",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="discussions",
+                application_type="MFE",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="edx-platform",
+                application_type="IDA",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="edxapp_theme",
+                application_type="IDA",
+                release="verawood",
+                branch_override="verawood",
+                origin_override="https://github.com/mitodl/mitxpro-theme",
+            ),
+            OpenEdxApplicationVersion(
+                application="gradebook",
+                application_type="MFE",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="learning",
+                application_type="MFE",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="notes-api",
+                application_type="IDA",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="ora-grading",
+                application_type="MFE",
+                release="verawood",
             ),
         ],
     },

--- a/src/bridge/settings/openedx/version_matrix.py
+++ b/src/bridge/settings/openedx/version_matrix.py
@@ -371,7 +371,7 @@ ReleaseMap: dict[
                 release="verawood",
                 branch_override="mitx/verawood",
                 origin_override="https://github.com/mitodl/edx-platform",
-                runtime_version_override="3.11",
+                runtime_version_override="3.12",
             ),
             OpenEdxApplicationVersion(
                 application="edxapp_theme",


### PR DESCRIPTION
### Description (What does it do?)
Completes the version matrix updates needed to do verawood updates of edxapp and other applications in the edx ecosystem. 

Outside of this PR, `verawood` branches were created for 

https://github.com/mitodl/mitxpro-theme
https://github.com/mitodl/mitx-theme

And `mitx/verawood` was created on https://github.com/mitodl/edx-platform with commit `b35beba8a4a` cherry-picked. 
