### PR TITLE
Backfill Pulumi Changes for OCW Site S3 Backup

### DIFF
--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -681,6 +681,241 @@ test_offline_bucket = OLBucket(
     ),
 )
 
+if stack_info.env_suffix == "production":
+    draft_bucket_replication_role_name = "s3crr_role_for_ocw-content-draft-production"
+    draft_bucket_replication_policy_name = (
+        "s3crr_for_ocw-content-draft-production_8da254"
+    )
+    draft_bucket_replication_policy_arn = (
+        f"arn:aws:iam::{aws_account.account_id}:policy/service-role/"
+        f"{draft_bucket_replication_policy_name}"
+    )
+    draft_bucket_replication_role = iam.Role(
+        "ocw-content-draft-production-replication-role",
+        name=draft_bucket_replication_role_name,
+        path="/service-role/",
+        assume_role_policy=json.dumps(
+            {
+                "Version": IAM_POLICY_VERSION,
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {"Service": "s3.amazonaws.com"},
+                        "Action": "sts:AssumeRole",
+                    }
+                ],
+            }
+        ),
+        opts=ResourceOptions(import_=draft_bucket_replication_role_name),
+    )
+    draft_bucket_replication_policy = iam.Policy(
+        "ocw-content-draft-production-replication-policy",
+        name=draft_bucket_replication_policy_name,
+        path="/service-role/",
+        policy=json.dumps(
+            {
+                "Version": IAM_POLICY_VERSION,
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "s3:ListBucket",
+                            "s3:GetReplicationConfiguration",
+                            "s3:GetObjectVersionForReplication",
+                            "s3:GetObjectVersionAcl",
+                            "s3:GetObjectVersionTagging",
+                            "s3:GetObjectRetention",
+                            "s3:GetObjectLegalHold",
+                        ],
+                        "Resource": [
+                            draft_bucket_arn,
+                            f"{draft_bucket_arn}/*",
+                            draft_backup_bucket_arn,
+                            f"{draft_backup_bucket_arn}/*",
+                        ],
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "s3:ReplicateObject",
+                            "s3:ReplicateDelete",
+                            "s3:ReplicateTags",
+                            "s3:ObjectOwnerOverrideToBucketOwner",
+                        ],
+                        "Resource": [
+                            f"{draft_bucket_arn}/*",
+                            f"{draft_backup_bucket_arn}/*",
+                        ],
+                    },
+                ],
+            }
+        ),
+        opts=ResourceOptions(import_=draft_bucket_replication_policy_arn),
+    )
+    draft_bucket_replication_policy_attachment = iam.RolePolicyAttachment(
+        "ocw-content-draft-production-replication-policy-attachment",
+        role=draft_bucket_replication_role.name,
+        policy_arn=draft_bucket_replication_policy.arn,
+        opts=ResourceOptions(
+            import_=(
+                f"{draft_bucket_replication_role_name}/"
+                f"{draft_bucket_replication_policy_arn}"
+            ),
+            depends_on=[
+                draft_bucket_replication_role,
+                draft_bucket_replication_policy,
+            ],
+        ),
+    )
+
+    draft_bucket_replication = s3.BucketReplicationConfig(
+        "ocw-content-draft-production-replication",
+        bucket=draft_bucket.bucket_v2.id,
+        role=draft_bucket_replication_role.arn,
+        rules=[
+            s3.BucketReplicationConfigRuleArgs(
+                id="OCWContentDraftProductionBackupRule",
+                priority=0,
+                filter=s3.BucketReplicationConfigRuleFilterArgs(),
+                status="Enabled",
+                destination=s3.BucketReplicationConfigRuleDestinationArgs(
+                    bucket=draft_backup_bucket.bucket_v2.arn,
+                ),
+                delete_marker_replication=s3.BucketReplicationConfigRuleDeleteMarkerReplicationArgs(
+                    status="Disabled"
+                ),
+            )
+        ],
+        opts=ResourceOptions(
+            import_=draft_bucket_name,
+            depends_on=[
+                resource
+                for resource in [
+                    draft_bucket.bucket_versioning,
+                    draft_backup_bucket.bucket_versioning,
+                    draft_bucket_replication_policy_attachment,
+                ]
+                if resource is not None
+            ],
+        ),
+    )
+
+    live_bucket_replication_role_name = "s3crr_role_for_ocw-content-live-production"
+    live_bucket_replication_policy_name = "s3crr_for_ocw-content-live-production_565f2a"
+    live_bucket_replication_policy_arn = (
+        f"arn:aws:iam::{aws_account.account_id}:policy/service-role/"
+        f"{live_bucket_replication_policy_name}"
+    )
+    live_bucket_replication_role = iam.Role(
+        "ocw-content-live-production-replication-role",
+        name=live_bucket_replication_role_name,
+        path="/service-role/",
+        assume_role_policy=json.dumps(
+            {
+                "Version": IAM_POLICY_VERSION,
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {"Service": "s3.amazonaws.com"},
+                        "Action": "sts:AssumeRole",
+                    }
+                ],
+            }
+        ),
+        opts=ResourceOptions(import_=live_bucket_replication_role_name),
+    )
+    live_bucket_replication_policy = iam.Policy(
+        "ocw-content-live-production-replication-policy",
+        name=live_bucket_replication_policy_name,
+        path="/service-role/",
+        policy=json.dumps(
+            {
+                "Version": IAM_POLICY_VERSION,
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "s3:ListBucket",
+                            "s3:GetReplicationConfiguration",
+                            "s3:GetObjectVersionForReplication",
+                            "s3:GetObjectVersionAcl",
+                            "s3:GetObjectVersionTagging",
+                            "s3:GetObjectRetention",
+                            "s3:GetObjectLegalHold",
+                        ],
+                        "Resource": [
+                            live_bucket_arn,
+                            f"{live_bucket_arn}/*",
+                            live_backup_bucket_arn,
+                            f"{live_backup_bucket_arn}/*",
+                        ],
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "s3:ReplicateObject",
+                            "s3:ReplicateDelete",
+                            "s3:ReplicateTags",
+                            "s3:ObjectOwnerOverrideToBucketOwner",
+                        ],
+                        "Resource": [
+                            f"{live_bucket_arn}/*",
+                            f"{live_backup_bucket_arn}/*",
+                        ],
+                    },
+                ],
+            }
+        ),
+        opts=ResourceOptions(import_=live_bucket_replication_policy_arn),
+    )
+    live_bucket_replication_policy_attachment = iam.RolePolicyAttachment(
+        "ocw-content-live-production-replication-policy-attachment",
+        role=live_bucket_replication_role.name,
+        policy_arn=live_bucket_replication_policy.arn,
+        opts=ResourceOptions(
+            import_=(
+                f"{live_bucket_replication_role_name}/"
+                f"{live_bucket_replication_policy_arn}"
+            ),
+            depends_on=[
+                live_bucket_replication_role,
+                live_bucket_replication_policy,
+            ],
+        ),
+    )
+
+    live_bucket_replication = s3.BucketReplicationConfig(
+        "ocw-content-live-production-replication",
+        bucket=live_bucket.bucket_v2.id,
+        role=live_bucket_replication_role.arn,
+        rules=[
+            s3.BucketReplicationConfigRuleArgs(
+                id="OCWContentLiveProductionBackupRule",
+                priority=0,
+                filter=s3.BucketReplicationConfigRuleFilterArgs(),
+                status="Enabled",
+                destination=s3.BucketReplicationConfigRuleDestinationArgs(
+                    bucket=live_backup_bucket.bucket_v2.arn,
+                ),
+                delete_marker_replication=s3.BucketReplicationConfigRuleDeleteMarkerReplicationArgs(
+                    status="Disabled"
+                ),
+            )
+        ],
+        opts=ResourceOptions(
+            import_=live_bucket_name,
+            depends_on=[
+                resource
+                for resource in [
+                    live_bucket.bucket_versioning,
+                    live_backup_bucket.bucket_versioning,
+                    live_bucket_replication_policy_attachment,
+                ]
+                if resource is not None
+            ],
+        ),
+    )
+
 policy_description = (
     "Access controls for the CDN to be able to read from the"
     f"{stack_info.env_suffix} website buckets"

--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -682,238 +682,151 @@ test_offline_bucket = OLBucket(
 )
 
 if stack_info.env_suffix == "production":
-    draft_bucket_replication_role_name = "s3crr_role_for_ocw-content-draft-production"
-    draft_bucket_replication_policy_name = (
-        "s3crr_for_ocw-content-draft-production_8da254"
-    )
-    draft_bucket_replication_policy_arn = (
-        f"arn:aws:iam::{aws_account.account_id}:policy/service-role/"
-        f"{draft_bucket_replication_policy_name}"
-    )
-    draft_bucket_replication_role = iam.Role(
-        "ocw-content-draft-production-replication-role",
-        name=draft_bucket_replication_role_name,
-        path="/service-role/",
-        assume_role_policy=json.dumps(
-            {
-                "Version": IAM_POLICY_VERSION,
-                "Statement": [
-                    {
-                        "Effect": "Allow",
-                        "Principal": {"Service": "s3.amazonaws.com"},
-                        "Action": "sts:AssumeRole",
-                    }
-                ],
-            }
-        ),
-        opts=ResourceOptions(import_=draft_bucket_replication_role_name),
-    )
-    draft_bucket_replication_policy = iam.Policy(
-        "ocw-content-draft-production-replication-policy",
-        name=draft_bucket_replication_policy_name,
-        path="/service-role/",
-        policy=json.dumps(
-            {
-                "Version": IAM_POLICY_VERSION,
-                "Statement": [
-                    {
-                        "Effect": "Allow",
-                        "Action": [
-                            "s3:ListBucket",
-                            "s3:GetReplicationConfiguration",
-                            "s3:GetObjectVersionForReplication",
-                            "s3:GetObjectVersionAcl",
-                            "s3:GetObjectVersionTagging",
-                            "s3:GetObjectRetention",
-                            "s3:GetObjectLegalHold",
-                        ],
-                        "Resource": [
-                            draft_bucket_arn,
-                            f"{draft_bucket_arn}/*",
-                            draft_backup_bucket_arn,
-                            f"{draft_backup_bucket_arn}/*",
-                        ],
-                    },
-                    {
-                        "Effect": "Allow",
-                        "Action": [
-                            "s3:ReplicateObject",
-                            "s3:ReplicateDelete",
-                            "s3:ReplicateTags",
-                            "s3:ObjectOwnerOverrideToBucketOwner",
-                        ],
-                        "Resource": [
-                            f"{draft_bucket_arn}/*",
-                            f"{draft_backup_bucket_arn}/*",
-                        ],
-                    },
-                ],
-            }
-        ),
-        opts=ResourceOptions(import_=draft_bucket_replication_policy_arn),
-    )
-    draft_bucket_replication_policy_attachment = iam.RolePolicyAttachment(
-        "ocw-content-draft-production-replication-policy-attachment",
-        role=draft_bucket_replication_role.name,
-        policy_arn=draft_bucket_replication_policy.arn,
-        opts=ResourceOptions(
-            import_=(
-                f"{draft_bucket_replication_role_name}/"
-                f"{draft_bucket_replication_policy_arn}"
+    def setup_bucket_replication(
+        source_bucket,
+        destination_bucket,
+        *,
+        source_bucket_name,
+        source_bucket_arn,
+        destination_bucket_arn,
+        resource_prefix,
+        role_name,
+        policy_name,
+        rule_id,
+    ):
+        policy_arn = (
+            f"arn:aws:iam::{aws_account.account_id}:policy/service-role/{policy_name}"
+        )
+        replication_role = iam.Role(
+            f"{resource_prefix}-replication-role",
+            name=role_name,
+            path="/service-role/",
+            assume_role_policy=json.dumps(
+                {
+                    "Version": IAM_POLICY_VERSION,
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {"Service": "s3.amazonaws.com"},
+                            "Action": "sts:AssumeRole",
+                        }
+                    ],
+                }
             ),
-            depends_on=[
-                draft_bucket_replication_role,
-                draft_bucket_replication_policy,
-            ],
-        ),
-    )
-
-    draft_bucket_replication = s3.BucketReplicationConfig(
-        "ocw-content-draft-production-replication",
-        bucket=draft_bucket.bucket_v2.id,
-        role=draft_bucket_replication_role.arn,
-        rules=[
-            s3.BucketReplicationConfigRuleArgs(
-                id="OCWContentDraftProductionBackupRule",
-                priority=0,
-                filter=s3.BucketReplicationConfigRuleFilterArgs(),
-                status="Enabled",
-                destination=s3.BucketReplicationConfigRuleDestinationArgs(
-                    bucket=draft_backup_bucket.bucket_v2.arn,
-                ),
-                delete_marker_replication=s3.BucketReplicationConfigRuleDeleteMarkerReplicationArgs(
-                    status="Disabled"
-                ),
-            )
-        ],
-        opts=ResourceOptions(
-            import_=draft_bucket_name,
-            depends_on=[
-                resource
-                for resource in [
-                    draft_bucket.bucket_versioning,
-                    draft_backup_bucket.bucket_versioning,
-                    draft_bucket_replication_policy_attachment,
-                ]
-                if resource is not None
-            ],
-        ),
-    )
-
-    live_bucket_replication_role_name = "s3crr_role_for_ocw-content-live-production"
-    live_bucket_replication_policy_name = "s3crr_for_ocw-content-live-production_565f2a"
-    live_bucket_replication_policy_arn = (
-        f"arn:aws:iam::{aws_account.account_id}:policy/service-role/"
-        f"{live_bucket_replication_policy_name}"
-    )
-    live_bucket_replication_role = iam.Role(
-        "ocw-content-live-production-replication-role",
-        name=live_bucket_replication_role_name,
-        path="/service-role/",
-        assume_role_policy=json.dumps(
-            {
-                "Version": IAM_POLICY_VERSION,
-                "Statement": [
-                    {
-                        "Effect": "Allow",
-                        "Principal": {"Service": "s3.amazonaws.com"},
-                        "Action": "sts:AssumeRole",
-                    }
-                ],
-            }
-        ),
-        opts=ResourceOptions(import_=live_bucket_replication_role_name),
-    )
-    live_bucket_replication_policy = iam.Policy(
-        "ocw-content-live-production-replication-policy",
-        name=live_bucket_replication_policy_name,
-        path="/service-role/",
-        policy=json.dumps(
-            {
-                "Version": IAM_POLICY_VERSION,
-                "Statement": [
-                    {
-                        "Effect": "Allow",
-                        "Action": [
-                            "s3:ListBucket",
-                            "s3:GetReplicationConfiguration",
-                            "s3:GetObjectVersionForReplication",
-                            "s3:GetObjectVersionAcl",
-                            "s3:GetObjectVersionTagging",
-                            "s3:GetObjectRetention",
-                            "s3:GetObjectLegalHold",
-                        ],
-                        "Resource": [
-                            live_bucket_arn,
-                            f"{live_bucket_arn}/*",
-                            live_backup_bucket_arn,
-                            f"{live_backup_bucket_arn}/*",
-                        ],
-                    },
-                    {
-                        "Effect": "Allow",
-                        "Action": [
-                            "s3:ReplicateObject",
-                            "s3:ReplicateDelete",
-                            "s3:ReplicateTags",
-                            "s3:ObjectOwnerOverrideToBucketOwner",
-                        ],
-                        "Resource": [
-                            f"{live_bucket_arn}/*",
-                            f"{live_backup_bucket_arn}/*",
-                        ],
-                    },
-                ],
-            }
-        ),
-        opts=ResourceOptions(import_=live_bucket_replication_policy_arn),
-    )
-    live_bucket_replication_policy_attachment = iam.RolePolicyAttachment(
-        "ocw-content-live-production-replication-policy-attachment",
-        role=live_bucket_replication_role.name,
-        policy_arn=live_bucket_replication_policy.arn,
-        opts=ResourceOptions(
-            import_=(
-                f"{live_bucket_replication_role_name}/"
-                f"{live_bucket_replication_policy_arn}"
+            opts=ResourceOptions(import_=role_name),
+        )
+        replication_policy = iam.Policy(
+            f"{resource_prefix}-replication-policy",
+            name=policy_name,
+            path="/service-role/",
+            policy=lint_iam_policy(
+                {
+                    "Version": IAM_POLICY_VERSION,
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                                "s3:ListBucket",
+                                "s3:GetReplicationConfiguration",
+                                "s3:GetObjectVersionForReplication",
+                                "s3:GetObjectVersionAcl",
+                                "s3:GetObjectVersionTagging",
+                                "s3:GetObjectRetention",
+                                "s3:GetObjectLegalHold",
+                            ],
+                            "Resource": [
+                                source_bucket_arn,
+                                f"{source_bucket_arn}/*",
+                                destination_bucket_arn,
+                                f"{destination_bucket_arn}/*",
+                            ],
+                        },
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                                "s3:ReplicateObject",
+                                "s3:ReplicateDelete",
+                                "s3:ReplicateTags",
+                                "s3:ObjectOwnerOverrideToBucketOwner",
+                            ],
+                            "Resource": [
+                                f"{source_bucket_arn}/*",
+                                f"{destination_bucket_arn}/*",
+                            ],
+                        },
+                    ],
+                },
+                stringify=True,
             ),
