### PR TITLE
fix(mit-learn): increase Granian workers to 2 and rate-limit SCIM ingress

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1493,7 +1493,7 @@ mitlearn_k8s_app = OLApplicationK8s(
         application_cmd_array=["uwsgi"],
         application_arg_array=["/tmp/uwsgi.ini"],  # noqa: S108
         granian_config=GranianConfig(
-            workers=1,
+            workers=2,  # was 1; Granian ASGI limits blocking_threads=1/worker, so this is the only concurrency lever for sync Django work
             enable_metrics=True,
             interface="asginl",
             backlog=None,
@@ -1667,6 +1667,40 @@ learn_external_service_apisix_route_no_prefix = OLApisixRoute(
             backend_service_name=mitlearn_k8s_app.application_lb_service_name,
             backend_service_port=mitlearn_k8s_app.application_lb_service_port_name,
         ),
+        OLApisixRouteConfig(
+            route_name="scim-rate-limit",
+            priority=5,
+            shared_plugin_config_name=learn_external_service_shared_plugins.resource_name,
+            plugins=[
+                # Rate-limit SCIM to protect against IdP flooding (2026-06-30 incident:
+                # 50-100 PATCH/5min/pod for 90+ min caused head-of-line blocking on
+                # single-worker Granian pods).
+                OLApisixPluginConfig(
+                    name="limit-req",
+                    config={
+                        "rate": 10,
+                        "burst": 5,
+                        "key": "remote_addr",
+                        "key_type": "var",
+                        "rejected_code": 429,
+                    },
+                ),
+                OLApisixPluginConfig(
+                    name="limit-conn",
+                    config={
+                        "conn": 5,
+                        "burst": 2,
+                        "key": "remote_addr",
+                        "key_type": "var",
+                        "rejected_code": 429,
+                    },
+                ),
+            ],
+            hosts=[mitlearn_api_domain],
+            paths=["/scim/v2/*"],
+            backend_service_name=mitlearn_k8s_app.application_lb_service_name,
+            backend_service_port=mitlearn_k8s_app.application_lb_service_port_name,
+        ),
     ],
     opts=ResourceOptions(
         delete_before_replace=True,
@@ -1721,6 +1755,41 @@ learn_external_service_apisix_route = OLApisixRoute(
                 "/learn/login",
                 "/learn/login/*",
             ],
+            backend_service_name=mitlearn_k8s_app.application_lb_service_name,
+            backend_service_port=mitlearn_k8s_app.application_lb_service_port_name,
+        ),
+        OLApisixRouteConfig(
+            route_name="scim-rate-limit",
+            priority=5,
+            shared_plugin_config_name=learn_external_service_shared_plugins.resource_name,
+            plugins=[
+                proxy_rewrite_plugin_config,
+                # Rate-limit SCIM to protect against IdP flooding (2026-06-30 incident:
+                # 50-100 PATCH/5min/pod for 90+ min caused head-of-line blocking on
+                # single-worker Granian pods).
+                OLApisixPluginConfig(
+                    name="limit-req",
+                    config={
+                        "rate": 10,
+                        "burst": 5,
+                        "key": "remote_addr",
+                        "key_type": "var",
+                        "rejected_code": 429,
+                    },
+                ),
+                OLApisixPluginConfig(
+                    name="limit-conn",
+                    config={
+                        "conn": 5,
+                        "burst": 2,
+                        "key": "remote_addr",
+                        "key_type": "var",
+                        "rejected_code": 429,
+                    },
+                ),
+            ],
+            hosts=[mitlearn_api_domain],
+            paths=["/learn/scim/v2/*"],
             backend_service_name=mitlearn_k8s_app.application_lb_service_name,
             backend_service_port=mitlearn_k8s_app.application_lb_service_port_name,
         ),


### PR DESCRIPTION
### What are the relevant tickets?

N/A (incident-driven hardening — 2026-06-30 SCIM storm)

### Description (What does it do?)

Two infrastructure hardening changes for MIT Learn following the 2026-06-30 SCIM flooding incident, where the upstream IdP hit all pods simultaneously at 50–100 PATCH/5min/pod for 90+ minutes:

**1. Granian workers: 1 → 2**

Granian ASGI hard-limits `blocking_threads` to 1 per worker. That means a single slow synchronous Django request (e.g. a SCIM PATCH touching the ORM) can monopolise the entire pod. Workers is the only concurrency lever for sync Django work under Granian ASGI. Doubling to 2 means a slow SCIM request no longer stalls every other request on the same pod.

Changed in [`src/ol_infrastructure/applications/mit_learn/__main__.py`](https://github.com/mitodl/ol-infrastructure/blob/fix/mitlearn-granian-workers-and-scim-rate-limit/src/ol_infrastructure/applications/mit_learn/__main__.py#L1495-L1503) — `GranianConfig(workers=2, ...)`.

**2. APISIX rate-limiting routes for `/scim/v2/`**

Added a dedicated `OLApisixRouteConfig` at priority 5 (between the general catch-all at 0 and auth routes at 10) for both route groups:

- No-prefix route: `/scim/v2/*`
- Prefixed route: `/learn/scim/v2/*` (with proxy-rewrite to strip the prefix)

Both routes apply two APISIX plugins:
- `limit-req`: 10 rps sustained, burst 5, keyed on `remote_addr`, returns 429 on excess
- `limit-conn`: 5 concurrent connections, burst 2, keyed on `remote_addr`, returns 429 on excess

Both `limit-req` and `limit-conn` are already in the APISIX plugin allowlist ([`apisix_official.py` lines 85–87](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py#L85-L87)).

### How can this be tested?

- Run `pulumi preview` against a non-prod MIT Learn stack and confirm:
  - `GranianConfig.workers` changes from 1 → 2 in the Deployment spec
  - Two new `ApisixRoute` rules named `scim-rate-limit` appear in each of the two `ApisixRoute` resources, with the `limit-req` and `limit-conn` plugin blocks
- For live validation: send a burst of requests to `/scim/v2/Users` at >10 rps and confirm 429 responses are returned after the burst is exhausted

### Additional Context

The `limit-req` and `limit-conn` plugins in APISIX use `remote_addr` as the key, which rate-limits per source IP. If the IdP uses a NAT gateway with a single egress IP this will cap that IP at 10 rps / 5 concurrent connections — sufficient to absorb a storm like the one on 2026-06-30 while still allowing normal SCIM sync traffic (which runs well under 1 rps in steady state).