### PR TITLE
Add Rootly Pulumi stack to simple-pulumi Concourse meta pipeline

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/meta.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/meta.py
@@ -204,6 +204,7 @@ if __name__ == "__main__":
         "open-metadata-substructure",
         "opensearch",
         "qdrant-cloud",
+        "rootly",
         "starrocks",
         "starrocks-substructure",
         "starburst",

--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
@@ -267,6 +267,12 @@ pipeline_params: dict[str, SimplePulumiParams] = {
             "src/bridge/lib/versions.py",
         ],
     ),
+    "rootly": SimplePulumiParams(
+        app_name="rootly",
+        pulumi_project_path="saas/rootly/",
+        pulumi_project_name="ol-saas-rootly",
+        stages=["Production"],
+    ),
     "starrocks": SimplePulumiParams(
         app_name="starrocks",
         pulumi_project_path="applications/starrocks/",


### PR DESCRIPTION
### What are the relevant tickets?
Relates to https://github.com/mitodl/ol-infrastructure/issues/4903

### Description (What does it do?)
Registers the `ol-saas-rootly` Pulumi stack (added in #4900) with the existing "simple Pulumi-only" Concourse meta pipeline, so Rootly infrastructure changes get a dedicated deploy pipeline instead of requiring manual `pulumi up` runs.

Changes:
- `src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py`: added a `"rootly"` entry to `pipeline_params`, pointing at `saas/rootly/` with Pulumi project name `ol-saas-rootly` and a single `Production` stage (the stack currently only defines `Pulumi.Production.yaml`).
- `src/ol_concourse/pipelines/infrastructure/simple_pulumi/meta.py`: added `"rootly"` to `production_app_names` so the meta pipeline generates and self-manages the new `pulumi-rootly` pipeline.

This follows the exact same pattern already used for other single-stage, Pulumi-only stacks in this fleet (`starburst`, `aws-sftp`, `monitoring`, `xpro-partner-dns`).

### How this behaves
- The generated pipeline watches `src/ol_infrastructure/saas/rootly/` plus the shared `src/ol_infrastructure/lib/`, `src/ol_infrastructure/components/`, and `src/bridge/secrets/` paths (the last of which already covers `src/bridge/secrets/rootly/`).
- Because the stack has only a `Production` stage, the pipeline follows the repo's existing safety convention for direct-to-production stacks: the git `get` step does **not** auto-trigger the deploy job. A human still has to manually trigger the `deploy-ol-saas-rootly-production` job in Concourse after reviewing the pending change, exactly like `starburst`/`aws-sftp`/`monitoring`/`xpro-partner-dns` today. This is intentional — none of the other direct-to-prod-only stacks in this pipeline auto-apply either.
- On successful deploy, a GitHub issue is opened via the existing `github_issues` put step, consistent with every other stack in this pipeline.

### How can this be tested?
From the repository root:

```bash
uv sync
uv run ruff check src/ol_concourse/pipelines/infrastructure/simple_pulumi/
uv run mypy src/ol_concourse/pipelines/infrastructure/simple_pulumi/
```

From `src/ol_concourse/pipelines/infrastructure/simple_pulumi/`:

```bash
python pipeline.py rootly
python -m json.tool definition.json > /dev/null && echo OK

python meta.py
python -m json.tool definition.json > /dev/null && echo OK
```

I ran all of the above locally. I also re-rendered `qdrant-cloud` and `starrocks` (the entries adjacent to the new `rootly` entry) to confirm they were unaffected.

Expected rendered `rootly` pipeline: one job `deploy-ol-saas-rootly-production`, a git resource watching the paths above, a `pulumi-provisioner` resource for `ol-saas-rootly`, and a GitHub-issue post-deploy notification resource.

### Additional Context
- Depends on the `ol-saas-rootly` Pulumi stack existing at `src/ol_infrastructure/saas/rootly/`, added in https://github.com/mitodl/ol-infrastructure/pull/4900.
- After merge, someone with `fly` access to the `pr-inf` Concourse target needs to re-apply the meta pipeline once so it picks up the new app:

```bash
cd src/ol_concourse/pipelines/infrastructure/simple_pulumi/
python meta.py
fly -t pr-inf sp -p simple-pulumi-meta -c definition.json
```

The meta pipeline is self-updating after that, so subsequent changes here will roll out automatically once the meta pipeline itself runs.

### Checklist:
- [ ] Merge https://github.com/mitodl/ol-infrastructure/pull/4900 first (or confirm `src/ol_infrastructure/saas/rootly/` already exists on `main`)
- [ ] Re-apply the `simple-pulumi-meta` pipeline on the `pr-inf` Concourse target after merge
