### PR TITLE
Migrate mitxonline (Django backend) to stack-output Sentry DSN

### DIFF
--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -125,6 +125,7 @@ network_stack = make_stack_reference(projects.NETWORKING, stack_info.name)
 apps_vpc = network_stack.require_output("applications_vpc")
 data_vpc = network_stack.require_output("data_vpc")
 k8s_pod_subnet_cidrs = apps_vpc["k8s_pod_subnet_cidrs"]
+sentry_stack = make_stack_reference(projects.SENTRY, "Production")
 operations_vpc = network_stack.require_output("operations_vpc")
 mitxonline_environment = f"mitxonline-{stack_info.env_suffix}"
 
@@ -416,6 +417,16 @@ mitxonline_vault_collected_static_secrets = vault.generic.Secret(
     path="secret-mitxonline/collected-static-secrets",
     data_json=json.dumps(mitxonline_collected_secrets),
     opts=ResourceOptions(depends_on=[mitxonline_vault_mount]),
+)
+# Dedicated single-purpose path also read by the mitxonline edxapp deployment's
+# k8s secrets (see applications/mitxonline/k8s_secrets.py); previously a
+# hard-coded secret, now sourced from the ol-infrastructure-sentry stack output.
+mitxonline_operations_sentry_dsn = vault.generic.Secret(
+    f"mitxonline-operations-sentry-dsn-{stack_info.env_suffix}",
+    path="secret-operations/global/mitxonline/sentry-dsn",
+    data_json=sentry_stack.require_output("mitxonline_sentry_dsn").apply(
+        lambda dsn: json.dumps({"value": dsn})
+    ),
 )
 
 mitxonline_vault_policy = vault.Policy(


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/ol-infrastructure/issues/5004

### Description (What does it do?)
`applications/mitxonline/k8s_secrets.py` reads `SENTRY_DSN` from the shared `secret-operations` KV-v1 mount at path `global/mitxonline/sentry-dsn`. Unlike the other consumers migrated for #5004, this path had **no existing Pulumi-managed write anywhere in this repo** -- it was populated externally/manually.

This PR adds a new, dedicated `vault.generic.Secret` write at that path, sourced from `sentry_stack.require_output("mitxonline_sentry_dsn")`. This is lower risk than it might sound: the path is single-purpose (holds only a `{"value": <dsn>}` shape, confirmed against the existing read template `{{ get .Secrets "value" }}`), and always kv-v1, so there's no risk of clobbering an unrelated key or getting kv1/kv2 path semantics wrong.

### How can this be tested?
- `uv run python -m py_compile src/ol_infrastructure/applications/mitxonline/__main__.py`
- `uv run ruff check src/ol_infrastructure/applications/mitxonline/__main__.py`
- `pulumi preview` against a mitxonline stack should show a **new** `vault.generic.Secret` resource (`mitxonline-operations-sentry-dsn-{env}`) being created at `secret-operations/global/mitxonline/sentry-dsn`, no other resource changes.

### Additional Context
Depends on https://github.com/mitodl/ol-infrastructure/pull/5222 being merged and deployed to the `ol-infrastructure-sentry` `Production` stack first.

Because this is a first-time Pulumi-managed write to a previously externally-populated path, it's worth a second pair of eyes from whoever currently owns/updates that secret manually, to confirm nothing else depends on the value staying exactly as it was set outside Pulumi.