### PR TITLE
fix(concourse): grant infra worker route53 write access + resolve IAM policy quota

### DIFF
--- a/src/ol_infrastructure/applications/concourse/__main__.py
+++ b/src/ol_infrastructure/applications/concourse/__main__.py
@@ -861,6 +861,21 @@ for worker_def in concourse_config.get_object("workers") or []:
         role=concourse_worker_instance_role.name,
     )
 
+    if worker_class_name == "infra":
+        # pulumi_infra only grants read-only route53 actions (see
+        # iam_policies/pulumi_infra.py), so pulumi_job() runs that manage
+        # records in any app-managed zone (e.g. the xpro Fastly CNAME) need
+        # the write policy too, same as the web nodes already get for the
+        # odl zone below. This pool runs deploys across all app stacks, so
+        # it gets the combined policy rather than one zone at a time.
+        iam.RolePolicyAttachment(
+            f"concourse-instance-policy-worker-{worker_class_name}-route53-all-zones-{stack_info.env_suffix}",
+            policy_arn=policy_stack.require_output("iam_policies")[
+                "route53_all_zones_records"
+            ],
+            role=concourse_worker_instance_role.name,
+        )
+
     concourse_worker_instance_profile = iam.InstanceProfile(
         f"concourse-instance-profile-worker-{worker_class_name}-{stack_info.env_suffix}",
         role=concourse_worker_instance_role.name,

--- a/src/ol_infrastructure/infrastructure/aws/policies/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/policies/__main__.py
@@ -1,4 +1,4 @@
-from pulumi import ResourceOptions, export
+from pulumi import Output, ResourceOptions, export
 from pulumi.resource import Alias
 from pulumi_aws import iam
 
@@ -90,6 +90,25 @@ for zone in app_route53_zones:
         ),
     )
     app_route53_policies[f"route53_{zone}_zone_records"] = policy.arn
+
+all_zone_ids = Output.all(
+    *[dns_stack.require_output(zone)["id"] for zone in app_route53_zones]
+)
+route53_all_zones_records_policy = iam.Policy(
+    "all-zones-route53-records-policy",
+    name="route53-all-zones-records-policy",
+    path="/ol-infrastructure/route53-all-zones-records-policy/",
+    policy=all_zone_ids.apply(
+        lambda zone_ids: lint_iam_policy(
+            route53_policy_template(zone_ids), stringify=True
+        )
+    ),
+    description=(
+        "Grant permissions to create Route53 records across all managed zones "
+        f"({', '.join(app_route53_zones)})"
+    ),
+)
+app_route53_policies["route53_all_zones_records"] = route53_all_zones_records_policy.arn
 
 
 cloudwatch_logs_policy = {

--- a/src/ol_infrastructure/infrastructure/aws/policies/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/policies/__main__.py
@@ -104,8 +104,8 @@ route53_all_zones_records_policy = iam.Policy(
         )
     ),
     description=(
-        "Grant permissions to create Route53 records across all managed zones "
-        f"({', '.join(app_route53_zones)})"
+        "Grant permissions to manage (create, update, delete) Route53 records "
+        f"across all managed zones ({', '.join(app_route53_zones)})"
     ),
 )
 app_route53_policies["route53_all_zones_records"] = route53_all_zones_records_policy.arn

