### PR TITLE
feat(concourse): reorganize odl-prod pipeline dashboard (Phase 1)

### DIFF
--- a/bin/concourse-order-pipelines
+++ b/bin/concourse-order-pipelines
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+# ruff: noqa: T201
+"""Apply a curated, semantic display order to Concourse dashboard tiles.
+
+Concourse 8.2.4 has no folder/tag/grouping primitive for distinct pipelines
+inside a team -- teams are the only hard partition, and instance groups only
+collapse templated variants of the *same* pipeline. The `infrastructure` team
+cannot be split into semantic sub-teams because its privileged EC2 workers are
+registered with `--team infrastructure` and are exclusive to it.
+
+So visual grouping has to be emulated with ordering. `fly order-pipelines` sets
+a display-order field via the API: it touches no pipeline config, no build
+history, no credentials, and no source. Re-running with a different list fully
+reverts. That makes this the zero-risk lever, and this script exists so the
+curated order is a reviewable artifact that can be re-applied idempotently
+rather than one-shot shell history.
+
+See docs/plans/concourse-dashboard-reorganization.md for the full spec and the
+rationale behind each cluster assignment.
+
+Usage:
+    bin/concourse-order-pipelines show
+    bin/concourse-order-pipelines check
+    bin/concourse-order-pipelines check --team infrastructure
+    bin/concourse-order-pipelines apply --dry-run
+    bin/concourse-order-pipelines apply
+    bin/concourse-order-pipelines apply --target odl-qa --order-file my-order.yaml
+
+Pipelines that are live but absent from the curated order are appended to the
+end of their team rather than dropped, so a newly-created pipeline never causes
+a partial ordering -- it just shows up in an `unclustered` bucket at the bottom
+where `check` will flag it for triage.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Annotated
+
+import cyclopts
+import yaml
+
+app = cyclopts.App(
+    help=(
+        "Apply a curated semantic display order to Concourse dashboard tiles via "
+        "`fly order-pipelines`. Purely display state -- no config, history, or "
+        "credentials are touched, and re-running reverts."
+    )
+)
+
+DEFAULT_TARGET = "odl-prod"
+
+# Bucket that live-but-uncurated pipelines land in, always ordered last.
+UNCLUSTERED = "unclustered"
+
+# The canonical ordering. Dict order is the display order: clusters top to
+# bottom, pipelines within a cluster left to right. Cluster names are for human
+# review and `show`/`check` output only -- Concourse never sees them, since it
+# has no grouping primitive to hang them on.
+PIPELINE_ORDER: dict[str, dict[str, list[str]]] = {
+    "infrastructure": {
+        # The registries that generate everything else, so the dashboard starts
+        # with "where do pipelines come from".
+        "meta": [
+            "pulumi-infrastructure-meta",
+            "simple-pulumi-meta",
+            "k8s-apps-meta",
+            "dagger-pulumi-edxapp-meta-v3",
+            "packer-pulumi-xqwatcher-meta",
+            "xqwatcher-grader-images-meta",
+        ],
+        # AWS substrate, clusters, AMIs, identity, observability, notification.
+        # Keycloak belongs here, not open-edx: it is the org-wide IdP.
+        "core-platform": [
+            "pulumi-aws",
+            "pulumi-aws-ecr",
+            "pulumi-aws-sftp",
+            "pulumi-eks-cluster",
+            "packer-docker-baseline",
+            "packer-pulumi-vault",
+            "packer-pulumi-consul",
+            "packer-pulumi-concourse",
+            "docker-pulumi-keycloak",
+            "pulumi-monitoring",
+            "misc-grafana-management",
+            "pulumi-vector-log-proxy",
+            "pulumi-kubewatch",
+            "pulumi-sentry",
+            "pulumi-rootly",
+            "misc-cloud-custodian",
+            "pulumi-mailgun",
+            "pulumi-fastly-redirector",
+            "pulumi-xpro-partner-dns",
+            "pulumi-celery-monitoring",
+            "pulumi-release-bot",
+            "pulumi-toolhive-operator",
+            "pulumi-toolhive-data",
+            "pulumi-toolhive-apps",
+            "pulumi-toolhive-swe",
+        ],
+        # Warehouse, ingestion, query engines, catalog, notebooks.
+        # ol-analytics-api-pipeline sits here rather than applications despite
+        # being a k8s_apps app -- it reads as part of the data stack.
+        "data-platform": [
+            "pulumi-data_warehouse",
+            "pulumi-airbyte",
+            "docker-pulumi-dagster",
+            "pulumi-clickhouse",
+            "pulumi-starrocks",
+            "pulumi-starrocks-substructure",
+            "pulumi-starburst",
+            "pulumi-open-metadata",
+            "pulumi-open-metadata-substructure",
+            "pulumi-opensearch",
+            "pulumi-qdrant-cloud",
+            "pulumi-mongodb-atlas",
+            "pulumi-tika",
+            "docker-pulumi-superset",
+            "ol-superset-deploy",
+            "ol-analytics-api-pipeline",
+            "pulumi-jupyterhub",
+            "pulumi-jupyterhub-data",
+            "pulumi-marimo-data",
+            "jupyter_notebook_docker_image_build",
+        ],
+        # Grouped by component, then by deployment (master/ulmo/verawood).
+        "open-edx": [
+            "dagger-pulumi-edxapp-global",
+            "dagger-pulumi-codejail-master",
+            "dagger-pulumi-codejail-ulmo",
+            "dagger-pulumi-codejail-verawood",
+            "dagger-pulumi-edx-notes-master",
+            "dagger-pulumi-edx-notes-ulmo",
+            "dagger-pulumi-edx-notes-verawood",
+            "docker-packer-pulumi-xqueue-master",
+            "docker-packer-pulumi-xqueue-ulmo",
+            "docker-packer-pulumi-xqueue-verawood",
+            "docker-pulumi-xqwatcher-master",
+            "docker-pulumi-xqwatcher-ulmo",
+            "docker-pulumi-xqwatcher-verawood",
+            "build-grader-base-image",
+            "build-graders-mit-600x-image",
+            "build-graders-mit-686x-image",
+        ],
+        # Product deploy pipelines. The release_bot-referenced ones come first;
+        # none of them may be renamed without a coordinated bot deploy.
+        "applications": [
+            "mit-learn-pipeline",
+            "mit-learn-nextjs-pipeline",
+            "learn-ai-pipeline",
+            "mitxonline-pipeline",
+            "xpro-pipeline",
+            "micromasters-pipeline",
+            "ocw-studio-pipeline",
+            "odl-video-service-pipeline",
+            "pulumi-ocw-site",
+            "pulumi-open-discussions",
+            "pulumi-digital-credentials",
+            "pulumi-b2b-partners-storage",
+        ],
+        # Parked last pending the Phase 2 archive decision. The three
+        # `-relesae-test` pipelines have no definition anywhere in this repo and
+        # still hold production deploy jobs; the two image pipelines are orphaned
+        # duplicates of the canonical copies on `main`.
+        "deprecated": [
+            "docker-pulumi-micromasters-relesae-test",
+            "docker-pulumi-ovs-relesae-test",
+            "docker-pulumi-xpro-relesae-test",
+            "dcind-resource-image",
+            "docker-google-ads-opt-image",
+        ],
+    },
+    "main": {
+        "meta": [
+            "container-images-meta",
+            "ol-concourse-resource-meta",
+            "ol-api-clients-meta",
+            "publish-python-packages-meta",
+            "mfe-meta-pipeline",
+            "dagger-pulumi-codejail-meta",
+            "dagger-pulumi-edx-notes-meta",
+            "docker-packer-pulumi-xqueue-meta",
+        ],
+        # Resource types and CI images.
+        "concourse-tooling": [
+            "build-ol-concourse-images",
+            "publish-ol-concourse",
+            "build-concourse-resources-rclone",
+            "build-concourse-resources-s3-sync",
+            "docker-concourse-vault-resource",
+            "docker-hashicorp-release-resource-image",
+            "docker-mitodl-concourse-npm-resource",
+            "dcind-resource-image",
+        ],
+        # Shared build/runtime images.
+        "base-images": [
+            "ol-python-base-docker",
+            "ol-infrastructure-docker-container",
+            "docker-openedx-tubular-image",
+            "ocw-course-publisher-image",
+            "ol-superset-image",
+            "build-redash-image",
+            "docker-google-ads-opt-image",
+        ],
+        "package-publishing": [
+            "publish-ol-django-pypi",
+            "publish-open-edx-plugins-pypi",
+            "publish-jupyterhub-extensions-pypi",
+            "mit-learn-api-client",
+            "mitxonline-api-client",
+        ],
+        "apps-misc": [
+            "platform-engineering-site",
+            "edx-sysadmin",
+            "sign-and-verify",
+            "google-ads-optimization",
+        ],
+    },
+}
+
+
+def load_order(order_file: Path | None) -> dict[str, dict[str, list[str]]]:
+    """Return the built-in ordering, or one loaded from a YAML override file."""
+    if order_file is None:
+        return PIPELINE_ORDER
+    return yaml.safe_load(order_file.read_text())
+
+
+def fly(target: str, *args: str) -> str:
+    """Run a `fly` subcommand against a target, exiting on failure."""
+    result = subprocess.run(  # noqa: S603
+        ["fly", "-t", target, *args],  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.exit(f"fly {' '.join(args)} failed:\n{result.stderr.strip()}")
+    return result.stdout
+
+
+def live_pipelines(target: str, team: str) -> list[str]:
+    """Live pipeline names for a team, in their current display order.
+
+    The API returns pipelines in display order. Instanced pipelines repeat their
+    name once per instance (`jupyter_notebook_docker_image_build` has 30) but
+    render as a single instance-group tile, so dedupe while preserving
+    first-seen position to get one entry per tile. Archived pipelines have no
+    tile and are excluded.
+    """
+    raw = fly(target, "pipelines", "--team", team, "--json")
+    names: list[str] = []
+    for pipeline in json.loads(raw):
+        name = pipeline["name"]
+        if pipeline.get("archived") or name in names:
+            continue
+        names.append(name)
+    return names
+
+
+def resolve(
+    desired: dict[str, list[str]], live: list[str]
+) -> tuple[dict[str, list[str]], list[str]]:
+    """Reconcile the curated order against what is actually live.
+
+    Returns the curated clusters filtered down to live pipelines (plus an
+    `unclustered` bucket for live pipelines the curation does not mention), and
+    the list of curated names that no longer exist. Passing a nonexistent name
+    to `fly order-pipelines` errors out, so phantoms are dropped rather than
+    sent.
+    """
+    live_set = set(live)
+    curated: set[str] = set()
+    clusters: dict[str, list[str]] = {}
+    phantoms: list[str] = []
+
+    for cluster, names in desired.items():
+        present = []
+        for name in names:
+            if name in live_set:
+                present.append(name)
+                curated.add(name)
+            else:
+                phantoms.append(name)
+        clusters[cluster] = present
+
+    unclustered = [name for name in live if name not in curated]
+    if unclustered:
+        clusters[UNCLUSTERED] = unclustered
+
+    return clusters, phantoms
+
+
+def flatten(clusters: dict[str, list[str]]) -> list[str]:
+    """Collapse clusters into the flat, ordered name list `fly` expects."""
+    return [name for names in clusters.values() for name in names]
+
+
+def teams_to_process(
+    order: dict[str, dict[str, list[str]]], team: str | None
+) -> list[str]:
+    """Resolve the `--team` flag to the list of teams to act on."""
+    if team is None:
+        return list(order)
+    if team not in order:
+        sys.exit(f"No curated ordering defined for team {team!r}. Known: {list(order)}")
+    return [team]
+
+
+@app.command
+def show(
+    *,
+    team: Annotated[str | None, cyclopts.Parameter(help="Limit to one team.")] = None,
+    order_file: Annotated[
+        Path | None,
+        cyclopts.Parameter(help="YAML file overriding the built-in ordering."),
+    ] = None,
+) -> None:
+    """Print the curated ordering without contacting Concourse."""
+    order = load_order(order_file)
+    for team_name in teams_to_process(order, team):
+        clusters = order[team_name]
+        total = sum(len(names) for names in clusters.values())
+        print(f"\n{team_name} ({total} tiles, {len(clusters)} clusters)")
+        for cluster, names in clusters.items():
+            print(f"  {cluster} ({len(names)})")
+            for name in names:
+                print(f"    {name}")
+
+
+@app.command
+def check(
+    *,
+    target: Annotated[
+        str, cyclopts.Parameter(help="fly target name.")
+    ] = DEFAULT_TARGET,
+    team: Annotated[str | None, cyclopts.Parameter(help="Limit to one team.")] = None,
+    order_file: Annotated[
+        Path | None,
+        cyclopts.Parameter(help="YAML file overriding the built-in ordering."),
+    ] = None,
+) -> None:
+    """Report drift between the curated ordering and the live dashboard.
+
+    Exits non-zero if any team is out of order, has live pipelines the curation
+    does not mention, or curates names that no longer exist.
+    """
+    order = load_order(order_file)
+    drifted = False
+
+    for team_name in teams_to_process(order, team):
+        live = live_pipelines(target, team_name)
+        clusters, phantoms = resolve(order[team_name], live)
+        desired = flatten(clusters)
+        unclustered = clusters.get(UNCLUSTERED, [])
+
+        print(f"\n{team_name}: {len(live)} live tiles")
+        if phantoms:
+            drifted = True
+            print(f"  curated but not live ({len(phantoms)}) -- will be skipped:")
+            for name in phantoms:
+                print(f"    {name}")
+        if unclustered:
+            drifted = True
+            print(f"  live but uncurated ({len(unclustered)}) -- ordered last:")
+            for name in unclustered:
+                print(f"    {name}")
+        if desired == live:
+            print("  order: matches curated ordering")
+        else:
+            drifted = True
+            first = next(
+                i for i, (a, b) in enumerate(zip(desired, live, strict=True)) if a != b
+            )
+            print(
+                f"  order: differs, first at position {first} "
+                f"(live {live[first]!r}, curated {desired[first]!r})"
+            )
+
+    if drifted:
+        sys.exit(1)
+
+
+@app.command
+def apply(
+    *,
+    target: Annotated[
+        str, cyclopts.Parameter(help="fly target name.")
+    ] = DEFAULT_TARGET,
+    team: Annotated[str | None, cyclopts.Parameter(help="Limit to one team.")] = None,
+    order_file: Annotated[
+        Path | None,
+        cyclopts.Parameter(help="YAML file overriding the built-in ordering."),
+    ] = None,
+    dry_run: Annotated[
+        bool,
+        cyclopts.Parameter(help="Print the fly invocation without running it."),
+    ] = False,
+) -> None:
+    """Apply the curated ordering via `fly order-pipelines`.
+
+    Idempotent: the full live tile list is sent every time, so re-running is a
+    no-op and running after new pipelines appear simply re-sorts them.
+    """
+    order = load_order(order_file)
+
+    for team_name in teams_to_process(order, team):
+        live = live_pipelines(target, team_name)
+        clusters, phantoms = resolve(order[team_name], live)
+        desired = flatten(clusters)
+
+        for name in phantoms:
+            print(f"{team_name}: skipping curated-but-not-live pipeline {name!r}")
+        for name in clusters.get(UNCLUSTERED, []):
+            print(f"{team_name}: uncurated pipeline {name!r} ordered last")
+
+        args = ["order-pipelines", "--team", team_name]
+        for name in desired:
+            args += ["-p", name]
+
+        if dry_run:
+            print(f"[dry-run] fly -t {target} {' '.join(args)}")
+            continue
+
+        fly(target, *args)
+        print(f"{team_name}: ordered {len(desired)} tiles")
+
+
+if __name__ == "__main__":
+    app()

--- a/bin/concourse-order-pipelines
+++ b/bin/concourse-order-pipelines
@@ -204,7 +204,6 @@ PIPELINE_ORDER: dict[str, dict[str, list[str]]] = {
             "docker-google-ads-opt-image",
         ],
         "package-publishing": [
-            "publish-ol-django-pypi",
             "publish-open-edx-plugins-pypi",
             "publish-jupyterhub-extensions-pypi",
             "mit-learn-api-client",
@@ -215,6 +214,14 @@ PIPELINE_ORDER: dict[str, dict[str, list[str]]] = {
             "edx-sysadmin",
             "sign-and-verify",
             "google-ads-optimization",
+        ],
+        # Parked last as a Phase 2 archive candidate. `publish-ol-django-pypi`
+        # has errored on every job since 2026-06-08 on an undefined
+        # `github.odlbot_private_ssh_key`, and the owner's call is that the
+        # pipeline is wrong by design and should be removed or left broken
+        # rather than repaired -- so it stays dead and stays out of the way.
+        "deprecated": [
+            "publish-ol-django-pypi",
         ],
     },
 }

--- a/bin/concourse-order-pipelines
+++ b/bin/concourse-order-pipelines
@@ -228,10 +228,34 @@ PIPELINE_ORDER: dict[str, dict[str, list[str]]] = {
 
 
 def load_order(order_file: Path | None) -> dict[str, dict[str, list[str]]]:
-    """Return the built-in ordering, or one loaded from a YAML override file."""
+    """Return the built-in ordering, or one loaded from a YAML override file.
+
+    Rejects a pipeline listed under more than one cluster. A duplicate would put
+    the same tile in the order list twice, which makes `apply` pass `-p <name>`
+    twice to `fly` and breaks the "one entry per live tile" invariant the rest of
+    this script depends on. Catching it here keeps that invariant true for both
+    subcommands, and turns a traceback into a message naming the offender.
+    """
     if order_file is None:
-        return PIPELINE_ORDER
-    return yaml.safe_load(order_file.read_text())
+        order, source = PIPELINE_ORDER, "built-in ordering"
+    else:
+        order, source = yaml.safe_load(order_file.read_text()), str(order_file)
+
+    for team, clusters in order.items():
+        placement: dict[str, list[str]] = {}
+        for cluster, names in clusters.items():
+            for name in names:
+                placement.setdefault(name, []).append(cluster)
+        duplicated = {n: c for n, c in placement.items() if len(c) > 1}
+        if duplicated:
+            detail = "; ".join(
+                f"{name} in {', '.join(cs)}" for name, cs in sorted(duplicated.items())
+            )
+            sys.exit(
+                f"{source}: team {team!r} lists the same pipeline under more than "
+                f"one cluster: {detail}"
+            )
+    return order
 
 
 def fly(target: str, *args: str) -> str:
@@ -377,6 +401,9 @@ def check(
             print("  order: matches curated ordering")
         else:
             drifted = True
+            # strict=True is a real invariant, not optimism: `load_order` rejects
+            # duplicates and `resolve` emits every live name exactly once, so a
+            # length mismatch here would mean one of those broke.
             first = next(
                 i for i, (a, b) in enumerate(zip(desired, live, strict=True)) if a != b
             )

--- a/bin/concourse-order-pipelines
+++ b/bin/concourse-order-pipelines
@@ -253,6 +253,15 @@ def load_order(order_file: Path | None) -> dict[str, dict[str, list[str]]]:
             )
         placement: dict[str, list[str]] = {}
         for cluster, names in clusters.items():
+            # A bare string would otherwise iterate character by character and
+            # "order" one-letter pipeline names without any error.
+            if not isinstance(names, list) or not all(
+                isinstance(n, str) for n in names
+            ):
+                sys.exit(
+                    f"{source}: team {team!r}, cluster {cluster!r} must be a list of "
+                    f"pipeline names, got {names!r}"
+                )
             for name in names:
                 placement.setdefault(name, []).append(cluster)
         duplicated = {n: c for n, c in placement.items() if len(c) > 1}

--- a/bin/concourse-order-pipelines
+++ b/bin/concourse-order-pipelines
@@ -239,8 +239,18 @@ def load_order(order_file: Path | None) -> dict[str, dict[str, list[str]]]:
         order, source = PIPELINE_ORDER, "built-in ordering"
     else:
         order, source = yaml.safe_load(order_file.read_text()), str(order_file)
+        if not isinstance(order, dict):
+            sys.exit(
+                f"{source}: expected a mapping of team -> cluster -> pipeline list, "
+                f"got {type(order).__name__}"
+            )
 
     for team, clusters in order.items():
+        if not isinstance(clusters, dict):
+            sys.exit(
+                f"{source}: team {team!r} must map cluster names to pipeline lists, "
+                f"got {type(clusters).__name__}"
+            )
         placement: dict[str, list[str]] = {}
         for cluster, names in clusters.items():
             for name in names:

--- a/bin/concourse-order-pipelines
+++ b/bin/concourse-order-pipelines
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# ruff: noqa: T201
 """Apply a curated, semantic display order to Concourse dashboard tiles.
 
 Concourse 8.2.4 has no folder/tag/grouping primitive for distinct pipelines

