### PR TITLE
feat(superset): add MCP server deployment

### DIFF
--- a/src/ol_infrastructure/applications/superset/__main__.py
+++ b/src/ol_infrastructure/applications/superset/__main__.py
@@ -630,6 +630,8 @@ superset_chart = kubernetes.helm.v3.Release(
             "secretEnv": {"create": False},
             "extraEnv": {
                 "REDIS_PROTO": "rediss",
+                # Public URL for MCP-generated links (chart previews, etc.)
+                "SUPERSET_MCP_PUBLIC_URL": f"https://{superset_domain}",
             },
             "configOverrides": {
                 "config": Path(__file__)
@@ -706,6 +708,20 @@ superset_chart = kubernetes.helm.v3.Release(
                 "enabled": True,
                 "podLabels": k8s_global_labels,
             },
+            # MCP server for AI clients (Claude Desktop, Claude Code, etc.) to
+            # interact with dashboards, datasets, and SQL Lab. Shares the same
+            # image, config (via configOverrides), envFromSecret(s), and
+            # service account/IRSA as the rest of the chart. Exposed at /mcp
+            # via the custom Gateway API HTTPRoute below.
+            "supersetMcp": {
+                "enabled": True,
+                "replicaCount": 2,
+                "podLabels": k8s_global_labels | {"ol.mit.edu/process": "mcp"},
+                "resources": {
+                    "limits": {"cpu": "500m", "memory": "512Mi"},
+                    "requests": {"cpu": "100m", "memory": "256Mi"},
+                },
+            },
             "serviceAccount": {
                 "create": True,
                 "name": "superset",
@@ -778,204 +794,6 @@ celery_keda_scaling = kubernetes.apiextensions.CustomResource(
         }
     ),
     opts=ResourceOptions(delete_before_replace=True),
-)
-
-########################################
-# Superset MCP Server                   #
-########################################
-# The MCP server runs as a separate Deployment using the same custom Superset
-# image.  It shares all Vault-synced secrets with the main pods and exposes
-# the MCP API at /mcp, routed through the existing HTTPS Gateway listener.
-#
-# Config delivery: the superset_config.py from this Pulumi project is mounted
-# via a dedicated ConfigMap and pointed to by SUPERSET_CONFIG_PATH so the
-# process loads the same Python config (including MCP_* settings) regardless
-# of what is baked into the image.
-#
-# Prerequisite: the custom 'mitodl/superset' image must include the fastmcp
-# package (pip install fastmcp) for the 'superset mcp run' sub-command to work.
-
-_MCP_CONFIG_CONFIGMAP_NAME = "superset-mcp-config"
-_MCP_CONFIG_FILENAME = "superset_config.py"
-_MCP_CONFIG_MOUNT_PATH = "/app/superset_mcp_config"
-_MCP_CONFIG_CONTENT = (
-    Path(__file__).parent.joinpath("superset_config.py").read_text(encoding="utf-8")
-)
-
-mcp_config_configmap = kubernetes.core.v1.ConfigMap(
-    "superset-mcp-config-configmap",
-    metadata=kubernetes.meta.v1.ObjectMetaArgs(
-        name=_MCP_CONFIG_CONFIGMAP_NAME,
-        namespace=superset_namespace,
-        labels=k8s_global_labels,
-    ),
-    data={_MCP_CONFIG_FILENAME: _MCP_CONFIG_CONTENT},
-)
-
-# Build envFrom sources matching those on the main Superset pods so the MCP
-# process has access to all credentials injected via Vault Secrets Operator.
-_mcp_env_from: list[kubernetes.core.v1.EnvFromSourceArgs] = [
-    kubernetes.core.v1.EnvFromSourceArgs(
-        secret_ref=kubernetes.core.v1.SecretEnvSourceArgs(name=app_config_secret_name)
-    ),
-    kubernetes.core.v1.EnvFromSourceArgs(
-        secret_ref=kubernetes.core.v1.SecretEnvSourceArgs(name=redis_secret_name)
-    ),
-    kubernetes.core.v1.EnvFromSourceArgs(
-        secret_ref=kubernetes.core.v1.SecretEnvSourceArgs(name=db_creds_secret_name)
-    ),
-    kubernetes.core.v1.EnvFromSourceArgs(
-        secret_ref=kubernetes.core.v1.SecretEnvSourceArgs(name=oidc_secret_name)
-    ),
-]
-if starrocks_creds_secret_name:
-    _mcp_env_from.append(
-        kubernetes.core.v1.EnvFromSourceArgs(
-            secret_ref=kubernetes.core.v1.SecretEnvSourceArgs(
-                name=starrocks_creds_secret_name
-            )
-        )
-    )
-
-mcp_deployment = kubernetes.apps.v1.Deployment(
-    "superset-mcp-deployment",
-    metadata=kubernetes.meta.v1.ObjectMetaArgs(
-        name="superset-mcp",
-        namespace=superset_namespace,
-        labels=k8s_global_labels | {"ol.mit.edu/process": "mcp"},
-    ),
-    spec=kubernetes.apps.v1.DeploymentSpecArgs(
-        replicas=2,
-        selector=kubernetes.meta.v1.LabelSelectorArgs(
-            match_labels={"app.kubernetes.io/name": "superset-mcp"},
-        ),
-        template=kubernetes.core.v1.PodTemplateSpecArgs(
-            metadata=kubernetes.meta.v1.ObjectMetaArgs(
-                labels=k8s_global_labels
-                | {
-                    "app.kubernetes.io/name": "superset-mcp",
-                    "ol.mit.edu/process": "mcp",
-                },
-            ),
-            spec=kubernetes.core.v1.PodSpecArgs(
-                service_account_name="superset",
-                containers=[
-                    kubernetes.core.v1.ContainerArgs(
-                        name="superset-mcp",
-                        image=f"{ecr_image_uri('mitodl/superset')}:{SUPERSET_TAG}",
-                        command=[
-                            "superset",
-                            "mcp",
-                            "run",
-                            "--host",
-                            "0.0.0.0",  # noqa: S104
-                            "--port",
-                            "5008",
-                        ],
-                        ports=[
-                            kubernetes.core.v1.ContainerPortArgs(
-                                container_port=5008,
-                                name="mcp",
-                            )
-                        ],
-                        env=[
-                            # Matches the extraEnv on the main Helm chart pods
-                            kubernetes.core.v1.EnvVarArgs(
-                                name="REDIS_PROTO",
-                                value="rediss",
-                            ),
-                            # Public URL for MCP-generated links (chart previews, etc.)
-                            kubernetes.core.v1.EnvVarArgs(
-                                name="SUPERSET_MCP_PUBLIC_URL",
-                                value=f"https://{superset_domain}",
-                            ),
-                            # Point Superset to the ConfigMap-mounted config file so
-                            # MCP_* settings are loaded regardless of image contents.
-                            kubernetes.core.v1.EnvVarArgs(
-                                name="SUPERSET_CONFIG_PATH",
-                                value=f"{_MCP_CONFIG_MOUNT_PATH}/{_MCP_CONFIG_FILENAME}",
-                            ),
-                        ],
-                        env_from=_mcp_env_from,
-                        # tcpSocket probes are used because the /mcp endpoint
-                        # speaks JSON-RPC (not plain HTTP GET), so an HTTP probe
-                        # would receive an unexpected response code.
-                        readiness_probe=kubernetes.core.v1.ProbeArgs(
-                            tcp_socket=kubernetes.core.v1.TCPSocketActionArgs(
-                                port=5008,
-                            ),
-                            initial_delay_seconds=10,
-                            period_seconds=5,
-                            failure_threshold=3,
-                        ),
-                        liveness_probe=kubernetes.core.v1.ProbeArgs(
-                            tcp_socket=kubernetes.core.v1.TCPSocketActionArgs(
-                                port=5008,
-                            ),
-                            initial_delay_seconds=15,
-                            period_seconds=10,
-                            failure_threshold=3,
-                        ),
-                        resources=kubernetes.core.v1.ResourceRequirementsArgs(
-                            limits={"cpu": "500m", "memory": "512Mi"},
-                            requests={"cpu": "100m", "memory": "256Mi"},
-                        ),
-                        volume_mounts=[
-                            # OL logo (matches the mount on main Superset pods)
-                            kubernetes.core.v1.VolumeMountArgs(
-                                name="ol-logo",
-                                mount_path=_LOGO_MOUNT_PATH,
-                                sub_path=_LOGO_FILENAME,
-                                read_only=True,
-                            ),
-                            # Superset config with MCP settings
-                            kubernetes.core.v1.VolumeMountArgs(
-                                name="mcp-config",
-                                mount_path=_MCP_CONFIG_MOUNT_PATH,
-                                read_only=True,
-                            ),
-                        ],
-                    )
-                ],
-                volumes=[
-                    kubernetes.core.v1.VolumeArgs(
-                        name="ol-logo",
-                        config_map=kubernetes.core.v1.ConfigMapVolumeSourceArgs(
-                            name=_LOGO_CONFIGMAP_NAME,
-                        ),
-                    ),
-                    kubernetes.core.v1.VolumeArgs(
-                        name="mcp-config",
-                        config_map=kubernetes.core.v1.ConfigMapVolumeSourceArgs(
-                            name=_MCP_CONFIG_CONFIGMAP_NAME,
-                        ),
-                    ),
-                ],
-            ),
-        ),
-    ),
-    opts=ResourceOptions(
-        depends_on=[logo_configmap, mcp_config_configmap, superset_chart],
-    ),
-)
-
-mcp_service = kubernetes.core.v1.Service(
-    "superset-mcp-service",
-    metadata=kubernetes.meta.v1.ObjectMetaArgs(
-        name="superset-mcp",
-        namespace=superset_namespace,
-        labels=k8s_global_labels | {"ol.mit.edu/process": "mcp"},
-    ),
-    spec=kubernetes.core.v1.ServiceSpecArgs(
-        selector={"app.kubernetes.io/name": "superset-mcp"},
-        ports=[
-            kubernetes.core.v1.ServicePortArgs(
-                port=5008,
-                target_port=5008,
-                name="mcp",
-            )
-        ],
-    ),
 )
 
 ########################################

--- a/src/ol_infrastructure/applications/superset/__main__.py
+++ b/src/ol_infrastructure/applications/superset/__main__.py
@@ -897,6 +897,25 @@ mcp_deployment = kubernetes.apps.v1.Deployment(
                             ),
                         ],
                         env_from=_mcp_env_from,
