### PR TITLE
Phase 4: estate audit as a query over committed data

### DIFF
--- a/bin/github-estate-audit
+++ b/bin/github-estate-audit
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Audit the mitodl GitHub estate from the committed fleet data.
+
+Phase 4 of docs/plans/github-org-pulumi-import.md. The rules live in
+`ol_infrastructure.saas.github.audit` as pure functions; this is the CLI around them.
+
+    github-estate-audit run                    # all axes, text
+    github-estate-audit run --axis security    # one axis
+    github-estate-audit run --json             # machine-readable, for CI
+    github-estate-audit drift                  # live GitHub vs. the committed data
+
+`run` needs NO credentials and hits NO API -- it reads data/repos/, which is why it
+finishes in milliseconds and works anywhere. `drift` is the exception: comparing
+declared against live is the one job that requires both.
+"""
+
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Annotated
+
+import cyclopts
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from ol_infrastructure.saas.github import audit
+from ol_infrastructure.saas.github.repositories import archetypes
+
+app = cyclopts.App(help="Audit the mitodl GitHub estate.")
+
+SEVERITY_ORDER = {"high": 0, "medium": 1, "low": 2}
+
+
+@app.command
+def run(
+    *,
+    axis: Annotated[
+        str | None, cyclopts.Parameter(help="Restrict to one axis.")
+    ] = None,
+    as_json: Annotated[
+        bool, cyclopts.Parameter(name=["--json"], help="Emit JSON instead of text.")
+    ] = False,
+    fail_on: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            help="Exit non-zero if any finding is at or above this severity."
+        ),
+    ] = None,
+) -> int:
+    """Report every rule that fires across the fleet."""
+    fleet = archetypes.load_fleet()
+    findings = audit.evaluate(fleet)
+    if axis:
+        findings = [f for f in findings if f.axis == axis]
+
+    by_rule = Counter(f.rule_id for f in findings)
+    rules = {r.rule_id: r for r in audit.RULES}
+
+    if as_json:
+        print(
+            json.dumps(
+                {
+                    "repos": len(fleet),
+                    "findings": len(findings),
+                    "by_rule": dict(by_rule),
+                    "detail": [f.__dict__ for f in findings],
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(
+            f"# mitodl estate audit -- {len(fleet)} repos, {len(findings)} findings\n"
+        )
+        ordered = sorted(
+            by_rule,
+            key=lambda rid: (SEVERITY_ORDER[rules[rid].severity], -by_rule[rid]),
+        )
+        for rule_id in ordered:
+            rule = rules[rule_id]
+            total = audit.population(fleet, rule.scope)
+            share = f"{by_rule[rule_id] / total:.0%}" if total else "-"
+            print(
+                f"  {rule.severity:6} {rule_id:8} {by_rule[rule_id]:4} "
+                f"({share:>4} of {total} {rule.scope})  {rule.summary}"
+            )
+        print("\nWorst offenders, by number of findings:")
+        for repo, count in Counter(f.repo for f in findings).most_common(8):
+            print(f"     {count:4}  {repo}")
+
+    if fail_on:
+        threshold = SEVERITY_ORDER[fail_on]
+        blocking = [f for f in findings if SEVERITY_ORDER[f.severity] <= threshold]
+        if blocking:
+            print(
+                f"\n{len(blocking)} finding(s) at or above {fail_on}", file=sys.stderr
+            )
+            return 1
+    return 0
+
+
+@app.command
+def drift(
+    *,
+    cache: Annotated[
+        Path, cyclopts.Parameter(help="Crawl cache to compare against.")
+    ] = Path(".github-org-inventory-cache.json"),
+) -> int:
+    """Compare the committed fleet data against a fresh crawl.
+
+    This is what keeps the estate managed after the import: an out-of-band console
+    change shows up here. Refresh the cache first --
+
+        uv run bin/github-org-inventory report --refresh
+
+    -- because this command deliberately does not crawl on its own. Keeping the fetch
+    and the comparison separate means a drift report can be re-run against the same
+    snapshot while investigating, instead of shifting under you.
+
+    NOTE for when the phase-3.5 rulesets land: while they sit at `enforcement:
+    evaluate` they are invisible to the per-repo read endpoints, so `_ruleset_count`
+    will not see them. Any ruleset-aware drift check must enumerate
+    `/orgs/{org}/rulesets` directly -- see probe controls C6a/C6b.
+    """
+    if not cache.exists():
+        print(f"no crawl cache at {cache}; run `github-org-inventory report --refresh`")
+        return 1
+    live = {r["name"]: r for r in json.loads(cache.read_text())["repos"]}
+    declared = {r["name"]: r for r in archetypes.load_fleet()}
+
+    only_live = sorted(set(live) - set(declared))
+    only_declared = sorted(set(declared) - set(live))
+    changed: list[str] = []
+    # Compare only the fields the fleet data actually declares. Anything else is
+    # inventory that moves on its own (pushed_at, environment counts) and would make
+    # every run look like drift.
+    tracked = (
+        "description",
+        "default_branch",
+        "archived",
+        "allow_squash_merge",
+        "allow_merge_commit",
+        "allow_rebase_merge",
+        "allow_auto_merge",
+        "delete_branch_on_merge",
+        "has_issues",
+        "has_wiki",
+        "secret_scanning",
+        "secret_scanning_push_protection",
+        "teams",
+    )
+    for name in sorted(set(live) & set(declared)):
+        for field in tracked:
+            want = declared[name].get(field)
+            got = live[name].get(field)
+            if want is not None and want != got:
+                changed.append(f"{name}.{field}: declared {want!r}, live {got!r}")
+
+    for name in only_live:
+        print(f"  UNMANAGED   {name} exists on GitHub but has no fleet entry")
+    for name in only_declared:
+        print(f"  MISSING     {name} is declared but not on GitHub")
+    for line in changed:
+        print(f"  DRIFT       {line}")
+
+    total = len(only_live) + len(only_declared) + len(changed)
+    print(f"\n{total} difference(s) between the committed fleet and {cache}")
+    return 1 if total else 0
+
+
+if __name__ == "__main__":
+    app()

--- a/bin/github-estate-audit
+++ b/bin/github-estate-audit
@@ -35,14 +35,21 @@ SEVERITY_ORDER = {"high": 0, "medium": 1, "low": 2}
 @app.command
 def run(
     *,
+    # Literal, not str: cyclopts then rejects a typo and lists the valid choices.
+    # `--axis securty` under a bare `str` would filter to zero findings and print a
+    # clean report -- an unmeasured axis and a clean one look identical, and only one
+    # of them is good news. That is the same trap audit.py's scope handling exists to
+    # avoid, so the CLI should not reintroduce it at the edge.
     axis: Annotated[
-        str | None, cyclopts.Parameter(help="Restrict to one axis.")
+        audit.Axis | None, cyclopts.Parameter(help="Restrict to one axis.")
     ] = None,
     as_json: Annotated[
         bool, cyclopts.Parameter(name=["--json"], help="Emit JSON instead of text.")
     ] = False,
+    # Literal for the same reason, plus a concrete one: the body indexes
+    # SEVERITY_ORDER[fail_on] directly, so an unvalidated typo raised KeyError.
     fail_on: Annotated[
-        str | None,
+        audit.Severity | None,
         cyclopts.Parameter(
             help="Exit non-zero if any finding is at or above this severity."
         ),

--- a/bin/github-org-inventory
+++ b/bin/github-org-inventory
@@ -919,12 +919,22 @@ def crawl(
             if field not in effective[archetype] and repo.get(field) is not None:
                 doc[field] = repo[field]
         doc.update(_deviations(repo, effective[archetype]))
-        # Environments are NEVER imported wholesale (§4.3). Record what was skipped so
-        # the exclusion stays visible rather than becoming silent.
+        # `_`-prefixed keys are INVENTORY, not configuration: nothing generates a
+        # Pulumi resource from them. They exist so `bin/github-estate-audit` is a query
+        # over committed data rather than an API crawl -- which makes it fast, testable
+        # with fixtures, and diffable in git over time. See data/README.md.
         if repo["environment_count"]:
+            # Environments are NEVER imported wholesale (§4.3). Recording the count
+            # keeps the exclusion visible rather than silent.
             doc["_excluded_environments"] = repo["environment_count"]
         if repo["actions_secrets"]:
             doc["_actions_secret_names"] = [s["name"] for s in repo["actions_secrets"]]
+        doc["_visibility"] = repo["visibility"]
+        doc["_pushed_at"] = repo["pushed_at"]
+        doc["_has_branch_protection"] = repo["has_branch_protection"]
+        doc["_ruleset_count"] = repo["ruleset_count"]
+        if repo.get("direct_collaborators"):
+            doc["_direct_collaborators"] = repo["direct_collaborators"]
 
         (out / f"{repo['name']}.yaml").write_text(
             # The leading `---` matches what the repo's YAML formatter enforces. Without

--- a/src/ol_infrastructure/saas/github/audit.py
+++ b/src/ol_infrastructure/saas/github/audit.py
@@ -25,6 +25,7 @@ from typing import Any, Literal
 
 Axis = Literal["security", "consistency", "developer-experience"]
 Scope = Literal["active", "archived", "fleet"]
+Severity = Literal["high", "medium", "low"]
 
 #: A repo is an archive candidate (DX-07) after this long with no push.
 STALE_DAYS = 365
@@ -44,7 +45,7 @@ class Finding:
 
     rule_id: str
     axis: Axis
-    severity: Literal["high", "medium", "low"]
+    severity: Severity
     repo: str
     current: str
     expected: str
@@ -57,7 +58,7 @@ class Rule:
 
     rule_id: str
     axis: Axis
-    severity: Literal["high", "medium", "low"]
+    severity: Severity
     scope: Scope
     summary: str
     check: Callable[[dict[str, Any]], tuple[str, str, str] | None]

--- a/src/ol_infrastructure/saas/github/audit.py
+++ b/src/ol_infrastructure/saas/github/audit.py
@@ -1,0 +1,318 @@
+"""Estate audit rules: pure functions over the resolved fleet model.
+
+Phase 4 of docs/plans/github-org-pulumi-import.md. Every rule takes the merged
+archetype+repo dict and returns a Finding or None, which is what makes them
+trivially testable with fixtures and cheap to add -- the rule set is meant to grow
+every time someone notices something.
+
+WHY THIS READS COMMITTED DATA RATHER THAN THE API. `data/repos/*.yaml` carries both
+the configuration Pulumi manages and, under `_`-prefixed keys, the observed state the
+rules need. So the audit is a dictionary comparison, not a crawl: it runs in
+milliseconds, needs no credentials, works in CI, and -- because the data is in git --
+`git log` over data/repos/ is a history of the estate. `drift` is the one mode that
+does hit the API, precisely because its job is to compare the two.
+
+SCOPE IS PART OF THE RULE. A rule that reports "94 of 138 archived" as a share of
+active repos is not wrong by a little, it is measuring a different population than it
+claims. Each rule declares its own `scope`, and the reporter uses that as the
+denominator. Getting this wrong has already happened twice on this project.
+"""
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+Axis = Literal["security", "consistency", "developer-experience"]
+Scope = Literal["active", "archived", "fleet"]
+
+#: A repo is an archive candidate (DX-07) after this long with no push.
+STALE_DAYS = 365
+#: Environments beyond this on one repo means CI is leaking review apps (DX-08).
+ENVIRONMENT_SPRAWL_THRESHOLD = 10
+#: Teams sanctioned to hold `admin` (SEC-15). An ALLOWLIST on purpose: under a
+#: denylist a newly created team acquires admin silently and the rule stays quiet.
+ADMIN_TEAMS = frozenset({"odl-engineering-owners", "devops"})
+#: Archetypes exempt from the default-branch rule. Forks follow upstream's naming.
+DEFAULT_BRANCH_EXEMPT = frozenset({"fork", "archived"})
+FEATURE_ENABLED = "enabled"
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One rule firing on one repo."""
+
+    rule_id: str
+    axis: Axis
+    severity: Literal["high", "medium", "low"]
+    repo: str
+    current: str
+    expected: str
+    remediation: str
+
+
+@dataclass(frozen=True)
+class Rule:
+    """A rule and the population it is measured against."""
+
+    rule_id: str
+    axis: Axis
+    severity: Literal["high", "medium", "low"]
+    scope: Scope
+    summary: str
+    check: Callable[[dict[str, Any]], tuple[str, str, str] | None]
+    """Returns (current, expected, remediation) when the rule fires, else None."""
+
+
+def _in_scope(repo: dict[str, Any], scope: Scope) -> bool:
+    archived = bool(repo.get("archived"))
+    if scope == "fleet":
+        return True
+    return archived if scope == "archived" else not archived
+
+
+def _is_stale(repo: dict[str, Any]) -> bool:
+    pushed = repo.get("_pushed_at")
+    if not pushed:
+        return False
+    age = datetime.now(UTC) - datetime.fromisoformat(pushed.replace("Z", "+00:00"))
+    return age.days > STALE_DAYS
+
+
+def _unsanctioned_admin(repo: dict[str, Any]) -> list[str]:
+    return sorted(
+        team
+        for team, perm in (repo.get("teams") or {}).items()
+        if perm == "admin" and team not in ADMIN_TEAMS
+    )
+
+
+RULES: tuple[Rule, ...] = (
+    Rule(
+        "SEC-01",
+        "security",
+        "high",
+        "active",
+        "default branch has no ruleset and no branch protection",
+        lambda r: (
+            (
+                "unprotected",
+                "covered by an org ruleset",
+                "set `tier` so a ruleset matches",
+            )
+            if not r.get("_has_branch_protection") and not r.get("_ruleset_count")
+            else None
+        ),
+    ),
+    Rule(
+        "SEC-04",
+        "security",
+        "high",
+        "active",
+        "secret scanning or push protection disabled",
+        lambda r: (
+            (
+                f"scanning={r.get('secret_scanning')} "
+                f"push_protection={r.get('secret_scanning_push_protection')}",
+                "both enabled",
+                "enable in repo settings, or org-wide for new repos",
+            )
+            if r.get("secret_scanning") != FEATURE_ENABLED
+            or r.get("secret_scanning_push_protection") != FEATURE_ENABLED
+            else None
+        ),
+    ),
+    Rule(
+        "SEC-05",
+        "security",
+        "high",
+        "active",
+        "Dependabot security updates disabled",
+        lambda r: (
+            ("disabled", "enabled", "set dependabot_security_updates in the archetype")
+            if not r.get("dependabot_security_updates")
+            else None
+        ),
+    ),
+    Rule(
+        "SEC-06",
+        "security",
+        "high",
+        "fleet",
+        "individual holds a direct permission on a repo",
+        lambda r: (
+            (
+                ", ".join(
+                    f"{u}:{p}"
+                    for u, p in sorted((r.get("_direct_collaborators") or {}).items())
+                ),
+                "no direct grants; access via team membership",
+                "move the person into a team that already has the right grant",
+            )
+            if r.get("_direct_collaborators")
+            else None
+        ),
+    ),
+    Rule(
+        "SEC-15",
+        "security",
+        "high",
+        "fleet",
+        "admin held by a team outside the sanctioned set",
+        lambda r: (
+            (
+                ", ".join(_unsanctioned_admin(r)),
+                f"admin only for {', '.join(sorted(ADMIN_TEAMS))}",
+                "downgrade to push or maintain",
+            )
+            if _unsanctioned_admin(r)
+            else None
+        ),
+    ),
+    Rule(
+        "CON-02",
+        "consistency",
+        "low",
+        "active",
+        "delete_branch_on_merge disabled",
+        lambda r: (
+            ("disabled", "enabled", "inherit from the base archetype")
+            if not r.get("delete_branch_on_merge")
+            else None
+        ),
+    ),
+    Rule(
+        "CON-03",
+        "consistency",
+        "low",
+        "active",
+        "default branch is not `main` (forks and archived exempt)",
+        lambda r: (
+            (r.get("default_branch", "?"), "main", "rename the default branch")
+            if r.get("default_branch") not in (None, "main")
+            and r.get("archetype") not in DEFAULT_BRANCH_EXEMPT
+            else None
+        ),
+    ),
+    Rule(
+        "CON-05",
+        "consistency",
+        "low",
+        "active",
+        "no topics",
+        lambda r: (
+            ("none", "at least one", "add topics to the repo's YAML")
+            if not r.get("topics")
+            else None
+        ),
+    ),
+    Rule(
+        "CON-07",
+        "consistency",
+        "medium",
+        "archived",
+        "archived repo still grants a team write or better",
+        lambda r: (
+            (
+                ", ".join(
+                    f"{t}:{p}"
+                    for t, p in sorted((r.get("teams") or {}).items())
+                    if p in ("push", "admin", "maintain")
+                ),
+                "read-only access",
+                "downgrade the grants, or accept and document",
+            )
+            if any(
+                p in ("push", "admin", "maintain")
+                for p in (r.get("teams") or {}).values()
+            )
+            else None
+        ),
+    ),
+    Rule(
+        "CON-10",
+        "consistency",
+        "low",
+        "active",
+        "no description",
+        lambda r: (
+            ("empty", "a one-line description", "add `description` to the repo's YAML")
+            if not r.get("description")
+            else None
+        ),
+    ),
+    Rule(
+        "DX-01",
+        "developer-experience",
+        "low",
+        "active",
+        "allow_auto_merge disabled",
+        lambda r: (
+            ("disabled", "enabled", "inherit from the base archetype")
+            if not r.get("allow_auto_merge")
+            else None
+        ),
+    ),
+    Rule(
+        "DX-07",
+        "developer-experience",
+        "low",
+        "active",
+        "no push in 12+ months -- archive candidate",
+        lambda r: (
+            (
+                f"last push {r.get('_pushed_at', '?')[:10]}",
+                "active development",
+                "archive it",
+            )
+            if _is_stale(r)
+            else None
+        ),
+    ),
+    Rule(
+        "DX-08",
+        "developer-experience",
+        "medium",
+        "active",
+        "environment sprawl -- CI is leaking review apps",
+        lambda r: (
+            (
+                f"{r.get('_excluded_environments')} environments",
+                f"at most {ENVIRONMENT_SPRAWL_THRESHOLD}",
+                "have CI delete review-app environments when the PR closes",
+            )
+            if (r.get("_excluded_environments") or 0) > ENVIRONMENT_SPRAWL_THRESHOLD
+            else None
+        ),
+    ),
+)
+
+
+def evaluate(fleet: Iterable[dict[str, Any]]) -> list[Finding]:
+    """Run every rule over every in-scope repo."""
+    findings: list[Finding] = []
+    for repo in fleet:
+        for rule in RULES:
+            if not _in_scope(repo, rule.scope):
+                continue
+            result = rule.check(repo)
+            if result is None:
+                continue
+            current, expected, remediation = result
+            findings.append(
+                Finding(
+                    rule_id=rule.rule_id,
+                    axis=rule.axis,
+                    severity=rule.severity,
+                    repo=repo["name"],
+                    current=current,
+                    expected=expected,
+                    remediation=remediation,
+                )
+            )
+    return findings
+
+
+def population(fleet: Iterable[dict[str, Any]], scope: Scope) -> int:
+    """How many repos a scope covers -- the honest denominator for a percentage."""
+    return sum(1 for repo in fleet if _in_scope(repo, scope))

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/.github.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/.github.yaml
@@ -1,6 +1,10 @@
 ---
 _actions_secret_names:
 - GH_PROJECT_AUTOMATION_TOKEN
