### PR TITLE
feat(concourse): add deploy key secret for platform-engineering-site pipeline

### DIFF
--- a/src/bridge/secrets/concourse/operations.production.yaml
+++ b/src/bridge/secrets/concourse/operations.production.yaml
@@ -1,3 +1,4 @@
+---
 web:
   admin_password: ENC[AES256_GCM,data:w1vE7aq0YYyNcSbv50HeCsf+lXhtgUOQqq+TBHeKZVf1WWNUGANeIwSGbg==,iv:ye1Xb3d4p4EC4p/kkX3YFaWWGQPQps9cb9frTRREe5A=,tag:T/1SlD+GYYSySzS2mHfyJg==,type:str]
   encryption_key: ENC[AES256_GCM,data:8ciFRgvagnKxCYxlfQ8TyFYuTmgTmFk5agUAUvzFDO8=,iv:TmgKGq+w/XuTv1m5mdSrrReKHxOXsPOtxQSVaYRA3Ho=,tag:VtLosDk4TCtoBj9iEGvtcg==,type:str]
@@ -135,16 +136,16 @@ pipelines:
     deploy_key: ENC[AES256_GCM,data:9yGK4qEAhn0TNM+IsRHoIhGHB5FOsIl9KkH9ZmYd3J3/8Z56wfu1UvRpyCeteOTN8Oo9AiXyLYbv+WXs/rsE3A+BfFY+IAPcqLWj6vOwjQictWkwbRH2TreoRrOFoBqj4/reL4yqV1+b7hu2IHzdDJOzLDZ0cNQx/9m8wf6ZlARCM2Y3gx+jQf2+2JEqHNz1tPjX0ga4a0A5uutH7yDL3p+QOXN0KG8IRpDJHhUXBPEQ8MstWEcp3M91IH1WdJJSzsdeh7gyMO2us5+p4XAAA2GiB7gXd4rn+r0W9EG8gniqKdE4+cFon5b7Zikn+YwTBEaaN1AiZHE6N42I1tzrpoAu4kN+ZDyvGG94dM5iUO+BQ3AQo1TMD9FzRlgjfHDwU6/1YYp74tg0grMJXZZytYz6W4gpjoKbdlMUDn5F/ZpeAlfatESX1Sx70fxFZJh7ywg1TeSei8RDJhRJT+3rne9VYVJox4mC/7HnadS5SrUyzISvBTIJ5bMbFLyD9EWhHO7OLvP2zF7MXCneN9njNYumet+QcOHzJLhZ756eYGN8pb2lw2w3WjMsEpKjiLPr1d6jtfEp/3M9mg2wRhyVc9+VWr6cZXJ6nEcTnew3HFY=,iv:/4H2QQuoM7xtuYLY/iJfTocTcLsqs5dDF3wLH05gzAc=,tag:YLxMpqO1Y7Zyo2iPAq+JRg==,type:str]
 sops:
   hc_vault:
-    - created_at: "2026-03-02T21:52:45Z"
-      enc: vault:v1:1CspMw0PIoKfgF0J5C02Xn0iO0tXQ6kn2q+JNINFqNAzYFWEQmQEC89QNkPxvpIl2iB3VeRXuN8qZ3vt
-      engine_path: infrastructure
-      key_name: sops
-      vault_address: https://vault-production.odl.mit.edu
+  - created_at: "2026-03-02T21:52:45Z"
+    enc: vault:v1:1CspMw0PIoKfgF0J5C02Xn0iO0tXQ6kn2q+JNINFqNAzYFWEQmQEC89QNkPxvpIl2iB3VeRXuN8qZ3vt
+    engine_path: infrastructure
+    key_name: sops
+    vault_address: https://vault-production.odl.mit.edu
   kms:
-    - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
-      aws_profile: ""
-      created_at: "2026-03-02T21:52:45Z"
-      enc: AQICAHi3FG4qowC3UzOLWOAA4Y9/RTwqKjovG3wyVVYDxkR+zAGhPzBxC+b94u64oL/jJUgdAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMsERB+69NhG26KzOFAgEQgDvT8FHmtW6oWyzK3X7gdSYHJOVvNe5YbXefba0GwVI/rHZFw87+ceYD8rnBiZKmO25CKKg2WTWOGPJuAA==
+  - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
+    aws_profile: ""
+    created_at: "2026-03-02T21:52:45Z"
+    enc: AQICAHi3FG4qowC3UzOLWOAA4Y9/RTwqKjovG3wyVVYDxkR+zAGhPzBxC+b94u64oL/jJUgdAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMsERB+69NhG26KzOFAgEQgDvT8FHmtW6oWyzK3X7gdSYHJOVvNe5YbXefba0GwVI/rHZFw87+ceYD8rnBiZKmO25CKKg2WTWOGPJuAA==
   lastmodified: "2026-07-10T19:41:03Z"
   mac: ENC[AES256_GCM,data:MGEZ1Ya4zoPOtlb9dQRzNwRMMqtpDUSGPzIfvjqctmGX38EFGFA6cNOF6ldTU/CxvtHhCQP+c2Ed5deg/rRS/gRX4zZfZv6wXNJKKE4jSUBeDaClAS90xXihj+2zLTX5iB9Wn/HU6e+qtEqOq/wU8FeoAbBqsOgrDyv13dPn3wg=,iv:qJAjR0QxK+xw/IdVlIu1kNqsQ5lz1ieI/fN23AH95iI=,tag:mEr3Yh8CXnwKaA0gSL24CQ==,type:str]
   unencrypted_suffix: _unencrypted

