### PR TITLE
Migrate edxapp deployments to stack-output Sentry DSNs

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -100,6 +100,15 @@ kms_stack = make_stack_reference(projects.KMS, stack_info.name)
 vault_stack = make_stack_reference(
     projects.VAULT_SERVER, f"operations.{stack_info.name}"
 )
+sentry_stack = make_stack_reference(projects.SENTRY, "Production")
+# Each edxapp deployment maps to its own Sentry project; mitx and
+# mitx-staging share the openedx-residential project.
+EDXAPP_SENTRY_DSN_OUTPUTS = {
+    "mitx": "openedx_residential_sentry_dsn",
+    "mitx-staging": "openedx_residential_sentry_dsn",
+    "mitxonline": "openedx_mitxonline_sentry_dsn",
+    "xpro": "openedx_mitxpro_sentry_dsn",
+}
 monitoring_stack = make_stack_reference(projects.MONITORING, "default")
 vector_log_proxy_stack = make_stack_reference(
     projects.VECTOR_LOG_PROXY, f"operations.{stack_info.name}"
@@ -546,13 +555,16 @@ edxapp_vault_mount = vault.Mount(
     ),
     type="kv",
 )
+edxapp_static_secrets = read_yaml_secrets(
+    Path(f"edxapp/{stack_info.env_prefix}.{stack_info.env_suffix}.yaml")
+)
 edxapp_secrets = vault.generic.Secret(
     "edxapp-static-secrets",
     path=edxapp_vault_mount.path.apply("{}/edxapp".format),
     data_json=Output.secret(
-        read_yaml_secrets(
-            Path(f"edxapp/{stack_info.env_prefix}.{stack_info.env_suffix}.yaml")
-        )
+        sentry_stack.require_output(
+            EDXAPP_SENTRY_DSN_OUTPUTS[stack_info.env_prefix]
+        ).apply(lambda dsn: {**edxapp_static_secrets, "sentry_dsn": dsn})
     ).apply(json.dumps),
 )
 forum_secrets = vault.generic.Secret(


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/ol-infrastructure/issues/5004

### Description (What does it do?)
`applications/edxapp/secrets_builder.py` templates `SENTRY_DSN` from a per-deployment `sentry_dsn` secret, previously sourced from `bridge/secrets/edxapp/{mitxonline,xpro,mitx,mitx-staging}.{ci,qa,production}.yaml` (SOPS). This PR overrides that value at the point it's written to Vault, sourcing it from the `ol-infrastructure-sentry` stack instead.

Each of the 4 edxapp deployments maps to its own Sentry project, based on shared Sentry team membership:
- `mitxonline` -> `openedx_mitxonline_sentry_dsn` (team: mitxonline)
- `xpro` -> `openedx_mitxpro_sentry_dsn` (team: xpro)
- `mitx` / `mitx-staging` -> `openedx_residential_sentry_dsn` (team: residential-mitx; these two deployments share a project)

`secrets_builder.py`'s Vault-Agent template (`{{ get .Secrets "sentry_dsn" }}`) needed no change since only the *source* of the `sentry_dsn` Vault key's value changed, not the key name itself.

### How can this be tested?
- `uv run python -m py_compile src/ol_infrastructure/applications/edxapp/__main__.py`
- `uv run ruff check src/ol_infrastructure/applications/edxapp/__main__.py`
- `pulumi preview` against each of the 4 edxapp stacks (mitx, mitx-staging, mitxonline, xpro) should show only the `edxapp-static-secrets` Vault secret's `sentry_dsn" field changing, no other resource changes.

### Additional Context
Depends on https://github.com/mitodl/ol-infrastructure/pull/5222 being merged and deployed to the `ol-infrastructure-sentry` `Production` stack first.

The mitx/mitx-staging -> openedx-residential mapping is inferred from Sentry team membership (both deployments' teams include `residential-mitx`) rather than an explicit written record; worth a sanity check from whoever owns Sentry project administration before merging.

Once deployed and verified, the `sentry_dsn` entries in `bridge/secrets/edxapp/{mitxonline,xpro,mitx,mitx-staging}.{ci,qa,production}.yaml` become redundant and can be removed in a follow-up cleanup PR.