### PR TITLE
Add mit-learn UNSUBSCRIBE_SECRET_KEY secret

### DIFF
--- a/local-dev/apps/mit-learn/secrets.yaml
+++ b/local-dev/apps/mit-learn/secrets.yaml
@@ -36,6 +36,7 @@ stringData:
 
   # ── Django secret key ─────────────────────────────────────────────────────
   SECRET_KEY: "local-dev-secret-key-not-for-production"  # pragma: allowlist secret
+  UNSUBSRIBE_SECRET_KEY: "local-dev-mitxonline-insecure-unsubscribe-secret-key" # pragma: allowlist secret
 
   # ── Misc optional secrets ─────────────────────────────────────────────────
   # Required only if running EDX/YouTube ETL pipelines:

--- a/src/bridge/secrets/mitlearn/secrets.ci.yaml
+++ b/src/bridge/secrets/mitlearn/secrets.ci.yaml
@@ -1,57 +1,58 @@
 ---
-#ENC[AES256_GCM,data:gZWH4nMn444tYXRQ89PRcdODKLAMeaeFfsAP+hscwJRIGbuhzELfyZG8ZCZpJVWqIg==,iv:fzVuOhXlrBIDxfa7VT9hI/Ty2Xa4/dyarWB+SRoyZvY=,tag:aDLpEtWqNZLwtQLg2RWTtg==,type:comment]
-#ENC[AES256_GCM,data:OwPpvWf9m+jKZttU,iv:98nR8VyDomvs7Uo5EYQidvcR0GVh8+lX9r7AnEHZy4s=,tag:jSxl3Xu/VllsmF9Dcng7OA==,type:comment]
+#ENC[AES256_GCM,data:lWlxvAeht9arOVv52E1e4rpIUc4XHZVsFcuzCnp1Jilt/NA87iTNQ9ilmNfWE3e+zg==,iv:FRtoO9nzAY6re7zcIScGI/j2bbuho/LbA5CkeFHX/YU=,tag:xCOb84sDlsaQHTh/iA5dfQ==,type:comment]
+#ENC[AES256_GCM,data:rhDuB/Rnt6BJUsxE,iv:rQbUhhRDcrdAmgCP8+wAwdFMD2eN8HSNxXwqRyT4oKI=,tag:RkO5MmWg3Y0WP4fVLsZ0Gw==,type:comment]
 ckeditor:
-  environment_id: ENC[AES256_GCM,data:m2ycBnLlQHUjyyqbqPb/GfLZkTQ=,iv:GII6RxkcdBhUXX0cldMAmzplRV6bCHhQHqp72ndK8wg=,tag:39fN0qmnYLAQkdNU5XMcGQ==,type:str]
-  secret_key: ENC[AES256_GCM,data:zkx/THen3vCvioVc3xCZGQ0mYRkyAqM23zSlz4nLU4PSy1g/C5ySv4pxXWJ48HHRO+RoNG9QNvOv+eFP,iv:ADRVUt+GrVWnDCxGBYh0/gyCEgxkfIxKrRcfLS4FCLE=,tag:asGj0hGSemPVZ4Wt38f/eA==,type:str]
-  upload_url: ENC[AES256_GCM,data:xbd16o0J7ixqxQNMkZSSVG1nbFUr4sTOjjp7aCnch6i/NOdie/lP0+BB,iv:hjzqKYvFQPnk5DJkvhHy2prSiKXZ3vtbYka5U0GEyc8=,tag:8jxAyfVuEOz8gVwnvdOLkg==,type:str]
+  environment_id: ENC[AES256_GCM,data:z2UiHXwYLqD4ZB6iL2IGdpbS9IE=,iv:Rr/W3MAybcBQ3aUE1Xi6bkFrFxOIuTWDJR0ZraaVLxI=,tag:D2t0au5ByTPb5p7h/nEiVg==,type:str]
+  secret_key: ENC[AES256_GCM,data:MbURjWCmq/zz092WOc78SKF/VPeNDvZv5WRZXPUF+rRjyIGo0W88AGeZYbt9oI7zCFSYjBIonOh9Yxok,iv:HdouKzSXSDl72oBsxtnVwLxcElWVslDpmSmblXLXWSY=,tag:KYiaPTzu55Y1a4XB4YhjQw==,type:str]
+  upload_url: ENC[AES256_GCM,data:AWmXzOH4jY9fXEZOkbMnJOFIj6LgwZM5qkYDZBcCGSXVOrnFf8jiNwyR,iv:Jh0YESYeqIB0hN0jBPvJ4+awR8o7h56FtouYeC6zbsQ=,tag:N3isGbi6mSzp2Pnpv0uIPw==,type:str]
 edx_api_client:
-  id: ENC[AES256_GCM,data:oASAkcM9DIaqECniVvZu3slXWERAvbld5XSlhxePi4wYfyyYe6Zigg==,iv:QAuh+arE3gwJ+7wUYIzKzqa3WujNUOtvPnHz00u+9Ag=,tag:rC47+R12kmyfv54BV1W4UA==,type:str]
-  secret: ENC[AES256_GCM,data:xEvx2uQrfTzLhjR7HW1MLDbsMtiw1pDVE7Dwh3w+CE4EdJQAxkzp8Y5nee39EjFZObSv+tTQaoaJqvsUILrAkmfXq640VqzmoFkncy6vvTeS4ro2w+3t+ZtCDuybQq3uEeS6BtlvVvtmfsbUm97UHb47AVYY52cfYtS/4GTBQgk=,iv:y14la52LA6XVt3qr2Knb7mTiUnKCua+4NmOR/W5yLaw=,tag:QwhSDeTq/nPzdj+X61rGKg==,type:str]
+  id: ENC[AES256_GCM,data:KlvKynG4B2cTRFTGjOdIT2R7VStLFk03kvkSBuipd8I0PuL03/3Y8Q==,iv:eRKnzn2egNlZO7fUgU/CE1Wc0rW7gWoCP3b+OWroyew=,tag:uH2eRAtTAGa1i979znfkuQ==,type:str]
+  secret: ENC[AES256_GCM,data:Q/kJqODZcYQIFtP7CGPxomhUgiKxKh0prk9tzYolL9Y8PH2C+kwAxfHjST2hgq9ujQoCEp79FyDiXrSmh6UL9yDEot79Uj8QgXeK3+5eOD/BakiyusyBCdzj7ea9AYT44H7CwP/S0y648kX0XQb3kX6LIfyXEZ1PiN+vNdf1hLM=,iv:xO0H/g76+PfGeZYhY1cTsjznOO1y86pmQaG5coLrZ54=,tag:v+AiFP7Lvom3K21cqLPGyg==,type:str]
 fastly:
-  api_key: ENC[AES256_GCM,data:2DPPI2ReQEolr2GLUFOVUssChJnMBT+MiXknZUcLBgE=,iv:oHtBZJFqPHf4XuPrgqzHXxbTkDubpL3b5UtsuUo1rYw=,tag:UDkWnbTQpqfm6+FvzIr6CQ==,type:str]
-  service_id: ENC[AES256_GCM,data:Q0zblUXu6uPk6B/xzMxsZxSV5zSVYw==,iv:79w7jQtYJt0ouThRIRswBV1FXdM+lotNhAIEdR4W/fw=,tag:HMaPyV5m+yWnfPrCg0YN6A==,type:str]
+  api_key: ENC[AES256_GCM,data:G7zoqTzbncDCvf1Cp04+j3trp/907+GlYHzhd/6zxfQ=,iv:vMfbtAL2tdUi0Tgrmgttugv0efMxrpQOKWKvOOKMM8s=,tag:pGQwFYvUMcFFnqfxtu2GyA==,type:str]
+  service_id: ENC[AES256_GCM,data:v8sxkLgjFOHQkJ/K/P0y4f1wL/b+tQ==,iv:TqwopJPCzqHzEZiczRlrFcymF27cyOuP+GtTRtXn/NY=,tag:F/EEJa346tS9fx53C45qAg==,type:str]
 open_learning_library_client:
-  client_id: ENC[AES256_GCM,data:/ZQRypS9u1oioFPDOOvtZdzy3a59xOxVCDKc9QB7ft1IBxin3oGJhQ==,iv:ukb6l6+8uB9LPrLIfTL4YwXVBPvyFNVH6qEa0Pehqss=,tag:hxq2ELSkM35+jME5MfHYcA==,type:str]
-  client_secret: ENC[AES256_GCM,data:btEGfSYS5mhE/TxtbimrG9YnSVlPc9292WemnpZVTn/IA13haLMP+o5SymKQj9IY/XQu6Ir+HfSYUrOj2rBo27IOjrRH3uNGP000E7p3d1JkCTIL0ZFUf0smwHF+3Ky/QIpYv8YhENi0Zh5JeDyinsLAR3VMRzGys2hbPIklA8g=,iv:44l017XtGuVBqrPMVMa/cF/EkFpSjeJ+WMr9KloLBGs=,tag:+UKMbLAGtrLDACCagauNcA==,type:str]
-oidc_secret_key: ENC[AES256_GCM,data:NRGkmizQbnauOA5jcOb9vPtzc4mlCLE8bmB0AUhS5T8=,iv:oeg8mggpo+SFe6LKjYKMlPbsGb4we+FbH2u9OEeoVmw=,tag:W/Wbk6kPkPSwWysu8Zkqsg==,type:str]
-jwt_secret: ENC[AES256_GCM,data:ANTsy5xqo6Nne1myMebN3NnaFkGqbqMsX7eL/X1DKgWYRqpi2COLc0vrEdh720KmURMnIaeAaQ==,iv:2BXvOpailU2rBtqEI+PAq/1f0iKNhJ83sZOcEV2A7YE=,tag:8pUMU/uwav5fW6Ad1Py7AQ==,type:str]
-#ENC[AES256_GCM,data:7GDSy6tA,iv:g75MMO/+aknNWpK/RM0lFTWABYe8PZ1GwWEcc1VI7Sg=,tag:E0GKyS5oaEoagBOroOrwbA==,type:comment]
+  client_id: ENC[AES256_GCM,data:8e4bfnU+knLXdAQKIZPUY4sntaHzd1leYbBSET10AsSq7n/9YsCvUA==,iv:zHKBT5eMF/s/T7MIqIdtOB5bfjUhBc0PKilvCzaqgS0=,tag:71xFxO2+AXfyqEnNKR0xEg==,type:str]
+  client_secret: ENC[AES256_GCM,data:Ee2m72grq4fTGZAVH5eO5XoncFGi4baJ39n8vk/ZlI/HcOc7MPr6VACm3Rtad9G632pMm407ToOm9vCtBzWcqvlbGoIFRO/qZYiDsmmBqCbiVyhNdRjiQtJaZhcto7wirwIXuLYKqt1BwwjeH2lJnv+VEEKsh7x1P7ZxQvGbvpo=,iv:lrloY38ovH4Z2YEXGyWMqG/USJZQRRGuUl+h89sPsds=,tag:wI3/BRwXhuXJ2Fv6AYkJTg==,type:str]
+oidc_secret_key: ENC[AES256_GCM,data:4+Xak5X3a7kPeK4J2RbrMgxJDk9QnjFJCvg+HQCbY+w=,iv:VC2PKLYTaKioEZmX8VAqjMGbKQ/aAxmQDXQK5zi5hFs=,tag:2x7ierYlx6h0DUIfKLCSJQ==,type:str]
+jwt_secret: ENC[AES256_GCM,data:j8Ii9Em2MlSNy+2ndsmw8uVs11V5vh2n5suYNn34BdlKnCvAavbS1+zU9f7LvXTUrokgMbvCMQ==,iv:F8rW7Cfr7PNlInCasgCC4RBWgGGkEFEVOkLoq0HmdUM=,tag:yumzNgJ2e5NT/DSRhVnjig==,type:str]
+#ENC[AES256_GCM,data:lqLFLXuD,iv:CEIpu2gZ2iUJ9e4hZ9rPTaQXkQcS6o5MmShFF0Pll0o=,tag:FEXCHdUfpKg3QkYjL9YoSw==,type:comment]
 openai:
