### PR TITLE
fix: raise Vault OIDC admin token TTL so Airbyte credentials survive

### DIFF
--- a/src/ol_infrastructure/substructure/vault/auth/__main__.py
+++ b/src/ol_infrastructure/substructure/vault/auth/__main__.py
@@ -13,7 +13,7 @@ from pulumi_vault import (
     jwt,
 )
 
-from bridge.lib.magic_numbers import EIGHT_HOURS_SECONDS
+from bridge.lib.magic_numbers import EIGHT_HOURS_SECONDS, ONE_MONTH_SECONDS
 from ol_infrastructure.lib import pulumi_projects as projects
 from ol_infrastructure.lib.ol_types import AWSBase, Environment
 from ol_infrastructure.lib.pulumi_helper import (
@@ -150,10 +150,16 @@ developer_role = jwt.AuthBackendRole(
 admin_role = jwt.AuthBackendRole(
     "admin-role",
     backend=vault_oidc_keycloak_auth.path,
-    # Pinned rather than inheriting Vault's system default, which is far longer
-    # than a working session needs.
-    token_ttl=EIGHT_HOURS_SECONDS,
-    token_max_ttl=EIGHT_HOURS_SECONDS,
+    # Longer than the eight hours a working session needs, because dynamic
+    # secrets are children of the token that created them: an eight-hour admin
+    # token means every credential minted through it dies in eight hours too.
+    # Airbyte stores connector credentials once and has no way to renew a lease,
+    # so its hand-issued source credentials were expiring the same day they were
+    # entered. Interim measure -- mitodl/hq#12319 moves Airbyte's source
+    # credentials to Vault static roles, at which point this drops back to
+    # EIGHT_HOURS_SECONDS.
+    token_ttl=ONE_MONTH_SECONDS,
+    token_max_ttl=ONE_MONTH_SECONDS,
     role_name="admin",
     token_policies=[admin_policy.name],
     allowed_redirect_uris=[


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Raises `token_ttl` / `token_max_ttl` on the Vault OIDC **admin** role from eight hours to thirty days. `readonly` and `developer` are unchanged.

In Vault, a dynamic secret's lease is a child of the token that created it — when the token expires, its leases are revoked with it, regardless of the secret engine role's own TTL. https://github.com/mitodl/ol-infrastructure/pull/5133 pinned all three OIDC roles to eight hours (they had previously inherited Vault's much longer system default), which had the side effect of capping every credential minted during an admin session at eight hours.

Airbyte stores connector configuration once and has no mechanism for renewing a lease, so source credentials issued by hand through an admin session were being revoked the same day they were entered, with no automated path to replace them.

Server-side `max_lease_ttl` is six months (`src/bilder/images/vault/deploy.py`), so thirty days is not clipped.

**This is deliberately interim.** The RFC at https://github.com/mitodl/hq/discussions/12319 (implementation step 5) moves Airbyte's source credentials to Vault *static* database roles, which removes the lease mismatch at its root. The code comment records that the admin role drops back to `EIGHT_HOURS_SECONDS` once that lands, so the thirty-day value doesn't quietly become the steady state.

### How can this be tested?
`pulumi preview` on `ol-substructure-vault-auth/operations.Production` shows one resource updating and nothing else:

```
~ vault:jwt/authBackendRole:AuthBackendRole: (update)
    [id=auth/oidc/role/admin]
  ~ boundClaims: {
      ~ roles: "admin,vault-admins" => "admin, vault-admins"
    }
  ~ tokenMaxTtl: 28800 => 2592000
  ~ tokenTtl   : 28800 => 2592000

Resources:
    ~ 1 to update
    32 unchanged
```

The `boundClaims` whitespace diff is pre-existing drift from Vault normalising the stored value — it is not introduced by this change and will settle on the next apply.

After applying, `vault login -method=oidc role=admin` followed by `vault token lookup` should report a TTL of `720h`. A dynamic credential generated from that session (e.g. a database secret engine read) should then carry a lease that is no longer truncated to eight hours.

pre-commit (ruff format, ruff check, mypy) passes on the changed file.

### Additional Context
The tradeoff worth reviewing rather than rubber-stamping: this widens the window on a compromised admin session from eight hours to thirty days, and it applies to **every** admin OIDC login, not only the one that issues Airbyte's credentials.

The narrower alternative is to skip the token TTL entirely and move just the Airbyte source DB roles to Vault static roles now — RFC step 5 pulled forward and decoupled from the inventory/Terraform work. That removes the lease problem instead of stretching it, at the cost of more work up front. Happy to take that route instead if reviewers would rather not carry the exposure in the interim.
