### PR TITLE
fix(concourse): register eks_clusters pipeline resources before validation

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/eks_clusters/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/eks_clusters/pipeline.py
@@ -37,7 +37,6 @@ for cluster in ["data", "operations", "applications", "residential"]:
         project_source_path=PULUMI_CODE_PATH.joinpath("infrastructure/aws/eks"),
         stack_names=[f"{cluster}.{stage}" for stage in stages],
     )
-    infra_chain.resources.append(eks_infrastructure_code)
     pipeline_fragments.append(infra_chain)
 
     substructure_chain = pulumi_jobs_chain(
@@ -47,8 +46,11 @@ for cluster in ["data", "operations", "applications", "residential"]:
         project_source_path=PULUMI_CODE_PATH.joinpath("substructure/aws/eks"),
         stack_names=[f"{cluster}.{stage}" for stage in stages],
     )
-    substructure_chain.resources.append(eks_substructure_code)
     pipeline_fragments.append(substructure_chain)
+
+pipeline_fragments.append(
+    PipelineFragment(resources=[eks_infrastructure_code, eks_substructure_code])
+)
 
 eks_cluster_update_pipeline = PipelineFragment.combine_fragments(
     *pipeline_fragments

--- a/src/ol_concourse/pipelines/infrastructure/eks_clusters/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/eks_clusters/pipeline.py
@@ -37,6 +37,7 @@ for cluster in ["data", "operations", "applications", "residential"]:
         project_source_path=PULUMI_CODE_PATH.joinpath("infrastructure/aws/eks"),
         stack_names=[f"{cluster}.{stage}" for stage in stages],
     )
+    infra_chain.resources.append(eks_infrastructure_code)
     pipeline_fragments.append(infra_chain)
 
     substructure_chain = pulumi_jobs_chain(
@@ -46,14 +47,12 @@ for cluster in ["data", "operations", "applications", "residential"]:
         project_source_path=PULUMI_CODE_PATH.joinpath("substructure/aws/eks"),
         stack_names=[f"{cluster}.{stage}" for stage in stages],
     )
+    substructure_chain.resources.append(eks_substructure_code)
     pipeline_fragments.append(substructure_chain)
 
 eks_cluster_update_pipeline = PipelineFragment.combine_fragments(
     *pipeline_fragments
 ).to_pipeline()
-
-eks_cluster_update_pipeline.resources.append(eks_infrastructure_code)
-eks_cluster_update_pipeline.resources.append(eks_substructure_code)
 
 if __name__ == "__main__":
     import sys


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
The `eks_clusters` Concourse pipeline definition (`src/ol_concourse/pipelines/infrastructure/eks_clusters/pipeline.py`) was failing to generate with:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for Pipeline
  Value error, unknown resource 'ol-infrastructure'
unknown resource 'ol-infrastructure-substructure' [type=value_error, ...]
```

`pulumi_jobs_chain()` builds job steps (get/put) that reference the `git_repo` resources (`ol-infrastructure`, `ol-infrastructure-substructure`) by name, but those resources were only appended to `eks_cluster_update_pipeline.resources` **after** `PipelineFragment.to_pipeline()` had already run, which performs pydantic validation that every referenced resource exists in the resources list at that point. That validation was failing because the resources hadn't been added yet.

Fix: append each `git_repo` resource to its own chain fragment (`infra_chain.resources` / `substructure_chain.resources`) before the fragments are combined and converted to a `Pipeline`, matching the existing pattern in `src/ol_concourse/pipelines/infrastructure/keycloak/pipeline.py`.

### Screenshots (if appropriate):
N/A

### How can this be tested?
```
uv run python src/ol_concourse/pipelines/infrastructure/eks_clusters/pipeline.py
```
Previously raised the `pydantic_core.ValidationError` above; now exits 0 and prints the rendered pipeline JSON.

### Additional Context
N/A