### PR TITLE
fix(mit-learn): reduce search API tail latency

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -9,7 +9,6 @@ from string import Template
 
 import pulumi_fastly as fastly
 import pulumi_github as github
-import pulumi_kubernetes as kubernetes
 import pulumi_qdrant_cloud as qdrant_cloud
 import pulumi_vault as vault
 from pulumi import (
@@ -31,6 +30,10 @@ from bridge.lib.magic_numbers import (
     ONE_MEGABYTE_BYTE,
 )
 from bridge.secrets.sops import read_yaml_secrets
+from ol_infrastructure.applications.mit_learn.k8s_autoscaling import (
+    build_webapp_keda_config,
+    create_webapp_trigger_auth,
+)
 from ol_infrastructure.applications.mit_learn.k8s_secrets import (
     create_mitlearn_k8s_secrets,
 )
@@ -1472,6 +1475,21 @@ secret_names, secret_resources = create_mitlearn_k8s_secrets(
     redis_cache=redis_cache,
 )
 
+# KEDA webapp autoscaling: scale on APISIX request-rate + p95 latency
+# (CPU backstop) instead of CPU/memory alone, since search blocks on I/O.
+webapp_trigger_auth, webapp_trigger_auth_name = create_webapp_trigger_auth(
+    env_name=stack_info.env_suffix,
+    namespace=learn_namespace,
+    k8s_global_labels=k8s_app_labels,
+    stack_info=stack_info,
+    vault_k8s_resources=vault_k8s_resources,
+)
+webapp_keda_config = build_webapp_keda_config(
+    trigger_auth_name=webapp_trigger_auth_name,
+    stack_info=stack_info,
+    mitlearn_config=mitlearn_config,
+)
+
 # Configure and deploy the mitlearn application using OLApplicationK8s
 mitlearn_k8s_app = OLApplicationK8s(
     ol_app_k8s_config=OLApplicationK8sConfig(
@@ -1539,35 +1557,14 @@ mitlearn_k8s_app = OLApplicationK8s(
             resource_requests={"cpu": "100m", "memory": "2048Mi"},
             resource_limits={"memory": "2048Mi"},
         ),
-        resource_requests={"cpu": "250m", "memory": "2400Mi"},
+        resource_requests={"cpu": "500m", "memory": "2400Mi"},
         resource_limits={"memory": "2400Mi"},
-        hpa_scaling_metrics=[
-            kubernetes.autoscaling.v2.MetricSpecArgs(
-                type="Resource",
-                resource=kubernetes.autoscaling.v2.ResourceMetricSourceArgs(
-                    name="cpu",
-                    target=kubernetes.autoscaling.v2.MetricTargetArgs(
-                        type="Utilization",
-                        average_utilization=60,  # Target CPU utilization (60%)
-                    ),
-                ),
-            ),
-            # Scale up when avg usage exceeds: 1800 * 0.8 = 1440 Mi
-            kubernetes.autoscaling.v2.MetricSpecArgs(
-                type="Resource",
-                resource=kubernetes.autoscaling.v2.ResourceMetricSourceArgs(
-                    name="memory",
-                    target=kubernetes.autoscaling.v2.MetricTargetArgs(
-                        type="Utilization",
-                        average_utilization=80,  # Target memory utilization (80%)
-                    ),
-                ),
-            ),
-        ],
+        webapp_keda_config=webapp_keda_config,
     ),
     opts=ResourceOptions(
         depends_on=[
             mitlearn_app_security_group,
+            webapp_trigger_auth,
             *secret_resources,
         ]
     ),

--- a/src/ol_infrastructure/applications/mit_learn/files/web.conf_granian
+++ b/src/ol_infrastructure/applications/mit_learn/files/web.conf_granian
@@ -37,6 +37,12 @@ server {
         proxy_pass_request_headers on;
         proxy_pass_request_body on;
         client_max_body_size 25M;
+
+        gzip on;
+        gzip_proxied any;
+        gzip_types application/json;
+        gzip_min_length 1024;
+        gzip_comp_level 5;
     }
 
 }

--- a/src/ol_infrastructure/applications/mit_learn/files/web.conf_granian
+++ b/src/ol_infrastructure/applications/mit_learn/files/web.conf_granian
@@ -42,7 +42,7 @@ server {
         gzip_proxied any;
         gzip_types application/json;
         gzip_min_length 1024;
-        gzip_comp_level 5;
+        gzip_comp_level 1;
     }
 
 }

--- a/src/ol_infrastructure/applications/mit_learn/files/web.conf_uwsgi
+++ b/src/ol_infrastructure/applications/mit_learn/files/web.conf_uwsgi
@@ -37,12 +37,6 @@ server {
         proxy_pass_request_headers on;
         proxy_pass_request_body on;
         client_max_body_size 25M;
-
-        gzip on;
-        gzip_proxied any;
-        gzip_types application/json;
-        gzip_min_length 1024;
-        gzip_comp_level 5;
     }
 
 }

