### PR TITLE
fix(vector): re-enable env var interpolation for Grafana Cloud auth (vector 0.57.0)

### DIFF
--- a/src/bilder/components/vector/steps.py
+++ b/src/bilder/components/vector/steps.py
@@ -150,6 +150,7 @@ def configure_vector(vector_config: VectorConfig):
             "HEROKU_PROXY_PASSWORD": "placeholder",  # pragma: allowlist secret
             "HEROKU_PROXY_USERNAME": "placeholder",
             "VECTOR_STRICT_ENV_VARS": "false",
+            "VECTOR_DANGEROUSLY_ALLOW_ENV_VAR_INTERPOLATION": "true",
         },
     )
 

--- a/src/ol_infrastructure/applications/concourse/__main__.py
+++ b/src/ol_infrastructure/applications/concourse/__main__.py
@@ -141,6 +141,7 @@ def build_worker_user_data(
                     SERVICE=concourse
                     VECTOR_CONFIG_DIR=/etc/vector/
                     VECTOR_STRICT_ENV_VARS=false
+                    VECTOR_DANGEROUSLY_ALLOW_ENV_VAR_INTERPOLATION=true
                     AWS_REGION={aws_config.region}
                     GRAFANA_CLOUD_API_KEY={grafana_credentials["api_key"]}
                     GRAFANA_CLOUD_PROMETHEUS_API_USER={grafana_credentials["prometheus_user_id"]}
@@ -596,6 +597,7 @@ ol_web_launch_config = OLLaunchTemplateConfig(
                                     SERVICE=concourse
                                     VECTOR_CONFIG_DIR=/etc/vector/
                                     VECTOR_STRICT_ENV_VARS=false
+                                    VECTOR_DANGEROUSLY_ALLOW_ENV_VAR_INTERPOLATION=true
                                     AWS_REGION={aws_config.region}
                                     GRAFANA_CLOUD_API_KEY={grafana_credentials["api_key"]}
                                     GRAFANA_CLOUD_PROMETHEUS_API_USER={grafana_credentials["prometheus_user_id"]}

--- a/src/ol_infrastructure/infrastructure/consul/__main__.py
+++ b/src/ol_infrastructure/infrastructure/consul/__main__.py
@@ -96,6 +96,7 @@ def cloud_init_userdata(
                     SERVICE=consul
                     VECTOR_CONFIG_DIR=/etc/vector/
                     VECTOR_STRICT_ENV_VARS=false
+                    VECTOR_DANGEROUSLY_ALLOW_ENV_VAR_INTERPOLATION=true
                     GRAFANA_CLOUD_API_KEY={grafana_credentials["api_key"]}
                     GRAFANA_CLOUD_PROMETHEUS_API_USER={grafana_credentials["prometheus_user_id"]}
                     GRAFANA_CLOUD_LOKI_API_USER={grafana_credentials["loki_user_id"]}

--- a/src/ol_infrastructure/infrastructure/vault/__main__.py
+++ b/src/ol_infrastructure/infrastructure/vault/__main__.py
@@ -481,6 +481,7 @@ def cloud_init_user_data(  # noqa: PLR0913
                     SERVICE=vault
                     VECTOR_CONFIG_DIR=/etc/vector/
                     VECTOR_STRICT_ENV_VARS=false
+                    VECTOR_DANGEROUSLY_ALLOW_ENV_VAR_INTERPOLATION=true
                     GRAFANA_CLOUD_API_KEY={grafana_credentials["api_key"]}
                     GRAFANA_CLOUD_PROMETHEUS_API_USER={grafana_credentials["prometheus_user_id"]}
                     GRAFANA_CLOUD_LOKI_API_USER={grafana_credentials["loki_user_id"]}

--- a/src/ol_infrastructure/infrastructure/vector_log_proxy/__main__.py
+++ b/src/ol_infrastructure/infrastructure/vector_log_proxy/__main__.py
@@ -455,6 +455,10 @@ vector_deployment = kubernetes.apps.v1.Deployment(
                                 value="false",
                             ),
                             kubernetes.core.v1.EnvVarArgs(
+                                name="VECTOR_DANGEROUSLY_ALLOW_ENV_VAR_INTERPOLATION",
+                                value="true",
+                            ),
+                            kubernetes.core.v1.EnvVarArgs(
                                 name="AWS_REGION",
                                 value="us-east-1",
                             ),


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Vector **0.57.0** ships a breaking change: `${VAR}` environment-variable interpolation inside config files is now **disabled by default**. Because our Grafana Cloud sinks resolve their credentials from env vars (`password: ${GRAFANA_CLOUD_API_KEY}`, `user: ${GRAFANA_CLOUD_LOKI_API_USER}` / `${GRAFANA_CLOUD_PROMETHEUS_API_USER}`), those fields stopped resolving and every authenticated sink began returning `401 Unauthorized` — both the Loki logs sink and the Prometheus `prometheus_remote_write` metrics sink. This affects the vault/consul/concourse VM fleets and the k8s `vector_log_proxy`.

The credentials themselves are valid; the breakage is entirely in vector's config loader. Confirmed by pulling the env vars straight out of the running process and authenticating successfully with `curl` against the Loki push and Prometheus remote-write endpoints, while vector's own pushes still 401'd.

This change re-enables interpolation by setting `VECTOR_DANGEROUSLY_ALLOW_ENV_VAR_INTERPOLATION=true` everywhere the vector environment is defined, alongside the existing `VECTOR_STRICT_ENV_VARS` (which does **not** govern this behavior):

- `/etc/default/vector` cloud-init blocks: `infrastructure/vault/__main__.py`, `infrastructure/consul/__main__.py`, `applications/concourse/__main__.py` (web + worker)
- k8s `EnvVarArgs`: `infrastructure/vector_log_proxy/__main__.py`
- `vector validate` `_env`: `bilder/components/vector/steps.py`

Note: Vector recommends its built-in [secrets backend](https://vector.dev/docs/reference/configuration/global-options/#secret) as the clean long-term replacement for the `--dangerously-allow-env-var-interpolation` flag; that's a reasonable follow-up, but this flag is the correct drop-in for the existing `${...}`-based templates.

Reference: [Vector 0.57.0 upgrade guide](https://vector.dev/highlights/2026-07-14-0-57-0-upgrade-guide/).

### How can this be tested?
On a rebuilt VM image (or by appending the flag to `/etc/default/vector` and running a full `systemctl restart vector` — not `reload`, since systemd only re-reads `EnvironmentFile` on restart):

1. `journalctl -u vector -b` shows no `401 Unauthorized` from `ship_vault_logs_to_grafana_cloud` (loki) or `ship_host_metrics_to_grafana_cloud` (prometheus_remote_write) on real data pushes. Note: the Loki healthcheck can pass even while pushes fail, so validate against an actual data push, not just the healthcheck.
2. Logs/metrics from the host appear in Grafana Cloud.
3. `vector validate` in the image build still passes.

### Additional Context
`VECTOR_STRICT_ENV_VARS` is unrelated to this regression and is left unchanged. The flag is added directly next to it at each site so the two stay together.