### PR TITLE
fix(edxapp): build a real mitx-staging OEP-65 Site Project

### DIFF
--- a/src/ol_concourse/pipelines/open_edx/mfe/site_pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/mfe/site_pipeline.py
@@ -11,7 +11,11 @@ Usage (called by meta.py, analogous to pipeline.py):
 
     e.g. python site_pipeline.py mitxonline
 
-Supported deployments: mitxonline, mitx, xpro.
+Supported deployments: mitxonline, mitx, mitx-staging, xpro.  mitx-staging has
+no Site Project directory of its own in lehrer — it builds from frontend/mitx
+(see ``SiteProjectEnv.config_source``) and publishes to its own bucket/public
+path, since per-site values come from the runtime frontend_site_config API
+rather than the build.
 
 Build: mitodl/dcind:latest (Docker-in-Docker) + ``dagger call mfe build-site``.
 Promote: rclone cross-bucket copy — no rebuild at QA or Production.
@@ -56,6 +60,12 @@ class SiteProjectEnv:
     deployment_name: str
     environment: str  # e.g. "mitxonline-ci"
     environment_stage: str  # "CI", "QA", "Production"
+    # lehrer frontend/ subdirectory to build from, when it differs from
+    # deployment_name — e.g. mitx-staging builds from frontend/mitx, since its
+    # site.config.build.tsx is explicitly written to cover both deployments
+    # (real per-site values come from the runtime frontend_site_config API,
+    # not the build).  Defaults to deployment_name when unset.
+    config_source: str | None = None
 
 
 @dataclass
@@ -85,6 +95,26 @@ SITE_PROJECTS: list[SiteProjectConfig] = [
             SiteProjectEnv("mitx", "mitx-production", "Production"),
         ],
     ),
