### PR TITLE
Add realm-role-to-userinfo mapper for gwarek's Keycloak client

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/ol_platform_engineering.py
+++ b/src/ol_infrastructure/substructure/keycloak/ol_platform_engineering.py
@@ -506,6 +506,28 @@ def create_ol_platform_engineering_realm(  # noqa: PLR0913, PLR0915
         opts=resource_options,
     )
 
+    # The built-in realm-roles mapper (part of the default "roles" client
+    # scope) adds realm_access.roles to the ID/access token, but not to the
+    # /userinfo endpoint response -- and APISIX's openid-connect plugin
+    # builds X-Userinfo from a live /userinfo call (session_contents.user
+    # in components/services/apisix.py), not from token claims. Without
+    # this, gwarek's get_role/require_admin never see any roles regardless
+    # of what's assigned in Keycloak. Mirrors Concourse's realm-role mapper
+    # above, but keeps the standard realm_access.roles claim shape gwarek's
+    # backend already reads instead of remapping to a custom claim.
+    keycloak.openid.UserRealmRoleProtocolMapper(
+        "ol-platform-engineering-gwarek-realm-role-userinfo-mapper",
+        realm_id=ol_platform_engineering_gwarek_client.realm_id,
+        client_id=ol_platform_engineering_gwarek_client.id,
+        name="Realm Roles Userinfo Mapper",
+        claim_name="realm_access.roles",
+        multivalued=True,
+        add_to_id_token=True,
+        add_to_access_token=True,
+        add_to_userinfo=True,
+        opts=resource_options,
+    )
+
     vault.generic.Secret(
         "ol-platform-engineering-gwarek-client-vault-oidc-credentials",
         path="secret-operations/sso/gwarek",


### PR DESCRIPTION
## Summary
- gwarek's FastAPI backend reads `realm_access.roles` from the `X-Userinfo` header APISIX injects, but APISIX's `openid-connect` plugin builds that header from a live call to Keycloak's `/userinfo` endpoint, not by decoding the ID/access token.
- Keycloak's built-in realm-roles mapper only adds `realm_access.roles` to the ID/access token by default — not to `/userinfo` — so gwarek's `get_role`/`require_admin` dependencies never saw any roles, regardless of what was assigned in Keycloak (confirmed via a live 403 after assigning `gwarek-admin` to a test user and re-logging in).
- Adds a `UserRealmRoleProtocolMapper` scoped to gwarek's own Keycloak client only (not the realm-wide default "roles" scope shared by other apps in `ol-platform-engineering`), mapping realm roles into `realm_access.roles` with `add_to_userinfo=True`. Mirrors Concourse's existing realm-role mapper in the same file, but keeps the standard claim shape gwarek's backend already reads instead of remapping to a custom claim.

## Test plan
- [x] Applied directly to the `Production` Keycloak substructure stack (`pulumi up --target` scoped to just this new resource, avoiding unrelated drift from a separately-merged `openlit` removal)
- [ ] Confirm a user with the `gwarek-admin` role can now load `/api/me` without a 403 after re-logging in
- [ ] Confirm viewer-only users still get 403 on admin-only routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)