### PR TITLE
fix(tika): bound JVM off-heap memory to stop production OOMKills

### DIFF
--- a/src/ol_infrastructure/applications/tika/__main__.py
+++ b/src/ol_infrastructure/applications/tika/__main__.py
@@ -153,6 +153,25 @@ tika_helm_release = kubernetes.helm.v3.Release(
                     "memory": "2Gi",
                 },
             },
+            # By default the JVM's container-aware ergonomics only give the
+            # heap 25% of the container memory limit (512Mi of 2Gi here),
+            # leaving the rest unclaimed while Metaspace/direct memory have no
+            # cap and can grow unbounded. That combination lets a single large
+            # or OCR-heavy document balloon off-heap and get the whole
+            # container OOMKilled by the kernel rather than the JVM raising a
+            # catchable OutOfMemoryError. Budget the full 2Gi limit instead:
+            # 1152Mi heap + 320Mi metaspace + 320Mi direct memory, leaving
+            # ~256Mi margin for thread stacks, JVM code cache, and native
+            # OCR/imagemagick subprocess memory.
+            "env": [
+                {
+                    "name": "JAVA_TOOL_OPTIONS",
+                    "value": (
+                        "-Xmx1152m -XX:MaxMetaspaceSize=320m "
+                        "-XX:MaxDirectMemorySize=320m"
+                    ),
+                },
+            ],
         },
         skip_await=False,
     ),

--- a/src/ol_infrastructure/applications/tika/__main__.py
+++ b/src/ol_infrastructure/applications/tika/__main__.py
@@ -147,22 +147,25 @@ tika_helm_release = kubernetes.helm.v3.Release(
             "resources": {
                 "requests": {
                     "cpu": "10m",  # does nothing most of the time
-                    "memory": "2Gi",  # java never gives it back
+                    "memory": "3Gi",  # java never gives it back
                 },
                 "limits": {
-                    "memory": "2Gi",
+                    "memory": "3Gi",
                 },
             },
             # By default the JVM's container-aware ergonomics only give the
-            # heap 25% of the container memory limit (512Mi of 2Gi here),
-            # leaving the rest unclaimed while Metaspace/direct memory have no
-            # cap and can grow unbounded. That combination lets a single large
-            # or OCR-heavy document balloon off-heap and get the whole
-            # container OOMKilled by the kernel rather than the JVM raising a
-            # catchable OutOfMemoryError. Budget the full 2Gi limit instead:
-            # 1152Mi heap + 320Mi metaspace + 320Mi direct memory, leaving
-            # ~256Mi margin for thread stacks, JVM code cache, and native
-            # OCR/imagemagick subprocess memory.
+            # heap 25% of the container memory limit, leaving the rest
+            # unclaimed while Metaspace/direct memory have no cap and can grow
+            # unbounded. That combination lets a single large document balloon
+            # off-heap and get the whole container OOMKilled by the kernel
+            # rather than the JVM raising a catchable OutOfMemoryError.
+            # Budget the JVM at 1152Mi heap + 320Mi metaspace + 320Mi direct
+            # memory (1792Mi total). The container limit is raised to 3Gi
+            # (rather than sized to exactly match the JVM budget) to leave
+            # ~1280Mi of headroom outside the JVM entirely: Tika's default PDF
+            # OCR strategy is AUTO, which auto-invokes the `tesseract` binary
+            # as a native subprocess for scanned/image PDF pages, and that
+            # subprocess's memory isn't bounded by any JAVA_TOOL_OPTIONS flag.
             "env": [
                 {
                     "name": "JAVA_TOOL_OPTIONS",


### PR DESCRIPTION
## Summary
- The `tika` deployment in `applications-production` has been crash-looping: both replicas are being OOMKilled (`exitCode: 137`), which trips the `DeploymentUnavailableCritical` Grafana alert.
- The JVM's default container-aware ergonomics only give the heap 25% of the container memory limit (512Mi of the original 2Gi), while Metaspace and direct memory are left uncapped — a large document can balloon off-heap memory until the kernel SIGKILLs the whole container instead of the JVM raising a catchable `OutOfMemoryError`.
- Sets `JAVA_TOOL_OPTIONS` to budget the JVM explicitly: `-Xmx1152m -XX:MaxMetaspaceSize=320m -XX:MaxDirectMemorySize=320m` (1792Mi total).
- **Follow-up commit**: review caught that these JVM flags only bound the JVM's own memory, not native subprocess memory. Tika's default PDF OCR strategy is `AUTO`, which auto-invokes the `tesseract` binary as a separate OS process for scanned/image PDF pages — that subprocess's memory is invisible to any JVM flag. Rather than disabling OCR (a functional behavior change with no visibility from this repo into whether `mit_learn`/`open_discussions` rely on it), raised the container memory request/limit from 2Gi to 3Gi, leaving ~1280Mi of headroom outside the JVM budget for native OCR/subprocess memory spikes.

## Test plan
- [x] `ruff check` / `ruff format` pass on the changed file
- [x] `pulumi preview --stack Production` run against the live `ol-application-tika` Production stack after each commit — shows only the intended `env` addition and `resources.limits/requests.memory` change to the Helm release values, 13 other resources unchanged, no errors
- [ ] After merge/deploy, confirm `tika` pods stop OOMKilling and the `DeploymentUnavailableCritical` alert resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)