### PR TITLE
Resize MIT Learn production Redis to r7g.4xlarge

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
@@ -115,7 +115,7 @@ config:
     UWSGI_WORKERS: 3
     YOUTUBE_CONFIG_URL: "https://raw.githubusercontent.com/mitodl/open-video-data/main/youtube/channels.yaml"
   mitlearn:zendesk_help_url: "mitlearn.zendesk.com"
-  redis:instance_type: "cache.r7g.2xlarge"
+  redis:instance_type: "cache.r7g.4xlarge"
   redis:password:
     secure: v1:xdJFi6D7NpeVwYrg:C0GQl3mctDO1+ehHcFAPdeJDuhk9PbuNdNGtghRNMlzP6GC/GCOyGS1V0ViUXwiO7JhAFD6zrstWmhg0X/yHQLnK8KA=
   vault:address: https://vault-production.odl.mit.edu


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Upsizes the MIT Learn production ElastiCache/Valkey node type from `cache.r7g.2xlarge` to `cache.r7g.4xlarge` as additional headroom after recurring Redis-related production alerts.

This changes `redis:instance_type` in `src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml`.

Capacity impact per Redis node:
- `cache.r7g.2xlarge`: 8 vCPU, ~52.82 GiB memory
- `cache.r7g.4xlarge`: 16 vCPU, ~105.81 GiB memory
- Delta: +8 vCPU and ~52.99 GiB memory per node

MIT Learn production has 3 Redis nodes, so cluster-wide provisioned capacity increases by approximately +24 vCPU and +158.97 GiB memory.

### How can this be tested?
Validation run:

```bash
uv run pre-commit run --files src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
MIT_LEARN_DOCKER_TAG=0.74.3 pulumi preview --stack Production --non-interactive
```

The Pulumi preview includes the expected ElastiCache replication group update:

```text
~ aws:elasticache/replicationGroup:ReplicationGroup mitlearn-redis-production-valkey-elasticache-cluster update [diff: ~nodeType]
~ nodeType: "cache.r7g.2xlarge" => "cache.r7g.4xlarge"
```

Note: the preview also showed unrelated Fastly service drift (`fastly-mit_learn-production`) already present outside this Redis node-type change.

### Additional Context
Current production Redis CloudWatch alarms were checked after preparing this change and were all `OK` at that time. The currently running MIT Learn production Kubernetes deployments use `mit-learn-app:0.74.3`, so use `MIT_LEARN_DOCKER_TAG=0.74.3` when applying this Pulumi update to avoid rolling application workloads back.

