### PR TITLE
fix(edxapp): make mitxonline SENTRY_IGNORED_EXCEPTION_MESSAGES single strings

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/config_builder.py
+++ b/src/ol_infrastructure/applications/edxapp/config_builder.py
@@ -615,19 +615,19 @@ def get_deployment_overrides(env_prefix: str) -> ConfigDict:
             },
             "SENTRY_IGNORED_EXCEPTION_MESSAGES": [
                 (
-                    "Tried to inspect an unsupported, broken, or",
-                    "missing downstream->upstream link:",
+                    "Tried to inspect an unsupported, broken, or "
+                    "missing downstream->upstream link:"
                 ),
                 (
-                    "Invalid HTTP_HOST header: 'vqbjqfz3ldd42z6qff3t2h5cr62c5rok._domainkey.huggingface.co'.",
-                    "The domain name provided is not valid according to RFC 1034/1035.",
+                    "Invalid HTTP_HOST header: 'vqbjqfz3ldd42z6qff3t2h5cr62c5rok._domainkey.huggingface.co'. "
+                    "The domain name provided is not valid according to RFC 1034/1035."
                 ),
                 (
-                    "A label was requested for language code `ht` but",
-                    "the code is completely unknown",
+                    "A label was requested for language code `ht` but "
+                    "the code is completely unknown"
                 ),
-                ("Failed async course content export to git",),
-                ("Failed to pull git repository",),
+                "Failed async course content export to git",
+                "Failed to pull git repository",
             ],
         },
     }


### PR DESCRIPTION
## What & why

The mitxonline `SENTRY_IGNORED_EXCEPTION_MESSAGES` entries in `config_builder.py` were each a **tuple** of string fragments — a stray trailing comma turned adjacent string literals into tuples instead of concatenating them:

```python
(
    "Tried to inspect an unsupported, broken, or",   # <- stray comma
    "missing downstream->upstream link:",
),
```

Rendered through `yaml.SafeDumper` (which represents tuples as YAML sequences), these reach edxapp as a **list of lists**. Before `ol-openedx-sentry` 0.4.0, the plugin's `before_send` filter called `re.search()` on each entry — a `list` argument raises `TypeError`, and sentry-sdk drops any event whose `before_send` raises. Net effect: **essentially all exception events for mitxonline were being silently dropped.**

## Change

Remove the stray commas so each entry is a single concatenated string (Python implicit string concatenation, adding the space each boundary needs), and flatten the one-element tuples to plain strings. The resulting config is what was originally intended — one regex per ignored message:

- `"Tried to inspect an unsupported, broken, or missing downstream->upstream link:"`
- `"Invalid HTTP_HOST header: '…huggingface.co'. The domain name provided is not valid according to RFC 1034/1035."`
- `"A label was requested for language code \`ht\` but the code is completely unknown"`
- `"Failed async course content export to git"`
- `"Failed to pull git repository"`

## Relationship to the plugin fix

The plugin side of this bug is fixed and merged in [mitodl/open-edx-plugins#829](https://github.com/mitodl/open-edx-plugins/pull/829) (`ol-openedx-sentry` 0.4.0), which makes `before_send` fail-open and tolerant of list/tuple-shaped entries. So this PR is the **config-side cleanup**, not a blocker — but it restores the intended precise matching and removes the footgun for the next reader.

## Testing

- `pre-commit` (ruff-format, ruff-check, mypy) passes.
- Verified the rendered list is now 5 `str` entries (no tuples/lists) with correct spacing via `ast.literal_eval`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)