### PR TITLE
feat(edx_platform_v3): cut over build-platform to --build-manifest

### DIFF
--- a/src/ol_concourse/pipelines/open_edx/edx_platform_v3/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/edx_platform_v3/pipeline.py
@@ -121,22 +121,6 @@ def build_edx_pipeline(release_names: list[str]) -> Pipeline:  # noqa: ARG001
                 password="((dockerhub.password))",  # noqa: S106
             )
 
-            # Per-deployment lehrer parameters (values previously hardcoded inside
-            # lehrer core, extracted in https://github.com/mitodl/lehrer/pull/41).
-            translations_repo = (
-                "mitodl/mitxonline-translations"
-                if deployment_name == "mitxonline"
-                else "openedx/openedx-translations"
-            )
-            # edx-name-affirmation conflicts with the mitxonline build only
-            packages_to_remove_args = (
-                "--packages-to-remove edx-name-affirmation"
-                if deployment_name == "mitxonline"
-                else ""
-            )
-            # Proctortrack is the same package for all deployments
-            proctortrack_url = "git+https://github.com/verificient/edx-proctoring-proctortrack.git#f0fa9edbd16aa5af5a41ac309d2609e529ea8732"
-
             # Each earthly build requires several inputs, build that list pre-emptively
             earthly_build_job = Job(
                 name=f"build-{release_name}-{deployment_name}-edxapp-image",
@@ -195,7 +179,7 @@ def build_edx_pipeline(release_names: list[str]) -> Pipeline:  # noqa: ARG001
                                     THEME_DIR="../{theme_git_resource.name}"
                                     PYTHON_VERSION="{edx_platform.runtime_version}"
                                     NODE_VERSION="((.:node_version))"
-                                    DAGGER_LOG_LEVEL=debug dagger call platform build-platform --progress plain --deployment-name $DEPLOYMENT_NAME --release-name $RELEASE_NAME --pip-package-lists ./deployments/mit-ol/pip_package_lists --pip-package-overrides ./deployments/mit-ol/pip_package_overrides --custom-settings ./deployments/mit-ol/settings --source $EDX_PLATFORM_DIR --theme-source $THEME_DIR --node-version $NODE_VERSION --python-version $PYTHON_VERSION --settings-namespace mitol --extra-ssh-hosts github.mit.edu --translations-repo {translations_repo} {packages_to_remove_args} --extra-npm-packages '{proctortrack_url}' export --path ../artifacts/image.tar;""",
+                                    DAGGER_LOG_LEVEL=debug dagger call platform build-platform --progress plain --deployment-name $DEPLOYMENT_NAME --release-name $RELEASE_NAME --build-manifest ./deployments/mit-ol/build_manifest.yaml --custom-settings ./deployments/mit-ol/settings --source $EDX_PLATFORM_DIR --theme-source $THEME_DIR --node-version $NODE_VERSION --python-version $PYTHON_VERSION export --path ../artifacts/image.tar;""",
                                 ],
                             ),
                         ),


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
`lehrer`'s `deployments/mit-ol/build_manifest.yaml` (see `mitodl/lehrer` `plans/06-build-manifest.md`) is meant to be the single declarative source of truth for each `(release, deployment)` edx-platform build cell: package set, translations repo, `packages_to_remove`, theme, node/python version, etc.

The `edx_platform_v3` Concourse pipeline generator (`src/ol_concourse/pipelines/open_edx/edx_platform_v3/pipeline.py`) never adopted it — it still calls `dagger call platform build-platform` with `--pip-package-lists ./deployments/mit-ol/pip_package_lists --pip-package-overrides ./deployments/mit-ol/pip_package_overrides`, which read `lehrer`'s legacy committed `.txt` files directly, bypassing the manifest for packages/overrides entirely. It also hardcoded a per-deployment `translations_repo`/`packages_to_remove` ternary and passed `--settings-namespace`/`--extra-ssh-hosts`/`--extra-npm-packages` values that already exist, identically, in the manifest's `defaults` block.

