### PR TITLE
chore: add OCW_EXTRA_THEMES_BASE_URLS env var

### DIFF
--- a/src/ol_infrastructure/applications/ocw_studio/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/ocw_studio/Pulumi.Production.yaml
@@ -27,6 +27,7 @@ config:
     OCW_COURSE_STARTER_SLUG: ocw-course-v2
     OCW_EXTRA_COURSE_THEMES: ocw-course-v3
     OCW_EXTRA_THEMES_GTM_IDS: '{"ocw-course-v3": "GTM-NMJ2CT6T&gtm_auth=TVdLeYWP6BLCRsILCebafA&gtm_preview=env-1&gtm_cookies_win=x"}'
+    OCW_EXTRA_THEMES_BASE_URLS: '{"ocw-course-v3": "/courses/o"}'
     OCW_GTM_ACCOUNT_ID: GTM-NMQZ25T
     OCW_HUGO_THEMES_SENTRY_DSN: 'https://eee58f41dda54d2b814296e12dced4b7@o48788.ingest.sentry.io/5304953'
     OCW_IMPORT_STARTER_SLUG: ocw-course

--- a/src/ol_infrastructure/applications/ocw_studio/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/ocw_studio/Pulumi.QA.yaml
@@ -30,6 +30,7 @@ config:
     OCW_COURSE_STARTER_SLUG: ocw-course-v2
     OCW_EXTRA_COURSE_THEMES: ocw-course-v3
     OCW_EXTRA_THEMES_GTM_IDS: '{"ocw-course-v3": "GTM-NMJ2CT6T&gtm_auth=Rl-qxbJnD78rPEq1OFQLow&gtm_preview=env-3&gtm_cookies_win=x"}'
+    OCW_EXTRA_THEMES_BASE_URLS: '{"ocw-course-v3": "/courses/o"}'
     OCW_GTM_ACCOUNT_ID: GTM-PJMJGF6
     OCW_HUGO_THEMES_SENTRY_DSN: 'https://eee58f41dda54d2b814296e12dced4b7@o48788.ingest.sentry.io/5304953'
     OCW_IMPORT_STARTER_SLUG: ocw-course


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11124

### Description (What does it do?)
Adds the OCW_EXTRA_THEMES_BASE_URLS env var introduced in https://github.com/mitodl/ocw-studio/pull/3032

