### PR TITLE
fix(edxapp): add meilisearch to CORS whitelist, drop stale verawood override

### DIFF
--- a/src/bridge/settings/openedx/version_matrix.py
+++ b/src/bridge/settings/openedx/version_matrix.py
@@ -301,8 +301,6 @@ ReleaseMap: dict[
                 application="edx-platform",
                 application_type="IDA",
                 release="verawood",
-                branch_override="mitx/verawood",
-                origin_override="https://github.com/mitodl/edx-platform",
             ),
             OpenEdxApplicationVersion(
                 application="edxapp_theme",
@@ -379,9 +377,6 @@ ReleaseMap: dict[
                 application="edx-platform",
                 application_type="IDA",
                 release="verawood",
-                branch_override="mitx/verawood",
-                origin_override="https://github.com/mitodl/edx-platform",
-                runtime_version_override="3.12",
             ),
             OpenEdxApplicationVersion(
                 application="edxapp_theme",

--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -237,6 +237,14 @@ def _build_interpolated_config_dict(
         },
     }
 
+    # Meilisearch is only enabled on the CMS side, but CORS_ORIGIN_WHITELIST is
+    # shared across the CMS and LMS in this single interpolated config.
+    meilisearch_config = Config("meilisearch")
+    if meilisearch_config.get_bool("enabled"):
+        config["CORS_ORIGIN_WHITELIST"].append(
+            f"https://{meilisearch_config.require('domain')}"
+        )
+
     # Ref: https://docs.openedx.org/en/latest/site_ops/how-tos/use_typesense_search_backend.html
     typesense_config = Config("typesense")
     if typesense_config.get_bool("enabled"):


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Two unrelated small fixes bundled together:

1. **Meilisearch CORS fix**: `CORS_ORIGIN_WHITELIST` only exists on the interpolated config dict built in `_build_interpolated_config_dict` (rendered as `60-interpolated-config.yaml`), not on `general_config_dict` (`50-general-config.yaml`). The previous implementation appended the Meilisearch public URL to `general_config_dict["CORS_ORIGIN_WHITELIST"]`, a key that dict never defines, so this would raise a `KeyError` at synth time whenever Meilisearch was enabled. The check now runs inside `_build_interpolated_config_dict`, mutating the correct dict before it's rendered. `CORS_ORIGIN_WHITELIST` is shared across CMS and LMS in this single interpolated config, so it's fine that `MEILISEARCH_ENABLED` itself stays CMS-only.

2. **Version matrix cleanup**: Removes the `branch_override`/`origin_override` (and one stray `runtime_version_override`) pointing `edx-platform` at `mitx/verawood` for the `mitx` and `mitx-staging` deployments, since `verawood` now tracks the upstream `edx-platform` release directly and no longer needs the fork override.

### Screenshots (if appropriate):
N/A - no UI changes

### How can this be tested?
- `uv run pre-commit run --files src/bridge/settings/openedx/version_matrix.py src/ol_infrastructure/applications/edxapp/k8s_configmaps.py` (ruff, mypy, etc.) passes.
- Run `pulumi preview` against a stack with `meilisearch:enabled=true` set (e.g. mitxonline or mitx CMS) and confirm the `60-interpolated-config.yaml` ConfigMap now includes the Meilisearch public URL in `CORS_ORIGIN_WHITELIST` without erroring, and that it previously would have thrown a `KeyError`.
- Run `pulumi preview` for `mitx`/`mitx-staging` and confirm `edx-platform` now resolves to the default `verawood` branch/origin instead of the `mitx/verawood` override.

### Additional Context
N/A