### PR TITLE
fix(keycloak): eliminate QA rolling-update downtime via rolling-updates:v2 and 3-replica HA

### DIFF
--- a/src/ol_infrastructure/applications/keycloak/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/keycloak/Pulumi.QA.yaml
@@ -4,7 +4,7 @@ encryptedkey: AQICAHi7xhTkB8tf1ObyPMxDhODJja4Mn4jyIo32zZVlOiZPFgHt3EmKiORMnsrUqO
 config:
   aws:region: us-east-1
   consul:address: https://consul-operations-qa.odl.mit.edu
-  keycloak:replicas: "2"
+  keycloak:replicas: "3"
   keycloak:memory_request: 1Gi
   keycloak:memory_limit: 2Gi
   keycloak:cpu_request: 1000m

--- a/src/ol_infrastructure/applications/keycloak/__main__.py
+++ b/src/ol_infrastructure/applications/keycloak/__main__.py
@@ -415,7 +415,14 @@ keycloak_resource = kubernetes.apiextensions.CustomResource(
         labels=k8s_global_labels,
     ),
     spec={
-        "update": {"strategy": "Auto"},
+        "update": {"strategy": "RollingUpdate"},
+        # rolling-updates:v2 coordinates Infinispan cache-sync during rolling
+        # updates so the embedded cluster topology change no longer causes a
+        # brief HTTP 503 on /health/ready, eliminating the zero-endpoint window
+        # that produces downtime on 2-replica deployments.
+        "features": {
+            "enabled": ["rolling-updates:v2"],
+        },
         "instances": keycloak_config.get_int("replicas") or 2,
         "image": cached_image_uri(f"mitodl/keycloak@{KEYCLOAK_DOCKER_DIGEST}"),
         "db": {
@@ -452,6 +459,9 @@ keycloak_resource = kubernetes.apiextensions.CustomResource(
         "unsupported": {
             "podTemplate": {
                 "spec": {
+                    # Give Infinispan enough time to gracefully leave the
+                    # cluster before the pod is force-killed.
+                    "terminationGracePeriodSeconds": 60,
                     "containers": [
                         {
                             "name": "keycloak",
@@ -490,7 +500,7 @@ keycloak_resource = kubernetes.apiextensions.CustomResource(
                                 ),
                             ],
                         },
-                    ]
+                    ],
                 }
             },
         },
@@ -560,6 +570,31 @@ keycloak_service_monitor = kubernetes.apiextensions.CustomResource(
     ),
 )
 
+# PodDisruptionBudget: ensures at least (replicas - 1) pods remain available
+# during voluntary disruptions (node drain, cluster upgrades).  With 3 replicas
+# this guarantees 2 serving pods at all times, which is also the minimum
+# required for the embedded Infinispan cluster to avoid a topology-change 503.
+keycloak_pdb = kubernetes.policy.v1.PodDisruptionBudget(
+    f"{env_name}-keycloak-pdb",
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        name=f"{keycloak_resource_name}-pdb",
+        namespace=keycloak_namespace,
+        labels=k8s_global_labels,
+    ),
+    spec=kubernetes.policy.v1.PodDisruptionBudgetSpecArgs(
+        max_unavailable=1,
+        selector=kubernetes.meta.v1.LabelSelectorArgs(
+            match_labels={
+                "app": "keycloak",
+                "app.kubernetes.io/instance": keycloak_resource_name,
+            },
+        ),
+    ),
+    opts=ResourceOptions(
+        depends_on=[keycloak_resource],
+    ),
+)
+
 gateway_config = OLEKSGatewayConfig(
     cert_issuer="letsencrypt-production",
     cert_issuer_class="cluster-issuer",
@@ -603,7 +638,7 @@ keycloak_server_vault_mount = vault.Mount(
     "keycloak-server-configuration-secrets-mount",
     path="secret-keycloak",
     type="kv-v2",
-    options={"version": 2},
+    options={"version": "2"},
     description="Storage of configuration credentials and secrets used by keycloak",
     opts=ResourceOptions(delete_before_replace=True),
 )


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)

QA Keycloak deployments have routinely caused complete service outages during rolling updates while production deployments do not. This PR identifies and fixes the root cause.

**Root cause — Infinispan topology-change 503 on a 2-replica cluster**

Keycloak uses an embedded Infinispan cache cluster. With 2 replicas and `maxUnavailable: 1` on the StatefulSet, a rolling update reduces the cluster to a single member. Infinispan responds to that topology change by triggering a rebalance, during which `/health/ready` returns HTTP 503. The Service removes that pod from its endpoint list. Because the other pod is simultaneously being replaced, both pods hit 503 within ~18 seconds of each other — producing a zero-endpoint window and full downtime. This was confirmed live in the `operations-qa` cluster:

```
Warning  Unhealthy  keycloak-qa-0  Readiness probe failed: HTTP probe failed with statuscode: 503
Warning  Unhealthy  keycloak-qa-1  Readiness probe failed: HTTP probe failed with statuscode: 503
```

Production is unaffected because 3 replicas means the Infinispan cluster always retains ≥ 2 members during any single-pod replacement, so no rebalance is triggered.

**Changes**

| File | Change | Reason |
|---|---|---|
| `__main__.py` | Enable `rolling-updates:v2` Keycloak feature | Primary fix. Coordinates Infinispan cache-sync during rolling updates so the topology-change 503 is no longer visible to the Service. This is the approach recommended in the [Keycloak HA operator docs](https://www.keycloak.org/high-availability/multi-cluster/deploy-keycloak-kubernetes). |
| `__main__.py` | `terminationGracePeriodSeconds: 60` on the pod template | Gives Infinispan time to cleanly leave the cluster before SIGKILL. The default 30 s is too short and can cause the surviving pods to see an abrupt departure, triggering a more disruptive rebalance. |
| `__main__.py` | Add `PodDisruptionBudget` (`maxUnavailable: 1`) | Prevents node drains and cluster upgrades from voluntarily removing more than 1 pod simultaneously, which would recreate the same 2→1 Infinispan scenario. |
| `__main__.py` | `update.strategy: RollingUpdate` (was `Auto`) | Explicit over implicit — prevents the operator from falling back to `Recreate` for any future change that it classifies as incompatible. |
| `__main__.py` | Fix `options={"version": "2"}` on Vault mount | Pre-existing type error: the Pulumi Vault provider expects `str` values in `options`, not `int`. |
| `Pulumi.QA.yaml` | `replicas: 2` → `replicas: 3` | Mirrors production and eliminates the single-member Infinispan window entirely, acting as a defence-in-depth backstop even if `rolling-updates:v2` is not effective for some reason. |

### How can this be tested?

1. Deploy to QA: `cd src/ol_infrastructure/applications/keycloak && pulumi stack select ol-application-keycloak.QA && pulumi up`
2. Confirm 3 pods reach `Ready` state: `kubectl --context operations-qa -n keycloak get pods -w`
3. Trigger a second deployment (change an env var, redeploy) and observe that all 3 pods cycle through `Running → Ready` without any pod ever dropping out of the Service endpoints.
4. Confirm the Keycloak CR status shows `Ready: True` throughout: `kubectl --context operations-qa -n keycloak get keycloak keycloak-qa -o jsonpath='{.status.conditions}'`
5. Verify the PDB is present: `kubectl --context operations-qa -n keycloak get pdb`

### Additional Context

The wrong probes added in an earlier attempt (HTTP port 8080, path `/realms/master`) were also removed. The Keycloak operator already configures the correct probes (`HTTPS :9000 /health/{ready,live,started}`) — overriding them with incorrect values would have made the situation worse.