### PR TITLE
allow anonymous access to /cart in mitxonline

### DIFF
--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -558,9 +558,11 @@ mitxonline_granian_workers_max_rss = (
 # it should react to.
 #
 # The route matcher aggregates every webapp route (direct + prefixed, passauth /
-# reqauth / cart) so total traffic drives scaling rather than a single route. Verified
-# against live metrics -- `count by (route) (apisix_http_status)` returns
-# mitxonline_mitxonline-apisix-route-{direct,prefixed}-production_{passauth,reqauth,cart}.
+# reqauth / checkout-anonymous) so total traffic drives scaling rather than a single
+# route. Verified against live metrics -- `count by (route) (apisix_http_status)`
+# returns mitxonline_mitxonline-apisix-route-{direct,prefixed}-production_{passauth,
+# reqauth,checkout-anonymous}. (The direct group's auth gate was renamed from "cart"
+# to "checkout-anonymous"; the ".*" matcher already covered it either way.)
 webapp_trigger_auth, webapp_trigger_auth_name = create_webapp_prometheus_trigger_auth(
     application_name="mitxonline",
     env_name=env_name,
@@ -852,14 +854,25 @@ mitxonline_apisix_route_direct = OLApisixRoute(
             backend_service_name=mitxonline_k8s_app.application_lb_service_name,
             backend_service_port=mitxonline_k8s_app.application_lb_service_port_name,
         ),
+        # Login gate for the reordered ("anonymous first") checkout flow, and the
+        # successor to the former "cart" route. A learner who built a basket
+        # while logged out now browses /cart anonymously -- with the cart auth
+        # gate gone, /cart falls through to the passauth route above, which
+        # serves the anonymous basket. When they proceed to checkout they land
+        # here, where unauth_action="auth" forces the OIDC login that
+        # establishes the MITx Online session, after which the anonymous basket
+        # is claimed and checkout proceeds. Mirrors mitxonline's own gateway,
+        # which renamed its app-cart route to app-checkout-anonymous and swapped
+        # /cart for /checkout/anonymous for exactly this reason. Same direct
+        # (MITx Online) session and default per-host /.apisix/redirect callback
+        # as the old cart route.
         OLApisixRouteConfig(
-            route_name="cart",
+            route_name="checkout-anonymous",
             priority=20,
             hosts=[api_domain, frontend_domain],
             paths=[
-                "/cart/",
-                "/cart",
-                "/cart/*",
+                "/checkout/anonymous",
+                "/checkout/anonymous/",
             ],
             plugins=[
                 mitxonline_direct_oidc.get_full_oidc_plugin_config(


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12530

### Description (What does it do?)
This PR moves the `/cart` endpoint in MITx Online to anonymous access, instead gating login on `/checkout/anonymous`.

Concretely, in the `mitxonline` app's direct APISIX route group it renames the existing `cart` route (which forced login via `unauth_action="auth"` on `/cart*`) to `checkout-anonymous` and swaps its paths to `/checkout/anonymous` + `/checkout/anonymous/`. Net effect: `/cart` falls through to the pass-auth wildcard and is served anonymously (the MITx Online cart endpoint returns the anonymous basket), while `/checkout/anonymous` becomes the login gate that establishes the session so the anonymous basket can be claimed. This mirrors the MITx Online app's own gateway change (`app-cart` → `app-checkout-anonymous`).

### How can this be tested?
Standard ol-infra flow: devops review, then deploy and verify in **RC**. Requires the MITx Online app PR (anonymous-basket support, #12530) in RC as well, or anonymous `/cart` will still error at the app layer.

Once applied to RC, verify on `rc.mitxonline.mit.edu`:
- Anonymous `/cart/` no longer bounces to Keycloak — returns the cart page showing the anonymous basket.
- Anonymous `/checkout/anonymous` redirects to login; after auth it claims the basket and lands on `/checkout/to_payment`.
- Logged-in checkout is unchanged (goes via `/checkout/to_payment`, never `/checkout/anonymous`).
- End-to-end from Learn RC (frontend flag on): add a paid item while logged out → MITx Online `/cart` shows it → proceed → `/checkout/anonymous` → log in / create account → payment.

### Additional Context
- **This is the infra half of a three-repo change:** the MITx Online app PR (anonymous baskets) and the Learn frontend PR (feature-flagged hand-off) are the other two.
- **Security:** moving `/cart` to anonymous only exposes basket viewing/building. Payment stays gated independently in Django (`LoginRequiredMixin` on `/checkout/to_payment` and `/checkout/anonymous`; `IsAuthenticated` on checkout/basket-mutation APIs) — the APISIX gate isn't what protects payment. No Keycloak change needed: the `olapps-mitlearn` client already whitelists `<env>.mitxonline.mit.edu/*` in all environments.
- **Metrics:** the APISIX route label changes from `…_cart` to `…_checkout-anonymous`; any Grafana panels/alerts keyed on the old label need updating. The KEDA autoscaler's `.*` route matcher already covers it.
- **Feature flag is UX-only:** once this deploys, the gateway/backend accept anonymous baskets regardless of the Learn frontend flag — it's not a hard server-side kill-switch.