### PR TITLE
fix(concourse): diversify CI/QA worker spot capacity, add on-demand floor everywhere

### DIFF
--- a/src/ol_infrastructure/applications/concourse/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/applications/concourse/Pulumi.CI.yaml
@@ -38,6 +38,11 @@ config:
     - pulumi_state
     instance_type: t3a.medium
     name: ocw
+    spot_options:
+      instance_type_overrides:
+      - t3.medium
+      - t2.medium
+      on_demand_base_capacity: 1
   - auto_scale:
       desired: 1
       max: 2
@@ -55,6 +60,11 @@ config:
     - pulumi_state
     instance_type: t3a.medium
     name: infra
+    spot_options:
+      instance_type_overrides:
+      - t3.medium
+      - t2.medium
+      on_demand_base_capacity: 1
   - auto_scale:
       desired: 1
       max: 2
@@ -62,7 +72,6 @@ config:
       max_instance_lifetime_seconds: 86400
     aws_tags:
       OU: operations
-    desired_capacity: 2
     disk_size_gb: 100
     iam_policies:
     - base
@@ -70,6 +79,11 @@ config:
     - pulumi_state
     instance_type: t3a.medium
     name: generic
+    spot_options:
+      instance_type_overrides:
+      - t3.medium
+      - t2.medium
+      on_demand_base_capacity: 1
   consul:address: https://consul-operations-ci.odl.mit.edu
   vault:address: https://vault-ci.odl.mit.edu
   vault_server:env_namespace: operations.ci

--- a/src/ol_infrastructure/applications/concourse/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/concourse/Pulumi.Production.yaml
@@ -45,6 +45,7 @@ config:
       - m6a.2xlarge
       - m5a.2xlarge
       - m5.2xlarge
+      on_demand_base_capacity: 1
     use_spot_instances: true
   - auto_scale:
       desired: 4
@@ -71,6 +72,7 @@ config:
       - m6a.4xlarge
       - m5a.4xlarge
       - m5.4xlarge
+      on_demand_base_capacity: 1
     use_spot_instances: true
   - auto_scale:
       desired: 4
@@ -93,6 +95,7 @@ config:
       - m6a.xlarge
       - m5a.xlarge
       - m5.xlarge
+      on_demand_base_capacity: 1
     use_spot_instances: true
   consul:address: https://consul-operations-production.odl.mit.edu
   vault:address: https://vault-production.odl.mit.edu

--- a/src/ol_infrastructure/applications/concourse/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/concourse/Pulumi.QA.yaml
@@ -39,6 +39,13 @@ config:
     - pulumi_state
     instance_type: general_purpose_xlarge
     name: ocw
+    spot_options:
+      instance_type_overrides:
+      - m7i.xlarge
+      - m6a.xlarge
+      - m5a.xlarge
+      - m5.xlarge
+      on_demand_base_capacity: 1
   - auto_scale:
       desired: 2
       max: 2
@@ -56,6 +63,11 @@ config:
     - pulumi_state
     instance_type: burstable_medium
     name: infra
+    spot_options:
+      instance_type_overrides:
+      - t3.medium
+      - t2.medium
+      on_demand_base_capacity: 1
   - auto_scale:
       desired: 2
       max: 2
@@ -70,6 +82,11 @@ config:
     - pulumi_state
     instance_type: burstable_medium
     name: generic
+    spot_options:
+      instance_type_overrides:
+      - t3.medium
+      - t2.medium
+      on_demand_base_capacity: 1
   consul:address: https://consul-operations-qa.odl.mit.edu
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa

--- a/src/ol_infrastructure/applications/concourse/__main__.py
+++ b/src/ol_infrastructure/applications/concourse/__main__.py
@@ -734,6 +734,7 @@ for worker_def in concourse_config.get_object("workers") or []:
             spot_allocation_strategy=spot_config.get(
                 "spot_allocation_strategy", "price-capacity-optimized"
             ),
