### PR TITLE
fix(concourse): pull grader base image locally instead of via buildkit ECR auth

### DIFF
--- a/src/ol_concourse/pipelines/open_edx/grader_images/build_pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/grader_images/build_pipeline.py
@@ -12,12 +12,14 @@ Triggers:
   - New digest of the Docker Hub grader base image (base image rebuilt /
     security patch applied).
 
-The base image digest is resolved at build time by reading the ``repository``
-and ``digest`` files that Concourse's ``registry-image`` resource writes for
-every fetched image.  The resolved ``repo@sha256:…`` reference is injected
-into the Docker build as ``GRADER_BASE_IMAGE`` via a shell wrapper around the
-``oci-build-task``'s ``build`` script so that the build layer cache is
-correctly invalidated and the published image records the exact base used.
+The base image is fetched by Concourse's ``registry-image`` resource (using its
+own IAM-based ECR auth) in ``oci`` format, producing a local ``image.tar``.
+That tarball is preloaded into the build via ``oci-build-task``'s
+``IMAGE_ARG_GRADER_BASE_IMAGE`` parameter, so buildkit resolves the
+Dockerfile's ``FROM ${GRADER_BASE_IMAGE}`` from local disk instead of pulling
+it from ECR itself.  buildkit has no ECR credentials of its own, so a live
+pull returns 401 Unauthorized even though the ``registry-image`` get step,
+which authenticates via the worker's IAM role, succeeds.
 """
 
 import dataclasses
@@ -86,12 +88,12 @@ def grader_image_pipeline(config: GraderPipelineConfig) -> Pipeline:
 
     The pipeline contains a single build job that:
       1. Watches the grader repo for new commits (trigger).
-      2. Watches the grader base image on DockerHub for updates (trigger).
-      3. Builds the Dockerfile in the root of the grader repo.  A shell
-         wrapper reads the ``repository`` and ``digest`` files written by the
-         ``registry-image`` resource and sets ``BUILD_ARG_GRADER_BASE_IMAGE``
-         to the immutable ``repo@sha256:…`` reference before invoking the
-         ``oci-build-task``'s ``build`` script.
+      2. Watches the grader base image on DockerHub for updates (trigger),
+         fetching it in ``oci`` format so it lands on disk as ``image.tar``.
+      3. Builds the Dockerfile in the root of the grader repo, preloading the
+         fetched ``image.tar`` via ``oci-build-task``'s
+         ``IMAGE_ARG_GRADER_BASE_IMAGE`` parameter so buildkit never needs to
+         pull the base image (or authenticate to ECR) itself.
       4. Pushes the resulting image to private ECR.
 
     Args:
@@ -125,22 +127,23 @@ def grader_image_pipeline(config: GraderPipelineConfig) -> Pipeline:
         ecr_region=config.aws_region,
     )
 
-    # The registry-image resource writes `repository` and `digest` files into
-    # the fetched directory.  We read them inside the task via a shell wrapper
-    # that sets BUILD_ARG_GRADER_BASE_IMAGE=repo@sha256:… before exec-ing the
-    # oci-build-task `build` script.  This pins the base image to the exact
-    # digest that triggered the pipeline run, ensuring reproducibility and
-    # correct Docker layer-cache invalidation.
-    #
-    # Note: oci-build-task `params` are env vars injected verbatim — shell
-    # expressions like $(cat …) are NOT evaluated there.  The `run.args` shell
-    # wrapper is the only way to dynamically set a BUILD_ARG from a file.
+    # buildkit (running inside oci-build-task) resolves Dockerfile `FROM`
+    # references itself and has no ECR credentials of its own — a live pull of
+    # a private ECR pull-through-cache repo 401s even though the
+    # registry-image get step above (which uses the worker's IAM role) can
+    # fetch it fine. Fetching in `oci` format writes an `image.tar` that we
+    # preload via IMAGE_ARG_GRADER_BASE_IMAGE, so buildkit resolves the base
+    # image from local disk instead of pulling it over the network.
     base_ref = grader_base_image.name
     build_job = Job(
         name=Identifier(f"build-{config.pipeline_name}-image"),
         plan=[
             GetStep(get=grader_repo.name, trigger=True),
-            GetStep(get=grader_base_image.name, trigger=True),
+            GetStep(
+                get=grader_base_image.name,
+                trigger=True,
+                params={"format": "oci"},
+            ),
             TaskStep(
                 task=Identifier("build-container-image"),
                 privileged=True,
@@ -158,6 +161,7 @@ def grader_image_pipeline(config: GraderPipelineConfig) -> Pipeline:
                     params={
                         "CONTEXT": str(grader_repo.name),
                         "DOCKERFILE": f"{grader_repo.name}/Dockerfile",
+                        "IMAGE_ARG_GRADER_BASE_IMAGE": f"{base_ref}/image.tar",
                     },
                     caches=[Cache(path="cache")],
                     inputs=[
@@ -165,20 +169,7 @@ def grader_image_pipeline(config: GraderPipelineConfig) -> Pipeline:
                         Input(name=grader_base_image.name),
                     ],
                     outputs=[Output(name=Identifier("image"))],
-                    # Read the base image digest file at runtime and export it
-                    # as BUILD_ARG_GRADER_BASE_IMAGE before running `build`.
-                    run=Command(
-                        path="sh",
-                        args=[
-                            "-euc",
-                            (
-                                f"export BUILD_ARG_GRADER_BASE_IMAGE="
-                                f'"$(cat {base_ref}/repository)'
-                                f'@$(cat {base_ref}/digest)"'
-                                " && exec build"
-                            ),
-                        ],
-                    ),
+                    run=Command(path="build"),
                 ),
             ),
             ensure_ecr_task(config.ecr_repo_name),


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Fixes a build failure in the open-edX grader-image Concourse pipelines
(`graders-mit-600x`, `graders-mit-686x`):

```
#4 ERROR: unexpected status from HEAD request to https://610119931565.dkr.ecr.us-east-1.amazonaws.com/v2/dockerhub/mitodl/xqueue-watcher-grader-base/manifests/sha256:...: 401 Unauthorized
```

Root cause: `oci-build-task`'s buildkit engine resolves the Dockerfile's
`FROM ${GRADER_BASE_IMAGE}` reference itself, completely independent of the
preceding Concourse `registry-image` get step. The get step authenticates to
the ECR pull-through-cache repo fine (it uses the worker's IAM role via the
resource type's `aws_region` source config), but buildkit has no ECR
credentials of its own — so its manifest HEAD request 401s even though the
same image was just fetched successfully earlier in the same job.

This was verified to be unrelated to IAM: all 9 Concourse worker roles
(`generic`/`infra`/`ocw` × `ci`/`qa`/`production`) were confirmed (via
`aws iam list-attached-role-policies`) to have the `describe-ec2-instances-policy`
attached, whose live policy document (`aws iam get-policy-version`) already
grants `ecr:GetAuthorizationToken`, `ecr:CreateRepository`,
`ecr:BatchImportUpstreamImage`, and the pull actions — matching the code in
`src/ol_infrastructure/infrastructure/aws/policies/__main__.py`. That's the
worker's own IAM identity; it doesn't extend to buildkit's independent
registry resolver running inside the `oci-build-task` container.

`oci-build-task` supports exactly this case via its `IMAGE_ARG_*` parameter,
which preloads an already-fetched image (tarball or OCI layout) for a given
Dockerfile `ARG`/`FROM`, bypassing any network pull. The fix:

- Fetches the grader base image with `format: oci` on the `get` step, which
  writes a local `image.tar` instead of an unpacked rootfs.
- Passes that tarball to the build task via `IMAGE_ARG_GRADER_BASE_IMAGE`
  instead of `BUILD_ARG_GRADER_BASE_IMAGE`, so buildkit resolves `FROM` from
  local disk rather than pulling from ECR.
- Removes the now-unnecessary shell wrapper that computed
  `BUILD_ARG_GRADER_BASE_IMAGE=repo@sha256:...` from the get step's
  `repository`/`digest` files, since `IMAGE_ARG_*` doesn't need a
  network-resolvable reference at all.

### How can this be tested?
- `uv run python -c "from ol_concourse.pipelines.open_edx.grader_images.build_pipeline import grader_image_pipeline, GRADER_PIPELINES; print(grader_image_pipeline(GRADER_PIPELINES[0]).model_dump_json(indent=2))"` renders a valid pipeline definition with the new `IMAGE_ARG_GRADER_BASE_IMAGE` param and `format: oci` get-step param for both configured grader pipelines.
- `ruff check` / `ruff format --check` / `mypy` all pass (also verified via the repo's pre-commit hooks on this commit).
- After merge, re-set and trigger the `graders-mit-600x` (or `graders-mit-686x`) pipeline and confirm the `build-container-image` task no longer 401s on the base image `FROM` resolution.

### Additional Context
Separately (not part of this PR — no code change needed), the same
investigation surfaced that `dockerhub/concourse/oci-build-task` itself had
never been lazily created in the ECR pull-through cache, since Concourse's
`check` step issues a `tags/list` call, which — unlike an actual manifest
pull — does not trigger ECR's on-demand repo creation. That was resolved
out-of-band via `aws ecr batch-import-upstream-image`.