### PR TITLE
chore(ol-analytics-api): initialize QA and Production Pulumi stacks

### DIFF
--- a/src/ol_infrastructure/applications/ol_analytics_api/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/ol_analytics_api/Pulumi.Production.yaml
@@ -25,3 +25,4 @@ config:
     # real backend API domain, matching mitxonline's own Pulumi.Production.yaml
     # backend_domain.
     OL_ANALYTICS_API_B2B_DASHBOARD_MITXONLINE_API_BASE_URL: https://api.mitxonline.mit.edu
+encryptedkey: AQICAHionUR8LBW1ALuVC0rCH3AE2oQIfGMCx3XmpDH9HjM2LQF6EHjQEU/rITguhkMpZkAGAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMmI837wHwSIpvnqVzAgEQgDu3S5KJVVdrunCdsumRyycZRYJKixWMYIT0bEO6Pn2q1unM9gsSLH+XwJYrzI4N5HKHZJWcibnBp+avGA==

--- a/src/ol_infrastructure/applications/ol_analytics_api/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/ol_analytics_api/Pulumi.QA.yaml
@@ -25,3 +25,4 @@ config:
     # must set this explicitly. QA points at the RC (release-candidate) stack,
     # matching mitxonline's own Pulumi.QA.yaml backend_domain.
     OL_ANALYTICS_API_B2B_DASHBOARD_MITXONLINE_API_BASE_URL: https://api.rc.mitxonline.mit.edu
+encryptedkey: AQICAHionUR8LBW1ALuVC0rCH3AE2oQIfGMCx3XmpDH9HjM2LQGpJg9r/l/e4/j3u7c1Q6PpAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMhYZkyfyFaBfe27o+AgEQgDtaxgvH+Z/eGa0K5VgjaN2FArYieVOl8cC1ovbTaqj8PCzatlhfnD9NnrMeTiuB/ktTIrhn3fOyzHMGiw==


### PR DESCRIPTION
## Summary
- `pulumi stack init QA` / `pulumi stack init Production` for `ol-application-ol-analytics-api` (KMS secrets provider `awskms://alias/PulumiSecrets`, matching the existing config templates).
- Only the CI stack had ever been initialized; the QA and Production deploy jobs in `ol-analytics-api-pipeline` were failing with `StackNotFoundError: no stack named 'QA' found` once the scheduler deadlock fix (#5091) let them actually run for the first time.
- Config content (`Pulumi.QA.yaml` / `Pulumi.Production.yaml`) is unchanged; `pulumi stack init` only added the stack's `encryptedkey` entry.

## Test plan
- [x] `pulumi stack ls` shows CI, QA, and Production all present
- [ ] Next `deploy-ol-application-ol-analytics-api-qa` build succeeds against the initialized QA stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)