### PR TITLE
fix(local-dev): OOM limits, mitxonline auth, and postgres CREATEDB

### DIFF
--- a/local-dev/apps/mit-learn-nextjs/deployment.yaml
+++ b/local-dev/apps/mit-learn-nextjs/deployment.yaml
@@ -62,8 +62,10 @@ spec:
             memory: 512Mi
           limits:
             # next dev (turbopack) needs far more headroom than the
-            # production standalone server.
-            memory: 4Gi
+            # production standalone server. 4Gi OOM-killed the pod during
+            # on-demand page compiles; measured peak over ~21h of use is
+            # ~4.3Gi (avg ~3.6Gi), so 6Gi clears the transient spikes.
+            memory: 6Gi
         readinessProbe:
           httpGet:
             path: /

--- a/local-dev/apps/mitxonline/configmaps/app-env.yaml
+++ b/local-dev/apps/mitxonline/configmaps/app-env.yaml
@@ -37,6 +37,14 @@ data:
   KEYCLOAK_REALM_NAME: "olapps"
   KEYCLOAK_DISCOVERY_URL: "https://sso.ol.mit.dev/realms/olapps/.well-known/openid-configuration"
 
+  # Enable the APISIX user middleware: it reads the X-Userinfo header APISIX
+  # injects and authenticates (and auto-creates) the Django user. Defaults to
+  # True (disabled), which leaves every request anonymous. Production sets this.
+  MITOL_APIGATEWAY_DISABLE_MIDDLEWARE: "false"
+  # Required for Django's CSRF origin check on POSTs behind HTTPS (e.g. the
+  # admin login form); defaults to empty, which rejects them with DEBUG=False.
+  CSRF_TRUSTED_ORIGINS: "https://mitxonline.mit.dev,https://learn.mit.dev"
+
   # Valkey
   REDIS_URL: "redis://valkey.local-infra.svc.cluster.local:6379/0"
   CELERY_BROKER_URL: "redis://valkey.local-infra.svc.cluster.local:6379/1"

--- a/local-dev/infra/modules/database.py
+++ b/local-dev/infra/modules/database.py
@@ -75,6 +75,10 @@ def create_database(
                     "owner": "app",
                     "secret": {"name": "pg-app-credentials"},
                     "postInitSQL": [
+                        # Django test runners (and pytest-django) create and
+                        # drop a throwaway test database, which requires the
+                        # app role to have the CREATEDB privilege.
+                        "ALTER ROLE app CREATEDB;",
                         "CREATE DATABASE mitlearn OWNER app;",
                         "CREATE DATABASE learnai OWNER app;",
                         "CREATE DATABASE mitxonline OWNER app;",

--- a/local-dev/infra/modules/ingress.py
+++ b/local-dev/infra/modules/ingress.py
@@ -163,7 +163,10 @@ def create_ingress(
                         },
                     },
                     "resources": {
-                        "limits": {"memory": "512Mi"},
+                        # 512Mi OOM-kills APISIX under active OIDC load (JWKS
+                        # cache + sessions), crash-looping the gateway and
+                        # dropping all app auth. 1Gi gives headroom.
+                        "limits": {"memory": "1Gi"},
                     },
                     "autoscaling": {"enabled": False},
                     "replicaCount": 1,


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Several fixes shaken out of running the local-dev stack:

- **Memory limits — stop OOM kills.**
  - mit-learn Next.js dev pod (`next dev` / turbopack): limit **4Gi → 6Gi**. 4Gi was OOM-killed during on-demand page compiles. The 6Gi value is backed by ~21h of sampled memory logs showing a **peak of ~4.3Gi** (avg ~3.6Gi), so 6Gi clears the transient compile spikes without over-allocating.
  - APISIX: limit **512Mi → 1Gi**. 512Mi OOM-killed the gateway under active OIDC load (JWKS cache + sessions), crash-looping it and dropping all app auth.
- **mitxonline auth behind APISIX.** Enable the APISIX user middleware (`MITOL_APIGATEWAY_DISABLE_MIDDLEWARE=false`) so mitxonline authenticates and auto-creates the Django user from the `X-Userinfo` header APISIX injects (otherwise every request is anonymous). Add `CSRF_TRUSTED_ORIGINS` so Django's CSRF origin check accepts HTTPS POSTs (e.g. the admin login form) under `DEBUG=False`.
- **postgres `CREATEDB`.** Add `ALTER ROLE app CREATEDB;` to the CNPG cluster's `postInitSQL` so Django/pytest can create throwaway test databases. Note: `postInitSQL` runs only at initial cluster bootstrap, so existing clusters need a one-off `ALTER ROLE app CREATEDB;` — already applied to the shared dev cluster.

### How can this be tested?
- `pulumi preview` on the core stack shows no unexpected changes (the APISIX limit and `postInitSQL` already match live state).
- postgres: `kubectl exec -n local-infra local-pg-1 -c postgres -- psql -U postgres -tAc "select rolcreatedb from pg_roles where rolname='app';"` returns `t`, then a Django test run (which creates a test DB) succeeds.
- mitxonline: log in and open Django admin behind the gateway — auth resolves the user and admin POSTs are not CSRF-rejected.
- memory: the 6Gi value comes from ~21h of sampled `kubectl top` logs (peak ~4.3Gi); confirm the `next dev` pod no longer OOMs under page compiles.