### PR TITLE
fix(omnigraph): start the startupProbe at the measured bind, not before it

### DIFF
--- a/src/ol_infrastructure/applications/omnigraph/data_tier.py
+++ b/src/ol_infrastructure/applications/omnigraph/data_tier.py
@@ -684,17 +684,17 @@ def create_data_tier(  # noqa: PLR0913
                             # initialDelaySeconds and every periodSeconds
                             # after, so the Nth failure lands at
                             # initial_delay + (N-1) x period — the container is
-                            # killed on the 24th, at 10 + 23x5 = 125s. (Not
+                            # killed on the 24th, at 20 + 23x5 = 135s. (Not
                             # 24x5=120, which ignores the initial delay, and
-                            # not 10+24x5=130, which counts an interval that
+                            # not 20+24x5=140, which counts an interval that
                             # never elapses.)
                             #
-                            # 125s is ~4.8x the measured 26s. Boot is roughly
-                            # 6s of fixed cost plus ~1.18s per declared graph,
-                            # so the budget absorbs about 100 graphs before it
-                            # needs revisiting — and a boot that blows it is
-                            # killed, which is correct: that is a stuck start,
-                            # not a slow one.
+                            # 135s is ~5.2x the measured 25-26s. Boot is
+                            # roughly 6s of fixed cost plus ~1.18s per declared
+                            # graph, so the budget absorbs about 110 graphs
+                            # before it needs revisiting — and a boot that
+                            # blows it is killed, which is correct: that is a
+                            # stuck start, not a slow one.
                             #
                             # Liveness and readiness then carry NO initial
                             # delay, deliberately: they cannot run until
@@ -707,11 +707,21 @@ def create_data_tier(  # noqa: PLR0913
                                     path="/healthz",
                                     port=OMNIGRAPH_SERVER_PORT,
                                 ),
-                                # Nothing can answer before the converge
-                                # finishes, so the first few probes are pure
-                                # cost; 10s skips them without cutting into the
-                                # budget meaningfully.
-                                initial_delay_seconds=10,
+                                # Sized to the measured bind, not below it.
+                                # At 10s this fired three guaranteed failures
+                                # per boot (probes at 10/15/20s against a
+                                # 20.5s bind, observed on CI 2026-08-05) —
+                                # harmless, but indistinguishable in
+                                # `kubectl get events` from a sick server,
+                                # which is the noise this whole change exists
+                                # to remove. 20s puts the first probe at the
+                                # point the server actually answers: one
+                                # failure at worst, none when boot runs fast,
+                                # and no delay to Ready either way since the
+                                # 25s probe was already the one that
+                                # succeeded. A later delay would only postpone
+                                # Ready on a fast boot.
+                                initial_delay_seconds=20,
                                 period_seconds=5,
                                 failure_threshold=24,
                             ),

--- a/src/ol_infrastructure/applications/omnigraph/data_tier.py
+++ b/src/ol_infrastructure/applications/omnigraph/data_tier.py
@@ -707,20 +707,26 @@ def create_data_tier(  # noqa: PLR0913
                                     path="/healthz",
                                     port=OMNIGRAPH_SERVER_PORT,
                                 ),
-                                # Sized to the measured bind, not below it.
-                                # At 10s this fired three guaranteed failures
-                                # per boot (probes at 10/15/20s against a
-                                # 20.5s bind, observed on CI 2026-08-05) —
-                                # harmless, but indistinguishable in
-                                # `kubectl get events` from a sick server,
-                                # which is the noise this whole change exists
-                                # to remove. 20s puts the first probe at the
-                                # point the server actually answers: one
-                                # failure at worst, none when boot runs fast,
-                                # and no delay to Ready either way since the
-                                # 25s probe was already the one that
-                                # succeeded. A later delay would only postpone
-                                # Ready on a fast boot.
+                                # Sized to the top of the observed bind
+                                # range. Binds measured 2026-08-05 were 17.2s
+                                # (CI), 19.8s (QA), 17.2s (Production), then
+                                # 19.3s and 20.5s on later CI boots.
+                                #
+                                # At 10s the first three probes could only
+                                # ever fail — three per boot, harmless but
+                                # indistinguishable in `kubectl get events`
+                                # from a sick server, which is the noise this
+                                # change exists to remove.
+                                #
+                                # 20s sits just above four of those five
+                                # binds, so the usual outcome is zero
+                                # failures; a boot at the slow end of the
+                                # range (the 20.5s one) fires exactly one
+                                # before the 25s probe succeeds. Either way
+                                # Ready is unchanged, because 25s was already
+                                # the probe that passed. Going later would
+                                # trade that away, delaying Ready on every
+                                # fast boot to buy the one failure back.
                                 initial_delay_seconds=20,
                                 period_seconds=5,
                                 failure_threshold=24,


### PR DESCRIPTION
## What are the relevant tickets?

Follow-up to #5269, correcting a value that PR chose badly. Project
`wp-witan-multi-user-service-deployment-dcf6ee`.

## Description (What does it do?)

#5269 set the startupProbe's `initialDelaySeconds=10` against a boot that binds
`:8080` at ~20.5s, so the first three probes could only ever fail. Observed on CI
immediately after that deploy landed:

```
container start   18:09:24.5
server binds      18:09:45.0   (20.5s)
pod Ready         18:09:49     (25s)

Startup probe failed: connection refused   x3   @ t = 10s, 15s, 20s
Liveness / readiness failures:              0
```

The core goal of #5269 held — liveness and readiness never fire against a closed port,
which is what removes the risk of killing a healthy pod. But the three startup failures
are indistinguishable in `kubectl get events` from a sick server, and that noise is
precisely what the change existed to eliminate. Predicting zero events and then
shipping three was the mistake: the delay was picked to be safely small rather than
sized to the measurement, even though the measurement was already in hand.

**20s** puts the first probe where the server actually answers:

| initialDelay | probes at | failures on a 20.5s bind |
| --- | --- | --- |
| 10s (now) | 10, 15, 20, 25 | 3 |
| **20s (this PR)** | **20, 25, 30, 35** | **1, or 0 on a fast boot** |
| 25s | 25, 30, 35, 40 | 0, but forfeits a fast Ready |

No delay to Ready either way — the 25s probe was already the one that succeeded — and
going later would only postpone Ready when boot runs fast. Budget grows with it,
125s → 135s (`20 + 23x5`), about 5.2x the measured 25–26s and roughly 110 declared
graphs.

## How can this be tested?

Validated against the live API without touching anything:

```shell
kubectl -n omnigraph patch deploy omnigraph-server --type=strategic \
  --patch-file p3.json --dry-run=server -o jsonpath='...'
# -> startup: delay=20 period=5 threshold=24     (live still reads delay=10)
```

`uv run pytest tests/ol_infrastructure/applications/omnigraph/` — 51 pass. ruff/mypy clean.

After deploy, the boot should show **at most one** startup-probe failure and still no
liveness or readiness failures:

```shell
kubectl -n omnigraph get events --field-selector involvedObject.name=<pod> | grep -i unhealthy
```

## Additional context

Restarts the data tier on deploy (single-replica `Recreate`, ~25s per environment).

Worth flagging separately: QA and Production are still on pre-#5263 probe values
(`liveness_delay=15`, generations 6 and 4). Three merged omnigraph changes are sitting
in CI only, the oldest merged several hours ago, so the `pulumi-omnigraph` promotion
chain does not appear to be advancing past CI. Not diagnosed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbTKYwDtNTskNKWg47NW2M