### PR TITLE
feat(omnigraph): storage_prefix override so a format migration repoints by config

### DIFF
--- a/docs/omnigraph-storage-format-upgrade-runbook.md
+++ b/docs/omnigraph-storage-format-upgrade-runbook.md
@@ -159,15 +159,19 @@ each old store first, leaving S3 object versioning as the only rollback. Do not
 do that. Reassembling a Lance store from thousands of object versions is not a
 recovery path anyone should be attempting under time pressure.
 
-> **Prerequisite, read before scheduling.** The storage root is derived, not
-> configurable: `data_tier.py` sets
-> `bucket_name = f"ol-data-witan-{stack_info.env_suffix}"` and builds `storage:`
-> from it. **There is no `omnigraph:storage_root` config key yet**, so step 5
-> repoints by editing that derivation, and setting a config key of that name
-> today would no-op silently. Adding the override — an optional key that
-> replaces the derived storage URI in cluster.yaml while leaving bucket
-> creation and IRSA alone — is what makes step 5 a config change instead.
-> Tracked in the witan project backlog.
+Repointing is a config change: **`omnigraph:storage_prefix`**. Unset (the
+steady state) puts the graphs at the bucket root; set to `fmt5` they live at
+`s3://ol-data-witan-<env>/fmt5`. Step 5 sets it, rollback removes it, and no
+code is edited during the outage.
+
+It is a *prefix inside the managed bucket*, not a free-form URI, on purpose:
+the bucket, its IAM policy and the IRSA grant are all keyed to the derived
+name, so a full URI could aim the cluster at storage nothing has granted
+access to — and that failure would land mid-migration. Keeping it inside the
+bucket also means backups and versioning cover the new root for free. The
+value is validated at `pulumi preview` time (single `[A-Za-z0-9._-]` segment,
+no wrapping slashes), which is the only place it *can* be caught — see the
+`cluster validate` note in step 4.
 
 ## Addressing: `--store`, not `--cluster`
 
@@ -479,28 +483,18 @@ and is the safe choice — `overwrite` is destructive and buys nothing here.
 
 ### 5. Repoint the cluster and deploy the new image
 
-> **Do this by code edit today.** `omnigraph:storage_root` does not exist yet
-> (see *Prerequisite* above). Setting that config key on a stack that does not
-> read it **fails silently** — `pulumi up` reports success, cluster.yaml still
-> names the old root, and the new binary hits the same version gate that
-> started this outage. Do not run `pulumi config set omnigraph:storage_root`
-> until the override has actually landed.
+Set the prefix — the same one `$NEW_ROOT` names, without the `s3://<bucket>/`:
 
