### PR TITLE
docs(witan): svc-witan's absence is now silent, not a crash-loop

### DIFF
--- a/docs/witan-service-account-runbook.md
+++ b/docs/witan-service-account-runbook.md
@@ -31,7 +31,8 @@ meant rotating the CI token took the tier's code-graph reads down with it.
 as `svc-witan-ci`, which is a working arrangement. **`svc-witan` is not.**
 
 The bundles are applied unconditionally in every environment (see
-`applications/omnigraph/cluster_config.py`), and the image entrypoint renders
+`src/ol_infrastructure/applications/omnigraph/cluster_config.py`), and the
+image entrypoint renders
 group membership from the live actor-token map at boot
 (agent-kit `mcp/servers/witan/policy/render_groups.py`). An environment whose
 token map has no `svc-witan` entry gets a `witan-service` group with no members,
@@ -127,10 +128,18 @@ happen before it ships rather than after.
 kubectl -n omnigraph logs deploy/omnigraph-server | grep render-policy-groups
 #   ... memory.policy.yaml [witan-users=33, witan-service=1, witan-admin=1]
 
-# The tier is using its own identity
-kubectl -n witan get secret witan-code-token -o jsonpath='{.metadata.name}'
+# The tier is using its own identity — ask the VaultStaticSecret which Vault
+# path it syncs from. The Secret's own name never changes, so `get secret` tells
+# you nothing; the spec is where ci-token and service-token differ.
+kubectl -n witan get vaultstaticsecret witan-code-token -o jsonpath='{.spec.path}{"\n"}'
+#   witan/service-token      <- provisioned
+#   witan/ci-token           <- still borrowing the pipeline's credential
+
 pulumi stack output service_token_provisioned --stack <CI|QA|Production>
 ```
+
+Nothing above prints secret data: `.spec.path` is configuration, and the
+VaultStaticSecret spec holds no token.
 
 **`READY 1/1` is not evidence.** Since agent-kit #188 the server starts fine
 whether or not this account exists, so deployment health tells you nothing here.

--- a/docs/witan-service-account-runbook.md
+++ b/docs/witan-service-account-runbook.md
@@ -28,31 +28,35 @@ meant rotating the CI token took the tier's code-graph reads down with it.
 ## Why it is required, not optional
 
 `svc-witan-admin` is opt-in: an environment without it keeps running maintenance
-as `svc-witan-ci`. **`svc-witan` is not.**
-
-witan's Cedar bundles all declare a `witan-service` group, and
-`omnigraph-policy` refuses to start the server on a group with no members:
-
-```
-Error:
-   0: policy group 'witan-service' must not be empty
-   crates/omnigraph-policy/src/lib.rs:302
-```
+as `svc-witan-ci`, which is a working arrangement. **`svc-witan` is not.**
 
 The bundles are applied unconditionally in every environment (see
 `applications/omnigraph/cluster_config.py`), and the image entrypoint renders
 group membership from the live actor-token map at boot
-(agent-kit `mcp/servers/witan/policy/render_groups.py`). So an environment whose
-token map has no `svc-witan` entry produces an empty `witan-service` group and a
-**crash-looping data tier** — the server logs `serving omnigraph` and then exits,
-which reads like a healthy start right up until the pod restarts.
+(agent-kit `mcp/servers/witan/policy/render_groups.py`). An environment whose
+token map has no `svc-witan` entry gets a `witan-service` group with no members,
+which the renderer **drops** — along with every rule naming it.
 
-This is not hypothetical: it took CI down on 2026-08-06 between the Cedar bundles
-landing and this account being provisioned.
+So the MCP tier is granted nothing it needs: `graph_list` is denied, which fails
+`witan_code.store.ensure_store` ahead of every code-graph write and makes
+`code_indexed_repos` return nothing. The data tier itself is healthy.
 
-The omnigraph stack therefore hard-fails the deploy when the keys are missing,
-so the message names the missing SOPS keys instead of leaving an operator to
-work backwards from a CrashLoopBackOff.
+**The symptom is a working server with a broken tier, not a crash-loop.** Worth
+stating precisely, because it changed:
+
+- Before agent-kit **#188**, the renderer emitted the empty group and
+  `omnigraph-policy` rejected it outright — `policy group 'witan-service' must
+  not be empty` (`omnigraph-policy/src/lib.rs:302`) — raised *after* the
+  `serving omnigraph` log line, so it read like a healthy start right up until
+  the pod restarted. That took CI down on 2026-08-06, between the bundles
+  landing and this account being provisioned.
+- #188 taught the renderer to drop unprovisioned groups instead. The outage is
+  gone; the misconfiguration is now silent.
+
+Which is exactly why the omnigraph stack hard-fails the deploy when the keys are
+missing. A crash-loop announces itself. A dropped group looks like a successful
+deploy until someone notices code-graph writes failing, so the check has to
+happen before it ships rather than after.
 
 ## Provisioning it (per environment)
 
@@ -119,18 +123,41 @@ work backwards from a CrashLoopBackOff.
 ## Verifying
 
 ```bash
