### PR TITLE
feat(local-dev): auto reload for mit-learn and mitxonline (Django + Next.js)

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -2,6 +2,15 @@
 # Run: tilt up
 # Docs: local-dev/README.md
 
+# Prune Tilt-built images/containers aggressively — the app images are
+# multi-GB, so stale builds eat disk fast.
+docker_prune_settings(
+    disable=False,
+    max_age_mins=720,     # anything older than 12h goes
+    num_builds=5,         # also prune every 5 image builds
+    keep_recent=2,        # always keep the 2 most recent tags per image
+)
+
 # ---------------------------------------------------------------------------
 # Developer configuration
 # ---------------------------------------------------------------------------

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -267,9 +267,11 @@ tilt up
 
 ### Live updates (Django apps)
 
-When a `.py` file changes in a checked-out app repo, Tilt syncs it directly into the running container without a rebuild. The granian/uwsgi process sees the change and reloads. This is typically sub-second.
+When a file changes in a checked-out app repo, Tilt syncs it directly into the running container without a rebuild (sub-second). granian runs with `--reload`, notices the change, and restarts its workers — the new code serves once Django finishes re-importing (roughly 10–30 s depending on the app). Watch for `Changes detected, reloading workers..` in the app logs.
 
-When `requirements.txt` changes, Tilt runs `pip install -r requirements.txt` inside the container and then restarts the process.
+This applies to the webapp (granian) containers. Celery workers and beat don't auto-reload — restart those resources from the Tilt UI after changing task code.
+
+When `pyproject.toml` or `uv.lock` changes, Tilt runs `uv sync` inside the container; granian then reloads as above.
 
 ### Pre-built image fallback
 

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -277,9 +277,13 @@ When `pyproject.toml` or `uv.lock` changes, Tilt runs `uv sync` inside the conta
 
 If an app repo is not cloned on your machine, Tilt uses the pre-built ECR image at the tag listed in `tilt_config.json` under `prebuilt_tags`. You can work on mit-learn without having learn-ai checked out.
 
-### Next.js rebuilds
+### Live updates (Next.js frontend)
 
-The Next.js frontend requires a **full Docker build** when source changes (because `NEXT_PUBLIC_*` env vars are baked in at compile time). Tilt will rebuild the image automatically but this is slow (~2–3 minutes). For active frontend development, consider running `yarn dev` locally against `https://api.learn.mit.dev`.
+With a mit-learn checkout, Tilt builds the `local-dev` stage of `Dockerfile.web`, which runs `next dev` (Turbopack). Source changes under `frontends/` are live-synced into the container and hot-reload in place — edit-to-served is roughly a second (the first request to each page after a pod start pays a one-time on-demand compile). HMR websockets are proxied through apisix, so the browser hot-updates on `https://learn.mit.dev` too. `NEXT_PUBLIC_*` values are runtime env vars (see `deployment.yaml`), not build args, so no rebuild is needed to change them — just edit and let Tilt redeploy.
+
+When `yarn.lock` changes, Tilt runs `yarn install` inside the container.
+
+Without a checkout, the prebuilt DockerHub image (production `runner` stage) serves instead; it does not hot-reload.
 
 ---
 

--- a/local-dev/apps/mit-learn-nextjs/Tiltfile
+++ b/local-dev/apps/mit-learn-nextjs/Tiltfile
@@ -1,12 +1,18 @@
 # mit-learn Next.js frontend Tiltfile
 #