--- a/src/ol_infrastructure/applications/mit_learn/files/web.conf_uwsgi
+++ b/src/ol_infrastructure/applications/mit_learn/files/web.conf_uwsgi
@@ -37,6 +37,12 @@ server {
         proxy_pass_request_headers on;
         proxy_pass_request_body on;
         client_max_body_size 25M;
+
+        gzip on;
+        gzip_proxied any;
+        gzip_types application/json;
+        gzip_min_length 1024;
+        gzip_comp_level 5;
     }
 
 }

--- a/src/ol_infrastructure/applications/mit_learn/k8s_autoscaling.py
+++ b/src/ol_infrastructure/applications/mit_learn/k8s_autoscaling.py
@@ -1,0 +1,147 @@
+# ruff: noqa: E501
+"""KEDA autoscaling resources for the mit-learn webapp deployment.
+
+Scales the webapp on APISIX request-rate and p95 latency (Prometheus) instead
+of CPU alone, because search requests may block on I/O and keep CPU
+low while requests queue. A CPU trigger is retained as a backstop.
+"""
+
+import pulumi
+import pulumi_kubernetes as kubernetes
+from pulumi import ResourceOptions
+
+from ol_infrastructure.components.services.k8s import (
+    OLApplicationK8sKedaWebappScalingConfig,
+)
+from ol_infrastructure.components.services.vault import (
+    OLVaultK8SResources,
+    OLVaultK8SSecret,
+    OLVaultK8SStaticSecretConfig,
+)
+from ol_infrastructure.lib.pulumi_helper import StackInfo
+
+_PROMETHEUS_SERVER = "https://prometheus-prod-10-prod-us-central-0.grafana.net/api/prom"
+
+
+def create_webapp_trigger_auth(
+    env_name: str,
+    namespace: str,
+    k8s_global_labels: dict[str, str],
+    stack_info: StackInfo,
+    vault_k8s_resources: OLVaultK8SResources,
+) -> tuple[kubernetes.apiextensions.CustomResource, str]:
+    """Create the Prometheus TriggerAuthentication for webapp KEDA scaling.
+
+    Returns:
+        A tuple of (TriggerAuthentication resource, trigger authentication name).
+    """
+    auth_secret_name = f"{env_name}-mitlearn-webapp-prometheus-auth"
+    trigger_auth_name = f"{env_name}-mitlearn-webapp-prometheus-auth-trigger"
+
+    auth_secret = OLVaultK8SSecret(
+        f"ol-{stack_info.env_prefix}-mitlearn-webapp-prometheus-auth-{stack_info.env_suffix}",
+        OLVaultK8SStaticSecretConfig(
+            name=auth_secret_name,
+            namespace=namespace,
+            dest_secret_labels=k8s_global_labels,
+            dest_secret_name=auth_secret_name,
+            labels=k8s_global_labels,
+            mount="secret-global",
+            mount_type="kv-v2",
+            path="grafana",
+            templates={
+                "username": '{{ get .Secrets "k8s_monitoring_metrics_username" }}',
+                "password": '{{ get .Secrets "k8s_monitoring_api_key" }}',
+            },
+            vaultauth=vault_k8s_resources.auth_name,
+        ),
+        opts=ResourceOptions(
+            delete_before_replace=True, depends_on=[vault_k8s_resources]
+        ),
+    )
+
+    trigger_auth = kubernetes.apiextensions.CustomResource(
+        f"ol-{stack_info.env_prefix}-mitlearn-webapp-prometheus-trigger-auth-{stack_info.env_suffix}",
+        api_version="keda.sh/v1alpha1",
+        kind="TriggerAuthentication",
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            name=trigger_auth_name,
+            namespace=namespace,
+            labels=k8s_global_labels,
+        ),
+        spec={
+            "secretTargetRef": [
+                {"parameter": "username", "name": auth_secret_name, "key": "username"},
+                {"parameter": "password", "name": auth_secret_name, "key": "password"},
+            ]
+        },
+        opts=pulumi.ResourceOptions(depends_on=[auth_secret]),
+    )
+
+    return trigger_auth, trigger_auth_name
+
+
+def build_webapp_keda_config(
+    trigger_auth_name: str,
+    stack_info: StackInfo,
+    mitlearn_config: pulumi.Config,
+) -> OLApplicationK8sKedaWebappScalingConfig:
+    """Build the KEDA ScaledObject config for the mit-learn webapp deployment.
+
+    Aggregates all webapp APISIX routes (prefixed + no-prefix, passauth +
+    reqauth) so total webapp traffic drives scaling, not a single route. The
+    route label format is confirmed against live metrics:
+    ``mitlearn_ol-mitlearn-k8s-apisix-route[-no-prefix]-<env_suffix>_<route_name>``.
+    """
+    route_regex = f"mitlearn_ol-mitlearn-k8s-apisix-route.*-{stack_info.env_suffix}_.*"
+
+    requests_query = (
+        f'sum(rate(apisix_http_status{{route=~"{route_regex}"}}[5m]))'
+        f'/count(kube_pod_info{{namespace="mitlearn",pod=~"mitlearn-app-.*"}})'
+    )
+    requests_threshold = mitlearn_config.get("autoscaling_requests_threshold") or "20"
+
+    latency_query = f'histogram_quantile(0.95,sum(rate(apisix_http_latency_bucket{{route=~"{route_regex}"}}[5m])) by (le))'
+    latency_threshold = mitlearn_config.get("autoscaling_latency_threshold") or "2000"
+
+    cpu_threshold = mitlearn_config.get("autoscaling_cpu_threshold") or "60"
+
+    return OLApplicationK8sKedaWebappScalingConfig(
+        scale_up_stabilization_seconds=60,
+        scale_up_percent=50,
+        scale_up_period_seconds=60,
+        scale_down_stabilization_seconds=300 * 5,  # 25 minutes
+        scale_down_percent=10,
+        scale_down_period_seconds=300 * 5,  # 25 minutes
+        polling_interval=60,
+        cooldown_period=300,
+        trigger_authentication_name=trigger_auth_name,
+        triggers=[
+            {
+                "type": "prometheus",
+                "metadata": {
+                    "serverAddress": _PROMETHEUS_SERVER,
+                    "query": requests_query,
+                    "threshold": requests_threshold,
+                    "authModes": "basic",
+                },
+            },
+            {
+                "type": "prometheus",
+                "metadata": {
+                    "serverAddress": _PROMETHEUS_SERVER,
+                    "query": latency_query,
+                    "threshold": latency_threshold,
+                    "authModes": "basic",
+                },
+            },
+            {
+                "type": "cpu",
+                "metricType": "Utilization",
+                "metadata": {
+                    "value": cpu_threshold,
+                    "containerName": "mitlearn-app",
+                },
+            },
+        ],
+    )

