### PR TITLE
feat(fastly): log Next-Router-Prefetch header in access logs

### DIFF
--- a/src/ol_infrastructure/lib/fastly.py
+++ b/src/ol_infrastructure/lib/fastly.py
@@ -32,6 +32,8 @@ from bridge.secrets.sops import read_yaml_secrets
 # request_duration_usec : The time since the request started in microseconds.
 # request_header_size_bytes : Total header bytes read from the client generating the request.
 # request_method : HTTP method sent by the client
+# request_next_router_prefetch : Next-Router-Prefetch request header, sent by the
+#   Next.js app router on prefetch requests. Empty if absent.
 # request_protocol : HTTP protocol version in use for this request.
 # request_referer : HTTP referer as provided by the client
 # request_user_agent : HTTP useragent as provided by the client
@@ -80,6 +82,7 @@ __base_fastly_log_format_string = """{
 "request_duration_usec":%{time.elapsed.usec}V,
 "request_header_size_bytes":%{req.header_bytes_read}V,
 "request_method":"%{json.escape(req.method)}V",
+"request_next_router_prefetch":"%{json.escape(req.http.Next-Router-Prefetch)}V",
 "request_protocol":"%{json.escape(req.proto)}V",
 "request_referer":"%{json.escape(req.http.referer)}V",
 "request_user_agent":"%{json.escape(req.http.User-Agent)}V",


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up from the mit-learn origin-traffic analysis: https://github.com/mitodl/hq/discussions/12502

### Description (What does it do?)
Logs the `Next-Router-Prefetch` request header (as `request_next_router_prefetch`) so RSC prefetches (cheap stubs) can be distinguished from real RSC navigations (full renders) in Loki — both currently look identical (`?_rsc=`).

Note: the log format is one shared template, so **all** Fastly services (mit_learn, xpro, learn_ai, micromasters, edxapp, ocw_site) pick up the field — empty except on prefetches — on their next deploy.

### Additional Context
Left `Sec-Purpose` out for now — it marks browser-initiated prefetches/prerenders (a separate population, never sent on Next.js router prefetches) and isn't needed for this split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)