### PR TITLE
fix(edxapp): route CMS chunked course-import uploads to a consistent pod

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/k8s_resources.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_resources.py
@@ -39,6 +39,8 @@ from ol_infrastructure.components.services.apisix import (
     OLApisixRouteConfig,
     OLApisixSharedPlugins,
     OLApisixSharedPluginsConfig,
+    OLApisixUpstream,
+    OLApisixUpstreamConfig,
 )
 from ol_infrastructure.components.services.cert_manager import (
     OLCertManagerCert,
@@ -1685,8 +1687,33 @@ def create_k8s_resources(  # noqa: C901
                 paths=["/*"],
                 backend_service_name=cms_webapp_deployment_name,
                 backend_service_port="http",
+                # "endpoint" makes APISIX load-balance across cms-edxapp-app
+                # pod IPs directly (paired with the chash ApisixUpstream
+                # below), instead of the default "service" granularity which
+                # would hand load-balancing off to a single ClusterIP node
+                # and make per-client hashing impossible.
+                backend_resolve_granularity="endpoint",
             ),
         ],
+    )
+
+    # Studio's chunked course-import upload endpoint tracks each chunk's
+    # progress via the on-disk file size at a path keyed by course id, which
+    # isn't safe to read/write from multiple pods concurrently. Consistent-
+    # hash on the (APISIX-resolved, real) client IP so every chunk of one
+    # upload lands on the same cms-edxapp-app pod, regardless of which of
+    # the 3-5 APISIX gateway replicas or which CMS pod a given HTTP request
+    # would otherwise round-robin to.
+    cms_apisix_upstream = OLApisixUpstream(
+        name=f"ol-{stack_info.env_prefix}-edxapp-cms-apisix-upstream-{stack_info.env_suffix}",
+        upstream_config=OLApisixUpstreamConfig(
+            service_name=cms_webapp_deployment_name,
+            k8s_namespace=namespace,
+            k8s_labels=k8s_global_labels,
+            loadbalancer_type="chash",
+            hash_on="vars",
+            hash_key="remote_addr",
+        ),
     )
 
     # VPA objects.

--- a/src/ol_infrastructure/components/services/apisix.py
+++ b/src/ol_infrastructure/components/services/apisix.py
@@ -560,3 +560,76 @@ class OLApisixExternalUpstream(ComponentResource):
                 opts=resource_options,
             )
         )
