### PR TITLE
fix(keycloak): update Georgian National University SEU SAML configuration from metadata

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/olapps.py
+++ b/src/ol_infrastructure/substructure/keycloak/olapps.py
@@ -837,10 +837,11 @@ def create_olapps_realm(  # noqa: PLR0913, PLR0915
             SamlIdpConfig(
                 idp_alias="SEU",
                 idp_display_name="Georgian National University Seu",
-                org_saml_metadata_url="https://auth.seu.edu.ge/realms/seu-realm/protocol/saml/descriptor",
+                org_saml_metadata_url="https://emis1.seu.edu.ge/saml/metadata",
                 principal_type="ATTRIBUTE",
                 principal_attribute="urn:oid:0.9.2342.19200300.100.1.3",
-                name_id_format=NameIdFormat.unspecified,
+                name_id_format=NameIdFormat.email,
+                single_sign_on_service_url="https://emis1.seu.edu.ge/saml/sso/mit",
                 keycloak_url=keycloak_url,
                 realm_id=ol_apps_realm.id,
                 first_login_flow=ol_first_login_flow,


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Updates the Georgian National University SEU SAML IdP configuration in the `olapps` Keycloak realm, based on introspection of the live metadata at `https://emis1.seu.edu.ge/saml/metadata`.

**Changes:**

- `name_id_format`: `Unspecified` → `Email`
  The IdP metadata declares `urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress` as its primary NameID format (listed first). Aligning to the IdP's advertised primary format avoids negotiation ambiguity during authentication.

- `single_sign_on_service_url`: added `https://emis1.seu.edu.ge/saml/sso/mit`
  The metadata's `SingleSignOnService` Location is `http://emis1.seu.edu.ge/saml/sso/mit` (plain HTTP). Without an override Keycloak would use that insecure URL for SP-initiated SSO redirects; this override pins it to the HTTPS equivalent.

All other settings (`want_assertions_encrypted=False`, `want_assertions_signed=True`, OID-based principal attribute, attribute map) were confirmed correct against the metadata.

### How can this be tested?
Pending deploy to QA Keycloak. Validate by attempting a SEU-domain SSO login through the `olapps` realm and confirming the authentication flow completes without NameID format negotiation errors.