### PR TITLE
docs(omnigraph): runbook + ADR-0009 addendum for a storage-format-bump upgrade

### DIFF
--- a/docs/adr/0009-deploy-witan-as-shared-multi-tenant-mcp-service.md
+++ b/docs/adr/0009-deploy-witan-as-shared-multi-tenant-mcp-service.md
@@ -285,6 +285,48 @@ the project/namespace renames needed no Pulumi state migration or aliases.
 from the foreign `mitodl/agent-kit` repo and gates its `pulumi_jobs_chain` on
 that build. See `src/ol_concourse/pipelines/infrastructure/{omnigraph,witan}/`.
 
+## Addendum (2026-08-05) — a storage-format bump is not a deploy; see the runbook
+
+The data tier's `strategy=Recreate` (2026-07-17 addendum, `data_tier.py`) covers
+*same*-format restarts: it tears the old pod down before the new one starts, so
+two binaries never write one S3 store. It does **not** cover an image bump that
+changes the storage format.
+
+omnigraph storage is strict-single-version — a binary reads exactly one
+internal-schema version, there is no in-place migration, and the gate is
+enforced on read-only opens too. Against a format-bumping image, Recreate
+starts the new pod on a store it refuses to open: the rollout fails on the
+version gate and the environment stays down until it is rolled back or the
+graphs are rebuilt offline. Nothing is corrupted — the graph is simply
+unreadable by the image that was just shipped.
+
+That rebuild is **export → `cluster apply` → `load` under a new storage root**,
+one pass over every declared graph (`council`, `code-bridge`, and one
+`code-<repo>` per `omnigraph:managed_repos` — 16 on CI today), with the old root
+left intact as the rollback. Ids stay identical, so clients — which address
+graphs by id, never by path — are unaffected.
+
+The procedure, the detection test that tells a format bump apart from an
+ordinary one, and the rollback are in
+[docs/omnigraph-storage-format-upgrade-runbook.md](../omnigraph-storage-format-upgrade-runbook.md).
+Two findings from validating it against the live CI deployment are worth
+recording here, since both contradict a reasonable reading of the CLI's help:
+
+- **`--cluster` does not address data commands.** `export`/`load`/`init`/
+  `snapshot` reach a cluster-managed graph by its store URI
+  (`--store <root>/graphs/<graph-id>.omni`); `--cluster <root> --graph <id>` is
+  for `optimize`/`repair`/`cleanup`/`cluster *` only and errors on the rest.
+- **`manifest_version` is not the format version.** `snapshot` reports both;
+  only `internal_schema_version` is what the gate compares, and
+  `manifest_version` legitimately differs between graphs in one cluster.
+
+This addendum records a consequence of the existing decision rather than
+changing it. One follow-on is required to make the runbook executable as
+written: the storage root is derived (`ol-data-witan-<env>`) with no override,
+so repointing it is a code edit today. A prefix within the existing bucket is a
+valid root (`cluster validate` accepts it), so the override is a config key, not
+a new bucket or IRSA change.
+
 ## Implementation Notes
 
 - **Effort Estimate:** Multi-week — spans a concurrency-behavior spike, witan
@@ -339,5 +381,6 @@ spanning both repos.
 | 2026-07-07 | _Pending_ | _Pending_ | Created during agentic scoping session |
 | 2026-07-07 | Tobias Macey | Approved | Accepted after Copilot automated review feedback addressed (RFC citation, ADR index, self-containment) |
 | 2026-07-17 | Tobias Macey | Amended | Added 2026-07-17 addendum: split `toolhive_witan` into separate `omnigraph` + `witan` projects/namespaces; dropped `toolhive` from element naming |
+| 2026-08-05 | Tobias Macey | Amended | Added 2026-08-05 addendum: storage-format bumps need the offline export/rebuild runbook, not a Recreate restart |
 
-**Last Updated:** 2026-07-17
+**Last Updated:** 2026-08-05

--- a/docs/adr/0009-deploy-witan-as-shared-multi-tenant-mcp-service.md
+++ b/docs/adr/0009-deploy-witan-as-shared-multi-tenant-mcp-service.md
@@ -321,11 +321,12 @@ recording here, since both contradict a reasonable reading of the CLI's help:
   `manifest_version` legitimately differs between graphs in one cluster.
 
 This addendum records a consequence of the existing decision rather than
-changing it. One follow-on is required to make the runbook executable as
-written: the storage root is derived (`ol-data-witan-<env>`) with no override,
-so repointing it is a code edit today. A prefix within the existing bucket is a
-valid root (`cluster validate` accepts it), so the override is a config key, not
-a new bucket or IRSA change.
+changing it. One follow-on is worth doing before the procedure is ever needed
+in anger: the storage root is derived (`ol-data-witan-<env>`) with no config
+override, so repointing it is an edit to `data_tier.py` — done under outage
+pressure, on the step where a mistake silently leaves the cluster on the old
+root. A prefix within the existing bucket is a valid root (`cluster validate`
+accepts it), so the override is a config key, not a new bucket or IRSA change.
 
 ## Implementation Notes
 

--- a/docs/omnigraph-storage-format-upgrade-runbook.md
+++ b/docs/omnigraph-storage-format-upgrade-runbook.md
@@ -400,11 +400,21 @@ grant and the versioning config.
 Confirm the generated config before applying:
 
 ```shell
-pulumi preview --stack <CI|QA|Production> --diff | grep -A5 'cluster.yaml'
+pulumi preview --stack <CI|QA|Production> --diff | grep -E '^\s*[-+]?\s*storage:'
 ```
 
-The `storage:` line must show the new root. If it does not, stop — the deploy
-will silently no-op back onto the old root.
+Expect a `-`/`+` pair showing the old root replaced by the new one. **Empty
+output means the edit did not take** — the ConfigMap is unchanged and the deploy
+will no-op back onto the old root. Stop and fix the edit rather than applying.
+
+If the diff is hard to read (the ConfigMap `data` renders as one blob), fall
+back to the generated value itself:
+
+```shell
+pulumi preview --stack <CI|QA|Production> --json \
+  | jq -r '.steps[]?.newState?.inputs?.data?["cluster.yaml"] // empty' \
+  | grep '^storage:'
+```
 
 Then let the paused pipeline's deploy job for this environment run (or
 `pulumi up` directly with `OMNIGRAPH_DOCKER_SHA` set to the new digest).

