### PR TITLE
feat(keycloak): add per-realm scim-manager service account in olapps

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/olapps.py
+++ b/src/ol_infrastructure/substructure/keycloak/olapps.py
@@ -1386,4 +1386,48 @@ def create_olapps_realm(  # noqa: PLR0913, PLR0915
         )
         # OKTA-DEV [END] # noqa: ERA001
 
+    # scim-for-keycloak admin backend: service account for managing SCIM config.
+    # The plugin processes admin API requests in each realm's own context, so the
+    # token must be issued by that same realm (cross-realm master tokens are
+    # rejected). Create one confidential service account client per realm and
+    # grant it scim-admin from realm-management (which the plugin populates).
+    olapps_scim_manager_client = keycloak.openid.Client(
+        "olapps-scim-manager-client",
+        name="scim-manager",
+        realm_id=ol_apps_realm.id,
+        client_id="scim-manager",
+        description="Service account for scim-for-keycloak admin API management",
+        enabled=True,
+        access_type="CONFIDENTIAL",
+        standard_flow_enabled=False,
+        implicit_flow_enabled=False,
+        direct_access_grants_enabled=False,
+        service_accounts_enabled=True,
+        valid_redirect_uris=[],
+        opts=resource_options.merge(ResourceOptions(delete_before_replace=True)),
+    )
+    olapps_realm_mgmt = keycloak.openid.get_client(
+        realm_id=ol_apps_realm.id,
+        client_id="realm-management",
+        opts=InvokeOptions(provider=keycloak_provider),
+    )
+    keycloak.openid.ClientServiceAccountRole(
+        "olapps-scim-manager-scim-admin",
+        realm_id=ol_apps_realm.id,
+        service_account_user_id=olapps_scim_manager_client.service_account_user_id,
+        client_id=olapps_realm_mgmt.id,
+        role="scim-admin",
+        opts=resource_options,
+    )
+    vault.generic.Secret(
+        "olapps-scim-manager-vault-credentials",
+        path="secret-operations/keycloak/olapps/scim-manager",
+        data_json=Output.all(
+            client_id=olapps_scim_manager_client.client_id,
+            client_secret=olapps_scim_manager_client.client_secret,
+            url=keycloak_url,
+            auth_realm=ol_apps_realm.id,
+        ).apply(json.dumps),
+    )
+
     return ol_apps_realm

