### PR TITLE
feat(redash): redirect bi.odl.mit.edu to Superset via Fastly

### DIFF
--- a/src/ol_infrastructure/applications/fastly_redirector/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/fastly_redirector/Pulumi.Production.yaml
@@ -4,6 +4,7 @@ encryptedkey: AQICAHi3FG4qowC3UzOLWOAA4Y9/RTwqKjovG3wyVVYDxkR+zAFUqc+t5s6+UczAij
 config:
   redirects:domains:
     amps.odl.mit.edu: https://video.odl.mit.edu
+    bi.odl.mit.edu: https://bi.ol.mit.edu
     chalkradiopodcast.com: https://chalk-radio.simplecast.com
     chalkradiopodcast.net: https://chalk-radio.simplecast.com
     chalkradiopodcast.org: https://chalk-radio.simplecast.com

--- a/src/ol_infrastructure/applications/redash/__main__.py
+++ b/src/ol_infrastructure/applications/redash/__main__.py
@@ -10,7 +10,6 @@
 - Provision a set of EC2 instances from a pre-built AMI with the configuration
   and code for Redash
 - Provision an AWS load balancer and connect the deployed EC2 instances
-- Create a DNS record for the deployed load balancer
 """
 
 import base64
@@ -24,7 +23,7 @@ import pulumi_vault as vault
 import yaml
 from pulumi import Config, export
 from pulumi.config import get_config
-from pulumi_aws import ec2, get_caller_identity, iam, route53
+from pulumi_aws import ec2, get_caller_identity, iam
 
 from bridge.lib.magic_numbers import DEFAULT_HTTPS_PORT, DEFAULT_POSTGRES_PORT
 from bridge.secrets.sops import read_yaml_secrets
@@ -58,9 +57,7 @@ redash_config = Config("redash")
 stack_info = parse_stack()
 network_stack = make_stack_reference(projects.NETWORKING, stack_info.name)
 consul_stack = make_stack_reference(projects.CONSUL_INFRA, f"data.{stack_info.name}")
-dns_stack = make_stack_reference(projects.DNS, "default")
 policy_stack = make_stack_reference(projects.POLICIES, "default")
-mitodl_zone_id = dns_stack.require_output("odl_zone_id")
 data_vpc = network_stack.require_output("data_vpc")
 operations_vpc = network_stack.require_output("operations_vpc")
 redash_environment = f"data-{stack_info.env_suffix}"
@@ -602,16 +599,6 @@ worker_as_setup = OLAutoScaling(
     lt_config=worker_lt_config,
     tg_config=None,
     lb_config=None,
-)
-
-fifteen_minutes = 60 * 15
-redash_domain = route53.Record(
-    f"redash-{stack_info.env_suffix}-service-domain",
-    name=redash_config.require("domain"),
-    type="CNAME",
-    ttl=fifteen_minutes,
-    records=[web_as_setup.load_balancer.dns_name],
-    zone_id=mitodl_zone_id,
 )
 
 export(


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Redash (`bi.odl.mit.edu`) is being retired in favor of Superset (`bi.ol.mit.edu`).

- Adds `bi.odl.mit.edu: https://bi.ol.mit.edu` to the Fastly redirector's `redirects:domains` map in `src/ol_infrastructure/applications/fastly_redirector/Pulumi.Production.yaml`, so Fastly will terminate TLS for the domain and 301/302 requests (path + query preserved) to `bi.ol.mit.edu`.
- Removes the `aws.route53.Record` in `src/ol_infrastructure/applications/redash/__main__.py` that Redash's own Pulumi stack used to manage for `bi.odl.mit.edu` (a CNAME to its ALB), along with the now-unused `dns_stack`/`mitodl_zone_id` stack reference and `route53` import. Both stacks previously tried to own DNS for the same name, which would have caused drift between them.

This only changes DNS ownership for `bi.odl.mit.edu`. The Redash application/instances are untouched by this PR — decommissioning the app itself is a separate follow-up.

### Screenshots (if appropriate):
N/A — no UI changes.

### How can this be tested?
Reviewed via `pulumi preview --stack Production` on both affected projects:

- `fastly_redirector`: adds `bi.odl.mit.edu` to the Fastly service's domain list and dictionary, creates a CNAME (`bi.odl.mit.edu` → `j.sni.global.fastly.net`), and provisions a new TLS subscription covering all redirector domains (recreated as a side effect of the existing domain-hash subscription-naming scheme — this briefly churns ACME validation records for *all* redirect domains, not just this one; pre-existing behavior).
- `redash`: deletes exactly one resource, the `redash-production-service-domain` CNAME record; no other resources affected.

After merge/deploy, confirm `curl -I https://bi.odl.mit.edu/<path>` returns a redirect to the equivalent `https://bi.ol.mit.edu/<path>`, and that TLS validation completes cleanly for the other redirect domains post cert-subscription recreation.

### Additional Context
Sequencing note for whoever deploys this: apply the `redash` stack first (drops its CNAME) before the `fastly_redirector` stack (creates its own CNAME for the same name), to avoid two stacks briefly claiming the same Route53 record.