### PR TITLE
feat(edxapp): enable frontend_site_config API and populate FRONTEND_SITE_CONFIG

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -192,6 +192,22 @@ def _build_interpolated_config_dict(
         "OTEL_SERVICE_NAME": env_name + "-edxapp",
         "OTEL_LOG_LEVEL": "info",
         "ECOMMERCE_PUBLIC_URL_ROOT": domains["lms"],
+        "ENABLE_MFE_CONFIG_API": True,
+        "FRONTEND_SITE_CONFIG": {
+            "lmsBaseUrl": f"https://{domains['lms']}",
+            "loginUrl": f"https://{domains['lms']}/login",
+            "logoutUrl": f"https://{domains['lms']}/logout",
+            "headerLogoImageUrl": f"https://{domains['lms']}/static/{stack_info.env_prefix}/images/logo.svg",
+            "accessTokenCookieName": f"{env_name}-edx-jwt-cookie-header-payload",
+            "languagePreferenceCookieName": f"{env_name}-openedx-language-preference",
+            "userInfoCookieName": f"{env_name}-edx-user-info",
+            "csrfTokenApiPath": "/csrf/api/v1/token",
+            "commonAppConfig": {
+                "mitolFooter": {
+                    "accessibilityUrl": "https://accessibility.mit.edu/",
+                },
+            },
+        },
     }
 
     # Ref: https://docs.openedx.org/en/latest/site_ops/how-tos/use_typesense_search_backend.html
@@ -247,6 +263,16 @@ def _build_interpolated_config_dict(
                 },
             }
         )
+        config["FRONTEND_SITE_CONFIG"]["commonAppConfig"]["mitolFooter"].update(
+            {
+                "privacyPolicyUrl": f"https://{marketing_domain}/privacy",
+                "termsOfServiceUrl": f"https://{marketing_domain}/terms",
+                "honorCodeUrl": f"https://{marketing_domain}/honor-code/",
+                "aboutUrl": f"https://{marketing_domain}/about",
+                "supportUrl": f"https://{stack_info.env_prefix}.zendesk.com/hc/en-us/requests/new/",
+                "copyrightText": "\u00a9 MIT Open Learning. All rights reserved except where noted.",
+            }
+        )
 
     # xPro-specific configuration
     elif stack_info.env_prefix == "xpro":
@@ -272,6 +298,16 @@ def _build_interpolated_config_dict(
                 "MKTG_URLS": {
                     "ROOT": f"https://{marketing_domain}/",
                 },
+            }
+        )
+        config["FRONTEND_SITE_CONFIG"]["commonAppConfig"]["mitolFooter"].update(
+            {
+                "privacyPolicyUrl": f"https://{marketing_domain}/privacy-policy/",
+                "termsOfServiceUrl": f"https://{marketing_domain}/terms-of-service/",
+                "honorCodeUrl": f"https://{marketing_domain}/honor-code/",
+                "aboutUrl": f"https://{marketing_domain}/about-us",
+                "supportUrl": f"https://{stack_info.env_prefix}.zendesk.com/hc/en-us/requests/new/",
+                "copyrightText": "\u00a9 MIT xPRO. All rights reserved except where noted.",
             }
         )
 
@@ -321,6 +357,16 @@ def _build_interpolated_config_dict(
                         "fail_silently": False,
                     }
                 },
+            }
+        )
+        config["FRONTEND_SITE_CONFIG"]["commonAppConfig"]["mitolFooter"].update(
+            {
+                "privacyPolicyUrl": f"https://{marketing_domain}/privacy-policy/",
+                "termsOfServiceUrl": f"https://{marketing_domain}/terms-of-service/",
+                "honorCodeUrl": f"https://{marketing_domain}/honor-code/",
+                "aboutUrl": f"https://{marketing_domain}/about-us/",
+                "supportUrl": f"https://{stack_info.env_prefix}.zendesk.com/hc/en-us/requests/new/",
+                "copyrightText": "\u00a9 MIT Open Learning. All rights reserved except where noted.",
             }
         )
 


### PR DESCRIPTION
### What are the relevant tickets?

N/A — prerequisite for frontend-base Site Project deployment (lehrer PR: https://github.com/mitodl/lehrer/pull/51)

### Description (What does it do?)

Enables `/api/frontend_site_config/v1/` for all three LMS deployments (mitx, mitx-staging, xpro, mitxonline) so that frontend-base Site Projects can receive environment-specific configuration at runtime rather than requiring separate per-environment builds.

**Changes to `k8s_configmaps.py` (`_build_interpolated_config_dict`):**

`ENABLE_MFE_CONFIG_API: True` — this Django setting gates the endpoint; it defaults to `False` in `lms/envs/common.py` and was never set to `True` in any of our configmaps. Without this, the endpoint returns 404.

`FRONTEND_SITE_CONFIG` base (shared across all deployments):
- `lmsBaseUrl`, `loginUrl`, `logoutUrl` — derived from `domains['lms']`
- `headerLogoImageUrl` — same `/static/{env_prefix}/images/logo.svg` pattern as existing `LOGO_URL`
- `accessTokenCookieName`, `languagePreferenceCookieName`, `userInfoCookieName` — derived from `env_name` (environment-specific)
- `csrfTokenApiPath` — `/csrf/api/v1/token`
- `commonAppConfig.mitolFooter.accessibilityUrl` — `https://accessibility.mit.edu/`

Per-deployment `mitolFooter` additions derived from the existing `marketing_domain` variable:

| Deployment | URLs |
|---|---|
| mitx / mitx-staging | `/privacy`, `/terms`, `/honor-code/`, `/about`; MIT Open Learning copyright |
| xpro | `/privacy-policy/`, `/terms-of-service/`, `/honor-code/`, `/about-us`; MIT xPRO copyright |
| mitxonline | `/privacy-policy/`, `/terms-of-service/`, `/honor-code/`, `/about-us/`; MIT Open Learning copyright |

**How `FrontendSiteConfigView` uses this:**

The view at `lms/djangoapps/mfe_config_api/views.py` deep-merges `FRONTEND_SITE_CONFIG` on top of a camelCase translation of `MFE_CONFIG` (currently `{}` for all our deployments). `FRONTEND_SITE_CONFIG` therefore provides the full site config with no dependency on `MFE_CONFIG` being populated.

The `commonAppConfig.mitolFooter` values are read at render time by `useSiteConfig()` hooks in the MIT OL footer slot app in the lehrer repo.

### How can this be tested?

After deploying to CI, hit the endpoint on any of the three LMS instances and confirm the response contains the expected camelCase fields:

```bash
curl -s https://<lms-ci-domain>/api/frontend_site_config/v1/ | python -m json.tool | grep -E 'lmsBaseUrl|accessTokenCookieName|mitolFooter'
```

Expected output should include:
```json
"lmsBaseUrl": "https://<lms-ci-domain>",
"accessTokenCookieName": "<env-name>-edx-jwt-cookie-header-payload",
"mitolFooter": { ... }
```

### Additional Context

The `FrontendSiteConfigView` implementation lives in the `mitx-platform` repo (`lms/djangoapps/mfe_config_api/views.py`), not in `edx-platform` upstream. The endpoint URL is `/api/frontend_site_config/v1/` (distinct from the legacy `/api/mfe_config/v1/`).

URL paths for footer links follow the same patterns already used in `MKTG_URL_OVERRIDES` for each deployment, so they are consistent with what Django already exposes to the legacy MFEs.