### PR TITLE
fix(starrocks): avoid duplicate vault Provider URN from setup_vault_provider

### DIFF
--- a/src/ol_infrastructure/lib/vault.py
+++ b/src/ol_infrastructure/lib/vault.py
@@ -376,7 +376,7 @@ def setup_vault_provider(
     stack_info: StackInfo | None = None,
     *,
     skip_child_token: bool | None = None,
-):
+) -> pulumi_vault.Provider:
     if stack_info:
         vault_address = f"https://vault-{stack_info.env_suffix}.odl.mit.edu"
         vault_env_namespace = f"operations.{stack_info.env_suffix}"
@@ -390,4 +390,7 @@ def setup_vault_provider(
             vault_env_namespace,
             skip_child_token=skip_child_token,
         )
+    )
+    return get_vault_provider(
+        vault_address, vault_env_namespace, skip_child_token=skip_child_token
     )

--- a/src/ol_infrastructure/lib/vault.py
+++ b/src/ol_infrastructure/lib/vault.py
@@ -331,7 +331,7 @@ def get_vault_provider(
     vault_env_namespace: str,
     provider_name: str | None = None,
     skip_child_token: bool | None = None,  # noqa: FBT001
-) -> pulumi.ResourceTransformationResult:
+) -> pulumi_vault.Provider:
     pulumi_vault_creds = read_yaml_secrets(
         Path().joinpath(
             # We are forcing the assumption that the Vault cluster is in the operations

--- a/src/ol_infrastructure/substructure/starrocks/__main__.py
+++ b/src/ol_infrastructure/substructure/starrocks/__main__.py
@@ -41,12 +41,9 @@ from bridge.lib.magic_numbers import ONE_MONTH_SECONDS
 from bridge.lib.versions import VAULT_PLUGIN_STARROCKS_SHA256
 from ol_infrastructure.lib import pulumi_projects
 from ol_infrastructure.lib.pulumi_helper import make_stack_reference, parse_stack
-from ol_infrastructure.lib.vault import get_vault_provider, setup_vault_provider
+from ol_infrastructure.lib.vault import setup_vault_provider
 
-setup_vault_provider()
-
-_vault_address = pulumi.Config("vault").require("address")
-_vault_env_namespace = pulumi.Config("vault_server").require("env_namespace")
+_vault_provider = setup_vault_provider()
 stack_info = parse_stack()
 starrocks_config = Config("starrocks")
 
@@ -545,9 +542,7 @@ if oidc_enabled:
     _oidc_vault = vault_get_secret_output(
         path="secret-operations/sso/starrocks",
         with_lease_start_time=False,
-        opts=InvokeOptions(
-            provider=get_vault_provider(_vault_address, _vault_env_namespace)
-        ),
+        opts=InvokeOptions(provider=_vault_provider),
     )
     _oidc_issuer_url: pulumi.Output[str] = _oidc_vault.data.apply(lambda d: d["url"])
     _oidc_client_id: pulumi.Output[str] = _oidc_vault.data.apply(


### PR DESCRIPTION
### What are the relevant tickets?
N/A — follow-up to #4816

### Description (What does it do?)

After #4816, the Production deploy failed with a new error:

```
pulumi:providers:vault (vault-provider):
  error: Duplicate resource URN 'urn:pulumi:lakehouse.QA::ol-substructure-starrocks::pulumi:providers:vault::vault-provider';
  try giving it a unique name
```

Root cause: Python's `lru_cache` uses positional and keyword arguments as distinct cache keys. The stack transformation (registered by `setup_vault_provider`) calls `get_vault_provider(addr, ns, skip_child_token=None)` — keyword form. The explicit call added in #4816 used `get_vault_provider(addr, ns)` — positional-only form. These produce different cache keys, so `get_vault_provider` created two `pulumi_vault.Provider` resources with the same name `"vault-provider"`, causing the duplicate URN error.

Fix: have `setup_vault_provider` return the provider it already constructs (calling `get_vault_provider` with the exact same arguments the transformation uses). The starrocks stack stores this as `_vault_provider` and passes it directly to `InvokeOptions`. No second `get_vault_provider` call, no cache key divergence.

All other callers of `setup_vault_provider` ignore its return value, so the change is fully backward-compatible.

### How can this be tested?

Run `pulumi preview` against the `lakehouse.Production` (or `lakehouse.QA`) stack in `src/ol_infrastructure/substructure/starrocks/`. Both the "no vault token" error and the "Duplicate resource URN" error should be gone.