### PR TITLE
feat(keycloak): add scim-manager service account for scim-for-keycloak admin API

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.Production.yaml
@@ -88,6 +88,12 @@ config:
   - "ol_researcher"
   - "ol_instructor"
   - "ol_business_analyst"
+  keycloak_realm:scim-plugin-managed-realms:
+  - master
+  - olapps
+  - ol-mit
+  - ol-data-platform
+  - ol-platform-engineering
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production
   keycloak_realm:olapps_email_theme: ol-learn

--- a/src/ol_infrastructure/substructure/keycloak/__main__.py
+++ b/src/ol_infrastructure/substructure/keycloak/__main__.py
@@ -9,6 +9,9 @@ from pulumi import Config, ResourceOptions
 
 from ol_infrastructure.lib.pulumi_helper import parse_stack
 from ol_infrastructure.lib.vault import setup_vault_provider
+from ol_infrastructure.substructure.keycloak.master import (
+    create_master_realm_resources,
+)
 from ol_infrastructure.substructure.keycloak.ol_data_platform import (
     create_ol_data_platform_realm,
 )
@@ -69,6 +72,10 @@ fetch_realm_public_key_partial = partial(
     keycloak_url,
 )
 
+create_master_realm_resources(
+    keycloak_provider,
+    keycloak_url,
+)
 create_ol_platform_engineering_realm(
     keycloak_provider,
     keycloak_url,

--- a/src/ol_infrastructure/substructure/keycloak/master.py
+++ b/src/ol_infrastructure/substructure/keycloak/master.py
@@ -62,30 +62,6 @@ def create_master_realm_resources(
         keycloak_realm_config.get_object("scim-plugin-managed-realms") or []
     )
 
-    if scim_managed_realms:
-        master_realm_mgmt = keycloak.openid.get_client(
-            realm_id="master",
-            client_id="realm-management",
-            opts=InvokeOptions(provider=keycloak_provider),
-        )
-        for resource_name, role_name in [
-            ("master-scim-manager-manage-realm", "manage-realm"),
-            ("master-scim-manager-manage-users", "manage-users"),
-            ("master-scim-manager-manage-clients", "manage-clients"),
-            ("master-scim-manager-view-realm", "view-realm"),
-            ("master-scim-manager-view-users", "view-users"),
-            ("master-scim-manager-query-users", "query-users"),
-            ("master-scim-manager-query-realms", "query-realms"),
-        ]:
-            keycloak.openid.ClientServiceAccountRole(
-                resource_name,
-                realm_id="master",
-                service_account_user_id=scim_manager_client.service_account_user_id,
-                client_id=master_realm_mgmt.id,
-                role=role_name,
-                opts=resource_options,
-            )
-
     for realm_name in scim_managed_realms:
         realm_mgmt_client = keycloak.openid.get_client(
             realm_id="master",

--- a/src/ol_infrastructure/substructure/keycloak/master.py
+++ b/src/ol_infrastructure/substructure/keycloak/master.py
@@ -9,7 +9,7 @@ import json
 
 import pulumi_keycloak as keycloak
 import pulumi_vault as vault
-from pulumi import InvokeOptions, Output, ResourceOptions
+from pulumi import Config, InvokeOptions, Output, ResourceOptions
 
 
 def create_master_realm_resources(
@@ -18,6 +18,7 @@ def create_master_realm_resources(
 ) -> None:
     """Create master-realm-scoped resources shared across all Keycloak realms."""
     resource_options = ResourceOptions(provider=keycloak_provider)
+    keycloak_realm_config = Config("keycloak_realm")
 
     # ── scim-manager service account ────────────────────────────────────────
     # scim-for-keycloak enterprise plugin's admin backend requires a confidential
@@ -65,17 +66,29 @@ def create_master_realm_resources(
             opts=resource_options,
         )
 
-    # Assign scim-admin from each realm's management client in master.
+    # Assign scim-admin from each realm's {realm}-realm management client in master.
+    #
     # scim-for-keycloak's BackendAuthentication.authenticateAsScimAdmin() checks
     # whether the token holder has the scim-admin role in the {realm}-realm client
     # that Keycloak auto-creates in master for each managed realm.
-    for realm_name in [
-        "master",
-        "olapps",
-        "ol-mit",
-        "ol-data-platform",
-        "ol-platform-engineering",
-    ]:
+    #
+    # Both the {realm}-realm clients AND the scim-admin role within them are created
+    # by the plugin at runtime — they do not exist before the plugin initialises.
+    # To avoid failing in environments where the plugin has not yet run, this block
+    # is gated on the "scim-plugin-managed-realms" config key (default: empty list).
+    # Add realm names there only after scim-for-keycloak has initialised in that env.
+    #
+    # Example stack config once the plugin is running:
+    #   keycloak_realm:scim-plugin-managed-realms:
+    #     - master
+    #     - olapps
+    #     - ol-mit
+    #     - ol-data-platform
+    #     - ol-platform-engineering
+    scim_managed_realms: list[str] = (
+        keycloak_realm_config.get_object("scim-plugin-managed-realms") or []
+    )
+    for realm_name in scim_managed_realms:
         realm_mgmt_client = keycloak.openid.get_client(
             realm_id="master",
             client_id=f"{realm_name}-realm",

--- a/src/ol_infrastructure/substructure/keycloak/master.py
+++ b/src/ol_infrastructure/substructure/keycloak/master.py
@@ -1,0 +1,102 @@
+"""Keycloak master realm resource definitions.
+
+Resources that live in the master realm but are not realm-specific (e.g. the
+scim-manager service account used to manage scim-for-keycloak via its admin
+REST API).
+"""
+
+import json
+
+import pulumi_keycloak as keycloak
+import pulumi_vault as vault
+from pulumi import InvokeOptions, Output, ResourceOptions
+
+
+def create_master_realm_resources(
+    keycloak_provider: keycloak.Provider,
+    keycloak_url: str,
+) -> None:
+    """Create master-realm-scoped resources shared across all Keycloak realms."""
+    resource_options = ResourceOptions(provider=keycloak_provider)
+
+    # ── scim-manager service account ────────────────────────────────────────
+    # scim-for-keycloak enterprise plugin's admin backend requires a confidential
+    # client with service accounts; it explicitly rejects admin-cli (public client)
+    # tokens and mandates the client_credentials grant.
+    scim_manager_client = keycloak.openid.Client(
+        "master-scim-manager-client",
+        name="scim-manager",
+        realm_id="master",
+        client_id="scim-manager",
+        description="Service account for scim-for-keycloak admin API management",
+        enabled=True,
+        access_type="CONFIDENTIAL",
+        standard_flow_enabled=False,
+        implicit_flow_enabled=False,
+        direct_access_grants_enabled=False,
+        service_accounts_enabled=True,
+        valid_redirect_uris=[],
+        opts=resource_options.merge(ResourceOptions(delete_before_replace=True)),
+    )
+
+    # Grant realm-management roles in master so the service account can call
+    # Keycloak's admin REST API (required by the SCIM plugin internally).
+    master_realm_mgmt = keycloak.openid.get_client(
+        realm_id="master",
+        client_id="realm-management",
+        opts=InvokeOptions(provider=keycloak_provider),
+    )
+
+    for resource_name, role_name in [
+        ("master-scim-manager-manage-realm", "manage-realm"),
+        ("master-scim-manager-manage-users", "manage-users"),
+        ("master-scim-manager-manage-clients", "manage-clients"),
+        ("master-scim-manager-view-realm", "view-realm"),
+        ("master-scim-manager-view-users", "view-users"),
+        ("master-scim-manager-query-users", "query-users"),
+        ("master-scim-manager-query-realms", "query-realms"),
+    ]:
+        keycloak.openid.ClientServiceAccountRole(
+            resource_name,
+            realm_id="master",
+            service_account_user_id=scim_manager_client.service_account_user_id,
+            client_id=master_realm_mgmt.id,
+            role=role_name,
+            opts=resource_options,
+        )
+
+    # Assign scim-admin from each realm's management client in master.
+    # scim-for-keycloak's BackendAuthentication.authenticateAsScimAdmin() checks
+    # whether the token holder has the scim-admin role in the {realm}-realm client
+    # that Keycloak auto-creates in master for each managed realm.
+    for realm_name in [
+        "master",
+        "olapps",
+        "ol-mit",
+        "ol-data-platform",
+        "ol-platform-engineering",
+    ]:
+        realm_mgmt_client = keycloak.openid.get_client(
+            realm_id="master",
+            client_id=f"{realm_name}-realm",
+            opts=InvokeOptions(provider=keycloak_provider),
+        )
+        keycloak.openid.ClientServiceAccountRole(
+            f"master-scim-manager-scim-admin-{realm_name}",
+            realm_id="master",
+            service_account_user_id=scim_manager_client.service_account_user_id,
+            client_id=realm_mgmt_client.id,
+            role="scim-admin",
+            opts=resource_options,
+        )
+
+    vault.generic.Secret(
+        "master-scim-manager-vault-credentials",
+        path="secret-operations/keycloak/scim-manager",
+        data_json=Output.all(
+            client_id=scim_manager_client.client_id,
+            client_secret=scim_manager_client.client_secret,
+            url=keycloak_url,
+            auth_realm="master",
+        ).apply(json.dumps),
+    )

--- a/src/ol_infrastructure/substructure/keycloak/master.py
+++ b/src/ol_infrastructure/substructure/keycloak/master.py
@@ -40,45 +40,18 @@ def create_master_realm_resources(
         opts=resource_options.merge(ResourceOptions(delete_before_replace=True)),
     )
 
-    # Grant realm-management roles in master so the service account can call
-    # Keycloak's admin REST API (required by the SCIM plugin internally).
-    master_realm_mgmt = keycloak.openid.get_client(
-        realm_id="master",
-        client_id="realm-management",
-        opts=InvokeOptions(provider=keycloak_provider),
-    )
-
-    for resource_name, role_name in [
-        ("master-scim-manager-manage-realm", "manage-realm"),
-        ("master-scim-manager-manage-users", "manage-users"),
-        ("master-scim-manager-manage-clients", "manage-clients"),
-        ("master-scim-manager-view-realm", "view-realm"),
-        ("master-scim-manager-view-users", "view-users"),
-        ("master-scim-manager-query-users", "query-users"),
-        ("master-scim-manager-query-realms", "query-realms"),
-    ]:
-        keycloak.openid.ClientServiceAccountRole(
-            resource_name,
-            realm_id="master",
-            service_account_user_id=scim_manager_client.service_account_user_id,
-            client_id=master_realm_mgmt.id,
-            role=role_name,
-            opts=resource_options,
-        )
-
-    # Assign scim-admin from each realm's {realm}-realm management client in master.
+    # Grant realm-management and scim-admin roles to the service account.
     #
-    # scim-for-keycloak's BackendAuthentication.authenticateAsScimAdmin() checks
-    # whether the token holder has the scim-admin role in the {realm}-realm client
-    # that Keycloak auto-creates in master for each managed realm.
+    # All get_client() invokes below require a live, initialized Keycloak:
+    #   - realm-management: built-in Keycloak client, exists once the master realm
+    #     is set up — but absent in local/CI environments with a fresh Keycloak.
+    #   - {realm}-realm: Keycloak creates these when realms are provisioned.
+    #   - scim-admin role: created by scim-for-keycloak at plugin init time.
     #
-    # Both the {realm}-realm clients AND the scim-admin role within them are created
-    # by the plugin at runtime — they do not exist before the plugin initialises.
-    # To avoid failing in environments where the plugin has not yet run, this block
-    # is gated on the "scim-plugin-managed-realms" config key (default: empty list).
-    # Add realm names there only after scim-for-keycloak has initialised in that env.
+    # Gate all lookups on scim-plugin-managed-realms (default: []). Populate
+    # this per-stack once Keycloak and the plugin are both running in that env.
     #
-    # Example stack config once the plugin is running:
+    # Example production config:
     #   keycloak_realm:scim-plugin-managed-realms:
     #     - master
     #     - olapps
@@ -88,6 +61,31 @@ def create_master_realm_resources(
     scim_managed_realms: list[str] = (
         keycloak_realm_config.get_object("scim-plugin-managed-realms") or []
     )
+
+    if scim_managed_realms:
+        master_realm_mgmt = keycloak.openid.get_client(
+            realm_id="master",
+            client_id="realm-management",
+            opts=InvokeOptions(provider=keycloak_provider),
+        )
+        for resource_name, role_name in [
+            ("master-scim-manager-manage-realm", "manage-realm"),
+            ("master-scim-manager-manage-users", "manage-users"),
+            ("master-scim-manager-manage-clients", "manage-clients"),
+            ("master-scim-manager-view-realm", "view-realm"),
+            ("master-scim-manager-view-users", "view-users"),
+            ("master-scim-manager-query-users", "query-users"),
+            ("master-scim-manager-query-realms", "query-realms"),
+        ]:
+            keycloak.openid.ClientServiceAccountRole(
+                resource_name,
+                realm_id="master",
+                service_account_user_id=scim_manager_client.service_account_user_id,
+                client_id=master_realm_mgmt.id,
+                role=role_name,
+                opts=resource_options,
+            )
+
     for realm_name in scim_managed_realms:
         realm_mgmt_client = keycloak.openid.get_client(
             realm_id="master",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Adds a `scim-manager` confidential Keycloak client in the master realm to enable programmatic management of the [scim-for-keycloak](https://scim-for-keycloak.de/) enterprise plugin's outbound SCIM provider configuration.

**Background**: The plugin's admin backend REST API (`/realms/{realm}/scim/admin/backend/scim/v2/`) requires authentication via `client_credentials` grant from a confidential client. It explicitly rejects tokens from `admin-cli` (a public client) with the error: _"add the 'admin-cli'-role to a service-account client and authenticate using the OAuth2 Client Credentials Grant."_

**What this adds** (`src/ol_infrastructure/substructure/keycloak/master.py`):
- `scim-manager` confidential client in master realm, service accounts enabled, no standard/implicit/direct-access flows
- `realm-management` client roles assigned to the service account (`manage-realm`, `manage-users`, `manage-clients`, `view-realm`, `view-users`, `query-users`, `query-realms`) for Keycloak admin API access required by the plugin internally
- `scim-admin` role from each managed realm's `{realm}-realm` management client (`master`, `olapps`, `ol-mit`, `ol-data-platform`, `ol-platform-engineering`), satisfying `BackendAuthentication.authenticateAsScimAdmin()` — the plugin checks that the token holder has this role in the Keycloak-generated realm management client for each realm it should be able to administer
- Vault secret at `secret-operations/keycloak/scim-manager` with `client_id`, `client_secret`, `url`, and `auth_realm`

After deploying, the SCIM admin API can be reached with:
```bash
python scripts/keycloak/export_scim_config.py \
    --url https://sso.ol.mit.edu \
    --realm olapps \
    --client-id scim-manager \
    --client-secret "$(vault kv get -field=client_secret secret-operations/keycloak/scim-manager)" \
    --output scim_export.json
```

### How can this be tested?
1. Deploy the Keycloak substructure stack against Production
2. Verify the `scim-manager` client appears in the Keycloak master realm admin UI with service accounts enabled
3. Verify the service account user has the expected `realm-management` and `scim-admin` role assignments
4. Run `scripts/keycloak/export_scim_config.py` with `--client-id scim-manager --client-secret <from vault>` and confirm `RemoteScimProviderConfig` returns 200 with the two configured providers (`ol-learn-scim`, `ol-mitxonline-scim`)

### Additional Context
The `scim-admin` role on each `{realm}-realm` client is an auto-generated client role that scim-for-keycloak creates when it initializes. These clients are Keycloak-internal (created automatically when each realm is provisioned) and are looked up as data sources via `keycloak.openid.get_client()`.

The role check was determined by decompiling `BackendAuthentication.class` and `Authentication.class` from the enterprise JAR (`scim-for-keycloak-kc-26-3.10.2-enterprise.jar`). The plugin runs a JPA query to enumerate all `{realm}.masterAdminClient` IDs, then checks whether the authenticated user has a `scim-admin` role whose container client is in that set.