### PR TITLE
fix(ocw-studio): scope session cookie name per environment

### DIFF
--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -425,6 +425,11 @@ app_env_vars = {
     "SOCIAL_AUTH_SAML_IDP_ENTITY_ID": "https://idp.mit.edu/shibboleth",
     "SOCIAL_AUTH_SAML_IDP_URL": "https://idp.mit.edu/idp/profile/SAML2/Redirect/SSO",
     "SOCIAL_AUTH_SAML_LOGIN_URL": "https://idp.mit.edu/idp/profile/SAML2/Redirect/SSO",
+    "SESSION_COOKIE_NAME": (
+        "session_ocwstudio"
+        if stack_info.name == "Production"
+        else f"session_ocwstudio_{env_name}"
+    ),
     "SOCIAL_AUTH_SAML_ORG_DISPLAYNAME": "MIT Open Learning",
     "SOCIAL_AUTH_SAML_SECURITY_ENCRYPTED": "True",
     "USE_X_FORWARDED_PORT": "True",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Sets `SESSION_COOKIE_NAME` for ocw-studio in the Pulumi K8s app config (`src/ol_infrastructure/applications/ocw_studio/__main__.py`), matching the naming convention already used by mit-learn and mitxonline:

- Production: `session_ocwstudio`
- QA: `session_ocwstudio_rc`
- CI: `session_ocwstudio_ci`
- Dev: `session_ocwstudio_dev`

Without this, ocw-studio falls back to Django's default `sessionid` cookie name. The value is computed from the existing `env_name` variable already used for `ENV_NAME`/`OCW_STUDIO_ENVIRONMENT`, so no per-stack YAML config changes were needed.

### Screenshots (if appropriate):
N/A — no UI change.

### How can this be tested?
- `ruff check src/ol_infrastructure/applications/ocw_studio/__main__.py` passes.
- After deploy, confirm the app sets a `session_ocwstudio[_<env>]` cookie instead of `sessionid` (e.g. via browser devtools on a login) for each stack.

### Additional Context
Follows the pattern from:
- `src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml` (`SESSION_COOKIE_NAME: "session_mitlearn"`)
- `src/ol_infrastructure/applications/mitxonline/Pulumi.Production.yaml` (`SESSION_COOKIE_NAME: "session_mitxonline"`)