### PR TITLE
feat(concourse): scope secret watches to the projects that read them

### DIFF
--- a/src/ol_concourse/pipelines/constants.py
+++ b/src/ol_concourse/pipelines/constants.py
@@ -45,9 +45,18 @@ PACKER_WATCHED_PATHS = [
     "src/bilder/components/",
 ]
 PULUMI_CODE_PATH = Path("src/ol_infrastructure")
+# Paths every Pulumi pipeline watches, regardless of which project it deploys.
+#
+# NOTE: this deliberately does NOT include "src/bridge/secrets/".  Watching the
+# whole secrets tree meant a change to any one application's secret file
+# re-triggered every Pulumi pipeline in both Concourse instances.  Each pipeline
+# now watches only the secrets its own project decrypts, via
+# `ol_concourse.pipelines.secrets_map.project_secrets_paths`.  The two modules
+# below are the SOPS decryption machinery itself, which every project does run.
 PULUMI_WATCHED_PATHS = [
     "src/ol_infrastructure/lib/",
     "src/ol_infrastructure/components/",
     "pipelines/infrastructure/scripts/",
-    "src/bridge/secrets/",
+    "src/bridge/secrets/sops.py",
+    "src/bridge/secrets/__init__.py",
 ]

--- a/src/ol_concourse/pipelines/constants.py
+++ b/src/ol_concourse/pipelines/constants.py
@@ -51,12 +51,14 @@ PULUMI_CODE_PATH = Path("src/ol_infrastructure")
 # whole secrets tree meant a change to any one application's secret file
 # re-triggered every Pulumi pipeline in both Concourse instances.  Each pipeline
 # now watches only the secrets its own project decrypts, via
-# `ol_concourse.pipelines.secrets_map.project_secrets_paths`.  The two modules
-# below are the SOPS decryption machinery itself, which every project does run.
+# `ol_concourse.pipelines.secrets_map.project_secrets_paths`.  What remains
+# below is the SOPS decryption machinery itself -- the helper module, and the
+# vendored sops binaries it shells out to -- which every project does run.
 PULUMI_WATCHED_PATHS = [
     "src/ol_infrastructure/lib/",
     "src/ol_infrastructure/components/",
     "pipelines/infrastructure/scripts/",
     "src/bridge/secrets/sops.py",
     "src/bridge/secrets/__init__.py",
+    "src/bridge/secrets/bin/",
 ]

--- a/src/ol_concourse/pipelines/infrastructure/aws/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/aws/pipeline.py
@@ -4,6 +4,7 @@ from ol_concourse.lib.resources import git_repo
 
 from ol_concourse.pipelines.constants import PULUMI_CODE_PATH, PULUMI_WATCHED_PATHS
 from ol_concourse.pipelines.jobs import pulumi_jobs_chain
+from ol_concourse.pipelines.secrets_map import project_secrets_paths
 
 # Project names differ from the service names for kms/network, so use explicit mapping.
 _SIMPLE_SERVICE_PROJECT_NAMES = {
@@ -22,6 +23,7 @@ for service in ["kms", "network"]:
         paths=[
             *PULUMI_WATCHED_PATHS,
             f"src/ol_infrastructure/infrastructure/aws/{service}",
+            *project_secrets_paths(f"infrastructure/aws/{service}/"),
         ],
     )
 
@@ -60,7 +62,8 @@ for service in ["dns", "policies", "iam"]:
         uri="https://github.com/mitodl/ol-infrastructure",
         paths=[
             *PULUMI_WATCHED_PATHS,
-            f"src/ol_infrastructure/infrastructurre/aws/{service}",
+            f"src/ol_infrastructure/infrastructure/aws/{service}",
+            *project_secrets_paths(f"infrastructure/aws/{service}/"),
         ],
     )
 

--- a/src/ol_concourse/pipelines/infrastructure/concourse/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/concourse/pipeline.py
@@ -10,6 +10,7 @@ from ol_concourse.pipelines.constants import (
     PULUMI_WATCHED_PATHS,
 )
 from ol_concourse.pipelines.jobs import packer_jobs, pulumi_jobs_chain
+from ol_concourse.pipelines.secrets_map import project_secrets_paths
 
 #############
 # RESOURCES #
@@ -33,7 +34,7 @@ concourse_pulumi_code = git_repo(
     paths=[
         *PULUMI_WATCHED_PATHS,
         "src/ol_infrastructure/applications/concourse",
-        "src/bridge/secrets/concourse",
+        *project_secrets_paths("applications/concourse/"),
     ],
 )
 

--- a/src/ol_concourse/pipelines/infrastructure/consul/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/consul/pipeline.py
@@ -11,6 +11,7 @@ from ol_concourse.pipelines.constants import (
     PULUMI_WATCHED_PATHS,
 )
 from ol_concourse.pipelines.jobs import packer_jobs, pulumi_jobs_chain
+from ol_concourse.pipelines.secrets_map import project_secrets_paths
 
 consul_release = hashicorp_release(Identifier("consul-release"), "consul")
 consul_image_code = git_repo(
@@ -29,6 +30,7 @@ consul_pulumi_infrastructure_code = git_repo(
     paths=[
         *PULUMI_WATCHED_PATHS,
         "src/ol_infrastructure/infrastructure/consul/",
+        *project_secrets_paths("infrastructure/consul/"),
     ],
 )
 
@@ -38,6 +40,7 @@ consul_pulumi_substructure_code = git_repo(
     paths=[
         *PULUMI_WATCHED_PATHS,
         "src/ol_infrastructure/substructure/consul/",
+        *project_secrets_paths("substructure/consul/"),
     ],
 )
 

--- a/src/ol_concourse/pipelines/infrastructure/dagster/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/dagster/pipeline.py
@@ -25,6 +25,7 @@ from ol_concourse.pipelines.constants import (
     dockerhub_ecr_image_uri,
 )
 from ol_concourse.pipelines.jobs import pulumi_jobs_chain
+from ol_concourse.pipelines.secrets_map import project_secrets_paths
 
 
 def build_dagster_docker_pipeline() -> Pipeline:
@@ -107,6 +108,7 @@ def build_dagster_docker_pipeline() -> Pipeline:
             *PULUMI_WATCHED_PATHS,
             "src/ol_infrastructure/applications/dagster/",
             "src/bridge/lib/versions.py",
+            *project_secrets_paths("applications/dagster/"),
         ],
         branch=pulumi_code_branch,
     )

--- a/src/ol_concourse/pipelines/infrastructure/eks_clusters/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/eks_clusters/pipeline.py
@@ -4,6 +4,7 @@ from ol_concourse.lib.resources import git_repo
 
 from ol_concourse.pipelines.constants import PULUMI_CODE_PATH, PULUMI_WATCHED_PATHS
 from ol_concourse.pipelines.jobs import pulumi_jobs_chain
+from ol_concourse.pipelines.secrets_map import project_secrets_paths
 
 eks_infrastructure_code = git_repo(
     Identifier("ol-infrastructure"),
@@ -12,6 +13,7 @@ eks_infrastructure_code = git_repo(
         "src/ol_infrastructure/infrastructure/aws/eks",
         *PULUMI_WATCHED_PATHS,
         "src/bridge/lib/versions.py",
+        *project_secrets_paths("infrastructure/aws/eks/"),
     ],
 )
 
@@ -22,6 +24,7 @@ eks_substructure_code = git_repo(
         "src/ol_infrastructure/substructure/aws/eks",
         *PULUMI_WATCHED_PATHS,
         "src/bridge/lib/versions.py",
+        *project_secrets_paths("substructure/aws/eks/"),
     ],
 )
 

