### PR TITLE
feat(omnigraph): provision svc-witan-admin in CI, QA and Production

### DIFF
--- a/src/bridge/secrets/omnigraph/secrets.ci.yaml
+++ b/src/bridge/secrets/omnigraph/secrets.ci.yaml
@@ -2,6 +2,8 @@
 ci_token: ENC[AES256_GCM,data:2yBmqrgx5BXoUFjJsUAkENS+HyZaqkoXa3PtQC5UxpzG7WvwFwqIgWKj1g==,iv:CaLOO2Vy2lKjArBhpBF32h4CnydWAeGdsjfOCc/NqE4=,tag:9224Sg5loyqbtKMMeIOTrg==,type:str]
 actor_tokens:
   svc-witan-ci: ENC[AES256_GCM,data:CMzi/oQyJeo3arQTW1s672sT4D9Z2WxrecgcA4iqtp2oowQJyYXvX6S4tQ==,iv:0O96buddDaCBLXcu6byIa9SCu8rbwxr1oD7vdmMgb3A=,tag:qfp2dtwcY0mMMzq9xFN+bg==,type:str]
+  svc-witan-admin: ENC[AES256_GCM,data:X/yCkaYLbXN+xjdHCVciroaw/JaiacYmavkfrs8RIs17YBqKQA6rHY6Q2nmrMrpdU00S511A8l4IWqsZ/eckkw==,iv:t/4X/BfIqlaQb8vTPJ4M2ZKsRDUDkXu0U0tXMQHhyjI=,tag:cGdRAoadO4EuVh9Txba4Ug==,type:str]
+admin_token: ENC[AES256_GCM,data:fVOmTm5sl8WOlGdtod2xoy+I8fEGnXAX7dT8460+JVptPksbU/2RUkXsXJyXpow684FgmlhJJLPjPNoPjkSLVg==,iv:mhstfHfMdG+Q1IXvsrreeWTF02TvBdb2kazrLpg999M=,tag:0qUqneziLI9XJOqqvuESIQ==,type:str]
 sops:
   hc_vault:
   - created_at: "2026-07-31T15:22:32Z"
@@ -14,7 +16,7 @@ sops:
     aws_profile: ""
     created_at: "2026-07-31T15:22:32Z"
     enc: AQICAHhMkpkBpCvmFjhyfy75ENALRrbg42uOs9cUsFNLXqPnagGvNoe+jzxsGO4erFHPzX/5AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMmTMEt3pPuQmKDQEkAgEQgDv9R2nQjDrc4iEMfENvbSK+VTnskrdnUfEZShH2NlKeampTSG/Rg8PfNXtWdMGOgG+n0euyemB2fuiXSQ==
-  lastmodified: "2026-07-31T15:22:32Z"
-  mac: ENC[AES256_GCM,data:BZl9pzuzKd1Y1xbghFXHU9poO0IHgYdEE4+ks6t5fGmY1kZShBI9Raley8iGzxiZiY8MZARk3Zc0AtGkR9g/rKahgNE4qdq9jcDRBQPrVHvfsn+vgcBBb2hQ9DysyUNkO7ydUH/GwiFnO9Vy2HI9QMWo5a7YuBghnCzOGtBgI2g=,iv:M9OFU5l6XTn4JYwxAiKJuTDB8AnoMtHigv7U9etI8Hg=,tag:mM70+2MvPoGlWAxthLALnw==,type:str]
+  lastmodified: "2026-08-05T20:47:43Z"
+  mac: ENC[AES256_GCM,data:lkEoyRjdkO9na+GygjIzt4+4JIxL2/r3+e6zHBgRXtiNV54sveSuMye6N4tNBbWPauaAb7z/VlNOYUM3alMtwhYZf0dc97h7h1n4gY5xfyTLEcawlnuNS89wsGOSLRysUAv+laDOWs/x/mysZYYHeFRnt523FeDhD7AQW97VWpg=,iv:rUEx0LIumvI7HUv6E5qkmYeUcO2cTp2aRHoLhBzN4u0=,tag:4oJCbcglyghjqaDWp9Tfow==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.13.3

--- a/src/bridge/secrets/omnigraph/secrets.production.yaml
+++ b/src/bridge/secrets/omnigraph/secrets.production.yaml
@@ -2,6 +2,8 @@
 ci_token: ENC[AES256_GCM,data:QBK1a1NSedW9E+jCGdp97KOeGRJB3RWiMNW4kMQutBU36Of4Sidq53n3lw==,iv:xFUw4mtk2aqeLKtBHqjqvJt1fNtvbi+vE6N59s+Ts0A=,tag:GNZR3MC4j1YOqTaaiTuZtA==,type:str]
 actor_tokens:
   svc-witan-ci: ENC[AES256_GCM,data:BLUr2vuEZDxHd/kFIACCbtC48FWaCKMcqGjTs8veICOw1YzVWfhiKRVThA==,iv:+sP59AytweaLC1s7ex8JEpUr6EQAfMwTdaIsE++tqZo=,tag:W8qIEtqfpl6iQU5AzcrA7Q==,type:str]
+  svc-witan-admin: ENC[AES256_GCM,data:NExzPUqTt12o6jOsA/W95cQNzYWLqiLQWBVzdcSad+YImwKSGhhC39LrXEYGxnnG5CUnivpHiSsUmMQ0QtxzmA==,iv:hg+WPZy2ndjqiM+TX1+imKZm36ggirSGU+/6wNwiA5c=,tag:wM5H9tvLvSX2y8t0+Objgw==,type:str]
+admin_token: ENC[AES256_GCM,data:1eoGX3UkU2ReNPnixUMwSw5/iZj24eIYTm2A13/A3PmSV5gC5tdV+/4CIU4YD7LLsLzrA4yRHOpadj+/QAJqPQ==,iv:93p9DORffTF3b1SiOCK48WDjNeH3Gh5K18umsRWRj3E=,tag:KuyZcbKS5kP9RvFU2ki0CQ==,type:str]
 sops:
   hc_vault:
   - created_at: "2026-07-31T15:21:56Z"
@@ -14,7 +16,7 @@ sops:
     aws_profile: ""
     created_at: "2026-07-31T15:21:56Z"
     enc: AQICAHjksIVfl1VtAHpBda/1YYjj6tSeS2o4TXgvEEyBIXLjjwGGmI6uTLc+d4E49Qm7p2a9AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMJtOzE5pKoHw7VbZnAgEQgDsU9THs15uO2iIzFmkI/J1k8SJciKbDffrObKc1VZZrr3BOsq2k7TvWBBrBhcBBNts5fm5Ay+JnL2M2Kw==
-  lastmodified: "2026-07-31T15:21:56Z"
-  mac: ENC[AES256_GCM,data:HI88C+/Wvaj0dG5i0J3Rj7QPArgp7FdAcTp7MRWPE+i5jmplIge7vPus904IeUP3ARWyktipthaK+LHTWNSRZgZM5cdv6b3N5tS8tjmyzBsv0USTAvYqcn53ZeDXDbo5v9ZRfAdSpnkB8AvOMyujcMK9LGlPqcaSA27FUWyJ+fA=,iv:29r2ypYbkJTC+dHJ66HO2m48EJYTQHbyzsl7V95u6/o=,tag:Dj4LDTLSbnj5pVEb3zOcIA==,type:str]
+  lastmodified: "2026-08-05T20:48:50Z"
+  mac: ENC[AES256_GCM,data:cLrteiteVFYE8GF02LsMaEnoNGmVcSMyGF889TXTGudnn2BUrItjfRE9Ds0uI5yWAXOcYj5REZlNvI5CWRk0bRNt3NyO7hAHInsMx8da3apFiEDmhvF6HhcwJtiFSLRcYzHbiRxcVy2AS257H5GozroHT7IqLbcMOoPeKSEmWr8=,iv:jef/LFYqB/4KC0JzW5xspo/mcycyPUFadyvNK++6Ghc=,tag:uHOIWmEQk9FTvaqJJ1YlNw==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.13.3

--- a/src/bridge/secrets/omnigraph/secrets.qa.yaml
+++ b/src/bridge/secrets/omnigraph/secrets.qa.yaml
@@ -2,6 +2,8 @@
 ci_token: ENC[AES256_GCM,data:nssIKN1asjwmcMWI7Im8+zRxay4Ml+eC0fsFrtMal8Ee5sMBfkdDi4T4dA==,iv:Uxt25r+CmcQNUrW/VQ3Qz9HK7f0qwEJMul3xJ1NVqUU=,tag:6Tt4jqKw8qsz4EJz5ZM+iA==,type:str]
 actor_tokens:
   svc-witan-ci: ENC[AES256_GCM,data:PB4Q54yV5Su0oDs0g/6cj+eR4SyfZzd78qXxkCqUYtwYXs+JU9pfKJB+WQ==,iv:X0bVMjkXssWD42oIw90o2r85RgaYY1hPXqxnjwgjK7A=,tag:GTYlQvE8ZidFBCao4a2oxQ==,type:str]
+  svc-witan-admin: ENC[AES256_GCM,data:m6R/pdTucue+q4Qu932/r36i4xyZyY181UchWPA1ed6S4+c4LsvETapGaHTK7o0xdiWzr7cKELnE36YQVA+NkQ==,iv:Q5K9sms0Bti0QJvYbMSpqFiZaZaLaGoCCaHlaQPGkfE=,tag:9NDyZh2eIJZFWQDim9cbsA==,type:str]
+admin_token: ENC[AES256_GCM,data:i3D0fypcBYotem602/14ZrvGTZSOSPae9oXj9WZkk6w5/e2mW6nRXYrjh/tmO/RD0HPvO0HFeUbciSEjtq5RJQ==,iv:4aLvLlWv97k3t93T+hQZAp9XcJK/2F3tchAsZy9imz4=,tag:U3PzpvmXMjML7hC2GAYqQg==,type:str]
 sops:
   hc_vault:
   - created_at: "2026-07-31T15:22:14Z"
@@ -14,7 +16,7 @@ sops:
     aws_profile: ""
     created_at: "2026-07-31T15:22:14Z"
     enc: AQICAHjE+jMY5DL7M1LMYX6YgtMueHEDNg05lsdN5Z0zeGHyJgE8atmiP3X+tc5NqCG+VRcVAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM045vR2toFS95GGXfAgEQgDvIai57QKgeLJClef57UOUY8SleOglRWh0ZEQRjFDs9k/J1pwbjpCjeu4zuyIPRguAntbiqWlrN77vs0A==
-  lastmodified: "2026-07-31T15:22:15Z"
-  mac: ENC[AES256_GCM,data:1tfnkFrc/7HBVg0r57BxGs8Aly9smMKG4QqjblgDv+rxPTckEfieWJkYC7kDm+++Swm72/buiBXu7RVBF6knCNO2Tru1p4FTJY5JDyltsrYvaEDDjxM1KtwEYVBILn4Ng7zX5UWXhHxAlQVmOLrxnq243DN78M/QpOxnr+8tENo=,iv:d84qqIzTxAbZeGf2epr8uDfQlOO9d7XMSZkJ0i3tmOs=,tag:M9nmcpevKO9BU5Vb7JtSKA==,type:str]
+  lastmodified: "2026-08-05T20:48:39Z"
+  mac: ENC[AES256_GCM,data:dndCg2e5PGpc3qwURjZg/YkQ+3rBTervIdSfgIBAm8VrRybigE9yXW6VlQbe0zI+LOPnbJzpyzaQrNFZ7o5LKb643JhauFI1eXawp3t6Kw7Vg9Qiz5V/uiXeN3wc+eewDMXU0U3qIv9ecfJD9NZd3153e4tLBOV0+kNzNxZKTro=,iv:J7wwvuSPyECLMR4cKTW2XOReyBx4AWc5As594JNZhLo=,tag:vJ9mZEWFtR3ZWzBTFZ14kw==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.13.3


### PR DESCRIPTION
## What are the relevant tickets?

Task `tk-enable-svc-witan-admin-per-environment-mint-the--a42a0a` in the witan multi-user service deployment project. Follows #5267 (ol-infrastructure) and mitodl/agent-kit#179, which landed the code side.

## Description (What does this do?)

Turns on the `svc-witan-admin` break-glass principal, which has been dormant in every environment since the code shipped.

The stack gates the principal on the omnigraph SOPS files carrying an `admin_token`. Without it, `admin_token_provisioned` stays false, the witan stack declares no admin-token Secret and no `witan-break-glass` CronJob, and the pre-deploy migration Job authenticates as `svc-witan-ci` on the memory graph. Separating the maintenance identity from the CI indexer's is the entire point of the principal, so leaving them merged defeated it.

This mints **one distinct 32-byte token per environment** and records each as both `admin_token` and `actor_tokens['svc-witan-admin']` — separate values per environment so a leak in CI cannot reach Production.

Token sync stays **off** here (`omnigraph:keycloak_url` remains unset), so Pulumi writes `actor-tokens` directly rather than the hourly job merging it in. That is deliberate: it is the simpler of the two documented paths, and enabling sync in the same change would make any failure much harder to attribute. Enabling sync is a separate follow-up.

## How can this be tested?

`pulumi preview` was run against all three stacks. All three are identical and match the runbook exactly:

```
Outputs:
  ~ admin_token_provisioned: false => true

Resources:
    + 1 to create      # vault secret secret-operations/witan/admin-token
    ~ 5 to update      # service-tokens, actor-tokens, omnigraph-server Deployment, both maintenance CronJobs
    +-1 to replace     # omnigraph-cluster-apply Job
    7 changes. 29 unchanged
```

The stack's own invariants were also asserted directly against the decrypted files — for each environment: `admin_token` present and non-blank, equal to `actor_tokens['svc-witan-admin']`, 64 hex chars, not equal to `ci_token`, `ci_token` still equal to `actor_tokens['svc-witan-ci']`, and all three admin tokens distinct from one another. The stack refuses the deploy on any of these, so this is a pre-flight of the same conditions.

After merge, per environment (see `docs/witan-admin-break-glass-runbook.md`):

```
pulumi stack output maintenance_actor_id      # expect svc-witan-admin
kubectl -n witan get cronjob witan-break-glass  # expect SUSPEND=True
# the witan migration Job should exit 0, not 401
```

A 401 means the actor entry reached `service-tokens` but not `actor-tokens`, or the server did not restart.

## ⚠️ Deployment notes

**Each environment's deploy briefly takes the omnigraph data tier down.** omnigraph-server hashes its bearer-token map once at boot, so it must restart to see the new actor — and it is a single replica with `strategy=Recreate`. **Roll CI first, let it settle, then QA, then Production.**

Worth knowing when watching the rollout: the deployed data tier is currently in **default-deny** (bearer tokens configured, no Cedar policy bundle applied) in all three environments, so it only permits `read` today. That is tracked separately and is not affected by this change, but it means a write failing after this merge is expected and is not evidence that this PR broke something.