### PR TITLE
fix(mit-learn-nextjs): set --max-old-space-size to stop recurring V8 heap OOM crashes

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
@@ -69,6 +69,13 @@ nextjs_config = Config("nextjs")
 # default. NEXTJS_NON_HEAP_OVERHEAD_MIB reserves headroom within the same limit for
 # non-heap V8/Node needs (code cache, native buffers, thread stacks) that sit outside
 # the old-space budget.
+#
+# This is a fixed MiB amount rather than a percentage of the limit on purpose:
+# non-heap overhead is driven by concurrency/workload shape, not by how much memory
+# the container happens to have, so it doesn't scale with the limit. A fixed reserve
+# means raising nextjs_memory_limit later hands all of the added memory straight to
+# the heap (the actual thing that needs more room); a percentage would keep skimming
+# an ever-larger, unneeded slice off the top as the limit grows.
 nextjs_memory_limit = "1Gi"
 NEXTJS_NON_HEAP_OVERHEAD_MIB = 224
 nextjs_max_old_space_size_mib = (

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
@@ -1,6 +1,7 @@
 """Pulumi program for deploying the MIT Learn Next.js application to Kubernetes."""
 
 import pulumi_kubernetes as kubernetes
+from kubernetes.utils.quantity import parse_quantity
 from pulumi import Config, ResourceOptions, export
 
 from bridge.lib.magic_numbers import DEFAULT_NEXTJS_PORT
@@ -59,6 +60,22 @@ cluster_stack.require_output("namespaces").apply(
 
 nextjs_config = Config("nextjs")
 
+# Node (v24) auto-sizes its default heap ceiling from the container's cgroup memory
+# limit, but production logs show it consistently landing around ~500MiB and crashing
+# with "FATAL ERROR: ... JavaScript heap out of memory" (exit 139) roughly every 90
+# minutes per pod under normal, steady request volume -- well short of the 1Gi this
+# container is actually allowed. Setting --max-old-space-size explicitly makes V8 use
+# the memory it's already been granted instead of self-limiting to a much lower
+# default. NEXTJS_NON_HEAP_OVERHEAD_MIB reserves headroom within the same limit for
+# non-heap V8/Node needs (code cache, native buffers, thread stacks) that sit outside
+# the old-space budget.
+nextjs_memory_limit = "1Gi"
+NEXTJS_NON_HEAP_OVERHEAD_MIB = 224
+nextjs_max_old_space_size_mib = (
+    int(parse_quantity(nextjs_memory_limit)) // (1024 * 1024)
+    - NEXTJS_NON_HEAP_OVERHEAD_MIB
+)
+
 stay_updated_hubspot_form_ids = {
     "ci": "f201f3af-c2c0-4b7d-b297-ddbb75912cc1",
     "qa": "f201f3af-c2c0-4b7d-b297-ddbb75912cc1",
@@ -73,6 +90,7 @@ except KeyError as exc:
 
 raw_env_vars = {
     # Env vars available only on server
+    "NODE_OPTIONS": f"--max-old-space-size={nextjs_max_old_space_size_mib}",
     "MITOL_NOINDEX": nextjs_config.get("mitol_noindex"),
     "NEXT_PUBLIC_OPTIMIZE_IMAGES": nextjs_config.get("optimize_images"),
     "GTM_TRACKING_ID": nextjs_config.get("gtm_tracking_id") or "",
@@ -221,8 +239,8 @@ mit_learn_nextjs_deployment = kubernetes.apps.v1.Deployment(
                         ],
                         image_pull_policy="Always",
                         resources=kubernetes.core.v1.ResourceRequirementsArgs(
-                            requests={"cpu": "100m", "memory": "1Gi"},
-                            limits={"memory": "1Gi"},
+                            requests={"cpu": "100m", "memory": nextjs_memory_limit},
+                            limits={"memory": nextjs_memory_limit},
                         ),
                         env=env_vars,
                         liveness_probe=kubernetes.core.v1.ProbeArgs(


### PR DESCRIPTION
## Summary

Investigating an `HPAAtMaxReplicasCritical` Rootly alert led to noticing that all 5 `mit-learn-nextjs` Production pods were actively crash-looping (`0/1 Ready`, ~14-15 restarts/pod in the last 24h). This isn't the same issue previously identified and set aside for this app (a liveness-probe kill, exit 137) — this is a distinct, real memory problem:

- 4 of 5 pods' last termination was **exit 139**, with the previous container's logs showing:
  ```
  FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
  ```
- Every crash across every pod hits almost exactly the same V8 heap size (~495-525MB), every time — a deterministic ceiling, not random spikes.
- The container has a **1Gi memory limit** and no `NODE_OPTIONS`/`--max-old-space-size` set, so Node (v24) auto-sizes its heap based on the cgroup limit and lands around ~500MB — leaving roughly half the container's actual memory allowance unused.
- Checked request volume via Loki over the preceding 12h: steady ~25-30 req/s baseline (with only a mild ~20-30% uptick during the investigation window), ruling out a traffic-spike/bot-storm explanation. This is a steady-state issue, not an anomaly-triggered one.

Raising the container memory limit alone would not fix this — the pod already has 1Gi and is only using about half of it before crashing, so the limit was never the binding constraint. The fix is making Node actually use the memory it already has.

## Change

Set `NODE_OPTIONS=--max-old-space-size=<N>` on the `nextjs-app` container, where `<N>` is derived from the existing `1Gi` memory limit minus a fixed reserve (`NEXTJS_NON_HEAP_OVERHEAD_MIB = 224`) for non-heap V8/Node needs (code cache, native buffers, thread stacks) that sit outside the old-space budget. Currently resolves to `800`.

The memory limit itself is unchanged (still `1Gi`) — just pulled into a named `nextjs_memory_limit` variable so the derived heap value and the container limit share one source of truth.

## Verification

- `pulumi preview --diff` against Production shows exactly the expected diff: one new env var inserted (causing the whole `env` list to show as shifted, which is normal for list-typed Kubernetes fields) and no change to `resources` (same literal value, now referenced via the variable).
- There's a pre-existing, unrelated diff on the `HTTPRoute` resource (`matches: <null>`) surfaced by the same preview — not touched by this change, appears to be drift unrelated to this PR.

## Test plan

- [ ] Deploy to Production
- [ ] Confirm `kubectl get pods -n mitlearn -l app=mit-learn-nextjs` shows `1/1 Ready` and restart counts stop climbing
- [ ] Watch for `JavaScript heap out of memory` recurring in logs over the following 24h at the new ceiling — if it still happens, that's a signal of an actual leak rather than just heap starvation, and the container memory limit itself may need to increase alongside a correspondingly higher `--max-old-space-size`

🤖 Generated with [Claude Code](https://claude.com/claude-code)