### PR TITLE
fix(omnigraph): grant witan-token-sync the delegator binding Vault login needs

### DIFF
--- a/src/ol_infrastructure/applications/omnigraph/token_sync.py
+++ b/src/ol_infrastructure/applications/omnigraph/token_sync.py
@@ -250,9 +250,9 @@ def create_token_sync(  # noqa: PLR0913
     script_body = (Path(__file__).parent / "scripts" / SCRIPT_FILENAME).read_text()
 
     # Its own ServiceAccount rather than the namespace's existing two. The IRSA
-    # one carries S3 write access to the graph bucket and the VSO one carries
-    # system:auth-delegator; this pod needs neither, and reusing either would
-    # hand it a credential far broader than the single Vault write it makes.
+    # one carries S3 write access to the graph bucket, which this pod has no use
+    # for; reusing it would hand this job a credential far broader than the
+    # single Vault write it makes.
     service_account = kubernetes.core.v1.ServiceAccount(
         f"witan-token-sync-service-account-{stack_info.env_suffix}",
         metadata=kubernetes.meta.v1.ObjectMetaArgs(
@@ -260,6 +260,42 @@ def create_token_sync(  # noqa: PLR0913
             namespace=namespace,
             labels=k8s_global_labels,
         ),
+    )
+
+    # It does need the one thing the VSO account has, though. The cluster's
+    # Vault kubernetes auth backend is configured with no token_reviewer_jwt
+    # (vault_secrets_operator.py, infrastructure/aws/eks), so Vault
+    # authenticates each login by replaying the CALLER's own JWT against the
+    # Kubernetes TokenReview API -- which requires that caller's ServiceAccount
+    # to hold "system:auth-delegator" clusterwide. OLVaultK8SResources
+    # (components/services/vault.py) grants that binding only to the
+    # "{application_name}-vault" VSO sync account, since nearly every app in
+    # this repo reaches Vault only through the vault-secrets-operator. This job
+    # is the exception in the omnigraph namespace: sync_actor_tokens.py logs in
+    # directly as this ServiceAccount. Without the binding every login 403s with
+    # a bare {"errors":["permission denied"]} naming neither the role nor the
+    # missing permission -- see the CI bootstrap Job BackoffLimitExceeded this
+    # was written to fix. ol_analytics_api carries the same binding for the same
+    # reason.
+    auth_delegator_binding = kubernetes.rbac.v1.ClusterRoleBinding(
+        f"witan-token-sync-vault-cluster-role-binding-{stack_info.env_suffix}",
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            name=f"{SERVICE_ACCOUNT_NAME}:cluster-auth",
+            labels=k8s_global_labels,
+        ),
+        role_ref=kubernetes.rbac.v1.RoleRefArgs(
+            api_group="rbac.authorization.k8s.io",
+            kind="ClusterRole",
+            name="system:auth-delegator",
+        ),
+        subjects=[
+            kubernetes.rbac.v1.SubjectArgs(
+                kind="ServiceAccount",
+                name=SERVICE_ACCOUNT_NAME,
+                namespace=namespace,
+            ),
+        ],
+        opts=ResourceOptions(parent=service_account),
     )
 
     vault_policy = Policy(
@@ -351,6 +387,10 @@ def create_token_sync(  # noqa: PLR0913
 
     job_depends_on: list[Resource] = [
         service_account,
+        # Ordered explicitly: without the delegator binding in place first, the
+        # pod's very first Vault login 403s, and the Job burns its backoffLimit
+        # before Kubernetes has finished creating the binding.
+        auth_delegator_binding,
         vault_auth_role,
         keycloak_credentials_secret,
         script_config_map,


### PR DESCRIPTION
### What are the relevant tickets?
Follows #5280, which enabled `omnigraph:keycloak_url` in CI, QA and Production.

### Description (What does it do?)
#5280 turned the token-sync path on, and its first real run failed. `deploy-ol-application-omnigraph-ci/47` created 8 of the 9 new resources fine and then died on the bootstrap Job — every pod exited 1 within two seconds, three times, until `BackoffLimitExceeded`:

```
2026-08-05 21:45:24,116 ERROR sync-actor-tokens
POST https://vault-ci.odl.mit.edu/v1/auth/k8s-operations/login
failed: HTTP 403 {"errors":["permission denied"]}
```

Nothing about the Vault role was wrong. Read back from stack state, it is exactly what was intended:

```
roleName: witan-token-sync          backend: k8s-operations
boundServiceAccountNames: ['witan-token-sync']
boundServiceAccountNamespaces: ['omnigraph']
tokenPolicies: ['witan-token-sync']
```

and the pod ran as ServiceAccount `witan-token-sync` in namespace `omnigraph` — the exact binding.

The missing piece is on the Kubernetes side. This cluster's Vault kubernetes auth backend has no `token_reviewer_jwt` set, so Vault authenticates a login by replaying **the caller's own JWT** against the TokenReview API. That requires the calling ServiceAccount to hold `system:auth-delegator` clusterwide. `OLVaultK8SResources` grants that only to the `{application_name}-vault` VSO sync account, because nearly every app in this repo reaches Vault through the vault-secrets-operator and never logs in itself. `sync_actor_tokens.py` logs in directly, so it needs the same binding — and Vault reports its absence as a bare `permission denied` naming neither the role nor the missing permission.

Confirmed against the live cluster — the only omnigraph-namespace account with the binding is the VSO one:

```
$ kubectl -n omnigraph get clusterrolebindings ... (subjects in omnigraph)
omnigraph-vault:cluster-auth -> system:auth-delegator | subject: omnigraph-vault
```

`ol_analytics_api` already carries this binding, with a comment describing the identical CI failure — this is the second time the same cluster behaviour has bitten, so the comment here is written to be found by the next person who reads the 403.

Two changes:
1. Add the `witan-token-sync:cluster-auth` ClusterRoleBinding granting `system:auth-delegator` to the job's ServiceAccount.
2. Add it to `job_depends_on`. Without explicit ordering the bootstrap Job can start before the binding exists and burn its `backoffLimit` on the race — the same failure with a far more confusing cause.

The original comment above the ServiceAccount argued this pod needed neither existing account's privileges. It was right about the IRSA account's S3 write and wrong about the VSO account's delegator binding; corrected in place.

### How can this be tested?
`pulumi preview --stack CI` on this branch (the 8 resources #5280 already created stay put):

```
+  ClusterRoleBinding  witan-token-sync-vault-cluster-role-binding-ci   create
~  Job                 witan-token-sync-bootstrap-ci                    update
+  CronJob             witan-token-sync-ci                              create
-  Secret              omnigraph-actor-tokens-vault-secret-ci           delete[retain]
Resources: + 2 to create, ~ 1 to update, - 1 to delete, 42 unchanged
```

`pre-commit run --files src/ol_infrastructure/applications/omnigraph/token_sync.py` passes (ruff format, ruff check, mypy, detect-secrets).

⚠ **Operational note for whoever lands this.** The failed Job object `witan-token-sync-bootstrap-ci-f5ccfab6` is still in the CI cluster in `Failed` state. Its name is derived from a hash of the script + keycloak_url + realm, none of which this PR changes, so the name is unchanged and a failed Job does not re-run on its own. If the redeploy does not produce a fresh pod, delete it and let Pulumi recreate it:

```
kubectl --context operations-ci -n omnigraph delete job witan-token-sync-bootstrap-ci-f5ccfab6
```

### Additional Context
Still unverified after this merges, because the login never got far enough to exercise any of it — these are the checks to run on the CI job log before promoting to QA:

- Whether the Keycloak service account's `view-users` role actually suffices for `GET /admin/realms/<realm>/users` (verified from docs, never against a live realm).
- Whether service accounts are filtered correctly — the log should carry `skipping service account` lines naming `ol-opik-client` and `witan-token-sync` itself. `act-` entries appearing instead would mean the `serviceAccountClientId` assumption is wrong for this Keycloak version.
- Whether steady state is quiet — the second and later runs must log `actor-token map already matches Keycloak; nothing to write`. `wrote N actors` every hour would mean something is re-minting and bouncing omnigraph-server hourly.

`admin_token_provisioned: true` held throughout the failed deploy, so #5279's svc-witan-admin tokens were never at risk.
