### PR TITLE
Add MITOL_API_BASE_URL to mit-learn

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1218,7 +1218,7 @@ env_vars = {
     "LITELLM_TOKEN_ENCODING_NAME": "cl100k_base",
     "MICROMASTERS_CMS_API_URL": "https://micromasters.mit.edu/api/v0/wagtail/",
     "MITOL_ADMIN_EMAIL": "cuddle-bunnies@mit.edu",
-    "MITOL_API_BASE_URL": f"https://{mitlearn_api_domain}/",
+    "MITOL_API_BASE_URL": f"https://{mitlearn_api_domain}",
     "MITOL_AXIOS_BASE_PATH": f"https://{mitlearn_config.get('frontend_domain')}",
     "MITOL_DB_CONN_MAX_AGE": 0,
     "MITOL_DB_DISABLE_SSL": "True",

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1218,6 +1218,7 @@ env_vars = {
     "LITELLM_TOKEN_ENCODING_NAME": "cl100k_base",
     "MICROMASTERS_CMS_API_URL": "https://micromasters.mit.edu/api/v0/wagtail/",
     "MITOL_ADMIN_EMAIL": "cuddle-bunnies@mit.edu",
+    "MITOL_API_BASE_URL": f"https://{mitlearn_api_domain}/",
     "MITOL_AXIOS_BASE_PATH": f"https://{mitlearn_config.get('frontend_domain')}",
     "MITOL_DB_CONN_MAX_AGE": 0,
     "MITOL_DB_DISABLE_SSL": "True",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
N/A

### Description (What does it do?)
<!--- Describe your changes in detail -->
It looks like we've had this setting but it was unused since we got rid of direct OIDC login from the django app, but the variable was [still in `settings.py`](https://github.com/mitodl/mit-learn/blob/main/main/settings.py#L235) so I though we were setting it in deployments. The TLDR is that certain operations, particularly celery tasks, need to be able to generate an absolute URL to the server when they don't have an existing request from which to derive the domain.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Only way to test this is by sending a specific email from a test system, so we should deploy to RC and test it there.