### PR TITLE
Harden meilisearch StatefulSet against EBS multi-attach reschedule loop

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/meilisearch.py
+++ b/src/ol_infrastructure/applications/edxapp/meilisearch.py
@@ -87,20 +87,16 @@ def create_meilisearch_resources(
         # EBS volume. Every time its node is rotated the volume must fully detach
         # from the old node before it can attach to the new one, producing a
         # multi-minute window with zero ready endpoints (AWS "Multi-Attach error"
-        # / FailedAttachVolume). The only durable fix is to make the pod's node
-        # stop rotating so often, so we harden against both drivers of churn:
-        #   1. karpenter.sh/do-not-disrupt blocks Karpenter's *voluntary*
-        #      disruption (consolidation, drift, emptiness) — the default
-        #      NodePool consolidates aggressively (consolidateAfter: 10m), which
-        #      would otherwise drain this pod's node repeatedly.
-        #   2. Pinning to on-demand capacity removes *spot-interruption*
-        #      evictions, the other involuntary churn source.
+        # / FailedAttachVolume). The durable fix is to keep the pod's node from
+        # rotating so often: karpenter.sh/do-not-disrupt blocks Karpenter's
+        # *voluntary* disruption (consolidation, drift, emptiness) — the default
+        # NodePool consolidates aggressively (consolidateAfter: 10m), which would
+        # otherwise drain this pod's node repeatedly. Involuntary disruption
+        # (spot interruption, node failure) is not covered here; pin to
+        # on-demand capacity via a nodeSelector if that becomes the dominant
+        # churn source in a given environment.
         "podAnnotations": {
             "karpenter.sh/do-not-disrupt": "true",
-        },
-        "nodeSelector": {
-            "karpenter.sh/capacity-type": meilisearch_config.get("node_capacity_type")
-            or "on-demand",
         },
         "persistence": {
             "enabled": True,

--- a/src/ol_infrastructure/applications/edxapp/meilisearch.py
+++ b/src/ol_infrastructure/applications/edxapp/meilisearch.py
@@ -83,6 +83,25 @@ def create_meilisearch_resources(
             "MEILI_ENV": "production",
             "MEILI_MASTER_KEY": secrets["meilisearch_master_key"],
         },
+        # Meilisearch is a single-replica StatefulSet backed by a ReadWriteOnce
+        # EBS volume. Every time its node is rotated the volume must fully detach
+        # from the old node before it can attach to the new one, producing a
+        # multi-minute window with zero ready endpoints (AWS "Multi-Attach error"
+        # / FailedAttachVolume). The only durable fix is to make the pod's node
+        # stop rotating so often, so we harden against both drivers of churn:
+        #   1. karpenter.sh/do-not-disrupt blocks Karpenter's *voluntary*
+        #      disruption (consolidation, drift, emptiness) — the default
+        #      NodePool consolidates aggressively (consolidateAfter: 10m), which
+        #      would otherwise drain this pod's node repeatedly.
+        #   2. Pinning to on-demand capacity removes *spot-interruption*
+        #      evictions, the other involuntary churn source.
+        "podAnnotations": {
+            "karpenter.sh/do-not-disrupt": "true",
+        },
+        "nodeSelector": {
+            "karpenter.sh/capacity-type": meilisearch_config.get("node_capacity_type")
+            or "on-demand",
+        },
         "persistence": {
             "enabled": True,
             "size": meilisearch_config.get("pv_size") or "10Gi",


### PR DESCRIPTION
## What & Why

`meilisearch.courses.learn.mit.edu` returns ~**660 "no valid upstream node" 503s/day** to studio users. Live `kubectl` (applications-production-readonly, namespace `mitxonline-openedx`) confirmed this is **not** a stale Pulumi route: the single-replica `meilisearch-0` pod is repeatedly rescheduled to a new node and then hits

```
FailedAttachVolume: Multi-Attach error for volume "pvc-16a8211a-..." — Volume is already exclusively attached to one node
```

for ~2–3 minutes while its ReadWriteOnce gp3 EBS volume detaches from the prior node. The meilisearch Service has **zero ready endpoints** for that whole window, which is what surfaces as the 503s.

The detach gap is inherent to RWO EBS, so this PR reduces **how often the pod's node rotates**. The default Karpenter NodePool runs `consolidationPolicy: WhenEmptyOrUnderutilized` with `consolidateAfter: 10m`, so it drains this pod's node whenever the node looks underutilized — the dominant, cost-free churn driver.

## Change

In `src/ol_infrastructure/applications/edxapp/meilisearch.py`, added one Helm value (supported by meilisearch-kubernetes chart 0.33.0 and wired into the StatefulSet pod template):

- **`podAnnotations: karpenter.sh/do-not-disrupt: "true"`** — blocks Karpenter from voluntarily draining/consolidating the node hosting meilisearch.

Spot-interruption / node-failure evictions are *involuntary* and not covered by this annotation. On-demand capacity pinning would remove those too, but `meilisearch:deploy=true` is set on **all 12 edxapp stacks** (mitx, mitx-staging, xpro, mitxonline × CI/QA/Prod), so defaulting a nodeSelector to on-demand would raise cost across 8 non-prod deployments for little benefit. It's documented in the code comment as a per-environment opt-in instead. (Earlier revisions of this PR added an on-demand nodeSelector + a `meilisearch:node_capacity_type` config key; both were dropped after review — see thread replies.)

## Scope / blast radius

Applies to the meilisearch StatefulSet in **every** stack with `meilisearch:deploy=true` (all 12 edxapp stacks). The `do-not-disrupt` annotation is capacity-neutral (no cost change) — on next `pulumi up` each pod gains the annotation in place and Karpenter stops voluntarily draining its node. No route/cert/PVC changes, no capacity-type change.

## Follow-ups (not in this PR)

- Confirm whether the recent `memory_limit` bump to 4Gi (`60971855a`) has eliminated OOM-driven evictions.
- If spot interruptions turn out to be a material churn source in a specific env, pin that stack's meilisearch to on-demand.
- Decide whether typesense (already deployed, `course_search_enabled=true`) is meant to fully replace meilisearch — decommissioning would remove this class of issue entirely.

Refs mitodl/hq#12179

🤖 Generated with [Claude Code](https://claude.com/claude-code)