### PR TITLE
fix(concourse): resolve stale imports in meta pipeline generation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "packaging>=24.2",
     "pulumiverse-time>=0.1.1",
     "kubernetes>=34.1.0",
-    "parliament@git+https://github.com/mitodl/parliament",
+    "ol-parliament>=1.7.0",
     "cyclopts>=4.4.0",
     "requests-aws4auth>=1.3.1",
     "pulumi-qdrant-cloud",

--- a/src/ol_concourse/pipelines/infrastructure/k8s_apps/meta.py
+++ b/src/ol_concourse/pipelines/infrastructure/k8s_apps/meta.py
@@ -43,6 +43,7 @@ def meta_job(app_name: str) -> Job:
                     ),
                     inputs=[Input(name=Identifier("k8s-app-pipeline-definitions"))],
                     outputs=[Output(name=Identifier("pipeline"))],
+                    params={"PYTHONPATH": "../k8s-app-pipeline-definitions/src"},
                     run=Command(
                         path="python",
                         dir="pipeline",
@@ -93,6 +94,7 @@ def meta_pipeline(app_names: list[str]) -> Pipeline:
                         ),
                         inputs=[Input(name=Identifier("k8s-app-pipeline-definitions"))],
                         outputs=[Output(name=Identifier("pipeline"))],
+                        params={"PYTHONPATH": "../k8s-app-pipeline-definitions/src"},
                         run=Command(
                             path="python",
                             dir="pipeline",

--- a/src/ol_concourse/pipelines/infrastructure/meta.py
+++ b/src/ol_concourse/pipelines/infrastructure/meta.py
@@ -105,6 +105,7 @@ def meta_job(pipeline_name: str, script_path: str) -> Job:
                         Input(name=Identifier("infrastructure-pipeline-definitions"))
                     ],
                     outputs=[Output(name=Identifier("pipeline"))],
+                    params={"PYTHONPATH": "../infrastructure-pipeline-definitions/src"},
                     run=Command(
                         path="python",
                         dir="pipeline",
@@ -163,6 +164,9 @@ def meta_pipeline() -> Pipeline:
                             )
                         ],
                         outputs=[Output(name=Identifier("pipeline"))],
+                        params={
+                            "PYTHONPATH": "../infrastructure-pipeline-definitions/src"
+                        },
                         run=Command(
                             path="python",
                             dir="pipeline",

--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/meta.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/meta.py
@@ -67,6 +67,7 @@ def meta_job(app_name: str) -> Job:
                         Input(name=Identifier("simple-pulumi-pipeline-definitions"))
                     ],
                     outputs=[Output(name=Identifier("pipeline"))],
+                    params={"PYTHONPATH": "../simple-pulumi-pipeline-definitions/src"},
                     run=Command(
                         path="python",
                         dir="pipeline",
@@ -135,6 +136,9 @@ def meta_pipeline(
                             Input(name=Identifier("simple-pulumi-pipeline-definitions"))
                         ],
                         outputs=[Output(name=Identifier("pipeline"))],
+                        params={
+                            "PYTHONPATH": "../simple-pulumi-pipeline-definitions/src"
+                        },
                         run=Command(
                             path="python",
                             dir="pipeline",

--- a/src/ol_concourse/pipelines/libraries/meta.py
+++ b/src/ol_concourse/pipelines/libraries/meta.py
@@ -62,7 +62,7 @@ def build_meta_job(variant: str) -> Job:
                         path="sh",
                         args=[
                             "-exc",
-                            f"python {ol_concourse_repo.name}/src/ol_concourse/pipelines/libraries/api_clients_pipeline.py --variant {variant} > {definition_path}",  # noqa: E501
+                            f"PYTHONPATH={ol_concourse_repo.name}/src python {ol_concourse_repo.name}/src/ol_concourse/pipelines/libraries/api_clients_pipeline.py --variant {variant} > {definition_path}",  # noqa: E501
                         ],
                     ),
                 ),
@@ -94,7 +94,7 @@ def set_self_job() -> Job:
                         path="sh",
                         args=[
                             "-exc",
-                            f"python {ol_concourse_repo.name}/src/ol_concourse/pipelines/libraries/meta.py > {definition_path}",  # noqa: E501
+                            f"PYTHONPATH={ol_concourse_repo.name}/src python {ol_concourse_repo.name}/src/ol_concourse/pipelines/libraries/meta.py > {definition_path}",  # noqa: E501
                         ],
                     ),
                 ),

--- a/src/ol_concourse/pipelines/open_edx/codejail_v3/meta.py
+++ b/src/ol_concourse/pipelines/open_edx/codejail_v3/meta.py
@@ -64,6 +64,7 @@ def build_meta_job(release_name):
                     ),
                     inputs=[Input(name=Identifier(pipeline_code.name))],
                     outputs=[Output(name=Identifier("pipeline"))],
