### PR TITLE
fix: help_links base url fixed

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/config_builder.py
+++ b/src/ol_infrastructure/applications/edxapp/config_builder.py
@@ -175,8 +175,8 @@ def build_base_general_config() -> ConfigDict:
         "FORUM_MONGODB_DATABASE": "forum",
         "GITHUB_REPO_ROOT": "/openedx/data",
         "HELP_TOKENS_BOOKS": {
-            "course_author": "http://edx.readthedocs.io/projects/open-edx-building-and-running-a-course",
-            "learner": "http://edx.readthedocs.io/projects/open-edx-learner-guide",
+            "course_author": "https://docs.openedx.org/en/latest/educators",
+            "learner": "https://docs.openedx.org/en/latest/learners",
         },
         "ICP_LICENSE": None,
         "ICP_LICENSE_INFO": {},


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11298

### Description (What does it do?)
This pull request updates the help documentation URLs in the `HELP_TOKENS_BOOKS` configuration for edX. The links now point to the latest official Open edX documentation rather than the older readthedocs URLs.
