### PR TITLE
fix(starrocks): use 'native' in authentication_chain and add query-clients Keycloak role

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/ol_data_platform.py
+++ b/src/ol_infrastructure/substructure/keycloak/ol_data_platform.py
@@ -500,6 +500,7 @@ def create_ol_data_platform_realm(  # noqa: C901, PLR0912, PLR0913, PLR0915
     for resource_name, role in [
         ("ol-starrocks-service-account-view-realm", "view-realm"),
         ("ol-starrocks-service-account-view-users", "view-users"),
+        ("ol-starrocks-service-account-query-clients", "query-clients"),
     ]:
         keycloak.openid.ClientServiceAccountRole(
             resource_name,

--- a/src/ol_infrastructure/substructure/starrocks/__main__.py
+++ b/src/ol_infrastructure/substructure/starrocks/__main__.py
@@ -622,13 +622,12 @@ if oidc_enabled:
     # Point the FE authentication chain at the new security integration.
     # StarRocks persists ADMIN SET FRONTEND CONFIG changes to BDB so they
     # survive pod restarts without requiring a fe.conf change.
-    _auth_chain = f"authentication_starrocks,{_OIDC_SECURITY_INTEGRATION_NAME}"
+    _auth_chain = f"native,{_OIDC_SECURITY_INTEGRATION_NAME}"
     _auth_chain_sql = (
         f'ADMIN SET FRONTEND CONFIG ("authentication_chain" = "{_auth_chain}");'
     )
     _auth_chain_disable_sql = (
-        "ADMIN SET FRONTEND CONFIG"
-        ' ("authentication_chain" = "authentication_starrocks");'
+        'ADMIN SET FRONTEND CONFIG ("authentication_chain" = "native");'
     )
     command.local.Command(
         f"starrocks-{stack_info.env_suffix}-oidc-auth-chain-setup",


### PR DESCRIPTION
### What are the relevant tickets?
N/A — follow-up to #4816, #4817, #4819

### Description (What does it do?)

Two errors from the latest Production deploy run:

**1. `starrocks-qa-oidc-auth-chain-setup` — authentication_chain syntax**

```
ERROR 1064 (HY000): Failed to set config 'authentication_chain'.
err: 'native' must be in the list, and cannot have duplicates,
current value: authentication_starrocks,keycloak_oauth2
```

Newer StarRocks versions renamed the built-in authentication method from `authentication_starrocks` to `native` in the `authentication_chain` FE config. Fixed in both the enable SQL (`native,keycloak_oauth2`) and the disable/destroy SQL (`native`).

**2. `starrocks-qa-keycloak-group-sync` — Keycloak 403**

```
Keycloak API error 403 for .../admin/realms/ol-data-platform/clients?clientId=ol-starrocks-client
```

`keycloak_group_sync.py` calls `GET /clients?clientId=ol-starrocks-client` to resolve the client UUID before listing client role memberships. This endpoint requires `query-clients` (or `view-clients`) on `realm-management`. The `ol-starrocks-client` service account only had `view-realm` and `view-users`. Added `query-clients` as the minimum required privilege in `substructure/keycloak/ol_data_platform.py`.

### How can this be tested?

- Run `pulumi up` on the `substructure/keycloak` stack (`ol-data-platform` realm) to grant `query-clients` to the service account.
- Then run `pulumi up` on `substructure/starrocks` — both the auth-chain setup and the Keycloak group sync should succeed.