### PR TITLE
fix(ol-analytics-api): use direct ECR image instead of dockerhub pull-through cache

### DIFF
--- a/src/ol_infrastructure/applications/ol_analytics_api/__main__.py
+++ b/src/ol_infrastructure/applications/ol_analytics_api/__main__.py
@@ -371,8 +371,7 @@ ol_analytics_api_k8s = OLApplicationK8s(
         application_security_group_name=Output.from_input(APPLICATION_NAME),
         application_service_account_name=APPLICATION_NAME,
         vault_k8s_resource_auth_name=ol_analytics_api_auth_binding.vault_k8s_resources.auth_name,
-        application_image_repository="mitodl/ol-analytics-api",
-        registry="dockerhub",
+        application_image_repository="mitodl/ol-analytics-api-app",
         **docker_image_config_kwargs("OL_ANALYTICS_API"),
         application_min_replicas=ol_analytics_api_config.get_int("min_replicas") or 2,
         # The image's own CMD runs uvicorn on port 8000 -- no command override.


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Fixes the ol-analytics-api Pulumi CI deployment failing with `ImagePullBackOff`:

```
[Pod ol-analytics/ol-analytics-api-app-bc485dcd7-nrdn7]: containers with unready status: [ol-analytics-api-app][ImagePullBackOff] Back-off pulling image "610119931565.dkr.ecr.us-east-1.amazonaws.com/dockerhub/mitodl/ol-analytics-api@sha256:b923bee15af8ae78a5e675ef573ad1cf7a2c4655675e1d9dafa19e6474a8ef08": ErrImagePull: ... not found
```

Root cause was two compounding bugs in `src/ol_infrastructure/applications/ol_analytics_api/__main__.py`:

1. **Wrong registry mode.** `registry="dockerhub"` tells `OLApplicationK8s` (`src/ol_infrastructure/components/services/k8s.py`) to build an ECR *pull-through-cache* image URI (`.../dockerhub/mitodl/<repo>@<digest>`). That path only resolves once the given digest has actually been requested from Docker Hub through the cache. But the Concourse CI job (`src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py`) pushes the image straight to a plain ECR repo via a `registry_image` resource configured with `ecr_kwargs`, and loads `OL_ANALYTICS_API_DOCKER_SHA` from that direct-push resource's digest. The pull-through-cache mirror never saw that digest, so ECR reported `NotFound`.
2. **Wrong repository name.** The pipeline pushes to `mitodl/ol-analytics-api-app` (`f"mitodl/{app_name}-app"`, matching the convention used by `mit_learn`/`learn_ai`), but `__main__.py` declared `application_image_repository="mitodl/ol-analytics-api"` — missing the `-app` suffix.

Fix: drop `registry="dockerhub"` (default is `"ecr"`, matching what the pipeline actually pushes to) and correct `application_image_repository` to `mitodl/ol-analytics-api-app`. The resulting image URI now matches exactly what the CI job pushes and what `_ensure_ecr_repository_step` provisions in ECR.

This is a single shared `__main__.py` used by all three Pulumi stacks (CI/QA/Production), so it fixes the image reference for all of them, not just CI.

### Screenshots (if appropriate):
N/A -- infrastructure-only change, no UI.

### How can this be tested?
- `ruff check` and the full `pre-commit` suite pass on the changed file.
- Verified the resulting image URI matches the actual ECR push target:
  ```
  ecr_image_uri("mitodl/ol-analytics-api-app@sha256:b923bee15af8ae78a5e675ef573ad1cf7a2c4655675e1d9dafa19e6474a8ef08")
  == "610119931565.dkr.ecr.us-east-1.amazonaws.com/mitodl/ol-analytics-api-app@sha256:b923bee15af8ae78a5e675ef573ad1cf7a2c4655675e1d9dafa19e6474a8ef08"
  ```
- Reviewer validation: re-run the `ol-analytics-api` CI Pulumi deploy in Concourse after merge and confirm the `ol-analytics-api-app` Deployment's pods pull the image successfully and reach `Ready`.

### Additional Context
`__main__.py` also has a stale docstring claiming "there is no CI stack" for this app (because StarRocks is only provisioned on QA/Production), yet the Concourse pipeline unconditionally deploys a CI stack for it. That's a separate, pre-existing inconsistency not addressed by this PR -- worth a follow-up to confirm whether the CI stack's Vault StarRocks path (`database-starrocks-ci/creds/app`) actually exists, since pods may still fail to start once the image pulls correctly.