--- a/src/ol_infrastructure/lib/aws/iam_helper.py
+++ b/src/ol_infrastructure/lib/aws/iam_helper.py
@@ -217,7 +217,7 @@ def split_iam_policy_by_size(
 
 
 def route53_policy_template(zone_id: str | list[str]) -> dict[str, Any]:
-    """Policy definition to allow Caddy to use Route 53 to resolve DNS challenges.
+    """Policy definition granting write access to one or more Route53 zones.
 
     This provides the permissions necessary to modify Route53 records, for example in a
     Caddy configuration that is using the DNS authorization method for Let's Encrypt.

--- a/src/ol_infrastructure/lib/aws/iam_helper.py
+++ b/src/ol_infrastructure/lib/aws/iam_helper.py
@@ -216,18 +216,20 @@ def split_iam_policy_by_size(
     ]
 
 
-def route53_policy_template(zone_id: str) -> dict[str, Any]:
+def route53_policy_template(zone_id: str | list[str]) -> dict[str, Any]:
     """Policy definition to allow Caddy to use Route 53 to resolve DNS challenges.
 
     This provides the permissions necessary to modify Route53 records, for example in a
     Caddy configuration that is using the DNS authorization method for Let's Encrypt.
 
-    :param zone_id: The ID of the DNS zone that the policy is being generated for.
-    :type zone_id: str
+    :param zone_id: The ID, or list of IDs, of the DNS zone(s) the policy is being
+        generated for.
+    :type zone_id: str | list[str]
 
     :returns: A dictionary object representing a policy document to allow access to
               modify records in a Route53 zone.
     """
+    zone_ids = [zone_id] if isinstance(zone_id, str) else zone_id
     return {
         "Version": "2012-10-17",
         "Statement": [
@@ -238,10 +240,8 @@ def route53_policy_template(zone_id: str) -> dict[str, Any]:
                     "route53:GetChange",
                     "route53:ChangeResourceRecordSets",
                 ],
-                "Resource": [
-                    f"arn:aws:route53:::hostedzone/{zone_id}",
-                    "arn:aws:route53:::change/*",
-                ],
+                "Resource": [f"arn:aws:route53:::hostedzone/{zid}" for zid in zone_ids]
+                + ["arn:aws:route53:::change/*"],
             },
             {
                 "Effect": "Allow",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Two related IAM gaps on the Concourse `infra` worker pool (the only worker pool that runs `pulumi_job()` steps):

1. **Missing Route53 write access.** `iam_policies/pulumi_infra.py` is a CloudTrail-derived least-privilege policy, and its only route53 actions are read-only (`GetHostedZone`, `ListResourceRecordSets`, etc.) since `route53:ChangeResourceRecordSets` hadn't fired in the lookback window used to generate it. This caused a production deploy managing the xpro Fastly DNS record to fail:

   ```
   AccessDenied: User: arn:aws:sts::610119931565:assumed-role/concourse-instance-role-worker-infra-production-ed1176e/i-0e83292a891c18b48
   is not authorized to perform: route53:ChangeResourceRecordSets on resource: arn:aws:route53:::hostedzone/Z2QA8Z43NX1KBT
   ```

   Fix: generalized `route53_policy_template()` (`lib/aws/iam_helper.py`) to accept a list of zone IDs instead of just one, and added a new `route53_all_zones_records` policy in the policies stack covering every app-managed zone (`learn`, `mitx`, `mitxonline`, `ocw`, `odl`, `ol`, `xpro`). The `infra` worker pool attaches this single combined policy — since it deploys across all app stacks, scoping to just one zone wasn't sufficient, and attaching all 7 per-zone policies individually would have cost 7 attachment slots instead of 1.

2. **QA infra worker at the AWS managed-policies-per-role quota.** Separately, the QA `infra` worker role (`concourse-instance-role-worker-infra-qa-...`) was already at AWS's default quota of 10 managed policies per role, one of which (`AmazonSSMManagedInstanceCore`) was a manual attachment not managed by this codebase (not present on the equivalent `ci` or `production` roles). This meant the next Concourse deploy — which needed to attach a 3rd `pulumi_infra` policy chunk as that policy has grown — would fail with `LimitExceeded`. Resolved out-of-band: requested an account-level quota increase to 20 via Service Quotas, and detached the orphaned `AmazonSSMManagedInstanceCore` policy directly from the QA role.

### Screenshots (if appropriate):
N/A

### How can this be tested?
- `uv run ruff check` / `uv run ruff format --check` / `uv run mypy` all pass on the changed files (no new errors relative to `main`).
- `pulumi preview` on the `ol-infrastructure-aws-policies` stack should show only the new `route53_all_zones_records` policy being created, with the existing per-zone policies unchanged.
- `pulumi preview` on the `concourse` QA and Production stacks should show one new `RolePolicyAttachment` on the `infra` worker role (`route53-all-zones`), with no changes to the web role or other worker pools.
- After deploy, `aws iam list-attached-role-policies --role-name <infra-worker-role>` should show the new `route53-all-zones-records-policy` attached, and a subsequent xpro Pulumi run touching the Fastly DNS record should no longer hit `AccessDenied`.

### Additional Context
The AWS-side fixes (quota increase to 20, and detaching `AmazonSSMManagedInstanceCore` from the QA infra worker role) were already applied directly against the account and are not part of this diff — only the IaC changes that prevent the underlying gaps from recurring are included here.