### PR TITLE
feat: hq-10826 sync secrets for residential to mitxonline.

### DIFF
--- a/src/bridge/secrets/edxapp/mitxonline.ci.yaml
+++ b/src/bridge/secrets/edxapp/mitxonline.ci.yaml
@@ -1,5 +1,6 @@
 ---
 canvas_access_token: ENC[AES256_GCM,data:Nmyf9HsWKLDMwoRYdEqWp+Dw1CHXdjT1roa1kTjTogvPlm2Ll3p+PIb0gxQKjHslm80DI4RyZZuDOxxWKKzxj37ZbB7e,iv:RruRtTuMhaSJ0fYkSMYP+FwWK9p1THqBrNUI2Bk2olA=,tag:SF8ws12Q6DpVdU8sjxJf9g==,type:str]
+youtube_api_key: ENC[AES256_GCM,data:VFbMOf9yMVZ7eVT3jS8/8qtf9RLuKXscLjq9mBjLW4HkO9RZUr8R,iv:VWB+OIwXO1KB7c90sZjU4oMpc0gLdgoRqCAgY/QhoAw=,tag:pRSLi+R0hQsqHsS4N+Ziaw==,type:str]
 deepl_api_key: ENC[AES256_GCM,data:fshHVZPy5l2/mykppFO2+XK2RnxWZccbDcbBC3V7KwnUiTY5,iv:RtBrC56ci5OvPaUFx+TiF3jnXXFwYqsGxGtuTDkwjfc=,tag:bxLIfrQkz9mHzm0h4foOiQ==,type:str]
 gemini_api_key: ENC[AES256_GCM,data:0yVw439DxS96wsWiLcoBdBRACkDg6YHpWUlBDPR7oyuw7+OVNvZV,iv:QU4BP0xPSuiP4kZk9x6Z0puybjuOR85SeKGblAj3yIM=,tag:HEb8a2TvAgHCclCjRVFlkg==,type:str]
 mistral_api_key: ENC[AES256_GCM,data:Sqsh46HTmBXRcsOS0ksiDxWdZyRsTJnJJAUwZe4dhhw=,iv:RJ/yJJWldCFFOOVar8OJL6ALhcNgNHjUE+aIuu5CgdE=,tag:L3DzSkovmIDPRUuYoYC5cw==,type:str]
@@ -41,8 +42,8 @@ sops:
     created_at: "2025-08-28T20:35:02Z"
     enc: vault:v1:hLtAum4sTZQgTXdhB78kGsXPj2m02TYFy2pu8dVo/akd0tPpmEzN8/ax0iypvf7anxbrMTCXAMNEm2Uv
   age: []
