### PR TITLE
Revert "move APISIX auth gate from /cart to /checkout/anonymous" (#5243)

### DIFF
--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -558,11 +558,9 @@ mitxonline_granian_workers_max_rss = (
 # it should react to.
 #
 # The route matcher aggregates every webapp route (direct + prefixed, passauth /
-# reqauth / checkout-anonymous) so total traffic drives scaling rather than a single
-# route. Verified against live metrics -- `count by (route) (apisix_http_status)`
-# returns mitxonline_mitxonline-apisix-route-{direct,prefixed}-production_{passauth,
-# reqauth,checkout-anonymous}. (The direct group's auth gate was renamed from "cart"
-# to "checkout-anonymous"; the ".*" matcher already covered it either way.)
+# reqauth / cart) so total traffic drives scaling rather than a single route. Verified
+# against live metrics -- `count by (route) (apisix_http_status)` returns
+# mitxonline_mitxonline-apisix-route-{direct,prefixed}-production_{passauth,reqauth,cart}.
 webapp_trigger_auth, webapp_trigger_auth_name = create_webapp_prometheus_trigger_auth(
     application_name="mitxonline",
     env_name=env_name,
@@ -852,26 +850,14 @@ mitxonline_apisix_route_direct = OLApisixRoute(
             backend_service_name=mitxonline_k8s_app.application_lb_service_name,
             backend_service_port=mitxonline_k8s_app.application_lb_service_port_name,
         ),
-        # Login gate for the reordered ("anonymous first") checkout flow, and the
-        # successor to the former "cart" route. A learner who built a basket
-        # while logged out now browses /cart anonymously -- with the cart auth
-        # gate gone, /cart falls through to the passauth route above, which
-        # serves the anonymous basket. When they proceed to checkout they land
-        # here, where unauth_action="auth" forces the OIDC login that
-        # establishes the MITx Online session, after which the anonymous basket
-        # is claimed and checkout proceeds. Mirrors mitxonline's own gateway,
-        # which renamed its app-cart route to app-checkout-anonymous and swapped
-        # /cart for /checkout/anonymous for exactly this reason. Same direct
-        # (MITx Online) session and default per-host /.apisix/redirect callback
-        # as the old cart route.
         OLApisixRouteConfig(
-            route_name="checkout-anonymous",
+            route_name="cart",
             priority=20,
             hosts=[api_domain, frontend_domain],
             paths=[
-                "/checkout/anonymous",
-                "/checkout/anonymous/",
-                "/checkout/anonymous/*",
+                "/cart/",
+                "/cart",
+                "/cart/*",
             ],
             plugins=[
                 mitxonline_direct_oidc.get_full_oidc_plugin_config(


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Reverts https://github.com/mitodl/ol-infrastructure/commit/0fed8505d42e2eab046d91c3fc71e1082fa81976 (#5243), which moved mitxonline's APISIX direct-route login gate from `/cart*` to `/checkout/anonymous(/)`.

This restores the `cart` route (`route_name="cart"`, paths `/cart/`, `/cart`, `/cart/*`) as the OIDC login gate on the direct route group, and drops the `checkout-anonymous` route added in #5243 (including the `/checkout/anonymous/*` wildcard added afterward in #5244).

Also reverts the accompanying doc comment above `create_webapp_prometheus_trigger_auth` back to referencing the `cart` route name instead of `checkout-anonymous`, since it describes the live route matcher used for KEDA request-rate metrics.

Not a straight `git revert`: #5244 added `/checkout/anonymous/*` on top of #5243's change to the same path list, so the revert was resolved manually to also remove that wildcard and restore the original three `/cart*` paths.

### How can this be tested?
`pulumi preview` against the mitxonline `Production` stack should show only the `OLApisixRoute` direct-group route resource changing (route name/paths reverting from `checkout-anonymous` back to `cart`), with no image/version changes. No infra has been applied yet — this PR only reverts the code; deploying it to production is a separate, explicit step.

### Additional Context
Opened per explicit request to revert #5243 and prepare (but not yet apply) the change to mitxonline production. The `pulumi up` against the Production stack is intentionally deferred until this PR is reviewed/merged.