### PR TITLE
feat(toolhive-swe): add Sentry MCP server (Production-only singleton)

### DIFF
--- a/src/bridge/lib/versions.py
+++ b/src/bridge/lib/versions.py
@@ -123,3 +123,7 @@ TOOLHIVE_OPERATOR_CRDS_CHART_VERSION = "0.33.0"
 TOOLHIVE_OPERATOR_CHART_VERSION = "0.33.0"
 # renovate: datasource=docker depName=mcp-grafana packageName=grafana/mcp-grafana
 MCP_GRAFANA_VERSION = "0.17.0"
+# ToolHive-built npx wrapper image for the Sentry MCP server (getsentry/sentry-mcp
+# self-hosted stdio mode). Tag tracks the dockyard build, not the upstream npm pkg.
+# renovate: datasource=docker depName=sentry-mcp-server packageName=ghcr.io/stacklok/dockyard/npx/sentry-mcp-server
+MCP_SENTRY_VERSION = "0.33.0"

--- a/src/ol_infrastructure/applications/toolhive_swe/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/applications/toolhive_swe/Pulumi.CI.yaml
@@ -27,3 +27,4 @@ config:
   toolhive_swe:grafana_url: https://mitolci.grafana.net
   toolhive_swe:grafana_service_account_token:
     secure: v1:6nOO1ObT6BhUYNC1:OETprMCV7BkNd72WQoV/wRuGLf/CtJUQXEfJvtsMzJL6HXoQPJPhM7K1/pRuYurI6f5h33cqWqp8ZikkxNs=
+  toolhive_swe:sentry_enabled: "false"

--- a/src/ol_infrastructure/applications/toolhive_swe/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/toolhive_swe/Pulumi.Production.yaml
@@ -14,3 +14,6 @@ config:
   toolhive_swe:grafana_url: https://mitolproduction.grafana.net
   toolhive_swe:grafana_service_account_token:
     secure: v1:qzYhhpp9dkOXST4d:nFgCTwLveiwghgDBAraaLsba+iqjsBJJbGhLKTdssBQF4LYsDVN/muwUfyg7UlyzAsyi+XeLv1X071pg4bw=
+  toolhive_swe:sentry_access_token:
+    secure: v1:8DW5qflxWxj4BQzn:GEH2+DWnOZeI6RIVQ4Ay4+8pwq8kFSEvFopN4OX2XdRx4oDIF/3MUTexIHwUpRMbOWDeZdaXvFYeTN0NcZzELDW079XoEfDvz1KoGJ1LlkM1dSwrigkz
+  toolhive_swe:sentry_enabled: "true"

--- a/src/ol_infrastructure/applications/toolhive_swe/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/toolhive_swe/Pulumi.QA.yaml
@@ -14,3 +14,4 @@ config:
     secure: v1:DT4oahHPicgz9/25:K2N/xob7w5ON8IZwsikDgZSKMk4rmIUKCxhT9PzIFbUYD/lBKEt6xCXVQJox5VcUUXd7ewMp0RCpFWks
   toolhive_swe:redis_password:
     secure: v1:iAmaEthWNJkVv4v5:7ZrIcEmmxyAyRkotl3aJ0Xe8XO1uEJ/79ZyN3HtfgB4AZXuSEFi4jt2iKYSfgIhomXnc1iNlTVChxKp2
+  toolhive_swe:sentry_enabled: "false"

--- a/src/ol_infrastructure/applications/toolhive_swe/mcp_servers.py
+++ b/src/ol_infrastructure/applications/toolhive_swe/mcp_servers.py
@@ -16,7 +16,7 @@ from typing import NamedTuple
 import pulumi_kubernetes as kubernetes
 from pulumi import Config, ResourceOptions, StackReference
 
-from bridge.lib.versions import MCP_GRAFANA_VERSION
+from bridge.lib.versions import MCP_GRAFANA_VERSION, MCP_SENTRY_VERSION
 from ol_infrastructure.lib.pulumi_helper import StackInfo
 
 # Name shared by the MCPGroup and every backend/virtual server that references it.
