### PR TITLE
fix(omnigraph): gate the health probes behind a startupProbe

### DIFF
--- a/src/ol_infrastructure/applications/omnigraph/data_tier.py
+++ b/src/ol_infrastructure/applications/omnigraph/data_tier.py
@@ -629,53 +629,70 @@ def create_data_tier(  # noqa: PLR0913
                             # server actually being up, not just the port being
                             # bound.
                             #
-                            # DELAYS ARE SIZED FROM A MEASURED BOOT, not picked.
+                            # A startupProbe gates the other two: while it is
+                            # running the kubelet suppresses liveness and
+                            # readiness entirely, and once it passes it never
+                            # runs again. That is the right shape here because
+                            # boot is slow, variable, and GROWS.
+                            #
                             # The entrypoint converges the cluster catalog
-                            # *before* the server binds :8080, and that converge
-                            # re-observes every declared graph over S3. Measured
-                            # 2026-08-05 with 17 graphs, from the container's
-                            # first log line to `serving omnigraph bind=`:
+                            # *before* the server binds :8080, re-observing
+                            # every declared graph over S3. Measured 2026-08-05
+                            # with 17 graphs: container start to `serving
+                            # omnigraph bind=` was 17.2s (CI), 19.8s (QA),
+                            # 17.2s (Production); container start to pod Ready
+                            # was 26s. Note the gap — the "serving" log line is
+                            # NOT when /healthz answers, so timing to that line
+                            # understates the target by several seconds.
                             #
-                            #     CI 17.2s | QA 19.8s | Production 17.2s
+                            # ~95% of that is the converge, which costs roughly
+                            # 1.2s per declared graph. Every repo added to
+                            # `managed_repos` makes boot slower, so any fixed
+                            # initialDelaySeconds is a guess with a shelf life:
+                            # too small and it fires against a closed port (the
+                            # connection-refused Unhealthy events seen on
+                            # healthy boots), too large and a genuinely wedged
+                            # server goes unnoticed for that long.
                             #
-                            # ~95% of which is the converge. At the previous
-                            # values (readiness 5, liveness 15) both probes were
-                            # guaranteed to fire against a closed port on every
-                            # start in every environment — the connection-refused
-                            # Unhealthy events on a healthy boot were this, not a
-                            # sick server. Only failureThreshold=3 kept it from
-                            # being a crashloop.
+                            # The startupProbe replaces the guess with a
+                            # budget: failureThreshold x periodSeconds = 24 x 5
+                            # = 120s to become healthy, ~4.6x the measured 26s.
+                            # At ~1.2s/graph that absorbs roughly 100 graphs
+                            # before needing a thought, and a boot that blows
+                            # the budget is killed — which is correct, that is
+                            # a stuck start, not a slow one.
                             #
-                            # The two probes are sized against that measurement
-                            # for DIFFERENT reasons, and only one of them
-                            # carries headroom:
-                            #
-                            # - readiness sits just past the slowest boot (20s
-                            #   vs 19.8s). Deliberate: a failed readiness probe
-                            #   costs nothing but a 5s retry, and every second
-                            #   spent out of the Service is restart outage. It
-                            #   is allowed to be tight.
-                            # - liveness carries the headroom (60s, 3x), because
-                            #   its failure mode is killing a healthy pod.
-                            #
-                            # The converge cost scales with the declared graph
-                            # count (~1.2s/graph), so as `managed_repos` grows
-                            # readiness will start probing early again — noisy
-                            # but harmless — and liveness eats into its 3x. A
-                            # fixed delay cannot track that growth; a
-                            # startupProbe is the mechanism that does, and is
-                            # the right follow-up if the graph list keeps
-                            # expanding.
+                            # Liveness and readiness then carry NO initial
+                            # delay, deliberately: they cannot run until
+                            # startup has already succeeded, so a delay would
+                            # only postpone detecting a server that broke
+                            # *after* boot. This also drops the wedged-server
+                            # kill from ~100s to ~60s.
+                            startup_probe=kubernetes.core.v1.ProbeArgs(
+                                http_get=kubernetes.core.v1.HTTPGetActionArgs(
+                                    path="/healthz",
+                                    port=OMNIGRAPH_SERVER_PORT,
+                                ),
+                                # Nothing can answer before the converge
+                                # finishes, so the first few probes are pure
+                                # cost; 10s skips them without cutting into the
+                                # budget meaningfully.
+                                initial_delay_seconds=10,
+                                period_seconds=5,
+                                failure_threshold=24,
+                            ),
                             readiness_probe=kubernetes.core.v1.ProbeArgs(
                                 http_get=kubernetes.core.v1.HTTPGetActionArgs(
                                     path="/healthz",
                                     port=OMNIGRAPH_SERVER_PORT,
                                 ),
-                                # First probe just past the measured boot, then
-                                # poll fast: this is what ends the restart
-                                # outage, so the gap between "bound" and "in the
-                                # Service" should be small.
-                                initial_delay_seconds=20,
+                                # Explicit 0, not omitted. A merge that only
+                                # sets the fields it names leaves a previously
+                                # set initialDelaySeconds in place — verified
+                                # against the live API with a server-side
+                                # dry-run, where dropping the key kept the old
+                                # 20s. Stating it removes the question.
+                                initial_delay_seconds=0,
                                 period_seconds=5,
                             ),
                             liveness_probe=kubernetes.core.v1.ProbeArgs(
@@ -683,11 +700,10 @@ def create_data_tier(  # noqa: PLR0913
                                     path="/healthz",
                                     port=OMNIGRAPH_SERVER_PORT,
                                 ),
-                                # 3x the slowest measured boot. With
-                                # period_seconds=20 and the default
-                                # failureThreshold=3, a genuinely wedged server
-                                # is still killed by ~100s.
-                                initial_delay_seconds=60,
+                                # Explicit 0, same reason as readiness. With
+                                # the default failureThreshold=3, a server that
+                                # wedges after boot is killed in ~60s.
+                                initial_delay_seconds=0,
                                 period_seconds=20,
                             ),
                             # The memory limit is what PER_ACTOR_BYTES_MAX is

--- a/src/ol_infrastructure/applications/omnigraph/data_tier.py
+++ b/src/ol_infrastructure/applications/omnigraph/data_tier.py
@@ -655,12 +655,21 @@ def create_data_tier(  # noqa: PLR0913
                             # server goes unnoticed for that long.
                             #
                             # The startupProbe replaces the guess with a
-                            # budget: failureThreshold x periodSeconds = 24 x 5
-                            # = 120s to become healthy, ~4.6x the measured 26s.
-                            # At ~1.2s/graph that absorbs roughly 100 graphs
-                            # before needing a thought, and a boot that blows
-                            # the budget is killed — which is correct, that is
-                            # a stuck start, not a slow one.
+                            # budget. The first probe fires at
+                            # initialDelaySeconds and every periodSeconds
+                            # after, so the Nth failure lands at
+                            # initial_delay + (N-1) x period — the container is
+                            # killed on the 24th, at 10 + 23x5 = 125s. (Not
+                            # 24x5=120, which ignores the initial delay, and
+                            # not 10+24x5=130, which counts an interval that
+                            # never elapses.)
+                            #
+                            # 125s is ~4.8x the measured 26s. Boot is roughly
+                            # 6s of fixed cost plus ~1.18s per declared graph,
+                            # so the budget absorbs about 100 graphs before it
+                            # needs revisiting — and a boot that blows it is
+                            # killed, which is correct: that is a stuck start,
+                            # not a slow one.
                             #
                             # Liveness and readiness then carry NO initial
                             # delay, deliberately: they cannot run until


### PR DESCRIPTION
## What are the relevant tickets?

Follow-up to #5263, which sized the probe delays from a measurement. This removes
the need for that measurement to keep being right. Project
`wp-witan-multi-user-service-deployment-dcf6ee`.

## Description (What does it do?)

#5263 fixed probes that fired against a closed port on every boot, by enlarging the
delays. That worked, but the values are guesses with a shelf life: the entrypoint
converges the cluster catalog *before* the server binds `:8080`, at roughly **1.2s per
declared graph**, so every repo added to `managed_repos` makes boot slower and walks
the constants back toward the failure they fixed. Too small and a probe fires early;
too large and a wedged server goes unnoticed for that long.

A `startupProbe` replaces the guess with a budget. While it runs the kubelet suppresses
liveness and readiness entirely; once it passes it never runs again.

| Probe | Before | After |
| --- | --- | --- |
| startup | — | delay 10s, period 5s, threshold 24 (**120s budget**) |
| readiness | delay 20s, period 5s | delay **0**, period 5s |
| liveness | delay 60s, period 20s | delay **0**, period 20s |

120s is ~4.6x the measured 26s, absorbing roughly 100 graphs before it needs a thought.
A boot that blows the budget is killed — correct, that is a stuck start, not a slow one.

**It also corrects a measurement from #5263.** That PR reported 17–20s, which was
container start to the `serving omnigraph bind=` log line. `/healthz` does **not**
answer at that line — true container-start-to-Ready is **26s**. So the 20s readiness
delay was under the real target, which is exactly why a spurious connection-refused
event survived #5263 (visible on the current CI pod). Measuring to a log line rather
than to the pod's `Ready` condition was the error.

Liveness and readiness now carry no initial delay, deliberately: they cannot run until
startup has succeeded, so a delay would only postpone detecting a server that broke
*after* boot. That drops the wedged-server kill from ~100s to ~60s as a side effect.

## How can this be tested?

Validated against the live API without touching anything:

```shell
kubectl -n omnigraph patch deploy omnigraph-server --type=strategic \
  --patch-file probe-patch.json --dry-run=server -o jsonpath='...'
```

That dry-run also caught a trap worth recording: **omitting `initialDelaySeconds` does
not clear it.** The first attempt left the previous `readiness: 20` and `liveness: 60`
in place, because a merge that only sets the fields it names leaves everything else
alone. Both zeros are therefore explicit in the code rather than omitted.

After deploy, a boot should produce **no** Unhealthy events at all — not even the one
readiness failure that survived #5263:

```shell
kubectl -n omnigraph get events --sort-by=.lastTimestamp | grep -i unhealthy
kubectl -n omnigraph get pod <pod> -o jsonpath='{.status.conditions[?(@.type=="Ready")].lastTransitionTime}'
```

`uv run pytest tests/ol_infrastructure/applications/omnigraph/` — 26 pass. ruff/mypy clean.

## Additional context

Deploying this restarts the data tier (single-replica `Recreate`, ~26s) in each
environment as it promotes.

Touches the same file as #5266 but a different region; they auto-merge cleanly, and
neither depends on the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbTKYwDtNTskNKWg47NW2M