### PR TITLE
Reduce trace sampling rate to 25%

### DIFF
--- a/src/ol_infrastructure/applications/keycloak/__main__.py
+++ b/src/ol_infrastructure/applications/keycloak/__main__.py
@@ -399,7 +399,7 @@ if stack_info.name != "CI":
     tracing_config = {
         "enabled": True,
         "endpoint": "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4317",
-        "samplerRatio": 1.0,
+        "samplerRatio": 0.25,
     }
 else:
     tracing_config = {"enabled": False}

--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.Production.yaml
@@ -42,7 +42,7 @@ config:
     OPENTELEMETRY_SERVICE_NAME: "learn-ai-webapp"
     OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=production,service.namespace=learn-ai,service.version=${GIT_SHA:-unknown},service.instance.id=${HOSTNAME}"
     OTEL_TRACES_SAMPLER: "parentbased_traceidratio"
-    OTEL_TRACES_SAMPLER_ARG: "1.0"
+    OTEL_TRACES_SAMPLER_ARG: "0.25"
     OTEL_PROPAGATORS: "tracecontext,baggage"
     OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
     OTEL_LOGS_EXPORTER: "otlp"

--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.QA.yaml
@@ -45,7 +45,7 @@ config:
     OPENTELEMETRY_SERVICE_NAME: "learn-ai-webapp"
     OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=qa,service.namespace=learn-ai,service.version=${GIT_SHA:-unknown},service.instance.id=${HOSTNAME}"
     OTEL_TRACES_SAMPLER: "parentbased_traceidratio"
-    OTEL_TRACES_SAMPLER_ARG: "1.0"
+    OTEL_TRACES_SAMPLER_ARG: "0.25"
     OTEL_PROPAGATORS: "tracecontext,baggage"
     OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
     OTEL_LOGS_EXPORTER: "otlp"

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
@@ -86,7 +86,7 @@ config:
     OPENTELEMETRY_SERVICE_NAME: "learn-webapp"
     OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=production,service.namespace=learn,service.version=${GIT_SHA:-unknown},service.instance.id=${HOSTNAME}"
     OTEL_TRACES_SAMPLER: "parentbased_traceidratio"
-    OTEL_TRACES_SAMPLER_ARG: "1.0"
+    OTEL_TRACES_SAMPLER_ARG: "0.25"
     OTEL_PROPAGATORS: "tracecontext,baggage"
     OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
     OTEL_LOGS_EXPORTER: "otlp"

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.QA.yaml
@@ -87,7 +87,7 @@ config:
     OPENTELEMETRY_SERVICE_NAME: "learn-webapp"
     OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=qa,service.namespace=learn,service.version=${GIT_SHA:-unknown},service.instance.id=${HOSTNAME}"
     OTEL_TRACES_SAMPLER: "parentbased_traceidratio"
-    OTEL_TRACES_SAMPLER_ARG: "1.0"
+    OTEL_TRACES_SAMPLER_ARG: "0.25"
     OTEL_PROPAGATORS: "tracecontext,baggage"
     OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
     OTEL_LOGS_EXPORTER: "otlp"

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
@@ -209,7 +209,7 @@ raw_env_vars = {
     "OTEL_SERVICE_NAME": "learn-nextjs",
     "OTEL_EXPORTER_OTLP_ENDPOINT": "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318",
     "OTEL_TRACES_SAMPLER": "parentbased_traceidratio",
-    "OTEL_TRACES_SAMPLER_ARG": "1.0",
+    "OTEL_TRACES_SAMPLER_ARG": "0.25",
     "OTEL_PROPAGATORS": "tracecontext,baggage",
     "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
     "OTEL_RESOURCE_ATTRIBUTES": (

--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.Production.yaml
@@ -60,7 +60,7 @@ config:
     OPENTELEMETRY_SERVICE_NAME: "mitxonline-webapp"
     OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=production,service.namespace=mitxonline,service.version=${GIT_SHA:-unknown},service.instance.id=${HOSTNAME}"
     OTEL_TRACES_SAMPLER: "parentbased_traceidratio"
-    OTEL_TRACES_SAMPLER_ARG: "1.0"
+    OTEL_TRACES_SAMPLER_ARG: "0.25"
     OTEL_PROPAGATORS: "tracecontext,baggage"
     OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
     OTEL_LOGS_EXPORTER: "otlp"

--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.QA.yaml
@@ -54,7 +54,7 @@ config:
     OPENTELEMETRY_SERVICE_NAME: "mitxonline-webapp"
     OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=qa,service.namespace=mitxonline,service.version=${GIT_SHA:-unknown},service.instance.id=${HOSTNAME}"
     OTEL_TRACES_SAMPLER: "parentbased_traceidratio"
-    OTEL_TRACES_SAMPLER_ARG: "1.0"
+    OTEL_TRACES_SAMPLER_ARG: "0.25"
     OTEL_PROPAGATORS: "tracecontext,baggage"
     OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
     OTEL_LOGS_EXPORTER: "otlp"


### PR DESCRIPTION
## Summary
- Reduce OTEL trace sampler args from 1.0 to 0.25 for MIT Learn, MITx Online, Learn AI, and MIT Learn Next.js
- Reduce Keycloak tracing samplerRatio from 1.0 to 0.25

## Validation
- pre-commit hooks ran during commit and passed