+                        # tcpSocket probes are used because the /mcp endpoint
+                        # speaks JSON-RPC (not plain HTTP GET), so an HTTP probe
+                        # would receive an unexpected response code.
+                        readiness_probe=kubernetes.core.v1.ProbeArgs(
+                            tcp_socket=kubernetes.core.v1.TCPSocketActionArgs(
+                                port=5008,
+                            ),
+                            initial_delay_seconds=10,
+                            period_seconds=5,
+                            failure_threshold=3,
+                        ),
+                        liveness_probe=kubernetes.core.v1.ProbeArgs(
+                            tcp_socket=kubernetes.core.v1.TCPSocketActionArgs(
+                                port=5008,
+                            ),
+                            initial_delay_seconds=15,
+                            period_seconds=10,
+                            failure_threshold=3,
+                        ),
                         resources=kubernetes.core.v1.ResourceRequirementsArgs(
                             limits={"cpu": "500m", "memory": "512Mi"},
                             requests={"cpu": "100m", "memory": "256Mi"},
@@ -979,8 +998,9 @@ gateway_config = OLEKSGatewayConfig(
         ),
     ],
     routes=[
-        # Route /mcp to the MCP server before the catch-all / route so Traefik
-        # matches the more-specific prefix first.
+        # Each OLEKSGatewayRouteConfig becomes a separate HTTPRoute resource;
+        # list order does not affect matching.  Gateway API selects the most
+        # specific matching route by prefix length, so /mcp always wins over /.
         OLEKSGatewayRouteConfig(
             backend_service_name="superset-mcp",
             backend_service_namespace=superset_namespace,

--- a/src/ol_infrastructure/applications/superset/__main__.py
+++ b/src/ol_infrastructure/applications/superset/__main__.py
@@ -781,6 +781,185 @@ celery_keda_scaling = kubernetes.apiextensions.CustomResource(
 )
 
 ########################################
+# Superset MCP Server                   #
+########################################
+# The MCP server runs as a separate Deployment using the same custom Superset
+# image.  It shares all Vault-synced secrets with the main pods and exposes
+# the MCP API at /mcp, routed through the existing HTTPS Gateway listener.
+#
+# Config delivery: the superset_config.py from this Pulumi project is mounted
+# via a dedicated ConfigMap and pointed to by SUPERSET_CONFIG_PATH so the
+# process loads the same Python config (including MCP_* settings) regardless
+# of what is baked into the image.
+#
+# Prerequisite: the custom 'mitodl/superset' image must include the fastmcp
+# package (pip install fastmcp) for the 'superset mcp run' sub-command to work.
+
+_MCP_CONFIG_CONFIGMAP_NAME = "superset-mcp-config"
+_MCP_CONFIG_FILENAME = "superset_config.py"
+_MCP_CONFIG_MOUNT_PATH = "/app/superset_mcp_config"
+_MCP_CONFIG_CONTENT = (
+    Path(__file__).parent.joinpath("superset_config.py").read_text(encoding="utf-8")
+)
+
+mcp_config_configmap = kubernetes.core.v1.ConfigMap(
+    "superset-mcp-config-configmap",
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        name=_MCP_CONFIG_CONFIGMAP_NAME,
+        namespace=superset_namespace,
+        labels=k8s_global_labels,
+    ),
+    data={_MCP_CONFIG_FILENAME: _MCP_CONFIG_CONTENT},
+)
+
+# Build envFrom sources matching those on the main Superset pods so the MCP
+# process has access to all credentials injected via Vault Secrets Operator.
+_mcp_env_from: list[kubernetes.core.v1.EnvFromSourceArgs] = [
+    kubernetes.core.v1.EnvFromSourceArgs(
+        secret_ref=kubernetes.core.v1.SecretEnvSourceArgs(name=app_config_secret_name)
+    ),
+    kubernetes.core.v1.EnvFromSourceArgs(
+        secret_ref=kubernetes.core.v1.SecretEnvSourceArgs(name=redis_secret_name)
+    ),
+    kubernetes.core.v1.EnvFromSourceArgs(
+        secret_ref=kubernetes.core.v1.SecretEnvSourceArgs(name=db_creds_secret_name)
+    ),
+    kubernetes.core.v1.EnvFromSourceArgs(
+        secret_ref=kubernetes.core.v1.SecretEnvSourceArgs(name=oidc_secret_name)
+    ),
+]
+if starrocks_creds_secret_name:
+    _mcp_env_from.append(
+        kubernetes.core.v1.EnvFromSourceArgs(
+            secret_ref=kubernetes.core.v1.SecretEnvSourceArgs(
+                name=starrocks_creds_secret_name
+            )
+        )
+    )
+
+mcp_deployment = kubernetes.apps.v1.Deployment(
+    "superset-mcp-deployment",
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        name="superset-mcp",
+        namespace=superset_namespace,
+        labels=k8s_global_labels | {"ol.mit.edu/process": "mcp"},
+    ),
+    spec=kubernetes.apps.v1.DeploymentSpecArgs(
+        replicas=2,
+        selector=kubernetes.meta.v1.LabelSelectorArgs(
+            match_labels={"app.kubernetes.io/name": "superset-mcp"},
+        ),
+        template=kubernetes.core.v1.PodTemplateSpecArgs(
+            metadata=kubernetes.meta.v1.ObjectMetaArgs(
+                labels=k8s_global_labels
+                | {
+                    "app.kubernetes.io/name": "superset-mcp",
+                    "ol.mit.edu/process": "mcp",
+                },
+            ),
+            spec=kubernetes.core.v1.PodSpecArgs(
+                service_account_name="superset",
+                containers=[
+                    kubernetes.core.v1.ContainerArgs(
+                        name="superset-mcp",
+                        image=f"{ecr_image_uri('mitodl/superset')}:{SUPERSET_TAG}",
+                        command=[
+                            "superset",
+                            "mcp",
+                            "run",
+                            "--host",
+                            "0.0.0.0",  # noqa: S104
+                            "--port",
+                            "5008",
+                        ],
+                        ports=[
+                            kubernetes.core.v1.ContainerPortArgs(
+                                container_port=5008,
+                                name="mcp",
+                            )
+                        ],
+                        env=[
+                            # Matches the extraEnv on the main Helm chart pods
+                            kubernetes.core.v1.EnvVarArgs(
+                                name="REDIS_PROTO",
+                                value="rediss",
+                            ),
+                            # Public URL for MCP-generated links (chart previews, etc.)
+                            kubernetes.core.v1.EnvVarArgs(
+                                name="SUPERSET_MCP_PUBLIC_URL",
+                                value=f"https://{superset_domain}",
+                            ),
+                            # Point Superset to the ConfigMap-mounted config file so
+                            # MCP_* settings are loaded regardless of image contents.
+                            kubernetes.core.v1.EnvVarArgs(
+                                name="SUPERSET_CONFIG_PATH",
+                                value=f"{_MCP_CONFIG_MOUNT_PATH}/{_MCP_CONFIG_FILENAME}",
+                            ),
+                        ],
+                        env_from=_mcp_env_from,
+                        resources=kubernetes.core.v1.ResourceRequirementsArgs(
+                            limits={"cpu": "500m", "memory": "512Mi"},
+                            requests={"cpu": "100m", "memory": "256Mi"},
+                        ),
+                        volume_mounts=[
+                            # OL logo (matches the mount on main Superset pods)
+                            kubernetes.core.v1.VolumeMountArgs(
+                                name="ol-logo",
+                                mount_path=_LOGO_MOUNT_PATH,
+                                sub_path=_LOGO_FILENAME,
+                                read_only=True,
+                            ),
+                            # Superset config with MCP settings
+                            kubernetes.core.v1.VolumeMountArgs(
+                                name="mcp-config",
+                                mount_path=_MCP_CONFIG_MOUNT_PATH,
+                                read_only=True,
+                            ),
+                        ],
+                    )
+                ],
+                volumes=[
+                    kubernetes.core.v1.VolumeArgs(
+                        name="ol-logo",
+                        config_map=kubernetes.core.v1.ConfigMapVolumeSourceArgs(
+                            name=_LOGO_CONFIGMAP_NAME,
+                        ),
+                    ),
+                    kubernetes.core.v1.VolumeArgs(
+                        name="mcp-config",
+                        config_map=kubernetes.core.v1.ConfigMapVolumeSourceArgs(
+                            name=_MCP_CONFIG_CONFIGMAP_NAME,
+                        ),
+                    ),
+                ],
+            ),
+        ),
+    ),
+    opts=ResourceOptions(
+        depends_on=[logo_configmap, mcp_config_configmap, superset_chart],
+    ),
+)
+
+mcp_service = kubernetes.core.v1.Service(
+    "superset-mcp-service",
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        name="superset-mcp",
+        namespace=superset_namespace,
+        labels=k8s_global_labels | {"ol.mit.edu/process": "mcp"},
+    ),
+    spec=kubernetes.core.v1.ServiceSpecArgs(
+        selector={"app.kubernetes.io/name": "superset-mcp"},
+        ports=[
+            kubernetes.core.v1.ServicePortArgs(
+                port=5008,
+                target_port=5008,
+                name="mcp",
+            )
+        ],
+    ),
+)
+
+########################################
 # Gateway API routing + TLS certificate #
 ########################################
 
