### PR TITLE
fix(gwarek): restore realm-role userinfo mapper, fix migration/deploy race

### DIFF
--- a/src/ol_infrastructure/applications/gwarek/__main__.py
+++ b/src/ol_infrastructure/applications/gwarek/__main__.py
@@ -655,16 +655,54 @@ gwarek_replicas = gwarek_config.get_int("replicas") or 1
 
 # ---------------------------------------------------------------------------
 # One-off migration Job — runs `alembic upgrade head` against the admin
-# Vault DB role before the api/worker Deployments are expected to serve
-# traffic. Defined before those Deployments and referenced in their
-# depends_on below: Pulumi's Kubernetes provider awaits a Job's Complete
-# condition by default, so this ordering is enforced, not advisory --
-# confirmed the hard way when an image-only deploy raced the app pods'
-# Vault-issued DB credential (whose GRANT ALL statement only covers tables
-# that exist at credential-creation time) ahead of this Job creating
-# finding_tracking/issue_trackers, leaving the app role with zero privileges
-# on either until a manual GRANT.
+# Vault DB role, then grants the *stable* "gwarek" role (every dynamic app
+# credential is a member of it) privileges on whatever tables now exist.
+#
+# The grant step is the actual fix for a real production incident: the
+# app-role Vault credential (gwarek_db_app_secret below) is a
+# VaultDynamicSecret reissued on Vault's own lease/TTL schedule, entirely
+# decoupled from any given `pulumi up` -- its one-time GRANT ALL creation
+# statement only covers tables that existed at *that* issuance time.
+# Ordering this Job before the api/worker Deployments (their depends_on
+# below) only changes when those pods start; it does nothing to make Vault
+# reissue a credential, so a long-lived, already-granted credential started
+# right back up with zero privileges on finding_tracking/issue_trackers
+# after they were added, regardless of deploy timing. Granting the stable
+# role directly here makes correctness independent of Vault's reissuance
+# schedule -- every migration run leaves it correct for the schema as it
+# stands, deterministically.
+#
+# Still defined before the Deployments and referenced in their depends_on:
+# Pulumi's Kubernetes provider awaits a Job's Complete condition by default,
+# so app pods won't start serving against a schema mid-migration -- a real
+# but separate concern from the privilege grant above.
 # ---------------------------------------------------------------------------
