### PR TITLE
feat(omnigraph): apply the Cedar policy bundles, ending default-deny

### DIFF
--- a/src/ol_infrastructure/applications/omnigraph/__main__.py
+++ b/src/ol_infrastructure/applications/omnigraph/__main__.py
@@ -147,6 +147,29 @@ TOKEN_SYNC_SCHEDULE = (
 )
 _TOKEN_SYNC_ENABLED = bool(KEYCLOAK_URL)
 
+# Cedar authorization is unconditional: cluster.yaml always carries the
+# `policies:` block. There is no per-environment gate because there is nothing
+# to stage — every environment finished its actor-token rollout on 2026-08-05,
+# and until a bundle is applied the graph is default-deny (only `read`
+# permitted), so an ungated environment is not a safer one, just an unusable
+# one.
+#
+# It does depend on token sync, and not advisorily: with a `policies:` block
+# and no bearer tokens omnigraph-server refuses to boot outright. Asserted here
+# rather than left to the data tier, because the failure it prevents is a
+# crash-looping server whose message ("policy file is configured but no bearer
+# tokens") points at the symptom, not at the environment that never enabled
+# sync. The SOPS-only service tokens would technically satisfy the server, but
+# they grant no human anything — the graph would be authenticated and unusable.
+if not _TOKEN_SYNC_ENABLED:
+    msg = (
+        "omnigraph:keycloak_url is unset, but the Cedar policy bundle is "
+        "always applied. Without per-user actor tokens every human user is "
+        "authenticated and then denied, and the server refuses to boot if the "
+        "token map is empty. Enable token sync for this environment first."
+    )
+    raise ValueError(msg)
+
 # Scheduled store maintenance (maintenance.py). Overridable per environment
 # because the two things that set the right cadence — write volume and how much
 # version history is worth keeping — differ between a CI store that is mostly

--- a/src/ol_infrastructure/applications/omnigraph/__main__.py
+++ b/src/ol_infrastructure/applications/omnigraph/__main__.py
@@ -54,8 +54,10 @@ from pulumi import Config, Output, ResourceOptions, export
 
 from bridge.secrets import sops as _bridge_sops
 from bridge.secrets.sops import read_yaml_secrets