-            depends_on=[
-                live_bucket_replication_role,
-                live_bucket_replication_policy,
+            opts=ResourceOptions(import_=policy_arn),
+        )
+        replication_policy_attachment = iam.RolePolicyAttachment(
+            f"{resource_prefix}-replication-policy-attachment",
+            role=replication_role.name,
+            policy_arn=replication_policy.arn,
+            opts=ResourceOptions(
+                import_=f"{role_name}/{policy_arn}",
+                depends_on=[
+                    replication_role,
+                    replication_policy,
+                ],
+            ),
+        )
+
+        return s3.BucketReplicationConfig(
+            f"{resource_prefix}-replication",
+            bucket=source_bucket.bucket_v2.id,
+            role=replication_role.arn,
+            rules=[
+                s3.BucketReplicationConfigRuleArgs(
+                    id=rule_id,
+                    priority=0,
+                    filter=s3.BucketReplicationConfigRuleFilterArgs(),
+                    status="Enabled",
+                    destination=s3.BucketReplicationConfigRuleDestinationArgs(
+                        bucket=destination_bucket.bucket_v2.arn,
+                    ),
+                    delete_marker_replication=s3.BucketReplicationConfigRuleDeleteMarkerReplicationArgs(
+                        status="Disabled"
+                    ),
+                )
             ],
-        ),
+            opts=ResourceOptions(
+                import_=source_bucket_name,
+                depends_on=[
+                    resource
+                    for resource in [
+                        source_bucket.bucket_versioning,
+                        destination_bucket.bucket_versioning,
+                        replication_policy_attachment,
+                    ]
+                    if resource is not None
+                ],
+            ),
+        )
+
+    draft_bucket_replication = setup_bucket_replication(
+        draft_bucket,
+        draft_backup_bucket,
+        source_bucket_name=draft_bucket_name,
+        source_bucket_arn=draft_bucket_arn,
+        destination_bucket_arn=draft_backup_bucket_arn,
+        resource_prefix="ocw-content-draft-production",
+        role_name="s3crr_role_for_ocw-content-draft-production",
+        policy_name="s3crr_for_ocw-content-draft-production_8da254",
+        rule_id="OCWContentDraftProductionBackupRule",
     )
 
