### PR TITLE
fix(local-dev): correct UNSUBSCRIBE_SECRET_KEY typo for mit-learn

### DIFF
--- a/local-dev/apps/mit-learn/secrets.yaml
+++ b/local-dev/apps/mit-learn/secrets.yaml
@@ -36,7 +36,7 @@ stringData:
 
   # ── Django secret key ─────────────────────────────────────────────────────
   SECRET_KEY: "local-dev-secret-key-not-for-production"  # pragma: allowlist secret
-  UNSUBSRIBE_SECRET_KEY: "local-dev-mitxonline-insecure-unsubscribe-secret-key" # pragma: allowlist secret
+  UNSUBSCRIBE_SECRET_KEY: "local-dev-mitxonline-insecure-unsubscribe-secret-key" # pragma: allowlist secret
 
   # ── Misc optional secrets ─────────────────────────────────────────────────
   # Required only if running EDX/YouTube ETL pipelines:


### PR DESCRIPTION
## Summary
- `secrets.yaml` defined `UNSUBSRIBE_SECRET_KEY` (missing the "C"), so Django never saw `UNSUBSCRIBE_SECRET_KEY` and required a personal `app-env.local.yaml` override to boot.
- Fixes the typo so the tracked local-dev default works without an override.

Related: mit-learn added the setting in mitodl/mit-learn#3637.

## Test plan
- [ ] `tilt up` mit-learn locally and confirm it starts without an `UNSUBSCRIBE_SECRET_KEY` override