### PR TITLE
fix(release-bot): send Concourse's required fly OAuth client credentials

### DIFF
--- a/src/ol_infrastructure/applications/release_bot/concourse_client.py
+++ b/src/ol_infrastructure/applications/release_bot/concourse_client.py
@@ -11,6 +11,13 @@ CONCOURSE_TEAM = os.environ.get("CONCOURSE_TEAM", "main")
 CONCOURSE_USER = os.environ.get("CONCOURSE_USER", "")
 CONCOURSE_PASS = os.environ.get("CONCOURSE_PASSWORD", "")
 
+# Concourse's skymarshal hardcodes this public OAuth2 client for the fly-login
+# (resource-owner password credentials) grant -- not a secret, just how
+# Concourse identifies "fly" as the calling client. See flyClientID/
+# flyClientSecret in concourse/concourse's atc/atccmd/command.go.
+_FLY_CLIENT_ID = "fly"
+_FLY_CLIENT_SECRET = "Zmx5"  # pragma: allowlist secret  # noqa: S105
+
 _token: str | None = None
 _token_expiry: float = 0.0
 _token_lock = asyncio.Lock()
@@ -34,9 +41,10 @@ async def _get_token() -> str:
             "password": CONCOURSE_PASS,
             "scope": "openid profile email federated:id groups",
         }
+        auth = aiohttp.BasicAuth(_FLY_CLIENT_ID, _FLY_CLIENT_SECRET)
         async with (
             aiohttp.ClientSession() as session,
-            session.post(url, data=data) as resp,
+            session.post(url, data=data, auth=auth) as resp,
         ):
             resp.raise_for_status()
             body = await resp.json()


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up to https://github.com/mitodl/ol-infrastructure/pull/5030, https://github.com/mitodl/ol-infrastructure/pull/5031, https://github.com/mitodl/ol-infrastructure/pull/5033, https://github.com/mitodl/ol-infrastructure/pull/5034, https://github.com/mitodl/ol-infrastructure/pull/5035

### Description (What does it do?)
`/doof release <app>` failed with:

```
aiohttp.client_exceptions.ClientResponseError: 401, message='Unauthorized', url='https://cicd.odl.mit.edu/sky/issuer/token'
```

`aiohttp`'s `raise_for_status()` only surfaces the generic "Unauthorized"
reason phrase, not the actual JSON error body, so the real cause wasn't
visible in the pod logs. Reproduced directly (via `kubectl exec` into the
running pod, hitting the real endpoint with the real release-bot
credentials):

```
$ python3 -c '... POST /sky/issuer/token with grant_type=password, no client auth ...'
401 {"error":"invalid_client","error_description":"Invalid client credentials."}
```

Root cause, confirmed against
[concourse/concourse's `atc/atccmd/command.go`](https://github.com/concourse/concourse/blob/master/atc/atccmd/command.go):
Concourse's skymarshal hardcodes a **public** OAuth2 client for the
password-grant ("fly login") flow --
`flyClientID = "fly"`, `flyClientSecret = "Zmx5"` -- and requires it via
HTTP Basic Auth on *every* token request to `/sky/issuer/token`,
regardless of which local user is authenticating.
[`concourse_client.py`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/applications/release_bot/concourse_client.py)
never sent it, so every token request was rejected with `invalid_client`
before Concourse even got to checking the `release-bot` local user's
password. **This was never actually about the local-user provisioning
from the earlier ASG instance refresh** -- that part was already correct.

Fix: send `Authorization: Basic base64("fly:Zmx5")` (via
`aiohttp.BasicAuth`) on the token request, matching what Concourse's own
`fly` CLI does.

### How can this be tested?
Verified twice against the real production endpoint:

1. Via `kubectl exec` into the running `release-bot-production` pod:
   ```
   # without client creds:
   {"error":"invalid_client","error_description":"Invalid client credentials."}
   # with Authorization: Basic base64("fly:Zmx5"):
   {"access_token":"...","token_type":"bearer","expires_in":86399,...}
   ```
2. Built the image locally with the fix and called
   `concourse_client._get_token()` directly against the real endpoint
   with the real `release-bot` credentials (without calling
   `trigger_job`, to avoid kicking off an actual production build):
   ```
   TOKEN OK, len= 38
   ```

`pre-commit` (ruff format/check, mypy, detect-secrets) passes.

### Additional Context
Once merged and a new image is built/pushed, `/doof release <app>` should
get past the token-acquisition step. Haven't done a full end-to-end
`trigger_job` test since that would kick off a real Concourse build --
that's the next thing to try once this lands.