### PR TITLE
fix(opik): unauthenticated /health route and simple_pulumi deployment registration

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/meta.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/meta.py
@@ -207,6 +207,7 @@ if __name__ == "__main__":
         "open-metadata",
         "open-metadata-substructure",
         "opensearch",
+        "opik",
         "qdrant-cloud",
         "release-bot",
         "rootly",

--- a/src/ol_infrastructure/applications/opik/__main__.py
+++ b/src/ol_infrastructure/applications/opik/__main__.py
@@ -369,6 +369,20 @@ opik_apisix_route = OLApisixRoute(
     k8s_namespace=OPIK_NAMESPACE,
     k8s_labels=k8s_global_labels,
     route_configs=[
+        # /health -> unauthenticated. The chart's frontend nginx serves this
+        # path directly (see configmap-frontend-nginx.yaml's "Dedicated
+        # healthcheck endpoint" location) for load balancer / uptime checks,
+        # so it must bypass OIDC entirely rather than redirect to Keycloak.
+        # Highest priority so it wins over the catch-all UI rule below.
+        OLApisixRouteConfig(
+            route_name="opik-health",
+            priority=30,
+            hosts=[opik_domain],
+            paths=["/health"],
+            backend_service_name="opik-frontend",
+            backend_service_port=5173,
+            shared_plugin_config_name=opik_shared_plugins.resource_name,
+        ),
         # /api/* WITH an Authorization header -> bearer-token validation (SDK /
         # programmatic clients). Highest priority so it wins over the session
         # /api rule when a token is present.


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Two small fixes for the Opik application deployment:

- Adds `opik` to the application list in `src/ol_concourse/pipelines/infrastructure/simple_pulumi/meta.py` so it is included in simple_pulumi deployment Concourse pipeline jobs.
- Adds an unauthenticated APISIX route for `/health` in `src/ol_infrastructure/applications/opik/__main__.py`. The Opik Helm chart's frontend nginx serves this path directly (see the chart's `configmap-frontend-nginx.yaml` "Dedicated healthcheck endpoint" location) for load balancer / uptime checks, so it must bypass OIDC entirely rather than redirect to Keycloak. It's registered at `priority=30` (highest) so it wins over the catch-all UI route.

### Screenshots (if appropriate):
N/A — no UI changes.

### How can this be tested?
- Confirm `opik` now appears in the `simple_pulumi` pipeline application list and gets a generated Concourse pipeline/job.
- After deploy, verify `GET https://<opik_domain>/health` returns success without being redirected to Keycloak login, while other `/`, `/api/*` routes still require authentication as before.

### Additional Context
N/A