### PR TITLE
fix(mitlearn): raise production webapp CPU request to 1200m

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
@@ -56,6 +56,15 @@ config:
   # declared limit, so the VPA can still size these pods down, just not into the
   # range that kills them.
   mitlearn:webapp_vpa_min_allowed_memory: 3Gi
+  # Raised from the 500m default (memory stays 3200Mi via the merge in
+  # __main__.py). granian runs 2 workers x 2 threads with no CPU limit, so 500m
+  # read as 95-116% utilization under normal load and pegged the HPA at
+  # max_replicas. Calibrated, not padded: at 0.035 cores/rps a pod doing the
+  # intended 20 rps draws ~700m, and 700m/0.60 is ~1170m. Don't raise it further
+  # without fixing the inert Prometheus triggers in lib/k8s_keda.py first -- the
+  # cpu trigger is currently the only working scale-up signal.
+  mitlearn:webapp_resource_requests:
+    cpu: 1200m
   mitlearn:vars:
     AI_MIT_SYLLABUS_URL: "https://api.learn.mit.edu/api/v0/vector_content_files_search/"
     AI_MIT_VIDEO_TRANSCRIPT_URL: "https://api.learn.mit.edu/api/v0/vector_content_files_search/"

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1445,6 +1445,11 @@ def _resource_config(config_key: str, default: dict[str, str]) -> dict[str, str]
     return {**default, **(mitlearn_config.get_object(config_key) or {})}
 
 
+# The 500m CPU default suits CI/QA, which idle. Production overrides it to 1200m:
+# granian can consume several cores, and a request this far below real usage makes
+# the KEDA cpu trigger read 95-116% utilization under normal load and peg the HPA at
+# max_replicas. See the calibration note on webapp_resource_requests in
+# Pulumi.Production.yaml before changing either value.
 webapp_resource_requests = _resource_config(
     "webapp_resource_requests", {"cpu": "500m", "memory": "3200Mi"}
 )


### PR DESCRIPTION
### What are the relevant tickets?
N/A — driven by repeated `HPAAtMaxReplicasCritical` pages for `keda-hpa-mitlearn-webapp-scaledobject`.

### Description (What does it do?)
Raises the production mit-learn webapp CPU request from 500m to 1200m. Memory stays at 3200Mi (the stack override is merged onto the defaults in `__main__.py`). Production-only, since the value derives from production traffic and CI/QA idle far below it.

granian runs `--workers 2 --runtime-threads 2` with no CPU limit, so a pod can burn several cores against a 500m request. Over the 7 days to 2026-08-06 on `applications-production`: peak single-pod usage 1.09 cores (219% of request), fleet-average utilization spiking to 95-116% against the KEDA cpu trigger's 60% target. Each spike demanded `ceil(N * util/60)`, saturating at `max_replicas=30`; the intentionally slow scale-down (10%/25min) then needs ~7-8h to recover, longer than the gap between spikes. The HPA sat at max ~40-50% of the trailing 14 days.

1200m is calibrated rather than padded: cost is a stable ~0.035 cores/rps, so a pod at the intended 20 rps draws ~700m, and 700m/0.60 ≈ 1170m. Implied replica counts land where the request-rate trigger was meant to put them — ~4 pods at the ~50 rps trough, ~10 at the ~200 rps peak, ~20 at the 420 rps p99 burst, all under the 30 cap.

Deliberately not sized higher: both Prometheus triggers in [`lib/k8s_keda.py`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/lib/k8s_keda.py#L175-L183) are currently inert (each is exposed to the HPA as `AverageValue`, which already divides by replica count — so the request-rate query's own `/count(pods)` divisor double-divides, and the p95 latency trigger reduces to "one replica per 2s of latency"). Until that's fixed the cpu trigger is the only working scale-up signal, so an oversized request would leave the webapp unable to scale at all. That fix spans mitxonline, learn_ai and edxapp too and is tracked separately.

### How can this be tested?
`pulumi preview --stack Production` (requires `MIT_LEARN_DOCKER_TAG`) shows exactly two intended changes:

- `mitlearn-application-production-deployment` — `cpu: "500m" => "1200m"`
- `mitlearn-production-pre-deploy-job` — replaced, inherits the same request (Jobs are immutable)

The `fastly-mit_learn-production` gzip diff in the preview is pre-existing list-ordering churn, not from this change — a baseline preview with the change stashed shows it alone (`1 to update, 161 unchanged`).

Post-deploy, confirm `kubectl -n mitlearn get hpa keda-hpa-mitlearn-webapp-scaledobject` reports CPU utilization well under the 60% target and that `currentReplicas` trends toward `minReplicas: 4`.

### Additional Context
Two things reviewers should know:

- **Recovery is slow by design.** The slow scale-down was kept intentionally, so the HPA needs ~5-6h to walk down from its current count after this lands. Expect a page or two in that window; it isn't a failed deploy.
- **CPU becomes the binding scheduling constraint.** Break-even on the `m8i-flex.4xlarge` nodes is ~833m (12 pods/node CPU-bound vs 18 memory-bound). Karpenter absorbs this so nothing goes `Pending`, but there's a transient cost bump while replicas are still high and each pod now reserves 1200m. It resolves as the count falls.

The webapp VPA is memory-only (`controlledResources: ["memory"]`, everything else `mode: Off`), so it won't fight this value.