### PR TITLE
Changes based on running eks.py

### DIFF
--- a/scripts/eks/KUBE_ACCESS.md
+++ b/scripts/eks/KUBE_ACCESS.md
@@ -29,6 +29,12 @@ Optional current context:
 uv run python scripts/eks/eks.py setup --mode readonly --current-context applications-qa
 ```
 
+Optional paired readonly contexts for automation tools:
+
+```bash
+uv run python scripts/eks/eks.py setup --mode developer --include-readonly-contexts
+```
+
 ## How auth works
 
 The generated kubeconfig uses an `exec` plugin that calls back into
@@ -40,6 +46,9 @@ The generated kubeconfig uses an `exec` plugin that calls back into
 - Users do **not** need to run `source eks.env` or manually refresh temporary
   AWS credentials before using `kubectl`.
 - The tool currently manages and overwrites `~/.kube/config` directly.
+- Developer and admin kubeconfigs write only operator contexts by default.
+  Add `--include-readonly-contexts` if you also want paired `-readonly`
+  contexts for automation.
 
 ## Access modes
 

--- a/scripts/eks/eks.py
+++ b/scripts/eks/eks.py
@@ -289,7 +289,9 @@ def fetch_all_cluster_configs(mode: AccessMode) -> list[ClusterConfig]:
     # Admin mode authenticates via the admin OIDC role but requests readonly
     # AWS credentials, which are sufficient for eks:ListClusters / DescribeCluster.
     discovery_mode = AccessMode.READONLY if mode is AccessMode.ADMIN else mode
-    discovery_credentials = load_valid_aws_credentials(discovery_mode)
+    discovery_credentials = load_valid_aws_credentials(
+        discovery_mode, block_noninteractive_login=False
+    )
     eks_client = make_eks_client(discovery_credentials)
 
     paginator = eks_client.get_paginator("list_clusters")
@@ -542,8 +544,16 @@ def cached_vault_token(mode: AccessMode) -> str | None:
     return None
 
 
-def load_valid_vault_token(mode: AccessMode) -> str:
-    """Load a cached Vault token or authenticate via OIDC."""
+def load_valid_vault_token(mode: AccessMode, block_noninteractive_login: bool = False) -> str:
+    """Load a cached Vault token or authenticate via OIDC.
+
+    Args:
+        mode: Access mode (readonly, developer, admin).
+        block_noninteractive_login: If True, raise an error when attempting to start
+            a browser OIDC login from a non-interactive environment. This prevents
+            GUI tools like Headlamp from spawning uncontrolled browser tabs. The
+            setup command should pass False to allow normal credential refresh in CI.
+    """
     oidc_role = VAULT_OIDC_ROLE_BY_MODE[mode.value]
     token_cache_path = cache_file(f"vault-token-{oidc_role}")
     token = cached_vault_token(mode)
@@ -565,7 +575,7 @@ def load_valid_vault_token(mode: AccessMode) -> str:
             )
             return token
 
-        if not exec_invocation_is_interactive():
+        if block_noninteractive_login and not exec_invocation_is_interactive():
             append_exec_debug_event(
                 "vault_login_blocked_noninteractive",
                 mode=mode.value,
@@ -621,13 +631,20 @@ def cached_aws_credentials(mode: AccessMode) -> AwsCredentialsCache | None:
     )
 
 
-def load_valid_aws_credentials(mode: AccessMode) -> AwsCredentialsCache:
+def load_valid_aws_credentials(
+    mode: AccessMode, block_noninteractive_login: bool = False
+) -> AwsCredentialsCache:
     """Load cached AWS credentials or generate fresh ones from Vault.
 
     Admin mode does not have a dedicated shared AWS role — it authenticates via
     the admin OIDC role but requests readonly AWS credentials for cluster discovery.
     The admin mode exec-credential path uses ``aws eks get-token --role`` directly
     with the per-cluster admin IAM role rather than Vault-vended STS credentials.
+
+    Args:
+        mode: Access mode (readonly, developer, admin).
+        block_noninteractive_login: Passed to load_valid_vault_token to prevent
+            browser OIDC login in non-interactive environments.
     """
     if mode is AccessMode.ADMIN:
         msg = (
@@ -652,7 +669,7 @@ def load_valid_aws_credentials(mode: AccessMode) -> AwsCredentialsCache:
             )
             return creds
 
-        token = load_valid_vault_token(mode)
+        token = load_valid_vault_token(mode, block_noninteractive_login=block_noninteractive_login)
         client = vault_client(token)
         append_exec_debug_event("aws_credentials_generate_start", mode=mode.value)
         aws_creds = client.secrets.aws.generate_credentials(
@@ -780,7 +797,9 @@ def exec_credential(
             raise RuntimeError(msg)
         command.extend(["--role", admin_role_arn])
     else:
-        credentials = load_valid_aws_credentials(mode)
+        credentials = load_valid_aws_credentials(
+            mode, block_noninteractive_login=True
+        )
         env = aws_env_from_credentials(credentials)
 
     token_json = run_command(command, env=env)

--- a/scripts/eks/eks.py
+++ b/scripts/eks/eks.py
@@ -9,9 +9,12 @@ import subprocess
 import sys
 import urllib.parse
 import webbrowser
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
+import fcntl
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any
@@ -26,6 +29,8 @@ app = cyclopts.App(help="Manage MIT Open Learning EKS kubeconfig setup and auth.
 AWS_REGION = "us-east-1"
 AWS_DEFAULT_REGION = "us-east-1"
 CACHE_DIR = Path.home() / ".cache" / "ol-infrastructure" / "eks"
+EXEC_DEBUG_LOG_PATH = CACHE_DIR / "exec-debug.log"
+EXEC_DEBUG_ENV_VAR = "OL_EKS_DEBUG_EXEC"
 KUBECONFIG_DEFAULT_PATH = Path.home() / ".kube" / "config"
 OIDC_CALLBACK_PORT = 8250
 OIDC_REDIRECT_URI = f"http://localhost:{OIDC_CALLBACK_PORT}/oidc/callback"
@@ -151,6 +156,19 @@ def dump_json(path: Path, payload: dict[str, Any]) -> None:
     path.write_text(json.dumps(payload, indent=2, sort_keys=True))
 
 
+@contextmanager
+def cache_lock(name: str) -> Iterator[None]:
+    """Serialize refreshes for a cache key across concurrent processes."""
+    lock_path = CACHE_DIR / f"{name}.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("w") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
 def run_command(
     command: list[str], cwd: Path | None = None, env: dict[str, str] | None = None
 ) -> str:
@@ -170,6 +188,59 @@ def run_command(
         msg = f"Command failed: {' '.join(command)}\n{details}"
         raise RuntimeError(msg)
     return completed.stdout
+
+
+def exec_debug_context() -> dict[str, Any]:
+    """Summarize current exec-plugin invocation details for local debugging."""
+    debug_context: dict[str, Any] = {
+        "argv": sys.argv[1:],
+        "has_exec_info": False,
+        "ppid": os.getppid(),
+        "stdin_isatty": sys.stdin.isatty(),
+    }
+    exec_info = os.environ.get("KUBERNETES_EXEC_INFO")
+    if not exec_info:
+        return debug_context
+
+    debug_context["has_exec_info"] = True
+    try:
+        payload = json.loads(exec_info)
+    except json.JSONDecodeError as exc:
+        debug_context["exec_info_parse_error"] = str(exc)
+        return debug_context
+
+    debug_context["exec_info_api_version"] = payload.get("apiVersion")
+    debug_context["exec_info_interactive"] = bool(
+        payload.get("spec", {}).get("interactive", False)
+    )
+    return debug_context
+
+
+def append_exec_debug_event(event: str, **fields: Any) -> None:
+    """Append a JSONL debug record for local exec-auth troubleshooting."""
+    if os.environ.get(EXEC_DEBUG_ENV_VAR) != "1":
+        return
+
+    payload = {
+        "event": event,
+        "pid": os.getpid(),
+        "timestamp": json_datetime_now().isoformat(),
+        **fields,
+    }
+    try:
+        EXEC_DEBUG_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with EXEC_DEBUG_LOG_PATH.open("a") as debug_log:
+            debug_log.write(json.dumps(payload, sort_keys=True) + "\n")
+    except OSError:
+        return
+
+
+def exec_invocation_is_interactive() -> bool:
+    """Return whether the current exec-plugin invocation may prompt the user."""
+    debug_context = exec_debug_context()
+    if debug_context["has_exec_info"]:
+        return bool(debug_context.get("exec_info_interactive", False))
+    return bool(debug_context["stdin_isatty"])
 
 
 def make_eks_client(credentials: AwsCredentialsCache) -> Any:
@@ -286,12 +357,13 @@ def build_kubeconfig(
     clusters: list[ClusterConfig],
     operator_mode: AccessMode,
     current_context: str | None,
+    include_readonly_contexts: bool = False,
 ) -> dict[str, Any]:
-    """Build a kubeconfig covering all clusters with dual contexts per cluster.
+    """Build a kubeconfig covering all clusters.
 
-    For operator modes (developer, admin) each cluster gets two contexts:
-      - ``<cluster-name>``          — operator credentials (read/write)
-      - ``<cluster-name>-readonly`` — readonly credentials (safe for agents)
+    For operator modes (developer, admin) each cluster always gets an operator
+    context named ``<cluster-name>``.  When ``include_readonly_contexts`` is
+    enabled, an additional ``<cluster-name>-readonly`` context is generated.
 
     For readonly mode a single context per cluster is generated since there is
     no separate operator credential to pair it with.
@@ -341,32 +413,32 @@ def build_kubeconfig(
                 }
             )
 
-            # Readonly context — always present alongside operator contexts
-            readonly_context_name = f"{cluster.cluster_name}-readonly"
-            readonly_user = f"{cluster.cluster_name}-readonly"
-            contexts.append(
-                {
-                    "name": readonly_context_name,
-                    "context": {
-                        "cluster": cluster.cluster_name,
-                        "user": readonly_user,
-                    },
-                }
-            )
-            users.append(
-                {
-                    "name": readonly_user,
-                    "user": {
-                        "exec": {
-                            "apiVersion": "client.authentication.k8s.io/v1beta1",
-                            "command": sys.executable,
-                            "args": kubeconfig_exec_args(cluster, AccessMode.READONLY),
-                            "interactiveMode": "IfAvailable",
-                            "provideClusterInfo": False,
+            if include_readonly_contexts:
+                readonly_context_name = f"{cluster.cluster_name}-readonly"
+                readonly_user = f"{cluster.cluster_name}-readonly"
+                contexts.append(
+                    {
+                        "name": readonly_context_name,
+                        "context": {
+                            "cluster": cluster.cluster_name,
+                            "user": readonly_user,
                         },
-                    },
-                }
-            )
+                    }
+                )
+                users.append(
+                    {
+                        "name": readonly_user,
+                        "user": {
+                            "exec": {
+                                "apiVersion": "client.authentication.k8s.io/v1beta1",
+                                "command": sys.executable,
+                                "args": kubeconfig_exec_args(cluster, AccessMode.READONLY),
+                                "interactiveMode": "IfAvailable",
+                                "provideClusterInfo": False,
+                            },
+                        },
+                    }
+                )
         else:
             # Readonly-only setup — single context per cluster
             contexts.append(
@@ -453,27 +525,98 @@ def vault_client(token: str | None = None) -> hvac.Client:
     return hvac.Client(url=PRODUCTION_VAULT_ADDRESS, token=token)
 
 
+def cached_vault_token(mode: AccessMode) -> str | None:
+    """Return a cached Vault token when present and still valid."""
+    oidc_role = VAULT_OIDC_ROLE_BY_MODE[mode.value]
+    token_cache_path = cache_file(f"vault-token-{oidc_role}")
+    cached_payload = load_json(token_cache_path)
+    if not cached_payload or not cached_payload.get("token"):
+        return None
+
+    token = str(cached_payload["token"])
+    client = vault_client(token)
+    if client.is_authenticated():
+        return token
+    return None
+
+
 def load_valid_vault_token(mode: AccessMode) -> str:
     """Load a cached Vault token or authenticate via OIDC."""
     oidc_role = VAULT_OIDC_ROLE_BY_MODE[mode.value]
     token_cache_path = cache_file(f"vault-token-{oidc_role}")
-    cached_payload = load_json(token_cache_path)
-    if cached_payload and cached_payload.get("token"):
-        token = str(cached_payload["token"])
-        client = vault_client(token)
-        if client.is_authenticated():
+    token = cached_vault_token(mode)
+    if token:
+        append_exec_debug_event(
+            "vault_token_cache_hit",
+            mode=mode.value,
+            oidc_role=oidc_role,
+        )
+        return token
+
+    with cache_lock(f"vault-token-{oidc_role}"):
+        token = cached_vault_token(mode)
+        if token:
+            append_exec_debug_event(
+                "vault_token_cache_hit_after_lock",
+                mode=mode.value,
+                oidc_role=oidc_role,
+            )
             return token
 
-    client = vault_client()
-    token = oidc_login(client, oidc_role)
-    dump_json(token_cache_path, asdict(VaultTokenCache(token=token)))
-    return token
+        if not exec_invocation_is_interactive():
+            append_exec_debug_event(
+                "vault_login_blocked_noninteractive",
+                mode=mode.value,
+                oidc_role=oidc_role,
+                **exec_debug_context(),
+            )
+            msg = (
+                "Vault login is required, but this Kubernetes client invocation "
+                "is non-interactive. Run `uv run python scripts/eks/eks.py setup "
+                f"--mode {mode.value}` from a terminal first to refresh the cached login."
+            )
+            raise RuntimeError(msg)
+
+        client = vault_client()
+        append_exec_debug_event(
+            "vault_login_start",
+            mode=mode.value,
+            oidc_role=oidc_role,
+            **exec_debug_context(),
+        )
+        token = oidc_login(client, oidc_role)
+        dump_json(token_cache_path, asdict(VaultTokenCache(token=token)))
+        append_exec_debug_event(
+            "vault_login_success",
+            mode=mode.value,
+            oidc_role=oidc_role,
+        )
+        return token
 
 
 def parse_expiration(value: str) -> datetime:
     """Parse an ISO8601 timestamp from cache data."""
     normalized = value.replace("Z", "+00:00")
     return datetime.fromisoformat(normalized)
