### PR TITLE
docs(adr): correct ADR-0009's ToolHive authentication-only framing

### DIFF
--- a/docs/adr/0009-deploy-witan-as-shared-multi-tenant-mcp-service.md
+++ b/docs/adr/0009-deploy-witan-as-shared-multi-tenant-mcp-service.md
@@ -171,6 +171,39 @@ detail belongs to implementation, not the architectural decision itself.
 - Observability for this class of service doesn't exist yet in either repo —
   greenfield follow-up work, not a blocker for a first internal pilot.
 
+### Addendum (2026-07-08) — point 3's "authentication-only" framing needs revisiting
+
+A capability audit of upstream `stacklok/toolhive` at git tag `v0.33.0` —
+the exact version already pinned as `TOOLHIVE_OPERATOR_CHART_VERSION` /
+`TOOLHIVE_OPERATOR_CRDS_CHART_VERSION` in `src/bridge/lib/versions.py` —
+found that decision point 3's "ToolHive... is authentication-only today"
+overstates the platform's actual capability, though it's an accurate read
+of `toolhive_swe`'s specific configuration:
+
+- ToolHive ships a pluggable authorization framework today, including a
+  Cedar-based authorizer (`docs/authz.md`, `cedarv1`) wired into `MCPServer`
+  via `MCPAuthzConfig`/`AuthzConfigRef` — not a future capability.
+- ToolHive's RFC 8693 Token Exchange support (`pkg/oauthproto/tokenexchange/`)
+  is real, tested code wired into the vMCP auth pipeline — this ADR's
+  characterization of it as "a real future capability... explicitly deferred
+  past v1" undersells how implemented it already is.
+- `docs/middleware.md` documents an "External OIDC provider" auth scenario
+  where the client's JWT is forwarded to the backend MCP container
+  **unmodified** — i.e. per-user identity propagation to a backend
+  `MCPServer` is achievable today via a ToolHive configuration choice, not
+  something requiring a future ToolHive release. `toolhive_swe` simply uses
+  a *different* scenario ("Embedded auth server" → upstream-token-swap,
+  vMCP-scoped JWT only) suited to its own needs.
+
+This doesn't necessarily change the v1 decision (splitting authz between
+ToolHive and omnigraph's own Cedar bundle instead of consolidating on one
+could still be the wrong tradeoff for other reasons — e.g. keeping omnigraph
+as the single authz source of truth). Tracked as an open decision, not
+resolved here: `tk-revisit-adr-0004-adr-0009-per-user-identity-desi-e9005a`
+(agent-kit repo, project `wp-witan-multi-user-service-deployment-dcf6ee`).
+Point 3 above and ADR-0004 (agent-kit) should both be updated once that
+task resolves.
+
 ## Implementation Notes
 
 - **Effort Estimate:** Multi-week — spans a concurrency-behavior spike, witan

--- a/docs/adr/0009-deploy-witan-as-shared-multi-tenant-mcp-service.md
+++ b/docs/adr/0009-deploy-witan-as-shared-multi-tenant-mcp-service.md
@@ -171,7 +171,7 @@ detail belongs to implementation, not the architectural decision itself.
 - Observability for this class of service doesn't exist yet in either repo —
   greenfield follow-up work, not a blocker for a first internal pilot.
 
-### Addendum (2026-07-08) — point 3's "authentication-only" framing needs revisiting
+## Addendum (2026-07-08) — point 3's "authentication-only" framing needs revisiting
 
 A capability audit of upstream `stacklok/toolhive` at git tag `v0.33.0` —
 the exact version already pinned as `TOOLHIVE_OPERATOR_CHART_VERSION` /

--- a/docs/adr/0009-deploy-witan-as-shared-multi-tenant-mcp-service.md
+++ b/docs/adr/0009-deploy-witan-as-shared-multi-tenant-mcp-service.md
@@ -181,13 +181,13 @@ overstates the platform's actual capability, though it's an accurate read
 of `toolhive_swe`'s specific configuration:
 
 - ToolHive ships a pluggable authorization framework today, including a
