### PR TITLE
fix: webhook access token corrections 

### DIFF
--- a/src/bridge/secrets/edxapp/mitxonline.qa.yaml
+++ b/src/bridge/secrets/edxapp/mitxonline.qa.yaml
@@ -26,6 +26,7 @@ github_access_token: ENC[AES256_GCM,data:CSsR6fFcKrz6T9Q7XXZ/wOzsEUXMJTXno8OW5Wg
 meilisearch_master_key: ENC[AES256_GCM,data:AruMFclrbpvG30v6aCYvtP6F3mcAGerA2hB/3UqMNypoJGIITwUcKP0YJSsBSAFqoEiPQ3BiyyI/oJM0zI42Iw==,iv:iwxf1Y6DME9Iq9bENhhulYeZyPEJESr+Wz/4fY3aBY0=,tag:K2Y8ZwoLbk7y9+WoOh/jJQ==,type:str]
 meilisearch_api_key: ENC[AES256_GCM,data:KgOLFKuVlzhmvAnSgewqLOjXzWFeUGPQ8aJ4NpljIKPKm3zu33w+XA8Lry+0+DI2yQW+auxhC7LHQS/eAIlH3A==,iv:MUgfZfWXgYpjjCPpeYQ1KD3uuC56fvSya+KRgPEzee4=,tag:HDytyH56dJcRcIYZMDi+lQ==,type:str]
 typesense_bootstrap_key: ENC[AES256_GCM,data:6uNFa7No/8hLrgzoKqUhTPUWGoM3URrcW5E+Zye0fFRgZ/9idtwgvi1J6aJCsq1b2pyukfSNQJcWYOurju1rWw==,iv:hMHBo3QIiiWy1FQ4GVuW/jHdrqXgrZ1ESKTQwaOcbsQ=,tag:UeAbCRp60i+FCkvIDA+k4A==,type:str]
+webhook_access_token: ENC[AES256_GCM,data:H0+hjAQCQ+4viU3Z5dG9qA2YDijA3jAW60RfdsBp,iv:R6opuBQF4mZuEdOdtaZGTHTiZgE53DqxeT45+4BRQFs=,tag:oIx8m8jloA0esdy49R6nsQ==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-qa
@@ -41,8 +42,8 @@ sops:
     created_at: "2025-08-28T20:37:22Z"
     enc: vault:v1:myA322x4V71XWIYseRNjdHuJMe9sPAKQ3rQrPF95bzQ34WselInLQ4nVNGeBy7HY+4wVTg2vUBnAce4Z
   age: []
-  lastmodified: "2026-04-08T17:47:02Z"
-  mac: ENC[AES256_GCM,data:6Bxx35H8KyZNqGeSFWDOI3ocQ+otS7nDybcOy6d38qCcsIs/ShijkPksTwP3X/2JCD8jLdjZz+nwCrQLAfsTQskCAMtxutAIpL4EmG1C/u6A33VTuFlwVYEMG5a4bUU9x3tXahDJmJTuae70UKI6ji+eX/akGVmqNR65doZ6bHE=,iv:Z+MOkZoXL70+bHJeTpvZzjZd9fEU2EJRTs+Fn//co8s=,tag:9ec/h3Qc0iom5kDAEkxCaA==,type:str]
+  lastmodified: "2026-05-18T18:35:14Z"
+  mac: ENC[AES256_GCM,data:XCkcH/3tJiij+nMGKIRRLYnhNLAPbOvw62QrPc0nbpmeYKlLh5corkZlryPJk1ipGM1nNi20cKti3ibFseI3zQJxkux0+oSnPmjG7PUygHdwnxp19U/xZB9zSFmx/XRac9rga5tg6oWZj7+pc5EJbxH0FIvSOkmyxVVnWYb/flw=,iv:C8ir7BDGYcHL6tclDY3MZfShjEHQgC0C5g7oVoWL3LY=,tag:NkM+PjEd+csXozWyABiWpA==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.10.2

--- a/src/ol_infrastructure/applications/edxapp/k8s_secrets.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_secrets.py
@@ -383,24 +383,6 @@ def create_k8s_secrets(
         },
     )
 
-    # Webhook tokens secret (conditional - only for mitxonline QA for now)
-    if stack_info.env_prefix == "mitxonline" and stack_info.env_suffix == "QA":
-        webhook_tokens_secret = builder.create_static(
-            name="webhook-tokens",
-            resource_name="webhook-tokens-secret",
-            secret_name=webhook_tokens_secret_name,
-            mount=f"secret-{stack_info.env_prefix}",
-            path="collected-static-secrets",
-            templates={
-                "17-webhook-tokens-secrets.yaml": textwrap.dedent("""
-                    CERTIFICATE_WEBHOOK_ACCESS_TOKEN: {{ index .Secrets "webhook_access_token" "access_token" }}
-                    ENROLLMENT_WEBHOOK_ACCESS_TOKEN: {{ index .Secrets "webhook_access_token" "access_token" }}
-                """),
-            },
-        )
-    else:
-        webhook_tokens_secret = None
-
     # Translations providers secret (conditional - only for mitxonline)
     if stack_info.env_prefix == "mitxonline":
         translations_providers_secret = builder.create_static(
@@ -466,6 +448,24 @@ def create_k8s_secrets(
     else:
         typesense_secret = None
 
+    # Webhook tokens secret (conditional - only for mitxonline QA for now)
+    if stack_info.env_prefix == "mitxonline" and stack_info.env_suffix == "qa":
+        webhook_tokens_secret = builder.create_static(
+            name="webhook-tokens",
+            resource_name="webhook-tokens-secret",
+            secret_name=webhook_tokens_secret_name,
+            mount=f"secret-{stack_info.env_prefix}",
+            path="edxapp",
+            templates={
+                "17-webhook-tokens-secrets.yaml": textwrap.dedent("""
+                    CERTIFICATE_WEBHOOK_ACCESS_TOKEN: {{ get .Secrets "webhook_access_token" }}
+                    ENROLLMENT_WEBHOOK_ACCESS_TOKEN: {{ get .Secrets "webhook_access_token" }}
+                """),
+            },
+        )
+    else:
+        webhook_tokens_secret = None
+
     # Return dataclass with all secrets
     return EdxappSecrets(
         db_creds=db_creds_secret,
@@ -498,7 +498,7 @@ def create_k8s_secrets(
         if stack_info.env_prefix == "mitxonline"
         else None,
         webhook_tokens_secret_name=webhook_tokens_secret_name
-        if stack_info.env_prefix == "mitxonline" and stack_info.env_suffix == "QA"
+        if stack_info.env_prefix == "mitxonline" and stack_info.env_suffix == "qa"
         else None,
         meilisearch_secret_name=meilisearch_secret_name,
         typesense_secret_name=typesense_secret_name,


### PR DESCRIPTION
### Description (What does it do?)
- Puts the secret in the right place in SOPS
- Fixed out of order secret creation (17 is after 16 not before 13)
- Fixes lookup path in vault for the new (correct) location of the secret.
- Fixes capitalization issue with the conditional check. 

### How can this be tested?
Already tested and verified in QA which is the only applicable location. 
