### PR TITLE
feat(keycloak): add University Of Dubai SAML IdP for olapps

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/olapps.py
+++ b/src/ol_infrastructure/substructure/keycloak/olapps.py
@@ -1054,6 +1054,38 @@ def create_olapps_realm(  # noqa: PLR0913, PLR0915
         )
         onboard_saml_org(
             SamlIdpConfig(
+                idp_alias="University_Of_Dubai",
+                idp_display_name="University Of Dubai",
+                org_saml_metadata_url="https://login.microsoftonline.com/5813cc51-31c7-4d29-a1be-fc6cb1b77e1c/federationmetadata/2007-06/federationmetadata.xml?appid=cbe26906-056e-49b5-92c3-a01836310582",
+                principal_type="SUBJECT",
+                principal_attribute="user.mail",
+                login_hint=False,
+                name_id_format=NameIdFormat.email,
+                keycloak_url=keycloak_url,
+                realm_id=ol_apps_realm.id,
+                first_login_flow=ol_first_login_flow,
+                resource_options=resource_options,
+                attribute_name_map={
+                    "email": "user.mail",
+                    "firstName": "user.givenname",
+                    "lastName": "user.surname",
+                    "fullName": "user.displayname",
+                    "username": "user.userprincipalname",
+                },
+                want_assertions_encrypted=False,
+                want_assertions_signed=False,
+            ),
+            org=OrgConfig(
+                org_domains=["ud.ac.ae"],
+                org_name="University Of Dubai",
+                org_alias="University_Of_Dubai",
+                learn_domain=mitlearn_domain,
+                realm_id=ol_apps_realm.id,
+                resource_options=resource_options,
+            ),
+        )
+        onboard_saml_org(
+            SamlIdpConfig(
                 idp_alias="UCV",
                 idp_display_name="Universidad Cesar Vallejo",
                 org_saml_metadata_xml=Path(__file__)


### PR DESCRIPTION
Onboards University Of Dubai (ud.ac.ae) as a new SAML SSO partner in the olapps realm, using Azure AD's federation metadata and attribute claim mappings (user.mail, user.givenname, user.surname, user.displayname, user.userprincipalname).

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Have a test account that I can use to verify new config
