### PR TITLE
Keep people out of the Pulumi estate; repo access comes from teams

### DIFF
--- a/bin/github-org-inventory
+++ b/bin/github-org-inventory
@@ -123,6 +123,14 @@ DEFAULT_BRANCH_EXEMPT_ARCHETYPES = frozenset({"fork", "archived"})
 # share of active repos overstates them badly (92 of 138 archived reads as "52% of active").
 ARCHIVED_SCOPED_RULES = frozenset({"CON-07 archived repo still grants team write"})
 
+# Rules whose population is the WHOLE fleet, active and archived alike. SEC-06 is here
+# because the no-direct-collaborators policy (2026-08-05) admits no exceptions: an admin
+# grant on an archived repo is inert only until someone unarchives it, and the fork fleet
+# was explicitly included when the policy was set.
+FLEET_SCOPED_RULES = frozenset(
+    {"SEC-06 direct collaborator on repo (policy: repo access via teams only)"}
+)
+
 # The value GitHub reports for an active security-and-analysis feature. Hoisted to a
 # constant because comparing the scanning-status fields against a literal trips both
 # ruff S105 and detect-secrets as a hardcoded-credential false positive.
@@ -239,6 +247,13 @@ def _crawl_repo(token: str, listed: dict[str, Any]) -> dict[str, Any]:
         # IDs, not just counts: `imports` needs them to build the Pulumi import payload.
         hooks = _maybe(client, f"/repos/{ORG}/{name}/hooks?per_page=100") or []
         deploy_keys = _maybe(client, f"/repos/{ORG}/{name}/keys?per_page=100") or []
+        direct_collaborators = (
+            _maybe(
+                client,
+                f"/repos/{ORG}/{name}/collaborators?affiliation=direct&per_page=100",
+            )
+            or []
+        )
         # A SAMPLE of environment names, not the full set -- mitxonline has 412 and the
         # rest are ephemeral review apps. The count below stays authoritative; these
         # names exist to tell a real deploy target from publishing plumbing.
@@ -319,10 +334,14 @@ def _crawl_repo(token: str, listed: dict[str, Any]) -> dict[str, Any]:
             "deploy_keys": [
                 {"id": k["id"], "read_only": k.get("read_only")} for k in deploy_keys
             ],
-            "collaborator_count": _count(
-                client, f"/repos/{ORG}/{name}/collaborators?affiliation=direct"
-            )
-            or 0,
+            "collaborator_count": len(direct_collaborators),
+            # WHO holds a direct grant and at what level, not just how many. Repo access
+            # is meant to come from team membership only (§4.7), so every entry here is a
+            # SEC-06 finding with a name attached and a specific team to migrate it to.
+            # A count alone cannot produce that remediation list.
+            "direct_collaborators": {
+                u["login"]: u.get("role_name") for u in direct_collaborators
+            },
             "custom_properties": {
                 p["property_name"]: p["value"] for p in properties if p.get("value")
             },
