### PR TITLE
fix(witan): stop the vMCP renaming every tool, so clients can find them

### DIFF
--- a/src/ol_infrastructure/applications/witan/__main__.py
+++ b/src/ol_infrastructure/applications/witan/__main__.py
@@ -865,9 +865,28 @@ witan_virtualmcpserver = kubernetes.apiextensions.CustomResource(
         },
         "serviceType": "ClusterIP",
         "config": {
+            # `priority`, NOT the CRD's `prefix` default, because prefix mode
+            # renames unconditionally: it does no conflict detection at all, so
+            # with witan as the group's only member it still rewrote all 65
+            # tools to `witan_*` and no client asking for `memory_search` could
+            # find them. `priority` leaves a tool whose name is unique across
+            # the group exactly as the backend published it, which — since
+            # nothing else is in the group — is every tool.
+            #
+            # There is no "don't rename anything" setting: the enum is
+            # prefix/priority/manual and an empty prefixFormat is rejected, so
+            # bare names have to come from one of the other two strategies.
+            # `manual` would also work; `priority` is chosen because its one
+            # downside (on a name collision the loser is dropped with only a
+            # log line, where manual fails the whole tools/list loudly) needs
+            # two backends to be reachable, and witan-code is mounted
+            # in-process rather than deployed separately.
             "aggregation": {
-                "conflictResolution": "prefix",
-                "conflictResolutionConfig": {"prefixFormat": "{workload}_"},
+                "conflictResolution": "priority",
+                # Required and must be non-empty — the vMCP refuses to start
+                # otherwise, and the CRD does not catch it, so a missing entry
+                # here is a CrashLoop rather than a rejected apply.
+                "conflictResolutionConfig": {"priorityOrder": [WITAN_MCPSERVER_NAME]},
             },
         },
     },

--- a/src/ol_infrastructure/applications/witan/mcp_servers.py
+++ b/src/ol_infrastructure/applications/witan/mcp_servers.py
@@ -1,10 +1,19 @@
 """Backend MCP server definition for witan.
 
 The ``witan-tools`` ``MCPGroup`` exists so the ``VirtualMCPServer`` in
-``__main__.py`` can front the group behind a single endpoint, following the
-``toolhive_swe`` pattern even though — today — witan is the group's only
-member. This leaves room to add a second backend (e.g. a dedicated
-``witan-code`` workload) later without restructuring the ingress/auth layer.
+``__main__.py`` can front it behind a single endpoint, following the
+``toolhive_swe`` pattern. witan is the group's only member, and is expected to
+stay that way: the code-graph tools are mounted **in-process** by ``witan
+serve`` (``witan_mcp.mount(code_mcp)``, agent-kit
+``mcp/servers/witan/witan/cli/__init__.py``), not run as a separate workload,
+and there is no intent to split them out. The group and the vMCP earn their
+keep as the OIDC and ingress boundary, not as an aggregation point.
+
+An earlier version of this docstring justified the group as leaving room for a
+second backend. That framing is what led ``__main__.py`` to accept the CRD's
+default ``conflictResolution: prefix``, which renamed every tool to
+``witan_*`` and broke every client. Aggregation config there is now set for
+the single-backend reality; see the comment on ``config.aggregation``.
 
 Unlike every backend in ``toolhive_swe`` (fetch/grafana/context7/sentry, which
 carry no identity of their own and trust the vMCP's auth wholesale), witan


### PR DESCRIPTION
## What are the relevant tickets?

Follow-on to #5295. Tracked as `tk-deployed-vmcp-prefixes-every-tool-as-witan-so-th-12816d`. Unblocks ADR-0005 path (a) — `witan login` + remote CLI.

## Description (What does it do?)

#5295 got the vMCP serving tools again. This makes them **usable**.

The endpoint advertises 65 tools, every one renamed `witan_*`. So against a deployed environment:

```
$ WITAN_REMOTE_URL=https://witan.ci.ol.mit.edu witan memory list --kind pattern
The deployed witan service exposes no `memory_search` tool.
```

The tool is there — as `witan_memory_search`, a name no client asks for. Path (a) is still not usable end to end without this.

### Cause

ToolHive's `prefix` strategy **does no conflict detection at all**. `pkg/vmcp/aggregator/prefix_resolver.go:38-78` iterates every backend × every tool and prefixes unconditionally; `applyPrefix` (:81-88) is a blind string substitution. witan is the only member of `witan-tools`, so there was never a conflict to resolve — the rename was pure loss. `{workload}` is the Backend ID, i.e. the MCPServer resource name (`pkg/vmcp/workloads/k8s.go:269-270`).

### Why `priority`

`priority` leaves any tool whose name is unique across the group exactly as the backend published it (`priority_resolver.go:68-83`) — which is every tool here.

There is no "rename nothing" setting: the enum is `prefix|priority|manual`, and an empty `prefixFormat` is rejected (`pkg/vmcp/config/validator.go:350-352`). So bare names have to come from one of the other two.

`manual` would work equally well and fails *loudly* on a collision (`ErrUnresolvedConflicts` takes down the whole `tools/list`), where `priority` drops the loser with only a `slog.Warn`. `priority` wins anyway because that downside needs **two reachable backends**, and the code-graph tools are mounted in-process by `witan serve` (`witan_mcp.mount(code_mcp)`) rather than deployed as a second workload — with no intent to split them out. `priority` also needs less ceremony: `manual` additionally requires a non-empty `aggregation.tools`.

⚠️ `priorityOrder` must be non-empty or the vMCP **refuses to start**, and the CRD does not catch it (`virtualmcpserver_types.go:682` only checks it when `conflictResolutionConfig` is non-nil). A missing entry is a CrashLoop, not a rejected apply. Noted at the call site so it isn't "cleaned up" later.

### Docstring correction

`mcp_servers.py` justified the MCPGroup as leaving room for a second backend. That framing is what made accepting the CRD's `prefix` default look harmless. Corrected: the group and vMCP earn their keep as the OIDC and ingress boundary, not as an aggregation point.

## How can this be tested?

`pulumi preview --stack CI` is exactly one resource: **1 to update, 44 unchanged**.

```
~ VirtualMCPServer witan-vmcp-ci
  ~ spec.config.aggregation:
      ~ conflictResolution      : "prefix" => "priority"
      ~ conflictResolutionConfig:
          - prefixFormat : "{workload}_"
          + priorityOrder: ["witan"]
```

`pre-commit` (ruff format, ruff check, mypy, detect-secrets) passes.

After deploy to CI, the check that currently fails:

```bash
WITAN_REMOTE_URL=https://witan.ci.ol.mit.edu \
WITAN_OIDC_ISSUER=https://sso-ci.ol.mit.edu/realms/ol-platform-engineering \
  witan memory list --kind pattern     # should return rows, not "exposes no memory_search tool"
```

and a raw `tools/list` should show bare `memory_search` / `recall` / `code_find_definition` rather than `witan_*`.

**No client is relying on the prefixed names** — the tier served zero tools until #5295 merged earlier today, so there is nothing deployed to break. That window is why this is worth doing now rather than adding prefix-tolerance to clients.

## Additional Context

Verified against ToolHive v0.40.1 (the deployed version) rather than inferred — the same discipline #5295's review asked for, since an unverified assumption about this vMCP is what caused that outage.

Separately worth fixing in agent-kit: the CLI claims the service "exposes no X tool" when it received a tool list it failed to match. It should report what it found, so a naming mismatch doesn't read as a missing feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017XMEFpyywYMgcv1BeSkUsP