### PR TITLE
Dansubak/202606 add s3 bucket for google ads opt v2

### DIFF
--- a/src/ol_infrastructure/applications/google_ads_optimization/Pulumi.applications.google_ads_optimization.CI.yaml
+++ b/src/ol_infrastructure/applications/google_ads_optimization/Pulumi.applications.google_ads_optimization.CI.yaml
@@ -1,0 +1,3 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-ci
+encryptedkey: AQICAHhMkpkBpCvmFjhyfy75ENALRrbg42uOs9cUsFNLXqPnagGxy6YdetIR0us51w5MZASLAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMX1+ZJgv+hinheVFDAgEQgDsit0P8puZOC0XYgDsVdU8sU0cBkUsa73OYCs8JpzkF1m3Sm3sviLTAesAU+ITxf6iUKPn0kp/Mz2PkYg==

--- a/src/ol_infrastructure/applications/google_ads_optimization/Pulumi.applications.google_ads_optimization.Production.yaml
+++ b/src/ol_infrastructure/applications/google_ads_optimization/Pulumi.applications.google_ads_optimization.Production.yaml
@@ -1,0 +1,3 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-production
+encryptedkey: AQICAHjksIVfl1VtAHpBda/1YYjj6tSeS2o4TXgvEEyBIXLjjwFYcK7N/vnFT4+itsE3gTr7AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM0g6/XT/QRO/6FaY5AgEQgDt1fyUXsDAcSF0Xfz+bGrzLqTDUSpKi2Zi7mYIv1XFhwte7OTstXLvNxsjfJdV63m4n7wE5JQbVQszL9Q==

--- a/src/ol_infrastructure/applications/google_ads_optimization/Pulumi.applications.google_ads_optimization.QA.yaml
+++ b/src/ol_infrastructure/applications/google_ads_optimization/Pulumi.applications.google_ads_optimization.QA.yaml
@@ -1,0 +1,3 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-qa
+encryptedkey: AQICAHjE+jMY5DL7M1LMYX6YgtMueHEDNg05lsdN5Z0zeGHyJgGsayfDLnblzgax1UKA2kHdAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMAe4/ueFgc2tbG7dyAgEQgDtFhMorGoq6P3/kvfo/7EgoK9KUG+fkEJ/ktA4y90FnPsNauvicGO9vgMnrhNng54OizV4uLpwYpRmHlw==

--- a/src/ol_infrastructure/applications/google_ads_optimization/Pulumi.yaml
+++ b/src/ol_infrastructure/applications/google_ads_optimization/Pulumi.yaml
@@ -1,0 +1,7 @@
+---
+name: ol-application-google-ads-opt
+runtime: python
+description: Pulumi project for deploying the infrastructure needed by Google Ads
+  Optimization
+backend:
+  url: s3://mitol-pulumi-state/ # should not be changed

--- a/src/ol_infrastructure/applications/google_ads_optimization/__main__.py
+++ b/src/ol_infrastructure/applications/google_ads_optimization/__main__.py
@@ -1,0 +1,46 @@
+from pulumi_aws import get_caller_identity, iam
+
+from ol_infrastructure.components.aws.s3 import OLBucket, S3BucketConfig
+from ol_infrastructure.lib.ol_types import AWSBase, BusinessUnit
+from ol_infrastructure.lib.pulumi_helper import (
+    parse_stack,
+)
+from ol_infrastructure.lib.vault import setup_vault_provider
+
+# Parse stack and setup providers
+stack_info = parse_stack()
+setup_vault_provider(stack_info)
+env_name = f"google-ads-opt-{stack_info.env_suffix}"
+
+aws_account = get_caller_identity()
+
+# No idea if we should use an existing OU or not.
+aws_config = AWSBase(
+    tags={"OU": BusinessUnit.mit_learn, "Environment": stack_info.env_suffix}
+)
+
+google_ads_opt_bucket_name = f"google-ads-opt-{stack_info.env_suffix}"
+google_ads_opt_bucket_config = S3BucketConfig(
+    bucket_name=google_ads_opt_bucket_name,
+    versioning_enabled=True,
+    bucket_policy_document=iam.get_policy_document(
+        statements=[
+            iam.GetPolicyDocumentStatementArgs(
+                effect="Allow",
+                principals=[
+                    iam.GetPolicyDocumentStatementPrincipalArgs(
+                        type="AWS",
+                        identifiers=[f"arn:aws:iam::{aws_account.account_id}:root"],
+                    )
+                ],
+                actions=["s3:*"],
+                resources=[f"arn:aws:s3:::{google_ads_opt_bucket_name}/*"],
+            )
+        ]
+    ).json,
+    tags=aws_config.tags,
+    region=aws_config.region,
+)
+google_ads_opt_bucket = OLBucket(
+    f"google-ads-opt-bucket-{env_name}", config=google_ads_opt_bucket_config
+)


### PR DESCRIPTION
### Description (What does it do?)
Previously, google ad optimization didn't need a persistence layer - all data was pulled from Google Ads APIs at the beginning of the run and pushed to Google Ads at the end; despite storing all this on the filesystem during the run, there was no data that needed persistence outside of Google Ads.

Unfortunately, the new version needs to carry forward a generated file every day. It's modified during the run and used as input to the next. This PR sets up an S3 bucket which can be accessed by anything within the AWS account. We'll modify the google ads optimization job (which runs on concourse) to pull the file from S3 at the start of the run and push an updated file at the end of the run.

To be clear, *this is not an ideal setup*, but as marketing is trying to get a test running in slightly over a week, this is all we're likely to have time for.

Pulumi up output is as follows:
```
daniel@dhcp-10-29-170-242 google_ads_optimization % pulumi up -s applications.google_ads_optimization.Production
Previewing update (applications.google_ads_optimization.Production):
     Type                                       Name                                                                           Plan       
 +   pulumi:pulumi:Stack                        ol-application-google-ads-opt-applications.google_ads_optimization.Production  create     
 +   └─ ol:aws:s3:OLBucket                      google-ads-opt-bucket-google-ads-opt-production                                create     
 +      ├─ aws:s3:Bucket                        google-ads-opt-bucket-google-ads-opt-production-bucket                         create     
 +      ├─ aws:s3:BucketPublicAccessBlock       google-ads-opt-bucket-google-ads-opt-production-public-access-block            create     
 +      ├─ aws:s3:BucketVersioning              google-ads-opt-bucket-google-ads-opt-production-versioning                     create     
 +      ├─ aws:s3:BucketOwnershipControls       google-ads-opt-bucket-google-ads-opt-production-ownership-controls             create     
 +      ├─ aws:s3:BucketLifecycleConfiguration  google-ads-opt-bucket-google-ads-opt-production-lifecycle                      create     
 +      └─ aws:s3:BucketPolicy                  google-ads-opt-bucket-google-ads-opt-production-policy                         create   
 ```