### PR TITLE
fix(grafana-alerting): require repeated restarts for PodOOMKilledCritical

### DIFF
--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
@@ -241,10 +241,16 @@ def create(
             # and rely on a VPA to raise limits toward a ceiling based on
             # observed usage, so a single OOM-and-recover right after a
             # deploy is expected, self-healing behavior, not an incident.
-            # Critical requires "> 1" (at least a second restart within the
-            # window) so a lone self-healing OOM doesn't page anyone, while a
+            # Critical requires "> 2" (at least 3 restarts within the window)
+            # so a lone self-healing OOM doesn't page anyone, while a
             # container that's genuinely stuck crash-looping still trips it
             # within a few minutes (container restart backoff is short).
+            # NOTE: increase() extrapolates over the range, so a single
+            # restart commonly reports as ~1.01-1.02 rather than exactly 1
+            # (observed directly in production: single-restart pods reported
+            # 1.008-1.017). A ">1" threshold would still fire on a single
+            # restart; ">2" leaves enough margin that two real restarts
+            # (~2.02-2.03 observed) still clear it while one restart cannot.
             alerting.RuleGroupRuleArgs(
                 name="PodOOMKilledWarning",
                 condition="C",
@@ -269,13 +275,13 @@ def create(
                 no_data_state="OK",
                 labels={"severity": "critical"},
                 annotations={
-                    "description": "Container {{ $labels.container }} in pod {{ $labels.pod }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has been OOMKilled and is repeatedly restarting (2+ restarts within the past hour). Memory limits may need to be increased."
+                    "description": "Container {{ $labels.container }} in pod {{ $labels.pod }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has been OOMKilled and is repeatedly restarting (3+ restarts within the past hour). Memory limits may need to be increased."
                 },
                 datas=rd(
                     "sum by (cluster, namespace, pod, container) (\n"
                     '  (kube_pod_container_status_last_terminated_reason{cluster=~".*-(production)", reason="OOMKilled"} == 1)\n'
                     "  * on (cluster, namespace, pod, container) group_left()\n"
-                    "  (increase(kube_pod_container_status_restarts_total[1h]) > 1)\n"
+                    "  (increase(kube_pod_container_status_restarts_total[1h]) > 2)\n"
                     ")"
                 ),
             ),

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
@@ -234,6 +234,17 @@ def create(
             # actively restarting (restart count increased in the past hour).
             # The join ensures we only alert on OOM-killed containers that are
             # still looping, not historical one-off kills.
+            #
+            # Warning stays at "> 0" restarts for visibility/trend-tracking:
+            # several production workloads (e.g. apisix, mitlearn-app,
+            # mitxonline-app) intentionally launch pods at a low memory floor
+            # and rely on a VPA to raise limits toward a ceiling based on
+            # observed usage, so a single OOM-and-recover right after a
+            # deploy is expected, self-healing behavior, not an incident.
+            # Critical requires "> 1" (at least a second restart within the
+            # window) so a lone self-healing OOM doesn't page anyone, while a
+            # container that's genuinely stuck crash-looping still trips it
+            # within a few minutes (container restart backoff is short).
             alerting.RuleGroupRuleArgs(
                 name="PodOOMKilledWarning",
                 condition="C",
@@ -258,13 +269,13 @@ def create(
                 no_data_state="OK",
                 labels={"severity": "critical"},
                 annotations={
-                    "description": "Container {{ $labels.container }} in pod {{ $labels.pod }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has been OOMKilled and is actively restarting. Memory limits may need to be increased."
+                    "description": "Container {{ $labels.container }} in pod {{ $labels.pod }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has been OOMKilled and is repeatedly restarting (2+ restarts within the past hour). Memory limits may need to be increased."
                 },
                 datas=rd(
                     "sum by (cluster, namespace, pod, container) (\n"
                     '  (kube_pod_container_status_last_terminated_reason{cluster=~".*-(production)", reason="OOMKilled"} == 1)\n'
                     "  * on (cluster, namespace, pod, container) group_left()\n"
-                    "  (increase(kube_pod_container_status_restarts_total[1h]) > 0)\n"
+                    "  (increase(kube_pod_container_status_restarts_total[1h]) > 1)\n"
                     ")"
                 ),
             ),

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
@@ -235,22 +235,31 @@ def create(
             # The join ensures we only alert on OOM-killed containers that are
             # still looping, not historical one-off kills.
             #
-            # Warning stays at "> 0" restarts for visibility/trend-tracking:
-            # several production workloads (e.g. apisix, mitlearn-app,
-            # mitxonline-app) intentionally launch pods at a low memory floor
-            # and rely on a VPA to raise limits toward a ceiling based on
-            # observed usage, so a single OOM-and-recover right after a
-            # deploy is expected, self-healing behavior, not an incident.
-            # Critical requires "> 2" (at least 3 restarts within the window)
-            # so a lone self-healing OOM doesn't page anyone, while a
-            # container that's genuinely stuck crash-looping still trips it
-            # within a few minutes (container restart backoff is short).
-            # NOTE: increase() extrapolates over the range, so a single
-            # restart commonly reports as ~1.01-1.02 rather than exactly 1
-            # (observed directly in production: single-restart pods reported
-            # 1.008-1.017). A ">1" threshold would still fire on a single
-            # restart; ">2" leaves enough margin that two real restarts
-            # (~2.02-2.03 observed) still clear it while one restart cannot.
+            # Warning ("> 0", ci/qa clusters only -- see cluster=~ below) is
+            # for visibility/trend-tracking in lower environments; there is
+            # no equivalent lower-severity signal for production, only
+            # Critical below. Several production workloads (e.g. apisix,
+            # mitlearn-app, mitxonline-app) intentionally launch pods at a
+            # low memory floor and rely on a VPA to raise limits toward a
+            # ceiling based on observed usage, so a single OOM-and-recover
+            # right after a deploy is expected, self-healing behavior, not an
+            # incident -- Critical's threshold below is set high enough that
+            # this case produces no alert in production at all, paging or
+            # otherwise.
+            #
+            # Critical requires "> 3", i.e. at least 3 real restarts within
+            # the window, so a lone self-healing OOM doesn't page anyone,
+            # while a container that's genuinely stuck crash-looping still
+            # trips it within a few minutes (container restart backoff is
+            # short). NOTE: increase() extrapolates over the range, so N real
+            # restarts commonly report as a value just above N rather than
+            # exactly N -- observed directly in production: single-restart
+            # pods reported 1.008-1.017, and a double-restart pod reported
+            # ~2.034. A raw ">2" threshold would therefore fire on 2 real
+            # restarts, not 3 as the description below states; ">3" is what
+            # actually requires a 3rd restart, since extrapolation is bounded
+            # to roughly one scrape interval per edge of the range and can't
+            # push 2 real restarts' value anywhere near 3.
             alerting.RuleGroupRuleArgs(
                 name="PodOOMKilledWarning",
                 condition="C",
@@ -281,7 +290,7 @@ def create(
                     "sum by (cluster, namespace, pod, container) (\n"
                     '  (kube_pod_container_status_last_terminated_reason{cluster=~".*-(production)", reason="OOMKilled"} == 1)\n'
                     "  * on (cluster, namespace, pod, container) group_left()\n"
-                    "  (increase(kube_pod_container_status_restarts_total[1h]) > 2)\n"
+                    "  (increase(kube_pod_container_status_restarts_total[1h]) > 3)\n"
                     ")"
                 ),
             ),

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
@@ -247,7 +247,7 @@ def create(
             # this case produces no alert in production at all, paging or
             # otherwise.
             #
-            # Critical requires "> 3", i.e. at least 3 real restarts within
+            # Critical requires ">= 3", i.e. at least 3 real restarts within
             # the window, so a lone self-healing OOM doesn't page anyone,
             # while a container that's genuinely stuck crash-looping still
             # trips it within a few minutes (container restart backoff is
@@ -256,10 +256,16 @@ def create(
             # exactly N -- observed directly in production: single-restart
             # pods reported 1.008-1.017, and a double-restart pod reported
             # ~2.034. A raw ">2" threshold would therefore fire on 2 real
-            # restarts, not 3 as the description below states; ">3" is what
-            # actually requires a 3rd restart, since extrapolation is bounded
-            # to roughly one scrape interval per edge of the range and can't
-            # push 2 real restarts' value anywhere near 3.
+            # restarts, not 3 as the description below states. We use ">= 3"
+            # rather than "> 3": extrapolation only pushes the value *up*
+            # from the raw integer delta, and only reaches exactly the raw
+            # integer (e.g. exactly 3.0 for 3 real restarts) in the edge case
+            # where a sample lands exactly on each range boundary, which can
+            # happen when scrape and rule-evaluation timestamps align. A
+            # strict "> 3" would then wrongly require a 4th restart in that
+            # case; ">= 3" reliably means "at least 3 real restarts" either
+            # way, since extrapolation can't push 2 real restarts' value
+            # anywhere near 3.
             alerting.RuleGroupRuleArgs(
                 name="PodOOMKilledWarning",
                 condition="C",
@@ -290,7 +296,7 @@ def create(
                     "sum by (cluster, namespace, pod, container) (\n"
                     '  (kube_pod_container_status_last_terminated_reason{cluster=~".*-(production)", reason="OOMKilled"} == 1)\n'
                     "  * on (cluster, namespace, pod, container) group_left()\n"
-                    "  (increase(kube_pod_container_status_restarts_total[1h]) > 3)\n"
+                    "  (increase(kube_pod_container_status_restarts_total[1h]) >= 3)\n"
                     ")"
                 ),
             ),


### PR DESCRIPTION
## Summary
- `PodOOMKilledCritical` fired for `apisix`, `mitlearn-app`, and `mitxonline-app` after routine deploys. All three intentionally launch pods at a low memory floor and rely on a VPA (`updateMode: InPlaceOrRecreate`) to raise limits toward a ceiling based on observed usage — so a single OOM-and-recover right after a deploy is expected, self-healing behavior, not an incident.
- The rule's `restarts > 0` threshold can't tell that apart from a container that's genuinely stuck crash-looping — both look identical the moment the first OOM happens.
- Several corrections from review, all confirmed real:
  1. Prometheus's `increase()` extrapolates over the query range, so a single restart within 1h reports as ~1.008-1.017, not exactly 1. An initial `> 1` threshold was a no-op.
  2. A follow-up `> 2` threshold fired starting at 2 real restarts (~2.02-2.03) while the description/comment claimed it required 3 — a doc/behavior mismatch. Raised to `> 3` to match the stated "3+ restarts" intent and give more margin against false alarms.
  3. A comment implied `PodOOMKilledWarning` gives production workloads a non-paging visibility tier, but that rule is scoped to `cluster=~".*-(ci|qa)"` only — production has no lower-severity OOM signal at all, just Critical. Comment corrected.
  4. A strict `> 3` has its own edge case: `increase()` only returns the raw integer delta with no extrapolation when a sample lands exactly on each range boundary (possible when scrape and rule-evaluation timestamps align), so 3 real restarts could evaluate to exactly `3.0` and `> 3` would wrongly require a 4th restart. Changed to `>= 3`, which reliably means "at least 3 real restarts" either way, with no added false-positive risk.

## Test plan
- [x] `ruff check` / `ruff format` pass on the changed file
- [x] `pulumi preview --stack Production --diff` against the live `ol-infrastructure-grafana-alerting` Production stack, re-run after each correction — diff shows only the intended `PodOOMKilledCritical` expr/description change (`> 0` → `>= 3`), 22 other resources unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)