### PR TITLE
Migrate open_discussions (legacy mit-open) to stack-output Sentry DSN

### DIFF
--- a/src/ol_infrastructure/applications/open_discussions/__main__.py
+++ b/src/ol_infrastructure/applications/open_discussions/__main__.py
@@ -362,10 +362,6 @@ vault.generic.Secret(
     ),
     opts=ResourceOptions(parent=mit_open_vault_iam_role),
 )
-secret_operations_global_mit_open_sentry_dsn = vault.generic.get_secret_output(
-    path="secret-operations/global/mit-open/sentry-dsn",
-    opts=InvokeOptions(parent=mit_open_vault_iam_role),
-)
 secret_operations_sso_open_discussions = vault.generic.get_secret_output(
     path="secret-operations/sso/open-discussions",
     opts=InvokeOptions(parent=mit_open_vault_iam_role),
@@ -530,9 +526,7 @@ sensitive_heroku_vars = {
     "SECRET_KEY": secret_mit_open_env_django_secret_key.data.apply(
         lambda data: "{}".format(data["value"])
     ),
-    "SENTRY_DSN": secret_operations_global_mit_open_sentry_dsn.data.apply(
-        lambda data: "{}".format(data["value"])
-    ),
+    "SENTRY_DSN": sentry_stack.require_output("open_sentry_dsn"),
     "SOCIAL_AUTH_OL_OIDC_SECRET": secret_operations_sso_open_discussions.data.apply(
         lambda data: "{}".format(data["client_secret"])
     ),

--- a/src/ol_infrastructure/applications/open_discussions/__main__.py
+++ b/src/ol_infrastructure/applications/open_discussions/__main__.py
@@ -1,5 +1,7 @@
 # ruff: noqa: E501
 
+import json
+
 import pulumi_vault as vault
 import pulumiverse_heroku as heroku
 from pulumi import (
@@ -15,15 +17,17 @@ from pulumi_aws import iam, s3
 from pulumi_vault import aws
 
 from ol_infrastructure.components.aws.s3 import OLBucket, S3BucketConfig
+from ol_infrastructure.lib import pulumi_projects as projects
 from ol_infrastructure.lib.aws.iam_helper import IAM_POLICY_VERSION, lint_iam_policy
 from ol_infrastructure.lib.heroku import setup_heroku_provider
 from ol_infrastructure.lib.ol_types import AWSBase
-from ol_infrastructure.lib.pulumi_helper import parse_stack
+from ol_infrastructure.lib.pulumi_helper import make_stack_reference, parse_stack
 from ol_infrastructure.lib.vault import setup_vault_provider
 
 stack_info = parse_stack()
 setup_vault_provider(stack_info, skip_child_token=True)
 setup_heroku_provider()
+sentry_stack = make_stack_reference(projects.SENTRY, "Production")
 
 mit_open_config = Config("mit_open")
 heroku_config = Config("heroku")
@@ -347,6 +351,16 @@ secret_global_mailgun_api_key = vault.generic.get_secret_output(
 secret_operations_global_mit_smtp = vault.generic.get_secret_output(
     path="secret-operations/global/mit-smtp",
     opts=InvokeOptions(parent=mit_open_vault_iam_role),
+)
+# Previously a hard-coded/manually-populated Vault secret; now sourced from
+# the ol-infrastructure-sentry stack output.
+vault.generic.Secret(
+    "mit-open-operations-sentry-dsn",
+    path="secret-operations/global/mit-open/sentry-dsn",
+    data_json=sentry_stack.require_output("open_sentry_dsn").apply(
+        lambda dsn: json.dumps({"value": dsn})
+    ),
+    opts=ResourceOptions(parent=mit_open_vault_iam_role),
 )
 secret_operations_global_mit_open_sentry_dsn = vault.generic.get_secret_output(
     path="secret-operations/global/mit-open/sentry-dsn",


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/ol-infrastructure/issues/5004

### Description (What does it do?)
`applications/open_discussions/__main__.py` reads `SENTRY_DSN` via `vault.generic.get_secret_output(path="secret-operations/global/mit-open/sentry-dsn")`. As with mitxonline (https://github.com/mitodl/ol-infrastructure/pull/5228), this path had **no existing Pulumi-managed write anywhere in this repo** -- it was populated externally/manually.

This app is confirmed still live: it's the legacy Heroku Django backend at `open.mit.edu` / `discussions.odl.mit.edu`, distinct from `mit_learn`'s current K8s deployment at `learn.mit.edu` (they run on different infrastructure with different Pulumi.\*.yaml domain configs).

This PR adds a new, dedicated `vault.generic.Secret` write at that path, sourced from `sentry_stack.require_output("open_sentry_dsn")` (Sentry project slug `open`, display name "Discussions"). Same low-risk shape as the mitxonline case: single-purpose path holding only `{"value": <dsn>}`.

### How can this be tested?
- `uv run python -m py_compile src/ol_infrastructure/applications/open_discussions/__main__.py`
- `uv run ruff check src/ol_infrastructure/applications/open_discussions/__main__.py`
- `pulumi preview` against the open_discussions stack should show a **new** `vault.generic.Secret` resource (`mit-open-operations-sentry-dsn`) being created at `secret-operations/global/mit-open/sentry-dsn`, no other resource changes.

### Additional Context
Depends on https://github.com/mitodl/ol-infrastructure/pull/5222 being merged and deployed to the `ol-infrastructure-sentry` `Production` stack first.

Same caveat as #5228: this is a first-time Pulumi-managed write to a previously externally-populated path, so worth a second pair of eyes from whoever currently owns that secret.