### PR TITLE
fix(omnigraph,witan): populate actor-tokens/ci-token Vault secrets from SOPS

### DIFF
--- a/src/bridge/secrets/omnigraph/secrets.ci.yaml
+++ b/src/bridge/secrets/omnigraph/secrets.ci.yaml
@@ -1,0 +1,20 @@
+---
+ci_token: ENC[AES256_GCM,data:2yBmqrgx5BXoUFjJsUAkENS+HyZaqkoXa3PtQC5UxpzG7WvwFwqIgWKj1g==,iv:CaLOO2Vy2lKjArBhpBF32h4CnydWAeGdsjfOCc/NqE4=,tag:9224Sg5loyqbtKMMeIOTrg==,type:str]
+actor_tokens:
+  svc-witan-ci: ENC[AES256_GCM,data:CMzi/oQyJeo3arQTW1s672sT4D9Z2WxrecgcA4iqtp2oowQJyYXvX6S4tQ==,iv:0O96buddDaCBLXcu6byIa9SCu8rbwxr1oD7vdmMgb3A=,tag:qfp2dtwcY0mMMzq9xFN+bg==,type:str]
+sops:
+  hc_vault:
+  - created_at: "2026-07-31T15:22:32Z"
+    enc: vault:v1:y1b3G90UuyZDnqnDhtkViSIfECPnNUXNhUkWforNh1qLZuFMQ5c4X8tnG8CVpckhDPy2F3wHne0pR5Yz
+    engine_path: infrastructure
+    key_name: sops
+    vault_address: https://vault-ci.odl.mit.edu
+  kms:
+  - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-ci
+    aws_profile: ""
+    created_at: "2026-07-31T15:22:32Z"
+    enc: AQICAHhMkpkBpCvmFjhyfy75ENALRrbg42uOs9cUsFNLXqPnagGvNoe+jzxsGO4erFHPzX/5AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMmTMEt3pPuQmKDQEkAgEQgDv9R2nQjDrc4iEMfENvbSK+VTnskrdnUfEZShH2NlKeampTSG/Rg8PfNXtWdMGOgG+n0euyemB2fuiXSQ==
+  lastmodified: "2026-07-31T15:22:32Z"
+  mac: ENC[AES256_GCM,data:BZl9pzuzKd1Y1xbghFXHU9poO0IHgYdEE4+ks6t5fGmY1kZShBI9Raley8iGzxiZiY8MZARk3Zc0AtGkR9g/rKahgNE4qdq9jcDRBQPrVHvfsn+vgcBBb2hQ9DysyUNkO7ydUH/GwiFnO9Vy2HI9QMWo5a7YuBghnCzOGtBgI2g=,iv:M9OFU5l6XTn4JYwxAiKJuTDB8AnoMtHigv7U9etI8Hg=,tag:mM70+2MvPoGlWAxthLALnw==,type:str]
+  unencrypted_suffix: _unencrypted
+  version: 3.13.3

