### PR TITLE
feat(witan): provision svc-witan, the MCP tier's own service account (fixes CI omnigraph crashloop)

### DIFF
--- a/docs/witan-service-account-runbook.md
+++ b/docs/witan-service-account-runbook.md
@@ -1,0 +1,147 @@
+# `svc-witan` — the MCP serving tier's service account
+
+The third and last of witan's non-human principals, alongside `svc-witan-ci`
+(the code-graph pipeline) and `svc-witan-admin` (break-glass maintenance).
+
+## What it is for
+
+The serving tier asks the omnigraph-server a small number of questions *about the
+server* rather than of a graph. The one that matters is `omnigraph graphs list`:
+
+- `witan_code.store.ensure_store` runs it before a write, to confirm the cluster
+  actually declares the target graph.
+- It backs the `code_indexed_repos` MCP tool.
+
+That listing is server-scoped — Cedar action `graph_list`, bound to
+`Omnigraph::Server::"root"` — so it belongs to no actor and happens *before*
+`witan_code.ingest._client` swaps in the requesting user's token. It therefore
+authenticates as the service or not at all, and an omnigraph-server booted with
+`OMNIGRAPH_SERVER_BEARER_TOKENS_FILE` rejects an absent token.
+
+Until this account existed the tier borrowed `svc-witan-ci` for it. That was not
+a privilege escalation — the actor swap in `_client` is unconditional and
+`WITAN_CODE_INDEX_ROLE` stays `client`, so the CI role's one real privilege
+(writing a graph's shared default-branch view) was never reachable from the tier
+— but it attributed the serving tier's enumerations to the data pipeline, and it
+meant rotating the CI token took the tier's code-graph reads down with it.
+
+## Why it is required, not optional
+
+`svc-witan-admin` is opt-in: an environment without it keeps running maintenance
+as `svc-witan-ci`. **`svc-witan` is not.**
+
+witan's Cedar bundles all declare a `witan-service` group, and
+`omnigraph-policy` refuses to start the server on a group with no members:
+
+```
+Error:
+   0: policy group 'witan-service' must not be empty
+   crates/omnigraph-policy/src/lib.rs:302
+```
+
+The bundles are applied unconditionally in every environment (see
+`applications/omnigraph/cluster_config.py`), and the image entrypoint renders
+group membership from the live actor-token map at boot
+(agent-kit `mcp/servers/witan/policy/render_groups.py`). So an environment whose
+token map has no `svc-witan` entry produces an empty `witan-service` group and a
+**crash-looping data tier** — the server logs `serving omnigraph` and then exits,
+which reads like a healthy start right up until the pod restarts.
+
+This is not hypothetical: it took CI down on 2026-08-06 between the Cedar bundles
+landing and this account being provisioned.
+
+The omnigraph stack therefore hard-fails the deploy when the keys are missing,
+so the message names the missing SOPS keys instead of leaving an operator to
+work backwards from a CrashLoopBackOff.
+
+## Provisioning it (per environment)
+
+1. **Mint a token and put it in SOPS.** Two keys, and they must match:
+
+   ```bash
+   openssl rand -hex 32
+   sops src/bridge/secrets/omnigraph/secrets.<env>.yaml
+   ```
+
+   ```yaml
+   ci_token: <unchanged>
+   admin_token: <unchanged>
+   service_token: <new value>
+   actor_tokens:
+     svc-witan-ci: <unchanged>
+     svc-witan-admin: <unchanged>
+     svc-witan: <the same new value>
+   ```
+
+   It must differ from **both** `ci_token` and `admin_token`, and the stack
+   refuses the deploy otherwise. Cedar tells these principals apart by actor id
+   alone, so a shared value is one principal holding the union of both sets of
+   grants while the bundle still shows them as separate groups. That matters
+   most here: the serving tier is the only principal holding a credential while
+   serving user traffic.
+
+   Non-interactively (which never prints the value):
+
+   ```bash
+   tok="$(openssl rand -hex 32)"
+   f=src/bridge/secrets/omnigraph/secrets.<env>.yaml
+   sops set "$f" '["service_token"]' "\"${tok}\""
+   sops set "$f" '["actor_tokens"]["svc-witan"]' "\"${tok}\""
+   unset tok
+   ```
+
+2. **Deploy the omnigraph stack.** This writes
+   `secret-operations/witan/service-token`, adds the actor to
+   `secret-operations/witan/service-tokens`, and exports
+   `service_token_provisioned: true`.
+
+   The entry has to reach `actor-tokens` and then omnigraph-server before it
+   authenticates anywhere — the server hashes its token map once at boot and
+   never re-reads it. With token sync **on** (every environment, as of
+   2026-08-05) the hourly CronJob merges service-tokens into actor-tokens; force
+   it rather than waiting:
+
+   ```bash
+   kubectl -n omnigraph create job witan-token-sync-manual --from=cronjob/witan-token-sync
+   kubectl -n omnigraph logs job/witan-token-sync-manual
+   ```
+
+   The `actor-tokens` VaultStaticSecret carries
+   `rolloutRestartTargets: [omnigraph-server]`, so the server restarts itself
+   once the map changes and re-renders `witan-service` with a member. Expect a
+   brief data-tier outage — single replica, `strategy=Recreate`.
+
+3. **Deploy the witan stack.** It picks up `service_token_provisioned` and moves
+   the `witan-code-token` Secret from `witan/ci-token` to `witan/service-token`.
+   The MCPServer spec is unchanged: the credential already had its own Secret
+   precisely so this move would be a one-line path change.
+
+## Verifying
+
+```bash
+# The group is populated and the server stayed up
+kubectl -n omnigraph logs deploy/omnigraph-server | grep render-policy-groups
+#   ... memory.policy.yaml [witan-users=33, witan-service=1, witan-admin=1]
+kubectl -n omnigraph get deploy omnigraph-server   # READY 1/1, no restarts
+
+# The tier is using its own identity
+kubectl -n witan get secret witan-code-token -o jsonpath='{.metadata.name}'
+pulumi stack output service_token_provisioned --stack <CI|QA|Production>
+```
+
+A `witan-service=0` in that log line is the failure this account exists to
+prevent — the server will exit immediately after.
+
+## Rotating
+
+Same as minting: change both keys to a new value, deploy the omnigraph stack,
+force the sync job, then deploy witan. Because the two keys are checked against
+each other, a half-rotation fails the deploy rather than reaching the cluster.
+
+## Related
+
+- `docs/witan-admin-break-glass-runbook.md` — `svc-witan-admin`, same shape,
+  opt-in rather than required.
+- `docs/witan-token-sync-runbook.md` — how service tokens reach `actor-tokens`.
+- agent-kit `mcp/servers/witan/policy/` — the Cedar bundles and the boot-time
+  membership renderer.

--- a/src/bridge/secrets/omnigraph/secrets.ci.yaml
+++ b/src/bridge/secrets/omnigraph/secrets.ci.yaml
@@ -3,7 +3,9 @@ ci_token: ENC[AES256_GCM,data:2yBmqrgx5BXoUFjJsUAkENS+HyZaqkoXa3PtQC5UxpzG7WvwFw
 actor_tokens:
   svc-witan-ci: ENC[AES256_GCM,data:CMzi/oQyJeo3arQTW1s672sT4D9Z2WxrecgcA4iqtp2oowQJyYXvX6S4tQ==,iv:0O96buddDaCBLXcu6byIa9SCu8rbwxr1oD7vdmMgb3A=,tag:qfp2dtwcY0mMMzq9xFN+bg==,type:str]
   svc-witan-admin: ENC[AES256_GCM,data:X/yCkaYLbXN+xjdHCVciroaw/JaiacYmavkfrs8RIs17YBqKQA6rHY6Q2nmrMrpdU00S511A8l4IWqsZ/eckkw==,iv:t/4X/BfIqlaQb8vTPJ4M2ZKsRDUDkXu0U0tXMQHhyjI=,tag:cGdRAoadO4EuVh9Txba4Ug==,type:str]
+  svc-witan: ENC[AES256_GCM,data:2JJlP7aWdgv3jvb3iNu+hCBbC5yCSe2et98kV8Z+VkshXYkhZyk30IAqkeH6Qc/BE+Du8w166TPwuH+UfnFU6w==,iv:fxLxGG71lR2pWNv127rxhnLIe7n8TzhCSULJ6dKS6Ec=,tag:7hcqGGH45j+fw3UyKB5Cxg==,type:str]
 admin_token: ENC[AES256_GCM,data:fVOmTm5sl8WOlGdtod2xoy+I8fEGnXAX7dT8460+JVptPksbU/2RUkXsXJyXpow684FgmlhJJLPjPNoPjkSLVg==,iv:mhstfHfMdG+Q1IXvsrreeWTF02TvBdb2kazrLpg999M=,tag:0qUqneziLI9XJOqqvuESIQ==,type:str]
+service_token: ENC[AES256_GCM,data:4jWqfEFao/q3mhUOfR5TEjJoHHL83j8NyOMwaBu8WS/TNBUfUXHl6M/1tERZFr3FEgw0EQqb6hgPZTWC1cBoZQ==,iv:o5QyraZFf7hAXjtJ/ZJWrl/V1BrEL3Gdh02fVAhj3yw=,tag:n+zpvFa+NMLxBJQeAovi+Q==,type:str]
 sops:
   hc_vault:
   - created_at: "2026-07-31T15:22:32Z"
@@ -16,7 +18,7 @@ sops:
     aws_profile: ""
     created_at: "2026-07-31T15:22:32Z"
     enc: AQICAHhMkpkBpCvmFjhyfy75ENALRrbg42uOs9cUsFNLXqPnagGvNoe+jzxsGO4erFHPzX/5AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMmTMEt3pPuQmKDQEkAgEQgDv9R2nQjDrc4iEMfENvbSK+VTnskrdnUfEZShH2NlKeampTSG/Rg8PfNXtWdMGOgG+n0euyemB2fuiXSQ==
-  lastmodified: "2026-08-05T20:47:43Z"
-  mac: ENC[AES256_GCM,data:lkEoyRjdkO9na+GygjIzt4+4JIxL2/r3+e6zHBgRXtiNV54sveSuMye6N4tNBbWPauaAb7z/VlNOYUM3alMtwhYZf0dc97h7h1n4gY5xfyTLEcawlnuNS89wsGOSLRysUAv+laDOWs/x/mysZYYHeFRnt523FeDhD7AQW97VWpg=,iv:rUEx0LIumvI7HUv6E5qkmYeUcO2cTp2aRHoLhBzN4u0=,tag:4oJCbcglyghjqaDWp9Tfow==,type:str]
+  lastmodified: "2026-08-06T00:55:51Z"
+  mac: ENC[AES256_GCM,data:Ve/dd9E3aJPRFgWUe4jtWq99yw+xpnymJh4N+VLgPVYlms4dDqnv0M3glvH5Hjet9G3Y9ADCMvP/H+zT3MEvNIw5qddxccVQ/RHuujOr4rUrLWqRjO+DBFdHHJF57kNzSpYnIYYz/aI0+wKX33wyDl/JjjgaUpVf56M7OZVn8VY=,iv:4IREze1MjTfSVzIJYHKTfFHM1mcCjfFUNgSZXp99n/0=,tag:QzEpQCvYS6Ci9Ui5V23erw==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.13.3

--- a/src/bridge/secrets/omnigraph/secrets.production.yaml
+++ b/src/bridge/secrets/omnigraph/secrets.production.yaml
@@ -3,7 +3,9 @@ ci_token: ENC[AES256_GCM,data:QBK1a1NSedW9E+jCGdp97KOeGRJB3RWiMNW4kMQutBU36Of4Si
 actor_tokens:
   svc-witan-ci: ENC[AES256_GCM,data:BLUr2vuEZDxHd/kFIACCbtC48FWaCKMcqGjTs8veICOw1YzVWfhiKRVThA==,iv:+sP59AytweaLC1s7ex8JEpUr6EQAfMwTdaIsE++tqZo=,tag:W8qIEtqfpl6iQU5AzcrA7Q==,type:str]
   svc-witan-admin: ENC[AES256_GCM,data:NExzPUqTt12o6jOsA/W95cQNzYWLqiLQWBVzdcSad+YImwKSGhhC39LrXEYGxnnG5CUnivpHiSsUmMQ0QtxzmA==,iv:hg+WPZy2ndjqiM+TX1+imKZm36ggirSGU+/6wNwiA5c=,tag:wM5H9tvLvSX2y8t0+Objgw==,type:str]
+  svc-witan: ENC[AES256_GCM,data:SnCTEC1nQSuaggE/batKNSjGx0te8QIxv0ryMVK41m9OMrTwY+rFMsaJ8p3ed6ZnIV6k56coxfAfJmoCNAqBrw==,iv:YgNrP8LS8jnlMMDXHNRtpNwL6GHDLpsihiAxiKrJRhU=,tag:7CEgUVVTw1vqj6EZTvEnqw==,type:str]
 admin_token: ENC[AES256_GCM,data:1eoGX3UkU2ReNPnixUMwSw5/iZj24eIYTm2A13/A3PmSV5gC5tdV+/4CIU4YD7LLsLzrA4yRHOpadj+/QAJqPQ==,iv:93p9DORffTF3b1SiOCK48WDjNeH3Gh5K18umsRWRj3E=,tag:KuyZcbKS5kP9RvFU2ki0CQ==,type:str]
+service_token: ENC[AES256_GCM,data:AEyPoF2bsahZ9Rzvom4PUUwdxEGHeQagxVht3yBB3Obuwf8t9CuU8frHAPWfxt8UZfwDo/QbAiE9wUlFajrgjg==,iv:C5AGz1SErQsyfbieKSMZki3/TTZu2uAt3X1EZqtN1SM=,tag:JPvr2IePIAuVNy2P/ypE8Q==,type:str]
 sops:
   hc_vault:
   - created_at: "2026-07-31T15:21:56Z"
@@ -16,7 +18,7 @@ sops:
     aws_profile: ""
     created_at: "2026-07-31T15:21:56Z"
     enc: AQICAHjksIVfl1VtAHpBda/1YYjj6tSeS2o4TXgvEEyBIXLjjwGGmI6uTLc+d4E49Qm7p2a9AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMJtOzE5pKoHw7VbZnAgEQgDsU9THs15uO2iIzFmkI/J1k8SJciKbDffrObKc1VZZrr3BOsq2k7TvWBBrBhcBBNts5fm5Ay+JnL2M2Kw==
-  lastmodified: "2026-08-05T20:48:50Z"
-  mac: ENC[AES256_GCM,data:cLrteiteVFYE8GF02LsMaEnoNGmVcSMyGF889TXTGudnn2BUrItjfRE9Ds0uI5yWAXOcYj5REZlNvI5CWRk0bRNt3NyO7hAHInsMx8da3apFiEDmhvF6HhcwJtiFSLRcYzHbiRxcVy2AS257H5GozroHT7IqLbcMOoPeKSEmWr8=,iv:jef/LFYqB/4KC0JzW5xspo/mcycyPUFadyvNK++6Ghc=,tag:uHOIWmEQk9FTvaqJJ1YlNw==,type:str]
+  lastmodified: "2026-08-06T00:55:51Z"
+  mac: ENC[AES256_GCM,data:tXxiHM6cb+zeJl3uKnuTS5yyf4S/7ZEG5Dhwc01XDbg4vA6IasGjKkekMKa+uOM/8SOylcGJOfM+iBnXx88aa64MZ+6GJjyHHiT77QJZfKw3VP2HckJ3G5Vxjx6ECZwyMlc2ySiULmpP4JEy2Avp4eCF/dMW5FTN5EpRLlewj0Q=,iv:mmRJerL8U2wsakbkK1RDtSvnU1fyi+D5BSDHATbS/VQ=,tag:4AYx3R2+zoh64FgJ3FCaXw==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.13.3

--- a/src/bridge/secrets/omnigraph/secrets.qa.yaml
+++ b/src/bridge/secrets/omnigraph/secrets.qa.yaml
@@ -3,7 +3,9 @@ ci_token: ENC[AES256_GCM,data:nssIKN1asjwmcMWI7Im8+zRxay4Ml+eC0fsFrtMal8Ee5sMBfk
 actor_tokens:
   svc-witan-ci: ENC[AES256_GCM,data:PB4Q54yV5Su0oDs0g/6cj+eR4SyfZzd78qXxkCqUYtwYXs+JU9pfKJB+WQ==,iv:X0bVMjkXssWD42oIw90o2r85RgaYY1hPXqxnjwgjK7A=,tag:GTYlQvE8ZidFBCao4a2oxQ==,type:str]
   svc-witan-admin: ENC[AES256_GCM,data:m6R/pdTucue+q4Qu932/r36i4xyZyY181UchWPA1ed6S4+c4LsvETapGaHTK7o0xdiWzr7cKELnE36YQVA+NkQ==,iv:Q5K9sms0Bti0QJvYbMSpqFiZaZaLaGoCCaHlaQPGkfE=,tag:9NDyZh2eIJZFWQDim9cbsA==,type:str]
+  svc-witan: ENC[AES256_GCM,data:IwkCO3Io0/zgZwZ2iJbSsclDjRI37VFZj4ufTYU63tkVNJq4Kdy1hB8f1oTB4xe6BYFROgM3vyxQQXAhypvjVg==,iv:ABpMxfO1qihnu3ps6RX3/81Pde/zIx0bjAHtlLFbPZw=,tag:d3im3AhoWE5WLsWmrhet9g==,type:str]
 admin_token: ENC[AES256_GCM,data:i3D0fypcBYotem602/14ZrvGTZSOSPae9oXj9WZkk6w5/e2mW6nRXYrjh/tmO/RD0HPvO0HFeUbciSEjtq5RJQ==,iv:4aLvLlWv97k3t93T+hQZAp9XcJK/2F3tchAsZy9imz4=,tag:U3PzpvmXMjML7hC2GAYqQg==,type:str]
+service_token: ENC[AES256_GCM,data:PVtqE+lawTK8SMtS2d5KTVE+M45jPz6KuMxsHT+9MEOexuBR0hAG18oyF4lT8mP3jEUvifq2VrK/8nQzxJgKQA==,iv:Zw9xqDL/S0L6rGeLpaUr3QnNv0a7Cn0YJaQDCSfpQHo=,tag:zdRy0wJEoRSbyLvTQC84Gg==,type:str]
 sops:
   hc_vault:
   - created_at: "2026-07-31T15:22:14Z"
@@ -16,7 +18,7 @@ sops:
     aws_profile: ""
     created_at: "2026-07-31T15:22:14Z"
     enc: AQICAHjE+jMY5DL7M1LMYX6YgtMueHEDNg05lsdN5Z0zeGHyJgE8atmiP3X+tc5NqCG+VRcVAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM045vR2toFS95GGXfAgEQgDvIai57QKgeLJClef57UOUY8SleOglRWh0ZEQRjFDs9k/J1pwbjpCjeu4zuyIPRguAntbiqWlrN77vs0A==
-  lastmodified: "2026-08-05T20:48:39Z"
-  mac: ENC[AES256_GCM,data:dndCg2e5PGpc3qwURjZg/YkQ+3rBTervIdSfgIBAm8VrRybigE9yXW6VlQbe0zI+LOPnbJzpyzaQrNFZ7o5LKb643JhauFI1eXawp3t6Kw7Vg9Qiz5V/uiXeN3wc+eewDMXU0U3qIv9ecfJD9NZd3153e4tLBOV0+kNzNxZKTro=,iv:J7wwvuSPyECLMR4cKTW2XOReyBx4AWc5As594JNZhLo=,tag:vJ9mZEWFtR3ZWzBTFZ14kw==,type:str]
+  lastmodified: "2026-08-06T00:55:51Z"
+  mac: ENC[AES256_GCM,data:lc+a8/hFpozPsolkY68u9BvidiTYq1NOCVYtlgjuXM7qsclO4VSCxMI8/OSh8MO1wKg2e2VhEjKDjvFvKW/mMzAR3HgpyrkMjI5iw3/MNjbDigmBvFeWl/Z5M8Ngfs29phSN9B8ATMRZkAf1yrlDf6umVNaS7LDQgweWp54w5o0=,iv:MRr/55zTPkt4xYqe8ve9gWzBUnCZSm95vAdGxB/v/2A=,tag:ymvZw1ghbvn7rkJAodvIxw==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.13.3

--- a/src/ol_infrastructure/applications/omnigraph/__main__.py
+++ b/src/ol_infrastructure/applications/omnigraph/__main__.py
@@ -254,6 +254,31 @@ WITAN_ADMIN_TOKEN_VAULT_PATH = "secret-operations/witan/admin-token"  # noqa: S1
 WITAN_ADMIN_TOKEN_VAULT_KEY = "token"  # noqa: S105  # pragma: allowlist secret
 WITAN_ADMIN_ACTOR_ID = "svc-witan-admin"
 
+# The MCP serving tier's own account — the third and last of the non-human
+# principals, same shape as the two above.
+#
+# It exists for the questions the tier asks *about* the server rather than of a
+# graph: `omnigraph graphs list`, which witan_code.store.ensure_store runs before
+# a write to confirm the cluster declares the target graph, and which backs
+# code_indexed_repos. That listing is server-scoped (Cedar `graph_list`), belongs
+# to no actor, and happens before witan_code.ingest._client swaps in the
+# requesting actor's token — so it authenticates as the service or not at all.
+# Until now the tier borrowed svc-witan-ci for it, which worked but attributed
+# the serving tier's enumerations to the code-graph pipeline and coupled the two
+# credentials' rotation.
+#
+# NOT OPTIONAL, unlike the admin principal — and this is the one real difference
+# between them. witan's Cedar bundles all declare a `witan-service` group, and
+# omnigraph-policy REFUSES TO BOOT on a group with no members ("policy group
+# 'witan-service' must not be empty", crates/omnigraph-policy/src/lib.rs:302).
+# Since the bundles are now applied unconditionally in every environment, an
+# environment without this token is a crash-looping data tier, not a degraded
+# one. The all-or-nothing checks below are therefore hard requirements wherever
+# a SOPS file exists at all, rather than the opt-in pair `admin_token` gets.
+WITAN_SERVICE_TOKEN_VAULT_PATH = "secret-operations/witan/service-token"  # noqa: S105  # pragma: allowlist secret
+WITAN_SERVICE_TOKEN_VAULT_KEY = "token"  # noqa: S105  # pragma: allowlist secret
+WITAN_SERVICE_ACTOR_ID = "svc-witan"
+
 ##############################################
 #   Vault secret source (SOPS -> Vault)       #
 ##############################################
@@ -363,10 +388,67 @@ if (_BRIDGE_SECRETS_DIR / _witan_secrets_path).exists():
             "the server while looking separate here."
         )
         raise ValueError(msg)
+
+    # svc-witan, the serving tier's own account. REQUIRED, not opt-in — see
+    # WITAN_SERVICE_TOKEN_VAULT_PATH: the Cedar bundles declare a
+    # `witan-service` group in every environment, and omnigraph-policy refuses
+    # to start on an empty group. A SOPS file without these keys is a
+    # crash-looping data tier, so this fails the deploy instead, where the
+    # message names the missing keys rather than leaving an operator reading
+    # "policy group 'witan-service' must not be empty" out of a CrashLoopBackOff.
+    _witan_service_token = _witan_secrets_source.get("service_token")
+    _mapped_service_token = _actor_tokens_map.get(WITAN_SERVICE_ACTOR_ID)
+
+    for _label, _value in (
+        ("service_token", _witan_service_token),
+        (f"actor_tokens['{WITAN_SERVICE_ACTOR_ID}']", _mapped_service_token),
+    ):
+        if _value is None or not str(_value).strip():
+            msg = (
+                f"omnigraph/secrets.{stack_info.env_suffix}.yaml: {_label} is "
+                "missing or empty, and it is required — witan's Cedar bundles "
+                "declare a 'witan-service' group in every environment, and "
+                "omnigraph-server refuses to boot on a group with no members. "
+                "Mint one with `openssl rand -hex 32` and set both keys to it "
+                "(see docs/witan-service-account-runbook.md)."
+            )
+            raise ValueError(msg)
+
+    if _mapped_service_token != _witan_service_token:
+        msg = (
+            f"omnigraph/secrets.{stack_info.env_suffix}.yaml: service_token must "
+            f"match actor_tokens['{WITAN_SERVICE_ACTOR_ID}'] — they are the same "
+            "token exposed to two different consumers, exactly as ci_token and "
+            "admin_token are."
+        )
+        raise ValueError(msg)
+
+    # Distinct from BOTH of the others. The serving tier is the one principal
+    # that holds a credential while serving user traffic, so collapsing it into
+    # either of the others is what would let a request-time identity reach
+    # privileges it should not have: svc-witan-ci can write a graph's shared
+    # default-branch view, and svc-witan-admin can rewrite memory rows. Cedar
+    # distinguishes them by actor id alone, so two principals sharing a token
+    # are one principal with the union of their grants, however separate the
+    # groups look in the bundle.
+    for _other_label, _other in (
+        ("ci_token", _witan_ci_token),
+        ("admin_token", _witan_admin_token),
+    ):
+        if _other is not None and _witan_service_token == _other:
+            msg = (
+                f"omnigraph/secrets.{stack_info.env_suffix}.yaml: service_token "
+                f"must not equal {_other_label}. Cedar tells these principals "
+                "apart by actor id only, so a shared value silently grants the "
+                f"serving tier everything {_other_label.removesuffix('_token')} "
+                "can do, while the bundle still shows them as separate groups."
+            )
+            raise ValueError(msg)
 else:
     _actor_tokens_map = {}
     _witan_ci_token = None
     _witan_admin_token = None
+    _witan_service_token = None
 
 # The non-human actors, on their own Vault path. This is always written, in
 # every environment, and is the *input* the token-sync job merges Keycloak's
@@ -444,6 +526,17 @@ if _witan_admin_token is not None:
         path=WITAN_ADMIN_TOKEN_VAULT_PATH,
         data_json=Output.secret(
             json.dumps({WITAN_ADMIN_TOKEN_VAULT_KEY: _witan_admin_token})
+        ),
+    )
+
+# The serving tier's account, same sole-writer arrangement. Consumed only by the
+# witan stack's `witan-code-token` Secret, which used to point at ci-token.
+if _witan_service_token is not None:
+    vault.generic.Secret(
+        f"omnigraph-witan-service-token-vault-secret-{stack_info.env_suffix}",
+        path=WITAN_SERVICE_TOKEN_VAULT_PATH,
+        data_json=Output.secret(
+            json.dumps({WITAN_SERVICE_TOKEN_VAULT_KEY: _witan_service_token})
         ),
     )
 
@@ -616,3 +709,8 @@ export("storage_prefix", STORAGE_PREFIX)
 # outputs, where `pulumi stack output` and every consumer's state would carry
 # it — the token travels through Vault, which is what Vault is for.
 export("admin_token_provisioned", _witan_admin_token is not None)
+# Read by the witan stack to decide whether `witan-code-token` syncs from
+# service-token or falls back to ci-token. Always true once a SOPS file exists
+# (the checks above are hard requirements), so the flag exists for exactly one
+# case: an environment with no SOPS file at all, which provisions neither.
+export("service_token_provisioned", _witan_service_token is not None)

--- a/src/ol_infrastructure/applications/omnigraph/__main__.py
+++ b/src/ol_infrastructure/applications/omnigraph/__main__.py
@@ -229,6 +229,7 @@ ACTOR_TOKENS_VAULT_KEY = "tokens_json"  # pragma: allowlist secret
 # the "svc-witan-ci" entry of the actor-tokens map above; both come from the
 # same SOPS source record below so they can't drift.
 WITAN_CI_TOKEN_VAULT_KEY = "token"  # noqa: S105  # pragma: allowlist secret
+WITAN_CI_ACTOR_ID = "svc-witan-ci"
 
 # The break-glass maintenance principal (agent-kit ADR-0005 path b, ADR-0002 D4
 # as amended). Same shape as the CI token above — a raw single-actor token
@@ -323,11 +324,12 @@ if (_BRIDGE_SECRETS_DIR / _witan_secrets_path).exists():
             "map are required once the file exists."
         )
         raise ValueError(msg)
-    if _actor_tokens_map.get("svc-witan-ci") != _witan_ci_token:
+    if _actor_tokens_map.get(WITAN_CI_ACTOR_ID) != _witan_ci_token:
         msg = (
             f"omnigraph/secrets.{stack_info.env_suffix}.yaml: ci_token must "
-            "match actor_tokens['svc-witan-ci'] (ADR-0009 decision point 3) "
-            "— they are the same token exposed to two different consumers."
+            f"match actor_tokens['{WITAN_CI_ACTOR_ID}'] (ADR-0009 decision "
+            "point 3) — they are the same token exposed to two different "
+            "consumers."
         )
         raise ValueError(msg)
 
@@ -431,17 +433,24 @@ if (_BRIDGE_SECRETS_DIR / _witan_secrets_path).exists():
     # distinguishes them by actor id alone, so two principals sharing a token
     # are one principal with the union of their grants, however separate the
     # groups look in the bundle.
-    for _other_label, _other in (
-        ("ci_token", _witan_ci_token),
-        ("admin_token", _witan_admin_token),
+    # Each pair carries the ACTOR ID, not a word derived from the key name. An
+    # earlier version said "everything ci can do", which is ambiguous on its own
+    # and actively misleading in this message: the same sentence already names
+    # the environment, and that environment is literally called `ci`. The thing
+    # being collapsed is an actor, so the message names actors.
+    for _other_label, _other_actor, _other in (
+        ("ci_token", WITAN_CI_ACTOR_ID, _witan_ci_token),
+        ("admin_token", WITAN_ADMIN_ACTOR_ID, _witan_admin_token),
     ):
         if _other is not None and _witan_service_token == _other:
             msg = (
                 f"omnigraph/secrets.{stack_info.env_suffix}.yaml: service_token "
                 f"must not equal {_other_label}. Cedar tells these principals "
-                "apart by actor id only, so a shared value silently grants the "
-                f"serving tier everything {_other_label.removesuffix('_token')} "
-                "can do, while the bundle still shows them as separate groups."
+                f"apart by actor id alone, so a shared value makes "
+                f"{WITAN_SERVICE_ACTOR_ID} and {_other_actor} one principal "
+                f"holding both sets of grants — the serving tier would gain "
+                f"everything {_other_actor} can do, while the bundle still "
+                "shows them as separate groups."
             )
             raise ValueError(msg)
 else:

--- a/src/ol_infrastructure/applications/witan/__main__.py
+++ b/src/ol_infrastructure/applications/witan/__main__.py
@@ -193,6 +193,16 @@ admin_token_provisioned = bool(
         omnigraph_stack, "admin_token_provisioned", default=False
     )
 )
+# Same shape, for svc-witan: whether the MCP tier has an account of its own to
+# enumerate graphs as, or is still borrowing svc-witan-ci for it. False only in
+# an environment whose omnigraph stack has no SOPS secrets file at all — where
+# there is no service-token path to read, so falling back is the only option
+# that yields a working Secret.
+service_token_provisioned = bool(
+    optional_stack_output_value(
+        omnigraph_stack, "service_token_provisioned", default=False
+    )
+)
 
 NAMESPACE = "witan"
 
@@ -427,9 +437,16 @@ witan_ci_token_secret = OLVaultK8SSecret(
     ),
 )
 
-# Same Vault path as witan_ci_token_secret above — see
-# WITAN_CODE_TOKEN_SECRET_NAME for why this is its own Secret and not a second
-# reference to that one.
+# The MCP tier's credential for its own server-scoped questions (graph_list).
+# Its own Secret rather than a second reference to witan-ci-token — see
+# WITAN_CODE_TOKEN_SECRET_NAME — which is what lets the Vault path move here
+# without touching the MCPServer spec.
+#
+# svc-witan where it is provisioned, svc-witan-ci where it is not. The fallback
+# is not a supported operating mode so much as the only thing that yields a
+# working Secret in an environment with no omnigraph SOPS file: reading an
+# absent Vault path would sync an empty Secret, and the tier would send an empty
+# bearer token and be denied every enumeration.
 witan_code_token_secret = OLVaultK8SSecret(
     f"witan-code-token-secret-{stack_info.env_suffix}",
     resource_config=OLVaultK8SStaticSecretConfig(
@@ -441,11 +458,13 @@ witan_code_token_secret = OLVaultK8SSecret(
         dest_secret_type="Opaque",  # pragma: allowlist secret  # noqa: S106
         mount="secret-operations",
         mount_type="kv-v1",
-        path="witan/ci-token",
+        path=("witan/service-token" if service_token_provisioned else "witan/ci-token"),
         exclude_raw=True,
         excludes=[".*"],
         templates={
             WITAN_CODE_TOKEN_SECRET_KEY: (
+                # Both paths store the raw token under the same "token" key, so
+                # the template is the same either way.
                 f'{{{{ get .Secrets "{WITAN_CI_TOKEN_VAULT_KEY}" }}}}'
             )
         },

--- a/src/ol_infrastructure/applications/witan/witan_policy.hcl
+++ b/src/ol_infrastructure/applications/witan/witan_policy.hcl
@@ -26,6 +26,18 @@ path "secret-operations/witan/admin-token" {
   capabilities = ["read"]
 }
 
+# svc-witan: the MCP serving tier's own account, used for the server-scoped
+# questions it asks before any per-actor token is in scope — `omnigraph graphs
+# list`, which gates code-graph writes and backs code_indexed_repos (Cedar
+# `graph_list`). Read by the witan-code-token Secret, which pointed at ci-token
+# until this account existed. Written by the omnigraph stack from the same SOPS
+# source as the other two. Unlike admin-token this is present in every
+# environment that has a SOPS file at all, because the Cedar bundles'
+# `witan-service` group cannot be empty.
+path "secret-operations/witan/service-token" {
+  capabilities = ["read"]
+}
+
 # {actor_id: token} JSON map — the same artifact omnigraph-server boots its
 # bearer-token auth from (OMNIGRAPH_SERVER_BEARER_TOKENS_FILE) and witan
 # resolves per-user tokens from (WITAN_ACTOR_TOKENS_FILE). Always carries the


### PR DESCRIPTION
### What are the relevant tickets?

N/A — tracked in the witan work graph as `tk-provision-act-svc-witan-witan-service-token-so-t-f5770c`, under project `wp-witan-multi-user-service-deployment-dcf6ee`. Follows #5209 (which gave the credential its own Secret in anticipation of this) and #5289 (which made it urgent).

### Description (What does it do?)

Provisions `svc-witan`, the MCP serving tier's own service account, in CI, QA and Production — the third and last of witan's non-human principals alongside `svc-witan-ci` and `svc-witan-admin`.

**This also fixes a live CI outage.** `omnigraph-server` in `operations-ci` has been in CrashLoopBackOff since #5289 landed:

```
omnigraph-server: cluster converged; starting server
INFO omnigraph_server: serving omnigraph bind=0.0.0.0:8080 mode="cluster" graph_count=17
Error:
   0: policy group 'witan-service' must not be empty
   crates/omnigraph-policy/src/lib.rs:302
```

witan's Cedar bundles all declare a `witan-service` group, and the image entrypoint renders group membership from the live actor-token map at boot. With no `svc-witan` entry that group renders empty — and `omnigraph-policy` treats an empty group as a fatal bundle error, not as "a group that grants nobody". The renderer even logs `WARNING empty group(s): ['witan-service']` immediately before the server exits on exactly that group. Note the failure happens *after* the `serving omnigraph` line, so it reads like a healthy start right up until the pod restarts.

That contradicts the assumption written into agent-kit's `render_groups.py` ("an empty group is far safer than inventing an id that silently matches no token"). The reasoning is sound; the engine just doesn't offer that option. A group must be either populated or absent.

#### Why the account exists at all

The serving tier asks the server a few questions *about the server* rather than of a graph — chiefly `omnigraph graphs list`, which `witan_code.store.ensure_store` runs before a write to confirm the cluster declares the target graph, and which backs `code_indexed_repos`. That listing is server-scoped (Cedar `graph_list`), belongs to no actor, and happens *before* `witan_code.ingest._client` swaps in the requesting user's token — so it authenticates as the service or not at all.

Until now it borrowed `svc-witan-ci`. That was never a privilege escalation (the actor swap in `_client` is unconditional and `WITAN_CODE_INDEX_ROLE` stays `client`, so the CI role's one real privilege — writing a graph's shared default-branch view — was unreachable from the tier), but it attributed the serving tier's enumerations to the data pipeline and meant rotating the CI token took the tier's code-graph reads down with it.

#### Required, not optional

This is the one real difference from `svc-witan-admin`, which is opt-in — an environment without it just keeps running maintenance as `svc-witan-ci`. Since #5289 applies the bundles unconditionally in every environment, an environment without `svc-witan` is a crash-looping data tier. So the checks here are hard requirements wherever a SOPS file exists, and they fail the deploy naming the missing keys rather than leaving an operator to work backwards from a CrashLoopBackOff.

#### Token distinctness

Each environment's token is distinct from that environment's `ci_token` and `admin_token`, and the stack refuses the deploy otherwise. Cedar tells these principals apart by actor id alone, so a shared value is one principal holding the union of both sets of grants while the bundle still shows them as separate groups. That matters most here: the serving tier is the only one of the three holding a credential while serving user traffic, and the other two can respectively write a graph's shared default-branch view and rewrite memory rows.

#### Changes

- **omnigraph stack** — validate the `service_token` / `actor_tokens['svc-witan']` pair, write `secret-operations/witan/service-token`, export `service_token_provisioned`.
- **witan stack** — move the `witan-code-token` Secret from `witan/ci-token` to `witan/service-token` once that flag is set, and grant the VSO read on the new path. The `MCPServer` spec is untouched: #5209 gave this credential its own Secret precisely so this would be a one-line path change.
- **SOPS** — `service_token` + `actor_tokens['svc-witan']` in all three environments.
- **`docs/witan-service-account-runbook.md`** — provisioning, verification, rotation.

### How can this be tested?

`pulumi preview` against the real CI stack, which exercises the SOPS decrypt and every new validation check:

```
$ pulumi preview --stack CI   # applications/omnigraph
 +  vault:generic:Secret omnigraph-witan-service-token-vault-secret-ci create
 ~  vault:generic:Secret omnigraph-service-tokens-vault-secret-ci update [diff: ~dataJson]

Outputs:
  + service_token_provisioned: true

Resources:
    + 1 to create
    ~ 1 to update
    2 changes. 44 unchanged
```

Exactly the two intended changes and nothing else — in particular the `omnigraph-server` Deployment is not modified here. Its restart comes from the VSO, which is the designed path: the `actor-tokens` VaultStaticSecret carries `rolloutRestartTargets: [omnigraph-server]`, so the server restarts once the map changes and re-renders `witan-service` with a member.

The `witan` stack preview shows the Vault policy gaining the `service-token` read grant, and `witan-code-token` **staying on `witan/ci-token`** — because `service_token_provisioned` is still false until the omnigraph stack is deployed. That is the ordering safety working by construction: running the witan stack first is a no-op, not a half-applied state.

Secrets verified without printing any values — for each environment: `service_token` present and 64-hex, `actor_tokens['svc-witan']` matches it, differs from both `ci_token` and `admin_token`, and the two pre-existing invariants (`svc-witan-ci == ci_token`, `svc-witan-admin == admin_token`) still hold. All three files still decrypt after the `yamlfmt` pre-commit hook rewrote them.

`ruff check`, `ruff format`, `mypy` and the full pre-commit run (including `detect-secrets`) pass.

### Additional Context

**Deploy order matters, and it is not the usual one** — see the runbook:

1. **omnigraph stack** — writes the Vault path and adds the actor to `service-tokens`.
2. **Force the token-sync job.** With sync on (all three environments since #5280), nothing merges into `actor-tokens` until the hourly CronJob runs, and the token authenticates nowhere until it does:
   ```
   kubectl -n omnigraph create job witan-token-sync-manual --from=cronjob/witan-token-sync
   ```
   The VSO then restarts `omnigraph-server`, which re-renders the group. Expect a brief data-tier outage — single replica, `strategy=Recreate`. In CI it is currently crash-looping anyway.
3. **witan stack** — picks up the flag and repoints `witan-code-token`.

Verify with `kubectl -n omnigraph logs deploy/omnigraph-server | grep render-policy-groups` — `witan-service=1` rather than `witan-service=0`.

**Deliberately not done here:** the task also asked whether `migrations.py` should move to this account, since its docstring concedes it authenticates as `svc-witan-ci` for operations the `witan-service` group is the modelled owner of. Leaving it on `svc-witan-admin`, which #5279 provisioned for exactly that purpose — moving it again now would be churn, and the serving tier's account is the wrong home for a job that rewrites memory rows. Worth revisiting only if the Cedar grants change.

**Follow-up worth considering separately:** `render_groups.py` should drop a group that renders empty (along with any rule referencing it) rather than writing `[]`, so a future unprovisioned principal degrades instead of crash-looping. Recorded in the witan graph as `les-omnigraph-policy-rejects-an-empty-cedar-group-an-f6eea5`. The `check.sh` in agent-kit has already gained a rendered-bundle validation step that would have caught this pre-deploy.