+
+
+def cached_aws_credentials(mode: AccessMode) -> AwsCredentialsCache | None:
+    """Return cached shared AWS credentials when present and not near expiry."""
+    aws_cache_path = cache_file(f"aws-creds-{mode.value}")
+    cached_payload = load_json(aws_cache_path)
+    if not cached_payload or not cached_payload.get("expires_at"):
+        return None
+
+    expires_at = parse_expiration(str(cached_payload["expires_at"]))
+    if expires_at <= json_datetime_now() + timedelta(minutes=5):
+        return None
+
+    return AwsCredentialsCache(
+        access_key=str(cached_payload["access_key"]),
+        secret_key=str(cached_payload["secret_key"]),
+        session_token=str(cached_payload["session_token"]),
+        expires_at=str(cached_payload["expires_at"]),
+    )
 
 
 def load_valid_aws_credentials(mode: AccessMode) -> AwsCredentialsCache:
@@ -493,33 +636,40 @@ def load_valid_aws_credentials(mode: AccessMode) -> AwsCredentialsCache:
 
     aws_role_name = VAULT_AWS_ROLE_BY_MODE[mode.value]
     aws_cache_path = cache_file(f"aws-creds-{mode.value}")
-    cached_payload = load_json(aws_cache_path)
-    if cached_payload and cached_payload.get("expires_at"):
-        expires_at = parse_expiration(str(cached_payload["expires_at"]))
-        if expires_at > json_datetime_now() + timedelta(minutes=5):
-            return AwsCredentialsCache(
-                access_key=str(cached_payload["access_key"]),
-                secret_key=str(cached_payload["secret_key"]),
-                session_token=str(cached_payload["session_token"]),
-                expires_at=str(cached_payload["expires_at"]),
-            )
+    creds = cached_aws_credentials(mode)
+    if creds:
+        append_exec_debug_event("aws_credentials_cache_hit", mode=mode.value)
+        return creds
 