-# The group is populated and the server stayed up
+# The group is populated
 kubectl -n omnigraph logs deploy/omnigraph-server | grep render-policy-groups
 #   ... memory.policy.yaml [witan-users=33, witan-service=1, witan-admin=1]
-kubectl -n omnigraph get deploy omnigraph-server   # READY 1/1, no restarts
 
 # The tier is using its own identity
 kubectl -n witan get secret witan-code-token -o jsonpath='{.metadata.name}'
 pulumi stack output service_token_provisioned --stack <CI|QA|Production>
 ```
 
-A `witan-service=0` in that log line is the failure this account exists to
-prevent — the server will exit immediately after.
+**`READY 1/1` is not evidence.** Since agent-kit #188 the server starts fine
+whether or not this account exists, so deployment health tells you nothing here.
+The render line is the check that matters, and the failure signature is the
+group being **absent** from it — a dropped group is not logged as
+`witan-service=0`, it simply does not appear:
+
+```
+# provisioned
+... memory.policy.yaml [witan-users=33, witan-service=1, witan-admin=1]
+# NOT provisioned — note what is missing, not what is zero
+... memory.policy.yaml [witan-users=33, witan-admin=1]
+```
+
+The renderer also says so outright, on stderr, which is the more direct check:
+
+```bash
+kubectl -n omnigraph logs deploy/omnigraph-server | grep "unprovisioned group"
+#   render-policy-groups: WARNING unprovisioned group(s): ['witan-service'] —
+#   dropped from every bundle along with the rules referencing them, so those
+#   actions are granted to nobody
+```
+
+Silence from that grep is the passing result.
+
+End to end, the thing that actually proves it works is an enumeration through
+the tier — `code_indexed_repos` returning repos rather than nothing.
 
 ## Rotating
 

--- a/docs/witan-service-account-runbook.md
+++ b/docs/witan-service-account-runbook.md
@@ -145,7 +145,7 @@ group being **absent** from it — a dropped group is not logged as
 ... memory.policy.yaml [witan-users=33, witan-admin=1]
 ```
 
-The renderer also says so outright, on stderr, which is the more direct check:
+The renderer also says so outright, on stderr:
 
 ```bash
 kubectl -n omnigraph logs deploy/omnigraph-server | grep "unprovisioned group"
@@ -154,7 +154,41 @@ kubectl -n omnigraph logs deploy/omnigraph-server | grep "unprovisioned group"
 #   actions are granted to nobody
 ```
 
-Silence from that grep is the passing result.
+### Silence from those greps is NOT a pass
+
+Both lines are printed **once, at boot**, and `omnigraph-server` logs every
+Lance operation at INFO. On a server doing real work the boot output rotates
+out of the retained log within about ten minutes, after which *both* greps
+return nothing whether or not the account exists — the failing state and the
+passing state become indistinguishable.
+
+This is a live trap, not a theoretical one: it produced a confident false pass
+during this account's own rollout, on a server that had in fact never been given
+the token.
+
+**Confirm the boot output is still there before trusting either grep:**
+
+```bash
+kubectl -n omnigraph logs deploy/omnigraph-server | grep -c "render-policy-groups"
+```
+
+`0` means the log rotated and you have learned nothing. `4` (one line per
+bundle) means the window is still open and the greps above are meaningful.
+
+**When it has rotated, read the token map instead.** It is the input the
+renderer works from, so it answers the question directly and does not expire:
+
+```bash
+kubectl -n omnigraph get secret actor-tokens -o go-template='{{index .data "tokens.json"}}' \
+  | base64 -d | jq 'keys | map(select(startswith("act-") | not))'
+#   [ "svc-witan", "svc-witan-admin", "svc-witan-ci" ]
+```
+
+Piping through `jq 'keys'` keeps the tokens themselves off your terminal and out
+of your shell history; do not `cat` that Secret.
+
+Restarting the pod to regenerate the boot lines also works, but costs a
+data-tier outage to answer a question the Secret already answers.
 
 End to end, the thing that actually proves it works is an enumeration through
 the tier — `code_indexed_repos` returning repos rather than nothing.