+_has_branch_protection: true
+_pushed_at: '2026-08-05T19:47:31Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/PASSSL.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/PASSSL.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-12-01T11:35:19Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/PyLmod.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/PyLmod.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2022-01-19T00:07:46Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/XBlock.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/XBlock.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2018-03-28T21:13:49Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/access-forge.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/access-forge.yaml
@@ -22,6 +22,10 @@ _actions_secret_names:
 - QA_KEYCLOAK_OL_ENG_REALM
 - QA_KEYCLOAK_REALM
 - QA_KEYCLOAK_SERVER_URL
+_has_branch_protection: false
+_pushed_at: '2026-08-06T12:40:38Z'
+_ruleset_count: 0
+_visibility: private
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/agent-kit.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/agent-kit.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 2
+_has_branch_protection: false
+_pushed_at: '2026-08-06T15:46:24Z'
+_ruleset_count: 1
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/alerting-omnibus.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/alerting-omnibus.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-06-30T18:10:28Z'
+_ruleset_count: 0
+_visibility: private
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ansible-salt-bootstrap.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ansible-salt-bootstrap.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2016-03-23T19:50:00Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/apisix-testbed.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/apisix-testbed.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  jkachel: admin
+_has_branch_protection: false
+_pushed_at: '2025-04-01T21:23:50Z'
+_ruleset_count: 0
+_visibility: private
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/apisix.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/apisix.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-08-04T20:50:18Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/bookkeeper-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/bookkeeper-formula.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2020-06-19T18:20:23Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/bootcamp-ecommerce.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/bootcamp-ecommerce.yaml
@@ -3,6 +3,10 @@ _actions_secret_names:
 - HEROKU_API_KEY
 - HEROKU_EMAIL
 _excluded_environments: 683
