### PR TITLE
fix(grafana-alerting): exclude fixed-replica HPAs from HPAAtMaxReplicas rule

### DIFF
--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
@@ -300,6 +300,13 @@ def create(
             # --- HPA at max replicas ---
             # Fires when an HPA has been at its maximum replica count for 15m,
             # meaning the workload cannot scale further under load.
+            #
+            # Excludes HPAs where min_replicas == max_replicas (e.g. a
+            # single-fixed-replica HPA with min=max=1): those are permanently
+            # "at max" by construction, so the condition is always true and
+            # carries no signal about the workload actually being saturated.
+            # Observed in production 2026-07: xqwatcher's HPAs (min=max=1)
+            # fired this rule continuously, unrelated to any real incident.
             alerting.RuleGroupRuleArgs(
                 name="HPAAtMaxReplicasWarning",
                 condition="C",
@@ -310,7 +317,7 @@ def create(
                     "description": "HPA {{ $labels.horizontalpodautoscaler }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has been at its maximum replica count for 15 minutes. The workload may be unable to scale further under load."
                 },
                 datas=rd(
-                    'sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_status_current_replicas{cluster=~".*-(ci|qa)"}) >= sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_spec_max_replicas{cluster=~".*-(ci|qa)"})'
+                    'sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_status_current_replicas{cluster=~".*-(ci|qa)"}) >= sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_spec_max_replicas{cluster=~".*-(ci|qa)"}) and sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_spec_max_replicas{cluster=~".*-(ci|qa)"}) != sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_spec_min_replicas{cluster=~".*-(ci|qa)"})'
                 ),
             ),
             alerting.RuleGroupRuleArgs(
@@ -323,7 +330,7 @@ def create(
                     "description": "HPA {{ $labels.horizontalpodautoscaler }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has been at its maximum replica count for 15 minutes. The workload may be unable to scale further under load."
                 },
                 datas=rd(
-                    'sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_status_current_replicas{cluster=~".*-(production)"}) >= sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_spec_max_replicas{cluster=~".*-(production)"})'
+                    'sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_status_current_replicas{cluster=~".*-(production)"}) >= sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_spec_max_replicas{cluster=~".*-(production)"}) and sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_spec_max_replicas{cluster=~".*-(production)"}) != sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_spec_min_replicas{cluster=~".*-(production)"})'
                 ),
             ),
         ],


### PR DESCRIPTION
### What are the relevant tickets?
N/A -- follow-on from investigating the 2026-07-20/21 PodOOMKilledCritical/HPAAtMaxReplicasCritical alert storm.

### Description (What does it do?)
`HPAAtMaxReplicasWarning`/`Critical` (`src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py`) fire whenever `current_replicas >= max_replicas` for 15 minutes, with no check on whether the HPA can actually scale any further.

An HPA with `min_replicas == max_replicas` (e.g. `mitxonline-openedx`'s `xqwatcher`/`xqwatcher-edxorg` HPAs in production, both pinned at `min=max=1`) is "at max" by construction, so this condition is permanently true for it. That HPA fired `HPAAtMaxReplicasCritical` to Rootly essentially continuously, unrelated to any real scaling/load incident -- pure noise that also made it harder to see the real HPA-saturation signal (mitlearn's webapp/celery-worker HPAs genuinely pegged at max during the bot-crawl incident) in the same alert stream.

This adds an `and (spec_max_replicas != spec_min_replicas)` clause (per HPA series) to both the Warning and Critical rules, so they only fire for HPAs that have actual scaling headroom to exhaust.

### How can this be tested?
- `uv run ruff check` / `uv run mypy` pass clean on the changed file.
- `pulumi preview` against the CI/QA/Production `grafana_alerting` stacks: expect only the two rule expressions in the `general` rule group to change (additional `and` clause appended), no other diff.
- After deploy: confirm `xqwatcher`'s HPAs stop appearing in `HPAAtMaxReplicasCritical`/`Warning` alert groups in Grafana, while genuinely-saturated HPAs (min < max, pegged at max) still fire normally.

### Additional Context
Found while triaging the OOM/HPA alert storm on 2026-07-21; see [#5071](https://github.com/mitodl/ol-infrastructure/pull/5071) for the mitlearn-side fixes to the actual saturation this rule was (correctly, in that case) flagging.