### PR TITLE
fix(local-dev): set MITx Online ETL URLs for mit-learn

### DIFF
--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -399,7 +399,7 @@ How it works — plain Kubernetes, visible in each app's `deployment.yaml`: ever
 
 Day-to-day behavior:
 
-- Creating or editing the file mid-session re-applies it — no Tilt restart. Pods roll automatically so new values actually take effect: because Kubernetes does not restart pods on ConfigMap changes, `tiltlib.star` stamps a fingerprint of your overrides onto each Deployment's pod template (the `ol.mit.edu/local-overrides-hash` annotation), which is also the idiomatic production pattern (cf. Helm `checksum/config` annotations).
+- Creating or editing the file mid-session re-applies it — no Tilt restart. Pods roll automatically so new values actually take effect: because Kubernetes does not restart pods on ConfigMap/Secret changes, `tiltlib.star` stamps a fingerprint of every applied ConfigMap's and Secret's data onto each Deployment's pod template (the `ol.mit.edu/config-hash` annotation) — this covers edits to the tracked `app-env.yaml`/`secrets.yaml` too, not just this override file — which is also the idiomatic production pattern (cf. Helm `checksum/config` annotations).
 - Overridden key **names** (never values) are printed in the **Tiltfile resource's log** in the Tilt UI, and your full delta is inspectable in-cluster at any time: `kubectl get cm -n mitxonline mitxonline-env-local -o yaml`
 - Gotchas: the ConfigMap's `metadata.name` must match what `deployment.yaml` references (`<app>-env-local` — copy the example, don't type it), and all `data:` values must be YAML **strings** (quote things like `"True"` and `"8080"`). A typo'd key is applied but ignored by the app. If you *delete* the file mid-session, prefer emptying `data:` instead — the already-applied ConfigMap can linger in-cluster until `tilt down`.
 

--- a/local-dev/apps/mit-learn/configmaps/app-env.yaml
+++ b/local-dev/apps/mit-learn/configmaps/app-env.yaml
@@ -125,7 +125,10 @@ data:
   XPRO_COURSES_API_URL: "https://xpro.mit.edu/api/courses/"
   # MITx Online runs locally in this stack (apps/mitxonline), so — unlike the
   # other catalogs above, which point at production — these target the
-  # in-cluster instance (same host mit-learn-nextjs uses for it).
+  # in-cluster instance directly, matching mit-learn-nextjs's
+  # NEXT_PUBLIC_MITX_ONLINE_LEGACY_BASE_URL (its primary
+  # NEXT_PUBLIC_MITX_ONLINE_BASE_URL instead routes through the API gateway:
+  # https://api.learn.mit.dev/mitxonline).
   MITX_ONLINE_BASE_URL: "https://mitxonline.mit.dev"
   MITX_ONLINE_COURSES_API_URL: "https://mitxonline.mit.dev/api/v2/courses/"
   MITX_ONLINE_PROGRAMS_API_URL: "https://mitxonline.mit.dev/api/v2/programs/"

--- a/local-dev/apps/mit-learn/configmaps/app-env.yaml
+++ b/local-dev/apps/mit-learn/configmaps/app-env.yaml
@@ -123,6 +123,12 @@ data:
   OLL_API_URL: "https://discovery.openlearninglibrary.mit.edu/api/v1/catalogs/1/courses/"
   XPRO_CATALOG_API_URL: "https://xpro.mit.edu/api/programs/"
   XPRO_COURSES_API_URL: "https://xpro.mit.edu/api/courses/"
+  # MITx Online runs locally in this stack (apps/mitxonline), so — unlike the
+  # other catalogs above, which point at production — these target the
+  # in-cluster instance (same host mit-learn-nextjs uses for it).
+  MITX_ONLINE_BASE_URL: "https://mitxonline.mit.dev"
+  MITX_ONLINE_COURSES_API_URL: "https://mitxonline.mit.dev/api/v2/courses/"
+  MITX_ONLINE_PROGRAMS_API_URL: "https://mitxonline.mit.dev/api/v2/programs/"
   PROLEARN_CATALOG_API_URL: "https://prolearn.mit.edu/graphql"
   CSAIL_BASE_URL: "https://cap.csail.mit.edu/"
   MITPE_BASE_URL: "https://professional.mit.edu/"

--- a/local-dev/tiltlib.star
+++ b/local-dev/tiltlib.star
@@ -11,49 +11,51 @@
 #    URLs, and cookie-domain references update consistently:
 #      export LOCAL_DEV_ROOT_DOMAIN=mycompany.dev && tilt up
 #
-# 2. Gitignored per-developer overrides. Pass local_overrides= the path of an
-#    optional, gitignored ConfigMap manifest (conventionally
-#    configmaps/app-env.local.yaml, named <app>-env-local). When the file
-#    exists it is applied with the other manifests; each app's
-#    deployment.yaml references it as the LAST envFrom entry with
-#    optional: true, so its keys override both the tracked ConfigMap and the
-#    tracked Secret, and its absence is a no-op. Because Kubernetes does not
-#    restart pods when a ConfigMap changes, every Deployment applied in the
-#    same call gets a pod-template annotation fingerprinting the overrides —
-#    editing the override file rolls the pods so new values take effect.
-#    See "Local Configuration Overrides" in local-dev/README.md.
+# 2. Config-change rollouts. Kubernetes does not restart pods when a
+#    ConfigMap/Secret they reference changes, so every Deployment applied in
+#    the same call gets a pod-template annotation fingerprinting the combined
+#    data/stringData of every ConfigMap and Secret passed in — editing any of
+#    them (the tracked app-env.yaml/secrets.yaml, or an optional gitignored
+#    local_overrides ConfigMap passed for per-developer overrides — see
+#    "Local Configuration Overrides" in local-dev/README.md) rolls the pods
+#    so new values actually take effect.
 
 _ROOT_DOMAIN_DEFAULT = "mit.dev"
-_OVERRIDE_HASH_ANNOTATION = "ol.mit.edu/local-overrides-hash"
+_CONFIG_HASH_ANNOTATION = "ol.mit.edu/config-hash"
 
-def _overrides_fingerprint(path, text):
-    """Validate the override manifest and return a stable fingerprint of its
-    data (not the raw text, so comment/formatting edits don't roll pods).
-    Also logs the overridden key names — never values — to the Tiltfile log."""
-    docs = [d for d in decode_yaml_stream(text) if d != None]
-    if len(docs) != 1 or docs[0].get("kind") != "ConfigMap":
-        fail("%s: expected a single ConfigMap manifest" % path)
-    # A data: key with nothing (or only comments) under it parses as None.
-    data = docs[0].get("data", {}) or {}
-    for k in data:
-        if type(data[k]) != "string":
-            fail(
-                '%s: data.%s must be a YAML string — quote the value (e.g. "True", "8080"); got %s'
-                % (path, k, type(data[k]))
-            )
-    keys = sorted(data.keys())
-    print("[%s] local overrides active: %s" % (path, ", ".join(keys) if keys else "(none)"))
-    if not keys:
-        # Empty data: treat as "no overrides" — apply the (empty) ConfigMap
-        # but skip stamping, so Deployments return to their unannotated state.
-        return ""
-    canon = "".join(["%s=%s\n" % (k, data[k]) for k in keys])
-    return str(hash(canon))
+def _config_fingerprint(paths_and_texts):
+    """Return a stable fingerprint of the combined data/stringData of every
+    ConfigMap and Secret across the given (path, text) pairs (not the raw
+    text, so comment/formatting-only edits don't roll pods)."""
+    pairs = []
+    for path, text in paths_and_texts:
+        docs = [d for d in decode_yaml_stream(text) if d != None]
+        for d in docs:
+            kind = d.get("kind")
+            if kind != "ConfigMap" and kind != "Secret":
+                continue
+            data = d.get("data") or d.get("stringData") or {}
+            name = d.get("metadata", {}).get("name", "?")
+            for k in sorted(data.keys()):
+                v = data[k]
+                # A `KEY:` with nothing after it parses as YAML null; Kubernetes'
+                # own JSON decode leaves map[string]string entries untouched (i.e.
+                # "") on null, so mirror that instead of failing on it.
+                if v == None:
+                    v = ""
+                elif type(v) != "string":
+                    fail(
+                        '%s: %s %s.data.%s must be a YAML string — quote the value (e.g. "True", "8080"); got %s'
+                        % (path, kind, name, k, type(v))
+                    )
+                pairs.append("%s/%s=%s" % (name, k, v))
+    return str(hash("\n".join(sorted(pairs))))
 
 def _stamp_deployments(content, fingerprint):
-    """Add the overrides-fingerprint annotation to every Deployment pod
-    template in a (possibly multi-doc) manifest text, so changing an override
-    rolls the pods. Returns a Blob, or None if there are no Deployments."""
+    """Add the config-fingerprint annotation to every Deployment pod
+    template in a (possibly multi-doc) manifest text, so changing any
+    applied ConfigMap/Secret rolls the pods. Returns a Blob, or None if
+    there are no Deployments."""
     docs = [d for d in decode_yaml_stream(content) if d != None]
     stamped = False
     for d in docs:
@@ -64,15 +66,17 @@ def _stamp_deployments(content, fingerprint):
                 .setdefault("metadata", {})
                 .setdefault("annotations", {})
             )
-            annotations[_OVERRIDE_HASH_ANNOTATION] = fingerprint
+            annotations[_CONFIG_HASH_ANNOTATION] = fingerprint
             stamped = True
     if not stamped:
         return None
     return encode_yaml_stream(docs)
 
 def k8s_yaml_local(paths, local_overrides=None):
