### PR TITLE
chore(rootly): add Vault transit recipient to SOPS secrets file

### DIFF
--- a/src/bridge/secrets/rootly/account.yaml
+++ b/src/bridge/secrets/rootly/account.yaml
@@ -11,11 +11,17 @@ alert_source_secrets:
   grafana: ENC[AES256_GCM,data:mwNF8x7wJ+YKzg1sVi/DlsD9ld3WEbw4JKEOt94DRyzQGyV+G4wlInB+1sc7x7kCBzP7IoRusVX6jRXv+WGRyqHi,iv:ra/eZUL2Ay4WfZSbKZnjMUMx8wRYIzJG7HYJX6K2Bng=,tag:wWlWfqTOam+jwVrtSnEDpQ==,type:str]
   pingdom: ENC[AES256_GCM,data:9mQ38E0q3Z+DnCK3BZ9B5CzoGKt1dZEFjeLiHshTwIYQciZqltc+b9dJABj+vRufQ52A5wtDc1JuAC9eQF76GaKc,iv:hlxlyrKnp5Qnsqsj2EixKi9/noPNpv672MuF5HRV+Qg=,tag:TqoGmxG0DdWs8cni0ADDSw==,type:str]
 sops:
+  hc_vault:
+  - created_at: "2026-07-16T19:45:37Z"
+    enc: vault:v1:W7UOs2YQfu7iBQBc5JNO1mDkI2O1YYmcFLNWIJJbhBwyQLF26LDb/45T05jaOfe62A+tKRifIvh0EF1N
+    engine_path: infrastructure
+    key_name: sops
+    vault_address: https://vault-production.odl.mit.edu
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
     aws_profile: ""
-    created_at: "2026-07-06T15:33:51Z"
-    enc: AQICAHjksIVfl1VtAHpBda/1YYjj6tSeS2o4TXgvEEyBIXLjjwH18gdMk35eSOh9uc/itLK4AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMlLkWKw16teN8xwDfAgEQgDtmbVLvtFV1h3ZEJGeKOtq4SC7LuNxJy1R8PipEW3yvCVzVcCvGJ05vnXBb/5DZJxEKzxkRv5vRiPJUjw==
+    created_at: "2026-07-16T19:45:37Z"
+    enc: AQICAHjksIVfl1VtAHpBda/1YYjj6tSeS2o4TXgvEEyBIXLjjwFs4uFkJimgKNmC8j9y/QxPAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMLFwovOMzhFG6YSKfAgEQgDsBs7+oNCoU4tGl+fvMQIvZ442X965TAU8rnZ0rGOsafICyy9chddVWIeTOkuy5lr9txIFVpBEXbqEJZg==
   lastmodified: "2026-07-06T18:09:37Z"
   mac: ENC[AES256_GCM,data:Nr0pIiW2MD/+E+zkJjuA+fWXwd5/4aRlrY2UumAd2TemGjxc6LWKK235qbOS05wqFQRWW1GfxI5uYJ6xI16QZ3Z2km4nZFzhy7Y65Q1GyAKywR5HNT/mscQmFqEOEdwAkmzS3QefPDFufidThQT9qsg3hedi6/JUapC+9vei6lU=,iv:jRN/5O/xMQwPP4/U4t9e7ytI4PON9CZqSP8km8N6ZVA=,tag:Ou6dfT6/3vX0ERJNRfgKlw==,type:str]
   unencrypted_suffix: _unencrypted


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up from https://github.com/mitodl/ol-infrastructure/pull/5020

### Description (What does it do?)
`src/bridge/secrets/rootly/account.yaml` was KMS-only. Ran `sops updatekeys` to add the production Vault transit key as a second recipient, matching the pattern used by other bridge secrets files. The file's name doesn't match any of the `ci`/`qa`/`production` path regexes in `.sops.yaml`, so it falls through to the catch-all `creation_rule` (KMS + `vault-production` transit) — no changes to `.sops.yaml` were needed.

Only the `sops:` metadata block changed; no secret values were touched.

### How can this be tested?
```
sops -d src/bridge/secrets/rootly/account.yaml
```
decrypts successfully both before and after this change (verified locally with both KMS and Vault transit recipients). `pre-commit` (yamlfmt, yamllint, detect-secrets) passes on the changed file.

### Additional Context
N/A