### PR TITLE
feat(omnigraph): per-repo code graphs, and name the memory graph `council`

### DIFF
--- a/src/ol_infrastructure/applications/omnigraph/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/applications/omnigraph/Pulumi.CI.yaml
@@ -6,6 +6,14 @@
 # run against this stack will populate both, matching every other stack under
 # this KMS alias.
 config:
+  omnigraph:managed_repos:
+    # Repos with a per-repo `code-<repo>` graph on this cluster. Canonical repo
+    # URIs, matched byte-for-byte against what witan-code detects from a
+    # checkout's git remote. Adding one here needs a `pulumi up` plus an
+    # `omnigraph cluster apply` and a server restart before clients can reach
+    # it — see applications/omnigraph/data_tier.py build_cluster_graphs.
+  - https://github.com/mitodl/agent-kit
+  - https://github.com/mitodl/ol-infrastructure
   aws:region: us-east-1
   vault:address: https://vault-ci.odl.mit.edu
   vault_server:env_namespace: operations.ci

--- a/src/ol_infrastructure/applications/omnigraph/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/applications/omnigraph/Pulumi.CI.yaml
@@ -12,8 +12,25 @@ config:
     # checkout's git remote. Adding one here needs a `pulumi up` plus an
     # `omnigraph cluster apply` and a server restart before clients can reach
     # it — see applications/omnigraph/data_tier.py build_cluster_graphs.
-  - https://github.com/mitodl/agent-kit
+    #
+    # Seeded from the mitodl repos with the most human-authored commits in the
+    # 90 days to 2026-07-31 (bot commits excluded), cut at >=35. Re-derive
+    # rather than assuming this stays current; a repo nobody works in is a
+    # graph nobody queries.
   - https://github.com/mitodl/ol-infrastructure
+  - https://github.com/mitodl/mit-learn
+  - https://github.com/mitodl/mitxonline
+  - https://github.com/mitodl/ol-data-platform
+  - https://github.com/mitodl/agent-kit
+  - https://github.com/mitodl/lehrer
+  - https://github.com/mitodl/ocw-studio
+  - https://github.com/mitodl/odl-video-service
+  - https://github.com/mitodl/mitxpro
+  - https://github.com/mitodl/ol-concourse
+  - https://github.com/mitodl/open-edx-plugins
+  - https://github.com/mitodl/learn-ai
+  - https://github.com/mitodl/ocw-hugo-themes
+  - https://github.com/mitodl/ol-django
   aws:region: us-east-1
   vault:address: https://vault-ci.odl.mit.edu
   vault_server:env_namespace: operations.ci

--- a/src/ol_infrastructure/applications/omnigraph/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/omnigraph/Pulumi.Production.yaml
@@ -1,6 +1,14 @@
 ---
 # See Pulumi.CI.yaml for why `secretsprovider`/`encryptedkey` are omitted.
 config:
+  omnigraph:managed_repos:
+    # Repos with a per-repo `code-<repo>` graph on this cluster. Canonical repo
+    # URIs, matched byte-for-byte against what witan-code detects from a
+    # checkout's git remote. Adding one here needs a `pulumi up` plus an
+    # `omnigraph cluster apply` and a server restart before clients can reach
+    # it — see applications/omnigraph/data_tier.py build_cluster_graphs.
+  - https://github.com/mitodl/agent-kit
+  - https://github.com/mitodl/ol-infrastructure
   aws:region: us-east-1
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production

--- a/src/ol_infrastructure/applications/omnigraph/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/omnigraph/Pulumi.Production.yaml
@@ -7,8 +7,25 @@ config:
     # checkout's git remote. Adding one here needs a `pulumi up` plus an
     # `omnigraph cluster apply` and a server restart before clients can reach
     # it — see applications/omnigraph/data_tier.py build_cluster_graphs.
-  - https://github.com/mitodl/agent-kit
+    #
+    # Seeded from the mitodl repos with the most human-authored commits in the
+    # 90 days to 2026-07-31 (bot commits excluded), cut at >=35. Re-derive
+    # rather than assuming this stays current; a repo nobody works in is a
+    # graph nobody queries.
   - https://github.com/mitodl/ol-infrastructure
