### PR TITLE
fix: fix MKTG ROOT url for learn

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -342,7 +342,7 @@ def _build_interpolated_config_dict(
                     f"https://{edxapp_config.require('mit_learn_api_domain')}/logout",
                 ],
                 "MKTG_URLS": {
-                    "ROOT": f"https://{marketing_domain}/",
+                    "ROOT": f"https://{edxapp_config.require('mit_learn_domain')}/",
                 },
                 "MKTG_URL_OVERRIDES": {
                     "TOS": f"https://{edxapp_config.require('mit_learn_domain')}/terms",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11838

### Description (What does it do?)
This pull request makes a minor update to the edX app Kubernetes config map generation logic by ensuring that the marketing root URL uses the correct domain. This change helps maintain consistency in domain usage across the application configuration.

- Configuration Update:
  * Changed the `MKTG_URLS["ROOT"]` value in the `_build_interpolated_config_dict` function to use the domain from `mit_learn_domain` instead of `marketing_domain` in `k8s_configmaps.py`.