### PR TITLE
add ocw-studio keycloak sso support in the ol-mit realm

### DIFF
--- a/src/ol_infrastructure/applications/ocw_studio/k8s_secrets.py
+++ b/src/ol_infrastructure/applications/ocw_studio/k8s_secrets.py
@@ -320,4 +320,25 @@ def create_ocw_studio_k8s_secrets(
         secret_names.append(secret_name)
         secret_resources.append(secret_resource)
 
+    # 7. Keycloak OIDC credentials for python-social-auth
+    keycloak_secret_name, keycloak_secret = _create_static_secret(
+        stack_info=stack_info,
+        secret_base_name="ocw-studio-keycloak-sso",  # pragma: allowlist secret
+        namespace=ocw_studio_namespace,
+        labels=k8s_global_labels,
+        mount="secret-operations",
+        mount_type="kv-v1",
+        path="sso/ocw-studio",
+        templates={
+            "SOCIAL_AUTH_KEYCLOAK_KEY": '{{ get .Secrets "client_id" }}',
+            "SOCIAL_AUTH_KEYCLOAK_SECRET": '{{ get .Secrets "client_secret" }}',  # pragma: allowlist secret
+            "SOCIAL_AUTH_KEYCLOAK_PUBLIC_KEY": '{{ get .Secrets "realm_public_key" }}',
+            "SOCIAL_AUTH_KEYCLOAK_AUTHORIZATION_URL": '{{ printf "%s/protocol/openid-connect/auth" (get .Secrets "url") }}',
+            "SOCIAL_AUTH_KEYCLOAK_ACCESS_TOKEN_URL": '{{ printf "%s/protocol/openid-connect/token" (get .Secrets "url") }}',
+        },
+        vaultauth=vaultauth,
+    )
+    secret_names.append(keycloak_secret_name)
+    secret_resources.append(keycloak_secret)
+
     return secret_names, secret_resources

--- a/src/ol_infrastructure/applications/ocw_studio/ocw_studio_policy.hcl
+++ b/src/ol_infrastructure/applications/ocw_studio/ocw_studio_policy.hcl
@@ -34,6 +34,11 @@ path "secret-concourse/data/web" {
   capabilities = ["read"]
 }
 
+# Keycloak OIDC credentials for OCW Studio
+path "secret-operations/sso/ocw-studio" {
+  capabilities = ["read"]
+}
+
 # Vault-secrets-operator lease management
 path "sys/leases/renew" {
   capabilities = ["update"]

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.CI.yaml
@@ -112,5 +112,11 @@ config:
   - "https://video-ci.odl.mit.edu/"
   keycloak_realm:ol-mit-ovs-web-origins:
   - "https://video-ci.odl.mit.edu"
+  keycloak_realm:ol-mit-ocw-studio-redirect-uris:
+  - "https://ocw-studio-ci.odl.mit.edu/auth/complete/keycloak/"
+  keycloak_realm:ol-mit-ocw-studio-logout-uris:
+  - "https://ocw-studio-ci.odl.mit.edu/"
+  keycloak_realm:ol-mit-ocw-studio-web-origins:
+  - "https://ocw-studio-ci.odl.mit.edu"
   keycloak_realm:ol-mit-ldap-bind-password:
     secure: v1:dOWj9QsOafyn3p+F:XdKusQqhsxVDx20tFJTdUG3Nc5/FJ4N/ZChyzakYHlXyXpcxRkICJA==

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.Production.yaml
@@ -113,5 +113,11 @@ config:
   - "https://video.odl.mit.edu/"
   keycloak_realm:ol-mit-ovs-web-origins:
   - "https://video.odl.mit.edu"
+  keycloak_realm:ol-mit-ocw-studio-redirect-uris:
+  - "https://ocw-studio.odl.mit.edu/auth/complete/keycloak/"
+  keycloak_realm:ol-mit-ocw-studio-logout-uris:
+  - "https://ocw-studio.odl.mit.edu/"
+  keycloak_realm:ol-mit-ocw-studio-web-origins:
+  - "https://ocw-studio.odl.mit.edu"
   keycloak_realm:ol-mit-ldap-bind-password:
     secure: v1:xuY2YgyBZnGNLTMy:ZnmyEmcaAOFd8EsiQX+7uG4rBcyP5QmVbI2HI39kkDllxf2TFRovQA==

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.QA.yaml
@@ -125,5 +125,11 @@ config:
   - "https://video-rc.odl.mit.edu/"
   keycloak_realm:ol-mit-ovs-web-origins:
   - "https://video-rc.odl.mit.edu"
+  keycloak_realm:ol-mit-ocw-studio-redirect-uris:
+  - "https://ocw-studio-rc.odl.mit.edu/auth/complete/keycloak/"
+  keycloak_realm:ol-mit-ocw-studio-logout-uris:
+  - "https://ocw-studio-rc.odl.mit.edu/"
+  keycloak_realm:ol-mit-ocw-studio-web-origins:
+  - "https://ocw-studio-rc.odl.mit.edu"
   keycloak_realm:ol-mit-ldap-bind-password:
     secure: v1:bm9R4ZzTLXsioNmr:BAS1km5mgbC94evdYsX1CqgKyXYxzBmfvMztk9p4ItE+CV0Ri8qt1w==

--- a/src/ol_infrastructure/substructure/keycloak/ol_mit.py
+++ b/src/ol_infrastructure/substructure/keycloak/ol_mit.py
@@ -620,4 +620,62 @@ def create_ol_mit_realm(  # noqa: PLR0913
     )
     # ODL VIDEO SERVICE [END]
 
+    # OCW STUDIO [START]
+    ol_mit_ocw_studio_client = keycloak.openid.Client(
+        "ol-mit-ocw-studio-client",
+        name="ol-mit-ocw-studio-client",
+        realm_id=ol_mit_realm.id,
+        client_id="ocw-studio-app",
+        client_secret=keycloak_realm_config.get("ol-mit-ocw-studio-client-secret"),
+        enabled=True,
+        access_type="CONFIDENTIAL",
+        standard_flow_enabled=True,
+        implicit_flow_enabled=False,
+        direct_access_grants_enabled=False,
+        service_accounts_enabled=False,
+        valid_redirect_uris=keycloak_realm_config.get_object(
+            "ol-mit-ocw-studio-redirect-uris"
+        ),
+        valid_post_logout_redirect_uris=keycloak_realm_config.get_object(
+            "ol-mit-ocw-studio-logout-uris"
+        ),
+        web_origins=keycloak_realm_config.get_object("ol-mit-ocw-studio-web-origins"),
+        opts=resource_options.merge(ResourceOptions(delete_before_replace=True)),
+    )
+
+    keycloak.openid.AudienceProtocolMapper(
+        "ol-mit-ocw-studio-audience-mapper",
+        realm_id=ol_mit_realm.id,
+        client_id=ol_mit_ocw_studio_client.id,
+        name="audience",
+        included_client_audience=ol_mit_ocw_studio_client.client_id,
+        add_to_id_token=True,
+        add_to_access_token=True,
+        opts=resource_options,
+    )
+
+    vault.generic.Secret(
+        "ol-mit-ocw-studio-client-vault-oidc-credentials",
+        path="secret-operations/sso/ocw-studio",
+        data_json=Output.all(
+            url=ol_mit_ocw_studio_client.realm_id.apply(
+                lambda realm_id: f"{keycloak_url}/realms/{realm_id}"
+            ),
+            server_url=keycloak_url,
+            client_id=ol_mit_ocw_studio_client.client_id,
+            client_secret=ol_mit_ocw_studio_client.client_secret,
+            secret=session_secret,
+            realm_id=ol_mit_ocw_studio_client.realm_id,
+            realm_name="ol-mit",
+            realm_public_key=ol_mit_ocw_studio_client.realm_id.apply(
+                lambda realm_id: (
+                    fetch_realm_public_key_partial(realm_id)
+                    .removeprefix("-----BEGIN PUBLIC KEY-----\n")
+                    .removesuffix("\n-----END PUBLIC KEY-----")
+                )
+            ),
+        ).apply(json.dumps),
+    )
+    # OCW STUDIO [END]
+
     return ol_mit_realm


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11110

### Description (What does it do?)
Adds the infrastructure level changes required to support ocw-studio keycloak SSO.

1. Sets up a client for ocw studio in the ol-mit realm
2. Creates vault secrets.
3. Injects those secrets into the ocw-studio environment

Mostly, we follow the pattern used for ovs keycloak integration.

### How can this be tested?
Run pulumi preview against the substructure.keycloak stack in CI to confirm no plan errors. The new ocw studio client will appear in the Keycloak admin console after pulumi up.

I have not carried any testing out myself as I can't access the infrastructure secrets in vault, and it would probably take me a lot of time to configure everything properly

