### PR TITLE
fix: missing MFE_CONFIG added for edxapp

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -224,6 +224,9 @@ def _build_interpolated_config_dict(
                 },
             },
         },
+        "MFE_CONFIG": {
+            "STUDIO_BASE_URL": f"https://{domains['studio']}/authoring",
+        },
     }
 
     # Ref: https://docs.openedx.org/en/latest/site_ops/how-tos/use_typesense_search_backend.html


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11864

### Description (What does it do?)
This pull request introduces a new configuration section for MFE (Micro-Frontend) settings in the Kubernetes config map for edX. The main addition is the inclusion of the `STUDIO_BASE_URL` key under `MFE_CONFIG`, which sets the base URL for the studio authoring interface.

Configuration updates:

* Added a new `MFE_CONFIG` section to the config map, including the `STUDIO_BASE_URL` key set to the studio authoring URL, constructed using the `domains['studio']` value.

### Additional Context
See https://github.com/mitodl/hq/issues/11864#issuecomment-4934886705 for additional context