### PR TITLE
Discover keycloak-operator CRDs from release manifest instead of hardcoding

### DIFF
--- a/src/ol_infrastructure/applications/keycloak/__main__.py
+++ b/src/ol_infrastructure/applications/keycloak/__main__.py
@@ -120,12 +120,20 @@ env_name = f"keycloak-{stack_info.env_suffix}"
 # download custom resource definitions for the keycloak operator
 KEYCLOAK_OPERATOR_CRD_BASE_URL = f"https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/{KEYCLOAK_OPERATOR_CRD_VERSION}/kubernetes"
 
+# Discover the CRD manifests for this release from its own kustomization.yml
+# rather than hardcoding filenames, which go stale whenever the operator adds
+# a new CRD (e.g. the SAML/OIDC client CRDs added in 26.7.0) and silently
+# leaves the new controller without its CRD, crashing the operator on startup.
+kustomization = yaml.safe_load(
+    requests.get(f"{KEYCLOAK_OPERATOR_CRD_BASE_URL}/kustomization.yml").content  # noqa: S113
+)
+crd_files = [
+    resource for resource in kustomization["resources"] if resource != "kubernetes.yml"
+]
+
 keycloak_operator_crds = kubernetes.yaml.v2.ConfigGroup(
     f"{env_name}-keycloak-operator-crds",
-    files=[
-        f"{KEYCLOAK_OPERATOR_CRD_BASE_URL}/keycloaks.k8s.keycloak.org-v1.yml",
-        f"{KEYCLOAK_OPERATOR_CRD_BASE_URL}/keycloakrealmimports.k8s.keycloak.org-v1.yml",
-    ],
+    files=[f"{KEYCLOAK_OPERATOR_CRD_BASE_URL}/{crd_file}" for crd_file in crd_files],
     opts=ResourceOptions(
         delete_before_replace=False,
     ),


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
The `keycloak-operator` deployment in the `operations-ci-readonly` cluster's `keycloak` namespace has been stuck in `CrashLoopBackOff` for ~22 hours (282+ restarts). Root cause:

- `KEYCLOAK_OPERATOR_CRD_VERSION` (`src/bridge/lib/versions.py`) was bumped to `26.7.0`.
- At that release, [`keycloak-k8s-resources`](https://github.com/keycloak/keycloak-k8s-resources) ships **four** CRD manifests: `keycloaks`, `keycloakrealmimports`, `keycloakoidcclients`, and `keycloaksamlclients` — the latter two are new in `26.7.0`.
- `src/ol_infrastructure/applications/keycloak/__main__.py` hardcoded only the original two CRD filenames in the `keycloak_operator_crds` `ConfigGroup`.
- The operator's Deployment (applied separately via the full `kubernetes.yml` manifest) sets env vars enabling `KeycloakSAMLClientController` and `KeycloakOIDCClientController` regardless — these are baked into that release's manifest, not something we opt into.
- On startup, the Java Operator SDK tries to start an informer for every enabled controller. It hit `404 Not Found` trying to watch `keycloaksamlclients.k8s.keycloak.org/v2alpha1`, since that CRD was never applied to the cluster, and the whole operator process crashed as a result.
- The crash was masked at the Deployment level: the previous `26.6.4` pod was still `Running`/`Ready` under an old ReplicaSet, so `kubectl get deployment` showed `Available: True` even though `Progressing: False / ProgressDeadlineExceeded`.

Fix: instead of hardcoding CRD filenames, fetch the release's own `kustomization.yml` (already fetched analogously for `kubernetes.yml` a few lines below) and derive the CRD file list from its `resources:` entries, excluding `kubernetes.yml` itself (which is applied separately, after the CRDs). This makes any future CRD added by an operator release get applied automatically, instead of silently missing and crash-looping the operator.

### Screenshots (if appropriate):

### How can this be tested?
- `uv run pre-commit run --files src/ol_infrastructure/applications/keycloak/__main__.py` passes (ruff, mypy, etc.).
- Manually resolved the discovery logic against the pinned `26.7.0` tag's `kustomization.yml` and confirmed it returns all 4 expected CRD filenames (`keycloakoidcclients`, `keycloakrealmimports`, `keycloaks`, `keycloaksamlclients`).
- `pulumi preview --stack CI` for the `keycloak` project shows a clean, isolated diff: `+2 to create` for exactly the two missing CRDs (`keycloaksamlclients.k8s.keycloak.org`, `keycloakoidcclients.k8s.keycloak.org`), no unexpected replacements/deletions.
- After `pulumi up`, the crashing `keycloak-operator` pod in `operations-ci-readonly`/`keycloak` should recover on its next restart (or can be forced with `kubectl rollout restart deployment/keycloak-operator -n keycloak`).

### Additional Context
This only fixes CRD discovery going forward. Someone still needs to run `pulumi up` against the CI (and likely QA/Production, once they pick up `26.7.0`) `keycloak` stack to actually create the missing CRDs and clear the current CrashLoopBackOff.