### PR TITLE
fix(vault): flatten StarRocks Vault database mount to a single non-env-scoped path

### DIFF
--- a/src/ol_infrastructure/applications/dagster/dagster_server_policy.hcl
+++ b/src/ol_infrastructure/applications/dagster/dagster_server_policy.hcl
@@ -1,4 +1,4 @@
-path "database-starrocks-production/creds/*" {
+path "database-starrocks/creds/*" {
   capabilities = ["read", "list"]
 }
 

--- a/src/ol_infrastructure/applications/ol_analytics_api/__main__.py
+++ b/src/ol_infrastructure/applications/ol_analytics_api/__main__.py
@@ -29,7 +29,7 @@ Key wiring decisions (see also ``k8s/README.md`` in the app repo):
   has the vault-secrets-operator sync a static-ish StarRocks credential into a
   K8s Secret), ``core/db/vault_credentials.py`` does a direct ``hvac``
   Kubernetes login using the pod's own ServiceAccount token and reads
-  ``database-starrocks-{env}/creds/app`` at startup.  So there is no DB Secret
+  ``database-starrocks/creds/app`` at startup.  So there is no DB Secret
   to sync here — instead the Vault policy attached to this service's Kubernetes
   auth role must grant read on that dynamic-credentials path.  The Vault role
   name, k8s auth mount, and StarRocks mount are handed to the app as
@@ -155,11 +155,12 @@ cluster_stack.require_output("namespaces").apply(
     lambda ns: check_cluster_namespace(APPLICATION_NAMESPACE, ns)
 )
 
-# StarRocks dynamic-credentials mount is environment-specific.  StarRocks only
-# exists on the QA and Production data clusters (setup_starrocks skips CI), and
-# this service fetches its StarRocks creds from Vault at startup, so it is
-# deployed to QA and Production only -- there is no CI stack.
-starrocks_vault_mount_path = f"database-starrocks-{stack_info.env_suffix}"
+# StarRocks exists on the QA and Production data clusters only (setup_starrocks
+# skips CI), so this service is deployed to QA and Production only -- there is
+# no CI stack. The mount name itself is not environment-specific: QA and
+# Production each run their own, entirely separate Vault deployment, so that
+# server (not the mount path) is what scopes the environment.
+starrocks_vault_mount_path = "database-starrocks"
 
 ########################################################################
 # IRSA + Vault Kubernetes auth via OLEKSAuthBinding

--- a/src/ol_infrastructure/applications/ol_analytics_api/ol_analytics_api_policy.hcl
+++ b/src/ol_infrastructure/applications/ol_analytics_api/ol_analytics_api_policy.hcl
@@ -4,15 +4,17 @@
 #   * ol-analytics-api        - the app pod itself, which does a direct hvac
 #                               Kubernetes login and reads its short-lived
 #                               StarRocks credentials from
-#                               database-starrocks-{env}/creds/app.
+#                               database-starrocks/creds/app.
 #   * ol-analytics-api-vault  - the vault-secrets-operator ServiceAccount that
 #                               syncs the APISIX OIDC client secret and the
 #                               static application secrets (SENTRY_DSN) into
 #                               Kubernetes Secrets.
 #
