### PR TITLE
feat(local-dev): add Open edX (edx-platform) to Tilt local dev stack

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -145,6 +145,30 @@ APPS = [
             },
         ],
     },
+    {
+        "name": "openedx",
+        "dir": "lehrer",
+        "namespace": "openedx",
+        "deploy_name": "lms",
+        "tiltfile": "./local-dev/apps/openedx/Tiltfile",
+        "seed_commands": [
+            {
+                "label": "seed-openedx-migrate",
+                "description": "Run edx-platform database migrations",
+                "cmd": "python manage.py lms migrate --run-syncdb",
+            },
+            {
+                "label": "seed-openedx-superuser",
+                "description": "Create a superuser (requires DJANGO_SUPERUSER_PASSWORD env var)",
+                "cmd": "python manage.py lms createsuperuser --noinput --username admin --email admin@example.com",
+            },
+            {
+                "label": "seed-openedx-assets",
+                "description": "Collect static assets (run after migrations)",
+                "cmd": "python manage.py lms collectstatic --noinput",
+            },
+        ],
+    },
 ]
 
 # ---------------------------------------------------------------------------

--- a/local-dev/apps/openedx/Tiltfile
+++ b/local-dev/apps/openedx/Tiltfile
@@ -1,0 +1,51 @@
+# openedx integration Tiltfile for ol-infrastructure local dev.
+#
+# Deploys edx-platform (LMS/CMS), codejail, edx-notes-api, and compiled MFEs
+# into the openedx namespace, sharing ol-infrastructure's Valkey and OpenSearch.
+# MySQL and MongoDB are deployed here since ol-infrastructure doesn't include them.
+#
+# Prerequisites:
+#   - MITOL_WORKSPACE_ROOT must be set (or lehrer must be at <workspace_root>/lehrer)
+#   - lehrer repo must be checked out alongside ol-infrastructure
+
+workspace_root = os.environ.get("MITOL_WORKSPACE_ROOT", config.main_dir + "/../../..")
+lehrer_dir = os.path.join(workspace_root, "lehrer")
+
+if not os.path.exists(os.path.join(lehrer_dir, ".git")):
+    print("WARNING: lehrer repo not found at " + lehrer_dir + " — skipping openedx deployment.")
+    print("  Set MITOL_WORKSPACE_ROOT to the directory containing the lehrer repo.")
+else:
+    # ---- Globals consumed by lehrer-core.star ----
+
+    LEHRER_DEPLOY_CONFIG   = os.path.join(lehrer_dir, "deployments/mit-ol")
+    LEHRER_REGISTRY        = "localhost:5001"                           # ol-infra registry (host-side)
+    LEHRER_REGISTRY_K8S    = "k3d-registry.localhost:5001"             # ol-infra registry (cluster-side)
+    LEHRER_REDIS_HOST      = "valkey-primary.local-infra.svc.cluster.local"
+    LEHRER_OPENSEARCH_HOST = "opensearch-master.local-infra.svc.cluster.local"
+    LEHRER_NAMESPACE       = "openedx"
+    LEHRER_MANAGE_INFRA    = False    # Valkey and OpenSearch come from ol-infra
+    LEHRER_MYSQL_MANAGED   = True     # ol-infra doesn't have MySQL — deploy it here
+    LEHRER_MONGO_MANAGED   = True     # ol-infra doesn't have MongoDB — deploy it here
+    LEHRER_INGRESS         = "apisix"
+    LEHRER_MFE_HOT_RELOAD  = False
+    LEHRER_NOTES_REPO      = "https://github.com/openedx/edx-notes-api"
+    LEHRER_HELM_OVERRIDE_DIR = config.main_dir + "/helm"
+    LEHRER_LOCAL_DEV_DIR   = os.path.join(lehrer_dir, "local-dev")
+    LEHRER_LMS_BASE_URL    = "https://lms.mit.dev"
+    LEHRER_CMS_BASE_URL    = "https://studio.mit.dev"
+    LEHRER_NOTES_PUBLIC_URL = "https://notes.mit.dev"
+    # Integration Tiltfile applies its own configmaps pointing at ol-infra services.
+    LEHRER_APPLY_PLATFORM_CONFIGMAPS = False
+
+    LEHRER_RELEASE_NAME    = "master"
+    LEHRER_DEPLOY_NAME     = "mitxonline"
+    LEHRER_SETTINGS_NS     = "mitol"
+
+    # Apply integration-specific configmaps (Valkey, ol-infra OpenSearch, public URLs).
+    k8s_yaml(config.main_dir + "/configmaps/lms-config.yaml")
+    k8s_yaml(config.main_dir + "/configmaps/cms-config.yaml")
+
+    include(os.path.join(lehrer_dir, "local-dev/lehrer-core.star"))
+
+    # APISIX routes for lms/studio/notes/mfe on the ol-infra cluster
+    k8s_yaml(config.main_dir + "/apisix-routes.yaml")

