### PR TITLE
feat(witan,omnigraph): ensure-ECR pattern + single shared image repo

### DIFF
--- a/src/ol_concourse/pipelines/ecr.py
+++ b/src/ol_concourse/pipelines/ecr.py
@@ -1,0 +1,84 @@
+"""Follow-up ECR repository configuration, paired with ``ensure_ecr_task``.
+
+``ensure_ecr_task`` (``ol_concourse.lib.containers``) only creates the
+repository if it's missing, with AWS defaults: scanning disabled, unlimited
+image retention. Pipelines whose ECR repo used to be a Pulumi-managed
+``aws.ecr.Repository`` (scan-on-push + a lifecycle policy) but moved
+ownership to the pipeline -- because a repo shared across CI/QA/Production
+can't be owned by three independent per-env Pulumi stacks -- need this step
+too, to keep the same repository configuration.
+"""
+
+import json
+
+from ol_concourse.lib.models.pipeline import (
+    AnonymousResource,
+    Command,
+    Identifier,
+    Platform,
+    TaskConfig,
+    TaskStep,
+)
+
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
+
+
+def configure_ecr_repository_task(
+    repo_name: str, *, keep_last_n_images: int = 10
+) -> TaskStep:
+    """Return a TaskStep applying scan-on-push + an image-count lifecycle policy.
+
+    Safe to run on every pipeline execution: both
+    ``put-image-scanning-configuration`` and ``put-lifecycle-policy`` are
+    idempotent -- each call just (re)applies the same configuration.
+
+    :param repo_name: The ECR repository name, e.g. ``"witan"``.
+    :param keep_last_n_images: Expire all but the most recent N images.
+    """
+    lifecycle_policy = json.dumps(
+        {
+            "rules": [
+                {
+                    "rulePriority": 1,
+                    "description": f"Keep last {keep_last_n_images} images",
+                    "selection": {
+                        "tagStatus": "any",
+                        "countType": "imageCountMoreThan",
+                        "countNumber": keep_last_n_images,
+                    },
+                    "action": {"type": "expire"},
+                }
+            ]
+        }
+    )
+    return TaskStep(
+        task=Identifier("configure-ecr-repository"),
+        config=TaskConfig(
+            platform=Platform.linux,
+            image_resource=AnonymousResource(
+                type="registry-image",
+                source={
+                    "repository": dockerhub_ecr_image_uri("amazon/aws-cli"),
+                    "tag": "latest",
+                    "aws_region": ECR_REGION,
+                },
+            ),
+            params={
+                "REPO_NAME": repo_name,
+                "LIFECYCLE_POLICY": lifecycle_policy,
+                "AWS_PAGER": "cat",
+            },
+            run=Command(
+                path="sh",
+                args=[
+                    "-exc",
+                    "aws ecr put-image-scanning-configuration"
+                    " --repository-name ${REPO_NAME}"
+                    " --image-scanning-configuration scanOnPush=true"
+                    " && aws ecr put-lifecycle-policy"
+                    " --repository-name ${REPO_NAME}"
+                    ' --lifecycle-policy-text "$LIFECYCLE_POLICY"',
+                ],
+            ),
+        ),
+    )

--- a/src/ol_concourse/pipelines/infrastructure/omnigraph/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/omnigraph/pipeline.py
@@ -49,6 +49,7 @@ from ol_concourse.pipelines.constants import (
     PULUMI_CODE_PATH,
     PULUMI_WATCHED_PATHS,
 )
+from ol_concourse.pipelines.ecr import configure_ecr_repository_task
 from ol_concourse.pipelines.jobs import pulumi_jobs_chain
 
 ENVIRONMENTS = ("CI", "QA", "Production")
@@ -110,6 +111,7 @@ def build_omnigraph_pipeline() -> PipelineFragment:
                 },
             ),
             ensure_ecr_task(IMAGE_NAME),
