### PR TITLE
fix(witan): forward the client's token to the backend, so the vMCP serves tools

### DIFF
--- a/src/ol_infrastructure/applications/witan/__main__.py
+++ b/src/ol_infrastructure/applications/witan/__main__.py
@@ -36,11 +36,9 @@ Incoming auth — ToolHive's "External OIDC provider" scenario, NOT
     Swapping that JWT for a vMCP-minted one before it reaches witan would
     break D1 outright. So this stack configures ``incomingAuth`` to validate
     directly against Keycloak's **real** issuer (no ``authServerConfig``,
-    hence no embedded broker, no persistent signing keys, no Redis) — ToolHive
-    then has nothing of its own to substitute and simply forwards the client's
-    original bearer token to the ``witan`` MCPServer. See ADR-0009's
-    Resolution addendum and agent-kit ADR-0004's matching Resolution addendum
-    (2026-07-10) for the full decision record.
+    hence no embedded broker, no persistent signing keys, no Redis). See
+    ADR-0009's Resolution addendum and agent-kit ADR-0004's matching
+    Resolution addendum (2026-07-10) for the full decision record.
 
     This also means clients need an already-valid Keycloak JWT with the right
     audience before calling — there is no vMCP-brokered interactive login
@@ -49,6 +47,44 @@ Incoming auth — ToolHive's "External OIDC provider" scenario, NOT
     it does mean whatever normally gets a human or CI agent a Keycloak JWT for
     other internal tools (existing SSO session, device-code flow, etc.) is a
     prerequisite this stack does not itself provide.
+
+Outgoing auth — why two settings are needed to forward one token:
+
+    Having no embedded broker to substitute a token does NOT mean ToolHive
+    forwards the client's. It forwards **nothing** unless told to. This stack
+    originally assumed otherwise, and the result was a total, silent outage:
+    the vMCP called the backend with no credential at all, witan's JWTVerifier
+    returned 401, and — because a backend whose resolved strategy is
+    ``unauthenticated`` has its 401 read as genuine misconfiguration rather
+    than as proof of life — the vMCP marked its only backend
+    ``unauthenticated`` and excluded it from capability aggregation. Clients
+    got a successful ``initialize`` and then ``tools/list`` failed, so every
+    external signal (pod ready, route resolving, TLS, 200 + session id) looked
+    healthy while the endpoint served zero tools. Two settings fix it, and
+    both are required:
+
+    - ``passthroughHeaders: ["Authorization"]`` is what actually forwards the
+      user's Keycloak JWT to witan. It applies to real session traffic only.
+    - ``outgoingAuth.backends.witan`` points at a ``headerInjection``
+      ``MCPExternalAuthConfig``. This is NOT how the backend authenticates —
+      witan ignores the injected header entirely. It exists because the
+      periodic backend health probe runs on a background context that carries
+      no client request and therefore no passthrough header, so the probe will
+      always 401. ToolHive treats a probe 401 as healthy when the backend has
+      *some* non-``unauthenticated`` strategy configured, and as a
+      misconfiguration when it does not. Configuring any such strategy is
+      what keeps the backend in the aggregated view; header injection is the
+      only one that neither sets ``Authorization`` (which would clobber the
+      passthrough token) nor needs new Keycloak plumbing.
+
+    The alternative, ``tokenExchange``, would authenticate the probe properly
+    via client-credentials instead of relying on 401-as-healthy, and would
+    still preserve per-user identity on real traffic. It is not used here
+    because it requires a confidential Keycloak client, realm-level token
+    exchange, and a rotated secret — where passthrough needs none of that,
+    since ``witan-cli`` already mints tokens with the ``witan`` audience that
+    witan's own verifier checks. Revisit if the probe's 401 noise or the
+    forwarded-header trust model becomes a problem.
 
 Follow-up work this stack does NOT cover, tracked separately rather than
 silently assumed:
@@ -103,6 +139,7 @@ from ol_infrastructure.applications.witan.ci_indexer import (
 from ol_infrastructure.applications.witan.ingress import create_ingress_resources
 from ol_infrastructure.applications.witan.mcp_servers import (
     MCP_GROUP_NAME,
+    WITAN_MCPSERVER_NAME,
     create_mcp_servers,
 )
 from ol_infrastructure.applications.witan.migrations import create_migration_job
@@ -720,14 +757,64 @@ mcp_oidc_config = kubernetes.apiextensions.CustomResource(
 )
 
 #########################################
+#   vMCP -> backend probe credential     #
+#########################################
+# Exists only to give the witan backend a non-`unauthenticated` outgoing-auth
+# strategy. See the "Outgoing auth" section of this module's docstring for why
+# that is load-bearing. The value is NOT a credential: witan never reads this
+# header, and the vMCP -> backend hop is ClusterIP-only. It is a fixed marker
+# because ToolHive's `headerInjection` strategy requires a non-empty
+# `valueSecretRef`, so a Secret is the only shape the CRD accepts. Deliberately
+# a plain Secret rather than a Vault-backed one — routing a constant with no
+# secret value through Vault would imply a rotation story that does not exist.
+VMCP_PROBE_HEADER_NAME = "X-Witan-Vmcp"
+VMCP_PROBE_SECRET_NAME = "witan-vmcp-backend-probe"  # noqa: S105  # pragma: allowlist secret
+VMCP_PROBE_SECRET_KEY = "value"  # noqa: S105  # pragma: allowlist secret
+VMCP_BACKEND_AUTH_CONFIG_NAME = "witan-vmcp-backend-auth"
+
+vmcp_probe_secret = kubernetes.core.v1.Secret(
+    f"witan-vmcp-backend-probe-secret-{stack_info.env_suffix}",
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        name=VMCP_PROBE_SECRET_NAME,
+        namespace=NAMESPACE,
+        labels=k8s_global_labels,
+    ),
+    string_data={VMCP_PROBE_SECRET_KEY: "witan-vmcp"},  # pragma: allowlist secret
+    opts=ResourceOptions(depends_on=[cluster_stack]),
+)
+
+vmcp_backend_auth_config = kubernetes.apiextensions.CustomResource(
+    f"witan-vmcp-backend-auth-{stack_info.env_suffix}",
+    api_version="toolhive.stacklok.dev/v1beta1",
+    kind="MCPExternalAuthConfig",
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        name=VMCP_BACKEND_AUTH_CONFIG_NAME,
+        namespace=NAMESPACE,
+        labels=k8s_global_labels,
+    ),
+    spec={
+        "type": "headerInjection",
+        "headerInjection": {
+            "headerName": VMCP_PROBE_HEADER_NAME,
+            "valueSecretRef": {
+                "name": VMCP_PROBE_SECRET_NAME,
+                "key": VMCP_PROBE_SECRET_KEY,
+            },
+        },
+    },
+    opts=ResourceOptions(depends_on=[vmcp_probe_secret]),
+)
+
+#########################################
 #   VirtualMCPServer aggregator          #
 #########################################
 # No authServerConfig block: unlike toolhive_swe, this vMCP is NOT an OAuth
 # provider of its own. incomingAuth validates the client's genuine Keycloak
-# JWT directly and — because there is no embedded auth server to substitute
-# a token — that same JWT reaches the witan MCPServer unmodified, which is
-# exactly the "External OIDC provider" scenario ADR-0009's Resolution
-# addendum specifies.
+# JWT directly, and `passthroughHeaders` then forwards that same JWT to the
+# witan MCPServer unmodified — which is exactly the "External OIDC provider"
+# scenario ADR-0009's Resolution addendum specifies. The forwarding is
+# explicit: ToolHive does not do it by default. See the "Outgoing auth"
+# section of this module's docstring.
 witan_virtualmcpserver = kubernetes.apiextensions.CustomResource(
     f"witan-vmcp-{stack_info.env_suffix}",
     api_version="toolhive.stacklok.dev/v1beta1",
@@ -747,6 +834,25 @@ witan_virtualmcpserver = kubernetes.apiextensions.CustomResource(
                 "resourceUrl": VMCP_RESOURCE_ID,
             },
         },
