### PR TITLE
fix: use givenName instead of cn for determining firstName in ol-mit realm

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/ol_mit.py
+++ b/src/ol_infrastructure/substructure/keycloak/ol_mit.py
@@ -510,13 +510,46 @@ def create_ol_mit_realm(  # noqa: PLR0913
         # MIT affiliate into Keycloak; users are provisioned on-demand via the
         # Touchstone SAML first-login flow.
         changed_sync_period=14400,
+        # Disable Keycloak's auto-created default mappers so we can take full
+        # control of the standard attribute mappings below.  The default "first
+        # name" mapper maps the LDAP "cn" attribute onto firstName; we instead
+        # want "givenName", so we define the full standard set explicitly rather
+        # than letting the default mapper shadow our intent or collide on
+        # the "first name" name.
+        delete_default_mappers=True,
         opts=resource_options,
     )
 
-    # MIT-specific attribute mappers.  Standard attributes (username, email,
-    # firstName, lastName) are handled by the default mappers that Keycloak
-    # creates automatically when delete_default_mappers is not set.
+    # Standard attribute mappers.  These replace the default mappers Keycloak
+    # would otherwise auto-create (disabled via delete_default_mappers above).
+    # The only deviation from the Keycloak defaults is "first name", which maps
+    # from "givenName" instead of "cn".
+    # MIT-specific attribute mappers follow.
     for resource_name, mapper_name, ldap_attr, model_attr in [
+        (
+            "ol-mit-ldap-username-mapper",
+            "username",
+            "uid",
+            "username",
+        ),
+        (
+            "ol-mit-ldap-email-mapper",
+            "email",
+            "mail",
+            "email",
+        ),
+        (
+            "ol-mit-ldap-last-name-mapper",
+            "last name",
+            "sn",
+            "lastName",
+        ),
+        (
+            "ol-mit-ldap-first-name-mapper",
+            "first name",
+            "givenName",
+            "firstName",
+        ),
         (
             "ol-mit-ldap-edu-person-principal-name-mapper",
             "eduPersonPrincipalName",
@@ -534,12 +567,6 @@ def create_ol_mit_realm(  # noqa: PLR0913
             "eduPersonPrimaryAffiliation",
             "eduPersonPrimaryAffiliation",
             "eduPersonPrimaryAffiliation",
-        ),
-        (
-            "ol-mit-ldap-first-name-mapper",
-            "first name",
-            "givenName",
-            "firstName",
         ),
     ]:
         keycloak.ldap.UserAttributeMapper(

--- a/src/ol_infrastructure/substructure/keycloak/ol_mit.py
+++ b/src/ol_infrastructure/substructure/keycloak/ol_mit.py
@@ -550,6 +550,23 @@ def create_ol_mit_realm(  # noqa: PLR0913
             "givenName",
             "firstName",
         ),
+        # createTimestamp/modifyTimestamp mappers are normally auto-created by
+        # Keycloak's default mapper set.  Since delete_default_mappers=True
+        # suppresses those, re-add them explicitly: the delta sync driven by
+        # changed_sync_period relies on modifyTimestamp to detect which LDAP
+        # entries have changed since the last sync.
+        (
+            "ol-mit-ldap-creation-date-mapper",
+            "creation date",
+            "createTimestamp",
+            "createTimestamp",
+        ),
+        (
+            "ol-mit-ldap-modify-date-mapper",
+            "modify date",
+            "modifyTimestamp",
+            "modifyTimestamp",
+        ),
         (
             "ol-mit-ldap-edu-person-principal-name-mapper",
             "eduPersonPrincipalName",

--- a/src/ol_infrastructure/substructure/keycloak/ol_mit.py
+++ b/src/ol_infrastructure/substructure/keycloak/ol_mit.py
@@ -535,6 +535,12 @@ def create_ol_mit_realm(  # noqa: PLR0913
             "eduPersonPrimaryAffiliation",
             "eduPersonPrimaryAffiliation",
         ),
+        (
+            "ol-mit-ldap-first-name-mapper",
+            "first name",
+            "givenName",
+            "firstName",
+        ),
     ]:
         keycloak.ldap.UserAttributeMapper(
             resource_name,

--- a/src/ol_infrastructure/substructure/keycloak/ol_mit.py
+++ b/src/ol_infrastructure/substructure/keycloak/ol_mit.py
@@ -517,7 +517,7 @@ def create_ol_mit_realm(  # noqa: PLR0913
         # than letting the default mapper shadow our intent or collide on
         # the "first name" name.
         delete_default_mappers=True,
-        opts=resource_options,
+        opts=resource_options.merge(ResourceOptions(delete_before_replace=True)),
     )
 
     # Standard attribute mappers.  These replace the default mappers Keycloak


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11110

### Description (What does it do?)
By default, when using LDAP in keycloak, the cn attribute which contains the full name of the user is mapped to the first name in keycloak. This is often not the desired behavior. In ocw studio, for example, account names have changed from "Michael Jackson" to "Michael Jackson Jackson" because of this. This PR aims to fix this by defining the mapping for the firstName to use the givenName LDAP attribute.

There is also an [open issue](https://github.com/keycloak/keycloak/issues/35941) on the keycloak project about this behavior.


### How can this be tested?
Run pulumi preview against the substructure.keycloak stack in QA to confirm no plan errors. Under the User Federation section in keycloak, go to Mappers. The First name mapper should use givenName as the LDAP attribute

I have not carried any testing out myself as I can't access the infrastructure secrets in vault, and it would probably take me a lot of time to configure everything properly