+            configure_ecr_repository_task(IMAGE_NAME),
             PutStep(
                 put=image_resource.name,
                 params={

--- a/src/ol_concourse/pipelines/infrastructure/omnigraph/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/omnigraph/pipeline.py
@@ -10,14 +10,17 @@ the image and runs the Pulumi deploy off the ol-infrastructure checkout.
 
 Flow (mirrors ``kubewatch``'s build-then-deploy shape):
 
-    agent-kit push -> build omnigraph-server image -> push to omnigraph-server-<env> ECR
-        -> pulumi deploy ``ol-application-omnigraph`` (CI -> QA -> Production),
-           each stage gated (``passed``) on its freshly built image.
+    agent-kit push -> build omnigraph-server image -> push to omnigraph-server ECR
+        -> pulumi deploy ``ol-application-omnigraph`` CI, gated on that image
+           -> pulumi deploy QA, gated (``passed``) on CI having deployed that
+              same image -> Production, gated on QA. One image is built once
+              and promoted unchanged through every stage, matching every
+              other build+deploy pipeline in this repo (e.g. ``k8s_apps``).
 
-The ECR repositories (``omnigraph-server-<env>``) are provisioned by the
-Pulumi stack itself (``applications/omnigraph``); this pipeline only builds the
-image and pushes to them, exactly like ``kubewatch_webhook_handler``'s "ECR
-repo in Pulumi, image built elsewhere" split.
+The build job ensures the ECR repository (``omnigraph-server``) exists before
+pushing to it (``ensure_ecr_task``), rather than depending on the Pulumi
+stack (``applications/omnigraph``) having already created it -- this removes
+the bootstrap ordering dependency between the two.
 
 witan (``pulumi-witan``) is a separate pipeline deploying a separate stack that
 reaches this service via a StackReference; the two ship independently.
@@ -30,7 +33,7 @@ Fly command to bootstrap this pipeline (normally set by the
 
 import sys
 
-from ol_concourse.lib.containers import container_build_task
+from ol_concourse.lib.containers import container_build_task, ensure_ecr_task
 from ol_concourse.lib.models.fragment import PipelineFragment
 from ol_concourse.lib.models.pipeline import (
     GetStep,
@@ -38,7 +41,6 @@ from ol_concourse.lib.models.pipeline import (
     Input,
     Job,
     PutStep,
-    Resource,
 )
 from ol_concourse.lib.resources import git_repo, registry_image
 
@@ -85,17 +87,15 @@ def build_omnigraph_pipeline() -> PipelineFragment:
         ],
     )
 
-    # One registry-image resource per env: the build job pushes the single
-    # freshly built tarball to each env's ECR repo, and each deploy stage gates
-    # on its own env resource.
-    image_resources: dict[str, Resource] = {
-        env: registry_image(
-            name=Identifier(f"{IMAGE_NAME}-{env.lower()}-image"),
-            image_repository=f"{IMAGE_NAME}-{env.lower()}",
-            ecr_region=ECR_REGION,
-        )
-        for env in ENVIRONMENTS
-    }
+    # A single registry-image resource: the build job pushes one tarball here,
+    # and that same image is promoted unchanged through every deploy stage
+    # below (via the ``passed`` chain pulumi_jobs_chain builds from
+    # ``dependencies``), rather than being pushed separately per env.
+    image_resource = registry_image(
+        name=Identifier(f"{IMAGE_NAME}-image"),
+        image_repository=IMAGE_NAME,
+        ecr_region=ECR_REGION,
+    )
 
     build_job = Job(
         name=Identifier(f"build-{IMAGE_NAME}-image"),
@@ -109,46 +109,45 @@ def build_omnigraph_pipeline() -> PipelineFragment:
                     "DOCKERFILE": f"{agent_kit_code.name}/{DOCKERFILE}",
                 },
             ),
-            *[
-                PutStep(
-                    put=image_resources[env].name,
-                    params={
-                        "image": "image/image.tar",
-                        "additional_tags": f"{agent_kit_code.name}/.git/short_ref",
-                    },
-                )
-                for env in ENVIRONMENTS
-            ],
+            ensure_ecr_task(IMAGE_NAME),
+            PutStep(
+                put=image_resource.name,
+                params={
+                    "image": "image/image.tar",
+                    "additional_tags": f"{agent_kit_code.name}/.git/short_ref",
+                },
+            ),
         ],
     )
 
-    # Each deploy stage triggers off — and is gated (``passed``) on — the image
-    # for that env, so a stage only redeploys images this pipeline itself built.
-    custom_dependencies: dict[int, list[GetStep]] = {
-        idx: [
-            GetStep(
-                get=image_resources[env].name,
-                trigger=True,
-                passed=[build_job.name],
-            )
-        ]
-        for idx, env in enumerate(ENVIRONMENTS)
-    }
-
+    # A single shared GetStep: pulumi_jobs_chain rewrites its trigger/passed
+    # per stage -- CI triggers on a fresh build, QA and Production instead
+    # gate (``passed``) on the *previous* stage having deployed that same
+    # image, so the identical artifact promotes through every stage. The
+    # image is pinned by digest (OMNIGRAPH_DOCKER_SHA, read by data_tier.py
+    # via format_docker_image_ref) rather than a mutable ``:latest`` tag, so
+    # a promoted image actually changes each stage's Deployment pod spec.
     deploy_fragment = pulumi_jobs_chain(
         refresh_stack=True,
         pulumi_code=pulumi_code,
         stack_names=list(ENVIRONMENTS),
         project_name="ol-application-omnigraph",
         project_source_path=PULUMI_PROJECT_PATH,
-        custom_dependencies=custom_dependencies,
+        dependencies=[
+            GetStep(
+                get=image_resource.name,
+                trigger=True,
+                passed=[build_job.name],
+            )
+        ],
+        env_vars_from_files={"OMNIGRAPH_DOCKER_SHA": f"{image_resource.name}/digest"},
     )
 
     # combine_fragments deduplicates resources/resource-types by name (the
     # field validators only fire on assignment, not on ``.append``), so route
     # the final assembly through it rather than mutating a fragment in place.
     build_fragment = PipelineFragment(
-        resources=[agent_kit_code, pulumi_code, *image_resources.values()],
+        resources=[agent_kit_code, pulumi_code, image_resource],
         jobs=[build_job],
     )
     return PipelineFragment.combine_fragments(build_fragment, deploy_fragment)

--- a/src/ol_concourse/pipelines/infrastructure/witan/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/witan/pipeline.py
@@ -52,6 +52,7 @@ from ol_concourse.pipelines.constants import (
     PULUMI_CODE_PATH,
     PULUMI_WATCHED_PATHS,
 )
+from ol_concourse.pipelines.ecr import configure_ecr_repository_task
 from ol_concourse.pipelines.jobs import pulumi_jobs_chain
 
 ENVIRONMENTS = ("CI", "QA", "Production")
@@ -113,6 +114,7 @@ def build_witan_pipeline() -> PipelineFragment:
                 },
             ),
             ensure_ecr_task(IMAGE_NAME),
