### PR TITLE
Add MITx Online production webhook access token

### DIFF
--- a/src/bridge/secrets/edxapp/mitxonline.production.yaml
+++ b/src/bridge/secrets/edxapp/mitxonline.production.yaml
@@ -29,18 +29,22 @@ meilisearch_api_key: ENC[AES256_GCM,data:l5RBU6uhMukaij08MVRNGTDX3poTyQ2MCkwsEtR
 typesense_bootstrap_key: ENC[AES256_GCM,data:ZvaZh5CFQxxt/fvRLS22Tk5iB88EuBPk03YBOp0b/Msw+n2bdeE9vpMn+2SiKTp9RVc0/jie3ewnXvZwdgNR6w==,iv:XEbPsyfvAws9qgjTla0ay5nPIDqbFaZ1vzv88Hd2qKE=,tag:ZZADeCeFGidnyo1AqNFn7A==,type:str]
 webhook_access_token: ENC[AES256_GCM,data:eLkLbYLGLXY4mVCIFx5XsmBGcN7XTV4j4CCZUeBO,iv:V23ZQ8dqG8WwPuCo4h1F5VarvUXPNMHvRAXHrOnGjLM=,tag:l6nHwfJCJMz2FMIrvbu7Zw==,type:str]
 sops:
+  kms:
+  - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
+    aws_profile: ""
+    created_at: "2026-02-23T16:23:32Z"
+    enc: AQICAHi3FG4qowC3UzOLWOAA4Y9/RTwqKjovG3wyVVYDxkR+zAGQRhidTTSRdqHrmAw6VSuhAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMKKLTPX27vQVm6+QfAgEQgDuvVEh5I4Z00IEVT9bS9viXvGsITixK4xLE0h187Lsu9cZ0uZIXq8NwJHk9IwrDJ68iM8sWCjXBsd5N/w==
+  gcp_kms: []
+  azure_kv: []
   hc_vault:
   - created_at: "2026-02-23T16:23:32Z"
     enc: vault:v1:dENz887tU/JbibzTNM6uvzdGc/61Q6p+5uMZkgLO9Ql5Myx5ka2T9JnDxH5xQdblVrH7bZ0hf8WO0TDx
     engine_path: infrastructure
     key_name: sops
     vault_address: https://vault-production.odl.mit.edu
-  kms:
-  - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
-    aws_profile: ""
-    created_at: "2026-02-23T16:23:32Z"
-    enc: AQICAHi3FG4qowC3UzOLWOAA4Y9/RTwqKjovG3wyVVYDxkR+zAGQRhidTTSRdqHrmAw6VSuhAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMKKLTPX27vQVm6+QfAgEQgDuvVEh5I4Z00IEVT9bS9viXvGsITixK4xLE0h187Lsu9cZ0uZIXq8NwJHk9IwrDJ68iM8sWCjXBsd5N/w==
+  age: []
   lastmodified: "2026-05-26T15:29:10Z"
   mac: ENC[AES256_GCM,data:bLz9WiD+2CEvrzX3nu3b6QEuUKAmryZguEw1wj4YfZ0BfgpSMB30QuIAt37JCcOldFoRHZJLFTMfUFtMXiPx9PZJAxVvTSvlDSTwKh9+RXfdnqM9Xty3PjCkP15g5YksWrjiN5c7F4Xusr/itbddefiEqAYfo09FTlOjLRRyt/c=,iv:5IDMUbe3ldy+s3Phtg6Yh2VC0HjVyNXdEfYb1C2w+wE=,tag:JC5YlhwVd+HJUHq7D+Alzw==,type:str]
+  pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/src/bridge/secrets/edxapp/mitxonline.production.yaml
+++ b/src/bridge/secrets/edxapp/mitxonline.production.yaml
@@ -27,23 +27,20 @@ github_access_token: ENC[AES256_GCM,data:hg67iYujwEJsKBIdg6DL+E+xFS9wQn0mCUuf922
 meilisearch_master_key: ENC[AES256_GCM,data:/3dHEF7G8qLExISc8d2QTLb38QSrHJhPEvUID7zqg7dS99m7ZDI0HSuCNlXh+AHA2ye899LxLutNpoyl5Z08JQ==,iv:2Z+FoYp/qYxHSU/fciR5p0Pkl0RMKJTFa3bZgLp0ZGQ=,tag:pBCnqjnx9P+0NmMDoXI7vA==,type:str]
 meilisearch_api_key: ENC[AES256_GCM,data:l5RBU6uhMukaij08MVRNGTDX3poTyQ2MCkwsEtRfmS3wpOihbtK03zHWq0fDV4gPRCSIIcV/JAULTQ4ieuYI5Q==,iv:FMbGjqNO6wes4WwAAfMY2njUajKPt9bcf9FWgnTBa54=,tag:vUS14fxXWK9f/BZAzGxn4w==,type:str]
 typesense_bootstrap_key: ENC[AES256_GCM,data:ZvaZh5CFQxxt/fvRLS22Tk5iB88EuBPk03YBOp0b/Msw+n2bdeE9vpMn+2SiKTp9RVc0/jie3ewnXvZwdgNR6w==,iv:XEbPsyfvAws9qgjTla0ay5nPIDqbFaZ1vzv88Hd2qKE=,tag:ZZADeCeFGidnyo1AqNFn7A==,type:str]
+webhook_access_token: ENC[AES256_GCM,data:eLkLbYLGLXY4mVCIFx5XsmBGcN7XTV4j4CCZUeBO,iv:V23ZQ8dqG8WwPuCo4h1F5VarvUXPNMHvRAXHrOnGjLM=,tag:l6nHwfJCJMz2FMIrvbu7Zw==,type:str]
 sops:
-  kms:
-  - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
-    created_at: "2026-02-23T16:23:32Z"
-    enc: AQICAHi3FG4qowC3UzOLWOAA4Y9/RTwqKjovG3wyVVYDxkR+zAGQRhidTTSRdqHrmAw6VSuhAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMKKLTPX27vQVm6+QfAgEQgDuvVEh5I4Z00IEVT9bS9viXvGsITixK4xLE0h187Lsu9cZ0uZIXq8NwJHk9IwrDJ68iM8sWCjXBsd5N/w==
-    aws_profile: ""
-  gcp_kms: []
-  azure_kv: []
   hc_vault:
-  - vault_address: https://vault-production.odl.mit.edu
+  - created_at: "2026-02-23T16:23:32Z"
+    enc: vault:v1:dENz887tU/JbibzTNM6uvzdGc/61Q6p+5uMZkgLO9Ql5Myx5ka2T9JnDxH5xQdblVrH7bZ0hf8WO0TDx
     engine_path: infrastructure
     key_name: sops
+    vault_address: https://vault-production.odl.mit.edu
+  kms:
+  - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
+    aws_profile: ""
     created_at: "2026-02-23T16:23:32Z"
-    enc: vault:v1:dENz887tU/JbibzTNM6uvzdGc/61Q6p+5uMZkgLO9Ql5Myx5ka2T9JnDxH5xQdblVrH7bZ0hf8WO0TDx
-  age: []
-  lastmodified: "2026-04-08T17:47:26Z"
-  mac: ENC[AES256_GCM,data:XVHqjKAD4gWJXQMyrD77vdtpsZAnvQWmcaH4sid+P5M1UdIhFjNvVaFP7wGb1Ve9r6moxaE1rsQ/lX2iYabTEu690y0fnU75ZCZ+wO6WqvBCAakpyHdc15JGa4y0NvNeM6Cint9f250iUnFcVprtmJ7X6yYj61/cae0eGF8/st4=,iv:6IIwZ5rdbIQHjqraYEgPsuwsYF06zif7KGZxQoM36fg=,tag:Ws5SOvxvLdVNF3NpvJ2Lfg==,type:str]
-  pgp: []
+    enc: AQICAHi3FG4qowC3UzOLWOAA4Y9/RTwqKjovG3wyVVYDxkR+zAGQRhidTTSRdqHrmAw6VSuhAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMKKLTPX27vQVm6+QfAgEQgDuvVEh5I4Z00IEVT9bS9viXvGsITixK4xLE0h187Lsu9cZ0uZIXq8NwJHk9IwrDJ68iM8sWCjXBsd5N/w==
+  lastmodified: "2026-05-26T15:29:10Z"
+  mac: ENC[AES256_GCM,data:bLz9WiD+2CEvrzX3nu3b6QEuUKAmryZguEw1wj4YfZ0BfgpSMB30QuIAt37JCcOldFoRHZJLFTMfUFtMXiPx9PZJAxVvTSvlDSTwKh9+RXfdnqM9Xty3PjCkP15g5YksWrjiN5c7F4Xusr/itbddefiEqAYfo09FTlOjLRRyt/c=,iv:5IDMUbe3ldy+s3Phtg6Yh2VC0HjVyNXdEfYb1C2w+wE=,tag:JC5YlhwVd+HJUHq7D+Alzw==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.1

--- a/src/ol_infrastructure/applications/edxapp/k8s_secrets.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_secrets.py
@@ -448,8 +448,11 @@ def create_k8s_secrets(
     else:
         typesense_secret = None
 
-    # Webhook tokens secret (conditional - only for mitxonline QA for now)
-    if stack_info.env_prefix == "mitxonline" and stack_info.env_suffix == "qa":
+    # Webhook tokens secret (conditional - only for mitxonline QA/Production)
+    if stack_info.env_prefix == "mitxonline" and stack_info.env_suffix in [
+        "qa",
+        "production",
+    ]:
         webhook_tokens_secret = builder.create_static(
             name="webhook-tokens",
             resource_name="webhook-tokens-secret",
@@ -498,7 +501,8 @@ def create_k8s_secrets(
         if stack_info.env_prefix == "mitxonline"
         else None,
         webhook_tokens_secret_name=webhook_tokens_secret_name
-        if stack_info.env_prefix == "mitxonline" and stack_info.env_suffix == "qa"
+        if stack_info.env_prefix == "mitxonline"
+        and stack_info.env_suffix in ["qa", "production"]
         else None,
         meilisearch_secret_name=meilisearch_secret_name,
         typesense_secret_name=typesense_secret_name,


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/9693

### Description (What does it do?)
Adds the MITx Online production Open edX webhook access token to the edxapp SOPS secrets file and enables the webhook token Kubernetes/Vault secret for MITx Online Production in addition to QA.

### How can this be tested?
- Confirm `sops -d src/bridge/secrets/edxapp/mitxonline.production.yaml` includes `webhook_access_token`.
- Confirm `uv run pre-commit run --files src/bridge/secrets/edxapp/mitxonline.production.yaml src/ol_infrastructure/applications/edxapp/k8s_secrets.py` passes.
- Confirm `pulumi preview --stack mitxonline.Production --json` from `src/ol_infrastructure/applications/edxapp` creates the `17-webhook-tokens-yaml` VaultStaticSecret for production.

### Additional Context
Pulumi preview was run with `EDXAPP_DOCKER_IMAGE_DIGEST` set from the current stack state.