### PR TITLE
fix(ol-analytics-api): move ingress to ol.mit.edu + add Learn-scoped host

### DIFF
--- a/src/ol_infrastructure/applications/ol_analytics_api/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/applications/ol_analytics_api/Pulumi.CI.yaml
@@ -4,7 +4,8 @@ config:
   aws:region: us-east-1
   vault:address: https://vault-ci.odl.mit.edu
   vault_server:env_namespace: operations.ci
-  ol_analytics_api:domain: analytics-ci.odl.mit.edu
+  ol_analytics_api:domain: analytics-ci.ol.mit.edu
+  ol_analytics_api:learn_domain: analytics.ci.learn.mit.edu
   ol_analytics_api:env_vars:
     OL_ANALYTICS_API_ENVIRONMENT: ci
     LOG_LEVEL: INFO

--- a/src/ol_infrastructure/applications/ol_analytics_api/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/ol_analytics_api/Pulumi.Production.yaml
@@ -4,7 +4,8 @@ config:
   aws:region: us-east-1
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production
-  ol_analytics_api:domain: analytics.odl.mit.edu
+  ol_analytics_api:domain: analytics.ol.mit.edu
+  ol_analytics_api:learn_domain: analytics.learn.mit.edu
   ol_analytics_api:env_vars:
     OL_ANALYTICS_API_ENVIRONMENT: production
     LOG_LEVEL: INFO

--- a/src/ol_infrastructure/applications/ol_analytics_api/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/ol_analytics_api/Pulumi.QA.yaml
@@ -4,7 +4,8 @@ config:
   aws:region: us-east-1
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa
-  ol_analytics_api:domain: analytics-qa.odl.mit.edu
+  ol_analytics_api:domain: analytics-qa.ol.mit.edu
+  ol_analytics_api:learn_domain: analytics.rc.learn.mit.edu
   ol_analytics_api:env_vars:
     OL_ANALYTICS_API_ENVIRONMENT: qa
     LOG_LEVEL: INFO

