### PR TITLE
Reduce mit-learn embeddings worker max replicas 30 → 3

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1528,7 +1528,7 @@ mitlearn_k8s_app = OLApplicationK8s(
             ),
             OLApplicationK8sCeleryWorkerConfig(
                 queue_name="embeddings",
-                max_replicas=30,
+                max_replicas=3,
                 redis_host=redis_cache.address,
                 redis_password=redis_config.require("password"),
                 resource_requests={"cpu": "200m", "memory": "2400Mi"},

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1529,6 +1529,7 @@ mitlearn_k8s_app = OLApplicationK8s(
             OLApplicationK8sCeleryWorkerConfig(
                 queue_name="embeddings",
                 max_replicas=3,
+                termination_grace_period_seconds=600,
                 redis_host=redis_cache.address,
                 redis_password=redis_config.require("password"),
                 resource_requests={"cpu": "200m", "memory": "2400Mi"},


### PR DESCRIPTION
## What are the relevant tickets?

Related to mitodl/hq#11987 — cross-repo companion to mitodl/mit-learn#3526.

Closes mitodl/hq#12015

## Description

Fixes two distinct failure modes in the mit-learn `embeddings` Celery worker on RC, where content-file embedding runs crawled for hours and wedged in PENDING. Both stem from the worker writing to Qdrant Cloud (remote gRPC) under unbounded KEDA autoscaling. Neither reproduces locally (local uses an in-process encoder + local Qdrant).

1. **Cap replicas 30 → 3 (`max_replicas`).** Up to ~20–30 replicas × `--concurrency=2` overwhelmed Qdrant Cloud → most upserts returned gRPC `DEADLINE_EXCEEDED` → every chunk burned its retries before landing → throughput collapse. Bounding concurrent writers stops the deadline storm. `min_replicas` stays 1 (scales to idle).
2. **`terminationGracePeriodSeconds` 30 → 600.** With the 30s default + `acks_late`/`reject_on_worker_lost`, scale-downs and deploys SIGKILLed chunks mid-write before they could ack → the message was redelivered and killed again → a redeliver **livelock** that stranded runs in PENDING (the chain never reached its `finalize` tail). 600s lets in-flight chunks drain on termination. Adds a backward-compatible `termination_grace_period_seconds` field to `OLApplicationK8sCeleryWorkerConfig` (default `None` = current 30s, so no change for other workers).


