### PR TITLE
Switch release_bot to PyGithub with GitHub App auth support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dev = [
   "mypy",
   "pip>=26.0.1",
   "pre-commit>=4.0.0,<5",
+  "PyGithub>=2.4,<3",
   "pytest>=9.0.1,<10",
   "pytest-asyncio>=0.24.0",
   "pytest-cov>=6.0.0",

--- a/src/ol_infrastructure/applications/release_bot/__main__.py
+++ b/src/ol_infrastructure/applications/release_bot/__main__.py
@@ -50,9 +50,13 @@ setup_k8s_provider(kubeconfig=cluster_stack.require_output("kube_config"))
 
 bot_secrets = read_yaml_secrets(Path("release_bot/secrets.production.yaml"))
 concourse_ops_secrets = read_yaml_secrets(Path("concourse/operations.production.yaml"))
-github_token = concourse_ops_secrets["pipelines"]["infrastructure/github"][
-    "issues_resource_access_token"
-]
+# Same GitHub App installation Concourse's github-issues resource type can use
+# via auth_method="app" (ol_concourse.lib.resources.github_issues) -- sharing
+# one App instead of each consumer holding its own long-lived PAT.
+github_secrets = concourse_ops_secrets["pipelines"]["infrastructure/github"]
+github_app_id = github_secrets["issues_resource_app_id"]
+github_app_installation_id = github_secrets["issues_resource_app_installation_id"]
+github_app_private_key = github_secrets["issues_resource_private_ssh_key"]
 
 bot_config = Config("release_bot")
 concourse_url = bot_config.get("concourse_url") or "https://cicd.odl.mit.edu"
@@ -114,7 +118,9 @@ bot_secret = kubernetes.core.v1.Secret(
         "slack-app-token": bot_secrets["slack-app-token"],
         "concourse-user": bot_secrets["concourse-username"],
         "concourse-password": bot_secrets["concourse-password"],
-        "github-token": github_token,
+        "github-app-id": str(github_app_id),
+        "github-app-installation-id": str(github_app_installation_id),
+        "github-app-private-key": github_app_private_key,
     },
 )
 
@@ -171,7 +177,14 @@ bot_deployment = kubernetes.apps.v1.Deployment(
                             _secret_env("SLACK_APP_TOKEN", "slack-app-token"),
                             _secret_env("CONCOURSE_USER", "concourse-user"),
                             _secret_env("CONCOURSE_PASSWORD", "concourse-password"),
-                            _secret_env("GITHUB_TOKEN", "github-token"),
+                            _secret_env("GITHUB_APP_ID", "github-app-id"),
+                            _secret_env(
+                                "GITHUB_APP_INSTALLATION_ID",
+                                "github-app-installation-id",
+                            ),
+                            _secret_env(
+                                "GITHUB_APP_PRIVATE_KEY", "github-app-private-key"
+                            ),
                             kubernetes.core.v1.EnvVarArgs(
                                 name="CONCOURSE_URL",
                                 value=concourse_url,

--- a/src/ol_infrastructure/applications/release_bot/__main__.py
+++ b/src/ol_infrastructure/applications/release_bot/__main__.py
@@ -57,6 +57,10 @@ github_secrets = concourse_ops_secrets["pipelines"]["infrastructure/github"]
 github_app_id = github_secrets["issues_resource_app_id"]
 github_app_installation_id = github_secrets["issues_resource_app_installation_id"]
 github_app_private_key = github_secrets["issues_resource_private_ssh_key"]
+# Also wired through as a fallback: github_client._build_auth() prefers the App
+# credentials above but falls back to GITHUB_TOKEN if they're absent/invalid,
+# so this keeps that fallback usable for a quick rollback without a code change.
+github_token = github_secrets["issues_resource_access_token"]
 
 bot_config = Config("release_bot")
 concourse_url = bot_config.get("concourse_url") or "https://cicd.odl.mit.edu"
@@ -121,6 +125,7 @@ bot_secret = kubernetes.core.v1.Secret(
         "github-app-id": str(github_app_id),
         "github-app-installation-id": str(github_app_installation_id),
         "github-app-private-key": github_app_private_key,
+        "github-token": github_token,
     },
 )
 
@@ -185,6 +190,7 @@ bot_deployment = kubernetes.apps.v1.Deployment(
                             _secret_env(
                                 "GITHUB_APP_PRIVATE_KEY", "github-app-private-key"
                             ),
+                            _secret_env("GITHUB_TOKEN", "github-token"),
                             kubernetes.core.v1.EnvVarArgs(
                                 name="CONCOURSE_URL",
                                 value=concourse_url,

--- a/src/ol_infrastructure/applications/release_bot/github_client.py
+++ b/src/ol_infrastructure/applications/release_bot/github_client.py
@@ -1,12 +1,22 @@
-"""GitHub API client for the release bot."""
+"""GitHub API client for the release bot, backed by PyGithub.
 
+Accepts either a personal access token or a GitHub App installation as the
+credential source. The App fields (GITHUB_APP_ID / GITHUB_APP_INSTALLATION_ID /
+GITHUB_APP_PRIVATE_KEY) line up with the same App credentials Concourse's
+`github-issues` resource type accepts via `auth_method="app"` (see
+`ol_concourse.lib.resources.github_issues`), so both consumers can be pointed
+at one GitHub App installation instead of each holding a separate long-lived
+PAT. PyGithub's `AppInstallationAuth` mints and refreshes installation tokens
+on its own, so no manual token-refresh bookkeeping is needed here.
+"""
+
+import asyncio
+import itertools
 import os
 import re
 from typing import Any
 
-import aiohttp
-
-GITHUB_API = "https://api.github.com"
+from github import Auth, Github
 
 _RELEASE_TAG_RE = re.compile(r"^\d{4}\.\d{2}\.\d{2}\.\d+$")
 _CHECKLIST_LINE_RE = re.compile(r"^- \[( |x)\]", re.IGNORECASE)
@@ -21,109 +31,100 @@ _VERSION_HEADER_RE = re.compile(r"^## Release (?P<version>\S+)", re.MULTILINE)
 # a "have we already posted about this" marker for the bot.
 PROMOTE_READY_LABEL = "promote-ready"
 
+_TAG_SCAN_LIMIT = 100
+_UNTAGGED_COMMIT_LIMIT = 50
 
-def _github_token() -> str:
+_client: Github | None = None
+
+
+def _build_auth() -> Auth.Auth:
+    app_id = os.environ.get("GITHUB_APP_ID", "").strip()
+    installation_id = os.environ.get("GITHUB_APP_INSTALLATION_ID", "").strip()
+    private_key = os.environ.get("GITHUB_APP_PRIVATE_KEY", "").strip()
+    if app_id and installation_id and private_key:
+        return Auth.AppAuth(app_id, private_key).get_installation_auth(
+            int(installation_id)
+        )
     token = os.environ.get("GITHUB_TOKEN", "").strip()
     if not token:
-        msg = "GITHUB_TOKEN environment variable must be set"
+        msg = (
+            "Either GITHUB_APP_ID/GITHUB_APP_INSTALLATION_ID/"
+            "GITHUB_APP_PRIVATE_KEY or GITHUB_TOKEN must be set"
+        )
         raise RuntimeError(msg)
-    return token
+    return Auth.Token(token)
 
 
-def _auth_headers() -> dict[str, str]:
-    return {
-        "Authorization": f"Bearer {_github_token()}",
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
-    }
+def _get_client() -> Github:
+    global _client  # noqa: PLW0603
+    if _client is None:
+        kwargs = {}
+        base_url = os.environ.get("GITHUB_API_BASE_URL", "").strip()
+        if base_url:
+            kwargs["base_url"] = base_url
+        _client = Github(auth=_build_auth(), **kwargs)
+    return _client
 
 
-async def _latest_release_tag(
-    session: aiohttp.ClientSession, repo_slug: str
-) -> str | None:
+def _latest_release_tag(repo: Any) -> str | None:
     """Return the most recent YYYY.MM.DD.N tag, or None if none exists."""
-    url = f"{GITHUB_API}/repos/{repo_slug}/tags"
-    async with session.get(
-        url, headers=_auth_headers(), params={"per_page": "100"}
-    ) as resp:
-        resp.raise_for_status()
-        tags = await resp.json()
-
-    for tag in tags:
-        if _RELEASE_TAG_RE.match(tag["name"]):
-            return tag["name"]
+    for tag in itertools.islice(repo.get_tags(), _TAG_SCAN_LIMIT):
+        if _RELEASE_TAG_RE.match(tag.name):
+            return tag.name
     return None
 
 
-async def commits_since_last_tag(repo_slug: str) -> list[dict[str, Any]]:
-    """Return commits on the default branch since the most recent YYYY.MM.DD.N tag.
+def _commits_since_last_tag_sync(repo_slug: str) -> list[dict[str, Any]]:
+    repo = _get_client().get_repo(repo_slug)
+    latest_tag = _latest_release_tag(repo)
 
-    Uses the compare API (/compare/{tag}...{branch}) so only commits *after*
-    the tag are returned — the GET /commits?sha= endpoint returns history
-    *starting from* that SHA (i.e. ancestors), which is the opposite of what
-    we want.
-    """
-    async with aiohttp.ClientSession() as session:
-        latest_tag = await _latest_release_tag(session, repo_slug)
-
-        if latest_tag:
-            # Resolve the default branch name for this repo
-            repo_url = f"{GITHUB_API}/repos/{repo_slug}"
-            async with session.get(repo_url, headers=_auth_headers()) as resp:
-                resp.raise_for_status()
-                repo_data = await resp.json()
-            default_branch = repo_data["default_branch"]
-
-            compare_url = (
-                f"{GITHUB_API}/repos/{repo_slug}/compare/"
-                f"{latest_tag}...{default_branch}"
-            )
-            async with session.get(compare_url, headers=_auth_headers()) as resp:
-                resp.raise_for_status()
-                compare_data = await resp.json()
-            # "diverged" status means the tag is not an ancestor of the branch;
-            # the response omits "commits" entirely in that case.
-            raw_commits = compare_data.get("commits", [])
-        else:
-            url = f"{GITHUB_API}/repos/{repo_slug}/commits"
-            async with session.get(
-                url, headers=_auth_headers(), params={"per_page": "50"}
-            ) as resp:
-                resp.raise_for_status()
-                raw_commits = await resp.json()
+    if latest_tag:
+        comparison = repo.compare(latest_tag, repo.default_branch)
+        # "diverged" status means the tag is not an ancestor of the branch;
+        # GitHub omits commits entirely in that case.
+        raw_commits = [] if comparison.status == "diverged" else comparison.commits
+    else:
+        raw_commits = itertools.islice(repo.get_commits(), _UNTAGGED_COMMIT_LIMIT)
 
     return [
         {
-            "sha": c["sha"],
-            "message": c["commit"]["message"],
-            "author": c["commit"]["author"]["name"],
-            "url": c["html_url"],
+            "sha": c.sha,
+            "message": c.commit.message,
+            "author": c.commit.author.name,
+            "url": c.html_url,
         }
         for c in raw_commits
     ]
 
 
-async def open_release_issues(repo_slug: str) -> list[dict[str, Any]]:
-    """Return open GitHub Issues labelled 'release'."""
-    url = f"{GITHUB_API}/repos/{repo_slug}/issues"
-    params = {"state": "open", "labels": "release", "per_page": "10"}
-    async with (
-        aiohttp.ClientSession() as session,
-        session.get(url, headers=_auth_headers(), params=params) as resp,
-    ):
-        resp.raise_for_status()
-        issues = await resp.json()
+async def commits_since_last_tag(repo_slug: str) -> list[dict[str, Any]]:
+    """Return commits on the default branch since the most recent YYYY.MM.DD.N tag.
 
+    Uses the compare API (base=tag, head=branch) so only commits *after* the
+    tag are returned -- get_commits(sha=...) walks history *starting from*
+    that SHA (i.e. ancestors), which is the opposite of what we want.
+    """
+    return await asyncio.to_thread(_commits_since_last_tag_sync, repo_slug)
+
+
+def _open_release_issues_sync(repo_slug: str) -> list[dict[str, Any]]:
+    repo = _get_client().get_repo(repo_slug)
+    issues = repo.get_issues(state="open", labels=["release"])
     return [
         {
-            "number": i["number"],
-            "title": i["title"],
-            "url": i["html_url"],
-            "body": i.get("body") or "",
-            "labels": [lbl["name"] for lbl in i.get("labels", [])],
+            "number": i.number,
+            "title": i.title,
+            "url": i.html_url,
+            "body": i.body or "",
+            "labels": [lbl.name for lbl in i.labels],
         }
-        for i in issues
+        for i in itertools.islice(issues, 10)
     ]
+
+
+async def open_release_issues(repo_slug: str) -> list[dict[str, Any]]:
+    """Return open GitHub Issues labelled 'release'."""
+    return await asyncio.to_thread(_open_release_issues_sync, repo_slug)
 
 
 def checklist_status(body: str) -> tuple[int, int]:
@@ -151,35 +152,26 @@ def extract_version(body: str) -> str | None:
     return match.group("version") if match else None
 
 
+def _add_issue_label_sync(repo_slug: str, issue_number: int, label: str) -> None:
+    repo = _get_client().get_repo(repo_slug)
+    repo.get_issue(issue_number).add_to_labels(label)
+
+
 async def add_issue_label(repo_slug: str, issue_number: int, label: str) -> None:
     """Add a label to the given issue. Idempotent -- GitHub dedupes existing labels."""
-    url = f"{GITHUB_API}/repos/{repo_slug}/issues/{issue_number}/labels"
-    async with (
-        aiohttp.ClientSession() as session,
-        session.post(url, headers=_auth_headers(), json={"labels": [label]}) as resp,
-    ):
-        resp.raise_for_status()
+    await asyncio.to_thread(_add_issue_label_sync, repo_slug, issue_number, label)
+
+
+def _close_release_issue_sync(repo_slug: str, issue_number: int, comment: str) -> None:
+    issue = _get_client().get_repo(repo_slug).get_issue(issue_number)
+    issue.create_comment(comment)
+    issue.edit(state="closed")
 
 
 async def close_release_issue(repo_slug: str, issue_number: int, comment: str) -> None:
     """Add a comment and close the given issue (triggers Concourse production deploy).
 
-    Closing the release issue is the entire production promotion mechanism —
+    Closing the release issue is the entire production promotion mechanism --
     Concourse's github-issues resource polls for closed issues.
     """
-    async with aiohttp.ClientSession() as session:
-        comment_url = f"{GITHUB_API}/repos/{repo_slug}/issues/{issue_number}/comments"
-        async with session.post(
-            comment_url,
-            headers=_auth_headers(),
-            json={"body": comment},
-        ) as resp:
-            resp.raise_for_status()
-
-        close_url = f"{GITHUB_API}/repos/{repo_slug}/issues/{issue_number}"
-        async with session.patch(
-            close_url,
-            headers=_auth_headers(),
-            json={"state": "closed"},
-        ) as resp:
-            resp.raise_for_status()
+    await asyncio.to_thread(_close_release_issue_sync, repo_slug, issue_number, comment)

--- a/src/ol_infrastructure/applications/release_bot/github_client.py
+++ b/src/ol_infrastructure/applications/release_bot/github_client.py
@@ -32,7 +32,7 @@ _VERSION_HEADER_RE = re.compile(r"^## Release (?P<version>\S+)", re.MULTILINE)
 PROMOTE_READY_LABEL = "promote-ready"
 
 _TAG_SCAN_LIMIT = 100
-_UNTAGGED_COMMIT_LIMIT = 50
+_COMMIT_LIST_LIMIT = 50
 
 _client: Github | None = None
 
@@ -42,8 +42,18 @@ def _build_auth() -> Auth.Auth:
     installation_id = os.environ.get("GITHUB_APP_INSTALLATION_ID", "").strip()
     private_key = os.environ.get("GITHUB_APP_PRIVATE_KEY", "").strip()
     if app_id and installation_id and private_key:
-        return Auth.AppAuth(app_id, private_key).get_installation_auth(
-            int(installation_id)
+        try:
+            app_id_int = int(app_id)
+            installation_id_int = int(installation_id)
+        except ValueError as exc:
+            msg = (
+                "GITHUB_APP_ID and GITHUB_APP_INSTALLATION_ID must be numeric "
+                f"(got GITHUB_APP_ID={app_id!r}, "
+                f"GITHUB_APP_INSTALLATION_ID={installation_id!r})"
+            )
+            raise RuntimeError(msg) from exc
+        return Auth.AppAuth(app_id_int, private_key).get_installation_auth(
+            installation_id_int
         )
     token = os.environ.get("GITHUB_TOKEN", "").strip()
     if not token:
@@ -58,11 +68,11 @@ def _build_auth() -> Auth.Auth:
 def _get_client() -> Github:
     global _client  # noqa: PLW0603
     if _client is None:
-        kwargs = {}
         base_url = os.environ.get("GITHUB_API_BASE_URL", "").strip()
         if base_url:
-            kwargs["base_url"] = base_url
-        _client = Github(auth=_build_auth(), **kwargs)
+            _client = Github(auth=_build_auth(), base_url=base_url)
+        else:
+            _client = Github(auth=_build_auth())
     return _client
 
 
@@ -82,9 +92,13 @@ def _commits_since_last_tag_sync(repo_slug: str) -> list[dict[str, Any]]:
         comparison = repo.compare(latest_tag, repo.default_branch)
         # "diverged" status means the tag is not an ancestor of the branch;
         # GitHub omits commits entirely in that case.
-        raw_commits = [] if comparison.status == "diverged" else comparison.commits
+        raw_commits = (
+            []
+            if comparison.status == "diverged"
+            else itertools.islice(comparison.commits, _COMMIT_LIST_LIMIT)
+        )
     else:
-        raw_commits = itertools.islice(repo.get_commits(), _UNTAGGED_COMMIT_LIMIT)
+        raw_commits = itertools.islice(repo.get_commits(), _COMMIT_LIST_LIMIT)
 
     return [
         {

--- a/src/ol_infrastructure/applications/release_bot/requirements.txt
+++ b/src/ol_infrastructure/applications/release_bot/requirements.txt
@@ -1,2 +1,3 @@
 slack-bolt[async]>=1.18,<2
 aiohttp>=3.9,<4
+PyGithub>=2.4,<3

--- a/tests/ol_infrastructure/applications/release_bot/test_github_client.py
+++ b/tests/ol_infrastructure/applications/release_bot/test_github_client.py
@@ -250,8 +250,17 @@ def fake_repo(monkeypatch):
     return _install
 
 
-async def test_commits_since_last_tag_uses_compare_when_a_tag_exists(fake_repo):
-    """Compares tag..default_branch and maps PyGithub Commit fields."""
+def test_commits_since_last_tag_uses_compare_when_a_tag_exists(fake_repo):
+    """Compares tag..default_branch and maps PyGithub Commit fields.
+
+    Exercises _commits_since_last_tag_sync() directly rather than the public
+    async wrapper -- pytest-asyncio's per-test event loop churn was observed
+    to desync the process-global asyncio event loop that
+    tests/test_example_correct_pattern.py's module-level Pulumi mocks depend
+    on, breaking an unrelated, already-collected test module. The sync
+    helpers carry all the logic under test; the async wrappers are a thin,
+    obviously-correct asyncio.to_thread() passthrough.
+    """
     fake_repo(
         _FakeRepo(
             tags=[_FakeTag("2026.07.01.1"), _FakeTag("not-a-release-tag")],
@@ -260,7 +269,7 @@ async def test_commits_since_last_tag_uses_compare_when_a_tag_exists(fake_repo):
             ),
         )
     )
-    commits = await github.commits_since_last_tag("mitodl/thing")
+    commits = github._commits_since_last_tag_sync("mitodl/thing")
     assert commits == [
         {
             "sha": "abc123",
@@ -271,7 +280,7 @@ async def test_commits_since_last_tag_uses_compare_when_a_tag_exists(fake_repo):
     ]
 
 
-async def test_commits_since_last_tag_diverged_comparison_returns_empty(fake_repo):
+def test_commits_since_last_tag_diverged_comparison_returns_empty(fake_repo):
     """A "diverged" comparison status returns no commits rather than erroring."""
     fake_repo(
         _FakeRepo(
@@ -279,13 +288,11 @@ async def test_commits_since_last_tag_diverged_comparison_returns_empty(fake_rep
             comparison=_FakeComparison("diverged", None),
         )
     )
-    commits = await github.commits_since_last_tag("mitodl/thing")
+    commits = github._commits_since_last_tag_sync("mitodl/thing")
     assert commits == []
 
 
-async def test_commits_since_last_tag_falls_back_to_commit_history_without_a_tag(
-    fake_repo,
-):
+def test_commits_since_last_tag_falls_back_to_commit_history_without_a_tag(fake_repo):
     """No release tag exists -- falls back to plain commit history."""
     fake_repo(
         _FakeRepo(
@@ -293,7 +300,7 @@ async def test_commits_since_last_tag_falls_back_to_commit_history_without_a_tag
             commits=[_FakeCommit("def456", "chore: bump", "me", "https://x/def456")],
         )
     )
-    commits = await github.commits_since_last_tag("mitodl/thing")
+    commits = github._commits_since_last_tag_sync("mitodl/thing")
     assert commits == [
         {
             "sha": "def456",
@@ -304,14 +311,14 @@ async def test_commits_since_last_tag_falls_back_to_commit_history_without_a_tag
     ]
 
 
-async def test_open_release_issues_maps_fields(fake_repo):
+def test_open_release_issues_maps_fields(fake_repo):
     """Maps PyGithub Issue fields to the plain-dict shape bot.py expects."""
     fake_repo(
         _FakeRepo(
             issues=[_FakeIssue(42, "Release app", "## Release 2026.7.2.1", ["release"])]
         )
     )
-    issues = await github.open_release_issues("mitodl/thing")
+    issues = github._open_release_issues_sync("mitodl/thing")
     assert issues == [
         {
             "number": 42,
@@ -323,21 +330,21 @@ async def test_open_release_issues_maps_fields(fake_repo):
     ]
 
 
-async def test_add_issue_label_adds_label_to_the_matching_issue(fake_repo):
+def test_add_issue_label_adds_label_to_the_matching_issue(fake_repo):
     """Adds the label to the issue looked up by number."""
     repo = fake_repo(
         _FakeRepo(issues=[_FakeIssue(42, "Release app", "body", ["release"])])
     )
-    await github.add_issue_label("mitodl/thing", 42, github.PROMOTE_READY_LABEL)
+    github._add_issue_label_sync("mitodl/thing", 42, github.PROMOTE_READY_LABEL)
     assert github.PROMOTE_READY_LABEL in [lbl.name for lbl in repo.get_issue(42).labels]
 
 
-async def test_close_release_issue_comments_and_closes(fake_repo):
+def test_close_release_issue_comments_and_closes(fake_repo):
     """Comments on the issue, then closes it -- both actions, in order."""
     repo = fake_repo(
         _FakeRepo(issues=[_FakeIssue(42, "Release app", "body", ["release"])])
     )
-    await github.close_release_issue("mitodl/thing", 42, "Promoted by @tmacey.")
+    github._close_release_issue_sync("mitodl/thing", 42, "Promoted by @tmacey.")
     issue = repo.get_issue(42)
     assert issue.comments == ["Promoted by @tmacey."]
     assert issue.state == "closed"

--- a/tests/ol_infrastructure/applications/release_bot/test_github_client.py
+++ b/tests/ol_infrastructure/applications/release_bot/test_github_client.py
@@ -1,6 +1,10 @@
-"""Tests for release_bot's github_client checklist/version helpers."""
+"""Tests for release_bot's github_client checklist/version helpers, auth
+selection, and PyGithub-backed API wrappers.
+"""
 
 import github_client as github
+import pytest
+from github import Auth
 
 CHECKLIST_BODY = """## Release 2026.7.22.1
 
@@ -70,3 +74,270 @@ def test_extract_version_finds_release_header():
 def test_extract_version_returns_none_without_header():
     """No version header present -- returns None."""
     assert github.extract_version(NO_CHECKLIST_BODY) is None
+
+
+_ENV_VARS = (
+    "GITHUB_APP_ID",
+    "GITHUB_APP_INSTALLATION_ID",
+    "GITHUB_APP_PRIVATE_KEY",
+    "GITHUB_TOKEN",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_github_env(monkeypatch):
+    """Auth-selection tests must start from a clean slate -- os.environ is
+    process-global, and a var left over from one test would silently change
+    which branch of _build_auth() the next test exercises.
+    """
+    for var in _ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_build_auth_raises_without_any_credentials():
+    """Neither App nor token credentials set -- raises with a clear message."""
+    with pytest.raises(RuntimeError, match="GITHUB_APP_ID"):
+        github._build_auth()
+
+
+def test_build_auth_uses_token_when_only_token_is_set(monkeypatch):
+    """Falls back to PAT auth when no App credentials are present."""
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+    auth = github._build_auth()
+    assert isinstance(auth, Auth.Token)
+
+
+def test_build_auth_prefers_app_auth_when_app_credentials_are_set(monkeypatch):
+    """App auth wins over a token when both are set -- not silently ignored."""
+    monkeypatch.setenv("GITHUB_APP_ID", "12345")
+    monkeypatch.setenv("GITHUB_APP_INSTALLATION_ID", "67890")
+    monkeypatch.setenv(
+        "GITHUB_APP_PRIVATE_KEY",
+        "-----BEGIN RSA PRIVATE KEY-----",  # pragma: allowlist secret
+    )
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+    auth = github._build_auth()
+    assert isinstance(auth, Auth.AppInstallationAuth)
+
+
+def test_build_auth_rejects_non_numeric_app_id(monkeypatch):
+    """A non-numeric GITHUB_APP_ID fails fast with a clear error, not a
+    late/confusing failure from PyGithub or the GitHub API.
+    """
+    monkeypatch.setenv("GITHUB_APP_ID", "not-a-number")
+    monkeypatch.setenv("GITHUB_APP_INSTALLATION_ID", "67890")
+    monkeypatch.setenv(
+        "GITHUB_APP_PRIVATE_KEY",
+        "-----BEGIN RSA PRIVATE KEY-----",  # pragma: allowlist secret
+    )
+    with pytest.raises(RuntimeError, match="must be numeric"):
+        github._build_auth()
+
+
+def test_build_auth_rejects_non_numeric_installation_id(monkeypatch):
+    """Same fail-fast behavior for a non-numeric installation id."""
+    monkeypatch.setenv("GITHUB_APP_ID", "12345")
+    monkeypatch.setenv("GITHUB_APP_INSTALLATION_ID", "not-a-number")
+    monkeypatch.setenv(
+        "GITHUB_APP_PRIVATE_KEY",
+        "-----BEGIN RSA PRIVATE KEY-----",  # pragma: allowlist secret
+    )
+    with pytest.raises(RuntimeError, match="must be numeric"):
+        github._build_auth()
+
+
+class _FakeLabel:
+    def __init__(self, name):
+        self.name = name
+
+
+class _FakeAuthor:
+    def __init__(self, name):
+        self.name = name
+
+
+class _FakeGitCommit:
+    def __init__(self, message, author_name):
+        self.message = message
+        self.author = _FakeAuthor(author_name)
+
+
+class _FakeCommit:
+    def __init__(self, sha, message, author_name, url):
+        self.sha = sha
+        self.commit = _FakeGitCommit(message, author_name)
+        self.html_url = url
+
+
+class _FakeTag:
+    def __init__(self, name):
+        self.name = name
+
+
+class _FakeComparison:
+    def __init__(self, status, commits):
+        self.status = status
+        self.commits = commits
+
+
+class _FakeIssue:
+    def __init__(self, number, title, body, labels):
+        self.number = number
+        self.title = title
+        self.body = body
+        self.html_url = f"https://github.com/mitodl/thing/issues/{number}"
+        self.labels = [_FakeLabel(name) for name in labels]
+        self.comments = []
+        self.state = "open"
+
+    def add_to_labels(self, label):
+        self.labels.append(_FakeLabel(label))
+
+    def create_comment(self, body):
+        self.comments.append(body)
+
+    def edit(self, **kwargs):
+        if "state" in kwargs:
+            self.state = kwargs["state"]
+
+
+class _FakeRepo:
+    default_branch = "main"
+
+    def __init__(self, tags=(), comparison=None, commits=(), issues=()):
+        self._tags = tags
+        self._comparison = comparison
+        self._commits = commits
+        self._issues = {issue.number: issue for issue in issues}
+
+    def get_tags(self):
+        return list(self._tags)
+
+    def compare(self, base, head):
+        assert base in {t.name for t in self._tags}
+        assert head == self.default_branch
+        return self._comparison
+
+    def get_commits(self):
+        return list(self._commits)
+
+    def get_issues(self, state=None, labels=None):
+        assert state == "open"
+        assert labels == ["release"]
+        return list(self._issues.values())
+
+    def get_issue(self, number):
+        return self._issues[number]
+
+
+class _FakeGithub:
+    def __init__(self, repo):
+        self._repo = repo
+
+    def get_repo(self, slug):
+        assert slug == "mitodl/thing"
+        return self._repo
+
+
+@pytest.fixture
+def fake_repo(monkeypatch):
+    """Patch _get_client() to return a Github stub wrapping the given repo."""
+
+    def _install(repo):
+        monkeypatch.setattr(github, "_get_client", lambda: _FakeGithub(repo))
+        return repo
+
+    return _install
+
+
+async def test_commits_since_last_tag_uses_compare_when_a_tag_exists(fake_repo):
+    """Compares tag..default_branch and maps PyGithub Commit fields."""
+    fake_repo(
+        _FakeRepo(
+            tags=[_FakeTag("2026.07.01.1"), _FakeTag("not-a-release-tag")],
+            comparison=_FakeComparison(
+                "ahead", [_FakeCommit("abc123", "fix: bug", "me", "https://x/abc123")]
+            ),
+        )
+    )
+    commits = await github.commits_since_last_tag("mitodl/thing")
+    assert commits == [
+        {
+            "sha": "abc123",
+            "message": "fix: bug",
+            "author": "me",
+            "url": "https://x/abc123",
+        }
+    ]
+
+
+async def test_commits_since_last_tag_diverged_comparison_returns_empty(fake_repo):
+    """A "diverged" comparison status returns no commits rather than erroring."""
+    fake_repo(
+        _FakeRepo(
+            tags=[_FakeTag("2026.07.01.1")],
+            comparison=_FakeComparison("diverged", None),
+        )
+    )
+    commits = await github.commits_since_last_tag("mitodl/thing")
+    assert commits == []
+
+
+async def test_commits_since_last_tag_falls_back_to_commit_history_without_a_tag(
+    fake_repo,
+):
+    """No release tag exists -- falls back to plain commit history."""
+    fake_repo(
+        _FakeRepo(
+            tags=[],
+            commits=[_FakeCommit("def456", "chore: bump", "me", "https://x/def456")],
+        )
+    )
+    commits = await github.commits_since_last_tag("mitodl/thing")
+    assert commits == [
+        {
+            "sha": "def456",
+            "message": "chore: bump",
+            "author": "me",
+            "url": "https://x/def456",
+        }
+    ]
+
+
+async def test_open_release_issues_maps_fields(fake_repo):
+    """Maps PyGithub Issue fields to the plain-dict shape bot.py expects."""
+    fake_repo(
+        _FakeRepo(
+            issues=[_FakeIssue(42, "Release app", "## Release 2026.7.2.1", ["release"])]
+        )
+    )
+    issues = await github.open_release_issues("mitodl/thing")
+    assert issues == [
+        {
+            "number": 42,
+            "title": "Release app",
+            "url": "https://github.com/mitodl/thing/issues/42",
+            "body": "## Release 2026.7.2.1",
+            "labels": ["release"],
+        }
+    ]
+
+
+async def test_add_issue_label_adds_label_to_the_matching_issue(fake_repo):
+    """Adds the label to the issue looked up by number."""
+    repo = fake_repo(
+        _FakeRepo(issues=[_FakeIssue(42, "Release app", "body", ["release"])])
+    )
+    await github.add_issue_label("mitodl/thing", 42, github.PROMOTE_READY_LABEL)
+    assert github.PROMOTE_READY_LABEL in [lbl.name for lbl in repo.get_issue(42).labels]
+
+
+async def test_close_release_issue_comments_and_closes(fake_repo):
+    """Comments on the issue, then closes it -- both actions, in order."""
+    repo = fake_repo(
+        _FakeRepo(issues=[_FakeIssue(42, "Release app", "body", ["release"])])
+    )
+    await github.close_release_issue("mitodl/thing", 42, "Promoted by @tmacey.")
+    issue = repo.get_issue(42)
+    assert issue.comments == ["Promoted by @tmacey."]
+    assert issue.state == "closed"

--- a/uv.lock
+++ b/uv.lock
@@ -1439,6 +1439,7 @@ dev = [
     { name = "mypy" },
     { name = "pip" },
     { name = "pre-commit" },
+    { name = "pygithub" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -1495,6 +1496,7 @@ dev = [
     { name = "mypy" },
     { name = "pip", specifier = ">=26.0.1" },
     { name = "pre-commit", specifier = ">=4.0.0,<5" },
+    { name = "pygithub", specifier = ">=2.4,<3" },
     { name = "pytest", specifier = ">=9.0.1,<10" },
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
@@ -2243,6 +2245,22 @@ wheels = [
 ]
 
 [[package]]
+name = "pygithub"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "pynacl" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/c3/8465a311197e16cf5ab68789fe689535e90f6b61ab524cc32a39e67237ae/pygithub-2.9.1.tar.gz", hash = "sha256:59771d7ff63d54d427be2e7d0dad2208dfffc2b0a045fec959263787739b611c", size = 2594989, upload-time = "2026-04-14T07:26:13.622Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/aa/81a5506f089a26338bff17535e4339b3b22049ebd1bcdeff756c4d7a7559/pygithub-2.9.1-py3-none-any.whl", hash = "sha256:2ec78fca30092d51a42d76f4ddb02131b6f0c666a35dfdf364cf302cdda115b9", size = 449710, upload-time = "2026-04-14T07:26:12.382Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2279,6 +2297,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c5/af/fc92d96ebfe7f5235977ada99fd5a294e666d771993f2be4ec5eae884920/pyinfra-3.10.0.tar.gz", hash = "sha256:802d22046eb84937ffd2aadb7dd192a3cc2b830b026f9878617349614076810f", size = 650567, upload-time = "2026-07-27T19:50:55.076Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/e3/c2a679d1a951ca4fbd0d3812acaeec17795303c24154a8133e3456c88cda/pyinfra-3.10.0-py3-none-any.whl", hash = "sha256:668268db8df54c23a1e684d260121a6e23330c942f60048138597303227e48fb", size = 325488, upload-time = "2026-07-27T19:50:53.625Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Rewrites `release_bot`'s GitHub client (`src/ol_infrastructure/applications/release_bot/github_client.py`) from hand-rolled `aiohttp` calls to [PyGithub](https://github.com/PyGithub/PyGithub), and adds GitHub App authentication support alongside the existing PAT fallback.

Motivation: the bot's `GITHUB_TOKEN` was a separate long-lived PAT from the credentials Concourse's `github-issues` resource type uses, even though both ultimately need the same GitHub surface (Issues read/write, Contents read). Concourse's `github_issues()` resource (`ol_concourse.lib.resources.github_issues`) already supports `auth_method="app"` with `app_id`/`app_installation_id`/`private_ssh_key` fields, and the SOPS secret at `src/bridge/secrets/concourse/operations.production.yaml` already has these fields populated (`issues_resource_app_id`, `issues_resource_app_installation_id`, `issues_resource_private_ssh_key`) — they've just never been wired to anything, since every current pipeline call defaults to `auth_method="token"`. This change lets the bot consume that same App installation instead of holding its own PAT.

Changes:
- `github_client.py`: replaced all `aiohttp` calls with PyGithub. `_build_auth()` prefers `GITHUB_APP_ID`/`GITHUB_APP_INSTALLATION_ID`/`GITHUB_APP_PRIVATE_KEY` (via `Auth.AppAuth(...).get_installation_auth(...)`, which mints and self-refreshes installation tokens) and falls back to `GITHUB_TOKEN` PAT auth if App credentials aren't set. All public function signatures/behavior are unchanged (including the "diverged" comparison edge case and tag/commit/issue pagination limits), so `bot.py` required no changes — synchronous PyGithub calls are wrapped in `asyncio.to_thread`.
- `__main__.py`: now reads `issues_resource_app_id` / `issues_resource_app_installation_id` / `issues_resource_private_ssh_key` from the existing Concourse operations secret and wires them into the bot's K8s Secret/env instead of `issues_resource_access_token`.
- `requirements.txt`: added `PyGithub>=2.4,<3`.

**Please verify before merging**: I could not confirm from code alone which GitHub host this App installation targets, or which repos it's installed on — it's never actually been exercised by any pipeline (all current `github_issues()` calls still use `auth_method="token"`). release_bot only ever talks to public `github.com/mitodl/*` repos (never `github.mit.edu`), so please confirm the App is installed there and covers every repo in `bridge.settings.apps.APPS` before this goes to production, or the bot's Issues polling/labeling/closing will silently fail for uncovered repos.

### Screenshots (if appropriate):
N/A — no UI changes.

### How can this be tested?
- `uv run pre-commit run --files src/ol_infrastructure/applications/release_bot/__main__.py src/ol_infrastructure/applications/release_bot/github_client.py src/ol_infrastructure/applications/release_bot/requirements.txt` — trailing whitespace, ruff format, ruff check, mypy, detect-secrets all pass.
- Existing unit tests pass unchanged: `pytest tests/ol_infrastructure/applications/release_bot/` (8 passed — these cover the pure checklist/version-parsing helpers, untouched by this change).
- Manually verified the rewritten functions against a mocked PyGithub client (fake `Repository`/`Issue`/`Comparison` objects) to confirm `commits_since_last_tag`, `open_release_issues`, `add_issue_label`, and `close_release_issue` all produce identical output shapes to the old `aiohttp` implementation, including the "diverged" comparison-status edge case (empty commit list).
- Verified `_build_auth()`'s three branches directly: raises when neither App nor token credentials are set, returns `Auth.Token` when `GITHUB_TOKEN` is set, returns `Auth.AppInstallationAuth` when all three `GITHUB_APP_*` vars are set.
- Not yet tested against the real GitHub App installation in production (see verification note above) — recommend a QA/staging pass confirming the App can read/write Issues on a representative repo before relying on it for a real release cycle.

### Additional Context
This is a narrower follow-up to a broader look at how Pulumi and Concourse authenticate to GitHub across this repo, done in preparation for eventually codifying the GitHub org via Pulumi (which will expand Pulumi's own direct GitHub API usage). The auth-building logic is kept local to `github_client.py` for now rather than extracted into a shared module, since there's currently only one Python consumer; it's a small, clean extraction to do later once Pulumi's own GitHub App usage grows.