### PR TITLE
fix(edxapp): attach CORS shared plugins to meilisearch APISIX route

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/meilisearch.py
+++ b/src/ol_infrastructure/applications/edxapp/meilisearch.py
@@ -61,6 +61,18 @@ def create_meilisearch_resources(
             resource_suffix="ol-shared-plugins",
             k8s_namespace=namespace,
             k8s_labels=k8s_global_labels,
+            # OLApisixHTTPRoute attaches only the shared PluginConfig via
+            # ExtensionRef when shared_plugin_config_name is set, ignoring the
+            # route's own `plugins` list entirely -- including the request-id
+            # plugin OLApisixHTTPRouteConfig's validator would otherwise add.
+            # Include it here explicitly so tracing/correlation still works.
+            plugins=[
+                {
+                    "name": "request-id",
+                    "enable": True,
+                    "config": {"include_in_response": True},
+                },
+            ],
         ),
     )
 

--- a/src/ol_infrastructure/applications/edxapp/meilisearch.py
+++ b/src/ol_infrastructure/applications/edxapp/meilisearch.py
@@ -8,6 +8,10 @@ from pulumi import Config, ResourceOptions
 
 from bridge.lib.versions import MEILISEARCH_CHART_VERSION, MEILISEARCH_VERSION
 from bridge.secrets.sops import read_yaml_secrets
+from ol_infrastructure.components.services.apisix import (
+    OLApisixSharedPlugins,
+    OLApisixSharedPluginsConfig,
+)
 from ol_infrastructure.components.services.apisix_gateway_api import (
     OLApisixHTTPRoute,
     OLApisixHTTPRouteConfig,
@@ -50,6 +54,16 @@ def create_meilisearch_resources(
         ),
     )
 
+    meilisearch_shared_plugins = OLApisixSharedPlugins(
+        f"ol-{stack_info.env_prefix}-edxapp-meilisearch-shared-plugins-{stack_info.env_suffix}",
+        plugin_config=OLApisixSharedPluginsConfig(
+            application_name="meilisearch",
+            resource_suffix="ol-shared-plugins",
+            k8s_namespace=namespace,
+            k8s_labels=k8s_global_labels,
+        ),
+    )
+
     OLApisixHTTPRoute(
         f"ol-{stack_info.env_prefix}-edxapp-meilisearch-httproute-{stack_info.env_suffix}",
         k8s_namespace=namespace,
@@ -61,6 +75,7 @@ def create_meilisearch_resources(
                 paths=["/*"],
                 backend_service_name="meilisearch",
                 backend_service_port=7700,
+                shared_plugin_config_name=meilisearch_shared_plugins.resource_name,
                 plugins=[],
             ),
         ],


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
The meilisearch Gateway API `HTTPRoute` (defined in `src/ol_infrastructure/applications/edxapp/meilisearch.py`) had no plugin configuration attached at all — the route config was built with `plugins=[]` and no `shared_plugin_config_name`. As a result, preflight `OPTIONS` requests to the meilisearch endpoint got no `Access-Control-Allow-*` response headers, which the browser reports as a CORS failure.

Every other application in this repo that exposes a browser-facing endpoint via `OLApisixHTTPRoute` (`opik`, `ol_analytics_api`, `mit_learn`, etc.) creates an `OLApisixSharedPlugins` resource and attaches it to each route via `shared_plugin_config_name`. That shared plugin config includes, among others, the `cors` plugin (`allow_origins: "**"`, `allow_methods: "**"`, `allow_headers: "**"`, `allow_credential: true`) as well as `redirect` (http->https), `response-rewrite`, `prometheus`, and `opentelemetry`.

This PR brings meilisearch in line with that pattern:
- Creates an `OLApisixSharedPlugins` resource for the meilisearch namespace/labels.
- Passes its `resource_name` as `shared_plugin_config_name` on the meilisearch `OLApisixHTTPRouteConfig`.

Reference implementation of the shared-plugins component: https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/components/services/apisix.py#L337-L502

### Screenshots (if appropriate):
N/A - infrastructure-only change, no UI.

### How can this be tested?
- `uv run pre-commit run --files src/ol_infrastructure/applications/edxapp/meilisearch.py` passes (ruff format/check, mypy, detect-secrets, etc.)
- After deploy, confirm the `ApisixPluginConfig`/`PluginConfig` CRD named `meilisearch-ol-shared-plugins` exists in the edxapp namespace and that the meilisearch `HTTPRoute` has an `ExtensionRef` filter pointing at it.
- From a browser, issue a preflight `OPTIONS` request against the meilisearch domain and confirm `Access-Control-Allow-Origin`/`Access-Control-Allow-Methods`/`Access-Control-Allow-Headers` are present in the response, and that the original CORS error in the console is resolved.

### Additional Context
No behavior change for existing traffic patterns other than adding CORS (and the other standard shared plugins) to the meilisearch route; `allow_origins: "**"` matches the wildcard behavior used by the other apps referenced above.