### PR TITLE
feat(local-dev): gitignored per-developer env/secret overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ pyinfra-debug.log
 .pulumi
 local-dev/certs/
 tilt_config.json
+# Per-developer local-dev overrides (see "Local Configuration Overrides" in
+# local-dev/README.md). Broad on purpose: never track a real secret anywhere
+# under local-dev/. Does not match the committed *.local.yaml.example files.
+local-dev/**/*.local.yaml
 
 # Generated Concourse pipeline JSON emitted by pipeline.py/meta.py __main__ blocks
 definition.json

--- a/Tiltfile
+++ b/Tiltfile
@@ -16,11 +16,10 @@ docker_prune_settings(
 # ---------------------------------------------------------------------------
 config.define_string_list("enabled_apps", usage="Apps to run: mit-learn learn-ai mitxonline odl-video-service")
 config.define_bool("per_app_databases", usage="Deploy isolated DB/Valkey per app namespace")
+# openedx_mode is declared but not yet wired: nothing branches on it, and
+# local-dev/apps/openedx/Tiltfile is not yet included by the APPS loop below.
 config.define_string("openedx_mode", usage="qa (default) or local (Tutor)")
 config.define_string_list("prebuilt_tags", usage="Prebuilt image tag overrides per app, e.g. mit-learn=0.62.0 learn-ai=0.28.3")
-config.define_string("openai_api_key", usage="OpenAI API key for AI/embedding features (optional)")
-config.define_string("langsmith_api_key", usage="LangSmith API key for tracing (optional)")
-config.define_string("canvas_ai_token", usage="Canvas AI token (optional)")
 config.define_string("root_domain", usage="Root DNS domain for all local-dev services (default: mit.dev). Overrides LOCAL_DEV_ROOT_DOMAIN env var.")
 cfg = config.parse()
 

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -100,6 +100,11 @@ cp tilt_config.json.example tilt_config.json
 
 At minimum, review `enabled_apps` to enable only the services you need.
 
+For per-developer app env vars and secrets (API keys, feature flags), don't
+edit the tracked manifests — drop a gitignored `app-env.local.yaml` ConfigMap
+next to the app's tracked one instead. See
+[Local Configuration Overrides](#local-configuration-overrides).
+
 ### 3. Start the environment
 
 The easiest way is to use the provided start script, which validates your setup and syncs dependencies:
@@ -218,6 +223,8 @@ ol-infrastructure/
         │   ├── apisix-routes.yaml    # Routes for api.learn.mit.dev
         │   └── configmaps/
         │       ├── app-env.yaml      # Non-secret env vars
+        │       ├── app-env.local.yaml         # (optional, gitignored) your overrides
+        │       ├── app-env.local.yaml.example
         │       └── nginx.yaml        # nginx sidecar config
         │
         ├── mit-learn-nextjs/         # Next.js frontend manifests
@@ -390,11 +397,7 @@ tilt trigger seed-mit-learn-fixtures
     "learn-ai=0.28.3",
     "mitxonline=1.144.5",
     "odl-video-service=0.85.0"
-  ],
-
-  "openai_api_key": "",
-  "langsmith_api_key": "",
-  "canvas_ai_token": ""
+  ]
 }
 ```
 
@@ -403,9 +406,15 @@ tilt trigger seed-mit-learn-fixtures
 | `enabled_apps` | all four | Apps to deploy. Omit any to skip it entirely. |
 | `per_app_databases` | `false` | `true` deploys isolated CNPG + Valkey per namespace (Phase 6A). |
 | `prebuilt_tags` | see file | `["app=tag"]` list of image tags used when the app repo is not checked out locally. |
-| `openai_api_key` | `""` | OpenAI API key — required for learn-ai vector search and LiteLLM. |
-| `langsmith_api_key` | `""` | LangSmith API key for tracing (optional). |
-| `canvas_ai_token` | `""` | Canvas AI token (optional). |
+
+The rule of thumb for which config surface a knob belongs to: settings that
+change **which/how Tilt runs things** (apps, image tags, domain) go in
+`tilt_config.json`; anything that sets an **env var or secret value inside a
+workload** (API keys, feature flags, endpoints) goes in a gitignored
+`app-env.local.yaml` override ConfigMap — see [Local Configuration Overrides](#local-configuration-overrides).
+(`openai_api_key`, `langsmith_api_key`, and `canvas_ai_token` used to be
+listed here but were never wired to anything and have been removed — delete
+them from your `tilt_config.json` if present, or `config.parse()` will error.)
 
 ### Pulumi stack config
 
@@ -442,10 +451,17 @@ local-dev/apps/<app-name>/
 ├── apisix-routes.yaml    # ApisixTls + ApisixRoute
 └── configmaps/
     ├── app-env.yaml      # Non-secret env vars
+    ├── app-env.local.yaml.example  # Template for per-dev overrides
     └── nginx.yaml        # (if using nginx sidecar)
 ```
 
