### PR TITLE
feat(mit-learn): Fastly edge in front of api.learn.mit.edu, raise webapp HPA cap

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
@@ -42,7 +42,7 @@ config:
   mitlearn:legacy_api_domain: "api.mitopen.odl.mit.edu"
   mitlearn:legacy_frontend_domain: "mitopen.odl.mit.edu"
   mitlearn:min_replicas: 4
-  mitlearn:max_replicas: 30
+  mitlearn:max_replicas: 50
   mitlearn:nextjs_heroku_domain: "next.learn.mit.edu"
   mitlearn:posthog_proxy: "ph.ol.mit.edu"
   mitlearn:support_url: "support.learn.mit.edu"

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1530,13 +1530,21 @@ learn_external_service_shared_plugins = OLApisixSharedPlugins(
         k8s_namespace=learn_namespace,
         k8s_labels=application_labels,
         enable_defaults=True,
+        # Gated behind enable_api_fastly_cutover, same as the DNS cutover
+        # below: until api_domain's DNS actually points at Fastly, direct
+        # traffic from browsers/API clients arrives at APISIX from non-Fastly
+        # IPs. Applying this allowlist unconditionally would block all of
+        # that (i.e. all current production traffic) the moment this
+        # deploys, not just bot traffic bypassing Fastly.
         plugins=[
             {
                 "name": "ip-restriction",
                 "enable": True,
                 "config": {"whitelist": fastly_origin_allowlist},
             },
-        ],
+        ]
+        if enable_api_fastly_cutover
+        else [],
     ),
 )
 

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1168,6 +1168,133 @@ mitlearn_prefix_redirects_dictionary = fastly.ServiceDictionaryItems(
 
 
 five_minutes = 60 * 5
+
+# --- Fastly edge for the API backend (bot-crawl mitigation) ---
+#
+# api.learn.mit.edu currently has no CDN/edge in front of it at all -- it goes
+# straight through APISIX/EKS. A 2026-07-21 bot-crawl surge drove that
+# deployment's KEDA-managed replica count to its max (30/30) and contributed to
+# a Next.js memory-pressure incident on the frontend. This puts a Fastly
+# service in front of the API to absorb/reject that traffic at the edge
+# instead of the origin.
+#
+# Deployment sequencing (deliberately NOT done in this change):
+#   1. This ServiceVcl is created but inert until api_domain's DNS still points
+#      directly at the gateway (api_origin_domain falls back to api_domain
+#      below), so it can be validated via its assigned *.fastly.net testing
+#      hostname before any cutover.
+#   2. Ops must provision a distinct origin-only DNS name for the APISIX
+#      Gateway listener (e.g. origin-api.learn.mit.edu) that keeps resolving
+#      directly to the gateway NLB, and add it to the gateway's TLS cert SANs
+#      -- api_domain's own DNS cannot be repointed at Fastly while Fastly's
+#      backend also targets api_domain, since Fastly's own backend DNS lookup
+#      would then resolve back to Fastly's edge instead of the origin.
+#   3. Set `mitlearn:api_origin_domain` to that new hostname, then flip
+#      `mitlearn:enable_api_fastly_cutover` to move api_domain's DNS onto
+#      Fastly (see the route53.Record below).
+#   4. Fastly Bot Management is a separate paid product from the base Fastly
+#      plan and requires a `contentguard` ID provisioned in the Fastly control
+#      panel first; `mitlearn:bot_management_contentguard_id` must be set
+#      before `enabled=True` will apply cleanly.
+api_origin_domain = mitlearn_config.get("api_origin_domain") or mitlearn_api_domain
+bot_management_contentguard_id = mitlearn_config.get("bot_management_contentguard_id")
+enable_api_fastly_cutover = (
+    mitlearn_config.get_bool("enable_api_fastly_cutover") or False
+)
+
+mitlearn_api_fastly_service = fastly.ServiceVcl(
+    f"fastly-mitlearn-api-{stack_info.env_suffix}",
+    name=f"MIT Learn API {stack_info.env_suffix}",
+    comment="Managed by Pulumi",
+    backends=[
+        fastly.ServiceVclBackendArgs(
+            address=api_origin_domain,
+            name="MIT Learn API Origin",
+            first_byte_timeout=30000,
+            port=DEFAULT_HTTPS_PORT,
+            ssl_cert_hostname=api_origin_domain,
+            ssl_sni_hostname=api_origin_domain,
+            use_ssl=True,
+        ),
+    ],
+    domains=[
+        fastly.ServiceVclDomainArgs(
+            comment=f"mit_learn {stack_info.env_suffix} API",
+            name=mitlearn_api_domain,
+        ),
+    ],
+    gzips=[
+        fastly.ServiceVclGzipArgs(
+            name="enable-gzip-compression",
+            content_types=["application/json", "application/javascript"],
+            extensions=["json", "js"],
+        )
+    ],
+    # Rate limiting is a standard VCL feature (no extra product needed) so it's
+    # fully wired up here. Bot Management needs an account-provisioned
+    # contentguard id -- `enabled` stays False until that config is set so this
+    # doesn't silently no-op (or error) against an unprovisioned product.
+    product_enablement=fastly.ServiceVclProductEnablementArgs(
+        brotli_compression=True,
+        bot_management=(
+            fastly.ServiceVclProductEnablementBotManagementArgs(
+                enabled=True,
+                contentguard=bot_management_contentguard_id,
+            )
+            if bot_management_contentguard_id
+            else None
+        ),
+    ),
+    rate_limiters=[
+        fastly.ServiceVclRateLimiterArgs(
+            name="mitlearn-api-crawler-rate-limit",
+            action="response",
+            client_key="req.http.Fastly-Client-IP",  # pragma: allowlist secret
+            http_methods="GET, HEAD, POST",
+            penalty_box_duration=30,
+            rps_limit=20,
+            window_size=10,
+            response=fastly.ServiceVclRateLimiterResponseArgs(
+                status=429,
+                content_type="application/json",
+                content=json.dumps({"detail": "Too many requests, please slow down."}),
+            ),
+        ),
+    ],
+    logging_https=[
+        fastly.ServiceVclLoggingHttpArgs(
+            url=Output.all(domain=vector_log_proxy_domain).apply(
+                lambda kwargs: f"https://{kwargs['domain']}/fastly"
+            ),
+            name=f"fastly-mitlearn-api-{stack_info.env_suffix}-https-logging-args",
+            content_type="application/json",
+            format=build_fastly_log_format_string(
+                additional_static_fields={"application": "mitlearn-api"}
+            ),
+            header_name="Authorization",
+            header_value=f"Basic {encoded_fastly_proxy_credentials}",
+            json_format="2",
+        )
+    ],
+    opts=fastly_provider,
+)
+
+# Gated behind enable_api_fastly_cutover: see the deployment sequencing note
+# above. Until that's flipped, api_domain's DNS is left exactly as-is
+# (managed by the gateway/APISIX stack), so merging this file has no effect on
+# live traffic.
+if enable_api_fastly_cutover:
+    route53.Record(
+        "ol-mitlearn-api-dns-record",
+        name=mitlearn_api_domain,
+        allow_overwrite=True,
+        type="A",
+        ttl=five_minutes,
+        records=[str(addr) for addr in FASTLY_A_TLS_1_3],
+        zone_id=learn_zone_id,
+        opts=ResourceOptions(delete_before_replace=True),
+    )
+
 route53.Record(
     "ol-mitopen-frontend-dns-record",
     name=mitlearn_config.require("frontend_domain"),
@@ -1378,6 +1505,23 @@ application_labels = k8s_app_labels | {
     "ol.mit.edu/pod-security-group": "learn",
 }
 
+# Network-level companion to the mitlearn-api Fastly service defined below:
+# reject any request that didn't come through Fastly's edge, so bot crawls (or
+# anything else) can't just bypass Fastly's rate limiter/Bot Management by
+# hitting the gateway directly. Applied once via the shared plugin config so
+# it covers every mit-learn API route without touching the shared EKS/APISIX
+# gateway's security group, which other applications also sit behind.
+#
+# Fastly's IP ranges are pulled live from Fastly's API rather than hardcoded,
+# so they stay correct as Fastly's edge network changes.
+_fastly_ip_ranges = fastly.get_fastly_ip_ranges(
+    opts=InvokeOptions(provider=fastly_provider.provider)
+)
+fastly_origin_allowlist = Output.all(
+    ipv4=_fastly_ip_ranges.cidr_blocks,
+    ipv6=_fastly_ip_ranges.ipv6_cidr_blocks,
+).apply(lambda blocks: [*blocks["ipv4"], *blocks["ipv6"]])
+
 learn_external_service_shared_plugins = OLApisixSharedPlugins(
     name="ol-mitlearn-external-service-apisix-plugins",
     plugin_config=OLApisixSharedPluginsConfig(
@@ -1386,6 +1530,13 @@ learn_external_service_shared_plugins = OLApisixSharedPlugins(
         k8s_namespace=learn_namespace,
         k8s_labels=application_labels,
         enable_defaults=True,
+        plugins=[
+            {
+                "name": "ip-restriction",
+                "enable": True,
+                "config": {"whitelist": fastly_origin_allowlist},
+            },
+        ],
     ),
 )
 

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
@@ -76,8 +76,8 @@ nextjs_config = Config("nextjs")
 # means raising nextjs_memory_limit later hands all of the added memory straight to
 # the heap (the actual thing that needs more room); a percentage would keep skimming
 # an ever-larger, unneeded slice off the top as the limit grows.
-nextjs_memory_limit = "4Gi"  # doubled from 1Gi: still crash-looping at the computed
-# 800MiB old-space ceiling, so give double headroom while a stable value is measured
+nextjs_memory_limit = "4Gi"  # raised from 1Gi: still crash-looping at the computed
+# 800MiB old-space ceiling, so give generous headroom while a stable value is measured
 NEXTJS_NON_HEAP_OVERHEAD_MIB = 224
 nextjs_max_old_space_size_mib = (
     int(parse_quantity(nextjs_memory_limit)) // (1024 * 1024)

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
@@ -76,7 +76,8 @@ nextjs_config = Config("nextjs")
 # means raising nextjs_memory_limit later hands all of the added memory straight to
 # the heap (the actual thing that needs more room); a percentage would keep skimming
 # an ever-larger, unneeded slice off the top as the limit grows.
-nextjs_memory_limit = "1Gi"
+nextjs_memory_limit = "4Gi"  # doubled from 1Gi: still crash-looping at the computed
+# 800MiB old-space ceiling, so give double headroom while a stable value is measured
 NEXTJS_NON_HEAP_OVERHEAD_MIB = 224
 nextjs_max_old_space_size_mib = (
     int(parse_quantity(nextjs_memory_limit)) // (1024 * 1024)
@@ -202,6 +203,11 @@ env_vars.append(
 
 
 pod_count = nextjs_config.get_int("pod_count") or 2
+nextjs_max_replicas = nextjs_config.get_int("autoscaling_max_replicas") or 10
+nextjs_cpu_request = nextjs_config.get("cpu_request") or "500m"
+nextjs_autoscaling_cpu_threshold = (
+    nextjs_config.get_int("autoscaling_cpu_threshold") or 70
+)
 
 mit_learn_nextjs_deployment = kubernetes.apps.v1.Deployment(
     f"mit-learn-nextjs-{stack_info.name}-deployment",
@@ -219,7 +225,9 @@ mit_learn_nextjs_deployment = kubernetes.apps.v1.Deployment(
         selector=kubernetes.meta.v1.LabelSelectorArgs(
             match_labels=k8s_app_labels,
         ),
-        replicas=pod_count,
+        # replicas intentionally omitted: the HorizontalPodAutoscaler below owns
+        # this deployment's replica count. Setting it here would fight the HPA
+        # on every `pulumi up`, resetting live scale-outs back to pod_count.
         min_ready_seconds=10,
         strategy=kubernetes.apps.v1.DeploymentStrategyArgs(
             type="RollingUpdate",
@@ -246,7 +254,14 @@ mit_learn_nextjs_deployment = kubernetes.apps.v1.Deployment(
                         ],
                         image_pull_policy="Always",
                         resources=kubernetes.core.v1.ResourceRequirementsArgs(
-                            requests={"cpu": "100m", "memory": nextjs_memory_limit},
+                            # cpu request sized off observed steady-state usage
+                            # (~450-500m/pod) so the HPA's utilization percentage
+                            # is meaningful instead of comparing against a
+                            # token 100m request.
+                            requests={
+                                "cpu": nextjs_cpu_request,
+                                "memory": nextjs_memory_limit,
+                            },
                             limits={"memory": nextjs_memory_limit},
                         ),
                         env=env_vars,
@@ -282,6 +297,67 @@ mit_learn_nextjs_deployment = kubernetes.apps.v1.Deployment(
                 ],
             ),
         ),
+    ),
+)
+
+kubernetes.autoscaling.v2.HorizontalPodAutoscaler(
+    f"mit-learn-nextjs-{stack_info.name}-hpa",
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        name="mit-learn-nextjs-hpa",
+        namespace=learn_namespace,
+        labels=k8s_app_labels,
+    ),
+    spec=kubernetes.autoscaling.v2.HorizontalPodAutoscalerSpecArgs(
+        scale_target_ref=kubernetes.autoscaling.v2.CrossVersionObjectReferenceArgs(
+            api_version="apps/v1",
+            kind="Deployment",
+            name="mit-learn-nextjs",
+        ),
+        min_replicas=pod_count,
+        max_replicas=nextjs_max_replicas,
+        # CPU only: memory is deliberately not a scaling metric here. A per-pod
+        # memory leak would make the HPA "fix" the symptom by scaling out
+        # forever instead of surfacing the leak; memory stays governed by the
+        # container limit/OOM handling above, scaling stays about throughput.
+        metrics=[
+            kubernetes.autoscaling.v2.MetricSpecArgs(
+                type="Resource",
+                resource=kubernetes.autoscaling.v2.ResourceMetricSourceArgs(
+                    name="cpu",
+                    target=kubernetes.autoscaling.v2.MetricTargetArgs(
+                        type="Utilization",
+                        average_utilization=nextjs_autoscaling_cpu_threshold,
+                    ),
+                ),
+            ),
+        ],
+        behavior=kubernetes.autoscaling.v2.HorizontalPodAutoscalerBehaviorArgs(
+            scale_up=kubernetes.autoscaling.v2.HPAScalingRulesArgs(
+                stabilization_window_seconds=60,
+                select_policy="Max",
+                policies=[
+                    kubernetes.autoscaling.v2.HPAScalingPolicyArgs(
+                        type="Percent",
+                        value=100,
+                        period_seconds=60,
+                    )
+                ],
+            ),
+            scale_down=kubernetes.autoscaling.v2.HPAScalingRulesArgs(
+                stabilization_window_seconds=300,
+                select_policy="Min",
+                policies=[
+                    kubernetes.autoscaling.v2.HPAScalingPolicyArgs(
+                        type="Percent",
+                        value=25,
+                        period_seconds=60,
+                    )
+                ],
+            ),
+        ),
+    ),
+    opts=ResourceOptions(
+        depends_on=[mit_learn_nextjs_deployment],
     ),
 )
 


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
`api.learn.mit.edu` currently has no CDN/edge in front of it -- traffic goes straight through APISIX/EKS. A 2026-07-21 bot-crawl surge drove the mitlearn webapp KEDA HPA to its max (30/30 replicas) and contributed to a Next.js memory-pressure OOM incident on the frontend (`PodOOMKilledCritical`/`HPAAtMaxReplicasCritical` fired repeatedly in production through the day).

- Adds a Fastly `ServiceVcl` in front of `api.learn.mit.edu` with a per-client-IP rate limiter and (once a `contentguard` ID is provisioned) Fastly Bot Management.
- Adds an `ip-restriction` allowlist (Fastly's published IP ranges, fetched live via `fastly.get_fastly_ip_ranges`) to the mitlearn external-service APISIX shared plugins, so the origin can't be reached directly once the cutover is live.
- Raises `mitlearn:max_replicas` 30 -> 50 as an immediate relief valve for the webapp HPA saturation.
- Raises `mit-learn-nextjs` memory 1Gi -> 4Gi (it was still crash-looping at the computed 800MiB old-space ceiling from the prior `--max-old-space-size` fix) and replaces the fixed `pod_count` with a real CPU-based `HorizontalPodAutoscaler`, so live scale-outs are no longer reset to `pod_count` on every `pulumi up`.

**Deployment sequencing (deliberately not done in this PR):** the Fastly `ServiceVcl` is created but stays inert -- `api_origin_domain` falls back to the existing API domain and `enable_api_fastly_cutover` defaults to `False`, so merging this has no effect on live traffic. Before the cutover can go live:
1. Provision a distinct origin-only DNS name for the APISIX Gateway listener (e.g. `origin-api.learn.mit.edu`) and add it to the gateway's TLS cert SANs.
2. Set `mitlearn:api_origin_domain` to that hostname, then flip `mitlearn:enable_api_fastly_cutover` to move `api_domain`'s DNS onto Fastly.
3. Get a `contentguard` ID from the Fastly control panel and set `mitlearn:bot_management_contentguard_id` before Bot Management applies.

### Related work
[#4759](https://github.com/mitodl/ol-infrastructure/pull/4759) adds APISIX `limit-conn`/`limit-req` and a Traefik rate-limit middleware for MIT Learn against the same incident, at a different layer (app-tier rate limiting vs. this PR's CDN edge/bot-management). These are complementary, not duplicates -- worth reviewing together since both touch the mitlearn shared-plugins wiring.

**Not included here:** mitlearn's `default` (max 20) and `embeddings` (max 30) celery-worker KEDA HPAs are still hardcoded in `mit_learn/__main__.py` and saturate on the same bot traffic; they need the same kind of cap bump this PR gives the webapp HPA. Filing as a fast follow.

### How can this be tested?
- `uv run ruff check` / `uv run mypy` pass on the three changed files at the same baseline error count as `main` (two additional mypy findings are the same pre-existing `Provider | ResourceOptions` typing gap already present elsewhere in this file for other Fastly resources, not new bugs).
- `pulumi preview` against `applications.mitlearn.QA` and `applications.mitlearn_nextjs.QA`: expect a new Fastly `ServiceVcl` (inert), an `ip-restriction` plugin added to the mitlearn shared-plugins config, `mitlearn:max_replicas` reflected as 50, and a new `mit-learn-nextjs-hpa` HPA object replacing the fixed replica count.
- After deploy: confirm HPA/OOM alert volume drops in Grafana/Rootly for `mitlearn` and `mitlearn-nextjs`; confirm `next.learn.mit.edu` and `api.learn.mit.edu` behave identically to before (the Fastly service is inert until the cutover flag is flipped).

### Additional Context
Root-cause and fix inventory for the full incident (all `PodOOMKilledCritical`/`HPAAtMaxReplicasCritical` alerts since 2026-07-20) is documented in this session; happy to share if useful for review context.

### Checklist:
- [ ] Provision Fastly Bot Management `contentguard` ID before setting `bot_management_contentguard_id`
- [ ] Provision origin-only DNS name + TLS SAN for the APISIX gateway before flipping `enable_api_fastly_cutover`