+                    params={"PYTHONPATH": f"../{pipeline_code.name}/src"},
                     run=Command(
                         path="python",
                         dir="pipeline",

--- a/src/ol_concourse/pipelines/open_edx/edx_notes_v3/meta.py
+++ b/src/ol_concourse/pipelines/open_edx/edx_notes_v3/meta.py
@@ -64,6 +64,7 @@ def build_meta_job(release_name):
                     ),
                     inputs=[Input(name=Identifier(pipeline_code.name))],
                     outputs=[Output(name=Identifier("pipeline"))],
+                    params={"PYTHONPATH": f"../{pipeline_code.name}/src"},
                     run=Command(
                         path="python",
                         dir="pipeline",

--- a/src/ol_concourse/pipelines/open_edx/edx_platform_v3/meta.py
+++ b/src/ol_concourse/pipelines/open_edx/edx_platform_v3/meta.py
@@ -58,6 +58,7 @@ def build_meta_job(pipeline_name: str):
                     ),
                     inputs=[Input(name=Identifier(pipeline_code.name))],
                     outputs=[Output(name=Identifier("pipeline"))],
+                    params={"PYTHONPATH": f"../{pipeline_code.name}/src"},
                     run=Command(
                         path="python",
                         dir="pipeline",

--- a/src/ol_concourse/pipelines/open_edx/grader_images/meta.py
+++ b/src/ol_concourse/pipelines/open_edx/grader_images/meta.py
@@ -75,6 +75,7 @@ def _generate_pipeline_task(
             image_resource=_OL_INFRA_IMAGE,
             inputs=[Input(name=pipeline_code.name)],
             outputs=[Output(name=Identifier("pipeline"))],
+            params={"PYTHONPATH": f"../{pipeline_code.name}/src"},
             run=Command(
                 path="python",
                 dir="pipeline",

--- a/src/ol_concourse/pipelines/open_edx/mfe/meta.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/meta.py
@@ -51,6 +51,7 @@ def meta_job(
                     ),
                     inputs=[Input(name=Identifier("mfe-pipeline-definitions"))],
                     outputs=[Output(name=Identifier("pipeline"))],
+                    params={"PYTHONPATH": "../mfe-pipeline-definitions/src"},
                     run=Command(
                         path="python",
                         dir="pipeline",
@@ -116,6 +117,7 @@ def meta_pipeline() -> Pipeline:
                         ),
                         inputs=[Input(name=Identifier("mfe-pipeline-definitions"))],
                         outputs=[Output(name=Identifier("pipeline"))],
+                        params={"PYTHONPATH": "../mfe-pipeline-definitions/src"},
                         run=Command(
                             path="python",
                             dir="pipeline",

--- a/src/ol_concourse/pipelines/open_edx/xqueue/meta.py
+++ b/src/ol_concourse/pipelines/open_edx/xqueue/meta.py
@@ -62,6 +62,7 @@ def build_meta_job(release_name):
                     ),
                     inputs=[Input(name=Identifier(pipeline_code.name))],
                     outputs=[Output(name=Identifier("pipeline"))],
+                    params={"PYTHONPATH": f"../{pipeline_code.name}/src"},
                     run=Command(
                         path="python",
                         dir="pipeline",

--- a/src/ol_concourse/pipelines/open_edx/xqwatcher/meta.py
+++ b/src/ol_concourse/pipelines/open_edx/xqwatcher/meta.py
@@ -64,6 +64,7 @@ def build_meta_job(release_name):
                     ),
                     inputs=[Input(name=Identifier(pipeline_code.name))],
                     outputs=[Output(name=Identifier("pipeline"))],
+                    params={"PYTHONPATH": f"../{pipeline_code.name}/src"},
                     run=Command(
                         path="python",
                         dir="pipeline",

--- a/uv.lock
+++ b/uv.lock
@@ -1430,8 +1430,8 @@ dependencies = [
     { name = "hvac", extra = ["parser"] },
     { name = "kubernetes" },
     { name = "ol-concourse" },
+    { name = "ol-parliament" },
     { name = "packaging" },
-    { name = "parliament" },
     { name = "pulumi" },
     { name = "pulumi-aws" },
     { name = "pulumi-aws-native" },
@@ -1483,8 +1483,8 @@ requires-dist = [
     { name = "hvac", extras = ["parser"], specifier = ">=2.0.0,<3" },
     { name = "kubernetes", specifier = ">=34.1.0" },
     { name = "ol-concourse", specifier = ">=0.8.4,<0.9" },
+    { name = "ol-parliament", specifier = ">=1.7.0" },
     { name = "packaging", specifier = ">=24.2" },
-    { name = "parliament", git = "https://github.com/mitodl/parliament" },
     { name = "pulumi", specifier = ">=3.39.1,<4" },
     { name = "pulumi-aws", specifier = ">=7.1,<8" },
     { name = "pulumi-aws-native", specifier = ">=1.25.0,<2" },
@@ -1525,6 +1525,21 @@ dev = [
     { name = "pytest-testinfra", specifier = ">=10.0.0,<11" },
     { name = "ruff", specifier = ">=0.12,<1" },
     { name = "types-boto3", specifier = ">=1.42.65" },
+]
+
+[[package]]
+name = "ol-parliament"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "jmespath" },
+    { name = "json-cfg" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/1e/c91f9efbaa4fc2d5b0943f781062b51b2360b9fa47ce4b306d4bb8faee37/ol_parliament-1.7.0.tar.gz", hash = "sha256:8a2899108904c4122e7c42f0af9752d8d51df5c8e31bc812a053f7586ee1e203", size = 680329, upload-time = "2026-05-28T18:33:36.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/47/2e46ecdcabeb0486f7e687fc67b8186e188875c756a04ab0ee8fbf59d4ab/ol_parliament-1.7.0-py3-none-any.whl", hash = "sha256:9ecc61c90df02d96444c5d8ff825db5bab0f37cefaddbcb33db90aabceca1b4a", size = 715211, upload-time = "2026-05-28T18:33:34.749Z" },
 ]
 
 [[package]]
@@ -1660,17 +1675,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1f/e7/81fdcbc7f190cdb058cffc9431587eb289833bdd633e2002455ca9bb13d4/paramiko-4.0.0.tar.gz", hash = "sha256:6a25f07b380cc9c9a88d2b920ad37167ac4667f8d9886ccebd8f90f654b5d69f", size = 1630743, upload-time = "2025-08-04T01:02:03.711Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/90/a744336f5af32c433bd09af7854599682a383b37cfd78f7de263de6ad6cb/paramiko-4.0.0-py3-none-any.whl", hash = "sha256:0e20e00ac666503bf0b4eda3b6d833465a2b7aff2e2b3d79a8bba5ef144ee3b9", size = 223932, upload-time = "2025-08-04T01:02:02.029Z" },
-]
-
-[[package]]
-name = "parliament"
-version = "1.7.0"
-source = { git = "https://github.com/mitodl/parliament#504b694459dc1852ee48ec2950ae83ef01cde78b" }
-dependencies = [
-    { name = "boto3" },
-    { name = "jmespath" },
-    { name = "json-cfg" },
-    { name = "pyyaml" },
 ]
 
 [[package]]


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Fixes meta-pipeline generation failing with `AttributeError` (e.g. `'OpenEdxVars' object has no attribute 'purge_fastly_cache'`) when a pipeline definition references a model field newer than the package baked into the `mitodl/ol-infrastructure:latest` image.

**Root cause:** each meta pipeline runs its definition script *by file path* inside the image. Running a script by path only puts the script's own directory on `sys.path`, so `ol_concourse`/`bridge` imports resolve to the **installed (stale) package in the image**, not the freshly-checked-out source. The script itself runs from the fresh checkout, so when fresh code reads a field the stale imported class lacks, generation blows up.

**Fixes:**
- Set `PYTHONPATH` to the checked-out `src` in every meta-pipeline generator and self-update task, so the script *and* its imports use the same source. Applied via task `params` for `python` invocations and inline for the `sh`-based tasks, mirroring the pattern already used in `python_packages_meta.py`.
- Swap the `parliament` git dependency for the published `ol-parliament>=1.7.0` package (import name unchanged). The git requirement was failing the `ol-infrastructure` image build — which is what left the stale package in the image to begin with.

Meta pipelines updated: `infrastructure/{meta,k8s_apps,simple_pulumi}`, `open_edx/{mfe,codejail_v3,edx_platform_v3,edx_notes_v3,xqueue,xqwatcher,grader_images}`, and `libraries/meta`.

### How can this be tested?
Locally, each meta pipeline regenerates cleanly and emits `PYTHONPATH` in every job:

```
uv sync
uv run python src/ol_concourse/pipelines/open_edx/mfe/meta.py | grep -c PYTHONPATH
uv run python src/ol_concourse/pipelines/infrastructure/meta.py | grep -c PYTHONPATH
```

`from parliament import analyze_policy_string` still resolves after the dependency swap. Full validation: `uv run ruff format src/ && uv run ruff check src/` (changed files clean; pre-commit passed on commit).

### Additional Context
The `ol-parliament` dependency change is logically separable from the PYTHONPATH fix but is bundled here because both were required to unblock the same MFE pipeline-generation failure: the parliament fix lets the image build succeed (so `:latest` carries current code), and the PYTHONPATH fix removes the dependence on the image being current at all.