### PR TITLE
fix(opik): pin liquibase migrations to a single clickhouse replica

### DIFF
--- a/src/ol_infrastructure/applications/opik/__main__.py
+++ b/src/ol_infrastructure/applications/opik/__main__.py
@@ -115,6 +115,21 @@ CLICKHOUSE_HTTP_PORT = 8123
 CLICKHOUSE_DATABASE = "opik_db"
 CLICKHOUSE_USER = "opik"
 
+# Liquibase migrations MUST target a single, stable ClickHouse replica rather
+# than the load-balanced ``clickhouse`` service. The changelog bookkeeping
+# tables (DATABASECHANGELOG / DATABASECHANGELOGLOCK) are node-local — the
+# liquibase-clickhouse extension only makes them replicated when a
+# ``liquibaseClickhouse.conf`` declares cluster mode, which the opik chart gives
+# us no way to mount. Round-robining the JDBC pool across the three replicas
+# therefore splits migration state three ways: each node believes a different
+# subset of changesets has run, while the ReplicatedMergeTree metadata they all
+# write lives in shared Keeper. That is how 000017_change_tables_to_replicated
+# ends up replaying its 12-column ``experiments`` DDL against a ZooKeeper path
+# that a further-along replica already advanced to 20 columns, failing with
+# "Missing columns: 'optimization_id'" (comet-ml/opik#2464). The Altinity
+# operator gives every replica a stable headless service, so pin to replica 0.
+CLICKHOUSE_MIGRATIONS_HOST = "chi-clickhouse-default-0-0.clickhouse.svc.cluster.local"
+
 # Vault KV-v2 mount + path holding the ClickHouse credentials. The ``opik`` key
 # is the password for the ``opik`` ClickHouse user / ``opik_db`` database.
 CLICKHOUSE_VAULT_MOUNT = "secret-clickhouse"
@@ -232,7 +247,7 @@ opik_helm_release = kubernetes.helm.v3.Release(
                         # changelog matches what those changesets manipulate. The
                         # ``opik`` ClickHouse user is granted access to ``default``
                         # for exactly this (see ol-application-clickhouse).
-                        "ANALYTICS_DB_MIGRATIONS_URL": f"jdbc:clickhouse://{CLICKHOUSE_HOST}:{CLICKHOUSE_HTTP_PORT}",
+                        "ANALYTICS_DB_MIGRATIONS_URL": f"jdbc:clickhouse://{CLICKHOUSE_MIGRATIONS_HOST}:{CLICKHOUSE_HTTP_PORT}",
                         "ANALYTICS_DB_PROTOCOL": "HTTP",
                         "ANALYTICS_DB_HOST": CLICKHOUSE_HOST,
                         "ANALYTICS_DB_PORT": str(CLICKHOUSE_HTTP_PORT),


### PR DESCRIPTION
### What are the relevant tickets?
N/A — upstream context: https://github.com/comet-ml/opik/issues/2464

### Description (What does it do?)
Points Opik's `ANALYTICS_DB_MIGRATIONS_URL` at a single stable ClickHouse replica (`chi-clickhouse-default-0-0`) instead of the load-balanced `clickhouse` service.

Liquibase's bookkeeping tables (`DATABASECHANGELOG` / `DATABASECHANGELOGLOCK`) are node-local — the liquibase-clickhouse extension only replicates them when a `liquibaseClickhouse.conf` declares cluster mode, and the opik chart gives us no way to mount one. Round-robining the JDBC pool across all three replicas therefore splits migration state three ways: each node tracks a different subset of applied changesets, while the ReplicatedMergeTree metadata they all write lives in shared Keeper.

That divergence is what makes `000017_change_tables_to_replicated` replay its 12-column `experiments` DDL against a Keeper path another replica has already advanced to 20 columns:

```
Missing columns: 'optimization_id'
```

The Altinity operator gives every replica a stable headless service, so pinning to replica 0 keeps migration state in one place. Runtime queries still go through the load-balanced service — only the migrations connection is pinned.

### How can this be tested?
`pulumi preview` on the opik stack should show a single change: the `ANALYTICS_DB_MIGRATIONS_URL` value in the Helm release / `opik-backend` ConfigMap.

After apply, the `backend-migrations` init container should complete without the `Missing columns` error, and `SELECT id, filename FROM default.DATABASECHANGELOG ORDER BY dateexecuted` against replica 0 should show a single coherent changelog.

### Additional Context
Replicas that already diverged may need their `000017` table definitions reconciled before this takes effect — pinning stops the state from splitting further but does not repair a split that already happened.