### PR TITLE
chore: update lehrer dagger invocations for structural refactor

### DIFF
--- a/src/ol_concourse/pipelines/open_edx/codejail_v3/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/codejail_v3/pipeline.py
@@ -91,7 +91,7 @@ def build_codejail_pipeline(
                             start_docker;
                             cd {codejail_lehrer_repo.name};
                             PYTHON_VERSION={openedx_release.python_version};
-                            DAGGER_LOG_LEVEL=debug dagger call build-codejail --progress plain --codejail-config ./codejail_config --python-version $PYTHON_VERSION --release-name {release_name} export --path ../artifacts/image.tar;
+                            DAGGER_LOG_LEVEL=debug dagger call codejail build --progress plain --codejail-config ./deployments/mit-ol/codejail_config --python-version $PYTHON_VERSION --release-name {release_name} export --path ../artifacts/image.tar;
                             """,
                         ],
                     ),

--- a/src/ol_concourse/pipelines/open_edx/edx_notes_v3/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/edx_notes_v3/pipeline.py
@@ -96,7 +96,7 @@ def build_notes_pipeline(
                             start_docker;
                             cd {notes_lehrer_repo.name};
                             PYTHON_VERSION={openedx_release.python_version};
-                            DAGGER_LOG_LEVEL=debug dagger call build-notes --progress plain --notes-code ../{notes_repo.name} --notes-config ./notes_config --python-version $PYTHON_VERSION --release-name {release_name} export --path ../artifacts/image.tar;
+                            DAGGER_LOG_LEVEL=debug dagger call notes build --progress plain --notes-code ../{notes_repo.name} --notes-config ./deployments/mit-ol/notes_config --python-version $PYTHON_VERSION --release-name {release_name} export --path ../artifacts/image.tar;
                             """,
                         ],
                     ),

--- a/src/ol_concourse/pipelines/open_edx/edx_platform_v3/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/edx_platform_v3/pipeline.py
@@ -121,6 +121,21 @@ def build_edx_pipeline(release_names: list[str]) -> Pipeline:  # noqa: ARG001
                 password="((dockerhub.password))",  # noqa: S106
             )
 
+            # Deployment-specific lehrer parameters (moved from lehrer core in
+            # https://github.com/mitodl/lehrer/pull/41).
+            translations_repo = (
+                "mitodl/mitxonline-translations"
+                if deployment_name == "mitxonline"
+                else "openedx/openedx-translations"
+            )
+            # edx-name-affirmation conflicts with the mitxonline build only
+            packages_to_remove_args = (
+                "--packages-to-remove edx-name-affirmation"
+                if deployment_name == "mitxonline"
+                else ""
+            )
+            proctortrack_url = "git+https://git@github.com/verificient/edx-proctoring-proctortrack.git#f0fa9edbd16aa5af5a41ac309d2609e529ea8732"
+
             # Each earthly build requires several inputs, build that list pre-emptively
             earthly_build_job = Job(
                 name=f"build-{release_name}-{deployment_name}-edxapp-image",
@@ -179,7 +194,7 @@ def build_edx_pipeline(release_names: list[str]) -> Pipeline:  # noqa: ARG001
                                     THEME_DIR="../{theme_git_resource.name}"
                                     PYTHON_VERSION="{edx_platform.runtime_version}"
                                     NODE_VERSION="((.:node_version))"
-                                    DAGGER_LOG_LEVEL=debug dagger call build-platform --progress plain --deployment-name $DEPLOYMENT_NAME --release-name $RELEASE_NAME --pip-package-lists ./pip_package_lists --pip-package-overrides ./pip_package_overrides --custom-settings ./settings --source $EDX_PLATFORM_DIR --theme-source $THEME_DIR --node-version $NODE_VERSION --python-version $PYTHON_VERSION export --path ../artifacts/image.tar;""",
+                                    DAGGER_LOG_LEVEL=debug dagger call platform build-platform --progress plain --deployment-name $DEPLOYMENT_NAME --release-name $RELEASE_NAME --pip-package-lists ./deployments/mit-ol/pip_package_lists --pip-package-overrides ./deployments/mit-ol/pip_package_overrides --custom-settings ./deployments/mit-ol/settings --source $EDX_PLATFORM_DIR --theme-source $THEME_DIR --node-version $NODE_VERSION --python-version $PYTHON_VERSION --settings-namespace mitol --extra-ssh-hosts github.mit.edu --translations-repo {translations_repo} {packages_to_remove_args} --extra-npm-packages '{proctortrack_url}' export --path ../artifacts/image.tar;""",
                                 ],
                             ),
                         ),