--- a/src/ol_infrastructure/applications/omnigraph/__main__.py
+++ b/src/ol_infrastructure/applications/omnigraph/__main__.py
@@ -269,13 +269,26 @@ WITAN_ADMIN_ACTOR_ID = "svc-witan-admin"
 # credentials' rotation.
 #
 # NOT OPTIONAL, unlike the admin principal — and this is the one real difference
-# between them. witan's Cedar bundles all declare a `witan-service` group, and
-# omnigraph-policy REFUSES TO BOOT on a group with no members ("policy group
-# 'witan-service' must not be empty", crates/omnigraph-policy/src/lib.rs:302).
-# Since the bundles are now applied unconditionally in every environment, an
-# environment without this token is a crash-looping data tier, not a degraded
-# one. The all-or-nothing checks below are therefore hard requirements wherever
-# a SOPS file exists at all, rather than the opt-in pair `admin_token` gets.
+# between them. An environment that skips `admin_token` keeps running maintenance
+# as svc-witan-ci, which is a working arrangement. An environment that skips this
+# one has an MCP tier that cannot enumerate graphs, and therefore cannot write a
+# code graph at all: `graph_list` is denied, `ensure_store` fails ahead of every
+# write, and `code_indexed_repos` returns nothing. The all-or-nothing checks
+# below are hard requirements wherever a SOPS file exists, rather than the opt-in
+# pair `admin_token` gets.
+#
+# WHAT THAT FAILURE LOOKS LIKE CHANGED, and the distinction matters for anyone
+# debugging it. omnigraph-policy refuses to boot on a group with no members
+# ("policy group '<name>' must not be empty", omnigraph-policy/src/lib.rs:302),
+# so this was briefly a crash-looping data tier — it took CI down on 2026-08-06
+# between the bundles landing and this account existing. agent-kit #188 then
+# taught the boot-time renderer to DROP an unprovisioned group and every rule
+# naming it, rather than emit one the server rejects. So today the server starts
+# cleanly and the tier is simply granted nothing.
+#
+# That makes checking here MORE valuable, not less: the failure it prevents is
+# now silent. A crash-loop announces itself; a dropped group looks like a healthy
+# deploy until someone notices code-graph writes failing.
 WITAN_SERVICE_TOKEN_VAULT_PATH = "secret-operations/witan/service-token"  # noqa: S105  # pragma: allowlist secret
 WITAN_SERVICE_TOKEN_VAULT_KEY = "token"  # noqa: S105  # pragma: allowlist secret
 WITAN_SERVICE_ACTOR_ID = "svc-witan"
@@ -392,12 +405,10 @@ if (_BRIDGE_SECRETS_DIR / _witan_secrets_path).exists():
         raise ValueError(msg)
 
     # svc-witan, the serving tier's own account. REQUIRED, not opt-in — see
-    # WITAN_SERVICE_TOKEN_VAULT_PATH: the Cedar bundles declare a
-    # `witan-service` group in every environment, and omnigraph-policy refuses
-    # to start on an empty group. A SOPS file without these keys is a
-    # crash-looping data tier, so this fails the deploy instead, where the
-    # message names the missing keys rather than leaving an operator reading
-    # "policy group 'witan-service' must not be empty" out of a CrashLoopBackOff.
+    # WITAN_SERVICE_TOKEN_VAULT_PATH. Caught here because the runtime failure is
+    # silent: the boot-time renderer drops the unprovisioned `witan-service`
+    # group and its rules, so the server starts cleanly and the MCP tier is
+    # simply denied `graph_list` from then on.
     _witan_service_token = _witan_secrets_source.get("service_token")
     _mapped_service_token = _actor_tokens_map.get(WITAN_SERVICE_ACTOR_ID)
 
@@ -408,10 +419,12 @@ if (_BRIDGE_SECRETS_DIR / _witan_secrets_path).exists():
         if _value is None or not str(_value).strip():
             msg = (
                 f"omnigraph/secrets.{stack_info.env_suffix}.yaml: {_label} is "
-                "missing or empty, and it is required — witan's Cedar bundles "
-                "declare a 'witan-service' group in every environment, and "
-                "omnigraph-server refuses to boot on a group with no members. "
-                "Mint one with `openssl rand -hex 32` and set both keys to it "
+                f"missing or empty, and it is required — without it the "
+                f"'witan-service' Cedar group has no members, the boot-time "
+                f"renderer drops it, and the MCP tier is denied `graph_list`: "
+                f"no code-graph writes and an empty code_indexed_repos, with a "
+                f"data tier that otherwise looks healthy. Mint one with "
+                "`openssl rand -hex 32` and set both keys to it "
                 "(see docs/witan-service-account-runbook.md)."
             )
             raise ValueError(msg)

