### PR TITLE
feat(s3): add Archive/Deep Archive access tier support to OLBucket

### DIFF
--- a/src/ol_infrastructure/applications/clickhouse/__main__.py
+++ b/src/ol_infrastructure/applications/clickhouse/__main__.py
@@ -615,6 +615,9 @@ cold_bucket_config = S3BucketConfig(
     sse_algorithm="AES256",
     intelligent_tiering_enabled=True,
     intelligent_tiering_days=1,  # Move to Intelligent-Tiering immediately
+    # ClickHouse cold storage is never user-facing: safe for archive tiers.
+    intelligent_tiering_archive_access_days=90,
+    intelligent_tiering_deep_archive_access_days=180,
 )
 
 cold_bucket = OLBucket(

--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -320,6 +320,9 @@ edxorg_courses_bucket_config = S3BucketConfig(
     bucket_name=edxorg_courses_bucket_name,
     versioning_enabled=True,
     server_side_encryption_enabled=True,
+    # edX.org course tarballs are cold archive data: safe for archive tiers.
+    intelligent_tiering_archive_access_days=90,
+    intelligent_tiering_deep_archive_access_days=180,
     tags=aws_config.tags,
 )
 edxorg_courses_bucket = OLBucket(

--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -184,6 +184,8 @@ edxapp_mfe_bucket_config = S3BucketConfig(
             allowed_origins=["*"],
         )
     ],
+    intelligent_tiering_archive_access_days=None,  # Fastly backend
+    intelligent_tiering_deep_archive_access_days=None,
     tags=aws_config.tags,
     bucket_policy_document=cast(
         str,

--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -165,6 +165,8 @@ learn_ai_app_storage_bucket_config = S3BucketConfig(
     block_public_policy=False,
     ignore_public_acls=False,
     restrict_public_buckets=False,
+    intelligent_tiering_archive_access_days=None,  # Fastly backend
+    intelligent_tiering_deep_archive_access_days=None,
     tags=aws_config.tags,
 )
 

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -262,6 +262,8 @@ mitlearn_application_storage_bucket_config = S3BucketConfig(
     block_public_policy=False,
     ignore_public_acls=False,
     restrict_public_buckets=False,
+    intelligent_tiering_archive_access_days=None,  # Fastly backend
+    intelligent_tiering_deep_archive_access_days=None,
     tags=aws_config.tags,
 )
 

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -155,6 +155,8 @@ mitxonline_bucket_config = S3BucketConfig(
     block_public_policy=False,
     ignore_public_acls=False,
     restrict_public_buckets=False,
+    intelligent_tiering_archive_access_days=None,  # Fastly backend
+    intelligent_tiering_deep_archive_access_days=None,
     tags=aws_config.tags,
 )
 

--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -314,6 +314,13 @@ live_bucket_config = S3BucketConfig(
         )
     ),
     logging_expected_bucket_owner=aws_account.account_id,
+    # Disable archive access tiers: this bucket is a live CDN origin and objects
+    # that haven't been accessed in 90 days may still be needed for cache misses.
+    # Archive/Deep Archive retrieval latency (minutes/hours) would cause request
+    # failures. The lifecycle rule still transitions objects to INTELLIGENT_TIERING
+    # for Frequent/Infrequent/Archive-Instant-Access savings (all instant retrieval).
+    intelligent_tiering_archive_access_days=None,
+    intelligent_tiering_deep_archive_access_days=None,
     tags=aws_config.tags,
 )
 

--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -319,8 +319,6 @@ live_bucket_config = S3BucketConfig(
     # Archive/Deep Archive retrieval latency (minutes/hours) would cause request
     # failures. The lifecycle rule still transitions objects to INTELLIGENT_TIERING
     # for Frequent/Infrequent/Archive-Instant-Access savings (all instant retrieval).
-    intelligent_tiering_archive_access_days=None,
-    intelligent_tiering_deep_archive_access_days=None,
     tags=aws_config.tags,
 )
 
@@ -370,6 +368,9 @@ draft_backup_bucket_config = S3BucketConfig(
             ],
         }
     ),
+    # Backup bucket: never CDN-served, safe for archive tiers.
+    intelligent_tiering_archive_access_days=90,
+    intelligent_tiering_deep_archive_access_days=180,
     tags=aws_config.tags,
 )
 
@@ -432,6 +433,9 @@ live_backup_bucket_config = S3BucketConfig(
         )
     ),
     logging_expected_bucket_owner=aws_account.account_id,
+    # Backup bucket: never CDN-served, safe for archive tiers.
+    intelligent_tiering_archive_access_days=90,
+    intelligent_tiering_deep_archive_access_days=180,
     tags=aws_config.tags,
 )
 

--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -197,6 +197,8 @@ draft_bucket_config = S3BucketConfig(
         )
     ),
     logging_expected_bucket_owner=aws_account.account_id,
+    intelligent_tiering_archive_access_days=None,  # Fastly backend
+    intelligent_tiering_deep_archive_access_days=None,
     tags=aws_config.tags,
 )
 
@@ -257,6 +259,8 @@ test_bucket_config = S3BucketConfig(
         )
     ),
     logging_expected_bucket_owner=aws_account.account_id,
