### PR TITLE
fix(open_metadata): switch semantic search embeddings from DJL to Bedrock

### DIFF
--- a/src/ol_infrastructure/applications/open_metadata/__main__.py
+++ b/src/ol_infrastructure/applications/open_metadata/__main__.py
@@ -731,8 +731,17 @@ open_metadata_application = kubernetes.helm.v3.Release(
                     "name": "EMBEDDING_PROVIDER",
                     "value": "bedrock",
                 },
+                # Bedrock's region (parsed by OM from AWS_DEFAULT_REGION per
+                # conf/openmetadata.yaml) and the AWS SDK v2 region-provider
+                # chain (which the IRSA credentials exchange uses internally,
+                # and only recognizes AWS_REGION) read two different env vars -
+                # set both rather than assume one covers the other.
                 {
                     "name": "AWS_DEFAULT_REGION",
+                    "value": "us-east-1",
+                },
+                {
+                    "name": "AWS_REGION",
                     "value": "us-east-1",
                 },
                 {

--- a/src/ol_infrastructure/applications/open_metadata/__main__.py
+++ b/src/ol_infrastructure/applications/open_metadata/__main__.py
@@ -538,6 +538,42 @@ open_metadata_glue_iam_policy = iam.Policy(
     tags=aws_config.tags,
 )
 
+# Grants the server pod access to invoke the Bedrock embedding model used for
+# semantic search (see EMBEDDING_PROVIDER below). The DJL provider is unusable
+# on the official OpenMetadata image: DJL downloads a glibc-linked PyTorch
+# native runtime, but the image is Alpine/musl, so it fails every time with
+# `UnsatisfiedLinkError: ... initial-exec TLS resolves to dynamic definition`.
+# Unresolved upstream as of 1.13.1 -
+# https://github.com/open-metadata/OpenMetadata/issues/29576
+open_metadata_bedrock_policy_document = {
+    "Version": IAM_POLICY_VERSION,
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": ["bedrock:InvokeModel"],
+            "Resource": ["arn:aws:bedrock:*::foundation-model/amazon.titan-embed-*"],
+        },
+    ],
+}
+
+open_metadata_bedrock_iam_policy = iam.Policy(
+    f"open-metadata-bedrock-embedding-policy-{stack_info.env_suffix}",
+    name=f"open-metadata-bedrock-embedding-policy-{stack_info.env_suffix}",
+    path=f"/ol-applications/open-metadata/open_metadata/{stack_info.env_suffix}/",
+    description=(
+        "Allows the OpenMetadata server to invoke the Bedrock Titan embedding"
+        " model used for semantic/vector search"
+    ),
+    policy=lint_iam_policy(
+        open_metadata_bedrock_policy_document,
+        stringify=True,
+        # Parliament's RESOURCE_MISMATCH check doesn't recognize the
+        # foundation-model resource type for bedrock:InvokeModel.
+        parliament_config={"RESOURCE_EFFECTIVELY_STAR": {}, "RESOURCE_MISMATCH": {}},
+    ),
+    tags=aws_config.tags,
+)
+
 open_metadata_irsa_role = OLEKSTrustRole(
     f"open-metadata-irsa-trust-role-{stack_info.env_suffix}",
     role_config=OLEKSTrustRoleConfig(
@@ -559,6 +595,13 @@ open_metadata_irsa_role = OLEKSTrustRole(
 open_metadata_glue_policy_attachment = iam.RolePolicyAttachment(
     f"open-metadata-glue-policy-attachment-{stack_info.env_suffix}",
     policy_arn=open_metadata_glue_iam_policy.arn,
+    role=open_metadata_irsa_role.role.name,
+    opts=ResourceOptions(parent=open_metadata_irsa_role),
+)
+
+open_metadata_bedrock_policy_attachment = iam.RolePolicyAttachment(
+    f"open-metadata-bedrock-policy-attachment-{stack_info.env_suffix}",
+    policy_arn=open_metadata_bedrock_iam_policy.arn,
     role=open_metadata_irsa_role.role.name,
     opts=ResourceOptions(parent=open_metadata_irsa_role),
 )
@@ -671,6 +714,13 @@ open_metadata_application = kubernetes.helm.v3.Release(
             # 1.13: hybrid search is now automatic when SEMANTIC_SEARCH_ENABLED=true;
             # the per-query semanticSearch flag is removed. Run the Search Index App
             # after upgrading to populate vector fields in OpenSearch.
+            # EMBEDDING_PROVIDER=bedrock (not djl): DJL is unusable on the official
+            # Alpine/musl-based server image - it fails to load its glibc-linked
+            # PyTorch native runtime every time. Unresolved upstream as of 1.13.1:
+            # https://github.com/open-metadata/OpenMetadata/issues/29576
+            # Bedrock auth uses the pod's IRSA role (open_metadata_bedrock_iam_policy
+            # below) via the AWS default credential provider chain - no API key
+            # needed, just AWS_DEFAULT_REGION.
             # LOG_FORMAT=json (1.13) enables JSON-structured Dropwizard server logs.
             "extraEnvs": [
                 {
@@ -679,7 +729,11 @@ open_metadata_application = kubernetes.helm.v3.Release(
                 },
                 {
                     "name": "EMBEDDING_PROVIDER",
-                    "value": "djl",
+                    "value": "bedrock",
+                },
+                {
+                    "name": "AWS_DEFAULT_REGION",
+                    "value": "us-east-1",
                 },
                 {
                     "name": "LOG_FORMAT",
@@ -726,6 +780,7 @@ open_metadata_application = kubernetes.helm.v3.Release(
             oidc_helm_secret,
             open_metadata_irsa_role,
             open_metadata_glue_policy_attachment,
+            open_metadata_bedrock_policy_attachment,
             *connector_secrets,
         ],
     ),


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
OpenMetadata's `semantic_search` (vector/embedding-based) discovery has been returning `{"error":"Vector search service is not initialized"}` for every query in production, even though `SEMANTIC_SEARCH_ENABLED=true` and `EMBEDDING_PROVIDER=djl` were already set.

Root cause, confirmed via the server's own `GET /api/v1/system/status` diagnostic endpoint against production:

```json
"Semantic Search": {
  "description": "Embeddings are used to allow Semantic Search",
  "passed": false,
  "message": "Embedding client could not be initialized. Error: ai.djl.engine.EngineException: Failed to load PyTorch native library. ... embeddingModel: ai.djl.huggingface.pytorch/sentence-transformers/all-MiniLM-L6-v2"
}
```

The official OpenMetadata server image (`docker.getcollate.io/openmetadata/server:1.13.x`) is Alpine/musl-libc based. DJL downloads a glibc-linked PyTorch native runtime at startup, which fails to load on musl with an `UnsatisfiedLinkError` (`libgomp`/`libc10.so` TLS relocation failure). This is a confirmed, unresolved upstream bug, reproduced across 1.12.3–1.13.1 with no workaround:
- https://github.com/open-metadata/OpenMetadata/issues/29576
- https://github.com/open-metadata/OpenMetadata/issues/26700

Network egress to `djl.ai`/Maven Central/HuggingFace from the pod was verified reachable, ruling out a firewall/egress cause — this is purely an image/runtime incompatibility.

This PR switches `EMBEDDING_PROVIDER` from `djl` to `bedrock`:
- No local native runtime needed — embeddings are generated via an HTTP call to AWS Bedrock (Titan embed model).
- Auth reuses the OpenMetadata server's existing IRSA role (already used for Glue/S3 access) via the AWS SDK's default credential provider chain — no new secret to manage.
- Adds a scoped IAM policy (`bedrock:InvokeModel` on `arn:aws:bedrock:*::foundation-model/amazon.titan-embed-*`) and its role attachment.
- Adds `AWS_DEFAULT_REGION=us-east-1`, which Bedrock's client requires explicitly (it throws `IllegalArgumentException` on a blank region rather than falling back silently).

### How can this be tested?
`pulumi preview --stack Production` shows exactly the expected diff: 2 resource creates (Bedrock IAM policy + attachment) and one Helm release update (`extraEnvs`: `EMBEDDING_PROVIDER: djl → bedrock`, add `AWS_DEFAULT_REGION`). No other resources affected.

After `pulumi up`:
1. Confirm `GET /api/v1/system/status` reports `"Semantic Search": {"passed": true}`.
2. Trigger a reindex (`POST /api/v1/apps/trigger/SearchIndexingApplication`) so existing entities get embeddings backfilled — `isVectorEmbeddingEnabled()`/`OpenSearchVectorService` only populate vectors going forward once initialized; a manual trigger avoids waiting for the next scheduled run.
3. Confirm the `SearchIndexingApplication` run's latest status shows non-zero `vectorStats` (previously `vectorSuccessRecords: 0` across every entity type).
4. Run `semantic_search` (MCP tool) with a natural-language query and confirm it returns results instead of `"Vector search service is not initialized"`.

### Additional Context
Secondary/nice-to-have noted during investigation but out of scope here: the profiler's PII auto-classification tags (`PII.Sensitive`/`PII.NonSensitive`) embed very large URL/email regex blobs in their `reason` field, which bloats API/MCP response sizes. Filed as a separate follow-up.