### PR TITLE
feat(concourse): matrix-build grader base image across Python 3.12-3.14

### DIFF
--- a/src/bridge/lib/versions.py
+++ b/src/bridge/lib/versions.py
@@ -127,4 +127,3 @@ MCP_GRAFANA_VERSION = "0.17.1"
 # self-hosted stdio mode). Tag tracks the dockyard build, not the upstream npm pkg.
 # renovate: datasource=docker depName=sentry-mcp-server packageName=ghcr.io/stacklok/dockyard/npx/sentry-mcp-server
 MCP_SENTRY_VERSION = "0.33.0"
-

--- a/src/ol_concourse/pipelines/open_edx/grader_images/base_image_pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/grader_images/base_image_pipeline.py
@@ -12,6 +12,13 @@ course-specific grader images.  Publishing it to both registries allows:
   - ECR (mitodl/xqueue-watcher-grader-base): private mirror for use inside
     AWS without DockerHub rate-limit concerns.
 
+Dockerfile.base exposes ``ARG PYTHON_VERSION=3.12``, so one build job per
+supported interpreter is run, each tagging its image with the Python version
+(e.g. ``3.14``).  The default version's job additionally publishes a
+``:latest`` tag so existing per-grader pipelines (build_pipeline.py), which
+still trigger off ``grader_base_dockerhub_repo``'s default ``latest`` tag,
+keep working unchanged.
+
 Triggers:
   - Push to the xqueue-watcher repo on paths under grader_support/.
 """
@@ -30,9 +37,14 @@ from ol_concourse.lib.models.pipeline import (
 )
 from ol_concourse.lib.resources import git_repo, registry_image
 
-_AWS_ACCOUNT_ID = "610119931565"
 _AWS_REGION = "us-east-1"
 _BASE_IMAGE_REPO = "mitodl/xqueue-watcher-grader-base"
+_PYTHON_VERSIONS = ("3.12", "3.13", "3.14")
+DEFAULT_PYTHON_VERSION = "3.12"  # matches Dockerfile.base's ARG default
+
+
+def _version_slug(python_version: str) -> str:
+    return python_version.replace(".", "")
 
 
 def grader_base_image_pipeline() -> Pipeline:
@@ -44,29 +56,49 @@ def grader_base_image_pipeline() -> Pipeline:
         paths=["grader_support/"],
     )
 
-    # DockerHub push target — public, used by grader repo Dockerfiles as default
-    # GRADER_BASE_IMAGE build arg and accessible without AWS credentials.
-    dockerhub_base_image = registry_image(
-        name=Identifier("grader-base-dockerhub"),
+    # DockerHub push targets — public, used by grader repo Dockerfiles as
+    # default GRADER_BASE_IMAGE build arg and accessible without AWS
+    # credentials.  One per Python version in the build matrix.
+    dockerhub_base_images = {
+        version: registry_image(
+            name=Identifier(f"grader-base-dockerhub-py{_version_slug(version)}"),
+            image_repository=_BASE_IMAGE_REPO,
+            image_tag=version,
+            username="((dockerhub.username))",
+            password="((dockerhub.password))",  # noqa: S106
+        )
+        for version in _PYTHON_VERSIONS
+    }
+
+    # ECR push targets — private mirror for use inside AWS without DockerHub
+    # rate-limit concerns.  The per-grader Concourse build pipelines trigger
+    # off the DockerHub base image (grader_base_dockerhub_repo), not ECR.
+    ecr_base_images = {
+        version: registry_image(
+            name=Identifier(f"grader-base-ecr-py{_version_slug(version)}"),
+            image_repository=_BASE_IMAGE_REPO,
+            image_tag=version,
+            ecr_region=_AWS_REGION,
+        )
+        for version in _PYTHON_VERSIONS
+    }
+
+    dockerhub_latest_image = registry_image(
+        name=Identifier("grader-base-dockerhub-latest"),
         image_repository=_BASE_IMAGE_REPO,
         image_tag="latest",
         username="((dockerhub.username))",
         password="((dockerhub.password))",  # noqa: S106
     )
-
-    # ECR push target — private mirror for use inside AWS without DockerHub
-    # rate-limit concerns.  The per-grader Concourse build pipelines trigger
-    # off the DockerHub base image (grader_base_dockerhub_repo), not ECR.
-    ecr_base_image = registry_image(
-        name=Identifier("grader-base-ecr"),
+    ecr_latest_image = registry_image(
+        name=Identifier("grader-base-ecr-latest"),
         image_repository=_BASE_IMAGE_REPO,
         image_tag="latest",
         ecr_region=_AWS_REGION,
     )
 
-    build_job = Job(
-        name=Identifier("build-grader-base-image"),
-        plan=[
+    def build_job(python_version: str) -> Job:
+        plan = [
             GetStep(get=xqwatcher_repo.name, trigger=True),
             container_build_task(
                 inputs=[Input(name=xqwatcher_repo.name)],
@@ -75,31 +107,56 @@ def grader_base_image_pipeline() -> Pipeline:
                     "DOCKERFILE": (
                         f"{xqwatcher_repo.name}/grader_support/Dockerfile.base"
                     ),
+                    "BUILD_ARG_PYTHON_VERSION": python_version,
                 },
             ),
             ensure_ecr_task(_BASE_IMAGE_REPO),
             # Push to DockerHub first — fail fast if credentials are wrong
             # before consuming the ECR push quota.
             PutStep(
-                put=dockerhub_base_image.name,
+                put=dockerhub_base_images[python_version].name,
                 params={
                     "image": "image/image.tar",
                     "additional_tags": f"./{xqwatcher_repo.name}/.git/describe_ref",
                 },
             ),
             PutStep(
-                put=ecr_base_image.name,
+                put=ecr_base_images[python_version].name,
                 params={
                     "image": "image/image.tar",
                     "additional_tags": f"./{xqwatcher_repo.name}/.git/describe_ref",
                 },
             ),
-        ],
-    )
+        ]
+        if python_version == DEFAULT_PYTHON_VERSION:
+            plan.extend(
+                [
+                    PutStep(
+                        put=dockerhub_latest_image.name,
+                        params={"image": "image/image.tar"},
+                    ),
+                    PutStep(
+                        put=ecr_latest_image.name,
+                        params={"image": "image/image.tar"},
+                    ),
+                ]
+            )
+        return Job(
+            name=Identifier(
+                f"build-grader-base-image-py{_version_slug(python_version)}"
+            ),
+            plan=plan,
+        )
 
     fragment = PipelineFragment(
-        resources=[xqwatcher_repo, dockerhub_base_image, ecr_base_image],
-        jobs=[build_job],
+        resources=[
+            xqwatcher_repo,
+            *dockerhub_base_images.values(),
+            *ecr_base_images.values(),
+            dockerhub_latest_image,
+            ecr_latest_image,
+        ],
+        jobs=[build_job(version) for version in _PYTHON_VERSIONS],
     )
 
     return Pipeline(

--- a/src/ol_concourse/pipelines/open_edx/grader_images/base_image_pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/grader_images/base_image_pipeline.py
@@ -15,9 +15,10 @@ course-specific grader images.  Publishing it to both registries allows:
 Dockerfile.base exposes ``ARG PYTHON_VERSION=3.12``, so one build job per
 supported interpreter is run, each tagging its image with the Python version
 (e.g. ``3.14``).  The default version's job additionally publishes a
-``:latest`` tag so existing per-grader pipelines (build_pipeline.py), which
-still trigger off ``grader_base_dockerhub_repo``'s default ``latest`` tag,
-keep working unchanged.
+``:latest`` tag for legacy/manual consumers that still pull the floating
+tag; build_pipeline.py itself now pins to an explicit Python-version tag
+(``GraderPipelineConfig.grader_base_image_tag``, default
+``DEFAULT_PYTHON_VERSION``) rather than ``:latest``.
 
 Triggers:
   - Push to the xqueue-watcher repo on paths under grader_support/.
@@ -25,15 +26,23 @@ Triggers:
 
 import sys
 
+from ol_concourse.lib.constants import REGISTRY_IMAGE
 from ol_concourse.lib.containers import container_build_task, ensure_ecr_task
 from ol_concourse.lib.models.fragment import PipelineFragment
 from ol_concourse.lib.models.pipeline import (
+    AnonymousResource,
+    Command,
     GetStep,
     Identifier,
     Input,
     Job,
+    Output,
     Pipeline,
+    Platform,
     PutStep,
+    RegistryImage,
+    TaskConfig,
+    TaskStep,
 )
 from ol_concourse.lib.resources import git_repo, registry_image
 
@@ -45,6 +54,40 @@ DEFAULT_PYTHON_VERSION = "3.12"  # matches Dockerfile.base's ARG default
 
 def _version_slug(python_version: str) -> str:
     return python_version.replace(".", "")
+
+
+def _version_tag_task(xqwatcher_repo_name: str, python_version: str) -> TaskStep:
+    """Write a Python-version-suffixed additional-tags file.
+
+    Every job in the matrix builds from the same commit, so they'd all
+    derive the same tag from ``.git/describe_ref`` and race to push it —
+    whichever job finishes last would silently overwrite the others'
+    version-specific image at that tag. Suffixing with the Python version
+    keeps each job's additional tag distinct.
+    """
+    slug = _version_slug(python_version)
+    return TaskStep(
+        task=Identifier(f"collect-tags-py{slug}"),
+        config=TaskConfig(
+            platform=Platform.linux,
+            inputs=[Input(name=Identifier(xqwatcher_repo_name))],
+            outputs=[Output(name=Identifier("tags"))],
+            image_resource=AnonymousResource(
+                type=REGISTRY_IMAGE,
+                source=RegistryImage(repository="busybox"),
+            ),
+            run=Command(
+                path="sh",
+                args=[
+                    "-exc",
+                    (
+                        f'echo "$(cat ./{xqwatcher_repo_name}/.git/describe_ref)'
+                        f'-py{slug}" > tags/additional_tags'
+                    ),
+                ],
+            ),
+        ),
+    )
 
 
 def grader_base_image_pipeline() -> Pipeline:
@@ -111,20 +154,23 @@ def grader_base_image_pipeline() -> Pipeline:
                 },
             ),
             ensure_ecr_task(_BASE_IMAGE_REPO),
+            _version_tag_task(str(xqwatcher_repo.name), python_version),
             # Push to DockerHub first — fail fast if credentials are wrong
             # before consuming the ECR push quota.
             PutStep(
                 put=dockerhub_base_images[python_version].name,
+                inputs="all",
                 params={
                     "image": "image/image.tar",
-                    "additional_tags": f"./{xqwatcher_repo.name}/.git/describe_ref",
+                    "additional_tags": "tags/additional_tags",
                 },
             ),
             PutStep(
                 put=ecr_base_images[python_version].name,
+                inputs="all",
                 params={
                     "image": "image/image.tar",
-                    "additional_tags": f"./{xqwatcher_repo.name}/.git/describe_ref",
+                    "additional_tags": "tags/additional_tags",
                 },
             ),
         ]

--- a/src/ol_concourse/pipelines/open_edx/grader_images/build_pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/grader_images/build_pipeline.py
@@ -44,6 +44,9 @@ from ol_concourse.lib.models.pipeline import (
 from ol_concourse.lib.resources import registry_image, ssh_git_repo
 
 from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
+from ol_concourse.pipelines.open_edx.grader_images.base_image_pipeline import (
+    DEFAULT_PYTHON_VERSION,
+)
 
 _AWS_ACCOUNT_ID = "610119931565"
 _AWS_REGION = "us-east-1"
@@ -66,6 +69,9 @@ class GraderPipelineConfig:
         grader_base_dockerhub_repo: DockerHub repository name for the grader
             base image used as the build trigger, e.g.
             ``"mitodl/xqueue-watcher-grader-base"``.
+        grader_base_image_tag: Tag of the grader base image to build from,
+            e.g. ``"3.12"``. Matches one of the Python-version tags produced
+            by the base image's build matrix (base_image_pipeline.py).
         github_private_key: Vault path for the SSH private key used to clone
             the (private) grader repository.  Defaults to the odlbot SSH key
             stored at ``infrastructure/open_api_clients`` in Vault.
@@ -78,6 +84,7 @@ class GraderPipelineConfig:
     grader_repo_branch: str
     ecr_repo_name: str
     grader_base_dockerhub_repo: str = "mitodl/xqueue-watcher-grader-base"
+    grader_base_image_tag: str = DEFAULT_PYTHON_VERSION
     github_private_key: str = "((open_api_clients.odlbot_private_ssh_key))"
     aws_account_id: str = _AWS_ACCOUNT_ID
     aws_region: str = _AWS_REGION
@@ -115,7 +122,7 @@ def grader_image_pipeline(config: GraderPipelineConfig) -> Pipeline:
     grader_base_image = registry_image(
         name=Identifier("grader-base-image"),
         image_repository=dockerhub_ecr_image_uri(config.grader_base_dockerhub_repo),
-        image_tag="latest",
+        image_tag=config.grader_base_image_tag,
         ecr_region=config.aws_region,
     )
 


### PR DESCRIPTION
## Summary
- `base_image_pipeline.py`: build one job per Python version (3.12, 3.13, 3.14) using `Dockerfile.base`'s `ARG PYTHON_VERSION`, tagging DockerHub/ECR images with the version. The default version (3.12) additionally publishes `:latest` so nothing downstream breaks.
- `build_pipeline.py`: added `GraderPipelineConfig.grader_base_image_tag` (default `3.12`), so `graders-mit-600x` and `graders-mit-686x` now pull the explicit `3.12` matrix tag instead of the floating `:latest` tag.

## Context
Investigated why the grader base image pipeline "wasn't pulling from master" — the code in this repo already tracks `branch="master"` (fixed back in March, commit f8899aac) and matches GitHub's actual default branch. The live Concourse team `infrastructure` has **two** base-image pipelines:
- `build-grader-base-image` — correctly tracks `master`, matches current code, kept in sync by `xqwatcher-grader-images-meta`.
- `build-xqwatcher-grader-base-image` — an orphaned pipeline from an earlier iteration, still frozen on `branch: chore/migrate-to-uv-and-k8s-container-grader` and not managed by the self-updating meta pipeline. This is very likely what was being observed as "not pulling from master."

Recommend destroying the orphaned `build-xqwatcher-grader-base-image` pipeline (`fly -t odl-prod destroy-pipeline -p build-xqwatcher-grader-base-image --team infrastructure`) as a follow-up — not included here since it's a live destructive action outside this PR's diff.

## Test plan
- [x] `ruff check` / `ruff format --check` / `mypy` pass on both changed files
- [x] `grader_base_image_pipeline()` generates valid pipeline JSON with 3 build jobs (py312/py313/py314) and 9 resources
- [x] `grader_image_pipeline()` for both `graders-mit-600x` and `graders-mit-686x` resolves `grader-base-image` tag to `3.12`
- [ ] Merge to `main` and confirm `xqwatcher-grader-images-meta`'s `create-grader-base-image-pipeline` / `create-graders-mit-*-pipeline` jobs auto-apply the new definitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2CXoocFttPJrMvBettfKA