Net effect: two independently-live sources of truth for the same build inputs (the manifest, edited by `lehrer` PRs and Renovate's `customManagers` regex; the `.txt` trees, edited by Renovate's legacy `pip_requirements` manager). They drift from each other silently — `lehrer`'s faithfulness test that's supposed to catch this drift is currently failing on 5 of 7 cells because of exactly that.

This PR switches the `build-platform` invocation to a single `--build-manifest ./deployments/mit-ol/build_manifest.yaml`; `lehrer` resolves every build param from the matching cell at build time. Removed: the hardcoded `translations_repo`/`packages_to_remove_args`/`proctortrack_url` variables and the `--pip-package-lists`/`--pip-package-overrides`/`--settings-namespace`/`--extra-ssh-hosts`/`--extra-npm-packages`/`--translations-repo`/`--packages-to-remove` flags. Kept unchanged: `--node-version`/`--python-version`, which Concourse still resolves dynamically (the `nodejs_github_release` resource, `edx_platform.runtime_version`) — the manifest's `node_version` handling isn't finalized upstream yet, so this intentionally doesn't touch that.

**Depends on `mitodl/lehrer#124` landing first.** The manifest stores `translations_repo` as a full GitHub URL (`https://github.com/org/repo`), but `lehrer`'s `fetch_translations` feeds it straight to `atlas pull --repository <value>`, which expects bare `org/repo` shorthand. Today that's masked because this pipeline passes an explicit, correctly-shorthand `--translations-repo` override, which wins over the manifest. Dropping that override without #124's normalization fix would silently stop pulling translations for every cell — every `atlas`/`pull_*_translations` call in `fetch_translations` is suffixed `|| true`, so it fails quietly (missing/stale i18n in the built image) rather than failing the build loudly.

Marked as draft: it changes the live edxapp build pipeline for all 7 mit-ol cells, and should stay draft until `lehrer#124` is merged and this has been validated against a real build.

### Screenshots (if appropriate):
N/A

### How can this be tested?
Locally rendered the pipeline generator against all `OpenEdxSupportedRelease` values and confirmed:
- All 7 expected build jobs are produced: `build-master-mitx`, `build-master-mitx-staging`, `build-master-mitxonline`, `build-ulmo-xpro`, `build-verawood-mitx`, `build-verawood-mitx-staging`, `build-verawood-xpro` (each suffixed `-edxapp-image`).
- Each job's build command now reads `... --build-manifest ./deployments/mit-ol/build_manifest.yaml --custom-settings ./deployments/mit-ol/settings --source $EDX_PLATFORM_DIR --theme-source $THEME_DIR --node-version $NODE_VERSION --python-version $PYTHON_VERSION export --path ../artifacts/image.tar` — no leftover references to `translations_repo`, `packages_to_remove_args`, `proctortrack_url`, or the `pip_package_lists`/`pip_package_overrides` paths.
- `mypy` and `ruff check`/`ruff format` pass on the changed file (pre-existing `D100`/`D103` docstring warnings only, unrelated to this change).

Before merging: `fly validate-pipeline`/`set-pipeline` a dry run against this branch, and once `lehrer#124` lands, run an actual `build-{release}-{deployment}-edxapp-image` job end-to-end (e.g. `master`/`mitxonline`, since it exercises the per-deployment `translations_repo` and `packages_to_remove` paths that used to be hardcoded here) and confirm the image builds with the expected translations and package set.

### Additional Context
Companion change: `mitodl/lehrer#124`.

Once this merges and a real build has validated the manifest-driven path end-to-end, `lehrer` can land its own follow-up PR: delete `deployments/mit-ol/pip_package_lists`/`pip_package_overrides` (and the `deployments/generic` equivalents), retire the now-obsolete faithfulness test (`TestFaithfulnessAgainstCommittedTxt` in `tests/core/test_build_manifest.py`), and drop `renovate.json`'s legacy `pip_requirements` manager. That's intentionally *not* included here or in #124 — deleting the `.txt` trees before this pipeline change is merged and validated would strand production builds with no fallback.