+            configure_ecr_repository_task(IMAGE_NAME),
             PutStep(
                 put=image_resource.name,
                 params={

--- a/src/ol_concourse/pipelines/infrastructure/witan/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/witan/pipeline.py
@@ -10,14 +10,17 @@ ol-infrastructure checkout.
 
 Flow (mirrors ``kubewatch``'s build-then-deploy shape):
 
-    agent-kit push -> build witan image -> push to witan-<env> ECR
-        -> pulumi deploy ``ol-application-witan`` (CI -> QA -> Production),
-           each stage gated (``passed``) on its freshly built image.
+    agent-kit push -> build witan image -> push to witan ECR
+        -> pulumi deploy ``ol-application-witan`` CI, gated on that image
+           -> pulumi deploy QA, gated (``passed``) on CI having deployed that
+              same image -> Production, gated on QA. One image is built once
+              and promoted unchanged through every stage, matching every
+              other build+deploy pipeline in this repo (e.g. ``k8s_apps``).
 
-The ECR repositories (``witan-<env>``) are provisioned by the Pulumi stack
-itself (``applications/witan``); this pipeline only builds the image and pushes
-to them, exactly like ``kubewatch_webhook_handler``'s "ECR repo in Pulumi,
-image built elsewhere" split.
+The build job ensures the ECR repository (``witan``) exists before pushing to
+it (``ensure_ecr_task``), rather than depending on the Pulumi stack
+(``applications/witan``) having already created it -- this removes the
+bootstrap ordering dependency between the two.
 
 The witan stack reaches the omnigraph-server data tier (deployed by the
 separate ``pulumi-omnigraph`` pipeline / ``ol-application-omnigraph`` stack)
@@ -33,7 +36,7 @@ Fly command to bootstrap this pipeline (normally set by the
 
 import sys
 
-from ol_concourse.lib.containers import container_build_task
+from ol_concourse.lib.containers import container_build_task, ensure_ecr_task
 from ol_concourse.lib.models.fragment import PipelineFragment
 from ol_concourse.lib.models.pipeline import (
     GetStep,
@@ -41,7 +44,6 @@ from ol_concourse.lib.models.pipeline import (
     Input,
     Job,
     PutStep,
-    Resource,
 )
 from ol_concourse.lib.resources import git_repo, registry_image
 
@@ -88,17 +90,15 @@ def build_witan_pipeline() -> PipelineFragment:
         ],
     )
 
-    # One registry-image resource per env: the build job pushes the single
-    # freshly built tarball to each env's ECR repo, and each deploy stage gates
-    # on its own env resource.
-    image_resources: dict[str, Resource] = {
-        env: registry_image(
-            name=Identifier(f"{IMAGE_NAME}-{env.lower()}-image"),
-            image_repository=f"{IMAGE_NAME}-{env.lower()}",
-            ecr_region=ECR_REGION,
-        )
-        for env in ENVIRONMENTS
-    }
+    # A single registry-image resource: the build job pushes one tarball here,
+    # and that same image is promoted unchanged through every deploy stage
+    # below (via the ``passed`` chain pulumi_jobs_chain builds from
+    # ``dependencies``), rather than being pushed separately per env.
+    image_resource = registry_image(
+        name=Identifier(f"{IMAGE_NAME}-image"),
+        image_repository=IMAGE_NAME,
+        ecr_region=ECR_REGION,
+    )
 
     build_job = Job(
         name=Identifier(f"build-{IMAGE_NAME}-image"),
@@ -112,46 +112,45 @@ def build_witan_pipeline() -> PipelineFragment:
                     "DOCKERFILE": f"{agent_kit_code.name}/{DOCKERFILE}",
                 },
             ),
-            *[
-                PutStep(
-                    put=image_resources[env].name,
-                    params={
-                        "image": "image/image.tar",
-                        "additional_tags": f"{agent_kit_code.name}/.git/short_ref",
-                    },
-                )
-                for env in ENVIRONMENTS
-            ],
+            ensure_ecr_task(IMAGE_NAME),
+            PutStep(
+                put=image_resource.name,
+                params={
+                    "image": "image/image.tar",
+                    "additional_tags": f"{agent_kit_code.name}/.git/short_ref",
+                },
+            ),
         ],
     )
 
