### PR TITLE
docs: add AGENTS.md to src/bilder, src/ol_concourse, src/ol_infrastructure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 This is a **large-scale infrastructure-as-code monorepo** (467 Python files, ~91K lines of code) for managing MIT Open Learning's cloud infrastructure using Pulumi, Packer/PyInfra, and Concourse.
 
-**Trust these instructions.** They are comprehensive and validated. Only search for additional information if these instructions are incomplete or incorrect.
+Scoped `AGENTS.md` files exist inside `src/bilder/`, `src/ol_concourse/`, and `src/ol_infrastructure/` — read those when working inside those packages. This root file covers repo-wide concerns only.
 
 ---
 
@@ -27,6 +27,7 @@ uv run pytest tests/           # Run tests
 The AGENTS.md instructions have been organized into focused documents. Read the relevant sections for your task:
 
 ### 📋 [Repository Overview](docs/context/01-repository-overview.md)
+
 - Repository structure and organization
 - Directory layout and purpose
 - Environment requirements
@@ -35,6 +36,7 @@ The AGENTS.md instructions have been organized into focused documents. Read the 
 **Use when:** Understanding the codebase structure or finding where code should live
 
 ### 🔨 [Build and Validation](docs/context/02-build-and-validation.md)
+
 - Environment setup and dependency installation
 - Linting, formatting, and type checking commands
 - Pre-commit hooks and validation checklist
@@ -42,24 +44,22 @@ The AGENTS.md instructions have been organized into focused documents. Read the 
 
 **Use when:** Setting up environment, validating code, or fixing build errors
 
-### 🔄 [Pulumi Workflows](docs/context/03-pulumi-workflows.md)
-- Pulumi project structure (68 projects total)
-- Stack naming conventions and management
-- Running Pulumi commands (preview, deploy)
-- Code style conventions for Pulumi
-- File modification tasks and validation
+### 🔄 Pulumi Workflows → [`src/ol_infrastructure/AGENTS.md`](src/ol_infrastructure/AGENTS.md)
 
-**Use when:** Creating or modifying Pulumi infrastructure, deploying changes
+Directory roles, stack naming, component rules, key helpers, validation.
+Deep reference: [docs/context/03-pulumi-workflows.md](docs/context/03-pulumi-workflows.md)
 
-### 📦 [Packer AMI Building](docs/context/04-packer-bilder.md)
-- Packer workflow and directory structure
-- PyInfra provisioning scripts
-- HCL formatting and validation
-- Best practices for reusable components
+### 📦 Packer AMI Building → [`src/bilder/AGENTS.md`](src/bilder/AGENTS.md)
 
-**Use when:** Building or modifying AMIs, creating Packer templates
+Build chain, PyInfra conventions, component reuse, HCL formatting.
+Deep reference: [docs/context/04-packer-bilder.md](docs/context/04-packer-bilder.md)
+
+### 🔄 Concourse Pipelines → [`src/ol_concourse/AGENTS.md`](src/ol_concourse/AGENTS.md)
+
+Pipeline DSL, factory functions, Identifier rules, meta pipeline registration.
 
 ### 🔐 [Secrets Management](docs/context/05-secrets-management.md)
+
 - SOPS encryption and KMS integration
 - Working with encrypted secrets in git
 - Pulumi secret integration
@@ -69,6 +69,7 @@ The AGENTS.md instructions have been organized into focused documents. Read the 
 **Use when:** Managing secrets, encrypting sensitive data, configuring SOPS
 
 ### 🎨 [Code Style & Conventions](docs/context/06-code-style-conventions.md)
+
 - Python type hints and Pydantic models
 - Import organization and formatting
 - Pulumi conventions (projects, stacks, components)
@@ -78,6 +79,7 @@ The AGENTS.md instructions have been organized into focused documents. Read the 
 **Use when:** Writing code, reviewing pull requests, establishing patterns
 
 ### 🧪 [Testing Strategy](docs/context/07-testing-strategy.md)
+
 - When to write unit, integration, and policy tests
 - Unit testing with Pulumi mocks
 - Integration testing with Automation API
@@ -87,6 +89,7 @@ The AGENTS.md instructions have been organized into focused documents. Read the 
 **Use when:** Creating tests, validating infrastructure code, testing components
 
 ### 🏗️ [Architecture Decisions (ADR)](docs/context/08-architecture-decisions.md)
+
 - When to create Architecture Decision Records
 - ADR creation process and template
 - Best practices for documenting decisions
@@ -95,6 +98,7 @@ The AGENTS.md instructions have been organized into focused documents. Read the 
 **Use when:** Making significant architectural changes, evaluating options
 
 ### 🐛 [Troubleshooting](docs/context/09-troubleshooting.md)
+
 - Common build, linting, and type-checking issues
 - Pulumi, Packer, and secrets management problems
 - Testing and timeout issues
@@ -108,11 +112,11 @@ The AGENTS.md instructions have been organized into focused documents. Read the 
 
 | Task | Files to Modify | Guide |
 |------|----------------|-------|
