### PR TITLE
config: Enable Fastly shielding in production for OCW and Learn

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
@@ -36,6 +36,7 @@ config:
     sso_url: "sso.ol.mit.edu"
   mitlearn:k8s_deploy: "true"
   mitlearn:k8s_cutover: "true"
+  mitlearn:enable_fastly_shielding: true
   mitlearn:learn_ai_recommendation_endpoint: "https://api.learn.mit.edu/ai/http/recommendation_agent/"
   mitlearn:learn_ai_syllabus_endpoint: "https://api.learn.mit.edu/ai/http/syllabus_agent/"
   mitlearn:legacy_api_domain: "api.mitopen.odl.mit.edu"

--- a/src/ol_infrastructure/applications/ocw_site/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/ocw_site/Pulumi.Production.yaml
@@ -3,6 +3,7 @@ secretsprovider: awskms://alias/infrastructure-secrets-production
 encryptedkey: AQICAHgQalNS7T35ZlcFdhF0QuKeiJAbXMUbm01pjGwHEsjRCgGPbSz7qllaLKSxEZcmDRxmAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMiW0X4xHd5cZ68j1uAgEQgDtqOisD1vkDetSKsy4Q4aHqZt4ZoWiScmYMkFGsRXTOCpzP2bU1U20TVIiN+hQrSWe60lqWycNfePaPtA==
 config:
   aws:region: us-east-1
+  ocw_site:enable_fastly_shielding: "true"
   ocw_site:domains:
     draft:
     - draft.ocw.mit.edu


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
Toggles on shielding in Fastly for production on Learn and OCW. This has been enabled in RC for several weeks and I haven't heard any issues from it.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
The same configuration is enabled on RC currently

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
Enabling shielding will reduce the amount of bandwidth to the origin and should speed up content delivery to non-US learners
