### PR TITLE
feat(edxapp): correct the MFE footer links and logos, set the MFE header base URLs

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -279,13 +279,18 @@ def _build_interpolated_config_dict(
                 },
             }
         )
+        # Match the legacy MITx (residential) footer: only Terms of Service +
+        # Accessibility (accessibilityUrl is set in the base config above), and
+        # the MITx theme logo (same asset the legacy header/footer use). Other
+        # links are intentionally omitted so the frontend-base MFE footer does not
+        # show more links than the legacy footer.
         config["FRONTEND_SITE_CONFIG"]["commonAppConfig"]["mitolFooter"].update(
             {
-                "privacyPolicyUrl": f"https://{marketing_domain}/privacy",
                 "termsOfServiceUrl": f"https://{marketing_domain}/terms",
-                "honorCodeUrl": f"https://{marketing_domain}/honor-code/",
-                "aboutUrl": f"https://{marketing_domain}/about",
-                "supportUrl": f"https://{stack_info.env_prefix}.zendesk.com/hc/en-us/requests/new/",
+                "footerLogoUrl": (
+                    f"https://{domains['lms']}/static/"
+                    f"{stack_info.env_prefix}/images/logo.svg"
+                ),
                 "copyrightText": "\u00a9 MIT Open Learning. All rights reserved except where noted.",
             }
         )

--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -384,10 +384,14 @@ def _build_interpolated_config_dict(
         config["FRONTEND_SITE_CONFIG"]["commonAppConfig"]["mitolFooter"].update(
             {
                 "privacyPolicyUrl": f"https://{marketing_domain}/privacy-policy/",
-                "termsOfServiceUrl": f"https://{marketing_domain}/terms-of-service/",
+                "termsOfServiceUrl": (
+                    f"https://{edxapp_config.require('mit_learn_domain')}/terms"
+                ),
                 "honorCodeUrl": f"https://{marketing_domain}/honor-code/",
-                "aboutUrl": f"https://{marketing_domain}/about-us/",
-                "supportUrl": f"https://{stack_info.env_prefix}.zendesk.com/hc/en-us/requests/new/",
+                "aboutUrl": (
+                    f"https://{edxapp_config.require('mit_learn_domain')}/about"
+                ),
+                "supportUrl": "https://support.learn.mit.edu/",
                 "copyrightText": "\u00a9 MIT Open Learning. All rights reserved except where noted.",
             }
         )

--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -291,7 +291,7 @@ def _build_interpolated_config_dict(
                     f"https://{domains['lms']}/static/"
                     f"{stack_info.env_prefix}/images/mit-ol-logo.svg"
                 ),
-                "copyrightText": "\u00a9 MITx Residential. All rights reserved.",
+                "copyrightText": "\u00a9 {year} MITx Residential. All rights reserved.",
             }
         )
 
@@ -328,7 +328,7 @@ def _build_interpolated_config_dict(
                 "honorCodeUrl": f"https://{marketing_domain}/honor-code/",
                 "aboutUrl": f"https://{marketing_domain}/about-us",
                 "supportUrl": f"https://{stack_info.env_prefix}.zendesk.com/hc/en-us/requests/new/",
-                "copyrightText": "\u00a9 MIT xPRO. All rights reserved except where noted.",
+                "copyrightText": "\u00a9 {year} MIT xPRO. All rights reserved.",
             }
         )
 
@@ -392,7 +392,13 @@ def _build_interpolated_config_dict(
                     f"https://{edxapp_config.require('mit_learn_domain')}/about"
                 ),
                 "supportUrl": "https://support.learn.mit.edu/",
-                "copyrightText": "\u00a9 MIT Open Learning. All rights reserved except where noted.",
+                "copyrightText": "\u00a9 {year} Massachusetts Institute of Technology",
+                # Footer uses the plain "MIT" mark (mit-logo.svg), not the header
+                # logo.svg, to match the legacy MITxOnline footer.
+                "footerLogoUrl": (
+                    f"https://{domains['lms']}/static/"
+                    f"{stack_info.env_prefix}/images/mit-logo.svg"
+                ),
             }
         )
 

