### PR TITLE
fix(k8s): stop recurring PodOOMKilled and efs-csi-node PodCrashLooping alerts

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/k8s_resources.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_resources.py
@@ -401,9 +401,20 @@ def create_k8s_resources(  # noqa: C901
                     protocol="TCP",
                 ),
             ],
+            # The 96Mi/128Mi rightsizing in #4731 was measured against the
+            # low-volume Open edX deployments and is too tight for the busy ones:
+            # residential-production mitx-openedx pegs at 127.8Mi against the 128Mi
+            # ceiling and has been OOMKilled repeatedly, and mitxonline-openedx peaks
+            # at ~180Mi (it has only escaped so far because that cluster still runs
+            # the pre-#4731 512Mi limit and would start OOMing on its next rollout).
+            # Vector's memory is driven by tracking-log throughput, which varies by
+            # an order of magnitude across deployments, so the limit is sized for the
+            # busiest one. The request stays well under the old 512Mi -- request is
+            # what drives bin-packing and cost, so most of the rightsizing saving is
+            # kept while the limit provides burst headroom instead of a hard kill.
             resources=kubernetes.core.v1.ResourceRequirementsArgs(
-                requests={"cpu": "10m", "memory": "96Mi"},
-                limits={"memory": "128Mi"},
+                requests={"cpu": "10m", "memory": "192Mi"},
+                limits={"memory": "512Mi"},
             ),
             volume_mounts=[
                 kubernetes.core.v1.VolumeMountArgs(

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1771,8 +1771,16 @@ learn_external_service_apisix_route = OLApisixRoute(
 # (a KEDA cpu trigger, in mit-learn's case) owns CPU and the VPA owns memory. Bounds
 # come from webapp_vpa_min/max_allowed_memory on the OLApplicationK8sConfig above.
 # Celery workers and beat are scaled via KEDA (Redis queue depth), so CPU+memory VPA is safe.
+# The 128Mi memory floor was too low to be safe. make_vpa() scales the limit
+# proportionally to the declared request:limit ratio, so the floor sets the limit
+# floor too -- at 128Mi the VPA was free to shrink the default worker's request to
+# ~662Mi, which dragged its limit down to 1324Mi. Steady-state use fits there, but
+# bursts hit 1307Mi and OOMKilled just under the cap, which is exactly the failure
+# the 2:1 ratio above was introduced to prevent: the ratio only helps if the request
+# it multiplies cannot collapse. A 1Gi floor keeps the effective limit at or above
+# 2Gi while still leaving the VPA room to trim over-provisioned workers.
 _worker_vpa_bounds = {
-    "min_allowed": {"cpu": "25m", "memory": "128Mi"},
+    "min_allowed": {"cpu": "25m", "memory": "1Gi"},
     "max_allowed": {"cpu": "1000m", "memory": "3Gi"},
 }
 # The embeddings worker runs ML inference (embedding generation), which is
@@ -1781,7 +1789,7 @@ _worker_vpa_bounds = {
 # 2026-07-28) already exceeds the shared 1000m ceiling above, so it gets its
 # own bounds instead of sharing _worker_vpa_bounds with the lighter queues.
 _embeddings_worker_vpa_bounds = {
-    "min_allowed": {"cpu": "25m", "memory": "128Mi"},
+    "min_allowed": {"cpu": "25m", "memory": "1Gi"},
     "max_allowed": {"cpu": "2000m", "memory": "3Gi"},
 }
 for _celery_name in mitlearn_k8s_app.celery_deployment_names:

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
@@ -76,12 +76,22 @@ nextjs_config = Config("nextjs")
 # means raising nextjs_memory_limit later hands all of the added memory straight to
 # the heap (the actual thing that needs more room); a percentage would keep skimming
 # an ever-larger, unneeded slice off the top as the limit grows.
-nextjs_memory_limit = "1Gi"
+# The heap budget the container is provisioned around: V8's old-space ceiling is
+# derived from this, and it is also the memory request (what the scheduler reserves).
+nextjs_memory_request = "1Gi"
 NEXTJS_NON_HEAP_OVERHEAD_MIB = 224
 nextjs_max_old_space_size_mib = (
-    int(parse_quantity(nextjs_memory_limit)) // (1024 * 1024)
+    int(parse_quantity(nextjs_memory_request)) // (1024 * 1024)
     - NEXTJS_NON_HEAP_OVERHEAD_MIB
 )
+# The limit sits above the request rather than matching it. With request == limit ==
+# 1Gi, the heap ceiling (800MiB) plus the 224MiB non-heap reserve exactly consumed the
+# whole limit, so there was no margin at all: production pods rode at ~1002Mi against
+# the 1024Mi cap and were OOMKilled whenever non-heap use drifted past its reserve
+# while the heap was near full. The extra headroom here is deliberately NOT given to
+# V8 -- max_old_space_size stays pinned to the request-derived budget above -- so it
+# stays available to absorb non-heap spikes instead of being absorbed into the heap.
+nextjs_memory_limit = "1536Mi"
 
 stay_updated_hubspot_form_ids = {
     "ci": "f201f3af-c2c0-4b7d-b297-ddbb75912cc1",
@@ -246,7 +256,7 @@ mit_learn_nextjs_deployment = kubernetes.apps.v1.Deployment(
                         ],
                         image_pull_policy="Always",
                         resources=kubernetes.core.v1.ResourceRequirementsArgs(
-                            requests={"cpu": "100m", "memory": nextjs_memory_limit},
+                            requests={"cpu": "100m", "memory": nextjs_memory_request},
                             limits={"memory": nextjs_memory_limit},
                         ),
                         env=env_vars,

--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -633,27 +633,31 @@ ocw_studio_k8s_app = OLApplicationK8s(
         pre_deploy_commands=[
             ("migrate", ["python", "manage.py", "migrate", "--noinput"])
         ],
+        # Worker memory limits are 2x the request rather than matching it. With
+        # request == limit == 768Mi the default queue rode at ~694Mi and OOMKilled
+        # on publish/batch bursts, taking the deployment unavailable; the request
+        # still reflects steady-state use, the limit now absorbs the spike.
         celery_worker_configs=[
             OLApplicationK8sCeleryWorkerConfig(
                 queue_name="default",
                 redis_host=redis_cache.address,
                 redis_password=redis_config.require("password"),
                 resource_requests={"cpu": "50m", "memory": "768Mi"},
-                resource_limits={"memory": "768Mi"},
+                resource_limits={"memory": "1536Mi"},
             ),
             OLApplicationK8sCeleryWorkerConfig(
                 queue_name="publish",
                 redis_host=redis_cache.address,
                 redis_password=redis_config.require("password"),
                 resource_requests={"cpu": "50m", "memory": "768Mi"},
-                resource_limits={"memory": "768Mi"},
+                resource_limits={"memory": "1536Mi"},
             ),
             OLApplicationK8sCeleryWorkerConfig(
                 queue_name="batch",
                 redis_host=redis_cache.address,
                 redis_password=redis_config.require("password"),
                 resource_requests={"cpu": "50m", "memory": "768Mi"},
-                resource_limits={"memory": "768Mi"},
+                resource_limits={"memory": "1536Mi"},
             ),
         ],
         celery_beat_config=OLApplicationK8sCeleryBeatConfig(

--- a/src/ol_infrastructure/infrastructure/aws/eks/external_dns.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/external_dns.py
@@ -149,13 +149,18 @@ def setup_external_dns(
                 "txtOwnerId": cluster_name,
                 # Limit the dns zones that external dns knows about
                 "domainFilters": eks_config.require_object("allowed_dns_zones"),
+                # request == limit leaves zero burst headroom: data-qa sat at
+                # 127.6Mi against the 128Mi ceiling and OOMKilled. Memory here
+                # scales with the number of Route53 records external-dns tracks,
+                # which grows as gateway routes are added, so the limit is set to
+                # 2x the request rather than matching it.
                 "resources": {
                     "requests": {
                         "memory": "128Mi",
                         "cpu": "10m",
                     },
                     "limits": {
-                        "memory": "128Mi",
+                        "memory": "256Mi",
                     },
                 },
             },

--- a/src/ol_infrastructure/substructure/aws/eks/marimo_operator.py
+++ b/src/ol_infrastructure/substructure/aws/eks/marimo_operator.py
@@ -30,6 +30,34 @@ MARIMO_OPERATOR_MANIFEST_URL = (
 )
 MARIMO_OPERATOR_NAMESPACE = "marimo-operator-system"
 
+# The upstream manifest ships the controller with memory request == limit == 128Mi.
+# That is too tight once the operator is reconciling real notebooks: on data-qa it
+# reached 117.5Mi against the 128Mi cap and entered an OOMKill/CrashLoopBackOff loop
+# that also took the Deployment unavailable. Raising the limit (leaving the upstream
+# request alone) restores burst headroom without over-reserving on the node.
+MARIMO_OPERATOR_MEMORY_LIMIT = "384Mi"
+
+
+def _patch_controller_memory_limit(doc: dict[str, Any]) -> dict[str, Any]:
+    """Raise the operator controller's memory limit above the upstream default.
+
+    Args:
+        doc: A single Kubernetes resource dict from the install manifest.
+
+    Returns:
+        The same dict, with the controller container's memory limit raised.
+    """
+    if doc.get("kind") != "Deployment":
+        return doc
+    containers = (
+        doc.get("spec", {}).get("template", {}).get("spec", {}).get("containers", [])
+    )
+    for container in containers:
+        if container.get("name") == "manager":
+            limits = container.setdefault("resources", {}).setdefault("limits", {})
+            limits["memory"] = MARIMO_OPERATOR_MEMORY_LIMIT
+    return doc
+
 
 def _fetch_operator_manifests() -> list[dict[str, Any]]:
     """Fetch and parse the marimo operator install YAML.
@@ -39,7 +67,11 @@ def _fetch_operator_manifests() -> list[dict[str, Any]]:
     """
     with urllib.request.urlopen(MARIMO_OPERATOR_MANIFEST_URL) as response:  # noqa: S310
         content = response.read().decode("utf-8")
-    return [doc for doc in pyyaml.safe_load_all(content) if doc is not None]
+    return [
+        _patch_controller_memory_limit(doc)
+        for doc in pyyaml.safe_load_all(content)
+        if doc is not None
+    ]
 
 
 def setup_marimo_operator(


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
A week of recurring Rootly `PodOOMKilledCritical` / `PodOOMKilledWarning` pages (Grafana → alertmanager) across several unrelated services turned out to share one cause: **memory `limit` set equal to memory `request`**. With no gap between steady-state usage and the cap, a transient spike is a hard OOM kill rather than page-cache reclaim, so these pods sit a few MiB under their ceiling and OOM on a loop.

Confirmed by cross-referencing 3-day peak working set, the configured limit, and the actual termination reason:

| Workload | Peak | Limit | Termination reason |
|---|---|---|---|
| `vector` sidecar (residential-production, `mitx-openedx`) | 127.8Mi | 128Mi | OOMKilled ×6 |
| `nextjs-app` (applications-production, `mitlearn`) | 1002Mi | 1024Mi | OOMKilled ×3 |
| `celery-worker` (applications-production, `mitlearn`) | 1307Mi | 1324Mi | OOMKilled ×3 |
| `celery-worker` (applications-production, `ocw-studio`) | 694Mi | 768Mi | OOMKilled ×1 |
| `external-dns` (data-qa, `operations`) | 127.6Mi | 128Mi | OOMKilled |
| `manager` (data-qa, `marimo-operator-system`) | 117.5Mi | 128Mi | OOMKilled |

Requests are left at (or near) observed steady-state so bin-packing and the cost savings from #4731 are largely preserved — only the limits move.

**Changes:**

- **edxapp `vector` sidecar** (`applications/edxapp/k8s_resources.py`) — 96Mi/128Mi → 192Mi request / 512Mi limit.
- **mit-learn Next.js** (`applications/mit_learn_nextjs/__main__.py`) — limit 1Gi → 1536Mi, request held at 1Gi.
- **mit-learn celery VPA bounds** (`applications/mit_learn/__main__.py`) — `min_allowed.memory` 128Mi → 1Gi.
- **ocw-studio celery workers** (`applications/ocw_studio/__main__.py`) — limit 768Mi → 1536Mi on all three queues (default/publish/batch).
- **external-dns** (`infrastructure/aws/eks/external_dns.py`) — limit 128Mi → 256Mi.
- **marimo-operator** (`substructure/aws/eks/marimo_operator.py`) — patch the controller's memory limit to 384Mi in the fetched upstream manifest docs before handing them to `ConfigGroup`, rather than forking the manifest.

Two details worth calling out for review:

**1. The `vector` change reverts a regression from #4731, and fixes a latent one.**
That PR cut the sidecar from 512Mi to 96Mi/128Mi based on usage sampled at ~75Mi — but that was measured on the low-volume Open edX deployments. `residential-production` / `mitx-openedx` carries an order of magnitude more tracking-log throughput and has been OOMKilling at 127.8Mi against the 128Mi cap. It is also latent elsewhere: `mitxonline-openedx` peaks at ~180Mi and has only escaped so far because `applications-production` still runs the pre-#4731 512Mi limit — it would have started OOMing on its next rollout.

**2. A declared 2:1 request:limit ratio is not sufficient when a VPA targets the workload.**
mit-learn already declared 1280Mi/2560Mi for exactly this reason (see the comment above `celery_default_resource_requests`). But [`make_vpa()`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/lib/k8s_vpa.py) uses `controlledValues: RequestsAndLimits`, which scales the limit *proportionally* to whatever request the VPA settles on. A `min_allowed.memory` of 128Mi let the VPA shrink the default worker's request to ~662Mi, dragging its limit down to 1324Mi — and it OOMed at 1307Mi. The ratio only protects you if the request it multiplies cannot collapse, hence the 1Gi floor.

The Next.js change deliberately preserves the existing V8 heap-sizing design. `--max-old-space-size` stays pinned at 800MiB, derived from the new `nextjs_memory_request` rather than the limit, so the added 512Mi is available to absorb non-heap spikes instead of being handed straight to the heap. Previously heap (800MiB) + the 224MiB non-heap reserve consumed the entire 1Gi limit, leaving zero margin.

### How can this be tested?

Validation run on this branch:

```
uv run pre-commit run --files <changed files>   # ruff format, ruff check, mypy — all Passed
uv run pytest tests/ -q -k "marimo or vpa or nextjs or external_dns"   # 9 passed
```

The `marimo_operator` manifest patch was exercised directly to confirm it only touches the `manager` container, leaves sidecars alone, and passes non-Deployment / malformed docs through untouched:

```
manager  : {'requests': {'memory': '128Mi'}, 'limits': {'memory': '384Mi'}}
sidecar  : {'limits': {'memory': '64Mi'}}   # untouched
passthrough for non-Deployment / malformed docs: OK
```

**Reviewer validation — please run `pulumi preview` on the affected stacks before merging.** I was not able to run it locally (needs live credentials against the production stacks), so the previews are unverified. Affected stacks: `applications.{QA,Production}`, `residential.{QA,Production}`, `data.{QA,Production}`. Expect in-place container resource updates only — any replacement or deletion is unexpected and should block the merge.

To confirm the fix after deploy, these are the queries used to diagnose it (Grafana Cloud, per environment):

```promql
# peak working set over 3d, MiB
max by (cluster,namespace,container) (
  max_over_time(container_memory_working_set_bytes{container=~"vector|nextjs-app|celery-worker|external-dns|manager"}[3d])
) / 1024/1024

# configured limit, MiB
max by (cluster,namespace,container) (
  kube_pod_container_resource_limits{resource="memory",container=~"vector|nextjs-app|celery-worker|external-dns|manager"}
) / 1024/1024

# termination reasons — should show no new OOMKilled for these containers
sum by (cluster,namespace,container,reason) (
  kube_pod_container_status_last_terminated_reason{reason="OOMKilled"} > 0
)
```

Peak should settle comfortably below limit for each container, and the OOMKilled counters should stop advancing.

---

## Second commit: `efs-csi-node` crashloop (not memory)

The `PodCrashLoopingCritical` pages for `efs-csi-node` in `applications-production` were the highest-frequency alert in the batch, and they are **not** OOM kills — they need a different fix, so they are a separate commit.

`efs-plugin` logs a complete, clean startup every time and then dies silently — no error, no shutdown line, memory flat at ~24Mi. The kill comes from outside the process: the `liveness-probe` sidecar logs `"Health check failed"` and `"context deadline exceeded"` against `csi.sock`, and the kubelet kills `efs-plugin` (only that container — the sidecars never restart).

It is entirely confined to one cluster:

| Cluster | efs-plugin restarts / 24h | Addon version | configurationValues |
|---|---|---|---|
| **applications-production** | **~345** | v3.4.1-eksbuild.1 | none |
| data-production | 0 | v3.4.1-eksbuild.1 | none |
| operations-production | 0 | v3.4.1-eksbuild.1 | none |
| residential-production | 0 | v3.4.1-eksbuild.1 | none |

All four clusters are byte-identical in version and config, every node in the DaemonSet is affected, and the EBS CSI driver is unaffected — so the *trigger* is environmental to `applications-production`, not a config difference. I could not isolate that trigger remotely; it needs `kubectl describe pod` / kubelet logs on one of those nodes. What this PR fixes is the two defects that let an environmental hiccup turn into a 345-restarts-per-day crashloop.

**1. The addon was installed with no `configuration_values`,** so the node DaemonSet inherited the addon defaults:
- `resources: {}` → `efs-plugin` runs in **BestEffort QoS** (no requests, no limits — first in line to be starved). Confirmed via its cgroup path, `/kubepods.slice/kubepods-besteffort.slice/...`.
- liveness probe `periodSeconds: 2`, `timeoutSeconds: 3`, `failureThreshold: 5` → only **~10s** of unresponsiveness before the kubelet kills it.

Requests (not limits) move it to Burstable so it has a guaranteed CPU share, and the probe is widened to **~50s** of grace — still restarts a genuinely wedged driver, but not one merely slow to answer under contention.

**2. `get_eks_addon_version()` ignored the version pins entirely.** It returned `sorted(versions, reverse=True)[0]` — always the newest version AWS offers. `EFS_CSI_DRIVER_VERSION` / `EBS_CSI_DRIVER_VERSION` fed the `VERSIONS` dict but were never passed to the addon, so both CSI addons silently tracked latest:

| Addon | Pinned in `versions.py` | Actually running |
|---|---|---|
| aws-efs-csi-driver | `v2.1.6-eksbuild.1` | `v3.4.1-eksbuild.1` |
| aws-ebs-csi-driver | `v1.40.1-eksbuild.1` | `v1.63.0-eksbuild.1` |

That is a **v2 → v3 major jump applied to production with no PR, no review, and no staged rollout**. The pins are updated to the versions running today, so this is a **no-op rollout, not a downgrade**. An unavailable pin now raises `ValueError` instead of silently falling back to latest.

### Validation for this commit

The `configuration_values` payload was validated against the live AWS addon schema (read-only `describe-addon-configuration`, no mutating call):

```
OK: validates against the v3.4.1-eksbuild.1 addon schema
OK: the literal payload in eks/__main__.py also validates
probe grace before: 10s (period 2 x threshold 5)
probe grace after : 50s (period 10 x threshold 5)
```

Version resolution was exercised against the real EKS API:

```
aws-efs-csi-driver
  pin      -> v3.4.1-eksbuild.1
  unpinned -> v3.4.1-eksbuild.1   (== deployed today, so this is a no-op rollout)
aws-ebs-csi-driver
  pin      -> v1.63.0-eksbuild.1
  unpinned -> v1.63.0-eksbuild.1  (== deployed today, so this is a no-op rollout)

bad pin raises ValueError (no silent fallback)
```

Full suite: `201 passed`. pre-commit / ruff / mypy clean.

**Reviewer note:** `pulumi preview` on the EKS stacks should show an in-place addon update (configurationValues added) and **no version change**. If it shows a version change, stop — the pin does not match what that cluster is running.

### Additional Context

For the mit-learn celery workers, the VPA floor change means the recommender can no longer trim those workers below a 1Gi request. That is intentional — it is the mechanism that keeps the proportionally-scaled limit at or above 2Gi — but it does give up some of the VPA's downward flexibility on those specific deployments. `max_allowed` is unchanged at 3Gi, so there is no change to the upper bound.

On the EFS commit: the environmental trigger specific to `applications-production` is still unidentified — this PR removes the fragility (BestEffort QoS, 10s probe grace) and the silent version drift, but if restarts continue after rollout the next step is kubelet logs on an affected node. Worth watching the restart counter for a day post-deploy.
