### PR TITLE
fix: prevent next.learn.mit.edu from being indexed by search engines

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1096,6 +1096,11 @@ mitlearn_fastly_service = fastly.ServiceVcl(
             .read_text(),
             type="fetch",
         ),
+        fastly.ServiceVclSnippetArgs(
+            name="Strip noindex header from NextJS backend",
+            content="unset resp.http.X-Robots-Tag;",
+            type="deliver",
+        ),
     ],
     logging_https=[
         fastly.ServiceVclLoggingHttpArgs(

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
@@ -326,6 +326,19 @@ gateway = OLEKSGateway(
                 name="mit-learn-nextjs-https",
                 listener_name="https",
                 port=8443,
+                filters=[
+                    {
+                        "type": "ResponseHeaderModifier",
+                        "responseHeaderModifier": {
+                            "add": [
+                                {
+                                    "name": "X-Robots-Tag",
+                                    "value": "noindex, nofollow",
+                                }
+                            ]
+                        },
+                    }
+                ],
             ),
         ],
     ),


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/11472

### Description (What does it do?)
`next.learn.mit.edu` is the raw Kubernetes-hosted NextJS backend that Fastly proxies for `learn.mit.edu`. It should never be directly indexed by search engines, but Google is currently crawling and indexing it.

Two changes:

**1. `mit_learn_nextjs/__main__.py`** — Adds a `ResponseHeaderModifier` filter to the Traefik HTTPRoute for `next.learn.mit.edu`. This injects `X-Robots-Tag: noindex, nofollow` on all HTTP responses from the K8s Gateway, covering direct browser and crawler access to the raw backend domain.

**2. `mit_learn/__main__.py`** — Adds a Fastly `deliver` VCL snippet (`unset resp.http.X-Robots-Tag`) that strips the backend-injected noindex header before Fastly returns responses to users at `learn.mit.edu`, preserving search indexability for the public canonical domain.

A companion issue has been filed in the `mit-learn` app repo to also fix the `robots.txt` served by `next.learn.mit.edu` (currently returns `Allow: /` in production): https://github.com/mitodl/mit-learn/issues/3446

### How can this be tested?
After deploying:
1. `curl -I https://next.learn.mit.edu/` — response should include `X-Robots-Tag: noindex, nofollow`
2. `curl -I https://learn.mit.edu/` — response should **not** include `X-Robots-Tag`
3. `curl -I https://learn.mit.edu/courses/` — response should **not** include `X-Robots-Tag`

### Additional Context
The `ResponseHeaderModifier` filter is a standard Gateway API v1 feature. Traefik 3.x (the gateway class in use) supports it natively on HTTPRoute rules.

The Fastly strip is unconditional — there are no paths on `learn.mit.edu` that require `X-Robots-Tag` to be set at the CDN layer today. Pages that should be noindex on `learn.mit.edu` (e.g. certificate pages) already use per-page `<meta name="robots" content="noindex">` tags in the NextJS app.