### PR TITLE
fix(local-dev): add uv dependency to local-dev README

### DIFF
--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -58,6 +58,7 @@ Install these tools before running setup:
 | Helm | ≥ 3.14 | `brew install helm` |
 | mkcert | ≥ 1.4 | `brew install mkcert` |
 | Pulumi CLI | ≥ 3.x | `brew install pulumi` |
+| uv | ≥ 0.11.x | `brew install uv` |
 
 > **Docker memory:** The cluster runs PostgreSQL, Valkey, APISIX, Keycloak, Qdrant, and up to four Django apps. Allocate at least 8 GB to Docker Desktop (Settings → Resources).
 

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -58,7 +58,7 @@ Install these tools before running setup:
 | Helm | ≥ 3.14 | `brew install helm` |
 | mkcert | ≥ 1.4 | `brew install mkcert` |
 | Pulumi CLI | ≥ 3.x | `brew install pulumi` |
-| uv | ≥ 0.11.x | `brew install uv` |
+| uv | ≥ 0.9.3 | `brew install uv` |
 
 > **Docker memory:** The cluster runs PostgreSQL, Valkey, APISIX, Keycloak, Qdrant, and up to four Django apps. Allocate at least 8 GB to Docker Desktop (Settings → Resources).
 


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
The setup documentation for ol-infrastructure/local-dev has a step where running it will result in an error if `uv` is not installed.

`./local-dev/scripts/setup.sh`. 

This PR adds `uv` to the list of dependences so that setup can be completed successfully.