+        # The client's Keycloak bearer token, forwarded verbatim to the backend
+        # so witan's own JWTVerifier sees the *user's* token and derives the
+        # per-request actor from its `sub` (ADR-0004 D1/D2). Header-forwarding
+        # runs outermost on the outbound chain and is skip-if-present, so the
+        # header-injection strategy below (a different header name) coexists
+        # with it rather than overwriting it.
+        "passthroughHeaders": ["Authorization"],
+        "outgoingAuth": {
+            # `discovered` inspects each backend's own externalAuthConfigRef;
+            # witan's MCPServer deliberately has none (see mcp_servers.py), so
+            # the per-backend override below is what actually applies.
+            "source": "discovered",
+            "backends": {
+                WITAN_MCPSERVER_NAME: {
+                    "type": "externalAuthConfigRef",
+                    "externalAuthConfigRef": {"name": VMCP_BACKEND_AUTH_CONFIG_NAME},
+                },
+            },
+        },
         "serviceType": "ClusterIP",
         "config": {
             "aggregation": {
@@ -760,6 +866,7 @@ witan_virtualmcpserver = kubernetes.apiextensions.CustomResource(
             mcp_servers.group,
             *mcp_servers.servers,
             mcp_oidc_config,
+            vmcp_backend_auth_config,
             # Every Secret the backend MCPServer consumes, restated here even
             # though `*mcp_servers.servers` already carries them: Pulumi orders
             # transitively, so this changes nothing the engine does. It is kept

--- a/src/ol_infrastructure/applications/witan/__main__.py
+++ b/src/ol_infrastructure/applications/witan/__main__.py
@@ -77,6 +77,16 @@ Outgoing auth — why two settings are needed to forward one token:
       only one that neither sets ``Authorization`` (which would clobber the
       passthrough token) nor needs new Keycloak plumbing.
 
+      That 401-is-healthy rule is upstream's deliberate, tested design, not an
+      inference from observed behavior. At ToolHive v0.40.1 it is
+      ``authErrorStatus`` (``pkg/vmcp/health/checker.go:192``), reached from
+      ``categorizeError`` (same file, :154 and :168), and pinned by
+      ``TestHealthChecker_CheckHealth_AuthErrorWithOutgoingAuthIsHealthy``
+      (``pkg/vmcp/health/checker_test.go:691``) — whose table includes a
+      ``header_injection`` row asserting ``BackendHealthy`` and a nil error.
+      Cited because the claim is not verifiable from this repository, and the
+      whole outage came from an unverified assumption about this same hop.
+
     The alternative, ``tokenExchange``, would authenticate the probe properly
     via client-credentials instead of relying on 401-as-healthy, and would
     still preserve per-user identity on real traffic. It is not used here

--- a/src/ol_infrastructure/applications/witan/mcp_servers.py
+++ b/src/ol_infrastructure/applications/witan/mcp_servers.py
@@ -39,6 +39,14 @@ from ol_infrastructure.lib.pulumi_helper import StackInfo
 # Name shared by the MCPGroup and the VirtualMCPServer that references it.
 MCP_GROUP_NAME = "witan-tools"
 
+# The MCPServer resource name. ToolHive derives a workload's backend id from the
+# resource name, so this is also the key the vMCP's `outgoingAuth.backends`
+# map must use. A key that doesn't match resolves to no per-backend strategy at
+# all, which lands on the unauthenticated one — the exact failure the "Outgoing
+# auth" section of `__main__.py`'s docstring describes. Shared as a constant so
+# the two cannot drift.
+WITAN_MCPSERVER_NAME = "witan"
+
 # Mount path (inside the witan container) for the actor-tokens Secret volume.
 # The MCPServer CRD's own `volumes` field only supports hostPath mounts, so
 # this is wired via `spec.podTemplateSpec` (RawExtension) instead — see
@@ -101,7 +109,7 @@ def create_mcp_servers(  # noqa: PLR0913
         api_version="toolhive.stacklok.dev/v1beta1",
         kind="MCPServer",
         metadata=kubernetes.meta.v1.ObjectMetaArgs(
-            name="witan",
+            name=WITAN_MCPSERVER_NAME,
             namespace=namespace,
             labels=k8s_global_labels,
         ),


### PR DESCRIPTION
## What are the relevant tickets?

Fixes the P0 found while attempting Cedar acceptance criteria (`tk-p0-witan-vmcp-cannot-authenticate-to-its-own-wit-736095`). Unblocks remote-server registration and Cedar criteria 2 and 3.

## Description (What does it do?)

`witan.<env>.ol.mit.edu` — the only externally exposed boundary and the whole of ADR-0005 path (a): `witan login`, the remote CLI, every agent MCP client — **has served zero tools in CI, QA and Production since the pods first booted.**

Not a regression. The first health probe two seconds after boot already 401'd, and the consecutive-failure counters match pod age exactly in all three environments (CI 2370×30s ≈ 19.75h against a 19h pod, and likewise QA and Production). There has never been a successful interval.

### Why it happened

This stack assumed that having no embedded auth server meant ToolHive would forward the client's bearer token to the backend. It doesn't — **it forwards nothing unless told to.** The chain:

1. `outgoingAuth: source: discovered` inspects the backend MCPServer's own `externalAuthConfigRef`. Ours deliberately has none, so the resolved strategy is `unauthenticated`.
2. The vMCP calls witan with no credential. witan's `JWTVerifier` correctly returns 401.
3. ToolHive reads a probe 401 as *proof of life* only when the backend has some non-`unauthenticated` strategy; with `unauthenticated` it reads the same 401 as genuine misconfiguration and pins the backend to `BackendUnauthenticated`.
4. `filterHealthyBackends` excludes it from capability aggregation. With one backend, that's zero backends, so `tools/list` errors.

That is the observed symptom exactly: `initialize` succeeds (incoming OIDC genuinely works — a real Keycloak token is accepted and a session id issued), then the next request 404s `Session terminated`.

### Why nobody noticed

Every external signal said healthy: pod `1/1 Running`, HTTPRoute resolving, TLS terminating, `initialize` returning 200 with a session id. Only the vMCP's own logs showed it. Worth raising the observability task on the back of this.

### The fix — two settings, both required

- **`passthroughHeaders: ["Authorization"]`** is what actually forwards the user's Keycloak JWT, so witan derives the per-request actor from its `sub` (ADR-0004 D1/D2). `witan-cli` already stamps the `witan` audience witan's verifier checks, so **no Keycloak change is needed.**
- **`outgoingAuth.backends.witan` → a `headerInjection` MCPExternalAuthConfig.** This is *not* how the backend authenticates; witan ignores the header entirely. Health probes run on a background context that carries no client request, and therefore can never carry a passthrough header — so the probe will always 401. This is what makes ToolHive read that inevitable 401 as healthy and keep the backend in the aggregated view. Header injection is the only strategy that neither sets `Authorization` (which would clobber the passthrough token) nor needs new Keycloak plumbing.

Header-forwarding runs outermost on the outbound chain and is skip-if-present, while the auth strategy `Set`s unconditionally afterwards — so a *different* header name coexists with the passthrough token rather than overwriting it. That ordering is why the header name must not be `Authorization`.

### Why not `tokenExchange`

It would authenticate the probe properly via client-credentials instead of relying on 401-as-healthy, and would still preserve per-user identity on real traffic. Deferred because it needs a confidential Keycloak client, realm-level token exchange, and a rotated secret — where passthrough needs none. Rationale is recorded in the module docstring so the next person doesn't have to rediscover it.

Also: the MCPServer name is now a shared constant. ToolHive keys the `outgoingAuth.backends` map off the resource name, and a drifted key falls back to exactly the unauthenticated strategy that caused this outage.

The module docstring's claim that ToolHive "simply forwards the client's original bearer token" was the false premise behind the outage; it is corrected, with the full mechanism written down.

## How can this be tested?

`pulumi preview --stack CI` is clean and precisely scoped — **2 creates + 1 update, 42 unchanged**:

- `+ kubernetes:core/v1:Secret witan-vmcp-backend-probe-secret-ci`
- `+ MCPExternalAuthConfig witan-vmcp-backend-auth-ci`
- `~ VirtualMCPServer witan-vmcp-ci` — adds `passthroughHeaders` and `outgoingAuth.backends.witan`, nothing else

`pre-commit` (ruff format, ruff check, mypy, detect-secrets) passes.

After deploying to CI, the acceptance checks from the task:

```bash
# 1. consecutive_failures stops climbing and the backend reports healthy
kubectl --context operations-ci-readonly -n witan logs \
  $(kubectl --context operations-ci-readonly -n witan get pods -o name | grep vmcp) \
  --tail=50 | grep "backend remains unhealthy"

# 2. an external client gets a NON-EMPTY tool list
witan login && witan whoami

# 3. a real read end to end against the deployed endpoint
```

Criterion 4 (a monitored alert on vMCP backend health, so the next occurrence isn't found by accident 20 hours later) is deliberately **not** in this PR — it belongs with the observability work, and this incident is the case that justifies it.

Note the CI-only preview: QA and Production carry the same defect and the same fix, but should be rolled forward one environment at a time with the tool-list check above run in between.

## Additional Context

Two upstream ToolHive issues worth filing, both confirmed by reading v0.40.1:

- `filterHealthyBackends` treats `BackendUnauthenticated` as fatal with no override, so a backend that would authenticate fine on real per-user traffic is unreachable because a credential-less probe can't.
- `partialFailureMode` is declared, defaulted and validated but **never read by any runtime code** — setting `best_effort` does nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017XMEFpyywYMgcv1BeSkUsP