### PR TITLE
feat(concourse): grant generic worker ECR push permissions

### DIFF
--- a/src/ol_infrastructure/applications/concourse/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/concourse/Pulumi.Production.yaml
@@ -68,6 +68,7 @@ config:
     disk_size_gb: 500
     iam_policies:
     - base
+    - ecr_push
     - operations
     instance_type: m7a.xlarge
     name: generic

--- a/src/ol_infrastructure/applications/concourse/iam_policies/ecr_push.py
+++ b/src/ol_infrastructure/applications/concourse/iam_policies/ecr_push.py
@@ -1,5 +1,7 @@
 from ol_infrastructure.lib.aws.iam_helper import IAM_POLICY_VERSION
 
+# AWS Permissions Document
+# Allow Concourse workers to push images to ECR repositories under mitodl/*.
 policy_definition = {
     "Version": IAM_POLICY_VERSION,
     "Statement": [

--- a/src/ol_infrastructure/applications/concourse/iam_policies/ecr_push.py
+++ b/src/ol_infrastructure/applications/concourse/iam_policies/ecr_push.py
@@ -1,0 +1,23 @@
+from ol_infrastructure.lib.aws.iam_helper import IAM_POLICY_VERSION
+
+policy_definition = {
+    "Version": IAM_POLICY_VERSION,
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "ecr:GetAuthorizationToken",
+            "Resource": "*",
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:CompleteLayerUpload",
+                "ecr:InitiateLayerUpload",
+                "ecr:PutImage",
+                "ecr:UploadLayerPart",
+            ],
+            "Resource": "arn:aws:ecr:*:*:repository/mitodl/*",
+        },
+    ],
+}


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
The Concourse generic worker was failing to push container images to ECR with:

```
DENIED: User: arn:aws:sts::610119931565:assumed-role/concourse-instance-role-worker-generic-production-.../i-0ad2a8fb0816ea31f is not authorized to perform: ecr:InitiateLayerUpload on resource: arn:aws:ecr:us-east-1:610119931565:repository/mitodl/concourse-npm-resource because no identity-based policy allows the ecr:InitiateLayerUpload action
```

Adds a new `ecr_push` IAM policy module that grants the five ECR push actions (`BatchCheckLayerAvailability`, `CompleteLayerUpload`, `InitiateLayerUpload`, `PutImage`, `UploadLayerPart`) scoped to `arn:aws:ecr:*:*:repository/mitodl/*`, plus `ecr:GetAuthorizationToken` on `*`. Wires it into the generic worker's `iam_policies` list in `Pulumi.Production.yaml`.

### How can this be tested?
1. Run `pulumi up` on the `concourse` Production stack — verify a new `cicd-iam-permissions-policy-ecr_push-production` policy and `RolePolicyAttachment` are created for the generic worker role.
2. Trigger a Concourse pipeline that pushes to an `mitodl/*` ECR repository from a generic worker and confirm the push succeeds.

### Additional Context
The `ecr_push` policy module follows the same pattern as the other modules in `src/ol_infrastructure/applications/concourse/iam_policies/`. The resource scope (`mitodl/*`) limits push access to our org's ECR namespace rather than all repositories in the account.