### PR TITLE
fix(local-dev): mitxonline Learn proxy + checkout/celery fixes

### DIFF
--- a/local-dev/apps/mit-learn-nextjs/deployment.yaml
+++ b/local-dev/apps/mit-learn-nextjs/deployment.yaml
@@ -51,7 +51,7 @@ spec:
         - name: NEXT_PUBLIC_MITOL_AXIOS_WITH_CREDENTIALS
           value: "true"
         - name: NEXT_PUBLIC_MITX_ONLINE_BASE_URL
-          value: "https://mitxonline.mit.dev"
+          value: "https://api.learn.mit.dev/mitxonline"
         - name: NEXT_PUBLIC_MITX_ONLINE_LEGACY_BASE_URL
           value: "https://mitxonline.mit.dev"
         - name: NEXT_PUBLIC_MITX_ONLINE_CSRF_COOKIE_NAME

--- a/local-dev/apps/mitxonline/apisix-routes.yaml
+++ b/local-dev/apps/mitxonline/apisix-routes.yaml
@@ -232,11 +232,10 @@ spec:
         - "/$1"
     - name: openid-connect
       enable: true
+      # Same mitlearn client as the learn route (must match for session/token
+      # refresh); secretRef avoids a second inlined copy of the secret.
+      secretRef: ol-mitlearn-oidc     # pragma: allowlist secret
       config:
-        # mitlearn OIDC client — MUST match the learn route so the shared session
-        # cookie can be read and its tokens refreshed (see mit-learn secrets.yaml).
-        client_id: "ol-mitlearn-client"
-        client_secret: "local-dev-mitlearn-secret"     # pragma: allowlist secret
         discovery: "http://keycloak-service.local-infra.svc.cluster.local:8080/realms/olapps/.well-known/openid-configuration"
         realm: olapps
         use_jwks: true

--- a/local-dev/apps/mitxonline/apisix-routes.yaml
+++ b/local-dev/apps/mitxonline/apisix-routes.yaml
@@ -76,7 +76,7 @@ spec:
     plugins:
     - name: openid-connect
       enable: true
-      secretRef: ol-mitxonline-oidc  # pragma: allowlist secret
+      secretRef: ol-mitxonline-oidc     # pragma: allowlist secret
       config:
         discovery: "http://keycloak-service.local-infra.svc.cluster.local:8080/realms/olapps/.well-known/openid-configuration"
         use_jwks: true
@@ -88,7 +88,7 @@ spec:
         logout_path: "/logout/oidc"
         post_logout_redirect_uri: "https://mitxonline.mit.dev/logout/"
         session:
-          secret: "local-dev-oidc-session-secret-32chars!"  # pragma: allowlist secret
+          secret: "local-dev-oidc-session-secret-32chars!"     # pragma: allowlist secret
           cookie:
             domain: ".mitxonline.mit.dev"
             lifetime: 1209600
@@ -135,7 +135,7 @@ spec:
     plugins:
     - name: openid-connect
       enable: true
-      secretRef: ol-mitxonline-oidc  # pragma: allowlist secret
+      secretRef: ol-mitxonline-oidc     # pragma: allowlist secret
       config:
         discovery: "http://keycloak-service.local-infra.svc.cluster.local:8080/realms/olapps/.well-known/openid-configuration"
         use_jwks: true
@@ -147,7 +147,7 @@ spec:
         logout_path: "/logout/oidc"
         post_logout_redirect_uri: "https://mitxonline.mit.dev/logout/"
         session:
-          secret: "local-dev-oidc-session-secret-32chars!"  # pragma: allowlist secret
+          secret: "local-dev-oidc-session-secret-32chars!"     # pragma: allowlist secret
           cookie:
             domain: ".mitxonline.mit.dev"
             lifetime: 1209600
@@ -175,7 +175,7 @@ spec:
     plugins:
     - name: openid-connect
       enable: true
-      secretRef: ol-mitxonline-oidc  # pragma: allowlist secret
+      secretRef: ol-mitxonline-oidc     # pragma: allowlist secret
       config:
         discovery: "http://keycloak-service.local-infra.svc.cluster.local:8080/realms/olapps/.well-known/openid-configuration"
         use_jwks: true
