### PR TITLE
config(edxapp): double RATELIMIT_RATE from 600/m to 1200/m

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -635,7 +635,7 @@ def create_k8s_configmaps(  # noqa: PLR0915
         "PROGRAM_CONSOLE_MICROFRONTEND_URL": None,
         "REGISTRATION_VALIDATION_RATELIMIT": "1000000/minute",
         "REGISTRATION_RATELIMIT": "1000000/minute",
-        "RATELIMIT_RATE": "600/m",
+        "RATELIMIT_RATE": "1200/m",
         "RECALCULATE_GRADES_ROUTING_KEY": "edx.lms.core.default",
         "STUDENT_FILEUPLOAD_MAX_SIZE": 52428800,
         "TRACKING_SEGMENTIO_WEBHOOK_SECRET": "",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Doubles the edxapp `RATELIMIT_RATE` setting from `600/m` to `1200/m` in [`src/ol_infrastructure/applications/edxapp/k8s_configmaps.py`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py#L638).

`RATELIMIT_RATE` is the default per-IP throttle Django's `ratelimit` decorator applies to rate-limited views in edx-platform (login, password reset, etc.). Raising it from 600 to 1200 requests per minute relaxes that throttle by 2x.

### How can this be tested?
Run `pulumi preview` against an edxapp stack and confirm the only change to the rendered ConfigMap is the `RATELIMIT_RATE` value flipping from `600/m` to `1200/m`. After deploy, the new value should be visible in the lms/cms ConfigMap and applied on pod restart.