### PR TITLE
feat(toolhive): register toolhive stacks in simple-pulumi meta pipeline

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/README.md
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/README.md
@@ -26,7 +26,11 @@ The following applications are currently managed by this meta pipeline:
 10. **opensearch** - OpenSearch search and analytics cluster
 11. **tika** - Apache Tika document processing service
 12. **vector-log-proxy** - Vector log proxy service
-13. **xpro-partner-dns** - xPRO partner DNS configuration
+13. **toolhive-apps** - ToolHive application-agent MCP workloads namespace bootstrap
+14. **toolhive-data** - ToolHive data-agent MCP workloads namespace bootstrap
+15. **toolhive-operator** - ToolHive Kubernetes operator (Helm charts on the ops EKS cluster)
+16. **toolhive-swe** - ToolHive SWE-agent MCP workloads (VirtualMCPServer, Redis, ingress, Vault wiring)
+17. **xpro-partner-dns** - xPRO partner DNS configuration
 
 ## Files
 

--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/meta.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/meta.py
@@ -209,6 +209,10 @@ if __name__ == "__main__":
         "starrocks-substructure",
         "starburst",
         "tika",
+        "toolhive-apps",
+        "toolhive-data",
+        "toolhive-operator",
+        "toolhive-swe",
         "vector-log-proxy",
         "xpro-partner-dns",
     ]

--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
@@ -324,7 +324,6 @@ pipeline_params: dict[str, SimplePulumiParams] = {
         app_name="toolhive-operator",
         pulumi_project_path="applications/toolhive_operator/",
         pulumi_project_name="ol-application-toolhive-operator",
-        additional_watched_paths=["src/bridge/lib/versions.py"],
     ),
     "toolhive-swe": SimplePulumiParams(
         app_name="toolhive-swe",

--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
@@ -310,6 +310,27 @@ pipeline_params: dict[str, SimplePulumiParams] = {
         pulumi_project_path="applications/tika/",
         pulumi_project_name="ol-application-tika",
     ),
+    "toolhive-apps": SimplePulumiParams(
+        app_name="toolhive-apps",
+        pulumi_project_path="applications/toolhive_apps/",
+        pulumi_project_name="ol-application-toolhive-apps",
+    ),
+    "toolhive-data": SimplePulumiParams(
+        app_name="toolhive-data",
+        pulumi_project_path="applications/toolhive_data/",
+        pulumi_project_name="ol-application-toolhive-data",
+    ),
+    "toolhive-operator": SimplePulumiParams(
+        app_name="toolhive-operator",
+        pulumi_project_path="applications/toolhive_operator/",
+        pulumi_project_name="ol-application-toolhive-operator",
+        additional_watched_paths=["src/bridge/lib/versions.py"],
+    ),
+    "toolhive-swe": SimplePulumiParams(
+        app_name="toolhive-swe",
+        pulumi_project_path="applications/toolhive_swe/",
+        pulumi_project_name="ol-application-toolhive-swe",
+    ),
     "vector-log-proxy": SimplePulumiParams(
         app_name="vector-log-proxy",
         pulumi_project_path="infrastructure/vector_log_proxy/",

--- a/src/ol_infrastructure/applications/toolhive_apps/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/toolhive_apps/Pulumi.Production.yaml
@@ -1,0 +1,5 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-production
+encryptedkey: AQICAHjksIVfl1VtAHpBda/1YYjj6tSeS2o4TXgvEEyBIXLjjwGwVBUtUw0KMvuqry+NktV4AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM08E+AlT0k2qn3BuzAgEQgDuv0px7bY/FGMyFBzFkeNs/rMz3qqnIw4Y2OsSFUDZ/NmtYUS+mDjvPVW7FTwRFme0COGVadPrFE2+esw==
+config:
+  aws:region: us-east-1

--- a/src/ol_infrastructure/applications/toolhive_apps/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/toolhive_apps/Pulumi.QA.yaml
@@ -1,0 +1,5 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-qa
+encryptedkey: AQICAHjE+jMY5DL7M1LMYX6YgtMueHEDNg05lsdN5Z0zeGHyJgGT9vIHmhnJQOAucs9E443gAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMoE5tOO80MHjF946PAgEQgDvGQKu/IFzuzv3TeTF2PLbXe991bmfd0isGdcs9xPGthKkWsY+uT+9r0s+Rn5HnlAzxGdqdGQDMsXGd0g==
+config:
+  aws:region: us-east-1

--- a/src/ol_infrastructure/applications/toolhive_data/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/toolhive_data/Pulumi.Production.yaml
@@ -1,0 +1,5 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-production
+encryptedkey: AQICAHjksIVfl1VtAHpBda/1YYjj6tSeS2o4TXgvEEyBIXLjjwGjqtawJYpGRf0TfVYfjErnAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM/YoQniBmHOhKft/rAgEQgDu3NcyJ2+RGCX2+c2kw/JmXrZqhSK0OZW0kKancbwrBx2SYXoASHX898sHHcggKacPIw+LmoX6WyBrcOg==
+config:
+  aws:region: us-east-1

--- a/src/ol_infrastructure/applications/toolhive_data/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/toolhive_data/Pulumi.QA.yaml
@@ -1,0 +1,5 @@
+---
+secretsprovider: awskms://alias/infrastructure-secrets-qa
+encryptedkey: AQICAHjE+jMY5DL7M1LMYX6YgtMueHEDNg05lsdN5Z0zeGHyJgEqJtWEZWhO9lFitV4Iz60fAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMlJVeBCPMVNLuqg5KAgEQgDsDTKH05j18C3PcaOM1fjS1k9hqx9brJKZFj+2GG/hmj6VIhGO/N3fgsBxtyq6tl7pScja4rMyWaaA9vg==
+config:
+  aws:region: us-east-1


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)

Adds four ToolHive Pulumi projects to the `simple_pulumi` meta pipeline so Concourse automatically manages their CI/CD pipelines:

- **toolhive-operator** — deploys the ToolHive Kubernetes operator (Helm charts) on the ops EKS cluster. Watches `src/bridge/lib/versions.py` in addition to the standard Pulumi paths because its `__main__.py` imports from `bridge.lib.versions`.
- **toolhive-apps** — bootstraps the `toolhive-apps` namespace for application-agent MCP workloads (CI/QA/Production).
- **toolhive-data** — bootstraps the `toolhive-data` namespace for data-agent MCP workloads (CI/QA/Production).
- **toolhive-swe** — deploys SWE-agent MCP workloads (VirtualMCPServer, Redis, ingress, Vault wiring). Registered with CI/QA/Production stages now; the `Pulumi.QA.yaml` and `Pulumi.Production.yaml` stack config files are on a separate branch awaiting approval and will be picked up once that branch merges.

Also includes the `Pulumi.QA.yaml` and `Pulumi.Production.yaml` stack config files for `toolhive_apps` and `toolhive_data`, which were missing.

### How can this be tested?

The pipeline generation can be verified locally:

```bash
# From repo root
python src/ol_concourse/pipelines/infrastructure/simple_pulumi/meta.py
python src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py toolhive-operator
python src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py toolhive-apps
python src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py toolhive-data
python src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py toolhive-swe
```

All four should produce valid `definition.json` output without errors. After merge, the `set-simple-pulumi-meta-pipeline` job in Concourse will pick up the change and register the four new `pulumi-toolhive-*` pipelines automatically.