### PR TITLE
fix(concourse): close worker IAM/identity gaps causing Pulumi AccessDenied

### DIFF
--- a/src/bilder/components/concourse/templates/concourse.service.j2
+++ b/src/bilder/components/concourse/templates/concourse.service.j2
@@ -3,6 +3,10 @@ Description=Concourse service for managing continuous deployment pipelines
 After=network.target vault.service
 Wants=vault.service
 Documentation=https://concourse-ci.org/
+{% if concourse_config._node_type == "worker" %}
+Requires=concourse-worker-preflight.service
+After=concourse-worker-preflight.service
+{% endif %}
 
 [Service]
 User={{ concourse_config.user }}
@@ -18,6 +22,7 @@ ExecReload=/bin/kill -HUP $MAINPID
 {% if concourse_config._node_type == "worker" %}
 EnvironmentFile=-/etc/default/concourse-team
 EnvironmentFile=-/etc/default/concourse-tags
+EnvironmentFile=-/etc/default/concourse-name
 Delegate=true  {# Allow the Concourse worker to manage its own cgroups for container execution #}
 KillSignal=SIGUSR2
 KillMode=process

--- a/src/bilder/images/concourse/deploy.py
+++ b/src/bilder/images/concourse/deploy.py
@@ -458,6 +458,7 @@ if host.get_fact(HasSystemd):
             ("concourse-worker-drain", "755"),
             ("concourse-worker-spot-watch", "755"),
             ("concourse-worker-lifecycle-hook", "755"),
+            ("concourse-worker-preflight", "755"),
         ]
         for script_name, script_mode in worker_scripts:
             files.put(
@@ -468,9 +469,15 @@ if host.get_fact(HasSystemd):
                 group="root",
                 mode=script_mode,
             )
+        # concourse-worker-preflight.service is uploaded here (so its unit file
+        # is present and daemon-reload picks it up) but intentionally not
+        # enabled/started below -- it's pulled in as a hard dependency of
+        # concourse.service itself via Requires=/After= (see
+        # concourse.service.j2), not run as an independent long-lived unit.
         worker_service_files = [
             "concourse-worker-spot-watch.service",
             "concourse-worker-lifecycle-hook.service",
+            "concourse-worker-preflight.service",
         ]
         worker_services_changed = False
         for service_file in worker_service_files:

--- a/src/bilder/images/concourse/files/concourse-worker-preflight
+++ b/src/bilder/images/concourse/files/concourse-worker-preflight
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Validate that this worker can actually reach the external services builds
+# depend on -- IMDS, GitHub, Docker Hub, and the Pulumi state bucket -- before
+# concourse.service starts and the worker registers with the TSA. A worker
+# that boots but has a broken NIC or a stale/poisoned DNS cache would
+# otherwise join the pool and fail every build routed to it (instead of being
+# replaced) since Concourse has no way to know a "running" worker is actually
+# unreachable from the outside. This is wired as a hard dependency of
+# concourse.service via [Unit] Requires=/After= (worker units only).
+set -uo pipefail
+
+RETRY_BUDGET_SECONDS=${RETRY_BUDGET_SECONDS:-180}
+RETRY_INTERVAL_SECONDS=${RETRY_INTERVAL_SECONDS:-10}
+METADATA_BASE="http://169.254.169.254/latest/meta-data"
+TOKEN_URL="http://169.254.169.254/latest/api/token"
+CHECK_ENDPOINTS=(
+    "github.com:443"
+    "registry-1.docker.io:443"
+    "auth.docker.io:443"
+    "mitol-pulumi-state.s3.amazonaws.com:443"
+)
+
+log() {
+    echo "[concourse-worker-preflight] $*" | systemd-cat -t concourse-worker-preflight -p info
+}
+
+get_imds_token() {
+    curl -s -X PUT "${TOKEN_URL}" \
+        -H "X-aws-ec2-metadata-token-ttl-seconds: 60" \
+        --connect-timeout 2 --max-time 5 2>/dev/null
+}
+
+imds_get() {
+    local path="$1"
+    local token="$2"
+    curl -s -H "X-aws-ec2-metadata-token: ${token}" \
+        --connect-timeout 2 --max-time 5 \
+        "${METADATA_BASE}/${path}" 2>/dev/null
+}
+
+check_tcp() {
+    local host="$1"
+    local port="$2"
+    timeout 5 bash -c "exec 3<>/dev/tcp/${host}/${port}" 2>/dev/null
+}
+
+run_checks() {
+    local token
+    token=$(get_imds_token)
+    if [ -z "${token}" ]; then
+        log "IMDS token fetch failed"
+        return 1
+    fi
+
+    local ok=0
+    for endpoint in "${CHECK_ENDPOINTS[@]}"; do
+        if ! check_tcp "${endpoint%%:*}" "${endpoint##*:}"; then
+            log "TCP connect failed: ${endpoint}"
+            ok=1
+        fi
+    done
+    return "${ok}"
+}
+
+deadline=$(($(date +%s) + RETRY_BUDGET_SECONDS))
+while true; do
+    if run_checks; then
+        log "All network preflight checks passed"
+        exit 0
+    fi
+    if [ "$(date +%s)" -ge "${deadline}" ]; then
+        break
+    fi
+    log "Preflight checks failed; retrying in ${RETRY_INTERVAL_SECONDS}s"
+    sleep "${RETRY_INTERVAL_SECONDS}"
+done
+
+log "Preflight checks did not pass within ${RETRY_BUDGET_SECONDS}s"
+
+TOKEN=$(get_imds_token)
+INSTANCE_ID=$(imds_get "instance-id" "${TOKEN}")
+REGION=$(imds_get "placement/region" "${TOKEN}")
+
+if [ -n "${INSTANCE_ID}" ] && [ -n "${REGION}" ] && \
+   aws autoscaling set-instance-health \
+        --instance-id "${INSTANCE_ID}" \
+        --health-status Unhealthy \
+        --region "${REGION}" 2>/dev/null; then
+    log "Marked instance Unhealthy; ASG will replace it before this worker joins the pool"
+else
+    log "set-instance-health unavailable; failing preflight anyway so concourse.service does not start"
+fi
+
+exit 1

