### PR TITLE
fix(rootly): stop overriding native CloudWatch dedup and resolution

### DIFF
--- a/src/ol_infrastructure/saas/rootly/__main__.py
+++ b/src/ol_infrastructure/saas/rootly/__main__.py
@@ -80,31 +80,29 @@ CLOUDWATCH_NON_PROD_URGENCY_RULES = [
     },
 ]
 
-# CloudWatch alarms publish both the breach and the ALARM->OK recovery to the
-# same SNS topic (ok_actions in src/ol_infrastructure/components/aws/cloudwatch.py).
-# Rootly otherwise treats every SNS notification as a brand new alert: repeated
-# breach notifications pile up as duplicates, and the recovery never closes
-# anything, so a blip that self-clears in minutes stays open indefinitely and
-# reads as an ongoing incident.
+# Deliberately no deduplication or resolution config on the two CloudWatch
+# sources below: the native cloud_watch integration already does both, keyed on
+# something better than we can express here.
 #
-# AlarmName is the stable identity of a CloudWatch alarm, so keying on it
-# collapses every notification for one alarm onto a single alert, and the
-# resolution rule closes that alert when NewStateValue flips to OK.
-CLOUDWATCH_DEDUPLICATION_KEY_PATH = "$.Message.AlarmName"
-CLOUDWATCH_RESOLUTION_RULE_ATTRIBUTES = {
-    "conditionType": "all",
-    "conditionsAttributes": [
-        {
-            "field": "$.Message.NewStateValue",
-            "kind": "payload",
-            "operator": "is",
-            "value": "OK",
-        },
-    ],
-    "enabled": True,
-    "identifierJsonPath": "$.Message.AlarmName",
-    "identifierReferenceKind": "payload",
-}
+# Per https://docs.rootly.com/integrations/aws-cloudwatch -- "Rootly uses the
+# alarm ARN as the external identifier for the alert, ensuring that repeated
+# alarm triggers update the same alert and that alerts are resolved when the
+# alarm returns to an OK state." The only prerequisite is on the AWS side:
+# "Configure the alarm to send notifications to the SNS topic for both the In
+# alarm and OK states", which is what ok_actions in
+# src/ol_infrastructure/components/aws/cloudwatch.py provides.
+#
+# Setting deduplicate_alerts_by_key here would REPLACE that ARN identifier with
+# a weaker one -- an alarm name is not unique across regions or accounts -- and
+# resolution matches on the ARN, so overriding the key risks recoveries no
+# longer matching the alert they should close. Setting resolution_rule_attributes
+# is simply inert on this source type; the API accepts the write and stores
+# nothing, because native resolution already covers it.
+#
+# deduplicate_alerts_by_key is set to False rather than omitted on purpose:
+# dropping the input leaves the previously-applied `true` in place and Pulumi
+# plans nothing. The stale deduplication_key_path stays behind in Rootly but
+# is unread once deduplication by key is off.
 
 # Foundation resources imported from the existing Rootly account.
 role_admin = rootly.Role(
@@ -2855,10 +2853,8 @@ alerts_source_cloudwatch_critical = rootly.AlertsSource(
     ],
     alert_source_urgency_rules_attributes=CLOUDWATCH_NON_PROD_URGENCY_RULES,
     alert_urgency_id="5d357977-9dbe-42ad-b647-5a442cab3d96",
-    deduplicate_alerts_by_key=True,
+    deduplicate_alerts_by_key=False,
     deduplication_key_kind="payload",
-    deduplication_key_path=CLOUDWATCH_DEDUPLICATION_KEY_PATH,
-    resolution_rule_attributes=CLOUDWATCH_RESOLUTION_RULE_ATTRIBUTES,
     name="Cloudwatch - Critical",
     owner_group_ids=["9f00e9f1-2f13-470e-a856-50ab5003f260"],
     secret=Output.secret(rootly_secrets["alert_source_secrets"]["cloudwatch_critical"]),
@@ -2877,10 +2873,8 @@ alerts_source_cloudwatch_warning = rootly.AlertsSource(
     ],
     alert_source_urgency_rules_attributes=CLOUDWATCH_NON_PROD_URGENCY_RULES,
     alert_urgency_id="5d357977-9dbe-42ad-b647-5a442cab3d96",
-    deduplicate_alerts_by_key=True,
+    deduplicate_alerts_by_key=False,
     deduplication_key_kind="payload",
-    deduplication_key_path=CLOUDWATCH_DEDUPLICATION_KEY_PATH,
-    resolution_rule_attributes=CLOUDWATCH_RESOLUTION_RULE_ATTRIBUTES,
     name="Cloudwatch - Warning",
     owner_group_ids=["9f00e9f1-2f13-470e-a856-50ab5003f260"],
     secret=Output.secret(rootly_secrets["alert_source_secrets"]["cloudwatch_warning"]),

--- a/src/ol_infrastructure/saas/rootly/__main__.py
+++ b/src/ol_infrastructure/saas/rootly/__main__.py
@@ -80,9 +80,10 @@ CLOUDWATCH_NON_PROD_URGENCY_RULES = [
     },
 ]
 
