### PR TITLE
fix(xpro): add CSRF_TRUSTED_ORIGINS to CI config

### DIFF
--- a/src/ol_infrastructure/applications/xpro/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/applications/xpro/Pulumi.CI.yaml
@@ -6,6 +6,7 @@ config:
     secure: v1:d1JeftBc68QcCrCH:tQV5P2EU4H/eF7jMjUied4fIcj2Q6d9ujnhvfn5oxJiPbh41oVff6sWQDs9SUl65gQOTWg==
   heroku:user: "mitx-devops"
   xpro:vars:
+    CSRF_TRUSTED_ORIGINS: "https://ci.xpro.mit.edu,https://xpro-ci.odl.mit.edu"
     CYBERSOURCE_SECURE_ACCEPTANCE_URL: "https://testsecureacceptance.cybersource.com/pay"
     CYBERSOURCE_WSDL_URL: "https://ics2wstest.ic3.com/commerce/1.x/transactionProcessor/CyberSourceTransaction_1.154.wsdl"
     DIGITAL_CREDENTIALS_SUPPORTED_RUNS: ""


### PR DESCRIPTION
### What are the relevant tickets?
Closes mitodl/hq#12633

### Description (What does it do?)
Adds `CSRF_TRUSTED_ORIGINS` to the xpro CI Pulumi config (`Pulumi.CI.yaml`), matching the pattern already set in `Pulumi.QA.yaml` and `Pulumi.Production.yaml` but missing from CI.

Set to `https://ci.xpro.mit.edu,https://xpro-ci.odl.mit.edu`, mirroring the CI environment's `xpro:frontend_domain` (`ci.xpro.mit.edu`) and `xpro:backend_domain`/`xpro:app_domain` (`xpro-ci.odl.mit.edu`), the same way QA maps to `rc.xpro.mit.edu`/`xpro-rc.odl.mit.edu` and Production maps to `xpro.mit.edu`/`xpro-web.odl.mit.edu`.

### Screenshots (if appropriate):
N/A

### How can this be tested?
Config-only change (Pulumi stack config, not code). Verify by diffing against QA/Production:

```bash
grep CSRF_TRUSTED_ORIGINS src/ol_infrastructure/applications/xpro/Pulumi.*.yaml
```

On deploy, confirm CSRF-protected form submissions (e.g. login/logout) from `https://ci.xpro.mit.edu` succeed against the CI backend.

### Additional Context
N/A