-  Cedar-based authorizer (`docs/authz.md`, `cedarv1`) wired into `MCPServer`
+  Cedar-based authorizer (`stacklok/toolhive/docs/authz.md`, `cedarv1`) wired into `MCPServer`
   via `MCPAuthzConfig`/`AuthzConfigRef` — not a future capability.
-- ToolHive's RFC 8693 Token Exchange support (`pkg/oauthproto/tokenexchange/`)
+- ToolHive's RFC 8693 Token Exchange support (`stacklok/toolhive/pkg/oauthproto/tokenexchange/`)
   is real, tested code wired into the vMCP auth pipeline — this ADR's
   characterization of it as "a real future capability... explicitly deferred
   past v1" undersells how implemented it already is.
-- `docs/middleware.md` documents an "External OIDC provider" auth scenario
+- `stacklok/toolhive/docs/middleware.md` documents an "External OIDC provider" auth scenario
   where the client's JWT is forwarded to the backend MCP container
   **unmodified** — i.e. per-user identity propagation to a backend
   `MCPServer` is achievable today via a ToolHive configuration choice, not


### PR DESCRIPTION
### What are the relevant tickets?
N/A — tracked in witan's internal work-coordination graph (task `tk-revisit-adr-0004-adr-0009-per-user-identity-desi-e9005a`, project `wp-witan-multi-user-service-deployment-dcf6ee`, agent-kit repo).

### Description (What does it do?)
ADR-0009's decision point 3 characterizes ToolHive as "authentication-only today: any Keycloak-authenticated user gets full access to the aggregated tool set" and calls RFC 8693 Token Exchange "a real future capability... explicitly deferred past v1." Both were accurate reads of `toolhive_swe`'s specific existing configuration, but overstate it as a platform-wide ToolHive limitation.

I cloned `stacklok/toolhive` (upstream OSS) and audited its actual capabilities at git tag `v0.33.0` — the exact version already pinned as `TOOLHIVE_OPERATOR_CHART_VERSION`/`TOOLHIVE_OPERATOR_CRDS_CHART_VERSION` in `src/bridge/lib/versions.py` (so these aren't unreleased/future features):

- `docs/authz.md`: a pluggable authorization framework ships today, including a Cedar-based authorizer (`cedarv1`) wired into `MCPServer` via `MCPAuthzConfig`/`AuthzConfigRef`.
- `pkg/oauthproto/tokenexchange/`: real, tested OAuth 2.0 Token Exchange (RFC 8693) support, wired into the vMCP auth pipeline — not just documented, implemented.
- `docs/middleware.md`: an "External OIDC provider" auth scenario where the client's JWT is forwarded to the backend MCP container **unmodified** — i.e. per-user identity propagation to a backend `MCPServer` is achievable today via a ToolHive configuration choice. `toolhive_swe` simply uses ToolHive's *other* scenario ("Embedded auth server" → upstream-token-swap, vMCP-scoped JWT only), suited to its own needs — that's a config choice, not a platform ceiling.

This adds an addendum to ADR-0009 recording the correction, and points to a new tracked task (`tk-revisit-adr-0004-adr-0009-per-user-identity-desi-e9005a`) for the actual re-decision (whether `toolhive_witan` should use one of these native ToolHive capabilities instead of, or alongside, witan's own JWTVerifier/Cedar-bundle path shipped in agent-kit PRs #84/#90). It does not change the v1 decision itself, and does not silently rewrite the original decision record.

### How can this be tested?
Documentation-only change. No code/infra affected.

### Additional Context
Companion correction filed in agent-kit against ADR-0004 (same finding, same addendum pattern) — see PR against `mitodl/agent-kit`'s `worktree-keycloak-jwt-actor-mapping` branch (PR #84).