### PR TITLE
fix(rootly): make #devops-alerts Slack visibility explicit, not implicit

### DIFF
--- a/src/ol_infrastructure/saas/rootly/__main__.py
+++ b/src/ol_infrastructure/saas/rootly/__main__.py
@@ -505,6 +505,15 @@ escalation_policy_exampledeleteme_escalationpolicy = rootly.EscalationPolicy(
     opts=rootly_opts,
 )
 
+# Adds an explicit Slack-channel notification target to this level, alongside
+# the existing schedule target, so #devops-alerts visibility for Production
+# no longer depends solely on the account-wide "default alerts channel" Slack
+# integration setting. Discovered 2026-07-22: that global setting posts every
+# alert account-wide unconditionally, independent of routing/escalation, which
+# is why CI/QA alerts (routed separately to their own Slack-only escalation
+# policy) were also still landing in #devops-alerts. Once this level -- and
+# its counterpart below on the other escalation path -- are confirmed working,
+# the global toggle can be turned off to fully separate the two channels.
 escalation_level_b94aa0a3_cda6_4ee6_bcb1_cddf33c69088 = rootly.EscalationLevel(
     "b94aa0a3-cda6-4ee6-bcb1-cddf33c69088",
     delay=5,
@@ -515,7 +524,11 @@ escalation_level_b94aa0a3_cda6_4ee6_bcb1_cddf33c69088 = rootly.EscalationLevel(
             "id": "fad27d50-f0e4-4d21-9b6d-57eb2dec648b",
             "teamMembers": "all",
             "type": "schedule",
-        }
+        },
+        {
+            "id": "GBDLJJX51",  # #devops-alerts
+            "type": "slack_channel",
+        },
     ],
     paging_strategy_configuration_schedule_strategy="on_call_only",
     paging_strategy_configuration_strategy="default",
@@ -535,6 +548,9 @@ escalation_level_r_4351b5b9_00d3_46ae_a044_05930cfbe0e2 = rootly.EscalationLevel
     opts=rootly_opts,
 )
 
+# See the comment on escalation_level_b94aa0a3_cda6_4ee6_bcb1_cddf33c69088
+# above -- this is the equivalent position-1 level on the Default Escalation
+# Policy's other escalation path, updated the same way for the same reason.
 escalation_level_r_75bc919c_824c_46a1_9589_0fc8b85e0d77 = rootly.EscalationLevel(
     "r-75bc919c-824c-46a1-9589-0fc8b85e0d77",
     delay=5,
@@ -545,7 +561,11 @@ escalation_level_r_75bc919c_824c_46a1_9589_0fc8b85e0d77 = rootly.EscalationLevel
             "id": "fad27d50-f0e4-4d21-9b6d-57eb2dec648b",
             "teamMembers": "all",
             "type": "schedule",
-        }
+        },
+        {
+            "id": "GBDLJJX51",  # #devops-alerts
+            "type": "slack_channel",
+        },
     ],
     paging_strategy_configuration_schedule_strategy="on_call_only",
     paging_strategy_configuration_strategy="default",


### PR DESCRIPTION
## Summary
- Discovered while investigating why CI/QA alerts were duplicating into both `#devops-alerts` and `#devops-warnings` after #5082: the Default Escalation Policy (Production's paging path, used by dozens of services per `escalation_policy_id="96629210-cc41-4e57-b059-b182a0f01c5b"`) has **no Slack notification target of its own** -- all 3 existing levels across its two escalation paths only target a `schedule` or a `user` directly (confirmed via `GET /v1/escalation_policies/96629210.../escalation_levels`).
- Its `#devops-alerts` visibility has been coming entirely from an account-wide "Set up a default alerts channel" toggle in the Rootly Slack integration settings, which posts every alert unconditionally, independent of any routing or escalation policy. That's also why CI/QA alerts -- routed separately to their own Slack-only escalation policy in #5082 -- were *also* still landing in `#devops-alerts` via this separate global mechanism.
- Adds an explicit `slack_channel` notification target (`#devops-alerts`, ID `GBDLJJX51`, matching the existing `primary-on-call-schedule`'s channel) to the position-1 level on **each** of the policy's two escalation paths, alongside the existing `schedule` target -- so Slack visibility fires immediately (same ~5s delay as paging) regardless of which path handles a given alert, without touching any existing paging delay/position/strategy.
- This is step 1 of 3 to fully separate the channels:
  1. **This PR**: make `#devops-alerts` visibility explicit for Production.
  2. Confirm with a real alert that Production still posts to `#devops-alerts` via this new explicit path.
  3. Turn off the global "default alerts channel" toggle (UI-only setting, not Pulumi-managed) -- at that point CI/QA -> only `#devops-warnings`, Production -> only `#devops-alerts`, no duplication.

## Test plan
- [x] `ruff check` / `ruff format` pass on the changed file
- [x] `pulumi preview --stack Production --diff` against the live `ol-saas-rootly` stack -- shows exactly 2 resources to *update* (not replace): the existing `schedule` target on each level's position-1 stays untouched, only a new `slack_channel` target is appended. 148 other resources unchanged, no errors.
- [ ] After merge/deploy, trigger or wait for a real Production alert and confirm it posts to `#devops-alerts` via this new explicit level (independent of the still-enabled global toggle for now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)