--- a/docs/plans/concourse-dashboard-reorganization.md
+++ b/docs/plans/concourse-dashboard-reorganization.md
@@ -55,10 +55,47 @@ Only `infrastructure` and `ocw` have dedicated pools. Every other team shares th
 unbound global pool. `src/ol_concourse/lib/jobs/infrastructure.py` (the
 `pulumi_job` / `packer_jobs` factories) uses no step-level `tags:` anywhere.
 
-**Consequence: the `infrastructure` team cannot be split into semantic sub-teams
-without re-registering EC2 workers per new team.** That is a separate, higher-risk
-infrastructure change and is explicitly out of scope. All 84 `infrastructure`
-tiles stay on the `infrastructure` team.
+A worker takes **exactly one** team, or none. There is no multi-team worker:
+concourse/concourse#2633 ("Concourse workers can be associated with multiple
+teams") was closed **"not planned"**. Confirmed against the 8.2.4 worker docs —
+"you can configure a worker to belong to a single team".
+
+Live shape (`fly -t odl-prod workers --json`, 2026-07-24): 18 workers — 7 bound
+to `infrastructure`, 7 to `ocw`, 4 global. **No worker carries any tag today.**
+
+**Revised 2026-07-24 (supersedes the original "out of scope" ruling).** Splitting
+`infrastructure` into semantic teams is now the chosen direction (§Phase 3), on
+the decision that team scoping beats naming prefixes. Since a pool cannot serve
+several teams, that reduces to exactly two implementations:
+
+| | Mechanism | Boundary | Cost |
+| --- | --- | --- | --- |
+| **A (chosen)** | Drop `concourse_team` from the infra pool, tag it, route jobs with step-level `tags:` | IAM boundary becomes a **convention** | none |
+| B | One dedicated ASG per semantic team | Boundary stays **enforced** | min 2 → 8 `m7a.4xlarge`, on-demand floor 1 → 4, burst capacity fragmented |
+
+Option B was rejected on cost and because fragmenting pools partially undoes the
+spot diversification shipped in #5112 — small pools are exactly what made CI
+fragile during the t3a exhaustion.
+
+**What Option A actually costs, stated plainly.** The infra pool's instance
+profile carries `base`, `infra`, `operations`, `cloud_custodian`, `pulumi_state`.
+Any container on those hosts can reach IMDS and assume that role. Today
+`concourse_team: infrastructure` *is* the authorization boundary. Once the pool
+is global, Concourse tags are a **scheduling hint, not authorization** — anyone
+who can set a pipeline in any team can add `tags: [pulumi]` and get that role.
+Tagging does prevent *accidental* scheduling (untagged builds will not land on a
+tagged worker), so the exposure is deliberate misuse, not drift. Accepting this
+implies the set of people who can set pipelines in *any* team is already the set
+trusted with the Pulumi deploy role — which is precisely what Phase 5 (teams as
+code) would make reviewable, and is therefore now a prerequisite rather than an
+independent workstream.
+
+Implementation is smaller than expected: `build_worker_user_data()` in
+`src/ol_infrastructure/applications/concourse/__main__.py` **already** supports
+`concourse_tags` → `/etc/default/concourse-tags` → `CONCOURSE_TAG`. The missing
+half is a `tags:` parameter on `pulumi_job` / `packer_jobs`, which live in the
+separately published `mitodl/ol-concourse` package — a cross-repo change plus a
+version bump here.
 
 ### 2.2 Renames have three-way coupling
 
