### PR TITLE
docs(rootly): confirm christest test objects deleted from Rootly

### DIFF
--- a/src/ol_infrastructure/saas/rootly/KNOWN_ISSUES.md
+++ b/src/ol_infrastructure/saas/rootly/KNOWN_ISSUES.md
@@ -214,7 +214,7 @@ Some resources were deliberately removed from Pulumi state after import because
 Rootly returned no readable state or the provider schema could not model the
 resource without diffs or validation errors.
 
-### Empty state after import
+### Empty state after import (RESOLVED: deleted from Rootly)
 
 The provider returned empty state for these imports, which would make Pulumi plan
 protected replacements if they were modeled in code:
@@ -226,9 +226,11 @@ protected replacements if they were modeled in code:
 - `rootly:index/escalationLevel:EscalationLevel::r-7f50a094-1f88-4e75-9afd-5e56ea8448a9`
 - `rootly:index/alertRoute:AlertRoute::chris-test-route`
 
-These are likely stale/example objects. The cleanest fix is deleting them in
-the Rootly UI (they are test artifacts, not operational resources); otherwise
-re-try only with preview-only imports first.
+These were stale/example objects and were never modeled in Pulumi. Confirmed
+via the Rootly API that they have all been deleted from the Rootly account
+(no `christest`/`chris-test` team, service, functionality, escalation policy,
+escalation level, or alert route remain), so there is nothing left to import
+or clean up here.
 
 ### `IncidentPermissionSetBoolean`
 


### PR DESCRIPTION
### What are the relevant tickets?
Related: https://github.com/mitodl/ol-infrastructure/pull/5020 (this is the follow-up cleanup it called out)

### Description (What does it do?)
Follow-up from #5020's KNOWN_ISSUES.md: verified via the live Rootly API (`teams`, `services`, `functionalities`, `escalation_policies`, `alert_routes` list endpoints) that the stale `christest`/`chris-test` test objects previously flagged as "likely stale/example objects" to delete have already been removed from the Rootly account:

- `rootly:index/team:Team::christestteam` — gone (only Platform Engineering team remains)
- `rootly:index/service:Service::christest` — gone (checked all 41 services)
- `rootly:index/functionality:Functionality::{search,checkout,login}` — gone (only 4 real functionalities remain)
- `rootly:index/escalationPolicy:EscalationPolicy::christest-escalation-policy` — gone
- `rootly:index/escalationLevel:EscalationLevel::r-7f50a094-1f88-4e75-9afd-5e56ea8448a9` — gone (parent policy no longer exists)
- `rootly:index/alertRoute:AlertRoute::chris-test-route` — gone (checked all 12 alert routes)

None of these were ever modeled in Pulumi (they were deliberately excluded after import per KNOWN_ISSUES.md), so there is no code or state to change — this PR only updates the doc to reflect that the cleanup is done.

### How can this be tested?
No functional change. Diff is limited to `src/ol_infrastructure/saas/rootly/KNOWN_ISSUES.md`.

### Additional Context
N/A