### PR TITLE
feat(mit-learn): trust courseware origin for content feedback CSRF

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.CI.yaml
@@ -29,6 +29,7 @@ config:
     csrf_domains:
     - "https://api.ci.learn.mit.edu"
     - "https://ci.learn.mit.edu"
+    - "https://courses.ci.learn.mit.edu"   # MITxOnline courseware MFE (content feedback submit)
     - "https://draft-ci.ocw.mit.edu"
     - "https://live-ci.ocw.mit.edu"
     mailgun_sender_domain: "mail-ci.learn.mit.edu"

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
@@ -27,6 +27,7 @@ config:
     csrf_domains:
     - "https://api.learn.mit.edu"
     - "https://learn.mit.edu"
+    - "https://courses.learn.mit.edu"   # MITxOnline courseware MFE (content feedback submit)
     - "https://api.mitopen.odl.mit.edu"   # legacy
     - "https://mitopen.odl.mit.edu"   # legacy
     - "https://draft.ocw.mit.edu"

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.QA.yaml
@@ -29,6 +29,7 @@ config:
     csrf_domains:
     - "https://api.rc.learn.mit.edu"
     - "https://rc.learn.mit.edu"
+    - "https://courses.rc.learn.mit.edu"   # MITxOnline courseware MFE (content feedback submit)
     - "https://api.mitopen-rc.odl.mit.edu"   # legacy
     - "https://mitopen-rc.odl.mit.edu"   # legacy
     - "https://draft-qa.ocw.mit.edu"


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/11816

### Description (What does it do?)

Adds the MITxOnline courseware MFE origin to mit-learn's `csrf_domains` (which feeds `CSRF_TRUSTED_ORIGINS`) for CI / QA / Production:

| Env | Added origin |
|---|---|
| CI | `https://courses.ci.learn.mit.edu` |
| QA / RC | `https://courses.rc.learn.mit.edu` |
| Production | `https://courses.learn.mit.edu` |

The content feedback drawer runs in the Learning MFE at `courses.<env>.learn.mit.edu` and submits an authenticated cross-origin `POST` to `/api/v0/content_feedback/`. Without the courseware origin in `CSRF_TRUSTED_ORIGINS`, Django's CSRF Origin check rejects the submit with a 403.

### How can this be tested?

After deploy, submit feedback from the courseware drawer and confirm a `201` (previously `403`) and a new `ContentFeedback` row.