### PR TITLE
fix(concourse): split least-privilege IAM policy under AWS's 6144-byte cap

### DIFF
--- a/src/ol_infrastructure/applications/concourse/__main__.py
+++ b/src/ol_infrastructure/applications/concourse/__main__.py
@@ -50,7 +50,11 @@ from ol_infrastructure.lib.aws.ec2_helper import (
     InstanceTypes,
     default_egress_args,
 )
-from ol_infrastructure.lib.aws.iam_helper import IAM_POLICY_VERSION, lint_iam_policy
+from ol_infrastructure.lib.aws.iam_helper import (
+    IAM_POLICY_VERSION,
+    lint_iam_policy,
+    split_iam_policy_by_size,
+)
 from ol_infrastructure.lib.consul import get_consul_provider
 from ol_infrastructure.lib.ol_types import AWSBase
 from ol_infrastructure.lib.pulumi_helper import (
@@ -261,26 +265,43 @@ for iam_policy in iam_policy_names or []:
                 {"actions": ["iam:updateassumerolepolicy"]},
             ]
         }
-    iam_policy_object = iam.Policy(
-        f"cicd-iam-permissions-policy-{iam_policy}-{stack_info.env_suffix}",
-        path=f"/ol-infrastructure/iam/cicd-{stack_info.env_suffix}/",
-        policy=lint_iam_policy(
-            policy_module.policy_definition,
-            parliament_config=parliament_config,
-        ),
-        name_prefix=f"cicd-policy-{iam_policy}-{stack_info.env_suffix}",
-        tags=aws_config.tags,
+    # IAM enforces a hard, non-adjustable 6,144 character cap per managed
+    # policy document. pulumi_infra's action list is real, CloudTrail-derived
+    # usage and doesn't compress -- split across sibling policies (a role can
+    # have several attached) rather than trimming it down to fit.
+    policy_chunks = split_iam_policy_by_size(
+        policy_module.policy_definition, max_bytes=6000
     )
-    iam_policy_objects[iam_policy] = iam_policy_object
+    chunk_objects = []
+    for chunk_index, policy_chunk in enumerate(policy_chunks):
+        name_suffix = f"-{chunk_index}" if len(policy_chunks) > 1 else ""
+        chunk_objects.append(
+            iam.Policy(
+                f"cicd-iam-permissions-policy-{iam_policy}-{stack_info.env_suffix}{name_suffix}",
+                path=f"/ol-infrastructure/iam/cicd-{stack_info.env_suffix}/",
+                policy=lint_iam_policy(
+                    policy_chunk,
+                    parliament_config=parliament_config,
+                ),
+                name_prefix=f"cicd-policy-{iam_policy}-{stack_info.env_suffix}{name_suffix}",
+                tags=aws_config.tags,
+            )
+        )
+    iam_policy_objects[iam_policy] = chunk_objects
 
 # Loop through the policy names hooked to web nodes and attach them
 for iam_policy_name in concourse_config.get_object("web_iam_policies") or []:
-    iam_policy_object = iam_policy_objects[iam_policy_name]
-    iam.RolePolicyAttachment(
-        f"concourse-instance-policy-web-policy-{iam_policy_name}-{stack_info.env_suffix}",
-        policy_arn=iam_policy_object.arn,
-        role=concourse_web_instance_role.name,
-    )
+    policy_chunk_objects = iam_policy_objects[iam_policy_name]
+    for chunk_index, iam_policy_object in enumerate(policy_chunk_objects):
+        # Only suffix the resource name when a policy was actually split --
+        # otherwise every already-attached, unsplit policy gets needlessly
+        # replaced (Pulumi diffs by resource name, not by what it points to).
+        name_suffix = f"-{chunk_index}" if len(policy_chunk_objects) > 1 else ""
+        iam.RolePolicyAttachment(
+            f"concourse-instance-policy-web-policy-{iam_policy_name}{name_suffix}-{stack_info.env_suffix}",
+            policy_arn=iam_policy_object.arn,
+            role=concourse_web_instance_role.name,
+        )
 
 # Other, misc IAM policy attachments
 iam.RolePolicyAttachment(
@@ -718,6 +739,26 @@ for worker_def in concourse_config.get_object("workers") or []:
                 if isinstance(action, str):
                     action = [action]
                 infra_worker_boundary_actions.update(action)
+        # The IAM self-escalation guard this boundary exists for (see comment
+        # above) only depends on the iam:* action list, so those stay
+        # enumerated exactly. Every other service is collapsed to a
+        # service-level wildcard: a boundary is intersected with, never
+        # unioned into, the role's actual policies, so widening it here can't
+        # grant anything beyond what those policies already allow -- and
+        # unlike the attached policy itself (split across siblings in the
+        # loop above), a role can only have one permissions boundary, so it
+        # has to fit under IAM's 6,144 character document cap as a single
+        # policy without splitting.
+        boundary_iam_actions = sorted(
+            a for a in infra_worker_boundary_actions if a.startswith("iam:")
+        )
+        boundary_other_services = sorted(
+            {
+                a.split(":")[0]
+                for a in infra_worker_boundary_actions
+                if not a.startswith("iam:")
+            }
+        )
         concourse_infra_worker_permissions_boundary = iam.Policy(
             f"concourse-instance-role-worker-infra-permissions-boundary-{stack_info.env_suffix}",
             path="/ol-security-boundaries/concourse/",
@@ -727,9 +768,16 @@ for worker_def in concourse_config.get_object("workers") or []:
                     "Statement": [
                         {
                             "Effect": "Allow",
-                            "Action": sorted(infra_worker_boundary_actions),
+                            "Action": boundary_iam_actions,
                             "Resource": "*",
-                        }
+                        },
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                                f"{service}:*" for service in boundary_other_services
+                            ],
+                            "Resource": "*",
+                        },
                     ],
                 },
                 parliament_config={
@@ -788,12 +836,17 @@ for worker_def in concourse_config.get_object("workers") or []:
     export(f"{worker_class_name}-instance-role-arn", concourse_worker_instance_role.arn)
 
     for iam_policy_name in worker_def["iam_policies"] or []:
-        iam_policy_object = iam_policy_objects[iam_policy_name]
-        iam.RolePolicyAttachment(
-            f"concourse-instance-policy-worker-{worker_class_name}-policy-{iam_policy_name}-{stack_info.env_suffix}",
-            policy_arn=iam_policy_object.arn,
-            role=concourse_worker_instance_role.name,
-        )
+        policy_chunk_objects = iam_policy_objects[iam_policy_name]
+        for chunk_index, iam_policy_object in enumerate(policy_chunk_objects):
+            # Only suffix the resource name when a policy was actually split --
+            # otherwise every already-attached, unsplit policy gets needlessly
+            # replaced (Pulumi diffs by resource name, not by what it points to).
+            name_suffix = f"-{chunk_index}" if len(policy_chunk_objects) > 1 else ""
+            iam.RolePolicyAttachment(
+                f"concourse-instance-policy-worker-{worker_class_name}-policy-{iam_policy_name}{name_suffix}-{stack_info.env_suffix}",
+                policy_arn=iam_policy_object.arn,
+                role=concourse_worker_instance_role.name,
+            )
 
     # Attach the describe_instances policy to all workers so they can authenticate
     # with ECR and pull images through the ECR pull-through cache.

--- a/src/ol_infrastructure/lib/aws/iam_helper.py
+++ b/src/ol_infrastructure/lib/aws/iam_helper.py
@@ -114,6 +114,67 @@ def lint_iam_policy(
     )
 
 
+def split_iam_policy_by_size(
+    policy_definition: dict[str, Any],
+    max_bytes: int = 6144,
+) -> list[dict[str, Any]]:
+    """Split a policy document into multiple documents that each fit max_bytes.
+
+    IAM enforces a hard, non-adjustable 6,144 character cap on a single managed
+    policy document. A role can have several managed policies attached, so a
+    document that would exceed the cap can instead be split into siblings that
+    are all attached to the same role, each carrying its own copy of a
+    statement's Effect/Resource/Condition and a slice of its Action list.
+
+    :param policy_definition: An IAM policy document (Version + Statement).
+    :param max_bytes: The per-document size ceiling to split against.
+
+    :returns: One or more policy documents, each within max_bytes when
+        JSON-serialized, that together grant everything policy_definition does.
+    """
+    version = policy_definition["Version"]
+    envelope_size = len(json.dumps({"Version": version, "Statement": []}))
+    action_budget = max_bytes - envelope_size
+
+    pieces: list[dict[str, Any]] = []
+    for statement in policy_definition["Statement"]:
+        actions = statement["Action"]
+        if isinstance(actions, str):
+            actions = [actions]
+        base = {key: value for key, value in statement.items() if key != "Action"}
+        current: list[str] = []
+        for action in actions:
+            candidate = [*current, action]
+            if (
+                current
+                and len(json.dumps({**base, "Action": candidate})) > action_budget
+            ):
+                pieces.append({**base, "Action": current})
+                current = [action]
+            else:
+                current = candidate
+        pieces.append({**base, "Action": current})
+
+    documents: list[list[dict[str, Any]]] = []
+    for piece in pieces:
+        for document_statements in documents:
+            candidate_size = len(
+                json.dumps(
+                    {"Version": version, "Statement": [*document_statements, piece]}
+                )
+            )
+            if candidate_size <= max_bytes:
+                document_statements.append(piece)
+                break
+        else:
+            documents.append([piece])
+
+    return [
+        {"Version": version, "Statement": document_statements}
+        for document_statements in documents
+    ]
+
+
 def route53_policy_template(zone_id: str) -> dict[str, Any]:
     """Policy definition to allow Caddy to use Route 53 to resolve DNS challenges.
 

--- a/src/ol_infrastructure/lib/aws/iam_helper.py
+++ b/src/ol_infrastructure/lib/aws/iam_helper.py
@@ -114,13 +114,61 @@ def lint_iam_policy(
     )
 
 
+def _json_byte_size(document: dict[str, Any]) -> int:
+    """Return the UTF-8 byte size of a document's compact JSON serialization.
+
+    IAM's policy size quota is enforced on the document's byte size, not its
+    character count -- these differ once any non-ASCII character appears.
+    """
+    return len(json.dumps(document).encode("utf-8"))
+
+
+def _split_statement_by_action(
+    base: dict[str, Any],
+    actions: list[str],
+    action_budget: int,
+    max_bytes: int,
+) -> list[dict[str, Any]]:
+    """Split one statement's Action list into pieces that fit action_budget.
+
+    Each returned piece is base (Effect/Resource/Condition) plus a slice of
+    actions, small enough to serialize within action_budget on its own.
+
+    :raises ValueError: If a single action, together with base, is too large
+        to fit on its own -- there's no further way to split it.
+    """
+    pieces: list[dict[str, Any]] = []
+    current: list[str] = []
+    for action in actions:
+        candidate = [*current, action]
+        if _json_byte_size({**base, "Action": candidate}) <= action_budget:
+            current = candidate
+            continue
+        if current:
+            pieces.append({**base, "Action": current})
+            current = []
+        single_size = _json_byte_size({**base, "Action": [action]})
+        if single_size > action_budget:
+            msg = (
+                f"IAM action {action!r} alone (with its statement's "
+                f"Effect/Resource/Condition) is {single_size} bytes, which "
+                f"exceeds the {action_budget}-byte per-statement budget "
+                f"under max_bytes={max_bytes}; it cannot be split further."
+            )
+            raise ValueError(msg)
+        current = [action]
+    if current:
+        pieces.append({**base, "Action": current})
+    return pieces
+
+
 def split_iam_policy_by_size(
     policy_definition: dict[str, Any],
     max_bytes: int = 6144,
 ) -> list[dict[str, Any]]:
     """Split a policy document into multiple documents that each fit max_bytes.
 
-    IAM enforces a hard, non-adjustable 6,144 character cap on a single managed
+    IAM enforces a hard, non-adjustable 6,144 byte cap on a single managed
     policy document. A role can have several managed policies attached, so a
     document that would exceed the cap can instead be split into siblings that
     are all attached to the same role, each carrying its own copy of a
@@ -129,11 +177,15 @@ def split_iam_policy_by_size(
     :param policy_definition: An IAM policy document (Version + Statement).
     :param max_bytes: The per-document size ceiling to split against.
 
+    :raises ValueError: If a single action, together with its statement's
+        Effect/Resource/Condition, is too large to fit in any document on its
+        own -- there's no further way to split it.
+
     :returns: One or more policy documents, each within max_bytes when
         JSON-serialized, that together grant everything policy_definition does.
     """
     version = policy_definition["Version"]
-    envelope_size = len(json.dumps({"Version": version, "Statement": []}))
+    envelope_size = _json_byte_size({"Version": version, "Statement": []})
     action_budget = max_bytes - envelope_size
 
     pieces: list[dict[str, Any]] = []
@@ -142,26 +194,15 @@ def split_iam_policy_by_size(
         if isinstance(actions, str):
             actions = [actions]
         base = {key: value for key, value in statement.items() if key != "Action"}
-        current: list[str] = []
-        for action in actions:
-            candidate = [*current, action]
-            if (
-                current
-                and len(json.dumps({**base, "Action": candidate})) > action_budget
-            ):
-                pieces.append({**base, "Action": current})
-                current = [action]
-            else:
-                current = candidate
-        pieces.append({**base, "Action": current})
+        pieces.extend(
+            _split_statement_by_action(base, actions, action_budget, max_bytes)
+        )
 
     documents: list[list[dict[str, Any]]] = []
     for piece in pieces:
         for document_statements in documents:
-            candidate_size = len(
-                json.dumps(
-                    {"Version": version, "Statement": [*document_statements, piece]}
-                )
+            candidate_size = _json_byte_size(
+                {"Version": version, "Statement": [*document_statements, piece]}
             )
             if candidate_size <= max_bytes:
                 document_statements.append(piece)


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
https://github.com/mitodl/ol-infrastructure/pull/4873 replaced the `AdministratorAccess`-based grant on the Concourse infra worker pool with a hand-scoped least-privilege policy (`iam_policies/pulumi_infra.py`) plus a derived permissions boundary. After merging, `pulumi up` on the CI stack failed:

```
aws:iam:Policy (cicd-iam-permissions-policy-pulumi_infra-ci):
    error: ... operation error IAM: CreatePolicy, https response error StatusCode: 409, ...
    LimitExceeded: Cannot exceed quota for PolicySize: 6144

aws:iam:Policy (concourse-instance-role-worker-infra-permissions-boundary-ci):
    error: ... operation error IAM: CreatePolicy, https response error StatusCode: 409, ...
    LimitExceeded: Cannot exceed quota for PolicySize: 6144
```

Both documents exceed IAM's hard, non-adjustable 6,144-character cap on a single managed policy:
- The attached `pulumi_infra` policy serializes to ~10.8KB (342 actions).
- The derived permissions boundary (built by flattening every action from every attached statement into one `Resource: "*"` list) serializes to ~10.1KB.

Fix, split by how each resource is constrained:
- **Attached policy** -- a role can have multiple managed policies attached, so `iam_helper.split_iam_policy_by_size()` (new helper) splits the document into sibling `iam.Policy` resources, each under the byte cap, all attached to the role. No change in scope -- same actions, same resource restrictions, just spread across two documents.
- **Permissions boundary** -- a role can only have *one* boundary, so it can't be split; it has to fit as a single document. The boundary's own purpose (per the existing code comments) is narrowly to block IAM self-escalation via this role's own `iam:CreatePolicy`/`AttachRolePolicy`/etc. actions. So `iam:*` actions stay enumerated exactly, and every other service collapses to a service-level wildcard (`ec2:*`, `s3:*`, etc.). Since a boundary is intersected with, never unioned into, the role's actual permissions, widening it for non-IAM services can't grant anything beyond what the (still tightly scoped) attached policy already allows. This shrinks the boundary from ~10.1KB to ~1.2KB.

Also fixed: the `RolePolicyAttachment` resource names only get a chunk-index suffix when a policy was actually split, so already-attached, unsplit policies (`base`, `operations`, `ocw`, `infra`, `cloud_custodian`, `pulumi_state`) aren't needlessly replaced.

### How can this be tested?
Verified with `pulumi preview` against the `CI`, `QA`, and `Production` stacks for `applications/concourse` -- each now shows a clean `+5 to create` (2 `pulumi_infra` policy chunks, the shrunk boundary policy, and 2 new `RolePolicyAttachment`s), no deletions or unexpected replacements. The remaining diff in each preview is pre-existing, unrelated drift (AMI IDs, launch template userdata, autoscaling group tags).

Also ran `ruff check`, `mypy`, and pre-commit against both changed files -- no new findings (existing unrelated findings in `concourse/__main__.py` are untouched).

Reviewer can re-run:
```
cd src/ol_infrastructure/applications/concourse
uv run pulumi preview --stack CI
```

### Additional Context
N/A