@@ -82,12 +119,49 @@ Any rename or team move must be checked against:
    registry edit creates a new pipeline and orphans the old build history. A real
    rename is `registry edit + fly rename-pipeline` landed together, ahead of the
    meta pipeline's next git-triggered run.
-3. **Vault credential paths are `{team}/{pipeline}`-scoped.** Concourse's built-in
-   Vault credential manager resolves `((var))` against
-   `/concourse/{{.Team}}/{{.Pipeline}}/{{.Secret}}` (see
-   `src/bilder/components/concourse/models.py`). Moving a pipeline across teams
-   breaks secret injection unless the KV secrets are migrated first. Renames
-   within a team break it the same way.
+3. **Vault credential paths are team-scoped — but by *group*, not per pipeline.**
+   Deployed config (`src/bilder/images/concourse/deploy.py:186`) is
+   `vault_path_prefix="/secret-concourse"`, `vault_shared_path="shared"`, so the
+   lookup chain is `/secret-concourse/{team}/{pipeline}/{secret}` →
+   `/secret-concourse/{team}/{secret}` → `/secret-concourse/shared/{secret}`.
+
+   In practice **nothing uses the pipeline-scoped tier.** References are
+   `((group.key))` — a KV entry per group, fields within it — resolving via the
+   `{team}/{secret}` template. So a team move relocates *groups*, not per-pipeline
+   secrets, which makes the migration far smaller than "83 pipelines × secrets".
+
+   Authoritative inventory, `vault kv list secret-concourse/<team>` against
+   vault-production (KV v2), 2026-07-24:
+
+   | Team | Groups |
+   | --- | --- |
+   | `infrastructure` | cortextool, dbt, dockerhub, eks, fastly, github, github_enterprise, grizzly, mit-github, open_api_clients, superset_qa_service_account, superset_service_account, unified_ecommerce_api_clients (13) |
+   | `main` | consul, dockerhub, fastly, google_ads_optimization, grafana, npm_publish, platform_engineering_site, pypi_creds (8) |
+   | `shared` | fastly, sentry (2) |
+   | `ocw` | api-bearer-token, draft/, fastly_draft, fastly_live, fastly_test, git-private-key, healthchecks-io-{draft,live}-uuid, live/, slack-url |
+   | `mitx` / `mitx-staging` | github |
+   | `mitxonline` / `xpro` | github, tubular_oauth_client |
+
+   **Do not derive this from the SOPS file.** `src/bridge/secrets/concourse/
+   operations.production.yaml` is missing five live groups (§4.5).
+
+   Mapping `infrastructure`'s 13 groups onto the §3 clusters, by which pipeline
+   files reference them:
+
+   - **core-platform** — `cortextool`, `grizzly` (both `grafana_cloud/pipeline.py`)
+   - **data-platform** — `dbt` (`dagster/`), `superset_service_account` +
+     `superset_qa_service_account` (`ol_superset_deploy.py`)
+   - **open-edx** — `github_enterprise`, `open_api_clients` (both
+     `grader_images/build_pipeline.py`)
+   - **promote to `shared`** — `dockerhub` (17 referencing files spanning every
+     cluster) and `github` (`k8s_apps/`, `container_images/jupyter_courses.py`)
+   - **verify before moving** — `eks`, `fastly` (a `shared` copy already exists),
+     `mit-github`, `unified_ecommerce_api_clients`. The last two have **zero**
+     `((...))` references anywhere under `src/ol_concourse` and may be dead.
+
+   So the migration is: 2 groups promoted to `shared`, 5 moved with their
+   cluster, 4 to triage. That is tractable, and it is the strongest argument that
+   the team split is affordable.
 
 ### 2.3 Concourse has no folder/tag primitive
 
@@ -262,15 +336,58 @@ name no longer exists.
 
 See §4 — this is now a *correctness* finding, not just cosmetics.
 
-### Phase 3 — Semantic naming prefixes
+### Phase 3 — Semantic teams on a globally-tagged worker pool
 
-Emulates grouping by making alphabetical/lexical order match semantic order.
-Current naming encodes the *tool* (`pulumi-`, `packer-`, `docker-`,
-`dagger-pulumi-`) rather than the *domain*, which is exactly backwards for
-navigation. Target shape is `<domain>-<component>`, e.g. `data-starrocks`,
-`core-eks-cluster`, `edx-xqwatcher-master`.
+**Direction changed 2026-07-24.** Team scoping replaces naming prefixes as the
+primary grouping mechanism. Teams give real partitioning — separate dashboards,
+separate RBAC, separate secret namespaces — where prefixes only simulate grouping
+through sort order. Prefixes remain available as a *complement* within a team
+(and the rename mechanics below still apply if we take them up), but they are no
+longer the plan.
 
