### PR TITLE
feat(local-dev): bound Docker/k3d disk usage with retention instead of reactive cleanup

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -2,13 +2,16 @@
 # Run: tilt up
 # Docs: local-dev/README.md
 
-# Prune Tilt-built images/containers aggressively — the app images are
-# multi-GB, so stale builds eat disk fast.
+# Tilt's own pruner, kept as a backstop only — disk-janitor (below) is
+# authoritative for tilt-built images. keep_recent matches the janitor's
+# default keep_tags so the two policies agree on retention depth; a lower
+# value here would silently cap the janitor's knob (Tilt prunes the tag from
+# the daemon, and the janitor then drops its registry copy).
 docker_prune_settings(
     disable=False,
-    max_age_mins=60,      # anything older than 1h goes (local daemon only — see below)
+    max_age_mins=720,     # 12h — the janitor handles day-to-day retention
     num_builds=5,         # also prune every 5 image builds
-    keep_recent=2,        # always keep the 2 most recent tags per image
+    keep_recent=3,        # keep in sync with disk_keep_tags default
 )
 
 # ---------------------------------------------------------------------------

--- a/Tiltfile
+++ b/Tiltfile
@@ -2,18 +2,6 @@
 # Run: tilt up
 # Docs: local-dev/README.md
 
-# Tilt's own pruner, kept as a backstop only — disk-janitor (below) is
-# authoritative for tilt-built images. keep_recent matches the janitor's
-# default keep_tags so the two policies agree on retention depth; a lower
-# value here would silently cap the janitor's knob (Tilt prunes the tag from
-# the daemon, and the janitor then drops its registry copy).
-docker_prune_settings(
-    disable=False,
-    max_age_mins=720,     # 12h — the janitor handles day-to-day retention
-    num_builds=5,         # also prune every 5 image builds
-    keep_recent=3,        # keep in sync with disk_keep_tags default
-)
-
 # ---------------------------------------------------------------------------
 # Developer configuration
 # ---------------------------------------------------------------------------
@@ -53,24 +41,36 @@ workspace_root = os.environ.get("MITOL_WORKSPACE_ROOT", config.main_dir + "/..")
 # ---------------------------------------------------------------------------
 # Disk management
 #
-# docker_prune_settings above only covers the local Docker daemon and has
-# silent failure modes; it can never reach the k3d registry or the k3s nodes'
-# containerd stores, which otherwise grow unbounded until kubelet taints the
-# nodes with disk-pressure. Three complementary mechanisms keep the footprint
-# bounded (details in local-dev/scripts/disk-janitor.sh and the "Disk
-# Management" section of local-dev/README.md):
-#   - disk-janitor (below): retention policy for tilt-built image tags
-#     (local daemon + registry) and a build-cache size cap.
+# Every image store bounds itself with retention config owned by the
+# component that enforces it (details in the "Disk Management" section of
+# local-dev/README.md):
+#   - disk-janitor (below): newest-N retention for tilt-built image tags in
+#     the local Docker daemon, plus a build-cache size cap.
+#   - zot registry: enforces its own retention + GC declaratively
+#     (local-dev/cluster/zot-config.json).
 #   - kubelet image GC: node containerd stores, thresholds in
 #     local-dev/cluster/k3d-config.yaml.
 #   - prune-docker (below): manual break-glass full cleanup.
 # ---------------------------------------------------------------------------
