### PR TITLE
fix(local-dev): Learn Management Commands / OpenSearch

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -89,6 +89,14 @@ APPS = [
                 "description": "Backpopulate MITx Online resources",
                 "cmd": "python manage.py backpopulate_mitxonline_data",
             },
+            {
+                "label": "seed-mit-learn-featured-lists",
+                # dev/rc-only command. Prereqs: offeror channels
+                # (backpopulate_resource_channels), published courses per
+                # offeror, and at least one user (author of the learning path).
+                "description": "Create dev-only featured lists per offeror channel",
+                "cmd": "python manage.py populate_featured_lists",
+            },
         ],
     },
     {

--- a/Tiltfile
+++ b/Tiltfile
@@ -75,7 +75,9 @@ APPS = [
             {
                 "label": "seed-mit-learn-opensearch",
                 "description": "Recreate OpenSearch index from scratch",
-                "cmd": "python manage.py recreate_index",
+                # --all is required: without an index selector the command just
+                # prints "Must select at least one index to update" and no-ops.
+                "cmd": "python manage.py recreate_index --all",
             },
             {
                 "label": "seed-mit-learn-ocw",

--- a/local-dev/apps/mit-learn/configmaps/app-env.yaml
+++ b/local-dev/apps/mit-learn/configmaps/app-env.yaml
@@ -82,6 +82,11 @@ data:
   # ── Valkey / Celery ────────────────────────────────────────────────────────
   # CELERY_BROKER_URL and REDISCACHE_URL are set in secrets.
   CELERY_TASK_ALWAYS_EAGER: "False"
+  # Disable the Celery beat scheduler by default in local dev so backpopulate/
+  # news ETL and search reindex tasks run on demand (via the Tilt seed buttons),
+  # not automatically on a schedule. Set to "False" to re-enable scheduled
+  # background population.
+  CELERY_BEAT_DISABLED: "True"
 
   # ── OpenSearch ─────────────────────────────────────────────────────────────
   OPENSEARCH_INDEX: "mitlearn-local"

--- a/local-dev/infra/modules/search.py
+++ b/local-dev/infra/modules/search.py
@@ -88,9 +88,13 @@ def create_search(
             values={
                 "singleNode": True,
                 "replicas": 1,
-                "opensearchJavaOpts": "-Xms256m -Xmx256m",
+                # Heap matches the known-good mit-learn docker-compose value
+                # (-Xmx1024m). 256m tripped the parent circuit breaker at baseline
+                # and made `recreate_index` fail. Keep heap ~50% of the container
+                # limit so the JVM has room for off-heap/direct memory + OS.
+                "opensearchJavaOpts": "-Xms1024m -Xmx1024m",
                 "resources": {
-                    "limits": {"memory": "1Gi"},
+                    "limits": {"memory": "2Gi"},
                 },
                 "persistence": {"size": "5Gi"},
                 "config": {"opensearch.yml": "plugins.security.disabled: true\n"},


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Makes MIT Learn local-dev data actually reach the catalog. The DB was being populated but the catalog rendered nothing because OpenSearch had no usable index.

- **OpenSearch heap 256m→1024m (container limit 1Gi→2Gi).** `./manage.py recreate_index --all` was OOMing; this matches what is set in Learn's opensearch.base dockerfile https://github.com/mitodl/mit-learn/blob/0bca7e4bd18a9d99721cab493b080b7bb96ca83f/docker-compose.opensearch.base.yml#L8
- **Disable Celery beat by default for mit-learn** (`CELERY_BEAT_DISABLED=True`) Matches current learn dev practice. Constantly running ETL is annoying and resource intensive
- **`recreate_index --all` in the reindex seed.**  Was missing the `--all` before, so command crashed.
- **New `seed-mit-learn-featured-lists` seed** running `populate_featured_lists` (dev-only featured lists per offeror channel)... Otherwise the homepage looks empty.

### How can this be tested?
1. `tilt up` the local-dev stack with mit-learn enabled.
2. Log in to mit-learn once as an admin user... `admin@odl.local / localdev123` 
3. Let the `local-infra-core` resource apply, then confirm OpenSearch came up with the new sizing: `kubectl get statefulset opensearch-cluster-master -n local-infra -o jsonpath='{.spec.template.spec.containers[0].resources.limits.memory}'` → `2Gi`, and its `OPENSEARCH_JAVA_OPTS` → `-Xms1024m -Xmx1024m`.
4. Populate the DB via the backpopulate seed buttons, then click `seed-mit-learn-opensearch`. It should end with "Recreate index finished…" rather than a `circuit_breaking_exception`.
5. Confirm the catalog: `curl -sk "https://api.learn.mit.dev/api/v1/learning_resources_search/?limit=1"` returns a non-zero `count` (2,241 in my run: 99 courses, 27 programs, 37 podcasts, 2,078 podcast episodes), and the homepage carousels render.
6. Verify beat is off: `mitlearn-env` ConfigMap has `CELERY_BEAT_DISABLED=True`, and after a `kubectl rollout restart deploy/mitlearn-beat` the RedBeat schedule (`redbeat::schedule` in Valkey db 0) is empty.
7. (Optional) `seed-mit-learn-featured-lists` runs `populate_featured_lists`; requires offeror channels, published courses. This also requires at least one user in your Learn db, but that should exist per (1).
