### PR TITLE
fix(apisix): compress responses on every shared-gateway route

### DIFF
--- a/src/ol_infrastructure/components/services/apisix.py
+++ b/src/ol_infrastructure/components/services/apisix.py
@@ -441,6 +441,14 @@ class OLApisixSharedPluginsConfig(BaseModel):
     # references a plugin APISIX has not loaded is rejected, so the route-level
     # attachment must be gated to match the cluster-level plugin enablement.
     enable_opentelemetry: bool = True
+    # Attach the gzip response-compression plugin.  ``None`` (the default)
+    # resolves from the stack: on everywhere except Production.  Compression is
+    # cheap to validate for correctness, but its real cost is CPU on a gateway
+    # whose HPA scales on CPU, and that only shows up under production traffic
+    # volume -- so Production stays off until the non-production soak says
+    # otherwise, at which point this default becomes the single line to flip.
+    # Pass True or False to override for one application ahead of that.
+    enable_gzip: bool | None = None
     k8s_labels: dict[str, str] = {}
     k8s_namespace: str
     # Either raw CRD dicts or OLApisixPluginConfig objects; the component
@@ -511,64 +519,66 @@ class OLApisixSharedPlugins(ComponentResource):
                 "enable": True,
                 "config": {"prefer_name": True},
             },
-            # Response compression.  APISIX loads the gzip plugin cluster-wide
-            # (see the enabled-plugins list in
-            # infrastructure/aws/eks/apisix_official.py) but until now it was
-            # attached to no route anywhere, so every response through every
-            # shared gateway went out uncompressed.  Measured on
-            # applications-production 2026-08-05: each JupyterHub
-            # notebook_core.<hash>.js fetch was exactly 7,167,719 bytes, byte
-            # for byte, on every single request -- ~4.85 GB/day of /static/ on
-            # nb.learn.mit.edu alone.  Compressing shrinks both the egress and
-            # the body NGINX has to buffer for a slow client, which is the
-            # mechanism behind the 2026-07-21 gateway OOM (see the
-            # proxy_buffering block in apisix_official.py).
-            #
-            # ``types`` deliberately lists only text-shaped payloads.  Formats
-            # that are already compressed (images, video, woff/woff2, archives)
-            # would burn CPU for no gain, and ``text/event-stream`` is excluded
-            # so SSE responses are not held back by the compression buffers.
-            #
-            # ``comp_level`` stays at NGINX's own default of 1 rather than
-            # something higher: this attaches to every route on a gateway whose
-            # HPA scales on CPU, and level 1 already captures most of the
-            # reduction on JS/JSON. Raise it only with gateway CPU headroom in
-            # hand.  ``vary`` is on so downstream shared caches key on
-            # Accept-Encoding instead of serving a gzipped body to a client
-            # that did not ask for one.
-            {
-                "name": "gzip",
-                "enable": True,
-                "config": {
-                    "types": [
-                        "application/javascript",
-                        "application/json",
-                        "application/manifest+json",
-                        "application/rss+xml",
-                        "application/wasm",
-                        "application/x-javascript",
-                        "application/xml",
-                        "image/svg+xml",
-                        "text/css",
-                        "text/html",
-                        "text/javascript",
-                        "text/plain",
-                        "text/xml",
-                    ],
-                    # Below roughly one MTU the framing overhead outweighs the
-                    # saving, and APISIX's own default of 20 bytes would
-                    # compress essentially every response.
-                    "min_length": 1024,
-                    "comp_level": 1,
-                    # 16 x 4 KiB = 64 KiB of compression buffers per in-flight
-                    # response, deliberately in the same range as the ~72 KiB
-                    # proxy-buffer budget set in apisix_official.py so the
-                    # per-request memory footprint stays predictable.
-                    "buffers": {"number": 16, "size": 4096},
-                    "vary": True,
-                },
-            },
         ]
