### PR TITLE
fix(apisix): raise HPA max replicas and CPU target for scaling headroom

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.applications.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.applications.Production.yaml
@@ -45,7 +45,8 @@ config:
   - video.odl.mit.edu
   - xpro-web.odl.mit.edu
   eks:apisix_min_replicas: '5'
-  eks:apisix_max_replicas: '16'
+  eks:apisix_max_replicas: '24'
+  eks:apisix_target_cpu_utilization_percentage: '65'
   eks:apisix_memory: 1500Mi
   eks:developer_role_policy_name: AmazonEKSClusterAdminPolicy
   eks:developer_role_kubernetes_groups:

--- a/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
@@ -317,10 +317,10 @@ def setup_apisix(
                     "enabled": True,
                     "minReplicas": eks_config.get_int("apisix_min_replicas") or 3,
                     "maxReplicas": eks_config.get_int("apisix_max_replicas") or 5,
-                    "targetCPUUtilizationPercentage": eks_config.get_int(
-                        "apisix_target_cpu_utilization_percentage"
-                    )
-                    or 50,
+                    "targetCPUUtilizationPercentage": (
+                        eks_config.get_int("apisix_target_cpu_utilization_percentage")
+                        or 50
+                    ),
                 },
                 # --- Pod Configuration ---
                 "tolerations": operations_tolerations,

--- a/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
@@ -317,7 +317,10 @@ def setup_apisix(
                     "enabled": True,
                     "minReplicas": eks_config.get_int("apisix_min_replicas") or 3,
                     "maxReplicas": eks_config.get_int("apisix_max_replicas") or 5,
-                    "targetCPUUtilizationPercentage": 50,
+                    "targetCPUUtilizationPercentage": eks_config.get_int(
+                        "apisix_target_cpu_utilization_percentage"
+                    )
+                    or 50,
                 },
                 # --- Pod Configuration ---
                 "tolerations": operations_tolerations,
@@ -1041,9 +1044,11 @@ def setup_apisix(
     # Create a VerticalPodAutoscaler for the APISIX gateway deployment.
     #
     # VPA manages memory sizing only; CPU-based horizontal scaling is handled by the HPA
-    # (targetCPUUtilizationPercentage: 50, minReplicas: 3, maxReplicas: 5). Splitting
-    # authority this way avoids the known HPA/VPA conflict: VPA adjusting CPU requests
-    # would distort the CPU utilization percentage that the HPA observes.
+    # above (targetCPUUtilizationPercentage/minReplicas/maxReplicas, configurable via
+    # apisix_target_cpu_utilization_percentage/apisix_min_replicas/apisix_max_replicas,
+    # defaulting to 50/3/5). Splitting authority this way avoids the known HPA/VPA
+    # conflict: VPA adjusting CPU requests would distort the CPU utilization
+    # percentage that the HPA observes.
     #
     # updateMode "InPlaceOrRecreate" attempts to resize memory without evicting the pod
     # (K8s 1.33+, VPA 1.6+), falling back to eviction only when an in-place update is


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
`apache-apisix` in `applications-production` (namespace `operations`) has been sitting at `current=desired=max=16` replicas with CPU utilization around 48-58% -- already at/above its 50% HPA target. This is genuine load-driven saturation with no slack left, following the memory/proxy-buffer OOM fix in #5074 and the max-replica bump in #5073.

This PR:
- Raises `apisix_max_replicas` from 16 to 24 in `applications-production` to give real headroom above current demand.
- Adds a new configurable `apisix_target_cpu_utilization_percentage` Pulumi config value (defaults to 50, unchanged for every other stack) and sets it to 65 in `applications-production`, so the HPA lets pods run a bit hotter before scaling out -- fewer replicas needed for the same load, leaving more of the new ceiling as actual headroom rather than being immediately re-consumed.

At current CPU usage (~48-58% of the 100m request across 16 pods, target 50%), the new 65% target implies roughly 13-14 replicas are needed to satisfy present load, leaving ~10 replicas / ~40% headroom under the new max=24 ceiling.

Part of the APISIX stability improvement work tracked internally as `wp-apisix-stability-improvement-c24b58`, following up on:
- https://github.com/mitodl/ol-infrastructure/commit/f70793ce76ef08466c1c991dd7331d93197de8e7 (apisix_max_replicas 10 -> 16)
- https://github.com/mitodl/ol-infrastructure/commit/24593af5d5c5263f63e0f0f060862349f18cb8a1 (memory limit headroom + explicit proxy buffering)
- https://github.com/mitodl/ol-infrastructure/commit/88fd1a998021ecaef5db51b07130260c0198fd2c (exclude fixed-replica HPAs from HPAAtMaxReplicas alert rule)

### Screenshots (if appropriate):
N/A

### How can this be tested?
`pulumi preview --stack applications.Production` in `src/ol_infrastructure/infrastructure/aws/eks` shows a single, non-replacing update to the `apache-apisix` Helm release:

```
~ kubernetes:helm.sh/v3:Release: (update)
    [id=operations/apache-apisix]
  ~ values: {
      ~ autoscaling: {
          ~ maxReplicas                   : 16 => 24
          ~ targetCPUUtilizationPercentage: 50 => 65
        }
    }
Resources:
    ~ 1 to update
    173 unchanged
```

After merge/deploy, confirm via Grafana/Prometheus (`kube_horizontalpodautoscaler_spec_max_replicas`, `kube_horizontalpodautoscaler_status_current_replicas` for `horizontalpodautoscaler="apache-apisix"`) that the HPA is no longer pinned at its ceiling under normal load, and that no `HPAAtMaxReplicasCritical` alerts fire for `apache-apisix` under steady-state traffic.

### Additional Context
Other stacks (CI/QA, other clusters) are unaffected -- `apisix_target_cpu_utilization_percentage` defaults to 50 (the prior hardcoded value) when unset, so this is opt-in per stack via config.