### PR TITLE
fix(concourse): make the build-time worker-identity cleanup actually run

### DIFF
--- a/src/bilder/images/concourse/deploy.py
+++ b/src/bilder/images/concourse/deploy.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import yaml
 from pyinfra import host
 from pyinfra.api.util import get_template
-from pyinfra.operations import files, systemd
+from pyinfra.operations import files, server, systemd
 
 from bilder.components.alloy.models import AlloyConfig
 from bilder.components.alloy.steps import install_and_configure_alloy
@@ -537,16 +537,23 @@ if host.get_fact(HasSystemd):
         # ships clean; a real instance's first boot starts concourse.service
         # fresh (still enabled via WantedBy=multi-user.target) and preflight
         # pins that instance's own identity.
-        files.file(
-            name="Remove build-time-baked worker identity file",
-            path="/etc/default/concourse-name",
-            present=False,
-        )
-        systemd.service(
-            name="Stop concourse.service after build-time configuration",
-            service="concourse",
-            running=False,
-            enabled=True,
+        #
+        # This must be a raw server.shell, not files.file(present=False) /
+        # systemd.service(running=False): pyinfra compiles this whole script
+        # into an ordered command queue by fact-checking each operation
+        # against the host's state *before any queued command has actually
+        # run* -- register_concourse_service's start was only queued, not
+        # yet applied, when these facts were checked. Both fact-gated ops
+        # therefore saw "file absent" / "service not running" and queued
+        # nothing. server.shell has no such precondition check, so it always
+        # queues its commands, which then run for real at this point in the
+        # execution order (after the start, once it has actually happened).
+        server.shell(
+            name="Stop concourse.service and remove build-time-baked worker identity",
+            commands=[
+                "systemctl stop concourse.service || true",
+                "rm -f /etc/default/concourse-name",
+            ],
         )
     service_configuration_watches(
         service_name="concourse",


### PR DESCRIPTION
### What are the relevant tickets?
N/A — follow-up to https://github.com/mitodl/ol-infrastructure/pull/5156, discovered live during the same production incident (Concourse workers not registering).

### Description (What does it do?)
#5156 fixed the root cause (a build-time-baked worker identity colliding across the fleet) by adding cleanup steps after `register_concourse_service` in `src/bilder/images/concourse/deploy.py`:

```python
files.file(path="/etc/default/concourse-name", present=False)
systemd.service(service="concourse", running=False, enabled=True)
```

That merged and was rolled out to production twice, but both rollouts showed the exact same collision — every worker still registered under the Packer builder's own instance-id, just a different one each build.

Root cause of *this*: pyinfra compiles a deploy script into an ordered command queue by fact-checking each operation against the host's state as it exists **before any of the script's own queued commands have actually applied**. `files.file(present=False)` fact-checks "does the file currently exist" and `systemd.service(running=False)` fact-checks "is the service currently running" — both were evaluated against the pre-deployment state (file absent, service not started), independent of where they're textually positioned relative to `register_concourse_service`'s own (also merely queued, not-yet-applied) start command. Both concluded nothing needed to change and queued zero commands. The identity file was never removed and the service was never stopped, so the AMI kept shipping with the builder's baked-in identity.

Fix: replace both fact-gated operations with a single `server.shell` call. Raw shell operations (already used throughout this codebase, e.g. `src/bilder/components/hashicorp/steps.py:56`) have no precondition check — they always queue their commands, which then execute for real, in their position in the execution order, after the earlier start has actually happened.

### How can this be tested?
- `uv run pre-commit run --files src/bilder/images/concourse/deploy.py` and `mypy` pass.
- Next worker AMI build/rollout: confirm via `fly -t odl-prod workers` that newly launched instances register under distinct instance-id-based names, not a single shared identity, and that the pool reaches a healthy worker count matching ASG desired capacities.

### Additional Context
Live evidence from the incident: after the #5156 rollout, `fly -t odl-prod workers` kept showing a single worker entry whose name was a Packer builder instance-id (confirmed via `aws ec2 describe-instances`, tagged `purpose=concourse-worker`, already terminated) rather than any of the real fleet's instance-ids — i.e. every real worker was still colliding under one baked-in name, unchanged from the pre-#5156 behavior.