### PR TITLE
fix(omnigraph): size the health probes to a measured boot

### DIFF
--- a/src/ol_infrastructure/applications/omnigraph/data_tier.py
+++ b/src/ol_infrastructure/applications/omnigraph/data_tier.py
@@ -554,13 +554,26 @@ def create_data_tier(  # noqa: PLR0913
                             # sick server. Only failureThreshold=3 kept it from
                             # being a crashloop.
                             #
+                            # The two probes are sized against that measurement
+                            # for DIFFERENT reasons, and only one of them
+                            # carries headroom:
+                            #
+                            # - readiness sits just past the slowest boot (20s
+                            #   vs 19.8s). Deliberate: a failed readiness probe
+                            #   costs nothing but a 5s retry, and every second
+                            #   spent out of the Service is restart outage. It
+                            #   is allowed to be tight.
+                            # - liveness carries the headroom (60s, 3x), because
+                            #   its failure mode is killing a healthy pod.
+                            #
                             # The converge cost scales with the declared graph
-                            # count (~1.2s/graph), so these are set well past
-                            # today's measurement to leave room as
-                            # `managed_repos` grows. A fixed delay still cannot
-                            # track that growth forever; a startupProbe is the
-                            # mechanism that does, and is the right follow-up if
-                            # the graph list keeps expanding.
+                            # count (~1.2s/graph), so as `managed_repos` grows
+                            # readiness will start probing early again — noisy
+                            # but harmless — and liveness eats into its 3x. A
+                            # fixed delay cannot track that growth; a
+                            # startupProbe is the mechanism that does, and is
+                            # the right follow-up if the graph list keeps
+                            # expanding.
                             readiness_probe=kubernetes.core.v1.ProbeArgs(
                                 http_get=kubernetes.core.v1.HTTPGetActionArgs(
                                     path="/healthz",

--- a/src/ol_infrastructure/applications/omnigraph/data_tier.py
+++ b/src/ol_infrastructure/applications/omnigraph/data_tier.py
@@ -536,20 +536,53 @@ def create_data_tier(  # noqa: PLR0913
                             # over a bare TCP check so the probe reflects the
                             # server actually being up, not just the port being
                             # bound.
+                            #
+                            # DELAYS ARE SIZED FROM A MEASURED BOOT, not picked.
+                            # The entrypoint converges the cluster catalog
+                            # *before* the server binds :8080, and that converge
+                            # re-observes every declared graph over S3. Measured
+                            # 2026-08-05 with 17 graphs, from the container's
+                            # first log line to `serving omnigraph bind=`:
+                            #
+                            #     CI 17.2s | QA 19.8s | Production 17.2s
+                            #
+                            # ~95% of which is the converge. At the previous
+                            # values (readiness 5, liveness 15) both probes were
+                            # guaranteed to fire against a closed port on every
+                            # start in every environment — the connection-refused
+                            # Unhealthy events on a healthy boot were this, not a
+                            # sick server. Only failureThreshold=3 kept it from
+                            # being a crashloop.
+                            #
+                            # The converge cost scales with the declared graph
+                            # count (~1.2s/graph), so these are set well past
+                            # today's measurement to leave room as
+                            # `managed_repos` grows. A fixed delay still cannot
+                            # track that growth forever; a startupProbe is the
+                            # mechanism that does, and is the right follow-up if
+                            # the graph list keeps expanding.
                             readiness_probe=kubernetes.core.v1.ProbeArgs(
                                 http_get=kubernetes.core.v1.HTTPGetActionArgs(
                                     path="/healthz",
                                     port=OMNIGRAPH_SERVER_PORT,
                                 ),
-                                initial_delay_seconds=5,
-                                period_seconds=10,
+                                # First probe just past the measured boot, then
+                                # poll fast: this is what ends the restart
+                                # outage, so the gap between "bound" and "in the
+                                # Service" should be small.
+                                initial_delay_seconds=20,
+                                period_seconds=5,
                             ),
                             liveness_probe=kubernetes.core.v1.ProbeArgs(
                                 http_get=kubernetes.core.v1.HTTPGetActionArgs(
                                     path="/healthz",
                                     port=OMNIGRAPH_SERVER_PORT,
                                 ),
-                                initial_delay_seconds=15,
+                                # 3x the slowest measured boot. With
+                                # period_seconds=20 and the default
+                                # failureThreshold=3, a genuinely wedged server
+                                # is still killed by ~100s.
+                                initial_delay_seconds=60,
                                 period_seconds=20,
                             ),
                             resources=kubernetes.core.v1.ResourceRequirementsArgs(


### PR DESCRIPTION
## What are the relevant tickets?

Fallout from work on #5257 — the CI `omnigraph-server` pod was observed restarting
with liveness/readiness failures on a boot that was, in fact, entirely healthy.
Related to the existing witan backlog item on the omnigraph-server restart outage.

## Description (What does it do?)

Both health probes were firing before `omnigraph-server` could possibly answer.

The entrypoint converges the cluster catalog **before** the server binds `:8080`,
and that converge re-observes every declared graph over S3. Measured 2026-08-05
from the container's first log line to `serving omnigraph bind=`, with 17 graphs
declared:

| Env | Boot to bind | of which converge |
| --- | --- | --- |
| CI | 17.2s | 16.8s |
| QA | 19.8s | 19.3s |
| Production | 17.2s | 16.9s |

Against `readiness initial_delay=5` and `liveness initial_delay=15`, both probes
were guaranteed to hit a closed port on **every start in every environment**. The
resulting `connection refused` Unhealthy events look like a sick server during
precisely the window an operator is watching a rollout. Only the default
`failureThreshold=3` kept the liveness probe from turning a normal boot into a
crashloop — the kill threshold was 55s against a ~20s boot.

Changes:

- **liveness `initial_delay` 15 → 60** — 3x the slowest measured boot. With
  `period_seconds=20` and `failureThreshold=3` unchanged, a genuinely wedged
  server is still killed by ~100s.
- **readiness `initial_delay` 5 → 20, `period` 10 → 5** — first probe just past
  the measured boot, then poll faster. The gap between the server binding and
  rejoining the Service *is* the restart outage, so a shorter period shortens it:
  previously first success landed at 25s, now ~20s.

The reasoning and the measurements are recorded in a comment next to the values,
since a bare `60` invites someone to tune it back down.

## How can this be tested?

`pulumi preview` on the omnigraph stack should show only the probe fields changing
on the Deployment's pod template. Note this **will** restart the data tier
(single-replica `Recreate`), which is the expected ~20s outage.

After deploy, a boot should produce no Unhealthy events at all:

```shell
kubectl -n omnigraph get events --sort-by=.lastTimestamp | grep -i unhealthy
```

Measurements are reproducible with:

```shell
kubectl -n omnigraph logs deploy/omnigraph-server --timestamps \
  | grep -E 'converging cluster catalog|serving omnigraph'
```

## Additional context

**This buys headroom, not a permanent fix.** The converge cost scales with the
declared graph count (~1.2s/graph across the 17 currently declared), so as
`omnigraph:managed_repos` grows, boot time grows with it and these constants drift
back toward the same failure. A `startupProbe` is the mechanism that actually
tracks a variable boot — liveness does not begin until startup succeeds — and is
the right follow-up if the graph list keeps expanding. I have not added one here
because it changes probe semantics rather than just their timing, and that felt
like a separate, deliberate decision rather than something to fold into a
constants change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbTKYwDtNTskNKWg47NW2M