### PR TITLE
fix(eks): raise applications-production apisix_max_replicas 10 -> 16

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.applications.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.applications.Production.yaml
@@ -45,7 +45,7 @@ config:
   - video.odl.mit.edu
   - xpro-web.odl.mit.edu
   eks:apisix_min_replicas: '5'
-  eks:apisix_max_replicas: '10'
+  eks:apisix_max_replicas: '16'
   eks:apisix_memory: 1500Mi
   eks:developer_role_policy_name: AmazonEKSClusterAdminPolicy
   eks:developer_role_kubernetes_groups:


### PR DESCRIPTION
### What are the relevant tickets?
N/A -- found while investigating APISIX OOMKills/HPA saturation during the 2026-07-21 bot-crawl incident (see mitodl/ol-infrastructure#5071).

### Description (What does it do?)
Raises `eks:apisix_max_replicas` for the `applications-production` EKS cluster from 10 to 16.

Live HPA data across all four EKS clusters' APISIX gateways shows only `applications-production`'s is currently saturated:

| Cluster | current/max replicas |
|---|---|
| **applications-production** | **10/10** |
| residential-production | 6/10 |
| data-production | 3/10 |
| operations-production | 3/10 |

`applications-production` runs the shared gateway in front of every app in that cluster (mitlearn, learn-ai, micromasters, etc., not just mitlearn's API), and its HPA has been pinned solidly at 10/10 for hours. One of the 10 live replicas has OOMKilled twice against its 1500Mi limit while the other 9 sit comfortably at 60MB-990MB -- this looks like load concentrating onto a single replica (plausibly connection-affinity from the same bot traffic behind the mitlearn incident) rather than a uniform capacity shortfall. Raising the replica ceiling gives the HPA room to spread load across more pods while that underlying question is investigated separately (tracked as a follow-up, not fixed by this PR).

The VPA (memory-only, min 1500Mi / max 3Gi, `InPlaceOrRecreate`) already provides ample per-pod headroom and needs no change here.

### How can this be tested?
- `pulumi preview` against the `applications.Production` eks stack: expect only the APISIX HPA's `maxReplicas` field to change (10 -> 16), no other diff.
- After deploy: confirm the HPA can scale past 10 replicas under load, and monitor whether OOMKills on individual replicas decrease.

### Additional Context
This gateway's saturation coincides with the same bot-crawl surge driving the mitlearn OOM/HPA incident (#5071) -- once that PR's Fastly edge cutover is actually live (it's currently gated/inert), traffic through this shared gateway should drop and this ceiling may end up with more headroom than it needs. Not blocking on that landing first since this is a cheap, reversible relief valve.