### PR TITLE
fix(concourse): stop worker self-terminate loop, diversify spot capacity

### DIFF
--- a/src/bilder/images/concourse/files/concourse-worker-preflight
+++ b/src/bilder/images/concourse/files/concourse-worker-preflight
@@ -9,7 +9,7 @@
 # concourse.service via [Unit] Requires=/After= (worker units only).
 set -uo pipefail
 
-RETRY_BUDGET_SECONDS=${RETRY_BUDGET_SECONDS:-180}
+RETRY_BUDGET_SECONDS=${RETRY_BUDGET_SECONDS:-600}
 RETRY_INTERVAL_SECONDS=${RETRY_INTERVAL_SECONDS:-10}
 METADATA_BASE="http://169.254.169.254/latest/meta-data"
 TOKEN_URL="http://169.254.169.254/latest/api/token"

--- a/src/bilder/images/concourse/files/concourse-worker-preflight.service
+++ b/src/bilder/images/concourse/files/concourse-worker-preflight.service
@@ -11,4 +11,4 @@ Type=oneshot
 RemainAfterExit=no
 ExecStart=/usr/local/bin/concourse-worker-preflight
 # Bounded by the script's own internal retry budget; leave headroom above it.
-TimeoutStartSec=240
+TimeoutStartSec=660