--- a/src/ol_infrastructure/applications/mit_learn/k8s_autoscaling.py
+++ b/src/ol_infrastructure/applications/mit_learn/k8s_autoscaling.py
@@ -97,7 +97,8 @@ def build_webapp_keda_config(
 
     requests_query = (
         f'sum(rate(apisix_http_status{{route=~"{route_regex}"}}[5m]))'
-        f'/count(kube_pod_info{{namespace="mitlearn",pod=~"mitlearn-app-.*"}})'
+        f'/count(kube_pod_info{{job="integrations/kubernetes/kube-state-metrics",'
+        f'namespace="mitlearn",pod=~"mitlearn-app-.*"}})'
     )
     requests_threshold = mitlearn_config.get("autoscaling_requests_threshold") or "20"
 


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/hq/issues/5101

### Description (What does it do?)
Three independent infra-side fixes for `/api/v1/learning_resources_search` tail latency (10–30s, occasional 502/499). The slow tail does not seem to be the API/search query — it's request queuing, autoscaling, and transmission:

- **nginx JSON gzip** — the API bypasses Fastly and the sidecar had no `gzip_types`, so JSON bodies (up to ~1.26 MB) shipped uncompressed.
- **Higher per-pod concurrency** — Granian `workers` 1→4 (config-tunable) and CPU request 250m→500m. Sync Django views under the `asginl` ASGI interface serialize to ~1 in-flight search per process, so a single homepage's ~7-call fan-out saturated the pods.
- **KEDA autoscaling** — scale the webapp on APISIX request-rate + p95 latency (with a CPU backstop) instead of CPU/memory alone. Search blocks on I/O, so CPU stayed low and the old HPA never added replicas while requests queued. Mirrors the existing edxapp KEDA pattern.

### How can this be tested?
- `pulumi -C src/ol_infrastructure/applications/mit_learn preview --stack mit_learn.QA`. Expect: webapp Deployment update (workers/CPU), nginx ConfigMap update, and the CPU/memory HPA replaced by a KEDA `ScaledObject` + `TriggerAuthentication`.
- Post-deploy: `curl -H 'Accept-Encoding: gzip' -sI <search-url>` returns `content-encoding: gzip`; `kubectl -n mitlearn get scaledobject` shows READY with the Prometheus triggers returning data.

### Additional Context
KEDA Prometheus query labels (route regex, `mitlearn-app` pod selector) were confirmed against live Grafana metrics. App-side fixes from the diagnosis (cache-stampede coalescing, SSR fan-out reduction) are out of scope here and tracked separately.