### PR TITLE
feat(k8s-apps): versioned release-issue titles + opt-in update_in_place

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
@@ -1238,11 +1238,17 @@ def _build_release_resource_app_pipeline(
     # Build per-stack additional_post_steps and custom_dependencies for QA+Production
     qa_post_steps: list[GetStep | PutStep | TaskStep] = [
         # Open a GitHub Release Issue with the checklist from the release resource.
+        # title_template embeds the release version (via the image_tag var
+        # loaded from release_res earlier in this job's plan) so each release
+        # gets its own distinct issue title instead of every version
+        # colliding on "Release {app_name}" -- Concourse resolves
+        # ((.:image_tag)) to a plain string before the resource ever sees it.
         PutStep(
             put=release_issue.name,
             params={
                 "body_file": f"{release_res.name}/checklist.md",
                 "labels": ["release"],
+                "title_template": f"Release {app_name} ((.:image_tag))",
             },
         ),
         # Mark the RC GitHub Deployment as successful.

--- a/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
@@ -870,6 +870,11 @@ def _define_release_resources(
         labels=["release"],
         access_token="((github.release_resource_access_token))",  # noqa: S106
         gh_host=None,
+        # A retriggered QA deploy with no new app commit re-runs this put
+        # with the same checklist; editing in place (instead of the default
+        # comment-per-hit behavior) avoids reopening the issue with a fresh,
+        # all-unchecked checklist for a release that hasn't actually changed.
+        update_in_place=True,
     )
     deployment_rc = github_deployment(
         name=Identifier(f"{app_name}-deployment-rc"),

--- a/uv.lock
+++ b/uv.lock
@@ -1402,14 +1402,14 @@ wheels = [
 
 [[package]]
 name = "ol-concourse"
-version = "0.8.11"
+version = "0.8.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/39/e5/f0d1bb2682fb0e5bfd89f1ba665ccbb64f0470745cf7b3e630d5c6f1b068/ol_concourse-0.8.11.tar.gz", hash = "sha256:9b0189ff251ce1f79680acc92319ebc16704499f9baeed06afbac98bce9a09c0", size = 52507, upload-time = "2026-06-15T23:33:50.65Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/e0/3cb179558748aa42bf913550b4cedfe0d9351a5beeef276aed616ceef682/ol_concourse-0.8.12.tar.gz", hash = "sha256:5f9915221a1369e8a3933836bee30488ce3fe4f14e4b623dae7522b4f71b47de", size = 52832, upload-time = "2026-07-23T20:08:44.146Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/67/8cb81f8d85c665a1ee873b132decf127075cf77ee3a468fe6080723079f0/ol_concourse-0.8.11-py3-none-any.whl", hash = "sha256:4eb8eb13bba2dfabf19c305c641dc86d001fca3f00ee96b8dd385b725aefcd92", size = 51577, upload-time = "2026-06-15T23:33:49.587Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4e/20c36e335b14f76d8a30e5b5e876f8441ca8526ed0aed1089faa2583c4cc/ol_concourse-0.8.12-py3-none-any.whl", hash = "sha256:735a1f2ba971e6f846fc4c747a96575d1fbcfc80ebc6b5acaea1419c6c9bb253", size = 51794, upload-time = "2026-07-23T20:08:43.173Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Two changes to the release issue, both depending on [ol-concourse#66](https://github.com/mitodl/ol-concourse/pull/66):

### 1. Versioned issue titles

Every release issue's title was just `Release {app_name}` with no version, so all releases of an app collided on the same title. Passes the new `title_template` put param with the release version embedded via `((.:image_tag))` — resolved by Concourse from the `image_tag` var already loaded earlier in this job's plan, so the resource itself never has to know about `((.:var))` syntax.

`issue_prefix` (still just `Release {app_name}`) continues to prefix-match the now-longer title fine, so the `release_gate`/ready-to-promote polling that keys off the prefix is unaffected; retriggering the same release still resolves to the same title, so the existing-issue search still finds the right issue.

### 2. Opt `release_issue` into `update_in_place`

A retriggered QA deploy with no new app commit re-runs the `release_issue` put with the same checklist; the default comment-per-hit behavior (kept as the default for every *other* consumer of this resource, since a fresh comment is itself a useful "gate hit again" signal there) would reopen the issue with a fresh, all-unchecked checklist for a release that hasn't actually changed. `release_gate` (the closed-state resource that triggers production) is untouched and stays on the safe default.

## ⚠️ Merge-order dependency — three steps, not two

Both changes require support that doesn't exist in the *currently locked* `ol-concourse` dependency yet. Verified this is a hard requirement, not a soft one: `concoursetools`' dispatch (`resource.publish_new_version(sources_dir, build_metadata, **params)` in `out_main`) passes every `params` key as a keyword argument, so `title_template` against the currently-published resource image raises `TypeError: publish_new_version() got an unexpected keyword argument 'title_template'` — a hard failure of the QA deploy job, not a silent no-op.

Three things need to happen, in order, before this PR is safe to merge:
1. [ol-concourse#66](https://github.com/mitodl/ol-concourse/pull/66) merges, and the `mitodl/concourse-github-issues-resource` Docker image republishes (confirm via Docker Hub `last_pushed`, same as verified for the release-resource fix) — this is what the *running Concourse job* needs.
2. ol-concourse also publishes a new PyPI release including the `pipeline_lib` changes (`update_in_place`/`title_template` params on the `github_issues()` wrapper).
3. **This repo's `pyproject.toml`/`uv.lock` `ol-concourse` pin (currently locked at `0.8.11`) gets bumped to that new version** (e.g. `uv lock --upgrade-package ol-concourse`) — this is what *generating this pipeline* needs. Without this step, running `pipeline.py` locally or in CI still uses the old wrapper signature and raises `TypeError: github_issues() got an unexpected keyword argument 'update_in_place'` at generation time, before the resource is ever invoked.

Step 3 is easy to miss since steps 1–2 make it *look* like the feature is live — confirmed by temporarily installing the modified `pipeline_lib` locally to verify this PR's changes are otherwise correct (see commit messages), then reverting that temporary install; the actual dependency bump is a separate, still-pending step.

## Test plan
- [x] Regenerated `ol-analytics-api-pipeline` (the only app currently on the release-resource workflow) with a temporarily-installed, modified `pipeline_lib` — `title_template` and `update_in_place: true` both appear correctly on `release_issue`'s config; `release_gate` correctly keeps `update_in_place: false`
- [x] Regenerated all legacy-workflow apps (micromasters, xpro, ocw-studio, odl-video-service, mitxonline) — confirmed no `title_template`/`update_in_place` occurrences, i.e. unaffected
- [x] `ruff check`, `mypy` clean against the *currently locked* `ol-concourse` (no static-typing safety net catches the pending dependency bump — this is a runtime-only failure mode)
- [ ] After the dependency bump (step 3 above), regenerate and re-verify once more against the real published package

🤖 Generated with [Claude Code](https://claude.com/claude-code)
