### PR TITLE
docs(rootly): document Concourse CI reproduction of upstream bridge bug

### DIFF
--- a/src/ol_infrastructure/saas/rootly/KNOWN_ISSUES.md
+++ b/src/ol_infrastructure/saas/rootly/KNOWN_ISSUES.md
@@ -35,6 +35,44 @@ Tracking issues:
 
 - Rootly provider: <https://github.com/rootlyhq/terraform-provider-rootly/issues/379>
 - Pulumi bridge: <https://github.com/pulumi/pulumi-terraform-bridge/issues/3514>
+- Internal follow-up (blocked by the two issues above): <https://github.com/mitodl/ol-infrastructure/issues/4906>
+
+## Concourse pipeline is currently non-functional
+
+The `pulumi-rootly` Concourse pipeline (added in
+[#4905](https://github.com/mitodl/ol-infrastructure/pull/4905)) exists and is wired
+up correctly, but the `deploy-ol-saas-rootly-production` job cannot currently
+complete a `pulumi up`. Triggering it reproduces the exact same upstream bug
+described above:
+
+```text
+pulumi:pulumi:Stack ol-saas-rootly-Production  warning: refresh operation is using an older version of package 'rootly' than the specified program version: 1.1.4 < 5.16.1
+...
+error: error calling ConfigureProvider: rpc error: code = Unavailable desc = error reading from server: EOF
+(repeated for every rootly:index resource in the stack)
+
+Resources:
+    2 unchanged
+    148 errored
+
+Duration: 1s
+```
+
+The shared `pulumi-provisioner` Concourse resource type (image
+`mitodl/concourse-pulumi-resource-provisioner`, source repo
+`mitodl/concourse-pulumi-resource`, currently **archived**) downloads the stock,
+unpatched Terraform bridge plugin at runtime and does not set
+`PULUMI_TERRAFORM_VERSION`. The local workaround above only exists on individual
+developer machines, not in the CI environment.
+
+**Decision:** we are intentionally not patching the shared
+`mitodl/concourse-pulumi-resource-provisioner` image, since it is used by every
+Pulumi pipeline in the fleet and its source repo is archived. Instead, this stack
+will remain manual-only (`pulumi up` from a developer machine with the patched
+bridge and `PULUMI_TERRAFORM_VERSION=1.5.0`) until the upstream issues are fixed.
+Follow-up tracked in
+[mitodl/ol-infrastructure#4906](https://github.com/mitodl/ol-infrastructure/issues/4906),
+which is blocked by the two upstream issues linked above.
 
 ## Imported resources
 


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/ol-infrastructure/issues/4906
Relates to https://github.com/mitodl/ol-infrastructure/issues/4903

### Description (What does it do?)
Docs-only update to `src/ol_infrastructure/saas/rootly/KNOWN_ISSUES.md` recording that the new `pulumi-rootly` Concourse pipeline (#4905) reproduces the same upstream `ConfigureProvider ... EOF` bug documented for local Pulumi runs.

Triggering `pulumi-rootly/deploy-ol-saas-rootly-production` in Concourse fails identically to the local repro:

```text
pulumi:pulumi:Stack ol-saas-rootly-Production  warning: refresh operation is using an older version of package 'rootly' than the specified program version: 1.1.4 < 5.16.1
...
error: error calling ConfigureProvider: rpc error: code = Unavailable desc = error reading from server: EOF
(repeated for every rootly:index resource in the stack)

Resources:
    2 unchanged
    148 errored
```

This happens because the shared `pulumi-provisioner` Concourse resource type (image `mitodl/concourse-pulumi-resource-provisioner`, source `mitodl/concourse-pulumi-resource`, currently archived) downloads the stock, unpatched Terraform bridge plugin at runtime and never sets `PULUMI_TERRAFORM_VERSION`.

Per team decision, we're not patching that shared fleet-wide image — it's used by every Pulumi pipeline, not just Rootly. This stack remains manual-only (`pulumi up` from a developer machine with the patched bridge) until the upstream issues are resolved.

Filed https://github.com/mitodl/ol-infrastructure/issues/4906 as a reminder, explicitly blocked by:
- https://github.com/rootlyhq/terraform-provider-rootly/issues/379
- https://github.com/pulumi/pulumi-terraform-bridge/issues/3514

### How can this be tested?
Docs-only change. Ran:

```bash
uv run pre-commit run --files src/ol_infrastructure/saas/rootly/KNOWN_ISSUES.md
```

All hooks passed (no code touched).

### Additional Context
No code changes, no Pulumi/Concourse state changes. This is purely recording what was already observed by manually triggering the job in Concourse.
