### PR TITLE
fix: add absolute url for COURSE_AUTHORING_MICROFRONTEND_URL

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/config_builder.py
+++ b/src/ol_infrastructure/applications/edxapp/config_builder.py
@@ -134,7 +134,6 @@ def build_base_general_config() -> ConfigDict:
         "COURSES_WITH_UNSAFE_CODE": [],
         "COURSES_INVITE_ONLY": True,
         "COURSE_ABOUT_VISIBILITY_PERMISSION": "see_exists",
-        "COURSE_AUTHORING_MICROFRONTEND_URL": "/authoring",
         "COURSE_CATALOG_API_URL": "http://localhost:8008/api/v1",
         "COURSE_CATALOG_URL_ROOT": "http://localhost:8008",
         "COURSE_CATALOG_VISIBILITY_PERMISSION": "staff",

--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -161,6 +161,7 @@ def _build_interpolated_config_dict(
         "MIT_LEARN_AI_XBLOCK_PROBLEM_SET_LIST_URL": f"https://{edxapp_config.require('mit_learn_api_domain')}/ai/api/v0/problem_set_list",
         "MIT_LEARN_AI_XBLOCK_CHAT_RATING_URL": f"https://{edxapp_config.require('mit_learn_api_domain')}/ai/api/v0/chat_sessions/",
         "MIT_LEARN_LOGO": f"https://{domains['lms']}/static/mitxonline/images/mit-learn-logo.svg",
+        "COURSE_AUTHORING_MICROFRONTEND_URL": f"https://{domains['studio']}/authoring",
         "LEARNING_MICROFRONTEND_URL": f"https://{domains['lms']}/learn",
         "LMS_BASE": domains["lms"],
         "LMS_INTERNAL_ROOT_URL": f"https://{domains['lms']}",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11294

### Description (What does it do?)
This PR updates `COURSE_AUTHORING_MICROFRONTEND_URL` to use an absolute URL in order to fix https://github.com/mitodl/hq/issues/11294.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
