### PR TITLE
feat: Add VPA observation-mode resources for Keycloak and MIT Learn

### DIFF
--- a/src/ol_infrastructure/applications/keycloak/__main__.py
+++ b/src/ol_infrastructure/applications/keycloak/__main__.py
@@ -560,6 +560,44 @@ keycloak_service_monitor = kubernetes.apiextensions.CustomResource(
     ),
 )
 
+# Vertical Pod Autoscaler — observation mode (updateMode: Off).
+#
+# VPA is installed cluster-wide by the EKS stack (setup_vpa in vpa.py).
+# This object collects right-sizing recommendations without evicting pods.
+# After 1-2 weeks of data, apply the recommendations by updating
+# spec.resources in the Keycloak CR above (not the StatefulSet directly —
+# the operator owns the StatefulSet and will overwrite manual patches).
+# Then switch updateMode to InPlaceOrRecreate for ongoing management.
+#
+# Keycloak has no HPA, so VPA can safely control both CPU and memory.
+kubernetes.apiextensions.CustomResource(
+    f"keycloak-vpa-{stack_info.env_suffix}",
+    api_version="autoscaling.k8s.io/v1",
+    kind="VerticalPodAutoscaler",
+    metadata={
+        "name": f"{keycloak_resource_name}-vpa",
+        "namespace": keycloak_namespace,
+    },
+    spec={
+        "targetRef": {
+            "apiVersion": "apps/v1",
+            "kind": "StatefulSet",
+            "name": keycloak_resource_name,
+        },
+        "updatePolicy": {"updateMode": "Off"},
+        "resourcePolicy": {
+            "containerPolicies": [
+                {
+                    "containerName": "*",
+                    "controlledResources": ["cpu", "memory"],
+                    "controlledValues": "RequestsAndLimits",
+                }
+            ]
+        },
+    },
+    opts=ResourceOptions(depends_on=[keycloak_resource]),
+)
+
 gateway_config = OLEKSGatewayConfig(
     cert_issuer="letsencrypt-production",
     cert_issuer_class="cluster-issuer",

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1563,6 +1563,114 @@ mitlearn_k8s_app = OLApplicationK8s(
     ),
 )
 
+##########################################################################
+# Vertical Pod Autoscaler — observation mode (updateMode: Off)
+#
+# VPA is installed cluster-wide by the EKS stack (setup_vpa in vpa.py).
+# These objects collect right-sizing recommendations without evicting pods.
+# After 1-2 weeks of data, update resource requests/limits directly in this
+# file, then switch updateMode to InPlaceOrRecreate for ongoing management.
+##########################################################################
+
+# Webapp VPA — memory only.
+# The webapp HPA scales on both CPU and memory utilisation; VPA must not
+# control CPU to avoid distorting the CPU metric the HPA observes.
+# NOTE: the HPA also uses a memory utilisation metric.  If you later enable
+# VPA updates, remove the memory metric from the HPA (or switch it to an
+# AverageValue target) to prevent the two controllers fighting over memory
+# requests.
+kubernetes.apiextensions.CustomResource(
+    f"mitlearn-webapp-vpa-{stack_info.env_suffix}",
+    api_version="autoscaling.k8s.io/v1",
+    kind="VerticalPodAutoscaler",
+    metadata={
+        "name": "mitlearn-webapp-vpa",
+        "namespace": learn_namespace,
+    },
+    spec={
+        "targetRef": {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "name": mitlearn_k8s_app.webapp_deployment_name,
+        },
+        "updatePolicy": {"updateMode": "Off"},
+        "resourcePolicy": {
+            "containerPolicies": [
+                {
+                    "containerName": "*",
+                    "controlledResources": ["memory"],
+                    "controlledValues": "RequestsAndLimits",
+                }
+            ]
+        },
+    },
+    opts=ResourceOptions(depends_on=[mitlearn_k8s_app]),
+)
+
+# Celery worker VPAs — CPU + memory.
+# KEDA scales these workers from Redis queue depth, not CPU utilisation, so
+# VPA controlling CPU requests does not conflict with KEDA replica decisions.
+for _worker_deployment_name in mitlearn_k8s_app.celery_deployment_names:
+    kubernetes.apiextensions.CustomResource(
+        f"mitlearn-{_worker_deployment_name}-vpa-{stack_info.env_suffix}",
+        api_version="autoscaling.k8s.io/v1",
+        kind="VerticalPodAutoscaler",
+        metadata={
+            "name": f"{_worker_deployment_name}-vpa",
+            "namespace": learn_namespace,
+        },
+        spec={
+            "targetRef": {
+                "apiVersion": "apps/v1",
+                "kind": "Deployment",
+                "name": _worker_deployment_name,
+            },
+            "updatePolicy": {"updateMode": "Off"},
+            "resourcePolicy": {
+                "containerPolicies": [
+                    {
+                        "containerName": "*",
+                        "controlledResources": ["cpu", "memory"],
+                        "controlledValues": "RequestsAndLimits",
+                    }
+                ]
+            },
+        },
+        opts=ResourceOptions(depends_on=[mitlearn_k8s_app]),
+    )
+
+# Celery beat VPA — CPU + memory.
+# Beat runs a single replica with no autoscaler, so VPA can safely control
+# both dimensions.
+if mitlearn_k8s_app.beat_deployment_name:
+    kubernetes.apiextensions.CustomResource(
+        f"mitlearn-celery-beat-vpa-{stack_info.env_suffix}",
+        api_version="autoscaling.k8s.io/v1",
+        kind="VerticalPodAutoscaler",
+        metadata={
+            "name": "mitlearn-celery-beat-vpa",
+            "namespace": learn_namespace,
+        },
+        spec={
+            "targetRef": {
+                "apiVersion": "apps/v1",
+                "kind": "Deployment",
+                "name": mitlearn_k8s_app.beat_deployment_name,
+            },
+            "updatePolicy": {"updateMode": "Off"},
+            "resourcePolicy": {
+                "containerPolicies": [
+                    {
+                        "containerName": "*",
+                        "controlledResources": ["cpu", "memory"],
+                        "controlledValues": "RequestsAndLimits",
+                    }
+                ]
+            },
+        },
+        opts=ResourceOptions(depends_on=[mitlearn_k8s_app]),
+    )
+
 mitlearn_k8s_app_oidc_resources_no_prefix = OLApisixOIDCResources(
     f"ol-mitlearn-k8s-olapisixoidcresources-no-prefix-{stack_info.env_suffix}",
     oidc_config=OLApisixOIDCConfig(


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Adds `VerticalPodAutoscaler` objects in `updateMode: Off` (observation only) to the Keycloak and MIT Learn application stacks. VPA in this mode collects right-sizing recommendations without evicting or resizing any pods, giving us data to identify over-provisioned containers and inform future resource request adjustments.

**MIT Learn (`applications/mit_learn`):**
- **Webapp VPA** — memory-only. The webapp HPA scales on CPU utilisation, so VPA must not control CPU. Note: the HPA also uses a memory utilisation metric; if VPA updates are later enabled, the HPA memory metric should be removed or converted to an `AverageValue` target to avoid the two controllers conflicting.
- **Celery worker VPAs** — CPU + memory. KEDA scales workers from Redis queue depth (not CPU), so controlling CPU requests does not conflict with KEDA replica decisions.
- **Celery beat VPA** — CPU + memory. Single replica, no autoscaler.

**Keycloak (`applications/keycloak`):**
- **StatefulSet VPA** — CPU + memory. No HPA. The Keycloak operator owns the StatefulSet, so once recommendations are ready, they should be applied back to `spec.resources` in the `Keycloak` CR — not patched directly on the StatefulSet.

Dagster and Airbyte are excluded from this pass: their workloads are primarily ephemeral jobs that VPA cannot usefully target.

Part of the k8s workload rightsizing cost-optimisation effort — see `docs/cost-optimization/k8s-workload-rightsizing.md`.

### How can this be tested?
Run `pulumi preview` against the Keycloak and MIT Learn stacks to confirm the VPA CustomResources are planned without errors. After deploying, verify with `kubectl get vpa -n keycloak` and `kubectl get vpa -n mitlearn`.