--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -286,7 +286,7 @@ def _build_interpolated_config_dict(
         # Other links are omitted so the MFE footer matches the legacy footer.
         config["FRONTEND_SITE_CONFIG"]["commonAppConfig"]["mitolFooter"].update(
             {
-                "termsOfServiceUrl": f"https://{marketing_domain}/terms",
+                "termsOfServiceUrl": f"https://{marketing_domain}/tos",
                 "footerLogoUrl": (
                     f"https://{domains['lms']}/static/"
                     f"{stack_info.env_prefix}/images/mit-ol-logo.svg"

--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -280,18 +280,18 @@ def _build_interpolated_config_dict(
             }
         )
         # Match the legacy MITx (residential) footer: only Terms of Service +
-        # Accessibility (accessibilityUrl is set in the base config above), and
-        # the MITx theme logo (same asset the legacy header/footer use). Other
-        # links are intentionally omitted so the frontend-base MFE footer does not
-        # show more links than the legacy footer.
+        # Accessibility (accessibilityUrl is set in the base config above), the
+        # trademark logo ("MIT Open Learning" = mit-ol-logo.svg, which the legacy
+        # footer uses \u2014 NOT the header's logo.svg), and the legacy copyright text.
+        # Other links are omitted so the MFE footer matches the legacy footer.
         config["FRONTEND_SITE_CONFIG"]["commonAppConfig"]["mitolFooter"].update(
             {
                 "termsOfServiceUrl": f"https://{marketing_domain}/terms",
                 "footerLogoUrl": (
                     f"https://{domains['lms']}/static/"
-                    f"{stack_info.env_prefix}/images/logo.svg"
+                    f"{stack_info.env_prefix}/images/mit-ol-logo.svg"
                 ),
-                "copyrightText": "\u00a9 MIT Open Learning. All rights reserved except where noted.",
+                "copyrightText": "\u00a9 MITx Residential. All rights reserved.",
             }
         )
 

--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -292,6 +292,11 @@ def _build_interpolated_config_dict(
                     f"{stack_info.env_prefix}/images/mit-ol-logo.svg"
                 ),
                 "copyrightText": "\u00a9 {year} MITx Residential. All rights reserved.",
+                # The legacy MITx footer links its trademark logo to MIT Open
+                # Learning (LOGO_TRADEMARK_URL + MIT_OPEN_LEARNING_SITE_LINK in
+                # mitx/common-mfe-config.env.jsx). Without this the Site Project
+                # footer renders the logo as a bare image.
+                "footerLogoDestination": "https://openlearning.mit.edu",
             }
         )
 
@@ -329,8 +334,23 @@ def _build_interpolated_config_dict(
                 "aboutUrl": f"https://{marketing_domain}/about-us",
                 "supportUrl": f"https://{stack_info.env_prefix}.zendesk.com/hc/en-us/requests/new/",
                 "copyrightText": "\u00a9 {year} MIT xPRO. All rights reserved.",
+                # xPRO's footer carries the xPRO logo linked to its marketing
+                # site, not an MIT mark -- the pairing the legacy footer used
+                # (LOGO_URL + MARKETING_SITE_BASE_URL in
+                # xpro/common-mfe-config.env.jsx). Left unset, the Site Project
+                # footer falls back to headerLogoImageUrl and renders it
+                # unlinked.
+                "footerLogoUrl": config["LOGO_URL"],
+                "footerLogoDestination": f"https://{marketing_domain}",
             }
         )
+        # Dashboard / Profile / Settings in the xPRO user menu are built as
+        # `${marketingSiteBaseUrl}/dashboard` etc. Unset, that yields a relative
+        # "/dashboard" against the LMS host instead of the marketing site. No
+        # trailing slash: the components append their own path segment.
+        config["FRONTEND_SITE_CONFIG"]["commonAppConfig"]["mitolHeader"] = {
+            "marketingSiteBaseUrl": f"https://{marketing_domain}",
+        }
 
     # MITx Online-specific configuration
     elif stack_info.env_prefix == "mitxonline":
@@ -399,8 +419,22 @@ def _build_interpolated_config_dict(
                     f"https://{domains['lms']}/static/"
                     f"{stack_info.env_prefix}/images/mit-logo.svg"
                 ),
