### PR TITLE
fix(eks): raise memory limits for controllers OOMKilled by watch relist

### DIFF
--- a/src/ol_infrastructure/applications/jupyterhub/deployment.py
+++ b/src/ol_infrastructure/applications/jupyterhub/deployment.py
@@ -315,13 +315,18 @@ def provision_jupyterhub_deployment(  # noqa: PLR0913
                     },
                     "userScheduler": {
                         "enabled": True,
+                        # The chart leaves this unbounded by default; our
+                        # 128Mi cap was too tight for a scheduler whose
+                        # informer caches scale with total cluster object
+                        # count. A watch invalidation forcing a full relist
+                        # of Pods/Nodes/etc. OOMKilled it in production.
                         "resources": {
                             "requests": {
                                 "cpu": "100m",
-                                "memory": "128Mi",
+                                "memory": "256Mi",
                             },
                             "limits": {
-                                "memory": "128Mi",
+                                "memory": "512Mi",
                             },
                         },
                     },

--- a/src/ol_infrastructure/substructure/aws/eks/keda.py
+++ b/src/ol_infrastructure/substructure/aws/eks/keda.py
@@ -94,13 +94,19 @@ def setup_keda(
                     },
                 },
                 "resources": {
+                    # The operator's informer caches scale with total cluster
+                    # object count. A watch invalidation ("too old resource
+                    # version") forces a full relist and a one-time memory
+                    # spike; 400Mi was too tight and OOMKilled the operator
+                    # during one such relist. Chart default is 1000Mi; split
+                    # the difference to give headroom without over-allocating.
                     "operator": {
                         "requests": {
                             "cpu": "10m",
-                            "memory": "400Mi",
+                            "memory": "200Mi",
                         },
                         "limits": {
-                            "memory": "400Mi",
+                            "memory": "800Mi",
                         },
                     },
                     "metricServer": {

--- a/src/ol_infrastructure/substructure/aws/eks/typesense_operator.py
+++ b/src/ol_infrastructure/substructure/aws/eks/typesense_operator.py
@@ -60,11 +60,9 @@ def setup_typesense_operator(
                     "manager": {
                         "resources": {
                             "requests": {
-                                "cpu": "10m",
                                 "memory": "128Mi",
                             },
                             "limits": {
-                                "cpu": "500m",
                                 "memory": "512Mi",
                             },
                         },

--- a/src/ol_infrastructure/substructure/aws/eks/typesense_operator.py
+++ b/src/ol_infrastructure/substructure/aws/eks/typesense_operator.py
@@ -51,6 +51,26 @@ def setup_typesense_operator(
             repository_opts=kubernetes.helm.v3.RepositoryOptsArgs(
                 repo="https://akyriako.github.io/typesense-operator/",
             ),
+            values={
+                # The chart's default 256Mi limit was too tight for the
+                # manager's cluster-wide informer caches: a watch
+                # invalidation forcing a full relist OOMKilled it in
+                # production. Give it more headroom in both directions.
+                "controllerManager": {
+                    "manager": {
+                        "resources": {
+                            "requests": {
+                                "cpu": "10m",
+                                "memory": "128Mi",
+                            },
+                            "limits": {
+                                "cpu": "500m",
+                                "memory": "512Mi",
+                            },
+                        },
+                    },
+                },
+            },
         ),
         opts=ResourceOptions(provider=k8s_provider, delete_before_replace=True),
     )


### PR DESCRIPTION
## Summary
- `PodOOMKilledCritical` fired for `keda-operator`, JupyterHub's `user-scheduler`, and `typesense-operator`'s `manager` in `applications-production`, all within the same second — on 3 different nodes, 3 unrelated codebases.
- Root cause: `user-scheduler`'s logs show `watch of *v1.Pod closed with: too old resource version` at the exact OOM timestamp. When a client-go watch is invalidated like this, the reflector does a full **relist** of the resource — a one-time memory spike proportional to total cluster object count (377 pods / 14 nodes currently). All three components hold cluster-wide informer caches and got hit by the same relist event, and each had a memory limit too tight to absorb the spike.
- Fixes:
  - `keda-operator`: `400Mi`/`400Mi` → `200Mi` request / `800Mi` limit (upstream chart default is `1000Mi`; this repo had tightened it to less than half that)
  - JupyterHub `user-scheduler`: `128Mi`/`128Mi` → `256Mi` request / `512Mi` limit (the chart leaves this completely unbounded by default — applies to both the `jupyter` and `jupyter-authoring` deployments, which share this code path)
  - `typesense-operator` `manager`: no override previously existed in this repo (chart defaults were `64Mi`/`256Mi`); added an explicit `values` block with `128Mi` request / `512Mi` limit

## Test plan
- [x] `ruff check` / `ruff format` pass on all three changed files
- [x] `pulumi preview --stack applications.Production --diff` (eks project) — shows only the intended `keda` and `typesense-operator` Helm release value changes, 47 other resources unchanged, no errors
- [x] `pulumi preview --stack Production --diff` (jupyterhub project) — shows the intended `userScheduler.resources` change applied identically to both the `jupyter` and `jupyter-authoring` releases, 92 other resources unchanged, no errors
- [ ] After merge/deploy, confirm no repeat `PodOOMKilledCritical` firing for these three components on the next watch-relist event

🤖 Generated with [Claude Code](https://claude.com/claude-code)