### PR TITLE
fix: add new legacy_instructor_dashboard flag for all envs

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.CI.yaml
@@ -37,6 +37,7 @@ config:
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["legacy_studio.certificates", "--create", "--everyone"]
+  - ["instructor.legacy_instructor_dashboard", "--create", "--everyone"]
   edxapp:business_unit: residential-staging
   edxapp:canvas_base_url: https://mit.test.instructure.com
   edxapp:db_password:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.Production.yaml
@@ -38,6 +38,7 @@ config:
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["studio.library_authoring_mfe", "--deactivate"]
   - ["legacy_studio.certificates", "--create", "--everyone"]
+  - ["instructor.legacy_instructor_dashboard", "--create", "--everyone"]
   edxapp:business_unit: residential-staging
   edxapp:db_password:
     secure: v1:ZWtTTF60+1g61/XW:K9osJstG/oeHJvYXOUQS6KSIUuTcQFgR1cjECmosVk7BPLCJMPkzlLviW7swdiUhUIPErfyYNqs=

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.QA.yaml
@@ -38,6 +38,7 @@ config:
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["studio.library_authoring_mfe", "--deactivate"]
   - ["legacy_studio.certificates", "--create", "--everyone"]
+  - ["instructor.legacy_instructor_dashboard", "--create", "--everyone"]
   edxapp:business_unit: residential-staging
   edxapp:canvas_base_url: https://mit.test.instructure.com
   edxapp:db_password:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.CI.yaml
@@ -47,6 +47,7 @@ config:
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["studio.library_authoring_mfe", "--deactivate"]
   - ["legacy_studio.certificates", "--create", "--everyone"]
+  - ["instructor.legacy_instructor_dashboard", "--create", "--everyone"]
   edxapp:business_unit: residential
   edxapp:canvas_base_url: https://mit.test.instructure.com
   edxapp:db_password:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.Production.yaml
@@ -48,6 +48,7 @@ config:
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["studio.library_authoring_mfe", "--deactivate"]
   - ["legacy_studio.certificates", "--create", "--everyone"]
+  - ["instructor.legacy_instructor_dashboard", "--create", "--everyone"]
   edxapp:business_unit: residential
   edxapp:db_instance_size: "db.r7g.xlarge"
   edxapp:db_max_storage_gb: "1500"

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.QA.yaml
@@ -47,6 +47,7 @@ config:
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["studio.library_authoring_mfe", "--deactivate"]
   - ["legacy_studio.certificates", "--create", "--everyone"]
+  - ["instructor.legacy_instructor_dashboard", "--create", "--everyone"]
   edxapp:business_unit: residential
   edxapp:canvas_base_url: https://mit.test.instructure.com
   edxapp:db_password:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.CI.yaml
@@ -53,6 +53,7 @@ config:
     "--authenticated"]
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["teams.enable_teams_app", "--create", "--superusers", "--staff"]
+  - ["instructor.legacy_instructor_dashboard", "--create", "--everyone"]
   edxapp:business_unit: mitxonline
   edxapp:db_password:
     secure: v1:nTKkM6zA0wbJaq3T:LyxTy566zTW65zkQLLKsFGmCIPmPRB1rkXcsAg37hI+EUTX07XfX5TkpfdyBBRdntiLJ7odzNss=

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
@@ -51,6 +51,7 @@ config:
     "--authenticated"]
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["teams.enable_teams_app", "--create", "--superusers", "--staff"]
+  - ["instructor.legacy_instructor_dashboard", "--create", "--everyone"]
   edxapp:use_extracted_html_block: "false"
   edxapp:appzi_url: "https://w.appzi.io/w.js?token=Q2pSI"
   edxapp:business_unit: mitxonline

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.QA.yaml
@@ -53,6 +53,7 @@ config:
     "--authenticated"]
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["teams.enable_teams_app", "--create", "--superusers", "--staff"]
+  - ["instructor.legacy_instructor_dashboard", "--create", "--everyone"]
   edxapp:use_extracted_html_block: "false"
   edxapp:business_unit: mitxonline
   edxapp:db_password:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.xpro.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.xpro.CI.yaml
@@ -28,6 +28,7 @@ config:
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["studio.library_authoring_mfe", "--deactivate"]
   - ["legacy_studio.certificates", "--create", "--everyone"]
