### PR TITLE
feat: wire OEP-65 Site Project Fastly routing for instructor-dashboard MFE

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.CI.yaml
@@ -141,3 +141,7 @@ config:
   typesense:enabled: "true"
   typesense:course_search_enabled: "true"
   typesense:forum_search_enabled: "false"
+  edxapp:site_project:
+    deployment: mitx
+    mfe_apps:
+    - instructor-dashboard

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.QA.yaml
@@ -141,3 +141,7 @@ config:
   typesense:enabled: "true"
   typesense:course_search_enabled: "true"
   typesense:forum_search_enabled: "false"
+  edxapp:site_project:
+    deployment: mitx
+    mfe_apps:
+    - instructor-dashboard

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.CI.yaml
@@ -158,3 +158,7 @@ config:
   typesense:enabled: "true"
   typesense:course_search_enabled: "true"
   typesense:forum_search_enabled: "false"
+  edxapp:site_project:
+    deployment: mitxonline
+    mfe_apps:
+    - instructor-dashboard

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.QA.yaml
@@ -159,3 +159,7 @@ config:
   typesense:enabled: "true"
   typesense:course_search_enabled: "true"
   typesense:forum_search_enabled: "false"
+  edxapp:site_project:
+    deployment: mitxonline
+    mfe_apps:
+    - instructor-dashboard

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.xpro.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.xpro.CI.yaml
@@ -118,3 +118,7 @@ config:
   typesense:enabled: "true"
   typesense:course_search_enabled: "true"
   typesense:forum_search_enabled: "false"
+  edxapp:site_project:
+    deployment: xpro
+    mfe_apps:
+    - instructor-dashboard

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.xpro.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.xpro.QA.yaml
@@ -113,3 +113,7 @@ config:
   meilisearch:memory_limit: "1Gi"
   typesense:deploy: "true"
   typesense:enabled: "false"
+  edxapp:site_project:
+    deployment: xpro
+    mfe_apps:
+    - instructor-dashboard

--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -162,6 +162,7 @@ def _build_interpolated_config_dict(
         "MIT_LEARN_AI_XBLOCK_CHAT_RATING_URL": f"https://{edxapp_config.require('mit_learn_api_domain')}/ai/api/v0/chat_sessions/",
         "MIT_LEARN_LOGO": f"https://{domains['lms']}/static/mitxonline/images/mit-learn-logo.svg",
         "COURSE_AUTHORING_MICROFRONTEND_URL": f"https://{domains['studio']}/authoring",
+        "INSTRUCTOR_MICROFRONTEND_URL": f"https://{domains['lms']}/apps/instructor-dashboard",
         "LEARNING_MICROFRONTEND_URL": f"https://{domains['lms']}/learn",
         "LMS_BASE": domains["lms"],
         "LMS_INTERNAL_ROOT_URL": f"https://{domains['lms']}",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)

Wires up the OEP-65 frontend-base Site Project Fastly routing for the instructor-dashboard MFE across CI and QA stacks for all three OL deployments (mitx, mitxonline, xpro).

**Background**: The instructor dashboard MFE (`frontend-app-instructor-dashboard`) has been migrated to `@openedx/frontend-base` and is now bundled into per-deployment Site Project builds (rather than deployed as a standalone legacy MFE). The Site Project artifacts are already present in S3 (`{env}-edxapp-mfe/{deployment}-site/`), but the Fastly VCL routing and LMS redirect URL were never set.

**Two changes:**

**1. `edxapp:site_project` Pulumi config blocks** (6 stack YAMLs)

Adding this key causes `__main__.py` to generate two Fastly VCL snippets per service:
- **recv** (priority 90): `/apps/{deployment}-site/*` → pass through to S3 (versioned JS/CSS chunks); `/apps/instructor-dashboard/*` → rewrite to `/{deployment}-site/index.html` (React Router handles client-side routing)
- **fetch**: `no-cache, no-store, must-revalidate` on `index.html` so deploys take effect immediately without a Fastly purge

The `_mfe_path_condition` for the MFE S3 backend is also extended to include requests tagged with `X-Site-Project: 1` so the backend is selected correctly after the URL rewrite.

**2. `INSTRUCTOR_MICROFRONTEND_URL` in `k8s_configmaps.py`**

Previously this key was only set in `config_builder.py` as the relative fallback `/instructor`, which causes the LMS to render the legacy Django instructor view rather than redirect to the MFE. Setting it to `https://{lms_domain}/apps/instructor-dashboard` in the interpolated configmap (alongside `LEARNING_MICROFRONTEND_URL`, `DISCUSSIONS_MICROFRONTEND_URL`, etc.) ensures the LMS sends instructors to the frontend-base Site Project.

**Stacks updated:**
| Stack | `deployment` | S3 prefix confirmed |
|---|---|---|
| mitx.CI / mitx.QA | `mitx` | `mitx-ci-edxapp-mfe/mitx-site/` ✅ |
| mitxonline.CI / mitxonline.QA | `mitxonline` | `mitxonline-ci-edxapp-mfe/mitxonline-site/` ✅ |
| xpro.CI / xpro.QA | `xpro` | `xpro-ci-edxapp-mfe/xpro-site/` ✅ |

**Intentionally excluded:**
- `mitx-staging`: no site build exists in either CI or QA S3 bucket yet; will be added once a Concourse pipeline job deploys it
- Production stacks: excluded pending QA validation

### How can this be tested?

1. Run `pulumi preview` on `ol-application-edxapp.mitx.QA` — confirm two new Fastly VCL snippet resources appear (`Handle Site Project routing` recv snippet and `No-cache for Site Project index.html` fetch snippet)
2. After `pulumi up` and LMS configmap rollout, navigate to a course instructor tab on `mitx-qa.mitx.mit.edu` — the browser should redirect to `https://mitx-qa.mitx.mit.edu/apps/instructor-dashboard/...` and load the frontend-base instructor dashboard
3. Verify `https://mitx-qa.mitx.mit.edu/apps/mitx-site/` serves JS/CSS chunks directly (200, correct content-type, long cache TTL)
4. Verify `https://mitx-qa.mitx.mit.edu/apps/mitx-site/index.html` returns `cache-control: no-cache, no-store, must-revalidate`

**Note:** The `instructor.legacy_instructor_dashboard` waffle flag in `Pulumi.mitx.QA.yaml` (set `--create --everyone`) will need to be removed or deactivated in a follow-up for the LMS redirect to fire. That flag forces the legacy Django dashboard regardless of `INSTRUCTOR_MICROFRONTEND_URL`.