### PR TITLE
SCIM User Updates Stop Triggering After Keycloak Runs for a While

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/ol_mit.py
+++ b/src/ol_infrastructure/substructure/keycloak/ol_mit.py
@@ -501,11 +501,15 @@ def create_ol_mit_realm(  # noqa: PLR0913
         connection_pooling=True,
         pagination=True,
         use_truststore_spi="ONLY_FOR_LDAPS",
+        # Fail fast rather than hanging indefinitely if the Okta LDAP endpoint
+        # is unreachable or slow.  Values are in milliseconds.
+        connection_timeout="30s",
+        read_timeout="120s",
         # Hourly delta sync picks up group-membership changes for users who have
         # already logged in.  Full sync is disabled to avoid bulk-importing every
         # MIT affiliate into Keycloak; users are provisioned on-demand via the
         # Touchstone SAML first-login flow.
-        changed_sync_period=3600,
+        changed_sync_period=14400,
         opts=resource_options,
     )
 


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
After Keycloak has been running for some time (hours), SCIM user updates (PATCH/PUT to the remote SCIM provider) stop being triggered entirely. User creates and deletes continue to work. Restarting Keycloak resolves the issue temporarily until it stops again. No errors appear in the logs.

### Root Cause
Keycloak's BasicTimerProvider uses a single [java.util.Timer](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) backed by exactly one background thread (Timer-0). Every scheduled task in Keycloak shares this thread — LDAP sync, SCIM update tasks, retry tasks, session cleanup, etc. all run sequentially on it.

The LDAP incremental sync task (UserStorageSyncTask) runs on Timer-0 on a periodic schedule. If the LDAP server is slow or unresponsive and no read timeout is configured, the LDAP search request blocks Timer-0 indefinitely waiting for a response that never arrives:
```
thread Timer-0 had stackTrace:
  com.sun.jndi.ldap.LdapRequest.getReplyBer        ← blocked on LDAP socket read
  ...
  GroupLDAPStorageMapper.syncDataFromFederationProviderToKeycloak
  LDAPStorageProviderFactory.syncSince
  UserStorageSyncTask.runIncrementalSync
  ...
  BasicTimerProvider$BasicTimerTask.run
  java.util.TimerThread.mainLoop                    ← Timer-0 is stuck here
```

While Timer-0 is blocked, all queued SCIM update tasks sit in the timer queue and never execute. The JTA transaction reaper (ARJUNA012404) detects the stalled transaction and marks it for rollback, but it cannot interrupt a thread blocked on a native socket read — so Timer-0 remains frozen.

Why creates and deletes continue working: These call [runJobInTransaction()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) directly and synchronously, bypassing the timer entirely. Only updates are scheduled via [timerProvider.schedule()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and depend on Timer-0 being available.

Why restart fixes it: A restart creates a fresh timer thread and fresh LDAP connections, so everything works again until the next time LDAP hangs.