+  - https://github.com/mitodl/mit-learn
+  - https://github.com/mitodl/mitxonline
+  - https://github.com/mitodl/ol-data-platform
+  - https://github.com/mitodl/agent-kit
+  - https://github.com/mitodl/lehrer
+  - https://github.com/mitodl/ocw-studio
+  - https://github.com/mitodl/odl-video-service
+  - https://github.com/mitodl/mitxpro
+  - https://github.com/mitodl/ol-concourse
+  - https://github.com/mitodl/open-edx-plugins
+  - https://github.com/mitodl/learn-ai
+  - https://github.com/mitodl/ocw-hugo-themes
+  - https://github.com/mitodl/ol-django
   aws:region: us-east-1
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production

--- a/src/ol_infrastructure/applications/omnigraph/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/omnigraph/Pulumi.QA.yaml
@@ -1,6 +1,14 @@
 ---
 # See Pulumi.CI.yaml for why `secretsprovider`/`encryptedkey` are omitted.
 config:
+  omnigraph:managed_repos:
+    # Repos with a per-repo `code-<repo>` graph on this cluster. Canonical repo
+    # URIs, matched byte-for-byte against what witan-code detects from a
+    # checkout's git remote. Adding one here needs a `pulumi up` plus an
+    # `omnigraph cluster apply` and a server restart before clients can reach
+    # it — see applications/omnigraph/data_tier.py build_cluster_graphs.
+  - https://github.com/mitodl/agent-kit
+  - https://github.com/mitodl/ol-infrastructure
   aws:region: us-east-1
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa

--- a/src/ol_infrastructure/applications/omnigraph/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/omnigraph/Pulumi.QA.yaml
@@ -7,8 +7,25 @@ config:
     # checkout's git remote. Adding one here needs a `pulumi up` plus an
     # `omnigraph cluster apply` and a server restart before clients can reach
     # it — see applications/omnigraph/data_tier.py build_cluster_graphs.
-  - https://github.com/mitodl/agent-kit
+    #
+    # Seeded from the mitodl repos with the most human-authored commits in the
+    # 90 days to 2026-07-31 (bot commits excluded), cut at >=35. Re-derive
+    # rather than assuming this stays current; a repo nobody works in is a
+    # graph nobody queries.
   - https://github.com/mitodl/ol-infrastructure
+  - https://github.com/mitodl/mit-learn
+  - https://github.com/mitodl/mitxonline
+  - https://github.com/mitodl/ol-data-platform
+  - https://github.com/mitodl/agent-kit
+  - https://github.com/mitodl/lehrer
+  - https://github.com/mitodl/ocw-studio
+  - https://github.com/mitodl/odl-video-service
+  - https://github.com/mitodl/mitxpro
+  - https://github.com/mitodl/ol-concourse
+  - https://github.com/mitodl/open-edx-plugins
+  - https://github.com/mitodl/learn-ai
+  - https://github.com/mitodl/ocw-hugo-themes
+  - https://github.com/mitodl/ol-django
   aws:region: us-east-1
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa

--- a/src/ol_infrastructure/applications/omnigraph/__main__.py
+++ b/src/ol_infrastructure/applications/omnigraph/__main__.py
@@ -42,11 +42,12 @@ from pathlib import Path
 from typing import Any
 
 import pulumi_vault as vault
-from pulumi import Output, ResourceOptions, export
+from pulumi import Config, Output, ResourceOptions, export
 
 from bridge.secrets import sops as _bridge_sops
 from bridge.secrets.sops import read_yaml_secrets
 from ol_infrastructure.applications.omnigraph.data_tier import (
+    COUNCIL_GRAPH_ID,
     create_data_tier,
     omnigraph_server_addr,
 )
@@ -79,6 +80,18 @@ _BRIDGE_SECRETS_DIR = Path(_bridge_sops.__file__).parent
 setup_vault_provider()
 
 stack_info = parse_stack()
+omnigraph_config = Config("omnigraph")
+
+# Repos that get a per-repo `code-<repo>` graph on this cluster. Canonical repo
+# URIs — the exact strings witan-code detects from a checkout's git remote and
+# runs through witan_code.config.graph_id to pick its `--graph`; data_tier's
+# code_graph_id mirrors that function to declare the same id here.
+#
+# Provisioning a new repo is deliberately explicit: add it here, `pulumi up`,
+# then `omnigraph cluster apply` + restart the server (see data_tier's
+# build_cluster_graphs). A repo that is not listed fails to resolve rather than
+# silently minting a graph nobody provisioned or backs up.
+MANAGED_REPOS: list[str] = omnigraph_config.get_object("managed_repos") or []
 
 cluster_stack = make_stack_reference(projects.EKS, f"operations.{stack_info.name}")
 setup_k8s_provider(kubeconfig=cluster_stack.require_output("kube_config"))
