### PR TITLE
feat(grafana_alerting): deploy grafana-alerting via the simple pulumi pipelines

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/meta.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/meta.py
@@ -197,6 +197,7 @@ if __name__ == "__main__":
         "data_warehouse",
         "digital-credentials",
         "fastly-redirector",
+        "grafana-alerting",
         "jupyterhub-data",
         "mailgun",
         "marimo-data",

--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
@@ -341,6 +341,11 @@ pipeline_params: dict[str, SimplePulumiParams] = {
         pulumi_project_name="ol-application-fastly-redirector",
         refresh_stack=False,
     ),
+    "grafana-alerting": SimplePulumiParams(
+        app_name="grafana-alerting",
+        pulumi_project_path="infrastructure/grafana_alerting/",
+        pulumi_project_name="ol-infrastructure-grafana-alerting",
+    ),
     "jupyterhub-data": SimplePulumiParams(
         app_name="jupyterhub-data",
         pulumi_project_path="applications/jupyterhub_data/",

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/Pulumi.CI.yaml
@@ -1,2 +1,3 @@
 ---
-encryptionsalt: v1:v2Ek/E5/5SU=:v1:JqVAy0zRS6psyinr:4hBjOOVWdRCP8P0UvjRfQNg2e7cLgw==
+secretsprovider: awskms://alias/infrastructure-secrets-ci
+encryptedkey: AQICAHhMkpkBpCvmFjhyfy75ENALRrbg42uOs9cUsFNLXqPnagEqrkzp6cnQ0aYHWqyg3esKAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMt5cCKS9BMIatKbEhAgEQgDtpLDNKXo6qc1mauPc2tVetS0ynqdfN3HtDVmQgSnVt+dA+maMvKPNqnDBFhA75ugTmy8oHn2y9SPYM9A==

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/Pulumi.Production.yaml
@@ -1,2 +1,3 @@
 ---
-encryptionsalt: v1:ut0g7Wr8b8Y=:v1:4qr110SYUeOUowgh:/N4mL8kguQh8Q9JD1sQ7iXShVJ9rkg==
+secretsprovider: awskms://alias/infrastructure-secrets-production
+encryptedkey: AQICAHjksIVfl1VtAHpBda/1YYjj6tSeS2o4TXgvEEyBIXLjjwG4tBva161e0ucBCCXDrIE0AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMCwVqXQPcOnnWj2pXAgEQgDtsiON1HfCMzrDGGoOvkO+5PYHe12k24s6E6Sv0PqVuCTdZDIEbCVYOEVawgsdRYH/a0W0gjVZGDSRtnQ==

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/Pulumi.QA.yaml
@@ -1,2 +1,3 @@
 ---
-encryptionsalt: v1:8lDpeSBr4Ms=:v1:uaU75ZN8tVKjJ6pB:e8zv/DgYNtRdtfJjpDcGzuc2dcnbpw==
+secretsprovider: awskms://alias/infrastructure-secrets-qa
+encryptedkey: AQICAHjE+jMY5DL7M1LMYX6YgtMueHEDNg05lsdN5Z0zeGHyJgE7QK2goKXvJtcjjzGVHSp1AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM+5+08abwC9U03HyOAgEQgDvTbZfeoi04uDc2rtJx7Bw5clU4beBT8C3d6GZgOxoi9ZM7QogmNKONrAQFAetFNGKyJDRXKNGAzpFf5g==


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Puts `ol-infrastructure-grafana-alerting` on a Concourse deploy pipeline instead of requiring manual `pulumi up` runs.

- Adds a `grafana-alerting` entry to `pipeline_params` in the simple_pulumi template. Defaults cover it: stacks are plain `CI`/`QA`/`Production`, no `stack_prefix`, no Docker image, no cross-env gate.
- Adds `grafana-alerting` to `production_app_names` in `meta.py` so the meta pipeline sets `pulumi-grafana-alerting`.

Also included is an earlier commit correcting the KMS secrets providers in the three `Pulumi.*.yaml` stack configs.

No `additional_watched_paths` is needed: `PULUMI_WATCHED_PATHS` already watches `src/bridge/secrets/`, which covers `src/bridge/secrets/grafana_cloud/`.

### How can this be tested?

```
PYTHONPATH=src uv run python src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py grafana-alerting
```

Produces the expected chain with GitHub-issue promotion gates between stages:

```
deploy-ol-infrastructure-grafana-alerting-ci
deploy-ol-infrastructure-grafana-alerting-qa
deploy-ol-infrastructure-grafana-alerting-production
```

`PYTHONPATH=src uv run python src/ol_concourse/pipelines/infrastructure/simple_pulumi/meta.py` renders with the new `create-grafana-alerting-pipeline` job. `pre-commit` (ruff + mypy) passes on both changed files.

### Additional Context

Two things a reviewer should be aware of, neither of which this PR changes:

- **Pingdom checks stay a no-op in Production.** Per [ADR 0010](https://github.com/mitodl/ol-infrastructure/blob/main/docs/adr/0010-pingdom-checks-unmanaged-in-pulumi-state.md), `pingdom_checks.create()` skips all 39 checks unless `allow_pingdom_apply` is set on the stack. That is the safe behavior under automation — setting that flag on Production would create duplicate checks in Pingdom.
- **`refresh_stack` is left at the default `True`.** The Pingdom dynamic provider's refresh path is what ADR 0010 calls unreliable, but nothing is registered in state today so refresh has nothing to touch. Worth revisiting if those resources are ever adopted.

The meta pipeline self-updates on the next push to `main`; no `fly` commands were run as part of this PR.