### PR TITLE
fix: disable stale-while-revalidate on Fastly shield requests for MIT Learn

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1087,6 +1087,13 @@ mitlearn_fastly_service = fastly.ServiceVcl(
             priority=10,
         ),
         fastly.ServiceVclSnippetArgs(
+            name="Disable stale-while-revalidate when acting as a shield",
+            content=Path(__file__)
+            .parent.joinpath("snippets/shield_stale_while_revalidate_guard.vcl")
+            .read_text(),
+            type="recv",
+        ),
+        fastly.ServiceVclSnippetArgs(
             name="deliver route dictionary redirect",
             content=Path(__file__)
             .parent.joinpath("snippets/redirect_deliver.vcl")

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1092,6 +1092,11 @@ mitlearn_fastly_service = fastly.ServiceVcl(
             .parent.joinpath("snippets/shield_stale_while_revalidate_guard.vcl")
             .read_text(),
             type="recv",
+            # After the priority-10 redirect snippets, which exit via `error` and so
+            # never reach a cache lookup, and before the priority-200 S3 routing,
+            # which this is independent of. 100 is Fastly's default, so this only
+            # makes the existing order explicit.
+            priority=100,
         ),
         fastly.ServiceVclSnippetArgs(
             name="deliver route dictionary redirect",

--- a/src/ol_infrastructure/applications/mit_learn/snippets/shield_stale_while_revalidate_guard.vcl
+++ b/src/ol_infrastructure/applications/mit_learn/snippets/shield_stale_while_revalidate_guard.vcl
@@ -1,0 +1,37 @@
+/*
+ * Prevent a shield POP from serving stale-while-revalidate content to an edge POP.
+ *
+ * With shielding enabled, a request path is client -> edge POP -> shield POP ->
+ * origin. `stale-while-revalidate` is intended to let a *client-facing* cache
+ * answer immediately from a stale object while it refreshes in the background.
+ * When the shield tier does the same thing, the edge POP receives a stale object
+ * that still carries a low `Age`, cannot tell it is stale, and caches it as
+ * fresh for a full `s-maxage`.
+ *
+ * Fastly documents three ways this happens (soft purge, edge code that rewrites
+ * TTLs, and conditional GETs that the shield answers with a 304 from its own
+ * stale copy) and recommends this guard under "Shielding considerations":
+ * https://www.fastly.com/documentation/guides/concepts/cache/stale/#shielding-considerations
+ *
+ * `fastly.ff.visits_this_service` counts how many Fastly nodes in this service a
+ * request has already passed through, so it is 0 for a request arriving from a
+ * client and > 0 for one forwarded by an edge POP -- i.e. this branch is taken
+ * only when we are acting as the shield.
+ *
+ * `req.max_stale_while_revalidate = 0s` caps stale-while-revalidate for this
+ * request, so the shield does a real fetch instead of answering from a stale
+ * object. Background revalidation absorbs the extra latency: the edge POP keeps
+ * its own stale-while-revalidate, so clients still get an immediate response.
+ *
+ * `req.max_stale_if_error` is deliberately left alone -- the shield should still
+ * serve stale content when the origin is genuinely failing.
+ *
+ * NOTE: this is a guard rail, not a fix for a live problem. MITxOnline product
+ * page invalidation uses hard purges, and the origin sends neither `ETag` nor
+ * `Last-Modified`, so none of the three trigger conditions are currently active.
+ * It is here so that adding origin validators, rewriting TTLs in VCL, or reaching
+ * for a soft purge does not silently reintroduce stale-served-as-fresh content.
+ */
+if (fastly.ff.visits_this_service > 0) {
+  set req.max_stale_while_revalidate = 0s;
+}

--- a/src/ol_infrastructure/applications/mit_learn/snippets/shield_stale_while_revalidate_guard.vcl
+++ b/src/ol_infrastructure/applications/mit_learn/snippets/shield_stale_while_revalidate_guard.vcl
@@ -26,9 +26,9 @@
  * `req.max_stale_if_error` is deliberately left alone -- the shield should still
  * serve stale content when the origin is genuinely failing.
  *
- * NOTE: this is a guard rail, not a fix for a live problem. MITxOnline product
- * page invalidation uses hard purges, and the origin sends neither `ETag` nor
- * `Last-Modified`, so none of the three trigger conditions are currently active.
+ * NOTE: this is a guard rail, not a fix for a live problem. Once MITxOnline switches
+ * its surrogate-key purges from soft to hard and the origin sends neither `ETag` nor
+ * `Last-Modified`, the three documented trigger conditions should be inactive.
  * It is here so that adding origin validators, rewriting TTLs in VCL, or reaching
  * for a soft purge does not silently reintroduce stale-served-as-fresh content.
  */

--- a/src/ol_infrastructure/applications/mit_learn/snippets/shield_stale_while_revalidate_guard.vcl
+++ b/src/ol_infrastructure/applications/mit_learn/snippets/shield_stale_while_revalidate_guard.vcl
@@ -26,11 +26,14 @@
  * `req.max_stale_if_error` is deliberately left alone -- the shield should still
  * serve stale content when the origin is genuinely failing.
  *
- * NOTE: this is a guard rail, not a fix for a live problem. Once MITxOnline switches
- * its surrogate-key purges from soft to hard and the origin sends neither `ETag` nor
- * `Last-Modified`, the three documented trigger conditions should be inactive.
- * It is here so that adding origin validators, rewriting TTLs in VCL, or reaching
- * for a soft purge does not silently reintroduce stale-served-as-fresh content.
+ * NOTE: of the three trigger conditions, soft purge is active today -- MITxOnline
+ * still soft-purges its surrogate keys (mitodl/mitxonline#3792 switches it to hard),
+ * so until that lands this snippet is what keeps a soft purge from being laundered
+ * back into a fresh response. The other two are inactive: nothing here rewrites
+ * TTLs, and the origin sends neither `ETag` nor `Last-Modified`. Once #3792 ships
+ * this becomes a guard rail, kept so that adding origin validators, rewriting TTLs,
+ * or reaching for a soft purge again does not silently reintroduce
+ * stale-served-as-fresh content.
  */
 if (fastly.ff.visits_this_service > 0) {
   set req.max_stale_while_revalidate = 0s;


### PR DESCRIPTION
### What are the relevant tickets?

Refs https://github.com/mitodl/hq/issues/12381

Not a `Closes` — the functional fix for stale MITxOnline product pages is switching MITxOnline's surrogate-key purge from soft to hard ([`cms/tasks.py`](https://github.com/mitodl/mitxonline/blob/main/cms/tasks.py#L142)). This PR fixes the underlying Fastly behaviour that made soft purges look like no-ops, so the two are independent.

### Description (What does it do?)

Adds a `vcl_recv` snippet to the MIT Learn Fastly service that disables `stale-while-revalidate` on requests where a POP is acting as the shield:

```vcl
if (fastly.ff.visits_this_service > 0) {
  set req.max_stale_while_revalidate = 0s;
}
```

**The problem.** MIT Learn has shielding enabled (`iad-va-us`, all envs) and the Next.js frontend sets `Cache-Control: s-maxage=7200, stale-if-error=86400, stale-while-revalidate=86400` on every page route. `stale-while-revalidate` is designed for a *client-facing* cache: answer immediately from a stale object, refresh in the background. When the shield tier does the same thing, the edge POP receives a stale object that still carries a low `Age`, cannot tell it is stale, and caches it as fresh for a full `s-maxage`.

Soft purge is the sharpest way to trigger this, because it marks an object logically stale **without changing its `Age`** — and `Age` is the only staleness signal that crosses the shield-to-edge hop.

Today, a soft purge of a MITxOnline surrogate key:

```mermaid
sequenceDiagram
    autonumber
    participant C as Client
    participant E as Edge POP
    participant S as Shield POP
    participant O as Origin

    Note over E,S: Soft purge marks the object stale<br/>at both tiers. Nothing is evicted,<br/>and Age is unchanged.

    C->>E: GET product page
    E-->>C: 200 OLD content, stale under SWR
    E->>S: Background revalidate
    S-->>E: 200 OLD content, Age 300
    Note over E,S: The shield answered from its own<br/>stale copy. Age 300 is far below<br/>s-maxage 7200, so the edge stores OLD<br/>content as FRESH for another 2 hours.
    S->>O: Background revalidate
    O-->>S: 200 NEW content
    Note over E,S: Only the shield ends up fresh.<br/>Every edge POP is now serving old<br/>content that it believes is fresh.
```

With the guard, the shield can no longer answer from its stale copy, so the edge's background revalidation returns genuinely fresh content:

```mermaid
sequenceDiagram
    autonumber
    participant C as Client
    participant E as Edge POP
    participant S as Shield POP
    participant O as Origin

    Note over E,S: Same soft purge, same stale<br/>objects at both tiers.

    C->>E: GET product page
    E-->>C: 200 OLD content, stale under SWR
    Note over C,E: The edge keeps its own<br/>stale-while-revalidate, so the client<br/>is never made to wait.
    E->>S: Background revalidate
    Note over S,O: fastly.ff.visits_this_service is<br/>nonzero at the shield, so<br/>req.max_stale_while_revalidate is 0s.<br/>The shield may not answer from its<br/>own stale copy.
    S->>O: Blocking fetch
    O-->>S: 200 NEW content
    S-->>E: 200 NEW content, Age 0
    Note over E,S: The edge now stores NEW content.<br/>Correct.
    C->>E: Next request
    E-->>C: 200 NEW content
```

The remaining single stale response per cache node is inherent to `stale-while-revalidate` and is the intended behaviour — not something this PR tries to remove.

This is Fastly's own documented recommendation, under **Shielding considerations**: https://www.fastly.com/documentation/guides/concepts/cache/stale/#shielding-considerations

`req.max_stale_if_error` is deliberately left untouched, so the shield still serves stale content when the origin is genuinely failing.

### How can this be tested?

**Pre-merge**

- `uv run pre-commit run` passes on both changed files (ruff format, ruff check, mypy, detect-secrets).
- ⚠️ **I could not run `pulumi preview`** — no access to the org's S3 state backend from where this was authored. Please run it against the CI/QA/Production `mit_learn` stacks before merging and confirm the only change is a **new VCL snippet on a new service version**. An in-place service update is expected; a service *replacement* would be a bug in this change.

**Post-deploy, non-functional check**

Response headers on a product page should be unchanged, and shielding should still show two Varnish hops:

```
$ curl -sS -o /dev/null -D - "https://learn.mit.edu/courses/course-v1:MITxT+14.009x" \
    | grep -i "cache-control\|^via\|x-served-by\|x-cache"
cache-control: s-maxage=7200, stale-if-error=86400, stale-while-revalidate=86400
via: 1.1 varnish, 1.1 varnish
x-served-by: cache-iad-kiad7000135-IAD, cache-chi-kmdw8640039-CHI
x-cache: MISS, MISS
```

**Post-deploy, functional check — this is the interesting one**

Because MITxOnline still soft-purges today, this branch can be validated directly against the live bug. Deploy to QA/production, then from a MITxOnline shell soft-purge a known key and poll the corresponding Learn page:

```python
import requests
from main.settings import (
    MITX_ONLINE_FASTLY_URL,
    MITX_ONLINE_FASTLY_SERVICE_ID,
    MITX_ONLINE_FASTLY_AUTH_TOKEN,
)

requests.post(
    f"{MITX_ONLINE_FASTLY_URL}/service/{MITX_ONLINE_FASTLY_SERVICE_ID}/purge/mitxonline:program:program-v1:UAI+B2C",
    headers={
        "Fastly-Key": MITX_ONLINE_FASTLY_AUTH_TOKEN,
        "fastly-soft-purge": "1",
    },
    timeout=10,
)
```

- **Before this change:** the page keeps serving old content for hours, and `age` climbs rather than resetting.
- **After this change:** the first request still returns old content once, and the request immediately after it returns the updated page.

That difference is also the confirmation of the root-cause diagnosis, which is worth capturing before the MITxOnline hard-purge change lands and makes it untestable.

### Additional Context

**This is a guard rail, not a fix for a live problem — after the MITxOnline change it becomes inert.** Fastly lists three ways the edge can cache shield-supplied stale content as fresh, and once MITxOnline hard-purges, none of them are active on this service:

| Trigger | Status after the MITxOnline change |
|---|---|
| Soft purge | Gone — MITxOnline will hard-purge; deploy purges are already hard (`{"mode": "surrogate_key", "surrogate_key": "html-pages"}`) |
| Conditional GET answered `304` from the shield's stale copy | Cannot occur — origin sends neither `ETag` nor `Last-Modified` |
| Edge/custom code rewriting TTLs | No `vcl_fetch` snippet on this service sets `beresp.ttl` |

Normal TTL expiry is **not** affected: the shield propagates `Age`, so an object arriving past `s-maxage` is already stale at the edge and cannot be mistaken for fresh. That is exactly what makes soft purge special.

It is worth carrying anyway because two of those three triggers are roughly one PR away — enabling origin `ETag`s, or adding a `vcl_fetch` snippet that sets a TTL — and the failure mode is completely silent. The snippet's comment says all of this inline so the next person can tell whether it is safe to touch.

**Cost:** on natural expiry the shield now does a blocking origin fetch instead of serve-stale-and-refresh. Because edge POPs retain their own `stale-while-revalidate`, that latency lands entirely in background revalidation and is not user-facing.

**Not addressed here, worth a follow-up:** `stale-while-revalidate=86400` against `s-maxage=7200` means 24 hours of "serve whatever we have" on product pages, which is what let this failure mode persist so long. Trimming it would shrink the blast radius of this whole class of problem, but it changes user-facing latency on expiry, so it belongs in its own change.
