### PR TITLE
fix(edxapp): let Meilisearch upgrade its own database

### DIFF
--- a/src/bridge/lib/versions.py
+++ b/src/bridge/lib/versions.py
@@ -10,9 +10,8 @@ JUPYTERHUB_VERSION = "5.5.0"
 KEYCLOAK_VERSION = "26.7.0"
 # renovate: datasource=docker depName=leek packageName=kodhive/leek
 LEEK_VERSION = "0.7.7"
-MEILISEARCH_VERSION = (
-    "v1.33.0"  # (MD 2026-03-30) pin to v1.33.0 because of upgrade compatibility issues
-)
+# renovate: datasource=docker depName=meilisearch packageName=getmeili/meilisearch
+MEILISEARCH_VERSION = "v1.51.0"
 # renovate: datasource=helm depName=open-metadata packageName=openmetadata registryUrl=https://helm.open-metadata.org
 OPEN_METADATA_VERSION = "1.13.3"
 OVS_VERSION = "v0.65.1-3-g2630021"

--- a/src/ol_infrastructure/applications/edxapp/meilisearch.py
+++ b/src/ol_infrastructure/applications/edxapp/meilisearch.py
@@ -104,11 +104,27 @@ def create_meilisearch_resources(
             "tag": MEILISEARCH_VERSION,
             "pullPolicy": "IfNotPresent",
         },
