### PR TITLE
fix(eks): stop efs-csi-node crashloop and make CSI addon versions actually pinned

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -10,6 +10,29 @@
         'pulumi{/,}**',
       ],
     },
+    {
+      // The aws-eks-addon datasource requires packageName to be a minified JSON
+      // object rather than a plain string, so it cannot be written directly in the
+      // versions.py marker comment the way every other datasource's can: raw JSON
+      // in a `#` comment trips ruff's ERA001 (commented-out code), and a `# noqa`
+      // appended to silence that would sit between the marker and the assignment
+      // and break the custom manager's regex. Building it here from depName keeps
+      // the comments uniform and lets the one generic manager handle these too.
+      //
+      // Without this, the addons resolved to an unparseable packageName and
+      // Renovate skipped them silently -- which is why EFS_CSI_DRIVER_VERSION sat
+      // at v2.1.6-eksbuild.1 while production had long since moved to v3.4.1.
+      //
+      // kubernetesVersion is deliberately left out of the filter so this does not
+      // silently go stale on every cluster upgrade. The cost is that Renovate may
+      // propose a version not offered for our Kubernetes version;
+      // get_eks_addon_version() validates the pin and raises at preview time, so
+      // that fails loudly in CI rather than reaching a cluster.
+      matchDatasources: [
+        'aws-eks-addon',
+      ],
+      overridePackageName: '{"addonName":"{{{depName}}}"}',
+    },
   ],
   pip_requirements: {
     managerFilePatterns: [
@@ -23,7 +46,7 @@
         '/^src/bridge/lib/versions.py$/',
       ],
       matchStrings: [
-        '# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>.+?)(?: packageName=(?<packageName>.+?))?(?: registryUrl=(?<registryUrl>.+?))?(?: versioning=(?<versioning>[a-z-]+?))?\\s*.+\\s*=\\s*"(?<currentValue>.+?)(-eksbuild.\\d+)?"',
+        '# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>.+?)(?: packageName=(?<packageName>.+?))?(?: registryUrl=(?<registryUrl>.+?))?(?: versioning=(?<versioning>[a-z-]+?))?\\s*.+\\s*=\\s*"(?<currentValue>.+?)"',
       ],
     },
   ],

--- a/src/bridge/lib/versions.py
+++ b/src/bridge/lib/versions.py
@@ -45,9 +45,9 @@ CERT_MANAGER_CHART_VERSION = "v1.16.1"
 # renovate: datasource=helm depName=dagster packageName=dagster registryUrl=https://dagster-io.github.io/helm
 DAGSTER_CHART_VERSION = "1.13.15"
 # renovate: datasource=aws-eks-addon depName=ebs-csi-driver
-EBS_CSI_DRIVER_VERSION = "v1.40.1-eksbuild.1"
+EBS_CSI_DRIVER_VERSION = "v1.63.0-eksbuild.1"
 # renovate: datasource=aws-eks-addon depName=efs-csi-driver
-EFS_CSI_DRIVER_VERSION = "v2.1.6-eksbuild.1"
+EFS_CSI_DRIVER_VERSION = "v3.4.1-eksbuild.1"
 # renovate: datasource=helm depName=external-dns packageName=external-dns registryUrl=https://kubernetes-sigs.github.io/external-dns/
 EXTERNAL_DNS_CHART_VERSION = "1.21.1"
 # renovate: datasource=github-releases depName=gateway-api packageName=kubernetes-sigs/gateway-api

--- a/src/bridge/lib/versions.py
+++ b/src/bridge/lib/versions.py
@@ -44,9 +44,9 @@ AWS_NODE_TERMINATION_HANDLER_CHART_VERSION = "0.27.2"
 CERT_MANAGER_CHART_VERSION = "v1.16.1"
 # renovate: datasource=helm depName=dagster packageName=dagster registryUrl=https://dagster-io.github.io/helm
 DAGSTER_CHART_VERSION = "1.13.15"
-# renovate: datasource=aws-eks-addon depName=ebs-csi-driver
+# renovate: datasource=aws-eks-addon depName=aws-ebs-csi-driver versioning=aws-eks-addon
 EBS_CSI_DRIVER_VERSION = "v1.63.0-eksbuild.1"
