### PR TITLE
feat(k8s-apps): replace curl Fastly purge TaskSteps with Fastly resource PutSteps

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
@@ -217,6 +217,57 @@ def _define_registry_image_resources(
     return docker_ci_image, docker_rc_image, ecr_ci_image, ecr_rc_image
 
 
+def _define_fastly_resources(
+    app_name: str,
+    fastly_service_prefix: str,
+) -> tuple[ResourceType, Resource, Resource, Resource]:
+    """Define the Fastly resource type and per-environment cache-purge resources.
+
+    :param app_name: The application name; used as a prefix for resource identifiers.
+    :param fastly_service_prefix: Vault path prefix used to resolve the per-environment
+        Fastly service IDs (e.g. ``"learn_"`` resolves to
+        ``((fastly.learn_service_id_ci))``, etc.).
+    :returns: A 4-tuple of
+        ``(resource_type, ci_resource, qa_resource, production_resource)``.
+    """
+    fastly_resource_type = ResourceType(
+        name=Identifier("fastly"),
+        type=REGISTRY_IMAGE,
+        source=RegistryImage(repository="mitodl/concourse-fastly-resource"),
+    )
+
+    def _env_resource(env: str) -> Resource:
+        return Resource(
+            name=Identifier(f"{app_name}-fastly-{env}"),
+            type="fastly",
+            check_every="never",
+            source={
+                "api_token": "((fastly.fastly_api_token))",
+                "service_id": f"((fastly.{fastly_service_prefix}service_id_{env}))",
+            },
+        )
+
+    return (
+        fastly_resource_type,
+        _env_resource("ci"),
+        _env_resource("qa"),
+        _env_resource("production"),
+    )
+
+
+def _fastly_purge_params(purge_scope: str) -> dict[str, str]:
+    """Return ``put`` params for a Fastly purge step.
+
+    :param purge_scope: Either ``"purge_all"`` to purge the entire service cache
+        (``mode: purge_all``), or a surrogate-key string (e.g. ``"html-pages"``)
+        to purge only objects tagged with that key (``mode: surrogate_key``).
+    :returns: A ``params`` dict suitable for a Concourse :class:`PutStep`.
+    """
+    if purge_scope == "purge_all":
+        return {"mode": "purge_all"}
+    return {"mode": "surrogate_key", "surrogate_key": purge_scope}
+
+
 def _define_pulumi_resources(
     app_name: str, ol_infra_repo_name: str
 ) -> tuple[ResourceType, str]:
@@ -393,6 +444,21 @@ def build_app_pipeline(app_name: str) -> Pipeline:
         app_name, ol_infra_repo.name
     )
 
+    # Optionally define Fastly resources for post-deployment cache purging
+    fastly_rtype: ResourceType | None = None
+    fastly_ci: Resource | None = None
+    fastly_qa: Resource | None = None
+    fastly_prod: Resource | None = None
+
+    if (
+        pipeline_parameters.purge_fastly_cache
+        and pipeline_parameters.fastly_service_prefix
+    ):
+        fastly_rtype, fastly_ci, fastly_qa, fastly_prod = _define_fastly_resources(
+            app_name=app_name,
+            fastly_service_prefix=pipeline_parameters.fastly_service_prefix,
+        )
+
     # Retrieve any special configurations needed from mapping above,
     # default to no special configuration if app name is not found in mapping
 
@@ -422,6 +488,16 @@ def build_app_pipeline(app_name: str) -> Pipeline:
 
     # Define Deployment Jobs
 
+    # Build CI post-steps list with the correct union type so Pyright is satisfied
+    ci_post_steps: list[GetStep | PutStep | TaskStep] = []
+    if fastly_ci is not None:
+        ci_post_steps.append(
+            PutStep(
+                put=fastly_ci.name,
+                params=_fastly_purge_params(pipeline_parameters.fastly_purge_scope),
+            )
+        )
+
     # CI Deployment
     ci_fragment = pulumi_job(
         pulumi_code=ol_infra_repo,
@@ -444,101 +520,21 @@ def build_app_pipeline(app_name: str) -> Pipeline:
                 reveal=True,
             ),
         ],
