### PR TITLE
feat(concourse): apply scan-on-push + lifecycle policy to more ECR repos

### DIFF
--- a/src/ol_concourse/pipelines/container_images/dcind.py
+++ b/src/ol_concourse/pipelines/container_images/dcind.py
@@ -19,6 +19,7 @@ from ol_concourse.lib.models.pipeline import (
 from ol_concourse.lib.resources import git_repo, github_release, registry_image
 
 from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
+from ol_concourse.pipelines.ecr import configure_ecr_repository_task
 
 ol_inf_repo = git_repo(
     name=Identifier("ol-infrastructure-repository"),
@@ -101,6 +102,7 @@ docker_pipeline = Pipeline(
                     },
                 ),
                 ensure_ecr_task("mitodl/dcind"),
+                configure_ecr_repository_task("mitodl/dcind"),
                 PutStep(
                     put=dcind_release_image.name,
                     inputs="detect",

--- a/src/ol_concourse/pipelines/container_images/google_ads_optimization.py
+++ b/src/ol_concourse/pipelines/container_images/google_ads_optimization.py
@@ -13,6 +13,7 @@ from ol_concourse.lib.models.pipeline import (
 from ol_concourse.lib.resources import git_repo, registry_image
 
 from ol_concourse.pipelines.constants import ECR_REGION
+from ol_concourse.pipelines.ecr import configure_ecr_repository_task
 
 ad_opt_repository = git_repo(
     name=Identifier("ad-opt-resource"),
@@ -54,6 +55,7 @@ docker_pipeline = Pipeline(
                 GetStep(get=ad_opt_repository.name, trigger=True),
                 build_task,
                 ensure_ecr_task("mitodl/ad-opt"),
+                configure_ecr_repository_task("mitodl/ad-opt"),
                 PutStep(
                     put=ad_opt_release_image.name,
                     params={

--- a/src/ol_concourse/pipelines/container_images/hashicorp_release_resource.py
+++ b/src/ol_concourse/pipelines/container_images/hashicorp_release_resource.py
@@ -13,6 +13,7 @@ from ol_concourse.lib.models.pipeline import (
 from ol_concourse.lib.resources import git_repo, registry_image
 
 from ol_concourse.pipelines.constants import ECR_REGION
+from ol_concourse.pipelines.ecr import configure_ecr_repository_task
 
 hashicorp_release_repository = git_repo(
     name=Identifier("hashicorp-release-resource"),
@@ -58,6 +59,7 @@ docker_pipeline = Pipeline(
                 GetStep(get=hashicorp_release_repository.name, trigger=True),
                 build_task,
                 ensure_ecr_task("mitodl/hashicorp-release-resource"),
+                configure_ecr_repository_task("mitodl/hashicorp-release-resource"),
                 PutStep(
                     put=hashicorp_release_image.name,
                     params={

--- a/src/ol_concourse/pipelines/container_images/mitodl_concourse_npm_resource.py
+++ b/src/ol_concourse/pipelines/container_images/mitodl_concourse_npm_resource.py
@@ -13,6 +13,7 @@ from ol_concourse.lib.models.pipeline import (
 from ol_concourse.lib.resources import git_repo, registry_image
 
 from ol_concourse.pipelines.constants import ECR_REGION
+from ol_concourse.pipelines.ecr import configure_ecr_repository_task
 
 concourse_npm_resource_repository = git_repo(
     name=Identifier("mitodl-concourse-npm-resource"),
@@ -58,6 +59,7 @@ docker_pipeline = Pipeline(
                 GetStep(get=concourse_npm_resource_repository.name, trigger=True),
                 build_task,
                 ensure_ecr_task("mitodl/concourse-npm-resource"),
+                configure_ecr_repository_task("mitodl/concourse-npm-resource"),
                 PutStep(
                     put=concourse_npm_resource_image.name,
                     params={

--- a/src/ol_concourse/pipelines/container_images/ocw_course_publisher.py
+++ b/src/ol_concourse/pipelines/container_images/ocw_course_publisher.py
@@ -13,6 +13,7 @@ from ol_concourse.lib.models.pipeline import (
 from ol_concourse.lib.resources import git_repo, registry_image
 
 from ol_concourse.pipelines.constants import ECR_REGION
+from ol_concourse.pipelines.ecr import configure_ecr_repository_task
 
 ocw_studio_repo = git_repo(
     name=Identifier("ocw-studio-repository"),
@@ -65,6 +66,7 @@ docker_pipeline = Pipeline(
                 GetStep(get=ocw_studio_repo.name, trigger=True),
                 build_task,
                 ensure_ecr_task("mitodl/ocw-course-publisher"),
+                configure_ecr_repository_task("mitodl/ocw-course-publisher"),
                 PutStep(
                     put=ocw_course_publisher_image.name,
                     params={

--- a/src/ol_concourse/pipelines/container_images/ol_python_base.py
+++ b/src/ol_concourse/pipelines/container_images/ol_python_base.py
@@ -12,6 +12,7 @@ from ol_concourse.lib.models.pipeline import (
 from ol_concourse.lib.resources import git_repo, registry_image
 
 from ol_concourse.pipelines.constants import ECR_REGION
+from ol_concourse.pipelines.ecr import configure_ecr_repository_task
 
 PYTHON_VERSIONS = ("3.11", "3.12", "3.13", "3.14")
 
@@ -65,6 +66,7 @@ def build_job(python_version: str) -> Job:
                 },
             ),
             ensure_ecr_task("mitodl/ol-python-base"),
+            configure_ecr_repository_task("mitodl/ol-python-base"),
             PutStep(
                 put=image_resources[python_version].name,
                 inputs="detect",

--- a/src/ol_concourse/pipelines/container_images/ol_superset.py
+++ b/src/ol_concourse/pipelines/container_images/ol_superset.py
@@ -13,6 +13,7 @@ from ol_concourse.lib.models.pipeline import (
 from ol_concourse.lib.resources import git_repo, registry_image
 
 from ol_concourse.pipelines.constants import ECR_REGION
+from ol_concourse.pipelines.ecr import configure_ecr_repository_task
 
 ol_data_platform_repo = git_repo(
     name=Identifier("ol-data-platform-repository"),
@@ -60,6 +61,7 @@ docker_pipeline = Pipeline(
                     },
                 ),
                 ensure_ecr_task("mitodl/ol-superset"),
+                configure_ecr_repository_task("mitodl/ol-superset"),
                 PutStep(
                     put=ol_superset_image.name,
                     params={"image": "image/image.tar"},

--- a/src/ol_concourse/pipelines/container_images/openedx_tubular.py
+++ b/src/ol_concourse/pipelines/container_images/openedx_tubular.py
@@ -13,6 +13,7 @@ from ol_concourse.lib.models.pipeline import (
 from ol_concourse.lib.resources import git_repo, registry_image
 
 from ol_concourse.pipelines.constants import ECR_REGION
+from ol_concourse.pipelines.ecr import configure_ecr_repository_task
 
 tubular_repository = git_repo(
     name=Identifier("openedx-tubular"),
@@ -54,6 +55,7 @@ docker_pipeline = Pipeline(
                 GetStep(get=tubular_repository.name, trigger=True),
                 build_task,
                 ensure_ecr_task("mitodl/openedx-tubular"),
+                configure_ecr_repository_task("mitodl/openedx-tubular"),
                 PutStep(
                     put=tubular_image.name,
                     params={

--- a/src/ol_concourse/pipelines/ecr.py
+++ b/src/ol_concourse/pipelines/ecr.py
@@ -1,0 +1,84 @@
+"""Follow-up ECR repository configuration, paired with ``ensure_ecr_task``.
+
+``ensure_ecr_task`` (``ol_concourse.lib.containers``) only creates the
+repository if it's missing, with AWS defaults: scanning disabled, unlimited
+image retention. Pipelines whose ECR repo used to be a Pulumi-managed
+``aws.ecr.Repository`` (scan-on-push + a lifecycle policy) but moved
+ownership to the pipeline -- because a repo shared across CI/QA/Production
+can't be owned by three independent per-env Pulumi stacks -- need this step
+too, to keep the same repository configuration.
+"""
+
+import json
+
+from ol_concourse.lib.models.pipeline import (
+    AnonymousResource,
+    Command,
+    Identifier,
+    Platform,
+    TaskConfig,
+    TaskStep,
+)
+
+from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
+
+
+def configure_ecr_repository_task(
+    repo_name: str, *, keep_last_n_images: int = 10
+) -> TaskStep:
+    """Return a TaskStep applying scan-on-push + an image-count lifecycle policy.
+
+    Safe to run on every pipeline execution: both
+    ``put-image-scanning-configuration`` and ``put-lifecycle-policy`` are
+    idempotent -- each call just (re)applies the same configuration.
+
+    :param repo_name: The ECR repository name, e.g. ``"witan"``.
+    :param keep_last_n_images: Expire all but the most recent N images.
+    """
+    lifecycle_policy = json.dumps(
+        {
+            "rules": [
+                {
+                    "rulePriority": 1,
+                    "description": f"Keep last {keep_last_n_images} images",
+                    "selection": {
+                        "tagStatus": "any",
+                        "countType": "imageCountMoreThan",
+                        "countNumber": keep_last_n_images,
+                    },
+                    "action": {"type": "expire"},
+                }
+            ]
+        }
+    )
+    return TaskStep(
+        task=Identifier("configure-ecr-repository"),
+        config=TaskConfig(
+            platform=Platform.linux,
+            image_resource=AnonymousResource(
+                type="registry-image",
+                source={
+                    "repository": dockerhub_ecr_image_uri("amazon/aws-cli"),
+                    "tag": "latest",
+                    "aws_region": ECR_REGION,
+                },
+            ),
+            params={
+                "REPO_NAME": repo_name,
+                "LIFECYCLE_POLICY": lifecycle_policy,
+                "AWS_PAGER": "cat",
+            },
+            run=Command(
+                path="sh",
+                args=[
+                    "-exc",
+                    "aws ecr put-image-scanning-configuration"
+                    " --repository-name ${REPO_NAME}"
+                    " --image-scanning-configuration scanOnPush=true"
+                    " && aws ecr put-lifecycle-policy"
+                    " --repository-name ${REPO_NAME}"
+                    ' --lifecycle-policy-text "$LIFECYCLE_POLICY"',
+                ],
+            ),
+        ),
+    )

--- a/src/ol_concourse/pipelines/infrastructure/omnigraph/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/omnigraph/pipeline.py
@@ -49,6 +49,7 @@ from ol_concourse.pipelines.constants import (
     PULUMI_CODE_PATH,
     PULUMI_WATCHED_PATHS,
 )
+from ol_concourse.pipelines.ecr import configure_ecr_repository_task
 from ol_concourse.pipelines.jobs import pulumi_jobs_chain
 
 ENVIRONMENTS = ("CI", "QA", "Production")
@@ -110,6 +111,7 @@ def build_omnigraph_pipeline() -> PipelineFragment:
                 },
             ),
             ensure_ecr_task(IMAGE_NAME),
+            configure_ecr_repository_task(IMAGE_NAME),
             PutStep(
                 put=image_resource.name,
                 params={

--- a/src/ol_concourse/pipelines/infrastructure/omnigraph/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/omnigraph/pipeline.py
@@ -10,14 +10,17 @@ the image and runs the Pulumi deploy off the ol-infrastructure checkout.
 
 Flow (mirrors ``kubewatch``'s build-then-deploy shape):
 
-    agent-kit push -> build omnigraph-server image -> push to omnigraph-server-<env> ECR
-        -> pulumi deploy ``ol-application-omnigraph`` (CI -> QA -> Production),
-           each stage gated (``passed``) on its freshly built image.
+    agent-kit push -> build omnigraph-server image -> push to omnigraph-server ECR
+        -> pulumi deploy ``ol-application-omnigraph`` CI, gated on that image
+           -> pulumi deploy QA, gated (``passed``) on CI having deployed that
+              same image -> Production, gated on QA. One image is built once
+              and promoted unchanged through every stage, matching every
+              other build+deploy pipeline in this repo (e.g. ``k8s_apps``).
 
-The ECR repositories (``omnigraph-server-<env>``) are provisioned by the
-Pulumi stack itself (``applications/omnigraph``); this pipeline only builds the
-image and pushes to them, exactly like ``kubewatch_webhook_handler``'s "ECR
-repo in Pulumi, image built elsewhere" split.
+The build job ensures the ECR repository (``omnigraph-server``) exists before
+pushing to it (``ensure_ecr_task``), rather than depending on the Pulumi
+stack (``applications/omnigraph``) having already created it -- this removes
+the bootstrap ordering dependency between the two.
 
 witan (``pulumi-witan``) is a separate pipeline deploying a separate stack that
 reaches this service via a StackReference; the two ship independently.
@@ -30,7 +33,7 @@ Fly command to bootstrap this pipeline (normally set by the
 
 import sys
 
-from ol_concourse.lib.containers import container_build_task
+from ol_concourse.lib.containers import container_build_task, ensure_ecr_task
 from ol_concourse.lib.models.fragment import PipelineFragment
 from ol_concourse.lib.models.pipeline import (
     GetStep,
@@ -38,7 +41,6 @@ from ol_concourse.lib.models.pipeline import (
     Input,
     Job,
     PutStep,
-    Resource,
 )
 from ol_concourse.lib.resources import git_repo, registry_image
 
@@ -85,17 +87,15 @@ def build_omnigraph_pipeline() -> PipelineFragment:
         ],
     )
 
-    # One registry-image resource per env: the build job pushes the single
-    # freshly built tarball to each env's ECR repo, and each deploy stage gates
-    # on its own env resource.
-    image_resources: dict[str, Resource] = {
-        env: registry_image(
-            name=Identifier(f"{IMAGE_NAME}-{env.lower()}-image"),
-            image_repository=f"{IMAGE_NAME}-{env.lower()}",
-            ecr_region=ECR_REGION,
-        )
-        for env in ENVIRONMENTS
-    }
+    # A single registry-image resource: the build job pushes one tarball here,
+    # and that same image is promoted unchanged through every deploy stage
+    # below (via the ``passed`` chain pulumi_jobs_chain builds from
+    # ``dependencies``), rather than being pushed separately per env.
+    image_resource = registry_image(
+        name=Identifier(f"{IMAGE_NAME}-image"),
+        image_repository=IMAGE_NAME,
+        ecr_region=ECR_REGION,
+    )
 
     build_job = Job(
         name=Identifier(f"build-{IMAGE_NAME}-image"),
@@ -109,46 +109,45 @@ def build_omnigraph_pipeline() -> PipelineFragment:
                     "DOCKERFILE": f"{agent_kit_code.name}/{DOCKERFILE}",
                 },
             ),
-            *[
-                PutStep(
-                    put=image_resources[env].name,
-                    params={
-                        "image": "image/image.tar",
-                        "additional_tags": f"{agent_kit_code.name}/.git/short_ref",
-                    },
-                )
-                for env in ENVIRONMENTS
-            ],
+            ensure_ecr_task(IMAGE_NAME),
+            PutStep(
+                put=image_resource.name,
+                params={
+                    "image": "image/image.tar",
+                    "additional_tags": f"{agent_kit_code.name}/.git/short_ref",
+                },
+            ),
         ],
     )
 
-    # Each deploy stage triggers off — and is gated (``passed``) on — the image
-    # for that env, so a stage only redeploys images this pipeline itself built.
-    custom_dependencies: dict[int, list[GetStep]] = {
-        idx: [
-            GetStep(
-                get=image_resources[env].name,
-                trigger=True,
-                passed=[build_job.name],
-            )
-        ]
-        for idx, env in enumerate(ENVIRONMENTS)
-    }
-
+    # A single shared GetStep: pulumi_jobs_chain rewrites its trigger/passed
+    # per stage -- CI triggers on a fresh build, QA and Production instead
+    # gate (``passed``) on the *previous* stage having deployed that same
+    # image, so the identical artifact promotes through every stage. The
+    # image is pinned by digest (OMNIGRAPH_DOCKER_SHA, read by data_tier.py
+    # via format_docker_image_ref) rather than a mutable ``:latest`` tag, so
+    # a promoted image actually changes each stage's Deployment pod spec.
     deploy_fragment = pulumi_jobs_chain(
         refresh_stack=True,
         pulumi_code=pulumi_code,
         stack_names=list(ENVIRONMENTS),
         project_name="ol-application-omnigraph",
         project_source_path=PULUMI_PROJECT_PATH,
-        custom_dependencies=custom_dependencies,
+        dependencies=[
+            GetStep(
+                get=image_resource.name,
+                trigger=True,
+                passed=[build_job.name],
+            )
+        ],
+        env_vars_from_files={"OMNIGRAPH_DOCKER_SHA": f"{image_resource.name}/digest"},
     )
 
     # combine_fragments deduplicates resources/resource-types by name (the
     # field validators only fire on assignment, not on ``.append``), so route
     # the final assembly through it rather than mutating a fragment in place.
     build_fragment = PipelineFragment(
-        resources=[agent_kit_code, pulumi_code, *image_resources.values()],
+        resources=[agent_kit_code, pulumi_code, image_resource],
         jobs=[build_job],
     )
     return PipelineFragment.combine_fragments(build_fragment, deploy_fragment)

--- a/src/ol_concourse/pipelines/infrastructure/witan/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/witan/pipeline.py
@@ -52,6 +52,7 @@ from ol_concourse.pipelines.constants import (
     PULUMI_CODE_PATH,
     PULUMI_WATCHED_PATHS,
 )
+from ol_concourse.pipelines.ecr import configure_ecr_repository_task
 from ol_concourse.pipelines.jobs import pulumi_jobs_chain
 
 ENVIRONMENTS = ("CI", "QA", "Production")
@@ -113,6 +114,7 @@ def build_witan_pipeline() -> PipelineFragment:
                 },
             ),
             ensure_ecr_task(IMAGE_NAME),
+            configure_ecr_repository_task(IMAGE_NAME),
             PutStep(
                 put=image_resource.name,
                 params={

--- a/src/ol_concourse/pipelines/infrastructure/witan/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/witan/pipeline.py
@@ -10,14 +10,17 @@ ol-infrastructure checkout.
 
 Flow (mirrors ``kubewatch``'s build-then-deploy shape):
 
-    agent-kit push -> build witan image -> push to witan-<env> ECR
-        -> pulumi deploy ``ol-application-witan`` (CI -> QA -> Production),
-           each stage gated (``passed``) on its freshly built image.
+    agent-kit push -> build witan image -> push to witan ECR
+        -> pulumi deploy ``ol-application-witan`` CI, gated on that image
+           -> pulumi deploy QA, gated (``passed``) on CI having deployed that
+              same image -> Production, gated on QA. One image is built once
+              and promoted unchanged through every stage, matching every
+              other build+deploy pipeline in this repo (e.g. ``k8s_apps``).
 
-The ECR repositories (``witan-<env>``) are provisioned by the Pulumi stack
-itself (``applications/witan``); this pipeline only builds the image and pushes
-to them, exactly like ``kubewatch_webhook_handler``'s "ECR repo in Pulumi,
-image built elsewhere" split.
+The build job ensures the ECR repository (``witan``) exists before pushing to
+it (``ensure_ecr_task``), rather than depending on the Pulumi stack
+(``applications/witan``) having already created it -- this removes the
+bootstrap ordering dependency between the two.
 
 The witan stack reaches the omnigraph-server data tier (deployed by the
 separate ``pulumi-omnigraph`` pipeline / ``ol-application-omnigraph`` stack)
@@ -33,7 +36,7 @@ Fly command to bootstrap this pipeline (normally set by the
 
 import sys
 
-from ol_concourse.lib.containers import container_build_task
+from ol_concourse.lib.containers import container_build_task, ensure_ecr_task
 from ol_concourse.lib.models.fragment import PipelineFragment
 from ol_concourse.lib.models.pipeline import (
     GetStep,
@@ -41,7 +44,6 @@ from ol_concourse.lib.models.pipeline import (
     Input,
     Job,
     PutStep,
-    Resource,
 )
 from ol_concourse.lib.resources import git_repo, registry_image
 
@@ -88,17 +90,15 @@ def build_witan_pipeline() -> PipelineFragment:
         ],
     )
 
-    # One registry-image resource per env: the build job pushes the single
-    # freshly built tarball to each env's ECR repo, and each deploy stage gates
-    # on its own env resource.
-    image_resources: dict[str, Resource] = {
-        env: registry_image(
-            name=Identifier(f"{IMAGE_NAME}-{env.lower()}-image"),
-            image_repository=f"{IMAGE_NAME}-{env.lower()}",
-            ecr_region=ECR_REGION,
-        )
-        for env in ENVIRONMENTS
-    }
+    # A single registry-image resource: the build job pushes one tarball here,
+    # and that same image is promoted unchanged through every deploy stage
+    # below (via the ``passed`` chain pulumi_jobs_chain builds from
+    # ``dependencies``), rather than being pushed separately per env.
+    image_resource = registry_image(
+        name=Identifier(f"{IMAGE_NAME}-image"),
+        image_repository=IMAGE_NAME,
+        ecr_region=ECR_REGION,
+    )
 
     build_job = Job(
         name=Identifier(f"build-{IMAGE_NAME}-image"),
@@ -112,46 +112,45 @@ def build_witan_pipeline() -> PipelineFragment:
                     "DOCKERFILE": f"{agent_kit_code.name}/{DOCKERFILE}",
                 },
             ),
-            *[
-                PutStep(
-                    put=image_resources[env].name,
-                    params={
-                        "image": "image/image.tar",
-                        "additional_tags": f"{agent_kit_code.name}/.git/short_ref",
-                    },
-                )
-                for env in ENVIRONMENTS
-            ],
+            ensure_ecr_task(IMAGE_NAME),
+            PutStep(
+                put=image_resource.name,
+                params={
+                    "image": "image/image.tar",
+                    "additional_tags": f"{agent_kit_code.name}/.git/short_ref",
+                },
+            ),
         ],
     )
 
-    # Each deploy stage triggers off — and is gated (``passed``) on — the image
-    # for that env, so a stage only redeploys images this pipeline itself built.
-    custom_dependencies: dict[int, list[GetStep]] = {
-        idx: [
-            GetStep(
-                get=image_resources[env].name,
-                trigger=True,
-                passed=[build_job.name],
-            )
-        ]
-        for idx, env in enumerate(ENVIRONMENTS)
-    }
-
+    # A single shared GetStep: pulumi_jobs_chain rewrites its trigger/passed
+    # per stage -- CI triggers on a fresh build, QA and Production instead
+    # gate (``passed``) on the *previous* stage having deployed that same
+    # image, so the identical artifact promotes through every stage. The
+    # image is pinned by digest (WITAN_DOCKER_SHA, read by __main__.py via
+    # format_docker_image_ref) rather than a mutable ``:latest`` tag, so a
+    # promoted image actually changes each stage's Deployment pod spec.
     deploy_fragment = pulumi_jobs_chain(
         refresh_stack=True,
         pulumi_code=pulumi_code,
         stack_names=list(ENVIRONMENTS),
         project_name="ol-application-witan",
         project_source_path=PULUMI_PROJECT_PATH,
-        custom_dependencies=custom_dependencies,
+        dependencies=[
+            GetStep(
+                get=image_resource.name,
+                trigger=True,
+                passed=[build_job.name],
+            )
+        ],
+        env_vars_from_files={"WITAN_DOCKER_SHA": f"{image_resource.name}/digest"},
     )
 
     # combine_fragments deduplicates resources/resource-types by name (the
     # field validators only fire on assignment, not on ``.append``), so route
     # the final assembly through it rather than mutating a fragment in place.
     build_fragment = PipelineFragment(
-        resources=[agent_kit_code, pulumi_code, *image_resources.values()],
+        resources=[agent_kit_code, pulumi_code, image_resource],
         jobs=[build_job],
     )
     return PipelineFragment.combine_fragments(build_fragment, deploy_fragment)

--- a/src/ol_concourse/pipelines/open_edx/grader_images/base_image_pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/grader_images/base_image_pipeline.py
@@ -46,6 +46,8 @@ from ol_concourse.lib.models.pipeline import (
 )
 from ol_concourse.lib.resources import git_repo, registry_image
 
+from ol_concourse.pipelines.ecr import configure_ecr_repository_task
+
 _AWS_REGION = "us-east-1"
 _BASE_IMAGE_REPO = "mitodl/xqueue-watcher-grader-base"
 _PYTHON_VERSIONS = ("3.12", "3.13", "3.14")
@@ -154,6 +156,7 @@ def grader_base_image_pipeline() -> Pipeline:
                 },
             ),
             ensure_ecr_task(_BASE_IMAGE_REPO),
+            configure_ecr_repository_task(_BASE_IMAGE_REPO),
             _version_tag_task(str(xqwatcher_repo.name), python_version),
             # Push to DockerHub first — fail fast if credentials are wrong
             # before consuming the ECR push quota.

--- a/src/ol_concourse/pipelines/open_edx/grader_images/build_pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/grader_images/build_pipeline.py
@@ -44,6 +44,7 @@ from ol_concourse.lib.models.pipeline import (
 from ol_concourse.lib.resources import registry_image, ssh_git_repo
 
 from ol_concourse.pipelines.constants import ECR_REGION, dockerhub_ecr_image_uri
+from ol_concourse.pipelines.ecr import configure_ecr_repository_task
 from ol_concourse.pipelines.open_edx.grader_images.base_image_pipeline import (
     DEFAULT_PYTHON_VERSION,
 )
@@ -180,6 +181,7 @@ def grader_image_pipeline(config: GraderPipelineConfig) -> Pipeline:
                 ),
             ),
             ensure_ecr_task(config.ecr_repo_name),
+            configure_ecr_repository_task(config.ecr_repo_name),
             PutStep(
                 put=grader_ecr_image.name,
                 params={

--- a/src/ol_infrastructure/applications/omnigraph/__main__.py
+++ b/src/ol_infrastructure/applications/omnigraph/__main__.py
@@ -22,10 +22,11 @@ into the ``actor-tokens`` Secret (agent-kit ADR-0004 D3). See
 ``docs/adr/0009-deploy-witan-as-shared-multi-tenant-mcp-service.md``.
 
 Follow-up work this stack does NOT cover (tracked separately):
-    - **Container image.** omnigraph-server has no image built in either repo
-      yet; this stack only provisions the ECR repository and references
-      ``:latest`` (the ``omnigraph``/``pulumi-omnigraph`` Concourse pipeline
-      builds and pushes it). ``schema.pg`` (agent-kit repo,
+    - **Container image.** The ``omnigraph``/``pulumi-omnigraph`` Concourse
+      pipeline builds the image once, owns the ECR repository itself
+      (idempotent create-if-missing), and promotes the same image unchanged
+      through CI -> QA -> Production — see ``data_tier.py``'s module
+      docstring. ``schema.pg`` (agent-kit repo,
       ``mcp/servers/witan/schema/schema.pg``) must be baked into the image at
       build time — this Pulumi program has no access to agent-kit's tree.
     - **Keycloak witan-users token sync.** This stack provisions the
@@ -174,7 +175,4 @@ data_tier = create_data_tier(
 
 export("namespace", NAMESPACE)
 export("omnigraph_server_addr", omnigraph_server_addr(NAMESPACE))
-export(
-    "omnigraph_server_ecr_repository_url",
-    data_tier.ecr_repository.repository_url,
-)
+export("omnigraph_server_image_repository", data_tier.image_repository)

--- a/src/ol_infrastructure/applications/omnigraph/data_tier.py
+++ b/src/ol_infrastructure/applications/omnigraph/data_tier.py
@@ -16,11 +16,14 @@ CLI invocation this follows). That file is generated here as a ConfigMap
 rather than hand-authored, so the S3 bucket name/region and graph list stay
 in lockstep with the Pulumi-managed bucket.
 
-No container image is built for ``omnigraph-server`` (or for witan) in either
-repo yet — this stack only provisions the ECR repository and references
-``:latest``, exactly like ``kubewatch_webhook_handler``'s pattern of "image
-built separately, by a Concourse job, before this stack runs." That build
-job does not exist yet; see the follow-up task noted in ``__main__.py``.
+The ``omnigraph-server`` image is built once and promoted unchanged through
+CI -> QA -> Production by the ``omnigraph``/``pulumi-omnigraph`` Concourse
+pipeline, which also owns the ``omnigraph-server`` ECR repository itself
+(idempotent create-if-missing on every build) rather than this stack
+creating it — a single repo can't be owned by three independent per-env
+Pulumi stacks. This stack instead pins the Deployment's image by digest,
+read from ``OMNIGRAPH_DOCKER_SHA`` (set by the build job via the
+pulumi-provisioner's ``env_vars_from_files``).
 """
 
 import json
@@ -36,7 +39,7 @@ from ol_infrastructure.components.aws.s3 import OLBucket, S3BucketConfig
 from ol_infrastructure.components.services.vault import OLVaultK8SSecret
 from ol_infrastructure.lib.aws.iam_helper import IAM_POLICY_VERSION
 from ol_infrastructure.lib.ol_types import AWSBase
-from ol_infrastructure.lib.pulumi_helper import StackInfo
+from ol_infrastructure.lib.pulumi_helper import StackInfo, format_docker_image_ref
 
 OMNIGRAPH_SERVER_SERVICE_NAME = "omnigraph-server"
 OMNIGRAPH_SERVER_PORT = 8080
@@ -64,7 +67,7 @@ class OmnigraphDataTier(NamedTuple):
     """Handles to the provisioned data-tier resources for depends_on wiring."""
 
     bucket: OLBucket
-    ecr_repository: aws.ecr.Repository
+    image_repository: str
     service: kubernetes.core.v1.Service
     deployment: kubernetes.apps.v1.Deployment
 
@@ -133,43 +136,18 @@ def create_data_tier(  # noqa: PLR0913
         role=auth_binding.irsa_role.name,
     )
 
-    # ECR repository for the omnigraph-server image. Built separately by a
-    # Concourse job (not yet written — see __main__.py's follow-up note),
-    # mirroring kubewatch_webhook_handler's "ECR repo here, image build
-    # elsewhere" split.
-    ecr_repository = aws.ecr.Repository(
-        f"omnigraph-omnigraph-server-ecr-repository-{stack_info.env_suffix}",
-        name=f"omnigraph-server-{stack_info.env_suffix.lower()}",
-        image_tag_mutability="MUTABLE",
-        image_scanning_configuration=aws.ecr.RepositoryImageScanningConfigurationArgs(
-            scan_on_push=True,
-        ),
-        force_delete=True,
-        tags=aws_config.tags,
+    # The ``omnigraph-server`` ECR repository is created (idempotently) by the
+    # Concourse build job on every push, not managed here — see this module's
+    # docstring. One repo is shared across CI/QA/Production (same AWS
+    # account); the image is pinned by digest (OMNIGRAPH_DOCKER_SHA, set by
+    # the build job) so a new push actually changes this stage's Deployment
+    # pod spec.
+    omnigraph_aws_account = aws.get_caller_identity()
+    image_repository = (
+        f"{omnigraph_aws_account.account_id}.dkr.ecr.{aws_config.region}"
+        ".amazonaws.com/omnigraph-server"
     )
-    aws.ecr.LifecyclePolicy(
-        f"omnigraph-omnigraph-server-ecr-lifecycle-{stack_info.env_suffix}",
-        repository=ecr_repository.name,
-        policy=json.dumps(
-            {
-                "rules": [
-                    {
-                        "rulePriority": 1,
-                        "description": "Keep last 10 images",
-                        "selection": {
-                            "tagStatus": "any",
-                            "countType": "imageCountMoreThan",
-                            "countNumber": 10,
-                        },
-                        "action": {"type": "expire"},
-                    }
-                ]
-            }
-        ),
-    )
-    omnigraph_server_image: Output[str] = ecr_repository.repository_url.apply(
-        lambda url: f"{url}:latest"
-    )
+    omnigraph_server_image = format_docker_image_ref(image_repository, "OMNIGRAPH")
 
     # cluster.yaml — the single Layer-1 (memory/task/workflow) graph,
     # organization-wide, plus room for per-repo code graphs added the same
@@ -370,7 +348,7 @@ def create_data_tier(  # noqa: PLR0913
 
     return OmnigraphDataTier(
         bucket=omnigraph_bucket,
-        ecr_repository=ecr_repository,
+        image_repository=image_repository,
         service=omnigraph_service,
         deployment=omnigraph_deployment,
     )

--- a/src/ol_infrastructure/applications/witan/__main__.py
+++ b/src/ol_infrastructure/applications/witan/__main__.py
@@ -42,9 +42,16 @@ Incoming auth — ToolHive's "External OIDC provider" scenario, NOT
 
 Follow-up work this stack does NOT cover, tracked separately rather than
 silently assumed:
-    - **Container image.** witan has no image built in either repo yet; this
-      stack only creates the ECR repository and references ``:latest``, and
-      the ``witan``/``pulumi-witan`` Concourse pipeline builds and pushes it.
+    - **Container image.** The ``witan``/``pulumi-witan`` Concourse pipeline
+      builds the image once and promotes it unchanged through CI -> QA ->
+      Production. It also owns the ``witan`` ECR repository itself
+      (idempotent create-if-missing on every build), rather than this stack
+      creating it -- a single repo can't be owned by three independent
+      per-env Pulumi stacks. This stack instead pins the Deployment's image
+      by digest, read from ``WITAN_DOCKER_SHA`` (set by the build job via
+      the pulumi-provisioner's ``env_vars_from_files``), so a new push always
+      changes the pod spec and triggers a rollout instead of silently
+      leaving the running pod on a stale image.
     - **Keycloak witan-users token provisioning.** agent-kit ADR-0004 D3
       assigns the job of "walking the Keycloak witan-users group/role
       membership and writing a generated token per user" into the shared
@@ -54,7 +61,6 @@ silently assumed:
       current as Keycloak group membership changes is not yet built.
 """
 
-import json
 from pathlib import Path
 
 import pulumi_aws as aws
@@ -86,6 +92,7 @@ from ol_infrastructure.lib.ol_types import (
     Services,
 )
 from ol_infrastructure.lib.pulumi_helper import (
+    format_docker_image_ref,
     make_stack_reference,
     parse_stack,
     require_stack_output_value,
@@ -256,41 +263,19 @@ actor_tokens_secret = OLVaultK8SSecret(
 )
 
 #########################################
-#   ECR repository for the witan image   #
+#   witan image (built + repo owned by   #
+#   the pulumi-witan Concourse pipeline) #
 #########################################
-# "Repo here, image built separately by a Concourse job" split, mirroring
-# kubewatch_webhook_handler — see this module's docstring.
-witan_ecr_repository = aws.ecr.Repository(
-    f"witan-ecr-repository-{stack_info.env_suffix}",
-    name=f"witan-{stack_info.env_suffix.lower()}",
-    image_tag_mutability="MUTABLE",
-    image_scanning_configuration=aws.ecr.RepositoryImageScanningConfigurationArgs(
-        scan_on_push=True,
-    ),
-    force_delete=True,
-    tags=aws_config.tags,
+# The ``witan`` ECR repository is created (idempotently) by the Concourse
+# build job on every push, not managed here -- see this module's docstring.
+# One repo is shared across CI/QA/Production (same AWS account); the image
+# is pinned by digest (WITAN_DOCKER_SHA, set by the build job) so a new push
+# actually changes this stage's Deployment pod spec.
+witan_aws_account = aws.get_caller_identity()
+witan_image_repository = (
+    f"{witan_aws_account.account_id}.dkr.ecr.{aws_config.region}.amazonaws.com/witan"
 )
-aws.ecr.LifecyclePolicy(
-    f"witan-ecr-lifecycle-{stack_info.env_suffix}",
-    repository=witan_ecr_repository.name,
-    policy=json.dumps(
-        {
-            "rules": [
-                {
-                    "rulePriority": 1,
-                    "description": "Keep last 10 images",
-                    "selection": {
-                        "tagStatus": "any",
-                        "countType": "imageCountMoreThan",
-                        "countNumber": 10,
-                    },
-                    "action": {"type": "expire"},
-                }
-            ]
-        }
-    ),
-)
-witan_image = witan_ecr_repository.repository_url.apply(lambda url: f"{url}:latest")
+witan_image = format_docker_image_ref(witan_image_repository, "WITAN")
 
 #########################################
 #   MCPGroup + witan MCPServer           #
@@ -397,5 +382,5 @@ export("namespace", NAMESPACE)
 export("mcp_group_name", MCP_GROUP_NAME)
 export("vmcp_domain", VMCP_DOMAIN)
 export("vmcp_oidc_issuer", KEYCLOAK_ISSUER)
-export("witan_ecr_repository_url", witan_ecr_repository.repository_url)
+export("witan_image_repository", witan_image_repository)
 export("omnigraph_server_addr", omnigraph_server_addr)


### PR DESCRIPTION
### What are the relevant tickets?
N/A

Stacked on #5176 — depends on `configure_ecr_repository_task()` added there (`src/ol_concourse/pipelines/ecr.py`).

### Description (What does it do?)
Follow-up to review feedback on #5176 (https://github.com/mitodl/ol-infrastructure/pull/5176#discussion_r2450471234 and the matching omnigraph thread), where `copilot-pull-request-reviewer` pointed out that `ensure_ecr_task()` only creates an ECR repo if missing, with AWS defaults (scanning off, unlimited retention) — it doesn't replicate scan-on-push or a lifecycle policy. #5176 fixed that for the two repos it touched (`witan`, `omnigraph-server`) by adding `configure_ecr_repository_task()` right after `ensure_ecr_task()`.

This PR extends the same fix to every other pipeline in the repo that calls `ensure_ecr_task()`, so those repos aren't left as the only outliers without scan-on-push/lifecycle management:

- `src/ol_concourse/pipelines/container_images/dcind.py`
- `src/ol_concourse/pipelines/container_images/google_ads_optimization.py`
- `src/ol_concourse/pipelines/container_images/hashicorp_release_resource.py`
- `src/ol_concourse/pipelines/container_images/mitodl_concourse_npm_resource.py`
- `src/ol_concourse/pipelines/container_images/ocw_course_publisher.py`
- `src/ol_concourse/pipelines/container_images/ol_python_base.py`
- `src/ol_concourse/pipelines/container_images/ol_superset.py`
- `src/ol_concourse/pipelines/container_images/openedx_tubular.py`
- `src/ol_concourse/pipelines/open_edx/grader_images/base_image_pipeline.py`
- `src/ol_concourse/pipelines/open_edx/grader_images/build_pipeline.py`

Each call site adds a single `configure_ecr_repository_task(<same repo-name argument already passed to ensure_ecr_task>)` line immediately after the existing `ensure_ecr_task(...)` call, plus the corresponding import. No behavioral change to build/push logic — this only adds a `put-image-scanning-configuration` + `put-lifecycle-policy` step (10-image retention, matching the policy previously used by Pulumi-managed repos elsewhere in this repo) ahead of the image push.

### Screenshots (if appropriate):
N/A

### How can this be tested?
- `ruff check`, `ruff format --check`, and `mypy` pass on all 10 changed files (pre-existing `D100`/`D103` missing-docstring warnings on some of these files are unrelated pre-existing lint debt, confirmed present on the unmodified `HEAD` version of each file too).
- Imported each affected module directly to confirm the added step doesn't break Pipeline construction (no `TaskStep`/`Job` validation errors).
- Not yet run against live Concourse (see Additional Context).

### Additional Context
This PR is stacked on #5176 and targets that branch (`witan-omnigraph-ecr-single-repo`), not `main` — merge #5176 first, then retarget/merge this one, since `configure_ecr_repository_task()` only exists once #5176 lands.