-    token = load_valid_vault_token(mode)
-    client = vault_client(token)
-    aws_creds = client.secrets.aws.generate_credentials(
-        name=aws_role_name,
-        ttl=8 * 60 * 60,
-        mount_point="aws-mitx",
-    )
-    expires_at = json_datetime_now() + timedelta(seconds=aws_creds["lease_duration"])
-    creds = AwsCredentialsCache(
-        access_key=aws_creds["data"]["access_key"],
-        secret_key=aws_creds["data"]["secret_key"],
-        session_token=aws_creds["data"]["security_token"],
-        expires_at=expires_at.isoformat(),
-    )
-    dump_json(aws_cache_path, asdict(creds))
-    return creds
+    with cache_lock(f"aws-creds-{mode.value}"):
+        creds = cached_aws_credentials(mode)
+        if creds:
+            append_exec_debug_event(
+                "aws_credentials_cache_hit_after_lock",
+                mode=mode.value,
+            )
+            return creds
+
+        token = load_valid_vault_token(mode)
+        client = vault_client(token)
+        append_exec_debug_event("aws_credentials_generate_start", mode=mode.value)
+        aws_creds = client.secrets.aws.generate_credentials(
+            name=aws_role_name,
+            ttl=8 * 60 * 60,
+            mount_point="aws-mitx",
+        )
+        expires_at = json_datetime_now() + timedelta(
+            seconds=aws_creds["lease_duration"]
+        )
+        creds = AwsCredentialsCache(
+            access_key=aws_creds["data"]["access_key"],
+            secret_key=aws_creds["data"]["secret_key"],
+            session_token=aws_creds["data"]["security_token"],
+            expires_at=expires_at.isoformat(),
+        )
+        dump_json(aws_cache_path, asdict(creds))
+        append_exec_debug_event("aws_credentials_generate_success", mode=mode.value)
+        return creds
 
 
 def aws_env_from_credentials(credentials: AwsCredentialsCache) -> dict[str, str]:
