### PR TITLE
Add Sentry DSN stack outputs for all Sentry projects

### DIFF
--- a/src/ol_infrastructure/infrastructure/sentry/IMPORT_SUMMARY.md
+++ b/src/ol_infrastructure/infrastructure/sentry/IMPORT_SUMMARY.md
@@ -75,3 +75,13 @@ configuration, then `pulumi import --file sentry_imports.json` followed by
   `dagster_sentry_dsn` stack output is consumed by the Dagster application
   stack, which writes it to Vault at `secret-data/dagster/sentry`. The same
   naming-convergence caveat as above applies to `key_dagster`.
+- `*_sentry_dsn` stack outputs for every other generated `key_*` resource
+  (see ol-infrastructure#5004): hand-added `pulumi.export(...)` calls at the
+  end of the file, exposing each project's DSN as `<project_slug>_sentry_dsn`
+  (name-suffixed for projects with more than one key, e.g.
+  `odl_video_service_eternal_mink_sentry_dsn`) so consuming Pulumi stacks can
+  read the DSN via `sentry_stack.require_output(...)` instead of a
+  hard-coded/SOPS/Vault secret. Like the `ol_analytics_api` exception, these
+  are not part of the generator's output template -- if `bin/import-sentry-config`
+  is re-run and a key's generated variable name changes (e.g. its numeric
+  suffix), update the matching export line by hand.

--- a/src/ol_infrastructure/infrastructure/sentry/IMPORT_SUMMARY.md
+++ b/src/ol_infrastructure/infrastructure/sentry/IMPORT_SUMMARY.md
@@ -91,12 +91,14 @@ configuration, then `pulumi import --file sentry_imports.json` followed by
   (unused, zero Sentry events/issues in any of them). If `bin/import-sentry-config`
   is re-run against a `sentry_imports.json` that still lists these live
   projects, drop them from the import file first or the regenerated code will
-  recreate the resource blocks. **All eight resources (4 projects + 4 keys)
-  carry `protect=True` via the file-wide `sentry_opts`, so `pulumi up` will
-  fail on these deletes with "cannot be deleted because it is protected"
-  until each is unprotected first**, e.g.:
-  `pulumi state unprotect 'urn:pulumi:default::ol-infrastructure-sentry::sentry:index/sentryProject:SentryProject::project_airbyte'`
-  (repeat for the other 3 projects and 4 keys) -- confirmed via `pulumi preview`.
+  recreate the resource blocks. All eight resources (4 projects + 4 keys)
+  carried `protect=True` via the file-wide `sentry_opts`, which would have
+  made `pulumi up` fail on these deletes with "cannot be deleted because it
+  is protected" -- each was unprotected by hand ahead of merge with
+  `pulumi state unprotect '<urn>'` (e.g.
+  `urn:pulumi:default::ol-infrastructure-sentry::sentry:index/sentryProject:SentryProject::project_airbyte`),
+  confirmed clean with a subsequent `pulumi preview` (4 updates, 8 deletes,
+  no unexpected replacements).
 - `project_ocw_next` / `key_ocw_next_default_*`: the live Sentry project's
   `name`/`slug` were hand-changed from `ocw-next` to `ocw-site` (matching the
   `ocw_site` application) without renaming the Pulumi resource identifiers,

--- a/src/ol_infrastructure/infrastructure/sentry/IMPORT_SUMMARY.md
+++ b/src/ol_infrastructure/infrastructure/sentry/IMPORT_SUMMARY.md
@@ -85,3 +85,17 @@ configuration, then `pulumi import --file sentry_imports.json` followed by
   are not part of the generator's output template -- if `bin/import-sentry-config`
   is re-run and a key's generated variable name changes (e.g. its numeric
   suffix), update the matching export line by hand.
+- `project_airbyte` / `key_airbyte_default_*` and `project_unified_ecommerce` /
+  `key_unified_ecommerce_default_*`: removed by hand post-import (unused,
+  zero Sentry events/issues). If `bin/import-sentry-config` is re-run against
+  a `sentry_imports.json` that still lists these live projects, drop them
+  from the import file first or the regenerated code will recreate the
+  resource blocks.
+- `project_ocw_next` / `key_ocw_next_default_*`: the live Sentry project's
+  `name`/`slug` were hand-changed from `ocw-next` to `ocw-site` (matching the
+  `ocw_site` application) without renaming the Pulumi resource identifiers,
+  so the update applies in place rather than replacing the resource. The
+  hand-added export is `ocw_site_sentry_dsn`. A future `bin/import-sentry-config`
+  run will regenerate `name`/`slug` back to whatever the live project is
+  named at that point -- expect it to match `ocw-site` unless it's renamed
+  again live.

