### PR TITLE
fix(local-dev): repair account-creation flow, expose Mailpit, require email verification

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -225,6 +225,18 @@ local_resource(
     resource_deps=["local-infra-apps"],
 )
 
+# Re-assert the realm's browser/first-broker-login flow bindings. The Keycloak
+# provider resets them to built-in defaults whenever the keycloak.Realm resource
+# is updated for an unrelated reason (see script comment) — Pulumi never
+# reapplies the Bindings resource to fix it since its own inputs didn't change.
+local_resource(
+    "kc-fix-flow-bindings",
+    cmd="LOCAL_DEV_ROOT_DOMAIN={rd} {script}".format(rd=root_domain, script="{}/local-dev/scripts/kc-fix-flow-bindings.sh".format(config.main_dir)),
+    deps=["./local-dev/scripts/kc-fix-flow-bindings.sh"],
+    labels=["infra"],
+    resource_deps=["local-infra-apps"],
+)
+
 # ---------------------------------------------------------------------------
 # Per-app deployment + manual seed resources
 # ---------------------------------------------------------------------------

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -329,12 +329,7 @@ kubectl exec -n local-infra local-pg-1 -- psql -U app -d mitlearn
 
 ### Inspect emails (Mailpit)
 
-All outbound email is captured by Mailpit. Access the web UI:
-
-```bash
-kubectl port-forward -n local-infra svc/mailpit 8025:8025
-open http://localhost:8025
-```
+All outbound email is captured by Mailpit. Access the web UI at `https://mail.mit.dev`.
 
 ---
 

--- a/local-dev/infra/apps_infra/__main__.py
+++ b/local-dev/infra/apps_infra/__main__.py
@@ -38,6 +38,12 @@ root_domain = config.get("root_domain") or os.environ.get(
 keycloak_hostname = config.get("keycloak_hostname") or f"sso.ol.{root_domain}"
 keycloak_url = config.get("keycloak_url") or f"https://{keycloak_hostname}"
 
+# Mirrors production by default; override locally (uncommitted) with:
+#   pulumi config set --stack local-dev.apps-infra.Dev verify_email false
+verify_email = config.get_bool("verify_email")
+if verify_email is None:
+    verify_email = True
+
 # Client secrets for OIDC configuration
 mitlearn_client_secret = config.require_secret("mitlearn_client_secret")
 learn_ai_client_secret = config.require_secret("learn_ai_client_secret")
@@ -90,6 +96,7 @@ create_olapps_dev_realm(
     learn_ai_client_secret=learn_ai_client_secret,
     mitxonline_client_secret=mitxonline_client_secret,
     unified_ecommerce_client_secret=unified_ecommerce_client_secret,
+    verify_email=verify_email,
 )
 
 # ---------------------------------------------------------------------------

--- a/local-dev/infra/core/__main__.py
+++ b/local-dev/infra/core/__main__.py
@@ -156,7 +156,13 @@ create_cache(_k8s, namespaces["local-infra"])
 
 search = create_search(_k8s, namespaces["local-infra"])
 
-messaging = create_messaging(_k8s, namespaces["local-infra"])
+messaging = create_messaging(
+    _k8s,
+    namespaces["local-infra"],
+    apisix_release=ingress.apisix,
+    tls_secret=tls.tls_secret,
+    mail_hostname=f"mail.{root_domain}",
+)
 
 # Create database cluster (needed by Keycloak, LiteLLM)
 db = create_database(_k8s, namespaces["local-infra"], cnpg_version)

--- a/local-dev/infra/modules/keycloak.py
+++ b/local-dev/infra/modules/keycloak.py
@@ -41,7 +41,8 @@ def create_olapps_dev_realm(  # noqa: PLR0913
 
     Provisions all clients and stores OIDC credentials as plain k8s Secrets
     (no Vault dependency). The realm mirrors production configuration but omits
-    production-only IdPs and disables email verification.
+    production-only IdPs. Email verification is configurable via the
+    ``verify_email`` argument (defaults to enabled, mirroring production).
     """
     kc_opts = ResourceOptions(provider=keycloak_provider)
     k8s_opts = ResourceOptions(provider=k8s_provider)

--- a/local-dev/infra/modules/keycloak.py
+++ b/local-dev/infra/modules/keycloak.py
@@ -4,7 +4,6 @@ Keycloak olapps realm for local development.
 Mirrors the production olapps.py structure but:
   - Skips Vault secrets (stores OIDC credentials as plain k8s Secrets instead)
   - Skips production SAML/OIDC org federation (real MIT Touchstone, B2B orgs)
-  - Disables verify_email (Mailpit is available but we want frictionless login)
   - Includes fake-touchstone and okta-test IdPs (same as CI/QA branch)
   - Skips all Vault-dependent resources
 
@@ -34,6 +33,8 @@ def create_olapps_dev_realm(  # noqa: PLR0913
     learn_ai_client_secret: Output,
     mitxonline_client_secret: Output,
     unified_ecommerce_client_secret: Output,
+    *,
+    verify_email: bool = True,
 ) -> None:
     """
     Create the olapps Keycloak realm for local development.
@@ -73,8 +74,9 @@ def create_olapps_dev_realm(  # noqa: PLR0913
         reset_password_allowed=True,
         login_with_email_allowed=True,
         registration_email_as_username=True,
-        # Disabled for local dev — avoids email verification friction.
-        verify_email=False,
+        # Mirrors production; Mailpit captures the verification email locally.
+        # Override locally via the verify_email Pulumi config (see __main__.py).
+        verify_email=verify_email,
         password_policy=(  # pragma: allowlist secret  # noqa: S106
             "length(8) and notUsername and notEmail"
         ),
@@ -131,7 +133,7 @@ def create_olapps_dev_realm(  # noqa: PLR0913
 
     for alias, default in [
         ("CONFIGURE_TOTP", False),
-        ("VERIFY_EMAIL", False),  # disabled for local dev
+        ("VERIFY_EMAIL", verify_email),
         # UPDATE_EMAIL was removed in Keycloak 26 — omit to avoid validation error.
         ("UPDATE_PASSWORD", False),
     ]:

--- a/local-dev/infra/modules/messaging.py
+++ b/local-dev/infra/modules/messaging.py
@@ -16,11 +16,14 @@ class MessagingResources:
 def create_messaging(
     _k8s: Callable[..., ResourceOptions],
     local_infra_ns: k8s.core.v1.Namespace,
+    apisix_release: k8s.helm.v3.Release,
+    tls_secret: k8s.core.v1.Secret,
+    mail_hostname: str,
 ) -> MessagingResources:
     """Deploy Mailpit to capture outbound email in local dev.
 
     Prevents broken Keycloak email-verification flows during development.
-    Web UI is accessible at http://mailpit.local-infra.svc.cluster.local:8025.
+    Web UI is exposed at https://{mail_hostname}.
     """
     deployment = k8s.apps.v1.Deployment(
         "mailpit",
@@ -61,6 +64,40 @@ def create_messaging(
             ],
         },
         opts=_k8s(parent=deployment),
+    )
+
+    k8s.apiextensions.CustomResource(
+        "mailpit-apisix-route",
+        api_version="apisix.apache.org/v2",
+        kind="ApisixRoute",
+        metadata={"name": "mailpit-route", "namespace": "local-infra"},
+        spec={
+            "ingressClassName": "apache-apisix",
+            "http": [
+                {
+                    "name": "mailpit",
+                    "match": {
+                        "hosts": [mail_hostname],
+                        "paths": ["/*"],
+                    },
+                    "backends": [{"serviceName": "mailpit", "servicePort": 8025}],
+                }
+            ],
+        },
+        opts=_k8s(parent=local_infra_ns, depends_on=[apisix_release, service]),
+    )
+
+    k8s.apiextensions.CustomResource(
+        "mailpit-apisix-tls",
+        api_version="apisix.apache.org/v2",
+        kind="ApisixTls",
+        metadata={"name": "mailpit-tls", "namespace": "local-infra"},
+        spec={
+            "ingressClassName": "apache-apisix",
+            "hosts": [mail_hostname],
+            "secret": {"name": "local-dev-tls", "namespace": "local-infra"},
+        },
+        opts=_k8s(parent=local_infra_ns, depends_on=[apisix_release, tls_secret]),
     )
 
     return MessagingResources(deployment=deployment, service=service)

--- a/local-dev/infra/modules/messaging.py
+++ b/local-dev/infra/modules/messaging.py
@@ -22,7 +22,7 @@ def create_messaging(
 ) -> MessagingResources:
     """Deploy Mailpit to capture outbound email in local dev.
 
-    Prevents broken Keycloak email-verification flows during development.
+    Captures the verification email so email-verification flows work locally.
     Web UI is exposed at https://{mail_hostname}.
     """
     deployment = k8s.apps.v1.Deployment(

--- a/local-dev/scripts/kc-fix-flow-bindings.sh
+++ b/local-dev/scripts/kc-fix-flow-bindings.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# kc-fix-flow-bindings.sh — Re-assert the olapps realm's browser/first-broker-login
+# flow bindings after every apply.
+#
+# keycloak.py binds browserFlow/firstBrokerLoginFlow to our custom "Organization
+# browser"/"Organization first broker login" flows via a keycloak.authentication.Bindings
+# resource. That binding only gets written once: any later update to the
+# keycloak.Realm resource itself (e.g. changing smtp_server, password_policy, etc.)
+# PUTs a full realm representation that doesn't include those two fields, and
+# Keycloak's API resets them to its built-in defaults ("browser" / "first broker
+# login") as a result. Pulumi never notices, because Bindings' own inputs didn't
+# change, so it doesn't reapply. Without the custom "Organization browser" flow,
+# the login page's identity-first screen dead-ends at a password-reset prompt
+# instead of routing unrecognized emails to registration.
+#
+# Usage:
+#   ./local-dev/scripts/kc-fix-flow-bindings.sh
+#
+# Resolves the Keycloak URL the same way kc-seed-users.sh does.
+
+set -euo pipefail
+
+_ROOT_DOMAIN="${LOCAL_DEV_ROOT_DOMAIN:-mit.dev}"
+KC_URL="${KC_URL:-https://sso.ol.${_ROOT_DOMAIN}}"
+REALM="olapps"
+KC_USER="admin"
+KC_PASS="admin"  # pragma: allowlist secret
+
+get_token() {
+    local token attempt
+    for attempt in 1 2 3 4 5; do
+        token=$(curl -sf --max-time 10 \
+            -X POST "${KC_URL}/realms/master/protocol/openid-connect/token" \
+            -d "client_id=admin-cli" \
+            -d "grant_type=password" \
+            -d "username=${KC_USER}" \
+            -d "password=${KC_PASS}" 2>/dev/null \
+            | jq -r '.access_token // empty' 2>/dev/null || true)
+        if [ -n "$token" ] && [ "$token" != "null" ]; then
+            echo "$token"
+            return 0
+        fi
+        echo "[kc-fix-flow-bindings] attempt ${attempt}/5: waiting for Keycloak..." >&2
+        sleep 5
+    done
+    echo "[kc-fix-flow-bindings] ERROR: could not obtain admin token from ${KC_URL}" >&2
+    return 1
+}
+
+echo "[kc-fix-flow-bindings] Connecting to Keycloak at ${KC_URL} ..."
+TOKEN=$(get_token)
+
+CURRENT=$(curl -sf --max-time 10 \
+    -H "Authorization: Bearer ${TOKEN}" \
+    "${KC_URL}/admin/realms/${REALM}" 2>/dev/null)
+
+BROWSER_FLOW=$(echo "$CURRENT" | jq -r '.browserFlow // empty')
+FIRST_BROKER_FLOW=$(echo "$CURRENT" | jq -r '.firstBrokerLoginFlow // empty')
+
+if [ "$BROWSER_FLOW" = "Organization browser" ] && [ "$FIRST_BROKER_FLOW" = "Organization first broker login" ]; then
+    echo "[kc-fix-flow-bindings] Flow bindings already correct, skipping."
+    exit 0
+fi
+
+echo "[kc-fix-flow-bindings] Flow bindings drifted (browserFlow=${BROWSER_FLOW}, firstBrokerLoginFlow=${FIRST_BROKER_FLOW}); re-asserting ..."
+PATCHED=$(echo "$CURRENT" | jq '.browserFlow = "Organization browser" | .firstBrokerLoginFlow = "Organization first broker login"')
+curl -sf --max-time 10 \
+    -X PUT \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Content-Type: application/json" \
+    "${KC_URL}/admin/realms/${REALM}" \
+    -d "$PATCHED" \
+    -o /dev/null
+
+echo "[kc-fix-flow-bindings] Done."

--- a/local-dev/scripts/setup.sh
+++ b/local-dev/scripts/setup.sh
@@ -43,6 +43,8 @@ HOSTS=(
     "video.odl.${ROOT_DOMAIN}"
     # Keycloak SSO
     "sso.ol.${ROOT_DOMAIN}"
+    # Mailpit (captured outbound email)
+    "mail.${ROOT_DOMAIN}"
 )
 
 # mkcert wildcard SANs — one wildcard per subdomain level needed.


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/12277

### Description (What does it do?)
Fixes the local-dev account-creation bug from the linked issue, plus two related follow-ups:

1. **Fixes account creation.** The `olapps` realm's `browserFlow`/`firstBrokerLoginFlow` bindings were silently drifting back to Keycloak's built-in defaults whenever the `keycloak.Realm` Pulumi resource updated for any unrelated reason — the provider's `Realm` and `Bindings` resources both write the same underlying realm object, and an update from either resets fields owned by the other. Pulumi never noticed, since `Bindings`' own inputs hadn't changed. Without our custom `"Organization browser"` flow actually bound, the identity-first login screen dead-ended at a password-reset prompt for unrecognized emails instead of routing to registration. Production isn't affected because self-registration isn't part of its normal Touchstone/org-SSO login path. Fixed with a `kc-fix-flow-bindings.sh` script, run automatically via Tilt after every apply, that idempotently re-asserts the correct bindings.
2. **Exposes Mailpit** at `https://mail.mit.dev` (previously only reachable via `kubectl port-forward`).
3. **Requires email verification** on registration, mirroring production now that Mailpit is reachable. Overridable per-developer (uncommitted) via `pulumi config set --stack local-dev.apps-infra.Dev verify_email false`.
    - ⚠️ The default to NOT require verification was, I think, intentional though perhaps borrowed from old docker stacks. With mailpit included + our real theme / keycloak, I think it is useful to have this on by default.

### How can this be tested?
Assumes a working local-dev stack. Run `tilt up`, wait for `local-infra-apps` and `kc-fix-flow-bindings` to go green, then try registering a new account through any app's login page with an email that has no existing account — you should land on the real registration form, and after submitting, be prompted to verify your email, which arrives at `https://mail.mit.dev`.

### Additional Context
N/A