--- a/docs/omnigraph-storage-format-upgrade-runbook.md
+++ b/docs/omnigraph-storage-format-upgrade-runbook.md
@@ -1,0 +1,381 @@
+# omnigraph storage-format upgrade runbook
+
+How to roll out an `omnigraph-server` image whose binary bumps the **storage
+format**, why the ordinary deploy cannot do it, and how to tell the two cases
+apart before you start.
+
+Commands here were checked against the live CI deployment on 2026-08-05
+(`operations-ci`, omnigraph 0.8.1, `internal-schema 4`). The read-only and
+addressing steps are verified; the two write steps that rebuild a graph are
+marked where they are not.
+
+## When this applies
+
+omnigraph storage is strict-single-version: a binary reads exactly one
+internal-schema (storage-format) version, there is no in-place migration, and
+the version gate is enforced in both directions — including read-only opens. A
+mixed fleet where an old binary still writes a graph a newer binary has stamped
+is unsupported; there is no mixed-version window.
+
+The data tier is already built for the *same*-format case. `applications/omnigraph`
+runs a single replica with `strategy=Recreate` (`data_tier.py`), so the old pod
+is gone before the new one starts and the two binaries never touch S3 at once.
+That is the whole of what Recreate buys, and it is enough for every normal image
+bump.
+
+It is **not** enough when the new binary changes the format. Recreate still
+starts the new pod against a store the new binary refuses to open, and the
+rollout fails on the version gate rather than corrupting anything. The graph is
+intact; it is simply unreadable by the image you just shipped, and stays that
+way until you either roll back or run the offline rebuild below.
+
+> This is the "offline export/rebuild" path referenced from `data_tier.py`'s
+> `strategy=Recreate` comment and from
+> [ADR-0009](adr/0009-deploy-witan-as-shared-multi-tenant-mcp-service.md).
+
+## First: is this actually a format bump?
+
+Most image bumps are not, and running this procedure on one buys an outage for
+nothing. There are two numbers, and only one of them is the gate.
+
+**The binary's format version** — `omnigraph version`, second line:
+
+```console
+$ kubectl -n omnigraph exec deploy/omnigraph-server -- omnigraph version
+omnigraph 0.8.1
+internal-schema 4
+```
+
+**The store's format version** — `omnigraph snapshot`, third line:
+
+```console
+$ kubectl -n omnigraph exec deploy/omnigraph-server -- \
+    omnigraph snapshot --store s3://ol-data-witan-ci/graphs/council.omni
+branch: main
+manifest_version: 4
+internal_schema_version: 4
+edge:Addresses v1 branch=main rows=0
+…
+```
+
+> **`manifest_version` is not the format version.** It is a per-store manifest
+> revision counter and legitimately differs between graphs in the same cluster —
+> on CI, `council` reads `manifest_version: 4` and
+> `code-github-com-mitodl-agent-kit` reads `3`, while both are
+> `internal_schema_version: 4`. Compare `internal-schema` (binary) against
+> `internal_schema_version` (store). Nothing else.
+
+Ask the candidate image directly rather than reading release notes — both images
+carry the `omnigraph` CLI alongside the server:
+
+```shell
+kubectl -n omnigraph run omnigraph-version-probe --rm -it --restart=Never \
+  --image=<new-image-ref> --command -- omnigraph version
+```
+
+Same number as the deployed stores → ordinary deploy, stop reading. Different
+number → continue.
+
+## Before you start
+
+- **Pause the `pulumi-omnigraph` Concourse pipeline.** The chain is
+  `build-omnigraph-server-image` → CI → QA → Production, each stage triggering
+  on the previous stage having deployed *that same image*
+  (`src/ol_concourse/pipelines/infrastructure/omnigraph/pipeline.py`). Unpaused,
+  it keeps promoting a format-bumping image into the next environment while you
+  are still migrating this one. Pause it before the build lands, or as soon as
+  you see the failed CI deploy.
+- **CI, then QA, then Production**, each with a soak. This rebuilds every graph;
+  do it once somewhere cheap first.
+- **Size the outage.** The data tier is down for the whole procedure — this is
+  not a rolling change. Duration scales with total graph size.
+
+  As of 2026-08-05 every environment's `council` is empty (0 rows in every
+  table) and the code graphs are effectively unpopulated, so a migration today
+  is minutes. Re-measure once real data lands rather than trusting that number.
+- **Write down the old image digest.** It is the rollback.
+
+## What gets rebuilt
+
+Every graph in the cluster, not just `council`. `build_cluster_graphs()`
+declares:
+
+| Graph id | Schema | Source |
+| --- | --- | --- |
+| `council` | `schema.pg` | fixed — the Layer-1 memory/task/workflow graph |
+| `code-bridge` | `bridge-schema.pg` | fixed — the Layer-2.5 cross-repo bridge |
+| `code-<repo>` | `code-schema.pg` | one per entry in `omnigraph:managed_repos` |
+
+CI currently declares 16 graphs. Enumerate from the running config, not from
+`managed_repos` — the ids are derived, and re-deriving them by hand is how you
+drop one:
+
+```shell
+kubectl -n omnigraph get configmap omnigraph-cluster-config \
+  -o jsonpath='{.data.cluster\.yaml}' | yq '.graphs | keys'
+```
+
+Then cross-check against what is actually in the bucket, which is not
+necessarily the same set:
+
+```shell
+aws s3 ls s3://ol-data-witan-<env>/graphs/
+```
+
+CI has a `main.omni/` in the bucket that no longer appears in cluster.yaml — a
+leftover from before the `council` rename. Undeclared stores are not served and
+not migrated by `cluster apply`; decide deliberately whether each one is dead
+(leave it, or clean it up separately) rather than discovering it mid-migration.
+
+## The shape of the migration
+
+The old store is never modified and never moved. Lance embeds absolute paths, so
+a store cannot be relocated with `mv`/`cp` — only rebuilt via `export` →
+`init`/`load`. That constraint drives the design:
+
+**Rebuild under a new storage root, keeping every graph id identical.** Clients
+address graphs by id (`WITAN_MEMORY_GRAPH=council`; witan-code's `graph_id()`
+for `code-<repo>`), never by storage path, so a new root is invisible to them.
+The old root stays byte-for-byte intact, making rollback a config change rather
+than a restore.
+
+The root can be a **prefix inside the existing bucket** — `cluster validate`
+accepts `storage: s3://ol-data-witan-ci/_fmt-drill`, verified 2026-08-05. So no
+new bucket, no new IRSA policy (the existing grant is `<bucket-arn>/*`), and no
+change to backups. Use `s3://ol-data-witan-<env>/fmt<N>` for new format `<N>`.
+
+The alternative — rebuilding in place at the same paths — would require deleting
+each old store first, leaving S3 object versioning as the only rollback. Do not
+do that. Reassembling a Lance store from thousands of object versions is not a
+recovery path anyone should be attempting under time pressure.
+
+> **Prerequisite, read before scheduling.** The storage root is derived, not
+> configurable: `data_tier.py` sets
+> `bucket_name = f"ol-data-witan-{stack_info.env_suffix}"` and builds `storage:`
+> from it, so step 5 is a code edit today. An `omnigraph:storage_root` override
+> — an optional config key that replaces the derived storage URI in cluster.yaml
+> while leaving bucket creation and IRSA alone — is what makes this runbook
+> executable as written. Tracked in the witan project backlog.
+
+## Addressing: `--store`, not `--cluster`
+
+The one thing most likely to waste your time. `--cluster <root> --graph <id>` is
+for **maintenance** commands only (`optimize`, `repair`, `cleanup`, `cluster *`).
+Data commands reject it:
+
+```console
+$ omnigraph snapshot --cluster s3://ol-data-witan-ci --graph council
+Error: `snapshot` is a data command; --cluster addresses a cluster-scoped
+command and does not apply.
+```
+
+`export`, `load`, `init`, and `snapshot` address a cluster graph by its store
+URI, which is `<root>/graphs/<graph-id>.omni`:
+
+```shell
+omnigraph snapshot --store s3://ol-data-witan-ci/graphs/council.omni
+```
+
+The cluster's own state ledger lives at `<root>/__cluster/state.json`.
+
+## Procedure
+
+`$ENV` is the lowercased env suffix (`ci`, `qa`, `production`), `$OLD_ROOT` is
+`s3://ol-data-witan-$ENV`, `$NEW_ROOT` is `$OLD_ROOT/fmt<N>`.
+
+All CLI work runs in-cluster as a one-off pod on the `omnigraph-server`
+ServiceAccount, which carries the bucket's IRSA grant — no human AWS credentials,
+and it is the `svc-witan-admin` break-glass identity (agent-kit ADR-0005 path
+(b)) rather than a side channel.
+
+### 1. Take the graph out of the serving set
+
+```shell
+kubectl -n omnigraph scale deploy/omnigraph-server --replicas=0
+kubectl -n omnigraph rollout status deploy/omnigraph-server --timeout=120s
+```
+
+Nothing may write to the old root from here until the migration completes or
+rolls back. Confirm no maintenance job is mid-run — `optimize`/`cleanup` write:
+
+```shell
+kubectl -n omnigraph get jobs
+```
+
+### 2. Record the baseline
+
+Per-table row counts, from `snapshot`, for every graph. This is what step 6
+checks against, and it is the only thing that catches a load that silently
+dropped a table:
+
+```shell
+for g in $(cat /tmp/graph-ids.txt); do
+  echo "== $g"
+  omnigraph snapshot --store "$OLD_ROOT/graphs/$g.omni" | grep -E 'rows=|internal_schema'
+done | tee /tmp/baseline.txt
+```
+
+### 3. Export every graph with the OLD binary
+
+Start a workspace pod on the currently-deployed image:
+
+```shell
+kubectl -n omnigraph run omnigraph-migrate-old --restart=Never \
+  --image=<OLD-image-ref> \
+  --overrides='{"spec":{"serviceAccountName":"omnigraph-server"}}' \
+  --env=AWS_REGION=us-east-1 --command -- sleep 86400
+kubectl -n omnigraph exec -it omnigraph-migrate-old -- sh
+```
+
+```shell
+mkdir -p /tmp/export
+for g in $(cat /tmp/graph-ids.txt); do
+  omnigraph export --store "$OLD_ROOT/graphs/$g.omni" > "/tmp/export/$g.jsonl"
+done
+aws s3 cp --recursive /tmp/export "$OLD_ROOT/_migration/<date>/"
+```
+
+Copy the exports off the pod (a scratch prefix in the bucket is simplest — the
+SA can already write it). A failure here is a clean stop: nothing has changed,
+so scale back to 1 and investigate.
+
+### 4. Rebuild at the new root with the NEW binary
+
+> Steps 4 and 5 are the write path and have **not** been rehearsed end to end —
+> the addressing, `cluster validate`, and the schema layout below are verified
+> against CI, but `cluster apply` at a new root and `load --mode merge` are not.
+> Do a full drill against a scratch prefix in CI before running this on
+> Production.
+
+Start a second pod on the **new** image, same ServiceAccount, and pull the
+exports back down. Build a config directory holding the baked-in schemas plus a
+cluster.yaml that is the live one with `storage:` repointed:
+
+```shell
+mkdir -p /tmp/rebuild
+cp /etc/omnigraph/cluster/*.pg /tmp/rebuild/     # schema.pg, code-schema.pg, bridge-schema.pg
+kubectl -n omnigraph get configmap omnigraph-cluster-config \
+  -o jsonpath='{.data.cluster\.yaml}' > /tmp/rebuild/cluster.yaml
+# edit only: storage: s3://ol-data-witan-$ENV/fmt<N>
+omnigraph cluster validate --config /tmp/rebuild
+```
+
+`cluster validate` is read-only and catches a mis-edited storage URI or an
+unresolvable `schema:` reference before anything is written. Then create every
+declared graph, empty, with the new binary's schemas:
+
+```shell
+omnigraph cluster apply --config /tmp/rebuild --as svc-witan-admin
+```
+
+And load each export:
+
+```shell
+for g in $(cat /tmp/graph-ids.txt); do
+  omnigraph load --store "$NEW_ROOT/graphs/$g.omni" \
+    --data "/tmp/export/$g.jsonl" --mode merge --yes
+done
+```
+
+`--mode merge` into a freshly-created empty graph is equivalent to a full load
+and is the safe choice — `overwrite` is destructive and buys nothing here.
+`--yes` is required because a non-local destructive write refuses without a TTY.
+
+### 5. Repoint the cluster and deploy the new image
+
+```shell
+cd src/ol_infrastructure/applications/omnigraph
+pulumi config set omnigraph:storage_root "$NEW_ROOT" --stack <CI|QA|Production>
+```
+
+Then let the paused pipeline's deploy job for this environment run (or
+`pulumi up` directly with `OMNIGRAPH_DOCKER_SHA` set to the new digest).
+
+The deploy regenerates cluster.yaml against the new root, runs its own
+`cluster apply` Job — a no-op, since step 4 already converged that root — and
+starts the Deployment on the rebuilt graphs. The pod-template config hash
+changes with cluster.yaml, so the restart happens on its own.
+
+### 6. Verify before releasing the outage
+
+```shell
+kubectl -n omnigraph exec deploy/omnigraph-server -- omnigraph version
+kubectl -n omnigraph exec deploy/omnigraph-server -- \
+  omnigraph snapshot --store "$NEW_ROOT/graphs/council.omni" | head -3
+```
+
+`internal_schema_version` must now match the new binary's `internal-schema`.
+Then diff per-table row counts for every graph against `/tmp/baseline.txt`.
+
+A graph that opens cleanly while missing half its rows looks perfectly healthy
+to `/healthz`, so the count diff is the check that matters. Finish by exercising
+a real client path (a `recall`, a `task_ready`) rather than trusting probes.
+
+### 7. Retire the old root
+
+**Not the same day.** Leave `$OLD_ROOT/graphs/` untouched through at least one
+full soak — a week for Production — because it is the only fast rollback. Delete
+it only after the next environment has migrated successfully too.
+
+## Rollback
+
+Before step 5 there is nothing to roll back: scale to 1 and you are on the old
+image against the old root.
+
+After step 5:
+
+```shell
+pulumi config rm omnigraph:storage_root --stack <CI|QA|Production>
+# redeploy with OMNIGRAPH_DOCKER_SHA pinned to the OLD image digest
+```
+
+The old root was never written to, so this is a revert, not a restore. Writes
+that landed on the new root after step 5 are lost — which is the real reason
+step 6 happens before you tell anyone the service is back.
+
+## Troubleshooting
+
+**The rollout fails on the version gate and you have not migrated.** Expected —
+this is the failure this runbook exists for, and the store is undamaged. Pause
+the pipeline so the image stops promoting, redeploy the old digest to restore
+service, then schedule the migration.
+
+**`cluster apply` fails holding a state lock.** The state ledger
+(`<root>/__cluster/state.json`) is locked; `cluster apply` is single-writer by
+design. If a previous attempt died mid-run, clear it deliberately — the lock id
+comes from `cluster status` or from the `state_lock_held` diagnostic, and is a
+required argument:
+
+```shell
+omnigraph cluster status --config /tmp/rebuild
+omnigraph cluster force-unlock <LOCK_ID> --config /tmp/rebuild --as svc-witan-admin
+```
+
+**A `code-<repo>` graph is missing after the rebuild.** Its id is derived by
+`code_graph_id()` in `data_tier.py`, mirroring `witan_code.config.graph_id` in
+agent-kit. Enumerating from `managed_repos` instead of from the live cluster.yaml
+will drop any repo whose normalization you got wrong. Re-check against the
+ConfigMap listing in *What gets rebuilt*.
+
+**Row counts do not match.** Do not release the outage. The exports are in
+`$OLD_ROOT/_migration/<date>/` and the old root is intact — roll back and
+reconcile offline. A partial load is the one outcome worse than a failed one,
+because it looks like success.
+
+## Not needed for
+
+- an ordinary image bump at the same format — `Recreate` handles it;
+- a **schema** change (adding a field to `schema.pg`) — the pre-deploy
+  `cluster apply` Job converges those on every deploy;
+- adding a managed repo — a cluster.yaml change the same Job handles.
+
+## References
+
+- [ADR-0009](adr/0009-deploy-witan-as-shared-multi-tenant-mcp-service.md) — the
+  two-tier deployment this operates on; see its storage-format addendum.
+- `src/ol_infrastructure/applications/omnigraph/data_tier.py` — the Deployment,
+  `Recreate` strategy, cluster.yaml generation, and `cluster apply` Job.
+- `src/ol_concourse/pipelines/infrastructure/omnigraph/pipeline.py` — the
+  build-and-promote chain to pause.
+- [witan token sync runbook](witan-token-sync-runbook.md) — the other
+  operational path that restarts this Deployment.

