### PR TITLE
fix(edxapp): add CORS rules to grades bucket

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -339,6 +339,17 @@ edxapp_grades_bucket_config = S3BucketConfig(
     block_public_policy=False,
     ignore_public_acls=False,
     restrict_public_buckets=False,
+    # The instructor dashboard MFE fetches report files from this bucket via
+    # XHR, which requires the bucket to allow cross-origin requests from the
+    # edxapp domains.
+    cors_rules=[
+        s3.BucketCorsConfigurationCorsRuleArgs(
+            allowed_headers=["*"],
+            allowed_methods=["GET", "HEAD"],
+            allowed_origins=[f"https://{domain}" for domain in edxapp_domains.values()],
+            max_age_seconds=3000,
+        )
+    ],
 )
 edxapp_grades_bucket = OLBucket(
     "edxapp-grades-s3-bucket",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11866

### Description (What does it do?)
The instructor dashboard MFE (installed via frontend-base) downloads grade report files by fetching the presigned S3 URL via an authenticated XHR rather than a top-level navigation. Because the grades bucket had no CORS configuration, the browser's preflight request was rejected with no Access-Control-Allow-Origin header, blocking the download.

Add cors_rules to the grades bucket, allowing GET/HEAD from the edxapp domains, mirroring the existing storage bucket configuration.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?

- The Download Reports button on the instructor dashboard MFE should work without a CORS error on RC.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