+
+        # Response compression.  APISIX loads the gzip plugin cluster-wide (see
+        # the enabled-plugins list in infrastructure/aws/eks/apisix_official.py)
+        # but until now it was attached to no route anywhere, so every response
+        # through every shared gateway went out uncompressed.  Measured on
+        # applications-production 2026-08-05: each JupyterHub
+        # notebook_core.<hash>.js fetch was exactly 7,167,719 bytes, byte for
+        # byte, on every single request -- ~4.85 GB/day of /static/ on
+        # nb.learn.mit.edu alone.  Compressing shrinks both the egress and the
+        # body NGINX has to buffer for a slow client, which is the mechanism
+        # behind the 2026-07-21 gateway OOM (see the proxy_buffering block in
+        # apisix_official.py).
+        #
+        # Kept out of __default_plugins because it is rolled out
+        # non-production-first -- see ``enable_gzip`` on the config class.
+        #
+        # ``types`` deliberately lists only text-shaped payloads.  Formats that
+        # are already compressed (images, video, woff/woff2, archives) would
+        # burn CPU for no gain, and ``text/event-stream`` is excluded so SSE
+        # responses are not held back by the compression buffers.
+        #
+        # ``comp_level`` stays at NGINX's own default of 1 rather than something
+        # higher: this attaches to every route on a gateway whose HPA scales on
+        # CPU, and level 1 already captures most of the reduction on JS/JSON.
+        # Raise it only with gateway CPU headroom in hand.  ``vary`` is on so
+        # downstream shared caches key on Accept-Encoding instead of serving a
+        # gzipped body to a client that did not ask for one.
+        __gzip_plugin: dict[str, Any] = {
+            "name": "gzip",
+            "enable": True,
+            "config": {
+                "types": [
+                    "application/javascript",
+                    "application/json",
+                    "application/manifest+json",
+                    "application/rss+xml",
+                    "application/wasm",
+                    "application/x-javascript",
+                    "application/xml",
+                    "image/svg+xml",
+                    "text/css",
+                    "text/html",
+                    "text/javascript",
+                    "text/plain",
+                    "text/xml",
+                ],
+                # Below roughly one MTU the framing overhead outweighs the
+                # saving, and APISIX's own default of 20 bytes would compress
+                # essentially every response.
+                "min_length": 1024,
+                "comp_level": 1,
+                # 16 x 4 KiB = 64 KiB of compression buffers per in-flight
+                # response, deliberately in the same range as the ~72 KiB
+                # proxy-buffer budget set in apisix_official.py so the
+                # per-request memory footprint stays predictable.
+                "buffers": {"number": 16, "size": 4096},
+                "vary": True,
+            },
+        }
 
         # opentelemetry emits an OTLP trace span per request.  ``always_on`` head
         # sampling exports every span to the Grafana Alloy receiver, which then
@@ -607,6 +617,16 @@ class OLApisixSharedPlugins(ComponentResource):
             and parse_stack().env_suffix.lower() != "ci"
         ):
             plugins.append(__opentelemetry_plugin)
+
+        # Unset means "resolve from the stack": every non-Production environment
+        # soaks compression first.  Unlike the opentelemetry gate above this is
+        # not a correctness constraint -- APISIX loads gzip everywhere -- it is
+        # a deliberate rollout order, so a caller may override it either way.
+        enable_gzip = plugin_config.enable_gzip
+        if enable_gzip is None:
+            enable_gzip = parse_stack().env_suffix.lower() != "production"
+        if enable_gzip:
+            plugins.append(__gzip_plugin)
 
         self.resource_name = (
             f"{plugin_config.application_name}-{plugin_config.resource_suffix}"

--- a/src/ol_infrastructure/components/services/apisix.py
+++ b/src/ol_infrastructure/components/services/apisix.py
@@ -511,6 +511,63 @@ class OLApisixSharedPlugins(ComponentResource):
                 "enable": True,
                 "config": {"prefer_name": True},
             },
