### PR TITLE
Improve Concourse spot worker robustness and stalled-worker pruning

### DIFF
--- a/src/bilder/images/concourse/deploy.py
+++ b/src/bilder/images/concourse/deploy.py
@@ -152,7 +152,7 @@ concourse_config_map = {
         enable_job_auditing=False,
         enable_pipeline_auditing=False,
         enable_resource_auditing=False,
-        enable_rerun_when_worker_disappears=False,
+        enable_rerun_when_worker_disappears=True,
         enable_system_auditing=False,
         enable_team_auditing=False,
         enable_volume_auditing=False,
@@ -244,9 +244,12 @@ vault_template_map = {
 }
 
 # Install Concourse
+# Web nodes need awscli + jq for the stalled-worker reaper; workers need awscli
+# for the spot/lifecycle drain helpers.
 install_baseline_packages(
     packages=["curl", "btrfs-progs"]
     + (["awscli"] if node_type == CONCOURSE_WORKER_NODE_TYPE else [])
+    + (["awscli", "jq"] if node_type == CONCOURSE_WEB_NODE_TYPE else [])
 )
 concourse_install_changed = install_concourse(concourse_base_config)
 concourse_config_changed = configure_concourse(concourse_config)
@@ -405,6 +408,43 @@ if host.get_fact(HasSystemd):
             ]
         )
         traefik_service(traefik_config=traefik_config, do_reload=traefik_config_changed)
