### PR TITLE
fix(open_metadata): own ingestion SA RBAC in substructure to end SSA conflict

### DIFF
--- a/src/ol_infrastructure/applications/open_metadata/__main__.py
+++ b/src/ol_infrastructure/applications/open_metadata/__main__.py
@@ -624,6 +624,10 @@ open_metadata_application = kubernetes.helm.v3.Release(
                         "k8s": {
                             # The schema doesn't yet support this value (TMM 2026-02-26)
                             # "namespace": open_metadata_namespace,  # noqa: ERA001
+                            # Pin the ingestion SA name (the chart default) so the
+                            # cross-stack contract is explicit: the substructure stack
+                            # creates this SA + its IRSA role/RBAC under this name.
+                            "serviceAccountName": "openmetadata-ingestion",
                             "enableFailureDiagnostics": True,
                             "ingestionImage": f"docker.getcollate.io/openmetadata/ingestion-base:{OPEN_METADATA_VERSION}",  # noqa: E501
                             "useOMJobOperator": True,

--- a/src/ol_infrastructure/applications/open_metadata/__main__.py
+++ b/src/ol_infrastructure/applications/open_metadata/__main__.py
@@ -627,6 +627,14 @@ open_metadata_application = kubernetes.helm.v3.Release(
                             "enableFailureDiagnostics": True,
                             "ingestionImage": f"docker.getcollate.io/openmetadata/ingestion-base:{OPEN_METADATA_VERSION}",  # noqa: E501
                             "useOMJobOperator": True,
+                            # The chart's k8s-pipeline-rbac.yaml stamps the shared
+                            # `serviceAccount.annotations` (the server IRSA role) onto
+                            # the ingestion SA too, which collides with the distinct
+                            # ingestion IRSA role applied in the substructure stack.
+                            # Disable chart-managed RBAC and own the ingestion SA, its
+                            # Role/RoleBinding, and the server pipeline-manager
+                            # Role/RoleBinding in substructure/open_metadata instead.
+                            "rbac": {"enabled": False},
                         },
                     },
                     "elasticsearch": {

--- a/src/ol_infrastructure/substructure/open_metadata/__main__.py
+++ b/src/ol_infrastructure/substructure/open_metadata/__main__.py
@@ -154,18 +154,180 @@ iam.RolePolicyAttachment(
     opts=ResourceOptions(parent=ingestion_irsa_role),
 )
 
-# Annotate the existing openmetadata-ingestion SA (created by the helm chart)
-# with the IRSA ARN so pods can assume the role.
-kubernetes.core.v1.ServiceAccountPatch(
-    f"om-ingestion-sa-irsa-annotation-{stack_info.env_suffix}",
-    metadata=kubernetes.meta.v1.ObjectMetaPatchArgs(
+# Pipeline RBAC for k8s ingestion jobs.
+#
+# The OpenMetadata Helm chart can create these via k8s-pipeline-rbac.yaml, but it
+# stamps the shared `serviceAccount.annotations` (the *server* IRSA role) onto the
+# ingestion SA, colliding with the distinct ingestion role we need here. So the app
+# stack sets `pipelineServiceClientConfig.k8s.rbac.enabled: false` and we own the
+# full set of resources here, giving the ingestion SA its own IRSA role-arn and
+# keeping clear lines of ownership between the two stacks.
+#
+# This mirrors the five resources from the chart's k8s-pipeline-rbac.yaml: the
+# ingestion ServiceAccount + Role + RoleBinding, plus the server pipeline-manager
+# Role + RoleBinding that lets the OpenMetadata server SA launch ingestion jobs.
+server_sa_name = "openmetadata"
+
+ingestion_service_account = kubernetes.core.v1.ServiceAccount(
+    f"om-ingestion-sa-{stack_info.env_suffix}",
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
         name=ingestion_sa_name,
         namespace=open_metadata_namespace,
+        labels={"app.kubernetes.io/component": "ingestion"},
         annotations={
             "eks.amazonaws.com/role-arn": ingestion_irsa_role.role.arn,
         },
     ),
     opts=ResourceOptions(depends_on=[ingestion_irsa_role]),
+)
+
+# Permissions the ingestion SA needs to run pipeline jobs in its own namespace.
+ingestion_role = kubernetes.rbac.v1.Role(
+    f"om-ingestion-role-{stack_info.env_suffix}",
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        name=ingestion_sa_name,
+        namespace=open_metadata_namespace,
+        labels={"app.kubernetes.io/component": "ingestion"},
+    ),
+    rules=[
+        kubernetes.rbac.v1.PolicyRuleArgs(
+            api_groups=[""],
+            resources=["pods"],
+            verbs=["get", "list", "create", "update", "patch", "delete"],
+        ),
+        kubernetes.rbac.v1.PolicyRuleArgs(
+            api_groups=[""],
+            resources=["pods/log"],
+            verbs=["get", "list", "watch"],
+        ),
+        kubernetes.rbac.v1.PolicyRuleArgs(
+            api_groups=[""],
+            resources=["configmaps"],
+            verbs=["get", "list", "create", "update", "patch", "delete"],
+        ),
+        kubernetes.rbac.v1.PolicyRuleArgs(
+            api_groups=[""],
+            resources=["secrets"],
+            verbs=["get", "list", "create", "update", "patch", "delete"],
+        ),
+        kubernetes.rbac.v1.PolicyRuleArgs(
+            api_groups=[""],
+            resources=["events"],
+            verbs=["get", "list"],
+        ),
+        kubernetes.rbac.v1.PolicyRuleArgs(
+            api_groups=["batch"],
+            resources=["jobs", "cronjobs"],
+            verbs=["get", "list", "create", "update", "patch", "delete"],
+        ),
+    ],
+)
+
+kubernetes.rbac.v1.RoleBinding(
+    f"om-ingestion-rolebinding-{stack_info.env_suffix}",
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        name=ingestion_sa_name,
+        namespace=open_metadata_namespace,
+        labels={"app.kubernetes.io/component": "ingestion"},
+    ),
+    subjects=[
+        kubernetes.rbac.v1.SubjectArgs(
+            kind="ServiceAccount",
+            name=ingestion_sa_name,
+            namespace=open_metadata_namespace,
+        )
+    ],
+    role_ref=kubernetes.rbac.v1.RoleRefArgs(
+        kind="Role",
+        name=ingestion_sa_name,
+        api_group="rbac.authorization.k8s.io",
+    ),
+    opts=ResourceOptions(depends_on=[ingestion_service_account, ingestion_role]),
+)
+
+# Permissions the OpenMetadata server SA needs to manage pipeline jobs and the
+# OMJob/CronOMJob custom resources used by the k8s pipeline client.
+server_pipeline_manager_role = kubernetes.rbac.v1.Role(
+    f"om-server-pipeline-manager-role-{stack_info.env_suffix}",
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        name="openmetadata-server-pipeline-manager",
+        namespace=open_metadata_namespace,
+        labels={"app.kubernetes.io/component": "server"},
+    ),
+    rules=[
+        kubernetes.rbac.v1.PolicyRuleArgs(
+            api_groups=[""],
+            resources=["pods"],
+            verbs=["get", "list", "create", "update", "patch", "delete"],
+        ),
+        kubernetes.rbac.v1.PolicyRuleArgs(
+            api_groups=[""],
+            resources=["pods/log"],
+            verbs=["get", "list", "watch"],
+        ),
+        kubernetes.rbac.v1.PolicyRuleArgs(
+            api_groups=[""],
+            resources=["configmaps"],
+            verbs=["get", "list", "create", "update", "patch", "delete"],
+        ),
+        kubernetes.rbac.v1.PolicyRuleArgs(
+            api_groups=[""],
+            resources=["secrets"],
+            verbs=["get", "list", "create", "update", "patch", "delete"],
+        ),
+        kubernetes.rbac.v1.PolicyRuleArgs(
+            api_groups=[""],
+            resources=["events"],
+            verbs=["get", "list"],
+        ),
+        kubernetes.rbac.v1.PolicyRuleArgs(
+            api_groups=["batch"],
+            resources=["jobs", "cronjobs"],
+            verbs=["get", "list", "create", "update", "patch", "delete"],
+        ),
+        kubernetes.rbac.v1.PolicyRuleArgs(
+            api_groups=["pipelines.openmetadata.org"],
+            resources=["omjobs"],
+            verbs=["get", "list", "create", "update", "patch", "delete"],
+        ),
+        kubernetes.rbac.v1.PolicyRuleArgs(
+            api_groups=["pipelines.openmetadata.org"],
+            resources=["omjobs/status"],
+            verbs=["get", "patch"],
+        ),
+        kubernetes.rbac.v1.PolicyRuleArgs(
+            api_groups=["pipelines.openmetadata.org"],
+            resources=["cronomjobs"],
+            verbs=["get", "list", "create", "update", "patch", "delete"],
+        ),
+        kubernetes.rbac.v1.PolicyRuleArgs(
+            api_groups=["pipelines.openmetadata.org"],
+            resources=["cronomjobs/status"],
+            verbs=["get", "patch"],
+        ),
+    ],
+)
+
+kubernetes.rbac.v1.RoleBinding(
+    f"om-server-pipeline-manager-rolebinding-{stack_info.env_suffix}",
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        name="openmetadata-server-pipeline-manager",
+        namespace=open_metadata_namespace,
+        labels={"app.kubernetes.io/component": "server"},
+    ),
+    subjects=[
+        kubernetes.rbac.v1.SubjectArgs(
+            kind="ServiceAccount",
+            name=server_sa_name,
+            namespace=open_metadata_namespace,
+        )
+    ],
+    role_ref=kubernetes.rbac.v1.RoleRefArgs(
+        kind="Role",
+        name="openmetadata-server-pipeline-manager",
+        api_group="rbac.authorization.k8s.io",
+    ),
+    opts=ResourceOptions(depends_on=[server_pipeline_manager_role]),
 )
 
 # ---------------------------------------------------------------------------

