### PR TITLE
Upload Next.js source maps to Sentry via decoupled Concourse task

### DIFF
--- a/src/bridge/secrets/concourse/operations.production.yaml
+++ b/src/bridge/secrets/concourse/operations.production.yaml
@@ -136,6 +136,8 @@ pipelines:
     issues_resource_access_token: ENC[AES256_GCM,data:cL8D9dINQd9l1rpWS9swyWtKsYGVvY5MhPR3wjIzv6fI5QTrnZC2Bw==,iv:zGF9Iezuob4URXW2NjwTPZNlJInu6RWFn+zudEj2KyA=,tag:/ZaGDfk74JTDD1v5xhwtbw==,type:str]
   main/platform_engineering_site:
     deploy_key: ENC[AES256_GCM,data:1f3DmdQNn2s4j2sb1Co8p6sSJblItyLsjIBvaD9liMQ7BlX2yrY0bZRqgkcxfiMRC+Ldr6p/s1k0HwhijqwL6Dt4sssu2++UfGmWABd2vFpSgDv3bbbbt3vikDAlEr8TTQAQeSarp0a3lGNTP2D0lyM7Bg2k0GH5LUYsfpjOyfUG8xcg4LKNy9XQuKqfaYO26w1TjiXCjCYxBcfbghjt4H2KsnFj6e60F0F9xjEVYyE2KaAR3xEtuRNjiellfq0bfvzfDwtKlNXJSHwtN9uWURYQXe1b3Cdr1n3uDUs4OS0mJS7J8rWeFTO5NScciwRpab0tXGRjxtJNdTS3DHFbVtwkSAIUQit0gv8pebK4amQjT7n4opE1kJGvjZUM30vU9yOs/kpyTMEhCmlBzcwThFFcDKox6wBj5nG55iKl2zeOOyGkia25LRjUeMrbjNcxkZJLouDFUfwxg7LJ3Lvk79PRSpXJk+kcgFGK5gdsreJ4W5NbVcxNwqlOpAScln8RnqMTy9og8LiyFsXyqHDVyDEl2gb3WvNJ4o0dQMyQS4XD1owMpimjLbJE+9IcUKUIGO/JsKajEbqW5DdkGYBbzft49Uy51wT32gQ3eewjy2E=,iv:Yllhxt5FMSYBG9piylZawYn8W3Fyy6b5UtVVR9qzEtk=,tag:nYftjkYAgZQEDCRno5Wg9g==,type:str]
+  shared/sentry:
+    mitlearn_auth_token: ENC[AES256_GCM,data:UPBMMHckSIjM4l6M70vW/8NsoXYTqNl83GWiXYH923LhRlFgtqODUNUXMZVKc0Wtqsm89ygJrYBgCMeTaVpjhrTFAujRsYB1uwAJS7AgLRfOcDMmxr7ItCDDQTLpvC5JrGX532XBFWW04MJhwa74wjGYq1nJs8jULc7Vfz6M8I66sLC47WgT3xulxlwSVAogcv9AjD6unS6xu9yDJ65O/Il6Zu2Vp/E1tuSAZV4RML9+gN9sIJFA2aSV058YAMFIjv1YfAdXPCKqdxpc1kfp+82MyjKtMddWdCBS,iv:oCNUvueP0LDcRPatI4Z98h0GStegusU9o672ef9KTaA=,tag:ekPQj77qjkxjD+qFqsmT/g==,type:str]
 sops:
   hc_vault:
   - created_at: "2026-07-13T17:37:00Z"
@@ -148,7 +150,7 @@ sops:
     aws_profile: ""
     created_at: "2026-07-13T17:37:00Z"
     enc: AQICAHjksIVfl1VtAHpBda/1YYjj6tSeS2o4TXgvEEyBIXLjjwGIp5OWFyTfZxgLPYl39bk6AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMySZCdbhf9mAPs2aLAgEQgDvgJFBuyX+yQbTQ+eeNiKQW1volOoTR+/KWK+dGJiQxLWM8cH5+F90T5+1uYldaXpPLmvPXq4Nf7hWdpw==
