### PR TITLE
fix(concourse): scope simple_pulumi self-build to the app's subdirectory

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
@@ -232,7 +232,7 @@ def _ensure_ecr_repository_step(ecr_registry_image_resource: Any) -> TaskStep:
 
 def _build_docker_image_job(
     app_name: str,
-    pulumi_code: Any,
+    build_source: Any,
     docker_image_resource: Any,
     build_config: BuildConfig,
     pulumi_project_path: str,
@@ -242,28 +242,34 @@ def _build_docker_image_job(
     Runs ahead of the Pulumi deploy chain; the deploy chain's docker_image
     GetStep gates on this job via `passed` so it only redeploys images this
     pipeline itself built, not an arbitrary push to the same ECR repository.
+
+    ``build_source`` is a git resource scoped to just this app's own
+    subdirectory (and its secrets), separate from the broader ``pulumi_code``
+    resource the deploy chain watches -- so an unrelated shared-lib change
+    (or another app's secrets changing) doesn't trigger a redundant rebuild
+    and push of this app's image.
     """
     job_name = f"build-{app_name}-image"
     additional_build_params = {}
     if build_config.build_target:
         additional_build_params = {"TARGET": build_config.build_target}
 
-    # pulumi_code checks out the whole repo, so CONTEXT/DOCKERFILE must be
+    # build_source checks out the whole repo, so CONTEXT/DOCKERFILE must be
     # scoped to the app's own subdirectory -- otherwise oci-build-task
     # happily builds the unrelated Dockerfile at the repo root instead.
     app_source_dir = (
-        f"{pulumi_code.name}/{PULUMI_CODE_PATH.joinpath(pulumi_project_path)}"
+        f"{build_source.name}/{PULUMI_CODE_PATH.joinpath(pulumi_project_path)}"
     )
 
     plan = [
-        GetStep(get=pulumi_code.name, trigger=True),
+        GetStep(get=build_source.name, trigger=True),
         LoadVarStep(
             load_var="git_ref",
-            file=f"{pulumi_code.name}/.git/ref",
+            file=f"{build_source.name}/.git/ref",
             reveal=True,
         ),
         container_build_task(
-            inputs=[Input(name=pulumi_code.name)],
+            inputs=[Input(name=build_source.name)],
             build_parameters={
                 "CONTEXT": app_source_dir,
                 "DOCKERFILE": str(Path(app_source_dir) / build_config.dockerfile_path),
@@ -278,7 +284,7 @@ def _build_docker_image_job(
             put=docker_image_resource.name,
             params={
                 "image": "image/image.tar",
-                "additional_tags": f"./{pulumi_code.name}/.git/short_ref",
+                "additional_tags": f"./{build_source.name}/.git/short_ref",
             },
         ),
     ]
@@ -586,6 +592,7 @@ def build_simple_pulumi_pipeline(app_name: str) -> Pipeline:
     docker_dependencies = []
     docker_env_vars_from_files = {}
     build_job: Job | None = None
+    build_source = None
 
     if params.docker_image:
         docker_image_resource = registry_image(
@@ -603,9 +610,22 @@ def build_simple_pulumi_pipeline(app_name: str) -> Pipeline:
         # redeploy only fires off images this pipeline itself built.
         get_params: dict[str, Any] = {}
         if params.build:
+            # Dedicated resource scoped to just this app's own subdirectory (and
+            # secrets), separate from pulumi_code's broad PULUMI_WATCHED_PATHS --
+            # otherwise an unrelated shared-lib change or another app's secrets
+            # changing triggers a redundant rebuild+push of this app's image.
+            build_source = git_repo(
+                name=Identifier(f"{app_name}-docker-source"),
+                uri="https://github.com/mitodl/ol-infrastructure",
+                branch=params.branch,
+                paths=[
+                    str(PULUMI_CODE_PATH.joinpath(params.pulumi_project_path)),
+                    *params.additional_watched_paths,
+                ],
+            )
             build_job = _build_docker_image_job(
                 app_name=app_name,
-                pulumi_code=pulumi_code,
+                build_source=build_source,
                 docker_image_resource=docker_image_resource,
                 build_config=params.build,
                 pulumi_project_path=params.pulumi_project_path,
@@ -736,6 +756,8 @@ def build_simple_pulumi_pipeline(app_name: str) -> Pipeline:
             all_pipeline_resources = [pulumi_code, *cross_env_resources, *all_resources]
             if docker_image_resource:
                 all_pipeline_resources.append(docker_image_resource)
+            if build_source:
+                all_pipeline_resources.append(build_source)
 
             combined_fragment = PipelineFragment(
                 resource_types=all_resource_types,
@@ -764,6 +786,8 @@ def build_simple_pulumi_pipeline(app_name: str) -> Pipeline:
             ]
             if docker_image_resource:
                 all_pipeline_resources.append(docker_image_resource)
+            if build_source:
+                all_pipeline_resources.append(build_source)
 
             combined_fragment = PipelineFragment(
                 resource_types=pulumi_fragment.resource_types,
@@ -797,6 +821,8 @@ def build_simple_pulumi_pipeline(app_name: str) -> Pipeline:
         ]
         if docker_image_resource:
             all_pipeline_resources.append(docker_image_resource)
+        if build_source:
+            all_pipeline_resources.append(build_source)
 
         combined_fragment = PipelineFragment(
             resource_types=pulumi_fragment.resource_types,

--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
@@ -235,6 +235,7 @@ def _build_docker_image_job(
     pulumi_code: Any,
     docker_image_resource: Any,
     build_config: BuildConfig,
+    pulumi_project_path: str,
 ) -> Job:
     """Generate a job that builds this app's own image and pushes it to ECR.
 
@@ -247,6 +248,13 @@ def _build_docker_image_job(
     if build_config.build_target:
         additional_build_params = {"TARGET": build_config.build_target}
 
+    # pulumi_code checks out the whole repo, so CONTEXT/DOCKERFILE must be
+    # scoped to the app's own subdirectory -- otherwise oci-build-task
+    # happily builds the unrelated Dockerfile at the repo root instead.
+    app_source_dir = (
+        f"{pulumi_code.name}/{PULUMI_CODE_PATH.joinpath(pulumi_project_path)}"
+    )
+
     plan = [
         GetStep(get=pulumi_code.name, trigger=True),
         LoadVarStep(
@@ -257,8 +265,8 @@ def _build_docker_image_job(
         container_build_task(
             inputs=[Input(name=pulumi_code.name)],
             build_parameters={
-                "CONTEXT": pulumi_code.name,
-                "DOCKERFILE": f"{pulumi_code.name}/{build_config.dockerfile_path}",
+                "CONTEXT": app_source_dir,
+                "DOCKERFILE": str(Path(app_source_dir) / build_config.dockerfile_path),
                 "BUILD_ARG_GIT_REF": "((.:git_ref))",
                 "PROGRESS": "plain",
                 **additional_build_params,
@@ -600,6 +608,7 @@ def build_simple_pulumi_pipeline(app_name: str) -> Pipeline:
                 pulumi_code=pulumi_code,
                 docker_image_resource=docker_image_resource,
                 build_config=params.build,
+                pulumi_project_path=params.pulumi_project_path,
             )
             get_params["passed"] = [build_job.name]
 


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up to https://github.com/mitodl/ol-infrastructure/pull/5030, https://github.com/mitodl/ol-infrastructure/pull/5031, https://github.com/mitodl/ol-infrastructure/pull/5033

### Description (What does it do?)
After deploying `release_bot`, the Kubernetes Deployment came up `0/1`
ready with the pod cycling `Completed` (exit 0) every ~30s and **zero log
output**:

```
NAME                                      READY   STATUS      RESTARTS   AGE
release-bot-production-6489dbf49b-nrqdj   0/1     Completed   4          2m
```

Pulled the actual `release-bot-production:latest` image locally to
investigate:

```
$ docker run --rm --entrypoint sh <repo>:latest -c 'ls /app; pip show slack-bolt; python3 --version'
ls: cannot access '/app': No such file or directory
WARNING: Package(s) not found: slack-bolt
Python 3.14.6
```

No `/app`, no `slack-bolt`, and Python **3.14.6** — not the `3.13-slim`
pinned in
[`applications/release_bot/Dockerfile`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/applications/release_bot/Dockerfile).
The pushed image was actually built from the **repo root's own
`Dockerfile`** (the generic `ol-infrastructure` Python package image,
`FROM python:3.14-slim`), which has no `CMD` — so it falls back to the
base image's bare `python3`, which hits EOF on stdin in a pod and exits 0
immediately. Confirmed the `latest` tag's digest matches a build tagged
with an unrelated commit SHA (`#5025`, an ElastiCache alarm fix).

Root cause in
[`_build_docker_image_job()`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py):
it built `CONTEXT`/`DOCKERFILE` from `pulumi_code.name` alone — the git
resource's checkout root, i.e. the *whole repo* (`paths:` only gates what
triggers a new version, it doesn't scope the checkout) — and never joined
in `pulumi_project_path`. So `oci-build-task` silently found and built the
repo's own top-level `Dockerfile` instead of erroring. `release-bot` is
the only `pipeline_params` entry currently using the self-build
(`BuildConfig`) path, so this had never been exercised before.

Fix: scope `CONTEXT`/`DOCKERFILE` to
`PULUMI_CODE_PATH.joinpath(pulumi_project_path)`, the same join already
used for the Pulumi deploy job elsewhere in this file
(`project_source_path=PULUMI_CODE_PATH.joinpath(params.pulumi_project_path)`).

### How can this be tested?
Regenerated the release-bot pipeline definition locally and confirmed the
build task's params now point at the right subdirectory:

```
CONTEXT:    ol-infrastructure-pulumi-release-bot/src/ol_infrastructure/applications/release_bot
DOCKERFILE: ol-infrastructure-pulumi-release-bot/src/ol_infrastructure/applications/release_bot/Dockerfile
```

`pre-commit` (ruff format/check, mypy) passes.

### Additional Context
Once this merges, `build-release-bot-image` needs to be re-triggered in
Concourse to push a correctly-built image before the k8s Deployment will
come up healthy -- the currently-running pod will keep restarting on the
bad image until that happens.