-        additional_post_steps=[
-            TaskStep(
-                task=Identifier("purge-fastly-cache"),
-                config=TaskConfig(
-                    platform=Platform.linux,
-                    image_resource=AnonymousResource(
-                        type=REGISTRY_IMAGE,
-                        source={
-                            "repository": dockerhub_ecr_image_uri("alpine/curl"),
-                            "tag": "latest",
-                            "aws_region": ECR_REGION,
-                        },
-                    ),
-                    run=Command(
-                        path="sh",
-                        args=[
-                            "-exc",
-                            (
-                                f'curl -H "Fastly-Key: ((fastly.fastly_api_token))" -H "Accept: application/json" -i -X POST "https://api.fastly.com/service/((fastly.{pipeline_parameters.fastly_service_prefix}service_id_ci))/purge_all"'
-                                if pipeline_parameters.fastly_purge_scope == "purge_all"
-                                else f'curl -H "Fastly-Key: ((fastly.fastly_api_token))" -H "Accept: application/json" -i -X POST "https://api.fastly.com/service/((fastly.{pipeline_parameters.fastly_service_prefix}service_id_ci))/purge/{pipeline_parameters.fastly_purge_scope}"'
-                            ),
-                        ],
-                    ),
-                ),
-            ),
-        ]
-        if pipeline_parameters.purge_fastly_cache
-        else [],
+        additional_post_steps=ci_post_steps,
         additional_env_vars={
             f"{app_name.replace('-', '_').upper()}_DOCKER_SHA": "((.:image_digest))",
         },
         slack_url_path="eks.slack_url",
     )
 
-    additional_post_steps: dict[int, list[TaskStep]] = {}
-    if pipeline_parameters.purge_fastly_cache:
-        additional_post_steps = {
-            0: [
-                TaskStep(
-                    task=Identifier("purge-fastly-cache"),
-                    config=TaskConfig(
-                        platform=Platform.linux,
-                        image_resource=AnonymousResource(
-                            type=REGISTRY_IMAGE,
-                            source={
-                                "repository": dockerhub_ecr_image_uri("alpine/curl"),
-                                "tag": "latest",
-                                "aws_region": ECR_REGION,
-                            },
-                        ),
-                        run=Command(
-                            path="sh",
-                            args=[
-                                "-exc",
-                                (
-                                    f'curl -H "Fastly-Key: ((fastly.fastly_api_token))" -H "Accept: application/json" -i -X POST "https://api.fastly.com/service/((fastly.{pipeline_parameters.fastly_service_prefix}service_id_qa))/purge_all"'
-                                    if pipeline_parameters.fastly_purge_scope
-                                    == "purge_all"
-                                    else f'curl -H "Fastly-Key: ((fastly.fastly_api_token))" -H "Accept: application/json" -i -X POST "https://api.fastly.com/service/((fastly.{pipeline_parameters.fastly_service_prefix}service_id_qa))/purge/{pipeline_parameters.fastly_purge_scope}"'
-                                ),
-                            ],
-                        ),
-                    ),
-                ),
-            ],
-            1: [
-                TaskStep(
-                    task=Identifier("purge-fastly-cache"),
-                    config=TaskConfig(
-                        platform=Platform.linux,
-                        image_resource=AnonymousResource(
-                            type=REGISTRY_IMAGE,
-                            source={
-                                "repository": dockerhub_ecr_image_uri("alpine/curl"),
-                                "tag": "latest",
-                                "aws_region": ECR_REGION,
-                            },
-                        ),
-                        run=Command(
-                            path="sh",
-                            args=[
-                                "-exc",
-                                (
-                                    f'curl -H "Fastly-Key: ((fastly.fastly_api_token))" -H "Accept: application/json" -i -X POST "https://api.fastly.com/service/((fastly.{pipeline_parameters.fastly_service_prefix}service_id_production))/purge_all"'
-                                    if pipeline_parameters.fastly_purge_scope
-                                    == "purge_all"
-                                    else f'curl -H "Fastly-Key: ((fastly.fastly_api_token))" -H "Accept: application/json" -i -X POST "https://api.fastly.com/service/((fastly.{pipeline_parameters.fastly_service_prefix}service_id_production))/purge/{pipeline_parameters.fastly_purge_scope}"'
-                                ),
-                            ],
-                        ),
-                    ),
-                ),
-            ],
-        }
+    additional_post_steps: dict[int, list[GetStep | PutStep | TaskStep]] = {}
+    if fastly_qa is not None and fastly_prod is not None:
+        purge_params = _fastly_purge_params(pipeline_parameters.fastly_purge_scope)
+        qa_purge_steps: list[GetStep | PutStep | TaskStep] = []
+        qa_purge_steps.append(PutStep(put=fastly_qa.name, params=purge_params))
+        prod_purge_steps: list[GetStep | PutStep | TaskStep] = []
+        prod_purge_steps.append(PutStep(put=fastly_prod.name, params=purge_params))
+        additional_post_steps = {0: qa_purge_steps, 1: prod_purge_steps}
 
     # QA and Production Deployments
     qa_and_production_fragment = pulumi_jobs_chain(
@@ -600,10 +596,15 @@ def build_app_pipeline(app_name: str) -> Pipeline:
         app_rc_image,  # Needed for QA/Prod deployment trigger
         docker_ci_image,
         docker_rc_image,
+        *([fastly_ci, fastly_qa, fastly_prod] if fastly_ci else []),
     ]
 
     ci_deployment_fragment = PipelineFragment(
-        resource_types=[pulumi_resource_type, *ci_fragment.resource_types],
+        resource_types=[
+            pulumi_resource_type,
+            *ci_fragment.resource_types,
+            *([fastly_rtype] if fastly_rtype else []),
+        ],
         resources=[*deployment_resources, *ci_fragment.resources],
         jobs=ci_fragment.jobs,
     )