--- a/src/bilder/images/concourse/files/concourse-worker-preflight.service
+++ b/src/bilder/images/concourse/files/concourse-worker-preflight.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Validate network reachability before the Concourse worker registers with the TSA
+Before=concourse.service
+# Needs its own network path up, but must not block on the (later) worker
+# identity/registration -- only on the box being able to reach the internet.
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=no
+ExecStart=/usr/local/bin/concourse-worker-preflight
+# Bounded by the script's own internal retry budget; leave headroom above it.
+TimeoutStartSec=240

--- a/src/ol_infrastructure/applications/concourse/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/applications/concourse/Pulumi.CI.yaml
@@ -35,6 +35,7 @@ config:
     iam_policies:
     - base
     - ocw
+    - pulumi_state
     instance_type: t3a.medium
     name: ocw
   - auto_scale:
@@ -51,6 +52,7 @@ config:
     - operations
     - cloud_custodian
     - infra
+    - pulumi_state
     instance_type: t3a.medium
     name: infra
   - auto_scale:
@@ -65,6 +67,7 @@ config:
     iam_policies:
     - base
     - operations
+    - pulumi_state
     instance_type: t3a.medium
     name: generic
   consul:address: https://consul-operations-ci.odl.mit.edu

--- a/src/ol_infrastructure/applications/concourse/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/concourse/Pulumi.Production.yaml
@@ -36,6 +36,7 @@ config:
     iam_policies:
     - base
     - ocw
+    - pulumi_state
     instance_type: m7a.2xlarge
     name: ocw
     use_spot_instances: true
@@ -55,6 +56,7 @@ config:
     - infra
     - operations
     - cloud_custodian
+    - pulumi_state
     instance_type: m7a.4xlarge
     name: infra
     use_spot_instances: true
@@ -70,6 +72,7 @@ config:
     - base
     - ecr_push
     - operations
+    - pulumi_state
     instance_type: m7a.xlarge
     name: generic
     use_spot_instances: true

--- a/src/ol_infrastructure/applications/concourse/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/concourse/Pulumi.QA.yaml
@@ -36,6 +36,7 @@ config:
     iam_policies:
     - base
     - ocw
+    - pulumi_state
     instance_type: general_purpose_xlarge
     name: ocw
   - auto_scale:
@@ -52,6 +53,7 @@ config:
     - operations
     - cloud_custodian
     - infra
+    - pulumi_state
     instance_type: burstable_medium
     name: infra
   - auto_scale:
@@ -65,6 +67,7 @@ config:
     iam_policies:
     - base
     - operations
+    - pulumi_state
     instance_type: burstable_medium
     name: generic
   consul:address: https://consul-operations-qa.odl.mit.edu

--- a/src/ol_infrastructure/applications/concourse/__main__.py
+++ b/src/ol_infrastructure/applications/concourse/__main__.py
@@ -13,6 +13,7 @@ import textwrap
 from functools import partial
 from pathlib import Path
 from string import Template
+from typing import Any
 
 import pulumi_vault as vault
 import yaml
