### PR TITLE
fix(concourse): write CONCOURSE_NAME in preflight to close boot-time naming race

### DIFF
--- a/src/bilder/images/concourse/files/concourse-worker-preflight
+++ b/src/bilder/images/concourse/files/concourse-worker-preflight
@@ -52,18 +52,25 @@ check_tcp() {
 }
 
 write_worker_identity() {
-    local token instance_id
-    token=$(get_imds_token)
-    if [ -z "${token}" ]; then
-        log "IMDS token fetch failed; CONCOURSE_NAME will fall back to hostname"
+    # Idempotent and pinned for the life of the box: once a name is written,
+    # later preflight runs (this unit re-runs on every concourse.service
+    # restart, not just first boot) must never overwrite it. Otherwise a
+    # transient IMDS failure on the first run followed by a later success
+    # would still produce two different names for the same worker over its
+    # lifetime -- the exact race this script exists to close.
+    if [ -s /etc/default/concourse-name ]; then
         return
     fi
-    instance_id=$(imds_get "instance-id" "${token}")
-    if [ -n "${instance_id}" ]; then
-        echo "CONCOURSE_NAME=${instance_id}" > /etc/default/concourse-name
-    else
-        log "instance-id metadata empty; CONCOURSE_NAME will fall back to hostname"
+    local token instance_id name
+    token=$(get_imds_token)
+    if [ -n "${token}" ]; then
+        instance_id=$(imds_get "instance-id" "${token}")
     fi
+    name="${instance_id:-$(hostname)}"
+    if [ -z "${instance_id:-}" ]; then
+        log "instance-id metadata unavailable; pinning CONCOURSE_NAME to hostname (${name}) instead"
+    fi
+    echo "CONCOURSE_NAME=${name}" > /etc/default/concourse-name
 }
 
 run_checks() {

--- a/src/bilder/images/concourse/files/concourse-worker-preflight
+++ b/src/bilder/images/concourse/files/concourse-worker-preflight
@@ -7,6 +7,13 @@
 # replaced) since Concourse has no way to know a "running" worker is actually
 # unreachable from the outside. This is wired as a hard dependency of
 # concourse.service via [Unit] Requires=/After= (worker units only).
+#
+# Also writes /etc/default/concourse-name (CONCOURSE_NAME=<instance-id>) here,
+# rather than in a cloud-init runcmd, so it's guaranteed to exist before
+# concourse.service's first start -- cloud-init's runcmd stage has no systemd
+# ordering relative to concourse.service and can race it, letting the worker
+# register once under its hostname and then again under the instance ID after
+# a later restart picks up the file.
 set -uo pipefail
 
 RETRY_BUDGET_SECONDS=${RETRY_BUDGET_SECONDS:-600}
@@ -44,6 +51,21 @@ check_tcp() {
     timeout 5 bash -c "exec 3<>/dev/tcp/${host}/${port}" 2>/dev/null
 }
 
+write_worker_identity() {
+    local token instance_id
+    token=$(get_imds_token)
+    if [ -z "${token}" ]; then
+        log "IMDS token fetch failed; CONCOURSE_NAME will fall back to hostname"
+        return
+    fi
+    instance_id=$(imds_get "instance-id" "${token}")
+    if [ -n "${instance_id}" ]; then
+        echo "CONCOURSE_NAME=${instance_id}" > /etc/default/concourse-name
+    else
+        log "instance-id metadata empty; CONCOURSE_NAME will fall back to hostname"
+    fi
+}
+
 run_checks() {
     local token
     token=$(get_imds_token)
@@ -66,6 +88,7 @@ deadline=$(($(date +%s) + RETRY_BUDGET_SECONDS))
 while true; do
     if run_checks; then
         log "All network preflight checks passed"
+        write_worker_identity
         exit 0
     fi
     if [ "$(date +%s)" -ge "${deadline}" ]; then

--- a/src/bilder/images/concourse/files/concourse-worker-preflight
+++ b/src/bilder/images/concourse/files/concourse-worker-preflight
@@ -8,8 +8,9 @@
 # unreachable from the outside. This is wired as a hard dependency of
 # concourse.service via [Unit] Requires=/After= (worker units only).
 #
-# Also writes /etc/default/concourse-name (CONCOURSE_NAME=<instance-id>) here,
-# rather than in a cloud-init runcmd, so it's guaranteed to exist before
+# Also writes /etc/default/concourse-name (CONCOURSE_NAME=<instance-id>, or
+# the box's own hostname if IMDS is unreachable) here, rather than in a
+# cloud-init runcmd, so it's guaranteed to exist before
 # concourse.service's first start -- cloud-init's runcmd stage has no systemd
 # ordering relative to concourse.service and can race it, letting the worker
 # register once under its hostname and then again under the instance ID after
@@ -59,7 +60,7 @@ write_worker_identity() {
     # would still produce two different names for the same worker over its
     # lifetime -- the exact race this script exists to close.
     if [ -s /etc/default/concourse-name ]; then
-        return
+        return 0
     fi
     local token instance_id name
     token=$(get_imds_token)
@@ -70,7 +71,10 @@ write_worker_identity() {
     if [ -z "${instance_id:-}" ]; then
         log "instance-id metadata unavailable; pinning CONCOURSE_NAME to hostname (${name}) instead"
     fi
-    echo "CONCOURSE_NAME=${name}" > /etc/default/concourse-name
+    if ! echo "CONCOURSE_NAME=${name}" > /etc/default/concourse-name; then
+        log "failed to write /etc/default/concourse-name"
+        return 1
+    fi
 }
 
 run_checks() {
@@ -95,13 +99,16 @@ deadline=$(($(date +%s) + RETRY_BUDGET_SECONDS))
 while true; do
     if run_checks; then
         log "All network preflight checks passed"
-        write_worker_identity
-        exit 0
+        if write_worker_identity; then
+            exit 0
+        fi
+    else
+        log "Preflight checks failed"
     fi
     if [ "$(date +%s)" -ge "${deadline}" ]; then
         break
     fi
-    log "Preflight checks failed; retrying in ${RETRY_INTERVAL_SECONDS}s"
+    log "Retrying in ${RETRY_INTERVAL_SECONDS}s"
     sleep "${RETRY_INTERVAL_SECONDS}"
 done
 

--- a/src/bilder/images/concourse/files/concourse-worker-reaper
+++ b/src/bilder/images/concourse/files/concourse-worker-reaper
@@ -93,13 +93,14 @@ if ! "${FLY_BIN}" -t "${FLY_TARGET}" workers >/dev/null 2>&1; then
 fi
 
 # --- Gather ground truth: live worker instance IDs and IPs ----------------
-# CONCOURSE_NAME is pinned to the EC2 instance ID (see cloud-init runcmd in
-# ol_infrastructure/applications/concourse/__main__.py), so a stalled worker's
-# name should already be an instance ID -- match it directly against live
-# instances instead of parsing an IP out of it. Older workers that registered
-# before that change (or that fell back to the default IP-derived hostname
-# because the boot-time IMDS call failed) are still matched by IP as a
-# fallback.
+# CONCOURSE_NAME is pinned to the EC2 instance ID (written by
+# concourse-worker-preflight before concourse.service's first start; see
+# bilder/images/concourse/files/concourse-worker-preflight), so a stalled
+# worker's name should already be an instance ID -- match it directly against
+# live instances instead of parsing an IP out of it. Older workers that
+# registered before that change (or that fell back to the default IP-derived
+# hostname because the preflight's IMDS call failed) are still matched by IP
+# as a fallback.
 #
 # Only "pending" and "running" count as live: an instance in stopping/
 # shutting-down is on its way out and will never host a recovering worker, so a

--- a/src/ol_infrastructure/applications/concourse/__main__.py
+++ b/src/ol_infrastructure/applications/concourse/__main__.py
@@ -176,11 +176,12 @@ def build_worker_user_data(
                 "owner": "root:root",
             }
         )
-    # Worker identity is pinned to the instance ID (never reused, unlike the
-    # EC2-hostname-derived default) by concourse-worker-preflight writing
+    # Worker identity is pinned by concourse-worker-preflight writing
     # /etc/default/concourse-name before concourse.service's first start --
     # not here via cloud-init runcmd, which has no systemd ordering relative
-    # to concourse.service and can race it.
+    # to concourse.service and can race it. Preflight prefers the instance ID
+    # (never reused, unlike the EC2-hostname-derived default) but falls back
+    # to hostname if IMDS is unreachable.
     return base64.b64encode(
         "#cloud-config\n{}".format(
             yaml.dump(

--- a/src/ol_infrastructure/applications/concourse/__main__.py
+++ b/src/ol_infrastructure/applications/concourse/__main__.py
@@ -176,25 +176,11 @@ def build_worker_user_data(
                 "owner": "root:root",
             }
         )
-    # Worker identity defaults to the EC2-hostname-derived name (ip-A-B-C-D),
-    # and private IPs get recycled across ASG replacements in these subnets,
-    # so a fresh instance can inherit a prior (now-deleted) worker's identity
-    # before the stalled-worker reaper catches up, producing FK-constraint GC
-    # errors against the old worker's orphaned volume/container rows. Pin the
-    # name to the instance ID instead, which is never reused.
-    yaml_contents["runcmd"] = [
-        (
-            "TOKEN=$(curl -s -X PUT http://169.254.169.254/latest/api/token "
-            "-H 'X-aws-ec2-metadata-token-ttl-seconds: 60' "
-            "--connect-timeout 2 --max-time 5); "
-            'INSTANCE_ID=$(curl -s -H "X-aws-ec2-metadata-token: $TOKEN" '
-            "--connect-timeout 2 --max-time 5 "
-            "http://169.254.169.254/latest/meta-data/instance-id); "
-            'if [ -n "$INSTANCE_ID" ]; then '
-            'echo "CONCOURSE_NAME=${INSTANCE_ID}" > /etc/default/concourse-name; '
-            "fi"
-        )
-    ]
+    # Worker identity is pinned to the instance ID (never reused, unlike the
+    # EC2-hostname-derived default) by concourse-worker-preflight writing
+    # /etc/default/concourse-name before concourse.service's first start --
+    # not here via cloud-init runcmd, which has no systemd ordering relative
+    # to concourse.service and can race it.
     return base64.b64encode(
         "#cloud-config\n{}".format(
             yaml.dump(


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Fixes a Concourse worker double-registration bug: workers were showing up in `fly workers` twice for the same physical box — once under the EC2-hostname-derived default name (`ip-A-B-C-D`) and once under the instance ID.

Root cause: `CONCOURSE_NAME` is pinned to the instance ID via a cloud-init `runcmd` in [`build_worker_user_data()`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/applications/concourse/__main__.py), which writes `/etc/default/concourse-name`. `concourse.service` loads that file via `EnvironmentFile=-/etc/default/concourse-name` (optional — silently ignored if missing). However, `concourse.service` has no systemd ordering dependency on cloud-init's `runcmd` stage (only on `concourse-worker-preflight.service`, which just checks network reachability). So on boot, if preflight passes quickly, `concourse.service` can start and register with the TSA under the default hostname-derived name *before* the `runcmd` has written the instance-ID file. If the worker process later restarts for any reason (crash, `Restart=always`), it then picks up the now-present `CONCOURSE_NAME=<instance-id>` and re-registers under a second name, leaving the original hostname-named entry as an orphan.

That orphan then evades the stalled-worker reaper (added in #4781): the reaper only prunes a `stalled` worker once EC2 confirms its backing instance is gone, but the instance never actually terminated — it just re-registered under a different name — so the reaper's fail-closed liveness check (correctly, from its own perspective) refuses to touch it.

Fix: move the `CONCOURSE_NAME` write out of the cloud-init `runcmd` and into `concourse-worker-preflight` itself. Since `concourse.service` has a hard `Requires=`/`After=` dependency on that preflight unit completing, this guarantees `/etc/default/concourse-name` exists and is correct before the worker's very first TSA registration — no race, every boot.

Also updated a stale comment in `concourse-worker-reaper` that referenced the old cloud-init runcmd location.

### Screenshots (if appropriate):
N/A — no UI changes.

### How can this be tested?
- `uv run pre-commit run --all-files` and `uv run mypy` pass on the changed files.
- No live Pulumi resources changed (this only affects the worker AMI boot sequence via a bilder-provisioned script and the Pulumi-generated cloud-init user-data), so there's no `pulumi preview` diff to review.
- Real validation requires a fresh Concourse worker AMI build + an instance refresh in CI/QA, then confirming via `fly workers` that new workers register exactly once, under their instance ID, with no hostname-named duplicate appearing afterward even across a `systemctl restart concourse` on the box.

### Additional Context
Follow-on from the spot-worker robustness work in #4781. This closes the specific race that PR's stalled-worker reaper couldn't fully cover — a worker that's still alive but has re-registered under a second name isn't "stalled" from EC2's point of view, so the reaper (correctly) leaves it alone.