### PR TITLE
fix(dagster): watch every tree a code-location image actually copies

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/dagster/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/dagster/pipeline.py
@@ -48,6 +48,18 @@ def build_dagster_docker_pipeline() -> Pipeline:
         {"name": "k8s", "module": None},  # dagster-k8s base image
     ]
 
+    # Trees an image's Dockerfile COPYs from outside its own dg_projects/<name>/
+    # directory. These MUST stay in sync with the COPY lines in each Dockerfile:
+    # a tree that is copied but not watched produces no new resource version when
+    # it changes, so the build never triggers and the image silently freezes at
+    # an older commit while the repo looks up to date. data_loading served
+    # pre-#2492 ol_dlt code in production for days because of exactly this.
+    extra_watched_paths = {
+        "data_loading": ["src/ol_dlt/"],
+        "lakehouse": ["src/ol_dbt/"],
+        "k8s": ["dg_deployments/reconcile_edxorg_partitions.py"],
+    }
+
     # Create git resources for each code location with specific path filters
     code_location_repos = {}
     for location in code_locations:
@@ -63,9 +75,7 @@ def build_dagster_docker_pipeline() -> Pipeline:
                 f"dg_projects/{name}/",
                 "packages/ol-orchestrate-lib/",
             ]
-            # Lakehouse also needs the dbt project
-            if name == "lakehouse":
-                paths.append("src/ol_dbt/")
+        paths.extend(extra_watched_paths.get(name, []))
 
         code_location_repos[name] = git_repo(
             name=Identifier(f"ol-data-platform-{name}"),


### PR DESCRIPTION
## What are the relevant tickets?

Follow-on to mitodl/ol-data-platform#2492 — that PR's fix was merged but never reached production because this pipeline never rebuilt the image carrying it.

## Description (What does it do?)

`data_loading`'s Dockerfile copies three trees:

```
COPY packages/ol-orchestrate-lib packages/ol-orchestrate-lib
COPY src/ol_dlt src/ol_dlt          <-- not watched
COPY dg_projects/data_loading dg_projects/data_loading
```

...but its Concourse git resource only watched the first and third. Concourse's `paths` filter gates *version detection*, so a commit touching only `src/ol_dlt` produced no new version for `ol-data-platform-data_loading` and the build job never triggered. The image silently froze at an older commit while the repo looked up to date.

`dagster-k8s` has the same latent gap — it copies `dg_deployments/reconcile_edxorg_partitions.py` without watching it.

This replaces the `lakehouse`-only `src/ol_dbt` special case with a table mapping each image to the trees it copies from outside its own directory:

```python
extra_watched_paths = {
    "data_loading": ["src/ol_dlt/"],
    "lakehouse": ["src/ol_dbt/"],
    "k8s": ["dg_deployments/reconcile_edxorg_partitions.py"],
}
```

I audited every `dg_projects/*/Dockerfile` plus `Dockerfile.dagster-k8s`; the other eight copy only `packages/ol-orchestrate-lib` and their own `dg_projects/<name>/`, so they were already correct.

## How was it tested?

- Rendered the pipeline and diffed the `paths` on all 11 `ol-data-platform-*` resources. `data_loading` gains `src/ol_dlt`, `k8s` gains the reconcile script, `lakehouse` keeps `src/ol_dbt`, the other eight are byte-identical.
- `pre-commit run --files src/ol_concourse/pipelines/infrastructure/dagster/pipeline.py` — ruff format, ruff check, and mypy all pass.

## Why the bug was worth chasing

The production symptom was `edxorg_s3_auth_userprofile` failing on DuckDB's CSV dialect sniffer. The error body is a fingerprint of the reader options actually in effect: it listed the full 9-pair quote/escape search space (so `quotechar`/`escapechar` were unset) and omitted the "Enable ignore errors" suggestion (so `ignore_errors=True` was set). That combination reproduces byte-for-byte against the *pre*-#2492 option set and not the current one — proving the running image predated the fix rather than the fix being wrong.

## Deployment notes

**Setting this pipeline does not retroactively build.** Concourse only picks up commits made *after* the resource's paths change, so `data_loading` still needs one manual trigger to pick up #2492:

```
fly -t pr-inf trigger-job -j docker-pulumi-dagster/build-dagster-data_loading-image
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NiYoSx7oqrTyeNHaDV5rcQ