### PR TITLE
feat(mfe): add frontend-app-admin-console to mitxonline pipeline and Fastly routing

### DIFF
--- a/src/bridge/settings/openedx/types.py
+++ b/src/bridge/settings/openedx/types.py
@@ -73,6 +73,11 @@ class OpenEdxMicroFrontend(StrEnum, metaclass=EnumInvertedLookupMeta):
         "https://github.com/openedx/frontend-app-learner-dashboard",
         "dashboard",
     )
+    admin_console = (
+        "admin-console",
+        "https://github.com/openedx/frontend-app-admin-console",
+        "admin-console",
+    )
     ora_grading = (
         "ora-grading",
         "https://github.com/openedx/frontend-app-ora-grading",

--- a/src/bridge/settings/openedx/version_matrix.py
+++ b/src/bridge/settings/openedx/version_matrix.py
@@ -476,6 +476,11 @@ ReleaseMap: dict[
     "master": {
         "mitxonline": [
             OpenEdxApplicationVersion(
+                application="admin-console",
+                application_type="MFE",
+                release="master",
+            ),
+            OpenEdxApplicationVersion(
                 application="codejail",
                 application_type="IDA",
                 release="master",

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -158,6 +158,7 @@ def mfe_params(
         "SEARCH_CATALOG_URL": f"https://{open_edx.lms_domain}/courses",
         "SESSION_COOKIE_DOMAIN": open_edx.lms_domain,
         "SITE_NAME": open_edx.site_name,
+        "COURSE_AUTHORING_MICROFRONTEND_URL": f"https://{open_edx.studio_domain}/authoring",
         "STUDIO_BASE_URL": f"https://{open_edx.studio_domain}",
         "SUPPORT_URL": open_edx.support_url,
         "TERMS_OF_SERVICE_URL": open_edx.terms_of_service_url,

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.CI.yaml
@@ -77,6 +77,7 @@ config:
     secure: v1:+8kgTH+x98kC+Lxc:bW03E5mk8wRB+FxZYtj06FPx/MEJuEiKO5ekaDTZKmqmfklisVhidp0fhX+So2Eygf/Aiyqp5L03RCzA8k7I4ZmlNss19//pdGgBDwa3HAbw
   edxapp:enable_notes: "True"
   edxapp:enabled_mfes:
+    admin_console: admin-console
     communications: communications
     authoring: authoring
     discussions: discuss

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.QA.yaml
@@ -79,6 +79,7 @@ config:
   edxapp:elb_healthcheck_interval: "30"
   edxapp:enable_notes: "True"
   edxapp:enabled_mfes:
+    admin_console: admin-console
     communications: communications
     authoring: authoring
     discussions: discuss

--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -161,6 +161,7 @@ def _build_interpolated_config_dict(
         "MIT_LEARN_AI_XBLOCK_PROBLEM_SET_LIST_URL": f"https://{edxapp_config.require('mit_learn_api_domain')}/ai/api/v0/problem_set_list",
         "MIT_LEARN_AI_XBLOCK_CHAT_RATING_URL": f"https://{edxapp_config.require('mit_learn_api_domain')}/ai/api/v0/chat_sessions/",
         "MIT_LEARN_LOGO": f"https://{domains['lms']}/static/mitxonline/images/mit-learn-logo.svg",
+        "ADMIN_CONSOLE_MICROFRONTEND_URL": f"https://{domains['lms']}/admin-console",
         "COURSE_AUTHORING_MICROFRONTEND_URL": f"https://{domains['studio']}/authoring",
         "INSTRUCTOR_MICROFRONTEND_URL": f"https://{domains['lms']}/apps/instructor-dashboard",
         "LEARNING_MICROFRONTEND_URL": f"https://{domains['lms']}/learn",

--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -52,6 +52,7 @@ def _build_interpolated_config_dict(
         Configuration dictionary for 60-interpolated-config.yaml
     """
     domains = edxapp_config.require_object("domains")
+    enabled_mfes: dict[str, str] = edxapp_config.get_object("enabled_mfes") or {}
 
     # Determine marketing domain based on deployment type
     marketing_domain = (
@@ -161,9 +162,17 @@ def _build_interpolated_config_dict(
         "MIT_LEARN_AI_XBLOCK_PROBLEM_SET_LIST_URL": f"https://{edxapp_config.require('mit_learn_api_domain')}/ai/api/v0/problem_set_list",
         "MIT_LEARN_AI_XBLOCK_CHAT_RATING_URL": f"https://{edxapp_config.require('mit_learn_api_domain')}/ai/api/v0/chat_sessions/",
         "MIT_LEARN_LOGO": f"https://{domains['lms']}/static/mitxonline/images/mit-learn-logo.svg",
-        "ADMIN_CONSOLE_MICROFRONTEND_URL": f"https://{domains['lms']}/admin-console",
+        "ADMIN_CONSOLE_MICROFRONTEND_URL": (
+            f"https://{domains['lms']}/admin-console"
+            if "admin_console" in enabled_mfes
+            else None
+        ),
         "COURSE_AUTHORING_MICROFRONTEND_URL": f"https://{domains['studio']}/authoring",
-        "INSTRUCTOR_MICROFRONTEND_URL": f"https://{domains['lms']}/apps/instructor-dashboard",
+        "INSTRUCTOR_MICROFRONTEND_URL": (
+            f"https://{domains['lms']}/apps/instructor-dashboard"
+            if "instructor" in enabled_mfes
+            else None
+        ),
         "LEARNING_MICROFRONTEND_URL": f"https://{domains['lms']}/learn",
         "LMS_BASE": domains["lms"],
         "LMS_INTERNAL_ROOT_URL": f"https://{domains['lms']}",


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

Adds `frontend-app-admin-console` to the mitxonline MFE build/deploy pipeline, Fastly CDN routing, and Django LMS configuration.

The admin console is an AuthZ/permissions management MFE (`APP_ID=admin-console`, served at `/admin-console/`). It uses `@openedx/frontend-build` (webpack) so it goes through the existing `build_legacy_configured` Concourse pipeline path. Companion lehrer PR: https://github.com/mitodl/lehrer/pull/74

**Changes:**

- **`types.py`** — Add `OpenEdxMicroFrontend.admin_console` with `app_id="admin-console"`, repo URL, and `path="admin-console"`. This is the single source of truth consumed by the pipeline and Fastly routing.

- **`version_matrix.py`** — Add to `master/mitxonline` build list so Concourse generates CI→QA→Production jobs for this MFE.

- **`Pulumi.mitxonline.CI.yaml` + `Pulumi.mitxonline.QA.yaml`** — Add `admin_console: admin-console` to `edxapp:enabled_mfes`. The `__main__.py` builds the Fastly routing regex from these path values (`^/(admin-console|...)/`), enabling S3 serving, cache-strip, and SPA 404→index.html fallback for the MFE.

- **`k8s_configmaps.py`** — Add `ADMIN_CONSOLE_MICROFRONTEND_URL` to the shared interpolated config. This setting is already read by [`lms/djangoapps/instructor/views/serializers_v2.py`](https://github.com/mitodl/mitx-platform/blob/master/lms/djangoapps/instructor/views/serializers_v2.py#L503-L509) — the LMS instructor API appends `/authz` to it and exposes the resulting URL to instructor-dashboard MFE users who have the appropriate access.

- **`pipeline.py`** — Add `COURSE_AUTHORING_MICROFRONTEND_URL` to `mfe_params()`. The admin-console reads `process.env.COURSE_AUTHORING_MICROFRONTEND_URL` at build time (see [index.tsx](https://github.com/openedx/frontend-app-admin-console/blob/master/src/index.tsx)) and if unset would override the runtime MFE config API value with `null`. Setting it at build time bakes in the correct `{studio_domain}/authoring` URL.

### How can this be tested?

1. Deploy Pulumi stack to CI (`pulumi up` for `mitxonline.CI`) — verify Fastly regex now includes `admin-console`.
2. Trigger the Concourse pipeline for `admin-console/mitxonline/CI` — verify the MFE builds and assets land in the S3 MFE bucket under `admin-console/`.
3. Navigate to `https://{ci-lms-domain}/admin-console/authz` — verify the SPA loads.
4. Hit the instructor API and verify `admin_console_url` is populated in the response.

### Additional Context

Production stack config is intentionally left unchanged — admin-console should complete CI→QA validation before being promoted to Production.

`COURSE_AUTHORING_MICROFRONTEND_URL` is added to `mfe_params()` globally (not admin-console-specific) since it is a standard Open edX env var that other MFEs may also want to reference, and the value is already derived from `open_edx.studio_domain` which is available to all builds.