### PR TITLE
fix(edxapp): schedule Canvas due-date sync from LMS beat for all mitx envs

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -533,17 +533,6 @@ def create_k8s_configmaps(  # noqa: PLR0915
         )
         cms_general_config_content["SEGMENT_IO"] = False
 
-    # TEMPORARY (mitx-qa testing): speed up Canvas due-date sync from the
-    # plugin's hourly default to every 5 minutes so Canvas changes appear
-    # quickly in Studio. Revert once Canvas due-date testing is complete.
-    if stack_info.env_prefix == "mitx" and stack_info.env_suffix == "qa":
-        cms_general_config_content["CELERYBEAT_SCHEDULE"] = {
-            "sync_canvas_due_dates": {
-                "task": "ol_openedx_canvas_integration.cms_tasks.sync_canvas_due_dates_for_all_courses",
-                "schedule": 300,  # seconds; 5 minutes (plugin default is hourly)
-            },
-        }
-
     cms_general_config_content["FEATURES"] = cms_features
 
     cms_general_config_map = kubernetes.core.v1.ConfigMap(
@@ -593,7 +582,7 @@ def create_k8s_configmaps(  # noqa: PLR0915
 
     # LMS general configuration
     lms_general_config_name = "81-lms-general-config-yaml"
-    lms_general_config_content = {
+    lms_general_config_content: dict[str, Any] = {
         "ACCOUNT_MICROFRONTEND_URL": None,
         "ACE_CHANNEL_DEFAULT_EMAIL": "django_email",
         "ACE_CHANNEL_TRANSACTIONAL_EMAIL": "django_email",
@@ -723,6 +712,21 @@ def create_k8s_configmaps(  # noqa: PLR0915
             "common.djangoapps.third_party_auth.lti.LTIAuthBackend",
         ]
         # mitxonline has no LEARNER_HOME_MICROFRONTEND_URL
+
+    # Schedule the Canvas due-date sync every 15 minutes (plugin default is
+    # hourly). The ol_openedx_canvas_integration plugin registers this beat
+    # schedule only in CMS settings, but the sole celery beat scheduler runs
+    # with the LMS settings, so the entry must live in the LMS config and
+    # route explicitly to the CMS worker queue. Excludes mitx-staging, which
+    # has no CANVAS_ACCESS_TOKEN wired.
+    if stack_info.env_prefix == "mitx":
+        lms_general_config_content["CELERYBEAT_SCHEDULE"] = {
+            "sync_canvas_due_dates": {
+                "task": "ol_openedx_canvas_integration.cms_tasks.sync_canvas_due_dates_for_all_courses",
+                "schedule": 900,  # seconds; 15 minutes
+                "options": {"queue": "edx.cms.core.default"},
+            },
+        }
 
     # Assign the deployment-specific FEATURES (already enriched with base config)
     lms_general_config_content["FEATURES"] = deployment_features


### PR DESCRIPTION
### What are the relevant tickets?
Relates to mitodl/hq#12250 (follow-up to #4937)

### Description (What does it do?)
Fixes the Canvas due-date sync task (`sync_canvas_due_dates_for_all_courses`) so it actually runs, and extends it to mitx Production. It turns out the task had **never run in any environment** — not hourly, and not every 5 minutes after #4937:

- The `ol_openedx_canvas_integration` plugin registers its `CELERYBEAT_SCHEDULE` entry only in **CMS** settings ([settings/cms/common.py](https://github.com/mitodl/open-edx-plugins/blob/main/src/ol_openedx_canvas_integration/ol_openedx_canvas_integration/settings/cms/common.py)).
- The k8s edxapp deployment runs exactly **one** celery beat scheduler, `<env>-edxapp-lms-beat`, with `--app=lms.celery` / `SERVICE_VARIANT=lms` — it only loads LMS settings, so the CMS-scoped schedule entry (both the plugin's hourly default and the #4937 override in the CMS general config) was never loaded by any scheduler. The lms-beat logs confirmed only `celery.backend_cleanup` and `refresh-saml-metadata` were ever dispatched.

Changes:
- Move the `CELERYBEAT_SCHEDULE` override from the CMS general config to the **LMS** general config (`81-lms-general-config.yaml`), which the lms-beat scheduler actually loads.
- Add `options: {queue: edx.cms.core.default}` so the task is enqueued onto the CMS worker queue, where the canvas tasks are registered (the LMS worker explicitly excludes that queue).
- Apply to **all mitx stacks** (QA, CI, Production) instead of QA only, since the end goal is for this sync to run everywhere. mitx-staging is excluded because it has no `CANVAS_ACCESS_TOKEN` wired in `secrets_builder.py`.
- Set the interval to **900 seconds (15 minutes)** — a middle ground between the plugin's hourly default and the 5-minute QA testing value.

### How can this be tested?
1. `pre-commit run --files src/ol_infrastructure/applications/edxapp/k8s_configmaps.py` — ruff, mypy, and secret checks pass.
2. `pulumi preview --diff` on **mitx.QA**: the only content change is `schedule: 300 => 900` in the LMS general ConfigMap. On **mitx.Production**: the LMS general ConfigMap gains the `CELERYBEAT_SCHEDULE` block (`schedule: 900`, `queue: edx.cms.core.default`); remaining preview changes are pre-existing undeployed drift from main, with zero deletes.
3. The QA half of this fix (at 300s) was already verified end-to-end on mitx-qa on 2026-07-09: lms-beat logs `Scheduler: Sending due task sync_canvas_due_dates`, the CMS celery worker receives and executes it (`Due Date Sync: ... course-v1:TestX+RR1+2024_Fall`), and the business partner confirmed due dates sync.
4. After deploy: restart the `<env>-edxapp-lms-beat` pod (config is assembled by an init container at pod start; a ConfigMap change alone does not trigger a rollout), then confirm the beat log line above appears every ~15 minutes and the CMS worker picks the task up.

### Additional Context
Beat only enqueues — the worker consuming the queue executes. Without the explicit `queue` option the task would land on the LMS default queue instead of the CMS worker.

Upstream plugin quirks worth knowing (not addressed here): the plugin's `settings/cms/production.py` unconditionally overwrites the schedule back to `crontab(minute=0)` after YAML env tokens load, so a CMS-side YAML override could never change the interval even if a CMS beat existed. Scheduling from LMS config sidesteps this because the plugin's LMS settings never touch `CELERYBEAT_SCHEDULE`.

### Checklist:
- [ ] After deploy, restart `<env>-edxapp-lms-beat` on mitx-qa and mitx-production and verify the task fires every 15 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)