### PR TITLE
fix(xqwatcher): draw down mitxonline prod concurrency to stop login storm

### DIFF
--- a/src/ol_infrastructure/applications/xqwatcher/Pulumi.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/xqwatcher/Pulumi.mitxonline.Production.yaml
@@ -6,14 +6,23 @@ config:
   xqwatcher:business_unit: mitxonline
   xqwatcher:cluster: applications
   xqwatcher:namespace: mitxonline-openedx
-  xqwatcher:min_replicas: 2
+  # Concurrency drawn down to a single worker to avoid the xqueue-watcher login
+  # storm: all watcher sessions authenticate as the shared `xqwatcher` LMS user,
+  # and PREVENT_CONCURRENT_LOGINS keeps only one session per user, so concurrent
+  # logins evict each other. One pod + one queue + CONNECTIONS=1 == one session.
+  # See openedx/edx-platform concurrent-login issue. Trade-off: no failover until
+  # the upstream exemption lands; revert min/max to 2+ afterward.
+  xqwatcher:min_replicas: 1
+  xqwatcher:max_replicas: 1
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production
   xqwatcher:edxorg_xqueue_enabled: true
   xqwatcher:xqueue_server_url: https://courses.learn.mit.edu
   xqwatcher:queues:
     Watcher-MITx-6.00x:
-      CONNECTIONS: 5
+      # Single connection: serializes grading for this queue but guarantees a
+      # single xqwatcher login session (see replica note above).
+      CONNECTIONS: 1
       HANDLERS:
       - HANDLER: xqueue_watcher.containergrader.ContainerGrader
         KWARGS:
@@ -38,15 +47,18 @@ config:
           memory_limit: 1Gi
           timeout: 60
           image_pull_policy: always
-    mitx-686xgrader:
-      CONNECTIONS: 5
-      HANDLERS:
-      - HANDLER: xqueue_watcher.containergrader.ContainerGrader
-        KWARGS:
-          grader_root: /graders/
-          image: 610119931565.dkr.ecr.us-east-1.amazonaws.com/mitodl/graders-mit-686x:latest
-          backend: kubernetes
-          cpu_limit: 1000m
-          memory_limit: 1Gi
-          timeout: 60
-          image_pull_policy: always
+    # 686x grader on the MITx LMS is not currently in use; commented out to
+    # remove its xqwatcher queue (a second concurrent login session) while the
+    # concurrency drawdown is in effect. Re-enable when 6.86x grading is needed.
+    # mitx-686xgrader:
+    #   CONNECTIONS: 1
+    #   HANDLERS:
+    #   - HANDLER: xqueue_watcher.containergrader.ContainerGrader
+    #     KWARGS:
+    #       grader_root: /graders/
+    #       image: 610119931565.dkr.ecr.us-east-1.amazonaws.com/mitodl/graders-mit-686x:latest
+    #       backend: kubernetes
+    #       cpu_limit: 1000m
+    #       memory_limit: 1Gi
+    #       timeout: 60
+    #       image_pull_policy: always


### PR DESCRIPTION
## What

Interim mitigation for the MITx Online xqueue-watcher login storm.

All watcher workers authenticate as the single shared `xqwatcher` LMS user. With `FEATURES['PREVENT_CONCURRENT_LOGINS']` enabled, the LMS stores **one** session per user and deletes the prior one on every login (`common/djangoapps/student/models/user.py::UserProfile.set_login_session`). The ~20 concurrent watcher logins (2 pods × 2 queues × CONNECTIONS=5) therefore continuously evict each other, producing a self-sustaining login storm and ~1:1 `403`s on `get_submission`/`put_result` that stalls grading.

## Change (mitxonline production only)

- `min_replicas` / `max_replicas` → `1` (single pod)
- `Watcher-MITx-6.00x` `CONNECTIONS` `5 → 1`
- comment out the unused `mitx-686xgrader` queue (it was a second concurrent session)

Net: exactly **one** `xqwatcher` login session on the LMS → storm eliminated.

## Trade-offs

- No watcher failover while at 1 replica; 6.00x grading is serialized (fine at current volume).
- `edxorg-686x` is left as-is (separate edx.org-facing deployment, not part of the LMS storm), though it inherits the single-replica setting.
- Revert replicas/CONNECTIONS once the durable fix lands (upstream `PREVENT_CONCURRENT_LOGINS` service-account exemption — openedx/edx-platform issue/PR filed separately).

## Verification

Root cause confirmed by faithful reproduction against QA (`courses.rc.learn.mit.edu`): a fresh `xqwatcher` session authenticates for a few seconds, then its Redis session row is deleted by the next fleet-wide `xqwatcher` login → `403`. Eviction/memory, cookie TTL, password-hash drift, and SECRET_KEY-across-pods were each tested and ruled out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)