### PR TITLE
Add webhook signing secret to all mitxonline envs

### DIFF
--- a/src/bridge/secrets/mitxonline/secrets.ci.yaml
+++ b/src/bridge/secrets/mitxonline/secrets.ci.yaml
@@ -50,23 +50,21 @@ fastly:
   api_key: ENC[AES256_GCM,data:n2yl5aNErmtpjrWyFXFpcSxkNnkOt1GyJkdCkgXpK3M=,iv:Earg7Avxtj0BqzFFMMxWrJWy2dvVo0Ju+pdutUZP9TY=,tag:iMLPcaAk7GsaWiM1kLTiUA==,type:str]
   service_id: ENC[AES256_GCM,data:87XP0AW7lWO7gl7u7MlwQHrCMLsQwg==,iv:J+MBi2PlPZXmHeGqe/0rsDjrvW9dh6VO2keKA7XCnrE=,tag:qXmFTuvpnmT/BoFxC2DzqA==,type:str]
   mit_learn_service_id: ENC[AES256_GCM,data:2vRciGsOGLkj95DRr8JyrcCL6w4yDw==,iv:f5r0hC9DW5ipbW0JNShZDnh7V1Cz7+3lkc+Nz+zhiRU=,tag:Xj7ZDzdaBvQ16K3zhI909A==,type:str]