-        "custom_labels": k8s_global_labels,
+        "customLabels": k8s_global_labels,
         "environment": {
             "MEILI_NO_ANALYTICS": True,
             "MEILI_ENV": "production",
             "MEILI_MASTER_KEY": secrets["meilisearch_master_key"],
+            # Without this, Meilisearch refuses to start whenever the on-disk
+            # database was written by a different engine version, which is what
+            # forced the v1.33.0 image pin in March 2026. It migrates the
+            # database in place on startup and is a no-op once the versions
+            # match, so it is safe to leave enabled permanently. Note that this
+            # is one-way: Meilisearch has no downgrade path, so rolling the
+            # image tag back requires restoring the volume from a snapshot.
+            "MEILI_UPGRADE_DB": True,
+        },
+        # The chart's default startup budget is 60s (60 x 1s). A version
+        # upgrade migrates the task queue synchronously before the HTTP server
+        # binds, so that default can kill the pod mid-migration and leave the
+        # database partially converted. Give it 15 minutes instead.
+        "startupProbe": {
+            "periodSeconds": 5,
+            "failureThreshold": 180,
         },
         "persistence": {
             "enabled": True,


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

Lifts the `v1.33.0` Meilisearch pin by letting the engine migrate its own database, and fixes the two things that kept the pin invisible and permanent.

**Why the pin never lifted on its own.** Meilisearch hard-fails at startup with `VersionMismatch` when the on-disk database was written by a different engine version:

```
Your database version (1.33.0) is incompatible with your current engine version (1.51.0).
```

That is the "upgrade compatibility issues" behind bbaec82095d98b57407b96843fc1968a494f4f22 (2026-03-30). Two things then made it permanent:

- `MEILISEARCH_VERSION` carried no `# renovate:` annotation, so Renovate never proposed an engine bump.
- The chart bumps Renovate *does* open (most recently https://github.com/mitodl/ol-infrastructure/pull/5206) only move the chart's **default** image tag, which the same commit started overriding via `image.tag`. So the chart drifted 18 minors ahead — chart `0.35.0` defaults to `v1.51.0` — while the running engine stayed at `v1.33.0`.

**The fix.** Setting `MEILI_UPGRADE_DB` makes Meilisearch migrate the database in place on startup instead of refusing to boot. Verified against the engine source rather than the release notes:

- `MEILI_UPGRADE_DB` is the env var for the `--upgrade-db` flag — https://github.com/meilisearch/meilisearch/blob/v1.51.0/crates/meilisearch/src/option.rs#L448
- Any database at or above `1.12.0` upgrades in a **single step**, so `v1.33.0` → `v1.51.0` needs no intermediate hop and no dump/import — https://github.com/meilisearch/meilisearch/blob/v1.51.0/crates/index-scheduler/src/upgrade/mod.rs#L66
- It is a **no-op** once the versions match (early return when the database version equals the engine version), so it is safe to leave enabled permanently — https://github.com/meilisearch/meilisearch/blob/v1.51.0/crates/index-scheduler/src/upgrade/mod.rs#L45

With the upgrade path in place, `MEILISEARCH_VERSION` gets a Renovate annotation so the engine tracks forward from here instead of silently freezing again.

**Startup budget.** The chart's default startup budget is 60s (`failureThreshold: 60` × `periodSeconds: 1`). The task-queue migration runs *synchronously* before the HTTP server binds, so on a large index that default could kill the pod partway through a migration. Widened to 15 minutes (`180` × `5s`); the remaining probe fields still come from chart defaults.

**Drive-by fix.** The values key was `custom_labels`, but the chart's key is `customLabels` — https://github.com/meilisearch/meilisearch-kubernetes/blob/master/charts/meilisearch/values.yaml. Helm silently drops unknown values keys, so `k8s_global_labels` have never reached a single Meilisearch resource. Rendering the chart with the corrected key applies them to 6 resources where the old key applied them to 0.

### How can this be tested?

Validation run on this branch:

- `uv run pre-commit run --files src/bridge/lib/versions.py src/ol_infrastructure/applications/edxapp/meilisearch.py` — passed (ruff, ruff format, mypy, detect-secrets)
- `uv run pytest` — 252 passed

Rendered the chart with the exact values this code produces to confirm all three changes land, since Helm fails silently on bad keys:

```
helm template ms meilisearch/meilisearch --version 0.35.0 -f values.yaml
```

```yaml
# ConfigMap
  MEILI_UPGRADE_DB: "true"
# StatefulSet
          image: "getmeili/meilisearch:v1.51.0"
          startupProbe:
            httpGet:
              path: /health
              port: http
            periodSeconds: 5
            initialDelaySeconds: 1
            failureThreshold: 180
            timeoutSeconds: 1
```

`pulumi preview` was **not** run — it needs stack credentials that were not available in this environment. Worth a preview against `applications.CI` before deploying.

To validate on a live deployment after deploy, the engine logs the migration explicitly:

```
Upgrading the task queue
[n/m]Applying migration: <description>
Task queue upgraded, spawning the upgrade database task
```

and `GET /version` should report `1.51.0`. The index-level migration then continues asynchronously as an `UpgradeDatabase` task in `GET /tasks`, so search may be degraded until that task reaches `succeeded` — the pod reaching Ready is not the end of the upgrade.

### Additional Context

**This is a one-way door.** Meilisearch has no downgrade path — `DowngradeNotSupported` (https://github.com/meilisearch/meilisearch/blob/v1.51.0/crates/meilisearch-types/src/versioning.rs#L89). Once a pod boots `v1.51.0` against a volume, reverting `MEILISEARCH_VERSION` will not start; recovery means restoring the volume from a snapshot. Hence the CI → QA → Production sequencing in the checklist below rather than merging and letting every stack roll.

One adjacent landmine noticed while working here, **not** touched by this PR: the chart's PVC (`templates/pvc.yaml`) carries no `helm.sh/resource-policy: keep`, and the `Release` sets `delete_before_replace=True`. A version change is an update rather than a replacement so it does not fire here, but any future change that forces replacement of that `Release` would delete the PVC first.

### Checklist:
- [ ] Snapshot the Meilisearch EBS volume for the target environment before deploying
- [ ] Deploy `applications.CI` first; confirm `GET /version` reports `1.51.0` and the `UpgradeDatabase` task reaches `succeeded` before promoting
- [ ] Repeat for QA, then Production
