### PR TITLE
feat: add Keycloak OIDC auth in front of OpenLIT

### DIFF
--- a/src/ol_infrastructure/applications/openlit/__main__.py
+++ b/src/ol_infrastructure/applications/openlit/__main__.py
@@ -17,8 +17,10 @@ NOTE: the ``openlit_db`` database must be created manually on the ClickHouse
 cluster before OpenLIT can persist telemetry (there is no ClickHouse Pulumi
 provider).  See ``applications/clickhouse/__main__.py``.
 
-The platform UI listens on port 3000 and is exposed via the cluster's Traefik
-Gateway API (OLEKSGateway) with a cert-manager issued TLS certificate.
+The platform UI listens on port 3000 and is exposed via the data cluster's
+APISIX gateway, which terminates TLS (cert-manager issued certificate) and
+enforces Keycloak OIDC authentication in front of OpenLIT (which has no native
+auth in its open-source edition).
 """
 
 import pulumi_kubernetes as kubernetes
@@ -26,11 +28,18 @@ import pulumi_vault as vault
 from pulumi import Config, ResourceOptions
 
 from bridge.lib.versions import OPENLIT_CHART_VERSION
-from ol_infrastructure.components.aws.eks import (
-    OLEKSGateway,
-    OLEKSGatewayConfig,
-    OLEKSGatewayListenerConfig,
-    OLEKSGatewayRouteConfig,
+from ol_infrastructure.components.services.apisix import (
+    OLApisixOIDCConfig,
+    OLApisixOIDCResources,
+    OLApisixPluginConfig,
+    OLApisixRoute,
+    OLApisixRouteConfig,
+    OLApisixSharedPlugins,
+    OLApisixSharedPluginsConfig,
+)
+from ol_infrastructure.components.services.cert_manager import (
+    OLCertManagerCert,
+    OLCertManagerCertConfig,
 )
 from ol_infrastructure.components.services.vault import (
     OLVaultK8SResources,
@@ -106,6 +115,16 @@ openlit_vault_policy = vault.Policy(
     name="openlit",
     policy="""
 path "secret-clickhouse/data/credentials" {
+  capabilities = ["read"]
+}
+
+# Keycloak OIDC client credentials for the APISIX openid-connect plugin
+# (secret-operations is a kv-v1 mount; include both path forms defensively).
+path "secret-operations/sso/openlit" {
+  capabilities = ["read"]
+}
+
+path "secret-operations/data/sso/openlit" {
   capabilities = ["read"]
 }
 """,
@@ -218,41 +237,93 @@ openlit_helm_release = kubernetes.helm.v3.Release(
     ),
 )
 
-# Expose the OpenLIT UI via the cluster's Traefik Gateway API. cert-manager
-# issues the TLS certificate referenced by the HTTPS listener.
-openlit_gateway = OLEKSGateway(
-    f"openlit-{stack_info.env_suffix}-gateway",
-    gateway_config=OLEKSGatewayConfig(
-        cert_issuer="letsencrypt-production",
-        cert_issuer_class="cluster-issuer",
-        gateway_name="openlit",
-        labels=k8s_global_labels,
-        namespace=openlit_namespace,
-        listeners=[
-            OLEKSGatewayListenerConfig(
-                name="https",
-                hostname=openlit_domain,
-                port=8443,
-                tls_mode="Terminate",
-                certificate_secret_name="openlit-tls",  # noqa: S106  # pragma: allowlist secret
-                certificate_secret_namespace=openlit_namespace,
-            ),
-        ],
-        routes=[
-            OLEKSGatewayRouteConfig(
-                backend_service_name=openlit_service_name,
-                backend_service_namespace=openlit_namespace,
-                backend_service_port=openlit_service_port,
-                hostnames=[openlit_domain],
-                name="openlit-https",
-                listener_name="https",
-                port=8443,
-            ),
-        ],
+##############################################################
+# APISIX ingress: Keycloak OIDC auth + TLS termination
+#
+# Authentication is enforced at the APISIX gateway (data cluster Gateway
+# ``apisix`` in the ``operations`` namespace) rather than by OpenLIT itself,
+# which has no native auth in its open-source edition. A single route applies
+# interactive OIDC to everything: unauthenticated browsers are redirected to
+# Keycloak for the authorization-code flow, and the OpenLIT SPA's same-origin
+# ``/api`` calls ride the APISIX session cookie established at login. Unlike
+# Opik, there is no separate bearer-token ``/api/*`` rule — external exposure
+# here is the dashboard UI, and programmatic telemetry ingestion does not flow
+# through this ingress.
+#
+# The OIDC client_id/client_secret/discovery URL are synced from Vault
+# (``secret-operations/sso/openlit``, published by the keycloak substructure)
+# into a K8s secret by the Vault Secrets Operator and referenced by the plugin
+# via ``secretRef``.
+##############################################################
+
+# TLS certificate + ApisixTls binding for the OpenLIT hostname. cert-manager
+# issues the cert; the ApisixTls CRD binds it to the domain in APISIX.
+OLCertManagerCert(
+    f"openlit-{stack_info.env_suffix}-tls",
+    cert_config=OLCertManagerCertConfig(
+        application_name="openlit",
+        k8s_namespace=openlit_namespace,
+        k8s_labels=k8s_global_labels,
+        create_apisixtls_resource=True,
+        dest_secret_name="openlit-tls",  # noqa: S106  # pragma: allowlist secret
+        dns_names=[openlit_domain],
     ),
+    opts=ResourceOptions(depends_on=[openlit_helm_release]),
+)
+
+# Shared plugins applied to the OpenLIT route (cors, http->https redirect,
+# prometheus, opentelemetry, request-id).
+openlit_shared_plugins = OLApisixSharedPlugins(
+    name=f"openlit-shared-plugins-{stack_info.env_suffix}",
+    plugin_config=OLApisixSharedPluginsConfig(
+        application_name="openlit",
+        resource_suffix="ol-shared-plugins",
+        k8s_namespace=openlit_namespace,
+        k8s_labels=k8s_global_labels,
+        enable_defaults=True,
+    ),
+)
+
+# OIDC secret sync (reuses the application's existing Vault auth binding) and
+# openid-connect plugin config generation.
+openlit_oidc = OLApisixOIDCResources(
+    f"openlit-oidc-{stack_info.env_suffix}",
+    oidc_config=OLApisixOIDCConfig(
+        application_name="openlit",
+        k8s_labels=k8s_global_labels,
+        k8s_namespace=openlit_namespace,
+        oidc_scope="openid profile email",
+        vault_mount="secret-operations",
+        vault_mount_type="kv-v1",
+        vault_path="sso/openlit",
+        vaultauth=openlit_vault_k8s_resources.auth_name,
+    ),
+    opts=ResourceOptions(depends_on=[openlit_vault_k8s_resources]),
+)
+
+# Single interactive OIDC route: redirect unauthenticated browsers to Keycloak
+# (authorization-code flow) and proxy authenticated traffic to the OpenLIT UI.
+openlit_apisix_route = OLApisixRoute(
+    f"openlit-{stack_info.env_suffix}-apisix-route",
+    k8s_namespace=openlit_namespace,
+    k8s_labels=k8s_global_labels,
+    route_configs=[
+        OLApisixRouteConfig(
+            route_name="openlit-ui",
+            priority=0,
+            hosts=[openlit_domain],
+            paths=["/*"],
+            backend_service_name=openlit_service_name,
+            backend_service_port=openlit_service_port,
+            shared_plugin_config_name=openlit_shared_plugins.resource_name,
+            plugins=[
+                OLApisixPluginConfig(
+                    **openlit_oidc.get_full_oidc_plugin_config(unauth_action="auth")
+                )
+            ],
+        ),
+    ],
     opts=ResourceOptions(
-        parent=openlit_helm_release,
-        delete_before_replace=True,
-        depends_on=[openlit_helm_release],
+        depends_on=[openlit_helm_release, openlit_oidc, openlit_shared_plugins]
     ),
 )

--- a/src/ol_infrastructure/applications/openlit/__main__.py
+++ b/src/ol_infrastructure/applications/openlit/__main__.py
@@ -271,8 +271,8 @@ OLCertManagerCert(
     opts=ResourceOptions(depends_on=[openlit_helm_release]),
 )
 
-# Shared plugins applied to the OpenLIT route (cors, http->https redirect,
-# prometheus, opentelemetry, request-id).
+# Shared plugins applied to the OpenLIT route (http->https redirect, cors,
+# response headers, prometheus, and (non-CI) opentelemetry).
 openlit_shared_plugins = OLApisixSharedPlugins(
     name=f"openlit-shared-plugins-{stack_info.env_suffix}",
     plugin_config=OLApisixSharedPluginsConfig(

--- a/src/ol_infrastructure/applications/openlit/__main__.py
+++ b/src/ol_infrastructure/applications/openlit/__main__.py
@@ -265,7 +265,7 @@ OLCertManagerCert(
         k8s_namespace=openlit_namespace,
         k8s_labels=k8s_global_labels,
         create_apisixtls_resource=True,
-        dest_secret_name="openlit-tls",  # noqa: S106  # pragma: allowlist secret
+        dest_secret_name="openlit-apisix-tls",  # noqa: S106  # pragma: allowlist secret
         dns_names=[openlit_domain],
     ),
     opts=ResourceOptions(depends_on=[openlit_helm_release]),

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.data.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.data.CI.yaml
@@ -13,6 +13,7 @@ config:
   eks:apisix_domains:
   - airbyte-ci.odl.mit.edu
   - api-airbyte-ci.odl.mit.edu
+  - openlit-ci.ol.mit.edu
   - pipelines-ci.odl.mit.edu
   eks:apisix_viewer_key:
     secure: v1:ZFN4gG/xa7D+1wDe:qwerlKPydX7u54UjHLBvNUCT2Oha5e4EgXs5Uf+8tMOMUtf4yz/5SYy4rfpfls1HDMgroXWwRUY9U21sgKsGF+YJ5lexA+Fo9VSStrw9zPc=

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.CI.yaml
@@ -120,3 +120,5 @@ config:
   - "https://ocw-studio-ci.odl.mit.edu"
   keycloak_realm:ol-mit-ldap-bind-password:
     secure: v1:dOWj9QsOafyn3p+F:XdKusQqhsxVDx20tFJTdUG3Nc5/FJ4N/ZChyzakYHlXyXpcxRkICJA==
+  keycloak_realm:ol-platform-engineering-openlit-redirect-uris:
+  - https://openlit-ci.ol.mit.edu/*

--- a/src/ol_infrastructure/substructure/keycloak/ol_platform_engineering.py
+++ b/src/ol_infrastructure/substructure/keycloak/ol_platform_engineering.py
@@ -169,6 +169,53 @@ def create_ol_platform_engineering_realm(  # noqa: PLR0913
     )
     # AIRBYTE [END] # noqa: ERA001
 
+    # OPENLIT [START] # noqa: ERA001
+    # OpenLIT (LLM/GenAI observability) has no native auth in its open-source
+    # edition, so authentication is enforced by APISIX in front of it. This
+    # CONFIDENTIAL client backs the interactive UI login (standard flow); unlike
+    # Opik there is no service-account / client-credentials flow because no
+    # bearer-token ingestion path is exposed through this ingress. Credentials
+    # are published to Vault for the APISIX openid-connect plugin to consume via
+    # the Vault Secrets Operator.
+    ol_platform_engineering_openlit_client = keycloak.openid.Client(
+        "ol-platform-engineering-openlit-client",
+        name="ol-platform-engineering-openlit-client",
+        realm_id="ol-platform-engineering",
+        client_id="ol-openlit-client",
+        client_secret=keycloak_realm_config.get(
+            "ol-platform-engineering-openlit-client-secret"
+        ),
+        enabled=True,
+        access_type="CONFIDENTIAL",
+        standard_flow_enabled=True,
+        implicit_flow_enabled=False,
+        service_accounts_enabled=False,
+        valid_redirect_uris=keycloak_realm_config.get_object(
+            "ol-platform-engineering-openlit-redirect-uris"
+        ),
+        opts=resource_options.merge(ResourceOptions(delete_before_replace=True)),
+    )
+    vault.generic.Secret(
+        "ol-platform-engineering-openlit-client-vault-oidc-credentials",
+        path="secret-operations/sso/openlit",
+        data_json=Output.all(
+            url=ol_platform_engineering_openlit_client.realm_id.apply(
+                lambda realm_id: f"{keycloak_url}/realms/{realm_id}"
+            ),
+            client_id=ol_platform_engineering_openlit_client.client_id,
+            client_secret=ol_platform_engineering_openlit_client.client_secret,
+            # Independent random value required by the APISIX openid-connect
+            # plugin for session signing; not part of the OAuth credentials.
+            secret=session_secret,
+            realm_id=ol_platform_engineering_openlit_client.realm_id,
+            realm_name="ol-platform-engineering",
+            realm_public_key=ol_platform_engineering_openlit_client.realm_id.apply(
+                fetch_realm_public_key_partial
+            ),
+        ).apply(json.dumps),
+    )
+    # OPENLIT [END] # noqa: ERA001
+
     # JUPYTERHUB [START] # noqa: ERA001
     ol_platform_engineering_jupyterhub_client = keycloak.openid.Client(
         "ol-platform-engineering-jupyterhub-client",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Adds Keycloak OIDC authentication in front of the OpenLIT (LLM/GenAI observability) deployment on the data EKS cluster, mirroring the pattern recently applied to Opik. OpenLIT has no native auth in its open-source edition, so authentication is enforced at the APISIX gateway.

**`applications/openlit/__main__.py`** — replaced the Traefik `OLEKSGateway` ingress with APISIX-based auth:
- `OLCertManagerCert` (with `create_apisixtls_resource=True`) for TLS termination at APISIX.
- `OLApisixSharedPlugins` (cors, http→https redirect, prometheus, opentelemetry, request-id).
- `OLApisixOIDCResources` — syncs the Keycloak client credentials from Vault `secret-operations/sso/openlit` into a K8s secret via the Vault Secrets Operator, reusing OpenLIT's existing Vault auth resources (`openlit_vault_k8s_resources`) rather than refactoring to `OLEKSAuthBinding`.
- A **single interactive OIDC route** (`/*`, `unauth_action="auth"`) proxying to the OpenLIT UI service on port 3000.
- Added Vault policy read paths for `secret-operations/sso/openlit`.

**`substructure/keycloak/ol_platform_engineering.py`** — added an `ol-openlit-client` CONFIDENTIAL Keycloak client and published its credentials to Vault at `secret-operations/sso/openlit`.

**`substructure/keycloak/Pulumi.CI.yaml`** — redirect URI `https://openlit-ci.ol.mit.edu/*`.

**`infrastructure/aws/eks/Pulumi.data.CI.yaml`** — registered `openlit-ci.ol.mit.edu` in `apisix_domains`.

#### Why no `/api/*` bearer-token handling (unlike Opik)
Opik needed three routes because its SDK clients mint Keycloak bearer tokens to hit `/api/*` programmatically. OpenLIT's external exposure here is just the dashboard UI; the SPA's same-origin `/api` calls ride the APISIX session cookie established at interactive login, and programmatic telemetry ingestion does not flow through this ingress. A single interactive OIDC route is therefore sufficient. As a result this PR does not need Opik's `exprs` addition to the apisix component, and the OpenLIT Keycloak client skips `service_accounts_enabled`.

### How can this be tested?
- `pre-commit run --files ...` passes (ruff, mypy, yamllint, detect-secrets).
- `pulumi preview` on the affected stacks: `substructure.keycloak.CI` (creates the `ol-openlit-client` and Vault secret), `infrastructure.aws.eks.data.CI` (adds the APISIX domain), and `applications.openlit.CI` (replaces the Gateway with APISIX OIDC resources).
- After apply: browse to `https://openlit-ci.ol.mit.edu` and confirm an unauthenticated request is redirected to Keycloak, and that after login the OpenLIT dashboard and its `/api` calls load correctly.

### Additional Context
**Apply ordering:** the keycloak substructure stack must be applied before the openlit application stack — the OIDC secret sync (`OLApisixOIDCResources`) depends on `secret-operations/sso/openlit` existing in Vault. Scoped to the CI stack only, matching the existing OpenLIT and Opik deployments.