--- a/src/ol_infrastructure/infrastructure/sentry/IMPORT_SUMMARY.md
+++ b/src/ol_infrastructure/infrastructure/sentry/IMPORT_SUMMARY.md
@@ -85,12 +85,18 @@ configuration, then `pulumi import --file sentry_imports.json` followed by
   are not part of the generator's output template -- if `bin/import-sentry-config`
   is re-run and a key's generated variable name changes (e.g. its numeric
   suffix), update the matching export line by hand.
-- `project_airbyte` / `key_airbyte_default_*` and `project_unified_ecommerce` /
-  `key_unified_ecommerce_default_*`: removed by hand post-import (unused,
-  zero Sentry events/issues). If `bin/import-sentry-config` is re-run against
-  a `sentry_imports.json` that still lists these live projects, drop them
-  from the import file first or the regenerated code will recreate the
-  resource blocks.
+- `project_airbyte` / `key_airbyte_default_*`, `project_unified_ecommerce` /
+  `key_unified_ecommerce_default_*`, `project_python` / `key_python_default_*`,
+  and `project_sandbox` / `key_sandbox_default_*`: removed by hand post-import
+  (unused, zero Sentry events/issues in any of them). If `bin/import-sentry-config`
+  is re-run against a `sentry_imports.json` that still lists these live
+  projects, drop them from the import file first or the regenerated code will
+  recreate the resource blocks. **All eight resources (4 projects + 4 keys)
+  carry `protect=True` via the file-wide `sentry_opts`, so `pulumi up` will
+  fail on these deletes with "cannot be deleted because it is protected"
+  until each is unprotected first**, e.g.:
+  `pulumi state unprotect 'urn:pulumi:default::ol-infrastructure-sentry::sentry:index/sentryProject:SentryProject::project_airbyte'`
+  (repeat for the other 3 projects and 4 keys) -- confirmed via `pulumi preview`.
 - `project_ocw_next` / `key_ocw_next_default_*`: the live Sentry project's
   `name`/`slug` were hand-changed from `ocw-next` to `ocw-site` (matching the
   `ocw_site` application) without renaming the Pulumi resource identifiers,
@@ -99,3 +105,17 @@ configuration, then `pulumi import --file sentry_imports.json` followed by
   run will regenerate `name`/`slug` back to whatever the live project is
   named at that point -- expect it to match `ocw-site` unless it's renamed
   again live.
+- `project_open_next` / `key_open_next_default_*`: the live Sentry project's
+  `name`/`slug` were hand-changed from `open-next` to `mit-learn` (without
+  renaming the Pulumi resource identifiers, same in-place-update rationale as
+  `project_ocw_next` above). `open` is the legacy `open-discussions`/`mit_open`
+  Heroku deployment (culprits are old `/api/v0/...` routes and old task
+  modules like `search.tasks.*`, `course_catalog.tasks.*`); `open-next` is the
+  current MIT Learn stack as a whole -- both the k8s `mit_learn` Django
+  backend (`/api/v1/learning_resources/...`, `vector_search.tasks.*`, SCIM)
+  and the `mit_learn_nextjs` frontend share this one project, the same way
+  `project_dagster` covers all of Dagster's code locations rather than
+  splitting by app. The hand-added export is `mit_learn_sentry_dsn`. A future
+  `bin/import-sentry-config` run will regenerate `name`/`slug` back to
+  whatever the live project is named at that point -- expect it to match
+  `mit-learn` unless it's renamed again live.

--- a/src/ol_infrastructure/infrastructure/sentry/__main__.py
+++ b/src/ol_infrastructure/infrastructure/sentry/__main__.py
@@ -3715,3 +3715,78 @@ key_dagster = sentry.SentryKey(
 )
 
 pulumi.export("dagster_sentry_dsn", key_dagster.dsn_public)
+
+# Hand-added stack outputs (not produced by bin/import-sentry-config) exposing
+# each project's DSN so consuming stacks can read it via
+# sentry_stack.require_output(...) instead of a hard-coded/SOPS/Vault secret.
+# See ol-infrastructure#5004. Naming convention: `<project_slug>_sentry_dsn`,
+# with a name-suffixed variant for projects that have more than one key.
+pulumi.export(
+    "airbyte_sentry_dsn",
+    key_airbyte_default_0e552f29a3594a6a972cf2d73dfa140b.dsn_public,
+)
+pulumi.export(
+    "learn_ai_sentry_dsn",
+    key_learn_ai_default_5e497d1f33127fc35dfc811b290747c7.dsn_public,
+)
+pulumi.export(
+    "micromasters_sentry_dsn",
+    key_micromasters_default_6134fa8f62f74ba49d3892f9eb8c2fb7.dsn_public,
+)
+pulumi.export(
+    "mitxonline_sentry_dsn",
+    key_mitxonline_default_8ba006dc817541a0865033722f8289ad.dsn_public,
+)
+pulumi.export(
+    "ocw_next_sentry_dsn",
+    key_ocw_next_default_eee58f41dda54d2b814296e12dced4b7.dsn_public,
+)
+pulumi.export(
+    "ocw_studio_sentry_dsn",
+    key_ocw_studio_default_ba06ef0080e342db9b9ae1db53944f1a.dsn_public,
+)
+pulumi.export(
+    "odl_video_service_sentry_dsn",
+    key_odl_video_service_default_f75d3b6abb8f4a30b95769f8f9644ee3.dsn_public,
+)
+pulumi.export(
+    "odl_video_service_eternal_mink_sentry_dsn",
+    key_odl_video_service_eternal_mink_7e70a5f1227743959ba1cb1e8db1240f.dsn_public,
+)
+pulumi.export(
+    "open_sentry_dsn", key_open_default_005a98ba45c3472dbb4c12405d814557.dsn_public
+)
+pulumi.export(
+    "open_next_sentry_dsn",
+    key_open_next_default_8131564a9b9e31ac3cbcf7952f0fea80.dsn_public,
+)
+pulumi.export(
+    "openedx_mitxonline_sentry_dsn",
+    key_openedx_mitxonline_default_8807f1e77ff44d91beeb2580507ad84a.dsn_public,
+)
+pulumi.export(
+    "openedx_mitxpro_sentry_dsn",
+    key_openedx_mitxpro_default_3b523a8e89c040f0a46ddc90a64f9d14.dsn_public,
+)
+pulumi.export(
+    "openedx_residential_sentry_dsn",
+    key_openedx_residential_default_3741f5e8334b429eaa048bec1e3daa30.dsn_public,
+)
+pulumi.export(
+    "python_sentry_dsn", key_python_default_7cc91e53ac70f26e91a2e788288be63d.dsn_public
+)
+pulumi.export(
+    "release_script_sentry_dsn",
+    key_release_script_default_67d74d4e5121a4ca332f1523ff8affdd.dsn_public,
+)
+pulumi.export(
+    "sandbox_sentry_dsn",
+    key_sandbox_default_8c6395a9422040c999373e204b15bd8b.dsn_public,
+)
+pulumi.export(
+    "unified_ecommerce_sentry_dsn",
+    key_unified_ecommerce_default_734c791eb3c83eb35db04c1b753ff67e.dsn_public,
+)
+pulumi.export(
+    "xpro_sentry_dsn", key_xpro_default_c9f9886a461647708cd0c0c551166866.dsn_public
+)

