### PR TITLE
fix(fastly): pin provider before TLS subscription regression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
   "pulumi-aws>=7.1,<8",
   "pulumi-docker>=5,<6",
   # 12.4.0 turns historical TLS activation state drift into unsafe API updates.
-  # Remove this cap after the read-path regression exposed by upstream #1353 is fixed.
+  # Remove this cap after the fastly/terraform-provider-fastly read-path regression (PR #1353) is fixed.
   "pulumi-fastly>=12,<12.4",
   "pulumi-github>=6.0.0,<7",
   "pulumi-mailgun>=3.0.0,<4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,9 @@ dependencies = [
   "pulumi>=3.39.1,<4",
   "pulumi-aws>=7.1,<8",
   "pulumi-docker>=5,<6",
-  "pulumi-fastly>=12,<13",
+  # 12.4.0 turns historical TLS activation state drift into unsafe API updates.
+  # Remove this cap after the read-path regression exposed by upstream #1353 is fixed.
+  "pulumi-fastly>=12,<12.4",
   "pulumi-github>=6.0.0,<7",
   "pulumi-mailgun>=3.0.0,<4",
   "pulumi-tls>=5.0.0,<6",

--- a/uv.lock
+++ b/uv.lock
@@ -1519,7 +1519,7 @@ requires-dist = [
     { name = "pulumi-consul", specifier = ">=3.5.0,<4" },
     { name = "pulumi-docker", specifier = ">=5,<6" },
     { name = "pulumi-eks", specifier = ">=4,<5" },
-    { name = "pulumi-fastly", specifier = ">=12,<13" },
+    { name = "pulumi-fastly", specifier = ">=12,<12.4" },
     { name = "pulumi-github", specifier = ">=6.0.0,<7" },
     { name = "pulumi-keycloak", specifier = ">=6.0.0,<7" },
     { name = "pulumi-mailgun", specifier = ">=3.0.0,<4" },
@@ -1990,16 +1990,16 @@ wheels = [
 
 [[package]]
 name = "pulumi-fastly"
-version = "12.4.0"
+version = "12.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "parver" },
     { name = "pulumi" },
     { name = "semver" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/fa/05e13a410598976d7cce57d14112352f530918a3823a8110cc1b22d200ab/pulumi_fastly-12.4.0.tar.gz", hash = "sha256:aa25aac36ea2f06656cbe1193f39ff434dcd2f7143d9d70569dd080e0f95e30d", size = 252143, upload-time = "2026-07-23T04:33:22.712Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/95/91154faf77b223eaa1f3c17f5b3f1be2894ee082323dad1d491626fe9ea4/pulumi_fastly-12.3.1.tar.gz", hash = "sha256:4814d2c83dfbcbbf98bfc50daf2097f6307496f7b3f6fc03e9767b96d9a2fe49", size = 249632, upload-time = "2026-07-10T04:55:41.639Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/ab/9e3e2aaefe56962e3343728dadf74637c9f8c40ef6fb11dbbf22d4d2f4bf/pulumi_fastly-12.4.0-py3-none-any.whl", hash = "sha256:2eef758a805927ddfbfcdb9a66ec4389b628dd288ef285b1f324fdf6a57b39af", size = 382934, upload-time = "2026-07-23T04:33:21.081Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/8c/1c2c8eb1f4eadb9670cb4d27d8de8ace1baf1c4b6225e1e594bde71f79ce/pulumi_fastly-12.3.1-py3-none-any.whl", hash = "sha256:ba58acebe1d4286bfa7768707f2297014e2be4ed3f4d7854d31c54cdbc10623c", size = 381061, upload-time = "2026-07-10T04:55:39.695Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

Caps `pulumi-fastly` below 12.4 and restores the lockfile to 12.3.1.

`pulumi-fastly` 12.4.0 upgraded the underlying Fastly Terraform provider to 9.4.0, which included [fastly/terraform-provider-fastly#1353](https://github.com/fastly/terraform-provider-fastly/pull/1353). That change began sending API updates when only a TLS subscription's `configuration_id` appears to change.

The Fastly provider's read path can select a historical activation for a domain instead of its current activation. In the MITx Online Production stack this makes the checkpoint alternate between the old TLS v1.2 configuration and the current TLS v1.3 configuration. Version 12.4.0 then attempts to reconcile that false drift, and Fastly rejects the request:

```
Can't update subscription
Subscription has active domains
```

Version 12.3.1 still reads the inconsistent state, but does not issue an API request for a configuration-only diff. The upper bound is documented as temporary and should be removed after the upstream read-path bug is fixed.

### How can this be tested?

1. Run `uv lock --check` and `uv sync --frozen`.
2. Confirm `uv run python -c "from importlib.metadata import version; print(version('pulumi-fastly'))"` prints `12.3.1`.
3. From `src/ol_infrastructure/applications/mitxonline`, run `pulumi preview --stack Production --diff --refresh=false`.
4. Confirm the preview downgrades the Fastly provider from 12.4.0 to 12.3.1 and contains no replacements or deletions.

Validation performed:

- `uv lock --check` — passed
- `uv sync --frozen` — passed
- `uv run pre-commit run --files pyproject.toml uv.lock` — passed
- `uv run pytest tests/ol_infrastructure/ -q` — 200 passed
- Production Pulumi preview — completed; 3 updates, 139 unchanged, no replacements or deletions

### Additional Context

The preview continues to display the existing TLS subscription state diff. Under provider 12.3.1, its update handler does not call Fastly unless `domains` or `common_name` changed, so the false configuration-only diff no longer triggers the rejected production API operation.

A full repository pre-commit run passed all relevant checks but still reports existing environmental/repository findings: Packer is unavailable locally, and hadolint reports pre-existing Dockerfile warnings. A direct repository-wide mypy run also reports the repository's existing type-check backlog; this PR changes no Python source.
