### PR TITLE
feat(witan): point the MCP tier at the cluster code graphs

### DIFF
--- a/src/ol_infrastructure/applications/witan/__main__.py
+++ b/src/ol_infrastructure/applications/witan/__main__.py
@@ -122,7 +122,9 @@ operator_stack = make_stack_reference(projects.TOOLHIVE_OPERATOR, stack_info.nam
 require_stack_output_value(operator_stack, "toolhive_namespace")
 
 # Fail fast if the omnigraph data-tier stack hasn't been deployed yet — witan's
-# MCPServer points WITAN_MEMORY_URI at its in-cluster address (below).
+# MCPServer points both WITAN_MEMORY_URI (the `council` graph) and
+# WITAN_CODE_SERVER (the per-repo `code-<repo>` graphs) at its in-cluster
+# address (below).
 omnigraph_stack = make_stack_reference(projects.OMNIGRAPH, stack_info.name)
 omnigraph_server_addr = require_stack_output_value(
     omnigraph_stack, "omnigraph_server_addr"
@@ -184,6 +186,21 @@ WITAN_OIDC_AUDIENCE = witan_config.get("oidc_audience") or "witan"
 # Vault source in its own namespace (see applications/omnigraph).
 WITAN_CI_TOKEN_SECRET_NAME = "witan-ci-token"  # noqa: S105  # pragma: allowlist secret
 WITAN_CI_TOKEN_SECRET_KEY = "token"  # noqa: S105  # pragma: allowlist secret
+# The MCP tier's own credential against the code graphs (WITAN_CODE_TOKEN, see
+# mcp_servers.py). A SEPARATE Secret holding the same Vault value rather than a
+# second `spec.secrets` entry against witan-ci-token: that list is keyed by
+# secret name, so two entries naming one Secret are rejected outright
+# (`.spec.secrets: duplicate entries for key [name="witan-ci-token"]`).
+#
+# Which is the right shape anyway — these are two identities that happen to
+# share a token today. witan's Cedar bundle models a distinct
+# `witan-service`/`act-svc-witan` account for the tier's graph enumeration, and
+# when one is provisioned this Secret's `path` moves to it while the MCPServer
+# spec stays as it is.
+WITAN_CODE_TOKEN_SECRET_NAME = (  # pragma: allowlist secret
+    "witan-code-token"  # noqa: S105
+)
+WITAN_CODE_TOKEN_SECRET_KEY = "token"  # noqa: S105  # pragma: allowlist secret
 ACTOR_TOKENS_SECRET_NAME = "actor-tokens"  # noqa: S105  # pragma: allowlist secret
 ACTOR_TOKENS_SECRET_KEY = "tokens.json"  # noqa: S105  # pragma: allowlist secret
 # Keys these maps are stored under *inside* their Vault secrets. This stack
@@ -236,6 +253,37 @@ witan_ci_token_secret = OLVaultK8SSecret(
         excludes=[".*"],
         templates={
             WITAN_CI_TOKEN_SECRET_KEY: (
+                f'{{{{ get .Secrets "{WITAN_CI_TOKEN_VAULT_KEY}" }}}}'
+            )
+        },
+        refresh_after="1h",
+        vaultauth=witan_auth_binding.vault_k8s_resources.auth_name,
+    ),
+    opts=ResourceOptions(
+        delete_before_replace=True,
+        depends_on=witan_auth_binding.vault_k8s_resources,
+    ),
+)
+
+# Same Vault path as witan_ci_token_secret above — see
+# WITAN_CODE_TOKEN_SECRET_NAME for why this is its own Secret and not a second
+# reference to that one.
+witan_code_token_secret = OLVaultK8SSecret(
+    f"witan-code-token-secret-{stack_info.env_suffix}",
+    resource_config=OLVaultK8SStaticSecretConfig(
+        name=WITAN_CODE_TOKEN_SECRET_NAME,
+        namespace=NAMESPACE,
+        labels=k8s_global_labels,
+        dest_secret_labels=k8s_global_labels,
+        dest_secret_name=WITAN_CODE_TOKEN_SECRET_NAME,
+        dest_secret_type="Opaque",  # pragma: allowlist secret  # noqa: S106
+        mount="secret-operations",
+        mount_type="kv-v1",
+        path="witan/ci-token",
+        exclude_raw=True,
+        excludes=[".*"],
+        templates={
+            WITAN_CODE_TOKEN_SECRET_KEY: (
                 f'{{{{ get .Secrets "{WITAN_CI_TOKEN_VAULT_KEY}" }}}}'
             )
         },
@@ -328,6 +376,9 @@ mcp_servers = create_mcp_servers(
     witan_ci_token_secret_name=WITAN_CI_TOKEN_SECRET_NAME,
     witan_ci_token_secret_key=WITAN_CI_TOKEN_SECRET_KEY,
     witan_ci_token_secret=witan_ci_token_secret,
+    witan_code_token_secret_name=WITAN_CODE_TOKEN_SECRET_NAME,
+    witan_code_token_secret_key=WITAN_CODE_TOKEN_SECRET_KEY,
+    witan_code_token_secret=witan_code_token_secret,
     migration_job=witan_migration_job,
 )
 

--- a/src/ol_infrastructure/applications/witan/__main__.py
+++ b/src/ol_infrastructure/applications/witan/__main__.py
@@ -447,7 +447,14 @@ witan_virtualmcpserver = kubernetes.apiextensions.CustomResource(
             mcp_servers.group,
             *mcp_servers.servers,
             mcp_oidc_config,
+            # Every Secret the backend MCPServer consumes, restated here even
+            # though `*mcp_servers.servers` already carries them: Pulumi orders
+            # transitively, so this changes nothing the engine does. It is kept
+            # so the list reads as the complete set of things that must exist
+            # before the aggregator does — a Secret missing from it looks like
+            # an oversight rather than a deliberate omission.
             witan_ci_token_secret,
+            witan_code_token_secret,
             actor_tokens_secret,
         ]
     ),

--- a/src/ol_infrastructure/applications/witan/mcp_servers.py
+++ b/src/ol_infrastructure/applications/witan/mcp_servers.py
@@ -69,6 +69,9 @@ def create_mcp_servers(  # noqa: PLR0913
     witan_ci_token_secret_name: str,
     witan_ci_token_secret_key: str,
     witan_ci_token_secret: Resource,
+    witan_code_token_secret_name: str,
+    witan_code_token_secret_key: str,
+    witan_code_token_secret: Resource,
     migration_job: Resource,
 ) -> WitanMCPServers:
     """Provision the witan-tools MCPGroup and the witan MCPServer backend."""
@@ -140,13 +143,68 @@ def create_mcp_servers(  # noqa: PLR0913
                 # relying on two independent defaults agreeing is the failure
                 # mode this avoids.)
                 {"name": "WITAN_MEMORY_GRAPH", "value": council_graph_id},
+                # The code-graph data tier — the same omnigraph-server, whose
+                # `code-<repo>` graphs data_tier.py declares alongside
+                # `council`. Without it the tier serves code-graph reads out of
+                # whatever `code_dir` the container has (nothing) and can serve
+                # no cluster writes at all, so the `code_store_*` tools it
+                # registers for remote indexers (agent-kit ADR-0005 path c)
+                # have nowhere to write.
+                #
+                # No graph id counterpart to WITAN_MEMORY_GRAPH here: a code
+                # graph is addressed per repo, and witan-code derives the id
+                # from the canonical repo URI the caller names
+                # (`witan_code.config.graph_id`, the byte-for-byte mirror of
+                # `data_tier.code_graph_id`). A graph this cluster does not
+                # declare fails loudly on the first store call.
+                #
+                # WITAN_CODE_INDEX_ROLE is deliberately left at its default
+                # (`client`). It is what keeps a write arriving through the MCP
+                # boundary from claiming a graph's shared default-branch view;
+                # only the in-cluster CI indexer Job declares itself `ci`.
+                {"name": "WITAN_CODE_SERVER", "value": omnigraph_server_addr},
             ],
             "secrets": [
                 {
                     "name": witan_ci_token_secret_name,
                     "key": witan_ci_token_secret_key,
                     "targetEnvName": "WITAN_MEMORY_TOKEN",
-                }
+                },
+                # The tier's own credential against the code graphs, for the
+                # questions asked *about* the server rather than of a graph:
+                # `omnigraph graphs list`, which `ensure_store` runs to check
+                # the cluster actually declares a graph before a write starts
+                # (a provisioning gap becomes one clear refusal instead of an
+                # error per record), and which backs `code_indexed_repos`. That
+                # listing is server-scoped (Cedar `graph_list`) and belongs to
+                # no actor, so it authenticates as the service or not at all —
+                # and omnigraph-server, booted with a bearer-tokens file,
+                # resolves no actor from an absent token and denies it.
+                #
+                # It is NOT what a caller's records are written under.
+                # `witan_code.ingest._client` resolves the actor from the
+                # request's JWT and swaps in that actor's token from
+                # WITAN_ACTOR_TOKENS_FILE before any read or mutation, refusing
+                # outright when the actor has none — serving a caller under the
+                # service identity is what that layer exists to prevent
+                # (agent-kit ADR-0005 path c).
+                #
+                # Its own Secret rather than a second entry against
+                # witan-ci-token, whose value it currently duplicates: this
+                # list is keyed by secret name and rejects two entries naming
+                # one Secret. See WITAN_CODE_TOKEN_SECRET_NAME in __main__.py —
+                # svc-witan-ci is borrowed here, the same way migrations.py
+                # borrows it, until the `witan-service`/`act-svc-witan` account
+                # witan's Cedar bundle already models is provisioned. Sharing
+                # it grants the tier no write it could not otherwise make: the
+                # actor swap above is unconditional, and WITAN_CODE_INDEX_ROLE
+                # stays `client`, so the CI role's one real privilege — writing
+                # a graph's shared default-branch view — stays unreachable.
+                {
+                    "name": witan_code_token_secret_name,
+                    "key": witan_code_token_secret_key,
+                    "targetEnvName": "WITAN_CODE_TOKEN",
+                },
             ],
             # No outbound network needed beyond the in-cluster omnigraph-server
             # Service and the Keycloak JWKS endpoint (JWT validation).
@@ -185,8 +243,9 @@ def create_mcp_servers(  # noqa: PLR0913
                 }
             },
         },
