### PR TITLE
feat(apisix): enable OpenTelemetry trace export to Grafana Cloud

### DIFF
--- a/src/ol_infrastructure/components/services/apisix.py
+++ b/src/ol_infrastructure/components/services/apisix.py
@@ -11,6 +11,7 @@ from ol_infrastructure.components.services.vault import (
     OLVaultK8SSecret,
     OLVaultK8SStaticSecretConfig,
 )
+from ol_infrastructure.lib.pulumi_helper import parse_stack
 
 
 class OLApisixPluginConfig(BaseModel):
@@ -315,6 +316,13 @@ class OLApisixSharedPluginsConfig(BaseModel):
     application_name: str
     resource_suffix: str = "shared-plugins"
     enable_defaults: bool = True
+    # Attach the opentelemetry plugin (OTLP trace export) to every route that
+    # references this shared plugin config.  Automatically disabled on CI, where
+    # the plugin is not loaded into APISIX and the Grafana Alloy collector does
+    # not exist (see infrastructure/aws/eks/apisix_official.py).  A route that
+    # references a plugin APISIX has not loaded is rejected, so the route-level
+    # attachment must be gated to match the cluster-level plugin enablement.
+    enable_opentelemetry: bool = True
     k8s_labels: dict[str, str] = {}
     k8s_namespace: str
     plugins: list[dict[str, Any]] = []
@@ -385,10 +393,31 @@ class OLApisixSharedPlugins(ComponentResource):
             },
         ]
 
+        # opentelemetry emits an OTLP trace span per request.  ``always_on`` head
+        # sampling exports every span to the Grafana Alloy receiver, which then
+        # applies tail sampling (keep errors, keep slow traces, probabilistic
+        # remainder) before forwarding to Grafana Cloud (see grafana.py).  The
+        # collector address and resource attributes are set cluster-wide via the
+        # plugin's plugin_attr block in apisix_official.py.
+        __opentelemetry_plugin: dict[str, Any] = {
+            "name": "opentelemetry",
+            "enable": True,
+            "config": {"sampler": {"name": "always_on"}},
+        }
+
         resource_options = ResourceOptions(parent=self).merge(opts)
 
         if plugin_config.enable_defaults:
             plugin_config.plugins.extend(__default_plugins)
