### PR TITLE
feat(witan): pre-deploy migration jobs for the witan and omnigraph stacks

### DIFF
--- a/src/ol_infrastructure/applications/omnigraph/data_tier.py
+++ b/src/ol_infrastructure/applications/omnigraph/data_tier.py
@@ -25,7 +25,7 @@ against the deployed graph. The server only serves the converged revision after
 a restart, hence Job-then-Deployment ordering.
 
 The Job and the Deployment's pod template carry the same
-``omnigraph.mit.edu/config-hash`` (cluster.yaml + image digest), which is what
+``ol.mit.edu/config-hash`` (cluster.yaml + image digest), which is what
 keeps converge and restart in lockstep: any change the Job acts on also
 restarts the server into it, including a cluster.yaml-only edit that leaves the
 image untouched. That makes a config change a brief data-tier outage — this is
@@ -351,12 +351,15 @@ def create_data_tier(  # noqa: PLR0913
     # rather than once per pod restart (crashloop, eviction, node drain), and so
     # a convergence failure surfaces as a failed Job that blocks the rollout
     # instead of a pod stuck in Init.
+    # Full digest, matching the `ol.mit.edu/config-hash` convention in
+    # components/services/k8s.py — an annotation value has no length pressure,
+    # so there is nothing to buy by truncating.
     cluster_apply_hash: Output[str] = Output.all(
         cluster_yaml=cluster_yaml_content, image=omnigraph_server_image
     ).apply(
         lambda args: hashlib.sha256(
             f"{args['cluster_yaml']}\n{args['image']}".encode()
-        ).hexdigest()[:12]
+        ).hexdigest()
     )
     cluster_apply_job = kubernetes.batch.v1.Job(
         f"omnigraph-cluster-apply-{stack_info.env_suffix}",
@@ -384,7 +387,7 @@ def create_data_tier(  # noqa: PLR0913
                     # image (and therefore the baked schemas) changes. Without
                     # it, adding a repo to cluster.yaml would leave this Job's
                     # spec byte-identical and the graph would never be created.
-                    annotations={"omnigraph.mit.edu/config-hash": cluster_apply_hash},
+                    annotations={"ol.mit.edu/config-hash": cluster_apply_hash},
                 ),
                 spec=kubernetes.core.v1.PodSpecArgs(
                     restart_policy="Never",
@@ -494,7 +497,7 @@ def create_data_tier(  # noqa: PLR0913
                     # consistency is worth the restart: this Deployment is
                     # single-replica `Recreate`, so a config change is a brief
                     # data-tier outage by construction.
-                    annotations={"omnigraph.mit.edu/config-hash": cluster_apply_hash},
+                    annotations={"ol.mit.edu/config-hash": cluster_apply_hash},
                 ),
                 spec=kubernetes.core.v1.PodSpecArgs(
                     service_account_name=OMNIGRAPH_SERVICE_ACCOUNT_NAME,

--- a/src/ol_infrastructure/applications/omnigraph/data_tier.py
+++ b/src/ol_infrastructure/applications/omnigraph/data_tier.py
@@ -24,6 +24,14 @@ with — so without this step an image whose code reads a newly-added field fail
 against the deployed graph. The server only serves the converged revision after
 a restart, hence Job-then-Deployment ordering.
 
+The Job and the Deployment's pod template carry the same
+``omnigraph.mit.edu/config-hash`` (cluster.yaml + image digest), which is what
+keeps converge and restart in lockstep: any change the Job acts on also
+restarts the server into it, including a cluster.yaml-only edit that leaves the
+image untouched. That makes a config change a brief data-tier outage — this is
+a single-replica ``Recreate`` Deployment — which is the deliberate trade for
+never serving a config the store has already moved past.
+
 The ``omnigraph-server`` image is built once and promoted unchanged through
 CI -> QA -> Production by the ``omnigraph``/``pulumi-omnigraph`` Concourse
 pipeline, which also owns the ``omnigraph-server`` ECR repository itself
@@ -146,10 +154,13 @@ def build_cluster_graphs(managed_repos: list[str]) -> dict[str, dict[str, str]]:
     nothing beyond the entry here, and per-user/per-session WIP branches live
     inside their own repo's graph.
 
-    Adding a repo is deliberately a config change plus a ``cluster apply`` and
-    a server restart, not ad-hoc self-creation by a client: an unmanaged repo
-    should fail to resolve rather than silently mint a graph nobody provisioned
-    or backs up.
+    Adding a repo is deliberately a config change rather than ad-hoc
+    self-creation by a client: an unmanaged repo should fail to resolve rather
+    than silently mint a graph nobody provisioned or backs up. The
+    ``cluster apply`` and server restart it requires are both automatic — the
+    converge Job and the Deployment's pod template share one config hash, so
+    editing this list creates the graph and restarts the server into it in the
+    same deploy.
 
     Raises ``ValueError`` on a duplicate derived id — two repo URIs that
     normalize to the same graph id would otherwise silently share one store.
@@ -314,8 +325,9 @@ def create_data_tier(  # noqa: PLR0913
         # Safe despite the Deployment mounting this: the mount uses `sub_path`,
         # and sub-path volume mounts never receive ConfigMap updates, so the
         # running pod holds its own copy of cluster.yaml either way. A changed
-        # graph list only reaches the server on the pod restart that the
-        # `cluster apply` step already requires.
+        # graph list reaches the server on the pod restart that the config-hash
+        # annotation on the Deployment's pod template forces — same hash the
+        # converge Job carries, so apply and restart always move together.
         opts=ResourceOptions(delete_before_replace=True),
     )
 
@@ -467,7 +479,23 @@ def create_data_tier(  # noqa: PLR0913
                 match_labels={"app.kubernetes.io/name": OMNIGRAPH_SERVER_SERVICE_NAME}
             ),
             template=kubernetes.core.v1.PodTemplateSpecArgs(
-                metadata=kubernetes.meta.v1.ObjectMetaArgs(labels=omnigraph_pod_labels),
+                metadata=kubernetes.meta.v1.ObjectMetaArgs(
+                    labels=omnigraph_pod_labels,
+                    # The same hash the converge Job carries, so the server is
+                    # restarted by any change the Job acted on — not just the
+                    # ones that happen to change the image.
+                    #
+                    # omnigraph serves the revision it read at boot, and the
+                    # cluster.yaml mount is a sub_path (which never receives
+                    # ConfigMap updates), so without this a deploy that only
+                    # edits cluster.yaml — adding a managed repo, say — would
+                    # converge the new graph into S3 and then keep serving a
+                    # config that has never heard of it. Deploy-time
+                    # consistency is worth the restart: this Deployment is
+                    # single-replica `Recreate`, so a config change is a brief
+                    # data-tier outage by construction.
+                    annotations={"omnigraph.mit.edu/config-hash": cluster_apply_hash},
+                ),
                 spec=kubernetes.core.v1.PodSpecArgs(
                     service_account_name=OMNIGRAPH_SERVICE_ACCOUNT_NAME,
                     containers=[

--- a/src/ol_infrastructure/applications/omnigraph/data_tier.py
+++ b/src/ol_infrastructure/applications/omnigraph/data_tier.py
@@ -16,6 +16,14 @@ CLI invocation this follows). That file is generated here as a ConfigMap
 rather than hand-authored, so the S3 bucket name/region and graph list stay
 in lockstep with the Pulumi-managed bucket.
 
+A pre-deploy ``omnigraph cluster apply`` Job runs ahead of the Deployment on
+every deploy, creating newly-declared graphs and applying schema updates to
+existing ones from the schemas baked into the image. Nothing else reconciles a
+live graph with a changed schema — a graph keeps whatever schema it was created
+with — so without this step an image whose code reads a newly-added field fails
+against the deployed graph. The server only serves the converged revision after
+a restart, hence Job-then-Deployment ordering.
+
 The ``omnigraph-server`` image is built once and promoted unchanged through
 CI -> QA -> Production by the ``omnigraph``/``pulumi-omnigraph`` Concourse
 pipeline, which also owns the ``omnigraph-server`` ECR repository itself
@@ -55,6 +63,14 @@ OMNIGRAPH_SERVICE_ACCOUNT_NAME = "omnigraph-server"
 CLUSTER_CONFIG_DIR = "/etc/omnigraph/cluster"
 ACTOR_TOKENS_MOUNT_PATH = "/etc/omnigraph/actor-tokens"  # pragma: allowlist secret
 ACTOR_TOKENS_FILENAME = "tokens.json"  # pragma: allowlist secret
+
+# Actor recorded in the commit ledger for the converge job's direct-engine
+# writes. cluster.yaml declares no `policy:` block today, so omnigraph does not
+# *require* an actor — this is passed for an attributable audit trail, and so
+# that if a policy bundle is added later the job fails loudly (denied) rather
+# than silently writing as nobody. Matches the break-glass identity in
+# agent-kit ADR-0005 path (b).
+CLUSTER_APPLY_ACTOR = "svc-witan-admin"
 
 # Fixed ConfigMap name, referenced both by the ConfigMap's own metadata and by
 # the Deployment's volume. The Deployment uses this constant rather than
@@ -170,6 +186,7 @@ class OmnigraphDataTier(NamedTuple):
     image_repository: str
     service: kubernetes.core.v1.Service
     deployment: kubernetes.apps.v1.Deployment
+    cluster_apply_job: kubernetes.batch.v1.Job
 
 
 def create_data_tier(  # noqa: PLR0913
@@ -302,6 +319,123 @@ def create_data_tier(  # noqa: PLR0913
         opts=ResourceOptions(delete_before_replace=True),
     )
 
+    # ── Pre-deploy schema convergence ────────────────────────────────────────
+    #
+    # `omnigraph cluster apply` creates any newly-declared graph and applies
+    # schema updates to the existing ones, from the schemas baked into this very
+    # image. It is the *only* thing that reconciles a live graph with a changed
+    # schema: a graph is created with whatever schema it was born with, and
+    # nothing re-reads the file afterwards. Without this, adding a field in
+    # agent-kit (e.g. `WorkflowSession.superseded_by`) ships an image whose code
+    # selects a column the store has never heard of, and every read of that type
+    # fails against the deployed graph.
+    #
+    # Ordered before the Deployment (its depends_on, below) because omnigraph
+    # only picks up the applied revision on an `omnigraph-server --cluster`
+    # restart — converge first, then let the rollout restart into it. This is
+    # the "cluster apply step" the ConfigMap comment above already refers to.
+    #
+    # Runs as a Job rather than an initContainer so it executes once per deploy
+    # rather than once per pod restart (crashloop, eviction, node drain), and so
+    # a convergence failure surfaces as a failed Job that blocks the rollout
+    # instead of a pod stuck in Init.
+    cluster_apply_hash: Output[str] = Output.all(
+        cluster_yaml=cluster_yaml_content, image=omnigraph_server_image
+    ).apply(
+        lambda args: hashlib.sha256(
+            f"{args['cluster_yaml']}\n{args['image']}".encode()
+        ).hexdigest()[:12]
+    )
+    cluster_apply_job = kubernetes.batch.v1.Job(
+        f"omnigraph-cluster-apply-{stack_info.env_suffix}",
+        # Deliberately unnamed (Pulumi auto-naming): a Job's pod template is
+        # immutable, so every change here is a replacement, and auto-naming lets
+        # the new Job be created before the old one is removed.
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            namespace=namespace,
+            labels=k8s_global_labels,
+        ),
+        spec=kubernetes.batch.v1.JobSpecArgs(
+            # Converging is idempotent, so a couple of retries costs nothing and
+            # rides out a transient S3 or IRSA-credential hiccup.
+            backoff_limit=2,
+            # Keep a completed Job around for a day so its logs are readable
+            # after a deploy, then let the TTL controller reap it.
+            ttl_seconds_after_finished=86400,
+            template=kubernetes.core.v1.PodTemplateSpecArgs(
+                metadata=kubernetes.meta.v1.ObjectMetaArgs(
+                    labels={
+                        **k8s_global_labels,
+                        "app.kubernetes.io/name": "omnigraph-cluster-apply",
+                    },
+                    # Forces a new Job whenever the declared graph list OR the
+                    # image (and therefore the baked schemas) changes. Without
+                    # it, adding a repo to cluster.yaml would leave this Job's
+                    # spec byte-identical and the graph would never be created.
+                    annotations={"omnigraph.mit.edu/config-hash": cluster_apply_hash},
+                ),
+                spec=kubernetes.core.v1.PodSpecArgs(
+                    restart_policy="Never",
+                    # Same IRSA identity as the server: this writes the graphs'
+                    # Lance stores directly in S3, not through the server.
+                    service_account_name=OMNIGRAPH_SERVICE_ACCOUNT_NAME,
+                    containers=[
+                        kubernetes.core.v1.ContainerArgs(
+                            name="cluster-apply",
+                            image=omnigraph_server_image,
+                            # Override the image's server entrypoint script —
+                            # this runs the `omnigraph` CLI baked alongside it.
+                            command=["omnigraph"],
+                            args=[
+                                "cluster",
+                                "apply",
+                                "--config",
+                                CLUSTER_CONFIG_DIR,
+                                "--as",
+                                CLUSTER_APPLY_ACTOR,
+                            ],
+                            env=[
+                                kubernetes.core.v1.EnvVarArgs(
+                                    name="AWS_REGION", value=aws_config.region
+                                ),
+                            ],
+                            resources=kubernetes.core.v1.ResourceRequirementsArgs(
+                                requests={"cpu": "100m", "memory": "256Mi"},
+                                limits={"cpu": "1", "memory": "1Gi"},
+                            ),
+                            volume_mounts=[
+                                # sub_path for the same reason the Deployment
+                                # uses it: overlay only cluster.yaml and leave
+                                # the image's baked-in schema files visible
+                                # alongside it. `cluster apply` reads both.
+                                kubernetes.core.v1.VolumeMountArgs(
+                                    name="cluster-config",
+                                    mount_path=f"{CLUSTER_CONFIG_DIR}/cluster.yaml",
+                                    sub_path="cluster.yaml",
+                                    read_only=True,
+                                ),
+                            ],
+                        )
+                    ],
+                    volumes=[
+                        kubernetes.core.v1.VolumeArgs(
+                            name="cluster-config",
+                            config_map=kubernetes.core.v1.ConfigMapVolumeSourceArgs(
+                                name=CLUSTER_CONFIGMAP_NAME,
+                            ),
+                        ),
+                    ],
+                ),
+            ),
+        ),
+        opts=ResourceOptions(
+            depends_on=[
+                cluster_configmap,
+                *auth_binding.irsa_service_accounts,
+            ]
+        ),
+    )
+
     omnigraph_pod_labels = {
         **k8s_global_labels,
         "app.kubernetes.io/name": OMNIGRAPH_SERVER_SERVICE_NAME,
@@ -431,6 +565,10 @@ def create_data_tier(  # noqa: PLR0913
             depends_on=[
                 cluster_configmap,
                 actor_tokens_secret,
+                # Converge the graphs' schemas before the server restarts into
+                # them — omnigraph only serves the applied revision after a
+                # restart, so this ordering is what makes the new schema live.
+                cluster_apply_job,
                 # The pod's service_account_name is the IRSA SA this stack
                 # creates via auth_binding (create_irsa_service_account=True);
                 # wait for it so the initial apply doesn't transiently fail
@@ -467,4 +605,5 @@ def create_data_tier(  # noqa: PLR0913
         image_repository=image_repository,
         service=omnigraph_service,
         deployment=omnigraph_deployment,
+        cluster_apply_job=cluster_apply_job,
     )

--- a/src/ol_infrastructure/applications/witan/__main__.py
+++ b/src/ol_infrastructure/applications/witan/__main__.py
@@ -10,6 +10,13 @@ APISIX.
 The data tier — the ``omnigraph-server`` graph service witan reads/writes over
 the cluster network — is a **separate stack** (``applications/omnigraph``),
 reached here via a ``StackReference`` to its ``omnigraph_server_addr`` output.
+
+Migrations are split along that same boundary. **Schema** convergence belongs
+to the omnigraph stack, which runs ``omnigraph cluster apply`` before its
+server restarts — it declares the graphs and bakes their schema files into the
+omnigraph-server image. This stack runs only witan's own **data** backfills
+(``migrations.py``), gated ahead of the MCPServer so a new image never serves
+against a graph its migrations haven't run over.
 ToolHive is only the operator that runs this MCP tier; it is an implementation
 detail of this stack, not part of witan's or omnigraph's identity — hence the
 plain ``witan`` / ``omnigraph`` project and namespace names.
@@ -74,6 +81,7 @@ from ol_infrastructure.applications.witan.mcp_servers import (
     MCP_GROUP_NAME,
     create_mcp_servers,
 )
+from ol_infrastructure.applications.witan.migrations import create_migration_job
 from ol_infrastructure.components.applications.eks import (
     OLEKSAuthBinding,
     OLEKSAuthBindingConfig,
@@ -284,6 +292,25 @@ witan_image_repository = (
 witan_image = format_docker_image_ref(witan_image_repository, "WITAN")
 
 #########################################
+#   Pre-deploy witan data migrations     #
+#########################################
+# witan's own backfills only — schema convergence belongs to the omnigraph
+# stack's `cluster apply` step, which runs before its server restarts. Gated
+# ahead of the MCPServer below via depends_on, so the new image never serves
+# against a graph its migrations haven't run over. See migrations.py.
+witan_migration_job = create_migration_job(
+    stack_info=stack_info,
+    namespace=NAMESPACE,
+    k8s_global_labels=k8s_global_labels,
+    witan_image=witan_image,
+    omnigraph_server_addr=omnigraph_server_addr,
+    council_graph_id=council_graph_id,
+    witan_ci_token_secret_name=WITAN_CI_TOKEN_SECRET_NAME,
+    witan_ci_token_secret_key=WITAN_CI_TOKEN_SECRET_KEY,
+    witan_ci_token_secret=witan_ci_token_secret,
+)
+
+#########################################
 #   MCPGroup + witan MCPServer           #
 #########################################
 mcp_servers = create_mcp_servers(
@@ -301,6 +328,7 @@ mcp_servers = create_mcp_servers(
     witan_ci_token_secret_name=WITAN_CI_TOKEN_SECRET_NAME,
     witan_ci_token_secret_key=WITAN_CI_TOKEN_SECRET_KEY,
     witan_ci_token_secret=witan_ci_token_secret,
+    migration_job=witan_migration_job,
 )
 
 #########################################

--- a/src/ol_infrastructure/applications/witan/mcp_servers.py
+++ b/src/ol_infrastructure/applications/witan/mcp_servers.py
@@ -69,6 +69,7 @@ def create_mcp_servers(  # noqa: PLR0913
     witan_ci_token_secret_name: str,
     witan_ci_token_secret_key: str,
     witan_ci_token_secret: Resource,
+    migration_job: Resource,
 ) -> WitanMCPServers:
     """Provision the witan-tools MCPGroup and the witan MCPServer backend."""
     witan_mcpgroup = kubernetes.apiextensions.CustomResource(
@@ -188,8 +189,18 @@ def create_mcp_servers(  # noqa: PLR0913
         # spec.secrets, actor-tokens via podTemplateSpec) so the operator
         # doesn't reconcile it into a pending pod before they exist — the same
         # secret-in-depends_on wiring toolhive_swe uses for its backends.
+        #
+        # `migration_job` makes the data migrations a genuine pre-deploy gate:
+        # pulumi-kubernetes awaits a Job's completion, so the operator is not
+        # handed the new image until the backfills for it have succeeded, and a
+        # failed migration blocks the rollout instead of half-applying it.
         opts=ResourceOptions(
-            depends_on=[witan_mcpgroup, witan_ci_token_secret, actor_tokens_secret]
+            depends_on=[
+                witan_mcpgroup,
+                witan_ci_token_secret,
+                actor_tokens_secret,
+                migration_job,
+            ]
         ),
     )
 

--- a/src/ol_infrastructure/applications/witan/migrations.py
+++ b/src/ol_infrastructure/applications/witan/migrations.py
@@ -1,0 +1,148 @@
+"""Pre-deploy witan data migrations.
+
+Ownership split, deliberate: **schema** convergence is the omnigraph stack's
+job (``applications/omnigraph/data_tier.py`` runs ``omnigraph cluster apply``
+before its Deployment restarts), because the cluster declares the graphs and
+bakes their schema files into the omnigraph-server image. This Job covers only
+the migrations that are witan's own — data rewrites the graph engine has no
+notion of.
+
+Concretely it does NOT run ``witan migrate all``, which would re-apply
+``schema.pg`` via ``omnigraph schema apply --server``. That would reach past
+the cluster to a cluster-*managed* graph, duplicating work the omnigraph stack
+already did and risking divergence from the cluster's own state ledger. The two
+backfills are run individually instead:
+
+- ``migrate topics``    — promote every memory ``tag`` to a ``Topic`` node plus
+  a ``Tagged`` edge.
+- ``migrate repo-keys`` — fold every stored repo key onto its canonical,
+  case-folded form (agent-kit #142), so rows written before that fix stop
+  dropping out of repo-scoped reads.
+
+Both are idempotent and safe to re-run, which is what makes them acceptable on
+every deploy rather than as one-shot runbook steps.
+
+Note on timing: these are historical backfills. Against the freshly-created,
+empty graphs this deployment starts with they find nothing and exit 0 — they
+only have work to do once real data lands, which is the local-graph-to-remote
+migration tracked in agent-kit task
+``tk-remote-server-registration-local-remote-user-dat-dc753c``. Wiring the gate
+before there is data to lose is the point: the failure mode this prevents is a
+backfill that silently never ran.
+"""
+
+import pulumi_kubernetes as kubernetes
+from pulumi import Output, Resource, ResourceOptions
+
+from ol_infrastructure.lib.pulumi_helper import StackInfo
+
+# One container per migration, run as init containers so they execute strictly
+# in order and the Job fails at the first one that fails. `witan migrate all`
+# is deliberately not used — see the module docstring.
+WITAN_MIGRATIONS: tuple[tuple[str, list[str]], ...] = (
+    ("migrate-topics", ["migrate", "topics"]),
+    ("migrate-repo-keys", ["migrate", "repo-keys"]),
+)
+
+
+def create_migration_job(  # noqa: PLR0913
+    stack_info: StackInfo,
+    namespace: str,
+    k8s_global_labels: dict[str, str],
+    witan_image: str | Output[str],
+    omnigraph_server_addr: str | Output[str],
+    council_graph_id: str | Output[str],
+    witan_ci_token_secret_name: str,
+    witan_ci_token_secret_key: str,
+    witan_ci_token_secret: Resource,
+) -> kubernetes.batch.v1.Job:
+    """Run witan's own data backfills before the MCPServer serves the new image.
+
+    Talks to omnigraph-server over the cluster network with the same
+    ``WITAN_MEMORY_*`` wiring the MCPServer uses, authenticating as
+    ``svc-witan-ci`` — these are admin/module-level operations that never carry
+    a per-user JWT (agent-kit ADR-0005 path b).
+    """
+    migration_env = [
+        kubernetes.core.v1.EnvVarArgs(
+            name="WITAN_MEMORY_URI", value=omnigraph_server_addr
+        ),
+        kubernetes.core.v1.EnvVarArgs(
+            name="WITAN_MEMORY_GRAPH", value=council_graph_id
+        ),
+        kubernetes.core.v1.EnvVarArgs(
+            name="WITAN_MEMORY_TOKEN",
+            value_from=kubernetes.core.v1.EnvVarSourceArgs(
+                secret_key_ref=kubernetes.core.v1.SecretKeySelectorArgs(
+                    name=witan_ci_token_secret_name,
+                    key=witan_ci_token_secret_key,
+                )
+            ),
+        ),
+        # WITAN_REMOTE_URL is deliberately unset: that selects the remote
+        # MCP-client path, over which every `migrate_*` is refused as an
+        # admin-only operation (witan/remote/proxy.py `_ADMIN_ONLY`). This Job
+        # is the in-cluster path those functions are reserved for, talking to
+        # omnigraph-server directly.
+    ]
+    migration_resources = kubernetes.core.v1.ResourceRequirementsArgs(
+        requests={"cpu": "100m", "memory": "256Mi"},
+        limits={"cpu": "1", "memory": "1Gi"},
+    )
+
+    return kubernetes.batch.v1.Job(
+        f"witan-migrations-{stack_info.env_suffix}",
+        # Unnamed on purpose (Pulumi auto-naming): a Job's pod template is
+        # immutable, so a new image means a replacement, and auto-naming lets
+        # the new Job be created before the old one goes away.
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            namespace=namespace,
+            labels=k8s_global_labels,
+        ),
+        spec=kubernetes.batch.v1.JobSpecArgs(
+            backoff_limit=2,
+            ttl_seconds_after_finished=86400,
+            template=kubernetes.core.v1.PodTemplateSpecArgs(
+                metadata=kubernetes.meta.v1.ObjectMetaArgs(
+                    labels={
+                        **k8s_global_labels,
+                        "app.kubernetes.io/name": "witan-migrations",
+                    },
+                ),
+                spec=kubernetes.core.v1.PodSpecArgs(
+                    restart_policy="Never",
+                    # initContainers run to completion in declaration order and
+                    # short-circuit the pod on the first failure, which is the
+                    # ordering guarantee these migrations want. The final
+                    # container is a no-op so the Job has something to
+                    # "complete" as.
+                    init_containers=[
+                        kubernetes.core.v1.ContainerArgs(
+                            name=name,
+                            image=witan_image,
+                            args=args,
+                            env=migration_env,
+                            resources=migration_resources,
+                        )
+                        for name, args in WITAN_MIGRATIONS
+                    ],
+                    # A Job needs at least one non-init container to complete
+                    # as. Every migration is an initContainer (above) so they
+                    # run in a guaranteed order, which leaves nothing for this
+                    # one to do — `/bin/true` rather than a witan invocation so
+                    # a deploy can never be blocked by the exit status of a
+                    # command that exists only to be a placeholder. `command`
+                    # overrides the image's `witan` ENTRYPOINT.
+                    containers=[
+                        kubernetes.core.v1.ContainerArgs(
+                            name="done",
+                            image=witan_image,
+                            command=["/bin/true"],
+                            resources=migration_resources,
+                        )
+                    ],
+                ),
+            ),
+        ),
+        opts=ResourceOptions(depends_on=[witan_ci_token_secret]),
+    )

--- a/src/ol_infrastructure/applications/witan/migrations.py
+++ b/src/ol_infrastructure/applications/witan/migrations.py
@@ -36,13 +36,48 @@ from pulumi import Output, Resource, ResourceOptions
 
 from ol_infrastructure.lib.pulumi_helper import StackInfo
 
-# One container per migration, run as init containers so they execute strictly
-# in order and the Job fails at the first one that fails. `witan migrate all`
-# is deliberately not used — see the module docstring.
+# One container per migration, executed strictly in order so the Job stops at
+# the first failure. `witan migrate all` is deliberately not used — see the
+# module docstring.
 WITAN_MIGRATIONS: tuple[tuple[str, list[str]], ...] = (
     ("migrate-topics", ["migrate", "topics"]),
     ("migrate-repo-keys", ["migrate", "repo-keys"]),
 )
+
+# omnigraph-server is a single-replica `Recreate` Deployment in a *separate*
+# stack, so it has a genuine downtime window on every one of its deploys — and
+# since its pod template now carries a config hash, that is every deploy, not
+# only the ones that change its image. Two stacks deploying at once can
+# therefore land this Job inside that window, where it fails to connect.
+#
+# Kubernetes' own Job backoff is the retry loop for that: attempts are spaced
+# 10s, 20s, 40s, … so 6 retries span roughly ten minutes, comfortably longer
+# than a single-pod Recreate rollout (image pull + readiness probe). Each
+# attempt re-runs the migration from scratch, which is safe because both are
+# idempotent.
+#
+# A cross-stack `depends_on` — the obvious-looking alternative — is not
+# available: a StackReference yields the other stack's *outputs*, not resource
+# handles, so there is nothing to order against and no way to make one stack's
+# deploy wait on another's rollout.
+MIGRATION_BACKOFF_LIMIT = 6
+
+
+def _migration_container(
+    name: str,
+    args: list[str],
+    witan_image: str | Output[str],
+    env: list[kubernetes.core.v1.EnvVarArgs],
+    resources: kubernetes.core.v1.ResourceRequirementsArgs,
+) -> kubernetes.core.v1.ContainerArgs:
+    """One migration step. Identical whether it lands in init or main position."""
+    return kubernetes.core.v1.ContainerArgs(
+        name=name,
+        image=witan_image,
+        args=args,
+        env=env,
+        resources=resources,
+    )
 
 
 def create_migration_job(  # noqa: PLR0913
@@ -100,7 +135,7 @@ def create_migration_job(  # noqa: PLR0913
             labels=k8s_global_labels,
         ),
         spec=kubernetes.batch.v1.JobSpecArgs(
-            backoff_limit=2,
+            backoff_limit=MIGRATION_BACKOFF_LIMIT,
             ttl_seconds_after_finished=86400,
             template=kubernetes.core.v1.PodTemplateSpecArgs(
                 metadata=kubernetes.meta.v1.ObjectMetaArgs(
@@ -113,32 +148,24 @@ def create_migration_job(  # noqa: PLR0913
                     restart_policy="Never",
                     # initContainers run to completion in declaration order and
                     # short-circuit the pod on the first failure, which is the
-                    # ordering guarantee these migrations want. The final
-                    # container is a no-op so the Job has something to
-                    # "complete" as.
+                    # ordering guarantee these migrations want. A Job also needs
+                    # at least one non-init container to complete as, so the
+                    # *last* migration is that container rather than a
+                    # placeholder: every container here does real work, and
+                    # nothing depends on a stub binary being present in an image
+                    # this repo doesn't build.
                     init_containers=[
-                        kubernetes.core.v1.ContainerArgs(
-                            name=name,
-                            image=witan_image,
-                            args=args,
-                            env=migration_env,
-                            resources=migration_resources,
+                        _migration_container(
+                            name, args, witan_image, migration_env, migration_resources
                         )
-                        for name, args in WITAN_MIGRATIONS
+                        for name, args in WITAN_MIGRATIONS[:-1]
                     ],
-                    # A Job needs at least one non-init container to complete
-                    # as. Every migration is an initContainer (above) so they
-                    # run in a guaranteed order, which leaves nothing for this
-                    # one to do — `/bin/true` rather than a witan invocation so
-                    # a deploy can never be blocked by the exit status of a
-                    # command that exists only to be a placeholder. `command`
-                    # overrides the image's `witan` ENTRYPOINT.
                     containers=[
-                        kubernetes.core.v1.ContainerArgs(
-                            name="done",
-                            image=witan_image,
-                            command=["/bin/true"],
-                            resources=migration_resources,
+                        _migration_container(
+                            *WITAN_MIGRATIONS[-1],
+                            witan_image,
+                            migration_env,
+                            migration_resources,
                         )
                     ],
                 ),


### PR DESCRIPTION
## Problem

Nothing converged a deployed graph with a changed schema. A graph keeps whatever schema it was created with, and neither stack ran any convergence step — I grepped both for `cluster apply` / `schema apply` / `Job` / `initContainer` and found nothing.

The immediate case: mitodl/agent-kit#161 added `WorkflowSession.superseded_by`, and **every** session read now selects it. Shipping that image without a converge step means the code asks the store for a column it has never heard of, and `workflow_project_status`, `workflow_project_complete` and the context hook all fail against the deployed graph.

## Approach — split along the boundary the stacks already draw

**`applications/omnigraph` owns schema.** It declares the graphs in `cluster.yaml` and bakes their schema files into the omnigraph-server image, so `omnigraph cluster apply` — *"create graphs, apply schema updates (soft drops)… Serving picks up the applied revision after an `omnigraph-server --cluster` restart"* — belongs there. It runs as a Job ordered ahead of the Deployment: converge first, then let the rollout restart into it.

This step was already designed for and never built. `data_tier.py` refers to it twice:
- `build_cluster_graphs`: *"Adding a repo is deliberately a config change plus a `cluster apply` and a server restart"*
- the ConfigMap comment: *"A changed graph list only reaches the server on the pod restart that the `cluster apply` step already requires."*

A pod-template annotation carrying `sha256(cluster.yaml + image digest)` forces a fresh Job whenever either changes. Without it, adding a managed repo would leave the Job spec byte-identical and the new graph would silently never be created.

**`applications/witan` owns its own data migrations** — `migrate topics` and `migrate repo-keys`, as ordered initContainers.

Deliberately **not** `witan migrate all`: that would re-apply `schema.pg` via `omnigraph schema apply --server`, reaching past the cluster to a cluster-*managed* graph — duplicating what the omnigraph stack just did, and risking divergence from the cluster's own state ledger.

## Why Jobs rather than initContainers on the workloads

Once per deploy rather than once per pod restart (crashloop, eviction, node drain), and a failure surfaces as a failed Job that blocks the rollout instead of a pod stuck in `Init`. pulumi-kubernetes awaits Job completion, which is what makes the `depends_on` wiring a real gate rather than decoration.

## Timing note — the witan backfills are inert today

`migrate topics` backfills from existing memory tags and `migrate repo-keys` folds existing repo keys; the deployed graphs are new and empty, so both find nothing and exit 0. They earn their place once real data lands — the local-graph→remote migration tracked in agent-kit task `tk-remote-server-registration-local-remote-user-dat-dc753c`. Wiring the gate before there is data to lose is the point; the failure mode this prevents is a backfill that silently never ran.

## Converge and restart move together

omnigraph serves the revision it read at boot, and the `cluster.yaml` mount is a `sub_path` — which never receives ConfigMap updates. So a Job that converged on every change, paired with a Deployment that only restarted when the *image* changed, would leave a real hole: a deploy that adds a managed repo creates the graph in S3 and then keeps serving a config that has never heard of it, until some unrelated change happens to restart the pod.

The Deployment's pod template therefore carries the same config hash the Job does. Whatever the Job acted on, the server restarts into.

The trade is explicit: this is a single-replica `Recreate` Deployment, so a `cluster.yaml` change is now a brief data-tier outage rather than a no-op. That is the deliberate choice — a serving config silently behind the store is the worse failure, since it fails at read time on whichever graph or field is missing rather than at deploy time.

## Verification

`pulumi preview` against CI for both stacks (image digests pinned to what is currently deployed, since `*_DOCKER_SHA` is normally injected by the Concourse build job):

| Stack | Plan |
|---|---|
| `ol-application-witan` CI | `+ 1 to create`, 30 unchanged |
| `ol-application-omnigraph` CI | `+ 1 to create`, `~ 1 to update`, 30 unchanged |

The single update is the omnigraph Deployment gaining the config-hash annotation — an in-place update adding only that key, confirmed against `--diff`, not a replacement. No replacements, no deletions, no `assumeRole`/StackReference/export changes. `ruff check`, `ruff format`, `mypy` and the full pre-commit hook set pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETnr9nQHKVohFHyUvi1RUd
