### PR TITLE
Streamline kubeconfig generation workflow

### DIFF
--- a/scripts/eks/KUBE_ACCESS.md
+++ b/scripts/eks/KUBE_ACCESS.md
@@ -1,13 +1,58 @@
 # Developer EKS Access
 
-See https://pe.ol.mit.edu/how_to/developer_eks_access/ for instructions on
-how to initially set up developer access to EKS and learn about the available
-commands.
+See https://pe.ol.mit.edu/how_to/developer_eks_access/ for initial setup and
+background on access requirements.
 
-Once that is complete, you can use the helper bash script `eks.sh` as a shortcut
-for regenerating AWS creds, creating/overwriting your `~/.kube/config` file,
-setting a context (default is "applications-qa") and optionally listing the
-pods available in a namespace.
+## Preferred workflow
 
-You should run `source eks.env` after the script finishes to ensure the
-environment values are applied to your shell.
+The preferred entrypoint is the cyclopts-based CLI in `scripts/eks/eks.py`.
+It manages a single `~/.kube/config` file covering all OL EKS clusters.
+
+Generate a kubeconfig for all clusters:
+
+```bash
+uv run python scripts/eks/eks.py setup
+```
+
+By default this creates a **readonly** kubeconfig. You can also choose an
+access mode at setup time:
+
+```bash
+uv run python scripts/eks/eks.py setup --mode readonly
+uv run python scripts/eks/eks.py setup --mode developer
+uv run python scripts/eks/eks.py setup --mode admin
+```
+
+Optional current context:
+
+```bash
+uv run python scripts/eks/eks.py setup --mode readonly --current-context applications-qa
+```
+
+## How auth works
+
+The generated kubeconfig uses an `exec` plugin that calls back into
+`scripts/eks/eks.py`.
+
+- `readonly` and `developer` modes are OIDC-first.
+- Vault authentication and generated AWS credentials are cached locally under
+  `~/.cache/ol-infrastructure/eks/`.
+- Users do **not** need to run `source eks.env` or manually refresh temporary
+  AWS credentials before using `kubectl`.
+- The tool currently manages and overwrites `~/.kube/config` directly.
+
+## Access modes
+
+- `readonly` — safe exploratory access everywhere using `AmazonEKSViewPolicy`
+- `developer` — existing shared developer write permissions
+- `admin` — existing cluster-specific admin access
+
+> Note: admin mode still relies on the existing AWS assume-role path for the
+> cluster admin role. Readonly and developer modes are the primary OIDC-first,
+> cached flows.
+
+## Legacy helper
+
+`scripts/eks/eks.sh` is still present for compatibility, but it represents the
+older workflow that required generating shell AWS credentials separately. Prefer
+`uv run python scripts/eks/eks.py setup ...` for new usage.

--- a/scripts/eks/eks.py
+++ b/scripts/eks/eks.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""Manage kubeconfig generation and exec-based auth for OL EKS clusters."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import urllib.parse
+import webbrowser
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Any
+
+import cyclopts
+import hvac
+import yaml
+
+app = cyclopts.App(help="Manage MIT Open Learning EKS kubeconfig setup and auth.")
+
+AWS_REGION = "us-east-1"
+AWS_DEFAULT_REGION = "us-east-1"
+CACHE_DIR = Path.home() / ".cache" / "ol-infrastructure" / "eks"
+KUBECONFIG_DEFAULT_PATH = Path.home() / ".kube" / "config"
+OIDC_CALLBACK_PORT = 8250
+OIDC_REDIRECT_URI = f"http://localhost:{OIDC_CALLBACK_PORT}/oidc/callback"
+PULUMI_EKS_PROJECT_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "ol_infrastructure"
+    / "infrastructure"
+    / "aws"
+    / "eks"
+)
+PRODUCTION_VAULT_ADDRESS = "https://vault-production.odl.mit.edu"
+SELF_CLOSING_PAGE = """
+<!doctype html>
+<html>
+<head>
+<script>
+window.onload = function load() {
+  window.open('', '_self', '');
+  window.close();
+};
+</script>
+</head>
+<body>
+  <p>Authentication successful, you can close the browser now.</p>
+  <script>
+    setTimeout(function() {
+      window.close()
+    }, 5000);
+  </script>
+</body>
+</html>
+"""
+VAULT_AWS_ROLE_BY_MODE = {
+    "readonly": "eks-cluster-shared-readonly-role",
+    "developer": "eks-cluster-shared-developer-role",
+}
+VAULT_OIDC_ROLE_BY_MODE = {
+    "readonly": "readonly",
+    "developer": "developer",
+    "admin": "admin",
+}
+
+
+class AccessMode(StrEnum):
+    """Supported access modes for generated kubeconfig entries."""
+
+    READONLY = "readonly"
+    DEVELOPER = "developer"
+    ADMIN = "admin"
+
+
+@dataclass(slots=True)
+class ClusterConfig:
+    """Cluster connection details sourced from Pulumi stack outputs."""
+
+    cluster_name: str
+    stack_name: str
+    server: str
+    certificate_authority_data: str
+    admin_role_arn: str
+
+
+@dataclass(slots=True)
+class VaultTokenCache:
+    """Cached Vault token state."""
+
+    token: str
+
+
+@dataclass(slots=True)
+class AwsCredentialsCache:
+    """Cached AWS credentials generated from Vault."""
+
+    access_key: str
+    secret_key: str
+    session_token: str
+    expires_at: str
+
+
+class OidcHttpServer(HTTPServer):
+    """HTTP server that stores the Vault OIDC callback code."""
+
+    token: str | None = None
+
+
+class OidcCallbackHandler(BaseHTTPRequestHandler):
+    """Capture the OIDC callback code and return a self-closing page."""
+
+    def do_GET(self) -> None:
+        """Handle the OIDC callback."""
+        parsed = urllib.parse.urlparse(self.path)
+        params = urllib.parse.parse_qs(parsed.query)
+        self.server.token = params["code"][0]  # type: ignore[attr-defined]
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(SELF_CLOSING_PAGE.encode())
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        """Silence default HTTP request logging."""
+
+
+def json_datetime_now() -> datetime:
+    """Return the current UTC time."""
+    return datetime.now(tz=UTC)
+
+
+def repo_root() -> Path:
+    """Return the repository root directory."""
+    return Path(__file__).resolve().parents[2]
+
+
+def cache_file(name: str) -> Path:
+    """Return the cache file path for a given cache key."""
+    return CACHE_DIR / f"{name}.json"
+
+
+def load_json(path: Path) -> dict[str, Any] | None:
+    """Load a JSON file if it exists."""
+    if not path.exists():
+        return None
+    return json.loads(path.read_text())
+
+
+def dump_json(path: Path, payload: dict[str, Any]) -> None:
+    """Write JSON payloads to a cache file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def cluster_name_for_stack(stack_name: str) -> str:
+    """Translate a Pulumi stack name into a cluster name."""
+    stack_parts = stack_name.split(".")
+    return f"{stack_parts[-2]}-{stack_parts[-1].lower()}"
+
+
+def read_stack_names() -> list[str]:
+    """Discover all EKS Pulumi stacks from stack config files."""
+    stack_files = sorted(PULUMI_EKS_PROJECT_DIR.glob("Pulumi.*.yaml"))
+    return [
+        path.name.removeprefix("Pulumi.").removesuffix(".yaml") for path in stack_files
+    ]
+
+
+def run_command(
+    command: list[str], cwd: Path | None = None, env: dict[str, str] | None = None
+) -> str:
+    """Run a subprocess and return stdout or raise a helpful error."""
+    completed = subprocess.run(  # noqa: S603
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+        env=env,
+    )
+    if completed.returncode != 0:
+        stderr = completed.stderr.strip()
+        stdout = completed.stdout.strip()
+        details = stderr or stdout or f"command exited with {completed.returncode}"
+        msg = f"Command failed: {' '.join(command)}\n{details}"
+        raise RuntimeError(msg)
+    return completed.stdout
+
+
+def fetch_cluster_config(stack_name: str) -> ClusterConfig:
+    """Fetch cluster connection details from Pulumi outputs."""
+    command_output = run_command(
+        ["pulumi", "stack", "output", "-j", "-s", stack_name, "kube_config_data"],
+        cwd=PULUMI_EKS_PROJECT_DIR,
+    )
+    output_data = json.loads(command_output)
+    return ClusterConfig(
+        cluster_name=cluster_name_for_stack(stack_name),
+        stack_name=stack_name,
+        server=output_data["server"],
+        certificate_authority_data=output_data["certificate-authority-data"]["data"],
+        admin_role_arn=output_data["admin_role_arn"],
+    )
+
+
+def fetch_all_cluster_configs() -> list[ClusterConfig]:
+    """Load all known cluster configs from Pulumi."""
+    return [fetch_cluster_config(stack_name) for stack_name in read_stack_names()]
+
+
+def kubeconfig_exec_args(cluster: ClusterConfig, mode: AccessMode) -> list[str]:
+    """Build exec args for kubeconfig user entries."""
+    args = [
+        "run",
+        "python",
+        str(Path(__file__).resolve()),
+        "exec-credential",
+        "--cluster-name",
+        cluster.cluster_name,
+        "--mode",
+        mode.value,
+    ]
+    if mode is AccessMode.ADMIN:
+        args.extend(["--admin-role-arn", cluster.admin_role_arn])
+    return args
+
+
+def build_kubeconfig(
+    clusters: list[ClusterConfig],
+    mode: AccessMode,
+    current_context: str | None,
+) -> dict[str, Any]:
+    """Build kubeconfig content for all clusters."""
+    kube_clusters = []
+    contexts = []
+    users = []
+
+    for cluster in clusters:
+        kube_clusters.append(
+            {
+                "name": cluster.cluster_name,
+                "cluster": {
+                    "certificate-authority-data": cluster.certificate_authority_data,
+                    "server": cluster.server,
+                },
+            }
+        )
+        contexts.append(
+            {
+                "name": cluster.cluster_name,
+                "context": {
+                    "cluster": cluster.cluster_name,
+                    "user": cluster.cluster_name,
+                },
+            }
+        )
+        users.append(
+            {
+                "name": cluster.cluster_name,
+                "user": {
+                    "exec": {
+                        "apiVersion": "client.authentication.k8s.io/v1beta1",
+                        "command": "uv",
+                        "args": kubeconfig_exec_args(cluster, mode),
+                        "interactiveMode": "IfAvailable",
+                        "provideClusterInfo": False,
+                    },
+                },
+            }
+        )
+
+    kube_config = {
+        "apiVersion": "v1",
+        "kind": "Config",
+        "preferences": {},
+        "clusters": kube_clusters,
+        "contexts": contexts,
+        "users": users,
+    }
+    if current_context:
+        kube_config["current-context"] = current_context
+    return kube_config
+
+
+def login_oidc_get_token() -> str:
+    """Wait for the Vault OIDC callback and return the authorization code."""
+    httpd = OidcHttpServer(("", OIDC_CALLBACK_PORT), OidcCallbackHandler)
+    httpd.handle_request()
+    if not httpd.token:
+        msg = "Vault OIDC callback did not return an authorization code"
+        raise RuntimeError(msg)
+    return httpd.token
+
+
+def oidc_login(client: hvac.Client, role: str) -> str:
+    """Authenticate to Vault using OIDC and return the client token."""
+    auth_url_response = client.auth.oidc.oidc_authorization_url_request(
+        role=role,
+        redirect_uri=OIDC_REDIRECT_URI,
+    )
+    auth_url = auth_url_response["data"]["auth_url"]
+    if not auth_url:
+        msg = "Unable to retrieve auth URL from Vault"
+        raise RuntimeError(msg)
+
+    params = urllib.parse.parse_qs(urllib.parse.urlparse(auth_url).query)
+    auth_url_nonce = params["nonce"][0]
+    auth_url_state = params["state"][0]
+
+    webbrowser.open(auth_url)
+    code = login_oidc_get_token()
+    auth_result = client.auth.oidc.oidc_callback(
+        code=code,
+        nonce=auth_url_nonce,
+        state=auth_url_state,
+    )
+    return auth_result["auth"]["client_token"]
+
+
+def vault_client(token: str | None = None) -> hvac.Client:
+    """Create a Vault client for the production Vault instance."""
+    return hvac.Client(url=PRODUCTION_VAULT_ADDRESS, token=token)
+
+
+def load_valid_vault_token(mode: AccessMode) -> str:
+    """Load a cached Vault token or authenticate via OIDC."""
+    oidc_role = VAULT_OIDC_ROLE_BY_MODE[mode.value]
+    token_cache_path = cache_file(f"vault-token-{oidc_role}")
+    cached_payload = load_json(token_cache_path)
+    if cached_payload and cached_payload.get("token"):
+        token = str(cached_payload["token"])
+        client = vault_client(token)
+        if client.is_authenticated():
+            return token
+
+    client = vault_client()
+    token = oidc_login(client, oidc_role)
+    dump_json(token_cache_path, asdict(VaultTokenCache(token=token)))
+    return token
+
+
+def parse_expiration(value: str) -> datetime:
+    """Parse an ISO8601 timestamp from cache data."""
+    normalized = value.replace("Z", "+00:00")
+    return datetime.fromisoformat(normalized)
+
+
+def load_valid_aws_credentials(mode: AccessMode) -> AwsCredentialsCache:
+    """Load cached AWS credentials or generate fresh credentials from Vault."""
+    if mode is AccessMode.ADMIN:
+        msg = "Admin mode does not use Vault-generated shared AWS credentials"
+        raise RuntimeError(msg)
+
+    aws_role_name = VAULT_AWS_ROLE_BY_MODE[mode.value]
+    aws_cache_path = cache_file(f"aws-creds-{mode.value}")
+    cached_payload = load_json(aws_cache_path)
+    if cached_payload and cached_payload.get("expires_at"):
+        expires_at = parse_expiration(str(cached_payload["expires_at"]))
+        if expires_at > json_datetime_now() + timedelta(minutes=5):
+            return AwsCredentialsCache(
+                access_key=str(cached_payload["access_key"]),
+                secret_key=str(cached_payload["secret_key"]),
+                session_token=str(cached_payload["session_token"]),
+                expires_at=str(cached_payload["expires_at"]),
+            )
+
+    token = load_valid_vault_token(mode)
+    client = vault_client(token)
+    aws_creds = client.secrets.aws.generate_credentials(
+        name=aws_role_name,
+        ttl=8 * 60 * 60,
+        mount_point="aws-mitx",
+    )
+    expires_at = json_datetime_now() + timedelta(seconds=aws_creds["lease_duration"])
+    creds = AwsCredentialsCache(
+        access_key=aws_creds["data"]["access_key"],
+        secret_key=aws_creds["data"]["secret_key"],
+        session_token=aws_creds["data"]["security_token"],
+        expires_at=expires_at.isoformat(),
+    )
+    dump_json(aws_cache_path, asdict(creds))
+    return creds
+
+
+def aws_env_from_credentials(credentials: AwsCredentialsCache) -> dict[str, str]:
+    """Build an environment override containing AWS credentials."""
+    return {
+        **os.environ,
+        "AWS_REGION": AWS_REGION,
+        "AWS_DEFAULT_REGION": AWS_DEFAULT_REGION,
+        "AWS_ACCESS_KEY_ID": credentials.access_key,
+        "AWS_SECRET_ACCESS_KEY": credentials.secret_key,
+        "AWS_SESSION_TOKEN": credentials.session_token,
+    }
+
+
+@app.command
+def setup(
+    mode: AccessMode = AccessMode.READONLY,
+    current_context: str | None = None,
+    output_path: Path = KUBECONFIG_DEFAULT_PATH,
+) -> None:
+    """Generate and write a kubeconfig covering all OL EKS clusters."""
+    clusters = fetch_all_cluster_configs()
+    kube_config = build_kubeconfig(clusters, mode, current_context)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(yaml.safe_dump(kube_config, sort_keys=False))
+    print(f"Wrote kubeconfig for {len(clusters)} clusters to {output_path}")
+
+
+@app.command(name="exec-credential")
+def exec_credential(
+    cluster_name: str,
+    mode: AccessMode,
+    admin_role_arn: str | None = None,
+) -> None:
+    """Emit an ExecCredential document for kubectl/kubeconfig exec auth."""
+    command = [
+        "aws",
+        "eks",
+        "get-token",
+        "--cluster-name",
+        cluster_name,
+    ]
+    env = os.environ.copy()
+
+    if mode is AccessMode.ADMIN:
+        if not admin_role_arn:
+            msg = "admin_role_arn is required for admin mode"
+            raise RuntimeError(msg)
+        command.extend(["--role", admin_role_arn])
+    else:
+        credentials = load_valid_aws_credentials(mode)
+        env = aws_env_from_credentials(credentials)
+
+    token_json = run_command(command, env=env)
+    print(token_json, end="")
+
+
+@app.default
+def main() -> None:
+    """Show CLI help."""
+    app.help_print()
+
+
+if __name__ == "__main__":
+    app()

--- a/scripts/eks/eks.py
+++ b/scripts/eks/eks.py
@@ -32,14 +32,12 @@ OIDC_REDIRECT_URI = f"http://localhost:{OIDC_CALLBACK_PORT}/oidc/callback"
 PRODUCTION_VAULT_ADDRESS = "https://vault-production.odl.mit.edu"
 PREFERRED_DEFAULT_CONTEXT = "applications-qa"
 
-# Role names registered as EKS access entries that are NOT the cluster admin role.
-# Used to filter access entries when discovering the admin role ARN.
-SHARED_ACCESS_ENTRY_ROLE_NAMES: frozenset[str] = frozenset(
-    {
-        "eks-cluster-shared-readonly-role",
-        "eks-cluster-shared-developer-role",
-    }
-)
+# Truncation-safe prefix of the "eks-admin-role" infix that Pulumi uses when
+# naming the cluster admin IAM role.  Pulumi truncates IAM role names that would
+# exceed 64 characters by dropping characters from the resource name before the
+# hash/timestamp suffix.  Eight characters ("eks-admi") survive truncation for
+# every cluster name in use in this repository.
+EKS_ADMIN_ROLE_INFIX = "eks-admi"
 
 SELF_CLOSING_PAGE = """
 <!doctype html>
@@ -188,22 +186,23 @@ def make_eks_client(credentials: AwsCredentialsCache) -> Any:
 def fetch_admin_role_arn(eks_client: Any, cluster_name: str) -> str:
     """Find the cluster admin IAM role ARN via EKS access entries.
 
-    Iterates access entries for the cluster and returns the ARN of the first entry
-    that has AmazonEKSClusterAdminPolicy associated with it, skipping known shared
-    roles.
+    The admin role is identified by the naming convention used in the EKS
+    Pulumi stack: ``<cluster-name>-eks-admin-role-<pulumi-suffix>``.
+
+    For long cluster names Pulumi truncates the physical IAM role name before
+    appending the suffix, so we match on a prefix short enough to survive any
+    truncation: ``<cluster-name>-eks-admi``.
+
+    IAM user entries and all other non-matching roles are skipped automatically
+    because their last ARN segment will not start with the expected prefix.
     """
+    admin_name_prefix = f"{cluster_name}-{EKS_ADMIN_ROLE_INFIX}"
     paginator = eks_client.get_paginator("list_access_entries")
     for page in paginator.paginate(clusterName=cluster_name):
         for entry_arn in page["accessEntries"]:
             role_name = entry_arn.split("/")[-1]
-            if role_name in SHARED_ACCESS_ENTRY_ROLE_NAMES:
-                continue
-            policies_response = eks_client.list_associated_access_policies(
-                clusterName=cluster_name, principalArn=entry_arn
-            )
-            for policy in policies_response["associatedAccessPolicies"]:
-                if "AmazonEKSClusterAdminPolicy" in policy["policyArn"]:
-                    return entry_arn
+            if role_name.startswith(admin_name_prefix):
+                return entry_arn
     msg = f"No cluster admin role found in EKS access entries for cluster {cluster_name!r}"
     raise RuntimeError(msg)
 

--- a/scripts/eks/eks.py
+++ b/scripts/eks/eks.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 import urllib.parse
 import webbrowser
 from dataclasses import asdict, dataclass
@@ -15,6 +16,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any
 
+import boto3
 import cyclopts
 import hvac
 import yaml
@@ -27,16 +29,18 @@ CACHE_DIR = Path.home() / ".cache" / "ol-infrastructure" / "eks"
 KUBECONFIG_DEFAULT_PATH = Path.home() / ".kube" / "config"
 OIDC_CALLBACK_PORT = 8250
 OIDC_REDIRECT_URI = f"http://localhost:{OIDC_CALLBACK_PORT}/oidc/callback"
-PULUMI_EKS_PROJECT_DIR = (
-    Path(__file__).resolve().parents[2]
-    / "src"
-    / "ol_infrastructure"
-    / "infrastructure"
-    / "aws"
-    / "eks"
-)
 PRODUCTION_VAULT_ADDRESS = "https://vault-production.odl.mit.edu"
 PREFERRED_DEFAULT_CONTEXT = "applications-qa"
