### PR TITLE
fix(concourse): grant s3:ListBucket to infra worker role

### DIFF
--- a/src/ol_infrastructure/applications/concourse/iam_policies/pulumi_infra.py
+++ b/src/ol_infrastructure/applications/concourse/iam_policies/pulumi_infra.py
@@ -335,6 +335,15 @@ policy_definition = {
                 "s3:GetLifecycleConfiguration",
                 "s3:GetReplicationConfiguration",
                 "s3:ListAllMyBuckets",
+                # The provider reads every aws:s3:Bucket via HeadBucket, which
+                # authorizes as s3:ListBucket. A 403 there has an empty response
+                # body, so it is indistinguishable from a 404: the provider
+                # treats the bucket as gone and refresh silently DELETES it from
+                # state, with no AccessDenied anywhere in the log. The next run
+                # then tries to recreate a bucket that still exists. Only
+                # mitol-pulumi-state and a couple of operations buckets are
+                # covered by ListBucket* elsewhere, so it must be granted here.
+                "s3:ListBucket",
                 "s3:PutBucketCORS",
                 "s3:PutBucketLogging",
                 "s3:PutBucketOwnershipControls",


### PR DESCRIPTION
## This is the actual cause of the S3 state drops — and it is still live

The AWS provider reads every `aws:s3:Bucket` via **`HeadBucket`**, which authorizes
as **`s3:ListBucket`**. A 403 from `HeadBucket` has an **empty response body**, so it
is indistinguishable from a 404. The provider concludes the bucket is gone and
`pulumi refresh` **silently deletes it from state** — no `AccessDenied`, no error,
just:

```
 -  aws:s3:Bucket ol_data_lake_s3_bucket_raw-bucket deleted (1s)
Resources:
    - 10 deleted
    71 unchanged
```

The next run then tries to create a bucket that still exists and fails.

## Why it was missed

`s3:ListBucket*` **is** granted — but only scoped to `mitol-pulumi-state`
(`pulumi_state`) and `*-edxapp-mfe` / `ol-eng-artifacts` (`operations`). Every other
bucket resolves to `implicitDeny`. Confirmed with the IAM simulator against a real
bucket:

| Action | Decision |
|---|---|
| `s3:ListBucket` on `ol-data-lake-raw-ci` | **implicitDeny** |
| `s3:GetBucketTagging` | allowed |
| `s3:GetBucketVersioning` | allowed |

The earlier `s3:GetBucketTagging` grant (4b82226e2) was necessary but **not
sufficient**, and actively masked this — the tagging denial was visible in build
logs, while the `HeadBucket` one never surfaces. Buckets kept being purged after
that fix landed: 10 data-lake buckets were dropped again from `data-warehouse/CI`
as recently as build #53.

## The asymmetry worth remembering

Every **child** resource refreshes fine — `BucketVersioning`,
`BucketPublicAccessBlock`, `BucketOwnershipControls`, `BucketLifecycleConfiguration`,
`BucketServerSideEncryptionConfiguration` — because each reads through an API that
returns a real `AccessDenied`. **Only the parent `Bucket` disappears, and only
silently.** Any future audit that greps build logs for `not authorized` will miss
this class of failure entirely.

## Impact

46 `aws:s3/bucket:Bucket` resources across 24 stacks were purged from state,
including all 10 data-lake buckets in **both** `data-warehouse/CI` and
`data-warehouse/Production`. **No data was lost** — every bucket still exists in
AWS; only Pulumi state was corrupted.

State restoration cannot hold until this lands, since each pipeline run re-drops the
buckets. Restores applied earlier today were undone within the hour by exactly this.

## Verification

- `pre-commit` — all hooks pass (ruff format, ruff check, mypy, detect-secrets)
- Parliament lint with the real suppression config — both chunks **PASS**
- Still splits into 2 chunks under the 6000-byte cap: **5777** and **5433** bytes
- `glue:GetTags` from #5165 confirmed still present

⚠️ Chunk 0 remains at 5777/6000 — ~223 bytes of headroom. The next action added here
will likely force a third chunk, meaning new policy ARNs and another privileged
re-apply.

## Follow-up

Needs a privileged `pulumi up` on the concourse stack (CI/QA/Production) to take
effect, since the worker cannot update its own permissions boundary by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)