### PR TITLE
grow redis for mit-learn production

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
@@ -114,6 +114,7 @@ config:
     UWSGI_WORKERS: 3
     YOUTUBE_CONFIG_URL: "https://raw.githubusercontent.com/mitodl/open-video-data/main/youtube/channels.yaml"
   mitlearn:zendesk_help_url: "mitlearn.zendesk.com"
+  redis:instance_type: "cache.r7g.xlarge"
   redis:password:
     secure: v1:xdJFi6D7NpeVwYrg:C0GQl3mctDO1+ehHcFAPdeJDuhk9PbuNdNGtghRNMlzP6GC/GCOyGS1V0ViUXwiO7JhAFD6zrstWmhg0X/yHQLnK8KA=
   vault:address: https://vault-production.odl.mit.edu


### PR DESCRIPTION
### Description (What does it do?)
fix: Grow the valkey instance for mit-learn production.
