### PR TITLE
fix: skip pulumi refresh for Fastly-provisioning pipelines during token rotation

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
@@ -115,6 +115,11 @@ class AppPipelineParams(BaseModel):
             source maps to Sentry with an auth token -- the token never enters the
             image build. See :class:`SentrySourcemapsConfig`. Left unset, no source
             maps are uploaded.
+        refresh_stack (bool): Whether the Pulumi deploy jobs run `pulumi refresh`
+            before `up`. Defaults to True. Set False for apps whose Pulumi code
+            provisions Fastly resources while the Fastly API token is being
+            rotated -- refresh calls the Fastly API with the old token and fails
+            the whole job.
     """
 
     app_name: str
@@ -134,6 +139,7 @@ class AppPipelineParams(BaseModel):
     github_repo: str | None = None
     use_release_resource_workflow: bool = False
     sentry_sourcemaps: SentrySourcemapsConfig | None = None
+    refresh_stack: bool = True
 
     @model_validator(mode="after")
     def set_repo_name(self) -> "AppPipelineParams":
@@ -179,8 +185,11 @@ pipeline_params = {
         repo_main_branch=app_repo_main_branch("micromasters"),
         settings_dir="micromasters",
         version_file="VERSION",
+        refresh_stack=False,
     ),
-    "mitxonline": AppPipelineParams(app_name="mitxonline", build_target="production"),
+    "mitxonline": AppPipelineParams(
+        app_name="mitxonline", build_target="production", refresh_stack=False
+    ),
     "mit-learn-nextjs": AppPipelineParams(
         app_name="mit-learn-nextjs",
         # No build_target: use the default `runner` stage, which bakes `yarn build`
@@ -208,7 +217,10 @@ pipeline_params = {
         repo_main_branch=app_repo_main_branch("xpro"),
         build_target="production",
         settings_dir="mitxpro",
+        refresh_stack=False,
     ),
+    "learn-ai": AppPipelineParams(app_name="learn-ai", refresh_stack=False),
+    "mit-learn": AppPipelineParams(app_name="mit-learn", refresh_stack=False),
     "ocw-studio": AppPipelineParams(
         app_name="ocw-studio",
         repo_main_branch=app_repo_main_branch("ocw-studio"),
@@ -679,7 +691,7 @@ def _build_legacy_app_pipeline(
         pulumi_job(
             pulumi_code=ol_infra_repo,
             stack_name="CI",
-            refresh_stack=True,
+            refresh_stack=pipeline_parameters.refresh_stack,
             project_name=f"ol-application-{app_name}",
             project_source_path=(
                 f"src/ol_infrastructure/applications/{app_name.replace('-', '_')}"
@@ -721,7 +733,7 @@ def _build_legacy_app_pipeline(
         additional_post_steps = {0: qa_purge_steps, 1: prod_purge_steps}
 
     qa_and_production_fragment = pulumi_jobs_chain(
-        refresh_stack=True,
+        refresh_stack=pipeline_parameters.refresh_stack,
         pulumi_code=ol_infra_repo,
         stack_names=["QA", "Production"],
         project_name=f"ol-application-{app_name}",
@@ -1215,7 +1227,7 @@ def _build_release_resource_app_pipeline(
     ci_fragment = pulumi_job(
         pulumi_code=ol_infra_repo,
         stack_name="CI",
-        refresh_stack=True,
+        refresh_stack=pipeline_parameters.refresh_stack,
         project_name=f"ol-application-{app_name}",
         project_source_path=(
             f"src/ol_infrastructure/applications/{app_name.replace('-', '_')}"
@@ -1312,7 +1324,7 @@ def _build_release_resource_app_pipeline(
 
     # QA and Production Deployments
     qa_and_production_fragment = pulumi_jobs_chain(
-        refresh_stack=True,
+        refresh_stack=pipeline_parameters.refresh_stack,
         pulumi_code=ol_infra_repo,
         stack_names=["QA", "Production"],
         project_name=f"ol-application-{app_name}",

--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
@@ -117,6 +117,11 @@ class SimplePulumiParams(BaseModel):
                           added so this pipeline gates on the prior stage's deployment
                           issue being closed, preserving the same promotion workflow
                           used within a single chained pipeline.
+        refresh_stack: Whether the Pulumi deploy jobs run `pulumi refresh` before
+                      `up`. Defaults to True. Set False for apps whose Pulumi code
+                      provisions Fastly resources while the Fastly API token is
+                      being rotated -- refresh calls the Fastly API with the old
+                      token and fails the whole job.
     """
 
     app_name: str
@@ -131,6 +136,7 @@ class SimplePulumiParams(BaseModel):
     docker_image: DockerImageConfig | None = None
     build: BuildConfig | None = None
     prior_stage_stack: str | None = None
+    refresh_stack: bool = True
 
     @model_validator(mode="before")
     @classmethod
