### PR TITLE
fix: migrate Concourse to Let's Encrypt TLS and remove dangling wildcard cert policies

### DIFF
--- a/src/bilder/images/concourse/deploy.py
+++ b/src/bilder/images/concourse/deploy.py
@@ -222,22 +222,6 @@ vault_template_map = {
             ),
             destination=concourse_config.model_dump().get("authorized_keys_file"),
         ),
-        partial(
-            VaultTemplate,
-            contents=(
-                '{{ with secret "secret-operations/global/odl_wildcard_cert" }}'
-                "{{ printf .Data.value }}{{ end }}"
-            ),
-            destination=Path("/etc/traefik/odl_wildcard.cert"),
-        ),
-        partial(
-            VaultTemplate,
-            contents=(
-                '{{ with secret "secret-operations/global/odl_wildcard_cert" }}'
-                "{{ printf .Data.key }}{{ end }}"
-            ),
-            destination=Path("/etc/traefik/odl_wildcard.key"),
-        ),
     ],
     CONCOURSE_WORKER_NODE_TYPE: [
         partial(

--- a/src/bilder/images/concourse/files/traefik/dynamic_config.yaml
+++ b/src/bilder/images/concourse/files/traefik/dynamic_config.yaml
@@ -5,17 +5,15 @@ http:
     concourse-router:
       rule: Host("{{env "DOMAIN"}}")
       service: concourse-service
-      tls: {}
+      tls:
+        certResolver: letsencrypt_resolver
     concourse-healthcheck:
       rule: Path("/api/v1/info")
       service: concourse-service
-      tls: {}
+      tls:
+        certResolver: letsencrypt_resolver
   services:
     concourse-service:
       loadBalancer:
         servers:
         - url: http://localhost:8080
-tls:
-  certificates:
-  - certFile: /etc/traefik/odl_wildcard.cert
-    keyFile: /etc/traefik/odl_wildcard.key

--- a/src/bilder/images/concourse/files/traefik/static_config.yaml
+++ b/src/bilder/images/concourse/files/traefik/static_config.yaml
@@ -12,3 +12,10 @@ entryPoints:
 providers:
   file:
     filename: /etc/traefik/concourse.yaml
+certificatesResolvers:
+  letsencrypt_resolver:
+    acme:
+      email: odl-devops@mit.edu
+      storage: /etc/traefik/acme.json
+      dnsChallenge:
+        provider: route53

--- a/src/ol_infrastructure/applications/airbyte/airbyte_server_policy.hcl
+++ b/src/ol_infrastructure/applications/airbyte/airbyte_server_policy.hcl
@@ -1,7 +1,3 @@
-path "secret-operations/global/odl_wildcard_cert" {
-  capabilities = ["read"]
-}
-
 path "postgres-airbyte/creds/app" {
   capabilities = ["read"]
 }

--- a/src/ol_infrastructure/applications/celery_monitoring/celery_monitoring_server_policy.hcl
+++ b/src/ol_infrastructure/applications/celery_monitoring/celery_monitoring_server_policy.hcl
@@ -6,10 +6,6 @@ path "secret-celery-monitoring/data/*" {
   capabilities = ["read", "list"]
 }
 
-path "secret-operations/global/odl_wildcard_cert" {
-  capabilities = ["read"]
-}
-
 path "secret-operations/sso/leek" {
   capabilities = ["read"]
 }

--- a/src/ol_infrastructure/applications/concourse/concourse_policy.hcl
+++ b/src/ol_infrastructure/applications/concourse/concourse_policy.hcl
@@ -6,10 +6,6 @@ path "secret-concourse/*" {
   capabilities = ["read"]
 }
 
-path "secret-operations/global/odl_wildcard_cert" {
-  capabilities = ["read"]
-}
-
 path "secret-operations/sso/concourse" {
   capabilities = ["read"]
 }

--- a/src/ol_infrastructure/applications/tika/tika_server_policy.hcl
+++ b/src/ol_infrastructure/applications/tika/tika_server_policy.hcl
@@ -1,7 +1,3 @@
-path "secret-operations/global/odl_wildcard_cert" {
-  capabilities = ["read"]
-}
-
 path "secret-operations/production-apps/tika/access-token" {
   capabilities = ["read"]
 }

--- a/src/ol_infrastructure/infrastructure/vector_log_proxy/vector_log_proxy_policy.hcl
+++ b/src/ol_infrastructure/infrastructure/vector_log_proxy/vector_log_proxy_policy.hcl
@@ -2,10 +2,6 @@ path "secret-vector-log-proxy/*" {
   capabilities = ["read"]
 }
 
-path "secret-operations/global/odl_wildcard_cert" {
-  capabilities = ["read"]
-}
-
 path "sys/leases/renew" {
   capabilities = ["update"]
 }


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)

**Concourse — Let's Encrypt via Traefik ACME (DNS challenge)**

Replaces the manually-managed `*.odl.mit.edu` wildcard certificate in
Concourse with automated Let's Encrypt certificates managed entirely by
Traefik's ACME resolver. The Vault image already uses an identical
pattern; this change brings Concourse in line with it.

Changes to the Concourse Traefik config:
- `static_config.yaml` — adds a `certificatesResolvers.letsencrypt_resolver`
  block using the Route53 DNS challenge provider (the Concourse web IAM
  role already holds the `route53_odl_zone_records` policy, so no
  infrastructure change is required)
- `dynamic_config.yaml` — replaces the static `tls.certificates` block
  (which pointed at manually-placed cert/key files) with
  `certResolver: letsencrypt_resolver` on both routers; the cert and key
  files are gone entirely
- `deploy.py` — removes the two `VaultTemplate` entries that fetched
  `.Data.value` and `.Data.key` from
  `secret-operations/global/odl_wildcard_cert`
- `concourse_policy.hcl` — removes the `read` grant on
  `secret-operations/global/odl_wildcard_cert`

**Dangling wildcard cert policy grants — removed**

An audit of all Vault policy files found four services that held `read`
access to `secret-operations/global/odl_wildcard_cert` but had no
corresponding Vault Agent or Consul Template code that actually fetched
or wrote the cert. These dead grants have been removed:

| Service | Policy file |
|---|---|
| Airbyte | `applications/airbyte/airbyte_server_policy.hcl` |
| Tika | `applications/tika/tika_server_policy.hcl` |
| Celery Monitoring (Leek) | `applications/celery_monitoring/celery_monitoring_server_policy.hcl` |
| Vector Log Proxy | `infrastructure/vector_log_proxy/vector_log_proxy_policy.hcl` |

After this PR the only remaining consumer of the ODL wildcard cert
(via the legacy `secret-operations/global/odl_wildcard_cert` path) is
Redash, which is slated for retirement.

### How can this be tested?

1. Bake a new Concourse AMI with the updated `deploy.py` and confirm
   the build completes without errors (no Vault template errors for the
   removed paths).
2. Launch a Concourse web instance from the new AMI. Confirm:
   - Traefik starts cleanly and `/etc/traefik/acme.json` is created
   - The configured domain resolves over HTTPS with a valid Let's
     Encrypt certificate (not the ODL wildcard)
   - The HTTP → HTTPS redirect on port 80 continues to work
   - Concourse's `/api/v1/info` healthcheck is reachable
3. Confirm no vault-agent errors in logs related to `odl_wildcard_cert`
   for the four services whose policy grants were removed (Airbyte,
   Tika, Celery Monitoring, Vector Log Proxy).

### Additional Context

The Vault image (`src/bilder/images/vault/files/traefik/`) uses the
same `letsencrypt_resolver` + Route53 pattern and has been running in
production. The Concourse web role's existing `route53_odl_zone_records`
IAM attachment covers the permissions Traefik's Route53 provider needs
to complete the DNS-01 challenge — no IAM changes are required.