### PR TITLE
feat(dagster): let data_loading reach the Keycloak database

### DIFF
--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -89,6 +89,14 @@ vault_stack = make_stack_reference(
     projects.VAULT_SERVER, f"operations.{stack_info.name}"
 )
 cluster_stack = make_stack_reference(projects.EKS, f"data.{stack_info.name}")
+# Keycloak is deployed to CI/QA/Production only; the Dev Dagster stack has no
+# counterpart to reference, so its data_loading deployment simply goes without
+# the Keycloak host and that source stays unavailable there.
+keycloak_stack = (
+    make_stack_reference(projects.KEYCLOAK_APP, stack_info.name)
+    if stack_info.env_suffix in ("ci", "qa", "production")
+    else None
+)
 
 # VPC and network configuration
 mitodl_zone_id = dns_stack.require_output("odl_zone_id")
@@ -999,6 +1007,17 @@ for location in code_locations:
             {"name": "dagster-postgresql-secret"},
         ],
     }
+
+    # data_loading's dlt database sources connect by host and take their
+    # credentials from Vault at run time, so only the host is passed through
+    # here -- from the owning application's stack, not duplicated in config.
+    if name == "data_loading" and keycloak_stack is not None:
+        deployment["env"].append(
+            {
+                "name": "KEYCLOAK_DB_HOST",
+                "value": keycloak_stack.require_output("keycloak")["rds_host"],
+            }
+        )
 
     # Add higher resources for lakehouse deployment (runs dbt)
     if name == "lakehouse":

--- a/src/ol_infrastructure/applications/dagster/dagster_server_policy.hcl
+++ b/src/ol_infrastructure/applications/dagster/dagster_server_policy.hcl
@@ -56,6 +56,13 @@ path "postgres-micromasters/creds/readonly/*" {
 path "postgres-micromasters/creds/readonly" {
   capabilities = ["read"]
 }
+# Keycloak identity tables, ingested by the data_loading dlt pipeline.
+path "postgres-keycloak/creds/readonly/*" {
+  capabilities = ["read"]
+}
+path "postgres-keycloak/creds/readonly" {
+  capabilities = ["read"]
+}
 path "secret-data/" {
   capabilities = ["list"]
 }


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Grants the Dagster deployment what it needs to ingest the Keycloak identity tables via the new dlt database source in ol-data-platform (companion PR: https://github.com/mitodl/ol-data-platform/pull/2472).

Two changes, both in `src/ol_infrastructure/applications/dagster/`:

1. **`dagster_server_policy.hcl`** — grants `postgres-keycloak/creds/readonly`, matching the existing pattern for `mariadb-xpro` and `postgresql-micromasters`. The Keycloak Vault database mount and its `readonly` role already exist; they are created by `OLVaultDatabaseBackend` in the Keycloak application stack (mount point is `f"{engine}-keycloak"`, and `OLPostgresDBConfig.engine` is `"postgres"`).

2. **`__main__.py`** — appends `KEYCLOAK_DB_HOST` to the `data_loading` code location's environment, sourced from the Keycloak stack's exported `keycloak.rds_host` rather than duplicated into Dagster config, so it cannot drift when the RDS instance is replaced.

Only the *host* is passed through. The pipeline mints its own short-lived credentials from `postgres-keycloak/creds/readonly` at connection time using the existing `DAGSTER_VAULT_ROLE` / `DAGSTER_VAULT_MOUNT` Kubernetes auth, so no username or password is stored in the deployment, and no lease is held open between runs.

The Keycloak stack reference is guarded on `stack_info.env_suffix`: Keycloak is deployed to CI/QA/Production only, so the Dev Dagster stack has no counterpart to reference and simply goes without the variable.

Network access needs no change — the Keycloak database security group already admits the data VPC CIDR and its `integrator` security group.

### How can this be tested?

`pulumi preview` has **not** been run against live state — that needs credentials I did not have while preparing this. A reviewer should preview each stack before merging; the expected diff is the Vault policy document and one added container env var on the `data-loading` deployment, with no change to the Dev stack.

After deploy, from a `data-loading` pod:

```
echo $KEYCLOAK_DB_HOST     # expect the Keycloak RDS address for this environment
vault read postgres-keycloak/creds/readonly
```

Local checks that were run: `pre-commit run --files src/ol_infrastructure/applications/dagster/__main__.py src/ol_infrastructure/applications/dagster/dagster_server_policy.hcl` passes clean (ruff, mypy, detect-secrets).

### Additional Context

**Merge order matters.** This PR should merge and deploy *before* the Keycloak ingest runs in QA or production. Without it, the pipeline fails in one of two ways, both loudly and without partial writes:

- Missing `KEYCLOAK_DB_HOST` → `ValueError: KEYCLOAK_DB_HOST is not set. The production deployment must pass the keycloak database host through from its Pulumi stack reference.`
- Missing Vault grant → `RuntimeError: Vault denied 'postgres-keycloak/creds/readonly' — the token's policy does not grant it. Source database mounts must be added to the dagster policy in ol-infrastructure (dagster_server_policy.hcl).`

The ol-data-platform side is written so this pattern generalizes: each future database source needs exactly these two additions here (a `<mount>/creds/readonly` grant, and a `<NAME>_DB_HOST` env var from the owning application's stack export).