+
+# Role names registered as EKS access entries that are NOT the cluster admin role.
+# Used to filter access entries when discovering the admin role ARN.
+SHARED_ACCESS_ENTRY_ROLE_NAMES: frozenset[str] = frozenset(
+    {
+        "eks-cluster-shared-readonly-role",
+        "eks-cluster-shared-developer-role",
+    }
+)
+
 SELF_CLOSING_PAGE = """
 <!doctype html>
 <html>
@@ -79,10 +83,9 @@ class AccessMode(StrEnum):
 
 @dataclass(slots=True)
 class ClusterConfig:
-    """Cluster connection details sourced from Pulumi stack outputs."""
+    """Cluster connection details sourced from the AWS EKS API."""
 
     cluster_name: str
-    stack_name: str
     server: str
     certificate_authority_data: str
     admin_role_arn: str
@@ -132,11 +135,6 @@ def json_datetime_now() -> datetime:
     return datetime.now(tz=UTC)
 
 
-def repo_root() -> Path:
-    """Return the repository root directory."""
-    return Path(__file__).resolve().parents[2]
-
-
 def cache_file(name: str) -> Path:
     """Return the cache file path for a given cache key."""
     return CACHE_DIR / f"{name}.json"
@@ -153,20 +151,6 @@ def dump_json(path: Path, payload: dict[str, Any]) -> None:
     """Write JSON payloads to a cache file."""
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2, sort_keys=True))
-
-
-def cluster_name_for_stack(stack_name: str) -> str:
-    """Translate a Pulumi stack name into a cluster name."""
-    stack_parts = stack_name.split(".")
-    return f"{stack_parts[-2]}-{stack_parts[-1].lower()}"
-
-
-def read_stack_names() -> list[str]:
-    """Discover all EKS Pulumi stacks from stack config files."""
-    stack_files = sorted(PULUMI_EKS_PROJECT_DIR.glob("Pulumi.*.yaml"))
-    return [
-        path.name.removeprefix("Pulumi.").removesuffix(".yaml") for path in stack_files
-    ]
 
 
 def run_command(
@@ -190,29 +174,79 @@ def run_command(
     return completed.stdout
 
 
-def fetch_cluster_config(stack_name: str) -> ClusterConfig:
-    """Fetch cluster connection details from Pulumi outputs."""
-    command_output = run_command(
-        ["pulumi", "stack", "output", "-j", "-s", stack_name, "kube_config_data"],
-        cwd=PULUMI_EKS_PROJECT_DIR,
-    )
-    output_data = json.loads(command_output)
-    return ClusterConfig(
-        cluster_name=cluster_name_for_stack(stack_name),
-        stack_name=stack_name,
-        server=output_data["server"],
-        certificate_authority_data=output_data["certificate-authority-data"]["data"],
-        admin_role_arn=output_data["admin_role_arn"],
+def make_eks_client(credentials: AwsCredentialsCache) -> Any:
+    """Create a boto3 EKS client authenticated with Vault-generated credentials."""
+    return boto3.client(
+        "eks",
+        region_name=AWS_REGION,
+        aws_access_key_id=credentials.access_key,
+        aws_secret_access_key=credentials.secret_key,
+        aws_session_token=credentials.session_token,
     )
 
 
-def fetch_all_cluster_configs() -> list[ClusterConfig]:
-    """Load all known cluster configs from Pulumi."""
-    return [fetch_cluster_config(stack_name) for stack_name in read_stack_names()]
+def fetch_admin_role_arn(eks_client: Any, cluster_name: str) -> str:
+    """Find the cluster admin IAM role ARN via EKS access entries.
+
+    Iterates access entries for the cluster and returns the ARN of the first entry
+    that has AmazonEKSClusterAdminPolicy associated with it, skipping known shared
+    roles.
+    """
+    paginator = eks_client.get_paginator("list_access_entries")
+    for page in paginator.paginate(clusterName=cluster_name):
+        for entry_arn in page["accessEntries"]:
+            role_name = entry_arn.split("/")[-1]
+            if role_name in SHARED_ACCESS_ENTRY_ROLE_NAMES:
+                continue
+            policies_response = eks_client.list_associated_access_policies(
+                clusterName=cluster_name, principalArn=entry_arn
+            )
+            for policy in policies_response["associatedAccessPolicies"]:
+                if "AmazonEKSClusterAdminPolicy" in policy["policyArn"]:
+                    return entry_arn
+    msg = f"No cluster admin role found in EKS access entries for cluster {cluster_name!r}"
+    raise RuntimeError(msg)
+
+
+def fetch_all_cluster_configs(mode: AccessMode) -> list[ClusterConfig]:
+    """Discover all EKS clusters via the AWS API using Vault-generated credentials.
+
+    Uses readonly credentials for cluster discovery regardless of operator mode —
+    listing and describing clusters requires only read access to the EKS API.
+    For admin mode, also discovers each cluster's admin IAM role from access entries.
+    """
+    # All modes use the readonly AWS role for cluster discovery.
+    # Admin mode authenticates via the admin OIDC role but requests readonly
+    # AWS credentials, which are sufficient for eks:ListClusters / DescribeCluster.
+    discovery_mode = AccessMode.READONLY if mode is AccessMode.ADMIN else mode
+    discovery_credentials = load_valid_aws_credentials(discovery_mode)
+    eks_client = make_eks_client(discovery_credentials)
+
+    paginator = eks_client.get_paginator("list_clusters")
+    cluster_names: list[str] = []
+    for page in paginator.paginate():
+        cluster_names.extend(page["clusters"])
+    cluster_names.sort()
+
+    configs: list[ClusterConfig] = []
+    for cluster_name in cluster_names:
+        detail = eks_client.describe_cluster(name=cluster_name)["cluster"]
+        admin_role_arn = ""
+        if mode is AccessMode.ADMIN:
+            admin_role_arn = fetch_admin_role_arn(eks_client, cluster_name)
+        configs.append(
+            ClusterConfig(
+                cluster_name=cluster_name,
+                server=detail["endpoint"],
+                certificate_authority_data=detail["certificateAuthority"]["data"],
+                admin_role_arn=admin_role_arn,
+            )
+        )
+    return configs
 
 
 def kubeconfig_exec_args(cluster: ClusterConfig, mode: AccessMode) -> list[str]:
-    """Build exec args for kubeconfig user entries."""
+    """Build exec args for a kubeconfig user entry."""
     args = [
         "run",
         "python",
@@ -231,7 +265,10 @@ def kubeconfig_exec_args(cluster: ClusterConfig, mode: AccessMode) -> list[str]:
 def resolve_current_context(
     clusters: list[ClusterConfig], current_context: str | None
 ) -> str | None:
-    """Choose an explicit or sensible default current context."""
+    """Choose an explicit or sensible default current context.
+
+    The default context is always an operator context (not a -readonly suffixed one).
+    """
     if current_context:
         return current_context
     cluster_names = [cluster.cluster_name for cluster in clusters]
@@ -244,15 +281,26 @@ def resolve_current_context(
 
 def build_kubeconfig(
     clusters: list[ClusterConfig],
-    mode: AccessMode,
+    operator_mode: AccessMode,
     current_context: str | None,
 ) -> dict[str, Any]:
-    """Build kubeconfig content for all clusters."""
+    """Build a kubeconfig covering all clusters with dual contexts per cluster.
+
+    For operator modes (developer, admin) each cluster gets two contexts:
+      - ``<cluster-name>``          — operator credentials (read/write)
+      - ``<cluster-name>-readonly`` — readonly credentials (safe for agents)
+
+    For readonly mode a single context per cluster is generated since there is
+    no separate operator credential to pair it with.
+
+    The current-context always points to the operator (non-readonly) context.
+    """
     kube_clusters = []
     contexts = []
     users = []
 
     for cluster in clusters:
+        # One cluster entry shared by both contexts
         kube_clusters.append(
             {
                 "name": cluster.cluster_name,
@@ -262,31 +310,87 @@ def build_kubeconfig(
                 },
             }
         )
-        contexts.append(
-            {
-                "name": cluster.cluster_name,
-                "context": {
-                    "cluster": cluster.cluster_name,
-                    "user": cluster.cluster_name,
-                },
-            }
-        )
-        users.append(
-            {
-                "name": cluster.cluster_name,
-                "user": {
-                    "exec": {
-                        "apiVersion": "client.authentication.k8s.io/v1beta1",
-                        "command": "uv",
-                        "args": kubeconfig_exec_args(cluster, mode),
-                        "interactiveMode": "IfAvailable",
-                        "provideClusterInfo": False,
-                    },
-                },
-            }
-        )
 
-    kube_config = {
+        if operator_mode is not AccessMode.READONLY:
+            # Operator context — developer or admin credentials
+            operator_user = f"{cluster.cluster_name}-{operator_mode.value}"
+            contexts.append(
+                {
+                    "name": cluster.cluster_name,
+                    "context": {
+                        "cluster": cluster.cluster_name,
+                        "user": operator_user,
+                    },
+                }
+            )
+            users.append(
+                {
+                    "name": operator_user,
+                    "user": {
+                        "exec": {
+                            "apiVersion": "client.authentication.k8s.io/v1beta1",
+                            "command": "uv",
+                            "args": kubeconfig_exec_args(cluster, operator_mode),
+                            "interactiveMode": "IfAvailable",
+                            "provideClusterInfo": False,
+                        },
+                    },
+                }
+            )
+
+            # Readonly context — always present alongside operator contexts
+            readonly_context_name = f"{cluster.cluster_name}-readonly"
+            readonly_user = f"{cluster.cluster_name}-readonly"
+            contexts.append(
+                {
+                    "name": readonly_context_name,
+                    "context": {
+                        "cluster": cluster.cluster_name,
+                        "user": readonly_user,
+                    },
+                }
+            )
+            users.append(
+                {
+                    "name": readonly_user,
+                    "user": {
+                        "exec": {
+                            "apiVersion": "client.authentication.k8s.io/v1beta1",
+                            "command": "uv",
+                            "args": kubeconfig_exec_args(cluster, AccessMode.READONLY),
+                            "interactiveMode": "IfAvailable",
+                            "provideClusterInfo": False,
+                        },
+                    },
+                }
+            )
+        else:
+            # Readonly-only setup — single context per cluster
+            contexts.append(
+                {
+                    "name": cluster.cluster_name,
+                    "context": {
+                        "cluster": cluster.cluster_name,
+                        "user": cluster.cluster_name,
+                    },
+                }
+            )
+            users.append(
+                {
+                    "name": cluster.cluster_name,
+                    "user": {
+                        "exec": {
+                            "apiVersion": "client.authentication.k8s.io/v1beta1",
+                            "command": "uv",
+                            "args": kubeconfig_exec_args(cluster, AccessMode.READONLY),
+                            "interactiveMode": "IfAvailable",
+                            "provideClusterInfo": False,
+                        },
+                    },
+                }
+            )
+
+    kube_config: dict[str, Any] = {
         "apiVersion": "v1",
         "kind": "Config",
         "preferences": {},
@@ -364,9 +468,18 @@ def parse_expiration(value: str) -> datetime:
 
 
 def load_valid_aws_credentials(mode: AccessMode) -> AwsCredentialsCache:
-    """Load cached AWS credentials or generate fresh credentials from Vault."""
+    """Load cached AWS credentials or generate fresh ones from Vault.
+
+    Admin mode does not have a dedicated shared AWS role — it authenticates via
+    the admin OIDC role but requests readonly AWS credentials for cluster discovery.
+    The admin mode exec-credential path uses ``aws eks get-token --role`` directly
+    with the per-cluster admin IAM role rather than Vault-vended STS credentials.
+    """
     if mode is AccessMode.ADMIN:
-        msg = "Admin mode does not use Vault-generated shared AWS credentials"
+        msg = (
+            "Admin mode does not use a shared Vault AWS role. "
+            "Use AccessMode.READONLY for cluster discovery in admin setup."
+        )
         raise RuntimeError(msg)
 
     aws_role_name = VAULT_AWS_ROLE_BY_MODE[mode.value]
@@ -414,16 +527,49 @@ def aws_env_from_credentials(credentials: AwsCredentialsCache) -> dict[str, str]
 
 @app.command
 def setup(
-    mode: AccessMode = AccessMode.READONLY,
+    mode: AccessMode = AccessMode.DEVELOPER,
     current_context: str | None = None,
     output_path: Path = KUBECONFIG_DEFAULT_PATH,
 ) -> None:
-    """Generate and write a kubeconfig covering all OL EKS clusters."""
-    clusters = fetch_all_cluster_configs()
+    """Generate a kubeconfig covering all OL EKS clusters.
+
+    Cluster metadata is discovered via the AWS EKS API using Vault-generated
+    credentials — no Pulumi CLI or state is required.
+
+    For developer and admin modes each cluster gets two contexts:
+      - ``<cluster-name>``          — operator credentials (read/write)
+      - ``<cluster-name>-readonly`` — readonly credentials for agents/automation
+
+    For readonly mode a single context per cluster is generated.
+
+    EXAMPLES:
+      # Developer access (default) — human read/write + agent readonly contexts
+      uv run python scripts/eks/eks.py setup
+
+      # Admin access — cluster-admin + agent readonly contexts
+      uv run python scripts/eks/eks.py setup --mode admin
+
+      # Readonly only — for automation or read-only users
+      uv run python scripts/eks/eks.py setup --mode readonly
+    """
+    clusters = fetch_all_cluster_configs(mode)
+    if not clusters:
+        print("Warning: No EKS clusters found in this AWS account.", file=sys.stderr)
+
     kube_config = build_kubeconfig(clusters, mode, current_context)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(yaml.safe_dump(kube_config, sort_keys=False))
-    print(f"Wrote kubeconfig for {len(clusters)} clusters to {output_path}")
+
+    context_count = len(kube_config.get("contexts", []))
+    print(
+        f"Wrote kubeconfig: {len(clusters)} clusters, "
+        f"{context_count} contexts to {output_path}"
+    )
+    if mode is not AccessMode.READONLY:
+        print(f"  Operator contexts  : {', '.join(c.cluster_name for c in clusters)}")
+        print(
+            f"  Readonly contexts  : {', '.join(c.cluster_name + '-readonly' for c in clusters)}"
+        )
 
 
 @app.command(name="exec-credential")
@@ -432,7 +578,12 @@ def exec_credential(
     mode: AccessMode,
     admin_role_arn: str | None = None,
 ) -> None:
-    """Emit an ExecCredential document for kubectl/kubeconfig exec auth."""
+    """Emit an ExecCredential document for kubectl/kubeconfig exec auth.
+
+    Called automatically by kubectl via the kubeconfig exec plugin; not intended
+    for direct invocation.  Handles Vault OIDC auth, credential generation, and
+    local caching transparently.
+    """
     command = [
         "aws",
         "eks",

--- a/scripts/eks/eks.py
+++ b/scripts/eks/eks.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 import urllib.parse
 import webbrowser
 from dataclasses import asdict, dataclass
@@ -37,6 +38,7 @@ PULUMI_EKS_PROJECT_DIR = (
 )
 PRODUCTION_VAULT_ADDRESS = "https://vault-production.odl.mit.edu"
 PREFERRED_DEFAULT_CONTEXT = "applications-qa"
+PYTHON_EXECUTABLE = str(Path(sys.executable).resolve())
 SELF_CLOSING_PAGE = """
 <!doctype html>
 <html>
