### PR TITLE
feat(omnigraph): schedule store maintenance and size the per-actor admission caps

### DIFF
--- a/docs/omnigraph-store-maintenance-runbook.md
+++ b/docs/omnigraph-store-maintenance-runbook.md
@@ -1,0 +1,153 @@
+# omnigraph store maintenance runbook
+
+What keeps the witan graph store from degrading, what runs on a schedule, and
+what to do by hand when it drifts.
+
+## What runs on its own
+
+Two CronJobs in the `omnigraph` namespace, both defined in
+`src/ol_infrastructure/applications/omnigraph/maintenance.py`:
+
+| CronJob | Default schedule | What it does | Destructive |
+|---|---|---|---|
+| `omnigraph-optimize` | `20 3 * * *` (nightly) | Compacts small Lance fragments in every table of every graph | No |
+| `omnigraph-cleanup` | `20 4 * * 0` (Sundays) | Removes Lance versions older than 30d | **Yes** |
+
+Both run the `omnigraph` CLI baked into the `omnigraph-server` image, as the
+`omnigraph-server` IRSA service account, **against the S3 store directly** —
+never through the server. That is not a shortcut: `optimize`, `cleanup` and
+`repair` are direct-storage commands and reject `--server` outright.
+
+Running compaction while the server is serving is safe. omnigraph's publisher
+uses compare-and-swap, so a maintenance write that loses a race refreshes and
+retries rather than corrupting anything.
+
+Per-environment overrides (`pulumi config set omnigraph:<key>`):
+
+- `optimize_schedule`, `cleanup_schedule` — cron expressions, in UTC.
+- `cleanup_older_than` — a Go-style duration (`30d`, `72h`).
+
+Keep the two schedules apart. Each is `concurrencyPolicy: Forbid` against
+*itself*, but Kubernetes cannot express "forbid against that other CronJob", so
+only the schedule gap stops cleanup from deleting versions optimize is in the
+middle of writing. The default hour of separation is far beyond a run's expected
+duration; the Jobs' `activeDeadlineSeconds` (45m) is set below the gap so a hung
+optimize is killed before cleanup starts.
+
+## The addressing that works
+
+Maintenance is **per graph**, and the flags are unforgiving. Verified against
+omnigraph 0.8.1:
+
+```sh
+omnigraph optimize --cluster s3://ol-data-witan-<env> --graph council
+```
+
+- **`--cluster <storage-root-URI> --graph <id>` is the form to use.**
+- Omitting `--graph` is a hard error, not an all-graphs default:
+  `cluster '<uri>' has N graphs: [...]; pass --graph <id> to select one`.
+  That is why the CronJobs loop over the graph list.
+- Passing the *config directory* (`--cluster /etc/omnigraph/cluster`) fails with
+  `has no applied state`. The cluster state ledger lives under the storage root
+  (`__cluster/state.json`), not next to `cluster.yaml`.
+- A bare positional URI (`omnigraph optimize s3://ol-data-witan-<env>`) addresses
+  a *single graph store*, not the cluster root, and errors. It reads like the
+  right command and is not.
+- On an `s3://` store, `cleanup` needs **both** `--confirm` (to arm the
+  destructive run) and `--yes` (to skip the confirmation a non-local scope
+  demands). A pod has no TTY, so without `--yes` every run refuses having
+  deleted nothing.
+
+The graph list the sweeps cover is exactly what `cluster.yaml` declares —
+`council`, `code-bridge`, and one `code-<repo>` per managed repo. Adding a repo
+to `omnigraph:managed_repos` extends the sweep in the same deploy that creates
+the graph.
+
+## Why retention is an age, not a version count
+
+`cleanup` accepts `--keep <N>` and `--older-than <duration>`. The CLI reports a
+combined policy without stating whether it intersects or unions them — and the
+two readings differ in safety, because a union would let `--keep` delete
+versions younger than the age cutoff. The CronJob passes `--older-than` alone,
+which is safe either way.
+
+30d is sized against what actually needs the history: witan-code's per-writer
+WIP branch views, which are per-session/per-git-branch and measured in days,
+plus margin for time-travel reads. The cost is that a heavily-written graph
+carries up to 30 days of dead versions — bounded storage. Query latency is
+driven by fragment count, which the nightly optimize handles.
+
+## Reading a failed run
+
+```sh
+kubectl -n omnigraph get cronjob
+kubectl -n omnigraph get jobs -l app.kubernetes.io/name=omnigraph-optimize
+kubectl -n omnigraph logs job/<job-name>
+```
+
+The sweep does **not** stop at the first failing graph. It logs
+`!!! omnigraph <command> failed for <graph>`, continues, and exits non-zero at
+the end with the full failing set:
+
+```
+!!! omnigraph optimize failed for: code-github-com-mitodl-some-repo
+```
+
+So a red Job means "at least one graph was not maintained", not "nothing was
+maintained". The last line of a clean run is
+`omnigraph <command>: all graphs completed`.
+
+There is no retry (`backoffLimit: 0`). Both commands are idempotent so a retry
+would be safe, but neither is urgent — the next scheduled run is the retry, and
+an immediate re-attempt of a run that failed on a held lock fails the same way
+while making the Job history harder to read.
+
+### `graph 'X' is not applied in cluster ...`
+
+The sweep's graph list and the cluster's applied state have diverged. Normally
+impossible — both come from the same `build_cluster_graphs` call, and the
+CronJobs depend on the converge Job — so this means the converge Job did not
+run or did not succeed for that graph. Check it:
+
+```sh
+kubectl -n omnigraph get jobs -l app.kubernetes.io/name=omnigraph-cluster-apply
+```
+
+Re-running `pulumi up` re-runs convergence.
+
+## `omnigraph repair` — manual only, deliberately
+
+`repair` reconciles manifest/head drift. It is **not** scheduled, and should not
+be: it is reactive, and its `--force` mode publishes drift that nothing has
+verified. Run it when a graph fails to open or reports inconsistent state.
+
+Preview first — without `--confirm` it only reports what it would do:
+
+```sh
+kubectl -n omnigraph run omnigraph-repair --rm -it --restart=Never \
+  --image=<the image the omnigraph-server Deployment is running> \
+  --overrides='{"spec":{"serviceAccountName":"omnigraph-server"}}' \
+  --command -- omnigraph repair \
+    --cluster s3://ol-data-witan-<env> --graph <graph-id> --as svc-witan-admin
+```
+
+Then re-run with `--confirm` to publish *verified* drift. `--force` (which also
+publishes suspicious or unverifiable drift) requires operator review first —
+read the preview output and understand each item before reaching for it.
+
+Use the exact image the Deployment is running, not `:latest`. Storage is
+strict-single-version — a binary reads exactly one storage-format version — so a
+maintenance CLI at a different version than the server writing the store is the
+mixed-fleet case upstream documents as unsupported. This is also why the
+CronJobs pin the same digest the Deployment does.
+
+## What this does not cover
+
+- **A storage-format bump.** That cannot be done by restart or by any command
+  here; it needs the offline export → rebuild → repoint procedure. Tracked
+  separately (`tk-runbook-adr-addendum-omnigraph-storage-format-bu-a2032d`).
+- **A quarantined graph.** By default the server logs a graph that fails to open
+  and serves the rest, and `/healthz` stays 200 throughout — so a quarantined
+  `council` is a silent brownout that no probe catches. `OMNIGRAPH_REQUIRE_ALL_GRAPHS`
+  is deliberately left unset (see the rationale in `data_tier.py`); detecting it
+  belongs with the service's monitoring.

