### PR TITLE
Migrate airbyte to stack-output Sentry DSN

### DIFF
--- a/src/ol_infrastructure/applications/airbyte/__main__.py
+++ b/src/ol_infrastructure/applications/airbyte/__main__.py
@@ -23,7 +23,6 @@ from bridge.lib.magic_numbers import (
     DEFAULT_POSTGRES_PORT,
 )
 from bridge.lib.versions import AIRBYTE_CHART_VERSION
-from bridge.secrets.sops import read_yaml_secrets
 from ol_infrastructure.components.aws.database import OLAmazonDB, OLPostgresDBConfig
 from ol_infrastructure.components.aws.eks import (
     OLEKSTrustRole,
@@ -88,6 +87,7 @@ vault_stack = make_stack_reference(
     projects.VAULT_SERVER, f"operations.{stack_info.name}"
 )
 cluster_stack = make_stack_reference(projects.EKS, f"data.{stack_info.name}")
+sentry_stack = make_stack_reference(projects.SENTRY, "Production")
 
 mitodl_zone_id = dns_stack.require_output("odl_zone_id")
 
@@ -437,14 +437,12 @@ vault.aws.SecretBackendRole(
     policy_arns=[s3_source_policy.arn],
 )
 
-airbyte_vault_secrets = read_yaml_secrets(
-    Path(f"airbyte/data.{stack_info.env_suffix}.yaml")
-)
-
 vault.generic.Secret(
     "airbyte-server-configuration-sentry-secrets",
     path=airbyte_vault_mount.path.apply("{}/sentry-dsn".format),
-    data_json=json.dumps(airbyte_vault_secrets["sentry-dsn"]),
+    data_json=sentry_stack.require_output("airbyte_sentry_dsn").apply(
+        lambda dsn: json.dumps({"value": dsn})
+    ),
 )
 ##################################
 #     Network Access Control     #


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/ol-infrastructure/issues/5004

### Description (What does it do?)
`applications/airbyte/__main__.py` previously read its Sentry DSN from a Vault secret at `sentry-dsn`, itself populated from a SOPS-encrypted value in `bridge/secrets/airbyte/data.{ci,qa,production}.yaml`. This switches it to `sentry_stack.require_output("airbyte_sentry_dsn")`, reading the DSN from the `ol-infrastructure-sentry` Pulumi stack instead.

The now-unused `read_yaml_secrets` call and its import were removed since nothing else in the file referenced that dict.

### How can this be tested?
- `uv run python -m py_compile src/ol_infrastructure/applications/airbyte/__main__.py`
- `uv run ruff check src/ol_infrastructure/applications/airbyte/__main__.py`
- `pulumi preview` against an airbyte stack should show only the `airbyte-server-configuration-sentry-secrets` Vault secret's value changing (same shape: `{"value": <dsn>}`), no other resource changes.

### Additional Context
Depends on https://github.com/mitodl/ol-infrastructure/pull/5222 being merged and deployed to the `ol-infrastructure-sentry` `Production` stack first, since this PR calls `sentry_stack.require_output("airbyte_sentry_dsn")`.

Once this is deployed and verified, the `sentry-dsn` entry in `bridge/secrets/airbyte/data.{ci,qa,production}.yaml` becomes redundant and can be removed in a follow-up cleanup PR.