### PR TITLE
bump up pages to process with LLM to 20

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1206,6 +1206,7 @@ env_vars = {
     "QDRANT_ENABLE_INDEXING_PLUGIN_HOOKS": True,
     "QDRANT_ENCODER": "vector_search.encoders.litellm.LiteLLMEncoder",
     "QDRANT_SPARSE_ENCODER_V2": "vector_search.encoders.qdrant_cloud.QdrantCloudEncoder",
+    "OCR_PDF_MAX_PAGE_THRESHOLD": 20,
     "QDRANT_SPARSE_MODEL_V2": "qdrant/bm25",
     "QDRANT_HOST_V2": qdrant_cloud_stack.require_output("cluster_url"),
     "QDRANT_SPARSE_ENCODER": "vector_search.encoders.qdrant_cloud.QdrantCloudEncoder",


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/mitodl/hq/issues/12744
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR bumps up  OCR_PDF_MAX_PAGE_THRESHOLD  which defines the page count threshold below which PDF documents are processed using LLM-based OCR.

### How can this be tested?
Feature already tried and tested - this bumps up the number of pages we allow too be processed via LLM

