### PR TITLE
local-dev: auto-heal wedged kubelet exec/streaming after sleep

### DIFF
--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -109,8 +109,9 @@ The easiest way is to use the provided start script, which validates your setup 
 
 This will:
 1. Validate that `setup.sh` has been run (cluster exists, kubeconfig configured, certs present)
-2. Sync Python dependencies via `uv`
-3. Start Tilt
+2. Heal any wedged kubelet exec/streaming (see [Troubleshooting](#kubectl-exec-fails-with-a-502-after-sleep-macos)) — a no-op when healthy
+3. Sync Python dependencies via `uv`
+4. Start Tilt
 
 **Alternative:** If you prefer to start manually without the validation wrapper:
 
@@ -186,10 +187,12 @@ ol-infrastructure/
     │
     ├── scripts/
     │   ├── setup.sh                  # One-time bootstrap (cluster, certs, /etc/hosts)
-    │   ├── start.sh                  # Start the environment (validate setup, sync deps, tilt up)
+    │   ├── start.sh                  # Start the environment (validate setup, heal exec, sync deps, tilt up)
     │   ├── stop.sh                   # Pause the cluster (fast resume via start.sh)
     │   ├── teardown.sh               # Destroy the cluster
-    │   └── seed.sh                   # CLI seeding wrapper (kubectl exec into pods)
+    │   ├── seed.sh                   # CLI seeding wrapper (kubectl exec into pods)
+    │   ├── heal-exec.sh              # Repair wedged kubelet exec/streaming after sleep
+    │   └── wakeup.example.sh         # Example sleepwatcher wake hook (macOS auto-heal)
     │
     ├── certs/                        # mkcert output (gitignored)
     │   ├── local-dev.pem
@@ -694,6 +697,37 @@ Then restart your browser. The cert was generated with the correct wildcard SANs
 The Next.js build needs ~4 GB of memory. If it OOMs:
 - Increase Docker Desktop memory to 10+ GB
 - Or use a prebuilt image by removing `mit-learn` from `enabled_apps` in `tilt_config.json` and letting Tilt use the `prebuilt_tags` value instead
+
+### `kubectl exec` fails with a 502 after sleep (macOS)
+
+After the Mac sleeps, `kubectl exec` / `attach` / `logs -f` into a pod may fail like this, even though `kubectl get` / `describe` / `logs` still work and the node shows `Ready`:
+
+```
+error: Internal error occurred: error sending request: Post
+"https://192.168.97.3:10250/exec/...": proxy error from 127.0.0.1:6443
+while dialing 192.168.97.3:10250, code 502: 502 Bad Gateway
+```
+
+**Why:** the API server proxies exec/attach/logs-follow to each node's kubelet on `:10250`. k3d nodes run inside the Docker VM (OrbStack or Docker Desktop); when the Mac sleeps that VM is paused, and on resume a node's kubelet streaming server can come back wedged. Ordinary kubectl keeps working because it doesn't use that streaming path. Restarting Tilt does **not** help — it only recycles workloads, not the node containers.
+
+**Fix:** run the heal script, which probes each node and `docker restart`s only the wedged ones (it's a no-op when everything is healthy):
+
+```bash
+./local-dev/scripts/heal-exec.sh
+```
+
+`start.sh` runs this automatically, so starting your session with it already covers the cold-start case.
+
+**Automatic on wake (macOS, optional):** to heal without thinking about it, use [sleepwatcher](https://www.bernhard-baehr.de/) to run the heal on every wake:
+
+```bash
+brew install sleepwatcher
+# edit the REPO path inside the example hook first, then symlink it as ~/.wakeup:
+ln -sf "$PWD/local-dev/scripts/wakeup.example.sh" ~/.wakeup
+brew services start sleepwatcher
+```
+
+sleepwatcher runs `~/.wakeup` on every wake; the example hook calls `heal-exec.sh` and logs to `~/Library/Logs/local-dev-heal.log`. This is macOS-only: Linux runs Docker natively (no paused VM), so it doesn't hit this.
 
 ### macOS: Port conflict during cluster creation
 

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -109,7 +109,7 @@ The easiest way is to use the provided start script, which validates your setup 
 
 This will:
 1. Validate that `setup.sh` has been run (cluster exists, kubeconfig configured, certs present)
-2. Heal any wedged kubelet exec/streaming (see [Troubleshooting](#kubectl-exec-fails-with-a-502-after-sleep-macos)) — a no-op when healthy
+2. Heal any wedged kubelet exec/streaming (see [Troubleshooting](#kubectl-exec-fails-with-a-502-wedged-kubelet-streaming)) — a no-op when healthy
 3. Sync Python dependencies via `uv`
 4. Start Tilt
 
@@ -698,9 +698,9 @@ The Next.js build needs ~4 GB of memory. If it OOMs:
 - Increase Docker Desktop memory to 10+ GB
 - Or use a prebuilt image by removing `mit-learn` from `enabled_apps` in `tilt_config.json` and letting Tilt use the `prebuilt_tags` value instead
 
-### `kubectl exec` fails with a 502 after sleep (macOS)
+### `kubectl exec` fails with a 502 (wedged kubelet streaming)
 
-After the Mac sleeps, `kubectl exec` / `attach` / `logs -f` into a pod may fail like this, even though `kubectl get` / `describe` / `logs` still work and the node shows `Ready`:
+`kubectl exec` / `attach` / `logs -f` into a pod may fail like this, even though `kubectl get` / `describe` / `logs` still work and the node shows `Ready`:
 
 ```
 error: Internal error occurred: error sending request: Post
@@ -708,17 +708,17 @@ error: Internal error occurred: error sending request: Post
 while dialing 192.168.97.3:10250, code 502: 502 Bad Gateway
 ```
 
-**Why:** the API server proxies exec/attach/logs-follow to each node's kubelet on `:10250`. k3d nodes run inside the Docker VM (OrbStack or Docker Desktop); when the Mac sleeps that VM is paused, and on resume a node's kubelet streaming server can come back wedged. Ordinary kubectl keeps working because it doesn't use that streaming path. Restarting Tilt does **not** help — it only recycles workloads, not the node containers.
+**Why:** the API server proxies exec/attach/logs-follow to each node's kubelet on `:10250`. When that streaming server on a node gets wedged, exec 502s while ordinary kubectl keeps working (it doesn't use the streaming path). This is a known k3s/kind failure mode with several triggers; the one you'll hit most on this stack is **macOS sleep** — k3d nodes run inside the Docker VM (OrbStack or Docker Desktop), the Mac sleeping pauses that VM, and a node's kubelet can come back wedged on resume. (A Linux host that suspends could in principle do the same; a Linux box that never sleeps generally won't.) Either way, restarting Tilt does **not** help — it only recycles workloads, not the node containers.
 
-**Fix:** run the heal script, which probes each node and `docker restart`s only the wedged ones (it's a no-op when everything is healthy):
+**Fix (any platform):** run the heal script, which probes each node and `docker restart`s only the wedged ones — this clears the wedge whatever caused it, and preserves the node's IP (unlike `k3d cluster stop/start`). It's a no-op when everything is healthy:
 
 ```bash
 ./local-dev/scripts/heal-exec.sh
 ```
 
-`start.sh` runs this automatically, so starting your session with it already covers the cold-start case.
+`start.sh` runs this automatically, so starting your session with it already covers the cold-start case on every platform.
 
-**Automatic on wake (macOS, optional):** to heal without thinking about it, use [sleepwatcher](https://www.bernhard-baehr.de/) to run the heal on every wake:
+**Automatic on wake (macOS):** to heal without thinking about it, use [sleepwatcher](https://www.bernhard-baehr.de/) to run the heal on every wake:
 
 ```bash
 brew install sleepwatcher
@@ -727,7 +727,9 @@ ln -sf "$PWD/local-dev/scripts/wakeup.example.sh" ~/.wakeup
 brew services start sleepwatcher
 ```
 
-sleepwatcher runs `~/.wakeup` on every wake; the example hook calls `heal-exec.sh` and logs to `~/Library/Logs/local-dev-heal.log`. This is macOS-only: Linux runs Docker natively (no paused VM), so it doesn't hit this.
+sleepwatcher runs `~/.wakeup` on every wake; the example hook calls `heal-exec.sh` and logs to `~/Library/Logs/local-dev-heal.log`.
+
+**Automatic on wake (Linux):** we don't ship a hook, but if your dev box suspends and you hit this, wrap `heal-exec.sh` in a systemd resume hook — a script in `/usr/lib/systemd/system-sleep/` (invoked with `post`/`resume`) or a unit ordered `After=suspend.target`.
 
 ### macOS: Port conflict during cluster creation
 

--- a/local-dev/scripts/heal-exec.sh
+++ b/local-dev/scripts/heal-exec.sh
@@ -116,9 +116,13 @@ while IFS= read -r n; do
 done < <(kubectl --context "$CONTEXT" get nodes \
 	-o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
 
+# Detect with probe_retry, not a single probe: a node that is merely slow to
+# rebind :10250 right after wake would otherwise be misread as wedged and
+# needlessly restarted (an expensive full node bounce). probe_retry returns on
+# the first success, so a healthy node still costs just one probe.
 wedged=()
 for node in "${NODES[@]}"; do
-	if probe "$node"; then
+	if probe_retry "$node"; then
 		ok "exec streaming healthy: $node"
 	else
 		warn "exec streaming wedged: $node"
@@ -138,8 +142,10 @@ for node in "${wedged[@]}"; do
 		failed+=("$node")
 		continue
 	fi
-	kubectl --context "$CONTEXT" wait --for=condition=Ready "node/$node" \
-		--timeout="$READY_TIMEOUT" >/dev/null 2>&1 || true
+	if ! kubectl --context "$CONTEXT" wait --for=condition=Ready "node/$node" \
+		--timeout="$READY_TIMEOUT" >/dev/null 2>&1; then
+		warn "Node '$node' not Ready within $READY_TIMEOUT after restart; re-probing anyway."
+	fi
 	if probe_retry "$node"; then
 		ok "Healed: $node"
 	else

--- a/local-dev/scripts/heal-exec.sh
+++ b/local-dev/scripts/heal-exec.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# heal-exec.sh — repair wedged kubelet exec/streaming on the local-dev cluster.
+#
+# Why this exists: the API server proxies `kubectl exec` / `attach` / `logs -f`
+# to each node's kubelet on :10250. After the Docker VM (OrbStack or Docker
+# Desktop) is paused on Mac sleep and resumed, that streaming server can come
+# back wedged on a node — the node
+# still reports Ready and ordinary kubectl (get / describe / logs) keeps
+# working, but exec fails with:
+#
+#     error: Internal error occurred: error sending request: Post
+#     "https://<node-ip>:10250/exec/...": proxy error from 127.0.0.1:6443
+#     while dialing <node-ip>:10250, code 502: 502 Bad Gateway
+#
+# Restarting Tilt only recycles workloads; it does not touch the node
+# containers, so it cannot fix this. `docker restart`ing the affected node
+# container rebuilds the kubelet and clears the wedge — and, unlike
+# `k3d cluster stop/start`, it keeps the node's IP, so it does not trigger the
+# node-IP reshuffle that breaks kubelet serving-cert SANs and node registration.
+#
+# This script probes each node's kubelet through the API server proxy (the same
+# :10250 path exec rides) and `docker restart`s only the nodes that fail, then
+# waits for them to recover. It is a no-op when everything is healthy, so it is
+# safe to run on every session start and on wake.
+#
+# Usage: ./local-dev/scripts/heal-exec.sh
+
+set -euo pipefail
+
+CONTEXT="local-dev"
+READY_TIMEOUT="120s"      # kubectl wait for a node to report Ready after restart
+PROBE_RETRIES=8
+PROBE_INTERVAL=3
+DOCKER_READY_WAIT=90     # seconds to wait for the Docker engine to resume on wake
+CLUSTER_READY_WAIT=90    # seconds to wait for the cluster API to resume on wake
+RESTART_ATTEMPTS=3
+REQUEST_TIMEOUT="10s"    # per-call kubectl timeout so an unreachable node fails fast
+
+log()  { echo "▶ $*"; }
+ok()   { echo "  ✓ $*"; }
+warn() { echo "  ⚠ $*" >&2; }
+err()  { echo "  ✗ $*" >&2; exit 1; }
+
+# Is the node's kubelet reachable through the API server proxy? This is the
+# same apiserver->kubelet :10250 path that exec/attach/logs-follow use, so a
+# dial-level wedge fails this probe too.
+probe() {
+	kubectl --context "$CONTEXT" --request-timeout="$REQUEST_TIMEOUT" \
+		get --raw "/api/v1/nodes/$1/proxy/healthz" >/dev/null 2>&1
+}
+
+# Run "$@" repeatedly until it succeeds or `seconds` elapse.
+wait_ready() {
+	local seconds="$1" i
+	shift
+	for ((i = 0; i < seconds; i++)); do
+		"$@" >/dev/null 2>&1 && return 0
+		sleep 1
+	done
+	return 1
+}
+
+# docker restart with retries; on failure surface docker's actual stderr (the
+# original version swallowed it, so wake-time failures were undiagnosable).
+restart_node() {
+	local node="$1" attempt out
+	for ((attempt = 1; attempt <= RESTART_ATTEMPTS; attempt++)); do
+		if out=$(docker restart "$node" 2>&1); then
+			return 0
+		fi
+		warn "docker restart $node failed (attempt $attempt/$RESTART_ATTEMPTS): $out"
+		sleep 3
+	done
+	return 1
+}
+
+# Probe with a few retries — after a node container restart the kubelet takes a
+# moment to rebind :10250.
+probe_retry() {
+	local node="$1" i
+	for ((i = 1; i <= PROBE_RETRIES; i++)); do
+		probe "$node" && return 0
+		sleep "$PROBE_INTERVAL"
+	done
+	return 1
+}
+
+# Fail fast with a clear message if the tools are missing. In a launchd /
+# sleepwatcher hook the PATH is minimal, and the docker CLI lives outside the
+# Homebrew dirs (~/.orbstack/bin for OrbStack, ~/.docker/bin for Docker Desktop)
+# — a missing binary would otherwise masquerade as the confusing 90s "not
+# ready" timeout below.
+for bin in docker kubectl; do
+	command -v "$bin" >/dev/null 2>&1 || err "'$bin' not found on PATH ($PATH).
+        If this ran from a wake hook, ensure it exports the docker CLI dir (~/.orbstack/bin or ~/.docker/bin) plus /opt/homebrew/bin or /usr/local/bin."
+done
+
+# On wake, the Docker VM (OrbStack or Docker Desktop) — and the Docker engine + k3s cluster inside it —
+# resume asynchronously, and the sleepwatcher hook fires immediately. Wait,
+# bounded, for both to come back before doing anything; otherwise our docker
+# and kubectl calls race the resume and fail. When the cluster is simply
+# stopped (not resuming), these time out and we skip — that is not ours to fix.
+if ! wait_ready "$DOCKER_READY_WAIT" docker info; then
+	warn "Docker engine not ready after ${DOCKER_READY_WAIT}s; skipping exec heal."
+	exit 0
+fi
+if ! wait_ready "$CLUSTER_READY_WAIT" \
+	kubectl --context "$CONTEXT" --request-timeout="$REQUEST_TIMEOUT" get nodes; then
+	warn "Cluster '$CONTEXT' API not ready after ${CLUSTER_READY_WAIT}s; skipping exec heal."
+	exit 0
+fi
+
+NODES=()
+while IFS= read -r n; do
+	[[ -n "$n" ]] && NODES+=("$n")
+done < <(kubectl --context "$CONTEXT" get nodes \
+	-o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
+
+wedged=()
+for node in "${NODES[@]}"; do
+	if probe "$node"; then
+		ok "exec streaming healthy: $node"
+	else
+		warn "exec streaming wedged: $node"
+		wedged+=("$node")
+	fi
+done
+
+if [[ ${#wedged[@]} -eq 0 ]]; then
+	ok "All ${#NODES[@]} nodes healthy — nothing to heal."
+	exit 0
+fi
+
+failed=()
+for node in "${wedged[@]}"; do
+	log "Restarting node container '$node' to clear the wedge..."
+	if ! restart_node "$node"; then
+		failed+=("$node")
+		continue
+	fi
+	kubectl --context "$CONTEXT" wait --for=condition=Ready "node/$node" \
+		--timeout="$READY_TIMEOUT" >/dev/null 2>&1 || true
+	if probe_retry "$node"; then
+		ok "Healed: $node"
+	else
+		warn "Still wedged after restart: $node"
+		failed+=("$node")
+	fi
+done
+
+if [[ ${#failed[@]} -gt 0 ]]; then
+	warn "Could not heal: ${failed[*]}"
+	exit 1
+fi
+
+ok "Exec streaming restored on: ${wedged[*]}"

--- a/local-dev/scripts/start.sh
+++ b/local-dev/scripts/start.sh
@@ -78,9 +78,7 @@ ok "TLS certificates found."
 # can come back wedged, so `kubectl exec` 502s even though the node is Ready.
 # This is a no-op when everything is healthy. Best-effort: never block startup.
 log "Checking kubelet exec/streaming health..."
-if "${SCRIPT_DIR}/heal-exec.sh"; then
-	ok "Exec streaming healthy."
-else
+if ! "${SCRIPT_DIR}/heal-exec.sh"; then
 	warn "Exec heal reported problems; continuing to start Tilt anyway."
 fi
 

--- a/local-dev/scripts/start.sh
+++ b/local-dev/scripts/start.sh
@@ -72,6 +72,19 @@ fi
 ok "TLS certificates found."
 
 # ---------------------------------------------------------------------------
+# Heal wedged kubelet exec/streaming (post-sleep recovery)
+# ---------------------------------------------------------------------------
+# After a Docker VM pause on Mac sleep (OrbStack or Docker Desktop), a node's kubelet exec/streaming server
+# can come back wedged, so `kubectl exec` 502s even though the node is Ready.
+# This is a no-op when everything is healthy. Best-effort: never block startup.
+log "Checking kubelet exec/streaming health..."
+if "${SCRIPT_DIR}/heal-exec.sh"; then
+	ok "Exec streaming healthy."
+else
+	warn "Exec heal reported problems; continuing to start Tilt anyway."
+fi
+
+# ---------------------------------------------------------------------------
 # Sync Python dependencies
 # ---------------------------------------------------------------------------
 log "Syncing Python dependencies via uv..."

--- a/local-dev/scripts/wakeup.example.sh
+++ b/local-dev/scripts/wakeup.example.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# wakeup.example.sh — example sleepwatcher wake hook (macOS only).
+#
+# Purpose: after the Mac wakes, the Docker VM (OrbStack or Docker Desktop) resumes and a k3d node's kubelet
+# exec/streaming server can come back wedged (see heal-exec.sh). This hook runs
+# the heal on every wake so `kubectl exec` is reliable without you thinking
+# about it. It is a no-op when the cluster is healthy or stopped.
+#
+# Setup (Homebrew sleepwatcher runs ~/.wakeup on wake):
+#
+#   brew install sleepwatcher
+#   # point ~/.wakeup at this script (edit REPO below to your checkout first),
+#   # or symlink it:
+#   ln -sf "$HOME/dev/ol-infrastructure/local-dev/scripts/wakeup.example.sh" ~/.wakeup
+#   chmod +x ~/.wakeup
+#   brew services start sleepwatcher
+#
+# Notes:
+# - sleepwatcher runs hooks with a minimal PATH, so we add the tool locations
+#   below. This covers both Docker backends: OrbStack's `docker` CLI lives in
+#   ~/.orbstack/bin and Docker Desktop's in ~/.docker/bin (neither is in the
+#   Homebrew dirs). Non-existent dirs on PATH are harmless, so listing both is
+#   safe regardless of which backend you run.
+# - heal-exec.sh targets the `local-dev` kube context; that context must exist
+#   in your default kubeconfig (~/.kube/config). If yours lives elsewhere, set
+#   KUBECONFIG here.
+# - Output is appended to ~/Library/Logs/local-dev-heal.log for debugging.
+
+export PATH="$HOME/.orbstack/bin:$HOME/.docker/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+
+REPO="$HOME/dev/ol-infrastructure"
+LOG="$HOME/Library/Logs/local-dev-heal.log"
+
+mkdir -p "$(dirname "$LOG")"
+echo "=== wake $(date '+%Y-%m-%dT%H:%M:%S') ===" >>"$LOG"
+"$REPO/local-dev/scripts/heal-exec.sh" >>"$LOG" 2>&1 || true

--- a/local-dev/scripts/wakeup.example.sh
+++ b/local-dev/scripts/wakeup.example.sh
@@ -26,6 +26,8 @@
 #   KUBECONFIG here.
 # - Output is appended to ~/Library/Logs/local-dev-heal.log for debugging.
 
+set -euo pipefail
+
 export PATH="$HOME/.orbstack/bin:$HOME/.docker/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
 
 REPO="$HOME/dev/ol-infrastructure"


### PR DESCRIPTION
### What are the relevant tickets?
N/A (tracked internally)

### Description (What does it do?)
After a Docker VM pause on macOS sleep, a k3d node's kubelet exec/streaming server can come back wedged: `kubectl exec` / `attach` / `logs -f` fail with a `502 Bad Gateway` dialing the node on `:10250`, even though the node reports `Ready` and ordinary `kubectl get`/`logs` work. Restarting Tilt doesn't help — it recycles workloads, not the node containers.

This adds an auto-heal:

- **`local-dev/scripts/heal-exec.sh`** (new) — probes each node's kubelet through the API server proxy (`/api/v1/nodes/<n>/proxy/healthz`, the same `:10250` path exec rides) and `docker restart`s *only* the wedged node containers. `docker restart` preserves the node IP, unlike `k3d cluster stop/start`. No-op (~0.4s) when everything is healthy.
- **`local-dev/scripts/start.sh`** — runs the heal on every start, best-effort; never blocks Tilt startup.
- **`local-dev/scripts/wakeup.example.sh`** (new) — optional macOS [sleepwatcher](https://www.bernhard-baehr.de/) `~/.wakeup` hook so the heal runs automatically on wake. Backend-agnostic PATH (OrbStack or Docker Desktop).
- **`local-dev/README.md`** — troubleshooting section covering the symptom, the heal, and wake-hook setup (macOS + a Linux systemd pointer).

The heal itself is cross-platform; only the sleepwatcher wiring is macOS-specific.

### How can this be tested?
Simulate a wedge and confirm recovery:

```bash
docker pause k3d-local-dev-agent-1     # simulate the post-wake wedge
kubectl exec -it deploy/mitxonline-webapp -n mitxonline -- true   # 502s
./local-dev/scripts/heal-exec.sh       # detects + docker-restarts agent-1
kubectl exec -it deploy/mitxonline-webapp -n mitxonline -- true   # works
```

On a healthy cluster `heal-exec.sh` should report all nodes healthy and exit without restarting anything. `./local-dev/scripts/start.sh` runs it inline.

### Additional Context
This is a known, cross-platform k3s/kind failure mode with a macOS-sleep trigger:

- [k3s#11418](https://github.com/k3s-io/k3s/issues/11418) — same symptom (exec 502 on some nodes, logs fine); diagnosed as a lost apiserver↔kubelet tunnel session, cleared by restarting the affected agent.
- [minikube#6462](https://github.com/kubernetes/minikube/issues/6462), [#21593](https://github.com/kubernetes/minikube/issues/21593) — macOS sleep/hibernate leaves the Docker VM stuck on wake (status reports healthy while it isn't); a restart is required.