@@ -266,8 +279,13 @@ data_tier = create_data_tier(
     auth_binding=omnigraph_auth_binding,
     actor_tokens_secret_name=ACTOR_TOKENS_SECRET_NAME,
     actor_tokens_secret=actor_tokens_secret,
+    managed_repos=MANAGED_REPOS,
 )
 
 export("namespace", NAMESPACE)
 export("omnigraph_server_addr", omnigraph_server_addr(NAMESPACE))
+# The Layer-1 graph id consumers must address (`--graph <id>`). Exported
+# rather than left to each consumer's own default so the witan stack asks
+# for exactly the graph declared in cluster.yaml here.
+export("council_graph_id", COUNCIL_GRAPH_ID)
 export("omnigraph_server_image_repository", data_tier.image_repository)

--- a/src/ol_infrastructure/applications/omnigraph/data_tier.py
+++ b/src/ol_infrastructure/applications/omnigraph/data_tier.py
@@ -26,7 +26,9 @@ read from ``OMNIGRAPH_DOCKER_SHA`` (set by the build job via the
 pulumi-provisioner's ``env_vars_from_files``).
 """
 
+import hashlib
 import json
+import re
 from typing import NamedTuple
 
 import pulumi_aws as aws
@@ -54,6 +56,104 @@ CLUSTER_CONFIG_DIR = "/etc/omnigraph/cluster"
 ACTOR_TOKENS_MOUNT_PATH = "/etc/omnigraph/actor-tokens"  # pragma: allowlist secret
 ACTOR_TOKENS_FILENAME = "tokens.json"  # pragma: allowlist secret
 
+# Fixed ConfigMap name, referenced both by the ConfigMap's own metadata and by
+# the Deployment's volume. The Deployment uses this constant rather than
+# `cluster_configmap.metadata.name` deliberately: the ConfigMap is replaced on
+# every `data` change, which makes that Output unknown at preview time and
+# reports the Deployment as replaced too — a replacement that would never
+# actually be needed, since the name is pinned and therefore identical across
+# the replacement. `depends_on` still orders the two.
+CLUSTER_CONFIGMAP_NAME = "omnigraph-cluster-config"
+
+# ── Cluster graph ids ────────────────────────────────────────────────────────
+#
+# Graph ids track the owning published package rather than the omnigraph
+# default branch name: omnigraph's default *branch* is `main`, so a graph also
+# called `main` conflates the two. `council` is what witan-council asks for
+# (WITAN_MEMORY_GRAPH, default `council` in agent-kit
+# mcp/servers/witan/witan/config.py) — a cluster that declares anything else
+# serves a graph no client addresses.
+COUNCIL_GRAPH_ID = "council"
+# Layer 2.5 cross-repo bridge, the deployed analogue of witan-code's local
+# `_bridge.omni` store. Fixed id, not derived from any repo.
+BRIDGE_GRAPH_ID = "code-bridge"
+CODE_GRAPH_PREFIX = "code-"
+
+# Schema filenames, all three baked into the omnigraph-server image at
+# CLUSTER_CONFIG_DIR by the image build (agent-kit
+# docker/omnigraph-server.Dockerfile). Not sourced here: this Pulumi program
+# has no access to agent-kit's working tree at apply time.
+COUNCIL_SCHEMA_FILE = "schema.pg"
+CODE_SCHEMA_FILE = "code-schema.pg"
+BRIDGE_SCHEMA_FILE = "bridge-schema.pg"
+
+_GRAPH_ID_MAX_LEN = 64
+
+
+def code_graph_id(repo: str) -> str:
+    """Canonical cluster graph id for ``repo``'s code graph.
+
+    e.g. ``https://github.com/mitodl/ol-django`` ->
+    ``code-github-com-mitodl-ol-django``.
+
+    SHARED CONTRACT — this is a mirror of ``witan_code.config.graph_id``
+    (agent-kit, mcp/servers/witan-code/witan_code/config.py), which is what
+    selects the ``--graph`` id on the *client* side. This function declares the
+    graph the cluster creates. They MUST agree byte-for-byte or a client will
+    address a graph that was never created. Any change has to land in lockstep
+    on both sides — see agent-kit task
+    tk-code-graph-deployment-topology-shared-per-repo-c-cac400.
+
+    Strips the URI scheme, collapses every run of non-alphanumerics to ``-``,
+    lowercases, and prefixes ``code-``. omnigraph graph ids must match
+    ``^[a-zA-Z0-9-]{1,64}$`` (note: no underscores), so ids that would exceed
+    64 characters are truncated and disambiguated with a hash of the full repo
+    URI, keeping distinct long repos from colliding.
+    """
+    body = re.sub(r"(?i)^[a-z][a-z0-9+.-]*://", "", repo)  # strip scheme
+    body = re.sub(r"[^a-zA-Z0-9]+", "-", body).strip("-").lower()
+    candidate = f"{CODE_GRAPH_PREFIX}{body}"
+    if len(candidate) <= _GRAPH_ID_MAX_LEN:
+        return candidate
+    digest = hashlib.sha256(repo.encode()).hexdigest()[:8]
+    keep = _GRAPH_ID_MAX_LEN - len(CODE_GRAPH_PREFIX) - len(digest) - 1
+    return f"{CODE_GRAPH_PREFIX}{body[:keep].strip('-')}-{digest}"
+
+
+def build_cluster_graphs(managed_repos: list[str]) -> dict[str, dict[str, str]]:
+    """Build the ``graphs:`` block of cluster.yaml for ``managed_repos``.
+
+    One graph per repo rather than one shared code graph (ADR-0009 follow-up,
+    decided: option A), matching the per-repo model witan-code already uses
+    locally. Each is a self-contained Lance store under
+    ``s3://<bucket>/graphs/<graph-id>.omni/``, so per-repo isolation costs
+    nothing beyond the entry here, and per-user/per-session WIP branches live
+    inside their own repo's graph.
+
+    Adding a repo is deliberately a config change plus a ``cluster apply`` and
+    a server restart, not ad-hoc self-creation by a client: an unmanaged repo
+    should fail to resolve rather than silently mint a graph nobody provisioned
+    or backs up.
+
+    Raises ``ValueError`` on a duplicate derived id — two repo URIs that
+    normalize to the same graph id would otherwise silently share one store.
+    """
+    graphs: dict[str, dict[str, str]] = {
+        COUNCIL_GRAPH_ID: {"schema": COUNCIL_SCHEMA_FILE},
+        BRIDGE_GRAPH_ID: {"schema": BRIDGE_SCHEMA_FILE},
+    }
+    for repo in managed_repos:
+        graph = code_graph_id(repo)
+        if graph in graphs:
+            msg = (
+                f"Duplicate cluster graph id {graph!r} derived from repo "
+                f"{repo!r}. Two managed repos normalize to the same id, which "
+                "would silently share one store."
+            )
+            raise ValueError(msg)
+        graphs[graph] = {"schema": CODE_SCHEMA_FILE}
+    return graphs
+
 
 def omnigraph_server_addr(namespace: str) -> str:
     """Return the in-cluster HTTP address witan's MCPServer talks to."""
@@ -80,6 +180,7 @@ def create_data_tier(  # noqa: PLR0913
     auth_binding: OLEKSAuthBinding,
     actor_tokens_secret_name: str,
     actor_tokens_secret: OLVaultK8SSecret,
+    managed_repos: list[str],
 ) -> OmnigraphDataTier:
     """Provision the S3 bucket, IRSA policy, ECR repo, ConfigMap, and Deployment."""
     # The bucket is named for its tenant (witan's graphs), not the omnigraph
@@ -150,17 +251,17 @@ def create_data_tier(  # noqa: PLR0913
     )
     omnigraph_server_image = format_docker_image_ref(image_repository, "OMNIGRAPH")
 
-    # cluster.yaml — the single Layer-1 (memory/task/workflow) graph,
-    # organization-wide, plus room for per-repo code graphs added the same
-    # way (`omnigraph graphs` management, per ADR-0009 decision point 2).
-    # `schema.pg` (agent-kit repo, mcp/servers/witan/schema/schema.pg) is NOT
-    # sourced here — this Pulumi program has no access to agent-kit's working
-    # tree at apply time. It must be baked into the omnigraph-server image at
-    # build time, at ``{CLUSTER_CONFIG_DIR}/schema.pg``, by the (not yet
-    # written) image-build job — see the follow-up note in __main__.py. The
-    # ConfigMap volume below is mounted with ``sub_path`` so it overlays only
-    # the single ``cluster.yaml`` file and leaves that baked-in schema.pg
-    # visible alongside it, rather than replacing the whole directory.
+    # cluster.yaml — the Layer-1 (memory/task/workflow) `council` graph,
+    # organization-wide, plus the `code-bridge` graph and one `code-<repo>`
+    # graph per managed repo (see build_cluster_graphs).
+    # None of the three schema files are sourced here — this Pulumi program has
+    # no access to agent-kit's working tree at apply time. All are baked into
+    # the omnigraph-server image at build time under ``{CLUSTER_CONFIG_DIR}``
+    # by agent-kit's docker/omnigraph-server.Dockerfile. The ConfigMap volume
+    # below is mounted with ``sub_path`` so it overlays only the single
+    # ``cluster.yaml`` file and leaves those baked-in schemas visible alongside
+    # it, rather than replacing the whole directory.
+    cluster_graphs = build_cluster_graphs(managed_repos)
     storage_uri: Output[str] = omnigraph_bucket.bucket_v2.bucket.apply(
         lambda name: f"s3://{name}"
     )
@@ -172,7 +273,7 @@ def create_data_tier(  # noqa: PLR0913
                 "metadata": {"name": cluster_name},
                 "state": {"backend": "cluster"},
                 "storage": uri,
-                "graphs": {"main": {"schema": "schema.pg"}},
+                "graphs": cluster_graphs,
             },
             sort_keys=False,
         )