+_has_branch_protection: true
+_pushed_at: '2026-03-02T11:50:32Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/bootcamps-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/bootcamps-zendesk-theme.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-05-06T19:07:35Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/bootcamps.json.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/bootcamps.json.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-12-01T11:26:27Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/brand-mitol-residential.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/brand-mitol-residential.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  arslanashraf7: admin
+_has_branch_protection: false
+_pushed_at: '2023-08-16T13:55:04Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/caddy-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/caddy-formula.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-12-01T08:55:05Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ccx-idde-overrides-slides.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ccx-idde-overrides-slides.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-10-20T13:38:07Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ccxcon.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ccxcon.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 46
+_has_branch_protection: true
+_pushed_at: '2016-03-16T15:42:13Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ckeditor-custom-build.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ckeditor-custom-build.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2022-12-10T13:28:56Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ckeditor5-media-embed.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ckeditor5-media-embed.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2019-01-23T09:27:12Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ckeditor5.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ckeditor5.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2022-12-14T18:31:57Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/codejail.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/codejail.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2021-03-18T17:00:41Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/common-access.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/common-access.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  jkachel: admin
+_has_branch_protection: false
+_pushed_at: '2026-08-05T16:57:02Z'
+_ruleset_count: 0
+_visibility: private
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/community-integrations.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/community-integrations.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-05-26T17:50:58Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-dcind.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-dcind.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  Ardiea: admin
+_has_branch_protection: false
+_pushed_at: '2020-12-28T23:42:19Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-github-issue-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-github-issue-resource.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-04-07T10:58:16Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-npm-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-npm-resource.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-04-08T21:11:04Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-packer-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-packer-resource.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 1
+_has_branch_protection: false
+_pushed_at: '2026-04-14T13:39:00Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-pulumi-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-pulumi-resource.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 1
+_has_branch_protection: false
+_pushed_at: '2026-04-14T13:24:26Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-pypi-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-pypi-resource.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2025-07-15T19:08:35Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-rclone-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-rclone-resource.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-10-21T05:51:21Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-s3-sync-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-s3-sync-resource.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-10-21T08:18:52Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-vault-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-vault-resource.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-04-09T03:28:10Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-workflow.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-workflow.yaml
@@ -1,6 +1,13 @@
 ---
 _actions_secret_names:
 - PRIVATE_KEY
+_direct_collaborators:
+  Ardiea: admin
+  odlbot: admin
+_has_branch_protection: false
+_pushed_at: '2024-06-17T15:06:41Z'
+_ruleset_count: 0
+_visibility: private
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-07-31T13:33:16Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concoursepy.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concoursepy.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  mbertrand: admin
+_has_branch_protection: false
+_pushed_at: '2023-06-16T11:55:30Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/configuration.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/configuration.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-04-10T16:48:36Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/consul-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/consul-formula.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-06-05T23:45:15Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/cookiecutter-djangoapp.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/cookiecutter-djangoapp.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2025-03-20T04:15:34Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/cookiecutter-pylib.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/cookiecutter-pylib.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  rhysyngsun: admin
+_has_branch_protection: false
+_pushed_at: '2025-10-12T18:26:24Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/copier-djangoapp.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/copier-djangoapp.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  rhysyngsun: admin
+_has_branch_protection: false
+_pushed_at: '2025-12-10T04:36:39Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/course-catalog.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/course-catalog.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  mbertrand: admin
+_has_branch_protection: false
+_pushed_at: '2019-02-14T02:11:35Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/course-search-utils.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/course-search-utils.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 1
+_has_branch_protection: false
+_pushed_at: '2026-08-06T12:49:23Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/cs_comments_service.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/cs_comments_service.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-04-21T16:56:43Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/custom-courses-on-edx-slides.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/custom-courses-on-edx-slides.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-10-20T13:38:06Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/dagster-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/dagster-formula.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2021-02-04T20:11:02Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/dagster.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/dagster.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2025-06-20T15:55:25Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/datadog-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/datadog-formula.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2021-06-29T19:32:22Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/default-labels-repo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/default-labels-repo.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-03-21T17:37:54Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/demo-test-course.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/demo-test-course.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  pdpinch: admin
+_has_branch_protection: false
+_pushed_at: '2021-06-10T06:44:16Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/discern.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/discern.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2014-04-03T12:59:30Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-aqueduct.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-aqueduct.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 2
+_has_branch_protection: false
+_pushed_at: '2026-08-06T12:24:38Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-cas-mapper.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-cas-mapper.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2016-07-21T13:25:12Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-cas.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-cas.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-11-02T14:55:44Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-elastic-transcoder.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-elastic-transcoder.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-05-16T21:37:09Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-formula.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-05-02T23:09:49Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-guardian.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-guardian.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2015-06-05T14:39:10Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-longer-username.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-longer-username.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2015-07-15T09:44:36Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-role-permissions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-role-permissions.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2016-07-01T17:14:08Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-server-status.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-server-status.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-10-20T13:38:08Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-settings-export.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-settings-export.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2015-08-13T21:34:13Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-shibboleth-remoteuser.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-shibboleth-remoteuser.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2018-09-19T14:29:52Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-user-tasks.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-user-tasks.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2025-10-21T14:19:07Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/dls-boeing-web.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/dls-boeing-web.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 1
+_has_branch_protection: false
+_pushed_at: '2016-10-07T17:20:32Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/dls-syseng-web.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/dls-syseng-web.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 1
+_has_branch_protection: false
+_pushed_at: '2016-10-27T16:30:22Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/docs.openedx.org.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/docs.openedx.org.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-08-03T14:22:38Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/doof.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/doof.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-06-10T14:53:02Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/dremio-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/dremio-formula.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2020-06-19T18:26:27Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ecommerce.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ecommerce.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-11-04T16:02:41Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-analytics-api-client.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-analytics-api-client.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2014-07-11T19:23:32Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-api-client.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-api-client.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 1
+_has_branch_protection: false
+_pushed_at: '2026-08-06T12:46:19Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-dev-intro-slides.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-dev-intro-slides.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-12-01T11:47:38Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-documentation.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-documentation.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2022-06-09T11:57:56Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-enterprise-data.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-enterprise-data.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2025-10-21T14:20:12Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-enterprise.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-enterprise.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2025-10-24T20:30:02Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-git-auto-export.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-git-auto-export.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-04-05T11:52:20Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-notes-api.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-notes-api.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2019-01-31T20:03:23Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-ora2.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-ora2.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2025-10-21T14:14:36Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-platform.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-platform.yaml
@@ -1,4 +1,11 @@
 ---
