### PR TITLE
feat: add DBT_ARTIFACTS_S3_BUCKET env vars to lakehouse Dagster deployment

### DIFF
--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -1476,3 +1476,10 @@ export(
         "domain": dagster_config.require("domain"),
     },
 )
+export(
+    "dbt_artifacts",
+    {
+        "s3_bucket": dagster_bucket_name,
+        "s3_prefix": "openmetadata/dbt-artifacts",
+    },
+)

--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -1013,6 +1013,19 @@ for location in code_locations:
             "failureThreshold": 3,
             "initialDelaySeconds": 30,
         }
+        # dbt artifact upload for OpenMetadata ingestion
+        deployment["env"].extend(
+            [
+                {
+                    "name": "DBT_ARTIFACTS_S3_BUCKET",
+                    "value": dagster_bucket_name,
+                },
+                {
+                    "name": "DBT_ARTIFACTS_S3_PREFIX",
+                    "value": "openmetadata/dbt-artifacts",
+                },
+            ]
+        )
 
     # Increase RAM for legacy edX because of studentmodule loading to memory
     if name == "legacy_openedx":


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/ol-data-platform/issues/1355

Related: https://github.com/mitodl/ol-data-platform/pull/2203

### Description (What does it do?)
Sets `DBT_ARTIFACTS_S3_BUCKET` and `DBT_ARTIFACTS_S3_PREFIX` environment variables on the `lakehouse` Dagster code location deployment.

These variables enable the new `DbtS3ArtifactsResource` (added in ol-data-platform#2203) to upload dbt artifacts (`manifest.json`, `run_results.json`, `catalog.json`) to S3 after each dbt build run, so that OpenMetadata OMJobs can ingest dbt metadata.

The artifacts land in the existing Dagster runtime bucket (`dagster-data-{env}`) under the `openmetadata/dbt-artifacts/` prefix. The bucket already has `s3:PutObject` IAM permissions for all Dagster pods — no new IAM changes needed.

### How can this be tested?
After deploying ol-data-platform#2203, trigger a full lakehouse dbt run and verify that `manifest.json`, `run_results.json`, and `catalog.json` appear at `s3://dagster-data-{env}/openmetadata/dbt-artifacts/`.