--- a/src/ol_concourse/pipelines/infrastructure/jupyterhub/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/jupyterhub/pipeline.py
@@ -7,6 +7,7 @@ from ol_concourse.pipelines.constants import (
     PULUMI_WATCHED_PATHS,
 )
 from ol_concourse.pipelines.jobs import pulumi_jobs_chain
+from ol_concourse.pipelines.secrets_map import project_secrets_paths
 
 jupyterhub_pulumi_code = git_repo(
     name=Identifier("ol-infrastructure-pulumi"),
@@ -14,6 +15,7 @@ jupyterhub_pulumi_code = git_repo(
     paths=[
         *PULUMI_WATCHED_PATHS,
         "src/ol_infrastructure/applications/jupyterhub/",
+        *project_secrets_paths("applications/jupyterhub/"),
     ],
 )
 

--- a/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py
@@ -50,6 +50,7 @@ from ol_concourse.pipelines.constants import (
     dockerhub_ecr_image_uri,
 )
 from ol_concourse.pipelines.jobs import pulumi_job, pulumi_jobs_chain
+from ol_concourse.pipelines.secrets_map import project_secrets_paths
 
 
 class SentrySourcemapsConfig(BaseModel):
@@ -381,6 +382,7 @@ def _define_git_resources_legacy(
         paths=[
             f"src/ol_infrastructure/applications/{app_name.replace('-', '_')}",
             *PULUMI_WATCHED_PATHS,
+            *project_secrets_paths(f"applications/{app_name.replace('-', '_')}/"),
         ],
     )
     return (
@@ -842,6 +844,7 @@ def _define_git_resources(
         paths=[
             f"src/ol_infrastructure/applications/{app_name.replace('-', '_')}",
             *PULUMI_WATCHED_PATHS,
+            *project_secrets_paths(f"applications/{app_name.replace('-', '_')}/"),
         ],
     )
     return main_repo, ol_infra_repo

--- a/src/ol_concourse/pipelines/infrastructure/keycloak/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/keycloak/pipeline.py
@@ -33,6 +33,7 @@ from ol_concourse.pipelines.constants import (
     dockerhub_ecr_image_uri,
 )
 from ol_concourse.pipelines.jobs import pulumi_jobs_chain
+from ol_concourse.pipelines.secrets_map import project_secrets_paths
 
 
 def build_keycloak_substructure_pipeline() -> PipelineFragment:
@@ -43,6 +44,7 @@ def build_keycloak_substructure_pipeline() -> PipelineFragment:
         paths=[
             *PULUMI_WATCHED_PATHS,
             str(PULUMI_CODE_PATH.joinpath("substructure/keycloak/")),
+            *project_secrets_paths("substructure/keycloak/"),
         ],
     )
     substructure_fragment = pulumi_jobs_chain(
@@ -83,6 +85,7 @@ def build_keycloak_infrastructure_pipeline() -> PipelineFragment:
             *PULUMI_WATCHED_PATHS,
             str(PULUMI_CODE_PATH.joinpath("applications/keycloak/")),
             "src/bridge/lib/versions.py",
+            *project_secrets_paths("applications/keycloak/"),
         ],
     )
 

--- a/src/ol_concourse/pipelines/infrastructure/kubewatch/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/kubewatch/pipeline.py
@@ -18,6 +18,7 @@ from ol_concourse.pipelines.constants import (
     PULUMI_WATCHED_PATHS,
 )
 from ol_concourse.pipelines.jobs import pulumi_jobs_chain
+from ol_concourse.pipelines.secrets_map import project_secrets_paths
 
 
 def build_kubewatch_webhook_handler_pipeline() -> PipelineFragment:
@@ -32,6 +33,7 @@ def build_kubewatch_webhook_handler_pipeline() -> PipelineFragment:
         paths=[
             *PULUMI_WATCHED_PATHS,
             str(PULUMI_CODE_PATH.joinpath("applications/kubewatch_webhook_handler/")),
+            *project_secrets_paths("applications/kubewatch_webhook_handler/"),
         ],
     )
 
@@ -108,6 +110,7 @@ def build_kubewatch_pipeline() -> PipelineFragment:
         paths=[
             *PULUMI_WATCHED_PATHS,
             str(PULUMI_CODE_PATH.joinpath("applications/kubewatch/")),
+            *project_secrets_paths("applications/kubewatch/"),
         ],
     )
 

--- a/src/ol_concourse/pipelines/infrastructure/omnigraph/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/omnigraph/pipeline.py
@@ -51,6 +51,7 @@ from ol_concourse.pipelines.constants import (
 )
 from ol_concourse.pipelines.ecr import configure_ecr_repository_task
 from ol_concourse.pipelines.jobs import pulumi_jobs_chain
+from ol_concourse.pipelines.secrets_map import project_secrets_paths
 
 ENVIRONMENTS = ("CI", "QA", "Production")
 IMAGE_NAME = "omnigraph-server"
@@ -85,6 +86,7 @@ def build_omnigraph_pipeline() -> PipelineFragment:
         paths=[
             *PULUMI_WATCHED_PATHS,
             str(PULUMI_PROJECT_PATH),
+            *project_secrets_paths("applications/omnigraph/"),
         ],
     )
 

--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/README.md
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/README.md
@@ -194,16 +194,24 @@ If you're migrating an existing pipeline to this pattern:
 
 ### Additional Watched Paths
 
-Some apps need to watch additional directories beyond standard Pulumi paths:
+Some apps need to watch additional directories beyond the standard Pulumi paths:
 
 ```python
-"ocw-studio": SimplePulumiParams(
-    app_name="ocw-studio",
-    pulumi_project_path="applications/ocw_studio/",
-    stack_prefix="applications.ocw_studio",
-    additional_watched_paths=["src/bridge/secrets/ocw_studio/"],
+"rootly": SimplePulumiParams(
+    app_name="rootly",
+    pulumi_project_path="saas/rootly/",
+    pulumi_project_name="ol-saas-rootly",
+    additional_watched_paths=["sdks/rootly/"],
+    stages=["Production"],
 ),
 ```
+
+Do **not** list `src/bridge/secrets/...` here. Secrets are scoped centrally in
+`src/ol_concourse/pipelines/secrets_map.py`, keyed by `pulumi_project_path`, and
+added to every pipeline automatically. Watching the whole secrets tree is what
+used to make one app's secret change re-trigger every Pulumi pipeline. If a
+project starts reading a new secret, add it to `PROJECT_SECRETS` there --
+`tests/ol_concourse/test_secrets_map.py` fails if you forget.
 
 ### Custom Stages Configuration
 

--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
@@ -38,6 +38,7 @@ from ol_concourse.pipelines.constants import (
     dockerhub_ecr_image_uri,
 )
 from ol_concourse.pipelines.jobs import pulumi_jobs_chain
+from ol_concourse.pipelines.secrets_map import project_secrets_paths
 
 
 class DockerImageConfig(BaseModel):
@@ -103,7 +104,12 @@ class SimplePulumiParams(BaseModel):
                           If specified, auto_discover_stacks will be used.
         auto_discover_stacks: If True, automatically discover stacks from repo
                              (default: False unless deployment_groups is set).
-        additional_watched_paths: Additional paths to watch beyond PULUMI_WATCHED_PATHS.
+        additional_watched_paths: Additional paths to watch beyond
+                          PULUMI_WATCHED_PATHS and the project's own directory.
+                          Do NOT list src/bridge/secrets paths here -- those come
+                          from `secrets_map.PROJECT_SECRETS`, which is what keeps
+                          one app's secret change from re-triggering every
+                          Pulumi pipeline.
         branch: Git branch to watch (default: "main").
         docker_image: Optional Docker image configuration for apps that depend on
                      external Docker images, or (with ``build`` set) their own image.
