### PR TITLE
fix: override instructor-dashboard support url

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -223,6 +223,12 @@ def _build_interpolated_config_dict(
                     "accessibilityUrl": "https://accessibility.mit.edu/",
                 },
             },
+            "apps": [
+                {
+                    "appId": "org.openedx.frontend.app.instructorDashboard",
+                    "config": { "SUPPORT_URL": "https://odl.zendesk.com/hc/en-us/requests/new" }
+                }
+            ],
         },
         "MFE_CONFIG": {
             "STUDIO_BASE_URL": f"https://{domains['studio']}/authoring",

--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -226,7 +226,9 @@ def _build_interpolated_config_dict(
             "apps": [
                 {
                     "appId": "org.openedx.frontend.app.instructorDashboard",
-                    "config": { "SUPPORT_URL": "https://odl.zendesk.com/hc/en-us/requests/new" }
+                    "config": {
+                        "SUPPORT_URL": "https://odl.zendesk.com/hc/en-us/requests/new"
+                    },
                 }
             ],
         },


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11875

### Description (What does it do?)
This pull request introduces a configuration update to the `edxapp` Kubernetes configmaps, specifically adding support for the Instructor Dashboard frontend application. The main change is the addition of a new entry in the `apps` configuration list, which provides the application ID and a support URL for the Instructor Dashboard.

**Frontend application configuration:**

* Added an entry to the `apps` list for the Instructor Dashboard (`org.openedx.frontend.app.instructorDashboard`), including a `SUPPORT_URL` pointing to the Zendesk support page.