-Use an existing app (e.g., `learn-ai/`) as a template.
+Use an existing app (e.g., `learn-ai/`) as a template. In particular, copy
+the `envFrom` pattern from an existing `deployment.yaml`: every container
+lists the tracked ConfigMap, the tracked Secret, then the optional
+`<app>-env-local` override ConfigMap **last** (see
+[Local Configuration Overrides](#local-configuration-overrides)), and pass
+`local_overrides='configmaps/app-env.local.yaml'` to `k8s_yaml_local` in the
+Tiltfile.
 
 ### 2. Add the app database to the CNPG cluster
 
@@ -552,59 +568,71 @@ Tilt also runs `pulumi up` automatically when infra files change. You can also t
 
 ### Local Configuration Overrides
 
-The ConfigMaps and Secrets are tracked by the repository. For personal development customizations (API keys, custom endpoints, etc.), you have several options:
-
-**Option 1: tilt_config.json (recommended for most cases)**
-
-```json
-{
-  "enabled_apps": ["mit-learn"],
-  "openai_api_key": "sk-...",  # pragma: allowlist secret
-  "langsmith_api_key": "ls-..."  # pragma: allowlist secret
-}
-```
-
-Pass config values via Tilt's config system. See `tilt_config.json.example` for all available options.
-
-**Option 2: kubectl patch (for local debugging)**
-
-Modify a ConfigMap or Secret in-cluster without committing:
+The ConfigMaps and Secrets are tracked by the repository. For per-developer
+customizations (API keys, feature flags, custom endpoints), each app has an
+optional, gitignored override ConfigMap:
 
 ```bash
-# Patch an env var
-kubectl patch configmap -n mit-learn app-env -p \
-  '{"data":{"MY_VAR":"new_value"}}'
-
-# View changes
-kubectl get configmap -n mit-learn app-env -o yaml
+cp local-dev/apps/mitxonline/configmaps/app-env.local.yaml.example \
+   local-dev/apps/mitxonline/configmaps/app-env.local.yaml
+# then add your overrides under data:, e.g.
+#   FEATURE_IGNORE_EDX_FAILURES: "True"
 ```
 
-These changes persist until the pod restarts or `tilt up` is re-run.
+How it works — plain Kubernetes, visible in each app's `deployment.yaml`:
+every container's `envFrom` list references the override ConfigMap
+(`mitxonline-env-local` etc.) **last** and with `optional: true`. Kubernetes
+resolves duplicate `envFrom` keys by letting the last source win, so your
+overrides beat both the tracked ConfigMap *and* the tracked Secret — secret
+values are fine in this file, it never leaves your machine. `optional: true`
+means no file → no ConfigMap → no-op for everyone else.
 
-**Option 3: Stash workflow (if heavily customizing)**
+Day-to-day behavior:
 
-If you have many local changes to tracked files, you can stash them before pulling:
+- Creating or editing the file mid-session re-applies it — no Tilt restart.
+  Pods roll automatically so new values actually take effect: because
+  Kubernetes does not restart pods on ConfigMap changes, `tiltlib.star`
+  stamps a fingerprint of your overrides onto each Deployment's pod template
+  (the `ol.mit.edu/local-overrides-hash` annotation), which is also the
+  idiomatic production pattern (cf. Helm `checksum/config` annotations).
+- Overridden key **names** (never values) are printed in the **Tiltfile
+  resource's log** in the Tilt UI, and your full delta is inspectable
+  in-cluster at any time:
+  `kubectl get cm -n mitxonline mitxonline-env-local -o yaml`
+- Gotchas: the ConfigMap's `metadata.name` must match what `deployment.yaml`
+  references (`<app>-env-local` — copy the example, don't type it), and all
+  `data:` values must be YAML **strings** (quote things like `"True"` and
+  `"8080"`). A typo'd key is applied but ignored by the app. If you *delete*
+  the file mid-session, prefer emptying `data:` instead — the already-applied
+  ConfigMap can linger in-cluster until `tilt down`.
 
-```bash
-# Stash local changes
-git stash
+Scope notes:
 
-# Pull latest
-git pull
-
-# Reapply your changes
-git stash pop
-```
+- **mit-learn-nextjs** can't participate yet: it has no ConfigMap/Secret —
+  its env lives directly in `deployment.yaml`. Moving that env block to a
+  ConfigMap would enable it.
+- **OpenAI key for LiteLLM** (`local-infra` namespace, Pulumi-managed) is
+  separate from the app overlays — create the Secret directly (the
+  deployment marks it optional, so this is safe to skip entirely):
+  ```bash
+  kubectl create secret generic litellm-secrets -n local-infra \
+    --from-literal=openai_api_key=sk-your-key  # pragma: allowlist secret
+  ```
+  (That `openai_api_key` Secret *data key* is unrelated to the old
+  `tilt_config.json` key of the same name, which was never wired to anything
+  and has been removed.)
 
 ### GPU Support for Ollama
 
 If you prefer to run Ollama on your host machine to use GPU acceleration:
 
-1. **Stop the in-cluster Ollama** — Set `OLLAMA_ENDPOINT` in your app ConfigMap to point to your host:
+1. **Stop the in-cluster Ollama** — point `OLLAMA_ENDPOINT` at your host via
+   the app's gitignored `app-env.local.yaml` (see
+   [Local Configuration Overrides](#local-configuration-overrides)):
    ```yaml
-   OLLAMA_ENDPOINT: "http://host.docker.internal:11434"  # Docker Desktop
-   OLLAMA_ENDPOINT: "http://172.17.0.1:11434"            # Linux
+   OLLAMA_ENDPOINT: "http://host.docker.internal:11434"
    ```
+   (Docker Desktop; on Linux use `http://172.17.0.1:11434`.)
 
 2. **Run Ollama on your host:**
    ```bash
@@ -615,13 +643,15 @@ If you prefer to run Ollama on your host machine to use GPU acceleration:
 
 The local-dev stack doesn't include S3 storage by default. To add it:
 
-**Option 1: Use external MinIO instance** — Run MinIO on your host and configure apps to use it:
+**Option 1: Use external MinIO instance** — Run MinIO on your host and point
+apps at it via their gitignored `app-env.local.yaml` (see
+[Local Configuration Overrides](#local-configuration-overrides)):
 ```yaml
-AWS_ENDPOINT_URL: "http://host.docker.internal:9000"  # Docker Desktop
-AWS_ENDPOINT_URL: "http://172.17.0.1:9000"            # Linux
+AWS_ENDPOINT_URL: "http://host.docker.internal:9000"
 AWS_ACCESS_KEY_ID: "minioadmin"  # pragma: allowlist secret
 AWS_SECRET_ACCESS_KEY: "minioadmin"  # pragma: allowlist secret
 ```
+(Docker Desktop; on Linux use `http://172.17.0.1:9000`.)
 
 **Option 2: Deploy MinIO in-cluster** — Modify `local-dev/infra/__main__.py` to add a MinIO Helm chart and patch the ConfigMaps accordingly.
 

--- a/local-dev/apps/learn-ai/Tiltfile
+++ b/local-dev/apps/learn-ai/Tiltfile
@@ -3,7 +3,7 @@
 # When the sibling learn-ai repo is not checked out, Tilt uses the prebuilt
 # DockerHub image (mitodl/learn-ai-app:latest) without attempting a local build.
 
-load("../../tiltlib.star", "k8s_yaml_with_domain")
+load("../../tiltlib.star", "k8s_yaml_local")
 
 workspace_root = os.environ.get("MITOL_WORKSPACE_ROOT", config.main_dir + "/..")
 APP_DIR = os.path.join(workspace_root, "learn-ai")
@@ -25,13 +25,13 @@ if os.path.exists(os.path.join(APP_DIR, '.git')):
         ],
     )
 
-k8s_yaml_with_domain([
+k8s_yaml_local([
     'configmaps/app-env.yaml',
     'configmaps/nginx.yaml',
     'secrets.yaml',
     'deployment.yaml',
     'apisix-routes.yaml',
-])
+], local_overrides='configmaps/app-env.local.yaml')
 
 k8s_resource(
     DEPLOY_NAME,

--- a/local-dev/apps/learn-ai/configmaps/app-env.local.yaml.example
+++ b/local-dev/apps/learn-ai/configmaps/app-env.local.yaml.example
@@ -1,0 +1,16 @@
+# Per-developer overrides for learn-ai (gitignored when copied).
+#
+# Copy to app-env.local.yaml and add entries under data: — because this
+# ConfigMap is referenced LAST in every envFrom list in deployment.yaml, its
+# keys override both the tracked app-env ConfigMap AND the tracked Secret
+# (secret values are fine here: the file never leaves your machine). Pods
+# roll automatically when you edit it. See "Local Configuration Overrides"
+# in local-dev/README.md.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: learn-ai-env-local
+  namespace: learn-ai
+data:
+  # DEBUG: "False"

--- a/local-dev/apps/learn-ai/deployment.yaml
+++ b/local-dev/apps/learn-ai/deployment.yaml
@@ -48,6 +48,12 @@ spec:
             name: learn-ai-env
         - secretRef:
             name: learn-ai-secrets
+        # Gitignored per-developer overrides; must stay LAST so its keys win
+        # over both sources above. See "Local Configuration Overrides" in
+        # local-dev/README.md.
+        - configMapRef:
+            name: learn-ai-env-local
+            optional: true
         volumeMounts:
         - name: static-files
           mountPath: /src/staticfiles
@@ -75,6 +81,12 @@ spec:
             name: learn-ai-env
         - secretRef:
             name: learn-ai-secrets
+        # Gitignored per-developer overrides; must stay LAST so its keys win
+        # over both sources above. See "Local Configuration Overrides" in
+        # local-dev/README.md.
+        - configMapRef:
+            name: learn-ai-env-local
+            optional: true
         resources:
           requests:
             cpu: 250m
@@ -172,6 +184,12 @@ spec:
             name: learn-ai-env
         - secretRef:
             name: learn-ai-secrets
+        # Gitignored per-developer overrides; must stay LAST so its keys win
+        # over both sources above. See "Local Configuration Overrides" in
+        # local-dev/README.md.
+        - configMapRef:
+            name: learn-ai-env-local
+            optional: true
         resources:
           requests:
             cpu: 100m
@@ -238,6 +256,12 @@ spec:
             name: learn-ai-env
         - secretRef:
             name: learn-ai-secrets
+        # Gitignored per-developer overrides; must stay LAST so its keys win
+        # over both sources above. See "Local Configuration Overrides" in
+        # local-dev/README.md.
+        - configMapRef:
+            name: learn-ai-env-local
+            optional: true
         resources:
           requests:
             cpu: 100m
@@ -304,6 +328,12 @@ spec:
             name: learn-ai-env
         - secretRef:
             name: learn-ai-secrets
+        # Gitignored per-developer overrides; must stay LAST so its keys win
+        # over both sources above. See "Local Configuration Overrides" in
+        # local-dev/README.md.
+        - configMapRef:
+            name: learn-ai-env-local
+            optional: true
         resources:
           requests:
             cpu: 50m

--- a/local-dev/apps/mit-learn-nextjs/Tiltfile
+++ b/local-dev/apps/mit-learn-nextjs/Tiltfile
@@ -14,7 +14,7 @@
 # DockerHub image (mitodl/mit-learn-nextjs-app:latest) without a local build;
 # that image is the production `runner` stage (no hot reload).
 
-load("../../tiltlib.star", "k8s_yaml_with_domain")
+load("../../tiltlib.star", "k8s_yaml_local")
 
 workspace_root = os.environ.get("MITOL_WORKSPACE_ROOT", config.main_dir + "/..")
 APP_DIR = os.path.join(workspace_root, "mit-learn")
@@ -56,7 +56,7 @@ if os.path.exists(os.path.join(APP_DIR, '.git')):
         ],
     )
 
-k8s_yaml_with_domain([
+k8s_yaml_local([
     'deployment.yaml',
     'apisix-routes.yaml',
 ])

--- a/local-dev/apps/mit-learn/Tiltfile
+++ b/local-dev/apps/mit-learn/Tiltfile
@@ -4,7 +4,7 @@
 # When the sibling mit-learn repo is not checked out, Tilt uses the prebuilt
 # DockerHub image (mitodl/mit-learn-app:latest) without attempting a local build.
 
-load("../../tiltlib.star", "k8s_yaml_with_domain")
+load("../../tiltlib.star", "k8s_yaml_local")
 
 NAMESPACE = "mit-learn"
 IMAGE = "mitodl/mit-learn-app"
@@ -47,13 +47,13 @@ if os.path.exists(os.path.join(MIT_LEARN_DIR, ".git")):
 # ─────────────────────────────────────────────────────────────
 
 # Apply all manifests in order.
-k8s_yaml_with_domain([
+k8s_yaml_local([
     os.path.join(config.main_dir, "local-dev/apps/mit-learn/configmaps/nginx.yaml"),
     os.path.join(config.main_dir, "local-dev/apps/mit-learn/configmaps/app-env.yaml"),
     os.path.join(config.main_dir, "local-dev/apps/mit-learn/secrets.yaml"),
     os.path.join(config.main_dir, "local-dev/apps/mit-learn/deployment.yaml"),
     os.path.join(config.main_dir, "local-dev/apps/mit-learn/apisix-routes.yaml"),
-])
+], local_overrides=os.path.join(config.main_dir, "local-dev/apps/mit-learn/configmaps/app-env.local.yaml"))
 
 # ─────────────────────────────────────────────────────────────
 # Resource grouping + dependency declarations

--- a/local-dev/apps/mit-learn/configmaps/app-env.local.yaml.example
+++ b/local-dev/apps/mit-learn/configmaps/app-env.local.yaml.example
@@ -1,0 +1,16 @@
+# Per-developer overrides for mit-learn (gitignored when copied).
+#
+# Copy to app-env.local.yaml and add entries under data: — because this
+# ConfigMap is referenced LAST in every envFrom list in deployment.yaml, its
+# keys override both the tracked app-env ConfigMap AND the tracked Secret
+# (secret values are fine here: the file never leaves your machine). Pods
+# roll automatically when you edit it. See "Local Configuration Overrides"
+# in local-dev/README.md.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mitlearn-env-local
+  namespace: mit-learn
+data:
+  # CONTENT_FILE_EMBEDDING_CHUNK_SIZE: "1024"

--- a/local-dev/apps/mit-learn/deployment.yaml
+++ b/local-dev/apps/mit-learn/deployment.yaml
@@ -80,6 +80,12 @@ spec:
             name: mitlearn-env
         - secretRef:
             name: mitlearn-secrets
+        # Gitignored per-developer overrides; must stay LAST so its keys win
+        # over both sources above. See "Local Configuration Overrides" in
+        # local-dev/README.md.
+        - configMapRef:
+            name: mitlearn-env-local
+            optional: true
         resources:
           requests:
             cpu: 100m
@@ -134,6 +140,12 @@ spec:
             name: mitlearn-env
         - secretRef:
             name: mitlearn-secrets
+        # Gitignored per-developer overrides; must stay LAST so its keys win
+        # over both sources above. See "Local Configuration Overrides" in
+        # local-dev/README.md.
+        - configMapRef:
+            name: mitlearn-env-local
+            optional: true
         resources:
           requests:
             cpu: 100m
@@ -250,6 +262,12 @@ spec:
             name: mitlearn-env
         - secretRef:
             name: mitlearn-secrets
+        # Gitignored per-developer overrides; must stay LAST so its keys win
+        # over both sources above. See "Local Configuration Overrides" in
+        # local-dev/README.md.
+        - configMapRef:
+            name: mitlearn-env-local
+            optional: true
         resources:
           requests:
             cpu: 100m
@@ -322,6 +340,12 @@ spec:
             name: mitlearn-env
         - secretRef:
             name: mitlearn-secrets
+        # Gitignored per-developer overrides; must stay LAST so its keys win
+        # over both sources above. See "Local Configuration Overrides" in
+        # local-dev/README.md.
+        - configMapRef:
+            name: mitlearn-env-local
+            optional: true
         resources:
           requests:
             cpu: 100m
@@ -394,6 +418,12 @@ spec:
             name: mitlearn-env
         - secretRef:
             name: mitlearn-secrets
+        # Gitignored per-developer overrides; must stay LAST so its keys win
+        # over both sources above. See "Local Configuration Overrides" in
+        # local-dev/README.md.
+        - configMapRef:
+            name: mitlearn-env-local
+            optional: true
         resources:
           requests:
             cpu: 100m
@@ -463,6 +493,12 @@ spec:
             name: mitlearn-env
         - secretRef:
             name: mitlearn-secrets
+        # Gitignored per-developer overrides; must stay LAST so its keys win
+        # over both sources above. See "Local Configuration Overrides" in
+        # local-dev/README.md.
+        - configMapRef:
+            name: mitlearn-env-local
+            optional: true
         resources:
           requests:
             cpu: 50m

--- a/local-dev/apps/mitxonline/Tiltfile
+++ b/local-dev/apps/mitxonline/Tiltfile
@@ -3,7 +3,7 @@
 # When the sibling mitxonline repo is not checked out, Tilt uses the prebuilt
 # DockerHub image (mitodl/mitxonline-app:latest) without attempting a local build.
 
-load("../../tiltlib.star", "k8s_yaml_with_domain")
+load("../../tiltlib.star", "k8s_yaml_local")
 
 workspace_root = os.environ.get("MITOL_WORKSPACE_ROOT", config.main_dir + "/..")
 APP_DIR = os.path.join(workspace_root, "mitxonline")
@@ -36,13 +36,13 @@ if os.path.exists(os.path.join(APP_DIR, '.git')):
         ],
     )
 
-k8s_yaml_with_domain([
+k8s_yaml_local([
     'configmaps/app-env.yaml',
     'configmaps/nginx.yaml',
     'secrets.yaml',
     'deployment.yaml',
     'apisix-routes.yaml',
-])
+], local_overrides='configmaps/app-env.local.yaml')
 
 k8s_resource(
     DEPLOY_NAME,

--- a/local-dev/apps/mitxonline/configmaps/app-env.local.yaml.example
+++ b/local-dev/apps/mitxonline/configmaps/app-env.local.yaml.example
@@ -1,0 +1,16 @@
+# Per-developer overrides for mitxonline (gitignored when copied).
+#
+# Copy to app-env.local.yaml and add entries under data: — because this
+# ConfigMap is referenced LAST in every envFrom list in deployment.yaml, its
+# keys override both the tracked app-env ConfigMap AND the tracked Secret
+# (secret values are fine here: the file never leaves your machine). Pods
+# roll automatically when you edit it. See "Local Configuration Overrides"
+# in local-dev/README.md.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mitxonline-env-local
+  namespace: mitxonline
+data:
+  # FEATURE_IGNORE_EDX_FAILURES: "True"

--- a/local-dev/apps/mitxonline/deployment.yaml
+++ b/local-dev/apps/mitxonline/deployment.yaml
@@ -48,6 +48,12 @@ spec:
             name: mitxonline-env
         - secretRef:
             name: mitxonline-secrets
+        # Gitignored per-developer overrides; must stay LAST so its keys win
+        # over both sources above. See "Local Configuration Overrides" in
+        # local-dev/README.md.
+        - configMapRef:
+            name: mitxonline-env-local
+            optional: true
         volumeMounts:
         - name: static-files
           mountPath: /src/staticfiles
@@ -81,6 +87,12 @@ spec:
             name: mitxonline-env
         - secretRef:
             name: mitxonline-secrets
+        # Gitignored per-developer overrides; must stay LAST so its keys win
+        # over both sources above. See "Local Configuration Overrides" in
+        # local-dev/README.md.
+        - configMapRef:
+            name: mitxonline-env-local
+            optional: true
         resources:
           requests:
             cpu: 250m
@@ -184,6 +196,12 @@ spec:
             name: mitxonline-env
         - secretRef:
             name: mitxonline-secrets
+        # Gitignored per-developer overrides; must stay LAST so its keys win
+        # over both sources above. See "Local Configuration Overrides" in
+        # local-dev/README.md.
+        - configMapRef:
+            name: mitxonline-env-local
+            optional: true
         resources:
           requests:
             cpu: 100m
@@ -248,6 +266,12 @@ spec:
             name: mitxonline-env
         - secretRef:
             name: mitxonline-secrets
+        # Gitignored per-developer overrides; must stay LAST so its keys win
+        # over both sources above. See "Local Configuration Overrides" in
+        # local-dev/README.md.
+        - configMapRef:
+            name: mitxonline-env-local
+            optional: true
         # beat loads the full Django app like the worker, so give it comparable
         # memory headroom — it OOMs with less.
         resources:

--- a/local-dev/apps/mitxonline/secrets.yaml
+++ b/local-dev/apps/mitxonline/secrets.yaml
@@ -19,10 +19,12 @@ stringData:
   # Placeholders, not real creds. Without these,
   # MITOL_PAYMENT_GATEWAY_CYBERSOURCE_SECURITY_KEY defaults to None and the
   # checkout flow's HMAC signing crashes with AttributeError before it can
-  # redirect to CyberSource. To actually test checkout, replace these with
-  # real CyberSource test/sandbox credentials (e.g. sops-decrypt the
-  # cybersource keys in src/bridge/secrets/unified_ecommerce/secrets.ci.yaml)
-  # in your local, uncommitted copy of this file.
+  # redirect to CyberSource. To actually test checkout, put real CyberSource
+  # test/sandbox credentials (e.g. sops-decrypt the cybersource keys in
+  # src/bridge/secrets/unified_ecommerce/secrets.ci.yaml) in the gitignored
+  # configmaps/app-env.local.yaml override ConfigMap — it is referenced last
+  # in envFrom, so its keys beat this Secret. See "Local Configuration
+  # Overrides" in local-dev/README.md.
   MITOL_PAYMENT_GATEWAY_CYBERSOURCE_ACCESS_KEY: "REPLACE-WITH-REAL-CYBERSOURCE-TEST-ACCESS-KEY"  # pragma: allowlist secret
   MITOL_PAYMENT_GATEWAY_CYBERSOURCE_SECURITY_KEY: "REPLACE-WITH-REAL-CYBERSOURCE-TEST-SECURITY-KEY"  # pragma: allowlist secret
   MITOL_PAYMENT_GATEWAY_CYBERSOURCE_PROFILE_ID: "REPLACE-WITH-REAL-CYBERSOURCE-TEST-PROFILE-ID"

--- a/local-dev/apps/odl-video-service/Tiltfile
+++ b/local-dev/apps/odl-video-service/Tiltfile
@@ -3,7 +3,7 @@
 # prebuilt DockerHub image (mitodl/odl-video-service-app:latest) without
 # attempting a local build.
 
-load("../../tiltlib.star", "k8s_yaml_with_domain")
+load("../../tiltlib.star", "k8s_yaml_local")
 
 workspace_root = os.environ.get("MITOL_WORKSPACE_ROOT", config.main_dir + "/..")
 APP_DIR = os.path.join(workspace_root, "odl-video-service")
@@ -25,13 +25,13 @@ if os.path.exists(os.path.join(APP_DIR, '.git')):
         ],
     )
 
