### PR TITLE
feat(witan): export the traces and metrics the code already emits

### DIFF
--- a/src/ol_infrastructure/applications/witan/__main__.py
+++ b/src/ol_infrastructure/applications/witan/__main__.py
@@ -174,6 +174,7 @@ from ol_infrastructure.lib.ol_types import (
 )
 from ol_infrastructure.lib.pulumi_helper import (
     format_docker_image_ref,
+    get_docker_image_tag,
     make_stack_reference,
     optional_stack_output_value,
     parse_stack,
@@ -674,6 +675,10 @@ witan_image_repository = (
     f"{witan_aws_account.account_id}.dkr.ecr.{aws_config.region}.amazonaws.com/witan"
 )
 witan_image = format_docker_image_ref(witan_image_repository, "WITAN")
+# `service.version` on every span and metric this stack's workloads emit. The
+# same tag-or-digest `witan_image` is built from, so a trace in Tempo names the
+# exact artifact it came from and not a build-time guess at one.
+witan_service_version = get_docker_image_tag("WITAN")
 
 #########################################
 #   Pre-deploy witan data migrations     #
@@ -740,6 +745,7 @@ mcp_servers = create_mcp_servers(
     witan_code_token_secret_key=WITAN_CODE_TOKEN_SECRET_KEY,
     witan_code_token_secret=witan_code_token_secret,
     migration_job=witan_migration_job,
+    service_version=witan_service_version,
 )
 
 #########################################
@@ -937,6 +943,7 @@ witan_ci_indexer = create_ci_indexer(
     witan_ci_token_secret_name=WITAN_CI_TOKEN_SECRET_NAME,
     witan_ci_token_secret_key=WITAN_CI_TOKEN_SECRET_KEY,
     witan_ci_token_secret=witan_ci_token_secret,
+    service_version=witan_service_version,
     github_app_id=WITAN_GITHUB_APP_ID if github_app_secret else None,
     github_app_installation_id=(
         WITAN_GITHUB_APP_INSTALLATION_ID if github_app_secret else None

--- a/src/ol_infrastructure/applications/witan/ci_indexer.py
+++ b/src/ol_infrastructure/applications/witan/ci_indexer.py
@@ -42,6 +42,11 @@ release apart in what they put in them.
 import pulumi_kubernetes as kubernetes
 from pulumi import Output, Resource, ResourceOptions
 
+from ol_infrastructure.applications.witan.observability import (
+    downward_api_env_args,
+    otel_env,
+    witan_log_env,
+)
 from ol_infrastructure.lib.pulumi_helper import StackInfo
 
 # Scratch space for the checkouts. An emptyDir rather than the container
@@ -92,6 +97,7 @@ def create_ci_indexer(  # noqa: PLR0913
     witan_ci_token_secret_name: str,
     witan_ci_token_secret_key: str,
     witan_ci_token_secret: Resource,
+    service_version: str,
     github_app_id: str | None = None,
     github_app_installation_id: str | None = None,
     github_app_secret_name: str | None = None,
@@ -193,6 +199,27 @@ def create_ci_indexer(  # noqa: PLR0913
                 value=f"{GITHUB_APP_MOUNT_PATH}/{GITHUB_APP_KEY_FILENAME}",
             ),
         ]
+
+    # Structured logging + OTel, from the same helper the MCP tier uses. Traced
+    # deliberately rather than as a freebie: this job is the one witan workload
+    # with a history of failing silently for hours between four-hourly ticks,
+    # and every diagnosis so far has come from `kubectl logs` on a pod that had
+    # already been garbage-collected. A per-repo span and an `outcome`-labelled
+    # counter are what let the next failure be noticed without that.
+    # `otel_env` is empty in CI, which has no collector.
+    #
+    # Appended last, after the optional block above, so adding it is a purely
+    # additive diff: k8s treats `env` as a list, and inserting ahead of the
+    # GitHub App vars would renumber them and show as three modifications on
+    # top of the additions in every environment that sets them.
+    indexer_env += [
+        kubernetes.core.v1.EnvVarArgs(name=name, value=value)
+        for name, value in (
+            witan_log_env()
+            | otel_env(stack_info, "witan-code-indexer", service_version)
+        ).items()
+    ]
+    indexer_env += downward_api_env_args()
 
     volume_mounts = [
         kubernetes.core.v1.VolumeMountArgs(

--- a/src/ol_infrastructure/applications/witan/mcp_servers.py
+++ b/src/ol_infrastructure/applications/witan/mcp_servers.py
@@ -43,6 +43,11 @@ from typing import NamedTuple
 import pulumi_kubernetes as kubernetes
 from pulumi import Output, Resource, ResourceOptions, StackReference
 
+from ol_infrastructure.applications.witan.observability import (
+    downward_api_env_dicts,
+    otel_env,
+    witan_log_env,
+)
 from ol_infrastructure.lib.pulumi_helper import StackInfo
 
 # Name shared by the MCPGroup and the VirtualMCPServer that references it.
@@ -90,6 +95,7 @@ def create_mcp_servers(  # noqa: PLR0913
     witan_code_token_secret_key: str,
     witan_code_token_secret: Resource,
     migration_job: Resource,
+    service_version: str,
 ) -> WitanMCPServers:
     """Provision the witan-tools MCPGroup and the witan MCPServer backend."""
     witan_mcpgroup = kubernetes.apiextensions.CustomResource(
@@ -180,6 +186,17 @@ def create_mcp_servers(  # noqa: PLR0913
                 # boundary from claiming a graph's shared default-branch view;
                 # only the in-cluster CI indexer Job declares itself `ci`.
                 {"name": "WITAN_CODE_SERVER", "value": omnigraph_server_addr},
+                # Structured logging + OTel. Appended from a shared helper
+                # rather than spelled out here so this workload, the CI
+                # indexer, and anything added later cannot drift into
+                # describing themselves as three different services. `otel_env`
+                # is empty in CI, which has no collector — see observability.py.
+                *(
+                    {"name": name, "value": value}
+                    for name, value in (
+                        witan_log_env() | otel_env(stack_info, "witan", service_version)
+                    ).items()
+                ),
             ],
             "secrets": [
                 {
@@ -242,6 +259,14 @@ def create_mcp_servers(  # noqa: PLR0913
                     "containers": [
                         {
                             "name": "mcp",
+                            # Pod identity for spans and log lines. It rides
+                            # the same patch as the volume mount because
+                            # `spec.env` above is name/value only and cannot
+                            # express a `fieldRef` — the operator merges full
+                            # EnvVars from here onto the `mcp` container, which
+                            # is already how `spec.secrets` arrives as
+                            # `secretKeyRef`.
+                            "env": downward_api_env_dicts(),
                             "volumeMounts": [
                                 {
                                     "name": "actor-tokens",

--- a/src/ol_infrastructure/applications/witan/observability.py
+++ b/src/ol_infrastructure/applications/witan/observability.py
@@ -1,0 +1,161 @@
+"""OpenTelemetry + structured-logging environment for the witan workloads.
+
+agent-kit ``witan_core.observability`` (PR #193) installs structlog plus OTel
+tracer and meter providers, but it deliberately installs **no provider at all**
+when no OTLP endpoint is in the environment — that is what keeps every local
+CLI run and stdio session free of exporters. So the instrumentation is inert
+until something sets these variables, and this module is that something.
+
+Nothing here is witan-specific translation: the code passes no endpoint to the
+exporters and no service name to the ``Resource``, precisely so the OTel SDK
+reads the standard variables itself. Adding a witan-shaped indirection layer
+would be a second thing to keep in sync with the SDK for no gain.
+
+── Why CI gets logs but no traces or metrics ──
+``setup_grafana`` (``substructure/aws/eks/grafana.py``) returns early for CI, so
+operations-ci runs no Grafana Alloy: its ``grafana`` namespace exists and is
+empty, and ``grafana-k8s-monitoring-alloy-receiver`` — the Service every
+precedent exports to — resolves in QA and Production only. Setting the endpoint
+uniformly across all three stacks would therefore not be free in CI; it would
+point the exporters at a name that does not resolve and buy a connection
+failure per batch and per 60s metric interval, forever, in the one environment
+where nobody is watching. ``ships_telemetry`` mirrors ``setup_grafana``'s own
+condition instead, so CI lands back on the SDK's no-provider path by
+construction.
+
+CI still gets the structured JSON logs, which are the half that does not depend
+on Alloy at all: they go to stderr and the k8s-monitoring chart ships pod logs
+to Loki. That is why ``witan_log_env`` is unconditional while the OTel block is
+not.
+"""
+
+import pulumi_kubernetes as kubernetes
+
+from ol_infrastructure.lib.pulumi_helper import StackInfo
+
+# The in-cluster OTLP/HTTP receiver, shared with mit_learn, learn_ai and edxapp
+# (see their Pulumi.{QA,Production}.yaml and edxapp/k8s_configmaps.py). Port
+# 4318 is http/protobuf; 4317 on the same Service is gRPC, which we do not use.
+OTLP_ENDPOINT = (
+    "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318"
+)
+
+# Sampling and propagation, matched to the mit_learn/learn_ai precedent rather
+# than chosen fresh, so a trace that crosses from one of those services into
+# witan is sampled consistently instead of being decided twice.
+TRACES_SAMPLER = "parentbased_traceidratio"
+TRACES_SAMPLER_ARG = "0.25"
+PROPAGATORS = "tracecontext,baggage"
+METRIC_EXPORT_INTERVAL_MS = "60000"
+
+# The three variables `witan_core.observability` reads for pod identity. It adds
+# them BOTH as OTel resource attributes (`k8s.pod.name`, `k8s.namespace.name`,
+# `k8s.node.name`) and as log fields (`pod_name`, `namespace`, `node_name`), and
+# it reads them ONCE at import — so they have to be in the pod environment at
+# startup, which is what makes the downward API the only workable source.
+# Without them a span cannot be attributed to a replica.
+_DOWNWARD_API_FIELDS = {
+    "KUBERNETES_POD_NAME": "metadata.name",
+    "KUBERNETES_NAMESPACE": "metadata.namespace",
+    "KUBERNETES_NODE_NAME": "spec.nodeName",
+}
+
+
+def ships_telemetry(stack_info: StackInfo) -> bool:
+    """Whether this environment has an OTLP receiver to export to.
+
+    Mirrors ``setup_grafana``'s CI early-return. Kept as a named predicate so
+    the reason a stack is dark is one grep away from the reason the collector
+    is absent.
+    """
+    return stack_info.env_suffix.lower() != "ci"
+
+
+def witan_log_env() -> dict[str, str]:
+    """Structured-logging variables, safe in every environment.
+
+    Both are what the code already defaults to in a container (``json``
+    whenever stderr is not a tty, ``INFO`` when neither ``WITAN_LOG_LEVEL`` nor
+    ``LOG_LEVEL`` is set). Stated anyway: a log format that depends on tty
+    detection is one ``kubectl exec`` away from looking different from what the
+    Loki pipeline was built against.
+    """
+    return {
+        "WITAN_LOG_FORMAT": "json",
+        "WITAN_LOG_LEVEL": "INFO",
+    }
+
+
+def otel_env(
+    stack_info: StackInfo,
+    service_name: str,
+    service_version: str,
+) -> dict[str, str]:
+    """Build the standard ``OTEL_*`` variables for a witan workload.
+
+    Returns an empty mapping where there is no collector, which puts
+    ``configure_tracing()``/``configure_metrics()`` back on their intended
+    no-provider path rather than on a failing exporter.
+
+    :param service_name: e.g. ``"witan"`` — prefixed with the environment to
+        match the ``<env>-<service>`` convention edxapp and mit_learn use.
+    :param service_version: the image tag or digest this workload runs, from
+        ``get_docker_image_tag("WITAN")``. The precedents carry a literal
+        ``${GIT_SHA:-unknown}`` because their Helm values are expanded by an
+        entrypoint shell; nothing expands variables here, so a copied literal
+        would ship the string ``${GIT_SHA:-unknown}`` as the version. Pulumi
+        already knows the exact identifier the pod will run, so use it.
+    """
+    if not ships_telemetry(stack_info):
+        return {}
+
+    resource_attributes = ",".join(
+        [
+            f"deployment.environment={stack_info.env_suffix}",
+            "service.namespace=witan",
+            f"service.version={service_version}",
+        ]
+    )
+    return {
+        "OTEL_EXPORTER_OTLP_ENDPOINT": OTLP_ENDPOINT,
+        "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
+        "OTEL_SERVICE_NAME": f"{stack_info.env_suffix}-{service_name}",
+        "OTEL_RESOURCE_ATTRIBUTES": resource_attributes,
+        "OTEL_TRACES_SAMPLER": TRACES_SAMPLER,
+        "OTEL_TRACES_SAMPLER_ARG": TRACES_SAMPLER_ARG,
+        "OTEL_PROPAGATORS": PROPAGATORS,
+        "OTEL_METRIC_EXPORT_INTERVAL": METRIC_EXPORT_INTERVAL_MS,
+    }
+
+
+def downward_api_env_dicts() -> list[dict[str, object]]:
+    """Pod-identity env in plain-dict form, for a ``podTemplateSpec`` patch.
+
+    The ``MCPServer`` CRD's own ``spec.env`` is name/value only, so a
+    ``fieldRef`` cannot go there; ToolHive's PodTemplateSpec escape hatch takes
+    a full ``EnvVar`` and merges it onto the operator-managed ``mcp`` container
+    — which is already how ``spec.secrets`` reaches the pod as
+    ``secretKeyRef`` entries.
+    """
+    return [
+        {
+            "name": name,
+            "valueFrom": {"fieldRef": {"fieldPath": field_path}},
+        }
+        for name, field_path in _DOWNWARD_API_FIELDS.items()
+    ]
+
+
+def downward_api_env_args() -> list[kubernetes.core.v1.EnvVarArgs]:
+    """Pod-identity env as ``EnvVarArgs``, for ordinary Job/CronJob specs."""
+    return [
+        kubernetes.core.v1.EnvVarArgs(
+            name=name,
+            value_from=kubernetes.core.v1.EnvVarSourceArgs(
+                field_ref=kubernetes.core.v1.ObjectFieldSelectorArgs(
+                    field_path=field_path,
+                )
+            ),
+        )
+        for name, field_path in _DOWNWARD_API_FIELDS.items()
+    ]

--- a/src/ol_infrastructure/applications/witan/observability.py
+++ b/src/ol_infrastructure/applications/witan/observability.py
@@ -67,6 +67,14 @@ def ships_telemetry(stack_info: StackInfo) -> bool:
     Mirrors ``setup_grafana``'s CI early-return. Kept as a named predicate so
     the reason a stack is dark is one grep away from the reason the collector
     is absent.
+
+    The ``.lower()`` is redundant and deliberate: ``parse_stack`` builds
+    ``env_suffix`` as ``stack_name.lower()`` (lib/pulumi_helper.py), so it is
+    lowercase by construction and the telemetry labels below can use it raw
+    without risk of a ``QA``/``qa`` split. It is kept here only so this
+    predicate is character-for-character the condition ``setup_grafana``
+    tests — the two drifting apart is the failure this function exists to
+    prevent.
     """
     return stack_info.env_suffix.lower() != "ci"
 
@@ -136,6 +144,30 @@ def downward_api_env_dicts() -> list[dict[str, object]]:
     a full ``EnvVar`` and merges it onto the operator-managed ``mcp`` container
     — which is already how ``spec.secrets`` reaches the pod as
     ``secretKeyRef`` entries.
+
+    THIS DOES NOT CLOBBER THE OPERATOR'S OWN ENV, and it is worth stating
+    because the obvious worry — that a PodTemplateSpec patch replaces list
+    fields wholesale, RFC 7386 style — is a real failure mode for other CRDs
+    and simply is not how this path works. Traced through toolhive v0.40.1,
+    every step is an explicit append:
+
+    1. ``PodTemplateSpecBuilder.WithSecrets`` starts from *this* template,
+       finds the container named ``mcp``, and does
+       ``Env = append(Env, secretEnvVars...)`` — the vars below are the
+       existing ``Env``, the secrets land after them. The result is what the
+       operator serializes into ``--k8s-pod-patch``.
+    2. The runner applies that patch to an **empty** base PodTemplateSpec, so
+       its ``WithSpec`` whole-spec assignment has nothing to overwrite.
+    3. ``configureContainer`` then calls client-go's
+       ``ContainerApplyConfiguration.WithEnv``, itself an append, to add the
+       ``spec.env`` entries.
+
+    Final order is podTemplateSpec env, then ``spec.secrets``, then
+    ``spec.env`` — all three coexist, which the live workload confirms
+    (2 ``secretKeyRef`` vars from the patch alongside 8 ``spec.env`` vars).
+    The one real constraint is that concatenation does not de-duplicate, so a
+    name used here must not collide with a ``spec.env`` or ``spec.secrets``
+    name; the three below do not.
     """
     return [
         {


### PR DESCRIPTION
## What are the relevant tickets?

witan task `tk-wire-otel-env-vars-into-the-witan-stack-so-the-n-e7ba6e`, under the shared-witan-service observability epic. Follows agent-kit #193 (merged `54728a7`), which added `witan_core.observability`.

## Description (What does this do?)

agent-kit #193 gave witan structlog + OpenTelemetry, but **the instrumentation has been inert in the cluster ever since.** `configure_tracing()` / `configure_metrics()` install no provider when no OTLP endpoint is in the environment — that is the design that keeps every local CLI run and stdio session exporter-free — and nothing set one. The structured JSON logs were already flowing (stderr, shipped to Loki by the k8s-monitoring chart); it is traces and metrics that were dark.

This sets the standard `OTEL_*` variables on the witan `MCPServer` and the `witan-ci-indexer` CronJob, plus the downward-API pod identity the instrumentation reads.

## How can this be tested?

`pulumi preview` was run against all three stacks. Each: **2 to update, 43 unchanged**, purely additive — no replacements, no deletions.

QA/Production pick up the full block:

```
OTEL_EXPORTER_OTLP_ENDPOINT = http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318
OTEL_SERVICE_NAME           = qa-witan
OTEL_RESOURCE_ATTRIBUTES    = deployment.environment=qa,service.namespace=witan,service.version=sha256:22aaf6f...
```

CI picks up only `WITAN_LOG_*` and the three `KUBERNETES_*` fieldRefs — see below.

After deploy, the acceptance checks are: an `mcp.tool/<tool_name>` span in Tempo; `witan.tool.calls` / `witan.tool.duration` in Mimir with `tool` and `outcome` labels; and `trace_id`/`span_id` on Loki lines (emitted for recording spans only — a sampled-out span deliberately contributes neither, since its ids would point at a trace that was never exported).

## Things to pay attention to in review

**CI is deliberately not uniform with QA and Production.** `setup_grafana` returns early for CI, so operations-ci runs no Alloy: I confirmed its `grafana` namespace exists and is empty, and `grafana-k8s-monitoring-alloy-receiver` resolves in QA and Production only. Setting the endpoint there would not be "harmless uniformity" — it would buy a connection failure per span batch and per 60s metric interval, forever, in the one environment nobody watches. `ships_telemetry()` mirrors `setup_grafana`'s own condition so CI lands back on the SDK's no-provider path by construction. CI still gets the structured logs and pod identity, which never depended on Alloy.

**`service.version` is the resolved digest, not `${GIT_SHA:-unknown}`.** The mit_learn/learn_ai precedents carry that literal because their Helm values are expanded by an entrypoint shell. Nothing expands variables here, so copying it would ship the string `${GIT_SHA:-unknown}` as the version. Pulumi already knows the exact artifact the pod will run.

**Pod identity goes through the PodTemplateSpec patch.** The `MCPServer` CRD's `spec.env` is name/value only, so a `fieldRef` cannot live there; the patch is already how `spec.secrets` reaches the pod as `secretKeyRef`. Without these three, a span cannot be attributed to a replica.

**The indexer CronJob is traced on purpose**, not for symmetry — it is the one witan workload with a history of failing silently for hours between four-hourly ticks, and every diagnosis so far has come from `kubectl logs` on a pod that had already been garbage-collected. Its env block is appended *after* the optional GitHub-App vars so the diff stays purely additive rather than renumbering them.

`migrations.py` and `break_glass.py` are intentionally left alone — out of scope for this task's acceptance criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUQxCo4fB6KXR1pGVbunSq