### PR TITLE
feat(mfe): OEP-65 Site Project Concourse pipeline and Fastly routing

### DIFF
--- a/src/ol_concourse/pipelines/open_edx/mfe/meta.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/meta.py
@@ -17,6 +17,7 @@ from ol_concourse.lib.resources import git_repo
 from bridge.settings.openedx.types import OpenEdxSupportedRelease
 from bridge.settings.openedx.version_matrix import OpenLearningOpenEdxDeployment
 from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
+from ol_concourse.pipelines.open_edx.mfe.site_pipeline import SITE_PROJECTS
 from ol_concourse.pipelines.open_edx.mfe.values import deployments
 
 
@@ -74,6 +75,51 @@ def meta_job(
     )
 
 
+def site_meta_job(deployment_name: str) -> Job:
+    """Generate a meta job that creates the Site Project pipeline for one deployment."""
+    return Job(
+        name=Identifier(f"create-{deployment_name}-site-pipeline"),
+        plan=[
+            GetStep(
+                get="mfe-pipeline-definitions",
+                trigger=True,
+            ),
+            TaskStep(
+                task=Identifier(f"generate-{deployment_name}-site-pipeline-file"),
+                config=TaskConfig(
+                    platform=Platform.linux,
+                    image_resource=AnonymousResource(
+                        type="registry-image",
+                        source={
+                            "repository": dockerhub_ecr_image_uri(
+                                "mitodl/ol-infrastructure"
+                            ),
+                            "tag": "latest",
+                            "aws_region": ECR_REGION,
+                        },
+                    ),
+                    inputs=[Input(name=Identifier("mfe-pipeline-definitions"))],
+                    outputs=[Output(name=Identifier("pipeline"))],
+                    run=Command(
+                        path="python",
+                        dir="pipeline",
+                        user="root",
+                        args=[
+                            "../mfe-pipeline-definitions/src/ol_concourse/pipelines/open_edx/mfe/site_pipeline.py",
+                            deployment_name,
+                        ],
+                    ),
+                ),
+            ),
+            SetPipelineStep(
+                team=Identifier(deployment_name),
+                set_pipeline=Identifier(f"{deployment_name}-site-pipeline"),
+                file="pipeline/definition.json",
+            ),
+        ],
+    )
+
+
 def meta_pipeline() -> Pipeline:
     pipeline_jobs = []
     mfe_definitions = git_repo(
@@ -92,6 +138,9 @@ def meta_pipeline() -> Pipeline:
         for deployment in deployments
         for release in OpenLearningOpenEdxDeployment.get_item(deployment).releases
     ]