--- a/src/bilder/images/concourse/files/concourse-worker-reaper
+++ b/src/bilder/images/concourse/files/concourse-worker-reaper
@@ -84,30 +84,33 @@ ADMIN_PASS=${LOCAL_USER_LINE#*:}
 # in ~/.flyrc, so the steady-state cost across the 3-minute timer is one cheap
 # `workers` probe rather than a full login round-trip each run.
 if ! "${FLY_BIN}" -t "${FLY_TARGET}" workers >/dev/null 2>&1; then
-    if ! "${FLY_BIN}" -t "${FLY_TARGET}" login \
-            -c "${ATC_URL}" -u "${ADMIN_USER}" -p "${ADMIN_PASS}" -n main >/dev/null 2>&1; then
-        fail "fly login to ${ATC_URL} failed; aborting (fail-closed)"
-    fi
+    login_err=$("${FLY_BIN}" -t "${FLY_TARGET}" login \
+            -c "${ATC_URL}" -u "${ADMIN_USER}" -p "${ADMIN_PASS}" -n main 2>&1 >/dev/null) \
+        || fail "fly login to ${ATC_URL} failed; aborting (fail-closed): ${login_err}"
 fi
 
-# --- Gather ground truth: private IPs of all live worker instances --------
-# Worker names default to the EC2 hostname (e.g. "ip-10-1-2-3"), which encodes
-# the private IPv4 address. We compare each stalled worker's name against the
-# set of live worker instance IPs.
+# --- Gather ground truth: live worker instance IDs and IPs ----------------
+# CONCOURSE_NAME is pinned to the EC2 instance ID (see cloud-init runcmd in
+# ol_infrastructure/applications/concourse/__main__.py), so a stalled worker's
+# name should already be an instance ID -- match it directly against live
+# instances instead of parsing an IP out of it. Older workers that registered
+# before that change (or that fell back to the default IP-derived hostname
+# because the boot-time IMDS call failed) are still matched by IP as a
+# fallback.
 #
 # Only "pending" and "running" count as live: an instance in stopping/
 # shutting-down is on its way out and will never host a recovering worker, so a
 # stalled worker pinned to it should be pruned, not preserved.
-LIVE_IPS=$(aws ec2 describe-instances \
+LIVE_INSTANCES=$(aws ec2 describe-instances \
     --region "${AWS_REGION}" \
     --filters "Name=tag:Name,Values=${WORKER_NAME_TAG}" \
               "Name=instance-state-name,Values=pending,running" \
-    --query 'Reservations[].Instances[].PrivateIpAddress' \
+    --query 'Reservations[].Instances[].[InstanceId,PrivateIpAddress]' \
     --output text 2>/dev/null) || fail "describe-instances failed; aborting (fail-closed)"
 
-# Normalize whitespace into a newline-delimited set for matching.
-LIVE_IP_SET=$(echo "${LIVE_IPS}" | tr '[:space:]' '\n' | grep -v '^$' || true)
-LIVE_COUNT=$(echo "${LIVE_IP_SET}" | grep -c . || true)
+LIVE_ID_SET=$(echo "${LIVE_INSTANCES}" | awk '{print $1}' | grep -v '^$' || true)
+LIVE_IP_SET=$(echo "${LIVE_INSTANCES}" | awk '{print $2}' | grep -v '^$' || true)
+LIVE_COUNT=$(echo "${LIVE_ID_SET}" | grep -c . || true)
 log "Found ${LIVE_COUNT} live worker instance(s) in ${AWS_REGION}"
 
 # --- Identify stalled workers and prune the orphans -----------------------
@@ -124,25 +127,30 @@ skipped=0
 while IFS= read -r worker_name; do
     [ -n "${worker_name}" ] || continue
 
-    # Derive the private IP encoded in the hostname-style worker name.
-    # "ip-10-1-2-3" -> "10.1.2.3". Names that don't match are left alone.
-    if [[ "${worker_name}" =~ ^ip-([0-9]+)-([0-9]+)-([0-9]+)-([0-9]+) ]]; then
+    if [[ "${worker_name}" =~ ^i-[0-9a-f]+$ ]]; then
+        # Instance-ID-style name (current format): check membership directly.
+        if echo "${LIVE_ID_SET}" | grep -qxF "${worker_name}"; then
+            log "Worker '${worker_name}' instance still live; leaving stalled worker to recover"
+            skipped=$((skipped + 1))
+            continue
+        fi
+        log "Worker '${worker_name}' has no live instance; pruning"
+    elif [[ "${worker_name}" =~ ^ip-([0-9]+)-([0-9]+)-([0-9]+)-([0-9]+) ]]; then
+        # Legacy IP-derived hostname (pre-CONCOURSE_NAME-pin, or IMDS lookup
+        # failed at boot): derive the private IP and check that instead.
         worker_ip="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}.${BASH_REMATCH[4]}"
+        if echo "${LIVE_IP_SET}" | grep -qxF "${worker_ip}"; then
+            log "Worker '${worker_name}' (${worker_ip}) instance still live; leaving stalled worker to recover"
+            skipped=$((skipped + 1))
+            continue
+        fi
+        log "Worker '${worker_name}' (${worker_ip}) has no live instance; pruning"
     else
-        log "Worker '${worker_name}' name is not IP-derived; skipping (cannot verify instance)"
+        log "Worker '${worker_name}' name is neither an instance ID nor IP-derived; skipping (cannot verify instance)"
         skipped=$((skipped + 1))
         continue
     fi
 
-    if echo "${LIVE_IP_SET}" | grep -qxF "${worker_ip}"; then
-        # Instance still exists -> worker is partitioned, not dead. Leave it;
-        # it will reconnect and recover its cache for free.
-        log "Worker '${worker_name}' (${worker_ip}) instance still live; leaving stalled worker to recover"
-        skipped=$((skipped + 1))
-        continue
-    fi
-
-    log "Worker '${worker_name}' (${worker_ip}) has no live instance; pruning"
     if "${FLY_BIN}" -t "${FLY_TARGET}" prune-worker -w "${worker_name}" >/dev/null 2>&1; then
         pruned=$((pruned + 1))
     elif ! "${FLY_BIN}" -t "${FLY_TARGET}" workers --json \

--- a/src/bilder/images/concourse/templates/vector/concourse_logs.yaml
+++ b/src/bilder/images/concourse/templates/vector/concourse_logs.yaml
@@ -7,6 +7,7 @@ sources:
     - concourse-worker-spot-watch
     - concourse-worker-lifecycle-hook
     - concourse-worker-reaper
+    - concourse-worker-preflight
 
 transforms:
   parse_concourse_logs:

--- a/src/ol_infrastructure/applications/concourse/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/concourse/Pulumi.Production.yaml
@@ -39,6 +39,12 @@ config:
     - pulumi_state
     instance_type: m7a.2xlarge
     name: ocw
+    spot_options:
+      instance_type_overrides:
+      - m7i.2xlarge
+      - m6a.2xlarge
+      - m5a.2xlarge
+      - m5.2xlarge
     use_spot_instances: true
   - auto_scale:
       desired: 4
@@ -59,6 +65,12 @@ config:
     - pulumi_state
     instance_type: m7a.4xlarge
     name: infra
+    spot_options:
+      instance_type_overrides:
+      - m7i.4xlarge
+      - m6a.4xlarge
+      - m5a.4xlarge
+      - m5.4xlarge
     use_spot_instances: true
   - auto_scale:
       desired: 4
@@ -75,6 +87,12 @@ config:
     - pulumi_state
     instance_type: m7a.xlarge
     name: generic
+    spot_options:
+      instance_type_overrides:
+      - m7i.xlarge
+      - m6a.xlarge
+      - m5a.xlarge
+      - m5.xlarge
     use_spot_instances: true
   consul:address: https://consul-operations-production.odl.mit.edu
   vault:address: https://vault-production.odl.mit.edu

--- a/src/ol_infrastructure/applications/concourse/__main__.py
+++ b/src/ol_infrastructure/applications/concourse/__main__.py
@@ -730,6 +730,10 @@ for worker_def in concourse_config.get_object("workers") or []:
             instance_interruption_behavior=spot_config.get(
                 "instance_interruption_behavior", "terminate"
             ),
+            instance_type_overrides=spot_config.get("instance_type_overrides"),
+            spot_allocation_strategy=spot_config.get(
+                "spot_allocation_strategy", "price-capacity-optimized"
+            ),
         )
 
     ol_worker_launch_config = OLLaunchTemplateConfig(

--- a/src/ol_infrastructure/components/aws/auto_scale_group.py
+++ b/src/ol_infrastructure/components/aws/auto_scale_group.py
@@ -7,6 +7,11 @@ from pulumi_aws.autoscaling import (
     GroupInstanceRefreshArgs,
     GroupInstanceRefreshPreferencesArgs,
     GroupLaunchTemplateArgs,
+    GroupMixedInstancesPolicyArgs,
+    GroupMixedInstancesPolicyInstancesDistributionArgs,
+    GroupMixedInstancesPolicyLaunchTemplateArgs,
+    GroupMixedInstancesPolicyLaunchTemplateLaunchTemplateSpecificationArgs,
+    GroupMixedInstancesPolicyLaunchTemplateOverrideArgs,
     GroupTagArgs,
 )
 from pulumi_aws.ec2 import (
@@ -79,6 +84,19 @@ class SpotInstanceOptions(BaseModel):
     instance_interruption_behavior: Literal["hibernate", "stop", "terminate"] = (
         "terminate"
     )
+    # Additional instance types (same rough vCPU/memory class as the launch
+    # template's primary instance_type) that the ASG may substitute in when the
+    # primary type has no spot capacity in a given AZ. When set, the ASG uses a
+    # MixedInstancesPolicy instead of a flat single-type spot request, so a
+    # capacity shortfall in one instance type/family no longer stalls capacity
+    # or drives repeated failed-launch retries.
+    instance_type_overrides: list[str] | None = None
+    spot_allocation_strategy: Literal[
+        "lowest-price",
+        "capacity-optimized",
+        "capacity-optimized-prioritized",
+        "price-capacity-optimized",
+    ] = "price-capacity-optimized"
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @field_validator("spot_instance_type")
@@ -98,6 +116,22 @@ class SpotInstanceOptions(BaseModel):
             msg = f"instance_interruption_behavior: {behavior} is not valid. Only 'hibernate', 'stop', or 'terminate' are accepted."  # noqa: E501
             raise ValueError(msg)
         return behavior
+
+    @field_validator("instance_type_overrides")
+    @classmethod
+    def is_valid_instance_type_overrides(
+        cls, instance_type_overrides: list[str] | None
+    ) -> list[str] | None:
+        """Validate that each override is a real, launchable instance type."""
+        for instance_type in instance_type_overrides or []:
+            if not is_valid_instance_type(instance_type):
+                msg = (
+                    f"instance_type_overrides: {instance_type} is not a valid "
+                    "specifier. Refer to https://instances.vantage.sh/ to find a "
+                    "supported instance type."
+                )
+                raise ValueError(msg)
+        return instance_type_overrides
 
 
 class OLTargetGroupConfig(AWSBase):
@@ -451,8 +485,17 @@ class OLAutoScaling(pulumi.ComponentResource):
             "opts": resource_options,
         }
 
-        # Configure spot instances if requested
-        if lt_config.use_spot_instances:
+        # Configure spot instances if requested. Diversifying across instance
+        # types (instance_type_overrides) requires a MixedInstancesPolicy on the
+        # Group instead of a flat spot request on the launch template itself --
+        # the two are mutually exclusive, so the spot market options only get
+        # set here for the single-instance-type case.
+        use_mixed_instances_policy = bool(
+            lt_config.use_spot_instances
+            and lt_config.spot_options
+            and lt_config.spot_options.instance_type_overrides
+        )
+        if lt_config.use_spot_instances and not use_mixed_instances_policy:
             spot_options_config = lt_config.spot_options or SpotInstanceOptions()
             spot_options_kwargs: dict[str, str] = {
                 "spot_instance_type": spot_options_config.spot_instance_type,
@@ -493,15 +536,47 @@ class OLAutoScaling(pulumi.ComponentResource):
         auto_scale_group_kwargs = {}
         if self.target_group:
             auto_scale_group_kwargs["target_group_arns"] = [self.target_group.arn]
+
+        if use_mixed_instances_policy:
+            mixed_spot_options = lt_config.spot_options
+            assert mixed_spot_options is not None  # noqa: S101
+            assert mixed_spot_options.instance_type_overrides is not None  # noqa: S101
+            overrides = [
+                GroupMixedInstancesPolicyLaunchTemplateOverrideArgs(
+                    instance_type=instance_type
+                )
+                for instance_type in [
+                    lt_config.instance_type,
+                    *mixed_spot_options.instance_type_overrides,
+                ]
+            ]
+            auto_scale_group_kwargs["mixed_instances_policy"] = (
+                GroupMixedInstancesPolicyArgs(
+                    launch_template=GroupMixedInstancesPolicyLaunchTemplateArgs(
+                        launch_template_specification=GroupMixedInstancesPolicyLaunchTemplateLaunchTemplateSpecificationArgs(
+                            launch_template_id=self.launch_template.id,
+                            version="$Latest",
+                        ),
+                        overrides=overrides,
+                    ),
+                    instances_distribution=GroupMixedInstancesPolicyInstancesDistributionArgs(
+                        on_demand_percentage_above_base_capacity=0,
+                        spot_allocation_strategy=mixed_spot_options.spot_allocation_strategy,
+                        spot_max_price=mixed_spot_options.max_price,
+                    ),
+                )
+            )
+        else:
+            auto_scale_group_kwargs["launch_template"] = GroupLaunchTemplateArgs(
+                id=self.launch_template.id,
+                version="$Latest",
+            )
+
         self.auto_scale_group = Group(
             f"{resource_name_prefix}auto-scale-group",
             desired_capacity=asg_config.desired_size,
             health_check_type=asg_config.health_check_type,
             instance_refresh=instance_refresh_policy,
-            launch_template=GroupLaunchTemplateArgs(
-                id=self.launch_template.id,
-                version="$Latest",
-            ),
             max_size=asg_config.max_size,
             min_size=asg_config.min_size,
             max_instance_lifetime=asg_config.max_instance_lifetime_seconds,


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)

Production's Concourse worker fleet has been rapidly cycling. Root-caused this by cross-referencing Grafana Cloud (Loki/Prometheus) against `aws autoscaling describe-scaling-activities` and CloudTrail:

- **`concourse-worker-preflight` (added in #4871) is self-terminating the fleet.** It's a oneshot unit that gates `concourse.service` via `Requires=`/`After=`, checking reachability to GitHub/Docker Hub/S3/IMDS before a worker registers with the TSA. If checks don't pass within its retry budget, it calls `aws autoscaling set-instance-health --health-status Unhealthy` against itself. CloudTrail showed **61 self-issued `SetInstanceHealth(Unhealthy)` calls in 75 minutes**, each from a distinct instance ID, spread across every worker pool (`ocw`/`infra`/`generic`) and every environment (production/qa/ci) — consistent with a boot-time race (most likely DNS/Consul-forwarding not yet ready when the checks run) rather than a real network fault. Widened `RETRY_BUDGET_SECONDS` 180s → 600s (and the matching systemd `TimeoutStartSec`) to give that race room to clear, while leaving the actual safety check (and its ability to self-terminate a genuinely broken instance) intact.
- **`concourse-worker-preflight` was never wired into log shipping**, so none of the above was visible in Grafana until pulled from CloudTrail directly. `templates/vector/concourse_logs.yaml`'s journald `include_units` allowlist had `concourse-worker-spot-watch`/`concourse-worker-lifecycle-hook`/`concourse-worker-reaper` but not `concourse-worker-preflight` — added it.
- **`concourse-worker-reaper` has never once succeeded** since it was introduced (~3 weeks of logs show zero successful runs, only repeated `fly login ... failed; aborting (fail-closed)` every 3 minutes on every web node). It was swallowing the actual login error, so there was no way to diagnose it — now captures and logs it. Independently, its stalled-worker → EC2-instance matching only understood the old `ip-a-b-c-d` hostname-derived worker name; `CONCOURSE_NAME` was pinned to the EC2 instance ID in #4871, so even a working reaper would skip every stalled worker as "cannot verify instance." Now matches instance-ID-style names directly against `describe-instances`, keeping the old IP-based match as a fallback for any lingering legacy-named workers.
- **Compounding the above**, the worker ASGs were also hitting genuine `m7a.xlarge` spot capacity exhaustion in `us-east-1a`/`us-east-1b` ("There is no Spot capacity available that matches your request" / "insufficient m7a.xlarge capacity"), so every preflight-triggered replacement was also fighting for scarce capacity. Added `instance_type_overrides` support to `SpotInstanceOptions`/`OLAutoScaleGroupConfig` (`ol_infrastructure/components/aws/auto_scale_group.py`): when set, the ASG uses a `MixedInstancesPolicy` (`spot_allocation_strategy=price-capacity-optimized`, pure spot) with same vCPU/RAM-class alternates instead of a flat single-type spot request. Wired up for all three production worker pools:
  - `generic` (`m7a.xlarge`): + `m7i.xlarge`, `m6a.xlarge`, `m5a.xlarge`, `m5.xlarge`
  - `infra` (`m7a.4xlarge`): + `m7i.4xlarge`, `m6a.4xlarge`, `m5a.4xlarge`, `m5.4xlarge`
  - `ocw` (`m7a.2xlarge`): + `m7i.2xlarge`, `m6a.2xlarge`, `m5a.2xlarge`, `m5.2xlarge`

### How can this be tested?

- `uv run pre-commit run --all-files` and `uv run mypy` pass.
- `pulumi preview --stack Production` against `ol_infrastructure/applications/concourse` shows only in-place updates (12 to update, 116 unchanged) — no resource replacement. The worker launch templates drop `instanceMarketOptions` (moved to the ASG-level `mixedInstancesPolicy`), each worker ASG gains a `mixedInstancesPolicy` block with 5 instance type overrides.
- After merge/deploy, watch CloudTrail for `SetInstanceHealth` calls from worker instance roles and Loki for `concourse-worker-preflight` logs to confirm the self-terminate rate drops; watch `aws autoscaling describe-scaling-activities` for the worker ASGs to confirm launches start succeeding across the diversified instance types instead of failing on `m7a.xlarge` alone.

### Additional Context

The AMI rebuild needed to pick up the preflight/reaper script and vector config changes goes through the existing Concourse Packer/Pulumi pipeline as usual.