### PR TITLE
feat: hq-10825 enable residential features on mitxonline.

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.CI.yaml
@@ -62,7 +62,7 @@ config:
   - ["new_studio_mfe.use_new_home_page", "--create", "--superusers", "--everyone"]
   - ["new_studio_mfe.use_tagging_taxonomy_list_page", "--create", "--superusers",
     "--everyone"]
-  edxapp:canvas_base_url: https://canvas.mit.edu
+  edxapp:canvas_base_url: https://mit.test.instructure.com
   edxapp:business_unit: mitxonline
   edxapp:db_password:
     secure: v1:nTKkM6zA0wbJaq3T:LyxTy566zTW65zkQLLKsFGmCIPmPRB1rkXcsAg37hI+EUTX07XfX5TkpfdyBBRdntiLJ7odzNss=

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.CI.yaml
@@ -54,6 +54,15 @@ config:
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["teams.enable_teams_app", "--create", "--superusers", "--staff"]
   - ["instructor.legacy_instructor_dashboard", "--create", "--everyone"]
+  - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
+    "--everyone"]
+  - ["new_core_editors.use_new_problem_editor", "--create", "--everyone"]
+  - ["new_core_editors.use_new_text_editor", "--create", "--superusers", "--everyone"]
+  - ["new_core_editors.use_new_video_editor", "--create", "--superusers", "--everyone"]
+  - ["new_studio_mfe.use_new_home_page", "--create", "--superusers", "--everyone"]
+  - ["new_studio_mfe.use_tagging_taxonomy_list_page", "--create", "--superusers",
+    "--everyone"]
+  edxapp:canvas_base_url: https://canvas.mit.edu
   edxapp:business_unit: mitxonline
   edxapp:db_password:
     secure: v1:nTKkM6zA0wbJaq3T:LyxTy566zTW65zkQLLKsFGmCIPmPRB1rkXcsAg37hI+EUTX07XfX5TkpfdyBBRdntiLJ7odzNss=

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
@@ -52,6 +52,15 @@ config:
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["teams.enable_teams_app", "--create", "--superusers", "--staff"]
   - ["instructor.legacy_instructor_dashboard", "--create", "--everyone"]
+  - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
+    "--everyone"]
+  - ["new_core_editors.use_new_problem_editor", "--create", "--everyone"]
+  - ["new_core_editors.use_new_text_editor", "--create", "--superusers", "--everyone"]
+  - ["new_core_editors.use_new_video_editor", "--create", "--superusers", "--everyone"]
+  - ["new_studio_mfe.use_new_home_page", "--create", "--superusers", "--everyone"]
+  - ["new_studio_mfe.use_tagging_taxonomy_list_page", "--create", "--superusers",
+    "--everyone"]
+  edxapp:canvas_base_url: https://canvas.mit.edu
   edxapp:use_extracted_html_block: "false"
   edxapp:appzi_url: "https://w.appzi.io/w.js?token=Q2pSI"
   edxapp:business_unit: mitxonline

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.QA.yaml
@@ -62,7 +62,7 @@ config:
   - ["new_studio_mfe.use_new_home_page", "--create", "--superusers", "--everyone"]
   - ["new_studio_mfe.use_tagging_taxonomy_list_page", "--create", "--superusers",
     "--everyone"]
-  edxapp:canvas_base_url: https://canvas.mit.edu
+  edxapp:canvas_base_url: https://mit.test.instructure.com
   edxapp:use_extracted_html_block: "false"
   edxapp:business_unit: mitxonline
   edxapp:db_password:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.QA.yaml
@@ -54,6 +54,15 @@ config:
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["teams.enable_teams_app", "--create", "--superusers", "--staff"]
   - ["instructor.legacy_instructor_dashboard", "--create", "--everyone"]
+  - ["learner_recommendations.enable_dashboard_recommendations", "--create", "--superusers",
+    "--everyone"]
+  - ["new_core_editors.use_new_problem_editor", "--create", "--everyone"]
+  - ["new_core_editors.use_new_text_editor", "--create", "--superusers", "--everyone"]
+  - ["new_core_editors.use_new_video_editor", "--create", "--superusers", "--everyone"]
+  - ["new_studio_mfe.use_new_home_page", "--create", "--superusers", "--everyone"]
+  - ["new_studio_mfe.use_tagging_taxonomy_list_page", "--create", "--superusers",
+    "--everyone"]
+  edxapp:canvas_base_url: https://canvas.mit.edu
   edxapp:use_extracted_html_block: "false"
   edxapp:business_unit: mitxonline
   edxapp:db_password:

--- a/src/ol_infrastructure/applications/edxapp/config_builder.py
+++ b/src/ol_infrastructure/applications/edxapp/config_builder.py
@@ -605,6 +605,10 @@ def get_deployment_overrides(env_prefix: str) -> ConfigDict:
                 "ENABLE_V2_CERT_DISPLAY_SETTINGS": True,
                 "ENABLE_BULK_USER_RETIREMENT": True,
                 "ENABLE_PROCTORED_EXAMS": True,
+                "ENABLE_CANVAS_INTEGRATION": True,
+                "ENABLE_RAPID_RESPONSE_AUTHOR_VIEW": True,
+                "MAX_PROBLEM_RESPONSES_COUNT": 10000,
+                "ENABLE_INSTRUCTOR_BACKGROUND_TASKS": True,
             },
             "OAUTH2_PROVIDER": {
                 "ALLOWED_REDIRECT_URI_SCHEMES": [

--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -276,12 +276,15 @@ def _build_interpolated_config_dict(
 
     # MITx Online-specific configuration
     elif stack_info.env_prefix == "mitxonline":
+        config["CORS_ORIGIN_WHITELIST"].append("https://idp.mit.edu")
         config["CSRF_TRUSTED_ORIGINS"] = [
+            "https://canvas.mit.edu",
             f"https://{domains['lms']}",
             f"https://{domains['studio']}",
         ]
         config.update(
             {
+                "CANVAS_BASE_URL": edxapp_config.require("canvas_base_url"),
                 "COURSE_ABOUT_VISIBILITY_PERMISSION": "see_about_page",
                 "MITXONLINE_BASE_URL": f"https://{marketing_domain}/",
                 "ENROLLMENT_WEBHOOK_URL": f"https://{marketing_domain}/api/openedx_webhook/enrollment/",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10825

### Description (What does it do?)
As part of consolidating MITx Residential courses into the mitxonline deployment, several application-level configuration changes are needed in ol-infrastructure. These enable Canvas integration and other residential features, and reconcile conflicting settings between the two deployments.
