### PR TITLE
Migrate mit_learn (Django backend) to stack-output Sentry DSN

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -137,6 +137,7 @@ ocw_site_buckets = ocw_site_stack.require_output("ocw_site_buckets")
 qdrant_cloud_stack = make_stack_reference(
     projects.QDRANT_CLOUD, f"mitlearn.{stack_info.name}"
 )
+sentry_stack = make_stack_reference(projects.SENTRY, "Production")
 
 qdrant_secrets = read_yaml_secrets(Path("qdrant_cloud/account.yaml"))
 qdrant_provider = qdrant_cloud.Provider(
@@ -408,11 +409,18 @@ mitlearn_vault_secrets = read_yaml_secrets(
 mitlearn_vault_static_secrets = vault.generic.Secret(
     f"ol-mitlearn-configuration-secrets-{stack_info.env_suffix}",
     path=mitlearn_vault_mount.path.apply("{}/secrets".format),
-    data_json=qdrant_api_key.key.apply(
-        lambda key: json.dumps(
+    data_json=Output.all(
+        qdrant_api_key=qdrant_api_key.key,
+        sentry_dsn=sentry_stack.require_output("open_next_sentry_dsn"),
+    ).apply(
+        lambda args: json.dumps(
             {
                 **mitlearn_vault_secrets,
-                "qdrant": {**mitlearn_vault_secrets["qdrant"], "api_key_v2": key},
+                "qdrant": {
+                    **mitlearn_vault_secrets["qdrant"],
+                    "api_key_v2": args["qdrant_api_key"],
+                },
+                "sentry_dsn": args["sentry_dsn"],
             }
         )
     ),


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/ol-infrastructure/issues/5004

### Description (What does it do?)
`applications/mit_learn/k8s_secrets.py` templates `SENTRY_DSN` from a `sentry_dsn` key previously sourced from `bridge/secrets/mitlearn/secrets.{ci,qa,production}.yaml` (SOPS). This switches the value written to Vault to `sentry_stack.require_output("open_next_sentry_dsn")`.

**Sentry project mapping note**: mit_learn (the K8s Django backend at `api.learn.mit.edu`) shares the `open-next` Sentry project with `mit_learn_nextjs` (the Next.js frontend, see https://github.com/mitodl/ol-infrastructure/pull/5227). The `open-next` project's `platform=python-django` label is stale/inaccurate as a result -- it predates the frontend/backend split, but both apps report there today. This mapping was confirmed directly rather than assumed, since guessing wrong would misroute production error monitoring.

### How can this be tested?
- `uv run python -m py_compile src/ol_infrastructure/applications/mit_learn/__main__.py`
- `uv run ruff check src/ol_infrastructure/applications/mit_learn/__main__.py`
- `pulumi preview` against a mit_learn stack should show only the `ol-mitlearn-configuration-secrets-{env}` Vault secret's `sentry_dsn` field changing, no other resource changes.

### Additional Context
Depends on https://github.com/mitodl/ol-infrastructure/pull/5222 being merged and deployed to the `ol-infrastructure-sentry` `Production` stack first.

Once deployed and verified, the `sentry_dsn` entry in `bridge/secrets/mitlearn/secrets.{ci,qa,production}.yaml` becomes redundant and can be removed in a follow-up cleanup PR.