### PR TITLE
Increase celery beat pod mem

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1535,7 +1535,10 @@ mitlearn_k8s_app = OLApplicationK8s(
                 resource_limits={"memory": "2400Mi"},
             ),
         ],
-        celery_beat_config=OLApplicationK8sCeleryBeatConfig(),
+        celery_beat_config=OLApplicationK8sCeleryBeatConfig(
+            resource_requests={"cpu": "100m", "memory": "2048Mi"},
+            resource_limits={"memory": "2048Mi"},
+        ),
         resource_requests={"cpu": "250m", "memory": "2400Mi"},
         resource_limits={"memory": "2400Mi"},
         hpa_scaling_metrics=[


### PR DESCRIPTION
### Description (What does it do?)
<!--- Describe your changes in detail -->
Increase memory of celery beat pods in learn given that they are OOM killed when running scheduled tasks.
<img width="1188" height="735" alt="image" src="https://github.com/user-attachments/assets/dea03ab7-ebc2-4fdd-a20d-10727127eb46" />
