### PR TITLE
fix(superset): stop Helm tpl from parsing a comment as a Go template

### DIFF
--- a/src/ol_infrastructure/applications/superset/superset_config.py
+++ b/src/ol_infrastructure/applications/superset/superset_config.py
@@ -1,4 +1,10 @@
 # ruff: noqa: ERA001
+#
+# This file is injected into the Superset Helm chart via `configOverrides`, and
+# the chart pipes that value through Helm's `tpl` function. Anything that looks
+# like a Go template action -- `{`+`{ ... }`+`}`, even inside a comment or a
+# string -- is evaluated at render time and fails the whole release. Never write
+# doubled curly braces here.
 import logging
 import os
 import re
@@ -700,7 +706,7 @@ def _interpolate_env_vars(value: str | None) -> str | None:
 
 # The bind address and port are not configurable from here: `superset mcp run`
 # takes them as CLI flags, and the chart's supersetMcp.command already passes
-# --host 0.0.0.0 --port {{ supersetMcp.service.port }}.
+# --host 0.0.0.0 with the port from supersetMcp.service.port.
 #
 # Public-facing base URL for MCP-generated links (e.g. chart preview URLs).
 # Injected at runtime via SUPERSET_MCP_PUBLIC_URL env var set in Pulumi.


### PR DESCRIPTION
### What are the relevant tickets?
N/A — regression from https://github.com/mitodl/ol-infrastructure/pull/4693

### Description (What does it do?)
Every Superset Pulumi deploy has failed since 2026-07-31. The last green CI build was 125; builds 126 through 133 are all red, and QA/Production are blocked behind CI in the job chain.

The Superset Helm chart pipes `configOverrides` through Helm's `tpl` function, so the entire `superset_config.py` is rendered as a Go template before it is written into the config secret. A comment added in #4693 documenting the chart's MCP launch command quoted the chart's own templating verbatim:

```python
# --host 0.0.0.0 --port {{ supersetMcp.service.port }}.
```

`tpl` parsed that as a function call and aborted:

```
kubernetes:helm.sh/v3:Release superset-helm-release updating; error:
template: superset/templates/secret-superset-config.yaml:33:8: executing
"superset/templates/secret-superset-config.yaml" at <include "superset.config" .>:
error calling include: template: superset/templates/_helpers.tpl:670:3: executing
"superset.config" at <tpl $value $>: error calling tpl: cannot parse template
"# ruff: noqa: ERA001\nimport logging\n...":
template: gotpl:703: function "supersetMcp" not defined
```

Because rendering fails before `helm upgrade` writes a release revision, this left no trace in Helm history — `helm history superset -n superset` on the CI cluster still shows revision 69 (2026-07-30) as `deployed`, which made it look like Pulumi was never reaching Helm at all. `pulumi preview` also passes clean, since preview never renders the chart.

This PR rewords the comment so it no longer contains Go template delimiters, and adds a file-level warning at the top of `superset_config.py` explaining that doubled curly braces anywhere in the file — comments and strings included — are evaluated by `tpl` at render time.

Superset is the only stack in this repo that feeds a file through a chart's `configOverrides`, so nothing else is exposed to the same trap.

### How can this be tested?

Render chart 0.22.3 with `supersetMcp.enabled=true` and this file as `configOverrides.config`, before and after the change:

```bash
helm repo add superset https://apache.github.io/superset
helm pull superset/superset --version 0.22.3 --untar
# values.json: {"configOverrides": {"config": "<contents of superset_config.py>"},
#               "supersetMcp": {"enabled": true}, "ingress": {"enabled": false},
#               "postgresql": {"enabled": false}, "redis": {"enabled": false}}
helm template superset ./superset -f values.json
```

- Before: fails with `template: gotpl:703: function "supersetMcp" not defined` — the exact error from CI build 133.
- After: renders cleanly, including `deployment-mcp.yaml` and `service-mcp.yaml`.

`pre-commit run --files src/ol_infrastructure/applications/superset/superset_config.py` passes (ruff format, ruff check, mypy, detect-secrets).

After merge, the `docker-pulumi-superset` deploy chain should go green for CI, then QA, then Production, and the `superset-mcp` Deployment/Service from #4693 should finally appear in each cluster — they have never been created, since no MCP-enabled Helm upgrade has ever succeeded.

### Additional Context

The failure signature is worth remembering: a Pulumi update that fails ~30s after a successful refresh, with **no** corresponding entry in `helm history`, means the chart failed during template rendering rather than during apply. A failed apply (for example the immutable-selector errors on this same release in July, revisions 60–62) does record a `failed` revision.
