### PR TITLE
Increase ClickHouse LLMOps query quota

### DIFF
--- a/src/ol_infrastructure/applications/clickhouse/__main__.py
+++ b/src/ol_infrastructure/applications/clickhouse/__main__.py
@@ -154,7 +154,7 @@ _LLMOPS_PROFILES = {
 }
 _LLMOPS_QUOTAS = {
     "llmops_quota/interval/duration": "3600",
-    "llmops_quota/interval/queries": "1000",
+    "llmops_quota/interval/queries": "20000",
     "llmops_quota/interval/errors": "100",
     "llmops_quota/interval/result_rows": "1000000000",
     "llmops_quota/interval/read_rows": "10000000000",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Increases the `llmops_quota/interval/queries` ClickHouse quota from `1000` to `20000` queries per hour (`llmops_quota/interval/duration` remains `3600`). The previous limit was too low for current LLMOps usage and was causing legitimate queries to be throttled.

Changed in `src/ol_infrastructure/applications/clickhouse/__main__.py`.

### How can this be tested?
Deploy via Pulumi to the affected ClickHouse stack and confirm the `llmops_quota` quota reflects the new `queries` limit of `20000` (e.g. via `SHOW QUOTA` or the `system.quotas` table), and that previously-throttled query volumes no longer hit the quota ceiling.

### Additional Context
N/A