### PR TITLE
Add new ai+d course repos

### DIFF
--- a/src/ol_concourse/pipelines/container_images/jupyter_courses.py
+++ b/src/ol_concourse/pipelines/container_images/jupyter_courses.py
@@ -162,6 +162,21 @@ courses = [
         repo_uri="git@github.mit.edu:ol-notebooks/UAI_SOURCE-UAI.15-1T2026.git",
         image_name="uai_source-uai.15",
     ),
+    CourseImageInfo(
+        course_name="mitxt-6.3710.3x",
+        repo_uri="git@github.mit.edu:ol-notebooks/MITxT-6.3710.3x-2T2026.git",
+        image_name="mitxt-6.3710.3x",
+    ),
+    CourseImageInfo(
+        course_name="mitxt-6.3710.4x",
+        repo_uri="git@github.mit.edu:ol-notebooks/MITxT-6.3710.4x-2T2026.git",
+        image_name="mitxt-6.3710.4x",
+    ),
+    CourseImageInfo(
+        course_name="mitxt-6.3710.5x",
+        repo_uri="git@github.mit.edu:ol-notebooks/MITxT-6.3710.5x-2T2026.git",
+        image_name="mitxt-6.3710.5x",
+    ),
 ]
 
 # This infers the ECR url from the AWS account,

--- a/src/ol_infrastructure/applications/jupyterhub/__main__.py
+++ b/src/ol_infrastructure/applications/jupyterhub/__main__.py
@@ -190,6 +190,9 @@ COURSE_NAMES = [
     "supervised_learning_fundamentals",
     "introduction_to_data_analytics_and_machine_learning",
     "base_authoring_image",
+    "mitxt-6.3710.3x",
+    "mitxt-6.3710.4x",
+    "mitxt-6.3710.5x",
 ]
 COURSE_NAMES.extend(
     [

--- a/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
+++ b/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
@@ -20,6 +20,9 @@ KNOWN_COURSES = [
     "supervised_learning_fundamentals",
     "introduction_to_data_analytics_and_machine_learning",
     "base_authoring_image",
+    "mitxt-6.3710.3x",
+    "mitxt-6.3710.4x",
+    "mitxt-6.3710.5x",
 ]
 # We have notebooks in UAI courses 6-13, excluding 10
 KNOWN_COURSES.extend(


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11190

### Description (What does it do?)
Adds new course repos to concourse build pipeline and known images in jupyterhub deployment. The concourse pipeline changes are already in place (see [this](https://cicd.odl.mit.edu/teams/infrastructure/pipelines/jupyter_notebook_docker_image_build/jobs/build-and-publish-container/builds/1?vars.image_name=%22mitxt-6.3710.5x%22) for an example)

Pulumi up output
```
    ~ kubernetes:helm.sh/v3:Release: (update)
        [id=jupyter-authoring/jupyterhub-authoring]
        [urn=urn:pulumi:CI::ol-application-jupyterhub::kubernetes:helm.sh/v3:Release::jupyterhub-authoring-CI-application-helm-release]
        [provider=urn:pulumi:CI::ol-application-jupyterhub::pulumi:providers:kubernetes::k8s-provider::5f3a8ac8-372e-491d-b910-ae7a4854e30c]
      ~ values: {
          ~ hub: {
              ~ extraConfig: {
                  ~ dynamicImageConfig.py: 
                        ...
                            "introduction_to_data_analytics_and_machine_learning",
                            "base_authoring_image",
                      +     "mitxt-6.3710.3x",
                      +     "mitxt-6.3710.4x",
                      +     "mitxt-6.3710.5x",
                        ]
                        # We have notebooks in UAI courses 6-13, excluding 10
                        ...
                }
            }
        }
    ~ kubernetes:helm.sh/v3:Release: (update)
        [id=jupyter/jupyterhub]
        [urn=urn:pulumi:CI::ol-application-jupyterhub::kubernetes:helm.sh/v3:Release::jupyterhub-CI-application-helm-release]
        [provider=urn:pulumi:CI::ol-application-jupyterhub::pulumi:providers:kubernetes::k8s-provider::5f3a8ac8-372e-491d-b910-ae7a4854e30c]
      ~ values: {
          ~ hub      : {
              ~ extraConfig: {
                  ~ dynamicImageConfig.py: 
                        ...
                            "introduction_to_data_analytics_and_machine_learning",
                            "base_authoring_image",
                      +     "mitxt-6.3710.3x",
                      +     "mitxt-6.3710.4x",
                      +     "mitxt-6.3710.5x",
                        ]
                        # We have notebooks in UAI courses 6-13, excluding 10
                        ...
                }
            }
          ~ prePuller: {
              ~ extraImages: {
                  + mitxt-6-3710-3x: {
                      + name: "610119931565.dkr.ecr.us-east-1.amazonaws.com/ol-course-notebooks"
                      + tag : "mitxt-6.3710.3x"
                    }
                  + mitxt-6-3710-4x: {
                      + name: "610119931565.dkr.ecr.us-east-1.amazonaws.com/ol-course-notebooks"
                      + tag : "mitxt-6.3710.4x"
                    }
                  + mitxt-6-3710-5x: {
                      + name: "610119931565.dkr.ecr.us-east-1.amazonaws.com/ol-course-notebooks"
                      + tag : "mitxt-6.3710.5x"
                    }
                }
            }
        }
```