### PR TITLE
Fix local-dev Keycloak bring-up: SSO login, apps-infra gate, and test-user seeding

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -184,6 +184,20 @@ local_resource(
     resource_deps=["local-infra-core"],
 )
 
+# Seed the local-dev test users (admin / student / prof, password localdev123)
+# into the olapps realm. Pulumi provisions the realm and OIDC clients, but the
+# Keycloak provider does not manage individual users, so they are created by
+# this idempotent script. It runs automatically after the realm is up so a
+# fresh setup has working login credentials — without it, every login fails
+# because no users exist.
+local_resource(
+    "kc-seed-users",
+    cmd="LOCAL_DEV_ROOT_DOMAIN={rd} {script}".format(rd=root_domain, script="{}/local-dev/scripts/kc-seed-users.sh".format(config.main_dir)),
+    deps=["./local-dev/scripts/kc-seed-users.sh"],
+    labels=["infra"],
+    resource_deps=["local-infra-apps"],
+)
+
 # ---------------------------------------------------------------------------
 # Per-app deployment + manual seed resources
 # ---------------------------------------------------------------------------

--- a/Tiltfile
+++ b/Tiltfile
@@ -165,18 +165,21 @@ local_resource(
 # Apps infrastructure stack (databases, Keycloak realm) — depends on core.
 #
 # The Keycloak provider talks to the realm over the public ingress, so we wait
-# for Keycloak to actually serve its discovery endpoint before running
-# `pulumi up`. Without the gate, the provider fires its calls while Keycloak is
-# still warming up and the gateway returns 502s, crash-looping the run.
+# for Keycloak's admin REST API to be ready before running `pulumi up`.
+# Gating on the OIDC discovery endpoint alone is insufficient: discovery comes
+# up well before the admin API can service writes, so the provider's
+# POST /admin/realms races into the warm-up window and times out
+# ("context deadline exceeded"). The script below proves the admin API is
+# serving (admin token + authenticated GET /admin/realms) before we proceed.
 #
 # `pulumi refresh` is intentionally omitted from this loop: it issues a burst
 # of concurrent admin-API calls on every reconcile, which was the main source
 # of the warm-up 502s. Refresh on demand instead.
 local_resource(
     "local-infra-apps",
-    cmd="LOCAL_DEV_ROOT_DOMAIN={rd} PULUMI_CONFIG_PASSPHRASE='' bash -c 'pulumi stack init local-dev.apps-infra.Dev 2>/dev/null; echo \"Waiting for Keycloak discovery endpoint...\"; for i in $(seq 1 60); do curl -sfk https://sso.ol.{rd}/realms/master/.well-known/openid-configuration >/dev/null 2>&1 && break; sleep 5; done; pulumi up --yes --skip-preview --logtostderr --stack local-dev.apps-infra.Dev'".format(rd=root_domain),
+    cmd="LOCAL_DEV_ROOT_DOMAIN={rd} PULUMI_CONFIG_PASSPHRASE='' bash -c '{wait} sso.ol.{rd} && {{ pulumi stack init local-dev.apps-infra.Dev 2>/dev/null; pulumi up --yes --skip-preview --logtostderr --stack local-dev.apps-infra.Dev; }}'".format(rd=root_domain, wait="{}/local-dev/scripts/wait-for-keycloak-admin.sh".format(config.main_dir)),
     dir="./local-dev/infra/apps_infra",
-    deps=["./local-dev/infra/modules", "./local-dev/infra/apps_infra/__main__.py"],
+    deps=["./local-dev/infra/modules", "./local-dev/infra/apps_infra/__main__.py", "./local-dev/scripts/wait-for-keycloak-admin.sh"],
     labels=["infra"],
     resource_deps=["local-infra-core"],
 )

--- a/Tiltfile
+++ b/Tiltfile
@@ -175,9 +175,17 @@ local_resource(
 # `pulumi refresh` is intentionally omitted from this loop: it issues a burst
 # of concurrent admin-API calls on every reconcile, which was the main source
 # of the warm-up 502s. Refresh on demand instead.
+#
+# `--parallel 1` serialises the apply for the same reason. The Keycloak provider
+# talks to the admin API over the public ingress (host -> k3d LB -> APISIX ->
+# Keycloak), and Pulumi otherwise creates independent realm resources
+# concurrently. That burst of simultaneous admin calls overwhelms the ingress
+# path (even while Keycloak itself is idle) and a batch of them trip
+# "context deadline exceeded" together. Serialising keeps one admin request in
+# flight at a time, which the path handles comfortably.
 local_resource(
     "local-infra-apps",
-    cmd="LOCAL_DEV_ROOT_DOMAIN={rd} PULUMI_CONFIG_PASSPHRASE='' bash -c '{wait} sso.ol.{rd} && {{ pulumi stack init local-dev.apps-infra.Dev 2>/dev/null; pulumi up --yes --skip-preview --logtostderr --stack local-dev.apps-infra.Dev; }}'".format(rd=root_domain, wait="{}/local-dev/scripts/wait-for-keycloak-admin.sh".format(config.main_dir)),
+    cmd="LOCAL_DEV_ROOT_DOMAIN={rd} PULUMI_CONFIG_PASSPHRASE='' bash -c '{wait} sso.ol.{rd} && {{ pulumi stack init local-dev.apps-infra.Dev 2>/dev/null; pulumi up --yes --skip-preview --parallel 1 --logtostderr --stack local-dev.apps-infra.Dev; }}'".format(rd=root_domain, wait="{}/local-dev/scripts/wait-for-keycloak-admin.sh".format(config.main_dir)),
     dir="./local-dev/infra/apps_infra",
     deps=["./local-dev/infra/modules", "./local-dev/infra/apps_infra/__main__.py", "./local-dev/scripts/wait-for-keycloak-admin.sh"],
     labels=["infra"],

--- a/local-dev/infra/modules/keycloak.py
+++ b/local-dev/infra/modules/keycloak.py
@@ -6,8 +6,12 @@ Mirrors the production olapps.py structure but:
   - Skips production SAML/OIDC org federation (real MIT Touchstone, B2B orgs)
   - Disables verify_email (Mailpit is available but we want frictionless login)
   - Includes fake-touchstone and okta-test IdPs (same as CI/QA branch)
-  - Adds test users: admin@odl.local, student@odl.local, prof@odl.local
   - Skips all Vault-dependent resources
+
+Test users (admin / student / prof, password localdev123) are NOT created
+here — the Keycloak provider does not manage individual users. They are
+seeded by local-dev/scripts/kc-seed-users.sh, which the root Tiltfile runs
+automatically (the "kc-seed-users" resource) after this realm is applied.
 """
 
 import json

--- a/local-dev/infra/modules/keycloak.py
+++ b/local-dev/infra/modules/keycloak.py
@@ -598,3 +598,35 @@ def create_olapps_dev_realm(  # noqa: PLR0913
             extra_config={"syncMode": "INHERIT"},
             opts=kc_opts,
         )
+
+    # -------------------------------------------------------------------------
+    # Organization seeding for local dev
+    #
+    # The realm's browser flow is the organization-aware "Organization
+    # Identity-First Login" flow (mirrors production). That authenticator only
+    # renders the email-first login screen when the realm has at least one
+    # organization; with zero organizations it falls through to the self-service
+    # registration form, sending every login attempt to "Register" instead of
+    # "Sign in". Production has real organizations so it works there; local dev
+    # had none, which is why login landed on registration.
+    #
+    # Seed one placeholder organization so identity-first login renders
+    # correctly. It owns a fake, non-routable domain (org.local): all outbound
+    # mail is captured by Mailpit regardless, but a fake domain keeps real
+    # addresses out of the picture. The org is intentionally NOT wired to the
+    # fake-touchstone IdP (that IdP is a local stub), so members fall through to
+    # the username/password screen like the seeded @odl.local test users.
+    # -------------------------------------------------------------------------
+    keycloak.organization.Organization(
+        "olapps-local-dev-org",
+        realm=realm.realm,
+        name="Local Dev",
+        alias="local-dev",
+        enabled=True,
+        domains=[
+            keycloak.organization.OrganizationDomainArgs(
+                name="org.local", verified=True
+            ),
+        ],
+        opts=kc_opts,
+    )

--- a/local-dev/infra/modules/keycloak.py
+++ b/local-dev/infra/modules/keycloak.py
@@ -315,10 +315,13 @@ def create_olapps_dev_realm(  # noqa: PLR0913
         "acr",
         "email",
         "profile",
-        "role_list",
         "roles",
         "web-origins",
         "ol-profile",
+        # "role_list" is intentionally omitted: it is a SAML-protocol client
+        # scope, and keycloak.openid.ClientDefaultScopes only accepts
+        # openid-connect scopes — including it fails with
+        # "validation error: scope role_list does not exist".
         # KC 26 auto-attaches "organization" as an optional scope when
         # organizations_enabled=True — adding it as default causes 409 Conflict.
     ]

--- a/local-dev/scripts/kc-seed-users.sh
+++ b/local-dev/scripts/kc-seed-users.sh
@@ -2,12 +2,13 @@
 # kc-seed-users.sh — Idempotent local-dev test-user provisioning
 #
 # Creates three test users in the Keycloak olapps realm.  If a user already
-# exists (by username) it is skipped — safe to run multiple times.
+# exists (looked up by email) it is skipped — safe to run multiple times.
 #
-# Users created:
-#   admin   / localdev123  — realm admin role
-#   student / localdev123
-#   prof    / localdev123
+# Users created (the realm has registrationEmailAsUsername=true, so log in with
+# the email address as the username):
+#   admin@odl.local   / localdev123  — realm admin role
+#   student@odl.local / localdev123
+#   prof@odl.local    / localdev123
 #
 # Usage:
 #   ./local-dev/scripts/kc-seed-users.sh
@@ -87,10 +88,14 @@ for USERNAME in admin student prof; do
     FIRST="${USER_FIRST[$USERNAME]}"
     LAST="${USER_LAST[$USERNAME]}"
 
-    # Check if user already exists.
+    # Check if user already exists. Look up by email, not username: the realm
+    # has registrationEmailAsUsername=true, so Keycloak stores the username as
+    # the email address (e.g. "admin@odl.local", not "admin"). A username=
+    # lookup would always miss and the script would try to re-create existing
+    # users on every run, breaking idempotency.
     EXISTING_ID=$(curl -sf --max-time 10 \
         -H "Authorization: Bearer ${TOKEN}" \
-        "${KC_URL}/admin/realms/${REALM}/users?username=${USERNAME}&exact=true" 2>/dev/null \
+        "${KC_URL}/admin/realms/${REALM}/users?email=${EMAIL}&exact=true" 2>/dev/null \
         | jq -r '.[0].id // empty' 2>/dev/null || true)
 
     if [ -n "${EXISTING_ID}" ]; then
@@ -105,7 +110,7 @@ for USERNAME in admin student prof; do
         -H "Content-Type: application/json" \
         "${KC_URL}/admin/realms/${REALM}/users" \
         -d "{
-            \"username\": \"${USERNAME}\",
+            \"username\": \"${EMAIL}\",
             \"email\": \"${EMAIL}\",
             \"firstName\": \"${FIRST}\",
             \"lastName\": \"${LAST}\",
@@ -119,10 +124,10 @@ for USERNAME in admin student prof; do
         }" \
         -o /dev/null
 
-    # Re-fetch the new user ID for role assignment.
+    # Re-fetch the new user ID for role assignment (by email; see note above).
     NEW_ID=$(curl -sf --max-time 10 \
         -H "Authorization: Bearer ${TOKEN}" \
-        "${KC_URL}/admin/realms/${REALM}/users?username=${USERNAME}&exact=true" 2>/dev/null \
+        "${KC_URL}/admin/realms/${REALM}/users?email=${EMAIL}&exact=true" 2>/dev/null \
         | jq -r '.[0].id // empty' 2>/dev/null || true)
 
     # Assign the admin realm role if applicable.

--- a/local-dev/scripts/wait-for-keycloak-admin.sh
+++ b/local-dev/scripts/wait-for-keycloak-admin.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# wait-for-keycloak-admin.sh — Block until Keycloak's admin REST API is ready.
+#
+# Why this exists:
+#   Keycloak serves its OIDC *discovery* endpoint
+#   (/realms/master/.well-known/openid-configuration) noticeably earlier than
+#   its *admin* REST API can reliably service write operations such as realm
+#   and client creation. Gating `pulumi up` on discovery alone races the
+#   pulumi-keycloak provider into the warm-up window, where POST /admin/realms
+#   times out ("context deadline exceeded"). A timed-out realm-create still
+#   succeeds server-side but is never recorded in Pulumi state, leaving the
+#   stack wedged on 409 "Realm already exists" on every retry.
+#
+#   This gate instead proves the admin API is actually serving: it obtains an
+#   admin token AND performs an authenticated admin read (GET /admin/realms)
+#   before returning success.
+#
+# Usage:
+#   wait-for-keycloak-admin.sh <keycloak-host> [attempts] [sleep-seconds]
+#
+# Examples:
+#   wait-for-keycloak-admin.sh sso.ol.mit.dev          # 60 attempts, 5s apart
+#   KEYCLOAK_ADMIN_PASSWORD=wrong \
+#     wait-for-keycloak-admin.sh sso.ol.mit.dev 2 1    # negative-path test
+#
+# Admin credentials default to the local-dev admin/admin used by the
+# pulumi-keycloak provider; override via KEYCLOAK_ADMIN_USER / _PASSWORD.
+set -euo pipefail
+
+HOST="${1:?usage: wait-for-keycloak-admin.sh <keycloak-host> [attempts] [sleep]}"
+ATTEMPTS="${2:-60}"
+SLEEP="${3:-5}"
+ADMIN_USER="${KEYCLOAK_ADMIN_USER:-admin}"
+ADMIN_PASS="${KEYCLOAK_ADMIN_PASSWORD:-admin}"
+
+token_url="https://${HOST}/realms/master/protocol/openid-connect/token"
+admin_url="https://${HOST}/admin/realms"
+
+SECONDS=0  # bash elapsed-time counter; tracks real wall-clock, curl time included
+echo "Waiting for Keycloak admin API at ${HOST} (up to $((ATTEMPTS * SLEEP))s)..."
+for _ in $(seq 1 "${ATTEMPTS}"); do
+    token=$(curl -sfk --max-time 10 \
+        --data "client_id=admin-cli&grant_type=password&username=${ADMIN_USER}&password=${ADMIN_PASS}" \
+        "${token_url}" 2>/dev/null \
+        | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p') || true
+
+    if [ -n "${token}" ] \
+        && curl -sfk --max-time 10 -o /dev/null -H "Authorization: Bearer ${token}" "${admin_url}"; then
+        echo "Keycloak admin API ready after ${SECONDS}s."
+        exit 0
+    fi
+    sleep "${SLEEP}"
+done
+
+echo "ERROR: Keycloak admin API not ready after ${SECONDS}s." >&2
+exit 1


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Fixes four issues that stopped the `local-dev` stack from coming up and logging in end-to-end (all on the shared Keycloak/APISIX SSO path). Local-dev only — no production code paths change.

1. **Drop SAML `role_list` from OIDC default scopes.** `keycloak.openid.ClientDefaultScopes` only accepts openid-connect scopes, so on Keycloak 26 / provider 6.12 every OIDC client failed with `validation error: scope role_list does not exist`, wedging the apps-infra stack.
    - NOTE: Was fixed in prod config by https://github.com/mitodl/ol-infrastructure/commit/ef7291e96e16ee12c3f9839ded08e3bdbdc44568
    - Can we / should we consider syncing prod and local configs more somehow? 
2. **Gate apps-infra on the Keycloak admin API, not just discovery.** Discovery comes up before the admin API can service writes, so realm creation raced into a `context deadline exceeded` timeout (leaving the realm created-but-not-in-state → 409 on retry). Now gated via a small standalone `wait-for-keycloak-admin.sh`.
3. **Seed an organization so login renders.** The realm's org-aware identity-first browser flow only shows the login screen when ≥1 organization exists; with zero it fell through to the registration form. Seeds one placeholder org on a fake `org.local` domain.
    - This seems to be a bug in https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/substructure/keycloak/org_flows.py#L87-L95; Claude noted for  me that [keycloak default theme adds org step conditionally](https://github.com/keycloak/keycloak/blob/8a67e82f8c85b35bbe69dbc9f3cd28aa26c00ebb/server-spi-private/src/main/java/org/keycloak/models/utils/DefaultAuthenticationFlows.java#L858-L867) gated on user configured. Might be something worth fixing in the flow.
4. **Auto-seed test users + fix idempotency.** `admin`/`student`/`prof` were never created automatically (docstring/README claimed otherwise). Wired `kc-seed-users.sh` into the Tiltfile as an auto-run resource and fixed idempotency: it looked users up by short username, but the realm stores email-as-username. So seeding now both looks up and creates by email.
5. **Serialize the apps-infra apply (`pulumi up --parallel 1`).** Pulumi otherwise creates the realm's ~60 Keycloak resources concurrently; that burst of admin-API calls over the ingress trips `context deadline exceeded` even while Keycloak sits idle, failing the bring-up intermittently. Serializing keeps one admin call in flight (same reason `pulumi refresh` was already dropped from the loop). Adds ~1 min to a one-time bring-up.

### How can this be tested?
1. Run `./local-dev/scripts/setup.sh` (or `./local-dev/scripts/start.sh` if the cluster already exists).
2. With `enabled_apps` including `mit-learn`, run `tilt up`.
3. Confirm `local-infra-core`, `local-infra-apps`, and `kc-seed-users` all go green on the first run with no manual retries.
4. Open https://learn.mit.dev/ → Login → enter `student@odl.local` / `localdev123`. You should get the **login** screen (not registration) and land back in the app authenticated.