+            # Response compression.  APISIX loads the gzip plugin cluster-wide
+            # (see the enabled-plugins list in
+            # infrastructure/aws/eks/apisix_official.py) but until now it was
+            # attached to no route anywhere, so every response through every
+            # shared gateway went out uncompressed.  Measured on
+            # applications-production 2026-08-05: each JupyterHub
+            # notebook_core.<hash>.js fetch was exactly 7,167,719 bytes, byte
+            # for byte, on every single request -- ~4.85 GB/day of /static/ on
+            # nb.learn.mit.edu alone.  Compressing shrinks both the egress and
+            # the body NGINX has to buffer for a slow client, which is the
+            # mechanism behind the 2026-07-21 gateway OOM (see the
+            # proxy_buffering block in apisix_official.py).
+            #
+            # ``types`` deliberately lists only text-shaped payloads.  Formats
+            # that are already compressed (images, video, woff/woff2, archives)
+            # would burn CPU for no gain, and ``text/event-stream`` is excluded
+            # so SSE responses are not held back by the compression buffers.
+            #
+            # ``comp_level`` stays at NGINX's own default of 1 rather than
+            # something higher: this attaches to every route on a gateway whose
+            # HPA scales on CPU, and level 1 already captures most of the
+            # reduction on JS/JSON. Raise it only with gateway CPU headroom in
+            # hand.  ``vary`` is on so downstream shared caches key on
+            # Accept-Encoding instead of serving a gzipped body to a client
+            # that did not ask for one.
+            {
+                "name": "gzip",
+                "enable": True,
+                "config": {
+                    "types": [
+                        "application/javascript",
+                        "application/json",
+                        "application/manifest+json",
+                        "application/rss+xml",
+                        "application/wasm",
+                        "application/x-javascript",
+                        "application/xml",
+                        "image/svg+xml",
+                        "text/css",
+                        "text/html",
+                        "text/javascript",
+                        "text/plain",
+                        "text/xml",
+                    ],
+                    # Below roughly one MTU the framing overhead outweighs the
+                    # saving, and APISIX's own default of 20 bytes would
+                    # compress essentially every response.
+                    "min_length": 1024,
+                    "comp_level": 1,
+                    # 16 x 4 KiB = 64 KiB of compression buffers per in-flight
+                    # response, deliberately in the same range as the ~72 KiB
+                    # proxy-buffer budget set in apisix_official.py so the
+                    # per-request memory footprint stays predictable.
+                    "buffers": {"number": 16, "size": 4096},
+                    "vary": True,
+                },
+            },
         ]
 
         # opentelemetry emits an OTLP trace span per request.  ``always_on`` head

