### PR TITLE
fix(dagster): set IRSA role max_session_duration to 12 hours to prevent ExpiredToken in long pipeline runs

### DIFF
--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -435,6 +435,10 @@ dagster_auth_binding = OLEKSAuthBinding(
         ],
         k8s_labels=k8s_global_labels,
         parliament_config=parliament_config,
+        # Dagster pipelines can run for several hours (e.g. bulk edxorg S3 loads).
+        # The AWS default of 1 hour causes ExpiredToken errors mid-pipeline.
+        # 12 hours (the AWS maximum) gives ample headroom for all workloads.
+        irsa_max_session_duration=43200,
     )
 )
 

--- a/src/ol_infrastructure/components/applications/eks.py
+++ b/src/ol_infrastructure/components/applications/eks.py
@@ -55,6 +55,11 @@ class OLEKSAuthBindingConfig(BaseModel):
     # Set to False (default) when the ServiceAccount is managed externally (e.g. by
     # Helm) or already exists in the cluster.
     create_irsa_service_account: bool = False
+    # Maximum STS session duration for the IRSA role (seconds).
+    # AWS default is 3600 (1 hour); maximum allowed by AWS is 43200 (12 hours).
+    # Increase this for deployments that run long pipeline jobs (e.g. bulk S3 loads)
+    # that would otherwise hit ExpiredToken after 1 hour.
+    irsa_max_session_duration: int = 3600
 
     @model_validator(mode="after")
     def validate_vault_policy(self):
@@ -133,6 +138,7 @@ class OLEKSAuthBinding(ComponentResource):
                 role_name=config.application_name,
                 service_account_name=config.irsa_service_account_name,
                 service_account_namespace=config.namespace,
+                max_session_duration=config.irsa_max_session_duration,
                 tags=config.aws_config.tags,
             ),
             opts=ResourceOptions(parent=self),

--- a/src/ol_infrastructure/components/aws/eks.py
+++ b/src/ol_infrastructure/components/aws/eks.py
@@ -296,6 +296,11 @@ class OLEKSTrustRoleConfig(AWSBase):
     service_account_identifier: str | list[str] | None = None
     service_account_name: str | list[str] | None = None
     service_account_namespace: str | None = None
+    # Maximum duration (seconds) for STS sessions issued via AssumeRoleWithWebIdentity.
+    # AWS default is 3600 (1 hour); maximum is 43200 (12 hours).
+    # Long-running pipeline workloads (e.g. large S3 bulk-loads) may need more than
+    # 1 hour.  Set this to 43200 for Dagster or similar batch-processing deployments.
+    max_session_duration: int = 3600
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @model_validator(mode="after")
@@ -381,6 +386,7 @@ class OLEKSTrustRole(pulumi.ComponentResource):
                     )
                 ),
                 description=role_config.description,
+                max_session_duration=role_config.max_session_duration,
                 tags=role_config.tags,
                 opts=pulumi.ResourceOptions(parent=self).merge(opts),
             )


### PR DESCRIPTION
### What are the relevant tickets?
N/A — companion to mitodl/ol-data-platform#2270

### Description (What does it do?)

Dagster pipeline jobs — in particular bulk S3 loads in the `data_loading` code location (e.g. processing all `auth_user` files from the edxorg landing zone) — can run for several hours. The AWS default `max_session_duration` for an IAM role is **3600 seconds (1 hour)**. When a Dagster asset materialisation outlasts that window, the STS session token obtained via `AssumeRoleWithWebIdentity` (IRSA) expires and every subsequent `s3:GetObject` call fails with:

```
botocore.exceptions.ClientError: An error occurred (ExpiredToken)
when calling the GetObject operation: The provided token has expired.
```

This PR:

1. **`OLEKSTrustRoleConfig`** (lowest-level component) — adds a `max_session_duration: int = 3600` field and passes it to `aws.iam.Role`. Default is 3600 to preserve existing behaviour for every other deployment that uses this component.

2. **`OLEKSAuthBindingConfig`** (mid-level component) — adds `irsa_max_session_duration: int = 3600` and threads it through to `OLEKSTrustRoleConfig`.

3. **Dagster `__main__.py`** — sets `irsa_max_session_duration=43200` (12 hours, the AWS maximum) on the Dagster `OLEKSAuthBinding`. All other deployments using `OLEKSAuthBinding` are unaffected because their field defaults to 3600.

#### Why 12 hours?

The `auth_user` table alone can have tens of thousands of TSV files across all edX.org courses. Even with the code-side fix (see companion PR), a first-run bulk load could take many hours. Setting the role maximum to 12 hours removes the hard ceiling entirely while staying within the AWS-allowed maximum for any role.

#### Companion code-side fix

mitodl/ol-data-platform#2270 also bypasses dlt's `get_frozen_credentials()` credential-snapshotting problem (which strips `RefreshableCredentials` down to static strings before handing them to s3fs). Together, both PRs provide belt-and-suspenders protection: the code fix ensures aiobotocore's `AioRefreshableCredentials` actually refreshes the token when it expires; this infrastructure fix ensures the role allows sessions long enough that even a worst-case first-time bulk load has plenty of headroom.

### How can this be tested?

1. Run `pulumi preview` against the QA stack and confirm the plan shows an **update** to the Dagster IRSA trust role with `max_session_duration` changing from 3600 → 43200. All other resources should be unchanged.
2. Apply to QA, then trigger a full `edxorg_s3_tables` materialisation and confirm no `ExpiredToken` errors across a multi-hour run.

### Additional Context

- No other deployments are affected — all callers of `OLEKSAuthBinding` that do not set `irsa_max_session_duration` continue to get the AWS default of 3600 seconds.
- `max_session_duration` on an IAM role is a ceiling, not a grant. The actual session duration for each `AssumeRoleWithWebIdentity` call is still determined by the `DurationSeconds` parameter (defaulting to 1 hour if not specified by the caller). aiobotocore's refreshable credentials renew automatically when the current session approaches expiry — this change simply raises the ceiling so long-running renewals are not rejected by IAM.