### PR TITLE
fix(k8s-apps): remove redundant get causing deploy job scheduler deadlock

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
@@ -1320,16 +1320,18 @@ def _build_release_resource_app_pipeline(
         # Production: wait for release gate (closed release issue); start prod deployment.
         custom_dependencies={
             0: [
+                # Concourse implicitly re-gets a resource right after a `put`
+                # succeeds, so deployment.json (written by the get/`in` action)
+                # is already available to the later action=finish put without
+                # an explicit `get` here. An explicit `get` step for this
+                # resource would count as a job input requiring the scheduler
+                # to resolve a pre-existing version -- which can never happen
+                # for a resource whose only versions come from this job's own
+                # `put`, deadlocking the job forever on its first-ever run.
                 PutStep(
                     put=deployment_rc.name,
                     params={"action": "start", "ref": "((.:image_tag))"},
                 ),
-                # The github-deployments resource's "finish" out-action reads
-                # deployment.json written by a `get`, not by the prior `put` itself
-                # (see ol-concourse resources/github-deployments/README.md's
-                # documented put-start -> get -> ... -> put-finish flow). Without
-                # this, the QA post-step's action=finish put fails to find the file.
-                GetStep(get=deployment_rc.name, trigger=False),
             ],
             1: [
                 GetStep(get=release_gate.name, trigger=True, version="every"),
@@ -1339,13 +1341,12 @@ def _build_release_resource_app_pipeline(
                     trigger=False,
                     passed=[release_image_build_job.name],
                 ),
+                # See the deployment_rc comment above: the implicit get after
+                # this put already makes deployment.json available.
                 PutStep(
                     put=deployment_prod.name,
                     params={"action": "start", "ref": "((.:image_tag))"},
                 ),
-                # See the deployment_rc comment above: action=finish needs
-                # deployment.json from an explicit `get`, not just the prior `put`.
-                GetStep(get=deployment_prod.name, trigger=False),
             ],
         },
         additional_env_vars={


### PR DESCRIPTION
## Summary
- Removes a redundant explicit `get` step for the `github-deployments` resource that the `k8s_apps` pipeline generator inserted right after each `action: start` put in the QA and Production deploy jobs.
- Concourse's `put` step already performs an implicit `get` immediately after it succeeds specifically so later steps can use the produced artifact — the extra explicit `get` was unnecessary.

## Why this matters
The explicit `get` is a real job-level input that Concourse's scheduler must resolve to a pre-existing version before it will ever schedule a build for that job — even though it's fed by a `put` earlier in the same job. For a brand-new `github-deployments` resource (zero GitHub deployments ever recorded for that environment), that version can only ever be produced by the job's own `put`, which can never run because the job can never be scheduled. This is a documented Concourse limitation (concourse/concourse#9590).

Concretely: `ol-analytics-api-pipeline`'s `deploy-ol-application-ol-analytics-api-qa` job has been stuck in `pending` since it was first triggered — every build ever created for it (including a manually-aborted one) never got a `start_time`, confirming the scheduler never even attempted to run it. Manually forcing a resource check confirmed zero versions exist and will exist until the job itself creates one via its `put` — a chicken-and-egg deadlock.

Removing the redundant `get` steps eliminates the extra scheduler-visible input; `deployment.json` is still available to the later `action: finish` put via Concourse's implicit get-after-put, so behavior is otherwise unchanged. Verified via a full plan diff of the regenerated pipeline JSON before/after — the only change is removal of the two `get` steps.

## Test plan
- [x] `ruff check` passes on the modified file
- [x] Regenerated `ol-analytics-api-pipeline` config before/after and diffed job plans — confirmed the only change is removal of the two redundant `get` steps
- [ ] After merge, re-apply via `fly set-pipeline` and confirm `deploy-ol-application-ol-analytics-api-qa` schedules and runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)