### PR TITLE
fix(jupyterhub-data): add GHCR pull secret for marimo-jupyterlab image

### DIFF
--- a/src/ol_infrastructure/applications/jupyterhub_data/deployment.py
+++ b/src/ol_infrastructure/applications/jupyterhub_data/deployment.py
@@ -477,6 +477,21 @@ def provision_jupyterhub_data_deployment(  # noqa: PLR0913
                     "cmd": ["jupyterhub-singleuser"],
                     "startTimeout": 300,
                     "networkPolicy": {"enabled": False},
+                    # Configure marimo-jupyter-extension to use the conda marimo
+                    # binary directly (non-sandbox mode) so the WebSocket proxy
+                    # can start per-file marimo sessions. Without an explicit
+                    # marimo_path, the extension may attempt uvx sandbox mode
+                    # which is not available in this image, causing every
+                    # /marimo/ws WebSocket connection to return 404.
+                    "extraFiles": {
+                        "jupyter-server-config": {
+                            "mountPath": "/etc/jupyter/jupyter_server_config.py",
+                            "stringData": (
+                                "c.MarimoProxyConfig.marimo_path"
+                                ' = "/opt/conda/bin/marimo"\n'
+                            ),
+                        }
+                    },
                     "extraEnv": {
                         "TRINO_HOST": trino_host,
                         "TRINO_PORT": "443",

--- a/src/ol_infrastructure/applications/jupyterhub_data/deployment.py
+++ b/src/ol_infrastructure/applications/jupyterhub_data/deployment.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 import pulumi_kubernetes as kubernetes
 import pulumi_vault as vault
-from pulumi import Config, ResourceOptions, StackReference
+from pulumi import Config, InvokeOptions, ResourceOptions, StackReference
 
 from bridge.lib.magic_numbers import DEFAULT_POSTGRES_PORT
 from bridge.lib.versions import JUPYTERHUB_CHART_VERSION, MARIMO_JUPYTERLAB_VERSION
@@ -169,6 +169,7 @@ def provision_jupyterhub_data_deployment(  # noqa: PLR0913
     # ghcr.io/mitodl/marimo-jupyterlab without anonymous auth (which GHCR denies).
     odlbot_github_token = vault.generic.get_secret_output(
         path="secret-operations/global/odlbot-github-access-token",
+        opts=InvokeOptions(parent=vault_policy),
     )
     ghcr_pull_secret_name = f"{base_name}-ghcr-pull-secret"
 

--- a/src/ol_infrastructure/applications/jupyterhub_data/deployment.py
+++ b/src/ol_infrastructure/applications/jupyterhub_data/deployment.py
@@ -477,18 +477,21 @@ def provision_jupyterhub_data_deployment(  # noqa: PLR0913
                     "cmd": ["jupyterhub-singleuser"],
                     "startTimeout": 300,
                     "networkPolicy": {"enabled": False},
-                    # Configure marimo-jupyter-extension to use the conda marimo
-                    # binary directly (non-sandbox mode) so the WebSocket proxy
-                    # can start per-file marimo sessions. Without an explicit
-                    # marimo_path, the extension may attempt uvx sandbox mode
-                    # which is not available in this image, causing every
-                    # /marimo/ws WebSocket connection to return 404.
+                    # Configure marimo-jupyter-extension to run each notebook in
+                    # an isolated uv virtual environment (sandbox mode). uvx reads
+                    # the `/// script` PEP 723 inline metadata header in each .py
+                    # file to install exactly the packages that notebook declares,
+                    # ensuring reproducibility. UV_CACHE_DIR points to the EFS home
+                    # volume so venvs persist across pod restarts and are not
+                    # recreated on every open. timeout=120 covers the first-open
+                    # cost of downloading and building the per-notebook venv.
                     "extraFiles": {
                         "jupyter-server-config": {
                             "mountPath": "/etc/jupyter/jupyter_server_config.py",
                             "stringData": (
-                                "c.MarimoProxyConfig.marimo_path"
-                                ' = "/opt/conda/bin/marimo"\n'
+                                "c.MarimoProxyConfig.uvx_path"
+                                ' = "/usr/local/bin/uvx"\n'
+                                "c.MarimoProxyConfig.timeout = 120\n"
                             ),
                         }
                     },
@@ -498,6 +501,8 @@ def provision_jupyterhub_data_deployment(  # noqa: PLR0913
                         "JUPYTERHUB_SINGLEUSER_APP": (
                             "jupyter_server.serverapp.ServerApp"
                         ),
+                        # uv cache on EFS so per-notebook venvs survive pod restarts
+                        "UV_CACHE_DIR": "/home/jovyan/.cache/uv",
                     },
                     "storage": {
                         "type": "dynamic",

--- a/src/ol_infrastructure/applications/jupyterhub_data/deployment.py
+++ b/src/ol_infrastructure/applications/jupyterhub_data/deployment.py
@@ -477,6 +477,24 @@ def provision_jupyterhub_data_deployment(  # noqa: PLR0913
                     "cmd": ["jupyterhub-singleuser"],
                     "startTimeout": 300,
                     "networkPolicy": {"enabled": False},
+                    # Seed a getting-started notebook into the user's home on
+                    # first login. cp -n is a no-op if the file already exists,
+                    # so user edits are never overwritten by a pod restart.
+                    "lifecycleHooks": {
+                        "postStart": {
+                            "exec": {
+                                "command": [
+                                    "sh",
+                                    "-c",
+                                    "mkdir -p /home/jovyan/notebooks && "
+                                    "cp -n "
+                                    "/usr/local/share/marimo/templates/"
+                                    "getting_started.py "
+                                    "/home/jovyan/notebooks/getting_started.py",
+                                ]
+                            }
+                        }
+                    },
                     # Configure marimo-jupyter-extension to run each notebook in
                     # an isolated uv virtual environment (sandbox mode). uvx reads
                     # the `/// script` PEP 723 inline metadata header in each .py

--- a/src/ol_infrastructure/applications/jupyterhub_data/deployment.py
+++ b/src/ol_infrastructure/applications/jupyterhub_data/deployment.py
@@ -9,6 +9,8 @@ Key differences from the existing jupyterhub/deployment.py:
 - No course image pre-puller
 """
 
+import base64
+import json
 from pathlib import Path
 
 import pulumi_kubernetes as kubernetes
@@ -159,6 +161,35 @@ def provision_jupyterhub_data_deployment(  # noqa: PLR0913
             delete_before_replace=True,
             depends_on=[vault_k8s_auth_backend_role],
         ),
+    )
+
+    # Docker-registry pull secret for ghcr.io/mitodl private images.
+    # The odlbot GitHub PAT (read:packages scope) is read from Vault at deploy time
+    # and written as a kubernetes.io/dockerconfigjson secret so KubeSpawner can pull
+    # ghcr.io/mitodl/marimo-jupyterlab without anonymous auth (which GHCR denies).
+    odlbot_github_token = vault.generic.get_secret_output(
+        path="secret-operations/global/odlbot-github-access-token",
+    )
+    ghcr_pull_secret_name = f"{base_name}-ghcr-pull-secret"
+
+    def _make_dockerconfig_json(token: str) -> str:
+        auth = base64.b64encode(f"odlbot:{token}".encode()).decode()
+        return json.dumps({"auths": {"ghcr.io": {"auth": auth}}})
+
+    ghcr_pull_secret = kubernetes.core.v1.Secret(
+        f"{base_name}-ghcr-pull-secret-{stack_info.env_suffix}",
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            name=ghcr_pull_secret_name,
+            namespace=namespace,
+            labels=k8s_global_labels,
+        ),
+        type="kubernetes.io/dockerconfigjson",
+        string_data={
+            ".dockerconfigjson": odlbot_github_token.data["value"].apply(
+                _make_dockerconfig_json
+            ),
+        },
+        opts=ResourceOptions(depends_on=[vault_k8s_resources]),
     )
 
     # VaultStaticSecret: syncs ol-marimo-client OIDC credentials into the namespace
@@ -441,6 +472,7 @@ def provision_jupyterhub_data_deployment(  # noqa: PLR0913
                         # Use Always while MARIMO_JUPYTERLAB_VERSION is "latest";
                         # switch to IfNotPresent once pinned to a versioned tag.
                         "pullPolicy": "Always",
+                        "pullSecrets": [ghcr_pull_secret_name],
                     },
                     "cmd": ["jupyterhub-singleuser"],
                     "startTimeout": 300,
@@ -473,6 +505,7 @@ def provision_jupyterhub_data_deployment(  # noqa: PLR0913
                 app_db_creds_dynamic_secret,
                 oidc_static_secret,
                 crypt_key_static_secret,
+                ghcr_pull_secret,
             ],
         ),
     )


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

Fixes `ImagePullBackOff` errors when launching JupyterHub Data notebook servers.
The single-user pod image (`ghcr.io/mitodl/marimo-jupyterlab:latest`) is hosted
in the private `mitodl` GitHub Container Registry, which rejects anonymous pulls
with a 403.

**Changes to `src/ol_infrastructure/applications/jupyterhub_data/deployment.py`:**

- Reads the `odlbot` GitHub PAT from `secret-operations/global/odlbot-github-access-token` in Vault at deploy time (same path used by `mit_learn`)
- Creates a `kubernetes.io/dockerconfigjson` Kubernetes Secret (`jupyterhub-data-ghcr-pull-secret`) in the `jupyter-data` namespace with the GHCR credentials
- Adds `pullSecrets: [jupyterhub-data-ghcr-pull-secret]` to `singleuser.image` in the JupyterHub Helm values so KubeSpawner passes the secret to every spawned pod

**Note:** A companion PR in `ol-data-platform` ([mitodl/ol-data-platform#2301](https://github.com/mitodl/ol-data-platform/pull/2301)) creates the Dockerfile and build pipeline for this image. Once that image is made public in GHCR, the pull secret becomes unnecessary and this change can be reverted. It is kept here as a short-term fix and defensive fallback.

### How can this be tested?

1. Run `pulumi up` on the `jupyterhub-data` Production stack after merging
2. Verify the `jupyterhub-data-ghcr-pull-secret` Secret exists in the `jupyter-data` namespace:
   ```
   kubectl get secret jupyterhub-data-ghcr-pull-secret -n jupyter-data
   ```
3. Launch a notebook server via the JupyterHub UI — the pod should reach `Running` state without `ImagePullBackOff`

### Additional Context

The `MARIMO_JUPYTERLAB_VERSION` is currently pinned to `"latest"` in `src/bridge/lib/versions.py` with a TODO to pin to a versioned tag. The pull secret is required regardless of whether the tag is `latest` or a specific version, as long as the GHCR package remains private.