### PR TITLE
fix: pin typesense/meilisearch to core nodegroup, diversify AZs

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/meilisearch.py
+++ b/src/ol_infrastructure/applications/edxapp/meilisearch.py
@@ -127,6 +127,13 @@ def create_meilisearch_resources(
                 "memory": meilisearch_config.get("memory_limit") or "512Mi",
             },
         },
+        # Pin to the static on-demand core nodegroup instead of the
+        # Karpenter spot fleet: its PVC is zone-locked once bound, and spot
+        # rebalance-recommendation waves were cordoning nodes faster than
+        # the pod could reach Ready (2026-07-27 TMM).
+        "nodeSelector": {
+            "ol.mit.edu/core_node": "true",
+        },
     }
 
     return kubernetes.helm.v3.Release(

--- a/src/ol_infrastructure/applications/edxapp/typesense.py
+++ b/src/ol_infrastructure/applications/edxapp/typesense.py
@@ -80,6 +80,28 @@ def create_typesense_resources(
             "adminApiKey": {
                 "name": typesense_bootstrap_key_name,
             },
+            # Pin to the static on-demand core nodegroup instead of the
+            # Karpenter spot fleet: typesense's PVCs are zone-locked once
+            # bound, and spot rebalance-recommendation waves were cordoning
+            # the node a replica's PVC was pinned to faster than the pod
+            # could reach Ready, keeping the StatefulSet permanently
+            # unstable (2026-07-27 TMM).
+            "nodeSelector": {
+                "ol.mit.edu/core_node": "true",
+            },
+            "topologySpreadConstraints": [
+                {
+                    "maxSkew": 1,
+                    "topologyKey": "topology.kubernetes.io/zone",
+                    "whenUnsatisfiable": "ScheduleAnyway",
+                    "labelSelector": {
+                        "matchLabels": {
+                            "app.kubernetes.io/name": "typesense",
+                            "app.kubernetes.io/instance": f"{stack_info.env_prefix}-ts",
+                        },
+                    },
+                },
+            ],
         },
         opts=ResourceOptions(depends_on=[typesense_bootstrap_key]),
     )

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.residential.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.residential.Production.yaml
@@ -40,9 +40,9 @@ config:
         ol.mit.edu/gpu_node: false
       node_group_options: {}
       scaling:
-        desired: 3
+        desired: 4
         max: 5
-        min: 3
+        min: 4
       tags:
         cluster: residential-production
       taints: {}


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Karpenter's `default` spot NodePool in `residential-production` had converged almost its entire fleet onto a single (`c7a.large`, `us-east-1d`) pool. An AWS spot rebalance-recommendation wave cordoned 9 of 11 nodes simultaneously. Because the `typesense` StatefulSet's PVCs are zone-locked to `us-east-1d` once bound, every replacement pod kept landing back on that same fragile pool and got cordoned again before it could reach `Ready` — the `mitx-staging-ts-sts-1` pod was recreated 50+ times in under 5 days, and the identical failure was live on `mitx-ts-sts-1` in production at the same time.

Changes:
- **`infrastructure/aws/eks/Pulumi.residential.Production.yaml`**: bump the core nodegroup (`worker-xlarge`) `desired`/`min` from 3 to 4, so all 4 AZ subnets (a/b/c/d) always have an on-demand core node. Previously the ASG only ran 3 nodes across those 4 subnets, leaving whichever AZ was momentarily uncovered (currently `us-east-1d` — the exact AZ typesense's PVCs are pinned to) without a stable landing spot.
- **`applications/edxapp/typesense.py`**: add `nodeSelector: {ol.mit.edu/core_node: "true"}` to the `TypesenseCluster` CR spec, pinning it to the static on-demand core nodegroup instead of the Karpenter spot fleet. Also add a zone-based `topologySpreadConstraint` (`maxSkew: 1`, `whenUnsatisfiable: ScheduleAnyway`) so future replica placement diversifies across AZs instead of concentrating in one, as all 3 existing replicas currently do.
- **`applications/edxapp/meilisearch.py`**: same `nodeSelector` added via the Helm chart's `nodeSelector` value.

Both the `TypesenseCluster` CRD and the meilisearch Helm chart natively support `nodeSelector`/`tolerations`/`affinity` (and `topologySpreadConstraints` for the CRD), confirmed against the live cluster's installed CRD schema and `helm show values`.

### Screenshots (if appropriate):
N/A — no UI changes.

### How can this be tested?
- `pulumi preview` for `infrastructure/aws/eks` (stack `residential.Production`) should show only the ASG `desiredCapacity`/`minSize` change (3→4) on `residential-production-eks-nodegroup-worker-xlarge`, plus a launch template refresh due to unrelated pre-existing AMI drift already pending in that stack.
- `pulumi preview` for `applications/edxapp` (stacks `mitx-staging.Production` and `mitx.Production`) should show the `TypesenseCluster` CR and meilisearch Helm release gaining `nodeSelector`/`topologySpreadConstraints`.
- After apply, `kubectl get pods -o wide` for `mitx-staging-ts-sts-*` and `mitx-ts-sts-*` should show them scheduled on `node_size=m8i-flex.2xlarge` core nodes (`kubectl get nodes -l ol.mit.edu/core_node=true`) rather than Karpenter spot nodes, and stop churning.
- `pre-commit run` and `mypy` already pass locally on the three changed files.

### Additional Context
- This does **not** rebalance the 3 existing staging `typesense` PVCs, which are all currently bound to `us-east-1d` (no AZ diversity) — that's a separate, deliberate live-data operation (delete+recreate one PVC at a time, letting the operator resync each replica from the other 2 quorum members) intentionally left out of this PR.
- The `infrastructure/aws/eks` stack for `residential.Production` currently has unrelated pending drift bundled in with this change when previewed (an AMI bump that would roll all 3 core nodes, a Fastly API key rotation, and 2 Helm chart version bumps for `vault-secrets-operator`/`vertical-pod-autoscaler`). Applying this PR's nodegroup scaling change may need to be done with a targeted `pulumi up --target` on the ASG resource to avoid pulling in that unrelated drift, or that drift should be reconciled first.