### PR TITLE
Remove micromasters api url from mit-learn

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1216,7 +1216,6 @@ env_vars = {
     "EMBEDDINGS_EXTERNAL_FETCH_USE_WEBDRIVER": True,
     "EMBEDDING_SCHEDULE_MINUTES": 120,
     "LITELLM_TOKEN_ENCODING_NAME": "cl100k_base",
-    "MICROMASTERS_CATALOG_API_URL": "https://micromasters.mit.edu/api/v0/catalog/",
     "MICROMASTERS_CMS_API_URL": "https://micromasters.mit.edu/api/v0/wagtail/",
     "MITOL_ADMIN_EMAIL": "cuddle-bunnies@mit.edu",
     "MITOL_AXIOS_BASE_PATH": f"https://{mitlearn_config.get('frontend_domain')}",


### PR DESCRIPTION
### What are the relevant tickets?
Related to https://github.com/mitodl/mit-learn/pull/3663

### Description (What does it do?)
Removes the MICROMASTERS_CATALOG_API_URL env value from mit-learn


### How can this be tested?
N/A

