### PR TITLE
Add GTM IDs for OCW v3 theme

### DIFF
--- a/src/ol_infrastructure/applications/ocw_studio/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/ocw_studio/Pulumi.Production.yaml
@@ -26,6 +26,7 @@ config:
     MIT_LEARN_BASE_URL: https://learn.mit.edu
     OCW_COURSE_STARTER_SLUG: ocw-course-v2
     OCW_EXTRA_COURSE_THEMES: ocw-course-v3
+    OCW_EXTRA_THEMES_GTM_IDS: '{"ocw-course-v3": "GTM-NMJ2CT6T&gtm_auth=TVdLeYWP6BLCRsILCebafA&gtm_preview=env-1&gtm_cookies_win=x"}'
     OCW_GTM_ACCOUNT_ID: GTM-NMQZ25T
     OCW_HUGO_THEMES_SENTRY_DSN: 'https://eee58f41dda54d2b814296e12dced4b7@o48788.ingest.sentry.io/5304953'
     OCW_IMPORT_STARTER_SLUG: ocw-course

--- a/src/ol_infrastructure/applications/ocw_studio/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/ocw_studio/Pulumi.QA.yaml
@@ -29,6 +29,7 @@ config:
     MIT_LEARN_API_BASE_URL: https://api.rc.learn.mit.edu
     OCW_COURSE_STARTER_SLUG: ocw-course-v2
     OCW_EXTRA_COURSE_THEMES: ocw-course-v3
+    OCW_EXTRA_THEMES_GTM_IDS: '{"ocw-course-v3": "GTM-NMJ2CT6T&gtm_auth=Rl-qxbJnD78rPEq1OFQLow&gtm_preview=env-3&gtm_cookies_win=x"}'
     OCW_GTM_ACCOUNT_ID: GTM-PJMJGF6
     OCW_HUGO_THEMES_SENTRY_DSN: 'https://eee58f41dda54d2b814296e12dced4b7@o48788.ingest.sentry.io/5304953'
     OCW_IMPORT_STARTER_SLUG: ocw-course


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/ocw-studio/pull/3043.

### Description (What does it do?)
This PR adds the `OCW_EXTRA_THEMES_GTM_IDS` values for both RC and production. The PR adding the functionality for site pipelines to read this setting is https://github.com/mitodl/ocw-studio/pull/3043.

### How can this be tested?
Verify that the values look correct, as listed in the linked issue; this can be tested thoroughly once https://github.com/mitodl/ocw-studio/pull/3043 is merged and deployed in RC.