### PR TITLE
fix(keycloak): don't create the gwarek client where gwarek doesn't run

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/ol_platform_engineering.py
+++ b/src/ol_infrastructure/substructure/keycloak/ol_platform_engineering.py
@@ -621,69 +621,80 @@ def create_ol_platform_engineering_realm(  # noqa: PLR0913, PLR0915
     # LEEK [END] # noqa: ERA001
 
     # GWAREK [START] # noqa: ERA001
-    ol_platform_engineering_gwarek_client = keycloak.openid.Client(
-        "ol-platform-engineering-gwarek-client",
-        name="ol-platform-engineering-gwarek-client",
-        realm_id="ol-platform-engineering",
-        client_id="ol-gwarek-client",
-        client_secret=keycloak_realm_config.get(
-            "ol-platform-engineering-gwarek-client-secret"
-        ),
-        enabled=True,
-        access_type="CONFIDENTIAL",
-        standard_flow_enabled=True,
-        implicit_flow_enabled=False,
-        service_accounts_enabled=False,
-        valid_redirect_uris=keycloak_realm_config.get_object(
-            "ol-platform-engineering-gwarek-redirect-uris"
-        ),
-        opts=resource_options.merge(ResourceOptions(delete_before_replace=True)),
-    )
-
-    # Realm-wide roles for gwarek's admin/viewer split. Kept distinct from
-    # the generic admin/developer roles above since those are shared across
-    # unrelated tools (Airbyte, Vault, Concourse) and granting them
-    # shouldn't imply gwarek access or vice versa. Realm roles land in
-    # every token's realm_access.roles claim automatically, so — unlike the
-    # Grafana client-role + UserClientRoleProtocolMapper pattern below — no
-    # protocol mapper is needed here; gwarek's FastAPI backend reads
-    # realm_access.roles directly (mirroring ol-analytics-api's
-    # require_mit_admin).
-    keycloak.Role(
-        "ol-platform-engineering-gwarek-admin-role",
-        realm_id=ol_platform_engineering_realm.id,
-        name="gwarek-admin",
-        description="Gwarek admin — manage integrations and trigger analysis",
-        opts=resource_options,
-    )
-    keycloak.Role(
-        "ol-platform-engineering-gwarek-viewer-role",
-        realm_id=ol_platform_engineering_realm.id,
-        name="gwarek-viewer",
-        description="Gwarek viewer — read-only access to findings/reports",
-        opts=resource_options,
-    )
-
-    vault.generic.Secret(
-        "ol-platform-engineering-gwarek-client-vault-oidc-credentials",
-        path="secret-operations/sso/gwarek",
-        data_json=Output.all(
-            url=ol_platform_engineering_gwarek_client.realm_id.apply(
-                lambda realm_id: f"{keycloak_url}/realms/{realm_id}"
+    # Guarded like OL ANALYTICS API and MIT LEARN in olapps.py: gwarek is a
+    # Production-only application (applications/gwarek has only a
+    # Pulumi.Production.yaml), so Pulumi.CI.yaml and Pulumi.QA.yaml define
+    # neither ol-platform-engineering-gwarek-client-secret nor
+    # -redirect-uris. Without this guard the CI and QA keycloak stacks try to
+    # create a CONFIDENTIAL client with a null secret and null
+    # valid_redirect_uris, which the provider rejects outright ("standard
+    # (authorization code) and implicit flows require at least one valid
+    # redirect uri") -- failing the whole substructure update, not just this
+    # resource.
+    if keycloak_realm_config.get("ol-platform-engineering-gwarek-client-secret"):
+        ol_platform_engineering_gwarek_client = keycloak.openid.Client(
+            "ol-platform-engineering-gwarek-client",
+            name="ol-platform-engineering-gwarek-client",
+            realm_id="ol-platform-engineering",
+            client_id="ol-gwarek-client",
+            client_secret=keycloak_realm_config.get(
+                "ol-platform-engineering-gwarek-client-secret"
             ),
-            client_id=ol_platform_engineering_gwarek_client.client_id,
-            client_secret=ol_platform_engineering_gwarek_client.client_secret,
-            # This is included for the case where we are using traefik-forward-auth.
-            # It requires a random secret value to be present which is independent
-            # of the OAuth credentials.
-            secret=session_secret,
-            realm_id=ol_platform_engineering_gwarek_client.realm_id,
-            realm_name="ol-platform-engineering",
-            realm_public_key=ol_platform_engineering_gwarek_client.realm_id.apply(
-                fetch_realm_public_key_partial
+            enabled=True,
+            access_type="CONFIDENTIAL",
+            standard_flow_enabled=True,
+            implicit_flow_enabled=False,
+            service_accounts_enabled=False,
+            valid_redirect_uris=keycloak_realm_config.get_object(
+                "ol-platform-engineering-gwarek-redirect-uris"
             ),
-        ).apply(json.dumps),
-    )
+            opts=resource_options.merge(ResourceOptions(delete_before_replace=True)),
+        )
+
+        # Realm-wide roles for gwarek's admin/viewer split. Kept distinct from
+        # the generic admin/developer roles above since those are shared across
+        # unrelated tools (Airbyte, Vault, Concourse) and granting them
+        # shouldn't imply gwarek access or vice versa. Realm roles land in
+        # every token's realm_access.roles claim automatically, so — unlike the
+        # Grafana client-role + UserClientRoleProtocolMapper pattern below — no
+        # protocol mapper is needed here; gwarek's FastAPI backend reads
+        # realm_access.roles directly (mirroring ol-analytics-api's
+        # require_mit_admin).
+        keycloak.Role(
+            "ol-platform-engineering-gwarek-admin-role",
+            realm_id=ol_platform_engineering_realm.id,
+            name="gwarek-admin",
+            description="Gwarek admin — manage integrations and trigger analysis",
+            opts=resource_options,
+        )
+        keycloak.Role(
+            "ol-platform-engineering-gwarek-viewer-role",
+            realm_id=ol_platform_engineering_realm.id,
+            name="gwarek-viewer",
+            description="Gwarek viewer — read-only access to findings/reports",
+            opts=resource_options,
+        )
+
+        vault.generic.Secret(
+            "ol-platform-engineering-gwarek-client-vault-oidc-credentials",
+            path="secret-operations/sso/gwarek",
+            data_json=Output.all(
+                url=ol_platform_engineering_gwarek_client.realm_id.apply(
+                    lambda realm_id: f"{keycloak_url}/realms/{realm_id}"
+                ),
+                client_id=ol_platform_engineering_gwarek_client.client_id,
+                client_secret=ol_platform_engineering_gwarek_client.client_secret,
+                # This is included for the case where we are using
+                # traefik-forward-auth. It requires a random secret value to be
+                # present which is independent of the OAuth credentials.
+                secret=session_secret,
+                realm_id=ol_platform_engineering_gwarek_client.realm_id,
+                realm_name="ol-platform-engineering",
+                realm_public_key=ol_platform_engineering_gwarek_client.realm_id.apply(
+                    fetch_realm_public_key_partial
+                ),
+            ).apply(json.dumps),
+        )
     # GWAREK [END] # noqa: ERA001
 
     # VAULT [START] # noqa: ERA001


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
`deploy-ol-substructure-keycloak-ci` has failed on every run since build 154 (2026-08-05 10:25 EDT), and it fails the same way each time:

```
keycloak:openid:Client (ol-platform-engineering-gwarek-client):
  error: sdk-v2/provider2.go:572: sdk.helper_schema: validation error:
  standard (authorization code) and implicit flows require at least one
  valid redirect uri: provider=keycloak@6.12.0
```

https://github.com/mitodl/ol-infrastructure/pull/5166 added the gwarek client to `ol_platform_engineering.py` unconditionally, but added `ol-platform-engineering-gwarek-client-secret` and `-redirect-uris` only to `Pulumi.Production.yaml`. That matches where gwarek actually runs — `src/ol_infrastructure/applications/gwarek/` carries only a `Pulumi.Production.yaml` — but the Keycloak substructure stack still tries to create the client in CI and QA, where both config keys resolve to `None`. A `CONFIDENTIAL` client with a null secret and no redirect URIs is rejected by the provider before the request ever reaches Keycloak, and because the create fails the **entire** `ol-substructure-keycloak` update aborts.

This guards the block on the client secret, which is the same guard `olapps.py` already puts on the OL ANALYTICS API and MIT LEARN clients for exactly this reason (Production-only apps whose config CI never defines).

**This was blocking more than gwarek.** The `witan-token-sync` and `witan-cli` clients from https://github.com/mitodl/ol-infrastructure/pull/5267 live in this same stack. CI got them from a run that predates the breakage, but QA and Production have zero witan resources and cannot receive any while the update aborts — which blocks the witan per-environment token-sync rollout.

### How can this be tested?
`pulumi preview` run locally against all three stacks with this branch:

**CI** — the client no longer attempts to create, and the two orphaned realm roles go away:
```
- keycloak:index/role:Role  ol-platform-engineering-gwarek-admin-role   (delete)
- keycloak:index/role:Role  ol-platform-engineering-gwarek-viewer-role  (delete)
Resources: - 2 to delete, 243 unchanged
```
Those two roles were created by the same failing runs (Pulumi created them, then the client create failed alongside). Nothing in CI consumes them — gwarek doesn't run there, no user is assigned them — so dropping them is the correct convergence, not a regression.

**QA** — clean, and picks up the five witan resources it is missing:
```
+ keycloak:openid:Client                    ol-platform-engineering-witan-token-sync-client
+ keycloak:openid:Client                    ol-platform-engineering-witan-cli-client
+ keycloak:openid:ClientServiceAccountRole   ol-platform-engineering-witan-token-sync-view-users
+ keycloak:openid:AudienceProtocolMapper     ol-platform-engineering-witan-cli-audience-mapper
+ vault:generic:Secret                       ol-platform-engineering-witan-token-sync-vault-oidc-credentials
Resources: + 5 to create, 250 unchanged
```

**Production** — keeps the gwarek client it actually configures (it appears in neither the create nor the delete set), and picks up the same five witan resources:
```
+ 5 to create, - 3 to delete, 322 unchanged
```
The three Production deletions — `ol-platform-engineering-openlit-client`, its Vault secret, and `ol-platform-engineering-gwarek-realm-role-userinfo-mapper` — are **pre-existing drift, not from this change**: none of those three resources exist in the program on `main` either, so they are already queued for removal on the next successful Production deploy.

`pre-commit run --files src/ol_infrastructure/substructure/keycloak/ol_platform_engineering.py` passes (ruff format, ruff check, mypy, detect-secrets).

### Additional Context
Two other failures on `docker-pulumi-keycloak` today are **separate causes** and are not addressed here:

1. `deploy-ol-application-keycloak-ci/238-240` fail on `ec2:RevokeSecurityGroupIngress` being denied to the infra worker role. That is the gap https://github.com/mitodl/ol-infrastructure/pull/5276 grants; it merged at 16:08 EDT, after those builds started, and clears once the `concourse` stack deploys.
2. `build-keycloak-docker-image/727` fails in 12s on `GET .../ol-keycloakify/releases/tags/v0.1.5: 403 The 'mitodl' organization forbids access via a personal access tokens (classic) if the token's lifetime is greater than 7 days`. That is a credential problem on the pipeline's GitHub token and needs a rotation, not a code change.

Also worth noting for whoever looks at the pipeline: `deploy-ol-substructure-keycloak-ci/158` sat "started" for 50+ minutes, but it is not hung on Pulumi and holds no stack lock — its update already failed at 27s with the gwarek error above, and the build is stalled afterwards on `streaming volume ol-infrastructure-pulumi-substructure from worker i-0c4000b14765b4494`. `pulumi stack export --stack CI` confirms no `pending_operations`.
