### PR TITLE
feat(starburst): add mit_learn_etl role for MIT Learn Trino-pull ETL

### DIFF
--- a/src/ol_infrastructure/applications/starburst/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/starburst/Pulumi.Production.yaml
@@ -107,3 +107,13 @@ config:
       - name: "ol-data-lake-production"
         privileges:
         - name: "UseCluster"
+
+    mit_learn_etl:
+      description: "Service account role for MIT Learn Trino-pull ETL tasks."
+      clusters:
+      - name: "ol-data-interactive"
+        privileges:
+        - name: "UseCluster"
+      - name: "ol-data-lake-production"
+        privileges:
+        - name: "UseCluster"

--- a/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
@@ -39,6 +39,7 @@ data_stages = (
     "staging",
     "intermediate",
     "mart",
+    "integrations",
     "external",
     "dimensional",
     "reporting",


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/11510

### Description (What does it do?)

Adds the `mit_learn_etl` Starburst Galaxy role needed by MIT Learn's Trino-pull ETL service account.

MIT Learn's `BaseTrinoETLTask` subclasses (part of the MIT Learn ETL migration to the OL Data Platform) connect to the production warehouse via Trino to query the `integrations__learn__*` views built from the dbt integrations layer. Those views expose catalog data for OCW, MITxOnline, xPRO, MIT edX, and MicroMasters as stable contracts for MIT Learn to consume.

The role needs only `UseCluster` access on both clusters:
- `ol-data-lake-production`: for production ETL queries
- `ol-data-interactive`: for QA and development use

**Data-level SELECT grants are not configured here.** They are managed by dbt in [ol-data-platform PR #2262](https://github.com/mitodl/ol-data-platform/pull/2262) via the `+grants: select: ["mit_learn_etl"]` configuration on the `integrations` schema layer in `dbt_project.yml`. The dbt grants apply when that PR merges and dbt runs against production.

The `integrations` Glue/S3 stage was provisioned by the now-merged [ol-infrastructure PR #4679](https://github.com/mitodl/ol-infrastructure/pull/4679).

### How can this be tested?

After `pulumi up` runs against the production stack:
1. Verify the `mit_learn_etl` role exists in Starburst Galaxy under the roles list
2. Assign the role to a test service account and confirm it can connect to both clusters
3. After ol-data-platform PR #2262 merges and dbt runs: confirm `SELECT * FROM ol_warehouse_production.integrations.integrations__learn__ocw_courses LIMIT 1` succeeds with the `mit_learn_etl` role