### PR TITLE
Granian: expose blocking_threads/backpressure, align defaults with Granian's own

### DIFF
--- a/docs/plans/granian-configuration-overhaul.md
+++ b/docs/plans/granian-configuration-overhaul.md
@@ -1,0 +1,252 @@
+# Granian configuration overhaul
+
+**Status:** stage 0 (component change) implemented 2026-07-22; stages 1–4 pending
+**Project:** `wp-granian-configuration-overhaul-expose-blocking-t-3debc2`
+**Component:** `src/ol_infrastructure/components/services/k8s.py` — `GranianConfig`
+**Evidence:** witan lessons `les-granianconfig-never-exposes-blocking-threads-bac-874462`,
+`les-ceiling-based-granian-workers-max-rss-mitxonline-2136f0`
+
+## Problem
+
+`GranianConfig` exposes no `blocking_threads` or `backpressure` field, so `build_args()`
+never emits `--blocking-threads` / `--backpressure` for any caller. Granian resolves them
+itself (`granian/server/common.py:155-166`):
+
+```
+backpressure     = max(1, backpressure_arg or backlog // workers)
+blocking_threads = blocking_threads_arg or (max(1, backpressure // 2) if WSGI else 1)
+```
+
+With the component defaults `backlog=128`, `workers=2`, `interface="wsgi"`:
+
+```
+backpressure     = 128 // 2 = 64
+blocking_threads = 64 // 2  = 32 per worker  →  64 GIL-competing Python threads per pod
+```
+
+Granian itself warns when `blocking_threads > cpu_count() * 2 + 1`
+(`granian/server/mp.py:445-450`). No pod here is near the ~15 vCPU that would make 32
+defensible — webapp CPU requests run 100m–500m with no CPU limit. This matches the
+"more concurrency, worse latency" GIL-contention pattern reported in Granian
+discussion #663.
+
+Three secondary deviations from Granian's own defaults compound it:
+
+| Setting | Granian CLI default | Component default | Maintainer guidance |
+|---|---|---|---|
+| `workers` | 1 | **2** | "1 worker per pod, scale via replicas" (#406), "1–2" (#663) |
+| `runtime_threads` | 1 | **2** | "leave threading at default" (#663) |
+| `runtime_mode` | auto | **"mt"** | same |
+
+And `--workers-max-rss` sizing: mitxonline derives it from the VPA *ceiling* (3Gi) rather
+than the pod's current declared limit (1200Mi), so two workers can reach ~2816MiB before
+the cap fires — more than 2x the actual cgroup limit in the steady state. The kernel OOM
+killer wins the race, which is exactly the failure the RSS cap exists to prevent.
+
+## Affected callers
+
+Eight webapp deployments across seven Pulumi projects. Note `edxapp` (LMS + CMS) was not
+in the original finding but is affected identically.
+
+| App | interface | workers | backlog | eff. blocking_threads | min_replicas | mem limit |
+|---|---|---|---|---|---|---|
+| `edxapp` LMS | wsgi | 2 | 128 | **32** | stack config | stack config |
+| `edxapp` CMS | wsgi | 2 | 128 | **32** | stack config | stack config |
+| `micromasters` | wsgi | 2 | 128 | **32** | 2 | 2000Mi |
+| `mitxonline` | wsgi | 2 | 128 | **32** | 2 | 1200Mi (VPA→3Gi) |
+| `ocw_studio` | wsgi | 2 | 128 | **32** | 2 | 3Gi |
+| `odl_video_service` | wsgi | 2 | 128 | **32** | 2 | 1Gi |
+| `xpro` | wsgi | 2 | 128 | **32** | 2 | 2Gi |
+| `mit_learn` | asginl | 2 | None | 1 (async) | 2 | 3200Mi |
+| `learn_ai` | asgi | **1** | None | 1 (async) | 2 | 1000Mi |
+
+`mit_learn` / `learn_ai` are unaffected on the blocking-threads axis (async interfaces
+force `blocking_threads=1`) but still get an untuned `backpressure` of 1024 from
+Granian's default backlog. `learn_ai` already models the target shape: `workers=1`,
+`runtime_mode=None`.
+
+## Component changes
+
+All in `GranianConfig` and the synth-time block at `k8s.py:855-878`.
+
+### 1. New field: `blocking_threads`
+
+```python
+blocking_threads: PositiveInt | None = None
+"""Size of the Python thread pool that executes WSGI request handlers
+(granian --blocking-threads). These threads compete for the GIL, so this is a
+concurrency knob, not a throughput knob -- keep it within a small multiple of the
+container's CPU allocation. Only meaningful for interface='wsgi'; Granian forces it
+to 1 for asgi/asginl. When None on a WSGI app, resolves to
+DEFAULT_WSGI_BLOCKING_THREADS rather than letting Granian derive it from
+backpressure//2."""
+```
+
+- Resolution happens in a `model_validator(mode="after")`, not at `build_args()` time, so
+  the effective value is inspectable and testable.
+- WSGI + `None` → `8`. asgi/asginl + `None` → not emitted (Granian's forced 1).
+- asgi/asginl + explicit value `> 1` → **`ValueError`**. Granian silently ignores it;
+  failing at synth time is strictly better than a config that reads as tuned but isn't.
+- `build_args()` emits `--blocking-threads <n>` only when the resolved value is not None.
+
+### 2. New field: `backpressure`
+
+```python
+backpressure: PositiveInt | None = None
+"""Maximum in-flight requests a single worker will accept before it stops draining the
+accept queue (granian --backpressure). Excess connections wait in the kernel backlog
+(and behind the nginx sidecar), which is where they belong -- an oversized backpressure
+just moves the queue inside the worker where it inflates tail latency invisibly. When
+None on a WSGI app, resolves to 2x the resolved blocking_threads."""
+```
+
+- WSGI + `None` → `2 * resolved_blocking_threads` (so `16` at the new defaults).
+- asgi/asginl + `None` → not emitted; Granian's `backlog // workers` stands. This is a
+  deliberate no-op for `mit_learn` / `learn_ai` in this change.
+- `build_args()` emits `--backpressure <n>` when resolved.
+
+### 3. Default changes
+
+| Field | Old | New | Note |
+|---|---|---|---|
+| `workers` | 2 | **1** | Granian CLI default; maintainer K8s guidance |
+| `runtime_threads` | 2 | **1** | Granian CLI default |
+| `runtime_mode` | `"mt"` | **`None`** | Granian's "auto"; `build_args()` already omits on None |
+
+`backlog` stays at 128. Once `backpressure` is explicit, `backlog` no longer feeds the
+thread-pool derivation and reverts to meaning only what it says: the listen backlog.
+
+### 4. `workers_max_rss` sizing
+
+Keep the mechanism and keep the existing synth-time formula
+`floor(resource_limits["memory"] * 0.9 / workers)`, evaluated against the pod's **current
+declared limit**. With `workers=1` this is simply 90% of the container limit, leaving 10%
+for the Granian master and interpreter overhead.
+
+Decided against the runtime cgroup-read variant (an entrypoint wrapper reading
+`/sys/fs/cgroup/memory.max`) for this project: it is a cross-repo image change, and the
+lesson's own caution about `mit_learn_nextjs`'s cgroup auto-sizing landing at a
+surprisingly low value in production applies. **Tracked as a follow-on task** to evaluate
+after the concurrency changes are validated in production.
+
+Consequences:
+
+- `mitxonline`'s ceiling-derived override (`__main__.py:536-543, 563-569`) is **removed**,
+  along with `MITXONLINE_GRANIAN_WORKERS` and `GRANIAN_MASTER_OVERHEAD_MIB`. It reverts to
+  the component default, which at `workers=1` / `1200Mi` gives ~1080MiB — a cap that
+  actually fires before the cgroup OOM killer instead of ~2816MiB, which never did.
+- `mit_learn`'s explicit `workers_max_rss=1080` needs re-derivation at `workers=1`
+  (3200Mi × 0.9 ≈ 2880MiB) or removal in favor of the default. Its inline comment about
+  `floor(limit/workers*0.9)` becomes stale either way.
+- The `webapp_vpa_max_allowed_memory` docstring caveat ("`--workers-max-rss` … will NOT
+  track this ceiling — set `GranianConfig.workers_max_rss` explicitly to keep the two in
+  sync") is **inverted**: pinning to the ceiling is now the documented anti-pattern. The
+  docstring must say so and point at the follow-on cgroup task.
+
+### 5. Health probes — deferred, not dropped
+
+Splitting liveness to a TCP socket check while readiness stays HTTP (per #663) is the
+right end state: an HTTP liveness probe can queue behind a saturated worker and restart a
+pod that is merely busy. It is *less* urgent once `backpressure` is 16 instead of 64, and
+the nginx sidecar already absorbs part of the risk (the probe hits nginx, not granian).
+**Tracked as a separate task**, sequenced after the pilot in stage 2 so probe behavior and
+concurrency behavior aren't changed in the same rollout window.
+
+## Capacity math
+
+Per-pod nominal request concurrency:
+
+```
+before:  2 workers × 32 blocking_threads = 64
+after:   1 worker  ×  8 blocking_threads =  8
+```
+
+That 8x drop is the headline risk and the reason for staged rollout. Two things make it
+much less severe than the ratio suggests:
+
+1. **The 64 was never real throughput.** All 64 threads contend for two GILs. Useful
+   parallelism was bounded by CPU (100m–500m requested, burstable) and by GIL handoff
+   overhead, which *rises* with thread count. The pattern in #663 is that reducing this
+   number improved p99.
+2. **Concurrency is not capacity.** For I/O-bound Django views (DB, redis, external HTTP),
+   8 threads still covers well above the requested CPU. Where it binds, the HPA sees
+   sustained CPU and adds replicas — which is the intended scaling axis.
+
+What genuinely changes and must be watched: a pod's ability to absorb a *burst* of slow
+requests without queuing. That surfaces as increased time-in-queue, not errors, as long as
+nginx and the listen backlog hold the overflow.
+
+**Replica re-sizing.** `application_min_replicas` comes from per-stack Pulumi config
+(`min_replicas`) for every affected app, so this is a config change per stack, not code.
+Baseline recommendation at each stage: leave `min_replicas` alone initially and let the
+HPA respond, but pre-raise it for any app whose steady-state CPU utilization already sits
+above ~40% of the 60% HPA target, since halving per-pod worker count roughly halves
+per-pod CPU and will otherwise trigger a scale-*down* before the load reappears.
+
+## Rollout
+
+Component change lands once; per-app behavior changes as each app's stack is deployed.
+
+> **Correction (stage 0 implementation).** This section originally claimed the component
+> change was inert because every affected caller passes `workers=2` explicitly. That only
+> held for `workers`. Only `edxapp` pinned `runtime_mode`/`runtime_threads`, and *every*
+> WSGI caller would have picked up the new `blocking_threads=8` / `backpressure=16` the
+> moment the component landed — applying the headline concurrency change to six apps in
+> one deploy, which is what staging exists to avoid. Stage 0 therefore also added
+> **holding pins** to every caller not yet in its stage: `runtime_mode="mt"`,
+> `runtime_threads=2`, `blocking_threads=32`, `backpressure=64` — the values Granian was
+> already deriving from `backlog=128 // workers=2` — plus `runtime_threads=2` alone on
+> `mit_learn`/`learn_ai`, whose async interfaces force `blocking_threads=1`.
+>
+> Each stage below therefore means **"delete that app's holding-pin block"**, not "drop
+> the explicit `workers=2`". Verified at stage 0 by reconstructing the pre-change
+> `GranianConfig` from git and diffing `build_args()` across all nine call sites: the
+> seven WSGI ones differ only by the two new flag pairs, and the two async ones are
+> byte-identical.
+>
+> General form worth carrying forward: "the new default is inert because callers override
+> it" must be checked per-field across every caller, and never covers newly-added fields
+> that resolve to a non-`None` default.
+
+- **Stage 0 — component.** Land `GranianConfig` fields, defaults, validators, and the
+  `workers_max_rss` docstring corrections. No app behavior changes except for any caller
+  relying on the `workers` default (none today). Unit tests + `pulumi preview` on one CI
+  stack showing zero webapp diffs.
+- **Stage 1 — pilot, lower traffic.** `ocw_studio` and `odl_video_service`. Drop the
+  explicit `workers=2`, let the new defaults apply. Deploy CI → QA → production. Hold
+  ≥ 3 business days at production before proceeding.
+- **Stage 2 — mid traffic.** `micromasters`, `xpro`. Same edit. Health-probe split task
+  becomes eligible here.
+- **Stage 3 — high traffic.** `mitxonline` (plus removal of the ceiling-based
+  `workers_max_rss` override), then `edxapp` LMS and CMS separately — CMS first, it takes
+  far less traffic than LMS.
+- **Stage 4 — async apps.** `mit_learn`, `learn_ai`: `workers=2→1` for `mit_learn` and an
+  explicit `backpressure` for both. No `blocking_threads` involvement. Lowest expected
+  impact, sequenced last because it shares no evidence with the WSGI stages.
+
+Each stage is one task with its own PR.
+
+## Validation
+
+Before/after per stage, comparing the same weekday-hour window:
+
+- **Latency** — granian request duration p50/p95/p99 from the existing PodMonitor scrape;
+  nginx upstream response time as the independent check.
+- **Errors** — 5xx rate at nginx and at APISIX; specifically 502/504, which is where
+  backpressure saturation would surface.
+- **Saturation** — pod CPU utilization vs request, HPA `currentReplicas`, and any
+  granian queue/backpressure metric exposed on the metrics port.
+- **Memory** — OOMKill count and container restart count; `--workers-max-rss` respawns
+  should appear in granian logs *before* any OOMKill, which is the whole point of the
+  sizing fix.
+- **Startup** — pod ready time, to catch any probe interaction early.
+
+Rollback for any stage is reverting that stage's PR and redeploying; the change is
+entirely in container args, so there is no data or schema migration to unwind.
+
+## Open items tracked separately
+
+1. Runtime cgroup-based `--workers-max-rss` (entrypoint wrapper) — evaluate post-rollout.
+2. TCP liveness / HTTP readiness probe split — eligible after stage 2.
+3. Per-app `blocking_threads` tuning from measured latency, once the uniform 8 is in
+   production everywhere.

--- a/src/bridge/lib/magic_numbers.py
+++ b/src/bridge/lib/magic_numbers.py
@@ -35,6 +35,13 @@ DEFAULT_POSTGRES_PORT = 5432
 DEFAULT_REDIS_PORT = 6379
 DEFAULT_RSA_KEY_SIZE = 2048
 DEFAULT_WSGI_PORT = 8073  # Arbitrary
+# Size of the Granian blocking-thread pool for WSGI apps. These threads all contend
+# for the GIL, so this tracks the container's CPU allocation (100m-500m requested for
+# our webapps), not the request rate.
+DEFAULT_WSGI_BLOCKING_THREADS = 8
+# Multiplier applied to blocking_threads to derive Granian's --backpressure for WSGI
+# apps: enough in-flight requests to keep every thread busy plus one queued each.
+DEFAULT_WSGI_BACKPRESSURE_MULTIPLIER = 2
 EIGHT_HOURS_SECONDS = 28800
 FIVE_MINUTES = 60 * 5
 FORUM_SERVICE_PORT = 4567

--- a/src/ol_infrastructure/applications/edxapp/k8s_resources.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_resources.py
@@ -674,6 +674,15 @@ def create_k8s_resources(  # noqa: C901
                 no_ws=True,
                 runtime_mode="mt",
                 runtime_threads=2,
+                # Holding pins: preserve the pre-overhaul effective concurrency
+                # until this app's stage of the rollout. Granian derived
+                # backpressure=64 (backlog=128 // workers=2) and
+                # blocking_threads=64 // 2 = 32. Delete these (plus workers,
+                # runtime_mode, runtime_threads above) to adopt the component
+                # defaults (1 worker, 8 blocking threads, 16 backpressure).
+                # See docs/plans/granian-configuration-overhaul.md
+                blocking_threads=32,
+                backpressure=64,
                 respawn_failed_workers=True,
                 backlog=128,
                 static_path_mounts=["/openedx/staticfiles"],
@@ -976,6 +985,15 @@ def create_k8s_resources(  # noqa: C901
                 no_ws=True,
                 runtime_mode="mt",
                 runtime_threads=2,
+                # Holding pins: preserve the pre-overhaul effective concurrency
+                # until this app's stage of the rollout. Granian derived
+                # backpressure=64 (backlog=128 // workers=2) and
+                # blocking_threads=64 // 2 = 32. Delete these (plus workers,
+                # runtime_mode, runtime_threads above) to adopt the component
+                # defaults (1 worker, 8 blocking threads, 16 backpressure).
+                # See docs/plans/granian-configuration-overhaul.md
+                blocking_threads=32,
+                backpressure=64,
                 respawn_failed_workers=True,
                 backlog=128,
                 static_path_mounts=["/openedx/staticfiles"],

--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -831,6 +831,11 @@ learn_ai_app_k8s = OLApplicationK8s(
             interface="asgi",
             workers=1,
             runtime_mode=None,
+            # Holding pin: the component default dropped to 1. asgi forces
+            # blocking_threads=1 regardless, so this is the only axis on which the
+            # overhaul touches learn_ai until its review task.
+            # See docs/plans/granian-configuration-overhaul.md
+            runtime_threads=2,
             no_ws=False,
             backlog=None,
             log_level="debug",

--- a/src/ol_infrastructure/applications/micromasters/__main__.py
+++ b/src/ol_infrastructure/applications/micromasters/__main__.py
@@ -858,7 +858,17 @@ micromasters_k8s_app = OLApplicationK8s(
         **docker_image_config_kwargs("MICROMASTERS"),
         granian_config=GranianConfig(
             application_module="micromasters.wsgi:application",
+            # Holding pins: preserve the pre-overhaul effective concurrency until
+            # this app's stage of the rollout. Granian derived backpressure=64
+            # (backlog=128 // workers=2) and blocking_threads=64 // 2 = 32.
+            # Delete all five to adopt the component defaults (1 worker, 8
+            # blocking threads, 16 backpressure).
+            # See docs/plans/granian-configuration-overhaul.md
             workers=2,
+            runtime_mode="mt",
+            runtime_threads=2,
+            blocking_threads=32,
+            backpressure=64,
             blocking_threads_idle_timeout=120,
             enable_metrics=True,
         ),

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1523,6 +1523,11 @@ mitlearn_k8s_app = OLApplicationK8s(
             log_level=mitlearn_config.get("granian_log_level") or "info",
             application_module="main.asgi:application",
             runtime_mode=None,
+            # Holding pin: the component default dropped to 1. asginl forces
+            # blocking_threads=1 regardless, so this is the only axis on which the
+            # overhaul touches mit_learn until its review task.
+            # See docs/plans/granian-configuration-overhaul.md
+            runtime_threads=2,
         )
         if mitlearn_config.get_bool("use_granian")
         else None,

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -561,7 +561,17 @@ mitxonline_k8s_app = OLApplicationK8s(
         application_cmd_array=["uwsgi"],
         application_arg_array=["/tmp/uwsgi.ini"],  # noqa: S108
         granian_config=GranianConfig(
+            # Holding pins: preserve the pre-overhaul effective concurrency until
+            # this app's stage of the rollout. Granian derived backpressure=64
+            # (backlog=128 // workers=2) and blocking_threads=64 // 2 = 32.
+            # Delete all four (and revert workers to the default) to adopt the
+            # component defaults (1 worker, 8 blocking threads, 16 backpressure).
+            # See docs/plans/granian-configuration-overhaul.md
             workers=MITXONLINE_GRANIAN_WORKERS,
+            runtime_mode="mt",
+            runtime_threads=2,
+            blocking_threads=32,
+            backpressure=64,
             blocking_threads_idle_timeout=120,
             enable_metrics=True,
             # Pinned to the VPA ceiling rather than the component's default

--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -619,7 +619,17 @@ ocw_studio_k8s_app = OLApplicationK8s(
         **docker_image_config_kwargs("OCW_STUDIO"),
         granian_config=GranianConfig(
             application_module="main.wsgi:application",
+            # Holding pins: preserve the pre-overhaul effective concurrency until
+            # this app's stage of the rollout. Granian derived backpressure=64
+            # (backlog=128 // workers=2) and blocking_threads=64 // 2 = 32.
+            # Delete all five to adopt the component defaults (1 worker, 8
+            # blocking threads, 16 backpressure).
+            # See docs/plans/granian-configuration-overhaul.md
             workers=2,
+            runtime_mode="mt",
+            runtime_threads=2,
+            blocking_threads=32,
+            backpressure=64,
             blocking_threads_idle_timeout=120,
             enable_metrics=True,
         ),

--- a/src/ol_infrastructure/applications/odl_video_service/__main__.py
+++ b/src/ol_infrastructure/applications/odl_video_service/__main__.py
@@ -842,7 +842,17 @@ ovs_k8s_app = OLApplicationK8s(
         **docker_image_config_kwargs("ODL_VIDEO_SERVICE"),
         granian_config=GranianConfig(
             application_module="odl_video.wsgi:application",
+            # Holding pins: preserve the pre-overhaul effective concurrency until
+            # this app's stage of the rollout. Granian derived backpressure=64
+            # (backlog=128 // workers=2) and blocking_threads=64 // 2 = 32.
+            # Delete all five to adopt the component defaults (1 worker, 8
+            # blocking threads, 16 backpressure).
+            # See docs/plans/granian-configuration-overhaul.md
             workers=2,
+            runtime_mode="mt",
+            runtime_threads=2,
+            blocking_threads=32,
+            backpressure=64,
             blocking_threads_idle_timeout=120,
             enable_metrics=True,
             log_level=(ovs_config.get("log_level") or "info").lower(),

--- a/src/ol_infrastructure/applications/xpro/__main__.py
+++ b/src/ol_infrastructure/applications/xpro/__main__.py
@@ -532,7 +532,17 @@ if k8s_deploy:
             **docker_image_config_kwargs("XPRO"),
             granian_config=GranianConfig(
                 application_module="mitxpro.wsgi:application",
+                # Holding pins: preserve the pre-overhaul effective concurrency
+                # until this app's stage of the rollout. Granian derived
+                # backpressure=64 (backlog=128 // workers=2) and
+                # blocking_threads=64 // 2 = 32. Delete all five to adopt the
+                # component defaults (1 worker, 8 blocking threads, 16
+                # backpressure). See docs/plans/granian-configuration-overhaul.md
                 workers=2,
+                runtime_mode="mt",
+                runtime_threads=2,
+                blocking_threads=32,
+                backpressure=64,
                 blocking_threads_idle_timeout=120,
                 enable_metrics=True,
             ),

--- a/src/ol_infrastructure/components/services/k8s.py
+++ b/src/ol_infrastructure/components/services/k8s.py
@@ -253,12 +253,16 @@ class GranianConfig(BaseModel):
             ("--backpressure", self.backpressure),
             ("--workers-max-rss", self.workers_max_rss),
             ("--blocking-threads-idle-timeout", self.blocking_threads_idle_timeout),
-            ("--backlog", self.backlog),
         ):
             if value is not None:
                 args += [flag, str(value)]
+        # Emitted after the loop rather than inside it so the relative order of
+        # --respawn-failed-workers and --backlog matches what deployed stacks
+        # already have, keeping the pulumi diff to the genuinely new flags.
         if self.respawn_failed_workers:
             args.append("--respawn-failed-workers")
+        if self.backlog is not None:
+            args += ["--backlog", str(self.backlog)]
         if self.enable_metrics:
             args += [
                 "--metrics",

--- a/src/ol_infrastructure/components/services/k8s.py
+++ b/src/ol_infrastructure/components/services/k8s.py
@@ -24,6 +24,8 @@ from pydantic import (
 from bridge.lib.magic_numbers import (
     DEFAULT_NGINX_PORT,
     DEFAULT_REDIS_PORT,
+    DEFAULT_WSGI_BACKPRESSURE_MULTIPLIER,
+    DEFAULT_WSGI_BLOCKING_THREADS,
     DEFAULT_WSGI_PORT,
     MAXIMUM_K8S_NAME_LENGTH,
 )
@@ -115,9 +117,16 @@ class GranianConfig(BaseModel):
     create a PodMonitor — replacing the manual if/else blocks in each caller.
 
     The supported subset of granian CLI options is: interface, host, port, workers,
-    runtime_mode, runtime_threads, no_ws, workers_max_rss,
-    blocking_threads_idle_timeout, respawn_failed_workers, backlog, log_level,
-    application_module, and metrics-related flags.
+    runtime_mode, runtime_threads, blocking_threads, backpressure, no_ws,
+    workers_max_rss, blocking_threads_idle_timeout, respawn_failed_workers, backlog,
+    log_level, application_module, and metrics-related flags.
+
+    **Concurrency defaults:** ``workers``, ``runtime_threads`` and ``runtime_mode`` track
+    Granian's own CLI defaults (1 / 1 / auto); scale horizontally with replicas rather
+    than with workers per pod.  ``blocking_threads`` and ``backpressure`` are resolved
+    explicitly for WSGI apps instead of being left to Granian's
+    ``backpressure = backlog // workers`` / ``blocking_threads = backpressure // 2``
+    derivation, which yielded 32 GIL-competing threads per worker at the old defaults.
 
     **Port/nginx coupling:** when ``import_nginx_config=True`` on
     ``OLApplicationK8sConfig``, the nginx config proxies to a fixed upstream address
@@ -130,9 +139,24 @@ class GranianConfig(BaseModel):
     interface: Literal["wsgi", "asgi", "asginl"] = "wsgi"
     host: str = "0.0.0.0"  # noqa: S104
     port: Annotated[int, Field(ge=1, le=65535)] = DEFAULT_WSGI_PORT
-    workers: PositiveInt = 2
-    runtime_mode: str | None = "mt"
-    runtime_threads: PositiveInt = 2
+    workers: PositiveInt = 1
+    runtime_mode: str | None = None
+    runtime_threads: PositiveInt = 1
+    blocking_threads: PositiveInt | None = None
+    """Size of the Python thread pool that executes WSGI request handlers (granian
+    ``--blocking-threads``). These threads compete for the GIL, so this is a concurrency
+    knob, not a throughput knob -- keep it within a small multiple of the container's CPU
+    allocation. Only meaningful for ``interface='wsgi'``; Granian forces it to 1 for
+    asgi/asginl. When ``None`` on a WSGI app, resolves to
+    ``DEFAULT_WSGI_BLOCKING_THREADS`` rather than letting Granian derive it from
+    ``backpressure // 2``."""
+    backpressure: PositiveInt | None = None
+    """Maximum in-flight requests a single worker will accept before it stops draining the
+    accept queue (granian ``--backpressure``). Excess connections wait in the kernel
+    backlog (and behind the nginx sidecar), which is where they belong -- an oversized
+    backpressure just moves the queue inside the worker where it inflates tail latency
+    invisibly. When ``None`` on a WSGI app, resolves to 2x the resolved
+    ``blocking_threads``."""
     no_ws: bool = True
     limit_workers_max_rss: bool = True
     """When ``True`` (default), automatically cap each worker's RSS at 90 % of the
@@ -148,6 +172,9 @@ class GranianConfig(BaseModel):
     """Seconds before an idle blocking thread is retired (granian ``--blocking-threads-idle-timeout``). Omitted when ``None``."""
     respawn_failed_workers: bool = True
     backlog: PositiveInt | None = 128
+    """Kernel listen backlog (granian ``--backlog``). Now that ``backpressure`` is
+    resolved explicitly this no longer feeds Granian's thread-pool derivation, so it means
+    only what it says: how many connections queue outside the workers."""
     log_level: str = "warning"
     application_module: str = "main.wsgi:application"
     enable_metrics: bool = True
@@ -176,6 +203,35 @@ class GranianConfig(BaseModel):
             raise ValueError(msg)
         return v
 
+    @model_validator(mode="after")
+    def resolve_concurrency(self) -> "GranianConfig":
+        """Resolve blocking_threads/backpressure at config time, not at build_args time.
+
+        Doing this here rather than inside ``build_args()`` keeps the effective values
+        inspectable from the model, which is what makes them testable and greppable in a
+        stack's Pulumi state.
+
+        Granian hard-codes ``blocking_threads=1`` for the async interfaces, so an explicit
+        value there would be silently ignored. A config that reads as tuned but isn't is
+        worse than a synth-time failure, hence the ValueError.
+        """
+        if self.interface == "wsgi":
+            if self.blocking_threads is None:
+                self.blocking_threads = DEFAULT_WSGI_BLOCKING_THREADS
+            if self.backpressure is None:
+                self.backpressure = (
+                    DEFAULT_WSGI_BACKPRESSURE_MULTIPLIER * self.blocking_threads
+                )
+        elif self.blocking_threads is not None and self.blocking_threads > 1:
+            msg = (
+                f"granian_config.blocking_threads={self.blocking_threads} was set with "
+                f"interface='{self.interface}', but Granian forces blocking_threads=1 "
+                "for the asgi/asginl interfaces and ignores the flag. Remove the setting "
+                "or switch to interface='wsgi'."
+            )
+            raise ValueError(msg)
+        return self
+
     def build_args(self) -> list[str]:
         """Build the granian CLI argument list from this configuration."""
         args = [
@@ -190,20 +246,19 @@ class GranianConfig(BaseModel):
         ]
         if self.no_ws:
             args.append("--no-ws")
-        if self.runtime_mode is not None:
-            args += ["--runtime-mode", self.runtime_mode]
-        args += ["--runtime-threads", str(self.runtime_threads)]
-        if self.workers_max_rss is not None:
-            args += ["--workers-max-rss", str(self.workers_max_rss)]
-        if self.blocking_threads_idle_timeout is not None:
-            args += [
-                "--blocking-threads-idle-timeout",
-                str(self.blocking_threads_idle_timeout),
-            ]
+        for flag, value in (
+            ("--runtime-mode", self.runtime_mode),
+            ("--runtime-threads", self.runtime_threads),
+            ("--blocking-threads", self.blocking_threads),
+            ("--backpressure", self.backpressure),
+            ("--workers-max-rss", self.workers_max_rss),
+            ("--blocking-threads-idle-timeout", self.blocking_threads_idle_timeout),
+            ("--backlog", self.backlog),
+        ):
+            if value is not None:
+                args += [flag, str(value)]
         if self.respawn_failed_workers:
             args.append("--respawn-failed-workers")
-        if self.backlog is not None:
-            args += ["--backlog", str(self.backlog)]
         if self.enable_metrics:
             args += [
                 "--metrics",
@@ -360,10 +415,16 @@ class OLApplicationK8sConfig(BaseModel):
         default=None,
         description=(
             "Ceiling for the webapp memory VPA. Defaults to 2x "
-            "resource_limits['memory']. Note that when granian_config is set with "
+            "resource_limits['memory']. When granian_config is set with "
             "limit_workers_max_rss, --workers-max-rss is resolved at synth time from "
-            "resource_limits and will NOT track this ceiling -- set "
-            "GranianConfig.workers_max_rss explicitly to keep the two in sync."
+            "resource_limits and deliberately does NOT track this ceiling: the RSS cap "
+            "has to fire before the kernel OOM killer does, and the OOM killer enforces "
+            "the pod's CURRENT declared limit, not the ceiling the VPA is allowed to "
+            "grow to. Pinning GranianConfig.workers_max_rss to this ceiling is an "
+            "anti-pattern -- it disables the RSS safety net until the VPA has already "
+            "grown the pod near its ceiling. Tracking the limit as the VPA moves it "
+            "requires reading the cgroup at runtime, tracked in "
+            "tk-evaluate-runtime-cgroup-derived-workers-max-rss--1cd258."
         ),
     )
     import_nginx_config: bool = Field(default=True)

--- a/tests/ol_infrastructure/components/services/test_k8s_granian_concurrency.py
+++ b/tests/ol_infrastructure/components/services/test_k8s_granian_concurrency.py
@@ -108,6 +108,30 @@ def test_async_interfaces_allow_explicit_backpressure(interface):
     assert arg_value(gc.build_args(), "--backpressure") == "64"
 
 
+def test_holding_pins_reproduce_granians_old_derivation():
+    """Callers awaiting their rollout stage pin the values Granian used to derive.
+
+    Granian's own resolution is ``backpressure = backlog // workers`` and, for WSGI,
+    ``blocking_threads = backpressure // 2``. At the pre-overhaul defaults
+    (backlog=128, workers=2) that is 64 and 32 -- which is what the pin blocks in
+    micromasters/xpro/ocw_studio/odl_video_service/mitxonline/edxapp carry, so
+    landing the component change does not alter their behavior.
+    """
+    backlog, workers = 128, 2
+    granian_backpressure = max(1, backlog // workers)
+    granian_blocking_threads = max(1, granian_backpressure // 2)
+    assert (granian_blocking_threads, granian_backpressure) == (32, 64)
+
+    args = GranianConfig(
+        workers=workers,
+        backlog=backlog,
+        blocking_threads=granian_blocking_threads,
+        backpressure=granian_backpressure,
+    ).build_args()
+    assert arg_value(args, "--blocking-threads") == "32"
+    assert arg_value(args, "--backpressure") == "64"
+
+
 # ─── workers_max_rss ──────────────────────────────────────────────────────────
 
 

--- a/tests/ol_infrastructure/components/services/test_k8s_granian_concurrency.py
+++ b/tests/ol_infrastructure/components/services/test_k8s_granian_concurrency.py
@@ -1,0 +1,140 @@
+"""Tests for GranianConfig concurrency resolution.
+
+Covers the blocking_threads/backpressure resolution matrix (wsgi/asgi x
+None/explicit), the CLI defaults that track Granian's own, and the synth-time
+workers_max_rss derivation from the container memory limit.
+"""
+
+from __future__ import annotations
+
+import pytest
+from kubernetes.utils.quantity import parse_quantity
+from pydantic import ValidationError
+
+from bridge.lib.magic_numbers import (
+    DEFAULT_WSGI_BACKPRESSURE_MULTIPLIER,
+    DEFAULT_WSGI_BLOCKING_THREADS,
+)
+from ol_infrastructure.components.services.k8s import GranianConfig
+
+
+def arg_value(args: list[str], flag: str) -> str | None:
+    """Return the value following ``flag`` in a granian arg list, or None."""
+    return args[args.index(flag) + 1] if flag in args else None
+
+
+# ─── CLI defaults ─────────────────────────────────────────────────────────────
+
+
+def test_defaults_track_granian_cli():
+    gc = GranianConfig()
+    assert gc.workers == 1
+    assert gc.runtime_threads == 1
+    assert gc.runtime_mode is None
+    assert gc.backlog == 128
+
+
+def test_runtime_mode_omitted_when_none():
+    args = GranianConfig().build_args()
+    assert "--runtime-mode" not in args
+    assert arg_value(args, "--runtime-threads") == "1"
+    assert arg_value(args, "--workers") == "1"
+
+
+# ─── blocking_threads / backpressure resolution ───────────────────────────────
+
+
+def test_wsgi_defaults_resolve_at_config_time():
+    gc = GranianConfig()
+    assert gc.blocking_threads == DEFAULT_WSGI_BLOCKING_THREADS
+    assert gc.backpressure == (
+        DEFAULT_WSGI_BACKPRESSURE_MULTIPLIER * DEFAULT_WSGI_BLOCKING_THREADS
+    )
+
+
+def test_wsgi_defaults_emitted():
+    args = GranianConfig().build_args()
+    assert arg_value(args, "--blocking-threads") == str(DEFAULT_WSGI_BLOCKING_THREADS)
+    assert arg_value(args, "--backpressure") == str(
+        DEFAULT_WSGI_BACKPRESSURE_MULTIPLIER * DEFAULT_WSGI_BLOCKING_THREADS
+    )
+
+
+def test_wsgi_explicit_blocking_threads_drives_backpressure():
+    gc = GranianConfig(blocking_threads=4)
+    assert gc.blocking_threads == 4
+    assert gc.backpressure == 8
+
+
+def test_wsgi_explicit_backpressure_preserved():
+    gc = GranianConfig(blocking_threads=4, backpressure=64)
+    args = gc.build_args()
+    assert arg_value(args, "--blocking-threads") == "4"
+    assert arg_value(args, "--backpressure") == "64"
+
+
+def test_wsgi_backpressure_alone_does_not_change_blocking_threads():
+    gc = GranianConfig(backpressure=32)
+    assert gc.blocking_threads == DEFAULT_WSGI_BLOCKING_THREADS
+    assert gc.backpressure == 32
+
+
+@pytest.mark.parametrize("interface", ["asgi", "asginl"])
+def test_async_interfaces_omit_both_flags_by_default(interface):
+    gc = GranianConfig(interface=interface, no_ws=False)
+    assert gc.blocking_threads is None
+    assert gc.backpressure is None
+    args = gc.build_args()
+    assert "--blocking-threads" not in args
+    assert "--backpressure" not in args
+
+
+@pytest.mark.parametrize("interface", ["asgi", "asginl"])
+def test_async_interfaces_reject_multiple_blocking_threads(interface):
+    with pytest.raises(ValidationError, match="forces blocking_threads=1"):
+        GranianConfig(interface=interface, blocking_threads=8)
+
+
+@pytest.mark.parametrize("interface", ["asgi", "asginl"])
+def test_async_interfaces_accept_blocking_threads_of_one(interface):
+    """1 matches what Granian does anyway, so it is redundant rather than wrong."""
+    gc = GranianConfig(interface=interface, blocking_threads=1)
+    assert arg_value(gc.build_args(), "--blocking-threads") == "1"
+
+
+@pytest.mark.parametrize("interface", ["asgi", "asginl"])
+def test_async_interfaces_allow_explicit_backpressure(interface):
+    gc = GranianConfig(interface=interface, backpressure=64)
+    assert arg_value(gc.build_args(), "--backpressure") == "64"
+
+
+# ─── workers_max_rss ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("memory_limit", "workers", "expected_mib"),
+    [
+        ("1200Mi", 1, 1080),
+        ("1Gi", 1, 921),
+        ("2000Mi", 2, 900),
+    ],
+)
+def test_workers_max_rss_derivation(memory_limit, workers, expected_mib):
+    """Mirrors the synth-time formula in OLApplicationK8s.
+
+    floor(limit_bytes / workers * 0.9) MiB, against the pod's *current* declared
+    limit -- not the VPA ceiling, which the kernel OOM killer does not enforce.
+    """
+    limit_bytes = int(parse_quantity(memory_limit))
+    computed = max(1, int(limit_bytes / workers * 0.9) // (1024 * 1024))
+    assert computed == expected_mib
+
+
+def test_workers_max_rss_explicit_is_emitted_verbatim():
+    args = GranianConfig(workers_max_rss=2880).build_args()
+    assert arg_value(args, "--workers-max-rss") == "2880"
+
+
+def test_workers_max_rss_absent_when_unresolved():
+    """The component resolves this at synth time; the model alone emits nothing."""
+    assert "--workers-max-rss" not in GranianConfig().build_args()


### PR DESCRIPTION
### What are the relevant tickets?

N/A — tracked in witan as project `wp-granian-configuration-overhaul-expose-blocking-t-3debc2`, task `tk-granianconfig-add-blocking-threads-backpressure--d0885d`. This is **stage 0** (the component change) of a staged rollout; the per-app behavior changes land in later PRs.

### Description (What does it do?)

`GranianConfig` never exposed `--blocking-threads` or `--backpressure`, so Granian resolved them itself ([`granian/server/common.py`](https://github.com/emmett-framework/granian/blob/master/granian/server/common.py)):

```
backpressure     = max(1, backpressure_arg or backlog // workers)
blocking_threads = blocking_threads_arg or (max(1, backpressure // 2) if WSGI else 1)
```

With this component's defaults (`backlog=128`, `workers=2`, `interface="wsgi"`) that resolves to **32 blocking threads per worker — 64 GIL-competing Python threads per pod**:

```
backpressure     = 128 // 2 = 64
blocking_threads = 64  // 2 = 32
```

Granian itself warns when `blocking_threads > cpu_count() * 2 + 1` ([`granian/server/mp.py`](https://github.com/emmett-framework/granian/blob/master/granian/server/mp.py)). Our webapps request 100m–500m of CPU with no limit — nowhere near the ~15 vCPU that would make 32 defensible. This is the "more concurrency, worse latency" GIL-contention pattern reported in [granian discussion #663](https://github.com/emmett-framework/granian/discussions/663).

Three secondary deviations from Granian's own defaults compounded it:

| Setting | Granian CLI default | Old component default | Maintainer guidance |
|---|---|---|---|
| `workers` | 1 | 2 | "1 worker per pod, scale via replicas" ([#406](https://github.com/emmett-framework/granian/discussions/406)) |
| `runtime_threads` | 1 | 2 | "leave threading at default" ([#663](https://github.com/emmett-framework/granian/discussions/663)) |
| `runtime_mode` | auto | `"mt"` | same |

**Commit 1 — component (`src/ol_infrastructure/components/services/k8s.py`)**

- New `blocking_threads` and `backpressure` fields, resolved in a `model_validator(mode="after")` rather than at `build_args()` time, so the effective value is inspectable on the model instead of being implied by two other settings.
  - WSGI + `None` → `8` / `16` (`DEFAULT_WSGI_BLOCKING_THREADS`, `DEFAULT_WSGI_BACKPRESSURE_MULTIPLIER` in `bridge.lib.magic_numbers`).
  - `asgi`/`asginl` + `None` → neither flag emitted; Granian's forced `blocking_threads=1` stands.
  - `asgi`/`asginl` + `blocking_threads > 1` → `ValueError`. Granian silently ignores the flag there, and a config that reads as tuned but isn't is worse than a synth-time failure.
- Defaults now track Granian's CLI: `workers` 2→1, `runtime_threads` 2→1, `runtime_mode` `"mt"`→`None`. `backlog` stays 128 and now means only the listen backlog, since it no longer feeds the thread-pool derivation.
- `workers_max_rss`: mechanism and synth-time formula unchanged — `floor(resource_limits["memory"] * 0.9 / workers)` against the pod's **current declared limit**. The `webapp_vpa_max_allowed_memory` docstring is **inverted**: pinning `GranianConfig.workers_max_rss` to the VPA ceiling is now documented as the anti-pattern, because the kernel OOM killer enforces the pod's current limit, not the ceiling the VPA is allowed to grow to. (mitxonline's ceiling-derived override is removed in its own stage.)
- `build_args()` optional scalar flags folded into one loop to stay under the C901 limit.

**Commit 2 — holding pins on all callers**

The component change is **not** inert on its own, contrary to the original plan's assumption:

1. Only `edxapp` passed `runtime_mode`/`runtime_threads` explicitly — `micromasters`, `xpro`, `ocw_studio`, `odl_video_service` and `mitxonline` inherit them.
2. More importantly, every WSGI caller would pick up `blocking_threads=8` / `backpressure=16` the moment this lands — applying the headline 32→8 concurrency change to six production apps in a single deploy, which is exactly what the staged rollout exists to avoid.

So each caller is pinned to the values Granian was already deriving:

- `micromasters`, `xpro`, `ocw_studio`, `odl_video_service`, `mitxonline` — `runtime_mode="mt"`, `runtime_threads=2`, `blocking_threads=32`, `backpressure=64` (alongside their existing `workers=2`).
- `edxapp` LMS + CMS — `blocking_threads=32`, `backpressure=64` only; they already pinned the other three.
- `mit_learn`, `learn_ai` — `runtime_threads=2` only. asgi/asginl force `blocking_threads=1`, and both pass `backlog=None`, so no other axis moves.

Each pin block carries a comment stating exactly which lines to delete to adopt the new defaults, so a rollout stage becomes a block deletion. `--respawn-failed-workers` / `--backlog` emission order was deliberately preserved so the two new flags are the entire arg diff.

**Net effect of this PR: no application behavior changes.** It makes the previously-implicit concurrency values explicit and gives every subsequent stage a one-block, one-app edit.

### How can this be tested?

**Unit tests** — new `tests/ol_infrastructure/components/services/test_k8s_granian_concurrency.py` (21 cases) covering the full `wsgi`/`asgi`/`asginl` × `None`/explicit resolution matrix, the CLI-default alignment, the `workers_max_rss` derivation, and a case asserting the holding-pin values reproduce Granian's own derivation:

```
uv run pytest tests/ol_infrastructure/components/services/ -q
# 63 passed
```

`uv run pre-commit run --all-files` equivalents for the touched files (ruff format, ruff check, mypy, detect-secrets) all pass.

**Behavior-preservation check** — the claim that this PR changes no app behavior was verified mechanically, not by inspection. I reconstructed the pre-change `GranianConfig` class out of git, instantiated both the old and new versions with each of the nine real call sites' kwargs, and diffed `build_args()`:

```
INERT+ micromasters
INERT+ xpro
INERT+ ocw_studio
INERT+ odl_video_service
INERT+ mitxonline
INERT+ edxapp-lms
INERT+ edxapp-cms
INERT  mit_learn
INERT  learn_ai
```

`INERT+` = identical after removing the two intentionally-new flag pairs; `INERT` = byte-identical. Example (micromasters), the complete diff:

```
old: ... --runtime-mode mt --runtime-threads 2 --blocking-threads-idle-timeout 120 ...
new: ... --runtime-mode mt --runtime-threads 2 --blocking-threads 32 --backpressure 64 --blocking-threads-idle-timeout 120 ...
```

**For a reviewer:** run a `pulumi preview` on any affected CI stack. The expected webapp diff is exactly `--blocking-threads 32 --backpressure 64` appended to the container args, with no other change to the Deployment. Anything else — a changed `--runtime-threads`, a changed `--workers`, a moved `--backlog`, a changed `--workers-max-rss` — is a bug in this PR.

### Additional Context

- **The plan doc's "lands inert" claim was wrong** and is the reason commit 2 exists. It reasoned only about `workers`; it did not account for the two newly-added fields resolving to non-`None` defaults, nor for the five callers inheriting `runtime_mode`/`runtime_threads`. General form worth remembering: "the new default is inert because callers override it" needs checking per-field across every caller, and never covers newly-added fields.
- **Rollout sequencing is unchanged** — stage 1 pilot (`ocw_studio`, `odl_video_service`) → stage 2 (`micromasters`, `xpro`) → stage 3 (`mitxonline`, then `edxapp` CMS before LMS) → stage 4 (async apps). Each stage now means "delete that app's pin block".
- **Capacity note for stage reviewers** (not this PR): per-pod nominal request concurrency goes from `2 workers × 32 threads = 64` to `1 worker × 8 threads = 8`. That 8× ratio overstates the real change — all 64 threads contended for two GILs, and useful parallelism was bounded by CPU and by GIL handoff overhead, which *rises* with thread count. What genuinely changes is a pod's ability to absorb a burst of slow requests without queuing, which should surface as time-in-queue rather than errors so long as nginx and the listen backlog hold the overflow.
- **Deferred, tracked separately:** (1) runtime cgroup-derived `--workers-max-rss` via an entrypoint wrapper, so the cap tracks the VPA as it moves the limit; (2) TCP-liveness / HTTP-readiness probe split, eligible after stage 2; (3) per-app `blocking_threads` tuning from measured latency once the uniform 8 is everywhere.