--- a/local-dev/apps/openedx/apisix-routes.yaml
+++ b/local-dev/apps/openedx/apisix-routes.yaml
@@ -1,0 +1,116 @@
+---
+# TLS certs for openedx services — reuse the shared local-dev-tls wildcard cert.
+apiVersion: apisix.apache.org/v2
+kind: ApisixTls
+metadata:
+  name: openedx-tls
+  namespace: openedx
+spec:
+  ingressClassName: apache-apisix
+  hosts:
+  - "lms.mit.dev"
+  - "studio.mit.dev"
+  - "notes.mit.dev"
+  - "mfe.mit.dev"
+  secret:
+    name: local-dev-tls
+    namespace: openedx
+---
+apiVersion: apisix.apache.org/v2
+kind: ApisixPluginConfig
+metadata:
+  name: openedx-shared-plugins
+  namespace: openedx
+spec:
+  plugins:
+  - name: redirect
+    enable: true
+    config:
+      http_to_https: true
+  - name: prometheus
+    enable: true
+---
+# LMS — edx-platform learning management system.
+# edx-platform handles its own session/auth — no OIDC plugin at the ingress layer.
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  name: lms-route
+  namespace: openedx
+spec:
+  ingressClassName: apache-apisix
+  http:
+  - name: lms
+    priority: 0
+    match:
+      hosts:
+      - "lms.mit.dev"
+      paths:
+      - "/*"
+    backends:
+    - serviceName: lms
+      servicePort: 8000
+    plugin_config_name: openedx-shared-plugins
+---
+# CMS (Studio) — edx-platform course authoring tool.
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  name: studio-route
+  namespace: openedx
+spec:
+  ingressClassName: apache-apisix
+  http:
+  - name: studio
+    priority: 0
+    match:
+      hosts:
+      - "studio.mit.dev"
+      paths:
+      - "/*"
+    backends:
+    - serviceName: cms
+      servicePort: 8010
+    plugin_config_name: openedx-shared-plugins
+---
+# Notes API — edx-notes-api annotation service.
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  name: notes-route
+  namespace: openedx
+spec:
+  ingressClassName: apache-apisix
+  http:
+  - name: notes
+    priority: 0
+    match:
+      hosts:
+      - "notes.mit.dev"
+      paths:
+      - "/*"
+    backends:
+    - serviceName: notes
+      servicePort: 8000
+    plugin_config_name: openedx-shared-plugins
+---
+# MFE — compiled nginx serving the default OEP-65 site project.
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  name: mfe-route
+  namespace: openedx
+spec:
+  ingressClassName: apache-apisix
+  http:
+  - name: mfe
+    priority: 0
+    match:
+      hosts:
+      - "mfe.mit.dev"
+      paths:
+      - "/*"
+    backends:
+    - serviceName: mfe-default
+      servicePort: 80
+    plugin_config_name: openedx-shared-plugins

--- a/local-dev/apps/openedx/configmaps/cms-config.yaml
+++ b/local-dev/apps/openedx/configmaps/cms-config.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cms-config
+  namespace: openedx
+data:
+  MYSQL_HOST: "mysql.openedx.svc.cluster.local"
+  MYSQL_PORT: "3306"
+  MYSQL_DB_NAME: "edxapp"
+  MYSQL_USER: "edxapp"
+
+  CELERY_BROKER_TRANSPORT: "redis"
+  CELERY_BROKER_HOSTNAME: "valkey-primary.local-infra.svc.cluster.local"
+  CELERY_BROKER_USER: ""
+  CELERY_BROKER_PASSWORD: ""
+  CELERY_BROKER_VHOST: ""
+
+  MONGODB_HOST: "mongodb.openedx.svc.cluster.local"
+  MONGODB_PORT: "27017"
+  MONGODB_USER: "edxapp"
+  MONGODB_DB: "edxapp"
+
+  ELASTIC_SEARCH_HOST: "opensearch-master.local-infra.svc.cluster.local"
+  ELASTIC_SEARCH_PORT: "9200"
+
+  LMS_BASE_URL: "https://lms.mit.dev"
+  CMS_BASE_URL: "https://studio.mit.dev"
+
+  STATIC_ROOT_BASE: "/openedx/staticfiles"
+  LOG_DIR: "/openedx/data/var/log/edx"
+  LOGGING_ENV: "sandbox"
+  LOCAL_LOGLEVEL: "INFO"
+
+  DEBUG: "false"
+  ALLOWED_HOSTS: "*"
+  HTTPS: "on"
+
+  OL_SETTINGS_DIR: ""
+  SERVICE_VARIANT: "cms"