@@ -214,8 +216,6 @@ def fetch_all_cluster_configs() -> list[ClusterConfig]:
 def kubeconfig_exec_args(cluster: ClusterConfig, mode: AccessMode) -> list[str]:
     """Build exec args for kubeconfig user entries."""
     args = [
-        "run",
-        "python",
         str(Path(__file__).resolve()),
         "exec-credential",
         "--cluster-name",
@@ -277,7 +277,7 @@ def build_kubeconfig(
                 "user": {
                     "exec": {
                         "apiVersion": "client.authentication.k8s.io/v1beta1",
-                        "command": "uv",
+                        "command": PYTHON_EXECUTABLE,
                         "args": kubeconfig_exec_args(cluster, mode),
                         "interactiveMode": "IfAvailable",
                         "provideClusterInfo": False,

--- a/scripts/eks/eks.py
+++ b/scripts/eks/eks.py
@@ -36,6 +36,7 @@ PULUMI_EKS_PROJECT_DIR = (
     / "eks"
 )
 PRODUCTION_VAULT_ADDRESS = "https://vault-production.odl.mit.edu"
+PREFERRED_DEFAULT_CONTEXT = "applications-qa"
 SELF_CLOSING_PAGE = """
 <!doctype html>
 <html>
@@ -227,6 +228,20 @@ def kubeconfig_exec_args(cluster: ClusterConfig, mode: AccessMode) -> list[str]:
     return args
 
 
+def resolve_current_context(
+    clusters: list[ClusterConfig], current_context: str | None
+) -> str | None:
+    """Choose an explicit or sensible default current context."""
+    if current_context:
+        return current_context
+    cluster_names = [cluster.cluster_name for cluster in clusters]
+    if PREFERRED_DEFAULT_CONTEXT in cluster_names:
+        return PREFERRED_DEFAULT_CONTEXT
+    if cluster_names:
+        return cluster_names[0]
+    return None
+
+
 def build_kubeconfig(
     clusters: list[ClusterConfig],
     mode: AccessMode,
@@ -279,8 +294,9 @@ def build_kubeconfig(
         "contexts": contexts,
         "users": users,
     }
-    if current_context:
-        kube_config["current-context"] = current_context
+    resolved_current_context = resolve_current_context(clusters, current_context)
+    if resolved_current_context:
+        kube_config["current-context"] = resolved_current_context
     return kube_config
 
 

--- a/scripts/eks/eks.py
+++ b/scripts/eks/eks.py
@@ -245,10 +245,14 @@ def fetch_all_cluster_configs(mode: AccessMode) -> list[ClusterConfig]:
 
 
 def kubeconfig_exec_args(cluster: ClusterConfig, mode: AccessMode) -> list[str]:
-    """Build exec args for a kubeconfig user entry."""
+    """Build exec args for a kubeconfig user entry.
+
+    Uses the venv Python that is running this script as the interpreter so the
+    exec-credential command is immune to working-directory and environment
+    differences (e.g. when called by GUI tools such as Headlamp that spawn
+    subprocesses with a reduced environment).
+    """
     args = [
-        "run",
-        "python",
         str(Path(__file__).resolve()),
         "exec-credential",
         "--cluster-name",
@@ -328,7 +332,7 @@ def build_kubeconfig(
                     "user": {
                         "exec": {
                             "apiVersion": "client.authentication.k8s.io/v1beta1",
-                            "command": "uv",
+                            "command": sys.executable,
                             "args": kubeconfig_exec_args(cluster, operator_mode),
                             "interactiveMode": "IfAvailable",
                             "provideClusterInfo": False,
@@ -355,7 +359,7 @@ def build_kubeconfig(
                     "user": {
                         "exec": {
                             "apiVersion": "client.authentication.k8s.io/v1beta1",
-                            "command": "uv",
+                            "command": sys.executable,
                             "args": kubeconfig_exec_args(cluster, AccessMode.READONLY),
                             "interactiveMode": "IfAvailable",
                             "provideClusterInfo": False,
@@ -380,7 +384,7 @@ def build_kubeconfig(
                     "user": {
                         "exec": {
                             "apiVersion": "client.authentication.k8s.io/v1beta1",
-                            "command": "uv",
+                            "command": sys.executable,
                             "args": kubeconfig_exec_args(cluster, AccessMode.READONLY),
                             "interactiveMode": "IfAvailable",
                             "provideClusterInfo": False,

--- a/scripts/eks/eks.py
+++ b/scripts/eks/eks.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-import sys
 import urllib.parse
 import webbrowser
 from dataclasses import asdict, dataclass
@@ -38,7 +37,6 @@ PULUMI_EKS_PROJECT_DIR = (
 )
 PRODUCTION_VAULT_ADDRESS = "https://vault-production.odl.mit.edu"
 PREFERRED_DEFAULT_CONTEXT = "applications-qa"
-PYTHON_EXECUTABLE = str(Path(sys.executable).resolve())
 SELF_CLOSING_PAGE = """
 <!doctype html>
 <html>
@@ -216,6 +214,8 @@ def fetch_all_cluster_configs() -> list[ClusterConfig]:
 def kubeconfig_exec_args(cluster: ClusterConfig, mode: AccessMode) -> list[str]:
     """Build exec args for kubeconfig user entries."""
     args = [
+        "run",
+        "python",
         str(Path(__file__).resolve()),
         "exec-credential",
         "--cluster-name",
@@ -277,7 +277,7 @@ def build_kubeconfig(
                 "user": {
                     "exec": {
                         "apiVersion": "client.authentication.k8s.io/v1beta1",
-                        "command": PYTHON_EXECUTABLE,
+                        "command": "uv",
                         "args": kubeconfig_exec_args(cluster, mode),
                         "interactiveMode": "IfAvailable",
                         "provideClusterInfo": False,

--- a/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
@@ -5,6 +5,7 @@
 
 import json
 import os
+from typing import Any, cast
 
 import boto3
 import pulumi_aws as aws
@@ -15,6 +16,7 @@ from botocore.exceptions import ClientError
 from pulumi import (
     Alias,
     Config,
+    Input,
     Output,
     ResourceOptions,
     export,
@@ -252,6 +254,18 @@ access_entries = {
         },
         kubernetes_groups=["admin"],
     ),
+    "readonly": eks.AccessEntryArgs(
+        principal_arn=vault_auth_stack.require_output("eks_shared_readonly_role_arn"),
+        access_policies={
+            "readonly": eks.AccessPolicyAssociationArgs(
+                access_scope=aws.eks.AccessPolicyAssociationAccessScopeArgs(
+                    type="cluster",
+                ),
+                policy_arn="arn:aws:eks::aws:cluster-access-policy/AmazonEKSViewPolicy",
+            ),
+        },
+        kubernetes_groups=["view"],
+    ),
     # Note: Node role access entry is automatically created by EKS for self-managed
     # node groups when authentication_mode="API". No explicit creation needed.
 }
@@ -373,7 +387,7 @@ cluster = eks.Cluster(
     # Ref: https://docs.aws.amazon.com/eks/latest/userguide/security-groups-pods-deployment.html
     # Ref: https://docs.aws.amazon.com/eks/latest/userguide/sg-pods-example-deployment.html
     # Ref: https://github.com/aws/amazon-vpc-cni-k8s/blob/master/README.md
-    vpc_cni_options=eks.cluster.VpcCniOptionsArgs(
+    vpc_cni_options=eks.VpcCniOptionsArgs(
         cni_external_snat=False,
         configuration_values={"env": {"POD_SECURITY_GROUP_ENFORCING_MODE": "standard"}},
         custom_network_config=False,
@@ -470,7 +484,7 @@ node_role = aws.iam.Role(
     path=f"/ol-infrastructure/eks/{cluster_name}/",
     tags=aws_config.tags,
 )
-managed_node_policy_arns = [
+managed_node_policy_arns: list[Input[str]] = [
     "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy",
     "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
     "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
@@ -484,10 +498,10 @@ if eks_config.get_bool("efs_csi_provisioner"):
     managed_node_policy_arns.append(
         "arn:aws:iam::aws:policy/service-role/AmazonEFSCSIDriverPolicy"
     )
-for i, policy in enumerate(managed_node_policy_arns):
+for i, policy_arn in enumerate(managed_node_policy_arns):
     aws.iam.RolePolicyAttachment(
         f"{cluster_name}-eks-node-role-policy-attachment-{i}",
-        policy_arn=policy,
+        policy_arn=policy_arn,
         role=node_role.id,
         opts=ResourceOptions(parent=node_role),
     )
@@ -598,7 +612,9 @@ for ng_name, ng_config in configured_node_groups.items():
         )
     node_group_sec_group = eks.NodeGroupSecurityGroup(
         f"{cluster_name}-eks-nodegroup-{ng_name}-secgroup",
-        cluster_security_group=cluster.cluster_security_group,
+        cluster_security_group=cast(
+            Output[aws.ec2.SecurityGroup], cluster.cluster_security_group
+        ),
         eks_cluster=cluster.eks_cluster,
         vpc_id=target_vpc["id"],
         tags=aws_config.tags,
@@ -749,39 +765,42 @@ if eks_config.get_bool("ebs_csi_provisioner"):
         f"{cluster_name}-ebs-csi-driver-kms-for-encryption-policy",
         name=f"{cluster_name}-ebs-csi-driver-kms-for-encryption-policy",
         path=f"/ol-infrastructure/eks/{cluster_name}/",
-        policy=kms_ebs.apply(
-            lambda kms_config: lint_iam_policy(
-                {
-                    "Version": IAM_POLICY_VERSION,
-                    "Statement": [
-                        {
-                            "Effect": "Allow",
-                            "Action": [
-                                "kms:CreateGrant",
-                                "kms:ListGrants",
-                                "kms:RevokeGrant",
-                            ],
-                            "Resource": [kms_config["arn"]],
-                            "Condition": {
-                                "Bool": {"kms:GrantIsForAWSResource": "true"}
+        policy=cast(
+            Output[str],
+            kms_ebs.apply(
+                lambda kms_config: lint_iam_policy(
+                    {
+                        "Version": IAM_POLICY_VERSION,
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "kms:CreateGrant",
+                                    "kms:ListGrants",
+                                    "kms:RevokeGrant",
+                                ],
+                                "Resource": [kms_config["arn"]],
+                                "Condition": {
+                                    "Bool": {"kms:GrantIsForAWSResource": "true"}
+                                },
                             },
-                        },
-                        {
-                            "Effect": "Allow",
-                            "Action": [
-                                "kms:Encrypt",
-                                "kms:Decrypt",
-                                "kms:ReEncrypt*",
-                                "kms:GenerateDataKey*",
-                                "kms:DescribeKey",
-                            ],
-                            "Resource": [kms_config["arn"]],
-                        },
-                    ],
-                },
-                parliament_config=csi_driver_role_parliament_config,
-                stringify=True,
-            )
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "kms:Encrypt",
+                                    "kms:Decrypt",
+                                    "kms:ReEncrypt*",
+                                    "kms:GenerateDataKey*",
+                                    "kms:DescribeKey",
+                                ],
+                                "Resource": [kms_config["arn"]],
+                            },
+                        ],
+                    },
+                    parliament_config=csi_driver_role_parliament_config,
+                    stringify=True,
+                )
+            ),
         ),
         opts=ResourceOptions(parent=ebs_csi_driver_role, depends_on=cluster),
     )
@@ -985,7 +1004,7 @@ create_core_dns_resources(
 ############################################################
 # Setup Fastly provider (shared by Traefik and APISIX)
 ############################################################
-fastly_provider = get_fastly_provider(wrap_in_pulumi_options=False)
+fastly_provider = cast(Any, get_fastly_provider(wrap_in_pulumi_options=False))
 
 ############################################################
 # Setup AWS integrations

--- a/src/ol_infrastructure/substructure/vault/auth/__main__.py
+++ b/src/ol_infrastructure/substructure/vault/auth/__main__.py
@@ -224,7 +224,6 @@ if stack_info.name == "Production":
                         "eks:ListClusters",
                         "eks:DescribeCluster",
                         "eks:ListAccessEntries",
-                        "eks:ListAssociatedAccessPolicies",
                     ],
                     "Resource": "*",
                 }

--- a/src/ol_infrastructure/substructure/vault/auth/__main__.py
+++ b/src/ol_infrastructure/substructure/vault/auth/__main__.py
@@ -1,3 +1,5 @@
+"""Configure Vault authentication, policies, and shared EKS access roles."""
+
 import json
 from pathlib import Path
 
@@ -24,6 +26,9 @@ from ol_infrastructure.lib.vault import setup_vault_provider
 vault_config = Config("vault")
 stack_info = parse_stack()
 keycloak_config = Config("keycloak")
+keycloak_url = keycloak_config.require("url")
+keycloak_client_id = keycloak_config.require("client_id")
+keycloak_client_secret = keycloak_config.require("client_secret")
 
 vault_stack = make_stack_reference(
     projects.VAULT_SERVER, f"operations.{stack_info.name}"
@@ -75,11 +80,20 @@ vault_oidc_keycloak_auth = jwt.AuthBackend(
     path="oidc",
     type="oidc",
     description="OIDC auth Keycloak integration for vault client",
-    oidc_discovery_url=f"{keycloak_config.get('url')}/realms/ol-platform-engineering",
-    oidc_client_id=keycloak_config.get("client_id"),
-    oidc_client_secret=keycloak_config.get("client_secret"),
+    oidc_discovery_url=f"{keycloak_url}/realms/ol-platform-engineering",
+    oidc_client_id=keycloak_client_id,
+    oidc_client_secret=keycloak_client_secret,
     default_role="developer",
     opts=ResourceOptions(delete_before_replace=True),
+)
+
+# Readonly policy definition
+readonly_policy = Policy(
+    "readonly-policy",
+    name="readonly",
+    policy=Path(__file__)
+    .parent.parent.joinpath("policies/readonly/readonly.hcl")
+    .read_text(),
 )
 
 # Developer policy definition
@@ -94,7 +108,7 @@ developer_policy = Policy(
 github.Team(
     "vault-github-auth-developer",
     team="vault-developer-access",
-    policies=[developer_policy.name],
+    policies=[readonly_policy.name, developer_policy.name],
 )
 
 # Admin policy definition
@@ -110,6 +124,21 @@ github.Team(
     "vault-github-auth-devops", team="vault-devops-access", policies=[admin_policy.name]
 )
 
+# Configure OIDC readonly role
+readonly_role = jwt.AuthBackendRole(
+    "readonly-role",
+    backend=vault_oidc_keycloak_auth.path,
+    role_name="readonly",
+    token_policies=[readonly_policy.name],
+    allowed_redirect_uris=[
+        "http://localhost:8250/oidc/callback",
+        f"{vault_config.get('address')}/ui/vault/auth/oidc/oidc/callback",
+    ],
+    bound_audiences=[keycloak_client_id],
+    user_claim="email",
+    role_type="oidc",
+)
+
 # Configure OIDC developer role
 developer_role = jwt.AuthBackendRole(
     "developer-role",
@@ -120,7 +149,7 @@ developer_role = jwt.AuthBackendRole(
         "http://localhost:8250/oidc/callback",
         f"{vault_config.get('address')}/ui/vault/auth/oidc/oidc/callback",
     ],
-    bound_audiences=[keycloak_config.get("client_id")],
+    bound_audiences=[keycloak_client_id],
     user_claim="email",
     role_type="oidc",
 )
@@ -135,7 +164,7 @@ admin_role = jwt.AuthBackendRole(
         "http://localhost:8250/oidc/callback",
         f"{vault_config.get('address')}/ui/vault/auth/oidc/oidc/callback",
     ],
-    bound_audiences=[keycloak_config.get("client_id")],
+    bound_audiences=[keycloak_client_id],
     user_claim="email",
     role_type="oidc",
     bound_claims={"roles": "admin, vault-admins"},
@@ -164,28 +193,48 @@ aws.AuthBackendRole(
     opts=ResourceOptions(delete_before_replace=True),
 )
 
-# This is the shared developer role that will be assumed by developers using vault
+# These are the shared roles assumed by users via Vault-generated AWS credentials
 if stack_info.name == "Production":
-    eks_shared_developer_role = iam.Role(
-        "eks-cluster-shared-developer-role",
-        assume_role_policy=vault_stack.require_output("vault_server").apply(
-            lambda vs: json.dumps(
-                {
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        {
-                            "Effect": "Allow",
-                            "Principal": {"AWS": vs["instance_role_arn"]},
-                            "Action": "sts:AssumeRole",
-                        }
-                    ],
-                }
-            )
-        ),
+    shared_assume_role_policy = vault_stack.require_output("vault_server").apply(
+        lambda vs: json.dumps(
+            {
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {"AWS": vs["instance_role_arn"]},
+                        "Action": "sts:AssumeRole",
+                    }
+                ],
+            }
+        )
+    )
+
+    eks_shared_readonly_role = iam.Role(
+        "eks-cluster-shared-readonly-role",
+        assume_role_policy=shared_assume_role_policy,
         max_session_duration=EIGHT_HOURS_SECONDS,
     )
 
-    eks_shared_developer_role_vault_backend_role = aws.SecretBackendRole(
+    aws.SecretBackendRole(
+        "eks-cluster-shared-readonly-role-vault-backend-role",
+        name="eks-cluster-shared-readonly-role",
+        backend="aws-mitx",
+        credential_type="assumed_role",
+        default_sts_ttl=EIGHT_HOURS_SECONDS,
+        max_sts_ttl=EIGHT_HOURS_SECONDS,
+        iam_tags={"OU": "operations", "environment": "production"},
+        role_arns=[eks_shared_readonly_role.arn],
+        opts=ResourceOptions(delete_before_replace=True),
+    )
+
+    eks_shared_developer_role = iam.Role(
+        "eks-cluster-shared-developer-role",
+        assume_role_policy=shared_assume_role_policy,
+        max_session_duration=EIGHT_HOURS_SECONDS,
+    )
+
+    aws.SecretBackendRole(
         "eks-cluster-shared-developer-role-vault-backend-role",
         name="eks-cluster-shared-developer-role",
         backend="aws-mitx",
@@ -197,4 +246,5 @@ if stack_info.name == "Production":
         opts=ResourceOptions(delete_before_replace=True),
     )
 
+    export("eks_shared_readonly_role_arn", eks_shared_readonly_role.arn)
     export("eks_shared_developer_role_arn", eks_shared_developer_role.arn)

--- a/src/ol_infrastructure/substructure/vault/auth/__main__.py
+++ b/src/ol_infrastructure/substructure/vault/auth/__main__.py
@@ -210,10 +210,38 @@ if stack_info.name == "Production":
         )
     )
 
+    # IAM policy granting the read-only EKS API access needed for cluster
+    # discovery (list_clusters / describe_cluster / list_access_entries).
+    # This is separate from Kubernetes RBAC — it controls AWS API calls made
+    # during `eks.py setup` to bootstrap the kubeconfig without Pulumi.
+    eks_discovery_policy_document = json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "eks:ListClusters",
+                        "eks:DescribeCluster",
+                        "eks:ListAccessEntries",
+                        "eks:ListAssociatedAccessPolicies",
+                    ],
+                    "Resource": "*",
+                }
+            ],
+        }
+    )
+
     eks_shared_readonly_role = iam.Role(
         "eks-cluster-shared-readonly-role",
         assume_role_policy=shared_assume_role_policy,
         max_session_duration=EIGHT_HOURS_SECONDS,
+    )
+
+    iam.RolePolicy(
+        "eks-cluster-shared-readonly-role-discovery-policy",
+        role=eks_shared_readonly_role.name,
+        policy=eks_discovery_policy_document,
     )
 
     aws.SecretBackendRole(
@@ -232,6 +260,12 @@ if stack_info.name == "Production":
         "eks-cluster-shared-developer-role",
         assume_role_policy=shared_assume_role_policy,
         max_session_duration=EIGHT_HOURS_SECONDS,
+    )
+
+    iam.RolePolicy(
+        "eks-cluster-shared-developer-role-discovery-policy",
+        role=eks_shared_developer_role.name,
+        policy=eks_discovery_policy_document,
     )
 
     aws.SecretBackendRole(

--- a/src/ol_infrastructure/substructure/vault/policies/readonly/readonly.hcl
+++ b/src/ol_infrastructure/substructure/vault/policies/readonly/readonly.hcl
@@ -1,0 +1,23 @@
+path "auth/token/lookup-self" {
+  capabilities = ["read"]
+}
+
+path "sys/capabilities-self" {
+  capabilities = ["read", "update"]
+}
+
+path "aws-mitx" {
+  capabilities = ["read", "list"]
+}
+
+path "aws-mitx/roles" {
+  capabilities = ["read", "list"]
+}
+
+path "aws-mitx/roles/eks-cluster-shared-readonly-role" {
+  capabilities = ["read"]
+}
+
+path "aws-mitx/creds/eks-cluster-shared-readonly-role" {
+  capabilities = ["read", "update"]
+}

--- a/tests/scripts/__init__.py
+++ b/tests/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for repository-level scripts."""

--- a/tests/scripts/eks/__init__.py
+++ b/tests/scripts/eks/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for EKS helper scripts."""

--- a/tests/scripts/eks/test_eks_cli.py
+++ b/tests/scripts/eks/test_eks_cli.py
@@ -78,6 +78,7 @@ def test_build_kubeconfig_for_readonly_mode(eks_module):
 
     assert kubeconfig["clusters"][0]["name"] == "applications-qa"
     assert kubeconfig["contexts"][0]["name"] == "applications-qa"
+    assert kubeconfig["current-context"] == "applications-qa"
     exec_config = kubeconfig["users"][0]["user"]["exec"]
     assert exec_config["command"] == "uv"
     assert "exec-credential" in exec_config["args"]
@@ -105,6 +106,29 @@ def test_build_kubeconfig_for_admin_mode_includes_admin_role(eks_module):
     assert "admin" in exec_args
     assert "--admin-role-arn" in exec_args
     assert "arn:aws:iam::123456789012:role/cluster-admin" in exec_args
+
+
+@pytest.mark.unit
+def test_resolve_current_context_falls_back_to_first_cluster(eks_module):
+    """The first cluster should be used when the preferred default is absent."""
+    clusters = [
+        eks_module.ClusterConfig(
+            cluster_name="operations-ci",
+            stack_name="operations.CI",
+            server="https://operations-ci.example.invalid",
+            certificate_authority_data="ca1",
+            admin_role_arn="arn:aws:iam::123456789012:role/admin-1",
+        ),
+        eks_module.ClusterConfig(
+            cluster_name="data-ci",
+            stack_name="data.CI",
+            server="https://data-ci.example.invalid",
+            certificate_authority_data="ca2",
+            admin_role_arn="arn:aws:iam::123456789012:role/admin-2",
+        ),
+    ]
+
+    assert eks_module.resolve_current_context(clusters, None) == "operations-ci"
 
 
 @pytest.mark.unit

--- a/tests/scripts/eks/test_eks_cli.py
+++ b/tests/scripts/eks/test_eks_cli.py
@@ -80,8 +80,12 @@ def test_build_kubeconfig_for_readonly_mode(eks_module):
     assert kubeconfig["contexts"][0]["name"] == "applications-qa"
     assert kubeconfig["current-context"] == "applications-qa"
     exec_config = kubeconfig["users"][0]["user"]["exec"]
-    assert exec_config["command"] == eks_module.PYTHON_EXECUTABLE
-    assert exec_config["args"][0] == str(Path(eks_module.__file__).resolve())
+    assert exec_config["command"] == "uv"
+    assert exec_config["args"][:3] == [
+        "run",
+        "python",
+        str(Path(eks_module.__file__).resolve()),
+    ]
     assert "exec-credential" in exec_config["args"]
     assert "readonly" in exec_config["args"]
     assert "--admin-role-arn" not in exec_config["args"]

--- a/tests/scripts/eks/test_eks_cli.py
+++ b/tests/scripts/eks/test_eks_cli.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
 
 import pytest
 import yaml
@@ -31,86 +33,173 @@ def eks_module():
     return load_eks_module()
 
 
-@pytest.mark.unit
-def test_cluster_name_for_stack(eks_module):
-    """Cluster names should be derived from Pulumi stack names."""
-    assert eks_module.cluster_name_for_stack("applications.QA") == "applications-qa"
-    assert eks_module.cluster_name_for_stack("operations.Production") == (
-        "operations-production"
-    )
+@pytest.fixture
+def two_clusters(eks_module):
+    """Two ClusterConfig fixtures covering common test cases."""
+    return [
+        eks_module.ClusterConfig(
+            cluster_name="applications-qa",
+            server="https://applications-qa.example.invalid",
+            certificate_authority_data="ca1",
+            admin_role_arn="arn:aws:iam::123456789012:role/applications-qa-admin",
+        ),
+        eks_module.ClusterConfig(
+            cluster_name="data-production",
+            server="https://data-production.example.invalid",
+            certificate_authority_data="ca2",
+            admin_role_arn="arn:aws:iam::123456789012:role/data-production-admin",
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# build_kubeconfig — developer mode (dual contexts)
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-def test_read_stack_names_uses_current_eks_stack_files(
-    tmp_path, eks_module, monkeypatch
+def test_build_kubeconfig_developer_mode_produces_dual_contexts(
+    eks_module, two_clusters
 ):
-    """Stack discovery should use sorted Pulumi stack config filenames."""
-    for filename in [
-        "Pulumi.operations.QA.yaml",
-        "Pulumi.applications.CI.yaml",
-        "Pulumi.data.Production.yaml",
-    ]:
-        (tmp_path / filename).write_text("config: {}\n")
+    """Developer mode: one operator context and one readonly context per cluster."""
+    kubeconfig = eks_module.build_kubeconfig(
+        two_clusters, eks_module.AccessMode.DEVELOPER, None
+    )
 
-    monkeypatch.setattr(eks_module, "PULUMI_EKS_PROJECT_DIR", tmp_path)
-
-    assert eks_module.read_stack_names() == [
-        "applications.CI",
-        "data.Production",
-        "operations.QA",
+    context_names = [ctx["name"] for ctx in kubeconfig["contexts"]]
+    assert context_names == [
+        "applications-qa",
+        "applications-qa-readonly",
+        "data-production",
+        "data-production-readonly",
     ]
 
 
 @pytest.mark.unit
-def test_build_kubeconfig_for_readonly_mode(eks_module):
-    """Readonly kubeconfigs should call the exec helper without admin role args."""
-    cluster = eks_module.ClusterConfig(
-        cluster_name="applications-qa",
-        stack_name="applications.QA",
-        server="https://example.invalid",
-        certificate_authority_data="abc123",
-        admin_role_arn="arn:aws:iam::123456789012:role/admin",
-    )
-
+def test_build_kubeconfig_developer_operator_context_uses_developer_exec(
+    eks_module, two_clusters
+):
+    """The operator context's exec args should include --mode developer."""
     kubeconfig = eks_module.build_kubeconfig(
-        [cluster], eks_module.AccessMode.READONLY, None
+        two_clusters, eks_module.AccessMode.DEVELOPER, None
     )
 
-    assert kubeconfig["clusters"][0]["name"] == "applications-qa"
-    assert kubeconfig["contexts"][0]["name"] == "applications-qa"
+    operator_user = next(
+        u for u in kubeconfig["users"] if u["name"] == "applications-qa-developer"
+    )
+    args = operator_user["user"]["exec"]["args"]
+    assert "--mode" in args
+    assert args[args.index("--mode") + 1] == "developer"
+    assert "--admin-role-arn" not in args
+
+
+@pytest.mark.unit
+def test_build_kubeconfig_developer_readonly_context_uses_readonly_exec(
+    eks_module, two_clusters
+):
+    """The readonly context's exec args should include --mode readonly."""
+    kubeconfig = eks_module.build_kubeconfig(
+        two_clusters, eks_module.AccessMode.DEVELOPER, None
+    )
+
+    readonly_user = next(
+        u for u in kubeconfig["users"] if u["name"] == "applications-qa-readonly"
+    )
+    args = readonly_user["user"]["exec"]["args"]
+    assert "--mode" in args
+    assert args[args.index("--mode") + 1] == "readonly"
+
+
+@pytest.mark.unit
+def test_build_kubeconfig_developer_current_context_is_operator(
+    eks_module, two_clusters
+):
+    """Default current-context should be the operator context, not the readonly one."""
+    kubeconfig = eks_module.build_kubeconfig(
+        two_clusters, eks_module.AccessMode.DEVELOPER, None
+    )
+    # PREFERRED_DEFAULT_CONTEXT is "applications-qa"
     assert kubeconfig["current-context"] == "applications-qa"
-    exec_config = kubeconfig["users"][0]["user"]["exec"]
-    assert exec_config["command"] == "uv"
-    assert exec_config["args"][:3] == [
-        "run",
-        "python",
-        str(Path(eks_module.__file__).resolve()),
-    ]
-    assert "exec-credential" in exec_config["args"]
-    assert "readonly" in exec_config["args"]
-    assert "--admin-role-arn" not in exec_config["args"]
+
+
+# ---------------------------------------------------------------------------
+# build_kubeconfig — admin mode (dual contexts)
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-def test_build_kubeconfig_for_admin_mode_includes_admin_role(eks_module):
-    """Admin kubeconfigs should pass the cluster-specific admin role ARN."""
-    cluster = eks_module.ClusterConfig(
-        cluster_name="operations-production",
-        stack_name="operations.Production",
-        server="https://example.invalid",
-        certificate_authority_data="xyz789",
-        admin_role_arn="arn:aws:iam::123456789012:role/cluster-admin",
-    )
-
+def test_build_kubeconfig_admin_mode_produces_dual_contexts(eks_module, two_clusters):
+    """Admin mode should emit one admin context and one readonly context per cluster."""
     kubeconfig = eks_module.build_kubeconfig(
-        [cluster], eks_module.AccessMode.ADMIN, "operations-production"
+        two_clusters, eks_module.AccessMode.ADMIN, None
     )
 
-    assert kubeconfig["current-context"] == "operations-production"
-    exec_args = kubeconfig["users"][0]["user"]["exec"]["args"]
-    assert "admin" in exec_args
-    assert "--admin-role-arn" in exec_args
-    assert "arn:aws:iam::123456789012:role/cluster-admin" in exec_args
+    context_names = [ctx["name"] for ctx in kubeconfig["contexts"]]
+    assert context_names == [
+        "applications-qa",
+        "applications-qa-readonly",
+        "data-production",
+        "data-production-readonly",
+    ]
+
+
+@pytest.mark.unit
+def test_build_kubeconfig_admin_operator_context_includes_admin_role(
+    eks_module, two_clusters
+):
+    """The admin operator context should pass --admin-role-arn in exec args."""
+    kubeconfig = eks_module.build_kubeconfig(
+        two_clusters, eks_module.AccessMode.ADMIN, "data-production"
+    )
+
+    assert kubeconfig["current-context"] == "data-production"
+    admin_user = next(
+        u for u in kubeconfig["users"] if u["name"] == "applications-qa-admin"
+    )
+    args = admin_user["user"]["exec"]["args"]
+    assert "--admin-role-arn" in args
+    assert "arn:aws:iam::123456789012:role/applications-qa-admin" in args
+
+
+@pytest.mark.unit
+def test_build_kubeconfig_admin_readonly_context_does_not_include_admin_role(
+    eks_module, two_clusters
+):
+    """The readonly context paired with admin mode must not pass an admin role ARN."""
+    kubeconfig = eks_module.build_kubeconfig(
+        two_clusters, eks_module.AccessMode.ADMIN, None
+    )
+
+    readonly_user = next(
+        u for u in kubeconfig["users"] if u["name"] == "applications-qa-readonly"
+    )
+    args = readonly_user["user"]["exec"]["args"]
+    assert "--admin-role-arn" not in args
+    assert args[args.index("--mode") + 1] == "readonly"
+
+
+# ---------------------------------------------------------------------------
+# build_kubeconfig — readonly mode (single contexts)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_build_kubeconfig_readonly_mode_produces_single_contexts(
+    eks_module, two_clusters
+):
+    """Readonly mode: single context per cluster, no -readonly suffix."""
+    kubeconfig = eks_module.build_kubeconfig(
+        two_clusters, eks_module.AccessMode.READONLY, None
+    )
+
+    context_names = [ctx["name"] for ctx in kubeconfig["contexts"]]
+    assert context_names == ["applications-qa", "data-production"]
+    assert not any("-readonly" in name for name in context_names)
+
+
+# ---------------------------------------------------------------------------
+# resolve_current_context
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
@@ -119,57 +208,112 @@ def test_resolve_current_context_falls_back_to_first_cluster(eks_module):
     clusters = [
         eks_module.ClusterConfig(
             cluster_name="operations-ci",
-            stack_name="operations.CI",
             server="https://operations-ci.example.invalid",
             certificate_authority_data="ca1",
-            admin_role_arn="arn:aws:iam::123456789012:role/admin-1",
+            admin_role_arn="",
         ),
         eks_module.ClusterConfig(
             cluster_name="data-ci",
-            stack_name="data.CI",
             server="https://data-ci.example.invalid",
             certificate_authority_data="ca2",
-            admin_role_arn="arn:aws:iam::123456789012:role/admin-2",
+            admin_role_arn="",
         ),
     ]
-
     assert eks_module.resolve_current_context(clusters, None) == "operations-ci"
 
 
-@pytest.mark.unit
-def test_setup_writes_managed_kubeconfig(tmp_path, eks_module, monkeypatch):
-    """Setup should write a full kubeconfig file to the requested path."""
-    output_path = tmp_path / "config"
-    clusters = [
-        eks_module.ClusterConfig(
-            cluster_name="applications-ci",
-            stack_name="applications.CI",
-            server="https://applications-ci.example.invalid",
-            certificate_authority_data="ca1",
-            admin_role_arn="arn:aws:iam::123456789012:role/admin-1",
-        ),
-        eks_module.ClusterConfig(
-            cluster_name="data-qa",
-            stack_name="data.QA",
-            server="https://data-qa.example.invalid",
-            certificate_authority_data="ca2",
-            admin_role_arn="arn:aws:iam::123456789012:role/admin-2",
-        ),
-    ]
+# ---------------------------------------------------------------------------
+# fetch_admin_role_arn
+# ---------------------------------------------------------------------------
 
-    monkeypatch.setattr(eks_module, "fetch_all_cluster_configs", lambda: clusters)
+
+@pytest.mark.unit
+def test_fetch_admin_role_arn_returns_cluster_admin_entry(eks_module):
+    """fetch_admin_role_arn should return the ARN with AmazonEKSClusterAdminPolicy."""
+    admin_arn = "arn:aws:iam::123456789012:role/applications-qa-cluster-admin"
+    readonly_arn = "arn:aws:iam::123456789012:role/eks-cluster-shared-readonly-role"
+    developer_arn = "arn:aws:iam::123456789012:role/eks-cluster-shared-developer-role"
+
+    mock_eks = MagicMock()
+    mock_paginator = MagicMock()
+    mock_paginator.paginate.return_value = [
+        {"accessEntries": [readonly_arn, developer_arn, admin_arn]}
+    ]
+    mock_eks.get_paginator.return_value = mock_paginator
+
+    def mock_list_policies(**kwargs: Any):
+        if kwargs["principalArn"] == admin_arn:
+            return {
+                "associatedAccessPolicies": [
+                    {
+                        "policyArn": (
+                            "arn:aws:eks::aws:cluster-access-policy/"
+                            "AmazonEKSClusterAdminPolicy"
+                        )
+                    }
+                ]
+            }
+        return {"associatedAccessPolicies": []}
+
+    mock_eks.list_associated_access_policies.side_effect = mock_list_policies
+
+    result = eks_module.fetch_admin_role_arn(mock_eks, "applications-qa")
+    assert result == admin_arn
+
+
+@pytest.mark.unit
+def test_fetch_admin_role_arn_raises_when_none_found(eks_module):
+    """fetch_admin_role_arn should raise when no admin entry exists."""
+    mock_eks = MagicMock()
+    mock_paginator = MagicMock()
+    mock_paginator.paginate.return_value = [{"accessEntries": []}]
+    mock_eks.get_paginator.return_value = mock_paginator
+
+    with pytest.raises(RuntimeError, match="No cluster admin role found"):
+        eks_module.fetch_admin_role_arn(mock_eks, "empty-cluster")
+
+
+# ---------------------------------------------------------------------------
+# setup command
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_setup_writes_kubeconfig_with_dual_contexts(
+    tmp_path, eks_module, monkeypatch, two_clusters
+):
+    """Setup in developer mode should write a kubeconfig with dual contexts."""
+    output_path = tmp_path / "config"
+    monkeypatch.setattr(
+        eks_module, "fetch_all_cluster_configs", lambda _mode: two_clusters
+    )
 
     eks_module.setup(
         mode=eks_module.AccessMode.DEVELOPER,
-        current_context="data-qa",
+        current_context="applications-qa",
         output_path=output_path,
     )
 
     kubeconfig = yaml.safe_load(output_path.read_text())
-    assert kubeconfig["current-context"] == "data-qa"
+    assert kubeconfig["current-context"] == "applications-qa"
     assert len(kubeconfig["clusters"]) == 2
-    assert [context["name"] for context in kubeconfig["contexts"]] == [
-        "applications-ci",
-        "data-qa",
+
+    context_names = [ctx["name"] for ctx in kubeconfig["contexts"]]
+    assert context_names == [
+        "applications-qa",
+        "applications-qa-readonly",
+        "data-production",
+        "data-production-readonly",
     ]
-    assert kubeconfig["users"][1]["user"]["exec"]["args"][-1] == "developer"
+
+    # Operator user uses developer exec
+    developer_user = next(
+        u for u in kubeconfig["users"] if u["name"] == "applications-qa-developer"
+    )
+    assert "developer" in developer_user["user"]["exec"]["args"]
+
+    # Readonly user uses readonly exec
+    readonly_user = next(
+        u for u in kubeconfig["users"] if u["name"] == "applications-qa-readonly"
+    )
+    assert "readonly" in readonly_user["user"]["exec"]["args"]

--- a/tests/scripts/eks/test_eks_cli.py
+++ b/tests/scripts/eks/test_eks_cli.py
@@ -1,0 +1,146 @@
+"""Tests for the top-level EKS CLI."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+SCRIPT_PATH = Path(__file__).resolve().parents[3] / "scripts" / "eks" / "eks.py"
+
+
+def load_eks_module():
+    """Load the EKS CLI module directly from scripts/eks/eks.py."""
+    spec = importlib.util.spec_from_file_location("test_scripts_eks_cli", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        msg = f"Unable to load module from {SCRIPT_PATH}"
+        raise RuntimeError(msg)
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def eks_module():
+    """Return the loaded EKS CLI module."""
+    return load_eks_module()
+
+
+@pytest.mark.unit
+def test_cluster_name_for_stack(eks_module):
+    """Cluster names should be derived from Pulumi stack names."""
+    assert eks_module.cluster_name_for_stack("applications.QA") == "applications-qa"
+    assert eks_module.cluster_name_for_stack("operations.Production") == (
+        "operations-production"
+    )
+
+
+@pytest.mark.unit
+def test_read_stack_names_uses_current_eks_stack_files(
+    tmp_path, eks_module, monkeypatch
+):
+    """Stack discovery should use sorted Pulumi stack config filenames."""
+    for filename in [
+        "Pulumi.operations.QA.yaml",
+        "Pulumi.applications.CI.yaml",
+        "Pulumi.data.Production.yaml",
+    ]:
+        (tmp_path / filename).write_text("config: {}\n")
+
+    monkeypatch.setattr(eks_module, "PULUMI_EKS_PROJECT_DIR", tmp_path)
+
+    assert eks_module.read_stack_names() == [
+        "applications.CI",
+        "data.Production",
+        "operations.QA",
+    ]
+
+
+@pytest.mark.unit
+def test_build_kubeconfig_for_readonly_mode(eks_module):
+    """Readonly kubeconfigs should call the exec helper without admin role args."""
+    cluster = eks_module.ClusterConfig(
+        cluster_name="applications-qa",
+        stack_name="applications.QA",
+        server="https://example.invalid",
+        certificate_authority_data="abc123",
+        admin_role_arn="arn:aws:iam::123456789012:role/admin",
+    )
+
+    kubeconfig = eks_module.build_kubeconfig(
+        [cluster], eks_module.AccessMode.READONLY, None
+    )
+
+    assert kubeconfig["clusters"][0]["name"] == "applications-qa"
+    assert kubeconfig["contexts"][0]["name"] == "applications-qa"
+    exec_config = kubeconfig["users"][0]["user"]["exec"]
+    assert exec_config["command"] == "uv"
+    assert "exec-credential" in exec_config["args"]
+    assert "readonly" in exec_config["args"]
+    assert "--admin-role-arn" not in exec_config["args"]
+
+
+@pytest.mark.unit
+def test_build_kubeconfig_for_admin_mode_includes_admin_role(eks_module):
+    """Admin kubeconfigs should pass the cluster-specific admin role ARN."""
+    cluster = eks_module.ClusterConfig(
+        cluster_name="operations-production",
+        stack_name="operations.Production",
+        server="https://example.invalid",
+        certificate_authority_data="xyz789",
+        admin_role_arn="arn:aws:iam::123456789012:role/cluster-admin",
+    )
+
+    kubeconfig = eks_module.build_kubeconfig(
+        [cluster], eks_module.AccessMode.ADMIN, "operations-production"
+    )
+
+    assert kubeconfig["current-context"] == "operations-production"
+    exec_args = kubeconfig["users"][0]["user"]["exec"]["args"]
+    assert "admin" in exec_args
+    assert "--admin-role-arn" in exec_args
+    assert "arn:aws:iam::123456789012:role/cluster-admin" in exec_args
+
+
+@pytest.mark.unit
+def test_setup_writes_managed_kubeconfig(tmp_path, eks_module, monkeypatch):
+    """Setup should write a full kubeconfig file to the requested path."""
+    output_path = tmp_path / "config"
+    clusters = [
+        eks_module.ClusterConfig(
+            cluster_name="applications-ci",
+            stack_name="applications.CI",
+            server="https://applications-ci.example.invalid",
+            certificate_authority_data="ca1",
+            admin_role_arn="arn:aws:iam::123456789012:role/admin-1",
+        ),
+        eks_module.ClusterConfig(
+            cluster_name="data-qa",
+            stack_name="data.QA",
+            server="https://data-qa.example.invalid",
+            certificate_authority_data="ca2",
+            admin_role_arn="arn:aws:iam::123456789012:role/admin-2",
+        ),
+    ]
+
+    monkeypatch.setattr(eks_module, "fetch_all_cluster_configs", lambda: clusters)
+
+    eks_module.setup(
+        mode=eks_module.AccessMode.DEVELOPER,
+        current_context="data-qa",
+        output_path=output_path,
+    )
+
+    kubeconfig = yaml.safe_load(output_path.read_text())
+    assert kubeconfig["current-context"] == "data-qa"
+    assert len(kubeconfig["clusters"]) == 2
+    assert [context["name"] for context in kubeconfig["contexts"]] == [
+        "applications-ci",
+        "data-qa",
+    ]
+    assert kubeconfig["users"][1]["user"]["exec"]["args"][-1] == "developer"

--- a/tests/scripts/eks/test_eks_cli.py
+++ b/tests/scripts/eks/test_eks_cli.py
@@ -80,7 +80,8 @@ def test_build_kubeconfig_for_readonly_mode(eks_module):
     assert kubeconfig["contexts"][0]["name"] == "applications-qa"
     assert kubeconfig["current-context"] == "applications-qa"
     exec_config = kubeconfig["users"][0]["user"]["exec"]
-    assert exec_config["command"] == "uv"
+    assert exec_config["command"] == eks_module.PYTHON_EXECUTABLE
+    assert exec_config["args"][0] == str(Path(eks_module.__file__).resolve())
     assert "exec-credential" in exec_config["args"]
     assert "readonly" in exec_config["args"]
     assert "--admin-role-arn" not in exec_config["args"]

--- a/tests/scripts/eks/test_eks_cli.py
+++ b/tests/scripts/eks/test_eks_cli.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
-from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -229,35 +228,52 @@ def test_resolve_current_context_falls_back_to_first_cluster(eks_module):
 
 @pytest.mark.unit
 def test_fetch_admin_role_arn_returns_cluster_admin_entry(eks_module):
-    """fetch_admin_role_arn should return the ARN with AmazonEKSClusterAdminPolicy."""
-    admin_arn = "arn:aws:iam::123456789012:role/applications-qa-cluster-admin"
-    readonly_arn = "arn:aws:iam::123456789012:role/eks-cluster-shared-readonly-role"
-    developer_arn = "arn:aws:iam::123456789012:role/eks-cluster-shared-developer-role"
+    """fetch_admin_role_arn should return the ARN matching the naming convention."""
+    # The production admin role is truncated by Pulumi (IAM 64-char limit):
+    # 'applications-production-eks-admin-role-<suffix>' would be 65 chars, so
+    # Pulumi emits 'applications-production-eks-admi<suffix>' instead.
+    admin_arn = (
+        "arn:aws:iam::123456789012:role/ol-infrastructure/eks/applications-production/"
+        "applications-production-eks-admi20241203204503342200000005"
+    )
+    developer_arn = (
+        "arn:aws:iam::123456789012:role/eks-cluster-shared-developer-role-c79eb98"
+    )
+    creator_arn = (
+        "arn:aws:iam::123456789012:role/ol-infrastructure/eks/shared/"
+        "eks-cluster-creator-role-b2b132f"
+    )
+    user_arn = "arn:aws:iam::123456789012:user/tmacey"
+    backup_arn = (
+        "arn:aws:iam::123456789012:role/ol-infrastructure/eks/applications-production/"
+        "backup/applications-production-eks-backup-role"
+    )
 
     mock_eks = MagicMock()
     mock_paginator = MagicMock()
     mock_paginator.paginate.return_value = [
-        {"accessEntries": [readonly_arn, developer_arn, admin_arn]}
+        {"accessEntries": [developer_arn, creator_arn, user_arn, backup_arn, admin_arn]}
     ]
     mock_eks.get_paginator.return_value = mock_paginator
 
-    def mock_list_policies(**kwargs: Any):
-        if kwargs["principalArn"] == admin_arn:
-            return {
-                "associatedAccessPolicies": [
-                    {
-                        "policyArn": (
-                            "arn:aws:eks::aws:cluster-access-policy/"
-                            "AmazonEKSClusterAdminPolicy"
-                        )
-                    }
-                ]
-            }
-        return {"associatedAccessPolicies": []}
+    result = eks_module.fetch_admin_role_arn(mock_eks, "applications-production")
+    assert result == admin_arn
+    mock_eks.list_associated_access_policies.assert_not_called()
 
-    mock_eks.list_associated_access_policies.side_effect = mock_list_policies
 
-    result = eks_module.fetch_admin_role_arn(mock_eks, "applications-qa")
+@pytest.mark.unit
+def test_fetch_admin_role_arn_works_for_short_cluster_name(eks_module):
+    """fetch_admin_role_arn also matches non-truncated names (short cluster names)."""
+    admin_arn = (
+        "arn:aws:iam::123456789012:role/ol-infrastructure/eks/data-qa/"
+        "data-qa-eks-admin-role-20241203183334260200000005"
+    )
+    mock_eks = MagicMock()
+    mock_paginator = MagicMock()
+    mock_paginator.paginate.return_value = [{"accessEntries": [admin_arn]}]
+    mock_eks.get_paginator.return_value = mock_paginator
+
+    result = eks_module.fetch_admin_role_arn(mock_eks, "data-qa")
     assert result == admin_arn
 
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/issues/assigned?issue=mitodl%7Col-infrastructure%7C4702

### Description (What does it do?)
- add a new cyclopts-based `scripts/eks/eks.py` CLI for one-time kubeconfig generation
- generate a single managed kubeconfig covering all EKS clusters with setup-time access modes (`readonly`, `developer`, `admin`)
- switch kubeconfig auth to an exec-based flow with OIDC-first Vault auth and local credential caching
- add a shared readonly Vault/IAM role and EKS access entry so safe read-only access is available everywhere
- add tests for stack discovery, kubeconfig rendering, and mode-specific exec wiring
- update EKS access documentation to point users to the new workflow

### How can this be tested?
- run `uv run python scripts/eks/eks.py setup --mode readonly --output-path /tmp/kubeconfig` and confirm it writes one context per cluster
- run `uv run pytest tests/scripts/eks/test_eks_cli.py -q`
- run `uv run ruff check scripts/eks/eks.py src/ol_infrastructure/substructure/vault/auth/__main__.py src/ol_infrastructure/infrastructure/aws/eks/__main__.py tests/scripts/eks/test_eks_cli.py`
- run `uv run mypy scripts/eks/eks.py src/ol_infrastructure/substructure/vault/auth/__main__.py src/ol_infrastructure/infrastructure/aws/eks/__main__.py tests/scripts/eks/test_eks_cli.py`
- run `cd src/ol_infrastructure/substructure/vault/auth && pulumi preview --stack operations.Production` and review the readonly role/policy additions

### Additional Context
- This keeps `scripts/eks/eks.sh` in place for compatibility; cleanup can follow in a later PR.
- Deploy order matters for infrastructure changes: apply `src/ol_infrastructure/substructure/vault/auth` (`operations.Production`) first so `eks_shared_readonly_role_arn` is exported, then apply `src/ol_infrastructure/infrastructure/aws/eks` stacks.
- `pulumi preview` for `src/ol_infrastructure/infrastructure/aws/eks` was initially blocked in this environment by a missing `parliament` dependency during program startup.