### PR TITLE
fix(grafana-alerting): use generic Grafana Cloud datasource UIDs + id…

### DIFF
--- a/src/ol_infrastructure/infrastructure/grafana_alerting/CLAUDE.md
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/CLAUDE.md
@@ -14,11 +14,17 @@ ruled out due to cost (~$3,200/month at 4 probe regions × 1-minute polling cade
 
 There are three separate Grafana Cloud stacks, one per environment:
 
-| Stack | Secrets file | Mimir (metrics) UID | Loki (logs) UID |
-|---|---|---|---|
-| CI | `src/bridge/secrets/grafana_cloud/api.ci.yaml` | `grafanacloud-mitolci-prom` | `grafanacloud-mitolci-logs` |
-| QA | `src/bridge/secrets/grafana_cloud/api.qa.yaml` | `grafanacloud-mitolqa-prom` | `grafanacloud-mitolqa-logs` |
-| Production | `src/bridge/secrets/grafana_cloud/api.production.yaml` | `grafanacloud-mitolproduction-prom` | `grafanacloud-mitolproduction-logs` |
+| Stack | Secrets file |
+|---|---|
+| CI | `src/bridge/secrets/grafana_cloud/api.ci.yaml` |
+| QA | `src/bridge/secrets/grafana_cloud/api.qa.yaml` |
+| Production | `src/bridge/secrets/grafana_cloud/api.production.yaml` |
+
+Every stack provisions its own Mimir and Loki datasources under the same
+generic UIDs: `grafanacloud-prom` (Mimir) and `grafanacloud-logs` (Loki).
+The per-stack slugs shown in the UI (e.g. `grafanacloud-mitolci-prom`) are
+datasource *names*, not UIDs — using them as UIDs fails with
+"data source not found".
 
 Each stack has its own Mimir metrics backend, its own Alertmanager, and its own
 set of Grafana-managed alert rules. The Pulumi stacks (CI, QA, Production) map
@@ -94,8 +100,8 @@ needed is passed as a parameter.
 
 ```python
 alertmanager.create(grafana_secrets: dict, resource_opts: ResourceOptions)
-metric_rules.create(stack_info: StackInfo, resource_opts: ResourceOptions)
-log_rules.create(stack_info: StackInfo, resource_opts: ResourceOptions)
+metric_rules.create(resource_opts: ResourceOptions)
+log_rules.create(resource_opts: ResourceOptions)
 pingdom_checks.create(api_token: Input[str], integration_ids: list[int])
 ```
 

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/__main__.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/__main__.py
@@ -39,8 +39,8 @@ grafana_provider = grafana.Provider(
 resource_opts = ResourceOptions(provider=grafana_provider)
 
 alertmanager.create(grafana_secrets, resource_opts)
-metric_rules.create(stack_info, resource_opts)
-log_rules.create(stack_info, resource_opts)
+metric_rules.create(resource_opts)
+log_rules.create(resource_opts)
 
 # Pingdom checks are account-wide — only create from the production stack.
 if is_production:

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/alertmanager.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/alertmanager.py
@@ -97,7 +97,9 @@ def create(grafana_secrets: dict[str, Any], resource_opts: ResourceOptions) -> N
         "grafana-notification-policy",
         contact_point="oblivion",
         group_bies=["alertname", "environment"],
-        group_wait="60s",
+        # "1m", not "60s" — Grafana normalizes durations to the largest unit and
+        # a mismatched spelling shows as a perpetual diff on every preview.
+        group_wait="1m",
         group_interval="5m",
         repeat_interval="4h",
         policies=[

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/log_rules/base.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/log_rules/base.py
@@ -48,13 +48,11 @@ from ol_infrastructure.infrastructure.grafana_alerting.log_rules import (
     mit_learn,
     vault,
 )
-from ol_infrastructure.lib.pulumi_helper import StackInfo
 
-_LOKI_DATASOURCE_UID: dict[str, str] = {
-    "ci": "grafanacloud-mitolci-logs",
-    "qa": "grafanacloud-mitolqa-logs",
-    "production": "grafanacloud-mitolproduction-logs",
-}
+# Every Grafana Cloud stack provisions its own Loki datasource with this same
+# generic UID. The per-stack slug (e.g. grafanacloud-mitolci-logs) is only the
+# datasource *name*; referencing it as a UID fails with "data source not found".
+_LOKI_DATASOURCE_UID = "grafanacloud-logs"
 
 
 def _rule_data(expr: str, loki_uid: str) -> list[alerting.RuleGroupRuleDataArgs]:
@@ -64,6 +62,9 @@ def _rule_data(expr: str, loki_uid: str) -> list[alerting.RuleGroupRuleDataArgs]
         alerting.RuleGroupRuleDataArgs(
             ref_id="A",
             datasource_uid=loki_uid,
+            # Grafana copies queryType from the model up to the data envelope;
+            # omitting it here shows as a perpetual diff on every preview.
+            query_type="range",
             relative_time_range=alerting.RuleGroupRuleDataRelativeTimeRangeArgs(
                 from_=600, to=0
             ),
@@ -105,9 +106,9 @@ def _rule_data(expr: str, loki_uid: str) -> list[alerting.RuleGroupRuleDataArgs]
     ]
 
 
-def create(stack_info: StackInfo, resource_opts: ResourceOptions) -> None:
+def create(resource_opts: ResourceOptions) -> None:
     """Create all Grafana log-based alert rule groups."""
-    loki_uid = _LOKI_DATASOURCE_UID[stack_info.env_suffix]
+    loki_uid = _LOKI_DATASOURCE_UID
 
     log_alerts_folder = Folder(
         "log-alerts-folder",

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/base.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/base.py
@@ -36,13 +36,11 @@ from ol_infrastructure.infrastructure.grafana_alerting.metric_rules import (
     eks_general,
     linux_host,
 )
-from ol_infrastructure.lib.pulumi_helper import StackInfo
 
-_MIMIR_DATASOURCE_UID: dict[str, str] = {
-    "ci": "grafanacloud-mitolci-prom",
-    "qa": "grafanacloud-mitolqa-prom",
-    "production": "grafanacloud-mitolproduction-prom",
-}
+# Every Grafana Cloud stack provisions its own Mimir datasource with this same
+# generic UID. The per-stack slug (e.g. grafanacloud-mitolci-prom) is only the
+# datasource *name*; referencing it as a UID fails with "data source not found".
+_MIMIR_DATASOURCE_UID = "grafanacloud-prom"
 
 
 def _rule_data(expr: str, mimir_uid: str) -> list[alerting.RuleGroupRuleDataArgs]:
@@ -93,9 +91,9 @@ def _rule_data(expr: str, mimir_uid: str) -> list[alerting.RuleGroupRuleDataArgs
     ]
 
 
-def create(stack_info: StackInfo, resource_opts: ResourceOptions) -> None:
+def create(resource_opts: ResourceOptions) -> None:
     """Create all Grafana metric alert rule groups."""
-    mimir_uid = _MIMIR_DATASOURCE_UID[stack_info.env_suffix]
+    mimir_uid = _MIMIR_DATASOURCE_UID
 
     alerts_folder = Folder(
         "infrastructure-alerts-folder",


### PR DESCRIPTION
Grafana Cloud provisions every stack's Mimir/Loki datasources with the generic UIDs grafanacloud-prom / grafanacloud-logs; the per-stack slugs (grafanacloud-mitolci-prom etc.) are datasource names, not UIDs. Using the names put all 53 rules in Error state ('data source not found'), firing error alerts through Rootly.

Also aligns two fields with Grafana's normalized form to eliminate perpetual preview diffs: group_wait '60s' -> '1m', and explicit query_type='range' on log rule Stage A queries.

Verified on CI: pulumi preview clean, all 53 rules health=ok.