--- a/docs/omnigraph-storage-format-upgrade-runbook.md
+++ b/docs/omnigraph-storage-format-upgrade-runbook.md
@@ -108,11 +108,23 @@ declares:
 
 CI currently declares 16 graphs. Enumerate from the running config, not from
 `managed_repos` — the ids are derived, and re-deriving them by hand is how you
-drop one:
+drop one. Produce a plain one-id-per-line list, because every loop below reads
+it:
 
 ```shell
 kubectl -n omnigraph get configmap omnigraph-cluster-config \
-  -o jsonpath='{.data.cluster\.yaml}' | yq '.graphs | keys'
+  -o jsonpath='{.data.cluster\.yaml}' | yq -r '.graphs | keys | .[]' \
+  > /tmp/graph-ids.txt
+wc -l /tmp/graph-ids.txt
+```
+
+That file is on your workstation, but the loops in steps 2–4 run **inside** the
+workspace pods, which do not mount the cluster ConfigMap. Copy it in after
+starting each pod:
+
+```shell
+kubectl -n omnigraph exec -i <pod> -- sh -c 'cat > /tmp/graph-ids.txt' \
+  < /tmp/graph-ids.txt
 ```
 
 Then cross-check against what is actually in the bucket, which is not
@@ -152,10 +164,12 @@ recovery path anyone should be attempting under time pressure.
 > **Prerequisite, read before scheduling.** The storage root is derived, not
 > configurable: `data_tier.py` sets
 > `bucket_name = f"ol-data-witan-{stack_info.env_suffix}"` and builds `storage:`
-> from it, so step 5 is a code edit today. An `omnigraph:storage_root` override
-> — an optional config key that replaces the derived storage URI in cluster.yaml
-> while leaving bucket creation and IRSA alone — is what makes this runbook
-> executable as written. Tracked in the witan project backlog.
+> from it. **There is no `omnigraph:storage_root` config key yet**, so step 5
+> repoints by editing that derivation, and setting a config key of that name
+> today would no-op silently. Adding the override — an optional key that
+> replaces the derived storage URI in cluster.yaml while leaving bucket
+> creation and IRSA alone — is what makes step 5 a config change instead.
+> Tracked in the witan project backlog.
 
 ## Addressing: `--store`, not `--cluster`
 
@@ -283,13 +297,49 @@ and is the safe choice — `overwrite` is destructive and buys nothing here.
 
 ### 5. Repoint the cluster and deploy the new image
 
