### PR TITLE
fix(monitoring): add correctly-named alert SNS topics (issue #4828 phase 6)

### DIFF
--- a/src/ol_infrastructure/infrastructure/monitoring/__main__.py
+++ b/src/ol_infrastructure/infrastructure/monitoring/__main__.py
@@ -101,8 +101,18 @@ warning_notifications_webhook_subscription = sns.TopicSubscription(
 )
 
 # Old export retained so any not-yet-redeployed downstream stack's
-# StackReference read still resolves during the transition; remove once
-# nothing consumes it (grep the repo for "opsgenie_sns_topics").
+# StackReference read still resolves during the transition; get_monitoring_sns_arn()
+# (lib/aws/monitoring_helper.py) falls back to this if notification_sns_topics
+# is absent. A repo-wide grep for "opsgenie_sns_topics" is NOT a sufficient
+# removal criterion by itself -- it only reflects checked-out code, not
+# deployed state. A stack can have zero code references to the old export
+# while its last-deployed CloudWatch alarms still have the old topic ARN
+# baked in, simply because it hasn't been redeployed since this change
+# merged. Before removing this export (and, later, the old topics
+# themselves), confirm via a live AWS check -- e.g. `aws cloudwatch
+# describe-alarms` across all accounts/regions, filtered for AlarmActions
+# matching the old OpsGenie_* topic ARNs -- that nothing still points at
+# them, not just that the source code has moved on.
 export(
     "opsgenie_sns_topics",
     {

--- a/src/ol_infrastructure/infrastructure/monitoring/__main__.py
+++ b/src/ol_infrastructure/infrastructure/monitoring/__main__.py
@@ -63,14 +63,14 @@ warning_sns_topic = sns.Topic(
 
 critical_top_webhook_subscription = sns.TopicSubscription(
     "monitoring-critical-alerts-sns-topic-webhook-subscription",
-    endpoint=monitoring_config.get("rootly_critical_webhook_url"),
+    endpoint=monitoring_config.require_secret("rootly_critical_webhook_url"),
     protocol="https",
     topic=critical_sns_topic.arn,
 )
 
 warning_topic_subscription = sns.TopicSubscription(
     "monitoring-warning-alerts-sns-topic-subscription",
-    endpoint=monitoring_config.get("rootly_warning_webhook_url"),
+    endpoint=monitoring_config.require_secret("rootly_warning_webhook_url"),
     protocol="https",
     topic=warning_sns_topic.arn,
 )
@@ -88,14 +88,14 @@ warning_notifications_sns_topic = sns.Topic(
 
 critical_notifications_webhook_subscription = sns.TopicSubscription(
     "monitoring-critical-notifications-sns-topic-webhook-subscription",
-    endpoint=monitoring_config.get("rootly_critical_webhook_url"),
+    endpoint=monitoring_config.require_secret("rootly_critical_webhook_url"),
     protocol="https",
     topic=critical_notifications_sns_topic.arn,
 )
 
 warning_notifications_webhook_subscription = sns.TopicSubscription(
     "monitoring-warning-notifications-sns-topic-webhook-subscription",
-    endpoint=monitoring_config.get("rootly_warning_webhook_url"),
+    endpoint=monitoring_config.require_secret("rootly_warning_webhook_url"),
     protocol="https",
     topic=warning_notifications_sns_topic.arn,
 )

--- a/src/ol_infrastructure/infrastructure/monitoring/__main__.py
+++ b/src/ol_infrastructure/infrastructure/monitoring/__main__.py
@@ -27,8 +27,29 @@ monitoring_config = Config("monitoring")
 
 aws_config = AWSBase(tags={"OU": "operations", "Environment": "operations-production"})
 
-### SNS Resources for notifying opsgenie
-
+### SNS resources for severity-based alert notifications
+#
+# Phase 6 of https://github.com/mitodl/ol-infrastructure/issues/4828: these
+# topics are named `OpsGenie_*` because the org actually used OpsGenie when
+# they were created; the name was never updated after migrating to Rootly,
+# so it's stale history rather than a typo. Renaming an sns.Topic forces
+# replacement (new ARN), and every consumer across 16+ downstream app stacks
+# resolves the ARN dynamically via get_monitoring_sns_arn()'s StackReference
+# lookup rather than a hardcoded name/ARN, so deleting the old topics
+# immediately would silently break CloudWatch alarm notifications for any
+# stack not yet redeployed.
+#
+# So this adds new topics alongside the old ones (not a rename in place) and
+# repoints the shared export at them. Downstream stacks pick up the new ARN
+# the next time they redeploy on their own schedule -- no code changes
+# needed on their end, since none of them reference the topic by literal
+# name. The old OpsGenie_* topics are intentionally left defined here and
+# NOT deleted yet; do that as a separate follow-up once a live AWS check
+# (CloudWatch alarms' AlarmActions across all accounts/regions) confirms
+# nothing still references them.
+#
+# Named after the severity tier, not the destination service, so the next
+# notification-service change doesn't leave another stale vendor name behind.
 critical_sns_topic = sns.Topic(
     "monitoring-critical-alerts-sns-topic",
     name="OpsGenie_Critical_Notifications",
@@ -54,11 +75,46 @@ warning_topic_subscription = sns.TopicSubscription(
     topic=warning_sns_topic.arn,
 )
 
+critical_notifications_sns_topic = sns.Topic(
+    "monitoring-critical-notifications-sns-topic",
+    name="Critical_Notifications",
+    tags=aws_config.merged_tags({"Name": "Critical Notifications"}),
+)
+warning_notifications_sns_topic = sns.Topic(
+    "monitoring-warning-notifications-sns-topic",
+    name="Warning_Notifications",
+    tags=aws_config.merged_tags({"Name": "Warning Notifications"}),
+)
+
+critical_notifications_webhook_subscription = sns.TopicSubscription(
+    "monitoring-critical-notifications-sns-topic-webhook-subscription",
+    endpoint=monitoring_config.get("rootly_critical_webhook_url"),
+    protocol="https",
+    topic=critical_notifications_sns_topic.arn,
+)
+
+warning_notifications_webhook_subscription = sns.TopicSubscription(
+    "monitoring-warning-notifications-sns-topic-webhook-subscription",
+    endpoint=monitoring_config.get("rootly_warning_webhook_url"),
+    protocol="https",
+    topic=warning_notifications_sns_topic.arn,
+)
+
+# Old export retained so any not-yet-redeployed downstream stack's
+# StackReference read still resolves during the transition; remove once
+# nothing consumes it (grep the repo for "opsgenie_sns_topics").
 export(
     "opsgenie_sns_topics",
     {
         "critical_sns_topic_arn": critical_sns_topic.arn,
         "warning_sns_topic_arn": warning_sns_topic.arn,
+    },
+)
+export(
+    "notification_sns_topics",
+    {
+        "critical_sns_topic_arn": critical_notifications_sns_topic.arn,
+        "warning_sns_topic_arn": warning_notifications_sns_topic.arn,
     },
 )
 

--- a/src/ol_infrastructure/lib/aws/monitoring_helper.py
+++ b/src/ol_infrastructure/lib/aws/monitoring_helper.py
@@ -20,7 +20,20 @@ def get_monitoring_sns_arn(level: Literal["warning", "critical"]) -> Output[str]
     # delete_before_replace is intentionally omitted (defaults to False) so that
     # if the referenced stack name changes Pulumi creates the new reference before
     # removing the old one, avoiding a failed read from the now-gone legacy stack.
-    return StackReference(
+    monitoring_stack = StackReference(
         "implicit.infrastructure.monitoring",
         stack_name=stack_ref(projects.MONITORING, "default"),
-    ).require_output("notification_sns_topics")[f"{level}_sns_topic_arn"]
+    )
+    # Downstream stacks redeploy independently, on their own schedule, so this
+    # code can reach a stack's deploy before the monitoring stack itself has
+    # been applied with the notification_sns_topics export (added alongside
+    # the legacy opsgenie_sns_topics one -- see monitoring/__main__.py).
+    # get_output returns None for a missing key instead of raising, for both
+    # exports, so this never hard-fails a downstream deploy regardless of
+    # which side gets applied first; it just prefers the new export once
+    # that stack's redeploy makes it visible.
+    new_topics = monitoring_stack.get_output("notification_sns_topics")
+    legacy_topics = monitoring_stack.get_output("opsgenie_sns_topics")
+    return Output.all(new_topics, legacy_topics).apply(
+        lambda topics: (topics[0] or topics[1])[f"{level}_sns_topic_arn"]
+    )

--- a/src/ol_infrastructure/lib/aws/monitoring_helper.py
+++ b/src/ol_infrastructure/lib/aws/monitoring_helper.py
@@ -23,4 +23,4 @@ def get_monitoring_sns_arn(level: Literal["warning", "critical"]) -> Output[str]
     return StackReference(
         "implicit.infrastructure.monitoring",
         stack_name=stack_ref(projects.MONITORING, "default"),
-    ).require_output("opsgenie_sns_topics")[f"{level}_sns_topic_arn"]
+    ).require_output("notification_sns_topics")[f"{level}_sns_topic_arn"]

--- a/src/ol_infrastructure/lib/aws/monitoring_helper.py
+++ b/src/ol_infrastructure/lib/aws/monitoring_helper.py
@@ -29,11 +29,24 @@ def get_monitoring_sns_arn(level: Literal["warning", "critical"]) -> Output[str]
     # been applied with the notification_sns_topics export (added alongside
     # the legacy opsgenie_sns_topics one -- see monitoring/__main__.py).
     # get_output returns None for a missing key instead of raising, for both
-    # exports, so this never hard-fails a downstream deploy regardless of
-    # which side gets applied first; it just prefers the new export once
-    # that stack's redeploy makes it visible.
+    # exports, so a stack picking up this code before the monitoring stack's
+    # own redeploy still resolves via the legacy export rather than hard
+    # failing. If the monitoring stack has neither export -- which shouldn't
+    # happen today (the legacy export is already live), but would if a
+    # future change ever dropped it before this one -- raise a clear error
+    # instead of a bare TypeError from indexing into None.
     new_topics = monitoring_stack.get_output("notification_sns_topics")
     legacy_topics = monitoring_stack.get_output("opsgenie_sns_topics")
-    return Output.all(new_topics, legacy_topics).apply(
-        lambda topics: (topics[0] or topics[1])[f"{level}_sns_topic_arn"]
-    )
+
+    def _resolve_topic_arn(topics: list[dict[str, str] | None]) -> str:
+        resolved = topics[0] or topics[1]
+        if resolved is None:
+            msg = (
+                "Neither the notification_sns_topics nor the legacy "
+                "opsgenie_sns_topics export was found on the monitoring "
+                "stack -- has it been deployed at least once?"
+            )
+            raise ValueError(msg)
+        return resolved[f"{level}_sns_topic_arn"]
+
+    return Output.all(new_topics, legacy_topics).apply(_resolve_topic_arn)


### PR DESCRIPTION
## Summary
Addresses Phase 6 of #4828 (Migrate Grafana Alerting + Synthetic Monitoring to Pulumi) — cleaning up the misleadingly-named `OpsGenie_Critical_Notifications` / `OpsGenie_Warning_Notifications` SNS topics.

- These topics are named after OpsGenie because the org actually used it when they were created; the name was never updated after migrating to Rootly. Not a typo, just stale history.
- **Not a rename in place.** Renaming an `sns.Topic` forces replacement (new ARN), and every consumer across 16+ downstream app stacks (RDS/ElastiCache CloudWatch alarms, via `get_monitoring_sns_arn()`'s `StackReference` lookup — confirmed no stack hardcodes the topic name/ARN) resolves it dynamically. Deleting the old topics immediately would silently break alarm notifications for any stack not yet redeployed.
- Adds two new topics (`Critical_Notifications` / `Warning_Notifications`) and subscriptions alongside the old ones, and repoints the shared export (renamed `opsgenie_sns_topics` → `notification_sns_topics`) at the new topics.
- Named after the severity tier, not the destination service, so a future notification-service change doesn't leave another stale vendor name behind.
- Downstream stacks pick up the new ARN the next time they redeploy **on their own schedule** — no code changes needed on their end. The old `OpsGenie_*` topics stay defined and undeleted for now.

## Review fixes
1. `get_monitoring_sns_arn()` originally used `require_output("notification_sns_topics")`, which raises `KeyError` if the key is missing. Since downstream stacks redeploy independently, any stack picking up this code before the monitoring stack itself has been applied would hard-fail. **Confirmed live** against the actual current monitoring stack state. Switched to `get_output` for both exports, preferring the new one when present and falling back to the legacy one otherwise.
2. The "grep the repo for `opsgenie_sns_topics`" removal criterion was misleading — it only reflects checked-out code, not deployed state. Reworded to point at a live AWS check (CloudWatch alarms' `AlarmActions`) instead.
3. The fallback (`topics[0] or topics[1]`) would evaluate to `None` if *neither* export exists, and indexing into `None` raised a bare `TypeError` — contradicting the comment's claim that this never hard-fails. Now raises an explicit, actionable `ValueError` instead.
4. `Config.get()` returns a plain, unwrapped string even for keys stored as `secure:` in `Pulumi.default.yaml` — confirmed via the Pulumi SDK source that only `get_secret()`/`require_secret()` call `Output.secret()`. The `[secret]` shown in earlier previews for the webhook `endpoint` was the CLI's heuristic redaction of a string matching a known decrypted secret's value, not real secret-tracking — the underlying state file would have stored the URL in plaintext. Switched all four `endpoint=` call sites (two pre-existing, two added in this PR) to `require_secret()`. Re-verified live: the property now renders as `[secret]` *without* quotes (Pulumi's genuine secret marker) instead of `"[secret]"` *with* quotes (an ordinary string that merely matched the heuristic) — direct confirmation of the fix.

## Test plan
- [x] `ruff check` / `ruff format` / `mypy` pass on all changed files
- [x] `pulumi preview --stack default --diff` against the live `ol-infrastructure-monitoring` stack, re-run after each fix — shows exactly 4 resources to *create* (2 new topics + 2 new subscriptions), 14 unchanged, **no deletes**, no errors; `endpoint` now renders as a genuine Pulumi secret.
- [x] `pulumi preview --stack QA --diff` against the live `mitxonline` app stack — completes without error, confirming the fallback logic works under the actual current monitoring stack state.
- [ ] After merge/deploy, downstream app stacks will pick up the new topic ARN on their next regular `pulumi up`.
- [ ] Follow-up (separate PR, later): once a live AWS check confirms no CloudWatch alarm still references the old `OpsGenie_*` topic ARNs, remove them from this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)