### PR TITLE
Fix OVS Celery monitoring events

### DIFF
--- a/src/ol_infrastructure/applications/celery_monitoring/__main__.py
+++ b/src/ol_infrastructure/applications/celery_monitoring/__main__.py
@@ -3,6 +3,7 @@
 import json
 import re
 from pathlib import Path
+from typing import Any
 
 import pulumi_kubernetes as kubernetes
 import pulumi_vault as vault
@@ -69,21 +70,21 @@ setup_k8s_provider(kubeconfig=cluster_stack.require_output("kube_config"))
 
 
 def build_broker_subscriptions(
-    project_outputs: list[tuple[str, Output]],
+    project_outputs: list[tuple[str, Output[Any], int]],
 ) -> str:
-    """Create a dict of Redis cache configs for each edxapp stack"""
+    """Create a dict of Redis broker subscriptions for monitored Celery apps."""
     broker_subs = []
 
     def stack_to_app(stack):
         return re.sub(r"[^a-zA-Z]", "", "".join(stack.split(".")[1:-1]))
 
-    for stack, project_output in project_outputs:
+    for stack, project_output, redis_database_index in project_outputs:
         app_name = stack_to_app(stack)
         if app_name.endswith("mitx"):
             app_name += "live"
         broker_subs.append(
             {
-                "broker": f"rediss://default:{project_output['redis_token']}@{project_output['redis']}:6379/1?ssl_cert_reqs=required",
+                "broker": f"rediss://default:{project_output['redis_token']}@{project_output['redis']}:6379/{redis_database_index}?ssl_cert_reqs=required",
                 "broker_management_url": None,
                 "exchange": "celeryev",
                 "queue": "leek.fanout",
@@ -117,85 +118,98 @@ def build_broker_subscriptions(
     return json.dumps(arbitrary_dict)
 
 
-# List of (legacy_name, project_const, short_stack_name, output_key) tuples.
-# legacy_name is preserved so that build_broker_subscriptions/stack_to_app can
-# still derive the app label from the historical dotted namespace.
+# List of (legacy_name, project_const, short_stack_name, output_key,
+# redis_database_index) tuples. legacy_name is preserved so that
+# build_broker_subscriptions/stack_to_app can still derive the app label from the
+# historical dotted namespace.
 stacks = [
     (
         f"applications.edxapp.xpro.{stack_info.name}",
         projects.EDXAPP,
         f"xpro.{stack_info.name}",
         "edxapp",
+        1,
     ),
     (
         f"applications.edxapp.mitx.{stack_info.name}",
         projects.EDXAPP,
         f"mitx.{stack_info.name}",
         "edxapp",
+        1,
     ),
     (
         f"applications.edxapp.mitx-staging.{stack_info.name}",
         projects.EDXAPP,
         f"mitx-staging.{stack_info.name}",
         "edxapp",
+        1,
     ),
     (
         f"applications.edxapp.mitxonline.{stack_info.name}",
         projects.EDXAPP,
         f"mitxonline.{stack_info.name}",
         "edxapp",
+        1,
     ),
     (
         f"applications.superset.{stack_info.name}",
         projects.SUPERSET,
         stack_info.name,
         "superset",
+        1,
     ),
     (
         f"applications.mitxonline.{stack_info.name}",
         projects.MITXONLINE,
         stack_info.name,
         "mitxonline",
+        1,
     ),
     (
         f"applications.mit_learn.{stack_info.name}",
         projects.MIT_LEARN,
         stack_info.name,
         "mit_learn",
+        1,
     ),
     (
         f"applications.learn_ai.{stack_info.name}",
         projects.LEARN_AI,
         stack_info.name,
         "learn_ai",
+        1,
     ),
-    (f"applications.xpro.{stack_info.name}", projects.XPRO, stack_info.name, "xpro"),
+    (f"applications.xpro.{stack_info.name}", projects.XPRO, stack_info.name, "xpro", 1),
     (
         f"applications.ocw_studio.{stack_info.name}",
         projects.OCW_STUDIO,
         stack_info.name,
         "ocw_studio",
+        1,
     ),
     (
         f"applications.odl_video_service.{stack_info.name}",
         projects.ODL_VIDEO_SERVICE,
         stack_info.name,
         "odl_video_service",
+        0,
     ),
     (
         f"applications.micromasters.{stack_info.name}",
         projects.MICROMASTERS,
         stack_info.name,
         "micromasters",
+        1,
     ),
 ]
 
-redis_outputs: list[tuple[str, Output]] = []
-for legacy_name, project_const, short_stack, output_key in stacks:
+redis_outputs: list[tuple[str, Output[Any], int]] = []
+for legacy_name, project_const, short_stack, output_key, redis_database_index in stacks:
     redis_outputs.append(
         (
             legacy_name,
             make_stack_reference(project_const, short_stack).require_output(output_key),
+            redis_database_index,
         )
     )
 redis_broker_subscriptions = Output.all(*redis_outputs).apply(

--- a/src/ol_infrastructure/applications/odl_video_service/__main__.py
+++ b/src/ol_infrastructure/applications/odl_video_service/__main__.py
@@ -100,6 +100,7 @@ target_vpc_name = ovs_config.get("target_vpc") or "applications_vpc"
 target_vpc = network_stack.require_output(target_vpc_name)
 target_vpc_id = target_vpc["id"]
 data_vpc = network_stack.require_output("data_vpc")
+operations_vpc = network_stack.require_output("operations_vpc")
 
 mitodl_zone_id = dns_stack.require_output("odl_zone_id")
 
@@ -559,6 +560,13 @@ ovs_redis_security_group = ec2.SecurityGroup(
             from_port=DEFAULT_REDIS_PORT,
             to_port=DEFAULT_REDIS_PORT,
             description=("Allow access from OVS K8s pods to Redis"),
+        ),
+        ec2.SecurityGroupIngressArgs(
+            cidr_blocks=operations_vpc["k8s_pod_subnet_cidrs"],
+            protocol="tcp",
+            from_port=DEFAULT_REDIS_PORT,
+            to_port=DEFAULT_REDIS_PORT,
+            description="Allow Operations VPC celery monitoring pods to Redis",
         ),
     ],
     egress=default_egress_args,
@@ -1212,6 +1220,7 @@ celery_deployment = kubernetes.apps.v1.Deployment(
                             "-A",
                             "odl_video",
                             "worker",
+                            "-E",
                             "-B",
                             "-l",
                             celery_log_level,


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
- Enables Celery event emission for the ODL Video Service worker by adding `-E` to the worker command.
- Allows celery-monitoring pods in the Operations VPC to connect to the OVS Redis broker.
- Lets celery-monitoring subscribe to OVS Redis DB 0 while preserving DB 1 for the existing monitored application brokers.

### How can this be tested?
- `uv run ruff format __main__.py ../odl_video_service/__main__.py`
- `uv run ruff check __main__.py ../odl_video_service/__main__.py`
- `uv run pre-commit run ruff-format --all-files`
- `uv run pre-commit run ruff-check --all-files`
- `uv run pre-commit run mypy --all-files`
- `pulumi preview --stack Production` in `src/ol_infrastructure/applications/celery_monitoring` showed one Vault secret update for the broker subscription JSON.
- `ODL_VIDEO_SERVICE_DOCKER_TAG=0.92.0 pulumi preview --stack Production` in `src/ol_infrastructure/applications/odl_video_service` showed updates to the Redis security group ingress and the OVS Celery deployment.

Note: `uv run pre-commit run --all-files` was also attempted, but repository-wide hooks unrelated to this change failed because `packer` was unavailable in the local environment and existing Dockerfiles have hadolint warnings.