--- a/src/ol_infrastructure/substructure/open_metadata/__main__.py
+++ b/src/ol_infrastructure/substructure/open_metadata/__main__.py
@@ -181,6 +181,42 @@ ingestion_service_account = kubernetes.core.v1.ServiceAccount(
     opts=ResourceOptions(depends_on=[ingestion_irsa_role]),
 )
 
+# Core pipeline-job permissions shared by the ingestion SA and the server SA.
+# The server additionally needs the OMJob/CronOMJob rules appended below. Keeping
+# one source of truth avoids the two Roles drifting apart on a chart version bump.
+pipeline_job_rules = [
+    kubernetes.rbac.v1.PolicyRuleArgs(
+        api_groups=[""],
+        resources=["pods"],
+        verbs=["get", "list", "create", "update", "patch", "delete"],
+    ),
+    kubernetes.rbac.v1.PolicyRuleArgs(
+        api_groups=[""],
+        resources=["pods/log"],
+        verbs=["get", "list", "watch"],
+    ),
+    kubernetes.rbac.v1.PolicyRuleArgs(
+        api_groups=[""],
+        resources=["configmaps"],
+        verbs=["get", "list", "create", "update", "patch", "delete"],
+    ),
+    kubernetes.rbac.v1.PolicyRuleArgs(
+        api_groups=[""],
+        resources=["secrets"],
+        verbs=["get", "list", "create", "update", "patch", "delete"],
+    ),
+    kubernetes.rbac.v1.PolicyRuleArgs(
+        api_groups=[""],
+        resources=["events"],
+        verbs=["get", "list"],
+    ),
+    kubernetes.rbac.v1.PolicyRuleArgs(
+        api_groups=["batch"],
+        resources=["jobs", "cronjobs"],
+        verbs=["get", "list", "create", "update", "patch", "delete"],
+    ),
+]
+
 # Permissions the ingestion SA needs to run pipeline jobs in its own namespace.
 ingestion_role = kubernetes.rbac.v1.Role(
     f"om-ingestion-role-{stack_info.env_suffix}",
@@ -189,38 +225,7 @@ ingestion_role = kubernetes.rbac.v1.Role(
         namespace=open_metadata_namespace,
         labels={"app.kubernetes.io/component": "ingestion"},
     ),
-    rules=[
-        kubernetes.rbac.v1.PolicyRuleArgs(
-            api_groups=[""],
-            resources=["pods"],
-            verbs=["get", "list", "create", "update", "patch", "delete"],
-        ),
-        kubernetes.rbac.v1.PolicyRuleArgs(
-            api_groups=[""],
-            resources=["pods/log"],
-            verbs=["get", "list", "watch"],
-        ),
-        kubernetes.rbac.v1.PolicyRuleArgs(
-            api_groups=[""],
-            resources=["configmaps"],
-            verbs=["get", "list", "create", "update", "patch", "delete"],
-        ),
-        kubernetes.rbac.v1.PolicyRuleArgs(
-            api_groups=[""],
-            resources=["secrets"],
-            verbs=["get", "list", "create", "update", "patch", "delete"],
-        ),
-        kubernetes.rbac.v1.PolicyRuleArgs(
-            api_groups=[""],
-            resources=["events"],
-            verbs=["get", "list"],
-        ),
-        kubernetes.rbac.v1.PolicyRuleArgs(
-            api_groups=["batch"],
-            resources=["jobs", "cronjobs"],
-            verbs=["get", "list", "create", "update", "patch", "delete"],
-        ),
-    ],
+    rules=pipeline_job_rules,
 )
 
 kubernetes.rbac.v1.RoleBinding(
@@ -255,36 +260,7 @@ server_pipeline_manager_role = kubernetes.rbac.v1.Role(
         labels={"app.kubernetes.io/component": "server"},
     ),
     rules=[
-        kubernetes.rbac.v1.PolicyRuleArgs(
-            api_groups=[""],
-            resources=["pods"],
-            verbs=["get", "list", "create", "update", "patch", "delete"],
-        ),
-        kubernetes.rbac.v1.PolicyRuleArgs(
-            api_groups=[""],
-            resources=["pods/log"],
-            verbs=["get", "list", "watch"],
-        ),
-        kubernetes.rbac.v1.PolicyRuleArgs(
-            api_groups=[""],
-            resources=["configmaps"],
-            verbs=["get", "list", "create", "update", "patch", "delete"],
-        ),
-        kubernetes.rbac.v1.PolicyRuleArgs(
-            api_groups=[""],
-            resources=["secrets"],
-            verbs=["get", "list", "create", "update", "patch", "delete"],
-        ),
-        kubernetes.rbac.v1.PolicyRuleArgs(
-            api_groups=[""],
-            resources=["events"],
-            verbs=["get", "list"],
-        ),
-        kubernetes.rbac.v1.PolicyRuleArgs(
-            api_groups=["batch"],
-            resources=["jobs", "cronjobs"],
-            verbs=["get", "list", "create", "update", "patch", "delete"],
-        ),
+        *pipeline_job_rules,
         kubernetes.rbac.v1.PolicyRuleArgs(
             api_groups=["pipelines.openmetadata.org"],
             resources=["omjobs"],


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Fixes flakey `substructure/open_metadata` deploys in Concourse that routinely failed with a server-side apply (SSA) field conflict:

```
kubernetes:core/v1:ServiceAccountPatch (om-ingestion-sa-irsa-annotation-qa):
  error: ... server-side apply field conflict detected
  The resource managed by field manager "pulumi-kubernetes-..." had an apply conflict:
  conflict with "pulumi-resource-kubernetes" using v1: .metadata.annotations.eks.amazonaws.com/role-arn
```

**Root cause:** The OpenMetadata Helm chart's `k8s-pipeline-rbac.yaml` creates the `openmetadata-ingestion` ServiceAccount and stamps the chart's shared `serviceAccount.annotations` — i.e. the **server** IRSA role-arn — onto it. The substructure stack then tried to overwrite that same annotation with the dedicated **ingestion** IRSA role via a `ServiceAccountPatch`. Two field managers fighting over `.metadata.annotations.eks.amazonaws.com/role-arn` with different values → SSA rejects the patch.

**Fix (clear ownership split):**
- **Application stack:** set `pipelineServiceClientConfig.k8s.rbac.enabled: false` so the chart no longer creates the ingestion SA + RBAC, and stops stamping the server role onto the ingestion SA. The server SA keeps its own role-arn via the unchanged `serviceAccount.annotations`.
- **Substructure stack:** replace the `ServiceAccountPatch` with the five resources the chart's `rbac.enabled` block used to own:
  - `openmetadata-ingestion` ServiceAccount — created with its **own** ingestion IRSA role-arn at creation time (no patch, no conflict).
  - its `Role` + `RoleBinding` (pod/log/configmap/secret/event/job permissions).
  - the `openmetadata-server-pipeline-manager` `Role` + `RoleBinding`, bound to the server SA so the OpenMetadata server can still launch ingestion jobs and manage `omjobs`/`cronomjobs`.

Net result: the app chart owns the server deployment; the substructure stack owns ingestion identity and its RBAC, alongside the IRSA role it already creates.

RBAC rules are copied verbatim from the chart's `k8s-pipeline-rbac.yaml` for OpenMetadata 1.13.0.

### How can this be tested?
- Deploy the `open_metadata` application stack (QA): confirm the `openmetadata` server SA still carries the server role-arn, and the chart no longer renders `openmetadata-ingestion` SA / pipeline RBAC.
- Deploy the `substructure/open_metadata` stack (QA): it should now apply cleanly with no SSA `role-arn` conflict, and create the ingestion SA (with the **ingestion** role-arn), both Role/RoleBindings.
- Verify ingestion still works end-to-end: trigger a CronOMJob and confirm the server can launch the job (server pipeline-manager RoleBinding present) and the ingestion pod assumes the ingestion IRSA role for Glue/S3/RDS access.
- `kubectl get sa openmetadata-ingestion -n open-metadata -o yaml` → annotation points at the `om-ingestion-*` role, not the server role.

### Additional Context
- The `rbac.enabled` block in the chart wraps **five** resources, not just the SA — including the `openmetadata-server-pipeline-manager` Role/RoleBinding that grants the server SA permission to launch jobs. Disabling chart RBAC without recreating that piece would silently break the server's ability to start ingestion jobs; this PR recreates it.
- Deploy ordering: substructure must run with/after the app stack so the server regains job-launch RBAC. This cross-stack dependency already existed (the IRSA role has always lived in substructure).
- If `OPEN_METADATA_VERSION` is bumped past 1.13.0, re-diff `k8s-pipeline-rbac.yaml` upstream in case the required permissions change.

### Checklist:
One-time migration per environment (QA, Production) to avoid a transient SSA conflict while ownership moves from Helm to the substructure stack:
- [ ] Deploy the **application** `open_metadata` stack first so the `helm upgrade` prunes the old Helm-managed `openmetadata-ingestion` SA + pipeline RBAC, **or** manually delete them once: `kubectl delete sa,role,rolebinding openmetadata-ingestion -n open-metadata` (and `role/rolebinding openmetadata-server-pipeline-manager`).
- [ ] Then deploy the **substructure** `open_metadata` stack to recreate the SA (with the ingestion role-arn) + RBAC.
