### PR TITLE
Fix Keycloak OIDC private_key_jwt provider validation

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/oidc_helpers.py
+++ b/src/ol_infrastructure/substructure/keycloak/oidc_helpers.py
@@ -1,3 +1,5 @@
+"""Helpers for configuring Keycloak OIDC identity providers."""
+
 import logging
 from typing import Any
 
@@ -82,5 +84,10 @@ def oidc_identity_provider_args_from_discovery_url(
         ):
             msg = f"OIDC provider at {discovery_url} does not support private_key_jwt client auth method"  # noqa: E501
             raise RuntimeError(msg)
+        # pulumi-keycloak >=6.12.0 marks client_secret/client_secret_wo as
+        # required even when Keycloak is configured for private_key_jwt client
+        # authentication. Provide an explicit empty value to satisfy provider
+        # schema validation without configuring shared-secret authentication.
+        oidc_idp_args["client_secret"] = ""
         oidc_idp_args["extra_config"] = {"clientAuthMethod": "private_key_jwt"}
     return oidc_idp_args


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Fixes the Keycloak substructure Production pipeline failure for OIDC identity providers that use `private_key_jwt` authentication and do not have a shared client secret configured.

After the `pulumi-keycloak` provider update, `keycloak:oidc:IdentityProvider` schema validation requires one of `client_secret` or `client_secret_wo`, even when the IdP is configured with `extra_config.clientAuthMethod = private_key_jwt`. The HAEF organization IdP hit this validation error:

```text
Missing required argument. "client_secret": one of `client_secret,client_secret_wo` must be specified.
Missing required argument. "client_secret_wo": one of `client_secret,client_secret_wo` must be specified.
```

This change explicitly passes an empty `client_secret` for `private_key_jwt` OIDC providers so provider schema validation succeeds without changing the Keycloak client authentication method.

### How can this be tested?
Validation run locally:

```bash
uv run ruff format src/ol_infrastructure/substructure/keycloak/oidc_helpers.py
uv run ruff check src/ol_infrastructure/substructure/keycloak/oidc_helpers.py
uv run mypy src/ol_infrastructure/substructure/keycloak/oidc_helpers.py
uv run pre-commit run --files src/ol_infrastructure/substructure/keycloak/oidc_helpers.py
pulumi preview --stack Production --non-interactive
```

The Production preview no longer reports the missing `client_secret` / `client_secret_wo` error for `ol-apps-HAEF-oidc-idp`. The preview still shows unrelated pre-existing LDAP replacement changes.
