### PR TITLE
Remove ProctorTrack default from MITx Residential

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/secrets_builder.py
+++ b/src/ol_infrastructure/applications/edxapp/secrets_builder.py
@@ -124,12 +124,14 @@ def _apply_deployment_secret_overrides(
         )
         secrets["YOUTUBE_API_KEY"] = '{{ get .Secrets "youtube_api_key" }}'
 
-    # Proctoring backend configuration
-    default_backend = "null" if env_prefix == "xpro" else "proctortrack"
-    secrets["PROCTORING_BACKENDS"] = {"DEFAULT": default_backend}
+    # Proctoring backend configuration. Only deployments with an explicit
+    # ProctorTrack URL should use ProctorTrack as the default; MITx Residential
+    # does not use ProctorTrack and should remain on the null backend.
+    default_backend = "proctortrack" if proctortrack_url else "null"
+    proctoring_backends: dict[str, Any] = {"DEFAULT": default_backend}
 
     if proctortrack_url:
-        secrets["PROCTORING_BACKENDS"]["proctortrack"] = {
+        proctoring_backends["proctortrack"] = {
             "client_id": '{{ get .Secrets "proctortrack_client_id" }}',
             "client_secret": '{{ get .Secrets "proctortrack_client_secret" }}',
             "base_url": proctortrack_url,
@@ -139,7 +141,8 @@ def _apply_deployment_secret_overrides(
         )
 
     # Always include null backend
-    secrets["PROCTORING_BACKENDS"]["null"] = {}
+    proctoring_backends["null"] = {}
+    secrets["PROCTORING_BACKENDS"] = proctoring_backends
     # Always include GitHub access token
     secrets["GITHUB_ACCESS_TOKEN"] = '{{ get .Secrets "github_access_token" }}'
 

--- a/tests/ol_infrastructure/applications/edxapp/test_secrets_builder.py
+++ b/tests/ol_infrastructure/applications/edxapp/test_secrets_builder.py
@@ -169,26 +169,27 @@ class TestBuildBaseGeneralSecretsDict:
         assert secrets["PROCTORING_BACKENDS"]["DEFAULT"] == "null"
 
     def test_proctoring_default_backend_mitx(self, mock_stack_info_mitx):
-        """Verify mitx uses proctortrack as default backend."""
+        """Verify MITx Residential uses null as default proctoring backend."""
         secrets = build_base_general_secrets_dict(
             stack_info=mock_stack_info_mitx,
             redis_hostname="redis.example.com",
             lms_domain="mitx.example.com",
         )
 
-        assert secrets["PROCTORING_BACKENDS"]["DEFAULT"] == "proctortrack"
+        assert secrets["PROCTORING_BACKENDS"]["DEFAULT"] == "null"
 
-    def test_proctortrack_url_configuration(self, mock_stack_info_mitx):
+    def test_proctortrack_url_configuration(self, mock_stack_info_mitxonline):
         """Test proctortrack URL configuration."""
         proctortrack_url = "https://proctortrack.example.com"
         secrets = build_base_general_secrets_dict(
-            stack_info=mock_stack_info_mitx,
+            stack_info=mock_stack_info_mitxonline,
             redis_hostname="redis.example.com",
-            lms_domain="mitx.example.com",
+            lms_domain="mitxonline.example.com",
             proctortrack_url=proctortrack_url,
         )
 
         pt_config = secrets["PROCTORING_BACKENDS"]["proctortrack"]
+        assert secrets["PROCTORING_BACKENDS"]["DEFAULT"] == "proctortrack"
         assert pt_config["base_url"] == proctortrack_url
         assert "client_id" in pt_config
         assert "client_secret" in pt_config
@@ -204,6 +205,7 @@ class TestBuildBaseGeneralSecretsDict:
         )
 
         # Should only have null backend
+        assert secrets["PROCTORING_BACKENDS"]["DEFAULT"] == "null"
         assert "proctortrack" not in secrets["PROCTORING_BACKENDS"]
         assert "null" in secrets["PROCTORING_BACKENDS"]
 


### PR DESCRIPTION
### What are the relevant tickets?
N/A — follow-up from Rootly/Sentry alert investigation for MITx Residential production.

### Description (What does it do?)
MITx Residential (`mitx` / `mitx-staging`) does not use ProctorTrack, but the generated Open edX secrets defaulted every non-xPRO deployment to `proctortrack` even when no ProctorTrack URL was configured.

This changes the generated `PROCTORING_BACKENDS` so ProctorTrack is only used as the default when a deployment explicitly configures a `proctortrack_url`. Residential deployments without that URL now default to the `null` proctoring backend, while deployments that do configure ProctorTrack continue to generate the ProctorTrack backend and credentials template.

### How can this be tested?
- `uv run pytest tests/ol_infrastructure/applications/edxapp/test_secrets_builder.py`
- `uv run mypy src/ol_infrastructure/applications/edxapp/secrets_builder.py tests/ol_infrastructure/applications/edxapp/test_secrets_builder.py`
- `EDXAPP_DOCKER_IMAGE_DIGEST=sha256:fd0e1539e018e1b172003cf7ef9061ec169d328cf7b4e4b0216b5f30cfc3333c pulumi preview --stack mitx.Production --diff` from `src/ol_infrastructure/applications/edxapp`
  - Expected diff includes `PROCTORING_BACKENDS.DEFAULT: proctortrack -> null` in `10-general-secrets-yaml`.
  - No resource deletes or replacements were planned for `mitx.Production`.

### Additional Context
`uv run pre-commit run --all-files` was attempted. Python formatting, ruff, mypy, YAML, shellcheck, and other relevant checks passed, but the full run failed on unrelated repository-wide hooks: missing local `packer` binary and pre-existing hadolint warnings in unchanged Dockerfiles.