+
+        # Gate on CI to match the cluster-level plugin enablement: APISIX does not
+        # load the opentelemetry plugin on CI, so attaching it to a route there
+        # would cause the route config to be rejected.
+        if (
+            plugin_config.enable_opentelemetry
+            and parse_stack().env_suffix.lower() != "ci"
+        ):
+            plugin_config.plugins.append(__opentelemetry_plugin)
 
         self.resource_name = (
             f"{plugin_config.application_name}-{plugin_config.resource_suffix}"

--- a/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
@@ -19,6 +19,122 @@ from ol_infrastructure.lib.aws.eks_helper import (
 from ol_infrastructure.lib.ol_types import AWSBase
 from ol_infrastructure.lib.pulumi_helper import StackInfo
 
+# APISIX's default enabled-plugins list for the version shipped by the pinned
+# chart (chart 2.12.x => APISIX 3.14.x), extracted verbatim from
+# https://github.com/apache/apisix/blob/3.14.0/apisix/cli/config.lua
+#
+# Setting ``apisix.plugins`` in the Helm values REPLACES this default list
+# rather than extending it, so the full list must be reproduced here.  We do
+# this solely to add ``opentelemetry`` (which is NOT enabled by default) without
+# silently dropping any plugin that applications already rely on.
+#
+# IMPORTANT: revisit this list on every APISIX major/minor upgrade.  If it
+# drifts from the APISIX default for the running version, plugins omitted here
+# will stop loading.  ``opentelemetry`` is appended at the end below.
+APISIX_DEFAULT_PLUGINS_3_14: list[str] = [
+    "real-ip",
+    "ai",
+    "client-control",
+    "proxy-control",
+    "request-id",
+    "zipkin",
+    "ext-plugin-pre-req",
+    "fault-injection",
+    "mocking",
+    "serverless-pre-function",
+    "cors",
+    "ip-restriction",
+    "ua-restriction",
+    "referer-restriction",
+    "csrf",
+    "uri-blocker",
+    "request-validation",
+    "chaitin-waf",
+    "multi-auth",
+    "openid-connect",
+    "cas-auth",
+    "authz-casbin",
+    "authz-casdoor",
+    "wolf-rbac",
+    "ldap-auth",
+    "hmac-auth",
+    "basic-auth",
+    "jwt-auth",
+    "jwe-decrypt",
+    "key-auth",
+    "consumer-restriction",
+    "attach-consumer-label",
+    "forward-auth",
+    "opa",
+    "authz-keycloak",
+    "proxy-cache",
+    "body-transformer",
+    "ai-prompt-template",
+    "ai-prompt-decorator",
+    "ai-prompt-guard",
+    "ai-rag",
+    "ai-rate-limiting",
+    "ai-proxy-multi",
+    "ai-proxy",
+    "ai-aws-content-moderation",
+    "ai-aliyun-content-moderation",
+    "proxy-mirror",
+    "proxy-rewrite",
+    "workflow",
+    "api-breaker",
+    "limit-conn",
+    "limit-count",
+    "limit-req",
+    "gzip",
+    "traffic-split",
+    "redirect",
+    "response-rewrite",
+    "mcp-bridge",
+    "degraphql",
+    "kafka-proxy",
+    "grpc-transcode",
+    "grpc-web",
+    "http-dubbo",
+    "public-api",
+    "prometheus",
+    "datadog",
+    "lago",
+    "loki-logger",
+    "elasticsearch-logger",
+    "echo",
+    "loggly",
+    "http-logger",
+    "splunk-hec-logging",
+    "skywalking-logger",
+    "google-cloud-logging",
+    "sls-logger",
+    "tcp-logger",
+    "kafka-logger",
+    "rocketmq-logger",
+    "syslog",
+    "udp-logger",
+    "file-logger",
+    "clickhouse-logger",
+    "tencent-cloud-cls",
+    "inspect",
+    "example-plugin",
+    "aws-lambda",
+    "azure-functions",
+    "openwhisk",
+    "openfunction",
+    "serverless-post-function",
+    "ext-plugin-post-req",
+    "ext-plugin-post-resp",
+    "ai-request-rewrite",
+]
+
+# Full enabled-plugins list applied via the Helm chart: APISIX defaults plus the
+# opentelemetry plugin, which emits OTLP traces (not metrics) for every request.
+APISIX_ENABLED_PLUGINS: list[str] = [
+    *APISIX_DEFAULT_PLUGINS_3_14,
+    "opentelemetry",
+]
+
 
 def setup_apisix(
     cluster_name: str,
@@ -73,6 +189,13 @@ def setup_apisix(
     # APISIX chart uses a different chart version scheme
     # Chart version 2.12.x contains APISIX 3.14.x
     apisix_chart_version = versions["APISIX_CHART"]
+
+    # OpenTelemetry tracing is exported to the in-cluster Grafana Alloy receiver,
+    # which only exists where the grafana k8s-monitoring stack is installed (it is
+    # skipped on CI -- see substructure/aws/eks/grafana.py).  Gate both the plugin
+    # enablement and its collector config on non-CI environments so APISIX does not
+    # repeatedly fail to reach a non-existent collector.
+    otel_tracing_enabled = stack_info.env_suffix.lower() != "ci"
 
     # Create apache-apisix specific labels that include both global labels
     # and app-specific labels for proper service selector matching
@@ -284,6 +407,58 @@ def setup_apisix(
                             "config_provider": "yaml",
                         },
                     },
+                    # Enable the opentelemetry plugin globally (it is NOT in the
+                    # APISIX default plugin list).  Setting ``plugins`` replaces the
+                    # default list, so APISIX_ENABLED_PLUGINS reproduces the full
+                    # default set plus opentelemetry.  Omitted on CI so the default
+                    # list (which already excludes opentelemetry) remains in effect.
+                    **(
+                        {"plugins": APISIX_ENABLED_PLUGINS}
+                        if otel_tracing_enabled
+                        else {}
+                    ),
+                    # Configure the opentelemetry plugin's collector and span
+                    # defaults.  ``pluginAttrs`` renders to ``plugin_attr`` in
+                    # config.yaml and is additive (it does not replace defaults for
+                    # other plugins).  The plugin only supports binary OTLP over
+                    # HTTP, so it targets the Alloy receiver's HTTP port (4318); the
+                    # plugin appends ``/v1/traces`` to the address itself.  From the
+                    # receiver, traces flow through the existing tail-sampling
+                    # pipeline to Grafana Cloud (see grafana.py gc-otlp-endpoint).
+                    **(
+                        {
+                            "pluginAttrs": {
+                                "opentelemetry": {
+                                    # Generate spec-compliant random trace ids.  Do
+                                    # NOT use "x-request-id" here: APISIX uses that
+                                    # header value verbatim as the trace id with no
+                                    # validation, and the request-id plugin emits a
+                                    # 36-char UUID (with dashes) which is not a valid
+                                    # 16-byte OTLP trace id -- Tempo silently drops
+                                    # the resulting malformed spans.
+                                    "trace_id_source": "random",
+                                    "resource": {
+                                        "service.name": "apisix",
+                                        "deployment.environment": stack_info.env_suffix.lower(),
+                                    },
+                                    "collector": {
+                                        "address": "grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318",
+                                        "request_timeout": 3,
+                                    },
+                                    "batch_span_processor": {
+                                        "drop_on_queue_full": False,
+                                        "max_queue_size": 1024,
+                                        "batch_timeout": 2,
+                                        "inactive_timeout": 1,
+                                        "max_export_batch_size": 16,
+                                    },
+                                    "set_ngx_var": False,
+                                },
+                            }
+                        }
+                        if otel_tracing_enabled
+                        else {}
+                    ),
                     "trustedAddresses": fastly_ips,
                     "admin": {
                         "enabled": True,


### PR DESCRIPTION
## What

Enable the Apache APISIX `opentelemetry` plugin globally so every request through the gateway produces an OTLP trace span. Spans are exported to the in-cluster Grafana Alloy receiver (`grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318`), which forwards them — via the existing tail-sampling pipeline (`gc-otlp-endpoint`) — to Grafana Cloud Tempo. APISIX becomes the root/entry span and propagates W3C trace context to upstreams, so gateway spans link to application spans (e.g. learn-ai).

> Scope note: this adds **traces**. APISIX **metrics** were already exported via the Prometheus plugin + ServiceMonitor and are unchanged. The `opentelemetry` plugin emits traces only.

## How

**`infrastructure/aws/eks/apisix_official.py`** (cluster-wide, gated to non-CI):
- Set `apisix.plugins` to APISIX 3.14.x's full default plugin list **plus `opentelemetry`** (not enabled by default). Setting `plugins` *replaces* the default list rather than extending it, so the full default set is reproduced verbatim to avoid silently dropping plugins already in use. ⚠️ This list is version-coupled and must be revisited on APISIX upgrades.
- Add `apisix.pluginAttrs.opentelemetry` (collector address, resource attributes, batch span processor).
- `trace_id_source: random` — spec-compliant 16-byte trace ids. (`x-request-id` would pass the request-id UUID verbatim as the trace id, which Tempo drops as malformed.)

**`components/services/apisix.py`** (per-route attachment):
- Add `enable_opentelemetry` flag (default on) to `OLApisixSharedPluginsConfig`; attach the `opentelemetry` plugin (`always_on` head sampling) to every shared plugin config. Head sampling at the edge → Alloy tail sampling decides what reaches Grafana Cloud.
- Auto-gate off on CI (via `parse_stack`) to match the cluster-level plugin enablement — a route referencing an unloaded plugin is rejected.

## Deploy notes

Two stacks must be deployed for traces to flow:
1. **operations/eks stack** — enables the plugin + sets `plugin_attr`.
2. **application stacks** — attach the plugin to routes via the shared `PluginConfig` CRDs. `plugin_attr` alone does **not** enable tracing.

## Verification

- `kubectl get apisixpluginconfigs.apisix.apache.org -A -o yaml | grep -i opentelemetry` (and `pluginconfigs.apisix.apache.org` for the Gateway API path) — confirm routes have the plugin attached.
- In Grafana Cloud (Prometheus): watch `otelcol_receiver_accepted_spans_total` and `otelcol_exporter_sent_spans_total` while sending QA traffic.
- In Grafana Cloud (Tempo): Explore → TraceQL `{ resource.service.name = "apisix" }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)