### PR TITLE
fix(rootly): suppress paging for QA/CI CloudWatch alarms

### DIFF
--- a/src/ol_infrastructure/saas/rootly/__main__.py
+++ b/src/ol_infrastructure/saas/rootly/__main__.py
@@ -33,6 +33,32 @@ rootly_pingdom_alert_source_opts = ResourceOptions(
     ignore_changes=["secret", "resolutionRuleAttributes"],
 )
 
+# CloudWatch alarms for QA/CI resources (e.g. "mitlearn-redis-qa-003") route
+# through the same shared warning/critical SNS topics as production (see
+# src/ol_infrastructure/lib/aws/monitoring_helper.py) and would otherwise page
+# on-call just like a production incident. Interim mitigation until the
+# underlying CloudWatch alarms stop sending actions for non-prod resources
+# (see src/ol_infrastructure/components/aws/cache.py): demote urgency to
+# Medium -- the same tier already used as the base urgency for the
+# "Grafana Prometheus - QA" alert source -- for any alarm whose name contains
+# a "-qa-" or "-ci-" environment segment.
+CLOUDWATCH_NON_PROD_URGENCY_RULES = [
+    {
+        "alertUrgencyId": "fce5c971-6660-4ad9-90eb-e75122055f50",
+        "jsonPath": "$.Message.AlarmName",
+        "kind": "payload",
+        "operator": "contains",
+        "value": "-qa-",
+    },
+    {
+        "alertUrgencyId": "fce5c971-6660-4ad9-90eb-e75122055f50",
+        "jsonPath": "$.Message.AlarmName",
+        "kind": "payload",
+        "operator": "contains",
+        "value": "-ci-",
+    },
+]
+
 # Foundation resources imported from the existing Rootly account.
 role_admin = rootly.Role(
     "admin",
@@ -2702,6 +2728,7 @@ alerts_source_cloudwatch_critical = rootly.AlertsSource(
         {"alertFieldId": "4a3add3c-5611-4dd9-ba65-4fb60b7f4fc6"},
         {"alertFieldId": "45a09cf3-b0f2-43cf-b596-34aaab9279dc"},
     ],
+    alert_source_urgency_rules_attributes=CLOUDWATCH_NON_PROD_URGENCY_RULES,
     alert_urgency_id="5d357977-9dbe-42ad-b647-5a442cab3d96",
     deduplication_key_kind="payload",
     name="Cloudwatch - Critical",
@@ -2720,6 +2747,7 @@ alerts_source_cloudwatch_warning = rootly.AlertsSource(
         {"alertFieldId": "4a3add3c-5611-4dd9-ba65-4fb60b7f4fc6"},
         {"alertFieldId": "45a09cf3-b0f2-43cf-b596-34aaab9279dc"},
     ],
+    alert_source_urgency_rules_attributes=CLOUDWATCH_NON_PROD_URGENCY_RULES,
     alert_urgency_id="5d357977-9dbe-42ad-b647-5a442cab3d96",
     deduplication_key_kind="payload",
     name="Cloudwatch - Warning",


### PR DESCRIPTION
### What are the relevant tickets?
N/A — triggered by an actual page for a QA CloudWatch alarm (https://rootly.com/account/alerts/1eTwIY)

### Description (What does it do?)
On-call was just paged by `simple-elasticache-mitlearn-redis-qa-003-EngineCPUUtilization` — a CloudWatch alarm on a **QA** ElastiCache Redis cluster. Root cause: CloudWatch alarms across every environment (CI/QA/Production) route through the same two shared SNS topics (`OpsGenie_Warning_Notifications` / `OpsGenie_Critical_Notifications`, see `get_monitoring_sns_arn` in `src/ol_infrastructure/lib/aws/monitoring_helper.py`), which feed the same `cloudwatch-warning`/`cloudwatch-critical` Rootly alert sources with no environment distinction at all.

This PR adds `alert_source_urgency_rules_attributes` to both CloudWatch alert sources: any alarm whose `AlarmName` contains a `-qa-` or `-ci-` environment segment is demoted from the default **High** urgency to **Medium** — the same tier already used as the base urgency for the existing `Grafana Prometheus - QA` alert source, so this follows an established team convention rather than introducing a new one.

The `jsonPath` (`$.Message.AlarmName`) targets Rootly's own normalized `alert.data` representation of the incoming SNS webhook, not the raw wire payload — confirmed by cross-referencing the existing Sentry alert source's urgency rule (`$.data.action`) against the nested structure its `templateBody` fields already reference (`alert.data.data.action`), and by checking that the SNS topic subscriptions don't enable raw message delivery (so `Message` really does arrive as the alarm's JSON body, which Rootly parses server-side for its `cloud_watch` source type).

### How can this be tested?
```
pulumi preview --diff
Resources:
    ~ 3 to update
    142 unchanged
```
Diff is exactly the 2 new urgency rules on each of the 2 CloudWatch alert sources (plus the unrelated pending provider-bridge-version update from #5020). `ruff`, `mypy`, and `pre-commit` all pass.

### Additional Context
This is an **interim mitigation** at the Rootly routing layer, matching the existing per-alert-source-urgency-rule pattern already used for Pingdom/Sentry/Grafana Prometheus. The systemic fix — making the underlying CloudWatch alarms themselves not fire actions for QA/CI resources — is in a companion PR against the shared `OLAmazonCache` Pulumi component: (to be linked once opened).

One caveat worth flagging for reviewers: whether "Medium" urgency actually avoids paging depends on each on-call engineer's personal Rootly notification preferences (push/SMS/call per urgency tier), which aren't managed by this IaC. This matches the same assumption already baked into the existing `Grafana Prometheus - QA" alert source, so it's a pre-existing team convention, not a new unknown introduced here.