### PR TITLE
Md/202605 xqueue

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.CI.yaml
@@ -35,6 +35,8 @@ config:
   - ["new_studio_mfe.use_tagging_taxonomy_list_page", "--create", "--superusers",
     "--everyone"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]
+  - ["send_to_submission_course.enable", "--create", "--superusers", "--everyone",
+    "--staff", "--authenticated"]
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["legacy_studio.certificates", "--create", "--everyone"]
   - ["instructor.legacy_instructor_dashboard", "--create", "--everyone"]
@@ -69,7 +71,7 @@ config:
   edxapp:sender_email_address: mitx-support+staging-ci@mit.edu
   edxapp:target_vpc: residential_mitx_staging_vpc
   edxapp:enable_xqueue: "true"
-  edxapp:xqueue_domain: xqueue.mitx-staging-ci.odl.mit.edu
+  edxapp:xqueue_domain: unused-placeholder
   mongodb:atlas_project_id: 6193f02d576a70760e8bcb02
   vault:address: https://vault-ci.odl.mit.edu
   vault_server:env_namespace: operations.ci

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.Production.yaml
@@ -35,6 +35,8 @@ config:
   - ["new_studio_mfe.use_tagging_taxonomy_list_page", "--create", "--superusers",
     "--everyone"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]
+  - ["send_to_submission_course.enable", "--create", "--superusers", "--everyone",
+    "--staff", "--authenticated"]
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["studio.library_authoring_mfe", "--deactivate"]
   - ["legacy_studio.certificates", "--create", "--everyone"]
@@ -68,7 +70,7 @@ config:
   edxapp:sender_email_address: mitx-support+staging@mit.edu
   edxapp:target_vpc: residential_mitx_staging_vpc
   edxapp:enable_xqueue: "true"
-  edxapp:xqueue_domain: xqueue.mitx-staging-prod.odl.mit.edu
+  edxapp:xqueue_domain: unused-placeholder
   edxapp:web_instance_type: general_purpose_xlarge
   edxapp:worker_instance_type: "m7a.xlarge"
   mongodb:atlas_project_id: 61b72cf6148de8714e671440

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.QA.yaml
@@ -35,6 +35,8 @@ config:
   - ["new_studio_mfe.use_tagging_taxonomy_list_page", "--create", "--superusers",
     "--everyone"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]
+  - ["send_to_submission_course.enable", "--create", "--superusers", "--everyone",
+    "--staff", "--authenticated"]
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["studio.library_authoring_mfe", "--deactivate"]
   - ["legacy_studio.certificates", "--create", "--everyone"]
@@ -69,7 +71,7 @@ config:
   edxapp:sender_email_address: mitx-support+staging-qa@mit.edu
   edxapp:target_vpc: residential_mitx_staging_vpc
   edxapp:enable_xqueue: "true"
-  edxapp:xqueue_domain: xqueue.mitx-staging-qa.odl.mit.edu
+  edxapp:xqueue_domain: unused-placeholder
   mongodb:atlas_project_id: 61a8fc35438c21331e5773f6
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.CI.yaml
@@ -44,6 +44,8 @@ config:
   - ["new_studio_mfe.use_tagging_taxonomy_list_page", "--create", "--superusers",
     "--everyone"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]
+  - ["send_to_submission_course.enable", "--create", "--superusers", "--everyone",
+    "--staff", "--authenticated"]
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["studio.library_authoring_mfe", "--deactivate"]
   - ["legacy_studio.certificates", "--create", "--everyone"]
@@ -80,7 +82,7 @@ config:
   edxapp:sender_email_address: mitx-support+ci@mit.edu
   edxapp:target_vpc: residential_mitx_vpc
   edxapp:enable_xqueue: "true"
-  edxapp:xqueue_domain: xqueue.mitx.ci.odl.mit.edu
+  edxapp:xqueue_domain: unused-placeholder
   mongodb:atlas_project_id: 617858f961f3016e0ade73e7
   vault:address: https://vault-ci.odl.mit.edu
   vault_server:env_namespace: operations.ci

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.Production.yaml
@@ -45,6 +45,8 @@ config:
   - ["new_studio_mfe.use_tagging_taxonomy_list_page", "--create", "--superusers",
     "--everyone"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]
+  - ["send_to_submission_course.enable", "--create", "--superusers", "--everyone",
+    "--staff", "--authenticated"]
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["studio.library_authoring_mfe", "--deactivate"]
   - ["legacy_studio.certificates", "--create", "--everyone"]
@@ -83,7 +85,7 @@ config:
   edxapp:worker_disk_size: "50"
   edxapp:worker_instance_type: "m7a.xlarge"
   edxapp:enable_xqueue: "true"
-  edxapp:xqueue_domain: xqueue.mitx.odl.mit.edu
+  edxapp:xqueue_domain: unused-placeholder
   mongodb:atlas_project_id: 61b728704656cb4747e589a0
   redis:instance_type: cache.r7g.2xlarge
   vault:address: https://vault-production.odl.mit.edu

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.QA.yaml
@@ -44,6 +44,8 @@ config:
   - ["new_studio_mfe.use_tagging_taxonomy_list_page", "--create", "--superusers",
     "--everyone"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone"]
+  - ["send_to_submission_course.enable", "--create", "--superusers", "--everyone",
+    "--staff", "--authenticated"]
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["studio.library_authoring_mfe", "--deactivate"]
   - ["legacy_studio.certificates", "--create", "--everyone"]
@@ -80,7 +82,7 @@ config:
   edxapp:sender_email_address: mitx-support+qa@mit.edu
   edxapp:target_vpc: residential_mitx_vpc
   edxapp:enable_xqueue: "true"
-  edxapp:xqueue_domain: xqueue.mitx.qa.odl.mit.edu
+  edxapp:xqueue_domain: unused-placeholder
   mongodb:atlas_project_id: 61a8f2d2c263e144f50f13b4
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.CI.yaml
@@ -49,6 +49,8 @@ config:
   - ["notifications.enable_notifications", "--create", "--everyone"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone",
     "--staff", "--authenticated"]
+  - ["send_to_submission_course.enable", "--create", "--superusers", "--everyone",
+    "--staff", "--authenticated"]
   - ["seo.enable_anonymous_courseware_access", "--create", "--superusers", "--staff",
     "--authenticated"]
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
@@ -95,7 +97,7 @@ config:
   vault:address: https://vault-ci.odl.mit.edu
   vault_server:env_namespace: operations.ci
   edxapp:enable_xqueue: "true"
-  edxapp:xqueue_domain: xqueue.mitxonline.ci.odl.mit.edu
+  edxapp:xqueue_domain: unused-placeholder
   edxapp:enable_auto_language_selection: "true"
   edxapp:autoscaling_lms_requests_threshold: "20"
   edxapp:autoscaling_lms_latency_threshold: "2000"

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
@@ -47,6 +47,8 @@ config:
   - ["notifications.enable_email_notifications", "--create", "--everyone"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone",
     "--staff", "--authenticated"]
+  - ["send_to_submission_course.enable", "--create", "--superusers", "--everyone",
+    "--staff", "--authenticated"]
   - ["seo.enable_anonymous_courseware_access", "--create", "--superusers", "--staff",
     "--authenticated"]
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
@@ -90,7 +92,7 @@ config:
   edxapp:email_use_course_id_from_for_bulk: "True"
   edxapp:bulk_email_default_from_email: no-reply@edxapp-mail.learn.mit.edu
   edxapp:enable_xqueue: "true"
-  edxapp:xqueue_domain: xqueue.mitxonline.odl.mit.edu
+  edxapp:xqueue_domain: unused-placeholder
   edxapp:web_instance_type: m7a.2xlarge
   edxapp:worker_instance_type: "r7a.large"
   edxapp:backend_lms_domain: courses-backend.learn.mit.edu

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.QA.yaml
@@ -49,6 +49,8 @@ config:
   - ["notifications.enable_notifications", "--create", "--everyone"]
   - ["openresponseassessment.enhanced_staff_grader", "--create", "--superusers", "--everyone",
     "--staff", "--authenticated"]
+  - ["send_to_submission_course.enable", "--create", "--superusers", "--everyone",
+    "--staff", "--authenticated"]
   - ["seo.enable_anonymous_courseware_access", "--create", "--superusers", "--staff",
     "--authenticated"]
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
@@ -93,7 +95,7 @@ config:
   edxapp:email_use_course_id_from_for_bulk: "True"
   edxapp:bulk_email_default_from_email: no-reply@edxapp-mail.rc.learn.mit.edu
   edxapp:enable_xqueue: "true"
-  edxapp:xqueue_domain: xqueue.mitxonline.qa.odl.mit.edu
+  edxapp:xqueue_domain: unused-placeholder
   edxapp:enable_auto_language_selection: "true"
   edxapp:autoscaling_lms_requests_threshold: "20"
   edxapp:autoscaling_lms_latency_threshold: "2000"

--- a/src/ol_infrastructure/applications/edxapp/config_builder.py
+++ b/src/ol_infrastructure/applications/edxapp/config_builder.py
@@ -484,7 +484,7 @@ def get_deployment_overrides(env_prefix: str) -> ConfigDict:
             "PRESS_EMAIL": "support@xpro.mit.edu",
             "MITX_REDIRECT_ENABLED": True,
             "MITX_REDIRECT_ALLOW_RE_LIST": [
-                "^/(admin|auth|logout|register|api|oauth2|user_api|heartbeat|login_refresh|c4x|asset-v1:|assets/courseware/)",
+                "^/(admin|auth|logout|register|api|oauth2|user_api|heartbeat|login_refresh|c4x|xqueue|asset-v1:|assets/courseware/)",
                 "^/courses/.*/xblock/.*/handler_noauth/outcome_service_handler",
                 "^/courses/.*/courseware-navigation-sidebar/toggles/?$",
                 "^/courses/.*/courseware-search/enabled/?$",
@@ -543,7 +543,7 @@ def get_deployment_overrides(env_prefix: str) -> ConfigDict:
             "ENABLE_DATES_COURSE_APP": True,
             "MITX_REDIRECT_ENABLED": True,
             "MITX_REDIRECT_ALLOW_RE_LIST": [
-                "^/(admin|auth|logout|register|api|oauth2|user_api|heartbeat|login_refresh|c4x|asset-v1:|assets/courseware/|lti_provider)",
+                "^/(admin|auth|logout|register|api|oauth2|user_api|heartbeat|login_refresh|c4x|xqueue|asset-v1:|assets/courseware/|lti_provider)",
                 "^/courses/.*/xblock/.*/handler_noauth/outcome_service_handler",
                 "^/v1/accounts/bulk_retire_users",
                 "^/courses/course-v1:.*?/xqueue/.*$",

--- a/src/ol_infrastructure/applications/xqwatcher/Pulumi.mitx-staging.CI.yaml
+++ b/src/ol_infrastructure/applications/xqwatcher/Pulumi.mitx-staging.CI.yaml
@@ -9,7 +9,7 @@ config:
   xqwatcher:min_replicas: 1
   vault:address: https://vault-ci.odl.mit.edu
   vault_server:env_namespace: operations.ci
-  xqwatcher:xqueue_server_url: https://xqueue.mitx-staging-ci.odl.mit.edu
+  xqwatcher:xqueue_server_url: https://staging-ci.mitx.mit.edu
   xqwatcher:queues:
     Watcher-MITx-6.00x:
       CONNECTIONS: 5

--- a/src/ol_infrastructure/applications/xqwatcher/Pulumi.mitx-staging.Production.yaml
+++ b/src/ol_infrastructure/applications/xqwatcher/Pulumi.mitx-staging.Production.yaml
@@ -9,7 +9,7 @@ config:
   xqwatcher:min_replicas: 1
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production
-  xqwatcher:xqueue_server_url: https://xqueue.mitx-staging-prod.odl.mit.edu
+  xqwatcher:xqueue_server_url: https://staging.mitx.mit.edu
   xqwatcher:queues:
     Watcher-MITx-staging-6.00x:
       CONNECTIONS: 5

--- a/src/ol_infrastructure/applications/xqwatcher/Pulumi.mitx-staging.QA.yaml
+++ b/src/ol_infrastructure/applications/xqwatcher/Pulumi.mitx-staging.QA.yaml
@@ -9,7 +9,7 @@ config:
   xqwatcher:min_replicas: 1
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa
-  xqwatcher:xqueue_server_url: https://xqueue.mitx-staging-qa.odl.mit.edu
+  xqwatcher:xqueue_server_url: https://mitx-qa-draft.mitx.mit.edu
   xqwatcher:queues:
     Watcher-MITx-staging-6.00x:
       CONNECTIONS: 5

--- a/src/ol_infrastructure/applications/xqwatcher/Pulumi.mitx.CI.yaml
+++ b/src/ol_infrastructure/applications/xqwatcher/Pulumi.mitx.CI.yaml
@@ -9,7 +9,7 @@ config:
   xqwatcher:min_replicas: 1
   vault:address: https://vault-ci.odl.mit.edu
   vault_server:env_namespace: operations.ci
-  xqwatcher:xqueue_server_url: https://xqueue.mitx.ci.odl.mit.edu
+  xqwatcher:xqueue_server_url: https://lms-ci.mitx.mit.edu
   xqwatcher:queues:
     Watcher-MITx-6.00x:
       CONNECTIONS: 5

--- a/src/ol_infrastructure/applications/xqwatcher/Pulumi.mitx.Production.yaml
+++ b/src/ol_infrastructure/applications/xqwatcher/Pulumi.mitx.Production.yaml
@@ -9,7 +9,7 @@ config:
   xqwatcher:min_replicas: 2
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production
-  xqwatcher:xqueue_server_url: https://xqueue.mitx.odl.mit.edu
+  xqwatcher:xqueue_server_url: https://lms.mitx.mit.edu
   xqwatcher:queues:
     Watcher-MITx-6.00x:
       CONNECTIONS: 5

--- a/src/ol_infrastructure/applications/xqwatcher/Pulumi.mitx.QA.yaml
+++ b/src/ol_infrastructure/applications/xqwatcher/Pulumi.mitx.QA.yaml
@@ -9,7 +9,7 @@ config:
   xqwatcher:min_replicas: 1
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa
-  xqwatcher:xqueue_server_url: https://xqueue.mitx.qa.odl.mit.edu
+  xqwatcher:xqueue_server_url: https://mitx-qa.mitx.mit.edu
   xqwatcher:queues:
     Watcher-MITx-6.00x:
       CONNECTIONS: 5

--- a/src/ol_infrastructure/applications/xqwatcher/Pulumi.mitxonline.CI.yaml
+++ b/src/ol_infrastructure/applications/xqwatcher/Pulumi.mitxonline.CI.yaml
@@ -9,9 +9,21 @@ config:
   xqwatcher:min_replicas: 1
   vault:address: https://vault-ci.odl.mit.edu
   vault_server:env_namespace: operations.ci
-  xqwatcher:xqueue_server_url: https://xqueue.mitxonline.ci.odl.mit.edu
+  xqwatcher:xqueue_server_url: https://courses.ci.learn.mit.edu
   xqwatcher:queues:
     Watcher-MITx-6.00x:
+      CONNECTIONS: 5
+      HANDLERS:
+      - HANDLER: xqueue_watcher.containergrader.ContainerGrader
+        KWARGS:
+          grader_root: /graders/python3graders/
+          image: 610119931565.dkr.ecr.us-east-1.amazonaws.com/mitodl/graders-mit-600x:latest
+          backend: kubernetes
+          cpu_limit: 1000m
+          memory_limit: 512Mi
+          timeout: 60
+          image_pull_policy: always
+    Watcher-MITx-6.0001r:
       CONNECTIONS: 5
       HANDLERS:
       - HANDLER: xqueue_watcher.containergrader.ContainerGrader

--- a/src/ol_infrastructure/applications/xqwatcher/Pulumi.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/xqwatcher/Pulumi.mitxonline.Production.yaml
@@ -9,7 +9,7 @@ config:
   xqwatcher:min_replicas: 2
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production
-  xqwatcher:xqueue_server_url: https://xqueue.mitxonline.odl.mit.edu
+  xqwatcher:xqueue_server_url: https://courses.learn.mit.edu
   xqwatcher:queues:
     Watcher-MITx-6.00x:
       CONNECTIONS: 5

--- a/src/ol_infrastructure/applications/xqwatcher/Pulumi.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/xqwatcher/Pulumi.mitxonline.QA.yaml
@@ -9,7 +9,7 @@ config:
   xqwatcher:min_replicas: 1
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa
-  xqwatcher:xqueue_server_url: https://xqueue.mitxonline.qa.odl.mit.edu
+  xqwatcher:xqueue_server_url: https://courses.rc.learn.mit.edu
   xqwatcher:queues:
     Watcher-MITx-6.00x:
       CONNECTIONS: 5


### PR DESCRIPTION
### Description (What does it do?)
Updates edxapp deployments on `master` and `verawood` to use xqueue-builtin rather than an external xqueue application / deployment. This PR does the following:

- Updates legacy xqueue configuration in edxapp to point to 'unused-placeholder'
  - This config needs to continue to be set / exist but set to something invalid. 
- Sets the `send_to_submission_course.enable` waffle flag.
- Adds `xqueue` to `MITX_REDIRECT_ALLOW_RE_LIST`
- Updates the xqwatcher config `xqueue_server_url` to point to the LMS of each environment.

#### Click-ops stuff for setting up `xqwatcher` user

Every environment needs a super-user named `xqwatcher` that is in a group `xqueue` with a password set that is known to xqwatcher. I set this password to the same password that xqwatcher was using to login to xqueue for simplicity and to reduce the changeset. 

mitxonline-ci DONE
mitxonline-qa DONE
mitxonline-production DONE

mitx-ci DONE 
mitx-qa DONE
mitx-production DONE

mitx-staging-ci DONE
mitx-staging-qa DONE
mitx-staging-production DONE

Finally, A separate PR will be opened to decomm xqueue-proper. 

