### PR TITLE
Point micromasters/ocw-studio/odl-video-service/xpro probes at django-health-check

### DIFF
--- a/src/ol_infrastructure/applications/micromasters/__main__.py
+++ b/src/ol_infrastructure/applications/micromasters/__main__.py
@@ -27,7 +27,6 @@ from pulumi_aws import ec2, iam, route53, s3
 
 from bridge.lib.magic_numbers import (
     DEFAULT_HTTPS_PORT,
-    DEFAULT_NGINX_PORT,
     DEFAULT_POSTGRES_PORT,
     DEFAULT_REDIS_PORT,
     ONE_MEGABYTE_BYTE,
@@ -907,38 +906,6 @@ micromasters_k8s_app = OLApplicationK8s(
             resource_requests={"cpu": "10m", "memory": "384Mi"},
             resource_limits={"memory": "384Mi"},
         ),
-        probe_configs={
-            "liveness_probe": kubernetes.core.v1.ProbeArgs(
-                http_get=kubernetes.core.v1.HTTPGetActionArgs(
-                    path="/nginx-health", port=DEFAULT_NGINX_PORT
-                ),
-                initial_delay_seconds=30,
-                period_seconds=30,
-                failure_threshold=3,
-                timeout_seconds=3,
-            ),
-            "readiness_probe": kubernetes.core.v1.ProbeArgs(
-                http_get=kubernetes.core.v1.HTTPGetActionArgs(
-                    path="/nginx-health",
-                    port=DEFAULT_NGINX_PORT,
-                ),
-                initial_delay_seconds=15,
-                period_seconds=15,
-                failure_threshold=3,
-                timeout_seconds=3,
-            ),
-            "startup_probe": kubernetes.core.v1.ProbeArgs(
-                http_get=kubernetes.core.v1.HTTPGetActionArgs(
-                    path="/nginx-health",
-                    port=DEFAULT_NGINX_PORT,
-                ),
-                initial_delay_seconds=10,
-                period_seconds=10,
-                failure_threshold=6,
-                success_threshold=1,
-                timeout_seconds=5,
-            ),
-        },
     ),
     opts=ResourceOptions(
         depends_on=[micromasters_app_security_group, *k8s_secret_resources]

--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -10,7 +10,6 @@ import json
 from pathlib import Path
 
 import pulumi_github as github
-import pulumi_kubernetes as kubernetes
 import pulumi_vault as vault
 from pulumi import (
     ROOT_STACK_RESOURCE,
@@ -23,7 +22,6 @@ from pulumi import (
 from pulumi_aws import ec2, get_caller_identity, iam
 
 from bridge.lib.magic_numbers import (
-    DEFAULT_NGINX_PORT,
     DEFAULT_POSTGRES_PORT,
     DEFAULT_REDIS_PORT,
 )
@@ -646,40 +644,6 @@ ocw_studio_k8s_app = OLApplicationK8s(
         ),
         resource_requests={"cpu": "100m", "memory": "1Gi"},
         resource_limits={"memory": "3Gi"},
-        # App lacks health check endpoints so we use nginx's
-        probe_configs={
-            "liveness_probe": kubernetes.core.v1.ProbeArgs(
-                http_get=kubernetes.core.v1.HTTPGetActionArgs(
-                    path="/nginx-health",
-                    port=DEFAULT_NGINX_PORT,
-                ),
-                initial_delay_seconds=30,
-                period_seconds=30,
-                failure_threshold=3,
-                timeout_seconds=3,
-            ),
-            "readiness_probe": kubernetes.core.v1.ProbeArgs(
-                http_get=kubernetes.core.v1.HTTPGetActionArgs(
-                    path="/nginx-health",
-                    port=DEFAULT_NGINX_PORT,
-                ),
-                initial_delay_seconds=15,
-                period_seconds=15,
-                failure_threshold=3,
-                timeout_seconds=3,
-            ),
-            "startup_probe": kubernetes.core.v1.ProbeArgs(
-                http_get=kubernetes.core.v1.HTTPGetActionArgs(
-                    path="/nginx-health",
-                    port=DEFAULT_NGINX_PORT,
-                ),
-                initial_delay_seconds=10,
-                period_seconds=10,
-                failure_threshold=6,
-                success_threshold=1,
-                timeout_seconds=5,
-            ),
-        },
     ),
     opts=ResourceOptions(depends_on=[ocw_studio_app_security_group, *secret_resources]),
 )

--- a/src/ol_infrastructure/applications/odl_video_service/__main__.py
+++ b/src/ol_infrastructure/applications/odl_video_service/__main__.py
@@ -10,7 +10,6 @@
 import json
 from pathlib import Path
 
-import pulumi_kubernetes as kubernetes
 import pulumi_vault as vault
 from pulumi import (
     ROOT_STACK_RESOURCE,
@@ -854,39 +853,6 @@ ovs_k8s_app = OLApplicationK8s(
         init_collectstatic=True,
         resource_requests={"cpu": "250m", "memory": "512Mi"},
         resource_limits={"memory": "1Gi"},
-        probe_configs={
-            "liveness_probe": kubernetes.core.v1.ProbeArgs(
-                http_get=kubernetes.core.v1.HTTPGetActionArgs(
-                    path="/nginx-health",
-                    port=DEFAULT_NGINX_PORT,
-                ),
-                initial_delay_seconds=30,
-                period_seconds=30,
-                failure_threshold=3,
-                timeout_seconds=5,
-            ),
-            "readiness_probe": kubernetes.core.v1.ProbeArgs(
-                http_get=kubernetes.core.v1.HTTPGetActionArgs(
-                    path="/nginx-health",
-                    port=DEFAULT_NGINX_PORT,
-                ),
-                initial_delay_seconds=15,
-                period_seconds=15,
-                failure_threshold=3,
-                timeout_seconds=5,
-            ),
-            "startup_probe": kubernetes.core.v1.ProbeArgs(
-                http_get=kubernetes.core.v1.HTTPGetActionArgs(
-                    path="/nginx-health",
-                    port=DEFAULT_NGINX_PORT,
-                ),
-                initial_delay_seconds=10,
-                period_seconds=10,
-                failure_threshold=12,
-                success_threshold=1,
-                timeout_seconds=5,
-            ),
-        },
         celery_worker_configs=[
             OLApplicationK8sCeleryWorkerConfig(
                 application_name="odl_video",

--- a/src/ol_infrastructure/applications/odl_video_service/__main__.py
+++ b/src/ol_infrastructure/applications/odl_video_service/__main__.py
@@ -10,6 +10,7 @@
 import json
 from pathlib import Path
 
+import pulumi_kubernetes as kubernetes
 import pulumi_vault as vault
 from pulumi import (
     ROOT_STACK_RESOURCE,
@@ -853,6 +854,39 @@ ovs_k8s_app = OLApplicationK8s(
         init_collectstatic=True,
         resource_requests={"cpu": "250m", "memory": "512Mi"},
         resource_limits={"memory": "1Gi"},
+        probe_configs={
+            "liveness_probe": kubernetes.core.v1.ProbeArgs(
+                http_get=kubernetes.core.v1.HTTPGetActionArgs(
+                    path="/health/liveness/",
+                    port=DEFAULT_NGINX_PORT,
+                ),
+                initial_delay_seconds=30,
+                period_seconds=30,
+                failure_threshold=3,
+                timeout_seconds=5,
+            ),
+            "readiness_probe": kubernetes.core.v1.ProbeArgs(
+                http_get=kubernetes.core.v1.HTTPGetActionArgs(
+                    path="/health/readiness/",
+                    port=DEFAULT_NGINX_PORT,
+                ),
+                initial_delay_seconds=15,
+                period_seconds=15,
+                failure_threshold=3,
+                timeout_seconds=5,
+            ),
+            "startup_probe": kubernetes.core.v1.ProbeArgs(
+                http_get=kubernetes.core.v1.HTTPGetActionArgs(
+                    path="/health/startup/",
+                    port=DEFAULT_NGINX_PORT,
+                ),
+                initial_delay_seconds=10,
+                period_seconds=10,
+                failure_threshold=12,
+                success_threshold=1,
+                timeout_seconds=5,
+            ),
+        },
         celery_worker_configs=[
             OLApplicationK8sCeleryWorkerConfig(
                 application_name="odl_video",

--- a/src/ol_infrastructure/applications/xpro/__main__.py
+++ b/src/ol_infrastructure/applications/xpro/__main__.py
@@ -10,7 +10,6 @@ import json
 from pathlib import Path
 
 import pulumi_fastly as fastly
-import pulumi_kubernetes as kubernetes
 import pulumi_vault as vault
 from pulumi import (
     ROOT_STACK_RESOURCE,
@@ -23,7 +22,6 @@ from pulumi import (
 from pulumi_aws import ec2, iam, route53
 
 from bridge.lib.magic_numbers import (
-    DEFAULT_NGINX_PORT,
     DEFAULT_POSTGRES_PORT,
     DEFAULT_REDIS_PORT,
     ONE_MEGABYTE_BYTE,
@@ -562,39 +560,6 @@ if k8s_deploy:
             ),
             resource_requests={"cpu": "250m", "memory": "2Gi"},
             resource_limits={"memory": "2Gi"},
-            probe_configs={
-                "liveness_probe": kubernetes.core.v1.ProbeArgs(
-                    http_get=kubernetes.core.v1.HTTPGetActionArgs(
-                        path="/nginx-health",
-                        port=DEFAULT_NGINX_PORT,
-                    ),
-                    initial_delay_seconds=30,
-                    period_seconds=30,
-                    failure_threshold=3,
-                    timeout_seconds=3,
-                ),
-                "readiness_probe": kubernetes.core.v1.ProbeArgs(
-                    http_get=kubernetes.core.v1.HTTPGetActionArgs(
-                        path="/nginx-health",
-                        port=DEFAULT_NGINX_PORT,
-                    ),
-                    initial_delay_seconds=15,
-                    period_seconds=15,
-                    failure_threshold=3,
-                    timeout_seconds=3,
-                ),
-                "startup_probe": kubernetes.core.v1.ProbeArgs(
-                    http_get=kubernetes.core.v1.HTTPGetActionArgs(
-                        path="/nginx-health",
-                        port=DEFAULT_NGINX_PORT,
-                    ),
-                    initial_delay_seconds=10,
-                    period_seconds=10,
-                    failure_threshold=6,
-                    success_threshold=1,
-                    timeout_seconds=5,
-                ),
-            },
         ),
         opts=ResourceOptions(depends_on=[xpro_app_security_group, *secret_resources]),
     )


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Removes the per-app `probe_configs` overrides for **micromasters**, **ocw-studio**, **odl-video-service**, and **xpro**, which currently pin Kubernetes liveness/readiness/startup probes to nginx's own `/nginx-health` endpoint. Without an explicit override, these apps now fall back to `OLApplicationK8sConfig`'s component default, which is already:

```python
"liveness_probe":  path="/health/liveness/",  port=DEFAULT_NGINX_PORT,
"readiness_probe": path="/health/readiness/", port=DEFAULT_NGINX_PORT,
"startup_probe":   path="/health/startup/",   port=DEFAULT_NGINX_PORT,
```//
(see `src/ol_infrastructure/components/services/k8s.py`)

This matches `mit-learn`, `learn-ai`, and `mitxonline`, which already rely on this same default because they've had `django-health-check` wired in for a while.

nginx serves `/nginx-health` directly (`return 200`) but proxies every other path — including `/health/*` — straight through to the Django/gunicorn backend on the same port, so no port or nginx-config change is needed here, just dropping the override.

Also removed the now-unused `DEFAULT_NGINX_PORT` import in the 3 files where it was only referenced by the deleted `probe_configs` block (micromasters, ocw-studio, xpro still use it elsewhere so kept there; odl-video-service still uses it elsewhere too).

### How can this be tested?
Ran `pulumi preview --diff` against the QA stack for both `micromasters` and `xpro` to confirm the actual planned diff. Confirmed the *only* spec change is the probe path/threshold (no resource replacement, no unrelated changes):
```
~ livenessProbe : { httpGet: { path: "/nginx-health" => "/health/liveness/" } }
~ readinessProbe: { httpGet: { path: "/nginx-health" => "/health/readiness/" } }
~ startupProbe  : { failureThreshold: 6 => 12, httpGet: { path: "/nginx-health" => "/health/startup/" } }
```
`ruff`, `mypy`, and the rest of pre-commit all pass on the touched files.

### Additional Context
**This PR is intentionally opened as a draft and must NOT be merged/deployed until all four of the following companion app-side PRs are merged AND deployed to the target environment(s) first** — otherwise these probes will 404 against still-running old app code (which has no `/health/*` endpoint yet), which would fail readiness checks and could take pods out of rotation:
- micromasters: https://github.com/mitodl/micromasters/pull/5527
- ocw-studio: https://github.com/mitodl/ocw-studio/pull/3083
- odl-video-service: https://github.com/mitodl/odl-video-service/pull/1530
- xpro: https://github.com/mitodl/mitxpro/pull/3978

Recommend merging/deploying each app PR first, confirming `/health/liveness/` etc. respond correctly in that environment, and only then converting this PR out of draft and merging it — ideally per-app rather than all four at once, to limit blast radius if something is wrong.