-    live_bucket_replication = s3.BucketReplicationConfig(
-        "ocw-content-live-production-replication",
-        bucket=live_bucket.bucket_v2.id,
-        role=live_bucket_replication_role.arn,
-        rules=[
-            s3.BucketReplicationConfigRuleArgs(
-                id="OCWContentLiveProductionBackupRule",
-                priority=0,
-                filter=s3.BucketReplicationConfigRuleFilterArgs(),
-                status="Enabled",
-                destination=s3.BucketReplicationConfigRuleDestinationArgs(
-                    bucket=live_backup_bucket.bucket_v2.arn,
-                ),
-                delete_marker_replication=s3.BucketReplicationConfigRuleDeleteMarkerReplicationArgs(
-                    status="Disabled"
-                ),
-            )
-        ],
-        opts=ResourceOptions(
-            import_=live_bucket_name,
-            depends_on=[
-                resource
-                for resource in [
-                    live_bucket.bucket_versioning,
-                    live_backup_bucket.bucket_versioning,
-                    live_bucket_replication_policy_attachment,
-                ]
-                if resource is not None
-            ],
-        ),
+    live_bucket_replication = setup_bucket_replication(
+        live_bucket,
+        live_backup_bucket,
+        source_bucket_name=live_bucket_name,
+        source_bucket_arn=live_bucket_arn,
+        destination_bucket_arn=live_backup_bucket_arn,
+        resource_prefix="ocw-content-live-production",
+        role_name="s3crr_role_for_ocw-content-live-production",
+        policy_name="s3crr_for_ocw-content-live-production_565f2a",
+        rule_id="OCWContentLiveProductionBackupRule",
     )
 
 policy_description = (

--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -686,13 +686,13 @@ if stack_info.env_suffix == "production":
         source_bucket: OLBucket,
         destination_bucket: OLBucket,
         *,
-        source_bucket_name,
-        source_bucket_arn,
-        destination_bucket_arn,
-        resource_prefix,
-        role_name,
-        policy_name,
-        rule_id,
+        source_bucket_name: str,
+        source_bucket_arn: str,
+        destination_bucket_arn: str,
+        resource_prefix: str,
+        role_name: str,
+        policy_name: str,
+        rule_id: str,
     ) -> s3.BucketReplicationConfig:
         """Set up imported S3 same-region replication resources for one bucket pair."""
         policy_arn = (

--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -683,8 +683,8 @@ test_offline_bucket = OLBucket(
 
 if stack_info.env_suffix == "production":
     def setup_bucket_replication(
-        source_bucket,
-        destination_bucket,
+        source_bucket: OLBucket,
+        destination_bucket: OLBucket,
         *,
         source_bucket_name,
         source_bucket_arn,
@@ -693,7 +693,8 @@ if stack_info.env_suffix == "production":
         role_name,
         policy_name,
         rule_id,
-    ):
+    ) -> s3.BucketReplicationConfig:
+        """Set up imported S3 same-region replication resources for one bucket pair."""
         policy_arn = (
             f"arn:aws:iam::{aws_account.account_id}:policy/service-role/{policy_name}"
         )

--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -682,17 +682,13 @@ test_offline_bucket = OLBucket(
 )
 
 if stack_info.env_suffix == "production":
+
     def setup_bucket_replication(
         source_bucket: OLBucket,
         destination_bucket: OLBucket,
         *,
         source_bucket_name: str,
-        source_bucket_arn: str,
-        destination_bucket_arn: str,
-        resource_prefix: str,
-        role_name: str,
-        policy_name: str,
-        rule_id: str,
+        replication_settings: dict[str, str],
     ) -> s3.BucketReplicationConfig:
         """Create imported IAM and replication resources for a source/destination pair.
 
@@ -700,21 +696,23 @@ if stack_info.env_suffix == "production":
             source_bucket: Source OCW bucket component.
             destination_bucket: Destination backup OCW bucket component.
             source_bucket_name: Existing source bucket name used for import IDs.
-            source_bucket_arn: Source bucket ARN string used in linted IAM policy JSON.
-            destination_bucket_arn: Destination bucket ARN string used in IAM policy JSON.
-            resource_prefix: Pulumi logical resource name prefix.
-            role_name: Existing replication IAM role name to import/manage.
-            policy_name: Existing replication IAM policy name to import/manage.
-            rule_id: Existing replication rule identifier.
+            replication_settings: Existing ARNs and names used for imports and
+                replication-rule identity.
 
         Returns:
             The imported BucketReplicationConfig resource for the source bucket.
         """
+        source_bucket_arn = replication_settings["source_bucket_arn"]
+        destination_bucket_arn = replication_settings["destination_bucket_arn"]
+        role_name = replication_settings["role_name"]
+        policy_name = replication_settings["policy_name"]
+        rule_id = replication_settings["rule_id"]
+
         policy_arn = (
             f"arn:aws:iam::{aws_account.account_id}:policy/service-role/{policy_name}"
         )
         replication_role = iam.Role(
-            f"{resource_prefix}-replication-role",
+            f"{source_bucket_name}-replication-role",
             name=role_name,
             path="/service-role/",
             assume_role_policy=json.dumps(
@@ -732,7 +730,7 @@ if stack_info.env_suffix == "production":
             opts=ResourceOptions(import_=role_name),
         )
         replication_policy = iam.Policy(
-            f"{resource_prefix}-replication-policy",
+            f"{source_bucket_name}-replication-policy",
             name=policy_name,
             path="/service-role/",
             policy=lint_iam_policy(
@@ -777,7 +775,7 @@ if stack_info.env_suffix == "production":
             opts=ResourceOptions(import_=policy_arn),
         )
         replication_policy_attachment = iam.RolePolicyAttachment(
-            f"{resource_prefix}-replication-policy-attachment",
+            f"{source_bucket_name}-replication-policy-attachment",
             role=replication_role.name,
             policy_arn=replication_policy.arn,
             opts=ResourceOptions(
@@ -790,7 +788,7 @@ if stack_info.env_suffix == "production":
         )
 
         return s3.BucketReplicationConfig(
-            f"{resource_prefix}-replication",
+            f"{source_bucket_name}-replication",
             bucket=source_bucket.bucket_v2.id,
             role=replication_role.arn,
             rules=[
@@ -825,24 +823,26 @@ if stack_info.env_suffix == "production":
         draft_bucket,
         draft_backup_bucket,
         source_bucket_name=draft_bucket_name,
-        source_bucket_arn=draft_bucket_arn,
-        destination_bucket_arn=draft_backup_bucket_arn,
-        resource_prefix="ocw-content-draft-production",
-        role_name="s3crr_role_for_ocw-content-draft-production",
-        policy_name="s3crr_for_ocw-content-draft-production_8da254",
-        rule_id="OCWContentDraftProductionBackupRule",
+        replication_settings={
+            "source_bucket_arn": draft_bucket_arn,
+            "destination_bucket_arn": draft_backup_bucket_arn,
+            "role_name": "s3crr_role_for_ocw-content-draft-production",
+            "policy_name": "s3crr_for_ocw-content-draft-production_8da254",
+            "rule_id": "OCWContentDraftProductionBackupRule",
+        },
     )
 
     live_bucket_replication = setup_bucket_replication(
         live_bucket,
         live_backup_bucket,
         source_bucket_name=live_bucket_name,
-        source_bucket_arn=live_bucket_arn,
-        destination_bucket_arn=live_backup_bucket_arn,
-        resource_prefix="ocw-content-live-production",
-        role_name="s3crr_role_for_ocw-content-live-production",
-        policy_name="s3crr_for_ocw-content-live-production_565f2a",
-        rule_id="OCWContentLiveProductionBackupRule",
+        replication_settings={
+            "source_bucket_arn": live_bucket_arn,
+            "destination_bucket_arn": live_backup_bucket_arn,
+            "role_name": "s3crr_role_for_ocw-content-live-production",
+            "policy_name": "s3crr_for_ocw-content-live-production_565f2a",
+            "rule_id": "OCWContentLiveProductionBackupRule",
+        },
     )
 
 policy_description = (

--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -694,7 +694,22 @@ if stack_info.env_suffix == "production":
         policy_name: str,
         rule_id: str,
     ) -> s3.BucketReplicationConfig:
-        """Set up imported S3 same-region replication resources for one bucket pair."""
+        """Create imported IAM and replication resources for a source/destination pair.
+
+        Args:
+            source_bucket: Source OCW bucket component.
+            destination_bucket: Destination backup OCW bucket component.
+            source_bucket_name: Existing source bucket name used for import IDs.
+            source_bucket_arn: Source bucket ARN string used in linted IAM policy JSON.
+            destination_bucket_arn: Destination bucket ARN string used in IAM policy JSON.
+            resource_prefix: Pulumi logical resource name prefix.
+            role_name: Existing replication IAM role name to import/manage.
+            policy_name: Existing replication IAM policy name to import/manage.
+            rule_id: Existing replication rule identifier.
+
+        Returns:
+            The imported BucketReplicationConfig resource for the source bucket.
+        """
         policy_arn = (
             f"arn:aws:iam::{aws_account.account_id}:policy/service-role/{policy_name}"
         )


### PR DESCRIPTION
### What are the relevant tickets?
Closes #4510

### Description (What does it do?)
- backfill the existing OCW production S3 same-region replication configuration into Pulumi
- import and manage the existing replication IAM roles, policies, and role attachments used by the draft and live OCW content buckets
- import and manage the existing replication configuration for:
  - `ocw-content-draft-production` -> `ocw-content-backup-draft-production`
  - `ocw-content-live-production` -> `ocw-content-backup-live-production`

### How can this be tested?
- Review the Pulumi changes in `src/ol_infrastructure/applications/ocw_site/__main__.py`
- Run `uv run pre-commit run --files src/ol_infrastructure/applications/ocw_site/__main__.py`
- Run `pulumi preview --stack Production --diff` from `src/ol_infrastructure/applications/ocw_site/`
- Confirm the preview summary matches what was validated for this branch:
  - `= 8 to import`
  - `~ 1 to update`
  - `109 unchanged`
- Confirm the safety condition from preview: no S3 bucket replacements and no S3 bucket deletions were proposed

### Additional Context
- The only non-import change shown in preview was an unrelated Fastly TLS subscription update (`fastly-ocw_site-production-live-tls-subscription`) caused by drift in `configurationId`
- This PR is intended to make the existing production OCW bucket replication declarative in Pulumi without recreating the buckets