+
+        # Install the stalled-worker reaper. It reconciles Concourse's worker
+        # registry against EC2 and prunes "stalled" workers whose instance is
+        # gone, recovering the cleanup behaviour of the `ephemeral` flag without
+        # its cache-wiping hair-trigger. Runs on a 3-minute systemd timer.
+        files.put(
+            name="Upload concourse-worker-reaper script",
+            src=str(FILES_DIRECTORY.joinpath("concourse-worker-reaper")),
+            dest="/usr/local/bin/concourse-worker-reaper",
+            user="root",
+            group="root",
+            mode="755",
+        )
+        reaper_unit_files = [
+            "concourse-worker-reaper.service",
+            "concourse-worker-reaper.timer",
+        ]
+        reaper_units_changed = False
+        for unit_file in reaper_unit_files:
+            result = files.put(
+                name=f"Upload {unit_file} systemd unit",
+                src=str(FILES_DIRECTORY.joinpath(unit_file)),
+                dest=f"/etc/systemd/system/{unit_file}",
+                user="root",
+                group="root",
+                mode="644",
+            )
+            reaper_units_changed = reaper_units_changed or result.changed
+        # Enable the timer (not the service directly); the timer triggers the
+        # oneshot service on its schedule.
+        systemd.service(
+            name="Enable and start concourse-worker-reaper timer",
+            service="concourse-worker-reaper.timer",
+            running=True,
+            enabled=True,
+            daemon_reload=reaper_units_changed,
+        )
     else:
         watched_concourse_files.extend(
             [

--- a/src/bilder/images/concourse/files/concourse-worker-reaper
+++ b/src/bilder/images/concourse/files/concourse-worker-reaper
@@ -79,19 +79,29 @@ LOCAL_USER_LINE=$(grep -E '^CONCOURSE_ADD_LOCAL_USER=' "${CONCOURSE_ENV_FILE}" |
 ADMIN_USER=${LOCAL_USER_LINE%%:*}
 ADMIN_PASS=${LOCAL_USER_LINE#*:}
 
-if ! "${FLY_BIN}" -t "${FLY_TARGET}" login \
-        -c "${ATC_URL}" -u "${ADMIN_USER}" -p "${ADMIN_PASS}" -n main >/dev/null 2>&1; then
-    fail "fly login to ${ATC_URL} failed; aborting (fail-closed)"
+# Reuse the cached token from a prior run when it is still valid; only perform a
+# fresh login when the cached token is missing or expired. fly caches per-target
+# in ~/.flyrc, so the steady-state cost across the 3-minute timer is one cheap
+# `workers` probe rather than a full login round-trip each run.
+if ! "${FLY_BIN}" -t "${FLY_TARGET}" workers >/dev/null 2>&1; then
+    if ! "${FLY_BIN}" -t "${FLY_TARGET}" login \
+            -c "${ATC_URL}" -u "${ADMIN_USER}" -p "${ADMIN_PASS}" -n main >/dev/null 2>&1; then
+        fail "fly login to ${ATC_URL} failed; aborting (fail-closed)"
+    fi
 fi
 
-# --- Gather ground truth: private IPs of all running worker instances -----
+# --- Gather ground truth: private IPs of all live worker instances --------
 # Worker names default to the EC2 hostname (e.g. "ip-10-1-2-3"), which encodes
 # the private IPv4 address. We compare each stalled worker's name against the
 # set of live worker instance IPs.
+#
+# Only "pending" and "running" count as live: an instance in stopping/
+# shutting-down is on its way out and will never host a recovering worker, so a
+# stalled worker pinned to it should be pruned, not preserved.
 LIVE_IPS=$(aws ec2 describe-instances \
     --region "${AWS_REGION}" \
     --filters "Name=tag:Name,Values=${WORKER_NAME_TAG}" \
-              "Name=instance-state-name,Values=pending,running,stopping,shutting-down" \
+              "Name=instance-state-name,Values=pending,running" \
     --query 'Reservations[].Instances[].PrivateIpAddress' \
     --output text 2>/dev/null) || fail "describe-instances failed; aborting (fail-closed)"
 
@@ -134,6 +144,12 @@ while IFS= read -r worker_name; do
 
     log "Worker '${worker_name}' (${worker_ip}) has no live instance; pruning"
     if "${FLY_BIN}" -t "${FLY_TARGET}" prune-worker -w "${worker_name}" >/dev/null 2>&1; then
+        pruned=$((pruned + 1))
+    elif ! "${FLY_BIN}" -t "${FLY_TARGET}" workers --json \
+            | jq -e --arg n "${worker_name}" 'any(.[]; .name == $n)' >/dev/null 2>&1; then
+        # The worker is already gone — a reaper on another web node won the race
+        # (each node runs this independently). That's the intended outcome, not an
+        # error, so count it as pruned and stay quiet.
         pruned=$((pruned + 1))
     else
         log "Warning: failed to prune worker '${worker_name}' (it may have changed state)"

--- a/src/bilder/images/concourse/files/concourse-worker-reaper
+++ b/src/bilder/images/concourse/files/concourse-worker-reaper
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Reconcile Concourse's worker registry against EC2 ground truth and prune
+# "stalled" workers whose backing instance no longer exists.
+#
+# Why this exists:
+#   When a spot worker is reclaimed (or its instance otherwise dies) without
+#   completing a graceful drain, the ATC marks it "stalled" but never deletes
+#   it. Stalled workers linger in the database, hold stale resource-cache
+#   references, and add build friction until manually pruned. The `ephemeral`
+#   worker flag would auto-delete them, but it deletes on a ~60-90s heartbeat
+#   gap — which, with our churning web/TSA fleet, wrongly wipes the volume
+#   cache of healthy-but-transiently-disconnected workers. See ADR / branch
+#   notes for the full analysis.
+#
+#   This reaper takes the safe middle path: it only prunes a stalled worker
+#   when EC2 confirms the instance is genuinely gone, so a worker that is
+#   merely partitioned (and will reconnect, restoring its cache for free) is
+#   never pruned.
+#
+# Safety properties:
+#   - Only ever prunes workers in the "stalled" state (never running/landing).
+#   - Only prunes when the worker's instance is confirmed absent from EC2.
+#   - Fails closed: any error querying EC2 or the ATC results in zero prunes.
+#
+# Environment overrides (optional):
+#   ATC_URL          - local ATC address (default: http://localhost:8080)
+#   CONCOURSE_ENV_FILE - path to env file holding CONCOURSE_ADD_LOCAL_USER
+#                        (default: /etc/default/concourse)
+#   FLY_BIN          - path to the fly binary (default: /usr/local/bin/fly)
+#   AWS_REGION       - region for EC2 queries (default: from IMDS)
+#   WORKER_NAME_TAG  - EC2 Name tag glob identifying worker instances
+#                      (default: concourse-worker-*)
+set -euo pipefail
+
+ATC_URL=${ATC_URL:-http://localhost:8080}
+CONCOURSE_ENV_FILE=${CONCOURSE_ENV_FILE:-/etc/default/concourse}
+FLY_BIN=${FLY_BIN:-/usr/local/bin/fly}
+FLY_TARGET=local-reaper
+WORKER_NAME_TAG=${WORKER_NAME_TAG:-concourse-worker-*}
+
+log() {
+    echo "[concourse-worker-reaper] $*" | systemd-cat -t concourse-worker-reaper -p info
+}
+
+fail() {
+    echo "[concourse-worker-reaper] $*" | systemd-cat -t concourse-worker-reaper -p err
+    exit 1
+}
+
+# --- Resolve region from IMDS if not provided -----------------------------
+get_imds_token() {
+    curl -s -X PUT "http://169.254.169.254/latest/api/token" \
+        -H "X-aws-ec2-metadata-token-ttl-seconds: 300" \
+        --connect-timeout 2 --max-time 5 2>/dev/null || echo ""
+}
+
+if [ -z "${AWS_REGION:-}" ]; then
+    IMDS_TOKEN=$(get_imds_token)
+    AWS_REGION=$(curl -s -H "X-aws-ec2-metadata-token: ${IMDS_TOKEN}" \
+        --connect-timeout 2 --max-time 5 \
+        "http://169.254.169.254/latest/meta-data/placement/region" 2>/dev/null || echo "")
+fi
+[ -n "${AWS_REGION}" ] || fail "Could not determine AWS region; aborting (fail-closed)"
+
+# --- Ensure a fly binary is available, version-matched to the ATC ---------
+if [ ! -x "${FLY_BIN}" ]; then
+    log "fly binary not found at ${FLY_BIN}; downloading from local ATC"
+    if ! curl -fsSL "${ATC_URL}/api/v1/cli?arch=amd64&platform=linux" -o "${FLY_BIN}.tmp"; then
+        fail "Failed to download fly from ${ATC_URL}; aborting (fail-closed)"
+    fi
+    chmod 0755 "${FLY_BIN}.tmp"
+    mv "${FLY_BIN}.tmp" "${FLY_BIN}"
+fi
+
+# --- Authenticate to the local ATC as the local admin user ----------------
+# CONCOURSE_ADD_LOCAL_USER is rendered into the env file as "user:password".
+LOCAL_USER_LINE=$(grep -E '^CONCOURSE_ADD_LOCAL_USER=' "${CONCOURSE_ENV_FILE}" | head -1 | cut -d= -f2-)
+[ -n "${LOCAL_USER_LINE}" ] || fail "CONCOURSE_ADD_LOCAL_USER not found in ${CONCOURSE_ENV_FILE}"
+ADMIN_USER=${LOCAL_USER_LINE%%:*}
+ADMIN_PASS=${LOCAL_USER_LINE#*:}
+
+if ! "${FLY_BIN}" -t "${FLY_TARGET}" login \
+        -c "${ATC_URL}" -u "${ADMIN_USER}" -p "${ADMIN_PASS}" -n main >/dev/null 2>&1; then
+    fail "fly login to ${ATC_URL} failed; aborting (fail-closed)"
+fi
+
+# --- Gather ground truth: private IPs of all running worker instances -----
+# Worker names default to the EC2 hostname (e.g. "ip-10-1-2-3"), which encodes
+# the private IPv4 address. We compare each stalled worker's name against the
+# set of live worker instance IPs.
+LIVE_IPS=$(aws ec2 describe-instances \
+    --region "${AWS_REGION}" \
+    --filters "Name=tag:Name,Values=${WORKER_NAME_TAG}" \
+              "Name=instance-state-name,Values=pending,running,stopping,shutting-down" \
+    --query 'Reservations[].Instances[].PrivateIpAddress' \
+    --output text 2>/dev/null) || fail "describe-instances failed; aborting (fail-closed)"
+
+# Normalize whitespace into a newline-delimited set for matching.
+LIVE_IP_SET=$(echo "${LIVE_IPS}" | tr '[:space:]' '\n' | grep -v '^$' || true)
+LIVE_COUNT=$(echo "${LIVE_IP_SET}" | grep -c . || true)
+log "Found ${LIVE_COUNT} live worker instance(s) in ${AWS_REGION}"
+
+# --- Identify stalled workers and prune the orphans -----------------------
+STALLED_WORKERS=$("${FLY_BIN}" -t "${FLY_TARGET}" workers --json \
+    | jq -r '.[] | select(.state == "stalled") | .name' 2>/dev/null || true)
+
+if [ -z "${STALLED_WORKERS}" ]; then
+    log "No stalled workers found; nothing to do"
+    exit 0
+fi
+
+pruned=0
+skipped=0
+while IFS= read -r worker_name; do
+    [ -n "${worker_name}" ] || continue
+
+    # Derive the private IP encoded in the hostname-style worker name.
+    # "ip-10-1-2-3" -> "10.1.2.3". Names that don't match are left alone.
+    if [[ "${worker_name}" =~ ^ip-([0-9]+)-([0-9]+)-([0-9]+)-([0-9]+) ]]; then
+        worker_ip="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}.${BASH_REMATCH[4]}"
+    else
+        log "Worker '${worker_name}' name is not IP-derived; skipping (cannot verify instance)"
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    if echo "${LIVE_IP_SET}" | grep -qxF "${worker_ip}"; then
+        # Instance still exists -> worker is partitioned, not dead. Leave it;
+        # it will reconnect and recover its cache for free.
+        log "Worker '${worker_name}' (${worker_ip}) instance still live; leaving stalled worker to recover"
+        skipped=$((skipped + 1))
+        continue
+    fi
+
+    log "Worker '${worker_name}' (${worker_ip}) has no live instance; pruning"
+    if "${FLY_BIN}" -t "${FLY_TARGET}" prune-worker -w "${worker_name}" >/dev/null 2>&1; then
+        pruned=$((pruned + 1))
+    else
+        log "Warning: failed to prune worker '${worker_name}' (it may have changed state)"
+    fi
+done <<< "${STALLED_WORKERS}"
+
+log "Reaper run complete: ${pruned} pruned, ${skipped} left in place"

--- a/src/bilder/images/concourse/files/concourse-worker-reaper.service
+++ b/src/bilder/images/concourse/files/concourse-worker-reaper.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Reconcile Concourse stalled workers against EC2 and prune orphans
+Documentation=https://concourse-ci.org/concourse-worker.html#worker-lifecycle
+After=concourse.service network-online.target
+Wants=network-online.target
+# Only meaningful on web nodes where the local ATC is reachable.
+ConditionPathExists=/etc/default/concourse
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/concourse-worker-reaper
+# The reaper fails closed; a non-zero exit just means "pruned nothing this run".
+# Don't let a transient failure mark the unit failed and spam alerts.
+SuccessExitStatus=0 1

--- a/src/bilder/images/concourse/files/concourse-worker-reaper.timer
+++ b/src/bilder/images/concourse/files/concourse-worker-reaper.timer
@@ -1,0 +1,17 @@
+[Unit]
+Description=Periodically reconcile Concourse stalled workers against EC2
+Documentation=https://concourse-ci.org/concourse-worker.html#worker-lifecycle
+
+[Timer]
+# Wait a bit after boot so the ATC is up and serving the API.
+OnBootSec=5min
+# Run every 3 minutes. A genuinely-dead worker is pruned within one interval
+# of EC2 reporting its instance gone, while a partitioned worker (instance
+# still live) is always left to reconnect.
+OnUnitActiveSec=3min
+# Spread runs across the web fleet so they don't all hammer the API at once.
+RandomizedDelaySec=60
+AccuracySec=30
+
+[Install]
+WantedBy=timers.target

--- a/src/bilder/images/concourse/files/concourse-worker-spot-watch
+++ b/src/bilder/images/concourse/files/concourse-worker-spot-watch
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
-# Poll the EC2 instance metadata service for a spot interruption notice.
-# When one is detected, immediately initiate a graceful concourse worker
-# retirement so running builds can complete before the instance is reclaimed.
+# Poll the EC2 instance metadata service for spot rebalance recommendations and
+# interruption notices. A rebalance recommendation (10-30 min warning) triggers
+# graceful retirement first; the interruption notice (2-min warning) is a fallback.
 set -euo pipefail
 
 POLL_INTERVAL=${POLL_INTERVAL:-5}
-TERMINATION_TIME_URL="http://169.254.169.254/latest/meta-data/spot/termination-time"
+METADATA_BASE="http://169.254.169.254/latest/meta-data"
+REBALANCE_URL="${METADATA_BASE}/events/recommendations/rebalance"
+TERMINATION_TIME_URL="${METADATA_BASE}/spot/termination-time"
 TOKEN_URL="http://169.254.169.254/latest/api/token"
 
 log() {
@@ -18,27 +20,39 @@ get_imds_token() {
         --connect-timeout 2 --max-time 5 2>/dev/null || echo ""
 }
 
+imds_status() {
+    local url="$1"
+    local token="$2"
+    if [ -n "${token}" ]; then
+        curl -s -o /dev/null -w "%{http_code}" \
+            -H "X-aws-ec2-metadata-token: ${token}" \
+            --connect-timeout 2 --max-time 5 \
+            "${url}" 2>/dev/null || echo "000"
+    else
+        curl -s -o /dev/null -w "%{http_code}" \
+            --connect-timeout 2 --max-time 5 \
+            "${url}" 2>/dev/null || echo "000"
+    fi
+}
+
 log "Starting spot interruption watch (poll interval: ${POLL_INTERVAL}s)"
 
 while true; do
     TOKEN=$(get_imds_token)
 
-    if [ -n "${TOKEN}" ]; then
-        HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-            -H "X-aws-ec2-metadata-token: ${TOKEN}" \
-            --connect-timeout 2 --max-time 5 \
-            "${TERMINATION_TIME_URL}" 2>/dev/null || echo "000")
-    else
-        HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-            --connect-timeout 2 --max-time 5 \
-            "${TERMINATION_TIME_URL}" 2>/dev/null || echo "000")
+    REBALANCE_CODE=$(imds_status "${REBALANCE_URL}" "${TOKEN}")
+    if [ "${REBALANCE_CODE}" = "200" ]; then
+        log "EC2 rebalance recommendation received — initiating early graceful worker retirement"
+        /usr/local/bin/concourse-worker-drain
+        log "Drain complete; waiting for OS shutdown or interruption"
+        sleep infinity
     fi
 
-    if [ "${HTTP_CODE}" = "200" ]; then
+    TERM_CODE=$(imds_status "${TERMINATION_TIME_URL}" "${TOKEN}")
+    if [ "${TERM_CODE}" = "200" ]; then
         log "Spot interruption notice detected — initiating graceful worker retirement"
         /usr/local/bin/concourse-worker-drain
         log "Drain complete; waiting for OS shutdown"
-        # Sleep indefinitely; systemd will stop this service when the OS shuts down.
         sleep infinity
     fi
 

--- a/src/bilder/images/concourse/files/concourse-worker-spot-watch
+++ b/src/bilder/images/concourse/files/concourse-worker-spot-watch
@@ -1,7 +1,18 @@
 #!/usr/bin/env bash
 # Poll the EC2 instance metadata service for spot rebalance recommendations and
-# interruption notices. A rebalance recommendation (10-30 min warning) triggers
-# graceful retirement first; the interruption notice (2-min warning) is a fallback.
+# interruption notices, and react appropriately to each:
+#
+#   - Rebalance recommendation (advisory, ~10-30 min lead time): the instance is
+#     at elevated risk of interruption but is NOT guaranteed to be reclaimed.
+#     Proactively mark it Unhealthy so the Auto Scaling Group replaces it through
+#     the existing termination lifecycle hook — that drains gracefully (up to
+#     10 min) AND launches a replacement, keeping desired capacity intact. This
+#     avoids both a risky last-second 2-minute drain and the capacity erosion of
+#     simply parking the worker.
+#
+#   - Interruption notice (authoritative, 2 min): AWS will reclaim the instance
+#     regardless, so drain immediately to let in-flight builds finish, then wait
+#     for the OS to shut down.
 set -euo pipefail
 
 POLL_INTERVAL=${POLL_INTERVAL:-5}
@@ -35,25 +46,56 @@ imds_status() {
     fi
 }
 
+imds_get() {
+    local path="$1"
+    local token="$2"
+    curl -s -H "X-aws-ec2-metadata-token: ${token}" \
+        --connect-timeout 2 --max-time 5 \
+        "${METADATA_BASE}/${path}" 2>/dev/null || echo ""
+}
+
+# Identity used to ask the ASG to replace this instance on a rebalance signal.
+TOKEN=$(get_imds_token)
+INSTANCE_ID=$(imds_get "instance-id" "${TOKEN}")
+REGION=$(imds_get "placement/region" "${TOKEN}")
+
+handle_rebalance() {
+    log "EC2 rebalance recommendation received"
+    if [ -n "${INSTANCE_ID}" ] && [ -n "${REGION}" ] && \
+       aws autoscaling set-instance-health \
+            --instance-id "${INSTANCE_ID}" \
+            --health-status Unhealthy \
+            --region "${REGION}" 2>/dev/null; then
+        log "Marked instance Unhealthy; ASG will drain via lifecycle hook and launch a replacement"
+    else
+        # Could not reach the ASG API (or no identity) — fall back to draining
+        # locally so in-flight builds still finish before any interruption.
+        log "set-instance-health unavailable; draining locally as a fallback"
+        /usr/local/bin/concourse-worker-drain
+    fi
+    # We've acted on the signal; stop watching so we don't repeatedly react to
+    # the (sticky) rebalance endpoint. systemd stops this service at shutdown.
+    sleep infinity
+}
+
+handle_interruption() {
+    log "Spot interruption notice detected — initiating graceful worker retirement"
+    /usr/local/bin/concourse-worker-drain
+    log "Drain complete; waiting for OS shutdown"
+    sleep infinity
+}
+
 log "Starting spot interruption watch (poll interval: ${POLL_INTERVAL}s)"
 
 while true; do
     TOKEN=$(get_imds_token)
 
-    REBALANCE_CODE=$(imds_status "${REBALANCE_URL}" "${TOKEN}")
-    if [ "${REBALANCE_CODE}" = "200" ]; then
-        log "EC2 rebalance recommendation received — initiating early graceful worker retirement"
-        /usr/local/bin/concourse-worker-drain
-        log "Drain complete; waiting for OS shutdown or interruption"
-        sleep infinity
+    if [ "$(imds_status "${REBALANCE_URL}" "${TOKEN}")" = "200" ]; then
+        handle_rebalance
     fi
 
-    TERM_CODE=$(imds_status "${TERMINATION_TIME_URL}" "${TOKEN}")
-    if [ "${TERM_CODE}" = "200" ]; then
-        log "Spot interruption notice detected — initiating graceful worker retirement"
-        /usr/local/bin/concourse-worker-drain
-        log "Drain complete; waiting for OS shutdown"
-        sleep infinity
+    if [ "$(imds_status "${TERMINATION_TIME_URL}" "${TOKEN}")" = "200" ]; then
+        handle_interruption
     fi
 
     sleep "${POLL_INTERVAL}"

--- a/src/bilder/images/concourse/templates/vector/concourse_logs.yaml
+++ b/src/bilder/images/concourse/templates/vector/concourse_logs.yaml
@@ -4,6 +4,9 @@ sources:
     type: journald
     include_units:
     - concourse
+    - concourse-worker-spot-watch
+    - concourse-worker-lifecycle-hook
+    - concourse-worker-reaper
 
 transforms:
   parse_concourse_logs:
@@ -24,10 +27,15 @@ transforms:
     inputs:
     - "parse_concourse_logs"
     source: |
-      # Drop all 'INFO' level messages
-      abort_match_info, err = (match_any(.level, [r'info']))
-      if abort_match_info {
-        abort
+      # For the concourse process itself, drop INFO to reduce volume —
+      # but keep all logs from the worker drain helper services since they
+      # are low-volume and operationally critical.
+      is_concourse_service = (.__SYSTEMD_UNIT == "concourse.service")
+      if is_concourse_service {
+        abort_match_info, err = (match_any(.level, [r'info']))
+        if abort_match_info {
+          abort
+        }
       }
 
   enrich_concourse_logs:

--- a/src/bilder/images/concourse/templates/vector/concourse_logs.yaml
+++ b/src/bilder/images/concourse/templates/vector/concourse_logs.yaml
@@ -30,7 +30,7 @@ transforms:
       # For the concourse process itself, drop INFO to reduce volume —
       # but keep all logs from the worker drain helper services since they
       # are low-volume and operationally critical.
-      is_concourse_service = (.__SYSTEMD_UNIT == "concourse.service")
+      is_concourse_service = (._SYSTEMD_UNIT == "concourse.service")
       if is_concourse_service {
         abort_match_info, err = (match_any(.level, [r'info']))
         if abort_match_info {

--- a/src/bilder/images/concourse/templates/vector/concourse_metrics.yaml
+++ b/src/bilder/images/concourse/templates/vector/concourse_metrics.yaml
@@ -26,8 +26,11 @@ transforms:
       if abort_name_match {
         abort
       }
-      ## Any metrics that match these prefixes will have the 'instance' label removed
-      remove_instance_label_match, err = match_any(.name, [r'^concourse_workers_.*'])
+      ## Cluster-state metrics have the same value on every web node (they reflect the
+      ## shared database). Strip the instance label so CloudWatch treats them as a
+      ## single aggregate time series rather than N per-host series, making alarm
+      ## thresholds straightforward.
+      remove_instance_label_match, err = match_any(.name, [r'^concourse_workers_.*', r'^concourse_builds_running$', r'^concourse_steps_waiting$', r'^concourse_jobs_scheduling$'])
       if remove_instance_label_match {
         del(.tags.instance)
       }

--- a/src/bilder/images/concourse/templates/vector/concourse_metrics.yaml
+++ b/src/bilder/images/concourse/templates/vector/concourse_metrics.yaml
@@ -26,11 +26,8 @@ transforms:
       if abort_name_match {
         abort
       }
-      ## Cluster-state metrics have the same value on every web node (they reflect the
-      ## shared database). Strip the instance label so CloudWatch treats them as a
-      ## single aggregate time series rather than N per-host series, making alarm
-      ## thresholds straightforward.
-      remove_instance_label_match, err = match_any(.name, [r'^concourse_workers_.*', r'^concourse_builds_running$', r'^concourse_steps_waiting$', r'^concourse_jobs_scheduling$'])
+      ## Any metrics that match these prefixes will have the 'instance' label removed
+      remove_instance_label_match, err = match_any(.name, [r'^concourse_workers_.*'])
       if remove_instance_label_match {
         del(.tags.instance)
       }

--- a/src/ol_infrastructure/applications/concourse/__main__.py
+++ b/src/ol_infrastructure/applications/concourse/__main__.py
@@ -17,8 +17,9 @@ from string import Template
 import pulumi_vault as vault
 import yaml
 from pulumi import Config, Output, export
-from pulumi_aws import ec2, get_caller_identity, iam, route53
+from pulumi_aws import cloudwatch, ec2, get_caller_identity, iam, route53
 from pulumi_aws.autoscaling import LifecycleHook
+from pulumi_aws.autoscaling import Policy as AutoscalingPolicy
 from pulumi_consul import Node, Service, ServiceCheckArgs
 
 from bridge.lib.magic_numbers import (
@@ -758,14 +759,14 @@ for worker_def in concourse_config.get_object("workers") or []:
     )
     ol_worker_target_group_config = OLTargetGroupConfig(
         vpc_id=ops_vpc_id,
-        health_check_interval=60,
+        health_check_interval=30,
         health_check_healthy_threshold=2,
         health_check_matcher="200",
         health_check_path="/",
         health_check_port=str(CONCOURSE_WORKER_HEALTHCHECK_PORT),
         health_check_protocol="HTTP",
         health_check_timeout=20,
-        health_check_unhealthy_threshold=5,
+        health_check_unhealthy_threshold=3,
         tags=aws_config.merged_tags({"Name": worker_name_tag}, worker_def["aws_tags"]),
     )
 
@@ -818,6 +819,76 @@ for worker_def in concourse_config.get_object("workers") or []:
         heartbeat_timeout=600,
         lifecycle_transition="autoscaling:EC2_INSTANCE_TERMINATING",
         name=f"concourse-worker-{worker_class_name}-{stack_info.env_suffix}-drain",
+    )
+
+    # ASG scaling policies driven by Concourse Prometheus metrics that Vector
+    # ships to CloudWatch (namespace = consul datacenter, e.g. "operations-production").
+    # Scale-out: add one instance when build steps are waiting for a worker for
+    # two consecutive 1-minute periods. Steps waiting > 0 means workers are saturated.
+    # Scale-in: remove one instance when the cluster has very few running builds
+    # sustained over 20 minutes AND we are above the minimum size.
+    scale_out_policy = AutoscalingPolicy(
+        f"concourse-worker-{worker_class_name}-{stack_info.env_suffix}-scale-out",
+        autoscaling_group_name=ol_worker_as_setup.auto_scale_group.name,
+        adjustment_type="ChangeInCapacity",
+        scaling_adjustment=1,
+        cooldown=300,
+        policy_type="SimpleScaling",
+    )
+    scale_in_policy = AutoscalingPolicy(
+        f"concourse-worker-{worker_class_name}-{stack_info.env_suffix}-scale-in",
+        autoscaling_group_name=ol_worker_as_setup.auto_scale_group.name,
+        adjustment_type="ChangeInCapacity",
+        scaling_adjustment=-1,
+        cooldown=600,
+        policy_type="SimpleScaling",
+    )
+
+    # concourse_steps_waiting is emitted by the web node's Prometheus endpoint and
+    # forwarded to CloudWatch by Vector. The metric has no dimensions that vary
+    # across worker classes — it reflects global cluster queue depth. A sustained
+    # non-zero value means at least one worker class should grow.
+    # Each worker ASG reacts independently so that specialist classes (ocw, infra)
+    # can scale without requiring every class to respond.
+    cloudwatch.MetricAlarm(
+        f"concourse-worker-{worker_class_name}-{stack_info.env_suffix}-steps-waiting",
+        name=f"concourse-{worker_class_name}-{stack_info.env_suffix}-steps-waiting",
+        namespace=consul_datacenter,
+        metric_name="concourse_steps_waiting",
+        statistic="Sum",
+        period=60,
+        evaluation_periods=2,
+        threshold=1,
+        comparison_operator="GreaterThanOrEqualToThreshold",
+        treat_missing_data="notBreaching",
+        alarm_description=(
+            f"Concourse build steps are waiting for a worker in the "
+            f"{worker_class_name} pool — scale out to reduce queue depth."
+        ),
+        alarm_actions=[scale_out_policy.arn],
+        ok_actions=[],
+    )
+
+    # Scale in when builds_running (cluster-wide) drops near zero for 20 minutes.
+    # Using a high evaluation_periods + cooldown prevents aggressive scale-in
+    # during brief idle gaps between pipeline runs.
+    cloudwatch.MetricAlarm(
+        f"concourse-worker-{worker_class_name}-{stack_info.env_suffix}-low-load",
+        name=f"concourse-{worker_class_name}-{stack_info.env_suffix}-low-load",
+        namespace=consul_datacenter,
+        metric_name="concourse_builds_running",
+        statistic="Average",
+        period=60,
+        evaluation_periods=20,
+        threshold=2,
+        comparison_operator="LessThanThreshold",
+        treat_missing_data="notBreaching",
+        alarm_description=(
+            f"Concourse cluster has very few active builds for 20 minutes — "
+            f"scale in {worker_class_name} workers to reduce cost."
+        ),
+        alarm_actions=[scale_in_policy.arn],
+        ok_actions=[],
     )
 
 

--- a/src/ol_infrastructure/applications/concourse/__main__.py
+++ b/src/ol_infrastructure/applications/concourse/__main__.py
@@ -17,9 +17,8 @@ from string import Template
 import pulumi_vault as vault
 import yaml
 from pulumi import Config, Output, export
-from pulumi_aws import cloudwatch, ec2, get_caller_identity, iam, route53
+from pulumi_aws import ec2, get_caller_identity, iam, route53
 from pulumi_aws.autoscaling import LifecycleHook
-from pulumi_aws.autoscaling import Policy as AutoscalingPolicy
 from pulumi_consul import Node, Service, ServiceCheckArgs
 
 from bridge.lib.magic_numbers import (
@@ -819,76 +818,6 @@ for worker_def in concourse_config.get_object("workers") or []:
         heartbeat_timeout=600,
         lifecycle_transition="autoscaling:EC2_INSTANCE_TERMINATING",
         name=f"concourse-worker-{worker_class_name}-{stack_info.env_suffix}-drain",
-    )
-
-    # ASG scaling policies driven by Concourse Prometheus metrics that Vector
-    # ships to CloudWatch (namespace = consul datacenter, e.g. "operations-production").
-    # Scale-out: add one instance when build steps are waiting for a worker for
-    # two consecutive 1-minute periods. Steps waiting > 0 means workers are saturated.
-    # Scale-in: remove one instance when the cluster has very few running builds
-    # sustained over 20 minutes AND we are above the minimum size.
-    scale_out_policy = AutoscalingPolicy(
-        f"concourse-worker-{worker_class_name}-{stack_info.env_suffix}-scale-out",
-        autoscaling_group_name=ol_worker_as_setup.auto_scale_group.name,
-        adjustment_type="ChangeInCapacity",
-        scaling_adjustment=1,
-        cooldown=300,
-        policy_type="SimpleScaling",
-    )
-    scale_in_policy = AutoscalingPolicy(
-        f"concourse-worker-{worker_class_name}-{stack_info.env_suffix}-scale-in",
-        autoscaling_group_name=ol_worker_as_setup.auto_scale_group.name,
-        adjustment_type="ChangeInCapacity",
-        scaling_adjustment=-1,
-        cooldown=600,
-        policy_type="SimpleScaling",
-    )
-
-    # concourse_steps_waiting is emitted by the web node's Prometheus endpoint and
-    # forwarded to CloudWatch by Vector. The metric has no dimensions that vary
-    # across worker classes — it reflects global cluster queue depth. A sustained
-    # non-zero value means at least one worker class should grow.
-    # Each worker ASG reacts independently so that specialist classes (ocw, infra)
-    # can scale without requiring every class to respond.
-    cloudwatch.MetricAlarm(
-        f"concourse-worker-{worker_class_name}-{stack_info.env_suffix}-steps-waiting",
-        name=f"concourse-{worker_class_name}-{stack_info.env_suffix}-steps-waiting",
-        namespace=consul_datacenter,
-        metric_name="concourse_steps_waiting",
-        statistic="Sum",
-        period=60,
-        evaluation_periods=2,
-        threshold=1,
-        comparison_operator="GreaterThanOrEqualToThreshold",
-        treat_missing_data="notBreaching",
-        alarm_description=(
-            f"Concourse build steps are waiting for a worker in the "
-            f"{worker_class_name} pool — scale out to reduce queue depth."
-        ),
-        alarm_actions=[scale_out_policy.arn],
-        ok_actions=[],
-    )
-
-    # Scale in when builds_running (cluster-wide) drops near zero for 20 minutes.
-    # Using a high evaluation_periods + cooldown prevents aggressive scale-in
-    # during brief idle gaps between pipeline runs.
-    cloudwatch.MetricAlarm(
-        f"concourse-worker-{worker_class_name}-{stack_info.env_suffix}-low-load",
-        name=f"concourse-{worker_class_name}-{stack_info.env_suffix}-low-load",
-        namespace=consul_datacenter,
-        metric_name="concourse_builds_running",
-        statistic="Average",
-        period=60,
-        evaluation_periods=20,
-        threshold=2,
-        comparison_operator="LessThanThreshold",
-        treat_missing_data="notBreaching",
-        alarm_description=(
-            f"Concourse cluster has very few active builds for 20 minutes — "
-            f"scale in {worker_class_name} workers to reduce cost."
-        ),
-        alarm_actions=[scale_in_policy.arn],
-        ok_actions=[],
     )
 
 

--- a/src/ol_infrastructure/applications/concourse/iam_policies/base.py
+++ b/src/ol_infrastructure/applications/concourse/iam_policies/base.py
@@ -25,7 +25,10 @@ policy_definition = {
         },
         {
             "Effect": "Allow",
-            "Action": ["autoscaling:CompleteLifecycleAction"],
+            "Action": [
+                "autoscaling:CompleteLifecycleAction",
+                "autoscaling:SetInstanceHealth",
+            ],
             "Resource": "arn:aws:autoscaling:*:*:autoScalingGroup:*:autoScalingGroupName/concourse-worker-*",  # noqa: E501
         },
     ],


### PR DESCRIPTION
### What are the relevant tickets?
N/A — internal reliability work. Includes an upstream Concourse feature request filed as part of this effort: https://github.com/concourse/concourse/issues/9603

### Description (What does it do?)
Strengthens Concourse worker resilience on spot-instance ASGs, focused on two things: **graceful worker lifecycle handling** and **automatic cleanup of stalled workers** — *without* using the `ephemeral` worker flag.

> **Scope note:** an earlier revision of this PR also added CloudWatch-driven autoscaling. That was removed after review (the alarms declared no dimensions while Vector publishes the metrics *with* dimensions, so they never fired, and the design conflated two concerns). Autoscaling will be revisited separately. This PR is now purely worker robustness + pruning.

**Why not `ephemeral`?** Tracing the upstream code confirmed it's a poor fit. `ephemeral=true` deletes the worker DB row ~60–90s after a heartbeat gap (TTL = `heartbeat-interval * 2` = 60s, + 30s GC). Every worker-scoped table (`containers`, `volumes`, `worker_base_resource_types`, `worker_task_caches`, `worker_resource_caches`) is `ON DELETE CASCADE` on `workers(name)`, so deletion wipes the worker's volume-locality cache. But the worker→TSA keepalive timeout is hardcoded to 5 minutes ([`tsa/client.go`](https://github.com/concourse/concourse/blob/master/tsa/client.go)), so on an unclean disconnect a *healthy* worker is deleted and cache-wiped before it even notices the dead tunnel. With our web/TSA fleet recycling every 24h, that causes routine cache thrash. A `stalled` worker, by contrast, recovers for free — `HeartbeatWorker` maps `stalled → running` on reconnect with its cache intact. The only thing missing is cleanup of workers that *never* come back, which the reaper below provides.

**Worker lifecycle / robustness**
- **spot-watch — two signals, two responses:**
  - *Rebalance recommendation* (advisory, ~10–30 min lead): mark the instance **Unhealthy** so the ASG drains it through the existing termination lifecycle hook (graceful, up to 10 min) **and launches a replacement**, keeping desired capacity intact and getting ahead of a forced interruption. Falls back to a local drain if the ASG API is unreachable.
  - *Interruption notice* (authoritative, 2 min): drain in place immediately, then wait for shutdown.
- **`enable_rerun_when_worker_disappears=True`**: builds on a vanished spot worker retry on another worker instead of hanging.
- **Stalled-worker reaper** (new): a systemd timer on the web nodes that reconciles Concourse's worker registry against EC2 and prunes a `stalled` worker **only when EC2 confirms its backing instance is gone** (states `pending`/`running` count as live; `stopping`/`shutting-down` do not). This recovers `ephemeral`'s cleanup behaviour without its cache-wiping hair-trigger — a partitioned-but-alive worker is never pruned, so it reconnects and keeps its cache. Fails closed (any EC2/ATC error prunes nothing); reuses the cached `fly` token between runs; treats an already-pruned worker (a peer reaper won the race) as success rather than a warning.
- **Faster ALB health checks** on workers: interval 60s→30s, unhealthy threshold 5→3, cutting dead-worker detection from ~5 min to ~90s.

**Observability**
- Ship `spot-watch`, `lifecycle-hook`, and `reaper` unit logs to Grafana Loki, and fix the INFO-drop filter (`._SYSTEMD_UNIT`) so high-volume INFO logs from `concourse.service` are dropped as intended while the low-volume helper logs are kept.

**IAM:** adds `autoscaling:SetInstanceHealth` to the worker base policy (scoped to `concourse-worker-*` ASGs) for the rebalance→replace path. The web role already has `ec2:DescribeInstances` (via `describe_instances`) used by the reaper; no other IAM changes.

### How can this be tested?
Builds new `concourse-web-*` and `concourse-worker-*` AMIs and applies the Pulumi `applications.concourse` stack. After deploy:

**Reaper (web nodes)**
- `systemctl list-timers concourse-worker-reaper.timer` shows it scheduled (~every 3 min); `journalctl -u concourse-worker-reaper.service` shows runs reporting live-instance counts and `pruned/left in place`.
- Terminate a worker instance out-of-band (simulating a hard spot kill that skips drain); within a few minutes the now-`stalled` worker is auto-pruned (`fly workers` no longer lists it). A worker whose instance is still running is never pruned.

**Spot lifecycle**
- On a worker, `journalctl -u concourse-worker-spot-watch`. Simulate/observe a rebalance recommendation → the instance is marked Unhealthy and the ASG replaces it (new instance launched, desired capacity unchanged). On an interruption notice it drains in place via `concourse-worker-drain`.

**Logs**
- Confirm in Grafana that `concourse.service` INFO logs are absent while `concourse-worker-spot-watch` / `-reaper` / `-lifecycle-hook` logs appear.

### Additional Context
- Worker names default to the EC2 hostname (`ip-a-b-c-d`), which the reaper parses to a private IP and matches against running worker instances. A more robust join key would be `CONCOURSE_NAME=<instance-id>` set in worker cloud-init — deferred to a fast-follow to avoid changing worker-naming semantics (and the one-time re-registration churn) in this PR.
- The reaper currently runs independently on every web node and is safe to do so (idempotent; peer races are treated as success). A single-actor design (leader election) is a possible future refinement.
- The reaper is the local stopgap for the upstream gap in https://github.com/concourse/concourse/issues/9603 (a native `--worker-stall-timeout`). If that lands upstream, the reaper can be retired.