### PR TITLE
fix(local-dev): make kc-seed-users.sh compatible with bash 3.2

### DIFF
--- a/local-dev/scripts/kc-seed-users.sh
+++ b/local-dev/scripts/kc-seed-users.sh
@@ -92,16 +92,31 @@ ensure_admin_role
 
 # ---------------------------------------------------------------------------
 # User definitions: (username, email, firstName, lastName, assign_admin_role)
+#
+# Plain case statements instead of associative arrays: declare -A requires
+# bash 4+, but macOS ships bash 3.2 (GPLv3 licensing) as the only /bin/bash on
+# PATH, where declare -A silently misparses and fails with a confusing
+# "unbound variable" error under set -u.
 # ---------------------------------------------------------------------------
-declare -A USER_EMAILS=( [admin]="admin@odl.local" [student]="student@odl.local" [prof]="prof@odl.local" )
-declare -A USER_FIRST=( [admin]="Admin" [student]="Student" [prof]="Professor" )
-declare -A USER_LAST=( [admin]="User" [student]="User" [prof]="User" )
-ADMIN_USERS=("admin")
+user_email() {
+    case "$1" in
+        admin) echo "admin@odl.local" ;;
+        student) echo "student@odl.local" ;;
+        prof) echo "prof@odl.local" ;;
+    esac
+}
+user_first() {
+    case "$1" in
+        admin) echo "Admin" ;;
+        student) echo "Student" ;;
+        prof) echo "Professor" ;;
+    esac
+}
 
 for USERNAME in admin student prof; do
-    EMAIL="${USER_EMAILS[$USERNAME]}"
-    FIRST="${USER_FIRST[$USERNAME]}"
-    LAST="${USER_LAST[$USERNAME]}"
+    EMAIL="$(user_email "$USERNAME")"
+    FIRST="$(user_first "$USERNAME")"
+    LAST="User"
 
     # Check if user already exists. Look up by email, not username: the realm
     # has registrationEmailAsUsername=true, so Keycloak stores the username as
@@ -146,21 +161,19 @@ for USERNAME in admin student prof; do
         | jq -r '.[0].id // empty' 2>/dev/null || true)
 
     # Assign the admin realm role if applicable.
-    for admin_user in "${ADMIN_USERS[@]}"; do
-        if [ "$admin_user" = "$USERNAME" ] && [ -n "$NEW_ID" ]; then
-            echo "[kc-seed-users] Assigning 'admin' realm role to ${USERNAME} ..."
-            ROLE_JSON=$(curl -sf --cacert "${KC_CACERT}" --max-time 10 \
-                -H "Authorization: Bearer ${TOKEN}" \
-                "${KC_URL}/admin/realms/${REALM}/roles/admin" 2>/dev/null || true)
-            curl -sf --cacert "${KC_CACERT}" --max-time 10 \
-                -X POST \
-                -H "Authorization: Bearer ${TOKEN}" \
-                -H "Content-Type: application/json" \
-                "${KC_URL}/admin/realms/${REALM}/users/${NEW_ID}/role-mappings/realm" \
-                -d "[${ROLE_JSON}]" \
-                -o /dev/null
-        fi
-    done
+    if [ "$USERNAME" = "admin" ] && [ -n "$NEW_ID" ]; then
+        echo "[kc-seed-users] Assigning 'admin' realm role to ${USERNAME} ..."
+        ROLE_JSON=$(curl -sf --cacert "${KC_CACERT}" --max-time 10 \
+            -H "Authorization: Bearer ${TOKEN}" \
+            "${KC_URL}/admin/realms/${REALM}/roles/admin" 2>/dev/null || true)
+        curl -sf --cacert "${KC_CACERT}" --max-time 10 \
+            -X POST \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Content-Type: application/json" \
+            "${KC_URL}/admin/realms/${REALM}/users/${NEW_ID}/role-mappings/realm" \
+            -d "[${ROLE_JSON}]" \
+            -o /dev/null
+    fi
 done
 
 echo "[kc-seed-users] Done."

--- a/local-dev/scripts/kc-seed-users.sh
+++ b/local-dev/scripts/kc-seed-users.sh
@@ -93,10 +93,10 @@ ensure_admin_role
 # ---------------------------------------------------------------------------
 # User definitions: (username, email, firstName, lastName, assign_admin_role)
 #
-# Plain case statements instead of associative arrays: declare -A requires
-# bash 4+, but macOS ships bash 3.2 (GPLv3 licensing) as the only /bin/bash on
-# PATH, where declare -A silently misparses and fails with a confusing
-# "unbound variable" error under set -u.
+# Plain case statements instead of associative arrays: `declare -A` requires
+# bash 4+, but macOS ships bash 3.2 as /bin/bash (Apple hasn't updated it
+# since bash moved to GPLv3 licensing). Under bash 3.2, `declare -A` silently
+# misparses and fails with a confusing "unbound variable" error under set -u.
 # ---------------------------------------------------------------------------
 user_email() {
     case "$1" in


### PR DESCRIPTION
### What are the relevant tickets?
Closes #5275

### Description (What does it do?)
Fixes `kc-seed-users.sh` to work on bash 3.2, which is the only `/bin/bash` macOS ships (Apple hasn't updated it since bash moved to GPLv3 licensing).

The script previously used `declare -A` associative arrays (`USER_EMAILS`, `USER_FIRST`, `USER_LAST`) and an array-based loop (`ADMIN_USERS`) to assign the admin realm role. Both require bash 4+. Under bash 3.2 with `set -u`, `declare -A` silently misparses and fails with a confusing `line 81: admin: unbound variable` error instead of a clear syntax error — so the `kc-seed-users` Tilt resource fails on every fresh local-dev bring-up on stock macOS.

Replaces the associative-array lookups with portable `case`-statement functions (`user_email`, `user_first`) and replaces the `ADMIN_USERS` array/loop with a direct string comparison (`[ "$USERNAME" = "admin" ]`). Behavior is unchanged — same three users created, same emails, same admin role assignment, same idempotency (skips users that already exist).

### Screenshots (if appropriate):
N/A — shell script change, no UI

### How can this be tested?
Tested directly against macOS's system bash (`/bin/bash`, bash 3.2.57):
- **Before the fix**: running `local-dev/scripts/kc-seed-users.sh` fails immediately with `line 81: admin: unbound variable`.
- **After the fix**: the script runs successfully, creating (or skipping, if already present) the three local-dev test users — `admin@odl.local`, `student@odl.local`, `prof@odl.local` — in the local `olapps` Keycloak realm, and correctly assigns the `admin` realm role to the admin user.

Also validated via `pre-commit` (`shellcheck` passes cleanly on the changed file).

**For reviewers**: on a machine where `/bin/bash` is bash 3.2 (any stock macOS), run `local-dev/scripts/kc-seed-users.sh` (or trigger the `kc-seed-users` Tilt resource) against a running local-dev Keycloak instance and confirm no `unbound variable` error occurs, and that the three test users are created/verified idempotently on repeat runs.

### Additional Context
Root cause was introduced by #4750 fka commit `fef2b977f` ("auto-seed Keycloak test users and make the seed idempotent"). This affects any developer running local-dev on stock macOS, not just one machine. No intentional behavior change beyond fixing the crash.