### PR TITLE
fix(traefik): raise memory limit from 150Mi to 512Mi

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
@@ -1026,6 +1026,20 @@ lb_controller = setup_aws_integrations(
     cert_manager=cert_manager_release,
 )
 
+############################################################
+# Install VPA ahead of Traefik/APISIX so both gateways can be
+# configured with vertical autoscaling
+############################################################
+vpa_release = setup_vpa(
+    cluster_name=cluster_name,
+    cluster=cluster,
+    k8s_provider=k8s_provider,
+    node_groups=node_groups,
+    k8s_global_labels=k8s_global_labels,
+    operations_tolerations=operations_tolerations,
+    versions=VERSIONS,
+)
+
 gateway_api_crds = setup_traefik(
     cluster_name=cluster_name,
     k8s_provider=k8s_provider,
@@ -1041,19 +1055,7 @@ gateway_api_crds = setup_traefik(
     cluster=cluster,
     lb_controller=lb_controller,
     fastly_provider=fastly_provider,
-)
-
-############################################################
-# Install VPA and configure APISIX with vertical autoscaling
-############################################################
-vpa_release = setup_vpa(
-    cluster_name=cluster_name,
-    cluster=cluster,
-    k8s_provider=k8s_provider,
-    node_groups=node_groups,
-    k8s_global_labels=k8s_global_labels,
-    operations_tolerations=operations_tolerations,
-    versions=VERSIONS,
+    vpa_release=vpa_release,
 )
 
 setup_apisix(

--- a/src/ol_infrastructure/infrastructure/aws/eks/traefik.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/traefik.py
@@ -24,6 +24,7 @@ def setup_traefik(
     cluster,
     lb_controller,
     fastly_provider: fastly.Provider,
+    vpa_release: kubernetes.helm.v3.Release,
 ):
     """
     Configure and install the Traefik ingress controller.
@@ -42,6 +43,7 @@ def setup_traefik(
     :param cluster: The EKS cluster object.
     :param lb_controller: The AWS Load Balancer Controller.
     :param fastly_provider: The Fastly provider instance.
+    :param vpa_release: The VPA Helm release; ensures VPA CRDs exist before the VPA object is created.
 
     :return: The Gateway API CRDs.
     """
@@ -78,7 +80,7 @@ def setup_traefik(
     # Ref: https://doc.traefik.io/traefik/providers/kubernetes-gateway/
     #
     # TODO: @Ardiea add the ability to define more ports in config.
-    kubernetes.helm.v3.Release(
+    traefik_helm_release = kubernetes.helm.v3.Release(
         f"{cluster_name}-traefik-gateway-controller-helm-release",
         kubernetes.helm.v3.ReleaseArgs(
             name="traefik-gateway-controller",
@@ -254,4 +256,66 @@ def setup_traefik(
             ],
         ),
     )
+
+    # Create a VerticalPodAutoscaler for the Traefik gateway deployment.
+    #
+    # VPA manages memory sizing only; CPU-based horizontal scaling is handled by the
+    # HPA above (autoscaling.metrics, targeting 50% CPU utilization). Splitting
+    # authority this way avoids the known HPA/VPA conflict where VPA-adjusted CPU
+    # requests would distort the CPU utilization percentage the HPA observes. See
+    # apisix_official.py for the same pattern applied to the APISIX gateway.
+    #
+    # Added after an incident where every pod in operations-production OOMKilled
+    # (memory request == limit == 150Mi, zero headroom) and the CPU-only HPA could
+    # not compensate -- adding replicas doesn't help when the bottleneck is a
+    # per-pod memory ceiling; it just means more pods hitting the same wall.
+    #
+    # updateMode "InPlaceOrRecreate" attempts to resize memory without evicting the
+    # pod (K8s 1.33+, VPA 1.6+), falling back to eviction only when an in-place
+    # update is not possible.
+    kubernetes.apiextensions.CustomResource(
+        f"{cluster_name}-traefik-gateway-controller-vpa",
+        api_version="autoscaling.k8s.io/v1",
+        kind="VerticalPodAutoscaler",
+        metadata={
+            "name": "traefik-gateway-controller",
+            "namespace": "operations",
+        },
+        spec={
+            "targetRef": {
+                "apiVersion": "apps/v1",
+                "kind": "Deployment",
+                "name": "traefik-gateway-controller",
+            },
+            "updatePolicy": {
+                "updateMode": "InPlaceOrRecreate",
+            },
+            "resourcePolicy": {
+                "containerPolicies": [
+                    {
+                        "containerName": "traefik-gateway-controller",
+                        # Only control memory so the HPA retains full authority
+                        # over CPU requests and therefore replica count decisions.
+                        "controlledResources": ["memory"],
+                        "controlledValues": "RequestsAndLimits",
+                        "minAllowed": {
+                            "memory": eks_config.get("traefik_memory") or "150Mi",
+                        },
+                        "maxAllowed": {
+                            "memory": eks_config.get("traefik_max_memory") or "1Gi",
+                        },
+                    }
+                ]
+            },
+        },
+        opts=ResourceOptions(
+            provider=k8s_provider,
+            parent=operations_namespace,
+            # vpa_release ensures the autoscaling.k8s.io CRDs are installed first.
+            # traefik_helm_release ensures the target Deployment exists before VPA
+            # targets it.
+            depends_on=[vpa_release, traefik_helm_release],
+        ),
+    )
+
     return gateway_api_crds

--- a/src/ol_infrastructure/infrastructure/aws/eks/traefik.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/traefik.py
@@ -200,7 +200,7 @@ def setup_traefik(
                         "memory": "150Mi",
                     },
                     "limits": {
-                        "memory": "150Mi",
+                        "memory": "512Mi",
                     },
                 },
                 "metrics": {


### PR DESCRIPTION
### What are the relevant tickets?
N/A — live incident remediation, same investigation thread as #5145/#5146

### Description (What does it do?)
Two changes to the shared `setup_traefik()` component (`src/ol_infrastructure/infrastructure/aws/eks/traefik.py`), used by every EKS cluster (applications/data/operations/residential):

1. **Raises the memory limit from `150Mi` to `512Mi`.**
2. **Adds a memory-only VerticalPodAutoscaler** for the Traefik Deployment, so the resource ceiling can grow further under real load instead of just being a slightly-bigger fixed wall.

**Live incident:** all 10 `traefik-gateway-controller` pods in `operations-production` (fronts `sso.ol.mit.edu`/Keycloak and `log-proxy.odl.mit.edu`, the latter carrying >11x the request volume of the former) were in `OOMKilled`/`CrashLoopBackOff`, taking the deployment fully unavailable (`0/10` ready). Confirmed directly via `kubectl`:
```
lastState: {"terminated":{"exitCode":137,"reason":"OOMKilled", ...}}
```
with `resources.requests.memory == resources.limits.memory == 150Mi` — zero headroom.

Root cause: the Deployment's HPA is CPU-only (`autoscaling.metrics` targets 50% CPU utilization) — it has no way to react to memory pressure, and adding replicas doesn't help when the bottleneck is a per-pod memory ceiling each replica hits independently. Once one pod OOMKilled, survivors absorbed the same log-shipping volume with fewer replicas, deepening memory pressure until all 10 were down — a cascading failure, not a single spike (24h request-volume history for `log-proxy.odl.mit.edu` was fairly stable at ~14-16 req/s for most of the window; the last 2h before recovery saw ~50% of all its requests return `499`, consistent with an overloaded/restarting backend generating client-side timeouts that likely compounded via retries).

**Immediate mitigation (already applied and verified live):** patched the `operations-production` Deployment directly (`kubectl patch ... resources/limits/memory=512Mi`). All 10 pods recovered to `Running`/`1/1`.

This PR codifies that fix in code so the next `pulumi up` doesn't drift the live patch back down to `150Mi`, extends the same headroom to every other cluster using this component, and adds a VPA (mirroring the existing pattern for the APISIX gateway in `apisix_official.py`) so memory can keep scaling with observed usage instead of relying on a second guess-and-fix cycle later. The VPA is scoped to `controlledResources: ["memory"]` only, so the HPA retains full authority over CPU/replica-count decisions (avoids the known HPA/VPA conflict where VPA-adjusted CPU requests distort the utilization percentage the HPA observes).

### How can this be tested?
`pulumi preview --diff` against `operations.CI` shows a clean diff — the existing in-place update plus one new resource creation, nothing unexpected:
```
~ kubernetes:helm.sh/v3:Release: (update)
  ~ values: { ~ resources: { ~ limits: { ~ memory: "150Mi" => "512Mi" } } }
+ kubernetes:autoscaling.k8s.io/v1:VerticalPodAutoscaler: (create)
    metadata: { name: "traefik-gateway-controller", namespace: "operations" }
    spec: {
      resourcePolicy: { containerPolicies: [{ containerName: "traefik-gateway-controller",
        controlledResources: ["memory"], controlledValues: "RequestsAndLimits",
        minAllowed: { memory: "150Mi" }, maxAllowed: { memory: "1Gi" } }] }
      targetRef: { apiVersion: "apps/v1", kind: "Deployment", name: "traefik-gateway-controller" }
      updatePolicy: { updateMode: "InPlaceOrRecreate" }
    }
Resources: + 1 to create, ~ 1 to update, 2 changes, 148 unchanged
```
`pre-commit run` (ruff format/check, mypy, etc.) passes on both modified files.

Required reordering `setup_vpa()` before `setup_traefik()` in `__main__.py` so the VPA Helm release can be passed in as a `depends_on` dependency (the same way it already is for `setup_apisix()`); `setup_vpa()` has no dependency on Traefik or the Gateway API CRDs, so this reorder is safe and doesn't affect any other resource's dependency graph.

### Additional Context
Request stays at `150Mi` (unchanged) as the VPA's `minAllowed` floor; only the limit and the VPA's `maxAllowed` (`1Gi`) add headroom. `1Gi`/`512Mi` were chosen as generous starting points for a long-running ingress proxy under real SSO + log-proxy traffic; both can be tuned down later with real usage data once the gateway has been stable for a while.