### PR TITLE
Scale MITx Online Open edX Redis

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
@@ -139,7 +139,7 @@ config:
         memory_request: "4Gi"
         memory_limit: "6Gi"
   mongodb:atlas_project_id: 61f0a63f8bc1f86a073a7148
-  redis:instance_type: cache.r7g.2xlarge
+  redis:instance_type: cache.r7g.4xlarge
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production
   edxapp:edx_xqueue_secrets:


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Scales the MITx Online Open edX production Redis/Valkey ElastiCache replication group from `cache.r7g.2xlarge` to the next largest instance size, `cache.r7g.4xlarge`, to address high memory usage alerts.

### How can this be tested?
- `uv run pre-commit run --files src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml`
- `EDXAPP_DOCKER_IMAGE_DIGEST=sha256:d07dfc506521d852e4e2d9d6fd65b625fb167edc678640217052407bedf8a589 OPENEDX_RELEASE=master pulumi preview --stack mitxonline.Production --diff`

The Pulumi preview shows an in-place ElastiCache ReplicationGroup update:

```diff
~ nodeType: "cache.r7g.2xlarge" => "cache.r7g.4xlarge"
```

### Additional Context
The preview also shows unrelated pending provider/Kubernetes/configmap changes already present in the stack/code state; this PR's file diff only changes the Redis instance size.