+_GWAREK_MIGRATE_AND_GRANT_SCRIPT = """
+import asyncio, os, subprocess, sys
+import asyncpg
+
+subprocess.run([sys.executable, "-m", "alembic", "upgrade", "head"], check=True)
+
+async def _grant():
+    conn = await asyncpg.connect(
+        user=os.environ["DB_USERNAME"],
+        password=os.environ["DB_PASSWORD"],
+        host=os.environ["DB_HOST"],
+        database="gwarek",
+    )
+    try:
+        await conn.execute(
+            "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO gwarek"
+        )
+        await conn.execute(
+            "GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO gwarek"
+        )
+    finally:
+        await conn.close()
+
+asyncio.run(_grant())
+"""
+
 gwarek_migration_job = batch.v1.Job(
     f"gwarek-migration-job-{stack_info.env_suffix}",
     metadata=meta.v1.ObjectMetaArgs(
@@ -682,12 +720,13 @@ gwarek_migration_job = batch.v1.Job(
                     core.v1.ContainerArgs(
                         name="migrate",
                         image=gwarek_api_image,
+                        # subprocess, not a shell wrapper -- the DHI runtime
+                        # image this runs on ships no shell to chain `&&`
+                        # through.
                         command=[
                             "/app/.venv/bin/python",
-                            "-m",
-                            "alembic",
-                            "upgrade",
-                            "head",
+                            "-c",
+                            _GWAREK_MIGRATE_AND_GRANT_SCRIPT,
                         ],
                         env=_db_env(gwarek_db_admin_secret_k8s_name),
                     ),

--- a/src/ol_infrastructure/applications/gwarek/__main__.py
+++ b/src/ol_infrastructure/applications/gwarek/__main__.py
@@ -654,6 +654,51 @@ gwarek_common_env_from = [
 gwarek_replicas = gwarek_config.get_int("replicas") or 1
 
 # ---------------------------------------------------------------------------
+# One-off migration Job — runs `alembic upgrade head` against the admin
+# Vault DB role before the api/worker Deployments are expected to serve
+# traffic. Defined before those Deployments and referenced in their
+# depends_on below: Pulumi's Kubernetes provider awaits a Job's Complete
+# condition by default, so this ordering is enforced, not advisory --
+# confirmed the hard way when an image-only deploy raced the app pods'
+# Vault-issued DB credential (whose GRANT ALL statement only covers tables
+# that exist at credential-creation time) ahead of this Job creating
+# finding_tracking/issue_trackers, leaving the app role with zero privileges
+# on either until a manual GRANT.
+# ---------------------------------------------------------------------------
+gwarek_migration_job = batch.v1.Job(
+    f"gwarek-migration-job-{stack_info.env_suffix}",
+    metadata=meta.v1.ObjectMetaArgs(
+        name="gwarek-migrate",
+        namespace=gwarek_namespace,
+        labels=application_labels,
+    ),
+    spec=batch.v1.JobSpecArgs(
+        backoff_limit=2,
+        template=core.v1.PodTemplateSpecArgs(
+            metadata=meta.v1.ObjectMetaArgs(labels=application_labels),
+            spec=core.v1.PodSpecArgs(
+                restart_policy="Never",
+                containers=[
+                    core.v1.ContainerArgs(
+                        name="migrate",
+                        image=gwarek_api_image,
+                        command=[
+                            "/app/.venv/bin/python",
+                            "-m",
+                            "alembic",
+                            "upgrade",
+                            "head",
+                        ],
+                        env=_db_env(gwarek_db_admin_secret_k8s_name),
+                    ),
+                ],
+            ),
+        ),
+    ),
+    opts=ResourceOptions(depends_on=[gwarek_db_admin_secret]),
+)
+
+# ---------------------------------------------------------------------------
 # api Deployment + Service
 # ---------------------------------------------------------------------------
 gwarek_api_deployment = apps_v1.Deployment(
@@ -714,7 +759,12 @@ gwarek_api_deployment = apps_v1.Deployment(
         ),
     ),
     opts=ResourceOptions(
-        depends_on=[gwarek_db_app_secret, gwarek_app_secrets, gwarek_redis_creds]
+        depends_on=[
+            gwarek_db_app_secret,
+            gwarek_app_secrets,
+            gwarek_redis_creds,
+            gwarek_migration_job,
+        ]
     ),
 )
 
@@ -786,7 +836,12 @@ gwarek_worker_deployment = apps_v1.Deployment(
         ),
     ),
     opts=ResourceOptions(
-        depends_on=[gwarek_db_app_secret, gwarek_app_secrets, gwarek_redis_creds]
+        depends_on=[
+            gwarek_db_app_secret,
+            gwarek_app_secrets,
+            gwarek_redis_creds,
+            gwarek_migration_job,
+        ]
     ),
 )
 
@@ -866,47 +921,6 @@ gwarek_web_service = core.v1.Service(
         selector={"app": "gwarek", "component": "web"},
         ports=[core.v1.ServicePortArgs(port=3000, target_port=3000, name="http")],
     ),
-)
-
-# ---------------------------------------------------------------------------
-# One-off migration Job — runs `alembic upgrade head` against the admin
-# Vault DB role before the api/worker Deployments are expected to serve
-# traffic. Pulumi does not block on Job completion, so this ordering is
-# advisory only (via depends_on on the Job's own secret) — confirm the
-# migration actually completed before considering a deploy done (see the
-# plan's Phase 6/7 manual verification step).
-# ---------------------------------------------------------------------------
-gwarek_migration_job = batch.v1.Job(
-    f"gwarek-migration-job-{stack_info.env_suffix}",
-    metadata=meta.v1.ObjectMetaArgs(
-        name="gwarek-migrate",
-        namespace=gwarek_namespace,
-        labels=application_labels,
-    ),
-    spec=batch.v1.JobSpecArgs(
-        backoff_limit=2,
-        template=core.v1.PodTemplateSpecArgs(
-            metadata=meta.v1.ObjectMetaArgs(labels=application_labels),
-            spec=core.v1.PodSpecArgs(
-                restart_policy="Never",
-                containers=[
-                    core.v1.ContainerArgs(
-                        name="migrate",
-                        image=gwarek_api_image,
-                        command=[
-                            "/app/.venv/bin/python",
-                            "-m",
-                            "alembic",
-                            "upgrade",
-                            "head",
-                        ],
-                        env=_db_env(gwarek_db_admin_secret_k8s_name),
-                    ),
-                ],
-            ),
-        ),
-    ),
-    opts=ResourceOptions(depends_on=[gwarek_db_admin_secret]),
 )
 
 # ---------------------------------------------------------------------------