+    # mitx-staging has no frontend/mitx-staging/ Site Project of its own — it
+    # builds from frontend/mitx (see SiteProjectEnv.config_source) and
+    # publishes under its own deployment identity/bucket.
+    SiteProjectConfig(
+        deployment_name="mitx-staging",
+        envs=[
+            SiteProjectEnv(
+                "mitx-staging", "mitx-staging-ci", "CI", config_source="mitx"
+            ),
+            SiteProjectEnv(
+                "mitx-staging", "mitx-staging-qa", "QA", config_source="mitx"
+            ),
+            SiteProjectEnv(
+                "mitx-staging",
+                "mitx-staging-production",
+                "Production",
+                config_source="mitx",
+            ),
+        ],
+    ),
     SiteProjectConfig(
         deployment_name="xpro",
         envs=[
@@ -96,13 +126,13 @@ SITE_PROJECTS: list[SiteProjectConfig] = [
 ]
 
 
-def _lehrer_resource(deployment_name: str) -> Resource:
+def _lehrer_resource(deployment_name: str, config_source: str) -> Resource:
     return git_repo(
         name=Identifier(f"lehrer-{deployment_name}"),
         uri=LEHRER_URI,
         branch="main",
         paths=[
-            f"deployments/mit-ol/mfe_slot_config/frontend/{deployment_name}/",
+            f"deployments/mit-ol/mfe_slot_config/frontend/{config_source}/",
             "deployments/mit-ol/mfe_slot_config/frontend/shared/",
         ],
     )
@@ -160,7 +190,8 @@ def site_build_job(
     DinD), exports dist/, then syncs it to the deployment's CI S3 bucket.
     QA and Production artifacts are promoted via :func:`site_promote_job`.
     """
-    lehrer = _lehrer_resource(env.deployment_name)
+    config_source = env.config_source or env.deployment_name
+    lehrer = _lehrer_resource(env.deployment_name, config_source)
     post_resource = _gh_issues_post(env.deployment_name, env.environment_stage)
 
     get_lehrer = GetStep(get=lehrer.name, trigger=True)
@@ -173,7 +204,7 @@ def site_build_job(
 
     deployment = env.deployment_name
     lehrer_input = str(lehrer.name)
-    site_project_path = f"./deployments/mit-ol/mfe_slot_config/frontend/{deployment}"
+    site_project_path = f"./deployments/mit-ol/mfe_slot_config/frontend/{config_source}"
     shared_src_path = "./deployments/mit-ol/mfe_slot_config/frontend/shared"
     public_path = f"/apps/{deployment}-site/"
 

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.CI.yaml
@@ -131,6 +131,6 @@ config:
   typesense:course_search_enabled: "true"
   typesense:forum_search_enabled: "false"
   edxapp:site_project:
-    deployment: mitx
+    deployment: mitx-staging
     mfe_apps:
     - instructor-dashboard

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.Production.yaml
@@ -133,6 +133,6 @@ config:
   typesense:course_search_enabled: "true"
   typesense:forum_search_enabled: "false"
   edxapp:site_project:
-    deployment: mitx
+    deployment: mitx-staging
     mfe_apps:
     - instructor-dashboard

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.QA.yaml
@@ -132,6 +132,6 @@ config:
   typesense:course_search_enabled: "true"
   typesense:forum_search_enabled: "false"
   edxapp:site_project:
-    deployment: mitx
+    deployment: mitx-staging
     mfe_apps:
     - instructor-dashboard


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
The instructor-dashboard "frontend-base" (OEP-65 Site Project) build for `mitx-staging` was failing entirely because it was never actually built. `edxapp:site_project.deployment` was set to `mitx` in the `mitx-staging` stack configs on the assumption that mitx-staging could just reuse mitx's build artifact — but nothing in the codebase actually copies or shares S3 assets across deployments, and `mitx-staging` was never registered in `SITE_PROJECTS` at all, so there was no Concourse pipeline generating or publishing anything for it.

Two changes, needed together:

1. **`src/ol_concourse/pipelines/open_edx/mfe/site_pipeline.py`** — registers `mitx-staging` in `SITE_PROJECTS` so the self-managing meta pipeline creates a real `create-mitx-staging-site-pipeline` job. `mitx-staging` has no `frontend/mitx-staging/` Site Project source of its own in the [lehrer](https://github.com/mitodl/lehrer) repo — its `site.config.build.tsx` explicitly covers both `mitx` and `mitx-staging` via a single build, since per-site values (domains, branding) are supplied at runtime by `/api/frontend_site_config/v1/` rather than baked into the build. So a new `SiteProjectEnv.config_source` field lets `mitx-staging` build from the shared `frontend/mitx` source while still publishing under its own identity: public path `/apps/mitx-staging-site/` and bucket prefix `mitx-staging-site/` in its own per-stage S3 buckets (`mitx-staging-{ci,qa,production}-edxapp-mfe`).

2. **`Pulumi.mitx-staging.{CI,QA,Production}.yaml`** — corrects `edxapp:site_project.deployment` from `mitx` to `mitx-staging` in all three stages, so the Fastly VCL rewrite (`/apps/{deployment}-site/` → `{deployment}-site/index.html`) matches what the new pipeline actually publishes into mitx-staging's own bucket, instead of looking for a `mitx-site/` prefix that will never exist there.

Verified the other three deployments (`mitx`, `mitxonline`, `xpro`) produce byte-identical pipeline output to before this change.

### Screenshots (if appropriate):
N/A — no UI changes, Concourse pipeline / Pulumi config only.

### How can this be tested?
- `uv run python -c "from ol_concourse.pipelines.open_edx.mfe.site_pipeline import site_pipeline; print(site_pipeline('mitx-staging').model_dump_json(indent=2))"` generates a valid pipeline with CI build + QA/Production promote jobs, building from `frontend/mitx` and publishing to `mitx-staging-site/`.
- Confirmed `mitx`, `mitxonline`, and `xpro` still generate identical pipelines (no regression from the `config_source` refactor).
- `pre-commit run` (ruff format/check, mypy, yamllint) passes on all four changed files.
- After merge, the `set-mfe-meta-pipeline` job will register `create-mitx-staging-site-pipeline`; triggering it should produce a working `mitx-staging-site-pipeline` that builds and, once promoted through the GitHub-issue gates, populates `mitx-staging-{ci,qa,production}-edxapp-mfe/mitx-staging-site/`. A subsequent `pulumi up` on the `edxapp` stacks picks up the corrected `site_project.deployment` value.

### Additional Context
This assumes the `mitx-staging` Concourse team already exists (used elsewhere, e.g. `deployment_groups` in `src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py`), since `site_meta_job` sets `team=Identifier(deployment_name)` on the generated `SetPipelineStep`.