### PR TITLE
Migrate Superset chart values to database/cache (0.20.0 schema)

### DIFF
--- a/src/ol_infrastructure/applications/superset/__main__.py
+++ b/src/ol_infrastructure/applications/superset/__main__.py
@@ -672,16 +672,19 @@ superset_chart = kubernetes.helm.v3.Release(
                 ]
                 if secret_name is not None
             ],
-            # Connections (non-secret parts)
+            # Connections (non-secret parts). `database`/`cache` supersede the
+            # chart's deprecated `supersetNode.connections.*` keys as of 0.20.0.
+            "database": {
+                "host": superset_db.db_instance.address,
+                "port": str(DEFAULT_POSTGRES_PORT),
+                "name": superset_db_config.db_name,
+            },
+            "cache": {
+                "host": superset_redis_cache.address,
+                "port": str(DEFAULT_REDIS_PORT),
+            },
             "supersetNode": {
                 "podLabels": k8s_global_labels,
-                "connections": {
-                    "redis_host": superset_redis_cache.address,
-                    "redis_port": str(DEFAULT_REDIS_PORT),
-                    "db_name": superset_db_config.db_name,
-                    "db_port": str(DEFAULT_POSTGRES_PORT),
-                    "db_host": superset_db.db_instance.address,
-                },
                 "replicas": {"enabled": False},
                 "autoscaling": {
                     "enabled": True,


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Follow-up to #4978 (Superset helm chart 0.17.2 → 0.20.0). That chart release deprecates `supersetNode.connections.*` in favor of top-level `database.*`/`cache.*` keys — the old keys still work but are flagged for removal in a future major, so this migrates our values to the new schema before that happens.

This is a like-for-like swap of the same DB/Redis host, port, and name values — no behavioral change. (Our actual Superset DB/cache wiring is driven entirely by `superset_config.py` via `configOverrides`, which reads connection details from env vars injected by Vault-synced secrets, not from the chart's generated config — so these values were already inert for that purpose. The migration is purely to track the chart's supported schema going forward.)

### Screenshots (if appropriate):
N/A

### How can this be tested?
Ran `pulumi preview --diff` against all three stacks (QA, CI, Production). Each shows the same clean, non-replacing update to the `superset-helm-release` Helm `Release` resource:

```
~ values       : {
    + cache       : {
        + host: "<redis-cache-address>"
        + port: "6379"
      }
    + database    : {
        + host: "<postgres-address>"
        + name: "superset"
        + port: "5432"
      }
    ~ supersetNode: {
        - connections: {
            - db_host   : "<postgres-address>"
            - db_name   : "superset"
            - db_port   : "5432"
            - redis_host: "<redis-cache-address>"
            - redis_port: "6379"
          }
      }
  }
```

No resource replacements or deletions in any stack. `pre-commit` (ruff, mypy) passes clean.

### Additional Context
N/A