@@ -800,6 +979,18 @@ gateway_config = OLEKSGatewayConfig(
         ),
     ],
     routes=[
+        # Route /mcp to the MCP server before the catch-all / route so Traefik
+        # matches the more-specific prefix first.
+        OLEKSGatewayRouteConfig(
+            backend_service_name="superset-mcp",
+            backend_service_namespace=superset_namespace,
+            backend_service_port=5008,
+            name="superset-mcp-https",
+            listener_name="https-web",
+            hostnames=[superset_domain],
+            port=8443,
+            matches=[{"path": {"type": "PathPrefix", "value": "/mcp"}}],
+        ),
         OLEKSGatewayRouteConfig(
             backend_service_name="superset",
             backend_service_namespace=superset_namespace,

--- a/src/ol_infrastructure/applications/superset/superset_config.py
+++ b/src/ol_infrastructure/applications/superset/superset_config.py
@@ -661,9 +661,11 @@ MCP_JWT_ISSUER = OIDC_URL
 def _mcp_user_resolver(app: object, access_token: object) -> str:  # noqa: ARG001
     """Resolve a Superset username from a validated Keycloak JWT.
 
-    Checks claims in the same order as
-    ``CustomSsoSecurityManager.load_user_jwt`` so both the UI and MCP paths
-    identify the same Superset user from a given Keycloak token.
+    Tries ``preferred_username`` first (the canonical Keycloak claim), then
+    falls back to ``username``, ``email``, and the ``sub`` subject claim in
+    that order.  The primary ``preferred_username`` path aligns with
+    ``CustomSsoSecurityManager.load_user_jwt``; the additional fallbacks handle
+    machine/service-account tokens that may omit ``preferred_username``.
     """
     payload: dict[str, object] = getattr(access_token, "payload", {})
     return (

--- a/src/ol_infrastructure/applications/superset/superset_config.py
+++ b/src/ol_infrastructure/applications/superset/superset_config.py
@@ -622,6 +622,92 @@ def _interpolate_env_vars(value: str | None) -> str | None:
     return _ENV_VAR_PATTERN.sub(_replace, value)
 
 
+# ---------------------------------------------------
+# MCP Server Configuration
+# ---------------------------------------------------
+# The MCP server runs as a separate Kubernetes Deployment (superset-mcp)
+# alongside the main Superset web pods.  It exposes the Superset MCP API at
+# /mcp, routed through the existing Gateway listener at https://{domain}/mcp.
+#
+# Authentication re-uses the Keycloak RS256 JWT tokens already issued for
+# Superset UI access.  The MCP server validates incoming Bearer tokens against
+# the Keycloak JWKS endpoint and resolves the Superset user by
+# preferred_username, which mirrors the existing
+# CustomSsoSecurityManager.load_user_jwt path.
+#
+# Multi-pod session state is backed by Redis DB 3 (distinct from the Superset
+# metadata cache on DB 0, Celery broker on DB 1, and Celery results on DB 2)
+# so that all MCP replicas share session context.
+#
+# Requires: fastmcp package in the Superset image (pip install fastmcp).
+
+MCP_SERVICE_HOST = "0.0.0.0"  # noqa: S104 - bind all interfaces in k8s
+MCP_SERVICE_PORT = 5008
+# Public-facing base URL for MCP-generated links (e.g. chart preview URLs).
+# Injected at runtime via SUPERSET_MCP_PUBLIC_URL env var set in Pulumi.
+MCP_SERVICE_URL = os.environ.get("SUPERSET_MCP_PUBLIC_URL")
+
+# JWT authentication via Keycloak RS256 JWKS endpoint.
+# OIDC_URL is the Keycloak realm base URL injected from the oidc k8s secret
+# (e.g. https://keycloak.example.com/realms/master).
+MCP_AUTH_ENABLED = True
+MCP_JWT_ALGORITHM = "RS256"
+# Keycloak publishes its realm signing keys at this well-known path.
+MCP_JWKS_URI = f"{OIDC_URL}/protocol/openid-connect/certs" if OIDC_URL else None
+# Keycloak sets the 'iss' claim to the realm URL.
+MCP_JWT_ISSUER = OIDC_URL
+
+
+def _mcp_user_resolver(app: object, access_token: object) -> str:  # noqa: ARG001
+    """Resolve a Superset username from a validated Keycloak JWT.
+
+    Checks claims in the same order as
+    ``CustomSsoSecurityManager.load_user_jwt`` so both the UI and MCP paths
+    identify the same Superset user from a given Keycloak token.
+    """
+    payload: dict[str, object] = getattr(access_token, "payload", {})
+    return (
+        str(payload.get("preferred_username") or "")
+        or str(payload.get("username") or "")
+        or str(payload.get("email") or "")
+        or str(getattr(access_token, "subject", "") or "")
+        or ""
+    )
+
+
+MCP_USER_RESOLVER = _mcp_user_resolver
+
+# Redis-backed session store so all MCP replicas share session state.
+# Uses Redis DB 3 — distinct from metadata cache (DB 0), Celery broker (DB 1),
+# and Celery results backend (DB 2).
+MCP_STORE_CONFIG = {
+    "enabled": True,
+    "CACHE_REDIS_URL": f"rediss://default:{REDIS_TOKEN}@{REDIS_HOST}:{REDIS_PORT}/3",
+    "event_store_max_events": 100,
+    "event_store_ttl": 3600,
+}
+
+# Response caching for read-heavy tool calls (dashboard/dataset listings).
+# Mutating and non-deterministic tools are always excluded.
+MCP_CACHE_CONFIG = {
+    "enabled": True,
+    "CACHE_KEY_PREFIX": "superset_mcp_cache",
+    "list_tools_ttl": 300,
+    "list_resources_ttl": 300,
+    "list_prompts_ttl": 300,
+    "read_resource_ttl": 3600,
+    "get_prompt_ttl": 3600,
+    "call_tool_ttl": 3600,
+    "max_item_size": 1048576,  # 1 MB per cached response
+    "excluded_tools": [
+        "execute_sql",
+        "generate_dashboard",
+        "generate_chart",
+        "update_chart",
+    ],
+}
+
+
 def DB_CONNECTION_MUTATOR(  # noqa: N802
     uri: URL,
     params: dict[str, object],

--- a/src/ol_infrastructure/applications/superset/superset_config.py
+++ b/src/ol_infrastructure/applications/superset/superset_config.py
@@ -641,8 +641,10 @@ def _interpolate_env_vars(value: str | None) -> str | None:
 #
 # Requires: fastmcp package in the Superset image (pip install fastmcp).
 
-MCP_SERVICE_HOST = "0.0.0.0"  # noqa: S104 - bind all interfaces in k8s
-MCP_SERVICE_PORT = 5008
+# The bind address and port are not configurable from here: `superset mcp run`
+# takes them as CLI flags, and the chart's supersetMcp.command already passes
+# --host 0.0.0.0 --port {{ supersetMcp.service.port }}.
+#
 # Public-facing base URL for MCP-generated links (e.g. chart preview URLs).
 # Injected at runtime via SUPERSET_MCP_PUBLIC_URL env var set in Pulumi.
 MCP_SERVICE_URL = os.environ.get("SUPERSET_MCP_PUBLIC_URL")
@@ -700,7 +702,9 @@ MCP_CACHE_CONFIG = {
     "read_resource_ttl": 3600,
     "get_prompt_ttl": 3600,
     "call_tool_ttl": 3600,
-    "max_item_size": 1048576,  # 1 MB per cached response
+    # No per-item size cap: upstream documents max_item_size but
+    # _build_caching_settings() never forwards it to FastMCP's
+    # ResponseCachingMiddleware, so setting it would be inert.
     "excluded_tools": [
         "execute_sql",
         "generate_dashboard",

--- a/src/ol_superset/requirements.txt
+++ b/src/ol_superset/requirements.txt
@@ -4,6 +4,7 @@ starrocks
 mysqlclient
 celery-redbeat
 duckdb
+fastmcp
 flask-caching
 flask-oidc
 flask-openid


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)

Deploys the [Superset MCP server](https://superset.apache.org/admin-docs/6.1.0/configuration/mcp-server/) alongside the existing Superset web pods, exposing it at `https://{domain}/mcp` so MCP-compatible AI clients (Claude Desktop, Claude Code, etc.) can interact with Superset dashboards, datasets, and SQL Lab.

**Three files changed:**

#### `src/ol_superset/requirements.txt`
Adds `fastmcp` — the package that provides the `superset mcp run` CLI sub-command (Superset 5.0+ prerequisite).

#### `src/ol_infrastructure/applications/superset/superset_config.py`
New `MCP Server Configuration` section:
- **Auth**: `MCP_AUTH_ENABLED = True` with RS256 JWT validated against Keycloak's JWKS endpoint (`{OIDC_URL}/protocol/openid-connect/certs`). Reuses the `OIDC_URL` env var already injected from the `superset-oidc-secret` Vault-synced secret.
- **User resolver**: `_mcp_user_resolver` resolves `preferred_username → username → email → sub`, mirroring the existing `CustomSsoSecurityManager.load_user_jwt` path so both UI and MCP flows identify the same Superset user from a Keycloak token.
- **Session store**: Redis DB 3 (`MCP_STORE_CONFIG`) for cross-replica session consistency. DB 3 is distinct from the existing allocations (metadata cache DB 0, Celery broker DB 1, Celery results DB 2).
- **Response cache**: `MCP_CACHE_CONFIG` with per-operation TTLs; mutating tools (`execute_sql`, `generate_chart`, etc.) are always excluded.
- **Public URL**: `MCP_SERVICE_URL` read from `SUPERSET_MCP_PUBLIC_URL` env var (injected by Pulumi) so MCP-generated chart/dashboard links resolve to the correct domain.

#### `src/ol_infrastructure/applications/superset/__main__.py`
Four new Pulumi resources:

| Resource | Kind | Purpose |
|---|---|---|
| `superset-mcp-config` | ConfigMap | Mounts `superset_config.py` from the Pulumi project directory; `SUPERSET_CONFIG_PATH` points the MCP process to it so it loads identical config to the web pods regardless of image contents |
| `superset-mcp` | Deployment (2 replicas) | Same image/service account/Vault secrets as main pods; runs `superset mcp run --host 0.0.0.0 --port 5008` |
| `superset-mcp` | Service (ClusterIP :5008) | Selects `app.kubernetes.io/name: superset-mcp` pods |
| `superset-mcp-https` | HTTPRoute | `PathPrefix: /mcp` on the existing HTTPS Gateway listener, ordered **before** the catch-all `PathPrefix: /` route so Traefik matches it first |

RBAC is enforced by default (`MCP_RBAC_ENABLED` defaults to `True`): every MCP tool call respects the authenticated user's Superset roles.

### How can this be tested?

1. Deploy to QA: `cd src/ol_infrastructure/applications/superset && pulumi stack select applications.superset.QA && pulumi preview` (then `pulumi up`)
2. Verify the MCP pod starts: `kubectl -n superset get pods -l app.kubernetes.io/name=superset-mcp`
3. Check the health endpoint: `curl https://bi-qa.ol.mit.edu/mcp` — should return an MCP protocol response (not 404)
4. Connect Claude Desktop or Claude Code to `https://bi-qa.ol.mit.edu/mcp` with a valid Keycloak Bearer token and confirm tools like `list_dashboards` work

### Additional Context

- The MCP server shares the `superset` Kubernetes service account (IRSA), so it inherits the same S3/SES/Bedrock IAM permissions as the web pods — no new IAM changes needed.
- Redis DB index 3 was chosen to avoid collisions with the existing allocations documented in `superset_config.py`.
- The MCP endpoint is on the same domain as the Superset UI (`/mcp` path), so no additional TLS certificate or DNS record is required.