--- a/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
@@ -46,7 +46,11 @@ class AppPipelineParams(BaseModel):
         app_name (str): The name of the application.
         build_target (Optional[str]): The specific target stage to build within the Dockerfile.
         dockerfile_path (str): The path to the Dockerfile within the repository. Defaults to "./Dockerfile".
-        fastly_service_prefix (Optional[str]): A prefix used to identify Fastly service IDs in Vault.
+        fastly_domains (Optional[dict[str, str]]): Per-environment hostnames served by the Fastly
+            service for this app.  When set together with ``purge_fastly_cache=True``, the
+            pipeline registers a Fastly resource for each environment and resolves the service ID
+            automatically from the domain name at pipeline runtime — no opaque service IDs need to
+            be stored in Vault.  Keys must be ``"ci"``, ``"qa"``, and ``"production"``.
         purge_fastly_cache (bool): Whether to include steps to purge the Fastly cache after deployment. Defaults to False.
         fastly_purge_scope (str): Controls which Fastly purge endpoint is called when purge_fastly_cache is True.
             Use "purge_all" (the default) to purge the entire service cache via POST /purge_all.
@@ -59,7 +63,7 @@ class AppPipelineParams(BaseModel):
     app_name: str
     build_target: str | None = None
     dockerfile_path: str = "./Dockerfile"
-    fastly_service_prefix: str | None = None
+    fastly_domains: dict[str, str] | None = None
     purge_fastly_cache: bool = False
     fastly_purge_scope: str = "purge_all"
     repo_name: str | None = None
