### PR TITLE
Phase 3.5: two property-targeted org rulesets, at evaluate

### DIFF
--- a/docs/plans/github-org-pulumi-import.md
+++ b/docs/plans/github-org-pulumi-import.md
@@ -971,7 +971,7 @@ and route findings to the project's witan task list.
 | **1** | Build `bin/github-org-inventory`. Crawl. Human-confirm archetype per repo. Commit `data/`. | 317 repos classified; estate report reviewed |
 | **2** | Author `organization/`. Import org settings and the 14 teams — **not** members or team rosters (§4.7). Define the `tier` custom-property schema (§5.4) — a prerequisite, not a fast-follow. | **Empty diff** on `ol-saas-github-organization` |
 | **3** | Author `repositories/`. Import in ~25-repo batches, including each repo's `tier` value. | **Empty diff** after every batch, and on the whole stack |
-| **3.5** | Add the two property-targeted org rulesets at `enforcement: evaluate`. Watch, then promote to `active`. | Rule-suite logs show the expected repos matching and no surprises |
+| **3.5** | Add the two property-targeted org rulesets at `enforcement: evaluate`. Watch, then promote to `active` by flipping `_ENFORCEMENT` in `organization/org_rulesets.py`. | Rule-suite logs show the expected repos matching and no surprises |
 | **4** | Build `bin/github-estate-audit`. Run all three axes. Emit witan tasks. | Backlog exists and is triaged |
 | **5** | Remediate by tightening archetypes, not per-repo edits. Land in reviewed waves. | Each wave previews clean and is approved |
 | **6** | Nightly `drift` job in Concourse; org custom-properties schema populated; consider Vault-sourced Actions secrets. | Drift job green |

--- a/src/ol_infrastructure/saas/github/organization/__main__.py
+++ b/src/ol_infrastructure/saas/github/organization/__main__.py
@@ -1,7 +1,7 @@
 """Management of the mitodl GitHub organization, its teams, and the `tier` schema.
 
-Phase 2 of docs/plans/github-org-pulumi-import.md. Fifteen resources: org settings, the
-14 teams, and the custom property that org rulesets will target.
+Phases 2 and 3.5 of docs/plans/github-org-pulumi-import.md: org settings, the 14
+teams, the `tier` custom property, and the two org rulesets that target it.
 
 Deliberately absent, each for a reason worth knowing:
 
@@ -11,10 +11,6 @@ Deliberately absent, each for a reason worth knowing:
       at the cost of a PR per hire, departure and team move -- on a stack gated behind
       manual approval. It also removes the highest-blast-radius resource in the estate,
       since deleting a Membership evicts a human from the org.
-
-  OrganizationRuleset
-      Phase 3.5, and NOT before the repositories project has set per-repo tiers. See the
-      sequencing hazard documented in custom_properties.py.
 
   OrganizationWebhook
       None exist (crawl 2026-08-05).
@@ -34,6 +30,7 @@ setup_github_provider()
 
 from ol_infrastructure.saas.github.organization import (  # noqa: E402, F401
     custom_properties,
+    org_rulesets,
     org_settings,
     teams,
 )

--- a/src/ol_infrastructure/saas/github/organization/__main__.py
+++ b/src/ol_infrastructure/saas/github/organization/__main__.py
@@ -18,8 +18,11 @@ Deliberately absent, each for a reason worth knowing:
   OrganizationCustomRole / OrganizationRepositoryRole
       Enterprise-only; 404 on the Team plan. Withdrawn from scope entirely.
 
-Everything except `tier` is an import of something that already exists, so after the
-first apply this stack should preview clean. That empty diff is the gate (§6).
+Three resources here are new creates -- the `tier` property schema and the two org
+rulesets, none of which exist on GitHub today. Everything else, the org settings and
+the 14 teams, is an import of something that already exists. So the empty-diff gate
+(§6) applies from the SECOND preview: the first apply creates those three, and every
+preview after it should be clean.
 """
 
 from ol_infrastructure.lib.github_helper import setup_github_provider

