### PR TITLE
fix: residential-ci core nodegroup AZ coverage + cluster-wide sizing report

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.residential.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.residential.CI.yaml
@@ -40,9 +40,9 @@ config:
         ol.mit.edu/gpu_node: false
       node_group_options: {}
       scaling:
-        desired: 3
+        desired: 4
         max: 5
-        min: 3
+        min: 4
       tags:
         cluster: residential-ci
       taints: {}


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Fixes a live deployment failure in `residential-ci`: `mitx-staging-ts-sts` (typesense) and `meilisearch` pods in the `mitx-staging-openedx` namespace were stuck `Pending` with `didn't match Pod's node affinity/selector`.

Root cause: same pattern as the already-merged `residential-production` fix (#5132). The `worker-xlarge` core nodegroup's ASG spans all 4 AZ subnets (a/b/c/d) but `desired`/`min` was 3, so one AZ was always left without an on-demand core node. In `residential-ci` that gap landed on `us-east-1a` — the exact zone every existing `mitx-staging-ts-sts`/`meilisearch` PVC is bound to. Once typesense/meilisearch were pinned to core nodes (via the merged PR), those pods became permanently unschedulable.

This PR bumps `desired`/`min` from 3 to 4 in `src/ol_infrastructure/infrastructure/aws/eks/Pulumi.residential.CI.yaml`, adding a 4th core node in the previously-uncovered AZ. This also relieves a separate problem found on this cluster: the 3 existing core nodes were already at 99% memory requests / 210% memory limits allocated (no scheduling headroom left) purely from existing CI workloads (edxapp, xqueue, celery, coredns, karpenter, etc.).

### Screenshots (if appropriate):
N/A — no UI changes.

### How can this be tested?
- `pulumi preview` for `infrastructure/aws/eks` (stack `residential.CI`) should show the ASG `desiredCapacity`/`minSize` change (3→4) on `residential-ci-eks-nodegroup-worker-xlarge`.
- After apply, `kubectl --context residential-ci get nodes -L topology.kubernetes.io/zone,ol.mit.edu/core_node` should show a core node in `us-east-1a`.
- `kubectl --context residential-ci -n mitx-staging-openedx get pods` should show `mitx-staging-ts-sts-2` and `meilisearch-0` scheduling successfully (previously stuck `Pending`).
- `pre-commit run` passes locally on the changed file.

### Additional Context

#### Cluster-wide resource sizing audit (2026-07-27)

At the user's request, ran `scripts/kubernetes/analyze_cluster_resources.py` against all 12 EKS clusters (residential/applications/data/operations × CI/QA/Production) to check whether any cluster's static core nodegroup needs resizing. Only the `residential-ci` fix above is included as an actual change in this PR — the rest is a **report only**, per explicit decision not to downsize clusters based on a single point-in-time snapshot without a longer observation window.

| Cluster | Verdict | Notes |
|---|---|---|
| residential-production | Adequate | Already fixed in #5132 |
| residential-ci | Undersized (fixed here) | AZ gap + 99%/210% memory overcommit |
| residential-qa | Adequate | — |
| applications-ci | Oversized | Script suggests core nodegroup 4→3 nodes, same instance shape (`m8i-flex.2xlarge`) |
| applications-qa | Adequate / slightly oversized on CPU | Memory is the real constraint (76-95% allocated on core nodes); no clean instance-type swap identified |
| applications-production | Adequate | Apparent oversizing is mostly Karpenter-elastic capacity (15 of 19 nodes), not the static core reserve, which itself runs at 88% memory requests |
| data-ci | Oversized | ~15-18% utilization of allocatable capacity |
| data-qa | Oversized | Caveat from the analysis: confirm the 5 extra Karpenter nodes are transient burst capacity, not steady-state, before downsizing |
| data-production | Oversized | 5.5 CPU / 93GB actual peak vs. 178.9 CPU / 723GB allocatable across 10 nodes — **production cluster, not touched in this PR** |
| operations-ci | Oversized | Memory is the binding constraint on core nodes (71% requested / 124% limits), CPU has ample slack |
| operations-qa | Oversized | ~2% CPU / 26% memory utilization of allocatable |
| operations-production | Oversized | Caveat from the analysis: nodes were 8-23 minutes old at scan time, may reflect a recent scale-event/rollout rather than steady state — **production cluster, not touched in this PR** |

Recommend a follow-up pass that re-runs the analysis after a longer observation window (a full daily/weekly traffic cycle) before acting on any of the "oversized" findings above, particularly the two production clusters and the two QA clusters where extra Karpenter-provisioned nodes may be transient burst capacity rather than genuine steady-state overprovisioning.