### PR TITLE
Default kubectl exec/logs to the app container instead of nginx

### DIFF
--- a/src/ol_infrastructure/components/services/k8s.py
+++ b/src/ol_infrastructure/components/services/k8s.py
@@ -1192,6 +1192,11 @@ class OLApplicationK8s(ComponentResource):
                 template=kubernetes.core.v1.PodTemplateSpecArgs(
                     metadata=kubernetes.meta.v1.ObjectMetaArgs(
                         labels=application_labels,
+                        annotations={
+                            "kubectl.kubernetes.io/default-container": (
+                                f"{ol_app_k8s_config.application_name}-app"
+                            ),
+                        },
                     ),
                     spec=kubernetes.core.v1.PodSpecArgs(
                         volumes=volumes,

--- a/src/ol_infrastructure/components/services/k8s.py
+++ b/src/ol_infrastructure/components/services/k8s.py
@@ -1213,6 +1213,9 @@ class OLApplicationK8s(ComponentResource):
             ),
             opts=deployment_options,
         )
+        self.application_deployment: kubernetes.apps.v1.Deployment = (
+            _application_deployment
+        )
 
         if (
             ol_app_k8s_config.granian_config is not None

--- a/tests/ol_infrastructure/components/services/test_k8s_extra_containers.py
+++ b/tests/ol_infrastructure/components/services/test_k8s_extra_containers.py
@@ -11,10 +11,13 @@ This module verifies:
    - application_port == metrics_port
 
 Note:
-    These tests operate at the configuration/model level and do not instantiate
-    OLApplicationK8s or assert on full Kubernetes pod specs (e.g., sidecars,
-    init containers, volumes, or pod_security_context), nor do they assert on
-    autoscaling resources such as HPAs or KEDA ScaledObjects.
+    Most of these tests operate at the configuration/model level and do not
+    instantiate OLApplicationK8s or assert on full Kubernetes pod specs (e.g.,
+    sidecars, init containers, volumes, or pod_security_context), nor do they
+    assert on autoscaling resources such as HPAs or KEDA ScaledObjects. The
+    exception is test_default_container_annotation_set_to_app_container, which
+    instantiates OLApplicationK8s under Pulumi mocks to verify the Deployment's
+    pod template annotations.
 """
 
 from __future__ import annotations
@@ -46,6 +49,7 @@ from pydantic import ValidationError  # noqa: E402
 
 from ol_infrastructure.components.services.k8s import (  # noqa: E402
     GranianConfig,
+    OLApplicationK8s,
     OLApplicationK8sCeleryBeatConfig,
     OLApplicationK8sCeleryWorkerConfig,
     OLApplicationK8sConfig,
@@ -387,6 +391,21 @@ def test_celery_beat_uses_custom_application_name():
     # is sufficient for unit testing this path.
     assert beat_cfg.application_name == "lms.celery:app"
     assert beat_cfg.application_name != "main.celery:app"
+
+
+# ─── Deployment pod template annotations ──────────────────────────────────────
+
+
+@pulumi.runtime.test
+def test_default_container_annotation_set_to_app_container():
+    """Deployment pod template must point kubectl exec/logs at the app container."""
+    cfg = _base_config(application_name="myapp")
+    app = OLApplicationK8s(cfg)
+
+    def check(annotations):
+        assert annotations["kubectl.kubernetes.io/default-container"] == "myapp-app"
+
+    return app.application_deployment.spec.template.metadata.annotations.apply(check)
 
 
 # ─── validate_no_duplicate_metrics_port ────────────────────────────────────────


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Applications deployed via `OLApplicationK8s` (`src/ol_infrastructure/components/services/k8s.py`) that run an nginx sidecar in front of the Django/webapp container had `kubectl exec`/`kubectl logs` default to the `nginx` container, since it was appended first in the pod's container list. This adds the `kubectl.kubernetes.io/default-container` annotation to the pod template, pointing it at the `<application_name>-app` container so operators land in the Django app by default without needing `-c <container>`.

### Screenshots (if appropriate):
N/A — no UI changes

### How can this be tested?
- `pulumi preview` on a stack that uses `OLApplicationK8s` with `import_nginx_config=True` and confirm the deployment's pod template gains the `kubectl.kubernetes.io/default-container` annotation set to `<application_name>-app`.
- After deploying, run `kubectl exec -it <pod> -- sh` and confirm it opens a shell in the app container (not nginx), and `kubectl logs <pod>` without `-c` streams the app container's logs.

### Additional Context
N/A