-# NEXT_PUBLIC_* values are baked into the image at build time.
-# A change to any build arg or frontend source triggers a full image rebuild.
-# (Next.js production builds can't hot-reload without switching to `yarn dev`.)
+# Builds the `local-dev` stage of Dockerfile.web, which runs `next dev` (HMR).
+# Source changes are live-synced into the container; Next.js hot-reloads
+# them without an image rebuild or pod restart.
+#
+# NEXT_PUBLIC_* values are injected at runtime from deployment.yaml env vars
+# (surfaced to the browser via PublicEnvScript) — they are NOT build args.
+# next.config.js derives allowedDevOrigins from NEXT_PUBLIC_ORIGIN, so the
+# dev server accepts HMR requests proxied through learn.<root-domain>.
 #
 # The build context is the mit-learn repo root (needed for yarn workspaces).
 # When the sibling mit-learn repo is not checked out, Tilt uses the prebuilt
-# DockerHub image (mitodl/mit-learn-nextjs-app:latest) without a local build.
+# DockerHub image (mitodl/mit-learn-nextjs-app:latest) without a local build;
+# that image is the production `runner` stage (no hot reload).
 
 load("../../tiltlib.star", "k8s_yaml_with_domain")
 
@@ -21,44 +27,32 @@ if os.path.exists(os.path.join(APP_DIR, '.git')):
         IMAGE,
         context=APP_DIR,
         dockerfile=APP_DIR + '/frontends/main/Dockerfile.web',
-        build_args={
-            # Core — required by validateEnv.js
-            'NEXT_PUBLIC_ORIGIN': 'https://learn.{rd}'.format(rd=_rd),
-            'NEXT_PUBLIC_MITOL_API_BASE_URL': 'https://api.learn.{rd}'.format(rd=_rd),
-            'NEXT_PUBLIC_SITE_NAME': 'MIT Learn',
-            'NEXT_PUBLIC_MITOL_SUPPORT_EMAIL': 'mitlearn-support@mit.edu',
-            'NEXT_PUBLIC_CSRF_COOKIE_NAME': 'csrftoken',
-            'NEXT_PUBLIC_MITOL_AXIOS_WITH_CREDENTIALS': 'true',
-            'NEXT_PUBLIC_MITX_ONLINE_BASE_URL': 'https://mitxonline.{rd}'.format(rd=_rd),
-            'NEXT_PUBLIC_MITX_ONLINE_CSRF_COOKIE_NAME': 'csrf_mitxonline',
-
-            # AI endpoints (point to learn-ai local service)
-            'NEXT_PUBLIC_LEARN_AI_RECOMMENDATION_ENDPOINT':
-                'https://ai.learn.{rd}/api/v0/recommendations/'.format(rd=_rd),
-            'NEXT_PUBLIC_LEARN_AI_SYLLABUS_ENDPOINT':
-                'https://ai.learn.{rd}/api/v0/syllabus/'.format(rd=_rd),
-
-            # Optional — blank disables analytics/monitoring
-            'NEXT_PUBLIC_EMBEDLY_KEY': '',
-            'NEXT_PUBLIC_POSTHOG_API_KEY': '',
-            'NEXT_PUBLIC_POSTHOG_API_HOST': '',
-            'NEXT_PUBLIC_POSTHOG_UI_HOST': '',
-            'NEXT_PUBLIC_POSTHOG_PROJECT_ID': '',
-            'NEXT_PUBLIC_SENTRY_DSN': '',
-            'NEXT_PUBLIC_SENTRY_ENV': 'local',
-            'NEXT_PUBLIC_APPZI_URL': '',
-            'NEXT_PUBLIC_HUBSPOT_PORTAL_ID': '',
-            'NEXT_PUBLIC_VERSION': 'local',
-            'NEXT_PUBLIC_MITX_ONLINE_LEGACY_BASE_URL': 'https://mitxonline.{rd}'.format(rd=_rd),
-        },
-        # Rebuild when any frontend source or config changes.
-        # (Full rebuild is required; no incremental hot-reload in production mode.)
+        target='local-dev',
         only=[
             'frontends/',
             'package.json',
             '.yarnrc.yml',
             '.yarn/',
             'yarn.lock',
+        ],
+        # node_modules: host installs are OS/arch-specific and must not reach
+        # the container. .next: host build artifacts would fight the
+        # container's own dev-server cache.
+        ignore=[
+            '**/node_modules',
+            '**/.next',
+        ],
+        live_update=[
+            sync(os.path.join(APP_DIR, 'frontends'), '/app/frontends'),
+            sync(os.path.join(APP_DIR, 'package.json'), '/app/package.json'),
+            sync(os.path.join(APP_DIR, 'yarn.lock'), '/app/yarn.lock'),
+            # Reinstall node deps when the lockfile changes.
+            run(
+                'cd /app && yarn install --immutable',
+                trigger=[
+                    os.path.join(APP_DIR, 'yarn.lock'),
+                ],
+            ),
         ],
     )
 