--- a/src/ol_concourse/pipelines/open_edx/edx_platform_v3/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/edx_platform_v3/pipeline.py
@@ -121,8 +121,8 @@ def build_edx_pipeline(release_names: list[str]) -> Pipeline:  # noqa: ARG001
                 password="((dockerhub.password))",  # noqa: S106
             )
 
-            # Deployment-specific lehrer parameters (moved from lehrer core in
-            # https://github.com/mitodl/lehrer/pull/41).
+            # Per-deployment lehrer parameters (values previously hardcoded inside
+            # lehrer core, extracted in https://github.com/mitodl/lehrer/pull/41).
             translations_repo = (
                 "mitodl/mitxonline-translations"
                 if deployment_name == "mitxonline"
@@ -134,7 +134,8 @@ def build_edx_pipeline(release_names: list[str]) -> Pipeline:  # noqa: ARG001
                 if deployment_name == "mitxonline"
                 else ""
             )
-            proctortrack_url = "git+https://git@github.com/verificient/edx-proctoring-proctortrack.git#f0fa9edbd16aa5af5a41ac309d2609e529ea8732"
+            # Proctortrack is the same package for all deployments
+            proctortrack_url = "git+https://github.com/verificient/edx-proctoring-proctortrack.git#f0fa9edbd16aa5af5a41ac309d2609e529ea8732"
 
             # Each earthly build requires several inputs, build that list pre-emptively
             earthly_build_job = Job(


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Updates the three Concourse pipeline files that invoke lehrer to match the new
sub-command structure and config directory layout introduced in
https://github.com/mitodl/lehrer/pull/41.

**This PR must merge after (or together with) mitodl/lehrer#41.**

#### Changes per pipeline

**`codejail_v3/pipeline.py`**
- `dagger call build-codejail` → `dagger call codejail build`
- `--codejail-config ./codejail_config` → `--codejail-config ./deployments/mit-ol/codejail_config`

**`edx_notes_v3/pipeline.py`**
- `dagger call build-notes` → `dagger call notes build`
- `--notes-config ./notes_config` → `--notes-config ./deployments/mit-ol/notes_config`

**`edx_platform_v3/pipeline.py`**
- `dagger call build-platform` → `dagger call platform build-platform`
- `./pip_package_lists` → `./deployments/mit-ol/pip_package_lists`
- `./pip_package_overrides` → `./deployments/mit-ol/pip_package_overrides`
- `./settings` → `./deployments/mit-ol/settings`
- Added `--settings-namespace mitol` (previously hardcoded inside lehrer)
- Added `--extra-ssh-hosts github.mit.edu` (previously hardcoded inside lehrer)
- Added `--translations-repo` per deployment:
  - `mitxonline` → `mitodl/mitxonline-translations`
  - all others → `openedx/openedx-translations`
- Added `--packages-to-remove edx-name-affirmation` for `mitxonline` only (previously an `if deployment_name == "mitxonline"` branch inside lehrer)
- Added `--extra-npm-packages` with the proctortrack git URL for all deployments (previously hardcoded inside lehrer)

### How can this be tested?
After merging mitodl/lehrer#41, trigger each pipeline against a non-production
environment and confirm the dagger call succeeds:

```bash
# Verify the new sub-command routing resolves (requires dagger CLI + lehrer checked out at main)
cd lehrer
dagger call codejail build --help
dagger call notes build --help
dagger call platform build-platform --help
```

Note: full end-to-end pipeline runs are the definitive test and should be
validated in CI before merging this to production pipelines.

### Additional Context
The translations repo mapping (`mitxonline` → `mitodl/mitxonline-translations`,
others → `openedx/openedx-translations`) was derived from `translation_overrides`
entries in `src/bridge/settings/openedx/version_matrix.py` — only `mitxonline`
has an override set. If another deployment adds a translations repo in future,
`edx_platform_v3/pipeline.py` will need a corresponding entry in the
`translations_repo` mapping.