-# The environment-specific StarRocks dynamic-credentials path is appended to
-# this base policy at deploy time (see __main__.py), matching the pattern used
-# by superset_server_policy.hcl, because the mount name carries the env suffix.
+# The StarRocks dynamic-credentials path is appended to this base policy at
+# deploy time (see __main__.py), matching the pattern used by
+# superset_server_policy.hcl. The mount name itself is fixed (not
+# environment-specific) since QA and Production each run their own, entirely
+# separate Vault deployment.
 
 # APISIX OIDC (Keycloak) client config consumed by OLApisixOIDCResources.
 path "secret-operations/sso/ol-analytics-api" {

--- a/src/ol_infrastructure/applications/superset/__main__.py
+++ b/src/ol_infrastructure/applications/superset/__main__.py
@@ -165,10 +165,12 @@ superset_parliament_config: dict[str, Any] = {
 
 _POLICY_DIR = Path(__file__).parent
 
-# StarRocks dynamic DB mount is environment-specific; build the Vault policy
-# text dynamically so the exact mount path is baked in without wildcards.
-# StarRocks only has QA and Production substructure stacks, so skip on CI.
-starrocks_vault_mount_path = f"database-starrocks-{stack_info.env_suffix}"
+# Build the Vault policy text dynamically so the exact mount path is baked in
+# without wildcards. StarRocks only has QA and Production substructure stacks,
+# so skip on CI. The mount name is not environment-specific: QA and Production
+# each run their own, entirely separate Vault deployment, so that server (not
+# the mount path) is what scopes the environment.
+starrocks_vault_mount_path = "database-starrocks"
 if stack_info.name != "CI":
     _base_vault_policy = (_POLICY_DIR / "superset_server_policy.hcl").read_text(
         encoding="utf-8"

--- a/src/ol_infrastructure/substructure/starrocks/__main__.py
+++ b/src/ol_infrastructure/substructure/starrocks/__main__.py
@@ -52,7 +52,11 @@ stack_info = parse_stack()
 starrocks_config = Config("starrocks")
 
 env_name = f"data-{stack_info.env_suffix}"
-mount_point = f"database-starrocks-{stack_info.env_suffix}"
+# Each environment (dev/qa/ci/production) runs its own, entirely separate Vault
+# deployment (vault-qa.odl.mit.edu, vault-production.odl.mit.edu, ...), so the
+# mount path itself doesn't need an env suffix -- the Vault server it lives in
+# already provides that scoping.
+mount_point = "database-starrocks"
 
 cluster_stack = make_stack_reference(pulumi_projects.EKS, f"data.{stack_info.name}")
 _kube_config_raw = require_stack_output_value(cluster_stack, "kube_config")


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
The Dagster `b2b_analytics` StarRocks dbt job was failing in QA with:

```
hvac.exceptions.Forbidden: 1 error occurred:
    * permission denied
, on get https://vault-qa.odl.mit.edu/v1/database-starrocks-qa/creds/admin
```

`dagster_server_policy.hcl` only granted `database-starrocks-production/creds/*`, so QA/dev/CI Dagster (which read from a `database-starrocks-qa` mount) had no matching policy path.

Rather than just patching in the missing QA path, this drops the per-env suffix entirely. QA/Production/CI each run their own, completely separate Vault deployment (`vault-qa.odl.mit.edu`, `vault-production.odl.mit.edu`, `vault-ci.odl.mit.edu` — confirmed from each stack's `Pulumi.*.yaml` `vault:address` config), so the Vault server itself already scopes the environment. The mount path doesn't need to duplicate that scoping.

Changes:
- `substructure/starrocks/__main__.py` — Vault database secrets engine mount is now the literal `"database-starrocks"` (was `f"database-starrocks-{stack_info.env_suffix}"`)
- `applications/dagster/dagster_server_policy.hcl` — single `database-starrocks/creds/*` path (was two separate `-production`/`-qa` paths)
- `applications/ol_analytics_api/__main__.py` + `ol_analytics_api_policy.hcl` — mount path and comments updated to match
- `applications/superset/__main__.py` — same

Companion change in `ol-data-platform` (dg_projects/lakehouse, `bin/starrocks-auth`, `ol_dbt_cli`) updates the consumer side to match: https://github.com/mitodl/ol-data-platform/pull/2477#TODO

### How can this be tested?
- `uv run pre-commit run --all-files` and `uv run mypy` pass on all changed files.
- `pulumi preview --diff` run against the QA stacks for all four affected Pulumi programs:
  - `substructure/starrocks` (`lakehouse.QA`): shows the Vault `Mount` resource updating `path` in place from `database-starrocks-qa` → `database-starrocks`, plus the DB connection `Secret` and the three `SecretBackendRole`s (readonly/app/admin) forced to replace (expected — their `path`/`backend` attributes aren't independently updatable). No other resources affected.
  - `applications/dagster` (`QA`): `vault:index/policy:Policy` updates in place, diff shows only the `database-starrocks-production/creds/*` → `database-starrocks/creds/*` path change.
  - `applications/superset` (`QA`): same — `Policy` updates in place, plus the `VaultDynamicSecret` CRD's `spec.mount` field updates from `database-starrocks-qa` → `database-starrocks`.
  - `applications/ol_analytics_api` (`QA`): policy diff shows the expected path/comment changes (preview errored afterward on an unrelated missing `OL_ANALYTICS_API_DOCKER_TAG` env var in this environment, not caused by this change).

### Additional Context
**Rollout order matters** and this PR should not be applied blind:
1. Apply `substructure/starrocks` first for each of QA and Production — this renames the mount and recreates the DB connection config + roles at the new path.
2. Then apply `applications/dagster`, `applications/superset`, and `applications/ol_analytics_api` for QA and Production — Vault re-evaluates policy content per-request, so already-running pods pick up the new grants without needing a restart.

Also noticed but **not touched** in this PR: `bin/starrocks-auth` and `ol_dbt_cli`'s `"ci"` environment entries point `vault_addr` at `vault-qa.odl.mit.edu`, while the real `substructure/starrocks` CI stack (`Pulumi.lakehouse.CI.yaml`) deploys against `vault-ci.odl.mit.edu`. That mismatch predates this change and is unrelated to the StarRocks Vault QA failure being fixed here — flagging for a separate look.
