### PR TITLE
fix(starrocks): allow FE config guard for chart 1.11.7

### DIFF
--- a/src/ol_infrastructure/applications/starrocks/__main__.py
+++ b/src/ol_infrastructure/applications/starrocks/__main__.py
@@ -635,6 +635,9 @@ if starrocks_config.get_bool("use_cn"):
 # Ref: starrocks/values.yaml starrocksFESpec.config in the operator Helm chart.
 # Reviewed for 1.11.6: the only diff from 1.11.5 is an unrelated
 # externalTrafficPolicy service field; the fe.conf config block is unchanged.
+# Reviewed for 1.11.7: the only diff from 1.11.6 is unrelated csiVolumes
+# support (CSI ephemeral inline volumes); the fe.conf config block is
+# byte-identical.
 #
 # NOTE: The SSL keystore password appears in fe.conf (→ K8s ConfigMap). This is
 # an inherent limitation of StarRocks' SSL design; the password protects the
@@ -643,10 +646,10 @@ if (
     ssl_enabled
     or starrocks_config.get_bool("use_cn")
     or starrocks_config.get_bool("use_be")
-) and (STARROCKS_CHART_VERSION != "1.11.6"):
+) and (STARROCKS_CHART_VERSION not in ("1.11.6", "1.11.7")):
     msg = (
-        f"_FE_CONFIG_BASE was sourced from chart 1.11.6; review defaults for"
-        f" {STARROCKS_CHART_VERSION} before deploying with SSL or CN enabled"
+        f"_FE_CONFIG_BASE was sourced from chart 1.11.6/1.11.7; review defaults"
+        f" for {STARROCKS_CHART_VERSION} before deploying with SSL or CN enabled"
     )
     raise ValueError(msg)
 # Set JVM heap to 87.5 % of the container memory limit to leave headroom for

--- a/src/ol_infrastructure/applications/starrocks/__main__.py
+++ b/src/ol_infrastructure/applications/starrocks/__main__.py
@@ -649,7 +649,8 @@ if (
 ) and (STARROCKS_CHART_VERSION not in ("1.11.6", "1.11.7")):
     msg = (
         f"_FE_CONFIG_BASE was sourced from chart 1.11.6/1.11.7; review defaults"
-        f" for {STARROCKS_CHART_VERSION} before deploying with SSL or CN enabled"
+        f" for {STARROCKS_CHART_VERSION} before deploying with SSL, CN, or BE"
+        f" enabled"
     )
     raise ValueError(msg)
 # Set JVM heap to 87.5 % of the container memory limit to leave headroom for


### PR DESCRIPTION
### What are the relevant tickets?
N/A — fixes a broken CI/CD deploy pipeline.

### Description (What does it do?)
The `pulumi-starrocks` deploy pipeline (`deploy-ol-application-starrocks-lakehouse.ci`) was failing with:

```
ValueError: _FE_CONFIG_BASE was sourced from chart 1.11.6; review defaults for 1.11.7 before deploying with SSL or CN enabled
```

This is a deliberate guard in `src/ol_infrastructure/applications/starrocks/__main__.py` that raises when `STARROCKS_CHART_VERSION` (bumped by Renovate to `1.11.7`) no longer matches the version `_FE_CONFIG_BASE` was last reviewed against, and SSL/CN/BE mode is enabled. It forces a human to confirm the chart's `fe.conf` defaults haven't drifted before letting a deploy proceed with a config the code assembles by hand.

I pulled the `kube-starrocks` Helm chart at both `1.11.6` and `1.11.7` from `https://starrocks.github.io/starrocks-kubernetes-operator` and diffed `charts/starrocks/values.yaml`. The only change in `starrocksFESpec` (and the equivalent CN/BE specs) between the two versions is the addition of unrelated `csiVolumes` support (CSI ephemeral inline volume mounts); the `starrocksFESpec.config` (`fe.conf`) default block is byte-for-byte identical.

Updated the guard to accept `1.11.7` in addition to `1.11.6`, and added a "Reviewed for 1.11.7" comment documenting the diff, matching the existing pattern for the `1.11.6` review.

### How can this be tested?
```
cd src/ol_infrastructure/applications/starrocks
pulumi stack select lakehouse.CI
pulumi preview
```
Before this change, `pulumi preview`/`up` on the `lakehouse.CI` stack (which has `use_cn`/SSL enabled) raised the `ValueError` above before reaching the helm release diff. After this change, preview completes and shows only the expected helm chart version bump (`~version` diff on the `starrocks-lakehouse-ci-helm-release` resource) plus the routine kubeconfig diff — no other resource changes.

Ran `uv run pre-commit run --files src/ol_infrastructure/applications/starrocks/__main__.py` (includes ruff, mypy) — all hooks passed.

### Additional Context
Failing build for reference: https://cicd.odl.mit.edu/teams/infrastructure/pipelines/pulumi-starrocks/jobs/deploy-ol-application-starrocks-lakehouse.ci/builds/92