### PR TITLE
fix(mit-learn): grant Vault read on secret-global/grafana for KEDA autoscaler

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/mitlearn_policy.hcl
+++ b/src/ol_infrastructure/applications/mit_learn/mitlearn_policy.hcl
@@ -43,6 +43,9 @@ path "secret-global/data/mailgun" {
 path "secret-global/data/shared_hmac" {
   capabilities = ["read"]
 }
+path "secret-global/data/grafana" {
+  capabilities = ["read"]
+}
 
 path "secret-mitlearn/*" {
   capabilities = ["read"]


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up to #4858

### Description (What does it do?)
#4858 added a KEDA autoscaler for the mit-learn webapp that reads Grafana Cloud Prometheus credentials from Vault at `secret-global/grafana`, but the matching read grant was never added to `mitlearn_policy.hcl`.

As a result, in production:
- Vault returns **403** on `secret-global/data/grafana`
- the `VaultStaticSecret` never syncs, so the auth secret doesn't exist
- the KEDA `TriggerAuthentication` has no username → `ScaledObjectCheckFailed`
- **no HPA is created**, so `mitlearn-app` is pinned at min replicas with no autoscaling

This adds the one missing grant. edxapp's policies already have the identical line (same path, same credential keys), so this is a copy-paste omission, not a new access requirement.

### How can this be tested?
After `pulumi up` on the mit-learn stack:
```
kubectl -n mitlearn get vaultstaticsecret production-mitlearn-webapp-prometheus-auth   # SYNCED=True
kubectl -n mitlearn get scaledobject mitlearn-webapp-scaledobject                       # READY=True
```