@@ -302,10 +308,6 @@ pipeline_params: dict[str, SimplePulumiParams] = {
         app_name="airbyte",
         pulumi_project_path="applications/airbyte/",
         pulumi_project_name="ol-application-airbyte",
-        additional_watched_paths=[
-            "src/bridge/secrets/airbyte/",
-            "src/bridge/lib/versions.py",
-        ],
     ),
     "celery-monitoring": SimplePulumiParams(
         app_name="celery-monitoring",
@@ -333,7 +335,6 @@ pipeline_params: dict[str, SimplePulumiParams] = {
         app_name="digital-credentials",
         pulumi_project_path="applications/digital_credentials/",
         pulumi_project_name="ol-application-digital-credentials",
-        additional_watched_paths=["src/bridge/secrets/digital_credentials/"],
     ),
     "fastly-redirector": SimplePulumiParams(
         app_name="fastly-redirector",
@@ -350,7 +351,6 @@ pipeline_params: dict[str, SimplePulumiParams] = {
         app_name="jupyterhub-data",
         pulumi_project_path="applications/jupyterhub_data/",
         pulumi_project_name="ol-application-jupyterhub-data",
-        additional_watched_paths=["src/bridge/secrets/jupyterhub_data/"],
     ),
     "marimo-data": SimplePulumiParams(
         app_name="marimo-data",
@@ -380,19 +380,11 @@ pipeline_params: dict[str, SimplePulumiParams] = {
         app_name="open-metadata",
         pulumi_project_path="applications/open_metadata/",
         pulumi_project_name="ol-application-open-metadata",
-        additional_watched_paths=[
-            "src/bridge/secrets/open_metadata/",
-            "src/bridge/lib/versions.py",
-        ],
     ),
     "open-metadata-substructure": SimplePulumiParams(
         app_name="open-metadata-substructure",
         pulumi_project_path="substructure/open_metadata/",
         pulumi_project_name="ol-substructure-open-metadata",
-        additional_watched_paths=[
-            "src/bridge/secrets/open_metadata/",
-            "src/bridge/lib/versions.py",
-        ],
         stages=["QA", "Production"],
     ),
     "opensearch": SimplePulumiParams(
@@ -422,10 +414,6 @@ pipeline_params: dict[str, SimplePulumiParams] = {
         pulumi_project_path="infrastructure/qdrant_cloud/",
         pulumi_project_name="ol-infrastructure-qdrant-cloud",
         stack_prefix="mitlearn",
-        additional_watched_paths=[
-            "src/bridge/secrets/qdrant_cloud/",
-            "src/bridge/lib/versions.py",
-        ],
     ),
     "rootly": SimplePulumiParams(
         app_name="rootly",
@@ -438,10 +426,6 @@ pipeline_params: dict[str, SimplePulumiParams] = {
         app_name="sentry",
         pulumi_project_path="infrastructure/sentry/",
         pulumi_project_name="ol-infrastructure-sentry",
-        additional_watched_paths=[
-            "src/bridge/secrets/sentry/",
-            "src/bridge/lib/versions.py",
-        ],
         stages=["Production"],
     ),
     "starrocks": SimplePulumiParams(
@@ -564,7 +548,6 @@ pipeline_params: dict[str, SimplePulumiParams] = {
         pulumi_project_path="applications/release_bot/",
         pulumi_project_name="ol-infrastructure-release-bot",
         stages=["default"],
-        additional_watched_paths=["src/bridge/secrets/release_bot/"],
         # __main__.py is a singleton (stack "default") and always creates the
         # ECR repository named "release-bot-production" regardless of stage.
         docker_image=DockerImageConfig(
@@ -607,6 +590,7 @@ def build_simple_pulumi_pipeline(app_name: str) -> Pipeline:
             *PULUMI_WATCHED_PATHS,
             str(PULUMI_CODE_PATH.joinpath(params.pulumi_project_path)),
             "src/bridge/lib/versions.py",
+            *project_secrets_paths(params.pulumi_project_path),
             *params.additional_watched_paths,
         ],
     )

--- a/src/ol_concourse/pipelines/infrastructure/superset/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/superset/pipeline.py
@@ -25,6 +25,7 @@ from ol_concourse.pipelines.constants import (
     dockerhub_ecr_image_uri,
 )
 from ol_concourse.pipelines.jobs import pulumi_jobs_chain
+from ol_concourse.pipelines.secrets_map import project_secrets_paths
 
 
 def build_superset_docker_pipeline() -> Pipeline:
@@ -52,7 +53,7 @@ def build_superset_docker_pipeline() -> Pipeline:
         paths=[
             *PULUMI_WATCHED_PATHS,
             "src/ol_infrastructure/applications/superset/",
-            "src/bridge/secrets/superset",
+            *project_secrets_paths("applications/superset/"),
         ],
     )
 

--- a/src/ol_concourse/pipelines/infrastructure/vault/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/vault/pipeline.py
@@ -13,6 +13,21 @@ from ol_concourse.pipelines.constants import (
     PULUMI_WATCHED_PATHS,
 )
 from ol_concourse.pipelines.jobs import packer_jobs, pulumi_jobs_chain
+from ol_concourse.pipelines.secrets_map import (
+    combined_secrets_paths,
+    project_secrets_paths,
+)
+
+# Every substructure/vault/* Pulumi project deployed by this pipeline, sharing a
+# single git resource -- so its watched secrets are the union across all of them.
+VAULT_SUBSTRUCTURE_PROJECTS = (
+    "pki",
+    "static_mounts",
+    "auth",
+    "encryption_mounts",
+    "secrets",
+    "setup",
+)
 
 vault_release = hashicorp_release(Identifier("vault-release"), "vault")
 vault_image_code = git_repo(
@@ -28,12 +43,24 @@ vault_image_code = git_repo(
 vault_pulumi_code = git_repo(
     name=Identifier("ol-infrastructure-pulumi"),
     uri="https://github.com/mitodl/ol-infrastructure",
-    paths=[*PULUMI_WATCHED_PATHS, "src/ol_infrastructure/infrastructure/vault/"],
+    paths=[
+        *PULUMI_WATCHED_PATHS,
+        "src/ol_infrastructure/infrastructure/vault/",
+        *project_secrets_paths("infrastructure/vault/"),
+    ],
 )
 vault_pulumi_substructure_code = git_repo(
     name=Identifier("ol-infrastructure-pulumi-substructure"),
     uri="https://github.com/mitodl/ol-infrastructure",
-    paths=[*PULUMI_WATCHED_PATHS, "src/ol_infrastructure/substructure/vault/"],
+    paths=[
+        *PULUMI_WATCHED_PATHS,
+        "src/ol_infrastructure/substructure/vault/",
+        # One checkout drives every substructure/vault/* project, so watch the
+        # union of the secrets those projects read.
+        *combined_secrets_paths(
+            *(f"substructure/vault/{p}/" for p in VAULT_SUBSTRUCTURE_PROJECTS)
+        ),
+    ],
 )
 
 get_vault_release = GetStep(get=vault_release.name, trigger=True)
@@ -65,14 +92,7 @@ vault_pulumi_fragment = pulumi_jobs_chain(
 
 substructure_fragments = []
 
-for substructure in [
-    "pki",
-    "static_mounts",
-    "auth",
-    "encryption_mounts",
-    "secrets",
-    "setup",
-]:
+for substructure in VAULT_SUBSTRUCTURE_PROJECTS:
     substructure_fragments.append(  # noqa: PERF401
         pulumi_jobs_chain(
             vault_pulumi_substructure_code,

--- a/src/ol_concourse/pipelines/infrastructure/witan/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/witan/pipeline.py
@@ -54,6 +54,7 @@ from ol_concourse.pipelines.constants import (
 )
 from ol_concourse.pipelines.ecr import configure_ecr_repository_task
 from ol_concourse.pipelines.jobs import pulumi_jobs_chain
+from ol_concourse.pipelines.secrets_map import project_secrets_paths
 
 ENVIRONMENTS = ("CI", "QA", "Production")
 IMAGE_NAME = "witan"
@@ -88,6 +89,7 @@ def build_witan_pipeline() -> PipelineFragment:
         paths=[
             *PULUMI_WATCHED_PATHS,
             str(PULUMI_PROJECT_PATH),
+            *project_secrets_paths("applications/witan/"),
         ],
     )
 

--- a/src/ol_concourse/pipelines/open_edx/codejail_v3/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/codejail_v3/pipeline.py
@@ -23,6 +23,7 @@ from bridge.settings.openedx.types import DeploymentEnvRelease, OpenEdxSupported
 from bridge.settings.openedx.version_matrix import OpenLearningOpenEdxDeployment
 from ol_concourse.pipelines.constants import PULUMI_CODE_PATH, PULUMI_WATCHED_PATHS
 from ol_concourse.pipelines.jobs import pulumi_jobs_chain
+from ol_concourse.pipelines.secrets_map import project_secrets_paths
 
 
 def build_codejail_pipeline(
@@ -58,6 +59,7 @@ def build_codejail_pipeline(
             *PULUMI_WATCHED_PATHS,
             PULUMI_CODE_PATH.joinpath("applications/codejail/"),
             "src/bridge/settings/openedx",
+            *project_secrets_paths("applications/codejail/"),
         ],
     )
 

--- a/src/ol_concourse/pipelines/open_edx/edx_notes_v3/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/edx_notes_v3/pipeline.py
@@ -26,6 +26,7 @@ from ol_concourse.pipelines.constants import (
     PULUMI_WATCHED_PATHS,
 )
 from ol_concourse.pipelines.jobs import pulumi_jobs_chain
+from ol_concourse.pipelines.secrets_map import project_secrets_paths
 
 
 def build_notes_pipeline(
@@ -62,7 +63,7 @@ def build_notes_pipeline(
             *PULUMI_WATCHED_PATHS,
             PULUMI_CODE_PATH.joinpath("applications/edx_notes/"),
             "src/bridge/settings/openedx/",
-            "src/bridge/secrets/edx_notes/",
+            *project_secrets_paths("applications/edx_notes/"),
         ],
     )
 

--- a/src/ol_concourse/pipelines/open_edx/edx_platform_v3/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/edx_platform_v3/pipeline.py
@@ -31,6 +31,7 @@ from bridge.settings.openedx.types import (
 )
 from ol_concourse.pipelines.constants import PULUMI_CODE_PATH, PULUMI_WATCHED_PATHS
 from ol_concourse.pipelines.jobs import pulumi_jobs_chain
+from ol_concourse.pipelines.secrets_map import project_secrets_paths
 
 
 def build_edx_pipeline(release_names: list[str]) -> Pipeline:  # noqa: ARG001
@@ -107,8 +108,8 @@ def build_edx_pipeline(release_names: list[str]) -> Pipeline:  # noqa: ARG001
                 paths=[
                     *PULUMI_WATCHED_PATHS,
                     "src/ol_infrastructure/applications/edxapp/",
-                    "src/bridge/secrets/edxapp/",
                     "src/bridge/settings/openedx/",
+                    *project_secrets_paths("applications/edxapp/"),
                 ],
             )
 

--- a/src/ol_concourse/pipelines/open_edx/xqueue/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/xqueue/pipeline.py
@@ -16,6 +16,7 @@ from bridge.settings.openedx.accessors import filter_deployments_by_application
 from bridge.settings.openedx.types import OpenEdxSupportedRelease
 from ol_concourse.pipelines.constants import PULUMI_CODE_PATH, PULUMI_WATCHED_PATHS
 from ol_concourse.pipelines.jobs import pulumi_jobs_chain
+from ol_concourse.pipelines.secrets_map import project_secrets_paths
 
 
 def build_xqueue_pipeline(release_name: str):
@@ -53,6 +54,7 @@ def build_xqueue_pipeline(release_name: str):
             *PULUMI_WATCHED_PATHS,
             PULUMI_CODE_PATH.joinpath("applications/xqueue/"),
             "src/bridge/settings/openedx/",
+            *project_secrets_paths("applications/xqueue/"),
         ],
     )
 

--- a/src/ol_concourse/pipelines/open_edx/xqwatcher/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/xqwatcher/pipeline.py
@@ -15,6 +15,7 @@ from ol_concourse.lib.resources import git_repo, registry_image
 from bridge.settings.openedx.accessors import filter_deployments_by_application
 from ol_concourse.pipelines.constants import PULUMI_CODE_PATH, PULUMI_WATCHED_PATHS
 from ol_concourse.pipelines.jobs import pulumi_jobs_chain
+from ol_concourse.pipelines.secrets_map import project_secrets_paths
 
 
 def build_xqwatcher_pipeline(release_name: str):
@@ -40,6 +41,7 @@ def build_xqwatcher_pipeline(release_name: str):
             *PULUMI_WATCHED_PATHS,
             PULUMI_CODE_PATH.joinpath("applications/xqwatcher/"),
             "src/bridge/settings/openedx/",
+            *project_secrets_paths("applications/xqwatcher/"),
         ],
     )
 

--- a/src/ol_concourse/pipelines/secrets_map.py
+++ b/src/ol_concourse/pipelines/secrets_map.py
@@ -15,8 +15,9 @@ The mapping is derived from static analysis of ``read_yaml_secrets`` /
 ``read_json_secrets`` / ``set_env_secrets`` calls, following imports so that
 secrets read through shared modules (``lib/fastly.py``, ``lib/heroku.py``,
 ``lib/consul.py``, ``substructure/aws/eks/grafana.py``, ...) are attributed to
-every project that imports them.  ``tests/test_secrets_map.py`` re-runs that
-analysis and fails if the two ever disagree, so this file cannot silently rot.
+every project that imports them.  ``tests/ol_concourse/test_secrets_map.py``
+re-runs that analysis and fails if the two ever disagree, so this file cannot
+silently rot.
 """
 
 SECRETS_ROOT = "src/bridge/secrets"  # pragma: allowlist secret

--- a/src/ol_concourse/pipelines/secrets_map.py
+++ b/src/ol_concourse/pipelines/secrets_map.py
@@ -1,0 +1,227 @@
+"""Per-Pulumi-project mapping of the SOPS secrets each project actually reads.
+
+Concourse ``git`` resources trigger on ``paths``.  Watching the whole of
+``src/bridge/secrets/`` -- which is what ``PULUMI_WATCHED_PATHS`` used to do --
+means editing one application's secret file re-triggers *every* Pulumi pipeline
+in both Concourse instances.  This module narrows that: a pipeline watches only
+the secrets directories whose contents its own Pulumi project decrypts.
+
+The mapping keys are Pulumi project paths relative to ``src/ol_infrastructure/``
+(the same value pipelines pass as ``pulumi_project_path`` /
+``project_source_path``).  Values are entries under ``src/bridge/secrets/`` --
+either a directory name or a bare file name.
+
+The mapping is derived from static analysis of ``read_yaml_secrets`` /
+``read_json_secrets`` / ``set_env_secrets`` calls, following imports so that
+secrets read through shared modules (``lib/fastly.py``, ``lib/heroku.py``,
+``lib/consul.py``, ``substructure/aws/eks/grafana.py``, ...) are attributed to
+every project that imports them.  ``tests/test_secrets_map.py`` re-runs that
+analysis and fails if the two ever disagree, so this file cannot silently rot.
+"""
+
+SECRETS_ROOT = "src/bridge/secrets"  # pragma: allowlist secret
+
+# Secrets that only ever supply *deploy-time provider credentials* and never end
+# up in any managed resource's inputs.  Rotating one of these changes how Pulumi
+# authenticates on the next run; it does not change the desired state of
+# anything, so it must not trigger a deploy.  ``pulumi/vault.*.yaml`` is the
+# reason this exemption exists at all -- ``lib.vault.get_vault_provider`` reads
+# it, and nearly every project imports ``lib.vault``, so watching it would
+# re-create the exact cascade this module exists to remove.
+#
+# Anything NOT listed here is treated as content-bearing and must be watched by
+# each project that reads it.  Note that some files are provider credentials for
+# most readers but content for one -- e.g. ``fastly.yaml`` is provider auth via
+# ``lib/fastly.py`` but ``infrastructure/vector_log_proxy`` writes its
+# ``global_read_api_key`` into Vault -- so those stay watched.
+# Keys are secret paths relative to ``src/bridge/secrets/`` as rendered by the
+# static analysis in ``tests/ol_concourse/test_secrets_map.py`` (``*`` stands in
+# for an f-string hole); values explain why the read is credential-only.
+DEPLOY_CREDENTIAL_SECRETS: dict[str, str] = {
+    "pulumi/vault.*.yaml": "lib.vault.get_vault_provider -- Vault provider auth",
+    "pulumi/vault.*.*.yaml": "infrastructure/vault -- Vault provider auth",
+    "pulumi/consul.*.yaml": "lib.consul.get_consul_provider -- Consul provider auth",
+    "pulumi/github_app.yaml": "lib.github_helper -- GitHub provider auth",
+    "pulumi/mongodb_atlas.yaml": "MongoDB Atlas provider public/private key pair",
+}
+
+# (project, secret) pairs where a normally credential-only secret really is
+# content for that one project, so its pipeline must still watch it.
+CONTENT_BEARING_OVERRIDES = frozenset(
+    {
+        # basic_auth_password is baked into the Consul server cloud-init userdata.
+        ("infrastructure/consul/", "pulumi/consul.*.yaml"),
+    }
+)
+
+# Reads whose directory component is computed at runtime and so cannot be
+# resolved statically.  Recording what each one actually resolves to keeps the
+# drift test meaningful instead of silently skipping the read.
+DYNAMIC_SECRET_READS: dict[str, dict[str, list[str]]] = {
+    # "<env_prefix>/secrets.<env>.yaml" for the OpenSearch OpenAI connector,
+    # which is only enabled for the mitlearn deployment group today.
+    "infrastructure/aws/opensearch/": {"*/secrets.*.yaml": ["mitlearn/"]},
+}
+
+# Pulumi project path (relative to src/ol_infrastructure/) -> secrets it reads.
+# Projects that read no secrets are present with an empty list so that the drift
+# test can tell "audited, reads nothing" apart from "never audited".
+PROJECT_SECRETS: dict[str, list[str]] = {
+    # ---- applications/ ----------------------------------------------------
+    "applications/airbyte/": ["airbyte/"],
+    "applications/b2b_partners_storage/": [],
+    "applications/celery_monitoring/": ["heroku/"],
+    "applications/clickhouse/": [],
+    "applications/codejail/": [],
+    "applications/concourse/": ["concourse/", "vector/"],
+    "applications/dagster/": [],
+    "applications/digital_credentials/": ["digital_credentials/"],
+    "applications/ecs_test/": [],
+    "applications/edx_notes/": ["edx_notes/"],
+    "applications/edxapp/": [
+        "edxapp/",
+        "fastly.yaml",
+        # mongodb_atlas.<deployment>.<env>.yaml holds the Atlas DB user
+        # passwords edxapp manages; the bare mongodb_atlas.yaml next to it is
+        # provider auth only, so it is deliberately not matched.
+        "pulumi/mongodb_atlas.*.*.yaml",
+        "vector/",
+    ],
+    "applications/fastly_redirector/": ["fastly.yaml"],
+    "applications/google_ads_optimization/": [],
+    "applications/gwarek/": [],
+    "applications/jupyterhub/": [],
+    "applications/jupyterhub_data/": ["jupyterhub_data/"],
+    "applications/keycloak/": ["keycloak/"],
+    "applications/kubewatch/": ["kubewatch/"],
+    "applications/kubewatch_webhook_handler/": ["kubewatch/"],
+    "applications/learn_ai/": [
+        "fastly.yaml",
+        "learn_ai/",
+        "mitopen/",
+        "vault/",
+        "vector/",
+    ],
+    "applications/mailgun/": [],
+    "applications/marimo_data/": [],
+    "applications/micromasters/": ["fastly.yaml", "vector/"],
+    "applications/mit_learn/": [
+        "fastly.yaml",
+        "mitlearn/",
+        "qdrant_cloud/",
+        "vector/",
+    ],
+    "applications/mit_learn_nextjs/": [],
+    "applications/mitxonline/": ["fastly.yaml", "mitxonline/"],
+    "applications/ocw_site/": ["fastly.yaml", "vector/"],
+    "applications/ocw_studio/": ["ocw_studio/"],
+    "applications/odl_video_service/": ["odl_video_service/"],
+    "applications/ol_analytics_api/": [],
+    "applications/omnigraph/": ["omnigraph/"],
+    "applications/open_discussions/": ["heroku/"],
+    "applications/open_metadata/": ["open_metadata/"],
+    "applications/opik/": [],
+    "applications/release_bot/": ["concourse/", "release_bot/"],
+    "applications/starburst/": [],
+    "applications/starrocks/": [],
+    "applications/superset/": ["superset/"],
+    "applications/tika/": ["tika/"],
+    "applications/toolhive_apps/": [],
+    "applications/toolhive_data/": [],
+    "applications/toolhive_operator/": [],
+    "applications/toolhive_swe/": [],
+    "applications/witan/": ["witan/"],
+    "applications/xpro/": ["fastly.yaml", "vector/", "xpro/"],
+    "applications/xqueue/": [],
+    "applications/xqwatcher/": [],
+    # ---- infrastructure/ --------------------------------------------------
+    "infrastructure/aws/data_warehouse/": [],
+    "infrastructure/aws/dns/": [],
+    "infrastructure/aws/ecr/": [],
+    "infrastructure/aws/eks/": ["fastly.yaml"],
+    "infrastructure/aws/iam/": [],
+    "infrastructure/aws/kms/": [],
+    "infrastructure/aws/network/": [],
+    # opensearch also reads "<env_prefix>/secrets.<env>.yaml" for the OpenAI
+    # connector; today the only env_prefix that enables it is mitlearn.
+    "infrastructure/aws/opensearch/": ["mitlearn/", "opensearch/"],
+    "infrastructure/aws/policies/": [],
+    "infrastructure/aws/private_ca/": [],
+    "infrastructure/aws/s3_sites/": [],
+    "infrastructure/aws/sftp_servers/": [],
+    # consul.<env>.yaml's basic_auth_password is baked into the server cloud-init
+    # userdata, so it is content-bearing here (unlike the provider-auth reads in
+    # substructure/consul and applications/concourse via lib.consul).
+    "infrastructure/consul/": ["pulumi/consul.*.yaml", "vector/"],
+    "infrastructure/grafana_alerting/": ["grafana_cloud/"],
+    "infrastructure/grafana_cloud/": [],
+    "infrastructure/mongodb_atlas/": [],
+    "infrastructure/monitoring/": [],
+    "infrastructure/qdrant_cloud/": ["qdrant_cloud/"],
+    "infrastructure/sentry/": ["sentry/"],
+    "infrastructure/vault/": ["vector/"],
+    "infrastructure/vector_log_proxy/": ["fastly.yaml", "vector/"],
+    # ---- saas/ ------------------------------------------------------------
+    "saas/rootly/": ["rootly/"],
+    # ---- substructure/ ----------------------------------------------------
+    "substructure/aws/eks/": ["alloy/"],
+    "substructure/consul/": [],
+    "substructure/keycloak/": [],
+    "substructure/open_metadata/": [],
+    "substructure/starrocks/": [],
+    "substructure/vault/auth/": [],
+    "substructure/vault/encryption_mounts/": [],
+    "substructure/vault/pki/": [],
+    "substructure/vault/secrets/": ["alloy/", "mitopen/", "vault/"],
+    "substructure/vault/setup/": [],
+    "substructure/vault/static_mounts/": [],
+    "substructure/xpro_partner_dns/": [],
+}
+
+
+def secrets_paths(*entries: str) -> list[str]:
+    """Return ``src/bridge/secrets`` watched-path entries for ``entries``.
+
+    :param entries: Directory names (``"edxapp/"``) or bare file names
+        (``"fastly.yaml"``) beneath ``src/bridge/secrets/``.
+    :returns: Full repo-relative paths suitable for a git resource's ``paths``.
+    """
+    return [f"{SECRETS_ROOT}/{entry}" for entry in entries]
+
+
+def project_secrets_paths(project_path: str) -> list[str]:
+    """Return the watched secrets paths for a Pulumi project.
+
+    :param project_path: Project path relative to ``src/ol_infrastructure/``,
+        e.g. ``"applications/edxapp/"``.  A missing trailing slash is tolerated.
+    :returns: Repo-relative paths under ``src/bridge/secrets/``.  Empty for
+        projects that read no secrets.
+    :raises KeyError: If the project has never been audited -- add it to
+        :data:`PROJECT_SECRETS` (an empty list is a valid answer).
+    """
+    key = project_path if project_path.endswith("/") else f"{project_path}/"
+    try:
+        entries = PROJECT_SECRETS[key]
+    except KeyError:
+        msg = (
+            f"Pulumi project {key!r} is missing from PROJECT_SECRETS in "
+            "src/ol_concourse/pipelines/secrets_map.py. Add it (an empty list "
+            "is correct for projects that read no SOPS secrets) so its pipeline "
+            "watches the right secrets."
+        )
+        raise KeyError(msg) from None
+    return secrets_paths(*entries)
+
+
+def combined_secrets_paths(*project_paths: str) -> list[str]:
+    """Return the deduplicated union of several projects' watched secrets paths.
+
+    Use this when one git resource feeds Pulumi jobs for more than one project
+    (e.g. the Vault pipeline's substructure resource, which drives every
+    ``substructure/vault/*`` project from a single checkout).
+
+    :param project_paths: Project paths relative to ``src/ol_infrastructure/``.
+    :returns: Sorted, deduplicated repo-relative paths under
+        ``src/bridge/secrets/``.
+    """
+    return sorted({p for path in project_paths for p in project_secrets_paths(path)})

--- a/tests/ol_concourse/__init__.py
+++ b/tests/ol_concourse/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Concourse pipeline generators in ``src/ol_concourse``."""

--- a/tests/ol_concourse/test_secrets_map.py
+++ b/tests/ol_concourse/test_secrets_map.py
@@ -1,0 +1,246 @@
+"""Guard `ol_concourse.pipelines.secrets_map` against drift.
+
+The registry decides which Concourse pipelines re-trigger when a SOPS secret
+changes.  If a Pulumi project starts reading a new secret and nobody updates the
+registry, that project's pipeline silently stops noticing the change -- a much
+worse failure than the over-triggering the registry exists to fix.  These tests
+re-derive the truth from the source tree and compare.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from ol_concourse.pipelines.secrets_map import (
+    CONTENT_BEARING_OVERRIDES,
+    DEPLOY_CREDENTIAL_SECRETS,
+    DYNAMIC_SECRET_READS,
+    PROJECT_SECRETS,
+    SECRETS_ROOT,
+    project_secrets_paths,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC = REPO_ROOT / "src"
+PULUMI_SRC = SRC / "ol_infrastructure"
+SECRET_READERS = frozenset(
+    {"read_yaml_secrets", "read_json_secrets", "set_env_secrets"}
+)
+
+
+def _module_file(module: str) -> Path | None:
+    """Resolve a dotted module name to a file under ``src/``, if it is local."""
+    candidate = SRC / (module.replace(".", "/") + ".py")
+    if candidate.exists():
+        return candidate
+    package = SRC / module.replace(".", "/") / "__init__.py"
+    return package if package.exists() else None
+
+
+def _as_path_string(node: ast.AST) -> str | None:
+    """Render a ``Path(...)``-ish expression, with f-string holes as ``*``."""
+    if isinstance(node, ast.Constant):
+        return str(node.value)
+    if isinstance(node, ast.JoinedStr):
+        return "".join(
+            str(part.value) if isinstance(part, ast.Constant) else "*"
+            for part in node.values
+        )
+    if isinstance(node, ast.Call):
+        parts = [_as_path_string(arg) for arg in node.args]
+        return None if any(part is None for part in parts) else "/".join(parts)  # type: ignore[arg-type]
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+        left, right = _as_path_string(node.left), _as_path_string(node.right)
+        return f"{left}/{right}" if left and right else right
+    return None
+
+
+def _path_valued_assignments(tree: ast.Module) -> dict[str, str]:
+    """Map module-level names to the path expression they were assigned."""
+    assigned: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+        ):
+            rendered = _as_path_string(node.value)
+            if rendered:
+                assigned[node.targets[0].id] = rendered
+    return assigned
+
+
+def _imported_module_files(node: ast.AST) -> set[Path]:
+    """Resolve an import node to the local files under ``src/`` it pulls in."""
+    if isinstance(node, ast.ImportFrom) and node.module:
+        candidates = (
+            node.module,
+            *(f"{node.module}.{alias.name}" for alias in node.names),
+        )
+    elif isinstance(node, ast.Import):
+        candidates = tuple(alias.name for alias in node.names)
+    else:
+        return set()
+    return {
+        resolved
+        for resolved in (_module_file(candidate) for candidate in candidates)
+        if resolved
+    }
+
+
+def _analyze(path: Path) -> tuple[set[str], set[Path]]:
+    """Return (secret paths read directly by ``path``, local modules it imports)."""
+    tree = ast.parse(path.read_text())
+    local_paths = _path_valued_assignments(tree)
+
+    secrets: set[str] = set()
+    imports: set[Path] = set()
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in SECRET_READERS
+            and node.args
+        ):
+            arg = node.args[0]
+            rendered = _as_path_string(arg)
+            if rendered is None and isinstance(arg, ast.Name):
+                rendered = local_paths.get(arg.id)
+            if rendered:
+                secrets.add(rendered)
+        else:
+            imports |= _imported_module_files(node)
+    return secrets, imports
+
+
+_ANALYSIS_CACHE: dict[Path, tuple[set[str], set[Path]]] = {}
+
+
+def _cached_analyze(path: Path) -> tuple[set[str], set[Path]]:
+    """Memoized :func:`_analyze`, tolerating files this Python cannot parse."""
+    if path not in _ANALYSIS_CACHE:
+        try:
+            _ANALYSIS_CACHE[path] = _analyze(path)
+        except SyntaxError:
+            _ANALYSIS_CACHE[path] = (set(), set())
+    return _ANALYSIS_CACHE[path]
+
+
+def _transitive_secrets(path: Path, seen: set[Path] | None = None) -> set[str]:
+    """Collect the secrets read by ``path`` or by anything it imports."""
+    seen = seen if seen is not None else set()
+    if path in seen:
+        return set()
+    seen.add(path)
+    direct, imports = _cached_analyze(path)
+    return direct.union(*(_transitive_secrets(i, seen) for i in imports), set())
+
+
+def _actual_secrets(project: Path) -> set[str]:
+    """Collect every secret read anywhere under a Pulumi project directory."""
+    return set().union(*(_transitive_secrets(f) for f in project.rglob("*.py")), set())
+
+
+def _pulumi_projects() -> list[str]:
+    """List every Pulumi project path, relative to ``src/ol_infrastructure/``."""
+    return sorted(
+        str(p.parent.relative_to(PULUMI_SRC)) + "/"
+        for p in PULUMI_SRC.rglob("Pulumi.yaml")
+    )
+
+
+def _covers(watched: set[str], secret: str) -> bool:
+    """Report whether any watched entry covers ``secret`` (relative to SECRETS_ROOT)."""
+    head = secret.split("/", 1)[0]
+    for entry in watched:
+        rel = entry[len(SECRETS_ROOT) + 1 :]
+        if rel.endswith("/"):
+            if secret.startswith(rel):
+                return True
+        elif "/" in rel:
+            # Glob within a directory, e.g. "pulumi/mongodb_atlas.*.*.yaml".
+            entry_dir, entry_glob = rel.split("/", 1)
+            secret_dir, _, secret_file = secret.partition("/")
+            if entry_dir == secret_dir and _glob_match(entry_glob, secret_file):
+                return True
+        elif rel == head:
+            return True
+    return False
+
+
+def _glob_match(pattern: str, value: str) -> bool:
+    """Match ``*``-separated segments, treating ``*`` as "one path-free chunk"."""
+    parts = pattern.split("*")
+    if not value.startswith(parts[0]):
+        return False
+    cursor = len(parts[0])
+    for part in parts[1:-1]:
+        found = value.find(part, cursor)
+        if found == -1:
+            return False
+        cursor = found + len(part)
+    return value.endswith(parts[-1]) and cursor <= len(value) - len(parts[-1])
+
+
+@pytest.mark.parametrize("project", _pulumi_projects())
+def test_every_pulumi_project_is_registered(project: str) -> None:
+    """Every Pulumi project on disk has an audited PROJECT_SECRETS entry."""
+    assert project in PROJECT_SECRETS, (
+        f"Pulumi project {project!r} has no entry in PROJECT_SECRETS. Add one "
+        "(an empty list is correct if it reads no SOPS secrets), otherwise its "
+        "pipeline will not re-trigger when its secrets change."
+    )
+
+
+def _expected_secrets(project: str) -> set[str]:
+    """Derive the secrets ``project``'s pipeline must watch, after exemptions."""
+    dynamic = DYNAMIC_SECRET_READS.get(project, {})
+    expected: set[str] = set()
+    for secret in _actual_secrets(PULUMI_SRC / project):
+        if secret in dynamic:
+            expected.update(dynamic[secret])
+        elif (
+            secret in DEPLOY_CREDENTIAL_SECRETS
+            and (project, secret) not in CONTENT_BEARING_OVERRIDES
+        ):
+            continue
+        else:
+            expected.add(secret)
+    return expected
+
+
+@pytest.mark.parametrize("project", _pulumi_projects())
+def test_registry_covers_every_secret_the_project_reads(project: str) -> None:
+    """A project's pipeline watches every content-bearing secret it decrypts."""
+    watched = set(project_secrets_paths(project))
+    missing = sorted(
+        secret for secret in _expected_secrets(project) if not _covers(watched, secret)
+    )
+    assert not missing, (
+        f"{project} reads {missing} but its pipeline does not watch them. Add "
+        "the entries to PROJECT_SECRETS in "
+        "src/ol_concourse/pipelines/secrets_map.py (or, if the secret is only "
+        "ever provider auth, to DEPLOY_CREDENTIAL_SECRETS with a rationale)."
+    )
+
+
+def test_registry_has_no_stale_projects() -> None:
+    """PROJECT_SECRETS does not list Pulumi projects that no longer exist."""
+    stale = sorted(set(PROJECT_SECRETS) - set(_pulumi_projects()))
+    assert not stale, (
+        f"PROJECT_SECRETS lists projects that no longer exist: {stale}. Remove "
+        "them so the registry keeps matching the tree."
+    )
+
+
+def test_registry_entries_exist_on_disk() -> None:
+    """Every non-glob PROJECT_SECRETS entry points at a real secrets path."""
+    secrets_root = REPO_ROOT / SECRETS_ROOT
+    missing = sorted(
+        f"{project} -> {entry}"
+        for project, entries in PROJECT_SECRETS.items()
+        for entry in entries
+        if "*" not in entry and not (secrets_root / entry).exists()
+    )
+    assert not missing, f"PROJECT_SECRETS points at nonexistent paths: {missing}"

--- a/tests/ol_concourse/test_secrets_map.py
+++ b/tests/ol_concourse/test_secrets_map.py
@@ -8,6 +8,7 @@ re-derive the truth from the source tree and compare.
 """
 
 import ast
+from collections import defaultdict
 from pathlib import Path
 
 import pytest
@@ -56,9 +57,20 @@ def _as_path_string(node: ast.AST) -> str | None:
     return None
 
 
-def _path_valued_assignments(tree: ast.Module) -> dict[str, str]:
-    """Map module-level names to the path expression they were assigned."""
-    assigned: dict[str, str] = {}
+def _path_valued_names(tree: ast.Module) -> dict[str, set[str]]:
+    """Map each assigned name to every path expression bound to it anywhere.
+
+    Deliberately walks the whole tree rather than just the module body: a
+    project is free to build a secrets path inside a function, and missing that
+    read would be a false negative -- the direction that actually hurts, since
+    it would let a pipeline stop watching a secret it decrypts.
+
+    For the same reason a name that is assigned more than once (in different
+    scopes, or reassigned) keeps *all* of its renderings rather than whichever
+    the walk happened to reach last. Over-approximating asks the registry to
+    watch a bit too much; guessing wrong could ask it to watch too little.
+    """
+    assigned: dict[str, set[str]] = defaultdict(set)
     for node in ast.walk(tree):
         if (
             isinstance(node, ast.Assign)
@@ -67,7 +79,7 @@ def _path_valued_assignments(tree: ast.Module) -> dict[str, str]:
         ):
             rendered = _as_path_string(node.value)
             if rendered:
-                assigned[node.targets[0].id] = rendered
+                assigned[node.targets[0].id].add(rendered)
     return assigned
 
 
@@ -92,7 +104,7 @@ def _imported_module_files(node: ast.AST) -> set[Path]:
 def _analyze(path: Path) -> tuple[set[str], set[Path]]:
     """Return (secret paths read directly by ``path``, local modules it imports)."""
     tree = ast.parse(path.read_text())
-    local_paths = _path_valued_assignments(tree)
+    name_paths = _path_valued_names(tree)
 
     secrets: set[str] = set()
     imports: set[Path] = set()
@@ -105,10 +117,10 @@ def _analyze(path: Path) -> tuple[set[str], set[Path]]:
         ):
             arg = node.args[0]
             rendered = _as_path_string(arg)
-            if rendered is None and isinstance(arg, ast.Name):
-                rendered = local_paths.get(arg.id)
             if rendered:
                 secrets.add(rendered)
+            elif isinstance(arg, ast.Name):
+                secrets |= name_paths.get(arg.id, set())
         else:
             imports |= _imported_module_files(node)
     return secrets, imports


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

A change to **any** file under `src/bridge/secrets/` currently re-triggers **every** Pulumi pipeline in both Concourse instances. This scopes each pipeline to the secrets its own Pulumi project actually decrypts.

**Root cause:** `src/ol_concourse/pipelines/constants.py` had `"src/bridge/secrets/"` in `PULUMI_WATCHED_PATHS`, and all 21 pipeline generators splat that list into their git resource `paths`. The per-app `additional_watched_paths=["src/bridge/secrets/<app>/"]` entries that already existed (airbyte, digital_credentials, jupyterhub_data, open_metadata, qdrant_cloud, sentry, release_bot, superset, concourse, edx_notes, edxapp) were no-ops — the broad path already matched everything they listed.

**How the mapping was derived:** static AST analysis of every `read_yaml_secrets` / `read_json_secrets` / `set_env_secrets` call under `src/`, following imports so that secrets reached through shared modules (`lib/fastly.py`, `lib/vault.py`, `lib/consul.py`, `lib/heroku.py`, `lib/github_helper.py`, `substructure/aws/eks/grafana.py`) are attributed to every project that imports them. All 79 Pulumi projects are covered; projects that read nothing are recorded with an empty list so "audited, reads nothing" is distinguishable from "never audited".

**Result** — reverse index of the new registry. Most secrets now reach one or two projects instead of all of them:

| Secret | Consuming projects |
| --- | --- |
| `fastly.yaml` | 10 |
| `vector/` | 10 |
| `alloy/`, `concourse/`, `heroku/`, `kubewatch/`, `mitlearn/`, `mitopen/`, `qdrant_cloud/`, `vault/` | 2 each |
| the remaining 25 (`edxapp/`, `keycloak/`, `superset/`, `witan/`, `omnigraph/`, `tika/`, …) | 1 each |

**Files:**

- `src/ol_concourse/pipelines/secrets_map.py` (new) — `PROJECT_SECRETS` registry plus `project_secrets_paths()` / `combined_secrets_paths()` helpers.
- `src/ol_concourse/pipelines/constants.py` — drops `src/bridge/secrets/` from `PULUMI_WATCHED_PATHS`, keeps `sops.py` and `__init__.py` (the decryption machinery every project does run).
- 19 pipeline generators — call `project_secrets_paths(<project path>)` instead of inheriting the blanket path; redundant `src/bridge/secrets/...` and `src/bridge/lib/versions.py` entries removed from `additional_watched_paths`.
- `tests/ol_concourse/test_secrets_map.py` (new) — drift guard, 164 cases.

### How can this be tested?

Locally, from the repo root:

```
uv run pytest tests/ol_concourse/ -q     # 164 passed
uv run pre-commit run --all-files        # ruff format, ruff check, mypy, detect-secrets
```

Every pipeline generator was rendered to confirm its resulting `paths` list, e.g.:

```
simple_pulumi[airbyte]        ol-infrastructure-pulumi-airbyte    ['src/bridge/secrets/airbyte/']
simple_pulumi[mongodb-atlas]  ol-infrastructure-pulumi-mongodb-atlas  []
k8s_apps[mit-learn]           ol-infra-mit-learn                  ['src/bridge/secrets/fastly.yaml',
                                                                   'src/bridge/secrets/mitlearn/',
                                                                   'src/bridge/secrets/qdrant_cloud/',
                                                                   'src/bridge/secrets/vector/']
vault.vault_pipeline          ol-infrastructure-pulumi-substructure  ['src/bridge/secrets/alloy/',
                                                                     'src/bridge/secrets/mitopen/',
                                                                     'src/bridge/secrets/vault/']
```

To validate after merge: touch a single-consumer secret (e.g. `src/bridge/secrets/tika/`) and confirm only `pulumi-tika` picks up a new version of its `ol-infrastructure-pulumi-tika` resource, rather than the whole fleet.

Note that the meta pipeline must re-run `set_pipeline` for each affected pipeline before the narrowed `paths` take effect in Concourse.

### Additional Context

Three things reviewers should weigh in on:

**1. `pulumi/vault.*.yaml` is deliberately watched by nothing.** `lib.vault.get_vault_provider` reads it and nearly every project imports `lib.vault`, so watching it would recreate the exact cascade this PR removes. It supplies only deploy-time Vault provider auth and never reaches a managed resource's inputs, so rotating it does not change any desired state — the next natural deploy picks up the new credentials. The same reasoning applies to `pulumi/github_app.yaml`, the bare `pulumi/mongodb_atlas.yaml` (Atlas provider public/private key pair), and `pulumi/consul.*.yaml`. These live in `DEPLOY_CREDENTIAL_SECRETS` with a per-entry rationale string.

`infrastructure/consul` is exempted back via `CONTENT_BEARING_OVERRIDES`, because its `basic_auth_password` is baked into the Consul server cloud-init userdata. Likewise `edxapp` still watches `pulumi/mongodb_atlas.*.*.yaml` (Atlas DB user passwords) while ignoring the bare provider-key file next to it, and `infrastructure/vector_log_proxy` still watches `fastly.yaml` because it writes `global_read_api_key` into Vault rather than only using it for provider auth.

**2. Behaviour change: `open-metadata-substructure` no longer watches `src/bridge/secrets/open_metadata/`.** `substructure/open_metadata` reads no SOPS secrets — connector credentials reach it as `secretKeyRef` env vars from K8s secrets that the `applications/open_metadata` stack manages, and the connector list is hardcoded in the substructure code. So a connector credential change should only need the applications stack to rerun. Worth a second opinion if you think adding a *new* connector needs the substructure stack triggered too.

**3. Pre-existing typo fixed.** `src/ol_concourse/pipelines/infrastructure/aws/pipeline.py` watched `src/ol_infrastructure/infrastructurre/aws/{service}` (double `r`), which matched nothing — so the `pulumi-aws` dns / policies / iam job chains never self-triggered on changes to their own Pulumi code. Fixed here since the same line was being edited. **Expect those three to start triggering on code changes to `infrastructure/aws/{dns,policies,iam}/` after this merges.**

**Under-triggering is the dangerous direction**, so the registry is tested rather than trusted. `tests/ol_concourse/test_secrets_map.py` re-runs the static analysis against the source tree and fails if:

- a Pulumi project reads a content-bearing secret its pipeline does not watch,
- a Pulumi project on disk is missing from `PROJECT_SECRETS`,
- `PROJECT_SECRETS` lists a project that no longer exists, or
- a non-glob registry entry points at a path that is not on disk.

Statically unresolvable reads are handled explicitly rather than skipped: `infrastructure/aws/opensearch` reads `"<env_prefix>/secrets.<env>.yaml"` for the OpenAI connector, recorded in `DYNAMIC_SECRET_READS` as resolving to `mitlearn/` (the only deployment group that enables it today).

**Two findings not addressed here:**

- `src/ol_concourse/pipelines/open_edx/edx_platform_v3/pipeline.py` line 50 iterates an undefined `releases` (the parameter is `release_names`, and is even marked `# noqa: ARG001` as unused). `build_edx_pipeline` raises `NameError` and cannot generate at all today. Left alone — out of scope, and fixing it changes which pipelines get produced.
- No Pulumi project reads `src/bridge/secrets/botkube/`, `starburst/`, `unified_ecommerce/`, `xqwatcher/`, or `pulumi/mongodb_atlas.env`. (`consul/consul.env` is genuinely used, but by `src/bilder` packer builds rather than Pulumi.) Deletion candidates for a follow-up; nothing removed here.
