### PR TITLE
feat(edxapp): isolate long instructor tasks on a dedicated high_mem celery worker

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
@@ -116,6 +116,12 @@ config:
       lms:
         max: 20
         min: 1
+      # Dedicated edx.lms.core.high_mem worker for long instructor-task reports.
+      # Keep one warm so a report starts immediately; cap low because each pod runs
+      # exactly one report at a time and they are infrequent.
+      lms_high_mem:
+        max: 3
+        min: 1
       cms:
         max: 20
         min: 1
@@ -134,6 +140,17 @@ config:
         cpu_request: "250m"
         memory_request: "3Gi"
         memory_limit: "4Gi"
+      # The high_mem worker runs one report at a time, so it wants CPU (the compile
+      # loop is serial and DB-bound) more than it wants headroom. Measured peak for
+      # the shared LMS worker was ~2.1Gi across all task types; a 5k-learner problem
+      # grade report projects to a few hundred MB of that, so 4Gi stays generous.
+      # ephemeral-storage covers the TemporaryFile spill path in instructor_task.
+      lms_high_mem:
+        cpu_request: "1000m"
+        memory_request: "3Gi"
+        memory_limit: "6Gi"
+        ephemeral_storage_request: "2Gi"
+        ephemeral_storage_limit: "8Gi"
       cms:
         cpu_request: "250m"
         memory_request: "4Gi"