-  api_key: ENC[AES256_GCM,data:c+utqon6XjbpndElYeIRr23BRUPYqvJwBrJ59/KUg7IAq0zwAdIwgSiajJluUA98jjGO6tGc35TfNKRjfm66Zq7hA5NRrEOi8x9viKUKiku6d0ndnGxSJo3lfDkyrW+LyplVFzAVo8XpqvLVk6F2Nrdie9tJ4ZxLw8kWm8w9Ej/FxbWZkNaiNFjF6zZwk1waJXicy+wuxAoIyBJJ9CMtKipx6HjO0UE=,iv:okr5lazqSQW+w1eriabBHRXsq6chRjIM8FZREdn0jgw=,tag:0CgV8w9a4feuOFWYsdef7w==,type:str]
+  api_key: ENC[AES256_GCM,data:8fmEzruhva5iosDYQrjAlyLhCge3C2MlfMll0hNypAsOcpS80xwRgDAqupxroOcxDlf+Lq68io1lihhY4fCsr1CW4z7MDc+04I+mxhWkbjmK0OVqClA4CwdX5Cz6caMrs0nwJcvc3LeIhOHl9SmJn3lFGl8Gf/TUY+7prEvqm7PdKKn8PF57ahsk3QYsY6Abt45rXPQH11+VGo6SBZA/DHMByABSuFY=,iv:DwMftzERsmEMy75f2Db6v6RlQXYSzDdameY2LNPaL8k=,tag:x7Q/8376GIIgtoVwRT3xCw==,type:str]
 opensearch:
-  http_auth: ENC[AES256_GCM,data:bWbBi8HFU+KnTD52tGX7CJmo0iRYFMHryvsr2YTZGuEaLooaqjZyOFAHLkhEY5tovNzxgG1Q+E4RSyhTEorqc48=,iv:KIfzSg7cd5/F7+hTxIlwRgzn45cXk/UEuHG9Hx/Rhpw=,tag:9B2NwfUtiFKgmFWdg/Yb7w==,type:str]
+  http_auth: ENC[AES256_GCM,data:Kwi4lw9xdLfHDLLi1YQV2qvidxfrOrZ3CQWUiRuTeekrS0XhJtlPP43nYY9Wo7ZDvqZusvfPvOYNpnNoo5M6RqI=,iv:WfxTEFFEhYxeMBWUvZGC17uhekAayfaQkOW3spVZNH4=,tag:wIwijk34dEqL1dzdd5Vd7A==,type:str]
 qdrant:
-  api_key: ENC[AES256_GCM,data:gQuCOnH4T0fOwXi8lNoY2RCji/2McjdJbC6aaXrh0wLqaLNXaEq2wh70T06r/FtSX0Ar1tvL,iv:oiQtklRInht381PIwMEYY54AnRdniJQUjIqqiZ82IVQ=,tag:gvh9KWcYx+bfKUHMm/xuGA==,type:str]
-  host_url: ENC[AES256_GCM,data:BBSiAF78J4Pju9Lv9/o59JPEBZSvyi7JM4f+XQ/KbzD7uUxp88eiYah4X2EV8cpdLnhqkRBhXs+sRop9Qi+ip3CiRPmWDXSb0YBUyw==,iv:/8JR99H11uBx+k1Ln9XPk+04nGnwAFqRTegqlexWDyU=,tag:BMHrPMtc3d7Q73Hrim6iDw==,type:str]
-django_secret_key: ENC[AES256_GCM,data:Jh2tKSegFPEeOQYGYR1hYs8gEyOahNlacxZku5DZV/fzal4hy4I8TC3Zo3zIC68/01nOWiGoOtR1lAwGBXlb+g==,iv:KAttP7AQ3Ytm8Tw1AfVeRnBtOsXIB8VJWsmINdhJuok=,tag:KkEkQGjl8+RwusHrz+jfmA==,type:str]
-django_status_token: ENC[AES256_GCM,data:WtHyTk5/XZehfbrLrxOWQ9YtxFlsXdsU/hsnKQxW7HvqMkloqLYwJ9Cxzzle6uoHDWnL/f7Lx3aXuuwWj8Wobg==,iv:+09EwY74JRMztKB8961nigQF+nB19hURDegOp0VzuEw=,tag:TVwzDKR950PQpPDJnLVbFQ==,type:str]
-youtube_developer_key: ENC[AES256_GCM,data:sysv/LjqiZ28xoz1CKZqjppo0sTFiSsNfLBRrtA+L6+2QKbyIcGt,iv:ZiwcM42pTVd78jtkwx852DmlUPkgYo0pGL6k0Ar1NMs=,tag:sAccC/1Dof7v19r53lUqlQ==,type:str]
-sentry_dsn: ENC[AES256_GCM,data:M2SI7T2eqbmCwlyVQEjLBZOVEWmAPIOV1RL6ACz8VUj+TUFEHyO2CuAuaYsXLnXCfPQEjhEKTf58cx9010eju5O4rfHIf0acshcB1GVqiN8F+SHz,iv:e0SjR8Qkk134QNUd/S4HLNTTB8InCB+v95TF1J/eWH0=,tag:FJbFsF8R9ORlQhsync3JlQ==,type:str]
+  api_key: ENC[AES256_GCM,data:UCHHnEraPa2B4Si61Fjsd4mXg0n/thXGUcg/4U1WyH6vEQzaL7V/JsoYqOxT8fZ/GwS4UTjY,iv:RDtXETHF9kp7SMN8t2B6NCsiSaW0Fj3SbaHeTre0h7U=,tag:z8dP3ndW/inEPOBiFqu7Eg==,type:str]
+  host_url: ENC[AES256_GCM,data:MgrCMtah2wh+FI679nJIAOKNxBxuYTTZ/uXKMVLj1V4JvHFEWh6tw0xMd3nkUsR60wpYeJyUVW/TKznO6DFBf7y8a8iDQxfbb/jqew==,iv:94xKoPvjp89OJYjkzkrM2VUXvK1u0l201Myv600t474=,tag:IDUq+sieRjBZmCBGwwedkA==,type:str]
+django_secret_key: ENC[AES256_GCM,data:bBPwVnZ6xwOH6pytOELGO3T7nF5bdtjMS9ZPDUQvVjyk952WMowyxydIZKgLr5VdTQynbKYfLLG2RNmKFV53vg==,iv:L2zyxT2Ip8Ms3R+6sFx8SEdM9Jaln3QQxqv24yGwG/o=,tag:AklPONgAxEerXYfILUoG/g==,type:str]
+django_status_token: ENC[AES256_GCM,data:ZMru5voPe+pnSMEPFidrQJUMz1iTEQKsRI3dVtUfzRufyrdrn5U25lYFpLXL5Tepo4J+eCMhmMN1SM34nd52+Q==,iv:5oOEnDP6BV3OvU65+8YhgtGDIccfETiSwp8DCx4V18Q=,tag:Pd2eMCMotONge88BeObewQ==,type:str]
+youtube_developer_key: ENC[AES256_GCM,data:QsYh1LEQziEEzdsjkmAQDAk27oLlWfTGTuKxdlEy0vJwGdcprwH6,iv:Ith4WJh3bmJeAEB3JoS4HFQ9NVH36JT4oY8W/PnFfFg=,tag:EY/2dGDwfY7oEPeoMjPPiA==,type:str]
+sentry_dsn: ENC[AES256_GCM,data:VQsYWG3V1FxJNxlRr/P8bSKnt7XEOA76sGMb2pVK7fimlid6ogj6lh/8uF5vqJUv3fLF8u2fUbAqGTBYKI8yaGK45uVcP0bzZVjv1ZbSkFmZPTy9,iv:SKiGyc3TUcpTANyLWz2429qpp5CB0bKKWGKBmJlkx58=,tag:crVBxOSJ5JAlJXX3TH+xwQ==,type:str]
 see_api_client:
-  id: ENC[AES256_GCM,data:w06+z/3L8evY3FUYmKcUaj5/gXTfhNF4widZxU3mJtI=,iv:y9Zt9aXaGTIufPUCLIMUMmf4EV+d1kRt+skE62VQQiY=,tag:QW99bopVdIGLj3yXqGzNug==,type:str]
-  secret: ENC[AES256_GCM,data:uql/uhME+DyVY683/ZzTuDO+r/QzU1rVkNbrVaolXFM=,iv:wTOUQNWgeAImADnkE2G0uwU0ZCqQOCGawipq4Zww5IU=,tag:EajlHWab7bznhmQ4pEY17w==,type:str]
+  id: ENC[AES256_GCM,data:D5f0cFO+am+P16XaALqrXN6W8gYdTbIuoYvFzd69gq8=,iv:o+CnpVce4hwEcOHawzzwe3s6NGpXv/9YmAz2c0jEZ+Q=,tag:5fBJ3RVWodCbTK5OmXF4wQ==,type:str]
+  secret: ENC[AES256_GCM,data:dNWBGv4kVCrof4CgL7OM6pwCGJ+6p4zciBabLIto65c=,iv:etpCO4eO1euV4LAXFLtchQKRcsK4IEUN/GJvNn0YnPA=,tag:ivR8L9wFbm5XJqvlAri8zg==,type:str]
 posthog:
-  project_api_key: ENC[AES256_GCM,data:9jmbVUgebyvkUO8Cl8SUpfLmda72DmA+I3yk081XcbJftraC4EhomX1gwNkZvUs=,iv:g0WcfzqF4r/PEWLR/sEx9Uy1vDGDwxQZrEiMk6WUUKU=,tag:k8YkPeE08grS3e33rGsBug==,type:str]
-  personal_api_key: ENC[AES256_GCM,data:W/+/28d4YIfxh7Zh6DYxREXMBk+rt4V3bdK7Sdo42qfBNTWLgtCMKeiSt3GQmyD1x1FK,iv:xKeJOvoJ33x/XIPoDCaKhPOx5+Vs/IDacyCQop9448I=,tag:iTzgHGppb053vjgIjNsj+A==,type:str]
+  project_api_key: ENC[AES256_GCM,data:5E+gfYJMIma2r4RECEJapdOiueh6yEb4NOspywINkLDl//N2okA4DKlAQLJRdF4=,iv:UMZRlTVN+8H63hFFpRnZx63aW0hq3R8PAxIKneR1Krs=,tag:QxT7xAMrJ0x7C/4Q+M1BPA==,type:str]
+  personal_api_key: ENC[AES256_GCM,data:c3BbDWFhP9LgAs91ecM1D1eI4A68qzRknh3UeembsbXy79lnnOSR+Vx+VPC8H5+GT4c5,iv:If//ARP8l18fZu7OlZ7B6SKKke8lMfe3GpkIkum+hww=,tag:gtnLy2smqtADa8wJ2oG87w==,type:str]
 wagtail:
-  client-id: ENC[AES256_GCM,data:zZMj125TJB7x/htU1fJhFHwJoEWJMFcd7HW/Ghc8RDFQGXJuJrOZKA==,iv:H21wDfP5JUOvUnDRGEUHlyCsalVIEAYEiza08Jdc4Ww=,tag:YR7pN+lyrzFx0QiV91aS7Q==,type:str]
-  client-secret: ENC[AES256_GCM,data:h8LlrSjbuBRnBk0QHWSic1Z9SGENy5xfYlH1zfFsxo0PqBt0WGBJcNYDJd2nIMcs4XPxaK58QiolsUIQWUYF6T7sSMPQDiJ5zKyt54bynKX+CA19qBHDOth++m88NcxrJGP7JUANeCTDdbXHm2luxlNtviX0vwt5TW3WzLtQzVY=,iv:pCvLDmEj2ewHfQXCb9kuQ/UMpR/LhKwCl3cCe4AIrjw=,tag:JaZ9Jh1uqv+n26Ki/RviPg==,type:str]
-  username: ENC[AES256_GCM,data:DnoSkD657IrDCydmBZRgW6+hakS3VS1hsA==,iv:eSdywFDnpmL35i25YnJz1gUL/Foo4d23U3648YygvGg=,tag:vMANqZnp6GmboYVVxEDErQ==,type:str]
-  password: ENC[AES256_GCM,data:r7gvVrpfxWtoIpZvQWWGLGwF,iv:sJ4cusQUWfj3WACh8por6WNTVNuBGkdoJtc0xcKBkRY=,tag:cDi44VWh62JTWTNTLdhI8Q==,type:str]
+  client-id: ENC[AES256_GCM,data:fAL6Yr2vxlyH1xU92iqYcT7jKmbgmSfPf/9fSDIhKouA0m2lj9dPQw==,iv:UgOgMOZT3U1x30H0IhYHJiOkRoWmhfzXc14BJJhQ6Z8=,tag:1a/0xS/8ZxLp+O98FutrIg==,type:str]
+  client-secret: ENC[AES256_GCM,data:7dcjtWWqOCCfDdlfbD8nxyYGXXWrFhTHpA8h/3KhB+NSwSzWtX0w+gi3yI0ifrgyM9aSNfWgHN9JyzR8lI7cITKyMYMskTxcNUpohMxSa6VXtAko6At7G7mm6l+lPARxP+hJI0v4fVa6B3sz2WzuhRnxAr50u6FJcWzD1c/Attw=,iv:R8vkW18CIimotO3pkOM+ATrcvwqV3sZdIVT9E2X93mU=,tag:k+pBeeyzZb/yuqVGD76bqw==,type:str]
+  username: ENC[AES256_GCM,data:DqJaRoexck6cXMyspNGlzzCW+mzPN84NHQ==,iv:iNo0snCncMAMD9+CXYOqFJ18KKXAO/n7JnV1nTpL8wE=,tag:WHfAblZXV0BVFvvC6wxFsw==,type:str]
+  password: ENC[AES256_GCM,data:8uTA9b5uO2SWEjOlbpuw1O1R,iv:w131PHdQaXkMRDfC7ktyI/McnGBG9AS2oh0rhm4z4l8=,tag:7EQrg2fWlW9NKGEhl31j9A==,type:str]
+unsubscribe_secret_key: ENC[AES256_GCM,data:7ALGhwoarjrcG+zJSdBfAJogM3utTRHb7+IZ2snHWAsY9Kn5+wDqIg==,iv:rbp1EZrYR+hkIOlkVO7JWsz/Y8bGgK5F1CsvlVvEZoU=,tag:5jyEAToTkPJTL1lXFFN3lw==,type:str]
 sops:
-  kms:
-  - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-ci
-    created_at: "2026-01-28T15:23:26Z"
-    enc: AQICAHhMkpkBpCvmFjhyfy75ENALRrbg42uOs9cUsFNLXqPnagGnPcKFcq+UvK8GxYuhm9OuAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMRX50dy4Cg8DuUMV8AgEQgDv9N8bLq6dJylvdJydQsPQToeahgnnW68MZhsIsrI2V32BHlPFkvwZMgtVrtpP4iqqs+3B2nabTDRCmSg==
-    aws_profile: ""
   hc_vault:
-  - vault_address: https://vault-ci.odl.mit.edu
+  - created_at: "2026-07-22T16:46:34Z"
+    enc: vault:v1:4rVnuHm5zfd1RjIqpku6esZJ9bdDFxQtxR7VC47nIQTHRIOJT0n+t3Cr9lHG7HF69YEb6MkV+v0/ckz5
     engine_path: infrastructure
     key_name: sops
-    created_at: "2026-01-28T15:23:26Z"
-    enc: vault:v1:rfTO++KODl5OOKJy+OdH8yXCG05qe0I4FlpfSUXUCaKBDdJGbIK7S60QIAJwgUJYsKQrOAXKtAyfY1VH
-  lastmodified: "2026-01-28T15:23:26Z"
-  mac: ENC[AES256_GCM,data:N1ovWzo9rZeKBHSaXYzoHp1loneB5PG586FuQX2rX1QcJQfqESMjQ+7/46vBoBsNWD1Winwpm6zJROXIqT+KK6o3s7/0sx04TxF/WFhIHmB+HMwDY3Yajg35oAPVHnmddrfB8YYCt56teDMu21SFO8KllCZ/6oC+1nyjzsv5dcA=,iv:u0FAPN5DnifPgUFUb1X+keCNGcNCNYDsj4SquMSHgm4=,tag:MrhmLz5EzK7HXgXeXKfV1Q==,type:str]
+    vault_address: https://vault-ci.odl.mit.edu
+  kms:
+  - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-ci
+    aws_profile: ""
+    created_at: "2026-07-22T16:46:34Z"
+    enc: AQICAHhMkpkBpCvmFjhyfy75ENALRrbg42uOs9cUsFNLXqPnagGLiYpaEMWgeU3GOCJzsNpuAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMtp+XTPFfmJySr8a5AgEQgDtQrc4K17TvXxUU3jp9FynKH3SN/vgxa4mV4vgtT97YcOALTnlah1NIO2uC9rsYX4VOT/nJi9m9sadbvQ==
+  lastmodified: "2026-07-22T16:46:34Z"
+  mac: ENC[AES256_GCM,data:nyy9inSyqlaZh3214vNCby2ZYw+j+tq9qmhtjrkUgv7bTZdC4sH1eovnhu8FEfXv/KmYceSW8wCrUx1n066PqEZYxRLRaj4uawIQqVocD7FH6ZrZHa/g3NO/m0UN7fl89LVGNHMvZN9xcUttb9hCxdU4IeguPz5B8HswSqIuxrU=,iv:RSYUC2vtWHoy5wjxz9UdozRGV+1VZkpmgqV5Tp6SPL8=,tag:mutfBHWEYgN2d6akUnhMvw==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.11.0
+  version: 3.13.2

--- a/src/bridge/secrets/mitlearn/secrets.production.yaml
+++ b/src/bridge/secrets/mitlearn/secrets.production.yaml
@@ -1,58 +1,59 @@
 ---
 ckeditor:
-  environment_id: ENC[AES256_GCM,data:MPPOGrqlfS3UGgaGBLfd1Av6hQY=,iv:mMr7h++5Dqp9ebhqz6/36OlgUAPlymF9plMGw5V+qF8=,tag:4uTU6kIziICBi5vi37bH2g==,type:str]
-  secret_key: ENC[AES256_GCM,data:FgQtAJwHGtKIq4J7SmXEiiq3wLxFRsBw2F6mK3ZYNcwbUi1FOd+uYBm09aePkjURrg4hAAA/jIJ6mP5V,iv:+DT7ye4l6/bxT1IMFi7GiK/bRMt0lvWMHq2t22J4DpQ=,tag:axiQ9SH3fTrGOmKSUxCtTw==,type:str]
-  upload_url: ENC[AES256_GCM,data:vZc5F6sZXU6qlGPhLlfDzY+FX1PtCu8fGbSOlIJ6CwcTdzd/LeMmoXQH,iv:6LPZ9gfnLfFEmu1vPgeA4IuSRHE5U/HbL51UFi+fKpg=,tag:rPuO0fKCRVBG+ae2zvyekg==,type:str]
+  environment_id: ENC[AES256_GCM,data:IrSBBhLff0GhMw6CGSxIXzV03fU=,iv:reSHVkmYQNMO/uXLLaCbBh2HWxRSUF4gHKeAztE4LBw=,tag:beT0mx6PRIkW9TB/OzExTg==,type:str]
+  secret_key: ENC[AES256_GCM,data:xDVARBM+TNQdy/JZttWfLP2TI7nAMfNDMjTiW+67FDJgMNsFyX7dXfhhW8vCK5jTaoOTPvydm4yBlY5T,iv:zasQLxaQbB654E4trStG726Rr5BEBgyp8fpEhau5fHI=,tag:FLMOpg0d3sUPvn35CzJPXA==,type:str]
+  upload_url: ENC[AES256_GCM,data:4SzokyNYqxXik+soUzqYayc+Abdm03E6XbCwc/dmflEepSfxJzxMEC2s,iv:9zSbSPwW1fxJ3+bLKglEhWm4K3sqmq3BTC7AIREVttY=,tag:b/2V/PZ/2AOit1YvKSPnQg==,type:str]
 edx_api_client:
-  id: ENC[AES256_GCM,data:IuATI2Rnppu2uZW7vOLJtCqmBYfdqvl2+rlgYD9wkJF3vFy58KVFSw==,iv:mGkDAdUBygwMXbQvvvd8eR/zPssrGuXXuuX8iStwLy0=,tag:cRENBkoN4sqZaZv4NJ1oug==,type:str]
-  secret: ENC[AES256_GCM,data:knZT4Guq3qKXvTvdA+7YPNaByM0+1tpvdclzDd/vNyqyEMoCneMdnzUwjsrcQHt7jFSXLPtD7bLxATtM1CV6XGRXVpyxlJZ584SVIsReurm0/WGwEqdfpAtKBNN5F7XSDumMGxZZLkY7kI85kB5Am0w9YKcV6OTZSC2b7LtORdc=,iv:FnARRxQRzVjoWSqh1CCgG9/g4bjcVTaQIGscY7+T+bc=,tag:mLiANRRF/j0fYaKqRO/kTA==,type:str]
+  id: ENC[AES256_GCM,data:Td5l1MncGHrINQ6AjtCPh0E0yMVlZwPM4Q15IJoVrG+dlRbO9ZUfJA==,iv:yXFUawxeP5eNiEHS5U2KbvJMNaL6yChNl+IaFF6CE0s=,tag:IjVHXdgN+m/nj5h6Tj4lqA==,type:str]
+  secret: ENC[AES256_GCM,data:zNveKm7daryiHFTNBLDrkpdHCwSDKVlNgVUCR3lR3shpS2OzldyJd/b5B58JXIpgnpZ/7w0OK9tpbuOlvz4G/ItbA8WCUscj3A7DoHnENHZqiowSaygK9Icz9Xai1JRPxTQPsR51f7llMUdPvpIjAh98VI4xRP+Wnd/BM8Jrkjg=,iv:l+6afTObcSl5NR9hLwVwEVCy76ujsm9CsDEooNjIcZc=,tag:UY3mMYJkKt7m+1Ux7p5qqQ==,type:str]
 fastly:
-  api_key: ENC[AES256_GCM,data://TqTC9dXGgxIutnzuDiS2HRaSDFKTEvmthKcbr4UP4=,iv:AGy74KHk7Kw+zPp4R9UWiKsGdtou3W8ymCvXJFYLWg4=,tag:cGvNwrkwTrNhuyVDUfItLw==,type:str]
-  service_id: ENC[AES256_GCM,data:onsyNerhi09XgK1MTt3DoXZ/0bScJg==,iv:il9q1xQOYWMo2Ctme86/bwh8IlVkhXcBUaLAtMFrGwU=,tag:q+VV0vWaNEOc/ZT5tA3Fog==,type:str]
+  api_key: ENC[AES256_GCM,data:tzCvqH/5F85Lq/L7yy7oxxHhI3405ZvLqSZxZQ8LEj4=,iv:3TJPws58ClGlObhGCZ3jeaegChGNSGD/cHIJpjSiOAY=,tag:5B04/m9Q3HeBUUOaHFgxmg==,type:str]
+  service_id: ENC[AES256_GCM,data:CutZSKSOClMFqARWt30D+ZtjMnSDVQ==,iv:nzc6AngkXazeuXoh0xbnqC3je9GwjDigS996hOHTRQg=,tag:GuwahQfDD7hrDy8utAMapw==,type:str]
 open_learning_library_client:
-  client_id: ENC[AES256_GCM,data:VVzHCQWLinZZCsJhw+XAnFnxNatbhg6F4awff4/tWUAaA00uaRUQEQ==,iv:7xi0JZo+lkVkLjaIVFT0xQS9zAIY+xC/f3O8NyAxKY8=,tag:k0mRGwuAMbHg3UmCaqf+zQ==,type:str]
-  client_secret: ENC[AES256_GCM,data:gF+WwRUCBUy/JtSMrbWHUF6lxZGJUVy7/JH+IW6oMnV8mzyzaw+9YXLZ6GTvrJAGzLqvMLcJjU+nf6Uocf/xHPUpKKEOLvppc03fhtvau3Fp0wQW/dho6Pzff5kIBBpZ1O7VKAGlYpJ9Q/lmyeHjKSCwBSV0W+w+U+hW8q0O7gw=,iv:xrmwJH3M1u3CKsTrszllGw/Nq0A1TfGM4gMYzwuEoZ4=,tag:6o05GD5OYIBxQ1NAjKHEEw==,type:str]
-jwt_secret: ENC[AES256_GCM,data:I4Vh8SE2yye2mEYfS/ZMK3so4UA7qfcNG3GF/UbhsQ4rmGfUkshThWVu4AKO1hvf6JvWN6UCsw==,iv:3FBk40OBYD4jRxJCLE5/f4Zewxbgmbpg/TDEphW8PhA=,tag:hyb0KNKP6k3asI2UTlXzhQ==,type:str]
+  client_id: ENC[AES256_GCM,data:maSreyFoJl0tXy1k9Um0M9wVL6xnwTHdqgONnGPvI2UMoICBr2ptWQ==,iv:rwSaIiJ+7UH+TIpN4VSXRDivCbti5+iEoofI/tVuNJM=,tag:1lCtCii/+nuAZDQRST9raw==,type:str]
+  client_secret: ENC[AES256_GCM,data:ohfuptbauoV7vVtUjnawS6PZF4E15k9JfozvII4LTxyH5TRM/WgiBsD1OQjRMPm2LQfYHT7oOCpS5hSLfbo5vb8qsNQJvS4Z1ydYeiWptDM2+fUvK79A58Vl27RHx3Yvqls47wD9rjUh6Fo1WfbYsBWdYcho4hnTLhF6QQ+Ctyk=,iv:WUBF6NMi/4l571JIZ/5eiGBpP5uhG1RPTo7g4A4IwSU=,tag:81HnxDPljYXucMieT34NoQ==,type:str]
+jwt_secret: ENC[AES256_GCM,data:Su5KtiHBa0LSl8wO1ajDftWUzNX0+D2DaKTRY3g8HUGpUZpdhOyafJlXqFS0ecojHKswfmavZw==,iv:RIxt2lBIHY0xNkYOOcQ2Yu2qWMfPMDQiAKCbPjnLEQA=,tag:FCaWvDRDzC7yiXvg+QHfpw==,type:str]
 qdrant:
-  api_key: ENC[AES256_GCM,data:xiVymCE/WiW5+sjNSeK+fzN4mO5pba7SwaK03UkDURZFtlfQ2lhJhdSo3bTzktCfflTeCOsNqoKlLxf0S79QHXgvmNL1X2RSIkKOuqAZAmh8o0VqOKmwr1wqNP6vvOqXXVqUXA==,iv:PwcXf/5XOGVpRIvG4ZtP4WXwzDA/okSOPa0VdZWDk9E=,tag:9qBEIk7kO49FwCT8t4ZwMw==,type:str]
-  host_url: ENC[AES256_GCM,data:ApTvKu+28Nx2/8ofIOUhXfFLr6Evf/hwRBah0OaqS60A+h1od+x8wkA+zt4V1TmEFYSwhL24p6+ZLJl9HcVZ5LNDfBomDQl+2zlYcQ==,iv:pswmSdFhj/lN5CW0rEfWYoVJmiw4aJUQ5X5FsDuzGLg=,tag:zKqWI1lohknNeZ2JHT1L+g==,type:str]
+  api_key: ENC[AES256_GCM,data:/ofnpuxpaqkLJ8lnfO+HY7QI19Rc7wITU5syaIG4zMgj+6c/w60RO+I+rCoGjNNjDvN/9oxfsj91myUuW+prcpK9Rgtbu99/0bK/CH1vulagp5+yzvcdNyI6yT9jyzdULyHZ5g==,iv:IjoQzLrPbjBU2WoCImZBIPsd8pIqwiKDp8EWxNHOKLM=,tag:R7wp98wVfFJVhMf1aRMlqQ==,type:str]
+  host_url: ENC[AES256_GCM,data:wfIfeVzsAGIlQqt2xTC0Zq6Jj25H5L1TDvt9rI6c51zRPTJG6Ce4ffNJIVmCNxP+WTzZiqX0Foyf7RUH+OrxvHR8/bxYyyYVSrZubQ==,iv:bXe0flpEbQBJRmftj0BOmPtPYoGUL508VcMXvY7O6xE=,tag:z+FL1mlifmTCEkjwl27McQ==,type:str]
 openai:
-  api_key: ENC[AES256_GCM,data:OOn4xgNzRh7iU/+MGzXKeKEEUHngkBikfyJncOmZcv9V3OC7EpSyY2SG3Ivt5H7hmHN+2nSBZknBfIynzuHcJX9/fCUUKPe4p5qa63PnSGh//C+b7/3WbWNTNP5hAP8uUBqOaEfUGi/8Pbml7taPc7+GVsGYHOO3SB+btBfrAg+fDj7REIpGPFzE2OvNID5NhlDBNoXG3Uegi2FOIuGqEtzpdVNT0aQ=,iv:6I/6rssfr7OpGSOlhjTHIWwIuT0nS/FMvWvot3eBaJQ=,tag:Pnha4hTtzW4IDWpDTHJBUQ==,type:str]
+  api_key: ENC[AES256_GCM,data:Iu/LQpPyTUlgNSeCoRj3B/DVm5uvoWNG2iYcFTXVzHjPmLodGThoIXVQLYTOuc8D1XJqHvWX4Lg6Mq1B9xeeollGBqTwDBkkQqgS9SNADOR010N+m1YbIJ5M5UT5LaCYu5isn+AWtp1SkD1nFHk6Xc/cUkO6G2Q08d9RHd8oA45/YcRJWCrE477ZbD82Sx1Gc+NDz122uDD3KAEgiDrnuF0E2cQ6xJQ=,iv:t6K+iibXJO+anHyXVqlZTWYsaKMvBSx3TdaavhoTm0E=,tag:HdAQo11XNfH5gaaq4/YImQ==,type:str]
 opensearch:
-  http_auth: ENC[AES256_GCM,data:PeIbuwN1ifCVFVBJ+zsrxjJrEE685AfHXedqi9Gb2fan8a5/auQsr5t2afe7IrMMbggJggMqrA==,iv:upAxPR84p0YSsAStu/RyBXI98aAByNdErPbDFBiY2RY=,tag:1P0HvXCKDNYchMQHE6A4Sw==,type:str]
+  http_auth: ENC[AES256_GCM,data:8iJ3ZLczQmv5PP/kEkEGR6thLka40mXneC4UYfyC6qK0WiV4Cfjdgpu2kEgxuGwffbT/ku4THg==,iv:sPeG0UnmxCjiMoutN4iQwc49W9zH+HVw0tqCePNhddQ=,tag:vUgkTEUgRFXi24NgO02uMg==,type:str]
 recaptcha:
-  site_key: ENC[AES256_GCM,data:bSlSX2wZYTj7rL05jzrJQUfA8L7+jhlCJLQ5svYQOGbMC9meYwYfWg==,iv:QMjhFm780wWXJj4xzrBzegnvjBgndt4DcVKDqzH+x7k=,tag:evm9EqT0gR30c5om+DwyuA==,type:str]
-  secret_key: ENC[AES256_GCM,data:eFgH/y1VvfEHzG2rbODxnsTkt4BPT/QuQpoS9Lskx1dUPWN5vIVWKg==,iv:RUAsnuMRO5pMHRocXpAl0FduonGT7IMx6zZ93PRXoUA=,tag:2j4U8QwKroYhjX9vL1Likg==,type:str]
-django_secret_key: ENC[AES256_GCM,data:M7gGfyykHoKMXl/9rejtPgY6yJ594pN9S0GM0zLZb5flzyEFTwIhzZC8n4vo3SJaUI/Q8fzECPqVexwwkvAaWw==,iv:yygUtzY8rbevnLXF0LMO4wWAMO+gy2YnFkH75yzaUAg=,tag:shyRlvLR1iVpJo3LEhgyuQ==,type:str]
-django_status_token: ENC[AES256_GCM,data:XqW8RDQgzG53cRI5l6uM3J17DVDW1M9n4vsZMmZ88WaYnbLXmdA9NVbv2McPhIHWRkrT78KdhCbhaeLXZc2l0g==,iv:VLlSUuhnMAnXocWYCwhKs26gK9ZSqlG4vAAwcDHKMNw=,tag:PK1NbIsph+cdWp+czZFJbw==,type:str]
-youtube_developer_key: ENC[AES256_GCM,data:q9zjMja7XfPyR4ytymc1MzPY13llqfObHfvmDvyFvn+2PgDBWssP,iv:tCKhw2EeuI1RKmSlP6NdCxZCiIrn63HsqZyd4yRz8Rs=,tag:WRzWK7usTrWXbWHFnM6q/A==,type:str]
-sentry_dsn: ENC[AES256_GCM,data:o8lJRjlbx/6nrJFjR4hD98HEbvbH0j9Qb4/4rGz+MMcnlDcGP+UNkLrsRAmf48iS9Q35d3hKeitejknFJiaWLHwnZ6iZn+6K3rugteYSC/sRoIYG,iv:IuVYFaNpwoq8ZRXIaLbka7qUN+YcyUm96ecku65OR/8=,tag:Lk9P9T+eUIo35G4+Q84exg==,type:str]
+  site_key: ENC[AES256_GCM,data:xGwonVk8Nagt9L5sT9adRDj7fsDLctliEQJ7ixof6Lew7JE3PNXV7g==,iv:ddiKHtE8l4zMgpYfUk/lFBMJHGLPHgTNMJqKRApxOlo=,tag:JcaYGOGU1o4RGpB7eUi9cg==,type:str]
+  secret_key: ENC[AES256_GCM,data:T4J6bne6D8T2l5Xkm7tTEUw3FBwODy/NcsUpIW/c6QThkuFgWRdulQ==,iv:oJ17oNT4Ys4KkvKlaco3FTm9hF4vFKctzBCOOgZI5pk=,tag:JnciFGe+noEkTYxeompIZA==,type:str]
+django_secret_key: ENC[AES256_GCM,data:0h4Q/mT2tNrqzZk/L2R0SkVHk6MJoE0V9sYD8h8fpUPTNGpqYFiPbzyCtrTMHqHjhizhuUD5B2PyFmsx5Ac+wA==,iv:MB7vqOdA5HF3oMXcD1AqWX/gAeGHa4H7SSCUl5FAMM4=,tag:+AsEKspRuIn6mSOJ27YwiQ==,type:str]
+django_status_token: ENC[AES256_GCM,data:xC4+hbQlciNyiyoLYXm8Tgr0aR4zVT/1V+jaBdLYM+vFVP6H9X/q9oUI8DvQoaPe0V6EvGAQJfAtx4JgEliIwg==,iv:DAb6Y4J6eAPNFccSPhs8lRVo2ASJHZl27XDlufMs6W4=,tag:GohFm5gP+I2uh88bur2dew==,type:str]
+youtube_developer_key: ENC[AES256_GCM,data:37MHnnTh0u2kJKa3M9vYhwARjnI2suokZkFRT6EO5awck/4/sYKu,iv:mX4Czwd+7FuwepToeR14QegN+1G+Nrd7e21AsBNsUS8=,tag:4IIDdIdk3cyeEb5HUaUmsA==,type:str]
+sentry_dsn: ENC[AES256_GCM,data:NcKIDSyKDiysYK9gQL7Jgmc9YmRCWHGsRi5ff1Z8x3cGRrIFiDAVn5K5pEvGrRegKQQS4YNlXbWy1hsASfPyPmTXm9njVLPUXUGV+rfDHLwojawL,iv:mcFtFwFL3/zo0KiFJeeiBCLsCPaowRuAsagX7NYSmbo=,tag:JWJWojSMAL81okNS6JYG/Q==,type:str]
 see_api_client:
-  id: ENC[AES256_GCM,data:fe4UNMCior8m64KujwjKpT/LmtXQ2pzZPmGWrNSGNF8=,iv:4sXmy26c4GWQKHebcIoejBeYrbkczA24b1SuYU34aXU=,tag:QgH6F+EmEhF04Ols4mBPVw==,type:str]
-  secret: ENC[AES256_GCM,data:8SgjD/6Ljlmkb8xbC62MAzKvsB/nz5F1U0XOV5jGBU8=,iv:GW/fukui/cyJO0mtpx/G6sWcf26kpTgtiYnVWdX1+0o=,tag:YhxQRrTdHkvN4ijlrSSE/g==,type:str]
+  id: ENC[AES256_GCM,data:pNQxvEmoP4OqjUInxzV9rSOdv1EYrHQEM2Or6DedksI=,iv:JH4CKpw99k1zpZD0PsSmh8By4UwF3e2NiPVZ16YQ3Kk=,tag:iZFRKl6jDaZXOY85Pmy5fg==,type:str]
+  secret: ENC[AES256_GCM,data:yT6at+HVWOZb7d+OW5X2SakWDRZ9xSRWo9gC5UFt774=,iv:/rGe94ASmKtQ8jyFYMO2B9kItRXhsGmd9BPvy6wJeyE=,tag:8G6t1ayZQYQxtIf0ZMj2UQ==,type:str]
 posthog:
-  project_api_key: ENC[AES256_GCM,data:L+e5eujP3QFngSflL8BjrcsE7KRF3vfZC9YP+QkY+vEqBAGjScVdW2f4xby6ciQ=,iv:t8vCCX7M0y2FtprCKp3+lz1INUl+MLWHtqgUQx6h1qA=,tag:3MzzEN/jEM4IRC4zRb0A8A==,type:str]
-  personal_api_key: ENC[AES256_GCM,data:BE8u0vPpsc2GnLU1fvk3u9pebreCPjKbZdC0TGjkop7XP8imOmldevkpcxSeSYPUOVRv,iv:H/OtWTEqhSXgzRFSYZTk/bCONIwwus6WBOa3qYB/Ufg=,tag:i/qSXVbFAfSNmKaqsy9N5Q==,type:str]
+  project_api_key: ENC[AES256_GCM,data:r2uMGjX1U1TOmtcLtcWXj/2vZ417C/QsnF116latXSQeKNUBGq/f8DorYeRxgsU=,iv:sTLrzZQd+1MsLhXeg9R0Rf1J04oauJiQEv3DEMpnVSA=,tag:mlWFUS4RPQj/4vAbxI+Hyg==,type:str]
+  personal_api_key: ENC[AES256_GCM,data:w5mNuYCjNuDVe50q8VurQPFnXFOy66VNTPnfsP9ezVSYWaW+omADVu/6rvNzdxpW09s7,iv:0XcGeDZPOOnisCZnqZVZa2ubMB8CX5Dgv/VgCAtcz/Q=,tag:fchdUZQ0B+k+M66pQB0YLQ==,type:str]
 wagtail:
-  client-id: ENC[AES256_GCM,data:ej1g/WKfU+YFKHbZHY46Y8YaKL0lVlBvlu48pytqB4IBFskmsYS0cg==,iv:kpLE2qWkhc6+L5f9kizpc92tzr0PS3ZyNAbrO1tfKvY=,tag:bP25cQNx3Ug4tgbMJ0R47w==,type:str]
-  client-secret: ENC[AES256_GCM,data:D3umgGb37gGyILTmrpIIEeiRtqNjtXDxRjgCg6mezzvCbQcKGGtJ6bFZB1ixsvZDhuMqyIm+HbNMkPTMHSwkAtKvwy9pyOWVasrMI1a/so0z3oqk5elxqZgGQ76M+m1yPtLf1p0dChIjcoF1/e9C/9+D+r1ey4C9MXoPPVGPAMU=,iv:aYDKp5C+JuSQ3sS9J0Etwwjk2aG2kCOTZOvjGflzcpU=,tag:vsrIwBl1VQto6ZukgvkawA==,type:str]
-  username: ENC[AES256_GCM,data:ZGwVpds1dzzJF3nlWKZuBwcfUF0Ks10Qyw==,iv:+ScmyJztk3V4srkFQToFlGHgn0YRj/VsK6xg5xHY+J4=,tag:F6vMPGeAQatowCTrXomiNQ==,type:str]
-  password: ENC[AES256_GCM,data:lJ17cmFD0QzZaNYrFDxyPEo8,iv:z9wAPIB71pnOBLW+2ContI6BgKb56uv+Cbstbp93kdc=,tag:4PkPcPrSR5NNyvxcJEbD+A==,type:str]
+  client-id: ENC[AES256_GCM,data:PXORVmjPvWvy+dNbWeJ1nA0ykOZGHSFfnuwOMyonvoJRHpMq+u6Etw==,iv:4/VE2yhBj0+tYx8b1/3CyxdMrJX8833i/ZS3jdaAI5o=,tag:4k6YeXFUve+x/k4MTk+PjA==,type:str]
+  client-secret: ENC[AES256_GCM,data:vDcHXpfcd6ocTFCZqHer5rP9qUoN1MNjxbsb6z9b1aGYnvQfrrWJwG9dZwo1b2ySfW/I54IITZVFUm3GDAgfEvcn27kQZUJ2iDOxTudDEXsRw3SGK25fI/9e+WBidIp+B9P0DhVTToZ0VyWUWk+lrJNRctuOM1y7ZlMlsdWqupQ=,iv:zFzHW7x7C2D9LyqQkz64uob+TnFun2bK8gpHcZGnK8c=,tag:3+qPmMLCVeYHMsZ/aoYSvA==,type:str]
+  username: ENC[AES256_GCM,data:ogC3jzWzYaFIuC4+O1HQkgZLvd7Kpz4OVQ==,iv:VE6O7IL18V8cGHiiYFfoUkZms18EtEGoZQhOQ6phJ7k=,tag:LPSD4hsSS2xEIuABDwzbgA==,type:str]
+  password: ENC[AES256_GCM,data:uZCeReQ9OPCHbJN6WnX3VIup,iv:cESLnyqNeNn7g5GtUJXRgVuULQq5wBBJhbSiSbn8MMQ=,tag:c58mJ88YsUMDu9EIdmQV7A==,type:str]
 mitxonline:
-  etl_api_key: ENC[AES256_GCM,data:29JrcLZLS3t7AdcOA9QcxiefwxO9GNYL7Kv9qWQDPlFLfcMx77LG3so=,iv:+5yAJ9jIJcN1SsMPxQqpgbo0ZIIMu4Y9whXuS33/g5c=,tag:V3WNC8P6FWIkiDbmmxKptw==,type:str]
+  etl_api_key: ENC[AES256_GCM,data:r4n5BNsjjMx6XbatPAhrJTz17HtVnfgWE8OqV9j57ju+2fNhYSGO9oo=,iv:IK0sOgXYWWv0pkLB29AH/hgv3G7VMzYHCjVYtqOpZ4Q=,tag:WWQcP3Jio+Uy7c5J30f7Aw==,type:str]
+unsubscribe_secret_key: ENC[AES256_GCM,data:G33BFGkRIw9UE7C/pp5Se7MGx4gQrQOw4on7feuw4y5wJW01yCPlGg==,iv:2cvEjSrTDsVioULwF5wcg/vd2zzrryRo+Z4nO42gdfo=,tag:HBkw2HWG+P7zVIqxnNca5A==,type:str]
 sops:
-  kms:
-  - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
-    created_at: "2026-01-28T15:22:20Z"
-    enc: AQICAHi3FG4qowC3UzOLWOAA4Y9/RTwqKjovG3wyVVYDxkR+zAHot8eTpEgmJ7OwDpz1eYizAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMrsRAPFouQmTpyCP4AgEQgDt/MXpR8720j85FtLW7T8CENPR1noxdMJ1oyaZ6GMkYxDSf6rQY3E8tI5rAOAXoOMFPiXKxmCKiP36O4Q==
-    aws_profile: ""
   hc_vault:
-  - vault_address: https://vault-production.odl.mit.edu
+  - created_at: "2026-07-22T16:45:33Z"
+    enc: vault:v1:jjRU9bTUX4tUUlvbkb9JNn8Cc2TzWQCaU3Wk1FsbDtOuqyhKBAxS951jRdjqkmExT3mbE06GcIPNwdP+
     engine_path: infrastructure
     key_name: sops
-    created_at: "2026-01-28T15:22:20Z"
-    enc: vault:v1:MXzLvpD7+wNYi60wklOJTIRoiGHleUxdY0Rd4tQr9R9+FsjnObKUaLocK8mzn+pPNnIN3lRTVe3pb9PX
-  lastmodified: "2026-07-07T20:03:32Z"
-  mac: ENC[AES256_GCM,data:NPwPeUVLDsoiwZQKNl3/5wgsayQA6/6zoMZyvLkVKgzS3DVyB0SbXUuryfo870fiJkvfzZ5g8kpg2YEjyHP8OxfwUuHfimc/GIxzvbG3SxHsmgR0iQBb2INUEUFZF4s0yeMflC+qTSoozMVdUGTIo8wIus0amb7ID8EaNqVjWhQ=,iv:rz+4U9t8q0KR6znNojMjR5UyQx/YlDLqOrVLeBvTP+Q=,tag:cDLYRWMANietUWga9cK+4A==,type:str]
+    vault_address: https://vault-production.odl.mit.edu
+  kms:
+  - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
+    aws_profile: ""
+    created_at: "2026-07-22T16:45:33Z"
+    enc: AQICAHjksIVfl1VtAHpBda/1YYjj6tSeS2o4TXgvEEyBIXLjjwGNRPa1GBO1Co56kS6yE7teAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMh6JJ37+hKFnqgSB4AgEQgDv8pJ4lfAGLIRA7GFHdJvO6XgrS2vGVZRtoAb8w8mFPfFLKDoNW9PdZS9XiEsBG+3Nv0gJ63GKyh3ZLfA==
+  lastmodified: "2026-07-22T16:45:34Z"
+  mac: ENC[AES256_GCM,data:nWybqqHySti1X+nuctQKklLnKbuqZuZc7sSZQUQdQce107uW/U65P99Kk9s9GPEHGouOAPGgA2QX90+CqVZR9PPHlo8o583zIHf8L1bIEE+U8p76OjhifqcX4OEMz9WAFHse463uh5DL4+GYSVGH+xB3TXYmwMKNq5tJonBz3qI=,iv:HHSgPVdQQB9TsseGZnwXBIaojYu42qgx1muOI8yZiic=,tag:JqhyAeagAov5IO2hjiIGpw==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.12.2
+  version: 3.13.2

--- a/src/bridge/secrets/mitlearn/secrets.qa.yaml
+++ b/src/bridge/secrets/mitlearn/secrets.qa.yaml
@@ -1,59 +1,60 @@
 ---
 ckeditor:
-  environment_id: ENC[AES256_GCM,data:xdDN/i+8f/Ycx2smBdWiYDSisMI=,iv:Q56wWQVqxirxGStDNgzRd5QEhJEz7R8c3HWEG++KoNI=,tag:N3JmUr8d5Q2yrxRxy7UeVA==,type:str]
-  secret_key: ENC[AES256_GCM,data:JE6zfAutmxav2Neyneju3WoVWq9DeftI+DwvmpDOUQULoAPRy/Gl6V+iwXtITRssT3IUbI4//OVub5Mg,iv:1zoIispJ4/21zPaCzVZAoq82+Wr/d4GVYb1vxDxTLOg=,tag:DLAq8RBb+ntVCsdtDkN0tA==,type:str]
-  upload_url: ENC[AES256_GCM,data:rFU3UT0FWBnvtMusaCqAHRpXslJ1qhn784/hPwL1I+i+tuPEqQghXfL0,iv:/9kYw6y6F6BYzfSbDtlWY06o7A9Ya55qjaF2kVBkpnc=,tag:mnugcgqAO/5P85P2rlmF9Q==,type:str]
+  environment_id: ENC[AES256_GCM,data:cX/UBHRCmix3Jpm4Q5NlrH8QhdA=,iv:PP9UO2DkU2LFvfpVrZg1xGa1D6Zjq1C2M98h+17P/C0=,tag:EZ4k26tIQ9WJBCOw+KfMUQ==,type:str]
+  secret_key: ENC[AES256_GCM,data:EM7QP87RREQvCMIioDixDG0GFHVot9NOF/5RQ6uQWyl/umPuqgaR+3F09+JL+uV1lXzO8sigk7q2jYcj,iv:8A0onqGRw7E2v10TD/r7s34yygga5xu6N4bGJoJv+Ik=,tag:sUv+tsPYK7hVGdbiPnhMsw==,type:str]
+  upload_url: ENC[AES256_GCM,data:H+TRCluHP6e1KkMmybxche9oqDJjW3fgfo33oIrrV9d+7wJklJX5jOgq,iv:+T7DViwjlCmxmCP3O43FU+R5TLOILML0ZLCrJ0iVtEQ=,tag:a9sxt1ApMWpsJRBMHxPQQQ==,type:str]
 edx_api_client:
-  id: ENC[AES256_GCM,data:8oJ9J/CEvuvqo7HQPAiAp67UlLxBTkOJ5VYrN5QWgSqbqj0jc2OC3Q==,iv:FMKrZLJ+kCc+uhavDBLAeQcD3VBashFwerLQJNAm6lY=,tag:bqHeVFtgTb0TmRhTmxGhPg==,type:str]
-  secret: ENC[AES256_GCM,data:GI7AL+zY1qCd1pmzW3Jvxp35GqLVGAi/w8qQAIieD6tmNjKZhbMUa6w14IWXpggTF8cV1ZjGwP765duVYVw7lD3MvYrfoqIugRLNO/c8tjaGd0R5PTmhPOqtMjMBu+PzO5Bwa9Xe67THtFX3CzzNZUPAkR/FakhX93uD+S/RfYA=,iv:lQ7FAWPwEFVMGuP2u15wLG2N/gFfnQ5NXvtmrSFj8ig=,tag:qQ5r4445tTRD3N51X1Smbw==,type:str]
+  id: ENC[AES256_GCM,data:ihryEMVLGVNijSx8CxDm9/9NPbBpoIGDnGF2IjOLkrKNO1M2kLHyCQ==,iv:8uRvF42fLrUpEv9PXGEoQBSeAx2ySvNFPt9Tfvzdn5U=,tag:AJeUP60zUTZp+tC3QuRjpQ==,type:str]
+  secret: ENC[AES256_GCM,data:JIIE3LHRBynhokQ0Z9MXQ97u8QQqUvHR90yNJqT6fCcw3fxE1UwAqPL0lo0OBW5AkZ6NNr2Dy7Q2KObdFz4ElWavVMXs43dImF3eT7hR4fRnozGQh/BXjwLoWEy3kX/c7VPgOCh/JVHBkoPDwsyXmyirJ8IbKC5aGdu2MkznUdY=,iv:thHD4QzMG1q6Vto6HMnhZBHMF0Gkzzh3tLcbE1aim/w=,tag:bKjnv8A0iNcsU+Dg6n5/Pw==,type:str]
 fastly:
-  api_key: ENC[AES256_GCM,data:fz33hKg2/5KesBGUAoELfSXApPM3X+gGSdMg7GBau84=,iv:zbpKAmvsLeiGy9v8hKF6fxe/altYaoKGnljxg6015RI=,tag:1ZWmjtdQ7wIcp34ozLLRiw==,type:str]
-  service_id: ENC[AES256_GCM,data:uMOA/BOtP0G9ReTExfwsSJY37JzDwA==,iv:klvr0Q7P++3C1mY6Xq5H2kLUeIXj+yrDwjxRY1doM5Y=,tag:JwVFmGbdzA5XeDyZSE/GnA==,type:str]
+  api_key: ENC[AES256_GCM,data:H6nQAfaQNOm2u2BmvQlbSVHT2A8SWOaGBBoMo9aER1A=,iv:QLz+zWVoG3dSXJMRfEsRXrfxKo3UcdaMMeF+yBIWhIs=,tag:kBMd9UpriZDXvS80DZED9A==,type:str]
+  service_id: ENC[AES256_GCM,data:wbN30IxHXX7hlAwxe83IeefcPFdg/Q==,iv:J9iBvDGU/deeRJcBMvbwJnNMcZ9ozD3ZCfjaKFzSgs0=,tag:3/FKNkpziwPdoC0t555MPw==,type:str]
 open_learning_library_client:
-  client_id: ENC[AES256_GCM,data:xeiSmlS9rSMvSQ3lXIS0rWMViDppgU9K47WEHDXOwQgNpMNdKYUFkQ==,iv:f8/tOpuX8YpwEWZOxgX+5bY0vyZyshByjf7x1AKfKtg=,tag:/BC9GagT9cS3ZCbe/aGKcA==,type:str]
-  client_secret: ENC[AES256_GCM,data:L82lT6EMpcHxDqKUzdNkKQ9W64BDHyNSDJR35pQ1Lfl1gD/TCFZMLwtvHdWlDzg7Z9SGseIwwm/IJ/r+B7k+Sv4Q5h9hC8gcY4pdaAfcEBrmCe5LVWUS92GxVNiIXjz6alJBtjxk9yqmNUKThjQyETYDH0LC27JNXb09RUK8e4Y=,iv:J+3xyeh9qKSkI9/OiiRyQrQ1yrym60GLE/y8jP1JH68=,tag:FOiVzo9dkHIThZ8oalySbQ==,type:str]
-oidc_secret_key: ENC[AES256_GCM,data:NT1UJKOJDd7bITYhVlt/FF/dk3aFRft5PH36+7LITjE=,iv:tAMkdaKKdcnl99E6wJObqdkxrMllLvz4IdUsESfGBoU=,tag:T4CPWcvVz2irBYslmqPjUg==,type:str]
-jwt_secret: ENC[AES256_GCM,data:9nqyMJadQUruizfl8U70pSbtsjFF1+LHsYZ4i9uHio4xEE9D8g29shN6/B7+0SoR7NRxbYcatA==,iv:JceCVIqoyfr7reMqs+qKgyJTOF+AcEIl4TO8bjLzq9o=,tag:7j38o33Tt7ELjR7mdd9qtA==,type:str]
+  client_id: ENC[AES256_GCM,data:DsdM1TkEG6l4vx4QMpj0o0OASmXco+Gs4EHavTfg/dFqEfZvIuJ5uw==,iv:wORzWeeQ+tjez9wc1OkrfxIKYv5g45gjSnRqGCgURIg=,tag:z6+mDJDQuD0uPEby8iMtQA==,type:str]
+  client_secret: ENC[AES256_GCM,data:5G2QzlAsqC5bDXg6bsm1CjH2ugH9QHkoJXFFP12CUvBwTagXnJgI7orKmue7lmSdQYvCdvedNya9AC8c4/xRqtDoxflKL4SN5VPBFEyS8G+79ii6MM0Agovq30h6Vzxy2Sr2RGSRRrTFcBJTFuSHjptBeECl+byzAXyXken4GKc=,iv:u/st+ENjlQROjeO8ccAhsU2VwtCUur9pwLoTq/aNuBk=,tag:yyHDjsjgJD/mNRpEOcDvlw==,type:str]
+oidc_secret_key: ENC[AES256_GCM,data:6RDgh2/EvC5+RLAIrEkzP8NxBI1WjM0uqCNaD9zMFEQ=,iv:7AgTnl9owt+hnCZ8aWGdhfJmg72ibD0p25rp3BRs9D4=,tag:fliuDt727hG7+hsLQeU8HQ==,type:str]
+jwt_secret: ENC[AES256_GCM,data:6TsdawBSHjL0bFCk0HZN6acq5RVGJHcA6gKrrS5Y+LISufj+lHiU3xzikhpvL96U1Zlp4ucRKQ==,iv:XxZnOR7IorryKOdF5Uk1piJYxrqTZVL89FlW3kDW4lo=,tag:iVWEaa8LfYg3dng4ApQT+A==,type:str]
 openai:
-  api_key: ENC[AES256_GCM,data:Jsp4STXcD5sihOaI6zKL62A6b69L0pq9ymGMwpaFuqpPSDAEHcoSOaa3+vZdoQGGH0/yN3rIN3QNEqrUtgd0A8GhaAicGWdnO6i1Zn0qo3JkH6G+I5A6Bmed3HwebQqbDk18kGtACHdCZU7Ag1IYP8galOXBmCoF4mY3wJ4LXtBDa04mRZaRSAbPEL37JF5SwMgoUFQCXw==,iv:6zUbv9Oy549dyWenKA1wkaIIr1yfkZIgKP9pznxLGZc=,tag:c1l/m7tghm2+rgRGF6cE0w==,type:str]
+  api_key: ENC[AES256_GCM,data:7MkUDJYE6NHQWi5QJRojDwx0Thy0an/GKwXBMp5OKKmBPa4sKK5qPkdoJ9zjMEFMqNZYA7BvwPWMZTAOcGNs4K6S8HLTgfzL2Hm1NSA+Zh2PsKRZ9hPA3LYeLSz+4OlWjMe3nBbAmFdNuQwd1zYJg58u+DarA++qZ0RMNd+l2k+8qkbQd3GEw3qv8q9NPE+nhwMX3Da21w==,iv:5hnkjrH7mvytBfI8aJlN7rVGWhAshsgFK+PAu4pjVq0=,tag:+z3cFvNxX5Nlok0jVjplcQ==,type:str]
 opensearch:
-  http_auth: ENC[AES256_GCM,data:E3XrQOV9rMqAtiWV6dwgwgKAKX1mat6MY2Le7xtdaltXMn+87o2qb3ysFt7BMoJRM7s0oD1x01gLQV8=,iv:O7qw1p4oOLLHLUInGGOxAGEeIRbL52BUk8wN3cXPUHM=,tag:9/Vd1rXAq1Nr5a6nDDLXNQ==,type:str]
+  http_auth: ENC[AES256_GCM,data:y3bOt+/Jzm7lTFIcioiFLWjk7JR8IMH3ZuqPn/rDF4oC1JgLf+5bbz+J+wQi309K4WKRyw8t9QYlJXc=,iv:NvgXt4FKNX8/cnF7W1sxwUFeCpoJM8pusP3XSk4ac7c=,tag:grENOkSkqj6GNdzYA2GLxQ==,type:str]
 qdrant:
-  api_key: ENC[AES256_GCM,data:njvQMxrlGPdolX6x+qZS6Ro4tQ6QpGkBXpPBhBu0VsVibyYJkSQ2dre2NOgncu1kDQG82fkW,iv:PsmAaHcOW0rlz1nHOE8IbOyvypZkEjhIp4dY7+y9ePo=,tag:89OVqPSkLUNtQMYpjvUPuQ==,type:str]
-  host_url: ENC[AES256_GCM,data:OkRDijgppymDRE5CwkVQKX8DH0UFOfvQC/d7Te6zVo5IBMXX9dkga9yvnrPFPH4ZHS4uxchHD2/3slACq6nbCKuw1Jc3d4ZRUzJGxg==,iv:gWtyiEaEI30WhmTBZxWdHn877HaP8THdS8KwTbsBlig=,tag:6SQS1sRcmYwDkPgqrP5qqw==,type:str]
+  api_key: ENC[AES256_GCM,data:AKQgaw54ANEKDN/ddPlQnH9kferJYiE77SbiXWa5oYVkqxTN/TVD05LCrj2zEJZVEA/nGqAf,iv:9Gtuq8Mkuj2DrIdY2UsoYuQBViBh8sWGmYWvxhUvWWc=,tag:8PXpnoIN8SGnDjcNeWq6Rg==,type:str]
+  host_url: ENC[AES256_GCM,data:4AMgJJ8hq6/3fW02ATiGXL6tVx4e97qceALOC1Iex9z84F7eukCY47QpSapNmJZrHVMOPOlntbzYk44VwcV0YKY86oSWJM2Ns+vFiw==,iv:G/Cgx1vmI04BVLtDqEY7fITOYuLARxeLSOnB5N8rGgk=,tag:JujDHPKmOG1PxLFqtSbghg==,type:str]
 recaptcha:
-  secret_key: ENC[AES256_GCM,data:5adHsx9DpUp5A+3UF55ZKNnNasAQ9Ky4Tv/2wP/kTBHNOzK9CSNqjg==,iv:poq5ql886ixWXdiEadmwYVe0isGoFgsJkNhE7q7oEqg=,tag:XRAXOxWqr0VuC4X4NlH52g==,type:str]
-  site_key: ENC[AES256_GCM,data:o5GDSNhh1wpzdnGgHEPIL+tDXKjmrkdrEFNNvGXCRLA5H+di/nBOUg==,iv:vcdo3U7IY6mT+iPKDgcRCaKaQCekbhdqVg524qbCSJc=,tag:IeMe9XcDhyHcRQIvq3B7mA==,type:str]
-django_secret_key: ENC[AES256_GCM,data:gWFueCOw9u/kFuee1JpNYuU57JEB8id/xouK4QHue5mZEYaJRK3a6s/xuc+m5evuWBhwNSaq7zsXKmyS37PqwQ==,iv:xE4f/S5O+MnEkfMuV6CtG8Ff0NVaXzbmFTQVSz+ZvK4=,tag:WcnDapiqsbupTWTj8zMBnw==,type:str]
-django_status_token: ENC[AES256_GCM,data:Qzhhu6kz/iT/+OY3DYfT48H6vyXl7qPSjFBM+fS0A+QL+a7tu5SX2zUZkTIOXk2Ca5CfoXXnwtKOLphgz7CtuQ==,iv:ld36mqHvqa9L83x3C5KrReh5X5ZkbYMLJ/6q6DfOKBI=,tag:GDX4CW+i7+o6GgfcVLneZg==,type:str]
-youtube_developer_key: ENC[AES256_GCM,data:trIt04itBXlrc6kWwl77uzE7nVRGGzDQ5aTLjngmyThKQT2rmD5R,iv:WM0kWlkHPOrMO61+FnidmsCBz4/0+jgKLD9HyCPddgk=,tag:C5UBttwLTx+m3XLgtmwlDQ==,type:str]
-sentry_dsn: ENC[AES256_GCM,data:ge5WwdUmo/bJrZnVUaz1KzVXxLKKCLT+ro89mM3GXUZJWbj4LWASzExC/BOZtmQPty+9DtjGSE4UNyGilLtULGCrlqtG3yVIYMlJnRYQ3c7B2Let,iv:X5roZ/bzEN7eFCuHQh+qhgiAZ73w+CjL24NZgEqs1aQ=,tag:k4Br9FtlMG6kvoMNOA5WUw==,type:str]
+  secret_key: ENC[AES256_GCM,data:nfPPQilDxHDBJi3NGkc/477CV2X/bnIEUWELDsArZKhhGb0AeGBalQ==,iv:s4UDeqv+VULsYit6+dxlINJj0SVZNh1xtayrVOOkohU=,tag:R9Pg0KqPG/LlDoCaIugBUA==,type:str]
+  site_key: ENC[AES256_GCM,data:AHm9IqDI4nAcMbdXPKIQlqZ9NvRgCWLDQQ/zXwBOWkNUnZ1Sb9F9+Q==,iv:VQMiMsLUNPL8ildonWHt7dq5KLA+xGM+t+BNycEmR8E=,tag:k/MsAJP/QA/3awQkVGw0Ew==,type:str]
+django_secret_key: ENC[AES256_GCM,data:kzw0oQHSI0fA68VzkTVZt1kulzbQ0LIZkZsq5N7ceIcA3t+mUprYOZslRHBwKLEXOLhyHr9lqx1N5ArYFaxGwQ==,iv:LXdiQoNTH+1Ba6sKgOShvOHKBU1LF+50zhhEeynPm04=,tag:CDib0fc/uh1sSoqTdsn23A==,type:str]
+django_status_token: ENC[AES256_GCM,data:crhw8iWx27jjrzQhOVVbGVEW9M6nSh3WpACSHCiEIV0GxZ/htia1/T3Fl19b9vz/60atWRl7qgTUY803iOcmUg==,iv:A4tYcuwMQYeDrvLNAqwrs2T89e+1QMDEZQcGaWkagXw=,tag:uaZcNuCFzyisbae798uFdA==,type:str]
+youtube_developer_key: ENC[AES256_GCM,data:7Rb6XsJhzIfGCL7Hasxn+UJeBq/PNDy2HyvVXsDzZxX5k5cXjCTw,iv:TGgrfsqiNuiXBUK/k/vG8A2joUhN1Q18kn3psJDG3TE=,tag:1hZcQnztKvVsaKdT8cDNQw==,type:str]
+sentry_dsn: ENC[AES256_GCM,data:YW3tLqzOXupPgdujID9gMhW36f8Q40iFoGJW3iANXt1bDbbtTmNMOvnuVbuwHFlozwqJjsGvjkEfhFaHokUWyXOgK8yh/XMIVQiOprKo7xYQrSBe,iv:cuRc0u2QoQ3ABQ1S8t0Hq/DVzHVC0Qv+DQeKmjqGv88=,tag:5RWYsE1jkvd7EUBKu1eNxg==,type:str]
 see_api_client:
-  id: ENC[AES256_GCM,data:DqSbKullmfbCs5fcH83u/dtACISQh6NPUprLs1uUSHE=,iv:JFzUapTXyAazzrFYDT9+z60BhP2+UdfH6KYzTghyieQ=,tag:TtZmhq2UICHWRfufsaorZQ==,type:str]
-  secret: ENC[AES256_GCM,data:IlumDjRN+JLO+RxenE4CStpB6PtPhzT+9ik+f5Wq8rs=,iv:Ckbj4ikx3+25eKINcN9f8FMMivwIL3udO5SCAV689hI=,tag:Lj67uXgOFE8u0HrMr/1oLw==,type:str]
+  id: ENC[AES256_GCM,data:QDgeYLfLfI+I0zcGtxXUAwmP2JW1MawsynI+TxnUF7Y=,iv:+sxhOv6witAi58VNrmTvGvYmXedIMB3Z2Axbk0MW308=,tag:QBQAk3vhCZGAuYLQVJS9vg==,type:str]
+  secret: ENC[AES256_GCM,data:q91rmjubCZOl7xnJbO3ZPPE9BegBJeT9FASLW6T77/0=,iv:bj/ExgW/TpuyAKUUYbCzAHch91TEG/cdD0omCFW94fo=,tag:To2EFqXddUEnNEn9Wr8I7A==,type:str]
 posthog:
-  project_api_key: ENC[AES256_GCM,data:C34uGXSdTFdEeaxKIrH4lyKp3cexDC6P96hopPmlTZCZ54ZZyCFDZzXRQiOpR7g=,iv:/L5Ve/3qLbHYF2uTjuB03EfAME+YpoeRfXVlV32LpJ8=,tag:BGyjHbYBWIkUrb32bxYNXw==,type:str]
-  personal_api_key: ENC[AES256_GCM,data:iJVk/0zSjzjYvKZB1bUGMb8e+/QO1Y+4khF8S1xCNv7aJiAfEtwviD3lpnmj8NtZ62Gy,iv:si4pFflFgR2ov/vngY5kAYlsv2mY+ByRk87a3pZ9jco=,tag:RX5Q5xWqBy2bIpIG4+2y5w==,type:str]
+  project_api_key: ENC[AES256_GCM,data:1yKp9nEmHnwpiBrLRVPu2oLL17X09PAdGCJtsYvsMlR1qVmySieLgjD11GPcgAw=,iv:2j6ALSJXOk4l4417cHFCT6Kyu32Kc8vRNr9/xOTUo9g=,tag:p5Za+psgKxjotdacLEjI6Q==,type:str]
+  personal_api_key: ENC[AES256_GCM,data:zy0ozp3JpplsQ9iKE2bJmTbCcam/iNtoFXorP7zKOGc/sE79D5BSy50jyCRF2wvCsPhP,iv:WCRWohPYUKOWYj0il6dsjfnqPq0SlVoAmdQuq7Bq0Wk=,tag:pjKGB9ysnus5iNJsxHg9pg==,type:str]
 wagtail:
-  client-id: ENC[AES256_GCM,data:UAHwTpJT9e70bB9+ANXIS5+1U7r99wR89kslWwAAqJkVxvKqDg01EQ==,iv:T/vQMERUHETu6RmP3Nxrl6MQmSOnkMYcZDgQZrsDs04=,tag:ZGSeh+kqyMKtfL0eoRsSgA==,type:str]
-  client-secret: ENC[AES256_GCM,data:z7zGc2ka6nSuQyciuOG1D9lbDMXSa3qjGW7buNcNy3o3ChEAls6scrar9k2QMMVHNU7y7CrHRoemfoYeTsE6bbsVWwftUqWReW929/4VTQAorufk0axSl41mRhUm6JRVXTeTdTy2SwrJS9K06dQ0A86q/dsdk51r4gAmCR82+6g=,iv:B99yJotPrU6g0RBsH9e8Pgv7SSfIZJPMBRCGVhL0E7o=,tag:NqAAluA3OqQ1L77vA3GFew==,type:str]
-  username: ENC[AES256_GCM,data:pkkE6tr0qo/ycfPdQmK4EE4nQgNrlUiJ+A==,iv:pmx3JojiDYHmbvp468dxvLYB3kf0wMvAItMAqdyCDPg=,tag:eLQqzfyKRHahKb9ME1bmHA==,type:str]
-  password: ENC[AES256_GCM,data:HlfAgURee06QohNAntLSInQC,iv:Xh5UXcdKKw5/6y7ha0GOOn9qrFhAzAj2b0AuZs3nfbc=,tag:+1hvetHcJG/8tbY6XufOfQ==,type:str]
+  client-id: ENC[AES256_GCM,data:amxbXZTsFCC843nYqyTd0/iWQjVT4Ov4UIJrzHyAK+MCJonb1ehjCw==,iv:Q5z6zZjC6l7kYmgQw/KMbATkKc8M0hIdy1ffRxc1NsM=,tag:pjsVNRsn6JtSGEjlZ9eN+Q==,type:str]
+  client-secret: ENC[AES256_GCM,data:AHdp1Gq1FVtkw/RBqDcRg96yQNvKTZZtmX+TaoefYTePBjq5CliZyHDIG34TclXv8jMBSlTsjg1knhnbmiy5RxdOWTi3KVYy6DXbwvwFpSgsFmPw0td2ULQG8RYYpiQ2dGQTpdlWXpNC3OPkcWRZIGNxXw9xtLAUmsMa3l91gew=,iv:JbSHNX1P1GJLcVtda7wwFalW3CuCWbmVg6seKUSwjec=,tag:54MfVCLZJFG6IyWz/iAldQ==,type:str]
+  username: ENC[AES256_GCM,data:NlDtEbJBF6667vjZ8P+M/yR/NUM4cskDrw==,iv:cLUrKOcB29KgVHpHZX9GyCCi9miE0QJkXvbnhVuFbG4=,tag:SM7DQjos9gq8Fgg0ptZGjg==,type:str]
+  password: ENC[AES256_GCM,data:7dMhTSjImhs5I6cSqDwEq/0r,iv:a9VHykIIQpFTBh0oXQLkmpbWhdrBEjiWL2/4PVzS6Go=,tag:1EFtjKoXnI3WAk7IYPHyUg==,type:str]
 mitxonline:
-  etl_api_key: ENC[AES256_GCM,data:1HIRrp/5al3jTwvc5/AwE/G8FWcOl6gE8W7obxnfxHXV/aYf770sQQg=,iv:p0Yk6ZkIVLIH9BZI1Hk38J6U154/wRva0scU29dK1hQ=,tag:RpmJ9+4hnybsIBRuh/LeHw==,type:str]
+  etl_api_key: ENC[AES256_GCM,data:8HiwY2dBDj6Y1Gk8YxJ8mvcfB4tww0atWJEnDjBs5Azt21MXZeVy6dE=,iv:lnpA4KS0bPz7DjaKYDE/7vtrbVpZAVL3aO5R/XclO9U=,tag:dkxNVYWAdZrOn4TxzU52QA==,type:str]
+unsubscribe_secret_key: ENC[AES256_GCM,data:NOze7P+WfQzo5jllx+XNeHQag0Onrl4IBvS/vlKNNzGHkMXDz+6CNw==,iv:ma5udziMtywfooQ4gqkncROrTmyGtaG0w0C64LRiz34=,tag:jFKYhV1XDiDCRl/yKWaz/g==,type:str]
 sops:
-  kms:
-  - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-qa
-    created_at: "2026-01-28T15:21:08Z"
-    enc: AQICAHjZAY5LtmRWGljev0oiDGn0jR5cRwD4IVXCn50TW5i0qQGmmO6lLCdR2Po5BE/NOU1KAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM3WXAHZuaJGW68OF0AgEQgDtVeQd4DVHobQddXKqaadoWcx6SbObtfDbJ0g935TjykNERqgUttDFI5SwtMz1uElMGEYME6BdR9kw66Q==
-    aws_profile: ""
   hc_vault:
-  - vault_address: https://vault-qa.odl.mit.edu
+  - created_at: "2026-07-22T16:46:06Z"
+    enc: vault:v1:XDgBELLj7+0Wy1iggu7jTaQ2/QlnA2pqVMuZItBzaatqotePx2y0ZxnSAzfITn1WSBLxF73/kx7RLj0o
     engine_path: infrastructure
     key_name: sops
-    created_at: "2026-01-28T15:21:08Z"
-    enc: vault:v1:wfE1atbfFtjAzbeyn5yTnsktzMFwPKIuIzAt/6C5YE8YKdmu6RCDc/Oei712nWMzrEO0cMxPZuH734QR
-  lastmodified: "2026-07-07T20:03:31Z"
-  mac: ENC[AES256_GCM,data:bfzpqtQpfJFbPbCaaXOaW/clRGmXCNzoMExhwt6fWC2BUa7JFj+jJ0NewIJw6LKEbK+JTzLu3HEyFxxwC5MvV9OL+Siwjr3j1WHaBQ1ycflKwa+qDftehw3PDXuL1ZTrml2S0BUKi/j1kI622F+n944fv5ssKrSUtLpdkl/uIis=,iv:F6wslp1H0cG7xy/pVdbcjkz2DCKo+BnCD400YD+Fc7I=,tag:eT0xkxJSCEm5blBxsh+kyA==,type:str]
+    vault_address: https://vault-qa.odl.mit.edu
+  kms:
+  - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-qa
+    aws_profile: ""
+    created_at: "2026-07-22T16:46:06Z"
+    enc: AQICAHjE+jMY5DL7M1LMYX6YgtMueHEDNg05lsdN5Z0zeGHyJgEMmRrs2Jkq5Ubzrx5fOF+BAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMvl/qZsrFms3fPc1YAgEQgDtIsN80y+50/CuggOgpEktStIr5TeHCWfekYL8D8kjoecQBu2GakG0h5foOTa26pPSRPAexUS40n1FB2g==
+  lastmodified: "2026-07-22T16:46:07Z"
+  mac: ENC[AES256_GCM,data:114co7i1cRN8O/wAMc7CWtXdk4twrYL3RyQigtOHGqXJoHCDneSjN5fnD2qSe7b7jdfLBdemX5f/AMYO6JPlAawHz0g6Y+HDDQcgBjSoe1d5nkrhj1bcQoltidqrbzkDvPo/FK0n8irW51GhuU/BO+CrjiabUbzHMvBO6dC/vVs=,iv:pxhqX92h8CKeOGeYD73wMA2gMT+Eta3k5s5mpl8SMx4=,tag:ieH+KqbwMPoYECx3H+LQsw==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.12.2
+  version: 3.13.2

--- a/src/ol_infrastructure/applications/mit_learn/k8s_secrets.py
+++ b/src/ol_infrastructure/applications/mit_learn/k8s_secrets.py
@@ -195,6 +195,7 @@ def create_mitlearn_k8s_secrets(
             "SECRET_KEY": '{{ get .Secrets "django_secret_key" }}',
             "SENTRY_DSN": '{{ get .Secrets "sentry_dsn" }}',
             "STATUS_TOKEN": '{{ get .Secrets "django_status_token" }}',
+            "UNSUBSCRIBE_SECRET_KEY": '{{ get .Secrets "unsubscribe_secret_key" }}',
             "YOUTUBE_DEVELOPER_KEY": '{{ get .Secrets "youtube_developer_key" }}',
         },
         vaultauth=vault_k8s_resources.auth_name,


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Part of https://github.com/mitodl/hq/issues/8424

### Description (What does it do?)
<!--- Describe your changes in detail --> 
This is a follow up to the PR https://github.com/mitodl/mit-learn/pull/3636 that adds the environment variable `UNSUBSCRIBE_SECRET_KEY` [here](https://github.com/mitodl/mit-learn/blob/ca3bee8c6654a8373799882283ee4893df8616fc/main/settings.py#L896). I *think* I've added the correct glue code but I think I need someone else to set encrypted values in the secrets files. The value can be any random string of a reasonable enough length, it's using the same encryption utilities as `SECRET_KEY` but I've kept it as a separate setting because while we might have need to rotate it, we will also need to still be able to verify existing unsubscribe tokens so there's future option for being able to rotate these via `UNSUBSCRIBE_SECRET_KEY_FALLBACKS` (I'm not introducing that here because we don't need it immediately).

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Test that CI/RC deploys as this is currently breaking them as I made this a required setting and forgot to follow up with this PR while I was out sick.