### PR TITLE
feat(data-warehouse): add integrations stage for MIT Learn contract layer

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
@@ -39,6 +39,7 @@ data_stages = (
     "staging",
     "intermediate",
     "mart",
+    "integrations",
     "external",
     "dimensional",
     "reporting",


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/ol-data-platform#2262

### Description (What does it do?)

Adds `"integrations"` to the `data_stages` tuple in the data warehouse Pulumi stack. This provisions the corresponding S3 prefix and AWS Glue database alongside the existing `staging`, `mart`, `reporting`, and `external` stages.

The `integrations` schema is the target for the new `integrations__learn__*` dbt models in `mitodl/ol-data-platform`, which expose stable application-level contracts for MIT Learn's Trino-pull ETL tasks (OCW, MITxOnline, xPRO, MicroMasters catalog data).

### How can this be tested?

```bash
cd src/ol_infrastructure/infrastructure/aws/data_warehouse
pulumi preview --stack ol-infrastructure.data-warehouse.production
```

Expect: one new S3 prefix and one new Glue database for the `integrations` stage, mirroring the pattern of `staging`, `mart`, etc.

### Additional Context

This is a companion to mitodl/ol-data-platform#2262. The Glue database is required before `dbt run --select 'integrations__learn*'` can succeed in the production warehouse target.