--- a/src/ol_infrastructure/substructure/keycloak/ol_platform_engineering.py
+++ b/src/ol_infrastructure/substructure/keycloak/ol_platform_engineering.py
@@ -655,11 +655,18 @@ def create_ol_platform_engineering_realm(  # noqa: PLR0913, PLR0915
         # the generic admin/developer roles above since those are shared across
         # unrelated tools (Airbyte, Vault, Concourse) and granting them
         # shouldn't imply gwarek access or vice versa. Realm roles land in
-        # every token's realm_access.roles claim automatically, so — unlike the
-        # Grafana client-role + UserClientRoleProtocolMapper pattern below — no
-        # protocol mapper is needed here; gwarek's FastAPI backend reads
-        # realm_access.roles directly (mirroring ol-analytics-api's
-        # require_mit_admin).
+        # every access/ID token's realm_access.roles claim automatically via
+        # Keycloak's default "roles" client scope -- but that default mapper's
+        # "Add to userinfo" is off, and APISIX's openid-connect plugin builds
+        # the X-Userinfo header gwarek's backend trusts from the /userinfo
+        # response, not the raw token. Confirmed in production: gwarek-admin
+        # assigned to a user still 403'd on every request ("No gwarek role
+        # assigned") because realm_access was simply absent from userinfo.
+        # The explicit UserRealmRoleProtocolMapper below (userinfo-only, so it
+        # doesn't duplicate what the default scope already puts in the
+        # access/ID token) closes that gap -- same shape as the Concourse
+        # groups-mapper above, just writing to realm_access.roles instead of
+        # a custom "groups" claim.
         keycloak.Role(
             "ol-platform-engineering-gwarek-admin-role",
             realm_id=ol_platform_engineering_realm.id,
@@ -672,6 +679,18 @@ def create_ol_platform_engineering_realm(  # noqa: PLR0913, PLR0915
             realm_id=ol_platform_engineering_realm.id,
             name="gwarek-viewer",
             description="Gwarek viewer — read-only access to findings/reports",
+            opts=resource_options,
+        )
+        keycloak.openid.UserRealmRoleProtocolMapper(
+            "ol-platform-engineering-gwarek-realm-role-userinfo-mapper",
+            realm_id=ol_platform_engineering_realm.id,
+            client_id=ol_platform_engineering_gwarek_client.id,
+            name="Realm Roles Userinfo Mapper",
+            claim_name="realm_access.roles",
+            multivalued=True,
+            add_to_id_token=False,
+            add_to_access_token=False,
+            add_to_userinfo=True,
             opts=resource_options,
         )
 


### PR DESCRIPTION
## Summary

Two related production incidents from today's gwarek settings-feature deploy, both already remediated live and fixed here so they can't recur.

**1. `gwarek-admin` role wasn't recognized (`/api/me` always 403 "No gwarek role assigned")**

Keycloak's default "roles" client scope puts `realm_access.roles` into the access/ID token automatically, but not into the `/userinfo` response — and APISIX's `X-Userinfo` header, which gwarek's backend trusts entirely, is built from that `/userinfo` call. A `UserRealmRoleProtocolMapper` closing this gap already existed against the live Production Keycloak stack, but was never committed — PR #5282 (an unrelated CI fix) called it out by name as "pre-existing drift, not from this change" while reconciling Production, and its `pulumi up` deleted it. Re-added here, this time actually committed.

Confirmed via production logs: `/api/me` and admin-gated endpoints worked fine 2026-08-03 15:15 UTC (minutes after the gwarek Keycloak client was first created) through 2026-08-05 19:05 UTC, then 403'd continuously afterward — the exact window bounded by PR #5282's merge.

**2. New tables (`finding_tracking`, `issue_trackers`) had no privileges for the app DB role → 500s on every integration page**

The app-role Vault credential (`gwarek_db_app_secret`) is a `VaultDynamicSecret` reissued on Vault's own lease/TTL schedule, entirely decoupled from any given `pulumi up` — its one-time `GRANT ALL PRIVILEGES ON ALL TABLES` creation statement only covers tables that existed at *that* issuance time. A long-lived, already-issued app credential had zero privileges on the two new tables, causing 500s on every integration detail page. Fixed manually in production with an out-of-band `GRANT`.

Fixed here at the source: the migration Job now grants the *stable* `gwarek` role (every dynamic app credential is a member of it) privileges on whatever tables exist immediately after `alembic upgrade head`, using the admin credential's `WITH GRANT OPTION`. This makes correctness deterministic on every migration run, independent of Vault's reissuance schedule — an earlier version of this fix here tried ordering the api/worker Deployments after the migration Job via `depends_on`, but that only changes when pods *start*, not whether Vault has reissued a credential, so it didn't actually address the gap (caught in review). The `depends_on` ordering is kept anyway for a narrower, real concern — pods shouldn't start serving against a schema mid-migration — but the privilege fix no longer depends on it.

Implemented as a single `python -c` script (`subprocess` for the alembic invocation, `asyncpg` for the grant) rather than a shell one-liner, since the DHI runtime image this runs on ships no shell to chain `&&` through.

## Test plan

- [x] `pulumi preview` on `ol-substructure-keycloak` Production: 1 resource to create (the mapper), 333 unchanged
- [x] Applied to Production directly; confirmed live — gwarek-admin now resolves correctly, Settings page accessible
- [x] `pulumi preview` on `ol-application-gwarek` Production: diff is exactly what's expected (Job replace for the script change, Deployments update for the newer image, same pre-existing unrelated CloudWatch alarm drift) — no surprises
- [x] Verified the embedded migrate-and-grant script's syntax via `ast.parse`, and exercised its actual `GRANT` statements against a real local Postgres connection before landing this
- [x] Manually granted DB privileges on the two new tables in production via a one-off debug pod as an immediate remediation; confirmed the GitHub integration page loads again (this PR makes that manual step unnecessary on future migrations)
- [x] `ruff format`/`check`, `mypy`, pre-commit all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)