### PR TITLE
feat(rootly): adopt the five unmanaged Service Routes into Pulumi

### DIFF
--- a/src/ol_infrastructure/saas/rootly/__main__.py
+++ b/src/ol_infrastructure/saas/rootly/__main__.py
@@ -39,8 +39,16 @@ def rootly_imported_route_opts(route_id: str) -> ResourceOptions:
 
     The Service Routes below were built in the Rootly UI and carry the real
     payload-to-service mappings, so they are adopted rather than created --
-    `import_` makes Pulumi refuse the apply if the declared rules don't match
-    what is live, instead of silently creating a duplicate route alongside it.
+    without `import_` Pulumi would create a second, duplicate route alongside
+    the live one instead of taking ownership of it.
+
+    Note what `import_` does NOT do: it does not refuse an apply when the
+    declared rules disagree with what is live. Pulumi adopts the resource and
+    then plans an update to force the live route to match this file, so a
+    mistake here silently rewrites production routing rather than erroring.
+    Diff the preview before applying; the rule bodies were generated from
+    `GET /v1/alert_routes` precisely so the declared state starts out matching.
+
     Safe to drop back to `rootly_opts` once every stack has applied this.
     """
     return ResourceOptions.merge(rootly_opts, ResourceOptions(import_=route_id))

--- a/src/ol_infrastructure/saas/rootly/__main__.py
+++ b/src/ol_infrastructure/saas/rootly/__main__.py
@@ -4601,3 +4601,21 @@ alert_route_sentry_service_route = rootly.AlertRoute(
     ],
     opts=rootly_imported_route_opts("57544c42-bef8-40f2-99bb-9e5041c0927f"),
 )
+
+# Adopted ONLY so that Pulumi can destroy it. "sh-test" is leftover scratch
+# config from 2026-07-22 with zero rules, which makes it inert -- its source
+# (Grafana Prometheus - CI) is still routed by the Slack Warnings Route above.
+# Pulumi cannot delete a resource it does not manage, so removing it takes two
+# applies: this one adopts it, then a follow-up drops this block and the next
+# apply destroys it. Delete this resource, do not extend it.
+alert_route_sh_test = rootly.AlertRoute(
+    "sh-test",
+    alerts_source_ids=[alerts_source_grafana_prometheus_ci.id],
+    enabled=True,
+    name="sh-test",
+    owning_team_ids=[
+        "9f00e9f1-2f13-470e-a856-50ab5003f260",
+    ],
+    rules=[],
+    opts=rootly_imported_route_opts("08b6b334-1bb4-4f93-830a-0cb99b9b270d"),
+)

--- a/src/ol_infrastructure/saas/rootly/__main__.py
+++ b/src/ol_infrastructure/saas/rootly/__main__.py
@@ -33,6 +33,19 @@ rootly_pingdom_alert_source_opts = ResourceOptions(
     ignore_changes=["secret", "resolutionRuleAttributes"],
 )
 
+
+def rootly_imported_route_opts(route_id: str) -> ResourceOptions:
+    """Adopt an alert route that already exists in Rootly into this stack.
+
+    The Service Routes below were built in the Rootly UI and carry the real
+    payload-to-service mappings, so they are adopted rather than created --
+    `import_` makes Pulumi refuse the apply if the declared rules don't match
+    what is live, instead of silently creating a duplicate route alongside it.
+    Safe to drop back to `rootly_opts` once every stack has applied this.
+    """
+    return ResourceOptions.merge(rootly_opts, ResourceOptions(import_=route_id))
+
+
 # CloudWatch alarms for QA/CI resources (e.g. "mitlearn-redis-qa-003") route
 # through the same shared warning/critical SNS topics as production (see
 # src/ol_infrastructure/lib/aws/monitoring_helper.py) and would otherwise page
@@ -3198,7 +3211,7 @@ alerts_source_platform_engineering_team_email_monitor = rootly.AlertsSource(
 
 alert_route_cloudwatch_catch_all_route = rootly.AlertRoute(
     "cloudwatch-catch-all-route",
-    alerts_source_ids=["6e5745ec-7cef-4a20-a524-cb8829846167"],
+    alerts_source_ids=[alerts_source_cloudwatch_critical.id],
     enabled=True,
     name="Cloudwatch Catch-All Route",
     owning_team_ids=["9f00e9f1-2f13-470e-a856-50ab5003f260"],
@@ -3220,7 +3233,7 @@ alert_route_cloudwatch_catch_all_route = rootly.AlertRoute(
 
 alert_route_grafana_production_catch_all_route = rootly.AlertRoute(
     "grafana-production-catch-all-route",
-    alerts_source_ids=["90cda8ea-ff34-4553-b0c3-8744ee74200d"],
+    alerts_source_ids=[alerts_source_grafana_prometheus_production.id],
     enabled=True,
     name="Grafana Production Catch-All Route",
     owning_team_ids=["9f00e9f1-2f13-470e-a856-50ab5003f260"],
@@ -3242,7 +3255,7 @@ alert_route_grafana_production_catch_all_route = rootly.AlertRoute(
 
 alert_route_pingdom_catch_all_route = rootly.AlertRoute(
     "pingdom-catch-all-route",
-    alerts_source_ids=["0b59c848-f764-4a31-a90f-1d473cc2b134"],
+    alerts_source_ids=[alerts_source_pingdom.id],
     enabled=True,
     name="Pingdom Catch-All Route",
     owning_team_ids=["9f00e9f1-2f13-470e-a856-50ab5003f260"],
@@ -3264,7 +3277,7 @@ alert_route_pingdom_catch_all_route = rootly.AlertRoute(
 
 alert_route_platform_engineering_team_email_monitor_route = rootly.AlertRoute(
     "platform-engineering-team-email-monitor-route",
-    alerts_source_ids=["5933666e-e61e-4339-9b39-41756dafdd00"],
+    alerts_source_ids=[alerts_source_platform_engineering_team_email_monitor.id],
     enabled=True,
     name="Platform Engineering Team Email Monitor Route",
     owning_team_ids=["9f00e9f1-2f13-470e-a856-50ab5003f260"],
@@ -3282,4 +3295,1309 @@ alert_route_platform_engineering_team_email_monitor_route = rootly.AlertRoute(
         }
     ],
     opts=rootly_opts,
+)
+
+# Service Routes adopted from Rootly. Unlike the Catch-All routes above -- whose
+# single fallback rule just hands everything to one escalation policy -- these
+# carry the payload-to-service mappings that decide which team actually owns an
+# alert, so they are the routing config most worth keeping under review.
+#
+# Caveat on individual rules: the provider models a rule as exactly
+# (condition_groups, destinations, fallback_rule, name, position). Rootly's API
+# also returns a per-rule "enabled" flag, but there is no Pulumi field for it, so
+# a rule disabled in the UI stays disabled through an apply -- and equally, that
+# state cannot be enforced from here. Three fallback rules are disabled live
+# today (the Cloudwatch, Grafana Prometheus CI, and Grafana Prometheus QA
+# catch-alls); if that matters it has to be asserted outside this stack.
+alert_route_cloudwatch_service_route = rootly.AlertRoute(
+    "cloudwatch-service-route",
+    alerts_source_ids=[
+        alerts_source_cloudwatch_critical.id,
+        alerts_source_cloudwatch_warning.id,
+    ],
+    enabled=True,
+    name="Cloudwatch Service Route",
+    owning_team_ids=[
+        "9f00e9f1-2f13-470e-a856-50ab5003f260",
+    ],
+    rules=[
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.Message.AlarmName",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "learn-ai",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "dfc02e84-e281-43a6-b340-0e7cadd62036",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "learn-ai AlarmName to MIT Learn AI - Django Webapp",
+            "position": 1,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.Message.AlarmName",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "mitlearn",
+                        },
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.Message.AlarmName",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "rds",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "7b46658d-cd59-4c49-970b-9e9dc8998a7e",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "mitlearn rds AlarmName to MIT Learn - Postgres",
+            "position": 2,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.Message.AlarmName",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "mitlearn",
+                        },
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.Message.AlarmName",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "elasticache",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "0e8c091d-274d-4687-bb70-d85c5600e90b",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "mitlearn elasticache AlarmName to MIT Learn - Redis",
+            "position": 3,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.Message.AlarmName",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "mitlearn",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "c144023f-00c1-48dd-9e38-ad4c302207e3",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "mitlearn AlarmName to MIT Learn - Django Webapp",
+            "position": 4,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.Message.AlarmName",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "mitxonline",
+                        },
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.Message.AlarmName",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "elasticache",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "24abd4d9-4aac-4ea0-afc6-eb2106cc52fd",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "mitxonline elasticache AlarmName to MITx Online Open edX Redis",
+            "position": 5,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.Message.AlarmName",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "mitxonline",
+                        },
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.Message.AlarmName",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "edxapp",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "6ee39557-47af-40e9-a4f7-eccee9406ecf",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "mitxonline edxapp AlarmName to MITx Online Open edX LMS Webapp",
+            "position": 6,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.Message.AlarmName",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "mitxonline",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "db3e4db5-fa3f-4239-a0f4-aa558847df66",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "mitxonline AlarmName to MITx Online - Django Webapp",
+            "position": 7,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.Message.AlarmName",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "xpro",
+                        },
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.Message.AlarmName",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "elasticache",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "aa801b70-0496-4d9e-b889-e5ad99f2237b",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "xpro elasticache AlarmName to MIT XPro Open edX Redis",
+            "position": 8,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.Message.AlarmName",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "xpro",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "0d45ed4d-bd52-4488-9953-f739f18bbdaf",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "xpro AlarmName to MIT XPro Django Webapp",
+            "position": 9,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.Message.AlarmName",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "mitx-qa",
+                        },
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.Message.AlarmName",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "elasticache",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "cc36d725-ecfe-4d37-94f3-55d4e2ef91be",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "mitx-qa elasticache AlarmName to MITx Online QA - Open edX - Redis",  # noqa: E501
+            "position": 10,
+        },
+        {
+            "destinations": [
+                {
+                    "targetId": "96629210-cc41-4e57-b059-b182a0f01c5b",
+                    "targetType": "EscalationPolicy",
+                },
+            ],
+            "fallbackRule": True,
+            "name": "Fallback Rule for Cloudwatch Service Route",
+            "position": 11,
+        },
+    ],
+    opts=rootly_imported_route_opts("61d2fb04-f85f-4d9c-a1bc-1a6afad7ca0f"),
+)
+
+alert_route_grafana_service_route = rootly.AlertRoute(
+    "grafana-service-route",
+    alerts_source_ids=[alerts_source_grafana.id],
+    enabled=True,
+    name="Grafana Service Route",
+    owning_team_ids=[
+        "9f00e9f1-2f13-470e-a856-50ab5003f260",
+    ],
+    rules=[
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.commonLabels.service",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "learn-ai",
+                        },
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.commonLabels.component",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "api",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "2c92b8b0-df02-4369-a876-72a895524773",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "MIT Learn AI API to MIT Learn AI - API Service",
+            "position": 1,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.commonLabels.service",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "learn-ai",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "dfc02e84-e281-43a6-b340-0e7cadd62036",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "MIT Learn AI to MIT Learn AI - Django Webapp Service",
+            "position": 2,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.commonLabels.service",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "mitlearn",
+                        },
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.commonLabels.component",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "api",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "3ad10823-4726-4207-9e99-0d81e87b0473",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "MIT Learn API to MIT Learn - API Service",
+            "position": 3,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.commonLabels.service",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "mitlearn",
+                        },
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.commonLabels.component",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "nextjs",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "b2389961-09be-4167-a304-a2ee1ef9af1b",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "MIT Learn NextJS to NextJS Service",
+            "position": 4,
+        },
+        {
+            "destinations": [
+                {
+                    "targetId": "96629210-cc41-4e57-b059-b182a0f01c5b",
+                    "targetType": "EscalationPolicy",
+                },
+            ],
+            "fallbackRule": True,
+            "name": "Fallback Rule for Grafana Service Route",
+            "position": 5,
+        },
+    ],
+    opts=rootly_imported_route_opts("c1e812d2-e14b-4233-a368-c240e9a03d17"),
+)
+
+alert_route_grafana_production_service_route = rootly.AlertRoute(
+    "grafana-production-service-route",
+    alerts_source_ids=[alerts_source_grafana_prometheus_production.id],
+    enabled=True,
+    name="Grafana Production Service Route",
+    owning_team_ids=[
+        "9f00e9f1-2f13-470e-a856-50ab5003f260",
+    ],
+    rules=[
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.commonLabels.namespace",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "learn-ai",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "dfc02e84-e281-43a6-b340-0e7cadd62036",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "learn-ai namespace to MIT Learn AI - Django Webapp",
+            "position": 1,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.commonLabels.namespace",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "mitlearn",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "c144023f-00c1-48dd-9e38-ad4c302207e3",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "mitlearn namespace to MIT Learn - Django Webapp",
+            "position": 2,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.commonLabels.namespace",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "mitxonline-openedx",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "6ee39557-47af-40e9-a4f7-eccee9406ecf",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "mitxonline-openedx namespace to MITx Online Open edX LMS Webapp",
+            "position": 3,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.commonLabels.namespace",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "mitxonline",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "db3e4db5-fa3f-4239-a0f4-aa558847df66",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "mitxonline namespace to MITx Online - Django Webapp",
+            "position": 4,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.commonLabels.service",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "openedx",
+                        },
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.commonLabels.environment",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "xpro-",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "f42f1288-eca1-4bd4-b474-8a6bb96486fb",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "openedx service + xpro- env to MIT XPro Open edX LMS Webapp",
+            "position": 5,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.commonLabels.service",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "openedx",
+                        },
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.commonLabels.environment",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "mitx-",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "bdbf5e32-61dd-4184-9af6-f4c163e097d0",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "openedx service + mitx- env to MITx Residential Open edX LMS Webapp",  # noqa: E501
+            "position": 6,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.commonLabels.service",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "openedx",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "6ee39557-47af-40e9-a4f7-eccee9406ecf",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "openedx service label to MITx Online Open edX LMS Webapp",
+            "position": 7,
+        },
+        {
+            "destinations": [
+                {
+                    "targetId": "96629210-cc41-4e57-b059-b182a0f01c5b",
+                    "targetType": "EscalationPolicy",
+                },
+            ],
+            "fallbackRule": True,
+            "name": "Fallback Rule for Grafana Production Service Route",
+            "position": 8,
+        },
+    ],
+    opts=rootly_imported_route_opts("e7b002f8-e13f-4b63-b0df-af1c78aee890"),
+)
+
+alert_route_pingdom_service_route = rootly.AlertRoute(
+    "pingdom-service-route",
+    alerts_source_ids=[alerts_source_pingdom.id],
+    enabled=True,
+    name="Pingdom Service Route",
+    owning_team_ids=[
+        "9f00e9f1-2f13-470e-a856-50ab5003f260",
+    ],
+    rules=[
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.check_name",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "learn-ai api",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "2c92b8b0-df02-4369-a876-72a895524773",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "learn-ai api Checks to MIT Learn AI - API",
+            "position": 1,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.check_name",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "learn-ai frontend",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "dfc02e84-e281-43a6-b340-0e7cadd62036",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "learn-ai frontend Checks to MIT Learn AI - Django Webapp",
+            "position": 2,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.check_name",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "Learn AI API",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "2c92b8b0-df02-4369-a876-72a895524773",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "Learn AI API Checks to MIT Learn AI - API",
+            "position": 3,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.check_name",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "Learn API",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "3ad10823-4726-4207-9e99-0d81e87b0473",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "Learn API Checks to MIT Learn - API",
+            "position": 4,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.check_name",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "MIT Learn Open edX",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "6ee39557-47af-40e9-a4f7-eccee9406ecf",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "MIT Learn Open edX Checks to MITx Online Open edX LMS Webapp",
+            "position": 5,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.check_name",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "MITx Online QA",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "6ee39557-47af-40e9-a4f7-eccee9406ecf",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "MITx Online QA edX Checks to MITx Online Open edX LMS Webapp",
+            "position": 6,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.check_name",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "MITx Online RC",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "db3e4db5-fa3f-4239-a0f4-aa558847df66",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "MITx Online RC Checks to MITx Online Django Webapp",
+            "position": 7,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.check_name",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "MITx Online Production edX",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "6ee39557-47af-40e9-a4f7-eccee9406ecf",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "MITx Online Production edX Checks to MITx Online Open edX LMS Webapp",  # noqa: E501
+            "position": 8,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.check_name",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "MITx Online Production",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "db3e4db5-fa3f-4239-a0f4-aa558847df66",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "MITx Online Production Checks to MITx Online Django Webapp",
+            "position": 9,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.check_name",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "MITx QA CMS",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "0f046ecc-a5eb-4cdf-aba2-6922001ad774",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "MITx QA CMS Checks to MITx Online Open edX CMS Webapp",
+            "position": 10,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.check_name",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "MITx production LMS",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "bdbf5e32-61dd-4184-9af6-f4c163e097d0",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "MITx production LMS Checks to MITx Residential Open edX LMS Webapp",  # noqa: E501
+            "position": 11,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.check_name",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "MITx production login",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "bdbf5e32-61dd-4184-9af6-f4c163e097d0",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "MITx production login Checks to MITx Residential Open edX LMS Webapp",  # noqa: E501
+            "position": 12,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.check_name",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "Learn Production",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "c144023f-00c1-48dd-9e38-ad4c302207e3",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "Learn Production Checks to MIT Learn Django Webapp",
+            "position": 13,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.check_name",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "Learn QA",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "c144023f-00c1-48dd-9e38-ad4c302207e3",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "Learn QA Checks to MIT Learn Django Webapp",
+            "position": 14,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.check_name",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "xPro CMS",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "fa1c967f-d271-443f-b2bf-011cc78f5f20",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "xPro CMS Checks to MIT XPro Open edX CMS Webapp",
+            "position": 15,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.check_name",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "xPro LMS",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "f42f1288-eca1-4bd4-b474-8a6bb96486fb",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "xPro LMS Checks to MIT XPro Open edX LMS Webapp",
+            "position": 16,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.check_name",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "xPro",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "0d45ed4d-bd52-4488-9953-f739f18bbdaf",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "xPro Checks to MIT XPro Django Webapp",
+            "position": 17,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.check_name",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "SSO",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "503028e7-d65f-44b6-8968-b9795ccc41c2",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "SSO Checks to Keycloak SSO Webapp",
+            "position": 18,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.check_name",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "Bootcamp",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "dc51f8d3-56fb-4ee3-b921-c9fdda79ea9c",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "Bootcamp Checks to Bootcamp Django Webapp",
+            "position": 19,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.check_name",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "ODL Video",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "defb1faa-e8a4-4fe5-8f03-4103667592f1",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "ODL Video Checks to ODL Video Django Webapp",
+            "position": 20,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.check_name",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "Airbyte",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "5281c3c5-eb5e-4b7f-9407-950570d66261",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "Airbyte Checks to Airbyte Webapp",
+            "position": 21,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.check_name",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "Dagster",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "e7f7e16e-a7e7-4666-b779-96b33bbf402b",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "Dagster Checks to Dagster Webapp",
+            "position": 22,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.check_name",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "Open Discussions",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "9f00e9f1-2f13-470e-a856-50ab5003f260",
+                    "targetType": "Group",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "Open Discussions Checks to Platform Engineering Team (Non-Paging)",
+            "position": 23,
+        },
+        {
+            "destinations": [
+                {
+                    "targetId": "96629210-cc41-4e57-b059-b182a0f01c5b",
+                    "targetType": "EscalationPolicy",
+                },
+            ],
+            "fallbackRule": True,
+            "name": "Fallback Rule for Pingdom Service Route",
+            "position": 24,
+        },
+    ],
+    opts=rootly_imported_route_opts("548c23ea-bcc9-4a83-823e-1563aef5aa14"),
+)
+
+alert_route_sentry_service_route = rootly.AlertRoute(
+    "sentry-service-route",
+    alerts_source_ids=[alerts_source_mitol_sentry.id],
+    enabled=True,
+    name="Sentry Service Route",
+    owning_team_ids=[
+        "9f00e9f1-2f13-470e-a856-50ab5003f260",
+    ],
+    rules=[
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.data.metric_alert.projects[0]",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "openedx-residential",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "bdbf5e32-61dd-4184-9af6-f4c163e097d0",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "openedx-residential project to MITx Residential Open edX LMS Webapp",  # noqa: E501
+            "position": 1,
+        },
+        {
+            "conditionGroups": [
+                {
+                    "conditions": [
+                        {
+                            "propertyFieldConditionType": "contains",
+                            "propertyFieldName": "$.data.metric_alert.projects[0]",
+                            "propertyFieldType": "payload",
+                            "propertyFieldValue": "mitxonline",
+                        },
+                    ],
+                    "position": 1,
+                },
+            ],
+            "destinations": [
+                {
+                    "targetId": "db3e4db5-fa3f-4239-a0f4-aa558847df66",
+                    "targetType": "Service",
+                },
+            ],
+            "fallbackRule": False,
+            "name": "mitxonline project to MITx Online - Django Webapp",
+            "position": 2,
+        },
+        {
+            "destinations": [
+                {
+                    "targetId": "96629210-cc41-4e57-b059-b182a0f01c5b",
+                    "targetType": "EscalationPolicy",
+                },
+            ],
+            "fallbackRule": True,
+            "name": "Fallback Rule for Sentry Service Route",
+            "position": 3,
+        },
+    ],
+    opts=rootly_imported_route_opts("57544c42-bef8-40f2-99bb-9e5041c0927f"),
 )


### PR DESCRIPTION
### What are the relevant tickets?

Closes #5217

### Description (What does it do?)

Rootly has 12 alert routes. This stack managed 6, and the split fell the wrong way: the managed ones were the Catch-Alls, whose single fallback rule just hands everything to one escalation policy, while the unmanaged ones were the Service Routes holding all 51 rules that decide which team actually owns an alert.

That includes the rule that routed the mit-learn `DiskQueueDepth` page on 2026-08-03:

```
"mitlearn rds AlarmName to MIT Learn - Postgres"   (rule 7f9c9d1c-da85-4434-826c-31cd0c34db37)
  $.Message.AlarmName contains "mitlearn" AND contains "rds"
  -> Service 7b46658d-cd59-4c49-970b-9e9dc8998a7e
```

Editable in the Rootly UI with no review and no diff, and nothing in the repo recorded that it existed.

**Six routes adopted, 51 rules:**

| Route | ID | Sources | Rules |
|---|---|---|---|
| Cloudwatch Service Route | `61d2fb04` | critical + warning | 11 |
| Pingdom Service Route | `548c23ea` | pingdom | 24 |
| Grafana Production Service Route | `e7b002f8` | grafana-prometheus-production | 8 |
| Grafana Service Route | `c1e812d2` | grafana | 5 |
| Sentry Service Route | `57544c42` | mitol-sentry | 3 |
| `sh-test` (adopted only to be destroyed — see below) | `08b6b334` | grafana-prometheus-ci | 0 |

They are adopted with `import_` (via the new `rootly_imported_route_opts` helper) rather than declared as fresh resources, so Pulumi takes ownership of the live routes instead of creating a second, duplicate set alongside them. Once every stack has applied this, the helper can be swapped back to plain `rootly_opts`.

> **Correction (thanks @copilot-pull-request-reviewer).** An earlier revision of this PR and the helper docstring claimed `import_` makes Pulumi *refuse* the apply on drift. That is wrong, and wrong in the unsafe direction — [the docs](https://www.pulumi.com/docs/iac/concepts/options/import/) state "if the resource's arguments differ from the imported state, the import will succeed, and the resource will then be modified to reflect the inputs in your Pulumi program." So a mistake in these rule bodies would silently **rewrite production routing**, not error. That is the reason the bodies were generated from `GET /v1/alert_routes` rather than typed by hand, and the reason the zero-diff preview below is the thing to check before applying. Docstring corrected in 7b23c335d.

The rule bodies were generated directly from `GET /v1/alert_routes` rather than transcribed by hand, so they match the live config by construction.

**Also:** replaces the four remaining hardcoded source UUIDs in `alerts_source_ids` (`__main__.py:3201`, `:3223`, `:3245`, `:3267` pre-change) with references to the managed `alerts_source_*` resources. These resolve to identical values today, so it is dependency-ordering and readability rather than behaviour — preview confirms no diff. This is the nitpick a bot raised on #5213, done here where it belongs instead of as a drive-by on an unrelated PR.

### How can this be tested?

`pulumi preview --stack Production` in `src/ol_infrastructure/saas/rootly`:

```
Resources:
    ~ 2 to update
    = 6 to import
    8 changes. 148 unchanged
```

- **`= 6 to import`** — the five Service Routes plus `sh-test`, with **zero property-diff markers** anywhere in their blocks. Grepping the preview for drift markers (`^\s+[~-] [a-zA-Z]`) returns exactly 2 hits, both at lines 4 and 24, i.e. before the first import block at line 44. So the declared rules match live exactly.
- **`~ 2 to update`** — these are **not** from this PR. They are #5213's `deduplicateAlertsByKey` / `resolutionRuleAttributes` change on the two CloudWatch sources, which is merged but not yet deployed to this stack. Whoever applies this will apply that at the same time.
- The four UUID→reference swaps produce no diff at all, confirming they are value-identical.

`pre-commit run` passes (ruff format, ruff check, mypy, detect-secrets).

**This resolves the round-trip risk flagged in #5217.** The file already carries two provider-normalization workarounds (`ignore_changes=["secret"]` on all alert sources, plus `resolutionRuleAttributes` for Pingdom), so a no-op-diff loop on rule bodies was a plausible failure mode. It does not reproduce — `AlertRouteRule` round-trips cleanly across all 51 rules.

### Additional Context

**Answering #5217's question about the disabled fallback rules:** the concern was that an apply might silently re-enable the Cloudwatch catch-all's fallback rule and start paging escalation policy `96629210-…`. That cannot happen, because the provider does not model the field:

```python
>>> sorted(inspect.signature(AlertRouteRule.__init__).parameters)[1:]
['condition_groups', 'destinations', 'fallback_rule', 'name', 'position']
```

Rootly's API returns a per-rule `enabled` flag; Pulumi has no field for it. So a rule disabled in the UI stays disabled through an apply — and equally, **that state cannot be enforced from this stack**. Three fallback rules are disabled live today (Cloudwatch, Grafana Prometheus CI, and Grafana Prometheus QA catch-alls). All three are on already-managed routes and show no diff in preview, which confirms the behaviour empirically. This is documented in a comment rather than fixed, since fixing it would need a provider change.

**`sh-test` (`08b6b334`) is adopted here only so it can be destroyed.** It is leftover scratch config from 2026-07-22 with zero rules, which makes it inert — its source (Grafana Prometheus - CI) is still routed by the Slack Warnings Route, so nothing is orphaned when it goes.

Pulumi cannot delete a resource it does not manage, so removing it takes two applies:

1. **This PR** adopts it (`= 6 to import`).
2. **A follow-up PR**, opened only *after* this one is merged **and applied**, drops the `alert_route_sh_test` block so the next apply destroys it.

Sequencing matters: if the follow-up merges before this one is applied, Pulumi never imported the route and the deletion is a no-op, leaving `sh-test` alive and unmanaged again. The code comment on the resource says the same thing so nobody extends it by mistake.

**Deploy note carried over from #5213:** the Rootly stack should be applied before the application stacks. Nothing enforces this in code, and neither stack auto-applies (`.github/workflows/` contains only `pytest.yml`, and `saas/rootly` is not registered in `pulumi_projects.py`), so it is a manual sequencing step.
