### PR TITLE
fix(release-bot): pin deployed image by digest, fix Concourse team

### DIFF
--- a/concourse/teams/ocw.yaml
+++ b/concourse/teams/ocw.yaml
@@ -21,4 +21,4 @@ roles:
 - name: pipeline-operator
   local:
     users:
-    - release-bot
+    - ocw

--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
@@ -547,6 +547,7 @@ pipeline_params: dict[str, SimplePulumiParams] = {
         docker_image=DockerImageConfig(
             image_repository="release-bot-production",
             ecr_region=ECR_REGION,
+            env_var_for_digest="RELEASE_BOT_DOCKER_SHA",
         ),
         build=BuildConfig(dockerfile_path="./Dockerfile"),
     ),

--- a/src/ol_infrastructure/applications/release_bot/__main__.py
+++ b/src/ol_infrastructure/applications/release_bot/__main__.py
@@ -22,7 +22,11 @@ from bridge.secrets.sops import read_yaml_secrets
 from ol_infrastructure.lib import pulumi_projects as projects
 from ol_infrastructure.lib.aws.eks_helper import setup_k8s_provider
 from ol_infrastructure.lib.ol_types import AWSBase, BusinessUnit, Environment
-from ol_infrastructure.lib.pulumi_helper import make_stack_reference, parse_stack
+from ol_infrastructure.lib.pulumi_helper import (
+    format_docker_image_ref,
+    make_stack_reference,
+    parse_stack,
+)
 
 stack_info = parse_stack()
 log.info(f"{stack_info=}")
@@ -103,12 +107,17 @@ resource_name = "release-bot-production"
 namespace = "operations"
 
 # The ECR repository itself is created (idempotently) by the Concourse
-# simple_pulumi image-build job on push, not managed here.
+# simple_pulumi image-build job on push, not managed here. The image is
+# pinned by digest (RELEASE_BOT_DOCKER_SHA, set by the build job) rather
+# than the mutable "latest" tag, so a new push actually changes this
+# Deployment's pod spec and triggers a rollout instead of silently leaving
+# the running pod on a stale image.
 aws_account = aws.get_caller_identity()
-bot_image_name = (
+image_repository = (
     f"{aws_account.account_id}.dkr.ecr.{aws_config.region}.amazonaws.com"
-    f"/{resource_name}:latest"
+    f"/{resource_name}"
 )
+bot_image_name = format_docker_image_ref(image_repository, "RELEASE_BOT")
 
 secret_resource_name = (
     "release-bot-secret-production"  # pragma: allowlist secret  # noqa: S105
@@ -188,7 +197,7 @@ bot_deployment = kubernetes.apps.v1.Deployment(
                             ),
                             kubernetes.core.v1.EnvVarArgs(
                                 name="CONCOURSE_TEAM",
-                                value="main",
+                                value="infrastructure",
                             ),
                             kubernetes.core.v1.EnvVarArgs(
                                 name="REPOS_CONFIG",


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up to https://github.com/mitodl/ol-infrastructure/pull/5030 through https://github.com/mitodl/ol-infrastructure/pull/5036

### Description (What does it do?)
Two separate issues found while chasing "release still erroring" after
the fly-client OAuth fix (#5036) merged and released.

**1. The pod never actually picked up the new image.** `release-bot`'s
Deployment references `release-bot-production:latest` — a mutable tag.
Pushing a new image to ECR doesn't change the Deployment's pod spec, so
Kubernetes never had a reason to recreate the pod. Confirmed via
`aws ecr describe-images` vs. `kubectl get pod ... imageID`: the running
pod's digest was 2 days stale relative to what `:latest` pointed to.
Worked around this time with `kubectl rollout restart`, but the real fix
is to stop depending on a mutable tag: wire `RELEASE_BOT_DOCKER_SHA`
through from the `simple_pulumi` build job's `registry_image` resource
(the same `env_var_for_digest` mechanism other apps already use via
`docker_image_config_kwargs`/`format_docker_image_ref` in
`pulumi_helper.py`), and pin `bot_image_name` to that digest. Now every
image push changes the Deployment spec and triggers a normal rollout.

Verified with `pulumi preview` using a real digest:
```
Outputs:
  ~ bot_image: ".../release-bot-production:latest" => ".../release-bot-production@sha256:8efe0003..."
Resources:
    ~ 1 to update
```

**2. Once the pod was running the fixed code, `/doof release` still
404'd**: `.../pipelines/ol-analytics-api-pipeline/jobs/build-ol-analytics-api-release-image/builds`.
Queried the real Concourse API directly with `release-bot`'s own token
(via `kubectl exec` into the pod):
- Team `main` has 47 pipelines — none of them app release pipelines.
- Team `infrastructure` (where the real release pipelines live) returned
  `200` with an **empty** pipeline list for `release-bot`'s token, even
  though the team itself exists — i.e. no membership/role granted there.

`__main__.py` hardcoded `CONCOURSE_TEAM=main`; fixed to `"infrastructure"`.

### How can this be tested?
- `pulumi preview` (shown above) confirms the digest-pin change produces
  exactly the expected `Deployment` diff.
- `pre-commit` (ruff, mypy) passes on both changed files.
- Regenerated the `release-bot` Concourse pipeline definition locally and
  confirmed the deploy job's `put` step now includes
  `"env_vars_from_files": {"RELEASE_BOT_DOCKER_SHA": "release-bot-docker-image/digest"}`.

### Additional Context
Still needed, **not a code fix** — tracked separately: `release-bot`'s
Concourse local user has no team-membership/role on `infrastructure`.
That's live Concourse RBAC state (`fly set-team` or the admin UI), not
managed anywhere in this repo's Pulumi/bilder code, and needs an admin
action against the running Concourse instance before `/doof release`
will actually succeed end-to-end.