### PR TITLE
config: Make mit_learn resource limits configurable via stack

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.QA.yaml
@@ -4,6 +4,11 @@ encryptedkey: AQICAHg42pDDDGBhpaX14TdtzcK1hbiMYTHsYRH4k5GL5RFpIwEi8MniqKSK7PJ7AI
 config:
 
   mitlearn:api_domain: "api.rc.learn.mit.edu"
+  mitlearn:celery_default_resource_requests:
+    cpu: "200m"
+    memory: "4800Mi"
+  mitlearn:celery_default_resource_limits:
+    memory: "4800Mi"
   mitlearn:db_instance_size: db.m7g.xlarge
   mitlearn:db_password:
     secure: v1:Xk9oxNvxSQAJUAHE:8CdeLN2SlyhyU0iZpqEX5rnHSJ3PClleDJi2UpzoCsVZ4UjNkr7vCOAKY7CvCuB/7CBKJKM=

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1491,39 +1491,45 @@ webapp_keda_config = build_webapp_keda_config(
     mitlearn_config=mitlearn_config,
 )
 
+
 # Resource requests/limits, configurable per-stack via Pulumi config, falling back
-# to these hard-coded defaults when unset.
-webapp_resource_requests = mitlearn_config.get_object("webapp_resource_requests") or {
-    "cpu": "500m",
-    "memory": "3200Mi",
-}
-webapp_resource_limits = mitlearn_config.get_object("webapp_resource_limits") or {
-    "memory": "3200Mi",
-}
-celery_default_resource_requests = mitlearn_config.get_object(
-    "celery_default_resource_requests"
-) or {"cpu": "200m", "memory": "2400Mi"}
-celery_default_resource_limits = mitlearn_config.get_object(
-    "celery_default_resource_limits"
-) or {"memory": "2400Mi"}
-celery_edx_content_resource_requests = mitlearn_config.get_object(
-    "celery_edx_content_resource_requests"
-) or {"cpu": "200m", "memory": "2400Mi"}
-celery_edx_content_resource_limits = mitlearn_config.get_object(
-    "celery_edx_content_resource_limits"
-) or {"memory": "2400Mi"}
-celery_embeddings_resource_requests = mitlearn_config.get_object(
-    "celery_embeddings_resource_requests"
-) or {"cpu": "200m", "memory": "2400Mi"}
-celery_embeddings_resource_limits = mitlearn_config.get_object(
-    "celery_embeddings_resource_limits"
-) or {"memory": "2400Mi"}
-celery_beat_resource_requests = mitlearn_config.get_object(
-    "celery_beat_resource_requests"
-) or {"cpu": "100m", "memory": "2048Mi"}
-celery_beat_resource_limits = mitlearn_config.get_object(
-    "celery_beat_resource_limits"
-) or {"memory": "2048Mi"}
+# to these hard-coded defaults when unset. Stack overrides are merged onto the
+# defaults (rather than replacing them outright) so a stack that only overrides
+# one key (e.g. `memory`) doesn't silently drop the other (e.g. `cpu`).
+def _resource_config(config_key: str, default: dict[str, str]) -> dict[str, str]:
+    return {**default, **(mitlearn_config.get_object(config_key) or {})}
+
+
+webapp_resource_requests = _resource_config(
+    "webapp_resource_requests", {"cpu": "500m", "memory": "3200Mi"}
+)
+webapp_resource_limits = _resource_config(
+    "webapp_resource_limits", {"memory": "3200Mi"}
+)
+celery_default_resource_requests = _resource_config(
+    "celery_default_resource_requests", {"cpu": "200m", "memory": "2400Mi"}
+)
+celery_default_resource_limits = _resource_config(
+    "celery_default_resource_limits", {"memory": "2400Mi"}
+)
+celery_edx_content_resource_requests = _resource_config(
+    "celery_edx_content_resource_requests", {"cpu": "200m", "memory": "2400Mi"}
+)
+celery_edx_content_resource_limits = _resource_config(
+    "celery_edx_content_resource_limits", {"memory": "2400Mi"}
+)
+celery_embeddings_resource_requests = _resource_config(
+    "celery_embeddings_resource_requests", {"cpu": "200m", "memory": "2400Mi"}
+)
+celery_embeddings_resource_limits = _resource_config(
+    "celery_embeddings_resource_limits", {"memory": "2400Mi"}
+)
+celery_beat_resource_requests = _resource_config(
+    "celery_beat_resource_requests", {"cpu": "100m", "memory": "2048Mi"}
+)
+celery_beat_resource_limits = _resource_config(
+    "celery_beat_resource_limits", {"memory": "2048Mi"}
+)
 
 # Configure and deploy the mitlearn application using OLApplicationK8s
 mitlearn_k8s_app = OLApplicationK8s(

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1491,6 +1491,40 @@ webapp_keda_config = build_webapp_keda_config(
     mitlearn_config=mitlearn_config,
 )
 
+# Resource requests/limits, configurable per-stack via Pulumi config, falling back
+# to these hard-coded defaults when unset.
+webapp_resource_requests = mitlearn_config.get_object("webapp_resource_requests") or {
+    "cpu": "500m",
+    "memory": "3200Mi",
+}
+webapp_resource_limits = mitlearn_config.get_object("webapp_resource_limits") or {
+    "memory": "3200Mi",
+}
+celery_default_resource_requests = mitlearn_config.get_object(
+    "celery_default_resource_requests"
+) or {"cpu": "200m", "memory": "2400Mi"}
+celery_default_resource_limits = mitlearn_config.get_object(
+    "celery_default_resource_limits"
+) or {"memory": "2400Mi"}
+celery_edx_content_resource_requests = mitlearn_config.get_object(
+    "celery_edx_content_resource_requests"
+) or {"cpu": "200m", "memory": "2400Mi"}
+celery_edx_content_resource_limits = mitlearn_config.get_object(
+    "celery_edx_content_resource_limits"
+) or {"memory": "2400Mi"}
+celery_embeddings_resource_requests = mitlearn_config.get_object(
+    "celery_embeddings_resource_requests"
+) or {"cpu": "200m", "memory": "2400Mi"}
+celery_embeddings_resource_limits = mitlearn_config.get_object(
+    "celery_embeddings_resource_limits"
+) or {"memory": "2400Mi"}
+celery_beat_resource_requests = mitlearn_config.get_object(
+    "celery_beat_resource_requests"
+) or {"cpu": "100m", "memory": "2048Mi"}
+celery_beat_resource_limits = mitlearn_config.get_object(
+    "celery_beat_resource_limits"
+) or {"memory": "2048Mi"}
+
 # Configure and deploy the mitlearn application using OLApplicationK8s
 mitlearn_k8s_app = OLApplicationK8s(
     ol_app_k8s_config=OLApplicationK8sConfig(
@@ -1544,31 +1578,31 @@ mitlearn_k8s_app = OLApplicationK8s(
                 max_replicas=20,
                 redis_host=redis_cache.address,
                 redis_password=redis_config.require("password"),
-                resource_requests={"cpu": "200m", "memory": "2400Mi"},
-                resource_limits={"memory": "2400Mi"},
+                resource_requests=celery_default_resource_requests,
+                resource_limits=celery_default_resource_limits,
             ),
             OLApplicationK8sCeleryWorkerConfig(
                 queue_name="edx_content",
                 redis_host=redis_cache.address,
                 redis_password=redis_config.require("password"),
-                resource_requests={"cpu": "200m", "memory": "2400Mi"},
-                resource_limits={"memory": "2400Mi"},
+                resource_requests=celery_edx_content_resource_requests,
+                resource_limits=celery_edx_content_resource_limits,
             ),
             OLApplicationK8sCeleryWorkerConfig(
                 queue_name="embeddings",
                 max_replicas=30,
                 redis_host=redis_cache.address,
                 redis_password=redis_config.require("password"),
-                resource_requests={"cpu": "200m", "memory": "2400Mi"},
-                resource_limits={"memory": "2400Mi"},
+                resource_requests=celery_embeddings_resource_requests,
+                resource_limits=celery_embeddings_resource_limits,
             ),
         ],
         celery_beat_config=OLApplicationK8sCeleryBeatConfig(
-            resource_requests={"cpu": "100m", "memory": "2048Mi"},
-            resource_limits={"memory": "2048Mi"},
+            resource_requests=celery_beat_resource_requests,
+            resource_limits=celery_beat_resource_limits,
         ),
-        resource_requests={"cpu": "500m", "memory": "3200Mi"},
-        resource_limits={"memory": "3200Mi"},
+        resource_requests=webapp_resource_requests,
+        resource_limits=webapp_resource_limits,
         # Preserves the bounds of the hand-rolled mitlearn-webapp-vpa this replaces.
         # The floor is deliberately well below resource_limits (unlike the component
         # default, which pins the floor at the limit) so the VPA can also size these


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
The webapp, celery worker (`default`, `edx_content`, `embeddings`), and celery beat resource requests/limits in [`src/ol_infrastructure/applications/mit_learn/__main__.py`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/applications/mit_learn/__main__.py) were hard-coded, so tuning them per environment required a code change. This PR pulls each `resource_requests`/`resource_limits` dict out into Pulumi stack config (via `mitlearn_config.get_object(...)`), falling back to the previous hard-coded values when unset, so CI/QA/Production can override independently without touching `__main__.py`.

As a first use of this, QA's `default` celery worker queue now gets double the memory (`2400Mi` -> `4800Mi`, both request and limit) via an override in `Pulumi.QA.yaml`. CPU and all other queues/environments are unchanged.

### Screenshots (if appropriate):
N/A - no UI changes

### How can this be tested?
- `uv run pre-commit run --files src/ol_infrastructure/applications/mit_learn/__main__.py src/ol_infrastructure/applications/mit_learn/Pulumi.QA.yaml` passes (ruff, mypy, yaml checks all green).
- `pulumi preview --stack QA` for the `mit_learn` project should show the `default` celery worker deployment's container resources changing from `2400Mi` request/limit to `4800Mi`, with no other resources affected.
- `pulumi preview --stack CI` / `--stack Production` should show no diff, since neither stack config sets the new keys and the code falls back to the prior hard-coded defaults.

### Additional Context
New Pulumi config keys added (all under the `mitlearn:` namespace, all optional with defaults matching current hard-coded values):
- `webapp_resource_requests` / `webapp_resource_limits`
- `celery_default_resource_requests` / `celery_default_resource_limits`
- `celery_edx_content_resource_requests` / `celery_edx_content_resource_limits`
- `celery_embeddings_resource_requests` / `celery_embeddings_resource_limits`
- `celery_beat_resource_requests` / `celery_beat_resource_limits`