### PR TITLE
feat(vector-log-proxy): add CPU HPA, switch VPA to memory-only

### DIFF
--- a/src/ol_infrastructure/infrastructure/vector_log_proxy/__main__.py
+++ b/src/ol_infrastructure/infrastructure/vector_log_proxy/__main__.py
@@ -549,13 +549,20 @@ vector_deployment = kubernetes.apps.v1.Deployment(
                             period_seconds=10,
                         ),
                         resources=kubernetes.core.v1.ResourceRequirementsArgs(
+                            # Sized from observed usage on operations-production
+                            # (~50-65m CPU, ~580-640Mi memory per pod sustained
+                            # under real Fastly + Heroku log-shipping volume,
+                            # confirmed via `kubectl top` 2026-07-28) rather than
+                            # the original guess. CPU is now HPA-controlled
+                            # (below) so this request is the utilization-percent
+                            # baseline; memory stays VPA-controlled.
                             requests={
-                                "cpu": "500m",
-                                "memory": "512Mi",
+                                "cpu": "100m",
+                                "memory": "1Gi",
                             },
                             limits={
-                                "cpu": "1000m",
-                                "memory": "1Gi",
+                                "cpu": "250m",
+                                "memory": "2Gi",
                             },
                         ),
                     ),
@@ -779,10 +786,53 @@ make_vpa(
     namespace=namespace,
     target_kind="Deployment",
     target_name=application_name,
-    controlled_resources=["cpu", "memory"],
+    # Memory only -- CPU-based horizontal scaling is handled by the HPA below.
+    # Splitting authority this way avoids the known HPA/VPA conflict where
+    # VPA-adjusted CPU requests would distort the utilization percentage the
+    # HPA observes (same pattern used for the Traefik/APISIX gateways).
+    controlled_resources=["memory"],
     container_name="vector",
-    min_allowed={"cpu": "10m", "memory": "64Mi"},
-    max_allowed={"cpu": "2000m", "memory": "4Gi"},
+    min_allowed={"memory": "64Mi"},
+    max_allowed={"memory": "4Gi"},
+    opts=ResourceOptions(depends_on=[vector_deployment]),
+)
+
+# Horizontal scaling for request-volume growth. vector-log-proxy is stateless
+# (each replica independently forwards events to the same downstream sinks),
+# so this is a safe standard scale-out. Added after an incident where the
+# operations-production Traefik gateway in front of this service OOMKilled
+# under sustained log-shipping volume (~1.3M requests/24h to this Service);
+# giving this workload real horizontal headroom reduces the odds that it
+# becomes a slow/saturated backend that holds connections open at the
+# ingress layer during a future volume spike.
+kubernetes.autoscaling.v2.HorizontalPodAutoscaler(
+    f"{application_name}-hpa",
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        name=application_name,
+        namespace=namespace,
+        labels=k8s_global_labels,
+    ),
+    spec=kubernetes.autoscaling.v2.HorizontalPodAutoscalerSpecArgs(
+        scale_target_ref=kubernetes.autoscaling.v2.CrossVersionObjectReferenceArgs(
+            api_version="apps/v1",
+            kind="Deployment",
+            name=application_name,
+        ),
+        min_replicas=2,
+        max_replicas=6,
+        metrics=[
+            kubernetes.autoscaling.v2.MetricSpecArgs(
+                type="Resource",
+                resource=kubernetes.autoscaling.v2.ResourceMetricSourceArgs(
+                    name="cpu",
+                    target=kubernetes.autoscaling.v2.MetricTargetArgs(
+                        type="Utilization",
+                        average_utilization=70,
+                    ),
+                ),
+            ),
+        ],
+    ),
     opts=ResourceOptions(depends_on=[vector_deployment]),
 )
 

--- a/src/ol_infrastructure/infrastructure/vector_log_proxy/__main__.py
+++ b/src/ol_infrastructure/infrastructure/vector_log_proxy/__main__.py
@@ -648,6 +648,12 @@ vector_deployment = kubernetes.apps.v1.Deployment(
             ),
         ),
     ),
+    opts=ResourceOptions(
+        # Let the HPA (below) manage replica count without Pulumi reverting
+        # it back to the static replicas=2 on every pulumi up. Same pattern
+        # as applications/xqwatcher/__main__.py.
+        ignore_changes=["spec.replicas"],
+    ),
 )
 
 ##################################
@@ -778,10 +784,6 @@ vector_gateway = OLEKSGateway(
     ),
     opts=ResourceOptions(
         delete_before_replace=True,
-        # Let the HPA (below) manage replica count without Pulumi reverting
-        # it back to the static replicas=2 on every pulumi up. Same pattern
-        # as applications/xqwatcher/__main__.py.
-        ignore_changes=["spec.replicas"],
     ),
 )
 

