### PR TITLE
Granian stage 1: adopt new concurrency defaults for ocw_studio and odl_video_service

### DIFF
--- a/docs/plans/granian-configuration-overhaul.md
+++ b/docs/plans/granian-configuration-overhaul.md
@@ -1,7 +1,6 @@
 # Granian configuration overhaul
 
-**Status:** stage 0 (component change) merged 2026-07-23 (#5083); stage 1 in review as of
-2026-07-27; stages 2–4 pending
+**Status:** stage 0 merged 2026-07-23 (#5083); stage 1 in review 2026-07-27; stages 2–4 pending
 **Project:** `wp-granian-configuration-overhaul-expose-blocking-t-3debc2`
 **Component:** `src/ol_infrastructure/components/services/k8s.py` — `GranianConfig`
 **Evidence:** witan lessons `les-granianconfig-never-exposes-blocking-threads-bac-874462`,
@@ -218,13 +217,13 @@ Component change lands once; per-app behavior changes as each app's stack is dep
   Hold ≥ 3 business days at production before proceeding.
 
   Replica pre-raise was evaluated against production and **not** applied. Over the 7 days
-  to 2026-07-27 both webapps sat pinned at `min_replicas=2` with p95 CPU ≈ 3 m/pod
-  (≈ 3 % of `ocw_studio`'s 100m request, ≈ 1 % of `odl_video_service`'s 250m) and 7-day
-  peaks of 26 m and 9 m. The HPA's 60 % target has never been approached in either
+  to 2026-07-27 both webapps sat pinned at `min_replicas=2` with p95 CPU ≈ 3m/pod
+  (≈ 3% of `ocw_studio`'s 100m request, ≈ 1% of `odl_video_service`'s 250m) and 7-day
+  peaks of 26m and 9m. The HPA's 60% target has never been approached in either
   direction, so there is no scale-down to guard against. Peak working set over the same
-  window — 904 MiB of a 3Gi limit (`ocw_studio`) and 423 MiB of 1Gi
-  (`odl_video_service`) — stays under the new single-worker RSS caps of 2764 MiB and
-  921 MiB, so the cap still fires ahead of the cgroup OOM killer.
+  window — 904MiB of a 3Gi limit (`ocw_studio`) and 423MiB of 1Gi
+  (`odl_video_service`) — stays under the new single-worker RSS caps of 2764MiB and
+  921MiB, so the cap still fires ahead of the cgroup OOM killer.
 - **Stage 2 — mid traffic.** `micromasters`, `xpro`. Same edit. Health-probe split task
   becomes eligible here.
 - **Stage 3 — high traffic.** `mitxonline` (plus removal of the ceiling-based

--- a/docs/plans/granian-configuration-overhaul.md
+++ b/docs/plans/granian-configuration-overhaul.md
@@ -1,6 +1,7 @@
 # Granian configuration overhaul
 
-**Status:** stage 0 (component change) implemented 2026-07-22; stages 1–4 pending
+**Status:** stage 0 (component change) merged 2026-07-23 (#5083); stage 1 in review as of
+2026-07-27; stages 2–4 pending
 **Project:** `wp-granian-configuration-overhaul-expose-blocking-t-3debc2`
 **Component:** `src/ol_infrastructure/components/services/k8s.py` — `GranianConfig`
 **Evidence:** witan lessons `les-granianconfig-never-exposes-blocking-threads-bac-874462`,
@@ -212,9 +213,18 @@ Component change lands once; per-app behavior changes as each app's stack is dep
   `workers_max_rss` docstring corrections. No app behavior changes except for any caller
   relying on the `workers` default (none today). Unit tests + `pulumi preview` on one CI
   stack showing zero webapp diffs.
-- **Stage 1 — pilot, lower traffic.** `ocw_studio` and `odl_video_service`. Drop the
-  explicit `workers=2`, let the new defaults apply. Deploy CI → QA → production. Hold
-  ≥ 3 business days at production before proceeding.
+- **Stage 1 — pilot, lower traffic.** `ocw_studio` and `odl_video_service`. Delete each
+  app's holding-pin block, letting the new defaults apply. Deploy CI → QA → production.
+  Hold ≥ 3 business days at production before proceeding.
+
+  Replica pre-raise was evaluated against production and **not** applied. Over the 7 days
+  to 2026-07-27 both webapps sat pinned at `min_replicas=2` with p95 CPU ≈ 3 m/pod
+  (≈ 3 % of `ocw_studio`'s 100m request, ≈ 1 % of `odl_video_service`'s 250m) and 7-day
+  peaks of 26 m and 9 m. The HPA's 60 % target has never been approached in either
+  direction, so there is no scale-down to guard against. Peak working set over the same
+  window — 904 MiB of a 3Gi limit (`ocw_studio`) and 423 MiB of 1Gi
+  (`odl_video_service`) — stays under the new single-worker RSS caps of 2764 MiB and
+  921 MiB, so the cap still fires ahead of the cgroup OOM killer.
 - **Stage 2 — mid traffic.** `micromasters`, `xpro`. Same edit. Health-probe split task
   becomes eligible here.
 - **Stage 3 — high traffic.** `mitxonline` (plus removal of the ceiling-based

--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -619,17 +619,9 @@ ocw_studio_k8s_app = OLApplicationK8s(
         **docker_image_config_kwargs("OCW_STUDIO"),
         granian_config=GranianConfig(
             application_module="main.wsgi:application",
-            # Holding pins: preserve the pre-overhaul effective concurrency until
-            # this app's stage of the rollout. Granian derived backpressure=64
-            # (backlog=128 // workers=2) and blocking_threads=64 // 2 = 32.
-            # Delete all five to adopt the component defaults (1 worker, 8
-            # blocking threads, 16 backpressure).
-            # See docs/plans/granian-configuration-overhaul.md
-            workers=2,
-            runtime_mode="mt",
-            runtime_threads=2,
-            blocking_threads=32,
-            backpressure=64,
+            # Stage 1 of docs/plans/granian-configuration-overhaul.md: holding pins
+            # removed, so this app now runs on the component defaults (1 worker, 8
+            # blocking threads, 16 backpressure, runtime defaults).
             blocking_threads_idle_timeout=120,
             enable_metrics=True,
         ),

--- a/src/ol_infrastructure/applications/odl_video_service/__main__.py
+++ b/src/ol_infrastructure/applications/odl_video_service/__main__.py
@@ -842,17 +842,9 @@ ovs_k8s_app = OLApplicationK8s(
         **docker_image_config_kwargs("ODL_VIDEO_SERVICE"),
         granian_config=GranianConfig(
             application_module="odl_video.wsgi:application",
-            # Holding pins: preserve the pre-overhaul effective concurrency until
-            # this app's stage of the rollout. Granian derived backpressure=64
-            # (backlog=128 // workers=2) and blocking_threads=64 // 2 = 32.
-            # Delete all five to adopt the component defaults (1 worker, 8
-            # blocking threads, 16 backpressure).
-            # See docs/plans/granian-configuration-overhaul.md
-            workers=2,
-            runtime_mode="mt",
-            runtime_threads=2,
-            blocking_threads=32,
-            backpressure=64,
+            # Stage 1 of docs/plans/granian-configuration-overhaul.md: holding pins
+            # removed, so this app now runs on the component defaults (1 worker, 8
+            # blocking threads, 16 backpressure, runtime defaults).
             blocking_threads_idle_timeout=120,
             enable_metrics=True,
             log_level=(ovs_config.get("log_level") or "info").lower(),


### PR DESCRIPTION
### What are the relevant tickets?

N/A — tracked in the witan project `wp-granian-configuration-overhaul-expose-blocking-t-3debc2`, task `tk-stage-1-pilot-adopt-new-granian-defaults-for-ocw-e33798`. Follows https://github.com/mitodl/ol-infrastructure/pull/5083 (stage 0, the component change).

### Description (What does it do?)

Stage 1 of the Granian configuration overhaul. PR #5083 landed the `GranianConfig` changes behind per-caller **holding pins** so that merging it changed no app's request handling. This PR deletes those pins for the two lowest-traffic WSGI apps — `ocw_studio` and `odl_video_service` — so they pick up the new component defaults.

Effective per-pod change for both apps:

| Setting | Before (pinned) | After (component default) |
|---|---|---|
| `--workers` | 2 | **1** |
| `--runtime-mode` | `mt` | *(omitted → Granian's `auto`)* |
| `--runtime-threads` | 2 | **1** |
| `--blocking-threads` | 32 | **8** |
| `--backpressure` | 64 | **16** |
| `--workers-max-rss` (ocw_studio) | 1382 MiB | **2764 MiB** |
| `--workers-max-rss` (odl_video_service) | 460 MiB | **921 MiB** |

`--backlog 128`, `--blocking-threads-idle-timeout 120`, log level and the metrics flags are all unchanged.

Why the numbers move the way they do:

- The pinned `32 blocking_threads x 2 workers = 64 threads/pod` was never real throughput. Those threads all contended for two GILs on pods requesting **100m** (ocw_studio) / **250m** (odl_video_service) of CPU. Granian's own source warns when `blocking_threads > cpu_count() * 2 + 1`; neither pod is anywhere near the ~15 vCPU that would make 32 defensible. Reducing this is the change the whole project exists to make.
- `--workers-max-rss` *rises* only because it is now 90% of **one** worker's share of an unchanged container limit rather than two workers' shares. The container limit itself does not change (3Gi / 1Gi).

**Replica counts are deliberately untouched.** The plan called for pre-raising `min_replicas` on any app already sitting above ~40% of the 60% HPA CPU target, since halving per-pod workers roughly halves per-pod CPU and can trip a scale-*down*. Checked against production Prometheus over the 7 days to 2026-07-27:

| App | CPU request | p95 CPU/pod | 7d peak CPU/pod | Replicas |
|---|---|---|---|---|
| `ocw_studio` | 100m | ~3m (≈3%) | 26m (≈26%) | 2 (= `min_replicas`) |
| `odl_video_service` | 250m | ~3m (≈1%) | 9m (≈4%) | 2 (= `min_replicas`) |

Both have sat pinned at `min_replicas=2` continuously; the HPA's 60% target has never been approached in either direction, so there is no scale-down to guard against and nothing to pre-raise.

Memory headroom over the same window: peak working set 904 MiB against a 3Gi limit (`ocw_studio`) and 423 MiB against 1Gi (`odl_video_service`) — comfortably under the new single-worker RSS caps, so the cap still fires ahead of the cgroup OOM killer, which is the point of the sizing fix.

Also updates `docs/plans/granian-configuration-overhaul.md` with the stage status and the replica-sizing finding, so stage 2 (`micromasters`, `xpro`) reuses the query rather than re-deriving it — those apps may well come out differently.

### How can this be tested?

`pulumi preview` on both CI stacks shows exactly one resource updated per stack — the webapp `Deployment` — and the only field that differs is the granian container's `args`. No Service, HPA, PodMonitor, ConfigMap, or Secret churn.

`ol-application-odl-video-service` / CI:

```
    ~ kubernetes:apps/v1:Deployment: (update)
        [id=odl-video-service/ovs-app]
      ~ spec: { ~ template: { ~ spec: { ~ containers: [ ~ [1]: { ~ args: [
                                  ~ [7]: "2" => "1"
                                  ~ [9]: "--runtime-mode" => "--runtime-threads"
                                  ~ [10]: "mt" => "1"
                                  ~ [11]: "--runtime-threads" => "--blocking-threads"
                                  ~ [12]: "2" => "8"
                                  ~ [13]: "--blocking-threads" => "--backpressure"
                                  ~ [14]: "32" => "16"
                                  ~ [15]: "--backpressure" => "--workers-max-rss"
                                  ~ [16]: "64" => "921"
                                  ...
Resources:
    ~ 1 to update
    135 unchanged
```

`ol-application-ocw-studio` / CI is identical in shape, with `--workers-max-rss` `1382 => 2764`:

```
    ~ kubernetes:apps/v1:Deployment: (update)
        [id=ocw-studio/ocw-studio-app]
Resources:
    ~ 1 to update
    112 unchanged
```

(The long run of `~ [n]:` lines after the first few are positional shifts, not value changes — dropping `--runtime-mode mt` removes two elements from the list, so every later index reads as "changed" in Pulumi's array diff.)

Component unit tests still pass unchanged: `uv run pytest tests/ol_infrastructure/components/services/` → 72 passed. `pre-commit` (ruff format, ruff check, mypy, detect-secrets) clean on both touched files.

**To validate after deploy**, per the plan's validation section, comparing the same weekday-hour window before/after:

- **Latency** — granian request duration p50/p95/p99 from the existing PodMonitor scrape; nginx upstream response time as the independent check.
- **Errors** — 5xx at nginx and APISIX, specifically 502/504, which is where backpressure saturation would surface.
- **Saturation** — pod CPU vs request, HPA `currentReplicas`.
- **Memory** — OOMKill and container restart counts; `--workers-max-rss` respawns should appear in granian logs *before* any OOMKill.
- **Startup** — pod ready time, to catch probe interaction early.

### Additional Context

- Rollback is reverting this PR and redeploying. The change is entirely container args — no data or schema migration to unwind.
- Sequencing: hold **≥ 3 business days at production** on these two apps before stage 2 (`micromasters`, `xpro`). Stage 3 is `mitxonline` then `edxapp` CMS/LMS; stage 4 is the async apps.
- The TCP-liveness / HTTP-readiness probe split is deliberately **not** in this PR. It becomes eligible after stage 2 so probe behavior and concurrency behavior are never changed in the same rollout window.
- The remaining apps keep their holding pins and are unaffected by this PR.

### Checklist:
- [ ] Deploy CI, then QA, then Production — in that order, not in parallel
- [ ] Hold ≥ 3 business days at Production and collect the validation metrics above before opening the stage 2 PR
