### PR TITLE
Prototype: per-pipeline description text via display.background_image

### DIFF
--- a/src/ol_concourse/pipelines/description_svg.py
+++ b/src/ol_concourse/pipelines/description_svg.py
@@ -9,19 +9,38 @@ draws the job graph on top of it starting from the top-left. This module
 renders a description string into a minimal SVG that reads reasonably under
 that blend, meant to be committed alongside each pipeline's ``pipeline.py``
 and served via a raw.githubusercontent.com URL.
+
+Concourse applies the image via CSS ``background-size: cover;
+background-position: center`` (see ``web/elm/src/Pipeline/Styles.elm`` in
+concourse/concourse) — there is no user-facing zoom/rescale control. ``cover``
+scales the image up until it fills the container in *both* dimensions, then
+crops whatever overflows, centered. A source image with an extreme aspect
+ratio (very wide and short, or very tall and narrow) gets scaled up hard on
+its short axis to satisfy ``cover``, blowing its long axis far past the
+viewport. The mitigations are in the source image, not in Concourse: pick an
+aspect ratio closer to a typical browser viewport, and keep content within a
+smaller, centered fraction of the canvas — the crop is always centered, so
+margin from the canvas center (not from a particular edge) is what
+determines whether content survives.
 """
 
 import textwrap
 from dataclasses import dataclass
 from typing import Literal
 
-_DEFAULT_WIDTH = 800
-_DEFAULT_HEIGHT = 200
-_DEFAULT_FONT_SIZE = 22
+# 16:9 reads much closer to a typical viewport than a short, wide banner, which
+# keeps the "cover" scale-up factor (and thus the risk of content running off
+# the visible crop) far smaller than an extreme aspect ratio would.
+_DEFAULT_WIDTH = 1200
+_DEFAULT_HEIGHT = 675
+_DEFAULT_FONT_SIZE = 30
 _DEFAULT_PADDING = 20
 _LINE_HEIGHT_RATIO = 1.35
 # Rough average glyph width for a sans-serif font, as a fraction of font_size.
 _AVG_CHAR_WIDTH_RATIO = 0.55
+# Cap the text block to this fraction of canvas width by default, centered,
+# so there's margin on both sides before a "cover" crop reaches it.
+_DEFAULT_TEXT_WIDTH_FRACTION = 0.6
 
 Anchor = Literal["top", "center", "bottom"]
 
@@ -42,8 +61,14 @@ class DescriptionStyle:
     by default, i.e. no panel) additionally draw a solid backdrop rectangle
     behind the whole text block. Both are independent, combinable contrast
     controls. ``width``/``height``/``font_size`` control overall scaling;
-    ``wrap_chars`` overrides the automatic line-wrap width (derived from
-    ``width`` and ``font_size`` otherwise).
+    ``wrap_chars`` overrides the automatic line-wrap width entirely.
+    ``text_width_fraction`` instead caps the auto-derived wrap width to a
+    fraction of ``width`` (default 0.6, i.e. text stays centered within the
+    middle 60%) — since Concourse renders this image with
+    ``background-size: cover`` and no rescale control, keeping the text
+    block narrower than the full canvas and centered is what makes it
+    survive being cropped on viewports with a different aspect ratio than
+    ``width``/``height`` (see module docstring).
     """
 
     width: int = _DEFAULT_WIDTH
@@ -52,6 +77,7 @@ class DescriptionStyle:
     padding: int = _DEFAULT_PADDING
     anchor: Anchor = "bottom"
     wrap_chars: int | None = None
+    text_width_fraction: float = _DEFAULT_TEXT_WIDTH_FRACTION
     text_color: str = "white"
     outline_color: str | None = "black"
     outline_width: float = 3
@@ -67,8 +93,12 @@ def render_description_svg(text: str, style: DescriptionStyle | None = None) -> 
     line_height = round(style.font_size * _LINE_HEIGHT_RATIO)
     wrap_chars = style.wrap_chars
     if wrap_chars is None:
+        text_width = min(
+            style.width - 2 * style.padding,
+            style.width * style.text_width_fraction,
+        )
         avg_char_width = style.font_size * _AVG_CHAR_WIDTH_RATIO
-        wrap_chars = max(10, int((style.width - 2 * style.padding) / avg_char_width))
+        wrap_chars = max(10, int(text_width / avg_char_width))
     lines = textwrap.wrap(text, width=wrap_chars)
     block_height = len(lines) * line_height
 

--- a/src/ol_concourse/pipelines/description_svg.py
+++ b/src/ol_concourse/pipelines/description_svg.py
@@ -33,7 +33,6 @@ can always be dragged aside if it does overlap, while a cover-crop cannot.
 
 import textwrap
 from dataclasses import dataclass
