### PR TITLE
fix(concourse): lengthen github-issues poll frequency for github.mit.edu

### DIFF
--- a/src/ol_concourse/pipelines/constants.py
+++ b/src/ol_concourse/pipelines/constants.py
@@ -1,6 +1,14 @@
 from pathlib import Path
 
+from ol_concourse.lib.models.pipeline import Duration
+
 GH_ISSUES_DEFAULT_REPOSITORY = "ol-platform-eng/concourse-workflow"
+
+# The github-issues resource defaults to polling the github.mit.edu enterprise
+# appliance (gh_host defaults to https://github.mit.edu/api/v3). That appliance
+# is under heavy load, so pipelines gating on it should poll less often than
+# the resource's own 60m default.
+GH_ISSUES_ENTERPRISE_POLL_FREQUENCY = Duration("4h")
 
 # ECR pull-through cache for Docker Hub — avoids Docker Hub rate limits.
 # Set aws_region (inline dicts) or ecr_region (registry_image()) alongside

--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
@@ -15,7 +15,6 @@ from ol_concourse.lib.models.fragment import PipelineFragment
 from ol_concourse.lib.models.pipeline import (
     AnonymousResource,
     Command,
-    Duration,
     GetStep,
     Identifier,
     Input,
@@ -33,6 +32,7 @@ from pydantic import BaseModel, model_validator
 from ol_concourse.pipelines.constants import (
     ECR_REGION,
     GH_ISSUES_DEFAULT_REPOSITORY,
+    GH_ISSUES_ENTERPRISE_POLL_FREQUENCY,
     PULUMI_CODE_PATH,
     PULUMI_WATCHED_PATHS,
     dockerhub_ecr_image_uri,
@@ -687,7 +687,7 @@ def build_simple_pulumi_pipeline(app_name: str) -> Pipeline:
                 f" {params.prior_stage_stack} deployed."
             ),
             issue_state="closed",
-            poll_frequency=Duration("15m"),
+            poll_frequency=GH_ISSUES_ENTERPRISE_POLL_FREQUENCY,
         )
         cross_env_resources.append(prior_trigger)
         cross_env_custom_deps = {0: [GetStep(get=prior_trigger.name, trigger=True)]}

--- a/src/ol_concourse/pipelines/open_edx/mfe/meta.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/meta.py
@@ -130,6 +130,7 @@ def meta_pipeline() -> Pipeline:
         paths=[
             "src/ol_concourse/pipelines/open_edx/mfe/",
             "pyproject.toml",
+            "src/ol_concourse/pipelines/constants.py",
             "src/ol_concourse/pipelines/jobs.py",
             "src/bridge/settings/openedx/",
         ],

