### PR TITLE
feat(concourse): attach ECR pull-through cache IAM policy to all worker roles

### DIFF
--- a/src/ol_infrastructure/applications/concourse/__main__.py
+++ b/src/ol_infrastructure/applications/concourse/__main__.py
@@ -666,6 +666,14 @@ for worker_def in concourse_config.get_object("workers") or []:
             role=concourse_worker_instance_role.name,
         )
 
+    # Attach the describe_instances policy to all workers so they can authenticate
+    # with ECR and pull images through the ECR pull-through cache.
+    iam.RolePolicyAttachment(
+        f"concourse-instance-policy-worker-{worker_class_name}-ecr-pull-through-{stack_info.env_suffix}",
+        policy_arn=policy_stack.require_output("iam_policies")["describe_instances"],
+        role=concourse_worker_instance_role.name,
+    )
+
     concourse_worker_instance_profile = iam.InstanceProfile(
         f"concourse-instance-profile-worker-{worker_class_name}-{stack_info.env_suffix}",
         role=concourse_worker_instance_role.name,


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
After routing all Concourse Docker Hub image pulls through the ECR pull-through cache (commit [3e9b74fd3](https://github.com/mitodl/ol-infrastructure/commit/3e9b74fd3d4f9f458bc571b05f212b8386e6f7db)), workers outside the `infra` group began hitting IAM permission errors when attempting to pull images from ECR.

The root cause: the `describe_instances` policy from the shared policies stack — which already carries the full set of ECR pull-through cache permissions — was attached to web nodes but was never attached to any worker IAM roles.

**Fix:** Add an unconditional `RolePolicyAttachment` inside the worker loop in [`src/ol_infrastructure/applications/concourse/__main__.py`](https://github.com/mitodl/ol-infrastructure/blob/feat/concourse-worker-ecr-iam-policy/src/ol_infrastructure/applications/concourse/__main__.py) so every worker class receives the policy. The policy grants:

- `ecr:GetAuthorizationToken` — authenticate with ECR
- `ecr:CreateRepository` + `ecr:BatchImportUpstreamImage` — populate the pull-through cache on first pull
- `ecr:BatchGetImage`, `ecr:GetDownloadUrlForLayer`, etc. — pull images from cached repositories

This adds one new `aws:iam/rolePolicyAttachment` per worker class (e.g. `ocw`, `infra`, `generic`) in each stack.

### How can this be tested?
1. Run `pulumi preview` against the QA and Production Concourse stacks and confirm the only changes are new `RolePolicyAttachment` resources (one per worker class) — no replacements or deletions.
2. After deploying, trigger a Concourse pipeline that uses a Docker Hub image routed through the ECR pull-through cache on a non-infra worker (e.g. the `ocw` or `generic` worker) and confirm the image pull succeeds without an ECR authorization error.