### PR TITLE
fix(keycloak): revert invalid update strategy and remove rolling-updates:v2 feature flag

### DIFF
--- a/src/ol_infrastructure/applications/keycloak/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/applications/keycloak/Pulumi.CI.yaml
@@ -4,7 +4,7 @@ encryptedkey: AQICAHi+npazf3LfzV9oCtcYyCMYLOzaQhbo9xt6lJVVpz9tkQHNlCOaS3lGDlMCvG
 config:
   aws:region: us-east-1
   consul:address: https://consul-operations-ci.odl.mit.edu
-  keycloak:replicas: 2
+  keycloak:replicas: 3
   keycloak:memory_request: 1Gi
   keycloak:memory_limit: 2Gi
   keycloak:cpu_request: 1000m

--- a/src/ol_infrastructure/applications/keycloak/__main__.py
+++ b/src/ol_infrastructure/applications/keycloak/__main__.py
@@ -415,14 +415,7 @@ keycloak_resource = kubernetes.apiextensions.CustomResource(
         labels=k8s_global_labels,
     ),
     spec={
-        "update": {"strategy": "RollingUpdate"},
-        # rolling-updates:v2 coordinates Infinispan cache-sync during rolling
-        # updates so the embedded cluster topology change no longer causes a
-        # brief HTTP 503 on /health/ready, eliminating the zero-endpoint window
-        # that produces downtime on 2-replica deployments.
-        "features": {
-            "enabled": ["rolling-updates:v2"],
-        },
+        "update": {"strategy": "Auto"},
         "instances": keycloak_config.get_int("replicas") or 2,
         "image": cached_image_uri(f"mitodl/keycloak@{KEYCLOAK_DOCKER_DIGEST}"),
         "db": {


### PR DESCRIPTION
### What are the relevant tickets?
N/A — follow-up to #4696

### Description (What does it do?)

Two regressions were introduced in #4696 that need to be corrected, plus a consistency fix for CI.

**Regression 1 — invalid `spec.update.strategy` value**

The strategy was changed from `Auto` to `RollingUpdate`. However, the Keycloak Operator CRD (v26.2.4) only accepts `Auto`, `Explicit`, `RecreateOnImageChange`, or `null` for that field. `RollingUpdate` is not valid and is immediately rejected by the API server with:

```
spec.update.strategy: Unsupported value: "RollingUpdate":
  supported values: "Auto", "Explicit", "RecreateOnImageChange", <nil>
```

This caused the CI stack to fail on every deploy and blocked the QA deploy from completing cleanly.

**Regression 2 — `rolling-updates:v2` feature flag causes operator deadlock**

Adding `features.enabled: [rolling-updates:v2]` triggered a code path in `AutoUpdateLogic` that continuously searches for an "Update Job" pod it never successfully creates. The operator's reconciler threads pile up racing to write CR status updates, producing cascading HTTP 409 Conflicts. This drove the StatefulSet to 0 desired replicas and put the QA environment into a pod create→kill loop cycling every ~1 second — a complete outage worse than the original problem.

Recovery required:
1. Patching the live CR to clear `features.enabled`
2. Restarting the keycloak-operator deployment to drain the reconciliation backlog
3. Patching `instances` back to 3 (it did not survive the storm)

**CI replica bump**

CI was left at 2 replicas. It has the same Infinispan topology-change risk as QA did, and is additionally more exposed because it runs with `startOptimized: false` (slower startup = longer readiness race window). Bumped to 3 to match QA and production.

**What is retained from #4696**

The effective fixes that do not require these features remain in place:
- QA replicas bumped to 3 (matches production; prevents Infinispan ever dropping to a single member during a rolling update)
- `PodDisruptionBudget` with `maxUnavailable: 1`
- `terminationGracePeriodSeconds: 60` on the pod template
- `options={"version": "2"}` Vault mount type fix

The root cause of the original QA downtime (Infinispan topology-change 503 with only 2 replicas) is addressed entirely by the replica count change. `strategy: Auto` is the correct operator-managed value and is restored here.

### How can this be tested?

1. Confirm CI stack deploys cleanly with no API validation errors.
2. Confirm QA stack deploys cleanly and all 3 pods reach Ready without downtime.
3. Verify the Keycloak CR accepts the spec: `kubectl --context operations-qa -n keycloak get keycloak keycloak-qa -o jsonpath='{.spec.update}'` should show `{"strategy":"Auto"}`.

### Additional Context

The operator restart and live CR patches applied during the incident restored QA to a healthy 2-pod state. The replica count still needs to reach 3 once this PR is deployed; a manual patch was applied as a temporary measure.