### PR TITLE
feat(grafana_alerting): route overnight warning alerts to Slack instead of paging

### DIFF
--- a/src/ol_infrastructure/infrastructure/grafana_alerting/CLAUDE.md
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/CLAUDE.md
@@ -2,6 +2,7 @@
 
 This Pulumi program manages alerting and uptime monitoring for MIT Open Learning.
 It replaces two legacy systems:
+
 - **Pingdom (manual)** → Pingdom checks managed via a Pulumi dynamic provider (`pingdom_checks.py`)
 - **grafana-alerts repo + cortextool** → Grafana-managed alert rules and Alertmanager config
 
@@ -31,6 +32,7 @@ set of Grafana-managed alert rules. The Pulumi stacks (CI, QA, Production) map
 1:1 to the Grafana Cloud stacks.
 
 Secrets files must be encrypted with SOPS before committing:
+
 ```
 sops --encrypt --in-place src/bridge/secrets/grafana_cloud/api.<env>.yaml
 ```
@@ -183,11 +185,22 @@ The notification policy in `alertmanager.py` mirrors the original
 1. `channel=notifications-ocw-misc` → Slack by severity (warning/critical),
    anything else with that label is silenced.
 2. `alertname=~Kube.*` → silenced (built-in k8s noise, not actionable).
-3. `severity=warning` → Rootly.
-4. `severity=critical` → Rootly.
+3. `severity=warning`:
+   - daytime (09:00–17:00 `America/New_York`) → Rootly (pages).
+   - overnight (17:00–09:00) → `#notifications-oncall` Slack only (no page).
+4. `severity=critical` → Rootly, 24/7.
 5. Default (catch-all) → `oblivion` (empty contact point, acts as drop sink).
 
 OpsGenie is no longer active. All actionable alerts route to Rootly.
+
+The warning day/night split is driven by two `MuteTiming` resources
+(`overnight-17-to-09-eastern`, `daytime-09-to-17-eastern`). The daytime Rootly
+route sets `continue_=True` so a warning is offered to both the Rootly route and
+the overnight Slack route; the route muted for the current time drops out,
+leaving one active destination. Time ranges are `America/New_York`-local so the
+window tracks EST/EDT. Only Grafana-pipeline alerts (source `grafana` and
+`alertmanager`) pass through this policy; CloudWatch and Sentry webhook Rootly
+directly and are not yet time-gated (planned fast-follow).
 
 ---
 
@@ -201,6 +214,7 @@ grafana_url: https://<stack>.grafana.net
 grafana_api_token: <service-account-token>
 rootly_bearer_token: <rootly-webhook-bearer-token>
 slack_notifications_ocw_misc_api_url: <slack-webhook-url>
+slack_oncall_overnight_api_url: <slack-webhook-url>  # #notifications-oncall channel; receives overnight warning alerts
 
 # Production only (Pingdom checks run from production stack only):
 pingdom_api_token: <pingdom-api-token>

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/CLAUDE.md
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/CLAUDE.md
@@ -187,7 +187,7 @@ The notification policy in `alertmanager.py` mirrors the original
 2. `alertname=~Kube.*` → silenced (built-in k8s noise, not actionable).
 3. `severity=warning`:
    - daytime (09:00–17:00 `America/New_York`) → Rootly (pages).
-   - overnight (17:00–09:00) → `#notifications-oncall` Slack only (no page).
+   - overnight (17:00–09:00) → `#devops-alerts` Slack only (no page).
 4. `severity=critical` → Rootly, 24/7.
 5. Default (catch-all) → `oblivion` (empty contact point, acts as drop sink).
 
@@ -214,7 +214,7 @@ grafana_url: https://<stack>.grafana.net
 grafana_api_token: <service-account-token>
 rootly_bearer_token: <rootly-webhook-bearer-token>
 slack_notifications_ocw_misc_api_url: <slack-webhook-url>
-slack_oncall_overnight_api_url: <slack-webhook-url>  # #notifications-oncall channel; receives overnight warning alerts
+slack_devops_alerts_overnight_api_url: <slack-webhook-url>  # #devops-alerts channel; receives overnight warning alerts
 
 # Production only (Pingdom checks run from production stack only):
 pingdom_api_token: <pingdom-api-token>

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/alertmanager.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/alertmanager.py
@@ -103,12 +103,12 @@ def create(grafana_secrets: dict[str, Any], resource_opts: ResourceOptions) -> N
     # business hours land here instead of paging Rootly. Preserves awareness of
     # a spike without waking someone for something that usually self-resolves.
     alerting.ContactPoint(
-        "slack-oncall-overnight-warning",
-        name="slack-oncall-overnight-warning",
+        "slack-devops-alerts-overnight-warning",
+        name="slack-devops-alerts-overnight-warning",
         slacks=[
             alerting.ContactPointSlackArgs(
-                url=grafana_secrets["slack_oncall_overnight_api_url"],
-                recipient="#notifications-oncall",
+                url=grafana_secrets["slack_devops_alerts_overnight_api_url"],
+                recipient="#devops-alerts",
                 color="warning",
                 icon_emoji=":goose_warning:",
                 title=':goose_warning: [OVERNIGHT] [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{- end }}] - {{ .CommonLabels.alertname }}',
@@ -243,7 +243,7 @@ def create(grafana_secrets: dict[str, Any], resource_opts: ResourceOptions) -> N
                         value="warning",
                     )
                 ],
-                contact_point="slack-oncall-overnight-warning",
+                contact_point="slack-devops-alerts-overnight-warning",
                 mute_timings=[mute_daytime.name],
                 continue_=False,
             ),

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/alertmanager.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/alertmanager.py
@@ -6,9 +6,18 @@ Routing logic (mirrors the original alertmanager.yaml route tree):
   1. Alerts labelled channel=notifications-ocw-misc go to dedicated Slack
      channels by severity; anything else with that channel label is silenced.
   2. Alerts whose name matches Kube.* are silenced (built-in k8s noise).
-  3. All remaining warning-severity alerts → Rootly.
-  4. All remaining critical-severity alerts → Rootly.
+  3. Warning-severity alerts:
+       - during the day (09:00-17:00 America/New_York) → Rootly (pages).
+       - overnight (17:00-09:00) → Slack only, so transient warnings that
+         self-resolve do not page a human in the middle of the night while
+         still surfacing the spike for awareness.
+  4. All critical-severity alerts → Rootly, 24/7 (unchanged).
   5. Everything else → oblivion (default receiver, acts as a drop sink).