@@ -187,7 +187,7 @@ spec:
         logout_path: "/logout/oidc"
         post_logout_redirect_uri: "https://mitxonline.mit.dev/logout/"
         session:
-          secret: "local-dev-oidc-session-secret-32chars!"  # pragma: allowlist secret
+          secret: "local-dev-oidc-session-secret-32chars!"     # pragma: allowlist secret
           cookie:
             domain: ".mitxonline.mit.dev"
             lifetime: 1209600
@@ -197,3 +197,56 @@ spec:
           id_token: true
           user: true
         unauth_action: auth
+---
+# ─────────────────────────────────────────────────────────────────────────────
+# Learn → mitxonline API proxy (mirrors production).
+# In production this is
+# mitxonline_apisix_route_prefix in
+# src/ol_infrastructure/applications/mitxonline/__main__.py.
+# ─────────────────────────────────────────────────────────────────────────────
+apiVersion: apisix.apache.org/v2
+kind: ApisixRoute
+metadata:
+  name: mitxonline-learn-proxy-route
+  namespace: mitxonline
+spec:
+  ingressClassName: apache-apisix
+  http:
+  - name: passauth
+    priority: 0
+    match:
+      hosts:
+      - api.learn.mit.dev
+      paths:
+      - "/mitxonline/*"
+    backends:
+    - serviceName: mitxonline-webapp
+      servicePort: 8010
+    plugin_config_name: mitxonline-shared-plugins
+    plugins:
+    - name: proxy-rewrite
+      enable: true
+      config:
+        regex_uri:
+        - "^/mitxonline/(.*)"
+        - "/$1"
+    - name: openid-connect
+      enable: true
+      config:
+        # mitlearn OIDC client — MUST match the learn route so the shared session
+        # cookie can be read and its tokens refreshed (see mit-learn secrets.yaml).
+        client_id: "ol-mitlearn-client"
+        client_secret: "local-dev-mitlearn-secret"     # pragma: allowlist secret
+        discovery: "http://keycloak-service.local-infra.svc.cluster.local:8080/realms/olapps/.well-known/openid-configuration"
+        realm: olapps
+        use_jwks: true
+        bearer_only: false
+        introspection_endpoint_auth_method: client_secret_post
+        scope: "openid profile email ol-profile"
+        ssl_verify: false
+        renew_access_token_on_expiry: true
+        # No cookie name/domain override → default name "session" on host
+        # api.learn.mit.dev, matching the learn route that issued the cookie.
+        session:
+          secret: "local-dev-oidc-session-secret-32chars!"     # pragma: allowlist secret
+        unauth_action: pass

--- a/local-dev/apps/mitxonline/configmaps/app-env.yaml
+++ b/local-dev/apps/mitxonline/configmaps/app-env.yaml
@@ -58,8 +58,12 @@ data:
   MAILGUN_SENDER_DOMAIN: "local.dev"
   MAILGUN_KEY: "local-dev-stub-mailgun-key"
   # Required OpenEdX API credentials (stub — OpenEdX integration degraded locally)
-  OPENEDX_API_CLIENT_ID: "local-dev-openedx-client-id"  # pragma: allowlist secret
-  OPENEDX_API_CLIENT_SECRET: "local-dev-openedx-client-secret"  # pragma: allowlist secret
+  OPENEDX_API_CLIENT_ID: "local-dev-openedx-client-id" # pragma: allowlist secret
+  OPENEDX_API_CLIENT_SECRET: "local-dev-openedx-client-secret" # pragma: allowlist secret
 
   # Unified Ecommerce (optional — disable if not running)
   UNIFIED_ECOMMERCE_URL: ""
+
+  # CyberSource sandbox endpoint (paired with the stub creds in secrets.yaml —
+  # see the comment there for why these are needed at all).
+  MITOL_PAYMENT_GATEWAY_CYBERSOURCE_SECURE_ACCEPTANCE_URL: "https://testsecureacceptance.cybersource.com/pay"