-        # Wait for the secrets this MCPServer consumes (witan-ci-token via
-        # spec.secrets, actor-tokens via podTemplateSpec) so the operator
+        # Wait for the secrets this MCPServer consumes (witan-ci-token and
+        # witan-code-token via spec.secrets, actor-tokens via podTemplateSpec)
+        # so the operator
         # doesn't reconcile it into a pending pod before they exist — the same
         # secret-in-depends_on wiring toolhive_swe uses for its backends.
         #
@@ -198,6 +257,7 @@ def create_mcp_servers(  # noqa: PLR0913
             depends_on=[
                 witan_mcpgroup,
                 witan_ci_token_secret,
+                witan_code_token_secret,
                 actor_tokens_secret,
                 migration_job,
             ]


### PR DESCRIPTION
## What are the relevant tickets?

witan task `tk-ol-infrastructure-set-witan-code-server-on-the-w-e48e2d`, the ol-infrastructure follow-up called out in agent-kit ADR-0005 path (c) and delivered on the agent-kit side by mitodl/agent-kit#171.

## What's this PR do?

The witan MCP tier registers witan-code's `code_store_*` tools so a remote indexer can write a code graph through the deployed endpoint as itself. It could not actually serve them: with no `WITAN_CODE_SERVER`, witan-code resolves every code graph to a local `code_dir` the container does not have, so the tier served code-graph *reads* from nothing and could serve no cluster write at all. This points it at the same `omnigraph-server` whose `code-<repo>` graphs `applications/omnigraph/data_tier.py` already declares.

`WITAN_CODE_TOKEN` comes with it, which ADR-0005 did not anticipate ("and nothing else new"). Before any per-actor token swap, `store.ensure_store` runs `omnigraph graphs list` to check the cluster actually declares the graph a write is about to target — turning a provisioning gap into one clear refusal instead of an error per record. That listing is server-scoped (Cedar `graph_list`), belongs to no actor, and `omnigraph-server` — booted with `OMNIGRAPH_SERVER_BEARER_TOKENS_FILE` — resolves no actor from an absent token. Without a token the tier's first store call fails with "could not be listed" and `code_indexed_repos` silently degrades to empty.

It gets its own `witan-code-token` Secret rather than a second `spec.secrets` entry against `witan-ci-token`: that list is keyed by secret name and the API server rejects the duplicate outright (caught by `pulumi preview`, see below). That is also the honest shape — the account the tier *should* enumerate graphs under is `act-svc-witan`/`witan-service`, already modelled in witan's Cedar bundle but not provisioned in the SOPS source, so this borrows `svc-witan-ci` the same way `migrations.py` does. When the dedicated token lands, only this Secret's Vault `path` moves.

Nothing here lets the tier act as itself on a caller's behalf: `witan_code.ingest._client` swaps in the requesting actor's token from `WITAN_ACTOR_TOKENS_FILE` before any read or mutation and refuses outright when the actor has none, and `WITAN_CODE_INDEX_ROLE` stays at its default `client` — so no write through the MCP boundary can claim a graph's shared default-branch view, whose single writer is the in-cluster CI indexer.

## How should this be manually tested?

`pulumi preview --stack applications.witan.CI` (server-side dry-run against the live cluster) shows exactly three creates for the new `VaultStaticSecret` and one MCPServer update adding `WITAN_CODE_SERVER` + the `WITAN_CODE_TOKEN` secret entry, nothing else. `pre-commit run` (ruff/format/mypy/detect-secrets) passes.

After deploy, from a laptop with `code_transport = "mcp"`, a `remote_url` pointing at this deployment, and a live `witan login`:

- `witan-code index` on a feature branch should land on `<actor>/<branch>` of that repo's cluster graph, and `witan-code branches` should list it.
- Indexing a repo the cluster declares no graph for should fail immediately naming the expected graph id and the ids the server serves, rather than reporting success having written nothing.
- Targeting the default view (no branch) should be refused — that is the CI indexer's alone.

## Any background context you want to provide?

Each repo's `code-<repo>` graph must still be declared by the data-tier stack (`applications/omnigraph/data_tier.py`); this client cannot create one. That side already landed in #5189.

Follow-up, not in scope here: provision the `svc-witan-admin`/`act-svc-witan` service account in the SOPS source so the tier stops borrowing the CI credential for graph enumeration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxLjHFrhHQ5pxAz7gMgPBT