-This is the highest-risk phase because of §2.2. Sequencing rule per pipeline:
+Target teams mirror the §3 clusters: `core-platform`, `data-platform`,
+`open-edx`, `applications`. `meta` and `deprecated` are dispositions rather than
+domains — meta pipelines follow whatever they generate, and the deprecated five
+are resolved by Phase 2 instead of being moved.
+
+Sequence, in dependency order:
+
+1. **Phase 5 first, not in parallel.** Teams-as-code becomes a prerequisite:
+   Option A (§2.1) makes "who can set a pipeline in any team" equivalent to "who
+   can assume the Pulumi deploy role", so team membership must be reviewable
+   before the boundary is relaxed, not after.
+2. **Tag the pool, keep it bound.** Add `concourse_tags` to the infra `worker_def`
+   while `concourse_team: infrastructure` is still set, and confirm existing jobs
+   still schedule. Tagged workers only accept tag-requesting builds, so this step
+   is where that gets proven without giving anything up.
+3. **Add `tags:` to `pulumi_job` / `packer_jobs`** in `mitodl/ol-concourse`,
+   release, bump here, regenerate. Confirm every infra pipeline still lands on the
+   infra pool.
+4. **Drop `concourse_team`** from the infra `worker_def`. This is the step that
+   trades the enforced boundary for a conventional one — land it on its own.
+5. **Move secrets before pipelines.** Promote `dockerhub` and `github` to
+   `shared`; copy each cluster's groups to its new team path (§2.2.3). Copy, don't
+   move — leave the `infrastructure` originals until the move is proven, then
+   clean up.
+6. **Move pipelines per cluster, smallest first.** `open-edx` (2 secret groups) is
+   the best pilot. Per cluster: `fly set-team`, update the meta registry's
+   `SetPipelineStep` team, `fly rename-pipeline`/re-set as needed, re-run
+   `bin/concourse-order-pipelines check`.
+7. **`release_bot` last.** It pins `CONCOURSE_TEAM=infrastructure` plus nine
+   pipeline names (§2.2.1). The `applications` cluster holds eight of the nine, so
+   that cluster cannot move until the bot takes a team-per-pipeline mapping.
+
+Risks specific to this path, beyond §2.1's IAM trade: `ol-analytics-api-pipeline`
+is `release_bot`-referenced but sits in **data-platform**, so the bot's mapping
+must be per-pipeline, not per-cluster. And the `infrastructure` team keeps its
+name and its worker pool throughout — only pipelines leave it — so nothing has to
+be re-registered at any point.
+
+#### Deferred: semantic naming prefixes
+
+Retained for reference. Current naming encodes the *tool* (`pulumi-`, `packer-`,
+`docker-`, `dagger-pulumi-`) rather than the *domain*. If taken up later, the
+target shape is `<domain>-<component>` and the per-pipeline sequencing rule is:
 
 1. Verify the name is not in the `release_bot` nine (or update the bot first, in
    its own deploy).
@@ -310,7 +427,10 @@ pipeline job that applies each file, making the eight teams' membership
 reviewable. Auth backend is already GitHub OAuth, so `roles:` entries map onto
 existing `mitodl:*` GitHub teams.
 
-This is independent of the dashboard work and can proceed in parallel.
+**Reclassified 2026-07-24: this is now a prerequisite for Phase 3, not an
+independent workstream.** Option A (§2.1) makes pipeline-set access in any team
+equivalent to holding the Pulumi deploy role, so team membership has to be
+reviewable before that boundary is relaxed.
 
 ### Phase 6 — Per-pipeline descriptions: wait for upstream, don't ship the SVG workaround
 
@@ -415,6 +535,46 @@ Action: unstick `main/dcind-resource-image` build #1, confirm both `main` copies
 publish successfully, then archive the two `infrastructure` copies. Until then,
 they sit in the **deprecated** cluster at the bottom of the ordering.
 
+### 4.4 `publish-ol-django-pypi` has been failing for six weeks
+
+Found by the §2.2.3 secret inventory — and it is exactly the failure mode a team
+move causes, already present in `main`.
+
+Every job errors in 1–2s since 2026-06-08. `fly watch` on
+`publish-ol-django-pypi/build-common` #29:
+
+```
+failed to interpolate task config: undefined vars: github.odlbot_private_ssh_key
+errored
+```
+
+`src/ol_concourse/pipelines/libraries/ol_django.py:28` passes
+`GIT_SSH_KEY: ((github.odlbot_private_ssh_key))`, but the pipeline runs on `main`
+and `main` has no `github` group — the chain falls through to `shared`, which has
+only `fastly` and `sentry`. `main` holds the same key under `npm_publish`, and the
+sibling `api_clients_pipeline.py` (also `main`) already uses
+`((npm_publish.odlbot_private_ssh_key))`. One-line fix. No `mitol-django-*`
+release has published since.
+
+Tracked as `tk-fix-publish-ol-django-pypi-undefined-var-github--505ae3`.
+
+### 4.5 The Concourse SOPS file is not a complete secret inventory
+
+`src/bridge/secrets/concourse/operations.production.yaml` is how these secrets
+are *populated*, but five live groups have no SOPS entry:
+`infrastructure/{dockerhub,mit-github,unified_ecommerce_api_clients}` and
+`main/{consul,fastly}`.
+
+`infrastructure/dockerhub` is provably load-bearing, not stale:
+`((dockerhub.username))` is referenced from 17 pipeline files, and
+`docker-pulumi-keycloak/build-keycloak-docker-image` #724 and
+`docker-pulumi-superset/build-superset-image` #243 both succeeded on 2026-07-23/24.
+
+Consequence for this project: the SOPS-derived inventory showed `infrastructure`
+with 10 groups when Vault has 13. Any team-split reasoning must come from
+`vault kv list`, not from SOPS. Tracked as
+`tk-reconcile-concourse-sops-secrets-file-against-li-d0f940`.
+
 ### 4.3 Stale `simple_pulumi/README.md`
 
 `src/ol_concourse/pipelines/infrastructure/simple_pulumi/README.md` documents 16
@@ -423,7 +583,7 @@ Trivial doc fix, independent of everything else.
 
 ## 5. Non-goals
 
-- Splitting the `infrastructure` team (§2.1).
+- Re-registering or re-provisioning the `ocw` worker pool.
 - Touching `ocw` (§1 — already correctly organized via instance groups).
 - Renaming any of the nine `release_bot` pipelines without a coordinated bot
   update.
@@ -435,9 +595,9 @@ Trivial doc fix, independent of everything else.
 | --- | --- | --- |
 | 1 | `bin/concourse-order-pipelines` applying the §3 orderings idempotently — **built**, validated end-to-end on `odl-ci`; awaiting an unexpired `odl-prod` token to apply | none |
 | 2 | Archive decision + `fly archive-pipeline` for confirmed-dead tiles | low, reversible |
-| 3 | Naming convention doc + per-pipeline rename runbook | high, deferred |
+| 3 | Semantic teams on a globally-tagged pool: tag pool → `tags:` in ol-concourse → unbind → migrate secrets → move clusters | high; trades an enforced IAM boundary for a conventional one |
 | 4 | `main`-split evaluation memo (execute only if it wins) | medium |
-| 5 | `src/ol_concourse/teams/*.yml` + apply job | low, independent |
+| 5 | `src/ol_concourse/teams/*.yml` + apply job — **now a prerequisite for Phase 3**, not independent | low |
 | 1b | Bookmarkable per-cluster dashboard filter URLs (§2.5), published wherever the team keeps links | none |
 | 6 | Per-pipeline descriptions — de-scoped; track upstream PR concourse/concourse#9661, adopt after it ships | blocked upstream |
 

--- a/docs/plans/concourse-dashboard-reorganization.md
+++ b/docs/plans/concourse-dashboard-reorganization.md
@@ -290,7 +290,7 @@ component). `ol-analytics-api-pipeline` sits in data-platform rather than
 applications despite being a `k8s_apps` app, because it is read as part of the
 data stack; it is still `release_bot`-referenced and must not be renamed.
 
-#### `main` (32 tiles, 5 clusters)
+#### `main` (32 tiles, 6 clusters)
 
 1. **meta** (8) — `container-images-meta`, `ol-concourse-resource-meta`,
    `ol-api-clients-meta`, `publish-python-packages-meta`, `mfe-meta-pipeline`,
@@ -306,11 +306,11 @@ data stack; it is still `release_bot`-referenced and must not be renamed.
    `ol-python-base-docker`, `ol-infrastructure-docker-container`,
    `docker-openedx-tubular-image`, `ocw-course-publisher-image`,
    `ol-superset-image`, `build-redash-image`, `docker-google-ads-opt-image`
-4. **package-publishing** (5) — `publish-ol-django-pypi`,
-   `publish-open-edx-plugins-pypi`, `publish-jupyterhub-extensions-pypi`,
+4. **package-publishing** (4) — `publish-open-edx-plugins-pypi`, `publish-jupyterhub-extensions-pypi`,
    `mit-learn-api-client`, `mitxonline-api-client`
 5. **apps-misc** (4) — `platform-engineering-site`, `edx-sysadmin`,
    `sign-and-verify`, `google-ads-optimization`
+6. **deprecated** (1) — `publish-ol-django-pypi`, parked pending archive (§4.4)
 
 The canonical ordering lists live in `bin/` (see §6) so they can be re-applied
 idempotently rather than being one-shot shell history.
@@ -556,7 +556,17 @@ sibling `api_clients_pipeline.py` (also `main`) already uses
 `((npm_publish.odlbot_private_ssh_key))`. One-line fix. No `mitol-django-*`
 release has published since.
 
-Tracked as `tk-fix-publish-ol-django-pypi-undefined-var-github--505ae3`.
+**Decision 2026-07-24: not fixing.** The owner's call is that this pipeline is
+incorrectly implemented as a whole and should be removed or left broken rather
+than repaired — applying the one-line secret fix would resume publishing from a
+pipeline whose design is wrong. Tracked and closed won't-fix as
+`tk-fix-publish-ol-django-pypi-undefined-var-github--505ae3`.
+
+Disposition: `publish-ol-django-pypi` moves out of `main`'s `package-publishing`
+cluster into a new `deprecated` cluster at the bottom of the `main` ordering, and
+joins the Phase 2 archive candidates (§4.1 covers the `infrastructure` ones). A
+replacement for mitol-django publishing, if wanted, is a rewrite filed
+separately — not a repair of this pipeline.
 
 ### 4.5 The Concourse SOPS file is not a complete secret inventory
 

--- a/docs/plans/concourse-dashboard-reorganization.md
+++ b/docs/plans/concourse-dashboard-reorganization.md
@@ -241,11 +241,22 @@ data stack; it is still `release_bot`-referenced and must not be renamed.
 The canonical ordering lists live in `bin/` (see §6) so they can be re-applied
 idempotently rather than being one-shot shell history.
 
