### PR TITLE
fix(superset): make StarRocks reflection objects hashable

### DIFF
--- a/src/ol_infrastructure/applications/superset/superset_config.py
+++ b/src/ol_infrastructure/applications/superset/superset_config.py
@@ -718,3 +718,52 @@ def DB_CONNECTION_MUTATOR(  # noqa: N802
         database=new_database,
     )
     return uri, params
+
+
+# ---------------------------------------------------
+# STARROCKS DIALECT / SQLALCHEMY 1.4 COMPATIBILITY
+# ---------------------------------------------------
+# Reflecting any StarRocks table with a PARTITION BY clause raises
+# `TypeError: unhashable type: 'ReflectedPartitionInfo'`, which surfaces as an
+# HTTP 500 on every endpoint that has to reflect a new dataset (dataset create,
+# /get_or_create/). In production this blocked three Iceberg-partitioned
+# datasets from ever being created -- organization_administration_report,
+# tfact_problem_events, tfact_studentmodule_problems -- failing the nightly
+# Dagster sync run for 11 runs straight.
+#
+# The collision is between two upstreams, neither of which is wrong alone:
+#
+#   * SQLAlchemy 1.4's @reflection.cache builds its cache key from *every*
+#     kwarg it is handed -- `tuple((k, v) for k, v in kw.items() if k !=
+#     "info_cache")` -- and Inspector.reflect_table merges the dialect's
+#     get_table_options() result into table.dialect_kwargs before splatting
+#     them into get_columns(). (SQLAlchemy 2.0 filters that key by type, so
+#     this only bites on 1.x, which is what Superset 6 pins.)
+#   * The starrocks dialect returns its reflected table options as plain
+#     non-frozen dataclasses, so `__hash__` is None and the key can't be
+#     hashed.
+#
+# Give those dataclasses a hash derived from __str__ -- the dialect's own
+# canonical DDL rendering of the fields, so objects that compare equal always
+# hash equal. Discovered by iteration rather than by name so a dialect upgrade
+# that adds another reflected option is covered too.
+#
+# Remove once the dialect ships hashable reflection objects (or Superset moves
+# to SQLAlchemy 2.0).
+try:
+    import dataclasses
+
+    from starrocks.engine import interfaces as _starrocks_interfaces
+except ImportError:  # dialect absent or restructured -- nothing to patch
+    logging.getLogger(__name__).debug(
+        "starrocks.engine.interfaces not importable; skipping reflection shim"
+    )
+else:
+    for _name in dir(_starrocks_interfaces):
+        _candidate = getattr(_starrocks_interfaces, _name)
+        if (
+            isinstance(_candidate, type)
+            and dataclasses.is_dataclass(_candidate)
+            and _candidate.__hash__ is None
+        ):
+            _candidate.__hash__ = lambda self: hash(str(self))


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

Creating a Superset dataset for any StarRocks table with a `PARTITION BY` clause returns HTTP 500. Reflection dies on:

```
TypeError: unhashable type: 'ReflectedPartitionInfo'
```

Full traceback from a production pod (`superset-6ff49ccf5-nrp5j`, 2026-07-29 16:30:16 UTC):

```
File "/app/superset/datasets/api.py", line 1102, in get_or_create_dataset
  tbl = CreateDatasetCommand(body).run()
File "/app/superset/commands/dataset/create.py", line 84, in validate
  and not DatasetDAO.validate_table_exists(database, table)
File "/app/superset/daos/dataset.py", line 135, in validate_table_exists
  database.get_table(table)
File "/app/superset/models/core.py", line 1072, in get_table
  return SqlaTable(
File "/app/.venv/lib/python3.10/site-packages/starrocks/reflection.py", line 124, in reflect_table
  super().reflect_table(table, include_columns, exclude_columns, resolve_fks, _extend_on)
File "/app/.venv/lib/python3.10/site-packages/sqlalchemy/engine/reflection.py", line 774, in reflect_table
  for col_d in self.get_columns(
File "/app/.venv/lib/python3.10/site-packages/sqlalchemy/engine/reflection.py", line 53, in cache
  ret = info_cache.get(key)
TypeError: unhashable type: 'ReflectedPartitionInfo'
```

That 500 kept three Iceberg-partitioned datasets from ever being created, failing the nightly Dagster sync run 11 times in a row (e.g. run `06561830-271e-4ac9-990e-d2e59ff9d9ac`): `organization_administration_report`, `tfact_problem_events`, `tfact_studentmodule_problems` — which are exactly the three `mart`/`reporting`/`dimensional` dbt models that declare a `partitioning` property.

**Neither upstream is wrong on its own.** The bug is in how they meet:

- SQLAlchemy 1.4's `@reflection.cache` builds its cache key from *every* kwarg it receives — `tuple((k, v) for k, v in kw.items() if k != "info_cache")` — and `Inspector.reflect_table` merges the dialect's `get_table_options()` result into `table.dialect_kwargs` before splatting them into `get_columns()`. So whatever the dialect reports as a table option has to be hashable. SQLAlchemy 2.0 filters that key by type; 1.x, which Superset 6 pins, does not.
  ([sqlalchemy/engine/reflection.py#L43-L56](https://github.com/sqlalchemy/sqlalchemy/blob/rel_1_4_54/lib/sqlalchemy/engine/reflection.py#L43-L56))
- The `starrocks` dialect reports its reflected table options as plain non-frozen dataclasses (`ReflectedPartitionInfo`, `ReflectedDistributionInfo`, `ReflectedTableKeyInfo`, `ReflectedRefreshInfo`), so `@dataclasses.dataclass` sets `__hash__ = None` and the key can't be hashed.

This adds a startup shim to `superset_config.py` giving those dataclasses a hash derived from `__str__` — the dialect's own canonical DDL rendering of the fields, so objects that compare equal always hash equal. It's applied by iterating the `starrocks.engine.interfaces` module rather than naming classes, so a dialect upgrade that adds another reflected option is covered too, and it's wrapped in `try/except ImportError` so a dialect restructure can't stop Superset booting.

The dialect is unpinned in [`src/ol_superset/requirements.txt`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_superset/requirements.txt#L3), so builds float onto 1.3.x where these classes exist. Downgrading to `starrocks<1.3` also fixes it (1.2.x has no `ReflectedPartitionInfo` at all) but gives up ~4 months of dialect work, so the shim was preferred.

### How can this be tested?

**Automated reproduction.** The failure reproduces outside Superset with just the two production dependencies, which is how the fix was verified:

```bash
uv venv --python 3.10 /tmp/srrepro
uv pip install --python /tmp/srrepro/bin/python "sqlalchemy==1.4.54" "starrocks==1.3.3"
```

```python
import dataclasses
from starrocks.engine import interfaces

def make_cache_key():
    """The key SQLAlchemy builds for get_columns on a partitioned table."""
    partition = interfaces.ReflectedPartitionInfo(
        type="RANGE",
        partition_method="RANGE(event_timestamp)",
        pre_created_partitions=None,
    )
    return ("get_columns", ("tfact_problem_events",),
            (("starrocks_partition_by", partition),))

info_cache: dict = {}
try:
    info_cache.get(make_cache_key())
except TypeError as exc:
    print(f"BEFORE shim: TypeError: {exc}")

# The shim, exactly as superset_config.py applies it.
for name in dir(interfaces):
    candidate = getattr(interfaces, name)
    if (isinstance(candidate, type) and dataclasses.is_dataclass(candidate)
            and candidate.__hash__ is None):
        candidate.__hash__ = lambda self: hash(str(self))

key = make_cache_key()
assert info_cache.get(key) is None
info_cache[key] = ["a_column"]
assert info_cache.get(make_cache_key()) == ["a_column"], "equal keys must collide"
print("AFTER shim:  cache get/set works, equal keys hit the same entry")
```

Output:

```
BEFORE shim: TypeError: unhashable type: 'ReflectedPartitionInfo'
AFTER shim:  cache get/set works, equal keys hit the same entry
```

The shim patches 7 dataclasses (`ReflectedDistributionInfo`, `ReflectedMVState`, `ReflectedPartitionInfo`, `ReflectedRefreshInfo`, `ReflectedState`, `ReflectedTableKeyInfo`, `ReflectedViewState`). `__eq__`/`__hash__` consistency was checked on all 5 that can be constructed without guessing nested field types.

**Validation run:**

```
uv run pre-commit run --files src/ol_infrastructure/applications/superset/superset_config.py
  ruff format ... Passed
  ruff check .... Passed
  mypy .......... Passed

uv run pytest tests/ol_infrastructure/
  175 passed

SUPERSET_IMAGE_TAG=6184d0d69 pulumi preview --stack Production
  ~ kubernetes:helm.sh/v3:Release superset-helm-release update [diff: ~values]
  Resources: ~ 1 to update, 92 unchanged
```

**Reviewer validation after deploy.** In Superset, add a dataset against the StarRocks database for a partitioned table (e.g. schema `ol_warehouse_production_dimensional`, table `tfact_problem_events`). Before this change that returns a 500 "Fatal error"; after, the dataset is created. Or just watch the next nightly Dagster asset run — the three `superset/starrocks/dataset/*` assets listed above should stop failing.

### Additional Context

**Deploy ordering.** This is the server-side half of a two-repo fix. The companion PR is mitodl/ol-data-platform#2491, which fixes two *Trino* datasets failing the same run for an unrelated reason. The two are independent, but the three partitioned StarRocks datasets keep 500ing until *this* config change rolls out and the Superset pods restart.

**Watch out when previewing/applying locally.** `SUPERSET_TAG = os.environ.get("SUPERSET_IMAGE_TAG", "latest")` ([`__main__.py#L83`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/applications/superset/__main__.py#L83)). A `pulumi up` from an interactive shell without `SUPERSET_IMAGE_TAG` set will move the image tag off the currently deployed `6184d0d69` to `latest`. CI sets it; a local shell does not. The preview above pins it explicitly for that reason.

**Removing the shim later.** It becomes dead weight once either upstream moves — the dialect shipping hashable reflection objects, or Superset moving to SQLAlchemy 2.0 (whose cache key filters by type). Worth reporting upstream to StarRocks; the minimal fix there is `@dataclasses.dataclass(frozen=True)` or `eq=False` on the reflected-info classes.

**Unrelated noise spotted while digging,** not addressed here:

- Every StarRocks reflection logs `starrocks.dialect: Failed to get run_mode: ... you need (at least one of) the OPERATE privilege(s) on SYSTEM ... Current role(s): [readonly]`. Harmless, but constant.
- `superset.datasets.datetime_format_detector` logs `Unknown catalog 'ol_warehouse_production_dimensional'` on every StarRocks dataset refresh. Superset's StarRocks engine spec reads a dataset's `schema` as `catalog.database`, so a bare schema name is parsed as a catalog — meaning datetime format detection never actually works for StarRocks datasets. Deserves its own issue.
