### PR TITLE
fix(eks): preserve real client IPs on the Traefik gateway NLB

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/eks/traefik.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/traefik.py
@@ -222,6 +222,14 @@ def setup_traefik(
                         "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "ip",
                         "service.beta.kubernetes.io/aws-load-balancer-scheme": "internet-facing",
                         "service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled": "true",
+                        # NLB target-type "ip" disables client IP preservation by
+                        # default (unlike "instance" targets). Without this,
+                        # Traefik only ever sees the NLB's own address as the
+                        # peer IP -- breaking ForwardedHeaders/real client IP
+                        # visibility for anything routed through this gateway.
+                        # See src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
+                        # for the same fix applied to the APISIX gateway NLB.
+                        "service.beta.kubernetes.io/aws-load-balancer-target-group-attributes": "preserve_client_ip.enabled=true",
                         "service.beta.kubernetes.io/aws-load-balancer-subnets": target_vpc.apply(
                             lambda tvpc: ",".join(tvpc["k8s_public_subnet_ids"])
                         ),


### PR DESCRIPTION
### What are the relevant tickets?
N/A. Follow-up to #5096 (merged).

### Description (What does it do?)
Applies the same fix as #5096 to the Traefik gateway (used for Gateway API `HTTPRoute` traffic, e.g. `mit-learn-nextjs`), which sits behind an identically-configured NLB and has the identical bug.

`src/ol_infrastructure/infrastructure/aws/eks/traefik.py`'s gateway Service uses `aws-load-balancer-nlb-target-type: ip` (so Traefik can target pods directly), which disables AWS's client-IP preservation by default. Confirmed in production Loki logs while verifying #5096's QA rollout: Traefik's own access logs show `ClientAddr`/`ClientHost` as internal VPC addresses (`10.12.x.x`) instead of real client IPs for `next.rc.learn.mit.edu` traffic — the same symptom already root-caused and fixed for the APISIX gateway in #5096.

Sets `preserve_client_ip.enabled=true` on the Traefik gateway NLB target group, mirroring `apisix_official.py`. This is a shared component instantiated once per EKS cluster, so it affects every app routed through Traefik/Gateway API across all four clusters (`residential`, `applications`, `data`, `operations`).

### Screenshots (if appropriate):
N/A - infrastructure/backend only.

### How can this be tested?
`pulumi preview` run locally against both `residential.Production` and `applications.Production` (eks stack) shows an isolated single-annotation diff on the `traefik-gateway-controller` Helm release, no other changes, no replacements.

After deploy: confirm via Traefik access logs (`{namespace="operations", app_kubernetes_io_name="traefik"}` in Loki, `ClientAddr`/`ClientHost` fields) that real public client IPs are now visible instead of internal `10.x.x.x` addresses, following the same verification done for the APISIX side in #5096.

### Additional Context
Same blast-radius consideration as #5096: `preserve_client_ip.enabled=true` on an NLB target group is a standard, well-documented AWS setting and shouldn't break anything, but it changes client-IP visibility behavior for every app routed through this shared gateway across all four EKS clusters, not just one app. Flagging for reviewer awareness since it's shared infrastructure.