### PR TITLE
fix(ol-analytics-api): grant app SA system:auth-delegator for direct Vault k8s auth

### DIFF
--- a/src/ol_infrastructure/applications/ol_analytics_api/__main__.py
+++ b/src/ol_infrastructure/applications/ol_analytics_api/__main__.py
@@ -213,6 +213,38 @@ ol_analytics_api_auth_binding = OLEKSAuthBinding(
     )
 )
 
+# The data cluster's Vault kubernetes auth backend config (vault_secrets_operator.py,
+# infrastructure/aws/eks) has no token_reviewer_jwt set, so Vault authenticates each
+# login by replaying the caller's own JWT against the Kubernetes TokenReview API --
+# which requires that caller's ServiceAccount to hold "system:auth-delegator"
+# clusterwide. OLVaultK8SResources (components/services/vault.py) only grants that
+# binding to the "{application_name}-vault" VSO sync account, since every other app
+# in this repo only ever authenticates to Vault through the vault-secrets-operator.
+# ol_analytics_api is the exception: core/db/vault_credentials.py logs in directly
+# with the app's own IRSA ServiceAccount to fetch dynamic StarRocks credentials, so
+# that account needs the same delegator binding or every login 403s with a generic
+# "permission denied" -- see the CI CrashLoopBackOff this was written to fix.
+ol_analytics_api_app_auth_delegator_binding = kubernetes.rbac.v1.ClusterRoleBinding(
+    f"ol-analytics-api-app-vault-cluster-role-binding-{stack_info.env_suffix}",
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        name=f"{APPLICATION_NAME}:cluster-auth",
+        labels=k8s_global_labels,
+    ),
+    role_ref=kubernetes.rbac.v1.RoleRefArgs(
+        api_group="rbac.authorization.k8s.io",
+        kind="ClusterRole",
+        name="system:auth-delegator",
+    ),
+    subjects=[
+        kubernetes.rbac.v1.SubjectArgs(
+            kind="ServiceAccount",
+            name=APPLICATION_NAME,
+            namespace=APPLICATION_NAMESPACE,
+        ),
+    ],
+    opts=ResourceOptions(parent=ol_analytics_api_auth_binding),
+)
+
 ########################################################################
 # Static application secrets -- SENTRY_DSN
 ########################################################################


### PR DESCRIPTION
### What are the relevant tickets?
N/A -- found and fixed via live debugging of a CI incident, no tracking issue was filed.

### Description (What does it do?)
`ol-analytics-api` pods in the `data-ci` cluster were stuck in `CrashLoopBackOff`. The app's own startup code (`core/db/vault_credentials.py` in the `ol-analytics-api` app repo) logs in to Vault directly via Kubernetes auth to fetch dynamic StarRocks credentials -- unlike every other app in this repo, which only ever reaches Vault through the vault-secrets-operator (VSO).

Root cause: the `data` cluster's `k8s-data` Vault auth backend (`src/ol_infrastructure/infrastructure/aws/eks/vault_secrets_operator.py`) has no `token_reviewer_jwt` configured. Without one, Vault authenticates a login by replaying the *caller's own JWT* against the Kubernetes `TokenReview` API, which requires that caller's ServiceAccount to hold cluster-wide `system:auth-delegator` RBAC. The shared `OLVaultK8SResources` component (`src/ol_infrastructure/components/services/vault.py`) only grants that binding to the `{application_name}-vault` ServiceAccount used by the VSO sync sidecar -- never to the app's own pod ServiceAccount. So the VSO's logins succeeded (its `VaultAuth` custom resource showed `Healthy: True`), while the app's direct logins as SA `ol-analytics-api` were rejected by Kubernetes at the `TokenReview` step every time, which Vault surfaces to the client as a generic `permission denied`.

This adds an explicit `ClusterRoleBinding` granting `system:auth-delegator` to the app's own `ol-analytics-api` IRSA ServiceAccount, mirroring the one `OLVaultK8SResources` already creates automatically for the `-vault` SA.

### Screenshots (if appropriate):
N/A -- infrastructure-only change, no UI impact.

### How can this be tested?
Confirmed via `kubectl --context data-ci`:
- Pods `ol-analytics-api-app-*` in namespace `ol-analytics` were `CrashLoopBackOff`, exit code 3, with a traceback ending in `hvac.exceptions.Forbidden: permission denied, on post https://vault-ci.odl.mit.edu/v1/auth/k8s-data/login`.
- `kubectl get clusterrolebinding -o json` showed only one `ol-analytics-api*` binding (`ol-analytics-api-vault:cluster-auth`, for the VSO SA) and none for the app's own `ol-analytics-api` SA.
- Vault's own audit logs (via Grafana Cloud Loki, `service_name="vault"`) show every `auth/k8s-data/login` request/response pair over the observed window failing identically with `"error":"permission denied"`.
- `pulumi preview --diff` against the `CI` stack for `ol_analytics_api` shows a clean, single-resource diff (`+ 1 to create`, `21 unchanged`) -- just the new `ClusterRoleBinding`, no other drift.

Once merged and applied (`pulumi up` on the `ol-application-ol-analytics-api` `CI` stack, or via the normal Concourse deploy pipeline), the app pods should be able to complete their Vault kubernetes-auth login on startup and the deployment should stop crash-looping. Reviewer can re-run `pulumi preview --diff` against QA/Production stacks too, though those aren't currently affected since neither of those environments has hit this path yet.

### Additional Context
While debugging this I also found the `ol-analytics-api` OIDC static secret sync is failing separately with `empty response from Vault` at Vault path `secret-operations/sso/ol-analytics-api` (a data-provisioning gap, not an auth issue). That's unrelated to this crash loop and is not addressed by this PR -- flagging here for visibility, will need a follow-up.