-| Add AWS resource | `src/ol_infrastructure/infrastructure/aws/<service>/__main__.py` | [Pulumi Workflows](docs/context/03-pulumi-workflows.md) |
-| Create new app | `src/ol_infrastructure/applications/<app>/` | [Pulumi Workflows](docs/context/03-pulumi-workflows.md) |
-| Add reusable component | `src/ol_infrastructure/components/<category>/` | [Pulumi Workflows](docs/context/03-pulumi-workflows.md) + [Testing](docs/context/07-testing-strategy.md) |
-| Modify AMI build | `src/bilder/images/<image>/deploy.py` | [Packer AMI Building](docs/context/04-packer-bilder.md) |
-| Add CI/CD pipeline | `src/ol_concourse/pipelines/<category>/` | [Pulumi Workflows](docs/context/03-pulumi-workflows.md) |
+| Add AWS resource | `src/ol_infrastructure/infrastructure/aws/<service>/__main__.py` | [`src/ol_infrastructure/AGENTS.md`](src/ol_infrastructure/AGENTS.md) |
+| Create new app | `src/ol_infrastructure/applications/<app>/` | [`src/ol_infrastructure/AGENTS.md`](src/ol_infrastructure/AGENTS.md) |
+| Add reusable component | `src/ol_infrastructure/components/<category>/` | [`src/ol_infrastructure/AGENTS.md`](src/ol_infrastructure/AGENTS.md) + [Testing](docs/context/07-testing-strategy.md) |
+| Modify AMI build | `src/bilder/images/<image>/deploy.py` | [`src/bilder/AGENTS.md`](src/bilder/AGENTS.md) |
+| Add CI/CD pipeline | `src/ol_concourse/pipelines/<category>/` | [`src/ol_concourse/AGENTS.md`](src/ol_concourse/AGENTS.md) |
 | Manage secrets | `src/bridge/secrets/<context>/` | [Secrets Management](docs/context/05-secrets-management.md) |
 | Document architecture | `docs/adr/NNNN-title.md` | [Architecture Decisions](docs/context/08-architecture-decisions.md) |
 | Write tests | `tests/unit/` or `tests/integration/` | [Testing Strategy](docs/context/07-testing-strategy.md) |
@@ -124,29 +128,14 @@ The AGENTS.md instructions have been organized into focused documents. Read the 
 Before submitting changes:
 
 ```bash
-# 1. Install dependencies
 uv sync
-
-# 2. Format code
 uv run ruff format src/
-
-# 3. Check code quality
 uv run ruff check src/
-
-# 4. Type check (budget 75+ seconds)
-uv run mypy src/
-
-# 5. Format Packer files (if modified)
-packer fmt -recursive src/bilder/
-
-# 6. Validate Pulumi changes (if applicable)
-pulumi preview
-
-# 7. Run tests (if applicable)
+uv run mypy src/                          # budget 75+ seconds
+packer fmt -recursive src/bilder/         # if bilder files changed
+pulumi preview                            # from inside the project dir
 uv run pytest tests/
-
-# 8. Optional: Run all pre-commit hooks (budget 2+ minutes)
-uv run pre-commit run --all-files
+uv run pre-commit run --all-files         # optional; budget 2+ minutes
 ```
 
 ---
@@ -154,6 +143,7 @@ uv run pre-commit run --all-files
 ## Key Resources
 
 ### Documentation
+
 - **Repository Overview:** `docs/context/01-repository-overview.md`
 - **Architecture Decision Records:** `docs/adr/` directory
 - **README.md:** High-level project overview
@@ -164,12 +154,14 @@ uv run pre-commit run --all-files
   - Test examples: `tests/ol_infrastructure/components/aws/test_kubernetes_app_auth.py`
 
 ### Configuration Files
+
 - `pyproject.toml` — Dependencies and tool configuration
 - `.pre-commit-config.yaml` — Pre-commit hook definitions
 - `.sops.yaml` — Secrets encryption rules
 - `uv.lock` — Locked dependency versions
 
 ### Tools & Versions
+
 - Python 3.12.7
 - uv 0.9.3 (use instead of Poetry)
 - Pulumi 3.199.0
@@ -186,8 +178,9 @@ uv run pre-commit run --all-files
 |----------|-------|
 | Where do I find or add code? | [Repository Overview](docs/context/01-repository-overview.md) |
 | How do I run tests or validate code? | [Build and Validation](docs/context/02-build-and-validation.md) |
-| How do I deploy infrastructure? | [Pulumi Workflows](docs/context/03-pulumi-workflows.md) |
-| How do I build AMIs? | [Packer AMI Building](docs/context/04-packer-bilder.md) |
+| How do I deploy infrastructure? | [`src/ol_infrastructure/AGENTS.md`](src/ol_infrastructure/AGENTS.md) |
+| How do I build AMIs? | [`src/bilder/AGENTS.md`](src/bilder/AGENTS.md) |
+| How do I write a Concourse pipeline? | [`src/ol_concourse/AGENTS.md`](src/ol_concourse/AGENTS.md) |
 | How do I manage secrets? | [Secrets Management](docs/context/05-secrets-management.md) |
 | What code style should I follow? | [Code Style & Conventions](docs/context/06-code-style-conventions.md) |
 | How do I write tests? | [Testing Strategy](docs/context/07-testing-strategy.md) |