+            on_demand_base_capacity=spot_config.get("on_demand_base_capacity", 0),
         )
 
     ol_worker_launch_config = OLLaunchTemplateConfig(

--- a/src/ol_infrastructure/components/aws/auto_scale_group.py
+++ b/src/ol_infrastructure/components/aws/auto_scale_group.py
@@ -97,6 +97,11 @@ class SpotInstanceOptions(BaseModel):
         "capacity-optimized-prioritized",
         "price-capacity-optimized",
     ] = "price-capacity-optimized"
+    # Guaranteed number of on-demand instances the ASG maintains as a floor,
+    # independent of spot capacity. Only takes effect when instance_type_overrides
+    # is also set (MixedInstancesPolicy is required for on_demand_base_capacity to
+    # apply). Capacity above this floor still fills from spot.
+    on_demand_base_capacity: NonNegativeInt = NonNegativeInt(0)
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @field_validator("spot_instance_type")
@@ -560,6 +565,7 @@ class OLAutoScaling(pulumi.ComponentResource):
                         overrides=overrides,
                     ),
                     instances_distribution=GroupMixedInstancesPolicyInstancesDistributionArgs(
+                        on_demand_base_capacity=mixed_spot_options.on_demand_base_capacity,
                         on_demand_percentage_above_base_capacity=0,
                         spot_allocation_strategy=mixed_spot_options.spot_allocation_strategy,
                         spot_max_price=mixed_spot_options.max_price,


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
CI Concourse worker pools (ocw/infra/generic) were pinned to a single spot instance type (`t3a.medium`) with no fallback. As of this writing, AWS is failing every launch attempt for `t3a.medium` across multiple us-east-1 AZs ("no spot capacity" / per-AZ capacity errors), so the CI `infra` and `generic` ASGs are sitting at 0 running instances despite `desired=1` — CI has effectively no workers right now.

https://github.com/mitodl/ol-infrastructure/commit/fdb9e6ae53c636ab348a2f6c4d5afa158e9687b9 (#4923, 2026-07-07) already solved exactly this class of problem for Production via `spot_options.instance_type_overrides` + a `MixedInstancesPolicy` (`price-capacity-optimized` allocation), but it was only ever wired into `Pulumi.Production.yaml`. CI and QA never got the equivalent block, so they remained exactly as exposed to a single-instance-type spot shortage as Production was before that fix.

This PR:
- Adds `spot_options.instance_type_overrides` to every CI and QA worker pool: `t3.medium`/`t2.medium` alternates for the `t3a.medium` burstable pools, and the same `m7i`/`m6a`/`m5a`/`m5.xlarge` set Production already uses, applied to QA's `ocw` pool (`m7a.xlarge`).
- Adds a new `on_demand_base_capacity` field on `SpotInstanceOptions` (`src/ol_infrastructure/components/aws/auto_scale_group.py`), wired into `GroupMixedInstancesPolicyInstancesDistributionArgs`, and sets it to `1` on every worker pool in every environment — including Production, which had diversification but no on-demand floor. Under a genuine capacity crunch across every candidate spot type/family, each pool now keeps a guaranteed single on-demand worker; capacity above that floor still fills from spot.
- Removes a stale, unused `desired_capacity: 2` key on CI's `generic` pool. `__main__.py` only ever reads `worker_def["auto_scale"]["desired"]`, so this key was dead config left over from an earlier edit and didn't do anything.

### Screenshots (if appropriate):
N/A

### How can this be tested?
`pulumi preview` was run against all three stacks and shows clean in-place updates, no resource replacements:
- CI: 7 to update, 93 unchanged
- QA: 7 to update, 100 unchanged
- Production: 4 to update, 126 unchanged (just `onDemandBaseCapacity: 0 => 1` on the existing mixed-instance ASGs)

Reviewer can re-run `pulumi preview` on each stack to confirm. Pre-commit (ruff/mypy/yamllint/format) all pass.

### Additional Context
Live AWS state at the time of writing (`aws autoscaling describe-scaling-activities`) showed CI's `infra` and `generic` ASGs repeatedly failing to launch `t3a.medium` spot instances over ~90 minutes with errors like:
- `There is no Spot capacity available that matches your request.`
- `We currently do not have sufficient t3a.medium capacity in the Availability Zone you requested (us-east-1{b,c,d})`

This PR is the direct fix for that outage plus the same hardening for QA and an added on-demand safety floor for Production.