### PR TITLE
fix(ocw_site): don't override Content-Type set by Fastly Image Optimization

### DIFF
--- a/src/ol_infrastructure/applications/ocw_site/snippets/set_correct_content_type_for_S3_assets.vcl
+++ b/src/ol_infrastructure/applications/ocw_site/snippets/set_correct_content_type_for_S3_assets.vcl
@@ -6,16 +6,21 @@ if (req.url.ext == "js") {
   set beresp.http.Content-type = "application/javascript";
 }
 
-if (req.url.ext == "png") {
-  set beresp.http.Content-type = "image/png";
-}
+# Only infer an image Content-Type from the extension when one isn't already
+# set to an image type. This avoids clobbering the Content-Type that Fastly
+# Image Optimization produces (e.g. webp/avif via format negotiation).
+if (beresp.http.Content-Type !~ "(?i)^image/") {
+  if (req.url.ext == "png") {
+    set beresp.http.Content-type = "image/png";
+  }
 
-if (req.url.ext == "jpg") {
-  set beresp.http.Content-type = "image/jpeg";
-}
+  if (req.url.ext == "jpg") {
+    set beresp.http.Content-type = "image/jpeg";
+  }
 
-if (req.url.ext == "gif") {
-  set beresp.http.Content-type = "image/gif";
+  if (req.url.ext == "gif") {
+    set beresp.http.Content-type = "image/gif";
+  }
 }
 
 if (req.url.ext == "pdf") {


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10882

### Description (What does it do?)
The `set_correct_content_type_for_S3_assets` fetch snippet inferred image `Content-Type`s purely from the URL extension (`.png` → `image/png`, etc.). That logic predates Fastly Image Optimization and existed to fix S3 assets served with a missing/generic `Content-Type`.

With Image Optimization now enabled (`image_optimizer=True`, `webp=True`), IO transcodes images via format negotiation — e.g. a `.png` requested by a WebP-capable browser is delivered as WebP. The extension-based override then clobbered IO's correct `Content-Type`, so the optimized bytes were mislabeled (WebP served as `image/png`).

This change guards the `png`/`jpg`/`gif` branches so they only run when an image `Content-Type` isn't already present:

```vcl
if (beresp.http.Content-Type !~ "(?i)^image/") {
  ...
}
```

The `css`, `js`, and `pdf` branches are unchanged.

### How can this be tested?
Once this is deployed to RC, visit https://live-qa.ocw.mit.edu/about and search for `brett-paci` in the network tab(under images). Verify that the response content type matches the ofmt (output format) field under the Fastly-Io-Info response header.