### PR TITLE
fix(mitxonline): split web memory request/limit based on real usage

### DIFF
--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -516,10 +516,24 @@ secret_names, secret_resources = create_mitxonline_k8s_secrets(
 )
 
 # Webapp memory is owned by the VPA (see the VPA block at the end of this file), not
-# the HPA. `mitxonline_web_memory_limit` is only the starting/floor budget pods launch
-# with; the VPA raises requests and limits toward `mitxonline_web_memory_ceiling` based
-# on observed usage.
-mitxonline_web_memory_limit = "1200Mi"
+# the HPA. These are the starting values pods launch with; the VPA raises them toward
+# `mitxonline_web_memory_ceiling` based on observed usage -- in principle. In practice
+# the VPA updater's "don't disrupt short-lived pods" safety check appears to have
+# prevented it from ever applying its own (correct) recommendation here, since this
+# deployment is redeployed often enough that pods rarely age past that threshold. See
+# https://github.com/mitodl/ol-infrastructure/pull/XXXX for the investigation.
+#
+# request vs limit are intentionally different (Burstable QoS), not equal like most
+# other apps in this file: 7 days of container_memory_working_set_bytes history showed
+# p50=863MB, p90=1038MB, p99=1946MB, p99.9=2561MB, max=2651MB. The previous 1200Mi
+# figure, used for both request and limit, sat right around p85-90 -- meaning roughly
+# 10-15% of all samples already exceeded it, which is why OOMKilled was firing
+# regularly (confirmed via `kubectl describe pod` showing Reason: OOMKilled,
+# exitCode=137). Splitting them lets the *reservation* (request) track typical usage
+# instead of the rare worst case, while the *limit* still has enough headroom for a
+# real burst to not get killed.
+mitxonline_web_memory_request = "1000Mi"  # ~p90 of observed usage
+mitxonline_web_memory_limit = "2560Mi"  # ~p99.9 of observed usage, plus a little margin
 mitxonline_web_memory_ceiling = "3Gi"
 
 # Granian's --workers-max-rss is resolved at Pulumi synth time, so it cannot be derived
@@ -600,7 +614,7 @@ mitxonline_k8s_app = OLApplicationK8s(
             resource_requests={"cpu": "10m", "memory": "384Mi"},
             resource_limits={"memory": "384Mi"},
         ),
-        resource_requests={"cpu": "250m", "memory": mitxonline_web_memory_limit},
+        resource_requests={"cpu": "250m", "memory": mitxonline_web_memory_request},
         resource_limits={"memory": mitxonline_web_memory_limit},
         # hpa_scaling_metrics is left at the component default (CPU only). Memory is
         # managed vertically by the component's webapp VPA; the ceiling below is what


### PR DESCRIPTION
## Summary

Overnight on-call investigation of repeated `PodOOMKilledCritical` / `PodCrashLoopingCritical` / `DeploymentUnavailableCritical` pages across five apps on `applications-production` (`tika`, `learn-ai`, `mitxonline`, `micromasters`, `mitlearn`). `tika` is already covered by a separate fix (#5066). Of the rest, `mitxonline-app` showed the most extreme memory overshoot, so this PR addresses it specifically.

## What we found

- `mitxonline-app`'s container has `resource_requests == resource_limits == 1200Mi` (Guaranteed QoS) — one number doing two conflicting jobs (scheduling reservation *and* hard OOM ceiling).
- 7 days of `container_memory_working_set_bytes` for this container:

  | p50 | p75 | p90 | p95 | p99 | p99.9 | max |
  |---|---|---|---|---|---|---|
  | 863MB | 940MB | 1038MB | 1317MB | 1946MB | 2561MB | 2651MB |

  The current 1200Mi limit sits right around p85-90 — roughly 10-15% of all samples already exceed it, which is why `OOMKilled` (confirmed via `kubectl describe pod`: `Reason: OOMKilled, exitCode=137`) was firing regularly rather than being a rare fluke.
- The deployment already has a `VerticalPodAutoscaler` (`mitxonline-app-memory-vpa`) with a correct recommendation (~2.8GB target, closely matching the p99.9/max data) that's been sitting unapplied for the full 21+ hours the VPA has existed. `vertical-pod-autoscaler-updater` logs show why: every reconcile loop logs `"Not updating a short-lived pod, request within recommended range"` for every `mitxonline-app` pod. The updater's "don't disrupt short-lived pods" safety check appears to structurally prevent it from ever correcting this, since the deployment is redeployed often enough that pods rarely age past whatever threshold it uses. Not a bug in the VPA — just a gap this specific deploy cadence falls into.

## What this changes

Splits `requests` from `limits` (Burstable QoS) instead of raising both to cover the worst case, matching the actual usage shape (mostly steady, occasionally spiky):

- `requests.memory`: `1200Mi` → `1000Mi` (~p90 — the scheduling reservation now tracks typical usage instead of over-reserving cluster capacity 24/7 across all replicas)
- `limits.memory`: `1200Mi` → `2560Mi` (~p99.9 + a little margin — enough headroom that a real burst doesn't get OOM-killed)

The VPA's own `max_allowed` ceiling (`3Gi`) is untouched, and its `minAllowed` will automatically follow the new lower request. `controlledValues: RequestsAndLimits` (hardcoded in the shared `make_vpa` helper) scales both proportionally without requiring them to be equal, so no VPA config changes were needed.

## Test plan

- [x] `pulumi preview --diff` against Production shows exactly the intended 4 resources: the `mitxonline-app` container's `resources` on the Deployment, the pre-deploy migration Job (requires a **replace**, not an update — Job pod specs are immutable in Kubernetes, expected), and the VPA's `minAllowed` following the new request.
- [x] Confirmed no other unintended drift from this change.
- ⚠️ **Heads up for whoever applies this:** the same preview also shows two pre-existing, unrelated Fastly resource diffs (a `gzip` content-type list reordering, a TLS subscription `configurationId` change) — these predate this branch and aren't part of this PR; don't be surprised if they show up in the plan.
- [ ] After deploy: confirm no `OOMKilled` events for `mitxonline-app` over the following few days, and spot-check actual memory usage settles comfortably under the new 2560Mi limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)