@@ -201,80 +194,31 @@ uv run pre-commit run --all-files
 ### Python Code
 
 ```python
-# Type hints (required)
+# All functions require type hints
 def create_resource(name: str, config: dict[str, Any]) -> Resource:
-    """Create resource with config."""
     pass
 
-# Pydantic models
 from pydantic import BaseModel
 class Config(BaseModel):
     environment: str
     replicas: int = 3
 ```
 
-### Pulumi Infrastructure
-
-```python
-import pulumi
-from ol_infrastructure.lib.ol_types import AWSBase
-
-class MyComponent(pulumi.ComponentResource):
-    def __init__(self, name: str, config: MyConfig, opts=None):
-        super().__init__("custom:resource:MyComponent", name, opts=opts)
-        # Create resources and export outputs
-```
-
-### Pulumi Commands
-
-```bash
-# Preview changes before deploying
-cd src/ol_infrastructure/infrastructure/aws/network/
-pulumi stack select infrastructure.aws.network.QA
-pulumi preview
-
-# Deploy changes
-pulumi up
-```
-
-### Test Structure
-
-```python
-import pulumi
-import asyncio
-
-# Python 3.14+ compatibility
-try:
-    asyncio.get_event_loop()
-except RuntimeError:
-    asyncio.set_event_loop(asyncio.new_event_loop())
-
-# Set mocks BEFORE importing code under test
-class MyMocks(pulumi.runtime.Mocks):
-    def new_resource(self, args):
-        return [args.name + "_id", args.inputs]
-
-pulumi.runtime.set_mocks(MyMocks())
-from ol_infrastructure.components.aws.my_component import MyComponent
-
-# Write tests with @pulumi.runtime.test decorator
-@pulumi.runtime.test
-def test_component():
-    def check(args):
-        assert args == expected
-    return pulumi.Output.all(...).apply(check)
-```
+For Pulumi component patterns, stack commands, and test structure with Pulumi mocks,
+see [`src/ol_infrastructure/AGENTS.md`](src/ol_infrastructure/AGENTS.md).
 
 ---
 
 ## Learning Resources
 
 ### External
-- **Pulumi Documentation:** https://www.pulumi.com/docs/
-- **Packer Documentation:** https://www.packer.io/docs
-- **Pytest Documentation:** https://docs.pytest.org/
+
+- **Pulumi Documentation:** <https://www.pulumi.com/docs/>
+- **Packer Documentation:** <https://www.packer.io/docs>
+- **Pytest Documentation:** <https://docs.pytest.org/>
 
 ### Internal
+
 - **Test Examples:** `tests/ol_infrastructure/components/aws/test_kubernetes_app_auth.py`
 - **Component Examples:** `src/ol_infrastructure/components/aws/`
 - **ADR Examples:** `docs/adr/0001-*.md`, `docs/adr/0002-*.md`
@@ -289,14 +233,3 @@ def test_component():
 4. **Test reusable components** — Always write tests for components in `src/ol_infrastructure/components/`
 5. **Create ADRs for major decisions** — Document architectural changes in ADRs
 6. **Validate before committing** — Run the validation checklist to catch issues early
