### PR TITLE
fix(s3): disable archive tiering on data lake landing zone bucket

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
@@ -111,9 +111,13 @@ data_landing_zone_bucket = OLBucket(
         sse_algorithm="aws:kms",
         bucket_key_enabled=True,
         tags=aws_config.tags,
-        # Data landing zone is write-heavy ingest storage: safe for archive tiers.
-        intelligent_tiering_archive_access_days=90,
-        intelligent_tiering_deep_archive_access_days=180,
+        # Archive/deep-archive tiers disabled: Airbyte's source-s3 connector
+        # full-scans and re-opens every historical object in this bucket on
+        # every sync, and archived objects raise InvalidObjectState until
+        # explicitly restored. Revisit once sources here move to incremental
+        # (dlt) extraction that doesn't re-read old files.
+        intelligent_tiering_archive_access_days=None,
+        intelligent_tiering_deep_archive_access_days=None,
     ),
     opts=ResourceOptions(
         aliases=[


### PR DESCRIPTION
### What are the relevant tickets?
N/A — incident follow-up, tracked as witan task `tk-prioritize-s3-file-based-sources-edxorg-in-airby-552536` under the Airbyte→dlt migration project.

### Description (What does it do?)
The edxorg S3 Airbyte connection started failing its stream availability check with:

```
airbyte_cdk.sources.file_based.exceptions.CheckAvailabilityError: Error opening file. Please check the credentials provided in the config...
stream=raw__edxorg__s3__mitx_course file=edxorg-raw-data/edxorg/api_data/course_metadata/....json
```

(masked behind an `UnboundLocalError` in the connector's own exception handling, `source_s3/v4/stream_reader.py:206`, which swallows the real error).

Root cause: `ol-data-lake-landing-zone-production` has S3 Intelligent-Tiering configured with Archive Access at 90 days and Deep Archive Access at 180 days (`intelligent_tiering_archive_access_days=90` / `intelligent_tiering_deep_archive_access_days=180` on the `OLBucket` config in `src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py`). Objects older than ~6 months had aged into `ARCHIVE_ACCESS` and return `InvalidObjectState: The operation is not valid for the object's access tier` on `GetObject`.

Airbyte's `source-s3` file-based connector does a full listing + per-file availability check across the entire prefix on *every* sync, including files ingested long ago, so this recurs as more objects age past the threshold — it isn't a one-off.

This PR removes the archive/deep-archive day thresholds for this one bucket only (sets both to `None`). Confirmed via `pulumi preview --diff` against the `Production` stack that this deletes exactly one resource — the `aws:s3/bucketIntelligentTieringConfiguration:BucketIntelligentTieringConfiguration` for `ol-data-lake-landing-zone-production` — with 90 other resources unchanged. The base `INTELLIGENT_TIERING` storage-class transition (day 90) is untouched, as is every other bucket built through the shared `OLBucket` component (~20 call sites across the repo) — the archive-day fields are set per call site, not in the shared component logic.

As an immediate mitigation (already done, outside this PR), the 752 objects that had aged into `ARCHIVE_ACCESS`/`DEEP_ARCHIVE_ACCESS` across the edxorg `course_metadata`, `course_run_metadata`, `program_course_metadata`, and `program_metadata` prefixes were restored via `aws s3api restore-object` (Standard tier) so the current sync can complete.

This is a "for now" fix — a witan task has been filed to prioritize migrating S3 file-based Airbyte sources (starting with edxorg) to dlt with incremental/cursor-based extraction, which doesn't re-scan the full file history on every run and wouldn't depend on disabling archive tiering.

### Screenshots (if appropriate):

### How can this be tested?
```
cd src/ol_infrastructure/infrastructure/aws/data_warehouse
pulumi stack select Production
pulumi preview --diff
```
Expect exactly one delete: the `standard-tiering` `BucketIntelligentTieringConfiguration` on `ol-data-lake-landing-zone-production`, with all other resources unchanged.

### Additional Context
No established pattern exists in this repo for prefix-scoped lifecycle rules (checked — zero usages of `BucketLifecycleConfigurationRuleFilterArgs` anywhere in `src/ol_infrastructure`), so disabling archive tiering bucket-wide for the landing zone was the minimal, lowest-risk change rather than inventing a new prefix-exclusion mechanism in the shared `OLBucket` component for this one incident.