### PR TITLE
fix(concourse): grant glue:GetTags to infra worker role

### DIFF
--- a/src/ol_infrastructure/applications/concourse/iam_policies/pulumi_infra.py
+++ b/src/ol_infrastructure/applications/concourse/iam_policies/pulumi_infra.py
@@ -258,6 +258,10 @@ policy_definition = {
                 "glue:CreateDatabase",
                 "glue:DeleteDatabase",
                 "glue:GetDatabase",
+                # The AWS provider reads tags on every Glue database refresh,
+                # even though CatalogDatabase sets none -- without this, refresh
+                # fails closed and the data-warehouse stacks can't deploy.
+                "glue:GetTags",
                 "glue:UpdateDatabase",
                 "iam:GetGroup",
                 "iam:GetInstanceProfile",


### PR DESCRIPTION
## What

Adds `glue:GetTags` to the infra worker's least-privilege `pulumi_infra` policy.

## Why

The AWS provider issues `glue:GetTags` on **every** Glue database refresh to detect
tag drift — even though `CatalogDatabase` in the data-warehouse stack sets no tags
at all. Without the grant the refresh fails closed:

```
AccessDeniedException: User: .../concourse-instance-role-worker-infra-production-...
is not authorized to perform: glue:GetTags on resource:
arn:aws:glue:us-east-1:...:database/ol_warehouse_ci_raw
```

`deploy-ol-infrastructure-data-warehouse-{ci,production}` could not run at all. This
is the last gap left over from replacing the infra worker's `AdministratorAccess`
with the least-privilege policy in aacad3609.

## How it was found

Swept every failed infrastructure deploy from today (137 distinct jobs) for
`not authorized to perform:` and collected the action names. Exactly two came back:

| Action | Verdict |
|---|---|
| `glue:GetTags` | Real gap — fixed here |
| `iam:CreatePolicyVersion` on `/ol-security-boundaries/concourse/*` | **Not a gap.** The self-management guard working as intended — the worker is deliberately barred from editing its own permissions boundary. Applied out-of-band instead. |

## Blast radius

`glue` is already among the permissions boundary's service wildcards and `GetTags`
is not an `iam:` action, so the derived boundary document is **unchanged** and needs
no privileged re-apply on account of this change.

## Verification

- `pre-commit run --files ...` — all hooks pass (ruff format, ruff check, mypy, detect-secrets)
- `pytest -k 'iam or policy'` — passes
- Parliament lint with the real suppression config — both chunks **PASS**
- Policy still splits into 2 chunks under the 6000-byte cap: **5777** and **5417** bytes

⚠️ Chunk 0 is at 5777/6000 — roughly **223 bytes of headroom**. The next action added
here will likely force a third chunk, which means new policy ARNs and another
privileged re-apply.

## Related

This landed while reconciling Pulumi state drift from the same IAM regression: the
missing `s3:GetBucketTagging` caused `refresh` to treat 46 S3 buckets across 24
stacks as deleted and purge them from state. All buckets still exist in AWS — no
data loss. `data-warehouse` specifically could not self-heal because it died at this
`glue:GetTags` refresh before ever reaching the create step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)