### PR TITLE
fix(starrocks): pass Vault provider to get_secret_output invoke

### DIFF
--- a/src/ol_infrastructure/substructure/starrocks/__main__.py
+++ b/src/ol_infrastructure/substructure/starrocks/__main__.py
@@ -34,16 +34,19 @@ from pathlib import Path
 import pulumi
 import pulumi_command as command
 import pulumi_vault as vault
-from pulumi import Config, ResourceOptions, export
+from pulumi import Config, InvokeOptions, ResourceOptions, export
 from pulumi_vault.generic.get_secret import get_secret_output as vault_get_secret_output
 
 from bridge.lib.magic_numbers import ONE_MONTH_SECONDS
 from bridge.lib.versions import VAULT_PLUGIN_STARROCKS_SHA256
 from ol_infrastructure.lib import pulumi_projects
 from ol_infrastructure.lib.pulumi_helper import make_stack_reference, parse_stack
-from ol_infrastructure.lib.vault import setup_vault_provider
+from ol_infrastructure.lib.vault import get_vault_provider, setup_vault_provider
 
 setup_vault_provider()
+
+_vault_address = pulumi.Config("vault").require("address")
+_vault_env_namespace = pulumi.Config("vault_server").require("env_namespace")
 stack_info = parse_stack()
 starrocks_config = Config("starrocks")
 
@@ -542,6 +545,9 @@ if oidc_enabled:
     _oidc_vault = vault_get_secret_output(
         path="secret-operations/sso/starrocks",
         with_lease_start_time=False,
+        opts=InvokeOptions(
+            provider=get_vault_provider(_vault_address, _vault_env_namespace)
+        ),
     )
     _oidc_issuer_url: pulumi.Output[str] = _oidc_vault.data.apply(lambda d: d["url"])
     _oidc_client_id: pulumi.Output[str] = _oidc_vault.data.apply(


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)

The Production StarRocks substructure deploy was failing with:

```
Exception: invoke of vault:generic/getSecret:getSecret failed: invocation of
vault:generic/getSecret:getSecret returned an error: invoking
vault:generic/getSecret:getSecret: 1 error occurred:
    * no vault token set on Client
```

Root cause: `setup_vault_provider()` registers a Pulumi stack transformation that injects the authenticated Vault provider onto every `vault:*` **resource**. However, `vault_get_secret_output` (used to read OIDC credentials from `secret-operations/sso/starrocks`) is a Pulumi **invoke** (data-source lookup), not a resource. Stack transformations do not apply to invokes — they bypass the transformation entirely and hit the default provider, which has no token.

Fix: explicitly pass the authenticated provider via `InvokeOptions(provider=...)` to the `vault_get_secret_output` call. This matches the pattern already used elsewhere in the codebase:
- `src/ol_infrastructure/infrastructure/aws/eks/traefik.py:179`
- `src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py:211`
- `src/ol_infrastructure/substructure/keycloak/olapps.py:536`

`get_vault_provider` is `@lru_cache`-decorated so the provider object is reused — no redundant auth handshakes.

### How can this be tested?

Run `pulumi preview` or `pulumi up` against the `lakehouse.Production` stack in `src/ol_infrastructure/substructure/starrocks/`. The OIDC security integration setup should no longer fail with "no vault token set on Client".