--- a/src/bridge/secrets/omnigraph/secrets.production.yaml
+++ b/src/bridge/secrets/omnigraph/secrets.production.yaml
@@ -1,0 +1,20 @@
+---
+ci_token: ENC[AES256_GCM,data:QBK1a1NSedW9E+jCGdp97KOeGRJB3RWiMNW4kMQutBU36Of4Sidq53n3lw==,iv:xFUw4mtk2aqeLKtBHqjqvJt1fNtvbi+vE6N59s+Ts0A=,tag:GNZR3MC4j1YOqTaaiTuZtA==,type:str]
+actor_tokens:
+  svc-witan-ci: ENC[AES256_GCM,data:BLUr2vuEZDxHd/kFIACCbtC48FWaCKMcqGjTs8veICOw1YzVWfhiKRVThA==,iv:+sP59AytweaLC1s7ex8JEpUr6EQAfMwTdaIsE++tqZo=,tag:W8qIEtqfpl6iQU5AzcrA7Q==,type:str]
+sops:
+  hc_vault:
+  - created_at: "2026-07-31T15:21:56Z"
+    enc: vault:v1:QY1l4xEuTQBvOJ5C66IWP1YzLnCW+zAUfidEzyebk1HclIJp+DqIkwD8/NBgoBxEiJAjFQRm+/b+frQd
+    engine_path: infrastructure
+    key_name: sops
+    vault_address: https://vault-production.odl.mit.edu
+  kms:
+  - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-production
+    aws_profile: ""
+    created_at: "2026-07-31T15:21:56Z"
+    enc: AQICAHjksIVfl1VtAHpBda/1YYjj6tSeS2o4TXgvEEyBIXLjjwGGmI6uTLc+d4E49Qm7p2a9AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMJtOzE5pKoHw7VbZnAgEQgDsU9THs15uO2iIzFmkI/J1k8SJciKbDffrObKc1VZZrr3BOsq2k7TvWBBrBhcBBNts5fm5Ay+JnL2M2Kw==
+  lastmodified: "2026-07-31T15:21:56Z"
+  mac: ENC[AES256_GCM,data:HI88C+/Wvaj0dG5i0J3Rj7QPArgp7FdAcTp7MRWPE+i5jmplIge7vPus904IeUP3ARWyktipthaK+LHTWNSRZgZM5cdv6b3N5tS8tjmyzBsv0USTAvYqcn53ZeDXDbo5v9ZRfAdSpnkB8AvOMyujcMK9LGlPqcaSA27FUWyJ+fA=,iv:29r2ypYbkJTC+dHJ66HO2m48EJYTQHbyzsl7V95u6/o=,tag:Dj4LDTLSbnj5pVEb3zOcIA==,type:str]
+  unencrypted_suffix: _unencrypted
+  version: 3.13.3

--- a/src/bridge/secrets/omnigraph/secrets.qa.yaml
+++ b/src/bridge/secrets/omnigraph/secrets.qa.yaml
@@ -1,0 +1,20 @@
+---
+ci_token: ENC[AES256_GCM,data:nssIKN1asjwmcMWI7Im8+zRxay4Ml+eC0fsFrtMal8Ee5sMBfkdDi4T4dA==,iv:Uxt25r+CmcQNUrW/VQ3Qz9HK7f0qwEJMul3xJ1NVqUU=,tag:6Tt4jqKw8qsz4EJz5ZM+iA==,type:str]
+actor_tokens:
+  svc-witan-ci: ENC[AES256_GCM,data:PB4Q54yV5Su0oDs0g/6cj+eR4SyfZzd78qXxkCqUYtwYXs+JU9pfKJB+WQ==,iv:X0bVMjkXssWD42oIw90o2r85RgaYY1hPXqxnjwgjK7A=,tag:GTYlQvE8ZidFBCao4a2oxQ==,type:str]
+sops:
+  hc_vault:
+  - created_at: "2026-07-31T15:22:14Z"
+    enc: vault:v1:qBEs1mPbGqCDeKkre9mzQI6spFNIbufem24XeajCURIoKS8xWOIjHswsPzyoNT9sjN/QakDjnNlZpviw
+    engine_path: infrastructure
+    key_name: sops
+    vault_address: https://vault-qa.odl.mit.edu
+  kms:
+  - arn: arn:aws:kms:us-east-1:610119931565:alias/infrastructure-secrets-qa
+    aws_profile: ""
+    created_at: "2026-07-31T15:22:14Z"
+    enc: AQICAHjE+jMY5DL7M1LMYX6YgtMueHEDNg05lsdN5Z0zeGHyJgE8atmiP3X+tc5NqCG+VRcVAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM045vR2toFS95GGXfAgEQgDvIai57QKgeLJClef57UOUY8SleOglRWh0ZEQRjFDs9k/J1pwbjpCjeu4zuyIPRguAntbiqWlrN77vs0A==
+  lastmodified: "2026-07-31T15:22:15Z"
+  mac: ENC[AES256_GCM,data:1tfnkFrc/7HBVg0r57BxGs8Aly9smMKG4QqjblgDv+rxPTckEfieWJkYC7kDm+++Swm72/buiBXu7RVBF6knCNO2Tru1p4FTJY5JDyltsrYvaEDDjxM1KtwEYVBILn4Ng7zX5UWXhHxAlQVmOLrxnq243DN78M/QpOxnr+8tENo=,iv:d84qqIzTxAbZeGf2epr8uDfQlOO9d7XMSZkJ0i3tmOs=,tag:M9nmcpevKO9BU5Vb7JtSKA==,type:str]
+  unencrypted_suffix: _unencrypted
+  version: 3.13.3

--- a/src/ol_infrastructure/applications/omnigraph/__main__.py
+++ b/src/ol_infrastructure/applications/omnigraph/__main__.py
@@ -29,15 +29,23 @@ Follow-up work this stack does NOT cover (tracked separately):
       docstring. ``schema.pg`` (agent-kit repo,
       ``mcp/servers/witan/schema/schema.pg``) must be baked into the image at
       build time — this Pulumi program has no access to agent-kit's tree.
-    - **Keycloak witan-users token sync.** This stack provisions the
-      ``actor-tokens`` Secret destination but not the job that keeps per-user
-      entries current as Keycloak group membership changes.
+    - **Keycloak witan-users token sync.** This stack writes the Vault
+      ``secret-operations/witan/actor-tokens`` source (below) from a
+      hand-authored SOPS file, and provisions the ``actor-tokens`` Secret
+      destination, but not the job that keeps per-user entries current as
+      Keycloak group membership changes — today the SOPS file only ever
+      carries the one ``svc-witan-ci`` entry.
 """
 
+import json
 from pathlib import Path
+from typing import Any
 
-from pulumi import ResourceOptions, export
+import pulumi_vault as vault
+from pulumi import Output, ResourceOptions, export
 
+from bridge.secrets import sops as _bridge_sops
+from bridge.secrets.sops import read_yaml_secrets
 from ol_infrastructure.applications.omnigraph.data_tier import (
     create_data_tier,
     omnigraph_server_addr,
@@ -63,6 +71,10 @@ from ol_infrastructure.lib.ol_types import (
 )
 from ol_infrastructure.lib.pulumi_helper import make_stack_reference, parse_stack
 from ol_infrastructure.lib.vault import setup_vault_provider
+
+# Resolve the bridge secrets directory once at module level using the sops
+# module's own __file__ — the same base path read_yaml_secrets uses internally.
+_BRIDGE_SECRETS_DIR = Path(_bridge_sops.__file__).parent
 
 setup_vault_provider()
 
@@ -99,12 +111,67 @@ k8s_global_labels = k8s_labels.model_dump()
 # source (secret-operations/witan/actor-tokens), agent-kit ADR-0004 D3.
 ACTOR_TOKENS_SECRET_NAME = "actor-tokens"  # noqa: S105  # pragma: allowlist secret
 ACTOR_TOKENS_SECRET_KEY = "tokens.json"  # noqa: S105  # pragma: allowlist secret
-# Key the map is stored under *inside* the Vault secret, which this stack does
-# not provision (out-of-band, see the module docstring). The VSO template below
-# resolves to an empty Secret — and the app to an empty token map — if the
-# Vault secret uses any other key, so the name is part of the contract:
-# `vault kv put secret-operations/witan/actor-tokens tokens_json=@tokens.json`.
+# Key the map is stored under *inside* the Vault secret. Populated below from a
+# SOPS-encrypted, per-environment source file — this is the contract that file
+# must follow (an "actor_tokens" mapping under this key), and the VSO template
+# further down resolves to an empty Secret — and the app to an empty token
+# map — if the Vault secret uses any other key.
 ACTOR_TOKENS_VAULT_KEY = "tokens_json"  # pragma: allowlist secret
+# witan's own module-level fallback OmnigraphClient authenticates as this raw
+# token (WITAN_MEMORY_TOKEN) when a request carries no per-actor JWT — see
+# applications/witan/__main__.py and witan_policy.hcl. Its value must match
+# the "svc-witan-ci" entry of the actor-tokens map above; both come from the
+# same SOPS source record below so they can't drift.
+WITAN_CI_TOKEN_VAULT_KEY = "token"  # noqa: S105  # pragma: allowlist secret
+
+##############################################
+#   Vault secret source (SOPS -> Vault)       #
+##############################################
+# This stack is the sole writer of both Vault paths below — the witan stack
+# (applications/witan) only ever reads them via its own OLVaultK8SSecret. One
+# writer per path avoids two independent Pulumi programs racing to write the
+# same Vault secret. The destination path is deliberately the same literal
+# string in every environment: CI/QA/Production each already have their own
+# physically separate Vault server (vault-<env>.odl.mit.edu, see
+# setup_vault_provider), so environment separation comes from which Vault
+# this stack's provider is pointed at, not from anything in the path itself.
+# Not yet seeded for every environment (bootstrapping is manual), so this
+# reads best-effort: an environment without the file yet just gets neither
+# Vault write, leaving actor_tokens_secret's VSO sync exactly as unfulfilled
+# as it is today rather than hard-failing the rest of this stack's resources.
+_witan_secrets_path = Path(f"omnigraph/secrets.{stack_info.env_suffix}.yaml")
+_witan_secrets_source: dict[str, Any] = {}
+if (_BRIDGE_SECRETS_DIR / _witan_secrets_path).exists():
+    _witan_secrets_source = read_yaml_secrets(_witan_secrets_path)
+
+_actor_tokens_map = _witan_secrets_source.get("actor_tokens") or {}
+_witan_ci_token = _witan_secrets_source.get("ci_token")
+if _witan_ci_token and _actor_tokens_map.get("svc-witan-ci") != _witan_ci_token:
+    msg = (
+        f"omnigraph/secrets.{stack_info.env_suffix}.yaml: ci_token must match "
+        "actor_tokens['svc-witan-ci'] (ADR-0009 decision point 3) — they are "
+        "the same token exposed to two different consumers."
+    )
+    raise ValueError(msg)
+
+actor_tokens_vault_secret = None
+if _actor_tokens_map:
+    actor_tokens_vault_secret = vault.generic.Secret(
+        f"omnigraph-actor-tokens-vault-secret-{stack_info.env_suffix}",
+        path="secret-operations/witan/actor-tokens",
+        data_json=Output.secret(
+            json.dumps({ACTOR_TOKENS_VAULT_KEY: json.dumps(_actor_tokens_map)})
+        ),
+    )
+
+if _witan_ci_token:
+    vault.generic.Secret(
+        f"omnigraph-witan-ci-token-vault-secret-{stack_info.env_suffix}",
+        path="secret-operations/witan/ci-token",
+        data_json=Output.secret(
+            json.dumps({WITAN_CI_TOKEN_VAULT_KEY: _witan_ci_token})
+        ),
+    )
 
 ##############################################
 #   Vault auth binding (IRSA + VSO sync)      #
@@ -156,7 +223,10 @@ actor_tokens_secret = OLVaultK8SSecret(
     ),
     opts=ResourceOptions(
         delete_before_replace=True,
-        depends_on=omnigraph_auth_binding.vault_k8s_resources,
+        depends_on=[
+            omnigraph_auth_binding.vault_k8s_resources,
+            *([actor_tokens_vault_secret] if actor_tokens_vault_secret else []),
+        ],
     ),
 )
 

--- a/src/ol_infrastructure/applications/omnigraph/__main__.py
+++ b/src/ol_infrastructure/applications/omnigraph/__main__.py
@@ -135,24 +135,49 @@ WITAN_CI_TOKEN_VAULT_KEY = "token"  # noqa: S105  # pragma: allowlist secret
 # physically separate Vault server (vault-<env>.odl.mit.edu, see
 # setup_vault_provider), so environment separation comes from which Vault
 # this stack's provider is pointed at, not from anything in the path itself.
-# Not yet seeded for every environment (bootstrapping is manual), so this
-# reads best-effort: an environment without the file yet just gets neither
+# Not yet seeded for every environment (bootstrapping is manual), so a
+# *missing* file is read best-effort — that environment just gets neither
 # Vault write, leaving actor_tokens_secret's VSO sync exactly as unfulfilled
-# as it is today rather than hard-failing the rest of this stack's resources.
+# as it is today rather than hard-failing the rest of this stack's resources
+# (same tolerance open_metadata/__main__.py uses for its own connector
+# secrets). A *present* file is not optional, though: a decrypt failure or
+# missing/mismatched keys fails the whole preview/up rather than silently
+# creating actor_tokens_secret and the Deployment that mounts it against an
+# incomplete or absent Vault source — which would just recreate the
+# ContainerCreating bug this stack exists to fix, with `pulumi up` reporting
+# success.
 _witan_secrets_path = Path(f"omnigraph/secrets.{stack_info.env_suffix}.yaml")
 _witan_secrets_source: dict[str, Any] = {}
 if (_BRIDGE_SECRETS_DIR / _witan_secrets_path).exists():
     _witan_secrets_source = read_yaml_secrets(_witan_secrets_path)
+    if not isinstance(_witan_secrets_source, dict):
+        msg = (
+            f"Failed to decrypt omnigraph/secrets.{stack_info.env_suffix}.yaml: "
+            f"expected a dict but got {type(_witan_secrets_source).__name__}. "
+            "Check that sops can decrypt the file and that Vault-transit/KMS "
+            "access is available."
+        )
+        raise TypeError(msg)
 
-_actor_tokens_map = _witan_secrets_source.get("actor_tokens") or {}
-_witan_ci_token = _witan_secrets_source.get("ci_token")
-if _witan_ci_token and _actor_tokens_map.get("svc-witan-ci") != _witan_ci_token:
-    msg = (
-        f"omnigraph/secrets.{stack_info.env_suffix}.yaml: ci_token must match "
-        "actor_tokens['svc-witan-ci'] (ADR-0009 decision point 3) — they are "
-        "the same token exposed to two different consumers."
-    )
-    raise ValueError(msg)
+    _actor_tokens_map = _witan_secrets_source.get("actor_tokens") or {}
+    _witan_ci_token = _witan_secrets_source.get("ci_token")
+    if not _witan_ci_token or not _actor_tokens_map:
+        msg = (
+            f"omnigraph/secrets.{stack_info.env_suffix}.yaml is missing "
+            "required keys: both 'ci_token' and a non-empty 'actor_tokens' "
+            "map are required once the file exists."
+        )
+        raise ValueError(msg)
+    if _actor_tokens_map.get("svc-witan-ci") != _witan_ci_token:
+        msg = (
+            f"omnigraph/secrets.{stack_info.env_suffix}.yaml: ci_token must "
+            "match actor_tokens['svc-witan-ci'] (ADR-0009 decision point 3) "
+            "— they are the same token exposed to two different consumers."
+        )
+        raise ValueError(msg)
+else:
+    _actor_tokens_map = {}
+    _witan_ci_token = None
 
 actor_tokens_vault_secret = None
 if _actor_tokens_map:

--- a/src/ol_infrastructure/applications/witan/__main__.py
+++ b/src/ol_infrastructure/applications/witan/__main__.py
@@ -56,9 +56,11 @@ silently assumed:
       assigns the job of "walking the Keycloak witan-users group/role
       membership and writing a generated token per user" into the shared
       actor-tokens source. This stack only provisions the destination (the
-      Vault-backed ``actor-tokens`` Secret, seeded with at minimum the
-      ``svc-witan-ci`` entry) — the sync job that keeps per-user entries
-      current as Keycloak group membership changes is not yet built.
+      Vault-backed ``actor-tokens`` Secret) — the omnigraph stack
+      (``applications/omnigraph``) writes the Vault source itself from a
+      SOPS file, seeded today with at minimum the ``svc-witan-ci`` entry —
+      the sync job that keeps per-user entries current as Keycloak group
+      membership changes is not yet built.
 """
 
 from pathlib import Path
