### PR TITLE
spike(apisix): opt-in Coraza WAF proxy-wasm image + Helm wiring

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -21,6 +21,22 @@ fly -t <target> set-pipeline \
     -c pipelines/infrastructure/ol_python_base_docker.yaml
 ```
 
+## apisix-waf
+
+[`apisix-waf/`](apisix-waf/) — Spike image layering the [Coraza](https://www.coraza.io/)
+proxy-wasm WAF filter (OWASP Core Rule Set embedded at compile time by the
+upstream `coraza-proxy-wasm` project) onto the stock `apache/apisix` image.
+`wasm-nginx-module`/wasmtime are already compiled into every apisix-base
+build, so this image only needs to copy the plugin binary in.
+
+Published as `mitodl/apisix-waf` (ECR only, not Docker Hub) via the Concourse
+pipeline at
+[`pipelines/container_images/apisix_waf.py`](../src/ol_concourse/pipelines/container_images/apisix_waf.py).
+Deliberately not chained to a Pulumi deploy -- see
+`apisix_custom_image_repository`/`apisix_custom_image_tag` in
+[`apisix_official.py`](../src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py)
+for the opt-in per-cluster config that actually references this image.
+
 ## edX / Open edX
 
 The edX Dockerfiles that previously lived here (`openedx-edxapp`,

--- a/dockerfiles/apisix-waf/Dockerfile
+++ b/dockerfiles/apisix-waf/Dockerfile
@@ -1,0 +1,17 @@
+# Spike: layers the Coraza WAF proxy-wasm filter (OWASP Core Rule Set embedded
+# at compile time by the upstream project -- no separate ruleset files needed)
+# onto the stock APISIX image. wasm-nginx-module/wasmtime are already compiled
+# into every apisix-base build (confirmed against api7/apisix-build-tools'
+# build-apisix-base.sh), so this needs nothing beyond copying the plugin binary
+# in and registering it via Helm values (see apisix_official.py).
+#
+# Base tag must track APISIX_CHART_VERSION's default appVersion
+# (src/bridge/lib/versions.py) -- chart 2.16.0 => APISIX 3.17.0-ubuntu.
+ARG APISIX_IMAGE_TAG="3.17.0-ubuntu"
+ARG CORAZA_PROXY_WASM_VERSION="0.6.0"
+
+FROM ghcr.io/corazawaf/coraza-proxy-wasm:${CORAZA_PROXY_WASM_VERSION} AS coraza
+
+FROM apache/apisix:${APISIX_IMAGE_TAG}
+
+COPY --from=coraza /plugin.wasm /usr/local/apisix/coraza-filter.wasm

--- a/src/ol_concourse/pipelines/container_images/apisix_waf.py
+++ b/src/ol_concourse/pipelines/container_images/apisix_waf.py
@@ -1,0 +1,73 @@
+"""Build and publish the apisix-waf spike image (APISIX + Coraza proxy-wasm).
+
+Deliberately NOT chained into a pulumi_jobs_chain -- this is an opt-in spike
+image. `apisix_official.py` only references it when a per-cluster Pulumi
+stack config explicitly sets `apisix_custom_image_repository`, so image
+builds here never trigger a deploy on their own.
+"""
+
+import sys
+
+from ol_concourse.lib.containers import container_build_task, ensure_ecr_task
+from ol_concourse.lib.models.pipeline import (
+    GetStep,
+    Identifier,
+    Input,
+    Job,
+    Pipeline,
+    PutStep,
+)
+from ol_concourse.lib.resources import git_repo, registry_image
+
+from ol_concourse.pipelines.constants import ECR_REGION
+
+ol_infrastructure_repo = git_repo(
+    name=Identifier("ol-infrastructure"),
+    uri="https://github.com/mitodl/ol-infrastructure",
+    branch="main",
+    paths=["dockerfiles/apisix-waf/Dockerfile"],
+)
+
+ecr_image_resource = registry_image(
+    name=Identifier("apisix-waf-image"),
+    image_repository="mitodl/apisix-waf",
+    ecr_region=ECR_REGION,
+)
+
+
+def build_job() -> Job:
+    context = f"{ol_infrastructure_repo.name}/dockerfiles/apisix-waf"
+    return Job(
+        name=Identifier("build-and-publish"),
+        public=True,
+        plan=[
+            GetStep(get=ol_infrastructure_repo.name, trigger=True),
+            container_build_task(
+                inputs=[Input(name=ol_infrastructure_repo.name)],
+                build_parameters={"CONTEXT": context},
+            ),
+            ensure_ecr_task("mitodl/apisix-waf"),
+            PutStep(
+                put=ecr_image_resource.name,
+                inputs="detect",
+                params={
+                    "image": "image/image.tar",
+                    "additional_tags": f"{ol_infrastructure_repo.name}/.git/short_ref",
+                },
+            ),
+        ],
+    )
+
+
+apisix_waf_pipeline = Pipeline(
+    resources=[ol_infrastructure_repo, ecr_image_resource],
+    jobs=[build_job()],
+)
+
+if __name__ == "__main__":
+    with open("definition.json", "w") as definition:  # noqa: PTH123
+        definition.write(apisix_waf_pipeline.model_dump_json(indent=2))
+    sys.stdout.write(apisix_waf_pipeline.model_dump_json(indent=2))
+    sys.stdout.write(
+        "\nfly -t pr-inf set-pipeline -p apisix-waf-docker -c definition.json\n"
+    )

--- a/src/ol_concourse/pipelines/container_images/meta.py
+++ b/src/ol_concourse/pipelines/container_images/meta.py
@@ -74,6 +74,10 @@ PIPELINE_CONFIGS: list[tuple[str, str]] = [
         "ocw-course-publisher-image",
         "src/ol_concourse/pipelines/container_images/ocw_course_publisher.py",
     ),
+    (
+        "apisix-waf-docker",
+        "src/ol_concourse/pipelines/container_images/apisix_waf.py",
+    ),
 ]
 
 

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.applications.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.applications.CI.yaml
@@ -43,6 +43,16 @@ config:
   - tika-ci.ol.mit.edu
   - video-ci.odl.mit.edu
   - xpro-ci.odl.mit.edu
+  # Coraza WAF spike (ol-infrastructure#5101) -- pre-production only,
+  # low-risk long-horizon soak test before considering it for production.
+  # wasm.enabled loads the coraza-filter plugin globally but nothing
+  # routes through it yet, so this has no effect on live traffic.
+  eks:apisix_custom_image_repository: mitodl/apisix-waf
+  eks:apisix_custom_image_tag: latest
+  eks:apisix_wasm_plugins:
+  - name: coraza-filter
+    priority: 7999
+    file: /usr/local/apisix/coraza-filter.wasm
   eks:developer_role_policy_name: AmazonEKSClusterAdminPolicy
   eks:developer_role_kubernetes_groups:
   - admin

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.applications.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.applications.QA.yaml
@@ -41,6 +41,16 @@ config:
   - tika-qa.ol.mit.edu
   - video-rc.odl.mit.edu
   - xpro-rc.odl.mit.edu
+  # Coraza WAF spike (ol-infrastructure#5101) -- pre-production only,
+  # low-risk long-horizon soak test before considering it for production.
+  # wasm.enabled loads the coraza-filter plugin globally but nothing
+  # routes through it yet, so this has no effect on live traffic.
+  eks:apisix_custom_image_repository: mitodl/apisix-waf
+  eks:apisix_custom_image_tag: latest
+  eks:apisix_wasm_plugins:
+  - name: coraza-filter
+    priority: 7999
+    file: /usr/local/apisix/coraza-filter.wasm
   eks:developer_role_policy_name: AmazonEKSClusterAdminPolicy
   eks:developer_role_kubernetes_groups:
   - admin

--- a/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
@@ -15,6 +15,7 @@ from pulumi import Config, InvokeOptions, Output, ResourceOptions
 from bridge.lib.magic_numbers import AWS_LOAD_BALANCER_NAME_MAX_LENGTH
 from ol_infrastructure.lib.aws.eks_helper import (
     cached_image_uri,
+    ecr_image_uri,
 )
 from ol_infrastructure.lib.ol_types import AWSBase
 from ol_infrastructure.lib.pulumi_helper import StackInfo
@@ -211,6 +212,18 @@ def setup_apisix(
     """
     apisix_domains = eks_config.get_object("apisix_domains") or []
 
+    # Opt-in, per-cluster: point at a custom-built APISIX image (e.g. the
+    # apisix-waf spike image at dockerfiles/apisix-waf/, published by
+    # src/ol_concourse/pipelines/container_images/apisix_waf.py) instead of
+    # the stock apache/apisix image, and/or register wasm plugins against it.
+    # Defaults to today's behavior (stock image, no wasm) on every cluster
+    # unless a stack explicitly sets these.
+    apisix_custom_image_repository = eks_config.get("apisix_custom_image_repository")
+    apisix_custom_image_tag = eks_config.get("apisix_custom_image_tag")
+    # e.g. [{"name": "coraza-filter", "priority": 7999,
+    #        "file": "/usr/local/apisix/coraza-filter.wasm"}]
+    apisix_wasm_plugins = eks_config.get_object("apisix_wasm_plugins") or []
+
     session_cookie_name = f"{stack_info.env_suffix}_gateway_session".removeprefix(
         "production"
     ).strip("_")
@@ -309,9 +322,24 @@ def setup_apisix(
             values={
                 # --- Global/Image Configuration ---
                 "image": {
-                    "repository": cached_image_uri("apache/apisix"),
+                    "repository": (
+                        ecr_image_uri(apisix_custom_image_repository)
+                        if apisix_custom_image_repository
+                        else cached_image_uri("apache/apisix")
+                    ),
+                    **(
+                        {"tag": apisix_custom_image_tag}
+                        if apisix_custom_image_tag
+                        else {}
+                    ),
                     "pullPolicy": "IfNotPresent",
                 },
+                # --- Wasm plugins (opt-in, see apisix_wasm_plugins above) ---
+                **(
+                    {"wasm": {"enabled": True, "plugins": apisix_wasm_plugins}}
+                    if apisix_wasm_plugins
+                    else {}
+                ),
                 # --- Autoscaling ---
                 "autoscaling": {
                     "enabled": True,

--- a/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
@@ -223,6 +223,21 @@ def setup_apisix(
     # e.g. [{"name": "coraza-filter", "priority": 7999,
     #        "file": "/usr/local/apisix/coraza-filter.wasm"}]
     apisix_wasm_plugins = eks_config.get_object("apisix_wasm_plugins") or []
+    if apisix_custom_image_repository and not apisix_custom_image_tag:
+        msg = (
+            "apisix_custom_image_tag must be set when "
+            "apisix_custom_image_repository is set -- the custom image build "
+            "only publishes 'latest' and git-short-ref tags, not the stock "
+            "chart's default appVersion tag, so an untagged pull would fail."
+        )
+        raise ValueError(msg)
+    if apisix_wasm_plugins and not apisix_custom_image_repository:
+        msg = (
+            "apisix_wasm_plugins requires apisix_custom_image_repository -- "
+            "the stock apache/apisix image does not contain any wasm plugin "
+            "binaries, so APISIX would fail to load the configured plugin file."
+        )
+        raise ValueError(msg)
 
     session_cookie_name = f"{stack_info.env_suffix}_gateway_session".removeprefix(
         "production"

--- a/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
@@ -231,6 +231,14 @@ def setup_apisix(
             "chart's default appVersion tag, so an untagged pull would fail."
         )
         raise ValueError(msg)
+    if apisix_custom_image_tag and not apisix_custom_image_repository:
+        msg = (
+            "apisix_custom_image_repository must be set when "
+            "apisix_custom_image_tag is set -- otherwise the tag is silently "
+            "applied to the stock apache/apisix image instead of the intended "
+            "custom image."
+        )
+        raise ValueError(msg)
     if apisix_wasm_plugins and not apisix_custom_image_repository:
         msg = (
             "apisix_wasm_plugins requires apisix_custom_image_repository -- "

--- a/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
@@ -332,7 +332,12 @@ def setup_apisix(
                         if apisix_custom_image_tag
                         else {}
                     ),
-                    "pullPolicy": "IfNotPresent",
+                    # A custom image is expected to track a moving tag (e.g.
+                    # "latest"), so always re-check the registry; the stock
+                    # image is already digest-cached via cached_image_uri.
+                    "pullPolicy": (
+                        "Always" if apisix_custom_image_repository else "IfNotPresent"
+                    ),
                 },
                 # --- Wasm plugins (opt-in, see apisix_wasm_plugins above) ---
                 **(

--- a/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
@@ -348,8 +348,10 @@ def setup_apisix(
                         else {}
                     ),
                     # A custom image is expected to track a moving tag (e.g.
-                    # "latest"), so always re-check the registry; the stock
-                    # image is already digest-cached via cached_image_uri.
+                    # "latest"), so always re-check the registry. The stock
+                    # image path is unchanged from prior behavior -- it isn't
+                    # digest-pinned either, cached_image_uri only rewrites the
+                    # repository to our ECR pull-through cache, not a digest.
                     "pullPolicy": (
                         "Always" if apisix_custom_image_repository else "IfNotPresent"
                     ),


### PR DESCRIPTION
### What are the relevant tickets?
N/A. Follow-up spike from the investigation on #5096/#5099 (bot/scanner noise mitigation at the APISIX layer).

### Description (What does it do?)
Spike, not a full rollout: builds a custom APISIX image bundling the Coraza WAF proxy-wasm filter, registers its build pipeline, and opts pre-production `applications` clusters into a low-risk long-horizon soak test before considering it for production.

**Why Coraza over other options evaluated:**
- `chaitin-waf` is already in our loaded APISIX plugin list, but it isn't self-contained — it proxies every request to a separate self-hosted Chaitin SafeLine WAF detection-engine service (APISIX >=3.5.0, SafeLine >=5.6.0) that would need to be deployed and operated as new infrastructure.
- Coraza runs in-process as a proxy-wasm filter — no separate service, no network hop per request.
- Confirmed against the actual upstream build script (`api7/apisix-build-tools`'s `build-apisix-base.sh`) that `wasm-nginx-module` is compiled into every standard `apisix-base` build unconditionally (`--add-module=../wasm-nginx-module-...`, not an opt-in variant) — so the wasm/proxy-wasm runtime our stock `apache/apisix` image already ships is sufficient; no custom OpenResty compile needed.
- The only gap is getting the compiled `coraza-proxy-wasm.wasm` binary into the image. Confirmed via the `coraza-proxy-wasm` project's own README that OWASP Core Rule Set "comes embedded in the extension" at compile time by the upstream project — no separate ruleset files to deliver or mount.

**Changes:**
- `dockerfiles/apisix-waf/Dockerfile`: two-stage build — `COPY --from=ghcr.io/corazawaf/coraza-proxy-wasm:0.6.0 /plugin.wasm` onto `apache/apisix:3.17.0-ubuntu` (tracks `APISIX_CHART_VERSION`'s default `appVersion`).
- `src/ol_concourse/pipelines/container_images/apisix_waf.py`: build-and-push-to-ECR pipeline, following the existing `ol_python_base.py`/`kubewatch` pattern (`container_build_task` + `ensure_ecr_task` + `PutStep`). Published as `mitodl/apisix-waf:latest` (+ git-short-ref secondary tag), ECR only (not Docker Hub — internal security tooling, not meant for public distribution). Deliberately **not** chained into a `pulumi_jobs_chain` — image builds here never trigger a deploy on their own.
- `src/ol_concourse/pipelines/container_images/meta.py`: registers `apisix-waf-docker` in `PIPELINE_CONFIGS` so the meta-pipeline auto-creates/updates it on merge, same as every other image-build pipeline.
- `src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py`: new opt-in, per-cluster Pulumi config (`apisix_custom_image_repository`, `apisix_custom_image_tag`, `apisix_wasm_plugins`) that only diverges from today's behavior when a stack explicitly sets it, following the existing `eks_config.get(...) or <default>` pattern already used throughout this file for other per-cluster tunables (`apisix_min_replicas`, `apisix_memory`, etc.). `pullPolicy` switches to `Always` when a custom image is configured (since `:latest` needs re-checking on pod restart); the stock image path is unaffected.
- `Pulumi.applications.CI.yaml` / `Pulumi.applications.QA.yaml`: opt in with the three new config keys. `applications.Production` is deliberately **not** touched.
- `dockerfiles/README.md`: documents the new image per the directory's existing convention.

**Why this is low-risk despite being "live" on two clusters**: `wasm.enabled: true` loads the `coraza-filter` plugin globally, but no `ApisixRoute` or shared-plugin-config references it by name yet, so it's inert with respect to live traffic. What this soak-tests is narrower and specific: does APISIX start up and run stably over time on the custom image with the wasm runtime active. That's the operational confidence needed before attaching the plugin to any real route.

### Screenshots (if appropriate):
N/A - infrastructure/backend only.

### How can this be tested?
- `pulumi preview` against `applications.QA` and `applications.CI`, both configured: identical isolated diff on each (`image.repository`/`image.tag`/`image.pullPolicy` + new `wasm` block), 1 resource updated, 167 unchanged.
- `pulumi preview` against `applications.Production`: zero apisix-related diff (only the unrelated, already-known pending Traefik NLB fix from #5099 shows up).
- Dockerfile passes the repo's pre-commit Dockerfile-linting hook; all changed Python/YAML files pass ruff, mypy, and yamllint.

**Not done in this PR (deliberately, this is a spike, not a full rollout):**
- The Concourse pipeline is registered but hasn't been run yet on merge to actually confirm — first real build happens on merge via the meta-pipeline.
- No route has `coraza-filter` attached — it isn't wired into the shared `OLApisixSharedPluginsConfig` any app depends on, and won't be until the soak test on CI/QA shows it's stable.
- Production is not opted in.

### Additional Context
Suggested next step after this merges and the soak test has run for a while with no stability issues: attach `coraza-filter` to a single low-traffic test route on one of the opted-in clusters (directives: `Include @demo-conf`, `Include @crs-setup-conf`, `SecRuleEngine On`, `Include @owasp_crs/*.conf`) to confirm it actually blocks known scanner traffic patterns (`/wls-wsat/`, `/seeyon/htmlofficeservlet`, etc.) before considering it for the shared plugin config any real app traffic depends on.