+  - ["instructor.legacy_instructor_dashboard", "--create", "--everyone"]
   edxapp:business_unit: mitxpro
   edxapp:db_password:
     secure: v1:gkXc0/WssuL5whQt:/28AEA/UN9lAkRHEl1B6D6OjWjysfgzUTG0KGFd6aYvrAU5bbBxUsZUe6RMI9wyKFA5f0l9z3hQ=

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.xpro.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.xpro.Production.yaml
@@ -29,6 +29,7 @@ config:
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["studio.library_authoring_mfe", "--deactivate"]
   - ["legacy_studio.certificates", "--create", "--everyone"]
+  - ["instructor.legacy_instructor_dashboard", "--create", "--everyone"]
   edxapp:business_unit: mitxpro
   edxapp:db_password:
     secure: v1:U83x0i6WAndxuOLK:XsAILALTGbtjCqGJllcqg3EaOM0FF/SNmuiMAK2r3E9X5joW26kjOQzYUcKr0slkHBv8RUEr3xA=

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.xpro.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.xpro.QA.yaml
@@ -29,6 +29,7 @@ config:
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["studio.library_authoring_mfe", "--deactivate"]
   - ["legacy_studio.certificates", "--create", "--everyone"]
+  - ["instructor.legacy_instructor_dashboard", "--create", "--everyone"]
   edxapp:business_unit: mitxpro
   edxapp:db_password:
     secure: v1:+Bcw4dSZUPqWY2cL:g/KKgzrmRlgx2SOuOOB4grCveVaNv5mZVuuFrpGgAGwKEussIqUWTBnFJknEdJ4Hjf5Jw/1W560=


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11068

### Description (What does it do?)
This pull request enables the legacy instructor dashboard feature for all users across all edX application environments (CI, QA, Production) and business units (mitx, mitx-staging, mitxonline, mitxpro). The change ensures that the `instructor.legacy_instructor_dashboard` feature flag is created and available to everyone in each deployment configuration.

**Feature flag enablement:**

* Added `["instructor.legacy_instructor_dashboard", "--create", "--everyone"]` to the feature flag configuration in all environment YAML files for the following business units:
  - mitx (CI, QA, Production) [[1]](diffhunk://#diff-e27428fe87dfbfd997233a8a134a1d8b2bb57ce94a011ecfa0702e946cff5717R50) [[2]](diffhunk://#diff-9231ccbdd7aa7a141a281eeec3a70aa664fff48baf8edcb0d4702d0a11384225R50) [[3]](diffhunk://#diff-348ef42524626cf542dbd5440be35c0b59ab18a6e03dc2112e2e56dd5b5c5d7cR51)
  - mitx-staging (CI, QA, Production) [[1]](diffhunk://#diff-b26850c89dfe4d58aa3648fa5c5bc1352ae549501789fcb610f78082b20241b4R40) [[2]](diffhunk://#diff-e0ff994140ce36813477b35e05f92d673a55bc2b6aa4b623e56996ff48af4eccR41) [[3]](diffhunk://#diff-40e723e0b8aa7878d829addf0973ec94763d13011912a43513d607d40acdf7bbR41)
  - mitxonline (CI, QA, Production) [[1]](diffhunk://#diff-d2a9ae6ec633db97e70008ad52ae1eb94c4ea724487bb526016e5fbb7c137b28R56) [[2]](diffhunk://#diff-8a75509e0413571a7cf84c7709f1cb32489573bcb01defbd33ecdbea4363ca4dR56) [[3]](diffhunk://#diff-4a6cca9da58e41b799bfd9f640861f6496bc2e511fd86f2991a39da797195cffR54)
  - mitxpro (CI, QA, Production) [[1]](diffhunk://#diff-d4ca488f2fe9caf4b683b39a9df04f142e444e7262604c02b6347535960f2dfeR31) [[2]](diffhunk://#diff-19124f7f71f13e06465623767cc951a8b2d133c3df16f6dee93e8bdccd73c49fR32) [[3]](diffhunk://#diff-48cd902c49db9b3b5266eccf6629c45bcc24fa162ff3baef3ae9df2d82c11f21R32)