--- a/local-dev/apps/openedx/configmaps/lms-config.yaml
+++ b/local-dev/apps/openedx/configmaps/lms-config.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lms-config
+  namespace: openedx
+data:
+  MYSQL_HOST: "mysql.openedx.svc.cluster.local"
+  MYSQL_PORT: "3306"
+  MYSQL_DB_NAME: "edxapp"
+  MYSQL_USER: "edxapp"
+
+  # Valkey from ol-infrastructure shared infra (local-infra namespace)
+  CELERY_BROKER_TRANSPORT: "redis"
+  CELERY_BROKER_HOSTNAME: "valkey-primary.local-infra.svc.cluster.local"
+  CELERY_BROKER_USER: ""
+  CELERY_BROKER_PASSWORD: ""
+  CELERY_BROKER_VHOST: ""
+
+  MONGODB_HOST: "mongodb.openedx.svc.cluster.local"
+  MONGODB_PORT: "27017"
+  MONGODB_USER: "edxapp"
+  MONGODB_DB: "edxapp"
+
+  # OpenSearch from ol-infrastructure shared infra (local-infra namespace)
+  ELASTIC_SEARCH_HOST: "opensearch-master.local-infra.svc.cluster.local"
+  ELASTIC_SEARCH_PORT: "9200"
+
+  CODE_JAIL_REST_SERVICE_HOST: "http://codejail.openedx.svc.cluster.local:8000"
+  ENABLE_CODEJAIL_REST_SERVICE: "true"
+
+  EDXNOTES_INTERNAL_API: "http://notes.openedx.svc.cluster.local:8000/api/v1"
+  EDXNOTES_PUBLIC_API: "https://notes.mit.dev/api/v1"
+  ENABLE_EDXNOTES: "true"
+
+  LMS_BASE_URL: "https://lms.mit.dev"
+  CMS_BASE_URL: "https://studio.mit.dev"
+
+  STATIC_ROOT_BASE: "/openedx/staticfiles"
+  LOG_DIR: "/openedx/data/var/log/edx"
+  LOGGING_ENV: "sandbox"
+  LOCAL_LOGLEVEL: "INFO"
+
+  DEBUG: "false"
+  ALLOWED_HOSTS: "*"
+  HTTPS: "on"
+
+  OL_SETTINGS_DIR: ""
+  SERVICE_VARIANT: "lms"

--- a/local-dev/apps/openedx/helm/mongodb-values.yaml
+++ b/local-dev/apps/openedx/helm/mongodb-values.yaml
@@ -1,0 +1,23 @@
+# MongoDB for edx-platform (modulestore + forums) in ol-infrastructure integrated mode.
+architecture: standalone
+
+auth:
+  enabled: true
+  rootPassword: openedx-dev  # pragma: allowlist secret
+  username: edxapp
+  password: openedx-dev  # pragma: allowlist secret
+  database: edxapp
+
+persistence:
+  enabled: false
+
+resources:
+  requests:
+    memory: "256Mi"
+    cpu: "100m"
+  limits:
+    memory: "512Mi"
+    cpu: "500m"
+
+metrics:
+  enabled: false

