### PR TITLE
fix(release-bot): pin slack-bolt to an actually-published version

### DIFF
--- a/src/ol_infrastructure/applications/release_bot/requirements.txt
+++ b/src/ol_infrastructure/applications/release_bot/requirements.txt
@@ -1,2 +1,2 @@
-slack-bolt[async]>=2.0,<3
+slack-bolt[async]>=1.18,<2
 aiohttp>=3.9,<4


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up to https://github.com/mitodl/ol-infrastructure/pull/5030, https://github.com/mitodl/ol-infrastructure/pull/5031, https://github.com/mitodl/ol-infrastructure/pull/5033, https://github.com/mitodl/ol-infrastructure/pull/5034

### Description (What does it do?)
With the build CONTEXT/DOCKERFILE fix from #5034 merged, the Concourse
image-build now actually builds `applications/release_bot/Dockerfile` --
which surfaced the next problem:

```
#8 1.163 ERROR: Could not find a version that satisfies the requirement slack-bolt<3,>=2.0 (from versions: ... 1.28.0, 1.29.0, 1.30.0)
#8 1.163 ERROR: No matching distribution found for slack-bolt<3,>=2.0
```

`requirements.txt` pinned `slack-bolt[async]>=2.0,<3`, but slack-bolt has
never published a 2.x release -- PyPI tops out at 1.30.0. Pinned to
`>=1.18,<2` instead (1.18+ is where the `AsyncApp`/`AsyncSocketModeHandler`
classes `bot.py` uses have been stable).

### How can this be tested?
Built and ran the image locally end-to-end:

```
$ docker build -t release-bot-local:test .
...
Successfully installed ... slack-bolt-1.30.0 ...

$ docker run --rm -e SLACK_BOT_TOKEN=xoxb-invalid-test-token -e SLACK_APP_TOKEN=xapp-invalid-test-token ... release-bot-local:test
ERROR:slack_bolt.AsyncApp:Failed to retrieve WSS URL: The request to the Slack API failed. (url: https://slack.com/api/apps.connections.open, status: 200)
The server responded with: {'ok': False, 'error': 'invalid_auth'}
ERROR:slack_bolt.AsyncApp:Failed to connect (...); Retrying...
```

That's the expected behavior for fake tokens -- `bot.py` is genuinely
running, attempting the Socket Mode connection, correctly detecting
`invalid_auth`, and retrying with backoff, instead of the previous
instant silent `exit(0)` (base-image `python3` REPL hitting EOF).

### Additional Context
Once merged, `build-release-bot-image` needs a re-trigger in Concourse to
push a corrected image; the real Slack tokens are already in
`src/bridge/secrets/release_bot/secrets.production.yaml`, so with a good
image the pod should come up and connect for real.