+    intelligent_tiering_archive_access_days=None,  # Fastly backend
+    intelligent_tiering_deep_archive_access_days=None,
     tags=aws_config.tags,
 )
 
@@ -319,6 +323,8 @@ live_bucket_config = S3BucketConfig(
     # Archive/Deep Archive retrieval latency (minutes/hours) would cause request
     # failures. The lifecycle rule still transitions objects to INTELLIGENT_TIERING
     # for Frequent/Infrequent/Archive-Instant-Access savings (all instant retrieval).
+    intelligent_tiering_archive_access_days=None,
+    intelligent_tiering_deep_archive_access_days=None,
     tags=aws_config.tags,
 )
 
@@ -507,6 +513,8 @@ draft_offline_bucket_config = S3BucketConfig(
         )
     ),
     logging_expected_bucket_owner=aws_account.account_id,
+    intelligent_tiering_archive_access_days=None,  # S3 website, user-facing downloads
+    intelligent_tiering_deep_archive_access_days=None,
     tags=aws_config.tags,
 )
 
@@ -582,6 +590,8 @@ live_offline_bucket_config = S3BucketConfig(
         )
     ),
     logging_expected_bucket_owner=aws_account.account_id,
+    intelligent_tiering_archive_access_days=None,  # S3 website, user-facing downloads
+    intelligent_tiering_deep_archive_access_days=None,
     tags=aws_config.tags,
 )
 
@@ -645,6 +655,8 @@ test_offline_bucket_config = S3BucketConfig(
         )
     ),
     logging_expected_bucket_owner=aws_account.account_id,
+    intelligent_tiering_archive_access_days=None,  # S3 website, user-facing downloads
+    intelligent_tiering_deep_archive_access_days=None,
     tags=aws_config.tags,
 )
 

--- a/src/ol_infrastructure/applications/odl_video_service/__main__.py
+++ b/src/ol_infrastructure/applications/odl_video_service/__main__.py
@@ -133,6 +133,8 @@ ovs_main_bucket_config = S3BucketConfig(
     server_side_encryption_enabled=True,
     intelligent_tiering_enabled=True,
     intelligent_tiering_days=90,
+    intelligent_tiering_archive_access_days=None,  # CloudFront origin
+    intelligent_tiering_deep_archive_access_days=None,
     cors_rules=[
         BucketCorsConfigurationCorsRuleArgs(
             allowed_headers=["*"],
@@ -166,6 +168,8 @@ ovs_subtitles_bucket_config = S3BucketConfig(
     sse_algorithm="AES256",  # Use SSE-S3 for CloudFront compatibility
     intelligent_tiering_enabled=True,
     intelligent_tiering_days=90,
+    intelligent_tiering_archive_access_days=None,  # CloudFront origin
+    intelligent_tiering_deep_archive_access_days=None,
     cors_rules=[
         BucketCorsConfigurationCorsRuleArgs(
             allowed_headers=["*"],
@@ -199,6 +203,8 @@ ovs_thumbnails_bucket_config = S3BucketConfig(
     sse_algorithm="AES256",  # Use SSE-S3 for CloudFront compatibility
     intelligent_tiering_enabled=True,
     intelligent_tiering_days=90,
+    intelligent_tiering_archive_access_days=None,  # CloudFront origin
+    intelligent_tiering_deep_archive_access_days=None,
     cors_rules=[
         BucketCorsConfigurationCorsRuleArgs(
             allowed_headers=["*"],
@@ -234,6 +240,8 @@ ovs_transcoded_bucket_config = S3BucketConfig(
     sse_algorithm="AES256",  # Use SSE-S3 for CloudFront compatibility
     intelligent_tiering_enabled=True,
     intelligent_tiering_days=90,
+    intelligent_tiering_archive_access_days=None,  # CloudFront origin
+    intelligent_tiering_deep_archive_access_days=None,
     block_public_acls=False,
     block_public_policy=False,
     ignore_public_acls=False,

--- a/src/ol_infrastructure/components/aws/s3.py
+++ b/src/ol_infrastructure/components/aws/s3.py
@@ -165,25 +165,29 @@ class S3BucketConfig(AWSBase):
         ),
     )
     intelligent_tiering_archive_access_days: int | None = Field(
-        default=90,
+        default=None,
         description=(
             "Days of no access after which objects in INTELLIGENT_TIERING storage "
             "class move to the Archive Access tier (68% cheaper than Standard, "
             "minutes retrieval latency). Must be between 90 and 730. "
-            "Set to None to disable. Do not enable for buckets that serve live "
-            "CDN content — retrieval latency will cause cache-miss delays. "
+            "Disabled by default (None) -- only opt in for cold-data buckets "
+            "(backups, archives, data lakes) that are never CDN or application "
+            "origins. Retrieval latency will cause cache-miss or request failures "
+            "on any bucket accessed by users or CDN. "
             "Only used when intelligent_tiering_enabled is True."
         ),
     )
     intelligent_tiering_deep_archive_access_days: int | None = Field(
-        default=180,
+        default=None,
         description=(
             "Days of no access after which objects in INTELLIGENT_TIERING storage "
             "class move to the Deep Archive Access tier (95% cheaper than Standard, "
             "hours retrieval latency). Must be between 180 and 730 and greater than "
             "intelligent_tiering_archive_access_days when both are set. "
-            "Set to None to disable. Do not enable for buckets that serve live "
-            "CDN content — retrieval latency will cause cache-miss delays. "
+            "Disabled by default (None) -- only opt in for cold-data buckets "
+            "(backups, archives, data lakes) that are never CDN or application "
+            "origins. Retrieval latency will cause cache-miss or request failures "
+            "on any bucket accessed by users or CDN. "
             "Only used when intelligent_tiering_enabled is True."
         ),
     )

--- a/src/ol_infrastructure/components/aws/s3.py
+++ b/src/ol_infrastructure/components/aws/s3.py
@@ -164,6 +164,29 @@ class S3BucketConfig(AWSBase):
             "Only used if intelligent_tiering_enabled is True."
         ),
     )
+    intelligent_tiering_archive_access_days: int | None = Field(
+        default=90,
+        description=(
+            "Days of no access after which objects in INTELLIGENT_TIERING storage "
+            "class move to the Archive Access tier (68% cheaper than Standard, "
+            "minutes retrieval latency). Must be between 90 and 730. "
+            "Set to None to disable. Do not enable for buckets that serve live "
+            "CDN content — retrieval latency will cause cache-miss delays. "
+            "Only used when intelligent_tiering_enabled is True."
+        ),
+    )
+    intelligent_tiering_deep_archive_access_days: int | None = Field(
+        default=180,
+        description=(
+            "Days of no access after which objects in INTELLIGENT_TIERING storage "
+            "class move to the Deep Archive Access tier (95% cheaper than Standard, "
+            "hours retrieval latency). Must be between 180 and 730 and greater than "
+            "intelligent_tiering_archive_access_days when both are set. "
+            "Set to None to disable. Do not enable for buckets that serve live "
+            "CDN content — retrieval latency will cause cache-miss delays. "
+            "Only used when intelligent_tiering_enabled is True."
+        ),
+    )
     cors_rules: list[s3.BucketCorsConfigurationCorsRuleArgs] | None = Field(
         default=None,
         description="CORS configuration rules for the bucket.",
@@ -206,6 +229,39 @@ class S3BucketConfig(AWSBase):
                 "intelligent_tiering_enabled is True."
             )
             raise ValueError(error_message)
+        return self
+
+    @model_validator(mode="after")
+    def check_archive_tiering_config(self) -> "S3BucketConfig":
+        """Validate archive access tier configuration."""
+        _ARCHIVE_MIN_DAYS = 90
+        _DEEP_ARCHIVE_MIN_DAYS = 180
+        if (
+            self.intelligent_tiering_archive_access_days is not None
+            and self.intelligent_tiering_archive_access_days < _ARCHIVE_MIN_DAYS
+        ):
+            error_message = (
+                "intelligent_tiering_archive_access_days must be >= 90 (AWS minimum)"
+            )
+            raise ValueError(error_message)
+        if self.intelligent_tiering_deep_archive_access_days is not None:
+            deep_days = self.intelligent_tiering_deep_archive_access_days
+            if deep_days < _DEEP_ARCHIVE_MIN_DAYS:
+                error_message = (
+                    "intelligent_tiering_deep_archive_access_days must be >= 180 "
+                    "(AWS minimum)"
+                )
+                raise ValueError(error_message)
+            if (
+                self.intelligent_tiering_archive_access_days is not None
+                and self.intelligent_tiering_deep_archive_access_days
+                <= self.intelligent_tiering_archive_access_days
+            ):
+                error_message = (
+                    "intelligent_tiering_deep_archive_access_days must be greater "
+                    "than intelligent_tiering_archive_access_days"
+                )
+                raise ValueError(error_message)
         return self
 
     @model_validator(mode="after")
@@ -268,13 +324,14 @@ class OLBucket(pulumi.ComponentResource):
     bucket_public_access_block: s3.BucketPublicAccessBlock | None = None
     bucket_logging: s3.BucketLogging | None = None
     bucket_lifecycle: s3.BucketLifecycleConfiguration | None = None
+    bucket_intelligent_tiering: s3.BucketIntelligentTieringConfiguration | None = None
     bucket_website: s3.BucketWebsiteConfiguration | None = None
     bucket_encryption: s3.BucketServerSideEncryptionConfiguration | None = None
     bucket_cors: s3.BucketCorsConfiguration | None = None
     bucket_ownership_controls: s3.BucketOwnershipControls | None = None
     bucket_policy: s3.BucketPolicy | None = None
 
-    def __init__(  # noqa: C901
+    def __init__(  # noqa: C901, PLR0912
         self,
         name: str,
         config: S3BucketConfig,
@@ -409,6 +466,41 @@ class OLBucket(pulumi.ComponentResource):
                 f"{name}-lifecycle",
                 bucket=self.bucket_v2.id,
                 rules=lifecycle_rules,
+                opts=child_opts,
+            )
+
+        # Create BucketIntelligentTieringConfiguration to enable the optional
+        # Archive Access and Deep Archive Access tiers within INTELLIGENT_TIERING.
+        # These tiers require explicit opt-in and provide 68-95% cost savings for
+        # truly cold objects, but have minutes-to-hours retrieval latency - do not
+        # enable on buckets serving live CDN content.
+        if config.intelligent_tiering_enabled and (
+            config.intelligent_tiering_archive_access_days is not None
+            or config.intelligent_tiering_deep_archive_access_days is not None
+        ):
+            archive_tierings: list[
+                s3.BucketIntelligentTieringConfigurationTieringArgs
+            ] = []
+            if config.intelligent_tiering_archive_access_days is not None:
+                archive_tierings.append(
+                    s3.BucketIntelligentTieringConfigurationTieringArgs(
+                        access_tier="ARCHIVE_ACCESS",
+                        days=config.intelligent_tiering_archive_access_days,
+                    )
+                )
+            if config.intelligent_tiering_deep_archive_access_days is not None:
+                archive_tierings.append(
+                    s3.BucketIntelligentTieringConfigurationTieringArgs(
+                        access_tier="DEEP_ARCHIVE_ACCESS",
+                        days=config.intelligent_tiering_deep_archive_access_days,
+                    )
+                )
+            self.bucket_intelligent_tiering = s3.BucketIntelligentTieringConfiguration(
+                f"{name}-intelligent-tiering-config",
+                bucket=self.bucket_v2.id,
+                name="standard-tiering",
+                status="Enabled",
+                tierings=archive_tierings,
                 opts=child_opts,
             )
 

--- a/src/ol_infrastructure/components/aws/s3.py
+++ b/src/ol_infrastructure/components/aws/s3.py
@@ -191,6 +191,17 @@ class S3BucketConfig(AWSBase):
             "Only used when intelligent_tiering_enabled is True."
         ),
     )
+    abort_incomplete_mpu_days: int | None = Field(
+        default=7,
+        description=(
+            "Days after which S3 automatically aborts incomplete multipart uploads "
+            "and deletes the uploaded parts. Defaults to 7 days, which is safe for "
+            "all buckets -- any upload genuinely in progress will complete well "
+            "within 7 days; stale parts from failed uploads are cleaned up "
+            "automatically. Set to None only if a bucket has a known use case "
+            "requiring uploads longer than 7 days."
+        ),
+    )
     cors_rules: list[s3.BucketCorsConfigurationCorsRuleArgs] | None = Field(
         default=None,
         description="CORS configuration rules for the bucket.",
@@ -315,6 +326,17 @@ class S3BucketConfig(AWSBase):
                 f"versioning_status must be 'Enabled', 'Suspended', or 'Disabled', "
                 f"got '{self.versioning_status}'"
             )
+            raise ValueError(error_message)
+        return self
+
+    @model_validator(mode="after")
+    def check_abort_mpu_days(self) -> "S3BucketConfig":
+        """Validate abort_incomplete_mpu_days is a positive integer when set."""
+        if (
+            self.abort_incomplete_mpu_days is not None
+            and self.abort_incomplete_mpu_days < 1
+        ):
+            error_message = "abort_incomplete_mpu_days must be >= 1"
             raise ValueError(error_message)
         return self
 
@@ -464,6 +486,19 @@ class OLBucket(pulumi.ComponentResource):
 
         # Create or enhance BucketLifecycleConfiguration
         lifecycle_rules = list(config.lifecycle_rules) if config.lifecycle_rules else []
+
+        # Add abort-incomplete-multipart-upload rule if enabled (default: 7 days).
+        # This prevents stale MPU parts from accumulating and billing indefinitely.
+        if config.abort_incomplete_mpu_days is not None:
+            lifecycle_rules.append(
+                s3.BucketLifecycleConfigurationRuleArgs(
+                    id="abort-incomplete-multipart-uploads",
+                    status="Enabled",
+                    abort_incomplete_multipart_upload=s3.BucketLifecycleConfigurationRuleAbortIncompleteMultipartUploadArgs(
+                        days_after_initiation=config.abort_incomplete_mpu_days,
+                    ),
+                )
+            )
 
         # Add intelligent tiering rule if enabled
         if config.intelligent_tiering_enabled:

--- a/src/ol_infrastructure/components/aws/s3.py
+++ b/src/ol_infrastructure/components/aws/s3.py
@@ -238,22 +238,37 @@ class S3BucketConfig(AWSBase):
     @model_validator(mode="after")
     def check_archive_tiering_config(self) -> "S3BucketConfig":
         """Validate archive access tier configuration."""
+        if not self.intelligent_tiering_enabled:
+            return self
         _ARCHIVE_MIN_DAYS = 90
+        _ARCHIVE_MAX_DAYS = 730
         _DEEP_ARCHIVE_MIN_DAYS = 180
-        if (
-            self.intelligent_tiering_archive_access_days is not None
-            and self.intelligent_tiering_archive_access_days < _ARCHIVE_MIN_DAYS
-        ):
-            error_message = (
-                "intelligent_tiering_archive_access_days must be >= 90 (AWS minimum)"
-            )
-            raise ValueError(error_message)
+        if self.intelligent_tiering_archive_access_days is not None:
+            archive_days = self.intelligent_tiering_archive_access_days
+            if archive_days < _ARCHIVE_MIN_DAYS:
+                error_message = (
+                    "intelligent_tiering_archive_access_days must be "
+                    ">= 90 (AWS minimum)"
+                )
+                raise ValueError(error_message)
+            if archive_days > _ARCHIVE_MAX_DAYS:
+                error_message = (
+                    "intelligent_tiering_archive_access_days must be "
+                    "<= 730 (AWS maximum)"
+                )
+                raise ValueError(error_message)
         if self.intelligent_tiering_deep_archive_access_days is not None:
             deep_days = self.intelligent_tiering_deep_archive_access_days
             if deep_days < _DEEP_ARCHIVE_MIN_DAYS:
                 error_message = (
                     "intelligent_tiering_deep_archive_access_days must be >= 180 "
                     "(AWS minimum)"
+                )
+                raise ValueError(error_message)
+            if deep_days > _ARCHIVE_MAX_DAYS:
+                error_message = (
+                    "intelligent_tiering_deep_archive_access_days must be <= 730 "
+                    "(AWS maximum)"
                 )
                 raise ValueError(error_message)
             if (

--- a/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
@@ -49,6 +49,9 @@ results_bucket_config = S3BucketConfig(
     server_side_encryption_enabled=True,
     kms_key_id=s3_kms_key["id"],
     bucket_key_enabled=True,
+    # Query results are cold storage: safe for archive tiers.
+    intelligent_tiering_archive_access_days=90,
+    intelligent_tiering_deep_archive_access_days=180,
     lifecycle_rules=[
         s3.BucketLifecycleConfigurationRuleArgs(
             id="expire_old_query_results",
@@ -107,6 +110,9 @@ data_landing_zone_bucket = OLBucket(
         sse_algorithm="aws:kms",
         bucket_key_enabled=True,
         tags=aws_config.tags,
+        # Data landing zone is write-heavy ingest storage: safe for archive tiers.
+        intelligent_tiering_archive_access_days=90,
+        intelligent_tiering_deep_archive_access_days=180,
     ),
     opts=ResourceOptions(
         aliases=[
@@ -137,6 +143,9 @@ for data_stage in data_stages:
             kms_key_id=s3_kms_key["arn"],
             bucket_key_enabled=True,
             tags=aws_config.merged_tags({"OU": "data"}),
+            # Data lake storage is analytical cold storage: safe for archive tiers.
+            intelligent_tiering_archive_access_days=90,
+            intelligent_tiering_deep_archive_access_days=180,
         ),
         opts=ResourceOptions(
             aliases=[

--- a/src/ol_infrastructure/infrastructure/vault/__main__.py
+++ b/src/ol_infrastructure/infrastructure/vault/__main__.py
@@ -280,6 +280,9 @@ backup_bucket_config = S3BucketConfig(
     kms_key_id=vault_unseal_key["id"],  # CRITICAL: Preserve for Vault auto-unseal
     intelligent_tiering_enabled=True,
     intelligent_tiering_days=30,  # Match existing 30-day transition
+    # Vault backups are write-once cold storage: safe for archive tiers.
+    intelligent_tiering_archive_access_days=90,
+    intelligent_tiering_deep_archive_access_days=180,
     lifecycle_rules=[vault_delete_rule],  # 365-day deletion rule
     tags=aws_config.merged_tags(),
 )

--- a/tests/ol_infrastructure/components/aws/test_s3_bucket.py
+++ b/tests/ol_infrastructure/components/aws/test_s3_bucket.py
@@ -5,6 +5,8 @@ This test validates:
 2. S3BucketConfig versioning_status rejects invalid values
 3. versioning_status takes precedence over versioning_enabled
 4. OLBucket creates BucketVersioning resource with correct status
+5. S3BucketConfig archive tiering fields accept and reject valid/invalid values
+6. OLBucket creates/omits BucketIntelligentTieringConfiguration based on config
 """
 
 import asyncio
@@ -256,3 +258,233 @@ class TestOLBucketVersioningResource:
                 lambda vc: vc.get("status") if vc else None
             ),
         ).apply(check_status_precedence)
+
+
+class TestS3BucketConfigArchiveTieringValidation:
+    """Test S3BucketConfig validation for archive access tier fields."""
+
+    @staticmethod
+    def get_valid_tags():
+        return {
+            "OU": "operations",
+            "Environment": "test",
+            "Application": "test-app",
+            "Owner": "test-owner",
+        }
+
+    # --- archive_access_days ---
+
+    def test_archive_access_days_default_none(self):
+        """Archive access tier is disabled by default."""
+        config = S3BucketConfig(
+            bucket_name="test-bucket",
+            tags=self.get_valid_tags(),
+        )
+        assert config.intelligent_tiering_archive_access_days is None
+        assert config.intelligent_tiering_deep_archive_access_days is None
+
+    def test_archive_access_days_valid_minimum(self):
+        """Minimum valid value (90) is accepted."""
+        config = S3BucketConfig(
+            bucket_name="test-bucket",
+            intelligent_tiering_archive_access_days=90,
+            tags=self.get_valid_tags(),
+        )
+        assert config.intelligent_tiering_archive_access_days == 90
+
+    def test_archive_access_days_valid_maximum(self):
+        """Maximum valid value (730) is accepted."""
+        config = S3BucketConfig(
+            bucket_name="test-bucket",
+            intelligent_tiering_archive_access_days=730,
+            tags=self.get_valid_tags(),
+        )
+        assert config.intelligent_tiering_archive_access_days == 730
+
+    def test_archive_access_days_below_minimum(self):
+        """Values below 90 days are rejected."""
+        with pytest.raises(ValueError, match="must be >= 90"):
+            S3BucketConfig(
+                bucket_name="test-bucket",
+                intelligent_tiering_archive_access_days=89,
+                tags=self.get_valid_tags(),
+            )
+
+    def test_archive_access_days_above_maximum(self):
+        """Values above 730 days are rejected."""
+        with pytest.raises(ValueError, match="must be <= 730"):
+            S3BucketConfig(
+                bucket_name="test-bucket",
+                intelligent_tiering_archive_access_days=731,
+                tags=self.get_valid_tags(),
+            )
+
+    def test_archive_access_days_skipped_when_tiering_disabled(self):
+        """Validator is skipped entirely when intelligent_tiering_enabled=False."""
+        # Would normally be invalid (below minimum), but validation is
+        # skipped because intelligent tiering is disabled, so these values
+        # are irrelevant and should not raise.
+        config = S3BucketConfig(
+            bucket_name="test-bucket",
+            intelligent_tiering_enabled=False,
+            intelligent_tiering_archive_access_days=89,
+            intelligent_tiering_deep_archive_access_days=179,
+            tags=self.get_valid_tags(),
+        )
+        assert config.intelligent_tiering_archive_access_days == 89
+
+    # --- deep_archive_access_days ---
+
+    def test_deep_archive_access_days_valid_minimum(self):
+        """Minimum valid value (180) is accepted."""
+        config = S3BucketConfig(
+            bucket_name="test-bucket",
+            intelligent_tiering_archive_access_days=90,
+            intelligent_tiering_deep_archive_access_days=180,
+            tags=self.get_valid_tags(),
+        )
+        assert config.intelligent_tiering_deep_archive_access_days == 180
+
+    def test_deep_archive_access_days_valid_maximum(self):
+        """Maximum valid value (730) is accepted."""
+        config = S3BucketConfig(
+            bucket_name="test-bucket",
+            intelligent_tiering_archive_access_days=90,
+            intelligent_tiering_deep_archive_access_days=730,
+            tags=self.get_valid_tags(),
+        )
+        assert config.intelligent_tiering_deep_archive_access_days == 730
+
+    def test_deep_archive_access_days_below_minimum(self):
+        """Values below 180 days are rejected."""
+        with pytest.raises(ValueError, match="must be >= 180"):
+            S3BucketConfig(
+                bucket_name="test-bucket",
+                intelligent_tiering_deep_archive_access_days=179,
+                tags=self.get_valid_tags(),
+            )
+
+    def test_deep_archive_access_days_above_maximum(self):
+        """Values above 730 days are rejected."""
+        with pytest.raises(ValueError, match="must be <= 730"):
+            S3BucketConfig(
+                bucket_name="test-bucket",
+                intelligent_tiering_deep_archive_access_days=731,
+                tags=self.get_valid_tags(),
+            )
+
+    def test_deep_must_exceed_archive(self):
+        """deep_archive days must be strictly greater than archive_access_days."""
+        with pytest.raises(ValueError, match="must be greater than"):
+            S3BucketConfig(
+                bucket_name="test-bucket",
+                intelligent_tiering_archive_access_days=180,
+                intelligent_tiering_deep_archive_access_days=180,
+                tags=self.get_valid_tags(),
+            )
+
+    def test_deep_without_archive_is_valid(self):
+        """deep_archive_access_days can be set without archive_access_days."""
+        config = S3BucketConfig(
+            bucket_name="test-bucket",
+            intelligent_tiering_archive_access_days=None,
+            intelligent_tiering_deep_archive_access_days=180,
+            tags=self.get_valid_tags(),
+        )
+        assert config.intelligent_tiering_deep_archive_access_days == 180
+
+
+class TestOLBucketArchiveTieringResource:
+    """Test OLBucket creates/omits BucketIntelligentTieringConfiguration."""
+
+    @staticmethod
+    def get_valid_tags():
+        return {
+            "OU": "operations",
+            "Environment": "test",
+            "Application": "test-app",
+            "Owner": "test-owner",
+        }
+
+    @pulumi.runtime.test
+    def test_no_archive_tiering_by_default(self):
+        """OLBucket does not create BucketIntelligentTieringConfiguration by default."""
+        config = S3BucketConfig(
+            bucket_name="test-default-bucket",
+            tags=self.get_valid_tags(),
+        )
+        bucket = OLBucket("test-default-tiering", config=config)
+
+        def check_no_tiering_config(tiering_resource):
+            assert tiering_resource is None, (
+                "BucketIntelligentTieringConfiguration should not be created "
+                "when archive tier fields are None (default)"
+            )
+
+        return pulumi.Output.from_input(bucket.bucket_intelligent_tiering).apply(
+            check_no_tiering_config
+        )
+
+    @pulumi.runtime.test
+    def test_archive_tiering_created_when_opted_in(self):
+        """OLBucket creates BucketIntelligentTieringConfiguration when opted in."""
+        config = S3BucketConfig(
+            bucket_name="test-archive-bucket",
+            intelligent_tiering_archive_access_days=90,
+            intelligent_tiering_deep_archive_access_days=180,
+            tags=self.get_valid_tags(),
+        )
+        bucket = OLBucket("test-archive-tiering", config=config)
+
+        def check_tiering_created(tiering_resource):
+            assert tiering_resource is not None, (
+                "BucketIntelligentTieringConfiguration should be created "
+                "when archive tier days are set"
+            )
+
+        return pulumi.Output.from_input(bucket.bucket_intelligent_tiering).apply(
+            check_tiering_created
+        )
+
+    @pulumi.runtime.test
+    def test_archive_only_tiering(self):
+        """OLBucket creates config with only ARCHIVE_ACCESS when deep is None."""
+        config = S3BucketConfig(
+            bucket_name="test-archive-only-bucket",
+            intelligent_tiering_archive_access_days=90,
+            intelligent_tiering_deep_archive_access_days=None,
+            tags=self.get_valid_tags(),
+        )
+        bucket = OLBucket("test-archive-only", config=config)
+
+        def check_archive_only(tiering_resource):
+            assert tiering_resource is not None, (
+                "BucketIntelligentTieringConfiguration should be created "
+                "when archive_access_days is set"
+            )
+
+        return pulumi.Output.from_input(bucket.bucket_intelligent_tiering).apply(
+            check_archive_only
+        )
+
+    @pulumi.runtime.test
+    def test_no_tiering_config_when_tiering_disabled(self):
+        """OLBucket omits BucketIntelligentTieringConfiguration when disabled."""
+        config = S3BucketConfig(
+            bucket_name="test-no-tiering-bucket",
+            intelligent_tiering_enabled=False,
+            intelligent_tiering_archive_access_days=90,
+            intelligent_tiering_deep_archive_access_days=180,
+            tags=self.get_valid_tags(),
+        )
+        bucket = OLBucket("test-tiering-disabled", config=config)
+
+        def check_no_config(tiering_resource):
+            assert tiering_resource is None, (
+                "BucketIntelligentTieringConfiguration should not be created "
+                "when intelligent_tiering_enabled=False"
+            )
+
+        return pulumi.Output.from_input(bucket.bucket_intelligent_tiering).apply(
+            check_no_config
+        )

--- a/tests/ol_infrastructure/components/aws/test_s3_bucket.py
+++ b/tests/ol_infrastructure/components/aws/test_s3_bucket.py
@@ -488,3 +488,125 @@ class TestOLBucketArchiveTieringResource:
         return pulumi.Output.from_input(bucket.bucket_intelligent_tiering).apply(
             check_no_config
         )
+
+
+class TestS3BucketConfigAbortMPUValidation:
+    """Test S3BucketConfig validation for abort_incomplete_mpu_days."""
+
+    @staticmethod
+    def get_valid_tags():
+        return {
+            "OU": "operations",
+            "Environment": "test",
+            "Application": "test-app",
+            "Owner": "test-owner",
+        }
+
+    def test_abort_mpu_default_is_seven(self):
+        """abort_incomplete_mpu_days defaults to 7."""
+        config = S3BucketConfig(
+            bucket_name="test-bucket",
+            tags=self.get_valid_tags(),
+        )
+        assert config.abort_incomplete_mpu_days == 7
+
+    def test_abort_mpu_can_be_disabled(self):
+        """abort_incomplete_mpu_days=None disables the rule."""
+        config = S3BucketConfig(
+            bucket_name="test-bucket",
+            abort_incomplete_mpu_days=None,
+            tags=self.get_valid_tags(),
+        )
+        assert config.abort_incomplete_mpu_days is None
+
+    def test_abort_mpu_valid_custom_value(self):
+        """Any positive integer is accepted."""
+        config = S3BucketConfig(
+            bucket_name="test-bucket",
+            abort_incomplete_mpu_days=30,
+            tags=self.get_valid_tags(),
+        )
+        assert config.abort_incomplete_mpu_days == 30
+
+    def test_abort_mpu_zero_rejected(self):
+        """Zero is rejected."""
+        with pytest.raises(ValueError, match="must be >= 1"):
+            S3BucketConfig(
+                bucket_name="test-bucket",
+                abort_incomplete_mpu_days=0,
+                tags=self.get_valid_tags(),
+            )
+
+    def test_abort_mpu_negative_rejected(self):
+        """Negative values are rejected."""
+        with pytest.raises(ValueError, match="must be >= 1"):
+            S3BucketConfig(
+                bucket_name="test-bucket",
+                abort_incomplete_mpu_days=-1,
+                tags=self.get_valid_tags(),
+            )
+
+
+class TestOLBucketAbortMPUResource:
+    """Test OLBucket creates/omits AbortIncompleteMultipartUpload lifecycle rule."""
+
+    @staticmethod
+    def get_valid_tags():
+        return {
+            "OU": "operations",
+            "Environment": "test",
+            "Application": "test-app",
+            "Owner": "test-owner",
+        }
+
+    @pulumi.runtime.test
+    def test_abort_mpu_rule_present_by_default(self):
+        """OLBucket lifecycle config includes abort-MPU rule by default."""
+        config = S3BucketConfig(
+            bucket_name="test-abort-default",
+            tags=self.get_valid_tags(),
+        )
+        bucket = OLBucket("test-abort-default", config=config)
+
+        def check_abort_rule(args):
+            lifecycle, rules = args
+            assert lifecycle is not None, "BucketLifecycleConfiguration should exist"
+            rule_ids = [r.get("id") for r in (rules or [])]
+            assert "abort-incomplete-multipart-uploads" in rule_ids, (
+                f"Expected abort rule in lifecycle rules, got: {rule_ids}"
+            )
+
+        return pulumi.Output.all(
+            bucket.bucket_lifecycle,
+            bucket.bucket_lifecycle.rules.apply(
+                lambda r: [
+                    {
+                        "id": rule.get("id")
+                        if isinstance(rule, dict)
+                        else getattr(rule, "id", None)
+                    }
+                    for rule in (r or [])
+                ]
+            ),
+        ).apply(check_abort_rule)
+
+    @pulumi.runtime.test
+    def test_abort_mpu_rule_absent_when_disabled(self):
+        """OLBucket omits abort-MPU rule when abort_incomplete_mpu_days=None."""
+        config = S3BucketConfig(
+            bucket_name="test-abort-disabled",
+            intelligent_tiering_enabled=False,
+            abort_incomplete_mpu_days=None,
+            tags=self.get_valid_tags(),
+        )
+        bucket = OLBucket("test-abort-disabled", config=config)
+
+        def check_no_lifecycle(lifecycle):
+            assert lifecycle is None, (
+                "BucketLifecycleConfiguration should not exist when both "
+                "intelligent tiering and abort MPU are disabled"
+            )
+
+        return pulumi.Output.from_input(bucket.bucket_lifecycle).apply(
+            check_no_lifecycle
+        )


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Extends `OLBucket` and `S3BucketConfig` to fully configure S3 Intelligent-Tiering using both required mechanisms:

**Background:** S3 Intelligent-Tiering works via two separate, complementary APIs that must both be applied to capture maximum savings:
1. A **lifecycle rule** that transitions objects from Standard into the `INTELLIGENT_TIERING` storage class (already implemented). Once there, objects automatically cycle through Frequent Access, Infrequent Access, and Archive Instant Access tiers — all with instant retrieval and no retrieval fee.
2. A **`BucketIntelligentTieringConfiguration`** (new) that opts objects already in `INTELLIGENT_TIERING` into the optional Archive Access (~71% cheaper, minutes retrieval) and Deep Archive Access (~95% cheaper, hours retrieval) tiers. These require explicit opt-in and are not enabled by the lifecycle rule alone.

Previously `OLBucket` only applied mechanism 1. Mechanism 2 was silently missing, leaving significant savings on the table for cold objects.

**Changes:**
- Adds two new `S3BucketConfig` fields:
  - `intelligent_tiering_archive_access_days: int | None` (default: `90`) — set `None` to disable Archive Access tier
  - `intelligent_tiering_deep_archive_access_days: int | None` (default: `180`) — set `None` to disable Deep Archive Access tier
- Adds a `check_archive_tiering_config` validator enforcing AWS minimums (≥90/≥180 days, deep > archive when both set)
- Creates an `aws.s3.BucketIntelligentTieringConfiguration` child resource (`bucket_intelligent_tiering`) whenever either archive field is not `None`
- Opts `ocw-content-live-*` out of archive tiers in `ocw_site/__main__.py` via `intelligent_tiering_archive_access_days=None` — this bucket is a live CDN origin and Archive/Deep Archive retrieval latency would cause CloudFront cache-miss failures

**Opt-out pattern** for any bucket serving live content:
```python
S3BucketConfig(
    ...
    intelligent_tiering_archive_access_days=None,
    intelligent_tiering_deep_archive_access_days=None,
)
```

### How can this be tested?
- `uv run ruff check src/ol_infrastructure/components/aws/s3.py` — passes clean
- `uv run mypy src/ol_infrastructure/components/aws/s3.py` — no issues
- All pre-commit hooks passed on commit
- After merging, run `pulumi preview` on any stack that uses `OLBucket` (e.g. `applications.ocw_site.Production`). You should see a new `aws:s3:BucketIntelligentTieringConfiguration` resource planned for creation on each managed bucket (except `ocw-content-live-*` and `ocw-site-audit-logs-*` which are opted out)

### Additional Context
This is part of a broader S3 Intelligent-Tiering cost-optimization effort. A companion CLI script (`bin/enable_s3_intelligent_tiering.sh`) will be submitted separately to handle unmanaged legacy buckets that are not created via `OLBucket`.