### PR TITLE
Increase Keycloak Prod Memory

### DIFF
--- a/src/ol_infrastructure/applications/keycloak/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/keycloak/Pulumi.Production.yaml
@@ -5,8 +5,8 @@ config:
   aws:region: us-east-1
   consul:address: https://consul-operations-production.odl.mit.edu
   keycloak:replicas: "3"
-  keycloak:memory_request: 2Gi
-  keycloak:memory_limit: 4Gi
+  keycloak:memory_request: 4Gi
+  keycloak:memory_limit: 8Gi
   keycloak:cpu_request: 1000m
   keycloak:cpu_limit: 2000m
   keycloak:db_capacity: "100"


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
Based on Grafana data, appears that we need to increase memory for the Keycloak production pods.