### PR TITLE
feat(apisix): improve rollout stability and pod resilience

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
@@ -138,6 +138,55 @@ def setup_apisix(
                 },
                 # --- Pod Configuration ---
                 "tolerations": operations_tolerations,
+                # Spread gateway pods across availability zones and nodes so that:
+                # - An AZ-level failure takes out at most one pod
+                # - A rolling update never places two consecutive pods on the same node,
+                #   which reduces the window where a pod with a stale services_conf_version
+                #   can block the ADC sidecar's sync on a newly-started ingress controller.
+                # ScheduleAnyway keeps scheduling unblocked when perfect balance is
+                # impossible (e.g. when scaled to fewer pods than AZs).
+                "topologySpreadConstraints": [
+                    {
+                        "maxSkew": 1,
+                        "topologyKey": "topology.kubernetes.io/zone",
+                        "whenUnsatisfiable": "ScheduleAnyway",
+                        "labelSelector": {
+                            "matchLabels": {
+                                "app.kubernetes.io/name": "apache-apisix",
+                                "app.kubernetes.io/component": "gateway",
+                            },
+                        },
+                    },
+                    {
+                        "maxSkew": 1,
+                        "topologyKey": "kubernetes.io/hostname",
+                        "whenUnsatisfiable": "ScheduleAnyway",
+                        "labelSelector": {
+                            "matchLabels": {
+                                "app.kubernetes.io/name": "apache-apisix",
+                                "app.kubernetes.io/component": "gateway",
+                            },
+                        },
+                    },
+                ],
+                "affinity": {
+                    "podAntiAffinity": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": [
+                            {
+                                "weight": 100,
+                                "podAffinityTerm": {
+                                    "labelSelector": {
+                                        "matchLabels": {
+                                            "app.kubernetes.io/name": "apache-apisix",
+                                            "app.kubernetes.io/component": "gateway",
+                                        }
+                                    },
+                                    "topologyKey": "kubernetes.io/hostname",
+                                },
+                            }
+                        ]
+                    }
+                },
                 "readinessProbe": {
                     # Temporarily relax readiness to break chicken-egg problem
                     # Workers need to be in service to receive config via Admin API
@@ -154,6 +203,42 @@ def setup_apisix(
                     "limits": {
                         "memory": eks_config.get("apisix_memory") or "400Mi",
                     },
+                },
+                # --- Rolling Update Strategy and Pod Lifecycle ---
+                # maxSurge: 0 / maxUnavailable: 1 (drain-first) ensures that an old
+                # pod — which may hold a high services_conf_version accumulated over
+                # days of ADC syncs — is fully removed from endpoint slices BEFORE a
+                # replacement pod starts.  This eliminates the race where a freshly
+                # restarted ingress-controller ADC sidecar resolves a mix of old (high-
+                # version) and new (version-0) APISix pod IPs and gets a
+                # "services_conf_version must be >= N" rejection from the old pod.
+                #
+                # The tradeoff is a brief capacity dip to (desired-1) pods during each
+                # step, which the PDB (maxUnavailable: 1) already accounts for.
+                #
+                # minReadySeconds: 30 forces Kubernetes to observe the new pod as
+                # healthy for 30 s before advancing to the next rollout step, preventing
+                # a bad image from racing through the entire fleet undetected.
+                "updateStrategy": {
+                    "type": "RollingUpdate",
+                    "rollingUpdate": {
+                        "maxSurge": 0,
+                        "maxUnavailable": 1,
+                    },
+                },
+                "minReadySeconds": 30,
+                # Give in-flight requests up to 120 s to complete after the pod is
+                # removed from the NLB target group and endpoint slice.  The preStop
+                # sleep bridges the gap between endpoint-slice propagation (< 5 s) and
+                # the last long-lived connection draining; 90 s < 120 s leaves a 30 s
+                # hard-kill buffer so the kubelet never has to SIGKILL the process.
+                "terminationGracePeriodSeconds": 120,
+                "lifecycle": {
+                    "preStop": {
+                        "exec": {
+                            "command": ["/bin/sh", "-c", "sleep 90"],
+                        }
+                    }
                 },
                 # --- Service (LoadBalancer) ---
                 "service": {
@@ -395,16 +480,94 @@ def setup_apisix(
                                 "memory": "256Mi",
                             },
                         },
+                        # Surge-first rolling update (maxUnavailable: 0): a new IC pod
+                        # comes up and resolves *current* APISix endpoint IPs before the
+                        # old IC pod is terminated.  This means every new ADC sidecar
+                        # starts with a fresh, consistent view of the APISix fleet — no
+                        # stale pod IPs that could produce services_conf_version conflicts.
+                        # minReadySeconds: 30 ensures the new IC pod has successfully
+                        # completed at least one ADC sync cycle before the old pod is
+                        # decommissioned.
+                        "strategy": {
+                            "type": "RollingUpdate",
+                            "rollingUpdate": {
+                                "maxSurge": 1,
+                                "maxUnavailable": 0,
+                            },
+                        },
+                        "minReadySeconds": 30,
+                        # Allow in-flight ADC sync operations and leader-election
+                        # transitions to complete gracefully before the pod exits.
+                        "terminationGracePeriodSeconds": 60,
+                        "lifecycle": {
+                            "preStop": {
+                                "exec": {
+                                    "command": ["/bin/sh", "-c", "sleep 20"],
+                                }
+                            }
+                        },
+                        # Spread ingress-controller pods across AZs and nodes to prevent
+                        # all three replicas landing on the same node/AZ, which would
+                        # make a single node failure take down the entire control plane.
+                        "topologySpreadConstraints": [
+                            {
+                                "maxSkew": 1,
+                                "topologyKey": "topology.kubernetes.io/zone",
+                                "whenUnsatisfiable": "ScheduleAnyway",
+                                "labelSelector": {
+                                    "matchLabels": {
+                                        "app.kubernetes.io/name": "apisix-ingress-controller",
+                                    },
+                                },
+                            },
+                            {
+                                "maxSkew": 1,
+                                "topologyKey": "kubernetes.io/hostname",
+                                "whenUnsatisfiable": "ScheduleAnyway",
+                                "labelSelector": {
+                                    "matchLabels": {
+                                        "app.kubernetes.io/name": "apisix-ingress-controller",
+                                    },
+                                },
+                            },
+                        ],
+                        "affinity": {
+                            "podAntiAffinity": {
+                                "preferredDuringSchedulingIgnoredDuringExecution": [
+                                    {
+                                        "weight": 100,
+                                        "podAffinityTerm": {
+                                            "labelSelector": {
+                                                "matchLabels": {
+                                                    "app.kubernetes.io/name": "apisix-ingress-controller",
+                                                }
+                                            },
+                                            "topologyKey": "kubernetes.io/hostname",
+                                        },
+                                    }
+                                ]
+                            }
+                        },
+                    },
+                    # Protect the ingress-controller fleet from simultaneous evictions
+                    # during node drains and rolling updates.  With 3 replicas this
+                    # keeps at least 2 IC pods running so the APISix fleet always has a
+                    # functioning control-plane sidecar pushing configuration.
+                    "podDisruptionBudget": {
+                        "enabled": True,
+                        "maxUnavailable": 1,
                     },
                 },
                 # --- Pod Disruption Budget ---