+
+
+class OLApisixUpstreamConfig(BaseModel):
+    """Configuration for OLApisixUpstream.
+
+    Configures load-balancing behavior for an in-cluster Kubernetes Service
+    upstream. ``service_name`` must match the target Service's name exactly —
+    apisix-ingress-controller associates an ApisixUpstream resource with a
+    Service by same-name, same-namespace lookup, not by an explicit
+    reference from ApisixRoute.
+    Ref: https://apisix.apache.org/docs/ingress-controller/concepts/apisix_upstream/
+    """
+
+    service_name: str
+    k8s_namespace: str
+    k8s_labels: dict[str, str] = {}
+    loadbalancer_type: Literal["roundrobin", "chash", "ewma", "least_conn"] = (
+        "roundrobin"
+    )
+    # Required when loadbalancer_type == "chash", e.g. hash_on="vars" with
+    # hash_key="remote_addr" to consistently route a given client IP to the
+    # same upstream pod.
+    hash_on: Literal["vars", "header", "cookie", "consumer"] | None = None
+    hash_key: str | None = None
+
+    @model_validator(mode="after")
+    def validate_chash_fields(self) -> "OLApisixUpstreamConfig":
+        """Ensure hash_on/hash_key are set only when using chash load balancing."""
+        if self.loadbalancer_type == "chash" and not (self.hash_on and self.hash_key):
+            msg = "chash load balancing requires both hash_on and hash_key."
+            raise ValueError(msg)
+        if self.loadbalancer_type != "chash" and (self.hash_on or self.hash_key):
+            msg = "hash_on/hash_key are only meaningful when loadbalancer_type='chash'."
+            raise ValueError(msg)
+        return self
+
+
+class OLApisixUpstream(ComponentResource):
+    """
+    Load-balancing configuration for an in-cluster Service-backed upstream.
+    Defines and creates an "ApisixUpstream" resource in the k8s cluster.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        upstream_config: OLApisixUpstreamConfig,
+        opts: ResourceOptions | None = None,
+    ):
+        """Initialize the OLApisixUpstream component resource."""
+        super().__init__(
+            "ol:infrastructure:services:k8s:OLApisixUpstream", name, None, opts
+        )
+        resource_options = ResourceOptions(parent=self).merge(opts)
+
+        loadbalancer_spec: dict[str, Any] = {"type": upstream_config.loadbalancer_type}
+        if upstream_config.loadbalancer_type == "chash":
+            loadbalancer_spec["hashOn"] = upstream_config.hash_on
+            loadbalancer_spec["key"] = upstream_config.hash_key
+
+        self.apisix_upstream_resource = kubernetes.apiextensions.CustomResource(
+            f"OLApisixUpstream-{name}",
+            api_version="apisix.apache.org/v2",
+            kind="ApisixUpstream",
+            metadata=kubernetes.meta.v1.ObjectMetaArgs(
+                # Must equal the target Service's name — see class docstring.
+                name=upstream_config.service_name,
+                labels=upstream_config.k8s_labels,
+                namespace=upstream_config.k8s_namespace,
+            ),
+            spec={"loadbalancer": loadbalancer_spec},
+            opts=resource_options,
+        )

--- a/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
@@ -458,6 +458,14 @@ def setup_apisix(
                         "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "ip",
                         "service.beta.kubernetes.io/aws-load-balancer-scheme": "internet-facing",
                         "service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled": "true",
+                        # NLB target-type "ip" disables client IP preservation by
+                        # default (unlike "instance" targets). Without this, APISIX
+                        # only ever sees the NLB's own address as $remote_addr, which
+                        # breaks the "real-ip" plugin's trustedAddresses check (it can
+                        # never match a Fastly IP) and any per-client-IP logic
+                        # downstream (upstream chash/hashOn=remote_addr, rate
+                        # limiting, etc).
+                        "service.beta.kubernetes.io/aws-load-balancer-target-group-attributes": "preserve_client_ip.enabled=true",
                         "service.beta.kubernetes.io/aws-load-balancer-subnets": target_vpc.apply(
                             lambda tvpc: ",".join(tvpc["k8s_public_subnet_ids"])
                         ),

--- a/tests/ol_infrastructure/components/services/test_apisix.py
+++ b/tests/ol_infrastructure/components/services/test_apisix.py
@@ -1,0 +1,173 @@
+"""Tests for the OLApisixUpstream Pulumi component.
+
+This module verifies:
+1. OLApisixUpstreamConfig's chash field validation (hash_on/hash_key are
+   required together with loadbalancer_type="chash", and rejected otherwise)
+2. The rendered ApisixUpstream CRD spec for roundrobin vs chash
+3. The ApisixUpstream resource is named after the target Service, per the
+   apisix-ingress-controller name-matching contract documented on the class
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pulumi
+
+# Python 3.14+ compatibility
+try:
+    asyncio.get_event_loop()
+except RuntimeError:
+    asyncio.set_event_loop(asyncio.new_event_loop())
+
+
+class K8sMocks(pulumi.runtime.Mocks):
+    def new_resource(self, args: pulumi.runtime.MockResourceArgs):
+        return [args.name + "_id", args.inputs]
+
+    def call(self, args: pulumi.runtime.MockCallArgs):  # noqa: ARG002
+        return {}
+
+
+pulumi.runtime.set_mocks(K8sMocks())
+
+import pytest  # noqa: E402
+from pydantic import ValidationError  # noqa: E402
+
+from ol_infrastructure.components.services.apisix import (  # noqa: E402
+    OLApisixUpstream,
+    OLApisixUpstreamConfig,
+)
+
+# ─── OLApisixUpstreamConfig validation ─────────────────────────────────────────
+
+
+def test_chash_requires_hash_on_and_hash_key():
+    with pytest.raises(ValidationError, match="chash load balancing requires"):
+        OLApisixUpstreamConfig(
+            service_name="myapp-service",
+            k8s_namespace="myapp-ns",
+            loadbalancer_type="chash",
+        )
+
+
+def test_chash_requires_hash_key_even_with_hash_on():
+    with pytest.raises(ValidationError, match="chash load balancing requires"):
+        OLApisixUpstreamConfig(
+            service_name="myapp-service",
+            k8s_namespace="myapp-ns",
+            loadbalancer_type="chash",
+            hash_on="vars",
+        )
+
+
+def test_chash_with_hash_on_and_hash_key_ok():
+    cfg = OLApisixUpstreamConfig(
+        service_name="myapp-service",
+        k8s_namespace="myapp-ns",
+        loadbalancer_type="chash",
+        hash_on="vars",
+        hash_key="remote_addr",
+    )
+    assert cfg.hash_on == "vars"
+    assert cfg.hash_key == "remote_addr"
+
+
+def test_roundrobin_rejects_hash_on():
+    with pytest.raises(ValidationError, match="only meaningful when"):
+        OLApisixUpstreamConfig(
+            service_name="myapp-service",
+            k8s_namespace="myapp-ns",
+            loadbalancer_type="roundrobin",
+            hash_on="vars",
+        )
+
+
+def test_roundrobin_rejects_hash_key():
+    with pytest.raises(ValidationError, match="only meaningful when"):
+        OLApisixUpstreamConfig(
+            service_name="myapp-service",
+            k8s_namespace="myapp-ns",
+            loadbalancer_type="roundrobin",
+            hash_key="remote_addr",
+        )
+
+
+def test_default_loadbalancer_type_is_roundrobin():
+    cfg = OLApisixUpstreamConfig(
+        service_name="myapp-service",
+        k8s_namespace="myapp-ns",
+    )
+    assert cfg.loadbalancer_type == "roundrobin"
+    assert cfg.hash_on is None
+    assert cfg.hash_key is None
+
+
+# ─── Rendered ApisixUpstream CRD spec ──────────────────────────────────────────
+
+
+@pulumi.runtime.test
+def test_roundrobin_spec_has_no_hash_fields():
+    """A roundrobin upstream's rendered spec must not carry hashOn/key."""
+    upstream = OLApisixUpstream(
+        "test-roundrobin-upstream",
+        OLApisixUpstreamConfig(
+            service_name="myapp-service",
+            k8s_namespace="myapp-ns",
+        ),
+    )
+
+    def check(spec):
+        assert spec == {"loadbalancer": {"type": "roundrobin"}}
+
+    return upstream.apisix_upstream_resource.spec.apply(check)
+
+
+@pulumi.runtime.test
+def test_chash_spec_has_hash_on_and_key():
+    """A chash upstream's rendered spec must carry the configured hashOn/key."""
+    upstream = OLApisixUpstream(
+        "test-chash-upstream",
+        OLApisixUpstreamConfig(
+            service_name="cms-edxapp-app",
+            k8s_namespace="mitx-openedx",
+            loadbalancer_type="chash",
+            hash_on="vars",
+            hash_key="remote_addr",
+        ),
+    )
+
+    def check(spec):
+        assert spec == {
+            "loadbalancer": {
+                "type": "chash",
+                "hashOn": "vars",
+                "key": "remote_addr",
+            }
+        }
+
+    return upstream.apisix_upstream_resource.spec.apply(check)
+
+
+@pulumi.runtime.test
+def test_resource_name_matches_service_name():
+    """apisix-ingress-controller matches ApisixUpstream to a Service by exact
+    same-name, same-namespace lookup -- metadata.name must equal service_name,
+    not the Pulumi resource name.
+    """
+    upstream = OLApisixUpstream(
+        "test-name-matching-upstream",
+        OLApisixUpstreamConfig(
+            service_name="cms-edxapp-app",
+            k8s_namespace="mitx-openedx",
+            loadbalancer_type="chash",
+            hash_on="vars",
+            hash_key="remote_addr",
+        ),
+    )
+
+    def check(metadata):
+        assert metadata["name"] == "cms-edxapp-app"
+        assert metadata["namespace"] == "mitx-openedx"
+
+    return upstream.apisix_upstream_resource.metadata.apply(check)


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Fixes intermittent course-import failures on MITx residential production Studio. Confirmed in production logs (`residential-production` cluster, `mitx-openedx` namespace) on two separate course imports:

