### PR TITLE
Migrate ocw_studio to stack-output Sentry DSN

### DIFF
--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -94,6 +94,7 @@ network_stack = make_stack_reference(projects.NETWORKING, stack_info.name)
 vault_stack = make_stack_reference(
     projects.VAULT_SERVER, f"operations.{stack_info.name}"
 )
+sentry_stack = make_stack_reference(projects.SENTRY, "Production")
 apps_vpc = network_stack.require_output("applications_vpc")
 data_vpc = network_stack.require_output("data_vpc")
 operations_vpc = network_stack.require_output("operations_vpc")
@@ -341,7 +342,9 @@ vault_secrets = read_yaml_secrets(
 vault.generic.Secret(
     "ocw-studio-vault-secrets",
     path=ocw_studio_secrets.path.apply("{}/collected".format),
-    data_json=json.dumps(vault_secrets),
+    data_json=sentry_stack.require_output("ocw_studio_sentry_dsn").apply(
+        lambda dsn: json.dumps({**vault_secrets, "sentry_dsn": dsn})
+    ),
 )
 
 


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/ol-infrastructure/issues/5004

### Description (What does it do?)
`applications/ocw_studio/k8s_secrets.py` templates `SENTRY_DSN` from a `sentry_dsn` key previously sourced from `bridge/secrets/ocw_studio/ocw_studio.{ci,qa,production}.yaml` (SOPS, nested under `collected_secrets`). This switches the value written to Vault to `sentry_stack.require_output("ocw_studio_sentry_dsn")`.

### How can this be tested?
- `uv run python -m py_compile src/ol_infrastructure/applications/ocw_studio/__main__.py`
- `uv run ruff check src/ol_infrastructure/applications/ocw_studio/__main__.py`
- `pulumi preview` against an ocw_studio stack should show only the `ocw-studio-vault-secrets` Vault secret's `sentry_dsn` field changing, no other resource changes.

### Additional Context
Depends on https://github.com/mitodl/ol-infrastructure/pull/5222 being merged and deployed to the `ol-infrastructure-sentry` `Production` stack first.

Once deployed and verified, the `sentry_dsn` entry in `bridge/secrets/ocw_studio/ocw_studio.{ci,qa,production}.yaml` becomes redundant and can be removed in a follow-up cleanup PR.