--- a/src/bridge/secrets/concourse/operations.production.yaml
+++ b/src/bridge/secrets/concourse/operations.production.yaml
@@ -1,4 +1,3 @@
----
 web:
   admin_password: ENC[AES256_GCM,data:w1vE7aq0YYyNcSbv50HeCsf+lXhtgUOQqq+TBHeKZVf1WWNUGANeIwSGbg==,iv:ye1Xb3d4p4EC4p/kkX3YFaWWGQPQps9cb9frTRREe5A=,tag:T/1SlD+GYYSySzS2mHfyJg==,type:str]
   encryption_key: ENC[AES256_GCM,data:8ciFRgvagnKxCYxlfQ8TyFYuTmgTmFk5agUAUvzFDO8=,iv:TmgKGq+w/XuTv1m5mdSrrReKHxOXsPOtxQSVaYRA3Ho=,tag:VtLosDk4TCtoBj9iEGvtcg==,type:str]
@@ -132,19 +131,21 @@ pipelines:
     issues_resource_access_token: ENC[AES256_GCM,data:cOy4jUFY1imaR4UPjxAaLZhuEf+T3krFqa+X4109a9jDEPwdVMdliQ==,iv:jiaWleBUNiJufOlJQ6SEkv/Xw546yr8hfaW6IIXdfnc=,tag:22FvFtejZ1HfKD8kyx7C0A==,type:str]
   xpro/github:
     issues_resource_access_token: ENC[AES256_GCM,data:YLZPtMLllhKyL5C61Gf7a6co9pYDwYBm+bMQKYXedGoHi0LAVlElbQ==,iv:P9za4OkGGTudeYH5jQUn6dQXo8vn+poQj3dMw7OCpi0=,tag:o4ZMCx+ow0+mjjRlbDovBg==,type:str]
+  main/platform_engineering_site:
+    deploy_key: ENC[AES256_GCM,data:9yGK4qEAhn0TNM+IsRHoIhGHB5FOsIl9KkH9ZmYd3J3/8Z56wfu1UvRpyCeteOTN8Oo9AiXyLYbv+WXs/rsE3A+BfFY+IAPcqLWj6vOwjQictWkwbRH2TreoRrOFoBqj4/reL4yqV1+b7hu2IHzdDJOzLDZ0cNQx/9m8wf6ZlARCM2Y3gx+jQf2+2JEqHNz1tPjX0ga4a0A5uutH7yDL3p+QOXN0KG8IRpDJHhUXBPEQ8MstWEcp3M91IH1WdJJSzsdeh7gyMO2us5+p4XAAA2GiB7gXd4rn+r0W9EG8gniqKdE4+cFon5b7Zikn+YwTBEaaN1AiZHE6N42I1tzrpoAu4kN+ZDyvGG94dM5iUO+BQ3AQo1TMD9FzRlgjfHDwU6/1YYp74tg0grMJXZZytYz6W4gpjoKbdlMUDn5F/ZpeAlfatESX1Sx70fxFZJh7ywg1TeSei8RDJhRJT+3rne9VYVJox4mC/7HnadS5SrUyzISvBTIJ5bMbFLyD9EWhHO7OLvP2zF7MXCneN9njNYumet+QcOHzJLhZ756eYGN8pb2lw2w3WjMsEpKjiLPr1d6jtfEp/3M9mg2wRhyVc9+VWr6cZXJ6nEcTnew3HFY=,iv:/4H2QQuoM7xtuYLY/iJfTocTcLsqs5dDF3wLH05gzAc=,tag:YLxMpqO1Y7Zyo2iPAq+JRg==,type:str]
 sops:
-  kms:
-  - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
-    created_at: "2026-03-02T21:52:45Z"
-    enc: AQICAHi3FG4qowC3UzOLWOAA4Y9/RTwqKjovG3wyVVYDxkR+zAGhPzBxC+b94u64oL/jJUgdAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMsERB+69NhG26KzOFAgEQgDvT8FHmtW6oWyzK3X7gdSYHJOVvNe5YbXefba0GwVI/rHZFw87+ceYD8rnBiZKmO25CKKg2WTWOGPJuAA==
-    aws_profile: ""
   hc_vault:
-  - vault_address: https://vault-production.odl.mit.edu
-    engine_path: infrastructure
-    key_name: sops
-    created_at: "2026-03-02T21:52:45Z"
-    enc: vault:v1:1CspMw0PIoKfgF0J5C02Xn0iO0tXQ6kn2q+JNINFqNAzYFWEQmQEC89QNkPxvpIl2iB3VeRXuN8qZ3vt
-  lastmodified: "2026-06-18T17:30:53Z"
-  mac: ENC[AES256_GCM,data:zCpMymxm40uuX5S0aAjJhOJ7chReCAsK9QQCTetWQo3Y7Yh8NeEF0KLvFvnpcKsLvXQVKzKfwyibqo13apBchYsy5R8qd36A3+tFJGWzFCBN5O+JT7Of0jhQ30TR8k9vM+ezH1qzVVCoyb/LSOj0hTOlJaOsc6mNuVxn34K80wo=,iv:CYZMGNTsZoOn5tTVgQCQMfFQnTBYwfy8P2PFYVusDXo=,tag:InyfFut/dyOrHkap/AtCvg==,type:str]
+    - created_at: "2026-03-02T21:52:45Z"
+      enc: vault:v1:1CspMw0PIoKfgF0J5C02Xn0iO0tXQ6kn2q+JNINFqNAzYFWEQmQEC89QNkPxvpIl2iB3VeRXuN8qZ3vt
+      engine_path: infrastructure
+      key_name: sops
+      vault_address: https://vault-production.odl.mit.edu
+  kms:
+    - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
+      aws_profile: ""
+      created_at: "2026-03-02T21:52:45Z"
+      enc: AQICAHi3FG4qowC3UzOLWOAA4Y9/RTwqKjovG3wyVVYDxkR+zAGhPzBxC+b94u64oL/jJUgdAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMsERB+69NhG26KzOFAgEQgDvT8FHmtW6oWyzK3X7gdSYHJOVvNe5YbXefba0GwVI/rHZFw87+ceYD8rnBiZKmO25CKKg2WTWOGPJuAA==
+  lastmodified: "2026-07-10T19:41:03Z"
+  mac: ENC[AES256_GCM,data:MGEZ1Ya4zoPOtlb9dQRzNwRMMqtpDUSGPzIfvjqctmGX38EFGFA6cNOF6ldTU/CxvtHhCQP+c2Ed5deg/rRS/gRX4zZfZv6wXNJKKE4jSUBeDaClAS90xXihj+2zLTX5iB9Wn/HU6e+qtEqOq/wU8FeoAbBqsOgrDyv13dPn3wg=,iv:qJAjR0QxK+xw/IdVlIu1kNqsQ5lz1ieI/fN23AH95iI=,tag:mEr3Yh8CXnwKaA0gSL24CQ==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.13.1


### PR DESCRIPTION
## Problem

The `platform-engineering-site` Concourse pipeline's `site-repo` git resource references `((platform_engineering_site.deploy_key))`, but that credential was never created in Vault. The resource check has always errored:

```
resource config creds evaluation: undefined vars: platform_engineering_site.deploy_key
```

So the pipeline has never been able to auto-deploy pushes to `main` on [mitodl/platform-engineering-site](https://github.com/mitodl/platform-engineering-site) to `gh-pages` / https://pe.ol.mit.edu.

## Change

Adds a new write-access deploy keypair's private half as a SOPS-encrypted secret at `pipelines: "main/platform_engineering_site": {deploy_key: ...}` in `operations.production.yaml`. On merge, the Concourse app's Pulumi program (`src/ol_infrastructure/applications/concourse/__main__.py`) will write this to production Vault at `secret-concourse/main/platform_engineering_site`, matching Concourse's default credential lookup template.

The matching public key has already been added as a write-access deploy key on `mitodl/platform-engineering-site` (key id 156939389).

## Follow-up (tracked in #4884)

Once this merges and the secret is live in Vault:
1. Verify `fly -t pr-main check-resource -r platform-engineering-site/site-repo` succeeds
2. Unpause the pipeline: `fly -t pr-main unpause-pipeline -p platform-engineering-site`
3. Verify a push to `main` on platform-engineering-site auto-triggers a build and deploy

Ref: #4884