### PR TITLE
fix(keycloak): migrate to v2beta1 API and remove duplicate ServiceMonitor

### DIFF
--- a/src/ol_infrastructure/applications/keycloak/__main__.py
+++ b/src/ol_infrastructure/applications/keycloak/__main__.py
@@ -409,7 +409,7 @@ else:
 keycloak_resource_name = f"keycloak-{stack_info.env_suffix}"
 keycloak_resource = kubernetes.apiextensions.CustomResource(
     f"{env_name}-keycloak",
-    api_version="k8s.keycloak.org/v2alpha1",
+    api_version="k8s.keycloak.org/v2beta1",
     kind="Keycloak",
     metadata=kubernetes.meta.v1.ObjectMetaArgs(
         name=keycloak_resource_name,
@@ -497,11 +497,13 @@ keycloak_resource = kubernetes.apiextensions.CustomResource(
                 else []
             ),
         ],
+        # Disable the operator-managed Ingress; we expose Keycloak through our
+        # own APISix Gateway instead.
+        "ingress": {"enabled": False},
+        # Configure the ServiceMonitor the operator auto-creates when
+        # metrics-enabled is set in the image build.
+        "serviceMonitor": {"interval": "30s", "scrapeTimeout": "10s"},
         "additionalOptions": [
-            {
-                "name": "disable-external-access",
-                "value": "true",
-            },
             {"name": "metrics-enabled", "value": "true"},
             {
                 "name": "spi-realm-restapi-extension-scim-admin-url-check",
@@ -528,38 +530,6 @@ keycloak_resource = kubernetes.apiextensions.CustomResource(
     opts=ResourceOptions(
         delete_before_replace=True,
         depends_on=[keycloak_resources, db_creds_secret],
-    ),
-)
-
-keycloak_service_monitor = kubernetes.apiextensions.CustomResource(
-    f"{env_name}-keycloak-service-monitor",
-    api_version="monitoring.coreos.com/v1",
-    kind="ServiceMonitor",
-    metadata=kubernetes.meta.v1.ObjectMetaArgs(
-        name=f"{keycloak_resource_name}-monitor",
-        namespace=keycloak_namespace,
-        labels=k8s_global_labels,
-    ),
-    spec={
-        "selector": {
-            "matchLabels": {
-                "app": "keycloak",
-                "app.kubernetes.io/instance": keycloak_resource_name,
-            }
-        },
-        "endpoints": [
-            {
-                "port": "management",
-                "path": "/metrics",
-                "scheme": "https",
-                "interval": "30s",
-                "tlsConfig": {"insecureSkipVerify": True},
-            }
-        ],
-        "namespaceSelector": {"matchNames": [keycloak_namespace]},
-    },
-    opts=ResourceOptions(
-        depends_on=[keycloak_resource],
     ),
 )
 


### PR DESCRIPTION
### What are the relevant tickets?
N/A — follow-up optimizations identified by inspecting the live QA cluster after deploying #4715.

### Description (What does it do?)

Four improvements identified by comparing the deployed QA state against the 26.6.2 CRD schema and live cluster resources.

#### 1. Migrate `api_version` `v2alpha1` → `v2beta1`

The operator emits a deprecation warning on every `kubectl` command targeting Keycloak resources. `v2beta1` is the storage version in the 26.6.2 CRD; `v2alpha1` is served but marked for removal with `storage: false` and a `deprecationWarning`.

#### 2. Remove duplicate ServiceMonitor

Inspecting the cluster revealed two ServiceMonitors scraping the same endpoint:
- `keycloak-qa` — auto-created by the operator (67 minutes old at time of analysis), selector includes `app.kubernetes.io/managed-by: keycloak-operator`, includes `scrapeProtocols: OpenMetricsText1.0.0` and `scrapeTimeout: 10s`
- `keycloak-qa-monitor` — manually managed by Pulumi (377 days old), identical endpoint config, missing `scrapeTimeout`

The [operator docs](https://www.keycloak.org/operator/advanced-configuration#_servicemonitor) state the operator auto-creates a ServiceMonitor when `metrics-enabled` is set (which it is, baked into the image). Removing the manual resource eliminates double-scraping and lets the operator own this resource.

#### 3. Replace `disable-external-access` additionalOption with `spec.ingress`

`v2beta1` exposes `spec.ingress.enabled` as a first-class boolean field. The `disable-external-access: true` additionalOption was the `v2alpha1`-era workaround for the same intent: prevent the operator from creating a Kubernetes Ingress in front of Keycloak. We expose Keycloak through APISix Gateway and do not want the operator managing an Ingress.

#### 4. Add `spec.serviceMonitor` configuration

Sets `interval: 30s` and `scrapeTimeout: 10s` on the operator-managed ServiceMonitor to match the scrape behaviour of the manual ServiceMonitor it replaces.

### How can this be tested?

1. Deploy to QA (`pulumi up` in `src/ol_infrastructure/applications/keycloak/` with stack `ol-application-keycloak.QA`)
2. Confirm no deprecation warning: `kubectl --context operations-qa -n keycloak get keycloak keycloak-qa` should return cleanly without `Warning: Please migrate to v2beta1`
3. Confirm only one ServiceMonitor remains: `kubectl --context operations-qa -n keycloak get servicemonitor` should show only `keycloak-qa` (operator-managed), not `keycloak-qa-monitor`
4. Confirm `keycloak-qa` ServiceMonitor has the configured interval/timeout: `kubectl --context operations-qa -n keycloak get servicemonitor keycloak-qa -o jsonpath='{.spec.endpoints[0]}'`
5. Confirm no Ingress created by operator: `kubectl --context operations-qa -n keycloak get ingress` should return empty