+_direct_collaborators:
+  odlbot: admin
+  shaidar: admin
+_has_branch_protection: false
+_pushed_at: '2026-07-31T20:18:00Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-proctoring-proctortrack.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-proctoring-proctortrack.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-09-21T16:08:46Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-proctoring.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-proctoring.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-07-28T15:43:13Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-sandbox-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-sandbox-formula.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2016-05-12T13:13:01Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-search.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-search.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-04-17T17:45:42Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-sga.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-sga.yaml
@@ -1,5 +1,11 @@
 ---
+_direct_collaborators:
+  indagation: write
 _excluded_environments: 1
+_has_branch_protection: false
+_pushed_at: '2026-07-29T11:51:54Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-submissions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-submissions.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-07-23T18:15:31Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-sysadmin.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-sysadmin.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-07-24T09:18:12Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-username-changer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-username-changer.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2025-01-09T12:36:35Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-username-updater.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-username-updater.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-12-20T15:50:41Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-val.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-val.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2025-11-19T14:14:15Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-video-api.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-video-api.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2019-08-02T20:23:31Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx2bigquery.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx2bigquery.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-12-01T14:41:01Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx2course_axis.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx2course_axis.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2015-07-29T13:04:58Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edxcut.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edxcut.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2022-08-28T16:33:05Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/elastic-stack-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/elastic-stack-formula.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-05-02T23:13:36Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/elasticsearch-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/elasticsearch-formula.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2020-06-19T18:28:07Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-access.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-access.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2025-10-21T14:18:09Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-catalog.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-catalog.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2025-10-20T14:45:02Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-integrated-channels.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-integrated-channels.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2025-10-21T14:47:36Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-subsidy.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-subsidy.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2025-10-21T14:26:50Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/epithet.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/epithet.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2019-08-15T17:26:49Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/eslint-config.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/eslint-config.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-08-06T12:47:42Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/flask-log.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/flask-log.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-10-20T13:38:04Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/fluentd-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/fluentd-formula.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2021-03-05T17:04:10Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/forum.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/forum.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-03-30T10:22:19Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-communications.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-communications.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2025-09-30T11:08:04Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-course-authoring.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-course-authoring.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-06-24T10:31:08Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-discussions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-discussions.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  Anas12091101: admin
+_has_branch_protection: false
+_pushed_at: '2025-11-14T16:22:25Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-gradebook.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-gradebook.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2025-09-17T14:02:03Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-instructor-dashboard.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-instructor-dashboard.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  Anas12091101: admin
+_has_branch_protection: false
+_pushed_at: '2026-07-27T10:48:45Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-learner-dashboard.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-learner-dashboard.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-03-05T12:07:06Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-learning.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-learning.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  Anas12091101: admin
+_has_branch_protection: false
+_pushed_at: '2026-03-06T11:55:12Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-library-authoring.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-library-authoring.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2022-02-09T20:15:09Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-footer-mitol.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-footer-mitol.yaml
@@ -2,6 +2,10 @@
 _actions_secret_names:
 - SEMANTIC_RELEASE_GITHUB_TOKEN
 - SEMANTIC_RELEASE_NPM_TOKEN
+_has_branch_protection: true
+_pushed_at: '2025-04-08T18:28:13Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-header-edx-mitol.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-header-edx-mitol.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-09-01T17:33:22Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-header-mitol.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-header-mitol.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: true
+_pushed_at: '2024-09-01T11:46:11Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-lib-special-exams-mitol.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-lib-special-exams-mitol.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  arslanashraf7: admin
+_has_branch_protection: true
+_pushed_at: '2025-02-12T07:47:20Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-platform.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-platform.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-09-01T11:24:16Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-slot-footer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-slot-footer.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  Anas12091101: admin
+_has_branch_protection: false
+_pushed_at: '2025-03-25T18:38:33Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/git-based-courses-slides.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/git-based-courses-slides.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-10-20T13:38:06Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/git2edx.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/git2edx.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-01-01T18:35:23Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/gitreload.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/gitreload.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-10-20T13:38:11Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/grafana-alerts.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/grafana-alerts.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  Ardiea: admin
+_has_branch_protection: false
+_pushed_at: '2026-06-25T15:06:09Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/grafana-dashboards.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/grafana-dashboards.yaml
@@ -1,4 +1,11 @@
 ---
+_direct_collaborators:
+  Ardiea: admin
+  odlbot: admin
+_has_branch_protection: false
+_pushed_at: '2025-11-21T19:30:39Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/gwarek.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/gwarek.yaml
@@ -2,6 +2,10 @@
 _actions_secret_names:
 - DOCKERHUB_TOKEN
 - DOCKERHUB_USERNAME
+_has_branch_protection: false
+_pushed_at: '2026-08-06T12:24:02Z'
+_ruleset_count: 0
+_visibility: private
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/hacksnack.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/hacksnack.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  abeglova: admin
+_has_branch_protection: false
+_pushed_at: '2026-07-01T15:24:21Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/handbook.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/handbook.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 1
+_has_branch_protection: true
+_pushed_at: '2026-06-11T20:45:57Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/hashicorp-release-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/hashicorp-release-resource.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2019-11-18T08:23:34Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/healthchecks.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/healthchecks.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2018-01-19T19:59:31Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/heroku-database-backups.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/heroku-database-backups.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2016-09-25T18:12:26Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/herokuconfigurator.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/herokuconfigurator.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2025-04-23T13:36:11Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/hq.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/hq.yaml
@@ -2,6 +2,12 @@
 _actions_secret_names:
 - STANDUP_CAT_ID
 - STANDUP_REPO_ID
+_direct_collaborators:
+  rhysyngsun: admin
+_has_branch_protection: false
+_pushed_at: '2026-08-06T12:40:16Z'
+_ruleset_count: 0
+_visibility: private
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/hugo-course-publisher.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/hugo-course-publisher.yaml
@@ -10,6 +10,10 @@ _actions_secret_names:
 - ZAP_PROD_TARGET
 - ZAP_RC_TARGET
 _excluded_environments: 2
+_has_branch_protection: false
+_pushed_at: '2022-02-21T19:44:11Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/import-api-slides.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/import-api-slides.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-10-20T13:38:05Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ims_lti_py_django.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ims_lti_py_django.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2018-11-19T18:39:37Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/internal.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/internal.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  rhysyngsun: admin
+_has_branch_protection: false
+_pushed_at: '2023-12-01T14:36:25Z'
+_ruleset_count: 0
+_visibility: private
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/interview-scenario-frontend.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/interview-scenario-frontend.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  ChristopherChudzicki: admin
+_has_branch_protection: false
+_pushed_at: '2026-03-12T19:18:13Z'
+_ruleset_count: 0
+_visibility: private
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/iso-3166-2.js.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/iso-3166-2.js.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2022-12-07T14:02:03Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ist-slides.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ist-slides.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-10-20T13:37:58Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/jenkins-atlassian-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/jenkins-atlassian-theme.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2015-01-20T16:00:18Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/jsdom-global.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/jsdom-global.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2021-11-24T15:46:07Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/keycloak-scim.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/keycloak-scim.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-07-21T00:07:13Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/kubectl-slice.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/kubectl-slice.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-09-01T11:32:15Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/latex2edx_xserver.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/latex2edx_xserver.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-10-20T13:38:05Z'
+_ruleset_count: 0
+_visibility: private
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/learn-ai-compromised.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/learn-ai-compromised.yaml
@@ -16,6 +16,14 @@ _actions_secret_names:
 - POSTHOG_PERSONAL_API_KEY_RC
 - POSTHOG_PROJECT_API_KEY_PROD
 - POSTHOG_PROJECT_API_KEY_RC