--- a/local-dev/apps/openedx/helm/mysql-values.yaml
+++ b/local-dev/apps/openedx/helm/mysql-values.yaml
@@ -1,0 +1,31 @@
+# MySQL for edx-platform in ol-infrastructure integrated mode.
+# Deployed into the openedx namespace since ol-infrastructure doesn't include MySQL.
+architecture: standalone
+
+auth:
+  rootPassword: openedx-dev  # pragma: allowlist secret
+  database: edxapp
+  username: edxapp
+  password: openedx-dev  # pragma: allowlist secret
+  existingSecret: ""
+
+primary:
+  configuration: |
+    [mysqld]
+    character-set-server=utf8mb4
+    collation-server=utf8mb4_unicode_ci
+    sql_mode=
+    max_connections=500
+  persistence:
+    enabled: false
+  initdb:
+    scripts:
+      create-dbs.sql: |
+        CREATE DATABASE IF NOT EXISTS notes CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+        CREATE DATABASE IF NOT EXISTS csmh CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+        GRANT ALL PRIVILEGES ON notes.* TO 'edxapp'@'%';
+        GRANT ALL PRIVILEGES ON csmh.* TO 'edxapp'@'%';
+        FLUSH PRIVILEGES;
+
+metrics:
+  enabled: false


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)

Adds edx-platform (LMS, CMS, Celery worker, codejail, edx-notes-api, and MFEs) as an opt-in app in the ol-infrastructure local dev Tilt stack. This is the companion PR to https://github.com/mitodl/lehrer/pull/61, which contains the shared `lehrer-core.star` Starlark logic and standalone K3d cluster setup.

**Usage:**
```bash
tilt up -- --enabled_apps mit-learn,openedx
```

`openedx` is intentionally absent from the default `enabled_apps` list — edx-platform builds take 45–90 minutes on first run (Dagger layer-caches subsequent runs to ~5 minutes).

#### What's included

**`local-dev/apps/openedx/Tiltfile`** — Integration entry point that:
- Locates the `lehrer` repo via `MITOL_WORKSPACE_ROOT` (or sibling-directory convention)
- Sets `LEHRER_*` globals for integrated mode: reuses ol-infra's Valkey and OpenSearch from `local-infra` namespace, deploys MySQL + MongoDB into `openedx` namespace
- Applies its own configmaps (pointing at Valkey/OpenSearch), then `include()`s `lehrer/local-dev/lehrer-core.star`
- Applies APISIX routes after lehrer-core.star runs

**`local-dev/apps/openedx/apisix-routes.yaml`** — `ApisixRoute` resources for:
- `lms.mit.dev` → LMS service port 8000
- `studio.mit.dev` → CMS service port 8010
- `notes.mit.dev` → edx-notes-api port 8000
- `mfe.mit.dev` → compiled MFE nginx port 80

**`local-dev/apps/openedx/configmaps/{lms,cms}-config.yaml`** — Django env vars for integrated mode:
- Redis: `valkey-primary.local-infra.svc.cluster.local` (ol-infra Valkey)
- OpenSearch: `opensearch-master.local-infra.svc.cluster.local` (ol-infra OpenSearch)
- MySQL/MongoDB: in `openedx` namespace (deployed by this integration's own Helm resources)

**`local-dev/apps/openedx/helm/{mysql,mongodb}-values.yaml`** — Ephemeral Helm deployments (no persistence) for the databases edx-platform needs that ol-infrastructure's shared infra doesn't provide.

**`Tiltfile`** — Adds `openedx` entry to the `APPS` list with three seed commands: `migrate`, `createsuperuser`, `collectstatic`.

#### Prerequisites

- The `lehrer` repo must be checked out at `$MITOL_WORKSPACE_ROOT/lehrer` (or as a sibling to `ol-infrastructure` if `MITOL_WORKSPACE_ROOT` isn't set)
- `local-infra-core` and `local-infra-apps` Pulumi stacks must be running (provides Valkey, OpenSearch, APISIX, TLS certs)
- The `openedx-secrets` K8s Secret must exist in the `openedx` namespace (created by `lehrer/local-dev/scripts/setup.sh` or manually)

### How can this be tested?

1. Check out lehrer alongside ol-infrastructure: `git clone https://github.com/mitodl/lehrer ../lehrer`
2. Ensure `local-infra-core` and `local-infra-apps` are up
3. Run: `tilt up -- --enabled_apps openedx`
4. Verify MySQL and MongoDB deploy into `openedx` namespace: `kubectl -n openedx get pods`
5. Verify APISIX routes are applied: `kubectl -n openedx get apisixroute`
6. Trigger the migrate seed command from Tilt UI and confirm it runs

### Additional Context

The integration Tiltfile gracefully degrades: if the `lehrer` repo isn't found at the expected path, it prints a warning and skips the openedx deployment rather than failing the whole stack.

The `openedx` entry uses `deploy_name: "lms"` (matching the K8s Deployment name) so Tilt's seed command exec targets the right pod.