--- a/src/ol_infrastructure/saas/github/organization/org_rulesets.py
+++ b/src/ol_infrastructure/saas/github/organization/org_rulesets.py
@@ -1,0 +1,133 @@
+"""Org rulesets, targeted by the `tier` custom property.
+
+Two rulesets replace what would otherwise be ~176 near-identical per-repo
+`RepositoryRuleset` resources. Tightening the baseline becomes a one-line change to
+one object rather than a fleet-wide rollout, and a new repo is protected the moment
+its `tier` is set -- which, because `tier` has a default, is at creation (§3.5).
+
+BOTH LAND AT `enforcement: evaluate`. Evaluate mode logs what *would* have been
+blocked without blocking it, so the baseline can be watched against real traffic
+before it starts failing anyone's push. Probe check C7 confirmed evaluate is
+available on the Team plan; without it this would have to roll out blind.
+
+  Promotion to `active` is a deliberate, separate change: flip `_ENFORCEMENT` to
+  "active" after reading the rule-suite logs at
+  https://github.com/organizations/mitodl/settings/rules -- and expect it to be the
+  moment CI stops being advisory (SEC-03 fires on 175 of 176 active repos today).
+
+ORDERING. These must not be applied before `ol-saas-github-repositories` has set
+per-repo tiers. Until then every repo carries the property default `standard`, which
+`baseline-default-branch` targets -- so applying early would sweep in all 102 forks
+and 140 archived repos. Evaluate mode makes that survivable rather than harmless:
+nothing would be blocked, but the rule-suite logs would be full of noise from repos
+that are meant to be untargeted. See organization/custom_properties.py.
+
+A READ-API GOTCHA THAT AFFECTS DRIFT DETECTION. Probe controls C6a/C6b established
+that no read endpoint reports a non-`active` ruleset as applying to a repo: a ruleset
+in evaluate mode is invisible to both `/repos/{repo}/rulesets?includes_parents=true`
+and `/repos/{repo}/rules/branches/{branch}`. While these sit at `evaluate`, the only
+way to see them is `/orgs/{org}/rulesets`. Any drift check that uses the
+effective-rules endpoints will report them as absent and be wrong.
+"""
+
+import pulumi_github as github
+from pulumi import ResourceOptions
+
+from ol_infrastructure.saas.github.tiers import (
+    TIER_ONE,
+    TIER_PROPERTY_NAME,
+    TIER_STANDARD,
+)
+
+#: Flip to "active" only after watching the rule-suite logs. See the module docstring.
+_ENFORCEMENT = "evaluate"
+
+#: `~DEFAULT_BRANCH` is GitHub's alias for whatever each repo's default branch is,
+#: which is what makes one ruleset work across a fleet where 102 repos are on
+#: `master` and the rest on `main` (§3.4).
+_DEFAULT_BRANCH_ONLY = github.OrganizationRulesetConditionsRefNameArgs(
+    includes=["~DEFAULT_BRANCH"],
+    excludes=[],
+)
+
+
+def _tier_condition(*tiers: str) -> github.OrganizationRulesetConditionsArgs:
+    """Match repos whose `tier` property is one of `tiers`.
+
+    `source: "custom"` distinguishes our property from GitHub's system properties
+    (`visibility`, `language`, `fork`). Probe check C6c confirmed this genuinely
+    matches -- the labelled repo saw the ruleset, the unlabelled control did not,
+    and both read endpoints agreed -- which is the empirical basis for the whole
+    org-ruleset design rather than per-repo resources.
+    """
+    return github.OrganizationRulesetConditionsArgs(
+        ref_name=_DEFAULT_BRANCH_ONLY,
+        repository_property=github.OrganizationRulesetConditionsRepositoryPropertyArgs(
+            includes=[
+                github.OrganizationRulesetConditionsRepositoryPropertyIncludeArgs(
+                    name=TIER_PROPERTY_NAME,
+                    property_values=list(tiers),
+                    source="custom",
+                )
+            ],
+            excludes=[],
+        ),
+    )
+
+
+# Everything that is not a fork and not archived. `standard` is in scope because it
+# is the property default, so a brand-new repo is covered before anyone classifies
+# it -- that is the entire point of the default (§3.5).
+baseline_default_branch = github.OrganizationRuleset(
+    "mitodl-ruleset-baseline-default-branch",
+    name="baseline-default-branch",
+    target="branch",
+    enforcement=_ENFORCEMENT,
+    conditions=_tier_condition(TIER_ONE, TIER_STANDARD),
+    rules=github.OrganizationRulesetRulesArgs(
+        # No force-pushing over the default branch, and no deleting it.
+        non_fast_forward=True,
+        deletion=True,
+        pull_request=github.OrganizationRulesetRulesPullRequestArgs(
+            required_approving_review_count=1,
+            dismiss_stale_reviews_on_push=True,
+        ),
+    ),
+    opts=ResourceOptions(protect=True),
+)
+
+# Tier-1 is application, library and infrastructure -- 74 repos. The two extra rules
+# are the ones that cost a reviewer nothing but close real gaps: an approval that
+# predates the last push is not an approval of what merges, and an unresolved
+# conversation is feedback that was never answered.
+tier_one_hardening = github.OrganizationRuleset(
+    "mitodl-ruleset-tier-1-hardening",
+    name="tier-1-hardening",
+    target="branch",
+    enforcement=_ENFORCEMENT,
+    conditions=_tier_condition(TIER_ONE),
+    rules=github.OrganizationRulesetRulesArgs(
+        pull_request=github.OrganizationRulesetRulesPullRequestArgs(
+            require_last_push_approval=True,
+            required_review_thread_resolution=True,
+        ),
+    ),
+    opts=ResourceOptions(protect=True),
+)
+
+# NOT DEFINED, deliberately:
+#
+#   archived-freeze   Dropped 2026-08-05. It would have enforced read-only on repos
+#                     GitHub already refuses writes to -- a resource to maintain for
+#                     nothing. Archived repos take `tier: unmanaged` instead, which
+#                     nothing targets (§5.4).
+#
+#   required_status_checks
+#                     Stays per-repo. Check names differ (`javascript-tests` vs
+#                     `python-tests`), so there is no fleet-wide value to assert.
+#                     This is why DX-02 and DX-03 remain per-repo audit rules.
+#
+#   copilot_code_review
+#                     Supported on OrganizationRuleset and arguably belongs here --
+#                     six repos carry a hand-made per-repo ruleset for it today. Left
+#                     out pending the decision in the Copilot governance task (§4.6).

