### PR TITLE
fix: give dagger build verbose build outputs.

### DIFF
--- a/src/ol_concourse/pipelines/open_edx/codejail_v3/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/codejail_v3/pipeline.py
@@ -91,7 +91,7 @@ def build_codejail_pipeline(
                             start_docker;
                             cd {codejail_lehrer_repo.name};
                             PYTHON_VERSION={openedx_release.python_version};
-                            DAGGER_LOG_LEVEL=debug dagger call build-codejail --codejail-config ./codejail_config --python-version $PYTHON_VERSION --release-name {release_name} export --path ../artifacts/image.tar;
+                            DAGGER_LOG_LEVEL=debug dagger call build-codejail --progress plain --codejail-config ./codejail_config --python-version $PYTHON_VERSION --release-name {release_name} export --path ../artifacts/image.tar;
                             """,
                         ],
                     ),

--- a/src/ol_concourse/pipelines/open_edx/edx_notes_v3/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/edx_notes_v3/pipeline.py
@@ -96,7 +96,7 @@ def build_notes_pipeline(
                             start_docker;
                             cd {notes_lehrer_repo.name};
                             PYTHON_VERSION={openedx_release.python_version};
-                            DAGGER_LOG_LEVEL=debug dagger call build-notes --notes-code ../{notes_repo.name} --notes-config ./notes_config --python-version $PYTHON_VERSION --release-name {release_name} export --path ../artifacts/image.tar;
+                            DAGGER_LOG_LEVEL=debug dagger call build-notes --progress plain --notes-code ../{notes_repo.name} --notes-config ./notes_config --python-version $PYTHON_VERSION --release-name {release_name} export --path ../artifacts/image.tar;
                             """,
                         ],
                     ),

--- a/src/ol_concourse/pipelines/open_edx/edx_platform_v3/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/edx_platform_v3/pipeline.py
@@ -179,7 +179,7 @@ def build_edx_pipeline(release_names: list[str]) -> Pipeline:  # noqa: ARG001
                                     THEME_DIR="../{theme_git_resource.name}"
                                     PYTHON_VERSION="{edx_platform.runtime_version}"
                                     NODE_VERSION="((.:node_version))"
-                                    DAGGER_LOG_LEVEL=debug dagger call build-platform --deployment-name $DEPLOYMENT_NAME --release-name $RELEASE_NAME --pip-package-lists ./pip_package_lists --pip-package-overrides ./pip_package_overrides --custom-settings ./settings --source $EDX_PLATFORM_DIR --theme-source $THEME_DIR --node-version $NODE_VERSION --python-version $PYTHON_VERSION export --path ../artifacts/image.tar;""",
+                                    DAGGER_LOG_LEVEL=debug dagger call build-platform --progress plain --deployment-name $DEPLOYMENT_NAME --release-name $RELEASE_NAME --pip-package-lists ./pip_package_lists --pip-package-overrides ./pip_package_overrides --custom-settings ./settings --source $EDX_PLATFORM_DIR --theme-source $THEME_DIR --node-version $NODE_VERSION --python-version $PYTHON_VERSION export --path ../artifacts/image.tar;""",
                                 ],
                             ),
                         ),


### PR DESCRIPTION
### Description (What does it do?)
Gives the dagger.io builds for edxapp + relations more traditional output that can be parsed for failures rather than just a cryptic "it broke" when it fails.
