### PR TITLE
fix: bump starrocks chart-version guard to 1.11.6

### DIFF
--- a/src/ol_infrastructure/applications/starrocks/__main__.py
+++ b/src/ol_infrastructure/applications/starrocks/__main__.py
@@ -526,6 +526,8 @@ if starrocks_config.get_bool("use_cn"):
 # entirely.  The base config below is sourced from the starrocks Helm chart
 # defaults and must be reviewed whenever STARROCKS_CHART_VERSION is bumped.
 # Ref: starrocks/values.yaml starrocksFESpec.config in the operator Helm chart.
+# Reviewed for 1.11.6: the only diff from 1.11.5 is an unrelated
+# externalTrafficPolicy service field; the fe.conf config block is unchanged.
 #
 # NOTE: The SSL keystore password appears in fe.conf (→ K8s ConfigMap). This is
 # an inherent limitation of StarRocks' SSL design; the password protects the
@@ -534,9 +536,9 @@ if (
     ssl_enabled
     or starrocks_config.get_bool("use_cn")
     or starrocks_config.get_bool("use_be")
-) and (STARROCKS_CHART_VERSION != "1.11.5"):
+) and (STARROCKS_CHART_VERSION != "1.11.6"):
     msg = (
-        f"_FE_CONFIG_BASE was sourced from chart 1.11.5; review defaults for"
+        f"_FE_CONFIG_BASE was sourced from chart 1.11.6; review defaults for"
         f" {STARROCKS_CHART_VERSION} before deploying with SSL or CN enabled"
     )
     raise ValueError(msg)


### PR DESCRIPTION
## Summary
- `STARROCKS_CHART_VERSION` was bumped to `1.11.6` by Renovate in #4997, but the `_FE_CONFIG_BASE` version trip-wire in `starrocks/__main__.py` still pinned `1.11.5`, so CI failed with `ValueError: _FE_CONFIG_BASE was sourced from chart 1.11.5; review defaults for 1.11.6 before deploying with SSL or CN enabled` on any deploy with SSL/CN/BE enabled.
- Reviewed the upstream `starrocks-kubernetes-operator` chart's `values.yaml` diff between `v1.11.5` and `v1.11.6`: the only change is an unrelated `externalTrafficPolicy` service field. The `fe.conf` defaults baked into `_FE_CONFIG_BASE` are unchanged.
- Bumped the guard's pinned version to `1.11.6` now that the review is complete.

## Test plan
- [x] `uv run pre-commit run --files src/ol_infrastructure/applications/starrocks/__main__.py` passes (ruff, mypy)
- [ ] CI green on `ol-application-starrocks-lakehouse` stacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)