-**Open verification item:** confirm that a meta pipeline's `set_pipeline` on an
-existing pipeline does not reset its display order (expected: order is a separate
-field, only new pipelines get appended). Test on `odl-ci` or `odl-qa` before
-applying to prod. If ordering *is* reset, ordering must be re-applied on a
-schedule, which changes the shape of the deliverable.
+**Verification item — resolved 2026-07-24 on `odl-ci`, outcome as expected.**
+`set_pipeline` does **not** reset display order, so Phase 1 is a run-once
+deliverable rather than a scheduled one.
+
+Method: created three throwaway paused pipelines on `odl-ci`'s `infrastructure`
+team, reordered them to the top via `fly order-pipelines`, then re-set one of
+them with a genuinely *changed* config (confirmed written by diffing
+`fly get-pipeline` — `v2-changed` on the target, `v1` on an untouched sibling).
+The display order was byte-identical before and after. Newly-created pipelines
+were observed appending to the end of the team, never disturbing existing
+positions. Test pipelines were destroyed and the team's original order restored.
+
+Consequence: ordering only needs re-applying when the pipeline *set* changes, not
+on every meta run. `check` is what detects that — it exits non-zero when a live
+pipeline is missing from the curation (it lands in `unclustered`) or a curated
+name no longer exists.
 
 ### Phase 2 — Archive genuinely dead tiles
 
@@ -422,7 +433,7 @@ Trivial doc fix, independent of everything else.
 
 | Phase | Deliverable | Risk |
 | --- | --- | --- |
-| 1 | `bin/concourse-order-pipelines` applying the §3 orderings idempotently | none |
+| 1 | `bin/concourse-order-pipelines` applying the §3 orderings idempotently — **built**, validated end-to-end on `odl-ci`; awaiting an unexpired `odl-prod` token to apply | none |
 | 2 | Archive decision + `fly archive-pipeline` for confirmed-dead tiles | low, reversible |
 | 3 | Naming convention doc + per-pipeline rename runbook | high, deferred |
 | 4 | `main`-split evaluation memo (execute only if it wins) | medium |
@@ -432,10 +443,10 @@ Trivial doc fix, independent of everything else.
 
 ## 7. Verification
 
-- Phase 1: reload the dashboard per team, confirm tile order matches §3; confirm
-  cluster boundaries are visually legible at default zoom. Re-run after the next
-  meta-pipeline git trigger to confirm ordering survives `set_pipeline` (§3 open
-  item).
+- Phase 1: `bin/concourse-order-pipelines check` exits zero; reload the dashboard
+  per team and confirm cluster boundaries are visually legible at default zoom.
+  Ordering surviving `set_pipeline` is already settled (§3) and does not need
+  re-testing per rollout.
 - Phase 2: confirm each archived pipeline's replacement has a green build newer
   than the archived one's last green build.
 - Phase 3: per rename, confirm build history carried over, Vault-backed `((var))`

