### PR TITLE
Correct OVS Dropbox QA/RC refresh token

### DIFF
--- a/src/bridge/secrets/odl_video_service/data.qa.yaml
+++ b/src/bridge/secrets/odl_video_service/data.qa.yaml
@@ -9,7 +9,7 @@ dropbox:
   key: ENC[AES256_GCM,data:fDAfv9qRvAPn74G24obA,iv:X+EZ+tA5xW4T4RQPG2TZBv4DDAc1hfgRFaRF3DhnXbc=,tag:RAs/su4m2J0zd48foUnFkw==,type:str]
   token: ENC[AES256_GCM,data:qbTRm6ax0oHkA++v92D88ErCjfk2qfRuRxcTKl1vGzg/+BkjLdDydTpCao800G17UF+SuxiIIKBLu4loCUZfDA==,iv:VwwbSoi3H3qhvTs+xoq49DdODWZbGpkLwDB7joCuLwY=,tag:LXDwm7KHlki33DLiijZnaw==,type:str]
   secret: ENC[AES256_GCM,data:Mh4LV53HyAInFe1iY9QZ,iv:CFAfT0dXZFGcrSrLyyhuoH0P8fF7v4WFYQZTKwFe1Ak=,tag:XY98VJz1HjYHcMMQtA6Nvw==,type:str]
-  refresh_token: ENC[AES256_GCM,data:qVLliVWexXGul/tbbPJB1oQwmY7CkXZ3nkeyrDxrkF/wgSchVJwjLzt6USzSSarmpzA8nk7NZzaag+FKMgw8RT8=,iv:OSuyTSNYbdLccOO8hj2HlpT51D5oTbrIWgPluVq7Ld4=,tag:Tqy2JM356EP751WDw/P3xQ==,type:str]
+  refresh_token: ENC[AES256_GCM,data:3vkuR479wt/FT+BQ1HQoywS3mrThJ1LaorbgRCaFZkwAPF8ye0kotUbra5TUWpDVnAGhJvDHAaXQleDdvWl+dw==,iv:TXJqfnXYjJbvcppGGzCr8NhNPDm0OQLtKHPIo656LEw=,tag:xn5DmYWG3gF3oxqk/grqJA==,type:str]
 misc:
   et_pipeline_id: ENC[AES256_GCM,data:yRn5LTZ9Mh/xbUpeLqB9qApgHG8=,iv:3OFdO8RxXqItc9pxUUoxO/FAe35GcjvCBXx/I/o++Sw=,tag:tNFUY8H/F65pKgBR6TVywA==,type:str]
   field_encryption_key: ENC[AES256_GCM,data:C0ERe2kyUYCEULFIlPxUF4Pu/aHyTVvEZadMGucxD8U8P+V40PV3POeozNU=,iv:6MHTAU9sWkJ1dnxcZBa/+37BthTk7EnNHuyQdT0r3Os=,tag:1Le2kN8dAWpDh7n4RieUPQ==,type:str]
@@ -52,8 +52,8 @@ sops:
     aws_profile: ""
     created_at: "2024-01-24T20:21:31Z"
     enc: AQICAHg42pDDDGBhpaX14TdtzcK1hbiMYTHsYRH4k5GL5RFpIwGUJS+jz4ZAd6fbbZtCED1qAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM2UCggkaWHTlPvO1kAgEQgDtjZfNgKC1VZC1ulksGMgt1HtdflXNlSxjCLlEnKnM3jhoUGFMG7uNsMMVO1UfpMlRI5xPuFh5NLK0SKQ==
-  lastmodified: "2026-06-08T18:27:14Z"
-  mac: ENC[AES256_GCM,data:yRp/NqZl6vHSX20pXe4HgkzqkKyqS5/UGsrgEUG9gG+dSYb+zetMeQxuc2REALQTRHetUhMOAf4/x08UUmXP+8T5gmCr92P99lOBPuF2sOE1tPRgYEg2iVm1HBlvciw00ciL78iBiCsI4GUwkcHe1DgDfpAZ9jmPAW9HY+1gC3A=,iv:lXp9IN8w9ku1VXR1ETJZ1wPohuJwZIS46guZ66sJ+8g=,tag:EYSWWpV1QM79zSHx15Qrrg==,type:str]
+  lastmodified: "2026-06-08T18:58:33Z"
+  mac: ENC[AES256_GCM,data:mnQ7gMc1MnF4ZvDLcg3N8OJf5yfZAAMjR2hpLQ9Ap8jg3IScGjsHtmKTpGpXEr0g7NuERxY6l0/AuC/nU5HuqgehXKvD9Cxku0NQgGoBvFsCcAJwRLTL5D6gPxTslwUYZFTwX1lGjSN6H9B58ktLsdpk9au8unBU8SXHKqYyy4o=,iv:OXWLSAy15WknrzsJyKK3SXX09T7NziU4GjJeEii4eDI=,tag:FNSqjqFVfFS0hLjinkX+vQ==,type:str]
   pgp:
   - created_at: "2024-01-24T20:21:31Z"
     enc: |-


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/11665

### Description (What does it do?)
Corrects the OVS QA/RC Dropbox API `refresh_token` value in the SOPS-managed `odl_video_service` secrets. The previous value had an extra trailing comma; this update uses the corrected value from the environment.

### How can this be tested?
- Confirmed `sops -d src/bridge/secrets/odl_video_service/data.qa.yaml` decrypts successfully.
- Confirmed the decrypted `dropbox.refresh_token` matches the corrected provided environment variable value and does not end with a comma.
- Ran `uv run pre-commit run --files src/bridge/secrets/odl_video_service/data.qa.yaml`.
