### PR TITLE
feat(admin): add executable employee offboarding tool

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,19 @@
+# Pulumi's `awskms://` secrets provider stores ciphertext in stack files by design:
+# `encryptedkey` is a KMS-wrapped data encryption key and `secure` values are the
+# config entries it protects. Both are inert without `kms:Decrypt` on the alias named
+# in `secretsprovider`, so they are not credentials and cannot be rotated by editing
+# source. Their high entropy otherwise trips the generic-api-key heuristic on all ~300
+# stack files. This mirrors the identical exclusion already applied to detect-secrets
+# in .pre-commit-config.yaml.
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Pulumi KMS/SOPS ciphertext committed by design"
+regexTarget = "line"
+regexes = [
+  '''^\s*encryptedkey:\s''',
+  '''^\s*secure:\s''',
+  '''^\s*secretsprovider:\s''',
+]

--- a/docs/adr/0011-executable-offboarding-script-over-runbook.md
+++ b/docs/adr/0011-executable-offboarding-script-over-runbook.md
@@ -1,0 +1,264 @@
+# 0011. Executable Offboarding Script Over a Prose Runbook
+
+**Status:** Proposed
+**Date:** 2026-08-04
+**Deciders:** Infrastructure team
+**Technical Story:** [#5235 — Write an offboarding runbook for employees](https://github.com/mitodl/ol-infrastructure/issues/5235)
+
+## Context
+
+### Current Situation
+
+Issue #5235 asks for a prose offboarding runbook covering "removing people from" roughly a dozen
+systems: Keycloak/SSO, AWS IAM, Kubernetes, GitHub, CI/CD, Vault, observability and
+incident-response tools, DNS/CDN/control planes, and privileged SaaS.
+
+Auditing the repository for where human access actually lives produced a far more concentrated
+picture than that list suggests, and — critically — it revealed that the access surfaces split
+into two categories with **opposite** correct handling. A prose runbook cannot enforce that split;
+a reader following instructions is exactly the failure mode we need to design against.
+
+**Access surface 1 — Keycloak is the identity hub.** The `ol-platform-engineering` realm
+(`src/ol_infrastructure/substructure/keycloak/ol_platform_engineering.py`) declares **ten** OIDC
+clients, all of which federate interactive login from it:
+
+| Keycloak client | Service |
+|---|---|
+| `ol-vault-client` | Vault |
+| `ol-grafana-client` | Grafana (with role mapper → admin/editor/viewer client roles) |
+| `ol-concourse-client` | Concourse |
+| `ol-dagster-client` | Dagster |
+| `ol-airbyte-client` | Airbyte |
+| `ol-jupyterhub-client` | JupyterHub |
+| `ol-opik-client` | Opik |
+| `ol-toolhive-client` | ToolHive |
+| `ol-leek-client` | Leek |
+| `ol-gwarek-client` | Gwarek |
+
+Disabling one Keycloak user therefore revokes interactive access to ten services in one action.
+The realm sets `registration_email_as_username=True`, so username == email address, which makes an
+email address a sufficient and unambiguous identity key for this surface. Keycloak **users** are
+not Pulumi-declared (only realms, roles, clients and mappers are), so users are pure
+Admin-REST-API territory.
+
+Vault reinforces this: GitHub auth was deliberately removed and OIDC-via-Keycloak is the only
+interactive path, with an explicit "do not re-add GitHub auth" comment at
+`src/ol_infrastructure/substructure/vault/auth/__main__.py:69`.
+
+**Access surface 2 — Pulumi-managed, hardcoded human identity.** Two places encode humans
+directly in infrastructure code:
+
+- `src/ol_infrastructure/lib/aws/iam_helper.py` holds four hardcoded username lists —
+  `ADMIN_USERNAMES`, `DEVOPS_ADMIN_USERNAMES`, `EKS_ADMIN_USERNAMES`, `EKS_DEVELOPER_USERNAMES` —
+  consumed by `infrastructure/aws/iam`, `infrastructure/aws/eks`, `infrastructure/aws/opensearch`
+  and `applications/concourse/iam_policies/pulumi_infra.py`.
+- `src/ol_infrastructure/saas/rootly/__main__.py` holds hardcoded numeric Rootly `user_id`s in
+  team membership (`user_ids=[99415, 100683, 103372, 103392]`) and in on-call escalation policy
+  member positions.
+
+For these, an API deletion is actively harmful: the next `pulumi up` would recreate the access, and
+in the AWS case a deleted-out-of-band IAM user breaks the `iam.GroupMembership` resource. The
+correct action is a **code change plus `pulumi up`**, which a script can identify precisely but must
+not perform.
+
+### Problem Statement
+
+An offboarding procedure must (a) be fast and complete enough to use under urgent-termination
+pressure, (b) be *verifiable* — someone must be able to confirm access is gone — and (c) never
+take an API action against a Pulumi-managed resource. A prose runbook satisfies none of these
+reliably: it drifts from the code it describes, it produces no artifact proving what was done, and
+it puts the never-API-delete-Pulumi-managed-resources rule in the reader's head rather than in the
+tooling.
+
+### Business/Technical Drivers
+
+- Departing staff currently retain access to whatever nobody remembered to check.
+- The ten-service Keycloak fan-out means the highest-value action is also the easiest to script,
+  and is currently undocumented anywhere.
+- Vault's OIDC `readonly` and `developer` roles carry **no** `bound_claims` (only `admin` is
+  claim-gated at `substructure/vault/auth/__main__.py:165`), so any authenticated realm user can
+  mint a Vault token. Combined with an 8-hour `token_ttl`, a Keycloak disable alone leaves a live
+  Vault session valid for up to 8 more hours. Nothing in the repo records that gap today.
+
+### Constraints
+
+- **Verification must be non-destructive.** We cannot test an offboarding tool by offboarding
+  someone. Correctness has to come from HTTP-mocked unit tests plus read-only `discover()` runs
+  against QA/non-prod.
+- **Pulumi-managed identity is off-limits to the API path**, per the two surfaces above.
+- Credentials for each service differ (Keycloak admin password, Vault token, AWS profile, Rootly
+  API token); the tool must degrade to a partial run rather than fail closed when one is absent,
+  because an urgent offboard should not stall on a missing Rootly token.
+- Repo conventions: single-file executable under `scripts/` (see `scripts/where-is-my-pr`),
+  `cyclopts` for CLI, `httpx` for HTTP (see `scripts/keycloak_user_org_manager.py`).
+
+### Assumptions
+
+- Email address is the primary identity key. It resolves Keycloak directly. It resolves AWS only
+  by *convention* (MIT Kerberos localpart == IAM username, e.g. `cpatti@mit.edu` → `cpatti`) —
+  a convention the tool must verify rather than trust.
+- Rootly numeric user IDs cannot be derived from an email offline; they require an API lookup.
+- Sentry, Grafana Cloud org membership, and password-manager/SaaS consoles have no
+  Pulumi-managed or in-repo human-access surface, so they are irreducibly manual.
+
+### Options Considered
+
+1. **Prose runbook, as literally requested in #5235**
+   - Pros: cheapest to write; no credentials or blast radius; covers systems that have no API.
+   - Cons: drifts silently from `iam_helper.py` and the Rootly user IDs the moment either changes;
+     produces no record of what was actually revoked; relies on a human to know that deleting an
+     AWS IAM user by hand is wrong; unverifiable.
+
+2. **Fully automated offboarding, including the Pulumi-managed surfaces**
+   - Pros: single action, nothing left to a human.
+   - Cons: requires either API-deleting Pulumi-managed identities (which `pulumi up` then reverts,
+     and which breaks `iam.GroupMembership`) or having the script commit code and run `pulumi up`
+     itself — an unreviewed automated production deploy during a security-sensitive event. Rejected
+     on both counts.
+
+3. **Executable script, dry-run by default, that revokes what is safe to revoke via API and
+   *reports* what is not** — with findings classified into API-revoked / needs-code-change /
+   needs-a-human, plus a thin residual doc for the genuinely manual tail.
+   - Pros: the never-touch-Pulumi-managed rule is encoded in the tool, not in the operator;
+     dry-run output doubles as the always-current runbook, so it cannot drift from the code;
+     every run produces an auditable artifact; the ten-service Keycloak win is one command.
+   - Cons: more work than prose; needs credentials for four services; the manual tail still needs
+     a human, so this does not fully eliminate the runbook — it shrinks it.
+
+## Decision
+
+### Chosen Option
+
+Option 3. Build `scripts/admin/offboard-employee` — a single-file `cyclopts` executable taking one
+or more email addresses — and reduce the #5235 runbook to a thin residual document covering only
+what no API can reach.
+
+### Rationale
+
+The decisive factor is that the two access surfaces require opposite handling, and that asymmetry
+is a *property of this codebase* discoverable only by reading it. Encoding it in a tool makes it
+enforced; encoding it in prose makes it advisory. Secondarily, generating the runbook from a
+dry-run means the documentation is derived from the code rather than maintained alongside it,
+which is the only way it stays true as `iam_helper.py` and the Rootly user IDs change.
+
+### Key Implementation Details
+
+**Provider protocol.** Each service is a provider implementing two methods:
+
+- `discover(identity) -> list[Finding]` — strictly read-only, always safe to run.
+- `revoke(finding, *, execute: bool) -> ActionRecord` — emits an identically-shaped record whether
+  or not it mutates, so dry-run and execute output are diffable.
+
+**Three-way outcome taxonomy.** Every finding classifies into exactly one of:
+
+- `REVOKED_VIA_API` — the tool can and did (or would) revoke it.
+- `NEEDS_CODE_CHANGE` — requires a repo edit plus `pulumi up`. The finding must name the exact
+  file, symbol, and stack(s) to re-deploy.
+- `NEEDS_HUMAN` — a UI-only action, with the console URL and the owning team.
+
+**Safety model.**
+
+- Dry-run is the **default**. Mutation requires an explicit `--execute`.
+- `--execute` additionally requires interactive confirmation echoing the resolved human identity
+  per service, unless `--yes` is passed.
+- `--only` / `--skip` accept service names, so a partial or resumed run is possible.
+- A missing credential for one service degrades that provider to skipped-with-a-warning; it does
+  not abort the run.
+
+**Per-service plan.**
+
+| Service | `REVOKED_VIA_API` | `NEEDS_CODE_CHANGE` | `NEEDS_HUMAN` |
+|---|---|---|---|
+| Keycloak (`ol-platform-engineering`) | disable user, kill sessions, drop realm/client role mappings, drop federated identities — cascades to all ten clients | — | — |
+| Vault | revoke the OIDC entity's live token accessors (closes the ≤8h `token_ttl` window Keycloak alone leaves open) | — | — |
+| AWS IAM | ephemeral credentials only: access keys, console login profile, MFA devices | remove from the relevant `iam_helper.py` list + `pulumi up` on `aws/iam`, `aws/eks`, `aws/opensearch`, `concourse` | — |
+| Rootly | user deactivation, **if** the API supports it (open question below) | remove `user_id` from `saas/rootly/__main__.py` team membership and escalation positions + `pulumi up` | reassign open incidents |
+| GitHub org | — | — | org/team membership removal |
+| Sentry, Grafana Cloud org, password manager, other SaaS | — | — | console removal |
+
+Note the AWS split is deliberate: the script revokes credentials (immediate, reversible,
+not Pulumi-managed) and reports group membership (Pulumi-managed). Note also that
+`EKS_DEVELOPER_USERNAMES` differs from the other three lists — those users are *declared* as
+`iam.User` resources at `infrastructure/aws/iam/__main__.py:65`, so removing a name from that list
+destroys the user, whereas removing a name from `ADMIN_USERNAMES` only drops a group membership.
+The reported code-change instruction must say which.
+
+**Verification.** HTTP-mocked unit tests for each provider's `discover()` parsing and `revoke()`
+request construction, plus read-only `discover()` runs against QA. No test may mutate.
+
+### Open Questions To Resolve During Implementation
+
+- Does Rootly's REST API expose user deactivation? The `pulumi_rootly` provider has a
+  `GetUser` data source but **no** `User` resource, confirming Pulumi cannot manage Rootly users
+  either way. If the API has no deactivation verb, Rootly's user-level action becomes
+  `NEEDS_HUMAN` while team membership stays `NEEDS_CODE_CHANGE`. Resolve with a read-only
+  `GET /v1/users` probe.
+- Email → AWS IAM username resolution relies on the Kerberos-localpart convention. The tool must
+  confirm the derived username exists in IAM and report an unresolved-identity finding rather than
+  guessing or silently skipping.
+
+## Consequences
+
+### Positive Consequences
+
+- The highest-leverage action — disabling one Keycloak user, which cuts interactive access to ten
+  services — becomes a single documented command instead of tribal knowledge.
+- The ≤8-hour live-Vault-token gap after a Keycloak disable is closed explicitly rather than
+  being an unrecorded hazard.
+- Dry-run output is a runbook generated from the code, so it cannot drift from `iam_helper.py` or
+  the Rootly user IDs.
+- Every offboard produces an auditable record of what was and was not revoked.
+- The rule "never API-delete a Pulumi-managed identity" moves from operator memory into tooling.
+
+### Negative Consequences
+
+- Substantially more work than writing prose, and the manual tail still needs a documented
+  procedure — this shrinks the runbook rather than eliminating it.
+- The tool needs credentials for four services; whoever runs it holds significant privilege.
+- The `NEEDS_CODE_CHANGE` path is inherently slower than an API call: a PR plus `pulumi up`. For
+  urgent terminations, the Keycloak + credential-revocation path is the fast containment and the
+  code change is follow-up cleanup. The tool's output ordering should make that sequencing obvious.
+- A script that is not run is worse than a runbook that is read; this needs an owner and a place
+  in the offboarding process, not just a merge.
+
+### Neutral Consequences
+
+- The email → AWS username convention becomes load-bearing and therefore worth stating explicitly
+  somewhere.
+- `iam_helper.py`'s hardcoded lists and Rootly's hardcoded user IDs remain the underlying design
+  problem. This ADR does not fix that; it makes the cost visible on every offboard. A future ADR
+  could move human AWS access to Keycloak-federated SSO and delete the lists, which would collapse
+  most of the `NEEDS_CODE_CHANGE` column.
+
+## Implementation Notes
+
+- **Effort Estimate:** 2–3 days for CLI, safety model, and the Keycloak/Vault/AWS providers;
+  Rootly and the residual doc follow.
+- **Risk Level:** High blast radius by nature, mitigated by dry-run-default and by never mutating
+  Pulumi-managed resources.
+- **Dependencies:** Keycloak admin credentials, a Vault token, an AWS profile, a Rootly API token.
+- **Migration Path:** N/A — new tooling. The residual doc replaces the runbook ask in #5235.
+
+## Related Decisions
+
+- [0010. Pingdom Checks Unmanaged in Pulumi State](0010-pingdom-checks-unmanaged-in-pulumi-state.md) —
+  same underlying theme of real-world state diverging from Pulumi's model.
+
+## References
+
+- `src/ol_infrastructure/substructure/keycloak/ol_platform_engineering.py` — realm, ten OIDC clients
+- `src/ol_infrastructure/substructure/vault/auth/__main__.py` — OIDC backend, role `bound_claims`, TTLs
+- `src/ol_infrastructure/lib/aws/iam_helper.py` — the four hardcoded username lists
+- `src/ol_infrastructure/infrastructure/aws/iam/__main__.py` — group memberships and declared `iam.User`s
+- `src/ol_infrastructure/saas/rootly/__main__.py` — hardcoded numeric user IDs
+- `scripts/where-is-my-pr`, `scripts/keycloak_user_org_manager.py` — script conventions being followed
+
+---
+
+**Review History:**
+
+| Date | Reviewer | Decision | Notes |
+|------|----------|----------|-------|
+| | | | |
+
+**Last Updated:** 2026-08-04

--- a/docs/adr/0011-executable-offboarding-script-over-runbook.md
+++ b/docs/adr/0011-executable-offboarding-script-over-runbook.md
@@ -99,7 +99,11 @@ tooling.
   a convention the tool must verify rather than trust.
 - Rootly numeric user IDs cannot be derived from an email offline; they require an API lookup.
 - Sentry, Grafana Cloud org membership, and password-manager/SaaS consoles have no
-  Pulumi-managed or in-repo human-access surface, so they are irreducibly manual.
+  Pulumi-managed or in-repo human-access surface, so they are irreducibly manual. Their console
+  URLs are still derived from stack configuration wherever the repository declares them — the
+  Grafana stack hosts from the Keycloak client's allowed web origins and the MongoDB Atlas
+  organization from `mongodb_atlas:organization_id` — so a manual step is still a clickable link
+  that cannot drift from the deployed stacks.
 
 ### Options Considered
 
@@ -176,7 +180,8 @@ which is the only way it stays true as `iam_helper.py` and the Rootly user IDs c
 | AWS IAM | ephemeral credentials only: access keys, console login profile, MFA devices | remove from the relevant `iam_helper.py` list + `pulumi up` on `aws/iam`, `aws/eks`, `aws/opensearch`, `concourse` | — |
 | Rootly | user deactivation, **if** the API supports it (open question below) | remove `user_id` from `saas/rootly/__main__.py` team membership and escalation positions + `pulumi up` | reassign open incidents |
 | GitHub org | — | — | org/team membership removal |
-| Sentry, Grafana Cloud org, password manager, other SaaS | — | — | console removal |
+| Sentry, Grafana stacks, Fastly, Heroku, MongoDB Atlas, Qdrant Cloud, Mailgun | — | — | console removal, each with a deep-linked console URL |
+| Password manager | — | — | console removal; vendor is not declared in this repo, so no URL is emitted |
 
 Note the AWS split is deliberate: the script revokes credentials (immediate, reversible,
 not Pulumi-managed) and reports group membership (Pulumi-managed). Note also that

--- a/docs/adr/0011-executable-offboarding-script-over-runbook.md
+++ b/docs/adr/0011-executable-offboarding-script-over-runbook.md
@@ -23,7 +23,7 @@ a reader following instructions is exactly the failure mode we need to design ag
 clients, all of which federate interactive login from it:
 
 | Keycloak client | Service |
-|---|---|
+| --- | --- |
 | `ol-vault-client` | Vault |
 | `ol-grafana-client` | Grafana (with role mapper → admin/editor/viewer client roles) |
 | `ol-concourse-client` | Concourse |
@@ -160,17 +160,19 @@ which is the only way it stays true as `iam_helper.py` and the Rootly user IDs c
 
 - Dry-run is the **default**. Mutation requires an explicit `--execute`.
 - `--execute` additionally requires interactive confirmation echoing the resolved human identity
-  per service, unless `--yes` is passed.
+  per service, unless `--yes` is passed. The prompt explicitly lists incomplete provider discovery.
+- AWS execution additionally requires `--aws-account-id`; the discovered IAM user's ARN must match
+  that explicitly confirmed 12-digit account before any credential can be revoked.
 - `--only` / `--skip` accept service names, so a partial or resumed run is possible.
-- A missing credential for one service degrades that provider to skipped-with-a-warning; it does
-  not abort the run.
+- A missing credential or unresolved identity for one service is reported as incomplete and returns
+  a non-zero exit status, but it does not prevent known urgent containment actions in other services.
 
 **Per-service plan.**
 
 | Service | `REVOKED_VIA_API` | `NEEDS_CODE_CHANGE` | `NEEDS_HUMAN` |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | Keycloak (`ol-platform-engineering`) | disable user, kill sessions, drop realm/client role mappings, drop federated identities — cascades to all ten clients | — | — |
-| Vault | revoke the OIDC entity's live token accessors (closes the ≤8h `token_ttl` window Keycloak alone leaves open) | — | — |
+| Vault | revoke the OIDC entity's live token accessors (closes the ≤8h `token_ttl` window Keycloak alone leaves open), then disable the entity while preserving aliases for audit and safe retries | — | — |
 | AWS IAM | ephemeral credentials only: access keys, console login profile, MFA devices | remove from the relevant `iam_helper.py` list + `pulumi up` on `aws/iam`, `aws/eks`, `aws/opensearch`, `concourse` | — |
 | Rootly | user deactivation, **if** the API supports it (open question below) | remove `user_id` from `saas/rootly/__main__.py` team membership and escalation positions + `pulumi up` | reassign open incidents |
 | GitHub org | — | — | org/team membership removal |