+                # The legacy learning MFE footer links that mark to web.mit.edu
+                # (LOGO_TRADEMARK_URL + MIT_BASE_URL in
+                # mitxonline/common-mfe-config.env.jsx).
+                "footerLogoDestination": "https://web.mit.edu",
             }
         )
+        # Header destinations for the Site Project MFEs. The components fall back
+        # to the production learn.mit.edu and to lmsBaseUrl when these are
+        # absent, so on RC the instructor dashboard's Dashboard button points at
+        # production MIT Learn and Profile / Settings at the LMS rather than the
+        # marketing site. No trailing slash: the components append their own
+        # path segment.
+        config["FRONTEND_SITE_CONFIG"]["commonAppConfig"]["mitolHeader"] = {
+            "mitLearnBaseUrl": f"https://{edxapp_config.require('mit_learn_domain')}",
+            "marketingSiteBaseUrl": f"https://{marketing_domain}",
+        }
 
     return config
 

--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -334,8 +334,20 @@ def _build_interpolated_config_dict(
                 "aboutUrl": f"https://{marketing_domain}/about-us",
                 "supportUrl": f"https://{stack_info.env_prefix}.zendesk.com/hc/en-us/requests/new/",
                 "copyrightText": "\u00a9 {year} MIT xPRO. All rights reserved.",
+                # The xPRO logo linked to the marketing site, as the legacy
+                # footer had it (LOGO_URL + MARKETING_SITE_BASE_URL in
+                # xpro/common-mfe-config.env.jsx). Note xPRO uses LOGO_URL, not
+                # the trademark mark mitx and mitxonline use.
+                "footerLogoUrl": config["LOGO_URL"],
+                "footerLogoDestination": f"https://{marketing_domain}",
             }
         )
+        # The xPRO user menu builds `${marketingSiteBaseUrl}/dashboard` etc, so
+        # without this those resolved to relative paths on the LMS host. No
+        # trailing slash: the components append their own segment.
+        config["FRONTEND_SITE_CONFIG"]["commonAppConfig"]["mitolHeader"] = {
+            "marketingSiteBaseUrl": f"https://{marketing_domain}",
+        }
 
     # MITx Online-specific configuration
     elif stack_info.env_prefix == "mitxonline":

--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -334,23 +334,8 @@ def _build_interpolated_config_dict(
                 "aboutUrl": f"https://{marketing_domain}/about-us",
                 "supportUrl": f"https://{stack_info.env_prefix}.zendesk.com/hc/en-us/requests/new/",
                 "copyrightText": "\u00a9 {year} MIT xPRO. All rights reserved.",
-                # xPRO's footer carries the xPRO logo linked to its marketing
-                # site, not an MIT mark -- the pairing the legacy footer used
-                # (LOGO_URL + MARKETING_SITE_BASE_URL in
-                # xpro/common-mfe-config.env.jsx). Left unset, the Site Project
-                # footer falls back to headerLogoImageUrl and renders it
-                # unlinked.
-                "footerLogoUrl": config["LOGO_URL"],
-                "footerLogoDestination": f"https://{marketing_domain}",
             }
         )
-        # Dashboard / Profile / Settings in the xPRO user menu are built as
-        # `${marketingSiteBaseUrl}/dashboard` etc. Unset, that yields a relative
-        # "/dashboard" against the LMS host instead of the marketing site. No
-        # trailing slash: the components append their own path segment.
-        config["FRONTEND_SITE_CONFIG"]["commonAppConfig"]["mitolHeader"] = {
-            "marketingSiteBaseUrl": f"https://{marketing_domain}",
-        }
 
     # MITx Online-specific configuration
     elif stack_info.env_prefix == "mitxonline":


### PR DESCRIPTION
## Issue

https://github.com/mitodl/hq/issues/12777

## Description

Correct the production frontend-base MFE footer config (`FRONTEND_SITE_CONFIG.commonAppConfig.mitolFooter`) so each MFE footer matches its intended destinations, and populate `commonAppConfig.mitolHeader`, which nothing had set. The instructor-dashboard and other frontend-base MFEs share one header and footer component that render whatever each deployment configures.

