### PR TITLE
chore(rootly): remove deprecated ScheduleRotationUser resources

### DIFF
--- a/src/ol_infrastructure/saas/rootly/KNOWN_ISSUES.md
+++ b/src/ol_infrastructure/saas/rootly/KNOWN_ISSUES.md
@@ -10,7 +10,7 @@ Last verified preview state for this branch:
 ```text
 PULUMI_TERRAFORM_VERSION=1.5.0 pulumi preview --diff
 Resources:
-    149 unchanged
+    145 unchanged
 ```
 
 ## Upstream bug and required workaround (now fixed in CI and locally)
@@ -96,7 +96,8 @@ Imported categories include:
 - Severities, roles, environments, incident causes, incident types, and incident role
 - Platform Engineering team
 - Rootly services, excluding the empty-state `christest` service
-- On-call schedule, schedule rotation, rotation users, escalation policies, and escalation levels
+- On-call schedule, schedule rotation, and rotation members (via `schedule_rotation_members`),
+  escalation policies, and escalation levels
 - Dashboards and dashboard panels
 - Incident permission sets and resource-scoped incident permissions
 - Alert sources and alert routes, excluding the empty-state Chris Test route
@@ -170,6 +171,27 @@ under `alert_source_secrets` and passed with `Output.secret(...)`.
 
 The SOPS secret file is currently KMS-encrypted. Add Vault transit recipients with
 `sops updatekeys` when suitable Vault access is available.
+
+### Legacy `ScheduleRotationUser` resources removed
+
+The provider deprecates `rootly_schedule_rotation_user` in favor of the
+`schedule_rotation_members` attribute on `rootly_schedule_rotation` (removal
+planned for the next provider major version). The primary rotation's
+`ScheduleRotation` resource already declared `schedule_rotation_members` with
+the same 4 people/positions as 4 separately-managed `ScheduleRotationUser`
+resources — Rootly was carrying two parallel membership record sets for the
+same rotation (legacy `schedule_rotation_users`, created 2025-05-09, alongside
+newer `schedule_rotation_members`, created 2025-10-09).
+
+Verified via the live Shifts API (`GET /v1/schedules/{id}/shifts`) that actual
+on-call computation already used the `schedule_rotation_members` set (one
+person per week, no duplication), so the legacy records were inert. Removed
+the 4 `ScheduleRotationUser` resources from Pulumi state with
+`pulumi state delete --force` (state-only; no Rootly API calls, so the live
+schedule was unaffected) and deleted the corresponding code. The 4 legacy
+`schedule_rotation_users` API records themselves still exist in Rootly,
+unmanaged and orphaned — deleting them via the Rootly UI/API is optional
+future cleanup, not urgent since they're inert.
 
 ## Validation commands
 

--- a/src/ol_infrastructure/saas/rootly/__main__.py
+++ b/src/ol_infrastructure/saas/rootly/__main__.py
@@ -422,46 +422,6 @@ schedule_rotation_primary_rotation = rootly.ScheduleRotation(
     opts=rootly_opts,
 )
 
-schedule_rotation_user_c582bafc_4fa2_4a79_9cdc_41c7bb256b88 = (
-    rootly.ScheduleRotationUser(
-        "c582bafc-4fa2-4a79-9cdc-41c7bb256b88",
-        position=1,
-        schedule_rotation_id="6744d26c-c81d-43c9-96b0-c6d30f4670a7",
-        user_id=99415,
-        opts=rootly_opts,
-    )
-)
-
-schedule_rotation_user_r_4b415521_c830_491e_b818_2d1081f06a26 = (
-    rootly.ScheduleRotationUser(
-        "r-4b415521-c830-491e-b818-2d1081f06a26",
-        position=3,
-        schedule_rotation_id="6744d26c-c81d-43c9-96b0-c6d30f4670a7",
-        user_id=100683,
-        opts=rootly_opts,
-    )
-)
-
-schedule_rotation_user_r_7ebd67c4_f881_4495_baa5_52714520a1a3 = (
-    rootly.ScheduleRotationUser(
-        "r-7ebd67c4-f881-4495-baa5-52714520a1a3",
-        position=2,
-        schedule_rotation_id="6744d26c-c81d-43c9-96b0-c6d30f4670a7",
-        user_id=103372,
-        opts=rootly_opts,
-    )
-)
-
-schedule_rotation_user_r_945d320a_641b_4957_9eaa_245894905e7b = (
-    rootly.ScheduleRotationUser(
-        "r-945d320a-641b-4957-9eaa-245894905e7b",
-        position=4,
-        schedule_rotation_id="6744d26c-c81d-43c9-96b0-c6d30f4670a7",
-        user_id=103392,
-        opts=rootly_opts,
-    )
-)
-
 escalation_policy_default_escalation_policy = rootly.EscalationPolicy(
     "default-escalation-policy",
     business_hours={


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up from https://github.com/mitodl/ol-infrastructure/pull/5020

### Description (What does it do?)
The Rootly provider deprecates `rootly_schedule_rotation_user`:

> Please use the `schedule_rotation_members` attribute within the `rootly_schedule_rotation` resource instead. This resource will be removed in the next major version.

The primary on-call rotation's `ScheduleRotation` resource in this stack already declared `schedule_rotation_members` inline with 4 people/positions — but the stack *also* separately managed 4 `ScheduleRotationUser` resources for the same rotation, pointing at the same 4 users/positions. Investigating via Rootly's API showed these are genuinely two parallel record sets server-side, not the same underlying objects:

- Legacy `schedule_rotation_users` (created 2025-05-09) — what Pulumi was managing as `ScheduleRotationUser`
- Newer `schedule_rotation_members` (created 2025-10-09) — already declared on `ScheduleRotation`

I confirmed via the live Shifts API (`GET /v1/schedules/{id}/shifts`) that the actual computed on-call rotation is correct today — one person per week, no duplication — meaning Rootly's scheduling engine already uses the `schedule_rotation_members` set, and the legacy records are inert leftovers.

This PR:
- Removes the 4 `ScheduleRotationUser` resources from Pulumi state via `pulumi state delete --force` (state-only operation — does **not** call Rootly's API, so the live on-call schedule was unaffected by this step)
- Deletes the corresponding ~35 lines of now-redundant code from `__main__.py`
- Updates `KNOWN_ISSUES.md` with the investigation findings

The 4 legacy `schedule_rotation_users` API records still exist in Rootly, orphaned and unmanaged. Deleting them via the Rootly UI/API is optional future cleanup (they're inert, not urgent).

### How can this be tested?
```
PULUMI_TERRAFORM_VERSION=1.5.0 pulumi preview --diff
Resources:
    145 unchanged
```
Zero drift (149 → 145, exactly the 4 removed resources, no other changes). `ruff`, `mypy`, and `pre-commit` all pass on the changed files.

### Additional Context
The Pulumi state deletion has already been applied to the production stack (state-only, no infrastructure impact) so that this PR's `__main__.py` change matches the deployed reality. This should be safe to merge whenever convenient.