--- a/src/ol_infrastructure/infrastructure/vector_log_proxy/__main__.py
+++ b/src/ol_infrastructure/infrastructure/vector_log_proxy/__main__.py
@@ -778,6 +778,10 @@ vector_gateway = OLEKSGateway(
     ),
     opts=ResourceOptions(
         delete_before_replace=True,
+        # Let the HPA (below) manage replica count without Pulumi reverting
+        # it back to the static replicas=2 on every pulumi up. Same pattern
+        # as applications/xqwatcher/__main__.py.
+        ignore_changes=["spec.replicas"],
     ),
 )
 
@@ -794,6 +798,13 @@ make_vpa(
     container_name="vector",
     min_allowed={"memory": "64Mi"},
     max_allowed={"memory": "4Gi"},
+    # Without this, VPA applies its default behavior to the fastly-challenge
+    # sidecar too -- silently overriding its declared resources, and (more
+    # importantly) still mutating its CPU request, which would reintroduce
+    # the HPA/VPA conflict this split is meant to avoid: HPA CPU utilization
+    # is computed against total pod CPU requests, not just the vector
+    # container's.
+    disable_other_containers=True,
     opts=ResourceOptions(depends_on=[vector_deployment]),
 )
 


### PR DESCRIPTION
### What are the relevant tickets?
N/A — follow-up from the same investigation thread as #5147 (Traefik OOM fix)

### Description (What does it do?)
Adds horizontal autoscaling to `vector-log-proxy` (the Fastly/Heroku real-time log-shipping proxy in `operations-production`), and right-sizes its resources based on actual measured usage.

**Analysis performed** (via `kubectl top` on `operations-production`, taken right after the Traefik incident that fronts this Service — see #5147):
- The `vector` container runs sustained **~50-65m CPU / ~580-640Mi memory per pod**, under real Fastly + Heroku log-shipping volume (~1.3M requests/24h through the fronting Traefik gateway, per Loki).
- The existing VPA (already in place, previously `controlled_resources=["cpu", "memory"]`) had independently adapted the live request/limit to **~933Mi/1.87Gi memory** and **~23m/46m CPU** — far from the originally-declared static `500m CPU / 512Mi memory`, confirming that original guess was stale.
- This also confirms `vector-log-proxy` itself was **not** the workload that OOMKilled during the incident — its memory usage stayed comfortably within range throughout. Traefik, in front of it, was.

**Changes** (`src/ol_infrastructure/infrastructure/vector_log_proxy/__main__.py`):
1. Right-sized the `vector` container's static request/limit: `500m/512Mi → 100m/1Gi` request, `1000m/1Gi → 250m/2Gi` limit — matching observed usage with real headroom instead of the untested original guess.
2. Switched the existing VPA from `controlled_resources=["cpu", "memory"]` to **memory-only**, and added a **CPU-based `HorizontalPodAutoscaler`** (2-6 replicas, 70% target utilization). This mirrors the same split already used for the Traefik and APISIX gateways elsewhere in this repo: without it, an HPA reading a VPA-adjusted CPU request gets a distorted utilization signal (the exact conflict those two components already guard against).
3. `vector-log-proxy` is stateless — each replica independently forwards events to the same downstream sinks (Grafana Cloud Loki/Prometheus) — so horizontal scale-out is architecturally safe here, unlike single-writer services elsewhere in this repo (e.g. `omnigraph-server`).

This doesn't directly fix the Traefik OOM (that's #5147) — it gives the backend behind that gateway real horizontal headroom, reducing the odds it becomes a slow/saturated backend that holds connections open at the ingress layer during a future traffic spike.

### How can this be tested?
`pulumi preview --diff` against `operations.CI` shows exactly the expected changes, no unexpected replacements:
```
~ kubernetes:apps/v1:Deployment: (update)
    resources: { limits: cpu 1->250m, memory 1Gi->2Gi; requests: cpu 500m->100m, memory 512Mi->1Gi }
~ kubernetes:autoscaling.k8s.io/v1:VerticalPodAutoscaler: (update)
    controlledResources: ["cpu","memory"] -> ["memory"]; cpu bounds removed
+ kubernetes:autoscaling/v2:HorizontalPodAutoscaler: (create)
    minReplicas: 2, maxReplicas: 6, cpu target 70%
Resources: + 1 to create, ~ 3 to update, 4 changes, 32 unchanged
```
(An unrelated `vault:generic/secret:Secret` update also shows in the diff — pre-existing secret-rotation drift, not caused by this change.)

`pre-commit run` (ruff format/check, mypy, etc.) passes.

### Additional Context
`minReplicas=2` preserves today's baseline capacity exactly; `maxReplicas=6` gives room for real traffic growth without being excessive for a log-shipping sidecar-style service. Both the HPA bounds and the resource values can be tuned down later with more usage data once this has run for a while.