@@ -172,12 +174,12 @@ WITAN_CI_TOKEN_SECRET_NAME = "witan-ci-token"  # noqa: S105  # pragma: allowlist
 WITAN_CI_TOKEN_SECRET_KEY = "token"  # noqa: S105  # pragma: allowlist secret
 ACTOR_TOKENS_SECRET_NAME = "actor-tokens"  # noqa: S105  # pragma: allowlist secret
 ACTOR_TOKENS_SECRET_KEY = "tokens.json"  # noqa: S105  # pragma: allowlist secret
-# Keys these maps are stored under *inside* their Vault secrets, which this
-# stack does not provision (out-of-band, see the module docstring). The VSO
-# templates below resolve to empty Secrets — and the apps to empty tokens — if
-# the Vault secrets use any other key, so the names are part of the contract:
-#   vault kv put secret-operations/witan/ci-token token=<raw token>
-#   vault kv put secret-operations/witan/actor-tokens tokens_json=@tokens.json
+# Keys these maps are stored under *inside* their Vault secrets. This stack
+# only reads them (OLVaultK8SSecret/VSO below) — the omnigraph stack
+# (applications/omnigraph/__main__.py) is the sole writer, populating both
+# from a SOPS-encrypted per-environment file. The VSO templates below resolve
+# to empty Secrets — and the apps to empty tokens — if the Vault secrets use
+# any other key, so the names are part of the contract.
 WITAN_CI_TOKEN_VAULT_KEY = "token"  # noqa: S105  # pragma: allowlist secret
 ACTOR_TOKENS_VAULT_KEY = "tokens_json"  # pragma: allowlist secret
 


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
`omnigraph-server` in the CI environment has been stuck in `ContainerCreating` because its `actor-tokens` Secret volume could never mount. Root cause: the `VaultStaticSecret` at `secret-operations/witan/actor-tokens` (KV-v1) was returning an empty response from Vault — nothing had ever written that path. Both `applications/omnigraph` and `applications/witan` only ever *read* it via `OLVaultK8SSecret`/VSO; there was no writer.