--- a/src/ol_infrastructure/infrastructure/sentry/__main__.py
+++ b/src/ol_infrastructure/infrastructure/sentry/__main__.py
@@ -252,8 +252,8 @@ project_open = sentry.SentryProject(
 project_open_next = sentry.SentryProject(
     "project_open_next",
     organization=ORGANIZATION,
-    name="open-next",
-    slug="open-next",
+    name="mit-learn",
+    slug="mit-learn",
     platform="python-django",
     teams=["mit-learn", "mit-office-of-digital-learning", "devops"],
     digests_min_delay=300,
@@ -301,19 +301,6 @@ project_openedx_residential = sentry.SentryProject(
     opts=sentry_opts,
 )
 
-project_python = sentry.SentryProject(
-    "project_python",
-    organization=ORGANIZATION,
-    name="python",
-    slug="python",
-    platform="python",
-    teams=["mit-office-of-digital-learning"],
-    digests_min_delay=300,
-    digests_max_delay=1800,
-    resolve_age=0,
-    opts=sentry_opts,
-)
-
 project_release_script = sentry.SentryProject(
     "project_release_script",
     organization=ORGANIZATION,
@@ -324,19 +311,6 @@ project_release_script = sentry.SentryProject(
     digests_min_delay=300,
     digests_max_delay=1800,
     resolve_age=0,
-    opts=sentry_opts,
-)
-
-project_sandbox = sentry.SentryProject(
-    "project_sandbox",
-    organization=ORGANIZATION,
-    name="Python",
-    slug="sandbox",
-    platform="python",
-    teams=["mit-office-of-digital-learning"],
-    digests_min_delay=300,
-    digests_max_delay=1800,
-    resolve_age=120,
     opts=sentry_opts,
 )
 
@@ -3382,7 +3356,7 @@ key_open_default_005a98ba45c3472dbb4c12405d814557 = sentry.SentryKey(
 key_open_next_default_8131564a9b9e31ac3cbcf7952f0fea80 = sentry.SentryKey(
     "key_open_next_default_8131564a9b9e31ac3cbcf7952f0fea80",  # pragma: allowlist secret
     organization=ORGANIZATION,
-    project="open-next",
+    project="mit-learn",
     name="Default",
     opts=sentry_opts,
 )
@@ -3411,26 +3385,10 @@ key_openedx_residential_default_3741f5e8334b429eaa048bec1e3daa30 = sentry.Sentry
     opts=sentry_opts,
 )
 
-key_python_default_7cc91e53ac70f26e91a2e788288be63d = sentry.SentryKey(
-    "key_python_default_7cc91e53ac70f26e91a2e788288be63d",  # pragma: allowlist secret
-    organization=ORGANIZATION,
-    project="python",
-    name="Default",
-    opts=sentry_opts,
-)
-
 key_release_script_default_67d74d4e5121a4ca332f1523ff8affdd = sentry.SentryKey(
     "key_release_script_default_67d74d4e5121a4ca332f1523ff8affdd",  # pragma: allowlist secret
     organization=ORGANIZATION,
     project="release-script",
-    name="Default",
-    opts=sentry_opts,
-)
-
-key_sandbox_default_8c6395a9422040c999373e204b15bd8b = sentry.SentryKey(
-    "key_sandbox_default_8c6395a9422040c999373e204b15bd8b",  # pragma: allowlist secret
-    organization=ORGANIZATION,
-    project="sandbox",
     name="Default",
     opts=sentry_opts,
 )
@@ -3712,7 +3670,7 @@ pulumi.export(
     key_open_default_005a98ba45c3472dbb4c12405d814557.dsn_public,
 )
 pulumi.export(
-    "open_next_sentry_dsn",
+    "mit_learn_sentry_dsn",
     key_open_next_default_8131564a9b9e31ac3cbcf7952f0fea80.dsn_public,
 )
 pulumi.export(
@@ -3728,16 +3686,8 @@ pulumi.export(
     key_openedx_residential_default_3741f5e8334b429eaa048bec1e3daa30.dsn_public,
 )
 pulumi.export(
-    "python_sentry_dsn",
-    key_python_default_7cc91e53ac70f26e91a2e788288be63d.dsn_public,
-)
-pulumi.export(
     "release_script_sentry_dsn",
     key_release_script_default_67d74d4e5121a4ca332f1523ff8affdd.dsn_public,
-)
-pulumi.export(
-    "sandbox_sentry_dsn",
-    key_sandbox_default_8c6395a9422040c999373e204b15bd8b.dsn_public,
 )
 pulumi.export(
     "xpro_sentry_dsn",

--- a/src/ol_infrastructure/infrastructure/sentry/__main__.py
+++ b/src/ol_infrastructure/infrastructure/sentry/__main__.py
@@ -3754,7 +3754,8 @@ pulumi.export(
     key_odl_video_service_eternal_mink_7e70a5f1227743959ba1cb1e8db1240f.dsn_public,
 )
 pulumi.export(
-    "open_sentry_dsn", key_open_default_005a98ba45c3472dbb4c12405d814557.dsn_public
+    "open_sentry_dsn",
+    key_open_default_005a98ba45c3472dbb4c12405d814557.dsn_public,
 )
 pulumi.export(
     "open_next_sentry_dsn",
@@ -3773,7 +3774,8 @@ pulumi.export(
     key_openedx_residential_default_3741f5e8334b429eaa048bec1e3daa30.dsn_public,
 )
 pulumi.export(
-    "python_sentry_dsn", key_python_default_7cc91e53ac70f26e91a2e788288be63d.dsn_public
+    "python_sentry_dsn",
+    key_python_default_7cc91e53ac70f26e91a2e788288be63d.dsn_public,
 )
 pulumi.export(
     "release_script_sentry_dsn",
@@ -3788,5 +3790,6 @@ pulumi.export(
     key_unified_ecommerce_default_734c791eb3c83eb35db04c1b753ff67e.dsn_public,
 )
 pulumi.export(
-    "xpro_sentry_dsn", key_xpro_default_c9f9886a461647708cd0c0c551166866.dsn_public
+    "xpro_sentry_dsn",
+    key_xpro_default_c9f9886a461647708cd0c0c551166866.dsn_public,
 )

--- a/src/ol_infrastructure/infrastructure/sentry/__main__.py
+++ b/src/ol_infrastructure/infrastructure/sentry/__main__.py
@@ -152,19 +152,6 @@ team_xpro = sentry.SentryTeam(
     opts=sentry_opts,
 )
 
-project_airbyte = sentry.SentryProject(
-    "project_airbyte",
-    organization=ORGANIZATION,
-    name="airbyte",
-    slug="airbyte",
-    platform="java",
-    teams=["devops"],
-    digests_min_delay=300,
-    digests_max_delay=1800,
-    resolve_age=0,
-    opts=sentry_opts,
-)
-
 project_learn_ai = sentry.SentryProject(
     "project_learn_ai",
     organization=ORGANIZATION,
@@ -213,8 +200,8 @@ project_mitxonline = sentry.SentryProject(
 project_ocw_next = sentry.SentryProject(
     "project_ocw_next",
     organization=ORGANIZATION,
-    name="ocw-next",
-    slug="ocw-next",
+    name="ocw-site",
+    slug="ocw-site",
     platform="python-django",
     teams=["mit-office-of-digital-learning", "applications", "ocw"],
     digests_min_delay=300,
@@ -350,19 +337,6 @@ project_sandbox = sentry.SentryProject(
     digests_min_delay=300,
     digests_max_delay=1800,
     resolve_age=120,
-    opts=sentry_opts,
-)
-
-project_unified_ecommerce = sentry.SentryProject(
-    "project_unified_ecommerce",
-    organization=ORGANIZATION,
-    name="unified-ecommerce",
-    slug="unified-ecommerce",
-    platform="python-django",
-    teams=["team-jkachel"],
-    digests_min_delay=300,
-    digests_max_delay=1800,
-    resolve_age=0,
     opts=sentry_opts,
 )
 
@@ -3341,14 +3315,6 @@ dashboard_caches_1072565 = sentry.SentryDashboard(
     opts=sentry_opts,
 )
 
-key_airbyte_default_0e552f29a3594a6a972cf2d73dfa140b = sentry.SentryKey(
-    "key_airbyte_default_0e552f29a3594a6a972cf2d73dfa140b",  # pragma: allowlist secret
-    organization=ORGANIZATION,
-    project="airbyte",
-    name="Default",
-    opts=sentry_opts,
-)
-
 key_learn_ai_default_5e497d1f33127fc35dfc811b290747c7 = sentry.SentryKey(
     "key_learn_ai_default_5e497d1f33127fc35dfc811b290747c7",  # pragma: allowlist secret
     organization=ORGANIZATION,
@@ -3376,7 +3342,7 @@ key_mitxonline_default_8ba006dc817541a0865033722f8289ad = sentry.SentryKey(
 key_ocw_next_default_eee58f41dda54d2b814296e12dced4b7 = sentry.SentryKey(
     "key_ocw_next_default_eee58f41dda54d2b814296e12dced4b7",  # pragma: allowlist secret
     organization=ORGANIZATION,
-    project="ocw-next",
+    project="ocw-site",
     name="Default",
     opts=sentry_opts,
 )
@@ -3465,14 +3431,6 @@ key_sandbox_default_8c6395a9422040c999373e204b15bd8b = sentry.SentryKey(
     "key_sandbox_default_8c6395a9422040c999373e204b15bd8b",  # pragma: allowlist secret
     organization=ORGANIZATION,
     project="sandbox",
-    name="Default",
-    opts=sentry_opts,
-)
-
-key_unified_ecommerce_default_734c791eb3c83eb35db04c1b753ff67e = sentry.SentryKey(
-    "key_unified_ecommerce_default_734c791eb3c83eb35db04c1b753ff67e",  # pragma: allowlist secret
-    organization=ORGANIZATION,
-    project="unified-ecommerce",
     name="Default",
     opts=sentry_opts,
 )
@@ -3722,10 +3680,6 @@ pulumi.export("dagster_sentry_dsn", key_dagster.dsn_public)
 # See ol-infrastructure#5004. Naming convention: `<project_slug>_sentry_dsn`,
 # with a name-suffixed variant for projects that have more than one key.
 pulumi.export(
-    "airbyte_sentry_dsn",
-    key_airbyte_default_0e552f29a3594a6a972cf2d73dfa140b.dsn_public,
-)
-pulumi.export(
     "learn_ai_sentry_dsn",
     key_learn_ai_default_5e497d1f33127fc35dfc811b290747c7.dsn_public,
 )
@@ -3738,7 +3692,7 @@ pulumi.export(
     key_mitxonline_default_8ba006dc817541a0865033722f8289ad.dsn_public,
 )
 pulumi.export(
-    "ocw_next_sentry_dsn",
+    "ocw_site_sentry_dsn",
     key_ocw_next_default_eee58f41dda54d2b814296e12dced4b7.dsn_public,
 )
 pulumi.export(
@@ -3784,10 +3738,6 @@ pulumi.export(
 pulumi.export(
     "sandbox_sentry_dsn",
     key_sandbox_default_8c6395a9422040c999373e204b15bd8b.dsn_public,
-)
-pulumi.export(
-    "unified_ecommerce_sentry_dsn",
-    key_unified_ecommerce_default_734c791eb3c83eb35db04c1b753ff67e.dsn_public,
 )
 pulumi.export(
     "xpro_sentry_dsn",


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/ol-infrastructure/issues/5004

### Description (What does it do?)
Adds `pulumi.export(...)` calls for every remaining `SentryKey` resource in `infrastructure/sentry/__main__.py`, exposing each Sentry project's DSN as a stack output. This follows the pattern already established by `ol_analytics_api_sentry_dsn` (the only existing example of this pattern in the file).

Naming convention: `<project_slug>_sentry_dsn`, with a name-suffixed variant for projects that have more than one key (e.g. `odl_video_service_eternal_mink_sentry_dsn` alongside `odl_video_service_sentry_dsn`).

This is the foundational change for #5004: it does not remove any existing hard-coded/SOPS/Vault secrets by itself, but unblocks a series of follow-up PRs that migrate each consuming application to read its DSN via `sentry_stack.require_output(...)` instead.

Also documents this as a hand-authored generator exception in `IMPORT_SUMMARY.md`, matching the existing note for `ol_analytics_api`, since `infrastructure/sentry/__main__.py` is otherwise owned by `bin/import-sentry-config`.

### How can this be tested?
- `uv run python -m py_compile src/ol_infrastructure/infrastructure/sentry/__main__.py`
- `uv run ruff check src/ol_infrastructure/infrastructure/sentry/__main__.py`
- `pulumi preview` against the `ol-infrastructure-sentry` `Production` stack should show only new stack outputs being added, no resource changes.

### Additional Context
This PR must be merged and deployed (`pulumi up` on the `ol-infrastructure-sentry` `Production` stack) before any of the follow-up consumer-migration PRs from #5004 can be deployed, since they call `sentry_stack.require_output(...)` on these new outputs.