-
----
-
-## Next Steps
-
-1. **Read** the overview docs relevant to your task
-2. **Follow** the code style and conventions guide
-3. **Validate** your changes using the checklist
-4. **Submit** your code with tests and documentation
-
-For specific tasks, consult the appropriate guide in the [Documentation Index](#documentation-index).

--- a/src/bilder/AGENTS.md
+++ b/src/bilder/AGENTS.md
@@ -1,0 +1,145 @@
+# Agent Instructions — `src/bilder`
+
+PyInfra + Packer AMI build system. Packer drives the EC2 instance lifecycle; PyInfra
+(`deploy.py`) runs inside the instance to configure it. These two tools are tightly
+coupled — understanding both is required before modifying either.
+
+## How AMI Builds Work
+
+```
+Packer reads *.pkr.hcl  →  launches EC2 instance from base AMI
+                         →  runs deploy.py via PyInfra over SSH
+                         →  snapshots the configured instance as a new AMI
+```
+
+The `.pkr.hcl` files and `deploy.py` in the same image directory are a matched pair.
+Packer passes variables to PyInfra via environment variables read in `deploy.py`.
+
+## Directory Layout
+
+```
+src/bilder/
+  images/                   # One directory per AMI build target
+    consul/
+      deploy.py             # PyInfra provisioning script (the "what to install")
+      consul.pkr.hcl        # Packer template (the "how to build")
+      files/                # Static files copied to the instance
+      templates/            # Jinja2 config templates
+    vault/
+    redash/
+    concourse/
+    ...
+  components/               # Reusable provisioning components (imported by deploy.py)
+    hashicorp/              # Consul, Vault, Nomad installers
+    baseline/               # Base OS setup, users, SSH hardening
+    vector/                 # Vector log agent
+    alloy/                  # Grafana Alloy agent
+    caddy/                  # Caddy web server
+    docker/                 # Docker daemon setup
+    traefik/                # Traefik proxy
+    ...
+  facts/                    # PyInfra fact classes for host introspection
+  lib/                      # Shared Python utilities for build scripts
+  deployments/              # Non-AMI deployment scripts (PyInfra only, no Packer)
+```
+
+## Writing a `deploy.py`
+
+PyInfra operations must be **idempotent** — safe to run multiple times. Use operations
+from `pyinfra.operations`, not raw shell commands.
+
+```python
+from pyinfra import host
+from pyinfra.operations import apt, files, systemd
+
+from bilder.components.baseline.setup import baseline
+from bilder.components.hashicorp.consul import install_consul
+from bilder.facts.has_systemd import HasSystemd
+
+# Reuse components instead of reimplementing
+baseline()
+install_consul(version=host.get_fact(ConsulVersion))
+
+# Deploy config files
+files.put(
+    src="files/myapp.conf",
+    dest="/etc/myapp/myapp.conf",
+    mode="0644",
+)
+
+# Manage services
+if host.get_fact(HasSystemd):
+    systemd.service(
+        service="myapp",
+        enabled=True,
+        running=True,
+    )
+```
+
+## Using Existing Components
+
+Always check `src/bilder/components/` before writing new provisioning logic:
+
+| Component | Import path | What it does |
+|-----------|------------|-------------|
+| Baseline OS setup | `bilder.components.baseline.setup` | Users, SSH, sysctl, auditd |
+| Consul install | `bilder.components.hashicorp.consul` | Installs and configures Consul |
+| Vault install | `bilder.components.hashicorp.vault` | Installs and configures Vault |
+| Vector log agent | `bilder.components.vector` | Ships logs to Grafana/Loki |
+| Alloy agent | `bilder.components.alloy` | Grafana Alloy observability agent |
+| Docker | `bilder.components.docker` | Docker daemon + compose |
+
+## HCL Files
+
+Packer HCL follows its own formatting standard — always run:
+
+```bash
+packer fmt -recursive src/bilder/
+```
+
+before committing. The CI pipeline will reject incorrectly formatted HCL.
+
+Validate a template (requires AWS credentials):
+
+```bash
+cd src/bilder/images/consul/
+packer validate .
+```
+
+Top-level shared HCL is in `src/bilder/`:
+
+- `packer.pkr.hcl` — required plugins
+- `config.pkr.hcl` — shared source AMI lookup
+- `variables.pkr.hcl` — common variables (app_name, node_type, etc.)
+
+## Adding a New Image
+
+1. Create `src/bilder/images/<name>/` with `deploy.py` and `<name>.pkr.hcl`
+2. Reference the shared `config.pkr.hcl` and `variables.pkr.hcl` from the root
+3. Compose from existing components; add a new component only if the logic is reusable
+4. Run `packer fmt -recursive src/bilder/` and `packer validate src/bilder/images/<name>/`
+5. Add a Concourse pipeline entry in `src/ol_concourse/pipelines/infrastructure/`
+
+## Adding a New Component
+
+Components live in `src/bilder/components/<category>/`. A component is a Python module
+that exports functions called from `deploy.py`. Keep components side-effect-free when
+possible (configure, don't start services — leave that to the image's `deploy.py`).
+
+## Validation
+
+```bash
+packer fmt -recursive src/bilder/        # format HCL
+packer validate src/bilder/images/<name>/  # validate template syntax
+
+uv run ruff format src/bilder/
+uv run ruff check src/bilder/
+uv run mypy src/bilder/
+```
+
+## Where NOT to put code
+
+- Pulumi resource declarations → `src/ol_infrastructure/`
+- Concourse pipeline definitions → `src/ol_concourse/`
+- Constants shared with `ol_infrastructure` → `src/bridge/`
+- One-off operational scripts → `scripts/`

--- a/src/bilder/AGENTS.md
+++ b/src/bilder/AGENTS.md
@@ -49,18 +49,29 @@ PyInfra operations must be **idempotent** — safe to run multiple times. Use op
 from `pyinfra.operations`, not raw shell commands.
 
 ```python
+import os
 from pyinfra import host
-from pyinfra.operations import apt, files, systemd
+from pyinfra.operations import files, systemd
 
-from bilder.components.baseline.setup import baseline
-from bilder.components.hashicorp.consul import install_consul
+from bilder.components.baseline.steps import install_baseline_packages
+from bilder.components.hashicorp.consul.models import Consul, ConsulConfig
+from bilder.components.hashicorp.steps import (
+    configure_hashicorp_product,
+    install_hashicorp_products,
+)
 from bilder.facts.has_systemd import HasSystemd
+from bridge.lib.versions import CONSUL_VERSION
+
+# Versions come from environment variables set by Packer (fall back to bridge defaults)
+consul_version = os.environ.get("CONSUL_VERSION", CONSUL_VERSION)
 
 # Reuse components instead of reimplementing
-baseline()
-install_consul(version=host.get_fact(ConsulVersion))
+install_baseline_packages()
+consul = Consul(version=consul_version, configuration={...})
+install_hashicorp_products([consul])
+configure_hashicorp_product(consul)
 
-# Deploy config files
+# Deploy static config files
 files.put(
     src="files/myapp.conf",
     dest="/etc/myapp/myapp.conf",
@@ -82,9 +93,9 @@ Always check `src/bilder/components/` before writing new provisioning logic:
 
 | Component | Import path | What it does |
 |-----------|------------|-------------|
-| Baseline OS setup | `bilder.components.baseline.setup` | Users, SSH, sysctl, auditd |
-| Consul install | `bilder.components.hashicorp.consul` | Installs and configures Consul |
-| Vault install | `bilder.components.hashicorp.vault` | Installs and configures Vault |
+| Baseline OS setup | `bilder.components.baseline.steps.install_baseline_packages` | apt packages, system baseline |
+| HashiCorp products | `bilder.components.hashicorp.steps.install_hashicorp_products` | Installs Consul, Vault, Nomad, etc. |
+| HashiCorp config | `bilder.components.hashicorp.steps.configure_hashicorp_product` | Renders config files from models |
 | Vector log agent | `bilder.components.vector` | Ships logs to Grafana/Loki |
 | Alloy agent | `bilder.components.alloy` | Grafana Alloy observability agent |
 | Docker | `bilder.components.docker` | Docker daemon + compose |
@@ -106,7 +117,7 @@ cd src/bilder/images/consul/
 packer validate .
 ```
 
-Top-level shared HCL is in `src/bilder/`:
+Shared HCL lives in `src/bilder/images/` (the images root, not the package root):
 
 - `packer.pkr.hcl` — required plugins
 - `config.pkr.hcl` — shared source AMI lookup
@@ -115,7 +126,7 @@ Top-level shared HCL is in `src/bilder/`:
 ## Adding a New Image
 
 1. Create `src/bilder/images/<name>/` with `deploy.py` and `<name>.pkr.hcl`
-2. Reference the shared `config.pkr.hcl` and `variables.pkr.hcl` from the root
+2. Reference the shared `config.pkr.hcl` and `variables.pkr.hcl` from `src/bilder/images/`
 3. Compose from existing components; add a new component only if the logic is reusable
 4. Run `packer fmt -recursive src/bilder/` and `packer validate src/bilder/images/<name>/`
 5. Add a Concourse pipeline entry in `src/ol_concourse/pipelines/infrastructure/`

--- a/src/ol_concourse/AGENTS.md
+++ b/src/ol_concourse/AGENTS.md
@@ -7,13 +7,14 @@ raw YAML.
 ## How Pipelines Work
 
 ```
-pipelines/<category>/<name>/pipeline.py   # builds Pipeline object, prints JSON to stdout
-    → python pipeline.py > definition.json
+pipelines/<category>/<name>/pipeline.py   # builds Pipeline object, writes definition.json
+    → python pipeline.py               # writes definition.json; prints fly command to stdout
     → fly -t <target> sp -p <pipeline-name> -c definition.json
 ```
 
-Each `pipeline.py` is a standalone script. Running it writes `definition.json` and prints
-the `fly set-pipeline` command to stdout. There is no separate render step.
+Each `pipeline.py` is a standalone script. Running it **writes `definition.json` directly**
+(via `open("definition.json", "w")`) and prints the `fly set-pipeline` command to stdout.
+Do not redirect stdout to a file — that would mix the JSON with the fly command.
 
 ## Directory Layout
 
@@ -112,9 +113,9 @@ uv run ruff format src/ol_concourse/
 uv run ruff check src/ol_concourse/
 uv run mypy src/ol_concourse/
 
-# Render a specific pipeline and validate JSON is well-formed
+# Render a pipeline and validate the output JSON is well-formed
 cd src/ol_concourse/pipelines/infrastructure/dagster/
-python pipeline.py | python -m json.tool > /dev/null && echo "OK"
+python pipeline.py && python -m json.tool definition.json > /dev/null && echo "OK"
 ```
 
 ## Common Mistakes

--- a/src/ol_concourse/AGENTS.md
+++ b/src/ol_concourse/AGENTS.md
@@ -1,0 +1,125 @@
+# Agent Instructions — `src/ol_concourse`
+
+Pydantic-model-based DSL for generating Concourse CI/CD pipeline YAML. Pipelines are
+Python scripts that build a `Pipeline` object and serialize it to JSON; they are never
+raw YAML.
+
+## How Pipelines Work
+
+```
+pipelines/<category>/<name>/pipeline.py   # builds Pipeline object, prints JSON to stdout
+    → python pipeline.py > definition.json
+    → fly -t <target> sp -p <pipeline-name> -c definition.json
+```
+
+Each `pipeline.py` is a standalone script. Running it writes `definition.json` and prints
+the `fly set-pipeline` command to stdout. There is no separate render step.
+
+## Directory Layout
+
+```
+lib/
+  models/pipeline.py      # Core Pydantic models: Pipeline, Job, Step types, Resource, etc.
+  models/fragment.py      # PipelineFragment — composable sub-pipeline pieces
+  jobs/                   # Reusable job factory functions (packer_jobs, pulumi_jobs_chain, etc.)
+  resources.py            # Resource factory functions (git_repo, registry_image, etc.)
+  resource_types.py       # ResourceType definitions (hashicorp_resource, etc.)
+  containers.py           # container_build_task helper
+  constants.py            # Shared constants
+
+pipelines/
+  constants.py            # Pipeline-level constants (ECR_REGION, PULUMI_WATCHED_PATHS, etc.)
+  jobs.py                 # Top-level job factories (packer_jobs, pulumi_jobs_chain, pulumi_job)
+  infrastructure/         # Platform infra pipelines (consul, vault, eks, dagster, etc.)
+  applications/           # Application deployment pipelines
+```
+
+## Writing a New Pipeline
+
+1. Create `pipelines/<category>/<name>/pipeline.py` with a `__init__.py`.
+2. Build resources, then jobs, then return a `Pipeline`.
+3. Use factory functions from `lib/` — don't construct raw `Job`/`Resource` dicts.
+
+```python
+import sys
+from ol_concourse.lib.models.pipeline import GetStep, Identifier, Pipeline
+from ol_concourse.lib.resources import git_repo
+from ol_concourse.pipelines.constants import PULUMI_WATCHED_PATHS
+from ol_concourse.pipelines.jobs import pulumi_jobs_chain
+
+code = git_repo(
+    Identifier("ol-infrastructure"),
+    uri="https://github.com/mitodl/ol-infrastructure",
+    paths=["src/ol_infrastructure/applications/myapp/", *PULUMI_WATCHED_PATHS],
+)
+
+pipeline = Pipeline(
+    resources=[code],
+    jobs=pulumi_jobs_chain(
+        code_resource=code,
+        environments=["CI", "QA", "Production"],
+        project_path="src/ol_infrastructure/applications/myapp/",
+    ),
+)
+
+if __name__ == "__main__":
+    output = pipeline.model_dump_json(indent=2)
+    with open("definition.json", "w") as f:
+        f.write(output)
+    sys.stdout.write(output)
+    print()
+    print("fly -t pr-inf sp -p myapp -c definition.json")
+```
+
+## Key Factories
+
+| Factory | Location | What it builds |
+|---------|----------|---------------|
+| `git_repo(name, uri, paths)` | `lib/resources.py` | Git resource watching specific paths |
+| `registry_image(name, ...)` | `lib/resources.py` | Docker registry image resource |
+| `pulumi_provisioner(...)` | `lib/resources.py` | Pulumi provisioner resource |
+| `hashicorp_release(name, product)` | `lib/resources.py` | HashiCorp release resource |
+| `packer_jobs(...)` | `pipelines/jobs.py` | AMI build job chain |
+| `pulumi_jobs_chain(...)` | `pipelines/jobs.py` | Multi-env Pulumi deploy chain |
+| `pulumi_job(...)` | `pipelines/jobs.py` | Single-env Pulumi deploy job |
+| `container_build_task(...)` | `lib/containers.py` | Docker image build task config |
+
+## Pydantic Model Rules
+
+- `Identifier` is a validated string type — all resource/job names must be `Identifier(...)`, not bare strings
+- `PipelineFragment` composes multiple jobs and resources into a reusable unit
+- All step types (`GetStep`, `PutStep`, `TaskStep`, `SetPipelineStep`, etc.) are in `lib/models/pipeline.py`
+- Use `model_dump_json(indent=2)` to serialize — never `json.dumps` a pipeline manually
+
+## Adding a Pipeline to the Meta Pipeline
+
+Infrastructure pipelines are self-managed via `pipelines/infrastructure/meta.py`. After
+creating a new pipeline, add an entry to `PIPELINE_CONFIGS` in that file:
+
+```python
+PIPELINE_CONFIGS: list[tuple[str, str]] = [
+    ("my-pipeline-name", "src/ol_concourse/pipelines/infrastructure/myapp/pipeline.py"),
+    ...
+]
+```
+
+Then regenerate and re-apply the meta pipeline itself.
+
+## Validation
+
+```bash
+uv run ruff format src/ol_concourse/
+uv run ruff check src/ol_concourse/
+uv run mypy src/ol_concourse/
+
+# Render a specific pipeline and validate JSON is well-formed
+cd src/ol_concourse/pipelines/infrastructure/dagster/
+python pipeline.py | python -m json.tool > /dev/null && echo "OK"
+```
+
+## Common Mistakes
+
+- **Bare strings as names** — always wrap in `Identifier("...")`, validation will fail at runtime otherwise
+- **Importing from `pipeline.py` in other files** — each pipeline is a standalone script, not a library
+- **Writing raw YAML** — if you're writing YAML, you're doing it wrong; use the model DSL
+- **Forgetting `trigger=True`** on `GetStep` — pipelines won't auto-trigger without it

--- a/src/ol_concourse/AGENTS.md
+++ b/src/ol_concourse/AGENTS.md
@@ -19,21 +19,17 @@ Do not redirect stdout to a file — that would mix the JSON with the fly comman
 ## Directory Layout
 
 ```
-lib/
-  models/pipeline.py      # Core Pydantic models: Pipeline, Job, Step types, Resource, etc.
-  models/fragment.py      # PipelineFragment — composable sub-pipeline pieces
-  jobs/                   # Reusable job factory functions (packer_jobs, pulumi_jobs_chain, etc.)
-  resources.py            # Resource factory functions (git_repo, registry_image, etc.)
-  resource_types.py       # ResourceType definitions (hashicorp_resource, etc.)
-  containers.py           # container_build_task helper
-  constants.py            # Shared constants
-
 pipelines/
   constants.py            # Pipeline-level constants (ECR_REGION, PULUMI_WATCHED_PATHS, etc.)
   jobs.py                 # Top-level job factories (packer_jobs, pulumi_jobs_chain, pulumi_job)
   infrastructure/         # Platform infra pipelines (consul, vault, eks, dagster, etc.)
   applications/           # Application deployment pipelines
 ```
+
+The `ol_concourse.lib` modules (models, resources, resource_types, containers) are provided
+by the `ol-concourse` pip package (installed into the venv). Browse them under
+`.venv/lib/pythonX.Y/site-packages/ol_concourse/lib/` or via the upstream repo. Do not
+create a local `lib/` directory here.
 
 ## Writing a New Pipeline
 

--- a/src/ol_infrastructure/AGENTS.md
+++ b/src/ol_infrastructure/AGENTS.md
@@ -1,0 +1,109 @@
+# Agent Instructions — `src/ol_infrastructure`
+
+Pulumi infrastructure-as-code for MIT Open Learning. Each subdirectory has a distinct role;
+place code in the right one before writing anything.
+
+## Directory Roles
+
+| Directory | Purpose | When to add code here |
+|-----------|---------|----------------------|
+| `applications/<app>/` | Per-app Pulumi stacks (Pulumi.yaml entrypoints) | New or existing application infrastructure |
+| `components/aws/` | Reusable AWS Pulumi ComponentResources | Any AWS resource group used in 2+ places |
+| `components/services/` | Reusable third-party service components (k8s operators, Vault, etc.) | Same as above but for non-AWS services |
+| `components/applications/` | App-level reusable components | App patterns shared across stacks |
+| `infrastructure/aws/<service>/` | Shared AWS platform infrastructure (VPCs, EKS clusters, IAM, KMS, DNS) | Platform-level resources not tied to a single app |
+| `lib/` | Pure-Python helpers (no Pulumi resources) | Shared logic, type definitions, Pulumi helpers |
+| `providers/` | Custom Pulumi provider wrappers | Wrapping external provider APIs |
+| `saas/` | SaaS integrations (not AWS-native) | Rootly, etc. |
+| `substructure/` | Cross-cutting Pulumi stacks (Consul, Vault) | Infrastructure that spans apps |
+
+## Stack Structure
+
+Every Pulumi project is a directory containing:
+
+```
+__main__.py              # Resource declarations
+Pulumi.yaml              # Project definition
+Pulumi.<env>.yaml        # Stack config per environment (QA, Production, CI, Dev)
+```
+
+Stack names follow `<namespace>.<environment>`, e.g. `infrastructure.aws.network.QA`.
+
+```bash
+cd src/ol_infrastructure/applications/mit_learn/
+pulumi stack ls
+pulumi stack select applications.mit_learn.QA
+pulumi preview    # always preview before up
+```
+
+## Components: Non-Negotiable Rules
+
+Components in `components/` **must**:
+
+1. Inherit from `pulumi.ComponentResource`
+2. Accept config via a Pydantic model (inherit from `ol_infrastructure.lib.ol_types.AWSBase` for AWS config)
+3. Export outputs as instance attributes
+4. Have unit tests using Pulumi mocks (in `tests/ol_infrastructure/components/`)
+
+```python
+import pulumi
+from ol_infrastructure.lib.ol_types import AWSBase
+
+class MyConfig(AWSBase):
+    instance_count: int = 1
+
+class MyComponent(pulumi.ComponentResource):
+    def __init__(self, name: str, config: MyConfig, opts: pulumi.ResourceOptions | None = None):
+        super().__init__("ol:aws:MyComponent", name, opts=opts)
+        # create child resources with opts=pulumi.ResourceOptions(parent=self)
+```
+
+## Key Helpers
+
+- `ol_infrastructure.lib.pulumi_helper.parse_stack()` → `StackInfo` (stack name, environment)
+- `ol_infrastructure.lib.ol_types.AWSBase` → Pydantic base for all AWS configs
+- `ol_infrastructure.lib.ol_types.BusinessUnit` → enum for OU tags; apply to all resources
+- `ol_infrastructure.lib.aws.iam_helper.lint_iam_policy()` → validate IAM policy docs before use
+- `bridge.lib.magic_numbers` → canonical port/size constants; don't hardcode these values
+
+## Common Patterns
+
+### Reading stack config
+
+```python
+from ol_infrastructure.lib.pulumi_helper import parse_stack
+stack_info = parse_stack()
+env = stack_info.env_suffix  # "QA" | "Production" | "CI" | "Dev"
+```
+
+### IAM policy
+
+```python
+from ol_infrastructure.lib.aws.iam_helper import lint_iam_policy
+policy_doc = {"Version": "2012-10-17", "Statement": [...]}
+lint_iam_policy(policy_doc, "MyPolicy")  # raises on errors
+```
+
+### Resource tags
+
+```python
+from ol_infrastructure.lib.ol_types import BusinessUnit
+tags = {"BusinessUnit": BusinessUnit.OPERATIONS, "Environment": stack_info.env_suffix}
+```
+
+## Validation
+
+```bash
+uv run ruff format src/ol_infrastructure/
+uv run ruff check src/ol_infrastructure/
+uv run mypy src/ol_infrastructure/
+pulumi preview    # from inside the project directory
+uv run pytest tests/ol_infrastructure/
+```
+
+## Where NOT to put code
+
+- Logic used in only one stack → keep it in that stack's `__main__.py`
+- PyInfra/Packer provisioning → belongs in `src/bilder/`, not here
+- Concourse pipeline definitions → belongs in `src/ol_concourse/`
+- Glue between bilder and ol_infrastructure → belongs in `src/bridge/`

--- a/src/ol_infrastructure/AGENTS.md
+++ b/src/ol_infrastructure/AGENTS.md
@@ -27,12 +27,13 @@ Pulumi.yaml              # Project definition
 Pulumi.<env>.yaml        # Stack config per environment (QA, Production, CI, Dev)
 ```
 
-Stack names follow `<namespace>.<environment>`, e.g. `infrastructure.aws.network.QA`.
+After the project-scoped stack migration, stack names are short: `QA`, `Production`, `CI`,
+or `<tenant>.QA` for multi-tenant projects. Select from inside the project directory.
 
 ```bash
 cd src/ol_infrastructure/applications/mit_learn/
 pulumi stack ls
-pulumi stack select applications.mit_learn.QA
+pulumi stack select QA
 pulumi preview    # always preview before up
 ```
 
@@ -73,7 +74,8 @@ class MyComponent(pulumi.ComponentResource):
 ```python
 from ol_infrastructure.lib.pulumi_helper import parse_stack
 stack_info = parse_stack()
-env = stack_info.env_suffix  # "QA" | "Production" | "CI" | "Dev"
+env_upper = stack_info.name        # "QA" | "Production" | "CI" | "Dev"
+env_lower = stack_info.env_suffix  # "qa" | "production" | "ci" | "dev"
 ```
 
 ### IAM policy
@@ -81,14 +83,16 @@ env = stack_info.env_suffix  # "QA" | "Production" | "CI" | "Dev"
 ```python
 from ol_infrastructure.lib.aws.iam_helper import lint_iam_policy
 policy_doc = {"Version": "2012-10-17", "Statement": [...]}
-lint_iam_policy(policy_doc, "MyPolicy")  # raises on errors
+lint_iam_policy(policy_doc)  # raises on errors; signature: (policy_document, stringify=False)
 ```
 
 ### Resource tags
 
+`AWSBase` requires `OU` and `Environment` tags. `OU` must be a valid `BusinessUnit` value.
+
 ```python
 from ol_infrastructure.lib.ol_types import BusinessUnit
-tags = {"BusinessUnit": BusinessUnit.OPERATIONS, "Environment": stack_info.env_suffix}
+tags = {"OU": BusinessUnit.operations, "Environment": stack_info.name}
 ```
 
 ## Validation


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Adds co-located `AGENTS.md` files to the three highest-value source packages so AI agents (and humans) working in those subtrees get the right context immediately, without having to trace back to root docs or read multiple context files.

**`src/ol_infrastructure/AGENTS.md`**
- Directory role table: `applications/` vs `components/` vs `infrastructure/` vs `lib/` — what belongs where
- Stack naming convention and per-project file structure
- Non-negotiable component rules (inherit `ComponentResource`, Pydantic config model, unit test required)
- Key helper inventory: `parse_stack`, `AWSBase`, `lint_iam_policy`, `magic_numbers`

**`src/ol_concourse/AGENTS.md`**
- Python → JSON → `fly sp` pipeline lifecycle
- Directory layout and factory function table (`git_repo`, `pulumi_jobs_chain`, etc.)
- `Identifier` type requirement (common source of runtime errors)
- How to register a new pipeline in the meta pipeline
- Common mistakes: bare strings, writing raw YAML, missing `trigger=True`

**`src/bilder/AGENTS.md`**
- Packer → PyInfra → AMI build chain explained
- Directory roles and component inventory so agents reach for existing components first
- `deploy.py` idempotency rules
- `packer fmt` as a required step (CI rejects unformatted HCL)
- Steps for adding a new image or component

### How can this be tested?
These are documentation-only files with no runtime effect. Review that the content is accurate against the code in each directory.

### Additional Context
These complement the existing root `AGENTS.md` (which links to `docs/context/` for deep dives) by providing fast local context when an agent's working directory is inside one of these packages.