### PR TITLE
Secure Opik with Keycloak OIDC via APISIX

### DIFF
--- a/src/ol_infrastructure/applications/opik/__main__.py
+++ b/src/ol_infrastructure/applications/opik/__main__.py
@@ -1,4 +1,3 @@
-# ruff: noqa: E501
 """Deploy Opik (Comet's open-source LLM observability platform) on the data EKS cluster.
 
 Opik provides tracing, evaluation, and prompt management for LLM applications.
@@ -33,11 +32,18 @@ from ol_infrastructure.components.applications.eks import (
     OLEKSAuthBinding,
     OLEKSAuthBindingConfig,
 )
-from ol_infrastructure.components.aws.eks import (
-    OLEKSGateway,
-    OLEKSGatewayConfig,
-    OLEKSGatewayListenerConfig,
-    OLEKSGatewayRouteConfig,
+from ol_infrastructure.components.services.apisix import (
+    OLApisixOIDCConfig,
+    OLApisixOIDCResources,
+    OLApisixPluginConfig,
+    OLApisixRoute,
+    OLApisixRouteConfig,
+    OLApisixSharedPlugins,
+    OLApisixSharedPluginsConfig,
+)
+from ol_infrastructure.components.services.cert_manager import (
+    OLCertManagerCert,
+    OLCertManagerCertConfig,
 )
 from ol_infrastructure.components.services.vault import (
     OLVaultK8SSecret,
@@ -259,42 +265,149 @@ opik_helm_release = kubernetes.helm.v3.Release(
     ),
 )
 
-########################################
-# Gateway API routing + TLS certificate #
-########################################
-opik_gateway_config = OLEKSGatewayConfig(
-    cert_issuer="letsencrypt-production",
-    cert_issuer_class="cluster-issuer",
-    gateway_name="opik",
-    namespace=OPIK_NAMESPACE,
-    listeners=[
-        OLEKSGatewayListenerConfig(
-            name="https",
-            hostname=opik_domain,
-            port=8443,
-            tls_mode="Terminate",
-            certificate_secret_name="opik-tls",  # pragma: allowlist secret  # noqa: S106
-            certificate_secret_namespace=OPIK_NAMESPACE,
-        ),
-    ],
-    routes=[
-        OLEKSGatewayRouteConfig(
-            backend_service_name="opik-frontend",
-            backend_service_namespace=OPIK_NAMESPACE,
-            backend_service_port=5173,
-            name="opik-https-root",
-            listener_name="https",
-            hostnames=[opik_domain],
-            port=8443,
-            matches=[{"path": {"type": "PathPrefix", "value": "/"}}],
-        ),
-    ],
+##############################################################
+# APISIX ingress: Keycloak OIDC auth + TLS termination
+#
+# Opik's open-source edition has no native OIDC, so authentication is enforced
+# at the APISIX gateway (data cluster Gateway ``apisix`` in the ``operations``
+# namespace) rather than by Opik itself. Two route rules share the same backend
+# (``opik-frontend`` proxies ``/api`` to the backend) but apply different auth:
+#
+#   * ``/api/*`` — bearer-token only. SDK / programmatic clients present a
+#     Keycloak access token (client-credentials via the ``ol-opik-client``
+#     service account); APISIX validates the JWT and rejects unauthenticated
+#     requests rather than redirecting them.
+#   * everything else — interactive OIDC. Unauthenticated browsers are
+#     redirected to Keycloak for the authorization-code flow.
+#
+# The OIDC client_id/client_secret/discovery URL are synced from Vault
+# (``secret-operations/sso/opik``, published by the keycloak substructure) into
+# a K8s secret by the Vault Secrets Operator and referenced by the plugin via
+# ``secretRef`` (only supported on the legacy ApisixRoute/v2 path).
+##############################################################
+
+# TLS certificate + ApisixTls binding for the Opik hostname. cert-manager issues
+# the cert; the ApisixTls CRD binds it to the domain in APISIX.
+OLCertManagerCert(
+    f"opik-{stack_info.env_suffix}-tls",
+    cert_config=OLCertManagerCertConfig(
+        application_name="opik",
+        k8s_namespace=OPIK_NAMESPACE,
+        k8s_labels=k8s_global_labels,
+        create_apisixtls_resource=True,
+        dest_secret_name="opik-tls",  # noqa: S106  # pragma: allowlist secret
+        dns_names=[opik_domain],
+    ),
+    opts=ResourceOptions(depends_on=[opik_helm_release]),
 )
 
-opik_gateway = OLEKSGateway(
-    "opik-gateway",
-    gateway_config=opik_gateway_config,
-    opts=ResourceOptions(parent=opik_helm_release, depends_on=[opik_helm_release]),
+# Shared plugins applied to every Opik route (cors, http->https redirect,
+# prometheus, opentelemetry, request-id).
+opik_shared_plugins = OLApisixSharedPlugins(
+    name=f"opik-shared-plugins-{stack_info.env_suffix}",
+    plugin_config=OLApisixSharedPluginsConfig(
+        application_name="opik",
+        resource_suffix="ol-shared-plugins",
+        k8s_namespace=OPIK_NAMESPACE,
+        k8s_labels=k8s_global_labels,
+        enable_defaults=True,
+    ),
+)
+
+# OIDC secret sync (reuses the application's existing Vault auth binding) and
+# openid-connect plugin config generation.
+opik_oidc = OLApisixOIDCResources(
+    f"opik-oidc-{stack_info.env_suffix}",
+    oidc_config=OLApisixOIDCConfig(
+        application_name="opik",
+        k8s_labels=k8s_global_labels,
+        k8s_namespace=OPIK_NAMESPACE,
+        oidc_scope="openid profile email",
+        vault_mount="secret-operations",
+        vault_mount_type="kv-v1",
+        vault_path="sso/opik",
+        vaultauth=opik_app.vault_k8s_resources.auth_name,
+    ),
+    opts=ResourceOptions(depends_on=opik_app.vault_k8s_resources),
+)
+
+# Session (cookie) auth: redirect unauthenticated browsers to Keycloak
+# (authorization-code flow). Used for the UI *and* for browser-originated API
+# calls — the Opik SPA and its API share an origin, so the SPA authenticates
+# the user once at ``/`` and then calls ``/api/*`` from the browser carrying
+# only the APISIX session cookie (no bearer token).
+opik_session_oidc_plugin = opik_oidc.get_full_oidc_plugin_config(unauth_action="auth")
+# Bearer auth: validate a Keycloak access token from the Authorization header
+# and reject (rather than redirect) unauthenticated requests, so SDK / machine
+# clients get a clean 401 instead of an HTML login page.
+opik_bearer_oidc_plugin = opik_oidc.get_full_oidc_plugin_config(unauth_action="deny")
+opik_bearer_oidc_plugin["config"]["bearer_only"] = True
+
+# Match ``/api/*`` requests that carry an Authorization header so they are
+# routed to the bearer-only rule; everything else under ``/api`` falls through
+# to the session rule (the browser SPA's cookie-authenticated calls).
+# This is a ROUTING condition only — it selects the bearer rule when an
+# Authorization header is present. It does not (and must not) validate the
+# token: the openid-connect plugin below cryptographically validates the JWT
+# against Keycloak's JWKS. Tokens are short-lived per-client JWTs that rotate
+# constantly, so there is no fixed value to match here; ``^Bearer\s`` simply
+# limits the bearer route to the Bearer auth scheme.
+authorization_header_present_expr = {
+    "subject": {"scope": "Header", "name": "Authorization"},
+    "op": "RegexMatch",
+    "value": r"^Bearer\s",
+}
+
+opik_apisix_route = OLApisixRoute(
+    f"opik-{stack_info.env_suffix}-apisix-route",
+    k8s_namespace=OPIK_NAMESPACE,
+    k8s_labels=k8s_global_labels,
+    route_configs=[
+        # /api/* WITH an Authorization header -> bearer-token validation (SDK /
+        # programmatic clients). Highest priority so it wins over the session
+        # /api rule when a token is present.
+        OLApisixRouteConfig(
+            route_name="opik-api-bearer",
+            priority=20,
+            hosts=[opik_domain],
+            paths=["/api/*"],
+            exprs=[authorization_header_present_expr],
+            backend_service_name="opik-frontend",
+            backend_service_port=5173,
+            shared_plugin_config_name=opik_shared_plugins.resource_name,
+            plugins=[OLApisixPluginConfig(**opik_bearer_oidc_plugin)],
+        ),
+        # /api/* WITHOUT an Authorization header -> session auth, so the browser
+        # SPA's cookie-authenticated API calls succeed after interactive login.
+        OLApisixRouteConfig(
+            route_name="opik-api-session",
+            priority=15,
+            hosts=[opik_domain],
+            paths=["/api/*"],
+            backend_service_name="opik-frontend",
+            backend_service_port=5173,
+            shared_plugin_config_name=opik_shared_plugins.resource_name,
+            plugins=[OLApisixPluginConfig(**opik_session_oidc_plugin)],
+        ),
+        # Everything else -> interactive OIDC for human browsers.
+        OLApisixRouteConfig(
+            route_name="opik-ui",
+            priority=0,
+            hosts=[opik_domain],
+            paths=["/*"],
+            backend_service_name="opik-frontend",
+            backend_service_port=5173,
+            shared_plugin_config_name=opik_shared_plugins.resource_name,
+            plugins=[
+                OLApisixPluginConfig(
+                    **opik_oidc.get_full_oidc_plugin_config(unauth_action="auth")
+                )
+            ],
+        ),
+    ],
+    opts=ResourceOptions(
+        depends_on=[opik_helm_release, opik_oidc, opik_shared_plugins]
+    ),
 )
 
 export("opik_namespace", OPIK_NAMESPACE)

--- a/src/ol_infrastructure/applications/opik/__main__.py
+++ b/src/ol_infrastructure/applications/opik/__main__.py
@@ -343,12 +343,11 @@ opik_session_oidc_plugin = opik_oidc.get_full_oidc_plugin_config(unauth_action="
 opik_bearer_oidc_plugin = opik_oidc.get_full_oidc_plugin_config(unauth_action="deny")
 opik_bearer_oidc_plugin["config"]["bearer_only"] = True
 
-# Match ``/api/*`` requests that carry an Authorization header so they are
-# routed to the bearer-only rule; everything else under ``/api`` falls through
-# to the session rule (the browser SPA's cookie-authenticated calls).
-# This is a ROUTING condition only — it selects the bearer rule when an
-# Authorization header is present. It does not (and must not) validate the
-# token: the openid-connect plugin below cryptographically validates the JWT
+# Match ``/api/*`` requests that carry a Bearer ``Authorization`` header so they
+# are routed to the bearer-only rule; everything else under ``/api`` falls
+# through to the session rule (the browser SPA's cookie-authenticated calls).
+# This is a ROUTING condition only — it selects the bearer rule when a Bearer
+# ``Authorization`` header is present. It does not (and must not) validate the
 # against Keycloak's JWKS. Tokens are short-lived per-client JWTs that rotate
 # constantly, so there is no fixed value to match here; ``^Bearer\s`` simply
 # limits the bearer route to the Bearer auth scheme.

--- a/src/ol_infrastructure/applications/opik/__main__.py
+++ b/src/ol_infrastructure/applications/opik/__main__.py
@@ -268,18 +268,18 @@ opik_helm_release = kubernetes.helm.v3.Release(
 ##############################################################
 # APISIX ingress: Keycloak OIDC auth + TLS termination
 #
-# Opik's open-source edition has no native OIDC, so authentication is enforced
 # at the APISIX gateway (data cluster Gateway ``apisix`` in the ``operations``
-# namespace) rather than by Opik itself. Two route rules share the same backend
+# namespace) rather than by Opik itself. Three route rules share the same backend
 # (``opik-frontend`` proxies ``/api`` to the backend) but apply different auth:
 #
-#   * ``/api/*`` — bearer-token only. SDK / programmatic clients present a
-#     Keycloak access token (client-credentials via the ``ol-opik-client``
-#     service account); APISIX validates the JWT and rejects unauthenticated
-#     requests rather than redirecting them.
+#   * ``/api/*`` with a Bearer ``Authorization`` header — bearer-token only. SDK /
+#     programmatic clients present a Keycloak access token (client-credentials via
+#     the ``ol-opik-client`` service account); APISIX validates the JWT and
+#     rejects unauthenticated requests rather than redirecting them.
+#   * ``/api/*`` without one — session (cookie) auth, so the browser SPA's API
+#     calls work after interactive login.
 #   * everything else — interactive OIDC. Unauthenticated browsers are
 #     redirected to Keycloak for the authorization-code flow.
-#
 # The OIDC client_id/client_secret/discovery URL are synced from Vault
 # (``secret-operations/sso/opik``, published by the keycloak substructure) into
 # a K8s secret by the Vault Secrets Operator and referenced by the plugin via

--- a/src/ol_infrastructure/applications/opik/opik_policy.hcl
+++ b/src/ol_infrastructure/applications/opik/opik_policy.hcl
@@ -9,3 +9,13 @@ path "secret-clickhouse/metadata/credentials" {
 path "sys/leases/renew" {
   capabilities = ["update"]
 }
+
+# Keycloak OIDC client credentials for the APISIX openid-connect plugin
+# (secret-operations is a kv-v1 mount; include both path forms defensively).
+path "secret-operations/sso/opik" {
+  capabilities = ["read"]
+}
+
+path "secret-operations/data/sso/opik" {
+  capabilities = ["read"]
+}

--- a/src/ol_infrastructure/components/services/apisix.py
+++ b/src/ol_infrastructure/components/services/apisix.py
@@ -40,6 +40,13 @@ class OLApisixRouteConfig(BaseModel):
     plugins: list[OLApisixPluginConfig] = []
     hosts: list[str] = []
     paths: list[str] = []
+    # Optional ApisixRoute ``match.exprs`` entries for matching on headers,
+    # query args, cookies, etc. in addition to host/path. Each entry follows the
+    # ApisixRoute v2 schema, e.g.
+    # ``{"subject": {"scope": "Header", "name": "Authorization"},
+    #    "op": "RegexMatch", "value": ".+"}``.
+    # Ref: https://apisix.apache.org/docs/ingress-controller/concepts/apisix_route/#advanced-route-matching
+    exprs: list[dict[str, Any]] | None = None
     backend_service_name: str | None = None
     backend_service_port: str | NonNegativeInt | None = None
     # Ref: https://apisix.apache.org/docs/ingress-controller/concepts/apisix_route/#service-resolution-granularity
@@ -148,6 +155,7 @@ class OLApisixRoute(ComponentResource):
                 "match": {
                     "hosts": route_config.hosts,
                     "paths": route_config.paths,
+                    **({"exprs": route_config.exprs} if route_config.exprs else {}),
                 },
                 "websocket": route_config.websocket,
                 "timeout": {

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.data.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.data.CI.yaml
@@ -14,6 +14,7 @@ config:
   - airbyte-ci.odl.mit.edu
   - api-airbyte-ci.odl.mit.edu
   - pipelines-ci.odl.mit.edu
+  - opik-ci.ol.mit.edu
   eks:apisix_viewer_key:
     secure: v1:ZFN4gG/xa7D+1wDe:qwerlKPydX7u54UjHLBvNUCT2Oha5e4EgXs5Uf+8tMOMUtf4yz/5SYy4rfpfls1HDMgroXWwRUY9U21sgKsGF+YJ5lexA+Fo9VSStrw9zPc=
   eks:stateful_workload_storage_backend: ebs

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.CI.yaml
@@ -120,3 +120,5 @@ config:
   - "https://ocw-studio-ci.odl.mit.edu"
   keycloak_realm:ol-mit-ldap-bind-password:
     secure: v1:dOWj9QsOafyn3p+F:XdKusQqhsxVDx20tFJTdUG3Nc5/FJ4N/ZChyzakYHlXyXpcxRkICJA==
+  keycloak_realm:ol-platform-engineering-opik-redirect-uris:
+  - https://opik-ci.ol.mit.edu/*

--- a/src/ol_infrastructure/substructure/keycloak/ol_platform_engineering.py
+++ b/src/ol_infrastructure/substructure/keycloak/ol_platform_engineering.py
@@ -4,7 +4,7 @@ import json
 
 import pulumi_keycloak as keycloak
 import pulumi_vault as vault
-from pulumi import Config, Output, ResourceOptions
+from pulumi import Alias, Config, Output, ResourceOptions
 
 
 def create_ol_platform_engineering_realm(  # noqa: PLR0913
@@ -168,6 +168,62 @@ def create_ol_platform_engineering_realm(  # noqa: PLR0913
         ).apply(json.dumps),
     )
     # AIRBYTE [END] # noqa: ERA001
+
+    # OPIK [START] # noqa: ERA001
+    # Opik (Comet LLM observability) has no native OIDC in its open-source
+    # edition, so authentication is enforced by APISIX in front of it. This
+    # CONFIDENTIAL client backs both the interactive UI login (standard flow)
+    # and the service-account / client-credentials flow that SDK clients use to
+    # mint bearer tokens for the /api ingestion path (see the opik application
+    # stack). Credentials are published to Vault for the APISIX openid-connect
+    # plugin to consume via the Vault Secrets Operator.
+    ol_platform_engineering_opik_client = keycloak.openid.Client(
+        "ol-platform-engineering-opik-client",
+        name="ol-platform-engineering-opik-client",
+        realm_id="ol-platform-engineering",
+        client_id="ol-opik-client",
+        client_secret=keycloak_realm_config.get(
+            "ol-platform-engineering-opik-client-secret"
+        ),
+        enabled=True,
+        access_type="CONFIDENTIAL",
+        standard_flow_enabled=True,
+        implicit_flow_enabled=False,
+        service_accounts_enabled=True,
+        direct_access_grants_enabled=False,
+        valid_redirect_uris=keycloak_realm_config.get_object(
+            "ol-platform-engineering-opik-redirect-uris"
+        ),
+        opts=resource_options.merge(ResourceOptions(delete_before_replace=True)),
+    )
+    vault.generic.Secret(
+        "ol-platform-engineering-opik-client-vault-oidc-credentials",
+        path="secret-operations/sso/opik",
+        data_json=Output.all(
+            url=ol_platform_engineering_opik_client.realm_id.apply(
+                lambda realm_id: f"{keycloak_url}/realms/{realm_id}"
+            ),
+            client_id=ol_platform_engineering_opik_client.client_id,
+            client_secret=ol_platform_engineering_opik_client.client_secret,
+            # Independent random value required by the APISIX openid-connect
+            # plugin for session signing; not part of the OAuth credentials.
+            secret=session_secret,
+            realm_id=ol_platform_engineering_opik_client.realm_id,
+            realm_name="ol-platform-engineering",
+            realm_public_key=ol_platform_engineering_opik_client.realm_id.apply(
+                fetch_realm_public_key_partial
+            ),
+        ).apply(json.dumps),
+        # This secret was previously created by the ol-data-platform realm
+        # module at the same Vault path. Alias it so Pulumi performs an in-place
+        # move/update (rewriting the credentials for the new realm's client)
+        # instead of create+delete — the latter would delete the shared Vault
+        # path after writing it, leaving it empty.
+        opts=ResourceOptions(
+            aliases=[Alias(name="ol-data-platform-opik-client-vault-oidc-credentials")]
+        ),
+    )
+    # OPIK [END] # noqa: ERA001
 
     # JUPYTERHUB [START] # noqa: ERA001
     ol_platform_engineering_jupyterhub_client = keycloak.openid.Client(


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Puts the self-hosted Opik (Comet LLM observability) deployment behind Keycloak authentication. Opik's open-source edition has **no native OIDC** (it's an Enterprise-only feature), so authentication is enforced by an authenticating proxy in front of it rather than by Opik itself.

Key changes:

- **APISIX OIDC instead of the Traefik Gateway.** Opik moves off `OLEKSGateway` onto the data-cluster APISIX gateway using the legacy `OLApisixRoute` (v2) path, matching the established pattern for OIDC apps (Airbyte/Dagster/Marimo). This is required because secret-backed OIDC relies on the APISIX `secretRef` mechanism, which only exists on the v2 `ApisixRoute` path (the Gateway-API `PluginConfig` drops `secretRef`). TLS is terminated per-app via an `ApisixTls` CRD (`OLCertManagerCert`).
- **UI vs API auth split.** The Opik web UI and its API share an origin, and the SPA calls `/api/*` from the browser using only the session cookie. A single bearer-only policy would 401 the UI's own API calls, so `/api/*` is split by the presence of a Bearer `Authorization` header:
  - `/api/*` **with** a Bearer token → `bearer_only` validation (SDK / programmatic clients), rejects rather than redirects.
  - `/api/*` **without** one → session (cookie) auth, so the browser SPA works after interactive login.
  - everything else → interactive authorization-code flow for human browsers.
- **Keycloak client in the `ol-platform-engineering` realm.** A `CONFIDENTIAL` `ol-opik-client` is created in `ol-platform-engineering` (alongside Airbyte/Grafana/Dagster/Concourse/Vault), with `service_accounts_enabled=True` for the bearer-token path. Credentials are published to Vault at `secret-operations/sso/opik` and synced into the cluster by the Vault Secrets Operator. The client lives in `ol-platform-engineering` rather than `ol-data-platform` deliberately: that realm authenticates via username/password + passkey and has no Touchstone SAML IdP, avoiding the realm's `want_assertions_encrypted=True` requirement that caused Keycloak "Invalid Requester" (unencrypted-assertion) failures.
- **Reusable component addition.** `OLApisixRouteConfig` gains an optional `exprs` field so legacy `ApisixRoute` rules can match on headers/query/cookies (used here for the Bearer-header split). Backward-compatible — only emitted into `match` when set.
- **Vault policy + config.** The Opik Vault policy grants read on `secret-operations/sso/opik`; the redirect-URI stack config is keyed under `ol-platform-engineering-opik-redirect-uris`.

The Vault secret resource is aliased to its previous `ol-data-platform` resource name so the realm move is a non-destructive in-place update of the shared Vault path rather than a create+delete that would leave it empty.

### How can this be tested?
Validated with `pre-commit` (ruff + mypy) and `pulumi preview` on both the `keycloak` CI and `opik` CI stacks.

Deploy order:
1. `pulumi up` the **keycloak** CI stack — creates the `ol-platform-engineering` Opik client and rewrites `secret-operations/sso/opik`.
2. `pulumi up` the **opik** CI stack — APISIX route (with TLS, shared plugins, OIDC), Vault sync, and the `/api` split.

Reviewer validation against CI:
- `curl -sI https://opik-ci.ol.mit.edu/` → `302` to `sso-ci.ol.mit.edu` (interactive OIDC).
- APISIX ingress-controller logs show no `failed to match service port` for `opik-frontend` (the backend port is numeric `5173`, matched by number not name).
- Browser login uses `ol-platform-engineering` realm credentials; after login the SPA's `/api/v1/session` returns `200` (session rule), while `curl -H "Authorization: Bearer <invalid>" .../api/v1/session` returns `401` from bearer validation.

### Additional Context
- Authorization is coarse: this enforces authentication (any `ol-platform-engineering` realm user); Opik OSS has no per-user RBAC.
- External SDK / programmatic ingestion must present a Keycloak access token (service-account client-credentials) as a Bearer header. In-cluster producers posting directly to the `opik-frontend` service bypass APISIX and are unaffected.