### PR TITLE
fix(jupyterhub_data): restore request-id plugin on APISIX route

### DIFF
--- a/src/ol_infrastructure/applications/jupyterhub_data/deployment.py
+++ b/src/ol_infrastructure/applications/jupyterhub_data/deployment.py
@@ -283,9 +283,17 @@ def provision_jupyterhub_data_deployment(  # noqa: PLR0913
         opts=ResourceOptions(depends_on=app_vault_backend),
     )
 
-    # APISIX shared plugins (request-id, prometheus, etc.) — creates both v2
-    # ApisixPluginConfig (legacy) and v1alpha1 PluginConfig (Gateway API) resources
-    # under the same name so OLApisixHTTPRoute can reference it via ExtensionRef.
+    # APISIX shared plugins (cors, redirect, response-rewrite, prometheus,
+    # opentelemetry, request-id) — creates both v2 ApisixPluginConfig (legacy)
+    # and v1alpha1 PluginConfig (Gateway API) resources under the same name so
+    # OLApisixHTTPRoute can reference it via ExtensionRef.
+    #
+    # OLApisixHTTPRoute attaches only the shared PluginConfig via ExtensionRef
+    # when shared_plugin_config_name is set, ignoring the route's own
+    # `plugins` list entirely -- including the request-id plugin
+    # OLApisixHTTPRouteConfig's validator would otherwise add. request-id is
+    # not part of OLApisixSharedPlugins' defaults, so it's added explicitly
+    # here to keep request tracing/correlation working.
     shared_plugins = OLApisixSharedPlugins(
         name=f"ol-{base_name}-external-service-apisix-plugins",
         plugin_config=OLApisixSharedPluginsConfig(
@@ -294,6 +302,13 @@ def provision_jupyterhub_data_deployment(  # noqa: PLR0913
             k8s_namespace=namespace,
             k8s_labels=application_labels,
             enable_defaults=True,
+            plugins=[
+                {
+                    "name": "request-id",
+                    "enable": True,
+                    "config": {"include_in_response": True},
+                },
+            ],
         ),
     )
 


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up to https://github.com/mitodl/ol-infrastructure/pull/5064

### Description (What does it do?)
While addressing review feedback on #5064 (meilisearch CORS fix), reviewers (sentry and copilot-pull-request-reviewer) identified that `OLApisixHTTPRoute` (Gateway API path, `src/ol_infrastructure/components/services/apisix_gateway_api.py`) attaches **only** the shared `PluginConfig` via `ExtensionRef` when `shared_plugin_config_name` is set on a route — the route's own `plugins` list is ignored entirely, including the `request-id` plugin that `OLApisixHTTPRouteConfig`'s validator auto-adds:

https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/components/services/apisix_gateway_api.py#L502-L534

`src/ol_infrastructure/applications/jupyterhub_data/deployment.py` uses the exact same `shared_plugin_config_name` + `plugins=[]` pattern, and its existing comment (`# APISIX shared plugins (request-id, prometheus, etc.)`) incorrectly claims `request-id` is included by `OLApisixSharedPlugins`' defaults — it isn't (see the default plugin list at https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/components/services/apisix.py#L389-L423, which only has `redirect`, `cors`, `response-rewrite`, `prometheus`). So this app's deployed route has been missing request-id-based tracing/correlation.

This PR:
- Adds `request-id` explicitly to jupyterhub_data's `OLApisixSharedPluginsConfig.plugins`, matching the fix applied to meilisearch in #5064.
- Corrects the misleading comment and documents the ExtensionRef-only behavior for future readers.

### Screenshots (if appropriate):
N/A - infrastructure-only change, no UI.

### How can this be tested?
- `uv run pre-commit run --files src/ol_infrastructure/applications/jupyterhub_data/deployment.py` passes (ruff format/check, mypy, detect-secrets, etc.)
- After deploy, confirm the `PluginConfig` CRD (`apisix.apache.org/v1alpha1`) referenced by this app's `HTTPRoute` includes a `request-id` plugin entry.
- Make a request through the JupyterHub-data APISIX route and confirm an `X-Request-Id` response header is present (the `include_in_response: true` config option).

### Additional Context
No behavior change to CORS/redirect/prometheus/opentelemetry — only adds the missing `request-id` plugin. Scoped to this app rather than changing `OLApisixSharedPlugins`' shared defaults, since that would also touch opik, ol_analytics_api, and mit_learn's already-deployed `PluginConfig` resources — out of scope here.