-    # Each deploy stage triggers off — and is gated (``passed``) on — the image
-    # for that env, so a stage only redeploys images this pipeline itself built.
-    custom_dependencies: dict[int, list[GetStep]] = {
-        idx: [
-            GetStep(
-                get=image_resources[env].name,
-                trigger=True,
-                passed=[build_job.name],
-            )
-        ]
-        for idx, env in enumerate(ENVIRONMENTS)
-    }
-
+    # A single shared GetStep: pulumi_jobs_chain rewrites its trigger/passed
+    # per stage -- CI triggers on a fresh build, QA and Production instead
+    # gate (``passed``) on the *previous* stage having deployed that same
+    # image, so the identical artifact promotes through every stage. The
+    # image is pinned by digest (WITAN_DOCKER_SHA, read by __main__.py via
+    # format_docker_image_ref) rather than a mutable ``:latest`` tag, so a
+    # promoted image actually changes each stage's Deployment pod spec.
     deploy_fragment = pulumi_jobs_chain(
         refresh_stack=True,
         pulumi_code=pulumi_code,
         stack_names=list(ENVIRONMENTS),
         project_name="ol-application-witan",
         project_source_path=PULUMI_PROJECT_PATH,
-        custom_dependencies=custom_dependencies,
+        dependencies=[
+            GetStep(
+                get=image_resource.name,
+                trigger=True,
+                passed=[build_job.name],
+            )
+        ],
+        env_vars_from_files={"WITAN_DOCKER_SHA": f"{image_resource.name}/digest"},
     )
 
     # combine_fragments deduplicates resources/resource-types by name (the
     # field validators only fire on assignment, not on ``.append``), so route
     # the final assembly through it rather than mutating a fragment in place.
     build_fragment = PipelineFragment(
-        resources=[agent_kit_code, pulumi_code, *image_resources.values()],
+        resources=[agent_kit_code, pulumi_code, image_resource],
         jobs=[build_job],
     )
     return PipelineFragment.combine_fragments(build_fragment, deploy_fragment)

--- a/src/ol_infrastructure/applications/omnigraph/__main__.py
+++ b/src/ol_infrastructure/applications/omnigraph/__main__.py
@@ -22,10 +22,11 @@ into the ``actor-tokens`` Secret (agent-kit ADR-0004 D3). See
 ``docs/adr/0009-deploy-witan-as-shared-multi-tenant-mcp-service.md``.
 
 Follow-up work this stack does NOT cover (tracked separately):
