### PR TITLE
feat(ol-analytics-api): run the app under Granian via GranianConfig

### DIFF
--- a/src/ol_infrastructure/applications/ol_analytics_api/__main__.py
+++ b/src/ol_infrastructure/applications/ol_analytics_api/__main__.py
@@ -117,10 +117,9 @@ from ol_infrastructure.lib.pulumi_helper import (
 )
 from ol_infrastructure.lib.vault import setup_vault_provider
 
-# The container listens on this port (see the app repo's Dockerfile CMD:
-# `granian --interface asgi --host 0.0.0.0 --port 8000
-# ol_analytics_api.main:app`).  No nginx sidecar sits in front, so the Service
-# and the health probes target it directly.
+# The container listens on this port. No nginx sidecar sits in front, so the
+# Service and the health probes target it directly. Keep this aligned with
+# granian_config.port below.
 APPLICATION_PORT = 8000
 
 APPLICATION_NAME = "ol-analytics-api"
@@ -416,10 +415,9 @@ ol_analytics_api_k8s = OLApplicationK8s(
         application_image_repository="mitodl/ol-analytics-api-app",
         **docker_image_config_kwargs("OL_ANALYTICS_API"),
         application_min_replicas=ol_analytics_api_config.get_int("min_replicas") or 2,
-        # Granian settings come from the shared component rather than being left
-        # to the image's own CMD, so the server config is visible and diffable in
-        # this stack (and picks up the component's metrics/PodMonitor wiring).
-        # The image CMD stays as the local-run default; this supersedes it.
+        # Granian settings are declared here via the shared component so server
+        # config is visible and diffable in this stack (and picks up the
+        # component's metrics/PodMonitor wiring).
         granian_config=GranianConfig(
             # FastAPI is ASGI; Granian's own default interface is RSGI.
             interface="asgi",

--- a/src/ol_infrastructure/applications/ol_analytics_api/__main__.py
+++ b/src/ol_infrastructure/applications/ol_analytics_api/__main__.py
@@ -41,7 +41,7 @@ Key wiring decisions (see also ``k8s/README.md`` in the app repo):
   dry-run reference) means the ``/health/{startup,readiness,liveness}/`` probe
   paths and timings that ``core/health.py`` was built to match come straight
   from the component instead of being maintained in a second place.  The
-  service runs a single uvicorn process on port 8000 with no nginx sidecar, so
+  service runs a single Granian worker on port 8000 with no nginx sidecar, so
   ``import_nginx_config`` is off and the probes are re-pointed at 8000.  This is
   the first data-cluster use of ``OLApplicationK8s``; it creates a
   ``SecurityGroupPolicy`` binding the pods to a dedicated security group (see
@@ -88,6 +88,7 @@ from ol_infrastructure.components.services.cert_manager import (
     OLCertManagerCertConfig,
 )
 from ol_infrastructure.components.services.k8s import (
+    GranianConfig,
     OLApplicationK8s,
     OLApplicationK8sConfig,
 )
@@ -117,9 +118,9 @@ from ol_infrastructure.lib.pulumi_helper import (
 from ol_infrastructure.lib.vault import setup_vault_provider
 
 # The container listens on this port (see the app repo's Dockerfile CMD:
-# `uvicorn ol_analytics_api.main:app --host 0.0.0.0 --port 8000`).  No nginx
-# sidecar sits in front, so the Service and the health probes target it
-# directly.
+# `granian --interface asgi --host 0.0.0.0 --port 8000
+# ol_analytics_api.main:app`).  No nginx sidecar sits in front, so the Service
+# and the health probes target it directly.
 APPLICATION_PORT = 8000
 
 APPLICATION_NAME = "ol-analytics-api"
@@ -415,7 +416,33 @@ ol_analytics_api_k8s = OLApplicationK8s(
         application_image_repository="mitodl/ol-analytics-api-app",
         **docker_image_config_kwargs("OL_ANALYTICS_API"),
         application_min_replicas=ol_analytics_api_config.get_int("min_replicas") or 2,
-        # The image's own CMD runs uvicorn on port 8000 -- no command override.
+        # Granian settings come from the shared component rather than being left
+        # to the image's own CMD, so the server config is visible and diffable in
+        # this stack (and picks up the component's metrics/PodMonitor wiring).
+        # The image CMD stays as the local-run default; this supersedes it.
+        granian_config=GranianConfig(
+            # FastAPI is ASGI; Granian's own default interface is RSGI.
+            interface="asgi",
+            # Not DEFAULT_WSGI_PORT: there is no nginx sidecar here, so the
+            # Service and the health probes talk to Granian directly on
+            # APPLICATION_PORT (see import_nginx_config=False below).
+            port=APPLICATION_PORT,
+            # Scale horizontally on replicas rather than workers-per-pod --
+            # this pod is CPU-request-small (100m) and the workload is
+            # IO-bound on StarRocks, not CPU-bound.
+            workers=1,
+            runtime_threads=1,
+            # blocking_threads is deliberately unset: Granian forces it to 1
+            # on the asgi interface and the component rejects an explicit >1.
+            #
+            # No websockets anywhere in this service's surface.
+            no_ws=True,
+            # Matches the app's own LOG_LEVEL=INFO, so Granian's lifecycle
+            # lines land in Loki alongside the app's structured output rather
+            # than being suppressed at the component's "warning" default.
+            log_level="info",
+            application_module="ol_analytics_api.main:app",
+        ),
         application_port=APPLICATION_PORT,
         import_nginx_config=False,
         # Not a Django app: no migrations, no collectstatic, no nginx.


### PR DESCRIPTION
### What are the relevant tickets?
N/A — companion to https://github.com/mitodl/ol-analytics-api/pull/21

### Description (What does it do?)
`ol-analytics-api` is switching from uvicorn to Granian to match the org standard. This sets `OLApplicationK8sConfig.granian_config` on its stack so the shared component generates the container command/args, rather than the deployed pod inheriting whatever the image `CMD` happens to be.

Doing it through the component (instead of leaving it to the Dockerfile) means the server settings are visible and diffable in this stack, and the component's Prometheus metrics exporter + `PodMonitor` get wired up for free.

```python
granian_config=GranianConfig(
    interface="asgi",
    port=APPLICATION_PORT,
    workers=1,
    runtime_threads=1,
    no_ws=True,
    log_level="info",
    application_module="ol_analytics_api.main:app",
),
```

Also updates three now-stale comments that referred to uvicorn.

Rationale for the non-default values:

- **`interface="asgi"`** — the app is FastAPI. Granian's own default is RSGI.
- **`port=APPLICATION_PORT`** (8000) rather than `DEFAULT_WSGI_PORT` (8073) — there is no nginx sidecar in front of this service (`import_nginx_config=False`), so the Service and the health probes talk to Granian directly. The `validate_granian_port_nginx_coupling` validator only fires when `import_nginx_config=True`, so the override is safe here.
- **`workers=1`, `runtime_threads=1`** — the pod is CPU-request-small (100m) and the workload is IO-bound on StarRocks. Scale on replicas.
- **`blocking_threads` unset** — Granian pins it to 1 on the `asgi` interface, and `resolve_concurrency` raises on an explicit value >1 rather than letting a config read as tuned when it isn't.
- **`no_ws=True`** — no websockets anywhere in this service's surface.
- **`log_level="info"`** rather than the component's `"warning"` default — matches the app's own `LOG_LEVEL=INFO`, so Granian's lifecycle lines land in Loki alongside the app's structured output instead of being suppressed.
- **`enable_metrics`** left at the component default (`True`).

### How can this be tested?

`pulumi preview` on the CI/QA stack. The expected Deployment change is the container `command`/`args`, plus a new named `metrics` container port and a `PodMonitor`.

The generated argv is:

```
granian --interface asgi --host 0.0.0.0 --port 8000 --workers 1 --no-ws \
  --runtime-threads 1 --workers-max-rss 460 --respawn-failed-workers --backlog 128 \
  --metrics --metrics-scrape-interval 30 --metrics-address 0.0.0.0 --metrics-port 9090 \
  --log-level info ol_analytics_api.main:app
```

(`--workers-max-rss 460` is the component's derivation from the 512Mi memory limit at 1 worker.)

That exact argv was run against the app image on the companion PR's branch: the service came up, `/health/liveness/` returned 200, and the metrics exporter served `granian_workers_spawns` etc. on port 9090.

Pre-commit passes, including `ruff` and `mypy`.

### Additional Context

**Must merge with https://github.com/mitodl/ol-analytics-api/pull/21.** Once `granian_config` is set here, these args supersede the image `CMD`; before that PR merges, the image still ships uvicorn as its entrypoint and this config would not apply cleanly.

`enable_metrics=True` creates a `monitoring.coreos.com/v1` `PodMonitor`. This service runs on `data-qa`, and the docstring notes it is the first data-cluster use of `OLApplicationK8s` — I checked that the PodMonitor CRDs are installed on every cluster by the shared EKS stack (`infrastructure/aws/eks/__main__.py`, `prometheus-operator-crds`), so this should be fine. Worth a second pair of eyes given it is the first use there.

I was not able to run `pulumi preview` against the live stack from the authoring environment (no AWS credentials), so that check is still outstanding.
