### PR TITLE
fix(grafana-alerting): stop paging on the mitxonline hubspot-sync worker HPA at max replicas

### DIFF
--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
@@ -399,6 +399,13 @@ def create(
                     'sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_status_current_replicas{cluster=~".*-(ci|qa)"}) >= sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_spec_max_replicas{cluster=~".*-(ci|qa)"}) and sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_spec_max_replicas{cluster=~".*-(ci|qa)"}) != sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_spec_min_replicas{cluster=~".*-(ci|qa)"})'
                 ),
             ),
+            # Also excludes the mitxonline hubspot-sync celery worker HPA:
+            # a scheduled certificate-generation task enqueues ~20k contact
+            # sync tasks every 6 hours, and the worker legitimately sits at
+            # max replicas for ~20 minutes while draining, throughput-capped
+            # by the HubSpot API rate limiter rather than replica count.
+            # Remove the exclusion once the producer stops enqueueing no-op
+            # syncs: https://github.com/mitodl/hq/issues/12701
             alerting.RuleGroupRuleArgs(
                 name="HPAAtMaxReplicasCritical",
                 condition="C",
@@ -409,7 +416,7 @@ def create(
                     "description": "HPA {{ $labels.horizontalpodautoscaler }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has been at its maximum replica count for 15 minutes. The workload may be unable to scale further under load."
                 },
                 datas=rd(
-                    'sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_status_current_replicas{cluster=~".*-(production)"}) >= sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_spec_max_replicas{cluster=~".*-(production)"}) and sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_spec_max_replicas{cluster=~".*-(production)"}) != sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_spec_min_replicas{cluster=~".*-(production)"})'
+                    'sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_status_current_replicas{cluster=~".*-(production)", horizontalpodautoscaler!="keda-hpa-mitxonline-hubspot-sync-celery-worker"}) >= sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_spec_max_replicas{cluster=~".*-(production)"}) and sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_spec_max_replicas{cluster=~".*-(production)"}) != sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_spec_min_replicas{cluster=~".*-(production)"})'
                 ),
             ),
         ],


### PR DESCRIPTION
### What are the relevant tickets?
Tracking issue for the underlying producer fix: https://github.com/mitodl/hq/issues/12701 (moved from https://github.com/mitodl/mitxonline/issues/3816). This PR is the alerting-side mitigation; the exclusion should be removed once that issue is resolved.

### Description (What does it do?)
Excludes `keda-hpa-mitxonline-hubspot-sync-celery-worker` from the `HPAAtMaxReplicasCritical` Grafana alert rule.

The mitxonline `generate-course-certificate` beat task (`CRON_COURSE_CERTIFICATES_HOURS="*/6"` in production) enqueues ~20,000 no-op `sync_contact_with_hubspot` tasks at 00:00/06:00/12:00/18:00 UTC. The hubspot-sync worker's KEDA ScaledObject correctly scales 1→10 (max) and drains the backlog in ~20 minutes. Throughput is capped by the shared HubSpot API rate limiter (~15–20 req/s), not replica count, so being at max replicas for >15 minutes is expected, healthy burst-drain behavior — yet it pages on-call four times a day via this rule.

The change adds a `horizontalpodautoscaler!="keda-hpa-mitxonline-hubspot-sync-celery-worker"` matcher to the rule's first selector, following the existing precedent in the same rule that excludes min==max HPAs (the xqwatcher case). Excluding the series from the left-hand side of the `>=` comparison is sufficient: PromQL vector matching drops the series from the comparison output, so the subsequent `and` can never produce a row for it.

Deliberately narrow scope:
- Only the **critical** (production, paging) rule is touched. The warning rule for CI/QA clusters still covers this HPA.
- Every other HPA in every production cluster pages exactly as before.
- Trade-off (accepted): a genuinely stuck hubspot_sync queue (HubSpot outage, poison task) will no longer page through this rule; it would surface via task failures/Sentry instead. The exclusion becomes unnecessary once the producer fix lands.

### How can this be tested?
- `pulumi preview --stack Production` in `src/ol_infrastructure/infrastructure/grafana_alerting` shows exactly one meaningful update: the `grafana:alerting/ruleGroup:RuleGroup` expression change adding the label matcher (plus a benign provider metadata update). No creates/deletes/replaces.
- After deploy, the rule can be verified in Grafana Cloud (production stack) — the `HPAAtMaxReplicasCritical` query with the new matcher returns no series for the hubspot worker HPA even while it is at max, and unchanged results for all other HPAs.
- The alert should stop firing at the next 6-hour certificate-generation run (00:00/06:00/12:00/18:00 UTC).

### Additional Context
Investigation summary: the worker drains ~20k tasks at ~17–18 tasks/s with all tasks succeeding in ~1s; the queue returns to zero after each burst (verified via the HPA external metric and Loki task logs). Removing the ScaledObject or raising `maxReplicas` were both evaluated and rejected — one static worker would stretch the drain to ~2.8 hours and delay real-time ecommerce/contact syncs sharing the queue, while more replicas cannot exceed the HubSpot rate limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