+_direct_collaborators:
+  ChristopherChudzicki: admin
+  mbertrand: write
+  odlbot: write
+_has_branch_protection: false
+_pushed_at: '2026-07-27T14:15:12Z'
+_ruleset_count: 0
+_visibility: private
 allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/learn-ai.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/learn-ai.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 1
+_has_branch_protection: false
+_pushed_at: '2026-08-06T13:09:53Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/learn-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/learn-zendesk-theme.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-02-13T13:10:20Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/lehrer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/lehrer.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 1
+_has_branch_protection: false
+_pushed_at: '2026-08-06T12:39:06Z'
+_ruleset_count: 2
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/letsencrypt-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/letsencrypt-formula.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-12-01T11:36:04Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/library-customization.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/library-customization.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2021-02-24T19:55:58Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/library.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/library.yaml
@@ -1,5 +1,11 @@
 ---
+_direct_collaborators:
+  odlbot: admin
 _excluded_environments: 4
+_has_branch_protection: false
+_pushed_at: '2023-08-03T18:12:05Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/lmod_proxy.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/lmod_proxy.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2021-12-22T21:44:40Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/locust-tests.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/locust-tests.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2025-12-10T15:58:11Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/lore.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/lore.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 3
+_has_branch_protection: false
+_pushed_at: '2016-08-13T16:27:00Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/loretemplates.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/loretemplates.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2015-08-11T16:27:54Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/master-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/master-formula.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-12-01T14:52:52Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mdl-react-components.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mdl-react-components.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2025-12-10T15:27:22Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mga.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mga.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 1
+_has_branch_protection: false
+_pushed_at: '2016-12-05T15:47:50Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters-templates.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters-templates.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-12-01T08:40:47Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters-zendesk-theme.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-05-08T06:27:47Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters.yaml
@@ -4,6 +4,10 @@ _actions_secret_names:
 - HEROKU_EMAIL
 - SENTRY_AUTH_TOKEN
 _excluded_environments: 2694
+_has_branch_protection: true
+_pushed_at: '2026-08-06T14:27:37Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn-api-clients.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn-api-clients.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 1
+_has_branch_protection: false
+_pushed_at: '2026-08-06T12:25:50Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
@@ -7,6 +7,10 @@ _actions_secret_names:
 - MITX_ONLINE_BASE_URL_PROD
 - MITX_ONLINE_BASE_URL_RC
 _excluded_environments: 44
+_has_branch_protection: true
+_pushed_at: '2026-08-06T14:21:55Z'
+_ruleset_count: 1
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-moira.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-moira.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2018-05-24T14:42:31Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-open-bk.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-open-bk.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  rhysyngsun: admin
+_has_branch_protection: false
+_pushed_at: '2023-07-28T13:16:48Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-open-login-button.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-open-login-button.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  gumaerc: admin
+_has_branch_protection: true
+_pushed_at: '2025-04-21T09:15:19Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit_lti_flask_sample.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit_lti_flask_sample.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-03-07T18:23:53Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitili.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitili.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2017-04-19T13:35:09Z'
+_ruleset_count: 0
+_visibility: private
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-devstack.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-devstack.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2018-12-17T20:00:29Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-grading-library.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-grading-library.yaml
@@ -1,5 +1,12 @@
 ---
+_direct_collaborators:
+  ChristopherChudzicki: admin
+  MaferMazu: write
 _excluded_environments: 1
+_has_branch_protection: false
+_pushed_at: '2026-08-06T12:29:32Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-theme.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 1
+_has_branch_protection: false
+_pushed_at: '2026-07-13T13:04:55Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitx_cas_mapper.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitx_cas_mapper.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2016-07-21T18:56:42Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-api-clients.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-api-clients.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 1
+_has_branch_protection: false
+_pushed_at: '2026-08-06T12:32:37Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-theme.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 1
+_has_branch_protection: false
+_pushed_at: '2026-08-04T07:48:37Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-translations.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-translations.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  Anas12091101: admin
+_has_branch_protection: false
+_pushed_at: '2026-08-06T01:16:37Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-zendesk-theme.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2025-01-30T16:50:14Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline.yaml
@@ -3,7 +3,13 @@ _actions_secret_names:
 - HEROKU_API_KEY
 - HEROKU_EMAIL
 - OL_HQ_PROJECT_SECRET
+_direct_collaborators:
+  rhysyngsun: admin
 _excluded_environments: 412
+_has_branch_protection: true
+_pushed_at: '2026-08-06T14:20:29Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-openedx-extensions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-openedx-extensions.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  rhysyngsun: admin
+_has_branch_protection: false
+_pushed_at: '2024-06-17T15:05:43Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-theme.yaml
@@ -1,5 +1,11 @@
 ---
+_direct_collaborators:
+  pdpinch: admin
 _excluded_environments: 1
+_has_branch_protection: false
+_pushed_at: '2026-07-13T13:05:34Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-zendesk-theme.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-10-07T16:41:35Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro.yaml
@@ -3,7 +3,13 @@ _actions_secret_names:
 - HEROKU_API_KEY
 - HEROKU_EMAIL
 - OL_HQ_PROJECT_SECRET
+_direct_collaborators:
+  rhysyngsun: admin
 _excluded_environments: 2042
+_has_branch_protection: true
+_pushed_at: '2026-08-06T13:17:53Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mongodb-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mongodb-formula.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2021-06-27T12:36:57Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/monit-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/monit-formula.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2019-11-07T19:16:04Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mynumbers.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mynumbers.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  abeglova: admin
+_has_branch_protection: false
+_pushed_at: '2026-06-17T14:28:07Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/netdata-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/netdata-formula.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2020-06-19T18:34:36Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/nginx-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/nginx-formula.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2020-06-19T18:34:54Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/nginx-shibboleth-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/nginx-shibboleth-formula.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-05-03T14:47:44Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/no_op2_resizer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/no_op2_resizer.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  rhysyngsun: admin
+_has_branch_protection: false
+_pushed_at: '2023-12-01T08:29:27Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-course-example-html.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-course-example-html.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2022-04-04T14:28:58Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-course-example-markdown.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-course-example-markdown.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  gumaerc: admin
+_has_branch_protection: false
+_pushed_at: '2023-12-01T14:17:25Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-course-hugo-starter.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-course-hugo-starter.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  gumaerc: admin
+_has_branch_protection: false
+_pushed_at: '2022-04-17T19:04:10Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-course-hugo-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-course-hugo-theme.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  gumaerc: admin
+_has_branch_protection: false
+_pushed_at: '2021-05-04T13:53:05Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-data-parser.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-data-parser.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2025-01-23T13:55:50Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-projects.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-projects.yaml
@@ -1,5 +1,11 @@
 ---
+_direct_collaborators:
+  gumaerc: admin
 _excluded_environments: 1
+_has_branch_protection: true
+_pushed_at: '2026-08-05T20:00:12Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-themes.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-themes.yaml
@@ -12,7 +12,13 @@ _actions_secret_names:
 - SEARCH_API_URL
 - SSH_KEY
 - STATIC_API_BASE_URL
+_direct_collaborators:
+  gumaerc: admin
 _excluded_environments: 3
+_has_branch_protection: true
+_pushed_at: '2026-08-06T13:47:48Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-studio.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-studio.yaml
@@ -2,7 +2,13 @@
 _actions_secret_names:
 - HEROKU_API_KEY
 - HEROKU_EMAIL
+_direct_collaborators:
+  rhysyngsun: admin
 _excluded_environments: 5
+_has_branch_protection: true
+_pushed_at: '2026-08-06T12:23:54Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-to-hugo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-to-hugo.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  gumaerc: admin
+_has_branch_protection: false
+_pushed_at: '2024-04-28T17:49:17Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-www.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-www.yaml
@@ -5,6 +5,10 @@ _actions_secret_names:
 - OCW_STUDIO_BASE_URL
 - SEARCH_API_URL
 _excluded_environments: 3
+_has_branch_protection: false
+_pushed_at: '2021-11-08T14:22:21Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-zendesk-theme.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-03-04T14:30:01Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw_oer_export.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw_oer_export.yaml
@@ -1,6 +1,12 @@
 ---
 _actions_secret_names:
 - SLACK_WEBHOOK
+_direct_collaborators:
+  ChristopherChudzicki: admin
+_has_branch_protection: false
+_pushed_at: '2026-08-06T12:27:21Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/odl-etl.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/odl-etl.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2022-12-08T10:41:08Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/odl-keycloak.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/odl-keycloak.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-02-10T23:20:31Z'
+_ruleset_count: 0
+_visibility: private
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/odl-video-service.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/odl-video-service.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 6
+_has_branch_protection: true
+_pushed_at: '2026-08-05T20:26:29Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/odl_devstack_tools.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/odl_devstack_tools.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-10-20T13:38:10Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/odleng-update-slides.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/odleng-update-slides.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-12-01T11:47:26Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/odlengweb.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/odlengweb.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-04-08T14:40:34Z'
+_ruleset_count: 0
+_visibility: private
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-analytics-api.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-analytics-api.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 3
+_has_branch_protection: false
+_pushed_at: '2026-08-03T21:20:30Z'
+_ruleset_count: 1
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-concourse-github-issues.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-concourse-github-issues.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-04-14T13:39:28Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-concourse.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-concourse.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 1
+_has_branch_protection: false
+_pushed_at: '2026-08-06T15:48:33Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-configuration-management.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-configuration-management.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2021-04-27T19:52:09Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-customizations-nytimes-library.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-customizations-nytimes-library.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-08-06T03:42:39Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-data-platform.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-data-platform.yaml
@@ -2,6 +2,10 @@
 _actions_secret_names:
 - GH_PROJECT_AUTOMATION_TOKEN
 _excluded_environments: 2
+_has_branch_protection: true
+_pushed_at: '2026-08-06T13:01:09Z'
+_ruleset_count: 1
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-django.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-django.yaml
@@ -1,7 +1,13 @@
 ---
 _actions_secret_names:
 - PYPI_TOKEN
+_direct_collaborators:
+  rhysyngsun: admin
 _excluded_environments: 1
+_has_branch_protection: false
+_pushed_at: '2026-08-05T20:30:04Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-github-workflows.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-github-workflows.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  rhysyngsun: admin
+_has_branch_protection: false
+_pushed_at: '2024-06-17T14:47:01Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infra-health-checks.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infra-health-checks.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-07-28T23:48:52Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
@@ -2,6 +2,10 @@
 _actions_secret_names:
 - GH_PROJECT_AUTOMATION_TOKEN
 _excluded_environments: 2
+_has_branch_protection: true
+_pushed_at: '2026-08-06T15:31:19Z'
+_ruleset_count: 1
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloak-customization.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloak-customization.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-10-17T20:17:31Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloak.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloak.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: true
+_pushed_at: '2026-08-05T20:28:02Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloakify.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloakify.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 2
+_has_branch_protection: false
+_pushed_at: '2026-08-06T12:38:02Z'
+_ruleset_count: 1
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-notebook-extensions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-notebook-extensions.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  dsubak: admin
+_has_branch_protection: false
+_pushed_at: '2026-08-02T23:15:42Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-npm-libraries.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-npm-libraries.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  rhysyngsun: admin
+_has_branch_protection: true
+_pushed_at: '2024-04-11T10:34:56Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-openedx-mfe-overrides.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-openedx-mfe-overrides.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  Anas12091101: admin
+_has_branch_protection: false
+_pushed_at: '2026-06-10T16:00:19Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-parliament.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-parliament.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 1
+_has_branch_protection: false
+_pushed_at: '2026-06-05T20:37:09Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-rootly-manager.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-rootly-manager.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-06-29T21:02:58Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/oldevops-scratch.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/oldevops-scratch.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-09-26T20:52:27Z'
+_ruleset_count: 0
+_visibility: private
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-collaboration.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-collaboration.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  Ferdi: admin
+_has_branch_protection: false
+_pushed_at: '2023-10-25T13:45:42Z'
+_ruleset_count: 0
+_visibility: private
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-discussions-client.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-discussions-client.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  rhysyngsun: admin
+_has_branch_protection: true
+_pushed_at: '2023-10-20T13:38:04Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-discussions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-discussions.yaml
@@ -3,6 +3,10 @@ _actions_secret_names:
 - HEROKU_API_KEY
 - HEROKU_EMAIL
 _excluded_environments: 1723
+_has_branch_protection: true
+_pushed_at: '2026-07-23T18:59:37Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-plugins.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-plugins.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 1
+_has_branch_protection: true
+_pushed_at: '2026-08-06T13:10:06Z'
+_ruleset_count: 1
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-proposals.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-proposals.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2025-02-27T21:13:04Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-learning-ai-tutor.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-learning-ai-tutor.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 1
+_has_branch_protection: false
+_pushed_at: '2026-08-04T19:34:46Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-learnix.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-learnix.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-01-15T16:47:09Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-podcast-data.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-podcast-data.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  odlbot: admin
+_has_branch_protection: false
+_pushed_at: '2026-06-04T14:57:27Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-resource-blocklists.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-resource-blocklists.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  mbertrand: admin
+_has_branch_protection: false
+_pushed_at: '2026-07-23T20:01:50Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-video-data.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-video-data.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-05-12T14:38:52Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-widget-framework.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-widget-framework.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2020-09-12T04:10:38Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-widget-sample-app.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-widget-sample-app.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2025-02-24T04:55:24Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/openedx-course-test.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/openedx-course-test.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-10-20T13:38:12Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/openedx-events.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/openedx-events.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  Anas12091101: admin
+_has_branch_protection: false
+_pushed_at: '2026-03-25T07:09:56Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/openedx-ledger.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/openedx-ledger.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2025-10-21T14:27:47Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/opentelemetry-python-contrib.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/opentelemetry-python-contrib.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-03-11T21:14:17Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/orcoursetrion.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/orcoursetrion.yaml
@@ -1,4 +1,12 @@
 ---
+_direct_collaborators:
+  NotoriousMKD: write
+  indagation: write
+  sfrucht: write
+_has_branch_protection: false
+_pushed_at: '2023-10-20T13:38:02Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pgbouncer-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pgbouncer-formula.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-12-01T08:59:41Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/platform-engineering-site.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/platform-engineering-site.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 2
+_has_branch_protection: false
+_pushed_at: '2026-08-06T12:25:35Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pre-commit-ci-config.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pre-commit-ci-config.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-09-07T17:57:54Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pre-commit-packer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pre-commit-packer.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-05-09T14:57:05Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/product.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/product.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-04-11T14:12:31Z'
+_ruleset_count: 0
+_visibility: private
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pulsar-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pulsar-formula.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2020-06-19T18:36:28Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/py-tree-sitter.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/py-tree-sitter.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-07-09T21:12:53Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pycaption.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pycaption.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  mbertrand: admin
+_has_branch_protection: false
+_pushed_at: '2018-01-31T15:25:01Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pycassa.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pycassa.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2017-10-03T19:38:47Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pylint-django.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pylint-django.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2017-09-08T19:22:16Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pylti.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pylti.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-10-20T13:38:01Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/python-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/python-formula.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-05-01T14:24:37Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/rabbitmq-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/rabbitmq-formula.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-05-01T14:39:24Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/rapid-response-xblock.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/rapid-response-xblock.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-07-24T14:04:07Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/react-dropzone-uploader.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/react-dropzone-uploader.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2020-09-03T18:56:24Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/realistic-mm-users.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/realistic-mm-users.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2017-01-17T21:09:26Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/redash.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/redash.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2022-10-27T17:40:29Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-config.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-config.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  rhysyngsun: admin
+_has_branch_protection: false
+_pushed_at: '2020-07-03T15:06:49Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-formula.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-05-03T11:29:49Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-i18n.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-i18n.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2017-04-25T19:19:30Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-service-activity.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-service-activity.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2017-05-30T16:54:20Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-service-websockets.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-service-websockets.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2017-06-06T21:17:55Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/reddit.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/reddit.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  rhysyngsun: admin
+_has_branch_protection: false
+_pushed_at: '2023-10-20T13:38:09Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/redux-asserts.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/redux-asserts.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: true
+_pushed_at: '2026-08-05T20:40:46Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/redux-hammock.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/redux-hammock.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-08-06T12:44:20Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/refresh_token.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/refresh_token.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-10-20T13:38:11Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/release-script.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/release-script.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 2
+_has_branch_protection: false
+_pushed_at: '2026-08-06T12:46:08Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/response-map.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/response-map.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2019-09-27T18:07:00Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/salt-extensions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/salt-extensions.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-04-05T19:55:10Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/salt-ops.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/salt-ops.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2025-09-25T19:21:38Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/saltstack-formula-cookiecutter.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/saltstack-formula-cookiecutter.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2020-06-19T18:38:50Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/screenshot_xblock.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/screenshot_xblock.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-04-16T21:00:38Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/searchkit.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/searchkit.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2017-01-26T16:18:08Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/semantic-mitopen.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/semantic-mitopen.yaml
@@ -1,5 +1,11 @@
 ---
+_direct_collaborators:
+  mbertrand: admin
 _excluded_environments: 1
+_has_branch_protection: false
+_pushed_at: '2024-08-29T20:01:40Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/sga-lti.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/sga-lti.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 29
+_has_branch_protection: false
+_pushed_at: '2025-09-19T15:26:34Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/sifters.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/sifters.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2014-10-08T16:44:40Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/sign-and-verify.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/sign-and-verify.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  rhysyngsun: admin
+_has_branch_protection: false
+_pushed_at: '2020-10-01T17:59:24Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/smoot-design.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/smoot-design.yaml
@@ -1,7 +1,13 @@
 ---
 _actions_secret_names:
 - SEMANTIC_RELEASE_GITHUB_TOKEN
+_direct_collaborators:
+  ChristopherChudzicki: admin
 _excluded_environments: 2
+_has_branch_protection: true
+_pushed_at: '2026-08-05T19:38:49Z'
+_ruleset_count: 1
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/social-auth-mitxpro.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/social-auth-mitxpro.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  rhysyngsun: admin
+_has_branch_protection: false
+_pushed_at: '2025-05-26T20:25:40Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/sso-django-prototype.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/sso-django-prototype.yaml
@@ -1,5 +1,12 @@
 ---
+_direct_collaborators:
+  odlbot: admin
+  rhysyngsun: admin
 _excluded_environments: 1
+_has_branch_protection: false
+_pushed_at: '2023-10-20T13:38:14Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/standalone-course-prototype.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/standalone-course-prototype.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  gumaerc: admin
+_has_branch_protection: false
+_pushed_at: '2024-06-11T02:44:20Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/superset-marimo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/superset-marimo.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: true
+_pushed_at: '2026-05-22T19:14:05Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/superset-nl-explorer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/superset-nl-explorer.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-02-26T00:27:57Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/superset-sup.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/superset-sup.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-07-24T14:04:41Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/taxonomy-connector.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/taxonomy-connector.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2025-10-30T13:24:01Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/teachersportal.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/teachersportal.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 54
+_has_branch_protection: false
+_pushed_at: '2020-07-06T16:37:49Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/tech-talk-slides.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/tech-talk-slides.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 1
+_has_branch_protection: false
+_pushed_at: '2026-08-06T12:46:04Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/template-mit-demo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/template-mit-demo.yaml
@@ -1,4 +1,12 @@
 ---
+_direct_collaborators:
+  NotoriousMKD: write
+  indagation: write
+  sfrucht: write
+_has_branch_protection: false
+_pushed_at: '2019-07-10T16:26:56Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/testinfra.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/testinfra.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-04-19T12:37:11Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/tika-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/tika-formula.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2020-06-19T18:39:23Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/travisfail.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/travisfail.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-10-20T13:37:59Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/tubular.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/tubular.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  feoh: admin
+_has_branch_protection: false
+_pushed_at: '2023-05-18T20:00:09Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/tutor-mentor.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/tutor-mentor.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  rhysyngsun: admin
+_has_branch_protection: false
+_pushed_at: '2023-10-20T13:38:08Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/tutor.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/tutor.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2025-04-16T17:15:25Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ubcpi.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ubcpi.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 1
+_has_branch_protection: false
+_pushed_at: '2026-03-11T11:24:32Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/unified-ecommerce-api-clients.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/unified-ecommerce-api-clients.yaml
@@ -1,4 +1,10 @@
 ---
+_direct_collaborators:
+  jkachel: admin
+_has_branch_protection: false
+_pushed_at: '2025-12-09T05:04:21Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/unified-ecommerce-frontend.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/unified-ecommerce-frontend.yaml
@@ -1,5 +1,11 @@
 ---
+_direct_collaborators:
+  ChristopherChudzicki: admin
 _excluded_environments: 1
+_has_branch_protection: true
+_pushed_at: '2025-12-03T22:25:52Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/unified-ecommerce.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/unified-ecommerce.yaml
@@ -1,5 +1,11 @@
 ---
+_direct_collaborators:
+  jkachel: admin
 _excluded_environments: 1
+_has_branch_protection: true
+_pushed_at: '2025-12-08T21:56:21Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/uwsgi-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/uwsgi-formula.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-12-01T08:44:20Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/vault-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/vault-formula.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2024-07-09T18:00:20Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/vault-plugin-database-starrocks.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/vault-plugin-database-starrocks.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-08-06T12:31:15Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/vault-plugin-secrets-openai.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/vault-plugin-secrets-openai.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-06-01T20:47:46Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/vault-raft-backup.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/vault-raft-backup.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-08-06T12:31:18Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/video_translation_demo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/video_translation_demo.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 1
+_has_branch_protection: false
+_pushed_at: '2026-03-01T08:32:07Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/webcast.mit.edu.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/webcast.mit.edu.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 1
+_has_branch_protection: false
+_pushed_at: '2025-12-03T20:30:14Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/world_geographic_regions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/world_geographic_regions.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2015-11-11T14:31:40Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xanalytics.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xanalytics.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2021-09-23T12:45:56Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xblock-lti-consumer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xblock-lti-consumer.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2025-10-21T14:28:39Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xblock-utils.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xblock-utils.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2017-12-15T17:04:58Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xblocks-contrib.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xblocks-contrib.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2026-07-29T09:49:33Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xbundle.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xbundle.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-10-20T13:38:09Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xqueue-watcher.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xqueue-watcher.yaml
@@ -1,5 +1,9 @@
 ---
 _excluded_environments: 1
+_has_branch_protection: false
+_pushed_at: '2026-07-17T14:58:24Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xqueue.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xqueue.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2021-06-14T21:44:27Z'
+_ruleset_count: 0
+_visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xsiftx.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xsiftx.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2023-10-20T13:37:59Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/zookeeper-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/zookeeper-formula.yaml
@@ -1,4 +1,8 @@
 ---
+_has_branch_protection: false
+_pushed_at: '2020-06-19T18:40:54Z'
+_ruleset_count: 0
+_visibility: public
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/tests/ol_infrastructure/saas/github/test_audit.py
+++ b/tests/ol_infrastructure/saas/github/test_audit.py
@@ -1,0 +1,140 @@
+"""Tests for the estate audit rules.
+
+The rules are pure functions over a merged archetype+repo dict, so every case here is
+a literal -- no crawl, no fixtures on disk, no credentials. That is the property the
+phase-4 design was chosen for, and these tests are what make it worth having.
+
+The cases that earn their keep are the SCOPE ones. A rule measured against the wrong
+population is not wrong by a little; it reports a real number about a different set of
+repos than it claims. That mistake has been made twice on this project, both times
+caught by cross-checking a percentage against raw data rather than by reading the code.
+"""
+
+from typing import Any
+
+import pytest
+
+from ol_infrastructure.saas.github import audit
+
+
+def repo(**overrides: Any) -> dict[str, Any]:
+    """Return a repo that fires no rules, so each test breaks exactly one thing."""
+    base: dict[str, Any] = {
+        "name": "example",
+        "archetype": "library",
+        "archived": False,
+        "description": "a repo",
+        "topics": ["python"],
+        "default_branch": "main",
+        "allow_auto_merge": True,
+        "delete_branch_on_merge": True,
+        "dependabot_security_updates": True,
+        "secret_scanning": "enabled",  # pragma: allowlist secret
+        "secret_scanning_push_protection": "enabled",  # pragma: allowlist secret
+        "teams": {"odl-engineering-owners": "admin", "odl-engineering": "push"},
+        "_has_branch_protection": True,
+        "_ruleset_count": 1,
+        "_pushed_at": "2026-08-01T00:00:00Z",
+        "_visibility": "public",
+    }
+    return {**base, **overrides}
+
+
+def fired(fleet: list[dict[str, Any]]) -> set[str]:
+    return {f.rule_id for f in audit.evaluate(fleet)}
+
+
+def test_clean_repo_fires_nothing() -> None:
+    assert fired([repo()]) == set()
+
+
+@pytest.mark.parametrize(
+    ("rule_id", "overrides"),
+    [
+        ("SEC-01", {"_has_branch_protection": False, "_ruleset_count": 0}),
+        ("SEC-04", {"secret_scanning": "disabled"}),  # pragma: allowlist secret
+        ("SEC-05", {"dependabot_security_updates": False}),
+        ("SEC-06", {"_direct_collaborators": {"someone": "admin"}}),
+        ("SEC-15", {"teams": {"arbisoft-contractors": "admin"}}),
+        ("CON-02", {"delete_branch_on_merge": False}),
+        ("CON-03", {"default_branch": "master"}),
+        ("CON-05", {"topics": []}),
+        ("CON-10", {"description": None}),
+        ("DX-01", {"allow_auto_merge": False}),
+        ("DX-07", {"_pushed_at": "2020-01-01T00:00:00Z"}),
+        ("DX-08", {"_excluded_environments": 500}),
+    ],
+)
+def test_each_rule_fires_on_its_own_trigger(rule_id: str, overrides: Any) -> None:
+    assert rule_id in fired([repo(**overrides)])
+
+
+def test_sec01_needs_both_missing() -> None:
+    """A ruleset alone is protection, and so is branch protection alone."""
+    assert "SEC-01" not in fired([repo(_has_branch_protection=False, _ruleset_count=1)])
+    assert "SEC-01" not in fired([repo(_has_branch_protection=True, _ruleset_count=0)])
+
+
+def test_sec15_is_an_allowlist_not_a_denylist() -> None:
+    """A team nobody has sanctioned must fire, which a denylist would miss."""
+    assert "SEC-15" in fired([repo(teams={"a-brand-new-team": "admin"})])
+    assert "SEC-15" not in fired([repo(teams={"devops": "admin"})])
+    # Non-admin from an unsanctioned team is fine -- the rule is about the level.
+    assert "SEC-15" not in fired([repo(teams={"arbisoft-contractors": "push"})])
+
+
+def test_con03_exempts_forks_and_archived() -> None:
+    """102 active repos default to `master` and nearly all are forks."""
+    assert "CON-03" not in fired([repo(archetype="fork", default_branch="master")])
+    assert "CON-03" in fired([repo(archetype="library", default_branch="master")])
+
+
+def test_archived_repos_are_out_of_scope_for_active_rules() -> None:
+    """An archived repo must not be reported for things nobody can change on it."""
+    archived = repo(archived=True, topics=[], description=None, allow_auto_merge=False)
+    assert fired([archived]).isdisjoint({"CON-05", "CON-10", "DX-01"})
+
+
+def test_con07_only_looks_at_archived_repos() -> None:
+    """Its whole subject is archived repos; on an active one it is meaningless."""
+    grants = {"odl-engineering": "push"}
+    assert "CON-07" in fired([repo(archived=True, teams=grants)])
+    assert "CON-07" not in fired([repo(archived=False, teams=grants)])
+
+
+def test_fleet_scoped_rules_cover_archived_repos() -> None:
+    """SEC-06 and SEC-15 have no exemptions -- an admin grant on an archived repo is
+    inert only until someone unarchives it.
+    """
+    archived = repo(archived=True, _direct_collaborators={"someone": "admin"})
+    assert "SEC-06" in fired([archived])
+
+
+def test_population_matches_each_rules_scope() -> None:
+    """The denominator a percentage is reported against must be the set measured."""
+    fleet = [repo(name="a"), repo(name="b", archived=True), repo(name="c")]
+    assert audit.population(fleet, "active") == 2
+    assert audit.population(fleet, "archived") == 1
+    assert audit.population(fleet, "fleet") == 3
+
+
+def test_every_rule_declares_a_known_axis_and_scope() -> None:
+    """Guards the reporter, which indexes findings by both."""
+    for rule in audit.RULES:
+        assert rule.axis in ("security", "consistency", "developer-experience")
+        assert rule.scope in ("active", "archived", "fleet")
+        assert rule.severity in ("high", "medium", "low")
+
+
+def test_rule_ids_are_unique() -> None:
+    ids = [rule.rule_id for rule in audit.RULES]
+    assert len(ids) == len(set(ids))
+
+
+def test_findings_carry_remediation() -> None:
+    """A finding without a next action is a complaint, not a backlog item."""
+    findings = audit.evaluate([repo(dependabot_security_updates=False)])
+    assert findings
+    for finding in findings:
+        assert finding.remediation
+        assert finding.expected


### PR DESCRIPTION
### What are the relevant tickets?

N/A — **fourth layer of a stack**: #5288 → #5297 → #5300 → this. Review in that order. Tracked in witan under `wp-import-the-mitodl-github-organization-into-pulum-47211a`.

### Description (What does it do?)

Phase 4: `bin/github-estate-audit`, with the rules in `ol_infrastructure.saas.github.audit` as pure functions over the merged archetype+repo dict.

**Thirteen rules across the three axes, 1,258 findings on the current fleet, in 0.44s with no credentials and no API call.**

```
  high   SEC-05    174 ( 99% of 176 active)  Dependabot security updates disabled
  high   SEC-01    151 ( 86% of 176 active)  default branch has no ruleset and no branch protection
  high   SEC-15    125 ( 40% of 316 fleet)   admin held by a team outside the sanctioned set
  high   SEC-06     69 ( 22% of 316 fleet)   individual holds a direct permission on a repo
  high   SEC-04     10 (  6% of 176 active)  secret scanning or push protection disabled
  medium CON-07     94 ( 67% of 140 archived) archived repo still grants a team write or better
  medium DX-08       5 (  3% of 176 active)  environment sprawl -- CI is leaking review apps
  low    DX-01     174 ( 99% of 176 active)  allow_auto_merge disabled
  low    CON-05    166 ( 94% of 176 active)  no topics
  low    CON-02    155 ( 88% of 176 active)  delete_branch_on_merge disabled
  low    DX-07      74 ( 42% of 176 active)  no push in 12+ months -- archive candidate
  low    CON-10     36 ( 20% of 176 active)  no description
  low    CON-03     25 ( 14% of 176 active)  default branch is not `main` (forks exempt)
```

#### Why it reads committed data rather than the API

`data/repos/*.yaml` already carried the configuration Pulumi manages. It now also carries the observed state the rules need under `_`-prefixed keys — extending the convention the fleet data already used for `_excluded_environments` and `_actions_secret_names`.

So auditing is a dictionary comparison, not a crawl. It runs in CI, needs no sops key, and — because the data is in git — **`git log` over `data/repos/` is a history of the estate**. `drift` is the one mode that hits the API, because comparing declared against live is the one job that needs both.

#### Scope is part of the rule, not the reporter

A rule reporting *"94 of 138 archived"* as a share of **active** repos is not slightly wrong — it describes a different population than it claims. That mistake has been made twice on this project, both times caught by cross-checking a percentage against raw data rather than by reading the code.

Each rule declares `active`, `archived` or `fleet`, and the reporter uses that as the denominator. Four of the 23 tests exist purely to hold that line.

#### `drift` deliberately does not crawl

It compares the committed fleet against an existing cache. Keeping the fetch separate means a drift report can be re-run against the same snapshot while investigating, instead of shifting underneath you. Currently reports **0 differences**.

### How can this be tested?

`run` needs nothing — no credentials, no network:

```sh
uv run bin/github-estate-audit run
uv run bin/github-estate-audit run --axis security
uv run bin/github-estate-audit run --json          # for CI
uv run bin/github-estate-audit run --fail-on high  # exit 1 if any high finding

uv run pytest tests/ol_infrastructure/saas/github/ -q
# 23 passed in 0.04s
```

`drift` needs a crawl cache, which does require the sops key:

```sh
uv run bin/github-org-inventory report --refresh
uv run bin/github-estate-audit drift
# 0 difference(s) between the committed fleet and .github-org-inventory-cache.json
```

The tests are all literals — no fixtures on disk, no crawl — which is the property the pure-function design was chosen for. Each rule has a case that fires it, plus the scope cases above and a check that every finding carries a remediation, on the grounds that a finding without a next action is a complaint rather than a backlog item.

### Additional Context

**A trap recorded for when #5300 applies.** Once the phase-3.5 rulesets land at `enforcement: evaluate`, they are invisible to the per-repo read endpoints (probe controls C6a/C6b). `_ruleset_count` will not see them, so **SEC-01 would start reporting protected repos as unprotected**. A ruleset-aware check has to enumerate `/orgs/{org}/rulesets` directly. This is noted in `drift`'s docstring so it is read at the point it matters.

**Not implemented: `--emit-tasks`.** §7 lists it, and it is a small addition on top of the `Finding` dataclass, but creating ~1,258 witan tasks unprompted is not obviously the right move — the useful version is probably one task per *rule* rather than per finding, and that is a decision rather than a mechanism. Left out until someone says which.

**What the numbers mean for phase 5.** The three `high` rules with fleet-wide counts — SEC-05, SEC-01, SEC-15 — are the remediation backlog, and they are large by design: this is the first time the estate has been measured rather than sampled. SEC-15 and SEC-06 already have a task (`tk-sec-15-...`); the `devops-contractors`-on-`ol-infrastructure` grant remains the single highest-leverage item in it.
