### PR TITLE
feat(starrocks): give FE pods scheduling priority on core nodes

### DIFF
--- a/src/ol_infrastructure/applications/starrocks/__main__.py
+++ b/src/ol_infrastructure/applications/starrocks/__main__.py
@@ -122,6 +122,31 @@ io_optimized_node_affinity = {
 # available rather than the Karpenter spot/on-demand fleet that BE/CN use.
 core_node_selector = {"ol.mit.edu/core_node": "true"}
 
+# Incident 2026-07-30 (QA + prod): core nodes have no taint, so ordinary
+# Deployments (Airbyte, Dagster, JupyterHub, etc.) land there freely and can
+# fill a core node before an FE pod needs to reschedule onto it, leaving FE
+# Pending indefinitely with no automatic recovery. A hard taint would fix this
+# but would waste core-node capacity whenever FE isn't using it. A PriorityClass
+# instead lets other workloads use the spare capacity while letting the
+# scheduler preempt them if FE ever needs the room. Value is well below the
+# reserved system-* range (2,000,000,000+) but far above the default (0) used
+# by everything else on these clusters.
+starrocks_fe_priority_class_name = f"{stack_info.env_prefix}-starrocks-fe"
+starrocks_fe_priority_class = kubernetes.scheduling.v1.PriorityClass(
+    f"starrocks-{stack_info.env_prefix}-{stack_info.env_suffix}-fe-priority-class",
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        name=starrocks_fe_priority_class_name,
+        labels=k8s_app_labels.model_dump(),
+    ),
+    value=1000000,
+    global_default=False,
+    description=(
+        "StarRocks FE pods on the shared core nodegroup. Allows preempting "
+        "lower-priority pods (Airbyte, Dagster, JupyterHub, etc.) that would "
+        "otherwise starve FE of scheduling room on core nodes."
+    ),
+)
+
 
 def _starrocks_pod_anti_affinity(component: str, *, required: bool) -> dict[str, Any]:
     """Spread replicas of one StarRocks pod type across distinct nodes.
@@ -414,6 +439,7 @@ starrocks_values: dict[str, Any] = {
         "serviceAccount": "starrocks",
         "runAsNonRoot": True,
         "nodeSelector": core_node_selector,
+        "priorityClassName": starrocks_fe_priority_class_name,
         "affinity": _starrocks_pod_anti_affinity("fe", required=True),
         "service": {
             "type": "ClusterIP",
@@ -889,7 +915,11 @@ starrocks_release = kubernetes.helm.v3.Release(
     ),
     opts=ResourceOptions(
         delete_before_replace=True,
-        depends_on=[starrocks_root_password_secret, starrocks_auth_binding],
+        depends_on=[
+            starrocks_root_password_secret,
+            starrocks_auth_binding,
+            starrocks_fe_priority_class,
+        ],
     ),
 )
 


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Adds a `PriorityClass` (`<env>-starrocks-fe`, value `1000000`) and wires it into the StarRocks FE pod spec (`starrocksFESpec.priorityClassName`), scoped to FE only.

The `ol.mit.edu/core_node` nodegroup that StarRocks FE is pinned to carries no taint, so ordinary Deployments (Airbyte, Dagster, JupyterHub, etc.) can freely land there and fill a core node before an FE pod needs to reschedule onto it — leaving FE stuck `Pending` indefinitely with no automatic recovery. This happened twice on 2026-07-30, in both `data-qa` and `data-production`, and required manually identifying and evicting/rescaling specific pods on the affected core nodes to free capacity.

A hard `NoSchedule` taint (mirroring the existing `ol.mit.edu/gpu_node` pattern) would prevent this, but would waste core-node capacity whenever FE isn't using all of it. A `PriorityClass` instead lets other workloads keep using the spare capacity, while letting the scheduler automatically preempt them if FE ever needs the room — no manual intervention required going forward.

Scoped to FE only because FE is the only StarRocks component pinned to the core nodegroup (`core_node_selector`); CN and BE float on the general Karpenter-managed fleet and don't compete for that same capacity, so a priority class there wouldn't address this failure mode.

### Screenshots (if appropriate):
N/A — no UI changes

### How can this be tested?
- `uv run pre-commit run --files src/ol_infrastructure/applications/starrocks/__main__.py` — passes (ruff format/check, mypy).
- `pulumi preview` run against all three stacks (`lakehouse.CI`, `lakehouse.QA`, `lakehouse.Production`) shows an identical, minimal diff in each: 1 new `PriorityClass` resource created, 1 in-place `helm.sh/v3:Release` values update adding `priorityClassName` to `starrocksFESpec`. No replacements or deletions in any stack.
- After deploy, confirm via `kubectl --context <ctx> -n starrocks get pod <fe-pod> -o jsonpath='{.spec.priorityClassName}'` that FE pods pick up the new priority class on their next restart (existing running FE pods won't be recreated by this change alone — it takes effect on the next pod replacement).

### Additional Context
This is a preventative fix for future contention, not a fix for the specific `data-qa`/`data-production` FE scheduling incidents from 2026-07-30 — those were already resolved manually (stale zone-pinned PVCs deleted and FE replicas rescheduled/rejoined the quorum) before this PR was opened.

Priority value (`1000000`) was chosen to sit well above the default (`0`) used by every other workload in these clusters, and well below Kubernetes' reserved `system-*` priority range (`2,000,000,000`+, e.g. `system-cluster-critical`, `system-node-critical`).