### PR TITLE
Disable CI alerts

### DIFF
--- a/src/ol_infrastructure/components/aws/cloudwatch.py
+++ b/src/ol_infrastructure/components/aws/cloudwatch.py
@@ -145,11 +145,12 @@ class OLCloudWatchAlarmSimpleElastiCache(ComponentResource):
 
         sns_topic_arn = get_monitoring_sns_arn(alarm_config.level)
         cache_cluster_id = f"{alarm_config.cluster_id}{alarm_config.node_id}"
+        alarm_actions = [sns_topic_arn] if alarm_config.enabled else []
 
         self.metric_alarm = cloudwatch.MetricAlarm(
             f"{cache_cluster_id}-{alarm_config.metric_name}-simple-elasticache_alarm",
-            actions_enabled=True,
-            alarm_actions=[sns_topic_arn],
+            actions_enabled=alarm_config.enabled,
+            alarm_actions=alarm_actions,
             alarm_description=alarm_config.description,
             comparison_operator=alarm_config.comparison_operator,
             datapoints_to_alarm=alarm_config.datapoints_to_alarm,
@@ -195,11 +196,12 @@ class OLCloudWatchAlarmSimpleRDS(ComponentResource):
         resource_options = ResourceOptions(parent=self).merge(opts)
 
         sns_topic_arn = get_monitoring_sns_arn(alarm_config.level)
+        alarm_actions = [sns_topic_arn] if alarm_config.enabled else []
 
         self.metric_alarm = cloudwatch.MetricAlarm(
             f"{alarm_config.database_identifier}-{alarm_config.metric_name}-simple-rds-alarm",
-            actions_enabled=True,
-            alarm_actions=[sns_topic_arn],
+            actions_enabled=alarm_config.enabled,
+            alarm_actions=alarm_actions,
             alarm_description=alarm_config.description,
             comparison_operator=alarm_config.comparison_operator,
             datapoints_to_alarm=alarm_config.datapoints_to_alarm,

--- a/src/ol_infrastructure/components/aws/database.py
+++ b/src/ol_infrastructure/components/aws/database.py
@@ -634,8 +634,16 @@ class OLAmazonDB(pulumi.ComponentResource):
             },
         }
 
+        ci_profiles = {
+            alarm_name: {
+                **alarm_args,
+                "enabled": False,
+            }
+            for alarm_name, alarm_args in global_profiles.items()
+        }
+
         monitoring_profiles = {
-            "ci": {},
+            "ci": ci_profiles,
             "qa": {},
             "production": {
                 "EBSIOBlance": {


### PR DESCRIPTION
### Summary

This change updates CloudWatch alarm behavior so CI RDS alarms remain visible for monitoring but do not trigger notifications.

### What Changed

- Added support for non-notifying alarms by honoring the existing `enabled` flag in the CloudWatch alarm component.
- Updated the CI RDS monitoring profile to create alarms with notifications disabled (`enabled: false`).

### Outcome

- CI still surfaces RDS issues in CloudWatch (state changes and history are preserved).
- CI no longer sends SNS/Rootly alerts for these alarms.
- QA and Production alert behavior is unchanged.

