### PR TITLE
feat(starrocks): create b2b_analytics database and grant dbt CREATE TABLE/MV privileges

### DIFF
--- a/src/ol_infrastructure/substructure/starrocks/__main__.py
+++ b/src/ol_infrastructure/substructure/starrocks/__main__.py
@@ -523,6 +523,39 @@ roles_setup_cmd = command.local.Command(
     opts=ResourceOptions(delete_before_replace=True, depends_on=_role_deps),
 )
 
+# --- b2b_analytics database ---------------------------------------------
+# Dedicated database (default_catalog) backing the B2B self-serve analytics
+# StarRocks MVs (see hq#10006 / hq#10012). The `app` role already has
+# SELECT/INSERT/UPDATE/DELETE ON ALL TABLES IN ALL DATABASES from the base
+# roles SQL above, which covers dbt's write path once tables/MVs exist in
+# this database. What's missing — and StarRocks-specific — is that creating
+# new tables/materialized views requires its own CREATE TABLE / CREATE
+# MATERIALIZED VIEW privilege, granted at the database level, distinct from
+# the table-level DML privileges above.
+_b2b_analytics_db_sql = """\
+CREATE DATABASE IF NOT EXISTS b2b_analytics;
+GRANT CREATE TABLE ON DATABASE b2b_analytics TO ROLE app;
+GRANT CREATE MATERIALIZED VIEW ON DATABASE b2b_analytics TO ROLE app;"""
+
+_b2b_analytics_db_drop_sql = "DROP DATABASE IF EXISTS b2b_analytics;"
+
+command.local.Command(
+    f"starrocks-{stack_info.env_suffix}-b2b-analytics-database-setup",
+    create=_exec_sql,
+    update=_exec_sql,
+    delete=_exec_delete_sql,
+    environment={
+        **_mysql_env,
+        "STARROCKS_SQL": _b2b_analytics_db_sql,
+        "STARROCKS_DELETE_SQL": _b2b_analytics_db_drop_sql,
+    },
+    triggers=[hashlib.sha256(_b2b_analytics_db_sql.encode()).hexdigest()],
+    opts=ResourceOptions(
+        delete_before_replace=True,
+        depends_on=[roles_setup_cmd],
+    ),
+)
+
 # --- OIDC / OAuth2 authentication via Keycloak ------------------------------
 # StarRocks v3.5+ uses a "security integration" (SQL object) to hold OAuth2
 # provider settings rather than fe.conf env vars.  The integration name goes


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/10006

### Description (What does it do?)
Adds a `b2b_analytics` database in StarRocks' `default_catalog` (QA + production, both stacks apply the same substructure code) and grants the `app` role (the native StarRocks role assigned to dbt's Vault-issued dynamic credentials) database-scoped `CREATE TABLE` and `CREATE MATERIALIZED VIEW` privileges on it.

Context: the six B2B analytics StarRocks materialized views (`mv_b2b_contract_utilization`, `mv_b2b_enrollment_completion_funnel`, `mv_b2b_monthly_engagement_trend`, `mv_b2b_program_funnel`, `mv_b2b_content_engagement_depth`, `mv_b2b_mit_admin_contract_health`) were added to `ol-data-platform` in [PR #2329](https://github.com/mitodl/ol-data-platform/pull/2329), targeting a `b2b_analytics` schema that doesn't exist in the cluster yet. The `app` role already has `SELECT/INSERT/UPDATE/DELETE ON ALL TABLES IN ALL DATABASES` from the existing base-roles SQL in `src/ol_infrastructure/substructure/starrocks/__main__.py`, which will cover dbt's DML once the tables/MVs exist — but StarRocks requires object-creation privileges (`CREATE TABLE`, `CREATE MATERIALIZED VIEW`) to be granted separately, scoped to a database, distinct from the table-level DML grants. Without this, `dbt run --target starrocks_qa --select b2b_analytics` fails to create the MVs.

Implemented as a new `command.local.Command` resource (`b2b-analytics-database-setup`), following the existing pattern used for catalog/role setup in this file — SQL piped through the `mysql` CLI with credentials passed via environment variables, never embedded in the command string or Pulumi state. It depends on `roles_setup_cmd` so the `app` role exists before the grant runs.

### How can this be tested?
- `pulumi preview` against stack `lakehouse.QA` (`src/ol_infrastructure/substructure/starrocks`) shows exactly one new resource (`b2b-analytics-database-setup`) with no changes to any other resource — no deletions or replacements.
- After `pulumi up`, verify from a StarRocks client authenticated as the `app` role (or via `starrocks-auth --env qa --mode vault --vault-role app`):
  ```sql
  SHOW DATABASES; -- b2b_analytics should be listed
  SHOW GRANTS FOR ROLE app; -- should include CREATE TABLE / CREATE MATERIALIZED VIEW ON DATABASE b2b_analytics
  ```
- End-to-end: once merged and applied, `dbt run --target starrocks_qa --select b2b_analytics` from `ol-data-platform` (branch `feat/dbt-starrocks-adapter`, PR #2329) should succeed in materializing the six MVs — this is the live verification tracked separately under the B2B analytics project's Verification & QA task.

### Additional Context
This is one of two prerequisites blocking a live `dbt run` against `starrocks_qa` for the B2B self-serve analytics project (github.com/mitodl/hq/discussions/11845); the other (dbt models themselves) already landed in ol-data-platform PR #2329. Both QA and production stacks share this substructure code, so applying to `lakehouse.QA` first is recommended before `lakehouse.Production`.