### PR TITLE
Migrate the student_module_history connection during LMS pre-deploy

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/k8s_resources.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_resources.py
@@ -791,11 +791,11 @@ def create_k8s_resources(  # noqa: C901
                     "lms-migrate",
                     ["python", "manage.py", "lms", "migrate", "--noinput"],
                 ),
-                # `migrate` only ever touches the `default` connection, so the
-                # `student_module_history` schema (edxapp_csmh) is not migrated by
-                # the command above -- StudentModuleHistoryExtendedRouter sends the
-                # StudentModuleHistoryExtended model to its own database, and blocks
-                # every other model's migrations there.
+                # The migrate above passes no `--database`, so it targets only the
+                # `default` connection. StudentModuleHistoryExtendedRouter sends the
+                # StudentModuleHistoryExtended model to the `student_module_history`
+                # connection instead (the edxapp_csmh schema), and blocks every other
+                # model's migrations there -- so csmh needs its own explicit migrate.
                 #
                 # Without this, csmh silently stops receiving migrations: every
                 # deployment sat at 0002 while `default` had advanced to 0003, so

--- a/src/ol_infrastructure/applications/edxapp/k8s_resources.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_resources.py
@@ -791,6 +791,38 @@ def create_k8s_resources(  # noqa: C901
                     "lms-migrate",
                     ["python", "manage.py", "lms", "migrate", "--noinput"],
                 ),
+                # `migrate` only ever touches the `default` connection, so the
+                # `student_module_history` schema (edxapp_csmh) is not migrated by
+                # the command above -- StudentModuleHistoryExtendedRouter sends the
+                # StudentModuleHistoryExtended model to its own database, and blocks
+                # every other model's migrations there.
+                #
+                # Without this, csmh silently stops receiving migrations: every
+                # deployment sat at 0002 while `default` had advanced to 0003, so
+                # csmh kept both of 0003's superseded indexes on student_module_id
+                # and never gained the `student_module_idx` that replaces them. Two
+                # of those stale duplicates went corrupt (errno 1712), which broke
+                # the staff Submission History view and made StudentModule deletion
+                # throw, until they were rebuilt by hand on 2026-08-05.
+                #
+                # Deliberately LMS-only even though Studio also installs the app,
+                # loads the router, and has the connection (cms/envs/common.py lists
+                # `lms.djangoapps.coursewarehistoryextended` among apps "imported by
+                # other apps"). The LMS and CMS pre-deploy Jobs run concurrently, so
+                # migrating csmh from both would race two processes against the same
+                # schema. The LMS is the single owner.
+                (
+                    "lms-migrate-csmh",
+                    [
+                        "python",
+                        "manage.py",
+                        "lms",
+                        "migrate",
+                        "coursewarehistoryextended",
+                        "--noinput",
+                        "--database=student_module_history",
+                    ],
+                ),
                 (
                     "lms-waffleflag",
                     [


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

The LMS pre-deploy `manage.py lms migrate` passes no `--database`, so it targets only the `default` connection. edxapp routes the `coursewarehistoryextended` app to a separate `student_module_history` connection (the `edxapp_csmh` schema) via `StudentModuleHistoryExtendedRouter`, so that schema was never being migrated by the pre-deploy step.

This adds a second pre-deploy command that targets it explicitly:

```
python manage.py lms migrate coursewarehistoryextended --noinput --database=student_module_history
```

Consequence of the gap: `edxapp_csmh` stopped receiving migrations after 2021. Every deployment (mitxonline, xpro, residential, residential-staging) sat at `coursewarehistoryextended.0002` while `default` had advanced to `0003`. Migration `0003` replaces two superseded indexes on `student_module_id` with a single `student_module_idx`; because it never ran against csmh, all four kept both stale duplicates and never gained the replacement. Two of those duplicates were subsequently flagged corrupt by InnoDB (errno 1712) on three of the four deployments, which made the staff Submission History view error and caused `StudentModule` deletion to throw via the `delete_history` `post_delete` receiver. The indexes have already been rebuilt by hand and `0003` fake-applied on the csmh connection of all four deployments; this change is what stops the divergence recurring.

The command is scoped to the `coursewarehistoryextended` app rather than being a bare `migrate --database=...`, because the router routes only that app to this connection. The unscoped form additionally *records* every other app's migrations into `edxapp_csmh.django_migrations` while skipping their DDL, which is how that table accumulated ~1000 rows historically.

**Deliberately LMS-only**, even though Studio would also be capable of running it: `cms/envs/common.py` lists `lms.djangoapps.coursewarehistoryextended` among the apps that "aren't strictly needed by Studio, but are imported by other apps that are", and the CMS resolves the same `StudentModuleHistoryExtendedRouter` and has the `student_module_history` connection in its config. Since the LMS and CMS pre-deploy Jobs run concurrently, migrating csmh from both would race two processes against the same schema. The LMS is the single owner.

### How can this be tested?

`pre-commit` passes on the changed file (ruff format, ruff check, and mypy all green).

`pulumi preview --stack mitxonline.CI` shows exactly one resource changing — the LMS pre-deploy Job, replaced on `~spec` — with everything else untouched:

```
 -- kubernetes:batch/v1:Job lms-edxapp-ci-pre-deploy-job delete original
 +- kubernetes:batch/v1:Job lms-edxapp-ci-pre-deploy-job replace [diff: ~spec]
 ++ kubernetes:batch/v1:Job lms-edxapp-ci-pre-deploy-job create replacement [diff: ~spec]

Resources:
    +-1 to replace
    229 unchanged
```

The spec diff is the added `lms-migrate-csmh` container. No CMS resource changes, as intended. Note that preview requires `EDXAPP_DOCKER_IMAGE_DIGEST` to be set.

Because a Job is immutable, any change to `pre_deploy_commands` replaces it, and the replacement can collide with a still-live Job from a recent deploy (`ttl_seconds_after_finished` is 30 minutes) — preview surfaces this as `creation failed: jobs.batch "lms-edxapp-app-pre-deploy" already exists; Retry #0`. That is inherent to editing this Job at all rather than specific to this change.

To confirm the underlying behaviour on a deployed environment, from an `lms-celery` pod:

```bash
# Before this change: shows 0003 unapplied on the csmh connection
python manage.py lms showmigrations coursewarehistoryextended --database=student_module_history

# Shows the operations that would be applied
python manage.py lms migrate coursewarehistoryextended \
  --database=student_module_history --plan
```

After a deploy carrying this change, `showmigrations` against `--database=student_module_history` should report every `coursewarehistoryextended` migration as applied, and stay in sync with the `default` connection on subsequent releases.

### Additional Context

Two things a reviewer should weigh:

1. **These pre-deploy commands run in parallel, not sequentially.** `pre_deploy_commands` are rendered as separate containers within a single Job pod (`src/ol_infrastructure/components/services/k8s.py`), and all containers in a pod start together. So `lms-migrate-csmh` races `lms-migrate`. I believe this is safe: the csmh run's DDL for non-csmh apps is skipped by the router, and its dependency resolution reads csmh's own migration recorder, so the two runs touch disjoint schemas. Flagging it explicitly in case anyone disagrees.

2. **Pre-existing, not introduced here:** the same parallelism means `lms-waffleflag` already races `lms-migrate`, which looks like a real ordering bug given waffle flags presumably need migrations applied first. Left alone as out of scope for this PR.
