### PR TITLE
feat(opik): add Pingdom monitoring for Opik QA and production URLs

### DIFF
--- a/src/ol_infrastructure/infrastructure/grafana_alerting/pingdom_checks.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/pingdom_checks.py
@@ -407,6 +407,23 @@ _CHECKS: list[_SMCheck] = [
         alert_sensitivity="high",
         labels={"env": "production", "service": "open-discussions"},
     ),
+    # --- Opik ---
+    _SMCheck(
+        resource_name="opik-production-http",
+        job="Opik Production",
+        target="https://opik.ol.mit.edu/health",
+        frequency=60000,
+        alert_sensitivity="high",
+        labels={"env": "production", "service": "opik"},
+    ),
+    _SMCheck(
+        resource_name="opik-qa-http",
+        job="Opik QA",
+        target="https://opik-qa.ol.mit.edu/health",
+        frequency=60000,
+        alert_sensitivity="low",
+        labels={"env": "qa", "service": "opik"},
+    ),
     # --- SSO (Keycloak) ---
     _SMCheck(
         resource_name="sso-production-olapps-http",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Adds two Pingdom uptime checks to `src/ol_infrastructure/infrastructure/grafana_alerting/pingdom_checks.py` for the new Opik service:

- `opik-production-http` — `https://opik.ol.mit.edu/health`, `high` alert sensitivity (NA + EU probes, 1-minute polling)
- `opik-qa-http` — `https://opik-qa.ol.mit.edu/health`, `low` alert sensitivity (NA probe, 1-minute polling)

Both follow the existing `_SMCheck` pattern used for the rest of the checks in this file.

### How can this be tested?
- Verified the file parses and passes `ruff check` locally.
- `pulumi preview` could not be run in this environment (missing `PULUMI_CONFIG_PASSPHRASE` for the SOPS-encrypted stack config); a reviewer with stack access should run `pulumi preview --stack Production` in `src/ol_infrastructure/infrastructure/grafana_alerting/` to confirm the two new resources are the only diff.
- Per this module's existing gate (see its `CLAUDE.md` and the linked ADR), these checks won't actually be created on a normal `pulumi up` — that requires `pulumi config set allow_pingdom_apply true` on the Production stack, ideally scoped to just these two new resources via `--target`, with the result verified directly against the Pingdom API (`GET /api/3.1/checks`) afterward.

### Additional Context
N/A