### PR TITLE
feat(omnigraph): enable witan actor-token sync in CI, QA and Production

### DIFF
--- a/src/ol_infrastructure/applications/omnigraph/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/applications/omnigraph/Pulumi.CI.yaml
@@ -31,6 +31,20 @@ config:
   - https://github.com/mitodl/learn-ai
   - https://github.com/mitodl/ocw-hugo-themes
   - https://github.com/mitodl/ol-django
+  # Setting this is what turns actor-token sync on: the bootstrap Job and the
+  # hourly CronJob take ownership of secret-operations/witan/actor-tokens,
+  # which Pulumi otherwise writes directly. Safe to set only because the
+  # existing actor-tokens resource already carries retainOnDelete=true (from
+  # #5253) — without that, dropping it from the program deletes the Vault path
+  # and leaves a window where no token is valid for anybody.
+  #
+  # QA and Production deliberately do NOT set this yet. Their
+  # substructure/keycloak stacks carry no witan resources, so
+  # secret-operations/witan/token-sync-oidc does not exist there and the
+  # bootstrap Job would block the deploy. Deploy that stack per environment
+  # first, then set this (note: Production is https://sso.ol.mit.edu, not
+  # sso-production — the runbook's `sso-<env>` template does not hold there).
+  omnigraph:keycloak_url: https://sso-ci.ol.mit.edu
   aws:region: us-east-1
   vault:address: https://vault-ci.odl.mit.edu
   vault_server:env_namespace: operations.ci

--- a/src/ol_infrastructure/applications/omnigraph/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/applications/omnigraph/Pulumi.CI.yaml
@@ -38,12 +38,10 @@ config:
   # #5253) — without that, dropping it from the program deletes the Vault path
   # and leaves a window where no token is valid for anybody.
   #
-  # QA and Production deliberately do NOT set this yet. Their
-  # substructure/keycloak stacks carry no witan resources, so
-  # secret-operations/witan/token-sync-oidc does not exist there and the
-  # bootstrap Job would block the deploy. Deploy that stack per environment
-  # first, then set this (note: Production is https://sso.ol.mit.edu, not
-  # sso-production — the runbook's `sso-<env>` template does not hold there).
+  # REQUIRES ol-substructure-keycloak to have been deployed to this
+  # environment first: it creates the witan-token-sync client and populates
+  # secret-operations/witan/token-sync-oidc, without which the bootstrap Job
+  # has no credential to authenticate to Keycloak with.
   omnigraph:keycloak_url: https://sso-ci.ol.mit.edu
   aws:region: us-east-1
   vault:address: https://vault-ci.odl.mit.edu

--- a/src/ol_infrastructure/applications/omnigraph/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/omnigraph/Pulumi.Production.yaml
@@ -26,6 +26,21 @@ config:
   - https://github.com/mitodl/learn-ai
   - https://github.com/mitodl/ocw-hugo-themes
   - https://github.com/mitodl/ol-django
+  # Turns actor-token sync on: the bootstrap Job and the hourly CronJob take
+  # ownership of secret-operations/witan/actor-tokens, which Pulumi otherwise
+  # writes directly. Safe only because the existing actor-tokens resource
+  # already carries retainOnDelete=true (from #5253) — without that, dropping
+  # it from the program deletes the Vault path and leaves a window where no
+  # token is valid for anybody.
+  #
+  # REQUIRES ol-substructure-keycloak to have been deployed to this
+  # environment first: it creates the witan-token-sync client and populates
+  # secret-operations/witan/token-sync-oidc, without which the bootstrap Job
+  # has no credential to authenticate to Keycloak with.
+  #
+  # Production's realm is sso.ol.mit.edu — NOT sso-production. The runbook's
+  # `https://sso-<env>.ol.mit.edu` template holds for CI and QA but not here.
+  omnigraph:keycloak_url: https://sso.ol.mit.edu
   aws:region: us-east-1
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production

--- a/src/ol_infrastructure/applications/omnigraph/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/omnigraph/Pulumi.QA.yaml
@@ -26,6 +26,18 @@ config:
   - https://github.com/mitodl/learn-ai
   - https://github.com/mitodl/ocw-hugo-themes
   - https://github.com/mitodl/ol-django
+  # Turns actor-token sync on: the bootstrap Job and the hourly CronJob take
+  # ownership of secret-operations/witan/actor-tokens, which Pulumi otherwise
+  # writes directly. Safe only because the existing actor-tokens resource
+  # already carries retainOnDelete=true (from #5253) — without that, dropping
+  # it from the program deletes the Vault path and leaves a window where no
+  # token is valid for anybody.
+  #
+  # REQUIRES ol-substructure-keycloak to have been deployed to this
+  # environment first: it creates the witan-token-sync client and populates
+  # secret-operations/witan/token-sync-oidc, without which the bootstrap Job
+  # has no credential to authenticate to Keycloak with.
+  omnigraph:keycloak_url: https://sso-qa.ol.mit.edu
   aws:region: us-east-1
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa


### PR DESCRIPTION
## What are the relevant tickets?

Task `tk-enable-witan-token-sync-per-environment-two-step-a7b4ec` in the witan multi-user service deployment project. Follows #5253, which shipped the job itself, and #5279, which provisioned `svc-witan-admin`.

## Description (What does this do?)

Sets `omnigraph:keycloak_url` in **all three** stacks, which is the switch that turns actor-token sync on. Until it runs, nothing provisions per-user tokens and witan stays effectively single-identity (`svc-witan-ci`) in the deployed cluster — the thing the multi-user work exists to change.

| Environment | Realm |
|---|---|
| CI | `https://sso-ci.ol.mit.edu` |
| QA | `https://sso-qa.ol.mit.edu` |
| Production | `https://sso.ol.mit.edu` |

**Production is `sso.ol.mit.edu`, not `sso-production`.** The runbook's `https://sso-<env>.ol.mit.edu` template holds for CI and QA and breaks here; it's called out in the config comment so the next person doesn't re-derive it from the pattern and get it wrong.

## How can this be tested?

`pulumi preview` is **identical on all three stacks** — 14 changes each:

```
+ 9 to create      # witan-token-sync SA, script ConfigMap, OIDC VaultStaticSecret,
                   # bootstrap Job, hourly CronJob
~ 3 to update
- 1 to delete      # <-- see below
+-1 to replace     # omnigraph-cluster-apply Job
```

The delete is the one that matters:

```
- vault:generic:Secret omnigraph-actor-tokens-vault-secret-<env> delete[retain]
```

Setting this hands ownership of `secret-operations/witan/actor-tokens` from Pulumi to the bootstrap Job and the hourly CronJob, so Pulumi drops the resource from state. **`delete[retain]` is the load-bearing word.** Pulumi reads `retainOnDelete` from state at deletion time, and #5253 already recorded it — verified independently via `pulumi stack export`, and it is `true` in CI, QA and Production. Without it the Vault path would be deleted and rewritten later in the same run with nothing ordering the two, leaving a window where no token is valid for anybody, including `svc-witan-ci`.

`admin_token_provisioned` is untouched in all three previews, which is the check that this doesn't regress #5279.

## ⚠️ Deployment notes

**Each environment requires `ol-substructure-keycloak` to have deployed there FIRST.** That stack creates the `witan-token-sync` client and populates `secret-operations/witan/token-sync-oidc`; without it the bootstrap Job has no credential to reach Keycloak with and will block the deploy.

As of this PR, confirmed by `pulumi stack export` on that stack:

- **CI** — has all five witan resources. Ready.
- **QA and Production** — have **zero**. Not ready.

So **do not promote this past CI until `ol-substructure-keycloak` has been promoted to QA and Production.** That pipeline had a bad afternoon (several failed builds, one 67-minute hang) but has since recovered — substructure builds 158 and 159 both succeeded — so it's a sequencing step, not a blocker.

**This branch was rebased onto main rather than merged from its original base.** Before the rebase it predated #5279, and previewing QA showed `admin_token_provisioned: true => false` — merging it as-was would have torn out the `svc-witan-admin` tokens that #5279 had just provisioned. Worth knowing if anyone re-bases or cherry-picks it again.

Once deployed, watch the first environment for the things no unit test covers:

- Does Vault Kubernetes auth work for the new `witan-token-sync` ServiceAccount + role? This path has never run.
- Does the Keycloak service account's `view-users` role suffice for `GET /admin/realms/<realm>/users`? Verified from docs, not against a live realm.
- Are service accounts filtered correctly? The job log should carry `skipping service account` lines naming `ol-opik-client` and `witan-token-sync` itself. If `act-` entries appear instead, the `serviceAccountClientId` assumption is wrong for this Keycloak version.
- **Is steady state quiet?** The second and later runs must log `actor-token map already matches Keycloak; nothing to write`. If `wrote N actors` appears every hour, something is re-minting and omnigraph-server is being bounced hourly — stop and fix before going further.

Also worth knowing: the deployed data tier is currently in **default-deny** (bearer tokens configured, no Cedar policy bundle applied) in all three environments, so it only permits `read`. Tracked separately and unaffected by this change — but it means writes failing after merge is expected, and not evidence that this PR broke something.