--- a/local-dev/apps/mitxonline/configmaps/app-env.yaml
+++ b/local-dev/apps/mitxonline/configmaps/app-env.yaml
@@ -10,8 +10,6 @@ data:
   MITXONLINE_DOCKER_BASE_URL: "https://mitxonline.mit.dev"
   MITX_ONLINE_DB_DISABLE_SSL: "True"
   MITX_ONLINE_USE_S3: "False"
-  # Must stay False: the production image (see Tiltfile) has no dev deps, so
-  # DEBUG=True would import debug_toolbar → boot crash.
   DEBUG: "False"
   ALLOWED_HOSTS: "*"
   USE_X_FORWARDED_HOST: "True"

--- a/local-dev/apps/mitxonline/deployment.yaml
+++ b/local-dev/apps/mitxonline/deployment.yaml
@@ -129,7 +129,13 @@ spec:
       - name: combined-ca
         emptyDir: {}
 ---
-# Celery worker (mitxonline uses a single default queue)
+# Celery worker. Listens on "celery" (Celery's actual default routing key —
+# main/celery.py sets no task_default_queue override) plus "hubspot_sync"
+# (routed there explicitly in main/celery.py), matching production's two
+# celery_worker_configs in mitxonline/__main__.py. A prior version listened on
+# "-Q default" instead, a queue name nothing ever routes to — every task
+# queued via .delay() (e.g. openedx.tasks.create_user_from_id) piled up
+# unconsumed forever.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -170,7 +176,7 @@ spec:
         - main.celery:app
         - worker
         - -Q
-        - default
+        - celery,hubspot_sync
         - -c
         - "2"
         envFrom:

--- a/local-dev/apps/mitxonline/secrets.yaml
+++ b/local-dev/apps/mitxonline/secrets.yaml
@@ -16,3 +16,11 @@ stringData:
   KEYCLOAK_ADMIN_CLIENT_SECRET: "local-dev-mitxonline-secret"  # pragma: allowlist secret
   # OpenEdX stub token (degraded mode)
   OPENEDX_SERVICE_WORKER_API_TOKEN: "local-dev-stub-token"
+  # CyberSource stub creds (degraded mode). Without these,
+  # MITOL_PAYMENT_GATEWAY_CYBERSOURCE_SECURITY_KEY defaults to None and the
+  # checkout flow's HMAC signing crashes with AttributeError before it can
+  # redirect to CyberSource. These aren't real sandbox credentials, so the
+  # actual CyberSource submission will still fail once redirected there.
+  MITOL_PAYMENT_GATEWAY_CYBERSOURCE_ACCESS_KEY: "local-dev-stub-cybersource-access-key"  # pragma: allowlist secret
+  MITOL_PAYMENT_GATEWAY_CYBERSOURCE_SECURITY_KEY: "local-dev-stub-cybersource-security-key"  # pragma: allowlist secret
+  MITOL_PAYMENT_GATEWAY_CYBERSOURCE_PROFILE_ID: "local-dev-stub-cybersource-profile-id"

--- a/local-dev/apps/mitxonline/secrets.yaml
+++ b/local-dev/apps/mitxonline/secrets.yaml
@@ -16,11 +16,13 @@ stringData:
   KEYCLOAK_ADMIN_CLIENT_SECRET: "local-dev-mitxonline-secret"  # pragma: allowlist secret
   # OpenEdX stub token (degraded mode)
   OPENEDX_SERVICE_WORKER_API_TOKEN: "local-dev-stub-token"
-  # CyberSource stub creds (degraded mode). Without these,
+  # Placeholders, not real creds. Without these,
   # MITOL_PAYMENT_GATEWAY_CYBERSOURCE_SECURITY_KEY defaults to None and the
   # checkout flow's HMAC signing crashes with AttributeError before it can
