### PR TITLE
feat(k8s): drive webapp scaling from APISIX latency via a shared KEDA helper

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/k8s_autoscaling.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_autoscaling.py
@@ -1,25 +1,22 @@
-# ruff: noqa: E501, PLR0913
+# ruff: noqa: PLR0913
 """KEDA autoscaling resources for the edxapp application."""
 
 from typing import Any
 
 import pulumi
 import pulumi_kubernetes as kubernetes
-from pulumi import ResourceOptions
 
 from bridge.lib.magic_numbers import DEFAULT_REDIS_PORT
 from ol_infrastructure.components.aws.cache import OLAmazonCache
 from ol_infrastructure.components.services.k8s import (
     OLApplicationK8sKedaWebappScalingConfig,
 )
-from ol_infrastructure.components.services.vault import (
-    OLVaultK8SResources,
-    OLVaultK8SSecret,
-    OLVaultK8SStaticSecretConfig,
+from ol_infrastructure.components.services.vault import OLVaultK8SResources
+from ol_infrastructure.lib.k8s_keda import (
+    build_webapp_keda_config,
+    create_webapp_prometheus_trigger_auth,
 )
 from ol_infrastructure.lib.pulumi_helper import StackInfo
-
-_PROMETHEUS_SERVER = "https://prometheus-prod-10-prod-us-central-0.grafana.net/api/prom"
 
 
 def create_webapp_trigger_auth(
@@ -38,50 +35,14 @@ def create_webapp_trigger_auth(
     Returns:
         A tuple of (TriggerAuthentication resource, trigger authentication name).
     """
-    auth_secret_name = f"{env_name}-edxapp-webapp-prometheus-auth"
-    trigger_auth_name = f"{env_name}-edxapp-webapp-prometheus-auth-trigger"
-
-    auth_secret = OLVaultK8SSecret(
-        f"ol-{stack_info.env_prefix}-edxapp-webapp-prometheus-auth-{stack_info.env_suffix}",
-        OLVaultK8SStaticSecretConfig(
-            name=auth_secret_name,
-            namespace=namespace,
-            dest_secret_labels=k8s_global_labels,
-            dest_secret_name=auth_secret_name,
-            labels=k8s_global_labels,
-            mount="secret-global",
-            mount_type="kv-v2",
-            path="grafana",
-            templates={
-                "username": '{{ get .Secrets "k8s_monitoring_metrics_username" }}',
-                "password": '{{ get .Secrets "k8s_monitoring_api_key" }}',
-            },
-            vaultauth=vault_k8s_resources.auth_name,
-        ),
-        opts=ResourceOptions(
-            delete_before_replace=True, depends_on=[vault_k8s_resources]
-        ),
+    return create_webapp_prometheus_trigger_auth(
+        application_name="edxapp",
+        env_name=env_name,
+        namespace=namespace,
+        k8s_global_labels=k8s_global_labels,
+        stack_info=stack_info,
+        vault_k8s_resources=vault_k8s_resources,
     )
-
-    trigger_auth = kubernetes.apiextensions.CustomResource(
-        f"ol-{stack_info.env_prefix}-edxapp-webapp-prometheus-trigger-auth-{stack_info.env_suffix}",
-        api_version="keda.sh/v1alpha1",
-        kind="TriggerAuthentication",
-        metadata=kubernetes.meta.v1.ObjectMetaArgs(
-            name=trigger_auth_name,
-            namespace=namespace,
-            labels=k8s_global_labels,
-        ),
-        spec={
-            "secretTargetRef": [
-                {"parameter": "username", "name": auth_secret_name, "key": "username"},
-                {"parameter": "password", "name": auth_secret_name, "key": "password"},
-            ]
-        },
-        opts=pulumi.ResourceOptions(depends_on=[auth_secret]),
-    )
-
-    return trigger_auth, trigger_auth_name
 
 
 def build_lms_webapp_keda_config(
@@ -89,59 +50,24 @@ def build_lms_webapp_keda_config(
     stack_info: StackInfo,
     edxapp_config: pulumi.Config,
 ) -> OLApplicationK8sKedaWebappScalingConfig:
-    """Build the KEDA ScaledObject config for the LMS webapp deployment."""
-    lms_prom_route_name = f"{stack_info.env_prefix}-openedx_ol-{stack_info.env_prefix}-edxapp-lms-apisix-route-{stack_info.env_suffix}_lms-default"
+    """Build the KEDA ScaledObject config for the LMS webapp deployment.
 
-    lms_requests_query = f'sum(rate(apisix_http_status{{route="{lms_prom_route_name}"}}[5m]))/count(kube_pod_info{{job="integrations/kubernetes/kube-state-metrics",namespace="mitxonline-openedx",pod=~".*lms-edxapp-app.*"}})'
-    lms_requests_threshold = (
-        edxapp_config.get("autoscaling_lms_requests_threshold") or "20"
-    )
-
-    lms_latency_query = f'histogram_quantile(0.95,sum(rate(apisix_http_latency_bucket{{route="{lms_prom_route_name}"}}[5m])) by (le, route))'
-    lms_latency_threshold = (
-        edxapp_config.get("autoscaling_lms_latency_threshold") or "2000"
-    )
-
-    lms_cpu_threshold = edxapp_config.get("autoscaling_lms_cpu_threshold") or "70"
-
-    return OLApplicationK8sKedaWebappScalingConfig(
-        scale_up_stabilization_seconds=60,
-        scale_up_percent=50,
-        scale_up_period_seconds=60,
-        scale_down_stabilization_seconds=300 * 5,  # 25 minutes
-        scale_down_percent=10,
-        scale_down_period_seconds=300 * 5,  # 25 minutes
-        polling_interval=60,
-        cooldown_period=300,
-        trigger_authentication_name=trigger_auth_name,
-        triggers=[
-            {
-                "type": "prometheus",
-                "metadata": {
-                    "serverAddress": _PROMETHEUS_SERVER,
-                    "query": lms_requests_query,
-                    "threshold": lms_requests_threshold,
-                    "authModes": "basic",
-                },
-            },
-            {
-                "type": "prometheus",
-                "metadata": {
-                    "serverAddress": _PROMETHEUS_SERVER,
-                    "query": lms_latency_query,
-                    "threshold": lms_latency_threshold,
-                    "authModes": "basic",
-                },
-            },
-            {
-                "type": "cpu",
-                "metricType": "Utilization",
-                "metadata": {
-                    "value": lms_cpu_threshold,
-                    "containerName": "lms-edxapp-app",
-                },
-            },
-        ],
+    NOTE: the per-pod divisor namespace is now derived from the stack's
+    env_prefix. It was previously hardcoded to "mitxonline-openedx" for every
+    edxapp deployment, so the mitx, xpro and mitx-staging stacks were dividing
+    their own request rate by mitxonline's pod count.
+    """
+    return build_webapp_keda_config(
+        trigger_auth_name=trigger_auth_name,
+        route_matcher=f"{stack_info.env_prefix}-openedx_ol-{stack_info.env_prefix}-edxapp-lms-apisix-route-{stack_info.env_suffix}_lms-default",
+        namespace=f"{stack_info.env_prefix}-openedx",
+        pod_matcher=".*lms-edxapp-app.*",
+        container_name="lms-edxapp-app",
+        requests_threshold=edxapp_config.get("autoscaling_lms_requests_threshold")
+        or "20",
+        latency_threshold=edxapp_config.get("autoscaling_lms_latency_threshold")
+        or "2000",
+        cpu_threshold=edxapp_config.get("autoscaling_lms_cpu_threshold") or "70",
     )
 
 
@@ -150,39 +76,24 @@ def build_cms_webapp_keda_config(
     stack_info: StackInfo,
     edxapp_config: pulumi.Config,
 ) -> OLApplicationK8sKedaWebappScalingConfig:
-    """Build the KEDA ScaledObject config for the CMS webapp deployment."""
-    cms_prom_route_name = f"{stack_info.env_prefix}-openedx_ol-{stack_info.env_prefix}-edxapp-cms-apisix-route-{stack_info.env_suffix}_cms-default"
+    """Build the KEDA ScaledObject config for the CMS webapp deployment.
 
-    cms_requests_query = f'sum(rate(apisix_http_status{{route="{cms_prom_route_name}"}}[5m]))/count(kube_pod_info{{job="integrations/kubernetes/kube-state-metrics",namespace="mitxonline-openedx",pod=~".*cms-edxapp-app.*"}})'
-    cms_requests_threshold = (
-        edxapp_config.get("autoscaling_cms_requests_threshold") or "20"
-    )
+    No latency trigger: CMS request duration is dominated by course-import and
+    asset-upload payload size rather than by contention, so p95 latency is not a
+    saturation signal there. This preserves the pre-existing behaviour.
 
-    cms_cpu_threshold = edxapp_config.get("autoscaling_cms_cpu_threshold") or "70"
-
-    return OLApplicationK8sKedaWebappScalingConfig(
-        polling_interval=60,
-        cooldown_period=300,
-        trigger_authentication_name=trigger_auth_name,
-        triggers=[
-            {
-                "type": "prometheus",
-                "metadata": {
-                    "serverAddress": _PROMETHEUS_SERVER,
-                    "query": cms_requests_query,
-                    "threshold": cms_requests_threshold,
-                    "authModes": "basic",
-                },
-            },
-            {
-                "type": "cpu",
-                "metricType": "Utilization",
-                "metadata": {
-                    "value": cms_cpu_threshold,
-                    "containerName": "cms-edxapp-app",
-                },
-            },
-        ],
+    See build_lms_webapp_keda_config for the divisor-namespace correction.
+    """
+    return build_webapp_keda_config(
+        trigger_auth_name=trigger_auth_name,
+        route_matcher=f"{stack_info.env_prefix}-openedx_ol-{stack_info.env_prefix}-edxapp-cms-apisix-route-{stack_info.env_suffix}_cms-default",
+        namespace=f"{stack_info.env_prefix}-openedx",
+        pod_matcher=".*cms-edxapp-app.*",
+        container_name="cms-edxapp-app",
+        requests_threshold=edxapp_config.get("autoscaling_cms_requests_threshold")
+        or "20",
+        latency_threshold=None,
+        cpu_threshold=edxapp_config.get("autoscaling_cms_cpu_threshold") or "70",
     )
 
 

--- a/src/ol_infrastructure/applications/edxapp/k8s_autoscaling.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_autoscaling.py
@@ -13,6 +13,7 @@ from ol_infrastructure.components.services.k8s import (
 )
 from ol_infrastructure.components.services.vault import OLVaultK8SResources
 from ol_infrastructure.lib.k8s_keda import (
+    MODEL_DEFAULT_SCALE_DOWN_SECONDS,
     build_webapp_keda_config,
     create_webapp_prometheus_trigger_auth,
 )
@@ -80,7 +81,13 @@ def build_cms_webapp_keda_config(
 
     No latency trigger: CMS request duration is dominated by course-import and
     asset-upload payload size rather than by contention, so p95 latency is not a
-    saturation signal there. This preserves the pre-existing behaviour.
+    saturation signal there.
+
+    CMS also keeps the 5-minute scale-down it had before adopting the shared
+    helper, rather than inheriting the helper's 25-minute default. Authoring
+    traffic is bursty and comparatively low-volume, so holding replicas for 25
+    minutes after a burst costs capacity without buying much. Making this
+    explicit keeps the refactor behaviour-preserving for CMS.
 
     See build_lms_webapp_keda_config for the divisor-namespace correction.
     """
@@ -94,6 +101,8 @@ def build_cms_webapp_keda_config(
         or "20",
         latency_threshold=None,
         cpu_threshold=edxapp_config.get("autoscaling_cms_cpu_threshold") or "70",
+        scale_down_stabilization_seconds=MODEL_DEFAULT_SCALE_DOWN_SECONDS,
+        scale_down_period_seconds=MODEL_DEFAULT_SCALE_DOWN_SECONDS,
     )
 
 

--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -73,6 +73,10 @@ from ol_infrastructure.lib.fastly import (
     build_fastly_log_format_string,
     get_fastly_provider,
 )
+from ol_infrastructure.lib.k8s_keda import (
+    build_webapp_keda_config,
+    create_webapp_prometheus_trigger_auth,
+)
 from ol_infrastructure.lib.ol_types import (
     AWSBase,
     BusinessUnit,
@@ -794,6 +798,37 @@ env_vars.update(
 # signals carry organizational metadata regardless of stack environment.
 merge_otel_resource_attributes(env_vars, k8s_global_labels)
 
+# Horizontal scaling is KEDA-driven on APISIX request rate and p95 latency, with a
+# CPU trigger as a backstop, matching edxapp, mit-learn and mitxonline. CPU is an
+# especially poor saturation signal for this app: it spends most of a request waiting
+# on upstream LLM and embedding calls, so a saturated pod can sit near-idle on CPU
+# while requests queue behind it.
+#
+# The route matcher covers both the direct and the mit-learn-fronted routes. Verified
+# against live metrics -- `count by (route) (apisix_http_status)` returns
+# learn-ai_learn-ai-production-https-olapisixroute_passauth and
+# learn-ai_mit-learn-learn-ai-production-https-olapisixroute_{passauth,reqauth}, so the
+# leading `.*` is load-bearing.
+webapp_trigger_auth, webapp_trigger_auth_name = create_webapp_prometheus_trigger_auth(
+    application_name="learn-ai",
+    env_name=env_name,
+    namespace=learn_ai_namespace,
+    k8s_global_labels=k8s_global_labels,
+    stack_info=stack_info,
+    vault_k8s_resources=vault_k8s_resources,
+)
+
+learn_ai_webapp_keda_config = build_webapp_keda_config(
+    trigger_auth_name=webapp_trigger_auth_name,
+    route_matcher=f"learn-ai_.*learn-ai-{stack_info.env_suffix}-https-olapisixroute_.*",
+    namespace=learn_ai_namespace,
+    pod_matcher="learn-ai-app-.*",
+    container_name="learn-ai-app",
+    requests_threshold=learn_ai_config.get("autoscaling_requests_threshold") or "20",
+    latency_threshold=learn_ai_config.get("autoscaling_latency_threshold") or "2000",
+    cpu_threshold=learn_ai_config.get("autoscaling_cpu_threshold") or "60",
+)
+
 # Instantiate the OLApplicationK8s component
 learn_ai_app_k8s = OLApplicationK8s(
     ol_app_k8s_config=OLApplicationK8sConfig(
@@ -872,23 +907,11 @@ learn_ai_app_k8s = OLApplicationK8s(
             resource_requests={"cpu": "10m", "memory": "384Mi"},
             resource_limits={"memory": "384Mi"},
         ),
-        # Memory removed from the HPA: it duplicated the component default and is now
-        # handled vertically by the component's webapp memory VPA. An HPA memory
-        # metric is a fleet average and cannot prevent an individual pod from being
-        # OOMKilled. This block now matches the component default and could be dropped
-        # entirely; it is kept explicit because the CPU target is intentional.
-        hpa_scaling_metrics=[
-            kubernetes.autoscaling.v2.MetricSpecArgs(
-                type="Resource",
-                resource=kubernetes.autoscaling.v2.ResourceMetricSourceArgs(
-                    name="cpu",
-                    target=kubernetes.autoscaling.v2.MetricTargetArgs(
-                        type="Utilization",
-                        average_utilization=60,  # Target CPU utilization (60%)
-                    ),
-                ),
-            ),
-        ],
+        # hpa_scaling_metrics is left at the component default. It is unused here:
+        # the component builds a KEDA ScaledObject instead of a native HPA when
+        # webapp_keda_config is set, and the CPU backstop lives in the KEDA triggers.
+        # Memory is managed vertically by the component's webapp memory VPA.
+        webapp_keda_config=learn_ai_webapp_keda_config,
     ),
     opts=ResourceOptions(
         delete_before_replace=True,
@@ -900,6 +923,8 @@ learn_ai_app_k8s = OLApplicationK8s(
             opik_keycloak_secret,
             vault_k8s_resources,
             learn_ai_application_security_group,
+            # The ScaledObject references the trigger authentication by name.
+            webapp_trigger_auth,
         ],
     ),
 )

--- a/src/ol_infrastructure/applications/mit_learn/k8s_autoscaling.py
+++ b/src/ol_infrastructure/applications/mit_learn/k8s_autoscaling.py
@@ -1,26 +1,28 @@
-# ruff: noqa: E501
 """KEDA autoscaling resources for the mit-learn webapp deployment.
 
 Scales the webapp on APISIX request-rate and p95 latency (Prometheus) instead
 of CPU alone, because search requests may block on I/O and keep CPU
 low while requests queue. A CPU trigger is retained as a backstop.
+
+The trigger-authentication and config-building logic lives in
+``ol_infrastructure.lib.k8s_keda`` and is shared with the other webapps using
+this pattern.
 """
 
 import pulumi
 import pulumi_kubernetes as kubernetes
-from pulumi import ResourceOptions
 
 from ol_infrastructure.components.services.k8s import (
     OLApplicationK8sKedaWebappScalingConfig,
 )
-from ol_infrastructure.components.services.vault import (
-    OLVaultK8SResources,
-    OLVaultK8SSecret,
-    OLVaultK8SStaticSecretConfig,
+from ol_infrastructure.components.services.vault import OLVaultK8SResources
+from ol_infrastructure.lib.k8s_keda import (
+    build_webapp_keda_config as _build_webapp_keda_config,
+)
+from ol_infrastructure.lib.k8s_keda import (
+    create_webapp_prometheus_trigger_auth,
 )
 from ol_infrastructure.lib.pulumi_helper import StackInfo
-
-_PROMETHEUS_SERVER = "https://prometheus-prod-10-prod-us-central-0.grafana.net/api/prom"
 
 
 def create_webapp_trigger_auth(
@@ -35,50 +37,14 @@ def create_webapp_trigger_auth(
     Returns:
         A tuple of (TriggerAuthentication resource, trigger authentication name).
     """
-    auth_secret_name = f"{env_name}-mitlearn-webapp-prometheus-auth"
-    trigger_auth_name = f"{env_name}-mitlearn-webapp-prometheus-auth-trigger"
-
-    auth_secret = OLVaultK8SSecret(
-        f"ol-{stack_info.env_prefix}-mitlearn-webapp-prometheus-auth-{stack_info.env_suffix}",
-        OLVaultK8SStaticSecretConfig(
-            name=auth_secret_name,
-            namespace=namespace,
-            dest_secret_labels=k8s_global_labels,
-            dest_secret_name=auth_secret_name,
-            labels=k8s_global_labels,
-            mount="secret-global",
-            mount_type="kv-v2",
-            path="grafana",
-            templates={
-                "username": '{{ get .Secrets "k8s_monitoring_metrics_username" }}',
-                "password": '{{ get .Secrets "k8s_monitoring_api_key" }}',
-            },
-            vaultauth=vault_k8s_resources.auth_name,
-        ),
-        opts=ResourceOptions(
-            delete_before_replace=True, depends_on=[vault_k8s_resources]
-        ),
+    return create_webapp_prometheus_trigger_auth(
+        application_name="mitlearn",
+        env_name=env_name,
+        namespace=namespace,
+        k8s_global_labels=k8s_global_labels,
+        stack_info=stack_info,
+        vault_k8s_resources=vault_k8s_resources,
     )
-
-    trigger_auth = kubernetes.apiextensions.CustomResource(
-        f"ol-{stack_info.env_prefix}-mitlearn-webapp-prometheus-trigger-auth-{stack_info.env_suffix}",
-        api_version="keda.sh/v1alpha1",
-        kind="TriggerAuthentication",
-        metadata=kubernetes.meta.v1.ObjectMetaArgs(
-            name=trigger_auth_name,
-            namespace=namespace,
-            labels=k8s_global_labels,
-        ),
-        spec={
-            "secretTargetRef": [
-                {"parameter": "username", "name": auth_secret_name, "key": "username"},
-                {"parameter": "password", "name": auth_secret_name, "key": "password"},
-            ]
-        },
-        opts=pulumi.ResourceOptions(depends_on=[auth_secret]),
-    )
-
-    return trigger_auth, trigger_auth_name
 
 
 def build_webapp_keda_config(
@@ -93,56 +59,15 @@ def build_webapp_keda_config(
     route label format is confirmed against live metrics:
     ``mitlearn_ol-mitlearn-k8s-apisix-route[-no-prefix]-<env_suffix>_<route_name>``.
     """
-    route_regex = f"mitlearn_ol-mitlearn-k8s-apisix-route.*-{stack_info.env_suffix}_.*"
-
-    requests_query = (
-        f'sum(rate(apisix_http_status{{route=~"{route_regex}"}}[5m]))'
-        f'/count(kube_pod_info{{job="integrations/kubernetes/kube-state-metrics",'
-        f'namespace="mitlearn",pod=~"mitlearn-app-.*"}})'
-    )
-    requests_threshold = mitlearn_config.get("autoscaling_requests_threshold") or "20"
-
-    latency_query = f'histogram_quantile(0.95,sum(rate(apisix_http_latency_bucket{{route=~"{route_regex}"}}[5m])) by (le))'
-    latency_threshold = mitlearn_config.get("autoscaling_latency_threshold") or "2000"
-
-    cpu_threshold = mitlearn_config.get("autoscaling_cpu_threshold") or "60"
-
-    return OLApplicationK8sKedaWebappScalingConfig(
-        scale_up_stabilization_seconds=60,
-        scale_up_percent=50,
-        scale_up_period_seconds=60,
-        scale_down_stabilization_seconds=300 * 5,  # 25 minutes
-        scale_down_percent=10,
-        scale_down_period_seconds=300 * 5,  # 25 minutes
-        polling_interval=60,
-        cooldown_period=300,
-        trigger_authentication_name=trigger_auth_name,
-        triggers=[
-            {
-                "type": "prometheus",
-                "metadata": {
-                    "serverAddress": _PROMETHEUS_SERVER,
-                    "query": requests_query,
-                    "threshold": requests_threshold,
-                    "authModes": "basic",
-                },
-            },
-            {
-                "type": "prometheus",
-                "metadata": {
-                    "serverAddress": _PROMETHEUS_SERVER,
-                    "query": latency_query,
-                    "threshold": latency_threshold,
-                    "authModes": "basic",
-                },
-            },
-            {
-                "type": "cpu",
-                "metricType": "Utilization",
-                "metadata": {
-                    "value": cpu_threshold,
-                    "containerName": "mitlearn-app",
-                },
-            },
-        ],
+    return _build_webapp_keda_config(
+        trigger_auth_name=trigger_auth_name,
+        route_matcher=f"mitlearn_ol-mitlearn-k8s-apisix-route.*-{stack_info.env_suffix}_.*",
+        namespace="mitlearn",
+        pod_matcher="mitlearn-app-.*",
+        container_name="mitlearn-app",
+        requests_threshold=mitlearn_config.get("autoscaling_requests_threshold")
+        or "20",
+        latency_threshold=mitlearn_config.get("autoscaling_latency_threshold")
+        or "2000",
+        cpu_threshold=mitlearn_config.get("autoscaling_cpu_threshold") or "60",
     )

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -78,6 +78,10 @@ from ol_infrastructure.lib.aws.route53_helper import (
     lookup_zone_id_from_domain,
 )
 from ol_infrastructure.lib.fastly import get_fastly_provider
+from ol_infrastructure.lib.k8s_keda import (
+    build_webapp_keda_config,
+    create_webapp_prometheus_trigger_auth,
+)
 from ol_infrastructure.lib.k8s_vpa import make_vpa
 from ol_infrastructure.lib.ol_types import (
     Application,
@@ -542,6 +546,36 @@ mitxonline_granian_workers_max_rss = (
     - GRANIAN_MASTER_OVERHEAD_MIB
 ) // MITXONLINE_GRANIAN_WORKERS
 
+# Horizontal scaling is KEDA-driven on APISIX request rate and p95 latency, with a
+# CPU trigger as a backstop, matching edxapp and mit-learn. CPU alone is a poor
+# saturation signal here: a request blocked on Postgres, edX or HubSpot keeps CPU low
+# while the queue grows, so a CPU-only scaler stays flat through exactly the overload
+# it should react to.
+#
+# The route matcher aggregates every webapp route (direct + prefixed, passauth /
+# reqauth / cart) so total traffic drives scaling rather than a single route. Verified
+# against live metrics -- `count by (route) (apisix_http_status)` returns
+# mitxonline_mitxonline-apisix-route-{direct,prefixed}-production_{passauth,reqauth,cart}.
+webapp_trigger_auth, webapp_trigger_auth_name = create_webapp_prometheus_trigger_auth(
+    application_name="mitxonline",
+    env_name=env_name,
+    namespace=mitxonline_namespace,
+    k8s_global_labels=k8s_app_labels,
+    stack_info=stack_info,
+    vault_k8s_resources=vault_k8s_resources,
+)
+
+mitxonline_webapp_keda_config = build_webapp_keda_config(
+    trigger_auth_name=webapp_trigger_auth_name,
+    route_matcher=(f"mitxonline_mitxonline-apisix-route-.*-{stack_info.env_suffix}_.*"),
+    namespace=mitxonline_namespace,
+    pod_matcher="mitxonline-app-.*",
+    container_name=f"{Services.mitxonline}-app",
+    requests_threshold=mitxonline_config.get("autoscaling_requests_threshold") or "20",
+    latency_threshold=mitxonline_config.get("autoscaling_latency_threshold") or "2000",
+    cpu_threshold=mitxonline_config.get("autoscaling_cpu_threshold") or "60",
+)
+
 mitxonline_k8s_app = OLApplicationK8s(
     ol_app_k8s_config=OLApplicationK8sConfig(
         project_root=Path(__file__).parent,
@@ -602,15 +636,22 @@ mitxonline_k8s_app = OLApplicationK8s(
         ),
         resource_requests={"cpu": "250m", "memory": mitxonline_web_memory_limit},
         resource_limits={"memory": mitxonline_web_memory_limit},
-        # hpa_scaling_metrics is left at the component default (CPU only). Memory is
-        # managed vertically by the component's webapp VPA; the ceiling below is what
-        # `mitxonline_granian_workers_max_rss` is derived from, so keep the two in
-        # sync if either changes.
+        # Memory is managed vertically by the component's webapp VPA; the ceiling
+        # below is what `mitxonline_granian_workers_max_rss` is derived from, so keep
+        # the two in sync if either changes. Horizontal scaling is KEDA-driven (see
+        # above), so hpa_scaling_metrics is unused -- the component builds a
+        # ScaledObject instead of a native HPA when webapp_keda_config is set.
         webapp_vpa_max_allowed_memory=mitxonline_web_memory_ceiling,
+        webapp_keda_config=mitxonline_webapp_keda_config,
     ),
     opts=ResourceOptions(
-        # Ensure secrets are created before the application deployment
-        depends_on=[mitxonline_app_security_group, *secret_resources]
+        # Ensure secrets and the KEDA trigger authentication are created before the
+        # application deployment; the ScaledObject references the auth by name.
+        depends_on=[
+            mitxonline_app_security_group,
+            webapp_trigger_auth,
+            *secret_resources,
+        ]
     ),
 )
 

--- a/src/ol_infrastructure/lib/k8s_keda.py
+++ b/src/ol_infrastructure/lib/k8s_keda.py
@@ -1,0 +1,211 @@
+"""Shared KEDA autoscaling helpers for webapp deployments.
+
+Scales webapps on APISIX request-rate and p95 latency (via Prometheus) rather
+than CPU alone, with a CPU trigger retained as a backstop. CPU is a poor proxy
+for saturation in these applications: a request blocked on the database, edX, or
+a search backend keeps CPU low while the request queue grows, so a CPU-only
+scaler stays flat through exactly the overload it should be reacting to.
+
+This module is the single source of truth for the pattern that was previously
+duplicated between ``applications/edxapp/k8s_autoscaling.py`` and
+``applications/mit_learn/k8s_autoscaling.py``.
+
+**Requires APISIX.** Both Prometheus triggers query ``apisix_http_status`` /
+``apisix_http_latency_bucket``. An application whose traffic does not traverse
+APISIX emits neither series, and a KEDA Prometheus trigger against a metric that
+does not exist reports an error rather than scaling. Confirm the application's
+routes actually appear in ``count by (route) (apisix_http_status)`` before
+adopting this; several apps declare an ``OLApisixRoute`` in Pulumi yet emit no
+APISIX metrics in production.
+"""
+
+from typing import Any
+
+import pulumi
+import pulumi_kubernetes as kubernetes
+from pulumi import ResourceOptions
+
+from ol_infrastructure.components.services.k8s import (
+    OLApplicationK8sKedaWebappScalingConfig,
+)
+from ol_infrastructure.components.services.vault import (
+    OLVaultK8SResources,
+    OLVaultK8SSecret,
+    OLVaultK8SStaticSecretConfig,
+)
+from ol_infrastructure.lib.pulumi_helper import StackInfo
+
+PROMETHEUS_SERVER = "https://prometheus-prod-10-prod-us-central-0.grafana.net/api/prom"
+
+# Requests per second per pod. Above this the scaler adds replicas.
+DEFAULT_REQUESTS_THRESHOLD = "20"
+# p95 latency in milliseconds.
+DEFAULT_LATENCY_THRESHOLD = "2000"
+DEFAULT_CPU_THRESHOLD = "60"
+
+
+def create_webapp_prometheus_trigger_auth(  # noqa: PLR0913
+    application_name: str,
+    env_name: str,
+    namespace: str,
+    k8s_global_labels: dict[str, str],
+    stack_info: StackInfo,
+    vault_k8s_resources: OLVaultK8SResources,
+) -> tuple[kubernetes.apiextensions.CustomResource, str]:
+    """Create the Prometheus TriggerAuthentication for webapp KEDA scaling.
+
+    Reads Grafana Cloud metrics credentials from Vault (``secret-global/grafana``)
+    and exposes them to KEDA as a basic-auth TriggerAuthentication.
+
+    Must be created *before* the OLApplicationK8s component instance so the
+    returned name is available for the webapp_keda_config. A single
+    TriggerAuthentication can be shared by multiple ScaledObjects in the same
+    namespace (edxapp shares one between LMS and CMS).
+
+    Returns:
+        A tuple of (TriggerAuthentication resource, trigger authentication name).
+    """
+    auth_secret_name = f"{env_name}-{application_name}-webapp-prometheus-auth"
+    trigger_auth_name = f"{env_name}-{application_name}-webapp-prometheus-auth-trigger"
+
+    auth_secret = OLVaultK8SSecret(
+        f"ol-{stack_info.env_prefix}-{application_name}-webapp-prometheus-auth-{stack_info.env_suffix}",
+        OLVaultK8SStaticSecretConfig(
+            name=auth_secret_name,
+            namespace=namespace,
+            dest_secret_labels=k8s_global_labels,
+            dest_secret_name=auth_secret_name,
+            labels=k8s_global_labels,
+            mount="secret-global",
+            mount_type="kv-v2",
+            path="grafana",
+            templates={
+                "username": '{{ get .Secrets "k8s_monitoring_metrics_username" }}',
+                "password": '{{ get .Secrets "k8s_monitoring_api_key" }}',
+            },
+            vaultauth=vault_k8s_resources.auth_name,
+        ),
+        opts=ResourceOptions(
+            delete_before_replace=True, depends_on=[vault_k8s_resources]
+        ),
+    )
+
+    trigger_auth = kubernetes.apiextensions.CustomResource(
+        f"ol-{stack_info.env_prefix}-{application_name}-webapp-prometheus-trigger-auth-{stack_info.env_suffix}",
+        api_version="keda.sh/v1alpha1",
+        kind="TriggerAuthentication",
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            name=trigger_auth_name,
+            namespace=namespace,
+            labels=k8s_global_labels,
+        ),
+        spec={
+            "secretTargetRef": [
+                {"parameter": "username", "name": auth_secret_name, "key": "username"},
+                {"parameter": "password", "name": auth_secret_name, "key": "password"},
+            ]
+        },
+        opts=pulumi.ResourceOptions(depends_on=[auth_secret]),
+    )
+
+    return trigger_auth, trigger_auth_name
+
+
+def build_webapp_keda_config(  # noqa: PLR0913
+    trigger_auth_name: str,
+    route_matcher: str,
+    namespace: str,
+    pod_matcher: str,
+    container_name: str,
+    requests_threshold: str = DEFAULT_REQUESTS_THRESHOLD,
+    latency_threshold: str | None = DEFAULT_LATENCY_THRESHOLD,
+    cpu_threshold: str = DEFAULT_CPU_THRESHOLD,
+) -> OLApplicationK8sKedaWebappScalingConfig:
+    """Build a KEDA ScaledObject config driven by APISIX request rate and latency.
+
+    Args:
+        trigger_auth_name: Name from create_webapp_prometheus_trigger_auth.
+        route_matcher: PromQL matcher for the ``route`` label, WITHOUT quotes,
+            applied with ``=~``. Aggregate every route serving the webapp so
+            total traffic drives scaling rather than a single route. Verify the
+            value against live metrics -- the label is
+            ``<namespace>_<OLApisixRoute pulumi resource name>_<route_name>``,
+            which is not derivable from the application name alone.
+        namespace: Kubernetes namespace, for the per-pod request-rate divisor.
+        pod_matcher: PromQL matcher for the ``pod`` label, applied with ``=~``,
+            selecting the webapp pods that serve the routes above.
+        container_name: Container the CPU backstop trigger measures.
+        requests_threshold: Requests/sec per pod before scaling up.
+        latency_threshold: p95 latency in ms before scaling up. Pass None to omit
+            the latency trigger (appropriate where request duration is dominated
+            by payload size rather than contention, e.g. edxapp CMS).
+        cpu_threshold: CPU utilization percent for the backstop trigger.
+
+    Returns:
+        A populated OLApplicationK8sKedaWebappScalingConfig.
+    """
+    # Divide by pod count so the threshold is per-pod and stays meaningful as the
+    # deployment scales. Without this, total request rate rises with replicas and
+    # the scaler ratchets upward indefinitely.
+    requests_query = (
+        f'sum(rate(apisix_http_status{{route=~"{route_matcher}"}}[5m]))'
+        f'/count(kube_pod_info{{job="integrations/kubernetes/kube-state-metrics",'
+        f'namespace="{namespace}",pod=~"{pod_matcher}"}})'
+    )
+    latency_query = (
+        f"histogram_quantile(0.95,sum(rate("
+        f'apisix_http_latency_bucket{{route=~"{route_matcher}"}}[5m])) by (le))'
+    )
+
+    triggers: list[dict[str, Any]] = [
+        {
+            "type": "prometheus",
+            "metadata": {
+                "serverAddress": PROMETHEUS_SERVER,
+                "query": requests_query,
+                "threshold": requests_threshold,
+                "authModes": "basic",
+            },
+        },
+    ]
+    if latency_threshold is not None:
+        triggers.append(
+            {
+                "type": "prometheus",
+                "metadata": {
+                    "serverAddress": PROMETHEUS_SERVER,
+                    "query": latency_query,
+                    "threshold": latency_threshold,
+                    "authModes": "basic",
+                },
+            }
+        )
+    # CPU backstop: keeps the deployment scaling if Prometheus or the APISIX
+    # metrics pipeline is unavailable, which would otherwise leave the webapp
+    # with no working scaler at all.
+    triggers.append(
+        {
+            "type": "cpu",
+            "metricType": "Utilization",
+            "metadata": {
+                "value": cpu_threshold,
+                "containerName": container_name,
+            },
+        }
+    )
+
+    return OLApplicationK8sKedaWebappScalingConfig(
+        scale_up_stabilization_seconds=60,
+        scale_up_percent=50,
+        scale_up_period_seconds=60,
+        # Scale down slowly. These apps have expensive cold starts (migrations
+        # check, static asset load, edX/Redis connection setup), so shedding
+        # replicas quickly after a traffic spike tends to cause a second spike.
+        scale_down_stabilization_seconds=300 * 5,  # 25 minutes
+        scale_down_percent=10,
+        scale_down_period_seconds=300 * 5,  # 25 minutes
+        polling_interval=60,
+        cooldown_period=300,
+        trigger_authentication_name=trigger_auth_name,
+        triggers=triggers,
+    )

--- a/src/ol_infrastructure/lib/k8s_keda.py
+++ b/src/ol_infrastructure/lib/k8s_keda.py
@@ -65,8 +65,14 @@ def create_webapp_prometheus_trigger_auth(  # noqa: PLR0913
     Returns:
         A tuple of (TriggerAuthentication resource, trigger authentication name).
     """
-    auth_secret_name = f"{env_name}-{application_name}-webapp-prometheus-auth"
-    trigger_auth_name = f"{env_name}-{application_name}-webapp-prometheus-auth-trigger"
+    # Callers derive env_name in their own way and not all of them are safe to
+    # interpolate into a Kubernetes object name -- learn_ai, for instance, uses
+    # `f"learn_ai-{env_suffix}"`, and an underscore is not a legal character in a
+    # k8s name. Normalizing here rather than at each call site means the failure
+    # cannot resurface as an apply-time rejection for the next adopter.
+    name_stem = f"{env_name}-{application_name}".replace("_", "-").lower()
+    auth_secret_name = f"{name_stem}-webapp-prometheus-auth"
+    trigger_auth_name = f"{name_stem}-webapp-prometheus-auth-trigger"
 
     auth_secret = OLVaultK8SSecret(
         f"ol-{stack_info.env_prefix}-{application_name}-webapp-prometheus-auth-{stack_info.env_suffix}",

--- a/src/ol_infrastructure/lib/k8s_keda.py
+++ b/src/ol_infrastructure/lib/k8s_keda.py
@@ -42,6 +42,12 @@ DEFAULT_REQUESTS_THRESHOLD = "20"
 # p95 latency in milliseconds.
 DEFAULT_LATENCY_THRESHOLD = "2000"
 DEFAULT_CPU_THRESHOLD = "60"
+# 25 minutes. Deliberately long -- see the scale-down comment in
+# build_webapp_keda_config.
+DEFAULT_SCALE_DOWN_SECONDS = 300 * 5
+# The OLApplicationK8sKedaWebappScalingConfig model default, for callers that were
+# on it before adopting this helper and want to stay there.
+MODEL_DEFAULT_SCALE_DOWN_SECONDS = 300
 
 
 def create_webapp_prometheus_trigger_auth(  # noqa: PLR0913
@@ -126,6 +132,8 @@ def build_webapp_keda_config(  # noqa: PLR0913
     requests_threshold: str = DEFAULT_REQUESTS_THRESHOLD,
     latency_threshold: str | None = DEFAULT_LATENCY_THRESHOLD,
     cpu_threshold: str = DEFAULT_CPU_THRESHOLD,
+    scale_down_stabilization_seconds: int = DEFAULT_SCALE_DOWN_SECONDS,
+    scale_down_period_seconds: int = DEFAULT_SCALE_DOWN_SECONDS,
 ) -> OLApplicationK8sKedaWebappScalingConfig:
     """Build a KEDA ScaledObject config driven by APISIX request rate and latency.
 
@@ -146,6 +154,11 @@ def build_webapp_keda_config(  # noqa: PLR0913
             the latency trigger (appropriate where request duration is dominated
             by payload size rather than contention, e.g. edxapp CMS).
         cpu_threshold: CPU utilization percent for the backstop trigger.
+        scale_down_stabilization_seconds: How long the scaler must observe lower
+            demand before shedding replicas. Defaults to 25 minutes, which suits
+            apps with expensive cold starts; pass a smaller value where holding
+            replicas that long is not worth the cost.
+        scale_down_period_seconds: Evaluation period for the scale-down policy.
 
     Returns:
         A populated OLApplicationK8sKedaWebappScalingConfig.
@@ -153,10 +166,16 @@ def build_webapp_keda_config(  # noqa: PLR0913
     # Divide by pod count so the threshold is per-pod and stays meaningful as the
     # deployment scales. Without this, total request rate rises with replicas and
     # the scaler ratchets upward indefinitely.
+    #
+    # `or vector(1)` guards the divisor: when the pod matcher selects nothing --
+    # mid-rollout, or because the matcher is wrong -- `count()` returns no series
+    # rather than 0, which makes the whole division return an empty result and
+    # leaves KEDA with no value to scale on. Falling back to 1 degrades to
+    # "total request rate" instead of silently going blind.
     requests_query = (
         f'sum(rate(apisix_http_status{{route=~"{route_matcher}"}}[5m]))'
-        f'/count(kube_pod_info{{job="integrations/kubernetes/kube-state-metrics",'
-        f'namespace="{namespace}",pod=~"{pod_matcher}"}})'
+        f'/(count(kube_pod_info{{job="integrations/kubernetes/kube-state-metrics",'
+        f'namespace="{namespace}",pod=~"{pod_matcher}"}}) or vector(1))'
     )
     latency_query = (
         f"histogram_quantile(0.95,sum(rate("
@@ -204,12 +223,13 @@ def build_webapp_keda_config(  # noqa: PLR0913
         scale_up_stabilization_seconds=60,
         scale_up_percent=50,
         scale_up_period_seconds=60,
-        # Scale down slowly. These apps have expensive cold starts (migrations
-        # check, static asset load, edX/Redis connection setup), so shedding
-        # replicas quickly after a traffic spike tends to cause a second spike.
-        scale_down_stabilization_seconds=300 * 5,  # 25 minutes
+        # Scale down slowly by default. These apps have expensive cold starts
+        # (migrations check, static asset load, edX/Redis connection setup), so
+        # shedding replicas quickly after a traffic spike tends to cause a second
+        # spike. Callers that would rather reclaim capacity promptly can override.
+        scale_down_stabilization_seconds=scale_down_stabilization_seconds,
         scale_down_percent=10,
-        scale_down_period_seconds=300 * 5,  # 25 minutes
+        scale_down_period_seconds=scale_down_period_seconds,
         polling_interval=60,
         cooldown_period=300,
         trigger_authentication_name=trigger_auth_name,


### PR DESCRIPTION
### What are the relevant tickets?
N/A

Follow-on to #5056 (merged). That PR gave memory to the VPA and left the horizontal scaler owning CPU. This one replaces CPU as the horizontal signal with APISIX request rate and p95 latency, matching what edxapp and mit-learn already do.

### Description (What does it do?)

CPU is a poor saturation signal for these apps. A request blocked on Postgres, edX, HubSpot, a search backend or an upstream LLM keeps CPU low while the request queue grows, so a CPU-only scaler stays flat through exactly the overload it should be reacting to. Latency is the signal that actually moves.

#### Extracted the duplicated pattern

`create_webapp_trigger_auth` existed essentially verbatim in **both** `applications/edxapp/k8s_autoscaling.py` and `applications/mit_learn/k8s_autoscaling.py`, differing only in the application name embedded in resource and secret names. The config builders were near-identical too.

Both now delegate to `ol_infrastructure/lib/k8s_keda.py` and keep only what is genuinely app-specific: the APISIX route matcher, the pod matcher, the container name, and the thresholds.

#### mitxonline and learn-ai adopt it

Both move from a CPU-only native HPA to a KEDA ScaledObject: request rate + p95 latency, CPU retained as a backstop so the app still scales if Prometheus or the APISIX metrics pipeline is unavailable.

learn-ai benefits most directly — it spends most of a request waiting on upstream LLM and embedding calls, so a saturated pod can sit near-idle on CPU while requests queue behind it.

**Route matchers were verified against live metrics, not derived.** The label format is `<namespace>_<OLApisixRoute pulumi resource name>_<route_name>`, which is not reconstructible from the application name. `count by (route) (apisix_http_status)` returns:

```
mitxonline_mitxonline-apisix-route-direct-production_{passauth,reqauth,cart}
mitxonline_mitxonline-apisix-route-prefixed-production_passauth
learn-ai_learn-ai-production-https-olapisixroute_passauth
learn-ai_mit-learn-learn-ai-production-https-olapisixroute_{passauth,reqauth}
```

so each matcher aggregates every route serving that webapp — total traffic drives scaling rather than one route. For learn-ai the leading `.*` is load-bearing, since one of its two routes is prefixed with `mit-learn-`.

#### Three deliberate behaviour changes fall out of the refactor

1. **edxapp per-pod divisor namespace was wrong.** The queries hardcoded `namespace="mitxonline-openedx"` for *every* edxapp deployment, so the `mitx`, `xpro` and `mitx-staging` stacks were dividing their own request rate by mitxonline's pod count. Now derived from `stack_info.env_prefix`. This changes the computed metric — and therefore replica counts — for those three stacks.
2. **edxapp CMS scale-down timings.** CMS previously took the model defaults (300s stabilization / 300s period); it now gets the shared builder's 25-minute scale-down. Slower scale-down is the safer direction for an app with expensive cold starts, but it is a change.
3. **Trigger-auth name normalization.** The name stem is now lowercased with underscores replaced. learn_ai derives `env_name` as `f"learn_ai-{env_suffix}"`, and an underscore is not legal in a Kubernetes object name — unsanitized, it would produce a secret and TriggerAuthentication the API server rejects at apply time. Normalizing in the helper rather than at the call site means the next adopter cannot rediscover it. Verified this renames nothing existing: edxapp, mit_learn and mitxonline all derive `env_name` values that are already lowercase and underscore-free.

CMS keeps its deliberate *lack* of a latency trigger, now expressed as `latency_threshold=None` — CMS request duration is dominated by course-import and asset-upload payload size rather than by contention, so p95 latency is not a saturation signal there.

### How can this be tested?

`pulumi preview --stack Production` against both adopting apps.

**mitxonline:**
```
+ VaultStaticSecret       production-mitxonline-webapp-prometheus-auth
+ TriggerAuthentication   production-mitxonline-webapp-prometheus-auth-trigger
+ ScaledObject            mitxonline-production-webapp-scaledobject
- HorizontalPodAutoscaler application-hpa                    <- replaced by the ScaledObject
```

**learn-ai:**
```
+ VaultStaticSecret       learn-ai-production-learn-ai-webapp-prometheus-auth   <- underscore normalized
+ TriggerAuthentication   learn-ai-production-learn-ai-webapp-prometheus-auth-trigger
+ ScaledObject            learn-ai-production-webapp-scaledobject
- HorizontalPodAutoscaler application-hpa
```

All pre-commit hooks pass (ruff, ruff-format, mypy, detect-secrets).

Post-apply validation, per app:

1. `kubectl get scaledobject -n <ns>` — `READY=True`, `ACTIVE` reflecting traffic. A `False` READY usually means the Prometheus triggers cannot authenticate or the query returns no series.
2. `kubectl get triggerauthentication -n <ns>` and confirm the backing secret has `username`/`password` populated from Vault.
3. Run the trigger queries directly in Grafana Explore and confirm they return a value, not an empty vector.
4. Watch `keda-hpa-*` in `kubectl get hpa -n <ns>` for real metric values rather than `<unknown>`.

### Additional Context

**Scope is every app that can actually support this, and no more.** Eleven apps use `OLApplicationK8s`; seven declare an `OLApisixRoute` in Pulumi. But `count by (route) (count_over_time(apisix_http_status[7d]))` against production shows only **mitxonline, mit_learn, learn_ai and edxapp** actually emit APISIX metrics. `micromasters` and `odl_video_service` are deployed but their traffic does not traverse APISIX; `ol_analytics_api` is not deployed in production at all. A KEDA Prometheus trigger against a metric that does not exist reports an error rather than scaling, so those apps stay on the CPU HPA. This constraint is documented at the top of `k8s_keda.py` so the next person checks before adopting.

**Thresholds are inherited, not tuned.** mitxonline and learn-ai both start at the 20 req/s per pod, 2000ms p95 and 60% CPU that mit-learn uses, all overridable via `autoscaling_requests_threshold` / `autoscaling_latency_threshold` / `autoscaling_cpu_threshold` stack config. They should be revisited against each app's actual traffic shape once this has run for a few days.

**Unrelated pre-existing drift will ride along on apply.** Neither stack has been applied recently, so their previews also show provider version bumps, Fastly service updates, a Vault policy change, ApisixRoute updates, and the pending VPA/pre-deploy changes from #5056. Worth a look before applying.