### PR TITLE
Restore django-health-check probes for ocw-studio

### DIFF
--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -10,7 +10,6 @@ import json
 from pathlib import Path
 
 import pulumi_github as github
-import pulumi_kubernetes as kubernetes
 import pulumi_vault as vault
 from pulumi import (
     ROOT_STACK_RESOURCE,
@@ -23,7 +22,6 @@ from pulumi import (
 from pulumi_aws import ec2, get_caller_identity, iam
 
 from bridge.lib.magic_numbers import (
-    DEFAULT_NGINX_PORT,
     DEFAULT_POSTGRES_PORT,
     DEFAULT_REDIS_PORT,
 )
@@ -646,44 +644,6 @@ ocw_studio_k8s_app = OLApplicationK8s(
         ),
         resource_requests={"cpu": "100m", "memory": "1Gi"},
         resource_limits={"memory": "3Gi"},
-        # Reverted from django-health-check probes (#4874): app-side
-        # django-health-check's redis contrib check raises
-        # AttributeError('Redis' object has no attribute 'aclose') against
-        # the app's sync redis client. Revert to /nginx-health until the
-        # app-side fix lands.
-        probe_configs={
-            "liveness_probe": kubernetes.core.v1.ProbeArgs(
-                http_get=kubernetes.core.v1.HTTPGetActionArgs(
-                    path="/nginx-health",
-                    port=DEFAULT_NGINX_PORT,
-                ),
-                initial_delay_seconds=30,
-                period_seconds=30,
-                failure_threshold=3,
-                timeout_seconds=3,
-            ),
-            "readiness_probe": kubernetes.core.v1.ProbeArgs(
-                http_get=kubernetes.core.v1.HTTPGetActionArgs(
-                    path="/nginx-health",
-                    port=DEFAULT_NGINX_PORT,
-                ),
-                initial_delay_seconds=15,
-                period_seconds=15,
-                failure_threshold=3,
-                timeout_seconds=3,
-            ),
-            "startup_probe": kubernetes.core.v1.ProbeArgs(
-                http_get=kubernetes.core.v1.HTTPGetActionArgs(
-                    path="/nginx-health",
-                    port=DEFAULT_NGINX_PORT,
-                ),
-                initial_delay_seconds=10,
-                period_seconds=10,
-                failure_threshold=6,
-                success_threshold=1,
-                timeout_seconds=5,
-            ),
-        },
     ),
     opts=ResourceOptions(depends_on=[ocw_studio_app_security_group, *secret_resources]),
 )


### PR DESCRIPTION
### What are the relevant tickets?
N/A

Blocked on / tracking: https://github.com/mitodl/ocw-studio/pull/3092

### Description (What does it do?)
Re-applies the k8s liveness/readiness/startup probe change originally introduced in `7989d5172` (#4874), which pointed ocw-studio's probes at `django-health-check`'s `/health/{liveness,readiness,startup}/` endpoints instead of the shallow `/nginx-health` check — matching the pattern already used by mit-learn, learn-ai, and mitxonline.

That change was reverted for ocw-studio in `7e6eb439e` after it started 500ing on every probe and crash-looping the app in QA. Root cause: `django-health-check`'s Redis contrib check calls `await client.aclose()` on the `redis.asyncio` client it creates, and `aclose()` wasn't added to redis-py until 5.0.1 — ocw-studio was pinned to `redis>=4.5.5,<5`. Every probe raised:

```
AttributeError: 'Redis' object has no attribute 'aclose'. Did you mean: 'close'?
```

This diff simply undoes the revert (drops the explicit `/nginx-health` `probe_configs` override so ocw-studio falls back to the shared `OLApplicationK8sConfig` defaults again), once the app-side fix is live.

### Screenshots (if appropriate):
N/A

### How can this be tested?
`pulumi preview --diff` against the QA stack shows only the probe path/threshold change back to `/health/*`, no resource replacement:

```
~ kubernetes:apps/v1:Deployment: (update)
    ~ livenessProbe.httpGet.path:  "/nginx-health" => "/health/liveness/"
    ~ readinessProbe.httpGet.path: "/nginx-health" => "/health/readiness/"
    ~ startupProbe.httpGet.path:   "/nginx-health" => "/health/startup/"
    ~ startupProbe.failureThreshold: 6 => 12
Resources:
    ~ 1 to update
    111 unchanged
```

After merging **mitodl/ocw-studio#3092** and deploying a release that includes it to QA, apply this PR and confirm via `kubectl --context applications-qa get pods -n ocw-studio` that the new pods pass their probes and roll over cleanly (no `CrashLoopBackOff`), and that `kubectl logs -n ocw-studio <pod> -c nginx` shows `200` responses on `/health/startup/` instead of `500`.

### Additional Context
**Do not merge or deploy this before mitodl/ocw-studio#3092 is merged and released to QA** — doing so will reproduce the exact crash loop this is meant to fix. Opened as a draft for that reason; mark ready for review once the app-side fix has shipped.