-  lastmodified: "2026-07-13T17:37:00Z"
-  mac: ENC[AES256_GCM,data:FbapwAsrg8KCrfiP0Iwza/mZRj+l11qT/qUF9j2PtSEUg4G8bfq3uEm6brezaPmT2pNnlvLl5mNe5PWoCCFYgowA32UfcStYJEkYQTfiTOg3C7aEBR57/LBsawPQ19UgFnN5MMB/7TWGCMKpXTmxcpeWpYnob0nJYSQ9X18pECQ=,iv:iEoJLp3xScV+Ki8tIL0ax43nDY3bK+1drBt25QJhitA=,tag:XaX71nl8lQXqmqx6yr7ewg==,type:str]
+  lastmodified: "2026-07-15T16:49:30Z"
+  mac: ENC[AES256_GCM,data:mk3Vxb9IiMX0ww3RcPKrhDV6+Hcu0GMDVw7GGPitAj4AMdmjNxkghjFsoWgKOK1hxGgvquk4mRBOiRfL7D5cWTd7GPOi6m36GR+Yf/R9vR/Ltd9UFDO2Q+EsX4oD4EAyGNGzUEot3DNPgRWer1zfvh/umEPcbpCIGPnLPpvxgsk=,iv:TWGRRVTj/xkmjpQ7QFOdQTW/T7zJssADEe7UcGnvJmI=,tag:MUjEKjLRQ8pBa1TPpmecGA==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.13.2

--- a/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
@@ -24,6 +24,7 @@ from ol_concourse.lib.models.pipeline import (
     ResourceType,
     TaskConfig,
     TaskStep,
+    TryStep,
 )
 from ol_concourse.lib.resource_types import (
     github_deployments_resource,
@@ -47,6 +48,27 @@ from ol_concourse.pipelines.constants import (
     dockerhub_ecr_image_uri,
 )
 from ol_concourse.pipelines.jobs import pulumi_job, pulumi_jobs_chain
+
+
+class SentrySourcemapsConfig(BaseModel):
+    """Config for uploading an app's source maps to Sentry after the image build.
+
+    Attributes:
+        org: Sentry organization slug (e.g. ``"mit-office-of-digital-learning"``).
+        project: Sentry project slug (e.g. ``"open-next"``).
+        auth_token_vault_key: Concourse credential reference for the Sentry auth
+            token (e.g. ``"((sentry.mitlearn_auth_token))"``). The token needs the
+            ``org:read`` and ``project:releases`` scopes.
+        rootfs_asset_path: Path, relative to the unpacked image rootfs, to the
+            directory holding the built JS and ``.map`` files (with debug IDs
+            already injected at build time). e.g. ``"app/frontends/main/.next"``
+            for the Next.js ``output: "standalone"`` runner image.
+    """
+
+    org: str
+    project: str
+    auth_token_vault_key: str
+    rootfs_asset_path: str
 
 
 class AppPipelineParams(BaseModel):
@@ -86,6 +108,11 @@ class AppPipelineParams(BaseModel):
             Release/Deployment-based pipeline shape instead of the legacy release-candidate/
             release git-branch pattern. Defaults to False so existing apps are unaffected;
             flip per-app once each has been validated on the new shape.
+        sentry_sourcemaps (Optional[SentrySourcemapsConfig]): When set, the app's
+            image build unpacks its rootfs and a decoupled task uploads the built
+            source maps to Sentry with an auth token -- the token never enters the
+            image build. See :class:`SentrySourcemapsConfig`. Left unset, no source
+            maps are uploaded.
     """
 
     app_name: str
@@ -104,6 +131,7 @@ class AppPipelineParams(BaseModel):
     enable_ci_deploy: bool = True
     github_repo: str | None = None
     use_release_resource_workflow: bool = False
+    sentry_sourcemaps: SentrySourcemapsConfig | None = None
 
     @model_validator(mode="after")
     def set_repo_name(self) -> "AppPipelineParams":
@@ -165,6 +193,12 @@ pipeline_params = {
             "production": "learn.mit.edu",
         },
         fastly_purge_scope="html-pages",
+        sentry_sourcemaps=SentrySourcemapsConfig(
+            org="mit-office-of-digital-learning",
+            project="open-next",
+            auth_token_vault_key="((sentry.mitlearn_auth_token))",  # noqa: S106  # pragma: allowlist secret
+            rootfs_asset_path="app/frontends/main/.next",
+        ),
     ),
     "xpro": AppPipelineParams(
         app_name="xpro",
@@ -392,6 +426,51 @@ def _define_registry_image_resources_legacy(
     return docker_ci_image, docker_rc_image, ecr_ci_image, ecr_rc_image
 
 
+def _sentry_js_sourcemaps_upload_step(
+    sentry_config: SentrySourcemapsConfig,
+    release_var: str | None = None,
+) -> TryStep:
+    """Upload injected source maps to Sentry from the built image's rootfs.
+
+    Runs after the image build. Sentry ties errors to source maps by Debug ID (not
+    release name); this step expects those already injected in the build output.
+
+    Wrapped in a ``try`` so a failed upload never blocks the release.
+    """
+    upload_args = [
+        "sourcemaps",
+        "upload",
+        "--org",
+        sentry_config.org,
+        "--project",
+        sentry_config.project,
+    ]
+    if release_var:
+        upload_args.extend(["--release", release_var])
+    upload_args.append(f"image/rootfs/{sentry_config.rootfs_asset_path}")
+
+    upload_task = TaskStep(
+        task=Identifier("upload-sentry-sourcemaps"),
+        attempts=3,
+        # sentry-cli auto-reads the SENTRY_AUTH_TOKEN param; Concourse redacts it.
+        config=TaskConfig(
+            platform=Platform.linux,
+            image_resource=AnonymousResource(
+                type=REGISTRY_IMAGE,
+                source={
+                    "repository": dockerhub_ecr_image_uri("getsentry/sentry-cli"),
+                    "tag": "latest",
+                    "aws_region": ECR_REGION,
+                },
+            ),
+            inputs=[Input(name=Identifier("image"))],
+            params={"SENTRY_AUTH_TOKEN": sentry_config.auth_token_vault_key},
+            run=Command(path="sentry-cli", args=upload_args),
+        ),
+    )
+    return TryStep(try_=upload_task)
+
+
 def _build_image_job_legacy(
     app_name: str,
     branch_type: str,
@@ -402,6 +481,7 @@ def _build_image_job_legacy(
     build_target: str | None = None,
     django_settings_dir: str = "main",
     repo_version_file: str | None = None,
+    sentry_sourcemaps: SentrySourcemapsConfig | None = None,
 ) -> Job:
     """Generate an image build job for a specific branch type (main or rc)."""
     job_name = f"build-{app_name}-image-from-{branch_type}"
@@ -457,6 +537,18 @@ def _build_image_job_legacy(
         )
         version_args = {"BUILD_ARG_RELEASE_VERSION": f"((.:{version_var}))"}
 
+    # Skip the main build: its image only serves CI. QA and Production both run the
+    # RC image, so the RC upload already covers production.
+    sourcemap_build_params: dict[str, str] = {}
+    sourcemap_upload_step: TryStep | None = None
+    if sentry_sourcemaps is not None and branch_type != "main":
+        # UNPACK_ROOTFS lets the upload step read the maps out of the built image.
+        sourcemap_build_params = {"UNPACK_ROOTFS": "true"}
+        # Tag the artifacts with this build's version (== runtime NEXT_PUBLIC_VERSION).
+        sourcemap_upload_step = _sentry_js_sourcemaps_upload_step(
+            sentry_sourcemaps, release_var=f"((.:{version_var}))"
+        )
+
     plan.extend(
         [
             LoadVarStep(
@@ -476,6 +568,7 @@ def _build_image_job_legacy(
                     "BUILD_ARG_GIT_SHA": "((.:git_ref))",
                     **version_args,
                     **additional_build_params,
+                    **sourcemap_build_params,
                 },
                 build_args=[],
             ),
@@ -493,6 +586,9 @@ def _build_image_job_legacy(
     plan.append(_ensure_ecr_repository_step(ecr_registry_image_resource))
     plan.append(PutStep(put=dockerhub_registry_image_resource.name, params=put_params))
     plan.append(PutStep(put=ecr_registry_image_resource.name, params=put_params))
+
+    if sourcemap_upload_step is not None:
+        plan.append(sourcemap_upload_step)
 
     return Job(name=Identifier(job_name), build_log_retention={"builds": 10}, plan=plan)
 
@@ -545,6 +641,7 @@ def _build_legacy_app_pipeline(
         build_target=pipeline_parameters.build_target,
         django_settings_dir=pipeline_parameters.settings_dir or "main",
         repo_version_file=pipeline_parameters.version_file,
+        sentry_sourcemaps=pipeline_parameters.sentry_sourcemaps,
     )
     rc_image_build_job = _build_image_job_legacy(
         app_name=app_name,
@@ -556,6 +653,7 @@ def _build_legacy_app_pipeline(
         build_target=pipeline_parameters.build_target,
         django_settings_dir=pipeline_parameters.settings_dir or "main",
         repo_version_file=pipeline_parameters.version_file,
+        sentry_sourcemaps=pipeline_parameters.sentry_sourcemaps,
     )
 
     ci_post_steps: list[GetStep | PutStep | TaskStep] = []
@@ -839,7 +937,11 @@ def _build_image_job(
     ecr_registry_image_resource: Resource,
     build_target: str | None = None,
 ) -> Job:
-    """Generate an image build job triggered by the configured git resource."""
+    """Generate an image build job triggered by the configured git resource.
+
+    This is the main-branch/CI build; its image only serves CI, so it uploads no
+    source maps (see _build_release_image_job, whose image serves QA/Production).
+    """
     job_name = f"build-{app_name}-image-from-{git_repo_resource.source['branch']}"
 
     additional_build_params = {}
@@ -896,6 +998,7 @@ def _build_release_image_job(
     dockerhub_registry_image_resource: Resource,
     ecr_registry_image_resource: Resource,
     build_target: str | None = None,
+    sentry_sourcemaps: SentrySourcemapsConfig | None = None,
 ) -> Job:
     """Generate an image build job triggered by the release resource.
 
@@ -910,6 +1013,9 @@ def _build_release_image_job(
     additional_build_params = {}
     if build_target:
         additional_build_params = {"TARGET": build_target}
+
+    # UNPACK_ROOTFS lets the upload step read the maps out of the built image.
+    sourcemap_build_params = {"UNPACK_ROOTFS": "true"} if sentry_sourcemaps else {}
 
     put_params: dict[str, Any] = {
         "image": "image/image.tar",
@@ -967,6 +1073,7 @@ def _build_release_image_job(
                 "BUILD_ARG_RELEASE_VERSION": "((.:release_version))",
                 "PROGRESS": "plain",
                 **additional_build_params,
+                **sourcemap_build_params,
             },
             build_args=[],
         ),
@@ -974,6 +1081,14 @@ def _build_release_image_job(
         PutStep(put=dockerhub_registry_image_resource.name, params=put_params),
         PutStep(put=ecr_registry_image_resource.name, params=put_params),
     ]
+
+    if sentry_sourcemaps:
+        # Tag the artifacts with the release being built.
+        plan.append(
+            _sentry_js_sourcemaps_upload_step(
+                sentry_sourcemaps, release_var="((.:release_version))"
+            )
+        )
 
     return Job(name=Identifier(job_name), build_log_retention={"builds": 10}, plan=plan)
 
@@ -1067,6 +1182,7 @@ def _build_release_resource_app_pipeline(
         dockerhub_registry_image_resource=docker_rc_image,
         ecr_registry_image_resource=app_rc_image,
         build_target=pipeline_parameters.build_target,
+        sentry_sourcemaps=pipeline_parameters.sentry_sourcemaps,
     )
     abandon_release_job = _build_abandon_release_job(
         app_name=app_name,

--- a/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
@@ -459,8 +459,12 @@ def _sentry_js_sourcemaps_upload_step(
                 type=REGISTRY_IMAGE,
                 source={
                     "repository": dockerhub_ecr_image_uri("getsentry/sentry-cli"),
-                    "tag": "latest",
+                    "tag": "3.6.0",
                     "aws_region": ECR_REGION,
+                },
+                # Pin the exact image by digest; the tag above is for humans.
+                version={
+                    "digest": "sha256:dd7ad57b7d1609d5dc76705bb9a2b2a7009ea0a1e74089202df8c20cfd8389c4"  # pragma: allowlist secret
                 },
             ),
             inputs=[Input(name=Identifier("image"))],


### PR DESCRIPTION
# Issue

- Closes https://github.com/mitodl/hq/issues/12330

### Description:

Adds a concourse task to upload sourcemaps to Sentry for MIT Learn NextJS code.

- `next build` already injects Sentry **Debug IDs** into every JS chunk + `.map` (no token, no network — that's `@sentry/nextjs`/`withSentryConfig` in https://github.com/mitodl/mit-learn/blob/af19656020f05dc67eee9f724a589b035102c888/frontends/main/next.config.js#L128).
- This adds a separate pipeline task that uploads those already-generated maps.
  - The RC/release image build unpacks its rootfs (`UNPACK_ROOTFS`).
  - A separate `sentry-cli sourcemaps upload` task reads the maps from that rootfs and uploads them with the token.

Notes:

- Skipped for CI — QA/prod run the RC image, so the RC upload already covers them.
- Does not block release. Task is a `try`
- Debug IDs (not release name) are what bind a map to its minified code, so `--release` is only for organizing the artifact bundle in the Sentry UI.

### How can this be tested?
Not sure. Deploy?

### Release Checklist

- [ ]  a Sentry org auth token must be provisioned at `((sentry.mitlearn_auth_token))` (scopes `org:read`, `project:releases`).
