### PR TITLE
fix: add absolute path for communication MFE

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -607,7 +607,7 @@ def create_k8s_configmaps(  # noqa: PLR0915
         "AUDIT_CERT_CUTOFF_DATE": None,
         "AUTH_DOCUMENTATION_URL": "http://course-catalog-api-guide.readthedocs.io/en/latest/authentication/index.html",
         "BULK_EMAIL_ROUTING_KEY_SMALL_JOBS": "edx.lms.core.default",
-        "COMMUNICATIONS_MICROFRONTEND_URL": "/communications",
+        "COMMUNICATIONS_MICROFRONTEND_URL": f"https://{edxapp_config.require_object('domains')['lms']}/communications",
         "CONTACT_MAILING_ADDRESS": "SET-ME-PLEASE",
         "CREDIT_HELP_LINK_URL": "",
         "DCS_SESSION_COOKIE_SAMESITE": "None",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11862

### Description (What does it do?)
This pull request updates the configuration for the `COMMUNICATIONS_MICROFRONTEND_URL` in the edX app Kubernetes ConfigMaps to use a full HTTPS URL based on the LMS domain, instead of a relative path.

Configuration improvements:

* Updated the `COMMUNICATIONS_MICROFRONTEND_URL` value in `k8s_configmaps.py` to dynamically use the LMS domain from configuration, ensuring the URL is fully qualified and environment-specific.

### Additional Context
Adding relative path was causing issues, `frontend-app-instructor-dashboard` was considering that as [internal route](https://github.com/openedx/frontend-app-instructor-dashboard/blob/main/src/instructorNav/InstructorNav.tsx#L71-L84) as it starts with `/` and adding `React Link` instead of `href` causing it to through 404 as that route does not exists in `instructor-dashboard`