-from ol_infrastructure.applications.omnigraph.data_tier import (
+from ol_infrastructure.applications.omnigraph.cluster_config import (
     COUNCIL_GRAPH_ID,
+)
+from ol_infrastructure.applications.omnigraph.data_tier import (
     OMNIGRAPH_SERVER_SERVICE_NAME,
     create_data_tier,
     omnigraph_server_addr,

--- a/src/ol_infrastructure/applications/omnigraph/cluster_config.py
+++ b/src/ol_infrastructure/applications/omnigraph/cluster_config.py
@@ -1,0 +1,177 @@
+"""Cluster catalog shape: the graph ids, schema/policy filenames, and the
+``graphs:`` / ``policies:`` blocks of the generated ``cluster.yaml``.
+
+Split out of ``data_tier.py`` so it can be imported without pulling in
+``pulumi_aws`` and the EKS/S3 components, which need AWS credentials and a
+region at import time. That makes this module unit-testable in CI, which
+matters more here than it looks: ``code_graph_id`` is a byte-for-byte shared
+contract with agent-kit's client-side ``witan_code.config.graph_id``, and
+``build_cluster_policies`` decides which Cedar bundle governs which graph — a
+graph that ends up in no bundle is not "open", it is default-deny, and it
+fails every write with an error pointing at policy rather than at the missing
+wiring. ``storage.py`` exists for the same reason.
+"""
+
+import hashlib
+import re
+
+# ── Cluster graph ids ────────────────────────────────────────────────────────
+#
+# Graph ids track the owning published package rather than the omnigraph
+# default branch name: omnigraph's default *branch* is `main`, so a graph also
+# called `main` conflates the two. `council` is what witan-council asks for
+# (WITAN_MEMORY_GRAPH, default `council` in agent-kit
+# mcp/servers/witan/witan/config.py) — a cluster that declares anything else
+# serves a graph no client addresses.
+COUNCIL_GRAPH_ID = "council"
+# Layer 2.5 cross-repo bridge, the deployed analogue of witan-code's local
+# `_bridge.omni` store. Fixed id, not derived from any repo.
+BRIDGE_GRAPH_ID = "code-bridge"
+CODE_GRAPH_PREFIX = "code-"
+
+# Schema filenames, all three baked into the omnigraph-server image at
+# CLUSTER_CONFIG_DIR by the image build (agent-kit
+# docker/omnigraph-server.Dockerfile). Not sourced here: this Pulumi program
+# has no access to agent-kit's working tree at apply time.
+COUNCIL_SCHEMA_FILE = "schema.pg"
+CODE_SCHEMA_FILE = "code-schema.pg"
+BRIDGE_SCHEMA_FILE = "bridge-schema.pg"
+
+# Cedar bundle filenames, baked into the image next to the schemas by the same
+# build and for the same reason. Their committed `groups:` are fixtures — the
+# image entrypoint rewrites membership from the mounted actor-token map before
+# `cluster apply`, because `witan-users` has to track the hourly token-sync
+# job's output and this program cannot see it. See agent-kit
+# mcp/servers/witan/policy/README.md § "Group membership is rendered at boot".
+MEMORY_POLICY_FILE = "memory.policy.yaml"
+CODE_POLICY_FILE = "code-graph.policy.yaml"
+BRIDGE_POLICY_FILE = "bridge.policy.yaml"
+SERVER_POLICY_FILE = "server.policy.yaml"
+
+_GRAPH_ID_MAX_LEN = 64
+
+
+def code_graph_id(repo: str) -> str:
+    """Canonical cluster graph id for ``repo``'s code graph.
+
+    e.g. ``https://github.com/mitodl/ol-django`` ->
+    ``code-github-com-mitodl-ol-django``.
+
+    SHARED CONTRACT — this is a mirror of ``witan_code.config.graph_id``
+    (agent-kit, mcp/servers/witan-code/witan_code/config.py), which is what
+    selects the ``--graph`` id on the *client* side. This function declares the
+    graph the cluster creates. They MUST agree byte-for-byte or a client will
+    address a graph that was never created. Any change has to land in lockstep
+    on both sides — see agent-kit task
+    tk-code-graph-deployment-topology-shared-per-repo-c-cac400.
+
+    Strips the URI scheme, collapses every run of non-alphanumerics to ``-``,
+    lowercases, and prefixes ``code-``. omnigraph graph ids must match
+    ``^[a-zA-Z0-9-]{1,64}$`` (note: no underscores), so ids that would exceed
+    64 characters are truncated and disambiguated with a hash of the full repo
+    URI, keeping distinct long repos from colliding.
+    """
+    body = re.sub(r"(?i)^[a-z][a-z0-9+.-]*://", "", repo)  # strip scheme
+    body = re.sub(r"[^a-zA-Z0-9]+", "-", body).strip("-").lower()
+    candidate = f"{CODE_GRAPH_PREFIX}{body}"
+    if len(candidate) <= _GRAPH_ID_MAX_LEN:
+        return candidate
+    digest = hashlib.sha256(repo.encode()).hexdigest()[:8]
+    keep = _GRAPH_ID_MAX_LEN - len(CODE_GRAPH_PREFIX) - len(digest) - 1
+    return f"{CODE_GRAPH_PREFIX}{body[:keep].strip('-')}-{digest}"
+
+
+def build_cluster_graphs(managed_repos: list[str]) -> dict[str, dict[str, str]]:
+    """Build the ``graphs:`` block of cluster.yaml for ``managed_repos``.
+
+    One graph per repo rather than one shared code graph (ADR-0009 follow-up,
+    decided: option A), matching the per-repo model witan-code already uses
+    locally. Each is a self-contained Lance store under
+    ``s3://<bucket>/graphs/<graph-id>.omni/``, so per-repo isolation costs
+    nothing beyond the entry here, and per-user/per-session WIP branches live
+    inside their own repo's graph.
+
+    Adding a repo is deliberately a config change rather than ad-hoc
+    self-creation by a client: an unmanaged repo should fail to resolve rather
+    than silently mint a graph nobody provisioned or backs up. The
+    ``cluster apply`` and server restart it requires are both automatic — the
+    converge Job and the Deployment's pod template share one config hash, so
+    editing this list creates the graph and restarts the server into it in the
+    same deploy.
+
+    Raises ``ValueError`` on a duplicate derived id — two repo URIs that
+    normalize to the same graph id would otherwise silently share one store.
+    """
+    graphs: dict[str, dict[str, str]] = {
+        COUNCIL_GRAPH_ID: {"schema": COUNCIL_SCHEMA_FILE},
+        BRIDGE_GRAPH_ID: {"schema": BRIDGE_SCHEMA_FILE},
+    }
+    for repo in managed_repos:
+        graph = code_graph_id(repo)
+        if graph in graphs:
+            msg = (
+                f"Duplicate cluster graph id {graph!r} derived from repo "
+                f"{repo!r}. Two managed repos normalize to the same id, which "
+                "would silently share one store."
+            )
+            raise ValueError(msg)
+        graphs[graph] = {"schema": CODE_SCHEMA_FILE}
+    return graphs
+
+
+def build_cluster_policies(
+    cluster_graphs: dict[str, dict[str, str]],
+) -> dict[str, dict[str, object]]:
+    """Build the ``policies:`` block of cluster.yaml for ``cluster_graphs``.
+
+    Wires the four Cedar bundles baked into the image onto the graphs they
+    govern. Derived from the graph map rather than rebuilt from
+    ``managed_repos`` so a graph can never exist without a bundle: an
+    ungoverned graph is not "open", it is default-deny, and it would fail every
+    write with an error pointing at policy rather than at the missing wiring.
+
+    APPLYING ANY BUNDLE IS A HARD CUTOVER TO AUTHENTICATED-EVERYTHING. With a
+    ``policies:`` block the server refuses to boot without bearer tokens
+    ("policy file is configured but no bearer tokens — every request would 401
+    because no token can ever match"), and once booted an actor with no grant
+    gets ``policy denied action '…' for unknown actor '…'``. Unconditional
+    rather than gated per environment because every environment finished its
+    actor-token rollout on 2026-08-05 and nothing is using the graphs yet —
+    ``__main__.py`` asserts token sync is enabled, which is the precondition
+    that actually matters.
+
+    The server bundle is scoped to ``cluster`` rather than to a graph:
+    ``graph_list`` binds to ``Omnigraph::Server::"root"``. It is deploy-time
+    only — omnigraph 0.8.1's offline ``policy validate``/``policy test`` load
+    every bundle under the per-graph engine and reject a server-scoped action,
+    so agent-kit's CI fixture deliberately omits it and it is validated here by
+    omnigraph-server at boot instead.
+    """
+    code_graph_ids = sorted(
+        graph
+        for graph, spec in cluster_graphs.items()
+        if spec["schema"] == CODE_SCHEMA_FILE
+    )
+    policies: dict[str, dict[str, object]] = {
+        "memory_rules": {
+            "file": f"./{MEMORY_POLICY_FILE}",
+            "applies_to": [COUNCIL_GRAPH_ID],
+        },
+        "bridge_rules": {
+            "file": f"./{BRIDGE_POLICY_FILE}",
+            "applies_to": [BRIDGE_GRAPH_ID],
+        },
+        "server_rules": {
+            "file": f"./{SERVER_POLICY_FILE}",
+            "applies_to": ["cluster"],
+        },
+    }
+    # Omitted entirely when no repo is managed: a bundle with an empty
+    # `applies_to` governs nothing, and declaring one reads as though the code
+    # graphs were covered when there are none.
+    if code_graph_ids:
+        policies["code_rules"] = {
+            "file": f"./{CODE_POLICY_FILE}",
+            "applies_to": code_graph_ids,
+        }
+    return policies

--- a/src/ol_infrastructure/applications/omnigraph/data_tier.py
+++ b/src/ol_infrastructure/applications/omnigraph/data_tier.py
@@ -191,6 +191,17 @@ COUNCIL_SCHEMA_FILE = "schema.pg"
 CODE_SCHEMA_FILE = "code-schema.pg"
 BRIDGE_SCHEMA_FILE = "bridge-schema.pg"
 
+# Cedar bundle filenames, baked into the image next to the schemas by the same
+# build and for the same reason. Their committed `groups:` are fixtures — the
+# image entrypoint rewrites membership from the mounted actor-token map before
+# `cluster apply`, because `witan-users` has to track the hourly token-sync
+# job's output and this program cannot see it. See agent-kit
+# mcp/servers/witan/policy/README.md § "Group membership is rendered at boot".
+MEMORY_POLICY_FILE = "memory.policy.yaml"
+CODE_POLICY_FILE = "code-graph.policy.yaml"
+BRIDGE_POLICY_FILE = "bridge.policy.yaml"
+SERVER_POLICY_FILE = "server.policy.yaml"
+
 _GRAPH_ID_MAX_LEN = 64
 
 
@@ -260,6 +271,64 @@ def build_cluster_graphs(managed_repos: list[str]) -> dict[str, dict[str, str]]:
             raise ValueError(msg)
         graphs[graph] = {"schema": CODE_SCHEMA_FILE}
     return graphs
+
+
+def build_cluster_policies(
+    cluster_graphs: dict[str, dict[str, str]],
+) -> dict[str, dict[str, object]]:
+    """Build the ``policies:`` block of cluster.yaml for ``cluster_graphs``.
+
+    Wires the four Cedar bundles baked into the image onto the graphs they
+    govern. Derived from the graph map rather than rebuilt from
+    ``managed_repos`` so a graph can never exist without a bundle: an
+    ungoverned graph is not "open", it is default-deny, and it would fail every
+    write with an error pointing at policy rather than at the missing wiring.
+
+    APPLYING ANY BUNDLE IS A HARD CUTOVER TO AUTHENTICATED-EVERYTHING. With a
+    ``policies:`` block the server refuses to boot without bearer tokens
+    ("policy file is configured but no bearer tokens — every request would 401
+    because no token can ever match"), and once booted an actor with no grant
+    gets ``policy denied action '…' for unknown actor '…'``. Unconditional
+    rather than gated per environment because every environment finished its
+    actor-token rollout on 2026-08-05 and nothing is using the graphs yet —
+    ``__main__.py`` asserts token sync is enabled, which is the precondition
+    that actually matters.
+
+    The server bundle is scoped to ``cluster`` rather than to a graph:
+    ``graph_list`` binds to ``Omnigraph::Server::"root"``. It is deploy-time
+    only — omnigraph 0.8.1's offline ``policy validate``/``policy test`` load
+    every bundle under the per-graph engine and reject a server-scoped action,
+    so agent-kit's CI fixture deliberately omits it and it is validated here by
+    omnigraph-server at boot instead.
+    """
+    code_graph_ids = sorted(
+        graph
+        for graph, spec in cluster_graphs.items()
+        if spec["schema"] == CODE_SCHEMA_FILE
+    )
+    policies: dict[str, dict[str, object]] = {
+        "memory_rules": {
+            "file": f"./{MEMORY_POLICY_FILE}",
+            "applies_to": [COUNCIL_GRAPH_ID],
+        },
+        "bridge_rules": {
+            "file": f"./{BRIDGE_POLICY_FILE}",
+            "applies_to": [BRIDGE_GRAPH_ID],
+        },
+        "server_rules": {
+            "file": f"./{SERVER_POLICY_FILE}",
+            "applies_to": ["cluster"],
+        },
+    }
+    # Omitted entirely when no repo is managed: a bundle with an empty
+    # `applies_to` governs nothing, and declaring one reads as though the code
+    # graphs were covered when there are none.
+    if code_graph_ids:
+        policies["code_rules"] = {
+            "file": f"./{CODE_POLICY_FILE}",
+            "applies_to": code_graph_ids,
+        }
+    return policies
 
 
 def omnigraph_server_addr(namespace: str) -> str:
@@ -402,6 +471,11 @@ def create_data_tier(  # noqa: PLR0913
         lambda name: storage_uri_for(name, storage_prefix)
     )
     cluster_name = f"mitodl-witan-{stack_info.env_suffix.lower()}"
+    # Appended after `graphs`, preserving the existing key order exactly: the
+    # ConfigMap's content feeds the config hash that restarts the server, so
+    # reordering keys would bounce the data tier on a deploy that changed
+    # nothing.
+    cluster_policies = build_cluster_policies(cluster_graphs)
     cluster_yaml_content: Output[str] = storage_uri.apply(
         lambda uri: yaml.dump(
             {
@@ -410,6 +484,7 @@ def create_data_tier(  # noqa: PLR0913
                 "state": {"backend": "cluster"},
                 "storage": uri,
                 "graphs": cluster_graphs,
+                "policies": cluster_policies,
             },
             sort_keys=False,
         )

--- a/src/ol_infrastructure/applications/omnigraph/data_tier.py
+++ b/src/ol_infrastructure/applications/omnigraph/data_tier.py
@@ -44,7 +44,6 @@ pulumi-provisioner's ``env_vars_from_files``).
 
 import hashlib
 import json
-import re
 from typing import NamedTuple
 
 import pulumi_aws as aws
@@ -52,6 +51,10 @@ import pulumi_kubernetes as kubernetes
 import yaml
 from pulumi import Output, ResourceOptions
 
+from ol_infrastructure.applications.omnigraph.cluster_config import (
+    build_cluster_graphs,
+    build_cluster_policies,
+)
 from ol_infrastructure.applications.omnigraph.maintenance import (
     OmnigraphMaintenance,
     create_maintenance,
@@ -168,167 +171,6 @@ PER_ACTOR_BYTES_MAX = 256 * 1024 * 1024
 # actually be needed, since the name is pinned and therefore identical across
 # the replacement. `depends_on` still orders the two.
 CLUSTER_CONFIGMAP_NAME = "omnigraph-cluster-config"
-
-# ── Cluster graph ids ────────────────────────────────────────────────────────
-#
-# Graph ids track the owning published package rather than the omnigraph
-# default branch name: omnigraph's default *branch* is `main`, so a graph also
-# called `main` conflates the two. `council` is what witan-council asks for
-# (WITAN_MEMORY_GRAPH, default `council` in agent-kit
-# mcp/servers/witan/witan/config.py) — a cluster that declares anything else
-# serves a graph no client addresses.
-COUNCIL_GRAPH_ID = "council"
-# Layer 2.5 cross-repo bridge, the deployed analogue of witan-code's local
-# `_bridge.omni` store. Fixed id, not derived from any repo.
-BRIDGE_GRAPH_ID = "code-bridge"
-CODE_GRAPH_PREFIX = "code-"
-
-# Schema filenames, all three baked into the omnigraph-server image at
-# CLUSTER_CONFIG_DIR by the image build (agent-kit
-# docker/omnigraph-server.Dockerfile). Not sourced here: this Pulumi program
-# has no access to agent-kit's working tree at apply time.
-COUNCIL_SCHEMA_FILE = "schema.pg"
-CODE_SCHEMA_FILE = "code-schema.pg"
-BRIDGE_SCHEMA_FILE = "bridge-schema.pg"
-
-# Cedar bundle filenames, baked into the image next to the schemas by the same
-# build and for the same reason. Their committed `groups:` are fixtures — the
-# image entrypoint rewrites membership from the mounted actor-token map before
-# `cluster apply`, because `witan-users` has to track the hourly token-sync
-# job's output and this program cannot see it. See agent-kit
-# mcp/servers/witan/policy/README.md § "Group membership is rendered at boot".
-MEMORY_POLICY_FILE = "memory.policy.yaml"
-CODE_POLICY_FILE = "code-graph.policy.yaml"
-BRIDGE_POLICY_FILE = "bridge.policy.yaml"
-SERVER_POLICY_FILE = "server.policy.yaml"
-
-_GRAPH_ID_MAX_LEN = 64
-
-
-def code_graph_id(repo: str) -> str:
-    """Canonical cluster graph id for ``repo``'s code graph.
-
-    e.g. ``https://github.com/mitodl/ol-django`` ->
-    ``code-github-com-mitodl-ol-django``.
-
-    SHARED CONTRACT — this is a mirror of ``witan_code.config.graph_id``
-    (agent-kit, mcp/servers/witan-code/witan_code/config.py), which is what
-    selects the ``--graph`` id on the *client* side. This function declares the
-    graph the cluster creates. They MUST agree byte-for-byte or a client will
-    address a graph that was never created. Any change has to land in lockstep
-    on both sides — see agent-kit task
-    tk-code-graph-deployment-topology-shared-per-repo-c-cac400.
-
-    Strips the URI scheme, collapses every run of non-alphanumerics to ``-``,
-    lowercases, and prefixes ``code-``. omnigraph graph ids must match
-    ``^[a-zA-Z0-9-]{1,64}$`` (note: no underscores), so ids that would exceed
-    64 characters are truncated and disambiguated with a hash of the full repo
-    URI, keeping distinct long repos from colliding.
-    """
-    body = re.sub(r"(?i)^[a-z][a-z0-9+.-]*://", "", repo)  # strip scheme
-    body = re.sub(r"[^a-zA-Z0-9]+", "-", body).strip("-").lower()
-    candidate = f"{CODE_GRAPH_PREFIX}{body}"
-    if len(candidate) <= _GRAPH_ID_MAX_LEN:
-        return candidate
-    digest = hashlib.sha256(repo.encode()).hexdigest()[:8]
-    keep = _GRAPH_ID_MAX_LEN - len(CODE_GRAPH_PREFIX) - len(digest) - 1
-    return f"{CODE_GRAPH_PREFIX}{body[:keep].strip('-')}-{digest}"
-
-
-def build_cluster_graphs(managed_repos: list[str]) -> dict[str, dict[str, str]]:
-    """Build the ``graphs:`` block of cluster.yaml for ``managed_repos``.
-
-    One graph per repo rather than one shared code graph (ADR-0009 follow-up,
-    decided: option A), matching the per-repo model witan-code already uses
-    locally. Each is a self-contained Lance store under
-    ``s3://<bucket>/graphs/<graph-id>.omni/``, so per-repo isolation costs
-    nothing beyond the entry here, and per-user/per-session WIP branches live
-    inside their own repo's graph.
-
-    Adding a repo is deliberately a config change rather than ad-hoc
-    self-creation by a client: an unmanaged repo should fail to resolve rather
-    than silently mint a graph nobody provisioned or backs up. The
-    ``cluster apply`` and server restart it requires are both automatic — the
-    converge Job and the Deployment's pod template share one config hash, so
-    editing this list creates the graph and restarts the server into it in the
-    same deploy.
-
-    Raises ``ValueError`` on a duplicate derived id — two repo URIs that
-    normalize to the same graph id would otherwise silently share one store.
-    """
-    graphs: dict[str, dict[str, str]] = {
-        COUNCIL_GRAPH_ID: {"schema": COUNCIL_SCHEMA_FILE},
-        BRIDGE_GRAPH_ID: {"schema": BRIDGE_SCHEMA_FILE},
-    }
-    for repo in managed_repos:
-        graph = code_graph_id(repo)
-        if graph in graphs:
-            msg = (
-                f"Duplicate cluster graph id {graph!r} derived from repo "
-                f"{repo!r}. Two managed repos normalize to the same id, which "
-                "would silently share one store."
-            )
-            raise ValueError(msg)
-        graphs[graph] = {"schema": CODE_SCHEMA_FILE}
-    return graphs
-
-
-def build_cluster_policies(
-    cluster_graphs: dict[str, dict[str, str]],
-) -> dict[str, dict[str, object]]:
-    """Build the ``policies:`` block of cluster.yaml for ``cluster_graphs``.
-
-    Wires the four Cedar bundles baked into the image onto the graphs they
-    govern. Derived from the graph map rather than rebuilt from
-    ``managed_repos`` so a graph can never exist without a bundle: an
-    ungoverned graph is not "open", it is default-deny, and it would fail every
-    write with an error pointing at policy rather than at the missing wiring.
-
-    APPLYING ANY BUNDLE IS A HARD CUTOVER TO AUTHENTICATED-EVERYTHING. With a
-    ``policies:`` block the server refuses to boot without bearer tokens
-    ("policy file is configured but no bearer tokens — every request would 401
-    because no token can ever match"), and once booted an actor with no grant
-    gets ``policy denied action '…' for unknown actor '…'``. Unconditional
-    rather than gated per environment because every environment finished its
-    actor-token rollout on 2026-08-05 and nothing is using the graphs yet —
-    ``__main__.py`` asserts token sync is enabled, which is the precondition
-    that actually matters.
-
-    The server bundle is scoped to ``cluster`` rather than to a graph:
-    ``graph_list`` binds to ``Omnigraph::Server::"root"``. It is deploy-time
-    only — omnigraph 0.8.1's offline ``policy validate``/``policy test`` load
-    every bundle under the per-graph engine and reject a server-scoped action,
-    so agent-kit's CI fixture deliberately omits it and it is validated here by
-    omnigraph-server at boot instead.
-    """
-    code_graph_ids = sorted(
-        graph
-        for graph, spec in cluster_graphs.items()
-        if spec["schema"] == CODE_SCHEMA_FILE
-    )
-    policies: dict[str, dict[str, object]] = {
-        "memory_rules": {
-            "file": f"./{MEMORY_POLICY_FILE}",
-            "applies_to": [COUNCIL_GRAPH_ID],
-        },
-        "bridge_rules": {
-            "file": f"./{BRIDGE_POLICY_FILE}",
-            "applies_to": [BRIDGE_GRAPH_ID],
-        },
-        "server_rules": {
-            "file": f"./{SERVER_POLICY_FILE}",
-            "applies_to": ["cluster"],
-        },
-    }
-    # Omitted entirely when no repo is managed: a bundle with an empty
-    # `applies_to` governs nothing, and declaring one reads as though the code
-    # graphs were covered when there are none.
-    if code_graph_ids:
-        policies["code_rules"] = {
-            "file": f"./{CODE_POLICY_FILE}",
-            "applies_to": code_graph_ids,
-        }
-    return policies
 
 
 def omnigraph_server_addr(namespace: str) -> str:

--- a/tests/ol_infrastructure/applications/omnigraph/test_cluster_policies.py
+++ b/tests/ol_infrastructure/applications/omnigraph/test_cluster_policies.py
@@ -1,0 +1,105 @@
+"""Tests for the Cedar ``policies:`` block of the generated cluster.yaml.
+
+The failure mode this guards is a graph that exists with no bundle governing
+it. That is not "open" — omnigraph is default-deny, so an ungoverned graph
+refuses every write with an error pointing at policy rather than at the missing
+wiring, and it looks identical to a policy that is simply too strict. Deriving
+the block from the graph map (rather than rebuilding it from ``managed_repos``)
+is what makes the two impossible to drift apart, so that is what is pinned.
+
+See agent-kit ``mcp/servers/witan/policy/README.md`` for the bundle contract.
+"""
+
+import pytest
+
+from ol_infrastructure.applications.omnigraph.data_tier import (
+    BRIDGE_GRAPH_ID,
+    COUNCIL_GRAPH_ID,
+    build_cluster_graphs,
+    build_cluster_policies,
+)
+
+REPOS = [
+    "https://github.com/mitodl/ol-infrastructure",
+    "https://github.com/mitodl/agent-kit",
+]
+
+
+def policies_for(repos: list[str]) -> dict[str, dict[str, object]]:
+    return build_cluster_policies(build_cluster_graphs(repos))
+
+
+class TestCoverage:
+    def test_every_graph_is_governed_by_exactly_one_bundle(self):
+        """The invariant: no graph ungoverned, none claimed twice.
+
+        A graph missing from every ``applies_to`` is default-deny with a
+        confusing error; a graph in two bundles trips omnigraph's "one bundle
+        per graph scope" selector at boot.
+        """
+        graphs = build_cluster_graphs(REPOS)
+        policies = build_cluster_policies(graphs)
+
+        governed = [
+            graph
+            for spec in policies.values()
+            for graph in spec["applies_to"]
+            if graph != "cluster"
+        ]
+
+        assert sorted(governed) == sorted(graphs)
+        assert len(governed) == len(set(governed))
+
+    def test_code_bundle_lists_every_code_graph(self):
+        policies = policies_for(REPOS)
+        assert policies["code_rules"]["applies_to"] == [
+            "code-github-com-mitodl-agent-kit",
+            "code-github-com-mitodl-ol-infrastructure",
+        ]
+
+    def test_memory_and_bridge_are_scoped_to_their_own_graph(self):
+        """The memory bundle must never govern a code graph, or vice versa.
+
+        They grant different actors entirely — witan-ci has no access to the
+        work graph, and witan-users' blanket `change` has no business on the
+        CI-owned code graphs.
+        """
+        policies = policies_for(REPOS)
+        assert policies["memory_rules"]["applies_to"] == [COUNCIL_GRAPH_ID]
+        assert policies["bridge_rules"]["applies_to"] == [BRIDGE_GRAPH_ID]
+
+    def test_server_bundle_is_cluster_scoped(self):
+        """`graph_list` binds to the server root, not to any graph."""
+        assert policies_for(REPOS)["server_rules"]["applies_to"] == ["cluster"]
+
+
+class TestEdgeCases:
+    def test_no_managed_repos_omits_the_code_bundle(self):
+        """An empty `applies_to` governs nothing but reads as though it did."""
+        policies = policies_for([])
+        assert "code_rules" not in policies
+        assert set(policies) == {"memory_rules", "bridge_rules", "server_rules"}
+
+    def test_code_graph_list_is_sorted(self):
+        """Unstable ordering churns the config hash, restarting the server."""
+        forward = policies_for(REPOS)["code_rules"]["applies_to"]
+        reversed_ = policies_for(list(reversed(REPOS)))["code_rules"]["applies_to"]
+        assert forward == reversed_
+
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("memory_rules", "./memory.policy.yaml"),
+            ("code_rules", "./code-graph.policy.yaml"),
+            ("bridge_rules", "./bridge.policy.yaml"),
+            ("server_rules", "./server.policy.yaml"),
+        ],
+    )
+    def test_bundle_paths_match_the_image_layout(self, name, expected):
+        """Paths are relative to the cluster config dir the image bakes into.
+
+        A rename on either side leaves the server unable to load the bundle,
+        which is a boot failure rather than a silent one — but it is a boot
+        failure in the data tier, so it is pinned on both sides.
+        """
+        assert policies_for(REPOS)[name]["file"] == expected

--- a/tests/ol_infrastructure/applications/omnigraph/test_cluster_policies.py
+++ b/tests/ol_infrastructure/applications/omnigraph/test_cluster_policies.py
@@ -12,7 +12,7 @@ See agent-kit ``mcp/servers/witan/policy/README.md`` for the bundle contract.
 
 import pytest
 
-from ol_infrastructure.applications.omnigraph.data_tier import (
+from ol_infrastructure.applications.omnigraph.cluster_config import (
     BRIDGE_GRAPH_ID,
     COUNCIL_GRAPH_ID,
     build_cluster_graphs,


### PR DESCRIPTION
### What are the relevant tickets?
Pairs with mitodl/agent-kit#186, which bakes the bundles into the omnigraph-server image. Unblocks the local→shared user migration.

### Description (What does it do?)
Every `omnigraph-server` in CI, QA and Production runs in **default-deny**: bearer tokens are configured but no Cedar policy bundle has ever been applied, and in that state omnigraph permits only `read`. Every write is refused. Verified live at the source rather than inferred from an error:

```
kubectl --context operations-ci -n omnigraph exec deploy/omnigraph-server -- \
  sh -c 'ls /etc/omnigraph/cluster/; find /etc/omnigraph -iname "*polic*"'
→ bridge-schema.pg  cluster.yaml  code-schema.pg  schema.pg
→ (find returns NOTHING)
```

`data_tier.py` said so outright in a comment: *"cluster.yaml declares no `policy:` block today"*. This is the change that ends that. It is why the CI code-graph indexer has never successfully written — 10 of its 14 repos fail on exactly this denial — and it blocks migrating any user onto the shared service.

This adds the `policies:` block, wiring the four bundles agent-kit bakes into the image onto the graphs they govern:

- `memory.policy.yaml` → `council`
- `bridge.policy.yaml` → `code-bridge`
- `code-graph.policy.yaml` → all 14 `code-*` graphs
- `server.policy.yaml` → cluster scope (`graph_list` binds to `Omnigraph::Server::"root"`)

**Derived from the graph map, not rebuilt from `managed_repos`.** That is the point of `build_cluster_policies` taking `cluster_graphs`: a graph can never exist without a bundle governing it. An ungoverned graph is not "open" — it is default-deny, and it fails every write with an error pointing at policy rather than at the missing wiring, which is indistinguishable from a policy that is merely too strict. The test pins that invariant directly (every graph governed exactly once).

**Unconditional rather than gated per environment.** All three finished their actor-token rollout earlier today and nothing is using the graphs yet, so an ungated environment is not a safer one — just an unusable one. What is asserted instead is the precondition that actually matters: token sync must be enabled, because with a `policies:` block and no bearer tokens the server *refuses to boot*. Failing in `pulumi preview` with that sentence beats a crash-looping data tier whose own message ("policy file is configured but no bearer tokens") points at the symptom rather than at the environment that never enabled sync.

**Group membership is deliberately not templated here.** `witan-users` has to track the actor set the hourly token-sync CronJob writes to `secret-operations/witan/actor-tokens`, and this program cannot see it — the job owns that Vault path, not the stack. Membership is rendered at boot by the image entrypoint from the mounted token map; the `actor-tokens` VaultStaticSecret already restarts the server on exactly the event that changes the actor set, so the two can never disagree. See agent-kit `mcp/servers/witan/policy/README.md` § "Group membership is rendered at boot".

### How can this be tested?
`pulumi preview --stack CI` on this branch (rebased onto #5284):

```
+ policies: {
    + bridge_rules: { applies_to: ["code-bridge"],  file: "./bridge.policy.yaml" }
    + code_rules:   { applies_to: [14 code-* graphs], file: "./code-graph.policy.yaml" }
    + memory_rules: { applies_to: ["council"],      file: "./memory.policy.yaml" }
    + server_rules: { applies_to: ["cluster"],      file: "./server.policy.yaml" }
  }
Resources: ~ 1 to update, +-2 to replace, 3 changes. 42 unchanged
```

No deletions. The two replacements are the cluster-config ConfigMap (`delete_before_replace`, as it already was) and the converge Job, which shares the config hash — so apply and restart move together, exactly as the existing comment describes.

Unit tests: `tests/ol_infrastructure/applications/omnigraph/test_cluster_policies.py`, 10 cases covering the every-graph-governed-once invariant, memory/bridge scoping (the memory bundle must never govern a code graph — they grant different actors entirely), cluster scope for the server bundle, the no-managed-repos case, sort stability (unstable ordering churns the config hash and restarts the server), and the bundle paths against the image layout.

`pre-commit run` passes (ruff format, ruff check, mypy, detect-secrets).

### Additional Context
★ **Deploy ordering.** This must not reach an environment before an omnigraph-server image built from mitodl/agent-kit#186 does. The bundle files are baked into that image; referencing them from cluster.yaml against an older image leaves the server unable to load a declared policy file.

Two things to watch on the first environment, neither covered by any test:

1. **The converge job is the first thing that becomes Cedar-gated.** `CLUSTER_APPLY_ACTOR = "svc-witan-admin"` was passed specifically so that *"if a policy bundle is added later the job fails loudly (denied) rather than silently writing as nobody"* — that comment is now load-bearing. Existing environments have their graphs already so `apply` should be a no-op, but a **new** environment's first boot is the untested path.
2. **`witan-service` renders empty.** `svc-witan` is not provisioned anywhere (`tk-provision-act-svc-witan`), so its rules — including `schema_apply` on the memory graph — grant nobody. `witan-admin` holds `schema_apply` and is provisioned everywhere, so schema convergence is covered; this is called out so the empty group is not mistaken for a bug later.
