### PR TITLE
feat(edxapp): enable admin-console MFE for mitx, mitx-staging, and xpro

### DIFF
--- a/src/bridge/settings/openedx/version_matrix.py
+++ b/src/bridge/settings/openedx/version_matrix.py
@@ -278,6 +278,11 @@ ReleaseMap: dict[
                 release="verawood",
             ),
             OpenEdxApplicationVersion(
+                application="admin-console",
+                application_type="MFE",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
                 application="communications",
                 application_type="MFE",
                 release="verawood",
@@ -348,6 +353,11 @@ ReleaseMap: dict[
             OpenEdxApplicationVersion(
                 application="codejail",
                 application_type="IDA",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="admin-console",
+                application_type="MFE",
                 release="verawood",
             ),
             OpenEdxApplicationVersion(
@@ -422,6 +432,11 @@ ReleaseMap: dict[
             OpenEdxApplicationVersion(
                 application="codejail",
                 application_type="IDA",
+                release="verawood",
+            ),
+            OpenEdxApplicationVersion(
+                application="admin-console",
+                application_type="MFE",
                 release="verawood",
             ),
             OpenEdxApplicationVersion(
@@ -559,6 +574,11 @@ ReleaseMap: dict[
                 release="master",
             ),
             OpenEdxApplicationVersion(
+                application="admin-console",
+                application_type="MFE",
+                release="master",
+            ),
+            OpenEdxApplicationVersion(
                 application="communications",
                 application_type="MFE",
                 release="master",
@@ -631,6 +651,11 @@ ReleaseMap: dict[
             OpenEdxApplicationVersion(
                 application="codejail",
                 application_type="IDA",
+                release="master",
+            ),
+            OpenEdxApplicationVersion(
+                application="admin-console",
+                application_type="MFE",
                 release="master",
             ),
             OpenEdxApplicationVersion(

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.CI.yaml
@@ -56,6 +56,7 @@ config:
   edxapp:elb_healthcheck_interval: "30"
   edxapp:enable_notes: "True"
   edxapp:enabled_mfes:
+    admin_console: admin-console
     authoring: authoring
     communications: communications
     discussions: discuss

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.QA.yaml
@@ -57,6 +57,7 @@ config:
   edxapp:elb_healthcheck_interval: "30"
   edxapp:enable_notes: "True"
   edxapp:enabled_mfes:
+    admin_console: admin-console
     authoring: authoring
     communications: communications
     discussions: discuss

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.CI.yaml
@@ -67,6 +67,7 @@ config:
   edxapp:elb_healthcheck_interval: "30"
   edxapp:enable_notes: "True"
   edxapp:enabled_mfes:
+    admin_console: admin-console
     authoring: authoring
     communications: communications
     discussions: discuss

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.QA.yaml
@@ -68,6 +68,7 @@ config:
   edxapp:elb_healthcheck_interval: "30"
   edxapp:enable_notes: "True"
   edxapp:enabled_mfes:
+    admin_console: admin-console
     authoring: authoring
     communications: communications
     discussions: discuss

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.xpro.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.xpro.CI.yaml
@@ -53,6 +53,7 @@ config:
   edxapp:web_instance_type: r7a.large
   edxapp:enable_notes: "True"
   edxapp:enabled_mfes:
+    admin_console: admin-console
     authoring: authoring
     communications: communications
     discussions: discuss


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Adds the `admin-console` MFE (`frontend-app-admin-console`) to the mitx, mitx-staging, and xpro deployments, matching the configuration already in place for mitxonline QA.

**Release map changes** (`src/bridge/settings/openedx/version_matrix.py`):
- `verawood` release: added `admin-console` for mitx, mitx-staging, and xpro
- `master` release: added `admin-console` for mitx and mitx-staging

**Stack config changes** (`edxapp:enabled_mfes`):
- `Pulumi.mitx.CI.yaml` (CI → master)
- `Pulumi.mitx.QA.yaml` (QA → verawood)
- `Pulumi.mitx-staging.CI.yaml` (CI → master)
- `Pulumi.mitx-staging.QA.yaml` (QA → verawood)
- `Pulumi.xpro.CI.yaml` (CI → verawood)

xpro QA/Production were left unchanged as they use the `ulmo` release, outside the scope of this change.

### How can this be tested?
Deploy to the mitx CI or QA environment and confirm that the admin-console MFE is built and reachable at `https://<lms-domain>/admin-console`. Verify parity with the mitxonline QA deployment where the MFE is already enabled.