### PR TITLE
fix(external-dns): add httproute hostnames to annotation

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.applications.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.applications.CI.yaml
@@ -13,6 +13,8 @@ config:
   - .mitxonline.mit.edu
   - xpro.mit.edu
   - .xpro.mit.edu
+  - mitx.mit.edu
+  - .mitx.mit.edu
   eks:backup: false
   eks:apisix_admin_key:
     secure: v1:sDse8RY8sLFEsPSE:8jqIrqb4BJHNipDXmbh4KXpVrAUUOmiLEV4aKjXqhIr2RvFqOks4pVz+km0wF1hh

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.applications.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.applications.CI.yaml
@@ -27,14 +27,20 @@ config:
   - courses-backend.ci.learn.mit.edu
   - courses-backend.ci.xpro.mit.edu
   - dcc.ci.learn.mit.edu
+  - meilisearch-ci.mitx.mit.edu
+  - meilisearch-ci.xpro.mit.edu
+  - meilisearch-staging-ci.mitx.mit.edu
+  - meilisearch.courses.ci.learn.mit.edu
   - micromasters-ci-backend.odl.mit.edu
   - nb.ci.learn.mit.edu
+  - ocw-studio-ci.odl.mit.edu
   - preview-backend.ci.learn.mit.edu
   - preview-backend.ci.xpro.mit.edu
   - studio-backend.ci.learn.mit.edu
   - studio-backend.ci.xpro.mit.edu
   - tika-ci.ol.mit.edu
   - video-ci.odl.mit.edu
+  - xpro-ci.odl.mit.edu
   eks:developer_role_policy_name: AmazonEKSClusterAdminPolicy
   eks:developer_role_kubernetes_groups:
   - admin

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.applications.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.applications.Production.yaml
@@ -28,14 +28,20 @@ config:
   - courses-backend.learn.mit.edu
   - courses-backend.xpro.mit.edu
   - dcc.learn.mit.edu
+  - meilisearch-staging.mitx.mit.edu
+  - meilisearch.courses.learn.mit.edu
+  - meilisearch.mitx.mit.edu
+  - meilisearch.xpro.mit.eduA
   - micromasters-backend.odl.mit.edu
   - nb.learn.mit.edu
+  - ocw-studio.odl.mit.edu
   - preview-backend.learn.mit.edu
   - preview.xpro.mit.edu
   - studio-backend.learn.mit.edu
   - studio-backend.xpro.mit.edu
   - tika-production.ol.mit.edu
   - video.odl.mit.edu
+  - xpro-web.odl.mit.edu
   eks:apisix_min_replicas: '5'
   eks:apisix_max_replicas: '10'
   eks:apisix_memory: 1500Mi

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.applications.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.applications.Production.yaml
@@ -31,7 +31,7 @@ config:
   - meilisearch-staging.mitx.mit.edu
   - meilisearch.courses.learn.mit.edu
   - meilisearch.mitx.mit.edu
-  - meilisearch.xpro.mit.eduA
+  - meilisearch.xpro.mit.edu
   - micromasters-backend.odl.mit.edu
   - nb.learn.mit.edu
   - ocw-studio.odl.mit.edu

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.applications.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.applications.Production.yaml
@@ -13,6 +13,8 @@ config:
   - .mitxonline.mit.edu
   - xpro.mit.edu
   - .xpro.mit.edu
+  - mitx.mit.edu
+  - .mitx.mit.edu
   eks:backup: true
   eks:apisix_admin_key:
     secure: v1:PafPE9cAPNoOSOrU:8V16zZH9OGc1jgfZffXRDLvb6ROksZLULaYJvdjHgPCG/zmB/8nA8EMZb8X2/O74

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.applications.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.applications.QA.yaml
@@ -13,6 +13,8 @@ config:
   - .mitxonline.mit.edu
   - xpro.mit.edu
   - .xpro.mit.edu
+  - mitx.mit.edu
+  - .mitx.mit.edu
   eks:apisix_memory: 1500Mi
   eks:backup: false
   eks:apisix_admin_key:

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.applications.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.applications.QA.yaml
@@ -27,14 +27,20 @@ config:
   - courses-backend.rc.learn.mit.edu
   - courses-backend.rc.xpro.mit.edu
   - dcc.rc.learn.mit.edu
+  - meilisearch-mitx-qa-draft.mitx.mit.edu
+  - meilisearch-mitx-qa.mitx.mit.edu
+  - meilisearch-rc.xpro.mit.edu
+  - meilisearch.courses.rc.learn.mit.edu
   - micromasters-rc-backend.odl.mit.edu
   - nb.rc.learn.mit.edu
+  - ocw-studio-rc.odl.mit.edu
   - preview-backend.rc.learn.mit.edu
   - preview-rc.xpro.mit.edu
   - studio-backend.rc.learn.mit.edu
   - studio-backend.rc.xpro.mit.edu
   - tika-qa.ol.mit.edu
   - video-rc.odl.mit.edu
+  - xpro-rc.odl.mit.edu
   eks:developer_role_policy_name: AmazonEKSClusterAdminPolicy
   eks:developer_role_kubernetes_groups:
   - admin


### PR DESCRIPTION


### What are the relevant tickets?
None

### Description (What does it do?)
added meilisearch, xpro-web, and ocw-studio domains to the apisix service annotation.

> Cheaper targeted mitigation: move these four hostnames onto the apisix gateway Service's external-dns.alpha.kubernetes.io/hostname annotation like the other 17 apisix-hosted domains, so they're sourced from the Service instead of route status
