### PR TITLE
fix(keycloak): pin SAML metadata fetch to certifi's CA bundle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
 ]
 dependencies = [
   "boto3~=1.24",
+  "certifi>=2024.2.2",
   "httpx>=0.28.0,<0.29",
   "hvac[parser]>=2.0.0,<3",
   "pulumi>=3.39.1,<4",

--- a/src/ol_infrastructure/substructure/keycloak/saml_helpers.py
+++ b/src/ol_infrastructure/substructure/keycloak/saml_helpers.py
@@ -14,9 +14,11 @@ logger = logging.getLogger(__name__)
 # Some standalone/pyenv-managed Python builds (e.g. on macOS) don't reliably
 # pick up the system trust store via ssl.create_default_context(), causing
 # CERTIFICATE_VERIFY_FAILED for otherwise-valid certificates (e.g. issued by
-# HARICA). Pin the CA bundle to certifi's, which is actively maintained and
-# bundled with the interpreter regardless of OS trust store quirks.
-_SSL_CONTEXT = ssl.create_default_context(cafile=certifi.where())
+# HARICA). Load the default (system) certs as usual, then layer certifi's
+# actively-maintained bundle on top, so both trust sources are honored instead
+# of certifi replacing the system/enterprise trust store.
+_SSL_CONTEXT = ssl.create_default_context()
+_SSL_CONTEXT.load_verify_locations(cafile=certifi.where())
 
 SAML_FRIENDLY_NAMES = {
     "firstName": [

--- a/src/ol_infrastructure/substructure/keycloak/saml_helpers.py
+++ b/src/ol_infrastructure/substructure/keycloak/saml_helpers.py
@@ -1,12 +1,22 @@
 """Helper functions for managing Keycloak SAML integrations."""
 
 import logging
+import ssl
 import xml.etree.ElementTree as ET
 from typing import Any
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
+import certifi
+
 logger = logging.getLogger(__name__)
+
+# Some standalone/pyenv-managed Python builds (e.g. on macOS) don't reliably
+# pick up the system trust store via ssl.create_default_context(), causing
+# CERTIFICATE_VERIFY_FAILED for otherwise-valid certificates (e.g. issued by
+# HARICA). Pin the CA bundle to certifi's, which is actively maintained and
+# bundled with the interpreter regardless of OS trust store quirks.
+_SSL_CONTEXT = ssl.create_default_context(cafile=certifi.where())
 
 SAML_FRIENDLY_NAMES = {
     "firstName": [
@@ -80,7 +90,7 @@ def _fetch_and_parse_saml_metadata(metadata_url: str) -> ET.Element | None:
                 "User-Agent": "Mozilla/5.0 (compatible; Keycloak-metadata-fetcher)"
             },
         )
-        with urlopen(request, timeout=10) as metadata_file:  # noqa: S310
+        with urlopen(request, timeout=10, context=_SSL_CONTEXT) as metadata_file:  # noqa: S310
             metadata_bytes = metadata_file.read(MAX_METADATA_SIZE + 1)
             if len(metadata_bytes) > MAX_METADATA_SIZE:
                 logger.warning(

--- a/uv.lock
+++ b/uv.lock
@@ -1419,6 +1419,7 @@ source = { editable = "." }
 dependencies = [
     { name = "bcrypt" },
     { name = "boto3" },
+    { name = "certifi" },
     { name = "cyclopts" },
     { name = "httpx" },
     { name = "hvac", extra = ["parser"] },
@@ -1475,6 +1476,7 @@ dev = [
 requires-dist = [
     { name = "bcrypt", specifier = ">=5,<6" },
     { name = "boto3", specifier = "~=1.24" },
+    { name = "certifi", specifier = ">=2024.2.2" },
     { name = "cyclopts", specifier = ">=4.4.0" },
     { name = "httpx", specifier = ">=0.28.0,<0.29" },
     { name = "hvac", extras = ["parser"], specifier = ">=2.0.0,<3" },


### PR DESCRIPTION
## Summary
- `onboard_saml_org` skips creating a partner's SAML IdP resource whenever fetching its metadata fails, which Pulumi then diffs as a **delete** of the existing production IdP + attribute mappers.
- Discovered this via a `pulumi up -s Production` preview (after merging #5059) that planned to delete NTUA's live IdP because `https://login.ntua.gr/metadata-signed.xml` failed `CERTIFICATE_VERIFY_FAILED`.
- The NTUA cert chain is valid (verified independently with `curl`/`openssl` and with the macOS system Python) — the failure is specific to the `uv`-managed standalone Python build not reliably surfacing the macOS system trust store to `ssl.create_default_context()`.
- Fix: pin the SAML metadata fetch's SSL context to `certifi`'s CA bundle instead of relying on interpreter/OS trust-store lookup. Added `certifi` as an explicit dependency (was only transitive) and regenerated `uv.lock`.

## Test plan
- [x] `extract_saml_metadata("https://login.ntua.gr/metadata-signed.xml")` returns metadata successfully (previously raised `SSLCertVerificationError`)
- [x] `ruff check` / `ruff format` / `mypy` / pre-commit pass
- [ ] `pulumi preview` against the olapps Production stack to confirm NTUA's IdP and mappers no longer show as `delete`