### PR TITLE
fix(apisix): give MIT Learn's gateway session cookie an environment-scoped name

### DIFF
--- a/src/bridge/lib/constants.py
+++ b/src/bridge/lib/constants.py
@@ -14,3 +14,37 @@ FASTLY_A_TLS_1_3 = [
     IPv4Address("151.101.130.132"),
     IPv4Address("151.101.194.132"),
 ]
+
+
+def mit_learn_session_cookie_name(env_suffix: str) -> str:
+    """Return the APISIX OIDC session cookie name for a MIT Learn environment.
+
+    APISIX's openid-connect plugin (lua-resty-session 4.x) names its session
+    cookie ``session`` by default.  That is a problem for MIT Learn for two
+    reasons:
+
+    * It is generic enough to collide with any other ``session`` cookie a
+      *.mit.edu host sets, and it says nothing about which system owns it when
+      debugging an oversized/garbled Cookie header.
+    * MIT Learn's session cookie is deliberately scoped to the parent domain
+      (``.learn.mit.edu``) so it also reaches sibling subdomains, which means
+      the Production cookie is sent to ``api.rc.learn.mit.edu`` and
+      ``api.ci.learn.mit.edu`` as well.  Under a single shared name the three
+      environments' cookies stack up on those hosts and the gateway can be
+      handed a session envelope it cannot decrypt (each environment has its own
+      session secret).  Giving every environment its own name keeps them
+      distinct in the browser's cookie jar.
+
+    Every APISIX OIDC resource that participates in the shared MIT Learn login
+    session must use the same name for a given environment: mit-learn's own
+    routes, learn-ai's ``/ai/*`` routes and ol-analytics-api's Learn-scoped
+    host all share the ``sso/mitlearn`` Keycloak client and read the cookie
+    mit-learn set, so a mismatch silently turns their ``unauth_action="pass"``
+    routes into anonymous ones.
+
+    :param env_suffix: The lowercase stack environment suffix, e.g. ``"qa"``.
+
+    :returns: The session cookie name for that environment.
+    :rtype: str
+    """
+    return f"mitlearn_session_{env_suffix.lower()}"

--- a/src/bridge/lib/constants.py
+++ b/src/bridge/lib/constants.py
@@ -16,35 +16,78 @@ FASTLY_A_TLS_1_3 = [
 ]
 
 
-def mit_learn_session_cookie_name(env_suffix: str) -> str:
-    """Return the APISIX OIDC session cookie name for a MIT Learn environment.
+# The cookie name lua-resty-session 4.x -- and therefore APISIX's
+# openid-connect plugin -- uses when nothing sets ``session.cookie_name``.
+# Every application that has since moved to an explicit name left one of these
+# behind in its users' browsers; see ``stale_session_cookie_cleanup_plugin`` in
+# ol_infrastructure.components.services.apisix for how they get evicted.
+DEFAULT_OIDC_SESSION_COOKIE_NAME = "session"  # pragma: allowlist secret
+
+
+def apisix_oidc_session_cookie_name(application: str, env_suffix: str) -> str:
+    """Return the APISIX OIDC session cookie name for an application/environment.
 
     APISIX's openid-connect plugin (lua-resty-session 4.x) names its session
-    cookie ``session`` by default.  That is a problem for MIT Learn for two
+    cookie ``session`` by default.  That is a poor default for us for two
     reasons:
 
     * It is generic enough to collide with any other ``session`` cookie a
       *.mit.edu host sets, and it says nothing about which system owns it when
       debugging an oversized/garbled Cookie header.
-    * MIT Learn's session cookie is deliberately scoped to the parent domain
-      (``.learn.mit.edu``) so it also reaches sibling subdomains, which means
-      the Production cookie is sent to ``api.rc.learn.mit.edu`` and
-      ``api.ci.learn.mit.edu`` as well.  Under a single shared name the three
+    * Several of our session cookies are deliberately scoped to a parent domain
+      (``.learn.mit.edu``, ``.mitxonline.mit.edu``) so they reach sibling
+      subdomains, which means the Production cookie is also sent to the RC and
+      CI hosts under that parent.  Under a single shared name the three
       environments' cookies stack up on those hosts and the gateway can be
       handed a session envelope it cannot decrypt (each environment has its own
       session secret).  Giving every environment its own name keeps them
       distinct in the browser's cookie jar.
 
-    Every APISIX OIDC resource that participates in the shared MIT Learn login
-    session must use the same name for a given environment: mit-learn's own
-    routes, learn-ai's ``/ai/*`` routes and ol-analytics-api's Learn-scoped
-    host all share the ``sso/mitlearn`` Keycloak client and read the cookie
-    mit-learn set, so a mismatch silently turns their ``unauth_action="pass"``
-    routes into anonymous ones.
+    Production is unsuffixed (``mitlearn_session``) to match how the rest of
+    the codebase names user-visible, environment-scoped strings -- compare the
+    ``learn_csrftoken`` / ``learn_rc_csrftoken`` pair.  That is safe precisely
+    because the non-production names *are* suffixed: a Production
+    ``.learn.mit.edu`` cookie riding along to ``api.rc.learn.mit.edu`` is
+    called ``mitlearn_session`` there, which is not the name the RC gateway
+    reads (``mitlearn_session_qa``), so the two never contend.
 
-    :param env_suffix: The lowercase stack environment suffix, e.g. ``"qa"``.
+    :param application: Slug of the application owning the session, e.g.
+        ``"mitlearn"``.  Hyphens are normalised to underscores.
+    :param env_suffix: The stack environment suffix, e.g. ``"qa"``.
 
