### PR TITLE
feat(edxapp): speed up Canvas due-date sync on mitx-qa to every 5 min

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -533,6 +533,17 @@ def create_k8s_configmaps(  # noqa: PLR0915
         )
         cms_general_config_content["SEGMENT_IO"] = False
 
+    # TEMPORARY (mitx-qa testing): speed up Canvas due-date sync from the
+    # plugin's hourly default to every 5 minutes so Canvas changes appear
+    # quickly in Studio. Revert once Canvas due-date testing is complete.
+    if stack_info.env_prefix == "mitx" and stack_info.env_suffix == "qa":
+        cms_general_config_content["CELERYBEAT_SCHEDULE"] = {
+            "sync_canvas_due_dates": {
+                "task": "ol_openedx_canvas_integration.cms_tasks.sync_canvas_due_dates_for_all_courses",
+                "schedule": 300,  # seconds; 5 minutes (plugin default is hourly)
+            },
+        }
+
     cms_general_config_content["FEATURES"] = cms_features
 
     cms_general_config_map = kubernetes.core.v1.ConfigMap(


### PR DESCRIPTION
### What are the relevant tickets?
Closes mitodl/hq#12250

### Description (What does it do?)
Reduces the Celery beat interval for the Canvas due-date sync task (`sync_canvas_due_dates`) from hourly to **every 5 minutes on mitx-qa**, so that changes made in Canvas appear quickly in Studio/LMS while testing the Canvas due-date feature (previously each change could take up to an hour).

The `ol_openedx_canvas_integration` plugin registers this task as a **common CMS setting** with a hardcoded hourly schedule (`crontab(minute=0)`). Because the environment YAML config is applied *after* the plugin's common settings in `production.py`, an infra-side override in the CMS config wins.

Implementation notes:
- The override is added to `cms_general_config_content` in `src/ol_infrastructure/applications/edxapp/k8s_configmaps.py`, which renders to the **CMS-only** `71-cms-general-config.yaml` (the sync task is a CMS task, `cms_tasks.sync_canvas_due_dates_for_all_courses`).
- It is gated on `stack_info.env_prefix == "mitx" and stack_info.env_suffix == "qa"` so only the **mitx QA** stack is affected — CI, Production, and all other deployments are untouched.
- `schedule` is expressed as an integer number of seconds (`300`) rather than a `crontab(...)` object, since YAML config cannot hold a Python object. This matches the existing `mitxonline` `send-email-digest` entry that uses `86400`.
- This is a **temporary testing aid** — the block is commented as such and should be reverted (and `pulumi up` re-run on mitx-qa) once Canvas due-date testing is complete.

### How can this be tested?
1. Run `pre-commit run --files src/ol_infrastructure/applications/edxapp/k8s_configmaps.py` — ruff, mypy, and secret checks pass.
2. `pulumi preview` on the mitx QA stack: confirm only the CMS general ConfigMap (`ol-mitx-edxapp-cms-general-config-qa`) changes and that `71-cms-general-config.yaml` gains a `CELERYBEAT_SCHEDULE` block with `sync_canvas_due_dates` / `schedule: 300`. Confirm the mitx Production and CI stacks show **no** change.
3. After deploy on mitx-qa: confirm the aggregated `cms.env.yaml` contains `sync_canvas_due_dates` with `schedule: 300`, that the CMS celery-beat worker fires the task every ~5 minutes, and that a Canvas due-date change then appears in Studio/LMS within ~5 minutes.

### Additional Context
Temporary override for QA testing only. Remove the `if stack_info.env_prefix == "mitx" and stack_info.env_suffix == "qa":` block once testing is finished to restore the plugin's hourly default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)