### PR TITLE
fix(concourse): grant IAM gaps blocking witan/omnigraph deploy and mit_learn cleanup

### DIFF
--- a/src/ol_infrastructure/applications/concourse/iam_policies/pulumi_infra.py
+++ b/src/ol_infrastructure/applications/concourse/iam_policies/pulumi_infra.py
@@ -20,17 +20,22 @@ _DEFAULT_PATH_MANAGED_GROUP_NAMES = ["Admins", "EKSAdmins", "EKSDevelopers"]
 # builds also run on this pool and are cadence-driven enough that they didn't
 # reliably show up in either usage-history source).
 #
-# IAM self-management actions are scoped to the /ol-applications/* and
-# /ol-infrastructure/* paths this repo provisions under, rather than
-# Resource: "*" -- closing the self-escalation path found via CloudTrail
-# (this role successfully called iam:AttachRolePolicy on itself under its
-# prior AdministratorAccess grant).
+# IAM self-management actions are scoped to the /ol-applications/*,
+# /ol-data/*, and /ol-infrastructure/* paths this repo provisions under,
+# rather than Resource: "*" -- closing the self-escalation path found via
+# CloudTrail (this role successfully called iam:AttachRolePolicy on itself
+# under its prior AdministratorAccess grant).
 policy_definition = {
     "Version": IAM_POLICY_VERSION,
     "Statement": [
         {
             "Effect": "Allow",
             "Action": [
+                "acm-pca:DescribeCertificateAuthority",
+                "acm-pca:GetCertificate",
+                "acm-pca:GetCertificateAuthorityCertificate",
+                "acm-pca:IssueCertificate",
+                "acm-pca:ListTags",
                 "acm:DeleteCertificate",
                 "acm:DescribeCertificate",
                 "acm:ExportCertificate",
@@ -411,20 +416,28 @@ policy_definition = {
                 "iam:CreateInstanceProfile",
                 "iam:CreatePolicy",
                 "iam:CreatePolicyVersion",
+                "iam:CreateRole",
                 "iam:CreateUser",
+                "iam:DeleteAccessKey",
                 "iam:DeleteGroup",
                 "iam:DeletePolicy",
                 "iam:DeletePolicyVersion",
+                "iam:DeleteRole",
                 "iam:DeleteUser",
                 "iam:DetachRolePolicy",
                 "iam:DetachUserPolicy",
                 "iam:RemoveUserFromGroup",
+                "iam:TagRole",
+                "iam:UntagRole",
                 "iam:UpdateAssumeRolePolicy",
+                "iam:UpdateRoleDescription",
             ],
             "Resource": [
                 "arn:aws:iam::*:role/ol-applications/*",
+                "arn:aws:iam::*:role/ol-data/*",
                 "arn:aws:iam::*:role/ol-infrastructure/*",
                 "arn:aws:iam::*:policy/ol-applications/*",
+                "arn:aws:iam::*:policy/ol-data/*",
                 "arn:aws:iam::*:policy/ol-infrastructure/*",
                 "arn:aws:iam::*:instance-profile/ol-applications/*",
                 "arn:aws:iam::*:instance-profile/ol-infrastructure/*",
@@ -443,6 +456,14 @@ policy_definition = {
                 *[
                     f"arn:aws:iam::*:group/{group_name}"
                     for group_name in _DEFAULT_PATH_MANAGED_GROUP_NAMES
+                ],
+                # mit_learn/__main__.py's now-deleted gh_workflow_user (commit
+                # 512678eec removed it from code) was provisioned at the
+                # default "/" path. Enumerated here, same as above, so the
+                # worker can finish deleting it out of Pulumi state.
+                *[
+                    f"arn:aws:iam::*:user/mitopen-gh-workflow-{env}"
+                    for env in ("ci", "qa", "production")
                 ],
             ],
         },

--- a/src/ol_infrastructure/applications/omnigraph/data_tier.py
+++ b/src/ol_infrastructure/applications/omnigraph/data_tier.py
@@ -128,6 +128,7 @@ def create_data_tier(  # noqa: PLR0913
     )
     omnigraph_s3_iam_policy = aws.iam.Policy(
         f"omnigraph-s3-iam-policy-{stack_info.env_suffix}",
+        path=f"/ol-data/omnigraph-s3-iam-policy-{stack_info.env_suffix}/",
         policy=omnigraph_s3_policy_json,
     )
     aws.iam.RolePolicyAttachment(


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
The infra worker's least-privilege IAM policy (`concourse-instance-role-worker-infra-*`, introduced in `aacad3609`) is missing several actions/resource-path grants that real deploys have since started hitting:

- **`iam:CreateRole`** was never granted, so any first-time `OLEKSTrustRole` creation fails outright. This blocked the new witan and omnigraph IRSA trust roles (`operations-ci-witan-trust-role`, `operations-ci-omnigraph-trust-role`) with `AccessDenied ... iam:CreateRole`.
- Self-management resource scoping only covered `/ol-applications/*` and `/ol-infrastructure/*` paths, missing the `/ol-data/*` convention already used elsewhere (clickhouse's S3 IAM policy, `data_warehouse`'s `etl-role`/`etl-policy`). Omnigraph's new `omnigraph-s3-iam-policy-ci` IAM policy follows that same `/ol-data/*` convention but had no `path=` set on the Pulumi resource, so it defaulted to `/` and fell outside any allowed scope, producing `AccessDenied ... iam:CreatePolicy`. Fixed by giving it an explicit `/ol-data/omnigraph-s3-iam-policy-{env}/` path, and adding `role/ol-data/*` + `policy/ol-data/*` to the worker's allowed resource paths.
- **`iam:DeleteAccessKey`** was never granted, and mit_learn's now-orphaned `gh_workflow` IAM user (code removed in #5148, but the live AWS resource remains in Pulumi state) was provisioned at the default `/` path rather than under `/ol-applications/*`. Deleting it now fails with `AccessDenied ... iam:DeleteAccessKey` / `iam:DetachUserPolicy`. Enumerated the specific `mitopen-gh-workflow-{ci,qa,production}` usernames explicitly (same pattern already used for `EKS_DEVELOPER_USERNAMES`) rather than widening the path patterns.
- No `acm-pca:*` actions were granted at all. The `operations-ci` vault-server stack's ACM PCA-issued listener certificate (`vault-server-listener-tls-certificate-2026`, an `aws.acmpca.Certificate` resource in `infrastructure/vault/__main__.py`) needs `GetCertificate`/`IssueCertificate`/`DescribeCertificateAuthority`/`GetCertificateAuthorityCertificate`/`ListTags` to refresh/apply. Added those as read/issue-only grants (no CA-management actions, which belong to the separate `private_ca` stack).

None of this touches the deliberate exclusion of `policy/ol-security-boundaries/concourse/*` from IAM self-management (the privilege-escalation guardrail added alongside this policy).

### How can this be tested?
- `uv run pre-commit run --files src/ol_infrastructure/applications/concourse/iam_policies/pulumi_infra.py src/ol_infrastructure/applications/omnigraph/data_tier.py` — passes (ruff, mypy, secrets scan).
- Ran the actual Parliament lint config this policy is checked with at deploy time (`lint_iam_policy` + the `pulumi_infra`-specific `parliament_config` from `concourse/__main__.py`, including the `PRIVILEGE_ESCALATION`/`RESOURCE_STAR`/`RESOURCE_POLICY_PRIVILEGE_ESCALATION` suppressions) directly against `policy_definition` — no findings survive.
- Did not run `pulumi preview` (no local AWS credentials for this stack); reviewer should confirm the next `deploy-ol-infrastructure-concourse-application-infra-*` and `pulumi-witan`/`pulumi-omnigraph`/`ol-infrastructure-vault-server` pipeline runs succeed.

### Additional Context
This is a reactive fix — each grant above corresponds to a specific `AccessDenied` error surfaced by real CI/Production pipeline runs today, following the same incremental pattern as prior fixes to this policy (e.g. #5167, #5165).