```
Course import course-v1:MITx+20.309r_12+2026_Fall: A chunk has been missed  (error, cms.djangoapps.contentstore.views.import_export)
Conflict: /import/course-v1:MITx+20.309r_12+2026_Fall  (warning, django.request, HTTP 409)
```

Studio's chunked course-import upload endpoint validates each chunk against the on-disk file size at a course-id-keyed path. With no session affinity between the browser and `cms-edxapp-app`, a multi-chunk upload (any course package large enough to span multiple HTTP requests) can land on a different pod for each chunk, and the mismatch between what's on disk and what the client thinks it already sent produces the "chunk missed" / 409 failure. Small imports that complete in a single request succeed regardless, which is why this only showed up for larger courses.

This took three iterations to root-cause correctly, each ruled out by checking against the actual production topology rather than assuming it would work:

1. **First attempt**: `session_affinity: ClientIP` on the Kubernetes Service. Doesn't help — APISIX sits between the browser and the Service, so the "client IP" kube-proxy sees is whichever APISIX gateway pod's own IP opened the connection, not the browser's.
2. **Second attempt**: APISIX-level `chash` upstream load balancing on `remote_addr`, so the hash happens at the layer that (in theory) knows the real per-request client identity, independent of which of the 3-5 APISIX gateway replicas or which CMS pod handles any given request. This is architecturally correct, but turned out to be silently ineffective — checked live APISIX access logs and found `remote_addr` resolving to private VPC addresses (`10.13.x.x`) even for genuine browser traffic (real Chrome/Safari user agents, correct `learn.mit.edu` referrers). AWS NLBs with `target-type: ip` (used here so APISIX can target pods directly) disable client IP preservation by default, so APISIX's `real-ip` plugin (`trustedAddresses` set to Fastly's IP ranges) never had a real client IP to trust in the first place.
3. **Final fix**: set `preserve_client_ip.enabled=true` on the APISIX gateway NLB target group, which is the actual missing piece — it makes the `chash`/`remote_addr` approach from step 2 work as originally intended.