-                # Protect against simultaneous evictions during VPA-triggered pod restarts,
-                # node drains, and rolling updates. minAvailable=2 guarantees at least 2
-                # APISIX pods are always serving while permitting more disruptions as the
-                # HPA scales the replica count above the 3-pod floor.
+                # maxUnavailable: 1 scales correctly as the HPA grows the replica count
+                # above the 3-pod floor: it always limits disruptions to at most one pod
+                # at a time, regardless of the current scale.  minAvailable: 2 would
+                # permit up to 3 simultaneous evictions at maxReplicas: 5, which could
+                # cascade a VPA eviction, a node drain, and a rolling-update step into
+                # a single disruptive event.
                 "podDisruptionBudget": {
                     "enabled": True,
-                    "minAvailable": 2,
+                    "maxUnavailable": 1,
                 },
                 # --- Metrics ---
                 "metrics": {

--- a/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
@@ -138,13 +138,15 @@ def setup_apisix(
                 },
                 # --- Pod Configuration ---
                 "tolerations": operations_tolerations,
-                # Spread gateway pods across availability zones and nodes so that:
-                # - An AZ-level failure takes out at most one pod
-                # - A rolling update never places two consecutive pods on the same node,
-                #   which reduces the window where a pod with a stale services_conf_version
-                #   can block the ADC sidecar's sync on a newly-started ingress controller.
-                # ScheduleAnyway keeps scheduling unblocked when perfect balance is
-                # impossible (e.g. when scaled to fewer pods than AZs).
+                # Spread gateway pods across availability zones and nodes to reduce
+                # the likelihood that an AZ-level failure takes out multiple pods and
+                # to lower the probability that a rolling update places consecutive pods
+                # on the same node (which shrinks the window where a pod with a stale
+                # services_conf_version can block ADC sidecar syncs on a freshly
+                # restarted ingress controller).
+                # These are soft constraints (ScheduleAnyway + preferred anti-affinity):
+                # they improve distribution where possible but do not block scheduling
+                # when the topology cannot be perfectly balanced.
                 "topologySpreadConstraints": [
                     {
                         "maxSkew": 1,
@@ -506,9 +508,11 @@ def setup_apisix(
                                 }
                             }
                         },
-                        # Spread ingress-controller pods across AZs and nodes to prevent
-                        # all three replicas landing on the same node/AZ, which would
-                        # make a single node failure take down the entire control plane.
+                        # Spread ingress-controller pods across AZs and nodes to reduce
+                        # the likelihood of multiple replicas landing on the same node or
+                        # AZ.  These are soft constraints (ScheduleAnyway + preferred
+                        # anti-affinity): they improve distribution where possible but do
+                        # not block scheduling when the topology cannot be balanced.
                         "topologySpreadConstraints": [
                             {
                                 "maxSkew": 1,


### PR DESCRIPTION
### What are the relevant tickets?
N/A — follow-up from a live incident on 2026-06-01 where `ocw-studio.odl.mit.edu` stopped resolving.

### Description (What does it do?)

**Root cause of the incident:** During a rolling restart of the APISix gateway and ingress-controller pods today, an old gateway pod (`apache-apisix-774445d975-wpcjt`, 5 days 21 hours old) had accumulated a high `services_conf_version` value (`1780039960846`) from days of continuous ADC sync cycles. When the freshly restarted ingress-controller pods resolved the `apache-apisix-admin` service endpoints, they received a server list that included the old pod. The ADC sidecar attempted to push the full declarative config to all resolved pod IPs; the old pod rejected the sync with `services_conf_version must be >= 1780039960846`. This caused the `ocw-studio-apisix-httproute-production` HTTPRoute to flip to `Accepted: False`, which caused external-dns to queue DELETE records for `ocw-studio.odl.mit.edu` A/AAAA. DNS stopped resolving within one TTL cycle.

This PR hardens the deployment against recurrence with seven targeted changes to `src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py`:

**1. Drain-first rolling update for the APISix gateway (`maxSurge:0, maxUnavailable:1`)**
Old pods with a high `services_conf_version` are removed from endpoint slices *before* their replacement is started. Any IC pod that restarts during or after the rollout only ever resolves fresh gateway pods whose in-memory version starts at 0 — the version conflict can never occur.

**2. Surge-first rolling update for the ingress controller (`maxSurge:1, maxUnavailable:0`)**
The complementary fix on the IC side: a new IC pod comes up, resolves the *current* APISix endpoint set, and completes its first ADC sync cycle (`minReadySeconds:30`) before the old IC pod is decommissioned. This ensures no IC pod ever carries a stale server list from before a gateway rollout.

**3. `minReadySeconds:30` on both deployments**
Forces Kubernetes to observe each new pod as continuously healthy for 30 seconds before advancing the rollout, preventing a bad image from propagating through the entire fleet before the issue surfaces.

**4. `terminationGracePeriodSeconds` + `lifecycle.preStop` sleep**
- Gateway: 120 s grace period / 90 s preStop sleep — bridges the gap between endpoint-slice propagation and the last in-flight request completing; leaves a 30 s hard-kill buffer.
- Ingress controller: 60 s grace period / 20 s preStop sleep — allows in-flight ADC sync RPCs and leader-election transitions to complete cleanly.

**5. `topologySpreadConstraints` + `podAntiAffinity` on both deployments**
Soft constraints (`whenUnsatisfiable: ScheduleAnyway` + `preferredDuringScheduling` anti-affinity) that reduce the likelihood of multiple pods landing on the same AZ or node, lowering the blast radius of AZ/node failures and reducing the probability that a rolling update concentrates pods with mismatched versions on the same node. These do not guarantee placement but improve distribution where the topology allows it.

**6. Gateway PDB: `maxUnavailable:1` (was `minAvailable:2`)**
`minAvailable:2` permits up to 3 simultaneous evictions when the HPA scales to `maxReplicas:5`, which could cascade a VPA eviction, a node drain, and a rolling-update step into one event. `maxUnavailable:1` is scale-invariant — always exactly 1 disruption at a time regardless of current replica count.

**7. Ingress-controller PDB: `maxUnavailable:1` (new)**
Ensures at least 2 of the 3 IC replicas are always running so the APISix fleet always has a functioning control-plane sidecar.

### How can this be tested?

1. Run `pulumi preview` against the `infrastructure.aws.eks.applications.Production` stack and confirm no unexpected resource replacements — the changes map to Helm values that update the existing Release in-place.
2. After applying, verify the gateway deployment's rolling-update strategy: `kubectl --context applications-production get deployment apache-apisix -n operations -o jsonpath='{.spec.strategy}'` should show `maxSurge:0, maxUnavailable:1`.
3. Verify the IC deployment: `kubectl --context applications-production get deployment apache-apisix-ingress-controller -n operations -o jsonpath='{.spec.strategy}'` should show `maxSurge:1, maxUnavailable:0`.
4. Verify PDBs: `kubectl --context applications-production get pdb -n operations` should show `maxUnavailable:1` for both gateway and IC.
5. Trigger a canary rollout of the gateway (e.g. add a benign annotation) and observe that pods are replaced one-at-a-time in drain-first order, with `minReadySeconds` delay between steps.

### Additional Context

The `services_conf_version` conflict is fundamentally a limitation of the `api7/adc:0.23.1` sidecar not re-reading the current version from APISix before its first sync after a restart. The upstream fix would be in the ADC tool itself. The changes here make the deployment topology robust against the failure mode without requiring an upstream patch.