--- a/src/ol_infrastructure/substructure/keycloak/olapps.py
+++ b/src/ol_infrastructure/substructure/keycloak/olapps.py
@@ -1391,43 +1391,52 @@ def create_olapps_realm(  # noqa: PLR0913, PLR0915
     # token must be issued by that same realm (cross-realm master tokens are
     # rejected). Create one confidential service account client per realm and
     # grant it scim-admin from realm-management (which the plugin populates).
-    olapps_scim_manager_client = keycloak.openid.Client(
-        "olapps-scim-manager-client",
-        name="scim-manager",
-        realm_id=ol_apps_realm.id,
-        client_id="scim-manager",
-        description="Service account for scim-for-keycloak admin API management",
-        enabled=True,
-        access_type="CONFIDENTIAL",
-        standard_flow_enabled=False,
-        implicit_flow_enabled=False,
-        direct_access_grants_enabled=False,
-        service_accounts_enabled=True,
-        valid_redirect_uris=[],
-        opts=resource_options.merge(ResourceOptions(delete_before_replace=True)),
+    #
+    # scim-admin is created by the plugin at init time — it does not exist in
+    # CI/QA environments where the plugin is not installed. Gate the role
+    # assignment (and dependent resources) on the same config key used in
+    # master.py: keycloak_realm:scim-plugin-managed-realms must include "olapps".
+    scim_managed_realms: list[str] = (
+        keycloak_realm_config.get_object("scim-plugin-managed-realms") or []
     )
-    olapps_realm_mgmt = keycloak.openid.get_client(
-        realm_id=ol_apps_realm.id,
-        client_id="realm-management",
-        opts=InvokeOptions(provider=keycloak_provider),
-    )
-    keycloak.openid.ClientServiceAccountRole(
-        "olapps-scim-manager-scim-admin",
-        realm_id=ol_apps_realm.id,
-        service_account_user_id=olapps_scim_manager_client.service_account_user_id,
-        client_id=olapps_realm_mgmt.id,
-        role="scim-admin",
-        opts=resource_options,
-    )
-    vault.generic.Secret(
-        "olapps-scim-manager-vault-credentials",
-        path="secret-operations/keycloak/olapps/scim-manager",
-        data_json=Output.all(
-            client_id=olapps_scim_manager_client.client_id,
-            client_secret=olapps_scim_manager_client.client_secret,
-            url=keycloak_url,
-            auth_realm=ol_apps_realm.id,
-        ).apply(json.dumps),
-    )
+    if "olapps" in scim_managed_realms:
+        olapps_scim_manager_client = keycloak.openid.Client(
+            "olapps-scim-manager-client",
+            name="scim-manager",
+            realm_id=ol_apps_realm.id,
+            client_id="scim-manager",
+            description="Service account for scim-for-keycloak admin API management",
+            enabled=True,
+            access_type="CONFIDENTIAL",
+            standard_flow_enabled=False,
+            implicit_flow_enabled=False,
+            direct_access_grants_enabled=False,
+            service_accounts_enabled=True,
+            valid_redirect_uris=[],
+            opts=resource_options.merge(ResourceOptions(delete_before_replace=True)),
+        )
+        olapps_realm_mgmt = keycloak.openid.get_client(
+            realm_id=ol_apps_realm.id,
+            client_id="realm-management",
+            opts=InvokeOptions(provider=keycloak_provider),
+        )
+        keycloak.openid.ClientServiceAccountRole(
+            "olapps-scim-manager-scim-admin",
+            realm_id=ol_apps_realm.id,
+            service_account_user_id=olapps_scim_manager_client.service_account_user_id,
+            client_id=olapps_realm_mgmt.id,
+            role="scim-admin",
+            opts=resource_options,
+        )
+        vault.generic.Secret(
+            "olapps-scim-manager-vault-credentials",
+            path="secret-operations/keycloak/olapps/scim-manager",
+            data_json=Output.all(
+                client_id=olapps_scim_manager_client.client_id,
+                client_secret=olapps_scim_manager_client.client_secret,
+                url=keycloak_url,
+                auth_realm=ol_apps_realm.id,
+            ).apply(json.dumps),
+        )
 
     return ol_apps_realm


### PR DESCRIPTION
### What are the relevant tickets?
N/A — follow-up to #4860

### Description (What does it do?)
The scim-for-keycloak admin backend validates tokens in the context of the realm being accessed. A token issued by the master realm is rejected by the olapps realm's plugin instance, even when the master-realm service account holds `scim-admin` in the cross-realm management client.

This PR adds a `scim-manager` confidential OIDC client directly in the `olapps` realm with `scim-admin` granted from `olapps/realm-management` (populated by the plugin). Credentials are written to Vault at `secret-operations/keycloak/olapps/scim-manager`.

After deploying, authenticate with `--auth-realm olapps` to access the olapps SCIM admin backend:
```
CLIENT_SECRET=$(vault kv get -field=client_secret secret-operations/keycloak/olapps/scim-manager)
python scripts/keycloak/export_scim_config.py \
  --url https://sso.ol.mit.edu \
  --client-id scim-manager \
  --client-secret "$CLIENT_SECRET" \
  --auth-realm olapps \
  --realm olapps
```

### How can this be tested?
1. Deploy Pulumi keycloak substructure to Production
2. Fetch credentials: `vault kv get secret-operations/keycloak/olapps/scim-manager`
3. Run the export script with `--auth-realm olapps` — all endpoints should return 200 (previously 401)
4. Confirm `PendingRemoteOperations` and `RemoteScimProviderConfig` are accessible