### PR TITLE
feat(edxapp): replace redbeat with dedicated celery beat pod

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/config_builder.py
+++ b/src/ol_infrastructure/applications/edxapp/config_builder.py
@@ -108,7 +108,6 @@ def build_base_general_config() -> ConfigDict:
         "BUGS_EMAIL": "odl-devops@mit.edu",
         "BULK_EMAIL_EMAILS_PER_TASK": 500,
         "BULK_EMAIL_LOG_SENT_EMAILS": False,
-        "CELERYBEAT_SCHEDULER": "redbeat.RedBeatScheduler",
         "CELERY_BROKER_TRANSPORT": "rediss",
         "CELERY_BROKER_USER": "default",
         "CELERY_BROKER_USE_SSL": {
@@ -239,7 +238,6 @@ def build_base_general_config() -> ConfigDict:
         "PLATFORM_TWITTER_ACCOUNT": "@YourPlatformTwitterAccount",
         "POLICY_CHANGE_GRADES_ROUTING_KEY": "edx.lms.core.default",
         "PROCTORING_SETTINGS": {},
-        "REDBEAT_KEY_PREFIX": "redbeat_lms",
         "REGISTRATION_EXTRA_FIELDS": {
             "city": "hidden",
             "confirm_email": "hidden",

--- a/src/ol_infrastructure/applications/edxapp/k8s_resources.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_resources.py
@@ -96,6 +96,7 @@ def create_k8s_resources(  # noqa: C901
 
     lms_celery_deployment_name = f"{env_name}-edxapp-lms-celery"
     cms_celery_deployment_name = f"{env_name}-edxapp-cms-celery"
+    lms_beat_deployment_name = f"{env_name}-edxapp-lms-beat"
 
     # All deployments that consume MariaDB credentials and need to restart on rotation.
     # Includes both OLApplicationK8s-managed webapps and hand-rolled celery/batch deployments.
@@ -104,6 +105,7 @@ def create_k8s_resources(  # noqa: C901
         "cms-edxapp-app",  # CMS webapp (OLApplicationK8s application_name="cms-edxapp")
         lms_celery_deployment_name,
         cms_celery_deployment_name,
+        lms_beat_deployment_name,
         f"{env_name}-edxapp-lms-process-scheduled-emails",
     ]
 
@@ -1140,7 +1142,6 @@ def create_k8s_resources(  # noqa: C901
                             args=[
                                 "--app=lms.celery",
                                 "worker",
-                                "-B",
                                 "-E",
                                 "--loglevel=info",
                                 "--hostname=edx.lms.core.default.%h",
@@ -1175,6 +1176,107 @@ def create_k8s_resources(  # noqa: C901
                                         "memory_limit"
                                     ],
                                 },
+                            ),
+                            volume_mounts=celery_volume_mounts,
+                        )
+                    ],
+                ),
+            ),
+        ),
+        opts=pulumi.ResourceOptions(
+            depends_on=[v for v in lms_edxapp_config_sources.values() if v is not None]
+        ),
+    )
+
+    ############################################
+    # Dedicated LMS celery beat deployment
+    # Runs exactly one replica of `celery beat` using the stdlib PersistentScheduler.
+    # A dedicated pod (not embedded in the worker via -B) is simpler to reason about:
+    # no distributed locking needed, KEDA can freely scale worker replicas without
+    # spawning competing schedulers.
+    ############################################
+    lms_beat_selector_labels = k8s_global_labels | {
+        "ol.mit.edu/component": "edxapp-lms-beat",
+        "ol.mit.edu/pod-security-group": edxapp_k8s_app_security_group.id,
+    }
+    lms_beat_labels = lms_beat_selector_labels | {
+        "ol.mit.edu/edxapp-celery-sg": "true",
+    }
+    lms_beat_deployment = kubernetes.apps.v1.Deployment(
+        f"ol-{stack_info.env_prefix}-edxapp-lms-beat-deployment-{stack_info.env_suffix}",
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            name=lms_beat_deployment_name,
+            namespace=namespace,
+            labels=lms_beat_labels,
+        ),
+        spec=kubernetes.apps.v1.DeploymentSpecArgs(
+            replicas=1,
+            selector=kubernetes.meta.v1.LabelSelectorArgs(
+                match_labels=lms_beat_selector_labels
+            ),
+            template=kubernetes.core.v1.PodTemplateSpecArgs(
+                metadata=kubernetes.meta.v1.ObjectMetaArgs(labels=lms_beat_labels),
+                spec=kubernetes.core.v1.PodSpecArgs(
+                    service_account_name=vault_k8s_resources.service_account_name,
+                    security_context=pod_security_context,
+                    volumes=lms_edxapp_volumes,
+                    init_containers=[
+                        kubernetes.core.v1.ContainerArgs(
+                            name="export-course-repos-mkdir",
+                            image=cached_image_uri("busybox:1.35"),
+                            command=[
+                                "/bin/sh",
+                                "-c",
+                                "mkdir -p /openedx/data/export_course_repos",
+                            ],
+                            volume_mounts=[
+                                kubernetes.core.v1.VolumeMountArgs(
+                                    name="openedx-data",
+                                    mount_path="/openedx/data",
+                                ),
+                            ],
+                        ),
+                        kubernetes.core.v1.ContainerArgs(
+                            name="config-aggregator",
+                            image=cached_image_uri("busybox:1.35"),
+                            command=["/bin/sh", "-c"],
+                            args=[
+                                "cat /openedx/config-sources/*/*.yaml > /openedx/config/lms.env.yml"
+                            ],
+                            volume_mounts=[
+                                *lms_edxapp_init_volume_mounts,
+                                kubernetes.core.v1.VolumeMountArgs(
+                                    name="edxapp-config",
+                                    mount_path="/openedx/config",
+                                ),
+                            ],
+                        ),
+                    ],
+                    containers=[
+                        kubernetes.core.v1.ContainerArgs(
+                            name="lms-edxapp",
+                            image=cached_image_uri(
+                                f"mitodl/edxapp@{EDXAPP_DOCKER_IMAGE_DIGEST}"
+                            ),
+                            command=["celery"],
+                            args=[
+                                "--app=lms.celery",
+                                "beat",
+                                "--scheduler=celery.beat.PersistentScheduler",
+                                "--loglevel=info",
+                            ],
+                            env=[
+                                kubernetes.core.v1.EnvVarArgs(
+                                    name="SERVICE_VARIANT", value="lms"
+                                ),
+                                kubernetes.core.v1.EnvVarArgs(
+                                    name="DJANGO_SETTINGS_MODULE",
+                                    value="lms.envs.production",
+                                ),
+                            ],
+                            resources=kubernetes.core.v1.ResourceRequirementsArgs(
+                                requests={"cpu": "100m", "memory": "512Mi"},
+                                limits={"memory": "1Gi"},
                             ),
                             volume_mounts=celery_volume_mounts,
                         )
@@ -1377,7 +1479,6 @@ def create_k8s_resources(  # noqa: C901
                             args=[
                                 "--app=cms.celery",
                                 "worker",
-                                "-B",
                                 "-E",
                                 "--loglevel=info",
                                 "--hostname=edx.cms.core.default.%h",

--- a/src/ol_infrastructure/components/services/k8s.py
+++ b/src/ol_infrastructure/components/services/k8s.py
@@ -101,7 +101,7 @@ class OLApplicationK8sCeleryBeatConfig(BaseModel):
         default={"cpu": "100m", "memory": "512Mi"}
     )
     resource_limits: dict[str, str] = Field(default={"memory": "512Mi"})
-    scheduler: str = "redbeat.RedBeatScheduler"
+    scheduler: str = "celery.beat.PersistentScheduler"
 
 
 class GranianConfig(BaseModel):
@@ -1659,11 +1659,7 @@ class OLApplicationK8s(ComponentResource):
                                             else []
                                         ),
                                         *(
-                                            [
-                                                "-B",  # beat scheduler - only on one worker to avoid multiple competing schedulers
-                                                "--scheduler",
-                                                "redbeat.RedBeatScheduler",
-                                            ]
+                                            ["-B"]
                                             if celery_worker_config.run_beat
                                             else []
                                         ),


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)

Replaces the fragile redbeat distributed-scheduler pattern with a single dedicated beat pod per edxapp deployment.

**Before:** both the LMS and CMS celery worker Deployments ran with the `-B` flag, embedding beat inside the worker. Every environment therefore had **two competing beat processes** (LMS + CMS), plus the LMS and CMS workers are KEDA-autoscaled — at scale each additional replica also spun up its own embedded beat, making the problem worse. All of these processes competed for a single Redis lock (`redbeat_lms:lock`) managed by `redbeat.RedBeatScheduler`.

This was observed to cause silent scheduling failures in `mitxonline-qa`: during a rolling update, the new pod's beat started but could never acquire the lock from the previous pod, leaving scheduled tasks (email digests, SAML metadata refresh, token expiry) unscheduled for the full lock TTL period.

**After:** a dedicated `{env}-edxapp-lms-beat` Deployment (`replicas=1`, never autoscaled) runs `celery beat --scheduler=celery.beat.PersistentScheduler`. The `-B` flag is removed from both LMS and CMS workers. No distributed locking is needed — Kubernetes guarantees exactly one beat pod.

**Files changed:**

- `applications/edxapp/k8s_resources.py` — adds the `lms-beat` Deployment (same volumes, init containers, and VPC security group as the LMS celery worker; 100m CPU / 512Mi–1Gi memory); removes `-B` from LMS and CMS celery args; includes the beat pod in `edxapp_db_restart_deployment_names` so it restarts on Vault credential rotation
- `applications/edxapp/config_builder.py` — removes `CELERYBEAT_SCHEDULER: redbeat.RedBeatScheduler` and `REDBEAT_KEY_PREFIX: redbeat_lms` from the base config
- `components/services/k8s.py` — updates `OLApplicationK8sCeleryBeatConfig.scheduler` default to `celery.beat.PersistentScheduler`; cleans up the deprecated `run_beat=True` worker path which previously injected `--scheduler redbeat.RedBeatScheduler`

### How can this be tested?

1. Deploy to a QA environment (`mitx.QA` or `mitxonline.QA`)
2. Confirm a new `{env}-edxapp-lms-beat` pod is Running with `kubectl -n {ns} get pods | grep beat`
3. Confirm `{env}-edxapp-lms-celery` and `{env}-edxapp-cms-celery` pods no longer have `-B` in their process args: `kubectl -n {ns} exec <pod> -- ps aux | grep celery`
4. Confirm the beat pod is dispatching scheduled tasks — after ~5 minutes, check the pod logs for `Scheduler: Sending due task` entries: `kubectl -n {ns} logs -l ol.mit.edu/component=edxapp-lms-beat --tail=50`
5. Confirm no `redbeat_lms:lock` key appears in Redis after the old pods are replaced

### Additional Context

The `PersistentScheduler` writes schedule state to a local shelve file inside the container. On pod restart the file is lost and the scheduler re-derives next-run times from `CELERYBEAT_SCHEDULE` in the Django config. For the daily/weekly tasks we schedule (email digests, SAML refresh, token expiry) this is acceptable — a restart may cause a task to run slightly early on the next cycle, but never skip a cycle entirely.

CMS never needed its own beat scheduler — all entries in `CELERYBEAT_SCHEDULE` are LMS tasks — so removing `-B` from CMS is a straightforward cleanup with no functional impact.