@@ -538,6 +688,7 @@ def aws_env_from_credentials(credentials: AwsCredentialsCache) -> dict[str, str]
 def setup(
     mode: AccessMode = AccessMode.DEVELOPER,
     current_context: str | None = None,
+        include_readonly_contexts: bool = False,
     output_path: Path = KUBECONFIG_DEFAULT_PATH,
 ) -> None:
     """Generate a kubeconfig covering all OL EKS clusters.
@@ -545,18 +696,23 @@ def setup(
     Cluster metadata is discovered via the AWS EKS API using Vault-generated
     credentials — no Pulumi CLI or state is required.
 
-    For developer and admin modes each cluster gets two contexts:
-      - ``<cluster-name>``          — operator credentials (read/write)
-      - ``<cluster-name>-readonly`` — readonly credentials for agents/automation
+        For developer and admin modes each cluster gets an operator context:
+            - ``<cluster-name>`` — operator credentials (read/write)
+
+        Optional readonly companions can also be added:
+            - ``<cluster-name>-readonly`` — readonly credentials for agents/automation
 
     For readonly mode a single context per cluster is generated.
 
     EXAMPLES:
-      # Developer access (default) — human read/write + agent readonly contexts
+            # Developer access (default) — human read/write contexts only
       uv run python scripts/eks/eks.py setup
 
       # Admin access — cluster-admin + agent readonly contexts
       uv run python scripts/eks/eks.py setup --mode admin
+
+            # Include paired readonly contexts for automation tools
+            uv run python scripts/eks/eks.py setup --mode developer --include-readonly-contexts
 
       # Readonly only — for automation or read-only users
       uv run python scripts/eks/eks.py setup --mode readonly
@@ -565,7 +721,12 @@ def setup(
     if not clusters:
         print("Warning: No EKS clusters found in this AWS account.", file=sys.stderr)
 
-    kube_config = build_kubeconfig(clusters, mode, current_context)
+    kube_config = build_kubeconfig(
+        clusters,
+        mode,
+        current_context,
+        include_readonly_contexts=include_readonly_contexts,
+    )
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(yaml.safe_dump(kube_config, sort_keys=False))
 
@@ -576,9 +737,11 @@ def setup(
     )
     if mode is not AccessMode.READONLY:
         print(f"  Operator contexts  : {', '.join(c.cluster_name for c in clusters)}")
-        print(
-            f"  Readonly contexts  : {', '.join(c.cluster_name + '-readonly' for c in clusters)}"
-        )
+        if include_readonly_contexts:
+            print(
+                "  Readonly contexts  : "
+                f"{', '.join(c.cluster_name + '-readonly' for c in clusters)}"
+            )
 
 
 @app.command(name="exec-credential")
@@ -593,6 +756,13 @@ def exec_credential(
     for direct invocation.  Handles Vault OIDC auth, credential generation, and
     local caching transparently.
     """
