### PR TITLE
fix(monitoring): publish CloudWatch alarm recoveries and let Rootly resolve on them

### DIFF
--- a/src/ol_infrastructure/components/aws/cloudwatch.py
+++ b/src/ol_infrastructure/components/aws/cloudwatch.py
@@ -145,12 +145,16 @@ class OLCloudWatchAlarmSimpleElastiCache(ComponentResource):
 
         sns_topic_arn = get_monitoring_sns_arn(alarm_config.level)
         cache_cluster_id = f"{alarm_config.cluster_id}{alarm_config.node_id}"
+        # Publish the ALARM->OK transition to the same topic. Without it Rootly
+        # only ever hears about the breach, so a self-clearing blip stays open
+        # indefinitely and reads as an ongoing incident.
         alarm_actions = [sns_topic_arn] if alarm_config.enabled else []
 
         self.metric_alarm = cloudwatch.MetricAlarm(
             f"{cache_cluster_id}-{alarm_config.metric_name}-simple-elasticache_alarm",
             actions_enabled=alarm_config.enabled,
             alarm_actions=alarm_actions,
+            ok_actions=alarm_actions,
             alarm_description=alarm_config.description,
             comparison_operator=alarm_config.comparison_operator,
             datapoints_to_alarm=alarm_config.datapoints_to_alarm,
@@ -196,12 +200,16 @@ class OLCloudWatchAlarmSimpleRDS(ComponentResource):
         resource_options = ResourceOptions(parent=self).merge(opts)
 
         sns_topic_arn = get_monitoring_sns_arn(alarm_config.level)
+        # Publish the ALARM->OK transition to the same topic. Without it Rootly
+        # only ever hears about the breach, so a self-clearing blip stays open
+        # indefinitely and reads as an ongoing incident.
         alarm_actions = [sns_topic_arn] if alarm_config.enabled else []
 
         self.metric_alarm = cloudwatch.MetricAlarm(
             f"{alarm_config.database_identifier}-{alarm_config.metric_name}-simple-rds-alarm",
             actions_enabled=alarm_config.enabled,
             alarm_actions=alarm_actions,
+            ok_actions=alarm_actions,
             alarm_description=alarm_config.description,
             comparison_operator=alarm_config.comparison_operator,
             datapoints_to_alarm=alarm_config.datapoints_to_alarm,

--- a/src/ol_infrastructure/saas/rootly/__main__.py
+++ b/src/ol_infrastructure/saas/rootly/__main__.py
@@ -59,6 +59,32 @@ CLOUDWATCH_NON_PROD_URGENCY_RULES = [
     },
 ]
 
+# CloudWatch alarms publish both the breach and the ALARM->OK recovery to the
+# same SNS topic (ok_actions in src/ol_infrastructure/components/aws/cloudwatch.py).
+# Rootly otherwise treats every SNS notification as a brand new alert: repeated
+# breach notifications pile up as duplicates, and the recovery never closes
+# anything, so a blip that self-clears in minutes stays open indefinitely and
+# reads as an ongoing incident.
+#
+# AlarmName is the stable identity of a CloudWatch alarm, so keying on it
+# collapses every notification for one alarm onto a single alert, and the
+# resolution rule closes that alert when NewStateValue flips to OK.
+CLOUDWATCH_DEDUPLICATION_KEY_PATH = "$.Message.AlarmName"
+CLOUDWATCH_RESOLUTION_RULE_ATTRIBUTES = {
+    "conditionType": "all",
+    "conditionsAttributes": [
+        {
+            "field": "$.Message.NewStateValue",
+            "kind": "payload",
+            "operator": "is",
+            "value": "OK",
+        },
+    ],
+    "enabled": True,
+    "identifierJsonPath": "$.Message.AlarmName",
+    "identifierReferenceKind": "payload",
+}
+
 # Foundation resources imported from the existing Rootly account.
 role_admin = rootly.Role(
     "admin",
@@ -2808,7 +2834,10 @@ alerts_source_cloudwatch_critical = rootly.AlertsSource(
     ],
     alert_source_urgency_rules_attributes=CLOUDWATCH_NON_PROD_URGENCY_RULES,
     alert_urgency_id="5d357977-9dbe-42ad-b647-5a442cab3d96",
+    deduplicate_alerts_by_key=True,
     deduplication_key_kind="payload",
+    deduplication_key_path=CLOUDWATCH_DEDUPLICATION_KEY_PATH,
+    resolution_rule_attributes=CLOUDWATCH_RESOLUTION_RULE_ATTRIBUTES,
     name="Cloudwatch - Critical",
     owner_group_ids=["9f00e9f1-2f13-470e-a856-50ab5003f260"],
     secret=Output.secret(rootly_secrets["alert_source_secrets"]["cloudwatch_critical"]),
@@ -2827,7 +2856,10 @@ alerts_source_cloudwatch_warning = rootly.AlertsSource(
     ],
     alert_source_urgency_rules_attributes=CLOUDWATCH_NON_PROD_URGENCY_RULES,
     alert_urgency_id="5d357977-9dbe-42ad-b647-5a442cab3d96",
+    deduplicate_alerts_by_key=True,
     deduplication_key_kind="payload",
+    deduplication_key_path=CLOUDWATCH_DEDUPLICATION_KEY_PATH,
+    resolution_rule_attributes=CLOUDWATCH_RESOLUTION_RULE_ATTRIBUTES,
     name="Cloudwatch - Warning",
     owner_group_ids=["9f00e9f1-2f13-470e-a856-50ab5003f260"],
     secret=Output.secret(rootly_secrets["alert_source_secrets"]["cloudwatch_warning"]),


### PR DESCRIPTION
### What are the relevant tickets?

N/A — found while investigating the mit-learn production RDS `DiskQueueDepth` alerts of 2026-08-03. The application-side cause of that particular incident is tracked separately at https://github.com/mitodl/mit-learn/issues/3710; this PR fixes the monitoring gap that made a 5-minute blip look like an overnight outage.

### Description (What does it do?)

CloudWatch alarms only ever told Rootly about the breach, never about the recovery.

`OLCloudWatchAlarmSimpleRDS` and `OLCloudWatchAlarmSimpleElastiCache` both set `alarm_actions` but never `ok_actions`, so the ALARM→OK transition was never published to SNS. Rootly had no way to learn an alarm had cleared, and every alert stayed open until a human closed it by hand.

The practical effect: the `simple-rds-ol-mitlearn-db-production-DiskQueueDepth` alarm went OK→ALARM at 02:07:45 EDT on 2026-08-03 and ALARM→OK at 02:12:45 — five minutes — but the Rootly alert was still open the next morning and read as a sustained overnight incident. Three `simple-elasticache-mitlearn-redis-ci-*-DatabaseMemoryUsagePercentage` alarms have been sitting in ALARM since 2026-06-29 for the same reason.

**Publishing OK alone would have made this worse, so this PR fixes both halves.** The two Rootly CloudWatch alert sources had `resolution_rule_attributes: null` and `deduplicate_alerts_by_key: false`, meaning every SNS notification became a brand new alert. Turning on `ok_actions` without touching Rootly would have added a fresh alert on every recovery instead of closing anything.

Two changes, which must ship together:

1. **`src/ol_infrastructure/components/aws/cloudwatch.py`** — pass `ok_actions=alarm_actions` on both alarm components. It reuses `alarm_actions` directly so the OK routes to the same warning/critical topic as the breach, and so disabling an alarm (`enabled=False`) still silences both.

2. **`src/ol_infrastructure/saas/rootly/__main__.py`** — on both the `Cloudwatch - Critical` and `Cloudwatch - Warning` sources, enable deduplication keyed on `$.Message.AlarmName` and add a resolution rule that closes the alert when `$.Message.NewStateValue` is `OK`.

`AlarmName` is the stable identity of a CloudWatch alarm, so keying on it collapses repeated notifications for one alarm onto a single alert — which also addresses the duplicate-alert noise we get today when an alarm flaps. The `$.Message.` prefix is the same one the existing `CLOUDWATCH_NON_PROD_URGENCY_RULES` already use successfully against this payload shape.

### How can this be tested?

`pulumi preview` on both affected stacks, run against this branch:

`src/ol_infrastructure/applications/mit_learn` (stack `Production`) — 12 alarms updated in place, no replacements:

```
~ aws:cloudwatch/metricAlarm:MetricAlarm: (update)
    [...::ol-mitlearn-db-production-DiskQueueDepth-simple-rds-alarm]
  + okActions: [...]
```

The 12 are the 6 `ol-mitlearn-db-production` RDS alarms (CPUUtilization, ReadLatency, WriteLatency, DiskQueueDepth, FreeStorageSpace, EBSIOBalance%) and the 6 `mitlearn-redis-production-00{1,2,3}` ElastiCache alarms (EngineCPUUtilization, DatabaseMemoryUsagePercentage).

`src/ol_infrastructure/saas/rootly` (stack `Production`) — exactly 2 updates, 148 unchanged:

```
~ rootly:index/alertsSource:AlertsSource: (update)
    [urn=...::cloudwatch-warning]
  + deduplicateAlertsByKey  : true
  + deduplicationKeyPath    : "$.Message.AlarmName"
  + resolutionRuleAttributes: {
      + conditionType          : "all"
      + conditionsAttributes   : [
      +     [0]: {
              + field   : "$.Message.NewStateValue"
              + kind    : "payload"
              + operator: "is"
              + value   : "OK"
            }
        ]
      + enabled                : true
      + identifierJsonPath     : "$.Message.AlarmName"
      + identifierReferenceKind: "payload"
    }
```

`pre-commit run` passes on both files (ruff format, ruff check, mypy, detect-secrets).

**End-to-end validation after merge** — the cheapest real check is a non-prod alarm, because the existing `CLOUDWATCH_NON_PROD_URGENCY_RULES` already demote any alarm whose name contains `-ci-` or `-qa-` to Medium urgency, so nothing pages:

1. Deploy the Rootly stack first, then the application stacks. Ordering matters — if the alarms start publishing OK before Rootly can consume it, recoveries create duplicate alerts.
2. Temporarily lower the threshold on a CI ElastiCache alarm (or wait for a natural flap) so it transitions ALARM→OK.
3. Confirm in Rootly that the existing alert moves to `resolved` rather than a second alert appearing.
4. The three `simple-elasticache-mitlearn-redis-ci-*-DatabaseMemoryUsagePercentage` alarms stuck in ALARM since 2026-06-29 are a convenient natural test — they will emit an OK whenever they next recover.

### Additional Context

**Deploy the Rootly stack before the application stacks.** The two changes are safe in that order and noisy in the reverse order. Nothing enforces this in code.

**Watch for a provider diff loop on `resolutionRuleAttributes`.** There is a known quirk, already documented in this file for the Pingdom source, where the provider normalizes this field into a perpetual no-op diff (observed through provider v5.17.2):

```python
rootly_pingdom_alert_source_opts = ResourceOptions(
    provider=rootly_provider,
    protect=True,
    ignore_changes=["secret", "resolutionRuleAttributes"],
)
```

I deliberately did **not** pre-emptively add `resolutionRuleAttributes` to `ignore_changes` for the CloudWatch sources, because doing so before the first apply would stop the rule from ever being written. If the same churn shows up on these two sources after this lands, the follow-up is to give them their own `ResourceOptions` mirroring the Pingdom one.

**Scope check.** These are the only two `cloudwatch.MetricAlarm` constructors in the repo (`rg -n "MetricAlarm\(" --type py`), and `ok_actions` appeared nowhere before this change, so every CloudWatch alarm we manage was affected and all of them are fixed here.

**Not addressed:** alarms in stacks that have not been redeployed will keep the old behaviour until their next `pulumi up`.
