### PR TITLE
Point gwarek-web's probes at /health instead of /

### DIFF
--- a/src/ol_infrastructure/applications/gwarek/__main__.py
+++ b/src/ol_infrastructure/applications/gwarek/__main__.py
@@ -800,12 +800,16 @@ gwarek_web_deployment = apps_v1.Deployment(
                             limits={"memory": "512Mi"},
                         ),
                         liveness_probe=core.v1.ProbeArgs(
-                            http_get=core.v1.HTTPGetActionArgs(path="/", port=3000),
+                            http_get=core.v1.HTTPGetActionArgs(
+                                path="/health", port=3000
+                            ),
                             initial_delay_seconds=15,
                             period_seconds=10,
                         ),
                         readiness_probe=core.v1.ProbeArgs(
-                            http_get=core.v1.HTTPGetActionArgs(path="/", port=3000),
+                            http_get=core.v1.HTTPGetActionArgs(
+                                path="/health", port=3000
+                            ),
                             initial_delay_seconds=5,
                             period_seconds=5,
                         ),


### PR DESCRIPTION
## Summary
- The web Deployment's liveness (10s) and readiness (5s) probes were pointed at `/`, the full dashboard page — every probe cycle forced a real server-side data fetch to the api service.
- This was masking a real bug rather than just wasting resources: that server-side fetch goes pod-to-pod via `INTERNAL_API_URL`, bypassing APISIX's openid-connect plugin entirely, so it always 401'd (silently swallowed by a `.catch(() => [])`). The probe noise made this easy to miss in logs.
- Companion app-side change (mitodl/gwarek) adds a dependency-free `/health` route and forwards `X-Userinfo` on server-side fetches so the dashboard actually works, not just the probes.

## Test plan
- [x] Verified locally: new `/health` route returns 200 with no backend calls, on both `next dev` and the actual production Docker build/image.
- [ ] Confirm probe logs go quiet on the api pod after this + the new image deploy together
- [ ] Confirm dashboard shows real integration data in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)