@@ -27,6 +27,11 @@ MCP_GROUP_NAME = "swe-tools"
 # ``spec.secrets`` -> ``targetEnvName`` mechanism.
 GRAFANA_TOKEN_SECRET_NAME = "toolhive-swe-grafana-token"  # noqa: S105  # pragma: allowlist secret
 GRAFANA_TOKEN_SECRET_KEY = "token"  # noqa: S105  # pragma: allowlist secret
+
+# K8s Secret holding the Sentry user auth token, materialised from encrypted stack
+# config and injected into the sentry MCPServer the same way as the Grafana token.
+SENTRY_TOKEN_SECRET_NAME = "toolhive-swe-sentry-token"  # noqa: S105  # pragma: allowlist secret
+SENTRY_TOKEN_SECRET_KEY = "token"  # noqa: S105  # pragma: allowlist secret
 
 
 class ToolhiveSWEMCPServers(NamedTuple):
@@ -171,7 +176,88 @@ def create_mcp_servers(
         opts=ResourceOptions(depends_on=[swe_mcpgroup, grafana_token_secret]),
     )
 
+    servers = [fetch_mcpserver, grafana_mcpserver]
+
+    # Sentry MCP server (https://github.com/getsentry/sentry-mcp) running in its
+    # self-hosted ``stdio`` mode via ToolHive's prebuilt npx wrapper image; the
+    # operator's proxy exposes it over streamable-http like the other backends.
+    # Every user acts as the one Sentry user auth token, so scope that token's
+    # permissions accordingly (least privilege) — see the grafana note above.
+    #
+    # Gated behind a per-stack boolean so it only runs where explicitly enabled
+    # (currently Production only). When disabled neither the token Secret nor the
+    # MCPServer is created, so lower stacks don't need a ``sentry_access_token``:
+    #   pulumi config set toolhive_swe:sentry_enabled true
+    #   pulumi config set --secret toolhive_swe:sentry_access_token -- <token>
+    # ``SENTRY_HOST`` is only needed for self-hosted Sentry; left unset we default
+    # to the SaaS host (sentry.io). Set it via config to point at a self-hosted
+    # install:
+    #   pulumi config set toolhive_swe:sentry_host sentry.example.com
+    if toolhive_swe_config.get_bool("sentry_enabled") or False:
+        sentry_token_secret = kubernetes.core.v1.Secret(
+            f"toolhive-swe-sentry-token-secret-{stack_info.env_suffix}",
+            metadata=kubernetes.meta.v1.ObjectMetaArgs(
+                name=SENTRY_TOKEN_SECRET_NAME,
+                namespace=namespace,
+                labels=k8s_global_labels,
+            ),
+            type="Opaque",
+            string_data={
+                SENTRY_TOKEN_SECRET_KEY: toolhive_swe_config.require_secret(
+                    "sentry_access_token"
+                ),
+            },
+            opts=ResourceOptions(),
+        )
+        sentry_env = []
+        sentry_host = toolhive_swe_config.get("sentry_host")
+        if sentry_host:
+            sentry_env.append({"name": "SENTRY_HOST", "value": sentry_host})
+        sentry_mcpserver = kubernetes.apiextensions.CustomResource(
+            f"toolhive-swe-sentry-mcpserver-{stack_info.env_suffix}",
+            api_version="toolhive.stacklok.dev/v1beta1",
+            kind="MCPServer",
+            metadata=kubernetes.meta.v1.ObjectMetaArgs(
+                name="sentry",
+                namespace=namespace,
+                labels=k8s_global_labels,
+            ),
+            spec={
+                "image": (
+                    "ghcr.io/stacklok/dockyard/npx/sentry-mcp-server:"
+                    f"{MCP_SENTRY_VERSION}"
+                ),
+                # Self-hosted sentry-mcp only speaks stdio; the ToolHive proxy wraps
+                # it and fronts it with streamable-http on proxyPort (no mcpPort for
+                # stdio).
+                "transport": "stdio",
+                "proxyPort": 8080,
+                "groupRef": {"name": MCP_GROUP_NAME},
+                "env": sentry_env,
+                "secrets": [
+                    {
+                        "name": SENTRY_TOKEN_SECRET_NAME,
+                        "key": SENTRY_TOKEN_SECRET_KEY,
+                        "targetEnvName": "SENTRY_ACCESS_TOKEN",
+                    }
+                ],
+                # Needs outbound access to the Sentry API. Tighten to an allow-list
+                # profile (sentry.io + .sentry.io, port 443) once the builtin
+                # profile proves out.
+                "permissionProfile": {
+                    "type": "builtin",
+                    "name": "network",
+                },
+                "resources": {
+                    "requests": {"cpu": "50m", "memory": "128Mi"},
+                    "limits": {"cpu": "200m", "memory": "256Mi"},
+                },
+            },
+            opts=ResourceOptions(depends_on=[swe_mcpgroup, sentry_token_secret]),
+        )
+        servers.append(sentry_mcpserver)
+
     return ToolhiveSWEMCPServers(
         group=swe_mcpgroup,
-        servers=[fetch_mcpserver, grafana_mcpserver],
+        servers=servers,
     )

