### PR TITLE
Migrate mit_learn_nextjs to stack-output Sentry DSN

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.CI.yaml
@@ -23,8 +23,6 @@ config:
   nextjs:posthog_project_id:
     secure: v1:zDVvOZBoJfzj2JNp:zcKYzRHBEPZ8iM5+NvPL/G7Oskkw
   nextjs:recommendation_endpoint: "https://api.ci.learn.mit.edu/ai/http/recommendation_agent/"
-  nextjs:sentry_dsn:
-    secure: v1:GISrW09cyDNOopo5:3ubNcN1ZOhKreca0xTuBAQ==
   nextjs:sentry_env: "ci"
   nextjs:syllabus_endpoint: "https://api.ci.learn.mit.edu/ai/http/syllabus_agent/"
   nextjs:optimize_images: "true"

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.Production.yaml
@@ -27,8 +27,6 @@ config:
   nextjs:posthog_project_id:
     secure: v1:IY8kATrcMVk0PJdB:U5qEC1Iuoxnm707xldqg5SXBSPb2
   nextjs:recommendation_endpoint: "https://api.learn.mit.edu/ai/http/recommendation_agent/"
-  nextjs:sentry_dsn:
-    secure: v1:ox5oolYtQIKsmojo:0ogC8iKnU4ECkqSmDxGTb3dHlGU1oQFMOjhIkVLYrYNcc53LGHd3IdaCyLgAXtyyEkE+/Qk+d6l6WpFnKpPzmprsNeWsV5YhQYaGnQhKYBwaaDav4+HPY7S/xXRqwQE3DjbZBA==
   nextjs:sentry_env: "production"
   nextjs:syllabus_endpoint: "https://api.learn.mit.edu/ai/http/syllabus_agent/"
   nextjs:optimize_images: "false"

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/Pulumi.QA.yaml
@@ -27,8 +27,6 @@ config:
   nextjs:posthog_project_id:
     secure: v1:0RjYuffs0Kq5piyu:/Weziwdlwuk/A4W2YYEHx2g0Jczv
   nextjs:recommendation_endpoint: "https://api.rc.learn.mit.edu/ai/http/recommendation_agent/"
-  nextjs:sentry_dsn:
-    secure: v1:FVKlsmjuVBFWXhWG:dxpsTB02SGRWkUfDCpmanVKBOQA6EXh6KnnZ8R+nqHsCF/WOBY/SlZMqikOI6CYlYmhCt8T/BAFn2Ps3xzll68R8UXWBIEhQrfkky4ArOGLRC3xRO6MN7bMS5gjenAhzMIgg3g==
   nextjs:sentry_env: "rc"
   nextjs:syllabus_endpoint: "https://api.rc.learn.mit.edu/ai/http/syllabus_agent/"
   nextjs:optimize_images: "true"

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
@@ -151,7 +151,7 @@ raw_env_vars = {
     "NEXT_PUBLIC_POSTHOG_API_KEY": nextjs_config.require("posthog_api_key"),
     "NEXT_PUBLIC_POSTHOG_PROJECT_ID": nextjs_config.require("posthog_project_id"),
     "NEXT_PUBLIC_POSTHOG_UI_HOST": "https://us.posthog.com",
-    "NEXT_PUBLIC_SENTRY_DSN": sentry_stack.require_output("open_next_sentry_dsn"),
+    "NEXT_PUBLIC_SENTRY_DSN": sentry_stack.require_output("mit_learn_sentry_dsn"),
     "NEXT_PUBLIC_SENTRY_ENV": nextjs_config.require("sentry_env"),
     "NEXT_PUBLIC_SENTRY_PROFILES_SAMPLE_RATE": "0.25",
     "NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE": "0.001",

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
@@ -35,6 +35,7 @@ from ol_infrastructure.lib.pulumi_helper import (
 stack_info = parse_stack()
 
 cluster_stack = make_stack_reference(projects.EKS, f"applications.{stack_info.name}")
+sentry_stack = make_stack_reference(projects.SENTRY, "Production")
 MIT_LEARN_NEXTJS_DOCKER_TAG = get_docker_image_tag("MIT_LEARN_NEXTJS")
 
 app_image = ecr_image_uri(
@@ -150,7 +151,7 @@ raw_env_vars = {
     "NEXT_PUBLIC_POSTHOG_API_KEY": nextjs_config.require("posthog_api_key"),
     "NEXT_PUBLIC_POSTHOG_PROJECT_ID": nextjs_config.require("posthog_project_id"),
     "NEXT_PUBLIC_POSTHOG_UI_HOST": "https://us.posthog.com",
-    "NEXT_PUBLIC_SENTRY_DSN": nextjs_config.require("sentry_dsn"),
+    "NEXT_PUBLIC_SENTRY_DSN": sentry_stack.require_output("open_next_sentry_dsn"),
     "NEXT_PUBLIC_SENTRY_ENV": nextjs_config.require("sentry_env"),
     "NEXT_PUBLIC_SENTRY_PROFILES_SAMPLE_RATE": "0.25",
     "NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE": "0.001",


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/ol-infrastructure/issues/5004

### Description (What does it do?)
`applications/mit_learn_nextjs/__main__.py` previously set `NEXT_PUBLIC_SENTRY_DSN` from `nextjs_config.require("sentry_dsn")`, a per-stack encrypted Pulumi config value (not SOPS, but the same cargo-culted hard-coded-secret pattern). This switches it to `sentry_stack.require_output("open_next_sentry_dsn")`, and removes the now-unused `nextjs:sentry_dsn` config value from `Pulumi.{CI,QA,Production}.yaml`.

**Sentry project mapping note**: confirmed directly with the mit-learn team that this frontend shares the `open-next` Sentry project with the `mit_learn` Django backend (see https://github.com/mitodl/ol-infrastructure/pull/5226) -- there's no dedicated JS/Next.js-platform Sentry project among the live projects, so this wasn't assumed.

### How can this be tested?
- `uv run python -m py_compile src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py`
- `uv run ruff check src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py`
- YAML parse check on the 3 `Pulumi.*.yaml` files (`python -c "import yaml; yaml.safe_load(open(f))"`)
- `pulumi preview` against a mit_learn_nextjs stack should show the `NEXT_PUBLIC_SENTRY_DSN` env var's source changing and the `nextjs:sentry_dsn` config key being removed, no other resource changes.

### Additional Context
Depends on https://github.com/mitodl/ol-infrastructure/pull/5222 being merged and deployed to the `ol-infrastructure-sentry` `Production` stack first.