--- a/local-dev/apps/mit-learn-nextjs/apisix-routes.yaml
+++ b/local-dev/apps/mit-learn-nextjs/apisix-routes.yaml
@@ -35,6 +35,8 @@ spec:
     backends:
     - serviceName: mitlearn-nextjs
       servicePort: 3000
+    # next dev HMR runs over a websocket; harmless for the production image.
+    websocket: true
     plugins:
     - name: response-rewrite
       enable: true

--- a/local-dev/apps/mit-learn-nextjs/deployment.yaml
+++ b/local-dev/apps/mit-learn-nextjs/deployment.yaml
@@ -1,9 +1,11 @@
 ---
 # mit-learn Next.js frontend Deployment
-# Runs the production Next.js server (yarn start) on port 3000.
-# NEXT_PUBLIC_* env vars are also validated at server startup, so they must be
-# present as runtime env vars (not only baked in as build args). See Tiltfile
-# for the matching build arg values used when building from a local checkout.
+# With a local checkout, Tilt builds the `local-dev` stage of Dockerfile.web
+# (`next dev`, hot reload); otherwise the prebuilt DockerHub image runs the
+# production standalone server. Both listen on port 3000.
+# NEXT_PUBLIC_* env vars are injected at runtime (PublicEnvScript) and
+# validated at server startup. NODE_ENV is deliberately NOT set here — each
+# image's own ENV (dev: development, runner: production) must win.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -33,8 +35,6 @@ spec:
           value: "3000"
         - name: HOSTNAME
           value: "0.0.0.0"
-        - name: NODE_ENV
-          value: "production"
         - name: NODE_EXTRA_CA_CERTS
           value: /etc/ssl/local-dev/rootCA.pem
             # Required by validateEnv at server startup.
@@ -59,16 +59,22 @@ spec:
         resources:
           requests:
             cpu: 100m
-            memory: 256Mi
+            memory: 512Mi
           limits:
-            memory: 1Gi
+            # next dev (turbopack) needs far more headroom than the
+            # production standalone server.
+            memory: 4Gi
         readinessProbe:
           httpGet:
             path: /
             port: 3000
           initialDelaySeconds: 15
           periodSeconds: 10
-          timeoutSeconds: 5
+          # First request to `next dev` triggers an on-demand compile that
+          # can take tens of seconds; readiness failures are benign and
+          # just delay traffic until the compile finishes.
+          timeoutSeconds: 60
+          failureThreshold: 20
         volumeMounts:
         - name: mkcert-root-ca
           mountPath: /etc/ssl/local-dev

--- a/local-dev/apps/mit-learn/Tiltfile
+++ b/local-dev/apps/mit-learn/Tiltfile
@@ -21,6 +21,9 @@ if os.path.exists(os.path.join(MIT_LEARN_DIR, ".git")):
         IMAGE,
         context=MIT_LEARN_DIR,
         dockerfile=os.path.join(MIT_LEARN_DIR, "Dockerfile"),