--- a/tests/ol_infrastructure/components/services/test_apisix.py
+++ b/tests/ol_infrastructure/components/services/test_apisix.py
@@ -45,6 +45,8 @@ from bridge.lib.constants import (  # noqa: E402
 from ol_infrastructure.components.services.apisix import (  # noqa: E402
     OLApisixOIDCConfig,
     OLApisixOIDCResources,
+    OLApisixSharedPlugins,
+    OLApisixSharedPluginsConfig,
     OLApisixUpstream,
     OLApisixUpstreamConfig,
     stale_session_cookie_cleanup_plugin,
@@ -340,3 +342,114 @@ def test_cleanup_plugin_honours_a_custom_stale_name():
     ).config["functions"]
 
     assert 'name == "mitlearn_apisix_session"' in lua
+
+
+# ─── Shared plugin defaults ────────────────────────────────────────────────────
+
+
+def shared_plugins(name: str, **overrides) -> OLApisixSharedPlugins:
+    """Build a shared plugin config with the fields every caller has to supply."""
+    return OLApisixSharedPlugins(
+        name,
+        plugin_config=OLApisixSharedPluginsConfig(
+            application_name="myapp",
+            k8s_namespace="myapp-ns",
+            **overrides,
+        ),
+    )
+
+
+def plugin_named(plugins, name):
+    """Return the single plugin entry called ``name``, or None if absent."""
+    matches = [plugin for plugin in plugins if plugin["name"] == name]
+    assert len(matches) <= 1, f"{name} rendered more than once"
+    return matches[0] if matches else None
+
+
+@pulumi.runtime.test
+def test_gzip_is_attached_by_default():
+    """APISIX loads the gzip plugin cluster-wide, but a plugin does nothing
+    until a route or plugin config references it -- for a long time this one
+    referenced it nowhere and every shared-gateway response went out
+    uncompressed.
+    """
+    plugins = shared_plugins("test-shared-plugins-gzip-default")
+
+    def check(spec):
+        gzip = plugin_named(spec["plugins"], "gzip")
+        assert gzip is not None
+        assert gzip["enable"] is True
+
+    return plugins.shared_plugin_apisix_pluginconfig_resource.spec.apply(check)
+
+
+@pulumi.runtime.test
+def test_gzip_is_absent_when_defaults_disabled():
+    """enable_defaults=False has to drop gzip along with every other default;
+    a caller opting out of the defaults is opting out of this one too.
+    """
+    plugins = shared_plugins(
+        "test-shared-plugins-gzip-opt-out",
+        enable_defaults=False,
+    )
+
+    def check(spec):
+        assert plugin_named(spec["plugins"], "gzip") is None
+
+    return plugins.shared_plugin_apisix_pluginconfig_resource.spec.apply(check)
+
+
+@pulumi.runtime.test
+def test_gzip_reaches_the_gateway_api_plugin_config():
+    """The v1alpha1 PluginConfig is rendered by a separate comprehension that
+    rewrites each entry, so Gateway API HTTPRoutes need their own assertion
+    rather than inheriting the v2 one.
+    """
+    plugins = shared_plugins("test-shared-plugins-gzip-gateway-api")
+
+    def check(spec):
+        gzip = plugin_named(spec["plugins"], "gzip")
+        assert gzip is not None
+        # v1alpha1 accepts only name and config -- ``enable`` is v2-only.
+        assert set(gzip) == {"name", "config"}
+
+    return plugins.shared_plugin_pluginconfig_resource.spec.apply(check)
+
+
+@pulumi.runtime.test
+def test_gzip_does_not_compress_streaming_or_precompressed_types():
+    """text/event-stream is excluded so SSE responses are not held back by the
+    compression buffers, and already-compressed formats are excluded so they
+    do not burn gateway CPU for no gain. Both are easy to undo by accident
+    when someone widens the list.
+    """
+    plugins = shared_plugins("test-shared-plugins-gzip-types")
+
+    def check(spec):
+        types = plugin_named(spec["plugins"], "gzip")["config"]["types"]
+        assert "text/event-stream" not in types
+        for precompressed in (
+            "image/png",
+            "video/mp4",
+            "font/woff2",
+            "application/zip",
+        ):
+            assert precompressed not in types
+
+    return plugins.shared_plugin_apisix_pluginconfig_resource.spec.apply(check)
+
+
+@pulumi.runtime.test
+def test_gzip_compression_level_stays_cheap():
+    """comp_level is pinned to NGINX's own default of 1 on purpose: this
+    attaches to every route on a gateway whose HPA scales on CPU. Raising it
+    is a deliberate decision to make with measurement in hand, not a drive-by.
+    """
+    plugins = shared_plugins("test-shared-plugins-gzip-comp-level")
+
+    def check(spec):
+        config = plugin_named(spec["plugins"], "gzip")["config"]
+        assert config["comp_level"] == 1
+        assert config["vary"] is True
+
+    return plugins.shared_plugin_apisix_pluginconfig_resource.spec.apply(check)

--- a/tests/ol_infrastructure/components/services/test_apisix.py
+++ b/tests/ol_infrastructure/components/services/test_apisix.py
@@ -15,6 +15,8 @@ This module verifies:
 from __future__ import annotations
 
 import asyncio
+from contextlib import contextmanager
+from dataclasses import replace
 
 import pulumi
 
@@ -42,6 +44,7 @@ from bridge.lib.constants import (  # noqa: E402
     apisix_oidc_session_cookie_name,
     mit_learn_session_cookie_name,
 )
+from ol_infrastructure.components.services import apisix as apisix_module  # noqa: E402
 from ol_infrastructure.components.services.apisix import (  # noqa: E402
     OLApisixOIDCConfig,
     OLApisixOIDCResources,
@@ -366,14 +369,31 @@ def plugin_named(plugins, name):
     return matches[0] if matches else None
 
 
+@contextmanager
+def stack_env(env_suffix: str):
+    """Pretend the component is being rendered against a given environment.
+
+    ``parse_stack`` is imported into the apisix module's namespace, and the
+    mocks fix the stack name process-wide, so patching the reference there is
+    the only way to exercise the per-environment gate.
+    """
+    original = apisix_module.parse_stack
+    apisix_module.parse_stack = lambda: replace(original(), env_suffix=env_suffix)
+    try:
+        yield
+    finally:
+        apisix_module.parse_stack = original
+
+
 @pulumi.runtime.test
-def test_gzip_is_attached_by_default():
+def test_gzip_is_attached_outside_production():
     """APISIX loads the gzip plugin cluster-wide, but a plugin does nothing
     until a route or plugin config references it -- for a long time this one
     referenced it nowhere and every shared-gateway response went out
-    uncompressed.
+    uncompressed. Non-production environments soak the fix first.
     """
-    plugins = shared_plugins("test-shared-plugins-gzip-default")
+    with stack_env("qa"):
+        plugins = shared_plugins("test-shared-plugins-gzip-qa")
 
     def check(spec):
         gzip = plugin_named(spec["plugins"], "gzip")
@@ -384,17 +404,70 @@ def test_gzip_is_attached_by_default():
 
 
 @pulumi.runtime.test
-def test_gzip_is_absent_when_defaults_disabled():
-    """enable_defaults=False has to drop gzip along with every other default;
-    a caller opting out of the defaults is opting out of this one too.
+def test_gzip_is_absent_in_production_by_default():
+    """Production stays off until the non-production soak says otherwise. The
+    risk is not correctness -- APISIX loads gzip everywhere -- it is CPU on a
+    gateway whose HPA scales on CPU, which only shows up at production volume.
     """
-    plugins = shared_plugins(
-        "test-shared-plugins-gzip-opt-out",
-        enable_defaults=False,
-    )
+    with stack_env("production"):
+        plugins = shared_plugins("test-shared-plugins-gzip-production")
 
     def check(spec):
         assert plugin_named(spec["plugins"], "gzip") is None
+
+    return plugins.shared_plugin_apisix_pluginconfig_resource.spec.apply(check)
+
+
+@pulumi.runtime.test
+def test_gzip_can_be_forced_on_in_production():
+    """An application that has done its own measurement can go early without
+    waiting for the fleet-wide default to flip.
+    """
+    with stack_env("production"):
+        plugins = shared_plugins(
+            "test-shared-plugins-gzip-production-override",
+            enable_gzip=True,
+        )
+
+    def check(spec):
+        assert plugin_named(spec["plugins"], "gzip") is not None
+
+    return plugins.shared_plugin_apisix_pluginconfig_resource.spec.apply(check)
+
+
+@pulumi.runtime.test
+def test_gzip_can_be_forced_off_outside_production():
+    """The override has to work in both directions -- an app that streams, or
+    is otherwise a bad fit for compression, opts out of the soak too.
+    """
+    with stack_env("qa"):
+        plugins = shared_plugins(
+            "test-shared-plugins-gzip-qa-opt-out",
+            enable_gzip=False,
+        )
+
+    def check(spec):
+        assert plugin_named(spec["plugins"], "gzip") is None
+
+    return plugins.shared_plugin_apisix_pluginconfig_resource.spec.apply(check)
+
+
+@pulumi.runtime.test
+def test_gzip_is_independent_of_enable_defaults():
+    """Gzip carries its own flag rather than riding in __default_plugins, so
+    enable_defaults=False does not turn it off -- same contract as
+    opentelemetry. enable_gzip=False is the way to drop it.
+    """
+    with stack_env("qa"):
+        plugins = shared_plugins(
+            "test-shared-plugins-gzip-without-defaults",
+            enable_defaults=False,
+        )
+
+    def check(spec):
+        assert plugin_named(spec["plugins"], "gzip") is not None
+        # The actual defaults are gone, confirming the flag is doing the work.
+        assert plugin_named(spec["plugins"], "cors") is None
 
     return plugins.shared_plugin_apisix_pluginconfig_resource.spec.apply(check)
 


### PR DESCRIPTION
### What are the relevant tickets?

Follow-up from the 2026-07-21 `applications-production` APISIX OOM incident, same thread as #5074.

### Description (What does it do?)

APISIX has had the `gzip` plugin in its enabled-plugins list (`infrastructure/aws/eks/apisix_official.py:97`) since the official-chart migration, but it was attached to **no route anywhere in this repo**. Every response through every shared gateway, on all four EKS clusters, has been going out uncompressed.

Measured against live `applications-production` access logs on 2026-08-05: every single JupyterHub `notebook_core.<hash>.js` fetch is exactly **7,167,719 bytes**, byte for byte, on every request — `~4.85 GB/day` of `/static/` on `nb.learn.mit.edu` alone. That 7.2 MB is also the body NGINX buffers for the full duration of a slow client's download, which is precisely the mechanism behind the OOM that #5074 addressed at the buffering layer. Compressing it attacks the same failure from the other side, and makes the aborted-and-retried multi-MB downloads observed from slow international links substantially less likely.

**Rollout is non-production-first.** `gzip` gets its own `enable_gzip` flag on `OLApisixSharedPluginsConfig` rather than riding in `__default_plugins`, mirroring how `enable_opentelemetry` already works. Unset — the default — resolves from the stack: **on everywhere except Production**. The risk here is not correctness (APISIX loads the plugin on every cluster) but CPU, on a gateway whose HPA scales on CPU, and that cost only appears at production traffic volume. CI and QA cannot answer that question, so Production waits for the soak.

Once the non-production soak looks good, flipping the fleet is a one-line change to that default. An application that has done its own measurement can pass `enable_gzip=True` to go early, or `False` to sit out.

One consequence worth flagging for review: because `gzip` no longer lives in `__default_plugins`, `enable_defaults=False` no longer removes it. That matches the `opentelemetry` contract and is covered by a test, but it is a behaviour change from the first revision of this PR.

Both CRD paths are covered, since `OLApisixSharedPlugins` renders the same plugin list into each: the `apisix.apache.org/v2` `ApisixPluginConfig` consumed by legacy `ApisixRoute`/`Ingress`, and the `apisix.apache.org/v1alpha1` `PluginConfig` consumed by Gateway API `HTTPRoute`. The v1alpha1 spec is built by a separate comprehension that rewrites each entry, so it has its own assertion.

Config choices, for review:

- **`comp_level: 1`** — NGINX's own default, deliberately not raised. Level 1 already captures most of the reduction on JS/JSON payloads. Worth revisiting with the soak's CPU numbers in hand; current gateway utilisation is 22–62% of requests.
- **`types`** — text-shaped payloads only. Already-compressed formats (images, video, `woff`/`woff2`, archives) are excluded so they do not burn CPU for no gain, and `text/event-stream` is excluded so SSE responses are not held back by the compression buffers.
- **`min_length: 1024`** — APISIX's default of 20 bytes would compress essentially every response, below the point where framing overhead outweighs the saving.
- **`buffers: 16 x 4 KiB`** — 64 KiB per in-flight response, deliberately in the same range as the ~72 KiB proxy-buffer budget set in `apisix_official.py`, so the per-request memory footprint stays predictable.
- **`vary: true`** — so downstream shared caches key on `Accept-Encoding` rather than serving a gzipped body to a client that did not ask for one.

### How can this be tested?

- `uv run ruff check`, `uv run ruff format --check`, `uv run mypy`, and `uv run pre-commit run` all pass.
- `uv run pytest tests/ol_infrastructure/components/services/test_apisix.py` — 31 passed. Eight of those are new, covering: attached outside Production; absent in Production by default; both override directions; independence from `enable_defaults`; presence in the Gateway API `PluginConfig` with the v1alpha1-legal `{name, config}` shape; and two that pin reasoning rather than rendering — that `text/event-stream` and pre-compressed types stay out of `types`, and that `comp_level` stays at 1.
- `pulumi preview` on `src/ol_infrastructure/applications/jupyterhub` confirms the gate against real stack config:
  - stack `QA` → `4 to update, 84 unchanged` — the two `ApisixPluginConfig` (v2) and two `PluginConfig` (v1alpha1) resources for the `jupyterhub` and `jupyterhub-authoring` deployments each gain the `gzip` entry.
  - stack `Production` → `94 unchanged` — no diff at all.
- After deploy to a non-production cluster: `curl -H 'Accept-Encoding: gzip' -sI https://<host>/<a JS asset>` should return `Content-Encoding: gzip` and `Vary: Accept-Encoding`.
- During the soak, watch gateway CPU (the HPA scales on it) and any streaming or long-poll endpoint served as `application/json`.
- The Production evidence to collect before flipping the default: `body_bytes_sent` for `notebook_core.<hash>.js` on `nb.learn.mit.edu` should drop from the current invariant 7,167,719 to roughly 1.7–2 MB, and total `/static/` egress on that host should fall well below 4.85 GB/day.

### Additional Context

Not every route picks this up. 14 of the 44 `OLApisixRouteConfig` blocks in the repo pass no `shared_plugin_config_name` and so reference no shared plugin config at all — `airbyte` (web, api), `celery_monitoring` (web, api), `dagster`, `digital_credentials` (issuer-coordinator-protected), `gwarek` (api, web), `learn_ai` (canvas_syllabus_agent, logout-redirect — twice each), `micromasters` (passthrough), and `odl_video_service` (passthrough). Those routes get no compression from this change. Worth a separate pass to decide whether they should be on the shared plugin config; not in scope here.

The JupyterHub shared-cacheability and cookie-scope follow-ups from the same incident are tracked separately and are intentionally not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HabiWrse7J6UsuZEwbBB5B
