### PR TITLE
feat(traefik): capture User-Agent in gateway access logs

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/eks/traefik.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/traefik.py
@@ -193,6 +193,14 @@ def setup_traefik(
                 "accessLog": {
                     "enabled": True,
                     "format": "json",
+                    "fields": {
+                        "headers": {
+                            "defaultMode": "drop",
+                            "names": {
+                                "User-Agent": "keep",
+                            },
+                        },
+                    },
                 },
                 "resources": {
                     "requests": {


### PR DESCRIPTION
### What are the relevant tickets?
N/A — related to https://github.com/mitodl/mit-learn/issues/3688 (found during the same investigation, but that's an app-level fix in a different repo)

### Description (What does it do?)
Adds `accessLog.fields.headers` to the Traefik Helm release values (`src/ol_infrastructure/infrastructure/aws/eks/traefik.py`), explicitly keeping the `User-Agent` header while leaving all other request headers dropped by default.

While investigating why the `traefik-gateway-controller` HPA in `applications-production` was pegged at max replicas, a large share of the load turned out to be high-volume/duplicate requests to `next.learn.mit.edu`. Traefik's JSON access log currently has no `User-Agent` field at all (confirmed by inspecting live log output in Grafana Loki) — only `ClientAddr/ClientHost`, method, path, status, and timing fields are captured. That made it impossible to distinguish real browser traffic from crawlers/bots/automated retries by anything other than IP, which is unreliable on its own (client IPs seen at the edge can be CDN/shield IPs rather than end clients).

This change captures `User-Agent` going forward so future investigations of traffic spikes/HPA saturation on this gateway have a real signal to fingerprint clients with, without capturing other headers (cookies, auth headers, etc.) that shouldn't land in logs.

### How can this be tested?
- `pulumi preview` against `applications.CI` shows a clean in-place update to the `traefik-gateway-controller` Helm release, adding only the new `accessLog.fields.headers` values block — no resource replacement, no unrelated diffs:
  ```
  ~ kubernetes:helm.sh/v3:Release: (update)
      [id=operations/traefik-gateway-controller]
    ~ values: {
        ~ accessLog: {
            + fields: {
                + headers: {
                    + defaultMode: "drop"
                    + names      : {
                        + User-Agent: "keep"
                      }
                  }
              }
          }
      }
  ```
- `pre-commit run --files src/ol_infrastructure/infrastructure/aws/eks/traefik.py` passes (ruff format/check, mypy, etc.)
- After deploy, confirm `User-Agent` appears in Traefik's JSON access log lines in Grafana Loki (`{cluster="...", namespace="operations", container="traefik-gateway-controller"} | json`).

### Additional Context
This is an observability-only change (Traefik's own `defaultMode: "drop"` keeps every other header out of the logs), not a behavioral/routing change. No effect on request handling, only on what's captured in `accessLog`.