-```shell
-cd src/ol_infrastructure/applications/omnigraph
-pulumi config set omnigraph:storage_root "$NEW_ROOT" --stack <CI|QA|Production>
+> **Do this by code edit today.** `omnigraph:storage_root` does not exist yet
+> (see *Prerequisite* above). Setting that config key on a stack that does not
+> read it **fails silently** — `pulumi up` reports success, cluster.yaml still
+> names the old root, and the new binary hits the same version gate that
+> started this outage. Do not run `pulumi config set omnigraph:storage_root`
+> until the override has actually landed.
+
+Edit the storage URI in `src/ol_infrastructure/applications/omnigraph/data_tier.py`:
+
+```python
+# storage_uri: Output[str] = omnigraph_bucket.bucket_v2.bucket.apply(
+#     lambda name: f"s3://{name}"
+# )
+storage_uri: Output[str] = omnigraph_bucket.bucket_v2.bucket.apply(
+    lambda name: f"s3://{name}/fmt<N>"      # storage-format migration <date>
+)
 ```
+
+Change only this value. Leave the `OLBucket`, the IAM policy, and the IRSA
+grant keyed to the derived bucket name — the new root is a prefix *inside* that
+same bucket, so they already cover it, and repointing them would drop the
+grant and the versioning config.
+
+Confirm the generated config before applying:
+
+```shell
+pulumi preview --stack <CI|QA|Production> --diff | grep -A5 'cluster.yaml'
+```
+
+The `storage:` line must show the new root. If it does not, stop — the deploy
+will silently no-op back onto the old root.
 
 Then let the paused pipeline's deploy job for this environment run (or
 `pulumi up` directly with `OMNIGRAPH_DOCKER_SHA` set to the new digest).
+
+**Once `omnigraph:storage_root` lands**, this whole step collapses to:
+
+```shell
+pulumi config set omnigraph:storage_root "$NEW_ROOT" --stack <CI|QA|Production>
+```
+
+with the same `pulumi preview` confirmation, and the rollback below becomes
+`pulumi config rm` instead of reverting the edit.
 
 The deploy regenerates cluster.yaml against the new root, runs its own
 `cluster apply` Job — a no-op, since step 4 already converged that root — and
@@ -322,12 +372,11 @@ it only after the next environment has migrated successfully too.
 Before step 5 there is nothing to roll back: scale to 1 and you are on the old
 image against the old root.
 
-After step 5:
-
-```shell
-pulumi config rm omnigraph:storage_root --stack <CI|QA|Production>
-# redeploy with OMNIGRAPH_DOCKER_SHA pinned to the OLD image digest
-```
+After step 5 — revert the `storage_uri` edit from that step (or, once the
+override lands, `pulumi config rm omnigraph:storage_root --stack <…>`), then
+redeploy with `OMNIGRAPH_DOCKER_SHA` pinned to the **old** image digest.
+Confirm with the same `pulumi preview --diff` check that `storage:` is back to
+the derived root before applying.
 
 The old root was never written to, so this is a revert, not a restore. Writes
 that landed on the new root after step 5 are lost — which is the real reason

--- a/docs/omnigraph-storage-format-upgrade-runbook.md
+++ b/docs/omnigraph-storage-format-upgrade-runbook.md
@@ -227,14 +227,23 @@ Both are cleaned up in step 7.
 
 ```shell
 kubectl -n omnigraph scale deploy/omnigraph-server --replicas=0
-kubectl -n omnigraph rollout status deploy/omnigraph-server --timeout=120s
+kubectl -n omnigraph wait --for=delete pod \
+  -l app.kubernetes.io/name=omnigraph-server --timeout=120s
 ```
 
+Wait on the **pod being gone**, not on `rollout status`. The deployment
+reconciles to zero long before the old server finishes terminating —
+`omnigraph-server` uses the full SIGTERM grace period — and until that process
+exits it is still a writer against the old root. `rollout status` reports the
+Deployment converged and would let you proceed with the server still up.
+
 Nothing may write to the old root from here until the migration completes or
-rolls back. Confirm no maintenance job is mid-run — `optimize`/`cleanup` write:
+rolls back. Confirm no maintenance job is mid-run — `optimize`/`cleanup` write
+directly to the store, bypassing the server entirely:
 
 ```shell
 kubectl -n omnigraph get jobs
+kubectl -n omnigraph get pods            # expect no omnigraph-server pod at all
 ```
 
 ### 2. Start the OLD-image workspace pod
@@ -356,33 +365,37 @@ NEW_ROOT="$OLD_ROOT/fmt<N>"
 omnigraph version        # must show the NEW internal-schema number
 ```
 
-Everything below runs inside this pod. Build a config directory holding the
-image's baked-in schemas plus a cluster.yaml that is the live one with
-`storage:` repointed:
+Now build the config directory. The image carries the three schema files but
+**not** `cluster.yaml` — that only exists inside the *server* pod, where the
+ConfigMap is mounted over the same directory. A `kubectl run` pod has no such
+mount, so the config comes from the ConfigMap. From your **workstation**:
 
 ```shell
-mkdir -p /tmp/rebuild
-cp /etc/omnigraph/cluster/*.pg /tmp/rebuild/     # schema.pg, code-schema.pg, bridge-schema.pg
-cp /etc/omnigraph/cluster/cluster.yaml /tmp/rebuild/cluster.yaml
-vi /tmp/rebuild/cluster.yaml                     # edit only: storage: s3://ol-data-witan-$ENV/fmt<N>
-omnigraph cluster validate --config /tmp/rebuild
-```
+kubectl -n omnigraph exec omnigraph-migrate-new -- \
+  sh -c 'mkdir -p /tmp/rebuild && cp /etc/omnigraph/cluster/*.pg /tmp/rebuild/'
 
-The new image bakes in the same cluster.yaml the live ConfigMap overlays, so
-copying it from `/etc/omnigraph/cluster/` inside the pod avoids a round trip
-through the workstation. If that file is stale relative to the running config
-(it is baked at image build, the ConfigMap is generated per deploy), take the
-ConfigMap version instead and pipe it in:
-
-```shell
 kubectl -n omnigraph get configmap omnigraph-cluster-config \
   -o jsonpath='{.data.cluster\.yaml}' \
   | kubectl -n omnigraph exec -i omnigraph-migrate-new -- \
       sh -c 'cat > /tmp/rebuild/cluster.yaml'
 ```
 
-`cluster validate` is read-only and catches a mis-edited storage URI or an
-unresolvable `schema:` reference before anything is written.
+Back **inside the pod**, repoint `storage:` with `sed` — there is no `vi`,
+`vim`, `nano`, or `ed` in the image, and no `busybox` to fall back on:
+
+```shell
+sed -i "s|^storage: .*|storage: $NEW_ROOT|" /tmp/rebuild/cluster.yaml
+grep '^storage:' /tmp/rebuild/cluster.yaml     # confirm it took
+grep -c 'schema:' /tmp/rebuild/cluster.yaml    # graph count must be unchanged
+omnigraph cluster validate --config /tmp/rebuild
+```
+
+`cluster validate` reports `N resource(s), M dependency edge(s)` — two
+resources and one edge per declared graph, so 16 graphs give
+`32 resource(s), 16 dependency edge(s)`. A count that does not match the graph
+list means the `sed` ate more than the storage line. Validation is read-only,
+and catches a mis-edited storage URI or an unresolvable `schema:` reference
+before anything is written.
 
 Now bootstrap the new root's state ledger, **then** converge it. Both commands,
 in this order:

--- a/docs/omnigraph-storage-format-upgrade-runbook.md
+++ b/docs/omnigraph-storage-format-upgrade-runbook.md
@@ -189,8 +189,17 @@ The cluster's own state ledger lives at `<root>/__cluster/state.json`.
 
 ## Procedure
 
-`$ENV` is the lowercased env suffix (`ci`, `qa`, `production`), `$OLD_ROOT` is
-`s3://ol-data-witan-$ENV`, `$NEW_ROOT` is `$OLD_ROOT/fmt<N>`.
+Set these first, **on your workstation** — steps 5, 6 and 7 use them there:
+
+```shell
+ENV=ci                                    # ci | qa | production
+OLD_ROOT="s3://ol-data-witan-$ENV"
+NEW_ROOT="$OLD_ROOT/fmt<N>"               # <N> = the new internal-schema number
+```
+
+Each pod shell you open below needs the same three set again — a `kubectl exec`
+shell inherits nothing from your workstation, and the steps that open one say so
+where it matters.
 
 All `omnigraph` and `aws` work runs **in-cluster**, in a one-off pod on the
 `omnigraph-server` ServiceAccount, which carries the bucket's IRSA grant — no
@@ -238,9 +247,8 @@ kubectl -n omnigraph exec -it omnigraph-migrate-old -- sh
 ```
 
 Everything in steps 2 and 3 runs **inside this pod** unless it starts with
-`kubectl`. Set the roots in the pod shell — they are not inherited from your
-workstation — and sanity-check the binary and its addressing before relying on
-either:
+`kubectl`. Re-set the roots here — the pod shell inherits nothing — and
+sanity-check the binary and its addressing before relying on either:
 
 ```shell
 ENV=ci                                    # ci | qa | production
@@ -249,8 +257,6 @@ NEW_ROOT="$OLD_ROOT/fmt<N>"
 omnigraph version
 omnigraph snapshot --store "$OLD_ROOT/graphs/council.omni" | head -3
 ```
-
-Re-set the same three in the step 4 pod; each `kubectl exec` shell starts clean.
 
 Then record the baseline — per-table row counts for every graph. This is what
 step 6 checks against, and it is the only thing that catches a load which
@@ -309,10 +315,13 @@ kubectl -n omnigraph exec -i omnigraph-migrate-new -- sh -c 'cat > /tmp/graph-id
 kubectl -n omnigraph exec -it omnigraph-migrate-new -- sh
 ```
 
-Confirm you are on the binary you think you are — this is the whole point of
-the exercise:
+Re-set the roots (this shell inherits nothing either) and confirm you are on the
+binary you think you are — this is the whole point of the exercise:
 
 ```shell
+ENV=ci                                    # ci | qa | production
+OLD_ROOT="s3://ol-data-witan-$ENV"
+NEW_ROOT="$OLD_ROOT/fmt<N>"
 omnigraph version        # must show the NEW internal-schema number
 ```
 