+    append_exec_debug_event(
+        "exec_credential_start",
+        admin_role_supplied=bool(admin_role_arn),
+        cluster_name=cluster_name,
+        mode=mode.value,
+        **exec_debug_context(),
+    )
     command = [
         "aws",
         "eks",
@@ -612,6 +782,11 @@ def exec_credential(
         env = aws_env_from_credentials(credentials)
 
     token_json = run_command(command, env=env)
+    append_exec_debug_event(
+        "exec_credential_success",
+        cluster_name=cluster_name,
+        mode=mode.value,
+    )
     print(token_json, end="")
 
 

--- a/scripts/eks/eks.py
+++ b/scripts/eks/eks.py
@@ -202,13 +202,13 @@ def exec_debug_context() -> dict[str, Any]:
     if not exec_info:
         return debug_context
 
-    debug_context["has_exec_info"] = True
     try:
         payload = json.loads(exec_info)
     except json.JSONDecodeError as exc:
         debug_context["exec_info_parse_error"] = str(exc)
         return debug_context
 
+    debug_context["has_exec_info"] = True
     debug_context["exec_info_api_version"] = payload.get("apiVersion")
     debug_context["exec_info_interactive"] = bool(
         payload.get("spec", {}).get("interactive", False)

--- a/scripts/eks/eks.py
+++ b/scripts/eks/eks.py
@@ -544,7 +544,9 @@ def cached_vault_token(mode: AccessMode) -> str | None:
     return None
 
 
-def load_valid_vault_token(mode: AccessMode, block_noninteractive_login: bool = False) -> str:
+def load_valid_vault_token(
+    mode: AccessMode, block_noninteractive_login: bool = False
+) -> str:
     """Load a cached Vault token or authenticate via OIDC.
 
     Args:
@@ -669,7 +671,9 @@ def load_valid_aws_credentials(
             )
             return creds
 
-        token = load_valid_vault_token(mode, block_noninteractive_login=block_noninteractive_login)
+        token = load_valid_vault_token(
+            mode, block_noninteractive_login=block_noninteractive_login
+        )
         client = vault_client(token)
         append_exec_debug_event("aws_credentials_generate_start", mode=mode.value)
         aws_creds = client.secrets.aws.generate_credentials(
@@ -797,9 +801,7 @@ def exec_credential(
             raise RuntimeError(msg)
         command.extend(["--role", admin_role_arn])
     else:
-        credentials = load_valid_aws_credentials(
-            mode, block_noninteractive_login=True
-        )
+        credentials = load_valid_aws_credentials(mode, block_noninteractive_login=True)
         env = aws_env_from_credentials(credentials)
 
     token_json = run_command(command, env=env)

--- a/scripts/eks/eks.py
+++ b/scripts/eks/eks.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import fcntl
 import json
 import os
 import subprocess
@@ -14,7 +15,6 @@ from contextlib import contextmanager
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
-import fcntl
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any
@@ -432,7 +432,9 @@ def build_kubeconfig(
                             "exec": {
                                 "apiVersion": "client.authentication.k8s.io/v1beta1",
                                 "command": sys.executable,
-                                "args": kubeconfig_exec_args(cluster, AccessMode.READONLY),
+                                "args": kubeconfig_exec_args(
+                                    cluster, AccessMode.READONLY
+                                ),
                                 "interactiveMode": "IfAvailable",
                                 "provideClusterInfo": False,
                             },
@@ -688,7 +690,7 @@ def aws_env_from_credentials(credentials: AwsCredentialsCache) -> dict[str, str]
 def setup(
     mode: AccessMode = AccessMode.DEVELOPER,
     current_context: str | None = None,
-        include_readonly_contexts: bool = False,
+    include_readonly_contexts: bool = False,
     output_path: Path = KUBECONFIG_DEFAULT_PATH,
 ) -> None:
     """Generate a kubeconfig covering all OL EKS clusters.

--- a/tests/scripts/eks/test_eks_cli.py
+++ b/tests/scripts/eks/test_eks_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import sys
+from contextlib import nullcontext
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -52,17 +53,33 @@ def two_clusters(eks_module):
 
 
 # ---------------------------------------------------------------------------
-# build_kubeconfig — developer mode (dual contexts)
+# build_kubeconfig — developer mode
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-def test_build_kubeconfig_developer_mode_produces_dual_contexts(
+def test_build_kubeconfig_developer_mode_produces_operator_contexts_by_default(
     eks_module, two_clusters
 ):
-    """Developer mode: one operator context and one readonly context per cluster."""
+    """Developer mode defaults to operator contexts only."""
     kubeconfig = eks_module.build_kubeconfig(
         two_clusters, eks_module.AccessMode.DEVELOPER, None
+    )
+
+    context_names = [ctx["name"] for ctx in kubeconfig["contexts"]]
+    assert context_names == ["applications-qa", "data-production"]
+
+
+@pytest.mark.unit
+def test_build_kubeconfig_developer_mode_can_include_readonly_contexts(
+    eks_module, two_clusters
+):
+    """Developer mode can optionally include paired readonly contexts."""
+    kubeconfig = eks_module.build_kubeconfig(
+        two_clusters,
+        eks_module.AccessMode.DEVELOPER,
+        None,
+        include_readonly_contexts=True,
     )
 
     context_names = [ctx["name"] for ctx in kubeconfig["contexts"]]
@@ -98,7 +115,10 @@ def test_build_kubeconfig_developer_readonly_context_uses_readonly_exec(
 ):
     """The readonly context's exec args should include --mode readonly."""
     kubeconfig = eks_module.build_kubeconfig(
-        two_clusters, eks_module.AccessMode.DEVELOPER, None
+        two_clusters,
+        eks_module.AccessMode.DEVELOPER,
+        None,
+        include_readonly_contexts=True,
     )
 
     readonly_user = next(
@@ -107,6 +127,71 @@ def test_build_kubeconfig_developer_readonly_context_uses_readonly_exec(
     args = readonly_user["user"]["exec"]["args"]
     assert "--mode" in args
     assert args[args.index("--mode") + 1] == "readonly"
+
+
+@pytest.mark.unit
+def test_load_valid_vault_token_rechecks_cache_after_lock(eks_module, monkeypatch):
+    """A concurrent cache refresh should be reused instead of starting another login."""
+    observed_tokens = iter([None, "cached-token"])
+
+    monkeypatch.setattr(
+        eks_module,
+        "cached_vault_token",
+        lambda _mode: next(observed_tokens),
+    )
+    monkeypatch.setattr(eks_module, "cache_lock", lambda _name: nullcontext())
+    monkeypatch.setattr(
+        eks_module,
+        "oidc_login",
+        lambda _client, _role: pytest.fail("oidc_login should not run after cache refill"),
+    )
+
+    assert eks_module.load_valid_vault_token(eks_module.AccessMode.DEVELOPER) == "cached-token"
+
+
+@pytest.mark.unit
+def test_load_valid_vault_token_refuses_noninteractive_login(eks_module, monkeypatch):
+    """Non-interactive exec clients should not trigger browser-based OIDC login."""
+    monkeypatch.setattr(eks_module, "cached_vault_token", lambda _mode: None)
+    monkeypatch.setattr(eks_module, "cache_lock", lambda _name: nullcontext())
+    monkeypatch.setattr(eks_module, "exec_invocation_is_interactive", lambda: False)
+    monkeypatch.setattr(
+        eks_module,
+        "oidc_login",
+        lambda _client, _role: pytest.fail("oidc_login should not run for non-interactive exec callers"),
+    )
+
+    with pytest.raises(RuntimeError, match="non-interactive"):
+        eks_module.load_valid_vault_token(eks_module.AccessMode.DEVELOPER)
+
+
+@pytest.mark.unit
+def test_exec_invocation_is_interactive_uses_exec_info(eks_module, monkeypatch):
+    """KUBERNETES_EXEC_INFO should control interactive prompting behavior."""
+    monkeypatch.setenv(
+        "KUBERNETES_EXEC_INFO",
+        '{"apiVersion":"client.authentication.k8s.io/v1beta1","spec":{"interactive":false}}',
+    )
+    assert eks_module.exec_invocation_is_interactive() is False
+
+    monkeypatch.setenv(
+        "KUBERNETES_EXEC_INFO",
+        '{"apiVersion":"client.authentication.k8s.io/v1beta1","spec":{"interactive":true}}',
+    )
+    assert eks_module.exec_invocation_is_interactive() is True
+
+
+@pytest.mark.unit
+def test_append_exec_debug_event_is_disabled_by_default(
+    eks_module, monkeypatch, tmp_path
+):
+    """Debug logging should be opt-in so normal runs do not create a log file."""
+    monkeypatch.setattr(eks_module, "EXEC_DEBUG_LOG_PATH", tmp_path / "exec-debug.log")
+    monkeypatch.delenv(eks_module.EXEC_DEBUG_ENV_VAR, raising=False)
+
+    eks_module.append_exec_debug_event("test-event")
+
+    assert not eks_module.EXEC_DEBUG_LOG_PATH.exists()
 
 
 @pytest.mark.unit
@@ -122,15 +207,33 @@ def test_build_kubeconfig_developer_current_context_is_operator(
 
 
 # ---------------------------------------------------------------------------
-# build_kubeconfig — admin mode (dual contexts)
+# build_kubeconfig — admin mode
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
-def test_build_kubeconfig_admin_mode_produces_dual_contexts(eks_module, two_clusters):
-    """Admin mode should emit one admin context and one readonly context per cluster."""
+def test_build_kubeconfig_admin_mode_produces_operator_contexts_by_default(
+    eks_module, two_clusters
+):
+    """Admin mode defaults to admin contexts only."""
     kubeconfig = eks_module.build_kubeconfig(
         two_clusters, eks_module.AccessMode.ADMIN, None
+    )
+
+    context_names = [ctx["name"] for ctx in kubeconfig["contexts"]]
+    assert context_names == ["applications-qa", "data-production"]
+
+
+@pytest.mark.unit
+def test_build_kubeconfig_admin_mode_can_include_readonly_contexts(
+    eks_module, two_clusters
+):
+    """Admin mode can optionally include paired readonly contexts."""
+    kubeconfig = eks_module.build_kubeconfig(
+        two_clusters,
+        eks_module.AccessMode.ADMIN,
+        None,
+        include_readonly_contexts=True,
     )
 
     context_names = [ctx["name"] for ctx in kubeconfig["contexts"]]
@@ -166,7 +269,10 @@ def test_build_kubeconfig_admin_readonly_context_does_not_include_admin_role(
 ):
     """The readonly context paired with admin mode must not pass an admin role ARN."""
     kubeconfig = eks_module.build_kubeconfig(
-        two_clusters, eks_module.AccessMode.ADMIN, None
+        two_clusters,
+        eks_module.AccessMode.ADMIN,
+        None,
+        include_readonly_contexts=True,
     )
 
     readonly_user = next(
@@ -295,10 +401,10 @@ def test_fetch_admin_role_arn_raises_when_none_found(eks_module):
 
 
 @pytest.mark.unit
-def test_setup_writes_kubeconfig_with_dual_contexts(
+def test_setup_writes_kubeconfig_with_operator_contexts_by_default(
     tmp_path, eks_module, monkeypatch, two_clusters
 ):
-    """Setup in developer mode should write a kubeconfig with dual contexts."""
+    """Setup in developer mode should write operator contexts by default."""
     output_path = tmp_path / "config"
     monkeypatch.setattr(
         eks_module, "fetch_all_cluster_configs", lambda _mode: two_clusters
@@ -315,12 +421,7 @@ def test_setup_writes_kubeconfig_with_dual_contexts(
     assert len(kubeconfig["clusters"]) == 2
 
     context_names = [ctx["name"] for ctx in kubeconfig["contexts"]]
-    assert context_names == [
-        "applications-qa",
-        "applications-qa-readonly",
-        "data-production",
-        "data-production-readonly",
-    ]
+    assert context_names == ["applications-qa", "data-production"]
 
     # Operator user uses developer exec
     developer_user = next(
@@ -328,8 +429,5 @@ def test_setup_writes_kubeconfig_with_dual_contexts(
     )
     assert "developer" in developer_user["user"]["exec"]["args"]
 
-    # Readonly user uses readonly exec
-    readonly_user = next(
-        u for u in kubeconfig["users"] if u["name"] == "applications-qa-readonly"
-    )
-    assert "readonly" in readonly_user["user"]["exec"]["args"]
+    user_names = [user["name"] for user in kubeconfig["users"]]
+    assert "applications-qa-readonly" not in user_names

--- a/tests/scripts/eks/test_eks_cli.py
+++ b/tests/scripts/eks/test_eks_cli.py
@@ -220,6 +220,23 @@ def test_exec_invocation_is_interactive_uses_exec_info(eks_module, monkeypatch):
 
 
 @pytest.mark.unit
+def test_exec_invocation_is_interactive_falls_back_on_malformed_json(
+    eks_module, monkeypatch
+):
+    """Malformed KUBERNETES_EXEC_INFO should fall back to stdin.isatty()."""
+    # Set malformed JSON to force fallback
+    monkeypatch.setenv("KUBERNETES_EXEC_INFO", "{invalid json}")
+
+    # When stdin is TTY, should return True (fallback to stdin check)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    assert eks_module.exec_invocation_is_interactive() is True
+
+    # When stdin is not TTY, should return False
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    assert eks_module.exec_invocation_is_interactive() is False
+
+
+@pytest.mark.unit
 def test_append_exec_debug_event_is_disabled_by_default(
     eks_module, monkeypatch, tmp_path
 ):

--- a/tests/scripts/eks/test_eks_cli.py
+++ b/tests/scripts/eks/test_eks_cli.py
@@ -155,8 +155,8 @@ def test_load_valid_vault_token_rechecks_cache_after_lock(eks_module, monkeypatc
 
 
 @pytest.mark.unit
-def test_load_valid_vault_token_refuses_noninteractive_login(eks_module, monkeypatch):
-    """Non-interactive exec clients should not trigger browser-based OIDC login."""
+def test_load_valid_vault_token_refuses_noninteractive_login_when_blocked(eks_module, monkeypatch):
+    """Non-interactive exec clients should not trigger browser-based OIDC login when block_noninteractive_login=True."""
     monkeypatch.setattr(eks_module, "cached_vault_token", lambda _mode: None)
     monkeypatch.setattr(eks_module, "cache_lock", lambda _name: nullcontext())
     monkeypatch.setattr(eks_module, "exec_invocation_is_interactive", lambda: False)
@@ -169,7 +169,28 @@ def test_load_valid_vault_token_refuses_noninteractive_login(eks_module, monkeyp
     )
 
     with pytest.raises(RuntimeError, match="non-interactive"):
-        eks_module.load_valid_vault_token(eks_module.AccessMode.DEVELOPER)
+        eks_module.load_valid_vault_token(
+            eks_module.AccessMode.DEVELOPER, block_noninteractive_login=True
+        )
+
+
+@pytest.mark.unit
+def test_load_valid_vault_token_allows_noninteractive_login_when_not_blocked(eks_module, monkeypatch):
+    """Non-interactive setup calls should proceed to browser login when block_noninteractive_login=False."""
+    monkeypatch.setattr(eks_module, "cached_vault_token", lambda _mode: None)
+    monkeypatch.setattr(eks_module, "cache_lock", lambda _name: nullcontext())
+    monkeypatch.setattr(eks_module, "exec_invocation_is_interactive", lambda: False)
+    monkeypatch.setattr(
+        eks_module,
+        "oidc_login",
+        lambda _client, _role: "setup-token",
+    )
+    monkeypatch.setattr(eks_module, "dump_json", lambda *args, **kwargs: None)
+
+    token = eks_module.load_valid_vault_token(
+        eks_module.AccessMode.DEVELOPER, block_noninteractive_login=False
+    )
+    assert token == "setup-token"
 
 
 @pytest.mark.unit

--- a/tests/scripts/eks/test_eks_cli.py
+++ b/tests/scripts/eks/test_eks_cli.py
@@ -143,10 +143,15 @@ def test_load_valid_vault_token_rechecks_cache_after_lock(eks_module, monkeypatc
     monkeypatch.setattr(
         eks_module,
         "oidc_login",
-        lambda _client, _role: pytest.fail("oidc_login should not run after cache refill"),
+        lambda _client, _role: pytest.fail(
+            "oidc_login should not run after cache refill"
+        ),
     )
 
-    assert eks_module.load_valid_vault_token(eks_module.AccessMode.DEVELOPER) == "cached-token"
+    assert (
+        eks_module.load_valid_vault_token(eks_module.AccessMode.DEVELOPER)
+        == "cached-token"
+    )
 
 
 @pytest.mark.unit
@@ -158,7 +163,9 @@ def test_load_valid_vault_token_refuses_noninteractive_login(eks_module, monkeyp
     monkeypatch.setattr(
         eks_module,
         "oidc_login",
-        lambda _client, _role: pytest.fail("oidc_login should not run for non-interactive exec callers"),
+        lambda _client, _role: pytest.fail(
+            "oidc_login should not run for non-interactive exec callers"
+        ),
     )
 
     with pytest.raises(RuntimeError, match="non-interactive"):

--- a/tests/scripts/eks/test_eks_cli.py
+++ b/tests/scripts/eks/test_eks_cli.py
@@ -155,8 +155,13 @@ def test_load_valid_vault_token_rechecks_cache_after_lock(eks_module, monkeypatc
 
 
 @pytest.mark.unit
-def test_load_valid_vault_token_refuses_noninteractive_login_when_blocked(eks_module, monkeypatch):
-    """Non-interactive exec clients should not trigger browser-based OIDC login when block_noninteractive_login=True."""
+def test_load_valid_vault_token_refuses_noninteractive_login_when_blocked(
+    eks_module, monkeypatch
+):
+    """Non-interactive exec clients should not trigger OIDC login when blocked.
+
+    Verifies that block_noninteractive_login=True prevents browser-based login.
+    """
     monkeypatch.setattr(eks_module, "cached_vault_token", lambda _mode: None)
     monkeypatch.setattr(eks_module, "cache_lock", lambda _name: nullcontext())
     monkeypatch.setattr(eks_module, "exec_invocation_is_interactive", lambda: False)
@@ -175,8 +180,13 @@ def test_load_valid_vault_token_refuses_noninteractive_login_when_blocked(eks_mo
 
 
 @pytest.mark.unit
-def test_load_valid_vault_token_allows_noninteractive_login_when_not_blocked(eks_module, monkeypatch):
-    """Non-interactive setup calls should proceed to browser login when block_noninteractive_login=False."""
+def test_load_valid_vault_token_allows_noninteractive_login_when_not_blocked(
+    eks_module, monkeypatch
+):
+    """Non-interactive setup should proceed to OIDC login when not blocked.
+
+    Verifies that block_noninteractive_login=False allows browser login for setup.
+    """
     monkeypatch.setattr(eks_module, "cached_vault_token", lambda _mode: None)
     monkeypatch.setattr(eks_module, "cache_lock", lambda _name: nullcontext())
     monkeypatch.setattr(eks_module, "exec_invocation_is_interactive", lambda: False)
@@ -185,12 +195,12 @@ def test_load_valid_vault_token_allows_noninteractive_login_when_not_blocked(eks
         "oidc_login",
         lambda _client, _role: "setup-token",
     )
-    monkeypatch.setattr(eks_module, "dump_json", lambda *args, **kwargs: None)
+    monkeypatch.setattr(eks_module, "dump_json", lambda *_args, **_kwargs: None)
 
     token = eks_module.load_valid_vault_token(
         eks_module.AccessMode.DEVELOPER, block_noninteractive_login=False
     )
-    assert token == "setup-token"
+    assert token == "setup-token"  # noqa: S105
 
 
 @pytest.mark.unit


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
Ran setup on new laptop and came across a few issues that the changes appear to have resolved:

**Summary**
- Updated scripts/eks/eks.py so Headlamp/kubectl exec auth no longer auto-opens browser logins for non-interactive calls, and cache refreshes are serialized to avoid login storms.
- Changed kubeconfig generation in scripts/eks/eks.py so developer/admin setups write operator contexts by default instead of adding `-readonly` companion contexts.
- Added an opt-in `--include-readonly-contexts` path and kept the readonly-only mode unchanged.
- Updated tests in tests/scripts/eks/test_eks_cli.py and usage notes in scripts/eks/KUBE_ACCESS.md.