--- a/src/ol_infrastructure/applications/edxapp/k8s_autoscaling.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_autoscaling.py
@@ -111,11 +111,14 @@ def create_celery_autoscaling_resources(
     replicas_dict: dict[str, Any],
     namespace: str,
     lms_celery_labels: dict[str, str],
+    lms_high_mem_celery_labels: dict[str, str],
     cms_celery_labels: dict[str, str],
     lms_celery_deployment_name: str,
+    lms_high_mem_celery_deployment_name: str,
     cms_celery_deployment_name: str,
     stack_info: StackInfo,
     lms_celery_deployment: kubernetes.apps.v1.Deployment,
+    lms_high_mem_celery_deployment: kubernetes.apps.v1.Deployment,
     cms_celery_deployment: kubernetes.apps.v1.Deployment,
 ) -> dict[str, Any]:
     """Create KEDA ScaledObjects for LMS and CMS celery worker deployments.
@@ -171,6 +174,73 @@ def create_celery_autoscaling_resources(
         opts=pulumi.ResourceOptions(depends_on=[lms_celery_deployment]),
     )
 
+    # Nothing previously watched edx.lms.core.high_mem, so a queued grade report
+    # produced no scale-up signal at all. Scale on that queue directly.
+    #
+    # listLength is 1: these tasks are minutes-to-hours long and singly-concurrent per
+    # pod, so any queued message means another worker is warranted -- unlike the
+    # default queue where a backlog of 10 short tasks is normal.
+    #
+    # The scale-down guards matter more here than the scale-up ones. A task that has
+    # been picked up no longer counts toward list length, so a lone in-flight report
+    # leaves the queue reading empty; without these the HPA would immediately scale
+    # back toward minReplicaCount and delete the pod running it. The long grace period
+    # on the deployment means such a pod still finishes its task, but there is no
+    # reason to provoke that repeatedly.
+    high_mem_replicas = replicas_dict["celery"].get(
+        "lms_high_mem", {"min": 1, "max": 3}
+    )
+    lms_high_mem_celery_scaledobject = kubernetes.apiextensions.CustomResource(
+        f"ol-{stack_info.env_prefix}-edxapp-lms-high-mem-celery-scaledobject-{stack_info.env_suffix}",
+        api_version="keda.sh/v1alpha1",
+        kind="ScaledObject",
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            name=f"{lms_high_mem_celery_deployment_name}-scaledobject",
+            namespace=namespace,
+            labels=lms_high_mem_celery_labels,
+        ),
+        spec={
+            "scaleTargetRef": {
+                "kind": "Deployment",
+                "name": lms_high_mem_celery_deployment_name,
+            },
+            "pollingInterval": 60,
+            "cooldownPeriod": 1800,
+            "minReplicaCount": high_mem_replicas["min"],
+            "maxReplicaCount": high_mem_replicas["max"],
+            "advanced": {
+                "horizontalPodAutoscalerConfig": {
+                    "behavior": {
+                        "scaleUp": {"stabilizationWindowSeconds": 60},
+                        "scaleDown": {
+                            "stabilizationWindowSeconds": 3600,
+                            "policies": [
+                                {"type": "Pods", "value": 1, "periodSeconds": 1800},
+                            ],
+                        },
+                    }
+                }
+            },
+            "triggers": [
+                {
+                    "type": "redis",
+                    "metadata": {
+                        "address": edxapp_cache.address.apply(
+                            lambda addr: f"{addr}:{DEFAULT_REDIS_PORT}"
+                        ),
+                        "username": "default",
+                        "databaseIndex": "1",
+                        "password": edxapp_cache.cache_cluster.auth_token,
+                        "listName": "edx.lms.core.high_mem",
+                        "listLength": "1",
+                        "enableTLS": "true",
+                    },
+                }
+            ],
+        },
+        opts=pulumi.ResourceOptions(depends_on=[lms_high_mem_celery_deployment]),
+    )
+
     cms_celery_scaledobject = kubernetes.apiextensions.CustomResource(
         f"ol-{stack_info.env_prefix}-edxapp-cms-celery-scaledobject-{stack_info.env_suffix}",
         api_version="keda.sh/v1alpha1",
@@ -211,5 +281,6 @@ def create_celery_autoscaling_resources(
 
     return {
         "lms_celery_scaledobject": lms_celery_scaledobject,
+        "lms_high_mem_celery_scaledobject": lms_high_mem_celery_scaledobject,
         "cms_celery_scaledobject": cms_celery_scaledobject,
     }

--- a/src/ol_infrastructure/applications/edxapp/k8s_autoscaling.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_autoscaling.py
@@ -121,7 +121,11 @@ def create_celery_autoscaling_resources(
     lms_high_mem_celery_deployment: kubernetes.apps.v1.Deployment,
     cms_celery_deployment: kubernetes.apps.v1.Deployment,
 ) -> dict[str, Any]:
-    """Create KEDA ScaledObjects for LMS and CMS celery worker deployments.
+    """Create KEDA ScaledObjects for the celery worker deployments.
+
+    Covers three workers: the shared LMS worker (edx.lms.core.default), the
+    dedicated LMS high_mem worker that serves the long instructor-task reports
+    (edx.lms.core.high_mem), and the CMS worker (edx.cms.core.default).
 
     Celery workers use Redis list length triggers (not Prometheus) so they
     remain outside the OLApplicationK8s component.

--- a/src/ol_infrastructure/applications/edxapp/k8s_resources.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_resources.py
@@ -77,6 +77,16 @@ from ol_infrastructure.lib.pulumi_helper import (
     make_stack_reference,
 )
 
+# Long-running instructor tasks (grade reports, problem grade reports, certificate
+# generation) are routed to edx.lms.core.high_mem via GRADES_DOWNLOAD_ROUTING_KEY. A
+# 5k-learner problem grade report measured ~80 minutes of wall clock, so the high_mem
+# worker gets a grace period comfortably longer than that. On SIGTERM celery performs a
+# warm shutdown: it stops prefetching and finishes the task already in flight, and
+# Kubernetes waits up to terminationGracePeriodSeconds for that to happen. Without this
+# the pod is SIGKILLed after the 30s default and the report dies silently mid-run, which
+# is what mitodl/hq#11978 was.
+HIGH_MEM_CELERY_TERMINATION_GRACE_PERIOD_SECONDS = 4 * 60 * 60
+
 
 def create_k8s_resources(  # noqa: C901
     aws_config: AWSBase,
@@ -98,6 +108,7 @@ def create_k8s_resources(  # noqa: C901
     cms_webapp_deployment_name = f"{env_name}-edxapp-cms-webapp"
 
     lms_celery_deployment_name = f"{env_name}-edxapp-lms-celery"
+    lms_high_mem_celery_deployment_name = f"{env_name}-edxapp-lms-high-mem-celery"
     cms_celery_deployment_name = f"{env_name}-edxapp-cms-celery"
     lms_beat_deployment_name = f"{env_name}-edxapp-lms-beat"
 
@@ -107,6 +118,7 @@ def create_k8s_resources(  # noqa: C901
         "lms-edxapp-app",  # LMS webapp (OLApplicationK8s application_name="lms-edxapp")
         "cms-edxapp-app",  # CMS webapp (OLApplicationK8s application_name="cms-edxapp")
         lms_celery_deployment_name,
+        lms_high_mem_celery_deployment_name,
         cms_celery_deployment_name,
         lms_beat_deployment_name,
         f"{env_name}-edxapp-lms-process-scheduled-emails",
@@ -1236,7 +1248,11 @@ def create_k8s_resources(  # noqa: C901
                                 "--hostname=edx.lms.core.default.%h",
                                 "--max-tasks-per-child",
                                 "100",
-                                "--queues=edx.lms.core.default,edx.lms.core.high,edx.lms.core.high_mem",
+                                # edx.lms.core.high_mem is deliberately absent: it is
+                                # served by the dedicated high-mem deployment below so
+                                # that long instructor-task reports are not killed by
+                                # the scale-down churn this deployment experiences.
+                                "--queues=edx.lms.core.default,edx.lms.core.high",
                                 "--exclude-queues=edx.cms.core.default",
                                 "--concurrency=2",
                                 "--prefetch-multiplier=1",
@@ -1275,6 +1291,202 @@ def create_k8s_resources(  # noqa: C901
         opts=pulumi.ResourceOptions(
             depends_on=[v for v in lms_edxapp_config_sources.values() if v is not None]
         ),
+    )
+
+    ############################################
+    # Dedicated LMS high_mem celery deployment
+    #
+    # Serves only edx.lms.core.high_mem, which is where edx-platform routes the
+    # long-running instructor tasks (calculate_grades_csv,
+    # calculate_problem_grade_report, calculate_problem_responses_csv,
+    # generate_certificates) via GRADES_DOWNLOAD_ROUTING_KEY -> HIGH_MEM_QUEUE.
+    #
+    # These previously ran on the shared LMS worker above, which is scaled by KEDA on
+    # the depth of edx.lms.core.default. Every scale-down of that unrelated queue --
+    # several a day -- deleted pods with only the default 30s grace period, killing
+    # in-flight reports partway through and leaving the instructor dashboard showing
+    # them as perpetually in progress (mitodl/hq#11978).
+    #
+    # The isolation here is what makes a multi-hour report survivable:
+    #   * its own queue, so shared-worker churn cannot touch it
+    #   * a grace period longer than the job, so celery's warm shutdown can finish the
+    #     task in flight instead of being SIGKILLed
+    #   * do-not-disrupt / safe-to-evict=false, so node consolidation leaves it alone
+    #   * concurrency 1 and max-tasks-per-child 1, so one report has the pod to itself
+    #     and its RSS is returned to the OS afterwards rather than accumulating
+    ############################################
+    # Fall back to the shared LMS celery sizing when a stack has not been given
+    # explicit high_mem values, so this deployment works on every stack unmodified.
+    high_mem_resources = resources_dict["celery"].get(
+        "lms_high_mem", resources_dict["celery"]["lms"]
+    )
+    lms_high_mem_celery_selector_labels = k8s_global_labels | {
+        "ol.mit.edu/component": "edxapp-lms-high-mem-celery",
+        "ol.mit.edu/pod-security-group": edxapp_k8s_app_security_group.id,
+    }
+    lms_high_mem_celery_labels = lms_high_mem_celery_selector_labels | {
+        "ol.mit.edu/edxapp-celery-sg": "true",
+    }
+    lms_high_mem_celery_deployment = kubernetes.apps.v1.Deployment(
+        f"ol-{stack_info.env_prefix}-edxapp-lms-high-mem-celery-deployment-{stack_info.env_suffix}",
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            name=lms_high_mem_celery_deployment_name,
+            namespace=namespace,
+            labels=lms_high_mem_celery_labels,
+        ),
+        spec=kubernetes.apps.v1.DeploymentSpecArgs(
+            selector=kubernetes.meta.v1.LabelSelectorArgs(
+                match_labels=lms_high_mem_celery_selector_labels
+            ),
+            # Never run two generations concurrently: a rollout should drain the old
+            # pod (finishing its report) before the replacement starts consuming.
+            strategy=kubernetes.apps.v1.DeploymentStrategyArgs(
+                type="RollingUpdate",
+                rolling_update=kubernetes.apps.v1.RollingUpdateDeploymentArgs(
+                    max_surge=0,
+                    max_unavailable=1,
+                ),
+            ),
+            template=kubernetes.core.v1.PodTemplateSpecArgs(
+                metadata=kubernetes.meta.v1.ObjectMetaArgs(
+                    labels=lms_high_mem_celery_labels,
+                    annotations={
+                        # Keep Karpenter and the cluster autoscaler from reclaiming the
+                        # node underneath a running report.
+                        "karpenter.sh/do-not-disrupt": "true",
+                        "cluster-autoscaler.kubernetes.io/safe-to-evict": "false",
+                    },
+                ),
+                spec=kubernetes.core.v1.PodSpecArgs(
+                    termination_grace_period_seconds=HIGH_MEM_CELERY_TERMINATION_GRACE_PERIOD_SECONDS,
+                    affinity=kubernetes.core.v1.AffinityArgs(
+                        pod_anti_affinity=kubernetes.core.v1.PodAntiAffinityArgs(
+                            preferred_during_scheduling_ignored_during_execution=[
+                                kubernetes.core.v1.WeightedPodAffinityTermArgs(
+                                    weight=100,
+                                    pod_affinity_term=kubernetes.core.v1.PodAffinityTermArgs(
+                                        label_selector=kubernetes.meta.v1.LabelSelectorArgs(
+                                            match_labels=lms_high_mem_celery_selector_labels,
+                                        ),
+                                        topology_key="kubernetes.io/hostname",
+                                    ),
+                                ),
+                            ]
+                        )
+                    ),
+                    service_account_name=vault_k8s_resources.service_account_name,
+                    security_context=pod_security_context,
+                    volumes=lms_edxapp_volumes,
+                    init_containers=[
+                        kubernetes.core.v1.ContainerArgs(
+                            name="export-course-repos-mkdir",
+                            image=cached_image_uri("busybox:1.35"),
+                            command=[
+                                "/bin/sh",
+                                "-c",
+                                "mkdir -p /openedx/data/export_course_repos",
+                            ],
+                            volume_mounts=[
+                                kubernetes.core.v1.VolumeMountArgs(
+                                    name="openedx-data",
+                                    mount_path="/openedx/data",
+                                ),
+                            ],
+                        ),
+                        kubernetes.core.v1.ContainerArgs(
+                            name="config-aggregator",
+                            image=cached_image_uri("busybox:1.35"),
+                            command=["/bin/sh", "-c"],
+                            args=[
+                                "cat /openedx/config-sources/*/*.yaml > /openedx/config/lms.env.yml"
+                            ],
+                            volume_mounts=[
+                                *lms_edxapp_init_volume_mounts,
+                                kubernetes.core.v1.VolumeMountArgs(
+                                    name="edxapp-config",
+                                    mount_path="/openedx/config",
+                                ),
+                            ],
+                        ),
+                    ],
+                    containers=[
+                        kubernetes.core.v1.ContainerArgs(
+                            name="lms-edxapp",
+                            image=cached_image_uri(
+                                f"mitodl/edxapp@{EDXAPP_DOCKER_IMAGE_DIGEST}"
+                            ),
+                            command=["celery"],
+                            args=[
+                                "--app=lms.celery",
+                                "worker",
+                                "-E",
+                                "--loglevel=info",
+                                "--hostname=edx.lms.core.high_mem.%h",
+                                # One report per process, then recycle, so a report's
+                                # peak RSS is never carried into the next one.
+                                "--max-tasks-per-child",
+                                "1",
+                                "--queues=edx.lms.core.high_mem",
+                                "--exclude-queues=edx.cms.core.default",
+                                "--concurrency=1",
+                                "--prefetch-multiplier=1",
+                            ],
+                            env=[
+                                kubernetes.core.v1.EnvVarArgs(
+                                    name="SERVICE_VARIANT", value="lms"
+                                ),
+                                kubernetes.core.v1.EnvVarArgs(
+                                    name="DJANGO_SETTINGS_MODULE",
+                                    value="lms.envs.production",
+                                ),
+                                *celery_env_vars,
+                            ],
+                            resources=kubernetes.core.v1.ResourceRequirementsArgs(
+                                requests={
+                                    "cpu": high_mem_resources["cpu_request"],
+                                    "memory": high_mem_resources["memory_request"],
+                                    # instructor_task's TemporaryFileReportMixin spills
+                                    # report rows to /tmp, which is the container's
+                                    # writable layer (node disk). Declare it so a large
+                                    # report cannot trigger node disk-pressure eviction.
+                                    "ephemeral-storage": high_mem_resources.get(
+                                        "ephemeral_storage_request", "2Gi"
+                                    ),
+                                },
+                                limits={
+                                    "memory": high_mem_resources["memory_limit"],
+                                    "ephemeral-storage": high_mem_resources.get(
+                                        "ephemeral_storage_limit", "8Gi"
+                                    ),
+                                },
+                            ),
+                            volume_mounts=celery_volume_mounts,
+                        )
+                    ],
+                ),
+            ),
+        ),
+        opts=pulumi.ResourceOptions(
+            depends_on=[v for v in lms_edxapp_config_sources.values() if v is not None]
+        ),
+    )
+
+    # Keep at least one high_mem worker available across voluntary disruptions (node
+    # drains, cluster upgrades) so a drain cannot take out the only pod running a report.
+    lms_high_mem_celery_pdb = kubernetes.policy.v1.PodDisruptionBudget(
+        f"ol-{stack_info.env_prefix}-edxapp-lms-high-mem-celery-pdb-{stack_info.env_suffix}",
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            name=f"{lms_high_mem_celery_deployment_name}-pdb",
+            namespace=namespace,
+            labels=lms_high_mem_celery_labels,
+        ),
+        spec=kubernetes.policy.v1.PodDisruptionBudgetSpecArgs(
+            min_available=1,
+            selector=kubernetes.meta.v1.LabelSelectorArgs(
+                match_labels=lms_high_mem_celery_selector_labels
+            ),
+        ),
+        opts=pulumi.ResourceOptions(depends_on=[lms_high_mem_celery_deployment]),
     )
 
     ############################################
@@ -1621,11 +1833,14 @@ def create_k8s_resources(  # noqa: C901
         replicas_dict=replicas_dict,
         namespace=namespace,
         lms_celery_labels=lms_celery_labels,
+        lms_high_mem_celery_labels=lms_high_mem_celery_labels,
         cms_celery_labels=cms_celery_labels,
         lms_celery_deployment_name=lms_celery_deployment_name,
+        lms_high_mem_celery_deployment_name=lms_high_mem_celery_deployment_name,
         cms_celery_deployment_name=cms_celery_deployment_name,
         stack_info=stack_info,
         lms_celery_deployment=lms_celery_deployment,
+        lms_high_mem_celery_deployment=lms_high_mem_celery_deployment,
         cms_celery_deployment=cms_celery_deployment,
     )
 

--- a/src/ol_infrastructure/applications/edxapp/k8s_resources.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_resources.py
@@ -1475,23 +1475,18 @@ def create_k8s_resources(  # noqa: C901
         ),
     )
 
-    # Keep at least one high_mem worker available across voluntary disruptions (node
-    # drains, cluster upgrades) so a drain cannot take out the only pod running a report.
-    lms_high_mem_celery_pdb = kubernetes.policy.v1.PodDisruptionBudget(
-        f"ol-{stack_info.env_prefix}-edxapp-lms-high-mem-celery-pdb-{stack_info.env_suffix}",
-        metadata=kubernetes.meta.v1.ObjectMetaArgs(
-            name=f"{lms_high_mem_celery_deployment_name}-pdb",
-            namespace=namespace,
-            labels=lms_high_mem_celery_labels,
-        ),
-        spec=kubernetes.policy.v1.PodDisruptionBudgetSpecArgs(
-            min_available=1,
-            selector=kubernetes.meta.v1.LabelSelectorArgs(
-                match_labels=lms_high_mem_celery_selector_labels
-            ),
-        ),
-        opts=pulumi.ResourceOptions(depends_on=[lms_high_mem_celery_deployment]),
-    )
+    # No PodDisruptionBudget here, deliberately. The obvious one -- minAvailable: 1 --
+    # is undrainable: this deployment idles at a single replica, so a budget requiring
+    # one available pod leaves disruptionsAllowed at 0 permanently. Node drains use the
+    # Eviction API, which *does* honour PDBs (unlike the rolling-update path above), so
+    # every eviction would be rejected and `kubectl drain` would block indefinitely,
+    # stalling cluster upgrades until someone deletes the PDB by hand.
+    #
+    # The protection a PDB would have bought is already covered: a drain evicts the
+    # pod, celery warm-shuts-down and finishes the report in flight, and the drain
+    # waits out terminationGracePeriodSeconds before the pod goes away. That bounds a
+    # drain at the grace period rather than blocking it forever, and Karpenter
+    # consolidation is handled separately by the do-not-disrupt annotation.
 
     ############################################
     # Dedicated LMS celery beat deployment
@@ -2017,11 +2012,12 @@ def create_k8s_resources(  # noqa: C901
     # This is not an oversight:
     #
     #   1. make_vpa hardcodes updateMode InPlaceOrRecreate, which falls back to
-    #      *evicting* the pod when a resize cannot be applied in place. Eviction
-    #      mid-report is exactly the disruption this worker exists to avoid. Its PDB
-    #      does block VPA (the Eviction API honours PDBs, unlike rollouts), but only
-    #      while a single replica is running -- once KEDA scales to 2 or 3, a
-    #      minAvailable=1 budget permits evicting the others, report in flight or not.
+    #      *evicting* the pod when a resize cannot be applied in place. Nothing here
+    #      guards against that -- there is no PDB on this deployment, for the reasons
+    #      given at the deployment above. An in-flight report does survive (eviction
+    #      is graceful, so celery finishes the task within the grace period), but the
+    #      pod comes back sized by the recommender rather than by the config, which
+    #      runs straight into (2).
     #   2. VPA sizes from observed usage, and this worker's profile is idle almost
     #      always with rare multi-hour bursts. The recommender would learn the idle
     #      floor and walk the CPU request down toward _worker_vpa_min_allowed's 25m,

--- a/src/ol_infrastructure/applications/edxapp/k8s_resources.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_resources.py
@@ -1338,13 +1338,17 @@ def create_k8s_resources(  # noqa: C901
             selector=kubernetes.meta.v1.LabelSelectorArgs(
                 match_labels=lms_high_mem_celery_selector_labels
             ),
-            # Never run two generations concurrently: a rollout should drain the old
-            # pod (finishing its report) before the replacement starts consuming.
+            # Surge rather than drain-first. The old pod can sit in Terminating for the
+            # whole grace period below while it finishes an in-flight report, so
+            # deleting it before scheduling the replacement would leave
+            # edx.lms.core.high_mem with no consumer for hours during a rollout. Two
+            # generations briefly overlapping is harmless here: each pod runs a single
+            # task at a time and they pull distinct messages off the queue.
             strategy=kubernetes.apps.v1.DeploymentStrategyArgs(
                 type="RollingUpdate",
                 rolling_update=kubernetes.apps.v1.RollingUpdateDeploymentArgs(
-                    max_surge=0,
-                    max_unavailable=1,
+                    max_surge=1,
+                    max_unavailable=0,
                 ),
             ),
             template=kubernetes.core.v1.PodTemplateSpecArgs(

--- a/src/ol_infrastructure/applications/edxapp/k8s_resources.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_resources.py
@@ -2013,6 +2013,21 @@ def create_k8s_resources(  # noqa: C901
         },
         opts=ResourceOptions(depends_on=[cms_celery_deployment]),
     )
+    # The lms_high_mem celery worker deliberately has NO VPA, unlike the two above.
+    # This is not an oversight:
+    #
+    #   1. make_vpa hardcodes updateMode InPlaceOrRecreate, which falls back to
+    #      *evicting* the pod when a resize cannot be applied in place. Eviction
+    #      mid-report is exactly the disruption this worker exists to avoid. Its PDB
+    #      does block VPA (the Eviction API honours PDBs, unlike rollouts), but only
+    #      while a single replica is running -- once KEDA scales to 2 or 3, a
+    #      minAvailable=1 budget permits evicting the others, report in flight or not.
+    #   2. VPA sizes from observed usage, and this worker's profile is idle almost
+    #      always with rare multi-hour bursts. The recommender would learn the idle
+    #      floor and walk the CPU request down toward _worker_vpa_min_allowed's 25m,
+    #      undoing the deliberate 1000m request that the serial, DB-bound compile
+    #      loop in instructor_task needs. Static sizing is the right call for a
+    #      bursty workload whose whole purpose is finishing one long job promptly.
 
     return {
         "edxapp_k8s_app_security_group_id": edxapp_k8s_app_security_group.id,


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/11978 (separate repo, so no auto-close keyword)

### Description (What does it do?)

Gives the `edx.lms.core.high_mem` celery queue its own deployment, so long-running
instructor tasks stop being killed partway through by scale-down churn on an unrelated
queue.

**Background.** edx-platform routes the long instructor tasks — `calculate_grades_csv`,
`calculate_problem_grade_report`, `calculate_problem_responses_csv`,
`generate_certificates` — to `edx.lms.core.high_mem` via `GRADES_DOWNLOAD_ROUTING_KEY`
([`lms/envs/common.py`](https://github.com/openedx/edx-platform/blob/master/lms/envs/common.py),
applied in [`lms/envs/production.py`](https://github.com/openedx/edx-platform/blob/master/lms/envs/production.py)).
That queue was served by the shared LMS celery deployment, which consumed
`default,high,high_mem` together — so the routing bought no isolation at all. KEDA's
only trigger was on `edx.lms.core.default`, meaning a queued grade report produced **no
scale-up signal whatsoever**, and every scale-down of the default queue (observed
swinging 1 → 20 → 1 several times a day) deleted pods with only the default 30s grace
period.

The failure mode that produces: a report long enough to span a scale-down gets SIGKILLed
mid-run and leaves **no trace** — no success, no failure, no traceback, no redelivery.
The instructor dashboard polls forever and shows it as still in progress. Two mitxonline
production runs for `course-v1:MITxT+CTL.SC2x+2T2026` died exactly this way, each
emitting three log lines and then nothing:

```
InstructorTask 38431 (3623c746-…)  2026-07-29 20:11:41  last line: "2: Compiling grades"
InstructorTask 38446 (fbe4004d-…)  2026-07-30 18:02:49  last line: "2: Compiling grades"
```

followed only by repeated webapp warnings:

```
No task_output information found for instructor_task fbe4004d-66b9-42a2-9e27-8abac109c745
```

**This was never a memory problem.** Peak `container_memory_working_set_bytes` for the
LMS celery pods over 30 days was 2.09 GB against a 4 GiB limit, with
`increase(kube_pod_container_status_restarts_total[30d]) == 0`. A successful comparable
run (`MITxT+11.024x+3T2025`, 807 learners, 115 scorable blocks) took 661s, of which the
CSV upload was 0.17s — 0.82s/learner, essentially all of it in the per-learner compile
loop. `CTL.SC2x` is 5,154 learners over 128 scorable blocks, projecting to ~80 minutes
and a few hundred MB. It was an 80-minute job running on a pod that did not live 80
minutes.

**What this PR adds.** A dedicated `{env}-edxapp-lms-high-mem-celery` deployment:

- `edx.lms.core.high_mem` removed from the shared LMS worker's `--queues`
- `terminationGracePeriodSeconds: 14400` (4h) — **the load-bearing change**. On SIGTERM
  celery warm-shuts-down: it stops prefetching and finishes the task already in flight,
  and Kubernetes now waits for that instead of SIGKILLing at 30s
- `karpenter.sh/do-not-disrupt: "true"` and
  `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"`, plus a PodDisruptionBudget
  with `minAvailable: 1`, so consolidation and drains leave a running report alone
- `--concurrency=1 --max-tasks-per-child 1 --prefetch-multiplier=1` — one report per pod
  at a time, and its peak RSS returned to the OS rather than carried into the next task
- `maxSurge: 0` so a rollout drains the old pod before the replacement starts consuming
- a KEDA ScaledObject on `edx.lms.core.high_mem` (`listLength: 1`, `cooldownPeriod: 1800`,
  1h scale-down stabilization). The long scale-down guard matters because a task already
  picked up no longer counts toward Redis list length, so a lone in-flight report leaves
  the queue reading empty
- `ephemeral-storage` request/limit, covering the `TemporaryFile` spill path used by
  instructor_task's `TemporaryFileReportMixin` (`/tmp` is the container's writable layer,
  i.e. real node disk, and was previously unaccounted for)
- the new deployment added to `edxapp_db_restart_deployment_names` so it restarts on
  MariaDB credential rotation

Sizing falls back to the existing shared LMS celery values when a stack has no
`lms_high_mem` config, so all 12 stacks get the deployment without YAML edits.
`mitxonline.Production` gets explicit values (`cpu_request: 1000m`, `memory_limit: 6Gi`,
ephemeral-storage 2Gi/8Gi, replicas min 1 / max 3).

### How can this be tested?

Validation already run:

- `pre-commit run --files …` — all hooks pass (ruff, ruff format, mypy, yamllint,
  detect-secrets)
- `pulumi preview --stack mitxonline.QA` → `+3 to create, ~4 to update`, no replacements
  or deletions

`mitxonline.Production` was last deployed ~3 weeks ago and carries 47 changes of
pre-existing drift, so I diffed the preview against a baseline run on `main` with the
same `EDXAPP_DOCKER_IMAGE_DIGEST` to isolate this change. Exactly 6 diffs are
attributable to it:

```
+  kubernetes:apps/v1:Deployment          ol-mitxonline-edxapp-lms-high-mem-celery-deployment-production
+  kubernetes:keda.sh/v1alpha1:ScaledObject ol-mitxonline-edxapp-lms-high-mem-celery-scaledobject-production
+  kubernetes:policy/v1:PodDisruptionBudget ol-mitxonline-edxapp-lms-high-mem-celery-pdb-production
~  kubernetes:apps/v1:Deployment          ol-mitxonline-edxapp-lms-celery-deployment-production   (queues)
~  VaultDynamicSecret 00-database-credentials-yaml   (rolloutRestartTargets)
~  VaultDynamicSecret 01-database-connections-yaml   (rolloutRestartTargets)
```

The reverse comparison is empty — nothing present in the baseline is removed.

To validate on a live stack:

1. Apply to `mitxonline.QA` first and confirm the new pod comes up consuming only
   `edx.lms.core.high_mem`:
   ```
   kubectl -n mitxonline-openedx logs deploy/mitxonline-qa-edxapp-lms-high-mem-celery | grep -A5 'celery@'
   ```
2. Confirm the shared worker no longer lists `high_mem`:
   ```
   kubectl -n mitxonline-openedx get deploy mitxonline-qa-edxapp-lms-celery \
     -o jsonpath='{.spec.template.spec.containers[0].args}'
   ```
3. Trigger a problem grade report from the instructor dashboard and confirm it reaches
   `4: Completed grades` — the previous runs never got past `2: Compiling grades`:
   ```
   {namespace="mitxonline-openedx"} |= "problem distribution graded"
   ```
4. Optionally verify the grace period survives a deliberate `kubectl delete pod` on the
   high_mem worker mid-report: the pod should enter Terminating and the task should still
   log `4: Completed grades` before the pod exits.

### Additional Context

- The grace period is set to 4h against an ~80-minute measured worst case, deliberately
  generous. The trade-off is that a node drain touching this pod can block for up to that
  long. If that is unacceptable for cluster-upgrade workflows, it is a one-line change to
  `HIGH_MEM_CELERY_TERMINATION_GRACE_PERIOD_SECONDS`.
- This is infrastructure only. There is a complementary application-side toggle,
  the `instructor_task.use_on_disk_grade_reporting` CourseWaffleFlag, which switches the
  report from `InMemoryReportMixin` to `TemporaryFileReportMixin`. Worth enabling
  separately, but per the measurements above it addresses a phase accounting for 0.17s of
  a 661s run, so it is not the fix for this issue.
- Follow-up worth filing upstream: `ProblemGradeReport._rows_for_users` does no bulk
  prefetch, unlike `CourseGradeReport`, which is the likely cause of the 0.82s/learner
  rate. That is where a real runtime reduction lives.

### Checklist:
- [ ] Apply to `mitxonline.QA` and confirm a real problem grade report completes before applying to Production
- [ ] Review the ~47 unrelated pre-existing drift changes on `mitxonline.Production` (VPA creates, meilisearch PluginConfig deletion, pre-deploy Job replacements) before running `pulumi up` there