-Edit the storage URI in `src/ol_infrastructure/applications/omnigraph/data_tier.py`:
-
-```python
-# storage_uri: Output[str] = omnigraph_bucket.bucket_v2.bucket.apply(
-#     lambda name: f"s3://{name}"
-# )
-storage_uri: Output[str] = omnigraph_bucket.bucket_v2.bucket.apply(
-    lambda name: f"s3://{name}/fmt<N>"      # storage-format migration <date>
-)
+```shell
+cd src/ol_infrastructure/applications/omnigraph
+pulumi config set omnigraph:storage_prefix fmt5 --stack <CI|QA|Production>
 ```
 
-Change only this value. Leave the `OLBucket`, the IAM policy, and the IRSA
-grant keyed to the derived bucket name — the new root is a prefix *inside* that
-same bucket, so they already cover it, and repointing them would drop the
-grant and the versioning config.
+A malformed value fails the preview rather than deploying: wrapping slashes and
+anything outside a single `[A-Za-z0-9._-]` segment are rejected, which includes
+an unsubstituted `fmt<N>`. That check lives here because it cannot live
+downstream — `cluster validate` accepts any storage string, empty ones
+included.
 
 Confirm the generated config before applying:
 
@@ -523,15 +517,6 @@ pulumi preview --stack <CI|QA|Production> --json \
 
 Then let the paused pipeline's deploy job for this environment run (or
 `pulumi up` directly with `OMNIGRAPH_DOCKER_SHA` set to the new digest).
-
-**Once `omnigraph:storage_root` lands**, this whole step collapses to:
-
-```shell
-pulumi config set omnigraph:storage_root "$NEW_ROOT" --stack <CI|QA|Production>
-```
-
-with the same `pulumi preview` confirmation, and the rollback below becomes
-`pulumi config rm` instead of reverting the edit.
 
 The deploy regenerates cluster.yaml against the new root, runs its own
 `cluster apply` Job — a no-op, since step 4 already converged that root — and
@@ -595,9 +580,13 @@ the only fast rollback. Delete it, and the workstation copy of the exports in
 Before step 5 there is nothing to roll back: scale to 1 and you are on the old
 image against the old root.
 
-After step 5 — revert the `storage_uri` edit from that step (or, once the
-override lands, `pulumi config rm omnigraph:storage_root --stack <…>`), then
-redeploy with `OMNIGRAPH_DOCKER_SHA` pinned to the **old** image digest.
+After step 5:
+
+```shell
+pulumi config rm omnigraph:storage_prefix --stack <CI|QA|Production>
+```
+
+then redeploy with `OMNIGRAPH_DOCKER_SHA` pinned to the **old** image digest.
 Confirm with the same `pulumi preview --diff` check that `storage:` is back to
 the derived root before applying.
 

--- a/src/ol_infrastructure/applications/omnigraph/__main__.py
+++ b/src/ol_infrastructure/applications/omnigraph/__main__.py
@@ -54,13 +54,13 @@ from ol_infrastructure.applications.omnigraph.data_tier import (
     OMNIGRAPH_SERVER_SERVICE_NAME,
     create_data_tier,
     omnigraph_server_addr,
-    validate_storage_prefix,
 )
 from ol_infrastructure.applications.omnigraph.maintenance import (
     DEFAULT_CLEANUP_OLDER_THAN,
     DEFAULT_CLEANUP_SCHEDULE,
     DEFAULT_OPTIMIZE_SCHEDULE,
 )
+from ol_infrastructure.applications.omnigraph.storage import validate_storage_prefix
 from ol_infrastructure.applications.omnigraph.token_sync import (
     ACTOR_TOKENS_VAULT_PATH,
     DEFAULT_SYNC_SCHEDULE,
@@ -475,6 +475,9 @@ export("omnigraph_server_image_repository", data_tier.image_repository)
 # writer's repo list and the cluster's graph list are the same list, and a
 # second copy of it in another stack's config could only ever drift.
 export("managed_repos", MANAGED_REPOS)
-# The active storage root, so an operator mid-migration can confirm which
-# root the cluster is actually serving without reading the ConfigMap.
+# Mid-migration, the question an operator has is "which root is being served",
+# so export the resolved URI — not just the config knob that shaped it, which
+# is empty in the steady state and says nothing about the bucket. The prefix
+# goes out alongside it because that is the value they would set or clear.
+export("storage_uri", data_tier.storage_uri)
 export("storage_prefix", STORAGE_PREFIX)

--- a/src/ol_infrastructure/applications/omnigraph/__main__.py
+++ b/src/ol_infrastructure/applications/omnigraph/__main__.py
@@ -54,6 +54,7 @@ from ol_infrastructure.applications.omnigraph.data_tier import (
     OMNIGRAPH_SERVER_SERVICE_NAME,
     create_data_tier,
     omnigraph_server_addr,
+    validate_storage_prefix,
 )
 from ol_infrastructure.applications.omnigraph.maintenance import (
     DEFAULT_CLEANUP_OLDER_THAN,
@@ -108,6 +109,25 @@ omnigraph_config = Config("omnigraph")
 # build_cluster_graphs). A repo that is not listed fails to resolve rather than
 # silently minting a graph nobody provisioned or backs up.
 MANAGED_REPOS: list[str] = omnigraph_config.get_object("managed_repos") or []
+
+# Storage-root override for a storage-format migration. Unset (the steady
+# state) puts the cluster's graphs at the bucket root. Set it and they live at
+# `s3://ol-data-witan-<env>/<prefix>` instead — which is how
+# docs/omnigraph-storage-format-upgrade-runbook.md repoints the cluster at
+# graphs rebuilt under a new root while the old root stays intact as the
+# rollback.
+#
+# A prefix inside the managed bucket, NOT a full URI: the bucket, its IAM
+# policy and the IRSA grant are all keyed to the derived name, so a free-form
+# URI could aim the cluster at storage nothing has granted access to. It is
+# also what keeps backups and versioning covering the new root for free.
+#
+# Validated here rather than at the point of use because the failure this
+# guards against is silent: `omnigraph cluster validate` accepts any storage
+# string, including an empty one, so a malformed root is not caught downstream
+# — it just builds the graphs somewhere nobody looks. See the runbook's
+# "cluster validate does not catch an empty storage:" note.
+STORAGE_PREFIX: str = validate_storage_prefix(omnigraph_config.get("storage_prefix"))
 
 # Keycloak realm -> actor-token sync. Set `omnigraph:keycloak_url` for an
 # environment to turn it on; leaving it unset keeps that environment on the
