### PR TITLE
feat(ocw-studio): migrate k8s deployment from uwsgi to granian

### DIFF
--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -47,6 +47,7 @@ from ol_infrastructure.components.services.cert_manager import (
     OLCertManagerCertConfig,
 )
 from ol_infrastructure.components.services.k8s import (
+    GranianConfig,
     OLApplicationK8s,
     OLApplicationK8sCeleryBeatConfig,
     OLApplicationK8sCeleryWorkerConfig,
@@ -601,13 +602,15 @@ ocw_studio_k8s_app = OLApplicationK8s(
         application_security_group_name=ocw_studio_app_security_group.name,
         application_image_repository="mitodl/ocw-studio-app",
         **docker_image_config_kwargs("OCW_STUDIO"),
-        application_cmd_array=["uwsgi"],
-        application_arg_array=["/tmp/uwsgi.ini"],  # noqa: S108
+        granian_config=GranianConfig(
+            application_module="main.wsgi:application",
+            workers=2,
+            blocking_threads_idle_timeout=120,
+            enable_metrics=True,
+        ),
         vault_k8s_resource_auth_name=vault_k8s_resources.auth_name,
         registry="dockerhub",
         import_nginx_config=True,
-        import_nginx_config_path="files/web.conf",
-        import_uwsgi_config=True,
         init_migrations=True,
         init_collectstatic=True,
         pre_deploy_commands=[

--- a/src/ol_infrastructure/applications/ocw_studio/files/web.conf_granian
+++ b/src/ol_infrastructure/applications/ocw_studio/files/web.conf_granian
@@ -1,0 +1,42 @@
+server {
+    listen 8071 default_server;  # DEFAULT_NGINX_PORT
+    server_name _;
+    large_client_header_buffers 4 32k;
+
+    root /src;
+
+    set $my_scheme $http_x_forwarded_proto;
+    if ($my_scheme = "") { set $my_scheme $scheme; }
+
+    location = /nginx-health {
+        access_log off;
+        return 200 "healthy\n";
+        add_header Content-Type text/plain;
+    }
+
+    location = /.well-known/dnt-policy.txt {
+        return 204;
+    }
+
+    location ~* /static/hash.txt {
+        expires -1;
+        add_header Cache-Control private;
+        try_files /staticfiles/hash.txt =404;
+    }
+
+    location ~* /static/(.*$) {
+        expires max;
+        add_header Access-Control-Allow-Origin *;
+        try_files /staticfiles/$1 =404;
+    }
+
+    location / {
+        proxy_set_header X-Forwarded-Proto $my_scheme;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $host;
+        proxy_pass http://127.0.0.1:8073;  # DEFAULT_WSGI_PORT (Granian)
+        proxy_pass_request_headers on;
+        proxy_pass_request_body on;
+        client_max_body_size 25M;
+    }
+}

--- a/src/ol_infrastructure/applications/ocw_studio/files/web.conf_granian
+++ b/src/ol_infrastructure/applications/ocw_studio/files/web.conf_granian
@@ -37,6 +37,7 @@ server {
         proxy_pass http://127.0.0.1:8073;  # DEFAULT_WSGI_PORT (Granian)
         proxy_pass_request_headers on;
         proxy_pass_request_body on;
+        proxy_ignore_client_abort on;
         client_max_body_size 25M;
     }
 }


### PR DESCRIPTION
## Summary

- Replaces `application_cmd_array=["uwsgi"]` / `import_uwsgi_config=True` with `GranianConfig` in the ocw-studio Pulumi k8s stack
- Adds `files/web.conf_granian`: nginx config using `proxy_pass` (HTTP) instead of `uwsgi_pass`, matching granian's HTTP listener
- The ocw-studio Dockerfile (mitodl/ocw-studio#3078) already ships without uwsgi; this aligns the infrastructure deployment

## Test plan

- [ ] `pulumi preview` in ocw-studio CI/QA/Production stacks shows expected ConfigMap + Deployment command changes
- [ ] After deploy: verify nginx proxies correctly to granian on port 8073
- [ ] Confirm `/nginx-health` returns 200 and static files served correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)