Changes:
- `src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py`: add `preserve_client_ip.enabled=true` to the APISIX gateway Service's NLB target-group-attributes annotation. This is a shared component instantiated once per EKS cluster (`residential`, `applications`, `data`, `operations`), so it affects every app behind APISIX, not just edxapp — restores correct client-IP visibility for the `real-ip` plugin and anything downstream that depends on it (per-IP rate limiting, this fix's `chash` hashing, logging/observability).
- `src/ol_infrastructure/components/services/apisix.py`: new `OLApisixUpstreamConfig`/`OLApisixUpstream` component that creates an `ApisixUpstream` CRD for configuring Service-backed upstream load-balancing behavior (`roundrobin`/`chash`/`ewma`/`least_conn`, with `hashOn`/`key` for `chash`). Follows the same pattern as the existing `OLApisixExternalUpstream`. Not used by anything except the CMS route below, so it's additive with no behavior change for any other app.
- `src/ol_infrastructure/applications/edxapp/k8s_resources.py`: the CMS `ApisixRoute` now resolves at `endpoint` granularity (required so `chash` has multiple pod-IP nodes to hash across, instead of a single ClusterIP node) and gets a paired `ApisixUpstream` hashing on `remote_addr`, so every chunk of one upload consistently lands on the same `cms-edxapp-app` pod. LMS route and every other APISIX-routed app are untouched.

### Screenshots (if appropriate):
N/A - infrastructure/backend only.

### How can this be tested?
- `pulumi preview` run locally against `mitx.Production` (edxapp stack) shows an isolated diff: one new `ApisixUpstream` resource with the expected `chash`/`remote_addr` spec, and a one-field update to the CMS `ApisixRoute` (`resolveGranularity: "service" -> "endpoint"`). No unexpected replacements or deletions.
- `pulumi preview` run locally against both `residential.Production` and `applications.Production` (eks stack) shows the `preserve_client_ip.enabled=true` annotation as an isolated single-field addition to the APISIX Helm release values, with no other unrelated changes.
- After deploy, confirm via APISIX access logs (`{namespace="operations", app_kubernetes_io_name="apache-apisix"}` in Loki) that `remote_addr`/`client=` on real browser requests through Fastly now shows public client IPs instead of internal `10.x.x.x` addresses.
- Reproduce a large course import against MITx Studio in production (or QA, if the same NLB/APISIX topology exists there) and confirm no "A chunk has been missed" errors across the full upload sequence, with the CMS pod handling all chunks (checkable via structured logs' `pod` field on `cms.djangoapps.contentstore.tasks` / `cms.djangoapps.contentstore.views.import_export` log lines for the same course id).

### Additional Context
- The `preserve_client_ip.enabled=true` NLB target-group-attribute change is the highest-blast-radius part of this PR — it changes client-IP visibility behavior for every app behind APISIX across all four EKS clusters (`residential`, `applications`, `data`, `operations`), not just edxapp. It's a well-documented, standard AWS NLB setting and shouldn't break anything, but flagging for reviewer awareness since it's shared infrastructure.
- Investigation also surfaced (not fixed in this PR, filed for follow-up awareness): edx-platform's Django settings for edxapp don't set `SECURE_PROXY_SSL_HEADER`, so `request.is_secure()` likely always evaluates false since TLS terminates at APISIX and the APISIX-to-pod hop is plain HTTP. Sibling apps (e.g. micromasters) already set this. Separately, a MIT-specific `ol_openedx_git_auto_export` plugin failed to bootstrap a new git repo for course-to-git export around the same time as one of the reproduced import failures (`git clone` before the repo exists) — unrelated bug, not addressed here.