@@ -180,11 +281,25 @@ def create_data_tier(  # noqa: PLR0913
     cluster_configmap = kubernetes.core.v1.ConfigMap(
         f"omnigraph-omnigraph-cluster-config-{stack_info.env_suffix}",
         metadata=kubernetes.meta.v1.ObjectMetaArgs(
-            name="omnigraph-cluster-config",
+            name=CLUSTER_CONFIGMAP_NAME,
             namespace=namespace,
             labels=k8s_global_labels,
         ),
         data={"cluster.yaml": cluster_yaml_content},
+        # pulumi-kubernetes treats a ConfigMap `data` change as force-new, and
+        # normally relies on auto-naming so the replacement can be created
+        # before the old one is deleted. `metadata.name` is pinned here (the
+        # Deployment's volume references it by name), which disables
+        # auto-naming — so the default create-before-delete collides with the
+        # live object and the update fails with "configmaps
+        # omnigraph-cluster-config already exists". Delete first instead.
+        #
+        # Safe despite the Deployment mounting this: the mount uses `sub_path`,
+        # and sub-path volume mounts never receive ConfigMap updates, so the
+        # running pod holds its own copy of cluster.yaml either way. A changed
+        # graph list only reaches the server on the pod restart that the
+        # `cluster apply` step already requires.
+        opts=ResourceOptions(delete_before_replace=True),
     )
 
     omnigraph_pod_labels = {
@@ -299,7 +414,7 @@ def create_data_tier(  # noqa: PLR0913
                         kubernetes.core.v1.VolumeArgs(
                             name="cluster-config",
                             config_map=kubernetes.core.v1.ConfigMapVolumeSourceArgs(
-                                name=cluster_configmap.metadata.name,
+                                name=CLUSTER_CONFIGMAP_NAME,
                             ),
                         ),
                         kubernetes.core.v1.VolumeArgs(

--- a/src/ol_infrastructure/applications/witan/__main__.py
+++ b/src/ol_infrastructure/applications/witan/__main__.py
@@ -119,6 +119,10 @@ omnigraph_stack = make_stack_reference(projects.OMNIGRAPH, stack_info.name)
 omnigraph_server_addr = require_stack_output_value(
     omnigraph_stack, "omnigraph_server_addr"
 )
+# The graph id witan addresses on that server (`--graph <id>`), taken from the
+# stack that declares it in cluster.yaml rather than defaulted independently
+# here — see WITAN_MEMORY_GRAPH in mcp_servers.py.
+council_graph_id = require_stack_output_value(omnigraph_stack, "council_graph_id")
 
 NAMESPACE = "witan"
 
@@ -289,6 +293,7 @@ mcp_servers = create_mcp_servers(
     cluster_stack=cluster_stack,
     witan_image=witan_image,
     omnigraph_server_addr=omnigraph_server_addr,
+    council_graph_id=council_graph_id,
     oidc_issuer=KEYCLOAK_ISSUER,
     oidc_audience=WITAN_OIDC_AUDIENCE,
     actor_tokens_secret_name=ACTOR_TOKENS_SECRET_NAME,

--- a/src/ol_infrastructure/applications/witan/mcp_servers.py
+++ b/src/ol_infrastructure/applications/witan/mcp_servers.py
@@ -61,6 +61,7 @@ def create_mcp_servers(  # noqa: PLR0913
     cluster_stack: StackReference,
     witan_image: str | Output[str],
     omnigraph_server_addr: str | Output[str],
+    council_graph_id: str | Output[str],
     oidc_issuer: str,
     oidc_audience: str,
     actor_tokens_secret_name: str,
@@ -127,6 +128,17 @@ def create_mcp_servers(  # noqa: PLR0913
                 # Module-level fallback OmnigraphClient's target (ADR-0004
                 # D4) — the omnigraph-server Deployment's in-cluster address.
                 {"name": "WITAN_MEMORY_URI", "value": omnigraph_server_addr},
+                # An http(s) store is addressed as `--server <url> --graph
+                # <id>`, and the graph id is not encoded in WITAN_MEMORY_URI
+                # (a bare server URL), so it comes from here. Sourced from the
+                # omnigraph stack's own `council_graph_id` output rather than
+                # a literal, for the same reason the address is: witan must
+                # ask for exactly the graph that stack declared in cluster.yaml
+                # or it addresses a graph the cluster never created. (It also
+                # happens to equal witan's built-in `council` default, but
+                # relying on two independent defaults agreeing is the failure
+                # mode this avoids.)
+                {"name": "WITAN_MEMORY_GRAPH", "value": council_graph_id},
             ],
             "secrets": [
                 {


### PR DESCRIPTION
### What are the relevant tickets?

Task `tk-code-graph-deployment-topology-shared-per-repo-c-cac400` (project: witan multi-user service deployment). Companion to the already-merged agent-kit side, https://github.com/mitodl/agent-kit/pull/134. No GitHub issue.

### Description (What does it do?)

**Fixes a live mismatch.** `cluster.yaml` declares exactly one graph, `main`. witan asks for `council` — that is `WITAN_MEMORY_GRAPH`'s default in agent-kit since the remote-addressing work, and an http(s) store is addressed as `--server <url> --graph <id>`. As currently deployed, witan addresses a graph the cluster never created.

Renaming is the fix, not a migration. The `main` graph in `s3://ol-data-witan-ci` holds schema/table-creation metadata only — `nodes/` and `edges/` contain `_transactions`/`_versions` but no `data/` files, and the single `.lance` data object in the whole prefix is the branch-refs manifest. Zero user rows, nothing stranded. The rename also stops conflating graph with branch: omnigraph's default *branch* is `main`.

**Adds the code-graph topology** (ADR-0009 follow-up, option A — decided, and server-side verified with a 4-graph cluster):

- `council` — the Layer-1 memory/task/workflow graph, organization-wide
- `code-bridge` — the Layer-2.5 cross-repo bridge, the deployed analogue of witan-code's local `_bridge.omni`
- one `code-<repo>` per managed repo, matching the per-repo model witan-code already uses locally

The repo list is stack config (`omnigraph:managed_repos`), seeded with `agent-kit` and `ol-infrastructure` in all three environments. Adding a repo is deliberately explicit — config edit, `pulumi up`, `cluster apply`, restart — so an unmanaged repo fails to resolve rather than silently minting a graph nobody provisioned or backs up.

Generated `graphs:` block:

```yaml
graphs:
  council:
    schema: schema.pg
  code-bridge:
    schema: bridge-schema.pg
  code-github-com-mitodl-agent-kit:
    schema: code-schema.pg
  code-github-com-mitodl-ol-infrastructure:
    schema: code-schema.pg
```

**Shared contract.** `code_graph_id` mirrors `witan_code.config.graph_id` (agent-kit, `mcp/servers/witan-code/witan_code/config.py`) byte-for-byte. That function picks the `--graph` id on the client side; this one declares the graph the cluster creates. If they disagree, a client addresses a graph that was never created — so both copies carry a comment pointing at the other. `build_cluster_graphs` raises on a duplicate derived id rather than letting two repos silently share one store.

**Stack output instead of a matching default.** witan reads the graph id from this stack's new `council_graph_id` output rather than relying on its own built-in `council` default happening to equal ours — two independent defaults drifting apart is exactly the failure this avoids.

**Latent hazard fixed along the way.** A ConfigMap `data` change is force-new, and pulumi-kubernetes normally relies on auto-naming so the replacement is created before the old one is deleted. `metadata.name` is pinned here, which disables auto-naming, so the default create-before-delete collided:

```
Retry #0; creation failed: configmaps "omnigraph-cluster-config" already exists
```

`delete_before_replace=True` fixes it. Safe despite the Deployment mounting the ConfigMap: the mount uses `sub_path`, and sub-path volume mounts never receive ConfigMap updates, so the running pod holds its own copy either way — a changed graph list only reaches the server on the restart `cluster apply` already requires. The Deployment's volume now names the ConfigMap by constant rather than through the replaced resource's Output.

### How can this be tested?

**Graph-id parity against agent-kit's canonical function** — both stack configs' repos plus scheme-less, mixed-case, scp-style, and two >64-char inputs that exercise the truncate-and-hash path. 8/8 byte-identical, every id matching `^[a-zA-Z0-9-]{1,64}$`; `CODE_GRAPH_PREFIX`, `BRIDGE_GRAPH_ID`, and the 64-char limit agree on both sides. The duplicate guard fires on `https://` vs `http://` forms of one repo.

**pre-commit** (`uv run pre-commit run --files ...`): all hooks pass, including ruff check, ruff format, and mypy.

**pulumi preview** — CI, pinned to the currently deployed image digest (the stack needs `OMNIGRAPH_DOCKER_SHA`, normally injected by the pipeline):

```
Resources:
    +-2 to replace
    29 unchanged
```

Replacement reasons, from `--json`: the ConfigMap is `data["cluster.yaml"]`; the Deployment has no diff of its own and is replaced only as a dependent. Ordered steps:

```
delete-replaced      omnigraph-omnigraph-server-deployment-ci
delete-replaced      omnigraph-omnigraph-cluster-config-ci
create-replacement   omnigraph-omnigraph-cluster-config-ci
create-replacement   omnigraph-omnigraph-server-deployment-ci
```

Old server torn down before the new one starts, so there is never a window with two servers writing one S3 store — the invariant the `Recreate` strategy exists to protect. The restart is the one the provisioning flow requires anyway. Baseline preview on unmodified `main` with the same digest is `31 unchanged`, confirming both replacements come from this change and nothing else drifted.

The cluster.yaml diff itself:

```
~ graphs:
    + code-bridge:                              { schema: "bridge-schema.pg" }
    + code-github-com-mitodl-agent-kit:         { schema: "code-schema.pg" }
    + code-github-com-mitodl-ol-infrastructure: { schema: "code-schema.pg" }
    + council:                                  { schema: "schema.pg" }
    - main:                                     { schema: "schema.pg" }
```

### Additional Context

**Rollout ordering.** The omnigraph stack must be applied before witan, which now requires the new `council_graph_id` output — `pulumi preview` on witan fails with `Missing required stack output: council_graph_id` until then. This is not a new constraint: witan already fails fast the same way on `omnigraph_server_addr`, and the witan pipeline's own docstring documents that its deploy "fails loudly if omnigraph has not been deployed". Worth sequencing deliberately on the first apply.

**Prerequisite for the code graphs to be usable.** All three schema files (`schema.pg`, `code-schema.pg`, `bridge-schema.pg`) must be baked into the omnigraph-server image at `/etc/omnigraph/cluster`. That landed in agent-kit's `docker/omnigraph-server.Dockerfile` via https://github.com/mitodl/agent-kit/pull/134, so it needs an image build carrying that change before the two new schema references resolve. Worth confirming against the deployed digest before applying.

**Not in scope.** Seeding the code graphs with content — that is a re-index against the server or an export/load, never a copy of a local `<slug>.omni` up to S3, since Lance embeds root-relative paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAhPcnBdFFJpqTMCeysmtX