### PR TITLE
CREATE_HIDDEN_OCW_LEARNING_MATERIALS learn rc

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.QA.yaml
@@ -52,7 +52,7 @@ config:
     CANVAS_COURSE_BUCKET_NAME: "ol-data-lake-landing-zone-production"
     COURSE_ARCHIVE_BUCKET_NAME: "ol-data-lake-landing-zone-qa"
     CELERY_WORKER_CONCURRENCY: 1
-    CREATE_OCW_LEARNING_MATERIALS: "true"
+    CREATE_HIDDEN_OCW_LEARNING_MATERIALS: "true"
     COOKIE_TOMBSTONES: '[{"name":"csrftoken","domain":"rc.learn.mit.edu","path":"/"}]'
     CSRF_COOKIE_NAME: "learn_rc_csrftoken"
     DEBUG: "false"


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
https://github.com/mitodl/mit-learn/pull/3618 renamed the flag for ocw learning materials since some learning materials - lecture videos, textbooks - are now shown regardless of the flag value