--- a/docs/omnigraph-storage-format-upgrade-runbook.md
+++ b/docs/omnigraph-storage-format-upgrade-runbook.md
@@ -425,18 +425,40 @@ changes with cluster.yaml, so the restart happens on its own.
 
 ### 6. Verify before releasing the outage
 
+A graph that opens cleanly while missing half its rows looks perfectly healthy
+to `/healthz`, so the row-count diff — every graph, not a spot check — is the
+check that matters. From your workstation, with the server back up:
+
 ```shell
 kubectl -n omnigraph exec deploy/omnigraph-server -- omnigraph version
-kubectl -n omnigraph exec deploy/omnigraph-server -- \
-  omnigraph snapshot --store "$NEW_ROOT/graphs/council.omni" | head -3
+
+for g in $(cat /tmp/graph-ids.txt); do
+  echo "== $g"
+  kubectl -n omnigraph exec deploy/omnigraph-server -- \
+    omnigraph snapshot --store "$NEW_ROOT/graphs/$g.omni" \
+    | grep -E 'rows=|internal_schema'
+done | tee /tmp/after.txt
 ```
 
-`internal_schema_version` must now match the new binary's `internal-schema`.
-Then diff per-table row counts for every graph against `/tmp/baseline.txt`.
+Two comparisons against the step 2 baseline, and they expect **opposite**
+answers — which is why this is not one plain `diff`:
 
-A graph that opens cleanly while missing half its rows looks perfectly healthy
-to `/healthz`, so the count diff is the check that matters. Finish by exercising
-a real client path (a `recall`, a `task_ready`) rather than trusting probes.
+```shell
+# 1. Row counts must be identical. Empty output = pass.
+diff <(grep -E '^==|rows=' /tmp/baseline.txt) \
+     <(grep -E '^==|rows=' /tmp/after.txt) && echo "row counts match"
+
+# 2. The format version must have MOVED, uniformly, on every graph.
+grep internal_schema /tmp/after.txt | sort -u
+```
+
+The second must print exactly one line, carrying the new binary's
+`internal-schema` number. More than one line means some graph did not get
+rebuilt; the old number means you are still serving the old root — go back to
+step 5 and check the `pulumi preview --diff`.
+
+Finish by exercising a real client path (a `recall`, a `task_ready`) rather
+than trusting probes.
 
 ### 7. Clean up, then retire the old root
 

--- a/docs/omnigraph-storage-format-upgrade-runbook.md
+++ b/docs/omnigraph-storage-format-upgrade-runbook.md
@@ -4,10 +4,13 @@ How to roll out an `omnigraph-server` image whose binary bumps the **storage
 format**, why the ordinary deploy cannot do it, and how to tell the two cases
 apart before you start.
 
-Commands here were checked against the live CI deployment on 2026-08-05
-(`operations-ci`, omnigraph 0.8.1, `internal-schema 4`). The read-only and
-addressing steps are verified; the two write steps that rebuild a graph are
-marked where they are not.
+Every command here was run against the live CI deployment on 2026-08-05
+(`operations-ci`, omnigraph 0.8.1, `internal-schema 4`), including a full
+rehearsal of the rebuild — `cluster import` → `cluster apply` → `load` →
+verification — on a scratch prefix with synthetic rows, which round-tripped
+exactly. The one thing not exercised is the version gate itself: no
+format-bumping image exists yet, so the drill ran the same binary on both
+sides.
 
 ## When this applies
 
@@ -201,7 +204,7 @@ Each pod shell you open below needs the same three set again — a `kubectl exec
 shell inherits nothing from your workstation, and the steps that open one say so
 where it matters.
 
-All `omnigraph` and `aws` work runs **in-cluster**, in a one-off pod on the
+All `omnigraph` work runs **in-cluster**, in a one-off pod on the
 `omnigraph-server` ServiceAccount, which carries the bucket's IRSA grant — no
 human AWS credentials, and it is the `svc-witan-admin` break-glass identity
 (agent-kit ADR-0005 path (b)) rather than a side channel. There is no
@@ -209,6 +212,12 @@ human AWS credentials, and it is the `svc-witan-admin` break-glass identity
 server pod to `exec` into either, so each step below says which of the two
 workspace pods it runs in. Commands starting with `kubectl` are the ones you
 run locally.
+
+> **The image ships only `omnigraph`, `omnigraph-server`, and its entrypoint.**
+> No `aws`, no `curl`, no `python3`. Anything moving data in or out of a
+> workspace pod goes through `kubectl exec`, not an S3 round trip — which is why
+> steps 3 and 4 hand the exports across rather than staging them in the bucket.
+> `aws` commands in this runbook run on your **workstation**.
 
 Two pods, because the migration spans two binaries: `omnigraph-migrate-old`
 (step 2, baseline + export) and `omnigraph-migrate-new` (step 4, rebuild).
@@ -238,7 +247,7 @@ image, which is the old binary that can still read the old root:
 ```shell
 kubectl -n omnigraph run omnigraph-migrate-old --restart=Never \
   --image=<OLD-image-ref> \
-  --overrides='{"spec":{"serviceAccountName":"omnigraph-server"}}' \
+  --overrides='{"apiVersion":"v1","spec":{"serviceAccountName":"omnigraph-server"}}' \
   --env=AWS_REGION=us-east-1 --command -- sleep 86400
 kubectl -n omnigraph wait --for=condition=Ready pod/omnigraph-migrate-old --timeout=120s
 kubectl -n omnigraph exec -i omnigraph-migrate-old -- sh -c 'cat > /tmp/graph-ids.txt' \
@@ -285,33 +294,55 @@ Still inside `omnigraph-migrate-old`:
 mkdir -p /tmp/export
 for g in $(cat /tmp/graph-ids.txt); do
   omnigraph export --store "$OLD_ROOT/graphs/$g.omni" > "/tmp/export/$g.jsonl"
+  echo "$g: $(wc -l < /tmp/export/$g.jsonl) lines"
 done
