### PR TITLE
fix(concourse): drop classic-PAT auth from github-release checks

### DIFF
--- a/src/ol_concourse/pipelines/container_images/dcind.py
+++ b/src/ol_concourse/pipelines/container_images/dcind.py
@@ -34,6 +34,7 @@ dagger_release = github_release(
     owner="dagger",
     repository="dagger",
     order_by="time",
+    github_token="",
 )
 
 dcind_release_image = Resource(

--- a/src/ol_concourse/pipelines/infrastructure/concourse/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/concourse/pipeline.py
@@ -16,7 +16,7 @@ from ol_concourse.pipelines.secrets_map import project_secrets_paths
 # RESOURCES #
 #############
 concourse_release = github_release(
-    Identifier("concourse-release"), "concourse", "concourse"
+    Identifier("concourse-release"), "concourse", "concourse", github_token=""
 )
 concourse_image_code = git_repo(
     Identifier("ol-infrastructure-packer"),

--- a/src/ol_concourse/pipelines/infrastructure/docker_baseline/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/docker_baseline/pipeline.py
@@ -7,7 +7,9 @@ from ol_concourse.pipelines.constants import PACKER_WATCHED_PATHS
 from ol_concourse.pipelines.jobs import packer_jobs
 
 hashicorp_release_resource = hashicorp_resource()
-vector_release = github_release(Identifier("vector-release"), "vectordotdev", "vector")
+vector_release = github_release(
+    Identifier("vector-release"), "vectordotdev", "vector", github_token=""
+)
 vault_agent_release = hashicorp_release(
     name=Identifier("vault-release"), project="vault"
 )

--- a/src/ol_concourse/pipelines/infrastructure/keycloak/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/keycloak/pipeline.py
@@ -101,6 +101,7 @@ def build_keycloak_infrastructure_pipeline() -> PipelineFragment:
         repository="keycloak-protocol-cas",
         tag_filter=KEYCLOAK_VERSION,
         order_by="time",
+        github_token="",
     )
 
     # Repo: https://github.com/mitodl/ol-keycloak
@@ -110,12 +111,14 @@ def build_keycloak_infrastructure_pipeline() -> PipelineFragment:
         owner="mitodl",
         repository="ol-keycloak",
         check_frequency="1h",
+        github_token="",
     )
 
     ol_keycloakify = github_release(
         name=Identifier("ol-keycloakify"),
         owner="mitodl",
         repository="ol-keycloakify",
+        github_token="",
     )
 
     scim_plugin = s3_object(

--- a/src/ol_concourse/pipelines/infrastructure/superset/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/superset/pipeline.py
@@ -37,6 +37,7 @@ def build_superset_docker_pipeline() -> Pipeline:
         repository="superset",
         tag_filter="^6",
         order_by="time",
+        github_token="",
     )
 
     docker_code_repo = git_repo(

--- a/src/ol_concourse/pipelines/open_edx/edx_platform_v3/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/edx_platform_v3/pipeline.py
@@ -96,6 +96,7 @@ def build_edx_pipeline(release_names: list[str]) -> Pipeline:
                 repository="node",
                 tag_filter=rf"^v({node_version}\.\d+\.\d+)",
                 order_by="version",
+                github_token="",
             )
 
             # Pulumi code related resource setup


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
`docker-pulumi-keycloak`'s `ol-keycloakify` resource check started failing because mitodl restricted use of classic personal access tokens on GitHub, and the `github-release` Concourse resource type's default auth (`((github.public_repo_access_token))`, a classic PAT) is used by every `github_release()` call site in this repo.

Evaluated three options for the `github-release` resource type:
- **GitHub App auth** — not viable. The `github-release` Concourse resource type (`concourse/github-release-resource`) only accepts a static `access_token` string; it has no App/JWT auth support, and GitHub App installation tokens expire hourly with no mechanism here to refresh them per-check.
- **Fine-grained PAT** — works as a drop-in credential swap, but still requires manually creating and rotating a personal token, and could hit the same org-level restriction later.
- **Remove the token** — chosen. All 8 `github_release()` call sites in this repo only poll public release metadata, at check frequencies of 24h (most) or 1h (`ol-spi`). The anonymous GitHub API rate limit (60 req/hr per source IP) comfortably covers that, and it removes a credential to maintain entirely.

Passed `github_token=""` at each `github_release()` call site (the function's `if github_token:` guard then skips setting `access_token` in the resource's `source`) across:
- `src/ol_concourse/pipelines/infrastructure/keycloak/pipeline.py` (`cas-protocol-spi`, `ol-spi`, `ol-keycloakify`)
- `src/ol_concourse/pipelines/infrastructure/superset/pipeline.py` (`superset-release`)
- `src/ol_concourse/pipelines/infrastructure/concourse/pipeline.py` (`concourse-release`)
- `src/ol_concourse/pipelines/infrastructure/docker_baseline/pipeline.py` (`vector-release`)
- `src/ol_concourse/pipelines/open_edx/edx_platform_v3/pipeline.py` (`nodejs-*-released-version`)
- `src/ol_concourse/pipelines/container_images/dcind.py` (`dagger-release-binary`)

The now-unused `public_repo_access_token` secret in `src/bridge/secrets/concourse/operations.{ci,qa,production}.yaml` is left in place for now; can be removed in a follow-up once confirmed nothing else references it.

### Screenshots (if appropriate):
N/A - no UI changes

### How can this be tested?
Rendered each modified pipeline's `definition.json` locally (`uv run python <pipeline>.py`) and confirmed no `github-release` resource carries an `access_token` in its `source`:

```
$ python3 -c "
import json
d = json.load(open('definition.json'))
for r in d['resources']:
    if r['type'] == 'github-release':
        print(r['name'], 'access_token' in r['source'], repr(r['source'].get('access_token')))
"
cas-protocol-spi False None
ol-keycloakify False None
ol-spi False None
```

After merge, re-set the affected pipelines (e.g. `fly -t <target> set-pipeline -p docker-pulumi-keycloak -c definition.json`, or via whatever meta-pipeline manages these) and confirm the `ol-keycloakify` resource check on `docker-pulumi-keycloak` succeeds.

### Additional Context
The other `github-issues` resources in the superset/concourse pipelines (which post issues on failure) still use a separate `((github.issues_resource_access_token))` — untouched here since that's a write operation requiring real auth, and is a different problem than this read-only rate-limit token.