### PR TITLE
fix(mit-learn): give celery workers real request/limit headroom

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1452,7 +1452,7 @@ celery_edx_content_resource_limits = _resource_config(
     "celery_edx_content_resource_limits", {"memory": "3072Mi"}
 )
 # CPU request set to 1000m (not the 1311m uncapped VPA target) to match the
-# raised VPA max_allowed below -- see celery_embeddings_vpa_bounds.
+# raised VPA max_allowed below -- see _embeddings_worker_vpa_bounds.
 celery_embeddings_resource_requests = _resource_config(
     "celery_embeddings_resource_requests", {"cpu": "1000m", "memory": "1024Mi"}
 )

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1426,29 +1426,44 @@ webapp_vpa_min_allowed_memory = (
 webapp_vpa_max_allowed_memory = (
     mitlearn_config.get("webapp_vpa_max_allowed_memory") or "4Gi"
 )
+#
+# request/memory values below are sized from each worker's own VPA
+# recommendation (steady-state target, observed live on
+# applications-production 2026-07-28), and limits are set 2-2.5x request
+# instead of matching it 1:1. request == limit gives the VPA zero burst
+# headroom to work with: make_vpa() below scales the limit proportionally
+# to whatever ratio is declared here (controlledValues="RequestsAndLimits"),
+# so a 1:1 declaration means every VPA resize just moves the same
+# zero-headroom window to a new number instead of fixing it. The embeddings
+# worker was OOMKilling in production under this exact pattern -- VPA target
+# memory (~991Mi) was well within bounds, but request==limit meant any
+# transient spike above that immediately OOMed before the VPA's rolling
+# window had reason to react.
 celery_default_resource_requests = _resource_config(
-    "celery_default_resource_requests", {"cpu": "200m", "memory": "2400Mi"}
+    "celery_default_resource_requests", {"cpu": "600m", "memory": "1280Mi"}
 )
 celery_default_resource_limits = _resource_config(
-    "celery_default_resource_limits", {"memory": "2400Mi"}
+    "celery_default_resource_limits", {"memory": "2560Mi"}
 )
 celery_edx_content_resource_requests = _resource_config(
-    "celery_edx_content_resource_requests", {"cpu": "200m", "memory": "2400Mi"}
+    "celery_edx_content_resource_requests", {"cpu": "400m", "memory": "1536Mi"}
 )
 celery_edx_content_resource_limits = _resource_config(
-    "celery_edx_content_resource_limits", {"memory": "2400Mi"}
+    "celery_edx_content_resource_limits", {"memory": "3072Mi"}
 )
+# CPU request set to 1000m (not the 1311m uncapped VPA target) to match the
+# raised VPA max_allowed below -- see celery_embeddings_vpa_bounds.
 celery_embeddings_resource_requests = _resource_config(
-    "celery_embeddings_resource_requests", {"cpu": "200m", "memory": "2400Mi"}
+    "celery_embeddings_resource_requests", {"cpu": "1000m", "memory": "1024Mi"}
 )
 celery_embeddings_resource_limits = _resource_config(
-    "celery_embeddings_resource_limits", {"memory": "2400Mi"}
+    "celery_embeddings_resource_limits", {"memory": "2560Mi"}
 )
 celery_beat_resource_requests = _resource_config(
-    "celery_beat_resource_requests", {"cpu": "100m", "memory": "2048Mi"}
+    "celery_beat_resource_requests", {"cpu": "100m", "memory": "768Mi"}
 )
 celery_beat_resource_limits = _resource_config(
-    "celery_beat_resource_limits", {"memory": "2048Mi"}
+    "celery_beat_resource_limits", {"memory": "1536Mi"}
 )
 
 # Configure and deploy the mitlearn application using OLApplicationK8s
@@ -1748,7 +1763,21 @@ _worker_vpa_bounds = {
     "min_allowed": {"cpu": "25m", "memory": "128Mi"},
     "max_allowed": {"cpu": "1000m", "memory": "3Gi"},
 }
+# The embeddings worker runs ML inference (embedding generation), which is
+# more CPU-intensive than the other celery queues' typically I/O-bound tasks.
+# Its uncapped VPA CPU target (1311m, observed on applications-production
+# 2026-07-28) already exceeds the shared 1000m ceiling above, so it gets its
+# own bounds instead of sharing _worker_vpa_bounds with the lighter queues.
+_embeddings_worker_vpa_bounds = {
+    "min_allowed": {"cpu": "25m", "memory": "128Mi"},
+    "max_allowed": {"cpu": "2000m", "memory": "3Gi"},
+}
 for _celery_name in mitlearn_k8s_app.celery_deployment_names:
+    _vpa_bounds = (
+        _embeddings_worker_vpa_bounds
+        if _celery_name.endswith("-embeddings-celery-worker")
+        else _worker_vpa_bounds
+    )
     make_vpa(
         name=f"{_celery_name}-vpa",
         namespace=learn_namespace,
@@ -1756,7 +1785,7 @@ for _celery_name in mitlearn_k8s_app.celery_deployment_names:
         target_name=_celery_name,
         controlled_resources=["cpu", "memory"],
         container_name="celery-worker",
-        **_worker_vpa_bounds,
+        **_vpa_bounds,
         opts=ResourceOptions(depends_on=[mitlearn_k8s_app]),
     )
 if mitlearn_k8s_app.beat_deployment_name:


### PR DESCRIPTION
### What are the relevant tickets?
N/A — live incident follow-up, same investigation thread as #5145/#5146/#5147/#5149

### Description (What does it do?)
The `mitlearn-embeddings-celery-worker` was actively OOMKilling in production (confirmed live on `applications-production`: `exitCode: 137, reason: "OOMKilled"`, 3 restarts in 21 minutes on the pod I checked).

**Root cause**: every celery worker in this app (`default`/`edx_content`/`embeddings`/`beat`) declares `request == limit` for memory (all default to `2400Mi`/`2400Mi`, beat to `2048Mi`/`2048Mi`). There's already a VPA on each worker (`make_vpa(..., controlled_resources=["cpu","memory"])`), but `controlledValues="RequestsAndLimits"` scales the limit *proportionally to whatever ratio was declared* — so a 1:1 declaration means every VPA resize just moves the same zero-headroom window to a new number instead of fixing it. Confirmed the embeddings worker's VPA had already resized it to `request == limit == ~991Mi` — its own target recommendation (well within its 3Gi ceiling) wasn't wrong, but with zero headroom, any transient spike above that immediately OOMs before the VPA's rolling window has reason to react.

**Changes** (`src/ol_infrastructure/applications/mit_learn/__main__.py`):
1. Right-sized each worker's `resource_requests` to its own VPA's observed steady-state target (read live from `applications-production`, 2026-07-28), and set `resource_limits` to 2-2.5x request instead of 1:1:
   | Worker | Before (req/limit) | After (req → limit) |
   |---|---|---|
   | default | 200m/2400Mi → 2400Mi | 600m/1280Mi → 2560Mi |
   | edx_content | 200m/2400Mi → 2400Mi | 400m/1536Mi → 3072Mi |
   | embeddings | 200m/2400Mi → 2400Mi | 1000m/1024Mi → 2560Mi |
   | beat | 100m/2048Mi → 2048Mi | 100m/768Mi → 1536Mi |
2. Gave the embeddings worker its own VPA bounds instead of sharing `_worker_vpa_bounds` with the other three: its uncapped VPA CPU target (`1311m`, also read live) already exceeds the shared `max_allowed.cpu: 1000m` ceiling — embedding generation/inference is more CPU-intensive than the other queues' typically I/O-bound tasks. Bumped `max_allowed.cpu` to `2000m` for embeddings only; the other three aren't hitting any ceiling (CPU targets 587m/350m/25m respectively) and keep the original shared bounds.

### How can this be tested?
`pulumi preview --diff` against the `Production` stack shows exactly the intended changes on all four Deployments and the embeddings VPA, no unexpected replacements:
```
~ kubernetes:apps/v1:Deployment mitlearn-default-celery-worker: requests cpu 200m->600m, memory 2400Mi->1280Mi; limits memory 2400Mi->2560Mi
~ kubernetes:apps/v1:Deployment mitlearn-celery-beat: requests memory 2Gi->768Mi; limits memory 2Gi->1536Mi
~ kubernetes:apps/v1:Deployment mitlearn-edx-content-celery-worker: requests cpu 200m->400m, memory 2400Mi->1536Mi; limits memory 2400Mi->3Gi
~ kubernetes:apps/v1:Deployment mitlearn-embeddings-celery-worker: requests cpu 200m->1, memory 2400Mi->1Gi; limits memory 2400Mi->2560Mi
~ kubernetes:autoscaling.k8s.io/v1:VerticalPodAutoscaler mitlearn-embeddings-celery-worker-vpa: maxAllowed.cpu 1000m->2000m
```
(A few unrelated resources also show in the full diff — a pending Fastly `xff=leave`/`ServiceVcl` update from #5146 and some orphaned IAM cleanup from #5148 — both pre-existing drift from already-merged PRs not yet rolled out to this stack, untouched by this change.)

`pre-commit run` (ruff format/check, mypy, etc.) passes.

### Additional Context
Request values are sized from each worker's own VPA-observed target rather than guesses, so this should not itself cause new OOM risk on rollout — if anything the new declared requests (e.g. embeddings' `1Gi`) are lower than the previous `2400Mi`, matching what's actually been measured rather than an untested original guess. The VPA remains free to move both request and limit further within the new min/max bounds as real demand changes.