+        # local-dev target = final + a mitodl-owned /src so live-update syncs
+        # can write into the container.
+        target="local-dev",
         # Live update: sync source changes into the container; granian runs
         # with --reload (see deployment.yaml) and restarts workers on change.
         live_update=[

--- a/local-dev/apps/mit-learn/Tiltfile
+++ b/local-dev/apps/mit-learn/Tiltfile
@@ -21,8 +21,8 @@ if os.path.exists(os.path.join(MIT_LEARN_DIR, ".git")):
         IMAGE,
         context=MIT_LEARN_DIR,
         dockerfile=os.path.join(MIT_LEARN_DIR, "Dockerfile"),
-        # local-dev target = final + a mitodl-owned /src so live-update syncs
-        # can write into the container.
+        # local-dev target = development (dev deps included) + a mitodl-owned
+        # /src so live-update syncs can write into the container.
         target="local-dev",
         # Live update: sync source changes into the container; granian runs
         # with --reload (see deployment.yaml) and restarts workers on change.

--- a/local-dev/apps/mit-learn/Tiltfile
+++ b/local-dev/apps/mit-learn/Tiltfile
@@ -21,7 +21,8 @@ if os.path.exists(os.path.join(MIT_LEARN_DIR, ".git")):
         IMAGE,
         context=MIT_LEARN_DIR,
         dockerfile=os.path.join(MIT_LEARN_DIR, "Dockerfile"),
-        # Live update: sync Python source changes and trigger granian reload.
+        # Live update: sync source changes into the container; granian runs
+        # with --reload (see deployment.yaml) and restarts workers on change.
         live_update=[
             sync(
                 os.path.join(MIT_LEARN_DIR),
@@ -35,8 +36,6 @@ if os.path.exists(os.path.join(MIT_LEARN_DIR, ".git")):
                     os.path.join(MIT_LEARN_DIR, "uv.lock"),
                 ],
             ),
-            # Touch reload sentinel — granian watches for this.
-            run("touch /tmp/tilt-reload"),
         ],
     )
 

--- a/local-dev/apps/mit-learn/deployment.yaml
+++ b/local-dev/apps/mit-learn/deployment.yaml
@@ -107,9 +107,23 @@ spec:
         - "0.0.0.0"
         - --port
         - "8061"
+        # Single worker locally: reloads re-import Django once instead of
+        # twice competing for CPU, and ASGI handles dev concurrency fine.
         - --workers
-        - "2"
+        - "1"
         - --blocking-threads
+        - "1"
+        # Auto-reload on Tilt live-update syncs. Watches the working dir
+        # (/src); ignore dirs that churn without affecting Python.
+        - --reload
+        - --reload-ignore-dirs
+        - frontends
+        - --reload-ignore-dirs
+        - staticfiles
+        # App threads (e.g. onnxruntime) keep workers from stopping
+        # gracefully — every reload pays this full timeout before SIGKILL, so
+        # keep it short.
+        - --workers-kill-timeout
         - "1"
         - main.asgi:application
         ports:
@@ -134,14 +148,16 @@ spec:
           periodSeconds: 10
           failureThreshold: 6
           timeoutSeconds: 5
+        # Generous liveness: granian --reload makes /health/ hang while workers
+        # re-import Django after a live-update sync; don't kill mid-reload.
         livenessProbe:
           httpGet:
             path: /health/
             port: 8061
           initialDelaySeconds: 30
           periodSeconds: 30
-          failureThreshold: 3
-          timeoutSeconds: 5
+          failureThreshold: 10
+          timeoutSeconds: 10
         volumeMounts:
         - name: combined-ca
           mountPath: /etc/ssl/local-dev

--- a/local-dev/apps/mit-learn/deployment.yaml
+++ b/local-dev/apps/mit-learn/deployment.yaml
@@ -120,9 +120,9 @@ spec:
         - frontends
         - --reload-ignore-dirs
         - staticfiles