@@ -440,6 +460,7 @@ data_tier = create_data_tier(
     optimize_schedule=OPTIMIZE_SCHEDULE,
     cleanup_schedule=CLEANUP_SCHEDULE,
     cleanup_older_than=CLEANUP_OLDER_THAN,
+    storage_prefix=STORAGE_PREFIX,
 )
 
 export("namespace", NAMESPACE)
@@ -454,3 +475,6 @@ export("omnigraph_server_image_repository", data_tier.image_repository)
 # writer's repo list and the cluster's graph list are the same list, and a
 # second copy of it in another stack's config could only ever drift.
 export("managed_repos", MANAGED_REPOS)
+# The active storage root, so an operator mid-migration can confirm which
+# root the cluster is actually serving without reading the ConfigMap.
+export("storage_prefix", STORAGE_PREFIX)

--- a/src/ol_infrastructure/applications/omnigraph/data_tier.py
+++ b/src/ol_infrastructure/applications/omnigraph/data_tier.py
@@ -223,6 +223,53 @@ def code_graph_id(repo: str) -> str:
     return f"{CODE_GRAPH_PREFIX}{body[:keep].strip('-')}-{digest}"
 
 
+def validate_storage_prefix(prefix: str | None) -> str:
+    """Normalize and check ``omnigraph:storage_prefix``; return "" when unset.
+
+    The storage root is normally the bucket root; a prefix moves it to
+    ``s3://<bucket>/<prefix>`` for a storage-format migration (see
+    ``docs/omnigraph-storage-format-upgrade-runbook.md``).
+
+    Validated up front because every failure downstream of here is silent:
+    ``omnigraph cluster validate`` accepts *any* storage string, including an
+    empty one, so a malformed root is never caught by the tooling — the
+    migration just rebuilds the graphs somewhere nobody is looking, and
+    ``load`` reports success on top of it.
+
+    Raises ``ValueError`` on a leading/trailing ``/`` (it is joined as
+    ``s3://<bucket>/<prefix>``) or on anything that is not a single
+    ``[A-Za-z0-9._-]`` path segment. That last rule is what catches an
+    unsubstituted ``fmt<N>`` copied out of the runbook: ``<`` and ``>`` are
+    legal in S3 object keys, so it would otherwise become a real prefix.
+    """
+    cleaned = (prefix or "").strip()
+    if not cleaned:
+        return ""
+    if cleaned.startswith("/") or cleaned.endswith("/"):
+        msg = (
+            f"omnigraph:storage_prefix must not start or end with '/': "
+            f"{cleaned!r}. It is joined as s3://<bucket>/<prefix>."
+        )
+        raise ValueError(msg)
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", cleaned):
+        msg = (
+            f"omnigraph:storage_prefix must be a single path segment of "
+            f"[A-Za-z0-9._-] starting alphanumeric: {cleaned!r}. An "
+            "unsubstituted placeholder such as 'fmt<N>' lands here."
+        )
+        raise ValueError(msg)
+    return cleaned
+
+
+def storage_uri_for(bucket: str, prefix: str) -> str:
+    """Cluster storage root for ``bucket``, optionally under ``prefix``.
+
+    Kept separate from the ``Output.apply`` that calls it so the join is
+    testable — an off-by-one slash here silently relocates every graph.
+    """
+    return f"s3://{bucket}/{prefix}" if prefix else f"s3://{bucket}"
+
+
 def build_cluster_graphs(managed_repos: list[str]) -> dict[str, dict[str, str]]:
     """Build the ``graphs:`` block of cluster.yaml for ``managed_repos``.
 
@@ -292,8 +339,18 @@ def create_data_tier(  # noqa: PLR0913
     optimize_schedule: str,
     cleanup_schedule: str,
     cleanup_older_than: str,
+    storage_prefix: str = "",
 ) -> OmnigraphDataTier:
-    """Provision the S3 bucket, IRSA policy, ECR repo, ConfigMap, and Deployment."""
+    """Provision the S3 bucket, IRSA policy, ECR repo, ConfigMap, and Deployment.
+
+    ``storage_prefix`` moves the cluster's storage root to a prefix inside the
+    managed bucket (``s3://<bucket>/<prefix>``) instead of the bucket root. It
+    exists for the storage-format migration in
+    ``docs/omnigraph-storage-format-upgrade-runbook.md``, where the graphs are
+    rebuilt under a new root and the cluster is then repointed at it, leaving
+    the old root intact as the rollback. Empty (the default) means the bucket
+    root, which is the steady state.
+    """
     # The bucket is named for its tenant (witan's graphs), not the omnigraph
     # service — omnigraph is generic and a future second instance would get its
     # own tenant-named bucket rather than colliding on an omnigraph-named one.
@@ -373,8 +430,18 @@ def create_data_tier(  # noqa: PLR0913
     # ``cluster.yaml`` file and leaves those baked-in schemas visible alongside
     # it, rather than replacing the whole directory.
     cluster_graphs = build_cluster_graphs(managed_repos)
+    # Storage root. Normally the bucket root; `omnigraph:storage_prefix` moves
+    # it to a prefix *inside* that same bucket, which is what a storage-format
+    # migration needs (docs/omnigraph-storage-format-upgrade-runbook.md).
+    #
+    # Deliberately a prefix rather than a full URI: the bucket, its IAM policy
+    # and the IRSA grant above stay keyed to the derived name no matter what
+    # this is set to. A free-form URI could point the cluster at a bucket
+    # nothing has granted access to, and the failure would land mid-migration.
+    # `cluster validate` would not catch it either — it accepts any storage
+    # string, including an empty one.
     storage_uri: Output[str] = omnigraph_bucket.bucket_v2.bucket.apply(
-        lambda name: f"s3://{name}"
+        lambda name: storage_uri_for(name, storage_prefix)
     )
     cluster_name = f"mitodl-witan-{stack_info.env_suffix.lower()}"
     cluster_yaml_content: Output[str] = storage_uri.apply(

--- a/src/ol_infrastructure/applications/omnigraph/data_tier.py
+++ b/src/ol_infrastructure/applications/omnigraph/data_tier.py
@@ -56,6 +56,7 @@ from ol_infrastructure.applications.omnigraph.maintenance import (
     OmnigraphMaintenance,
     create_maintenance,
 )
+from ol_infrastructure.applications.omnigraph.storage import storage_uri_for
 from ol_infrastructure.components.applications.eks import OLEKSAuthBinding
 from ol_infrastructure.components.aws.s3 import OLBucket, S3BucketConfig
 from ol_infrastructure.components.services.vault import OLVaultK8SSecret
@@ -223,53 +224,6 @@ def code_graph_id(repo: str) -> str:
     return f"{CODE_GRAPH_PREFIX}{body[:keep].strip('-')}-{digest}"
 
 
-def validate_storage_prefix(prefix: str | None) -> str:
-    """Normalize and check ``omnigraph:storage_prefix``; return "" when unset.
-
-    The storage root is normally the bucket root; a prefix moves it to
-    ``s3://<bucket>/<prefix>`` for a storage-format migration (see
-    ``docs/omnigraph-storage-format-upgrade-runbook.md``).
-
-    Validated up front because every failure downstream of here is silent:
-    ``omnigraph cluster validate`` accepts *any* storage string, including an
-    empty one, so a malformed root is never caught by the tooling — the
-    migration just rebuilds the graphs somewhere nobody is looking, and
-    ``load`` reports success on top of it.
-
-    Raises ``ValueError`` on a leading/trailing ``/`` (it is joined as
-    ``s3://<bucket>/<prefix>``) or on anything that is not a single
-    ``[A-Za-z0-9._-]`` path segment. That last rule is what catches an
-    unsubstituted ``fmt<N>`` copied out of the runbook: ``<`` and ``>`` are
-    legal in S3 object keys, so it would otherwise become a real prefix.
-    """
-    cleaned = (prefix or "").strip()
-    if not cleaned:
-        return ""
-    if cleaned.startswith("/") or cleaned.endswith("/"):
-        msg = (
-            f"omnigraph:storage_prefix must not start or end with '/': "
-            f"{cleaned!r}. It is joined as s3://<bucket>/<prefix>."
-        )
-        raise ValueError(msg)
-    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", cleaned):
-        msg = (
-            f"omnigraph:storage_prefix must be a single path segment of "
-            f"[A-Za-z0-9._-] starting alphanumeric: {cleaned!r}. An "
-            "unsubstituted placeholder such as 'fmt<N>' lands here."
-        )
-        raise ValueError(msg)
-    return cleaned
-
-
-def storage_uri_for(bucket: str, prefix: str) -> str:
-    """Cluster storage root for ``bucket``, optionally under ``prefix``.
-
-    Kept separate from the ``Output.apply`` that calls it so the join is
-    testable — an off-by-one slash here silently relocates every graph.
-    """
-    return f"s3://{bucket}/{prefix}" if prefix else f"s3://{bucket}"
-
-
 def build_cluster_graphs(managed_repos: list[str]) -> dict[str, dict[str, str]]:
     """Build the ``graphs:`` block of cluster.yaml for ``managed_repos``.
 
@@ -325,6 +279,10 @@ class OmnigraphDataTier(NamedTuple):
     deployment: kubernetes.apps.v1.Deployment
     cluster_apply_job: kubernetes.batch.v1.Job
     maintenance: OmnigraphMaintenance
+    # The resolved cluster storage root (bucket + any storage_prefix), so the
+    # program can export what is actually being served rather than the config
+    # knob that shaped it.
+    storage_uri: Output[str]
 
 
 def create_data_tier(  # noqa: PLR0913
@@ -869,4 +827,5 @@ def create_data_tier(  # noqa: PLR0913
         deployment=omnigraph_deployment,
         cluster_apply_job=cluster_apply_job,
         maintenance=omnigraph_maintenance,
+        storage_uri=storage_uri,
     )

--- a/src/ol_infrastructure/applications/omnigraph/storage.py
+++ b/src/ol_infrastructure/applications/omnigraph/storage.py
@@ -1,0 +1,63 @@
+"""Storage-root addressing for the omnigraph cluster.
+
+Deliberately dependency-free — no pulumi, no boto, no ``ol_types``. Importing
+``data_tier`` pulls in the EKS component chain, which reaches
+``lib/aws/ec2_helper`` and calls boto at import time; that raises
+``NoRegionError`` anywhere AWS is not configured, including CI. These two
+functions are pure and are the ones worth unit-testing, so they live where a
+test can import them without credentials.
+"""
+
+import re
+
+# One path segment, starting alphanumeric. Everything else is rejected — see
+# validate_storage_prefix for why this is stricter than S3 requires.
+_PREFIX_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+
+
+def validate_storage_prefix(prefix: str | None) -> str:
+    """Normalize and check ``omnigraph:storage_prefix``; return "" when unset.
+
+    The storage root is normally the bucket root; a prefix moves it to
+    ``s3://<bucket>/<prefix>`` for a storage-format migration (see
+    ``docs/omnigraph-storage-format-upgrade-runbook.md``).
+
+    Validated up front because every failure downstream of here is silent:
+    ``omnigraph cluster validate`` accepts *any* storage string, including an
+    empty one, so a malformed root is never caught by the tooling — the
+    migration just rebuilds the graphs somewhere nobody is looking, and
+    ``load`` reports success on top of it. ``pulumi preview`` is the only
+    place this can fail loudly.
+
+    Raises ``ValueError`` on a leading/trailing ``/`` (it is joined as
+    ``s3://<bucket>/<prefix>``) or on anything that is not a single
+    ``[A-Za-z0-9._-]`` segment. That last rule is what catches an
+    unsubstituted ``fmt<N>`` copied out of the runbook: ``<`` and ``>`` are
+    legal in S3 object keys, so it would otherwise become a real prefix.
+    """
+    cleaned = (prefix or "").strip()
+    if not cleaned:
+        return ""
+    if cleaned.startswith("/") or cleaned.endswith("/"):
+        msg = (
+            f"omnigraph:storage_prefix must not start or end with '/': "
+            f"{cleaned!r}. It is joined as s3://<bucket>/<prefix>."
+        )
+        raise ValueError(msg)
+    if not _PREFIX_RE.fullmatch(cleaned):
+        msg = (
+            f"omnigraph:storage_prefix must be a single path segment of "
+            f"[A-Za-z0-9._-] starting alphanumeric: {cleaned!r}. An "
+            "unsubstituted placeholder such as 'fmt<N>' lands here."
+        )
+        raise ValueError(msg)
+    return cleaned
+
+
+def storage_uri_for(bucket: str, prefix: str) -> str:
+    """Cluster storage root for ``bucket``, optionally under ``prefix``.
+
+    Kept separate from the ``Output.apply`` that calls it so the join is
+    testable — an off-by-one slash here silently relocates every graph.
+    """
+    return f"s3://{bucket}/{prefix}" if prefix else f"s3://{bucket}"

--- a/tests/ol_infrastructure/applications/omnigraph/test_storage_prefix.py
+++ b/tests/ol_infrastructure/applications/omnigraph/test_storage_prefix.py
@@ -1,0 +1,91 @@
+"""Tests for the storage-root override used by a storage-format migration.
+
+Every failure mode here is silent, which is why it is validated at config time
+and pinned here. ``omnigraph cluster validate`` accepts *any* ``storage:``
+string — including an empty one — so nothing downstream rejects a malformed
+root. The migration simply rebuilds every graph somewhere nobody is looking and
+``load`` reports success on top of it, with the mistake surfacing only at the
+verification step, after the outage window.
+
+See ``docs/omnigraph-storage-format-upgrade-runbook.md``.
+"""
+
+import pytest
+
+from ol_infrastructure.applications.omnigraph.data_tier import (
+    storage_uri_for,
+    validate_storage_prefix,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, ""),
+        ("", ""),
+        ("   ", ""),
+        ("fmt5", "fmt5"),
+        ("  fmt5  ", "fmt5"),
+        ("fmt10", "fmt10"),
+        ("migration-2026-08", "migration-2026-08"),
+        ("v2.1", "v2.1"),
+        ("a", "a"),
+    ],
+)
+def test_accepts_and_normalizes_valid_prefixes(raw: str | None, expected: str) -> None:
+    assert validate_storage_prefix(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "fmt<N>",  # the runbook's placeholder, left unsubstituted
+        "<N>",
+        "fmt>",
+        "fmt 5",  # whitespace inside would make a surprising key
+        "fmt/5",  # more than one segment
+        "-fmt5",  # must start alphanumeric
+        ".fmt5",
+        "fmt5!",
+        "fmt5$",
+    ],
+)
+def test_rejects_malformed_prefixes(raw: str) -> None:
+    with pytest.raises(ValueError, match="storage_prefix"):
+        validate_storage_prefix(raw)
+
+
+@pytest.mark.parametrize("raw", ["/fmt5", "fmt5/", "/fmt5/"])
+def test_rejects_slash_wrapped_prefixes(raw: str) -> None:
+    """It is joined as ``s3://<bucket>/<prefix>``; a stray slash doubles up."""
+    with pytest.raises(ValueError, match="must not start or end with"):
+        validate_storage_prefix(raw)
+
+
+def test_placeholder_rejection_names_the_placeholder() -> None:
+    """The error has to point at the actual mistake.
+
+    ``<`` and ``>`` are legal in S3 object keys, so an unsubstituted ``fmt<N>``
+    would otherwise become a real prefix rather than an error.
+    """
+    with pytest.raises(ValueError, match="fmt<N>"):
+        validate_storage_prefix("fmt<N>")
+
+
+def test_storage_uri_without_prefix_is_the_bucket_root() -> None:
+    assert storage_uri_for("ol-data-witan-ci", "") == "s3://ol-data-witan-ci"
+
+
+def test_storage_uri_with_prefix_joins_with_exactly_one_slash() -> None:
+    assert storage_uri_for("ol-data-witan-ci", "fmt5") == "s3://ol-data-witan-ci/fmt5"
+
+
+def test_storage_uri_stays_inside_the_managed_bucket() -> None:
+    """The prefix must never be able to redirect to another bucket.
+
+    The bucket, its IAM policy and the IRSA grant are all keyed to the derived
+    name, so a root outside it would point the cluster at storage nothing has
+    granted access to — and that failure would land mid-migration.
+    """
+    uri = storage_uri_for("ol-data-witan-production", validate_storage_prefix("fmt5"))
+    assert uri.startswith("s3://ol-data-witan-production/")