@@ -236,7 +238,8 @@ request construction, plus read-only `discover()` runs against QA. No test may m
   Rootly and the residual doc follow.
 - **Risk Level:** High blast radius by nature, mitigated by dry-run-default and by never mutating
   Pulumi-managed resources.
-- **Dependencies:** Keycloak admin credentials, a Vault token, an AWS profile, a Rootly API token.
+- **Dependencies:** Keycloak admin credentials, a Vault token, an AWS profile and explicitly
+  confirmed account ID for execution, and a Rootly API token.
 - **Migration Path:** N/A — new tooling. The residual doc replaces the runbook ask in #5235.
 
 ## Related Decisions
@@ -258,7 +261,7 @@ request construction, plus read-only `discover()` runs against QA. No test may m
 **Review History:**
 
 | Date | Reviewer | Decision | Notes |
-|------|----------|----------|-------|
-| | | | |
+| --- | --- | --- | --- |
+|  |  |  |  |
 
 **Last Updated:** 2026-08-04

--- a/docs/adr/0011-executable-offboarding-script-over-runbook.md
+++ b/docs/adr/0011-executable-offboarding-script-over-runbook.md
@@ -76,7 +76,7 @@ tooling.
 - The ten-service Keycloak fan-out means the highest-value action is also the easiest to script,
   and is currently undocumented anywhere.
 - Vault's OIDC `readonly` and `developer` roles carry **no** `bound_claims` (only `admin` is
-  claim-gated at `substructure/vault/auth/__main__.py:165`), so any authenticated realm user can
+  claim-gated at `src/ol_infrastructure/substructure/vault/auth/__main__.py:165`), so any authenticated realm user can
   mint a Vault token. Combined with an 8-hour `token_ttl`, a Keycloak disable alone leaves a live
   Vault session valid for up to 8 more hours. Nothing in the repo records that gap today.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,6 +11,7 @@ An **Architecture Decision** (AD) is a software design choice that addresses a s
 An **Architecture Decision Log** (ADL) is the collection of all ADRs created and maintained for a particular project (or organization).
 
 **Key characteristics:**
+
 - Documents the "why" behind important decisions
 - Captures context at the time of decision
 - Records consequences (both positive and negative)
@@ -22,6 +23,7 @@ An **Architecture Decision Log** (ADL) is the collection of all ADRs created and
 Create an ADR when making decisions that:
 
 ### Infrastructure & Architecture
+
 - ✅ Change fundamental infrastructure patterns (e.g., ingress controller migration)
 - ✅ Introduce new core technologies or platforms
 - ✅ Modify deployment strategies or CI/CD patterns
@@ -30,18 +32,21 @@ Create an ADR when making decisions that:
 - ✅ Impact multiple applications or teams
 
 ### Complexity & Risk
+
 - ✅ Have significant complexity or risk
 - ✅ Require substantial effort (>8 hours) to implement or reverse
 - ✅ Affect system reliability, performance, or scalability
 - ✅ Create technical debt or constraints for future decisions
 
 ### Team & Organizational
+
 - ✅ Need buy-in from multiple stakeholders
 - ✅ Will affect future developers' understanding
 - ✅ Set precedents for future similar decisions
 - ✅ Resolve disagreements or debates within the team
 
 ### Cost & Resources
+
 - ✅ Have significant financial implications
 - ✅ Require resource allocation (time, budget, tooling)
 
@@ -114,16 +119,19 @@ NNNN-title-with-dashes.md
 ```
 
 Examples:
+
 - `0001-use-pulumi-for-infrastructure.md`
 - `0002-migrate-to-gateway-api-httproute.md`
 - `0003-adopt-eks-for-container-orchestration.md`
 
 **Numbering:**
+
 - Start at `0001`
 - Use 4-digit zero-padded numbers
 - Numbers are permanent (don't renumber when superseding)
 
 **Titles:**
+
 - Use lowercase with dashes
 - Be concise but descriptive
 - Start with a verb (use, adopt, migrate, implement, etc.)
@@ -167,6 +175,8 @@ graph LR
 | [0007](0007-clickhouse-llmops-multi-tenant.md) | Multi-Tenant ClickHouse Cluster for LLMOps on Data EKS | Accepted | 2026-02-25 |
 | [0008](0008-concourse-spot-worker-graceful-drain-no-ephemeral.md) | Concourse Spot Worker Graceful Drain Without Ephemeral Mode | Accepted | 2026-04-08 |
 | [0009](0009-deploy-witan-as-shared-multi-tenant-mcp-service.md) | Deploy witan as a Shared, Multi-Tenant MCP Service | Accepted | 2026-07-07 |
+| [0010](0010-pingdom-checks-unmanaged-in-pulumi-state.md) | Pingdom Checks Unmanaged in Pulumi State | Proposed | 2026-07-20 |
+| [0011](0011-executable-offboarding-script-over-runbook.md) | Executable Offboarding Script Over a Prose Runbook | Proposed | 2026-08-04 |
 
 ## Creating a New ADR
 
@@ -253,12 +263,14 @@ When AI agents make architectural decisions:
 ## Reviewing Old ADRs
 
 **Monthly ADR Review** (recommended):
+
 - Review recent ADRs (last 1-3 months)
 - Compare predictions vs reality
 - Document learnings in ADR comments or new ADRs
 - Update status if needed (Accepted → Deprecated)
 
 **Annual ADR Audit**:
+
 - Review all active ADRs
 - Identify deprecated or superseded decisions
 - Archive or update ADRs as needed
@@ -269,6 +281,7 @@ When AI agents make architectural decisions:
 ### Pulumi Changes
 
 When making Pulumi infrastructure changes:
+
 1. Small changes (< 2 hours) - No ADR needed
 2. Medium changes (2-8 hours) - Consider ADR for reusable patterns
 3. Large changes (> 8 hours) - ADR required
@@ -276,6 +289,7 @@ When making Pulumi infrastructure changes:
 ### Multi-Stack Changes
 
 When changes affect multiple Pulumi stacks:
+
 - Always create an ADR
 - Document migration strategy
 - Link to planning docs (like `gateway-api-migration-plan.md`)
@@ -283,6 +297,7 @@ When changes affect multiple Pulumi stacks:
 ### Breaking Changes
 
 Any breaking change requires an ADR documenting:
+
 - What is breaking
 - Why the break is necessary
 - Migration path for affected users
@@ -305,6 +320,7 @@ Any breaking change requires an ADR documenting:
 ## Questions?
 
 If you're unsure whether something needs an ADR:
+
 1. Ask yourself: "Will this decision matter in 6 months?"
 2. Consult with the platform team
 3. When in doubt, write it out - better to have too many than too few

--- a/scripts/admin/offboard-employee
+++ b/scripts/admin/offboard-employee
@@ -74,6 +74,7 @@ class ActionStatus(StrEnum):
     WOULD_REVOKE = "would_revoke"
     REVOKED = "revoked"
     REPORTED = "reported"
+    INCOMPLETE = "incomplete"
     SKIPPED = "skipped"
     ERROR = "error"
 
@@ -198,10 +199,12 @@ class KeycloakProvider:
         self.client = client or httpx.Client(timeout=30)
         self._token: str | None = None
 
-    def _token_headers(self) -> dict[str, str]:
+    def _token_headers(self, *, force_refresh: bool = False) -> dict[str, str]:
         if not self.password:
             msg = "set OFFBOARD_KEYCLOAK_PASSWORD or pass --keycloak-password"
             raise OffboardingError(msg)
+        if force_refresh:
+            self._token = None
         if self._token is None:
             response = self.client.post(
                 f"{self.base_url}/realms/{self.auth_realm}"
@@ -232,6 +235,12 @@ class KeycloakProvider:
             if str(user.get("email", "")).lower() == identity.email.lower()
             or str(user.get("username", "")).lower() == identity.email.lower()
         ]
+        if not users:
+            return [
+                keycloak_unresolved_identity_finding(
+                    identity, self.base_url, self.realm
+                )
+            ]
         return [
             Finding(
                 service=self.name,
@@ -260,19 +269,16 @@ class KeycloakProvider:
 
     def revoke(self, finding: Finding, *, execute: bool) -> ActionRecord:
         """Disable the user and remove session/role/federation state."""
+        if finding.outcome is not FindingOutcome.REVOKED_VIA_API:
+            return report_record(finding, execute=execute)
         if not execute:
             return api_record(finding, execute=False, status=ActionStatus.WOULD_REVOKE)
-        headers = self._token_headers()
+        headers = self._token_headers(force_refresh=True)
         user_url = (
             f"{self.base_url}/admin/realms/{self.realm}/users/{finding.target_id}"
         )
-        user_representation = dict(finding.metadata.get("user", {}))
-        if not user_representation:
-            msg = "Keycloak discovery did not preserve the user representation"
-            raise OffboardingError(msg)
-        user_representation["enabled"] = False
         disable_response = self.client.put(
-            user_url, headers=headers, json=user_representation
+            user_url, headers=headers, json={"enabled": False}
         )
         disable_response.raise_for_status()
         logout_url = f"{user_url}/logout"
@@ -445,12 +451,13 @@ class VaultProvider:
                 identity=identity,
                 target_id=entity_id,
                 target_label=f"Vault OIDC identity entity for {identity.email}",
-                verb="delete OIDC entity, aliases, and group memberships",
+                verb="disable OIDC entity while preserving aliases for audit and retries",
                 outcome=FindingOutcome.REVOKED_VIA_API,
                 scope=address,
                 request={
-                    "method": "DELETE",
+                    "method": "POST",
                     "path": f"/v1/identity/entity/id/{entity_id}",
+                    "json": {"disabled": True},
                     "order": 20,
                 },
             )
@@ -505,11 +512,12 @@ class VaultProvider:
             )
             message = "Revoked Vault token accessor and its associated child tokens and leases."
         else:
-            response = self.client.delete(
+            response = self.client.post(
                 f"{address}/v1/identity/entity/id/{finding.target_id}",
                 headers=headers,
+                json={"disabled": True},
             )
-            message = "Deleted Vault OIDC entity, aliases, and group memberships."
+            message = "Disabled Vault OIDC entity and preserved aliases for audit and retries."
         response.raise_for_status()
         return api_record(
             finding,
@@ -538,10 +546,17 @@ class AWSProvider:
 
     name = "aws"
 
-    def __init__(self, *, repo_root: Path, profile: str | None = None):
-        """Initialize AWS access with the repository root and optional profile."""
+    def __init__(
+        self,
+        *,
+        repo_root: Path,
+        profile: str | None = None,
+        expected_account_id: str | None = None,
+    ):
+        """Initialize AWS access with the repository root and target account guard."""
         self.repo_root = repo_root
         self.profile = profile
+        self.expected_account_id = expected_account_id
 
     def _iam_client(self) -> Any:
         if self.profile:
@@ -709,6 +724,12 @@ class AWSEphemeralCredentialProvider(AWSProvider):
             raise OffboardingError(msg) from exc
         arn = str(user_response.get("User", {}).get("Arn", ""))
         account_id = arn.split(":")[4] if arn.count(":") >= 4 else "unknown"
+        if self.expected_account_id and account_id != self.expected_account_id:
+            msg = (
+                f"AWS caller resolved account {account_id}, not explicitly confirmed "
+                f"account {self.expected_account_id}; refusing credential discovery"
+            )
+            raise OffboardingError(msg)
         scope = f"AWS account={account_id} profile={self.profile or 'default'}"
         return self._ephemeral_credential_findings(identity, iam, scope=scope)
 
@@ -775,7 +796,13 @@ class RootlyProvider:
             headers={"Authorization": f"Bearer {self.token}"},
         )
         response.raise_for_status()
-        users = response.json().get("data", [])
+        users = [
+            user
+            for user in response.json().get("data", [])
+            if rootly_user_email(user).lower() == identity.email.lower()
+        ]
+        if not users:
+            return [rootly_unresolved_identity_finding(identity, self.base_url)]
         findings: list[Finding] = []
         for user in users:
             user_id = str(user.get("id"))
@@ -808,8 +835,7 @@ class RootlyProvider:
 
     def _code_change_findings(self, identity: Identity, user_id: str) -> list[Finding]:
         rootly_path = self.repo_root / "src/ol_infrastructure/saas/rootly/__main__.py"
-        source_lines = rootly_path.read_text().splitlines()
-        lines = matching_numeric_literal_lines(rootly_path, user_id)
+        references = matching_numeric_literal_references(rootly_path, user_id)
         stacks = pulumi_stack_targets(
             self.repo_root, ("src/ol_infrastructure/saas/rootly",)
         )
@@ -824,15 +850,13 @@ class RootlyProvider:
                 scope=str(rootly_path.relative_to(self.repo_root)),
                 code_change=CodeChange(
                     path=str(rootly_path.relative_to(self.repo_root)),
-                    symbol=rootly_reference_symbol(source_lines[line - 1]),
+                    symbol=rootly_reference_symbol(context),
                     line=line,
                     stacks=stacks,
-                    instruction=rootly_reference_instruction(
-                        source_lines[line - 1], user_id
-                    ),
+                    instruction=rootly_reference_instruction(context, user_id),
                 ),
             )
-            for line in lines
+            for line, context in references
         ]
 
     def _incident_handoff_finding(
@@ -1008,6 +1032,32 @@ class ManualTailProvider:
         return report_record(finding, execute=execute)
 
 
+def finding_record(
+    finding: Finding,
+    *,
+    execute: bool,
+    status: ActionStatus,
+    message: str,
+    preserve_followup: bool = False,
+) -> ActionRecord:
+    """Build an action record from fields shared by every finding disposition."""
+    return ActionRecord(
+        service=finding.service,
+        identity=finding.identity.email,
+        target_id=finding.target_id,
+        target_label=finding.target_label,
+        verb=finding.verb,
+        scope=finding.scope,
+        outcome=finding.outcome,
+        status=status,
+        execute=execute,
+        request=finding.request,
+        message=message,
+        code_change=finding.code_change if preserve_followup else None,
+        human_action=finding.human_action if preserve_followup else None,
+    )
+
+
 def api_record(
     finding: Finding,
     *,
@@ -1022,37 +1072,27 @@ def api_record(
             if status is ActionStatus.WOULD_REVOKE
             else f"{finding.verb}."
         )
-    return ActionRecord(
-        service=finding.service,
-        identity=finding.identity.email,
-        target_id=finding.target_id,
-        target_label=finding.target_label,
-        verb=finding.verb,
-        scope=finding.scope,
-        outcome=finding.outcome,
-        status=status,
+    return finding_record(
+        finding,
         execute=execute,
-        request=finding.request,
+        status=status,
         message=message,
     )
 
 
 def report_record(finding: Finding, *, execute: bool) -> ActionRecord:
     """Build a non-mutating report record from a finding."""
-    return ActionRecord(
-        service=finding.service,
-        identity=finding.identity.email,
-        target_id=finding.target_id,
-        target_label=finding.target_label,
-        verb=finding.verb,
-        scope=finding.scope,
-        outcome=finding.outcome,
-        status=ActionStatus.REPORTED,
+    status = (
+        ActionStatus.INCOMPLETE
+        if finding.metadata.get("discovery_incomplete")
+        else ActionStatus.REPORTED
+    )
+    return finding_record(
+        finding,
         execute=execute,
-        request=finding.request,
+        status=status,
         message=finding.verb,
-        code_change=finding.code_change,
-        human_action=finding.human_action,
+        preserve_followup=True,
     )
 
 
@@ -1075,20 +1115,12 @@ def skipped_record(service: str, identity: Identity, reason: str) -> ActionRecor
 
 def error_record(finding: Finding, reason: str, *, execute: bool) -> ActionRecord:
     """Build a provider action error record without aborting the whole run."""
-    return ActionRecord(
-        service=finding.service,
-        identity=finding.identity.email,
-        target_id=finding.target_id,
-        target_label=finding.target_label,
-        verb=finding.verb,
-        scope=finding.scope,
-        outcome=finding.outcome,
-        status=ActionStatus.ERROR,
+    return finding_record(
+        finding,
         execute=execute,
-        request=finding.request,
+        status=ActionStatus.ERROR,
         message=reason,
-        code_change=finding.code_change,
-        human_action=finding.human_action,
+        preserve_followup=True,
     )
 
 
@@ -1138,6 +1170,30 @@ def has_login_profile(iam: Any, username: str) -> bool:
     return True
 
 
+def keycloak_unresolved_identity_finding(
+    identity: Identity, base_url: str, realm: str
+) -> Finding:
+    """Build an incomplete Keycloak identity-discovery finding."""
+    return Finding(
+        service="keycloak",
+        identity=identity,
+        target_id=identity.email,
+        target_label=f"Keycloak user for {identity.email}",
+        verb="verify Keycloak user identity before completing offboarding",
+        outcome=FindingOutcome.NEEDS_HUMAN,
+        scope=f"{base_url} realm={realm}",
+        human_action=HumanAction(
+            console_url=f"{base_url}/admin/{realm}/console/#/{realm}/users",
+            owning_team="Platform Engineering",
+            instruction=(
+                "Keycloak did not return an exact email or username match. Resolve "
+                "the account manually; SSO containment is incomplete until it is disabled."
+            ),
+        ),
+        metadata={"discovery_incomplete": True},
+    )
+
+
 def vault_unresolved_identity_finding(identity: Identity, address: str) -> Finding:
     """Build the read-only unresolved Vault OIDC entity finding."""
     return Finding(
@@ -1155,6 +1211,7 @@ def vault_unresolved_identity_finding(identity: Identity, address: str) -> Findi
                 "the user has ever logged in and manually inspect live tokens if needed."
             ),
         ),
+        metadata={"discovery_incomplete": True},
     )
 
 
@@ -1177,22 +1234,65 @@ def aws_unresolved_identity_finding(identity: Identity) -> Finding:
                 "complete."
             ),
         ),
+        metadata={"discovery_incomplete": True},
     )
 
 
-def matching_numeric_literal_lines(path: Path, value: str) -> list[int]:
-    """Return exact AST literal locations for a numeric Rootly user id."""
-    tree = ast.parse(path.read_text())
-    numeric_value = int(value)
-    return sorted(
-        {
-            node.lineno
-            for node in ast.walk(tree)
-            if isinstance(node, ast.Constant)
+def rootly_unresolved_identity_finding(identity: Identity, base_url: str) -> Finding:
+    """Build an incomplete Rootly identity-discovery finding."""
+    return Finding(
+        service="rootly",
+        identity=identity,
+        target_id=identity.email,
+        target_label=f"Rootly user for {identity.email}",
+        verb="verify Rootly user identity before completing offboarding",
+        outcome=FindingOutcome.NEEDS_HUMAN,
+        scope=base_url,
+        human_action=HumanAction(
+            console_url="https://app.rootly.com/account/users",
+            owning_team="Platform Engineering",
+            instruction=(
+                "Rootly did not return an exact email match. Resolve the account "
+                "manually; deactivation and on-call cleanup remain incomplete."
+            ),
+        ),
+        metadata={"discovery_incomplete": True},
+    )
+
+
+def matching_numeric_literal_references(
+    path: Path, value: str
+) -> list[tuple[int, str]]:
+    """Return Rootly user-id lines and enclosing AST source, independent of layout."""
+    source = path.read_text()
+    tree = ast.parse(source)
+    try:
+        numeric_value = int(value)
+    except ValueError:
+        return []
+    references: set[tuple[int, str]] = set()
+
+    def visit(node: ast.AST, ancestors: tuple[ast.AST, ...]) -> None:
+        if (
+            isinstance(node, ast.Constant)
             and not isinstance(node.value, bool)
             and (node.value == numeric_value or node.value == value)
-        }
-    )
+        ):
+            context = source.splitlines()[node.lineno - 1]
+            for ancestor in reversed(ancestors):
+                segment = ast.get_source_segment(source, ancestor)
+                if (
+                    segment
+                    and rootly_reference_symbol(segment) != "Rootly user_id reference"
+                ):
+                    context = segment
+                    break
+            references.add((node.lineno, context))
+        for child in ast.iter_child_nodes(node):
+            visit(child, (*ancestors, node))
+
+    visit(tree, ())
+    return sorted(references)
 
 
 def rootly_reference_symbol(line: str) -> str:
@@ -1264,14 +1364,22 @@ def scan_repo_for_text(repo_root: Path, needle: str) -> Iterable[tuple[Path, int
                 yield path, index, line
 
 
+def rootly_user_email(user: dict[str, Any]) -> str:
+    """Return the email from a JSON:API-ish Rootly user response."""
+    attrs = (
+        user.get("attributes", {}) if isinstance(user.get("attributes"), dict) else {}
+    )
+    return str(attrs.get("email") or user.get("email") or "")
+
+
 def rootly_user_label(user: dict[str, Any]) -> str:
     """Return a readable Rootly user label from JSON:API-ish responses."""
     attrs = (
         user.get("attributes", {}) if isinstance(user.get("attributes"), dict) else {}
     )
-    email = attrs.get("email") or user.get("email") or user.get("id")
+    email = rootly_user_email(user) or str(user.get("id"))
     name = attrs.get("name") or attrs.get("full_name") or user.get("name")
-    return f"{name} <{email}>" if name else str(email)
+    return f"{name} <{email}>" if name else email
 
 
 def parse_service_filter(value: Sequence[str] | None) -> set[str]:
@@ -1313,6 +1421,7 @@ def build_providers(
     vault_addr: str | None,
     vault_token: str | None,
     aws_profile: str | None,
+    aws_account_id: str | None,
     rootly_token: str | None,
 ) -> list[Provider]:
     """Construct providers in containment-first output order."""
@@ -1330,8 +1439,16 @@ def build_providers(
     return [
         *keycloak_providers,
         VaultProvider(address=vault_addr, token=vault_token),
-        AWSProvider(repo_root=repo_root, profile=aws_profile),
-        AWSEphemeralCredentialProvider(repo_root=repo_root, profile=aws_profile),
+        AWSProvider(
+            repo_root=repo_root,
+            profile=aws_profile,
+            expected_account_id=aws_account_id,
+        ),
+        AWSEphemeralCredentialProvider(
+            repo_root=repo_root,
+            profile=aws_profile,
+            expected_account_id=aws_account_id,
+        ),
         RootlyProvider(repo_root=repo_root, token=rootly_token),
         RepoCodeProvider(repo_root=repo_root),
         ManualTailProvider(),
@@ -1411,6 +1528,12 @@ def confirmation_summary(records: Sequence[ActionRecord]) -> str:
     api_records = [
         record for record in records if record.outcome is FindingOutcome.REVOKED_VIA_API
     ]
+    incomplete_records = [
+        record
+        for record in records
+        if record.status
+        in {ActionStatus.INCOMPLETE, ActionStatus.SKIPPED, ActionStatus.ERROR}
+    ]
     lines = ["The following API revocations will execute:"]
     lines.extend(
         f"- {record.identity}: {record.service} [{record.scope or 'scope unavailable'}] "
@@ -1419,7 +1542,14 @@ def confirmation_summary(records: Sequence[ActionRecord]) -> str:
     )
     if not api_records:
         lines.append("- none")
-    lines.append("Type EXECUTE to continue: ")
+    lines.append("Discovery is incomplete for these providers/identities:")
+    lines.extend(
+        f"- [{record.status}] {record.identity}: {record.service} -> {record.message}"
+        for record in incomplete_records
+    )
+    if not incomplete_records:
+        lines.append("- none")
+    lines.append("Type EXECUTE to continue with the known revocations: ")
     return "\n".join(lines)
 
 
@@ -1522,6 +1652,18 @@ def validate_execution_targets(providers: Sequence[Provider]) -> None:
             target = provider.base_url
         elif isinstance(provider, AWSEphemeralCredentialProvider):
             target = provider.profile or ""
+            if not provider.expected_account_id:
+                msg = (
+                    "Refusing --execute for AWS without --aws-account-id; explicitly "
+                    "confirm the 12-digit account that may be mutated."
+                )
+                raise RuntimeError(msg)
+            if not (
+                len(provider.expected_account_id) == 12
+                and provider.expected_account_id.isdecimal()
+            ):
+                msg = "--aws-account-id must be a 12-digit AWS account ID"
+                raise RuntimeError(msg)
         normalized = target.lower()
         nonproduction_markers = ("-qa.", "-ci.", ".qa.", ".ci.", "qa-", "ci-")
         if normalized and any(marker in normalized for marker in nonproduction_markers):
@@ -1536,7 +1678,10 @@ def records_exit_code(records: Sequence[ActionRecord], *, execute: bool) -> int:
     """Return a machine-readable failure code for incomplete offboarding runs."""
     if any(record.status is ActionStatus.ERROR for record in records):
         return 1
-    if any(record.status is ActionStatus.SKIPPED for record in records):
+    if any(
+        record.status in {ActionStatus.INCOMPLETE, ActionStatus.SKIPPED}
+        for record in records
+    ):
         return 2
     if execute and any(
         record.outcome is FindingOutcome.REVOKED_VIA_API
@@ -1570,6 +1715,12 @@ def main(
     vault_addr: str | None = None,
     vault_token: str | None = None,
     aws_profile: str | None = None,
+    aws_account_id: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            help="Required with --execute for AWS; confirms the 12-digit target account."
+        ),
+    ] = None,
     rootly_token: str | None = None,
 ) -> None:
     """Plan or execute employee offboarding for one or more email addresses."""
@@ -1596,6 +1747,7 @@ def main(
             vault_addr=vault_addr,
             vault_token=vault_token,
             aws_profile=aws_profile,
+            aws_account_id=aws_account_id,
             rootly_token=rootly_token,
         ),
         parse_service_filter(only),

--- a/scripts/admin/offboard-employee
+++ b/scripts/admin/offboard-employee
@@ -1,0 +1,1630 @@
+#!/usr/bin/env python3
+"""Employee offboarding planner and API revocation tool.
+
+The command accepts one or more email addresses and produces an ordered
+containment plan. Dry-run is the default. Mutating API calls require
+``--execute`` and an explicit confirmation unless ``--yes`` is supplied.
+
+The implementation intentionally splits findings into three outcomes:
+
+* ``REVOKED_VIA_API``: safe immediate containment, such as disabling Keycloak
+  login or revoking ephemeral AWS IAM credentials.
+* ``NEEDS_CODE_CHANGE``: Pulumi-managed identity that must be removed from this
+  repository and applied with ``pulumi up``. These are never API-deleted here.
+* ``NEEDS_HUMAN``: residual consoles and ownership handoffs that still need an
+  operator in a UI.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+from pathlib import Path
+from typing import Annotated, Any, Literal, Protocol
+
+import boto3
+import cyclopts
+import httpx
+from botocore.exceptions import (
+    BotoCoreError,
+    ClientError,
+    NoCredentialsError,
+    ProfileNotFound,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+DEFAULT_KEYCLOAK_URL = "https://sso-qa.ol.mit.edu"
+DEFAULT_KEYCLOAK_REALM = "ol-platform-engineering"
+DEFAULT_KEYCLOAK_AUTH_REALM = "master"
+DEFAULT_KEYCLOAK_USERNAME = "admin"
+ROOTLY_API_URL = "https://api.rootly.com"
+
+SERVICE_ORDER = {
+    "keycloak": 10,
+    "vault": 20,
+    "aws": 30,
+    "rootly": 40,
+    "repo-code": 50,
+    "human": 60,
+}
+
+app = cyclopts.App(
+    help="Plan and optionally execute safe employee offboarding actions."
+)
+
+
+class FindingOutcome(StrEnum):
+    """The mutually-exclusive disposition for an offboarding finding."""
+
+    REVOKED_VIA_API = "REVOKED_VIA_API"
+    NEEDS_CODE_CHANGE = "NEEDS_CODE_CHANGE"
+    NEEDS_HUMAN = "NEEDS_HUMAN"
+
+
+class ActionStatus(StrEnum):
+    """Execution status recorded for a finding."""
+
+    WOULD_REVOKE = "would_revoke"
+    REVOKED = "revoked"
+    REPORTED = "reported"
+    SKIPPED = "skipped"
+    ERROR = "error"
+
+
+@dataclass(frozen=True, slots=True)
+class Identity:
+    """The input employee identity and derived service-specific keys."""
+
+    email: str
+
+    def __post_init__(self) -> None:
+        """Reject ambiguous inputs before any provider can act on them."""
+        localpart, separator, domain = self.email.partition("@")
+        if not separator or not localpart or not domain or "@" in domain:
+            msg = f"Invalid email address: {self.email!r}"
+            raise ValueError(msg)
+
+    @property
+    def aws_username(self) -> str:
+        """Return the conventional MIT Kerberos/AWS username for the email."""
+        return self.email.split("@", 1)[0]
+
+    @property
+    def is_mit_email(self) -> bool:
+        """Return whether the IAM username convention is valid for this identity."""
+        return self.email.rsplit("@", 1)[1].lower() == "mit.edu"
+
+
+@dataclass(frozen=True, slots=True)
+class CodeChange:
+    """A Pulumi-managed change that must be made in code."""
+
+    path: str
+    symbol: str
+    stacks: tuple[str, ...]
+    instruction: str
+    line: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class HumanAction:
+    """A manual UI action that cannot be safely automated here."""
+
+    console_url: str
+    owning_team: str
+    instruction: str
+
+
+@dataclass(frozen=True, slots=True)
+class Finding:
+    """A read-only service discovery result."""
+
+    service: str
+    identity: Identity
+    target_id: str
+    target_label: str
+    verb: str
+    outcome: FindingOutcome
+    scope: str = ""
+    request: dict[str, Any] = field(default_factory=dict)
+    code_change: CodeChange | None = None
+    human_action: HumanAction | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class ActionRecord:
+    """Structured audit record emitted for every provider action."""
+
+    service: str
+    identity: str
+    target_id: str
+    target_label: str
+    verb: str
+    scope: str
+    outcome: FindingOutcome | None
+    status: ActionStatus
+    execute: bool
+    request: dict[str, Any]
+    message: str
+    code_change: CodeChange | None = None
+    human_action: HumanAction | None = None
+
+
+class Provider(Protocol):
+    """A service-specific offboarding provider."""
+
+    name: str
+
+    def discover(self, identity: Identity) -> list[Finding]:
+        """Return read-only findings for an employee identity."""
+
+    def revoke(self, finding: Finding, *, execute: bool) -> ActionRecord:
+        """Revoke or report a finding, preserving dry-run/action shape."""
+
+
+class OffboardingError(RuntimeError):
+    """Raised when a provider fails in a way that should be reported and skipped."""
+
+
+class KeycloakProvider:
+    """Disable the Keycloak user that fans out to OIDC-backed services."""
+
+    name = "keycloak"
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        realm: str,
+        auth_realm: str,
+        username: str,
+        password: str | None,
+        client: httpx.Client | None = None,
+    ):
+        """Initialize the Keycloak Admin REST API client."""
+        self.base_url = base_url.rstrip("/")
+        self.realm = realm
+        self.auth_realm = auth_realm
+        self.username = username
+        self.password = password
+        self.client = client or httpx.Client(timeout=30)
+        self._token: str | None = None
+
+    def _token_headers(self) -> dict[str, str]:
+        if not self.password:
+            msg = "set OFFBOARD_KEYCLOAK_PASSWORD or pass --keycloak-password"
+            raise OffboardingError(msg)
+        if self._token is None:
+            response = self.client.post(
+                f"{self.base_url}/realms/{self.auth_realm}"
+                "/protocol/openid-connect/token",
+                data={
+                    "client_id": "admin-cli",
+                    "username": self.username,
+                    "password": self.password,
+                    "grant_type": "password",
+                },
+            )
+            response.raise_for_status()
+            self._token = str(response.json()["access_token"])
+        return {"Authorization": f"Bearer {self._token}"}
+
+    def discover(self, identity: Identity) -> list[Finding]:
+        """Find the Keycloak user whose email or username matches the identity."""
+        users_url = f"{self.base_url}/admin/realms/{self.realm}/users"
+        response = self.client.get(
+            users_url,
+            params={"email": identity.email, "exact": "true"},
+            headers=self._token_headers(),
+        )
+        response.raise_for_status()
+        users = [
+            user
+            for user in response.json()
+            if str(user.get("email", "")).lower() == identity.email.lower()
+            or str(user.get("username", "")).lower() == identity.email.lower()
+        ]
+        return [
+            Finding(
+                service=self.name,
+                identity=identity,
+                target_id=str(user["id"]),
+                target_label=str(user.get("username") or user.get("email")),
+                verb=(
+                    "disable user, terminate sessions, remove role mappings and "
+                    "federated identities"
+                ),
+                outcome=FindingOutcome.REVOKED_VIA_API,
+                scope=f"{self.base_url} realm={self.realm}",
+                request={
+                    "method": "PUT/POST/DELETE",
+                    "paths": [
+                        f"/admin/realms/{self.realm}/users/{user['id']}",
+                        f"/admin/realms/{self.realm}/users/{user['id']}/logout",
+                        f"/admin/realms/{self.realm}/users/{user['id']}/role-mappings",
+                        f"/admin/realms/{self.realm}/users/{user['id']}/federated-identity",
+                    ],
+                },
+                metadata={"enabled": user.get("enabled", True), "user": user},
+            )
+            for user in users
+        ]
+
+    def revoke(self, finding: Finding, *, execute: bool) -> ActionRecord:
+        """Disable the user and remove session/role/federation state."""
+        if not execute:
+            return api_record(finding, execute=False, status=ActionStatus.WOULD_REVOKE)
+        headers = self._token_headers()
+        user_url = (
+            f"{self.base_url}/admin/realms/{self.realm}/users/{finding.target_id}"
+        )
+        user_representation = dict(finding.metadata.get("user", {}))
+        if not user_representation:
+            msg = "Keycloak discovery did not preserve the user representation"
+            raise OffboardingError(msg)
+        user_representation["enabled"] = False
+        disable_response = self.client.put(
+            user_url, headers=headers, json=user_representation
+        )
+        disable_response.raise_for_status()
+        logout_url = f"{user_url}/logout"
+        logout_response = self.client.post(logout_url, headers=headers)
+        logout_response.raise_for_status()
+        self._drop_groups(user_url, headers)
+        self._drop_role_mappings(user_url, headers)
+        self._drop_consents(user_url, headers)
+        self._drop_federated_identities(user_url, headers)
+        return api_record(
+            finding,
+            execute=True,
+            status=ActionStatus.REVOKED,
+            message=(
+                "Disabled Keycloak user, terminated sessions, and removed groups, "
+                "role mappings, consents, offline grants, and federated identities."
+            ),
+        )
+
+    def _drop_groups(self, user_url: str, headers: dict[str, str]) -> None:
+        """Remove every direct group membership for the user."""
+        response = self.client.get(f"{user_url}/groups", headers=headers)
+        response.raise_for_status()
+        for group in response.json():
+            group_id = group.get("id")
+            if not group_id:
+                continue
+            delete_response = self.client.delete(
+                f"{user_url}/groups/{group_id}", headers=headers
+            )
+            delete_response.raise_for_status()
+
+    def _drop_role_mappings(self, user_url: str, headers: dict[str, str]) -> None:
+        response = self.client.get(f"{user_url}/role-mappings", headers=headers)
+        if response.status_code == 404:
+            return
+        response.raise_for_status()
+        payload = response.json()
+        realm_mappings = payload.get("realmMappings") or []
+        if realm_mappings:
+            delete_response = self.client.request(
+                "DELETE",
+                f"{user_url}/role-mappings/realm",
+                headers=headers,
+                json=realm_mappings,
+            )
+            delete_response.raise_for_status()
+        for mapping in (payload.get("clientMappings") or {}).values():
+            client_id = mapping.get("id")
+            client_role_mappings = mapping.get("mappings") or []
+            if not client_id or not client_role_mappings:
+                continue
+            delete_response = self.client.request(
+                "DELETE",
+                f"{user_url}/role-mappings/clients/{client_id}",
+                headers=headers,
+                json=client_role_mappings,
+            )
+            delete_response.raise_for_status()
+
+    def _drop_consents(self, user_url: str, headers: dict[str, str]) -> None:
+        """Revoke client consents, including offline-token grants."""
+        response = self.client.get(f"{user_url}/consents", headers=headers)
+        response.raise_for_status()
+        for consent in response.json():
+            client_id = consent.get("clientId")
+            if not client_id:
+                continue
+            delete_response = self.client.delete(
+                f"{user_url}/consents/{client_id}", headers=headers
+            )
+            delete_response.raise_for_status()
+
+    def _drop_federated_identities(
+        self, user_url: str, headers: dict[str, str]
+    ) -> None:
+        response = self.client.get(f"{user_url}/federated-identity", headers=headers)
+        if response.status_code == 404:
+            return
+        response.raise_for_status()
+        for identity in response.json():
+            provider = identity.get("identityProvider")
+            if not provider:
+                continue
+            delete_response = self.client.delete(
+                f"{user_url}/federated-identity/{provider}", headers=headers
+            )
+            delete_response.raise_for_status()
+
+
+class VaultProvider:
+    """Revoke live Vault tokens associated with the Keycloak OIDC entity."""
+
+    name = "vault"
+
+    def __init__(
+        self,
+        *,
+        address: str | None,
+        token: str | None,
+        client: httpx.Client | None = None,
+    ):
+        """Initialize the Vault API client used for OIDC token lookup."""
+        self.address = address.rstrip("/") if address else None
+        self.token = token
+        self.client = client or httpx.Client(timeout=30)
+
+    def _headers(self) -> dict[str, str]:
+        """Return Vault token authentication headers."""
+        if not self.token:
+            msg = "set VAULT_ADDR and VAULT_TOKEN to check live OIDC entity tokens"
+            raise OffboardingError(msg)
+        return {"X-Vault-Token": self.token}
+
+    def _address(self) -> str:
+        """Return the configured Vault address or raise a provider skip."""
+        if not self.address:
+            msg = "set VAULT_ADDR and VAULT_TOKEN to check live OIDC entity tokens"
+            raise OffboardingError(msg)
+        return self.address
+
+    def discover(self, identity: Identity) -> list[Finding]:
+        """Find live Vault token accessors tied to the Keycloak OIDC entity."""
+        address = self._address()
+        headers = self._headers()
+        entity_id = self._lookup_oidc_entity_id(identity, headers)
+        if entity_id is None:
+            return [vault_unresolved_identity_finding(identity, address)]
+        accessors = self._token_accessors(headers)
+        findings: list[Finding] = []
+        for accessor in accessors:
+            response = self.client.post(
+                f"{self.address}/v1/auth/token/lookup-accessor",
+                headers=headers,
+                json={"accessor": accessor},
+            )
+            if response.status_code in {400, 404}:
+                continue
+            if response.status_code == 403:
+                msg = (
+                    "Vault token cannot inspect all accessors; refusing to report "
+                    "discovery as complete"
+                )
+                raise OffboardingError(msg)
+            response.raise_for_status()
+            token_data = response.json().get("data", {})
+            if token_data.get("entity_id") != entity_id:
+                continue
+            findings.append(
+                Finding(
+                    service=self.name,
+                    identity=identity,
+                    target_id=accessor,
+                    target_label=f"Vault token accessor {accessor} for {identity.email}",
+                    verb="revoke live OIDC token accessor",
+                    outcome=FindingOutcome.REVOKED_VIA_API,
+                    scope=address,
+                    request={
+                        "method": "POST",
+                        "path": "/v1/auth/token/revoke-accessor",
+                        "accessor": accessor,
+                        "order": 10,
+                    },
+                    metadata={"entity_id": entity_id},
+                )
+            )
+        findings.append(
+            Finding(
+                service=self.name,
+                identity=identity,
+                target_id=entity_id,
+                target_label=f"Vault OIDC identity entity for {identity.email}",
+                verb="delete OIDC entity, aliases, and group memberships",
+                outcome=FindingOutcome.REVOKED_VIA_API,
+                scope=address,
+                request={
+                    "method": "DELETE",
+                    "path": f"/v1/identity/entity/id/{entity_id}",
+                    "order": 20,
+                },
+            )
+        )
+        return findings
+
+    def _lookup_oidc_entity_id(
+        self, identity: Identity, headers: dict[str, str]
+    ) -> str | None:
+        """Return the Vault entity id for the email-backed OIDC alias."""
+        address = self._address()
+        auth_response = self.client.get(f"{address}/v1/sys/auth", headers=headers)
+        auth_response.raise_for_status()
+        auth_mount = auth_response.json().get("data", {}).get("oidc/")
+        if not auth_mount:
+            return None
+        accessor = auth_mount.get("accessor")
+        lookup_response = self.client.post(
+            f"{address}/v1/identity/lookup/entity",
+            headers=headers,
+            json={"alias_name": identity.email, "alias_mount_accessor": accessor},
+        )
+        if lookup_response.status_code in {400, 404}:
+            return None
+        lookup_response.raise_for_status()
+        entity_id = lookup_response.json().get("data", {}).get("id")
+        return str(entity_id) if entity_id else None
+
+    def _token_accessors(self, headers: dict[str, str]) -> list[str]:
+        """List Vault token accessors visible to the operator token."""
+        address = self._address()
+        response = self.client.request(
+            "LIST", f"{address}/v1/auth/token/accessors", headers=headers
+        )
+        response.raise_for_status()
+        keys = response.json().get("data", {}).get("keys", [])
+        return [str(accessor) for accessor in keys]
+
+    def revoke(self, finding: Finding, *, execute: bool) -> ActionRecord:
+        """Revoke a Vault token accessor, or report the dry-run action."""
+        if finding.outcome is not FindingOutcome.REVOKED_VIA_API:
+            return report_record(finding, execute=execute)
+        if not execute:
+            return api_record(finding, execute=False, status=ActionStatus.WOULD_REVOKE)
+        address = self._address()
+        headers = self._headers()
+        if finding.request.get("path") == "/v1/auth/token/revoke-accessor":
+            response = self.client.post(
+                f"{address}/v1/auth/token/revoke-accessor",
+                headers=headers,
+                json={"accessor": finding.target_id},
+            )
+            message = "Revoked Vault token accessor and its associated child tokens and leases."
+        else:
+            response = self.client.delete(
+                f"{address}/v1/identity/entity/id/{finding.target_id}",
+                headers=headers,
+            )
+            message = "Deleted Vault OIDC entity, aliases, and group memberships."
+        response.raise_for_status()
+        return api_record(
+            finding,
+            execute=True,
+            status=ActionStatus.REVOKED,
+            message=message,
+        )
+
+
+AWS_CODE_CHANGE_STACKS = {
+    "ADMIN_USERNAMES": ("src/ol_infrastructure/infrastructure/aws/iam",),
+    "DEVOPS_ADMIN_USERNAMES": ("src/ol_infrastructure/infrastructure/aws/opensearch",),
+    "EKS_ADMIN_USERNAMES": (
+        "src/ol_infrastructure/infrastructure/aws/iam",
+        "src/ol_infrastructure/infrastructure/aws/eks",
+    ),
+    "EKS_DEVELOPER_USERNAMES": (
+        "src/ol_infrastructure/infrastructure/aws/iam",
+        "src/ol_infrastructure/applications/concourse",
+    ),
+}
+
+
+class AWSProvider:
+    """Revoke ephemeral AWS IAM credentials and report Pulumi list cleanup."""
+
+    name = "aws"
+
+    def __init__(self, *, repo_root: Path, profile: str | None = None):
+        """Initialize AWS access with the repository root and optional profile."""
+        self.repo_root = repo_root
+        self.profile = profile
+
+    def _iam_client(self) -> Any:
+        if self.profile:
+            return boto3.Session(profile_name=self.profile).client("iam")
+        return boto3.Session().client("iam")
+
+    def discover(self, identity: Identity) -> list[Finding]:
+        """Report hardcoded Pulumi-managed IAM access for this identity."""
+        if not identity.is_mit_email:
+            return []
+        return self._code_change_findings(identity)
+
+    def _code_change_findings(self, identity: Identity) -> list[Finding]:
+        helper_path = self.repo_root / "src/ol_infrastructure/lib/aws/iam_helper.py"
+        username_locations = username_list_locations(helper_path)
+        findings: list[Finding] = []
+        for symbol, names in username_locations.items():
+            location = names.get(identity.aws_username)
+            if location is None:
+                continue
+            stack_dirs = AWS_CODE_CHANGE_STACKS[symbol]
+            stacks = pulumi_stack_targets(self.repo_root, stack_dirs)
+            instruction = (
+                f"Remove {identity.aws_username!r} from {symbol}, review the diff, "
+                f"and run pulumi up for every listed stack."
+            )
+            if symbol == "EKS_DEVELOPER_USERNAMES":
+                instruction += (
+                    " This list also declares iam.User resources; removal destroys "
+                    "that Pulumi-managed user."
+                )
+            elif symbol == "EKS_ADMIN_USERNAMES":
+                instruction += (
+                    " This removal also destroys the per-user EKS AccessEntry on "
+                    "every listed cluster stack."
+                )
+            findings.append(
+                Finding(
+                    service=self.name,
+                    identity=identity,
+                    target_id=f"{symbol}:{identity.aws_username}",
+                    target_label=f"{identity.aws_username} in {symbol}",
+                    verb="report Pulumi-managed AWS access cleanup",
+                    outcome=FindingOutcome.NEEDS_CODE_CHANGE,
+                    scope=str(helper_path.relative_to(self.repo_root)),
+                    code_change=CodeChange(
+                        path=str(helper_path.relative_to(self.repo_root)),
+                        symbol=symbol,
+                        line=location,
+                        stacks=stacks,
+                        instruction=instruction,
+                    ),
+                )
+            )
+        return findings
+
+    def _ephemeral_credential_findings(
+        self, identity: Identity, iam: Any, *, scope: str
+    ) -> list[Finding]:
+        username = identity.aws_username
+        findings = [
+            Finding(
+                service=self.name,
+                identity=identity,
+                target_id=str(key["AccessKeyId"]),
+                target_label=f"AWS access key {key['AccessKeyId']} for {username}",
+                verb="delete access key",
+                outcome=FindingOutcome.REVOKED_VIA_API,
+                scope=scope,
+                request={
+                    "operation": "DeleteAccessKey",
+                    "UserName": username,
+                    "AccessKeyId": key["AccessKeyId"],
+                },
+            )
+            for key in iam.list_access_keys(UserName=username).get(
+                "AccessKeyMetadata", []
+            )
+        ]
+        if has_login_profile(iam, username):
+            findings.append(
+                Finding(
+                    service=self.name,
+                    identity=identity,
+                    target_id=username,
+                    target_label=f"AWS console login profile for {username}",
+                    verb="delete login profile",
+                    outcome=FindingOutcome.REVOKED_VIA_API,
+                    scope=scope,
+                    request={"operation": "DeleteLoginProfile", "UserName": username},
+                )
+            )
+        for device in iam.list_mfa_devices(UserName=username).get("MFADevices", []):
+            serial = str(device["SerialNumber"])
+            findings.append(
+                Finding(
+                    service=self.name,
+                    identity=identity,
+                    target_id=serial,
+                    target_label=f"AWS MFA device {serial} for {username}",
+                    verb=(
+                        "deactivate and delete virtual MFA device"
+                        if ":mfa/" in serial
+                        else "deactivate hardware MFA device"
+                    ),
+                    outcome=FindingOutcome.REVOKED_VIA_API,
+                    scope=scope,
+                    request={
+                        "operation": (
+                            "DeactivateAndDeleteVirtualMFADevice"
+                            if ":mfa/" in serial
+                            else "DeactivateMFADevice"
+                        ),
+                        "UserName": username,
+                        "SerialNumber": serial,
+                    },
+                )
+            )
+        if findings:
+            findings.append(
+                Finding(
+                    service=self.name,
+                    identity=identity,
+                    target_id=f"sts-sessions:{username}",
+                    target_label=f"existing AWS STS sessions for {username}",
+                    verb="verify already-issued AWS STS sessions expire",
+                    outcome=FindingOutcome.NEEDS_HUMAN,
+                    scope=scope,
+                    human_action=HumanAction(
+                        console_url="https://console.aws.amazon.com/cloudtrail/home",
+                        owning_team="Platform Engineering",
+                        instruction=(
+                            "Deleting long-term credentials cannot revoke temporary STS "
+                            "credentials already issued from them. Review CloudTrail and "
+                            "treat the maximum session lifetime as residual access."
+                        ),
+                    ),
+                )
+            )
+        return findings
+
+    def revoke(self, finding: Finding, *, execute: bool) -> ActionRecord:
+        """Report Pulumi-managed AWS findings without API mutation."""
+        return report_record(finding, execute=execute)
+
+
+class AWSEphemeralCredentialProvider(AWSProvider):
+    """Revoke non-Pulumi AWS IAM credentials with the AWS API."""
+
+    def discover(self, identity: Identity) -> list[Finding]:
+        """Find ephemeral IAM credentials for the derived IAM username."""
+        if not identity.is_mit_email:
+            return [aws_unresolved_identity_finding(identity)]
+        try:
+            iam = self._iam_client()
+            user_response = iam.get_user(UserName=identity.aws_username)
+        except ClientError as exc:
+            error_code = exc.response.get("Error", {}).get("Code")
+            if error_code == "NoSuchEntity":
+                return [aws_unresolved_identity_finding(identity)]
+            msg = f"AWS API credential discovery skipped: {exc}"
+            raise OffboardingError(msg) from exc
+        except (BotoCoreError, NoCredentialsError, ProfileNotFound) as exc:
+            msg = f"AWS API credential discovery skipped: {exc}"
+            raise OffboardingError(msg) from exc
+        arn = str(user_response.get("User", {}).get("Arn", ""))
+        account_id = arn.split(":")[4] if arn.count(":") >= 4 else "unknown"
+        scope = f"AWS account={account_id} profile={self.profile or 'default'}"
+        return self._ephemeral_credential_findings(identity, iam, scope=scope)
+
+    def revoke(self, finding: Finding, *, execute: bool) -> ActionRecord:
+        """Delete AWS access keys, login profiles, or MFA devices when executing."""
+        if finding.outcome is not FindingOutcome.REVOKED_VIA_API:
+            return report_record(finding, execute=execute)
+        if not execute:
+            return api_record(finding, execute=False, status=ActionStatus.WOULD_REVOKE)
+        iam = self._iam_client()
+        operation = finding.request.get("operation")
+        if operation == "DeleteAccessKey":
+            iam.delete_access_key(
+                UserName=finding.request["UserName"],
+                AccessKeyId=finding.request["AccessKeyId"],
+            )
+        elif operation == "DeleteLoginProfile":
+            iam.delete_login_profile(UserName=finding.request["UserName"])
+        elif operation in {
+            "DeactivateMFADevice",
+            "DeactivateAndDeleteVirtualMFADevice",
+        }:
+            iam.deactivate_mfa_device(
+                UserName=finding.request["UserName"],
+                SerialNumber=finding.request["SerialNumber"],
+            )
+            if operation == "DeactivateAndDeleteVirtualMFADevice":
+                iam.delete_virtual_mfa_device(
+                    SerialNumber=finding.request["SerialNumber"]
+                )
+        else:
+            msg = f"Unsupported AWS operation: {operation}"
+            raise OffboardingError(msg)
+        return api_record(finding, execute=True, status=ActionStatus.REVOKED)
+
+
+class RootlyProvider:
+    """Discover Rootly users, report Pulumi-managed membership, and manual handoffs."""
+
+    name = "rootly"
+
+    def __init__(
+        self,
+        *,
+        repo_root: Path,
+        token: str | None,
+        base_url: str = ROOTLY_API_URL,
+        client: httpx.Client | None = None,
+    ):
+        """Initialize the Rootly REST API client."""
+        self.repo_root = repo_root
+        self.token = token
+        self.base_url = base_url.rstrip("/")
+        self.client = client or httpx.Client(timeout=30)
+
+    def discover(self, identity: Identity) -> list[Finding]:
+        """Resolve the email to Rootly user ids and code-change references."""
+        if not self.token:
+            msg = "set ROOTLY_API_TOKEN or OFFBOARD_ROOTLY_API_TOKEN"
+            raise OffboardingError(msg)
+        response = self.client.get(
+            f"{self.base_url}/v1/users",
+            params={"filter[email]": identity.email},
+            headers={"Authorization": f"Bearer {self.token}"},
+        )
+        response.raise_for_status()
+        users = response.json().get("data", [])
+        findings: list[Finding] = []
+        for user in users:
+            user_id = str(user.get("id"))
+            label = rootly_user_label(user)
+            findings.append(
+                Finding(
+                    service=self.name,
+                    identity=identity,
+                    target_id=user_id,
+                    target_label=label,
+                    verb="deactivate Rootly user and verify inactive state",
+                    outcome=FindingOutcome.REVOKED_VIA_API,
+                    scope=self.base_url,
+                    request={
+                        "method": "PATCH",
+                        "path": f"/v1/users/{user_id}",
+                        "json": {
+                            "data": {
+                                "id": user_id,
+                                "type": "users",
+                                "attributes": {"active": False},
+                            }
+                        },
+                    },
+                )
+            )
+            findings.extend(self._code_change_findings(identity, user_id))
+            findings.append(self._incident_handoff_finding(identity, user_id, label))
+        return findings
+
+    def _code_change_findings(self, identity: Identity, user_id: str) -> list[Finding]:
+        rootly_path = self.repo_root / "src/ol_infrastructure/saas/rootly/__main__.py"
+        source_lines = rootly_path.read_text().splitlines()
+        lines = matching_numeric_literal_lines(rootly_path, user_id)
+        stacks = pulumi_stack_targets(
+            self.repo_root, ("src/ol_infrastructure/saas/rootly",)
+        )
+        return [
+            Finding(
+                service=self.name,
+                identity=identity,
+                target_id=f"rootly:{user_id}:{line}",
+                target_label=f"Rootly user_id {user_id} at line {line}",
+                verb="report Pulumi-managed Rootly cleanup",
+                outcome=FindingOutcome.NEEDS_CODE_CHANGE,
+                scope=str(rootly_path.relative_to(self.repo_root)),
+                code_change=CodeChange(
+                    path=str(rootly_path.relative_to(self.repo_root)),
+                    symbol=rootly_reference_symbol(source_lines[line - 1]),
+                    line=line,
+                    stacks=stacks,
+                    instruction=rootly_reference_instruction(
+                        source_lines[line - 1], user_id
+                    ),
+                ),
+            )
+            for line in lines
+        ]
+
+    def _incident_handoff_finding(
+        self, identity: Identity, user_id: str, label: str
+    ) -> Finding:
+        """Build the manual Rootly incident reassignment finding."""
+        return Finding(
+            service=self.name,
+            identity=identity,
+            target_id=f"rootly-handoff:{user_id}",
+            target_label=f"Rootly incident ownership for {label}",
+            verb="reassign open incidents and on-call handoffs",
+            outcome=FindingOutcome.NEEDS_HUMAN,
+            scope=self.base_url,
+            human_action=HumanAction(
+                console_url=f"https://app.rootly.com/users/{user_id}",
+                owning_team="Platform Engineering",
+                instruction=(
+                    "Review open incidents, escalation coverage, and active on-call "
+                    "shifts before considering Rootly offboarding complete."
+                ),
+            ),
+        )
+
+    def revoke(self, finding: Finding, *, execute: bool) -> ActionRecord:
+        """Deactivate a Rootly user through the REST API when executing."""
+        if finding.outcome is not FindingOutcome.REVOKED_VIA_API:
+            return report_record(finding, execute=execute)
+        if not execute:
+            return api_record(finding, execute=False, status=ActionStatus.WOULD_REVOKE)
+        headers = {"Authorization": f"Bearer {self.token}"}
+        response = self.client.patch(
+            f"{self.base_url}/v1/users/{finding.target_id}",
+            headers=headers,
+            json={
+                "data": {
+                    "id": finding.target_id,
+                    "type": "users",
+                    "attributes": {"active": False},
+                }
+            },
+        )
+        response.raise_for_status()
+        verify_response = self.client.get(
+            f"{self.base_url}/v1/users/{finding.target_id}", headers=headers
+        )
+        verify_response.raise_for_status()
+        user = verify_response.json().get("data", {})
+        attributes = user.get("attributes", {})
+        if attributes.get("active") is not False:
+            msg = "Rootly API did not confirm the user is inactive"
+            raise OffboardingError(msg)
+        return api_record(
+            finding,
+            execute=True,
+            status=ActionStatus.REVOKED,
+            message="Deactivated Rootly user and verified active=false.",
+        )
+
+
+class RepoCodeProvider:
+    """Find hardcoded individual email references in tracked source files."""
+
+    name = "repo-code"
+
+    def __init__(self, *, repo_root: Path):
+        """Initialize the repository scanner with its root path."""
+        self.repo_root = repo_root
+
+    def discover(self, identity: Identity) -> list[Finding]:
+        """Scan tracked repository text for hardcoded email references."""
+        findings: list[Finding] = []
+        for path, line_number, line in scan_repo_for_text(
+            self.repo_root, identity.email
+        ):
+            rel_path = str(path.relative_to(self.repo_root))
+            if rel_path.startswith(("tests/scripts/admin/", "docs/adr/")):
+                continue
+            if line.lstrip().startswith("#"):
+                continue
+            findings.append(
+                Finding(
+                    service=self.name,
+                    identity=identity,
+                    target_id=f"{rel_path}:{line_number}",
+                    target_label=f"{rel_path}:{line_number}",
+                    verb="report hardcoded email cleanup",
+                    outcome=FindingOutcome.NEEDS_CODE_CHANGE,
+                    code_change=CodeChange(
+                        path=rel_path,
+                        symbol="hardcoded email reference",
+                        line=line_number,
+                        stacks=("repo follow-up",),
+                        instruction=(
+                            f"Review and remove or replace hardcoded email "
+                            f"{identity.email!r} at {rel_path}:{line_number}."
+                        ),
+                    ),
+                )
+            )
+        return findings
+
+    def revoke(self, finding: Finding, *, execute: bool) -> ActionRecord:
+        """Report repository code findings without editing files."""
+        return report_record(finding, execute=execute)
+
+
+class ManualTailProvider:
+    """Emit residual UI-only actions that cannot be proven from this repository."""
+
+    name = "human"
+
+    def discover(self, identity: Identity) -> list[Finding]:
+        """Return the residual manual access-review checklist."""
+        manual_actions = [
+            (
+                "github",
+                "https://github.com/orgs/mitodl/people",
+                "Platform Engineering",
+                (
+                    "Remove GitHub org/team and outside-collaborator memberships; this "
+                    "also removes the independent GitHub-auth path to Concourse's main "
+                    "team. Transfer sole-admin repositories and verify automation does "
+                    "not depend on a personal token before revoking authorizations."
+                ),
+            ),
+            (
+                "sentry",
+                "https://mit-office-of-digital-learning.sentry.io/settings/members/",
+                "Platform Engineering",
+                (
+                    "Remove Sentry organization membership if present and review audit "
+                    "logs for personal tokens or integrations that org admins cannot "
+                    "enumerate or revoke through the API."
+                ),
+            ),
+            (
+                "grafana-cloud",
+                "https://mitodl.grafana.net/",
+                "Platform Engineering",
+                (
+                    "Keycloak disable handles group-synced Grafana access. Remove any "
+                    "direct Grafana Cloud or portal membership and review attributable "
+                    "service accounts/API keys without deleting shared automation."
+                ),
+            ),
+            (
+                "password-manager-and-saas",
+                "https://github.mit.edu/ol-engineering/runbooks",
+                "Platform Engineering",
+                "Remove password manager vault access and any remaining privileged SaaS seats.",
+            ),
+        ]
+        return [
+            Finding(
+                service=self.name,
+                identity=identity,
+                target_id=f"{target}:{identity.email}",
+                target_label=f"{target} access for {identity.email}",
+                verb="manual access review",
+                outcome=FindingOutcome.NEEDS_HUMAN,
+                human_action=HumanAction(
+                    console_url=console_url,
+                    owning_team=owning_team,
+                    instruction=instruction,
+                ),
+            )
+            for target, console_url, owning_team, instruction in manual_actions
+        ]
+
+    def revoke(self, finding: Finding, *, execute: bool) -> ActionRecord:
+        """Report residual manual actions without mutating any service."""
+        return report_record(finding, execute=execute)
+
+
+def api_record(
+    finding: Finding,
+    *,
+    execute: bool,
+    status: ActionStatus,
+    message: str | None = None,
+) -> ActionRecord:
+    """Build an API action record from a finding."""
+    if message is None:
+        message = (
+            f"Would {finding.verb}."
+            if status is ActionStatus.WOULD_REVOKE
+            else f"{finding.verb}."
+        )
+    return ActionRecord(
+        service=finding.service,
+        identity=finding.identity.email,
+        target_id=finding.target_id,
+        target_label=finding.target_label,
+        verb=finding.verb,
+        scope=finding.scope,
+        outcome=finding.outcome,
+        status=status,
+        execute=execute,
+        request=finding.request,
+        message=message,
+    )
+
+
+def report_record(finding: Finding, *, execute: bool) -> ActionRecord:
+    """Build a non-mutating report record from a finding."""
+    return ActionRecord(
+        service=finding.service,
+        identity=finding.identity.email,
+        target_id=finding.target_id,
+        target_label=finding.target_label,
+        verb=finding.verb,
+        scope=finding.scope,
+        outcome=finding.outcome,
+        status=ActionStatus.REPORTED,
+        execute=execute,
+        request=finding.request,
+        message=finding.verb,
+        code_change=finding.code_change,
+        human_action=finding.human_action,
+    )
+
+
+def skipped_record(service: str, identity: Identity, reason: str) -> ActionRecord:
+    """Build a provider-skip record for missing credentials or discovery failures."""
+    return ActionRecord(
+        service=service,
+        identity=identity.email,
+        target_id=identity.email,
+        target_label=identity.email,
+        verb="discover",
+        scope="",
+        outcome=None,
+        status=ActionStatus.SKIPPED,
+        execute=False,
+        request={},
+        message=reason,
+    )
+
+
+def error_record(finding: Finding, reason: str, *, execute: bool) -> ActionRecord:
+    """Build a provider action error record without aborting the whole run."""
+    return ActionRecord(
+        service=finding.service,
+        identity=finding.identity.email,
+        target_id=finding.target_id,
+        target_label=finding.target_label,
+        verb=finding.verb,
+        scope=finding.scope,
+        outcome=finding.outcome,
+        status=ActionStatus.ERROR,
+        execute=execute,
+        request=finding.request,
+        message=reason,
+        code_change=finding.code_change,
+        human_action=finding.human_action,
+    )
+
+
+def pulumi_stack_targets(repo_root: Path, stack_dirs: Sequence[str]) -> tuple[str, ...]:
+    """Enumerate every concrete Pulumi stack affected by a code-list edit."""
+    targets: list[str] = []
+    for stack_dir in stack_dirs:
+        configs = sorted((repo_root / stack_dir).glob("Pulumi.*.yaml"))
+        if not configs:
+            targets.append(stack_dir)
+            continue
+        targets.extend(
+            f"{stack_dir}::{config.stem.removeprefix('Pulumi.')}" for config in configs
+        )
+    return tuple(targets)
+
+
+def username_list_locations(path: Path) -> dict[str, dict[str, int]]:
+    """Return line numbers for IAM username constants in ``iam_helper.py``."""
+    tree = ast.parse(path.read_text())
+    results: dict[str, dict[str, int]] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        targets = [target.id for target in node.targets if isinstance(target, ast.Name)]
+        if len(targets) != 1 or targets[0] not in AWS_CODE_CHANGE_STACKS:
+            continue
+        symbol = targets[0]
+        values: dict[str, int] = {}
+        if isinstance(node.value, ast.List):
+            for item in node.value.elts:
+                if isinstance(item, ast.Constant) and isinstance(item.value, str):
+                    values[item.value] = item.lineno
+        results[symbol] = values
+    return results
+
+
+def has_login_profile(iam: Any, username: str) -> bool:
+    """Return whether an IAM user has a console login profile."""
+    try:
+        iam.get_login_profile(UserName=username)
+    except ClientError as exc:
+        error_code = exc.response.get("Error", {}).get("Code")
+        if error_code == "NoSuchEntity":
+            return False
+        raise
+    return True
+
+
+def vault_unresolved_identity_finding(identity: Identity, address: str) -> Finding:
+    """Build the read-only unresolved Vault OIDC entity finding."""
+    return Finding(
+        service="vault",
+        identity=identity,
+        target_id=identity.email,
+        target_label=f"Vault OIDC entity for {identity.email}",
+        verb="verify Vault OIDC entity and live token accessors",
+        outcome=FindingOutcome.NEEDS_HUMAN,
+        human_action=HumanAction(
+            console_url=f"{address}/ui/vault/access/leases/list/auth/oidc",
+            owning_team="Platform Engineering",
+            instruction=(
+                "Vault did not return an OIDC entity for this email. Confirm whether "
+                "the user has ever logged in and manually inspect live tokens if needed."
+            ),
+        ),
+    )
+
+
+def aws_unresolved_identity_finding(identity: Identity) -> Finding:
+    """Build the read-only unresolved AWS username finding."""
+    return Finding(
+        service="aws",
+        identity=identity,
+        target_id=identity.aws_username,
+        target_label=f"AWS IAM user {identity.aws_username}",
+        verb="verify IAM user and ephemeral credentials",
+        outcome=FindingOutcome.NEEDS_HUMAN,
+        human_action=HumanAction(
+            console_url="https://console.aws.amazon.com/iam/home#/users",
+            owning_team="Platform Engineering",
+            instruction=(
+                "AWS API discovery succeeded, but the derived IAM username "
+                f"{identity.aws_username!r} does not exist. Confirm the user's "
+                "actual IAM username before considering AWS credential revocation "
+                "complete."
+            ),
+        ),
+    )
+
+
+def matching_numeric_literal_lines(path: Path, value: str) -> list[int]:
+    """Return exact AST literal locations for a numeric Rootly user id."""
+    tree = ast.parse(path.read_text())
+    numeric_value = int(value)
+    return sorted(
+        {
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Constant)
+            and not isinstance(node.value, bool)
+            and (node.value == numeric_value or node.value == value)
+        }
+    )
+
+
+def rootly_reference_symbol(line: str) -> str:
+    """Classify a Rootly user-id reference for an actionable report."""
+    if "user_ids" in line:
+        return "team_platform_engineering.user_ids"
+    if "memberId" in line:
+        return "schedule_rotation_members"
+    if "userId" in line or ('"id"' in line and '"type": "user"' in line):
+        return "notification_target_params"
+    for scalar in ("owner_user_id", "created_by_user_id", "last_updated_by_user_id"):
+        if scalar in line:
+            return scalar
+    return "Rootly user_id reference"
+
+
+def rootly_reference_instruction(line: str, user_id: str) -> str:
+    """Explain safe removals and refuse edits that need a successor decision."""
+    symbol = rootly_reference_symbol(line)
+    if symbol == "team_platform_engineering.user_ids":
+        return (
+            f"Remove Rootly user_id {user_id} from the team user_ids list, review "
+            "the diff, and run pulumi up for every listed Rootly stack."
+        )
+    if symbol == "schedule_rotation_members":
+        return (
+            f"URGENT: remove memberId {user_id} from the on-call rotation, resequence "
+            "surviving positions contiguously from 1, review the diff, and run pulumi up."
+        )
+    if symbol == "notification_target_params":
+        return (
+            f"REFUSE automatic removal of Rootly user_id {user_id}: an escalation "
+            "level must not be left without a notification target. Choose a replacement, "
+            "review the diff, and run pulumi up."
+        )
+    if symbol in {"owner_user_id", "created_by_user_id", "last_updated_by_user_id"}:
+        return (
+            f"REFUSE automatic removal of required scalar {symbol}={user_id}. "
+            "Choose the successor, review the diff, and run pulumi up."
+        )
+    return (
+        f"Review Rootly user_id {user_id}, make the required ownership or membership "
+        "change, and run pulumi up for every listed Rootly stack."
+    )
+
+
+def scan_repo_for_text(repo_root: Path, needle: str) -> Iterable[tuple[Path, int, str]]:
+    """Scan tracked repository text for a literal string."""
+    try:
+        result = subprocess.run(  # noqa: S603
+            ["git", "-C", str(repo_root), "ls-files", "-z"],  # noqa: S607
+            check=True,
+            capture_output=True,
+        )
+        paths = [
+            repo_root / entry.decode() for entry in result.stdout.split(b"\0") if entry
+        ]
+    except (OSError, subprocess.CalledProcessError, UnicodeDecodeError):
+        paths = list(repo_root.rglob("*"))
+    for path in paths:
+        if not path.is_file() or path.stat().st_size > 1_000_000:
+            continue
+        try:
+            lines = path.read_text().splitlines()
+        except (UnicodeDecodeError, OSError):
+            continue
+        for index, line in enumerate(lines, start=1):
+            if needle in line:
+                yield path, index, line
+
+
+def rootly_user_label(user: dict[str, Any]) -> str:
+    """Return a readable Rootly user label from JSON:API-ish responses."""
+    attrs = (
+        user.get("attributes", {}) if isinstance(user.get("attributes"), dict) else {}
+    )
+    email = attrs.get("email") or user.get("email") or user.get("id")
+    name = attrs.get("name") or attrs.get("full_name") or user.get("name")
+    return f"{name} <{email}>" if name else str(email)
+
+
+def parse_service_filter(value: Sequence[str] | None) -> set[str]:
+    """Parse comma-separated and repeated service filter values."""
+    if not value:
+        return set()
+    services: set[str] = set()
+    for item in value:
+        services.update(part.strip() for part in item.split(",") if part.strip())
+    unknown = services.difference(SERVICE_ORDER)
+    if unknown:
+        msg = f"Unknown service(s): {', '.join(sorted(unknown))}"
+        raise ValueError(msg)
+    return services
+
+
+def selected_providers(
+    providers: Sequence[Provider], only: set[str], skip: set[str]
+) -> list[Provider]:
+    """Return providers selected by --only/--skip."""
+    if only and skip:
+        msg = "Use either --only or --skip, not both."
+        raise ValueError(msg)
+    return [
+        provider
+        for provider in providers
+        if (not only or provider.name in only) and provider.name not in skip
+    ]
+
+
+def build_providers(
+    *,
+    repo_root: Path,
+    keycloak_url: str,
+    keycloak_realm: str,
+    keycloak_auth_realm: str,
+    keycloak_username: str,
+    keycloak_password: str | None,
+    vault_addr: str | None,
+    vault_token: str | None,
+    aws_profile: str | None,
+    rootly_token: str | None,
+) -> list[Provider]:
+    """Construct providers in containment-first output order."""
+    keycloak_providers = [
+        KeycloakProvider(
+            base_url=keycloak_url,
+            realm=realm.strip(),
+            auth_realm=keycloak_auth_realm,
+            username=keycloak_username,
+            password=keycloak_password,
+        )
+        for realm in keycloak_realm.split(",")
+        if realm.strip()
+    ]
+    return [
+        *keycloak_providers,
+        VaultProvider(address=vault_addr, token=vault_token),
+        AWSProvider(repo_root=repo_root, profile=aws_profile),
+        AWSEphemeralCredentialProvider(repo_root=repo_root, profile=aws_profile),
+        RootlyProvider(repo_root=repo_root, token=rootly_token),
+        RepoCodeProvider(repo_root=repo_root),
+        ManualTailProvider(),
+    ]
+
+
+def discover_provider_findings(
+    identities: Sequence[Identity], providers: Sequence[Provider]
+) -> tuple[list[tuple[Provider, Finding]], list[ActionRecord]]:
+    """Discover once so execution cannot drift from the confirmed plan."""
+    discovered: list[tuple[Provider, Finding]] = []
+    records: list[ActionRecord] = []
+    for identity in identities:
+        for provider in providers:
+            try:
+                findings = provider.discover(identity)
+            except OffboardingError as exc:
+                records.append(skipped_record(provider.name, identity, str(exc)))
+                continue
+            except httpx.HTTPError as exc:
+                records.append(
+                    skipped_record(provider.name, identity, f"HTTP error: {exc}")
+                )
+                continue
+            except Exception as exc:
+                records.append(
+                    skipped_record(provider.name, identity, f"Discovery failed: {exc}")
+                )
+                continue
+            discovered.extend((provider, finding) for finding in findings)
+    return discovered, records
+
+
+def records_for_discovery(
+    discovered: Sequence[tuple[Provider, Finding]],
+    discovery_records: Sequence[ActionRecord],
+    *,
+    execute: bool,
+) -> list[ActionRecord]:
+    """Revoke or report the exact findings returned by one discovery pass."""
+    records = list(discovery_records)
+    for provider, finding in discovered:
+        try:
+            records.append(provider.revoke(finding, execute=execute))
+        except Exception as exc:
+            records.append(error_record(finding, str(exc), execute=execute))
+    return sorted(records, key=record_sort_key)
+
+
+def collect_action_records(
+    identities: Sequence[Identity], providers: Sequence[Provider], *, execute: bool
+) -> list[ActionRecord]:
+    """Discover and record actions for callers that do not need confirmation."""
+    discovered, discovery_records = discover_provider_findings(identities, providers)
+    return records_for_discovery(discovered, discovery_records, execute=execute)
+
+
+def record_sort_key(record: ActionRecord) -> tuple[int, int, int, str, str]:
+    """Sort output by urgent API containment, then code changes, then humans."""
+    outcome_order = {
+        FindingOutcome.REVOKED_VIA_API: 0,
+        FindingOutcome.NEEDS_CODE_CHANGE: 1,
+        FindingOutcome.NEEDS_HUMAN: 2,
+        None: 3,
+    }
+    return (
+        outcome_order[record.outcome],
+        SERVICE_ORDER.get(record.service, 999),
+        int(record.request.get("order", 50)),
+        record.identity,
+        record.target_label,
+    )
+
+
+def confirmation_summary(records: Sequence[ActionRecord]) -> str:
+    """Return the identity summary an operator must confirm before execution."""
+    api_records = [
+        record for record in records if record.outcome is FindingOutcome.REVOKED_VIA_API
+    ]
+    lines = ["The following API revocations will execute:"]
+    lines.extend(
+        f"- {record.identity}: {record.service} [{record.scope or 'scope unavailable'}] "
+        f"-> {record.target_label} ({record.verb})"
+        for record in api_records
+    )
+    if not api_records:
+        lines.append("- none")
+    lines.append("Type EXECUTE to continue: ")
+    return "\n".join(lines)
+
+
+def require_confirmation(records: Sequence[ActionRecord]) -> None:
+    """Prompt for destructive execution confirmation."""
+    sys.stderr.write(confirmation_summary(records))
+    answer = input()
+    if answer != "EXECUTE":
+        msg = "Confirmation did not match; aborting without mutations."
+        raise RuntimeError(msg)
+
+
+def records_to_json(records: Sequence[ActionRecord]) -> str:
+    """Serialize action records as stable JSON."""
+    return json.dumps(
+        [record_to_dict(record) for record in records], indent=2, sort_keys=True
+    )
+
+
+def record_to_dict(record: ActionRecord) -> dict[str, Any]:
+    """Convert an action record to JSON-serializable data."""
+    return {
+        "service": record.service,
+        "identity": record.identity,
+        "target_id": record.target_id,
+        "target_label": record.target_label,
+        "verb": record.verb,
+        "scope": record.scope,
+        "outcome": record.outcome,
+        "status": record.status,
+        "execute": record.execute,
+        "request": record.request,
+        "message": record.message,
+        "code_change": None
+        if record.code_change is None
+        else {
+            "path": record.code_change.path,
+            "symbol": record.code_change.symbol,
+            "line": record.code_change.line,
+            "stacks": record.code_change.stacks,
+            "instruction": record.code_change.instruction,
+        },
+        "human_action": None
+        if record.human_action is None
+        else {
+            "console_url": record.human_action.console_url,
+            "owning_team": record.human_action.owning_team,
+            "instruction": record.human_action.instruction,
+        },
+    }
+
+
+def records_to_text(records: Sequence[ActionRecord], *, execute: bool) -> str:
+    """Render action records in the required three-section order."""
+    mode = "EXECUTE" if execute else "DRY RUN"
+    lines = [f"# Employee offboarding plan ({mode})", ""]
+    sections = [
+        (FindingOutcome.REVOKED_VIA_API, "Revoked via API"),
+        (FindingOutcome.NEEDS_CODE_CHANGE, "Requires code change + pulumi up"),
+        (FindingOutcome.NEEDS_HUMAN, "Requires human in a UI"),
+        (None, "Skipped providers / warnings"),
+    ]
+    for outcome, title in sections:
+        section_records = [record for record in records if record.outcome == outcome]
+        lines.append(f"## {title}")
+        if not section_records:
+            lines.append("- none")
+            lines.append("")
+            continue
+        for record in section_records:
+            scope = f" :: {record.scope}" if record.scope else ""
+            lines.append(
+                f"- [{record.status}] {record.identity} :: {record.service}{scope} :: "
+                f"{record.target_label} — {record.message}"
+            )
+            if record.code_change is not None:
+                line = f":{record.code_change.line}" if record.code_change.line else ""
+                lines.append(
+                    f"  - edit: {record.code_change.path}{line} ({record.code_change.symbol})"
+                )
+                lines.append(f"  - stacks: {', '.join(record.code_change.stacks)}")
+                lines.append(f"  - instruction: {record.code_change.instruction}")
+            if record.human_action is not None:
+                lines.append(f"  - console: {record.human_action.console_url}")
+                lines.append(f"  - owner: {record.human_action.owning_team}")
+                lines.append(f"  - instruction: {record.human_action.instruction}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def validate_execution_targets(providers: Sequence[Provider]) -> None:
+    """Refuse destructive execution against discovery-only non-production targets."""
+    for provider in providers:
+        target = ""
+        if isinstance(provider, KeycloakProvider):
+            target = provider.base_url
+        elif isinstance(provider, VaultProvider):
+            target = provider.address or ""
+        elif isinstance(provider, RootlyProvider):
+            target = provider.base_url
+        elif isinstance(provider, AWSEphemeralCredentialProvider):
+            target = provider.profile or ""
+        normalized = target.lower()
+        nonproduction_markers = ("-qa.", "-ci.", ".qa.", ".ci.", "qa-", "ci-")
+        if normalized and any(marker in normalized for marker in nonproduction_markers):
+            msg = (
+                f"Refusing --execute against non-production {provider.name} target "
+                f"{target}; QA/CI are read-only discovery targets."
+            )
+            raise RuntimeError(msg)
+
+
+def records_exit_code(records: Sequence[ActionRecord], *, execute: bool) -> int:
+    """Return a machine-readable failure code for incomplete offboarding runs."""
+    if any(record.status is ActionStatus.ERROR for record in records):
+        return 1
+    if any(record.status is ActionStatus.SKIPPED for record in records):
+        return 2
+    if execute and any(
+        record.outcome is FindingOutcome.REVOKED_VIA_API
+        and record.status is not ActionStatus.REVOKED
+        for record in records
+    ):
+        return 1
+    return 0
+
+
+@app.default
+def main(
+    emails: Annotated[list[str], cyclopts.Parameter(name="EMAIL")],
+    *,
+    execute: bool = False,
+    yes: bool = False,
+    only: Annotated[
+        list[str] | None,
+        cyclopts.Parameter(help="Run only these comma-separated service names."),
+    ] = None,
+    skip: Annotated[
+        list[str] | None,
+        cyclopts.Parameter(help="Skip these comma-separated service names."),
+    ] = None,
+    output: Literal["text", "json"] = "text",
+    keycloak_url: str = DEFAULT_KEYCLOAK_URL,
+    keycloak_realm: str = DEFAULT_KEYCLOAK_REALM,
+    keycloak_auth_realm: str = DEFAULT_KEYCLOAK_AUTH_REALM,
+    keycloak_username: str = DEFAULT_KEYCLOAK_USERNAME,
+    keycloak_password: str | None = None,
+    vault_addr: str | None = None,
+    vault_token: str | None = None,
+    aws_profile: str | None = None,
+    rootly_token: str | None = None,
+) -> None:
+    """Plan or execute employee offboarding for one or more email addresses."""
+    keycloak_password = (
+        keycloak_password
+        or os.getenv("OFFBOARD_KEYCLOAK_PASSWORD")
+        or os.getenv("KEYCLOAK_ADMIN_PASSWORD")
+    )
+    vault_addr = vault_addr or os.getenv("VAULT_ADDR")
+    vault_token = vault_token or os.getenv("VAULT_TOKEN")
+    rootly_token = (
+        rootly_token
+        or os.getenv("OFFBOARD_ROOTLY_API_TOKEN")
+        or os.getenv("ROOTLY_API_TOKEN")
+    )
+    providers = selected_providers(
+        build_providers(
+            repo_root=REPO_ROOT,
+            keycloak_url=keycloak_url,
+            keycloak_realm=keycloak_realm,
+            keycloak_auth_realm=keycloak_auth_realm,
+            keycloak_username=keycloak_username,
+            keycloak_password=keycloak_password,
+            vault_addr=vault_addr,
+            vault_token=vault_token,
+            aws_profile=aws_profile,
+            rootly_token=rootly_token,
+        ),
+        parse_service_filter(only),
+        parse_service_filter(skip),
+    )
+    identities = [Identity(email=email.strip().lower()) for email in emails]
+    if execute:
+        validate_execution_targets(providers)
+    discovered, discovery_records = discover_provider_findings(identities, providers)
+    dry_run_records = records_for_discovery(
+        discovered, discovery_records, execute=False
+    )
+    if execute and not yes:
+        require_confirmation(dry_run_records)
+    records = (
+        records_for_discovery(discovered, discovery_records, execute=True)
+        if execute
+        else dry_run_records
+    )
+    rendered = (
+        records_to_json(records)
+        if output == "json"
+        else records_to_text(records, execute=execute)
+    )
+    sys.stdout.write(rendered)
+    exit_code = records_exit_code(records, execute=execute)
+    if exit_code:
+        raise SystemExit(exit_code)
+
+
+if __name__ == "__main__":
+    app()

--- a/scripts/admin/offboard-employee
+++ b/scripts/admin/offboard-employee
@@ -31,6 +31,7 @@ from typing import Annotated, Any, Literal, Protocol
 import boto3
 import cyclopts
 import httpx
+import yaml
 from botocore.exceptions import (
     BotoCoreError,
     ClientError,
@@ -45,6 +46,11 @@ DEFAULT_KEYCLOAK_REALM = "ol-platform-engineering"
 DEFAULT_KEYCLOAK_AUTH_REALM = "master"
 DEFAULT_KEYCLOAK_USERNAME = "admin"
 ROOTLY_API_URL = "https://api.rootly.com"
+
+KEYCLOAK_STACK_DIR = "src/ol_infrastructure/substructure/keycloak"
+GRAFANA_WEB_ORIGINS_KEY = "keycloak_realm:ol-platform-engineering-grafana-web-origins"
+MONGODB_ATLAS_STACK_DIR = "src/ol_infrastructure/infrastructure/mongodb_atlas"
+MONGODB_ATLAS_ORG_KEY = "mongodb_atlas:organization_id"
 
 SERVICE_ORDER = {
     "keycloak": 10,
@@ -118,9 +124,9 @@ class CodeChange:
 class HumanAction:
     """A manual UI action that cannot be safely automated here."""
 
-    console_url: str
     owning_team: str
     instruction: str
+    console_url: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -969,47 +975,12 @@ class ManualTailProvider:
 
     name = "human"
 
+    def __init__(self, *, repo_root: Path):
+        """Initialize with the repository root used to derive console URLs."""
+        self.repo_root = repo_root
+
     def discover(self, identity: Identity) -> list[Finding]:
         """Return the residual manual access-review checklist."""
-        manual_actions = [
-            (
-                "github",
-                "https://github.com/orgs/mitodl/people",
-                "Platform Engineering",
-                (
-                    "Remove GitHub org/team and outside-collaborator memberships; this "
-                    "also removes the independent GitHub-auth path to Concourse's main "
-                    "team. Transfer sole-admin repositories and verify automation does "
-                    "not depend on a personal token before revoking authorizations."
-                ),
-            ),
-            (
-                "sentry",
-                "https://mit-office-of-digital-learning.sentry.io/settings/members/",
-                "Platform Engineering",
-                (
-                    "Remove Sentry organization membership if present and review audit "
-                    "logs for personal tokens or integrations that org admins cannot "
-                    "enumerate or revoke through the API."
-                ),
-            ),
-            (
-                "grafana-cloud",
-                "https://mitodl.grafana.net/",
-                "Platform Engineering",
-                (
-                    "Keycloak disable handles group-synced Grafana access. Remove any "
-                    "direct Grafana Cloud or portal membership and review attributable "
-                    "service accounts/API keys without deleting shared automation."
-                ),
-            ),
-            (
-                "password-manager-and-saas",
-                "https://github.mit.edu/ol-engineering/runbooks",
-                "Platform Engineering",
-                "Remove password manager vault access and any remaining privileged SaaS seats.",
-            ),
-        ]
         return [
             Finding(
                 service=self.name,
@@ -1020,12 +991,125 @@ class ManualTailProvider:
                 outcome=FindingOutcome.NEEDS_HUMAN,
                 human_action=HumanAction(
                     console_url=console_url,
-                    owning_team=owning_team,
+                    owning_team="Platform Engineering",
                     instruction=instruction,
                 ),
             )
-            for target, console_url, owning_team, instruction in manual_actions
+            for target, console_url, instruction in self._manual_actions()
         ]
+
+    def _manual_actions(self) -> list[tuple[str, str | None, str]]:
+        """Build the checklist, deriving console URLs from repository configuration."""
+        actions: list[tuple[str, str | None, str]] = [
+            (
+                "github",
+                "https://github.com/orgs/mitodl/people",
+                (
+                    "Remove GitHub org/team and outside-collaborator memberships; this "
+                    "also removes the independent GitHub-auth path to Concourse's main "
+                    "team. Transfer sole-admin repositories and verify automation does "
+                    "not depend on a personal token before revoking authorizations."
+                ),
+            ),
+            (
+                "sentry",
+                "https://mit-office-of-digital-learning.sentry.io/settings/members/",
+                (
+                    "Remove Sentry organization membership if present and review audit "
+                    "logs for personal tokens or integrations that org admins cannot "
+                    "enumerate or revoke through the API."
+                ),
+            ),
+        ]
+        actions.extend(
+            (
+                f"grafana:{host.removeprefix('https://').removesuffix('.grafana.net')}",
+                f"{host}/admin/users",
+                (
+                    f"Keycloak disable handles group-synced access to {host}. Remove any "
+                    "remaining local Grafana user, then review attributable service "
+                    "accounts and API keys without deleting shared automation. Grafana "
+                    "Cloud portal membership is managed separately from the stack and "
+                    "must be checked there too."
+                ),
+            )
+            for host in self._grafana_stack_urls()
+        )
+        actions.extend(
+            [
+                (
+                    "fastly",
+                    "https://manage.fastly.com/account/users",
+                    (
+                        "Remove the Fastly account user and review personal API tokens; "
+                        "tokens owned by a departing user break purges and TLS changes "
+                        "when the account is deleted."
+                    ),
+                ),
+                (
+                    "heroku",
+                    "https://dashboard.heroku.com/teams",
+                    (
+                        "Remove team membership and collaborator access on any remaining "
+                        "Heroku app, and confirm no pipeline depends on a personal API key."
+                    ),
+                ),
+                (
+                    "mongodb-atlas",
+                    self._mongodb_atlas_console_url(),
+                    (
+                        "Remove the Atlas organization user, then check project-level "
+                        "database users and API keys, which are not removed with the seat."
+                    ),
+                ),
+                (
+                    "qdrant-cloud",
+                    "https://cloud.qdrant.io/",
+                    "Remove Qdrant Cloud account access and review cluster API keys.",
+                ),
+                (
+                    "mailgun",
+                    "https://app.mailgun.com/",
+                    "Remove the Mailgun account user and review sending/API keys.",
+                ),
+                (
+                    "password-manager",
+                    None,
+                    (
+                        "Revoke the departing employee's credential store access and "
+                        "rotate any shared secret they could read. The vendor and console "
+                        "are not declared in this repository, so no URL can be derived; "
+                        "confirm the current tool with Platform Engineering."
+                    ),
+                ),
+            ]
+        )
+        return actions
+
+    def _grafana_stack_urls(self) -> tuple[str, ...]:
+        """Derive Grafana stack hosts from the Keycloak client's allowed web origins."""
+        origins: set[str] = set()
+        for config in (self.repo_root / KEYCLOAK_STACK_DIR).glob("Pulumi.*.yaml"):
+            values = pulumi_stack_config(config)
+            web_origins = values.get(GRAFANA_WEB_ORIGINS_KEY) or []
+            if isinstance(web_origins, str):
+                web_origins = [web_origins]
+            origins.update(
+                str(origin).rstrip("/")
+                for origin in web_origins
+                if str(origin).startswith("http")
+            )
+        return tuple(sorted(origins))
+
+    def _mongodb_atlas_console_url(self) -> str | None:
+        """Derive the Atlas organization user page from Pulumi stack configuration."""
+        for config in sorted(
+            (self.repo_root / MONGODB_ATLAS_STACK_DIR).glob("Pulumi.*.yaml")
+        ):
+            org_id = pulumi_stack_config(config).get(MONGODB_ATLAS_ORG_KEY)
+            if org_id:
+                return f"https://cloud.mongodb.com/v2#/org/{org_id}/access/users"
+        return "https://cloud.mongodb.com/"
 
     def revoke(self, finding: Finding, *, execute: bool) -> ActionRecord:
         """Report residual manual actions without mutating any service."""
@@ -1122,6 +1206,18 @@ def error_record(finding: Finding, reason: str, *, execute: bool) -> ActionRecor
         message=reason,
         preserve_followup=True,
     )
+
+
+def pulumi_stack_config(path: Path) -> dict[str, Any]:
+    """Return the ``config`` mapping of a Pulumi stack file, or empty on failure."""
+    try:
+        document = yaml.safe_load(path.read_text())
+    except (OSError, yaml.YAMLError):
+        return {}
+    if not isinstance(document, dict):
+        return {}
+    config = document.get("config")
+    return config if isinstance(config, dict) else {}
 
 
 def pulumi_stack_targets(repo_root: Path, stack_dirs: Sequence[str]) -> tuple[str, ...]:
@@ -1451,7 +1547,7 @@ def build_providers(
         ),
         RootlyProvider(repo_root=repo_root, token=rootly_token),
         RepoCodeProvider(repo_root=repo_root),
-        ManualTailProvider(),
+        ManualTailProvider(repo_root=repo_root),
     ]
 
 
@@ -1633,7 +1729,8 @@ def records_to_text(records: Sequence[ActionRecord], *, execute: bool) -> str:
                 lines.append(f"  - stacks: {', '.join(record.code_change.stacks)}")
                 lines.append(f"  - instruction: {record.code_change.instruction}")
             if record.human_action is not None:
-                lines.append(f"  - console: {record.human_action.console_url}")
+                if record.human_action.console_url:
+                    lines.append(f"  - console: {record.human_action.console_url}")
                 lines.append(f"  - owner: {record.human_action.owning_team}")
                 lines.append(f"  - instruction: {record.human_action.instruction}")
         lines.append("")

--- a/tests/scripts/admin/test_offboard_employee.py
+++ b/tests/scripts/admin/test_offboard_employee.py
@@ -632,8 +632,9 @@ def test_execute_uses_the_exact_confirmed_discovery(offboard_module: Any) -> Non
     assert provider.discover_count == 1
     assert provider.execute_values == [False, True]
     assert dry_run[0].target_id == executed[0].target_id == "user-id"
-    assert "https://sso.example.invalid" in offboard_module.confirmation_summary(
-        dry_run
+    assert offboard_module.confirmation_summary(dry_run).splitlines()[1] == (
+        "- user@example.com: keycloak "
+        "[https://sso.example.invalid realm=realm] -> user@example.com (disable user)"
     )
 
 

--- a/tests/scripts/admin/test_offboard_employee.py
+++ b/tests/scripts/admin/test_offboard_employee.py
@@ -1,0 +1,688 @@
+"""Tests for scripts/admin/offboard-employee."""
+
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[3] / "scripts" / "admin" / "offboard-employee"
+)
+
+
+def load_offboard_module() -> Any:
+    """Load the extensionless offboarding script as a Python module."""
+    loader = importlib.machinery.SourceFileLoader(
+        "test_offboard_employee", str(SCRIPT_PATH)
+    )
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    if spec is None:
+        msg = f"Unable to load module from {SCRIPT_PATH}"
+        raise RuntimeError(msg)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def offboard_module() -> Any:
+    """Return the loaded offboarding script module."""
+    return load_offboard_module()
+
+
+class FakeProvider:
+    """Provider test double that records whether revoke would execute."""
+
+    name = "keycloak"
+
+    def __init__(self, finding: Any):
+        """Initialize the provider with one finding."""
+        self.finding = finding
+        self.execute_values: list[bool] = []
+        self.discover_count = 0
+
+    def discover(self, _identity: Any) -> list[Any]:
+        """Return the configured finding."""
+        self.discover_count += 1
+        return [self.finding]
+
+    def revoke(self, finding: Any, *, execute: bool) -> Any:
+        """Record execute mode and return an action record."""
+        self.execute_values.append(execute)
+        return self.finding_module.api_record(
+            finding,
+            execute=execute,
+            status=self.finding_module.ActionStatus.REVOKED
+            if execute
+            else self.finding_module.ActionStatus.WOULD_REVOKE,
+        )
+
+    @property
+    def finding_module(self) -> Any:
+        """Return the loaded script module."""
+        return sys.modules["test_offboard_employee"]
+
+
+class MissingProvider:
+    """Provider test double that simulates absent credentials."""
+
+    name = "rootly"
+
+    def __init__(self, module: Any):
+        """Initialize with the loaded script module."""
+        self.module = module
+
+    def discover(self, _identity: Any) -> list[Any]:
+        """Raise the same missing-credential error real providers raise."""
+        msg = "missing token"
+        raise self.module.OffboardingError(msg)
+
+    def revoke(self, _finding: Any, *, execute: bool) -> Any:
+        """Fail if revoke is called after failed discovery."""
+        msg = f"revoke should not be called: {execute}"
+        raise AssertionError(msg)
+
+
+@pytest.mark.unit
+def test_collect_action_records_is_dry_run_by_default(offboard_module: Any) -> None:
+    """Provider revoke receives execute=False for the default safety path."""
+    identity = offboard_module.Identity("user@example.com")
+    finding = offboard_module.Finding(
+        service="keycloak",
+        identity=identity,
+        target_id="user-id",
+        target_label="user@example.com",
+        verb="disable user",
+        outcome=offboard_module.FindingOutcome.REVOKED_VIA_API,
+        request={"method": "PUT"},
+    )
+    provider = FakeProvider(finding)
+
+    records = offboard_module.collect_action_records(
+        [identity], [provider], execute=False
+    )
+
+    assert provider.execute_values == [False]
+    assert records[0].status is offboard_module.ActionStatus.WOULD_REVOKE
+    assert not records[0].execute
+
+
+@pytest.mark.unit
+def test_missing_provider_credentials_are_skipped_without_aborting(
+    offboard_module: Any,
+) -> None:
+    """A missing service credential yields a skipped record and keeps going."""
+    identity = offboard_module.Identity("user@example.com")
+    providers = [MissingProvider(offboard_module), offboard_module.ManualTailProvider()]
+
+    records = offboard_module.collect_action_records(
+        [identity], providers, execute=False
+    )
+
+    assert records[-1].service == "rootly"
+    assert records[-1].status is offboard_module.ActionStatus.SKIPPED
+    assert any(record.service == "human" for record in records)
+
+
+@pytest.mark.unit
+def test_selected_providers_support_comma_filters(offboard_module: Any) -> None:
+    """--only and --skip accept comma-separated service names."""
+    providers = offboard_module.build_providers(
+        repo_root=Path.cwd(),
+        keycloak_url="https://sso.example.invalid",
+        keycloak_realm="realm",
+        keycloak_auth_realm="master",
+        keycloak_username="admin",
+        keycloak_password=None,
+        vault_addr=None,
+        vault_token=None,
+        aws_profile=None,
+        rootly_token=None,
+    )
+
+    only = offboard_module.parse_service_filter(["aws,repo-code"])
+    selected = offboard_module.selected_providers(providers, only, set())
+
+    assert [provider.name for provider in selected] == ["aws", "aws", "repo-code"]
+
+
+@pytest.mark.unit
+def test_aws_code_change_discovery_reports_exact_iam_helper_symbol(
+    offboard_module: Any,
+) -> None:
+    """AWS Pulumi-managed access is reported as code cleanup, not API deletion."""
+    provider = offboard_module.AWSProvider(repo_root=Path.cwd())
+    identity = offboard_module.Identity("cpatti@mit.edu")
+
+    findings = provider._code_change_findings(identity)
+
+    symbols = {
+        finding.code_change.symbol for finding in findings if finding.code_change
+    }
+    assert "ADMIN_USERNAMES" in symbols
+    assert "DEVOPS_ADMIN_USERNAMES" in symbols
+    assert all(
+        finding.outcome is offboard_module.FindingOutcome.NEEDS_CODE_CHANGE
+        for finding in findings
+    )
+
+
+@pytest.mark.unit
+def test_repo_code_provider_finds_hardcoded_email(
+    offboard_module: Any, tmp_path: Path
+) -> None:
+    """Repository scanner reports scattered hardcoded email references."""
+    target = tmp_path / "docs" / "example.md"
+    target.parent.mkdir()
+    target.write_text("contact former.user@example.com for access\n")
+    provider = offboard_module.RepoCodeProvider(repo_root=tmp_path)
+
+    findings = provider.discover(offboard_module.Identity("former.user@example.com"))
+
+    assert len(findings) == 1
+    assert findings[0].code_change.path == "docs/example.md"
+    assert findings[0].outcome is offboard_module.FindingOutcome.NEEDS_CODE_CHANGE
+
+
+@pytest.mark.unit
+def test_keycloak_discover_and_dry_run_revoke_use_httpx_without_mutation(
+    offboard_module: Any,
+) -> None:
+    """Keycloak dry-run discovers users but does not send mutating requests."""
+    seen_methods: list[str] = []
+
+    def handler(request: Any) -> Any:
+        seen_methods.append(request.method)
+        if request.url.path.endswith("/protocol/openid-connect/token"):
+            return offboard_module.httpx.Response(200, json={"access_token": "token"})
+        if request.url.path.endswith("/admin/realms/ol-platform-engineering/users"):
+            return offboard_module.httpx.Response(
+                200,
+                json=[
+                    {
+                        "id": "keycloak-user-id",
+                        "email": "user@example.com",
+                        "username": "user@example.com",
+                        "enabled": True,
+                    }
+                ],
+            )
+        return offboard_module.httpx.Response(
+            500, json={"unexpected": request.url.path}
+        )
+
+    client = offboard_module.httpx.Client(
+        transport=offboard_module.httpx.MockTransport(handler),
+        base_url="https://sso.example.invalid",
+    )
+    provider = offboard_module.KeycloakProvider(
+        base_url="https://sso.example.invalid",
+        realm="ol-platform-engineering",
+        auth_realm="master",
+        username="admin",
+        password="password",  # pragma: allowlist secret
+        client=client,
+    )
+
+    findings = provider.discover(offboard_module.Identity("user@example.com"))
+    record = provider.revoke(findings[0], execute=False)
+
+    assert seen_methods == ["POST", "GET"]
+    assert record.status is offboard_module.ActionStatus.WOULD_REVOKE
+    assert record.target_id == "keycloak-user-id"
+
+
+@pytest.mark.unit
+def test_keycloak_execute_revokes_user_mappings_and_federated_identities(  # noqa: C901
+    offboard_module: Any,
+) -> None:
+    """Keycloak execute sends the destructive requests against the mock API."""
+    seen: list[tuple[str, str]] = []
+
+    def handler(request: Any) -> Any:  # noqa: PLR0911
+        seen.append((request.method, request.url.path))
+        if request.url.path.endswith("/protocol/openid-connect/token"):
+            return offboard_module.httpx.Response(200, json={"access_token": "token"})
+        if request.method == "GET" and request.url.path.endswith(
+            "/admin/realms/ol-platform-engineering/users"
+        ):
+            return offboard_module.httpx.Response(
+                200,
+                json=[
+                    {
+                        "id": "keycloak-user-id",
+                        "email": "user@example.com",
+                        "username": "user@example.com",
+                        "enabled": True,
+                    }
+                ],
+            )
+        if request.method == "PUT" and request.url.path.endswith(
+            "/users/keycloak-user-id"
+        ):
+            payload = offboard_module.json.loads(request.content)
+            assert payload["email"] == "user@example.com"
+            assert payload["username"] == "user@example.com"
+            assert payload["enabled"] is False
+            return offboard_module.httpx.Response(204)
+        if request.method == "POST" and request.url.path.endswith(
+            "/users/keycloak-user-id/logout"
+        ):
+            return offboard_module.httpx.Response(204)
+        if request.method == "GET" and request.url.path.endswith(
+            "/users/keycloak-user-id/groups"
+        ):
+            return offboard_module.httpx.Response(200, json=[{"id": "group-uuid"}])
+        if request.method == "GET" and request.url.path.endswith(
+            "/users/keycloak-user-id/role-mappings"
+        ):
+            return offboard_module.httpx.Response(
+                200,
+                json={
+                    "realmMappings": [{"id": "realm-role", "name": "admin"}],
+                    "clientMappings": {
+                        "ol-vault-client": {
+                            "id": "client-uuid",
+                            "mappings": [{"id": "client-role", "name": "admin"}],
+                        }
+                    },
+                },
+            )
+        if request.method == "GET" and request.url.path.endswith(
+            "/users/keycloak-user-id/consents"
+        ):
+            return offboard_module.httpx.Response(
+                200, json=[{"clientId": "offline-client"}]
+            )
+        if request.method == "DELETE" and request.url.path.endswith(
+            (
+                "/users/keycloak-user-id/groups/group-uuid",
+                "/users/keycloak-user-id/role-mappings/realm",
+                "/users/keycloak-user-id/role-mappings/clients/client-uuid",
+                "/users/keycloak-user-id/consents/offline-client",
+                "/users/keycloak-user-id/federated-identity/github",
+            )
+        ):
+            return offboard_module.httpx.Response(204)
+        if request.method == "GET" and request.url.path.endswith(
+            "/users/keycloak-user-id/federated-identity"
+        ):
+            return offboard_module.httpx.Response(
+                200, json=[{"identityProvider": "github"}]
+            )
+        return offboard_module.httpx.Response(
+            500, json={"unexpected": f"{request.method} {request.url.path}"}
+        )
+
+    client = offboard_module.httpx.Client(
+        transport=offboard_module.httpx.MockTransport(handler),
+        base_url="https://sso.example.invalid",
+    )
+    provider = offboard_module.KeycloakProvider(
+        base_url="https://sso.example.invalid",
+        realm="ol-platform-engineering",
+        auth_realm="master",
+        username="admin",
+        password="password",  # pragma: allowlist secret
+        client=client,
+    )
+
+    findings = provider.discover(offboard_module.Identity("user@example.com"))
+    record = provider.revoke(findings[0], execute=True)
+
+    assert record.status is offboard_module.ActionStatus.REVOKED
+    assert (
+        "PUT",
+        "/admin/realms/ol-platform-engineering/users/keycloak-user-id",
+    ) in seen
+    assert (
+        "DELETE",
+        "/admin/realms/ol-platform-engineering/users/keycloak-user-id/role-mappings/realm",
+    ) in seen
+    assert (
+        "DELETE",
+        "/admin/realms/ol-platform-engineering/users/keycloak-user-id/federated-identity/github",
+    ) in seen
+
+
+@pytest.mark.unit
+def test_vault_discover_and_revoke_live_oidc_token_accessors(
+    offboard_module: Any,
+) -> None:
+    """Vault provider maps email aliases to token accessors without mutation."""
+    seen: list[tuple[str, str]] = []
+
+    def handler(request: Any) -> Any:  # noqa: PLR0911
+        seen.append((request.method, request.url.path))
+        if request.method == "GET" and request.url.path == "/v1/sys/auth":
+            return offboard_module.httpx.Response(
+                200, json={"data": {"oidc/": {"accessor": "oidc-accessor"}}}
+            )
+        if (
+            request.method == "POST"
+            and request.url.path == "/v1/identity/lookup/entity"
+        ):
+            return offboard_module.httpx.Response(
+                200, json={"data": {"id": "entity-1"}}
+            )
+        if request.method == "LIST" and request.url.path == "/v1/auth/token/accessors":
+            return offboard_module.httpx.Response(
+                200, json={"data": {"keys": ["live-accessor", "other-accessor"]}}
+            )
+        if (
+            request.method == "POST"
+            and request.url.path == "/v1/auth/token/lookup-accessor"
+        ):
+            accessor = offboard_module.json.loads(request.content)["accessor"]
+            entity_id = "entity-1" if accessor == "live-accessor" else "entity-2"
+            return offboard_module.httpx.Response(
+                200, json={"data": {"entity_id": entity_id}}
+            )
+        if (
+            request.method == "POST"
+            and request.url.path == "/v1/auth/token/revoke-accessor"
+        ):
+            return offboard_module.httpx.Response(204)
+        if (
+            request.method == "DELETE"
+            and request.url.path == "/v1/identity/entity/id/entity-1"
+        ):
+            return offboard_module.httpx.Response(204)
+        return offboard_module.httpx.Response(
+            500, json={"unexpected": f"{request.method} {request.url.path}"}
+        )
+
+    client = offboard_module.httpx.Client(
+        transport=offboard_module.httpx.MockTransport(handler),
+        base_url="https://vault.example.invalid",
+    )
+    provider = offboard_module.VaultProvider(
+        address="https://vault.example.invalid",
+        token="test-token",
+        client=client,
+    )
+
+    findings = provider.discover(offboard_module.Identity("user@example.com"))
+    dry_run_record = provider.revoke(findings[0], execute=False)
+    execute_record = provider.revoke(findings[0], execute=True)
+    entity_record = provider.revoke(findings[1], execute=True)
+
+    assert [finding.target_id for finding in findings] == [
+        "live-accessor",
+        "entity-1",
+    ]
+    assert dry_run_record.status is offboard_module.ActionStatus.WOULD_REVOKE
+    assert execute_record.status is offboard_module.ActionStatus.REVOKED
+    assert entity_record.status is offboard_module.ActionStatus.REVOKED
+    assert ("POST", "/v1/auth/token/revoke-accessor") in seen
+    assert ("DELETE", "/v1/identity/entity/id/entity-1") in seen
+
+
+@pytest.mark.unit
+def test_rootly_discovers_api_deactivation_code_change_and_handoff(
+    offboard_module: Any, tmp_path: Path
+) -> None:
+    """Rootly provider splits API deactivation from Pulumi and human follow-up."""
+    rootly_file = (
+        tmp_path / "src" / "ol_infrastructure" / "saas" / "rootly" / "__main__.py"
+    )
+    rootly_file.parent.mkdir(parents=True)
+    rootly_file.write_text(
+        "user_ids=[99415]\n"
+        'schedule_rotation_members=[{"memberId": "99415", "position": 1}]\n'
+        'notification_target_params=[{"id": "99415", "type": "user"}]\n'
+    )
+    seen: list[tuple[str, str]] = []
+
+    def handler(request: Any) -> Any:
+        seen.append((request.method, request.url.path))
+        if request.method == "GET" and request.url.path == "/v1/users":
+            return offboard_module.httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {
+                            "id": "99415",
+                            "attributes": {
+                                "email": "user@example.com",
+                                "name": "Example User",
+                            },
+                        }
+                    ]
+                },
+            )
+        if request.method == "PATCH" and request.url.path == "/v1/users/99415":
+            payload = offboard_module.json.loads(request.content)
+            assert payload["data"] == {
+                "id": "99415",
+                "type": "users",
+                "attributes": {"active": False},
+            }
+            return offboard_module.httpx.Response(200, json={"data": {"id": "99415"}})
+        if request.method == "GET" and request.url.path == "/v1/users/99415":
+            return offboard_module.httpx.Response(
+                200,
+                json={
+                    "data": {
+                        "id": "99415",
+                        "attributes": {"active": False},
+                    }
+                },
+            )
+        return offboard_module.httpx.Response(
+            500, json={"unexpected": f"{request.method} {request.url.path}"}
+        )
+
+    client = offboard_module.httpx.Client(
+        transport=offboard_module.httpx.MockTransport(handler),
+        base_url="https://rootly.example.invalid",
+    )
+    provider = offboard_module.RootlyProvider(
+        repo_root=tmp_path,
+        token="test-token",
+        base_url="https://rootly.example.invalid",
+        client=client,
+    )
+
+    findings = provider.discover(offboard_module.Identity("user@example.com"))
+    api_finding = next(
+        finding
+        for finding in findings
+        if finding.outcome is offboard_module.FindingOutcome.REVOKED_VIA_API
+    )
+    dry_run_record = provider.revoke(api_finding, execute=False)
+    execute_record = provider.revoke(api_finding, execute=True)
+
+    assert dry_run_record.status is offboard_module.ActionStatus.WOULD_REVOKE
+    assert execute_record.status is offboard_module.ActionStatus.REVOKED
+    assert {finding.outcome for finding in findings} == {
+        offboard_module.FindingOutcome.REVOKED_VIA_API,
+        offboard_module.FindingOutcome.NEEDS_CODE_CHANGE,
+        offboard_module.FindingOutcome.NEEDS_HUMAN,
+    }
+    code_changes = [
+        finding.code_change for finding in findings if finding.code_change is not None
+    ]
+    assert {change.symbol for change in code_changes} == {
+        "team_platform_engineering.user_ids",
+        "schedule_rotation_members",
+        "notification_target_params",
+    }
+    assert any("URGENT" in change.instruction for change in code_changes)
+    assert any("REFUSE" in change.instruction for change in code_changes)
+    assert ("PATCH", "/v1/users/99415") in seen
+    assert ("GET", "/v1/users/99415") in seen
+
+
+@pytest.mark.unit
+def test_aws_virtual_mfa_is_deactivated_and_deleted(
+    offboard_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Virtual MFA resources are deleted after they are deactivated."""
+
+    class FakeIAM:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, str]] = []
+
+        def list_access_keys(self, **_kwargs: Any) -> dict[str, list[Any]]:
+            return {"AccessKeyMetadata": []}
+
+        def get_login_profile(self, **_kwargs: Any) -> None:
+            raise offboard_module.ClientError(
+                {"Error": {"Code": "NoSuchEntity", "Message": "missing"}},
+                "GetLoginProfile",
+            )
+
+        def list_mfa_devices(self, **_kwargs: Any) -> dict[str, list[Any]]:
+            return {
+                "MFADevices": [{"SerialNumber": "arn:aws:iam::123456789012:mfa/user"}]
+            }
+
+        def deactivate_mfa_device(self, **kwargs: Any) -> None:
+            self.calls.append(("deactivate", kwargs["SerialNumber"]))
+
+        def delete_virtual_mfa_device(self, **kwargs: Any) -> None:
+            self.calls.append(("delete", kwargs["SerialNumber"]))
+
+    iam = FakeIAM()
+    provider = offboard_module.AWSEphemeralCredentialProvider(repo_root=Path.cwd())
+    monkeypatch.setattr(provider, "_iam_client", lambda: iam)
+    findings = provider._ephemeral_credential_findings(
+        offboard_module.Identity("user@mit.edu"),
+        iam,
+        scope="AWS account=123456789012 profile=test",
+    )
+    mfa_finding = next(
+        finding
+        for finding in findings
+        if finding.outcome is offboard_module.FindingOutcome.REVOKED_VIA_API
+    )
+
+    record = provider.revoke(mfa_finding, execute=True)
+
+    assert record.status is offboard_module.ActionStatus.REVOKED
+    assert iam.calls == [
+        ("deactivate", "arn:aws:iam::123456789012:mfa/user"),
+        ("delete", "arn:aws:iam::123456789012:mfa/user"),
+    ]
+    assert any(
+        finding.outcome is offboard_module.FindingOutcome.NEEDS_HUMAN
+        for finding in findings
+    )
+
+
+@pytest.mark.unit
+def test_aws_code_change_revoke_never_calls_iam(
+    offboard_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pulumi-managed AWS findings remain reports even in execute mode."""
+    provider = offboard_module.AWSProvider(repo_root=Path.cwd())
+    monkeypatch.setattr(
+        provider,
+        "_iam_client",
+        lambda: pytest.fail("Pulumi-managed finding called IAM"),
+    )
+    finding = provider._code_change_findings(
+        offboard_module.Identity("cpatti@mit.edu")
+    )[0]
+
+    record = provider.revoke(finding, execute=True)
+
+    assert record.status is offboard_module.ActionStatus.REPORTED
+    assert record.outcome is offboard_module.FindingOutcome.NEEDS_CODE_CHANGE
+
+
+@pytest.mark.unit
+def test_identity_rejects_non_email_input(offboard_module: Any) -> None:
+    """Ambiguous localparts cannot reach the AWS provider as usernames."""
+    with pytest.raises(ValueError, match="Invalid email address"):
+        offboard_module.Identity("admin")
+
+
+@pytest.mark.unit
+def test_execute_uses_the_exact_confirmed_discovery(offboard_module: Any) -> None:
+    """Execution reuses one discovery result instead of discovering a new plan."""
+    identity = offboard_module.Identity("user@example.com")
+    finding = offboard_module.Finding(
+        service="keycloak",
+        identity=identity,
+        target_id="user-id",
+        target_label=identity.email,
+        verb="disable user",
+        outcome=offboard_module.FindingOutcome.REVOKED_VIA_API,
+        scope="https://sso.example.invalid realm=realm",
+    )
+    provider = FakeProvider(finding)
+    discovered, discovery_records = offboard_module.discover_provider_findings(
+        [identity], [provider]
+    )
+    dry_run = offboard_module.records_for_discovery(
+        discovered, discovery_records, execute=False
+    )
+    executed = offboard_module.records_for_discovery(
+        discovered, discovery_records, execute=True
+    )
+
+    assert provider.discover_count == 1
+    assert provider.execute_values == [False, True]
+    assert dry_run[0].target_id == executed[0].target_id == "user-id"
+    assert "https://sso.example.invalid" in offboard_module.confirmation_summary(
+        dry_run
+    )
+
+
+@pytest.mark.unit
+def test_nonproduction_keycloak_cannot_execute(offboard_module: Any) -> None:
+    """QA remains a read-only discovery target even with --execute."""
+    provider = offboard_module.KeycloakProvider(
+        base_url="https://sso-qa.ol.mit.edu",
+        realm="ol-platform-engineering",
+        auth_realm="master",
+        username="admin",
+        password="password",  # pragma: allowlist secret
+    )
+
+    with pytest.raises(RuntimeError, match="Refusing --execute"):
+        offboard_module.validate_execution_targets([provider])
+
+
+@pytest.mark.unit
+def test_login_profile_access_denied_is_not_reported_as_absent(
+    offboard_module: Any,
+) -> None:
+    """AWS authorization failures cannot masquerade as an absent login profile."""
+
+    class AccessDeniedIAM:
+        def get_login_profile(self, **_kwargs: Any) -> None:
+            raise offboard_module.ClientError(
+                {"Error": {"Code": "AccessDenied", "Message": "denied"}},
+                "GetLoginProfile",
+            )
+
+    with pytest.raises(offboard_module.ClientError):
+        offboard_module.has_login_profile(AccessDeniedIAM(), "user")
+
+
+@pytest.mark.unit
+def test_records_exit_nonzero_when_provider_is_incomplete(offboard_module: Any) -> None:
+    """Skipped and failed providers are visible to shell automation."""
+    identity = offboard_module.Identity("user@example.com")
+    skipped = offboard_module.skipped_record("vault", identity, "missing token")
+    finding = offboard_module.Finding(
+        service="keycloak",
+        identity=identity,
+        target_id="user-id",
+        target_label=identity.email,
+        verb="disable user",
+        outcome=offboard_module.FindingOutcome.REVOKED_VIA_API,
+    )
+    failed = offboard_module.error_record(finding, "request failed", execute=True)
+
+    assert offboard_module.records_exit_code([skipped], execute=False) == 2
+    assert offboard_module.records_exit_code([failed], execute=True) == 1

--- a/tests/scripts/admin/test_offboard_employee.py
+++ b/tests/scripts/admin/test_offboard_employee.py
@@ -7,6 +7,7 @@ import importlib.util
 import sys
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 import pytest
 
@@ -897,11 +898,12 @@ def test_manual_tail_console_urls_are_real_consoles(offboard_module: Any) -> Non
         if finding.human_action.console_url
     ]
 
+    parsed = [urlparse(console) for console in consoles]
+
     assert consoles
-    assert all(console.startswith("https://") for console in consoles)
-    assert not any(
-        "runbook" in console or "github.mit.edu" in console for console in consoles
-    )
+    assert all(url.scheme == "https" for url in parsed)
+    assert all(url.hostname != "github.mit.edu" for url in parsed)
+    assert not any("runbook" in url.path for url in parsed)
 
 
 @pytest.mark.unit

--- a/tests/scripts/admin/test_offboard_employee.py
+++ b/tests/scripts/admin/test_offboard_employee.py
@@ -36,6 +36,13 @@ def offboard_module() -> Any:
     return load_offboard_module()
 
 
+def write_iam_helper(repo_root: Path, username: str) -> None:
+    """Write a minimal IAM helper fixture containing one managed username."""
+    helper_path = repo_root / "src/ol_infrastructure/lib/aws/iam_helper.py"
+    helper_path.parent.mkdir(parents=True)
+    helper_path.write_text(f"ADMIN_USERNAMES = [{username!r}]\n")
+
+
 class FakeProvider:
     """Provider test double that records whether revoke would execute."""
 
@@ -143,6 +150,7 @@ def test_selected_providers_support_comma_filters(offboard_module: Any) -> None:
         vault_addr=None,
         vault_token=None,
         aws_profile=None,
+        aws_account_id=None,
         rootly_token=None,
     )
 
@@ -154,19 +162,19 @@ def test_selected_providers_support_comma_filters(offboard_module: Any) -> None:
 
 @pytest.mark.unit
 def test_aws_code_change_discovery_reports_exact_iam_helper_symbol(
-    offboard_module: Any,
+    offboard_module: Any, tmp_path: Path
 ) -> None:
     """AWS Pulumi-managed access is reported as code cleanup, not API deletion."""
-    provider = offboard_module.AWSProvider(repo_root=Path.cwd())
-    identity = offboard_module.Identity("cpatti@mit.edu")
+    write_iam_helper(tmp_path, "testuser")
+    provider = offboard_module.AWSProvider(repo_root=tmp_path)
+    identity = offboard_module.Identity("testuser@mit.edu")
 
     findings = provider._code_change_findings(identity)
 
     symbols = {
         finding.code_change.symbol for finding in findings if finding.code_change
     }
-    assert "ADMIN_USERNAMES" in symbols
-    assert "DEVOPS_ADMIN_USERNAMES" in symbols
+    assert symbols == {"ADMIN_USERNAMES"}
     assert all(
         finding.outcome is offboard_module.FindingOutcome.NEEDS_CODE_CHANGE
         for finding in findings
@@ -267,9 +275,7 @@ def test_keycloak_execute_revokes_user_mappings_and_federated_identities(  # noq
             "/users/keycloak-user-id"
         ):
             payload = offboard_module.json.loads(request.content)
-            assert payload["email"] == "user@example.com"
-            assert payload["username"] == "user@example.com"
-            assert payload["enabled"] is False
+            assert payload == {"enabled": False}
             return offboard_module.httpx.Response(204)
         if request.method == "POST" and request.url.path.endswith(
             "/users/keycloak-user-id/logout"
@@ -337,6 +343,7 @@ def test_keycloak_execute_revokes_user_mappings_and_federated_identities(  # noq
     record = provider.revoke(findings[0], execute=True)
 
     assert record.status is offboard_module.ActionStatus.REVOKED
+    assert seen.count(("POST", "/realms/master/protocol/openid-connect/token")) == 2
     assert (
         "PUT",
         "/admin/realms/ol-platform-engineering/users/keycloak-user-id",
@@ -390,9 +397,10 @@ def test_vault_discover_and_revoke_live_oidc_token_accessors(
         ):
             return offboard_module.httpx.Response(204)
         if (
-            request.method == "DELETE"
+            request.method == "POST"
             and request.url.path == "/v1/identity/entity/id/entity-1"
         ):
+            assert offboard_module.json.loads(request.content) == {"disabled": True}
             return offboard_module.httpx.Response(204)
         return offboard_module.httpx.Response(
             500, json={"unexpected": f"{request.method} {request.url.path}"}
@@ -421,7 +429,7 @@ def test_vault_discover_and_revoke_live_oidc_token_accessors(
     assert execute_record.status is offboard_module.ActionStatus.REVOKED
     assert entity_record.status is offboard_module.ActionStatus.REVOKED
     assert ("POST", "/v1/auth/token/revoke-accessor") in seen
-    assert ("DELETE", "/v1/identity/entity/id/entity-1") in seen
+    assert ("POST", "/v1/identity/entity/id/entity-1") in seen
 
 
 @pytest.mark.unit
@@ -434,9 +442,15 @@ def test_rootly_discovers_api_deactivation_code_change_and_handoff(
     )
     rootly_file.parent.mkdir(parents=True)
     rootly_file.write_text(
-        "user_ids=[99415]\n"
-        'schedule_rotation_members=[{"memberId": "99415", "position": 1}]\n'
-        'notification_target_params=[{"id": "99415", "type": "user"}]\n'
+        "user_ids=[\n"
+        "    99415,\n"
+        "]\n"
+        "schedule_rotation_members=[\n"
+        '    {"memberId": "99415", "position": 1},\n'
+        "]\n"
+        "notification_target_params=[\n"
+        '    {"id": "99415", "type": "user"},\n'
+        "]\n"
     )
     seen: list[tuple[str, str]] = []
 
@@ -453,7 +467,14 @@ def test_rootly_discovers_api_deactivation_code_change_and_handoff(
                                 "email": "user@example.com",
                                 "name": "Example User",
                             },
-                        }
+                        },
+                        {
+                            "id": "99999",
+                            "attributes": {
+                                "email": "unrelated@example.com",
+                                "name": "Unrelated User",
+                            },
+                        },
                     ]
                 },
             )
@@ -501,6 +522,7 @@ def test_rootly_discovers_api_deactivation_code_change_and_handoff(
 
     assert dry_run_record.status is offboard_module.ActionStatus.WOULD_REVOKE
     assert execute_record.status is offboard_module.ActionStatus.REVOKED
+    assert not any(finding.target_id == "99999" for finding in findings)
     assert {finding.outcome for finding in findings} == {
         offboard_module.FindingOutcome.REVOKED_VIA_API,
         offboard_module.FindingOutcome.NEEDS_CODE_CHANGE,
@@ -518,6 +540,29 @@ def test_rootly_discovers_api_deactivation_code_change_and_handoff(
     assert any("REFUSE" in change.instruction for change in code_changes)
     assert ("PATCH", "/v1/users/99415") in seen
     assert ("GET", "/v1/users/99415") in seen
+
+
+@pytest.mark.unit
+def test_non_mit_email_never_derives_an_aws_revocation_target(
+    offboard_module: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A contractor email remains manual and never reaches the AWS API."""
+    provider = offboard_module.AWSEphemeralCredentialProvider(repo_root=tmp_path)
+    monkeypatch.setattr(
+        provider,
+        "_iam_client",
+        lambda: pytest.fail("non-MIT identity called the AWS API"),
+    )
+
+    findings = provider.discover(
+        offboard_module.Identity("arslan.abdulrauf@arbisoft.com")
+    )
+    record = provider.revoke(findings[0], execute=False)
+
+    assert findings[0].outcome is offboard_module.FindingOutcome.NEEDS_HUMAN
+    assert record.status is offboard_module.ActionStatus.INCOMPLETE
+    assert record.target_id == "arslan.abdulrauf"
+    assert offboard_module.records_exit_code([record], execute=False) == 2
 
 
 @pytest.mark.unit
@@ -579,17 +624,18 @@ def test_aws_virtual_mfa_is_deactivated_and_deleted(
 
 @pytest.mark.unit
 def test_aws_code_change_revoke_never_calls_iam(
-    offboard_module: Any, monkeypatch: pytest.MonkeyPatch
+    offboard_module: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """Pulumi-managed AWS findings remain reports even in execute mode."""
-    provider = offboard_module.AWSProvider(repo_root=Path.cwd())
+    write_iam_helper(tmp_path, "testuser")
+    provider = offboard_module.AWSProvider(repo_root=tmp_path)
     monkeypatch.setattr(
         provider,
         "_iam_client",
         lambda: pytest.fail("Pulumi-managed finding called IAM"),
     )
     finding = provider._code_change_findings(
-        offboard_module.Identity("cpatti@mit.edu")
+        offboard_module.Identity("testuser@mit.edu")
     )[0]
 
     record = provider.revoke(finding, execute=True)
@@ -639,6 +685,43 @@ def test_execute_uses_the_exact_confirmed_discovery(offboard_module: Any) -> Non
 
 
 @pytest.mark.unit
+def test_keycloak_no_exact_match_is_incomplete(offboard_module: Any) -> None:
+    """A missing Keycloak identity cannot silently disappear from the report."""
+
+    def handler(request: Any) -> Any:
+        if request.url.path.endswith("/protocol/openid-connect/token"):
+            return offboard_module.httpx.Response(200, json={"access_token": "token"})
+        return offboard_module.httpx.Response(
+            200,
+            json=[
+                {
+                    "id": "wrong-user",
+                    "email": "other@example.com",
+                    "username": "other@example.com",
+                }
+            ],
+        )
+
+    provider = offboard_module.KeycloakProvider(
+        base_url="https://sso.example.invalid",
+        realm="ol-platform-engineering",
+        auth_realm="master",
+        username="admin",
+        password="password",  # pragma: allowlist secret
+        client=offboard_module.httpx.Client(
+            transport=offboard_module.httpx.MockTransport(handler)
+        ),
+    )
+
+    finding = provider.discover(offboard_module.Identity("user@example.com"))[0]
+    record = provider.revoke(finding, execute=False)
+
+    assert finding.outcome is offboard_module.FindingOutcome.NEEDS_HUMAN
+    assert record.status is offboard_module.ActionStatus.INCOMPLETE
+    assert offboard_module.records_exit_code([record], execute=False) == 2
+
+
+@pytest.mark.unit
 def test_nonproduction_keycloak_cannot_execute(offboard_module: Any) -> None:
     """QA remains a read-only discovery target even with --execute."""
     provider = offboard_module.KeycloakProvider(
@@ -651,6 +734,46 @@ def test_nonproduction_keycloak_cannot_execute(offboard_module: Any) -> None:
 
     with pytest.raises(RuntimeError, match="Refusing --execute"):
         offboard_module.validate_execution_targets([provider])
+
+
+@pytest.mark.unit
+def test_aws_execute_requires_explicit_account_id(
+    offboard_module: Any, tmp_path: Path
+) -> None:
+    """Ambient AWS credentials cannot mutate an unconfirmed account."""
+    provider = offboard_module.AWSEphemeralCredentialProvider(repo_root=tmp_path)
+
+    with pytest.raises(RuntimeError, match="--aws-account-id"):
+        offboard_module.validate_execution_targets([provider])
+
+    provider.expected_account_id = "not-an-account"
+    with pytest.raises(RuntimeError, match="12-digit"):
+        offboard_module.validate_execution_targets([provider])
+
+    provider.expected_account_id = "123456789012"
+    offboard_module.validate_execution_targets([provider])
+
+
+@pytest.mark.unit
+def test_aws_discovery_rejects_an_unexpected_account(
+    offboard_module: Any, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Discovery fails closed when ambient credentials target another AWS account."""
+
+    class FakeIAM:
+        def get_user(self, **_kwargs: Any) -> dict[str, Any]:
+            return {"User": {"Arn": "arn:aws:iam::999999999999:user/testuser"}}
+
+    provider = offboard_module.AWSEphemeralCredentialProvider(
+        repo_root=tmp_path,
+        expected_account_id="123456789012",
+    )
+    monkeypatch.setattr(provider, "_iam_client", FakeIAM)
+
+    with pytest.raises(
+        offboard_module.OffboardingError, match="not explicitly confirmed"
+    ):
+        provider.discover(offboard_module.Identity("testuser@mit.edu"))
 
 
 @pytest.mark.unit
@@ -685,5 +808,42 @@ def test_records_exit_nonzero_when_provider_is_incomplete(offboard_module: Any) 
     )
     failed = offboard_module.error_record(finding, "request failed", execute=True)
 
+    incomplete = offboard_module.report_record(
+        offboard_module.vault_unresolved_identity_finding(
+            identity, "https://vault.example.invalid"
+        ),
+        execute=False,
+    )
+
     assert offboard_module.records_exit_code([skipped], execute=False) == 2
+    assert offboard_module.records_exit_code([incomplete], execute=False) == 2
     assert offboard_module.records_exit_code([failed], execute=True) == 1
+
+
+@pytest.mark.unit
+def test_confirmation_warns_about_incomplete_discovery(offboard_module: Any) -> None:
+    """The destructive prompt makes unchecked providers explicit."""
+    identity = offboard_module.Identity("user@example.com")
+    incomplete = offboard_module.report_record(
+        offboard_module.rootly_unresolved_identity_finding(
+            identity, "https://api.rootly.example.invalid"
+        ),
+        execute=False,
+    )
+
+    summary = offboard_module.confirmation_summary([incomplete])
+
+    assert "Discovery is incomplete" in summary
+    assert "[incomplete] user@example.com: rootly" in summary
+    assert "known revocations" in summary
+
+
+@pytest.mark.unit
+def test_confirmation_must_match_exactly(
+    offboard_module: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A mistyped destructive confirmation aborts before execution."""
+    monkeypatch.setattr("builtins.input", lambda: "execute")
+
+    with pytest.raises(RuntimeError, match="aborting without mutations"):
+        offboard_module.require_confirmation([])

--- a/tests/scripts/admin/test_offboard_employee.py
+++ b/tests/scripts/admin/test_offboard_employee.py
@@ -126,7 +126,10 @@ def test_missing_provider_credentials_are_skipped_without_aborting(
 ) -> None:
     """A missing service credential yields a skipped record and keeps going."""
     identity = offboard_module.Identity("user@example.com")
-    providers = [MissingProvider(offboard_module), offboard_module.ManualTailProvider()]
+    providers = [
+        MissingProvider(offboard_module),
+        offboard_module.ManualTailProvider(repo_root=offboard_module.REPO_ROOT),
+    ]
 
     records = offboard_module.collect_action_records(
         [identity], providers, execute=False
@@ -847,3 +850,72 @@ def test_confirmation_must_match_exactly(
 
     with pytest.raises(RuntimeError, match="aborting without mutations"):
         offboard_module.require_confirmation([])
+
+
+@pytest.mark.unit
+def test_manual_tail_derives_console_urls_from_stack_config(
+    offboard_module: Any, tmp_path: Path
+) -> None:
+    """Grafana and Atlas consoles come from stack config, not hardcoded hostnames."""
+    keycloak_dir = tmp_path / "src/ol_infrastructure/substructure/keycloak"
+    keycloak_dir.mkdir(parents=True)
+    (keycloak_dir / "Pulumi.Production.yaml").write_text(
+        "config:\n"
+        "  keycloak_realm:ol-platform-engineering-grafana-web-origins:"
+        ' ["https://example-prod.grafana.net"]\n'
+    )
+    atlas_dir = tmp_path / "src/ol_infrastructure/infrastructure/mongodb_atlas"
+    atlas_dir.mkdir(parents=True)
+    (atlas_dir / "Pulumi.mitx.Production.yaml").write_text(
+        "config:\n  mongodb_atlas:organization_id: abc123\n"
+    )
+
+    findings = offboard_module.ManualTailProvider(repo_root=tmp_path).discover(
+        offboard_module.Identity("user@example.com")
+    )
+    consoles = {
+        finding.target_id.split(":", 1)[0]: finding.human_action.console_url
+        for finding in findings
+    }
+
+    assert consoles["grafana"] == "https://example-prod.grafana.net/admin/users"
+    assert (
+        consoles["mongodb-atlas"]
+        == "https://cloud.mongodb.com/v2#/org/abc123/access/users"
+    )
+
+
+@pytest.mark.unit
+def test_manual_tail_console_urls_are_real_consoles(offboard_module: Any) -> None:
+    """No manual action may point the operator at a docs or runbook repository."""
+    findings = offboard_module.ManualTailProvider(
+        repo_root=offboard_module.REPO_ROOT
+    ).discover(offboard_module.Identity("user@example.com"))
+    consoles = [
+        finding.human_action.console_url
+        for finding in findings
+        if finding.human_action.console_url
+    ]
+
+    assert consoles
+    assert all(console.startswith("https://") for console in consoles)
+    assert not any(
+        "runbook" in console or "github.mit.edu" in console for console in consoles
+    )
+
+
+@pytest.mark.unit
+def test_manual_tail_omits_console_url_it_cannot_derive(offboard_module: Any) -> None:
+    """An undiscoverable vendor yields no link rather than a misleading one."""
+    findings = offboard_module.ManualTailProvider(
+        repo_root=offboard_module.REPO_ROOT
+    ).discover(offboard_module.Identity("user@example.com"))
+    password_manager = next(
+        finding
+        for finding in findings
+        if finding.target_id.startswith("password-manager:")
+    )
+    record = offboard_module.report_record(password_manager, execute=False)
+
+    assert password_manager.human_action.console_url is None
+    assert "console:" not in offboard_module.records_to_text([record], execute=False)


### PR DESCRIPTION
### What are the relevant tickets?

Closes #5235

### Description (What does it do?)

Replaces the requested prose offboarding runbook with a dry-run-first executable:

```bash
uv run scripts/admin/offboard-employee person@mit.edu
```

The command accepts one or more email addresses and classifies every finding as:

- `REVOKED_VIA_API`: safe immediate containment
- `NEEDS_CODE_CHANGE`: Pulumi-managed access that must be removed in code and applied
- `NEEDS_HUMAN`: ownership, UI-only, or otherwise non-attributable work

Implemented providers and safety controls include:

- **Keycloak:** disables the account, terminates sessions, removes groups, realm/client roles, consents/offline grants, and federated identities. The default targets `ol-platform-engineering`; additional realms can be explicitly supplied.
- **Vault:** resolves the email-backed OIDC entity, revokes all matching token accessors (and their child leases), then disables the entity — aliases are preserved so the action stays auditable and safely retryable.
- **AWS IAM:** deletes only ephemeral credentials (access keys, console login profile, virtual/hardware MFA); it never API-deletes Pulumi-managed users or memberships. Exact `iam_helper.py` symbols and every affected Pulumi stack are reported. Already-issued STS sessions are called out as residual access. Execution requires `--aws-account-id`, and the discovered IAM user's ARN must match that confirmed 12-digit account, so ambient credentials cannot mutate the wrong account.
- **Rootly:** deactivates the API user with a read-back verification, reports every exact AST-matched Pulumi user-id reference, flags urgent rotation edits, and refuses to invent replacements for required scalar/notification targets.
- **Repository scanner:** scans tracked files for hardcoded personal emails without echoing source lines into the audit report.
- **Manual tail:** emits explicit GitHub/Concourse, Sentry, Grafana, Fastly, Heroku, MongoDB Atlas, Qdrant Cloud, Mailgun, and password-manager handoffs where API attribution or ownership transfer is unsafe. Each entry carries a deep-linked console URL, and the Grafana stack hosts and Atlas organization are derived from stack configuration rather than hardcoded, so the links cannot drift from what is deployed. The password manager is the one entry with no URL — the vendor is not declared in this repository, so no link is invented.

Destructive execution requires `--execute` and an `EXECUTE` confirmation unless `--yes` is supplied. Discovery runs once, and execution reuses that exact confirmed finding set. QA/CI targets are refused in execute mode. Partial or failed providers produce non-zero exit codes instead of false success.

Discovery fails closed on identity resolution: a Keycloak, Vault, AWS, or Rootly lookup that finds no exact match reports an explicit `incomplete` status rather than returning no findings, so "nothing to revoke" can never be confused with "nothing found." Incomplete providers are listed in the destructive confirmation prompt and force a non-zero exit.

The accompanying ADR documents why API deletion is correct for Keycloak users and ephemeral credentials but wrong for hardcoded Pulumi-managed AWS/Rootly access.

### How can this be tested?

```bash
uv run pytest -q tests/scripts/admin/test_offboard_employee.py
uv run ruff check scripts/admin/offboard-employee tests/scripts/admin/test_offboard_employee.py
uv run mypy scripts/admin/offboard-employee tests/scripts/admin/test_offboard_employee.py
uv run pre-commit run --files \
  docs/adr/0011-executable-offboarding-script-over-runbook.md \
  scripts/admin/offboard-employee \
  tests/scripts/admin/__init__.py \
  tests/scripts/admin/test_offboard_employee.py