--- a/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/pipeline.py
@@ -55,6 +55,7 @@ from bridge.settings.openedx.types import (
 from bridge.settings.openedx.version_matrix import OpenLearningOpenEdxDeployment
 from ol_concourse.pipelines.constants import (
     GH_ISSUES_DEFAULT_REPOSITORY,
+    GH_ISSUES_ENTERPRISE_POLL_FREQUENCY,
 )
 
 LEHRER_URI = "https://github.com/mitodl/lehrer"
@@ -374,6 +375,7 @@ def mfe_job(
             f"for {open_edx_deployment.deployment_name}"
         ),
         issue_state="open",
+        poll_frequency=GH_ISSUES_ENTERPRISE_POLL_FREQUENCY,
     )
 
     default_github_issue_labels = [
@@ -463,6 +465,7 @@ def mfe_pipeline(
                     issue_title_template=issue_title,
                     issue_prefix=issue_title,
                     issue_state="closed",
+                    poll_frequency=GH_ISSUES_ENTERPRISE_POLL_FREQUENCY,
                 )
                 mfe_fragment.resources.append(gh_issues_trigger)
                 last_gh_issue_resource_name_per_mfe[mfe_app_name] = (

--- a/src/ol_concourse/pipelines/open_edx/mfe/site_pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/site_pipeline.py
@@ -43,7 +43,10 @@ from ol_concourse.lib.resource_types import github_issues_resource, rclone
 from ol_concourse.lib.resources import git_repo, github_issues
 
 from bridge.settings.github.team_members import DEVOPS_MIT
-from ol_concourse.pipelines.constants import GH_ISSUES_DEFAULT_REPOSITORY
+from ol_concourse.pipelines.constants import (
+    GH_ISSUES_DEFAULT_REPOSITORY,
+    GH_ISSUES_ENTERPRISE_POLL_FREQUENCY,
+)
 
 LEHRER_URI = "https://github.com/mitodl/lehrer"
 
@@ -115,6 +118,7 @@ def _gh_issues_post(deployment_name: str, stage: str) -> Resource:
         issue_title_template=title,
         issue_prefix=title,
         issue_state="open",
+        poll_frequency=GH_ISSUES_ENTERPRISE_POLL_FREQUENCY,
     )
 
 
@@ -129,6 +133,7 @@ def _gh_issues_trigger(deployment_name: str, stage: str) -> Resource:
         issue_title_template=title,
         issue_prefix=title,
         issue_state="closed",
+        poll_frequency=GH_ISSUES_ENTERPRISE_POLL_FREQUENCY,
     )
 
 


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
The github.mit.edu GitHub Enterprise appliance has been under heavy load, and our Concourse `github-issues` resource integration is part of that load. The `github_issues()` helper in `ol_concourse.lib.resources` defaults `gh_host` to `https://github.mit.edu/api/v3`, so any pipeline that doesn't explicitly override `gh_host` is polling the enterprise appliance.

This adds a shared `GH_ISSUES_ENTERPRISE_POLL_FREQUENCY` constant (`Duration("4h")`) in `src/ol_concourse/pipelines/constants.py` and applies it to every `github_issues()` call site in `src/ol_concourse/pipelines/` that targets `github.mit.edu` (i.e. doesn't override `gh_host`):

- `open_edx/mfe/pipeline.py` — both `github_issues()` calls (previously relied on the library's 60m default)
- `open_edx/mfe/site_pipeline.py` — `_gh_issues_post` and `_gh_issues_trigger`
- `infrastructure/simple_pulumi/pipeline.py` — the cross-environment release gate, which was explicitly set to poll every **15m**, i.e. *more* often than the resource's own 60m default. This was the worst offender.

The two `github_issues()` calls in `infrastructure/k8s_apps/pipeline.py` are untouched — they already pass `gh_host=None`, so they poll public github.com, not the appliance.

Also added `src/ol_concourse/pipelines/constants.py` to the `mfe` meta pipeline's watched `paths` (`open_edx/mfe/meta.py`). It previously only watched the `mfe/` directory, `pyproject.toml`, `jobs.py`, and `bridge/settings/openedx/` — so a change to `constants.py` alone (like this one) would not have triggered that meta pipeline to regenerate and redeploy its child pipelines. The `simple_pulumi` meta pipeline already watched `constants.py`.

### Screenshots (if appropriate):

### How can this be tested?
- `ruff check` / `ruff format` / `mypy` / pre-commit all pass locally.
- Verified via `python -c "import ol_concourse.pipelines.constants"` etc. that all edited modules still import cleanly.
- Reviewer validation: confirm none of the affected pipelines need release/promotion issue-close latency tighter than ~4h; if they do, `GH_ISSUES_ENTERPRISE_POLL_FREQUENCY` is a single constant to tune.

### Additional Context
Trade-off: these `github-issues` resources gate release/promotion workflows (a job waits for a bot-filed issue to be closed before promoting to the next stage/environment). Raising the poll interval to 4h means promotion latency after closing the gating issue can now take up to ~4h instead of ~15–60m. If that's too coarse for some pipelines, a shorter shared value (e.g. `2h`) is a one-line change to the constant in `constants.py`.