+    pipeline_jobs.extend(
+        site_meta_job(project.deployment_name) for project in SITE_PROJECTS
+    )
     pipeline_jobs.append(
         Job(
             name=Identifier("set-mfe-meta-pipeline"),

--- a/src/ol_concourse/pipelines/open_edx/mfe/site_pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/site_pipeline.py
@@ -1,0 +1,391 @@
+"""Concourse pipeline for building and deploying OEP-65 Site Projects.
+
+Each Site Project is a single frontend-base build covering all registered MFE
+apps for one deployment.  Unlike the legacy per-MFE pipeline, the artifact is
+environment-agnostic: built once in CI using lehrer's Dagger module, then
+promoted unchanged to QA and Production via rclone cross-bucket copy.
+
+Usage (called by meta.py, analogous to pipeline.py):
+
+    python site_pipeline.py <deployment_name>
+
+    e.g. python site_pipeline.py mitxonline
+
+Supported deployments: mitxonline, mitx, xpro.
+
+Build: mitodl/dcind:latest (Docker-in-Docker) + ``dagger call mfe build-site``.
+Promote: rclone cross-bucket copy — no rebuild at QA or Production.
+IAM: Concourse worker role has cross-deployment S3 access for all three buckets.
+"""
+
+import sys
+import textwrap
+from dataclasses import dataclass, field
+from typing import Any
+
+from ol_concourse.lib.models.fragment import PipelineFragment
+from ol_concourse.lib.models.pipeline import (
+    AnonymousResource,
+    Command,
+    GetStep,
+    Identifier,
+    Input,
+    Job,
+    Output,
+    Pipeline,
+    Platform,
+    PutStep,
+    Resource,
+    TaskConfig,
+    TaskStep,
+)
+from ol_concourse.lib.resource_types import github_issues_resource, rclone
+from ol_concourse.lib.resources import git_repo, github_issues
+
+from bridge.settings.github.team_members import DEVOPS_MIT
+from ol_concourse.pipelines.constants import GH_ISSUES_DEFAULT_REPOSITORY
+
+LEHRER_URI = "https://github.com/mitodl/lehrer"
+
+
+@dataclass
+class SiteProjectEnv:
+    deployment_name: str
+    environment: str  # e.g. "mitxonline-ci"
+    environment_stage: str  # "CI", "QA", "Production"
+
+
+@dataclass
+class SiteProjectConfig:
+    """Configuration for one OEP-65 Site Project across its promotion chain."""
+
+    deployment_name: str
+    envs: list[SiteProjectEnv] = field(
+        default_factory=list
+    )  # ordered CI → QA → Production
+
+
+SITE_PROJECTS: list[SiteProjectConfig] = [
+    SiteProjectConfig(
+        deployment_name="mitxonline",
+        envs=[
+            SiteProjectEnv("mitxonline", "mitxonline-ci", "CI"),
+            SiteProjectEnv("mitxonline", "mitxonline-qa", "QA"),
+            SiteProjectEnv("mitxonline", "mitxonline-production", "Production"),
+        ],
+    ),
+    SiteProjectConfig(
+        deployment_name="mitx",
+        envs=[
+            SiteProjectEnv("mitx", "mitx-ci", "CI"),
+            SiteProjectEnv("mitx", "mitx-qa", "QA"),
+            SiteProjectEnv("mitx", "mitx-production", "Production"),
+        ],
+    ),
+    SiteProjectConfig(
+        deployment_name="xpro",
+        envs=[
+            SiteProjectEnv("xpro", "xpro-ci", "CI"),
+            SiteProjectEnv("xpro", "xpro-qa", "QA"),
+            SiteProjectEnv("xpro", "xpro-production", "Production"),
+        ],
+    ),
+]
+
+
+def _lehrer_resource(deployment_name: str) -> Resource:
+    return git_repo(
+        name=Identifier(f"lehrer-{deployment_name}"),
+        uri=LEHRER_URI,
+        branch="main",
+        paths=[
+            f"deployments/mit-ol/mfe_slot_config/frontend/{deployment_name}/",
+            "deployments/mit-ol/mfe_slot_config/frontend/shared/",
+        ],
+    )
+
+
+def _gh_issues_post(deployment_name: str, stage: str) -> Resource:
+    stage_lower = stage.lower()
+    title = f"[bot] Site Project {deployment_name} deployed to {stage}"
+    return github_issues(
+        auth_method="token",
+        name=Identifier(f"gh-issues-site-{deployment_name}-{stage_lower}-post"),
+        repository=GH_ISSUES_DEFAULT_REPOSITORY,
+        issue_title_template=title,
+        issue_prefix=title,
+        issue_state="open",
+    )
+
+
+def _gh_issues_trigger(deployment_name: str, stage: str) -> Resource:
+    """Closed-issue resource that gates promotion from ``stage`` to the next stage."""
+    stage_lower = stage.lower()
+    title = f"[bot] Site Project {deployment_name} deployed to {stage}"
+    return github_issues(
+        auth_method="token",
+        name=Identifier(f"gh-issues-site-{deployment_name}-{stage_lower}-trigger"),
+        repository=GH_ISSUES_DEFAULT_REPOSITORY,
+        issue_title_template=title,
+        issue_prefix=title,
+        issue_state="closed",
+    )
+
+
+def _gh_labels(stage: str) -> list[str]:
+    labels = ["product:infrastructure", "DevOps", "pipeline-workflow"]
+    stage_lower = stage.lower()
+    if stage_lower == "ci":
+        labels.append("promotion-to-qa")
+    elif stage_lower == "qa":
+        labels.append("promotion-to-production")
+    else:
+        labels.append("finalized-deployment")
+    return labels
+
+
+def site_build_job(
+    env: SiteProjectEnv,
+    previous_job: Job | None = None,
+    trigger_resource: Identifier | None = None,
+) -> PipelineFragment:
+    """Generate the CI build job for a Site Project.
+
+    Runs ``dagger call mfe build-site`` inside mitodl/dcind:latest (privileged
+    DinD), exports dist/, then syncs it to the deployment's CI S3 bucket.
+    QA and Production artifacts are promoted via :func:`site_promote_job`.
+    """
+    lehrer = _lehrer_resource(env.deployment_name)
+    post_resource = _gh_issues_post(env.deployment_name, env.environment_stage)
+
+    get_lehrer = GetStep(get=lehrer.name, trigger=True)
+    if previous_job:
+        get_lehrer.passed = [previous_job.name]
+
+    plan: list[Any] = [get_lehrer]
+    if trigger_resource:
+        plan.append(GetStep(get=trigger_resource, trigger=True))
+
+    deployment = env.deployment_name
+    lehrer_input = str(lehrer.name)
+    site_project_path = f"./deployments/mit-ol/mfe_slot_config/frontend/{deployment}"
+    shared_src_path = "./deployments/mit-ol/mfe_slot_config/frontend/shared"
+    public_path = f"/apps/{deployment}-site/"
+
+    plan.append(
+        TaskStep(
+            attempts=3,
+            task=Identifier(f"build-{deployment}-site"),
+            privileged=True,
+            config=TaskConfig(
+                platform=Platform.linux,
+                image_resource=AnonymousResource(
+                    type="registry-image",
+                    source={
+                        "repository": "mitodl/dcind",
+                        "tag": "latest",
+                    },
+                ),
+                inputs=[Input(name=lehrer.name)],
+                outputs=[Output(name=Identifier("site-dist"))],
+                run=Command(
+                    path="bash",
+                    args=[
+                        "-c",
+                        textwrap.dedent(
+                            f"""\
+                            source /docker-lib.sh
+                            start_docker
+                            cd {lehrer_input}
+                            dagger call mfe build-site \\
+                              --site-project {site_project_path} \\
+                              --shared-src   {shared_src_path} \\
+                              --public-path  {public_path} \\
+                              export --path ../site-dist/
+                            """
+                        ),
+                    ],
+                ),
+            ),
+        )
+    )
+
+    plan.append(
+        PutStep(
+            put="mfe-site-bucket",
+            params={
+                "source": "site-dist",
+                "destination": [
+                    {
+                        "command": "sync",
+                        "dir": (
+                            f"s3-remote:{env.environment}-edxapp-mfe/{deployment}-site/"
+                        ),
+                    }
+                ],
+            },
+        )
+    )
+
+    job = Job(
+        name=Identifier(f"build-{deployment}-site-{env.environment}"),
+        plan=plan,
+        on_success=PutStep(
+            put=post_resource.name,
+            params={
+                "labels": _gh_labels(env.environment_stage),
+                "assignees": DEVOPS_MIT,
+            },
+        ),
+    )
+
+    return PipelineFragment(resources=[lehrer, post_resource], jobs=[job])
+
+
+def site_promote_job(
+    env: SiteProjectEnv,
+    source_env: SiteProjectEnv,
+    previous_job: Job,
+    trigger_resource: Identifier,
+) -> PipelineFragment:
+    """Generate a QA or Production promotion job.
+
+    Copies the Site Project artifact from the source S3 bucket to the target
+    bucket via rclone — no rebuild required since the artifact is environment-agnostic.
+    """
+    deployment = env.deployment_name
+    post_resource = _gh_issues_post(deployment, env.environment_stage)
+
+    source_bucket = f"{source_env.environment}-edxapp-mfe/{deployment}-site/"
+    target_bucket = f"{env.environment}-edxapp-mfe/{deployment}-site/"
+
+    plan: list[Any] = [
+        GetStep(
+            get=trigger_resource,
+            trigger=True,
+            passed=[previous_job.name],
+        ),
+        TaskStep(
+            attempts=3,
+            task=Identifier(f"promote-{deployment}-site-to-{env.environment}"),
+            config=TaskConfig(
+                platform=Platform.linux,
+                image_resource=AnonymousResource(
+                    type="registry-image",
+                    source={"repository": "rclone/rclone", "tag": "latest"},
+                ),
+                inputs=[],
+                params={
+                    "RCLONE_CONFIG_S3REMOTE_TYPE": "s3",
+                    "RCLONE_CONFIG_S3REMOTE_PROVIDER": "AWS",
+                    "RCLONE_CONFIG_S3REMOTE_ENV_AUTH": "true",
+                    "RCLONE_CONFIG_S3REMOTE_REGION": "us-east-1",
+                },
+                run=Command(
+                    path="rclone",
+                    args=[
+                        "copy",
+                        f"s3remote:{source_bucket}",
+                        f"s3remote:{target_bucket}",
+                        "--checksum",
+                    ],
+                ),
+            ),
+        ),
+    ]
+
+    job = Job(
+        name=Identifier(
+            f"promote-{deployment}-site-{source_env.environment}-to-{env.environment}"
+        ),
+        plan=plan,
+        on_success=PutStep(
+            put=post_resource.name,
+            params={
+                "labels": _gh_labels(env.environment_stage),
+                "assignees": DEVOPS_MIT,
+            },
+        ),
+    )
+
+    return PipelineFragment(resources=[post_resource], jobs=[job])
+
+
+def site_pipeline(deployment_name: str) -> Pipeline:
+    """Generate the OEP-65 Site Project pipeline for one deployment.
+
+    Produces three jobs: CI (build + upload via Dagger), QA (rclone promote),
+    Production (rclone promote).  Called by meta.py analogously to pipeline.py.
+    """
+    project = next(p for p in SITE_PROJECTS if p.deployment_name == deployment_name)
+    ci_env, qa_env, prod_env = project.envs
+
+    ci_fragment = site_build_job(ci_env)
+    ci_job = ci_fragment.jobs[0]
+
+    ci_trigger = _gh_issues_trigger(deployment_name, ci_env.environment_stage)
+    if ci_trigger.name is None:
+        msg = f"ci_trigger resource has no name for {deployment_name}"
+        raise RuntimeError(msg)
+
+    qa_fragment = site_promote_job(
+        env=qa_env,
+        source_env=ci_env,
+        previous_job=ci_job,
+        trigger_resource=ci_trigger.name,
+    )
+    qa_job = qa_fragment.jobs[0]
+
+    qa_trigger = _gh_issues_trigger(deployment_name, qa_env.environment_stage)
+    if qa_trigger.name is None:
+        msg = f"qa_trigger resource has no name for {deployment_name}"
+        raise RuntimeError(msg)
+
+    prod_fragment = site_promote_job(
+        env=prod_env,
+        source_env=qa_env,
+        previous_job=qa_job,
+        trigger_resource=qa_trigger.name,
+    )
+
+    combined = PipelineFragment.combine_fragments(
+        ci_fragment,
+        qa_fragment,
+        prod_fragment,
+        PipelineFragment(resources=[ci_trigger, qa_trigger], jobs=[]),
+    )
+
+    return Pipeline(
+        resource_types=[
+            rclone(),
+            github_issues_resource(),
+            *combined.resource_types,
+        ],
+        resources=[
+            Resource(
+                name=Identifier("mfe-site-bucket"),
+                type="rclone",
+                source={
+                    "config": textwrap.dedent(
+                        """\
+                        [s3-remote]
+                        type = s3
+                        provider = AWS
+                        env_auth = true
+                        region = us-east-1
+                        """
+                    )
+                },
+            ),
+            *combined.resources,
+        ],
+        jobs=combined.jobs,
+    )
+
+
+if __name__ == "__main__":
+    deployment: str = sys.argv[1]
+    pipeline = site_pipeline(deployment)
+    with open("definition.json", "w") as definition:  # noqa: PTH123
+        definition.write(pipeline.model_dump_json(indent=2))
+    sys.stdout.write(pipeline.model_dump_json(indent=2))

--- a/src/ol_concourse/pipelines/open_edx/mfe/site_pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/site_pipeline.py
@@ -245,7 +245,6 @@ def site_build_job(
 def site_promote_job(
     env: SiteProjectEnv,
     source_env: SiteProjectEnv,
-    previous_job: Job,
     trigger_resource: Identifier,
 ) -> PipelineFragment:
     """Generate a QA or Production promotion job.
@@ -263,7 +262,6 @@ def site_promote_job(
         GetStep(
             get=trigger_resource,
             trigger=True,
-            passed=[previous_job.name],
         ),
         TaskStep(
             attempts=3,
@@ -317,11 +315,18 @@ def site_pipeline(deployment_name: str) -> Pipeline:
     Produces three jobs: CI (build + upload via Dagger), QA (rclone promote),
     Production (rclone promote).  Called by meta.py analogously to pipeline.py.
     """
-    project = next(p for p in SITE_PROJECTS if p.deployment_name == deployment_name)
+    _by_name = {p.deployment_name: p for p in SITE_PROJECTS}
+    project = _by_name.get(deployment_name)
+    if project is None:
+        supported = ", ".join(_by_name)
+        msg = (
+            f"Unknown deployment {deployment_name!r}. "
+            f"Supported deployments: {supported}"
+        )
+        raise SystemExit(msg)
     ci_env, qa_env, prod_env = project.envs
 
     ci_fragment = site_build_job(ci_env)
-    ci_job = ci_fragment.jobs[0]
 
     ci_trigger = _gh_issues_trigger(deployment_name, ci_env.environment_stage)
     if ci_trigger.name is None:
@@ -331,10 +336,8 @@ def site_pipeline(deployment_name: str) -> Pipeline:
     qa_fragment = site_promote_job(
         env=qa_env,
         source_env=ci_env,
-        previous_job=ci_job,
         trigger_resource=ci_trigger.name,
     )
-    qa_job = qa_fragment.jobs[0]
 
     qa_trigger = _gh_issues_trigger(deployment_name, qa_env.environment_stage)
     if qa_trigger.name is None:
@@ -344,7 +347,6 @@ def site_pipeline(deployment_name: str) -> Pipeline:
     prod_fragment = site_promote_job(
         env=prod_env,
         source_env=qa_env,
-        previous_job=qa_job,
         trigger_resource=qa_trigger.name,
     )
 

--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -932,12 +932,19 @@ if site_project_deployment:
 # Optionally build Site Project VCL snippets.
 _site_project_snippets: list[fastly.ServiceVclSnippetArgs] = []
 if site_project_deployment:
+    if not site_project_mfe_apps:
+        msg = (
+            "edxapp:site_project.mfe_apps must be a non-empty list "
+            "when edxapp:site_project is configured"
+        )
+        raise ValueError(msg)
     _sp = site_project_deployment
     _apps_alt = "|".join(site_project_mfe_apps)
     _site_project_snippets.append(
         fastly.ServiceVclSnippetArgs(
             content=textwrap.dedent(
                 f"""\
+                unset req.http.X-Site-Project;
                 if (req.url.path ~ "^/apps/{_sp}-site/") {{
                   set req.http.X-Site-Project = "1";
                   set req.url = regsub(req.url.path, "^/apps/", "/");

--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -909,6 +909,66 @@ fastly_access_logging_iam_role = monitoring_stack.require_output(
 
 
 mfe_regex = "^/({})/".format("|".join(edxapp_mfe_paths))
+
+# OEP-65 Site Project routing (optional, additive — legacy MFE rules are unchanged).
+# Set edxapp:site_project in the stack YAML with two keys:
+#   deployment — the Site Project deployment name (e.g. mitxonline)
+#   mfe_apps   — list of MFE app path names served by this Site Project (e.g. instructor-dashboard)
+site_project_config = edxapp_config.get_object("site_project")
+site_project_deployment = (
+    site_project_config.get("deployment") if site_project_config else None
+)
+site_project_mfe_apps: list[str] = (
+    list(site_project_config.get("mfe_apps", [])) if site_project_config else []
+)
+
+# When a Site Project is active, recv snippets tag matching requests with
+# X-Site-Project before rewriting the URL.  The backend condition checks this
+# flag so the MFE S3 Bucket backend is selected even after rewriting.
+_mfe_path_condition = f'req.url.path ~ "{mfe_regex}"'
+if site_project_deployment:
+    _mfe_path_condition = f'{_mfe_path_condition} || req.http.X-Site-Project == "1"'
+
+# Optionally build Site Project VCL snippets.
+_site_project_snippets: list[fastly.ServiceVclSnippetArgs] = []
+if site_project_deployment:
+    _sp = site_project_deployment
+    _apps_alt = "|".join(site_project_mfe_apps)
+    _site_project_snippets.append(
+        fastly.ServiceVclSnippetArgs(
+            content=textwrap.dedent(
+                f"""\
+                if (req.url.path ~ "^/apps/{_sp}-site/") {{
+                  set req.http.X-Site-Project = "1";
+                  set req.url = regsub(req.url.path, "^/apps/", "/");
+                  unset req.http.Cookie;
+                }} else if (req.url.path ~ "^/apps/({_apps_alt})(/|$)") {{
+                  set req.http.X-Site-Project = "1";
+                  set req.url = "/{_sp}-site/index.html";
+                  unset req.http.Cookie;
+                }}"""
+            ),
+            name="Handle Site Project routing",
+            priority=90,
+            type="recv",
+        )
+    )
+    # index.html is the SPA entry point; it must never be cached so deploys
+    # take effect immediately.  Versioned chunk files may be cached indefinitely.
+    _site_project_snippets.append(
+        fastly.ServiceVclSnippetArgs(
+            content=textwrap.dedent(
+                f"""\
+                if (req.url ~ "/{_sp}-site/index\\.html$") {{
+                  set beresp.ttl = 0s;
+                  set beresp.http.Cache-Control = "no-cache, no-store, must-revalidate";
+                }}"""
+            ),
+            name="No-cache for Site Project index.html",
+            type="fetch",
+        )
+    )
+
 edxapp_fastly_service = fastly.ServiceVcl(
     f"fastly-{stack_info.env_prefix}-{stack_info.env_suffix}",
     name=f"{stack_info.env_prefix} {stack_info.env_suffix} edX",
@@ -980,7 +1040,7 @@ edxapp_fastly_service = fastly.ServiceVcl(
         ),
         fastly.ServiceVclConditionArgs(
             name="MFE Path",
-            statement=f'req.url.path ~ "{mfe_regex}"',
+            statement=_mfe_path_condition,
             type="REQUEST",
         ),
     ],
@@ -1016,6 +1076,7 @@ edxapp_fastly_service = fastly.ServiceVcl(
         )
     ],
     snippets=[
+        *_site_project_snippets,
         fastly.ServiceVclSnippetArgs(
             content=textwrap.dedent(
                 """\


### PR DESCRIPTION
### What are the relevant tickets?

Companion to https://github.com/mitodl/lehrer/pull/51 (OEP-65 frontend-base scaffold in lehrer).

### Description (What does it do?)

Adds the infrastructure layer required to build and deploy OEP-65 frontend-base Site Projects alongside the existing legacy per-MFE pipeline.

**`src/ol_concourse/pipelines/open_edx/mfe/site_pipeline.py`** (new)

A Concourse pipeline for building and deploying OEP-65 Site Projects. Called by `meta.py` in the same way `pipeline.py` is — `python site_pipeline.py <deployment_name>` generates a `definition.json` for one deployment.

- Three supported deployments: `mitxonline`, `mitx`, `xpro`
- **CI job**: clones lehrer, runs `dagger call mfe build-site` inside `mitodl/dcind:latest` (privileged DinD, same pattern as `edx_platform_v3/dagger_pulumi_pipeline.py`), syncs `dist/` to `{env}-edxapp-mfe/{deployment}-site/` via rclone
- **QA / Production jobs**: `rclone copy` between S3 buckets — no rebuild. The artifact is environment-agnostic (all runtime configuration comes from the LMS `/api/frontend_site_config/v1/` endpoint rather than being baked in at build time)
- GitHub issue promotion chain matches the legacy pipeline pattern

**`src/ol_concourse/pipelines/open_edx/mfe/meta.py`** (updated)

Adds `site_meta_job(deployment_name)` following the same structure as the existing `meta_job()`. The three Site Project deployments are registered in `meta_pipeline()`, which means the meta pipeline will auto-create and update `{deployment}-site-pipeline` on each push to the relevant paths in `main`.

**`src/ol_infrastructure/applications/edxapp/__main__.py`** (updated)

Adds optional Fastly routing for Site Projects, activated by adding `edxapp:site_project` to a stack's YAML config:

```
edxapp:site_project:
  deployment: mitxonline
  mfe_apps:
    - instructor-dashboard
```

When configured:
- **`Handle Site Project routing` recv snippet (priority 90)**: rewrites `/apps/{deployment}-site/*` to strip the `/apps/` prefix (S3 key lookup), and rewrites `/apps/{mfe-app}/` to `/{deployment}-site/index.html` (SPA fallback). Both paths set `X-Site-Project: 1` before rewriting so the MFE S3 Bucket backend is selected even after the URL changes
- **`No-cache for Site Project index.html` fetch snippet**: sets `Cache-Control: no-cache` on `index.html`; versioned chunk files (content-hash names) are cached normally
- **`MFE Path` condition**: extended to check `req.http.X-Site-Project == "1"` alongside the existing legacy MFE regex

The legacy pipeline and all existing Fastly rules are untouched — this is purely additive.

### How can this be tested?

1. Generate pipeline JSON locally and verify structure:
   ```bash
   python src/ol_concourse/pipelines/open_edx/mfe/site_pipeline.py mitxonline
   cat definition.json | jq '.jobs[].name'
   # Expected: build-mitxonline-site-mitxonline-ci, promote-mitxonline-...-to-qa, promote-...-to-production
   ```

2. Generate meta pipeline and confirm the three site jobs appear:
   ```bash
   python src/ol_concourse/pipelines/open_edx/mfe/meta.py
   cat definition.json | jq '.jobs[].name' | grep site
   # Expected: create-mitxonline-site-pipeline, create-mitx-site-pipeline, create-xpro-site-pipeline
   ```

3. For the Fastly changes: add `edxapp:site_project` to `Pulumi.applications.edxapp.mitxonline.CI.yaml`, run `pulumi preview` against the mitxonline CI stack, and confirm the two new VCL snippets and the updated `MFE Path` condition appear in the diff.