--- a/src/ol_infrastructure/applications/ol_analytics_api/__main__.py
+++ b/src/ol_infrastructure/applications/ol_analytics_api/__main__.py
@@ -431,6 +431,24 @@ ol_analytics_api_k8s = OLApplicationK8s(
 ########################################################################
 ol_analytics_api_domain = ol_analytics_api_config.require("domain")
 
+# Additional host(s) that also route to this service beyond the canonical
+# `domain`: the MIT Learn frontend consumes it under a Learn-scoped host
+# (`analytics.learn.mit.edu`) alongside the canonical `analytics.ol.mit.edu`.
+# Each host gets its own APISIX route (same backend + OIDC plugin) rather than
+# being folded into one route's host list, so HOST-based tenant routing or
+# host-specific plugins can be layered on later without restructuring; all
+# hosts share a single SAN certificate. A learn.mit.edu host only provisions
+# once `learn.mit.edu` is in the data cluster's `allowed_dns_zones` -- both the
+# external-dns domainFilter and the cert-manager DNS-01 solver selector read
+# that list (see infrastructure/aws/eks and substructure/aws/eks).
+ol_analytics_api_learn_domain = ol_analytics_api_config.get("learn_domain")
+ol_analytics_api_routes = [("ol-analytics-api", ol_analytics_api_domain)]
+if ol_analytics_api_learn_domain:
+    ol_analytics_api_routes.append(
+        ("ol-analytics-api-learn", ol_analytics_api_learn_domain)
+    )
+ol_analytics_api_hosts = [host for _, host in ol_analytics_api_routes]
+
 # Shared plugins (redirect http->https, cors, prometheus, opentelemetry, ...).
 ol_analytics_api_shared_plugins = OLApisixSharedPlugins(
     f"ol-analytics-api-{stack_info.env_suffix}-ol-shared-plugins",
@@ -477,7 +495,7 @@ ol_analytics_api_cert = OLCertManagerCert(
         k8s_labels=k8s_global_labels,
         create_apisixtls_resource=True,
         dest_secret_name="ol-analytics-api-tls",  # noqa: S106  # pragma: allowlist secret
-        dns_names=[ol_analytics_api_domain],
+        dns_names=ol_analytics_api_hosts,
     ),
 )
 
@@ -491,7 +509,7 @@ ol_analytics_api_route = OLApisixRoute(
     k8s_labels=k8s_global_labels,
     route_configs=[
         OLApisixRouteConfig(
-            route_name="ol-analytics-api",
+            route_name=route_name,
             priority=10,
             shared_plugin_config_name=ol_analytics_api_shared_plugins.resource_name,
             plugins=[
@@ -501,12 +519,13 @@ ol_analytics_api_route = OLApisixRoute(
                     )
                 ),
             ],
-            hosts=[ol_analytics_api_domain],
+            hosts=[host],
             paths=["/*"],
             backend_service_name=ol_analytics_api_k8s.application_lb_service_name,
             backend_service_port=ol_analytics_api_k8s.application_lb_service_port_name,
             backend_resolve_granularity="service",
-        ),
+        )
+        for route_name, host in ol_analytics_api_routes
     ],
     opts=ResourceOptions(
         delete_before_replace=True,

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.data.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.data.CI.yaml
@@ -7,6 +7,8 @@ config:
   - odl.mit.edu
   - .ol.mit.edu
   - ol.mit.edu
+  - .learn.mit.edu
+  - learn.mit.edu
   eks:backup: false
   eks:apisix_admin_key:
     secure: v1:alhS5zTWGpzPC3t3:QxvqqeD7zQ0zWxyKnnGWVRsmQwVx35NmdIaza5rI5re8+frp5OzpQZJR++4cfgzd13VBeNdOB1PM9Q3Z8hUaqGbjAhtclG6HSOg7z7tf3Ak=
@@ -16,7 +18,8 @@ config:
   - openlit-ci.ol.mit.edu
   - pipelines-ci.odl.mit.edu
   - opik-ci.ol.mit.edu
-  - analytics-ci.odl.mit.edu
+  - analytics-ci.ol.mit.edu
+  - analytics.ci.learn.mit.edu
   eks:apisix_viewer_key:
     secure: v1:ZFN4gG/xa7D+1wDe:qwerlKPydX7u54UjHLBvNUCT2Oha5e4EgXs5Uf+8tMOMUtf4yz/5SYy4rfpfls1HDMgroXWwRUY9U21sgKsGF+YJ5lexA+Fo9VSStrw9zPc=
   eks:stateful_workload_storage_backend: ebs

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.data.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.data.Production.yaml
@@ -17,7 +17,8 @@ config:
   - api-airbyte.odl.mit.edu
   - opik.ol.mit.edu
   - pipelines.odl.mit.edu
-  - analytics.odl.mit.edu
+  - analytics.ol.mit.edu
+  - analytics.learn.mit.edu
   eks:apisix_min_replicas: '3'
   eks:apisix_max_replicas: '10'
   eks:apisix_memory: 800Mi

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.data.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.data.Production.yaml
@@ -7,6 +7,8 @@ config:
   - odl.mit.edu
   - .ol.mit.edu
   - ol.mit.edu
+  - .learn.mit.edu
+  - learn.mit.edu
   eks:backup: true
   eks:apisix_admin_key:
     secure: v1:+4IwDMDzHiVsfnbo:vr+qOCr5SVJhBDoy0N8JL0Mw+1nrcOWNktlN5AKPCCLtAVIJfFWo8m/UJcje8esGgzIql50D/Wj7n8AX3K9zVzh1A6IAws/iZ2GW7B5D0Rw=

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.data.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.data.QA.yaml
@@ -7,6 +7,8 @@ config:
   - odl.mit.edu
   - .ol.mit.edu
   - ol.mit.edu
+  - .learn.mit.edu
+  - learn.mit.edu
   eks:backup: true
   eks:apisix_admin_key:
     secure: v1:7MeUlqKSTbqRovyg:d+PtadLdy5md0WQvYWbW3rBF5WHO4mvN69eXpegY72UNos0qGAoWBT/o6eSGxKsjZDllxfFpFEUvKUuOTpjQDl14cDW9khKyaTQFrpJq3WI=

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.data.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.data.QA.yaml
@@ -17,7 +17,8 @@ config:
   - api-airbyte-qa.odl.mit.edu
   - opik-qa.ol.mit.edu
   - pipelines-qa.odl.mit.edu
-  - analytics-qa.odl.mit.edu
+  - analytics-qa.ol.mit.edu
+  - analytics.rc.learn.mit.edu
   eks:apisix_viewer_key:
     secure: v1:FXn/5LA92VaA0LDu:+M5NNNgprjafZJTssawGZoRrI9ZEoiGKbRa3oVh4YjtZO4B5MLwXgfRvfWyY1zSbT0LJxxMJT90KQtWN3MsWobIseTYXLrdnPcpcYXY9lmg=
   eks:stateful_workload_storage_backend: ebs

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.CI.yaml
@@ -127,4 +127,5 @@ config:
   keycloak_realm:olapps-ol-analytics-api-client-secret:
     secure: v1:bo+niIekVjjm04zJ:3ef+tjDwt4wRLqmsuFtc8x8hY2ieUxHoBEEMjKv3x5eBJssLymnNPwXZE4oS+mnj11QdZ/Jb3YuzE6gwhele7SzoAadvnd1kKglQ8Oq45Ss=
   keycloak_realm:olapps-ol-analytics-api-redirect-uris:
-  - https://analytics-ci.odl.mit.edu/*
+  - https://analytics-ci.ol.mit.edu/*
+  - https://analytics.ci.learn.mit.edu/*

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.Production.yaml
@@ -31,7 +31,8 @@ config:
   - "https://learn-ai.ol.mit.edu/*"
   - "https://api-learn-ai.ol.mit.edu/*"
   keycloak_realm:olapps-learn-ai-client-roles: ["https://api-learn-ai.ol.mit.edu/*"]
-  keycloak_realm:olapps-ol-analytics-api-redirect-uris: ["https://analytics.odl.mit.edu/*"]
+  keycloak_realm:olapps-ol-analytics-api-redirect-uris: ["https://analytics.ol.mit.edu/*",
+    "https://analytics.learn.mit.edu/*"]
   keycloak_realm:olapps-mitlearn-client-redirect-uris:
   - "https://api.learn.mit.edu/*"
   - "https://learn.mit.edu/*"

--- a/src/ol_infrastructure/substructure/keycloak/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/substructure/keycloak/Pulumi.QA.yaml
@@ -35,7 +35,8 @@ config:
   - "https://learn-ai-qa.ol.mit.edu/*"
   - "https://api-learn-ai-qa.ol.mit.edu/*"
   keycloak_realm:olapps-learn-ai-client-roles: ["https://api-learn-ai-qa.ol.mit.edu/*"]
-  keycloak_realm:olapps-ol-analytics-api-redirect-uris: ["https://analytics-qa.odl.mit.edu/*"]
+  keycloak_realm:olapps-ol-analytics-api-redirect-uris: ["https://analytics-qa.ol.mit.edu/*",
+    "https://analytics.rc.learn.mit.edu/*"]
   keycloak_realm:olapps-mitlearn-client-redirect-uris:
   - "https://api.rc.learn.mit.edu/*"
   - "https://rc.learn.mit.edu/*"

--- a/src/ol_infrastructure/substructure/keycloak/olapps.py
+++ b/src/ol_infrastructure/substructure/keycloak/olapps.py
@@ -388,7 +388,16 @@ def create_olapps_realm(  # noqa: PLR0913, PLR0915
             access_type="CONFIDENTIAL",
             standard_flow_enabled=True,
             implicit_flow_enabled=False,
-            service_accounts_enabled=False,
+            # Service accounts (the client-credentials grant) are enabled so the
+            # same client can issue machine-to-machine tokens -- for automated
+            # smoke checks and any headless caller -- alongside the browser
+            # authorization-code flow the MIT Learn frontend uses. A
+            # client-credentials token carries no `organization` claim or user
+            # `sub`, so it cannot satisfy the org-manager endpoints (which
+            # additionally verify manager status against MITx Online); grant the
+            # service account the realm role the admin endpoints check
+            # (mit_contract_admin) to authorize those.
+            service_accounts_enabled=True,
             valid_redirect_uris=keycloak_realm_config.get_object(
                 "olapps-ol-analytics-api-redirect-uris"
             ),

--- a/src/ol_infrastructure/substructure/keycloak/olapps.py
+++ b/src/ol_infrastructure/substructure/keycloak/olapps.py
@@ -388,16 +388,7 @@ def create_olapps_realm(  # noqa: PLR0913, PLR0915
             access_type="CONFIDENTIAL",
             standard_flow_enabled=True,
             implicit_flow_enabled=False,
-            # Service accounts (the client-credentials grant) are enabled so the
-            # same client can issue machine-to-machine tokens -- for automated
-            # smoke checks and any headless caller -- alongside the browser
-            # authorization-code flow the MIT Learn frontend uses. A
-            # client-credentials token carries no `organization` claim or user
-            # `sub`, so it cannot satisfy the org-manager endpoints (which
-            # additionally verify manager status against MITx Online); grant the
-            # service account the realm role the admin endpoints check
-            # (mit_contract_admin) to authorize those.
-            service_accounts_enabled=True,
+            service_accounts_enabled=False,
             valid_redirect_uris=keycloak_realm_config.get_object(
                 "olapps-ol-analytics-api-redirect-uris"
             ),


### PR DESCRIPTION
## Problem

`analytics.odl.mit.edu` (prod) / `analytics-qa.odl.mit.edu` (qa) never resolved to the data-cluster APISIX ingress, so the public name served a **`*.odl.mit.edu` wildcart cert expired since Jun 2025** and external traffic never reached the service. This blocks an end-to-end smoke-check of the API (Keycloak/JWT + StarRocks `b2b_analytics` access).

The deployment itself is healthy — pods 2/2, readiness green, APISIX route / ApisixTls / cert all `Ready`. Two things were actually wrong:

1. **Wrong zone + un-owned record.** `analytics.odl.mit.edu` was already in `eks:apisix_domains`, and external-dns *did* try to register it — but external-dns runs `policy: sync` with TXT ownership and refuses to overwrite the **unowned legacy `ghs.googlehosted.com` record** sitting in the `odl.mit.edu` zone. So the host stayed pointed at Google.
2. The name lived in `odl.mit.edu` rather than the `ol.mit.edu` zone the sibling data-cluster apps use (`bi.ol.mit.edu`, `opik.ol.mit.edu`).

## How DNS registration actually works here

external-dns on the data cluster watches only the `service` + `gateway-*route` sources — it does **not** watch the `ApisixRoute` CRD this app uses. Hosts for ApisixRoute-based apps (analytics, opik) are registered from the `external-dns.alpha.kubernetes.io/hostname` annotation on the APISIX LoadBalancer Service, whose value is the **`eks:apisix_domains`** list (`infrastructure/aws/eks/apisix_official.py:451`). So the fix moves those names into `ol.mit.edu`/`learn.mit.edu` in **both** `apisix_domains` (registration) and `allowed_dns_zones` (external-dns domainFilter **and** the cert-manager DNS-01 ClusterIssuer solver, which both read that list).

Staying on `OLApisixRoute` + `apisix_domains` matches opik. A Gateway-API/HTTPRoute migration was considered and rejected: no repo precedent runs the APISIX `openid-connect` plugin on an HTTPRoute, and the v1alpha1 PluginConfig path HTTPRoutes use drops the `secretRef` that injects the OIDC client credentials.

## Change

**Canonical host → `ol.mit.edu`; add a Learn-scoped host** (multi-tenant; distinct named ApisixRoute per host, shared SAN cert + OIDC client, room for HOST-based tenant routing later):

| env | canonical | Learn-scoped |
|-----|-----------|--------------|
| prod | `analytics.ol.mit.edu` | `analytics.learn.mit.edu` |
| qa | `analytics-qa.ol.mit.edu` | `analytics.rc.learn.mit.edu` (Learn RC = `rc.learn.mit.edu`) |
| ci | `analytics-ci.ol.mit.edu` | `analytics.ci.learn.mit.edu` |

Applied consistently across:
- `applications/ol_analytics_api/Pulumi.{CI,QA,Production}.yaml` — `domain` + new `learn_domain`
- `applications/ol_analytics_api/__main__.py` — per-host ApisixRoute configs + SAN cert `dns_names`
- `infrastructure/aws/eks/Pulumi.data.{CI,QA,Production}.yaml` — `apisix_domains` (registration) + `allowed_dns_zones` (adds `learn.mit.edu`, enabling both external-dns and the cert-manager solver for the Learn host)
- `substructure/keycloak/Pulumi.{CI,QA,Production}.yaml` — redirect URIs

`learn.mit.edu` is a hosted zone in the same account; the external-dns / cert-manager IAM roles already permit `route53:ChangeResourceRecordSets` on all zones.

## Deploy ordering
1. `infrastructure.aws.eks` (data CI/QA/prod) — external-dns picks up new `apisix_domains` + `allowed_dns_zones`, re-exports the zone list
2. `substructure.aws.eks` (data QA/prod) — cert-manager ClusterIssuer solver picks up `learn.mit.edu`
3. `substructure.keycloak` (CI/QA/prod) — redirect URIs
4. `applications.ol_analytics_api` (QA/prod) — new hosts, routes, SAN cert

After deploy, external-dns creates the `ol.mit.edu` + `learn.mit.edu` records at the APISIX NLB and cert-manager issues the SAN cert; the end-to-end smoke-check can then run.

## Out of scope / follow-up

**Machine-to-machine auth** was explored and pulled from this PR. Fully authorizing a client-credentials caller against the admin endpoints is a three-part, security-sensitive change: the `mit_contract_admin` realm role does not yet exist in Keycloak (only the app expects it), it would need assigning to the client's service account, and the APISIX route would need a `bearer_only` variant to honor a client-credentials token. Tracked as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)