### PR TITLE
fix(edxapp): remove dead legacy instructor MFE config across stacks

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.CI.yaml
@@ -61,7 +61,6 @@ config:
     communications: communications
     discussions: discuss
     gradebook: gradebook
-    instructor: instructor
     learner_dashboard: dashboard
     learning: learn
     ora_grading: ora-grading

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx.CI.yaml
@@ -72,7 +72,6 @@ config:
     communications: communications
     discussions: discuss
     gradebook: gradebook
-    instructor: instructor
     learner_dashboard: dashboard
     learning: learn
     ora_grading: ora-grading

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.CI.yaml
@@ -82,7 +82,6 @@ config:
     authoring: authoring
     discussions: discuss
     gradebook: gradebook
-    instructor: instructor
     learning: learn
     ora_grading: ora-grading
   edxapp:github_org_api_url: https://github.mit.edu/api/v3/orgs/mitxonline-rc

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
@@ -80,7 +80,6 @@ config:
     authoring: authoring
     discussions: discuss
     gradebook: gradebook
-    instructor: instructor
     learning: learn
     ora_grading: ora-grading
   edxapp:github_org_api_url: https://github.mit.edu/api/v3/orgs/mitxonline

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.QA.yaml
@@ -84,7 +84,6 @@ config:
     authoring: authoring
     discussions: discuss
     gradebook: gradebook
-    instructor: instructor
     learning: learn
     ora_grading: ora-grading
   edxapp:github_org_api_url: https://github.mit.edu/api/v3/orgs/mitxonline-rc

--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -174,8 +174,7 @@ def _build_interpolated_config_dict(
         "COURSE_AUTHORING_MICROFRONTEND_URL": f"https://{domains['studio']}/authoring",
         "INSTRUCTOR_MICROFRONTEND_URL": (
             f"https://{domains['lms']}/apps/instructor-dashboard"
-            if "instructor" in enabled_mfes
-            or "instructor-dashboard" in site_project_mfe_apps
+            if "instructor-dashboard" in site_project_mfe_apps
             else None
         ),
         "LEARNING_MICROFRONTEND_URL": f"https://{domains['lms']}/learn",

--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -53,6 +53,10 @@ def _build_interpolated_config_dict(
     """
     domains = edxapp_config.require_object("domains")
     enabled_mfes: dict[str, str] = edxapp_config.get_object("enabled_mfes") or {}
+    site_project_config = edxapp_config.get_object("site_project")
+    site_project_mfe_apps: list[str] = (
+        list(site_project_config.get("mfe_apps", [])) if site_project_config else []
+    )
 
     # Determine marketing domain based on deployment type
     marketing_domain = (
@@ -171,6 +175,7 @@ def _build_interpolated_config_dict(
         "INSTRUCTOR_MICROFRONTEND_URL": (
             f"https://{domains['lms']}/apps/instructor-dashboard"
             if "instructor" in enabled_mfes
+            or "instructor-dashboard" in site_project_mfe_apps
             else None
         ),
         "LEARNING_MICROFRONTEND_URL": f"https://{domains['lms']}/learn",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Removes the dead `instructor: instructor` entry from `enabled_mfes` across every stack that had it (`mitxonline.QA`, `mitx.CI`, `mitxonline.CI`, `mitx-staging.CI`, `mitxonline.Production`), and simplifies `INSTRUCTOR_MICROFRONTEND_URL` in `k8s_configmaps.py` to only check `site_project.mfe_apps`.

The instructor dashboard now only ever functions via the frontend-base OEP-65 Site Project. The Fastly VCL routing rule built from `edxapp:site_project.mfe_apps` (see `src/ol_infrastructure/applications/edxapp/__main__.py`) routes `/apps/instructor-dashboard/*` to the Site Project bundle unconditionally - it never checks the legacy `enabled_mfes` flag. So on every stack where `instructor-dashboard` is present in `site_project.mfe_apps` (confirmed for all five stacks above), the legacy `instructor` entry in `enabled_mfes` was dead: it only caused the legacy per-MFE Concourse pipeline to keep building and deploying a bundle that nothing ever serves.

`INSTRUCTOR_MICROFRONTEND_URL` in `k8s_configmaps.py` previously fell back to checking `"instructor" in enabled_mfes` in addition to `site_project.mfe_apps`. Since that legacy path never functions, the check now only looks at `site_project.mfe_apps`.

This was flagged while debugging an RC/QA crash in the instructor dashboard MFE (a React Router `useMatches`-outside-`RouterProvider` invariant, seen right after a `Redefining LocalForage driver` console warning - a symptom of the site bundle's `initialize()` running more than once on the page). The dual legacy+site-project config for `instructor` looked like a plausible contributing factor, so cleaning it up here regardless of whether it's the direct trigger.

### Screenshots (if appropriate):
N/A - infra config change only

### How can this be tested?
- `uv run pre-commit run` on the changed files passes (ruff, mypy, yamllint) - covers both the Python logic change and the five YAML stack configs.
- After merge, run `pulumi preview` against each affected stack (`mitxonline.QA`, `mitx.CI`, `mitxonline.CI`, `mitx-staging.CI`, `mitxonline.Production`) to confirm the only diff is the `enabled_mfes` config map entry disappearing, with `INSTRUCTOR_MICROFRONTEND_URL` remaining populated (pointing at `/apps/instructor-dashboard`).
- Once deployed, confirm the legacy instructor Concourse job no longer runs for these stacks, and the instructor dashboard link/tab in each stack's LMS nav still works and points at the Site Project bundle.

### Additional Context
Scoped to the five stacks that had the legacy `instructor` entry alongside an active `site_project.mfe_apps: [instructor-dashboard]` entry. `mitx.Production`, `mitx-staging.Production`, `mitx.QA`, `mitx-staging.QA`, and the `xpro` stacks either never had the legacy entry or don't yet have `instructor-dashboard` in `site_project.mfe_apps` (xpro uses the unmodified upstream instructor dashboard without the MIT OL overrides), so they're untouched.

The `mitxonline.QA` `enabled_mfes` fix was originally introduced in commit `54489d51f` ("Re-enable instructor dashboard MFE for MITx Online QA"), which re-enabled a flag that had been intentionally disabled in `a1e0cc05f` to test the Site Project in isolation - likely without realizing the Fastly routing already made it moot.