### PR TITLE
fix(starrocks): work around missing IF EXISTS on DROP SECURITY INTEGRATION

### DIFF
--- a/src/ol_infrastructure/substructure/starrocks/__main__.py
+++ b/src/ol_infrastructure/substructure/starrocks/__main__.py
@@ -594,8 +594,8 @@ if oidc_enabled:
     # The delete step uses _exec_delete_sql which propagates errors normally.
     _exec_integration_sql = (
         f"{_mysql_opts_setup}"
-        f" && printf 'DROP SECURITY INTEGRATION {_OIDC_SECURITY_INTEGRATION_NAME};'"
-        f" | {_mysql_client} 2>/dev/null; true"
+        f" && {{ printf 'DROP SECURITY INTEGRATION {_OIDC_SECURITY_INTEGRATION_NAME};'"
+        f" | {_mysql_client} 2>/dev/null || true; }}"
         f" && printf '%s' \"$STARROCKS_SQL\" | {_mysql_client}"
         f"; {_mysql_opts_cleanup}"
     )

--- a/src/ol_infrastructure/substructure/starrocks/__main__.py
+++ b/src/ol_infrastructure/substructure/starrocks/__main__.py
@@ -565,7 +565,6 @@ if oidc_enabled:
         client_secret = json.dumps(args[2])[1:-1]
         _n = _OIDC_SECURITY_INTEGRATION_NAME
         return (
-            f"DROP SECURITY INTEGRATION IF EXISTS {_n};\n"
             f"CREATE SECURITY INTEGRATION {_n} PROPERTIES (\n"
             '    "type" = "authentication_oauth2",\n'
             f'    "auth_server_url" = "{issuer}'
@@ -586,13 +585,25 @@ if oidc_enabled:
         _oidc_issuer_url, _oidc_client_id, _oidc_client_secret
     ).apply(_build_integration_sql)
     _drop_integration_sql = (
-        f"DROP SECURITY INTEGRATION IF EXISTS {_OIDC_SECURITY_INTEGRATION_NAME};"
+        f"DROP SECURITY INTEGRATION {_OIDC_SECURITY_INTEGRATION_NAME};"
+    )
+
+    # StarRocks does not support DROP SECURITY INTEGRATION IF EXISTS, so the
+    # create/update step silences the drop error (expected on first deploy when
+    # the integration does not yet exist) then unconditionally runs the CREATE.
+    # The delete step uses _exec_delete_sql which propagates errors normally.
+    _exec_integration_sql = (
+        f"{_mysql_opts_setup}"
+        f" && printf 'DROP SECURITY INTEGRATION {_OIDC_SECURITY_INTEGRATION_NAME};'"
+        f" | {_mysql_client} 2>/dev/null; true"
+        f" && printf '%s' \"$STARROCKS_SQL\" | {_mysql_client}"
+        f"; {_mysql_opts_cleanup}"
     )
 
     security_integration_cmd = command.local.Command(
         f"starrocks-{stack_info.env_suffix}-security-integration-setup",
-        create=_exec_sql,
-        update=_exec_sql,
+        create=_exec_integration_sql,
+        update=_exec_integration_sql,
         delete=_exec_delete_sql,
         environment={
             **_mysql_env,


### PR DESCRIPTION
### What are the relevant tickets?
N/A — follow-up to #4816 and #4817

### Description (What does it do?)

After the Vault provider fixes landed, the next deploy error was:

```
ERROR 1064 (HY000) at line 1: Getting syntax error at line 1, column 26.
Detail message: Unexpected input 'IF', the most similar input is {a legal identifier}.
```

StarRocks does not support `DROP SECURITY INTEGRATION IF EXISTS` — the parser rejects the `IF` token. The [StarRocks documentation](https://docs.starrocks.io/docs/administration/user_privs/authentication/security_integration.md) shows the syntax as simply `DROP SECURITY INTEGRATION <name>` with no conditional clause.

The previous create/update SQL embedded `DROP SECURITY INTEGRATION IF EXISTS keycloak_oauth2;` as the first statement in `STARROCKS_SQL`. On first deploy when the integration doesn't exist yet, this causes a parse error (not a "not found" error, but a syntax rejection).

**Fix:** Remove the DROP from the SQL payload (`STARROCKS_SQL`) and replace it with a shell-level silent drop that runs before the CREATE:
```bash
printf 'DROP SECURITY INTEGRATION keycloak_oauth2;' | mysql ... 2>/dev/null; true
printf '%s' "$STARROCKS_SQL" | mysql ...
```
The `2>/dev/null; true` suppresses the expected "does not exist" error on first deploy. All errors from the CREATE step propagate normally. The `pulumi destroy` path (`_exec_delete_sql`) is unchanged and continues to fail loudly if the integration is absent.

Also removed `IF EXISTS` from `_drop_integration_sql` (used on destroy) since that syntax is equally unsupported.

### How can this be tested?

Run `pulumi up` against `lakehouse.Production` or `lakehouse.QA` in `src/ol_infrastructure/substructure/starrocks/`. The security integration setup command should complete without syntax errors.