--- a/src/ol_infrastructure/applications/omnigraph/__main__.py
+++ b/src/ol_infrastructure/applications/omnigraph/__main__.py
@@ -26,6 +26,10 @@ CronJob in ``token_sync.py``, in environments that set
 ``omnigraph:keycloak_url``. Enabling it moves ownership of the actor-tokens
 Vault path from this program to that job — see the writer split below.
 
+Store upkeep — nightly fragment compaction and weekly version GC — runs as two
+further CronJobs (``maintenance.py``), against the S3 store directly rather
+than through the server. See ``docs/omnigraph-store-maintenance-runbook.md``.
+
 Follow-up work this stack does NOT cover (tracked separately):
     - **Container image.** The ``omnigraph``/``pulumi-omnigraph`` Concourse
       pipeline builds the image once, owns the ECR repository itself
@@ -50,6 +54,11 @@ from ol_infrastructure.applications.omnigraph.data_tier import (
     OMNIGRAPH_SERVER_SERVICE_NAME,
     create_data_tier,
     omnigraph_server_addr,
+)
+from ol_infrastructure.applications.omnigraph.maintenance import (
+    DEFAULT_CLEANUP_OLDER_THAN,
+    DEFAULT_CLEANUP_SCHEDULE,
+    DEFAULT_OPTIMIZE_SCHEDULE,
 )
 from ol_infrastructure.applications.omnigraph.token_sync import (
     ACTOR_TOKENS_VAULT_PATH,
@@ -112,6 +121,20 @@ TOKEN_SYNC_SCHEDULE = (
     omnigraph_config.get("token_sync_schedule") or DEFAULT_SYNC_SCHEDULE
 )
 _TOKEN_SYNC_ENABLED = bool(KEYCLOAK_URL)
+
+# Scheduled store maintenance (maintenance.py). Overridable per environment
+# because the two things that set the right cadence — write volume and how much
+# version history is worth keeping — differ between a CI store that is mostly
+# reindex churn and a Production one backing real team memory. The defaults are
+# sized for Production and are deliberately conservative; see maintenance.py
+# for why retention is an age rather than a version count.
+OPTIMIZE_SCHEDULE = (
+    omnigraph_config.get("optimize_schedule") or DEFAULT_OPTIMIZE_SCHEDULE
+)
+CLEANUP_SCHEDULE = omnigraph_config.get("cleanup_schedule") or DEFAULT_CLEANUP_SCHEDULE
+CLEANUP_OLDER_THAN = (
+    omnigraph_config.get("cleanup_older_than") or DEFAULT_CLEANUP_OLDER_THAN
+)
 
 cluster_stack = make_stack_reference(projects.EKS, f"operations.{stack_info.name}")
 setup_k8s_provider(kubeconfig=cluster_stack.require_output("kube_config"))
@@ -414,6 +437,9 @@ data_tier = create_data_tier(
     actor_tokens_secret_name=ACTOR_TOKENS_SECRET_NAME,
     actor_tokens_secret=actor_tokens_secret,
     managed_repos=MANAGED_REPOS,
+    optimize_schedule=OPTIMIZE_SCHEDULE,
+    cleanup_schedule=CLEANUP_SCHEDULE,
+    cleanup_older_than=CLEANUP_OLDER_THAN,
 )
 
 export("namespace", NAMESPACE)

--- a/src/ol_infrastructure/applications/omnigraph/data_tier.py
+++ b/src/ol_infrastructure/applications/omnigraph/data_tier.py
@@ -52,6 +52,10 @@ import pulumi_kubernetes as kubernetes
 import yaml
 from pulumi import Output, ResourceOptions
 
+from ol_infrastructure.applications.omnigraph.maintenance import (
+    OmnigraphMaintenance,
+    create_maintenance,
+)
 from ol_infrastructure.components.applications.eks import OLEKSAuthBinding
 from ol_infrastructure.components.aws.s3 import OLBucket, S3BucketConfig
 from ol_infrastructure.components.services.vault import OLVaultK8SSecret
@@ -79,6 +83,81 @@ ACTOR_TOKENS_FILENAME = "tokens.json"  # pragma: allowlist secret
 # than silently writing as nobody. Matches the break-glass identity in
 # agent-kit ADR-0005 path (b).
 CLUSTER_APPLY_ACTOR = "svc-witan-admin"
+
+# ── Server resource envelope ─────────────────────────────────────────────────
+#
+# Named rather than inlined because the per-actor admission caps below are
+# derived from the memory limit, and a limit raised without revisiting the caps
+# would silently leave them mis-sized.
+SERVER_MEMORY_LIMIT = "2Gi"
+
+# ── Per-actor admission caps ─────────────────────────────────────────────────
+#
+# omnigraph-server admits writes per actor and 429s (with Retry-After) over the
+# limit; Cedar authz runs first, so this is a resource guard, not an authz one.
+# Both env vars are confirmed present in the 0.8.1 server binary.
+#
+# WHY THE DEFAULTS ARE WRONG FOR THIS DEPLOYMENT, specifically the byte cap.
+# The upstream default is 4 GiB of in-flight bytes per actor — TWICE this pod's
+# entire memory limit. A cap above the limit can never bind: the pod OOMKills
+# before admission control ever declines a write, which turns a designed
+# backpressure signal (429 + client retry, already implemented in agent-kit's
+# OmnigraphClient) into a hard restart of a single-replica Recreate Deployment.
+# The cap is only useful below the memory limit, so it has to be set here.
+#
+# SIZING. The cap is PER ACTOR and there is no global limiter, so total
+# in-flight bytes are (concurrent actors x cap) and no single setting can bound
+# them. Sized against realistic peak concurrency rather than the worst case:
+# a handful of agent sessions plus svc-witan-ci, call it 4 concurrent writers;
+# reserving ~768 MiB of the 2 GiB for the server's own working set and Lance
+# buffers leaves ~1.25 GiB to share, so ~320 MiB each, rounded down to 256 MiB.
+# The pod's memory limit remains the real backstop for a concurrency spike
+# beyond that — this bounds the single-runaway-actor case, which is the one
+# that actually shows up (a CI reindex streaming a large NDJSON load).
+#
+# The in-flight COUNT comes down from 16 to 8 for the same reason: against a
+# 1-CPU pod, 16 concurrent writes from one actor only queue. An interactive
+# witan session issues one write at a time, so 8 is still far above any
+# legitimate single-user pattern while halving what one bursty indexer can pin.
+#
+# These are a deliberate starting point, not a measurement. Revisit from
+# observed 429 rates and in-flight-byte peaks once the shared service has
+# metrics (tk-observability-for-shared-witan-service-ad3dba) — and note that
+# witan's client-side retry cannot read the server's Retry-After header (the
+# omnigraph CLI's error path discards response headers), so the sizing signal
+# has to come from server-side metrics, not from the client.
+PER_ACTOR_INFLIGHT_MAX = 8
+PER_ACTOR_BYTES_MAX = 256 * 1024 * 1024
+
+# ── Startup behaviour on an unopenable graph ─────────────────────────────────
+#
+# DECISION: leave OMNIGRAPH_REQUIRE_ALL_GRAPHS unset (i.e. keep the default
+# quarantine behaviour). Setting it was proposed when this cluster served one
+# graph, where quarantine's failure mode is a silent brownout — pod Ready,
+# /healthz 200, /graphs empty, every real request 404ing — and all-or-nothing
+# startup would have made that loud.
+#
+# That premise no longer holds. build_cluster_graphs now declares `council`,
+# `code-bridge`, and one `code-<repo>` graph per managed repo, which is exactly
+# the multi-graph condition the original note named as the reversal trigger.
+# All-or-nothing would mean one unopenable per-repo code graph — the least
+# critical and most numerous kind, rebuildable by a reindex — takes down the
+# memory/task/workflow graph the entire team's agents depend on. Quarantine
+# gets the blast radius right: a broken code graph costs that repo's code
+# lookups and nothing else.
+#
+# The brownout risk quarantine leaves behind is real but narrower than it was:
+# it now only matters for `council` specifically, and the fix is a probe or
+# alert that distinguishes "serving" from "serving the graph that matters",
+# which /healthz structurally cannot (and /graphs cannot substitute for — it is
+# auth-gated behind a graph_list grant on Server::"root", so it is not usable
+# as a kubelet probe). That belongs with the service's monitoring, not with a
+# startup flag that trades a narrow failure for a broad one — see
+# tk-observability-for-shared-witan-service-ad3dba.
+#
+# REVISIT IF: the cluster ever collapses back to serving `council` alone, or
+# the server grows a per-graph health signal a readiness probe can reach
+# unauthenticated.
 
 # Fixed ConfigMap name, referenced both by the ConfigMap's own metadata and by
 # the Deployment's volume. The Deployment uses this constant rather than
@@ -198,6 +277,7 @@ class OmnigraphDataTier(NamedTuple):
     service: kubernetes.core.v1.Service
     deployment: kubernetes.apps.v1.Deployment
     cluster_apply_job: kubernetes.batch.v1.Job
+    maintenance: OmnigraphMaintenance
 
 
 def create_data_tier(  # noqa: PLR0913
@@ -209,6 +289,9 @@ def create_data_tier(  # noqa: PLR0913
     actor_tokens_secret_name: str,
     actor_tokens_secret: OLVaultK8SSecret,
     managed_repos: list[str],
+    optimize_schedule: str,
+    cleanup_schedule: str,
+    cleanup_older_than: str,
 ) -> OmnigraphDataTier:
     """Provision the S3 bucket, IRSA policy, ECR repo, ConfigMap, and Deployment."""
     # The bucket is named for its tenant (witan's graphs), not the omnigraph
@@ -515,15 +598,24 @@ def create_data_tier(  # noqa: PLR0913
                                 kubernetes.core.v1.EnvVarArgs(
                                     name="AWS_REGION", value=aws_config.region
                                 ),
-                                # Per-actor admission cap (tk-...-d241d2 sets
-                                # real values for this deployment; the
-                                # server's own defaults apply until then).
                                 kubernetes.core.v1.EnvVarArgs(
                                     name="OMNIGRAPH_SERVER_BEARER_TOKENS_FILE",
                                     value=(
                                         f"{ACTOR_TOKENS_MOUNT_PATH}/"
                                         f"{ACTOR_TOKENS_FILENAME}"
                                     ),
+                                ),
+                                # Per-actor admission caps, set deliberately
+                                # rather than inherited — the upstream byte
+                                # default is twice this pod's memory limit and
+                                # therefore unreachable. See the constants.
+                                kubernetes.core.v1.EnvVarArgs(
+                                    name="OMNIGRAPH_PER_ACTOR_INFLIGHT_MAX",
+                                    value=str(PER_ACTOR_INFLIGHT_MAX),
+                                ),
+                                kubernetes.core.v1.EnvVarArgs(
+                                    name="OMNIGRAPH_PER_ACTOR_BYTES_MAX",
+                                    value=str(PER_ACTOR_BYTES_MAX),
                                 ),
                             ],
                             ports=[
@@ -552,9 +644,11 @@ def create_data_tier(  # noqa: PLR0913
                                 initial_delay_seconds=15,
                                 period_seconds=20,
                             ),
+                            # The memory limit is what PER_ACTOR_BYTES_MAX is
+                            # sized against — change one and revisit the other.
                             resources=kubernetes.core.v1.ResourceRequirementsArgs(
                                 requests={"cpu": "250m", "memory": "512Mi"},
-                                limits={"cpu": "1", "memory": "2Gi"},
+                                limits={"cpu": "1", "memory": SERVER_MEMORY_LIMIT},
                             ),
                             volume_mounts=[
                                 # sub_path overlays only cluster.yaml, leaving
@@ -631,10 +725,35 @@ def create_data_tier(  # noqa: PLR0913
         opts=ResourceOptions(depends_on=[omnigraph_deployment]),
     )
 
+    # Scheduled compaction and version GC against the S3 store directly. Swept
+    # per graph over exactly the ids cluster.yaml declares — the same
+    # `cluster_graphs` dict rendered into the ConfigMap above, so a newly
+    # managed repo joins the sweep in the deploy that creates its graph.
+    #
+    # Ordered behind the converge Job because a graph that has not been applied
+    # yet is a hard error for `optimize --graph <id>` ("graph `X` is not applied
+    # in cluster ..."), which would fail the first sweep of every new graph.
+    omnigraph_maintenance = create_maintenance(
+        stack_info=stack_info,
+        namespace=namespace,
+        k8s_global_labels=k8s_global_labels,
+        image=omnigraph_server_image,
+        service_account_name=OMNIGRAPH_SERVICE_ACCOUNT_NAME,
+        aws_region=aws_config.region,
+        storage_uri=storage_uri,
+        maintenance_actor=CLUSTER_APPLY_ACTOR,
+        graph_ids=list(cluster_graphs),
+        optimize_schedule=optimize_schedule,
+        cleanup_schedule=cleanup_schedule,
+        cleanup_older_than=cleanup_older_than,
+        depends_on=[cluster_apply_job, *auth_binding.irsa_service_accounts],
+    )
+
     return OmnigraphDataTier(
         bucket=omnigraph_bucket,
         image_repository=image_repository,
         service=omnigraph_service,
         deployment=omnigraph_deployment,
         cluster_apply_job=cluster_apply_job,
+        maintenance=omnigraph_maintenance,
     )

--- a/src/ol_infrastructure/applications/omnigraph/maintenance.py
+++ b/src/ol_infrastructure/applications/omnigraph/maintenance.py
@@ -53,6 +53,7 @@ manifest/head drift and its ``--force`` mode publishes drift a human has not
 verified; it is a reactive, operator-driven command. See the runbook.
 """
 
+import shlex
 from typing import NamedTuple
 
 import pulumi_kubernetes as kubernetes
@@ -120,9 +121,20 @@ def _sweep_script(command: str, extra_args: list[str], graph_ids: list[str]) -> 
     command echoes ("omnigraph cleanup -> s3://.../graphs/council.omni") is the
     log line that proves a run addressed the store it was meant to, which is
     the first thing to check when a sweep reports success against nothing.
+
+    Every interpolated value is ``shlex.quote``d. ``extra_args`` carries
+    ``cleanup_older_than``, which is Pulumi config an operator can set to
+    anything: unquoted, a plausible typo like ``30 days`` silently becomes two
+    shell words and the CLI gets a stray positional argument, which is a
+    confusing 4am failure rather than an obvious one. Quoted, the same typo
+    reaches the CLI as one argument and comes back as a duration parse error
+    naming the value. ``graph_ids`` are already normalized to ``[a-z0-9-]`` by
+    ``code_graph_id``, so quoting them is a no-op today and stays correct if
+    that normalization ever loosens — quoting each id individually preserves
+    the word list the ``for`` loop needs.
     """
-    graph_list = " ".join(graph_ids)
-    args = " ".join(["--as", '"${OMNIGRAPH_MAINTENANCE_ACTOR}"', *extra_args])
+    graph_list = " ".join(shlex.quote(graph) for graph in graph_ids)
+    args = " ".join(shlex.quote(arg) for arg in extra_args)
     return f"""set -u
 failed=""
 for graph in {graph_list}; do
@@ -130,7 +142,7 @@ for graph in {graph_list}; do
     if omnigraph {command} \\
         --cluster "${{OMNIGRAPH_STORAGE_ROOT}}" \\
         --graph "${{graph}}" \\
-        {args}; then
+        --as "${{OMNIGRAPH_MAINTENANCE_ACTOR}}" {args}; then
         :
     else
         echo "!!! omnigraph {command} failed for ${{graph}}" >&2

--- a/src/ol_infrastructure/applications/omnigraph/maintenance.py
+++ b/src/ol_infrastructure/applications/omnigraph/maintenance.py
@@ -1,0 +1,321 @@
+"""Scheduled out-of-band maintenance for the omnigraph graph store.
+
+``optimize`` (Lance fragment compaction) and ``cleanup`` (old-version GC) are
+DIRECT-STORAGE commands: they reject ``--server`` outright and operate on the
+S3 store behind the running server's back. That is by design — the server's
+in-process publisher CAS lets optimize rebase-and-retry against concurrent
+writers, so this is safe to run while the data tier is serving, and neither
+command needs (or can use) the HTTP API.
+
+WHY TWO CRONJOBS AND NOT ONE
+
+They have genuinely different cadences and different risk. ``optimize`` is
+non-destructive and wants to run often enough that fragment count never gets
+far from steady state; ``cleanup`` permanently destroys old Lance versions and
+only needs to run often enough to keep the version history from growing without
+bound. Folding them into one job would either run the destructive one nightly
+or the cheap one weekly. Their schedules are offset so the two never overlap:
+each is ``concurrencyPolicy: Forbid`` against itself, but Kubernetes has no way
+to express "Forbid against that other CronJob", so the separation is the
+schedule's job.
+
+WHY A LOOP OVER GRAPH IDS RATHER THAN ONE COMMAND
+
+Verified against the omnigraph 0.8.1 CLI: maintenance addressing is
+``--cluster <storage-root-URI> --graph <id>``, and it is strictly per-graph.
+
+  - Omitting ``--graph`` is a hard error, not an all-graphs default:
+    ``cluster '<uri>' has 2 graphs: [alpha, beta]; pass --graph <id> to select
+    one``.
+  - Passing the *config directory* as ``--cluster`` fails with ``has no applied
+    state`` — the cluster state ledger lives under the storage root
+    (``__cluster/state.json``), not next to cluster.yaml, so the storage-root
+    URI is the form that works from a pod.
+  - A bare positional storage-root URI (``omnigraph optimize s3://bucket``)
+    addresses a SINGLE graph store and errors on the cluster root. It is not
+    the invocation to use, despite reading like it.
+
+So the graph list has to come from somewhere, and it comes from the same
+``build_cluster_graphs`` call that declares the graphs in cluster.yaml — one
+source for "which graphs exist", so adding a managed repo extends the
+maintenance sweep in the same deploy that creates the graph.
+
+WHY THE LOOP DOES NOT STOP ON THE FIRST FAILURE
+
+With one ``code-<repo>`` graph per managed repo, a single unopenable graph
+would otherwise skip every graph after it in the list — silently, since the
+failure is one non-zero exit among many. The loop records the failure, keeps
+going, and exits non-zero at the end, so a bad graph costs that graph's
+maintenance and nothing else while still failing the Job loudly.
+
+``omnigraph repair`` is deliberately NOT scheduled here. It reconciles
+manifest/head drift and its ``--force`` mode publishes drift a human has not
+verified; it is a reactive, operator-driven command. See the runbook.
+"""
+
+from typing import NamedTuple
+
+import pulumi_kubernetes as kubernetes
+from pulumi import Output, Resource, ResourceOptions
+
+from ol_infrastructure.lib.pulumi_helper import StackInfo
+
+# Nightly compaction, and weekly version GC an hour later on Sunday. Both are
+# in the cluster's UTC, and both sit in the small hours to keep their S3 read
+# amplification away from the CI indexer's own bursts.
+#
+# The one-hour gap is what keeps cleanup from running while optimize is still
+# going: optimize rewrites fragments and cleanup deletes old versions, and
+# running them at once means cleanup racing the versions optimize is in the
+# middle of creating. An hour is far beyond a run's expected duration at this
+# store size (see ACTIVE_DEADLINE_SECONDS) while still being auditable as "the
+# same night".
+DEFAULT_OPTIMIZE_SCHEDULE = "20 3 * * *"
+DEFAULT_CLEANUP_SCHEDULE = "20 4 * * 0"
+
+# Version retention for `cleanup`, expressed as an age rather than a count.
+#
+# `--keep <N>` and `--older-than <duration>` can both be passed, but the CLI
+# only reports the combined policy ("keep 2 versions, remove anything older
+# than 2592000s") without stating whether it intersects or unions them. An
+# intersection is more conservative than either alone; a union would let
+# `--keep` delete versions younger than the age cutoff. Since the difference is
+# unverified upstream and only one of the two readings is safe, this passes
+# `--older-than` ALONE, which is safe under both: nothing younger than the
+# cutoff can be removed no matter how the flags combine.
+#
+# 30d is chosen against what actually needs the history — witan-code's
+# per-writer WIP branch views, which are per-session/per-git-branch and
+# measured in days — plus a wide margin for time-travel reads over the recent
+# past. The cost of the generous window is that a heavily-written graph carries
+# up to 30 days of dead versions; that is bounded storage, and fragment bloat
+# (the thing that actually degrades query latency) is handled nightly by
+# optimize, not by this.
+DEFAULT_CLEANUP_OLDER_THAN = "30d"
+
+# Both jobs are S3-bound, single-threaded per graph, and run over a store whose
+# graphs are small. An hour without finishing means a wedged S3 connection or a
+# held lock, not slow progress — and the deadline has to stay well under the
+# gap between the two schedules so a hung optimize cannot still be running when
+# cleanup starts.
+ACTIVE_DEADLINE_SECONDS = 2700
+
+# No retry. Both commands are idempotent, so a retry would be safe, but neither
+# is urgent: the next scheduled run is the retry, and an immediate re-attempt
+# of a run that just failed on a held lock or an unopenable graph fails the
+# same way while making the failure harder to read in the Job history.
+BACKOFF_LIMIT = 0
+
+
+def _sweep_script(command: str, extra_args: list[str], graph_ids: list[str]) -> str:
+    """Render the per-graph sweep both CronJobs run.
+
+    ``graph_ids`` is interpolated as a literal shell word list rather than
+    passed through the environment: the ids are Pulumi-time constants derived
+    from cluster.yaml's own graph list, and having them visible in the pod spec
+    makes ``kubectl get cronjob -o yaml`` show exactly which graphs a run
+    covers.
+
+    Nothing here is ``--quiet``: the one-line resolved-target diagnostic each
+    command echoes ("omnigraph cleanup -> s3://.../graphs/council.omni") is the
+    log line that proves a run addressed the store it was meant to, which is
+    the first thing to check when a sweep reports success against nothing.
+    """
+    graph_list = " ".join(graph_ids)
+    args = " ".join(["--as", '"${OMNIGRAPH_MAINTENANCE_ACTOR}"', *extra_args])
+    return f"""set -u
+failed=""
+for graph in {graph_list}; do
+    echo "=== omnigraph {command} ${{graph}}"
+    if omnigraph {command} \\
+        --cluster "${{OMNIGRAPH_STORAGE_ROOT}}" \\
+        --graph "${{graph}}" \\
+        {args}; then
+        :
+    else
+        echo "!!! omnigraph {command} failed for ${{graph}}" >&2
+        failed="${{failed}} ${{graph}}"
+    fi
+done
+if [ -n "${{failed}}" ]; then
+    echo "!!! omnigraph {command} failed for:${{failed}}" >&2
+    exit 1
+fi
+echo "omnigraph {command}: all graphs completed"
+"""
+
+
+def _cron_job(  # noqa: PLR0913
+    name: str,
+    stack_info: StackInfo,
+    namespace: str,
+    k8s_global_labels: dict[str, str],
+    image: str | Output[str],
+    service_account_name: str,
+    aws_region: str,
+    storage_uri: Output[str],
+    maintenance_actor: str,
+    schedule: str,
+    script: str,
+    depends_on: list[Resource],
+) -> kubernetes.batch.v1.CronJob:
+    """Build one maintenance CronJob around ``script``."""
+    return kubernetes.batch.v1.CronJob(
+        f"omnigraph-{name}-{stack_info.env_suffix}",
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            name=f"omnigraph-{name}",
+            namespace=namespace,
+            labels=k8s_global_labels,
+        ),
+        spec=kubernetes.batch.v1.CronJobSpecArgs(
+            schedule=schedule,
+            # Two concurrent runs of the same command would contend on the same
+            # per-graph storage lock, and the loser would fail the whole sweep
+            # after doing real work. Skipping a tick because the previous one is
+            # still going is the right answer for maintenance that has no
+            # deadline.
+            concurrency_policy="Forbid",
+            starting_deadline_seconds=600,
+            successful_jobs_history_limit=1,
+            # A failed sweep is what an operator comes looking for, and it can
+            # go unnoticed for days on a weekly schedule — keep several.
+            failed_jobs_history_limit=3,
+            job_template=kubernetes.batch.v1.JobTemplateSpecArgs(
+                metadata=kubernetes.meta.v1.ObjectMetaArgs(labels=k8s_global_labels),
+                spec=kubernetes.batch.v1.JobSpecArgs(
+                    backoff_limit=BACKOFF_LIMIT,
+                    active_deadline_seconds=ACTIVE_DEADLINE_SECONDS,
+                    template=kubernetes.core.v1.PodTemplateSpecArgs(
+                        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+                            labels={
+                                **k8s_global_labels,
+                                "app.kubernetes.io/name": f"omnigraph-{name}",
+                            },
+                        ),
+                        spec=kubernetes.core.v1.PodSpecArgs(
+                            restart_policy="Never",
+                            # The omnigraph-server IRSA identity, reused rather
+                            # than duplicated: this needs exactly the S3 access
+                            # the server already has to the same bucket, and a
+                            # second role granting the same thing would be one
+                            # more place for the bucket policy to drift.
+                            service_account_name=service_account_name,
+                            containers=[
+                                kubernetes.core.v1.ContainerArgs(
+                                    name=name,
+                                    # Same image as the data tier, which bakes
+                                    # the `omnigraph` CLI alongside the server
+                                    # binary. Pinned by digest through the
+                                    # caller, so maintenance always runs the
+                                    # same storage-format version as the server
+                                    # writing the store — the strict-single-
+                                    # version rule applies to the CLI too.
+                                    image=image,
+                                    # Overrides the image's server entrypoint.
+                                    command=["/bin/sh", "-c", script],
+                                    env=[
+                                        kubernetes.core.v1.EnvVarArgs(
+                                            name="AWS_REGION", value=aws_region
+                                        ),
+                                        kubernetes.core.v1.EnvVarArgs(
+                                            name="OMNIGRAPH_STORAGE_ROOT",
+                                            value=storage_uri,
+                                        ),
+                                        kubernetes.core.v1.EnvVarArgs(
+                                            name="OMNIGRAPH_MAINTENANCE_ACTOR",
+                                            value=maintenance_actor,
+                                        ),
+                                    ],
+                                    # Compaction rewrites fragments through
+                                    # memory, so this is the one job here with a
+                                    # real memory floor. Kept below the server's
+                                    # own limit: it is the same node pool, and
+                                    # maintenance losing an eviction race to the
+                                    # serving pod is the correct outcome.
+                                    resources=kubernetes.core.v1.ResourceRequirementsArgs(
+                                        requests={"cpu": "100m", "memory": "256Mi"},
+                                        limits={"cpu": "1", "memory": "1Gi"},
+                                    ),
+                                )
+                            ],
+                        ),
+                    ),
+                ),
+            ),
+        ),
+        opts=ResourceOptions(depends_on=depends_on),
+    )
+
+
+class OmnigraphMaintenance(NamedTuple):
+    """Handles to the provisioned maintenance CronJobs."""
+
+    optimize: kubernetes.batch.v1.CronJob
+    cleanup: kubernetes.batch.v1.CronJob
+
+
+def create_maintenance(  # noqa: PLR0913
+    stack_info: StackInfo,
+    namespace: str,
+    k8s_global_labels: dict[str, str],
+    image: str | Output[str],
+    service_account_name: str,
+    aws_region: str,
+    storage_uri: Output[str],
+    maintenance_actor: str,
+    graph_ids: list[str],
+    optimize_schedule: str,
+    cleanup_schedule: str,
+    cleanup_older_than: str,
+    depends_on: list[Resource],
+) -> OmnigraphMaintenance:
+    """Provision the scheduled optimize and cleanup sweeps.
+
+    ``graph_ids`` must be the ids cluster.yaml declares — pass the keys of the
+    same ``build_cluster_graphs`` result the ConfigMap is rendered from, so a
+    graph can never exist without being swept or be swept without existing.
+    """
+    optimize_cron_job = _cron_job(
+        name="optimize",
+        stack_info=stack_info,
+        namespace=namespace,
+        k8s_global_labels=k8s_global_labels,
+        image=image,
+        service_account_name=service_account_name,
+        aws_region=aws_region,
+        storage_uri=storage_uri,
+        maintenance_actor=maintenance_actor,
+        schedule=optimize_schedule,
+        # Non-destructive, so no --confirm and no confirmation prompt to skip.
+        script=_sweep_script("optimize", [], graph_ids),
+        depends_on=depends_on,
+    )
+
+    # `--confirm` arms the destructive run; `--yes` is separately required
+    # because an s3:// store is a NON-LOCAL scope, and a non-local destructive
+    # write with no TTY refuses rather than prompting (RFC-011 Decision 9). A
+    # pod has no TTY, so without --yes every scheduled run would error out
+    # having deleted nothing — a silent no-op dressed as a failure.
+    cleanup_cron_job = _cron_job(
+        name="cleanup",
+        stack_info=stack_info,
+        namespace=namespace,
+        k8s_global_labels=k8s_global_labels,
+        image=image,
+        service_account_name=service_account_name,
+        aws_region=aws_region,
+        storage_uri=storage_uri,
+        maintenance_actor=maintenance_actor,
+        schedule=cleanup_schedule,
+        script=_sweep_script(
+            "cleanup",
+            ["--older-than", cleanup_older_than, "--confirm", "--yes"],
+            graph_ids,
+        ),
+        depends_on=depends_on,
+    )
+
+    return OmnigraphMaintenance(
+        optimize=optimize_cron_job,
+        cleanup=cleanup_cron_job,
+    )

--- a/tests/ol_infrastructure/applications/omnigraph/test_maintenance.py
+++ b/tests/ol_infrastructure/applications/omnigraph/test_maintenance.py
@@ -28,6 +28,15 @@ GRAPHS = ["council", "code-bridge", "code-github-com-mitodl-ol-django"]
 
 CLEANUP_ARGS = ["--older-than", DEFAULT_CLEANUP_OLDER_THAN, "--confirm", "--yes"]
 
+# Deliberately NOT the real bucket or actor. Both reach the script through the
+# environment, and what is under test is that it passes them through unaltered —
+# nothing here pins a naming convention. The real values are built in
+# data_tier.py (`ol-data-witan-<env>` from the OLBucket, and CLUSTER_APPLY_ACTOR),
+# so a realistic-looking literal here would only send someone renaming the bucket
+# to a test that never needed to change.
+STORAGE_ROOT = "s3://test-storage-root"
+MAINTENANCE_ACTOR = "test-actor"
+
 
 class SweepResult:
     """A sweep run: its exit status and the argv of each ``omnigraph`` call."""
@@ -82,8 +91,8 @@ def run_sweep(tmp_path: Path):
             text=True,
             env={
                 "PATH": str(bin_dir),
-                "OMNIGRAPH_STORAGE_ROOT": "s3://ol-data-witan-ci",
-                "OMNIGRAPH_MAINTENANCE_ACTOR": "svc-witan-admin",
+                "OMNIGRAPH_STORAGE_ROOT": STORAGE_ROOT,
+                "OMNIGRAPH_MAINTENANCE_ACTOR": MAINTENANCE_ACTOR,
             },
             check=False,
         )
@@ -119,11 +128,11 @@ def test_sweep_addresses_the_cluster_root_not_a_bare_uri(run_sweep):
     assert call == [
         "optimize",
         "--cluster",
-        "s3://ol-data-witan-ci",
+        STORAGE_ROOT,
         "--graph",
         "council",
         "--as",
-        "svc-witan-admin",
+        MAINTENANCE_ACTOR,
     ]
 
 
@@ -190,11 +199,11 @@ def test_shell_metacharacters_in_config_do_not_escape_the_argument(run_sweep):
     assert call == [
         "cleanup",
         "--cluster",
-        "s3://ol-data-witan-ci",
+        STORAGE_ROOT,
         "--graph",
         "council",
         "--as",
-        "svc-witan-admin",
+        MAINTENANCE_ACTOR,
         "--older-than",
         hostile,
         "--confirm",

--- a/tests/ol_infrastructure/applications/omnigraph/test_maintenance.py
+++ b/tests/ol_infrastructure/applications/omnigraph/test_maintenance.py
@@ -150,6 +150,59 @@ def test_cleanup_retention_is_an_age_not_a_version_count(run_sweep):
     assert "--keep" not in call
 
 
+def test_a_misconfigured_retention_stays_one_argument(run_sweep):
+    """``cleanup_older_than`` is operator-set Pulumi config, so it can be junk.
+
+    Unquoted, the plausible typo ``30 days`` splits into two shell words and the
+    CLI gets a stray positional argument — a confusing failure at 4am on a
+    Sunday. Quoted, it arrives as one argument and comes back as a duration
+    parse error naming the value.
+    """
+    result = run_sweep(
+        _sweep_script(
+            "cleanup", ["--older-than", "30 days", "--confirm", "--yes"], ["council"]
+        )
+    )
+
+    (call,) = result.calls
+    assert call[call.index("--older-than") + 1] == "30 days"
+
+
+def test_shell_metacharacters_in_config_do_not_escape_the_argument(run_sweep):
+    """Nothing an operator can put in config should change what runs.
+
+    Config is only settable by someone who could edit this program anyway, so
+    this is not a privilege boundary — but a value that silently rewrites the
+    command line is a failure mode worth foreclosing rather than reasoning
+    about.
+    """
+    hostile = '30d"; echo owned; #'
+    result = run_sweep(
+        _sweep_script(
+            "cleanup", ["--older-than", hostile, "--confirm", "--yes"], ["council"]
+        )
+    )
+
+    # The whole argv, not just the one field: had the metacharacters escaped,
+    # the `#` would have commented out everything after it and the flags below
+    # would be missing from the recorded call.
+    (call,) = result.calls
+    assert call == [
+        "cleanup",
+        "--cluster",
+        "s3://ol-data-witan-ci",
+        "--graph",
+        "council",
+        "--as",
+        "svc-witan-admin",
+        "--older-than",
+        hostile,
+        "--confirm",
+        "--yes",
+    ]
+    assert "owned" not in result.stdout
+
+
 def test_one_bad_graph_does_not_skip_the_rest(run_sweep):
     """A quarantined code graph must not cost every graph after it in the list.
 

--- a/tests/ol_infrastructure/applications/omnigraph/test_maintenance.py
+++ b/tests/ol_infrastructure/applications/omnigraph/test_maintenance.py
@@ -1,0 +1,190 @@
+"""Tests for the scheduled omnigraph store-maintenance sweep.
+
+The sweep is a generated shell script, and every way it can be wrong is quiet.
+A missing ``--yes`` makes every cleanup run refuse and delete nothing; a loop
+that stops at the first bad graph skips the rest of the list without saying so;
+a swallowed exit code reports a Job as successful having maintained nothing.
+None of those show up as an error anybody sees, so they are pinned here.
+
+The script is executed for real against ``/bin/sh`` with a stub ``omnigraph`` on
+PATH, rather than asserted against as a string: the properties that matter are
+behavioural (does it keep going, does it exit non-zero, what arguments does the
+CLI actually receive) and a substring assertion would pass on a script that
+does not run.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from ol_infrastructure.applications.omnigraph.maintenance import (
+    DEFAULT_CLEANUP_OLDER_THAN,
+    _sweep_script,
+)
+
+GRAPHS = ["council", "code-bridge", "code-github-com-mitodl-ol-django"]
+
+CLEANUP_ARGS = ["--older-than", DEFAULT_CLEANUP_OLDER_THAN, "--confirm", "--yes"]
+
+
+class SweepResult:
+    """A sweep run: its exit status and the argv of each ``omnigraph`` call."""
+
+    def __init__(self, returncode: int, calls: list[list[str]], stdout: str):
+        self.returncode = returncode
+        self.calls = calls
+        self.stdout = stdout
+
+    def graphs_swept(self) -> list[str]:
+        """Return the ``--graph`` value of every call, in call order."""
+        return [call[call.index("--graph") + 1] for call in self.calls]
+
+
+@pytest.fixture
+def run_sweep(tmp_path: Path):
+    """Run a generated sweep against a stub ``omnigraph`` that records argv.
+
+    ``fail_for`` names graph ids the stub should exit non-zero for, which is how
+    an unopenable graph presents — the real CLI errors with "graph `X` is not
+    applied in cluster ...".
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    calls_file = tmp_path / "calls.txt"
+
+    def _run(script: str, fail_for: tuple[str, ...] = ()) -> SweepResult:
+        # Records one line of tab-separated argv per invocation, then fails for
+        # the named graphs. Written per-run because the failure set is part of
+        # the stub.
+        fail_cases = "\n".join(f"    {graph}) exit 1 ;;" for graph in fail_for)
+        (bin_dir / "omnigraph").write_text(
+            "#!/bin/sh\n"
+            f'printf "%s\\t" "$@" >> "{calls_file}"\n'
+            f'printf "\\n" >> "{calls_file}"\n'
+            'graph=""\n'
+            "while [ $# -gt 0 ]; do\n"
+            '    if [ "$1" = "--graph" ]; then graph="$2"; fi\n'
+            "    shift\n"
+            "done\n"
+            'case "${graph}" in\n'
+            f"{fail_cases}\n"
+            "esac\n"
+            "exit 0\n"
+        )
+        (bin_dir / "omnigraph").chmod(0o755)
+        calls_file.write_text("")
+
+        completed = subprocess.run(  # noqa: S603
+            [shutil.which("sh") or "/bin/sh", "-c", script],
+            capture_output=True,
+            text=True,
+            env={
+                "PATH": str(bin_dir),
+                "OMNIGRAPH_STORAGE_ROOT": "s3://ol-data-witan-ci",
+                "OMNIGRAPH_MAINTENANCE_ACTOR": "svc-witan-admin",
+            },
+            check=False,
+        )
+        calls = [
+            line.rstrip("\t").split("\t")
+            for line in calls_file.read_text().splitlines()
+            if line.strip()
+        ]
+        return SweepResult(completed.returncode, calls, completed.stdout)
+
+    return _run
+
+
+def test_optimize_sweeps_every_declared_graph(run_sweep):
+    """Every graph in cluster.yaml gets maintained, not just the first."""
+    result = run_sweep(_sweep_script("optimize", [], GRAPHS))
+
+    assert result.returncode == 0
+    assert result.graphs_swept() == GRAPHS
+
+
+def test_sweep_addresses_the_cluster_root_not_a_bare_uri(run_sweep):
+    """``--cluster <root> --graph <id>`` is the only addressing that works.
+
+    A bare positional storage URI addresses a *single graph store* and errors
+    against a cluster root, and omitting ``--graph`` is a hard error listing the
+    available graphs. Both are easy to reintroduce and neither fails until it
+    runs in the cluster.
+    """
+    result = run_sweep(_sweep_script("optimize", [], ["council"]))
+
+    (call,) = result.calls
+    assert call == [
+        "optimize",
+        "--cluster",
+        "s3://ol-data-witan-ci",
+        "--graph",
+        "council",
+        "--as",
+        "svc-witan-admin",
+    ]
+
+
+def test_cleanup_passes_confirm_and_yes(run_sweep):
+    """Both flags are required, for different reasons, on an s3:// store.
+
+    ``--confirm`` arms the destructive run at all; ``--yes`` skips the
+    confirmation an s3:// (non-local) scope otherwise demands, which a pod has
+    no TTY to answer. Dropping either turns every scheduled run into a no-op.
+    """
+    result = run_sweep(_sweep_script("cleanup", CLEANUP_ARGS, ["council"]))
+
+    (call,) = result.calls
+    assert "--confirm" in call
+    assert "--yes" in call
+
+
+def test_cleanup_retention_is_an_age_not_a_version_count(run_sweep):
+    """``--older-than`` alone — see maintenance.py for why ``--keep`` is out."""
+    result = run_sweep(_sweep_script("cleanup", CLEANUP_ARGS, ["council"]))
+
+    (call,) = result.calls
+    assert call[call.index("--older-than") + 1] == DEFAULT_CLEANUP_OLDER_THAN
+    assert "--keep" not in call
+
+
+def test_one_bad_graph_does_not_skip_the_rest(run_sweep):
+    """A quarantined code graph must not cost every graph after it in the list.
+
+    This is the whole reason the loop does not `set -e`: with one graph per
+    managed repo, an early failure would silently drop the tail of the sweep.
+    """
+    result = run_sweep(_sweep_script("optimize", [], GRAPHS), fail_for=("code-bridge",))
+
+    assert result.graphs_swept() == GRAPHS
+
+
+def test_a_failed_graph_still_fails_the_job(run_sweep):
+    """Continuing past a failure must not swallow it.
+
+    A zero exit here reports a successful CronJob run that maintained less than
+    it was asked to, which is the failure nobody would ever go looking for.
+    """
+    result = run_sweep(_sweep_script("optimize", [], GRAPHS), fail_for=("code-bridge",))
+
+    assert result.returncode == 1
+
+
+def test_a_fully_successful_sweep_says_so(run_sweep):
+    """The success line is what distinguishes "swept" from "swept nothing"."""
+    result = run_sweep(_sweep_script("optimize", [], GRAPHS))
+
+    assert "all graphs completed" in result.stdout
+
+
+def test_every_failed_graph_is_named(run_sweep):
+    """An operator needs the whole failing set, not just the first one."""
+    result = run_sweep(
+        _sweep_script("optimize", [], GRAPHS),
+        fail_for=("council", "code-github-com-mitodl-ol-django"),
+    )
+
+    assert result.returncode == 1
+    assert result.graphs_swept() == GRAPHS


### PR DESCRIPTION
### What are the relevant tickets?

N/A — tracked in the witan work graph: `tk-omnigraph-maintenance-cronjob-scheduled-optimize-4321f8`, `tk-ol-infrastructure-set-omnigraph-per-actor-inflig-d241d2`, `tk-consider-omnigraph-require-all-graphs-1-for-fail-a02b6a`.

### Description (What does it do?)

Three deployment gaps in the shared witan data tier, all in `applications/omnigraph`.

**1. Nothing was maintaining the store.** Fragment count and Lance version history grew without bound. Adds two CronJobs — `omnigraph-optimize` (nightly, `20 3 * * *`) and `omnigraph-cleanup` (weekly, `20 4 * * 0`) — running the `omnigraph` CLI baked into the server image, as the `omnigraph-server` IRSA service account, against the S3 store directly. That is not a shortcut: `optimize`/`cleanup`/`repair` are direct-storage commands and reject `--server` outright. `concurrencyPolicy: Forbid`, and the schedules are offset by an hour because Kubernetes cannot express "Forbid against that *other* CronJob".

**2. The per-actor byte cap could never bind.** `OMNIGRAPH_PER_ACTOR_BYTES_MAX` defaulted to 4 GiB — *twice* this pod's 2Gi memory limit. The pod OOMKills before admission control ever declines a write, which turns a designed backpressure signal (429 + `Retry-After`, with client-side retry already shipped in agent-kit) into a hard restart of a single-replica `Recreate` Deployment. Now set to 256 MiB, sized against realistic peak concurrency; in-flight count 16 → 8, since a 1-CPU pod only queues 16. Arithmetic is recorded next to the constants, and `SERVER_MEMORY_LIMIT` is now named so a raised limit forces revisiting the caps.

**3. `OMNIGRAPH_REQUIRE_ALL_GRAPHS` stays unset** — a decision, with the rationale in `data_tier.py`. It was proposed when this cluster served one graph, and that proposal named the multi-graph case as its own reversal condition. `build_cluster_graphs` now declares `council`, `code-bridge`, and one `code-<repo>` graph per managed repo, so the condition has arrived. All-or-nothing startup would let one rebuildable per-repo code graph take down the memory graph every agent session depends on. Quarantine gets the blast radius right. The brownout risk it leaves behind is real, now narrowed to `council` specifically, and belongs with monitoring rather than a startup flag.

### How can this be tested?

**The CLI contract here was verified by running omnigraph 0.8.1 against a real two-graph cluster**, because the design sketch these tasks carried was wrong about the invocation in three ways that would each have failed only in the cluster:

- `omnigraph optimize s3://ol-data-witan-<env>` **does not work**. A bare positional URI addresses a *single graph store*, not a cluster root.
- Maintenance is strictly per-graph. Omitting `--graph` is a hard error — `cluster '<uri>' has 2 graphs: [alpha, beta]; pass --graph <id> to select one` — so there is no all-graphs mode, hence the loop.
- Passing the *config directory* as `--cluster` fails with `has no applied state` even after a successful apply; the state ledger lives under the storage root at `__cluster/state.json`.
- On an `s3://` store `cleanup` needs **both** `--confirm` and `--yes`: a non-local destructive write with no TTY refuses rather than prompting. Without `--yes` every scheduled run would error having deleted nothing. This never reproduces against a local `file://` store.

Automated:

```
uv run pytest tests/ol_infrastructure/applications/omnigraph/  # 24 passed
uv run pre-commit run --files <changed files>                  # all green, incl. mypy
```

The 8 new tests execute the generated sweep against `/bin/sh` with a stub `omnigraph` that records argv, rather than asserting on the script as a string — the properties that matter are behavioural (does it keep going past a bad graph, does it still exit non-zero, what arguments does the CLI actually receive).

Plan:

```
OMNIGRAPH_DOCKER_SHA=<digest> pulumi preview --stack CI
```

```
+ kubernetes:batch/v1:CronJob  omnigraph-optimize-ci   create
+ kubernetes:batch/v1:CronJob  omnigraph-cleanup-ci    create
~ kubernetes:apps/v1:Deployment omnigraph-omnigraph-server-deployment-ci update
```

The preview also shows a replacement of `omnigraph-cluster-apply-ci`. **That is an artifact of the placeholder image digest a local preview has to supply** (`OMNIGRAPH_DOCKER_SHA` is normally injected by the Concourse build job), not of this change — confirmed by running the identical preview on an `origin/main` worktree with the same placeholder, which produces the same replacement. Net delta of this PR is +2 CronJobs and the two env vars.

### Additional Context

**Retention is `--older-than 30d` alone, not `--keep N` as the original sketch proposed.** The CLI reports a combined policy (`keep 2 versions, remove anything older than 2592000s`) without stating whether it *intersects* or *unions* the two constraints. Intersection is more conservative than either alone; a union would let `--keep` delete versions younger than the age cutoff. Since the difference is unverified upstream and only one reading is safe, `--older-than` alone is safe under both. 30d is sized against witan-code's per-writer WIP branch views, which are per-session/per-git-branch and measured in days.

**The sweep deliberately does not `set -e`.** With one code graph per managed repo, stopping at the first failing graph would silently drop the tail of the list. It logs each failure, continues, and exits non-zero at the end naming the full failing set — so a red Job means "at least one graph was not maintained", not "nothing was".

New runbook: `docs/omnigraph-store-maintenance-runbook.md`, including the manual `omnigraph repair` procedure. `repair` is deliberately **not** scheduled — it is reactive, and its `--force` mode publishes drift nothing has verified.

Not covered here, tracked separately: the storage-format-bump upgrade procedure (offline export → rebuild → repoint), and detecting a quarantined `council` graph, which is what the `REQUIRE_ALL_GRAPHS` decision hands to observability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NHzFGPo7AdS85rEZJxaa2E