--- a/src/ol_infrastructure/saas/github/organization/org_rulesets.py
+++ b/src/ol_infrastructure/saas/github/organization/org_rulesets.py
@@ -12,8 +12,11 @@ available on the Team plan; without it this would have to roll out blind.
 
   Promotion to `active` is a deliberate, separate change: flip `_ENFORCEMENT` to
   "active" after reading the rule-suite logs at
-  https://github.com/organizations/mitodl/settings/rules -- and expect it to be the
-  moment CI stops being advisory (SEC-03 fires on 175 of 176 active repos today).
+  https://github.com/organizations/mitodl/settings/rules. What starts blocking then is
+  exactly what is declared below: force-push and deletion of the default branch, and
+  merging without an approving review. CI stays advisory either way -- neither ruleset
+  carries `required_status_checks` (see the omissions at the foot of this file), so
+  SEC-03 is untouched by the flip and remains a per-repo audit finding.
 
 ORDERING. These must not be applied before `ol-saas-github-repositories` has set
 per-repo tiers. Until then every repo carries the property default `standard`, which


### PR DESCRIPTION
### What are the relevant tickets?

N/A — **third layer of a stack**. Base is `worktree-github-phase3-repositories` (#5297), which is based on `worktree-github-phase2-organization` (#5288). Review in order: 5288 → 5297 → this. Tracked in witan under `wp-import-the-mitodl-github-organization-into-pulum-47211a`.

### Description (What does it do?)

Phase 3.5: two `OrganizationRuleset` resources targeting the `tier` custom property, both at `enforcement: evaluate`.

**Merging changes nothing on GitHub.** Nothing in the stack has been applied.

| Ruleset | Targets | Enforces |
|---|---|---|
| `baseline-default-branch` | `tier ∈ (tier-1, standard)` | no force-push, no deletion, 1 approving review, dismiss stale reviews on push |
| `tier-1-hardening` | `tier = tier-1` (74 repos) | require last-push approval, require conversation resolution |

The org stack now previews:

```
Resources:
    + 3 to create        <- the tier property + these two rulesets
    17 unchanged
```

**Two objects instead of ~176 near-identical per-repo rulesets.** Tightening the baseline becomes a one-line change rather than a fleet-wide rollout, and a new repo is covered the moment its `tier` is set — which, because `tier` has a default, is at creation (§3.5).

Conditions match on **`~DEFAULT_BRANCH`** rather than a branch name, which is what lets one ruleset span a fleet where 102 repos are still on `master` and the rest on `main`. That alias is not an assumption — `bin/github-ruleset-capability-probe` used it against the live API when it established C1–C9.

#### Why both land at `evaluate`

Evaluate mode logs what *would* have been blocked without blocking it. Probe check C7 established that evaluate is available on the Team plan; without it this would have to roll out blind.

That matters more than usual here: **SEC-03 says CI is advisory on 175 of 176 active repos**, so the first `active` apply is the moment that stops being true fleet-wide. Promotion is a deliberate one-line change — flip `_ENFORCEMENT` to `"active"` in `organization/org_rulesets.py` — after reading the rule-suite logs at `https://github.com/organizations/mitodl/settings/rules`.

#### Two things recorded because they are easy to get wrong later

**Ordering.** These must not be applied before `ol-saas-github-repositories` sets per-repo tiers. Until then every repo carries the property default `standard`, which `baseline-default-branch` targets — so an early apply would sweep in all 102 forks and 140 archived repos. Evaluate mode makes that survivable rather than harmless: nothing blocks, but the rule-suite logs fill with noise from repos that are meant to be untargeted.

**A read-API gotcha that will break drift detection if forgotten.** Probe controls C6a/C6b established that no read endpoint reports a non-`active` ruleset as applying to a repo. While these sit at `evaluate` they are invisible to both `/repos/{repo}/rulesets?includes_parents=true` and `/repos/{repo}/rules/branches/{branch}`. The only endpoint that sees them is `/orgs/{org}/rulesets`. A drift check built on the effective-rules endpoints will report them as absent and be wrong.

#### Deliberately not defined

- **`archived-freeze`** — dropped 2026-08-05. It would have enforced read-only on repos GitHub already refuses writes to. Archived repos take `tier: unmanaged`, which nothing targets.
- **`required_status_checks`** — stays per-repo. Check names differ (`javascript-tests` vs `python-tests`), so there is no fleet-wide value to assert. This is why DX-02/DX-03 remain per-repo audit rules.
- **`copilot_code_review`** — supported on `OrganizationRuleset`, and arguably belongs here since six repos carry a hand-made per-repo ruleset for it today. Left out pending the Copilot governance decision (§4.6).

### How can this be tested?

Requires the sops key for `src/bridge/secrets/pulumi/github_app.yaml` and AWS credentials for the KMS secrets provider.

```sh
cd src/ol_infrastructure/saas/github/organization
pulumi stack select default
pulumi preview --diff
#     + 3 to create
#     17 unchanged
```

The diff shows both rulesets with `enforcement: "evaluate"` and a `repositoryProperty` condition naming `tier` with `source: "custom"` — the form probe check C6c proved actually matches (labelled repo saw the ruleset, unlabelled control did not, both read endpoints agreed).

### Additional Context

**The apply sequence now spans all three PRs**, and the order is not optional:

1. `ol-saas-github-organization` — define `tier`; every repo becomes `standard` by default
2. `ol-saas-github-repositories` — set explicit values; forks and archived become `unmanaged`
3. `ol-saas-github-organization` again — the rulesets, at `evaluate`
4. later, deliberately — promote to `active`

Steps 1 and 3 are the same stack, so in practice it is: apply the org stack without rulesets, apply repositories, then apply the org stack again with rulesets. Landing 3.5 as code does not force that order — **the apply does**, and the hazard is invisible in preview because what changes is which repos *match*, and matching is not a Pulumi resource.

**Note on CI coverage for this stack:** PRs targeting a non-default branch do not get GitHub's default CodeQL setup (`Analyze (actions)`, `Analyze (python)`, `CodeQL`), which is configured repo-wide and runs on PRs into `main`. #5297 and this PR therefore have `test`, `pre-commit.ci` and GitGuardian but no static analysis until they retarget to `main` as the stack merges down.
