### PR TITLE
fix(apisix): refresh default plugin list for APISIX 3.17, enable per-phase tracing

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
@@ -20,8 +20,8 @@ from ol_infrastructure.lib.ol_types import AWSBase
 from ol_infrastructure.lib.pulumi_helper import StackInfo
 
 # APISIX's default enabled-plugins list for the version shipped by the pinned
-# chart (chart 2.12.x => APISIX 3.14.x), extracted verbatim from
-# https://github.com/apache/apisix/blob/3.14.0/apisix/cli/config.lua
+# chart (chart 2.16.x => APISIX 3.17.x), extracted verbatim from
+# https://github.com/apache/apisix/blob/3.17.0/apisix/cli/config.lua
 #
 # Setting ``apisix.plugins`` in the Helm values REPLACES this default list
 # rather than extending it, so the full list must be reproduced here.  We do
@@ -31,10 +31,11 @@ from ol_infrastructure.lib.pulumi_helper import StackInfo
 # IMPORTANT: revisit this list on every APISIX major/minor upgrade.  If it
 # drifts from the APISIX default for the running version, plugins omitted here
 # will stop loading.  ``opentelemetry`` is appended at the end below.
-APISIX_DEFAULT_PLUGINS_3_14: list[str] = [
+APISIX_DEFAULT_PLUGINS_3_17: list[str] = [
     "real-ip",
     "ai",
     "client-control",
+    "proxy-buffering",
     "proxy-control",
     "request-id",
     "zipkin",
@@ -52,6 +53,7 @@ APISIX_DEFAULT_PLUGINS_3_14: list[str] = [
     "chaitin-waf",
     "multi-auth",
     "openid-connect",
+    "saml-auth",
     "cas-auth",
     "authz-casbin",
     "authz-casdoor",
@@ -62,11 +64,15 @@ APISIX_DEFAULT_PLUGINS_3_14: list[str] = [
     "jwt-auth",
     "jwe-decrypt",
     "key-auth",
+    "dingtalk-auth",
+    "feishu-auth",
+    "acl",
     "consumer-restriction",
     "attach-consumer-label",
     "forward-auth",
     "opa",
     "authz-keycloak",
+    "data-mask",
     "proxy-cache",
     "body-transformer",
     "ai-prompt-template",
@@ -79,16 +85,20 @@ APISIX_DEFAULT_PLUGINS_3_14: list[str] = [
     "ai-aws-content-moderation",
     "ai-aliyun-content-moderation",
     "proxy-mirror",
+    "graphql-proxy-cache",
     "proxy-rewrite",
     "workflow",
     "api-breaker",
+    "graphql-limit-count",
     "limit-conn",
     "limit-count",
     "limit-req",
     "gzip",
+    "traffic-label",
     "traffic-split",
     "redirect",
     "response-rewrite",
+    "oas-validator",
     "mcp-bridge",
     "degraphql",
     "kafka-proxy",
@@ -131,7 +141,7 @@ APISIX_DEFAULT_PLUGINS_3_14: list[str] = [
 # Full enabled-plugins list applied via the Helm chart: APISIX defaults plus the
 # opentelemetry plugin, which emits OTLP traces (not metrics) for every request.
 APISIX_ENABLED_PLUGINS: list[str] = [
-    *APISIX_DEFAULT_PLUGINS_3_14,
+    *APISIX_DEFAULT_PLUGINS_3_17,
     "opentelemetry",
 ]
 
@@ -187,7 +197,7 @@ def setup_apisix(
     ).strip("_")
 
     # APISIX chart uses a different chart version scheme
-    # Chart version 2.12.x contains APISIX 3.14.x
+    # Chart version 2.16.x contains APISIX 3.17.x
     apisix_chart_version = versions["APISIX_CHART"]
 
     # OpenTelemetry tracing is exported to the in-cluster Grafana Alloy receiver,
@@ -465,6 +475,11 @@ def setup_apisix(
                         else {}
                     ),
                     "trustedAddresses": fastly_ips,
+                    # Enable comprehensive per-phase request lifecycle tracing
+                    # (SSL/SNI, rewrite, access, header_filter, body_filter, log).
+                    # Available since chart 2.16.0; without it OpenTelemetry only
+                    # emits a single span per request instead of one per phase.
+                    "tracing": otel_tracing_enabled,
                     "admin": {
                         "enabled": True,
                         "type": "ClusterIP",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Prompted by the Renovate bump of the `apisix` Helm chart from 2.15.0 to 2.16.0 (mitodl/ol-infrastructure#4955), I audited [`apisix_official.py`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py) against the chart diff and the actual APISIX version we run.

**1. Refresh the hardcoded default plugin list (bug fix, independent of the 2.15→2.16 bump)**

`APISIX_DEFAULT_PLUGINS_3_14` was extracted verbatim from [APISIX 3.14.0's `config.lua`](https://github.com/apache/apisix/blob/3.14.0/apisix/cli/config.lua), but the pinned chart has shipped `appVersion: 3.17.0` since chart 2.13.0 — well before this bump. Since our Helm values set `apisix.plugins`, which **replaces** rather than extends the built-in default list, this drift has been silently disabling every plugin that APISIX 3.17.0 added to its defaults since 3.14.0:

`proxy-buffering`, `saml-auth`, `dingtalk-auth`, `feishu-auth`, `acl`, `data-mask`, `graphql-proxy-cache`, `graphql-limit-count`, `traffic-label`, `oas-validator`

This is exactly the failure mode the file's own comment warns about ("If it drifts from the APISIX default for the running version, plugins omitted here will stop loading"). Renamed the constant to `APISIX_DEFAULT_PLUGINS_3_17` and regenerated it from [APISIX 3.17.0's `config.lua`](https://github.com/apache/apisix/blob/3.17.0/apisix/cli/config.lua) plus verified against `helm pull apisix/apisix --version 3.17.0`. Also corrected two stale comments that still referenced "chart 2.12.x / APISIX 3.14.x".

**2. Enable `apisix.tracing` (new in chart 2.16.0)**

Chart 2.16.0 adds an `apisix.tracing` toggle (default `false`, preserving prior behavior) that enables comprehensive per-phase request lifecycle tracing (SSL/SNI, rewrite, access, header_filter, body_filter, log) instead of a single span per request when using the `opentelemetry` plugin. Given the existing investment in the OTel pipeline in this file (`otel_plugin_metadata`, Tempo/Alloy export), this is a low-risk, high-value option to turn on. Gated it on the existing `otel_tracing_enabled` flag so it stays off on CI, matching how the `opentelemetry` plugin itself is gated.

**Other 2.16.0 chart changes evaluated, no action needed:**
- `ingress-controller` subchart unchanged (still 1.2.0), `etcd` subchart unchanged — no core upgrade risk.
- `apisix.dns.resolvers` default changed from a hardcoded external resolver list to reading `/etc/resolv.conf`; we don't set this key so we get the improved default automatically.
- New tunables (`proxyProtocol`, `showUpstreamStatusInResponseHeader`, `graphql.maxSize`, granular `nginx.http.*` timeouts) don't apply to our current setup.

I also evaluated mitodl/ol-infrastructure#4956 ("Use apisix error page plugin", referencing [apache/apisix#13380](https://github.com/apache/apisix/pull/13380)) as part of this same chart audit. The `error-page` plugin only supports `error_404`/`error_500`/`error_502`/`error_503` in its metadata schema — no 400, 431, or 504 — while our custom error page needs `400 431 500 502 503 504` (400/431 for oversized headers being the original reason the custom mechanism exists). Adopting it would split the branded error page across two delivery mechanisms instead of simplifying it, so I closed that issue with this reasoning rather than making a code change.

### Screenshots (if appropriate):
N/A — no UI changes.

### How can this be tested?
- `uv run ruff check` and `uv run mypy` both pass on the changed file (also verified via pre-commit on this branch).
- `pulumi preview` against the `applications.eks` stack for an affected cluster should show only Helm `values` diffs for the `apache-apisix` release (`apisix.plugins` gaining the 10 plugins listed above, and `apisix.tracing: true` when `otel_tracing_enabled`) — no resource replacement.
- After deploy, confirm APISIX starts cleanly and that a trace in Grafana Tempo now shows multiple spans per request (rewrite/access/header_filter/etc.) instead of a single span, confirming `apisix.tracing` took effect.

### Additional Context
No behavior change is expected for existing traffic; the plugin additions are net-new capabilities APISIX 3.17.0 already ships by default upstream, and `apisix.tracing` only affects trace granularity, not response behavior.