### PR TITLE
use ol keycloak theme for local dev

### DIFF
--- a/local-dev/infra/modules/keycloak.py
+++ b/local-dev/infra/modules/keycloak.py
@@ -57,7 +57,7 @@ def create_olapps_dev_realm(  # noqa: PLR0913
         display_name="MIT Learn",
         display_name_html="<b>MIT Learn</b>",
         enabled=True,
-        email_theme="ol",
+        email_theme="ol-learn",
         login_theme="ol-learn",
         duplicate_emails_allowed=False,
         otp_policy=keycloak.RealmOtpPolicyArgs(

--- a/local-dev/infra/modules/keycloak.py
+++ b/local-dev/infra/modules/keycloak.py
@@ -57,6 +57,8 @@ def create_olapps_dev_realm(  # noqa: PLR0913
         display_name="MIT Learn",
         display_name_html="<b>MIT Learn</b>",
         enabled=True,
+        email_theme="ol",
+        login_theme="ol-learn",
         duplicate_emails_allowed=False,
         otp_policy=keycloak.RealmOtpPolicyArgs(
             algorithm="HmacSHA256",


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Use ol keycloak theme during local dev.

### Screenshots (if appropriate):
<img width="1045" height="764" alt="Screenshot 2026-07-07 at 9 14 13 AM" src="https://github.com/user-attachments/assets/ecb84358-f303-416b-a80f-6935ccdba931" />


### How can this be tested?
1. ./local-dev/scripts/start.sh

Try logging into learn at learn.mit.dev

### Additional Context
