### PR TITLE
fix(superset): probe the MCP port with tcpSocket, not a nonexistent /health

### DIFF
--- a/src/ol_infrastructure/applications/superset/__main__.py
+++ b/src/ol_infrastructure/applications/superset/__main__.py
@@ -597,6 +597,21 @@ _LOGO_FILENAME = "ol-data-platform-logo.svg"
 _LOGO_CONFIGMAP_NAME = "superset-logo"
 _LOGO_MOUNT_PATH = f"/app/superset/static/assets/images/{_LOGO_FILENAME}"
 
+# "mcp" is the container port name the chart assigns to supersetMcp.service.port.
+# `httpGet: None` is load-bearing: Helm deep-merges these over the chart's
+# defaults rather than replacing them, so without an explicit null the chart's
+# default httpGet block survives alongside tcpSocket and the API server rejects
+# the pod for declaring two probe handlers.
+_MCP_TCP_PROBE = {
+    "httpGet": None,
+    "tcpSocket": {"port": "mcp"},
+    "initialDelaySeconds": 15,
+    "timeoutSeconds": 3,
+    "periodSeconds": 15,
+    "failureThreshold": 3,
+    "successThreshold": 1,
+}
+
 logo_configmap = kubernetes.core.v1.ConfigMap(
     "superset-logo-configmap",
     metadata=kubernetes.meta.v1.ObjectMetaArgs(
@@ -723,6 +738,19 @@ superset_chart = kubernetes.helm.v3.Release(
                     "limits": {"cpu": "500m", "memory": "512Mi"},
                     "requests": {"cpu": "100m", "memory": "256Mi"},
                 },
+                # The chart defaults every MCP probe to `httpGet /health`, but
+                # Superset 6.1.0 exposes health_check as an MCP *tool*, not an
+                # HTTP route -- the FastMCP app only serves the streamable-HTTP
+                # endpoint, so /health returns 404 and the pods never pass their
+                # startup probe. Probe the socket instead; a plain GET to the
+                # MCP endpoint is not a valid probe either, since it expects
+                # JSON-RPC with an SSE Accept header.
+                # Startup budget of 15s + 30*5s = 165s, comfortably inside the
+                # 300s Helm wait that this Release is subject to.
+                "startupProbe": _MCP_TCP_PROBE
+                | {"periodSeconds": 5, "failureThreshold": 30},
+                "readinessProbe": _MCP_TCP_PROBE,
+                "livenessProbe": _MCP_TCP_PROBE,
             },
             "serviceAccount": {
                 "create": True,


### PR DESCRIPTION
### What are the relevant tickets?
N/A — follow-up to https://github.com/mitodl/ol-infrastructure/pull/5255, second regression from https://github.com/mitodl/ol-infrastructure/pull/4693

### Description (What does it do?)
#5255 fixed the Go-template bug that was aborting Helm rendering. With rendering unblocked, the CI deploy got far enough to actually create the MCP pods for the first time — and immediately hit a second, independent bug that the first one had been masking.

The chart defaults every `supersetMcp` probe to `httpGet /health`, but Superset 6.1.0 exposes `health_check` as an **MCP tool**, not an HTTP route — the FastMCP app only serves the streamable-HTTP endpoint (see https://github.com/apache/superset/blob/6.1.0/superset/mcp_service/app.py#L86). So the pods answered 404:

```
Warning  Unhealthy  pod/superset-mcp-6c6cc94555-nmslt
  Startup probe failed: HTTP probe failed with statuscode: 404
Warning  Unhealthy  pod/superset-mcp-6c6cc94555-j26r6
  Startup probe failed: HTTP probe failed with statuscode: 404
```

`helm upgrade` waited the full 300s, timed out, and rolled back:

```
$ helm history superset -n superset
70   Wed Aug  5 14:08:42 2026   failed   superset-0.22.3   6.1.0   Upgrade "superset" failed: context deadline exceeded
```

Because `cleanup_on_fail` is set on the Release, the MCP Deployment and Service were created and then deleted again — which is why `kubectl get svc -n superset` on the CI cluster still shows only `superset`, with no `superset-mcp`, despite the deploy job reporting success on its retry.

This PR switches the three MCP probes to `tcpSocket` on the named `mcp` port. That restores the intent of the original hand-rolled Deployment in #4693, which used `tcpSocket` precisely because the MCP endpoint speaks JSON-RPC and rejects a bare `GET`. The startup budget is 15s + 30×5s = 165s, comfortably inside the 300s Helm wait.

**`httpGet: None` is load-bearing.** Helm deep-merges these overrides onto the chart defaults rather than replacing them, so without the explicit null the chart's default `httpGet` block survives alongside `tcpSocket` and the API server rejects the pod for declaring two probe handlers.

### How can this be tested?

Both halves of the `httpGet: None` behaviour were verified before pushing.

**1. Helm drops the default when the key is null.** Rendering `deployment-mcp.yaml` from chart 0.22.3 with `tcpSocket` overrides but *without* the null produces an invalid probe carrying both handlers:

```yaml
startupProbe:
  failureThreshold: 30
  httpGet:
    path: /health
    port: mcp
  periodSeconds: 5
  tcpSocket:
    port: mcp
```

Adding `httpGet: null` yields the intended result:

```yaml
startupProbe:
  failureThreshold: 30
  initialDelaySeconds: 15
  periodSeconds: 5
  successThreshold: 1
  tcpSocket:
    port: mcp
  timeoutSeconds: 3
```

**2. Pulumi marshals the null through** rather than stripping it. `pulumi preview -s CI --diff` on this branch:

```
+ startupProbe  : {
    + httpGet            : <null>
    + tcpSocket          : {
        + port: "mcp"
      }
  }
```

`pulumi preview -s CI` is otherwise clean (`~ 1 to update, 85 unchanged`), and `pre-commit run --files src/ol_infrastructure/applications/superset/__main__.py` passes.

After merge, the CI deploy should complete without the 300s Helm timeout, and `superset-mcp` should finally persist:

```bash
kubectl --context data-ci get pods,svc -n superset | grep mcp
helm history superset -n superset   # newest revision should be `deployed`, not `failed`
```

### Additional Context

`tcpSocket` is a weaker readiness signal than a real health endpoint — it confirms the listener is up, not that the MCP server can serve tools. That is the same tradeoff #4693 originally accepted. If a future Superset release adds a genuine HTTP health route for the MCP service, these overrides should be dropped in favour of the chart defaults.

Worth noting for anyone auditing the CI history: the deploy job for build 134 reported **success** even though the Helm release ended in a `failed` revision with the MCP workload rolled back. The pipeline retried after the timeout, and the retry saw no pending diff and exited clean. A green job on this pipeline is therefore not by itself proof that the release converged.