### MITx (residential) — match the legacy MFE footer
`mitx` / `mitx-staging` only:
- Show just **Terms of Service + Accessibility** (`accessibilityUrl` is already in the base config); remove `aboutUrl`, `supportUrl`, `privacyPolicyUrl`, `honorCodeUrl`.
- `termsOfServiceUrl` → `https://<lms>/tos`
- `footerLogoUrl` → the **trademark** logo `mit-ol-logo.svg` ("MIT Open Learning") — the asset the legacy footer uses, **not** the header's `logo.svg`.
- `footerLogoDestination` → `https://openlearning.mit.edu`, so the logo is a link as it is in the legacy footer.
- `copyrightText` → `© {year} MITx Residential. All rights reserved.`

### MITxOnline — repoint footer links to learn.mit.edu
- **Terms of Service** → `https://learn.mit.edu/terms`
- **About Us** → `https://learn.mit.edu/about`
- **Help** → `https://support.learn.mit.edu/`
- `footerLogoUrl` → the plain **MIT** mark `mit-logo.svg`, `footerLogoDestination` → `https://web.mit.edu` — the pairing the legacy learning MFE footer uses.
- `copyrightText` → `© {year} Massachusetts Institute of Technology`

About/Terms use the `mit_learn_domain` config var (env-aware, consistent with the `MKTG_URL_OVERRIDES` already in this block); Help uses the dedicated support portal URL. `privacyPolicyUrl` / `honorCodeUrl` are left on `marketing_domain` — they are not rendered in the footer.

### xPRO
- `copyrightText` → `© {year} MIT xPRO. All rights reserved.`, so the year stays current.
- `footerLogoUrl` → `LOGO_URL` and `footerLogoDestination` → `https://xpro.mit.edu`, the pairing the legacy xPRO footer used. It had neither, so the footer fell back to the header logo, unlinked. Note xPRO uses `LOGO_URL`, not the trademark mark mitx and mitxonline use.
- `mitolHeader.marketingSiteBaseUrl` → `https://xpro.mit.edu`. Its user menu builds `${marketingSiteBaseUrl}/dashboard`, `/profile/` and `/account-settings/`, which without it resolved to relative paths on the LMS host.

**These are a no-op on xPRO for now.** Both MFE config endpoints 404 there — `/api/frontend_site_config/v1/` and `/api/mfe_config/v1` — where mitx, mitxonline and RC all return 200, so nothing reads `FRONTEND_SITE_CONFIG` on that deployment yet. This lands the config for when the Site Project ships there; why those endpoints are off is worth chasing separately.

### MITxOnline header base URLs
`commonAppConfig.mitolHeader` was never set, so the header components fell back to their defaults: `mitLearnBaseUrl` → production `learn.mit.edu` and `marketingSiteBaseUrl` → `lmsBaseUrl`. On RC that sent the Dashboard button to **production** MIT Learn and Profile / Settings to the LMS host instead of the marketing site. Neither value carries a trailing slash; the components append their own path segment.

## Why

MITx was configured with a fuller link set than the legacy MITx footer (About Us / Help etc.), and MITxOnline pointed at `mitxonline.mit.edu` / zendesk rather than the `learn.mit.edu` destinations. The logo keys matter because the footer component falls back to `headerLogoImageUrl` when `footerLogoUrl` is absent — and for MITxOnline that SVG is drawn `fill="white"` for the dark header, so it is invisible on the light footer and the footer reads as having no logo at all. Reported in the instructor dashboard header/footer issue; the code half is mitodl/lehrer#224.

## How to test

- Add the configs in your local env and verify they work as expected

On xPRO only the configmap changes for now — see the no-op note above. For reference, the legacy xPRO footer this is aiming at is: the **MIT xPRO** mark bottom-left linking to `xpro.mit.edu`, five centred links in the order **About Us · Privacy Policy · Honor Code · Terms of Service · Accessibility**, `© <year> MIT xPRO. All rights reserved.` beneath them, and Powered by Open edX bottom-right. The link set and order already come from `linkOrder` in `xpro/site.config.build.tsx`, so this PR only supplies the logo and its destination. (`supportUrl` is set for xPRO but unused — its `linkOrder` has no `help` entry.)
