### PR TITLE
fix: add B2C UAI courses as UAI courses

### DIFF
--- a/src/bridge/secrets/mitxonline/secrets.qa.yaml
+++ b/src/bridge/secrets/mitxonline/secrets.qa.yaml
@@ -1,3 +1,4 @@
+---
 cybersource:
   access-key: ENC[AES256_GCM,data:oHnVyPifwwkyLlpORmB7d3hjutzuDPKuRzdI3so1ss8=,iv:nUCMerZbzmjj57AcjOuMz6O0BjGr7LBS3vFwm4VgCL4=,tag:6Lup5iWmdzPAE96KTBhfqA==,type:str]
   merchant-id: ENC[AES256_GCM,data:YBb4OZGTx4qYvqM=,iv:mk+HBkTrAAK/XST4A3iwZ71rujmVJfIH1mepRFUcGBs=,tag:yc/sT41oBTSW68G6ee+PcA==,type:str]
@@ -51,16 +52,16 @@ webhook_access_token:
   access_token: ENC[AES256_GCM,data:vzbP0WGq/deESI9jvM0/uO2g2Efhtky0S69pC3Ut,iv:k3hOCXpnZdVDJWPNDy3OcrWY9DtXST08ZmBWuUdyFOg=,tag:06lAb6StGdGBKIafvag/mQ==,type:str]
 sops:
   hc_vault:
-    - created_at: "2026-02-02T17:11:45Z"
-      enc: vault:v1:0y+YFRqZIXMxr0jX7vzFtCRy4cCDz261a3BOcLKq7gtYmbUJNdJV7PHabO7/1tJMhEYshQpIxGXEqiNh
-      engine_path: infrastructure
-      key_name: sops
-      vault_address: https://vault-qa.odl.mit.edu
+  - created_at: "2026-02-02T17:11:45Z"
+    enc: vault:v1:0y+YFRqZIXMxr0jX7vzFtCRy4cCDz261a3BOcLKq7gtYmbUJNdJV7PHabO7/1tJMhEYshQpIxGXEqiNh
+    engine_path: infrastructure
+    key_name: sops
+    vault_address: https://vault-qa.odl.mit.edu
   kms:
-    - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-qa
-      aws_profile: ""
-      created_at: "2026-02-02T17:11:45Z"
-      enc: AQICAHjZAY5LtmRWGljev0oiDGn0jR5cRwD4IVXCn50TW5i0qQHqmN8pFGX+2qcY5XXiY0kRAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMyhTtxzfD/gU5HUZNAgEQgDtvzRLa7AL13nl12d+v8Oc1Oenj4qF25AbX3SwGtVWH4LA75IUBGVA4H0DqqU4KBFFLe33xO7EIKLhOJQ==
+  - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-qa
+    aws_profile: ""
+    created_at: "2026-02-02T17:11:45Z"
+    enc: AQICAHjZAY5LtmRWGljev0oiDGn0jR5cRwD4IVXCn50TW5i0qQHqmN8pFGX+2qcY5XXiY0kRAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMyhTtxzfD/gU5HUZNAgEQgDtvzRLa7AL13nl12d+v8Oc1Oenj4qF25AbX3SwGtVWH4LA75IUBGVA4H0DqqU4KBFFLe33xO7EIKLhOJQ==
   lastmodified: "2026-05-12T19:23:33Z"
   mac: ENC[AES256_GCM,data:s1JRPRVBVif/jipCdLqSUC7KcTmeO6tGxnGUK0VIFoK3mfOfyaJI9olF/OdbhgfeazlmzNWIajY9czoL4IMq0mPaaX/V0C2vYL9wrLBAyDsm/Y96kMz+AWrVOKaY8ell9X8E8vDRIB8mca0svYDTOlAXkp0t8SskvVY6HsInkEc=,iv:fXLhm5ZPqbHw7ha6vfVKJZrCfhUdKbovtBpXAiSUNIw=,tag:VGrLpn1w/NlGo58p+c2QxQ==,type:str]
   unencrypted_suffix: _unencrypted

--- a/src/bridge/settings/openedx/mfe/slot_config/mitxonline/common-mfe-config.env.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/mitxonline/common-mfe-config.env.jsx
@@ -8,7 +8,7 @@ import Footer, { Logo, MenuLinks, CopyrightNotice } from './Footer.jsx';
 import './mitxonline-styles.scss';
 
 const configData = getConfig();
-const UAI_COURSE_KEYS = ['course-v1:uai_', 'course-v1:mitxt+ctl.scx_wm+1t2026'];
+const UAI_COURSE_KEYS = ['course-v1:uai_', 'course-v1:b2c+uai.', 'course-v1:mitxt+ctl.scx_wm+1t2026'];
 const COURSE_KEY_REGEX = '(?:course-v1:[^/+]+(/|\\+)[^/+]+(/|\\+)[^/?]+)';
 const MOBILE_BREAKPOINT = 991; // px
 const AUTHORING_APP_ID = 'authoring';


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11099

### Description (What does it do?)
This pull request makes a small update to the `UAI_COURSE_KEYS` array in the `common-mfe-config.env.jsx` file to include an additional course key prefix for better course identification.

* Added `'course-v1:b2c+uai.'` to the `UAI_COURSE_KEYS` array in `common-mfe-config.env.jsx` to support more course key formats.