uv run scripts/admin/offboard-employee \
  --only repo-code,human \
  --output json \
  nobody-offboarding-test@example.invalid
```

Results: 25 unit tests pass; Ruff, mypy, changed-file pre-commit, and local read-only discovery pass. HTTP APIs and AWS clients are mocked; no destructive live-service test was run.

`pre-commit --all-files` reaches all hooks but is not globally green because this environment lacks Packer and existing unrelated Dockerfiles fail hadolint. The changed-file run is green.

### Additional Context

- Dry-run is the default. Reviewers should not use `--execute` while testing.
- Live QA discovery was not attempted because this session had no Keycloak, Vault, AWS, or Rootly operator credentials. QA/CI are deliberately blocked from mutation.
- No Pulumi source or stack configuration is changed by this PR, so `pulumi preview` is not applicable.




### Unrelated drive-by

`.gitleaks.toml` allowlists the `encryptedkey:` / `secure:` / `secretsprovider:` lines in Pulumi
stack files. gitleaks' `generic-api-key` heuristic fired on the KMS-wrapped ciphertext in ~300
stack files (279 of 299 total findings), which buried the handful worth reading. `detect-secrets`
already excludes these same three prefixes in `.pre-commit-config.yaml`; this makes gitleaks agree.
No credential is involved — the ciphertext is inert without `kms:Decrypt` on the alias.
