### PR TITLE
Migrate learn_ai to stack-output Sentry DSN

### DIFF
--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -110,6 +110,7 @@ monitoring_stack = make_stack_reference(projects.MONITORING, "default")
 network_stack = make_stack_reference(projects.NETWORKING, stack_info.name)
 opik_stack = make_stack_reference(projects.OPIK, stack_info.name)
 policy_stack = make_stack_reference(projects.POLICIES, "default")
+sentry_stack = make_stack_reference(projects.SENTRY, "Production")
 vault_stack = make_stack_reference(
     projects.VAULT_SERVER, f"operations.{stack_info.name}"
 )
@@ -456,7 +457,9 @@ learn_ai_vault_mount = vault.Mount(
 learn_ai_static_vault_secrets = vault.generic.Secret(
     f"learn-ai-secrets-{stack_info.env_suffix}",
     path=learn_ai_vault_mount.path.apply("{}/secrets".format),
-    data_json=json.dumps(learn_ai_vault_secrets),
+    data_json=sentry_stack.require_output("learn_ai_sentry_dsn").apply(
+        lambda dsn: json.dumps({**learn_ai_vault_secrets, "SENTRY_DSN": dsn})
+    ),
 )
 
 ################################################


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/ol-infrastructure/issues/5004

### Description (What does it do?)
`applications/learn_ai/__main__.py` previously wrote the `SENTRY_DSN` key from `bridge/secrets/learn_ai/secrets.{ci,qa,production}.yaml` (SOPS) directly into the app's Vault secret. This switches it to `sentry_stack.require_output("learn_ai_sentry_dsn")` (Sentry project slug `learn-ai`).

### How can this be tested?
- `uv run python -m py_compile src/ol_infrastructure/applications/learn_ai/__main__.py`
- `uv run ruff check src/ol_infrastructure/applications/learn_ai/__main__.py`
- `pulumi preview` against a learn_ai stack should show only the `learn-ai-secrets-{env}` Vault secret's `SENTRY_DSN` field changing, no other resource changes.

### Additional Context
Depends on https://github.com/mitodl/ol-infrastructure/pull/5222 being merged and deployed to the `ol-infrastructure-sentry` `Production` stack first.

Once deployed and verified, the `SENTRY_DSN` entry in `bridge/secrets/learn_ai/secrets.{ci,qa,production}.yaml` becomes redundant and can be removed in a follow-up cleanup PR.