+
+The overnight/daytime split is implemented with two complementary mute timings
+and a continue=True on the daytime Rootly route: a warning is matched by both
+the Rootly route and the Slack route, and whichever one is muted for the
+current time drops out, leaving exactly one active destination.
 """
 
 from typing import Any
@@ -90,6 +99,61 @@ def create(grafana_secrets: dict[str, Any], resource_opts: ResourceOptions) -> N
         opts=resource_opts,
     )
 
+    # On-call overnight Slack — warning-severity alerts that fire outside
+    # business hours land here instead of paging Rootly. Preserves awareness of
+    # a spike without waking someone for something that usually self-resolves.
+    alerting.ContactPoint(
+        "slack-oncall-overnight-warning",
+        name="slack-oncall-overnight-warning",
+        slacks=[
+            alerting.ContactPointSlackArgs(
+                url=grafana_secrets["slack_oncall_overnight_api_url"],
+                recipient="#notifications-oncall",
+                color="warning",
+                icon_emoji=":goose_warning:",
+                title=':goose_warning: [OVERNIGHT] [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{- end }}] - {{ .CommonLabels.alertname }}',
+                text="{{ range .Alerts }}\n  {{- if .Annotations.message }}\n      Message - {{ .Annotations.message }}\n  {{- end }}\n  {{- if .Annotations.description }}\n      Description - {{ .Annotations.description }}\n  {{- end }}\n  {{- if .Annotations.summary }}\n      Summary - {{ .Annotations.summary }}\n  {{- end }}\n{{- end }}",
+                disable_resolve_message=False,
+            )
+        ],
+        opts=resource_opts,
+    )
+
+    # -------------------------------------------------------------------------
+    # Mute timings — the overnight/daytime split for warning-severity routing.
+    # Times are local to America/New_York, so the window tracks EST/EDT
+    # automatically. Alertmanager time ranges cannot span midnight, so the
+    # overnight window is expressed as two ranges (00:00-09:00 and 17:00-24:00).
+    # -------------------------------------------------------------------------
+    mute_overnight = alerting.MuteTiming(
+        "mute-overnight",
+        name="overnight-17-to-09-eastern",
+        intervals=[
+            alerting.MuteTimingIntervalArgs(
+                location="America/New_York",
+                times=[
+                    alerting.MuteTimingIntervalTimeArgs(start="00:00", end="09:00"),
+                    alerting.MuteTimingIntervalTimeArgs(start="17:00", end="24:00"),
+                ],
+            )
+        ],
+        opts=resource_opts,
+    )
+
+    mute_daytime = alerting.MuteTiming(
+        "mute-daytime",
+        name="daytime-09-to-17-eastern",
+        intervals=[
+            alerting.MuteTimingIntervalArgs(
+                location="America/New_York",
+                times=[
+                    alerting.MuteTimingIntervalTimeArgs(start="09:00", end="17:00"),
+                ],
+            )
+        ],
+        opts=resource_opts,
+    )
+
     # -------------------------------------------------------------------------
     # Notification policy (route tree)
     # -------------------------------------------------------------------------
@@ -153,7 +217,10 @@ def create(grafana_secrets: dict[str, Any], resource_opts: ResourceOptions) -> N
                 contact_point="oblivion",
                 continue_=False,
             ),
-            # All warning-severity alerts → Rootly.
+            # Warning-severity alerts, daytime (09:00-17:00 Eastern) → Rootly.
+            # Muted overnight so it does not page. continue_=True lets the same
+            # alert also reach the overnight Slack route below; whichever route
+            # is muted for the current time simply produces no notification.
             alerting.NotificationPolicyPolicyArgs(
                 matchers=[
                     alerting.NotificationPolicyPolicyMatcherArgs(
@@ -163,6 +230,21 @@ def create(grafana_secrets: dict[str, Any], resource_opts: ResourceOptions) -> N
                     )
                 ],
                 contact_point="rootly",
+                mute_timings=[mute_overnight.name],
+                continue_=True,
+            ),
+            # Warning-severity alerts, overnight (17:00-09:00 Eastern) → Slack
+            # only. Muted during the day, when the Rootly route above pages.
+            alerting.NotificationPolicyPolicyArgs(
+                matchers=[
+                    alerting.NotificationPolicyPolicyMatcherArgs(
+                        label="severity",
+                        match="=",
+                        value="warning",
+                    )
+                ],
+                contact_point="slack-oncall-overnight-warning",
+                mute_timings=[mute_daytime.name],
                 continue_=False,
             ),
             # All critical-severity alerts → Rootly.


### PR DESCRIPTION
### What are the relevant tickets?

Part of https://github.com/mitodl/ol-infrastructure/issues/5012

### Description (What does it do?)

On-call has been getting paged overnight by warning-severity alerts that last only a few minutes and self-resolve (e.g. Grafana Synthetic Monitoring "response times 30% above normal", `mitlearn-5xx-error-percentage`). These should not wake a human in the middle of the night, but we still want visibility that a service spiked past threshold.

This changes the Grafana Alertmanager notification policy (`src/ol_infrastructure/infrastructure/grafana_alerting/alertmanager.py`) so that **warning-severity** alerts are routed by time of day:

- **Daytime (09:00–17:00 `America/New_York`)** → Rootly (pages), unchanged.
- **Overnight (17:00–09:00)** → a new `#devops-alerts` Slack contact point **only** — no page. Awareness is preserved; nobody is woken.
- **Critical-severity** alerts → Rootly, 24/7. Unchanged.

Implementation notes:

- Two complementary `MuteTiming` resources (`overnight-17-to-09-eastern`, `daytime-09-to-17-eastern`). Times are `America/New_York`-local so the window tracks EST/EDT automatically. The overnight window is split into `00:00–09:00` + `17:00–24:00` because Alertmanager time ranges cannot span midnight.
- The daytime Rootly route uses `continue_=True` so a warning is offered to both the Rootly route and the overnight Slack route; whichever is muted for the current time drops out, leaving exactly one active destination. This is the idiom shown in the pulumiverse_grafana provider's own `NotificationPolicy` example.

### Scope / follow-up

This policy only governs the **Grafana pipeline** — alert sources `grafana` and `alertmanager` (~65% of Rootly alert volume over the last 30 days). **CloudWatch** (SNS→Rootly) and **Sentry** (→Rootly) webhook Rootly directly and bypass Grafana Alertmanager, so they are **not** time-gated by this change. Gating those is a planned fast-follow (likely at the Rootly layer, the one chokepoint all sources share).

Note on threshold: the original request was "must be in alert 2 minutes before paging," but the data showed most overnight noise already lasts 5–6 minutes, so a 2-minute duration gate would not have helped. This severity + time-of-day approach targets the actual noise while keeping criticals paging.

### How can this be tested?

- `uv run ruff check` and `uv run mypy` on `alertmanager.py` — both pass. `pre-commit run --files ...` passes all hooks.
- `pulumi preview` was **not** run locally: it requires Grafana Cloud credentials and the new `slack_devops_alerts_overnight_api_url` secret (see checklist), which are only present in the deploy environment. Please validate via `pulumi preview` in the CI pipeline / a stack with the secret populated before merge.
- Post-deploy validation: in Grafana Cloud → Alerting → Notification policies, confirm the two warning routes and the two mute timings render as expected; send a test warning alert during each window and confirm it reaches Rootly (day) vs `#devops-alerts` (night), and that a critical still pages in both.

### Additional Context

Open question for reviewers: this implements the **literal** 5 PM–9 AM window **every day**, so weekend daytime warnings still page. If weekends should be treated as fully overnight (Slack-only), say so and I'll add a weekday constraint to the mute timings.

### Checklist:
- [ ] Add `slack_devops_alerts_overnight_api_url` (an incoming webhook for `#devops-alerts`, or the chosen channel) to each `src/bridge/secrets/grafana_cloud/api.<env>.yaml` and re-encrypt with SOPS **before** deploying — `pulumi up` will fail without it.
- [ ] Confirm the target Slack channel name (`#devops-alerts` is a placeholder default in the contact point `recipient`).
