### PR TITLE
fix(eks): raise OOM-prone memory limits for node-termination-handler and vantage agent

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/eks/aws_utils.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/aws_utils.py
@@ -397,6 +397,18 @@ def setup_aws_integrations(
                 "enableRebalanceDraining": True,
                 "emitKubernetesEvents": True,
                 "podTerminationGracePeriod": 30,
+                # 24Mi (set in #3560, never revisited) is fine for idle
+                # steady-state -- 5 of 6 daemonset pods are healthy at
+                # exactly this limit. It's only insufficient while actively
+                # processing a real interruption/rebalance event
+                # (draining/cordoning the node, talking to the API server),
+                # and the pod re-discovers the same pending event via IMDS
+                # on every restart, so an undersized limit here means a
+                # crash loop that never clears on its own until the node is
+                # replaced. Burstable rather than Guaranteed: keep the
+                # request at the real idle footprint (cheap across every
+                # node, since this is a daemonset) and only raise the limit
+                # to cover the occasional burst.
                 "resources": {
                     "requests": {
                         "cpu": "50m",
@@ -404,7 +416,7 @@ def setup_aws_integrations(
                     },
                     "limits": {
                         "cpu": "50m",
-                        "memory": "24Mi",
+                        "memory": "64Mi",
                     },
                 },
             },

--- a/src/ol_infrastructure/substructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/substructure/aws/eks/__main__.py
@@ -263,13 +263,25 @@ if cluster_stack.require_output("has_ebs_storage"):
                         "ebs_storageclass"
                     ),
                 },
+                # This has bounced between 100Mi/200Mi/256Mi several times
+                # (see git history) chasing recurring OOM kills -- most
+                # recently 200Mi, which still OOMs: every restart reloads a
+                # full controller/pod/node cluster-state snapshot from
+                # backup before it can do anything else, so this is a
+                # consistent per-startup need, not an occasional burst above
+                # a fine idle baseline. Keeping request == limit
+                # (Guaranteed) rather than only raising the limit: a single
+                # pod per cluster, so the aggregate reservation cost is
+                # small, and Guaranteed protects it from being a preferred
+                # eviction target under node memory pressure while it's
+                # already struggling to survive its own startup.
                 "resources": {
                     "requests": {
                         "cpu": "10m",
-                        "memory": "200Mi",
+                        "memory": "512Mi",
                     },
                     "limits": {
-                        "memory": "200Mi",
+                        "memory": "512Mi",
                     },
                 },
             },

--- a/src/ol_infrastructure/substructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/substructure/aws/eks/__main__.py
@@ -269,18 +269,26 @@ if cluster_stack.require_output("has_ebs_storage"):
                 # full controller/pod/node cluster-state snapshot from
                 # backup before it can do anything else, so this is a
                 # consistent per-startup need, not an occasional burst above
-                # a fine idle baseline. Keeping request == limit
-                # (Guaranteed) rather than only raising the limit: a single
-                # pod per cluster, so the aggregate reservation cost is
-                # small, and Guaranteed protects it from being a preferred
-                # eviction target under node memory pressure while it's
-                # already struggling to survive its own startup.
+                # a fine idle baseline. Guaranteed QoS requires every
+                # resource (not just memory) to have request == limit, so
+                # cpu is set explicitly here too, matching the chart's own
+                # default limit (100m) that was already silently in effect
+                # -- our previous override only ever set requests.cpu=10m,
+                # never touched limits.cpu, so Helm merged in the chart
+                # default there. Making that explicit and matching request
+                # to it, rather than leaving the mismatch, so the pod
+                # actually gets Guaranteed QoS: a single pod per cluster, so
+                # the aggregate reservation cost is small, and Guaranteed
+                # protects it from being a preferred eviction target under
+                # node memory pressure while it's already struggling to
+                # survive its own startup.
                 "resources": {
                     "requests": {
-                        "cpu": "10m",
+                        "cpu": "100m",
                         "memory": "512Mi",
                     },
                     "limits": {
+                        "cpu": "100m",
                         "memory": "512Mi",
                     },
                 },


### PR DESCRIPTION
## Summary
- `PodCrashLoopingWarning` fired in `data-qa` for two cluster-wide utilities, both OOMKilled (`exitCode: 137`), confirmed live:
  - `aws-node-termination-handler-m24ct`: 86 restarts over 29h. Its `24Mi` limit (set in #3560, never revisited) is fine for idle-watching — 5 of 6 daemonset pods are healthy at exactly this limit — but insufficient while actively draining/cordoning a node during a real interruption event, and the pod re-discovers the same pending event via IMDS on every restart, so it never breaks the loop on its own.
  - `vantage-kubernetes-agent-0`: 214 restarts over 2d4h. Its memory has bounced between `100Mi`/`200Mi`/`256Mi` several times chasing recurring OOM kills; currently `200Mi` still OOMs because every restart reloads a full controller/pod/node cluster-state snapshot from backup before it can do anything else — a consistent per-startup need, not an occasional burst.
- Fixes, deliberately different QoS class for each based on the actual failure pattern:
  - `aws-node-termination-handler`: **Burstable** — request stays `24Mi` (matches real idle footprint, kept cheap since this is a daemonset multiplied across every node), limit raised to `64Mi` (covers the occasional active-processing burst).
  - `vantage-kubernetes-agent`: **Guaranteed** — memory raised to `512Mi`/`512Mi`. cpu also explicitly set to `100m`/`100m` (both request and limit): review caught that the initial version of this change only set `requests.cpu`, leaving `limits.cpu` unset — Helm was silently merging in the chart's own default limit (`100m`) there, so the pod was actually Burstable all along (request `10m` != limit `100m`), undermining the eviction-protection this change was meant to provide. `100m` isn't a new value — it's the chart's own default limit, already running live and never implicated in any failure (every crash was a memory OOM, never CPU throttling).
- Both values are hardcoded, cluster-agnostic Python dicts applied identically across all 12 EKS stacks (no per-stack override existed) — this change is cluster-wide, not QA-specific.

## Test plan
- [x] `ruff check` / `ruff format` pass on both changed files
- [x] `pulumi preview --stack data.QA --diff` against both live stacks (`ol-infrastructure-eks` and `ol-substructure-eks`), re-run after the QoS correction — each shows exactly the intended change (node-termination-handler: only `limits.memory` 24Mi→64Mi, `requests.memory` untouched; vantage agent: `requests`/`limits` for both cpu and memory now match at `100m`/`512Mi`), all other resources unchanged, no errors.
- [ ] After merge/deploy, confirm both pods stop crash-looping in `data-qa`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)