-    - **Container image.** omnigraph-server has no image built in either repo
-      yet; this stack only provisions the ECR repository and references
-      ``:latest`` (the ``omnigraph``/``pulumi-omnigraph`` Concourse pipeline
-      builds and pushes it). ``schema.pg`` (agent-kit repo,
+    - **Container image.** The ``omnigraph``/``pulumi-omnigraph`` Concourse
+      pipeline builds the image once, owns the ECR repository itself
+      (idempotent create-if-missing), and promotes the same image unchanged
+      through CI -> QA -> Production — see ``data_tier.py``'s module
+      docstring. ``schema.pg`` (agent-kit repo,
       ``mcp/servers/witan/schema/schema.pg``) must be baked into the image at
       build time — this Pulumi program has no access to agent-kit's tree.
     - **Keycloak witan-users token sync.** This stack provisions the
@@ -174,7 +175,4 @@ data_tier = create_data_tier(
 
 export("namespace", NAMESPACE)
 export("omnigraph_server_addr", omnigraph_server_addr(NAMESPACE))
-export(
-    "omnigraph_server_ecr_repository_url",
-    data_tier.ecr_repository.repository_url,
-)
+export("omnigraph_server_image_repository", data_tier.image_repository)

--- a/src/ol_infrastructure/applications/omnigraph/data_tier.py
+++ b/src/ol_infrastructure/applications/omnigraph/data_tier.py
@@ -16,11 +16,14 @@ CLI invocation this follows). That file is generated here as a ConfigMap
 rather than hand-authored, so the S3 bucket name/region and graph list stay
 in lockstep with the Pulumi-managed bucket.
 
-No container image is built for ``omnigraph-server`` (or for witan) in either
-repo yet — this stack only provisions the ECR repository and references
-``:latest``, exactly like ``kubewatch_webhook_handler``'s pattern of "image
-built separately, by a Concourse job, before this stack runs." That build
-job does not exist yet; see the follow-up task noted in ``__main__.py``.
+The ``omnigraph-server`` image is built once and promoted unchanged through
+CI -> QA -> Production by the ``omnigraph``/``pulumi-omnigraph`` Concourse
+pipeline, which also owns the ``omnigraph-server`` ECR repository itself
+(idempotent create-if-missing on every build) rather than this stack
+creating it — a single repo can't be owned by three independent per-env
+Pulumi stacks. This stack instead pins the Deployment's image by digest,
+read from ``OMNIGRAPH_DOCKER_SHA`` (set by the build job via the
+pulumi-provisioner's ``env_vars_from_files``).
 """
 
 import json
@@ -36,7 +39,7 @@ from ol_infrastructure.components.aws.s3 import OLBucket, S3BucketConfig
 from ol_infrastructure.components.services.vault import OLVaultK8SSecret
 from ol_infrastructure.lib.aws.iam_helper import IAM_POLICY_VERSION
 from ol_infrastructure.lib.ol_types import AWSBase
-from ol_infrastructure.lib.pulumi_helper import StackInfo
+from ol_infrastructure.lib.pulumi_helper import StackInfo, format_docker_image_ref
 
 OMNIGRAPH_SERVER_SERVICE_NAME = "omnigraph-server"
 OMNIGRAPH_SERVER_PORT = 8080
@@ -64,7 +67,7 @@ class OmnigraphDataTier(NamedTuple):
     """Handles to the provisioned data-tier resources for depends_on wiring."""
 
     bucket: OLBucket
-    ecr_repository: aws.ecr.Repository
+    image_repository: str
     service: kubernetes.core.v1.Service
     deployment: kubernetes.apps.v1.Deployment
 
@@ -133,43 +136,18 @@ def create_data_tier(  # noqa: PLR0913
         role=auth_binding.irsa_role.name,
     )
 
-    # ECR repository for the omnigraph-server image. Built separately by a
-    # Concourse job (not yet written — see __main__.py's follow-up note),
-    # mirroring kubewatch_webhook_handler's "ECR repo here, image build
-    # elsewhere" split.
-    ecr_repository = aws.ecr.Repository(
-        f"omnigraph-omnigraph-server-ecr-repository-{stack_info.env_suffix}",
-        name=f"omnigraph-server-{stack_info.env_suffix.lower()}",
-        image_tag_mutability="MUTABLE",
-        image_scanning_configuration=aws.ecr.RepositoryImageScanningConfigurationArgs(
-            scan_on_push=True,
-        ),
-        force_delete=True,
-        tags=aws_config.tags,
+    # The ``omnigraph-server`` ECR repository is created (idempotently) by the
+    # Concourse build job on every push, not managed here — see this module's
+    # docstring. One repo is shared across CI/QA/Production (same AWS
+    # account); the image is pinned by digest (OMNIGRAPH_DOCKER_SHA, set by
+    # the build job) so a new push actually changes this stage's Deployment
+    # pod spec.
+    omnigraph_aws_account = aws.get_caller_identity()
+    image_repository = (
+        f"{omnigraph_aws_account.account_id}.dkr.ecr.{aws_config.region}"
+        ".amazonaws.com/omnigraph-server"
     )
-    aws.ecr.LifecyclePolicy(
-        f"omnigraph-omnigraph-server-ecr-lifecycle-{stack_info.env_suffix}",
-        repository=ecr_repository.name,
-        policy=json.dumps(
-            {
-                "rules": [
-                    {
-                        "rulePriority": 1,
-                        "description": "Keep last 10 images",
-                        "selection": {
-                            "tagStatus": "any",
-                            "countType": "imageCountMoreThan",
-                            "countNumber": 10,
-                        },
-                        "action": {"type": "expire"},
-                    }
-                ]
-            }
-        ),
-    )
-    omnigraph_server_image: Output[str] = ecr_repository.repository_url.apply(
-        lambda url: f"{url}:latest"
-    )
+    omnigraph_server_image = format_docker_image_ref(image_repository, "OMNIGRAPH")
 
     # cluster.yaml — the single Layer-1 (memory/task/workflow) graph,
     # organization-wide, plus room for per-repo code graphs added the same
@@ -370,7 +348,7 @@ def create_data_tier(  # noqa: PLR0913
 
     return OmnigraphDataTier(
         bucket=omnigraph_bucket,
-        ecr_repository=ecr_repository,
+        image_repository=image_repository,
         service=omnigraph_service,
         deployment=omnigraph_deployment,
     )

--- a/src/ol_infrastructure/applications/witan/__main__.py
+++ b/src/ol_infrastructure/applications/witan/__main__.py
@@ -42,9 +42,16 @@ Incoming auth — ToolHive's "External OIDC provider" scenario, NOT
 
 Follow-up work this stack does NOT cover, tracked separately rather than
 silently assumed:
-    - **Container image.** witan has no image built in either repo yet; this
-      stack only creates the ECR repository and references ``:latest``, and
-      the ``witan``/``pulumi-witan`` Concourse pipeline builds and pushes it.
+    - **Container image.** The ``witan``/``pulumi-witan`` Concourse pipeline
+      builds the image once and promotes it unchanged through CI -> QA ->
+      Production. It also owns the ``witan`` ECR repository itself
+      (idempotent create-if-missing on every build), rather than this stack
+      creating it -- a single repo can't be owned by three independent
+      per-env Pulumi stacks. This stack instead pins the Deployment's image
+      by digest, read from ``WITAN_DOCKER_SHA`` (set by the build job via
+      the pulumi-provisioner's ``env_vars_from_files``), so a new push always
+      changes the pod spec and triggers a rollout instead of silently
+      leaving the running pod on a stale image.
     - **Keycloak witan-users token provisioning.** agent-kit ADR-0004 D3
       assigns the job of "walking the Keycloak witan-users group/role
       membership and writing a generated token per user" into the shared
@@ -54,7 +61,6 @@ silently assumed:
       current as Keycloak group membership changes is not yet built.
 """
 
-import json
 from pathlib import Path
 
 import pulumi_aws as aws
@@ -86,6 +92,7 @@ from ol_infrastructure.lib.ol_types import (
     Services,
 )
 from ol_infrastructure.lib.pulumi_helper import (
+    format_docker_image_ref,
     make_stack_reference,
     parse_stack,
     require_stack_output_value,
@@ -256,41 +263,19 @@ actor_tokens_secret = OLVaultK8SSecret(
 )
 
 #########################################
-#   ECR repository for the witan image   #
+#   witan image (built + repo owned by   #
+#   the pulumi-witan Concourse pipeline) #
 #########################################
-# "Repo here, image built separately by a Concourse job" split, mirroring
-# kubewatch_webhook_handler — see this module's docstring.
-witan_ecr_repository = aws.ecr.Repository(
-    f"witan-ecr-repository-{stack_info.env_suffix}",
-    name=f"witan-{stack_info.env_suffix.lower()}",
-    image_tag_mutability="MUTABLE",
-    image_scanning_configuration=aws.ecr.RepositoryImageScanningConfigurationArgs(
-        scan_on_push=True,
-    ),
-    force_delete=True,
-    tags=aws_config.tags,
+# The ``witan`` ECR repository is created (idempotently) by the Concourse
+# build job on every push, not managed here -- see this module's docstring.
+# One repo is shared across CI/QA/Production (same AWS account); the image
+# is pinned by digest (WITAN_DOCKER_SHA, set by the build job) so a new push
+# actually changes this stage's Deployment pod spec.
+witan_aws_account = aws.get_caller_identity()
+witan_image_repository = (
+    f"{witan_aws_account.account_id}.dkr.ecr.{aws_config.region}.amazonaws.com/witan"
 )
-aws.ecr.LifecyclePolicy(
-    f"witan-ecr-lifecycle-{stack_info.env_suffix}",
-    repository=witan_ecr_repository.name,
-    policy=json.dumps(
-        {
-            "rules": [
-                {
-                    "rulePriority": 1,
-                    "description": "Keep last 10 images",
-                    "selection": {
-                        "tagStatus": "any",
-                        "countType": "imageCountMoreThan",
-                        "countNumber": 10,
-                    },
-                    "action": {"type": "expire"},
-                }
-            ]
-        }
-    ),
-)
-witan_image = witan_ecr_repository.repository_url.apply(lambda url: f"{url}:latest")
+witan_image = format_docker_image_ref(witan_image_repository, "WITAN")
 
 #########################################
 #   MCPGroup + witan MCPServer           #
@@ -397,5 +382,5 @@ export("namespace", NAMESPACE)
 export("mcp_group_name", MCP_GROUP_NAME)
 export("vmcp_domain", VMCP_DOMAIN)
 export("vmcp_oidc_issuer", KEYCLOAK_ISSUER)
-export("witan_ecr_repository_url", witan_ecr_repository.repository_url)
+export("witan_image_repository", witan_image_repository)
 export("omnigraph_server_addr", omnigraph_server_addr)


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Updates the `witan` and `omnigraph-server` build+deploy Concourse pipelines (`src/ol_concourse/pipelines/infrastructure/witan/pipeline.py`, `src/ol_concourse/pipelines/infrastructure/omnigraph/pipeline.py`) to use the "ensure ECR" pattern for publishing their images (`ensure_ecr_task`, already used by e.g. `src/ol_concourse/pipelines/container_images/ol_superset.py`), and collapses each pipeline from three per-env ECR repos down to a single shared repo.

Previously, both pipelines built one image and pushed the identical tarball to three separately-named ECR repos (`witan-ci`/`witan-qa`/`witan-production`, `omnigraph-server-ci`/`-qa`/`-production`), each provisioned by its own per-env Pulumi stack. That's inconsistent with every other build+deploy pipeline in this repo (`k8s_apps`, `kubewatch_webhook_handler`), which build once and promote the same image unchanged through CI -> QA -> Production via Concourse's `passed` gating.

Changes:
- **Pipelines**: one shared registry-image resource per app instead of three; the build job now runs `ensure_ecr_task(IMAGE_NAME)` before pushing, so the pipeline itself idempotently creates the ECR repo instead of depending on Pulumi having already created it. Each deploy stage gates (`passed`) on the previous stage having deployed that same image, matching `k8s_apps`.
- **Pulumi (`applications/witan/__main__.py`, `applications/omnigraph/data_tier.py` + `__main__.py`)**: removed the per-env `aws.ecr.Repository`/`LifecyclePolicy` resources -- a single shared repo can't be safely co-owned by three independent per-env Pulumi stacks, so the Concourse pipeline now owns repo creation exclusively (mirroring the existing `release-bot` pattern, see `src/ol_infrastructure/applications/release_bot/__main__.py`). The Deployment's image reference switched from a mutable `:latest` tag to a digest pin via `format_docker_image_ref()` (`src/ol_infrastructure/lib/pulumi_helper.py`), read from `WITAN_DOCKER_SHA` / `OMNIGRAPH_DOCKER_SHA` -- set per stage by the pulumi-provisioner's `env_vars_from_files`, sourced from the pushed image's digest file. This ensures a promoted image actually changes the pod spec instead of silently leaving a running pod on a stale image.

### Screenshots (if appropriate):
N/A

### How can this be tested?
- `ruff check`, `ruff format --check`, and `mypy` pass on all 5 changed files.
- Verified the generated pipeline JSON (`build_witan_pipeline()` / `build_omnigraph_pipeline()`) produces a single `witan-image` / `omnigraph-server-image` resource, a build job with an `ensure-ecr-repository` task step ahead of the push, and that each deploy stage's `env_vars_from_files` carries `WITAN_DOCKER_SHA` / `OMNIGRAPH_DOCKER_SHA` pointing at the image resource's `digest` file.
- Verified the `passed` chain: CI's `GetStep` gates on the build job; QA gates (`passed`) on CI having deployed; Production gates on QA -- so the identical image promotes through every stage rather than being rebuilt or repushed per env.
- Not yet run against live Concourse/Pulumi state (see Additional Context).

### Additional Context
Rollout ordering: Pulumi currently manages the old per-env `witan-ci`/`witan-qa`/`witan-production` and `omnigraph-server-ci`/`-qa`/`-production` ECR repos in state. Once this merges, the next `pulumi up` for each stack will propose *deleting* those repos since they're no longer declared in code. Run the updated Concourse pipeline at least once first -- so the new shared `witan` / `omnigraph-server` repos exist and have an image pushed -- before applying the Pulumi changes, to avoid a window where a Deployment has nothing to pull.