@@ -469,8 +488,10 @@ def propose_archetype(repo: dict[str, Any]) -> str:
 def _findings(repos: list[dict[str, Any]]) -> dict[str, list[str]]:
     """Map §7 rule id -> repo names that fire it.
 
-    Every rule scopes to active repos except CON-07, which is about archived ones by
-    definition -- see the ARCHIVED_SCOPED_RULES set used when rendering percentages.
+    Rules scope to active repos by default. Two exceptions, both declared as frozensets
+    above so the percentage rendering agrees with the population: CON-07 is about archived
+    repos by definition, and SEC-06 is fleet-wide because the policy behind it has no
+    exemptions.
     """
     live = [r for r in repos if not r["archived"]]
     return {
@@ -491,8 +512,9 @@ def _findings(repos: list[dict[str, Any]]) -> dict[str, list[str]]:
         "SEC-05 dependabot security updates off": [
             r["name"] for r in live if not r["dependabot_security_updates"]
         ],
-        "SEC-06 direct collaborators on repo": [
-            r["name"] for r in live if r["collaborator_count"] > 0
+        # Fleet-wide, deliberately: see FLEET_SCOPED_RULES.
+        "SEC-06 direct collaborator on repo (policy: repo access via teams only)": [
+            r["name"] for r in repos if r["collaborator_count"] > 0
         ],
         "CON-02 delete_branch_on_merge off": [
             r["name"] for r in live if not r["delete_branch_on_merge"]
@@ -602,11 +624,29 @@ def report(
     archived_count = len(repos) - len(live)
     print("\n## Findings")
     for rule, hits in sorted(findings.items(), key=lambda kv: -len(kv[1])):
-        over_archived = rule in ARCHIVED_SCOPED_RULES
-        denominator = archived_count if over_archived else len(live)
-        label = "archived" if over_archived else "active"
+        if rule in FLEET_SCOPED_RULES:
+            denominator, label = len(repos), "all repos"
+        elif rule in ARCHIVED_SCOPED_RULES:
+            denominator, label = archived_count, "archived"
+        else:
+            denominator, label = len(live), "active"
         share = f"{len(hits) / denominator:.0%}" if denominator else "-"
         print(f"  {len(hits):4}  ({share:>4} of {label})  {rule}")
+
+    holders: Counter[str] = Counter()
+    levels: Counter[str] = Counter()
+    for repo in repos:
+        for login, role in repo.get("direct_collaborators", {}).items():
+            holders[login] += 1
+            levels[role or "unknown"] += 1
+    if holders:
+        print("\n## Direct collaborators (SEC-06) — every one of these moves to a team")
+        print(f"  {sum(levels.values())} grants across {len(holders)} people:")
+        for role, count in levels.most_common():
+            print(f"     {count:5}  {role}")
+        print("  most-granted:")
+        for login, count in holders.most_common(8):
+            print(f"     {count:5}  {login}")
 
     print("\n## Environment sprawl detail (DX-08)")
     for repo in sorted(live, key=lambda r: -r["environment_count"])[:10]:
@@ -818,17 +858,26 @@ def imports(
             "mitodl",
             str(data["org"]["id"]),
         )
+    # NO INDIVIDUAL PEOPLE IN THE ESTATE (decision 2026-08-05). Pulumi manages teams and
+    # what teams can do; it does not manage who is an org member or who is in a team.
+    #
+    # `Membership` (39) and `TeamMembership` (145) are deliberately not emitted, taking
+    # the organization payload from 199 resources to 15. Reasons, in order of weight:
+    #
+    #   1. Onboarding stops depending on infrastructure. Both resource types put every
+    #      hire, departure and team move behind a PR and this stack's manual-approval
+    #      apply. The org is also at 39/39 seats, so a Pulumi-managed Membership would
+    #      fail on the next hire -- loudly and harmlessly, but at the worst moment.
+    #   2. `Membership` deletion evicts a human from the org. Not modelling it removes
+    #      the highest-blast-radius resource in the estate rather than guarding it.
+    #   3. Repo access does not flow through either one. It flows through TeamRepository,
+    #      which the repositories payload still emits (169 of them) -- so "team
+    #      permissions" stay fully managed while people stay out.
+    #
+    # The crawl still RECORDS org members and team rosters; that is inventory feeding the
+    # audit, not Pulumi state. Drift in a roster stays visible without being enforced.
     for team in data["teams"]:
         add(org_resources, "team:Team", team["slug"], str(team["id"]))
-        for member in team["members"]:
-            add(
-                org_resources,
-                "teamMembership:TeamMembership",
-                f"{team['slug']}-{member}",
-                f"{team['id']}:{member}",
-            )
-    for member in data["members"]:
-        add(org_resources, "membership:Membership", member, f"{ORG}:{member}")
     for hook in data.get("org_webhooks", []):
         add(
             org_resources,

--- a/bin/github-org-inventory
+++ b/bin/github-org-inventory
@@ -130,16 +130,20 @@ ARCHIVED_SCOPED_RULES = frozenset({"CON-07 archived repo still grants team write
 FLEET_SCOPED_RULES = frozenset(
     {
         "SEC-06 direct collaborator on repo (policy: repo access via teams only)",
-        "SEC-15 broad team holds admin (policy: push or maintain)",
+        "SEC-15 admin held by a team other than odl-engineering-owners",
     }
 )
 
-# Teams broad enough that `admin` on a repo is over-privilege rather than ownership
-# (SEC-15, policy set 2026-08-05: odl-engineering should hold push or maintain). `admin`
-# carries repo deletion, settings changes and the ability to bypass rulesets -- with
-# direct collaborator grants going away (§4.7), team grants ARE the access control, so
-# their level is the whole story rather than a detail. Add teams here as the policy grows.
-NO_ADMIN_TEAMS = frozenset({"odl-engineering"})
+# The team(s) sanctioned to hold `admin` on a repository (policy 2026-08-05:
+# odl-engineering-owners is THE admin team; odl-engineering gets push or maintain).
+#
+# Deliberately an ALLOWLIST rather than a list of teams barred from admin. `admin` carries
+# repo deletion, settings changes and ruleset bypass, and with direct collaborator grants
+# going away (§4.7) team grants are the whole access control rather than one input to it.
+# Under a denylist a newly created team acquires admin silently and SEC-15 stays quiet;
+# under an allowlist it has to be named here first. Default-deny is the only version of
+# this rule that stays true as the org changes.
+ADMIN_TEAMS = frozenset({"odl-engineering-owners"})
 ADMIN_PERMISSIONS = frozenset({"admin"})
 
 # The value GitHub reports for an active security-and-analysis feature. Hoisted to a
@@ -536,11 +540,11 @@ def _findings(
                 if (r.get("teams") or {})
                 != (archetype_teams.get(propose_archetype(r)) or {})
             ],
-            "SEC-15 broad team holds admin (policy: push or maintain)": [
+            "SEC-15 admin held by a team other than odl-engineering-owners": [
                 r["name"]
                 for r in repos
                 if any(
-                    team in NO_ADMIN_TEAMS and perm in ADMIN_PERMISSIONS
+                    perm in ADMIN_PERMISSIONS and team not in ADMIN_TEAMS
                     for team, perm in (r.get("teams") or {}).items()
                 )
             ],
@@ -703,7 +707,7 @@ def report(
             print(f"     {count:5}  {perm}")
         print("  teams holding admin, by repo count:")
         for team, count in by_team.most_common(8):
-            flag = "  <-- SEC-15" if team in NO_ADMIN_TEAMS else ""
+            flag = "" if team in ADMIN_TEAMS else "  <-- SEC-15"
             print(f"     {count:5}  {team}{flag}")
 
     holders: Counter[str] = Counter()

--- a/bin/github-org-inventory
+++ b/bin/github-org-inventory
@@ -130,12 +130,23 @@ ARCHIVED_SCOPED_RULES = frozenset({"CON-07 archived repo still grants team write
 FLEET_SCOPED_RULES = frozenset(
     {
         "SEC-06 direct collaborator on repo (policy: repo access via teams only)",
-        "SEC-15 admin held by a team other than odl-engineering-owners",
+        "SEC-15 admin held by a team outside the sanctioned set",
     }
 )
 
-# The team(s) sanctioned to hold `admin` on a repository (policy 2026-08-05:
-# odl-engineering-owners is THE admin team; odl-engineering gets push or maintain).
+# The teams sanctioned to hold `admin` on a repository (policy 2026-08-05).
+#
+#   odl-engineering-owners  the org's admin team
+#   devops                  admin on infrastructure it operates
+#
+# NOT sanctioned, and each excluded on purpose:
+#   odl-engineering         the broad engineering team -- push or maintain (116 repos)
+#   devops-contractors      contractor counterpart to devops (4 repos)
+#   arbisoft-contractors    contractor team currently at admin on 57 repos
+#
+# The contractor teams are the point of the rule. Staff/contractor is exactly the boundary
+# where a permission ceiling earns its keep, and `devops` being sanctioned while
+# `devops-contractors` is not is a deliberate distinction rather than an oversight.
 #
 # Deliberately an ALLOWLIST rather than a list of teams barred from admin. `admin` carries
 # repo deletion, settings changes and ruleset bypass, and with direct collaborator grants
@@ -143,7 +154,7 @@ FLEET_SCOPED_RULES = frozenset(
 # Under a denylist a newly created team acquires admin silently and SEC-15 stays quiet;
 # under an allowlist it has to be named here first. Default-deny is the only version of
 # this rule that stays true as the org changes.
-ADMIN_TEAMS = frozenset({"odl-engineering-owners"})
+ADMIN_TEAMS = frozenset({"odl-engineering-owners", "devops"})
 ADMIN_PERMISSIONS = frozenset({"admin"})
 
 # The value GitHub reports for an active security-and-analysis feature. Hoisted to a
@@ -540,7 +551,7 @@ def _findings(
                 if (r.get("teams") or {})
                 != (archetype_teams.get(propose_archetype(r)) or {})
             ],
-            "SEC-15 admin held by a team other than odl-engineering-owners": [
+            "SEC-15 admin held by a team outside the sanctioned set": [
                 r["name"]
                 for r in repos
                 if any(

--- a/bin/github-org-inventory
+++ b/bin/github-org-inventory
@@ -128,8 +128,19 @@ ARCHIVED_SCOPED_RULES = frozenset({"CON-07 archived repo still grants team write
 # grant on an archived repo is inert only until someone unarchives it, and the fork fleet
 # was explicitly included when the policy was set.
 FLEET_SCOPED_RULES = frozenset(
-    {"SEC-06 direct collaborator on repo (policy: repo access via teams only)"}
+    {
+        "SEC-06 direct collaborator on repo (policy: repo access via teams only)",
+        "SEC-15 broad team holds admin (policy: push or maintain)",
+    }
 )
+
+# Teams broad enough that `admin` on a repo is over-privilege rather than ownership
+# (SEC-15, policy set 2026-08-05: odl-engineering should hold push or maintain). `admin`
+# carries repo deletion, settings changes and the ability to bypass rulesets -- with
+# direct collaborator grants going away (§4.7), team grants ARE the access control, so
+# their level is the whole story rather than a detail. Add teams here as the policy grows.
+NO_ADMIN_TEAMS = frozenset({"odl-engineering"})
+ADMIN_PERMISSIONS = frozenset({"admin"})
 
 # The value GitHub reports for an active security-and-analysis feature. Hoisted to a
 # constant because comparing the scanning-status fields against a literal trips both
@@ -485,7 +496,26 @@ def propose_archetype(repo: dict[str, Any]) -> str:
     return "library"
 
 
-def _findings(repos: list[dict[str, Any]]) -> dict[str, list[str]]:
+def _archetype_teams(archetypes_file: Path) -> dict[str, dict[str, str]] | None:
+    """Resolve each archetype's target team grants, or None if the file is absent.
+
+    `report` is documented as usable before any Pulumi exists, so a missing archetypes
+    file is a legitimate state rather than an error -- it just means the two conformance
+    rules cannot be evaluated, which the caller reports rather than scoring as zero.
+    """
+    if not archetypes_file.exists():
+        return None
+    archetypes = yaml.safe_load(archetypes_file.read_text())["archetypes"]
+    return {
+        name: _resolve_archetype(archetypes, name).get("teams") or {}
+        for name in archetypes
+    }
+
+
+def _findings(
+    repos: list[dict[str, Any]],
+    archetype_teams: dict[str, dict[str, str]] | None = None,
+) -> dict[str, list[str]]:
     """Map §7 rule id -> repo names that fire it.
 
     Rules scope to active repos by default. Two exceptions, both declared as frozensets
@@ -494,7 +524,29 @@ def _findings(repos: list[dict[str, Any]]) -> dict[str, list[str]]:
     exemptions.
     """
     live = [r for r in repos if not r["archived"]]
+    # CON-04/SEC-15 need each archetype's target team grants. Absent (no archetypes.yaml),
+    # both are skipped rather than reported as zero -- an empty finding and an unmeasured
+    # one look identical in a report, and only one of them is good news.
+    conformance: dict[str, list[str]] = {}
+    if archetype_teams is not None:
+        conformance = {
+            "CON-04 team grants deviate from archetype": [
+                r["name"]
+                for r in live
+                if (r.get("teams") or {})
+                != (archetype_teams.get(propose_archetype(r)) or {})
+            ],
+            "SEC-15 broad team holds admin (policy: push or maintain)": [
+                r["name"]
+                for r in repos
+                if any(
+                    team in NO_ADMIN_TEAMS and perm in ADMIN_PERMISSIONS
+                    for team, perm in (r.get("teams") or {}).items()
+                )
+            ],
+        }
     return {
+        **conformance,
         "SEC-01 no branch protection and no ruleset": [
             r["name"]
             for r in live
@@ -560,12 +612,15 @@ def report(
     as_json: Annotated[
         bool, cyclopts.Parameter(name=["--json"], help="Emit JSON instead of text.")
     ] = False,
+    archetypes_file: Annotated[
+        Path, cyclopts.Parameter(help="Archetype definitions, for CON-04 / SEC-15.")
+    ] = DATA_DIR / "archetypes.yaml",
 ) -> None:
     """Estate report for the whole org, before any Pulumi is involved."""
     data = _crawl_org(cache, refresh=refresh)
     repos = data["repos"]
     live = [r for r in repos if not r["archived"]]
-    findings = _findings(repos)
+    findings = _findings(repos, _archetype_teams(archetypes_file))
 
     if as_json:
         print(
@@ -632,6 +687,24 @@ def report(
             denominator, label = len(live), "active"
         share = f"{len(hits) / denominator:.0%}" if denominator else "-"
         print(f"  {len(hits):4}  ({share:>4} of {label})  {rule}")
+
+    grants: Counter[str] = Counter()
+    by_team: Counter[str] = Counter()
+    for repo in repos:
+        for team, perm in (repo.get("teams") or {}).items():
+            grants[perm] += 1
+            if perm in ADMIN_PERMISSIONS:
+                by_team[team] += 1
+    if grants:
+        total = sum(grants.values())
+        admin = sum(c for p, c in grants.items() if p in ADMIN_PERMISSIONS)
+        print(f"\n## Team permission spread — {admin}/{total} grants are admin")
+        for perm, count in grants.most_common():
+            print(f"     {count:5}  {perm}")
+        print("  teams holding admin, by repo count:")
+        for team, count in by_team.most_common(8):
+            flag = "  <-- SEC-15" if team in NO_ADMIN_TEAMS else ""
+            print(f"     {count:5}  {team}{flag}")
 
     holders: Counter[str] = Counter()
     levels: Counter[str] = Counter()

--- a/docs/plans/github-org-pulumi-import.md
+++ b/docs/plans/github-org-pulumi-import.md
@@ -206,9 +206,9 @@ each one is a new blast-radius surface for no current benefit.
 1. Every `github.Repository` carries `pulumi.ResourceOptions(retain_on_delete=True)`. Removing
    a repo from the YAML removes it from state and *never* from GitHub.
 2. Org-level resources (`OrganizationSettings`, `OrganizationRuleset`, `OrganizationWebhook`)
-   carry `protect=True`. **So does `Membership`** — deleting one removes a human from the org,
-   which is the same class of irreversible action as deleting a repo and was missing from the
-   first version of this list (see §9.3).
+   carry `protect=True`. `Membership` was going to join them for the same reason — deleting
+   one removes a human from the org — but as of 2026-08-05 it is **not modelled at all**
+   (§4.7). Not having the resource is a stronger guarantee than protecting it.
 3. The Concourse job for the `github-organization` project requires manual approval before
    `pulumi up`; `github-repositories` may auto-apply once the empty-diff gate (§6) is green.
 
@@ -238,7 +238,6 @@ src/ol_infrastructure/substructure/github/
 │   ├── org_settings.py
 │   ├── custom_properties.py
 │   ├── teams.py
-│   ├── members.py
 │   ├── org_rulesets.py
 │   └── org_automation.py         # org webhooks, runner groups, org secrets/vars
 └── repositories/                 # project: ol-substructure-github-repositories
@@ -357,8 +356,7 @@ dictionary comparison rather than an API crawl.
 |---|---|---:|
 | `organization/org_settings.py` | `OrganizationSettings` | 1 |
 | `organization/custom_properties.py` | `OrganizationCustomProperties` | **1 per property** (~3), not 1 total — see §5.2 |
-| `organization/teams.py` | `Team`, `TeamSettings`, `TeamMembership` | ~14 + ~60 |
-| `organization/members.py` | `Membership` | 39 |
+| `organization/teams.py` | `Team` (+`TeamSettings`) — **not** `TeamMembership` (§4.7) | 14 |
 | `organization/org_rulesets.py` | `OrganizationRuleset` (property-targeted, §5.4) | 2 |
 | `organization/org_automation.py` | `OrganizationWebhook`, `ActionsRunnerGroup`, org secrets/variables | ~10 |
 | `repositories/repository.py` | `Repository`, `RepositoryTopics`, `BranchDefault`, `RepositoryVulnerabilityAlerts`, `RepositoryDependabotSecurityUpdates`, `RepositoryCustomProperty`, `TeamRepository` | 317 × ~6 |
@@ -554,6 +552,67 @@ Copilot review whether or not anyone framed it as a decision. Three things follo
    `organization_copilot_seat_management` / `organization_copilot_agent_settings` remains
    correct. An audit-only read is the option worth revisiting in phase 4.
 
+### 4.7 People are not in the estate; teams are
+
+Decided 2026-08-05. Two rules that reinforce each other.
+
+**Rule 1 — Pulumi manages teams, not individuals.** Neither `Membership` (who belongs to
+the org) nor `TeamMembership` (who belongs to a team) is imported or declared. The
+organization payload drops from **199 resources to 15** — 14 `Team` plus
+`OrganizationSettings`.
+
+**Rule 2 — repo access comes from team membership only.** No individual is granted a direct
+permission on a repository. `TeamRepository` is the sole path from a person to a repo, via
+the team they are in.
+
+They fit together: rule 2 is what makes rule 1 safe. Modelling people would only be buying
+a security property if access flowed *through* the individual records — and it does not. It
+flows through `TeamRepository`, which stays fully managed, all **169** of them.
+
+What that buys:
+
+- **Onboarding, offboarding and team moves never touch this repository.** No PR, no
+  manual-approval apply, no waiting on the infra team. That is the single largest operational
+  cost the earlier design carried (§9.3).
+- **The 39/39 seat ceiling stops being a Pulumi problem.** A `pulumi up` can no longer fail
+  on the 40th hire because Pulumi never adds one.
+- **The highest-blast-radius resource in the estate disappears.** Deleting a `Membership`
+  evicts a human from the org. Not modelling it is a stronger guarantee than `protect=True`.
+
+What it gives up, stated plainly: org membership and team rosters are **not declared in
+code**, so drift there is visible but not enforced. The crawl still records both — that is
+inventory feeding the audit, not Pulumi state — so a roster change shows up in a `drift` run
+without anything blocking it.
+
+#### The direct-collaborator backlog
+
+Rule 2 is a policy the fleet does not currently satisfy. Measured 2026-08-05:
+
+| | |
+|---|---:|
+| Repos with ≥1 direct collaborator | **72** (43 active, 29 archived) |
+| Total direct grants | **83** |
+| — at `admin` | **73** |
+| — at `write` | 10 |
+| Distinct people holding them | 20 |
+
+**73 of 83 direct grants are `admin`**, which is the part worth pausing on: the informal
+path to access is not a lesser permission, it is the highest one. One person holds direct
+grants on 20 repos; a bot account (`odlbot`) holds admin on 7.
+
+The policy applies to **every repo, forks and archived included** — no exemptions. An
+`admin` grant on an archived repo is inert only until someone unarchives it, and the fork
+fleet was explicitly in scope when the rule was set. SEC-06 is therefore a fleet-wide rule
+(the only one besides CON-07 that is not scoped to active repos), and each finding names the
+person and permission so it converts into "which team should this be" rather than a count.
+
+Remediation is phase 5 work — it changes access, so it is downstream of a reviewed backlog,
+not something the import does on the way past.
+
+**One convenient consequence.** `RepositoryCollaborators` has no documented import in the
+provider schema (§5.2 flagged it as untrusted). Under rule 2 there is eventually nothing to
+import, so a gap in the provider stops mattering instead of needing a workaround.
+
 ## 5. Discovery and import mechanics
 
 ### 5.1 One inventory pass produces both sides
@@ -601,10 +660,10 @@ stable across majors, and three entries in the pre-verification draft of this ta
 | `BranchProtection` | `<repo>:<pattern>` | |
 | `Team` | `<team-id>` **or** `<team-slug>` | both accepted |
 | `TeamRepository` | `<team-id>:<repo>` **or** `<team-slug>:<repo>` | slug form is what §3.2 relies on |
-| `TeamMembership` | `<team-id>:<username>` **or** `<team-slug>:<username>` | |
+| ~~`TeamMembership`~~ | `<team-id>:<username>` **or** `<team-slug>:<username>` | **Out of scope (§4.7)** — form kept for reference only |
 | `TeamMembers` | `<team-id>` | **use the numeric id.** The provider warns that importing by slug makes it convert slug↔id and *destroy and recreate every membership*. |
 | `TeamSettings` | `<team-id>` or `<team-slug>` | |
-| `Membership` | `<org>:<username>` | |
+| ~~`Membership`~~ | `<org>:<username>` | **Out of scope (§4.7)** — form kept for reference only |
 | `RepositoryWebhook` | `<repo>/<hook-id>` | **slash**, not colon |
 | `OrganizationWebhook` | `<hook-id>` | |
 | `RepositoryVulnerabilityAlerts` | `<repo>` | |
@@ -776,7 +835,7 @@ fixtures and cheap to add — the rule set is meant to grow every time someone n
 | SEC-03 | No required status checks on default branch | every sampled repo |
 | SEC-04 | Secret scanning or push protection disabled | `hq` (private) |
 | SEC-05 | Dependabot alerts or security updates disabled | every sampled repo + org default |
-| SEC-06 | Outside collaborator holds `admin` or `maintain` | `mitxonline` has 1 direct collaborator |
+| SEC-06 | **Any** direct collaborator on **any** repo — repo access must come from team membership (§4.7) | **fires on 72 repos**: 83 grants, 73 of them `admin`, across 20 people |
 | SEC-07 | Webhook without a secret, or a non-HTTPS URL | unknown |
 | SEC-08 | Write-enabled deploy key on an active repo | unknown |
 | SEC-09 | Actions secret not rotated in > 12 months | unknown |
@@ -834,7 +893,7 @@ and route findings to the project's witan task list.
 |---|---|---|
 | **0** | Widen the GitHub App (§2). Write `docs/github-app-permissions.md`. Verify with a read-only crawl. | App can read every resource type in §3.3 |
 | **1** | Build `bin/github-org-inventory`. Crawl. Human-confirm archetype per repo. Commit `data/`. | 317 repos classified; estate report reviewed |
-| **2** | Author `organization/`. Import org, teams, members. Define the `tier` custom-property schema (§5.4) — now a prerequisite, not a fast-follow. | **Empty diff** on `ol-substructure-github-organization` |
+| **2** | Author `organization/`. Import org settings and the 14 teams — **not** members or team rosters (§4.7). Define the `tier` custom-property schema (§5.4) — a prerequisite, not a fast-follow. | **Empty diff** on `ol-substructure-github-organization` |
 | **3** | Author `repositories/`. Import in ~25-repo batches, including each repo's `tier` value. | **Empty diff** after every batch, and on the whole stack |
 | **3.5** | Add the two property-targeted org rulesets at `enforcement: evaluate`. Watch, then promote to `active`. | Rule-suite logs show the expected repos matching and no surprises |
 | **4** | Build `bin/github-estate-audit`. Run all three axes. Emit witan tasks. | Backlog exists and is triaged |
@@ -931,38 +990,35 @@ because the evidence is what makes a decision re-examinable when the estate chan
    That is cheap enough that the stack-size argument for excluding them does not survive
    contact with the audit-noise argument for including them.
 
-3. ~~**Seat pressure.**~~ **RESOLVED 2026-08-03 — keep `Membership` in Pulumi; the seat
-   ceiling is an operational precondition for phase 2, not a design constraint.**
+3. ~~**Seat pressure.**~~ **SUPERSEDED 2026-08-05 — `Membership` is out of scope entirely
+   (§4.7), which dissolves the question rather than answering it.**
 
-   Confirmed against the live org (`gh api /orgs/mitodl --jq .plan`):
+   The 2026-08-03 conclusion was *keep `Membership` in Pulumi and accept that onboarding
+   moves onto the infra team's critical path*. That reasoning was sound on its own terms and
+   is kept below, because the thing that changed was not the argument but a decision it had
+   treated as fixed.
 
-   ```json
-   {"name": "team", "seats": 39, "filled_seats": 39}
-   ```
+   It had framed "39 members go unmanaged" as the cost of not modelling them. That is only a
+   cost if managing *people* is what buys the security property. It is not — repo access
+   comes from `TeamRepository`, which stays fully managed. Once that is separated out,
+   modelling members buys a declared roster and costs a PR per hire, per departure and per
+   team move, on a stack that requires manual approval. The trade stops being close.
 
-   `seats == filled_seats`, so there is genuinely zero headroom. But the framing in the
-   original question was wrong in a way worth correcting: a `pulumi up` that fails on the 40th
-   member is *loud, immediate, and harmless* — nothing is half-applied and nobody is locked
-   out. That is not the failure mode to design around.
+   Everything the original analysis established still holds and is worth keeping:
 
-   The real cost is that onboarding moves onto the infra team's critical path, because
-   `ol-substructure-github-organization` requires manual approval before apply (§2.2). That is
-   a process consequence to accept knowingly, not a reason to leave 39 members unmanaged.
+   - Confirmed live: `{"name": "team", "seats": 39, "filled_seats": 39}` — zero headroom.
+   - A `pulumi up` failing on the 40th member would be loud, immediate and harmless. That
+     was never the failure mode to design around; the critical-path cost was.
+   - The billing question — whether a 40th member auto-provisions a paid seat or hard-fails
+     — is **not readable from the API** and still wants an answer from whoever owns the
+     GitHub bill. It is no longer a phase-2 blocker, since Pulumi never adds a member, but it
+     is still the difference between a smooth hire and a surprised one.
+   - Audit rule **DX-10** (zero seat headroom) stands, and matters *more* now: with members
+     unmanaged, the audit is the only thing watching the ceiling.
 
-   Two things follow, neither of which blocks the design:
-
-   - **Verify the billing behaviour before phase 2, not during it.** Whether adding a 40th
-     member auto-provisions a paid seat or hard-fails depends on the billing arrangement, and
-     that is not readable from the API — `/orgs/mitodl` reports the seat counts above but not
-     the billing cadence. Ask whoever owns the GitHub bill. The answer changes the runbook,
-     not the plan.
-   - **`Membership` carries `protect=True`**, joining the org-level resources in §2.2.
-     Deleting a `Membership` removes a human from the org; a bad merge to `members.py` should
-     fail the apply rather than evict people. This is the counterweight that the original
-     §2.2 list omitted, because it only considered repository deletion.
-
-   New audit rule **DX-10**: zero seat headroom (`filled_seats == seats`) — the next hire
-   cannot be added without a billing change. Fires now.
+   The counterweight the original conclusion added — `protect=True` on `Membership` — is
+   withdrawn along with the resource. Not modelling something is a stronger guarantee than
+   protecting it.
 
 4. **Actions secrets into Vault** (§4.1) — real value, but a source-of-truth migration.
    Recommend deferring to its own project rather than smuggling it into this one. Note that

--- a/docs/plans/github-org-pulumi-import.md
+++ b/docs/plans/github-org-pulumi-import.md
@@ -844,6 +844,7 @@ fixtures and cheap to add — the rule set is meant to grow every time someone n
 | SEC-12 | Our own app's live permissions diverge from `docs/github-app-permissions.md` | — |
 | SEC-13 | Private repo with weaker controls than the public baseline | `hq` |
 | SEC-14 | No CODEOWNERS on a tier-1 repo | unknown |
+| SEC-15 | A broad team holds `admin` — `odl-engineering` must be `push` or `maintain` (policy 2026-08-05) | **fires on 116 repos** (61 active, 55 archived) |
 
 ### Axis: Consistency
 
@@ -852,7 +853,7 @@ fixtures and cheap to add — the rule set is meant to grow every time someone n
 | CON-01 | Merge strategy deviates from archetype | 4 of 5 sampled repos disagree |
 | CON-02 | `delete_branch_on_merge` disabled | `hq` |
 | CON-03 | Default branch is not `main` | unknown |
-| CON-04 | Team grants deviate from archetype | unknown |
+| CON-04 | Team grants deviate from archetype | **fires on 174 of 176 active repos** — only 2 conform |
 | CON-05 | No topics, or topics outside the controlled vocabulary | `mit-learn`, `ol-django`, `mitxonline` have none |
 | CON-06 | Missing LICENSE / README / SECURITY.md | unknown |
 | CON-07 | Archived repo still grants write to a team | unknown |

--- a/docs/plans/github-org-pulumi-import.md
+++ b/docs/plans/github-org-pulumi-import.md
@@ -844,7 +844,7 @@ fixtures and cheap to add — the rule set is meant to grow every time someone n
 | SEC-12 | Our own app's live permissions diverge from `docs/github-app-permissions.md` | — |
 | SEC-13 | Private repo with weaker controls than the public baseline | `hq` |
 | SEC-14 | No CODEOWNERS on a tier-1 repo | unknown |
-| SEC-15 | `admin` held by any team other than `odl-engineering-owners`, the sanctioned admin team (policy 2026-08-05) | **fires on 144 repos** (74 active, 70 archived) |
+| SEC-15 | `admin` held by a team outside the sanctioned set — currently `odl-engineering-owners` and `devops` (policy 2026-08-05) | **fires on 125 repos** (66 active, 59 archived) |
 
 ### Axis: Consistency
 

--- a/docs/plans/github-org-pulumi-import.md
+++ b/docs/plans/github-org-pulumi-import.md
@@ -844,7 +844,7 @@ fixtures and cheap to add — the rule set is meant to grow every time someone n
 | SEC-12 | Our own app's live permissions diverge from `docs/github-app-permissions.md` | — |
 | SEC-13 | Private repo with weaker controls than the public baseline | `hq` |
 | SEC-14 | No CODEOWNERS on a tier-1 repo | unknown |
-| SEC-15 | A broad team holds `admin` — `odl-engineering` must be `push` or `maintain` (policy 2026-08-05) | **fires on 116 repos** (61 active, 55 archived) |
+| SEC-15 | `admin` held by any team other than `odl-engineering-owners`, the sanctioned admin team (policy 2026-08-05) | **fires on 144 repos** (74 active, 70 archived) |
 
 ### Axis: Consistency
 

--- a/src/ol_infrastructure/substructure/github/repositories/data/archetypes.yaml
+++ b/src/ol_infrastructure/substructure/github/repositories/data/archetypes.yaml
@@ -40,6 +40,14 @@ archetypes:
     secret_scanning: enabled  # pragma: allowlist secret
     secret_scanning_push_protection: enabled  # pragma: allowlist secret
     default_branch: main
+    # Repo access comes from these grants and nothing else -- no individual holds a
+    # direct permission on a repo (§4.7). That makes the LEVEL here the whole access
+    # story rather than a detail.
+    #
+    # `odl-engineering` is capped at push (maintain is also acceptable; admin is not --
+    # policy 2026-08-05, audited as SEC-15). It is the broad engineering team, and admin
+    # carries repo deletion, settings changes and ruleset bypass. It currently holds
+    # admin on 116 repos, so this target is aspirational and phase-5 work, not reality.
     teams:
       odl-engineering: push
       odl-engineering-owners: admin


### PR DESCRIPTION
### What are the relevant tickets?

N/A — follows PR #5233, tracked in witan under `wp-import-the-mitodl-github-organization-into-pulum-47211a`.

### Description (What does it do?)

Two decisions that reinforce each other, plus the tooling and audit changes they imply. No GitHub state is modified.

**Pulumi manages teams, not individuals.** Neither `Membership` (who belongs to the org) nor `TeamMembership` (who belongs to a team) is imported. The organization payload drops **199 → 15** resources — 14 `Team` plus `OrganizationSettings`.

**Repo access comes from team membership only.** No individual holds a direct permission on a repository. `TeamRepository` is the sole path from a person to a repo, and all **169** of those stay managed.

The second rule is what makes the first one safe. Modelling people would only buy a security property if access flowed *through* those records — it doesn't. So what it actually bought was a declared roster, in exchange for a PR and a manual-approval apply on every hire, departure and team move. It also removes the highest-blast-radius resource in the estate: deleting a `Membership` evicts a human from the org, and not modelling something is a stronger guarantee than `protect=True`. The 39/39 seat ceiling stops being Pulumi's problem for the same reason — it can't fail on the 40th hire if it never adds one.

Given up, stated plainly: org membership and team rosters are **not declared in code**, so drift there is visible but not enforced. The crawl still records both — inventory feeding the audit, not Pulumi state.

#### This reverses an earlier conclusion

§9.3 concluded on 2026-08-03 to *keep* `Membership` and accept the onboarding cost. That section is marked superseded rather than rewritten, because the reasoning was sound on its own terms — what changed is a premise it treated as fixed. It also established things that still hold: the live seat count, the billing question, and audit rule DX-10, which matters **more** now that the audit is the only thing watching the ceiling.

#### The direct-collaborator backlog

The fleet does not satisfy rule 2 yet. Measured across all 316 repos:

| | |
|---|---:|
| Repos with ≥1 direct collaborator | **72** (43 active, 29 archived) |
| Total direct grants | **83** |
| — at `admin` | **73** |
| — at `write` | 10 |
| Distinct people | 20 |

**73 of 83 direct grants are `admin`.** The informal path to access isn't a lesser permission, it's the highest one. One person holds direct grants on 20 repos; a bot account (`odlbot`) holds admin on 7.

The crawl now records **who** holds each grant and at what level rather than counting them, so SEC-06 produces a migration list with a name and a target team instead of a number. The rule is fleet-wide — forks and archived included, no exemptions — since an `admin` grant on an archived repo is inert only until someone unarchives it.

Remediation is **phase 5**: it changes access, so it belongs downstream of a reviewed backlog rather than happening on the way past.

One convenient consequence: `RepositoryCollaborators` has no documented import in the provider schema (§5.2 flagged it as untrusted). Under rule 2 there is eventually nothing to import, so a provider gap stops mattering instead of needing a workaround.

### How can this be tested?

Requires the sops key for `src/bridge/secrets/pulumi/github_app.yaml`. Read-only.

```sh
uv run bin/github-org-inventory report --refresh
# -> "Direct collaborators (SEC-06)" section: 83 grants across 20 people, 73 admin / 10 write
# -> SEC-06 now reports "72 (23% of all repos)" rather than an active-only count

uv run bin/github-org-inventory imports
#    15 resources -> import-organization.json      (was 199)
#  1067 resources -> import-repositories.json      (unchanged)
```

Verified: the org payload contains only `Team` × 14 and `OrganizationSettings` × 1, with no `Membership` or `TeamMembership` entries; `import-repositories.json` still carries 169 `TeamRepository`; `crawl` regenerates the 316 per-repo files byte-identical, so none of this changes the fleet data.

### Additional Context

`_findings()` now has three scopes rather than two — active (default), archived (CON-07), and fleet-wide (SEC-06) — with each declared in a frozenset so the percentage denominator matches the population it is reporting on. Getting that wrong is how "94 of 138 archived" once rendered as "52% of active".