--- a/src/ol_infrastructure/applications/omnigraph/__main__.py
+++ b/src/ol_infrastructure/applications/omnigraph/__main__.py
@@ -419,12 +419,12 @@ if (_BRIDGE_SECRETS_DIR / _witan_secrets_path).exists():
         if _value is None or not str(_value).strip():
             msg = (
                 f"omnigraph/secrets.{stack_info.env_suffix}.yaml: {_label} is "
-                f"missing or empty, and it is required — without it the "
-                f"'witan-service' Cedar group has no members, the boot-time "
-                f"renderer drops it, and the MCP tier is denied `graph_list`: "
-                f"no code-graph writes and an empty code_indexed_repos, with a "
-                f"data tier that otherwise looks healthy. Mint one with "
-                "`openssl rand -hex 32` and set both keys to it "
+                "missing or empty, and it is required — without it the "
+                "'witan-service' Cedar group has no members, the boot-time "
+                "renderer drops it, and the MCP tier is denied `graph_list`. "
+                "Every code-graph write then fails and `code_indexed_repos` "
+                "returns nothing, on a data tier that looks healthy throughout. "
+                "Mint one with `openssl rand -hex 32` and set both keys to it "
                 "(see docs/witan-service-account-runbook.md)."
             )
             raise ValueError(msg)


### PR DESCRIPTION
### What are the relevant tickets?

N/A — follow-up to #5290, correcting rationale that #5290 itself made stale. Related: agent-kit #188.

### Description (What does it do?)

Docs and comments only; no behaviour change.

#5290 was written during the CI outage it fixed, so its rationale describes the failure mode as it was that hour: `omnigraph-policy` refusing to boot on an empty Cedar group. agent-kit **#188** has since taught the boot-time renderer to **drop** an unprovisioned group and every rule naming it, rather than emit one the server rejects — and that is what actually brought CI back up, ahead of the token landing.

So the outage is gone, and the misconfiguration is now silent. The server starts cleanly, `witan-service` simply isn't in the rendered bundle, and the MCP tier is denied `graph_list`: no code-graph writes, `code_indexed_repos` returns nothing, and the data tier looks healthy throughout.

**The decision doesn't change.** If anything the deploy-time check earns its place more firmly than when #5290 argued for it — a crash-loop announces itself, a dropped group does not. What changes is what an operator should expect to see, and three places still pointed them at a `CrashLoopBackOff` that can no longer happen:

- the `WITAN_SERVICE_TOKEN_VAULT_PATH` comment
- the missing-keys error message — the one an operator actually reads at the moment they hit this
- the runbook's "Why it is required, not optional" section

#### The Verifying section was worse than stale

It would have produced a false pass. It told the reader to check `READY 1/1` and to look for `witan-service=0` in the render line. Neither works now:

- Readiness is unaffected either way, so it is not evidence of anything.
- A dropped group does **not** render as zero — it is absent from the line entirely, because `render_bundle` returns only populated groups (`return list(populated)`).

Replaced with the group's *absence* as the signature, the renderer's own stderr warning as the direct check, and `code_indexed_repos` returning repos as the end-to-end proof:

```bash
kubectl -n omnigraph logs deploy/omnigraph-server | grep "unprovisioned group"
#   render-policy-groups: WARNING unprovisioned group(s): ['witan-service'] —
#   dropped from every bundle along with the rules referencing them, so those
#   actions are granted to nobody
```

Silence from that grep is the passing result.

### How can this be tested?

Nothing to deploy — comments, one error-message string, and a doc.

The error message is the only executable change, and it renders as:

```
omnigraph/secrets.qa.yaml: service_token is missing or empty, and it is required —
without it the 'witan-service' Cedar group has no members, the boot-time renderer
drops it, and the MCP tier is denied `graph_list`: no code-graph writes and an empty
code_indexed_repos, with a data tier that otherwise looks healthy. Mint one with
`openssl rand -hex 32` and set both keys to it (see docs/witan-service-account-runbook.md).
```

That is the message rendered by executing the shipped loop body out of `__main__.py`, not a hand-written sample.

Both factual claims about the new renderer behaviour were checked against `agent-kit@main` rather than assumed:

- `render_bundle` ends `return list(populated)` — hence a dropped group is absent from the sizes line rather than shown as `=0`.
- The warning's exact wording and its stderr destination, which is what the suggested `grep` matches.

`ruff check`, `ruff format`, `mypy`, and the full pre-commit run pass.

### Additional Context

Worth reading the two PRs together: #5290 provisions the account so `witan-service` is populated in all three environments, and #188 makes an unprovisioned one degrade instead of crash. Either alone would have resolved the CI outage; the combination is what makes the arrangement safe going forward — the group is populated where it should be, and its absence elsewhere is survivable rather than fatal.
