### PR TITLE
Route all Concourse Docker Hub image pulls through ECR pull-through cache

### DIFF
--- a/src/ol_concourse/pipelines/applications/google_ads_optimization/ad_optimization_pipeline.py
+++ b/src/ol_concourse/pipelines/applications/google_ads_optimization/ad_optimization_pipeline.py
@@ -12,7 +12,6 @@ from ol_concourse.lib.models.pipeline import (
     Output,
     Pipeline,
     Platform,
-    RegistryImage,
     TaskConfig,
     TaskStep,
 )
@@ -21,6 +20,8 @@ from ol_concourse.lib.resource_types import (
     slack_notification_resource as slack_notification_resource_type,
 )
 from ol_concourse.lib.resources import schedule, slack_notification
+
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
 
 COURSES = ["ml", "gen_ai", "sys_think", "sys_eng"]
 
@@ -49,7 +50,10 @@ def ad_optimization_pipeline() -> Pipeline:
                     platform=Platform.linux,
                     image_resource=AnonymousResource(
                         type=REGISTRY_IMAGE,
-                        source=RegistryImage(repository="mitodl/ad-opt"),
+                        source={
+                            "repository": dockerhub_ecr_image_uri("mitodl/ad-opt"),
+                            "aws_region": ECR_REGION,
+                        },
                     ),
                     params={
                         "WLSACCESSID": "((google_ads_optimization.gurobi_wls_access_id))",
@@ -98,7 +102,11 @@ def ad_optimization_pipeline() -> Pipeline:
                     platform=Platform.linux,
                     image_resource=AnonymousResource(
                         type="registry-image",
-                        source=RegistryImage(repository="debian", tag="12-slim"),
+                        source={
+                            "repository": dockerhub_ecr_image_uri("debian"),
+                            "tag": "12-slim",
+                            "aws_region": ECR_REGION,
+                        },
                     ),
                     run=Command(
                         path="bash",

--- a/src/ol_concourse/pipelines/applications/ol_superset_deploy.py
+++ b/src/ol_concourse/pipelines/applications/ol_superset_deploy.py
@@ -14,6 +14,8 @@ from ol_concourse.lib.models.pipeline import (
 )
 from ol_concourse.lib.resources import git_repo
 
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
+
 ol_data_platform_repo = git_repo(
     name=Identifier("ol-data-platform-repository"),
     uri="https://github.com/mitodl/ol-data-platform",
@@ -69,8 +71,11 @@ deploy_pipeline = Pipeline(
                         image_resource=AnonymousResource(
                             type="registry-image",
                             source={
-                                "repository": "mitodl/ol-superset",
+                                "repository": dockerhub_ecr_image_uri(
+                                    "mitodl/ol-superset"
+                                ),
                                 "tag": "latest",
+                                "aws_region": ECR_REGION,
                             },
                         ),
                         inputs=[Input(name=ol_data_platform_repo.name)],

--- a/src/ol_concourse/pipelines/constants.py
+++ b/src/ol_concourse/pipelines/constants.py
@@ -1,6 +1,35 @@
 from pathlib import Path
 
 GH_ISSUES_DEFAULT_REPOSITORY = "ol-platform-eng/concourse-workflow"
+
+# ECR pull-through cache for Docker Hub — avoids Docker Hub rate limits.
+# Set aws_region (inline dicts) or ecr_region (registry_image()) alongside
+# image repos returned by dockerhub_ecr_image_uri().
+ECR_REGION = "us-east-1"
+
+
+def dockerhub_ecr_image_uri(image_repo: str) -> str:
+    """Return the ECR pull-through cache repository path for a Docker Hub image.
+
+    Routes image pulls through the ECR ``dockerhub`` pull-through cache prefix to
+    avoid Docker Hub anonymous/authenticated rate limits in Concourse pipelines.
+
+    Use this as:
+    - ``image_repository`` in :func:`~ol_concourse.lib.resources.registry_image`
+      together with ``ecr_region=ECR_REGION``.
+    - ``"repository"`` in an inline ``image_resource`` dict together with
+      ``"aws_region": ECR_REGION``.
+
+    :param image_repo: Docker Hub image name, e.g. ``"alpine"`` or
+        ``"grafana/grizzly"``.  Official library images (no namespace) are
+        automatically prefixed with ``library/``.
+    :returns: ECR pull-through repository path, e.g. ``"dockerhub/library/alpine"``.
+    """
+    if "/" not in image_repo:
+        image_repo = f"library/{image_repo}"
+    return f"dockerhub/{image_repo}"
+
+
 PACKER_WATCHED_PATHS = [
     "src/bilder/images/packer.pkr.hcl",
     "src/bilder/images/config.pkr.hcl",

--- a/src/ol_concourse/pipelines/container_images/dcind.py
+++ b/src/ol_concourse/pipelines/container_images/dcind.py
@@ -18,6 +18,8 @@ from ol_concourse.lib.models.pipeline import (
 )
 from ol_concourse.lib.resources import git_repo, github_release
 
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
+
 ol_inf_repo = git_repo(
     name=Identifier("ol-infrastructure-repository"),
     uri="https://github.com/mitodl/ol-infrastructure",
@@ -61,8 +63,9 @@ docker_pipeline = Pipeline(
                         image_resource=AnonymousResource(
                             type="registry-image",
                             source={
-                                "repository": "alpine",
+                                "repository": dockerhub_ecr_image_uri("alpine"),
                                 "tag": "3",
+                                "aws_region": ECR_REGION,
                             },
                         ),
                         inputs=[Input(name=dagger_release.name)],

--- a/src/ol_concourse/pipelines/infrastructure/cloud_custodian/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/cloud_custodian/pipeline.py
@@ -8,11 +8,12 @@ from ol_concourse.lib.models.pipeline import (
     Job,
     Pipeline,
     Platform,
-    RegistryImage,
     TaskConfig,
     TaskStep,
 )
 from ol_concourse.lib.resources import git_repo, schedule
+
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
 
 cloud_custodian_release = git_repo(
     Identifier("ol-infrastructure"),
@@ -23,7 +24,11 @@ build_schedule = schedule(Identifier("build-schedule"), "24h")
 
 custodian_registry_image = AnonymousResource(
     type=REGISTRY_IMAGE,
-    source=RegistryImage(repository="cloudcustodian/c7n", tag="0.9.15.0"),
+    source={
+        "repository": dockerhub_ecr_image_uri("cloudcustodian/c7n"),
+        "tag": "0.9.15.0",
+        "aws_region": ECR_REGION,
+    },
 )
 
 job_filename_dict = {

--- a/src/ol_concourse/pipelines/infrastructure/dagster/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/dagster/pipeline.py
@@ -19,8 +19,10 @@ from ol_concourse.lib.models.pipeline import (
 from ol_concourse.lib.resources import git_repo, registry_image
 
 from ol_concourse.pipelines.constants import (
+    ECR_REGION,
     PULUMI_CODE_PATH,
     PULUMI_WATCHED_PATHS,
+    dockerhub_ecr_image_uri,
 )
 from ol_concourse.pipelines.jobs import pulumi_jobs_chain
 
@@ -149,8 +151,11 @@ def build_dagster_docker_pipeline() -> Pipeline:
                         image_resource=AnonymousResource(
                             type="registry-image",
                             source={
-                                "repository": "mitodl/ol-infrastructure",
+                                "repository": dockerhub_ecr_image_uri(
+                                    "mitodl/ol-infrastructure"
+                                ),
                                 "tag": "latest",
+                                "aws_region": ECR_REGION,
                             },
                         ),
                         run=Command(
@@ -171,7 +176,11 @@ def build_dagster_docker_pipeline() -> Pipeline:
                         platform=Platform.linux,
                         image_resource=AnonymousResource(
                             type="registry-image",
-                            source={"repository": "amazon/aws-cli", "tag": "latest"},
+                            source={
+                                "repository": dockerhub_ecr_image_uri("amazon/aws-cli"),
+                                "tag": "latest",
+                                "aws_region": ECR_REGION,
+                            },
                         ),
                         params={
                             "REPO_NAME": image.source["repository"],

--- a/src/ol_concourse/pipelines/infrastructure/grafana_cloud/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/grafana_cloud/pipeline.py
@@ -11,13 +11,14 @@ from ol_concourse.lib.models.pipeline import (
     Pipeline,
     Platform,
     PutStep,
-    RegistryImage,
     TaskConfig,
     TaskStep,
 )
 from ol_concourse.lib.notifications import notification
 from ol_concourse.lib.resource_types import slack_notification_resource as snr_type
 from ol_concourse.lib.resources import schedule, slack_notification, ssh_git_repo
+
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
 
 build_schedule = schedule(Identifier("build-schedule"), "1h")
 
@@ -63,17 +64,29 @@ alertmanager_config = ssh_git_repo(
 
 grizzly_registry_image = AnonymousResource(
     type=REGISTRY_IMAGE,
-    source=RegistryImage(repository="grafana/grizzly", tag="0.2.0-beta3-amd64"),
+    source={
+        "repository": dockerhub_ecr_image_uri("grafana/grizzly"),
+        "tag": "0.2.0-beta3-amd64",
+        "aws_region": ECR_REGION,
+    },
 )
 
 cortextool_registry_image = AnonymousResource(
     type=REGISTRY_IMAGE,
-    source=RegistryImage(repository="grafana/cortex-tools", tag="v0.10.7"),
+    source={
+        "repository": dockerhub_ecr_image_uri("grafana/cortex-tools"),
+        "tag": "v0.10.7",
+        "aws_region": ECR_REGION,
+    },
 )
 
 git_registry_image = AnonymousResource(
     type=REGISTRY_IMAGE,
-    source=RegistryImage(repository="bitnamilegacy/git", tag="2.35.1"),
+    source={
+        "repository": dockerhub_ecr_image_uri("bitnamilegacy/git"),
+        "tag": "2.35.1",
+        "aws_region": ECR_REGION,
+    },
 )
 
 commit_managed_dashboards_job = Job(

--- a/src/ol_concourse/pipelines/infrastructure/heroku_dyno_reset/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/heroku_dyno_reset/pipeline.py
@@ -12,13 +12,13 @@ from ol_concourse.lib.models.pipeline import (
     Job,
     Pipeline,
     Platform,
-    RegistryImage,
     TaskConfig,
     TaskStep,
 )
 from ol_concourse.lib.resources import git_repo, schedule
 
 from bridge.secrets.sops import read_yaml_secrets
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
 
 qa_dyno_map = {
     "ocw-studio-ci": {
@@ -179,7 +179,11 @@ ol_infra_git_repo = git_repo(
 
 heroku_cli_resource = AnonymousResource(
     type=REGISTRY_IMAGE,
-    source=RegistryImage(repository="mitodl/heroku-cli", tag="latest"),
+    source={
+        "repository": dockerhub_ecr_image_uri("mitodl/heroku-cli"),
+        "tag": "latest",
+        "aws_region": ECR_REGION,
+    },
 )
 
 

--- a/src/ol_concourse/pipelines/infrastructure/k8s_apps/meta.py
+++ b/src/ol_concourse/pipelines/infrastructure/k8s_apps/meta.py
@@ -16,6 +16,14 @@ from ol_concourse.lib.models.pipeline import (
 )
 from ol_concourse.lib.resources import git_repo
 
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
+
+_OL_INFRA_IMAGE_SOURCE = {
+    "repository": dockerhub_ecr_image_uri("mitodl/ol-infrastructure"),
+    "tag": "latest",
+    "aws_region": ECR_REGION,
+}
+
 
 def meta_job(app_name: str) -> Job:
     return Job(
@@ -31,10 +39,7 @@ def meta_job(app_name: str) -> Job:
                     platform=Platform.linux,
                     image_resource=AnonymousResource(
                         type="registry-image",
-                        source={
-                            "repository": "mitodl/ol-infrastructure",
-                            "tag": "latest",
-                        },
+                        source=_OL_INFRA_IMAGE_SOURCE,
                     ),
                     inputs=[Input(name=Identifier("k8s-app-pipeline-definitions"))],
                     outputs=[Output(name=Identifier("pipeline"))],
@@ -84,10 +89,7 @@ def meta_pipeline(app_names: list[str]) -> Pipeline:
                         platform=Platform.linux,
                         image_resource=AnonymousResource(
                             type="registry-image",
-                            source={
-                                "repository": "mitodl/ol-infrastructure",
-                                "tag": "latest",
-                            },
+                            source=_OL_INFRA_IMAGE_SOURCE,
                         ),
                         inputs=[Input(name=Identifier("k8s-app-pipeline-definitions"))],
                         outputs=[Output(name=Identifier("pipeline"))],

--- a/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
@@ -19,7 +19,6 @@ from ol_concourse.lib.models.pipeline import (
     Pipeline,
     Platform,
     PutStep,
-    RegistryImage,
     Resource,
     ResourceType,
     TaskConfig,
@@ -29,7 +28,11 @@ from ol_concourse.lib.resource_types import pulumi_provisioner_resource
 from ol_concourse.lib.resources import git_repo, pulumi_provisioner, registry_image
 from pydantic import BaseModel, model_validator
 
-from ol_concourse.pipelines.constants import PULUMI_WATCHED_PATHS
+from ol_concourse.pipelines.constants import (
+    ECR_REGION,
+    PULUMI_WATCHED_PATHS,
+    dockerhub_ecr_image_uri,
+)
 from ol_concourse.pipelines.jobs import pulumi_job, pulumi_jobs_chain
 
 
@@ -267,7 +270,11 @@ def _build_image_job(
                         platform=Platform.linux,
                         image_resource=AnonymousResource(
                             type=REGISTRY_IMAGE,
-                            source=RegistryImage(repository="alpine"),
+                            source={
+                                "repository": dockerhub_ecr_image_uri("alpine"),
+                                "tag": "latest",
+                                "aws_region": ECR_REGION,
+                            },
                         ),
                         inputs=[Input(name=git_repo_resource.name)],
                         outputs=[Output(name=Identifier(version_output_dir))],
@@ -327,7 +334,11 @@ def _build_image_job(
                 platform=Platform.linux,
                 image_resource=AnonymousResource(
                     type="registry-image",
-                    source={"repository": "amazon/aws-cli", "tag": "latest"},
+                    source={
+                        "repository": dockerhub_ecr_image_uri("amazon/aws-cli"),
+                        "tag": "latest",
+                        "aws_region": ECR_REGION,
+                    },
                 ),
                 params={
                     "REPO_NAME": ecr_registry_image_resource.source["repository"],
@@ -440,7 +451,11 @@ def build_app_pipeline(app_name: str) -> Pipeline:
                     platform=Platform.linux,
                     image_resource=AnonymousResource(
                         type=REGISTRY_IMAGE,
-                        source=RegistryImage(repository="alpine/curl"),
+                        source={
+                            "repository": dockerhub_ecr_image_uri("alpine/curl"),
+                            "tag": "latest",
+                            "aws_region": ECR_REGION,
+                        },
                     ),
                     run=Command(
                         path="sh",
@@ -474,7 +489,11 @@ def build_app_pipeline(app_name: str) -> Pipeline:
                         platform=Platform.linux,
                         image_resource=AnonymousResource(
                             type=REGISTRY_IMAGE,
-                            source=RegistryImage(repository="alpine/curl"),
+                            source={
+                                "repository": dockerhub_ecr_image_uri("alpine/curl"),
+                                "tag": "latest",
+                                "aws_region": ECR_REGION,
+                            },
                         ),
                         run=Command(
                             path="sh",
@@ -498,7 +517,11 @@ def build_app_pipeline(app_name: str) -> Pipeline:
                         platform=Platform.linux,
                         image_resource=AnonymousResource(
                             type=REGISTRY_IMAGE,
-                            source=RegistryImage(repository="alpine/curl"),
+                            source={
+                                "repository": dockerhub_ecr_image_uri("alpine/curl"),
+                                "tag": "latest",
+                                "aws_region": ECR_REGION,
+                            },
                         ),
                         run=Command(
                             path="sh",

--- a/src/ol_concourse/pipelines/infrastructure/keycloak/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/keycloak/pipeline.py
@@ -15,7 +15,6 @@ from ol_concourse.lib.models.pipeline import (
     Output,
     Platform,
     PutStep,
-    RegistryImage,
     TaskConfig,
     TaskStep,
 )
@@ -27,7 +26,12 @@ from ol_concourse.lib.resources import (
 )
 
 from bridge.lib.versions import KEYCLOAK_VERSION
-from ol_concourse.pipelines.constants import PULUMI_CODE_PATH, PULUMI_WATCHED_PATHS
+from ol_concourse.pipelines.constants import (
+    ECR_REGION,
+    PULUMI_CODE_PATH,
+    PULUMI_WATCHED_PATHS,
+    dockerhub_ecr_image_uri,
+)
 from ol_concourse.pipelines.jobs import pulumi_jobs_chain
 
 
@@ -143,7 +147,11 @@ def build_keycloak_infrastructure_pipeline() -> PipelineFragment:
                     ],
                     image_resource=AnonymousResource(
                         type=REGISTRY_IMAGE,
-                        source=RegistryImage(repository="debian", tag="12-slim"),
+                        source={
+                            "repository": dockerhub_ecr_image_uri("debian"),
+                            "tag": "12-slim",
+                            "aws_region": ECR_REGION,
+                        },
                     ),
                     run=Command(
                         path="sh",

--- a/src/ol_concourse/pipelines/infrastructure/meta.py
+++ b/src/ol_concourse/pipelines/infrastructure/meta.py
@@ -29,7 +29,13 @@ from ol_concourse.lib.models.pipeline import (
 )
 from ol_concourse.lib.resources import git_repo
 
-# (concourse-pipeline-name, repo-relative script path)
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
+
+_OL_INFRA_IMAGE_SOURCE = {
+    "repository": dockerhub_ecr_image_uri("mitodl/ol-infrastructure"),
+    "tag": "latest",
+    "aws_region": ECR_REGION,
+}
 PIPELINE_CONFIGS: list[tuple[str, str]] = [
     (
         "pulumi-aws",
@@ -93,10 +99,7 @@ def meta_job(pipeline_name: str, script_path: str) -> Job:
                     platform=Platform.linux,
                     image_resource=AnonymousResource(
                         type="registry-image",
-                        source={
-                            "repository": "mitodl/ol-infrastructure",
-                            "tag": "latest",
-                        },
+                        source=_OL_INFRA_IMAGE_SOURCE,
                     ),
                     inputs=[
                         Input(name=Identifier("infrastructure-pipeline-definitions"))
@@ -152,10 +155,7 @@ def meta_pipeline() -> Pipeline:
                         platform=Platform.linux,
                         image_resource=AnonymousResource(
                             type="registry-image",
-                            source={
-                                "repository": "mitodl/ol-infrastructure",
-                                "tag": "latest",
-                            },
+                            source=_OL_INFRA_IMAGE_SOURCE,
                         ),
                         inputs=[
                             Input(

--- a/src/ol_concourse/pipelines/infrastructure/ocw_studio_db_replication/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/ocw_studio_db_replication/pipeline.py
@@ -8,13 +8,19 @@ from ol_concourse.lib.models.pipeline import (
     Output,
     Pipeline,
     Platform,
-    RegistryImage,
     TaskConfig,
     TaskStep,
 )
 
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
+
 postgres_resource = AnonymousResource(
-    type=REGISTRY_IMAGE, source=RegistryImage(repository="postgres", tag="12")
+    type=REGISTRY_IMAGE,
+    source={
+        "repository": dockerhub_ecr_image_uri("postgres"),
+        "tag": "12",
+        "aws_region": ECR_REGION,
+    },
 )
 
 

--- a/src/ol_concourse/pipelines/infrastructure/redash/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/redash/pipeline.py
@@ -2,12 +2,18 @@ from ol_concourse.lib.models.fragment import PipelineFragment
 from ol_concourse.lib.models.pipeline import GetStep, Identifier, Pipeline
 from ol_concourse.lib.resources import git_repo, registry_image
 
-from ol_concourse.pipelines.constants import PULUMI_CODE_PATH, PULUMI_WATCHED_PATHS
+from ol_concourse.pipelines.constants import (
+    ECR_REGION,
+    PULUMI_CODE_PATH,
+    PULUMI_WATCHED_PATHS,
+    dockerhub_ecr_image_uri,
+)
 from ol_concourse.pipelines.jobs import packer_jobs, pulumi_jobs_chain
 
 redash_container_resource = registry_image(
     name=Identifier("redash-container"),
-    image_repository="mitodl/redash",
+    image_repository=dockerhub_ecr_image_uri("mitodl/redash"),
+    ecr_region=ECR_REGION,
 )
 
 redash_image_code = git_repo(

--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/meta.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/meta.py
@@ -30,6 +30,14 @@ from ol_concourse.lib.models.pipeline import (
 )
 from ol_concourse.lib.resources import git_repo
 
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
+
+_OL_INFRA_IMAGE_SOURCE = {
+    "repository": dockerhub_ecr_image_uri("mitodl/ol-infrastructure"),
+    "tag": "latest",
+    "aws_region": ECR_REGION,
+}
+
 
 def meta_job(app_name: str) -> Job:
     """Generate a job that creates/updates the pipeline for a specific app.
@@ -53,10 +61,7 @@ def meta_job(app_name: str) -> Job:
                     platform=Platform.linux,
                     image_resource=AnonymousResource(
                         type="registry-image",
-                        source={
-                            "repository": "mitodl/ol-infrastructure",
-                            "tag": "latest",
-                        },
+                        source=_OL_INFRA_IMAGE_SOURCE,
                     ),
                     inputs=[
                         Input(name=Identifier("simple-pulumi-pipeline-definitions"))
@@ -124,10 +129,7 @@ def meta_pipeline(
                         platform=Platform.linux,
                         image_resource=AnonymousResource(
                             type="registry-image",
-                            source={
-                                "repository": "mitodl/ol-infrastructure",
-                                "tag": "latest",
-                            },
+                            source=_OL_INFRA_IMAGE_SOURCE,
                         ),
                         inputs=[
                             Input(name=Identifier("simple-pulumi-pipeline-definitions"))

--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
@@ -15,9 +15,11 @@ from ol_concourse.lib.resources import git_repo, github_issues, registry_image
 from pydantic import BaseModel, model_validator
 
 from ol_concourse.pipelines.constants import (
+    ECR_REGION,
     GH_ISSUES_DEFAULT_REPOSITORY,
     PULUMI_CODE_PATH,
     PULUMI_WATCHED_PATHS,
+    dockerhub_ecr_image_uri,
 )
 from ol_concourse.pipelines.jobs import pulumi_jobs_chain
 
@@ -26,8 +28,11 @@ class DockerImageConfig(BaseModel):
     """Configuration for a Docker image input.
 
     Attributes:
-        image_repository: Docker image repository (e.g., "kodhive/leek").
+        image_repository: Docker image repository. Use
+            :func:`~ol_concourse.pipelines.constants.dockerhub_ecr_image_uri` to
+            route Docker Hub images through the ECR pull-through cache.
         image_tag: Optional tag to watch (default: "latest").
+        ecr_region: Set to ECR_REGION to pull via ECR pull-through cache.
         username: Optional Docker registry username.
         password: Optional Docker registry password.
         env_var_for_digest: Optional environment variable name to pass digest to Pulumi.
@@ -36,6 +41,7 @@ class DockerImageConfig(BaseModel):
 
     image_repository: str
     image_tag: str | None = "latest"
+    ecr_region: str | None = None
     username: str | None = None
     password: str | None = None
     env_var_for_digest: str | None = None
@@ -159,8 +165,9 @@ pipeline_params: dict[str, SimplePulumiParams] = {
         pulumi_project_path="applications/celery_monitoring/",
         pulumi_project_name="ol-application-celery-monitoring",
         docker_image=DockerImageConfig(
-            image_repository="kodhive/leek",
+            image_repository=dockerhub_ecr_image_uri("kodhive/leek"),
             image_tag="0.7.5",  # Must match LEEK_VERSION in bridge.lib.versions
+            ecr_region=ECR_REGION,
         ),
     ),
     "clickhouse": SimplePulumiParams(
@@ -391,6 +398,7 @@ def build_simple_pulumi_pipeline(app_name: str) -> Pipeline:
             image_tag=params.docker_image.image_tag,
             username=params.docker_image.username,
             password=params.docker_image.password,
+            ecr_region=params.docker_image.ecr_region,
         )
         docker_dependencies.append(
             GetStep(get=docker_image_resource.name, trigger=True)

--- a/src/ol_concourse/pipelines/infrastructure/superset/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/superset/pipeline.py
@@ -18,7 +18,12 @@ from ol_concourse.lib.models.pipeline import (
 )
 from ol_concourse.lib.resources import git_repo, github_release, registry_image
 
-from ol_concourse.pipelines.constants import PULUMI_CODE_PATH, PULUMI_WATCHED_PATHS
+from ol_concourse.pipelines.constants import (
+    ECR_REGION,
+    PULUMI_CODE_PATH,
+    PULUMI_WATCHED_PATHS,
+    dockerhub_ecr_image_uri,
+)
 from ol_concourse.pipelines.jobs import pulumi_jobs_chain
 
 
@@ -88,7 +93,11 @@ def build_superset_docker_pipeline() -> Pipeline:
                     platform=Platform.linux,
                     image_resource=AnonymousResource(
                         type="registry-image",
-                        source={"repository": "amazon/aws-cli", "tag": "latest"},
+                        source={
+                            "repository": dockerhub_ecr_image_uri("amazon/aws-cli"),
+                            "tag": "latest",
+                            "aws_region": ECR_REGION,
+                        },
                     ),
                     params={
                         "REPO_NAME": superset_image.source["repository"],

--- a/src/ol_concourse/pipelines/libraries/api_clients_pipeline.py
+++ b/src/ol_concourse/pipelines/libraries/api_clients_pipeline.py
@@ -14,13 +14,12 @@ from ol_concourse.lib.models.pipeline import (
     Output,
     Pipeline,
     PutStep,
-    RegistryImage,
-    Resource,
     TaskConfig,
     TaskStep,
 )
-from ol_concourse.lib.resources import git_repo, ssh_git_repo
+from ol_concourse.lib.resources import git_repo, registry_image, ssh_git_repo
 
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
 from ol_concourse.pipelines.libraries.configuration import PIPELINE_CONFIGS
 
 
@@ -65,32 +64,23 @@ def generate_api_client_pipeline(  # noqa: PLR0913
     commit_script: str = "api-clients-commit-changes.sh"
     publish_script: str = "api-clients-publish-node.sh"
 
-    openapi_generator_image = Resource(
+    openapi_generator_image = registry_image(
         name=Identifier("openapi-generator-image"),
-        type="registry-image",
-        icon="docker",
-        source={
-            "repository": "openapitools/openapi-generator-cli",
-            "tag": openapi_generator_tag,
-        },
+        image_repository=dockerhub_ecr_image_uri("openapitools/openapi-generator-cli"),
+        image_tag=openapi_generator_tag,
+        ecr_region=ECR_REGION,
     )
-    python_image = Resource(
+    python_image = registry_image(
         name=Identifier("python-image"),
-        type="registry-image",
-        icon="docker",
-        source={
-            "repository": "python",
-            "tag": python_image_tag,
-        },
+        image_repository=dockerhub_ecr_image_uri("python"),
+        image_tag=python_image_tag,
+        ecr_region=ECR_REGION,
     )
-    node_image = Resource(
+    node_image = registry_image(
         name=Identifier("node-image"),
-        type="registry-image",
-        icon="docker",
-        source={
-            "repository": "node",
-            "tag": node_image_tag,
-        },
+        image_repository=dockerhub_ecr_image_uri("node"),
+        image_tag=node_image_tag,
+        ecr_region=ECR_REGION,
     )
 
     # Define source and client repositories using parameters
@@ -162,9 +152,13 @@ def generate_api_client_pipeline(  # noqa: PLR0913
                     inputs=[Input(name=api_clients_repository.name)],
                     outputs=[Output(name=api_clients_repository.name)],
                     image_resource=AnonymousResource(
-                        source=RegistryImage(
-                            repository="concourse/buildroot", tag="git"
-                        ),
+                        source={
+                            "repository": dockerhub_ecr_image_uri(
+                                "concourse/buildroot"
+                            ),
+                            "tag": "git",
+                            "aws_region": ECR_REGION,
+                        },
                         type="registry-image",
                     ),
                     platform="linux",

--- a/src/ol_concourse/pipelines/libraries/meta.py
+++ b/src/ol_concourse/pipelines/libraries/meta.py
@@ -15,6 +15,7 @@ from ol_concourse.lib.models.pipeline import (
 )
 from ol_concourse.lib.resources import git_repo
 
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
 from ol_concourse.pipelines.libraries.configuration import PIPELINE_CONFIGS
 
 # Resource for the ol-concourse code itself
@@ -34,8 +35,9 @@ python_image = Resource(
     type="registry-image",
     icon="docker",
     source={
-        "repository": "mitodl/ol-infrastructure",
+        "repository": dockerhub_ecr_image_uri("mitodl/ol-infrastructure"),
         "tag": "latest",
+        "aws_region": ECR_REGION,
     },
 )
 

--- a/src/ol_concourse/pipelines/libraries/python_packages_meta.py
+++ b/src/ol_concourse/pipelines/libraries/python_packages_meta.py
@@ -18,6 +18,8 @@ from ol_concourse.lib.models.pipeline import (
 )
 from ol_concourse.lib.resources import git_repo
 
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
+
 OL_INFRASTRUCTURE_REPO = git_repo(
     name=Identifier("python-package-pipeline-definitions"),
     uri="https://github.com/mitodl/ol-infrastructure",
@@ -46,8 +48,9 @@ OL_DJANGO_REPO = git_repo(
 PIPELINE_IMAGE = AnonymousResource(
     type="registry-image",
     source={
-        "repository": "mitodl/ol-infrastructure",
+        "repository": dockerhub_ecr_image_uri("mitodl/ol-infrastructure"),
         "tag": "latest",
+        "aws_region": ECR_REGION,
     },
 )
 

--- a/src/ol_concourse/pipelines/open_edx/codejail_v3/meta.py
+++ b/src/ol_concourse/pipelines/open_edx/codejail_v3/meta.py
@@ -17,6 +17,7 @@ from ol_concourse.lib.models.pipeline import (
 from ol_concourse.lib.resources import git_repo
 
 from bridge.settings.openedx.types import OpenEdxSupportedRelease
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
 
 pipeline_code = git_repo(
     name=Identifier("codejail-pipeline-code"),
@@ -54,8 +55,11 @@ def build_meta_job(release_name):
                     image_resource=AnonymousResource(
                         type="registry-image",
                         source={
-                            "repository": "mitodl/ol-infrastructure",
+                            "repository": dockerhub_ecr_image_uri(
+                                "mitodl/ol-infrastructure"
+                            ),
                             "tag": "latest",
+                            "aws_region": ECR_REGION,
                         },
                     ),
                     inputs=[Input(name=Identifier(pipeline_code.name))],

--- a/src/ol_concourse/pipelines/open_edx/edx_notes_v3/meta.py
+++ b/src/ol_concourse/pipelines/open_edx/edx_notes_v3/meta.py
@@ -17,6 +17,7 @@ from ol_concourse.lib.models.pipeline import (
 from ol_concourse.lib.resources import git_repo
 
 from bridge.settings.openedx.types import OpenEdxSupportedRelease
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
 
 pipeline_code = git_repo(
     name=Identifier("notes-pipeline-code"),
@@ -54,8 +55,11 @@ def build_meta_job(release_name):
                     image_resource=AnonymousResource(
                         type="registry-image",
                         source={
-                            "repository": "mitodl/ol-infrastructure",
+                            "repository": dockerhub_ecr_image_uri(
+                                "mitodl/ol-infrastructure"
+                            ),
                             "tag": "latest",
+                            "aws_region": ECR_REGION,
                         },
                     ),
                     inputs=[Input(name=Identifier(pipeline_code.name))],

--- a/src/ol_concourse/pipelines/open_edx/edx_platform_v3/meta.py
+++ b/src/ol_concourse/pipelines/open_edx/edx_platform_v3/meta.py
@@ -16,6 +16,8 @@ from ol_concourse.lib.models.pipeline import (
 )
 from ol_concourse.lib.resources import git_repo
 
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
+
 pipeline_code = git_repo(
     name=Identifier("edxapp-pipeline-code"),
     uri="https://github.com/mitodl/ol-infrastructure",
@@ -47,8 +49,11 @@ def build_meta_job(pipeline_name: str):
                     image_resource=AnonymousResource(
                         type="registry-image",
                         source={
-                            "repository": "mitodl/ol-infrastructure",
+                            "repository": dockerhub_ecr_image_uri(
+                                "mitodl/ol-infrastructure"
+                            ),
                             "tag": "latest",
+                            "aws_region": ECR_REGION,
                         },
                     ),
                     inputs=[Input(name=Identifier(pipeline_code.name))],

--- a/src/ol_concourse/pipelines/open_edx/grader_images/build_pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/grader_images/build_pipeline.py
@@ -41,6 +41,8 @@ from ol_concourse.lib.models.pipeline import (
 )
 from ol_concourse.lib.resources import registry_image, ssh_git_repo
 
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
+
 _AWS_ACCOUNT_ID = "610119931565"
 _AWS_REGION = "us-east-1"
 
@@ -105,14 +107,14 @@ def grader_image_pipeline(config: GraderPipelineConfig) -> Pipeline:
         private_key=config.github_private_key,
     )
 
-    # Grader base image on DockerHub — used as a build trigger so that
-    # rebuilding the base image automatically causes this pipeline to run.
+    # Grader base image via ECR pull-through cache — avoids Docker Hub rate limits
+    # while still triggering this pipeline when a new base image is published to
+    # DockerHub (ECR pull-through cache syncs automatically).
     grader_base_image = registry_image(
         name=Identifier("grader-base-image"),
-        image_repository=config.grader_base_dockerhub_repo,
+        image_repository=dockerhub_ecr_image_uri(config.grader_base_dockerhub_repo),
         image_tag="latest",
-        username="((dockerhub.username))",
-        password="((dockerhub.password))",  # noqa: S106
+        ecr_region=config.aws_region,
     )
 
     # Private ECR image for this course's grader.
@@ -146,7 +148,12 @@ def grader_image_pipeline(config: GraderPipelineConfig) -> Pipeline:
                     platform=Platform.linux,
                     image_resource={
                         "type": "registry-image",
-                        "source": {"repository": "concourse/oci-build-task"},
+                        "source": {
+                            "repository": dockerhub_ecr_image_uri(
+                                "concourse/oci-build-task"
+                            ),
+                            "aws_region": ECR_REGION,
+                        },
                     },
                     params={
                         "CONTEXT": str(grader_repo.name),

--- a/src/ol_concourse/pipelines/open_edx/grader_images/build_pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/grader_images/build_pipeline.py
@@ -107,9 +107,9 @@ def grader_image_pipeline(config: GraderPipelineConfig) -> Pipeline:
         private_key=config.github_private_key,
     )
 
-    # Grader base image via ECR pull-through cache — avoids Docker Hub rate limits
-    # while still triggering this pipeline when a new base image is published to
-    # DockerHub (ECR pull-through cache syncs automatically).
+    # Grader base image via ECR pull-through cache — avoids Docker Hub rate limits.
+    # Concourse's periodic `check` on this registry-image resource polls ECR
+    # (not push events), which is what prompts pull-through cache refreshes.
     grader_base_image = registry_image(
         name=Identifier("grader-base-image"),
         image_repository=dockerhub_ecr_image_uri(config.grader_base_dockerhub_repo),

--- a/src/ol_concourse/pipelines/open_edx/grader_images/meta.py
+++ b/src/ol_concourse/pipelines/open_edx/grader_images/meta.py
@@ -33,6 +33,7 @@ from ol_concourse.lib.models.pipeline import (
 )
 from ol_concourse.lib.resources import git_repo
 
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
 from ol_concourse.pipelines.open_edx.grader_images.build_pipeline import (
     GRADER_PIPELINES,
 )
@@ -52,8 +53,9 @@ pipeline_code = git_repo(
 _OL_INFRA_IMAGE = AnonymousResource(
     type="registry-image",
     source={
-        "repository": "mitodl/ol-infrastructure",
+        "repository": dockerhub_ecr_image_uri("mitodl/ol-infrastructure"),
         "tag": "latest",
+        "aws_region": ECR_REGION,
     },
 )
 

--- a/src/ol_concourse/pipelines/open_edx/mfe/meta.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/meta.py
@@ -16,6 +16,7 @@ from ol_concourse.lib.resources import git_repo
 
 from bridge.settings.openedx.types import OpenEdxSupportedRelease
 from bridge.settings.openedx.version_matrix import OpenLearningOpenEdxDeployment
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
 from ol_concourse.pipelines.open_edx.mfe.values import deployments
 
 
@@ -41,8 +42,11 @@ def meta_job(
                     image_resource=AnonymousResource(
                         type="registry-image",
                         source={
-                            "repository": "mitodl/ol-infrastructure",
+                            "repository": dockerhub_ecr_image_uri(
+                                "mitodl/ol-infrastructure"
+                            ),
                             "tag": "latest",
+                            "aws_region": ECR_REGION,
                         },
                     ),
                     inputs=[Input(name=Identifier("mfe-pipeline-definitions"))],
@@ -103,8 +107,11 @@ def meta_pipeline() -> Pipeline:
                         image_resource=AnonymousResource(
                             type="registry-image",
                             source={
-                                "repository": "mitodl/ol-infrastructure",
+                                "repository": dockerhub_ecr_image_uri(
+                                    "mitodl/ol-infrastructure"
+                                ),
                                 "tag": "latest",
+                                "aws_region": ECR_REGION,
                             },
                         ),
                         inputs=[Input(name=Identifier("mfe-pipeline-definitions"))],

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -37,7 +37,11 @@ from bridge.settings.openedx.types import (
     OpenEdxSupportedRelease,
 )
 from bridge.settings.openedx.version_matrix import OpenLearningOpenEdxDeployment
-from ol_concourse.pipelines.constants import GH_ISSUES_DEFAULT_REPOSITORY
+from ol_concourse.pipelines.constants import (
+    ECR_REGION,
+    GH_ISSUES_DEFAULT_REPOSITORY,
+    dockerhub_ecr_image_uri,
+)
 
 
 class OpenEdxVars(BaseModel):
@@ -312,7 +316,11 @@ def mfe_job(  # noqa: C901, PLR0915
                 platform=Platform.linux,
                 image_resource=AnonymousResource(
                     type="registry-image",
-                    source={"repository": "debian", "tag": "trixie-slim"},
+                    source={
+                        "repository": dockerhub_ecr_image_uri("debian"),
+                        "tag": "trixie-slim",
+                        "aws_region": ECR_REGION,
+                    },
                 ),
                 inputs=[Input(name=mfe_repo.name), Input(name=mfe_configs.name)],
                 outputs=[mfe_build_dir],
@@ -333,8 +341,9 @@ def mfe_job(  # noqa: C901, PLR0915
                 image_resource=AnonymousResource(
                     type="registry-image",
                     source={
-                        "repository": "node",
+                        "repository": dockerhub_ecr_image_uri("node"),
                         "tag": f"{mfe.runtime_version}-trixie-slim",
+                        "aws_region": ECR_REGION,
                     },
                 ),
                 inputs=[Input(name=mfe_build_dir.name)],

--- a/src/ol_concourse/pipelines/open_edx/tubular/tubular.py
+++ b/src/ol_concourse/pipelines/open_edx/tubular/tubular.py
@@ -13,11 +13,17 @@ from ol_concourse.lib.models.pipeline import (
     Output,
     Pipeline,
     Platform,
-    RegistryImage,
     TaskConfig,
     TaskStep,
 )
 from ol_concourse.lib.resources import git_repo, schedule
+
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
+
+_TUBULAR_IMAGE_SOURCE = {
+    "repository": dockerhub_ecr_image_uri("mitodl/openedx-tubular"),
+    "aws_region": ECR_REGION,
+}
 
 
 def tubular_pipeline() -> Pipeline:
@@ -42,7 +48,7 @@ def tubular_pipeline() -> Pipeline:
                     platform=Platform.linux,
                     image_resource=AnonymousResource(
                         type=REGISTRY_IMAGE,
-                        source=RegistryImage(repository="mitodl/openedx-tubular"),
+                        source=_TUBULAR_IMAGE_SOURCE,
                     ),
                     inputs=[Input(name=Identifier("tubular-pipeline-config"))],
                     outputs=[tubular_retirees],
@@ -72,7 +78,7 @@ def tubular_pipeline() -> Pipeline:
                     platform=Platform.linux,
                     image_resource=AnonymousResource(
                         type=REGISTRY_IMAGE,
-                        source=RegistryImage(repository="mitodl/openedx-tubular"),
+                        source=_TUBULAR_IMAGE_SOURCE,
                     ),
                     inputs=[Input(name=tubular_retirees.name)],
                     # inline bash script to generate retirees yaml
@@ -116,7 +122,7 @@ def tubular_pipeline() -> Pipeline:
                     platform=Platform.linux,
                     image_resource=AnonymousResource(
                         type=REGISTRY_IMAGE,
-                        source=RegistryImage(repository="mitodl/openedx-tubular"),
+                        source=_TUBULAR_IMAGE_SOURCE,
                     ),
                     inputs=[
                         Input(name=tubular_retirees.name),

--- a/src/ol_concourse/pipelines/open_edx/xqueue/meta.py
+++ b/src/ol_concourse/pipelines/open_edx/xqueue/meta.py
@@ -17,6 +17,7 @@ from ol_concourse.lib.models.pipeline import (
 from ol_concourse.lib.resources import git_repo
 
 from bridge.settings.openedx.types import OpenEdxSupportedRelease
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
 
 pipeline_code = git_repo(
     name=Identifier("xqueue-pipeline-code"),
@@ -52,8 +53,11 @@ def build_meta_job(release_name):
                     image_resource=AnonymousResource(
                         type="registry-image",
                         source={
-                            "repository": "mitodl/ol-infrastructure",
+                            "repository": dockerhub_ecr_image_uri(
+                                "mitodl/ol-infrastructure"
+                            ),
                             "tag": "latest",
+                            "aws_region": ECR_REGION,
                         },
                     ),
                     inputs=[Input(name=Identifier(pipeline_code.name))],

--- a/src/ol_concourse/pipelines/open_edx/xqwatcher/meta.py
+++ b/src/ol_concourse/pipelines/open_edx/xqwatcher/meta.py
@@ -17,6 +17,7 @@ from ol_concourse.lib.models.pipeline import (
 from ol_concourse.lib.resources import git_repo
 
 from bridge.settings.openedx.types import OpenEdxSupportedRelease
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
 
 pipeline_code = git_repo(
     name=Identifier("xqwatcher-pipeline-code"),
@@ -54,8 +55,11 @@ def build_meta_job(release_name):
                     image_resource=AnonymousResource(
                         type="registry-image",
                         source={
-                            "repository": "mitodl/ol-infrastructure",
+                            "repository": dockerhub_ecr_image_uri(
+                                "mitodl/ol-infrastructure"
+                            ),
                             "tag": "latest",
+                            "aws_region": ECR_REGION,
                         },
                     ),
                     inputs=[Input(name=Identifier(pipeline_code.name))],


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Concourse pipelines frequently hit Docker Hub anonymous pull rate limits, causing intermittent build failures. This PR routes all Docker Hub image pulls through the existing ECR pull-through cache (`dockerhub/` prefix in our AWS account), matching the pattern already used in Kubernetes deployments via `cached_image_uri()` in `eks_helper.py`.

**Changes:**
- Adds `dockerhub_ecr_image_uri(image_repo)` helper and `ECR_REGION` constant to `src/ol_concourse/pipelines/constants.py`
- Updates **30 pipeline files** across all pipeline categories

**Two usage patterns used throughout:**
```python
# Named resources (registry_image helper)
registry_image(
    image_repository=dockerhub_ecr_image_uri("alpine"),
    ecr_region=ECR_REGION,
)

# Inline task image_resource dicts
{"repository": dockerhub_ecr_image_uri("alpine"), "tag": "latest", "aws_region": ECR_REGION}
```

**Images now routed via ECR pull-through cache:**
`alpine`, `alpine/curl`, `debian`, `postgres`, `node`, `amazon/aws-cli`, `concourse/buildroot`, `concourse/oci-build-task`, `mitodl/ol-infrastructure`, `mitodl/redash`, `mitodl/heroku-cli`, `mitodl/ad-opt`, `mitodl/ol-superset`, `mitodl/openedx-tubular`, `cloudcustodian/c7n`, `grafana/grizzly`, `grafana/cortex-tools`, `bitnamilegacy/git`, `openapitools/openapi-generator-cli`, `python`, `kodhive/leek`, `mitodl/xqueue-watcher-grader-base`

**Intentionally unchanged:**
- Docker Hub `put` (push) resources — e.g. `mitodl/codejail`, `mitodl/edxapp`, `mitodl/xqueue` — must continue pointing to their real push registry
- `ghcr.io` images (e.g. `ghcr.io/astral-sh/uv`) — not Docker Hub
- `quay.io` images (e.g. `quay.io/keycloak/keycloak`) — not Docker Hub
- `examples/hello.py` — example file only

### How can this be tested?
- Run `uv run pytest tests/` — all 129 tests pass
- Run `uv run ruff check src/ol_concourse/pipelines/ --select F` — no errors
- Generate a pipeline locally: `python src/ol_concourse/pipelines/infrastructure/cloud_custodian/pipeline.py` and confirm `repository` values start with `dockerhub/` and include `aws_region`
- After merging and re-setting affected pipelines in Concourse, verify builds no longer fail with Docker Hub 429 rate-limit errors

### Additional Context
The ECR `dockerhub` pull-through cache is already configured in AWS and used by EKS workloads. Concourse workers run with IAM roles that have ECR pull permissions, so no additional credentials are needed — `ecr_region`/`aws_region` triggers IAM-based auth automatically in the Concourse `registry-image` resource type.