--- a/tests/ol_infrastructure/applications/omnigraph/test_storage_prefix.py
+++ b/tests/ol_infrastructure/applications/omnigraph/test_storage_prefix.py
@@ -12,7 +12,7 @@ See ``docs/omnigraph-storage-format-upgrade-runbook.md``.
 
 import pytest
 
-from ol_infrastructure.applications.omnigraph.data_tier import (
+from ol_infrastructure.applications.omnigraph.storage import (
     storage_uri_for,
     validate_storage_prefix,
 )


### PR DESCRIPTION
## What are the relevant tickets?

`tk-omnigraph-add-an-omnigraph-storage-root-override-ca4776`, project
`wp-witan-multi-user-service-deployment-dcf6ee`. Follow-up to #5257, which shipped
the runbook this makes executable.

## Description (What does it do?)

The storage-format upgrade runbook (#5257) rebuilds every graph under a new storage
root and then repoints the cluster at it. Until now step 5 — the step that *ends* the
outage — meant hand-editing `data_tier.py`'s `storage_uri` derivation and shipping a
code change while the data tier was down.

`omnigraph:storage_prefix` replaces that. Unset (the steady state) the graphs sit at
the bucket root, exactly as today. Set to `fmt5`, they sit at
`s3://ol-data-witan-<env>/fmt5`. Rollback is `pulumi config rm`.

**Note the name.** The task called for `storage_root`; this is `storage_prefix`,
because it takes a prefix *inside* the managed bucket rather than a free-form URI.
The bucket, its IAM policy and the IRSA grant are all keyed to the derived name
(`ol-data-witan-<env>`), so a full URI could point the cluster at storage nothing has
granted access to — and that failure would surface mid-migration, with the graphs
already exported and the server already down. Staying in-bucket also means versioning
and backups cover the new root for free. The runbook already established that a
bucket prefix is a valid `storage:` value.

**Validated at config time, deliberately.** Verified against the live CLI:
`omnigraph cluster validate` accepts *any* storage string, including an empty one.
Nothing downstream rejects a malformed root — the migration rebuilds the graphs
somewhere nobody is looking and `load` reports success on top of it, with the mistake
surfacing only at step 6 after the outage window. So `pulumi preview` is the only
place this can fail loudly, and it does: wrapping slashes and anything outside a
single `[A-Za-z0-9._-]` segment raise. That includes an unsubstituted `fmt<N>` copied
out of the runbook, which would otherwise become a real prefix, since `<` and `>` are
legal in S3 object keys.

**Maintenance follows automatically.** The optimize/cleanup CronJobs added in #5258
take `storage_uri` directly, so they sweep the active root with no change here. Worth
stating explicitly because the alternative was silent: they would have kept
maintaining the *pre-migration* root while the server served the new one.

## How can this be tested?

`uv run pytest tests/ol_infrastructure/applications/omnigraph/` — 51 pass, 24 of them
new. The validation and the URI join are extracted as pure functions
(`validate_storage_prefix`, `storage_uri_for`) specifically so they are testable;
they were inline in the Pulumi program's module body, which cannot be imported.

Coverage is aimed at the silent failures: placeholder rejection names the placeholder,
the join produces exactly one slash, and the result always stays inside the managed
bucket.

`pulumi preview` on the omnigraph stack with no config set should show **no diff** —
the default path is byte-identical to today's derived URI.

## Additional context

Not exercised end to end: an actual repoint against a live cluster. The rebuild
sequence it serves *was* rehearsed on CI (see #5257) — `cluster import` → `cluster
apply` → `load` → verification on a scratch prefix, row counts round-tripping exactly
— but that drill drove the CLI directly rather than through this config key. The
drill script is available to re-run against a real `storage_prefix` deploy if you want
that closed before the next format bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbTKYwDtNTskNKWg47NW2M