### PR TITLE
add missing wildcard route to mitxonline anonymous checkout

### DIFF
--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -873,6 +873,7 @@ mitxonline_apisix_route_direct = OLApisixRoute(
             paths=[
                 "/checkout/anonymous",
                 "/checkout/anonymous/",
+                "/checkout/anonymous/*",
             ],
             plugins=[
                 mitxonline_direct_oidc.get_full_oidc_plugin_config(


### PR DESCRIPTION
What are the relevant tickets?

https://github.com/mitodl/hq/issues/12530 (follow-up to the initial /checkout/anonymous routing PR)

Description (What does it do?)

Adds /checkout/anonymous/* to the checkout-anonymous APISIX route's paths so it catches its own OIDC callback.

The initial PR gated login on the exact paths /checkout/anonymous and /checkout/anonymous/. But APISIX's default OIDC callback is request-path-relative — /checkout/anonymous/.apisix/redirect — which those exact paths don't match, so the callback currently falls through to the pass-auth /* route and is completed there. It works today only because pass-auth happens to run the same OIDC/session config; it's an undeclared cross-route dependency. This restores the pattern every other auth route already uses (reqauth catches its callback via /login*, the former cart route via /cart/*), making the route self-contained.

How can this be tested?

Standard ol-infra flow: devops review, then verify in RC.

On rc.mitxonline.mit.edu, behavior should be unchanged from today (the flow already works) — this just moves callback handling onto the correct route:
- Anonymous /checkout/anonymous → login → lands in checkout (as before).
- Anonymous /cart/ still served anonymously (unchanged).