+mailgun:
+  webhook-signing-secret: ENC[AES256_GCM,data:XU6bf0js8ubQpH4yj72FjdAvHYUvzZzz1OS+LKtzIdQ=,iv:EAmbMPpZhLHRn9bGVvED8iTXokjLnoPyDChgaIW0nsk=,tag:NcPdQbup1LnZKGeC19VZ3w==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-ci
     created_at: "2025-09-29T20:51:01Z"
     enc: AQICAHi3MZ/Pjy2dahB1Qm+zKkKDPV1b9MYPGp7k649HPjmOHAF2zZLq2xGkUy9ABZ9y/fvDAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMD/b7t9+bezAonH8mAgEQgDtkQ2Q/N74r7cNm0gsQiFAqHcPn+kcH9LSWZkakBix81IEJ56PuSc/QQPYfNFAWpDJFVxo0aZXYKrzgSQ==
     aws_profile: ""
-  gcp_kms: []
-  azure_kv: []
   hc_vault:
   - vault_address: https://vault-ci.odl.mit.edu
     engine_path: infrastructure
     key_name: sops
     created_at: "2025-09-29T20:51:01Z"
     enc: vault:v1:RRmHUxUh3yhdXY+w0oVO573VCHyMru8LLbCgo6sJ+pmJdBFJ0GAJCN1tcrIbazSwN+N1AV38+E4dOQWr
-  age: []
-  lastmodified: "2026-07-29T14:30:10Z"
-  mac: ENC[AES256_GCM,data:oVG2xMRiPUI8JGXVZjme6o3z6c/0RO/ivKlXMrCdWs8b9hvCsw1uNpUxKoIG6Y8PwfUuN7ZYhFgyVlQAHANjGtnk/dfVdq4AtgqXh7oQps2wcUgQodQ4OeSh6zDxNl72lkb4AEZKznE0lXCZEOC+2oKJH14xiJLZ7ZFFZODxQRU=,iv:ZrMtVaZsj1vq+kCiLMydnRQ7K2ozmAa9PkY8tvc1jgI=,tag:S7+5krUrhxmJAlts3n3fSQ==,type:str]
-  pgp: []
+  lastmodified: "2026-07-29T15:17:59Z"
+  mac: ENC[AES256_GCM,data:+0KHrg5B+sBIVJqLlhsK+e3M0VpvEtRW0q9R1VUPPl4pDY+l2Grxu1BMj8zGmKm4+JWU9dZtMImAn2x2HD34z0RRn+XhXqI0nMABYkE88l256aWHotvfKTbcLBrsxxPIBhxRD0gkpxKlGzLGH9cOrnjKpEd5GGUYv9uf4ajwFTM=,iv:SeLNrFYgX/VgdMaqLUWuB6SAmLG/sMJf0jsy1jN6Pjk=,tag:16FVs1v3fpz1nRbmjMldLQ==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.12.2

--- a/src/bridge/secrets/mitxonline/secrets.production.yaml
+++ b/src/bridge/secrets/mitxonline/secrets.production.yaml
@@ -50,23 +50,21 @@ fastly:
   api_key: ENC[AES256_GCM,data:Ay95rQcEvyrsZrk3TvigRBbyH5jDe/9exSLgaXFy00U=,iv:iNmlgBnn9NU1OcgNN/MVrwwdhztse6zLN6XcSVMoR1Q=,tag:i3zE57fWW7B3UQBGdLDiOg==,type:str]
   service_id: ENC[AES256_GCM,data:2qDhAoehE8/pcZgpgXqJWttKJLTYhQ==,iv:henjJ1SY7aPDWWpc+Ih7CdE6R8Jlqz8qppEm157dPI0=,tag:rtRWpHkz05do9Kuckpxgmw==,type:str]
   mit_learn_service_id: ENC[AES256_GCM,data:Arj2Tzjv4virenb3uUulK/d79I9zbw==,iv:pHbuC1m3vLQVepZedVEZEv/PiCHK89ICueeNED1Pumc=,tag:HCQjLLMU4FPMNVTWhJ5/dg==,type:str]
+mailgun:
+  webhook-signing-secret: ENC[AES256_GCM,data:LZ6pVd9/fv5aOnWHN58DbtuTcAKdwdBRMZMeRXJC8SE=,iv:S7xnbG0iSbQsUOIFXoXZwE5IZGuqk5DEXI+dr3BK5uU=,tag:JEGSX9gvZg9eCtak+gOCQw==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
     created_at: "2025-09-29T20:20:52Z"
     enc: AQICAHi3FG4qowC3UzOLWOAA4Y9/RTwqKjovG3wyVVYDxkR+zAFoOLo90B9MZ0Q93d2jeOfQAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMhRRzldXn3mdtQbQpAgEQgDvK3+uFZz62P+J3mthF8tuEzirXsN/AEJvQ2+VCXia6FKzhkLGxKAc2v6kczvByNCHc9c/CMkfTHQN0TQ==
     aws_profile: ""
-  gcp_kms: []
-  azure_kv: []
   hc_vault:
   - vault_address: https://vault-production.odl.mit.edu
     engine_path: infrastructure
     key_name: sops
     created_at: "2025-09-29T20:20:52Z"
     enc: vault:v1:4LIMntJB9FpCBpDize1iMjVDLzeCg+DcMV+K79sLtxh0SzFzqXzsTJ/OESMMPobIlFl8rwqF71dC9/ee
-  age: []
-  lastmodified: "2026-07-29T14:31:04Z"
-  mac: ENC[AES256_GCM,data:JMWQ4opTwWgDseq4lP8g0wiYy/F0i9XdrTe01B23VoPru2kK4CrEE1PP6h9JQs1k4IaJyqffqZcU9CcWa6JJs7VIOVg9MVFOAX869xqDfI4nHpCna/bbNJPeR97cmKjofniW2oyZot24FQexePZGy9bgJ3qG/z9zirpBDQDLtag=,iv:BnZgbvzO1EPh8I7sxy5jfc9gvQnXqYSaGXSLgqlp06M=,tag:BUMlwUCjTUCjX4U1VNQPQQ==,type:str]
-  pgp: []
+  lastmodified: "2026-07-29T15:17:44Z"
+  mac: ENC[AES256_GCM,data:eBZWbGJi0trHZqX66gOGOW7IV5zCuZou5W8Zhx4sGUuls2WLeO9xj/w6h/xR8EODgtgUpgiJm/8PYXdyRIq8sHAj2DoSuKfGCPc+41kp2zjQP7ZIk8tHcQekNAJG2ZQs6vAznFzK8Fq5P40sRU/Jdvo/bkYhkxgsN8vMn5Uvx0o=,iv:i12tEYvFc1xm8sF379eniWcJmNqq7GHn8hs1V6PPN24=,tag:Y2GORTmE7XncPVvuOKdHGQ==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.13.2

--- a/src/bridge/secrets/mitxonline/secrets.qa.yaml
+++ b/src/bridge/secrets/mitxonline/secrets.qa.yaml
@@ -54,23 +54,21 @@ fastly:
   api_key: ENC[AES256_GCM,data:Zd55pRLUQe3K5NqeZ/1UMLKjYF+y7A5jtuFadstXXvU=,iv:DC4MUlWkvgGPT/Ea1aZ0DAiV5mz6T/vaZQBOOFfSbj0=,tag:LS3FkGPU3XUICB55eZdYrQ==,type:str]
   service_id: ENC[AES256_GCM,data:GmYnEib4llSGQc+2pASDN1m7Wx4DIQ==,iv:fgOPmQHbGIk7G23RXJWQ1mclIDOP/dDfwZSIpQj16/Q=,tag:0/hLJRRVfZ3pVML6bnD1lQ==,type:str]
   mit_learn_service_id: ENC[AES256_GCM,data:Xq9i4XmHdC+vdJIOA9H8CJcnr6mwHg==,iv:TJtGApogKsF2nWptDNa9k+rK/UiwpWt8J/8RFNTxREU=,tag:Gi00lPQkgVQ7H9AyXh62iQ==,type:str]
+mailgun:
+  webhook-signing-secret: ENC[AES256_GCM,data:AgmG4an3yHZzZy8wDTAoZPi+NKDzEyVkuZMTjULcS04=,iv:WYY3RgOGkYJb022f0EJSCm7SzTbTYrbQgUN/qFr82Rk=,tag:rjCzUMPEdZjWsi0DJmHzgQ==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-qa
     created_at: "2026-02-02T17:11:45Z"
     enc: AQICAHjZAY5LtmRWGljev0oiDGn0jR5cRwD4IVXCn50TW5i0qQHqmN8pFGX+2qcY5XXiY0kRAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMyhTtxzfD/gU5HUZNAgEQgDtvzRLa7AL13nl12d+v8Oc1Oenj4qF25AbX3SwGtVWH4LA75IUBGVA4H0DqqU4KBFFLe33xO7EIKLhOJQ==
     aws_profile: ""
-  gcp_kms: []
-  azure_kv: []
   hc_vault:
   - vault_address: https://vault-qa.odl.mit.edu
     engine_path: infrastructure
     key_name: sops
     created_at: "2026-02-02T17:11:45Z"
     enc: vault:v1:0y+YFRqZIXMxr0jX7vzFtCRy4cCDz261a3BOcLKq7gtYmbUJNdJV7PHabO7/1tJMhEYshQpIxGXEqiNh
-  age: []
-  lastmodified: "2026-07-29T14:30:35Z"
-  mac: ENC[AES256_GCM,data:jikNy1rDISDVqUwy9/Rxmps17v/Tas+cizFjzcmGs8o0Pu0PsAEiv4Z9b2PPtXIZKlW5ZDKr3o5WntuQT1iAGKVZ7G0GkjwL9oqa5LDgZkg90fj+GCJACRzB4+FnYM7gc+C1Qe+AlMJImvJQkG/WRIw51sHlnhcNkl5YcBRTe/I=,iv:SjwuwCm7QkZnSpHeE437Nm+FJYfx5HKlTtCzcFvYdgA=,tag:rS9rGTM4BZecIylRqhfljw==,type:str]
-  pgp: []
+  lastmodified: "2026-07-29T15:17:52Z"
+  mac: ENC[AES256_GCM,data:bkHkuG9fAUnaw+2peJ8Qmo9lWexC9Cl84nOYzTTE9OyEpioFP+Q2O/j5ISjXaunKyZGoC2pfLxFxPP6ojzYii4sNrS0rZLvKui8AnS3aZsHvrxmeLvX8dHyz9NFr+O0fOxuGk8GA2k94ghjGHdpUcJ4WQL/6oHXQC2vwgFY88sI=,iv:84tZJREV/bcascz627x9WRw6kX3/ggXASlV6ELKQn1E=,tag:usLXxzbRbFjODIyb5qqedg==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.13.0

--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.CI.yaml
@@ -26,6 +26,7 @@ config:
     LOGOUT_REDIRECT_URL: "https://courses.ci.learn.mit.edu/logout"
     MAILGUN_FROM_EMAIL: "MITx Online <no-reply@mitxonline-ci-mail.mitxonline.mit.edu>"
     MAILGUN_SENDER_DOMAIN: "mitxonline-ci-mail.mitxonline.mit.edu"
+    MAILGUN_WEBHOOK_VALIDATE_SIGNATURE: "true"
     MITOL_APIGATEWAY_DISABLE_MIDDLEWARE: "false"
     MITOL_GOOGLE_SHEETS_PROCESSOR_APP_NAME: "MITx Online (ci)"
     MITOL_GOOGLE_SHEETS_REFUNDS_FIRST_ROW: "4"

--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.Production.yaml
@@ -35,6 +35,7 @@ config:
     LOGOUT_REDIRECT_URL: "https://courses.learn.mit.edu/logout"
     MAILGUN_FROM_EMAIL: "MITx Online <no-reply@mail.mitxonline.mit.edu>"
     MAILGUN_SENDER_DOMAIN: "mail.mitxonline.mit.edu"
+    MAILGUN_WEBHOOK_VALIDATE_SIGNATURE: "true"
     MITOL_APIGATEWAY_DISABLE_MIDDLEWARE: "false"
     MITOL_GOOGLE_SHEETS_DEFERRALS_REQUEST_WORKSHEET_ID: "268521316"
     MITOL_GOOGLE_SHEETS_PROCESSOR_APP_NAME: "MITx Online (production)"

--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.QA.yaml
@@ -31,6 +31,7 @@ config:
     LOGOUT_REDIRECT_URL: "https://courses.rc.learn.mit.edu/logout"
     MAILGUN_FROM_EMAIL: "MITx Online <no-reply@mitxonline-rc-mail.mitxonline.mit.edu>"
     MAILGUN_SENDER_DOMAIN: "mitxonline-rc-mail.mitxonline.mit.edu"
+    MAILGUN_WEBHOOK_VALIDATE_SIGNATURE: "true"
     MITOL_APIGATEWAY_DISABLE_MIDDLEWARE: "false"
     MITOL_GOOGLE_SHEETS_PROCESSOR_APP_NAME: "MITx Online (rc)"
     MITOL_GOOGLE_SHEETS_REFUNDS_FIRST_ROW: "4"

--- a/src/ol_infrastructure/applications/mitxonline/k8s_secrets.py
+++ b/src/ol_infrastructure/applications/mitxonline/k8s_secrets.py
@@ -245,6 +245,7 @@ def create_mitxonline_k8s_secrets(
                 "MITOL_PAYMENT_GATEWAY_CYBERSOURCE_PROFILE_ID": '{{ index .Secrets "cybersource" "profile-id" }}',
                 "MITOL_PAYMENT_GATEWAY_CYBERSOURCE_SECURITY_KEY": '{{ index .Secrets "cybersource" "security-key" }}',
                 "MITX_ONLINE_REFINE_OIDC_CONFIG_CLIENT_ID": '{{ index .Secrets "refine-oidc" "client-id" }}',
+                "MAILGUN_WEBHOOK_SIGNING_SECRET": '{{ index .Secrets "mailgun" "webhook-signing-secret" }}',
                 "OIDC_RSA_PRIVATE_KEY": '{{ index .Secrets "refine-oidc" "rsa-private-key" }}',
                 "OPENEDX_API_CLIENT_ID": '{{ index .Secrets "open-edx-api-client" "client-id" }}',
                 "OPENEDX_API_CLIENT_SECRET": '{{ index .Secrets "open-edx-api-client" "client-secret" }}',


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12114

### Description (What does it do?)
Adds the signing secret that'll be used for Mailgun webhook validation (https://github.com/mitodl/mitxonline/pull/3775). Note that we have a single mailgun account which is used for all three environments, split up by sending domain, so the secret is the same for each at the moment.