-aws s3 cp --recursive /tmp/export "$OLD_ROOT/_migration/<date>/"
 ```
 
-Copy the exports off the pod (a scratch prefix in the bucket is simplest — the
-SA can already write it). A failure here is a clean stop: nothing has changed,
-so scale back to 1 and investigate.
+Then pull them onto your workstation, which is where step 4 pushes them from.
+**The image has no `aws`, `curl`, or `python3` — only the `omnigraph` binaries** —
+so the transfer goes through `kubectl`, not an S3 round trip:
+
+```shell
+mkdir -p /tmp/export
+for g in $(cat /tmp/graph-ids.txt); do
+  kubectl -n omnigraph exec omnigraph-migrate-old -- \
+    cat "/tmp/export/$g.jsonl" > "/tmp/export/$g.jsonl"
+done
+wc -l /tmp/export/*.jsonl
+```
+
+Keep that workstation copy until step 7 — it is the only artifact that survives
+both pods being deleted. A failure anywhere in this step is a clean stop:
+nothing has been written, so scale the Deployment back to 1 and investigate.
 
 ### 4. Rebuild at the new root with the NEW binary
 
-> Steps 4 and 5 are the write path and have **not** been rehearsed end to end —
-> the addressing, `cluster validate`, and the schema layout below are verified
-> against CI, but `cluster apply` at a new root and `load --mode merge` are not.
-> Do a full drill against a scratch prefix in CI before running this on
-> Production.
+> Rehearsed against CI on 2026-08-05 with synthetic rows: `cluster import` →
+> `cluster apply` → `load --mode merge` → step 6's verification, on a scratch
+> prefix. Row counts round-tripped exactly. What that drill could **not**
+> cover is the version gate itself — both pods ran the same binary, because no
+> format-bumping image exists yet. Expect the gate's behaviour, and only the
+> gate's behaviour, to be new on the day.
 
 This step needs the **new** binary, so it runs in a second pod. On your
-workstation:
+workstation — push the graph list and the exports in, since the image has no
+`aws`:
 
 ```shell
 kubectl -n omnigraph run omnigraph-migrate-new --restart=Never \
   --image=<NEW-image-ref> \
-  --overrides='{"spec":{"serviceAccountName":"omnigraph-server"}}' \
+  --overrides='{"apiVersion":"v1","spec":{"serviceAccountName":"omnigraph-server"}}' \
   --env=AWS_REGION=us-east-1 --command -- sleep 86400
-kubectl -n omnigraph wait --for=condition=Ready pod/omnigraph-migrate-new --timeout=120s
+kubectl -n omnigraph wait --for=condition=Ready pod/omnigraph-migrate-new --timeout=180s
+
 kubectl -n omnigraph exec -i omnigraph-migrate-new -- sh -c 'cat > /tmp/graph-ids.txt' \
   < /tmp/graph-ids.txt
+kubectl -n omnigraph exec omnigraph-migrate-new -- mkdir -p /tmp/export
+for g in $(cat /tmp/graph-ids.txt); do
+  kubectl -n omnigraph exec -i omnigraph-migrate-new -- \
+    sh -c "cat > /tmp/export/$g.jsonl" < "/tmp/export/$g.jsonl"
+done
+
 kubectl -n omnigraph exec -it omnigraph-migrate-new -- sh
 ```
 
@@ -325,13 +356,12 @@ NEW_ROOT="$OLD_ROOT/fmt<N>"
 omnigraph version        # must show the NEW internal-schema number
 ```
 
-Everything below runs inside this pod. Pull the exports back down and build a
-config directory holding the image's baked-in schemas plus a cluster.yaml that
-is the live one with `storage:` repointed:
+Everything below runs inside this pod. Build a config directory holding the
+image's baked-in schemas plus a cluster.yaml that is the live one with
+`storage:` repointed:
 
 ```shell
-mkdir -p /tmp/rebuild /tmp/export
-aws s3 cp --recursive "$OLD_ROOT/_migration/<date>/" /tmp/export/
+mkdir -p /tmp/rebuild
 cp /etc/omnigraph/cluster/*.pg /tmp/rebuild/     # schema.pg, code-schema.pg, bridge-schema.pg
 cp /etc/omnigraph/cluster/cluster.yaml /tmp/rebuild/cluster.yaml
 vi /tmp/rebuild/cluster.yaml                     # edit only: storage: s3://ol-data-witan-$ENV/fmt<N>
@@ -352,14 +382,33 @@ kubectl -n omnigraph get configmap omnigraph-cluster-config \
 ```
 
 `cluster validate` is read-only and catches a mis-edited storage URI or an
-unresolvable `schema:` reference before anything is written. Then create every
-declared graph, empty, with the new binary's schemas:
+unresolvable `schema:` reference before anything is written.
+
+Now bootstrap the new root's state ledger, **then** converge it. Both commands,
+in this order:
 
 ```shell
-omnigraph cluster apply --config /tmp/rebuild --as svc-witan-admin
+omnigraph cluster import --config /tmp/rebuild --as svc-witan-admin
+omnigraph cluster apply  --config /tmp/rebuild --as svc-witan-admin
 ```
 
-And load each export:
+> **`cluster apply` alone fails on a root that has never been applied to.** A
+> new storage root has no `__cluster/state.json`, and apply refuses rather than
+> creating one:
+>
+> ```
+> ERROR state_missing __cluster/state.json: apply requires an existing
+> state.json; run `cluster import` to bootstrap state
+> ```
+>
+> `cluster import` writes that ledger — at a fresh root it observes nothing and
+> records revision 1 with 0 resources, which is exactly right. `apply` then
+> creates the graphs and moves to revision 2. This bites only on the *first*
+> apply against a new root, which is precisely what this procedure does, at the
+> point of no return, during an outage.
+
+Expect apply to report `Create graph.<id>` and `Create schema.<id>` for every
+declared graph, ending `converged: true, written: true`. Then load each export:
 
 ```shell
 for g in $(cat /tmp/graph-ids.txt); do
@@ -482,8 +531,8 @@ kubectl -n omnigraph delete pod omnigraph-migrate-old omnigraph-migrate-new --ig
 
 The old root itself waits. **Not the same day** — leave `$OLD_ROOT/graphs/`
 untouched through at least one full soak (a week for Production), because it is
-the only fast rollback. Delete it, and the `_migration/<date>/` exports, only
-after the next environment has migrated successfully too.
+the only fast rollback. Delete it, and the workstation copy of the exports in
+`/tmp/export/`, only after the next environment has migrated successfully too.
 
 ## Rollback
 
@@ -525,7 +574,7 @@ will drop any repo whose normalization you got wrong. Re-check against the
 ConfigMap listing in *What gets rebuilt*.
 
 **Row counts do not match.** Do not release the outage. The exports are in
-`$OLD_ROOT/_migration/<date>/` and the old root is intact — roll back and
+`/tmp/export/` on your workstation and the old root is intact — roll back and
 reconcile offline. A partial load is the one outcome worse than a failed one,
 because it looks like success.
 

--- a/docs/omnigraph-storage-format-upgrade-runbook.md
+++ b/docs/omnigraph-storage-format-upgrade-runbook.md
@@ -118,14 +118,9 @@ kubectl -n omnigraph get configmap omnigraph-cluster-config \
 wc -l /tmp/graph-ids.txt
 ```
 
-That file is on your workstation, but the loops in steps 2–4 run **inside** the
-workspace pods, which do not mount the cluster ConfigMap. Copy it in after
-starting each pod:
-
-```shell
-kubectl -n omnigraph exec -i <pod> -- sh -c 'cat > /tmp/graph-ids.txt' \
-  < /tmp/graph-ids.txt
-```
+Keep that file — every loop in the procedure reads it. It lives on your
+workstation, and steps 2 and 4 each copy it into their workspace pod, which has
+no ConfigMap mount of its own.
 
 Then cross-check against what is actually in the bucket, which is not
 necessarily the same set:
@@ -197,10 +192,18 @@ The cluster's own state ledger lives at `<root>/__cluster/state.json`.
 `$ENV` is the lowercased env suffix (`ci`, `qa`, `production`), `$OLD_ROOT` is
 `s3://ol-data-witan-$ENV`, `$NEW_ROOT` is `$OLD_ROOT/fmt<N>`.
 
-All CLI work runs in-cluster as a one-off pod on the `omnigraph-server`
-ServiceAccount, which carries the bucket's IRSA grant — no human AWS credentials,
-and it is the `svc-witan-admin` break-glass identity (agent-kit ADR-0005 path
-(b)) rather than a side channel.
+All `omnigraph` and `aws` work runs **in-cluster**, in a one-off pod on the
+`omnigraph-server` ServiceAccount, which carries the bucket's IRSA grant — no
+human AWS credentials, and it is the `svc-witan-admin` break-glass identity
+(agent-kit ADR-0005 path (b)) rather than a side channel. There is no
+`omnigraph` binary on your workstation, and after step 1 there is no running
+server pod to `exec` into either, so each step below says which of the two
+workspace pods it runs in. Commands starting with `kubectl` are the ones you
+run locally.
+
+Two pods, because the migration spans two binaries: `omnigraph-migrate-old`
+(step 2, baseline + export) and `omnigraph-migrate-new` (step 4, rebuild).
+Both are cleaned up in step 7.
 
 ### 1. Take the graph out of the serving set
 
@@ -216,11 +219,42 @@ rolls back. Confirm no maintenance job is mid-run — `optimize`/`cleanup` write
 kubectl -n omnigraph get jobs
 ```
 
-### 2. Record the baseline
+### 2. Start the OLD-image workspace pod
 
-Per-table row counts, from `snapshot`, for every graph. This is what step 6
-checks against, and it is the only thing that catches a load that silently
-dropped a table:
+Step 1 scaled the Deployment to zero, so `kubectl exec deploy/omnigraph-server`
+is gone with it and there is no `omnigraph` binary on your workstation. Steps 2
+and 3 both need one, so start it here — a pod on the **currently-deployed**
+image, which is the old binary that can still read the old root:
+
+```shell
+kubectl -n omnigraph run omnigraph-migrate-old --restart=Never \
+  --image=<OLD-image-ref> \
+  --overrides='{"spec":{"serviceAccountName":"omnigraph-server"}}' \
+  --env=AWS_REGION=us-east-1 --command -- sleep 86400
+kubectl -n omnigraph wait --for=condition=Ready pod/omnigraph-migrate-old --timeout=120s
+kubectl -n omnigraph exec -i omnigraph-migrate-old -- sh -c 'cat > /tmp/graph-ids.txt' \
+  < /tmp/graph-ids.txt
+kubectl -n omnigraph exec -it omnigraph-migrate-old -- sh
+```
+
+Everything in steps 2 and 3 runs **inside this pod** unless it starts with
+`kubectl`. Set the roots in the pod shell — they are not inherited from your
+workstation — and sanity-check the binary and its addressing before relying on
+either:
+
+```shell
+ENV=ci                                    # ci | qa | production
+OLD_ROOT="s3://ol-data-witan-$ENV"
+NEW_ROOT="$OLD_ROOT/fmt<N>"
+omnigraph version
+omnigraph snapshot --store "$OLD_ROOT/graphs/council.omni" | head -3
+```
+
+Re-set the same three in the step 4 pod; each `kubectl exec` shell starts clean.
+
+Then record the baseline — per-table row counts for every graph. This is what
+step 6 checks against, and it is the only thing that catches a load which
+silently dropped a table:
 
 ```shell
 for g in $(cat /tmp/graph-ids.txt); do
@@ -229,17 +263,17 @@ for g in $(cat /tmp/graph-ids.txt); do
 done | tee /tmp/baseline.txt
 ```
 
-### 3. Export every graph with the OLD binary
-
-Start a workspace pod on the currently-deployed image:
+Copy it out so it survives the pod — from your workstation, in a second
+terminal or after exiting the pod shell:
 
 ```shell
-kubectl -n omnigraph run omnigraph-migrate-old --restart=Never \
-  --image=<OLD-image-ref> \
-  --overrides='{"spec":{"serviceAccountName":"omnigraph-server"}}' \
-  --env=AWS_REGION=us-east-1 --command -- sleep 86400
-kubectl -n omnigraph exec -it omnigraph-migrate-old -- sh
+kubectl -n omnigraph exec omnigraph-migrate-old -- cat /tmp/baseline.txt \
+  > /tmp/baseline.txt
 ```
+
+### 3. Export every graph with the OLD binary
+
+Still inside `omnigraph-migrate-old`:
 
 ```shell
 mkdir -p /tmp/export
@@ -261,17 +295,51 @@ so scale back to 1 and investigate.
 > Do a full drill against a scratch prefix in CI before running this on
 > Production.
 
-Start a second pod on the **new** image, same ServiceAccount, and pull the
-exports back down. Build a config directory holding the baked-in schemas plus a
-cluster.yaml that is the live one with `storage:` repointed:
+This step needs the **new** binary, so it runs in a second pod. On your
+workstation:
 
 ```shell
-mkdir -p /tmp/rebuild
+kubectl -n omnigraph run omnigraph-migrate-new --restart=Never \
+  --image=<NEW-image-ref> \
+  --overrides='{"spec":{"serviceAccountName":"omnigraph-server"}}' \
+  --env=AWS_REGION=us-east-1 --command -- sleep 86400
+kubectl -n omnigraph wait --for=condition=Ready pod/omnigraph-migrate-new --timeout=120s
+kubectl -n omnigraph exec -i omnigraph-migrate-new -- sh -c 'cat > /tmp/graph-ids.txt' \
+  < /tmp/graph-ids.txt
+kubectl -n omnigraph exec -it omnigraph-migrate-new -- sh
+```
+
+Confirm you are on the binary you think you are — this is the whole point of
+the exercise:
+
+```shell
+omnigraph version        # must show the NEW internal-schema number
+```
+
+Everything below runs inside this pod. Pull the exports back down and build a
+config directory holding the image's baked-in schemas plus a cluster.yaml that
+is the live one with `storage:` repointed:
+
+```shell
+mkdir -p /tmp/rebuild /tmp/export
+aws s3 cp --recursive "$OLD_ROOT/_migration/<date>/" /tmp/export/
 cp /etc/omnigraph/cluster/*.pg /tmp/rebuild/     # schema.pg, code-schema.pg, bridge-schema.pg
-kubectl -n omnigraph get configmap omnigraph-cluster-config \
-  -o jsonpath='{.data.cluster\.yaml}' > /tmp/rebuild/cluster.yaml
-# edit only: storage: s3://ol-data-witan-$ENV/fmt<N>
+cp /etc/omnigraph/cluster/cluster.yaml /tmp/rebuild/cluster.yaml
+vi /tmp/rebuild/cluster.yaml                     # edit only: storage: s3://ol-data-witan-$ENV/fmt<N>
 omnigraph cluster validate --config /tmp/rebuild
+```
+
+The new image bakes in the same cluster.yaml the live ConfigMap overlays, so
+copying it from `/etc/omnigraph/cluster/` inside the pod avoids a round trip
+through the workstation. If that file is stale relative to the running config
+(it is baked at image build, the ConfigMap is generated per deploy), take the
+ConfigMap version instead and pipe it in:
+
+```shell
+kubectl -n omnigraph get configmap omnigraph-cluster-config \
+  -o jsonpath='{.data.cluster\.yaml}' \
+  | kubectl -n omnigraph exec -i omnigraph-migrate-new -- \
+      sh -c 'cat > /tmp/rebuild/cluster.yaml'
 ```
 
 `cluster validate` is read-only and catches a mis-edited storage URI or an
@@ -361,11 +429,20 @@ A graph that opens cleanly while missing half its rows looks perfectly healthy
 to `/healthz`, so the count diff is the check that matters. Finish by exercising
 a real client path (a `recall`, a `task_ready`) rather than trusting probes.
 
-### 7. Retire the old root
+### 7. Clean up, then retire the old root
 
-**Not the same day.** Leave `$OLD_ROOT/graphs/` untouched through at least one
-full soak — a week for Production — because it is the only fast rollback. Delete
-it only after the next environment has migrated successfully too.
+Delete the workspace pods once verification passes — they hold an idle
+`sleep 86400` on the `omnigraph-server` ServiceAccount, and leaving them around
+is a stray identity with write access to the bucket:
+
+```shell
+kubectl -n omnigraph delete pod omnigraph-migrate-old omnigraph-migrate-new --ignore-not-found
+```
+
+The old root itself waits. **Not the same day** — leave `$OLD_ROOT/graphs/`
+untouched through at least one full soak (a week for Production), because it is
+the only fast rollback. Delete it, and the `_migration/<date>/` exports, only
+after the next environment has migrated successfully too.
 
 ## Rollback
 

--- a/docs/omnigraph-storage-format-upgrade-runbook.md
+++ b/docs/omnigraph-storage-format-upgrade-runbook.md
@@ -197,7 +197,20 @@ Set these first, **on your workstation** — steps 5, 6 and 7 use them there:
 ```shell
 ENV=ci                                    # ci | qa | production
 OLD_ROOT="s3://ol-data-witan-$ENV"
-NEW_ROOT="$OLD_ROOT/fmt<N>"               # <N> = the new internal-schema number
+NEW_ROOT="$OLD_ROOT/fmt5"                 # digits = the NEW internal-schema number
+```
+
+`fmt5` is an example. **Substitute the real number** — `<` and `>` are legal in
+S3 object keys, so a literal `fmt<N>` becomes a real prefix and the migration
+silently rebuilds into the wrong place. The pod-shell blocks below re-set these
+and guard against exactly that; the same guard is worth running here:
+
+```shell
+case "$NEW_ROOT" in
+  *'<'*|*'>'*) echo "NEW_ROOT still has a placeholder — stop"; exit 1 ;;
+esac
+printf '%s\n' "$NEW_ROOT" | grep -qE '^s3://[a-z0-9.-]+/fmt[0-9]+$' \
+  || { echo "NEW_ROOT malformed: $NEW_ROOT — stop"; exit 1; }
 ```
 
 Each pod shell you open below needs the same three set again — a `kubectl exec`
@@ -271,7 +284,7 @@ sanity-check the binary and its addressing before relying on either:
 ```shell
 ENV=ci                                    # ci | qa | production
 OLD_ROOT="s3://ol-data-witan-$ENV"
-NEW_ROOT="$OLD_ROOT/fmt<N>"
+NEW_ROOT="$OLD_ROOT/fmt5"                 # real digits — see the guard in step 4
 omnigraph version
 omnigraph snapshot --store "$OLD_ROOT/graphs/council.omni" | head -3
 ```
@@ -380,10 +393,22 @@ kubectl -n omnigraph exec -it omnigraph-migrate-new -- sh
 ```shell
 ENV=ci                                    # ci | qa | production
 OLD_ROOT="s3://ol-data-witan-$ENV"
-NEW_ROOT="$OLD_ROOT/fmt<N>"
-test -n "$NEW_ROOT" || { echo "NEW_ROOT unset — stop"; exit 1; }
+NEW_ROOT="$OLD_ROOT/fmt5"                 # <-- real digits, not fmt<N>
+
+# Reject an unsubstituted placeholder and a malformed root. `<`/`>` are legal
+# in S3 keys, so `fmt<N>` would happily become a real prefix.
+case "$NEW_ROOT" in
+  *'<'*|*'>'*) echo "NEW_ROOT still has a placeholder — stop"; exit 1 ;;
+esac
+printf '%s\n' "$NEW_ROOT" | grep -qE '^s3://[a-z0-9.-]+/fmt[0-9]+$' \
+  || { echo "NEW_ROOT malformed: $NEW_ROOT — stop"; exit 1; }
+
 omnigraph version        # must show the NEW internal-schema number
 ```
+
+> The pod's `/bin/sh` is **dash**, not bash — `[[ ... =~ ... ]]` fails with
+> `[[: not found`. Every guard in this runbook is POSIX `case`/`grep` for that
+> reason; keep it that way if you add more.
 
 Repoint `storage:` with `sed` — there is no `vi`, `vim`, `nano`, or `ed` in the
 image, and no `busybox` to fall back on:

--- a/docs/omnigraph-storage-format-upgrade-runbook.md
+++ b/docs/omnigraph-storage-format-upgrade-runbook.md
@@ -333,9 +333,15 @@ nothing has been written, so scale the Deployment back to 1 and investigate.
 > format-bumping image exists yet. Expect the gate's behaviour, and only the
 > gate's behaviour, to be new on the day.
 
-This step needs the **new** binary, so it runs in a second pod. On your
-workstation — push the graph list and the exports in, since the image has no
-`aws`:
+This step needs the **new** binary, so it runs in a second pod. Do **all** of
+the workstation-side setup first, in one go, and only then open the pod shell —
+the rest of the step never leaves it. Interleaving the two is how `$NEW_ROOT`
+ends up unset at the moment `sed` uses it.
+
+The image carries the three schema files but **not** `cluster.yaml` — that
+exists only inside the *server* pod, where the ConfigMap is mounted over the
+same directory. A `kubectl run` pod has no such mount, so the config, the graph
+list and the exports all get pushed in from here:
 
 ```shell
 kubectl -n omnigraph run omnigraph-migrate-new --restart=Never \
@@ -344,58 +350,70 @@ kubectl -n omnigraph run omnigraph-migrate-new --restart=Never \
   --env=AWS_REGION=us-east-1 --command -- sleep 86400
 kubectl -n omnigraph wait --for=condition=Ready pod/omnigraph-migrate-new --timeout=180s
 
+# graph list
 kubectl -n omnigraph exec -i omnigraph-migrate-new -- sh -c 'cat > /tmp/graph-ids.txt' \
   < /tmp/graph-ids.txt
+
+# exports
 kubectl -n omnigraph exec omnigraph-migrate-new -- mkdir -p /tmp/export
 for g in $(cat /tmp/graph-ids.txt); do
   kubectl -n omnigraph exec -i omnigraph-migrate-new -- \
     sh -c "cat > /tmp/export/$g.jsonl" < "/tmp/export/$g.jsonl"
 done
 
-kubectl -n omnigraph exec -it omnigraph-migrate-new -- sh
-```
-
-Re-set the roots (this shell inherits nothing either) and confirm you are on the
-binary you think you are — this is the whole point of the exercise:
-
-```shell
-ENV=ci                                    # ci | qa | production
-OLD_ROOT="s3://ol-data-witan-$ENV"
-NEW_ROOT="$OLD_ROOT/fmt<N>"
-omnigraph version        # must show the NEW internal-schema number
-```
-
-Now build the config directory. The image carries the three schema files but
-**not** `cluster.yaml` — that only exists inside the *server* pod, where the
-ConfigMap is mounted over the same directory. A `kubectl run` pod has no such
-mount, so the config comes from the ConfigMap. From your **workstation**:
-
-```shell
+# schemas from the image + cluster.yaml from the ConfigMap
 kubectl -n omnigraph exec omnigraph-migrate-new -- \
   sh -c 'mkdir -p /tmp/rebuild && cp /etc/omnigraph/cluster/*.pg /tmp/rebuild/'
-
 kubectl -n omnigraph get configmap omnigraph-cluster-config \
   -o jsonpath='{.data.cluster\.yaml}' \
   | kubectl -n omnigraph exec -i omnigraph-migrate-new -- \
       sh -c 'cat > /tmp/rebuild/cluster.yaml'
 ```
 
-Back **inside the pod**, repoint `storage:` with `sed` — there is no `vi`,
-`vim`, `nano`, or `ed` in the image, and no `busybox` to fall back on:
+Now open the shell. **Everything from here to the end of step 4 runs inside
+it** — if you do leave, re-set the three roots before doing anything else:
+
+```shell
+kubectl -n omnigraph exec -it omnigraph-migrate-new -- sh
+```
+
+```shell
+ENV=ci                                    # ci | qa | production
+OLD_ROOT="s3://ol-data-witan-$ENV"
+NEW_ROOT="$OLD_ROOT/fmt<N>"
+test -n "$NEW_ROOT" || { echo "NEW_ROOT unset — stop"; exit 1; }
+omnigraph version        # must show the NEW internal-schema number
+```
+
+Repoint `storage:` with `sed` — there is no `vi`, `vim`, `nano`, or `ed` in the
+image, and no `busybox` to fall back on:
 
 ```shell
 sed -i "s|^storage: .*|storage: $NEW_ROOT|" /tmp/rebuild/cluster.yaml
-grep '^storage:' /tmp/rebuild/cluster.yaml     # confirm it took
+
+# storage: must name the new root. An EMPTY value here is the dangerous case.
+grep '^storage:' /tmp/rebuild/cluster.yaml
+grep -q "^storage: $NEW_ROOT\$" /tmp/rebuild/cluster.yaml \
+  && echo "storage repointed OK" || echo "WRONG — do not continue"
+
 grep -c 'schema:' /tmp/rebuild/cluster.yaml    # graph count must be unchanged
 omnigraph cluster validate --config /tmp/rebuild
 ```
 
-`cluster validate` reports `N resource(s), M dependency edge(s)` — two
+> **`cluster validate` does not catch an empty `storage:`.** A cluster.yaml
+> with a blank storage value validates clean —
+> `cluster config valid: 2 resource(s), 1 dependency edge(s)` — verified
+> 2026-08-05. So if `$NEW_ROOT` were unset when `sed` ran, the blanked config
+> would sail through validation and `cluster import`/`apply` would build the
+> graphs somewhere other than the intended S3 root, with `load` then reporting
+> success. That is why the `grep -q` above exists: validation is not the guard
+> here.
+
+What validation *does* catch is an unresolvable `schema:` reference and
+structural damage. It reports `N resource(s), M dependency edge(s)` — two
 resources and one edge per declared graph, so 16 graphs give
 `32 resource(s), 16 dependency edge(s)`. A count that does not match the graph
-list means the `sed` ate more than the storage line. Validation is read-only,
-and catches a mis-edited storage URI or an unresolvable `schema:` reference
-before anything is written.
+list means the `sed` ate more than the storage line.
 
 Now bootstrap the new root's state ledger, **then** converge it. Both commands,
 in this order:


### PR DESCRIPTION
## What are the relevant tickets?

Task `tk-runbook-adr-addendum-omnigraph-storage-format-bu-a2032d`, project
`wp-witan-multi-user-service-deployment-dcf6ee`.

## Description (What does it do?)

Documents the upgrade path for an `omnigraph-server` image bump that changes the
**storage format**, which the current deploy cannot perform.

`strategy=Recreate` (added in #4985) makes a *same*-format restart safe — the old
pod is gone before the new one starts, so two binaries never write one S3 store.
A format-bumping image is different: the new binary refuses to open the existing
graphs, the rollout fails on the version gate, and the environment stays down
until the graphs are rebuilt offline. Nothing is corrupted; the graph is just
unreadable by the image that shipped.

Adds:

- `docs/omnigraph-storage-format-upgrade-runbook.md` — the detection test that
  distinguishes a format bump from an ordinary one, the offline
  export → `cluster apply` → `load` rebuild under a new storage root, verification,
  rollback, and troubleshooting.
- A 2026-08-05 addendum to ADR-0009 recording the consequence and pointing at the
  runbook.

The rebuild keeps every graph id identical and writes under a *new* storage root,
leaving the old root intact as the rollback. Ids are what clients address
(`WITAN_MEMORY_GRAPH=council`, witan-code's `graph_id()`), never paths, so a new
root is invisible to them. Rebuilding in place would mean deleting each old store
first, leaving S3 object versioning as the only rollback — not a credible recovery
path for a Lance store.

## How can this be tested?

The runbook was drafted against the code and then checked against the live CI
deployment (`operations-ci`, omnigraph 0.8.1, `internal-schema 4`). That corrected
two things a reasonable reading of the CLI help gets wrong:

- **`--cluster` does not address data commands.** `export`/`load`/`init`/`snapshot`
  reach a cluster-managed graph by store URI
  (`--store <root>/graphs/<graph-id>.omni`). `--cluster <root> --graph <id>` is for
  `optimize`/`repair`/`cleanup`/`cluster *` only and errors on the rest.
- **`manifest_version` is not the format version.** `snapshot` reports both; only
  `internal_schema_version` is what the gate compares. On CI, `council` reads
  `manifest_version: 4` and `code-github-com-mitodl-agent-kit` reads `3`, while
  both are `internal_schema_version: 4`.

Also verified: the storage layout (`s3://<bucket>/graphs/<id>.omni/`, state ledger
at `__cluster/state.json`), the baked schema files at `/etc/omnigraph/cluster/`,
that `cluster validate` accepts a **prefix inside the existing bucket** as a
storage root, and that all three environments are currently at
`internal_schema_version: 4` with empty graphs.

**Not rehearsed:** `cluster apply` at a new root and `load --mode merge` — the two
write steps. The runbook says so inline and asks for a scratch-prefix drill in CI
before this is ever run against Production.

## Additional context

The runbook is not executable exactly as written yet, and says so. The storage
root is derived (`ol-data-witan-<env>`) with no override, so repointing it is
currently a code edit to `data_tier.py`. Because a bucket *prefix* validates as a
root, that override is a config key rather than a new bucket or IRSA change — a
small follow-up, tracked in the witan project backlog.

Docs only; no infrastructure change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbTKYwDtNTskNKWg47NW2M