### PR TITLE
fix: whitespace below content in AskTIM side panel

### DIFF
--- a/src/bridge/settings/openedx/mfe/slot_config/SidebarAIDrawerCoordinator.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/SidebarAIDrawerCoordinator.jsx
@@ -21,6 +21,7 @@ const SidebarAIDrawerCoordinator = ({ courseId }) => {
     const [showAIDrawer, setShowAIDrawer] = useState(false);
     const prevUnitIdRef = useRef(unitId);
     const showAIDrawerRef = useRef(false);
+    const wrapperRef = useRef(null);
 
     const messageOrigin = useMemo(() => {
         const lmsBaseUrl = getConfig().LMS_BASE_URL;
@@ -80,10 +81,108 @@ const SidebarAIDrawerCoordinator = ({ courseId }) => {
         prevUnitIdRef.current = unitId;
     }, [unitId, messageOrigin]);
 
+    /**
+     * Sync the .ai-drawer-wrapper height to the visible viewport area so the
+     * entire drawer — including the input bar at the bottom — stays inside the
+     * viewport at every scroll position.
+     *
+     * Background: .ai-drawer-wrapper uses `position: sticky; top: 1rem`. CSS
+     * sticky only engages once the parent has scrolled far enough; until then
+     * the element sits at its natural position (below the platform header and
+     * breadcrumb). With a fixed `height: calc(100dvh - 2rem)`, the panel's
+     * bottom — and therefore the chat input — falls below the viewport when
+     * the user is at the top of the page.
+     *
+     * Fix: each animation frame, compute the panel's actual top in the
+     * viewport (max(parentTop, INSET)) and set --ai-drawer-height to the
+     * remaining viewport minus the bottom inset. The effect is gated by
+     * `showAIDrawer`, `shouldDisplayFullScreen`, and a >=1025px media query so
+     * it only runs when the inline sticky layout is actually in use.
+     */
+    useEffect(() => {
+        if (typeof window === 'undefined') return undefined;
+        const wrapper = wrapperRef.current;
+        if (!wrapper) return undefined;
+
+        if (!showAIDrawer || shouldDisplayFullScreen) {
+            wrapper.style.removeProperty('--ai-drawer-height');
+            return undefined;
+        }
+
+        const INSET_PX = 16; // matches the `1rem` inset in the CSS rule
+        const MIN_HEIGHT_PX = 200;
+        const mq = window.matchMedia('(min-width: 1025px)');
+
+        let rafId = null;
+        let resizeObserver = null;
+
+        const update = () => {
+            rafId = null;
+            if (!mq.matches) {
+                wrapper.style.removeProperty('--ai-drawer-height');
+                return;
+            }
+            const parent = wrapper.parentElement;
+            if (!parent) return;
+
+            const parentRect = parent.getBoundingClientRect();
+            const stickyTop = Math.max(parentRect.top, INSET_PX);
+            const effectiveBottom = Math.min(window.innerHeight - INSET_PX, parentRect.bottom);
+            const available = effectiveBottom - stickyTop;
+            wrapper.style.setProperty(
+                '--ai-drawer-height',
+                `${Math.max(MIN_HEIGHT_PX, available)}px`,
+            );
+        };
+
+        const schedule = () => {
+            if (rafId == null) {
+                rafId = window.requestAnimationFrame(update);
+            }
+        };
+
+        const attach = () => {
+            if (mq.matches) {
+                window.addEventListener('scroll', schedule, { passive: true });
+                window.addEventListener('resize', schedule);
+                if (!resizeObserver && wrapper.parentElement) {
+                    resizeObserver = new ResizeObserver(schedule);
+                    resizeObserver.observe(wrapper.parentElement);
+                }
+            } else {
+                detach();
+            }
+            schedule();
+        };
+
+        const detach = () => {
+            window.removeEventListener('scroll', schedule);
+            window.removeEventListener('resize', schedule);
+            if (resizeObserver) {
+                resizeObserver.disconnect();
+                resizeObserver = null;
+            }
+            if (rafId != null) {
+                window.cancelAnimationFrame(rafId);
+                rafId = null;
+            }
+            wrapper.style.removeProperty('--ai-drawer-height');
+        };
+
+        mq.addEventListener('change', attach);
+        attach();
+
+        return () => {
+            mq.removeEventListener('change', attach);
+            detach();
+        };
+    }, [showAIDrawer, shouldDisplayFullScreen]);
+
     return (
         <>
             {currentSidebar !== null && <Sidebar />}
             <div
+                ref={wrapperRef}
                 className={`ai-drawer-wrapper ml-0 ml-xl-4 align-top ${
                     shouldDisplayFullScreen ? 'ai-drawer-wrapper-fullscreen' : ''
                 } ${showAIDrawer ? '' : 'd-none'}`}

--- a/src/bridge/settings/openedx/mfe/slot_config/SidebarAIDrawerCoordinator.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/SidebarAIDrawerCoordinator.jsx
@@ -92,7 +92,6 @@ const SidebarAIDrawerCoordinator = ({ courseId }) => {
         }
 
         const INSET_PX = 16; // matches the `1rem` inset in the CSS rule
-        const MIN_HEIGHT_PX = 200;
         const mq = window.matchMedia('(min-width: 1025px)');
 
         let rafId = null;
@@ -113,7 +112,7 @@ const SidebarAIDrawerCoordinator = ({ courseId }) => {
 
             wrapper.style.setProperty(
                 '--ai-drawer-height',
-                `${Math.max(MIN_HEIGHT_PX, available)}px`,
+                `${Math.max(0, available)}px`,
             );
         };
 

--- a/src/bridge/settings/openedx/mfe/slot_config/SidebarAIDrawerCoordinator.jsx
+++ b/src/bridge/settings/openedx/mfe/slot_config/SidebarAIDrawerCoordinator.jsx
@@ -14,7 +14,7 @@ const AI_DRAWER_MESSAGE_TYPES = [
 const SidebarAIDrawerCoordinator = ({ courseId }) => {
     const contextValue = useContext(SidebarContext);
     const currentSidebar = contextValue?.currentSidebar ?? null;
-    const toggleSidebar = contextValue?.toggleSidebar ?? (() => {});
+    const toggleSidebar = contextValue?.toggleSidebar ?? (() => { });
     const shouldDisplayFullScreen = contextValue?.shouldDisplayFullScreen ?? false;
     const unitId = contextValue?.unitId ?? null;
 
@@ -81,28 +81,10 @@ const SidebarAIDrawerCoordinator = ({ courseId }) => {
         prevUnitIdRef.current = unitId;
     }, [unitId, messageOrigin]);
 
-    /**
-     * Sync the .ai-drawer-wrapper height to the visible viewport area so the
-     * entire drawer — including the input bar at the bottom — stays inside the
-     * viewport at every scroll position.
-     *
-     * Background: .ai-drawer-wrapper uses `position: sticky; top: 1rem`. CSS
-     * sticky only engages once the parent has scrolled far enough; until then
-     * the element sits at its natural position (below the platform header and
-     * breadcrumb). With a fixed `height: calc(100dvh - 2rem)`, the panel's
-     * bottom — and therefore the chat input — falls below the viewport when
-     * the user is at the top of the page.
-     *
-     * Fix: each animation frame, compute the panel's actual top in the
-     * viewport (max(parentTop, INSET)) and set --ai-drawer-height to the
-     * remaining viewport minus the bottom inset. The effect is gated by
-     * `showAIDrawer`, `shouldDisplayFullScreen`, and a >=1025px media query so
-     * it only runs when the inline sticky layout is actually in use.
-     */
+    // Keeps --ai-drawer-height in sync with the actual visible area on each
+    // scroll/resize so the sticky drawer never overflows the viewport bottom.
     useEffect(() => {
-        if (typeof window === 'undefined') return undefined;
         const wrapper = wrapperRef.current;
-        if (!wrapper) return undefined;
 
         if (!showAIDrawer || shouldDisplayFullScreen) {
             wrapper.style.removeProperty('--ai-drawer-height');
@@ -124,11 +106,11 @@ const SidebarAIDrawerCoordinator = ({ courseId }) => {
             }
             const parent = wrapper.parentElement;
             if (!parent) return;
-
             const parentRect = parent.getBoundingClientRect();
             const stickyTop = Math.max(parentRect.top, INSET_PX);
             const effectiveBottom = Math.min(window.innerHeight - INSET_PX, parentRect.bottom);
             const available = effectiveBottom - stickyTop;
+
             wrapper.style.setProperty(
                 '--ai-drawer-height',
                 `${Math.max(MIN_HEIGHT_PX, available)}px`,
@@ -149,10 +131,10 @@ const SidebarAIDrawerCoordinator = ({ courseId }) => {
                     resizeObserver = new ResizeObserver(schedule);
                     resizeObserver.observe(wrapper.parentElement);
                 }
+                schedule();
             } else {
                 detach();
             }
-            schedule();
         };
 
         const detach = () => {
@@ -183,8 +165,7 @@ const SidebarAIDrawerCoordinator = ({ courseId }) => {
             {currentSidebar !== null && <Sidebar />}
             <div
                 ref={wrapperRef}
-                className={`ai-drawer-wrapper ml-0 ml-xl-4 align-top ${
-                    shouldDisplayFullScreen ? 'ai-drawer-wrapper-fullscreen' : ''
+                className={`ai-drawer-wrapper ml-0 ml-xl-4 align-top ${shouldDisplayFullScreen ? 'ai-drawer-wrapper-fullscreen' : ''
                 } ${showAIDrawer ? '' : 'd-none'}`}
                 aria-hidden={!showAIDrawer}
             >

--- a/src/bridge/settings/openedx/mfe/slot_config/mitxonline-styles.scss
+++ b/src/bridge/settings/openedx/mfe/slot_config/mitxonline-styles.scss
@@ -234,6 +234,7 @@
 
   @media (min-width: 1025px) {
     top: 1rem;
+    height: calc(100vh - 2rem);
     height: var(--ai-drawer-height, calc(100dvh - 2rem));
   }
 

--- a/src/bridge/settings/openedx/mfe/slot_config/mitxonline-styles.scss
+++ b/src/bridge/settings/openedx/mfe/slot_config/mitxonline-styles.scss
@@ -232,9 +232,9 @@
   height: 100vh;
   height: 100dvh;
 
-  // On larger screens, use a smaller height
   @media (min-width: 1025px) {
-    height: 70vh;
+    top: 1rem;
+    height: var(--ai-drawer-height, calc(100dvh - 2rem));
   }
 
   &.ai-drawer-wrapper-fullscreen {


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11452

### Description (What does it do?)
The AskTIM panel is using the full height of the current visible page and there is no large empty area below the suggested questions.

### Screenshots (if appropriate):
https://www.loom.com/share/c4ef0024ca2249f2a0aeb5743c127d30
<img width="1719" height="1014" alt="Screenshot 2026-05-25 at 5 48 47 PM" src="https://github.com/user-attachments/assets/6fb12fd5-4c97-44f6-b074-a349171b42a9" />


### How can this be tested?
To test this feature locally:

1. **Set up Tutor instance locally** as described in [this guide](https://docs.google.com/document/d/1kt_8VspC_SSU5zpmw8kyRQPWQaPtEbzTcDJeKYNBOfE/edit?tab=t.0)

2. **Mount frontend-app-learning locally**

3. **Enable AI Chatbot** by following the configuration steps in the [ol_openedx_chat plugin documentation](https://github.com/mitodl/open-edx-plugins/tree/main/src/ol_openedx_chat)

4. The paths assume both directories are at the same level. If they're not siblings, adjust ../ as needed to navigate to the correct parent directory.

   ```bash
   cd smoot-design && yarn install && npm run build && npm pack && cp mitodl-smoot-design-*.tgz ../frontend-app-learning/ && cd ../frontend-app-learning && rm -rf package && tar -xvzf mitodl-smoot-design-*.tgz && mkdir -p public/static/smoot-design && cp package/dist/bundles/* public/static/smoot-design/
   ```
   ```bash
    cd ../frontend-app-learning && npm start
   ```

5. **Add AIDrawerManagerSidebar component and SidebarAIDrawerCoordinator**: Copy `AiDrawerManagerSidebar.jsx`  and `SidebarAIDrawerCoordinator` to the root of your local `frontend-app-learning` repository (alongside the `.env` file)

6. **Update configuration**: Update `env.config.jsx` with the content from `learning-mfe-config.env.jsx` of this repo.
7. Add ENABLE_AI_DRAWER_SLOT = 'true'  in .env.development file.
8. Update Bundle path with const BUNDLE_PATH =  '/static/smoot-design/aiDrawerManager.es.js';
9. Update your mitxonline-styles.scss file with the scss of the file in this pr. src/bridge/settings/openedx/mfe/slot_config/mitxonline-styles.scss

Now, on clicking the AskTim Button, it will open the AskTim Chat inside the Notifications/Discussions sidebar slot and on scrolling it will adjust its height automatically and remain on the top always. 