@@ -117,7 +118,7 @@ grafana_credentials = read_yaml_secrets(
 def build_worker_user_data(
     concourse_team: str, concourse_tags: list[str], consul_dc: str
 ) -> str:
-    yaml_contents = {
+    yaml_contents: dict[str, Any] = {
         "write_files": [
             {
                 "path": "/etc/consul.d/02-autojoin.json",
@@ -170,6 +171,21 @@ def build_worker_user_data(
                 "owner": "root:root",
             }
         )
+    # Worker identity defaults to the EC2-hostname-derived name (ip-A-B-C-D),
+    # and private IPs get recycled across ASG replacements in these subnets,
+    # so a fresh instance can inherit a prior (now-deleted) worker's identity
+    # before the stalled-worker reaper catches up, producing FK-constraint GC
+    # errors against the old worker's orphaned volume/container rows. Pin the
+    # name to the instance ID instead, which is never reused.
+    yaml_contents["runcmd"] = [
+        (
+            "TOKEN=$(curl -s -X PUT http://169.254.169.254/latest/api/token "
+            "-H 'X-aws-ec2-metadata-token-ttl-seconds: 60'); "
+            'INSTANCE_ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" '
+            "http://169.254.169.254/latest/meta-data/instance-id); "
+            'echo "CONCOURSE_NAME=${INSTANCE_ID}" > /etc/default/concourse-name'
+        )
+    ]
     return base64.b64encode(
         "#cloud-config\n{}".format(
             yaml.dump(

--- a/src/ol_infrastructure/applications/concourse/__main__.py
+++ b/src/ol_infrastructure/applications/concourse/__main__.py
@@ -180,10 +180,14 @@ def build_worker_user_data(
     yaml_contents["runcmd"] = [
         (
             "TOKEN=$(curl -s -X PUT http://169.254.169.254/latest/api/token "
-            "-H 'X-aws-ec2-metadata-token-ttl-seconds: 60'); "
+            "-H 'X-aws-ec2-metadata-token-ttl-seconds: 60' "
+            "--connect-timeout 2 --max-time 5); "
             'INSTANCE_ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" '
+            "--connect-timeout 2 --max-time 5 "
             "http://169.254.169.254/latest/meta-data/instance-id); "
-            'echo "CONCOURSE_NAME=${INSTANCE_ID}" > /etc/default/concourse-name'
+            'if [ -n "$INSTANCE_ID" ]; then '
+            'echo "CONCOURSE_NAME=${INSTANCE_ID}" > /etc/default/concourse-name; '
+            "fi"
         )
     ]
     return base64.b64encode(

--- a/src/ol_infrastructure/applications/concourse/iam_policies/pulumi_state.py
+++ b/src/ol_infrastructure/applications/concourse/iam_policies/pulumi_state.py
@@ -1,0 +1,25 @@
+from ol_infrastructure.lib.aws.iam_helper import IAM_POLICY_VERSION
+
+# AWS Permissions Document
+# Grants access to the shared Pulumi state backend bucket. Any worker pool that
+# can run a pulumi_job() step needs this, since Concourse's built-in scheduler
+# can place a team's build on an untagged/global worker pool (e.g. "generic")
+# whenever that team's own workers are saturated.
+policy_definition = {
+    "Version": IAM_POLICY_VERSION,
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject*",
+                "s3:PutObject",
+                "s3:DeleteObject",
+                "s3:ListBucket*",
+            ],
+            "Resource": [
+                "arn:aws:s3:::mitol-pulumi-state",
+                "arn:aws:s3:::mitol-pulumi-state/*",
+            ],
+        },
+    ],
+}

--- a/src/ol_infrastructure/applications/concourse/iam_policies/pulumi_state.py
+++ b/src/ol_infrastructure/applications/concourse/iam_policies/pulumi_state.py
@@ -11,6 +11,7 @@ policy_definition = {
         {
             "Effect": "Allow",
             "Action": [
+                "s3:GetBucketLocation",
                 "s3:GetObject*",
                 "s3:PutObject",
                 "s3:DeleteObject",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Diagnosed intermittent `AccessDenied` errors on Concourse worker instances (e.g. `s3:GetObject` on `mitol-pulumi-state`) that looked like flaky/degraded-instance network problems but turned out to be a routing + IAM permissions gap, plus a separate worker-identity churn issue. Fixes three things:

1. **Missing IAM permissions on `generic`/`ocw` worker pools.** All Pulumi jobs source their AWS credentials from the worker's own EC2 instance profile (via `generate_aws_config_from_instance_profile.sh` + `AWS_SHARED_CREDENTIALS_FILE`), not from Vault. Verified with `aws iam simulate-principal-policy` that the `generic` and `ocw` worker roles had **no** grant to `mitol-pulumi-state` at all (`implicitDeny`), while the `infra` role happened to work only because it has `AdministratorAccess` attached directly (see caveat below). The `generic` worker pool has no `concourse_team` set, making it a global/untagged worker pool that Concourse's scheduler can use as overflow capacity for *any* team's builds — including the `infrastructure` team's Pulumi jobs — whenever the dedicated `infra` pool is saturated. Landing a Pulumi job there produced this exact `AccessDenied`, unrelated to instance health.

   Adds a new least-privilege `iam_policies/pulumi_state.py` module (scoped `s3:GetObject*`/`PutObject`/`DeleteObject`/`ListBucket*` on `mitol-pulumi-state` and `mitol-pulumi-state/*`) and wires it into the `ocw`, `infra`, and `generic` worker pools across Production, QA, and CI.

2. **No pre-registration network health check.** A worker with a broken NIC or poisoned DNS cache could previously boot, pass EC2 status checks, and still register with the TSA and take builds it can't complete (failing to reach GitHub, Docker Hub, IMDS, etc.). Adds a `concourse-worker-preflight` oneshot systemd unit, wired as a hard `Requires=`/`After=` dependency of `concourse.service` on worker nodes only. It retries IMDS/GitHub/Docker Hub/S3 reachability checks for a bounded window; on persistent failure it calls `aws autoscaling set-instance-health --health-status Unhealthy` (same self-remediation pattern already used by `concourse-worker-spot-watch`) so the ASG replaces the instance *before* it ever joins the worker pool, instead of after it fails builds.

3. **Worker identity collisions from recycled private IPs.** Worker identity defaults to the EC2-hostname-derived name (`ip-A-B-C-D`), and these subnets reuse private IPs across ASG replacements. Confirmed via Grafana/Loki logs showing `atc.report-volumes-for-worker.failed-to-destroy-unknown-volumes` / `failed-to-destroy-unknown-containers` FK-constraint errors where a freshly-launched instance inherited a stale, already-deleted worker's name before the existing stalled-worker reaper caught up. Pins `CONCOURSE_NAME` to the EC2 instance ID (fetched from IMDS via cloud-init `runcmd`, written to `/etc/default/concourse-name`, loaded via a new `EnvironmentFile=-` line) so worker identity is never reused.

**Not included in this PR (flagged, not remediated):** while investigating, found that `concourse-instance-role-worker-infra-production` has AWS-managed `AdministratorAccess` + `SystemAdministrator` policies attached **directly** to the role, undeclared in any IaC in this repo (a separate, documented `eks-cluster-creator-role` assume-role path already exists for EKS cluster creation and is not the concern here). CloudTrail's 90-day `lookup-events` window doesn't cover when this was attached. This is a standing security exposure — any build on the `infra` pool currently has full account admin — and needs its own follow-up PR/discussion before touching it, since it's a live change on a role used by running production builds.

### Screenshots (if appropriate):
N/A — no UI changes.

### How can this be tested?
- `pulumi preview` against the `Production` and `QA` `ol-application-concourse` stacks shows exactly the expected diff: 1 new `iam:Policy` + 3 new `iam:RolePolicyAttachment` resources (one per worker pool), plus a `userData` update on each of the 3 worker launch templates (adds the `CONCOURSE_NAME` `runcmd`, no other change). No forced instance replacement — only affects newly-launched instances via the launch template's new version.
- Confirmed the underlying gap independently via `aws iam simulate-principal-policy --policy-source-arn <generic-worker-role-arn> --action-names s3:GetObject --resource-arns arn:aws:s3:::mitol-pulumi-state/.pulumi/meta.yaml` returning `implicitDeny` before this change (should return `allowed` after `pulumi up`).
- `pre-commit run` (ruff, mypy, yamllint, etc.) passes on all changed files.
- After merge + `pulumi up` + next AMI bake (Packer) that picks up the `bilder` changes: verify a newly-launched worker of each class registers with `CONCOURSE_NAME` equal to its instance ID (`fly workers` should show instance IDs instead of `ip-A-B-C-D` names for new workers), and that `journalctl -u concourse-worker-preflight` shows the preflight checks running before `concourse.service` starts.

### Additional Context
This PR only ships the IAM policy + bilder/cloud-init source changes. The IAM policy changes take effect on the next `pulumi up` for the `concourse` stack (Production/QA/CI). The preflight-gate and `CONCOURSE_NAME` changes are baked into the worker AMI and only take effect on the next Packer build + AMI rollout to the worker ASGs (existing running workers are unaffected until then).