### PR TITLE
fix(starrocks): protect FE quorum from Karpenter voluntary disruption

### DIFF
--- a/src/ol_infrastructure/applications/starrocks/__main__.py
+++ b/src/ol_infrastructure/applications/starrocks/__main__.py
@@ -409,6 +409,19 @@ starrocks_values: dict[str, Any] = {
     },
 }
 
+if stack_info.name == "Production":
+    # Incident 2026-07-22: Karpenter voluntarily consolidated the spot node
+    # under an FE pod three times in ~13 minutes (cost-driven, not a crash),
+    # and each EBS volume detach/reattach cycle took long enough that the
+    # StatefulSet spent over 10 minutes below full replica count, tripping
+    # StatefulSetReplicasMissingCritical. FE only tolerates losing 1 of 3
+    # replicas before quorum is at risk, so CI/QA (fine to disrupt anytime)
+    # are left alone and only prod opts out of voluntary node consolidation
+    # for FE pods specifically.
+    starrocks_values["starrocksFESpec"]["annotations"] = {
+        "karpenter.sh/do-not-disrupt": "true",
+    }
+
 # Placeholder ConfigMap for the file-based group provider managed by the substructure
 # stack (substructure/starrocks keycloak_group_sync.py).  Created here so the FE pods
 # have the volume available at startup; the substructure stack populates groups.txt
@@ -821,6 +834,33 @@ starrocks_release = kubernetes.helm.v3.Release(
         depends_on=[starrocks_root_password_secret, starrocks_auth_binding],
     ),
 )
+
+if stack_info.name == "Production":
+    # Backstop for any voluntary-eviction path other than Karpenter (e.g. a
+    # manual `kubectl drain`, an EKS-managed node group upgrade) that respects
+    # PDBs but not the karpenter.sh/do-not-disrupt annotation set above.
+    # max_unavailable=1 preserves FE's 2-of-3 quorum requirement while still
+    # allowing one replica at a time to be evicted when genuinely necessary.
+    starrocks_fe_pdb = kubernetes.policy.v1.PodDisruptionBudget(
+        f"starrocks-{stack_info.env_prefix}-{stack_info.env_suffix}-fe-pdb",
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            name=f"{stack_info.env_prefix}-starrocks-fe-pdb",
+            namespace=namespace,
+            labels=k8s_app_labels.model_dump(),
+        ),
+        spec=kubernetes.policy.v1.PodDisruptionBudgetSpecArgs(
+            max_unavailable=1,
+            selector=kubernetes.meta.v1.LabelSelectorArgs(
+                match_labels={
+                    "app.kubernetes.io/component": "fe",
+                    "app.starrocks.ownerreference/name": (
+                        f"{stack_info.env_prefix}-starrocks-fe"
+                    ),
+                },
+            ),
+        ),
+        opts=ResourceOptions(depends_on=[starrocks_release]),
+    )
 
 cert_manager_certificate = OLCertManagerCert(
     f"starrocks-{stack_info.env_prefix}-{stack_info.env_suffix}-tls-cert",


### PR DESCRIPTION
## Summary
- `StatefulSetReplicasMissingCritical` fired for `lakehouse-starrocks-fe` in `data-production`. Root cause: Karpenter voluntarily consolidated the spot node under an FE pod **three times within ~13 minutes** (cost-driven bin-packing, not a crash — confirmed via `DisruptionTerminating`/`Disrupting Node: Empty` events). Each eviction required an EBS volume detach/reattach cycle, and some of the replacement nodes were brand new with the EBS CSI driver not yet registered (`FailedAttachVolume: CSINode ... does not contain driver ebs.csi.aws.com`), adding further delay. Cumulatively this kept the StatefulSet below full replica count for more than the alert's 10-minute window.
- FE runs 3 replicas for quorum (2-of-3 required); losing more than 1 at once is an actual outage risk, not just noise. There was no `PodDisruptionBudget` and no Karpenter disruption exemption protecting these pods at all — confirmed via `kubectl get pdb -n starrocks` (empty) and the pod spec's annotations.
- Fix, scoped to **Production only** (CI/QA are fine to disrupt anytime), via `if stack_info.name == "Production":` guards:
  1. `karpenter.sh/do-not-disrupt: "true"` annotation on FE pods (via `starrocksFESpec.annotations` in the Helm values) — blocks Karpenter's own voluntary consolidation from touching FE nodes. Same pattern already used elsewhere in this cluster (a `dagster-run` pod).
  2. A `PodDisruptionBudget` (`max_unavailable=1`) as a backstop for any other voluntary-eviction path (manual `kubectl drain`, EKS-managed node group upgrades) that respects PDBs but not the Karpenter-specific annotation. Selector (`app.kubernetes.io/component=fe`, `app.starrocks.ownerreference/name=lakehouse-starrocks-fe`) matches the labels already used by this file's own FE MySQL NLB `Service` selector, and confirmed directly against the live pods.

## Test plan
- [x] `ruff check` / `ruff format` pass on the changed file
- [x] `pulumi preview --stack lakehouse.Production --diff` against the live `ol-application-starrocks` stack — shows exactly the intended `starrocksFESpec.annotations` addition and new `PodDisruptionBudget` creation, 36 other resources unchanged (plus one unrelated pre-existing `kubeconfig` JSON-reordering diff on the k8s provider, not from this change).
- [x] `pulumi preview --stack lakehouse.QA --diff` — confirms **no** FE annotation or PDB changes reach QA; only the same unrelated pre-existing kubeconfig diff appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)