### PR TITLE
Bump mitlearn production Redis (ElastiCache) to cache.r7g.2xlarge

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
@@ -115,7 +115,7 @@ config:
     UWSGI_WORKERS: 3
     YOUTUBE_CONFIG_URL: "https://raw.githubusercontent.com/mitodl/open-video-data/main/youtube/channels.yaml"
   mitlearn:zendesk_help_url: "mitlearn.zendesk.com"
-  redis:instance_type: "cache.r7g.xlarge"
+  redis:instance_type: "cache.r7g.2xlarge"
   redis:password:
     secure: v1:xdJFi6D7NpeVwYrg:C0GQl3mctDO1+ehHcFAPdeJDuhk9PbuNdNGtghRNMlzP6GC/GCOyGS1V0ViUXwiO7JhAFD6zrstWmhg0X/yHQLnK8KA=
   vault:address: https://vault-production.odl.mit.edu


### PR DESCRIPTION
### What are the relevant tickets?
N/A — operational stopgap for recurring production paging.

### Description (What does it do?)
Bumps the MIT Learn **production** ElastiCache (Valkey) node type one notch, from `cache.r7g.xlarge` to `cache.r7g.2xlarge`, in `src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml`.

**Why:** `mitlearn-redis-production` has repeatedly paged on-call with `DatabaseMemoryUsagePercentage` alerts at ~99.98% (CloudWatch, account 610119931565, `us-east-1`). Baseline sits ~13.5 GB (~60% of usable memory after the 25% reserved-memory headroom) and a catalog reindex chord fan-out spikes it another ~7.5 GB, tipping it past the 90% alarm threshold.

This doubles headroom on all three nodes (1 primary + 2 replicas):

| | Current `r7g.xlarge` | New `r7g.2xlarge` | Gain |
|---|---|---|---|
| Memory | 26.32 GiB | 52.82 GiB | +26.5 GiB (~2x) |
| vCPU | 4 | 8 | +4 (2x) |

That drops the resident baseline from ~60% to ~30% and leaves room for the reindex spike well under the alarm threshold.

**Scope / caveat:** this is a deliberate stopgap. It buys headroom but does not address the root pattern — the Celery broker, Celery result backend, RedBeat, and the Django response cache all share this one instance. Those are addressed separately in the mit-learn app repo:
- https://github.com/mitodl/mit-learn/pull/3625 (bound Celery result retention)
- https://github.com/mitodl/mit-learn/issues/3622 (move result backend off the shared instance)
- https://github.com/mitodl/mit-learn/issues/3623 (batch the catalog reindex chord)

### How can this be tested?
`pulumi preview --stack Production` shows the ElastiCache replication group as an **in-place update** (not a replacement):

```
~ aws:elasticache/replicationGroup:ReplicationGroup: (update)
    [id=mitlearn-redis-production]
```

Node-type scale-up is an online operation: ElastiCache scales the replicas, then fails over to a resized replica. `apply_immediately` defaults to `true` in the `OLAmazonCache` component, so the change applies right away rather than deferring to the `sun:03:00-04:00 UTC` maintenance window. Expected disruption is a single brief failover blip (seconds to ~1 min) with client reconnects; dataset is only ~13-20 GB so sync is fast (est. ~15-40 min end-to-end).

### Additional Context
- Local `pulumi preview` could not fully complete because `MIT_LEARN_DOCKER_TAG` / `MIT_LEARN_DOCKER_SHA` (CI-provided) were unset, but it evaluated far enough to confirm the ElastiCache resource is an in-place `update`. CI's preview will be authoritative for the full plan.
- The local preview also surfaced an unrelated pre-existing `fastly:ServiceVcl (update)` drift on the Production stack; it is not introduced by this change.
- Reverting is symmetric: scaling back down is the same online operation with another brief failover.