### PR TITLE
fix(mit-learn): raise webapp memory limit to 3200Mi to stop OOMKills

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1512,6 +1512,10 @@ mitlearn_k8s_app = OLApplicationK8s(
         application_arg_array=["/tmp/uwsgi.ini"],  # noqa: S108
         granian_config=GranianConfig(
             workers=2,
+            # Pin per-worker RSS so it doesn't auto-scale with the memory limit
+            # (floor(limit/workers*0.9)); 2*1080Mi leaves ~1GiB headroom under
+            # the 3200Mi limit for the master process and transient overshoot.
+            workers_max_rss=1080,
             enable_metrics=True,
             interface="asginl",
             backlog=None,

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1557,8 +1557,8 @@ mitlearn_k8s_app = OLApplicationK8s(
             resource_requests={"cpu": "100m", "memory": "2048Mi"},
             resource_limits={"memory": "2048Mi"},
         ),
-        resource_requests={"cpu": "500m", "memory": "2400Mi"},
-        resource_limits={"memory": "2400Mi"},
+        resource_requests={"cpu": "500m", "memory": "3200Mi"},
+        resource_limits={"memory": "3200Mi"},
         webapp_keda_config=webapp_keda_config,
     ),
     opts=ResourceOptions(


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up to #4858 / #4870

### Description (What does it do?)
Stops production OOMKills on the mit-learn webapp (and the resulting cold-restart tail-latency spikes) by giving the container real memory headroom above the granian worker RSS ceiling.

**Root cause:** the webapp memory limit (2400Mi) was sized for **1 granian worker**. Commit `241edbb9f` ("Increase worker count for mit-learn", Jun 30) bumped `workers=1 → 2` without raising memory. Pods hit the limit and are **OOMKilled** (`exitCode 137`), dropping in-flight requests and forcing cold restarts.

**Changes:**
1. **Memory limit/request 2400Mi → 3200Mi.**
2. **Pin `granian_config.workers_max_rss=1080`.** This is necessary because `OLApplicationK8s` otherwise derives the per-worker RSS cap from the memory limit (`floor(limit / workers * 0.9)`). Without pinning, raising the limit to 3200Mi would also raise the cap to 1440Mi/worker → 2×1440 = 2880Mi, leaving only ~320Mi headroom. Pinning at 1080Mi (today's effective value) keeps 2×1080 = 2160Mi under the 3200Mi limit, leaving **~1GiB** for the master process and transient overshoot.

Celery worker/beat resources are unchanged.

**QoS note:** request == limit for memory, but per this repo's convention there is no CPU limit (intentional, to avoid CPU throttling), so the pod is **Burstable** QoS, not Guaranteed.

### How can this be tested?
After `pulumi up` on the mit-learn stack:
```
kubectl -n mitlearn get pods -l ol.mit.edu/component=webapp
# RESTARTS stays 0; no lastState reason=OOMKilled under normal load
kubectl -n mitlearn get deploy mitlearn-app -o jsonpath='{..containers[?(@.name=="mitlearn-app")].args}' | tr ' ' '\n' | grep -A1 workers-max-rss
# confirms --workers-max-rss 1080 (not 1440)
```