### PR TITLE
fix(keycloak): resolve operator reconciliation storm

### DIFF
--- a/src/ol_infrastructure/applications/keycloak/__main__.py
+++ b/src/ol_infrastructure/applications/keycloak/__main__.py
@@ -11,6 +11,7 @@ import requests
 import yaml
 from pulumi import Config, Output, ResourceOptions, export
 from pulumi_aws import ec2, get_caller_identity, iam
+from pydantic import SecretStr
 
 from bridge.lib.magic_numbers import (
     AWS_RDS_DEFAULT_DATABASE_CAPACITY,
@@ -289,9 +290,10 @@ rds_password = keycloak_config.require("rds_password")
 
 keycloak_db_config = OLPostgresDBConfig(
     instance_name=f"keycloak-{stack_info.env_suffix}",
-    password=rds_password,
-    storage=keycloak_config.get("db_capacity")
-    or str(AWS_RDS_DEFAULT_DATABASE_CAPACITY),
+    password=SecretStr(rds_password),
+    storage=int(
+        keycloak_config.get("db_capacity") or AWS_RDS_DEFAULT_DATABASE_CAPACITY
+    ),
     subnet_group_name=target_vpc["rds_subnet"],
     security_groups=[keycloak_database_security_group],
     db_name="keycloak",
@@ -305,7 +307,7 @@ db_address = keycloak_db.db_instance.address
 db_port = keycloak_db.db_instance.port
 
 keycloak_db_vault_backend_config = OLVaultPostgresDatabaseConfig(
-    db_name=keycloak_db_config.db_name,
+    db_name=keycloak_db_config.db_name or "keycloak",
     mount_point=f"{keycloak_db_config.engine}-keycloak",
     db_admin_username=keycloak_db_config.username,
     db_admin_password=rds_password,
@@ -415,6 +417,13 @@ keycloak_resource = kubernetes.apiextensions.CustomResource(
         labels=k8s_global_labels,
     ),
     spec={
+        # Auto is the correct strategy now that unsupported.podTemplate has been
+        # removed. Previously, the operator could not reliably replicate the
+        # podTemplate into the compatibility-check Job, causing it to always fall
+        # back to RecreateUpdate and creating a reconciliation storm. With only
+        # spec.env and first-class CR fields in use, the Job replicates correctly
+        # and Auto can detect when a rolling update is safe (e.g. patch releases).
+        # See: https://www.keycloak.org/operator/rolling-updates
         "update": {"strategy": "Auto"},
         "instances": keycloak_config.get_int("replicas") or 2,
         "image": cached_image_uri(f"mitodl/keycloak@{KEYCLOAK_DOCKER_DIGEST}"),
@@ -449,54 +458,45 @@ keycloak_resource = kubernetes.apiextensions.CustomResource(
         "http": {
             "tlsSecret": keycloak_tls_secret_name,
         },
-        "unsupported": {
-            "podTemplate": {
-                "spec": {
-                    # Give Infinispan enough time to gracefully leave the
-                    # cluster before the pod is force-killed.
-                    "terminationGracePeriodSeconds": 60,
-                    "containers": [
-                        {
-                            "name": "keycloak",
-                            "env": [
-                                {
-                                    "name": "QUARKUS_HTTP_LIMITS_MAX_HEADER_SIZE",
-                                    "value": "128k",
-                                },
-                                {
-                                    "name": "QUARKUS_HTTP_LIMITS_MAX_HEADER_LIST_SIZE",
-                                    "value": "32768",
-                                },
-                                {
-                                    "name": "POSTHOG_API_KEY",
-                                    "value": posthog_api_key,
-                                },
-                                {
-                                    "name": "POSTHOG_API_HOST",
-                                    "value": posthog_api_host,
-                                },
-                                # The Docker image is built with --tracing-enabled=true,
-                                # baking the Quarkus OTel extension into the binary at
-                                # build time. KC_TRACING_ENABLED=false (from the CR's
-                                # tracing.enabled: false) only disables Keycloak-level
-                                # trace emission; it does not prevent the OTel SDK from
-                                # initialising and attempting to export to the default
-                                # OTLP endpoint (localhost:4317). Without a telemetry
-                                # receiver those connection attempts time out and
-                                # destabilise the pod. OTEL_SDK_DISABLED is the
-                                # OpenTelemetry-spec env var that suppresses the entire
-                                # SDK regardless of build-time compilation.
-                                *(
-                                    [{"name": "OTEL_SDK_DISABLED", "value": "true"}]
-                                    if stack_info.name == "CI"
-                                    else []
-                                ),
-                            ],
-                        },
-                    ],
-                }
+        # spec.env is the correct field for custom environment variables that have no
+        # first-class CR field and should not be in additionalOptions.
+        # Using unsupported.podTemplate.spec.containers[].env instead triggers a
+        # persistent HasErrors warning ("The name of the keycloak container cannot be
+        # modified") because specifying *any* name: in the containers list is treated
+        # as a rename attempt rather than a selector.
+        # See: https://www.keycloak.org/operator/advanced-configuration
+        "env": [
+            {
+                "name": "QUARKUS_HTTP_LIMITS_MAX_HEADER_SIZE",
+                "value": "128k",
             },
-        },
+            {
+                "name": "QUARKUS_HTTP_LIMITS_MAX_HEADER_LIST_SIZE",
+                "value": "32768",
+            },
+            {
+                "name": "POSTHOG_API_KEY",
+                "value": posthog_api_key,
+            },
+            {
+                "name": "POSTHOG_API_HOST",
+                "value": posthog_api_host,
+            },
+            # The Docker image is built with --tracing-enabled=true, baking the
+            # Quarkus OTel extension into the binary at build time.
+            # KC_TRACING_ENABLED=false (from tracing.enabled: false) only disables
+            # Keycloak-level trace emission; it does not prevent the OTel SDK from
+            # initialising and attempting to export to the default OTLP endpoint
+            # (localhost:4317). Without a receiver those connection attempts time out
+            # and destabilise the pod. OTEL_SDK_DISABLED is the OpenTelemetry-spec
+            # env var that suppresses the entire SDK regardless of build-time
+            # compilation.
+            *(
+                [{"name": "OTEL_SDK_DISABLED", "value": "true"}]
+                if stack_info.name == "CI"
+                else []
+            ),
+        ],
         "additionalOptions": [
             {
                 "name": "disable-external-access",

--- a/src/ol_infrastructure/lib/aws/eks_helper.py
+++ b/src/ol_infrastructure/lib/aws/eks_helper.py
@@ -1,5 +1,6 @@
 import json
 from functools import lru_cache, partial
+from typing import Any
 
 import boto3
 import pulumi
@@ -87,7 +88,7 @@ def get_eks_addon_version(addon_name: str, cluster_version: str | None = None) -
 
 @lru_cache
 def get_k8s_provider(
-    kubeconfig: str,
+    kubeconfig: pulumi.Output[Any] | str,
     provider_name: str | None,
 ):
     return Provider(
@@ -97,7 +98,7 @@ def get_k8s_provider(
 
 
 def set_k8s_provider(
-    kubeconfig: str,
+    kubeconfig: pulumi.Output[Any] | str,
     provider_name: str | None,
     resource_args: pulumi.ResourceTransformationArgs,
 ) -> pulumi.ResourceTransformationResult:
@@ -113,7 +114,7 @@ def set_k8s_provider(
 
 
 def setup_k8s_provider(
-    kubeconfig: str | dict[str, object],
+    kubeconfig: pulumi.Output[Any] | str | dict[str, object],
     provider_name: str | None = None,
 ):
     # lru_cache requires hashable arguments; serialize dict kubeconfigs to JSON
@@ -173,7 +174,7 @@ def access_entry_opts(
             import_=resource_id,
         )
     except ClientError as e:
-        if e.response["Error"]["Code"] != "ResourceNotFoundException":
+        if e.response.get("Error", {}).get("Code") != "ResourceNotFoundException":
             raise
         # Access entry doesn't exist, create new one
         opts = pulumi.ResourceOptions()


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)

The Keycloak StatefulSet in QA has been cycling `pod-0` continuously — 3,300+ creates/deletes over 7 days, with sub-second cycling at peak — causing periodic Keycloak unavailability. This fixes the root cause by removing the `unsupported.podTemplate` configuration that was incompatible with the operator's `Auto` update strategy.

#### Root cause: `unsupported.podTemplate` + `strategy: Auto` incompatibility

The [Keycloak operator rolling-updates guide](https://www.keycloak.org/operator/rolling-updates) explicitly warns:

> If you are using the unsupported `podTemplate`, you may need to use one of the other update strategies.

With `Auto`, the operator launches a `keycloak-update-job` compatibility-check Job on every reconciliation and tries to replicate the `unsupported.podTemplate` into it. Because the operator cannot fully do so (it's unsupported), `AutoUpdateLogic` never finds the pod and falls back to **RecreateUpdate** (scale StatefulSet to 0). This generates a flood of StatefulSet watch events queuing 100+ concurrent reconciler threads, all trying to PATCH the same Keycloak CR status simultaneously → 409 Conflicts → immediate retries → more threads. Pod-0 was cycling every 1–2 seconds.

#### Fix: remove `unsupported.podTemplate` and use first-class CR fields

Rather than switching update strategies, we remove the root cause entirely. The [advanced-configuration guide](https://www.keycloak.org/operator/advanced-configuration) defines `spec.env` as the correct field for custom environment variables. Using `unsupported.podTemplate.spec.containers[].env` was also causing a persistent `HasErrors` warning on every reconciliation since 2026-03-25 (specifying `name:` in the containers list is treated as a rename attempt rather than a container selector).

The `terminationGracePeriodSeconds: 60` that was the last remaining use of `unsupported.podTemplate` is not necessary: with persistent user sessions enabled (the default in 26.x), session caches are DB-backed with `fetchInMemoryState=false` — no state transfer occurs on pod leave. The Kubernetes default of 30s covers in-flight requests.

With `unsupported.podTemplate` fully removed, `strategy: Auto` is restored. The operator can now correctly replicate the pod configuration into the compatibility-check Job, and will perform rolling updates for compatible changes (patch releases) rather than always recreating.

#### Summary of spec changes

| Field | Before | After |
|---|---|---|
| `update.strategy` | `Auto` → `RecreateOnImageChange` (workaround) | `Auto` (restored) |
| `spec.env` | missing | `QUARKUS_*`, `POSTHOG_*`, `OTEL_SDK_DISABLED` moved here from `unsupported.podTemplate` |
| `unsupported.podTemplate` | env vars + `terminationGracePeriodSeconds` | **removed entirely** |

#### Pre-existing type errors in edited files

- `keycloak/__main__.py`: `OLPostgresDBConfig.password` requires `SecretStr` (not `str`); `storage` requires `int` (not `str`); `OLVaultPostgresDatabaseConfig.db_name` needs a `str | None` fallback
- `eks_helper.py`: `setup_k8s_provider` / `set_k8s_provider` / `get_k8s_provider` accept `Output[Any] | str` at every call site across ~20 applications but the type annotations only declared `str`; `ClientError.response` TypedDict access now uses `.get()` to satisfy Pyright

### How can this be tested?

1. Deploy to QA (`pulumi up` in `src/ol_infrastructure/applications/keycloak/` with stack `ol-application-keycloak.QA`)
2. Confirm the operator stops cycling pods: `kubectl --context operations-qa -n keycloak get events --sort-by=.lastTimestamp -w` — the rapid `Created` / `Killing` loop for `keycloak-qa-0` should cease
3. Confirm all three pods reach `Running 1/1` and stay there: `kubectl --context operations-qa -n keycloak get pods -w`
4. Confirm `RecreateUpdateUsed` transitions to `False` (rolling update used): `kubectl --context operations-qa -n keycloak get keycloak keycloak-qa -o jsonpath='{.status.conditions}' | python3 -m json.tool`
5. Confirm no `HasErrors` warning and no `Pod for Update Job not found` in operator logs: `kubectl --context operations-qa -n keycloak logs deploy/keycloak-operator --tail=100`

### Additional Context

**ServiceMonitor note:** The operator auto-creates a `ServiceMonitor` named after the CR (`keycloak-qa`) when `metrics-enabled` is set. A manually-created `keycloak-qa-monitor` already exists. Once the reconciliation storm clears the operator may create its own, resulting in two ServiceMonitors targeting the same service (double-scraping). If that occurs the manual resource should be removed from Pulumi and the operator's copy used instead (or `spec.serviceMonitor.enabled: false` added to suppress auto-creation). This is tracked as a follow-up.