### PR TITLE
fix: Set the proper env var for MITx Online to pick up the Fastly settings

### DIFF
--- a/src/ol_infrastructure/applications/mitxonline/k8s_secrets.py
+++ b/src/ol_infrastructure/applications/mitxonline/k8s_secrets.py
@@ -226,9 +226,9 @@ def create_mitxonline_k8s_secrets(
             "base_name": "collected",
             "path": "collected-static-secrets",
             "templates": {
-                "FASTLY_API_KEY": '{{ index .Secrets "fastly" "api_key" }}',
-                "FASTLY_AUTH_TOKEN": '{{ index .Secrets "fastly" "api_key" }}',
-                "FASTLY_SERVICE_ID": '{{ index .Secrets "fastly" "service_id" }}',
+                "MITX_ONLINE_FASTLY_API_KEY": '{{ index .Secrets "fastly" "api_key" }}',
+                "MITX_ONLINE_FASTLY_AUTH_TOKEN": '{{ index .Secrets "fastly" "api_key" }}',
+                "MITX_ONLINE_FASTLY_SERVICE_ID": '{{ index .Secrets "fastly" "service_id" }}',
                 "HUBSPOT_HOME_PAGE_FORM_GUID": '{{ index .Secrets "hubspot" "formId" }}',
                 "HUBSPOT_PORTAL_ID": '{{ index .Secrets "hubspot" "portalId" }}',
                 "MITOL_GOOGLE_SHEETS_DRIVE_API_PROJECT_ID": '{{ index .Secrets "google-sheets" "drive-api-project-id" }}',


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/12381

### Description (What does it do?)
<!--- Describe your changes in detail -->
Aligns the keys set by the deployment with the keys that the app is reading

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Deploy and try updating an article to ensure that the cache purges and the content updates

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->
Fastly purging from the app is failing and it looks like it's because there's a mismatch between the keys being set and the keys that the app is expecting for the Fastly settings.

