### PR TITLE
fix(s3): remove archive tiers from buckets with synchronous readers

### DIFF
--- a/src/ol_infrastructure/applications/clickhouse/__main__.py
+++ b/src/ol_infrastructure/applications/clickhouse/__main__.py
@@ -681,6 +681,8 @@ cold_bucket_config = S3BucketConfig(
     sse_algorithm="AES256",
     intelligent_tiering_enabled=True,
     intelligent_tiering_days=1,  # Move to Intelligent-Tiering immediately
+    intelligent_tiering_archive_access_days=None,
+    intelligent_tiering_deep_archive_access_days=None,
     # ClickHouse issues synchronous S3 reads against this disk for any query
     # that touches a cold part, so archive tiers (which require an explicit
     # restore before the object is readable) are not safe here even though

--- a/src/ol_infrastructure/applications/clickhouse/__main__.py
+++ b/src/ol_infrastructure/applications/clickhouse/__main__.py
@@ -681,9 +681,10 @@ cold_bucket_config = S3BucketConfig(
     sse_algorithm="AES256",
     intelligent_tiering_enabled=True,
     intelligent_tiering_days=1,  # Move to Intelligent-Tiering immediately
-    # ClickHouse cold storage is never user-facing: safe for archive tiers.
-    intelligent_tiering_archive_access_days=90,
-    intelligent_tiering_deep_archive_access_days=180,
+    # ClickHouse issues synchronous S3 reads against this disk for any query
+    # that touches a cold part, so archive tiers (which require an explicit
+    # restore before the object is readable) are not safe here even though
+    # the bucket itself is never user-facing.
 )
 
 cold_bucket = OLBucket(

--- a/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
@@ -148,9 +148,14 @@ for data_stage in data_stages:
             kms_key_id=s3_kms_key["arn"],
             bucket_key_enabled=True,
             tags=aws_config.merged_tags({"OU": "data"}),
-            # Data lake storage is analytical cold storage: safe for archive tiers.
-            intelligent_tiering_archive_access_days=90,
-            intelligent_tiering_deep_archive_access_days=180,
+            # Archive/deep-archive tiers disabled: StarRocks queries every
+            # stage's Iceberg/Glue catalog directly (data_lake_query_engine
+            # IAM policy grants it uniform read access across all stages),
+            # and archived objects raise InvalidObjectState until explicitly
+            # restored. There's no stage here that's exempt from ad-hoc BI
+            # queries, so none can safely age into an archive tier.
+            intelligent_tiering_archive_access_days=None,
+            intelligent_tiering_deep_archive_access_days=None,
         ),
         opts=ResourceOptions(
             aliases=[


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
We hit production incidents where objects in S3 buckets were transitioned to an archive storage tier (GLACIER/DEEP_ARCHIVE) by a lifecycle rule, and something tried to read those objects synchronously — which fails with `InvalidObjectState` until an explicit restore completes (minutes to hours).

A follow-up audit of every S3 bucket with archive-tier lifecycle rules in this codebase found two more buckets with the same footgun:

- **ClickHouse cold-storage bucket** (`ol-data-clickhouse-cold-*`, `applications/clickhouse/__main__.py`) — this is ClickHouse's own S3-backed disk in a hot/cold tiered storage policy. ClickHouse issues synchronous S3 `GetObject` calls against this disk whenever a query touches a "cold" part. The existing comment ("never user-facing: safe for archive tiers") conflates "not CDN/web-facing" with "not synchronously read," which doesn't hold here — any query over data untouched for 90+ days (a yearly report, an ad-hoc historical debug query) would fail.
- **Data-lake stage buckets** (`ol-data-lake-{raw,staging,intermediate,mart,integrations,external,dimensional,reporting}-*`, `infrastructure/aws/data_warehouse/__main__.py`) — StarRocks queries every stage's Iceberg/Glue catalog directly via the `data_lake_query_engine` IAM policy, which grants uniform read access across all 8 stages. There's no split between "hot" and "cold" stages here, so none of them can safely age into an archive tier.

This PR removes the `intelligent_tiering_archive_access_days`/`intelligent_tiering_deep_archive_access_days` opt-in for both, matching the reasoning already applied to the data-lake landing-zone bucket in the same file. Regular Intelligent-Tiering (Frequent/Infrequent Access, always instant-retrieval) stays enabled — only the archive-tier opt-in is removed.

The third bucket flagged by the audit (`edxorg-courses`, used as an export landing zone before data moves to the data-lake landing zone) was left as-is since it's expected to stay mostly empty.

### How can this be tested?
`pulumi preview --diff` was run against the CI stack for both affected Pulumi projects (`applications/clickhouse`, `infrastructure/aws/data_warehouse`). In both cases the only planned changes are deletions of the `aws:s3/bucketIntelligentTieringConfiguration:BucketIntelligentTieringConfiguration` resources carrying the archive/deep-archive tiering rules — no bucket, object, or other resource is affected.

### Additional Context
`pre-commit` (ruff format/check, mypy) passes on both changed files.