### PR TITLE
fix: remove aria-live="polite" from ai-drawer-manager-sidebar-wrapper

### DIFF
--- a/src/bridge/settings/openedx/mfe/slot_config/AIDrawerManagerSidebar.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/AIDrawerManagerSidebar.jsx
@@ -307,7 +307,6 @@ const AIDrawerManagerSidebar = () => {
             className="ai-drawer-manager-sidebar-wrapper"
             role="region"
             aria-label={intl.formatMessage(wrapperMessages.sidebarAriaLabel)}
-            aria-live="polite"
             aria-busy={isLoading}
         >
             {isLoading && (


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
Fixes https://github.com/mitodl/hq/issues/11223 
<!--- N/A --->

### Description (What does it do?)
<!--- Describe your changes in detail -->

Removes aria-live="polite" from the ai-drawer-manager-sidebar-wrapper element in the AI Drawer Manager sidebar.

The aria-live attribute was causing screen readers (specifically NVDA) to read the entire contents of the AI drawer aloud every time it was opened or its content changed. This created a disruptive and verbose experience for screen reader users — the full drawer content would be announced rather than just the relevant change.

The wrapper already uses role="region" with an aria-label, which provides appropriate landmark navigation for screen reader users without the unintended side effect of announcing all content changes.

### Screen Recording (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

https://github.com/user-attachments/assets/6ae58fc3-2fad-418e-b949-2874adb2f39e

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

Tested manually using NVDA on a course page in RC. Open browser DevTools and remove the aria-live="polite" attribute from the ai-drawer-manager-sidebar-wrapper element, then verify:

Opening the AI drawer no longer causes NVDA to read out the entire drawer contents.
When navigating between cards inside the drawer using arrow keys or the next/previous buttons, the card contents are announced only once (not twice).

RC test URL: https://courses.rc.learn.mit.edu/learn/course/course-v1:UAI_SOURCE+UAI.2+2T2025/block-v1:[…]025+type@vertical+block@f9624d0d20124dfa88d092bc0d9e19ec


### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