--- a/docs/plans/concourse-dashboard-reorganization.md
+++ b/docs/plans/concourse-dashboard-reorganization.md
@@ -1,0 +1,442 @@
+# Concourse Dashboard Reorganization — Spec
+
+Status: spec (approved for phased implementation)
+Target: `https://cicd.odl.mit.edu` (odl-prod), Concourse 8.2.4
+Tracking: `wp-concourse-pipeline-dashboard-reorganization-a35616`, epic
+`tk-reorganize-concourse-pipeline-dashboard-for-clar-aa08bf`
+
+## 1. Problem
+
+The odl-prod Concourse dashboard is unusable as a navigation surface. Pipelines
+are laid out in creation order within each team, with no grouping, so finding a
+specific pipeline requires the search box and prior knowledge of its name.
+
+Live inventory (captured 2026-07-25 via `fly -t odl-prod pipelines --all --json`):
+
+| Team | Pipeline objects | Distinct names (= dashboard tiles) |
+| --- | ---: | ---: |
+| `infrastructure` | 113 | 84 |
+| `main` | 35 | 32 |
+| `ocw` | 11704 | 10 |
+| `xpro` | 4 | 4 |
+| `mitx` | 3 | 3 |
+| `mitxonline` | 3 | 3 |
+| `mitx-staging` | 2 | 2 |
+| `resources` | 0 | 0 |
+
+The object/tile gap is instanced pipelines, which Concourse already collapses
+into one tile per instance group:
+
+- `infrastructure/jupyter_notebook_docker_image_build` — 30 instances keyed on
+  `image_name` (`uai_source-uai.*`, per-course authoring images).
+- `main/google-ads-optimization` — 4 instances keyed on `course_name`, all paused.
+- `ocw` — 2932 `draft`, 2931 `live`, 2914 `draft-ocw-course-v3`, 2914
+  `live-ocw-course-v3`, plus 8 `mass-build-sites` instances and 5 singletons.
+
+**`ocw` is therefore not a problem and is out of scope.** Its 11704 pipelines are
+already the intended use of instance groups and render as 10 tiles. The real
+scope is `infrastructure` (84 tiles) and `main` (32 tiles).
+
+## 2. Hard constraints
+
+These were established during discovery and bound every option below.
+
+### 2.1 Worker pools are bound to teams, not step tags
+
+`fly workers --json` reports `"team": "infrastructure"` on the privileged EC2
+workers. That binding originates in
+`src/ol_infrastructure/applications/concourse/Pulumi.{CI,QA,Production}.yaml`
+(`concourse_team:` per `worker_def`), flows through `build_worker_user_data()` in
+`src/ol_infrastructure/applications/concourse/__main__.py` into
+`/etc/default/concourse-team` on the worker AMI, and is passed to the worker as
+`--team`. A worker registered with a team is exclusive to it.
+
+Only `infrastructure` and `ocw` have dedicated pools. Every other team shares the
+unbound global pool. `src/ol_concourse/lib/jobs/infrastructure.py` (the
+`pulumi_job` / `packer_jobs` factories) uses no step-level `tags:` anywhere.
+
+**Consequence: the `infrastructure` team cannot be split into semantic sub-teams
+without re-registering EC2 workers per new team.** That is a separate, higher-risk
+infrastructure change and is explicitly out of scope. All 84 `infrastructure`
+tiles stay on the `infrastructure` team.
+
+### 2.2 Renames have three-way coupling
+
+Any rename or team move must be checked against:
+
+1. **`release_bot` hardcodes names and team.**
+   `src/ol_infrastructure/applications/release_bot/__main__.py` and
+   `concourse_client.py` pin `CONCOURSE_TEAM=infrastructure` plus nine exact
+   pipeline names: `learn-ai-pipeline`, `mit-learn-pipeline`,
+   `mit-learn-nextjs-pipeline`, `mitxonline-pipeline`, `xpro-pipeline`,
+   `ocw-studio-pipeline`, `odl-video-service-pipeline`, `micromasters-pipeline`,
+   `ol-analytics-api-pipeline`. Renaming any of these breaks the Slack slash
+   commands until the bot config changes in lockstep.
+2. **Pipelines are self-managing via meta registries.** Every pipeline is
+   re-applied by a meta pipeline (`PIPELINE_CONFIGS` in
+   `src/ol_concourse/pipelines/infrastructure/meta.py` and
+   `container_images/meta.py`; `production_app_names` in
+   `simple_pulumi/meta.py`; `app_names` in `k8s_apps/meta.py`; the six
+   `open_edx/*/meta.py` files; `libraries/configuration.py`). A live-only
+   `fly rename-pipeline` is silently reverted on the next meta run. A source-only
+   registry edit creates a new pipeline and orphans the old build history. A real
+   rename is `registry edit + fly rename-pipeline` landed together, ahead of the
+   meta pipeline's next git-triggered run.
+3. **Vault credential paths are `{team}/{pipeline}`-scoped.** Concourse's built-in
+   Vault credential manager resolves `((var))` against
+   `/concourse/{{.Team}}/{{.Pipeline}}/{{.Secret}}` (see
+   `src/bilder/components/concourse/models.py`). Moving a pipeline across teams
+   breaks secret injection unless the KV secrets are migrated first. Renames
+   within a team break it the same way.
+
+### 2.3 Concourse has no folder/tag primitive
+
+Confirmed against concourse-ci.org docs for 8.2.4. The complete set of
+cross-pipeline organization primitives is:
+
+| Primitive | What it does | Reversible |
+| --- | --- | --- |
+| Teams | Hard partition + RBAC + worker binding | Yes, but see 2.1/2.2 |
+| Instance groups | One tile for templated variants of *the same* pipeline | Yes |
+| `fly order-pipelines` | Cosmetic display order within a team | Yes |
+| `fly archive-pipeline` | Hides tile, preserves config + history | Yes (`unpause`/re-set) |
+| `fly rename-pipeline` | Renames, preserves build history | Yes |
+| `display.background_image` | Per-pipeline tile background image | Yes |
+
+There is no native way to nest or label distinct pipelines inside a team. Visual
+grouping must be emulated by **ordering + naming**.
+
+### 2.4 Version: already current; no newer grouping feature to wait for
+
+`CONCOURSE_VERSION = "8.2.4"` in `src/bridge/lib/versions.py`. Concourse v8.0.0
+shipped January 2026, so we are already on the current major line — there is no
+upgrade that would unlock a grouping primitive. The upstream request for pipeline
+folders/grouping (concourse discussion #8827) is open with no implementation. Do
+not gate the dashboard work on an upgrade.
+
+The one upstream item with an implementation behind it is discussion #9660 →
+**PR concourse/concourse#9661**, which adds a pipeline-level `description` field.
+That is a pipeline-page feature, not a dashboard one — see Phase 6. It is the
+only reason a future version bump matters to this project.
+
+(Side note: the pin's inline comment reads "Pin to <8.1.0 because of some login
+bugs with stale state tokens" while the pinned value is 8.2.4. The comment is
+stale and contradicts the value; worth correcting separately.)
+
+### 2.5 The dashboard search bar is URL-addressable — this is a real grouping lever
+
+Not previously accounted for. The Concourse dashboard's search field supports
+selectors (`team:<name>`, `status:succeeded|failed|running|pending|paused|
+errored|aborted`, plus fuzzy name match) **and reflects them into query
+parameters**, so a filtered view is a shareable, bookmarkable URL:
+
+- `https://cicd.odl.mit.edu/?search=foo` — all pipelines matching `foo`
+- `/?team=main&fuzzyName=pie` — equivalent of `team: main pie`
+- `/?status=running&status=pending`
+
+This does not replace ordering — it does not change what the default landing page
+looks like, and it is opt-in per person. But it means a curated set of "virtual
+folder" links (README, team wiki, Slack bookmarks) is achievable today with no
+server-side change at all, e.g. one link per §3 cluster.
+
+It also materially strengthens the case for **Phase 3 naming prefixes**: once
+names are `data-*`, `core-*`, `edx-*`, a bookmark of `/?search=data-` becomes a
+genuine, self-maintaining virtual folder rather than a hand-curated list of names
+that rots. Phase 3's payoff is therefore larger than "alphabetical order looks
+nicer".
+
+Verify the exact parameter names against the running 8.2.4 UI before publishing
+any bookmark set — the mapping above is from upstream issues
+(concourse/concourse#1684, #1703, #3573), not from the 8.2.4 docs.
+
+## 3. Approach
+
+Ordering + naming, applied in risk-ascending phases. Phase 1 is pure display
+state and delivers most of the value; nothing after it is required for the
+dashboard to be usable.
+
+### Phase 1 — Curated ordering (`fly order-pipelines`) — zero risk
+
+`fly order-pipelines --team <team> -p <name> -p <name> ...` sets a display-order
+field via the API. It touches no pipeline config, no build history, no
+credentials, and no source. Re-running it with a different list fully reverts.
+
+Both orderings below were verified for exact coverage against the live inventory
+— 84/84 for `infrastructure`, 32/32 for `main`, no duplicates, no phantoms.
+
+#### `infrastructure` (84 tiles, 6 clusters)
+
+1. **meta** — the registries that generate everything else, so the dashboard
+   starts with "where do pipelines come from":
+   `pulumi-infrastructure-meta`, `simple-pulumi-meta`, `k8s-apps-meta`,
+   `dagger-pulumi-edxapp-meta-v3`, `packer-pulumi-xqwatcher-meta`,
+   `xqwatcher-grader-images-meta`
+2. **core-platform** (25) — AWS substrate, clusters, AMIs, identity,
+   observability, notification:
+   `pulumi-aws`, `pulumi-aws-ecr`, `pulumi-aws-sftp`, `pulumi-eks-cluster`,
+   `packer-docker-baseline`, `packer-pulumi-vault`, `packer-pulumi-consul`,
+   `packer-pulumi-concourse`, `docker-pulumi-keycloak`, `pulumi-monitoring`,
+   `misc-grafana-management`, `pulumi-vector-log-proxy`, `pulumi-kubewatch`,
+   `pulumi-sentry`, `pulumi-rootly`, `misc-cloud-custodian`, `pulumi-mailgun`,
+   `pulumi-fastly-redirector`, `pulumi-xpro-partner-dns`,
+   `pulumi-celery-monitoring`, `pulumi-release-bot`, `pulumi-toolhive-operator`,
+   `pulumi-toolhive-data`, `pulumi-toolhive-apps`, `pulumi-toolhive-swe`
+3. **data-platform** (20) — warehouse, ingestion, query engines, catalog,
+   notebooks:
+   `pulumi-data_warehouse`, `pulumi-airbyte`, `docker-pulumi-dagster`,
+   `pulumi-clickhouse`, `pulumi-starrocks`, `pulumi-starrocks-substructure`,
+   `pulumi-starburst`, `pulumi-open-metadata`,
+   `pulumi-open-metadata-substructure`, `pulumi-opensearch`,
+   `pulumi-qdrant-cloud`, `pulumi-mongodb-atlas`, `pulumi-tika`,
+   `docker-pulumi-superset`, `ol-superset-deploy`, `ol-analytics-api-pipeline`,
+   `pulumi-jupyterhub`, `pulumi-jupyterhub-data`, `pulumi-marimo-data`,
+   `jupyter_notebook_docker_image_build`
+4. **open-edx** (16) — grouped by component, then by deployment
+   (master/ulmo/verawood):
+   `dagger-pulumi-edxapp-global`, `dagger-pulumi-codejail-{master,ulmo,verawood}`,
+   `dagger-pulumi-edx-notes-{master,ulmo,verawood}`,
+   `docker-packer-pulumi-xqueue-{master,ulmo,verawood}`,
+   `docker-pulumi-xqwatcher-{master,ulmo,verawood}`, `build-grader-base-image`,
+   `build-graders-mit-600x-image`, `build-graders-mit-686x-image`
+5. **applications** (12) — product deploy pipelines, `release_bot`-referenced ones
+   first:
+   `mit-learn-pipeline`, `mit-learn-nextjs-pipeline`, `learn-ai-pipeline`,
+   `mitxonline-pipeline`, `xpro-pipeline`, `micromasters-pipeline`,
+   `ocw-studio-pipeline`, `odl-video-service-pipeline`, `pulumi-ocw-site`,
+   `pulumi-open-discussions`, `pulumi-digital-credentials`,
+   `pulumi-b2b-partners-storage`
+6. **deprecated** (5) — parked last pending the Phase 2 archive decision (§4):
+   `docker-pulumi-micromasters-relesae-test`, `docker-pulumi-ovs-relesae-test`,
+   `docker-pulumi-xpro-relesae-test`, `dcind-resource-image`,
+   `docker-google-ads-opt-image`
+
+Placement decisions worth recording: **Keycloak sits in core-platform, not
+open-edx** (confirmed with the user — it is the org-wide IdP, not an Open edX
+component). `ol-analytics-api-pipeline` sits in data-platform rather than
+applications despite being a `k8s_apps` app, because it is read as part of the
+data stack; it is still `release_bot`-referenced and must not be renamed.
+
+#### `main` (32 tiles, 5 clusters)
+
+1. **meta** (8) — `container-images-meta`, `ol-concourse-resource-meta`,
+   `ol-api-clients-meta`, `publish-python-packages-meta`, `mfe-meta-pipeline`,
+   `dagger-pulumi-codejail-meta`, `dagger-pulumi-edx-notes-meta`,
+   `docker-packer-pulumi-xqueue-meta`
+2. **concourse-tooling** (8) — resource types and CI images:
+   `build-ol-concourse-images`, `publish-ol-concourse`,
+   `build-concourse-resources-rclone`, `build-concourse-resources-s3-sync`,
+   `docker-concourse-vault-resource`,
+   `docker-hashicorp-release-resource-image`,
+   `docker-mitodl-concourse-npm-resource`, `dcind-resource-image`
+3. **base-images** (7) — shared build/runtime images:
+   `ol-python-base-docker`, `ol-infrastructure-docker-container`,
+   `docker-openedx-tubular-image`, `ocw-course-publisher-image`,
+   `ol-superset-image`, `build-redash-image`, `docker-google-ads-opt-image`
+4. **package-publishing** (5) — `publish-ol-django-pypi`,
+   `publish-open-edx-plugins-pypi`, `publish-jupyterhub-extensions-pypi`,
+   `mit-learn-api-client`, `mitxonline-api-client`
+5. **apps-misc** (4) — `platform-engineering-site`, `edx-sysadmin`,
+   `sign-and-verify`, `google-ads-optimization`
+
+The canonical ordering lists live in `bin/` (see §6) so they can be re-applied
+idempotently rather than being one-shot shell history.
+
+**Open verification item:** confirm that a meta pipeline's `set_pipeline` on an
+existing pipeline does not reset its display order (expected: order is a separate
+field, only new pipelines get appended). Test on `odl-ci` or `odl-qa` before
+applying to prod. If ordering *is* reset, ordering must be re-applied on a
+schedule, which changes the shape of the deliverable.
+
+### Phase 2 — Archive genuinely dead tiles
+
+See §4 — this is now a *correctness* finding, not just cosmetics.
+
+### Phase 3 — Semantic naming prefixes
+
+Emulates grouping by making alphabetical/lexical order match semantic order.
+Current naming encodes the *tool* (`pulumi-`, `packer-`, `docker-`,
+`dagger-pulumi-`) rather than the *domain*, which is exactly backwards for
+navigation. Target shape is `<domain>-<component>`, e.g. `data-starrocks`,
+`core-eks-cluster`, `edx-xqwatcher-master`.
+
+This is the highest-risk phase because of §2.2. Sequencing rule per pipeline:
+
+1. Verify the name is not in the `release_bot` nine (or update the bot first, in
+   its own deploy).
+2. Migrate/duplicate the Vault KV secrets to the new
+   `/concourse/infrastructure/<new-name>/` path.
+3. Land the registry edit and run `fly rename-pipeline -o <old> -n <new>` in the
+   same change window, before the meta pipeline's next git-triggered run.
+4. Re-apply the Phase 1 ordering (names changed).
+
+Recommendation: defer Phase 3 until Phases 1–2 have been live long enough to
+judge whether ordering alone was sufficient. Ordering delivers most of the
+navigational benefit at none of the risk.
+
+### Phase 4 — `main` grab-bag split (evaluate, don't assume)
+
+`main` is not worker-bound, so pipelines can move teams freely from a scheduling
+standpoint. But moving a pipeline out of `main` breaks its Vault path (§2.3) and
+`main` has a special property: `CONCOURSE_MAIN_TEAM_GITHUB_TEAM` defaults to
+`mitodl:odl-engineering` and is the only team whose RBAC is currently
+declaratively managed (via the bilder/Pulumi AMI config). Everything else is
+manual.
+
+The empty `resources` team is a natural destination for the
+concourse-tooling + base-images clusters (15 tiles). Evaluate against: Vault
+secret migration cost, whether anyone's `fly` targets/CI scripts assume `main`,
+and whether the split actually beats Phase 1 ordering. **Do not execute without
+that evaluation.**
+
+### Phase 5 — Teams as code
+
+There is no "teams as code" for Concourse in this repo today; team creation and
+RBAC are manual `fly set-team` invocations, unlike everything else here.
+`fly set-team -n <team> -c <file>.yml` accepts a YAML config with a `roles:` list
+mapping GitHub org/teams to Concourse roles (owner/member/pipeline-operator/
+viewer). Proposal: a `src/ol_concourse/teams/<team>.yml` directory plus a
+pipeline job that applies each file, making the eight teams' membership
+reviewable. Auth backend is already GitHub OAuth, so `roles:` entries map onto
+existing `mitodl:*` GitHub teams.
+
+This is independent of the dashboard work and can proceed in parallel.
+
+### Phase 6 — Per-pipeline descriptions: wait for upstream, don't ship the SVG workaround
+
+**De-scoped.** The background-image SVG approach is dropped in favor of a proper
+upstream field.
+
+Concourse 8.2.4 has no native pipeline description field, and
+`display.background_image` was the only pipeline-level visual hook. A working
+SVG-caption workaround was built and validated on the unmerged branch
+`worktree-concourse-pipeline-descriptions`
+(`src/ol_concourse/pipelines/description_svg.py`, plus an example SVG and demo
+wiring in `examples/hello.py`). It works, but it is a workaround: the background
+layer is an absolutely-positioned `background-size: cover` div that competes with
+the job-graph SVG layer with no coordination between them, cannot be panned, and
+crops unpredictably depending on the viewer's viewport aspect ratio.
+
+That limitation is what motivated fixing it upstream instead:
+
+- Discussion: https://github.com/orgs/concourse/discussions/9660
+- **PR: https://github.com/concourse/concourse/pull/9661** — "Add pipeline-level
+  description field" (open, authored by blarghmatey, +196/-4 across 15 files)
+
+The PR adds a top-level `description` string to `Config`, plumbed through DB
+storage and the API the same way `Display` already is, rendered as markdown via
+`dillonkearns/elm-markdown`'s unmodified `defaultHtmlRenderer` (so embedded raw
+HTML does not render — the description is visible to anyone with view access,
+including anonymous viewers of public pipelines). Critically it renders as a flow
+*sibling* of the groups bar rather than a child of `.pipeline-content`, so it
+reserves its own space and pushes the graph down instead of fighting it for the
+same absolute layer.
+
+**Important scope caveat for this project:** PR #9661 renders the description on
+the **pipeline page only**. Dashboard tiles use a separate `Pipeline` type that
+does not carry `description`, deliberately left out of that first pass. So this
+field does **not** declutter the dashboard — Phases 1 (ordering) and 2.5 (filter
+URLs) remain the only dashboard levers. It solves per-pipeline *documentation*,
+which is what the SVG task was actually reaching for.
+
+Adoption is blocked on a chain we do not control: PR #9661 merges → lands in a
+Concourse release → we bump `CONCOURSE_VERSION` in `src/bridge/lib/versions.py`
+→ `description` is added to `Pipeline` in `ol_concourse.lib.models.pipeline`
+(the separate `mitodl/ol-concourse` package, published by the `publish-ol-concourse`
+pipeline) → descriptions authored per pipeline in the meta registries.
+
+Until that chain completes there is nothing to build here. Do not ship the SVG
+workaround in the meantime, and do not resurrect PR #5097 (closed unmerged) or
+the throwaway `misc-cloud-hello` pipeline (destroyed off odl-prod). Keep
+`worktree-concourse-pipeline-descriptions` unmerged as a record; if #9661 is
+rejected upstream, that branch is the fallback to reconsider.
+
+## 4. Findings that outgrew "dashboard cleanup"
+
+Investigating the archive candidates turned up two live correctness problems.
+These are the most important output of this phase.
+
+### 4.1 The `-relesae-test` pipelines are live shadow deploy pipelines
+
+`docker-pulumi-micromasters-relesae-test`, `docker-pulumi-ovs-relesae-test`, and
+`docker-pulumi-xpro-relesae-test` have **no definition anywhere in this repo**
+(`rg -n 'relesae' src/` → nothing). They were hand-set via `fly` and never
+codified. They are not dormant:
+
+- `docker-pulumi-micromasters-relesae-test` — `build-micromasters-image-from-master`
+  build #16 succeeded 2026-07-22.
+- `docker-pulumi-ovs-relesae-test` —
+  `deploy-ol-application-odl-video-service-qa` build #54 **failed** 2026-07-24;
+  #53 failed 2026-07-23. Failing repeatedly.
+- `docker-pulumi-xpro-relesae-test` — `build-mitxpro-release-image` #12 failed
+  2026-06-15.
+
+Each is a full legacy pre-Kubernetes clone of a current `k8s_apps` pipeline —
+same app, `pulumi-provisioner` resources, github-deployments, release-gate
+issues, Slack alerts, and **`deploy-ol-application-<app>-production` jobs**. They
+duplicate `micromasters-pipeline`, `odl-video-service-pipeline`, and
+`xpro-pipeline` respectively.
+
+Risk: an unmanaged, unreviewed pipeline holding a production deploy job for three
+live products, with no source of truth. Archiving is the right outcome but is
+**not** the zero-risk cleanup it was assumed to be — confirm with the product
+owners that the EC2/`ol-application` deploy path is genuinely retired for each
+app before archiving. `fly archive-pipeline` is reversible, so archive-first is
+acceptable if a quick rollback path is agreed.
+
+### 4.2 Two container-image pipelines are duplicated across teams and double-building
+
+`dcind-resource-image` and `docker-google-ads-opt-image` exist in **both**
+`infrastructure` and `main`. `container-images-meta` lives in `main` and its
+`SetPipelineStep`s carry no `team=`, so `main` holds the canonical, registry-
+managed copies (both last configured 2026-06-18). The `infrastructure` copies are
+orphans — last config update 2026-03-25 and 2026-06-10, before the `main` copies
+existed — that nothing in the repo maintains.
+
+They are still running: `docker-google-ads-opt-image` built at
+`2026-06-26@06:28:32` in *both* teams simultaneously, burning ~7min of worker
+time on `infrastructure` and ~15min on `main` to publish the same image.
+`infrastructure/dcind-resource-image` reached build #56 on 2026-06-18 while
+`main/dcind-resource-image` build #1 is still `pending` — i.e. the *main* copy has
+never actually completed a build, so archiving the `infrastructure` copy needs the
+`main` copy unstuck first.
+
+Action: unstick `main/dcind-resource-image` build #1, confirm both `main` copies
+publish successfully, then archive the two `infrastructure` copies. Until then,
+they sit in the **deprecated** cluster at the bottom of the ordering.
+
+### 4.3 Stale `simple_pulumi/README.md`
+
+`src/ol_concourse/pipelines/infrastructure/simple_pulumi/README.md` documents 16
+managed apps. `production_app_names` in that directory's `meta.py` has 33.
+Trivial doc fix, independent of everything else.
+
+## 5. Non-goals
+
+- Splitting the `infrastructure` team (§2.1).
+- Touching `ocw` (§1 — already correctly organized via instance groups).
+- Renaming any of the nine `release_bot` pipelines without a coordinated bot
+  update.
+- Any change to worker registration, IAM, or Vault policy.
+
+## 6. Deliverables
+
+| Phase | Deliverable | Risk |
+| --- | --- | --- |
+| 1 | `bin/concourse-order-pipelines` applying the §3 orderings idempotently | none |
+| 2 | Archive decision + `fly archive-pipeline` for confirmed-dead tiles | low, reversible |
+| 3 | Naming convention doc + per-pipeline rename runbook | high, deferred |
+| 4 | `main`-split evaluation memo (execute only if it wins) | medium |
+| 5 | `src/ol_concourse/teams/*.yml` + apply job | low, independent |
+| 1b | Bookmarkable per-cluster dashboard filter URLs (§2.5), published wherever the team keeps links | none |
+| 6 | Per-pipeline descriptions — de-scoped; track upstream PR concourse/concourse#9661, adopt after it ships | blocked upstream |
+
+## 7. Verification
+
+- Phase 1: reload the dashboard per team, confirm tile order matches §3; confirm
+  cluster boundaries are visually legible at default zoom. Re-run after the next
+  meta-pipeline git trigger to confirm ordering survives `set_pipeline` (§3 open
+  item).
+- Phase 2: confirm each archived pipeline's replacement has a green build newer
+  than the archived one's last green build.
+- Phase 3: per rename, confirm build history carried over, Vault-backed `((var))`
+  still resolves (trigger one job), and `release_bot` slash commands still work.

--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/README.md
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/README.md
@@ -12,30 +12,30 @@ The Simple Pulumi-Only pattern is for applications/services that:
 
 ## Managed Applications
 
-The following applications are currently managed by this meta pipeline:
+`production_app_names` in `meta.py` is the source of truth for what this meta
+pipeline manages on odl-prod. It currently holds 33 applications, each rendered
+as a `pulumi-{app_name}` pipeline on the `infrastructure` team:
 
-1. **airbyte** - Airbyte data integration platform
-2. **digital-credentials** - Digital credentials service
-3. **fastly-redirector** - Fastly redirector service
-4. **kubewatch** - Kubernetes cluster monitoring
-5. **mongodb-atlas** - MongoDB Atlas infrastructure
-6. **ocw-studio** - OCW Studio content management (Pulumi-only)
-7. **open-discussions** - Open Discussions platform (Pulumi-only, QA/Production only)
-8. **open-metadata** - OpenMetadata data catalog
-9. **opensearch** - OpenSearch search and analytics cluster
-10. **tika** - Apache Tika document processing service
-11. **vector-log-proxy** - Vector log proxy service
-12. **toolhive-apps** - ToolHive application-agent MCP workloads namespace bootstrap
-13. **toolhive-data** - ToolHive data-agent MCP workloads namespace bootstrap
-14. **toolhive-operator** - ToolHive Kubernetes operator (Helm charts on the ops EKS cluster)
-15. **toolhive-swe** - ToolHive SWE-agent MCP workloads (VirtualMCPServer, Redis, ingress, Vault wiring)
-16. **xpro-partner-dns** - xPRO partner DNS configuration
+`airbyte`, `aws-ecr`, `aws-sftp`, `b2b-partners-storage`, `celery-monitoring`,
+`clickhouse`, `data_warehouse`, `digital-credentials`, `fastly-redirector`,
+`jupyterhub-data`, `mailgun`, `marimo-data`, `mongodb-atlas`, `monitoring`,
+`ocw-site`, `open-discussions`, `open-metadata`, `open-metadata-substructure`,
+`opensearch`, `qdrant-cloud`, `release-bot`, `rootly`, `sentry`, `starrocks`,
+`starrocks-substructure`, `starburst`, `tika`, `toolhive-apps`, `toolhive-data`,
+`toolhive-operator`, `toolhive-swe`, `vector-log-proxy`, `xpro-partner-dns`
+
+`meta.py` also carries `qa_app_names` (`starrocks-substructure-qa`) and
+`ci_app_names` (`starrocks-substructure-ci`), selected via `--env qa` / `--env ci`
+for the odl-qa and odl-ci Concourse instances respectively.
+
+Note that `pipeline_params` in `pipeline.py` is a superset — an entry there is
+only deployed once its name is also added to the appropriate list in `meta.py`.
 
 ## Files
 
 - **`meta.py`**: Meta pipeline generator that creates/updates individual app pipelines
 - **`definition.json`**: Generated pipeline definition for the meta-pipeline
-- **`simple_pulumi_pipeline.py`**: Template for generating individual app pipelines
+- **`pipeline.py`**: `SimplePulumiParams` definitions plus the template for generating individual app pipelines
 - **`__init__.py`**: Package initialization
 
 ## Usage
@@ -50,7 +50,7 @@ fly -t pr-inf sp -p simple-pulumi-meta -c definition.json
 
 ### Adding a New Application
 
-1. Add configuration to `pipeline_params` in `simple_pulumi_pipeline.py`:
+1. Add configuration to `pipeline_params` in `pipeline.py`:
 
 ```python
 pipeline_params: dict[str, SimplePulumiParams] = {
@@ -87,7 +87,7 @@ fly -t pr-inf sp -p simple-pulumi-meta -c definition.json
 You can test generating a single app pipeline:
 
 ```bash
-python simple_pulumi_pipeline.py tika
+python pipeline.py tika
 ```
 
 This outputs the pipeline definition to both `definition.json` and stdout.
@@ -118,7 +118,7 @@ class SimplePulumiParams(BaseModel):
 1. **Git Resource**: Watches for changes to the meta pipeline code
 2. **Per-App Jobs**: For each app in `app_names`:
    - Fetches pipeline definitions from git
-   - Runs `simple_pulumi_pipeline.py {app_name}`
+   - Runs `pipeline.py {app_name}`
    - Sets the generated pipeline as `pulumi-{app_name}`
 3. **Self-Update Job**: Updates the meta pipeline itself when code changes
 
@@ -144,7 +144,7 @@ If you're migrating an existing pipeline to this pattern:
 
 1. Verify the app follows the simple Pulumi-only pattern (no builds)
 2. Extract parameters from the old pipeline file
-3. Add configuration to `simple_pulumi_pipeline.py`
+3. Add configuration to `pipeline.py`
 4. Add app name to `meta.py`
 5. Deploy meta pipeline
 6. Verify new pipeline works correctly
@@ -154,7 +154,7 @@ If you're migrating an existing pipeline to this pattern:
 
 ### Pipeline not generating
 
-- Check app name is in both `pipeline_params` (simple_pulumi_pipeline.py) and `app_names` (meta.py)
+- Check app name is in both `pipeline_params` (pipeline.py) and `app_names` (meta.py)
 - Verify the pipeline definitions repository is accessible
 - Check Concourse logs for the specific job
 


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
The odl-prod Concourse dashboard had become unusable as a navigation surface: 84 tiles on `infrastructure` and 32 on `main`, laid out in creation order with no grouping, so finding a pipeline required the search box and prior knowledge of its name.

Concourse 8.2.4 has no folder/tag primitive for distinct pipelines inside a team, and the `infrastructure` team cannot be split into sub-teams as things stand — its privileged EC2 workers are registered `--team infrastructure` and are exclusive to it. That leaves display ordering as the only zero-risk lever: `fly order-pipelines` writes a display-order field and touches no pipeline config, build history, credentials, or source.

**`bin/concourse-order-pipelines`** — a cyclopts CLI (`show` / `check` / `apply`, with `--dry-run`, `--target`, `--team`, `--order-file`) holding the curated ordering. Encoding it as a script rather than one-shot shell history is the point: the cluster assignments become the reviewable artifact, and the ordering can be re-applied idempotently.

- `infrastructure` (84): meta → core-platform → data-platform → open-edx → applications → deprecated
- `main` (32): meta → concourse-tooling → base-images → package-publishing → apps-misc → deprecated

`apply` always sends the complete live tile list. Live pipelines absent from the curation are appended in an `unclustered` bucket rather than dropped, so a newly-created pipeline degrades to "sorted last, flagged by `check`" instead of silently producing a partial ordering. Curated names that no longer exist are skipped, since `fly` errors on unknown names. Instanced pipelines are deduped to one entry per tile; archived pipelines are excluded.

**`docs/plans/concourse-dashboard-reorganization.md`** — the spec, tracked alongside the existing `granian-configuration-overhaul.md`. It records two decisions made while building this, both of which change the shape of later phases:

1. **Grouping pivots from naming prefixes to semantic teams.** Teams give real partitioning — separate dashboards, RBAC, and secret namespaces — where prefixes only simulate grouping via sort order. A worker takes exactly one team or none (concourse/concourse#2633, multi-team workers, was closed "not planned"), so this reduces to either unbinding the pool and routing with step tags, or one ASG per team. The former is chosen: per-team pools would take the baseline from min 2 to min 8 `m7a.4xlarge` and fragment burst capacity, partially undoing the spot diversification from #5112. The cost is written down rather than glossed — that pool's instance profile carries the Pulumi deploy role, and Concourse tags are a scheduling hint, not authorization, so unbinding converts an enforced boundary into a conventional one.
2. **Teams-as-code is reclassified from "independent" to a prerequisite** for the above, since membership must be reviewable before that boundary is relaxed.

**`simple_pulumi/README.md`** — documented 16 managed apps against a `production_app_names` that has held 33 for some time.

### How can this be tested?

Phase 1 is **already applied to odl-prod** and verified; this PR captures the tooling and rationale. To re-verify:

```
uv run bin/concourse-order-pipelines check --target odl-prod   # exits 0 when clean
uv run bin/concourse-order-pipelines show                      # ordering, no network
uv run bin/concourse-order-pipelines apply --target odl-prod --dry-run
```

Current state: `infrastructure` 84/84 and `main` 32/32, both matching the curated ordering, no phantoms and no uncurated pipelines. Ordering is pure display state, so re-running `apply` with any list fully reverts it.

The tooling was validated end-to-end on `odl-ci` before prod, using a scratch `--order-file`: a real apply, plus `check` correctly reporting a phantom name, an uncurated pipeline, and order drift (exit 1), then clean (exit 0). `odl-ci` was restored to its original order afterward.

**One open question was settled empirically**, because it determined whether this is run-once or a scheduled job: `set_pipeline` does *not* reset display order. Every pipeline here is re-applied by a meta pipeline on a git-trigger loop, so had ordering been reset, the curation would need re-applying on a schedule. Tested on `odl-ci` by creating three throwaway paused pipelines, ordering them to the top, then re-setting one with a genuinely changed config — confirmed written by diffing `fly get-pipeline` (`v2-changed` on the target, `v1` on an untouched sibling). Order was byte-identical after. New pipelines append to the end. Test pipelines were destroyed and the team's order restored.

### Additional Context

Reviewers should focus on the **cluster assignments** in `PIPELINE_ORDER` — that is the judgement call, and it is cheap to change (re-run `apply`). Two placements were deliberate: Keycloak sits in core-platform rather than open-edx (it is the org-wide IdP), and `ol-analytics-api-pipeline` sits in data-platform despite being a `k8s_apps` app, because it reads as part of the data stack.

Note the `deprecated` clusters are load-bearing, not cosmetic — they park tiles pending a Phase 2 archive decision:

- The three `-relesae-test` pipelines have **no definition anywhere in this repo** and still hold production deploy jobs for micromasters, ODL Video Service, and xPro. They are not dormant. Archiving them needs product-owner confirmation that the EC2/`ol-application` path is retired, not just a cleanup pass.
- `dcind-resource-image` and `docker-google-ads-opt-image` exist in *both* teams and double-build; the `infrastructure` copies are orphans, but `main/dcind-resource-image` build #1 is still pending, so it needs unsticking before the orphans can go.
- `publish-ol-django-pypi` has errored on every job since 2026-06-08 (`failed to interpolate task config: undefined vars: github.odlbot_private_ssh_key` — it runs on `main`, which has no `github` secret group). Per the owner, this pipeline is wrong by design and should be removed or left broken rather than repaired, so it is parked rather than fixed.

Separately, an inventory taken for the team-split design found that `src/bridge/secrets/concourse/operations.production.yaml` is **not** a complete picture of `/secret-concourse` — five live groups have no SOPS entry (`infrastructure/{dockerhub,mit-github,unified_ecommerce_api_clients}`, `main/{consul,fastly}`), and `infrastructure/dockerhub` is provably load-bearing. Anything reasoning about per-team secret ownership should use `vault kv list`, not SOPS. That is tracked separately and not addressed here.