-# renovate: datasource=aws-eks-addon depName=efs-csi-driver
+# renovate: datasource=aws-eks-addon depName=aws-efs-csi-driver versioning=aws-eks-addon
 EFS_CSI_DRIVER_VERSION = "v3.4.1-eksbuild.1"
 # renovate: datasource=helm depName=external-dns packageName=external-dns registryUrl=https://kubernetes-sigs.github.io/external-dns/
 EXTERNAL_DNS_CHART_VERSION = "1.21.1"

--- a/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
@@ -846,7 +846,9 @@ if eks_config.get_bool("ebs_csi_provisioner"):
         f"{cluster_name}-eks-addon-ebs-cni-driver-addon",
         cluster=cluster,
         addon_name="aws-ebs-csi-driver",
-        addon_version=get_eks_addon_version("aws-ebs-csi-driver"),
+        addon_version=get_eks_addon_version(
+            "aws-ebs-csi-driver", pinned_version=VERSIONS["EBS_CSI_DRIVER"]
+        ),
         service_account_role_arn=ebs_csi_driver_role.role.arn,
         opts=ResourceOptions(
             parent=cluster,
@@ -945,8 +947,40 @@ if eks_config.get_bool("efs_csi_provisioner"):
         f"{cluster_name}-eks-addon-efs-cni-driver-addon",
         cluster=cluster,
         addon_name="aws-efs-csi-driver",
-        addon_version=get_eks_addon_version("aws-efs-csi-driver"),
+        addon_version=get_eks_addon_version(
+            "aws-efs-csi-driver", pinned_version=VERSIONS["EFS_CSI_DRIVER"]
+        ),
         service_account_role_arn=efs_csi_driver_role.role.arn,
+        # Installed with no configuration_values, the node DaemonSet inherits the
+        # addon defaults: resources {} (so efs-plugin lands in BestEffort QoS, first
+        # in line to be starved) and a liveness probe of periodSeconds 2 /
+        # timeoutSeconds 3 / failureThreshold 5 -- roughly 10 seconds of
+        # unresponsiveness is enough for the kubelet to kill it. On
+        # applications-production that combination produced ~345 efs-plugin restarts
+        # per day across every node, with the liveness-probe sidecar logging
+        # "Health check failed" / "context deadline exceeded" against csi.sock while
+        # the driver itself logged no error and held flat at ~24Mi.
+        #
+        # Requests (not limits) move the container to Burstable so it has a
+        # guaranteed CPU share; the probe is widened to ~50s of grace, which still
+        # restarts a genuinely wedged driver but not one that is merely slow to
+        # answer under node contention.
+        configuration_values=json.dumps(
+            {
+                "node": {
+                    "resources": {
+                        "requests": {"cpu": "25m", "memory": "64Mi"},
+                    },
+                    "livenessProbe": {
+                        "httpGet": {"path": "/healthz", "port": "healthz"},
+                        "initialDelaySeconds": 10,
+                        "periodSeconds": 10,
+                        "timeoutSeconds": 5,
+                        "failureThreshold": 5,
+                    },
+                },
+            }
+        ),
         opts=ResourceOptions(
             parent=cluster,
             # Addons won't install properly if there are not nodes to schedule them on

--- a/src/ol_infrastructure/lib/aws/eks_helper.py
+++ b/src/ol_infrastructure/lib/aws/eks_helper.py
@@ -75,7 +75,33 @@ def get_cluster_version(*, use_default: bool = True) -> str:
 
 
 @lru_cache
-def get_eks_addon_version(addon_name: str, cluster_version: str | None = None) -> str:
+def get_eks_addon_version(
+    addon_name: str,
+    cluster_version: str | None = None,
+    pinned_version: str | None = None,
+) -> str:
+    """Resolve the addon version to install, honouring an explicit pin.
+
+    Without ``pinned_version`` this returns the newest version AWS offers for the
+    cluster's Kubernetes version, which means the addon silently tracks latest and
+    can take a major-version jump with no PR, no review, and no staged rollout.
+    Pass ``pinned_version`` (from ``bridge.lib.versions``, where Renovate manages
+    it) so addon upgrades go through code review like every other dependency.
+
+    Args:
+        addon_name: EKS addon name, e.g. ``aws-efs-csi-driver``.
+        cluster_version: Kubernetes version to resolve against. Defaults to the
+            current cluster version.
+        pinned_version: Exact addon version to install. Must be offered by AWS for
+            ``cluster_version``.
+
+    Returns:
+        The addon version to install.
+
+    Raises:
+        ValueError: If ``pinned_version`` is not available for this cluster
+            version, rather than silently falling back to latest.
+    """
     if cluster_version is None:
         cluster_version = get_cluster_version()
     version_info = eks_client.describe_addon_versions(
@@ -83,6 +109,15 @@ def get_eks_addon_version(addon_name: str, cluster_version: str | None = None) -
         addonName=addon_name,
     )["addons"][0]
     versions = [version["addonVersion"] for version in version_info["addonVersions"]]
+    if pinned_version is not None:
+        if pinned_version not in versions:
+            msg = (
+                f"Pinned version {pinned_version} of EKS addon {addon_name} is not "
+                f"available for Kubernetes {cluster_version}. Available versions: "
+                f"{', '.join(sorted(versions, reverse=True))}"
+            )
+            raise ValueError(msg)
+        return pinned_version
     return sorted(versions, reverse=True)[0]
 
 

--- a/src/ol_infrastructure/lib/aws/eks_helper.py
+++ b/src/ol_infrastructure/lib/aws/eks_helper.py
@@ -1,4 +1,5 @@
 import json
+import re
 from functools import lru_cache, partial
 from typing import Any
 
@@ -74,6 +75,38 @@ def get_cluster_version(*, use_default: bool = True) -> str:
     return versions_list[0]
 
 
+EKS_ADDON_VERSION_RE = re.compile(
+    r"^v?(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-eksbuild\.(?P<build>\d+))?$"
+)
+
+
+def eks_addon_version_sort_key(addon_version: str) -> tuple[int, int, int, int]:
+    """Order EKS addon versions numerically rather than lexicographically.
+
+    Addon versions look like ``v1.63.0-eksbuild.1``. Sorting those as plain
+    strings is wrong at every digit boundary -- ``v1.9.0-eksbuild.1`` sorts
+    *above* ``v1.63.0-eksbuild.1`` because "9" > "6" -- so a lexicographic
+    "newest" pick silently selects a years-old addon.
+
+    Args:
+        addon_version: An addon version string, e.g. ``v1.63.0-eksbuild.1``.
+
+    Returns:
+        A tuple ordering versions numerically. Unparseable versions sort below
+        every well-formed one instead of raising, so an unexpected format from
+        AWS degrades the ordering rather than breaking the deploy.
+    """
+    match = EKS_ADDON_VERSION_RE.match(addon_version)
+    if match is None:
+        return (-1, -1, -1, -1)
+    return (
+        int(match["major"]),
+        int(match["minor"]),
+        int(match["patch"]),
+        int(match["build"] or 0),
+    )
+
+
 @lru_cache
 def get_eks_addon_version(
     addon_name: str,
@@ -82,16 +115,19 @@ def get_eks_addon_version(
 ) -> str:
     """Resolve the addon version to install, honouring an explicit pin.
 
-    Without ``pinned_version`` this returns the newest version AWS offers for the
-    cluster's Kubernetes version, which means the addon silently tracks latest and
-    can take a major-version jump with no PR, no review, and no staged rollout.
-    Pass ``pinned_version`` (from ``bridge.lib.versions``, where Renovate manages
-    it) so addon upgrades go through code review like every other dependency.
+    Without ``pinned_version`` this returns the newest version AWS offers for
+    ``cluster_version``, which means the addon silently tracks latest and can take
+    a major-version jump with no PR, no review, and no staged rollout. Pass
+    ``pinned_version`` (from ``bridge.lib.versions``, where Renovate manages it) so
+    addon upgrades go through code review like every other dependency.
 
     Args:
         addon_name: EKS addon name, e.g. ``aws-efs-csi-driver``.
-        cluster_version: Kubernetes version to resolve against. Defaults to the
-            current cluster version.
+        cluster_version: Kubernetes version to resolve addon versions against.
+            Defaults to ``get_cluster_version()``, which is the newest
+            standard-support EKS Kubernetes version -- not the version of any
+            particular cluster. Pass an explicit value to resolve against a
+            cluster that is not on the newest release.
         pinned_version: Exact addon version to install. Must be offered by AWS for
             ``cluster_version``.
 
@@ -111,14 +147,15 @@ def get_eks_addon_version(
     versions = [version["addonVersion"] for version in version_info["addonVersions"]]
     if pinned_version is not None:
         if pinned_version not in versions:
+            available = sorted(versions, key=eks_addon_version_sort_key, reverse=True)
             msg = (
                 f"Pinned version {pinned_version} of EKS addon {addon_name} is not "
                 f"available for Kubernetes {cluster_version}. Available versions: "
-                f"{', '.join(sorted(versions, reverse=True))}"
+                f"{', '.join(available)}"
             )
             raise ValueError(msg)
         return pinned_version
-    return sorted(versions, reverse=True)[0]
+    return max(versions, key=eks_addon_version_sort_key)
 
 
 @lru_cache


### PR DESCRIPTION
### What are the relevant tickets?
N/A

Follow-up to https://github.com/mitodl/ol-infrastructure/pull/5162. That PR was squash-merged while this second commit was still in flight, so only its memory-headroom changes landed on `main` — these EFS/EKS changes were never merged and are re-proposed here on top of the updated `main`.

### Description (What does it do?)

The `PodCrashLoopingCritical` pages for `efs-csi-node` in `applications-production` were the highest-frequency alert in the recent Rootly batch, and unlike the rest of that batch they are **not** OOM kills.

`efs-plugin` logs a complete, clean startup on every cycle and then dies silently — no error line, no shutdown line, zero error entries across 2,214 log lines in 12h, and memory flat at ~24Mi. The kill comes from outside the process. The `liveness-probe` sidecar shows it:

```
"Health check failed" err="rpc error: code = Canceled desc = context canceled"
"Failed to establish connection to CSI driver" err="context deadline exceeded"
"Lost connection" address="unix:///csi/csi.sock"
```

The kubelet kills `efs-plugin` on liveness-probe failure — and only that container. Its sidecars never restart, which is the signature of a liveness probe rather than a pod-level fault.

It is entirely confined to one cluster:

| Cluster | efs-plugin restarts / 24h | Addon version | configurationValues |
|---|---|---|---|
| **applications-production** | **~345** | v3.4.1-eksbuild.1 | none |
| data-production | 0 | v3.4.1-eksbuild.1 | none |
| operations-production | 0 | v3.4.1-eksbuild.1 | none |
| residential-production | 0 | v3.4.1-eksbuild.1 | none |

All four clusters are byte-identical in addon version and config, every node in the DaemonSet is affected, and the EBS CSI driver is unaffected. Ruled out: mount count (apps-prod has 5 EFS PVCs; data-prod has 4 with zero restarts), node pressure (no MemoryPressure/DiskPressure/PIDPressure anywhere in the fleet), and driver CPU (0.004–0.017 cores).

So the **trigger** is environmental to `applications-production`, not a configuration difference — see Additional Context. What this PR fixes is the two defects that let an environmental hiccup turn into a 345-restarts-per-day crashloop.

**1. The addon was installed with no `configuration_values`,** so the node DaemonSet inherited the addon defaults:

- `resources: {}` → `efs-plugin` runs in **BestEffort QoS** (no requests, no limits — first in line to be starved). Confirmed via its cgroup path, `/kubepods.slice/kubepods-besteffort.slice/...`.
- liveness probe `periodSeconds: 2`, `timeoutSeconds: 3`, `failureThreshold: 5` → only **~10s** of unresponsiveness before the kubelet kills it.

Requests (not limits) move the container to Burstable so it has a guaranteed CPU share, and the probe is widened to **~50s** of grace — still restarts a genuinely wedged driver, but not one merely slow to answer under node contention.

**2. `get_eks_addon_version()` ignored the version pins entirely.** It ended with `return sorted(versions, reverse=True)[0]` — always the newest version AWS offers for the cluster's Kubernetes version. `EFS_CSI_DRIVER_VERSION` / `EBS_CSI_DRIVER_VERSION` fed the `VERSIONS` dict in [`eks/__main__.py`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/infrastructure/aws/eks/__main__.py) but were never passed to the `eks.Addon` resource, so both CSI addons silently tracked latest:

| Addon | Pinned in `versions.py` | Actually running in prod |
|---|---|---|
| aws-efs-csi-driver | `v2.1.6-eksbuild.1` | `v3.4.1-eksbuild.1` |
| aws-ebs-csi-driver | `v1.40.1-eksbuild.1` | `v1.63.0-eksbuild.1` |

That is a **v2 → v3 major version jump applied to all four production clusters with no PR, no review, and no staged rollout** — and it was invisible in code review, because the pins look authoritative in `versions.py`.

`get_eks_addon_version()` now takes an optional `pinned_version`, validates that AWS actually offers it for the cluster version, and raises `ValueError` rather than silently falling back to latest. **The pins are updated to the versions running in production today, so this is a no-op rollout, not a major-version downgrade.**

### How can this be tested?

The `configuration_values` payload was validated against the live AWS addon schema. This used the read-only `describe-addon-configuration` API plus local `jsonschema` validation — deliberately not `aws eks update-addon --dry-run`, which is a mutating verb:

```
OK: validates against the v3.4.1-eksbuild.1 addon schema
OK: the literal payload in eks/__main__.py also validates

probe grace before: 10s (period 2 x threshold 5)
probe grace after : 50s (period 10 x threshold 5)
```

Version resolution was exercised against the real EKS API:

```
aws-efs-csi-driver
  pin      -> v3.4.1-eksbuild.1
  unpinned -> v3.4.1-eksbuild.1   (== deployed today, so this is a no-op rollout)
aws-ebs-csi-driver
  pin      -> v1.63.0-eksbuild.1
  unpinned -> v1.63.0-eksbuild.1  (== deployed today, so this is a no-op rollout)

bad pin raises ValueError (no silent fallback):
  Pinned version v9.9.9-eksbuild.1 of EKS addon aws-efs-csi-driver is not
  available for Kubernetes 1.33. Available versions: ...
```

Rebased onto current `main` and re-validated there: `201 passed`, pre-commit / ruff / mypy clean.

To confirm what any cluster is actually running versus what is pinned (read-only):

```bash
aws eks describe-addon --cluster-name <cluster> --addon-name aws-efs-csi-driver \
  --query 'addon.{version:addonVersion,config:configurationValues}'
```

**Reviewer validation — please run `pulumi preview` on the EKS stacks before merging.** I could not run it locally (needs live credentials against the production stacks). Expect an in-place addon update adding `configurationValues`, and **no version change**. If the preview shows a version change, stop and investigate — it means the pin does not match what that cluster is running.

After deploy, the restart counter should flatten:

```promql
sum by (cluster) (increase(kube_pod_container_status_restarts_total{
  namespace="kube-system", container="efs-plugin"}[24h]))
```

### Additional Context

**The environmental trigger specific to `applications-production` is still unidentified.** Identical addon version, identical (empty) config, every node affected, and it is the only one of four clusters with any restarts at all. Isolating it needs `kubectl describe pod` or kubelet logs on one of those nodes, which I could not reach from the metrics/logs side.

This PR removes the fragility that converts a transient hiccup into a sustained crashloop (BestEffort QoS and a 10-second probe grace) and removes the silent version drift, but it does not claim to have found the underlying trigger. If restarts continue after rollout, kubelet logs on an affected node are the next thread to pull — worth watching the restart counter for a day post-deploy rather than assuming this closes it.

Note also that the version-pin fix changes behaviour for **both** CSI addons, not just EFS, since both call the same helper. Any other caller of `get_eks_addon_version()` that omits `pinned_version` keeps the previous track-latest behaviour unchanged.