-    :returns: The session cookie name for that environment.
+    :returns: The session cookie name for that application and environment.
     :rtype: str
     """
-    return f"mitlearn_session_{env_suffix.lower()}"
+    base = f"{application.replace('-', '_')}_session"
+    env = env_suffix.lower()
+    return base if env == "production" else f"{base}_{env}"
+
+
+def mit_learn_session_cookie_name(env_suffix: str) -> str:
+    """Return the APISIX OIDC session cookie name for a MIT Learn environment.
+
+    Every APISIX OIDC resource that participates in the shared MIT Learn login
+    session must use the same name for a given environment, so they all call
+    this rather than building the name themselves:
+
+    * mit-learn's own prefixed and un-prefixed routes on
+      ``api.<env>.learn.mit.edu``, which perform the login,
+    * learn-ai's ``/ai/*`` routes, served from that same host,
+    * ol-analytics-api's Learn-scoped host, and
+    * mitxonline's ``/mitxonline/*`` routes, which are served from
+      ``api.<env>.learn.mit.edu`` too and are what the MIT Learn frontend calls
+      as ``NEXT_PUBLIC_MITX_ONLINE_BASE_URL``.
+
+    All of them share the ``sso/mitlearn`` Keycloak client (and therefore the
+    session secret) and read the cookie mit-learn's login flow set, so a
+    mismatch silently turns their ``unauth_action="pass"`` routes into
+    anonymous ones.  mitxonline's *other* OIDC resource -- the one behind its
+    own ``*.mitxonline.mit.edu`` login -- is a separate session on a separate
+    parent domain and deliberately does not use this name.
+
+    :param env_suffix: The stack environment suffix, e.g. ``"qa"``.
+
+    :returns: The shared MIT Learn session cookie name for that environment.
+    :rtype: str
+    """
+    return apisix_oidc_session_cookie_name("mitlearn", env_suffix)

--- a/src/bridge/lib/constants.py
+++ b/src/bridge/lib/constants.py
@@ -43,13 +43,20 @@ def apisix_oidc_session_cookie_name(application: str, env_suffix: str) -> str:
       session secret).  Giving every environment its own name keeps them
       distinct in the browser's cookie jar.
 
-    Production is unsuffixed (``mitlearn_session``) to match how the rest of
-    the codebase names user-visible, environment-scoped strings -- compare the
-    ``learn_csrftoken`` / ``learn_rc_csrftoken`` pair.  That is safe precisely
-    because the non-production names *are* suffixed: a Production
-    ``.learn.mit.edu`` cookie riding along to ``api.rc.learn.mit.edu`` is
-    called ``mitlearn_session`` there, which is not the name the RC gateway
-    reads (``mitlearn_session_qa``), so the two never contend.
+    The ``apisix`` segment names the gateway as the owner.  The application
+    behind it sets cookies of its own on the same host -- mit-learn's Django
+    app is the obvious case -- and when the question in front of you is which
+    component wrote an oversized Cookie header, ``mitlearn_apisix_session``
+    answers it and ``mitlearn_session`` does not.
+
+    Production is unsuffixed (``mitlearn_apisix_session``) to match how the
+    rest of the codebase names user-visible, environment-scoped strings --
+    compare the ``learn_csrftoken`` / ``learn_rc_csrftoken`` pair.  That is
+    safe precisely because the non-production names *are* suffixed: a
+    Production ``.learn.mit.edu`` cookie riding along to
+    ``api.rc.learn.mit.edu`` is called ``mitlearn_apisix_session`` there, which
+    is not the name the RC gateway reads (``mitlearn_apisix_session_qa``), so
+    the two never contend.
 
     :param application: Slug of the application owning the session, e.g.
         ``"mitlearn"``.  Hyphens are normalised to underscores.
@@ -58,7 +65,7 @@ def apisix_oidc_session_cookie_name(application: str, env_suffix: str) -> str:
     :returns: The session cookie name for that application and environment.
     :rtype: str
     """
-    base = f"{application.replace('-', '_')}_session"
+    base = f"{application.replace('-', '_')}_apisix_session"
     env = env_suffix.lower()
     return base if env == "production" else f"{base}_{env}"
 

--- a/src/ol_infrastructure/applications/jupyterhub/deployment.py
+++ b/src/ol_infrastructure/applications/jupyterhub/deployment.py
@@ -8,6 +8,7 @@ import pulumi_kubernetes as kubernetes
 import pulumi_vault as vault
 from pulumi import Config, ResourceOptions, StackReference
 
