### PR TITLE
fix: Opik SDK bearer auth via JWKS + protect single-replica ClickHouse from Karpenter

### DIFF
--- a/docs/clickhouse-llmops-runbook.md
+++ b/docs/clickhouse-llmops-runbook.md
@@ -72,17 +72,24 @@ b. Add to the `vault.kv.SecretV2` data_json:
 .apply(json.dumps)  # add langfuse=langfuse_password to the Output.all()
 ```
 
-c. Add the user block to `USERS_XML_TEMPLATE`:
-```xml
-<langfuse>
-  <password_sha256_hex>{{ get .Secrets "langfuse" | sha256sum }}</password_sha256_hex>
-  <profile>llmops_profile</profile>
-  <quota>llmops_quota</quota>
-  <allow_databases>
-    <database>langfuse_db</database>
-  </allow_databases>
-</langfuse>
+c. Add the user block to the operator-native `ch_users` map:
+```python
+"langfuse/password_sha256_hex": _secret_ref("langfuse_sha256"),
+"langfuse/profile": "llmops_profile",
+"langfuse/quota": "llmops_quota",
+"langfuse/networks/ip": ["::/0", "0.0.0.0/0"],
+"langfuse/grants/query": [
+    "GRANT ALL ON langfuse_db.*",
+],
 ```
+
+Prefer explicit `grants/query` entries over the legacy `allow_databases/database`
+whitelist. `allow_databases` restricts the user's RBAC grants to *only* the listed
+application databases, which denies access to any `system.*` table. If the tool
+queries `system.parts` (or other system tables) — as opik does for storage
+metrics — add a targeted `"GRANT SELECT ON system.parts"` rather than exposing the
+whole `system` database, so cross-tenant isolation (e.g. `system.query_log`) is
+preserved.
 
 d. Add `"langfuse"` to the `LLMOPS_NAMESPACES` list for NetworkPolicy.
 

