### PR TITLE
fix(omnigraph): restart the server when the actor-token map changes

### DIFF
--- a/src/ol_infrastructure/applications/omnigraph/__main__.py
+++ b/src/ol_infrastructure/applications/omnigraph/__main__.py
@@ -34,7 +34,13 @@ Follow-up work this stack does NOT cover (tracked separately):
       hand-authored SOPS file, and provisions the ``actor-tokens`` Secret
       destination, but not the job that keeps per-user entries current as
       Keycloak group membership changes — today the SOPS file only ever
-      carries the one ``svc-witan-ci`` entry.
+      carries the one ``svc-witan-ci`` entry. What this stack DOES now cover
+      is the other half of "add a user": the ``actor-tokens`` secret carries
+      ``restart_targets`` so the Vault Secrets Operator bounces
+      omnigraph-server whenever the token map changes (it only reads the map
+      at boot). Whatever eventually writes that Vault path — the sync job, a
+      break-glass ``vault kv put``, or this stack — gets the restart for free
+      and does not need to orchestrate one itself.
 """
 
 import json
@@ -48,6 +54,7 @@ from bridge.secrets import sops as _bridge_sops
 from bridge.secrets.sops import read_yaml_secrets
 from ol_infrastructure.applications.omnigraph.data_tier import (
     COUNCIL_GRAPH_ID,
+    OMNIGRAPH_SERVER_SERVICE_NAME,
     create_data_tier,
     omnigraph_server_addr,
 )
@@ -58,6 +65,7 @@ from ol_infrastructure.components.applications.eks import (
 from ol_infrastructure.components.services.vault import (
     OLVaultK8SSecret,
     OLVaultK8SStaticSecretConfig,
+    OLVaultRestartTarget,
 )
 from ol_infrastructure.lib import pulumi_projects as projects
 from ol_infrastructure.lib.aws.eks_helper import (
@@ -257,6 +265,43 @@ actor_tokens_secret = OLVaultK8SSecret(
             )
         },
         refresh_after="15m",
+        # omnigraph-server SHA-256-hashes the token map once at boot and never
+        # re-reads the file (upstream docs/user/operations/server.md "Auth
+        # model"; there is no SIGHUP, admin endpoint, or runtime registration
+        # — see the upstream ask filed alongside this). So syncing a new token
+        # into the Secret is only half of "add a user": without a restart the
+        # server keeps 401-ing that bearer token indefinitely, even though
+        # witan's own ActorTokenResolver — reading the SAME file — picks it up
+        # on the very next request. The two halves have to be one operation.
+        #
+        # Making that one operation the VSO's job, rather than the (not yet
+        # built) Keycloak token-sync job's, is deliberate:
+        #   - it holds for EVERY writer of the Vault path, not just that job —
+        #     this stack's own SOPS-sourced write, a break-glass `vault kv
+        #     put`, and the sync job alike;
+        #   - the sync job would otherwise need RBAC to patch a Deployment in
+        #     a namespace it has no other business in, and "write Vault" and
+        #     "restart the server" would be two independently-failing steps
+        #     with a silently-stale server as the failure mode;
+        #   - the VSO already owns "Vault content changed -> Secret updated",
+        #     so it is the one controller that can observe the change.
+        # A restart fires only when the rendered Secret content actually
+        # changes, not on every `refresh_after` poll, so steady state is
+        # quiet; 15m is the resulting worst-case onboarding latency.
+        #
+        # BLAST RADIUS, deliberately accepted: the data tier is replicas=1 +
+        # strategy=Recreate (see data_tier.py — its storage is
+        # strict-single-version, so two binaries must never hold the same S3
+        # store), which makes this a hard ~10-30s outage of the graph, not a
+        # rolling one. Every witan MCP call in that window would fail, so it
+        # is paired with connect-failure retry in the client that absorbs the
+        # gap (agent-kit packages/witan-core/witan_core/omnigraph.py,
+        # _UNAVAILABLE_MARKERS: a ~42s budget, connection-ESTABLISHMENT
+        # failures only). Do not shorten refresh_after below the point where
+        # two restarts could overlap that retry budget.
+        restart_targets=[
+            OLVaultRestartTarget(kind="Deployment", name=OMNIGRAPH_SERVER_SERVICE_NAME)
+        ],
         vaultauth=omnigraph_auth_binding.vault_k8s_resources.auth_name,
     ),
     opts=ResourceOptions(

--- a/src/ol_infrastructure/applications/witan/__main__.py
+++ b/src/ol_infrastructure/applications/witan/__main__.py
@@ -268,6 +268,14 @@ actor_tokens_secret = OLVaultK8SSecret(
             )
         },
         refresh_after="15m",
+        # Deliberately NO restart_targets here, unlike the omnigraph stack's
+        # copy of this same secret. The asymmetry is real, not an omission:
+        # witan's ActorTokenResolver (agent-kit
+        # packages/witan-core/witan_core/identity.py) re-stats this file and
+        # reloads it on any cache miss, so a newly-synced actor's token is
+        # live on that actor's very next request with no restart. It is
+        # omnigraph-server that hashes the map once at boot and never looks
+        # again, which is why only that Deployment needs bouncing.
         vaultauth=witan_auth_binding.vault_k8s_resources.auth_name,
     ),
     opts=ResourceOptions(


### PR DESCRIPTION
### What are the relevant tickets?

Resolves witan task `tk-omnigraph-server-actor-token-hot-reload-or-coord-0e878a`, which unblocks `tk-keycloak-witan-users-per-user-omnigraph-token-sy-8e00c7` (the Keycloak `witan-users` → per-user token sync job). Client-side companion: https://github.com/mitodl/agent-kit/pull/174.

### Description (What does it do?)

`omnigraph-server` SHA-256-hashes `OMNIGRAPH_SERVER_BEARER_TOKENS_FILE` once at boot and never re-reads it. Upstream has no SIGHUP handler, admin endpoint, or runtime token registration — confirmed against omnigraph 0.8.1's [`docs/user/operations/server.md`](https://github.com/ModernRelay/omnigraph/blob/main/docs/user/operations/server.md) ("Auth model": tokens hashed on startup, no reload path documented) and [`docs/user/deployment.md`](https://github.com/ModernRelay/omnigraph/blob/main/docs/user/deployment.md) (no poll interval or TTL for any of the three token sources).

So syncing a new per-user token into the Vault-backed `actor-tokens` Secret was only **half** of "add a user". The server kept 401-ing that bearer token indefinitely, while witan's own `ActorTokenResolver` — reading the *same physical file*, and re-stat'ing it on any cache miss — picked it up on that actor's very next request. Adding a user was silently a config write **plus** a coordinated restart, and nothing in the design modelled the pair as one operation.

This makes the Vault Secrets Operator close that gap: `restart_targets=[OLVaultRestartTarget(kind="Deployment", name="omnigraph-server")]` on the `actor-tokens` `VaultStaticSecret`, so VSO bounces the Deployment whenever the *rendered* token map actually changes.

**Why here rather than in the sync job.** The task offered "the sync job triggers the restart as part of its own write path" as the in-our-control option. Putting it on the secret instead is strictly better:

- it holds for **every** writer of `secret-operations/witan/actor-tokens` — the not-yet-built sync job, this stack's own SOPS-sourced write, a break-glass `vault kv put` — not just the one job;
- the sync job would otherwise need RBAC to patch a Deployment in a namespace it has no other business in;
- "write Vault" and "restart the server" would be two independently-failing steps whose failure mode is a **silently stale server**;
- VSO already owns "Vault content changed → Secret updated", so it is the one controller positioned to observe the change.

A restart fires only on a real content change, not on every `refresh_after` poll, so steady state is unaffected; 15m is the resulting worst-case onboarding latency.

**Blast radius — deliberately accepted, and reviewed as the task asked.** The data tier is `replicas=1` + `strategy=Recreate` (strict-single-version storage: two binaries must never hold the same S3 store), so this is a **hard ~10-30s graph outage**, not a rolling one. It is therefore paired with connect-failure retry in the client (agent-kit PR #174: a ~42s jittered budget, connection-*establishment* failures only, so an ambiguous mid-flight write is never silently re-applied). Both the accepted trade-off and the "don't shorten `refresh_after` past this" constraint are recorded inline.

The witan MCP tier's copy of the same secret deliberately gets **no** restart target — witan hot-reloads the file — and a comment there records why that asymmetry is real rather than an omission.

### How can this be tested?

`pulumi preview --stack CI` on `applications/omnigraph` shows exactly the intended one-field diff on the existing resource, no replacement:

```
~ kubernetes:secrets.hashicorp.com/v1beta1:VaultStaticSecret: (update)
    [id=omnigraph/actor-tokens]
  ~ spec: {
      + rolloutRestartTargets: [
      +     [0]: {
              + kind: "Deployment"
              + name: "omnigraph-server"
            }
        ]
    }
```

(The preview also needs `OMNIGRAPH_DOCKER_SHA`, which Concourse supplies via `env_vars_from_files`; with a stub digest the full preview completes clean and the Deployment/Job churn is attributable to that stub, not to this change.)

`prek run` over both touched files: ruff format, ruff check, mypy, detect-secrets all pass.

Post-merge validation: add a throwaway entry to the `actor_tokens` map in `omnigraph/secrets.ci.yaml`, `pulumi up`, and confirm the `omnigraph-server` pod restarts within the `refresh_after` window and then accepts the new bearer token — where before it would have kept rejecting it until manually bounced.

### Additional Context

`restart_targets` / `restart_target_kind` is well-established in this repo — open_metadata, learn_ai, edxapp, dagster, ocw_studio, xqueue, and starrocks (StatefulSet) all use it — so no new VSO RBAC or operator capability is involved.

The clean long-term fix is upstream (a SIGHUP or admin endpoint to reload the token source). A feature request against [ModernRelay/omnigraph](https://github.com/ModernRelay/omnigraph) is being filed; tracked as witan task `tk-upstream-ask-omnigraph-server-runtime-reload-of--e27298`. When it lands, `restart_targets` here can be dropped and the client-side retry stays as general resilience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gu1MY5CuMBu7YttU2RbFMk