### PR TITLE
fix(superset): validate JWT audience/issuer to block cross-client Keycloak tokens

### DIFF
--- a/src/ol_infrastructure/applications/superset/superset_config.py
+++ b/src/ol_infrastructure/applications/superset/superset_config.py
@@ -80,6 +80,16 @@ OAUTH_PROVIDERS = [
 # ----------------------------------------------------------
 JWT_ALGORITHM = "RS256"
 JWT_PUBLIC_KEY = OIDC_REALM_PUBLIC_KEY
+# The realm public key signs the access tokens of EVERY client in the shared
+# ol-data-platform realm, so a signature check alone would accept a token minted
+# for any other client (e.g. the public ol-starrocks-cli PKCE client). Bind
+# acceptance to tokens whose `aud` includes Superset's own OIDC client and whose
+# `iss` is our realm, rejecting cross-client tokens. Requires the Keycloak
+# AudienceProtocolMapper on the Superset client (see
+# substructure/keycloak/ol_data_platform.py) so legitimate Superset tokens carry
+# this client id in `aud`.
+JWT_DECODE_AUDIENCE = OIDC_CLIENT_ID
+JWT_DECODE_ISSUER = OIDC_URL
 
 # Map Keycloak realm roles to Superset roles.
 # ol_platform_admin → built-in Admin (full privileges).
@@ -128,17 +138,14 @@ class CustomSsoSecurityManager(SupersetSecurityManager):
         a role like ``ol_platform_admin`` is expanded to ``["Admin"]`` regardless
         of which authentication flow the user arrives through.
 
-        Any key not present in AUTH_ROLES_MAPPING is passed through unchanged,
-        which allows Superset role names to be placed directly in tokens when
-        needed.
+        Keys not present in AUTH_ROLES_MAPPING are dropped rather than passed
+        through, so only the curated realm role vocabulary can ever resolve to a
+        Superset role. This prevents a token-supplied key from naming a Superset
+        role (e.g. ``Admin``) directly.
         """
         expanded: list[str] = []
         for role_key in role_keys:
-            mapped = AUTH_ROLES_MAPPING.get(role_key)
-            if mapped:
-                expanded.extend(mapped)
-            else:
-                expanded.append(role_key)
+            expanded.extend(AUTH_ROLES_MAPPING.get(role_key, []))
         return expanded
 
     def _get_roles_from_keycloak_roles(self, role_keys: list[str]) -> list[object]:

--- a/src/ol_infrastructure/substructure/keycloak/ol_data_platform.py
+++ b/src/ol_infrastructure/substructure/keycloak/ol_data_platform.py
@@ -348,6 +348,24 @@ def create_ol_data_platform_realm(  # noqa: C901, PLR0912, PLR0913, PLR0915
         opts=resource_options,
     )
 
+    # The realm public key signs every client's tokens, so Superset's JWT auth
+    # (JWT_DECODE_AUDIENCE=ol-superset-client) needs its own client id in the
+    # `aud` claim to distinguish its tokens from those minted for other realm
+    # clients. Keycloak omits the client from `aud` by default, so add it
+    # explicitly for all tokens issued through this client, including the
+    # service-account client_credentials token used for API access.
+    # See https://issues.redhat.com/browse/KEYCLOAK-6638
+    keycloak.openid.AudienceProtocolMapper(
+        "ol-data-platform-superset-audience-mapper",
+        realm_id=ol_data_platform_realm.id,
+        client_id=ol_data_platform_superset_client.id,
+        name="audience",
+        included_client_audience=ol_data_platform_superset_client.client_id,
+        add_to_id_token=True,
+        add_to_access_token=True,
+        opts=resource_options,
+    )
+
     keycloak.openid.ClientDefaultScopes(
         "ol-data-platform-superset-client-default-scopes",
         realm_id=ol_data_platform_realm.id,


### PR DESCRIPTION
## What & Why

Security review finding (Medium, p1): Superset's REST API JWT auth verified JWTs **only** by RS256 signature against the shared `ol-data-platform` realm public key, with **no audience or issuer check**. Since Keycloak signs every realm client's tokens with the same key, a token minted for *any* other client passed Superset's signature check.

**Exploit:** a user entitled only to StarRocks authenticates via the public `ol-starrocks-cli` PKCE client, gets a realm token, and sends it as `Authorization: Bearer` to Superset's REST API. The token is accepted despite being for a different client; Superset auto-provisions the account and maps `role_keys=["ol_platform_admin"]` → built-in `Admin` ⇒ full Superset admin.

## Changes

1. **`superset_config.py`** — set `JWT_DECODE_AUDIENCE = OIDC_CLIENT_ID` (`ol-superset-client`) and `JWT_DECODE_ISSUER = OIDC_URL` (the realm URL). flask-jwt-extended now rejects tokens whose `aud`/`iss` don't match Superset's own client/realm.
2. **`substructure/keycloak/ol_data_platform.py`** — add an `AudienceProtocolMapper` to the Superset client so legitimate tokens (including the service-account `client_credentials` token used for API access) carry `ol-superset-client` in `aud`. Keycloak omits the client from `aud` by default ([KEYCLOAK-6638](https://issues.redhat.com/browse/KEYCLOAK-6638)); this mirrors the existing pattern in `ol_mit.py`.
3. **`superset_config.py`** — drop the unknown-`role_keys` passthrough in `_expand_role_keys` so only the curated `AUTH_ROLES_MAPPING` vocabulary can resolve to a Superset role (defense-in-depth).

## Deployment ordering

Deploy the **`substructure/keycloak`** stack first (adds the audience mapper), then the **`applications/superset`** stack (starts requiring the audience). The Superset service account already holds the `ol_platform_admin` client role, so Keycloak's default Audience Resolve mapper already tends to include `ol-superset-client` in its `aud`, making the transition resilient — but the explicit mapper guarantees it.

## Follow-up

Gating auto-provisioning (`AUTH_USER_REGISTRATION`) behind an explicit allow-list claim is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)