-from typing import Literal
 
 # 16:9 reads much closer to a typical viewport than a short, wide banner, which
 # keeps the "cover" scale-up factor (and thus the risk of content running off
@@ -48,24 +47,25 @@ _AVG_CHAR_WIDTH_RATIO = 0.55
 # Cap the text block to this fraction of canvas width by default, centered,
 # so there's margin on both sides before a "cover" crop reaches it.
 _DEFAULT_TEXT_WIDTH_FRACTION = 0.6
-# Minimum top/bottom margin for a top/bottom-anchored text block, as a
-# fraction of canvas height (takes precedence over `padding` when larger).
+# Minimum top/bottom margin the text block's vertical range is confined
+# within, as a fraction of canvas height (takes precedence over `padding`
+# when larger).
 _DEFAULT_VERTICAL_MARGIN_FRACTION = 0.12
-
-Anchor = Literal["top", "center", "bottom"]
 
 
 @dataclass(frozen=True)
 class DescriptionStyle:
     """Sizing/scaling/contrast/positioning knobs for :func:`render_description_svg`.
 
-    ``anchor`` controls where the text block sits vertically (default
-    ``"center"`` — the only position safe against Concourse's
-    ``background-size: cover`` crop on an arbitrary viewport; see module
-    docstring). ``"top"``/``"bottom"`` are available to trade that safety
-    for a chance at clearing the job graph, which Concourse draws from the
-    top-left, but only make sense if you know your viewers' viewport shape
-    is close to ``width``/``height``'s aspect ratio.
+    ``vertical_position`` places the text block on a continuous 0.0 (top of
+    the safe zone) to 1.0 (bottom of the safe zone) scale; 0.5 (default) is
+    dead center — the only position safe against Concourse's
+    ``background-size: cover`` crop on an arbitrary viewport (see module
+    docstring). Moving away from 0.5 trades some of that crop-safety for a
+    chance at clearing the job graph, which Concourse draws from the
+    top-left; nudge it a little (e.g. 0.65) rather than going all the way to
+    an edge (0.0/1.0), and only if you have a sense of your viewers' typical
+    viewport shape relative to ``width``/``height``'s aspect ratio.
 
     ``outline_color``/``outline_width`` add a stroke around the text itself
     for contrast against a busy graph; ``panel_opacity``/``panel_color`` (0
@@ -89,7 +89,7 @@ class DescriptionStyle:
     height: int = _DEFAULT_HEIGHT
     font_size: int = _DEFAULT_FONT_SIZE
     padding: int = _DEFAULT_PADDING
-    anchor: Anchor = "center"
+    vertical_position: float = 0.5
     wrap_chars: int | None = None
     text_width_fraction: float = _DEFAULT_TEXT_WIDTH_FRACTION
     vertical_margin_fraction: float = _DEFAULT_VERTICAL_MARGIN_FRACTION
@@ -117,13 +117,9 @@ def render_description_svg(text: str, style: DescriptionStyle | None = None) -> 
     lines = textwrap.wrap(text, width=wrap_chars)
     block_height = len(lines) * line_height
     vertical_margin = max(style.padding, style.height * style.vertical_margin_fraction)
-
-    if style.anchor == "top":
-        first_line_y = vertical_margin + style.font_size
-    elif style.anchor == "bottom":
-        first_line_y = style.height - vertical_margin - block_height + style.font_size
-    else:
-        first_line_y = (style.height - block_height) / 2 + style.font_size
+    top_safe_y = vertical_margin + style.font_size
+    bottom_safe_y = style.height - vertical_margin - block_height + style.font_size
+    first_line_y = top_safe_y + style.vertical_position * (bottom_safe_y - top_safe_y)
 
     text_attrs = f'fill="{style.text_color}"'
     if style.outline_color:

--- a/src/ol_concourse/pipelines/description_svg.py
+++ b/src/ol_concourse/pipelines/description_svg.py
@@ -41,6 +41,9 @@ _AVG_CHAR_WIDTH_RATIO = 0.55
 # Cap the text block to this fraction of canvas width by default, centered,
 # so there's margin on both sides before a "cover" crop reaches it.
 _DEFAULT_TEXT_WIDTH_FRACTION = 0.6
+# Minimum top/bottom margin for a top/bottom-anchored text block, as a
+# fraction of canvas height (takes precedence over `padding` when larger).
+_DEFAULT_VERTICAL_MARGIN_FRACTION = 0.12
 
 Anchor = Literal["top", "center", "bottom"]
 
@@ -68,7 +71,10 @@ class DescriptionStyle:
     ``background-size: cover`` and no rescale control, keeping the text
     block narrower than the full canvas and centered is what makes it
     survive being cropped on viewports with a different aspect ratio than
-    ``width``/``height`` (see module docstring).
+    ``width``/``height`` (see module docstring). ``vertical_margin_fraction``
+    is the same idea for the top/bottom edge a top- or bottom-anchored block
+    sits against (default 0.12 of ``height``; ``padding`` is used instead
+    wherever it's larger).
     """
 
     width: int = _DEFAULT_WIDTH
