### PR TITLE
feat: move release-flow resources and release bot to shared GitHub App auth

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
   "pulumi-rootly",
   "pulumi-terraform>=6.0.1",
   "pulumi-command>=1.0,<2",
-  "ol-concourse>=0.8.11,<0.9",
+  "ol-concourse>=0.9.0,<0.10",
   "pulumiverse-grafana>=2.0.0,<3",
   "pulumiverse-sentry==0.0.9",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
   "pulumi-rootly",
   "pulumi-terraform>=6.0.1",
   "pulumi-command>=1.0,<2",
-  "ol-concourse>=0.9.0,<0.10",
+  "ol-concourse>=0.9.0,<0.11",
   "pulumiverse-grafana>=2.0.0,<3",
   "pulumiverse-sentry==0.0.9",
 ]

--- a/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
@@ -853,11 +853,22 @@ def _define_release_resources(
     repo_main_branch: str,
 ) -> tuple[Resource, Resource, Resource, Resource, Resource]:
     """Define the release-flow resources: release resource, gates, issues, and GitHub Deployments."""
+    # Shared GitHub App installation ol-concourse-lib no longer defaults --
+    # every consumer of this library supplies its own credential reference.
+    # Backed by the "shared/github" entry in
+    # bridge/secrets/concourse/operations.production.yaml (Vault path
+    # secret-concourse/shared/github), the same secret the release bot reads.
+    github_app_id = "((github.release_bot_app_id))"
+    github_app_installation_id = "((github.release_bot_app_installation_id))"
+    github_app_private_key = "((github.release_bot_app_pem))"
     release_res = release_resource(
         name=Identifier(f"{app_name}-release"),
         uri=f"https://github.com/{github_repo}",
         branch=repo_main_branch,
-        access_token="((github.release_resource_access_token))",  # noqa: S106
+        auth_method="app",
+        app_id=github_app_id,
+        app_installation_id=github_app_installation_id,
+        private_ssh_key=github_app_private_key,
         repository=github_repo,
         semver_tag_fallback=True,
     )
@@ -869,7 +880,10 @@ def _define_release_resources(
         issue_title_template=f"Release {app_name}",
         issue_state="closed",
         skip_if_labeled=["abandoned"],
-        access_token="((github.release_resource_access_token))",  # noqa: S106
+        auth_method="app",
+        app_id=github_app_id,
+        app_installation_id=github_app_installation_id,
+        private_ssh_key=github_app_private_key,
         gh_host=None,
     )
     # Open release issues are created after each QA deployment.
@@ -880,7 +894,10 @@ def _define_release_resources(
         issue_title_template=f"Release {app_name}",
         issue_state="open",
         labels=["release"],
-        access_token="((github.release_resource_access_token))",  # noqa: S106
+        auth_method="app",
+        app_id=github_app_id,
+        app_installation_id=github_app_installation_id,
+        private_ssh_key=github_app_private_key,
         gh_host=None,
         # A retriggered QA deploy with no new app commit re-runs this put
         # with the same checklist; editing in place (instead of the default
@@ -892,13 +909,19 @@ def _define_release_resources(
         name=Identifier(f"{app_name}-deployment-rc"),
         repository=github_repo,
         environment="RC",
-        access_token="((github.release_resource_access_token))",  # noqa: S106
+        auth_method="app",
+        app_id=github_app_id,
+        app_installation_id=github_app_installation_id,
+        private_ssh_key=github_app_private_key,
     )
     deployment_prod = github_deployment(
         name=Identifier(f"{app_name}-deployment-production"),
         repository=github_repo,
         environment="Production",
-        access_token="((github.release_resource_access_token))",  # noqa: S106
+        auth_method="app",
+        app_id=github_app_id,
+        app_installation_id=github_app_installation_id,
+        private_ssh_key=github_app_private_key,
     )
     return release_res, release_gate, release_issue, deployment_rc, deployment_prod
 

--- a/src/ol_infrastructure/applications/release_bot/__main__.py
+++ b/src/ol_infrastructure/applications/release_bot/__main__.py
@@ -52,15 +52,14 @@ bot_secrets = read_yaml_secrets(Path("release_bot/secrets.production.yaml"))
 concourse_ops_secrets = read_yaml_secrets(Path("concourse/operations.production.yaml"))
 # Same GitHub App installation Concourse's github-issues resource type can use
 # via auth_method="app" (ol_concourse.lib.resources.github_issues) -- sharing
-# one App instead of each consumer holding its own long-lived PAT.
-github_secrets = concourse_ops_secrets["pipelines"]["infrastructure/github"]
-github_app_id = github_secrets["issues_resource_app_id"]
-github_app_installation_id = github_secrets["issues_resource_app_installation_id"]
-github_app_private_key = github_secrets["issues_resource_private_ssh_key"]
-# Also wired through as a fallback: github_client._build_auth() prefers the App
-# credentials above but falls back to GITHUB_TOKEN if they're absent/invalid,
-# so this keeps that fallback usable for a quick rollback without a code change.
-github_token = github_secrets["issues_resource_access_token"]
+# one App instead of each consumer holding its own long-lived PAT. Backed by
+# the "shared/github" entry, the same Vault-synced secret Concourse pipelines
+# reference as ((github.release_bot_app_id)) etc. (see
+# ol_concourse.lib.constants.GITHUB_APP_ID).
+github_secrets = concourse_ops_secrets["pipelines"]["shared/github"]
+github_app_id = github_secrets["release_bot_app_id"]
+github_app_installation_id = github_secrets["release_bot_app_installation_id"]
+github_app_private_key = github_secrets["release_bot_app_pem"]
 
 bot_config = Config("release_bot")
 concourse_url = bot_config.get("concourse_url") or "https://cicd.odl.mit.edu"
@@ -125,7 +124,6 @@ bot_secret = kubernetes.core.v1.Secret(
         "github-app-id": str(github_app_id),
         "github-app-installation-id": str(github_app_installation_id),
         "github-app-private-key": github_app_private_key,
-        "github-token": github_token,
     },
 )
 
