### PR TITLE
feat(dagster): provision Sentry project and plumb the DSN to Dagster

### DIFF
--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -10,6 +10,7 @@ This deployment uses:
 - APISix ingress with OpenID Connect for authentication
 """
 
+import json
 import os
 from pathlib import Path
 
@@ -89,6 +90,10 @@ vault_stack = make_stack_reference(
     projects.VAULT_SERVER, f"operations.{stack_info.name}"
 )
 cluster_stack = make_stack_reference(projects.EKS, f"data.{stack_info.name}")
+# Owns the Sentry project and client key whose DSN this stack writes to Vault.
+# Single-stack (Production) because there is one Sentry org, and one Dagster
+# project within it shared by every environment.
+sentry_stack = make_stack_reference(projects.SENTRY, "Production")
 # Keycloak is deployed to CI/QA/Production only; the Dev Dagster stack has no
 # counterpart to reference, so its data_loading deployment simply goes without
 # the Keycloak host and that source stays unavailable there.
@@ -510,6 +515,47 @@ dagster_dbt_secrets = OLVaultK8SSecret(
         vaultauth=dagster_auth_binding.vault_k8s_resources.auth_name,
     ),
     opts=ResourceOptions(depends_on=[dagster_auth_binding]),
+)
+
+# The DSN is created by the ol-infrastructure-sentry stack, which owns the
+# Sentry project and its client key, so Pulumi manages the value end to end and
+# nobody has to hand-write it into Vault. secret-data is a pre-existing kv-v1
+# mount shared by the other Dagster secrets, so only the secret itself is
+# declared here, not the mount.
+dagster_sentry_vault_secret = vault.generic.Secret(
+    f"dagster-sentry-dsn-{stack_info.env_suffix}",
+    path="secret-data/dagster/sentry",
+    data_json=sentry_stack.require_output("dagster_sentry_dsn").apply(
+        lambda dsn: json.dumps({"dsn": dsn})
+    ),
+    opts=ResourceOptions(delete_before_replace=True),
+)
+
+# Sentry DSN for the code locations and run workers. Kept as its own secret
+# rather than folded into dagster-static-secrets because an OLVaultK8SSecret
+# reads a single Vault path, and the DSN is owned by the sentry stack.
+dagster_sentry_secrets = OLVaultK8SSecret(
+    f"dagster-k8s-sentry-secrets-{stack_info.env_suffix}",
+    resource_config=OLVaultK8SStaticSecretConfig(
+        dest_secret_labels=k8s_global_labels.model_dump(),
+        dest_secret_name="dagster-sentry-secrets",  # pragma: allowlist secret  # noqa: E501, S106
+        exclude_raw=True,
+        excludes=[".*"],
+        labels=k8s_global_labels.model_dump(),
+        mount="secret-data",
+        mount_type="kv-v1",
+        name="dagster-sentry-secrets",
+        namespace=dagster_namespace,
+        path="dagster/sentry",
+        refresh_after="1m",
+        templates={
+            "SENTRY_DSN": '{{ get .Secrets "dsn" }}',
+        },
+        vaultauth=dagster_auth_binding.vault_k8s_resources.auth_name,
+    ),
+    opts=ResourceOptions(
+        depends_on=[dagster_auth_binding, dagster_sentry_vault_secret]
+    ),
 )
 
 # Create Vault dynamic secret for database credentials
@@ -1000,11 +1046,15 @@ for location in code_locations:
             {"name": "DAGSTER_ENVIRONMENT", "value": stack_info.env_suffix},
             {"name": "AWS_DEFAULT_REGION", "value": "us-east-1"},
             {"name": "DAGSTER_VAULT_ROLE", "value": "dagster"},
+            # Ties each Sentry issue to the image it came from. Same git
+            # short-ref the Concourse pipeline tagged the image with.
+            {"name": "SENTRY_RELEASE", "value": image_tag_or_digest},
         ],
         "envSecrets": [
             {"name": "dagster-static-secrets"},
             {"name": "dagster-dbt-secrets"},
             {"name": "dagster-postgresql-secret"},
+            {"name": "dagster-sentry-secrets"},
         ],
     }
 

--- a/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
+++ b/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
@@ -50,6 +50,9 @@ run_launcher:
     - dagster-static-secrets
     - dagster-dbt-secrets
     - dagster-postgresql-secret
+    # Ops execute in run worker pods, not in the code location pods, so the
+    # Sentry DSN has to reach them here as well.
+    - dagster-sentry-secrets
 
 
 run_storage:

--- a/src/ol_infrastructure/infrastructure/sentry/IMPORT_SUMMARY.md
+++ b/src/ol_infrastructure/infrastructure/sentry/IMPORT_SUMMARY.md
@@ -74,3 +74,12 @@ The import file contains resource IDs only, not Sentry token values or DSNs.
   matching `pulumi state rename` at that point). The `ol_analytics_api_sentry_dsn`
   stack output is also hand-added and not part of the generator's output
   template.
+
+- `project_dagster` / `key_dagster`: added by hand for the same reason -- the
+  Dagster Sentry project does not exist live yet, so there is nothing to
+  import and `pulumi up` creates both. One project serves all environments and
+  all ten code locations; they are separated by the SDK's `environment` tag and
+  a `dagster_code_location` tag rather than by separate projects. The
+  `dagster_sentry_dsn` stack output is consumed by the Dagster application
+  stack, which writes it to Vault at `secret-data/dagster/sentry`. The same
+  naming-convergence caveat as above applies to `key_dagster`.

--- a/src/ol_infrastructure/infrastructure/sentry/__main__.py
+++ b/src/ol_infrastructure/infrastructure/sentry/__main__.py
@@ -3680,3 +3680,38 @@ key_ol_analytics_api = sentry.SentryKey(
 )
 
 pulumi.export("ol_analytics_api_sentry_dsn", key_ol_analytics_api.dsn_public)
+
+# Hand-authored addition, same rationale as project_ol_analytics_api above --
+# see IMPORT_SUMMARY.md.
+#
+# One project covers the whole Dagster deployment. CI/QA/Production are
+# separated by the SDK's `environment` tag and the ten code locations by a
+# `dagster_code_location` tag, rather than by multiplying projects.
+project_dagster = sentry.SentryProject(
+    "project_dagster",
+    organization=ORGANIZATION,
+    name="dagster",
+    slug="dagster",
+    platform="python",
+    # The data/BI team owns the pipelines; devops and MIT ODL get the same
+    # blanket access they hold on the other infrastructure projects.
+    teams=[
+        "bi",
+        "devops",
+        "mit-office-of-digital-learning",
+    ],
+    digests_min_delay=300,
+    digests_max_delay=1800,
+    resolve_age=0,
+    opts=sentry_opts,
+)
+
+key_dagster = sentry.SentryKey(
+    "key_dagster",  # pragma: allowlist secret
+    organization=ORGANIZATION,
+    project=project_dagster.slug,
+    name="Default",
+    opts=sentry_opts,
+)
+
+pulumi.export("dagster_sentry_dsn", key_dagster.dsn_public)


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Creates the Sentry project for Dagster and delivers its DSN to the Dagster pods. This is the infrastructure half of the Sentry integration in https://github.com/mitodl/ol-data-platform — that PR's application code reads `SENTRY_DSN` from the environment and no-ops without it, so the two can land in either order, but nothing reports to Sentry until this one is applied.

**Sentry stack** — adds a hand-authored `project_dagster` / `key_dagster` pair, following the `project_ol_analytics_api` precedent already documented under "Hand-authored exceptions" in `IMPORT_SUMMARY.md`. The project does not exist live, so there is nothing for `bin/import-sentry-config` to reconcile and `pulumi up` creates it as an ordinary new resource. Names follow the generator's `project_<slug>` / `key_<project_slug>` convention so a future regeneration converges onto these resources rather than creating parallel ones. `IMPORT_SUMMARY.md` is updated with the same caveat that entry carries.

One project covers the whole deployment. CI/QA/production are separated by the SDK's `environment` tag, and the ten code locations by a `dagster_code_location` tag, rather than by multiplying projects. Teams are `bi` (owns the pipelines) plus `devops` and `mit-office-of-digital-learning`.

**Dagster stack** — references the sentry stack's new `dagster_sentry_dsn` output and writes it to Vault at `secret-data/dagster/sentry`, so Pulumi manages the value end to end with no manual Vault write. A `VaultStaticSecret` templates it into `SENTRY_DSN` as the `dagster-sentry-secrets` k8s secret, which is added to:

- every code location's `envSecrets`, and
- the `K8sRunLauncher`'s `env_secrets` in `dagster_instance.yaml`.

Both are required: ops execute in per-run worker pods, not in the code location pods, so the DSN has to reach both. The existing `secret-data/dagster/*` grant in `dagster_server_policy.hcl` already covers the new path, so no policy change was needed.

`SENTRY_RELEASE` is set per deployment from `image_tag_or_digest` — the same git short-ref the Concourse pipeline tagged the image with — so Sentry issues correlate to the deploy that introduced them.

### How can this be tested?
`pulumi preview` on the **dagster/QA** stack is cleanly scoped to this change:

```
+  ol:services:Vault:K8S:VaultStaticSecret dagster-k8s-sentry-secrets-qa create
+  kubernetes:yaml/v2:ConfigGroup OLVaultK8SSecret-dagster-dagster-sentry-secrets create
+  kubernetes:secrets.hashicorp.com/v1beta1:VaultStaticSecret ...dagster-sentry-secrets create
~  kubernetes:helm.sh/v3:Release dagster-helm-release-qa update [diff: ~values]
~  kubernetes:helm.sh/v3:Release dagster-user-code-release-qa update [diff: ~values]
Resources: + 3 to create, ~ 2 to update, 70 unchanged
```

The values diff shows `SENTRY_RELEASE` and the `dagster-sentry-secrets` envSecret added to all ten deployments (`[0]`–`[9]`).

`pulumi preview` on the **sentry/Production** stack shows exactly the two new resources:

```
+  sentry:index:SentryProject project_dagster create
+  sentry:index:SentryKey key_dagster create
```

Two pre-existing conditions surfaced during review that are **not** caused by this branch — both confirmed by re-running each preview with the branch's changes stashed:

1. The dagster stack preview also shows `image.tag: "9a3fdd8f" => "latest"` on every deployment. That is the `DAGSTER_*_IMAGE_TAG` env vars being unset in a local shell (they are set by the Concourse pipeline), falling back to `latest`. The baseline preview shows the same `~ 2 to update`. Worth flagging as a standing footgun: running `pulumi up` on this stack from a laptop would downgrade every image to `latest`.
2. The sentry stack has 34 blocked deletes (decommissioned `redash` and `bootcamps` resources still in state, `protect=True`). The baseline preview shows the same 34. **This will block `pulumi up` on the sentry stack** until it is resolved separately — see the checklist below.

`pre-commit run` passes on all changed files (ruff, mypy, yamllint, detect-secrets).

### Additional Context
No `pulumi up` has been run. Both previews were read-only, and the QA and Production dagster stacks were being updated by others while this was being reviewed.

The DSN never appears in the repo — it flows sentry stack output → Vault → VSO → k8s secret → pod env.

### Checklist:
- [ ] Resolve the 34 pre-existing blocked deletes on the sentry/Production stack (or unprotect/remove them) — `pulumi up` cannot complete there until this is done, and the Dagster project cannot be created without it
- [ ] Apply the sentry/Production stack to create the project and key
- [ ] Apply the dagster stack per environment (CI → QA → Production) to write the DSN to Vault and roll the pods