### PR TITLE
fix(local-dev): learn-ai readiness probe + mitxonline anonymous checkout routes

### DIFF
--- a/local-dev/apps/learn-ai/deployment.yaml
+++ b/local-dev/apps/learn-ai/deployment.yaml
@@ -95,7 +95,12 @@ spec:
             memory: 2Gi
         readinessProbe:
           httpGet:
-            path: /health/
+            # learn-ai runs with SECURE_SSL_REDIRECT=True, so a plain-HTTP
+            # request from kubelet to a non-exempt path 301s to https:// and
+            # the probe fails against the HTTP-only app port. The dedicated
+            # health endpoints are in SECURE_REDIRECT_EXEMPT; the trailing
+            # slash is required to match its `^health/readiness/$` pattern.
+            path: /health/readiness/
             port: 8001
           initialDelaySeconds: 15
           periodSeconds: 10

--- a/local-dev/apps/mitxonline/apisix-routes.yaml
+++ b/local-dev/apps/mitxonline/apisix-routes.yaml
@@ -48,7 +48,8 @@ spec:
 #   passauth        : /*              (pass — injects X-Userinfo if session present)
 #   logout-redirect : /logout/oidc/* (redirect to /logout/oidc)
 #   reqauth         : /login/*, /admin/login/*, /login*, /login/oidc*
-#   cart            : /cart, /cart/, /cart/* (require authentication, priority 20)
+#   checkout-anonymous : /checkout/anonymous, /checkout/anonymous/,
+#                     /checkout/anonymous/* (require authentication, priority 20)
 #
 # No explicit redirect_uri — lua-resty-openidc auto-derives it.
 # session.cookie.domain set to .mitxonline.mit.dev so the cookie is shared
@@ -158,16 +159,24 @@ spec:
           user: true
         unauth_action: auth
 
-  - name: cart
+  # Login gate for the "anonymous first" checkout flow, and the successor to the
+  # former "cart" route. /cart is now served anonymously (it falls through to
+  # passauth above, which returns the anonymous basket); the login that
+  # establishes the session — so the anonymous basket can be claimed — happens
+  # when the learner proceeds to checkout and lands here. The /* path catches
+  # this route's own OIDC callback, which lua-resty-openidc derives relative to
+  # the request path (/checkout/anonymous/.apisix/redirect); without it the
+  # callback falls through to passauth and only works by accident.
+  - name: checkout-anonymous
     priority: 20
     match:
       hosts:
       - "mitxonline.mit.dev"
       - "api.mitxonline.mit.dev"
       paths:
-      - "/cart"
-      - "/cart/"
-      - "/cart/*"
+      - "/checkout/anonymous"
+      - "/checkout/anonymous/"
+      - "/checkout/anonymous/*"
     backends:
     - serviceName: mitxonline-webapp
       servicePort: 8010


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12530 — local-dev counterpart to https://github.com/mitodl/ol-infrastructure/pull/5243 and https://github.com/mitodl/ol-infrastructure/pull/5244. The learn-ai change below has no ticket.

### Description (What does it do?)
Two unrelated local-dev fixes.

- Ports #5243 and #5244 into `local-dev/apps/mitxonline/apisix-routes.yaml`, which mirrors the direct APISIX route group in `src/ol_infrastructure/applications/mitxonline/__main__.py` and had drifted from it: renames the `cart` sub-route to `checkout-anonymous` and swaps its paths to `/checkout/anonymous`, `/checkout/anonymous/`, `/checkout/anonymous/*`, so `/cart` falls through to the pass-auth wildcard and is served anonymously.[^1]
- Points learn-ai's readiness probe at `/health/readiness/` rather than `/health/`, which is not in the app's `SECURE_REDIRECT_EXEMPT` list — kubelet's plain-HTTP probe was getting a 301 to `https://` and then failing against the HTTP-only granian port, leaving `learnai-webapp` stuck at 1/2 Ready with two competing ReplicaSets.

[^1]: The `/checkout/anonymous/*` path is #5244's contribution and worth not dropping: APISIX derives its OIDC callback relative to the request path, so the callback lands on `/checkout/anonymous/.apisix/redirect`. Without `/*` that falls through to the pass-auth route and completes there, working only because pass-auth happens to carry the same OIDC client and session config.

### How can this be tested?

Bring the stack up (`tilt up`), or apply the routes directly:

```
kubectl apply -f local-dev/apps/mitxonline/apisix-routes.yaml
```

**mitxonline routing** — all anonymous, no cookies:

```
for p in /cart/ /cart /checkout/anonymous /checkout/to_payment; do
  printf "%-22s " "$p"
  curl -sk -o /dev/null -m 12 -w 'status=%{http_code} redirect=%{redirect_url}\n' \
    "https://mitxonline.mit.dev$p"
done
```

Expected:

```
/cart/                 status=200 redirect=
/cart                  status=301 redirect=https://mitxonline.mit.dev/cart/
/checkout/anonymous    status=302 redirect=https://sso.ol.mit.dev/realms/olapps/protocol/openid-connect/auth?...&redirect_uri=https%3A%2F%2Fmitxonline.mit.dev%2Fcheckout%2Fanonymous%2F.apisix%2Fredirect&...
/checkout/to_payment   status=302 redirect=https://mitxonline.mit.dev/login/?next=/checkout/to_payment
```

The two things to look for: `/cart/` returns 200 anonymously rather than bouncing to Keycloak, and the `redirect_uri` on `/checkout/anonymous` sits under `/checkout/anonymous/` — that is the callback the `/*` path exists to catch. `/checkout/to_payment` still gates at the app layer (Django `LoginRequiredMixin`), unchanged.

Confirm the live route group matches production's four sub-routes:

```
kubectl get apisixroute -n mitxonline mitxonline-route \
  -o jsonpath='{range .spec.http[*]}{.name}{" "}{.priority}{" "}{.match.paths}{"\n"}{end}'
```

```
passauth 0 ["/*"]
logout-redirect 10 ["/logout/oidc/*"]
reqauth 10 ["/login/*","/admin/login/*","/login*","/login/oidc*"]
checkout-anonymous 20 ["/checkout/anonymous","/checkout/anonymous/","/checkout/anonymous/*"]
```

A full browser checkout additionally needs the app-side anonymous-basket support from mitxonline#12530 (`ecommerce/urls.py` routing `^checkout/anonymous/?$` to `AnonymousCheckoutView`); the route change alone is testable with the curls above.

**learn-ai readiness** — `learnai-webapp` should reach `2/2` Ready:

```
kubectl get pods -n learn-ai -l app=learnai-webapp
```

The underlying behaviour, from inside the pod — the old probe path 301s to HTTPS against an HTTP-only port, the new one does not:

```
kubectl exec -n learn-ai deploy/learnai-webapp -c nginx -- \
  wget -S -qO- --timeout=8 http://127.0.0.1:8001/health/
# HTTP/1.1 301 Moved Permanently
# location: https://127.0.0.1:8001/health/
# ...SSL routines:wrong version number

kubectl exec -n learn-ai deploy/learnai-webapp -c nginx -- \
  wget -S -qO- --timeout=8 http://127.0.0.1:8001/health/readiness/
# HTTP/1.1 200 OK
```

Note the trailing slash is required — the exempt pattern is `^health/readiness/$`.

### Additional Context

`mit-learn` also probes `/health/` but is unaffected, since it runs with `SECURE_SSL_REDIRECT=False`.

One divergence I noticed but did not touch: local-dev's `mitxonline-learn-proxy-route` has only a `passauth` `/mitxonline/*` sub-route, while production's prefixed group also carries `logout-redirect` and `reqauth`. That may be a deliberate local-dev simplification — happy to follow up if not.
