### PR TITLE
Migrate xpro (Django backend) to stack-output Sentry DSN

### DIFF
--- a/src/ol_infrastructure/applications/xpro/__main__.py
+++ b/src/ol_infrastructure/applications/xpro/__main__.py
@@ -111,6 +111,7 @@ operations_vpc = network_stack.require_output("operations_vpc")
 vault_stack = make_stack_reference(
     projects.VAULT_SERVER, f"operations.{stack_info.name}"
 )
+sentry_stack = make_stack_reference(projects.SENTRY, "Production")
 aws_config = AWSBase(
     tags={
         "OU": "mitxpro",
@@ -315,6 +316,8 @@ xpro_vault_secrets = read_yaml_secrets(
 )
 
 for key, data in xpro_vault_secrets.items():
+    if key == "sentry":
+        continue
     vault.kv.Secret(
         f"xpro-vault-secrets-{key}",
         # This mount is created already as part of the edxapp Pulumi project. See note
@@ -322,6 +325,16 @@ for key, data in xpro_vault_secrets.items():
         path=f"secret-xpro/{key}",
         data_json=json.dumps(data),
     )
+
+# Previously a hard-coded SOPS secret; now sourced from the
+# ol-infrastructure-sentry stack output.
+vault.kv.Secret(
+    "xpro-vault-secrets-sentry",
+    path="secret-xpro/sentry",
+    data_json=sentry_stack.require_output("xpro_sentry_dsn").apply(
+        lambda dsn: json.dumps({**xpro_vault_secrets["sentry"], "dsn": dsn})
+    ),
+)
 
 # env_name is 'ci' 'rc' or 'production'
 env_name = stack_info.name.lower() if stack_info.name != "QA" else "rc"


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/ol-infrastructure/issues/5004

### Description (What does it do?)
`applications/xpro/__main__.py` writes each top-level key from `bridge/secrets/xpro/secrets.{ci,qa,production}.yaml` (SOPS) to its own Vault path via a generic loop, including `secret-xpro/sentry` (a `dsn` key, separate from the edxapp xpro instance's own SOPS-managed DSN migrated in https://github.com/mitodl/ol-infrastructure/pull/5224).

This PR excludes `sentry` from that generic loop and adds a dedicated write for `secret-xpro/sentry`, sourced from `sentry_stack.require_output("xpro_sentry_dsn")` merged over the existing sentry dict (which only has the one `dsn` key, so no other keys are at risk).

### How can this be tested?
- `uv run python -m py_compile src/ol_infrastructure/applications/xpro/__main__.py`
- `uv run ruff check src/ol_infrastructure/applications/xpro/__main__.py`
- `pulumi preview` against an xpro stack should show only the `secret-xpro/sentry` Vault secret's `dsn` field changing, no other resource changes.

### Additional Context
Depends on https://github.com/mitodl/ol-infrastructure/pull/5222 being merged and deployed to the `ol-infrastructure-sentry` `Production` stack first.

Once deployed and verified, the `sentry.dsn` entry in `bridge/secrets/xpro/secrets.{ci,qa,production}.yaml` becomes redundant and can be removed in a follow-up cleanup PR.