### PR TITLE
feat(mitxonline): add MIT_LEARN_FASTLY_SERVICE_ID to k8s secrets

### DIFF
--- a/src/bridge/secrets/mitxonline/secrets.ci.yaml
+++ b/src/bridge/secrets/mitxonline/secrets.ci.yaml
@@ -49,6 +49,7 @@ refine-oidc:
 fastly:
   api_key: ENC[AES256_GCM,data:n2yl5aNErmtpjrWyFXFpcSxkNnkOt1GyJkdCkgXpK3M=,iv:Earg7Avxtj0BqzFFMMxWrJWy2dvVo0Ju+pdutUZP9TY=,tag:iMLPcaAk7GsaWiM1kLTiUA==,type:str]
   service_id: ENC[AES256_GCM,data:87XP0AW7lWO7gl7u7MlwQHrCMLsQwg==,iv:J+MBi2PlPZXmHeGqe/0rsDjrvW9dh6VO2keKA7XCnrE=,tag:qXmFTuvpnmT/BoFxC2DzqA==,type:str]
+  mit_learn_service_id: ENC[AES256_GCM,data:2vRciGsOGLkj95DRr8JyrcCL6w4yDw==,iv:f5r0hC9DW5ipbW0JNShZDnh7V1Cz7+3lkc+Nz+zhiRU=,tag:Xj7ZDzdaBvQ16K3zhI909A==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-ci
@@ -64,8 +65,8 @@ sops:
     created_at: "2025-09-29T20:51:01Z"
     enc: vault:v1:RRmHUxUh3yhdXY+w0oVO573VCHyMru8LLbCgo6sJ+pmJdBFJ0GAJCN1tcrIbazSwN+N1AV38+E4dOQWr
   age: []
-  lastmodified: "2026-06-05T21:34:35Z"
-  mac: ENC[AES256_GCM,data:rRraOydqaONYRh4FhsHu4e04UpvK3/qY2xinKnyEmgBIqgCfxVUThePtwGRAH3/VCKrJ3NzlDlL4qq8Y8TfFtgaKQoo1t1k5WXzWid6l2aCE2373RuzaR8zuZvmM/eRarQM88AXdub2nsObXCNSaUzwLx8C9sQzaPYcWVAO0Vfo=,iv:3i0g9n88m7y1V2xEMSEEQyPPH1GfNHdE1SHG/0McVXw=,tag:EEKYFqCCG5n1rITtv7BHbw==,type:str]
+  lastmodified: "2026-07-29T14:30:10Z"
+  mac: ENC[AES256_GCM,data:oVG2xMRiPUI8JGXVZjme6o3z6c/0RO/ivKlXMrCdWs8b9hvCsw1uNpUxKoIG6Y8PwfUuN7ZYhFgyVlQAHANjGtnk/dfVdq4AtgqXh7oQps2wcUgQodQ4OeSh6zDxNl72lkb4AEZKznE0lXCZEOC+2oKJH14xiJLZ7ZFFZODxQRU=,iv:ZrMtVaZsj1vq+kCiLMydnRQ7K2ozmAa9PkY8tvc1jgI=,tag:S7+5krUrhxmJAlts3n3fSQ==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.12.2

--- a/src/bridge/secrets/mitxonline/secrets.production.yaml
+++ b/src/bridge/secrets/mitxonline/secrets.production.yaml
@@ -49,19 +49,24 @@ refine-oidc:
 fastly:
   api_key: ENC[AES256_GCM,data:Ay95rQcEvyrsZrk3TvigRBbyH5jDe/9exSLgaXFy00U=,iv:iNmlgBnn9NU1OcgNN/MVrwwdhztse6zLN6XcSVMoR1Q=,tag:i3zE57fWW7B3UQBGdLDiOg==,type:str]
   service_id: ENC[AES256_GCM,data:2qDhAoehE8/pcZgpgXqJWttKJLTYhQ==,iv:henjJ1SY7aPDWWpc+Ih7CdE6R8Jlqz8qppEm157dPI0=,tag:rtRWpHkz05do9Kuckpxgmw==,type:str]
+  mit_learn_service_id: ENC[AES256_GCM,data:Arj2Tzjv4virenb3uUulK/d79I9zbw==,iv:pHbuC1m3vLQVepZedVEZEv/PiCHK89ICueeNED1Pumc=,tag:HCQjLLMU4FPMNVTWhJ5/dg==,type:str]
 sops:
-  hc_vault:
-  - created_at: "2025-09-29T20:20:52Z"
-    enc: vault:v1:4LIMntJB9FpCBpDize1iMjVDLzeCg+DcMV+K79sLtxh0SzFzqXzsTJ/OESMMPobIlFl8rwqF71dC9/ee
-    engine_path: infrastructure
-    key_name: sops
-    vault_address: https://vault-production.odl.mit.edu
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
-    aws_profile: ""
     created_at: "2025-09-29T20:20:52Z"
     enc: AQICAHi3FG4qowC3UzOLWOAA4Y9/RTwqKjovG3wyVVYDxkR+zAFoOLo90B9MZ0Q93d2jeOfQAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMhRRzldXn3mdtQbQpAgEQgDvK3+uFZz62P+J3mthF8tuEzirXsN/AEJvQ2+VCXia6FKzhkLGxKAc2v6kczvByNCHc9c/CMkfTHQN0TQ==
-  lastmodified: "2026-07-10T18:54:15Z"
-  mac: ENC[AES256_GCM,data:9x/E+hDeDugdrh+Xd2jTocEYr56quMAnuN9+pH7+REYE61JqAiXwD5Lo9nS0jadYKvOSK8+8u1GWKHlszb5lsIa9LFG5zUs4L/g3erfwoP1YGE3f7E1BAtU4AlflNZrobgZIR1XHFMajjZinFgx3dMHhfnmrmXi69bBYMm3mdog=,iv:ECIoZ/8ifOGUBmKuVw9YN4JSFBVOeUtR0xEQbrkELXM=,tag:Fi+gBr/3OsXpXr0fBnDQeQ==,type:str]
+    aws_profile: ""
+  gcp_kms: []
+  azure_kv: []
+  hc_vault:
+  - vault_address: https://vault-production.odl.mit.edu
+    engine_path: infrastructure
+    key_name: sops
+    created_at: "2025-09-29T20:20:52Z"
+    enc: vault:v1:4LIMntJB9FpCBpDize1iMjVDLzeCg+DcMV+K79sLtxh0SzFzqXzsTJ/OESMMPobIlFl8rwqF71dC9/ee
+  age: []
+  lastmodified: "2026-07-29T14:31:04Z"
+  mac: ENC[AES256_GCM,data:JMWQ4opTwWgDseq4lP8g0wiYy/F0i9XdrTe01B23VoPru2kK4CrEE1PP6h9JQs1k4IaJyqffqZcU9CcWa6JJs7VIOVg9MVFOAX869xqDfI4nHpCna/bbNJPeR97cmKjofniW2oyZot24FQexePZGy9bgJ3qG/z9zirpBDQDLtag=,iv:BnZgbvzO1EPh8I7sxy5jfc9gvQnXqYSaGXSLgqlp06M=,tag:BUMlwUCjTUCjX4U1VNQPQQ==,type:str]
+  pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.13.2

--- a/src/bridge/secrets/mitxonline/secrets.qa.yaml
+++ b/src/bridge/secrets/mitxonline/secrets.qa.yaml
@@ -53,19 +53,24 @@ webhook_access_token:
 fastly:
   api_key: ENC[AES256_GCM,data:Zd55pRLUQe3K5NqeZ/1UMLKjYF+y7A5jtuFadstXXvU=,iv:DC4MUlWkvgGPT/Ea1aZ0DAiV5mz6T/vaZQBOOFfSbj0=,tag:LS3FkGPU3XUICB55eZdYrQ==,type:str]
   service_id: ENC[AES256_GCM,data:GmYnEib4llSGQc+2pASDN1m7Wx4DIQ==,iv:fgOPmQHbGIk7G23RXJWQ1mclIDOP/dDfwZSIpQj16/Q=,tag:0/hLJRRVfZ3pVML6bnD1lQ==,type:str]
+  mit_learn_service_id: ENC[AES256_GCM,data:Xq9i4XmHdC+vdJIOA9H8CJcnr6mwHg==,iv:TJtGApogKsF2nWptDNa9k+rK/UiwpWt8J/8RFNTxREU=,tag:Gi00lPQkgVQ7H9AyXh62iQ==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-qa
     created_at: "2026-02-02T17:11:45Z"
     enc: AQICAHjZAY5LtmRWGljev0oiDGn0jR5cRwD4IVXCn50TW5i0qQHqmN8pFGX+2qcY5XXiY0kRAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMyhTtxzfD/gU5HUZNAgEQgDtvzRLa7AL13nl12d+v8Oc1Oenj4qF25AbX3SwGtVWH4LA75IUBGVA4H0DqqU4KBFFLe33xO7EIKLhOJQ==
     aws_profile: ""
+  gcp_kms: []
+  azure_kv: []
   hc_vault:
   - vault_address: https://vault-qa.odl.mit.edu
     engine_path: infrastructure
     key_name: sops
     created_at: "2026-02-02T17:11:45Z"
     enc: vault:v1:0y+YFRqZIXMxr0jX7vzFtCRy4cCDz261a3BOcLKq7gtYmbUJNdJV7PHabO7/1tJMhEYshQpIxGXEqiNh
-  lastmodified: "2026-06-05T21:34:36Z"
-  mac: ENC[AES256_GCM,data:pUbxLpH8aG2GAa0KZL7VQL6FGsDenHL93ItZfGMW1Keb9Lxg57PAUldbalITnudxi/dm2KAo7ILQgjv0l5cpqqhpt2LT5Uc+63ww19M6PjisA7rtwT1Mj17fDizJIymk+05jAT1DWQBMP/SBedrXwUDItt50XIJR0HCAmu9Px/Y=,iv:JL+locjaaiw239qBQFS0lvUix5uslXEpgPkN0DgE2WA=,tag:Xu6LALdMS6u0xUhebM7e/w==,type:str]
+  age: []
+  lastmodified: "2026-07-29T14:30:35Z"
+  mac: ENC[AES256_GCM,data:jikNy1rDISDVqUwy9/Rxmps17v/Tas+cizFjzcmGs8o0Pu0PsAEiv4Z9b2PPtXIZKlW5ZDKr3o5WntuQT1iAGKVZ7G0GkjwL9oqa5LDgZkg90fj+GCJACRzB4+FnYM7gc+C1Qe+AlMJImvJQkG/WRIw51sHlnhcNkl5YcBRTe/I=,iv:SjwuwCm7QkZnSpHeE437Nm+FJYfx5HKlTtCzcFvYdgA=,tag:rS9rGTM4BZecIylRqhfljw==,type:str]
+  pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.13.0

--- a/src/ol_infrastructure/applications/mitxonline/k8s_secrets.py
+++ b/src/ol_infrastructure/applications/mitxonline/k8s_secrets.py
@@ -229,6 +229,7 @@ def create_mitxonline_k8s_secrets(
                 "MITX_ONLINE_FASTLY_API_KEY": '{{ index .Secrets "fastly" "api_key" }}',
                 "MITX_ONLINE_FASTLY_AUTH_TOKEN": '{{ index .Secrets "fastly" "api_key" }}',
                 "MITX_ONLINE_FASTLY_SERVICE_ID": '{{ index .Secrets "fastly" "service_id" }}',
+                "MIT_LEARN_FASTLY_SERVICE_ID": '{{ index .Secrets "fastly" "mit_learn_service_id" }}',
                 "HUBSPOT_HOME_PAGE_FORM_GUID": '{{ index .Secrets "hubspot" "formId" }}',
                 "HUBSPOT_PORTAL_ID": '{{ index .Secrets "hubspot" "portalId" }}',
                 "MITOL_GOOGLE_SHEETS_DRIVE_API_PROJECT_ID": '{{ index .Secrets "google-sheets" "drive-api-project-id" }}',


### PR DESCRIPTION
### What are the relevant tickets?
Supports mitodl/mitxonline#3794

### Description (What does it do?)
Supplies the mitxonline deployment with a new `MIT_LEARN_FASTLY_SERVICE_ID` environment variable, per environment.

mitxonline PR mitodl/mitxonline#3794 fixes a Fastly surrogate-key purge that was a no-op. The purge must target **MIT Learn's** Fastly service — MIT Learn is what tags product-page responses with the `mitxonline:*` surrogate keys — but the code had been using **MITxOnline's own** service ID. The app now reads `MIT_LEARN_FASTLY_SERVICE_ID` and passes it explicitly into `queue_fastly_surrogate_key_purge`.

Changes:
- **`src/ol_infrastructure/applications/mitxonline/k8s_secrets.py`**: adds `MIT_LEARN_FASTLY_SERVICE_ID` to the `collected` static-secret templates (rendered by the Vault agent from the `secret-mitxonline` mount, path `collected-static-secrets`), sourcing `fastly.mit_learn_service_id`. It rides the existing `mitxonline-collected-static-secret` K8s Secret, already consumed by the deployment via `envFrom`, so no `__main__.py` change is needed.
- **`src/bridge/secrets/mitxonline/secrets.{ci,qa,production}.yaml`**: adds a new `fastly.mit_learn_service_id` key to each env's SOPS file, alongside the existing `api_key`/`service_id`.

Why copy the values instead of reading them in place: the correct MIT Learn service IDs already exist as `learn_service_id_{ci,qa,production}` under `infrastructure/fastly` in `src/bridge/secrets/concourse/operations.production.yaml`, but those are loaded to `secret-concourse/infrastructure/fastly` **only by the production Concourse stack** — so they live only in the production Vault. mitxonline ci/qa/production each deploy against separate Vaults and read from the `secret-mitxonline` mount, so the value has to live in each env's own mitxonline SOPS file to work per-environment. `operations.production.yaml` is the source of truth the values were copied from.

The existing `MITX_ONLINE_FASTLY_SERVICE_ID` / `fastly.service_id` (MITxOnline's own service) is left untouched. `FASTLY_SERVICE_ID` is intentionally not restored — nothing reads it.

### How can this be tested?
- `pre-commit run --files <changed files>` passes (ruff, mypy, detect-secrets, yaml/sops checks).
- SOPS round-trip: `sops --decrypt src/bridge/secrets/mitxonline/secrets.<env>.yaml | grep -A3 '^fastly:'` shows `mit_learn_service_id` with the correct per-env value for ci/qa/production.
- `pulumi preview` per stack (CI first) from `src/ol_infrastructure/applications/mitxonline`: expect the `mitxonline-collected-static-secret` to add the `MIT_LEARN_FASTLY_SERVICE_ID` template key and the Vault `collected-static-secrets` secret to gain the `mit_learn_service_id` field.
- Post-deploy: `kubectl exec <mitxonline-pod> -n <ns> -- printenv MIT_LEARN_FASTLY_SERVICE_ID` returns MIT Learn's service ID and differs from `MITX_ONLINE_FASTLY_SERVICE_ID`.

### Checklist:
- [ ] Confirm the Fastly API token mitxonline uses has `purge_select` authorization on MIT Learn's Fastly service (called out in mitodl/mitxonline#3794).
- [ ] Deploy per environment so the new Vault key is written and the pods pick up the env var.