-  lastmodified: "2026-04-08T17:46:28Z"
-  mac: ENC[AES256_GCM,data:7fBi1ohrI2Ldqjwax19jWUa9Xef49LdJbjoUoR39pMih8ruwa7hb5Lo+WezEhWpuwoVAOHha2vDy66bcNg67JspBA8c/KRrWAzP57lESUdmIgg/FX9TBbYwIP3xqeewzZOQCL61pBXX9vuE8iTOtcfQh6xEMg8HOsGJZrF2SqZU=,iv:yvocTVujlD94Ywf/L5iDWmzLy7xch7XaSxdhbbB6vkE=,tag:XauJBFeKbQmewsJE1iCDLA==,type:str]
+  lastmodified: "2026-05-15T14:14:18Z"
+  mac: ENC[AES256_GCM,data:jV/boBZB06JoRcsr44PlHaQRT64ZEZ07wtbjtdAAMcQsSravJ8mdF329lCc940azZ9Y1/XKJkwbT9a3Bw+NEB03j2WJaF9trVZSifowa2Y/E54lRvHXAH7fWiS6o+ZaUcKYmCDXg31EygG/4Iod8hIHRCNbun3zJ5DL27Aak3No=,iv:yeAajqh/9cxjTnavC9WBOFXUmhNmUCVWi1EtAAQhmHw=,tag:8CaXzYc6FtCOcL/agfmVlA==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.10.2

--- a/src/bridge/secrets/edxapp/mitxonline.production.yaml
+++ b/src/bridge/secrets/edxapp/mitxonline.production.yaml
@@ -1,5 +1,6 @@
 ---
 canvas_access_token: ENC[AES256_GCM,data:1Y1grH9G8pZwkTg0eHNxAME+34RihdXdmenjxptLoS9RViVToUcu1/BBdhxFkvWgFLFS3gvd6n6+6ccpp1d0Nry5AL1Y,iv:Z2JiRscWD1Iav7d/OLwuG6bLUpG35S0K4qwPg1HNUN4=,tag:nbvWj6cA18FLRnghG5lVcg==,type:str]
+youtube_api_key: ENC[AES256_GCM,data:LJPM9X0N13PefRaJsW4DeEX9mAEMIr+l6n/u9Zey1NPdGXxBbq41,iv:AanYY5l5uzz4ED5y77hbHFvFwx+dqpyTtxHyFQ/EFlw=,tag:P1bZk5QsjxIiml6wtPYpwA==,type:str]
 deepl_api_key: ENC[AES256_GCM,data:+MmRaQclphfbqx5P4MBf5vw4L7WXFYDRVym8OphMSEhpDTqh,iv:gcIzniXkmQxOPktV47+4Pny0e1G1DghkX22HOQXirBA=,tag:qo+pZh04ps2HXttGElJN6Q==,type:str]
 gemini_api_key: ENC[AES256_GCM,data:mCF5gO99q86qOiST3tZ/+uZbNRy1FiTu5usgWUpKK705nQziT4Z8,iv:WxKhcma/rXFWgWziLTeVty3K1LgV+cesxPtiUgx63o4=,tag:kC5N3sZnvQj6GnAAndN6Kw==,type:str]
 mistral_api_key: ENC[AES256_GCM,data:R9XIXNWQfsMeHSplBWO3FV7d2W+DD0hc8u+PVd0FJpI=,iv:sR0EdX13ZeVY23Lirc3XGYVOPVengWS/J1l56NqNrpk=,tag:9a45B2kb4x/oMAnf2RAqbQ==,type:str]
@@ -42,8 +43,8 @@ sops:
     created_at: "2026-02-23T16:23:32Z"
     enc: vault:v1:dENz887tU/JbibzTNM6uvzdGc/61Q6p+5uMZkgLO9Ql5Myx5ka2T9JnDxH5xQdblVrH7bZ0hf8WO0TDx
   age: []
-  lastmodified: "2026-04-08T17:47:26Z"
-  mac: ENC[AES256_GCM,data:XVHqjKAD4gWJXQMyrD77vdtpsZAnvQWmcaH4sid+P5M1UdIhFjNvVaFP7wGb1Ve9r6moxaE1rsQ/lX2iYabTEu690y0fnU75ZCZ+wO6WqvBCAakpyHdc15JGa4y0NvNeM6Cint9f250iUnFcVprtmJ7X6yYj61/cae0eGF8/st4=,iv:6IIwZ5rdbIQHjqraYEgPsuwsYF06zif7KGZxQoM36fg=,tag:Ws5SOvxvLdVNF3NpvJ2Lfg==,type:str]
+  lastmodified: "2026-05-15T14:15:34Z"
+  mac: ENC[AES256_GCM,data:02KhurkPNRieOQ8KkYEOqxDGEr1aN0TzeuxcA7+P/Puwr39wB4cXlC4cxESdqNbwB5lBBASIKTT/yTQ1k9dYY0WoeX1p/RmtsQpplv7KVzcpapn2fpF6ZN6jT4bWOgBwDIftSZdprLI+Ecz5hqNZ8aOgfrxKd3d872zowTesm5o=,iv:R/xe1TVd9ZSNwN0pKgZu0j3QKNlksHkNRgcnk5F3Ccs=,tag:xeRqCbQ2YR8mFDX+ROQvvw==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/src/bridge/secrets/edxapp/mitxonline.qa.yaml
+++ b/src/bridge/secrets/edxapp/mitxonline.qa.yaml
@@ -1,5 +1,6 @@
 ---
 canvas_access_token: ENC[AES256_GCM,data:52ZXNyuHOlyvNco/k1BGqp/zOQDbHUtGziqvV67TlRWhlSrX6o16X9fmzdD15pjeP2t9yUWRzlRvrwx5F5SrIOadKm+d,iv:qF2iINaS0tinDONzJ8Ggpui4QD2JUbxoevCsLUOftao=,tag:2lkeeCQrbfOLOUeNc9p7xg==,type:str]
+youtube_api_key: ENC[AES256_GCM,data:Zx7nUR6aDA8zRaQovU/V6sne2EBNqbiU8uu+Q71lO4f0ccV7jI8c,iv:6XXaEVHepvDehvW5rbY7jp8URGvse5nfqtcilskHt6o=,tag:Tr0tVph4CUZLeh9cVpePiA==,type:str]
 deepl_api_key: ENC[AES256_GCM,data:+wH1r03q67GDIl+SN8L/nO23EJMIPfp9os2xfFOknHy0OAvW,iv:DwB82uX6bVC4zXmwzeW069B5ADYAH0vbKKcbShobCdw=,tag:9TmmYzIASp4c8k0BdA35cA==,type:str]
 gemini_api_key: ENC[AES256_GCM,data:4KwyXbEbjVROdBt8XSElJ/l4h3qicd+MNeSrj++HpBj2/U7cPlzC,iv:ry5raVtZh/1xZuzbMmha5Qsf7WnVbM2A72WZE2q1WjA=,tag:m2Ld8VixZdB/iRFmA3xjqg==,type:str]
 mistral_api_key: ENC[AES256_GCM,data:K+c5vDVLo4QBjlIPw7cHmx8vx+XpnsAFHn/7sfzp9R0=,iv:KbWI6EFQb+MiurcBr05E6eDxJh9lvJSul+m88WjP+Zw=,tag:5HNw5+RlVJt39wa+Jg2TXQ==,type:str]
@@ -41,8 +42,8 @@ sops:
     created_at: "2025-08-28T20:37:22Z"
     enc: vault:v1:myA322x4V71XWIYseRNjdHuJMe9sPAKQ3rQrPF95bzQ34WselInLQ4nVNGeBy7HY+4wVTg2vUBnAce4Z
   age: []
-  lastmodified: "2026-04-08T17:47:02Z"
-  mac: ENC[AES256_GCM,data:6Bxx35H8KyZNqGeSFWDOI3ocQ+otS7nDybcOy6d38qCcsIs/ShijkPksTwP3X/2JCD8jLdjZz+nwCrQLAfsTQskCAMtxutAIpL4EmG1C/u6A33VTuFlwVYEMG5a4bUU9x3tXahDJmJTuae70UKI6ji+eX/akGVmqNR65doZ6bHE=,iv:Z+MOkZoXL70+bHJeTpvZzjZd9fEU2EJRTs+Fn//co8s=,tag:9ec/h3Qc0iom5kDAEkxCaA==,type:str]
+  lastmodified: "2026-05-15T14:15:04Z"
+  mac: ENC[AES256_GCM,data:+mTkZeKPExcAhnQAV7ZhpysdYWOy2FOmjKsqCQlgabfavfoYjBHysaqEzuaI8U/PewqWtJiJJ5RoffRAYjE13EkAEOeT3/XFqMrvY4qKDIkc3qr/WUaaUq3+WIxeEhQ2hn4oIOHHxuw5ig6JpNtsgF+v0wGrl11SfLaYIO8QeJs=,iv:CCucMTVyc39gMdRVY3q4ifqIRfC2oB01fX0XGLjtGXY=,tag:JlWDFrk0Myf+fFNB5nMqjg==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.10.2

--- a/src/ol_infrastructure/applications/edxapp/secrets_builder.py
+++ b/src/ol_infrastructure/applications/edxapp/secrets_builder.py
@@ -108,6 +108,8 @@ def _apply_deployment_secret_overrides(
     # mitxonline-specific configuration
     if env_prefix == "mitxonline":
         secrets["DEEPL_API_KEY"] = '{{ get .Secrets "deepl_api_key" }}'
+        secrets["CANVAS_ACCESS_TOKEN"] = '{{ get .Secrets "canvas_access_token" }}'
+        secrets["YOUTUBE_API_KEY"] = '{{ get .Secrets "youtube_api_key" }}'
 
     # xpro and mitx share email configuration
     if env_prefix in ("xpro", "mitx"):


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10826

### Description (What does it do?)
Residential courses depend on Canvas LTI grade passback and YouTube API access. These secrets are currently only provisioned in the secret-mitx Vault mount. They need to be added to the mitxonline secrets template so the unified deployment can serve residential courses.