@@ -97,7 +101,11 @@ pipeline_params = {
         repo_name="mit-learn",
         dockerfile_path="frontends/main/Dockerfile.web",
         purge_fastly_cache=True,
-        fastly_service_prefix="learn_",
+        fastly_domains={
+            "ci": "next.ci.learn.mit.edu",
+            "qa": "next.rc.learn.mit.edu",
+            "production": "next.learn.mit.edu",
+        },
         fastly_purge_scope="html-pages",
     ),
     "xpro": AppPipelineParams(
@@ -219,14 +227,17 @@ def _define_registry_image_resources(
 
 def _define_fastly_resources(
     app_name: str,
-    fastly_service_prefix: str,
+    fastly_domains: dict[str, str],
 ) -> tuple[ResourceType, Resource, Resource, Resource]:
     """Define the Fastly resource type and per-environment cache-purge resources.
 
     :param app_name: The application name; used as a prefix for resource identifiers.
-    :param fastly_service_prefix: Vault path prefix used to resolve the per-environment
-        Fastly service IDs (e.g. ``"learn_"`` resolves to
-        ``((fastly.learn_service_id_ci))``, etc.).
+    :param fastly_domains: Mapping of environment name to the hostname served by the
+        Fastly service for that environment (e.g.
+        ``{"ci": "next.ci.learn.mit.edu", "qa": "next.rc.learn.mit.edu",
+        "production": "next.learn.mit.edu"}``).  The Fastly resource resolves the
+        service ID automatically from the domain at pipeline runtime — no opaque
+        service IDs need to be stored in Vault.
     :returns: A 4-tuple of
         ``(resource_type, ci_resource, qa_resource, production_resource)``.
     """
@@ -243,7 +254,7 @@ def _define_fastly_resources(
             check_every="never",
             source={
                 "api_token": "((fastly.fastly_api_token))",
-                "service_id": f"((fastly.{fastly_service_prefix}service_id_{env}))",
+                "domain": fastly_domains[env],
             },
         )
 
@@ -450,13 +461,10 @@ def build_app_pipeline(app_name: str) -> Pipeline:
     fastly_qa: Resource | None = None
     fastly_prod: Resource | None = None
 
-    if (
-        pipeline_parameters.purge_fastly_cache
-        and pipeline_parameters.fastly_service_prefix
-    ):
+    if pipeline_parameters.purge_fastly_cache and pipeline_parameters.fastly_domains:
         fastly_rtype, fastly_ci, fastly_qa, fastly_prod = _define_fastly_resources(
             app_name=app_name,
-            fastly_service_prefix=pipeline_parameters.fastly_service_prefix,
+            fastly_domains=pipeline_parameters.fastly_domains,
         )
 
     # Retrieve any special configurations needed from mapping above,

--- a/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
@@ -19,6 +19,7 @@ from ol_concourse.lib.models.pipeline import (
     Pipeline,
     Platform,
     PutStep,
+    RegistryImage,
     Resource,
     ResourceType,
     TaskConfig,
@@ -81,6 +82,33 @@ class AppPipelineParams(BaseModel):
         """Set the repo_name based on the app_name if not provided."""
         if not self.repo_name:
             self.repo_name = self.app_name
+        return self
+
+    @model_validator(mode="after")
+    def validate_fastly_config(self) -> "AppPipelineParams":
+        """Enforce that fastly_domains is fully specified when cache purging is enabled.
+
+        Raises:
+            ValueError: if ``purge_fastly_cache`` is True but ``fastly_domains`` is
+                not set, or if any of the required keys (``ci``, ``qa``,
+                ``production``) are missing from ``fastly_domains``.
+        """
+        if not self.purge_fastly_cache:
+            return self
+        if self.fastly_domains is None:
+            msg = (
+                f"{self.app_name}: purge_fastly_cache=True requires fastly_domains "
+                "to be set with keys 'ci', 'qa', and 'production'."
+            )
+            raise ValueError(msg)
+        required_envs = {"ci", "qa", "production"}
+        missing = required_envs - self.fastly_domains.keys()
+        if missing:
+            msg = (
+                f"{self.app_name}: fastly_domains is missing required environment "
+                f"keys: {sorted(missing)}"
+            )
+            raise ValueError(msg)
         return self
 
 
@@ -604,7 +632,13 @@ def build_app_pipeline(app_name: str) -> Pipeline:
         app_rc_image,  # Needed for QA/Prod deployment trigger
         docker_ci_image,
         docker_rc_image,
-        *([fastly_ci, fastly_qa, fastly_prod] if fastly_ci else []),
+        *(
+            [fastly_ci, fastly_qa, fastly_prod]
+            if fastly_ci is not None
+            and fastly_qa is not None
+            and fastly_prod is not None
+            else []
+        ),
     ]
 
     ci_deployment_fragment = PipelineFragment(

--- a/uv.lock
+++ b/uv.lock
@@ -1385,14 +1385,14 @@ wheels = [
 
 [[package]]
 name = "ol-concourse"
-version = "0.8.3"
+version = "0.8.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/58/b930e1ffd7eea4e33ac4969517651cd35f9026de9691ecdf414a1cbfde73/ol_concourse-0.8.3.tar.gz", hash = "sha256:eaf4f14a7d74a6563c1abf7e30fc54a87d134fcf0f350446fd88610a1c1420ca", size = 45488, upload-time = "2026-05-04T14:17:21.602Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/f3/1e444c3eb595cc66e114d920220bb65bd89dbd9aa323966061c0ba6e7f57/ol_concourse-0.8.6.tar.gz", hash = "sha256:1d6c66f58cbeeddf09a0beb17d46b0ae848ef5d7e3b509c3522b79a9de3aec0a", size = 46739, upload-time = "2026-06-03T19:23:02.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/cb/ff32bad195086050fe55e4fd88e6a637ed19fb737f644f5ab75f23044a1c/ol_concourse-0.8.3-py3-none-any.whl", hash = "sha256:5fc8ea832ab69d4d7aae3c7bf36a747b50599817a2d2d7a9453ba9ffc11b835b", size = 47001, upload-time = "2026-05-04T14:17:20.422Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/26/191216be9c80617eaf99a986c1b749805b3023783f7522dc4e52615d6e0b/ol_concourse-0.8.6-py3-none-any.whl", hash = "sha256:07665c42b38a163013f04ee53f803b89b1a0a20e36c5c5e64b6c03f211dfe1be", size = 48053, upload-time = "2026-06-03T19:23:01.466Z" },
 ]
 
 [[package]]
@@ -1458,7 +1458,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.0,<0.29" },
     { name = "hvac", extras = ["parser"], specifier = ">=2.0.0,<3" },
     { name = "kubernetes", specifier = ">=34.1.0" },
-    { name = "ol-concourse", specifier = ">=0.8.2,<0.9" },
+    { name = "ol-concourse", specifier = ">=0.8.5,<0.9" },
     { name = "ol-parliament", specifier = ">=1.7.0" },
     { name = "packaging", specifier = ">=24.2" },
     { name = "pulumi", specifier = ">=3.39.1,<4" },


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Replaces the inline `alpine/curl` `TaskStep` cache-purge steps in the k8s apps pipeline with first-class `PutStep`s backed by the `mitodl/concourse-fastly-resource` custom resource type (see [`resources/fastly/concourse.py`](https://github.com/mitodl/ol-concourse/blob/main/resources/fastly/concourse.py) in `ol-concourse`).

**What changed (two commits):**

**Commit 1 — replace curl with Fastly resource PutSteps**

Previously each post-deployment Fastly purge was a bare `curl` call inside a `TaskStep` using an `alpine/curl` container, with the API token and service ID interpolated directly into the shell command string — repeated three times (CI, QA, Production). This commit replaces all three with `PutStep`s against named Fastly resources.

Two helper functions are added:
- `_define_fastly_resources()` — registers a `fastly` `ResourceType` (backed by `mitodl/concourse-fastly-resource`) and creates three `Resource` objects per app (`ci`, `qa`, `production`), all with `check_every: never`.
- `_fastly_purge_params()` — maps the existing `fastly_purge_scope` string to the correct Fastly resource `put` params: `mode: purge_all` or `mode: surrogate_key`.

**Commit 2 — resolve service ID from domain name instead of Vault path**

`AppPipelineParams.fastly_service_prefix` (a Vault path prefix used to look up opaque Fastly service IDs) is replaced with `fastly_domains`: a dict mapping environment names to the actual hostnames served by the Fastly service. The Fastly resource resolves the service ID automatically at pipeline runtime via the Fastly API, so service IDs no longer need to be tracked or stored in Vault.

For `mit-learn-nextjs`:
| Environment | Domain |
|-------------|--------|
| CI | `next.ci.learn.mit.edu` |
| QA | `next.rc.learn.mit.edu` |
| Production | `next.learn.mit.edu` |

(Domain values taken from the per-stack `Pulumi.{env}.yaml` configs in [`src/ol_infrastructure/applications/mit_learn_nextjs/`](https://github.com/mitodl/ol-infrastructure/tree/main/src/ol_infrastructure/applications/mit_learn_nextjs).)

Apps without `purge_fastly_cache=True` are completely unaffected.

### How can this be tested?
Run the pipeline generator locally and inspect the output:

```bash
# Fastly-enabled app: should show fastly ResourceType, 3 fastly Resources with
# domain: set (no service_id:), and surrogate_key PutSteps in each deploy job
uv run python src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py mit-learn-nextjs | \
  python3 -c "
import sys, json
decoder = json.JSONDecoder()
data, _ = decoder.raw_decode(sys.stdin.read())
print('resource_types:', [rt['name'] for rt in data['resource_types']])
for r in data['resources']:
    if r.get('type') == 'fastly':
        print(r['name'], r['source'])
for j in data['jobs']:
    for s in j.get('plan', []):
        if 'fastly' in s.get('put', ''):
            print(j['name'], s['put'], s['params'])
"

# Non-Fastly app: should show no fastly resources or puts
uv run python src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py mitxonline | \
  python3 -c "
import sys, json
decoder = json.JSONDecoder()
data, _ = decoder.raw_decode(sys.stdin.read())
print('fastly (expect none):', [r for r in data['resources'] if 'fastly' in r.get('type','')])
"
```