### PR TITLE
fix(edxapp): raise mitx-staging LMS webapp KEDA max replicas 3 -> 5

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.Production.yaml
@@ -91,7 +91,7 @@ config:
         max: 3
       lms:
         min: 1
-        max: 3
+        max: 5
     celery:
       lms:
         min: 1


### PR DESCRIPTION
## Summary
- `HPAAtMaxReplicasCritical` fired for `keda-hpa-lms-edxapp-webapp-scaledobject` in `residential-production`/`mitx-staging-openedx`: the HPA's external Prometheus metric pushed replicas from 2 to 3 (the configured ceiling), tripping `ScalingLimited=TooManyReplicas`.
- This is expected, legitimate load, not an anomaly: course authors doing bursty content generation/testing on staging routinely need this headroom.
- Node headroom is ample (29-39% memory utilization across `residential-production` nodes) and each pod is modest (250m CPU / 2Gi memory), so raising the ceiling is safe.
- Raises `edxapp:k8s_replicas.webapp.lms.max` from `3` to `5` in `Pulumi.mitx-staging.Production.yaml` only. This is stack-specific Pulumi config, not a shared default — no other edxapp site (mitx, mitxonline, xpro, bootcamps) or other stack (`mitx-staging.QA`/`.CI`) is affected.

## Test plan
- [x] `pre-commit` (yaml checks) passes
- [x] `pulumi preview --stack mitx-staging.Production --diff` against the live `edxapp` stack — shows exactly `maxReplicaCount: 3 => 5` on `lms-edxapp-production-webapp-scaledobject`; confirmed via `git diff --stat origin/main` that the only code change is this one config line.
- [ ] After merge/deploy, confirm the HPA no longer hits its ceiling during normal staging content-authoring bursts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)