--- a/src/ol_infrastructure/applications/toolhive_swe/mcp_servers.py
+++ b/src/ol_infrastructure/applications/toolhive_swe/mcp_servers.py
@@ -193,7 +193,7 @@ def create_mcp_servers(
     # to the SaaS host (sentry.io). Set it via config to point at a self-hosted
     # install:
     #   pulumi config set toolhive_swe:sentry_host sentry.example.com
-    if toolhive_swe_config.get_bool("sentry_enabled") or False:
+    if toolhive_swe_config.get_bool("sentry_enabled"):
         sentry_token_secret = kubernetes.core.v1.Secret(
             f"toolhive-swe-sentry-token-secret-{stack_info.env_suffix}",
             metadata=kubernetes.meta.v1.ObjectMetaArgs(


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Adds a **Sentry MCP server** backend to the `toolhive-swe` MCPGroup. It runs the
[getsentry/sentry-mcp](https://github.com/getsentry/sentry-mcp) server in its
self-hosted `stdio` mode via ToolHive's prebuilt npx wrapper image
(`ghcr.io/stacklok/dockyard/npx/sentry-mcp-server`), and the operator's proxy
fronts it over streamable-http like the other backends (fetch, grafana).

Details:
- New `MCP_SENTRY_VERSION` pin in `src/bridge/lib/versions.py` (Renovate-tracked
  against the dockyard npx image).
- The Sentry user auth token is materialised from encrypted stack config into a
  K8s Secret and injected as `SENTRY_ACCESS_TOKEN`, mirroring how the Grafana
  token is wired.
- `SENTRY_HOST` is optional (defaults to SaaS `sentry.io`); set
  `toolhive_swe:sentry_host` to point at a self-hosted install.
- Creation is gated behind a per-stack `sentry_enabled` boolean. When disabled,
  neither the token Secret nor the MCPServer is created, so lower stacks don't
  need a `sentry_access_token`. CI and QA are set to `false`; Production is
  `true`.

> **Note:** Sentry is a **singleton** at this time — it exists and runs **only in
> the Production stack**. CI and QA have `sentry_enabled: "false"` and provision
> no Sentry resources.

### How can this be tested?
- `pulumi preview` on the CI/QA stacks should show **no** Sentry Secret or
  MCPServer resources (gate is `false`).
- `pulumi preview` on the Production stack should show the
  `toolhive-swe-sentry-token` Secret and a `sentry` MCPServer being created.
- After deploy to Production, confirm the `sentry` MCPServer becomes healthy and
  is reachable through the ToolHive proxy within the `swe-tools` group.

### Additional Context
Every user shares the single Sentry user auth token, so that token's scopes
should be kept least-privilege. The MCPServer currently uses the builtin
`network` permission profile for outbound Sentry API access; this can be
tightened to an allow-list (sentry.io + .sentry.io, port 443) once it proves out.
