### PR TITLE
fix(mit_learn): stop the webapp OOMKilling by raising the VPA memory floor

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
@@ -47,6 +47,14 @@ config:
   mitlearn:posthog_proxy: "ph.ol.mit.edu"
   mitlearn:support_url: "support.learn.mit.edu"
   mitlearn:use_granian: true
+  # Peak webapp container RSS measured 2774Mi over the 14 days to 2026-07-28. The
+  # 256Mi default floor let the VPA shrink the limit to ~2062-2295Mi, below that
+  # peak, and the kernel OOM-killed the container: 24-44 restarts/day whenever the
+  # limit sat at or under ~2553Mi, against 1-3/day whenever it sat at or above
+  # ~2990Mi. 3Gi clears the measured peak by ~11% while staying under the 3200Mi
+  # declared limit, so the VPA can still size these pods down, just not into the
+  # range that kills them.
+  mitlearn:webapp_vpa_min_allowed_memory: 3Gi
   mitlearn:vars:
     AI_MIT_SYLLABUS_URL: "https://api.learn.mit.edu/api/v0/vector_content_files_search/"
     AI_MIT_VIDEO_TRANSCRIPT_URL: "https://api.learn.mit.edu/api/v0/vector_content_files_search/"

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1578,6 +1578,16 @@ mitlearn_k8s_app = OLApplicationK8s(
             # together. Dropping to workers=1 without resizing this would cap the sole
             # worker at 1350Mi of a 3Gi pod. See the stage 4 task in
             # docs/plans/granian-configuration-overhaul.md.
+            #
+            # This is one value across all stacks, while the VPA floor it is sized
+            # against is production-only (CI/QA keep the 256Mi default). That is not
+            # the protection gap it looks like: a cap only guards anything when
+            # 2*cap + master fits under the running limit, and no cap derived from
+            # the 3200Mi declared limit fits under a VPA floor of 256Mi. Below a
+            # ~2300Mi limit the cap is inert at 1080 and at 1350 alike, so CI/QA are
+            # no worse off than before. Making it genuinely track the limit the
+            # kernel enforces needs a runtime cgroup read, not a synth-time constant
+            # -- tracked as tk-evaluate-runtime-cgroup-derived-workers-max-rss.
             workers_max_rss=1350,
             enable_metrics=True,
             interface="asginl",

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1506,6 +1506,15 @@ webapp_resource_requests = _resource_config(
 webapp_resource_limits = _resource_config(
     "webapp_resource_limits", {"memory": "3200Mi"}
 )
+# VPA bounds for the webapp's memory. Per-stack because the right floor depends on
+# measured production demand, and CI/QA idle far below it -- a floor sized for
+# production would pin those pods at several GiB each for nothing.
+webapp_vpa_min_allowed_memory = (
+    mitlearn_config.get("webapp_vpa_min_allowed_memory") or "256Mi"
+)
+webapp_vpa_max_allowed_memory = (
+    mitlearn_config.get("webapp_vpa_max_allowed_memory") or "4Gi"
+)
 celery_default_resource_requests = _resource_config(
     "celery_default_resource_requests", {"cpu": "200m", "memory": "2400Mi"}
 )
@@ -1553,10 +1562,23 @@ mitlearn_k8s_app = OLApplicationK8s(
         application_arg_array=["/tmp/uwsgi.ini"],  # noqa: S108
         granian_config=GranianConfig(
             workers=2,
-            # Pin per-worker RSS so it doesn't auto-scale with the memory limit
-            # (floor(limit/workers*0.9)); 2*1080Mi leaves ~1GiB headroom under
-            # the 3200Mi limit for the master process and transient overshoot.
-            workers_max_rss=1080,
+            # Sized against the VPA *floor* (3Gi in production), not the declared
+            # 3200Mi limit, because the floor is the smallest limit a pod can be
+            # running under and therefore the one the cap has to beat. The component's
+            # own floor(limit/workers*0.9) would give 1440, leaving the worker pair at
+            # 2880Mi with almost nothing left for the master under a 3072Mi floor.
+            #
+            # 2*1350 = 2700Mi bounds the pair below the 2774Mi peak container RSS
+            # measured over 14 days, leaving ~370Mi for the master and transient
+            # overshoot. The previous value of 1080 sat *below* the ~1300Mi a worker
+            # legitimately reaches at peak, so it fired during normal operation --
+            # graceful respawns as steady-state behaviour rather than a runaway guard.
+            #
+            # Coupled to `workers` and to the VPA floor: both must be revisited
+            # together. Dropping to workers=1 without resizing this would cap the sole
+            # worker at 1350Mi of a 3Gi pod. See the stage 4 task in
+            # docs/plans/granian-configuration-overhaul.md.
+            workers_max_rss=1350,
             enable_metrics=True,
             interface="asginl",
             backlog=None,
@@ -1609,12 +1631,13 @@ mitlearn_k8s_app = OLApplicationK8s(
         ),
         resource_requests=webapp_resource_requests,
         resource_limits=webapp_resource_limits,
-        # Preserves the bounds of the hand-rolled mitlearn-webapp-vpa this replaces.
-        # The floor is deliberately well below resource_limits (unlike the component
-        # default, which pins the floor at the limit) so the VPA can also size these
-        # pods back down rather than only up.
-        webapp_vpa_min_allowed_memory="256Mi",
-        webapp_vpa_max_allowed_memory="4Gi",
+        # The floor sits below resource_limits (unlike the component default, which
+        # pins it at the limit) so the VPA can size these pods back down as well as
+        # up. It must still clear measured peak RSS: a floor below real demand lets
+        # the VPA shrink the limit under the working set and the kernel OOM-kills the
+        # container. See Pulumi.Production.yaml for the production floor.
+        webapp_vpa_min_allowed_memory=webapp_vpa_min_allowed_memory,
+        webapp_vpa_max_allowed_memory=webapp_vpa_max_allowed_memory,
         webapp_keda_config=webapp_keda_config,
     ),
     opts=ResourceOptions(

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1631,11 +1631,12 @@ mitlearn_k8s_app = OLApplicationK8s(
         ),
         resource_requests=webapp_resource_requests,
         resource_limits=webapp_resource_limits,
-        # The floor sits below resource_limits (unlike the component default, which
-        # pins it at the limit) so the VPA can size these pods back down as well as
-        # up. It must still clear measured peak RSS: a floor below real demand lets
-        # the VPA shrink the limit under the working set and the kernel OOM-kills the
-        # container. See Pulumi.Production.yaml for the production floor.
+        # The component would default this floor to resource_requests["memory"],
+        # which here is the same 3200Mi as the limit. Setting it lower lets the VPA
+        # size these pods back down as well as up. It must still clear measured peak
+        # RSS: a floor below real demand lets the VPA shrink the limit under the
+        # working set and the kernel OOM-kills the container. See
+        # Pulumi.Production.yaml for the production floor.
         webapp_vpa_min_allowed_memory=webapp_vpa_min_allowed_memory,
         webapp_vpa_max_allowed_memory=webapp_vpa_max_allowed_memory,
         webapp_keda_config=webapp_keda_config,


### PR DESCRIPTION
### What are the relevant tickets?

N/A — tracked in witan as `tk-mit-learn-webapp-is-oomkilling-in-production-89--e9237c`, found while reviewing mit_learn for stage 4 of the Granian overhaul (https://github.com/mitodl/ol-infrastructure/pull/5135, https://github.com/mitodl/ol-infrastructure/pull/5083).

### Description (What does it do?)

The `mitlearn-app` webapp container is being OOMKilled repeatedly in production. **The cause is the VPA memory floor, not the application.**

`webapp_vpa_min_allowed_memory` was `256Mi` against a `3200Mi` declared limit. That was deliberate — the inline comment said the floor sits "well below resource_limits ... so the VPA can also size these pods back down rather than only up." But the floor was so far below actual demand that the VPA was free to shrink the limit *underneath the live working set*. Because the VPA runs `InPlaceOrRecreate` with `controlledValues: RequestsAndLimits`, it shrinks the limit on **running** pods — and when the new limit lands below current usage, the kernel kills the container immediately.

#### Evidence (production Prometheus, 14 days to 2026-07-28)

| Metric | Value |
|---|---|
| Peak container RSS | **2774MiB** |
| Peak working set | 2805MiB |
| p99 working set | 2747MiB |
| Median RSS | 1978MiB |
| VPA-set limit, observed range | **2062–3151MiB** |
| Declared limit | 3200Mi |

RSS ≈ working set, so page cache is negligible — this is genuine anonymous process memory, not reclaimable cache.

Restart rate tracks the VPA-set limit inversely and tightly:

| VPA-set limit | Restarts/day |
|---|---|
| ≥ ~2990MiB | **1–3** |
| ≤ ~2553MiB | **24–44** |

The container simply cannot fit in the limit the VPA keeps choosing. For comparison over the same window, `ocw-studio-app` and `ovs-app` had **zero** restarts.

#### Change 1 — VPA floor 256Mi → 3Gi (production only)

3Gi clears the measured 2774MiB peak by ~11% and stays under the 3200Mi declared limit, so the VPA retains downward room — just not into the range that kills the pod. `maxAllowed` stays 4Gi.

The bounds are now plumbed through per-stack Pulumi config, following the existing `_resource_config` idiom in this file. Only Production is set; CI and QA idle far below production and a floor sized for production would pin their pods at several GiB each for nothing.

#### Change 2 — `workers_max_rss` 1080 → 1350

Wrong in the same direction. At 1080 the cap sat **below** the ~1300MiB a worker legitimately reaches at peak, so it was firing during normal operation — graceful respawns as steady-state behaviour rather than as a runaway guard. Granian's own logs confirm it, repeatedly through the day:

```
[INFO] worker-2 RSS over threshold, gracefully respawning..
[INFO] Respawning worker-2
```

1350 bounds the worker pair at 2700MiB — below the 2774MiB observed peak — leaving ~370MiB under the 3Gi floor for the master process and transient overshoot.

I deliberately did **not** just delete the pin and let the component's `floor(limit / workers * 0.9)` derivation take over. That derivation computes from the *declared* 3200Mi limit and yields 1440, putting the pair at 2880MiB with almost nothing to spare under a 3072MiB floor. The cap has to be sized against the smallest limit a pod can actually be running under, which is the VPA floor, not the declared limit. Sizing a per-worker RSS cap from a limit the VPA overrides is the same class of mistake as the mitxonline ceiling-based cap.

### How can this be tested?

`pulumi preview --stack Production` reports **3 to update**, of which **1 is pre-existing on main** — a Fastly `ServiceVcl` gzip content-type/extension list reordering. I verified that by stashing this branch's changes and re-previewing the unmodified tree, which reports `~ 1 to update` on its own. The two that belong to this PR:

```
    ~ kubernetes:apps/v1:Deployment: (update)
        [id=mitlearn/mitlearn-app]
      ~ spec: { ~ template: { ~ spec: { ~ containers: [ ~ [1]: { ~ args: [
                                  ~ [12]: "1080" => "1350"
                                ]

    ~ kubernetes:autoscaling.k8s.io/v1:VerticalPodAutoscaler: (update)
        [id=mitlearn/mitlearn-app-memory-vpa]
      ~ spec: { ~ resourcePolicy: { ~ containerPolicies: [ ~ [0]: {
                          ~ minAllowed: { ~ memory: "256Mi" => "3Gi" }
```

`pre-commit` (ruff format, ruff check, mypy, yamllint, detect-secrets) clean.

**After deploy**, the signal is direct — `kube_pod_container_status_restarts_total` for `container="mitlearn-app"` should fall from its current 24–28/day toward the 1–3/day seen whenever the limit sat above ~2990MiB, and `kube_pod_container_resource_limits` should stop dipping below 3072MiB:

```promql
sum(increase(kube_pod_container_status_restarts_total{namespace="mitlearn", container="mitlearn-app"}[1d]))
min(kube_pod_container_resource_limits{namespace="mitlearn", container="mitlearn-app", resource="memory"}) / 1024/1024
```

Granian's `RSS over threshold` log lines should also become rare rather than routine.

### Additional Context

- **Cluster cost.** The VPA sets requests as well as limits, so this raises requests to ≥3072MiB per pod. At the current ~24 replicas that is roughly +21GiB; at the KEDA/HPA ceiling of 30 replicas, ~90GiB total for this deployment. `applications-production` currently has ~265GiB of ~456GiB allocatable requested, leaving ~191GiB free, so this fits with room to spare.
- **Rollout shape.** The VPA change raises limits on existing pods — growing a limit in place is safe. The `--workers-max-rss` arg change rolls the Deployment normally.
- **This reverses a deliberate decision**, so it deserves a look rather than a rubber stamp. The original intent — let these pods size back down — is preserved in kind, just bounded above the range where the pod dies. If you would rather keep more downward room and accept some restarts, the floor is now a one-line stack config change.
- **Coupling for Granian stage 4.** `workers_max_rss` is tied to both `workers` and the VPA floor. Dropping to `workers=1` without resizing it would cap the sole worker at 1350MiB of a 3Gi pod. Called out in an inline comment and in the stage 4 task.
