### PR TITLE
feat(rootly): route CI/QA Grafana alerts to #devops-warnings Slack channel

### DIFF
--- a/src/ol_infrastructure/saas/rootly/__main__.py
+++ b/src/ol_infrastructure/saas/rootly/__main__.py
@@ -2937,6 +2937,86 @@ alerts_source_grafana_prometheus_qa = rootly.AlertsSource(
     opts=rootly_alert_source_opts,
 )
 
+# CI/QA alerts currently have no effective routing to any Slack-visible
+# destination (confirmed against the live Rootly account), unlike Production,
+# which has two catch-all routes. So these alerts aren't cluttering
+# #devops-alerts today -- they're most likely not reaching Slack anywhere.
+# This adds a real route for both, additive alongside whatever else (if
+# anything) exists per source, per Rootly's own guidance: alerts fan out
+# across every route connected to their source, so adding a second route
+# here doesn't disturb any other existing routing.
+#
+# Per Rootly support: the recommended way to target a Slack channel is via an
+# EscalationPolicy whose level notifies the channel directly (as opposed to
+# a Workflow, which isn't ideal for this since you can't ack/resolve through
+# it, or a per-Service announcement setting). This policy is intentionally
+# minimal -- one level, no schedule, no paging -- since CI/QA alerts should
+# be visible in Slack, not page anyone.
+escalation_policy_ci_qa_slack_notifications = rootly.EscalationPolicy(
+    "ci-qa-slack-notifications-escalation-policy",
+    name="CI/QA Slack Notifications",
+    description=(
+        "Posts CI/QA Grafana alerts to #devops-warnings for visibility. "
+        "Not intended to page anyone -- see the single Slack-channel level."
+    ),
+    group_ids=["9f00e9f1-2f13-470e-a856-50ab5003f260"],
+    repeat_count=1,
+    opts=rootly_opts,
+)
+
+escalation_level_ci_qa_slack_notifications = rootly.EscalationLevel(
+    "ci-qa-slack-notifications-escalation-level",
+    escalation_policy_id=escalation_policy_ci_qa_slack_notifications.id,
+    position=1,
+    notification_target_params=[
+        {
+            "type": "slack_channel",
+            "id": "C0BK6BHUCDP",  # #devops-warnings
+        },
+    ],
+    opts=rootly_opts,
+)
+
+alert_route_grafana_prometheus_ci_slack_warnings = rootly.AlertRoute(
+    "grafana-prometheus-ci-slack-warnings-route",
+    name="Grafana Prometheus CI - Slack Warnings Route",
+    alerts_source_ids=[alerts_source_grafana_prometheus_ci.id],
+    rules=[
+        {
+            "name": "Fallback Rule for Grafana Prometheus CI - Slack Warnings Route",
+            "fallback_rule": True,
+            "position": 1,
+            "destinations": [
+                {
+                    "target_type": "EscalationPolicy",
+                    "target_id": escalation_policy_ci_qa_slack_notifications.id,
+                },
+            ],
+        },
+    ],
+    opts=rootly_opts,
+)
+
+alert_route_grafana_prometheus_qa_slack_warnings = rootly.AlertRoute(
+    "grafana-prometheus-qa-slack-warnings-route",
+    name="Grafana Prometheus QA - Slack Warnings Route",
+    alerts_source_ids=[alerts_source_grafana_prometheus_qa.id],
+    rules=[
+        {
+            "name": "Fallback Rule for Grafana Prometheus QA - Slack Warnings Route",
+            "fallback_rule": True,
+            "position": 1,
+            "destinations": [
+                {
+                    "target_type": "EscalationPolicy",
+                    "target_id": escalation_policy_ci_qa_slack_notifications.id,
+                },
+            ],
+        },
+    ],
+    opts=rootly_opts,
+)
+
 alerts_source_mitol_sentry = rootly.AlertsSource(
     "mitol-sentry",
     alert_source_fields_attributes=[

--- a/src/ol_infrastructure/saas/rootly/__main__.py
+++ b/src/ol_infrastructure/saas/rootly/__main__.py
@@ -2977,45 +2977,45 @@ escalation_level_ci_qa_slack_notifications = rootly.EscalationLevel(
     opts=rootly_opts,
 )
 
-alert_route_grafana_prometheus_ci_slack_warnings = rootly.AlertRoute(
+alert_route_grafana_prometheus_ci_slack_warnings_route = rootly.AlertRoute(
     "grafana-prometheus-ci-slack-warnings-route",
-    name="Grafana Prometheus CI - Slack Warnings Route",
-    enabled=True,
-    owning_team_ids=["9f00e9f1-2f13-470e-a856-50ab5003f260"],
     alerts_source_ids=[alerts_source_grafana_prometheus_ci.id],
+    enabled=True,
+    name="Grafana Prometheus CI - Slack Warnings Route",
+    owning_team_ids=["9f00e9f1-2f13-470e-a856-50ab5003f260"],
     rules=[
         {
-            "name": "Fallback Rule for Grafana Prometheus CI - Slack Warnings Route",
-            "fallback_rule": True,
-            "position": 1,
             "destinations": [
                 {
-                    "target_type": "EscalationPolicy",
-                    "target_id": escalation_policy_ci_qa_slack_notifications.id,
+                    "targetId": escalation_policy_ci_qa_slack_notifications.id,
+                    "targetType": "EscalationPolicy",
                 },
             ],
+            "fallbackRule": True,
+            "name": "Fallback Rule for Grafana Prometheus CI - Slack Warnings Route",
+            "position": 1,
         },
     ],
     opts=rootly_opts,
 )
 
-alert_route_grafana_prometheus_qa_slack_warnings = rootly.AlertRoute(
+alert_route_grafana_prometheus_qa_slack_warnings_route = rootly.AlertRoute(
     "grafana-prometheus-qa-slack-warnings-route",
-    name="Grafana Prometheus QA - Slack Warnings Route",
-    enabled=True,
-    owning_team_ids=["9f00e9f1-2f13-470e-a856-50ab5003f260"],
     alerts_source_ids=[alerts_source_grafana_prometheus_qa.id],
+    enabled=True,
+    name="Grafana Prometheus QA - Slack Warnings Route",
+    owning_team_ids=["9f00e9f1-2f13-470e-a856-50ab5003f260"],
     rules=[
         {
-            "name": "Fallback Rule for Grafana Prometheus QA - Slack Warnings Route",
-            "fallback_rule": True,
-            "position": 1,
             "destinations": [
                 {
-                    "target_type": "EscalationPolicy",
-                    "target_id": escalation_policy_ci_qa_slack_notifications.id,
+                    "targetId": escalation_policy_ci_qa_slack_notifications.id,
+                    "targetType": "EscalationPolicy",
                 },
             ],
+            "fallbackRule": True,
+            "name": "Fallback Rule for Grafana Prometheus QA - Slack Warnings Route",
+            "position": 1,
         },
     ],
     opts=rootly_opts,

--- a/src/ol_infrastructure/saas/rootly/__main__.py
+++ b/src/ol_infrastructure/saas/rootly/__main__.py
@@ -2980,6 +2980,8 @@ escalation_level_ci_qa_slack_notifications = rootly.EscalationLevel(
 alert_route_grafana_prometheus_ci_slack_warnings = rootly.AlertRoute(
     "grafana-prometheus-ci-slack-warnings-route",
     name="Grafana Prometheus CI - Slack Warnings Route",
+    enabled=True,
+    owning_team_ids=["9f00e9f1-2f13-470e-a856-50ab5003f260"],
     alerts_source_ids=[alerts_source_grafana_prometheus_ci.id],
     rules=[
         {
@@ -3000,6 +3002,8 @@ alert_route_grafana_prometheus_ci_slack_warnings = rootly.AlertRoute(
 alert_route_grafana_prometheus_qa_slack_warnings = rootly.AlertRoute(
     "grafana-prometheus-qa-slack-warnings-route",
     name="Grafana Prometheus QA - Slack Warnings Route",
+    enabled=True,
+    owning_team_ids=["9f00e9f1-2f13-470e-a856-50ab5003f260"],
     alerts_source_ids=[alerts_source_grafana_prometheus_qa.id],
     rules=[
         {


### PR DESCRIPTION
## Summary
- CI and QA's Grafana alerts sources currently have no effective routing to any Slack-visible destination, unlike Production, whose two catch-all routes fall back to the shared "Default Escalation Policy" -> `primary-on-call-schedule` -> `#devops-alerts`. Confirmed directly against the live Rootly API (`GET /v1/alert_routes`, `GET /v1/alert_sources`).
- Per Rootly support, the recommended way to target a Slack channel is an `EscalationPolicy` whose level notifies the channel directly (a Workflow isn't ideal here since alerts can't be ack'd/resolved through it; that's better suited for purely informational notices).
- Adds:
  1. A new, minimal `EscalationPolicy` ("CI/QA Slack Notifications") — no on-call schedule, not intended to page anyone.
  2. One `EscalationLevel` on that policy targeting `#devops-warnings` (Slack channel ID `C0BK6BHUCDP`) directly.
  3. A **second, additive** `AlertRoute` for each of the CI and QA alerts sources, whose fallback rule destinations point at the new policy. Alerts fan out across every route connected to a source, so this doesn't disturb whatever (if anything) already exists for either source today.
- Production's existing routing (`Default Escalation Policy`, `primary-on-call-schedule`, `#devops-alerts`) is completely untouched.

## Review fixes
- Explicitly set `enabled=True` and `owning_team_ids` on both new `AlertRoute` resources, matching every existing route in the live account, rather than relying on an undocumented API default.
- Renamed both `AlertRoute` variables to end in `_route` and switched their `rules`/`destinations` dict keys to camelCase (`targetId`/`targetType`/`fallbackRule`), matching the 4 pre-existing `AlertRoute` resources already in this file (missed in an earlier review pass by searching for the wrong legacy resource class name). `pulumi preview` confirms both casings produce an identical resulting plan, so this was a consistency fix, not a functional one.

## Test plan
- [x] `ruff check` / `ruff format` pass on the changed file
- [x] `pulumi preview --stack Production --diff` against the live `ol-saas-rootly` stack, re-run after each fix — shows exactly the 4 intended new resources (`EscalationPolicy`, `EscalationLevel`, 2x `AlertRoute` with `enabled`/`owningTeamIds` populated), referencing the correct live CI/QA alerts-source IDs, 146 other resources unchanged, no errors.
- [ ] After merge/deploy, trigger a test CI or QA alert and confirm it posts to `#devops-warnings` without paging anyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)