### PR TITLE
feat(concourse): add arm64 multi-arch build to ol-python-base images

### DIFF
--- a/dockerfiles/ol-python-base/Dockerfile
+++ b/dockerfiles/ol-python-base/Dockerfile
@@ -9,6 +9,9 @@
 #
 # Build:
 #   docker build --build-arg PYTHON_VERSION=3.12 -t mitodl/ol-python-base:3.12 .
+# Multi-arch build (published for both amd64 and arm64/Apple Silicon):
+#   docker buildx build --platform linux/amd64,linux/arm64 \
+#     --build-arg PYTHON_VERSION=3.12 -t mitodl/ol-python-base:3.12 .
 ARG PYTHON_VERSION=3.12
 FROM python:${PYTHON_VERSION}-slim
 

--- a/dockerfiles/ol-python-base/Dockerfile
+++ b/dockerfiles/ol-python-base/Dockerfile
@@ -9,8 +9,10 @@
 #
 # Build:
 #   docker build --build-arg PYTHON_VERSION=3.12 -t mitodl/ol-python-base:3.12 .
-# Multi-arch build (published for both amd64 and arm64/Apple Silicon):
-#   docker buildx build --platform linux/amd64,linux/arm64 \
+# Multi-arch build (published for both amd64 and arm64/Apple Silicon; --push
+# is required since a multi-platform result can't be loaded into the local
+# docker engine):
+#   docker buildx build --platform linux/amd64,linux/arm64 --push \
 #     --build-arg PYTHON_VERSION=3.12 -t mitodl/ol-python-base:3.12 .
 ARG PYTHON_VERSION=3.12
 FROM python:${PYTHON_VERSION}-slim

--- a/src/bilder/images/concourse/deploy.py
+++ b/src/bilder/images/concourse/deploy.py
@@ -246,10 +246,15 @@ vault_template_map = {
 
 # Install Concourse
 # Web nodes need awscli + jq for the stalled-worker reaper; workers need awscli
-# for the spot/lifecycle drain helpers.
+# for the spot/lifecycle drain helpers, plus qemu-user-static/binfmt-support so
+# oci-build-task can cross-build linux/arm64 images via QEMU emulation.
 install_baseline_packages(
     packages=["curl", "btrfs-progs"]
-    + (["awscli"] if node_type == CONCOURSE_WORKER_NODE_TYPE else [])
+    + (
+        ["awscli", "qemu-user-static", "binfmt-support"]
+        if node_type == CONCOURSE_WORKER_NODE_TYPE
+        else []
+    )
     + (["awscli", "jq"] if node_type == CONCOURSE_WEB_NODE_TYPE else [])
 )
 concourse_install_changed = install_concourse(concourse_base_config)

--- a/src/ol_concourse/pipelines/container_images/ol_python_base.py
+++ b/src/ol_concourse/pipelines/container_images/ol_python_base.py
@@ -56,18 +56,24 @@ def build_job(python_version: str) -> Job:
                 build_parameters={
                     "CONTEXT": context,
                     "BUILD_ARG_PYTHON_VERSION": python_version,
+                    # Cross-build linux/arm64 via QEMU emulation (workers have
+                    # qemu-user-static/binfmt-support installed) so Apple
+                    # Silicon can pull a native image. Multiple platforms
+                    # makes oci-build-task emit an OCI layout directory
+                    # (image/image) instead of a tarball.
+                    "IMAGE_PLATFORM": "linux/amd64,linux/arm64",
                 },
             ),
             ensure_ecr_task("mitodl/ol-python-base"),
             PutStep(
                 put=image_resources[python_version].name,
                 inputs="detect",
-                params={"image": "image/image.tar"},
+                params={"image": "image/image"},
             ),
             PutStep(
                 put=ecr_image_resources[python_version].name,
                 inputs="detect",
-                params={"image": "image/image.tar"},
+                params={"image": "image/image"},
             ),
         ],
     )


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Adds a native `linux/arm64` target to the `ol-python-base` Docker Hub/ECR build matrix so Apple Silicon developers get a matching image instead of falling back to amd64 emulation.

- `src/ol_concourse/pipelines/container_images/ol_python_base.py`: sets `IMAGE_PLATFORM=linux/amd64,linux/arm64` on the `oci-build-task` step, so each Python version now publishes a single multi-arch manifest covering both platforms. Updated the `put` step's `image` param from `image/image.tar` to `image/image`, since `oci-build-task` switches its output to an OCI image layout directory (rather than a tarball) whenever more than one platform is requested.
- `src/bilder/images/concourse/deploy.py`: installs `qemu-user-static` and `binfmt-support` on Concourse worker AMIs. Cross-building `linux/arm64` on the existing amd64 worker fleet requires QEMU/binfmt emulation registered on the host kernel — without it, the arm64 build stage fails with `exec format error` / "Invalid ELF image for this architecture" (this is a known `oci-build-task` limitation, see https://github.com/concourse/oci-build-task/issues/110). This avoids the alternative of provisioning a whole new native arm64 Concourse worker pool — no new AWS infra, just slower (emulated) arm64 builds.
- `dockerfiles/ol-python-base/Dockerfile`: added a `docker buildx build --platform linux/amd64,linux/arm64 ...` note for local multi-arch testing. No other Dockerfile changes were needed: `python:${PYTHON_VERSION}-slim` and the pinned `ghcr.io/astral-sh/uv` digest are both already multi-arch manifest lists (verified the pinned uv digest resolves to an OCI image index containing both `amd64` and `arm64` manifests), and every apt package it installs has an arm64 build.

### Screenshots (if appropriate):
N/A — no UI changes.

### How can this be tested?
- Ran `pre-commit run` (ruff, mypy, hadolint, etc.) against the three changed files — all pass.
- Rendered the pipeline definition locally and confirmed the `oci-build-task` params include `IMAGE_PLATFORM` and both `put` steps reference `image/image`:
  ```
  python -c "
  import sys; sys.path.insert(0, 'src')
  from ol_concourse.pipelines.container_images.ol_python_base import ol_python_base_pipeline
  print(ol_python_base_pipeline.model_dump_json(indent=2))
  "
  ```
- After merge, the next Concourse worker AMI rebuild (Packer) needs to roll out to the worker fleet before arm64 builds will succeed; until then the `IMAGE_PLATFORM` build will fail on the arm64 stage with an ELF-format error, since the current worker AMIs don't yet have QEMU/binfmt registered.
- Once deployed, verify with `fly trigger-job` on `ol-python-base-docker/build-and-publish-<version>` and confirm `docker manifest inspect mitodl/ol-python-base:<version>` lists both `linux/amd64` and `linux/arm64` entries.

### Additional Context
This only builds arm64 via QEMU emulation on the current amd64 worker fleet — it does not add a native arm64 Concourse worker pool. Emulated cross-builds will be noticeably slower than native amd64 builds for the same job; if that overhead becomes a problem, provisioning a native Graviton worker pool tagged e.g. `arm64` would be the next step, but that's out of scope here.

### Checklist:
- [ ] Rebuild and roll out the Concourse worker Packer AMI so `qemu-user-static`/`binfmt-support` land on the worker fleet before this pipeline change is expected to succeed