@@ -333,6 +339,7 @@ pipeline_params: dict[str, SimplePulumiParams] = {
         app_name="fastly-redirector",
         pulumi_project_path="applications/fastly_redirector/",
         pulumi_project_name="ol-application-fastly-redirector",
+        refresh_stack=False,
     ),
     "jupyterhub-data": SimplePulumiParams(
         app_name="jupyterhub-data",
@@ -356,6 +363,7 @@ pipeline_params: dict[str, SimplePulumiParams] = {
         pulumi_project_path="applications/ocw_site/",
         pulumi_project_name="ol-application-ocw-site",
         stages=["QA", "Production"],
+        refresh_stack=False,
     ),
     "open-discussions": SimplePulumiParams(
         app_name="open-discussions",
@@ -743,7 +751,7 @@ def build_simple_pulumi_pipeline(app_name: str) -> Pipeline:
                 # Create a job chain for this deployment group
                 group_fragment = pulumi_jobs_chain(
                     pulumi_code,
-                    refresh_stack=True,
+                    refresh_stack=params.refresh_stack,
                     project_name=params.pulumi_project_name,
                     stack_names=group_stacks,
                     project_source_path=PULUMI_CODE_PATH.joinpath(
@@ -775,7 +783,7 @@ def build_simple_pulumi_pipeline(app_name: str) -> Pipeline:
             # Single chain for simple discovered stacks
             pulumi_fragment = pulumi_jobs_chain(
                 pulumi_code,
-                refresh_stack=True,
+                refresh_stack=params.refresh_stack,
                 project_name=params.pulumi_project_name,
                 stack_names=discovered_stacks,
                 project_source_path=PULUMI_CODE_PATH.joinpath(
@@ -812,7 +820,7 @@ def build_simple_pulumi_pipeline(app_name: str) -> Pipeline:
 
         pulumi_fragment = pulumi_jobs_chain(
             pulumi_code,
-            refresh_stack=True,
+            refresh_stack=params.refresh_stack,
             project_name=params.pulumi_project_name,
             stack_names=stack_names,
             project_source_path=PULUMI_CODE_PATH.joinpath(params.pulumi_project_path),

--- a/src/ol_concourse/pipelines/open_edx/edx_platform_v3/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/edx_platform_v3/pipeline.py
@@ -214,7 +214,9 @@ def build_edx_pipeline(release_names: list[str]) -> Pipeline:  # noqa: ARG001
             pulumi_fragments.append(
                 pulumi_jobs_chain(
                     edx_pulumi_code,
-                    refresh_stack=True,
+                    # edxapp's Pulumi code provisions Fastly resources; refresh
+                    # calls the Fastly API and fails while the token is rotated.
+                    refresh_stack=False,
                     stack_names=[
                         f"{deployment.deployment_name}.{stage}"
                         for stage in deployment.envs_by_release(release_name)


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
The Fastly API token is being revoked and recreated, which breaks the `pulumi refresh` step for every Concourse pipeline whose Pulumi code provisions Fastly resources -- refresh calls the Fastly API with the old token and fails the whole deploy job before it ever reaches `up`.

Pulumi itself has no per-resource "skip refresh" option (confirmed against the installed `pulumi` Python SDK, v3.254 -- `ResourceOptions` has no `refresh` field). The actual control point is the `refresh_stack` param on this repo's shared `pulumi_jobs_chain`/`pulumi_job` Concourse job builders, which toggles the `refresh_stack` param on the `pulumi-provisioner` resource's `put` step.

Changes:
- Added a `refresh_stack: bool = True` field to `AppPipelineParams` (`k8s_apps/pipeline.py`) and `SimplePulumiParams` (`simple_pulumi/pipeline.py`), threaded through to all `pulumi_job`/`pulumi_jobs_chain` call sites in each file.
- Set `refresh_stack=False` for the apps whose Pulumi code provisions Fastly resources: `xpro`, `micromasters`, `mitxonline`, `learn-ai`, `mit-learn` (k8s_apps), `fastly-redirector`, `ocw-site` (simple_pulumi).
- `edxapp` (`edx_platform_v3/pipeline.py`) has no per-app params model, so `refresh_stack=False` is set directly at its single `pulumi_jobs_chain` call site (applies to all edxapp deployments, which share one Pulumi project that provisions Fastly resources).

This only disables the automatic refresh-before-update for these specific stacks; `pulumi up` still runs normally. Refresh can be re-enabled per-app once the Fastly token rotation is stable.

### Screenshots (if appropriate):
N/A

### How can this be tested?
Regenerated each affected pipeline's JSON locally and confirmed `refresh_stack: false` lands on the `pulumi-provisioner` put step params, e.g.:

```
deploy-ol-application-xpro-ci False
deploy-ol-application-xpro-qa False
deploy-ol-application-xpro-production False
deploy-ol-application-fastly-redirector-ci False
deploy-ol-application-fastly-redirector-qa False
deploy-ol-application-fastly-redirector-production False
deploy-ol-application-ocw-site-qa False
deploy-ol-application-ocw-site-production False
```

`pre-commit` (ruff format/check, mypy) passes on all three edited files. Reviewer validation: after merge, watch the next CI/QA run of one of the affected pipelines (e.g. `xpro` or `fastly-redirector`) and confirm the `pulumi-provisioner` job's Concourse output no longer attempts a refresh step and no longer errors on Fastly auth.

### Additional Context
Once the Fastly token has stabilized, `refresh_stack` should be flipped back to `True` (or removed) for these apps to restore normal drift detection.