### PR TITLE
Fix kubeconfig generator after EKS stack file rename

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/eks/generate_kube_config.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/generate_kube_config.py
@@ -1,3 +1,5 @@
+"""Generate a kubeconfig from the EKS Pulumi stack outputs."""
+
 # ruff:  noqa: E501
 
 # This script is only for devops to use. Requires access to the pulumi state files.
@@ -28,6 +30,7 @@ role_arn_name = "admin_role_arn"
 
 
 def extract_kube_config_params(role_arn, cluster_ca, cluster_endpoint, cluster_name):
+    """Append cluster, context, and user entries for a single EKS cluster."""
     clusters.append(
         {
             "name": cluster_name,
@@ -78,7 +81,7 @@ def extract_kube_config_params(role_arn, cluster_ca, cluster_endpoint, cluster_n
 
 
 stack_defs = glob.glob(  # noqa: PTH207
-    str(Path(__file__).parent.joinpath("Pulumi.infrastructure.*.yaml"))
+    str(Path(__file__).parent.joinpath("Pulumi.*.*.yaml"))
 )
 
 for stack in stack_defs:


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Updates the EKS kubeconfig generator to discover the current Pulumi stack config filenames after the stack file rename. The script now matches files like `Pulumi.applications.CI.yaml` instead of only the old `Pulumi.infrastructure.*.yaml` names, allowing it to populate clusters, contexts, and users again.

Also adds docstrings required by linting.

### How can this be tested?
From `src/ol_infrastructure/infrastructure/aws/eks`:

```bash
uv run ruff check generate_kube_config.py
python generate_kube_config.py | python -c "import sys, yaml; config=yaml.safe_load(sys.stdin); print({key: len(config[key]) for key in ('clusters','contexts','users')})"
```

Expected result: ruff passes and the script reports populated lists, currently 12 clusters/contexts/users.