-    """Apply k8s YAML with root-domain substitution and an optional
-    gitignored ConfigMap of per-developer overrides (see module docstring)."""
+    """Apply k8s YAML with root-domain substitution and a pod-template
+    fingerprint annotation covering every applied ConfigMap/Secret, including
+    an optional gitignored ConfigMap of per-developer overrides (see module
+    docstring)."""
     rd = os.environ.get("LOCAL_DEV_ROOT_DOMAIN", _ROOT_DOMAIN_DEFAULT)
 
     # read_file(default=...) also registers a watch on the override path —
@@ -81,21 +85,26 @@ def k8s_yaml_local(paths, local_overrides=None):
     overrides_text = ""
     if local_overrides:
         overrides_text = str(read_file(local_overrides, default=""))
+        if overrides_text.strip():
+            docs = [d for d in decode_yaml_stream(overrides_text) if d != None]
+            if len(docs) != 1 or docs[0].get("kind") != "ConfigMap":
+                fail("%s: expected a single ConfigMap manifest" % local_overrides)
+            keys = sorted((docs[0].get("data", {}) or {}).keys())
+            print("[%s] local overrides active: %s" % (local_overrides, ", ".join(keys) if keys else "(none)"))
 
-    if rd == _ROOT_DOMAIN_DEFAULT and not overrides_text.strip():
-        # Fast path: nothing to rewrite, apply files as-is.
-        k8s_yaml(paths)
-        return
-
-    fingerprint = ""
     all_paths = list(paths)
     if overrides_text.strip():
-        fingerprint = _overrides_fingerprint(local_overrides, overrides_text)
         all_paths.append(local_overrides)
 
+    contents = []
     for p in all_paths:
         content = str(read_file(p))
         if rd != _ROOT_DOMAIN_DEFAULT:
             content = content.replace(_ROOT_DOMAIN_DEFAULT, rd)
-        stamped = _stamp_deployments(content, fingerprint) if fingerprint else None
+        contents.append((p, content))
+
+    fingerprint = _config_fingerprint(contents)
+
+    for p, content in contents:
+        stamped = _stamp_deployments(content, fingerprint)
         k8s_yaml(stamped if stamped != None else blob(content))

--- a/local-dev/tiltlib.star
+++ b/local-dev/tiltlib.star
@@ -24,9 +24,9 @@ _ROOT_DOMAIN_DEFAULT = "mit.dev"
 _CONFIG_HASH_ANNOTATION = "ol.mit.edu/config-hash"
 
 def _config_fingerprint(paths_and_texts):
-    """Return a stable fingerprint of the combined data/stringData of every
-    ConfigMap and Secret across the given (path, text) pairs (not the raw
-    text, so comment/formatting-only edits don't roll pods)."""
+    """Return a stable fingerprint of the combined data/binaryData/stringData
+    of every ConfigMap and Secret across the given (path, text) pairs (not the
+    raw text, so comment/formatting-only edits don't roll pods)."""
     pairs = []
     for path, text in paths_and_texts:
         docs = [d for d in decode_yaml_stream(text) if d != None]
@@ -34,7 +34,13 @@ def _config_fingerprint(paths_and_texts):
             kind = d.get("kind")
             if kind != "ConfigMap" and kind != "Secret":
                 continue
-            data = d.get("data") or d.get("stringData") or {}
+            # Kubernetes merges all three value fields rather than picking one,
+            # with stringData taking precedence over data on key collisions, so
+            # fingerprint the union — otherwise an edit to a field we skipped
+            # would silently not roll the pods.
+            data = dict(d.get("data") or {})
+            data.update(d.get("binaryData") or {})
+            data.update(d.get("stringData") or {})
             name = d.get("metadata", {}).get("name", "?")
             for k in sorted(data.keys()):
                 v = data[k]
@@ -45,7 +51,7 @@ def _config_fingerprint(paths_and_texts):
                     v = ""
                 elif type(v) != "string":
                     fail(
-                        '%s: %s %s.data.%s must be a YAML string — quote the value (e.g. "True", "8080"); got %s'
+                        '%s: %s %s: key %s must be a YAML string — quote the value (e.g. "True", "8080"); got %s'
                         % (path, kind, name, k, type(v))
                     )
                 pairs.append("%s/%s=%s" % (name, k, v))


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
- Sets the missing `MITX_ONLINE_*` ETL env vars for mit-learn so `seed-mit-learn-mitxonline` actually ingests courses, and 
- makes `tiltlib.star` roll pods on any tracked ConfigMap/Secret change 
    - previously only edits to the local-override file did, so tracked config changes like this one left running pods stale.

### How can this be tested?
1. `kubectl exec -n mit-learn deploy/mitlearn-webapp -c app -- printenv MITX_ONLINE_COURSES_API_URL` → should print `https://mitxonline.mit.dev/api/v2/courses/`.
2. Trigger the `seed-mit-learn-mitxonline` Tilt button and confirm it reports a non-zero count of populated resources.
3. To check the rollout fix: edit any value in `local-dev/apps/mit-learn/configmaps/app-env.yaml`, save, and confirm Tilt rolls `mitlearn-webapp`/`mitlearn-worker-default` to new pods without a manual `kubectl rollout restart`.

### Additional Context
N/A