-# Deliberately no deduplication or resolution config on the two CloudWatch
-# sources below: the native cloud_watch integration already does both, keyed on
-# something better than we can express here.
+# Deliberately no CUSTOM deduplication-key or resolution-rule config on the two
+# CloudWatch sources below -- deduplicate_alerts_by_key is switched off so that
+# Rootly's native cloud_watch behaviour handles both, keyed on something better
+# than we can express here.
 #
 # Per https://docs.rootly.com/integrations/aws-cloudwatch -- "Rootly uses the
 # alarm ARN as the external identifier for the alert, ensuring that repeated


### PR DESCRIPTION
### What are the relevant tickets?

N/A — reverts the alert-source half of https://github.com/mitodl/ol-infrastructure/pull/5213. The `ok_actions` half of that PR is untouched and remains the real fix.

### Description (What does it do?)

**Rootly's native CloudWatch integration already deduplicates and auto-resolves.** I did not know this when I wrote #5213, and the configuration I added there was solving a problem the platform had already solved.

From https://docs.rootly.com/integrations/aws-cloudwatch:

> "Rootly uses the alarm ARN as the external identifier for the alert, ensuring that repeated alarm triggers update the same alert and that alerts are resolved when the alarm returns to an OK state."

> "When the same alarm transitions back into the `OK` state, Rootly automatically resolves the corresponding alert."

And the only documented prerequisite is on the AWS side:

> "Configure the alarm to send notifications to the SNS topic for both the **In alarm** and **OK** states. This ensures alerts are created and resolved automatically in Rootly."

That is precisely `ok_actions`, which #5213 added to `OLCloudWatchAlarmSimpleRDS` and `OLCloudWatchAlarmSimpleElastiCache`. **That component change was the complete fix on its own.**

This PR removes the two things #5213 added to the alert sources:

**1. `deduplicate_alerts_by_key` / `deduplication_key_path` — actively risky, so this is the part that matters.** It replaces Rootly's ARN-based external identifier with `$.Message.AlarmName`. An alarm name is not unique across regions or accounts, and — more importantly — native resolution matches on the ARN. Overriding the dedup key risks a recovery no longer matching the alert it is supposed to close, which would defeat the entire purpose of #5213. This is currently live in production.

**2. `resolution_rule_attributes` — inert rather than harmful.** The API accepts the write and stores nothing on a `cloud_watch` source, because native resolution already covers it. This is why it read back `null` after the stack was applied, and why `pulumi preview` reported no drift afterwards: Pulumi's state recorded it as applied (in both inputs and outputs) while Rootly had discarded it. Confirmed to be a platform behaviour and not a provider bug by bypassing Pulumi entirely — a direct API `PATCH` was accepted (`updated_at` advanced) and still left the field `null`. Account-wide, the only source with a resolution rule is the one `generic_webhook` (Pingdom); every `cloud_watch`, `sentry`, `alertmanager`, `email` and `grafana` source is `null`.

### How can this be tested?

`pulumi preview --stack Production` in `src/ol_infrastructure/saas/rootly`:

```
    ~ rootly:index/alertsSource:AlertsSource: (update)
        [urn=...::cloudwatch-critical]
      ~ deduplicateAlertsByKey: true => false
    ~ rootly:index/alertsSource:AlertsSource: (update)
        [urn=...::cloudwatch-warning]
      ~ deduplicateAlertsByKey: true => false

Resources:
    ~ 2 to update
    154 unchanged
```

`pre-commit run` passes (ruff format, ruff check, mypy, detect-secrets).

**After applying**, the end-to-end check is a real alarm cycle. The three `simple-elasticache-mitlearn-redis-ci-*-DatabaseMemoryUsagePercentage` alarms have been stuck in ALARM since 2026-06-29, and existing urgency rules already demote `-ci-` alarms, so watching one of those recover is a zero-paging way to confirm alerts now auto-resolve. Note this only works once the **application** stacks are applied — `ok_actions` is merged but not yet deployed, so no alarm is emitting OK notifications yet.

### Additional Context

**Why `deduplicate_alerts_by_key=False` instead of just deleting the line.** Removing the input entirely produces *no diff* — Pulumi leaves the previously-applied `true` in place and plans nothing, so the override would stay live. The explicit `False` is what generates `true => false`. Worth remembering for any future revert of an optional provider input in this file.

**One residue.** `deduplication_key_path` remains set to `$.Message.AlarmName` in Rootly. Passing `None` produced no diff, so it cannot be cleared from here. It is unread once deduplication by key is off, so this is cosmetic — noted in a code comment rather than worked around.

**Not pursued, for the record.** Before finding the integration doc I investigated two workarounds, both now unnecessary: an alert-triggered `WorkflowAlert` + `WorkflowTaskUpdateAttachedAlerts`, which cannot work because that action is an *incident*-workflow action ("update the status or position of alerts attached to the incident") with no alert-workflow equivalent in Rootly's action catalogue; and converting the sources to `generic_webhook`, which would have meant re-pointing both SNS subscriptions and giving up automatic subscription confirmation, payload parsing, and the auto-derived `{MetricName} - {NewStateReason}` alert summary.