-k8s_yaml_with_domain([
+k8s_yaml_local([
     'configmaps/app-env.yaml',
     'configmaps/nginx.yaml',
     'secrets.yaml',
     'deployment.yaml',
     'apisix-routes.yaml',
-])
+], local_overrides='configmaps/app-env.local.yaml')
 
 k8s_resource(
     DEPLOY_NAME,

--- a/local-dev/apps/odl-video-service/configmaps/app-env.local.yaml.example
+++ b/local-dev/apps/odl-video-service/configmaps/app-env.local.yaml.example
@@ -1,0 +1,16 @@
+# Per-developer overrides for odl-video-service (gitignored when copied).
+#
+# Copy to app-env.local.yaml and add entries under data: — because this
+# ConfigMap is referenced LAST in every envFrom list in deployment.yaml, its
+# keys override both the tracked app-env ConfigMap AND the tracked Secret
+# (secret values are fine here: the file never leaves your machine). Pods
+# roll automatically when you edit it. See "Local Configuration Overrides"
+# in local-dev/README.md.
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: odlvideo-env-local
+  namespace: odl-video-service
+data:
+  # VIDEO_S3_BUCKET: "my-test-bucket"

--- a/local-dev/apps/odl-video-service/deployment.yaml
+++ b/local-dev/apps/odl-video-service/deployment.yaml
@@ -45,6 +45,12 @@ spec:
             name: odlvideo-env
         - secretRef:
             name: odlvideo-secrets
+        # Gitignored per-developer overrides; must stay LAST so its keys win
+        # over both sources above. See "Local Configuration Overrides" in
+        # local-dev/README.md.
+        - configMapRef:
+            name: odlvideo-env-local
+            optional: true
         volumeMounts:
         - name: static-files
           mountPath: /src/staticfiles
@@ -74,6 +80,12 @@ spec:
             name: odlvideo-env
         - secretRef:
             name: odlvideo-secrets
+        # Gitignored per-developer overrides; must stay LAST so its keys win
+        # over both sources above. See "Local Configuration Overrides" in
+        # local-dev/README.md.
+        - configMapRef:
+            name: odlvideo-env-local
+            optional: true
         resources:
           requests:
             cpu: 250m
@@ -168,6 +180,12 @@ spec:
             name: odlvideo-env
         - secretRef:
             name: odlvideo-secrets
+        # Gitignored per-developer overrides; must stay LAST so its keys win
+        # over both sources above. See "Local Configuration Overrides" in
+        # local-dev/README.md.
+        - configMapRef:
+            name: odlvideo-env-local
+            optional: true
         resources:
           requests:
             cpu: 100m
@@ -232,6 +250,12 @@ spec:
             name: odlvideo-env
         - secretRef:
             name: odlvideo-secrets
+        # Gitignored per-developer overrides; must stay LAST so its keys win
+        # over both sources above. See "Local Configuration Overrides" in
+        # local-dev/README.md.
+        - configMapRef:
+            name: odlvideo-env-local
+            optional: true
         resources:
           requests:
             cpu: 50m

--- a/local-dev/scripts/setup.sh
+++ b/local-dev/scripts/setup.sh
@@ -420,7 +420,8 @@ cat <<EOF
   Next steps:
     1. Copy and edit your personal config:
          cp tilt_config.json.example tilt_config.json
-       (Add openai_api_key if you want AI/embedding features)
+       (App env vars / API keys go in gitignored app-env.local.yaml files instead —
+        see "Local Configuration Overrides" in local-dev/README.md)
 
     2. Start the full stack:
          tilt up

--- a/local-dev/tiltlib.star
+++ b/local-dev/tiltlib.star
@@ -33,9 +33,20 @@ def _overrides_fingerprint(path, text):
     docs = [d for d in decode_yaml_stream(text) if d != None]
     if len(docs) != 1 or docs[0].get("kind") != "ConfigMap":
         fail("%s: expected a single ConfigMap manifest" % path)
-    data = docs[0].get("data", {})
+    # A data: key with nothing (or only comments) under it parses as None.
+    data = docs[0].get("data", {}) or {}
+    for k in data:
+        if type(data[k]) != "string":
+            fail(
+                '%s: data.%s must be a YAML string — quote the value (e.g. "True", "8080"); got %s'
+                % (path, k, type(data[k]))
+            )
     keys = sorted(data.keys())
     print("[%s] local overrides active: %s" % (path, ", ".join(keys) if keys else "(none)"))
+    if not keys:
+        # Empty data: treat as "no overrides" — apply the (empty) ConfigMap
+        # but skip stamping, so Deployments return to their unannotated state.
+        return ""
     canon = "".join(["%s=%s\n" % (k, data[k]) for k in keys])
     return str(hash(canon))
 

--- a/local-dev/tiltlib.star
+++ b/local-dev/tiltlib.star
@@ -1,28 +1,90 @@
 # Shared Tilt helpers for local-dev.
 #
 # Load in any Tiltfile with:
-#   load("../../tiltlib.star", "k8s_yaml_with_domain")  # from apps/<app>/
-#   load("./local-dev/tiltlib.star", "k8s_yaml_with_domain")  # from repo root
+#   load("../../tiltlib.star", "k8s_yaml_local")  # from apps/<app>/
+#   load("./local-dev/tiltlib.star", "k8s_yaml_local")  # from repo root
 #
-# Root domain is read from the LOCAL_DEV_ROOT_DOMAIN environment variable
-# (default: mit.dev). Set it before running tilt up to use a custom domain:
-#   export LOCAL_DEV_ROOT_DOMAIN=mycompany.dev && tilt up
+# k8s_yaml_local applies manifests with two local-dev conveniences:
+#
+# 1. Root-domain substitution. The LOCAL_DEV_ROOT_DOMAIN environment variable
+#    (default: mit.dev) replaces every 'mit.dev' occurrence so hostnames,
+#    URLs, and cookie-domain references update consistently:
+#      export LOCAL_DEV_ROOT_DOMAIN=mycompany.dev && tilt up
+#
+# 2. Gitignored per-developer overrides. Pass local_overrides= the path of an
+#    optional, gitignored ConfigMap manifest (conventionally
+#    configmaps/app-env.local.yaml, named <app>-env-local). When the file
+#    exists it is applied with the other manifests; each app's
+#    deployment.yaml references it as the LAST envFrom entry with
+#    optional: true, so its keys override both the tracked ConfigMap and the
+#    tracked Secret, and its absence is a no-op. Because Kubernetes does not
+#    restart pods when a ConfigMap changes, every Deployment applied in the
+#    same call gets a pod-template annotation fingerprinting the overrides —
+#    editing the override file rolls the pods so new values take effect.
+#    See "Local Configuration Overrides" in local-dev/README.md.
 
-def k8s_yaml_with_domain(paths):
-    """Apply k8s YAML, substituting LOCAL_DEV_ROOT_DOMAIN for 'mit.dev'.
+_ROOT_DOMAIN_DEFAULT = "mit.dev"
+_OVERRIDE_HASH_ANNOTATION = "ol.mit.edu/local-overrides-hash"
 
-    When the env var is unset or equals the default 'mit.dev', files are
-    applied as-is with no overhead.  When overridden, each file is processed
-    through sed before being applied so that all hostnames, URLs, and
-    cookie-domain references update consistently.
-    """
-    rd = os.environ.get("LOCAL_DEV_ROOT_DOMAIN", "mit.dev")
-    if rd == "mit.dev":
+def _overrides_fingerprint(path, text):
+    """Validate the override manifest and return a stable fingerprint of its
+    data (not the raw text, so comment/formatting edits don't roll pods).
+    Also logs the overridden key names — never values — to the Tiltfile log."""
+    docs = [d for d in decode_yaml_stream(text) if d != None]
+    if len(docs) != 1 or docs[0].get("kind") != "ConfigMap":
+        fail("%s: expected a single ConfigMap manifest" % path)
+    data = docs[0].get("data", {})
+    keys = sorted(data.keys())
+    print("[%s] local overrides active: %s" % (path, ", ".join(keys) if keys else "(none)"))
+    canon = "".join(["%s=%s\n" % (k, data[k]) for k in keys])
+    return str(hash(canon))
+
+def _stamp_deployments(content, fingerprint):
+    """Add the overrides-fingerprint annotation to every Deployment pod
+    template in a (possibly multi-doc) manifest text, so changing an override
+    rolls the pods. Returns a Blob, or None if there are no Deployments."""
+    docs = [d for d in decode_yaml_stream(content) if d != None]
+    stamped = False
+    for d in docs:
+        if d.get("kind") == "Deployment":
+            annotations = (
+                d.setdefault("spec", {})
+                .setdefault("template", {})
+                .setdefault("metadata", {})
+                .setdefault("annotations", {})
+            )
+            annotations[_OVERRIDE_HASH_ANNOTATION] = fingerprint
+            stamped = True
+    if not stamped:
+        return None
+    return encode_yaml_stream(docs)
+
+def k8s_yaml_local(paths, local_overrides=None):
+    """Apply k8s YAML with root-domain substitution and an optional
+    gitignored ConfigMap of per-developer overrides (see module docstring)."""
+    rd = os.environ.get("LOCAL_DEV_ROOT_DOMAIN", _ROOT_DOMAIN_DEFAULT)
+
+    # read_file(default=...) also registers a watch on the override path —
+    # including its creation — so adding or editing it mid-session re-runs
+    # the Tiltfile.
+    overrides_text = ""
+    if local_overrides:
+        overrides_text = str(read_file(local_overrides, default=""))
+
+    if rd == _ROOT_DOMAIN_DEFAULT and not overrides_text.strip():
+        # Fast path: nothing to rewrite, apply files as-is.
         k8s_yaml(paths)
         return
-    for p in paths:
-        content = str(local(
-            "sed 's/mit\\.dev/{rd}/g' {p}".format(rd = rd, p = p),
-            quiet = True,
-        ))
-        k8s_yaml(blob(content))
+
+    fingerprint = ""
+    all_paths = list(paths)
+    if overrides_text.strip():
+        fingerprint = _overrides_fingerprint(local_overrides, overrides_text)
+        all_paths.append(local_overrides)
+
+    for p in all_paths:
+        content = str(read_file(p))
+        if rd != _ROOT_DOMAIN_DEFAULT:
+            content = content.replace(_ROOT_DOMAIN_DEFAULT, rd)
+        stamped = _stamp_deployments(content, fingerprint) if fingerprint else None
+        k8s_yaml(stamped if stamped != None else blob(content))

--- a/tilt_config.json.example
+++ b/tilt_config.json.example
@@ -13,9 +13,5 @@
     "odl-video-service=0.85.0"
   ],
 
-  "openai_api_key": "",
-  "langsmith_api_key": "",
-  "canvas_ai_token": "",
-
   "root_domain": "mit.dev"
 }


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Adds gitignored per-developer env/secret overrides to the local-dev stack — the docker-compose "uncommitted env file" workflow, done with plain Kubernetes.

**Why:** there was previously no way to set a per-developer env var or secret without editing tracked files (mitxonline's `secrets.yaml` literally instructed pasting CyberSource keys into a committed manifest). The other config surface, `tilt_config.json`, would have required plumbing every variable through a `config.define_*` declaration and Tiltfile code into the manifests — per-variable work just to set a value. With this change, any var is settable by dropping a line in one gitignored file, no plumbing.

- Each app gets an optional, gitignored override file, `local-dev/apps/<app>/configmaps/app-env.local.yaml`, containing a ConfigMap whose `metadata.name` is `<app>-env-local` (e.g. `mitxonline-env-local`); a committed `app-env.local.yaml.example` sits alongside as the template. Every container's `envFrom` in `deployment.yaml` (19 sites across mitxonline, mit-learn, learn-ai, odl-video-service) references it **last** with `optional: true`: Kubernetes resolves duplicate `envFrom` keys last-source-wins, so the override beats both the tracked ConfigMap and the tracked Secret, and a missing file is a no-op.
- `tiltlib.star`: `k8s_yaml_with_domain` becomes `k8s_yaml_local`. It watches the override file (including its creation mid-session), logs overridden key names (never values) to the Tiltfile log, and — because Kubernetes does not restart pods on ConfigMap changes — stamps an `ol.mit.edu/local-overrides-hash` pod-template annotation (fingerprint of the parsed `data:`) on each Deployment so pods roll automatically when override values change. The domain substitution also moves from a `sed` subprocess to Starlark `str.replace` (behavior-identical, fast path preserved).
- Cleanup: the `openai_api_key`/`langsmith_api_key`/`canvas_ai_token` tilt_config keys were never consumed by anything and are removed entirely (root Tiltfile, `tilt_config.json.example`, README). 

### How can this be tested?
0. **First, if your gitignored `tilt_config.json` still contains `openai_api_key`, `langsmith_api_key`, or `canvas_ai_token`, delete those lines** — their declarations are removed, so `config.parse()` now errors on them (the message names the offending key).
1. Run `tilt up` (or use an already-running session).
2. `cp local-dev/apps/mitxonline/configmaps/app-env.local.yaml.example local-dev/apps/mitxonline/configmaps/app-env.local.yaml` and add `FEATURE_IGNORE_EDX_FAILURES: "True"` under `data:`. (Or any other `VAR_NAME: VALUE` option)
3. Without restarting Tilt: the Tiltfile log prints `local overrides active: FEATURE_IGNORE_EDX_FAILURES`, and the three mitxonline deployments roll (`kubectl get pods -n mitxonline` shows fresh pods).
    - You can see the Tiltfile logs in Tilt's ui near bottom, http://localhost:10350/r/(Tiltfile)/overview
4. Confirm the value is live: `kubectl exec -n mitxonline deploy/mitxonline-webapp -- printenv FEATURE_IGNORE_EDX_FAILURES` → `True`.
    - may take a few moments for the pod to reload
5. Change the value in the file — pods roll again and Step 4's  `printenv` reflects the edit. `git status` stays clean throughout (the file is gitignored).

### Additional Context
A second design was fully prototyped and rejected: merging `KEY=value` `.local.env` files into the tracked manifests' `data:`/`stringData:` in Starlark before apply. It needed no `deployment.yaml` changes and was immune to a forgotten `envFrom` ref, but it hid the mechanism in ~130 lines of Tiltfile code; the shipped approach is readable directly in `deployment.yaml` by anyone k8s-literate, keeps each developer's delta independently inspectable (`kubectl get cm <app>-env-local -o yaml`), and the forgotten-ref risk is low in practice since new containers copy existing `envFrom` blocks. (Kubernetes' native answer, namespace-scoped PodPreset, was removed in 1.20.) Known limits, documented in the README: mit-learn-nextjs can't participate (its env is inline `env:` in the deployment, which beats `envFrom`), and deleting the override file mid-session may leave the applied ConfigMap in-cluster until `tilt down` — empty its `data:` instead.
