### PR TITLE
fix(grafana-alerting): stop false-positive paging on transient K8s workload disruption

### DIFF
--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
@@ -113,10 +113,24 @@ def create(
             ),
             # --- StatefulSet replicas ---
             # Fires when ready replicas / desired replicas < 1.0.
+            #
+            # for_ is 20m, not the more typical 10m, because EBS-backed StatefulSets
+            # (Typesense, etc.) can legitimately drop below full readiness for well
+            # over 10 minutes with no real problem: when Karpenter replaces an
+            # underlying node, more than one pod can be evicted at once, and each one
+            # waits on its EBS volume to detach from the old instance and reattach to
+            # the new one before it can even start. Observed directly on
+            # mitxonline-ts-sts on 2026-07-27: 2 of 3 replicas went down together and
+            # readiness didn't fully recover for ~17 minutes, entirely via normal
+            # volume reattachment with no crash-looping or intervention involved --
+            # comfortably past the old 10m threshold. A statefulset genuinely stuck
+            # (e.g. a corrupted Raft log requiring a manual data wipe, as seen
+            # separately on mitx-staging-ts-sts) stays down far longer than 20m
+            # either way, so this doesn't meaningfully delay catching a real issue.
             alerting.RuleGroupRuleArgs(
                 name="StatefulSetReplicasMissingWarning",
                 condition="C",
-                for_="10m",
+                for_="20m",
                 no_data_state="OK",
                 labels={"severity": "warning"},
                 annotations={
@@ -129,7 +143,7 @@ def create(
             alerting.RuleGroupRuleArgs(
                 name="StatefulSetReplicasMissingCritical",
                 condition="C",
-                for_="10m",
+                for_="20m",
                 no_data_state="OK",
                 labels={"severity": "critical"},
                 annotations={

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
@@ -104,6 +104,16 @@ def create(
             # The "and ... spec_replicas > 0" guard excludes deployments deliberately
             # scaled to zero (e.g. a disabled service in a staging namespace) -- those
             # sit at 0/0 available/desired indefinitely, which is not an outage.
+            #
+            # The nonzero-valued clause (spec_replicas > 0) is deliberately written
+            # FIRST. Every rule in this pipeline feeds into a fixed threshold stage
+            # that fires on last(A) > 0 (see base.py's _rule_data), and PromQL's
+            # `and` binary operator carries over the *value* of its left-hand side,
+            # not a boolean 1/0 -- so "available == 0 and spec_replicas > 0" would
+            # return the left side's value, which is 0 by construction, and 0 > 0
+            # never fires. Putting the nonzero clause on the left instead means the
+            # surviving series carries spec_replicas' own (always-positive, since
+            # it's already filtered > 0) value through to the threshold stage.
             alerting.RuleGroupRuleArgs(
                 name="DeploymentUnavailableWarning",
                 condition="C",
@@ -114,9 +124,9 @@ def create(
                     "description": "A deployment {{ $labels.deployment }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} is not available for an extended period of time."
                 },
                 datas=rd(
-                    'sum by (cluster, namespace, deployment) (kube_deployment_status_replicas_available{cluster=~".*-(ci|qa)"}) == 0'
-                    " and "
                     'sum by (cluster, namespace, deployment) (kube_deployment_spec_replicas{cluster=~".*-(ci|qa)"}) > 0'
+                    " and "
+                    'sum by (cluster, namespace, deployment) (kube_deployment_status_replicas_available{cluster=~".*-(ci|qa)"}) == 0'
                 ),
             ),
             alerting.RuleGroupRuleArgs(
@@ -129,9 +139,9 @@ def create(
                     "description": "A deployment {{ $labels.deployment }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} is not available for an extended period of time."
                 },
                 datas=rd(
-                    'sum by (cluster, namespace, deployment) (kube_deployment_status_replicas_available{cluster=~".*-(production)"}) == 0'
-                    " and "
                     'sum by (cluster, namespace, deployment) (kube_deployment_spec_replicas{cluster=~".*-(production)"}) > 0'
+                    " and "
+                    'sum by (cluster, namespace, deployment) (kube_deployment_status_replicas_available{cluster=~".*-(production)"}) == 0'
                 ),
             ),
             # --- StatefulSet replicas ---

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
@@ -156,7 +156,7 @@ def create(
             # mitxonline-ts-sts on 2026-07-27: 2 of 3 replicas went down together and
             # readiness didn't fully recover for ~17 minutes, entirely via normal
             # volume reattachment with no crash-looping or intervention involved --
-            # comfortably past the old 10m threshold. A statefulset genuinely stuck
+            # comfortably past the old 10m threshold. A StatefulSet genuinely stuck
             # (e.g. a corrupted Raft log requiring a manual data wipe, as seen
             # separately on mitx-staging-ts-sts) stays down far longer than 20m
             # either way, so this doesn't meaningfully delay catching a real issue.

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
@@ -83,8 +83,27 @@ def create(
                 ),
             ),
             # --- Deployment availability ---
-            # Fires when the Available condition on a deployment is "false",
-            # meaning the deployment cannot serve traffic.
+            # Fires only when a deployment has zero available replicas -- a genuine
+            # total outage, matching what "is not available" actually implies.
+            #
+            # This used to key off kube_deployment_status_condition's "Available"
+            # condition instead, which is NOT the same thing: that condition goes
+            # false once availableReplicas drops below desiredReplicas -
+            # maxUnavailable, not below 1. maxUnavailable is commonly expressed as a
+            # percentage (e.g. "25%"), and Kubernetes rounds percentage-based
+            # maxUnavailable DOWN, so on a low-replica-count deployment (3 replicas *
+            # 25% = 0.75, rounded down to 0) the condition flips false the moment a
+            # single pod is lost -- e.g. during a slow image pull while a node is
+            # being replaced. Confirmed directly on xpro-production-edxapp-lms-webapp
+            # on 2026-07-27: replicas_available only ever dropped 3 -> 2, never to 0,
+            # yet this alert fired as if the whole deployment were down. Partial
+            # degradation like that is already covered by DeploymentReplicasMissing
+            # above at the appropriate (lower) severity; this rule should only catch
+            # the case its name promises.
+            #
+            # The "and ... spec_replicas > 0" guard excludes deployments deliberately
+            # scaled to zero (e.g. a disabled service in a staging namespace) -- those
+            # sit at 0/0 available/desired indefinitely, which is not an outage.
             alerting.RuleGroupRuleArgs(
                 name="DeploymentUnavailableWarning",
                 condition="C",
@@ -95,7 +114,9 @@ def create(
                     "description": "A deployment {{ $labels.deployment }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} is not available for an extended period of time."
                 },
                 datas=rd(
-                    'sum by (cluster, namespace, deployment, condition, status) (kube_deployment_status_condition{cluster=~".*-(ci|qa)", condition="Available", status="false"}) > 0'
+                    'sum by (cluster, namespace, deployment) (kube_deployment_status_replicas_available{cluster=~".*-(ci|qa)"}) == 0'
+                    " and "
+                    'sum by (cluster, namespace, deployment) (kube_deployment_spec_replicas{cluster=~".*-(ci|qa)"}) > 0'
                 ),
             ),
             alerting.RuleGroupRuleArgs(
@@ -108,7 +129,9 @@ def create(
                     "description": "A deployment {{ $labels.deployment }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} is not available for an extended period of time."
                 },
                 datas=rd(
-                    'sum by (cluster, namespace, deployment, condition, status) (kube_deployment_status_condition{cluster=~".*-(production)", condition="Available", status="false"}) > 0'
+                    'sum by (cluster, namespace, deployment) (kube_deployment_status_replicas_available{cluster=~".*-(production)"}) == 0'
+                    " and "
+                    'sum by (cluster, namespace, deployment) (kube_deployment_spec_replicas{cluster=~".*-(production)"}) > 0'
                 ),
             ),
             # --- StatefulSet replicas ---


### PR DESCRIPTION
## Summary

Both fixes here came out of investigating pages this week that turned out not to be real problems, in a shared theme: alert rules whose underlying PromQL doesn't actually match what the rule's name/severity claims to detect.

### 1. `StatefulSetReplicasMissing{Warning,Critical}`: 10m → 20m grace period

`StatefulSetReplicasMissingCritical` paged for `mitxonline-ts-sts` (production). Checked the readiness history directly: 2 of 3 replicas dropped together at 19:47, and readiness didn't fully recover until 20:04 — ~17 minutes, all via normal EBS volume detach/reattach as Karpenter replaced the underlying node (consistent with #5132's AZ-diversification change). No crash-looping, no intervention needed, self-resolved.

I initially assumed this was a StatefulSet rolling update taking longer than the existing `for_="10m"` window and tried gating the query on `updated_replicas == replicas` to distinguish "mid-rollout" from "genuinely stuck." That doesn't actually work for this case — checked `kube_statefulset_status_current_revision` vs `kube_statefulset_status_update_revision` directly and they were identical throughout; there was no StatefulSet spec change involved at all, just node-level disruption forcing pod rescheduling.

Extended `for_` from `10m` to `20m` instead — a blunter fix but grounded in what was actually observed. A genuinely stuck statefulset (e.g. `mitx-staging-ts-sts`'s corrupted Raft log, needing a manual data wipe, seen separately this week) stays down for hours, not tens of minutes, so 20m doesn't meaningfully delay catching a real issue.

### 2. `DeploymentUnavailable{Warning,Critical}`: check zero replicas directly, not the k8s `Available` condition

`DeploymentUnavailableCritical` fired for `xpro-production-edxapp-lms-webapp` claiming it was "not available for an extended period of time." Checked `kube_deployment_status_replicas_available` directly: it only ever dropped 3 → 2, **never to 0**.

Root cause: the query keyed off Kubernetes's own `Available` *condition*, which goes `false` once `availableReplicas < desiredReplicas - maxUnavailable`, not below 1. This deployment's `maxUnavailable` is `25%`, and Kubernetes rounds percentage-based `maxUnavailable` **down** — on 3 replicas, `25% → 0.75 → 0`. So the condition flips `false` the instant a single pod is lost (e.g. during a slow image pull while a node is being replaced), even though 2 of 3 replicas are serving traffic fine. This is a fleet-wide risk for any low-replica-count deployment, not xpro-specific.

Changed the query to check `replicas_available == 0` directly — a genuine total outage, matching what the rule's name and description actually promise. Partial degradation is already covered by `DeploymentReplicasMissing{Warning,Critical}` at the appropriate (lower) severity, so no coverage is lost. Added a `spec_replicas > 0` guard so a deployment deliberately scaled to zero (sits at `0/0` indefinitely) doesn't get flagged as a permanent outage — caught this against live data: `xqwatcher` in `mitx-staging-openedx` is intentionally at `0/0` and would otherwise match forever.

## Verification

Both new queries tested directly against production Mimir data before writing the PromQL into code:
- StatefulSet: confirmed `current_revision == update_revision` throughout the mitxonline-ts-sts incident (ruling out the rollout theory), confirmed the ~17m recovery window from `kube_statefulset_status_replicas_ready`.
- Deployment: confirmed the new query returns empty for the now-healthy xpro deployment, confirmed it correctly matches a deployment currently at true zero availability, then confirmed the `spec_replicas > 0` guard correctly excludes the intentionally-scaled-to-zero `xqwatcher` case.

## Test plan

- [ ] Deploy to Production
- [ ] Confirm no regression: a real full-outage deployment (0 available, spec_replicas > 0) still fires Critical
- [ ] Watch for reduced false-positive paging from routine node replacement / rolling deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)