+
+# Tilt's own pruner, kept as a backstop only — disk-janitor (below) is
+# authoritative for tilt-built images in the local daemon. keep_recent is
+# derived from the same knob as the janitor so the two policies on that store
+# can't disagree (a lower keep_recent would silently cap disk_keep_tags).
+disk_keep_tags = int(cfg.get("disk_keep_tags") or os.environ.get("LOCAL_DEV_DISK_KEEP_TAGS", "") or "3")
+docker_prune_settings(
+    disable=False,
+    max_age_mins=720,     # 12h — the janitor handles day-to-day retention
+    num_builds=5,         # also prune every 5 image builds
+    keep_recent=disk_keep_tags,
+)
+
 local_resource(
     "disk-janitor",
     serve_cmd="./local-dev/scripts/disk-janitor.sh",
     deps=["./local-dev/scripts/disk-janitor.sh"],
     serve_env={
-        "JANITOR_KEEP_TAGS": cfg.get("disk_keep_tags") or os.environ.get("LOCAL_DEV_DISK_KEEP_TAGS", ""),
+        "JANITOR_KEEP_TAGS": str(disk_keep_tags),
         "JANITOR_BUILDCACHE_MAX_GB": cfg.get("disk_buildcache_max_gb") or os.environ.get("LOCAL_DEV_BUILDCACHE_MAX_GB", ""),
     },
     labels=["infra"],

--- a/Tiltfile
+++ b/Tiltfile
@@ -6,7 +6,7 @@
 # multi-GB, so stale builds eat disk fast.
 docker_prune_settings(
     disable=False,
-    max_age_mins=720,     # anything older than 12h goes
+    max_age_mins=60,      # anything older than 1h goes (local daemon only — see below)
     num_builds=5,         # also prune every 5 image builds
     keep_recent=2,        # always keep the 2 most recent tags per image
 )
@@ -21,6 +21,8 @@ config.define_bool("per_app_databases", usage="Deploy isolated DB/Valkey per app
 config.define_string("openedx_mode", usage="qa (default) or local (Tutor)")
 config.define_string_list("prebuilt_tags", usage="Prebuilt image tag overrides per app, e.g. mit-learn=0.62.0 learn-ai=0.28.3")
 config.define_string("root_domain", usage="Root DNS domain for all local-dev services (default: mit.dev). Overrides LOCAL_DEV_ROOT_DOMAIN env var.")
+config.define_string("disk_keep_tags", usage="Newest tilt-built image tags kept per repo by the disk janitor (default: 3). Overrides LOCAL_DEV_DISK_KEEP_TAGS env var.")
+config.define_string("disk_buildcache_max_gb", usage="Docker build-cache size cap in GB (default: 10% of total disk; 0 disables). Overrides LOCAL_DEV_BUILDCACHE_MAX_GB env var.")
 cfg = config.parse()
 
 enabled_apps = cfg.get("enabled_apps", ["mit-learn", "learn-ai", "mitxonline", "odl-video-service"])
@@ -44,6 +46,43 @@ prebuilt_tags = {
 # Workspace root: directory that contains ol-infrastructure and sibling app repos.
 # Override with MITOL_WORKSPACE_ROOT environment variable.
 workspace_root = os.environ.get("MITOL_WORKSPACE_ROOT", config.main_dir + "/..")
+
+# ---------------------------------------------------------------------------
+# Disk management
+#
+# docker_prune_settings above only covers the local Docker daemon and has
+# silent failure modes; it can never reach the k3d registry or the k3s nodes'
+# containerd stores, which otherwise grow unbounded until kubelet taints the
+# nodes with disk-pressure. Three complementary mechanisms keep the footprint
+# bounded (details in local-dev/scripts/disk-janitor.sh and the "Disk
+# Management" section of local-dev/README.md):
+#   - disk-janitor (below): retention policy for tilt-built image tags
+#     (local daemon + registry) and a build-cache size cap.
+#   - kubelet image GC: node containerd stores, thresholds in
+#     local-dev/cluster/k3d-config.yaml.
+#   - prune-docker (below): manual break-glass full cleanup.
+# ---------------------------------------------------------------------------
+local_resource(
+    "disk-janitor",
+    serve_cmd="./local-dev/scripts/disk-janitor.sh",
+    deps=["./local-dev/scripts/disk-janitor.sh"],
+    serve_env={
+        "JANITOR_KEEP_TAGS": cfg.get("disk_keep_tags") or os.environ.get("LOCAL_DEV_DISK_KEEP_TAGS", ""),
+        "JANITOR_BUILDCACHE_MAX_GB": cfg.get("disk_buildcache_max_gb") or os.environ.get("LOCAL_DEV_BUILDCACHE_MAX_GB", ""),
+    },
+    labels=["infra"],
+)
+
+# Break-glass full cleanup (Tilt UI button, or `tilt trigger prune-docker`).
+# The janitor should make this unnecessary; expect image re-pulls and full
+# rebuilds after running it.
+local_resource(
+    "prune-docker",
+    cmd="./local-dev/scripts/prune-docker.sh",
+    labels=["infra"],
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    auto_init=False,
+)
 
 # ---------------------------------------------------------------------------
 # Application registry

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -17,8 +17,9 @@ A fully local, Kubernetes-based development environment for the MIT Learn applic
 9. [Configuration Reference](#configuration-reference)
 10. [Adding a New App](#adding-a-new-app)
 11. [Modifying Shared Infrastructure](#modifying-shared-infrastructure)
-12. [Teardown](#teardown)
-13. [Troubleshooting](#troubleshooting)
+12. [Disk Management](#disk-management)
+13. [Teardown](#teardown)
+14. [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -541,6 +542,47 @@ Tilt also runs `pulumi up` automatically when infra files change. You can also t
 **Add a new shared service:** Add it to `infra/core/__main__.py`. Use the existing Qdrant or Valkey blocks as a reference.
 
 **Modify the Keycloak realm or add a new OIDC client:** Edit `infra/modules/keycloak.py`. On `pulumi up`, pulumi-keycloak will diff the realm state and apply only what changed.
+
+---
+
+## Disk Management
+
+Every Tilt image build produces a multi-GB image in **three places**: the
+local Docker daemon, the k3d registry (`k3d-registry.localhost:5001`), and —
+once pulled — each k3s node's internal containerd store. Tilt's built-in
+pruner (`docker_prune_settings`) only ever touches the first, has silent
+failure modes, and by design cannot reach the registry
+([tilt-dev/tilt#2102](https://github.com/tilt-dev/tilt/issues/2102)) or the
+node stores
+([tilt-dev/tilt#4228](https://github.com/tilt-dev/tilt/issues/4228)). Left
+alone, these stores grow by tens of GB per rebuild until kubelet taints every
+node with `disk-pressure` and no pod can schedule.
+
+Three mechanisms keep the footprint bounded, with no per-developer setup:
+
+| Mechanism | Covers | Where |
+|---|---|---|
+| `disk-janitor` (automatic, runs with every `tilt up`) | Old tilt-built image tags in the local daemon and the registry; build-cache size cap | `local-dev/scripts/disk-janitor.sh`, wired as a `serve_cmd` resource in the root Tiltfile |
+| kubelet image GC | Node containerd stores | Thresholds in `local-dev/cluster/k3d-config.yaml` (applies on cluster re-create) |
+| `prune-docker` (manual, break-glass) | Local daemon + registry, destructively (node stores only with `--sweep-nodes` — read the script header first; it orphans running containers) | Tilt UI button / `tilt trigger prune-docker`, or run `local-dev/scripts/prune-docker.sh` directly |
+
+The janitor enforces a **retention policy** — keep the newest N tags per
+image plus anything a pod currently references — so it is safe to run at any
+moment, unlike a wipe. Knobs, via `tilt_config.json` (or env var fallback):
+
+- `disk_keep_tags` / `LOCAL_DEV_DISK_KEEP_TAGS` — tags kept per image
+  (default 3). Old tags are nearly pure waste: pods only reference the
+  current tag, and rebuild speed comes from the build cache, not old tags.
+- `disk_buildcache_max_gb` / `LOCAL_DEV_BUILDCACHE_MAX_GB` — build-cache cap
+  in GB (default: 10% of total disk). **This is the one knob whose effect is
+  not scoped to local-dev**: BuildKit keeps a single daemon-wide cache pool,
+  so eviction can slow rebuilds of unrelated projects on your machine (speed
+  only, never correctness). Set to `0` to opt out and manage the pool
+  yourself (e.g. `builder.gc` in your Docker engine config).
+
+If images ever pile up again despite the janitor, `tilt docker-prune --debug`
+prints Tilt's own per-image skip reasons and is the fastest way to see why
+something isn't being reclaimed.
 
 ---
 

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -568,7 +568,7 @@ enforces it, with no per-developer setup:
 |---|---|---|
 | `disk-janitor` (automatic, runs with every `tilt up`) | Old tilt-built image tags in the local daemon; build-cache size cap | `local-dev/scripts/disk-janitor.sh`, wired as a `serve_cmd` resource in the root Tiltfile |
 | zot registry retention + GC | The k3d registry — zot keeps the 10 most recently pushed tags per repo and garbage-collects the rest itself | `local-dev/cluster/zot-config.json` (the registry image is [zot](https://zotregistry.dev), not registry:2; created by `setup.sh`) |
-| kubelet image GC | Node containerd stores | Thresholds in `local-dev/cluster/k3d-config.yaml` (applies on cluster re-create) |
+| kubelet image GC | Node containerd stores | Thresholds in `local-dev/cluster/k3d-config.yaml` (applies at cluster creation; existing clusters keep the old 85/80 until you run `local-dev/scripts/migrate-kubelet-gc-thresholds.sh`) |
 | `prune-docker` (manual, break-glass) | Local daemon + registry, destructively (node stores only with `--sweep-nodes` — read the script header first; it orphans running containers) | Tilt UI button / `tilt trigger prune-docker`, or run `local-dev/scripts/prune-docker.sh` directly |
 
 **Existing setups:** a registry container created before the zot swap
@@ -600,7 +600,9 @@ knobs, via `tilt_config.json` (or env var fallback):
 
 If images ever pile up again despite the janitor, `tilt docker-prune --debug`
 prints Tilt's own per-image skip reasons and is the fastest way to see why
-something isn't being reclaimed.
+something isn't being reclaimed. To check whether zot is doing its part,
+`docker logs k3d-registry.localhost` shows its retention decisions
+(`"module":"retention"` lines, logged at info level).
 
 ---
 

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -561,17 +561,32 @@ can schedule.
     node-store cleanup is
     [tilt-dev/tilt#4228](https://github.com/tilt-dev/tilt/issues/4228).
 
-Three mechanisms keep the footprint bounded, with no per-developer setup:
+Each store is bounded by retention config owned by the component that
+enforces it, with no per-developer setup:
 
 | Mechanism | Covers | Where |
 |---|---|---|
-| `disk-janitor` (automatic, runs with every `tilt up`) | Old tilt-built image tags in the local daemon and the registry; build-cache size cap | `local-dev/scripts/disk-janitor.sh`, wired as a `serve_cmd` resource in the root Tiltfile |
+| `disk-janitor` (automatic, runs with every `tilt up`) | Old tilt-built image tags in the local daemon; build-cache size cap | `local-dev/scripts/disk-janitor.sh`, wired as a `serve_cmd` resource in the root Tiltfile |
+| zot registry retention + GC | The k3d registry — zot keeps the 10 most recently pushed tags per repo and garbage-collects the rest itself | `local-dev/cluster/zot-config.json` (the registry image is [zot](https://zotregistry.dev), not registry:2; created by `setup.sh`) |
 | kubelet image GC | Node containerd stores | Thresholds in `local-dev/cluster/k3d-config.yaml` (applies on cluster re-create) |
 | `prune-docker` (manual, break-glass) | Local daemon + registry, destructively (node stores only with `--sweep-nodes` — read the script header first; it orphans running containers) | Tilt UI button / `tilt trigger prune-docker`, or run `local-dev/scripts/prune-docker.sh` directly |
 
-The janitor enforces a **retention policy** — keep the newest N tags per
-image plus anything the cluster still references (pods or workload
-templates) — so it is safe to run at any moment, unlike a wipe. Knobs, via `tilt_config.json` (or env var fallback):
+**Existing setups:** a registry container created before the zot swap
+(2026-07) still runs `registry:2`, which has no retention and will grow
+unbounded — the janitor warns about this each cycle until you migrate:
+
+```bash
+k3d registry delete k3d-registry.localhost
+./local-dev/scripts/setup.sh   # recreates it as zot, reconnects the cluster network
+```
+
+Registry contents are a disposable cache — Tilt re-pushes whatever the
+current build needs on its next build, and running pods are unaffected
+(nodes cache their images).
+
+Retention (keep the newest N) is safe to apply at any moment — unlike a
+wipe, it can never delete an image something is about to need. Janitor
+knobs, via `tilt_config.json` (or env var fallback):
 
 - `disk_keep_tags` / `LOCAL_DEV_DISK_KEEP_TAGS` — tags kept per image
   (default 3). Old tags are nearly pure waste: pods only reference the

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -59,6 +59,7 @@ Install these tools before running setup:
 | Helm | ≥ 3.14 | `brew install helm` |
 | mkcert | ≥ 1.4 | `brew install mkcert` |
 | Pulumi CLI | ≥ 3.x | `brew install pulumi` |
+| bash | ≥ 4 | `brew install bash` (stock macOS ships 3.2; the seeding and prune scripts use `mapfile`) |
 | uv | ≥ 0.9.3 | `brew install uv` |
 
 > **Docker memory:** The cluster runs PostgreSQL, Valkey, APISIX, Keycloak, Qdrant, and up to four Django apps. Allocate at least 8 GB to Docker Desktop (Settings → Resources).
@@ -550,13 +551,15 @@ Tilt also runs `pulumi up` automatically when infra files change. You can also t
 Every Tilt image build produces a multi-GB image in **three places**: the
 local Docker daemon, the k3d registry (`k3d-registry.localhost:5001`), and —
 once pulled — each k3s node's internal containerd store. Tilt's built-in
-pruner (`docker_prune_settings`) only ever touches the first, has silent
-failure modes, and by design cannot reach the registry
-([tilt-dev/tilt#2102](https://github.com/tilt-dev/tilt/issues/2102)) or the
-node stores
-([tilt-dev/tilt#4228](https://github.com/tilt-dev/tilt/issues/4228)). Left
-alone, these stores grow by tens of GB per rebuild until kubelet taints every
-node with `disk-pressure` and no pod can schedule.
+pruner (`docker_prune_settings`) has silent failure modes and by design only
+reaches the first[^tilt-pruner]. Left alone, these stores grow by several GB
+per rebuild until kubelet taints every node with `disk-pressure` and no pod
+can schedule.
+
+[^tilt-pruner]: Registry cleanup is
+    [tilt-dev/tilt#2102](https://github.com/tilt-dev/tilt/issues/2102);
+    node-store cleanup is
+    [tilt-dev/tilt#4228](https://github.com/tilt-dev/tilt/issues/4228).
 
 Three mechanisms keep the footprint bounded, with no per-developer setup:
 
@@ -567,8 +570,8 @@ Three mechanisms keep the footprint bounded, with no per-developer setup:
 | `prune-docker` (manual, break-glass) | Local daemon + registry, destructively (node stores only with `--sweep-nodes` — read the script header first; it orphans running containers) | Tilt UI button / `tilt trigger prune-docker`, or run `local-dev/scripts/prune-docker.sh` directly |
 
 The janitor enforces a **retention policy** — keep the newest N tags per
-image plus anything a pod currently references — so it is safe to run at any
-moment, unlike a wipe. Knobs, via `tilt_config.json` (or env var fallback):
+image plus anything the cluster still references (pods or workload
+templates) — so it is safe to run at any moment, unlike a wipe. Knobs, via `tilt_config.json` (or env var fallback):
 
 - `disk_keep_tags` / `LOCAL_DEV_DISK_KEEP_TAGS` — tags kept per image
   (default 3). Old tags are nearly pure waste: pods only reference the

--- a/local-dev/apps/mit-learn/Tiltfile
+++ b/local-dev/apps/mit-learn/Tiltfile
@@ -24,6 +24,19 @@ if os.path.exists(os.path.join(MIT_LEARN_DIR, ".git")):
         # local-dev target = development (dev deps included) + a mitodl-owned
         # /src so live-update syncs can write into the container.
         target="local-dev",
+        # This is the granian/Django backend; it never reads the frontend
+        # workspace (no STATICFILES_DIRS/webpack refs) — that ships as the
+        # separate mit-learn-nextjs image. Keep frontends/ (incl. its .next
+        # build output), the yarn cache, and all node_modules out of the build
+        # context: ~1GB of dead weight off the image, and frontend edits stop
+        # triggering backend syncs/rebuilds. Scoped here (not in the shared
+        # repo-root .dockerignore) because the nextjs build uses the same
+        # context and needs frontends/ + .yarn/ via its own only=[...].
+        ignore=[
+            "frontends/",
+            ".yarn/",
+            "**/node_modules",
+        ],
         # Live update: sync source changes into the container; granian runs
         # with --reload (see deployment.yaml) and restarts workers on change.
         live_update=[

--- a/local-dev/cluster/k3d-config.yaml
+++ b/local-dev/cluster/k3d-config.yaml
@@ -42,6 +42,22 @@ options:
     - arg: --disable=traefik
       nodeFilters:
       - server:*
+    # Each node's containerd image store caches every image it ever pulls and
+    # nothing else cleans it up (Tilt can't reach it; see disk-janitor.sh).
+    # kubelet's own image GC does, but its default thresholds (85%/80%) are
+    # percentages of the node filesystem — which under OrbStack/Docker Desktop
+    # is the entire host disk — so by default it only acts at nearly the same
+    # fullness that triggers the disk-pressure eviction taint. Lower the
+    # thresholds so node image caches are reclaimed long before that.
+    # Applies on cluster (re)create: teardown.sh + setup.sh.
+    - arg: --kubelet-arg=image-gc-high-threshold=75
+      nodeFilters:
+      - server:*
+      - agent:*
+    - arg: --kubelet-arg=image-gc-low-threshold=70
+      nodeFilters:
+      - server:*
+      - agent:*
 
 kubeAPI:
   hostIP: "0.0.0.0"

--- a/local-dev/cluster/k3d-config.yaml
+++ b/local-dev/cluster/k3d-config.yaml
@@ -14,11 +14,16 @@ agents: 2
 image: docker.io/rancher/k3s:v1.31.4-k3s1
 
 # Local image registry — images built by Tilt are pushed here.
+# The registry container itself is created by setup.sh (`k3d registry create
+# --image <zot>`) rather than by this file, because its config file must be
+# bind-mounted from the repo checkout and this YAML cannot express that host
+# path portably. The registry is zot rather than registry:2: zot enforces
+# image retention (keep the N most recently pushed tags) and garbage
+# collection as its own declarative config — local-dev/cluster/zot-config.json
+# — so no external cleanup process has to reach into its storage.
 registries:
-  create:
-    name: k3d-registry.localhost
-    host: "0.0.0.0"
-    hostPort: "5001"
+  use:
+  - k3d-registry.localhost:5001
   config: |
     mirrors:
       "k3d-registry.localhost:5001":

--- a/local-dev/cluster/k3d-config.yaml
+++ b/local-dev/cluster/k3d-config.yaml
@@ -45,10 +45,11 @@ options:
     # Each node's containerd image store caches every image it ever pulls and
     # nothing else cleans it up (Tilt can't reach it; see disk-janitor.sh).
     # kubelet's own image GC does, but its default thresholds (85%/80%) are
-    # percentages of the node filesystem — which under OrbStack/Docker Desktop
-    # is the entire host disk — so by default it only acts at nearly the same
-    # fullness that triggers the disk-pressure eviction taint. Lower the
-    # thresholds so node image caches are reclaimed long before that.
+    # percentages of the node filesystem — the Docker VM's data disk, shared
+    # by all nodes, under OrbStack/Docker Desktop — while k3s sets the
+    # disk-pressure eviction taint at 95% used (nodefs.available<5%). That
+    # leaves only ~10% of the disk between "GC starts" and "everything
+    # stops scheduling". Starting GC at 75% doubles that band to ~20%.
     # Applies on cluster (re)create: teardown.sh + setup.sh.
     - arg: --kubelet-arg=image-gc-high-threshold=75
       nodeFilters:

--- a/local-dev/cluster/zot-config.json
+++ b/local-dev/cluster/zot-config.json
@@ -1,0 +1,32 @@
+{
+  "distSpecVersion": "1.1.1",
+  "storage": {
+    "rootDirectory": "/var/lib/zot",
+    "gc": true,
+    "gcDelay": "1h",
+    "gcInterval": "1h",
+    "retention": {
+      "delay": "24h",
+      "policies": [
+        {
+          "repositories": ["**"],
+          "deleteReferrers": true,
+          "deleteUntagged": true,
+          "keepTags": [
+            {
+              "mostRecentlyPushedCount": 10
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "http": {
+    "address": "0.0.0.0",
+    "port": "5000",
+    "compat": ["docker2s2"]
+  },
+  "log": {
+    "level": "warn"
+  }
+}

--- a/local-dev/cluster/zot-config.json
+++ b/local-dev/cluster/zot-config.json
@@ -27,6 +27,6 @@
     "compat": ["docker2s2"]
   },
   "log": {
-    "level": "warn"
+    "level": "info"
   }
 }

--- a/local-dev/scripts/disk-janitor.sh
+++ b/local-dev/scripts/disk-janitor.sh
@@ -18,8 +18,8 @@
 #   1. Local Docker daemon: keep the newest N tilt-built tags per repo
 #      (localhost:5001/*); remove older ones. Never touches other images.
 #   2. k3d registry: delete tags that are neither kept locally nor referenced
-#      by any pod, then garbage-collect blobs (skipped while a push is in
-#      flight).
+#      by any pod, then garbage-collect blobs offline (the registry is
+#      briefly stopped; deferred while a push is in flight).
 #   3. Docker build cache: prune down to a size cap, least-recently-used
 #      first. NOTE: the BuildKit cache is one daemon-wide pool shared with
 #      everything else you build on this machine, so this is the one step
@@ -66,7 +66,9 @@ container_running() {
 
 # ---------------------------------------------------------------------------
 # 1. Local daemon: keep newest KEEP_TAGS tags per localhost:5001/* repo.
-# CreatedAt ("2026-07-23 15:17:42 +0000 UTC") sorts correctly lexically.
+# CreatedAt is formatted client-side in the local zone, where lexical sort
+# breaks during the DST fall-back hour — TZ=UTC pins it to a sortable format
+# ("2026-07-23 15:17:42 +0000 UTC").
 # `docker rmi` without --force fails (tolerated) on anything still in use.
 # ---------------------------------------------------------------------------
 prune_local_tags() {
@@ -79,7 +81,7 @@ prune_local_tags() {
             log "  kept $ref (in use or remove failed)"
         fi
     done < <(
-        docker images --filter reference='localhost:5001/*' \
+        TZ=UTC docker images --filter reference='localhost:5001/*' \
             --format '{{.CreatedAt}}\t{{.Repository}}\t{{.Tag}}' 2>/dev/null \
             | sort -r \
             | awk -F'\t' -v keep="$KEEP_TAGS" '{ if (++seen[$2] > keep) print $2 ":" $3 }'
@@ -126,76 +128,126 @@ strip_registry_prefix() {
 # 2. Registry: a tag is kept iff it survives locally (Tilt may redeploy it)
 # or a pod references it (kubelet may re-pull it). Everything else goes.
 # Tag dirs are removed in place; blobs are freed by the registry's own
-# garbage collector, which we only run when no upload is in flight.
-# If kubectl fails we skip the whole phase — fail safe, prune nothing.
+# garbage collector (offline — see registry_gc).
+# Delete candidates are snapshotted BEFORE the keep-set is computed, so a tag
+# Tilt pushes mid-phase can never be a candidate (it would race the keep-set
+# otherwise). If kubectl or docker fails we skip the whole phase — fail safe,
+# prune nothing.
+# Registry dirs are one level deep today: Tilt flattens image names
+# (mitodl/mit-learn-app -> mitodl_mit-learn-app) when it prepends the
+# registry. If a build ever pushes a nested repo (foo/bar), this ls walk
+# silently misses it — failure direction is unbounded growth for that repo,
+# never a wrong deletion.
 # ---------------------------------------------------------------------------
+REGISTRY_GC_PENDING=0
+
 prune_registry() {
     container_running "$REGISTRY_CONTAINER" || return 0
+
+    local candidates
+    candidates="$(
+        while IFS= read -r repo; do
+            [[ -z "$repo" ]] && continue
+            while IFS= read -r tag; do
+                [[ -z "$tag" ]] && continue
+                echo "${repo}:${tag}"
+            done < <(docker exec "$REGISTRY_CONTAINER" \
+                        ls "${REGISTRY_DATA}/repositories/${repo}/_manifests/tags" 2>/dev/null)
+        done < <(docker exec "$REGISTRY_CONTAINER" \
+                    ls "${REGISTRY_DATA}/repositories" 2>/dev/null)
+    )"
+    [[ -z "$candidates" ]] && return 0
 
     local pod_refs
     if ! pod_refs="$(pod_image_refs)"; then
         log "registry: kubectl unavailable — skipping registry retention this cycle"
         return 0
     fi
+    local local_tags
+    if ! local_tags="$(docker images --filter reference='localhost:5001/*' \
+            --format '{{.Repository}}:{{.Tag}}' 2>/dev/null)"; then
+        log "registry: docker images failed — skipping registry retention this cycle"
+        return 0
+    fi
 
     local keep
     keep="$(
         {
-            docker images --filter reference='localhost:5001/*' \
-                --format '{{.Repository}}:{{.Tag}}' 2>/dev/null
+            echo "$local_tags"
             echo "$pod_refs"
         } | strip_registry_prefix | sort -u
     )"
 
-    local removed=0 repo tag
-    while IFS= read -r repo; do
-        [[ -z "$repo" ]] && continue
-        while IFS= read -r tag; do
-            [[ -z "$tag" ]] && continue
-            if ! grep -qx "${repo}:${tag}" <<<"$keep"; then
-                docker exec "$REGISTRY_CONTAINER" \
-                    rm -rf "${REGISTRY_DATA}/repositories/${repo}/_manifests/tags/${tag}"
+    local removed=0 candidate repo tag
+    while IFS= read -r candidate; do
+        [[ -z "$candidate" ]] && continue
+        if ! grep -qxF "$candidate" <<<"$keep"; then
+            repo="${candidate%%:*}"
+            tag="${candidate#*:}"
+            if docker exec "$REGISTRY_CONTAINER" \
+                rm -rf "${REGISTRY_DATA}/repositories/${repo}/_manifests/tags/${tag}"; then
                 removed=$((removed + 1))
             fi
-        done < <(docker exec "$REGISTRY_CONTAINER" \
-                    ls "${REGISTRY_DATA}/repositories/${repo}/_manifests/tags" 2>/dev/null)
-    done < <(docker exec "$REGISTRY_CONTAINER" \
-                ls "${REGISTRY_DATA}/repositories" 2>/dev/null)
+        fi
+    done <<<"$candidates"
 
     if (( removed > 0 )); then
         log "registry: removed $removed stale tag(s)"
-        registry_gc
+        REGISTRY_GC_PENDING=1
     fi
 }
 
+# Blob GC runs OFFLINE: stop the registry, collect in a throwaway container
+# sharing its volume, start it again. Online GC is unsafe by construction —
+# a concurrent push whose layers "already exist" writes nothing to _uploads
+# (only HEAD checks + a manifest PUT), so no guard can see it, and the
+# registry's in-memory blob-descriptor cache would answer those HEADs from
+# blobs GC just deleted, storing a manifest with missing blobs (the
+# 2026-07-23 incident). With the registry stopped, a racing push fails
+# loudly and Docker/Tilt retries; and each start begins with a cold cache,
+# so no restart choreography is needed. GC stays pending across cycles until
+# it succeeds (a deferral is otherwise lost if no later cycle removes tags).
 registry_gc() {
-    # An in-flight push writes under _uploads/; GC during a push can corrupt
-    # it, so defer to the next cycle if anything is there.
+    container_running "$REGISTRY_CONTAINER" || return 0
+
+    # A visibly in-flight upload means Tilt is mid-push; defer rather than
+    # fail its push. (Politeness only — stopping the registry is what makes
+    # GC safe. A stale interrupted upload can defer this repeatedly; the
+    # registry purges those after ~168h.)
     if docker exec "$REGISTRY_CONTAINER" \
         sh -c "find ${REGISTRY_DATA}/repositories -path '*/_uploads/*' -type f 2>/dev/null | head -1" \
         | grep -q .; then
-        log "registry: push in flight — deferring blob GC to next cycle"
+        log "registry: push in flight — deferring blob GC"
         return 0
     fi
     # --delete-untagged (registry >= 2.8) also drops the manifests our tag
     # deletion orphaned; without it blobs stay pinned and GC frees ~nothing.
-    if docker exec "$REGISTRY_CONTAINER" registry garbage-collect --help 2>&1 \
+    if ! docker exec "$REGISTRY_CONTAINER" registry garbage-collect --help 2>&1 \
         | grep -q -- --delete-untagged; then
-        if docker exec "$REGISTRY_CONTAINER" \
-            registry garbage-collect --delete-untagged /etc/docker/registry/config.yml \
-            >/dev/null 2>&1; then
-            # The running registry's in-memory blob-descriptor cache still
-            # believes GC'd blobs exist, so it would tell the next `docker
-            # push` "layer already exists" and silently produce a manifest
-            # with missing blobs (this exact failure corrupted the registry
-            # in the 2026-07-23 incident). Restart to drop the cache.
-            docker restart "$REGISTRY_CONTAINER" >/dev/null 2>&1
-            log "registry: blob GC complete (registry restarted to drop its blob cache)"
-        else
-            log "registry: blob GC failed (will retry next cycle)"
-        fi
-    else
         log "registry: 'registry garbage-collect --delete-untagged' unsupported — tags removed but blobs not freed"
+        REGISTRY_GC_PENDING=0
+        return 0
+    fi
+
+    local image rc=0
+    image="$(docker inspect --format '{{.Config.Image}}' "$REGISTRY_CONTAINER" 2>/dev/null)"
+    if [[ -z "$image" ]]; then
+        log "registry: cannot determine registry image — deferring blob GC"
+        return 0
+    fi
+    docker stop "$REGISTRY_CONTAINER" >/dev/null 2>&1
+    docker run --rm --volumes-from "$REGISTRY_CONTAINER" "$image" \
+        garbage-collect --delete-untagged /etc/docker/registry/config.yml \
+        >/dev/null 2>&1 || rc=$?
+    if ! docker start "$REGISTRY_CONTAINER" >/dev/null 2>&1; then
+        log "registry: FAILED TO RESTART ${REGISTRY_CONTAINER} after GC — start it manually (docker start ${REGISTRY_CONTAINER})"
+        return 0
+    fi
+    if (( rc == 0 )); then
+        REGISTRY_GC_PENDING=0
+        log "registry: offline blob GC complete"
+    else
+        log "registry: blob GC failed (will retry next cycle)"
     fi
 }
 
@@ -212,7 +264,9 @@ prune_build_cache() {
     fi
     [[ "$cap" == "0" ]] && return 0
 
-    # Flag was renamed --keep-storage -> --max-used-space in newer buildx.
+    # --max-used-space (buildx >= 0.18, needs BuildKit >= 0.17) is the newer
+    # total-size cap; older tooling spells it --keep-storage (since
+    # deprecated in favor of --reserved-space). Both accept "<N>gb".
     local flag="--keep-storage"
     docker builder prune --help 2>&1 | grep -q -- --max-used-space && flag="--max-used-space"
     docker builder prune -f "$flag" "${cap}gb" >/dev/null 2>&1 \
@@ -222,6 +276,7 @@ prune_build_cache() {
 run_cycle() {
     prune_local_tags
     prune_registry
+    (( REGISTRY_GC_PENDING )) && registry_gc
     prune_build_cache
 }
 

--- a/local-dev/scripts/disk-janitor.sh
+++ b/local-dev/scripts/disk-janitor.sh
@@ -87,16 +87,24 @@ prune_local_tags() {
     (( removed > 0 )) && log "local daemon: removed $removed old tilt tag(s)"
 }
 
-# Every image ref any pod (incl. init containers) currently points at.
-# Failed pods (Evicted etc.) are excluded: their containers never restart in
-# place — a replacement pod is created from the current template — so they
-# should not pin old tags. Pending pods DO count: kubelet still has to pull
-# their images.
+# Every image ref the cluster might still pull: live pods (incl. init
+# containers) PLUS workload templates. Templates are the durable source of
+# truth — during node-restart churn pods can transiently be Failed or absent
+# while their Deployment still specifies the tag, and a pods-only keep-set
+# deletes a tag the replacement pod then fails to pull. Failed pods are
+# excluded (their containers never restart in place; the owning template is
+# what matters and is covered); Pending pods count — kubelet still has to
+# pull for them.
 pod_image_refs() {
-    kubectl --context "$KUBE_CONTEXT" get pods -A \
-        --field-selector=status.phase!=Failed \
-        -o jsonpath='{range .items[*]}{range .spec.initContainers[*]}{.image}{"\n"}{end}{range .spec.containers[*]}{.image}{"\n"}{end}{end}' \
-        2>/dev/null
+    {
+        kubectl --context "$KUBE_CONTEXT" get pods -A \
+            --field-selector=status.phase!=Failed \
+            -o jsonpath='{range .items[*]}{range .spec.initContainers[*]}{.image}{"\n"}{end}{range .spec.containers[*]}{.image}{"\n"}{end}{end}' \
+            2>/dev/null || return 1
+        kubectl --context "$KUBE_CONTEXT" get deployments,statefulsets,daemonsets -A \
+            -o jsonpath='{range .items[*]}{range .spec.template.spec.initContainers[*]}{.image}{"\n"}{end}{range .spec.template.spec.containers[*]}{.image}{"\n"}{end}{end}' \
+            2>/dev/null || return 1
+    }
 }
 
 # Strip any known registry host prefix, yielding "repo:tag" lines.

--- a/local-dev/scripts/disk-janitor.sh
+++ b/local-dev/scripts/disk-janitor.sh
@@ -5,7 +5,7 @@
 # modes (a Docker hiccup at `tilt up` disables it for the whole session, and
 # every per-image skip is Debug-level only), and it can never reach the k3d
 # registry (tilt-dev/tilt#2102) or the k3s nodes' containerd stores
-# (tilt-dev/tilt#4228). Left alone, those stores grow by ~36GB per app
+# (tilt-dev/tilt#4228). Left alone, those stores grow by several GB per app
 # rebuild until kubelet taints every node with disk-pressure and nothing
 # schedules.
 #

--- a/local-dev/scripts/disk-janitor.sh
+++ b/local-dev/scripts/disk-janitor.sh
@@ -1,35 +1,32 @@
 #!/usr/bin/env bash
-# disk-janitor.sh — keep the local-dev Docker/k3d disk footprint bounded.
+# disk-janitor.sh — keep the local-dev Docker disk footprint bounded.
 #
 # Tilt's built-in pruner can't be relied on for this: it has silent failure
 # modes (a Docker hiccup at `tilt up` disables it for the whole session, and
-# every per-image skip is Debug-level only), and it can never reach the k3d
-# registry (tilt-dev/tilt#2102) or the k3s nodes' containerd stores
-# (tilt-dev/tilt#4228). Left alone, those stores grow by several GB per app
-# rebuild until kubelet taints every node with disk-pressure and nothing
-# schedules.
+# every per-image skip is Debug-level only). Left alone, tilt-built images
+# and build cache grow by several GB per app rebuild.
 #
 # This janitor enforces a retention policy instead of reacting to low disk.
-# Retention (keep the newest N tags, plus anything a pod references) is safe
-# to run at any moment — unlike a wipe, it can never delete an image
-# something is about to need. It runs as a Tilt serve_cmd resource, so it is
-# alive exactly when builds (the only source of growth) can happen.
+# Retention (keep the newest N tags) is safe to run at any moment — unlike a
+# wipe, it can never delete an image something is about to need. It runs as
+# a Tilt serve_cmd resource, so it is alive exactly when builds (the only
+# source of growth) can happen.
 #
 #   1. Local Docker daemon: keep the newest N tilt-built tags per repo
 #      (localhost:5001/*); remove older ones. Never touches other images.
-#   2. k3d registry: delete tags that are neither kept locally nor referenced
-#      by any pod, then garbage-collect blobs offline (the registry is
-#      briefly stopped; deferred while a push is in flight).
-#   3. Docker build cache: prune down to a size cap, least-recently-used
+#   2. Docker build cache: prune down to a size cap, least-recently-used
 #      first. NOTE: the BuildKit cache is one daemon-wide pool shared with
 #      everything else you build on this machine, so this is the one step
 #      whose effect is not scoped to local-dev (the cost is only rebuild
 #      speed, never correctness). Set the cap to 0 to opt out and manage the
 #      pool yourself (e.g. daemon builder.gc config).
 #
-# The k3s nodes' internal containerd stores are intentionally NOT handled
-# here — kubelet's own image GC owns those (thresholds are set in
-# local-dev/cluster/k3d-config.yaml).
+# The other two image stores clean themselves and are intentionally NOT
+# handled here:
+#   - k3d registry: zot enforces its own retention + GC declaratively
+#     (local-dev/cluster/zot-config.json).
+#   - k3s node containerd stores: kubelet's image GC owns those (thresholds
+#     in local-dev/cluster/k3d-config.yaml).
 #
 # Knobs (wired from tilt_config.json / env by the root Tiltfile):
 #   JANITOR_KEEP_TAGS          newest tags kept per repo (default 3)
@@ -41,28 +38,11 @@
 
 set -uo pipefail
 
-KUBE_CONTEXT="${JANITOR_KUBE_CONTEXT:-k3d-local-dev}"
-REGISTRY_CONTAINER="k3d-registry.localhost"
-REGISTRY_DATA="/var/lib/registry/docker/registry/v2"
-# One registry, two identities. k3d maps host port 5001 to the registry
-# container's fixed internal port 5000, and k3d's Simple config offers no way
-# to unify them — so the same image has two names and both must be treated
-# as equivalent when deciding what to keep:
-REGISTRY_HOST_REF="localhost:5001"                    # how Tilt/docker on the host name it
-REGISTRY_CLUSTER_REF="k3d-registry.localhost:5000"    # how pod specs name it (Tilt rewrites to this)
-# k3d-registry.localhost also resolves on the host (via /etc/hosts), so
-# accept that spelling of the host-side port too.
-REGISTRY_PREFIXES=("$REGISTRY_HOST_REF" "$REGISTRY_CLUSTER_REF" "k3d-registry.localhost:5001")
-
 KEEP_TAGS="${JANITOR_KEEP_TAGS:-3}"
 INTERVAL="${JANITOR_INTERVAL_SECS:-1800}"
 
 ts() { date "+%Y-%m-%d %H:%M:%S"; }
 log() { echo "[$(ts)] $*"; }
-
-container_running() {
-    docker ps --format '{{.Names}}' | grep -qx "$1"
-}
 
 # ---------------------------------------------------------------------------
 # 1. Local daemon: keep newest KEEP_TAGS tags per localhost:5001/* repo.
@@ -89,170 +69,8 @@ prune_local_tags() {
     (( removed > 0 )) && log "local daemon: removed $removed old tilt tag(s)"
 }
 
-# Every image ref the cluster might still pull: live pods (incl. init
-# containers) PLUS workload templates. Templates are the durable source of
-# truth — during node-restart churn pods can transiently be Failed or absent
-# while their Deployment still specifies the tag, and a pods-only keep-set
-# deletes a tag the replacement pod then fails to pull. Failed pods are
-# excluded (their containers never restart in place; the owning template is
-# what matters and is covered); Pending pods count — kubelet still has to
-# pull for them.
-pod_image_refs() {
-    {
-        kubectl --context "$KUBE_CONTEXT" get pods -A \
-            --field-selector=status.phase!=Failed \
-            -o jsonpath='{range .items[*]}{range .spec.initContainers[*]}{.image}{"\n"}{end}{range .spec.containers[*]}{.image}{"\n"}{end}{end}' \
-            2>/dev/null || return 1
-        kubectl --context "$KUBE_CONTEXT" get deployments,statefulsets,daemonsets -A \
-            -o jsonpath='{range .items[*]}{range .spec.template.spec.initContainers[*]}{.image}{"\n"}{end}{range .spec.template.spec.containers[*]}{.image}{"\n"}{end}{end}' \
-            2>/dev/null || return 1
-    }
-}
-
-# Strip any known registry host prefix, yielding "repo:tag" lines.
-strip_registry_prefix() {
-    local prefix out
-    while IFS= read -r line; do
-        out=""
-        for prefix in "${REGISTRY_PREFIXES[@]}"; do
-            if [[ "$line" == "$prefix"/* ]]; then
-                out="${line#"$prefix"/}"
-                break
-            fi
-        done
-        [[ -n "$out" ]] && echo "$out"
-    done
-}
-
 # ---------------------------------------------------------------------------
-# 2. Registry: a tag is kept iff it survives locally (Tilt may redeploy it)
-# or a pod references it (kubelet may re-pull it). Everything else goes.
-# Tag dirs are removed in place; blobs are freed by the registry's own
-# garbage collector (offline — see registry_gc).
-# Delete candidates are snapshotted BEFORE the keep-set is computed, so a tag
-# Tilt pushes mid-phase can never be a candidate (it would race the keep-set
-# otherwise). If kubectl or docker fails we skip the whole phase — fail safe,
-# prune nothing.
-# Registry dirs are one level deep today: Tilt flattens image names
-# (mitodl/mit-learn-app -> mitodl_mit-learn-app) when it prepends the
-# registry. If a build ever pushes a nested repo (foo/bar), this ls walk
-# silently misses it — failure direction is unbounded growth for that repo,
-# never a wrong deletion.
-# ---------------------------------------------------------------------------
-REGISTRY_GC_PENDING=0
-
-prune_registry() {
-    container_running "$REGISTRY_CONTAINER" || return 0
-
-    local candidates
-    candidates="$(
-        while IFS= read -r repo; do
-            [[ -z "$repo" ]] && continue
-            while IFS= read -r tag; do
-                [[ -z "$tag" ]] && continue
-                echo "${repo}:${tag}"
-            done < <(docker exec "$REGISTRY_CONTAINER" \
-                        ls "${REGISTRY_DATA}/repositories/${repo}/_manifests/tags" 2>/dev/null)
-        done < <(docker exec "$REGISTRY_CONTAINER" \
-                    ls "${REGISTRY_DATA}/repositories" 2>/dev/null)
-    )"
-    [[ -z "$candidates" ]] && return 0
-
-    local pod_refs
-    if ! pod_refs="$(pod_image_refs)"; then
-        log "registry: kubectl unavailable — skipping registry retention this cycle"
-        return 0
-    fi
-    local local_tags
-    if ! local_tags="$(docker images --filter reference='localhost:5001/*' \
-            --format '{{.Repository}}:{{.Tag}}' 2>/dev/null)"; then
-        log "registry: docker images failed — skipping registry retention this cycle"
-        return 0
-    fi
-
-    local keep
-    keep="$(
-        {
-            echo "$local_tags"
-            echo "$pod_refs"
-        } | strip_registry_prefix | sort -u
-    )"
-
-    local removed=0 candidate repo tag
-    while IFS= read -r candidate; do
-        [[ -z "$candidate" ]] && continue
-        if ! grep -qxF "$candidate" <<<"$keep"; then
-            repo="${candidate%%:*}"
-            tag="${candidate#*:}"
-            if docker exec "$REGISTRY_CONTAINER" \
-                rm -rf "${REGISTRY_DATA}/repositories/${repo}/_manifests/tags/${tag}"; then
-                removed=$((removed + 1))
-            fi
-        fi
-    done <<<"$candidates"
-
-    if (( removed > 0 )); then
-        log "registry: removed $removed stale tag(s)"
-        REGISTRY_GC_PENDING=1
-    fi
-}
-
-# Blob GC runs OFFLINE: stop the registry, collect in a throwaway container
-# sharing its volume, start it again. Online GC is unsafe by construction —
-# a concurrent push whose layers "already exist" writes nothing to _uploads
-# (only HEAD checks + a manifest PUT), so no guard can see it, and the
-# registry's in-memory blob-descriptor cache would answer those HEADs from
-# blobs GC just deleted, storing a manifest with missing blobs (the
-# 2026-07-23 incident). With the registry stopped, a racing push fails
-# loudly and Docker/Tilt retries; and each start begins with a cold cache,
-# so no restart choreography is needed. GC stays pending across cycles until
-# it succeeds (a deferral is otherwise lost if no later cycle removes tags).
-registry_gc() {
-    container_running "$REGISTRY_CONTAINER" || return 0
-
-    # A visibly in-flight upload means Tilt is mid-push; defer rather than
-    # fail its push. (Politeness only — stopping the registry is what makes
-    # GC safe. A stale interrupted upload can defer this repeatedly; the
-    # registry purges those after ~168h.)
-    if docker exec "$REGISTRY_CONTAINER" \
-        sh -c "find ${REGISTRY_DATA}/repositories -path '*/_uploads/*' -type f 2>/dev/null | head -1" \
-        | grep -q .; then
-        log "registry: push in flight — deferring blob GC"
-        return 0
-    fi
-    # --delete-untagged (registry >= 2.8) also drops the manifests our tag
-    # deletion orphaned; without it blobs stay pinned and GC frees ~nothing.
-    if ! docker exec "$REGISTRY_CONTAINER" registry garbage-collect --help 2>&1 \
-        | grep -q -- --delete-untagged; then
-        log "registry: 'registry garbage-collect --delete-untagged' unsupported — tags removed but blobs not freed"
-        REGISTRY_GC_PENDING=0
-        return 0
-    fi
-
-    local image rc=0
-    image="$(docker inspect --format '{{.Config.Image}}' "$REGISTRY_CONTAINER" 2>/dev/null)"
-    if [[ -z "$image" ]]; then
-        log "registry: cannot determine registry image — deferring blob GC"
-        return 0
-    fi
-    docker stop "$REGISTRY_CONTAINER" >/dev/null 2>&1
-    docker run --rm --volumes-from "$REGISTRY_CONTAINER" "$image" \
-        garbage-collect --delete-untagged /etc/docker/registry/config.yml \
-        >/dev/null 2>&1 || rc=$?
-    if ! docker start "$REGISTRY_CONTAINER" >/dev/null 2>&1; then
-        log "registry: FAILED TO RESTART ${REGISTRY_CONTAINER} after GC — start it manually (docker start ${REGISTRY_CONTAINER})"
-        return 0
-    fi
-    if (( rc == 0 )); then
-        REGISTRY_GC_PENDING=0
-        log "registry: offline blob GC complete"
-    else
-        log "registry: blob GC failed (will retry next cycle)"
-    fi
-}
-
-# ---------------------------------------------------------------------------
-# 3. Build cache: cap the daemon-wide BuildKit pool, LRU eviction.
+# 2. Build cache: cap the daemon-wide BuildKit pool, LRU eviction.
 # ---------------------------------------------------------------------------
 prune_build_cache() {
     local cap="${JANITOR_BUILDCACHE_MAX_GB:-}"
@@ -273,10 +91,25 @@ prune_build_cache() {
         || log "build cache: prune failed"
 }
 
+# ---------------------------------------------------------------------------
+# Registry backend check. This janitor deliberately does NOT prune the
+# registry — zot does that itself — so a machine still on the pre-2026-07
+# registry:2 container has NO registry retention at all and will regrow
+# unbounded. setup.sh prints migration instructions, but plenty of setups
+# never re-run it; this warning runs where everyone actually is (tilt up).
+# ---------------------------------------------------------------------------
+warn_if_not_zot() {
+    local image
+    image="$(docker inspect k3d-registry.localhost --format '{{.Config.Image}}' 2>/dev/null)" || return 0
+    case "$image" in *zot*) return 0 ;; esac
+    log "WARNING: registry is '$image', not zot — it has no retention and will grow unbounded."
+    log "WARNING: migrate (registry contents are disposable; Tilt re-pushes on next build):"
+    log "WARNING:   k3d registry delete k3d-registry.localhost && ./local-dev/scripts/setup.sh"
+}
+
 run_cycle() {
+    warn_if_not_zot
     prune_local_tags
-    prune_registry
-    (( REGISTRY_GC_PENDING )) && registry_gc
     prune_build_cache
 }
 

--- a/local-dev/scripts/disk-janitor.sh
+++ b/local-dev/scripts/disk-janitor.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# disk-janitor.sh — keep the local-dev Docker/k3d disk footprint bounded.
+#
+# Tilt's built-in pruner can't be relied on for this: it has silent failure
+# modes (a Docker hiccup at `tilt up` disables it for the whole session, and
+# every per-image skip is Debug-level only), and it can never reach the k3d
+# registry (tilt-dev/tilt#2102) or the k3s nodes' containerd stores
+# (tilt-dev/tilt#4228). Left alone, those stores grow by ~36GB per app
+# rebuild until kubelet taints every node with disk-pressure and nothing
+# schedules.
+#
+# This janitor enforces a retention policy instead of reacting to low disk.
+# Retention (keep the newest N tags, plus anything a pod references) is safe
+# to run at any moment — unlike a wipe, it can never delete an image
+# something is about to need. It runs as a Tilt serve_cmd resource, so it is
+# alive exactly when builds (the only source of growth) can happen.
+#
+#   1. Local Docker daemon: keep the newest N tilt-built tags per repo
+#      (localhost:5001/*); remove older ones. Never touches other images.
+#   2. k3d registry: delete tags that are neither kept locally nor referenced
+#      by any pod, then garbage-collect blobs (skipped while a push is in
+#      flight).
+#   3. Docker build cache: prune down to a size cap, least-recently-used
+#      first. NOTE: the BuildKit cache is one daemon-wide pool shared with
+#      everything else you build on this machine, so this is the one step
+#      whose effect is not scoped to local-dev (the cost is only rebuild
+#      speed, never correctness). Set the cap to 0 to opt out and manage the
+#      pool yourself (e.g. daemon builder.gc config).
+#
+# The k3s nodes' internal containerd stores are intentionally NOT handled
+# here — kubelet's own image GC owns those (thresholds are set in
+# local-dev/cluster/k3d-config.yaml).
+#
+# Knobs (wired from tilt_config.json / env by the root Tiltfile):
+#   JANITOR_KEEP_TAGS          newest tags kept per repo (default 3)
+#   JANITOR_BUILDCACHE_MAX_GB  build-cache cap in GB; empty = 10% of total
+#                              disk; 0 = leave the build cache alone
+#   JANITOR_INTERVAL_SECS      loop interval (default 1800); 0 = single pass
+#
+# Usage: ./local-dev/scripts/disk-janitor.sh   (or let Tilt run it)
+
+set -uo pipefail
+
+KUBE_CONTEXT="${JANITOR_KUBE_CONTEXT:-k3d-local-dev}"
+REGISTRY_CONTAINER="k3d-registry.localhost"
+REGISTRY_DATA="/var/lib/registry/docker/registry/v2"
+# One registry, two identities. k3d maps host port 5001 to the registry
+# container's fixed internal port 5000, and k3d's Simple config offers no way
+# to unify them — so the same image has two names and both must be treated
+# as equivalent when deciding what to keep:
+REGISTRY_HOST_REF="localhost:5001"                    # how Tilt/docker on the host name it
+REGISTRY_CLUSTER_REF="k3d-registry.localhost:5000"    # how pod specs name it (Tilt rewrites to this)
+# k3d-registry.localhost also resolves on the host (via /etc/hosts), so
+# accept that spelling of the host-side port too.
+REGISTRY_PREFIXES=("$REGISTRY_HOST_REF" "$REGISTRY_CLUSTER_REF" "k3d-registry.localhost:5001")
+
+KEEP_TAGS="${JANITOR_KEEP_TAGS:-3}"
+INTERVAL="${JANITOR_INTERVAL_SECS:-1800}"
+
+ts() { date "+%Y-%m-%d %H:%M:%S"; }
+log() { echo "[$(ts)] $*"; }
+
+container_running() {
+    docker ps --format '{{.Names}}' | grep -qx "$1"
+}
+
+# ---------------------------------------------------------------------------
+# 1. Local daemon: keep newest KEEP_TAGS tags per localhost:5001/* repo.
+# CreatedAt ("2026-07-23 15:17:42 +0000 UTC") sorts correctly lexically.
+# `docker rmi` without --force fails (tolerated) on anything still in use.
+# ---------------------------------------------------------------------------
+prune_local_tags() {
+    local removed=0 ref
+    while IFS= read -r ref; do
+        [[ -z "$ref" ]] && continue
+        if docker rmi "$ref" >/dev/null 2>&1; then
+            removed=$((removed + 1))
+        else
+            log "  kept $ref (in use or remove failed)"
+        fi
+    done < <(
+        docker images --filter reference='localhost:5001/*' \
+            --format '{{.CreatedAt}}\t{{.Repository}}\t{{.Tag}}' 2>/dev/null \
+            | sort -r \
+            | awk -F'\t' -v keep="$KEEP_TAGS" '{ if (++seen[$2] > keep) print $2 ":" $3 }'
+    )
+    (( removed > 0 )) && log "local daemon: removed $removed old tilt tag(s)"
+}
+
+# Every image ref any pod (incl. init containers) currently points at.
+# Failed pods (Evicted etc.) are excluded: their containers never restart in
+# place — a replacement pod is created from the current template — so they
+# should not pin old tags. Pending pods DO count: kubelet still has to pull
+# their images.
+pod_image_refs() {
+    kubectl --context "$KUBE_CONTEXT" get pods -A \
+        --field-selector=status.phase!=Failed \
+        -o jsonpath='{range .items[*]}{range .spec.initContainers[*]}{.image}{"\n"}{end}{range .spec.containers[*]}{.image}{"\n"}{end}{end}' \
+        2>/dev/null
+}
+
+# Strip any known registry host prefix, yielding "repo:tag" lines.
+strip_registry_prefix() {
+    local prefix out
+    while IFS= read -r line; do
+        out=""
+        for prefix in "${REGISTRY_PREFIXES[@]}"; do
+            if [[ "$line" == "$prefix"/* ]]; then
+                out="${line#"$prefix"/}"
+                break
+            fi
+        done
+        [[ -n "$out" ]] && echo "$out"
+    done
+}
+
+# ---------------------------------------------------------------------------
+# 2. Registry: a tag is kept iff it survives locally (Tilt may redeploy it)
+# or a pod references it (kubelet may re-pull it). Everything else goes.
+# Tag dirs are removed in place; blobs are freed by the registry's own
+# garbage collector, which we only run when no upload is in flight.
+# If kubectl fails we skip the whole phase — fail safe, prune nothing.
+# ---------------------------------------------------------------------------
+prune_registry() {
+    container_running "$REGISTRY_CONTAINER" || return 0
+
+    local pod_refs
+    if ! pod_refs="$(pod_image_refs)"; then
+        log "registry: kubectl unavailable — skipping registry retention this cycle"
+        return 0
+    fi
+
+    local keep
+    keep="$(
+        {
+            docker images --filter reference='localhost:5001/*' \
+                --format '{{.Repository}}:{{.Tag}}' 2>/dev/null
+            echo "$pod_refs"
+        } | strip_registry_prefix | sort -u
+    )"
+
+    local removed=0 repo tag
+    while IFS= read -r repo; do
+        [[ -z "$repo" ]] && continue
+        while IFS= read -r tag; do
+            [[ -z "$tag" ]] && continue
+            if ! grep -qx "${repo}:${tag}" <<<"$keep"; then
+                docker exec "$REGISTRY_CONTAINER" \
+                    rm -rf "${REGISTRY_DATA}/repositories/${repo}/_manifests/tags/${tag}"
+                removed=$((removed + 1))
+            fi
+        done < <(docker exec "$REGISTRY_CONTAINER" \
+                    ls "${REGISTRY_DATA}/repositories/${repo}/_manifests/tags" 2>/dev/null)
+    done < <(docker exec "$REGISTRY_CONTAINER" \
+                ls "${REGISTRY_DATA}/repositories" 2>/dev/null)
+
+    if (( removed > 0 )); then
+        log "registry: removed $removed stale tag(s)"
+        registry_gc
+    fi
+}
+
+registry_gc() {
+    # An in-flight push writes under _uploads/; GC during a push can corrupt
+    # it, so defer to the next cycle if anything is there.
+    if docker exec "$REGISTRY_CONTAINER" \
+        sh -c "find ${REGISTRY_DATA}/repositories -path '*/_uploads/*' -type f 2>/dev/null | head -1" \
+        | grep -q .; then
+        log "registry: push in flight — deferring blob GC to next cycle"
+        return 0
+    fi
+    # --delete-untagged (registry >= 2.8) also drops the manifests our tag
+    # deletion orphaned; without it blobs stay pinned and GC frees ~nothing.
+    if docker exec "$REGISTRY_CONTAINER" registry garbage-collect --help 2>&1 \
+        | grep -q -- --delete-untagged; then
+        if docker exec "$REGISTRY_CONTAINER" \
+            registry garbage-collect --delete-untagged /etc/docker/registry/config.yml \
+            >/dev/null 2>&1; then
+            # The running registry's in-memory blob-descriptor cache still
+            # believes GC'd blobs exist, so it would tell the next `docker
+            # push` "layer already exists" and silently produce a manifest
+            # with missing blobs (this exact failure corrupted the registry
+            # in the 2026-07-23 incident). Restart to drop the cache.
+            docker restart "$REGISTRY_CONTAINER" >/dev/null 2>&1
+            log "registry: blob GC complete (registry restarted to drop its blob cache)"
+        else
+            log "registry: blob GC failed (will retry next cycle)"
+        fi
+    else
+        log "registry: 'registry garbage-collect --delete-untagged' unsupported — tags removed but blobs not freed"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# 3. Build cache: cap the daemon-wide BuildKit pool, LRU eviction.
+# ---------------------------------------------------------------------------
+prune_build_cache() {
+    local cap="${JANITOR_BUILDCACHE_MAX_GB:-}"
+    if [[ -z "$cap" ]]; then
+        local total_gb
+        total_gb="$(df -k / 2>/dev/null | awk 'NR==2 {print int($2/1048576)}')"
+        [[ -z "$total_gb" || "$total_gb" -eq 0 ]] && return 0
+        cap=$((total_gb / 10))
+    fi
+    [[ "$cap" == "0" ]] && return 0
+
+    # Flag was renamed --keep-storage -> --max-used-space in newer buildx.
+    local flag="--keep-storage"
+    docker builder prune --help 2>&1 | grep -q -- --max-used-space && flag="--max-used-space"
+    docker builder prune -f "$flag" "${cap}gb" >/dev/null 2>&1 \
+        || log "build cache: prune failed"
+}
+
+run_cycle() {
+    prune_local_tags
+    prune_registry
+    prune_build_cache
+}
+
+log "disk-janitor starting (keep_tags=${KEEP_TAGS}, buildcache_max_gb=${JANITOR_BUILDCACHE_MAX_GB:-auto}, interval=${INTERVAL}s)"
+
+if [[ "$INTERVAL" == "0" ]]; then
+    run_cycle
+    exit 0
+fi
+
+while true; do
+    run_cycle
+    log "cycle done — next in ${INTERVAL}s"
+    sleep "$INTERVAL"
+done

--- a/local-dev/scripts/disk-janitor.sh
+++ b/local-dev/scripts/disk-janitor.sh
@@ -44,6 +44,17 @@ INTERVAL="${JANITOR_INTERVAL_SECS:-1800}"
 ts() { date "+%Y-%m-%d %H:%M:%S"; }
 log() { echo "[$(ts)] $*"; }
 
+# Non-numeric knobs would misbehave quietly (a bad INTERVAL makes `sleep`
+# fail and the loop spin hot) — fall back to defaults loudly instead.
+if [[ ! "$KEEP_TAGS" =~ ^[0-9]+$ ]]; then
+    log "invalid JANITOR_KEEP_TAGS='${KEEP_TAGS}' — using 3"
+    KEEP_TAGS=3
+fi
+if [[ ! "$INTERVAL" =~ ^[0-9]+$ ]]; then
+    log "invalid JANITOR_INTERVAL_SECS='${INTERVAL}' — using 1800"
+    INTERVAL=1800
+fi
+
 # ---------------------------------------------------------------------------
 # 1. Local daemon: keep newest KEEP_TAGS tags per localhost:5001/* repo.
 # CreatedAt is formatted client-side in the local zone, where lexical sort
@@ -74,6 +85,10 @@ prune_local_tags() {
 # ---------------------------------------------------------------------------
 prune_build_cache() {
     local cap="${JANITOR_BUILDCACHE_MAX_GB:-}"
+    if [[ -n "$cap" && ! "$cap" =~ ^[0-9]+$ ]]; then
+        log "invalid JANITOR_BUILDCACHE_MAX_GB='${cap}' — skipping build-cache prune"
+        return 0
+    fi
     if [[ -z "$cap" ]]; then
         local total_gb
         total_gb="$(df -k / 2>/dev/null | awk 'NR==2 {print int($2/1048576)}')"

--- a/local-dev/scripts/migrate-kubelet-gc-thresholds.sh
+++ b/local-dev/scripts/migrate-kubelet-gc-thresholds.sh
@@ -21,7 +21,13 @@ NODES=(k3d-local-dev-agent-0 k3d-local-dev-agent-1 k3d-local-dev-server-0)
 
 for node in "${NODES[@]}"; do
     echo "▶ ${node}: writing kubelet GC thresholds to /etc/rancher/k3s/config.yaml"
-    docker exec "$node" sh -c 'printf "kubelet-arg:\n  - image-gc-high-threshold=75\n  - image-gc-low-threshold=70\n" > /etc/rancher/k3s/config.yaml'
+    # k3d nodes don't ship this file, but back up any existing one rather
+    # than silently discarding hand-added config.
+    docker exec "$node" sh -c 'if [ -s /etc/rancher/k3s/config.yaml ]; then
+        cp /etc/rancher/k3s/config.yaml /etc/rancher/k3s/config.yaml.pre-gc-thresholds.bak
+        echo "  (existing config.yaml backed up to config.yaml.pre-gc-thresholds.bak — its settings are no longer applied)"
+    fi
+    printf "kubelet-arg:\n  - image-gc-high-threshold=75\n  - image-gc-low-threshold=70\n" > /etc/rancher/k3s/config.yaml'
     echo "▶ ${node}: restarting (pods on this node will restart)"
     docker restart "$node" >/dev/null
     printf "  waiting for %s to be Ready" "$node"

--- a/local-dev/scripts/migrate-kubelet-gc-thresholds.sh
+++ b/local-dev/scripts/migrate-kubelet-gc-thresholds.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Apply the kubelet image-GC thresholds from local-dev/cluster/k3d-config.yaml
+# to an EXISTING local-dev cluster. New clusters get them automatically at
+# creation; k3s flags can't be changed on a live cluster, so this writes them
+# to each node's /etc/rancher/k3s/config.yaml (read at k3s startup — k3d
+# passes no competing CLI kubelet-args — and survives node restarts) and
+# rolling-restarts the nodes.
+#
+# Expect a few minutes of churn as each node's pods restart. Images persist
+# in the node volumes, so nothing re-pulls. Don't run mid-build.
+#
+# Usage: ./local-dev/scripts/migrate-kubelet-gc-thresholds.sh
+set -euo pipefail
+
+CTX=k3d-local-dev
+NODES=(k3d-local-dev-agent-0 k3d-local-dev-agent-1 k3d-local-dev-server-0)
+
+for node in "${NODES[@]}"; do
+    echo "▶ ${node}: writing kubelet GC thresholds to /etc/rancher/k3s/config.yaml"
+    docker exec "$node" sh -c 'printf "kubelet-arg:\n  - image-gc-high-threshold=75\n  - image-gc-low-threshold=70\n" > /etc/rancher/k3s/config.yaml'
+    echo "▶ ${node}: restarting (pods on this node will restart)"
+    docker restart "$node" >/dev/null
+    printf "  waiting for %s to be Ready" "$node"
+    for _ in $(seq 1 60); do
+        if kubectl --context "$CTX" wait --for=condition=Ready "node/${node}" \
+            --timeout=10s >/dev/null 2>&1; then
+            echo " ✓"
+            break
+        fi
+        printf "."
+        sleep 5
+    done
+done
+
+echo ""
+echo "▶ verifying thresholds took effect (expect 75 / 70 on every node):"
+for node in "${NODES[@]}"; do
+    kubectl --context "$CTX" get --raw "/api/v1/nodes/${node}/proxy/configz" \
+        | jq --arg n "$node" '.kubeletconfig | {node: $n, imageGCHighThresholdPercent, imageGCLowThresholdPercent}'
+done

--- a/local-dev/scripts/migrate-kubelet-gc-thresholds.sh
+++ b/local-dev/scripts/migrate-kubelet-gc-thresholds.sh
@@ -9,6 +9,10 @@
 # Expect a few minutes of churn as each node's pods restart. Images persist
 # in the node volumes, so nothing re-pulls. Don't run mid-build.
 #
+# DELETE ME once the handful of clusters that predate PR #5102 have migrated
+# (tracked in witan: tk-local-dev-delete-migrate-kubelet-gc-thresholds-s-1576b6).
+# Anyone creating a cluster after that PR merged never needs this script.
+#
 # Usage: ./local-dev/scripts/migrate-kubelet-gc-thresholds.sh
 set -euo pipefail
 

--- a/local-dev/scripts/prune-docker.sh
+++ b/local-dev/scripts/prune-docker.sh
@@ -28,8 +28,8 @@ log()  { echo "▶ $*"; }
 ok()   { echo "  ✓ $*"; }
 warn() { echo "  ⚠ $*"; }
 
-container_running() {
-    docker ps --format '{{.Names}}' | grep -qx "$1"
+container_exists() {
+    docker ps -a --format '{{.Names}}' | grep -qx "$1"
 }
 
 echo "Disk usage before:"
@@ -63,9 +63,9 @@ ok "Local Docker daemon pruned."
 #    incident — "layer already exists" for blobs that were gone). Paths cover
 #    both zot (/var/lib/zot) and pre-migration registry:2 (/var/lib/registry).
 # ---------------------------------------------------------------------------
-if container_running "$REGISTRY_CONTAINER"; then
+if container_exists "$REGISTRY_CONTAINER"; then
     log "Clearing local registry storage (${REGISTRY_CONTAINER})..."
-    docker stop "$REGISTRY_CONTAINER" >/dev/null
+    docker stop "$REGISTRY_CONTAINER" >/dev/null 2>&1 || true    # may already be stopped
     docker run --rm --volumes-from "$REGISTRY_CONTAINER" alpine sh -c \
         'rm -rf /var/lib/zot/* /var/lib/registry/docker/registry/v2/blobs/* /var/lib/registry/docker/registry/v2/repositories/* 2>/dev/null; true'
     if ! docker start "$REGISTRY_CONTAINER" >/dev/null; then
@@ -75,7 +75,7 @@ if container_running "$REGISTRY_CONTAINER"; then
     fi
     ok "Registry storage cleared (wiped stopped, restarted clean)."
 else
-    warn "${REGISTRY_CONTAINER} not running — skipping registry cleanup."
+    warn "${REGISTRY_CONTAINER} does not exist — skipping registry cleanup."
 fi
 
 # ---------------------------------------------------------------------------

--- a/local-dev/scripts/prune-docker.sh
+++ b/local-dev/scripts/prune-docker.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# prune-docker.sh — BREAK-GLASS full cleanup of the local-dev Docker/k3d disk
+# footprint. Day-to-day retention is handled automatically by
+# disk-janitor.sh (a Tilt serve_cmd resource); reach for this only when disk
+# is critically low or nodes are already tainted with disk-pressure.
+#
+# Expect fallout: this wipes the registry and sweeps every unused image from
+# the k3s nodes, so recovery means kubelet re-pulling infra images from
+# public registries and Tilt fully rebuilding the app images. Pods may sit in
+# ImagePullBackOff until that completes (this bit us in the 2026-07-23
+# incident — pods that were merely Pending counted as "not using" their
+# images, so the sweep took currently-needed images with it).
+#
+# What it cleans:
+#   1. Local Docker daemon (tilt-built images, dangling images, build cache)
+#   2. The k3d cluster's local registry (every pushed build)
+#   3. Each k3d node's containerd image store (all images not in active use)
+#
+# Usage:
+#   ./local-dev/scripts/prune-docker.sh
+
+set -euo pipefail
+
+CLUSTER_NAME="local-dev"
+REGISTRY_CONTAINER="k3d-registry.localhost"
+
+log()  { echo "▶ $*"; }
+ok()   { echo "  ✓ $*"; }
+warn() { echo "  ⚠ $*"; }
+
+container_running() {
+    docker ps --format '{{.Names}}' | grep -qx "$1"
+}
+
+echo "Disk usage before:"
+docker system df
+echo ""
+
+# ---------------------------------------------------------------------------
+# 1. Local Docker daemon. Image removal is scoped to tilt-built images
+#    (localhost:5001/*) plus dangling layers — a global `docker image prune
+#    -a` would also take images belonging to unrelated projects on this
+#    machine. The build-cache prune IS global (BuildKit keeps one daemon-wide
+#    pool; there is no way to scope it), but that only costs other projects
+#    rebuild speed.
+# ---------------------------------------------------------------------------
+log "Pruning local Docker build cache and tilt-built images..."
+docker builder prune -af >/dev/null
+docker images --filter reference='localhost:5001/*' --format '{{.Repository}}:{{.Tag}}' \
+    | xargs -r -n1 docker rmi >/dev/null 2>&1 || true
+docker image prune -f >/dev/null
+ok "Local Docker daemon pruned."
+
+# ---------------------------------------------------------------------------
+# 2. k3d registry — the registry has no default expiry, so old pushes (every
+#    Tilt build, forever) just accumulate as blobs. There's nothing worth
+#    keeping in this cache: Tilt re-pushes whatever the current build needs
+#    on the next `tilt up`, from its own local build cache, so wiping it is
+#    cheap to recover from.
+# ---------------------------------------------------------------------------
+if container_running "$REGISTRY_CONTAINER"; then
+    log "Clearing local registry storage (${REGISTRY_CONTAINER})..."
+    docker exec "$REGISTRY_CONTAINER" sh -c \
+        'rm -rf /var/lib/registry/docker/registry/v2/blobs/* /var/lib/registry/docker/registry/v2/repositories/*'
+    # The registry's in-memory blob-descriptor cache still believes the wiped
+    # blobs exist; without a restart it answers the next push's existence
+    # checks with "layer already exists", producing manifests whose blobs
+    # were never re-uploaded (pods then fail pulls with "unexpected EOF" —
+    # this corrupted the registry during the 2026-07-23 incident).
+    docker restart "$REGISTRY_CONTAINER" >/dev/null
+    ok "Registry storage cleared (registry restarted to drop its blob cache)."
+else
+    warn "${REGISTRY_CONTAINER} not running — skipping registry cleanup."
+fi
+
+# ---------------------------------------------------------------------------
+# 3. k3s node containerd stores — OFF by default; pass --sweep-nodes to run.
+#
+#    kubelet's own image GC normally reclaims these (thresholds in
+#    local-dev/cluster/k3d-config.yaml), so this sweep is only for when a
+#    node is already tainted and kubelet GC can't catch up.
+#
+#    WARNING: unlike `docker rmi`, `crictl rmi` deletes the image RECORD even
+#    when running containers use the image (containerd containers pin
+#    snapshots, not image records). During the 2026-07-23 incident this left
+#    every node with an empty image store, ~96GB of orphaned-but-pinned
+#    snapshots that containerd's GC could never reclaim, and containers that
+#    could not restart without a re-pull from a registry this same script had
+#    just wiped. After running this, you MUST let Tilt rebuild + push all app
+#    images, then `docker restart` each node one at a time so kubelet
+#    re-pulls and re-creates image records.
+# ---------------------------------------------------------------------------
+if [[ "${1:-}" == "--sweep-nodes" ]]; then
+    mapfile -t nodes < <(docker ps --format '{{.Names}}' | grep "^k3d-${CLUSTER_NAME}-\(server\|agent\)-" || true)
+    if [[ ${#nodes[@]} -eq 0 ]]; then
+        warn "No running k3d nodes found for cluster '${CLUSTER_NAME}' — skipping node image cleanup."
+    else
+        for node in "${nodes[@]}"; do
+            log "Sweeping images on node ${node} (containers will need re-pulls to restart)..."
+            docker exec "$node" sh -c \
+                'crictl images -q | xargs -r -n1 sh -c "crictl rmi \"\$0\" 2>/dev/null || true"'
+            ok "${node} swept."
+        done
+        warn "Node stores swept. Follow up: let Tilt rebuild+push all app images,"
+        warn "then 'docker restart' each k3d node one at a time (see script header)."
+    fi
+else
+    log "Skipping k3s node image stores (kubelet image GC owns those; pass --sweep-nodes to force)."
+fi
+
+echo ""
+echo "Disk usage after:"
+docker system df

--- a/local-dev/scripts/prune-docker.sh
+++ b/local-dev/scripts/prune-docker.sh
@@ -52,30 +52,28 @@ docker image prune -f >/dev/null
 ok "Local Docker daemon pruned."
 
 # ---------------------------------------------------------------------------
-# 2. k3d registry — the registry has no default expiry, so old pushes (every
-#    Tilt build, forever) just accumulate as blobs. There's nothing worth
-#    keeping in this cache: Tilt re-pushes whatever the current build needs
-#    on the next `tilt up`, from its own local build cache, so wiping it is
-#    cheap to recover from.
+# 2. k3d registry — day-to-day, zot's own retention/GC keeps this bounded
+#    (local-dev/cluster/zot-config.json); this is the break-glass full wipe.
+#    There's nothing worth keeping in this cache: Tilt re-pushes whatever the
+#    current build needs on the next `tilt up`, from its own local build
+#    cache, so wiping it is cheap to recover from.
+#    The wipe is done stopped: deleting storage under a RUNNING registry
+#    leaves stale in-memory state that can silently corrupt the next push
+#    (registry:2's blob-descriptor cache did exactly that in the 2026-07-23
+#    incident — "layer already exists" for blobs that were gone). Paths cover
+#    both zot (/var/lib/zot) and pre-migration registry:2 (/var/lib/registry).
 # ---------------------------------------------------------------------------
 if container_running "$REGISTRY_CONTAINER"; then
     log "Clearing local registry storage (${REGISTRY_CONTAINER})..."
-    docker exec "$REGISTRY_CONTAINER" sh -c \
-        'rm -rf /var/lib/registry/docker/registry/v2/blobs/* /var/lib/registry/docker/registry/v2/repositories/*'
-    # The registry's in-memory blob-descriptor cache still believes the wiped
-    # blobs exist; without a restart it answers the next push's existence
-    # checks with "layer already exists", producing manifests whose blobs
-    # were never re-uploaded (pods then fail pulls with "unexpected EOF" —
-    # this corrupted the registry during the 2026-07-23 incident). If the
-    # restart fails, the stale cache is live over wiped storage — the exact
-    # incident pre-condition — so stop hard rather than continue.
-    if ! docker restart "$REGISTRY_CONTAINER" >/dev/null; then
-        warn "REGISTRY RESTART FAILED — do NOT push (Tilt included) until"
-        warn "'docker restart ${REGISTRY_CONTAINER}' succeeds, or the next"
-        warn "push will silently corrupt the registry (stale blob cache)."
+    docker stop "$REGISTRY_CONTAINER" >/dev/null
+    docker run --rm --volumes-from "$REGISTRY_CONTAINER" alpine sh -c \
+        'rm -rf /var/lib/zot/* /var/lib/registry/docker/registry/v2/blobs/* /var/lib/registry/docker/registry/v2/repositories/* 2>/dev/null; true'
+    if ! docker start "$REGISTRY_CONTAINER" >/dev/null; then
+        warn "REGISTRY FAILED TO START after wipe — run"
+        warn "'docker start ${REGISTRY_CONTAINER}' before any push or pull."
         exit 1
     fi
-    ok "Registry storage cleared (registry restarted to drop its blob cache)."
+    ok "Registry storage cleared (wiped stopped, restarted clean)."
 else
     warn "${REGISTRY_CONTAINER} not running — skipping registry cleanup."
 fi

--- a/local-dev/scripts/prune-docker.sh
+++ b/local-dev/scripts/prune-docker.sh
@@ -66,8 +66,15 @@ if container_running "$REGISTRY_CONTAINER"; then
     # blobs exist; without a restart it answers the next push's existence
     # checks with "layer already exists", producing manifests whose blobs
     # were never re-uploaded (pods then fail pulls with "unexpected EOF" —
-    # this corrupted the registry during the 2026-07-23 incident).
-    docker restart "$REGISTRY_CONTAINER" >/dev/null
+    # this corrupted the registry during the 2026-07-23 incident). If the
+    # restart fails, the stale cache is live over wiped storage — the exact
+    # incident pre-condition — so stop hard rather than continue.
+    if ! docker restart "$REGISTRY_CONTAINER" >/dev/null; then
+        warn "REGISTRY RESTART FAILED — do NOT push (Tilt included) until"
+        warn "'docker restart ${REGISTRY_CONTAINER}' succeeds, or the next"
+        warn "push will silently corrupt the registry (stale blob cache)."
+        exit 1
+    fi
     ok "Registry storage cleared (registry restarted to drop its blob cache)."
 else
     warn "${REGISTRY_CONTAINER} not running — skipping registry cleanup."
@@ -97,9 +104,14 @@ if [[ "${1:-}" == "--sweep-nodes" ]]; then
     else
         for node in "${nodes[@]}"; do
             log "Sweeping images on node ${node} (containers will need re-pulls to restart)..."
-            docker exec "$node" sh -c \
-                'crictl images -q | xargs -r -n1 sh -c "crictl rmi \"\$0\" 2>/dev/null || true"'
-            ok "${node} swept."
+            # || warn: under set -e a node stopping mid-sweep would otherwise
+            # abort the remaining nodes and skip the follow-up instructions.
+            if docker exec "$node" sh -c \
+                'crictl images -q | xargs -r -n1 sh -c "crictl rmi \"\$0\" 2>/dev/null || true"'; then
+                ok "${node} swept."
+            else
+                warn "${node} sweep failed (node stopped?) — continuing with remaining nodes."
+            fi
         done
         warn "Node stores swept. Follow up: let Tilt rebuild+push all app images,"
         warn "then 'docker restart' each k3d node one at a time (see script header)."

--- a/local-dev/scripts/setup.sh
+++ b/local-dev/scripts/setup.sh
@@ -244,12 +244,49 @@ fi
 ok "Prerequisites satisfied (Docker ${DOCKER_MEM_GB} GB RAM)"
 
 # ---------------------------------------------------------------------------
-# 2. Create k3d cluster
+# 2. Create local image registry (zot)
+# ---------------------------------------------------------------------------
+# Created here rather than in k3d-config.yaml because zot's config file must
+# be bind-mounted from this checkout. zot enforces image retention (keep the
+# N most recently pushed tags) and GC itself — see zot-config.json — so
+# nothing else has to clean the registry. k3d-config.yaml attaches the
+# registry to the cluster via `registries.use`.
+REGISTRY_NAME="k3d-registry.localhost"
+REGISTRY_IMAGE="ghcr.io/project-zot/zot:v2.1.18"
+ZOT_CONFIG="${REPO_ROOT}/local-dev/cluster/zot-config.json"
+
+log "Setting up local image registry '${REGISTRY_NAME}'..."
+if docker ps -a --format '{{.Names}}' | grep -qx "${REGISTRY_NAME}"; then
+    if docker inspect "${REGISTRY_NAME}" --format '{{.Config.Image}}' | grep -q zot; then
+        docker start "${REGISTRY_NAME}" >/dev/null 2>&1 || true
+        ok "Registry '${REGISTRY_NAME}' already exists — skipping creation."
+    else
+        warn "Registry '${REGISTRY_NAME}' exists but is not zot (pre-2026-07 registry:2)."
+        warn "To migrate:  k3d registry delete ${REGISTRY_NAME}  then re-run setup.sh"
+        warn "(Tilt re-pushes all images on the next build; see local-dev/README.md)"
+    fi
+else
+    # `k3d registry create` prefixes the name with 'k3d-'. The bare
+    # /var/lib/zot mount makes image storage an anonymous volume (zot's image
+    # declares none), so prune-docker.sh can wipe it with the registry
+    # stopped via --volumes-from.
+    k3d registry create "${REGISTRY_NAME#k3d-}" --port 5001 \
+        --image "${REGISTRY_IMAGE}" \
+        -v "${ZOT_CONFIG}:/etc/zot/config.json" \
+        -v /var/lib/zot
+    ok "Registry '${REGISTRY_NAME}' created (zot, retention enabled)."
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Create k3d cluster
 # ---------------------------------------------------------------------------
 log "Setting up k3d cluster '${CLUSTER_NAME}'..."
 
 if k3d cluster list 2>/dev/null | grep -q "^${CLUSTER_NAME}"; then
     ok "Cluster '${CLUSTER_NAME}' already exists — skipping creation."
+    # An already-created cluster is not reconfigured by registries.use — make
+    # sure the registry is reachable from the cluster network regardless.
+    docker network connect "k3d-${CLUSTER_NAME}" "${REGISTRY_NAME}" 2>/dev/null || true
 else
     k3d cluster create --config "${K3D_CONFIG}"
     ok "Cluster '${CLUSTER_NAME}' created."
@@ -267,7 +304,7 @@ kubectl config use-context "local-dev"
 ok "kubectl context 'local-dev' registered and active."
 
 # ---------------------------------------------------------------------------
-# 3. TLS certificates via mkcert
+# 4. TLS certificates via mkcert
 # ---------------------------------------------------------------------------
 if $SKIP_CERTS; then
     warn "Skipping certificate generation (--skip-certs)."
@@ -317,7 +354,7 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 4. /etc/hosts entries
+# 5. /etc/hosts entries
 # ---------------------------------------------------------------------------
 if $SKIP_HOSTS; then
     warn "Skipping /etc/hosts update (--skip-hosts)."
@@ -375,7 +412,7 @@ with open('/etc/hosts', 'w') as f:
 fi
 
 # ---------------------------------------------------------------------------
-# 5. Pulumi stack prerequisites
+# 6. Pulumi stack prerequisites
 # ---------------------------------------------------------------------------
 log "Checking Pulumi stack prerequisites..."
 

--- a/tilt_config.json.example
+++ b/tilt_config.json.example
@@ -13,5 +13,9 @@
     "odl-video-service=0.85.0"
   ],
 
-  "root_domain": "mit.dev"
+  "root_domain": "mit.dev",
+
+  "disk_keep_tags": "3",
+
+  "disk_buildcache_max_gb": ""
 }


### PR DESCRIPTION

### What are the relevant tickets?

NA; followup to noticing local-dev had used up ~800GB of space on my computer today.



### Description (What does it do?)

Every Tilt build lands a multi-GB image in three stores:
1.  the local Docker daemon, 
2. the k3d registry, 
3. and each k3s node's containerd store.

Tilt's built-in pruner has silent failure modes (see Additional Context) and by design only reaches the first — registry cleanup is [tilt-dev/tilt#2102](https://github.com/tilt-dev/tilt/issues/2102), node stores [tilt-dev/tilt#4228](https://github.com/tilt-dev/tilt/issues/4228).

My dev machine reached ~800GB in 3 weeks; this was exacerbated by some huge gitignored-but-not-dockerignored files that were being copied multiple times in containers. I've removed those, but this would have happened eventually.

This PR bounds all three stores with retention — keep the newest N — rather than low-disk-triggered wipes, which can delete an image something is about to need. In order of importance:

1. **The registry is now [zot](https://zotregistry.dev) instead of `registry:2`** (`setup.sh` creates it; config in `local-dev/cluster/zot-config.json`). zot is a CNCF OCI registry with retention and garbage collection built in as config: keep the 10 newest tags per repo, GC hourly. `registry:2` has no retention story at all — bounding it requires external scripting against its API plus its `garbage-collect` command, which is unsafe to run online (a concurrent push whose layers "already exist" writes nothing detectable and silently stores a manifest with missing blobs — the incident's corruption mode). An earlier iteration of this PR did exactly that scripting, ~180 lines of keep-set computation and offline GC orchestration in bash; the swap replaces it with ~15 lines of JSON. `http.compat: ["docker2s2"]` is required — Docker (and therefore Tilt) still pushes Docker-format manifests, which zot rejects without it.
6. **`disk-janitor.sh`** (new; Tilt `serve_cmd` resource, runs with every `tilt up`) — covers the stores zot can't see: keeps the newest N `tilt-*` tags per repo in the **local Docker daemon** and caps the **BuildKit build cache** (one daemon-wide pool, no per-project scoping exists; eviction only costs other projects rebuild speed). Knobs via `tilt_config.json` or env: `disk_keep_tags` (default 3), `disk_buildcache_max_gb` (default 10% of total disk; `"0"` opts out).
7. **kubelet image-GC thresholds** (`k3d-config.yaml`, 85/80 → 75/70) — bounds the node containerd stores. The defaults are percentages of the node filesystem — the shared Docker VM data disk under OrbStack/Docker Desktop — and k3s taints at 95% used (`nodefs.available<5%`), so by default only ~10% of that disk (~68GB on a 678GB VM disk: one or two app images) separates "GC starts" from "nothing schedules"; 75/70 doubles the band to ~20%. Automatic on new clusters; existing clusters use the migration script below.
8. **`prune-docker.sh`** (break-glass only; Tilt UI button / `tilt trigger prune-docker`) — hardened with the incident's lessons:
   - image pruning scoped to `localhost:5001/*` (no longer nukes other projects' images)
   - the registry wipe now happens with the registry **stopped** (via `--volumes-from` from a throwaway container) — deleting storage under a running registry leaves stale in-memory state that can corrupt the next push (registry:2's blob-descriptor cache did exactly that during the incident; a pod sat in ImagePullBackOff for hours). Covers both zot and pre-migration registry:2 storage paths.
   - the `crictl` node sweep gated behind `--sweep-nodes`: `crictl rmi` deletes image records out from under **running** containers, orphaning their snapshots (~96GB unreclaimable on one node) and making every container restart require a re-pull

Also:

- **mit-learn backend build no longer sweeps in the frontend workspace** (`docker_build ignore=[...]` in `local-dev/apps/mit-learn/Tiltfile`): `frontends/` + the yarn cache were ~1GB of dead weight in every backend image, and frontend edits were triggering backend live-syncs. Multiplied across the ~5 places each image byte is stored, this was the highest-leverage single fix.
- New "Disk Management" section in `local-dev/README.md`.

### Migrating an existing setup (no cluster teardown needed)

1. ~**Check out this branch** (or pull `main` once this merges) — every step below runs scripts/config from the working tree.~ Pull `main` fresh.
2. **Swap the registry to zot.** Registry contents are a disposable cache — Tilt re-pushes whatever the current build needs, and running pods are unaffected because nodes cache their images. Tilt can stay up.

    ```bash
    k3d registry delete k3d-registry.localhost
    ./local-dev/scripts/setup.sh   # recreates it as zot, reconnects the cluster network
    ```

3. **Apply the kubelet thresholds** — they're k3s flags normally baked in at cluster creation, so existing clusters silently keep 85/80 until migrated:

    ```bash
    ./local-dev/scripts/migrate-kubelet-gc-thresholds.sh
    ```

    This writes the thresholds to each node's `/etc/rancher/k3s/config.yaml` (read at startup — k3d passes no competing CLI kubelet-args — and survives restarts; a future recreate applies the identical flags from `k3d-config.yaml`) and rolling-restarts the nodes. Expect a few minutes of churn as each node's pods restart (images persist in the node volumes, so nothing re-pulls); don't run it mid-build. **Verified working** — all three nodes report 75/70 after the run.

4. **`tilt up` as usual** — the janitor and Tilt-pruner changes take effect on their own.


If you skip step 2: `setup.sh` detects a pre-existing `registry:2` container and prints the swap instructions rather than deleting it out from under you, and — since a registry:2 left in place now has *no* retention at all (this PR removes the janitor's registry phase) — the janitor prints the same warning on every cycle until the registry is zot.

### Optional: reclaim space already accumulated on your nodes

The mechanisms above bound growth going forward, but they don't retroactively clean what your nodes accumulated before this PR — kubelet's image GC only acts once the disk crosses 75% full, so weeks of unused images can sit below that line indefinitely. To reclaim them immediately (safe: only removes images no container is using; worst case a future pod re-pulls from the registry):

```bash
for node in k3d-local-dev-server-0 k3d-local-dev-agent-0 k3d-local-dev-agent-1; do
    docker exec "$node" crictl rmi --prune
done
```

### How can this be tested?

Step one is the migration above, run from this branch. Beyond that, everything was exercised live on the cluster recovering from the actual incident:

1. Run the migration described above.
2. disk janitor should appear in tilt UI under infra label

### Additional Context

- Tilt pruner findings (from source): sticky silent disable when Docker is unreachable at startup; setting `num_builds` disables the hourly prune path entirely; multi-tag images are never pruned; all skips log at Debug only. Hence the janitor is self-sufficient rather than layered on Tilt's pruner. Diagnostic if images ever pile up again: `tilt docker-prune --debug`.
- zot's keep-10-per-repo is deliberately looser than the janitor's daemon-side keep-3: registry tags are the recovery path when a node needs to re-pull, so the extra headroom is cheap insurance and still bounded.
- The registry blob-cache and `crictl rmi` sharp edges are stored in witan shared memory (`les-registry-2-blob-cache-…`, `les-crictl-rmi-deletes-image-records-…`).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


