### PR TITLE
Remove GitHub Actions integration from learn-ai Pulumi stack

### DIFF
--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -8,14 +8,12 @@ import textwrap
 from pathlib import Path
 
 import pulumi_fastly as fastly
-import pulumi_github as github
 import pulumi_kubernetes as kubernetes
 import pulumi_vault as vault
 from pulumi import (
     ROOT_STACK_RESOURCE,
     Alias,
     Config,
-    InvokeOptions,
     Output,
     ResourceOptions,
     export,
@@ -68,7 +66,7 @@ from ol_infrastructure.lib.aws.eks_helper import (
     get_default_psg_ingress_args,
     setup_k8s_provider,
 )
-from ol_infrastructure.lib.aws.iam_helper import IAM_POLICY_VERSION, lint_iam_policy
+from ol_infrastructure.lib.aws.iam_helper import lint_iam_policy
 from ol_infrastructure.lib.fastly import (
     build_fastly_log_format_string,
     get_fastly_provider,
@@ -130,26 +128,11 @@ apisix_ingress_class = learn_ai_config.get("apisix_ingress_class") or "apisix"
 
 setup_vault_provider(stack_info)
 fastly_provider = get_fastly_provider()
-github_provider = github.Provider(
-    "github_provider",
-    owner=read_yaml_secrets(Path("pulumi/github_provider.yaml"))["owner"],
-    token=read_yaml_secrets(Path("pulumi/github_provider.yaml"))["token"],
-)
 
 k8s_global_labels = K8sGlobalLabels(
     ou=BusinessUnit.mit_learn, service=Services.mit_learn, stack=stack_info
 ).model_dump()
 setup_k8s_provider(kubeconfig=cluster_stack.require_output("kube_config"))
-
-match stack_info.env_suffix:
-    case "production":
-        env_var_suffix = "PROD"
-    case "qa":
-        env_var_suffix = "RC"
-    case "ci":
-        env_var_suffix = "CI"
-    case _:
-        env_var_suffix = "INVALID"
 
 learn_ai_namespace = "learn-ai"
 cluster_stack.require_output("namespaces").apply(
@@ -295,63 +278,6 @@ learn_ai_service_account = kubernetes.core.v1.ServiceAccount(
     automount_service_account_token=False,
 )
 
-
-gh_workflow_s3_bucket_permissions_doc = {
-    "Version": IAM_POLICY_VERSION,
-    "Statement": [
-        {
-            "Action": [
-                "s3:ListBucket*",
-            ],
-            "Effect": "Allow",
-            "Resource": [f"arn:aws:s3:::{learn_ai_app_storage_bucket_name}"],
-        },
-        {
-            "Action": [
-                "s3:GetObject*",
-                "s3:PutObject",
-                "s3:PutObjectAcl",
-                "s3:DeleteObject",
-            ],
-            "Effect": "Allow",
-            "Resource": [f"arn:aws:s3:::{learn_ai_app_storage_bucket_name}/frontend/*"],
-        },
-    ],
-}
-
-gh_workflow_iam_policy = iam.Policy(
-    f"learn-ai-gh-workflow-iam-policy-{stack_info.env_suffix}",
-    name=f"learn-ai-gh-workflow-iam-policy-{stack_info.env_suffix}",
-    policy=lint_iam_policy(
-        gh_workflow_s3_bucket_permissions_doc,
-        stringify=True,
-        parliament_config=parliament_config,
-    ),
-)
-
-################################################
-# Github frontend workflow IAM configuration
-# Just create a static user for now. Some day refactor to use
-# https://github.com/hashicorp/vault-action
-gh_workflow_user = iam.User(
-    f"learn-ai-gh-workflow-user-{stack_info.env_suffix}",
-    name=f"learn-ai-gh-workflow-{stack_info.env_suffix}",
-    tags=aws_config.tags,
-)
-iam.PolicyAttachment(
-    f"learn-ai-gh-workflow-iam-policy-attachment-{stack_info.env_suffix}",
-    policy_arn=gh_workflow_iam_policy.arn,
-    users=[gh_workflow_user.name],
-)
-gh_workflow_accesskey = iam.AccessKey(
-    f"learn-ai-gh-workflow-access-key-{stack_info.env_suffix}",
-    user=gh_workflow_user.name,
-    status="Active",
-)
-gh_repo = github.get_repository(
-    full_name="mitodl/learn-ai",
-    opts=InvokeOptions(provider=github_provider),
-)
 
 ################################################
 # Fastly configuration


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Removes the remaining GitHub-related infrastructure from the learn-ai Pulumi stack (`src/ol_infrastructure/applications/learn_ai/__main__.py`):

- `pulumi_github` provider registration and import
- The `env_var_suffix` match statement (only fed the GitHub Actions secret names removed in 78147dd8)
- `gh_workflow_iam_policy` / `gh_workflow_s3_bucket_permissions_doc` (AWS IAM policy granting S3 access to the workflow user)
- `gh_workflow_user` (AWS IAM user) and its policy attachment
- `gh_workflow_accesskey` (AWS IAM access key)
- `gh_repo` (GitHub repo lookup)
- The now-unused `IAM_POLICY_VERSION` import

This code was only consumed by the `github.ActionsSecret`/`github.ActionsVariable` resources that were removed from the code in 78147dd8 (the GitHub token used to manage them had gone invalid), leaving this block dead.

The corresponding Pulumi state entries were also cleaned up via `pulumi state delete` across the CI, QA, and Production stacks:
- `github_provider`
- `learn-ai-gh-workflow-user-{env}`
- `learn-ai-gh-workflow-access-key-{env}`
- `learn-ai-gh-workflow-iam-policy-{env}`
- `learn-ai-gh-workflow-iam-policy-attachment-{env}`

Note: these were untracked from Pulumi state only, not destroyed via `pulumi up` — the IAM user, access key, and policy still exist in AWS and should be cleaned up manually/separately if desired.

### Screenshots (if appropriate):
N/A

### How can this be tested?
- `uv run pre-commit run --files src/ol_infrastructure/applications/learn_ai/__main__.py` passes (ruff, mypy, secrets detection).
- `pulumi preview` against CI, QA, and Production shows zero GitHub- or IAM-related resource changes; only pre-existing, unrelated stack drift (Fastly, KEDA, VPA/HPA) appears in the diff.
- `rg -ni "github|gh_workflow|gh_repo"` against the file only matches two unrelated doc-comment URLs referencing upstream apisix-ingress-controller GitHub issues.

### Additional Context
Follow-up (out of scope here): the AWS IAM user/access-key/policy for the old GitHub Actions integration are still live in AWS since they were only untracked from Pulumi state, not destroyed. Worth a manual cleanup pass in the AWS console/CLI if they're confirmed unused elsewhere.