### PR TITLE
fix(k8s): split HPA/VPA memory ownership across all OLApplicationK8s apps

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/k8s_resources.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_resources.py
@@ -738,6 +738,11 @@ def create_k8s_resources(  # noqa: C901
             resource_limits={
                 "memory": resources_dict["webapp"]["lms"]["memory_limit"],
             },
+            # Preserves the bounds of the hand-rolled lms-webapp-vpa this replaces.
+            # The floor is deliberately below resource_limits so the VPA can size
+            # these pods down as well as up.
+            webapp_vpa_min_allowed_memory="256Mi",
+            webapp_vpa_max_allowed_memory="4Gi",
             pod_security_context=pod_security_context,
             extra_volumes=lms_edxapp_volumes,
             extra_volume_mounts=common_extra_volume_mounts,
@@ -1035,6 +1040,10 @@ def create_k8s_resources(  # noqa: C901
             resource_limits={
                 "memory": resources_dict["webapp"]["cms"]["memory_limit"],
             },
+            # Preserves the bounds of the hand-rolled cms-webapp-vpa this replaces.
+            # See the LMS config above.
+            webapp_vpa_min_allowed_memory="256Mi",
+            webapp_vpa_max_allowed_memory="4Gi",
             pod_security_context=pod_security_context,
             extra_volumes=cms_edxapp_volumes,
             extra_volume_mounts=common_extra_volume_mounts,
@@ -1681,6 +1690,12 @@ def create_k8s_resources(  # noqa: C901
     )
 
     # VPA objects.
+    # The LMS and CMS webapp memory VPAs are created by OLApplicationK8s
+    # (manage_webapp_memory_vpa) rather than declared here. Declaring them here as
+    # well would put two VPAs on each webapp Deployment, which is unsupported and
+    # produces undefined resizing behaviour. Bounds are passed through
+    # webapp_vpa_min/max_allowed_memory on each OLApplicationK8sConfig above.
+    #
     # Webapp scaling is managed by a KEDA ScaledObject (Prometheus request-rate)
     # with a cpu trigger retained as a backstop (autoscaling_lms/cms_cpu_threshold)
     # -- that cpu trigger becomes a Resource-type HPA metric under the hood, so
@@ -1688,32 +1703,8 @@ def create_k8s_resources(  # noqa: C901
     # same signal. Memory has no competing scaler, so VPA controls it alone.
     # Celery workers are scaled purely on Redis queue depth (an external metric),
     # so VPA may control both cpu and memory there.
-    _webapp_vpa_bounds = {
-        "min_allowed": {"memory": "256Mi"},
-        "max_allowed": {"memory": "4Gi"},
-    }
     _worker_vpa_min_allowed = {"cpu": "25m", "memory": "128Mi"}
 
-    make_vpa(
-        name=f"{env_name}-edxapp-lms-webapp-vpa",
-        namespace=namespace,
-        target_kind="Deployment",
-        target_name=lms_app.webapp_deployment_name,
-        controlled_resources=["memory"],
-        container_name="lms-edxapp-app",
-        **_webapp_vpa_bounds,
-        opts=ResourceOptions(depends_on=[lms_app]),
-    )
-    make_vpa(
-        name=f"{env_name}-edxapp-cms-webapp-vpa",
-        namespace=namespace,
-        target_kind="Deployment",
-        target_name=cms_app.webapp_deployment_name,
-        controlled_resources=["memory"],
-        container_name="cms-edxapp-app",
-        **_webapp_vpa_bounds,
-        opts=ResourceOptions(depends_on=[cms_app]),
-    )
     make_vpa(
         name=f"{env_name}-edxapp-lms-celery-vpa",
         namespace=namespace,

--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -818,6 +818,11 @@ learn_ai_app_k8s = OLApplicationK8s(
             resource_requests={"cpu": "10m", "memory": "384Mi"},
             resource_limits={"memory": "384Mi"},
         ),
+        # Memory removed from the HPA: it duplicated the component default and is now
+        # handled vertically by the component's webapp memory VPA. An HPA memory
+        # metric is a fleet average and cannot prevent an individual pod from being
+        # OOMKilled. This block now matches the component default and could be dropped
+        # entirely; it is kept explicit because the CPU target is intentional.
         hpa_scaling_metrics=[
             kubernetes.autoscaling.v2.MetricSpecArgs(
                 type="Resource",
@@ -826,17 +831,6 @@ learn_ai_app_k8s = OLApplicationK8s(
                     target=kubernetes.autoscaling.v2.MetricTargetArgs(
                         type="Utilization",
                         average_utilization=60,  # Target CPU utilization (60%)
-                    ),
-                ),
-            ),
-            # Scale up when avg usage exceeds: 1800 * 0.8 = 1440 Mi
-            kubernetes.autoscaling.v2.MetricSpecArgs(
-                type="Resource",
-                resource=kubernetes.autoscaling.v2.ResourceMetricSourceArgs(
-                    name="memory",
-                    target=kubernetes.autoscaling.v2.MetricTargetArgs(
-                        type="Utilization",
-                        average_utilization=80,  # Target memory utilization (80%)
                     ),
                 ),
             ),

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1564,6 +1564,12 @@ mitlearn_k8s_app = OLApplicationK8s(
         ),
         resource_requests={"cpu": "500m", "memory": "3200Mi"},
         resource_limits={"memory": "3200Mi"},
+        # Preserves the bounds of the hand-rolled mitlearn-webapp-vpa this replaces.
+        # The floor is deliberately well below resource_limits (unlike the component
+        # default, which pins the floor at the limit) so the VPA can also size these
+        # pods back down rather than only up.
+        webapp_vpa_min_allowed_memory="256Mi",
+        webapp_vpa_max_allowed_memory="4Gi",
         webapp_keda_config=webapp_keda_config,
     ),
     opts=ResourceOptions(
@@ -1743,23 +1749,15 @@ learn_external_service_apisix_route = OLApisixRoute(
 
 
 # VPA objects for mit-learn workloads.
-# Webapp has a CPU-based HPA, so VPA must not control CPU (would distort HPA utilization signals).
+# The webapp's memory VPA is created by OLApplicationK8s (manage_webapp_memory_vpa)
+# rather than declared here, so every app gets the same split: the horizontal scaler
+# (a KEDA cpu trigger, in mit-learn's case) owns CPU and the VPA owns memory. Bounds
+# come from webapp_vpa_min/max_allowed_memory on the OLApplicationK8sConfig above.
 # Celery workers and beat are scaled via KEDA (Redis queue depth), so CPU+memory VPA is safe.
 _worker_vpa_bounds = {
     "min_allowed": {"cpu": "25m", "memory": "128Mi"},
     "max_allowed": {"cpu": "1000m", "memory": "3Gi"},
 }
-make_vpa(
-    name="mitlearn-webapp-vpa",
-    namespace=learn_namespace,
-    target_kind="Deployment",
-    target_name=mitlearn_k8s_app.webapp_deployment_name,
-    controlled_resources=["memory"],
-    container_name="mitlearn-app",
-    min_allowed={"memory": "256Mi"},
-    max_allowed={"memory": "4Gi"},
-    opts=ResourceOptions(depends_on=[mitlearn_k8s_app]),
-)
 for _celery_name in mitlearn_k8s_app.celery_deployment_names:
     make_vpa(
         name=f"{_celery_name}-vpa",

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -13,7 +13,6 @@ from pathlib import Path
 
 import pulumi
 import pulumi_fastly as fastly
-import pulumi_kubernetes as kubernetes
 import pulumi_vault as vault
 from pulumi import (
     ROOT_STACK_RESOURCE,
@@ -598,24 +597,11 @@ mitxonline_k8s_app = OLApplicationK8s(
         ),
         resource_requests={"cpu": "250m", "memory": mitxonline_web_memory_limit},
         resource_limits={"memory": mitxonline_web_memory_limit},
-        # CPU only. Memory is deliberately NOT an HPA metric here: HPA Resource
-        # metrics are a mean across all pods, so a single pod ramping to its own
-        # limit gets OOMKilled while the fleet average stays well under target and
-        # the HPA never reacts. Observed in production 2026-07: pods OOMKilled at
-        # ~85% of limit while replicas sat pinned at minReplicas for a week. Memory
-        # is a vertical problem and is handled by the VPA at the end of this file.
-        hpa_scaling_metrics=[
-            kubernetes.autoscaling.v2.MetricSpecArgs(
-                type="Resource",
-                resource=kubernetes.autoscaling.v2.ResourceMetricSourceArgs(
-                    name="cpu",
-                    target=kubernetes.autoscaling.v2.MetricTargetArgs(
-                        type="Utilization",
-                        average_utilization=60,  # Target CPU utilization (60%)
-                    ),
-                ),
-            ),
-        ],
+        # hpa_scaling_metrics is left at the component default (CPU only). Memory is
+        # managed vertically by the component's webapp VPA; the ceiling below is what
+        # `mitxonline_granian_workers_max_rss` is derived from, so keep the two in
+        # sync if either changes.
+        webapp_vpa_max_allowed_memory=mitxonline_web_memory_ceiling,
     ),
     opts=ResourceOptions(
         # Ensure secrets are created before the application deployment
@@ -1060,37 +1046,8 @@ route53.Record(
 )
 
 # VPA objects for mitxonline workloads.
-#
-# The webapp splits the two autoscaling axes: the HPA owns horizontal scaling on CPU
-# only, and this VPA owns memory. They no longer contend, because they no longer share
-# a resource. This replaces the previous arrangement where the HPA nominally covered
-# memory and no webapp VPA existed, which left memory effectively unmanaged --
-# individual pods OOMKilled at their limit while the HPA's fleet-average memory
-# utilization stayed under target and never triggered a scale-out.
-#
-# controlled_resources is memory-only: letting the VPA move CPU requests would distort
-# the utilization denominator the CPU HPA divides by, which is the classic HPA/VPA
-# conflict.
-#
-# min_allowed pins the floor at the current limit so the VPA can only ever size up from
-# today's budget; max_allowed is the ceiling that
-# `mitxonline_granian_workers_max_rss` is derived from -- keep the two in sync.
-make_vpa(
-    name=f"{mitxonline_k8s_app.webapp_deployment_name}-vpa",
-    namespace=mitxonline_namespace,
-    target_kind="Deployment",
-    target_name=mitxonline_k8s_app.webapp_deployment_name,
-    controlled_resources=["memory"],
-    container_name=f"{Services.mitxonline}-app",
-    # Leave the nginx sidecar on its declared 50Mi request/limit. Without this the VPA
-    # applies its default behaviour to any container lacking an explicit policy and
-    # would resize the sidecar too.
-    disable_other_containers=True,
-    min_allowed={"memory": mitxonline_web_memory_limit},
-    max_allowed={"memory": mitxonline_web_memory_ceiling},
-    opts=ResourceOptions(depends_on=[mitxonline_k8s_app]),
-)
-
+# The webapp's memory VPA is created by OLApplicationK8s (manage_webapp_memory_vpa),
+# which pairs with the component's CPU-only HPA default.
 # Celery workers and beat are scaled via KEDA (Redis queue depth), so CPU+memory VPA is safe.
 _worker_vpa_min_allowed = {"cpu": "25m", "memory": "128Mi"}
 _worker_vpa_max_allowed = {"cpu": "1000m", "memory": "3Gi"}

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import pulumi
 import pulumi_fastly as fastly
 import pulumi_vault as vault
+from kubernetes.utils.quantity import parse_quantity
 from pulumi import (
     ROOT_STACK_RESOURCE,
     Alias,
@@ -520,7 +521,6 @@ secret_names, secret_resources = create_mitxonline_k8s_secrets(
 # on observed usage.
 mitxonline_web_memory_limit = "1200Mi"
 mitxonline_web_memory_ceiling = "3Gi"
-_MITXONLINE_WEB_MEMORY_CEILING_MIB = 3 * 1024
 
 # Granian's --workers-max-rss is resolved at Pulumi synth time, so it cannot be derived
 # from the container memory limit once the VPA starts moving that limit at runtime.
@@ -529,12 +529,17 @@ _MITXONLINE_WEB_MEMORY_CEILING_MIB = 3 * 1024
 # (limit / workers * 0.9) it would stay pinned to the 1200Mi starting budget, and
 # workers would recycle at ~540MiB forever without ever using the headroom the VPA
 # granted.
+#
+# The MiB value is parsed from `mitxonline_web_memory_ceiling` rather than restated as
+# a literal, so the ceiling has exactly one source of truth and changing its value or
+# units cannot silently mis-size the worker cap.
 MITXONLINE_GRANIAN_WORKERS = 2
 # Headroom for the Granian master process and interpreter overhead, which sit outside
 # the per-worker RSS budget but inside the container memory limit.
 GRANIAN_MASTER_OVERHEAD_MIB = 256
 mitxonline_granian_workers_max_rss = (
-    _MITXONLINE_WEB_MEMORY_CEILING_MIB - GRANIAN_MASTER_OVERHEAD_MIB
+    int(parse_quantity(mitxonline_web_memory_ceiling)) // (1024 * 1024)
+    - GRANIAN_MASTER_OVERHEAD_MIB
 ) // MITXONLINE_GRANIAN_WORKERS
 
 mitxonline_k8s_app = OLApplicationK8s(

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -515,7 +515,28 @@ secret_names, secret_resources = create_mitxonline_k8s_secrets(
     redis_cache=redis_cache,
 )
 
+# Webapp memory is owned by the VPA (see the VPA block at the end of this file), not
+# the HPA. `mitxonline_web_memory_limit` is only the starting/floor budget pods launch
+# with; the VPA raises requests and limits toward `mitxonline_web_memory_ceiling` based
+# on observed usage.
 mitxonline_web_memory_limit = "1200Mi"
+mitxonline_web_memory_ceiling = "3Gi"
+_MITXONLINE_WEB_MEMORY_CEILING_MIB = 3 * 1024
+
+# Granian's --workers-max-rss is resolved at Pulumi synth time, so it cannot be derived
+# from the container memory limit once the VPA starts moving that limit at runtime.
+# Deriving it from the VPA ceiling instead keeps the worker cap valid across the entire
+# range the VPA may resize into. Left to the component default
+# (limit / workers * 0.9) it would stay pinned to the 1200Mi starting budget, and
+# workers would recycle at ~540MiB forever without ever using the headroom the VPA
+# granted.
+MITXONLINE_GRANIAN_WORKERS = 2
+# Headroom for the Granian master process and interpreter overhead, which sit outside
+# the per-worker RSS budget but inside the container memory limit.
+GRANIAN_MASTER_OVERHEAD_MIB = 256
+mitxonline_granian_workers_max_rss = (
+    _MITXONLINE_WEB_MEMORY_CEILING_MIB - GRANIAN_MASTER_OVERHEAD_MIB
+) // MITXONLINE_GRANIAN_WORKERS
 
 mitxonline_k8s_app = OLApplicationK8s(
     ol_app_k8s_config=OLApplicationK8sConfig(
@@ -536,9 +557,12 @@ mitxonline_k8s_app = OLApplicationK8s(
         application_cmd_array=["uwsgi"],
         application_arg_array=["/tmp/uwsgi.ini"],  # noqa: S108
         granian_config=GranianConfig(
-            workers=2,
+            workers=MITXONLINE_GRANIAN_WORKERS,
             blocking_threads_idle_timeout=120,
             enable_metrics=True,
+            # Pinned to the VPA ceiling rather than the component's default
+            # limit-derived calculation. See the note above.
+            workers_max_rss=mitxonline_granian_workers_max_rss,
         )
         if mitxonline_config.get_bool("use_granian")
         else None,
@@ -574,6 +598,12 @@ mitxonline_k8s_app = OLApplicationK8s(
         ),
         resource_requests={"cpu": "250m", "memory": mitxonline_web_memory_limit},
         resource_limits={"memory": mitxonline_web_memory_limit},
+        # CPU only. Memory is deliberately NOT an HPA metric here: HPA Resource
+        # metrics are a mean across all pods, so a single pod ramping to its own
+        # limit gets OOMKilled while the fleet average stays well under target and
+        # the HPA never reacts. Observed in production 2026-07: pods OOMKilled at
+        # ~85% of limit while replicas sat pinned at minReplicas for a week. Memory
+        # is a vertical problem and is handled by the VPA at the end of this file.
         hpa_scaling_metrics=[
             kubernetes.autoscaling.v2.MetricSpecArgs(
                 type="Resource",
@@ -582,17 +612,6 @@ mitxonline_k8s_app = OLApplicationK8s(
                     target=kubernetes.autoscaling.v2.MetricTargetArgs(
                         type="Utilization",
                         average_utilization=60,  # Target CPU utilization (60%)
-                    ),
-                ),
-            ),
-            # Scale up when avg usage exceeds: 1800 * 0.8 = 1440 Mi
-            kubernetes.autoscaling.v2.MetricSpecArgs(
-                type="Resource",
-                resource=kubernetes.autoscaling.v2.ResourceMetricSourceArgs(
-                    name="memory",
-                    target=kubernetes.autoscaling.v2.MetricTargetArgs(
-                        type="Utilization",
-                        average_utilization=80,  # Target memory utilization (80%)
                     ),
                 ),
             ),
@@ -1041,15 +1060,40 @@ route53.Record(
 )
 
 # VPA objects for mitxonline workloads.
-# No webapp VPA: the webapp's native HPA scales on both cpu (60%) and memory
-# (80%) Resource metrics (see hpa_scaling_metrics default in
-# OLApplicationK8sConfig), so there's no resource axis left for VPA to safely
-# control without fighting the HPA's utilization signal.
+#
+# The webapp splits the two autoscaling axes: the HPA owns horizontal scaling on CPU
+# only, and this VPA owns memory. They no longer contend, because they no longer share
+# a resource. This replaces the previous arrangement where the HPA nominally covered
+# memory and no webapp VPA existed, which left memory effectively unmanaged --
+# individual pods OOMKilled at their limit while the HPA's fleet-average memory
+# utilization stayed under target and never triggered a scale-out.
+#
+# controlled_resources is memory-only: letting the VPA move CPU requests would distort
+# the utilization denominator the CPU HPA divides by, which is the classic HPA/VPA
+# conflict.
+#
+# min_allowed pins the floor at the current limit so the VPA can only ever size up from
+# today's budget; max_allowed is the ceiling that
+# `mitxonline_granian_workers_max_rss` is derived from -- keep the two in sync.
+make_vpa(
+    name=f"{mitxonline_k8s_app.webapp_deployment_name}-vpa",
+    namespace=mitxonline_namespace,
+    target_kind="Deployment",
+    target_name=mitxonline_k8s_app.webapp_deployment_name,
+    controlled_resources=["memory"],
+    container_name=f"{Services.mitxonline}-app",
+    # Leave the nginx sidecar on its declared 50Mi request/limit. Without this the VPA
+    # applies its default behaviour to any container lacking an explicit policy and
+    # would resize the sidecar too.
+    disable_other_containers=True,
+    min_allowed={"memory": mitxonline_web_memory_limit},
+    max_allowed={"memory": mitxonline_web_memory_ceiling},
+    opts=ResourceOptions(depends_on=[mitxonline_k8s_app]),
+)
+
 # Celery workers and beat are scaled via KEDA (Redis queue depth), so CPU+memory VPA is safe.
-_worker_vpa_bounds = {
-    "min_allowed": {"cpu": "25m", "memory": "128Mi"},
-    "max_allowed": {"cpu": "1000m", "memory": "3Gi"},
-}
+_worker_vpa_min_allowed = {"cpu": "25m", "memory": "128Mi"}
+_worker_vpa_max_allowed = {"cpu": "1000m", "memory": "3Gi"}
 for _celery_name in mitxonline_k8s_app.celery_deployment_names:
     make_vpa(
         name=f"{_celery_name}-vpa",
@@ -1058,7 +1102,8 @@ for _celery_name in mitxonline_k8s_app.celery_deployment_names:
         target_name=_celery_name,
         controlled_resources=["cpu", "memory"],
         container_name="celery-worker",
-        **_worker_vpa_bounds,
+        min_allowed=_worker_vpa_min_allowed,
+        max_allowed=_worker_vpa_max_allowed,
         opts=ResourceOptions(depends_on=[mitxonline_k8s_app]),
     )
 if mitxonline_k8s_app.beat_deployment_name:
@@ -1069,7 +1114,8 @@ if mitxonline_k8s_app.beat_deployment_name:
         target_name=mitxonline_k8s_app.beat_deployment_name,
         controlled_resources=["cpu", "memory"],
         container_name="celery-beat",
-        **_worker_vpa_bounds,
+        min_allowed=_worker_vpa_min_allowed,
+        max_allowed=_worker_vpa_max_allowed,
         opts=ResourceOptions(depends_on=[mitxonline_k8s_app]),
     )
 

--- a/src/ol_infrastructure/applications/xpro/__main__.py
+++ b/src/ol_infrastructure/applications/xpro/__main__.py
@@ -598,11 +598,11 @@ if k8s_deploy:
     )
 
     # VPA objects for xpro workloads.
-    # No webapp VPA: xpro doesn't set webapp_keda_config or override
-    # hpa_scaling_metrics, so it gets OLApplicationK8sConfig's default native HPA,
-    # which scales on both cpu (60%) and memory (80%) Resource metrics -- there's
-    # no resource axis left for VPA to safely control without fighting the HPA's
-    # utilization signal.
+    # The webapp's memory VPA is created by OLApplicationK8s
+    # (manage_webapp_memory_vpa), paired with the component's now CPU-only HPA
+    # default. Previously the default HPA also carried a memory metric and no webapp
+    # VPA existed, which left memory unmanaged: a fleet-average memory metric cannot
+    # prevent an individual pod from being OOMKilled.
     # Celery workers and beat are scaled via KEDA (Redis queue depth), so
     # CPU+memory VPA is safe for those.
     _worker_vpa_bounds = {

--- a/src/ol_infrastructure/components/services/k8s.py
+++ b/src/ol_infrastructure/components/services/k8s.py
@@ -1129,6 +1129,19 @@ class OLApplicationK8s(ComponentResource):
                                     image_pull_policy=image_pull_policy,
                                     env=application_deployment_env_vars,
                                     env_from=application_deployment_envfrom,
+                                    # This pod template carries `application_labels`,
+                                    # which is also the webapp Deployment's selector, so
+                                    # the HPA includes these pods when computing
+                                    # utilization. A container without cpu/memory
+                                    # requests makes the HPA fail closed with
+                                    # FailedGetResourceMetric ("missing request for cpu
+                                    # in container <name>"), reporting <unknown> for
+                                    # *every* metric and suspending all scaling until
+                                    # the Job is garbage collected.
+                                    resources=kubernetes.core.v1.ResourceRequirementsArgs(
+                                        requests=ol_app_k8s_config.resource_requests,
+                                        limits=ol_app_k8s_config.resource_limits,
+                                    ),
                                     volume_mounts=ol_app_k8s_config.extra_volume_mounts
                                     or None,
                                 )

--- a/src/ol_infrastructure/components/services/k8s.py
+++ b/src/ol_infrastructure/components/services/k8s.py
@@ -29,6 +29,7 @@ from bridge.lib.magic_numbers import (
 )
 from bridge.lib.versions import NGINX_VERSION
 from ol_infrastructure.lib.aws.eks_helper import cached_image_uri, ecr_image_uri
+from ol_infrastructure.lib.k8s_vpa import make_vpa
 from ol_infrastructure.lib.ol_types import Component, KubernetesServiceAppProtocol
 from ol_infrastructure.lib.pulumi_helper import parse_stack
 
@@ -312,7 +313,16 @@ class OLApplicationK8sConfig(BaseModel):
     vault_k8s_resource_auth_name: str
     registry: Literal["dockerhub", "ecr"] = "ecr"
     image_pull_policy: str = "IfNotPresent"
-    # You get CPU and memory autoscaling by default
+    # CPU-only by default. Memory is handled vertically by the webapp VPA (see
+    # manage_webapp_memory_vpa below), NOT horizontally here.
+    #
+    # HPA `type: Resource` metrics are a *mean across all pods*. A single pod
+    # ramping toward its own limit is OOMKilled while the fleet average stays
+    # under target, so a memory HPA never reacts to the failure it is nominally
+    # there to prevent. Observed on mitxonline production 2026-07: pods OOMKilled
+    # at ~85% of their limit while replicas sat pinned at minReplicas for a week.
+    # Adding more replicas also does not shrink the working set of the pod that is
+    # actually about to die. Memory is a vertical problem; use the VPA.
     hpa_scaling_metrics: list[kubernetes.autoscaling.v2.MetricSpecArgs] = [
         kubernetes.autoscaling.v2.MetricSpecArgs(
             type="Resource",
@@ -324,17 +334,38 @@ class OLApplicationK8sConfig(BaseModel):
                 ),
             ),
         ),
-        kubernetes.autoscaling.v2.MetricSpecArgs(
-            type="Resource",
-            resource=kubernetes.autoscaling.v2.ResourceMetricSourceArgs(
-                name="memory",  # Memory utilization as the scaling metric
-                target=kubernetes.autoscaling.v2.MetricTargetArgs(
-                    type="Utilization",
-                    average_utilization=80,  # Target memory utilization (60%)
-                ),
-            ),
-        ),
     ]
+    manage_webapp_memory_vpa: bool = Field(
+        default=True,
+        description=(
+            "Create a VerticalPodAutoscaler that manages memory requests/limits for "
+            "the webapp container. Memory-only, so it cannot distort the CPU "
+            "utilization signal the HPA (or a KEDA cpu trigger) divides by. Set False "
+            "only when the caller builds its own webapp VPA, otherwise two VPAs would "
+            "target the same Deployment."
+        ),
+    )
+    webapp_vpa_min_allowed_memory: str | None = Field(
+        default=None,
+        description=(
+            "Floor for the webapp memory VPA. Defaults to resource_requests['memory'] "
+            "(falling back to resource_limits['memory']), which preserves the pod's "
+            "current scheduling footprint as the floor. Deliberately NOT the memory "
+            "*limit*: for a burstable pod whose request is below its limit, a "
+            "limit-derived floor would silently inflate the cluster-wide reservation "
+            "the moment the VPA is introduced."
+        ),
+    )
+    webapp_vpa_max_allowed_memory: str | None = Field(
+        default=None,
+        description=(
+            "Ceiling for the webapp memory VPA. Defaults to 2x "
+            "resource_limits['memory']. Note that when granian_config is set with "
+            "limit_workers_max_rss, --workers-max-rss is resolved at synth time from "
+            "resource_limits and will NOT track this ceiling -- set "
+            "GranianConfig.workers_max_rss explicitly to keep the two in sync."
+        ),
+    )
     import_nginx_config: bool = Field(default=True)
     import_nginx_config_path: str = "files/web.conf"
     import_uwsgi_config: bool = Field(default=False)
@@ -591,6 +622,40 @@ class OLApplicationK8sConfig(BaseModel):
                 "whose upstream address matches the overridden port."
             )
             raise ValueError(msg)
+        return self
+
+    @model_validator(mode="after")
+    def validate_memory_scaling_not_split(self) -> "OLApplicationK8sConfig":
+        """Reject configs where memory is scaled both horizontally and vertically.
+
+        A memory HPA metric and a memory VPA on the same Deployment actively fight:
+        the VPA raises memory requests, which lowers the utilization percentage the
+        HPA computes (usage / request), which makes the HPA scale *down*, which
+        concentrates load onto fewer pods and drives usage back up. The two settle
+        into oscillation rather than a stable size.
+
+        Memory belongs to exactly one controller. The component default is the VPA;
+        a caller that genuinely wants a memory HPA must opt out of the VPA by
+        setting manage_webapp_memory_vpa=False.
+        """
+        if not self.manage_webapp_memory_vpa:
+            return self
+        for metric in self.hpa_scaling_metrics:
+            resource = getattr(metric, "resource", None)
+            if getattr(metric, "type", None) == "Resource" and (
+                getattr(resource, "name", None) == "memory"
+            ):
+                msg = (
+                    "hpa_scaling_metrics contains a memory Resource metric while "
+                    "manage_webapp_memory_vpa is True. Memory would be controlled by "
+                    "both the HPA and the VPA, which oscillate against each other. "
+                    "Remove the memory metric from hpa_scaling_metrics (preferred -- "
+                    "HPA memory metrics are a fleet average and cannot prevent a "
+                    "single pod from being OOMKilled), or set "
+                    "manage_webapp_memory_vpa=False to keep horizontal-only memory "
+                    "scaling."
+                )
+                raise ValueError(msg)
         return self
 
     @model_validator(mode="after")
@@ -1603,6 +1668,59 @@ class OLApplicationK8s(ComponentResource):
                 ),
                 metadata=kubernetes.meta.v1.ObjectMetaArgs(
                     namespace=ol_app_k8s_config.application_namespace,
+                ),
+            )
+
+        # Vertical memory management for the webapp container.
+        #
+        # This is the counterpart to dropping memory from hpa_scaling_metrics: the
+        # horizontal scaler (HPA or KEDA) owns CPU/throughput, and this VPA owns
+        # memory. They do not contend because they no longer share a resource.
+        # Without it, memory would be unmanaged entirely and pods would keep being
+        # OOMKilled at whatever static limit was declared.
+        #
+        # controlled_resources is memory-only by design -- letting the VPA move CPU
+        # requests would change the denominator of the CPU utilization the HPA (or a
+        # KEDA cpu trigger) scales on.
+        if ol_app_k8s_config.manage_webapp_memory_vpa:
+            _webapp_memory_limit = ol_app_k8s_config.resource_limits.get("memory")
+            if _webapp_memory_limit is None:
+                msg = (
+                    f"{ol_app_k8s_config.application_name}: "
+                    "manage_webapp_memory_vpa requires resource_limits['memory'] to "
+                    "derive the VPA bounds. Set a memory limit, or pass "
+                    "manage_webapp_memory_vpa=False."
+                )
+                raise ValueError(msg)
+            _vpa_min_memory = (
+                ol_app_k8s_config.webapp_vpa_min_allowed_memory
+                or ol_app_k8s_config.resource_requests.get("memory")
+                or _webapp_memory_limit
+            )
+            if ol_app_k8s_config.webapp_vpa_max_allowed_memory is not None:
+                _vpa_max_memory = ol_app_k8s_config.webapp_vpa_max_allowed_memory
+            else:
+                # Default ceiling of 2x the declared limit: enough headroom to absorb
+                # the growth that was previously ending in an OOM kill, while still
+                # bounding a genuine leak rather than letting it consume the node.
+                _vpa_max_memory = f"{int(parse_quantity(_webapp_memory_limit)) * 2 // (1024 * 1024)}Mi"
+            make_vpa(
+                name=truncate_k8s_metanames(
+                    f"{_application_deployment_name}-memory-vpa"
+                ),
+                namespace=ol_app_k8s_config.application_namespace,
+                target_kind="Deployment",
+                target_name=_application_deployment_name,
+                controlled_resources=["memory"],
+                container_name=f"{ol_app_k8s_config.application_name}-app",
+                # Sidecars (nginx, vector, ...) keep their own declared requests.
+                # Naming a single container is not enough on its own: VPA applies its
+                # default behaviour to any container lacking a matching policy.
+                disable_other_containers=True,
+                min_allowed={"memory": _vpa_min_memory},
+                max_allowed={"memory": _vpa_max_memory},
+                opts=resource_options.merge(
+                    ResourceOptions(depends_on=[_application_deployment])
                 ),
             )
 

--- a/src/ol_infrastructure/lib/k8s_vpa.py
+++ b/src/ol_infrastructure/lib/k8s_vpa.py
@@ -42,8 +42,10 @@ def make_vpa(  # noqa: PLR0913
     containers alone: VPA applies its default behaviour to any container without a
     matching policy, so sidecars would still be resized. Set
     disable_other_containers=True to append a catch-all ``containerName: "*"`` policy
-    with ``mode: "Off"``, which pins every unnamed container to its declared
-    requests. Only meaningful when container_name is not "*".
+    with ``mode: "Off"``, which leaves every unnamed container's requests *and*
+    limits exactly as declared in the pod spec -- VPA still computes
+    recommendations for them, but never applies them. Only meaningful when
+    container_name is not "*".
     """
     container_policies: list[dict[str, Any]] = [
         {

--- a/src/ol_infrastructure/lib/k8s_vpa.py
+++ b/src/ol_infrastructure/lib/k8s_vpa.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pulumi
 import pulumi_kubernetes as kubernetes
 from pulumi import ResourceOptions
@@ -16,6 +18,8 @@ def make_vpa(  # noqa: PLR0913
     min_allowed: dict[str, str],
     max_allowed: dict[str, str],
     container_name: str = "*",
+    *,
+    disable_other_containers: bool = False,
     k8s_provider: kubernetes.Provider | None = None,
     opts: ResourceOptions | None = None,
 ) -> kubernetes.apiextensions.CustomResource:
@@ -33,7 +37,26 @@ def make_vpa(  # noqa: PLR0913
     ("*"). Targeting "*" applies the same bounds to every container in the pod,
     including sidecars such as nginx or vector, which can override their independent
     resource requests and undermine per-container rightsizing.
+
+    Naming a single container is not by itself sufficient to leave the other
+    containers alone: VPA applies its default behaviour to any container without a
+    matching policy, so sidecars would still be resized. Set
+    disable_other_containers=True to append a catch-all ``containerName: "*"`` policy
+    with ``mode: "Off"``, which pins every unnamed container to its declared
+    requests. Only meaningful when container_name is not "*".
     """
+    container_policies: list[dict[str, Any]] = [
+        {
+            "containerName": container_name,
+            "controlledResources": controlled_resources,
+            "controlledValues": "RequestsAndLimits",
+            "minAllowed": min_allowed,
+            "maxAllowed": max_allowed,
+        }
+    ]
+    if disable_other_containers and container_name != "*":
+        container_policies.append({"containerName": "*", "mode": "Off"})
+
     return kubernetes.apiextensions.CustomResource(
         name,
         api_version="autoscaling.k8s.io/v1",
@@ -51,17 +74,7 @@ def make_vpa(  # noqa: PLR0913
             "updatePolicy": {
                 "updateMode": "InPlaceOrRecreate",
             },
-            "resourcePolicy": {
-                "containerPolicies": [
-                    {
-                        "containerName": container_name,
-                        "controlledResources": controlled_resources,
-                        "controlledValues": "RequestsAndLimits",
-                        "minAllowed": min_allowed,
-                        "maxAllowed": max_allowed,
-                    }
-                ]
-            },
+            "resourcePolicy": {"containerPolicies": container_policies},
         },
         opts=ResourceOptions.merge(
             ResourceOptions(provider=k8s_provider)

--- a/tests/ol_infrastructure/lib/test_k8s_vpa.py
+++ b/tests/ol_infrastructure/lib/test_k8s_vpa.py
@@ -139,6 +139,91 @@ def test_make_vpa_container_name_scoped():
 
 
 @pulumi.runtime.test
+def test_make_vpa_other_containers_not_disabled_by_default():
+    """Without disable_other_containers only the named policy is emitted.
+
+    This is the pre-existing behaviour and is a trap: VPA applies its default
+    behaviour to any container lacking a matching policy, so naming one container
+    does NOT leave sidecars alone.
+    """
+    vpa = make_vpa(
+        name="test-vpa-no-optout",
+        namespace="default",
+        target_kind="Deployment",
+        target_name="my-deployment",
+        controlled_resources=["memory"],
+        container_name="my-app",
+        min_allowed={"memory": "128Mi"},
+        max_allowed={"memory": "4Gi"},
+        k8s_provider=_fake_provider(),
+    )
+
+    def check(spec):
+        policies = spec["resourcePolicy"]["containerPolicies"]
+        assert len(policies) == 1
+        assert policies[0]["containerName"] == "my-app"
+
+    return vpa.spec.apply(check)
+
+
+@pulumi.runtime.test
+def test_make_vpa_disable_other_containers_appends_off_policy():
+    """disable_other_containers appends a catch-all policy with mode Off.
+
+    Order matters: the specific container policy must come first so it wins over
+    the wildcard for the container it names.
+    """
+    vpa = make_vpa(
+        name="test-vpa-optout",
+        namespace="default",
+        target_kind="Deployment",
+        target_name="my-deployment",
+        controlled_resources=["memory"],
+        container_name="my-app",
+        disable_other_containers=True,
+        min_allowed={"memory": "128Mi"},
+        max_allowed={"memory": "4Gi"},
+        k8s_provider=_fake_provider(),
+    )
+
+    def check(spec):
+        policies = spec["resourcePolicy"]["containerPolicies"]
+        assert len(policies) == 2
+        assert policies[0]["containerName"] == "my-app"
+        assert policies[0]["controlledResources"] == ["memory"]
+        assert policies[1] == {"containerName": "*", "mode": "Off"}
+
+    return vpa.spec.apply(check)
+
+
+@pulumi.runtime.test
+def test_make_vpa_disable_other_containers_ignored_for_wildcard_target():
+    """The opt-out is a no-op when the policy already targets every container.
+
+    Emitting both a wildcard bounds policy and a wildcard Off policy would be
+    self-contradictory, so the catch-all is suppressed in that case.
+    """
+    vpa = make_vpa(
+        name="test-vpa-optout-wildcard",
+        namespace="default",
+        target_kind="Deployment",
+        target_name="my-deployment",
+        controlled_resources=["memory"],
+        disable_other_containers=True,
+        min_allowed={"memory": "128Mi"},
+        max_allowed={"memory": "4Gi"},
+        k8s_provider=_fake_provider(),
+    )
+
+    def check(spec):
+        policies = spec["resourcePolicy"]["containerPolicies"]
+        assert len(policies) == 1
+        assert policies[0]["containerName"] == "*"
+
+    return vpa.spec.apply(check)
+
+
+@pulumi.runtime.test
 def test_make_vpa_target_ref():
     """VPA targetRef reflects the provided kind and name."""
     vpa = make_vpa(


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)

`mitxonline-app` pods were being OOMKilled in production. Each kill produced a burst of nginx 502s that tripped the `mitxonline-5xx-error-percentage` Grafana alert, paged through to Rootly, and auto-resolved ~6 minutes later once the pod came back. The 502s never appeared in Sentry because an OOM kill is a `SIGKILL` and raises no Python exception — which is why the Sentry backlog never explained them.

The root cause turned out to be a property of the shared deployment pattern, not of mitxonline, so this fixes it in `OLApplicationK8s` for every consumer.

#### 1. A memory HPA metric cannot prevent an OOM kill

HPA `type: Resource` metrics are a **mean across all pods**. A single pod ramping toward its own limit is OOMKilled while the fleet average stays comfortably under target, so the memory metric never fires for the failure it is nominally there to prevent. Adding replicas also does not shrink the working set of the pod that is about to die.

Measured on mitxonline production: `kube_horizontalpodautoscaler_status_current_replicas` sat pinned at `minReplicas=4` for a full week while individual pods were OOMKilled at ~85% of their 1200Mi limit.

`hpa_scaling_metrics` now defaults to **CPU only**, and `manage_webapp_memory_vpa` (on by default) creates a **memory-only VPA** for the webapp container. Every app gets the same split: the horizontal scaler (HPA, or a KEDA cpu trigger) owns CPU, the VPA owns memory. They cannot contend because they no longer share a resource.

Nine apps previously had a memory HPA metric and no webapp VPA, leaving memory entirely unmanaged: `edx_notes`, `learn_ai`, `micromasters`, `ocw_studio`, `odl_video_service`, `ol_analytics_api`, `xpro`, `xqueue`, and both `edxapp` deployments.

`validate_memory_scaling_not_split` makes the invariant a hard error rather than a comment. A memory HPA metric plus a memory VPA oscillate against each other: the VPA raises requests → the utilization the HPA computes (`usage / request`) drops → the HPA scales down → load concentrates on fewer pods → usage climbs again.

#### 2. The pre-deploy Job was silently disabling the HPA entirely

The Job's pod template uses `application_labels`, which is *also* the webapp Deployment's `selector.matchLabels`. The HPA selects pods via the scale target's selector, so it picked up the `migrate` pod — and because that container declared no cpu/memory requests, the HPA failed closed:

```
ScalingActive  False  FailedGetResourceMetric
  the HPA was unable to compute the replica count: failed to get cpu utilization:
  missing request for cpu in container migrate of Pod mitxonline-app-pre-deploy-4bb5l

Metrics: cpu <unknown>/60%, memory <unknown>/80%
```

Note it reports `<unknown>` for *every* metric, not just the one it could not compute — all scaling is suspended until the Job is garbage collected 30 minutes later (`ttl_seconds_after_finished`). This affected every app using `pre_deploy_commands`. Fixed by giving the pre-deploy containers the app's own requests/limits.

Stripping the labels instead would have been wrong: `ol.mit.edu/pod-security-group` is what binds the pod to its `SecurityGroupPolicy`, so migrations would lose their ENI.

#### 3. VPA bound defaults

The floor defaults to `resource_requests['memory']`, **not** the limit. For a burstable pod whose request sits below its limit (`ocw_studio` 1Gi/3Gi, `odl_video_service` 512Mi/1Gi) a limit-derived floor would have silently inflated the cluster-wide reservation the moment the VPA was introduced. The ceiling defaults to 2x the limit — enough headroom to absorb the growth that was ending in an OOM kill, while still bounding a genuine leak.

Sidecars are excluded via a catch-all `containerName: "*"` / `mode: "Off"` policy. Naming a single container is not sufficient on its own: VPA applies its default behaviour to any container lacking a matching policy. Worth noting that mit_learn's hand-rolled VPA was missing this and **has been resizing its nginx sidecar** off its declared 50Mi.

#### 4. Granian's RSS cap would have gone stale

`--workers-max-rss` is resolved at Pulumi synth time from `resource_limits` (`floor(limit / workers * 0.9)`). Once a VPA moves that limit at runtime the derived cap is stale — workers would keep recycling at the original 540MiB and never use the headroom the VPA granted. mitxonline now pins it to the VPA ceiling: `(3072 - 256 master overhead) / 2 = 1408` MiB. This coupling is documented on `webapp_vpa_max_allowed_memory`.

#### Caller changes

- **mitxonline**, **mit_learn** — drop their hand-rolled webapp VPAs for the component's, so there is one pattern. mit_learn keeps its wider `256Mi`–`4Gi` bounds explicitly via the new config fields.
- **learn_ai** — drops the memory metric it had copied from the old default.
- **xpro** — comment corrected; it now gets a webapp VPA.

### How can this be tested?

`pulumi preview` run against Production for four representative stacks — a native-HPA app, a KEDA app, and a burstable app:

**mitxonline** (native HPA, requests == limits) — `1 to create, 4 to update`:
```
~ HorizontalPodAutoscaler  spec.metrics: - memory Resource metric
+-Job  mitxonline-app-pre-deploy  (replace — Jobs are immutable)
    + resources: {limits: {memory: 1200Mi}, requests: {cpu: 250m, memory: 1200Mi}}
~ Deployment  containers[1].args: ~ [14]: "540" => "1408"
+ VerticalPodAutoscaler  mitxonline-app-memory-vpa
    containerName: mitxonline-app, controlledResources: [memory]
    minAllowed: 1200Mi, maxAllowed: 3Gi, + {containerName: "*", mode: "Off"}
```

**mit_learn** (KEDA cpu trigger) — `1 create, 1 update, 1 delete, 1 replace`. Old `mitlearn-webapp-vpa` deleted, component-owned `mitlearn-app-memory-vpa` created with the same `256Mi`–`4Gi` bounds *plus* the sidecar exclusion it previously lacked.

**ocw_studio** (burstable: requests 1Gi, limit 3Gi) — confirms the floor derives from the **request**:
```
+ VerticalPodAutoscaler  ocw-studio-app-memory-vpa
    containerName: ocw-studio-app
    minAllowed: {memory: "1Gi"}      # the request, NOT the 3Gi limit
    maxAllowed: {memory: "6144Mi"}   # 2x the limit
```

All pre-commit hooks pass (ruff, ruff-format, mypy, detect-secrets).

Post-apply validation:

1. `kubectl describe hpa <app>-hpa -n <ns>` — `ScalingActive` should be `True` with a real CPU percentage instead of `<unknown>`, and should stay `True` through a deploy rather than going `<unknown>` for 30 minutes.
2. `kubectl get vpa -n <ns> -o yaml` — `status.recommendation` converges within bounds, and sidecars are absent from the recommendations.
3. `kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}` should fall as VPA sizes pods up.
4. The `*-5xx-error-percentage` alerts should stop firing on pod recycles.

### Additional Context

**Please preview your own stack before this merges.** It changes a shared component, so all 11 `OLApplicationK8s` consumers are affected. Several stacks also carry unrelated pre-existing drift that an apply would sweep in — `ocw_studio` for example shows a `VaultStaticSecret` and four celery Deployment updates that have nothing to do with this change, and `mitxonline` shows Fastly `TlsSubscription.configurationId` drift plus gzip `extensions`/`content_types` list churn caused by nondeterministic `set` iteration in the existing `mimetypes` loop.

**mit_learn's VPA is deleted and recreated** under a new name. VPA recommendations and their checkpoints do not survive that, so its recommender starts cold and takes roughly a day to rebuild a confident recommendation. Transient and self-healing, but worth knowing. If that is unacceptable, the alternative is to keep the old resource name and add a Pulumi alias for the parent change — happy to do that instead.

**Not addressed here (alerting side, lives in Grafana):** the `5xx-error-percentage` rule group is structurally noisy independent of this fix. It is a pure ratio with no minimum-request floor; its `for: 5m` provides almost no debounce because the `rate(...[5m])` sliding window carries a single burst across the entire pending period; and it counts `/health/*` probe traffic in both numerator and denominator. `mitlearn-5xx-error-percentage` fired 28 times in the last 30 days from the same template and the same underlying cause (`mitlearn-app` OOMKills). Worth fixing separately, along with a non-paging `PodOOMKilled` alert that fires on the cause rather than the symptom.