### PR TITLE
fix(concourse): make release-resource finish step tolerant of retriggers

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
@@ -1266,7 +1266,7 @@ def _build_release_resource_app_pipeline(
             },
         ),
     ]
-    prod_post_steps: list[GetStep | PutStep | TaskStep] = [
+    prod_post_steps: list[GetStep | PutStep | TaskStep | TryStep] = [
         # Mark the Production GitHub Deployment as successful.
         PutStep(
             put=deployment_prod.name,
@@ -1277,17 +1277,27 @@ def _build_release_resource_app_pipeline(
             },
         ),
         # Merge the release branch back into the main branch and delete it so
-        # subsequent check calls no longer see a release as in-flight.
-        PutStep(
-            put=release_res.name,
-            params={
-                "action": "finish",
-                "repo_dir": str(main_repo.name),
-                "version_file": f"{release_res.name}/version",
-            },
+        # subsequent check calls no longer see a release as in-flight. Wrapped
+        # in a try since this job can be retriggered by an infra-only merge
+        # (QA re-runs on any change under the watched Pulumi paths, and its
+        # release_issue put edits the already-closed release_gate issue,
+        # which Concourse's version="every" get treats as a new trigger for
+        # this job) with no new app release -- the finish action then tries
+        # to fetch a release branch that a prior successful finish already
+        # deleted, and fails every time. That failure is safe to swallow:
+        # the release was already finished, there's nothing left to do.
+        TryStep(
+            try_=PutStep(
+                put=release_res.name,
+                params={
+                    "action": "finish",
+                    "repo_dir": str(main_repo.name),
+                    "version_file": f"{release_res.name}/version",
+                },
+            )
         ),
     ]
-    additional_post_steps: dict[int, list[GetStep | PutStep | TaskStep]] = {
+    additional_post_steps: dict[int, list[GetStep | PutStep | TaskStep | TryStep]] = {
         0: qa_post_steps,
         1: prod_post_steps,
     }

--- a/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
@@ -1241,7 +1241,7 @@ def _build_release_resource_app_pipeline(
     )
 
     # Build per-stack additional_post_steps and custom_dependencies for QA+Production
-    qa_post_steps: list[GetStep | PutStep | TaskStep] = [
+    qa_post_steps: list[GetStep | PutStep | TaskStep | TryStep] = [
         # Open a GitHub Release Issue with the checklist from the release resource.
         # title_template embeds the release version (via the image_tag var
         # loaded from release_res earlier in this job's plan) so each release


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
The `ol-analytics-api-pipeline` Production deploy job (https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py#L1281-L1288) started failing after an infra-only merge to `ol-infrastructure` (no new `ol-analytics-api` app release) — build: https://cicd.odl.mit.edu/teams/infrastructure/pipelines/ol-analytics-api-pipeline/jobs/deploy-ol-application-ol-analytics-api-production/builds/3

Root cause: `ol-analytics-api` is currently the only app on the modernized `use_release_resource_workflow=True` pipeline shape. Its QA stage's infra-repo `Get` triggers on any merge under the watched Pulumi paths, independent of a new app release. QA's `release_issue` `put` then edits the already-closed `release_gate` GitHub issue; since that gate is fetched with `version="every"`, Concourse treats the in-place edit as a new version and re-triggers Production. Production resolves `release_res`/`app_rc_image` back to the same already-finished version (via `passed=[...]`), so the Pulumi deploy itself is a harmless no-op — but the post-step's `release_res` `finish` `PutStep` unconditionally tries to `git fetch` the release branch that a prior successful `finish` already deleted, so it fails with:

```
[git stderr] fatal: couldn't find remote ref refs/heads/releases/2026.7.22.1
...
subprocess.CalledProcessError: Command '['git', 'fetch', 'origin', 'main', '+refs/heads/releases/2026.7.22.1:refs/remotes/origin/releases/2026.7.22.1']' returned non-zero exit status 128.
```

The `mitodl/concourse-release-resource` `finish` action has no idempotency, so this will fail identically on every future infra-only merge that touches this app's Pulumi program.

Fix: wrap the `release_res` finish `PutStep` in a `TryStep`, mirroring the existing pattern already used in this same file for the non-critical Sentry sourcemaps upload (`_sentry_js_sourcemaps_upload_step`, "Wrapped in a try so a failed upload never blocks the release"). A finish against an already-finished release has nothing left to do, so swallowing the failure is safe — the deployment itself already succeeded.

### How can this be tested?
Generated the pipeline definition locally and confirmed the step now renders wrapped in `try`:

```
$ python3 -m ol_concourse.pipelines.infrastructure.k8s_apps.pipeline ol-analytics-api
```

```json
{
  "try": {
    "params": {
      "action": "finish",
      "repo_dir": "ol-analytics-api-main",
      "version_file": "ol-analytics-api-release/version"
    },
    "put": "ol-analytics-api-release"
  }
}
```

Ran `ruff check` on the modified file (passed) and the repo's pre-commit hooks (ruff format/check, mypy — all passed). No dedicated unit tests exist for this pipeline generator module.

Once merged and the pipeline is re-set (`fly set-pipeline`), a reviewer can confirm by re-running the Production job on this pipeline and verifying it now succeeds even when triggered without a new app release.

### Additional Context
This only affects `ol-analytics-api` today, since it's the sole app currently opted into `use_release_resource_workflow=True`. Any other app that adopts this pipeline shape in the future will inherit the same fix automatically, since the guard lives in the shared `_build_release_resource_app_pipeline` generator rather than per-app config.