This PR makes the `omnigraph` stack the sole writer of both Vault paths it and `witan` depend on:
- `secret-operations/witan/actor-tokens` (`tokens_json` key — the `{actor_id: token}` map `omnigraph-server`'s bearer-token auth boots from, and that `witan` resolves per-user tokens from)
- `secret-operations/witan/ci-token` (`token` key — the raw `svc-witan-ci` token `witan`'s fallback client authenticates as when a request carries no per-actor JWT, per ADR-0009 decision point 3)

Both are sourced from a new SOPS-encrypted, per-environment file: `bridge/secrets/omnigraph/secrets.{ci,qa,production}.yaml`, containing `ci_token` and an `actor_tokens` map. Pulumi code validates that `ci_token` matches `actor_tokens["svc-witan-ci"]` at preview/up time, since ADR-0009 requires them to be the same token exposed to two different consumers.

The destination Vault *path* is deliberately identical across environments — CI/QA/Production each already run their own physically separate Vault server (`vault-<env>.odl.mit.edu`), so environment separation comes from which Vault the stack's provider talks to, not from anything encoded in the path itself.

Also updates `witan/__main__.py` comments to reflect that it's a read-only consumer of these two Vault paths (no behavior change there — it already pointed at the same paths).

### Screenshots (if appropriate):
N/A — infra-only change, no UI.

### How can this be tested?
- `uv run ruff check` / `uv run mypy` pass on both modified `__main__.py` files.
- `read_yaml_secrets` successfully decrypts all three new SOPS files and each round-trips to the expected `{ci_token, actor_tokens: {svc-witan-ci}}` shape with `ci_token == actor_tokens["svc-witan-ci"]`.
- `pulumi preview --diff` against the `omnigraph` `CI` stack shows exactly the expected diff: two new `vault:generic/secret:Secret` creates (the two paths above), one incidental `Deployment` update (dependency-triggered recreate under the existing `Recreate` strategy — no field-level diff), and one `Service` create (a pre-existing, unrelated gap — the `omnigraph-server` ClusterIP `Service` was missing from both live cluster and Pulumi state). 27 resources unchanged.
- After `pulumi up`, the `omnigraph` namespace's `actor-tokens` `VaultStaticSecret` should report `SYNCED=True`, and the `omnigraph-server` pod should leave `ContainerCreating`.

### Additional Context
- Diagnosed via `kubectl --context operations-ci -n omnigraph describe vaultstaticsecret actor-tokens`, which showed `Failed to sync the secret ... err=empty response from Vault, path="secret-operations/witan/actor-tokens"` repeating for 17h.
- The `svc-witan-ci` actor id refers to the *Continuous Integration* automation principal (ADR-0009 point 3: `svc-witan-<team>` / `svc-witan-ci` / `svc-witan-admin`), not the *CI deployment environment* — same three letters, different meaning. It's expected to appear with a distinct token value in every environment's map.
- QA/Production `omnigraph`/`witan` Pulumi stacks have 0 resources deployed today, so this PR only unblocks CI in practice; the QA/Production SOPS files are included so those stacks won't hit the same gap when they're first deployed.

### Checklist:
- [ ] After merge, run `pulumi up` on the `omnigraph` `CI` stack to apply (already previewed clean — 2 Vault secret creates, 1 Service create, 1 incidental Deployment recreate).