### PR TITLE
fix(apisix,ol-analytics-api): pass-through session auth for MIT Learn's analytics dashboard

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1613,6 +1613,14 @@ mitlearn_k8s_app_oidc_resources_no_prefix = OLApisixOIDCResources(
         # browser cookie lifetime instead of expiring early (hq#8416).
         oidc_session_idling_timeout=0,
         oidc_session_rolling_timeout=0,
+        # Broadened from the default host-only scope so a logged-in session
+        # cookie is also sent to ol-analytics-api's Learn-scoped host
+        # (analytics.learn.mit.edu et al.), letting its "pass" route recognize
+        # the same session instead of requiring a second login -- see
+        # ol_analytics_api/__main__.py's Learn-scoped OIDC resource, which
+        # shares this same "sso/mitlearn" Vault path/client and mirrors this
+        # cookie domain.
+        oidc_session_cookie_domain=mitlearn_api_domain.removeprefix("api"),
         oidc_use_session_secret=True,
         vault_mount="secret-operations",
         vault_mount_type="kv-v1",
@@ -1629,9 +1637,11 @@ mitlearn_k8s_app_oidc_resources = OLApisixOIDCResources(
         oidc_logout_path="/learn/logout/oidc",
         oidc_post_logout_redirect_uri=f"https://{mitlearn_config.get('api_domain')}/learn/logout/",
         oidc_session_absolute_timeout=60 * 20160,
-        # See the mitlearn-k8s-no-prefix resources above for why these are 0.
+        # See the mitlearn-k8s-no-prefix resources above for why these are 0,
+        # and for the cookie domain below.
         oidc_session_idling_timeout=0,
         oidc_session_rolling_timeout=0,
+        oidc_session_cookie_domain=mitlearn_api_domain.removeprefix("api"),
         oidc_use_session_secret=True,
         vault_mount="secret-operations",
         vault_mount_type="kv-v1",

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.Production.yaml
@@ -2,6 +2,7 @@
 secretsprovider: awskms://alias/infrastructure-secrets-production
 encryptedkey: AQICAHi3FG4qowC3UzOLWOAA4Y9/RTwqKjovG3wyVVYDxkR+zAEQSzOXcwWqoKOsuNhQanLhAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMtfhGqjMHIVcbAtDUAgEQgDvlaGoyAyk/AY2fzDUtGaiA5yzJjwbdCq90LkCH5nuk5n0vIeBFZD2H1tid4uJTG9lwE5EpJ7G2LJp1Cw==
 config:
+  nextjs:analytics_api_base_url: "https://analytics.learn.mit.edu"
   nextjs:appzi_url:
     secure: v1:NN7tWDa0Wxa5T54D:Yd+275vxZ40KZWjRxzuOfdrwZxDSt2g6IvruSU+xZwMxRYtOFOap1DPfnbWpMDrKzQYQ
   nextjs:cache_s_maxage_seconds: 7200

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.QA.yaml
@@ -2,6 +2,7 @@
 secretsprovider: awskms://alias/infrastructure-secrets-qa
 encryptedkey: AQICAHjZAY5LtmRWGljev0oiDGn0jR5cRwD4IVXCn50TW5i0qQGFNzbK/uuewL52WbAl1Ff3AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMVGbH/3ut2WFD5RmlAgEQgDsGgjF7DPjcruIeBZ8PGZcxuGFXVOyCCQj+BrJqIWymrfv+iFxrVhhHr7ke+h9J1PrpRroB8E+2oNTtoA==
 config:
+  nextjs:analytics_api_base_url: "https://analytics.rc.learn.mit.edu"
   nextjs:appzi_url:
     secure: v1:BvKYm13EnJavPEmi:Ef5Gf3J3tU+noMVdRHTzhw==
   nextjs:cache_s_maxage_seconds: 900

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
@@ -116,6 +116,12 @@ raw_env_vars = {
     "GTM_COOKIES_WIN": nextjs_config.get("gtm_cookies_win") or "",
     "NEXT_CACHE_S_MAXAGE_SECONDS": nextjs_config.get("cache_s_maxage_seconds") or "",
     # Env vars available on client and server
+    # Optional: ol-analytics-api has no CI deployment (see
+    # applications/ol_analytics_api/__main__.py), so this is left unset there.
+    # The app's own yup schema treats it as optional and reports the B2B
+    # analytics dashboard as unavailable rather than erroring when unset.
+    "NEXT_PUBLIC_ANALYTICS_API_BASE_URL": nextjs_config.get("analytics_api_base_url")
+    or "",
     "NEXT_PUBLIC_APPZI_URL": nextjs_config.require("appzi_url"),
     "NEXT_PUBLIC_CSRF_COOKIE_NAME": nextjs_config.require("csrf_cookie_name"),
     "NEXT_PUBLIC_EMBEDLY_KEY": nextjs_config.require("embedly_key"),

--- a/src/ol_infrastructure/applications/ol_analytics_api/__main__.py
+++ b/src/ol_infrastructure/applications/ol_analytics_api/__main__.py
@@ -47,11 +47,19 @@ Key wiring decisions (see also ``k8s/README.md`` in the app repo):
   ``SecurityGroupPolicy`` binding the pods to a dedicated security group (see
   ``ol_analytics_api_application_security_group`` below).
 
-* **APISIX + Keycloak OIDC.**  ``OLApisixRoute`` + ``OLApisixOIDCResources``
-  put the openid-connect plugin in front of the service so APISIX validates the
-  Keycloak session and forwards the decoded claims as the ``X-Userinfo`` header
-  that ``core/auth/userinfo.py`` expects.  This matches the dagster/opik
-  pattern.
+* **APISIX + Keycloak OIDC, two separate clients.**  ``OLApisixRoute`` +
+  ``OLApisixOIDCResources`` put the openid-connect plugin in front of the
+  service so APISIX validates the Keycloak session and forwards the decoded
+  claims as the ``X-Userinfo`` header that ``core/auth/userinfo.py`` expects.
+  The canonical ``domain`` host uses a dedicated ``ol-analytics-api`` client
+  with a full redirect-to-Keycloak flow (matching the dagster/opik pattern).
+  The Learn-scoped ``learn_domain`` host -- the one the MIT Learn frontend
+  actually calls -- uses a second OIDC resource that instead shares
+  mit-learn's own Keycloak client/session (``sso/mitlearn``) with
+  ``unauth_action="pass"``, so a browser already logged into mit-learn is
+  recognized here without a second redirect (a plain fetch() can't follow an
+  OIDC login redirect the way a browser navigation can). See the Learn-scoped
+  OIDC resource below for the full rationale.
 """
 
 import json
@@ -435,20 +443,18 @@ ol_analytics_api_domain = ol_analytics_api_config.require("domain")
 # Additional host(s) that also route to this service beyond the canonical
 # `domain`: the MIT Learn frontend consumes it under a Learn-scoped host
 # (`analytics.learn.mit.edu`) alongside the canonical `analytics.ol.mit.edu`.
-# Each host gets its own APISIX route (same backend + OIDC plugin) rather than
-# being folded into one route's host list, so HOST-based tenant routing or
-# host-specific plugins can be layered on later without restructuring; all
-# hosts share a single SAN certificate. A learn.mit.edu host only provisions
-# once `learn.mit.edu` is in the data cluster's `allowed_dns_zones` -- both the
-# external-dns domainFilter and the cert-manager DNS-01 solver selector read
-# that list (see infrastructure/aws/eks and substructure/aws/eks).
+# Each host gets its own APISIX route with its OWN OIDC resource (see below)
+# rather than being folded into one route's host list, so HOST-based tenant
+# routing or host-specific plugins can be layered on later without
+# restructuring; all hosts share a single SAN certificate. A learn.mit.edu
+# host only provisions once `learn.mit.edu` is in the data cluster's
+# `allowed_dns_zones` -- both the external-dns domainFilter and the
+# cert-manager DNS-01 solver selector read that list (see
+# infrastructure/aws/eks and substructure/aws/eks).
 ol_analytics_api_learn_domain = ol_analytics_api_config.get("learn_domain")
-ol_analytics_api_routes = [("ol-analytics-api", ol_analytics_api_domain)]
+ol_analytics_api_hosts = [ol_analytics_api_domain]
 if ol_analytics_api_learn_domain:
-    ol_analytics_api_routes.append(
-        ("ol-analytics-api-learn", ol_analytics_api_learn_domain)
-    )
-ol_analytics_api_hosts = [host for _, host in ol_analytics_api_routes]
+    ol_analytics_api_hosts.append(ol_analytics_api_learn_domain)
 
 # Shared plugins (redirect http->https, cors, prometheus, opentelemetry, ...).
 ol_analytics_api_shared_plugins = OLApisixSharedPlugins(
@@ -466,7 +472,10 @@ ol_analytics_api_shared_plugins = OLApisixSharedPlugins(
 # OIDC resources: sync the Keycloak client config from Vault and expose the
 # openid-connect plugin config.  The `organization:*` scope (the component
 # default) is required so the org membership claim reaches X-Userinfo, which the
-# b2b_dashboard tenant's auth checks depend on.
+# b2b_dashboard tenant's auth checks depend on.  This resource, with its own
+# dedicated Keycloak client (`ol-analytics-api-client`, see olapps.py), is used
+# only for the canonical `analytics.ol.mit.edu` host below with a full
+# redirect-to-Keycloak flow.
 ol_analytics_api_oidc_resources = OLApisixOIDCResources(
     f"ol-analytics-api-{stack_info.env_suffix}-oidc-resources",
     oidc_config=OLApisixOIDCConfig(
@@ -487,6 +496,52 @@ ol_analytics_api_oidc_resources = OLApisixOIDCResources(
     ),
 )
 
+# A second, separate OIDC resource for the Learn-scoped host
+# (`analytics.learn.mit.edu` et al.): the MIT Learn frontend calls this API
+# with `fetch`, not a browser navigation, so a redirect-to-Keycloak response
+# (what the canonical host's "auth" flow above returns) would show up as a
+# CORS/opaque-redirect failure, not the JSON 401/403 the frontend expects.
+# Rather than minting its own session, this resource reuses mit-learn's own
+# Keycloak client (`sso/mitlearn`, same vault_path mit_learn's and learn_ai's
+# own OIDC resources read -- see mit_learn/__main__.py and
+# learn_ai/__main__.py) so the cookie set when a user logs into mit-learn is
+# recognized here too, mirroring how learn-ai's `/ai/*` route piggybacks on
+# mit-learn's session rather than the JWT-plugin approach that ask implied
+# (this repo has no jwt-auth-plugin route anywhere; the shared-session
+# pass-through IS the established pattern). Sharing the session requires two
+# things beyond the shared client: `unauth_action="pass"` below (never
+# redirects) and a cookie domain broad enough to be sent cross-subdomain --
+# set to the same suffix as mit_learn's own broadened
+# oidc_session_cookie_domain (mitlearn_api_domain.removeprefix("api")) so the
+# exact same browser cookie reaches this host.
+ol_analytics_api_learn_oidc_resources = None
+if ol_analytics_api_learn_domain:
+    ol_analytics_api_learn_oidc_resources = OLApisixOIDCResources(
+        f"ol-analytics-api-{stack_info.env_suffix}-learn-oidc-resources",
+        oidc_config=OLApisixOIDCConfig(
+            application_name=f"{APPLICATION_NAME}-learn",
+            k8s_labels=k8s_global_labels,
+            k8s_namespace=APPLICATION_NAMESPACE,
+            oidc_logout_path="/logout/oidc",
+            oidc_post_logout_redirect_uri=f"https://{ol_analytics_api_learn_domain}/",
+            oidc_session_absolute_timeout=60 * 20160,
+            oidc_session_idling_timeout=0,
+            oidc_session_rolling_timeout=0,
+            oidc_session_cookie_domain=ol_analytics_api_learn_domain.removeprefix(
+                "analytics"
+            ),
+            oidc_use_session_secret=True,
+            vault_mount="secret-operations",
+            vault_mount_type="kv-v1",
+            vault_path="sso/mitlearn",
+            vaultauth=ol_analytics_api_auth_binding.vault_k8s_resources.auth_name,
+        ),
+        opts=ResourceOptions(
+            delete_before_replace=True,
+            parent=ol_analytics_api_auth_binding.vault_k8s_resources,
+        ),
+    )
+
 # TLS certificate + ApisixTls resource for the service domain.
 ol_analytics_api_cert = OLCertManagerCert(
     f"ol-analytics-api-{stack_info.env_suffix}-cert",
@@ -501,36 +556,66 @@ ol_analytics_api_cert = OLCertManagerCert(
 )
 
 # Route every path to the service behind the openid-connect plugin so APISIX
-# authenticates the Keycloak session and forwards X-Userinfo.  unauth_action
-# "auth" redirects unauthenticated browsers to Keycloak (the MIT Learn frontend
-# calls this API with an established Keycloak session).
-ol_analytics_api_route = OLApisixRoute(
-    f"ol-analytics-api-{stack_info.env_suffix}-route",
-    k8s_namespace=APPLICATION_NAMESPACE,
-    k8s_labels=k8s_global_labels,
-    route_configs=[
+# authenticates the Keycloak session and forwards X-Userinfo.  The canonical
+# host uses unauth_action "auth" (redirects unauthenticated browsers to
+# Keycloak); the Learn-scoped host uses "pass" against the shared mit-learn
+# session instead (see ol_analytics_api_learn_oidc_resources above for why).
+_ol_analytics_api_route_configs = [
+    OLApisixRouteConfig(
+        route_name="ol-analytics-api",
+        priority=10,
+        shared_plugin_config_name=ol_analytics_api_shared_plugins.resource_name,
+        plugins=[
+            OLApisixPluginConfig(
+                **ol_analytics_api_oidc_resources.get_full_oidc_plugin_config(
+                    unauth_action="auth"
+                )
+            ),
+        ],
+        hosts=[ol_analytics_api_domain],
+        paths=["/*"],
+        backend_service_name=ol_analytics_api_k8s.application_lb_service_name,
+        backend_service_port=ol_analytics_api_k8s.application_lb_service_port_name,
+        backend_resolve_granularity="service",
+    )
+]
+if ol_analytics_api_learn_oidc_resources is not None:
+    _ol_analytics_api_route_configs.append(
         OLApisixRouteConfig(
-            route_name=route_name,
+            route_name="ol-analytics-api-learn",
             priority=10,
             shared_plugin_config_name=ol_analytics_api_shared_plugins.resource_name,
             plugins=[
                 OLApisixPluginConfig(
-                    **ol_analytics_api_oidc_resources.get_full_oidc_plugin_config(
-                        unauth_action="auth"
+                    **ol_analytics_api_learn_oidc_resources.get_full_oidc_plugin_config(
+                        unauth_action="pass"
                     )
                 ),
             ],
-            hosts=[host],
+            hosts=[ol_analytics_api_learn_domain],
             paths=["/*"],
             backend_service_name=ol_analytics_api_k8s.application_lb_service_name,
             backend_service_port=ol_analytics_api_k8s.application_lb_service_port_name,
             backend_resolve_granularity="service",
         )
-        for route_name, host in ol_analytics_api_routes
-    ],
+    )
+
+ol_analytics_api_route = OLApisixRoute(
+    f"ol-analytics-api-{stack_info.env_suffix}-route",
+    k8s_namespace=APPLICATION_NAMESPACE,
+    k8s_labels=k8s_global_labels,
+    route_configs=_ol_analytics_api_route_configs,
     opts=ResourceOptions(
         delete_before_replace=True,
-        depends_on=[ol_analytics_api_k8s, ol_analytics_api_oidc_resources],
+        depends_on=[
+            ol_analytics_api_k8s,
+            ol_analytics_api_oidc_resources,
+            *(
+                [ol_analytics_api_learn_oidc_resources]
+                if ol_analytics_api_learn_oidc_resources is not None
+                else []
+            ),
+        ],
     ),
 )
 

--- a/src/ol_infrastructure/applications/ol_analytics_api/ol_analytics_api_policy.hcl
+++ b/src/ol_infrastructure/applications/ol_analytics_api/ol_analytics_api_policy.hcl
@@ -21,6 +21,13 @@ path "secret-operations/sso/ol-analytics-api" {
   capabilities = ["read"]
 }
 
+# The Learn-scoped host's OIDC resource reuses mit-learn's own Keycloak
+# client/session so the MIT Learn frontend's existing login is recognized
+# here without a second redirect (see __main__.py).
+path "secret-operations/sso/mitlearn" {
+  capabilities = ["read"]
+}
+
 # Static application secrets (SENTRY_DSN, ...) synced via the
 # vault-secrets-operator into the ol-analytics-api-static-secrets K8s Secret.
 # secret-ol-analytics-api is a kv-v2 mount, so reads go through the /data/

--- a/src/ol_infrastructure/components/services/apisix.py
+++ b/src/ol_infrastructure/components/services/apisix.py
@@ -273,10 +273,15 @@ class OLApisixOIDCResources(ComponentResource):
         )
 
         session_config: dict[str, Any] = {}
+        # Flat session.cookie_domain, per the openid-connect plugin's
+        # lua-resty-session 4.x schema on the pinned APISIX 3.17.0 (chart
+        # 2.15.0). The nested session.cookie.domain form was the pre-3.17.0
+        # shape; on 3.17.0+ it is a silent no-op since lua-resty-session 4.x
+        # only reads the flat key.
         if oidc_config.oidc_session_cookie_domain:
-            session_config.setdefault("session", {}).setdefault("cookie", {})[
-                "domain"
-            ] = oidc_config.oidc_session_cookie_domain
+            session_config.setdefault("session", {})["cookie_domain"] = (
+                oidc_config.oidc_session_cookie_domain
+            )
 
         if oidc_config.oidc_session_absolute_timeout:
             session_config.setdefault("session", {})["absolute_timeout"] = (


### PR DESCRIPTION
### What are the relevant tickets?

Unblocks the infra follow-up work called out in https://github.com/mitodl/mit-learn/pull/3679 (B2B org analytics dashboard). N/A for a tracked issue in this repo.

### Description (What does it do?)

mit-learn#3679 adds a B2B org analytics dashboard that calls `ol-analytics-api`'s `b2b_dashboard` endpoints via `fetch()` (cookie-based, `withCredentials`), expecting the existing MIT Learn login session to authenticate the request — mirroring how `learn-ai`'s `/ai/*` route piggybacks on mit-learn's own session rather than a dedicated login flow. `ol-analytics-api`'s existing Learn-scoped host (`analytics.learn.mit.edu`) instead did a full redirect-to-Keycloak flow with its own dedicated client, which breaks under `fetch()`: a 302 redirect surfaces as a CORS/opaque-redirect failure, not the JSON 401/403 the frontend is built to handle.

Note there is no `jwt-auth` plugin anywhere in this repo — the "JWT APISIX mints from the session cookie" language in the mit-learn PR refers to the `openid-connect` plugin's `id_token`/`access_token` forwarding, which is what this change wires up.

Changes:
- `components/services/apisix.py`: fixes a real bug — `oidc_session_cookie_domain` was writing the pre-3.17.0 nested `session.cookie.domain` key, which is a silent no-op on the pinned APISIX 3.17.0 (chart 2.15.0), since `lua-resty-session` 4.x only reads the flat `session.cookie_domain` key. This also un-breaks `mitxonline`'s existing (previously inert) use of the same setting.
- `mit_learn/__main__.py`: broadens mit-learn's own login session cookie domain to `*.learn.mit.edu` (per-env equivalent) so it reaches sibling subdomains.
- `ol_analytics_api/__main__.py`: gives the Learn-scoped host (`analytics.learn.mit.edu` / `analytics.rc.learn.mit.edu` / `analytics.ci.learn.mit.edu`) its own `OLApisixOIDCResources` sharing mit-learn's Keycloak client (`sso/mitlearn`, which already carries the `organization` scope needed for the b2b_dashboard's org-membership claim) with `unauth_action="pass"` and a matching cookie domain, instead of `ol-analytics-api`'s own dedicated auth-redirect client. The canonical `analytics.ol.mit.edu` host is unchanged (still its own client, still full redirect).
- `ol_analytics_api_policy.hcl`: grants read on the shared `secret-operations/sso/mitlearn` path so the new OIDC resource can sync that client secret.
- `mit_learn_nextjs`: wires `NEXT_PUBLIC_ANALYTICS_API_BASE_URL` to the Learn-scoped analytics domain in Production/QA (left unset in CI, since `ol-analytics-api` has no CI deployment — the frontend already treats this var as optional and reports the dashboard unavailable when unset).

Out of scope / not managed in this repo: the `b2b-analytics-dashboard` PostHog feature flag mentioned in mit-learn#3679 — there's no PostHog-as-code anywhere in ol-infrastructure, so that flag needs to be created directly in the PostHog UI.

### Screenshots (if appropriate):

N/A — infrastructure/Pulumi config only, no UI.

### How can this be tested?

Verified with `pulumi preview --diff` against live stacks (no `pulumi up` run):

- `ol_analytics_api` QA and CI: diff shows only the new `OLApisixOIDCResources` + synced Vault secret being created, the Vault policy addition, and the Learn-scoped route's plugin config switching from `unauth_action="auth"` to `"pass"` with the new `secretRef` and `session` block (`cookie_domain`, `absolute_timeout`, `idling_timeout`, `rolling_timeout`). The canonical route entry is untouched.
- `mit_learn` QA: diff shows only `session.cookie_domain` being added to both of mit-learn's own OIDC plugin configs, no change to `unauth_action` or any other behavior.
- `mit_learn_nextjs` QA: diff shows only the new `NEXT_PUBLIC_ANALYTICS_API_BASE_URL` env var being added to the Deployment spec.

`uv run pre-commit run --all-files` and `uv run mypy` both pass.

Once merged and deployed (QA first), the manual test from mit-learn#3679 becomes viable: with the `b2b-analytics-dashboard` PostHog flag enabled and `mitxonline#3789` + `ol-analytics-api#13` deployed, an org manager visiting `/dashboard/organization/<org>/analytics` should get real data instead of falling through to the "not available" notice, and a logged-out/non-manager request should surface as a clean 401/403 rather than a redirect/CORS failure.

### Additional Context

Reviewers may want to double check the cookie-domain broadening on mit-learn's own session (task 2 above) — this makes mit-learn's session cookie visible to any `*.learn.mit.edu` subdomain that shares the `sso/mitlearn` Vault secret, not just `analytics.learn.mit.edu`. The cookie value itself stays opaque/encrypted (only apps holding the same shared session secret can decrypt it), so this only extends trust to apps we've already deliberately wired to `sso/mitlearn` — same mechanism `mitxonline`'s own direct-domain OIDC resource already relies on.