### PR TITLE
fix(apisix): use v1alpha1/PluginConfig for Gateway API HTTPRoute ExtensionRefs

### DIFF
--- a/src/ol_infrastructure/components/services/apisix.py
+++ b/src/ol_infrastructure/components/services/apisix.py
@@ -4,7 +4,7 @@
 from typing import Any, Literal
 
 import pulumi_kubernetes as kubernetes
-from pulumi import ComponentResource, ResourceOptions
+from pulumi import ComponentResource, Output, ResourceOptions
 from pydantic import BaseModel, Field, NonNegativeInt, field_validator, model_validator
 
 from ol_infrastructure.components.services.vault import (
@@ -14,6 +14,13 @@ from ol_infrastructure.components.services.vault import (
 
 
 class OLApisixPluginConfig(BaseModel):
+    """Configuration for a single APISIX plugin instance.
+
+    Used with both legacy ApisixRoute/ApisixPluginConfig (v2) and Gateway API
+    HTTPRoute/PluginConfig (v1alpha1).  When targeting v1alpha1, the ``enable``
+    and ``secretRef`` fields are ignored — see ``OLApisixHTTPRoute`` for details.
+    """
+
     name: str
     enable: bool = True
     secret_ref: str | None = Field(
@@ -24,6 +31,8 @@ class OLApisixPluginConfig(BaseModel):
 
 
 class OLApisixRouteConfig(BaseModel):
+    """Configuration for a single ApisixRoute rule (legacy CRD path)."""
+
     route_name: str
     priority: int = 0
     shared_plugin_config_name: str | None = None
@@ -60,7 +69,9 @@ class OLApisixRouteConfig(BaseModel):
         if not any(plugin.name == "request-id" for plugin in v):
             v.append(
                 OLApisixPluginConfig(
-                    name="request-id", config={"include_in_response": True}
+                    name="request-id",
+                    secretRef=None,
+                    config={"include_in_response": True},
                 )
             )
         return v
@@ -161,11 +172,18 @@ class OLApisixRoute(ComponentResource):
 
 
 class OLApisixOIDCConfig(BaseModel):
+    """Configuration for APISIX OIDC authentication resources.
+
+    Holds Vault path details and OIDC plugin settings used to create the
+    per-application Kubernetes Secret (via OLVaultK8SSecret) and generate
+    the openid-connect plugin configuration block.
+    """
+
     application_name: str
     k8s_labels: dict[str, str] = {}
     k8s_namespace: str
     vault_mount: str = "secret-operations"
-    vault_mount_type: str = "kv-v1"
+    vault_mount_type: Literal["kv-v1", "kv-v2"] = "kv-v1"
     vault_path: str
     vaultauth: str
 
@@ -209,7 +227,7 @@ class OLApisixOIDCResources(ComponentResource):
 
         self.secret_name = f"ol-apisix-{oidc_config.application_name}-oidc-secrets"
 
-        __templates = {
+        __templates: dict[str, str | Output[str]] = {
             "client_id": '{{ get .Secrets "client_id" }}',
             "client_secret": '{{ get .Secrets "client_secret" }}',
             "realm": '{{ get .Secrets "realm_name" }}',
@@ -287,6 +305,13 @@ class OLApisixOIDCResources(ComponentResource):
 
 # Ref: https://apisix.apache.org/docs/ingress-controller/references/apisix_pluginconfig_v2/
 class OLApisixSharedPluginsConfig(BaseModel):
+    """Configuration for OLApisixSharedPlugins.
+
+    Defines the plugin list that will be materialised as both a v2
+    ApisixPluginConfig (for legacy ApisixRoute/Ingress) and a v1alpha1
+    PluginConfig (for Gateway API HTTPRoute).
+    """
+
     application_name: str
     resource_suffix: str = "shared-plugins"
     enable_defaults: bool = True
@@ -297,8 +322,20 @@ class OLApisixSharedPluginsConfig(BaseModel):
 
 class OLApisixSharedPlugins(ComponentResource):
     """
-    Shared plugin configuration for apisix
-    Defines and creates an "ApisixPluginConfig" resource in the k8s cluster
+    Shared plugin configuration for APISIX.
+
+    Creates two Kubernetes CRD resources with the same ``metadata.name``:
+
+    * ``apisix.apache.org/v2 / ApisixPluginConfig`` — consumed by legacy
+      ``ApisixRoute`` and ``Ingress`` resources via ``plugin_config_name``.
+
+    * ``apisix.apache.org/v1alpha1 / PluginConfig`` — consumed by Gateway API
+      ``HTTPRoute`` resources via ExtensionRef filters (``kind: PluginConfig``).
+      The v1alpha1 schema only accepts ``name`` and ``config`` per plugin;
+      ``enable: false`` plugins are omitted entirely and ``secretRef`` is dropped.
+
+    Callers can use ``self.resource_name`` in both ``OLApisixRouteConfig`` (legacy)
+    and ``OLApisixHTTPRouteConfig`` (Gateway API) without any distinction.
     """
 
     def __init__(
@@ -356,6 +393,8 @@ class OLApisixSharedPlugins(ComponentResource):
         self.resource_name = (
             f"{plugin_config.application_name}-{plugin_config.resource_suffix}"
         )
+        # v2/ApisixPluginConfig — consumed by legacy ApisixRoute/Ingress resources
+        # via ``plugin_config_name`` in the route spec.
         self.shared_plugin_apisix_pluginconfig_resource = (
             kubernetes.apiextensions.CustomResource(
                 f"OLApisixSharedPlugin-{self.resource_name}",
@@ -372,9 +411,46 @@ class OLApisixSharedPlugins(ComponentResource):
                 opts=resource_options,
             )
         )
+        # v1alpha1/PluginConfig — consumed by Gateway API HTTPRoute resources
+        # via ExtensionRef filters (kind: PluginConfig).  Both resources share
+        # the same metadata.name; callers pass self.resource_name to either
+        # OLApisixRouteConfig (legacy) or OLApisixHTTPRouteConfig (Gateway API)
+        # without distinction.
+        #
+        # The v1alpha1 schema only allows ``name`` and ``config`` per plugin;
+        # ``enable`` and ``secretRef`` are v2-only fields.  Plugins with
+        # ``enable: false`` are omitted so they don't appear in the Gateway API
+        # path either.
+        _v1alpha1_plugins = [
+            {"name": p["name"], **({"config": p["config"]} if p.get("config") else {})}
+            for p in plugin_config.plugins
+            if p.get("enable", True)
+        ]
+        self.shared_plugin_pluginconfig_resource = (
+            kubernetes.apiextensions.CustomResource(
+                f"OLApisixSharedPluginConfig-{self.resource_name}",
+                api_version="apisix.apache.org/v1alpha1",
+                kind="PluginConfig",
+                metadata=kubernetes.meta.v1.ObjectMetaArgs(
+                    name=self.resource_name,
+                    labels=plugin_config.k8s_labels,
+                    namespace=plugin_config.k8s_namespace,
+                ),
+                spec={
+                    "plugins": _v1alpha1_plugins,
+                },
+                opts=resource_options,
+            )
+        )
 
 
 class OLApisixExternalUpstreamConfig(BaseModel):
+    """Configuration for OLApisixExternalUpstream.
+
+    Defines an external (non-Kubernetes) upstream service to be proxied
+    through APISIX.
+    """
+
     application_name: str
     resource_suffix: str = "external-upstream"
     k8s_labels: dict[str, str] = {}

--- a/src/ol_infrastructure/components/services/apisix_gateway_api.py
+++ b/src/ol_infrastructure/components/services/apisix_gateway_api.py
@@ -239,6 +239,19 @@ class OLApisixHTTPRoute(ComponentResource):
         return f"{sanitized_httproute_name}-{sanitized_route_name}-{plugin_hash}"
 
     @staticmethod
+    def _active_plugins(
+        plugins: list[OLApisixPluginConfig],
+    ) -> list[OLApisixPluginConfig]:
+        """Return only plugins where ``enable`` is True.
+
+        v1alpha1 PluginConfig has no ``enable`` flag, so disabled plugins must
+        be dropped rather than serialised.  Using the same filtered list for
+        both name-hashing and spec-generation keeps the PluginConfig resource
+        name consistent with its contents.
+        """
+        return [p for p in plugins if p.enable]
+
+    @staticmethod
     def _serialize_plugin_for_v1alpha1(
         plugin: OLApisixPluginConfig,
     ) -> dict[str, Any]:
@@ -279,9 +292,14 @@ class OLApisixHTTPRoute(ComponentResource):
             if not route_config.plugins:
                 continue
 
+            # Only enabled plugins are written to v1alpha1 PluginConfig.
+            active = self._active_plugins(route_config.plugins)
+            if not active:
+                continue
+
             # Generate unique name for this plugin combination
             config_name = self._generate_plugin_config_name(
-                httproute_name, route_config.route_name, route_config.plugins
+                httproute_name, route_config.route_name, active
             )
 
             # Only create if we haven't seen this exact plugin combo before
@@ -297,8 +315,7 @@ class OLApisixHTTPRoute(ComponentResource):
                     ),
                     spec={
                         "plugins": [
-                            self._serialize_plugin_for_v1alpha1(p)
-                            for p in route_config.plugins
+                            self._serialize_plugin_for_v1alpha1(p) for p in active
                         ]
                     },
                     opts=resource_options,
@@ -379,19 +396,23 @@ class OLApisixHTTPRoute(ComponentResource):
                     }
                 ]
             elif route_config.plugins:
-                config_name = self._generate_plugin_config_name(
-                    httproute_name, route_config.route_name, route_config.plugins
-                )
-                rule["filters"] = [
-                    {
-                        "type": "ExtensionRef",
-                        "extensionRef": {
-                            "group": "apisix.apache.org",
-                            "kind": "PluginConfig",
-                            "name": config_name,
-                        },
-                    }
-                ]
+                # Use the same enabled-plugin subset that was used to create
+                # the PluginConfig resource so the name always matches.
+                active = self._active_plugins(route_config.plugins)
+                if active:
+                    config_name = self._generate_plugin_config_name(
+                        httproute_name, route_config.route_name, active
+                    )
+                    rule["filters"] = [
+                        {
+                            "type": "ExtensionRef",
+                            "extensionRef": {
+                                "group": "apisix.apache.org",
+                                "kind": "PluginConfig",
+                                "name": config_name,
+                            },
+                        }
+                    ]
 
             rules.append(rule)
 

--- a/src/ol_infrastructure/components/services/apisix_gateway_api.py
+++ b/src/ol_infrastructure/components/services/apisix_gateway_api.py
@@ -93,7 +93,9 @@ class OLApisixHTTPRouteConfig(BaseModel):
         if not any(plugin.name == "request-id" for plugin in v):
             v.append(
                 OLApisixPluginConfig(
-                    name="request-id", config={"include_in_response": True}
+                    name="request-id",
+                    secretRef=None,
+                    config={"include_in_response": True},
                 )
             )
         return v
@@ -119,11 +121,25 @@ class OLApisixHTTPRoute(ComponentResource):
     """
     HTTPRoute configuration for Gateway API with APISIX.
 
-    Creates HTTPRoute and associated ApisixPluginConfig resources for routing
-    traffic through the Gateway API. This is the modern replacement for ApisixRoute.
+    Creates HTTPRoute and associated PluginConfig (apisix.apache.org/v1alpha1)
+    resources for routing traffic through the Gateway API.  This is the modern
+    replacement for ApisixRoute.
+
+    NOTE ON CRD KINDS
+    -----------------
+    APISIX exposes two plugin-config CRD types:
+
+    * ``apisix.apache.org/v2 / ApisixPluginConfig`` — for legacy ApisixRoute and
+      Kubernetes Ingress resources only.  The APISIX ingress-controller's HTTPRoute
+      reconciler does **not** read this kind when processing ExtensionRef filters;
+      references to it are silently ignored.
+
+    * ``apisix.apache.org/v1alpha1 / PluginConfig`` — the Gateway-API-aligned
+      type that the HTTPRoute reconciler **does** process via ExtensionRef filters.
+      This component uses this kind exclusively.
 
     The component automatically:
-    - Creates ApisixPluginConfig resources for unique plugin combinations
+    - Creates PluginConfig (v1alpha1) resources for unique plugin combinations
     - Converts APISIX path patterns to Gateway API PathPrefix matches
     - Links routes to plugins via ExtensionRef filters
     - Supports both service backends and upstreams
@@ -222,6 +238,21 @@ class OLApisixHTTPRoute(ComponentResource):
         sanitized_route_name = route_name.replace("_", "-").lower()
         return f"{sanitized_httproute_name}-{sanitized_route_name}-{plugin_hash}"
 
+    @staticmethod
+    def _serialize_plugin_for_v1alpha1(
+        plugin: OLApisixPluginConfig,
+    ) -> dict[str, Any]:
+        """Serialise an OLApisixPluginConfig for the v1alpha1 PluginConfig CRD.
+
+        The v1alpha1 PluginConfig schema only accepts ``name`` and ``config``
+        fields — it has no ``enable`` or ``secretRef`` fields (those belong to
+        the legacy v2 ApisixPluginConfig CRD used with ApisixRoute/Ingress).
+        """
+        result: dict[str, Any] = {"name": plugin.name}
+        if plugin.config:  # omit empty config dicts
+            result["config"] = plugin.config
+        return result
+
     def _create_plugin_configs(
         self,
         httproute_name: str,
@@ -230,7 +261,13 @@ class OLApisixHTTPRoute(ComponentResource):
         k8s_labels: dict[str, str],
         resource_options: ResourceOptions,
     ) -> dict[str, kubernetes.apiextensions.CustomResource]:
-        """Create ApisixPluginConfig resources for unique plugin combinations."""
+        """Create PluginConfig (apisix.apache.org/v1alpha1) resources for unique plugin combinations.
+
+        Uses v1alpha1/PluginConfig — the correct CRD for Gateway API HTTPRoute
+        ExtensionRef filters.  The v2/ApisixPluginConfig CRD is for legacy
+        ApisixRoute/Ingress resources only and is silently ignored by the
+        HTTPRoute reconciler.
+        """
         plugin_configs = {}
 
         for route_config in route_configs:
@@ -250,9 +287,9 @@ class OLApisixHTTPRoute(ComponentResource):
             # Only create if we haven't seen this exact plugin combo before
             if config_name not in plugin_configs:
                 plugin_configs[config_name] = kubernetes.apiextensions.CustomResource(
-                    f"ApisixPluginConfig-{config_name}",
-                    api_version="apisix.apache.org/v2",
-                    kind="ApisixPluginConfig",
+                    f"PluginConfig-{config_name}",
+                    api_version="apisix.apache.org/v1alpha1",
+                    kind="PluginConfig",
                     metadata=kubernetes.meta.v1.ObjectMetaArgs(
                         name=config_name,
                         labels=k8s_labels,
@@ -260,7 +297,7 @@ class OLApisixHTTPRoute(ComponentResource):
                     ),
                     spec={
                         "plugins": [
-                            p.model_dump(by_alias=True, exclude_none=True)
+                            self._serialize_plugin_for_v1alpha1(p)
                             for p in route_config.plugins
                         ]
                     },
@@ -326,14 +363,17 @@ class OLApisixHTTPRoute(ComponentResource):
                 "backendRefs": backend_refs,
             }
 
-            # Add plugin config via ExtensionRef filter if plugins are configured
+            # Add plugin config via ExtensionRef filter if plugins are configured.
+            # Both paths use kind=PluginConfig (apisix.apache.org/v1alpha1) — the
+            # type the APISIX HTTPRoute reconciler actually processes.  The legacy
+            # v2/ApisixPluginConfig kind is silently ignored by the reconciler.
             if route_config.shared_plugin_config_name:
                 rule["filters"] = [
                     {
                         "type": "ExtensionRef",
                         "extensionRef": {
                             "group": "apisix.apache.org",
-                            "kind": "ApisixPluginConfig",
+                            "kind": "PluginConfig",
                             "name": route_config.shared_plugin_config_name,
                         },
                     }
@@ -347,7 +387,7 @@ class OLApisixHTTPRoute(ComponentResource):
                         "type": "ExtensionRef",
                         "extensionRef": {
                             "group": "apisix.apache.org",
-                            "kind": "ApisixPluginConfig",
+                            "kind": "PluginConfig",
                             "name": config_name,
                         },
                     }


### PR DESCRIPTION
### What are the relevant tickets?
Closes #4708

### Description (What does it do?)
The APISIX IC HTTPRoute reconciler only processes ExtensionRef filters that reference `apisix.apache.org/v1alpha1 / PluginConfig`. The legacy `apisix.apache.org/v2 / ApisixPluginConfig` kind is for `ApisixRoute`/`Ingress` only — the reconciler silently skips it in the Gateway API path. `OLApisixHTTPRoute` was creating v2 resources and referencing them as `kind: ApisixPluginConfig`, meaning **no per-route plugins were ever applied** to any Gateway API HTTPRoute.

**`apisix_gateway_api.py` — `OLApisixHTTPRoute`:**
- `_create_plugin_configs`: create `PluginConfig` (`apisix.apache.org/v1alpha1`) instead of `ApisixPluginConfig` (`apisix.apache.org/v2`); Pulumi logical name changed from `ApisixPluginConfig-{name}` to `PluginConfig-{name}` so Pulumi correctly deletes the old v2 resources on next deploy
- `_build_http_route_rules`: update ExtensionRef `kind` from `ApisixPluginConfig` to `PluginConfig` for both the auto-generated and shared-config branches
- Add `_serialize_plugin_for_v1alpha1()` helper that strips the v2-only `enable` and `secretRef` fields from plugin entries before writing the CRD spec

**`apisix.py` — `OLApisixSharedPlugins`:**
- Add a companion `PluginConfig` (`v1alpha1`) resource alongside the existing `ApisixPluginConfig` (`v2`). Both resources share the same `metadata.name`, so callers using `shared_plugin_config_name` in either `OLApisixRouteConfig` (legacy) or `OLApisixHTTPRouteConfig` (Gateway API) need no changes. Plugins with `enable: false` are omitted from the v1alpha1 resource; `enable` and `secretRef` keys are stripped per the v1alpha1 schema.

**Also fixes pre-existing type/lint errors found while touching these files:**
- `OLApisixOIDCConfig.vault_mount_type`: `str` → `Literal["kv-v1", "kv-v2"]`
- `__templates` annotation: `dict[str, str]` → `dict[str, str | Output[str]]`
- Add `Output` to `pulumi` import
- Add missing class docstrings (`OLApisixPluginConfig`, `OLApisixRouteConfig`, `OLApisixOIDCConfig`, `OLApisixSharedPluginsConfig`, `OLApisixExternalUpstreamConfig`, `OLApisixSharedPlugins`)
- Add `secretRef=None` to `OLApisixPluginConfig(name="request-id", ...)` validator calls (pyright alias-constructor issue)

### How can this be tested?
All current `OLApisixHTTPRoute` deployments pass `plugins=[]`, so no plugin config resources are created today and this change is safe to deploy without functional regression. After deploy:

1. `kubectl get pluginconfig -A` should return no resources (confirming no orphaned v1alpha1 resources pre-exist)
2. `kubectl get apisixpluginconfig -A` should still show the existing v2 shared-plugin resources created by `OLApisixSharedPlugins`
3. Run `pulumi preview` on any stack using `OLApisixSharedPlugins` (e.g. `applications.aws.xpro`) — expect: create one new `PluginConfig` (v1alpha1) per `OLApisixSharedPlugins` instance, no changes to existing `ApisixPluginConfig` (v2) resources
4. Run `pulumi preview` on a stack using `OLApisixHTTPRoute` — if any route has plugins, expect: delete old `ApisixPluginConfig-*` resources, create new `PluginConfig-*` resources

### Additional Context
The two CRD types and their correct usage paths:

| CRD | API version | Used with |
|-----|-------------|-----------|
| `ApisixPluginConfig` | `apisix.apache.org/v2` | `ApisixRoute`, `Ingress` (legacy) |
| `PluginConfig` | `apisix.apache.org/v1alpha1` | `HTTPRoute` (Gateway API) |

Confirmed in IC source: `httproute_controller.go` `processHTTPRoute` and `httproute.go` `fillPluginFromExtensionRef` both gate on `Kind == "PluginConfig"` only. See https://github.com/apache/apisix-ingress-controller/blob/main/internal/controller/httproute_controller.go and https://github.com/apache/apisix-ingress-controller/blob/main/internal/adc/translator/httproute.go.