@@ -78,6 +84,7 @@ class DescriptionStyle:
     anchor: Anchor = "bottom"
     wrap_chars: int | None = None
     text_width_fraction: float = _DEFAULT_TEXT_WIDTH_FRACTION
+    vertical_margin_fraction: float = _DEFAULT_VERTICAL_MARGIN_FRACTION
     text_color: str = "white"
     outline_color: str | None = "black"
     outline_width: float = 3
@@ -101,13 +108,12 @@ def render_description_svg(text: str, style: DescriptionStyle | None = None) -> 
         wrap_chars = max(10, int(text_width / avg_char_width))
     lines = textwrap.wrap(text, width=wrap_chars)
     block_height = len(lines) * line_height
+    vertical_margin = max(style.padding, style.height * style.vertical_margin_fraction)
 
     if style.anchor == "top":
-        first_line_y = float(style.padding + style.font_size)
+        first_line_y = vertical_margin + style.font_size
     elif style.anchor == "bottom":
-        first_line_y = float(
-            style.height - style.padding - block_height + style.font_size
-        )
+        first_line_y = style.height - vertical_margin - block_height + style.font_size
     else:
         first_line_y = (style.height - block_height) / 2 + style.font_size
 

--- a/src/ol_concourse/pipelines/description_svg.py
+++ b/src/ol_concourse/pipelines/description_svg.py
@@ -11,17 +11,24 @@ that blend, meant to be committed alongside each pipeline's ``pipeline.py``
 and served via a raw.githubusercontent.com URL.
 
 Concourse applies the image via CSS ``background-size: cover;
-background-position: center`` (see ``web/elm/src/Pipeline/Styles.elm`` in
-concourse/concourse) — there is no user-facing zoom/rescale control. ``cover``
-scales the image up until it fills the container in *both* dimensions, then
-crops whatever overflows, centered. A source image with an extreme aspect
-ratio (very wide and short, or very tall and narrow) gets scaled up hard on
-its short axis to satisfy ``cover``, blowing its long axis far past the
-viewport. The mitigations are in the source image, not in Concourse: pick an
-aspect ratio closer to a typical browser viewport, and keep content within a
-smaller, centered fraction of the canvas — the crop is always centered, so
-margin from the canvas center (not from a particular edge) is what
-determines whether content survives.
+background-position: center`` on a ``position: absolute; width/height: 100%``
+div (see ``pipelineBackground`` in ``web/elm/src/Pipeline/Styles.elm`` in
+concourse/concourse) sized to the visible viewport — there is no user-facing
+zoom/rescale control, and unlike the job graph (a separately pannable/
+zoomable SVG layer drawn on top) this background cannot be panned to reveal
+cropped content; whatever `cover` crops off is genuinely gone for that
+viewport. ``cover`` scales the image up until it fills the container on
+*both* axes, then crops whichever axis overflows, centered on the image.
+Which axis overflows depends on how the viewer's viewport aspect ratio
+compares to this image's aspect ratio — it can be either axis, and we can't
+know a given viewer's window size in advance. The only position that
+survives regardless of which axis gets cropped is the image's own center;
+anchoring near *any* edge (top, bottom, left, or right) is vulnerable on
+some viewport shape. `anchor="center"` is the safe default for that reason.
+Top/bottom anchoring trades that safety for a chance at clearing the job
+graph, which starts drawing from the top-left — reasonable only if you also
+know your own viewers' typical viewport proportions, since the graph itself
+can always be dragged aside if it does overlap, while a cover-crop cannot.
 """
 
 import textwrap
@@ -52,12 +59,13 @@ Anchor = Literal["top", "center", "bottom"]
 class DescriptionStyle:
     """Sizing/scaling/contrast/positioning knobs for :func:`render_description_svg`.
 