-        # App threads (e.g. onnxruntime) keep workers from stopping
-        # gracefully — every reload pays this full timeout before SIGKILL, so
-        # keep it short.
+        # Workers often fail to stop gracefully (cause undiagnosed; same
+        # symptom as granian#470) — every reload pays this full timeout
+        # before SIGKILL, so keep it short.
         - --workers-kill-timeout
         - "1"
         - main.asgi:application

--- a/local-dev/apps/mitxonline/Tiltfile
+++ b/local-dev/apps/mitxonline/Tiltfile
@@ -14,9 +14,8 @@ DEPLOY_NAME = 'mitxonline-webapp'
 if os.path.exists(os.path.join(APP_DIR, '.git')):
     # Build the `local-dev` target: `production` (the only target that bakes in
     # the compiled webpack frontend, which checkout needs since that flow still
-    # runs through mitxonline.mit.dev) plus watchfiles so granian can --reload
-    # (see deployment.yaml). No dev deps, so DEBUG must be False (see
-    # app-env.yaml) or the app crashes importing debug_toolbar.
+    # runs through mitxonline.mit.dev) plus dev deps (pytest, ipdb, ...) and
+    # watchfiles so granian can --reload (see deployment.yaml).
     docker_build(
         IMAGE,
         context=APP_DIR,
@@ -28,10 +27,10 @@ if os.path.exists(os.path.join(APP_DIR, '.git')):
         live_update=[
             sync(APP_DIR, '/src'),
             # Reinstall deps on pyproject.toml/uv.lock change (uv, not pip;
-            # --no-dev matches the production image; --inexact keeps the
-            # image's extra watchfiles install).
+            # dev deps included, matching the local-dev image; --inexact keeps
+            # the image's extra watchfiles install).
             run(
-                'cd /src && uv sync --frozen --no-dev --inexact',
+                'cd /src && uv sync --frozen --inexact',
                 trigger=[APP_DIR + '/pyproject.toml', APP_DIR + '/uv.lock'],
             ),
         ],

--- a/local-dev/apps/mitxonline/Tiltfile
+++ b/local-dev/apps/mitxonline/Tiltfile
@@ -12,24 +12,26 @@ NAMESPACE = 'mitxonline'
 DEPLOY_NAME = 'mitxonline-webapp'
 
 if os.path.exists(os.path.join(APP_DIR, '.git')):
-    # Build the `production` target: it's the only one that bakes in the
-    # compiled webpack frontend (`COPY --from=node`), which checkout needs since
-    # that flow still runs through mitxonline.mit.dev. `production` has no dev
-    # deps, so DEBUG must be False (see app-env.yaml) or the app crashes
-    # importing debug_toolbar. No Python hot-reload yet (granian has no
-    # --reload); synced source changes need a rebuild/restart.
+    # Build the `local-dev` target: `production` (the only target that bakes in
+    # the compiled webpack frontend, which checkout needs since that flow still
+    # runs through mitxonline.mit.dev) plus watchfiles so granian can --reload
+    # (see deployment.yaml). No dev deps, so DEBUG must be False (see
+    # app-env.yaml) or the app crashes importing debug_toolbar.
     docker_build(
         IMAGE,
         context=APP_DIR,
-        target='production',
+        target='local-dev',
         dockerfile=APP_DIR + '/Dockerfile',
+        # Sync the whole repo: Django apps are top-level dirs (courses,
+        # ecommerce, cms, ...). granian's --reload-ignore-dirs filters the
+        # non-Python churn.
         live_update=[
-            sync(APP_DIR + '/mitxonline', '/src/mitxonline'),
-            sync(APP_DIR + '/main', '/src/main'),
+            sync(APP_DIR, '/src'),
             # Reinstall deps on pyproject.toml/uv.lock change (uv, not pip;
-            # --no-dev matches the production image).
+            # --no-dev matches the production image; --inexact keeps the
+            # image's extra watchfiles install).
             run(
-                'cd /src && uv sync --frozen --no-dev',
+                'cd /src && uv sync --frozen --no-dev --inexact',
                 trigger=[APP_DIR + '/pyproject.toml', APP_DIR + '/uv.lock'],
             ),
         ],

--- a/local-dev/apps/mitxonline/Tiltfile
+++ b/local-dev/apps/mitxonline/Tiltfile
@@ -12,6 +12,12 @@ NAMESPACE = 'mitxonline'
 DEPLOY_NAME = 'mitxonline-webapp'
 
 if os.path.exists(os.path.join(APP_DIR, '.git')):
+    # Build the `production` target: it's the only one that bakes in the
+    # compiled webpack frontend (`COPY --from=node`), which checkout needs since
+    # that flow still runs through mitxonline.mit.dev. `production` has no dev
+    # deps, so DEBUG must be False (see app-env.yaml) or the app crashes
+    # importing debug_toolbar. No Python hot-reload yet (granian has no
+    # --reload); synced source changes need a rebuild/restart.
     docker_build(
         IMAGE,
         context=APP_DIR,
@@ -20,9 +26,11 @@ if os.path.exists(os.path.join(APP_DIR, '.git')):
         live_update=[
             sync(APP_DIR + '/mitxonline', '/src/mitxonline'),
             sync(APP_DIR + '/main', '/src/main'),
+            # Reinstall deps on pyproject.toml/uv.lock change (uv, not pip;
+            # --no-dev matches the production image).
             run(
-                'cd /src && pip install -r requirements.txt',
-                trigger=[APP_DIR + '/requirements.txt'],
+                'cd /src && uv sync --frozen --no-dev',
+                trigger=[APP_DIR + '/pyproject.toml', APP_DIR + '/uv.lock'],
             ),
         ],
     )

--- a/local-dev/apps/mitxonline/configmaps/app-env.yaml
+++ b/local-dev/apps/mitxonline/configmaps/app-env.yaml
@@ -10,7 +10,9 @@ data:
   MITXONLINE_DOCKER_BASE_URL: "https://mitxonline.mit.dev"
   MITX_ONLINE_DB_DISABLE_SSL: "True"
   MITX_ONLINE_USE_S3: "False"
-  DEBUG: "True"
+  # Must stay False: the production image (see Tiltfile) has no dev deps, so
+  # DEBUG=True would import debug_toolbar → boot crash.
+  DEBUG: "False"
   ALLOWED_HOSTS: "*"
   USE_X_FORWARDED_HOST: "True"
   USE_X_FORWARDED_PORT: "True"

--- a/local-dev/apps/mitxonline/deployment.yaml
+++ b/local-dev/apps/mitxonline/deployment.yaml
@@ -238,12 +238,14 @@ spec:
             name: mitxonline-env
         - secretRef:
             name: mitxonline-secrets
+        # beat loads the full Django app like the worker, so give it comparable
+        # memory headroom — it OOMs with less.
         resources:
           requests:
             cpu: 50m
-            memory: 128Mi
-          limits:
             memory: 256Mi
+          limits:
+            memory: 1Gi
         volumeMounts:
         - name: combined-ca
           mountPath: /etc/ssl/local-dev

--- a/local-dev/apps/mitxonline/deployment.yaml
+++ b/local-dev/apps/mitxonline/deployment.yaml
@@ -59,16 +59,20 @@ spec:
         image: mitodl/mitxonline-app:latest
         imagePullPolicy: IfNotPresent
         command:
-        - granian
-        - --interface
-        - wsgi
-        - --host
-        - 0.0.0.0
-        - --port
-        - "8011"
-        - --workers
-        - "2"
-        - main.wsgi:application
+        - sh
+        - -c
+        # Auto-reload on Tilt live-update syncs, but only when the image has
+        # watchfiles (the Tilt-built local-dev target does; the prebuilt
+        # DockerHub image used without a sibling checkout doesn't). Watches the
+        # working dir (/src); ignore dirs that churn without affecting Python.
+        - |
+          if python -c 'import watchfiles' 2>/dev/null; then
+            # --workers-kill-timeout: force-kill workers whose app threads
+            # keep them from stopping gracefully, so reloads don't hang.
+            # Every reload pays this full timeout, so keep it short.
+            RELOAD_ARGS="--reload --reload-ignore-dirs frontend --reload-ignore-dirs static --reload-ignore-dirs staticfiles --workers-kill-timeout 1"
+          fi
+          exec granian --interface wsgi --host 0.0.0.0 --port 8011 --workers 2 $RELOAD_ARGS main.wsgi:application
         ports:
         - containerPort: 8011
           name: http-wsgi


### PR DESCRIPTION
### What are the relevant tickets?

None

### Description (What does it do?)

Makes code changes hot-reload in the local-dev Tilt stack instead of requiring image rebuilds or pod restarts:

- **Django apps (mit-learn, mitxonline):** Tilt live-syncs source into the running container and granian runs with `--reload` plus a short `--workers-kill-timeout` (workers often never finish a graceful stop — same symptom as emmett-framework/granian#470 — so without the timeout, reloads can hang indefinitely). Edit-to-served is ~9 s for mit-learn (floor is its Django import time, primarily LLM-related libs) and ~4–6 s for mitxonline.
- **mit-learn Next.js frontend:** builds the new `local-dev` stage of `Dockerfile.web` (`next dev`/Turbopack) with source live-sync, and enables websockets on the `learn.<domain>` apisix route so HMR works in the browser. Edit-to-served is ~1 s, replacing a 2–3 min full image rebuild per change. Also removes the Tiltfile's `NEXT_PUBLIC_*` build-args block — those values are runtime env (PublicEnvScript) and the args were never consumed.
- **mitxonline local-dev fixes:** boots cleanly on the production image (DEBUG default, beat memory limit).
- **Housekeeping:** `docker_prune_settings` in the root Tiltfile bounds Tilt-built image disk usage (12 h max age, always keeping the 2 most recent per image).

Production manifests and images are untouched; all changes are under `local-dev/` (plus the root Tiltfile prune settings).

### How can this be tested?

**Prerequisite:* Checkout sibling PRs in mit-learn and mitxonline repos:
- https://github.com/mitodl/mit-learn/pull/3579
- https://github.com/mitodl/mitxonline/pull/3736

1. `./local-dev/scripts/start.sh` (or `tilt up`) and wait for resources to go green.
2. **Django reload:** add a `print()` to any mit-learn Python file. Within ~10 s the app logs show `Changes detected, reloading workers..` and the change is live at `https://api.learn.mit.dev` — no pod restart in `kubectl get pods -n mit-learn`.
3. **Frontend HMR:** open `https://learn.mit.dev`, edit visible text in `frontends/main/src/app/(site)/page.tsx` — the browser hot-updates in about a second without a reload.
4. **mitxonline:** same as step 2 against `https://mitxonline.mit.dev` (~5 s).
5. **Fallback path:** with a sibling repo not checked out, Tilt should fall back to the prebuilt DockerHub image (production behavior, no hot reload).

### Additional Context

This PR depends on companion changes in the app repos (mitodl/mit-learn#3579, mitodl/mitxonline#3736): a `local-dev` Docker target in mit-learn's and mitxonline's Dockerfiles (runtime-user-owned `/src` so Tilt syncs can write; production stages byte-identical to today), a `local-dev` stage in mit-learn's `frontends/main/Dockerfile.web`, and a `--workers-kill-timeout` in mit-learn's `run-django-dev.sh`. Without them, Tilt's local builds fail on the missing build stages — merge the companion PRs first.


### Checklist:
- [ ] Merge companion mit-learn and mitxonline Dockerfile PRs first

 

🤖+🧑‍🦱 Generated partly [Claude Code](https://claude.com/claude-code), partly by Chris