--- a/src/ol_infrastructure/applications/clickhouse/__main__.py
+++ b/src/ol_infrastructure/applications/clickhouse/__main__.py
@@ -282,7 +282,9 @@ def _create_clickhouse_keeper_installation(  # noqa: PLR0913
                             **(
                                 {
                                     "metadata": {
-                                        "annotations": {"karpenter.sh/do-not-disrupt": "true"},
+                                        "annotations": {
+                                            "karpenter.sh/do-not-disrupt": "true"
+                                        },
                                     },
                                 }
                                 if replicas == 1
@@ -557,7 +559,9 @@ def _create_clickhouse_installation(  # noqa: PLR0913
                             **(
                                 {
                                     "metadata": {
-                                        "annotations": {"karpenter.sh/do-not-disrupt": "true"},
+                                        "annotations": {
+                                            "karpenter.sh/do-not-disrupt": "true"
+                                        },
                                     },
                                 }
                                 if ch_replicas == 1

--- a/src/ol_infrastructure/applications/clickhouse/__main__.py
+++ b/src/ol_infrastructure/applications/clickhouse/__main__.py
@@ -484,13 +484,26 @@ def _create_clickhouse_installation(  # noqa: PLR0913
         "opik/profile": "llmops_profile",
         "opik/quota": "llmops_quota",
         "opik/networks/ip": ["::/0", "0.0.0.0/0"],
-        # ``default`` is required in addition to ``opik_db``: opik's Liquibase
+        # Explicit RBAC grants (rendered as <grants><query>…</query></grants> in
+        # the user's XML) instead of the legacy <allow_databases> whitelist.
+        # ``allow_databases`` restricts the user's grants to *only* the listed
+        # application databases, which denies opik the SELECT on ``system.parts``
+        # it needs to compute per-workspace/table storage metrics (Code: 497
+        # ACCESS_DENIED SELECT(...) ON system.parts). Enumerating grants lets us
+        # add that one system-table read without opening the whole ``system``
+        # database (preserving cross-tenant isolation vs. e.g. system.query_log).
+        #
+        # ``default`` is granted in addition to ``opik_db``: opik's Liquibase
         # migrations hard-code the DATABASECHANGELOG / DATABASECHANGELOGLOCK
         # bookkeeping tables (and the replicated ``...1`` shadow tables from
         # 000017_change_tables_to_replicated) into the ``default`` database,
         # while application tables live in ``opik_db``. ``default`` is otherwise
         # an unused scratch database in this cluster.
-        "opik/allow_databases/database": ["opik_db", "default"],
+        "opik/grants/query": [
+            "GRANT ALL ON opik_db.*",
+            "GRANT ALL ON default.*",
+            "GRANT SELECT ON system.parts",
+        ],
     }
 
     return Output.all(

--- a/src/ol_infrastructure/applications/clickhouse/__main__.py
+++ b/src/ol_infrastructure/applications/clickhouse/__main__.py
@@ -553,16 +553,16 @@ def _create_clickhouse_installation(  # noqa: PLR0913
                     "podTemplates": [
                         {
                             "name": "clickhouse-pod-template",
-                            # Karpenter must not evict ClickHouse during
-                            # consolidation: with replicas=1 (CI/QA) a voluntary
-                            # drain takes down the shared installation — and every
-                            # dependent app (opik, openlit) — for the minutes the
-                            # pod and its EBS volume need to move to a new node.
-                            "metadata": {
-                                "annotations": {
-                                    "karpenter.sh/do-not-disrupt": "true",
-                                },
-                            },
+                            # Prevent Karpenter consolidation from disrupting single-replica ClickHouse.
+                            **(
+                                {
+                                    "metadata": {
+                                        "annotations": {"karpenter.sh/do-not-disrupt": "true"},
+                                    },
+                                }
+                                if ch_replicas == 1
+                                else {}
+                            ),
                             "spec": {
                                 "serviceAccountName": "clickhouse",
                                 "tolerations": ch_tolerations,

--- a/src/ol_infrastructure/applications/clickhouse/__main__.py
+++ b/src/ol_infrastructure/applications/clickhouse/__main__.py
@@ -278,15 +278,16 @@ def _create_clickhouse_keeper_installation(  # noqa: PLR0913
                     "podTemplates": [
                         {
                             "name": "keeper-pod",
-                            # Karpenter must not evict Keeper during consolidation:
-                            # with keeper_replicas=1 (CI/QA) a voluntary drain
-                            # stalls all replicated-table writes until the pod and
-                            # its EBS volume finish moving to a new node.
-                            "metadata": {
-                                "annotations": {
-                                    "karpenter.sh/do-not-disrupt": "true",
-                                },
-                            },
+                            # Prevent Karpenter consolidation from disrupting single-replica Keeper.
+                            **(
+                                {
+                                    "metadata": {
+                                        "annotations": {"karpenter.sh/do-not-disrupt": "true"},
+                                    },
+                                }
+                                if replicas == 1
+                                else {}
+                            ),
                             "spec": {
                                 "securityContext": {"fsGroup": 101},
                                 "tolerations": tolerations,

--- a/src/ol_infrastructure/applications/clickhouse/__main__.py
+++ b/src/ol_infrastructure/applications/clickhouse/__main__.py
@@ -278,6 +278,15 @@ def _create_clickhouse_keeper_installation(  # noqa: PLR0913
                     "podTemplates": [
                         {
                             "name": "keeper-pod",
+                            # Karpenter must not evict Keeper during consolidation:
+                            # with keeper_replicas=1 (CI/QA) a voluntary drain
+                            # stalls all replicated-table writes until the pod and
+                            # its EBS volume finish moving to a new node.
+                            "metadata": {
+                                "annotations": {
+                                    "karpenter.sh/do-not-disrupt": "true",
+                                },
+                            },
                             "spec": {
                                 "securityContext": {"fsGroup": 101},
                                 "tolerations": tolerations,
@@ -543,6 +552,16 @@ def _create_clickhouse_installation(  # noqa: PLR0913
                     "podTemplates": [
                         {
                             "name": "clickhouse-pod-template",
+                            # Karpenter must not evict ClickHouse during
+                            # consolidation: with replicas=1 (CI/QA) a voluntary
+                            # drain takes down the shared installation — and every
+                            # dependent app (opik, openlit) — for the minutes the
+                            # pod and its EBS volume need to move to a new node.
+                            "metadata": {
+                                "annotations": {
+                                    "karpenter.sh/do-not-disrupt": "true",
+                                },
+                            },
                             "spec": {
                                 "serviceAccountName": "clickhouse",
                                 "tolerations": ch_tolerations,

--- a/src/ol_infrastructure/applications/opik/__main__.py
+++ b/src/ol_infrastructure/applications/opik/__main__.py
@@ -344,6 +344,11 @@ opik_session_oidc_plugin = opik_oidc.get_full_oidc_plugin_config(unauth_action="
 # clients get a clean 401 instead of an HTML login page.
 opik_bearer_oidc_plugin = opik_oidc.get_full_oidc_plugin_config(unauth_action="deny")
 opik_bearer_oidc_plugin["config"]["bearer_only"] = True
+# Verify the JWT signature locally against Keycloak's JWKS. Without this the
+# plugin falls back to token introspection, and Keycloak reports active: false
+# for client-credentials service-account tokens (transient sessions), so every
+# SDK request would 401 even with a freshly-issued valid token.
+opik_bearer_oidc_plugin["config"]["use_jwks"] = True
 
 # Match ``/api/*`` requests that carry a Bearer ``Authorization`` header so they
 # are routed to the bearer-only rule; everything else under ``/api`` falls


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Three fixes for the Opik/ClickHouse deployment on the data EKS cluster:

**1. Opik: accept SDK bearer tokens by validating JWTs via JWKS (`fix(opik)`)**

SDK / programmatic clients authenticating with a Keycloak client-credentials token (`ol-opik-client` service account) were getting a 401 from the APISIX gateway on every request, even with a freshly issued, valid token.

Root cause: the bearer-only `openid-connect` plugin config on the `/api/*` route never set `use_jwks`, so APISIX fell back to **token introspection** — and Keycloak reports `active: false` when introspecting client-credentials service-account tokens (transient sessions in recent Keycloak versions). The route could therefore never accept any token the client produced.

Fix: set `use_jwks: true` on the bearer route's plugin config so the gateway verifies the JWT signature locally against Keycloak's JWKS, matching the documented intent and sidestepping introspection entirely.

**2. ClickHouse: protect single-replica pods from Karpenter consolidation (`fix(clickhouse)`)**

Adds the `karpenter.sh/do-not-disrupt: "true"` pod annotation to both the ClickHouse Keeper and ClickHouse server pod templates. With `replicas=1` (CI/QA), a voluntary Karpenter drain takes down the shared installation — and every dependent app (opik, openlit) — for the minutes it takes the pod and its EBS volume to move to a new node; a Keeper eviction stalls all replicated-table writes for the same window.

**3. ClickHouse: grant opik the `system.parts` read it needs via explicit RBAC grants (`fix(clickhouse)`)**

Opik queries `system.parts` to compute per-workspace/table storage metrics, and was hitting `Code: 497 ACCESS_DENIED SELECT(...) ON system.parts`. The opik user was configured with the legacy `allow_databases` whitelist, which restricts the user's RBAC grants to *only* the listed application databases and therefore denies access to any `system.*` table.

Fix: replace `opik/allow_databases/database` with an explicit `opik/grants/query` list (`GRANT ALL ON opik_db.*`, `GRANT ALL ON default.*`, `GRANT SELECT ON system.parts`). This grants the one system-table read opik needs without exposing the whole `system` database, preserving cross-tenant isolation (e.g. `system.query_log`). The runbook (`docs/clickhouse-llmops-runbook.md`) is updated to document the operator-native `ch_users` grants approach and to steer new tenants toward explicit `grants/query` over `allow_databases`.

### How can this be tested?
- `pulumi preview --stack CI --diff` for `ol-application-opik` shows the only auth-related change is `+ use_jwks: true` on the bearer route's plugin config (no replacements/deletions). `pre-commit` (ruff, mypy, detect-secrets) passes.
- After deploy, smoke-test the SDK path: obtain a client-credentials access token from Keycloak as `ol-opik-client` and call `https://opik-ci.ol.mit.edu/api/...` with `Authorization: Bearer <token>` — it should return 200 instead of 401. Requests without a token should still get a clean 401, and browser/session auth should be unchanged.
- For the Karpenter change, verify the annotation lands on the pods after deploy: `kubectl -n clickhouse get pods -o jsonpath='{.items[*].metadata.annotations.karpenter\.sh/do-not-disrupt}'` should print `true` for the server and keeper pods.
- For the ClickHouse grants change, confirm opik's storage-metrics queries succeed (no more `Code: 497 ACCESS_DENIED` on `system.parts`), and verify the opik user's effective grants with `SHOW GRANTS FOR opik` — it should show grants on `opik_db.*`, `default.*`, and `SELECT ON system.parts`, but no broader `system` access.

### Additional Context
Note for reviewers: the Opik CI stack has undeployed drift that will ship alongside this change on the next `pulumi up` — the Helm chart bump (2.0.77 → 2.1.20), the bearer-route header regex tightening (`.+` → `^Bearer\s`), and the session idling/rolling timeout settings already on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
