### PR TITLE
fix(grafana-alerting): group notifications per-resource, not per-alertname

### DIFF
--- a/src/ol_infrastructure/infrastructure/grafana_alerting/alertmanager.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/alertmanager.py
@@ -96,7 +96,46 @@ def create(grafana_secrets: dict[str, Any], resource_opts: ResourceOptions) -> N
     alerting.NotificationPolicy(
         "grafana-notification-policy",
         contact_point="oblivion",
-        group_bies=["alertname", "environment"],
+        # Grouping by alertname (+ environment, which only log_rules-based
+        # alerts carry -- metric_rules ones use `cluster` instead) bundles
+        # every resource a rule can match into one notification thread. Most
+        # rules here match many independent resources at once (any pod, any
+        # HPA, any node, any deployment, ... cluster-wide, sometimes across
+        # multiple real clusters via regex), so one resource changing state
+        # resends the whole bundle and sweeps in every other still-firing
+        # resource under the same rule, even though nothing about them
+        # changed (observed 2026-07-23: an apisix HPA alert firing
+        # continuously since the day before kept reappearing in
+        # notifications purely because an unrelated HPA in another
+        # namespace kept flapping). Adding every resource-identifying label
+        # used across metric_rules and log_rules gives each distinct
+        # resource its own notification thread, only re-notified when that
+        # specific resource's own state changes. A label absent from a given
+        # alert (e.g. `pod` on an HPA alert) is harmless -- Alertmanager
+        # treats it as empty for grouping, so each rule naturally groups
+        # down to whichever of these labels it actually carries.
+        #
+        # Trade-off: this also splits apart genuinely-correlated alerts that
+        # used to bundle by coincidence (e.g. several unrelated pods
+        # OOMKilled by the same root cause at the same instant no longer
+        # arrive as one grouped message) -- accepted in exchange for no
+        # longer bundling truly-unrelated resources together.
+        group_bies=[
+            "alertname",
+            "environment",
+            "cluster",
+            "namespace",
+            "application",
+            "pod",
+            "container",
+            "deployment",
+            "statefulset",
+            "daemonset",
+            "horizontalpodautoscaler",
+            "node",
+            "job_name",
+            "instance",
+        ],
         # "1m", not "60s" — Grafana normalizes durations to the largest unit and
         # a mismatched spelling shows as a perpetual diff on every preview.
         group_wait="1m",


### PR DESCRIPTION
## Summary
- The notification policy grouped only by `alertname` (+ `environment`, which only `log_rules`-based alerts carry -- the k8s metric rules use `cluster` instead). Most rules here match many independent resources at once (any pod, any HPA, any node, any deployment, ... cluster-wide, sometimes across multiple real clusters via regex), so all of them share one notification bucket regardless of which specific resource is involved. One resource changing state resends the whole bucket and sweeps in every other still-firing resource under the same rule, even though nothing about them changed.
- Observed directly: an `apisix` HPA alert firing continuously since the day before kept reappearing in notifications purely because an unrelated HPA (different namespace, different workload) kept flapping in and out of firing under the same alertname (`HPAAtMaxReplicasCritical`).
- Adds every resource-identifying label used across `metric_rules` and `log_rules` (`cluster`, `namespace`, `application`, `pod`, `container`, `deployment`, `statefulset`, `daemonset`, `horizontalpodautoscaler`, `node`, `job_name`, `instance`) to the grouping. A label absent from a given alert is harmless -- Alertmanager treats it as empty for grouping -- so each rule naturally groups down to whichever of these labels it actually carries, with no per-rule configuration needed.
- **Trade-off, accepted**: this also splits apart genuinely-correlated alerts that used to bundle by coincidence (e.g. several unrelated pods OOMKilled by the same root cause at the same instant no longer arrive as one grouped message), in exchange for no longer bundling truly unrelated resources together.

## Test plan
- [x] `ruff check` / `ruff format` pass on the changed file
- [x] `pulumi preview --stack Production/CI/QA --diff` against all three live Grafana Cloud stacks -- each shows exactly the intended `groupBies` addition (12 new keys appended after `alertname`/`environment`), plus one unrelated pre-existing drift in CI/QA (the `>= 3` restart-threshold rule from #5077, already deployed to Production but never applied to CI/QA -- confirmed via `git diff --stat origin/main` that this branch's only change is this one file).
- [ ] After merge/deploy, confirm a subsequent HPA/pod/node alert notification is scoped to the specific resource rather than bundling in unrelated ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)