-    ``anchor`` controls where the text block sits vertically (top/center/
-    bottom) so it can be steered clear of a given pipeline's job graph, which
-    Concourse draws starting from the top-left of the canvas — a small
-    pipeline is least likely to occlude a bottom-anchored block. Panning by
-    click-and-drag in the Concourse UI is always available as a fallback for
-    larger graphs.
+    ``anchor`` controls where the text block sits vertically (default
+    ``"center"`` — the only position safe against Concourse's
+    ``background-size: cover`` crop on an arbitrary viewport; see module
+    docstring). ``"top"``/``"bottom"`` are available to trade that safety
+    for a chance at clearing the job graph, which Concourse draws from the
+    top-left, but only make sense if you know your viewers' viewport shape
+    is close to ``width``/``height``'s aspect ratio.
 
     ``outline_color``/``outline_width`` add a stroke around the text itself
     for contrast against a busy graph; ``panel_opacity``/``panel_color`` (0
@@ -81,7 +89,7 @@ class DescriptionStyle:
     height: int = _DEFAULT_HEIGHT
     font_size: int = _DEFAULT_FONT_SIZE
     padding: int = _DEFAULT_PADDING
-    anchor: Anchor = "bottom"
+    anchor: Anchor = "center"
     wrap_chars: int | None = None
     text_width_fraction: float = _DEFAULT_TEXT_WIDTH_FRACTION
     vertical_margin_fraction: float = _DEFAULT_VERTICAL_MARGIN_FRACTION

--- a/src/ol_concourse/pipelines/description_svg.py
+++ b/src/ol_concourse/pipelines/description_svg.py
@@ -1,0 +1,52 @@
+"""Render short pipeline description text as an SVG for use as a
+``display.background_image``.
+
+Concourse has no native pipeline description/documentation field. The only
+pipeline-level visual customization hook is ``display.background_image``
+(see ``ol_concourse.lib.models.pipeline.DisplayConfig``), which Concourse
+blends into the pipeline tile at 30% opacity, grayscaled, by default. This
+module renders a description string into a minimal SVG that reads reasonably
+under that blend, meant to be committed alongside each pipeline's
+``pipeline.py`` and served via a raw.githubusercontent.com URL.
+"""
+
+import textwrap
+
+_WIDTH = 800
+_HEIGHT = 200
+_FONT_SIZE = 22
+_LINE_HEIGHT = 30
+_WRAP_CHARS = 46
+_PADDING_TOP = 40
+
+
+def render_description_svg(text: str) -> str:
+    """Render ``text`` as a wrapped, centered SVG suitable for
+    ``display.background_image``.
+    """
+    lines = textwrap.wrap(text, width=_WRAP_CHARS)
+    tspans = "\n    ".join(
+        f'<tspan x="50%" dy="{0 if i == 0 else _LINE_HEIGHT}">{_escape(line)}</tspan>'
+        for i, line in enumerate(lines)
+    )
+    return f"""\
+<svg xmlns="http://www.w3.org/2000/svg" width="{_WIDTH}" height="{_HEIGHT}" \
+viewBox="0 0 {_WIDTH} {_HEIGHT}">
+  <text x="50%" y="{_PADDING_TOP}" text-anchor="middle" \
+font-family="sans-serif" font-size="{_FONT_SIZE}" fill="white">
+    {tspans}
+  </text>
+</svg>
+"""
+
+
+def _escape(text: str) -> str:
+    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def write_description_svg(text: str, path: str) -> None:
+    """Render ``text`` and write it to ``path`` (typically
+    ``description.svg`` next to a pipeline's ``pipeline.py``).
+    """
+    with open(path, "w") as description_file:  # noqa: PTH123
+        description_file.write(render_description_svg(text))

--- a/src/ol_concourse/pipelines/description_svg.py
+++ b/src/ol_concourse/pipelines/description_svg.py
@@ -4,36 +4,112 @@
 Concourse has no native pipeline description/documentation field. The only
 pipeline-level visual customization hook is ``display.background_image``
 (see ``ol_concourse.lib.models.pipeline.DisplayConfig``), which Concourse
-blends into the pipeline tile at 30% opacity, grayscaled, by default. This
-module renders a description string into a minimal SVG that reads reasonably
-under that blend, meant to be committed alongside each pipeline's
-``pipeline.py`` and served via a raw.githubusercontent.com URL.
+blends into the pipeline tile at 30% opacity, grayscaled, by default, and
+draws the job graph on top of it starting from the top-left. This module
+renders a description string into a minimal SVG that reads reasonably under
+that blend, meant to be committed alongside each pipeline's ``pipeline.py``
+and served via a raw.githubusercontent.com URL.
 """
 
 import textwrap
+from dataclasses import dataclass
+from typing import Literal
 
-_WIDTH = 800
-_HEIGHT = 200
-_FONT_SIZE = 22
-_LINE_HEIGHT = 30
-_WRAP_CHARS = 46
-_PADDING_TOP = 40
+_DEFAULT_WIDTH = 800
+_DEFAULT_HEIGHT = 200
+_DEFAULT_FONT_SIZE = 22
+_DEFAULT_PADDING = 20
+_LINE_HEIGHT_RATIO = 1.35
+# Rough average glyph width for a sans-serif font, as a fraction of font_size.
+_AVG_CHAR_WIDTH_RATIO = 0.55
+
+Anchor = Literal["top", "center", "bottom"]
 
 
-def render_description_svg(text: str) -> str:
-    """Render ``text`` as a wrapped, centered SVG suitable for
-    ``display.background_image``.
+@dataclass(frozen=True)
+class DescriptionStyle:
+    """Sizing/scaling/contrast/positioning knobs for :func:`render_description_svg`.
+
+    ``anchor`` controls where the text block sits vertically (top/center/
+    bottom) so it can be steered clear of a given pipeline's job graph, which
+    Concourse draws starting from the top-left of the canvas — a small
+    pipeline is least likely to occlude a bottom-anchored block. Panning by
+    click-and-drag in the Concourse UI is always available as a fallback for
+    larger graphs.
+
+    ``outline_color``/``outline_width`` add a stroke around the text itself
+    for contrast against a busy graph; ``panel_opacity``/``panel_color`` (0
+    by default, i.e. no panel) additionally draw a solid backdrop rectangle
+    behind the whole text block. Both are independent, combinable contrast
+    controls. ``width``/``height``/``font_size`` control overall scaling;
+    ``wrap_chars`` overrides the automatic line-wrap width (derived from
+    ``width`` and ``font_size`` otherwise).
     """
-    lines = textwrap.wrap(text, width=_WRAP_CHARS)
+
+    width: int = _DEFAULT_WIDTH
+    height: int = _DEFAULT_HEIGHT
+    font_size: int = _DEFAULT_FONT_SIZE
+    padding: int = _DEFAULT_PADDING
+    anchor: Anchor = "bottom"
+    wrap_chars: int | None = None
+    text_color: str = "white"
+    outline_color: str | None = "black"
+    outline_width: float = 3
+    panel_opacity: float = 0.0
+    panel_color: str = "black"
+
+
+def render_description_svg(text: str, style: DescriptionStyle | None = None) -> str:
+    """Render ``text`` as a wrapped SVG suitable for ``display.background_image``,
+    styled per ``style`` (see :class:`DescriptionStyle`; defaults if omitted).
+    """
+    style = style or DescriptionStyle()
+    line_height = round(style.font_size * _LINE_HEIGHT_RATIO)
+    wrap_chars = style.wrap_chars
+    if wrap_chars is None:
+        avg_char_width = style.font_size * _AVG_CHAR_WIDTH_RATIO
+        wrap_chars = max(10, int((style.width - 2 * style.padding) / avg_char_width))
+    lines = textwrap.wrap(text, width=wrap_chars)
+    block_height = len(lines) * line_height
+
+    if style.anchor == "top":
+        first_line_y = float(style.padding + style.font_size)
+    elif style.anchor == "bottom":
+        first_line_y = float(
+            style.height - style.padding - block_height + style.font_size
+        )
+    else:
+        first_line_y = (style.height - block_height) / 2 + style.font_size
+
+    text_attrs = f'fill="{style.text_color}"'
+    if style.outline_color:
+        text_attrs += (
+            f' stroke="{style.outline_color}" stroke-width="{style.outline_width}"'
+            ' paint-order="stroke"'
+        )
+
     tspans = "\n    ".join(
-        f'<tspan x="50%" dy="{0 if i == 0 else _LINE_HEIGHT}">{_escape(line)}</tspan>'
+        f'<tspan x="50%" dy="{0 if i == 0 else line_height}">{_escape(line)}</tspan>'
         for i, line in enumerate(lines)
     )
+
+    panel = ""
+    if style.panel_opacity > 0:
+        panel_y = max(
+            0.0, first_line_y - style.font_size - (line_height - style.font_size)
+        )
+        panel_height = min(style.height - panel_y, block_height + line_height)
+        panel = (
+            f'  <rect x="0" y="{panel_y:.1f}" width="{style.width}" '
+            f'height="{panel_height:.1f}" fill="{style.panel_color}" '
+            f'fill-opacity="{style.panel_opacity}" />\n'
+        )
+
     return f"""\
-<svg xmlns="http://www.w3.org/2000/svg" width="{_WIDTH}" height="{_HEIGHT}" \
-viewBox="0 0 {_WIDTH} {_HEIGHT}">
-  <text x="50%" y="{_PADDING_TOP}" text-anchor="middle" \
-font-family="sans-serif" font-size="{_FONT_SIZE}" fill="white">
+<svg xmlns="http://www.w3.org/2000/svg" width="{style.width}" height="{style.height}" \
+viewBox="0 0 {style.width} {style.height}">
+{panel}  <text x="50%" y="{first_line_y:.1f}" text-anchor="middle" \
+font-family="sans-serif" font-size="{style.font_size}" {text_attrs}>
     {tspans}
   </text>
 </svg>
@@ -44,9 +120,11 @@ def _escape(text: str) -> str:
     return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
 
 
-def write_description_svg(text: str, path: str) -> None:
+def write_description_svg(
+    text: str, path: str, style: DescriptionStyle | None = None
+) -> None:
     """Render ``text`` and write it to ``path`` (typically
     ``description.svg`` next to a pipeline's ``pipeline.py``).
     """
     with open(path, "w") as description_file:  # noqa: PTH123
-        description_file.write(render_description_svg(text))
+        description_file.write(render_description_svg(text, style))

--- a/src/ol_concourse/pipelines/examples/description.svg
+++ b/src/ol_concourse/pipelines/examples/description.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675">
-  <rect x="0" y="485.0" width="1200" height="190.0" fill="black" fill-opacity="0.45" />
-  <text x="50%" y="525.0" text-anchor="middle" font-family="sans-serif" font-size="30" fill="white" stroke="black" stroke-width="3" paint-order="stroke">
+  <rect x="0" y="424.0" width="1200" height="200.0" fill="black" fill-opacity="0.45" />
+  <text x="50%" y="464.0" text-anchor="middle" font-family="sans-serif" font-size="30" fill="white" stroke="black" stroke-width="3" paint-order="stroke">
     <tspan x="50%" dy="0">Prototype pipeline for validating per-</tspan>
     <tspan x="50%" dy="40">pipeline description text via</tspan>
     <tspan x="50%" dy="40">display.background_image. Not part of any</tspan>

--- a/src/ol_concourse/pipelines/examples/description.svg
+++ b/src/ol_concourse/pipelines/examples/description.svg
@@ -1,8 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="800" height="200" viewBox="0 0 800 200">
-  <rect x="0" y="82.0" width="800" height="118.0" fill="black" fill-opacity="0.45" />
-  <text x="50%" y="112.0" text-anchor="middle" font-family="sans-serif" font-size="22" fill="white" stroke="black" stroke-width="3" paint-order="stroke">
-    <tspan x="50%" dy="0">Prototype pipeline for validating per-pipeline description</tspan>
-    <tspan x="50%" dy="30">text via display.background_image. Not part of any real</tspan>
-    <tspan x="50%" dy="30">deployment.</tspan>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675">
+  <rect x="0" y="485.0" width="1200" height="190.0" fill="black" fill-opacity="0.45" />
+  <text x="50%" y="525.0" text-anchor="middle" font-family="sans-serif" font-size="30" fill="white" stroke="black" stroke-width="3" paint-order="stroke">
+    <tspan x="50%" dy="0">Prototype pipeline for validating per-</tspan>
+    <tspan x="50%" dy="40">pipeline description text via</tspan>
+    <tspan x="50%" dy="40">display.background_image. Not part of any</tspan>
+    <tspan x="50%" dy="40">real deployment.</tspan>
   </text>
 </svg>

--- a/src/ol_concourse/pipelines/examples/description.svg
+++ b/src/ol_concourse/pipelines/examples/description.svg
@@ -1,7 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="800" height="200" viewBox="0 0 800 200">
-  <text x="50%" y="40" text-anchor="middle" font-family="sans-serif" font-size="22" fill="white">
-    <tspan x="50%" dy="0">Prototype pipeline for validating per-pipeline</tspan>
-    <tspan x="50%" dy="30">description text via display.background_image.</tspan>
-    <tspan x="50%" dy="30">Not part of any real deployment.</tspan>
+  <rect x="0" y="82.0" width="800" height="118.0" fill="black" fill-opacity="0.45" />
+  <text x="50%" y="112.0" text-anchor="middle" font-family="sans-serif" font-size="22" fill="white" stroke="black" stroke-width="3" paint-order="stroke">
+    <tspan x="50%" dy="0">Prototype pipeline for validating per-pipeline description</tspan>
+    <tspan x="50%" dy="30">text via display.background_image. Not part of any real</tspan>
+    <tspan x="50%" dy="30">deployment.</tspan>
   </text>
 </svg>

--- a/src/ol_concourse/pipelines/examples/description.svg
+++ b/src/ol_concourse/pipelines/examples/description.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675">
-  <rect x="0" y="424.0" width="1200" height="200.0" fill="black" fill-opacity="0.45" />
-  <text x="50%" y="464.0" text-anchor="middle" font-family="sans-serif" font-size="30" fill="white" stroke="black" stroke-width="3" paint-order="stroke">
+  <rect x="0" y="247.5" width="1200" height="200.0" fill="black" fill-opacity="0.45" />
+  <text x="50%" y="287.5" text-anchor="middle" font-family="sans-serif" font-size="30" fill="white" stroke="black" stroke-width="3" paint-order="stroke">
     <tspan x="50%" dy="0">Prototype pipeline for validating per-</tspan>
     <tspan x="50%" dy="40">pipeline description text via</tspan>
     <tspan x="50%" dy="40">display.background_image. Not part of any</tspan>

--- a/src/ol_concourse/pipelines/examples/description.svg
+++ b/src/ol_concourse/pipelines/examples/description.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="675" viewBox="0 0 1200 675">
-  <rect x="0" y="247.5" width="1200" height="200.0" fill="black" fill-opacity="0.45" />
-  <text x="50%" y="287.5" text-anchor="middle" font-family="sans-serif" font-size="30" fill="white" stroke="black" stroke-width="3" paint-order="stroke">
+  <rect x="0" y="300.5" width="1200" height="200.0" fill="black" fill-opacity="0.45" />
+  <text x="50%" y="340.5" text-anchor="middle" font-family="sans-serif" font-size="30" fill="white" stroke="black" stroke-width="3" paint-order="stroke">
     <tspan x="50%" dy="0">Prototype pipeline for validating per-</tspan>
     <tspan x="50%" dy="40">pipeline description text via</tspan>
     <tspan x="50%" dy="40">display.background_image. Not part of any</tspan>

--- a/src/ol_concourse/pipelines/examples/description.svg
+++ b/src/ol_concourse/pipelines/examples/description.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="200" viewBox="0 0 800 200">
+  <text x="50%" y="40" text-anchor="middle" font-family="sans-serif" font-size="22" fill="white">
+    <tspan x="50%" dy="0">Prototype pipeline for validating per-pipeline</tspan>
+    <tspan x="50%" dy="30">description text via display.background_image.</tspan>
+    <tspan x="50%" dy="30">Not part of any real deployment.</tspan>
+  </text>
+</svg>

--- a/src/ol_concourse/pipelines/examples/hello.py
+++ b/src/ol_concourse/pipelines/examples/hello.py
@@ -62,7 +62,10 @@ if __name__ == "__main__":
     write_description_svg(
         DESCRIPTION,
         str(Path(__file__).parent / "description.svg"),
-        DescriptionStyle(panel_opacity=0.45),  # anchor="center" default
+        # vertical_position=0.5 (dead center) is the crop-safe default; nudged
+        # here to dodge this pipeline's own job graph on typical viewports,
+        # trading a little of that safety margin away (see description_svg.py).
+        DescriptionStyle(panel_opacity=0.45, vertical_position=0.65),
     )
     with open("definition.json", "w") as definition:  # noqa: PTH123
         definition.write(hello_pipeline().model_dump_json(indent=2))

--- a/src/ol_concourse/pipelines/examples/hello.py
+++ b/src/ol_concourse/pipelines/examples/hello.py
@@ -62,7 +62,7 @@ if __name__ == "__main__":
     write_description_svg(
         DESCRIPTION,
         str(Path(__file__).parent / "description.svg"),
-        DescriptionStyle(anchor="bottom", panel_opacity=0.45),
+        DescriptionStyle(panel_opacity=0.45),  # anchor="center" default
     )
     with open("definition.json", "w") as definition:  # noqa: PTH123
         definition.write(hello_pipeline().model_dump_json(indent=2))

--- a/src/ol_concourse/pipelines/examples/hello.py
+++ b/src/ol_concourse/pipelines/examples/hello.py
@@ -2,6 +2,7 @@ from ol_concourse.lib.constants import REGISTRY_IMAGE
 from ol_concourse.lib.models.pipeline import (
     AnonymousResource,
     Command,
+    DisplayConfig,
     Identifier,
     Job,
     Pipeline,
@@ -9,6 +10,21 @@ from ol_concourse.lib.models.pipeline import (
     RegistryImage,
     TaskConfig,
     TaskStep,
+)
+
+from ol_concourse.pipelines.description_svg import write_description_svg
+
+# Raw-GitHub-hosted SVG rendering of DESCRIPTION, committed as description.svg
+# alongside this file, used as the pipeline's dashboard background image
+# (Concourse has no native description field; see AGENTS.md / description_svg.py).
+DESCRIPTION = (
+    "Prototype pipeline for validating per-pipeline description text via "
+    "display.background_image. Not part of any real deployment."
+)
+_DESCRIPTION_SVG_RAW_URL = (
+    "https://raw.githubusercontent.com/mitodl/ol-infrastructure/"
+    "worktree-concourse-pipeline-descriptions/"
+    "src/ol_concourse/pipelines/examples/description.svg"
 )
 
 
@@ -30,12 +46,17 @@ def hello_pipeline() -> Pipeline:
             ),
         ],
     )
-    return Pipeline(jobs=[hello_job_object])
+    return Pipeline(
+        jobs=[hello_job_object],
+        display=DisplayConfig(background_image=_DESCRIPTION_SVG_RAW_URL),
+    )
 
 
 if __name__ == "__main__":
     import sys
+    from pathlib import Path
 
+    write_description_svg(DESCRIPTION, str(Path(__file__).parent / "description.svg"))
     with open("definition.json", "w") as definition:  # noqa: PTH123
         definition.write(hello_pipeline().model_dump_json(indent=2))
     sys.stdout.write(hello_pipeline().model_dump_json(indent=2))

--- a/src/ol_concourse/pipelines/examples/hello.py
+++ b/src/ol_concourse/pipelines/examples/hello.py
@@ -12,7 +12,10 @@ from ol_concourse.lib.models.pipeline import (
     TaskStep,
 )
 
-from ol_concourse.pipelines.description_svg import write_description_svg
+from ol_concourse.pipelines.description_svg import (
+    DescriptionStyle,
+    write_description_svg,
+)
 
 # Raw-GitHub-hosted SVG rendering of DESCRIPTION, committed as description.svg
 # alongside this file, used as the pipeline's dashboard background image
@@ -56,7 +59,11 @@ if __name__ == "__main__":
     import sys
     from pathlib import Path
 
-    write_description_svg(DESCRIPTION, str(Path(__file__).parent / "description.svg"))
+    write_description_svg(
+        DESCRIPTION,
+        str(Path(__file__).parent / "description.svg"),
+        DescriptionStyle(anchor="bottom", panel_opacity=0.45),
+    )
     with open("definition.json", "w") as definition:  # noqa: PTH123
         definition.write(hello_pipeline().model_dump_json(indent=2))
     sys.stdout.write(hello_pipeline().model_dump_json(indent=2))


### PR DESCRIPTION
## Summary
- Adds `src/ol_concourse/pipelines/description_svg.py`, a small helper that renders description text into an SVG suitable for `Pipeline(display=DisplayConfig(background_image=...))` — the only pipeline-level documentation hook Concourse exposes (no native description field).
- Wires it up in `src/ol_concourse/pipelines/examples/hello.py` as a live, working usage example.
- Validated end-to-end against a real pipeline on odl-prod (`misc-cloud-hello`, `main` team) across several rendering issues found and fixed along the way (see commit history): initial horizontal overflow and later vertical overflow, both traced to Concourse's `background-size: cover; background-position: center` CSS (not user-configurable — confirmed by reading `web/elm/src/Pipeline/Styles.elm` in concourse/concourse), which crops symmetrically around the image's center and can crop either axis depending on the viewer's own viewport shape. `vertical_position` (continuous 0.0–1.0, default 0.5/dead-center) lets a pipeline trade a controlled amount of that crop-safety for a chance at clearing its own job graph, which Concourse draws starting top-left.
- Also filed a feature request upstream proposing Concourse add a first-class, layout-aware pipeline description field, since a background image fundamentally can't coordinate with where the renderer places the job graph: https://github.com/orgs/concourse/discussions/9660

This is accepted as the interim solution pending that upstream request (if it goes anywhere). Tracked under the "Concourse pipeline dashboard reorganization" project (task `tk-add-per-pipeline-description-text-via-displaycon-13443d`).

## Test plan
- [x] `ruff format` / `ruff check` / `mypy` clean on both new/changed files (pre-existing D100/D103 on `hello.py` predate this change)
- [x] `python hello.py` generates valid `definition.json` and `description.svg`
- [x] Live-deployed to `misc-cloud-hello` on odl-prod (`main` team) via `fly set-pipeline`; `display.background_image` round-trips correctly on `fly get-pipeline`
- [x] Confirmed the SVG is publicly fetchable via `raw.githubusercontent.com` with no auth (repo is public)
- [x] Visually verified in the live dashboard across several iterations (horizontal overflow → fixed, vertical overflow → fixed, graph occlusion → mitigated via `vertical_position`)
- [ ] Reviewer: eyeball https://cicd.odl.mit.edu/teams/main/pipelines/misc-cloud-hello once this merges and the `background_image` URL is updated to point at `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)