@@ -190,7 +188,6 @@ bot_deployment = kubernetes.apps.v1.Deployment(
                             _secret_env(
                                 "GITHUB_APP_PRIVATE_KEY", "github-app-private-key"
                             ),
-                            _secret_env("GITHUB_TOKEN", "github-token"),
                             kubernetes.core.v1.EnvVarArgs(
                                 name="CONCOURSE_URL",
                                 value=concourse_url,

--- a/src/ol_infrastructure/applications/release_bot/github_client.py
+++ b/src/ol_infrastructure/applications/release_bot/github_client.py
@@ -1,11 +1,11 @@
 """GitHub API client for the release bot, backed by PyGithub.
 
-Accepts either a personal access token or a GitHub App installation as the
-credential source. The App fields (GITHUB_APP_ID / GITHUB_APP_INSTALLATION_ID /
-GITHUB_APP_PRIVATE_KEY) line up with the same App credentials Concourse's
-`github-issues` resource type accepts via `auth_method="app"` (see
-`ol_concourse.lib.resources.github_issues`), so both consumers can be pointed
-at one GitHub App installation instead of each holding a separate long-lived
+Authenticates as a GitHub App installation only -- no PAT fallback. The App
+fields (GITHUB_APP_ID / GITHUB_APP_INSTALLATION_ID / GITHUB_APP_PRIVATE_KEY)
+line up with the same App credentials Concourse's `github-issues` resource
+type accepts via `auth_method="app"` (see
+`ol_concourse.lib.resources.github_issues`), so both consumers are pointed at
+one GitHub App installation instead of each holding a separate long-lived
 PAT. PyGithub's `AppInstallationAuth` mints and refreshes installation tokens
 on its own, so no manual token-refresh bookkeeping is needed here.
 """
@@ -41,28 +41,25 @@ def _build_auth() -> Auth.Auth:
     app_id = os.environ.get("GITHUB_APP_ID", "").strip()
     installation_id = os.environ.get("GITHUB_APP_INSTALLATION_ID", "").strip()
     private_key = os.environ.get("GITHUB_APP_PRIVATE_KEY", "").strip()
-    if app_id and installation_id and private_key:
-        try:
-            app_id_int = int(app_id)
-            installation_id_int = int(installation_id)
-        except ValueError as exc:
-            msg = (
-                "GITHUB_APP_ID and GITHUB_APP_INSTALLATION_ID must be numeric "
-                f"(got GITHUB_APP_ID={app_id!r}, "
-                f"GITHUB_APP_INSTALLATION_ID={installation_id!r})"
-            )
-            raise RuntimeError(msg) from exc
-        return Auth.AppAuth(app_id_int, private_key).get_installation_auth(
-            installation_id_int
-        )
-    token = os.environ.get("GITHUB_TOKEN", "").strip()
-    if not token:
+    if not (app_id and installation_id and private_key):
         msg = (
-            "Either GITHUB_APP_ID/GITHUB_APP_INSTALLATION_ID/"
-            "GITHUB_APP_PRIVATE_KEY or GITHUB_TOKEN must be set"
+            "GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID, and "
+            "GITHUB_APP_PRIVATE_KEY must all be set"
         )
         raise RuntimeError(msg)
-    return Auth.Token(token)
+    try:
+        app_id_int = int(app_id)
+        installation_id_int = int(installation_id)
+    except ValueError as exc:
+        msg = (
+            "GITHUB_APP_ID and GITHUB_APP_INSTALLATION_ID must be numeric "
+            f"(got GITHUB_APP_ID={app_id!r}, "
+            f"GITHUB_APP_INSTALLATION_ID={installation_id!r})"
+        )
+        raise RuntimeError(msg) from exc
+    return Auth.AppAuth(app_id_int, private_key).get_installation_auth(
+        installation_id_int
+    )
 
 
 def _get_client() -> Github:

--- a/tests/ol_infrastructure/applications/release_bot/test_github_client.py
+++ b/tests/ol_infrastructure/applications/release_bot/test_github_client.py
@@ -80,7 +80,6 @@ _ENV_VARS = (
     "GITHUB_APP_ID",
     "GITHUB_APP_INSTALLATION_ID",
     "GITHUB_APP_PRIVATE_KEY",
-    "GITHUB_TOKEN",
 )
 
 
@@ -95,27 +94,28 @@ def _clear_github_env(monkeypatch):
 
 
 def test_build_auth_raises_without_any_credentials():
-    """Neither App nor token credentials set -- raises with a clear message."""
+    """No App credentials set -- raises with a clear message."""
     with pytest.raises(RuntimeError, match="GITHUB_APP_ID"):
         github._build_auth()
 
 
-def test_build_auth_uses_token_when_only_token_is_set(monkeypatch):
-    """Falls back to PAT auth when no App credentials are present."""
-    monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
-    auth = github._build_auth()
-    assert isinstance(auth, Auth.Token)
+def test_build_auth_raises_with_partial_credentials(monkeypatch):
+    """Only some App credentials set -- still raises rather than silently
+    falling back or passing partial creds to PyGithub.
+    """
+    monkeypatch.setenv("GITHUB_APP_ID", "12345")
+    with pytest.raises(RuntimeError, match="GITHUB_APP_ID"):
+        github._build_auth()
 
 
-def test_build_auth_prefers_app_auth_when_app_credentials_are_set(monkeypatch):
-    """App auth wins over a token when both are set -- not silently ignored."""
+def test_build_auth_uses_app_auth_when_app_credentials_are_set(monkeypatch):
+    """App auth is used when all three App credentials are present."""
     monkeypatch.setenv("GITHUB_APP_ID", "12345")
     monkeypatch.setenv("GITHUB_APP_INSTALLATION_ID", "67890")
     monkeypatch.setenv(
         "GITHUB_APP_PRIVATE_KEY",
         "-----BEGIN RSA PRIVATE KEY-----",  # pragma: allowlist secret
     )
-    monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
     auth = github._build_auth()
     assert isinstance(auth, Auth.AppInstallationAuth)
 

--- a/tests/ol_infrastructure/applications/release_bot/test_github_client.py
+++ b/tests/ol_infrastructure/applications/release_bot/test_github_client.py
@@ -104,7 +104,8 @@ def test_build_auth_raises_with_partial_credentials(monkeypatch):
     falling back or passing partial creds to PyGithub.
     """
     monkeypatch.setenv("GITHUB_APP_ID", "12345")
-    with pytest.raises(RuntimeError, match="GITHUB_APP_ID"):
+    monkeypatch.setenv("GITHUB_APP_INSTALLATION_ID", "67890")
+    with pytest.raises(RuntimeError, match="must all be set"):
         github._build_auth()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1379,14 +1379,14 @@ wheels = [
 
 [[package]]
 name = "ol-concourse"
-version = "0.8.13"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/41/0345c9c130454ad081e7de115ba070a54ba46e3d6720835946d25b78af0c/ol_concourse-0.8.13.tar.gz", hash = "sha256:f8dae50420d03f98248e070aa6149eaae2c2e7680f6d72bffea2ab5c0a8df4d2", size = 52646, upload-time = "2026-07-29T17:09:15.947Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/13/a1c72ddf3701e42316a29db677a323886bccac6976a4371b101275e07842/ol_concourse-0.9.0.tar.gz", hash = "sha256:ec2f0d895f1bcaa213c74e62cb6571260d8f68cc59513d90f38d296ff1a4abc0", size = 54066, upload-time = "2026-07-30T16:34:16.892Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/ec/92608bf4990b1fe230d74bd44a4b408421dde76b3217c8f9be355c71a6f6/ol_concourse-0.8.13-py3-none-any.whl", hash = "sha256:8b774fc1ec5184b155346b99c23fa4440350acef263cf6f20846b2dc21c9d098", size = 51468, upload-time = "2026-07-29T17:09:15.076Z" },
+    { url = "https://files.pythonhosted.org/packages/06/21/deadd443bfced2ffc8c9b736635c47eee72258145b8692713b05f8941d4d/ol_concourse-0.9.0-py3-none-any.whl", hash = "sha256:d1d353b4009db13db8dab829074fc4c279ec1f172d945d2d2d64b5ced639c41e", size = 52389, upload-time = "2026-07-30T16:34:15.819Z" },
 ]
 
 [[package]]
@@ -1458,7 +1458,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.0,<0.29" },
     { name = "hvac", extras = ["parser"], specifier = ">=2.0.0,<3" },
     { name = "kubernetes", specifier = ">=34.1.0" },
-    { name = "ol-concourse", specifier = ">=0.8.11,<0.9" },
+    { name = "ol-concourse", specifier = ">=0.9.0,<0.10" },
     { name = "ol-parliament", specifier = ">=1.7.0" },
     { name = "packaging", specifier = ">=24.2" },
     { name = "pulumi", specifier = ">=3.39.1,<4" },

--- a/uv.lock
+++ b/uv.lock
@@ -1458,7 +1458,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.0,<0.29" },
     { name = "hvac", extras = ["parser"], specifier = ">=2.0.0,<3" },
     { name = "kubernetes", specifier = ">=34.1.0" },
-    { name = "ol-concourse", specifier = ">=0.9.0,<0.10" },
+    { name = "ol-concourse", specifier = ">=0.9.0,<0.11" },
     { name = "ol-parliament", specifier = ">=1.7.0" },
     { name = "packaging", specifier = ">=24.2" },
     { name = "pulumi", specifier = ">=3.39.1,<4" },


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Wires the release bot and the k8s_apps Concourse pipeline's release-flow resources onto the shared GitHub App installation added in the previous commit's `shared/github` secrets entry (`release_bot_app_id`/`release_bot_app_installation_id`/`release_bot_app_pem`), moving away from long-lived PATs.

**Release bot (`src/ol_infrastructure/applications/release_bot/`):**
- `__main__.py` reads App credentials from `pipelines["shared/github"]` instead of `pipelines["infrastructure/github"]`'s `issues_resource_*` fields.
- Removed the `GITHUB_TOKEN` PAT fallback entirely — from `github_client.py`'s `_build_auth()`, the bot's k8s Secret, and its env var injection. App credentials are now required; there's no silent fallback to a token if they're missing/invalid.
- `tests/.../test_github_client.py` updated to match: dropped the token-precedence tests, added a partial-credentials-still-raises case.

**k8s_apps pipeline (`src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py`):**
- All five resources built by `_define_release_resources` (`release_resource`, both `github_issues` calls, both `github_deployment` calls) now use `auth_method="app"` with explicit `app_id`/`app_installation_id`/`private_ssh_key` pointing at the `shared/github` credential, instead of `access_token="((github.release_resource_access_token))"`.
- `pyproject.toml`: bumped `ol-concourse` from `>=0.8.11,<0.9` (locked at `0.8.13`) to `>=0.9.0,<0.10`. The App-auth params (`auth_method`, `app_id`, `app_installation_id`, `private_ssh_key`) were added in [ol-concourse#74](https://github.com/mitodl/ol-concourse/pull/74) and only exist starting at `0.9.0`, which is already published to PyPI — the locked `0.8.13` predates that feature entirely, so this pipeline would have failed with `TypeError: unexpected keyword argument 'auth_method'` without the bump. `uv.lock` regenerated via `uv lock --upgrade-package ol-concourse`.

Companion PR: [mitodl/ol-concourse#75](https://github.com/mitodl/ol-concourse/pull/75), which also removes a library-wide default credential these explicit params replace.

### How can this be tested?
- `uv run --active python3 -m pytest tests/ol_infrastructure/applications/release_bot/test_github_client.py -q` — 19 passed.
- Functional check against the newly-resolved `ol-concourse==0.9.0`:
  ```
  from ol_concourse.pipelines.infrastructure.k8s_apps.pipeline import _define_release_resources
  res = _define_release_resources('myapp', 'mitodl/myapp', 'main')
  # all five resources: auth_method=app, app_id=((github.release_bot_app_id))
  ```
- `ruff check` and `mypy` (via pre-commit) pass on every changed file.

### Additional Context
The `shared/github` secret this relies on was added directly to `concourse/operations.production.yaml` in a prior commit (`config: Add github app credentials for release bot workflow`). A real Vault sync (`pulumi up` on the `concourse` stack) is required before any pipeline using `auth_method="app"` against this credential can actually authenticate — this PR only wires the reference, it doesn't populate Vault.