### PR TITLE
Provision per-user omnigraph tokens from Keycloak witan-users membership

### DIFF
--- a/docs/witan-token-sync-runbook.md
+++ b/docs/witan-token-sync-runbook.md
@@ -12,17 +12,34 @@ CronJob in the `omnigraph` namespace is what mints and retires them:
 ```
 secret-operations/witan/actor-tokens
     = secret-operations/witan/service-tokens
-    + one act-<sub> entry per enabled member of the witan-users Keycloak group
+    + one act-<sub> entry per enabled, non-service-account user of the realm
 ```
 
-- **Onboarding a user is one action:** add them to the `witan-users` group in
-  the `ol-platform-engineering` realm. Within an hour they have a token.
-- **Offboarding is the same action in reverse** — remove them from the group, or
+- **Onboarding a user is one action:** add them to the `ol-platform-engineering`
+  realm. Within an hour they have a token.
+- **Offboarding is the same action in reverse** — remove them from the realm, or
   disable the account. Either retires the token on the next run.
 - **Nobody ever sees these tokens.** A user authenticates to the witan MCP tier
   with an OIDC JWT; witan maps their `sub` to `act-<sub>`, looks the token up,
   and presents it to omnigraph-server on their behalf. There is nothing to
   distribute and nothing for a user to configure.
+
+**There is no `witan-users` Keycloak group, deliberately.** ADR-0004 D3 names
+one, but `witan-users` is a *Cedar* group in agent-kit's policy bundles
+(`mcp/servers/witan/policy/server.policy.yaml`), populated with the `act-<sub>`
+ids this job writes — the name collision is what made a Keycloak group of the
+same name look mandatory. The realm has `registration_allowed=False`, no
+identity-provider brokering and no federation, so it is already limited to
+exactly the intended audience. A group inside it would be a second gate whose
+failure mode is somebody joining the realm, nobody adding them to the group, and
+a 401 that reads like a provisioning lag. The trade accepted: **no way to revoke
+witan while leaving this realm's other applications (jupyterhub, superset, opik)
+intact** — realm access is witan access.
+
+Clients' own service accounts (`service-account-*`, e.g. `ol-opik-client` and
+this job's own `witan-token-sync`) are realm users too, and are skipped. The
+non-human actors that *do* get tokens come from the service map, which is
+declared in SOPS rather than discovered in Keycloak.
 
 Source: `src/ol_infrastructure/applications/omnigraph/token_sync.py` (deployment)
 and `.../omnigraph/scripts/sync_actor_tokens.py` (the reconciliation itself).
@@ -48,10 +65,10 @@ the service map are the same thing).
 The switch is `omnigraph:keycloak_url`. Setting it moves ownership of
 `actor-tokens` from Pulumi to the CronJob.
 
-**Prerequisite:** the `witan-token-sync` Keycloak client and the `witan-users`
-group must exist in the target realm. Both come from the keycloak substructure
-stack, so deploy `ol-infrastructure-substructure-keycloak` for that environment
-first and confirm `secret-operations/witan/token-sync-oidc` is populated:
+**Prerequisite:** the `witan-token-sync` Keycloak client must exist in the target
+realm. It comes from the keycloak substructure stack, so deploy
+`ol-infrastructure-substructure-keycloak` for that environment first and confirm
+`secret-operations/witan/token-sync-oidc` is populated:
 
 ```shell
 vault kv get secret-operations/witan/token-sync-oidc
@@ -148,7 +165,7 @@ kubectl -n omnigraph create job --from=cronjob/witan-token-sync token-sync-rotat
 ## Troubleshooting
 
 **A new user still gets "No omnigraph bearer token provisioned for actor …".**
-Check, in order: are they in `witan-users` and enabled; has the CronJob run
+Check, in order: are they in the realm and enabled; has the CronJob run
 since; did it write; has the VSO propagated. The error text comes from
 agent-kit's `ActorTokenResolver` and means the map on disk has no such key.
 
@@ -169,11 +186,11 @@ replace, so an empty service map would silently retire `svc-witan-ci` and break
 the CI indexer and witan's fallback client. Fix `service-tokens` (it comes from
 the SOPS file via `pulumi up`), then re-run.
 
-**The job fails with "Keycloak group 'witan-users' does not exist".** Also
-deliberate: a missing group and an empty group are indistinguishable in the
-member list but not in consequence, and the job will not retire every per-user
-token on the strength of a lookup that failed. Deploy the keycloak substructure
-stack for that environment.
+**The job fails with "returned no users at all".** Also deliberate: a failed
+lookup and a genuinely empty realm are indistinguishable in the response but not
+in consequence, and the job will not retire every per-user token on the strength
+of one. The usual cause is the `witan-token-sync` service account having lost its
+`view-users` realm-management role — re-deploy the keycloak substructure stack.
 
 **403 from Vault.** The paths in `token_sync_policy.hcl` must match
 `ACTOR_TOKENS_VAULT_PATH` / `SERVICE_TOKENS_VAULT_PATH` in `token_sync.py`

--- a/docs/witan-token-sync-runbook.md
+++ b/docs/witan-token-sync-runbook.md
@@ -1,0 +1,186 @@
+# witan token sync runbook
+
+How per-user omnigraph bearer tokens are provisioned from Keycloak, how to turn
+the sync on for an environment, and what to do when it misbehaves.
+
+## What it is
+
+Every witan user gets their own omnigraph bearer token, keyed by the actor id
+derived from their Keycloak `sub` (agent-kit ADR-0004 D3). The `witan-token-sync`
+CronJob in the `omnigraph` namespace is what mints and retires them:
+
+```
+secret-operations/witan/actor-tokens
+    = secret-operations/witan/service-tokens
+    + one act-<sub> entry per enabled member of the witan-users Keycloak group
+```
+
+- **Onboarding a user is one action:** add them to the `witan-users` group in
+  the `ol-platform-engineering` realm. Within an hour they have a token.
+- **Offboarding is the same action in reverse** — remove them from the group, or
+  disable the account. Either retires the token on the next run.
+- **Nobody ever sees these tokens.** A user authenticates to the witan MCP tier
+  with an OIDC JWT; witan maps their `sub` to `act-<sub>`, looks the token up,
+  and presents it to omnigraph-server on their behalf. There is nothing to
+  distribute and nothing for a user to configure.
+
+Source: `src/ol_infrastructure/applications/omnigraph/token_sync.py` (deployment)
+and `.../omnigraph/scripts/sync_actor_tokens.py` (the reconciliation itself).
+
+## Ownership of the two Vault paths
+
+| Path | Writer | Contents |
+| --- | --- | --- |
+| `secret-operations/witan/service-tokens` | the omnigraph Pulumi stack, from `src/bridge/secrets/omnigraph/secrets.<env>.yaml` | non-human actors (`svc-witan-ci`, later `svc-witan-admin`) |
+| `secret-operations/witan/actor-tokens` | the `witan-token-sync` CronJob | the merged map both omnigraph-server and the witan tier read |
+
+One writer per path, and they must stay that way. A second writer on
+`actor-tokens` reverts every per-user entry on each `pulumi up`, which 401s
+every user until the next hourly run and restarts omnigraph-server at both ends
+of that window.
+
+Until an environment has the sync turned on, the Pulumi stack writes
+`actor-tokens` itself (there are no per-user entries yet, so the merged map and
+the service map are the same thing).
+
+## Turning it on for an environment — two steps, in this order
+
+The switch is `omnigraph:keycloak_url`. Setting it moves ownership of
+`actor-tokens` from Pulumi to the CronJob.
+
+**Prerequisite:** the `witan-token-sync` Keycloak client and the `witan-users`
+group must exist in the target realm. Both come from the keycloak substructure
+stack, so deploy `ol-infrastructure-substructure-keycloak` for that environment
+first and confirm `secret-operations/witan/token-sync-oidc` is populated:
+
+```shell
+vault kv get secret-operations/witan/token-sync-oidc
+```
+
+**Step 1 — deploy the code with the switch still off.**
+
+```shell
+cd src/ol_infrastructure/applications/omnigraph
+pulumi up --stack <CI|QA|Production>
+```
+
+This adds `service-tokens`, and — the part that matters — records
+`retainOnDelete` against the existing `actor-tokens` Pulumi resource. Pulumi
+reads that flag from state at deletion time, and a resource absent from the
+program is never re-registered, so it has to be recorded *before* step 2.
+
+**Step 2 — set the switch and deploy again.**
+
+```shell
+pulumi config set omnigraph:keycloak_url https://sso-<env>.ol.mit.edu
+pulumi up --stack <CI|QA|Production>
+```
+
+Pulumi drops the `actor-tokens` resource from state without touching the Vault
+path, and the bootstrap Job takes over an already-populated one. Expect roughly
+10 new resources: a ServiceAccount, a Vault policy and Kubernetes auth role, the
+OIDC-credential VaultStaticSecret, the script ConfigMap, the bootstrap Job and
+the CronJob.
+
+**Doing both steps in one `pulumi up` deletes the Vault path.** The bootstrap Job
+rewrites it later in the same run, but nothing orders the deletion against the
+job, so there is a window in which omnigraph-server has no valid token for
+anybody.
+
+Verify afterwards:
+
+```shell
+kubectl -n omnigraph get cronjob witan-token-sync
+kubectl -n omnigraph logs job/$(kubectl -n omnigraph get jobs \
+  -l app.kubernetes.io/name=witan-token-sync -o name | head -1 | cut -d/ -f2)
+vault kv get -field=tokens_json secret-operations/witan/actor-tokens | jq 'keys'
+```
+
+## Other configuration
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `omnigraph:keycloak_url` | unset (sync off) | the switch |
+| `omnigraph:keycloak_realm` | `ol-platform-engineering` | |
+| `omnigraph:token_sync_schedule` | `17 * * * *` | see the cost note below before shortening |
+
+## Why hourly
+
+Every write to `actor-tokens` trips the VSO `rolloutRestartTarget` on that
+secret, and the data tier is `replicas=1` + `strategy=Recreate` — a hard ~10-30s
+graph outage, absorbed by connect-failure retry in the agent-kit client. So the
+schedule is not bounded by Keycloak's cost (two API calls) but by how often a
+restart is acceptable. Steady state is free: an unchanged membership produces a
+byte-identical map and the job writes nothing at all, so the restart cost is
+paid only on real membership churn.
+
+## Running it by hand
+
+```shell
+kubectl -n omnigraph create job --from=cronjob/witan-token-sync token-sync-manual
+kubectl -n omnigraph logs job/token-sync-manual -f
+```
+
+For a read-only check of what it *would* do, add `WITAN_TOKEN_SYNC_DRY_RUN=1`:
+
+```shell
+kubectl -n omnigraph create job --from=cronjob/witan-token-sync token-sync-dryrun \
+  --dry-run=client -o json \
+  | jq '.spec.template.spec.containers[0].env += [{"name":"WITAN_TOKEN_SYNC_DRY_RUN","value":"1"}]' \
+  | kubectl apply -f -
+```
+
+## Rotating one user's token
+
+Rotation is deliberately manual — the job carries an existing member's token
+over verbatim, because re-minting on a schedule would restart omnigraph-server
+every interval. To force a rotation, delete that actor's entry and let the next
+run re-mint it:
+
+```shell
+vault kv get -field=tokens_json secret-operations/witan/actor-tokens \
+  | jq 'del(."act-<sub>")' \
+  | jq -R '{tokens_json: .}' \
+  | vault kv put secret-operations/witan/actor-tokens -
+kubectl -n omnigraph create job --from=cronjob/witan-token-sync token-sync-rotate
+```
+
+## Troubleshooting
+
+**A new user still gets "No omnigraph bearer token provisioned for actor …".**
+Check, in order: are they in `witan-users` and enabled; has the CronJob run
+since; did it write; has the VSO propagated. The error text comes from
+agent-kit's `ActorTokenResolver` and means the map on disk has no such key.
+
+```shell
+kubectl -n omnigraph get jobs -l app.kubernetes.io/name=witan-token-sync
+kubectl -n omnigraph get secret actor-tokens -o jsonpath='{.data.tokens\.json}' \
+  | base64 -d | jq 'keys'
+```
+
+Note the two-sided lag: witan's resolver re-reads the file on any cache miss, so
+it picks up a new entry immediately, but omnigraph-server hashes the map once at
+boot and only sees it after the VSO-triggered restart. A user who gets past
+witan and then 401s from the graph is in that window.
+
+**The job fails with "Service token map … is empty or missing".** It refused to
+write, which is the intended behaviour — the merged map is a whole-secret
+replace, so an empty service map would silently retire `svc-witan-ci` and break
+the CI indexer and witan's fallback client. Fix `service-tokens` (it comes from
+the SOPS file via `pulumi up`), then re-run.
+
+**The job fails with "Keycloak group 'witan-users' does not exist".** Also
+deliberate: a missing group and an empty group are indistinguishable in the
+member list but not in consequence, and the job will not retire every per-user
+token on the strength of a lookup that failed. Deploy the keycloak substructure
+stack for that environment.
+
+**403 from Vault.** The paths in `token_sync_policy.hcl` must match
+`ACTOR_TOKENS_VAULT_PATH` / `SERVICE_TOKENS_VAULT_PATH` in `token_sync.py`
+verbatim. They are duplicated between an HCL file and a Python constant, and a
+mismatch shows up only at runtime.
+
+**Everyone's token changed at once.** Something re-minted rather than carried
+over — check whether `actor-tokens` was emptied or made unreadable before a run.
+The `wrote N actors to …` line appears in the job log only when the map actually
+changed; if it appears every hour, that is the symptom.

--- a/src/ol_infrastructure/applications/omnigraph/__main__.py
+++ b/src/ol_infrastructure/applications/omnigraph/__main__.py
@@ -21,8 +21,8 @@ the same artifact witan resolves per-user tokens from — synced here from Vault
 into the ``actor-tokens`` Secret (agent-kit ADR-0004 D3). See
 ``docs/adr/0009-deploy-witan-as-shared-multi-tenant-mcp-service.md``.
 
-Keycloak ``witan-users`` membership is turned into per-user entries in that map
-by the CronJob in ``token_sync.py``, in environments that set
+Keycloak realm membership is turned into per-user entries in that map by the
+CronJob in ``token_sync.py``, in environments that set
 ``omnigraph:keycloak_url``. Enabling it moves ownership of the actor-tokens
 Vault path from this program to that job — see the writer split below.
 
@@ -100,7 +100,7 @@ omnigraph_config = Config("omnigraph")
 # silently minting a graph nobody provisioned or backs up.
 MANAGED_REPOS: list[str] = omnigraph_config.get_object("managed_repos") or []
 
-# Keycloak witan-users -> actor-token sync. Set `omnigraph:keycloak_url` for an
+# Keycloak realm -> actor-token sync. Set `omnigraph:keycloak_url` for an
 # environment to turn it on; leaving it unset keeps that environment on the
 # SOPS-only behaviour, which is the right default until its `witan-token-sync`
 # OIDC client exists (substructure/keycloak/ol_platform_engineering.py). The URL
@@ -236,8 +236,8 @@ if _actor_tokens_map:
 #                     to preserve, so the merged map and the service map are the
 #                     same thing.
 #   token sync ON  -> the CronJob in token_sync.py writes it, as
-#                     service-tokens plus one act-<sub> entry per witan-users
-#                     member, and this program stops writing it entirely.
+#                     service-tokens plus one act-<sub> entry per enabled
+#                     human realm user, and this program stops writing it.
 #
 # The two must never overlap. A Pulumi write alongside the job's would revert
 # every per-user entry on each `pulumi up` — every user 401ing until the next
@@ -305,7 +305,7 @@ omnigraph_auth_binding = OLEKSAuthBinding(
 )
 
 ##############################################
-#   Keycloak witan-users -> actor tokens      #
+#   Keycloak realm -> actor tokens             #
 ##############################################
 token_sync = None
 if _TOKEN_SYNC_ENABLED:

--- a/src/ol_infrastructure/applications/omnigraph/__main__.py
+++ b/src/ol_infrastructure/applications/omnigraph/__main__.py
@@ -21,6 +21,11 @@ the same artifact witan resolves per-user tokens from — synced here from Vault
 into the ``actor-tokens`` Secret (agent-kit ADR-0004 D3). See
 ``docs/adr/0009-deploy-witan-as-shared-multi-tenant-mcp-service.md``.
 
+Keycloak ``witan-users`` membership is turned into per-user entries in that map
+by the CronJob in ``token_sync.py``, in environments that set
+``omnigraph:keycloak_url``. Enabling it moves ownership of the actor-tokens
+Vault path from this program to that job — see the writer split below.
+
 Follow-up work this stack does NOT cover (tracked separately):
     - **Container image.** The ``omnigraph``/``pulumi-omnigraph`` Concourse
       pipeline builds the image once, owns the ECR repository itself
@@ -29,18 +34,6 @@ Follow-up work this stack does NOT cover (tracked separately):
       docstring. ``schema.pg`` (agent-kit repo,
       ``mcp/servers/witan/schema/schema.pg``) must be baked into the image at
       build time — this Pulumi program has no access to agent-kit's tree.
-    - **Keycloak witan-users token sync.** This stack writes the Vault
-      ``secret-operations/witan/actor-tokens`` source (below) from a
-      hand-authored SOPS file, and provisions the ``actor-tokens`` Secret
-      destination, but not the job that keeps per-user entries current as
-      Keycloak group membership changes — today the SOPS file only ever
-      carries the one ``svc-witan-ci`` entry. What this stack DOES now cover
-      is the other half of "add a user": the ``actor-tokens`` secret carries
-      ``restart_targets`` so the Vault Secrets Operator bounces
-      omnigraph-server whenever the token map changes (it only reads the map
-      at boot). Whatever eventually writes that Vault path — the sync job, a
-      break-glass ``vault kv put``, or this stack — gets the restart for free
-      and does not need to orchestrate one itself.
 """
 
 import json
@@ -57,6 +50,12 @@ from ol_infrastructure.applications.omnigraph.data_tier import (
     OMNIGRAPH_SERVER_SERVICE_NAME,
     create_data_tier,
     omnigraph_server_addr,
+)
+from ol_infrastructure.applications.omnigraph.token_sync import (
+    ACTOR_TOKENS_VAULT_PATH,
+    DEFAULT_SYNC_SCHEDULE,
+    SERVICE_TOKENS_VAULT_PATH,
+    create_token_sync,
 )
 from ol_infrastructure.components.applications.eks import (
     OLEKSAuthBinding,
@@ -100,6 +99,19 @@ omnigraph_config = Config("omnigraph")
 # build_cluster_graphs). A repo that is not listed fails to resolve rather than
 # silently minting a graph nobody provisioned or backs up.
 MANAGED_REPOS: list[str] = omnigraph_config.get_object("managed_repos") or []
+
+# Keycloak witan-users -> actor-token sync. Set `omnigraph:keycloak_url` for an
+# environment to turn it on; leaving it unset keeps that environment on the
+# SOPS-only behaviour, which is the right default until its `witan-token-sync`
+# OIDC client exists (substructure/keycloak/ol_platform_engineering.py). The URL
+# is the switch rather than a separate boolean because there is nothing this can
+# do without it, and one setting cannot disagree with itself.
+KEYCLOAK_URL = omnigraph_config.get("keycloak_url")
+KEYCLOAK_REALM = omnigraph_config.get("keycloak_realm") or "ol-platform-engineering"
+TOKEN_SYNC_SCHEDULE = (
+    omnigraph_config.get("token_sync_schedule") or DEFAULT_SYNC_SCHEDULE
+)
+_TOKEN_SYNC_ENABLED = bool(KEYCLOAK_URL)
 
 cluster_stack = make_stack_reference(projects.EKS, f"operations.{stack_info.name}")
 setup_k8s_provider(kubeconfig=cluster_stack.require_output("kube_config"))
@@ -200,14 +212,61 @@ else:
     _actor_tokens_map = {}
     _witan_ci_token = None
 
-actor_tokens_vault_secret = None
+# The non-human actors, on their own Vault path. This is always written, in
+# every environment, and is the *input* the token-sync job merges Keycloak's
+# per-user entries into — see WHO WRITES actor-tokens below.
+service_tokens_vault_secret = None
 if _actor_tokens_map:
-    actor_tokens_vault_secret = vault.generic.Secret(
-        f"omnigraph-actor-tokens-vault-secret-{stack_info.env_suffix}",
-        path="secret-operations/witan/actor-tokens",
+    service_tokens_vault_secret = vault.generic.Secret(
+        f"omnigraph-service-tokens-vault-secret-{stack_info.env_suffix}",
+        path=SERVICE_TOKENS_VAULT_PATH,
         data_json=Output.secret(
             json.dumps({ACTOR_TOKENS_VAULT_KEY: json.dumps(_actor_tokens_map)})
         ),
+    )
+
+##############################################
+#   WHO WRITES actor-tokens                   #
+##############################################
+# Exactly one writer, but which one depends on whether this environment has a
+# Keycloak client provisioned for the sync job:
+#
+#   token sync OFF -> this program writes secret-operations/witan/actor-tokens
+#                     straight from the SOPS map. There are no per-user entries
+#                     to preserve, so the merged map and the service map are the
+#                     same thing.
+#   token sync ON  -> the CronJob in token_sync.py writes it, as
+#                     service-tokens plus one act-<sub> entry per witan-users
+#                     member, and this program stops writing it entirely.
+#
+# The two must never overlap. A Pulumi write alongside the job's would revert
+# every per-user entry on each `pulumi up` — every user 401ing until the next
+# hourly run, plus an omnigraph-server restart at each end of that window.
+#
+# retain_on_delete is what makes the OFF -> ON transition safe. Removing this
+# resource from the program would otherwise DELETE the Vault path, and the
+# bootstrap Job that rewrites it is not ordered against that deletion; the
+# window between them is one where omnigraph-server has no valid token for
+# anybody. Retained, Pulumi drops it from state and leaves the content alone,
+# and the job's first run takes over an already-populated path.
+#
+# WHICH MAKES THE ROLLOUT TWO STEPS, NOT ONE. Pulumi reads retainOnDelete from
+# the STATE at deletion time, and a resource absent from the program is never
+# re-registered — so the flag has to already be recorded before the environment
+# is switched on. Deploy this change with the switch still off (one `pulumi up`
+# that records the flag against an otherwise unchanged resource), and only then
+# set `omnigraph:keycloak_url` and deploy again. Doing both in one `pulumi up`
+# deletes the Vault path and leaves every user 401ing until the bootstrap Job
+# lands. See docs/witan-token-sync-runbook.md.
+actor_tokens_vault_secret = None
+if _actor_tokens_map and not _TOKEN_SYNC_ENABLED:
+    actor_tokens_vault_secret = vault.generic.Secret(
+        f"omnigraph-actor-tokens-vault-secret-{stack_info.env_suffix}",
+        path=ACTOR_TOKENS_VAULT_PATH,
+        data_json=Output.secret(
+            json.dumps({ACTOR_TOKENS_VAULT_KEY: json.dumps(_actor_tokens_map)})
+        ),
+        opts=ResourceOptions(retain_on_delete=True),
     )
 
 if _witan_ci_token:
@@ -244,6 +303,31 @@ omnigraph_auth_binding = OLEKSAuthBinding(
         k8s_labels=k8s_labels,
     )
 )
+
+##############################################
+#   Keycloak witan-users -> actor tokens      #
+##############################################
+token_sync = None
+if _TOKEN_SYNC_ENABLED:
+    token_sync = create_token_sync(
+        stack_info=stack_info,
+        namespace=NAMESPACE,
+        k8s_global_labels=k8s_global_labels,
+        # Non-None by _TOKEN_SYNC_ENABLED, which is exactly `bool(KEYCLOAK_URL)`.
+        keycloak_url=KEYCLOAK_URL or "",
+        keycloak_realm=KEYCLOAK_REALM,
+        vault_address=Config("vault").get("address")
+        or f"https://vault-{stack_info.env_suffix}.odl.mit.edu",
+        vault_auth_endpoint=cluster_stack.require_output("vault_auth_endpoint"),
+        vault_auth_name=omnigraph_auth_binding.vault_k8s_resources.auth_name,
+        schedule=TOKEN_SYNC_SCHEDULE,
+        # The job reads the service map on every run and refuses to write an
+        # actor map without it, so the Vault write has to land first.
+        depends_on=[
+            omnigraph_auth_binding.vault_k8s_resources,
+            *([service_tokens_vault_secret] if service_tokens_vault_secret else []),
+        ],
+    )
 
 actor_tokens_secret = OLVaultK8SSecret(
     f"omnigraph-actor-tokens-secret-{stack_info.env_suffix}",
@@ -306,9 +390,14 @@ actor_tokens_secret = OLVaultK8SSecret(
     ),
     opts=ResourceOptions(
         delete_before_replace=True,
+        # Whichever of the two writers this environment uses has to have
+        # written the Vault path before the VSO is asked to render it —
+        # otherwise the Secret comes up empty and the Deployment that mounts it
+        # sits in ContainerCreating. Exactly one of these is ever non-None.
         depends_on=[
             omnigraph_auth_binding.vault_k8s_resources,
             *([actor_tokens_vault_secret] if actor_tokens_vault_secret else []),
+            *([token_sync.bootstrap_job] if token_sync else []),
         ],
     ),
 )

--- a/src/ol_infrastructure/applications/omnigraph/omnigraph_policy.hcl
+++ b/src/ol_infrastructure/applications/omnigraph/omnigraph_policy.hcl
@@ -11,7 +11,7 @@
 # {actor_id: token} JSON map — the artifact omnigraph-server boots its
 # bearer-token auth from (OMNIGRAPH_SERVER_BEARER_TOKENS_FILE). The same
 # Vault source witan resolves per-user tokens from (WITAN_ACTOR_TOKENS_FILE)
-# in its own namespace. Read-only, and read-only it stays: the witan-users sync
+# in its own namespace. Read-only, and read-only it stays: the realm token-sync
 # job that writes this path authenticates as its own Vault role with its own
 # policy (token_sync_policy.hcl), precisely so the write capability does not
 # land on the identity every VSO sync in this namespace uses.

--- a/src/ol_infrastructure/applications/omnigraph/omnigraph_policy.hcl
+++ b/src/ol_infrastructure/applications/omnigraph/omnigraph_policy.hcl
@@ -11,10 +11,18 @@
 # {actor_id: token} JSON map — the artifact omnigraph-server boots its
 # bearer-token auth from (OMNIGRAPH_SERVER_BEARER_TOKENS_FILE). The same
 # Vault source witan resolves per-user tokens from (WITAN_ACTOR_TOKENS_FILE)
-# in its own namespace. Seeded with at least the svc-witan-ci entry; per-user
-# entries are written by the Keycloak witan-users sync (follow-up, not yet
-# built — see applications/omnigraph/__main__.py).
+# in its own namespace. Read-only, and read-only it stays: the witan-users sync
+# job that writes this path authenticates as its own Vault role with its own
+# policy (token_sync_policy.hcl), precisely so the write capability does not
+# land on the identity every VSO sync in this namespace uses.
 path "secret-operations/witan/actor-tokens" {
+  capabilities = ["read"]
+}
+
+# OIDC credentials for the `witan-token-sync` Keycloak service account, written
+# by the keycloak substructure stack and rendered into the token-sync job's
+# environment by the VSO. Read by the operator, not by omnigraph-server.
+path "secret-operations/witan/token-sync-oidc" {
   capabilities = ["read"]
 }
 

--- a/src/ol_infrastructure/applications/omnigraph/scripts/__init__.py
+++ b/src/ol_infrastructure/applications/omnigraph/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Scripts run as in-cluster jobs by the omnigraph stack, shipped as ConfigMaps."""

--- a/src/ol_infrastructure/applications/omnigraph/scripts/sync_actor_tokens.py
+++ b/src/ol_infrastructure/applications/omnigraph/scripts/sync_actor_tokens.py
@@ -146,7 +146,19 @@ def _request(
         raise SyncError(msg) from exc
     if not body:
         return None
-    return json.loads(body)
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError as exc:
+        # A 2xx whose body is not JSON means we are talking to something other
+        # than the API we think we are — an HTML error page from a proxy, or a
+        # misrouted URL. Left uncaught this is the one failure in the script
+        # that escapes SyncError and reaches the operator as a bare traceback,
+        # which names json/decoder.py rather than the request that was wrong.
+        msg = (
+            f"{method} {url} returned HTTP 200 with a non-JSON body "
+            f"({body[:200]!r}): {exc}"
+        )
+        raise SyncError(msg) from exc
 
 
 ###############################################################################
@@ -172,9 +184,16 @@ def vault_login(vault_addr: str, auth_mount: str, role: str, jwt: str) -> str:
 def read_token_map(vault_addr: str, vault_token: str, path: str) -> dict[str, str]:
     """Read a ``{actor_id: token}`` map out of a kv-v1 Vault secret.
 
-    A missing secret is an empty map — the bootstrap case. A secret that exists
-    but whose payload is unparseable is not: that is corruption, and continuing
-    would rewrite the path with whatever we could still make sense of.
+    An ABSENT secret is an empty map — the bootstrap case, where this job's
+    first run is what creates the path. A secret that EXISTS but is not what we
+    write is not: that is corruption, and continuing would rewrite the path
+    with whatever we could still make sense of.
+
+    The distinction matters most for actor-tokens, whose only writer is this
+    job. Treating a present-but-malformed payload as empty would carry no
+    existing token over, re-mint one for every user, and — because that write
+    trips the VSO restart target — bounce omnigraph-server, invalidating every
+    live session to recover from what may be a transient read problem.
     """
     response = _request(
         f"{vault_addr}/v1/{path}",
@@ -186,10 +205,13 @@ def read_token_map(vault_addr: str, vault_token: str, path: str) -> dict[str, st
         return {}
     raw = (response.get("data") or {}).get(TOKENS_VAULT_KEY)
     if raw in (None, ""):
-        LOG.info(
-            "vault path %s has no %s key; treating as empty", path, TOKENS_VAULT_KEY
+        msg = (
+            f"Vault path {path} exists but has no non-empty {TOKENS_VAULT_KEY} "
+            "key. Every writer of this path sets it, so this is a malformed or "
+            "partially-written secret rather than an empty one — refusing to "
+            "treat it as no tokens and re-mint the whole map."
         )
-        return {}
+        raise SyncError(msg)
     try:
         parsed = json.loads(raw)
     except json.JSONDecodeError as exc:

--- a/src/ol_infrastructure/applications/omnigraph/scripts/sync_actor_tokens.py
+++ b/src/ol_infrastructure/applications/omnigraph/scripts/sync_actor_tokens.py
@@ -1,4 +1,4 @@
-"""Reconcile the omnigraph actor-token map against Keycloak group membership.
+"""Reconcile the omnigraph actor-token map against Keycloak realm membership.
 
 agent-kit ADR-0004 D3 gives every witan user their own omnigraph bearer token,
 keyed by the actor id derived from their Keycloak ``sub``. This script is the
@@ -9,7 +9,7 @@ tier (``WITAN_ACTOR_TOKENS_FILE``) resolve tokens from.
 
 WHAT IT COMPUTES
 
-    actor-tokens  =  service-tokens  +  one act-<sub> entry per witan-users member
+    actor-tokens  =  service-tokens  +  one act-<sub> entry per human realm user
 
 ``service-tokens`` is the Pulumi/SOPS-owned map of non-human actors
 (``svc-witan-ci``, and later ``svc-witan-admin``). Splitting it out of
@@ -19,8 +19,17 @@ per-user entry, and every user 401s until the next run of this job. So Pulumi
 owns the *input*, this job owns the *derived output*, and each path has exactly
 one writer. See ``token_sync.py`` for the deployment side of that split.
 
+WHO COUNTS AS A USER
+
+Every enabled, non-service-account user of the realm. The realm IS the
+audience: ``ol-platform-engineering`` has ``registration_allowed=False``, no
+identity-provider brokering and no federation, so its membership is already
+exactly the people who should have witan. See :func:`realm_users` for why a
+dedicated ``witan-users`` Keycloak group was removed rather than added, and
+:func:`is_service_account` for the one class of realm user that is skipped.
+
 The output is a pure function of its two inputs, which is the property worth
-protecting: a token already provisioned for a still-present member is carried
+protecting: a token already provisioned for a still-present user is carried
 over verbatim rather than re-minted, so a steady-state run is a no-op and
 writes nothing. That matters more than it looks — the actor-tokens Vault secret
 carries a VSO ``rolloutRestartTarget``, so *every* write to it bounces
@@ -79,13 +88,13 @@ TOKEN_ENTROPY_BYTES = 32
 # the VSO template that renders it into the mounted file.
 TOKENS_VAULT_KEY = "tokens_json"  # pragma: allowlist secret
 
-# Keycloak caps a members page well below this in some versions; it returns
-# fewer than asked rather than erroring, and the loop below keys off that.
+# Keycloak caps a user page well below this in some versions; it returns fewer
+# than asked rather than erroring, and the paging loop keys off that.
 MEMBERS_PAGE_SIZE = 100
 
 # Guard against a paging bug turning into an unbounded loop against Keycloak.
-# 200 pages at the size above is 20k members — orders of magnitude above any
-# plausible witan-users group.
+# 200 pages at the size above is 20k users — orders of magnitude above any
+# plausible size for a hand-managed staff realm.
 MAX_MEMBER_PAGES = 200
 
 HTTP_TIMEOUT_SECONDS = 30
@@ -242,58 +251,61 @@ def keycloak_token(
     return token
 
 
-def find_group_id(base_url: str, realm: str, token: str, group_name: str) -> str:
-    """Resolve a top-level group name to its uuid.
+def realm_users(base_url: str, realm: str, token: str) -> list[dict[str, Any]]:
+    """Page through every user in the realm.
 
-    A missing group is fatal rather than "zero members". The two are
-    indistinguishable in the member list but not in consequence: an empty group
-    legitimately retires every per-user token, whereas a typo'd or not-yet-created
-    group would do the same thing and call it success.
+    The realm IS the audience. ``ol-platform-engineering`` has
+    ``registration_allowed=False``, no identity-provider brokering and no
+    federation — membership is hand-managed and already limited to the people
+    who should have witan. A dedicated ``witan-users`` group inside it would be
+    a second gate on an already-gated population, and its failure mode is the
+    bad one: somebody is added to the realm, nobody adds them to the group, and
+    they get a 401 that reads like a provisioning lag.
+
+    (``witan-users`` still exists as a *Cedar* group in agent-kit's policy
+    bundles, populated with the ``act-<sub>`` ids this job writes. Only its
+    source changed — from a Keycloak group of the same name to the realm's
+    human users. The name collision is what made the group look mandatory.)
     """
-    query = urllib.parse.urlencode({"search": group_name, "exact": "true"})
-    groups = (
-        _request(
-            f"{base_url}/admin/realms/{realm}/groups?{query}",
-            headers={"Authorization": f"Bearer {token}"},
-        )
-        or []
-    )
-    for group in groups:
-        if group.get("name") == group_name:
-            return group["id"]
-    msg = (
-        f"Keycloak group {group_name!r} does not exist in realm {realm}. "
-        "It is provisioned by the keycloak substructure stack "
-        "(substructure/keycloak/ol_platform_engineering.py); this job will not "
-        "retire every per-user token on the strength of a lookup that failed."
-    )
-    raise SyncError(msg)
-
-
-def group_members(
-    base_url: str, realm: str, token: str, group_id: str
-) -> list[dict[str, Any]]:
-    """Page through the group's direct members."""
-    members: list[dict[str, Any]] = []
+    users: list[dict[str, Any]] = []
     for page in range(MAX_MEMBER_PAGES):
         query = urllib.parse.urlencode(
             {"first": page * MEMBERS_PAGE_SIZE, "max": MEMBERS_PAGE_SIZE}
         )
         batch = (
             _request(
-                f"{base_url}/admin/realms/{realm}/groups/{group_id}/members?{query}",
+                f"{base_url}/admin/realms/{realm}/users?{query}",
                 headers={"Authorization": f"Bearer {token}"},
             )
             or []
         )
-        members.extend(batch)
+        users.extend(batch)
         if len(batch) < MEMBERS_PAGE_SIZE:
-            return members
+            return users
     msg = (
-        f"Group {group_id} still paging after {MAX_MEMBER_PAGES} pages; "
+        f"Realm {realm} still paging after {MAX_MEMBER_PAGES} pages; "
         "refusing to continue"
     )
     raise SyncError(msg)
+
+
+def is_service_account(user: dict[str, Any]) -> bool:
+    """Whether this realm user is a client's service account rather than a human.
+
+    Keycloak stores a confidential client's service account as an ordinary
+    realm user, so enumerating the realm returns them alongside people — this
+    realm already has one for ``ol-opik-client`` and gains another for this
+    job's own ``witan-token-sync`` client. Minting a human's interactive
+    read/write token for them would hand every such client the Cedar rights of
+    a person.
+
+    ``serviceAccountClientId`` is where Keycloak records the owning client and
+    is the authoritative signal; the username prefix is Keycloak's own naming
+    convention for the same users and costs nothing to also check.
+    """
+    return bool(user.get("serviceAccountClientId")) or str(
+        user.get("username", "")
+    ).startswith("service-account-")
 
 
 ###############################################################################
@@ -304,23 +316,33 @@ def group_members(
 def reconcile(
     service_tokens: dict[str, str],
     current: dict[str, str],
-    members: list[dict[str, Any]],
+    users: list[dict[str, Any]],
 ) -> dict[str, str]:
     """Compute the desired actor-token map.
 
-    Disabled Keycloak users are treated as non-members: leaving a token live
-    for a disabled account would make "disable in Keycloak" a no-op for graph
-    access, which is the one thing an operator disabling an account expects it
-    not to be.
+    Disabled Keycloak users are skipped: leaving a token live for a disabled
+    account would make "disable in Keycloak" a no-op for graph access, which is
+    the one thing an operator disabling an account expects it not to be.
+
+    Service-account users are skipped too — see :func:`is_service_account`. The
+    non-human actors that DO get tokens come from the service map, which is
+    declared in SOPS rather than discovered in Keycloak.
     """
     desired = dict(service_tokens)
-    for member in members:
-        sub = member.get("id")
+    for user in users:
+        sub = user.get("id")
         if not sub:
-            msg = f"Keycloak returned a group member with no id: {member!r}"
+            msg = f"Keycloak returned a realm user with no id: {user!r}"
             raise SyncError(msg)
-        if not member.get("enabled", True):
-            LOG.info("skipping disabled user %s", member.get("username", sub))
+        if is_service_account(user):
+            LOG.info(
+                "skipping service account %s (client %s)",
+                user.get("username", sub),
+                user.get("serviceAccountClientId", "?"),
+            )
+            continue
+        if not user.get("enabled", True):
+            LOG.info("skipping disabled user %s", user.get("username", sub))
             continue
         actor_id = derive_actor_id(sub)
         if actor_id in service_tokens:
@@ -328,7 +350,7 @@ def reconcile(
             # the collision would hand a human the service identity's token, so
             # it stops the run rather than resolving in either direction.
             msg = (
-                f"Keycloak user {member.get('username', sub)} derives actor id "
+                f"Keycloak user {user.get('username', sub)} derives actor id "
                 f"{actor_id}, which collides with a service actor. Refusing to "
                 "overwrite either."
             )
@@ -376,7 +398,6 @@ def main() -> int:
     keycloak_realm = _require_env("KEYCLOAK_REALM")
     keycloak_client_id = _require_env("KEYCLOAK_CLIENT_ID")
     keycloak_client_secret = _require_env("KEYCLOAK_CLIENT_SECRET")
-    group_name = _require_env("WITAN_USERS_GROUP")
 
     try:
         with open(sa_token_path, encoding="utf-8") as handle:  # noqa: PTH123
@@ -415,11 +436,23 @@ def main() -> int:
     access_token = keycloak_token(
         keycloak_url, keycloak_realm, keycloak_client_id, keycloak_client_secret
     )
-    group_id = find_group_id(keycloak_url, keycloak_realm, access_token, group_name)
-    members = group_members(keycloak_url, keycloak_realm, access_token, group_id)
-    LOG.info("group %s (%s) has %d member(s)", group_name, group_id, len(members))
+    users = realm_users(keycloak_url, keycloak_realm, access_token)
+    # A realm with no users at all is a failed lookup wearing the costume of a
+    # legitimate result — a revoked role, a renamed realm, a silently-empty
+    # page. Left unguarded it would retire every per-user token and report
+    # success, which is exactly what the old group-does-not-exist check was
+    # protecting against before the realm replaced the group as the audience.
+    if not users:
+        msg = (
+            f"Keycloak realm {keycloak_realm} returned no users at all. That is "
+            "a lookup failure, not an empty realm — this job will not retire "
+            "every per-user token on the strength of it. Check that the "
+            "witan-token-sync service account still holds the view-users role."
+        )
+        raise SyncError(msg)
+    LOG.info("realm %s has %d user(s) before filtering", keycloak_realm, len(users))
 
-    desired = reconcile(service_tokens, current, members)
+    desired = reconcile(service_tokens, current, users)
 
     added = sorted(set(desired) - set(current))
     removed = sorted(set(current) - set(desired))

--- a/src/ol_infrastructure/applications/omnigraph/scripts/sync_actor_tokens.py
+++ b/src/ol_infrastructure/applications/omnigraph/scripts/sync_actor_tokens.py
@@ -1,0 +1,470 @@
+"""Reconcile the omnigraph actor-token map against Keycloak group membership.
+
+agent-kit ADR-0004 D3 gives every witan user their own omnigraph bearer token,
+keyed by the actor id derived from their Keycloak ``sub``. This script is the
+process that mints and retires those tokens. It is the *sole writer* of
+``secret-operations/witan/actor-tokens``, the one Vault artifact both
+omnigraph-server (``OMNIGRAPH_SERVER_BEARER_TOKENS_FILE``) and the witan MCP
+tier (``WITAN_ACTOR_TOKENS_FILE``) resolve tokens from.
+
+WHAT IT COMPUTES
+
+    actor-tokens  =  service-tokens  +  one act-<sub> entry per witan-users member
+
+``service-tokens`` is the Pulumi/SOPS-owned map of non-human actors
+(``svc-witan-ci``, and later ``svc-witan-admin``). Splitting it out of
+``actor-tokens`` is what lets this script own the merged output outright: two
+writers on one Vault path means every ``pulumi up`` silently reverts every
+per-user entry, and every user 401s until the next run of this job. So Pulumi
+owns the *input*, this job owns the *derived output*, and each path has exactly
+one writer. See ``token_sync.py`` for the deployment side of that split.
+
+The output is a pure function of its two inputs, which is the property worth
+protecting: a token already provisioned for a still-present member is carried
+over verbatim rather than re-minted, so a steady-state run is a no-op and
+writes nothing. That matters more than it looks — the actor-tokens Vault secret
+carries a VSO ``rolloutRestartTarget``, so *every* write to it bounces
+omnigraph-server, and the data tier is replicas=1/Recreate (a hard ~10-30s
+graph outage, absorbed by client-side connect retry). Writing only on a real
+change is what keeps that cost proportional to actual membership churn.
+
+Users are never shown these tokens and never present them. A user
+authenticates to the witan tier with an OIDC JWT; witan maps their ``sub`` to
+``act-<sub>``, looks the token up in this map, and presents it to
+omnigraph-server on their behalf. The token is an internal capability, so it is
+opaque random bytes with no format requirements and nothing to distribute.
+
+DELIBERATELY STDLIB-ONLY
+
+Both the Keycloak Admin API and the Vault HTTP API are plain JSON over HTTPS,
+so this needs no third-party client and therefore no image to build, publish,
+or keep patched — it runs on a stock ``python:3.12-slim``. Keep it that way;
+an ``import`` of anything outside the standard library turns a ConfigMap into a
+release pipeline.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import secrets
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+LOG = logging.getLogger("sync-actor-tokens")
+
+# Mirrors witan_core.identity.derive_actor_id (agent-kit
+# packages/witan-core/witan_core/identity.py). These two derivations MUST agree:
+# witan resolves a token by the id it derives from a validated JWT, and this
+# script files the token under the id it derives here. A divergence has no
+# symptom until a user whose sub happens to contain the differing characters
+# gets a 401 that looks like a provisioning lag.
+ACTOR_PREFIX = "act-"
+_SANITIZE_RE = re.compile(r"[^a-z0-9-]+")
+
+# Length of a freshly minted token, in bytes of entropy before base64url
+# encoding. These are bearer tokens for a service with no rate limiting in
+# front of it, so they are sized to be brute-force-irrelevant rather than
+# typeable — nobody ever reads one.
+TOKEN_ENTROPY_BYTES = 32
+
+# The key the {actor_id: token} map is stored under inside each Vault secret,
+# as a JSON *string* (so the secret has one scalar field, not one field per
+# actor). Must match ACTOR_TOKENS_VAULT_KEY in the omnigraph Pulumi stack and
+# the VSO template that renders it into the mounted file.
+TOKENS_VAULT_KEY = "tokens_json"  # pragma: allowlist secret
+
+# Keycloak caps a members page well below this in some versions; it returns
+# fewer than asked rather than erroring, and the loop below keys off that.
+MEMBERS_PAGE_SIZE = 100
+
+# Guard against a paging bug turning into an unbounded loop against Keycloak.
+# 200 pages at the size above is 20k members — orders of magnitude above any
+# plausible witan-users group.
+MAX_MEMBER_PAGES = 200
+
+HTTP_TIMEOUT_SECONDS = 30
+
+
+class SyncError(Exception):
+    """A condition that must stop the run before anything is written."""
+
+
+def derive_actor_id(sub: str) -> str:
+    """Map a Keycloak ``sub`` (== the user's uuid) to an omnigraph actor id."""
+    slug = _SANITIZE_RE.sub("-", sub.strip().lower()).strip("-")
+    if not slug:
+        msg = f"Cannot derive an actor id from sub={sub!r}"
+        raise SyncError(msg)
+    return f"{ACTOR_PREFIX}{slug}"
+
+
+def _request(
+    url: str,
+    *,
+    method: str = "GET",
+    headers: dict[str, str] | None = None,
+    data: bytes | None = None,
+    allow_404: bool = False,
+) -> Any:
+    """Issue one JSON HTTP request, returning the decoded body.
+
+    ``allow_404`` returns ``None`` for a missing resource instead of raising —
+    the one expected not-found is the actor-tokens path on a brand-new
+    environment, where this job's first run is what creates it.
+    """
+    request = urllib.request.Request(  # noqa: S310 - https URLs from config
+        url, method=method, data=data, headers=headers or {}
+    )
+    try:
+        with urllib.request.urlopen(  # noqa: S310 - https URLs from config
+            request, timeout=HTTP_TIMEOUT_SECONDS
+        ) as response:
+            body = response.read()
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404 and allow_404:  # noqa: PLR2004
+            return None
+        detail = exc.read().decode("utf-8", "replace")[:500]
+        msg = f"{method} {url} failed: HTTP {exc.code} {detail}"
+        raise SyncError(msg) from exc
+    except urllib.error.URLError as exc:
+        msg = f"{method} {url} failed: {exc.reason}"
+        raise SyncError(msg) from exc
+    if not body:
+        return None
+    return json.loads(body)
+
+
+###############################################################################
+#   Vault                                                                      #
+###############################################################################
+
+
+def vault_login(vault_addr: str, auth_mount: str, role: str, jwt: str) -> str:
+    """Exchange this pod's ServiceAccount JWT for a Vault token."""
+    response = _request(
+        f"{vault_addr}/v1/auth/{auth_mount}/login",
+        method="POST",
+        headers={"Content-Type": "application/json"},
+        data=json.dumps({"role": role, "jwt": jwt}).encode(),
+    )
+    token = (response or {}).get("auth", {}).get("client_token")
+    if not token:
+        msg = f"Vault login at auth/{auth_mount} returned no client_token"
+        raise SyncError(msg)
+    return token
+
+
+def read_token_map(vault_addr: str, vault_token: str, path: str) -> dict[str, str]:
+    """Read a ``{actor_id: token}`` map out of a kv-v1 Vault secret.
+
+    A missing secret is an empty map — the bootstrap case. A secret that exists
+    but whose payload is unparseable is not: that is corruption, and continuing
+    would rewrite the path with whatever we could still make sense of.
+    """
+    response = _request(
+        f"{vault_addr}/v1/{path}",
+        headers={"X-Vault-Token": vault_token},
+        allow_404=True,
+    )
+    if response is None:
+        LOG.info("vault path %s does not exist yet; treating as empty", path)
+        return {}
+    raw = (response.get("data") or {}).get(TOKENS_VAULT_KEY)
+    if raw in (None, ""):
+        LOG.info(
+            "vault path %s has no %s key; treating as empty", path, TOKENS_VAULT_KEY
+        )
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        msg = f"Vault path {path} key {TOKENS_VAULT_KEY} is not valid JSON: {exc}"
+        raise SyncError(msg) from exc
+    if not isinstance(parsed, dict) or not all(
+        isinstance(k, str) and isinstance(v, str) for k, v in parsed.items()
+    ):
+        msg = f"Vault path {path} key {TOKENS_VAULT_KEY} is not a {{str: str}} object"
+        raise SyncError(msg)
+    return parsed
+
+
+def write_token_map(
+    vault_addr: str, vault_token: str, path: str, tokens: dict[str, str]
+) -> None:
+    """Replace the kv-v1 secret at ``path`` with ``tokens``.
+
+    kv-v1 writes replace the whole secret rather than patching it, which is
+    exactly the semantics wanted here: the map is a computed artifact, so the
+    write is a declaration of the complete desired state.
+    """
+    _request(
+        f"{vault_addr}/v1/{path}",
+        method="POST",
+        headers={"X-Vault-Token": vault_token, "Content-Type": "application/json"},
+        data=json.dumps(
+            {TOKENS_VAULT_KEY: json.dumps(tokens, sort_keys=True)}
+        ).encode(),
+    )
+
+
+###############################################################################
+#   Keycloak                                                                   #
+###############################################################################
+
+
+def keycloak_token(
+    base_url: str, realm: str, client_id: str, client_secret: str
+) -> str:
+    """Client-credentials grant for the token-sync service account."""
+    form = urllib.parse.urlencode(
+        {
+            "grant_type": "client_credentials",
+            "client_id": client_id,
+            "client_secret": client_secret,
+        }
+    ).encode()
+    response = _request(
+        f"{base_url}/realms/{realm}/protocol/openid-connect/token",
+        method="POST",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        data=form,
+    )
+    token = (response or {}).get("access_token")
+    if not token:
+        msg = f"Keycloak client-credentials grant for {client_id} returned no token"
+        raise SyncError(msg)
+    return token
+
+
+def find_group_id(base_url: str, realm: str, token: str, group_name: str) -> str:
+    """Resolve a top-level group name to its uuid.
+
+    A missing group is fatal rather than "zero members". The two are
+    indistinguishable in the member list but not in consequence: an empty group
+    legitimately retires every per-user token, whereas a typo'd or not-yet-created
+    group would do the same thing and call it success.
+    """
+    query = urllib.parse.urlencode({"search": group_name, "exact": "true"})
+    groups = (
+        _request(
+            f"{base_url}/admin/realms/{realm}/groups?{query}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        or []
+    )
+    for group in groups:
+        if group.get("name") == group_name:
+            return group["id"]
+    msg = (
+        f"Keycloak group {group_name!r} does not exist in realm {realm}. "
+        "It is provisioned by the keycloak substructure stack "
+        "(substructure/keycloak/ol_platform_engineering.py); this job will not "
+        "retire every per-user token on the strength of a lookup that failed."
+    )
+    raise SyncError(msg)
+
+
+def group_members(
+    base_url: str, realm: str, token: str, group_id: str
+) -> list[dict[str, Any]]:
+    """Page through the group's direct members."""
+    members: list[dict[str, Any]] = []
+    for page in range(MAX_MEMBER_PAGES):
+        query = urllib.parse.urlencode(
+            {"first": page * MEMBERS_PAGE_SIZE, "max": MEMBERS_PAGE_SIZE}
+        )
+        batch = (
+            _request(
+                f"{base_url}/admin/realms/{realm}/groups/{group_id}/members?{query}",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+            or []
+        )
+        members.extend(batch)
+        if len(batch) < MEMBERS_PAGE_SIZE:
+            return members
+    msg = (
+        f"Group {group_id} still paging after {MAX_MEMBER_PAGES} pages; "
+        "refusing to continue"
+    )
+    raise SyncError(msg)
+
+
+###############################################################################
+#   Reconciliation                                                             #
+###############################################################################
+
+
+def reconcile(
+    service_tokens: dict[str, str],
+    current: dict[str, str],
+    members: list[dict[str, Any]],
+) -> dict[str, str]:
+    """Compute the desired actor-token map.
+
+    Disabled Keycloak users are treated as non-members: leaving a token live
+    for a disabled account would make "disable in Keycloak" a no-op for graph
+    access, which is the one thing an operator disabling an account expects it
+    not to be.
+    """
+    desired = dict(service_tokens)
+    for member in members:
+        sub = member.get("id")
+        if not sub:
+            msg = f"Keycloak returned a group member with no id: {member!r}"
+            raise SyncError(msg)
+        if not member.get("enabled", True):
+            LOG.info("skipping disabled user %s", member.get("username", sub))
+            continue
+        actor_id = derive_actor_id(sub)
+        if actor_id in service_tokens:
+            # Can only happen if a service actor were named `act-<uuid>`, but
+            # the collision would hand a human the service identity's token, so
+            # it stops the run rather than resolving in either direction.
+            msg = (
+                f"Keycloak user {member.get('username', sub)} derives actor id "
+                f"{actor_id}, which collides with a service actor. Refusing to "
+                "overwrite either."
+            )
+            raise SyncError(msg)
+        # Carried over verbatim when it already exists: re-minting a token for
+        # an unchanged member would churn the map and bounce omnigraph-server
+        # for no reason. Rotation is deliberately manual — delete the entry (or
+        # the whole path) and let the next run re-mint.
+        desired[actor_id] = current.get(actor_id) or secrets.token_urlsafe(
+            TOKEN_ENTROPY_BYTES
+        )
+    return desired
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        msg = f"Required environment variable {name} is unset or empty"
+        raise SyncError(msg)
+    return value
+
+
+def main() -> int:
+    """Run one reconciliation pass, returning a process exit status."""
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s"
+    )
+    dry_run = os.environ.get("WITAN_TOKEN_SYNC_DRY_RUN", "").lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+    vault_addr = _require_env("VAULT_ADDR").rstrip("/")
+    vault_auth_mount = _require_env("VAULT_K8S_AUTH_MOUNT").strip("/")
+    vault_role = _require_env("VAULT_K8S_ROLE")
+    sa_token_path = os.environ.get(
+        "VAULT_K8S_SA_TOKEN_PATH",
+        "/var/run/secrets/kubernetes.io/serviceaccount/token",
+    )
+    actor_tokens_path = _require_env("ACTOR_TOKENS_VAULT_PATH").strip("/")
+    service_tokens_path = _require_env("SERVICE_TOKENS_VAULT_PATH").strip("/")
+
+    keycloak_url = _require_env("KEYCLOAK_URL").rstrip("/")
+    keycloak_realm = _require_env("KEYCLOAK_REALM")
+    keycloak_client_id = _require_env("KEYCLOAK_CLIENT_ID")
+    keycloak_client_secret = _require_env("KEYCLOAK_CLIENT_SECRET")
+    group_name = _require_env("WITAN_USERS_GROUP")
+
+    try:
+        with open(sa_token_path, encoding="utf-8") as handle:  # noqa: PTH123
+            sa_jwt = handle.read().strip()
+    except OSError as exc:
+        msg = f"Cannot read the ServiceAccount token at {sa_token_path}: {exc}"
+        raise SyncError(msg) from exc
+
+    vault_token = vault_login(vault_addr, vault_auth_mount, vault_role, sa_jwt)
+    LOG.info("authenticated to vault at %s as role %s", vault_addr, vault_role)
+
+    service_tokens = read_token_map(vault_addr, vault_token, service_tokens_path)
+    # The whole output map is replaced on write, so an empty or unreadable
+    # service map would silently retire svc-witan-ci — breaking the CI indexer
+    # and the witan tier's own fallback client — and report success. The stack
+    # that writes this path enforces the same invariant at `pulumi up` time;
+    # this is the runtime half of it.
+    if not service_tokens:
+        msg = (
+            f"Service token map at {service_tokens_path} is empty or missing. "
+            "It is written by the omnigraph Pulumi stack from "
+            f"src/bridge/secrets/omnigraph/secrets.<env>.yaml. Refusing to write "
+            "an actor-token map that would drop every service identity."
+        )
+        raise SyncError(msg)
+    if "svc-witan-ci" not in service_tokens:
+        msg = (
+            f"Service token map at {service_tokens_path} has no 'svc-witan-ci' "
+            "entry. That identity backs the CI code-graph indexer and witan's "
+            "own fallback client; a map without it is not one to publish."
+        )
+        raise SyncError(msg)
+
+    current = read_token_map(vault_addr, vault_token, actor_tokens_path)
+
+    access_token = keycloak_token(
+        keycloak_url, keycloak_realm, keycloak_client_id, keycloak_client_secret
+    )
+    group_id = find_group_id(keycloak_url, keycloak_realm, access_token, group_name)
+    members = group_members(keycloak_url, keycloak_realm, access_token, group_id)
+    LOG.info("group %s (%s) has %d member(s)", group_name, group_id, len(members))
+
+    desired = reconcile(service_tokens, current, members)
+
+    added = sorted(set(desired) - set(current))
+    removed = sorted(set(current) - set(desired))
+    rotated = sorted(k for k in set(desired) & set(current) if desired[k] != current[k])
+    LOG.info(
+        "actors: %d current -> %d desired (+%d, -%d, ~%d)",
+        len(current),
+        len(desired),
+        len(added),
+        len(removed),
+        len(rotated),
+    )
+    # Actor ids are uuid-derived and the tokens themselves never appear — these
+    # names are what makes a run auditable after the fact.
+    for actor_id in added:
+        LOG.info("provisioning %s", actor_id)
+    for actor_id in removed:
+        LOG.info("retiring %s", actor_id)
+    for actor_id in rotated:
+        LOG.info("rotating %s", actor_id)
+
+    if desired == current:
+        LOG.info("actor-token map already matches Keycloak; nothing to write")
+        return 0
+    if dry_run:
+        LOG.info("dry run: not writing %s", actor_tokens_path)
+        return 0
+
+    write_token_map(vault_addr, vault_token, actor_tokens_path, desired)
+    # Worth saying explicitly: this write is what triggers the VSO
+    # rolloutRestartTarget on the actor-tokens secret, and therefore a brief
+    # omnigraph-server outage. If this line appears every run, something is
+    # re-minting tokens that should have been carried over.
+    LOG.info(
+        "wrote %d actors to %s; omnigraph-server will be restarted by the "
+        "Vault Secrets Operator",
+        len(desired),
+        actor_tokens_path,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except SyncError as error:
+        LOG.error("%s", error)  # noqa: TRY400 - the traceback adds nothing here
+        sys.exit(1)

--- a/src/ol_infrastructure/applications/omnigraph/token_sync.py
+++ b/src/ol_infrastructure/applications/omnigraph/token_sync.py
@@ -1,0 +1,416 @@
+"""Deploy the Keycloak witan-users -> actor-token sync job.
+
+The job itself is ``scripts/sync_actor_tokens.py``; its module docstring covers
+what it computes and why. This module is the deployment half: the identity it
+runs as, the Vault role that lets it write, and the schedule it runs on.
+
+WHY AN IN-CLUSTER CRONJOB RATHER THAN CONCOURSE
+
+The job's whole purpose is one privileged write to
+``secret-operations/witan/actor-tokens``. In-cluster it earns that privilege by
+being the pod it is: Vault's Kubernetes auth exchanges the pod's ServiceAccount
+token for a Vault token carrying exactly ``token_sync_policy.hcl``, and the
+credential is minted per run and expires on its own. From Concourse the same
+write needs a long-lived Vault credential provisioned into CI, which puts a
+build system on the write path of the auth secret for the whole graph — a
+strictly larger blast radius for no gain. The pod also needs nothing from a
+Concourse worker: it clones nothing and builds nothing, it makes two HTTPS
+calls. Everything else this write interacts with — the Vault path, the VSO sync
+that renders it, the Deployment that restarts on it — is already owned by this
+stack, so the writer belongs next to them.
+
+WHY A STOCK PYTHON IMAGE AND A CONFIGMAP
+
+The script is stdlib-only by design, so there is nothing to install and no
+image to build, publish, scan, or keep patched. Shipping it as a ConfigMap
+against ``python:3.12-slim`` (through the account's Docker Hub pull-through
+cache, like vector_log_proxy) means a change to the script is a change to this
+stack and nothing else — no ECR repository, no Concourse build job, no
+image-tag plumbing between two repos. The sibling witan CI indexer
+(``applications/witan/ci_indexer.py``) does use a built image, but it has to:
+it runs agent-kit's own ``witan-ci-index`` entrypoint and must stay in lockstep
+with the tier's release. This job shares no code with agent-kit beyond one
+15-line function it deliberately restates.
+
+THE ALL-OR-NOTHING SWITCH
+
+Everything here is gated on ``omnigraph:keycloak_url`` being set for the
+environment, because turning it on also transfers ownership of the
+actor-tokens Vault path from Pulumi to this job (see ``__main__.py``). An
+environment that has not had its Keycloak client provisioned yet keeps the
+SOPS-driven behaviour unchanged rather than getting a CronJob that fails every
+interval on a missing credential.
+"""
+
+import hashlib
+from pathlib import Path
+from typing import NamedTuple
+
+import pulumi_kubernetes as kubernetes
+from pulumi import Output, Resource, ResourceOptions
+from pulumi_vault import Policy
+from pulumi_vault import kubernetes as vault_kubernetes
+
+from ol_infrastructure.components.services.vault import (
+    OLVaultK8SSecret,
+    OLVaultK8SStaticSecretConfig,
+)
+from ol_infrastructure.lib.aws.eks_helper import cached_image_uri
+from ol_infrastructure.lib.pulumi_helper import StackInfo
+
+# Stock upstream image, pulled through the account's Docker Hub cache rather
+# than from Docker Hub directly — the same accommodation vector_log_proxy makes,
+# and the reason a rate-limited anonymous pull cannot wedge this job.
+TOKEN_SYNC_IMAGE = cached_image_uri("python:3.12-slim")
+
+SERVICE_ACCOUNT_NAME = "witan-token-sync"
+VAULT_ROLE_NAME = "witan-token-sync"
+SCRIPT_MOUNT_PATH = "/opt/witan-token-sync"
+SCRIPT_FILENAME = "sync_actor_tokens.py"
+
+# The Vault paths this job reads and writes. Both are the kv-v1 form used
+# everywhere in this stack, and both are relative to the same `secret-operations`
+# mount; they are spelled out in full here because they also appear verbatim in
+# token_sync_policy.hcl and a mismatch between the two is a 403 at runtime.
+ACTOR_TOKENS_VAULT_PATH = (  # pragma: allowlist secret
+    "secret-operations/witan/actor-tokens"
+)
+SERVICE_TOKENS_VAULT_PATH = (  # pragma: allowlist secret
+    "secret-operations/witan/service-tokens"
+)
+
+# Where the keycloak substructure stack publishes the token-sync service
+# account's OIDC credentials. Filed under `witan/` with the rest of this
+# deployment's secrets rather than under the `secret-operations/sso/<app>`
+# convention the realm's other clients use: those are per-application login
+# credentials consumed by the application itself, whereas this is one more
+# piece of witan's own plumbing, and grouping it with witan/actor-tokens and
+# witan/ci-token is what lets one policy stanza per path stay readable.
+# Relative to the `secret-operations` mount, as OLVaultK8SStaticSecretConfig
+# expects — the full path also appears in omnigraph_policy.hcl.
+KEYCLOAK_CREDENTIALS_VAULT_PATH = "witan/token-sync-oidc"
+KEYCLOAK_CREDENTIALS_SECRET_NAME = "witan-token-sync-oidc"  # noqa: S105  # pragma: allowlist secret
+
+# The Keycloak group whose membership defines who gets a token.
+WITAN_USERS_GROUP = "witan-users"
+
+# Hourly. The floor on this is not Keycloak's cost — the job makes two API
+# calls — but the fact that a membership change writes Vault and therefore
+# bounces omnigraph-server (replicas=1/Recreate, a hard ~10-30s graph outage
+# absorbed by client-side connect retry). Hourly makes onboarding latency an
+# hour in the worst case while keeping any conceivable churn well clear of
+# overlapping restarts. Steady state is free: an unchanged membership writes
+# nothing at all, so the restart cost is paid only on real change.
+DEFAULT_SYNC_SCHEDULE = "17 * * * *"
+
+# Two HTTPS calls and a Vault write. A run that has not finished in five
+# minutes is wedged on a hung connection, not slow.
+SYNC_ACTIVE_DEADLINE_SECONDS = 300
+
+# The script is idempotent, so a retry is safe; two of them ride out a Keycloak
+# blip or an omnigraph-server rollout without waiting for the next hour.
+SYNC_BACKOFF_LIMIT = 2
+
+
+def _pod_spec(  # noqa: PLR0913
+    script_config_map_name: str | Output[str],
+    keycloak_url: str,
+    keycloak_realm: str,
+    vault_address: str,
+    vault_auth_endpoint: str | Output[str],
+    k8s_global_labels: dict[str, str],
+) -> kubernetes.core.v1.PodTemplateSpecArgs:
+    """Build the pod both the CronJob and the bootstrap Job run.
+
+    Shared rather than duplicated because the two must stay identical: the
+    bootstrap run exists to make the scheduled run's first output available
+    before anything depends on it, and a bootstrap that ran a different
+    configuration would defeat that.
+    """
+    return kubernetes.core.v1.PodTemplateSpecArgs(
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            labels={
+                **k8s_global_labels,
+                "app.kubernetes.io/name": SERVICE_ACCOUNT_NAME,
+            },
+        ),
+        spec=kubernetes.core.v1.PodSpecArgs(
+            restart_policy="Never",
+            service_account_name=SERVICE_ACCOUNT_NAME,
+            # Required, and the one place in this deployment where it is: the
+            # projected ServiceAccount token IS the credential the script
+            # presents to Vault's Kubernetes auth method. The sibling CI
+            # indexer sets this False precisely because it has no such need.
+            automount_service_account_token=True,
+            security_context=kubernetes.core.v1.PodSecurityContextArgs(
+                run_as_non_root=True,
+                run_as_user=1000,
+                run_as_group=1000,
+            ),
+            containers=[
+                kubernetes.core.v1.ContainerArgs(
+                    name="sync-actor-tokens",
+                    image=TOKEN_SYNC_IMAGE,
+                    command=["python", f"{SCRIPT_MOUNT_PATH}/{SCRIPT_FILENAME}"],
+                    env=[
+                        kubernetes.core.v1.EnvVarArgs(
+                            name="VAULT_ADDR", value=vault_address
+                        ),
+                        kubernetes.core.v1.EnvVarArgs(
+                            name="VAULT_K8S_AUTH_MOUNT", value=vault_auth_endpoint
+                        ),
+                        kubernetes.core.v1.EnvVarArgs(
+                            name="VAULT_K8S_ROLE", value=VAULT_ROLE_NAME
+                        ),
+                        kubernetes.core.v1.EnvVarArgs(
+                            name="ACTOR_TOKENS_VAULT_PATH",
+                            value=ACTOR_TOKENS_VAULT_PATH,
+                        ),
+                        kubernetes.core.v1.EnvVarArgs(
+                            name="SERVICE_TOKENS_VAULT_PATH",
+                            value=SERVICE_TOKENS_VAULT_PATH,
+                        ),
+                        kubernetes.core.v1.EnvVarArgs(
+                            name="KEYCLOAK_URL", value=keycloak_url
+                        ),
+                        kubernetes.core.v1.EnvVarArgs(
+                            name="KEYCLOAK_REALM", value=keycloak_realm
+                        ),
+                        kubernetes.core.v1.EnvVarArgs(
+                            name="WITAN_USERS_GROUP", value=WITAN_USERS_GROUP
+                        ),
+                        kubernetes.core.v1.EnvVarArgs(
+                            name="KEYCLOAK_CLIENT_ID",
+                            value_from=kubernetes.core.v1.EnvVarSourceArgs(
+                                secret_key_ref=kubernetes.core.v1.SecretKeySelectorArgs(
+                                    name=KEYCLOAK_CREDENTIALS_SECRET_NAME,
+                                    key="client_id",
+                                )
+                            ),
+                        ),
+                        kubernetes.core.v1.EnvVarArgs(
+                            name="KEYCLOAK_CLIENT_SECRET",
+                            value_from=kubernetes.core.v1.EnvVarSourceArgs(
+                                secret_key_ref=kubernetes.core.v1.SecretKeySelectorArgs(
+                                    name=KEYCLOAK_CREDENTIALS_SECRET_NAME,
+                                    key="client_secret",
+                                )
+                            ),
+                        ),
+                    ],
+                    volume_mounts=[
+                        kubernetes.core.v1.VolumeMountArgs(
+                            name="script",
+                            mount_path=SCRIPT_MOUNT_PATH,
+                            read_only=True,
+                        )
+                    ],
+                    # A stdlib script making two HTTPS calls. The limits are
+                    # here to make it evictable-last rather than because it is
+                    # anywhere near them.
+                    resources=kubernetes.core.v1.ResourceRequirementsArgs(
+                        requests={"cpu": "50m", "memory": "64Mi"},
+                        limits={"cpu": "500m", "memory": "256Mi"},
+                    ),
+                )
+            ],
+            volumes=[
+                kubernetes.core.v1.VolumeArgs(
+                    name="script",
+                    config_map=kubernetes.core.v1.ConfigMapVolumeSourceArgs(
+                        name=script_config_map_name,
+                        default_mode=0o555,
+                    ),
+                )
+            ],
+        ),
+    )
+
+
+class WitanTokenSync(NamedTuple):
+    """Handles to the provisioned token-sync resources for depends_on wiring."""
+
+    cron_job: kubernetes.batch.v1.CronJob
+    bootstrap_job: kubernetes.batch.v1.Job
+
+
+def create_token_sync(  # noqa: PLR0913
+    stack_info: StackInfo,
+    namespace: str,
+    k8s_global_labels: dict[str, str],
+    keycloak_url: str,
+    keycloak_realm: str,
+    vault_address: str,
+    vault_auth_endpoint: str | Output[str],
+    vault_auth_name: str,
+    schedule: str,
+    depends_on: list[Resource],
+) -> WitanTokenSync:
+    """Provision the identity, credentials, schedule and bootstrap run.
+
+    ``bootstrap_job`` on the result is what callers should order the
+    actor-tokens VSO sync behind — see ``__main__.py``, which threads it in so
+    that a brand-new environment has a written actor-tokens path before
+    anything tries to render it.
+    """
+    script_body = (Path(__file__).parent / "scripts" / SCRIPT_FILENAME).read_text()
+
+    # Its own ServiceAccount rather than the namespace's existing two. The IRSA
+    # one carries S3 write access to the graph bucket and the VSO one carries
+    # system:auth-delegator; this pod needs neither, and reusing either would
+    # hand it a credential far broader than the single Vault write it makes.
+    service_account = kubernetes.core.v1.ServiceAccount(
+        f"witan-token-sync-service-account-{stack_info.env_suffix}",
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            name=SERVICE_ACCOUNT_NAME,
+            namespace=namespace,
+            labels=k8s_global_labels,
+        ),
+    )
+
+    vault_policy = Policy(
+        f"witan-token-sync-vault-policy-{stack_info.env_suffix}",
+        name=VAULT_ROLE_NAME,
+        policy=(Path(__file__).parent / "token_sync_policy.hcl").read_text(),
+    )
+
+    vault_auth_role = vault_kubernetes.AuthBackendRole(
+        f"witan-token-sync-k8s-vault-auth-backend-role-{stack_info.env_suffix}",
+        role_name=VAULT_ROLE_NAME,
+        backend=vault_auth_endpoint,
+        bound_service_account_names=[SERVICE_ACCOUNT_NAME],
+        bound_service_account_namespaces=[namespace],
+        token_policies=[vault_policy.name],
+        opts=ResourceOptions(depends_on=[vault_policy]),
+    )
+
+    # The Keycloak service-account credentials, written to Vault by the
+    # keycloak substructure stack. Synced with the namespace's existing VaultAuth
+    # (read-only, omnigraph_policy.hcl) rather than this job's write-capable
+    # role: the operator only ever reads it, and the write capability exists for
+    # the pod, not for the sync.
+    keycloak_credentials_secret = OLVaultK8SSecret(
+        f"witan-token-sync-oidc-secret-{stack_info.env_suffix}",
+        resource_config=OLVaultK8SStaticSecretConfig(
+            name=KEYCLOAK_CREDENTIALS_SECRET_NAME,
+            namespace=namespace,
+            labels=k8s_global_labels,
+            dest_secret_labels=k8s_global_labels,
+            dest_secret_name=KEYCLOAK_CREDENTIALS_SECRET_NAME,
+            dest_secret_type="Opaque",  # pragma: allowlist secret  # noqa: S106
+            mount="secret-operations",
+            mount_type="kv-v1",
+            path=KEYCLOAK_CREDENTIALS_VAULT_PATH,
+            exclude_raw=True,
+            excludes=[".*"],
+            templates={
+                "client_id": '{{ get .Secrets "client_id" }}',
+                "client_secret": '{{ get .Secrets "client_secret" }}',
+            },
+            refresh_after="1h",
+            # No restart target: the credential is read once per run by a pod
+            # that exits, so the next run picks up a rotation on its own.
+            vaultauth=vault_auth_name,
+        ),
+        opts=ResourceOptions(delete_before_replace=True, depends_on=depends_on),
+    )
+
+    # Auto-named so a script change rolls a new ConfigMap rather than mutating
+    # one in place: a mutated ConfigMap propagates to a running pod on the
+    # kubelet's own schedule, which for a CronJob means an indeterminate mix of
+    # old and new for the next interval.
+    script_config_map = kubernetes.core.v1.ConfigMap(
+        f"witan-token-sync-script-{stack_info.env_suffix}",
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            namespace=namespace,
+            labels=k8s_global_labels,
+        ),
+        data={SCRIPT_FILENAME: script_body},
+    )
+
+    pod_template = _pod_spec(
+        script_config_map_name=script_config_map.metadata.name,
+        keycloak_url=keycloak_url,
+        keycloak_realm=keycloak_realm,
+        vault_address=vault_address,
+        vault_auth_endpoint=vault_auth_endpoint,
+        k8s_global_labels=k8s_global_labels,
+    )
+
+    job_depends_on: list[Resource] = [
+        service_account,
+        vault_auth_role,
+        keycloak_credentials_secret,
+        script_config_map,
+    ]
+
+    # Runs the same reconciliation once at deploy time. Without it a brand-new
+    # environment has no actor-tokens path at all until the first scheduled
+    # tick, and the VSO sync that renders it — and the Deployment that mounts
+    # the result — would come up against nothing. Pulumi waits for a Job to
+    # succeed, so this also makes a broken Keycloak credential fail the deploy
+    # loudly instead of producing a CronJob that silently errors every hour.
+    bootstrap_hash = hashlib.sha256(
+        f"{script_body}\n{keycloak_url}\n{keycloak_realm}".encode()
+    ).hexdigest()
+    bootstrap_job = kubernetes.batch.v1.Job(
+        f"witan-token-sync-bootstrap-{stack_info.env_suffix}",
+        # Auto-named for the same reason as cluster_apply_job: a Job's pod
+        # template is immutable, so every change is a replacement.
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            namespace=namespace,
+            labels=k8s_global_labels,
+        ),
+        spec=kubernetes.batch.v1.JobSpecArgs(
+            backoff_limit=SYNC_BACKOFF_LIMIT,
+            active_deadline_seconds=SYNC_ACTIVE_DEADLINE_SECONDS,
+            ttl_seconds_after_finished=86400,
+            template=kubernetes.core.v1.PodTemplateSpecArgs(
+                metadata=kubernetes.meta.v1.ObjectMetaArgs(
+                    labels=pod_template.metadata.labels,
+                    # Re-runs the bootstrap when the script or the Keycloak
+                    # target changes. Membership changes deliberately do NOT
+                    # roll this — that is the CronJob's job, and a deploy is not
+                    # where onboarding should happen.
+                    annotations={"ol.mit.edu/config-hash": bootstrap_hash},
+                ),
+                spec=pod_template.spec,
+            ),
+        ),
+        opts=ResourceOptions(depends_on=job_depends_on),
+    )
+
+    cron_job = kubernetes.batch.v1.CronJob(
+        f"witan-token-sync-{stack_info.env_suffix}",
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            name=SERVICE_ACCOUNT_NAME,
+            namespace=namespace,
+            labels=k8s_global_labels,
+        ),
+        spec=kubernetes.batch.v1.CronJobSpecArgs(
+            schedule=schedule,
+            # Two concurrent runs would read the same actor-tokens map and
+            # write back divergent merges, and the loser's freshly minted
+            # tokens would be silently dropped. The reconciliation is a
+            # read-modify-write with no compare-and-swap behind it, so
+            # serialising the runs is what stands in for one.
+            concurrency_policy="Forbid",
+            starting_deadline_seconds=600,
+            successful_jobs_history_limit=1,
+            # A failed run is the one whose logs somebody needs; onboarding
+            # silently not happening is exactly the symptom that sends an
+            # operator here.
+            failed_jobs_history_limit=3,
+            job_template=kubernetes.batch.v1.JobTemplateSpecArgs(
+                metadata=kubernetes.meta.v1.ObjectMetaArgs(labels=k8s_global_labels),
+                spec=kubernetes.batch.v1.JobSpecArgs(
+                    backoff_limit=SYNC_BACKOFF_LIMIT,
+                    active_deadline_seconds=SYNC_ACTIVE_DEADLINE_SECONDS,
+                    template=pod_template,
+                ),
+            ),
+        ),
+        opts=ResourceOptions(depends_on=[*job_depends_on, bootstrap_job]),
+    )
+
+    return WitanTokenSync(cron_job=cron_job, bootstrap_job=bootstrap_job)

--- a/src/ol_infrastructure/applications/omnigraph/token_sync.py
+++ b/src/ol_infrastructure/applications/omnigraph/token_sync.py
@@ -1,4 +1,4 @@
-"""Deploy the Keycloak witan-users -> actor-token sync job.
+"""Deploy the Keycloak realm -> actor-token sync job.
 
 The job itself is ``scripts/sync_actor_tokens.py``; its module docstring covers
 what it computes and why. This module is the deployment half: the identity it
@@ -91,9 +91,6 @@ SERVICE_TOKENS_VAULT_PATH = (  # pragma: allowlist secret
 KEYCLOAK_CREDENTIALS_VAULT_PATH = "witan/token-sync-oidc"
 KEYCLOAK_CREDENTIALS_SECRET_NAME = "witan-token-sync-oidc"  # noqa: S105  # pragma: allowlist secret
 
-# The Keycloak group whose membership defines who gets a token.
-WITAN_USERS_GROUP = "witan-users"
-
 # Hourly. The floor on this is not Keycloak's cost — the job makes two API
 # calls — but the fact that a membership change writes Vault and therefore
 # bounces omnigraph-server (replicas=1/Recreate, a hard ~10-30s graph outage
@@ -175,9 +172,6 @@ def _pod_spec(  # noqa: PLR0913
                         ),
                         kubernetes.core.v1.EnvVarArgs(
                             name="KEYCLOAK_REALM", value=keycloak_realm
-                        ),
-                        kubernetes.core.v1.EnvVarArgs(
-                            name="WITAN_USERS_GROUP", value=WITAN_USERS_GROUP
                         ),
                         kubernetes.core.v1.EnvVarArgs(
                             name="KEYCLOAK_CLIENT_ID",

--- a/src/ol_infrastructure/applications/omnigraph/token_sync.py
+++ b/src/ol_infrastructure/applications/omnigraph/token_sync.py
@@ -309,10 +309,24 @@ def create_token_sync(  # noqa: PLR0913
         opts=ResourceOptions(delete_before_replace=True, depends_on=depends_on),
     )
 
-    # Auto-named so a script change rolls a new ConfigMap rather than mutating
-    # one in place: a mutated ConfigMap propagates to a running pod on the
-    # kubelet's own schedule, which for a CronJob means an indeterminate mix of
-    # old and new for the next interval.
+    # A script change must roll a NEW ConfigMap rather than mutate one in
+    # place: a mutated ConfigMap propagates to already-scheduled pods on the
+    # kubelet's own schedule, so a run that starts during propagation can mount
+    # a stale script.
+    #
+    # Auto-naming (no metadata.name) is only half of that, and on its own it
+    # does nothing here — Pulumi generates the name once, at creation, and a
+    # `data` change is an in-place update that keeps it. `replace_on_changes`
+    # is what makes the data the thing that forces a replacement; auto-naming
+    # is then what lets the replacement take a *different* name instead of
+    # colliding with the resource it replaces. Both are required, and because
+    # the new name flows into the pod spec through
+    # `script_config_map.metadata.name`, replacing the ConfigMap also updates
+    # the CronJob that mounts it.
+    #
+    # delete_before_replace stays False (the default, stated because it is
+    # load-bearing): the new ConfigMap is created before the old one goes, so
+    # there is no window in which a scheduled run finds no ConfigMap at all.
     script_config_map = kubernetes.core.v1.ConfigMap(
         f"witan-token-sync-script-{stack_info.env_suffix}",
         metadata=kubernetes.meta.v1.ObjectMetaArgs(
@@ -320,6 +334,10 @@ def create_token_sync(  # noqa: PLR0913
             labels=k8s_global_labels,
         ),
         data={SCRIPT_FILENAME: script_body},
+        opts=ResourceOptions(
+            replace_on_changes=["data"],
+            delete_before_replace=False,
+        ),
     )
 
     pod_template = _pod_spec(

--- a/src/ol_infrastructure/applications/omnigraph/token_sync_policy.hcl
+++ b/src/ol_infrastructure/applications/omnigraph/token_sync_policy.hcl
@@ -1,0 +1,28 @@
+# Vault policy for the witan-users token-sync job (scripts/sync_actor_tokens.py).
+#
+# Deliberately NOT the `omnigraph-server` policy this namespace already has.
+# That one is read-only and is what the Vault Secrets Operator authenticates
+# with; this job is the one workload here that WRITES, and giving the operator's
+# identity a write capability to save a role would hand it to every VSO sync in
+# the namespace. Separate ServiceAccount, separate Vault role, separate policy.
+#
+# kv-v1 paths, matching `secret-operations`' mount type — see the note in
+# omnigraph_policy.hcl for why there is no `secret-operations/data/...` twin.
+
+# The job's own output: the merged {actor_id: token} map that omnigraph-server
+# boots its bearer-token auth from and the witan tier resolves per-user tokens
+# through. `read` as well as write because the job carries an existing member's
+# token over verbatim rather than re-minting it — without the read it could only
+# ever rewrite the whole map with fresh tokens, invalidating every live session
+# on every run and bouncing omnigraph-server with it.
+path "secret-operations/witan/actor-tokens" {
+  capabilities = ["read", "create", "update"]
+}
+
+# The job's input: the Pulumi/SOPS-owned map of non-human actors (svc-witan-ci,
+# and later svc-witan-admin) that gets merged into every write of the path
+# above. Read-only here — this job is not the writer of that path, and the
+# separation of the two writers is the whole point of the split.
+path "secret-operations/witan/service-tokens" {
+  capabilities = ["read"]
+}

--- a/src/ol_infrastructure/applications/witan/__main__.py
+++ b/src/ol_infrastructure/applications/witan/__main__.py
@@ -59,15 +59,15 @@ silently assumed:
       the pulumi-provisioner's ``env_vars_from_files``), so a new push always
       changes the pod spec and triggers a rollout instead of silently
       leaving the running pod on a stale image.
-    - **Keycloak witan-users token provisioning.** agent-kit ADR-0004 D3
-      assigns the job of "walking the Keycloak witan-users group/role
-      membership and writing a generated token per user" into the shared
-      actor-tokens source. This stack only provisions the destination (the
-      Vault-backed ``actor-tokens`` Secret) — the omnigraph stack
-      (``applications/omnigraph``) writes the Vault source itself from a
-      SOPS file, seeded today with at minimum the ``svc-witan-ci`` entry —
-      the sync job that keeps per-user entries current as Keycloak group
-      membership changes is not yet built.
+    - **Per-user token provisioning.** agent-kit ADR-0004 D3's "writing a
+      generated token per user" into the shared actor-tokens source now
+      exists, but it lives in the omnigraph stack next to the Vault path it
+      writes — ``applications/omnigraph/token_sync.py``, a CronJob that
+      enumerates the Keycloak realm's users. This stack only provisions the
+      *destination*: the Vault-backed ``actor-tokens`` Secret its own
+      containers mount. It is off until an environment sets
+      ``omnigraph:keycloak_url``, and until then the omnigraph stack writes
+      that Vault path from a SOPS file carrying only ``svc-witan-ci``.
     - **GitHub App registration.** The CI indexer can clone private repos as a
       GitHub App installation (``ci_indexer.py``). Registering that App on the
       org, granting it ``contents: read``, and installing it on the repos it

--- a/src/ol_infrastructure/applications/witan/witan_policy.hcl
+++ b/src/ol_infrastructure/applications/witan/witan_policy.hcl
@@ -18,10 +18,11 @@ path "secret-operations/witan/ci-token" {
 
 # {actor_id: token} JSON map — the same artifact omnigraph-server boots its
 # bearer-token auth from (OMNIGRAPH_SERVER_BEARER_TOKENS_FILE) and witan
-# resolves per-user tokens from (WITAN_ACTOR_TOKENS_FILE). Seeded here with at
-# least the svc-witan-ci entry; per-user entries are written by the
-# Keycloak witan-users sync (tk-... follow-up, not yet built — see
-# applications/witan/__main__.py).
+# resolves per-user tokens from (WITAN_ACTOR_TOKENS_FILE). Always carries the
+# svc-witan-ci entry; per-user entries are written by the realm token-sync
+# CronJob in the omnigraph stack (applications/omnigraph/token_sync.py), in
+# environments that have it enabled. Read-only here either way — this stack is
+# a consumer of that path, never a writer of it.
 path "secret-operations/witan/actor-tokens" {
   capabilities = ["read"]
 }

--- a/src/ol_infrastructure/substructure/keycloak/ol_platform_engineering.py
+++ b/src/ol_infrastructure/substructure/keycloak/ol_platform_engineering.py
@@ -285,28 +285,27 @@ def create_ol_platform_engineering_realm(  # noqa: PLR0913, PLR0915
     # TOOLHIVE [END] # noqa: ERA001
 
     # WITAN [START] # noqa: ERA001
-    # Membership of this group is the authoritative answer to "who may use
-    # witan". The omnigraph stack's token-sync CronJob walks it hourly and
-    # maintains one omnigraph bearer token per member, keyed by the actor id
-    # derived from the member's `sub` (agent-kit ADR-0004 D3). Adding someone
-    # here is the entire onboarding step; removing them retires their token on
-    # the next run.
+    # Membership of THIS REALM is the authoritative answer to "who may use
+    # witan". The omnigraph stack's token-sync CronJob enumerates it hourly and
+    # maintains one omnigraph bearer token per enabled human user, keyed by the
+    # actor id derived from their `sub` (agent-kit ADR-0004 D3). Adding someone
+    # to the realm is the entire onboarding step; removing or disabling them
+    # retires their token on the next run.
     #
-    # A group rather than a realm role — the first keycloak.Group in this repo,
-    # which is worth a word. Roles here (`admin`, `developer`) describe what
-    # somebody is and get mapped into tokens for applications to authorize on.
-    # This is neither: nothing reads a `witan-users` claim, because the tokens
-    # the sync job mints are what carry the authority, and the group is only
-    # ever enumerated out-of-band by that job. A role would work and would put
-    # a claim nobody consumes into every token in the realm.
-    keycloak.Group(
-        "ol-platform-engineering-witan-users-group",
-        realm_id=ol_platform_engineering_realm.id,
-        name="witan-users",
-        opts=resource_options,
-    )
-
-    # The identity the token-sync job enumerates that group as. CONFIDENTIAL
+    # DELIBERATELY NO `witan-users` GROUP, despite ADR-0004 D3 naming one. That
+    # name is a *Cedar* group in agent-kit's policy bundles
+    # (mcp/servers/witan/policy/server.policy.yaml), populated with the
+    # act-<sub> ids the sync job writes — the collision with a hypothetical
+    # Keycloak group of the same name is what made one look mandatory. This
+    # realm has registration_allowed=False, no identity-provider brokering and
+    # no federation, so it is already limited to exactly the intended audience;
+    # a group inside it would be a second gate on an already-gated population,
+    # whose failure mode is somebody being added to the realm, nobody adding
+    # them to the group, and a 401 that reads like a provisioning lag. The
+    # trade accepted: no way to revoke witan while leaving this realm's other
+    # applications (jupyterhub, superset, opik) intact.
+    #
+    # The identity the token-sync job enumerates the realm as. CONFIDENTIAL
     # with only the service-account (client-credentials) flow enabled: no human
     # ever logs in as this, there is no redirect URI to get wrong, and the
     # standard/implicit/direct-access flows are all off so a leaked secret buys
@@ -333,31 +332,27 @@ def create_ol_platform_engineering_realm(  # noqa: PLR0913, PLR0915
         opts=resource_options.merge(ResourceOptions(delete_before_replace=True)),
     )
 
-    # Exactly the two realm-management roles the job's two calls need, and both
-    # are read-only. `view-users` covers listing a group's members;
-    # `query-groups` covers resolving the group name to its id. Deliberately not
-    # `realm-admin` or `manage-users`: this credential lives in a Kubernetes
+    # Exactly one realm-management role, and it is read-only: `view-users` is
+    # all that listing the realm's users requires. Deliberately not
+    # `realm-admin` or `manage-users` — this credential lives in a Kubernetes
     # Secret, and nothing about its job requires the ability to change a single
-    # thing in the realm.
+    # thing in the realm. (An earlier revision also granted `query-groups`, for
+    # resolving a `witan-users` group that no longer exists.)
     witan_realm_mgmt_client = keycloak.openid.get_client(
         realm_id="ol-platform-engineering",
         client_id="realm-management",
         opts=InvokeOptions(provider=keycloak_provider),
     )
-    for resource_name, role in [
-        ("ol-platform-engineering-witan-token-sync-view-users", "view-users"),
-        ("ol-platform-engineering-witan-token-sync-query-groups", "query-groups"),
-    ]:
-        keycloak.openid.ClientServiceAccountRole(
-            resource_name,
-            realm_id=ol_platform_engineering_realm.id,
-            service_account_user_id=(
-                ol_platform_engineering_witan_token_sync_client.service_account_user_id
-            ),
-            client_id=witan_realm_mgmt_client.id,
-            role=role,
-            opts=resource_options,
-        )
+    keycloak.openid.ClientServiceAccountRole(
+        "ol-platform-engineering-witan-token-sync-view-users",
+        realm_id=ol_platform_engineering_realm.id,
+        service_account_user_id=(
+            ol_platform_engineering_witan_token_sync_client.service_account_user_id
+        ),
+        client_id=witan_realm_mgmt_client.id,
+        role="view-users",
+        opts=resource_options,
+    )
 
     # Filed under `witan/` rather than `sso/` with this realm's application
     # clients: the consumer is witan's own provisioning plumbing, and the

--- a/src/ol_infrastructure/substructure/keycloak/ol_platform_engineering.py
+++ b/src/ol_infrastructure/substructure/keycloak/ol_platform_engineering.py
@@ -4,7 +4,7 @@ import json
 
 import pulumi_keycloak as keycloak
 import pulumi_vault as vault
-from pulumi import Alias, Config, Output, ResourceOptions
+from pulumi import Alias, Config, InvokeOptions, Output, ResourceOptions
 
 
 def create_ol_platform_engineering_realm(  # noqa: PLR0913, PLR0915
@@ -283,6 +283,99 @@ def create_ol_platform_engineering_realm(  # noqa: PLR0913, PLR0915
         ).apply(json.dumps),
     )
     # TOOLHIVE [END] # noqa: ERA001
+
+    # WITAN [START] # noqa: ERA001
+    # Membership of this group is the authoritative answer to "who may use
+    # witan". The omnigraph stack's token-sync CronJob walks it hourly and
+    # maintains one omnigraph bearer token per member, keyed by the actor id
+    # derived from the member's `sub` (agent-kit ADR-0004 D3). Adding someone
+    # here is the entire onboarding step; removing them retires their token on
+    # the next run.
+    #
+    # A group rather than a realm role — the first keycloak.Group in this repo,
+    # which is worth a word. Roles here (`admin`, `developer`) describe what
+    # somebody is and get mapped into tokens for applications to authorize on.
+    # This is neither: nothing reads a `witan-users` claim, because the tokens
+    # the sync job mints are what carry the authority, and the group is only
+    # ever enumerated out-of-band by that job. A role would work and would put
+    # a claim nobody consumes into every token in the realm.
+    keycloak.Group(
+        "ol-platform-engineering-witan-users-group",
+        realm_id=ol_platform_engineering_realm.id,
+        name="witan-users",
+        opts=resource_options,
+    )
+
+    # The identity the token-sync job enumerates that group as. CONFIDENTIAL
+    # with only the service-account (client-credentials) flow enabled: no human
+    # ever logs in as this, there is no redirect URI to get wrong, and the
+    # standard/implicit/direct-access flows are all off so a leaked secret buys
+    # exactly the two read-only Admin API calls below and nothing else.
+    #
+    # This is NOT the `witan-cli` public client that ADR-0005 path (a)'s
+    # `witan login` device-code flow authenticates against — that one is a
+    # separate, public client tracked on its own task. Interactive user login
+    # and this machine credential have no reason to share a client.
+    ol_platform_engineering_witan_token_sync_client = keycloak.openid.Client(
+        "ol-platform-engineering-witan-token-sync-client",
+        name="ol-platform-engineering-witan-token-sync-client",
+        realm_id="ol-platform-engineering",
+        client_id="witan-token-sync",
+        client_secret=keycloak_realm_config.get(
+            "ol-platform-engineering-witan-token-sync-client-secret"
+        ),
+        enabled=True,
+        access_type="CONFIDENTIAL",
+        service_accounts_enabled=True,
+        standard_flow_enabled=False,
+        implicit_flow_enabled=False,
+        direct_access_grants_enabled=False,
+        opts=resource_options.merge(ResourceOptions(delete_before_replace=True)),
+    )
+
+    # Exactly the two realm-management roles the job's two calls need, and both
+    # are read-only. `view-users` covers listing a group's members;
+    # `query-groups` covers resolving the group name to its id. Deliberately not
+    # `realm-admin` or `manage-users`: this credential lives in a Kubernetes
+    # Secret, and nothing about its job requires the ability to change a single
+    # thing in the realm.
+    witan_realm_mgmt_client = keycloak.openid.get_client(
+        realm_id="ol-platform-engineering",
+        client_id="realm-management",
+        opts=InvokeOptions(provider=keycloak_provider),
+    )
+    for resource_name, role in [
+        ("ol-platform-engineering-witan-token-sync-view-users", "view-users"),
+        ("ol-platform-engineering-witan-token-sync-query-groups", "query-groups"),
+    ]:
+        keycloak.openid.ClientServiceAccountRole(
+            resource_name,
+            realm_id=ol_platform_engineering_realm.id,
+            service_account_user_id=(
+                ol_platform_engineering_witan_token_sync_client.service_account_user_id
+            ),
+            client_id=witan_realm_mgmt_client.id,
+            role=role,
+            opts=resource_options,
+        )
+
+    # Filed under `witan/` rather than `sso/` with this realm's application
+    # clients: the consumer is witan's own provisioning plumbing, and the
+    # omnigraph stack's VSO reads it alongside witan/actor-tokens and
+    # witan/ci-token. Only the two fields the job actually uses — it talks to
+    # the Admin API, not to a login endpoint, so there is no realm public key
+    # or session secret to publish.
+    vault.generic.Secret(
+        "ol-platform-engineering-witan-token-sync-vault-oidc-credentials",
+        path="secret-operations/witan/token-sync-oidc",
+        data_json=Output.all(
+            client_id=ol_platform_engineering_witan_token_sync_client.client_id,
+            client_secret=(
+                ol_platform_engineering_witan_token_sync_client.client_secret
+            ),
+        ).apply(json.dumps),
+    )
+    # WITAN [END] # noqa: ERA001
 
     # JUPYTERHUB [START] # noqa: ERA001
     ol_platform_engineering_jupyterhub_client = keycloak.openid.Client(

--- a/tests/ol_infrastructure/applications/omnigraph/test_sync_actor_tokens.py
+++ b/tests/ol_infrastructure/applications/omnigraph/test_sync_actor_tokens.py
@@ -181,6 +181,33 @@ def test_read_token_map_rejects_a_corrupt_payload(stub_server):
         read_token_map(base, "token", "secret-operations/witan/actor-tokens")
 
 
+def test_read_token_map_rejects_an_existing_secret_with_no_key(stub_server):
+    _, base = stub_server
+    _StubHandler.routes = {
+        "/v1/secret-operations/witan/actor-tokens": (200, {"data": {"other": "x"}})
+    }
+
+    # Distinct from the 404 bootstrap case above. Every writer of this path sets
+    # tokens_json, so a secret that exists without it is malformed — and
+    # treating it as empty would re-mint every user's token and bounce
+    # omnigraph-server to recover from what may be a transient read problem.
+    with pytest.raises(SyncError, match="no non-empty tokens_json"):
+        read_token_map(base, "token", "secret-operations/witan/actor-tokens")
+
+
+def test_read_token_map_rejects_a_non_json_success_body(stub_server):
+    _, base = stub_server
+    # An HTML error page from a proxy, served with a 200.
+    _StubHandler.routes = {
+        "/v1/secret-operations/witan/actor-tokens": (200, "<html>gateway</html>")
+    }
+
+    # Must surface as SyncError, not a bare JSONDecodeError traceback naming
+    # json/decoder.py instead of the request that was misrouted.
+    with pytest.raises(SyncError, match="non-JSON body"):
+        read_token_map(base, "token", "secret-operations/witan/actor-tokens")
+
+
 def test_read_token_map_rejects_a_non_string_map(stub_server):
     _, base = stub_server
     _StubHandler.routes = {

--- a/tests/ol_infrastructure/applications/omnigraph/test_sync_actor_tokens.py
+++ b/tests/ol_infrastructure/applications/omnigraph/test_sync_actor_tokens.py
@@ -17,8 +17,9 @@ import pytest
 from ol_infrastructure.applications.omnigraph.scripts.sync_actor_tokens import (
     SyncError,
     derive_actor_id,
-    group_members,
+    is_service_account,
     read_token_map,
+    realm_users,
     reconcile,
 )
 
@@ -27,6 +28,16 @@ SERVICE_TOKENS = {"svc-witan-ci": "ci-token"}  # pragma: allowlist secret
 
 def member(user_id: str, *, enabled: bool = True) -> dict[str, Any]:
     return {"id": user_id, "username": f"user-{user_id}", "enabled": enabled}
+
+
+def service_account(client_id: str) -> dict[str, Any]:
+    """Build a realm user as Keycloak represents a client's own service account."""
+    return {
+        "id": f"sa-{client_id}",
+        "username": f"service-account-{client_id}",
+        "enabled": True,
+        "serviceAccountClientId": client_id,
+    }
 
 
 def test_derive_actor_id_matches_witan_core():
@@ -96,6 +107,31 @@ def test_reconcile_rejects_a_member_with_no_id():
         reconcile(SERVICE_TOKENS, {}, [{"username": "nameless"}])
 
 
+def test_reconcile_skips_service_account_users():
+    # Enumerating the realm returns clients' own service accounts alongside
+    # people — this realm has one for ol-opik-client and one for the token-sync
+    # client itself. Minting a human's interactive token for them would hand
+    # every such client the Cedar rights of a person.
+    desired = reconcile(
+        SERVICE_TOKENS,
+        {},
+        [
+            member("alice"),
+            service_account("ol-opik-client"),
+            service_account("witan-token-sync"),
+        ],
+    )
+
+    assert set(desired) == {"svc-witan-ci", "act-alice"}
+
+
+def test_is_service_account_detects_both_signals():
+    assert is_service_account(service_account("ol-opik-client"))
+    # Username convention alone, in case the representation omits the field.
+    assert is_service_account({"username": "service-account-something"})
+    assert not is_service_account(member("alice"))
+
+
 class _StubHandler(BaseHTTPRequestHandler):
     """Serves whatever ``routes`` maps the path to: (status, body)."""
 
@@ -158,18 +194,18 @@ def test_read_token_map_rejects_a_non_string_map(stub_server):
         read_token_map(base, "token", "secret-operations/witan/actor-tokens")
 
 
-def test_group_members_pages_to_the_end(stub_server):
+def test_realm_users_pages_to_the_end(stub_server):
     _, base = stub_server
     full_page = [member(f"u{i}") for i in range(100)]
     tail = [member("u100")]
     _StubHandler.routes = {
-        "/admin/realms/r/groups/g/members?first=0&max=100": (200, full_page),
-        "/admin/realms/r/groups/g/members?first=100&max=100": (200, tail),
+        "/admin/realms/r/users?first=0&max=100": (200, full_page),
+        "/admin/realms/r/users?first=100&max=100": (200, tail),
     }
 
-    # A short page is the only end-of-list signal Keycloak gives, so a group
+    # A short page is the only end-of-list signal Keycloak gives, so a realm
     # that lands exactly on the page size must still fetch the next one.
-    members = group_members(base, "r", "token", "g")
+    users = realm_users(base, "r", "token")
 
-    assert len(members) == 101
-    assert members[-1]["id"] == "u100"
+    assert len(users) == 101
+    assert users[-1]["id"] == "u100"

--- a/tests/ol_infrastructure/applications/omnigraph/test_sync_actor_tokens.py
+++ b/tests/ol_infrastructure/applications/omnigraph/test_sync_actor_tokens.py
@@ -1,0 +1,175 @@
+"""Tests for the witan-users -> actor-token reconciliation.
+
+The properties worth pinning are the ones whose failure is silent in
+production: a token that gets re-minted when it should have been carried over
+bounces omnigraph-server for every user, and a map that loses its service
+entries breaks CI without anybody's request failing in a way that names the
+cause.
+"""
+
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Thread
+from typing import Any, ClassVar
+
+import pytest
+
+from ol_infrastructure.applications.omnigraph.scripts.sync_actor_tokens import (
+    SyncError,
+    derive_actor_id,
+    group_members,
+    read_token_map,
+    reconcile,
+)
+
+SERVICE_TOKENS = {"svc-witan-ci": "ci-token"}  # pragma: allowlist secret
+
+
+def member(user_id: str, *, enabled: bool = True) -> dict[str, Any]:
+    return {"id": user_id, "username": f"user-{user_id}", "enabled": enabled}
+
+
+def test_derive_actor_id_matches_witan_core():
+    # The uuid case is the one that actually occurs; the others pin the
+    # sanitising that has to agree with witan_core.identity.derive_actor_id.
+    assert (
+        derive_actor_id("2b1f0b3e-4c5d-4e6f-8a9b-0c1d2e3f4a5b")
+        == "act-2b1f0b3e-4c5d-4e6f-8a9b-0c1d2e3f4a5b"
+    )
+    assert derive_actor_id("Mixed.Case_Sub") == "act-mixed-case-sub"
+    assert derive_actor_id("  padded  ") == "act-padded"
+
+
+def test_derive_actor_id_rejects_all_punctuation():
+    # An id of bare "act-" would collide with every other such claim.
+    with pytest.raises(SyncError):
+        derive_actor_id("...")
+
+
+def test_reconcile_adds_members_and_keeps_service_entries():
+    desired = reconcile(SERVICE_TOKENS, {}, [member("alice"), member("bob")])
+
+    assert desired["svc-witan-ci"] == "ci-token"  # pragma: allowlist secret
+    assert set(desired) == {"svc-witan-ci", "act-alice", "act-bob"}
+    # Freshly minted, distinct, and not derived from anything guessable.
+    assert desired["act-alice"] != desired["act-bob"]
+    assert len(desired["act-alice"]) >= 32
+
+
+def test_reconcile_is_a_noop_for_unchanged_membership():
+    # The property the whole restart budget rests on: an unchanged membership
+    # must produce a byte-identical map, so nothing is written and
+    # omnigraph-server is not bounced.
+    first = reconcile(SERVICE_TOKENS, {}, [member("alice")])
+    second = reconcile(SERVICE_TOKENS, first, [member("alice")])
+
+    assert second == first
+
+
+def test_reconcile_retires_departed_and_disabled_members():
+    current = reconcile(SERVICE_TOKENS, {}, [member("alice"), member("bob")])
+
+    # bob left the group entirely; alice is still a member but disabled.
+    desired = reconcile(SERVICE_TOKENS, current, [member("alice", enabled=False)])
+
+    assert set(desired) == {"svc-witan-ci"}
+
+
+def test_reconcile_carries_over_only_the_surviving_member():
+    current = reconcile(SERVICE_TOKENS, {}, [member("alice"), member("bob")])
+
+    desired = reconcile(SERVICE_TOKENS, current, [member("alice"), member("carol")])
+
+    assert desired["act-alice"] == current["act-alice"]
+    assert desired["act-carol"] not in current.values()
+    assert "act-bob" not in desired
+
+
+def test_reconcile_refuses_a_member_colliding_with_a_service_actor():
+    # Would hand a human the service identity's token.
+    with pytest.raises(SyncError, match="collides with a service actor"):
+        reconcile({"act-alice": "svc"}, {}, [member("alice")])
+
+
+def test_reconcile_rejects_a_member_with_no_id():
+    with pytest.raises(SyncError, match="no id"):
+        reconcile(SERVICE_TOKENS, {}, [{"username": "nameless"}])
+
+
+class _StubHandler(BaseHTTPRequestHandler):
+    """Serves whatever ``routes`` maps the path to: (status, body)."""
+
+    routes: ClassVar[dict[str, Any]] = {}
+
+    def do_GET(self):
+        status, body = self.routes.get(self.path, (404, ""))
+        payload = body.encode() if isinstance(body, str) else json.dumps(body).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *args):
+        pass
+
+
+@pytest.fixture
+def stub_server():
+    server = HTTPServer(("127.0.0.1", 0), _StubHandler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield server, f"http://127.0.0.1:{server.server_port}"
+    server.shutdown()
+
+
+def test_read_token_map_treats_a_missing_path_as_empty(stub_server):
+    _, base = stub_server
+    _StubHandler.routes = {}
+
+    # The bootstrap case: this job's first run is what creates the path.
+    assert read_token_map(base, "token", "secret-operations/witan/actor-tokens") == {}
+
+
+def test_read_token_map_rejects_a_corrupt_payload(stub_server):
+    _, base = stub_server
+    _StubHandler.routes = {
+        "/v1/secret-operations/witan/actor-tokens": (
+            200,
+            {"data": {"tokens_json": "{not json"}},
+        )
+    }
+
+    # Continuing here would rewrite the path with a partial map.
+    with pytest.raises(SyncError, match="not valid JSON"):
+        read_token_map(base, "token", "secret-operations/witan/actor-tokens")
+
+
+def test_read_token_map_rejects_a_non_string_map(stub_server):
+    _, base = stub_server
+    _StubHandler.routes = {
+        "/v1/secret-operations/witan/actor-tokens": (
+            200,
+            {"data": {"tokens_json": json.dumps({"act-alice": {"nested": 1}})}},
+        )
+    }
+
+    with pytest.raises(SyncError, match="not a"):
+        read_token_map(base, "token", "secret-operations/witan/actor-tokens")
+
+
+def test_group_members_pages_to_the_end(stub_server):
+    _, base = stub_server
+    full_page = [member(f"u{i}") for i in range(100)]
+    tail = [member("u100")]
+    _StubHandler.routes = {
+        "/admin/realms/r/groups/g/members?first=0&max=100": (200, full_page),
+        "/admin/realms/r/groups/g/members?first=100&max=100": (200, tail),
+    }
+
+    # A short page is the only end-of-list signal Keycloak gives, so a group
+    # that lands exactly on the page size must still fetch the next one.
+    members = group_members(base, "r", "token", "g")
+
+    assert len(members) == 101
+    assert members[-1]["id"] == "u100"


### PR DESCRIPTION
### What are the relevant tickets?
N/A — tracked in the witan work graph as `tk-keycloak-witan-users-per-user-omnigraph-token-sy-8e00c7`, under the "witan multi-user service deployment" project. Follows on from #5215 (VSO restart on actor-token change) and mitodl/agent-kit#174 (client-side connect retry that absorbs the resulting restart).

### Description (What does it do?)

agent-kit ADR-0004 D3 gives every witan user their own omnigraph bearer token, keyed by the actor id derived from their Keycloak `sub`. Until now nothing produced those entries: adding a user meant a hand-edit of a SOPS file, so in practice the actor-token map only ever carried `svc-witan-ci` and the per-user identity model had no process behind it.

This adds that process — a `witan-token-sync` CronJob in the `omnigraph` namespace that enumerates the `ol-platform-engineering` realm and maintains one token per enabled human user. **Adding someone to the realm becomes the entire onboarding step**, and removing or disabling them retires their token on the next run. Users never see these tokens: witan maps a caller's validated JWT to `act-<sub>`, looks the token up, and presents it to omnigraph-server on their behalf.

**The design point worth reviewing is the Vault path split.** Rather than adding a second writer to `secret-operations/witan/actor-tokens`, ownership is divided:

| Path | Writer | Contents |
| --- | --- | --- |
| `secret-operations/witan/service-tokens` (new) | this Pulumi stack, from the existing SOPS file | non-human actors (`svc-witan-ci`, later `svc-witan-admin`) |
| `secret-operations/witan/actor-tokens` | the CronJob | the merge of that map with the realm's human users |

Two writers on one path would mean every `pulumi up` silently reverting every per-user entry — every user 401ing until the next hourly run, with an omnigraph-server restart at each end of that window.

**Carrying an existing member's token over verbatim rather than re-minting it is load-bearing, not an optimization.** The `actor-tokens` secret carries a VSO `rolloutRestartTarget` (added in #5215) and the data tier is `replicas=1`/`Recreate`, so *every* write to it is a hard ~10-30s graph outage. An unchanged membership now produces a byte-identical map and writes nothing at all, which is what keeps the restart cost proportional to real membership churn. There is a test pinning exactly this.

Other decisions, with rationale in the module docstrings:

- **In-cluster CronJob, not Concourse.** The job's whole purpose is one privileged Vault write. In-cluster it earns that via Kubernetes auth — a credential minted per run that expires on its own. From Concourse it would need a long-lived Vault credential in CI, putting a build system on the write path of the auth secret for the entire graph.
- **Stdlib-only script on a stock `python:3.12-slim`, shipped as a ConfigMap.** Both the Keycloak Admin API and the Vault API are plain JSON over HTTPS, so there is no image to build, publish, scan or keep patched, and no image-tag plumbing between two repos.
- **Least privilege on both sides.** The Keycloak service-account client holds exactly one read-only role, `view-users`, and has every interactive flow disabled. The pod writes Vault under its own ServiceAccount, Vault role and policy rather than borrowing the namespace's read-only VSO identity.
- **Refuses to write rather than write something wrong.** An empty/missing service map, a service map without `svc-witan-ci`, a realm that returns zero users, or a user colliding with a service actor all abort the run. The whole-secret replace means a bad read would otherwise silently retire `svc-witan-ci` and break the CI indexer — and report success.

#### No `witan-users` Keycloak group — changed after review feedback

The first revision of this PR created one, because ADR-0004 D3 says the job should walk "the Keycloak `witan-users` group". That was a misreading: `witan-users` is a **Cedar** group in agent-kit's policy bundles (`mcp/servers/witan/policy/server.policy.yaml`), populated with the `act-<sub>` ids this job writes. The name collision is the whole reason a Keycloak group of the same name looked mandatory.

`ol-platform-engineering` has `registration_allowed=False`, no IdP brokering and no federation — its membership is hand-managed and already exactly the intended audience. A group inside it was a second gate on an already-gated population, whose failure mode is somebody joining the realm, nobody adding them to the group, and a 401 that reads like a provisioning lag.

**Accepted trade, stated rather than buried:** realm access is now witan access. There is no longer a way to revoke witan while leaving jupyterhub/superset/opik intact.

The consequence that needed handling: enumerating a realm returns clients' own service accounts alongside people — this realm has one for `ol-opik-client` and gains another for the token-sync client itself. Minting a human's interactive read/write token for them would hand every such client the Cedar rights of a person, so they are filtered on `serviceAccountClientId`, with the `service-account-` username convention as a second signal.

The safety property the group lookup was carrying is preserved: "group does not exist" was a hard failure so a botched lookup could not retire every per-user token and call it success. The equivalent for a realm is "zero users returned", which is now the same hard failure.

### How can this be tested?

**This PR changes nothing in any environment on merge.** The feature is gated on `omnigraph:keycloak_url`, which is unset everywhere. With it off, `pulumi preview --stack CI` shows exactly one added resource — the new `service-tokens` Vault secret:

```
+  vault:generic:Secret omnigraph-service-tokens-vault-secret-ci create
Resources:
    + 1 to create
```

(A `~ vault:index:Policy omnigraph-server-vault-policy` and some `cluster-apply` Job churn also appear, but both are present on an unmodified `main` preview too — the latter is an artifact of running preview with `OMNIGRAPH_DOCKER_TAG=latest` instead of the digest the pipeline pins.)

With the switch flipped, preview constructs the full set cleanly — ServiceAccount, Vault policy, Kubernetes auth role, OIDC-credential VaultStaticSecret, script ConfigMap, bootstrap Job, CronJob:

```
+  vault:index:Policy witan-token-sync-vault-policy-ci create
+  vault:kubernetes:AuthBackendRole witan-token-sync-k8s-vault-auth-backend-role-ci create
+  ol:services:Vault:K8S:VaultStaticSecret witan-token-sync-oidc-secret-ci create
+  kubernetes:core/v1:ServiceAccount witan-token-sync-service-account-ci create
+  kubernetes:core/v1:ConfigMap witan-token-sync-script-ci create
+  kubernetes:batch/v1:Job witan-token-sync-bootstrap-ci create
+  kubernetes:batch/v1:CronJob witan-token-sync-ci create
-  vault:generic:Secret omnigraph-actor-tokens-vault-secret-ci delete
Resources:
    + 10 to create
```

That last `delete` is the ownership handover, and is why the rollout is two steps (see the Checklist).

Also run:

- `pytest tests/ol_infrastructure/applications/omnigraph/` — 16 tests, all passing. They cover the no-op-on-unchanged-membership property, carry-over vs. re-mint, retirement of departed and disabled users, service-account filtering, the service-actor collision guard, rejection of a present-but-malformed Vault payload and of a non-JSON 200, actor-id derivation matching agent-kit's `witan_core.identity.derive_actor_id`, corrupt-payload rejection, and Keycloak user paging across an exact page boundary (the case where a short page is the only end-of-list signal).
- `prek run` on all changed files — ruff format, ruff check, mypy and detect-secrets all clean.

Once enabled in CI, the end-to-end check is: add a user to the realm, then within the hour

```shell
vault kv get -field=tokens_json secret-operations/witan/actor-tokens | jq 'keys'
```

should contain their `act-<sub>` entry, and `kubectl -n omnigraph logs` for the job should name it. A dry-run mode (`WITAN_TOKEN_SYNC_DRY_RUN=1`) reports the diff without writing.

### Additional Context

**Reviewer questions I'd most like answered:**

1. **Is realm-as-audience right, given it removes per-service revocation?** Flagged above; this is the change made in response to review.
2. **Is the path split the right call?** The alternative was keeping Pulumi as sole writer and having the job write elsewhere, but the consumers read one file and nothing else can merge two Vault paths into it, so the merge has to happen at write time. If you see a third option I missed, this is the decision to push on.
3. **Is hourly the right cadence?** It is bounded by restart tolerance rather than Keycloak cost. Onboarding latency is up to an hour in the worst case; shortening it trades directly against how often a membership change can bounce the graph. Configurable per environment via `omnigraph:token_sync_schedule`.
4. **The reconciliation is a read-modify-write with no compare-and-swap behind it.** `concurrencyPolicy: Forbid` serialises the CronJob's own runs, which is sufficient given it is the only writer — but it does not protect against a concurrent break-glass `vault kv put`.

**Known gap, deliberately out of scope:** rotation is manual. The job carries tokens over rather than re-minting, so there is no automatic expiry — forcing a rotation means deleting an actor's entry and letting the next run re-mint it (documented in the runbook). Adding real rotation needs per-token issue timestamps, which cannot live in the `{actor_id: token}` map itself since both consumers parse it strictly.

`docs/witan-token-sync-runbook.md` covers the enablement sequence, manual/dry runs, rotation, and the failure modes above with the log lines that identify each.

### Checklist:
- [ ] Deploy `ol-infrastructure-substructure-keycloak` for the target environment first, so the `witan-token-sync` client exists and `secret-operations/witan/token-sync-oidc` is populated.
- [ ] **Deploy this stack with `omnigraph:keycloak_url` still unset**, then set it and deploy again — the handover is two `pulumi up`s by necessity. Pulumi reads `retainOnDelete` from state at deletion time, and I confirmed the flag is not currently in state for the `actor-tokens` resource, so it must be recorded by an interim deploy. Doing both at once deletes the Vault path; the bootstrap Job rewrites it later in the same run, but nothing orders the deletion against the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019nGkccjfp8dkRbEKYugz6B

