### PR TITLE
fix(dagster): enable multi-replica gRPC user code servers + fix deploymentStrategy key

### DIFF
--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -881,6 +881,10 @@ code_locations: list[dict[str, str | int]] = [
 ]
 
 # Build deployments list for user code
+# Code locations that run 2 replicas for resilience. Criteria: OOM-prone,
+# slow-starting (making restarts expensive), or high sensor-tick frequency.
+multi_replica_locations = {"legacy_openedx", "lakehouse", "data_loading"}
+
 deployments = []
 for location in code_locations:
     name: str = location["name"]  # type: ignore[assignment]
@@ -907,7 +911,8 @@ for location in code_locations:
             "tag": image_tag_or_digest,
             "pullPolicy": "IfNotPresent",
         },
-        "strategy": {
+        # Chart key is deploymentStrategy, not strategy.
+        "deploymentStrategy": {
             "type": "RollingUpdate",
             "rollingUpdate": {"maxSurge": 1, "maxUnavailable": 0},
         },
@@ -1077,6 +1082,30 @@ for location in code_locations:
                 "memory": "32Gi",
             },
         }
+
+    if name in multi_replica_locations:
+        deployment["replicaCount"] = 2
+        # Spread replicas across nodes so a single node failure doesn't take
+        # both down. Soft preference (preferred) avoids scheduling failures on
+        # small clusters.
+        deployment["affinity"] = {
+            "podAntiAffinity": {
+                "preferredDuringSchedulingIgnoredDuringExecution": [
+                    {
+                        "weight": 100,
+                        "podAffinityTerm": {
+                            "labelSelector": {
+                                "matchLabels": {
+                                    "deployment": name.replace("_", "-"),
+                                }
+                            },
+                            "topologyKey": "kubernetes.io/hostname",
+                        },
+                    }
+                ]
+            }
+        }
+
     deployments.append(deployment)
 
 # Custom Dagster instance ConfigMap with dynamic credentials support


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

Two changes to the Dagster user code deployment config:

**1. Fix silent `strategy` → `deploymentStrategy` bug (all 10 code locations)**

The chart key for deployment rolling-update config is `deploymentStrategy`, not `strategy`. Our config was passing `strategy`, which the chart template silently ignores (it checks `if $deployment.deploymentStrategy`). As a result, the intended `maxSurge: 1 / maxUnavailable: 0` rolling update was never being applied — Kubernetes was using its default (25%/25%), meaning a single-replica deployment's pod could be terminated before its replacement was running.

Reference: `deployment-user.yaml` in the `dagster-user-deployments` chart, lines rendering the Deployment spec strategy.

**2. Enable `replicaCount: 2` for three high-risk code locations**

The `dagster-user-deployments` chart supports `replicaCount` per deployment. When using `dagsterApiGrpcArgs`, the chart passes `--fixed-server-id <sha256-of-config>` to each gRPC process, so all replicas of a given code location report the same server identity to the Dagster daemon and webserver — making round-robin load balancing across replicas safe.

Note: `codeServerArgs` (hot-reload) is explicitly blocked by the chart template at `replicaCount > 1`; we use `dagsterApiGrpcArgs` so this is not a concern.

Code locations getting 2 replicas, with `preferredDuringSchedulingIgnoredDuringExecution` pod anti-affinity to spread across nodes:

| Code location | Reason |
|---|---|
| `legacy_openedx` | 32Gi memory limit — most OOM-prone; a kill drops all in-flight sensor ticks |
| `lakehouse` | ~19s definition load time makes pod restarts visibly disruptive |
| `data_loading` | High sensor-tick frequency means a restart window misses pipeline triggers |

The remaining 7 code locations stay at 1 replica (lower risk + memory cost savings).

### How can this be tested?

1. Deploy to CI/QA via the Dagster Concourse pipeline.
2. Confirm `kubectl get pods -n dagster` shows 2 pods each for `data-loading`, `lakehouse`, and `legacy-openedx`.
3. Confirm all other code locations show 1 pod.
4. Confirm rolling update strategy is applied: `kubectl get deploy -n dagster <name> -o jsonpath='{.spec.strategy}'` should show `RollingUpdate` with `maxSurge: 1 / maxUnavailable: 0` for any code location.
5. Verify the Dagster webserver UI shows all code locations as healthy (green).

### Additional Context

The `affinity` block uses `preferredDuring...` (soft preference) rather than `required` so scheduling is not blocked on clusters where two replicas would have to share a node.