+from bridge.lib.constants import apisix_oidc_session_cookie_name
 from bridge.lib.magic_numbers import DEFAULT_POSTGRES_PORT
 from bridge.lib.versions import JUPYTERHUB_CHART_VERSION
 from ol_infrastructure.applications.jupyterhub.values import (
@@ -22,6 +23,7 @@ from ol_infrastructure.components.services.apisix import (
     OLApisixRouteConfig,
     OLApisixSharedPlugins,
     OLApisixSharedPluginsConfig,
+    stale_session_cookie_cleanup_plugin,
 )
 from ol_infrastructure.components.services.cert_manager import (
     OLCertManagerCert,
@@ -176,6 +178,15 @@ def provision_jupyterhub_deployment(  # noqa: PLR0913
             k8s_namespace=namespace,
             k8s_labels=application_labels,
             enable_defaults=True,
+            plugins=[
+                # Evict the host-only cookie the OIDC resource below used to
+                # set under lua-resty-session's default name.  No cookie_domains
+                # here: this deployment's cookie was never scoped to a parent
+                # domain, and the .learn.mit.edu entry that also reaches this
+                # host belongs to mit-learn, which clears it from its own
+                # routes.  Safe to delete once the old cookies have aged out.
+                stale_session_cookie_cleanup_plugin(),
+            ],
         ),
     )
 
@@ -205,6 +216,16 @@ def provision_jupyterhub_deployment(  # noqa: PLR0913
             oidc_logout_path="hub/logout",
             oidc_post_logout_redirect_uri=f"https://{domain_name}/hub/login",
             oidc_session_absolute_timeout=60 * 20160,
+            # Named rather than left on lua-resty-session's default "session".
+            # This host sits under .learn.mit.edu, so the browser also delivers
+            # mit-learn's parent-domain session cookie here; while both were
+            # called "session" the gateway was picking whichever of the two the
+            # browser happened to send first.  Per deployment, since
+            # nb. and authoring.nb. are separate hosts with separate logins.
+            oidc_session_cookie_name=apisix_oidc_session_cookie_name(
+                base_name,
+                stack_info.env_suffix,
+            ),
             oidc_session_idling_timeout=0,
             oidc_session_rolling_timeout=0,
             oidc_use_session_secret=True,

--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -20,7 +20,7 @@ from pulumi import (
 )
 from pulumi_aws import ec2, get_caller_identity, iam, route53, s3
 
-from bridge.lib.constants import FASTLY_A_TLS_1_3
+from bridge.lib.constants import FASTLY_A_TLS_1_3, mit_learn_session_cookie_name
 from bridge.lib.magic_numbers import (
     DEFAULT_HTTPS_PORT,
     DEFAULT_REDIS_PORT,
@@ -927,6 +927,14 @@ learn_ai_oidc_resources = OLApisixOIDCResources(
         oidc_post_logout_redirect_uri="/",
         oidc_session_idling_timeout=0,
         oidc_session_rolling_timeout=0,
+        # The /ai/* routes below are served from mit-learn's own host
+        # (api.<env>.learn.mit.edu) and their unauth_action="pass" plugins
+        # recognize the session mit-learn's login flow set, which is only
+        # possible while both name the cookie identically -- so this must
+        # track mit_learn/__main__.py's oidc_session_cookie_name.
+        oidc_session_cookie_name=mit_learn_session_cookie_name(
+            stack_info.env_suffix,
+        ),
         oidc_use_session_secret=True,
         vault_mount="secret-operations",
         vault_mount_type="kv-v1",

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -21,7 +21,11 @@ from pulumi import (
 from pulumi.output import Output
 from pulumi_aws import ec2, iam, route53, s3
 
-from bridge.lib.constants import FASTLY_A_TLS_1_3, FASTLY_CNAME_TLS_1_3
+from bridge.lib.constants import (
+    FASTLY_A_TLS_1_3,
+    FASTLY_CNAME_TLS_1_3,
+    mit_learn_session_cookie_name,
+)
 from bridge.lib.magic_numbers import (
     DEFAULT_HTTPS_PORT,
     DEFAULT_POSTGRES_PORT,
@@ -1621,6 +1625,15 @@ mitlearn_k8s_app_oidc_resources_no_prefix = OLApisixOIDCResources(
         # shares this same "sso/mitlearn" Vault path/client and mirrors this
         # cookie domain.
         oidc_session_cookie_domain=mitlearn_api_domain.removeprefix("api"),
+        # Environment-scoped name instead of lua-resty-session's default
+        # "session". Required because of the broadened cookie domain above:
+        # a *.learn.mit.edu cookie is also sent to the RC and CI hosts, where
+        # a same-named cookie from another environment cannot be decrypted.
+        # Shared with learn-ai and ol-analytics-api -- see the helper's
+        # docstring.
+        oidc_session_cookie_name=mit_learn_session_cookie_name(
+            stack_info.env_suffix,
+        ),
         oidc_use_session_secret=True,
         vault_mount="secret-operations",
         vault_mount_type="kv-v1",
@@ -1638,10 +1651,13 @@ mitlearn_k8s_app_oidc_resources = OLApisixOIDCResources(
         oidc_post_logout_redirect_uri=f"https://{mitlearn_config.get('api_domain')}/learn/logout/",
         oidc_session_absolute_timeout=60 * 20160,
         # See the mitlearn-k8s-no-prefix resources above for why these are 0,
-        # and for the cookie domain below.
+        # and for the cookie domain and name below.
         oidc_session_idling_timeout=0,
         oidc_session_rolling_timeout=0,
         oidc_session_cookie_domain=mitlearn_api_domain.removeprefix("api"),
+        oidc_session_cookie_name=mit_learn_session_cookie_name(
+            stack_info.env_suffix,
+        ),
         oidc_use_session_secret=True,
         vault_mount="secret-operations",
         vault_mount_type="kv-v1",

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -54,6 +54,7 @@ from ol_infrastructure.components.services.apisix import (
     OLApisixRouteConfig,
     OLApisixSharedPlugins,
     OLApisixSharedPluginsConfig,
+    stale_session_cookie_cleanup_plugin,
 )
 from ol_infrastructure.components.services.cert_manager import (
     OLCertManagerCert,
@@ -1313,6 +1314,23 @@ learn_external_service_shared_plugins = OLApisixSharedPlugins(
         k8s_namespace=learn_namespace,
         k8s_labels=application_labels,
         enable_defaults=True,
+        plugins=[
+            # Everyone currently logged in is holding a session cookie under
+            # lua-resty-session's old default name, which the renamed plugins
+            # below now ignore -- it would otherwise sit in their browser
+            # unread until they fully quit it.  Both variants have to go: the
+            # host-only one predates the move to a parent-domain cookie in
+            # #5182 (and is also what mitxonline's /mitxonline/* routes on this
+            # host used to set), and the domain-scoped one is what #5182
+            # replaced it with.  Every route on this host references this
+            # shared config, and clearing the .learn.mit.edu entry from here
+            # also clears it for analytics.<env>.learn.mit.edu, since a
+            # domain-scoped cookie is a single entry in the browser's jar.
+            # Safe to delete once the old cookies have aged out of circulation.
+            stale_session_cookie_cleanup_plugin(
+                cookie_domains=[mitlearn_api_domain.removeprefix("api")],
+            ),
+        ],
     ),
 )
 

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -24,6 +24,10 @@ from pulumi import (
 )
 from pulumi_aws import ec2, iam, route53, s3
 
+from bridge.lib.constants import (
+    apisix_oidc_session_cookie_name,
+    mit_learn_session_cookie_name,
+)
 from bridge.lib.magic_numbers import (
     DEFAULT_POSTGRES_PORT,
     DEFAULT_REDIS_PORT,
@@ -46,6 +50,7 @@ from ol_infrastructure.components.services.apisix import (
     OLApisixRouteConfig,
     OLApisixSharedPlugins,
     OLApisixSharedPluginsConfig,
+    stale_session_cookie_cleanup_plugin,
 )
 from ol_infrastructure.components.services.cert_manager import (
     OLCertManagerCert,
@@ -694,6 +699,17 @@ mitxonline_direct_oidc = OLApisixOIDCResources(
         oidc_post_logout_redirect_uri=f"https://{api_domain}/logout/",
         oidc_session_absolute_timeout=60 * 20160,
         oidc_session_cookie_domain=api_domain.removeprefix("api"),
+        # This is MITx Online's own login session, on its own parent domain --
+        # distinct from the MIT Learn session the prefixed resources below read,
+        # so it gets its own name rather than the shared one.  It needs an
+        # explicit name for the same reason mit-learn does: the cookie domain
+        # above means the Production cookie is also sent to
+        # rc./ci.mitxonline.mit.edu, where a same-named cookie belonging to
+        # another environment cannot be decrypted.
+        oidc_session_cookie_name=apisix_oidc_session_cookie_name(
+            "mitxonline",
+            stack_info.env_suffix,
+        ),
         oidc_session_idling_timeout=0,
         oidc_session_rolling_timeout=0,
         oidc_use_session_secret=True,
@@ -712,6 +728,24 @@ mitxonline_prefixed_oidc_resources = OLApisixOIDCResources(
         oidc_logout_path=f"/{api_path_prefix}/logout/oidc",
         oidc_post_logout_redirect_uri=f"https://{api_domain}/{api_path_prefix}/logout/",
         oidc_session_absolute_timeout=60 * 20160,
+        # These routes are served from MIT Learn's own host
+        # (api.<env>.learn.mit.edu, see learn_api_domain below) and are what the
+        # MIT Learn frontend calls as NEXT_PUBLIC_MITX_ONLINE_BASE_URL.  Their
+        # unauth_action="pass" plugins recognize the session mit-learn's login
+        # flow set, which only works while both name the cookie identically --
+        # so this must track mit_learn/__main__.py's oidc_session_cookie_name,
+        # not the mitxonline name used above.
+        oidc_session_cookie_name=mit_learn_session_cookie_name(
+            stack_info.env_suffix,
+        ),
+        # Matching mit_learn/__main__.py's cookie domain matters as much as
+        # matching its name.  The "reqauth" route below performs a real login
+        # (unauth_action="auth" on /mitxonline/login/), and without a domain the
+        # plugin would write a *host-only* cookie on api.<env>.learn.mit.edu
+        # under the shared name -- a second, separate entry in the browser's jar
+        # shadowing mit-learn's .learn.mit.edu cookie on that host.  With the
+        # domain set, all of them read and write the one shared cookie.
+        oidc_session_cookie_domain=learn_backend_domain.removeprefix("api"),
         oidc_session_idling_timeout=0,
         oidc_session_rolling_timeout=0,
         oidc_use_session_secret=True,
@@ -752,6 +786,21 @@ response_rewrite_plugin_config = OLApisixPluginConfig(
         }
     },
 )
+
+# Both OIDC resources above moved off lua-resty-session's default "session"
+# cookie name, so every current user has a dead one in their browser.  The two
+# route groups need different deletions because a cookie's identity includes its
+# domain: the direct routes' cookie was scoped to the mitxonline parent domain,
+# while the prefixed routes' was host-only on MIT Learn's API host.  These are
+# attached per route group rather than to mitxonline_shared_plugins because that
+# config is referenced from both groups, and a Domain=.mitxonline.mit.edu
+# deletion emitted from api.<env>.learn.mit.edu is simply rejected by the
+# browser.  Safe to delete once the old cookies have aged out of circulation.
+direct_stale_session_cleanup = stale_session_cookie_cleanup_plugin(
+    cookie_domains=[api_domain.removeprefix("api")],
+)
+prefixed_stale_session_cleanup = stale_session_cookie_cleanup_plugin()
+
 mitxonline_apisix_route_direct = OLApisixRoute(
     name=f"mitxonline-apisix-route-direct-{stack_info.env_suffix}",
     k8s_namespace=mitxonline_namespace,
@@ -768,6 +817,7 @@ mitxonline_apisix_route_direct = OLApisixRoute(
                     unauth_action="pass"
                 ),
                 response_rewrite_plugin_config,
+                direct_stale_session_cleanup,
             ],
             backend_service_name=mitxonline_k8s_app.application_lb_service_name,
             backend_service_port=mitxonline_k8s_app.application_lb_service_port_name,
@@ -780,6 +830,7 @@ mitxonline_apisix_route_direct = OLApisixRoute(
             plugins=[
                 OLApisixPluginConfig(name="redirect", config={"uri": "/logout/oidc"}),
                 response_rewrite_plugin_config,
+                direct_stale_session_cleanup,
             ],
             shared_plugin_config_name=mitxonline_shared_plugins.resource_name,
             backend_service_name=mitxonline_k8s_app.application_lb_service_name,
@@ -795,6 +846,7 @@ mitxonline_apisix_route_direct = OLApisixRoute(
                     unauth_action="auth"
                 ),
                 response_rewrite_plugin_config,
+                direct_stale_session_cleanup,
             ],
             shared_plugin_config_name=mitxonline_shared_plugins.resource_name,
             backend_service_name=mitxonline_k8s_app.application_lb_service_name,
@@ -814,6 +866,7 @@ mitxonline_apisix_route_direct = OLApisixRoute(
                     unauth_action="auth"
                 ),
                 response_rewrite_plugin_config,
+                direct_stale_session_cleanup,
             ],
             shared_plugin_config_name=mitxonline_shared_plugins.resource_name,
             backend_service_name=mitxonline_k8s_app.application_lb_service_name,
@@ -844,6 +897,7 @@ mitxonline_apisix_route_prefix = OLApisixRoute(
                     unauth_action="pass"
                 ),
                 response_rewrite_plugin_config,
+                prefixed_stale_session_cleanup,
             ],
             backend_service_name=mitxonline_k8s_app.application_lb_service_name,
             backend_service_port=mitxonline_k8s_app.application_lb_service_port_name,
@@ -856,6 +910,7 @@ mitxonline_apisix_route_prefix = OLApisixRoute(
             plugins=[
                 OLApisixPluginConfig(name="redirect", config={"uri": "/logout/oidc"}),
                 response_rewrite_plugin_config,
+                prefixed_stale_session_cleanup,
             ],
             shared_plugin_config_name=mitxonline_shared_plugins.resource_name,
             backend_service_name=mitxonline_k8s_app.application_lb_service_name,
@@ -877,6 +932,7 @@ mitxonline_apisix_route_prefix = OLApisixRoute(
                     unauth_action="auth"
                 ),
                 response_rewrite_plugin_config,
+                prefixed_stale_session_cleanup,
             ],
             shared_plugin_config_name=mitxonline_shared_plugins.resource_name,
             backend_service_name=mitxonline_k8s_app.application_lb_service_name,

--- a/src/ol_infrastructure/applications/ol_analytics_api/__main__.py
+++ b/src/ol_infrastructure/applications/ol_analytics_api/__main__.py
@@ -70,6 +70,7 @@ import pulumi_vault as vault
 from pulumi import Config, Output, ResourceOptions, export
 from pulumi_aws import ec2
 
+from bridge.lib.constants import mit_learn_session_cookie_name
 from ol_infrastructure.components.applications.eks import (
     OLEKSAuthBinding,
     OLEKSAuthBindingConfig,
@@ -554,6 +555,12 @@ if ol_analytics_api_learn_domain:
             oidc_session_rolling_timeout=0,
             oidc_session_cookie_domain=ol_analytics_api_learn_domain.removeprefix(
                 "analytics"
+            ),
+            # Same reason as the cookie domain above: this host reads the
+            # cookie mit-learn's login flow set, so the name has to match
+            # mit_learn/__main__.py's oidc_session_cookie_name exactly.
+            oidc_session_cookie_name=mit_learn_session_cookie_name(
+                stack_info.env_suffix,
             ),
             oidc_use_session_secret=True,
             vault_mount="secret-operations",

--- a/src/ol_infrastructure/components/services/apisix.py
+++ b/src/ol_infrastructure/components/services/apisix.py
@@ -209,6 +209,11 @@ class OLApisixOIDCConfig(BaseModel):
         "user": True,
     }
     oidc_session_cookie_domain: str | None = None
+    # None leaves lua-resty-session's default cookie name ("session") in
+    # place. Applications that share a parent domain with other environments
+    # or other applications should set an explicit, environment-scoped name so
+    # their session cookies stay distinct in the browser's cookie jar.
+    oidc_session_cookie_name: str | None = None
     oidc_session_absolute_timeout: NonNegativeInt = 0
     # None leaves lua-resty-session's compiled-in defaults (900s idling /
     # 3600s rolling) untouched for callers that haven't opted in. 0
@@ -281,6 +286,13 @@ class OLApisixOIDCResources(ComponentResource):
         if oidc_config.oidc_session_cookie_domain:
             session_config.setdefault("session", {})["cookie_domain"] = (
                 oidc_config.oidc_session_cookie_domain
+            )
+
+        # Flat session.cookie_name, same lua-resty-session 4.x schema as
+        # cookie_domain above. Defaults to "session" in the plugin when unset.
+        if oidc_config.oidc_session_cookie_name:
+            session_config.setdefault("session", {})["cookie_name"] = (
+                oidc_config.oidc_session_cookie_name
             )
 
         if oidc_config.oidc_session_absolute_timeout:

--- a/src/ol_infrastructure/components/services/apisix.py
+++ b/src/ol_infrastructure/components/services/apisix.py
@@ -7,6 +7,7 @@ import pulumi_kubernetes as kubernetes
 from pulumi import ComponentResource, Output, ResourceOptions
 from pydantic import BaseModel, Field, NonNegativeInt, field_validator, model_validator
 
+from bridge.lib.constants import DEFAULT_OIDC_SESSION_COOKIE_NAME
 from ol_infrastructure.components.services.vault import (
     OLVaultK8SSecret,
     OLVaultK8SStaticSecretConfig,
@@ -29,6 +30,77 @@ class OLApisixPluginConfig(BaseModel):
         alias="secretRef",
     )
     config: dict[str, Any] = {}
+
+
+def stale_session_cookie_cleanup_plugin(
+    cookie_domains: list[str] | None = None,
+    stale_cookie_name: str = DEFAULT_OIDC_SESSION_COOKIE_NAME,
+) -> OLApisixPluginConfig:
+    """Build a plugin that evicts a session cookie an application no longer uses.
+
+    Renaming an OIDC session cookie does not remove the old one: the browser
+    keeps sending the abandoned cookie to every route on the host, where the
+    plugin now ignores it.  lua-resty-session cookies are large -- large enough
+    that we watch their size on a dashboard -- and they are session-scoped, so
+    they only expire when the user fully quits the browser, which most people
+    never do.  This emits the matching ``Set-Cookie ... Max-Age=0`` so the
+    browser drops them on the next response instead.
+
+    The deletion is conditional: it only fires when a stale cookie is actually
+    present on the request, so it costs nothing on the overwhelming majority of
+    responses and stops firing for a given browser after the one response that
+    clears it.  Chunked cookies are handled too -- lua-resty-session splits an
+    oversized payload across ``<name>``, ``<name>_2``, ``<name>_3``... and each
+    chunk is its own cookie that has to be expired individually.
+
+    A cookie's identity is (name, domain, path), so the domain-scoped and
+    host-only variants are separate entries in the browser's jar and each needs
+    its own deletion.  ``cookie_domains`` must therefore list exactly the parent
+    domains the stale cookie was ever scoped to, and the caller has to be able
+    to name them: attaching this to routes on a host that is not under one of
+    the listed domains just gets the header rejected by the browser, and
+    deriving a domain from the request host risks clearing an unrelated
+    ``.mit.edu`` cookie belonging to someone else.  The host-only variant is
+    always cleared.
+
+    :param cookie_domains: Parent domains (leading dot, e.g. ``.learn.mit.edu``)
+        the stale cookie was scoped to, in addition to the host-only variant.
+    :param stale_cookie_name: Name of the abandoned cookie.  Defaults to
+        lua-resty-session's built-in name, which is what every application that
+        has adopted an explicit name was previously using.
+
+    :returns: A ``serverless-post-function`` plugin config to attach to routes.
+    :rtype: OLApisixPluginConfig
+    """
+    scopes = ["", *[f"; Domain={domain}" for domain in cookie_domains or []]]
+    expirations = "\n".join(
+        f'            core.response.add_header("Set-Cookie", name .. "=; '
+        f'Path=/; Max-Age=0; Secure; HttpOnly; SameSite=Lax{scope}")'
+        for scope in scopes
+    )
+    cleanup_function = f"""return function(conf, ctx)
+    local cookie = ngx.var.http_cookie
+    if not cookie then
+        return
+    end
+    local core = require("apisix.core")
+    for pair in cookie:gmatch("[^;]+") do
+        local name = pair:match("^%s*([^=%s]+)=")
+        if name and (name == "{stale_cookie_name}"
+                     or name:match("^{stale_cookie_name}_%d+$")) then
+{expirations}
+        end
+    end
+end"""
+    return OLApisixPluginConfig(
+        name="serverless-post-function",
+        secretRef=None,
+        # header_filter rather than the plugin's default log phase: the response
+        # headers are still mutable there, and this needs to run after the
+        # openid-connect plugin has set the cookies it *does* own so that
+        # add_header appends to them rather than being overwritten.
+        config={"phase": "header_filter", "functions": [cleanup_function]},
+    )
 
 
 class OLApisixRouteConfig(BaseModel):
@@ -371,7 +443,9 @@ class OLApisixSharedPluginsConfig(BaseModel):
     enable_opentelemetry: bool = True
     k8s_labels: dict[str, str] = {}
     k8s_namespace: str
-    plugins: list[dict[str, Any]] = []
+    # Either raw CRD dicts or OLApisixPluginConfig objects; the component
+    # normalises the latter to dicts before rendering.
+    plugins: list[dict[str, Any] | OLApisixPluginConfig] = []
 
 
 class OLApisixSharedPlugins(ComponentResource):
@@ -453,8 +527,20 @@ class OLApisixSharedPlugins(ComponentResource):
 
         resource_options = ResourceOptions(parent=self).merge(opts)
 
-        if plugin_config.enable_defaults:
-            plugin_config.plugins.extend(__default_plugins)
+        # Defaults first, then the caller's own plugins.  APISIX dispatches by
+        # each plugin's registered priority rather than by array position, so
+        # the order here is cosmetic -- but keeping the defaults at stable
+        # indices means adding a plugin renders as a one-line append in
+        # `pulumi preview` instead of shifting every entry down by one.
+        plugins: list[dict[str, Any]] = (
+            list(__default_plugins) if plugin_config.enable_defaults else []
+        )
+        plugins.extend(
+            plugin.model_dump(by_alias=True, exclude_none=True)
+            if isinstance(plugin, OLApisixPluginConfig)
+            else plugin
+            for plugin in plugin_config.plugins
+        )
 
         # Gate on CI to match the cluster-level plugin enablement: APISIX does not
         # load the opentelemetry plugin on CI, so attaching it to a route there
@@ -463,7 +549,7 @@ class OLApisixSharedPlugins(ComponentResource):
             plugin_config.enable_opentelemetry
             and parse_stack().env_suffix.lower() != "ci"
         ):
-            plugin_config.plugins.append(__opentelemetry_plugin)
+            plugins.append(__opentelemetry_plugin)
 
         self.resource_name = (
             f"{plugin_config.application_name}-{plugin_config.resource_suffix}"
@@ -481,7 +567,7 @@ class OLApisixSharedPlugins(ComponentResource):
                     namespace=plugin_config.k8s_namespace,
                 ),
                 spec={
-                    "plugins": plugin_config.plugins,
+                    "plugins": plugins,
                 },
                 opts=resource_options,
             )
@@ -498,7 +584,7 @@ class OLApisixSharedPlugins(ComponentResource):
         # path either.
         _v1alpha1_plugins = [
             {"name": p["name"], **({"config": p["config"]} if p.get("config") else {})}
-            for p in plugin_config.plugins
+            for p in plugins
             if p.get("enable", True)
         ]
         self.shared_plugin_pluginconfig_resource = (

--- a/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
@@ -12,6 +12,7 @@ import pulumi_fastly as fastly
 import pulumi_kubernetes as kubernetes
 from pulumi import Config, InvokeOptions, Output, ResourceOptions
 
+from bridge.lib.constants import mit_learn_session_cookie_name
 from bridge.lib.magic_numbers import AWS_LOAD_BALANCER_NAME_MAX_LENGTH
 from ol_infrastructure.lib.aws.eks_helper import (
     cached_image_uri,
@@ -211,9 +212,15 @@ def setup_apisix(
     """
     apisix_domains = eks_config.get_object("apisix_domains") or []
 
-    session_cookie_name = f"{stack_info.env_suffix}_gateway_session".removeprefix(
-        "production"
-    ).strip("_")
+    # Name of the OIDC session cookie the $oidc_session_bytes access-log field
+    # (and the apisix_oidc_session_cookie_bytes dashboard built on it) measures.
+    # There is one such variable per gateway but several OIDC-protected
+    # applications behind it, so it tracks the largest and most-watched session
+    # on the cluster: MIT Learn's, whose cookie is shared by learn-ai and
+    # ol-analytics-api. Purely observational -- lua-resty-session 4.x ignores
+    # these nginx variables, the cookie name itself is set per-application via
+    # OLApisixOIDCConfig.oidc_session_cookie_name.
+    session_cookie_name = mit_learn_session_cookie_name(stack_info.env_suffix)
 
     # APISIX chart uses a different chart version scheme
     # Chart version 2.16.x contains APISIX 3.17.x

--- a/tests/ol_infrastructure/components/services/test_apisix.py
+++ b/tests/ol_infrastructure/components/services/test_apisix.py
@@ -1,4 +1,4 @@
-"""Tests for the OLApisixUpstream Pulumi component.
+"""Tests for the APISIX Pulumi components.
 
 This module verifies:
 1. OLApisixUpstreamConfig's chash field validation (hash_on/hash_key are
@@ -6,6 +6,10 @@ This module verifies:
 2. The rendered ApisixUpstream CRD spec for roundrobin vs chash
 3. The ApisixUpstream resource is named after the target Service, per the
    apisix-ingress-controller name-matching contract documented on the class
+4. OLApisixOIDCResources renders the flat lua-resty-session 4.x session.*
+   keys the pinned APISIX expects, and omits them when unset
+5. The session cookie names derived by bridge.lib.constants, and the stale
+   cookie cleanup plugin's generated Lua
 """
 
 from __future__ import annotations
@@ -34,9 +38,16 @@ pulumi.runtime.set_mocks(K8sMocks())
 import pytest  # noqa: E402
 from pydantic import ValidationError  # noqa: E402
 
+from bridge.lib.constants import (  # noqa: E402
+    apisix_oidc_session_cookie_name,
+    mit_learn_session_cookie_name,
+)
 from ol_infrastructure.components.services.apisix import (  # noqa: E402
+    OLApisixOIDCConfig,
+    OLApisixOIDCResources,
     OLApisixUpstream,
     OLApisixUpstreamConfig,
+    stale_session_cookie_cleanup_plugin,
 )
 
 # ─── OLApisixUpstreamConfig validation ─────────────────────────────────────────
@@ -171,3 +182,161 @@ def test_resource_name_matches_service_name():
         assert metadata["namespace"] == "mitx-openedx"
 
     return upstream.apisix_upstream_resource.metadata.apply(check)
+
+
+# ─── OLApisixOIDCResources session config ──────────────────────────────────────
+
+
+def oidc_resources(name: str, **overrides) -> OLApisixOIDCResources:
+    """Build an OIDC component with the fields every caller has to supply."""
+    return OLApisixOIDCResources(
+        name,
+        oidc_config=OLApisixOIDCConfig(
+            application_name="myapp",
+            k8s_namespace="myapp-ns",
+            vault_path="sso/myapp",
+            vaultauth="myapp-vaultauth",
+            **overrides,
+        ),
+    )
+
+
+def test_session_cookie_name_is_emitted_flat():
+    """lua-resty-session 4.x only reads the flat session.cookie_name key; the
+    nested session.cookie.name form is a silent no-op on APISIX 3.17.0+.
+    """
+    oidc = oidc_resources(
+        "test-oidc-cookie-name",
+        oidc_session_cookie_name="mitlearn_apisix_session",
+    )
+
+    assert oidc.base_oidc_config["session"]["cookie_name"] == "mitlearn_apisix_session"
+
+
+def test_session_cookie_name_and_domain_coexist():
+    """Both flat keys land in the same session block rather than overwriting
+    each other -- a broadened cookie domain is the reason the name matters.
+    """
+    oidc = oidc_resources(
+        "test-oidc-cookie-name-and-domain",
+        oidc_session_cookie_name="mitlearn_apisix_session",
+        oidc_session_cookie_domain=".learn.mit.edu",
+    )
+
+    assert oidc.base_oidc_config["session"] == {
+        "cookie_name": "mitlearn_apisix_session",
+        "cookie_domain": ".learn.mit.edu",
+    }
+
+
+def test_session_block_omitted_when_nothing_set():
+    """Callers that opt into none of the session settings must not get an empty
+    session block, which would override lua-resty-session's own defaults.
+    """
+    oidc = oidc_resources("test-oidc-no-session-config")
+
+    assert "session" not in oidc.base_oidc_config
+
+
+def test_session_cookie_name_survives_plugin_rendering():
+    """The name has to reach the actual plugin config attached to a route, not
+    just the component's intermediate dict.
+    """
+    oidc = oidc_resources(
+        "test-oidc-plugin-rendering",
+        oidc_session_cookie_name="mitlearn_apisix_session",
+    )
+
+    plugin = oidc.get_full_oidc_plugin_config(unauth_action="pass")
+
+    assert plugin["name"] == "openid-connect"
+    assert plugin["config"]["session"]["cookie_name"] == "mitlearn_apisix_session"
+    assert plugin["config"]["unauth_action"] == "pass"
+
+
+# ─── Session cookie naming ─────────────────────────────────────────────────────
+
+
+def test_production_cookie_name_has_no_env_suffix():
+    assert apisix_oidc_session_cookie_name("mitlearn", "production") == (
+        "mitlearn_apisix_session"
+    )
+
+
+@pytest.mark.parametrize(
+    ("env_suffix", "expected"),
+    [("qa", "mitlearn_apisix_session_qa"), ("ci", "mitlearn_apisix_session_ci")],
+)
+def test_non_production_cookie_names_are_suffixed(env_suffix, expected):
+    """Suffixing the non-production names is what makes the unsuffixed
+    Production name safe: a Production .learn.mit.edu cookie is also delivered
+    to api.rc.learn.mit.edu, and must not be the name the RC gateway reads.
+    """
+    assert apisix_oidc_session_cookie_name("mitlearn", env_suffix) == expected
+
+
+def test_cookie_name_normalises_hyphens():
+    """Application slugs are hyphenated (jupyterhub-authoring); cookie names in
+    this codebase are not.
+    """
+    assert apisix_oidc_session_cookie_name("jupyterhub-authoring", "production") == (
+        "jupyterhub_authoring_apisix_session"
+    )
+
+
+def test_mit_learn_helper_matches_generic_helper():
+    """Every resource sharing the MIT Learn session derives its name from
+    mit_learn_session_cookie_name, so it must not drift from the generic form.
+    """
+    for env_suffix in ("production", "qa", "ci"):
+        assert mit_learn_session_cookie_name(env_suffix) == (
+            apisix_oidc_session_cookie_name("mitlearn", env_suffix)
+        )
+
+
+# ─── Stale session cookie cleanup ──────────────────────────────────────────────
+
+
+def test_cleanup_plugin_runs_in_header_filter():
+    """The default log phase is too late to mutate response headers."""
+    plugin = stale_session_cookie_cleanup_plugin()
+
+    assert plugin.name == "serverless-post-function"
+    assert plugin.config["phase"] == "header_filter"
+
+
+def test_cleanup_plugin_expires_host_only_variant_by_default():
+    (lua,) = stale_session_cookie_cleanup_plugin().config["functions"]
+
+    assert 'name == "session"' in lua
+    assert "Max-Age=0" in lua
+    assert "Domain=" not in lua
+
+
+def test_cleanup_plugin_expires_each_named_domain_separately():
+    """A cookie's identity is (name, domain, path), so the host-only and
+    domain-scoped variants need one deletion each.
+    """
+    (lua,) = stale_session_cookie_cleanup_plugin(
+        cookie_domains=[".learn.mit.edu"],
+    ).config["functions"]
+
+    assert lua.count("add_header") == 2
+    assert "Domain=.learn.mit.edu" in lua
+
+
+def test_cleanup_plugin_matches_chunked_cookies():
+    """lua-resty-session splits an oversized payload across <name>, <name>_2,
+    <name>_3... and each chunk is its own cookie to expire.
+    """
+    (lua,) = stale_session_cookie_cleanup_plugin().config["functions"]
+
+    assert 'name:match("^session_%d+$")' in lua
+
+
+def test_cleanup_plugin_honours_a_custom_stale_name():
+    (lua,) = stale_session_cookie_cleanup_plugin(
+        stale_cookie_name="mitlearn_apisix_session",
+    ).config["functions"]
+
+    assert 'name == "mitlearn_apisix_session"' in lua


### PR DESCRIPTION
APISIX's openid-connect plugin (lua-resty-session 4.x) names its session
cookie "session" by default, which every OIDC-protected application here was
using unchanged. That is a poor fit for two reasons:

- The name is generic enough to collide with any other "session" cookie a
  *.mit.edu host sets, and says nothing about which system owns it when
  reading a Cookie header during an oversized-header investigation.
- Several of these cookies are deliberately scoped to a parent domain
  (.learn.mit.edu, see #5182; .mitxonline.mit.edu) so they reach sibling
  subdomains, which means the Production cookie is also sent to the RC and CI
  hosts under that parent. Under one shared name all three environments'
  cookies stack up on those hosts, where each gateway can be handed a session
  envelope encrypted with a different environment's secret.

## Naming

Adds `OLApisixOIDCConfig.oidc_session_cookie_name`, emitted as the flat
`session.cookie_name` key (same lua-resty-session 4.x schema as the existing
`session.cookie_domain`), and a shared
`apisix_oidc_session_cookie_name(application, env_suffix)` helper.
`mit_learn_session_cookie_name()` is a thin wrapper over it, so every resource
participating in the shared MIT Learn login session derives its name from one
place. The `apisix` segment names the gateway as owner: the application behind
it sets cookies of its own on the same host — mit-learn's Django app being the
obvious case — so when the question is which component wrote an oversized
Cookie header, `mitlearn_apisix_session` answers it and `mitlearn_session`
does not.

The field stays optional rather than required. Requiring it would rename the
cookie for all 14 `OLApisixOIDCConfig` call sites across 12 stacks in one
deploy — airbyte, dagster, gwarek, opik, leek, marimo and ol-analytics-api's
canonical host — each of which also wants its own cleanup plugin to avoid
leaving a dead cookie behind. That is a follow-up, where the component
defaults the name from `application_name` + stack environment so no caller can
forget it, and the field remains an override for resources that must share a
name they do not own.

Production is unsuffixed — `mitlearn_apisix_session`, not
`mitlearn_apisix_session_production` — matching how the rest of the codebase names
environment-scoped, user-visible strings (compare the `learn_csrftoken` /
`learn_rc_csrftoken` pair). That is safe precisely because the non-production
names *are* suffixed: a Production `.learn.mit.edu` cookie riding along to
`api.rc.learn.mit.edu` is called `mitlearn_apisix_session` there, which is not the
name the RC gateway reads (`mitlearn_apisix_session_qa`), so the two never contend.

| OIDC resource | Host | Cookie name (Production) |
| --- | --- | --- |
| mit-learn, prefix + no-prefix | `api.learn.mit.edu` | `mitlearn_apisix_session` |
| learn-ai `/ai/*` | `api.learn.mit.edu` | `mitlearn_apisix_session` |
| ol-analytics-api, Learn-scoped | `analytics.learn.mit.edu` | `mitlearn_apisix_session` |
| mitxonline `/mitxonline/*` | `api.learn.mit.edu` | `mitlearn_apisix_session` |
| mitxonline, own login | `*.mitxonline.mit.edu` | `mitxonline_apisix_session` |
| jupyterhub | `nb.learn.mit.edu` | `jupyterhub_apisix_session` |
| jupyterhub-authoring | `authoring.nb.learn.mit.edu` | `jupyterhub_authoring_apisix_session` |

The first four all share the `sso/mitlearn` Keycloak client and read the
cookie mit-learn's login flow set, so they must agree exactly — a mismatch
silently turns their `unauth_action="pass"` routes anonymous. mitxonline's
`/mitxonline/*` routes are the sharpest case: they are served from MIT Learn's
own host and are what the MIT Learn frontend calls as
`NEXT_PUBLIC_MITX_ONLINE_BASE_URL`. They also pick up mit-learn's cookie
domain, because their `reqauth` route performs a real login and without a
domain that write lands as a *host-only* cookie under the shared name,
shadowing the `.learn.mit.edu` one on that host.

The last three are separate sessions and get their own names. mitxonline's own
login needed one for the same reason mit-learn did (parent-domain cookie
stacking across environments); jupyterhub's host-only "session" was colliding
outright with mit-learn's `.learn.mit.edu` "session" on `nb.learn.mit.edu`,
with the gateway reading whichever the browser happened to send first.

Also points the gateway's `$session_name` variable at the shared helper. That
variable only feeds the `$oidc_session_bytes` access-log field and the
`apisix_oidc_session_cookie_bytes` dashboard (lua-resty-session 4.x ignores
nginx-variable configuration), and it previously named a cookie that never
existed — `{env}_gateway_session` — so the metric was measuring nothing.

## Evicting the old cookies

Renaming does not remove the old cookie. The browser keeps sending the
abandoned lua-resty-session envelope to every route on the host, where the
plugin now ignores it — and these are large, and session-scoped, so they only
go away when the user fully quits their browser. Most people never do.

`stale_session_cookie_cleanup_plugin()` emits the matching `Max-Age=0`
deletions from a `serverless-post-function` in the `header_filter` phase,
guarded on a stale cookie actually being present on the request. So it costs
nothing on the overwhelming majority of responses and stops firing for a given
browser after the one response that clears it. Chunked cookies are handled
too — lua-resty-session splits an oversized payload across `<name>`,
`<name>_2`, `<name>_3`… and each chunk is its own cookie to expire.

A cookie's identity is (name, domain, path), so the host-only and
domain-scoped variants are separate entries in the browser's jar and each
needs its own deletion. The caller has to name the domains explicitly:
a `Domain=.mitxonline.mit.edu` deletion emitted from `api.learn.mit.edu` is
simply rejected by the browser, and deriving a domain from the request host
risks clearing an unrelated `.mit.edu` cookie belonging to someone else. That
is why mitxonline attaches this per route group rather than through its shared
plugin config, which both groups reference.

learn-ai and ol-analytics-api are deliberately not covered: they sit on hosts
mit-learn's own routes already clean (a domain-scoped cookie is a single jar
entry, so clearing `.learn.mit.edu` from mit-learn's routes clears it
everywhere), and ol-analytics-api's shared plugin config is also used by
`analytics.ol.mit.edu`, where "session" is still a **live** cookie for a
different Keycloak client.

Safe to delete these plugin attachments once the old cookies have aged out of
circulation.

## Incidental

`OLApisixSharedPlugins` now orders the defaults ahead of caller-supplied
plugins, so adding one renders as a one-line append in `pulumi preview`
instead of shifting every entry down by one. APISIX dispatches by each
plugin's registered priority rather than array position, so the order is
cosmetic. No existing caller passed `plugins`. The config also now accepts
`OLApisixPluginConfig` objects directly instead of only raw dicts.

## Rollout

Existing sessions are invalidated for mit-learn, mitxonline and jupyterhub:
browsers keep sending the old "session" cookie, which the renamed plugins
ignore, so users log in again once. local-dev is left alone — it pins APISIX
chart 2.12.0, whose plugin schema predates the flat `session.*` keys.

## Known gap

learn-ai has the same host-only shadow problem and is **not** fixed here. Its
OIDC resource has no `oidc_session_cookie_domain`, and its `reqauth` route on
`api.<env>.learn.mit.edu` (`/ai/admin/login/*`, `/ai/http/login/*`) performs a
login — so it writes a host-only `mitlearn_apisix_session` alongside mit-learn's
domain-scoped one. Impact is mild (same session secret, so either decrypts to
the same user) but it doubles the cookie bytes on the host we measure and
makes logout clear only one of the two. Fixing it properly means splitting
learn-ai into two OIDC resources, one per host group, the way mitxonline
already is, because that single resource is shared with the legacy
`api-learn-ai.ol.mit.edu` host where a `.learn.mit.edu` cookie domain would be
rejected outright.

## Validation

pre-commit (ruff format, ruff check, mypy, detect-secrets) passes, as does
the full test suite (226 tests).

`tests/ol_infrastructure/components/services/test_apisix.py` gains coverage
for the new surface: `session.cookie_name` emitted as the flat
lua-resty-session 4.x key when set, absent when not, coexisting with
`cookie_domain`, and surviving into the plugin config a route actually
receives; the derived names including the unsuffixed-Production and
hyphen-normalising cases; and the cleanup plugin's generated Lua — its
`header_filter` phase, per-domain deletions and chunked-cookie matching.

The Lua was additionally exercised against a real interpreter with stubbed
openresty: no false positives on `mitlearn_apisix_session`, `presession`,
`session_extra` or `my_session`; correct deletions for `session` and its
chunked variants. `pulumi preview` on the CI stacks for mit_learn, mitxonline
and jupyterhub shows the intended diffs and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179yZeaewx1VYnUCpxy4sju
https://claude.ai/code/session_019SwYqX2HKKLW7oHdcERrrP
