### PR TITLE
admin: Redirect pe.ol.mit.edu to engineering.ol.mit.edu

### DIFF
--- a/src/ol_infrastructure/applications/fastly_redirector/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/fastly_redirector/Pulumi.Production.yaml
@@ -14,3 +14,4 @@ config:
     preview.mitxonline.mit.edu: https://preview.courses.learn.mit.edu
     starcellbio.mit.edu: https://github.com/starteam/starcellbio_html
     studio.mitxonline.mit.edu: https://studio.courses.learn.mit.edu
+    pe.ol.mit.edu: https://engineering.ol.mit.edu


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #4884 


### Description (What does it do?)
Adds a redirect from pe.ol.mit.edu to engineering.ol.mit.edu