### PR TITLE
fix(concourse): stop worker's build-time-baked identity from shipping in AMI

### DIFF
--- a/src/bilder/images/concourse/deploy.py
+++ b/src/bilder/images/concourse/deploy.py
@@ -524,6 +524,30 @@ if host.get_fact(HasSystemd):
                 enabled=True,
                 daemon_reload=worker_services_changed,
             )
+        # register_concourse_service above started concourse.service, which
+        # pulled in concourse-worker-preflight.service as a hard dependency
+        # (Requires=/After=) and ran it for real -- on *this* Packer builder
+        # instance. That run wrote /etc/default/concourse-name using the
+        # builder's own instance-id, and the write is intentionally
+        # idempotent (never overwritten once present). Left in place, every
+        # real worker booted from this AMI would inherit that same stale
+        # identity file, skip writing its own, and register with the TSA
+        # under the builder's identity -- colliding with every other worker
+        # from this image. Stop the service and remove the file so the AMI
+        # ships clean; a real instance's first boot starts concourse.service
+        # fresh (still enabled via WantedBy=multi-user.target) and preflight
+        # pins that instance's own identity.
+        files.file(
+            name="Remove build-time-baked worker identity file",
+            path="/etc/default/concourse-name",
+            present=False,
+        )
+        systemd.service(
+            name="Stop concourse.service after build-time configuration",
+            service="concourse",
+            running=False,
+            enabled=True,
+        )
     service_configuration_watches(
         service_name="concourse",
         watched_files=watched_concourse_files,


### PR DESCRIPTION
### What are the relevant tickets?
N/A — diagnosed live from a production incident (zero healthy Concourse workers registered in `odl-prod`).

### Description (What does it do?)
Production Concourse had zero healthy workers connected. `fly -t odl-prod workers` showed only one worker, in `retiring` state, despite every worker ASG/ALB reporting healthy, running instances. Root cause traced to https://github.com/mitodl/ol-infrastructure/commit/3981afa7d195eff1b959c9fc550d28ca5b97046b (#5151, merged 2026-07-28):

That change moved `CONCOURSE_NAME` identity pinning into `concourse-worker-preflight.service`, wired as a hard `Requires=`/`After=` dependency of `concourse.service` (`src/bilder/components/concourse/templates/concourse.service.j2`), and made the write idempotent — it skips writing if `/etc/default/concourse-name` already has content.

The problem: `concourse.service` is started unconditionally during the Packer/pyinfra AMI build itself, via `register_concourse_service` → `systemd.service(service="concourse", running=True, ...)` in `src/bilder/images/concourse/deploy.py`. Starting the service on the *build* instance pulls in `concourse-worker-preflight.service` as a hard dependency and runs it for real — writing the **Packer builder's own EC2 instance-id** into `/etc/default/concourse-name`. That file had no cleanup step before the AMI was snapshotted, so it shipped baked into the image.

Every production worker later launched from that AMI booted with the identity file already populated with the builder's instance-id, so the idempotency guard skipped writing its own identity. Every worker across all three pools (generic/infra/ocw) therefore registered with the TSA under the *identical* `CONCOURSE_NAME`, colliding with each other continuously and never settling into a stable registration — matching the live `fly workers` output.

This mirrors a trap the codebase already guards against elsewhere: `register_services(hashicorp_products, start_services_immediately=False)` (Vault/Consul) and codejail's `docker-compose` service (`running=False, enabled=True`) both deliberately avoid leaving services running across an AMI snapshot for exactly this class of bug. `register_concourse_service` didn't follow that pattern, and PR #5151 is what turned the pre-existing gap from harmless into fleet-breaking by adding a stateful write behind the newly-added dependency.

**Fix:** after the worker build path configures and enables `concourse.service`, explicitly stop it and delete the build-time-baked `/etc/default/concourse-name` before Packer snapshots the AMI. The unit stays `enabled=True`, so a real instance's first boot starts `concourse.service` fresh via `WantedBy=multi-user.target`, and preflight pins that instance's own identity as originally intended.

### How can this be tested?
- `uv run pre-commit run --files src/bilder/images/concourse/deploy.py` and `mypy` pass.
- Next worker AMI build/rollout: confirm via `fly -t odl-prod workers` that newly launched instances register under distinct instance-id-based names (not a shared name), and that the pool returns to a healthy worker count matching the ASG desired capacities.
- The existing stalled-worker reaper (`concourse-worker-reaper`) should clean up any leftover colliding registrations from the bad AMI generation once real per-instance identities land.

### Additional Context
This is a production-incident fix. Once merged, the worker AMI needs to be rebuilt and rolled out to `odl-prod` (and CI/QA, which are on the same code path) before workers will register correctly — merging alone does not fix the currently-running fleet.