### PR TITLE
security: Scope data-VPC database ingress to the EKS pod subnets

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -516,7 +516,10 @@ edxapp_db_security_group = ec2.SecurityGroup(
             protocol="tcp",
             from_port=DEFAULT_MYSQL_PORT,
             to_port=DEFAULT_MYSQL_PORT,
-            description="Access to MariaDB from Edxapp web nodes and Vault",
+            description=(
+                "Access to MariaDB from the Vault server security group and the"
+                " whole edxapp VPC CIDR (web and worker nodes)"
+            ),
         ),
         # This is needed because the security group pinning near the bottom does not work
         ec2.SecurityGroupIngressArgs(

--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -498,15 +498,25 @@ edxapp_db_security_group = ec2.SecurityGroup(
             security_groups=[
                 data_vpc["security_groups"]["orchestrator"],
                 data_vpc["security_groups"]["integrator"],
-                vault_stack.require_output("vault_server")["security_group"],
             ],
-            cidr_blocks=data_vpc["k8s_pod_subnet_cidrs"].apply(
-                lambda pod_cidrs: [*pod_cidrs, edxapp_vpc["cidr"]]
-            ),
+            # Airbyte isn't using pod security groups in Kubernetes. This is a
+            # workaround to allow for data integration from the data Kubernetes
+            # cluster. (TMM 2025-05-16)
+            cidr_blocks=data_vpc["k8s_pod_subnet_cidrs"],
             protocol="tcp",
             from_port=DEFAULT_MYSQL_PORT,
             to_port=DEFAULT_MYSQL_PORT,
-            description="Access to MariaDB from Edxapp web nodes",
+            description="Access to MariaDB from data VPC pod subnets",
+        ),
+        ec2.SecurityGroupIngressArgs(
+            security_groups=[
+                vault_stack.require_output("vault_server")["security_group"],
+            ],
+            cidr_blocks=[edxapp_vpc["cidr"]],
+            protocol="tcp",
+            from_port=DEFAULT_MYSQL_PORT,
+            to_port=DEFAULT_MYSQL_PORT,
+            description="Access to MariaDB from Edxapp web nodes and Vault",
         ),
         # This is needed because the security group pinning near the bottom does not work
         ec2.SecurityGroupIngressArgs(

--- a/src/ol_infrastructure/applications/keycloak/__main__.py
+++ b/src/ol_infrastructure/applications/keycloak/__main__.py
@@ -261,16 +261,27 @@ keycloak_database_security_group = ec2.SecurityGroup(
             security_groups=[
                 keycloak_server_security_group.id,
                 vault_stack.require_output("vault_server")["security_group"],
-                data_vpc["security_groups"]["integrator"],
             ],
-            # TODO: @Ardiea 20250521 Why are we opening the entire VPC?  # noqa: FIX002, TD002, E501
-            cidr_blocks=[target_vpc["cidr"], data_vpc["cidr"]],
+            cidr_blocks=[target_vpc["cidr"]],
             protocol="tcp",
             from_port=DEFAULT_POSTGRES_PORT,
             to_port=DEFAULT_POSTGRES_PORT,
             description=(
                 f"Access to Postgres from keycloak nodes on {DEFAULT_POSTGRES_PORT}"
             ),
+        ),
+        ec2.SecurityGroupIngressArgs(
+            security_groups=[
+                data_vpc["security_groups"]["integrator"],
+            ],
+            # Airbyte isn't using pod security groups in Kubernetes. This is a
+            # workaround to allow for data integration from the data Kubernetes
+            # cluster. (TMM 2025-05-16)
+            cidr_blocks=data_vpc["k8s_pod_subnet_cidrs"],
+            protocol="tcp",
+            from_port=DEFAULT_POSTGRES_PORT,
+            to_port=DEFAULT_POSTGRES_PORT,
+            description="Allow access from data VPC pod subnets.",
         ),
     ],
     vpc_id=target_vpc_id,

--- a/src/ol_infrastructure/applications/keycloak/__main__.py
+++ b/src/ol_infrastructure/applications/keycloak/__main__.py
@@ -267,7 +267,9 @@ keycloak_database_security_group = ec2.SecurityGroup(
             from_port=DEFAULT_POSTGRES_PORT,
             to_port=DEFAULT_POSTGRES_PORT,
             description=(
-                f"Access to Postgres from keycloak nodes on {DEFAULT_POSTGRES_PORT}"
+                f"Access to Postgres on {DEFAULT_POSTGRES_PORT} from the keycloak"
+                f" server and Vault server security groups, and the whole"
+                f" {target_vpc_name} CIDR"
             ),
         ),
         ec2.SecurityGroupIngressArgs(

--- a/src/ol_infrastructure/applications/odl_video_service/__main__.py
+++ b/src/ol_infrastructure/applications/odl_video_service/__main__.py
@@ -538,11 +538,8 @@ ovs_database_security_group = ec2.SecurityGroup(
         ec2.SecurityGroupIngressArgs(
             security_groups=[
                 vault_stack.require_output("vault_server")["security_group"],
-                data_vpc["security_groups"]["integrator"],
             ],
-            cidr_blocks=data_vpc["k8s_pod_subnet_cidrs"].apply(
-                lambda pod_cidrs: [*pod_cidrs, target_vpc["cidr"]]
-            ),
+            cidr_blocks=[target_vpc["cidr"]],
             protocol="tcp",
             from_port=DEFAULT_POSTGRES_PORT,
             to_port=DEFAULT_POSTGRES_PORT,
@@ -550,6 +547,19 @@ ovs_database_security_group = ec2.SecurityGroup(
                 "Access to Postgres from odl-video-service nodes on"
                 f" {DEFAULT_POSTGRES_PORT}"
             ),
+        ),
+        ec2.SecurityGroupIngressArgs(
+            security_groups=[
+                data_vpc["security_groups"]["integrator"],
+            ],
+            # Airbyte isn't using pod security groups in Kubernetes. This is a
+            # workaround to allow for data integration from the data Kubernetes
+            # cluster. (TMM 2025-05-16)
+            cidr_blocks=data_vpc["k8s_pod_subnet_cidrs"],
+            protocol="tcp",
+            from_port=DEFAULT_POSTGRES_PORT,
+            to_port=DEFAULT_POSTGRES_PORT,
+            description="Allow access from data VPC pod subnets.",
         ),
     ],
     vpc_id=target_vpc_id,

--- a/src/ol_infrastructure/applications/odl_video_service/__main__.py
+++ b/src/ol_infrastructure/applications/odl_video_service/__main__.py
@@ -544,8 +544,9 @@ ovs_database_security_group = ec2.SecurityGroup(
             from_port=DEFAULT_POSTGRES_PORT,
             to_port=DEFAULT_POSTGRES_PORT,
             description=(
-                "Access to Postgres from odl-video-service nodes on"
-                f" {DEFAULT_POSTGRES_PORT}"
+                f"Access to Postgres on {DEFAULT_POSTGRES_PORT} from the Vault server"
+                f" security group and the whole {target_vpc_name} CIDR"
+                " (odl-video-service nodes)"
             ),
         ),
         ec2.SecurityGroupIngressArgs(


### PR DESCRIPTION
## What are the relevant tickets?

Follow-up from review of https://github.com/mitodl/ol-infrastructure/pull/5092 (dagster `data_loading` → Keycloak DB via dlt).

## Description (What does it do?)

Audit of the ~8 application databases that the data VPC's Airbyte/Dagster workloads ingest from found inconsistent CIDR scoping. Most already follow the minimal pattern — ingress scoped to `data_vpc["k8s_pod_subnet_cidrs"]` (the four /21 EKS pod subnets) — because Airbyte doesn't use pod security groups in Kubernetes, which makes the `data_vpc["security_groups"]["integrator"]` reference on the same rule inert and the CIDR block the actual operative control.

Three were broader than necessary. This PR fixes all three:

1. **keycloak** (`keycloak_database_security_group`) — admitted the **entire data VPC CIDR** (`10.2.0.0/16`, ~65k addresses, ~8x the pod subnets), covering the RDS, public, NAT and non-k8s EC2 subnets that never originate data-integration traffic. Now scoped to the pod subnets in its own rule; `target_vpc["cidr"]` is retained on a separate rule for operations-VPC-local keycloak server + Vault access. Resolves the pre-existing `# TODO: @Ardiea 20250521 Why are we opening the entire VPC?` on that rule.
2. **edxapp** (`edxapp_db_security_group`) — the data-VPC rule's `cidr_blocks` was `[*data_vpc["k8s_pod_subnet_cidrs"], edxapp_vpc["cidr"]]`, folding the whole application VPC into the data-integration rule. Split into separate rules.
3. **odl_video_service** — same shape (`[*data_vpc["k8s_pod_subnet_cidrs"], target_vpc["cidr"]]`). Split the same way.

For (2) and (3) the **effective permission set is unchanged** — this is purely un-conflating the app access path from the data-integration path so each can be reasoned about and tightened independently later. Only keycloak actually narrows.

Confirmed already correct, no changes needed: `mongodb_atlas` (PrivateLink SG), `ocw_studio`, `xpro`, `mit_learn`, `micromasters`, `mitxonline`.

## How can this be tested?

`pulumi preview --diff` run against QA for each stack. Only the intended security group changes appear:

**keycloak QA** — whole data VPC CIDR removed, pod subnets added as a distinct rule:
```
~ cidrBlocks: [ [0]: "10.1.0.0/16"    (unchanged, operations VPC)
              - [1]: "10.2.0.0/16" ]  (data VPC — removed)
+ [1]: cidrBlocks: [ "10.2.128.0/21", "10.2.136.0/21",
                     "10.2.144.0/21", "10.2.152.0/21" ]
       description: "Allow access from data VPC pod subnets."
```

**edxapp mitxonline.QA** and **odl_video_service QA** — rules reshuffle into separate entries with an identical union of allowed sources.

(Both previews then stop on the unrelated `EDXAPP_DOCKER_IMAGE_DIGEST` / `ODL_VIDEO_SERVICE` digest env vars that CI supplies. `pre-commit` including ruff and mypy passes.)

## Additional Context

Network-layer looseness here is mitigated in practice by Vault dynamic credentials gating actual DB auth — each consumer's Vault policy (e.g. `dagster_server_policy.hcl`) scopes to specific `<mount>/creds/readonly` paths. This is defense-in-depth / blast-radius cleanup, **not** an active credential-bypass vulnerability, and PR #5092 was correct that no network change was needed to unblock it. The pre-existing overbreadth simply now also covers that new access path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012hekaJ6dZPWgiJCkPNAPaa
