### PR TITLE
fix(witan): give the MCP container a writable /tmp

### DIFF
--- a/src/ol_infrastructure/applications/witan/mcp_servers.py
+++ b/src/ol_infrastructure/applications/witan/mcp_servers.py
@@ -82,12 +82,18 @@ ACTOR_TOKENS_FILENAME = "tokens.json"  # pragma: allowlist secret
 # Disk-backed on purpose — `medium: Memory` would charge this to the pod's
 # 512Mi memory limit and OOM the server on a large export.
 #
-# Writability depends on the pod's `fsGroup: 1000` (the ToolHive operator sets
-# it, and the container runs as uid/gid 1000): kubelet group-owns an emptyDir
-# by fsGroup, so a non-root process can write it. Remove fsGroup and this mount
-# silently becomes root-owned and useless — the same trap ci_indexer.py
-# documents on its scratch volume.
+# Writability depends on `fsGroup`: kubelet group-owns an emptyDir by it, and
+# the container runs as uid/gid 1000, so without it the mount is root-owned and
+# useless — the same trap ci_indexer.py documents on its scratch volume.
+#
+# The ToolHive operator already sets `fsGroup: 1000` (verified on the running
+# pod in CI, QA and Production), so TMP_FS_GROUP below is a no-op today. It is
+# declared anyway: that value is the operator's default, not something this
+# stack asked for, and an upgrade that changed it would turn this mount
+# read-only with no signal beyond witan tools failing again. Declaring it makes
+# the invariant ours instead of inherited.
 TMP_MOUNT_PATH = "/tmp"  # noqa: S108
+TMP_FS_GROUP = 1000
 # Sized for the server-side work, which is dominated by the graph export
 # `store_merge` takes of its OWN target to reconcile against — that grows with
 # the shared graph, not with the caller's upload (the client's batches are
@@ -317,6 +323,9 @@ def create_mcp_servers(  # noqa: PLR0913
                             "emptyDir": {"sizeLimit": TMP_SIZE_LIMIT},
                         },
                     ],
+                    # What makes the emptyDir above writable by a non-root
+                    # container — see TMP_FS_GROUP.
+                    "securityContext": {"fsGroup": TMP_FS_GROUP},
                 }
             },
         },

--- a/src/ol_infrastructure/applications/witan/mcp_servers.py
+++ b/src/ol_infrastructure/applications/witan/mcp_servers.py
@@ -68,6 +68,33 @@ WITAN_MCPSERVER_NAME = "witan"
 ACTOR_TOKENS_MOUNT_PATH = "/etc/witan/actor-tokens"  # pragma: allowlist secret
 ACTOR_TOKENS_FILENAME = "tokens.json"  # pragma: allowlist secret
 
+# Writable scratch space. The container runs `readOnlyRootFilesystem: true`
+# with no writable volume, so Python's tempfile found nothing in
+# ['/tmp', '/var/tmp', '/usr/tmp', '/src'] and every server-side tool that
+# needs a temp file failed outright — verified against CI on 2026-08-07, where
+# `witan migrate merge` through the MCP tier (ADR-0007 D5) returned
+# "No usable temporary directory found" at every payload size, including
+# --dry-run. Those tools hand a file to the `omnigraph` binary, so there is no
+# in-memory path to fall back to.
+#
+# An emptyDir rather than relaxing readOnlyRootFilesystem: the read-only root
+# is worth keeping, and this grants exactly the one writable directory needed.
+# Disk-backed on purpose — `medium: Memory` would charge this to the pod's
+# 512Mi memory limit and OOM the server on a large export.
+#
+# Writability depends on the pod's `fsGroup: 1000` (the ToolHive operator sets
+# it, and the container runs as uid/gid 1000): kubelet group-owns an emptyDir
+# by fsGroup, so a non-root process can write it. Remove fsGroup and this mount
+# silently becomes root-owned and useless — the same trap ci_indexer.py
+# documents on its scratch volume.
+TMP_MOUNT_PATH = "/tmp"  # noqa: S108
+# Sized for the server-side work, which is dominated by the graph export
+# `store_merge` takes of its OWN target to reconcile against — that grows with
+# the shared graph, not with the caller's upload (the client's batches are
+# capped near 2 MiB by witan_core.chunking.MCP_LOAD_MAX_BYTES). 2Gi is well
+# clear of a council graph's export today and far below the indexer's 8Gi.
+TMP_SIZE_LIMIT = "2Gi"
+
 
 class WitanMCPServers(NamedTuple):
     """Handles to the group and backend server CRs for depends_on wiring."""
@@ -272,7 +299,11 @@ def create_mcp_servers(  # noqa: PLR0913
                                     "name": "actor-tokens",
                                     "mountPath": ACTOR_TOKENS_MOUNT_PATH,
                                     "readOnly": True,
-                                }
+                                },
+                                {
+                                    "name": "tmp",
+                                    "mountPath": TMP_MOUNT_PATH,
+                                },
                             ],
                         }
                     ],
@@ -280,7 +311,11 @@ def create_mcp_servers(  # noqa: PLR0913
                         {
                             "name": "actor-tokens",
                             "secret": {"secretName": actor_tokens_secret_name},
-                        }
+                        },
+                        {
+                            "name": "tmp",
+                            "emptyDir": {"sizeLimit": TMP_SIZE_LIMIT},
+                        },
                     ],
                 }
             },


### PR DESCRIPTION
## What's broken

The witan `mcp` container runs `readOnlyRootFilesystem: true` with **no writable volume** — only two read-only secret mounts. Python's `tempfile` therefore finds nothing in `['/tmp', '/var/tmp', '/usr/tmp', '/src']` (`/src` being the image WORKDIR), and every server-side tool needing a temp file fails outright.

Found by the first live migration test against CI:

```
Error calling tool 'store_merge':
  [Errno 2] No usable temporary directory found in
  ['/tmp', '/var/tmp', '/usr/tmp', '/src']
```

at **every** payload size, including `--dry-run`.

So the self-service cutover that agent-kit ADR-0007 D5 describes has never worked in the cluster, despite being merged, tested and signed off. The tests run an in-process FastMCP server on a developer machine, which inherits a writable `/tmp` — the one property the deployed pod doesn't have.

`store_merge` needs a temp file by construction: it hands a file to the `omnigraph` binary, both for the batch it receives and for the export it takes of its *own* target to reconcile against. There's no in-memory path to fall back to.

## The change

An `emptyDir` at `/tmp`, added to the existing `podTemplateSpec` patch.

- **emptyDir rather than relaxing `readOnlyRootFilesystem`** — the read-only root is worth keeping; this grants exactly the one writable directory needed.
- **Disk-backed on purpose.** `medium: Memory` would charge it to the pod's 512Mi limit and OOM the server on a large export.
- **2Gi**, sized for the server-side export, which grows with the shared graph rather than with the caller's upload (client batches are capped near 2 MiB by `witan_core.chunking.MCP_LOAD_MAX_BYTES`). Well clear of a council graph's export today, far below the 8Gi the CI indexer takes for checkouts.

**Writability rests on the pod's existing `fsGroup: 1000`** — kubelet group-owns an emptyDir by fsGroup, and the container runs as uid/gid 1000. That's recorded in the comment because removing fsGroup would make this mount root-owned and useless, which is the same trap `ci_indexer.py` documents on its scratch volume.

Sibling witan pods are unaffected: neither `break_glass.py` nor `migrations.py` sets a security context, so their containers already get a writable root.

## Verification

`pulumi preview` against all three stacks, using the currently-deployed digest so the diff isolates this change:

| Stack | Result |
|---|---|
| CI | 1 to update, 44 unchanged |
| QA | 1 to update, 44 unchanged |
| Production | 1 to update, 44 unchanged |

The CI diff is one `volumeMount` and one `volume` added — no replacements, nothing else touched. pre-commit green including mypy.

## Companion change

agent-kit [#200](https://github.com/mitodl/agent-kit/pull/200) fixes the *second*, independent blocker found by the same test: client batches were sized by omnigraph's 8 MiB budget while the MCP SDK caps request bodies at 4 MiB. **Both are needed** — this one unblocks `store_merge` at all, that one keeps a real store's batches under the cap.

Once both land I can re-run the live migration and confirm end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RYhh9nDjtX31gMEbGMfh73