### PR TITLE
preserve publish_posthog_api_host var

### DIFF
--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -581,7 +581,7 @@ secret_names, secret_resources = create_ocw_studio_k8s_secrets(
 
 # Merge stack-level config vars into the app env vars
 app_env_vars.update(**ocw_studio_config.get_object("vars") or {})
-app_env_vars["POSTHOG_API_HOST"] = app_env_vars.pop(
+app_env_vars["POSTHOG_API_HOST"] = app_env_vars.get(
     "PUBLISH_POSTHOG_API_HOST",
     ocw_studio_config.get("posthog_api_host") or "https://app.posthog.com",
 )


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12194

### Description (What does it do?)
Currently, the PUBLISH_POSTHOG_API_HOST var is removed from the application variables and its value is copied to the POSTHOG_API_HOST variable. We wish to preserve both of them as that's what the application expects.

Looking at git history, this appears to be a regression caused by the heroku -> k8s migration


### How can this be tested?
- Once the change is in QA, verify that the pod environment contains both PUBLISH_POSTHOG_API_HOST and POSTHOG_API_HOST


