### PR TITLE
fix(ocw): extend Fastly backend conditions for shielding compatibility

### DIFF
--- a/src/ol_infrastructure/applications/ocw_site/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_site/__main__.py
@@ -968,13 +968,15 @@ for purpose in ("draft", "live", "test"):
                 name="not course media or old akamai",
                 statement=(
                     'req.url.path !~ "^/coursemedia" && req.url.path !~ "^/ans\\d+"'
+                    ' && req.url.path !~ "^/largefiles" && req.url.path !~ "^/zipfiles"'
                 ),
                 type="REQUEST",
             ),
             fastly.ServiceVclConditionArgs(
                 name="is old Akamai file",
                 statement=(
-                    'req.url.path ~ "^/ans\\d+" && req.url.path !~'
+                    '(req.url.path ~ "^/ans\\d+" || req.url.path ~ "^/largefiles"'
+                    ' || req.url.path ~ "^/zipfiles") && req.url.path !~'
                     ' "/ans7870/21f/21f.027"'
                 ),
                 type="REQUEST",


### PR DESCRIPTION
### What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/11810

### Description (What does it do?)

When Fastly shielding is enabled (enabled in production via [commit 4d5e009](https://github.com/mitodl/ol-infrastructure/commit/4d5e009973362ed29cad8f6bcd23685228ba1ef2), May 19 2026), the edge POP's `vcl_miss` snippet (`s3_bucket_proxying.vcl`) rewrites `bereq.url` from `/ans7870/…` → `/largefiles/…` and `/ans15436/…` → `/zipfiles/…` **before** forwarding to the shield POP (iad-va-us). The shield POP receives the already-rewritten URL as `req.url` and re-evaluates the Fastly backend `request_condition` expressions against it.

The previous conditions only matched `^/ans\d+`, so `/largefiles/…` and `/zipfiles/…` paths at the shield fell through to `WebsiteBucket` (`ocw-content-live-production`) instead of `OCWWebsiteStorageBucket` (`ocw-website-storage`) — where the files actually live — causing 404s for all `/ans7870/` and `/ans15436/` URLs on cache misses.

This explains the "works on MIT campus, fails externally" symptom: edge POPs with warm cache from before shielding was enabled still serve correctly; all cold-cache requests through the shield misrouted.

**Fix:** extend both backend conditions to also match `^/largefiles` and `^/zipfiles`, so the shield selects the correct backend. The miss snippet's `regsub` rules have no effect on already-rewritten paths, preventing double-rewriting.

### How can this be tested?

1. Deploy to QA and confirm `/ans7870/` URLs (e.g. `https://test.ocw.mit.edu/ans7870/16/16.unified/propulsionS04/UnifiedPropulsion8/UnifiedPropulsion8.htm`) return 200 after a Fastly cache purge.
2. Confirm `/courses/` and other non-Akamai URLs are unaffected.
3. After deploying to production, purge affected URLs from Fastly cache (or wait for TTL expiry) and confirm they resolve.

### Additional Context

The specific URLs reported as broken in the linked issue are all under `/ans7870/16/16.unified/` (thermodynamics and propulsion reading materials for course 16.01 Unified Engineering). The S3 object at `s3://ocw-website-storage/largefiles/16/16.unified/propulsionS04/UnifiedPropulsion8/UnifiedPropulsion8.htm` returns HTTP 200 for anonymous requests, confirming the file exists and is publicly readable — the fault is purely in Fastly's routing at the shield tier.

Note: the existing exception `!~ "/ans7870/21f/21f.027"` in the "is old Akamai file" condition continues to work for the original `/ans7870/21f/21f.027/…` paths at the edge. For the rewritten `/largefiles/21f/21f.027/…` variant the exception does not apply (the literal string `/ans7870/21f/21f.027` is absent), so those paths now route to `OCWWebsiteStorageBucket` at the shield — which is the same behavior the edge already produces.