### PR TITLE
feat(edxapp): enable ol_openedx_feedback content feedback waffle flag for mitxonline QA

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.QA.yaml
@@ -56,6 +56,7 @@ config:
   - ["studio.enable_checklists_quality", "--create", "--superusers", "--everyone"]
   - ["teams.enable_teams_app", "--create", "--superusers", "--staff"]
   - ["instructor.legacy_instructor_dashboard", "--deactivate"]
+  - ["ol_openedx_feedback.feedback_enabled", "--create", "--everyone"]
   edxapp:use_extracted_html_block: "false"
   edxapp:business_unit: mitxonline
   edxapp:db_password:


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/11629

### Description (What does it do?)

Adds the `ol_openedx_feedback.feedback_enabled` `CourseWaffleFlag` to the `edxapp:waffle_flags` list for the **mitxonline QA (RC)** edxapp stack, set to `--create --everyone`.

This is the LMS-side gate for the per-block content feedback feature. The flag is currently set to `Everyone: Yes` **manually via Django admin** on RC, so its "on" state lives only in mutable DB state and isn't captured in code. 

- The entry is **idempotent** — the flag is already `Everyone: Yes` on RC, so re-applying `--create --everyone` is a no-op.
- Scope is limited to `Pulumi.mitxonline.QA.yaml`; the CI/Production configs are intentionally left unchanged.

### Screenshots (if appropriate):

N/A — config-only change.

### How can this be tested?

- After deploy, confirm the LMS `lms-waffleflag` init step ran successfully and the flag is present: `./manage.py lms waffle_flag --list` should include `ol_openedx_feedback.feedback_enabled` with everyone = Yes.
- In Django admin (waffle → Flags), `ol_openedx_feedback.feedback_enabled` shows `Everyone: Yes`.
- On an RC course, the "Send feedback" megaphone renders next to leaf blocks (video/problem/html) and not on containers (course/chapter/sequential/vertical).

### Additional Context

This PR only controls whether the feedback **trigger renders** in the LMS. The submit path is gated by separate, companion infra work (MFE feedback env, the mit-learn CSRF courseware-origin allow-list, and pointing the feedback URLs at the API domain). Enabling this flag does not change that path; it codifies the already-live RC state.