### PR TITLE
fix(release-bot): make slash command responses visible to the channel

### DIFF
--- a/src/ol_infrastructure/applications/release_bot/bot.py
+++ b/src/ol_infrastructure/applications/release_bot/bot.py
@@ -199,6 +199,19 @@ _SUBCOMMANDS = {
 }
 
 
+def _in_channel(respond):
+    """Wrap `respond` so its message posts visibly to the channel.
+
+    Slash command responses are ephemeral (visible only to the invoker) by
+    default; release state needs to be visible to the whole team.
+    """
+
+    async def wrapped(text):
+        await respond(text=text, response_type="in_channel")
+
+    return wrapped
+
+
 async def _cmd_doof(repos, ack, respond, command, context):
     parts = command["text"].split(None, 1)
     if not parts or parts[0] not in _SUBCOMMANDS:
@@ -207,7 +220,9 @@ async def _cmd_doof(repos, ack, respond, command, context):
         return
     subcommand, *rest = parts
     sub_command = dict(command, text=rest[0] if rest else "")
-    await _SUBCOMMANDS[subcommand](repos, ack, respond, sub_command, context)
+    await _SUBCOMMANDS[subcommand](
+        repos, ack, _in_channel(respond), sub_command, context
+    )
 
 
 def create_app():

--- a/src/ol_infrastructure/applications/release_bot/bot.py
+++ b/src/ol_infrastructure/applications/release_bot/bot.py
@@ -206,8 +206,9 @@ def _in_channel(respond):
     default; release state needs to be visible to the whole team.
     """
 
-    async def wrapped(text):
-        await respond(text=text, response_type="in_channel")
+    async def wrapped(*args, **kwargs):
+        kwargs.setdefault("response_type", "in_channel")
+        await respond(*args, **kwargs)
 
     return wrapped
 


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Slack slash command responses are ephemeral (visible only to the invoking
user) by default. That defeats the point of a shared release bot -- the
whole team should be able to see release state (who triggered a release,
build status, promote/publish/abandon actions) without everyone running
the command themselves.

Wraps `respond()` with `response_type="in_channel"` for every subcommand's
output (release, release-notes, release-status, promote, publish,
abandon). Left the bare `/doof` usage/help message (unknown or missing
subcommand) as the default ephemeral response -- that's command help for
the invoker, not release state, and keeping it private avoids channel
spam from people fumbling the syntax. `_handle_promote_button` already
uses `say()`, which posts to the channel by default, so it needed no
change.

### How can this be tested?
- Called `_cmd_doof` locally with a fake `respond()` and confirmed the
  dispatched call includes `response_type: "in_channel"`.
- Confirmed the image still builds cleanly with this change.
- `pre-commit` (ruff, mypy) passes.

Once merged and redeployed, the real test is running `/doof release-status`
(harmless, read-only) in Slack and confirming the response is visible to
the whole channel, not just the invoker.

### Additional Context
N/A