-  # redirect to CyberSource. These aren't real sandbox credentials, so the
-  # actual CyberSource submission will still fail once redirected there.
-  MITOL_PAYMENT_GATEWAY_CYBERSOURCE_ACCESS_KEY: "local-dev-stub-cybersource-access-key"  # pragma: allowlist secret
-  MITOL_PAYMENT_GATEWAY_CYBERSOURCE_SECURITY_KEY: "local-dev-stub-cybersource-security-key"  # pragma: allowlist secret
-  MITOL_PAYMENT_GATEWAY_CYBERSOURCE_PROFILE_ID: "local-dev-stub-cybersource-profile-id"
+  # redirect to CyberSource. To actually test checkout, replace these with
+  # real CyberSource test/sandbox credentials (e.g. sops-decrypt the
+  # cybersource keys in src/bridge/secrets/unified_ecommerce/secrets.ci.yaml)
+  # in your local, uncommitted copy of this file.
+  MITOL_PAYMENT_GATEWAY_CYBERSOURCE_ACCESS_KEY: "REPLACE-WITH-REAL-CYBERSOURCE-TEST-ACCESS-KEY"  # pragma: allowlist secret
+  MITOL_PAYMENT_GATEWAY_CYBERSOURCE_SECURITY_KEY: "REPLACE-WITH-REAL-CYBERSOURCE-TEST-SECURITY-KEY"  # pragma: allowlist secret
+  MITOL_PAYMENT_GATEWAY_CYBERSOURCE_PROFILE_ID: "REPLACE-WITH-REAL-CYBERSOURCE-TEST-PROFILE-ID"

--- a/local-dev/infra/modules/keycloak.py
+++ b/local-dev/infra/modules/keycloak.py
@@ -473,6 +473,14 @@ def create_olapps_dev_realm(  # noqa: PLR0913
         mitlearn_client,
         mitlearn_client_secret,
     )
+    # Same mitlearn creds, for mitxonline-learn-proxy-route's secretRef.
+    _make_oidc_secret(
+        "oidc-secret-mitlearn-in-mitxonline",
+        "mitxonline",
+        "ol-mitlearn-oidc",
+        mitlearn_client,
+        mitlearn_client_secret,
+    )
 
     # --- MITx Online ---
     mitxonline_client = keycloak.openid.Client(


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Fixes local-dev's Learn <--> MITxOnline integration, plus several MITxOnline issues found while testing the ecommerce checkout flow afterward.

**Learn → MITxOnline API proxy**

Now similar to prod:
- Learn uses `api.learn.mit.dev/mitxonline` as the URL for API requests to mitxonline
- APISIX forwards those requests with auth to MITxOnline

My earlier PR, https://github.com/mitodl/ol-infrastructure/pull/4936/, fixed a different issue for MITxOnline in localdev. When working on that, my `Learn -> MITxOnline` api calls happened to work because I already had an MITxOnline session. Now they work just with your learn session.

**Checkout 500 on `/checkout/to_payment`**

Two independent bugs, same crash signature (`AttributeError: 'NoneType' object has no attribute 'encode'`):
- `MITOL_PAYMENT_GATEWAY_CYBERSOURCE_SECURITY_KEY` had no local-dev stub, so CyberSource's HMAC signing step crashed on `None.encode()`. Added stub creds, matching the existing OpenEdX/Mailgun stub pattern — checkout will still fail once actually posted to CyberSource's sandbox, but signing no longer crashes first.
    - ⚠️ The stubbed values are not actually functional, they result in "You are not authorized to view this page. The transaction has not been processed." But that's better than an attribute error, and the stub names clearly indicate they nee to be replaced locally.
- The `mitxonline-celery` worker listened on queue `default`, which nothing routes to (Celery's real default queue is `celery`; production runs `celery` + `hubspot_sync`). Every async task ever queued in this local-dev stack — including the one that sets a user's `edx_username`, which checkout requires — was stuck unconsumed. Fixed the queue name to match production.

**Misc**

Removed a stale comment on `DEBUG` in mitxonline's `app-env.yaml` claiming `DEBUG=True` would crash the app; local-dev builds mitxonline's `local-dev` Docker target, which does include dev deps, so this doesn't apply.

### How can this be tested?
1. With local dev setup, visit https://learn.mit.dev in a private browser (no existing mitxonline session)
2. Log in
3. Observe the dashboard making authenticated API requests to mitxonline
4. As a seeded test user, add a course to your cart and click Checkout — confirm `/checkout/to_payment` no longer 500s (it will redirect to CyberSource's sandbox checkout page, which then fails since the creds are fake stubs — expected locally)
    - if you actually want to do this, you can set some up with https://gist.github.com/ChristopherChudzicki/78e77f73139b8fdd59e91f522b0bb8b2