### PR TITLE
fix(eks,edxapp): right-size CPU requests for HPA scaling and run metrics-server HA

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
@@ -132,7 +132,11 @@ config:
         memory_request: "2Gi"
         memory_limit: "3Gi"
       cms:
-        cpu_request: "250m"
+        # Studio operations (course publish/import, outline rebuilds) burst to
+        # ~0.65 cores per pod at only 1-9 req/s. The KEDA CPU trigger scales on
+        # utilization relative to this request, so an undersized request pins
+        # the webapp at max replicas during routine authoring activity.
+        cpu_request: "500m"
         memory_request: "2Gi"
         memory_limit: "4Gi"
     celery:

--- a/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
@@ -1126,6 +1126,14 @@ metrics_server_release = kubernetes.helm.v3.Release(
         values={
             "commonLabels": k8s_global_labels,
             "tolerations": operations_tolerations,
+            # Every HPA in the cluster depends on metrics-server for resource
+            # metrics. A single replica means any restart or node drain leaves
+            # all HPAs blind until it comes back.
+            "replicas": 2,
+            "podDisruptionBudget": {
+                "enabled": True,
+                "minAvailable": 1,
+            },
             "resources": {
                 "requests": {
                     "memory": "100Mi",

--- a/src/ol_infrastructure/infrastructure/aws/eks/traefik.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/traefik.py
@@ -206,7 +206,11 @@ def setup_traefik(
                 },
                 "resources": {
                     "requests": {
-                        "cpu": "100m",
+                        # The HPA above scales on CPU utilization as a percentage of
+                        # this request. Keep it near observed per-pod burst usage or
+                        # every minor traffic burst pins the deployment at
+                        # maxReplicas.
+                        "cpu": eks_config.get("traefik_cpu_request") or "500m",
                         "memory": "150Mi",
                     },
                     "limits": {


### PR DESCRIPTION
### What are the relevant tickets?
N/A — follow-up to two Grafana alerts on 2026-08-04: `HPA keda-hpa-cms-edxapp-webapp-scaledobject in namespace mitxonline-openedx ... at its maximum replica count for 15 minutes` and `HPA traefik-gateway-controller in namespace operations ... at its maximum replica count for 15 minutes` (cluster `applications-production`).

### Description (What does it do?)
Both HPAs were pinning at max replicas without any real saturation (near-zero 5xx at the gateway, both workloads <15% CPU shortly after the alerts). Root causes found during investigation:

1. **CPU requests far below observed burst usage** make percentage-of-request utilization targets hair-trigger:
   - `traefik-gateway-controller`: request was hardcoded to `100m` with a 50% utilization target, so any pod averaging >50 millicores scaled up. Observed per-pod bursts reach ~200m (200% of request), which computes a desired replica count pinned at max — the HPA scaled to max **176 times in ~3 days**, flapping constantly between min and max.
   - `cms-edxapp-webapp` (mitxonline production): request was `250m` with a 70% target (threshold 175m). Studio traffic is tiny (1–9 req/s) but individual operations (course publish/import, outline rebuilds) burst pods to ~0.65 cores, so routine authoring pinned the deployment at max.
2. **metrics-server was a single replica.** It restarted ~1h before the alerts; both HPAs logged `FailedGetContainerResourceMetric: the server is currently unable to handle the request` and latched their highest recent recommendation (`ScaleDownStabilized`), which is why both alerts fired simultaneously.

Changes:
- `infrastructure/aws/eks/traefik.py`: traefik CPU request is now configurable via `eks:traefik_cpu_request`, defaulting to `500m` (scale-up threshold becomes ~250m/pod, above the observed burst peak).
- `applications/edxapp/Pulumi.mitxonline.Production.yaml`: CMS webapp `cpu_request` `250m` → `500m` (matches the LMS; KEDA CPU trigger threshold moves from 175m to 350m).
- `infrastructure/aws/eks/__main__.py`: metrics-server now runs `replicas: 2` with a PodDisruptionBudget (`minAvailable: 1`) so a restart/drain never blinds every HPA in the cluster at once.

### How can this be tested?
- `pulumi preview --stack applications.Production` in `src/ol_infrastructure/infrastructure/aws/eks` shows exactly the expected in-place updates and no replacements/deletions from this change:
  - traefik Helm release: `values.resources.requests.cpu: "100m" => "500m"`
  - metrics-server Helm release: `+ replicas: 2`, `+ podDisruptionBudget: {minAvailable: 1}`
- `pulumi preview --stack mitxonline.Production` in `src/ol_infrastructure/applications/edxapp` (with `EDXAPP_DOCKER_IMAGE_DIGEST` set to the currently deployed digest) shows the CMS deployment update `resources.requests.cpu: "250m" => "500m"`. Other diffs in that preview (ConfigMap replacements, granian args, VPA creation, a meilisearch APISIX PluginConfig delete) are pre-existing drift from `main` commits not yet deployed, not from this change.
- After deploy, watch `kubectl -n operations get hpa traefik-gateway-controller -w` and `kubectl -n mitxonline-openedx get hpa keda-hpa-cms-edxapp-webapp-scaledobject -w` — the constant flap to max replicas should stop, and `kubectl -n kube-system get pods -l app.kubernetes.io/name=metrics-server` should show 2 pods.

### Additional Context
- Capacity impact is small: traefik reserves an extra 400m × 5 pods = 2 cores per cluster; CMS reserves an extra 250m × 3–10 pods.
- The traefik default applies to all EKS clusters (they all share the same flapping-prone 100m request); any cluster can override with `eks:traefik_cpu_request`.
- The "HPA at max for 15 minutes" alert itself was left untouched; once the requests are right-sized the flapping that makes it noisy should stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
