### PR TITLE
Add a read-only AWS MCP backend to toolhive-swe

### DIFF
--- a/src/bridge/lib/versions.py
+++ b/src/bridge/lib/versions.py
@@ -127,3 +127,7 @@ MCP_SENTRY_VERSION = "0.37.0"
 # stdio mode). Tag tracks the dockyard build, not the upstream npm pkg.
 # renovate: datasource=docker depName=context7 packageName=ghcr.io/stacklok/dockyard/npx/context7
 MCP_CONTEXT7_VERSION = "3.2.5"
+# AWS's official SigV4 proxy image, the stdio bridge to the managed AWS MCP Server
+# endpoint. Image tags track the PyPI package (mcp-proxy-for-aws) one-for-one.
+# renovate: datasource=docker depName=mcp-proxy-for-aws packageName=public.ecr.aws/mcp-proxy-for-aws/mcp-proxy-for-aws
+MCP_PROXY_FOR_AWS_VERSION = "1.6.4"

--- a/src/ol_infrastructure/applications/toolhive_swe/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/applications/toolhive_swe/Pulumi.CI.yaml
@@ -29,3 +29,5 @@ config:
     secure: v1:6nOO1ObT6BhUYNC1:OETprMCV7BkNd72WQoV/wRuGLf/CtJUQXEfJvtsMzJL6HXoQPJPhM7K1/pRuYurI6f5h33cqWqp8ZikkxNs=
   toolhive_swe:sentry_enabled: "false"
   toolhive_swe:context7_enabled: "false"
+  # The `aws` backend needs no secret config: it authenticates with IRSA.
+  toolhive_swe:aws_mcp_enabled: "true"

--- a/src/ol_infrastructure/applications/toolhive_swe/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/applications/toolhive_swe/Pulumi.CI.yaml
@@ -29,5 +29,4 @@ config:
     secure: v1:6nOO1ObT6BhUYNC1:OETprMCV7BkNd72WQoV/wRuGLf/CtJUQXEfJvtsMzJL6HXoQPJPhM7K1/pRuYurI6f5h33cqWqp8ZikkxNs=
   toolhive_swe:sentry_enabled: "false"
   toolhive_swe:context7_enabled: "false"
-  # The `aws` backend needs no secret config: it authenticates with IRSA.
-  toolhive_swe:aws_mcp_enabled: "true"
+  toolhive_swe:aws_mcp_enabled: "false"

--- a/src/ol_infrastructure/applications/toolhive_swe/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/toolhive_swe/Pulumi.Production.yaml
@@ -20,4 +20,5 @@ config:
   toolhive_swe:context7_enabled: "true"
   toolhive_swe:context7_api_key:
     secure: v1:+EHQSAypsSet/IkB:wNtFOo5pAO1dUtlJFZqWOo93F0r4EOgUA8kV1whv66c0Y54Sbeczbv2W97eek2JphIhJilcRLl4P78g=
-  toolhive_swe:aws_mcp_enabled: "false"
+  # The `aws` backend needs no secret config: it authenticates with IRSA.
+  toolhive_swe:aws_mcp_enabled: "true"

--- a/src/ol_infrastructure/applications/toolhive_swe/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/toolhive_swe/Pulumi.Production.yaml
@@ -20,3 +20,4 @@ config:
   toolhive_swe:context7_enabled: "true"
   toolhive_swe:context7_api_key:
     secure: v1:+EHQSAypsSet/IkB:wNtFOo5pAO1dUtlJFZqWOo93F0r4EOgUA8kV1whv66c0Y54Sbeczbv2W97eek2JphIhJilcRLl4P78g=
+  toolhive_swe:aws_mcp_enabled: "false"

--- a/src/ol_infrastructure/applications/toolhive_swe/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/toolhive_swe/Pulumi.QA.yaml
@@ -16,3 +16,4 @@ config:
     secure: v1:iAmaEthWNJkVv4v5:7ZrIcEmmxyAyRkotl3aJ0Xe8XO1uEJ/79ZyN3HtfgB4AZXuSEFi4jt2iKYSfgIhomXnc1iNlTVChxKp2
   toolhive_swe:sentry_enabled: "false"
   toolhive_swe:context7_enabled: "false"
+  toolhive_swe:aws_mcp_enabled: "false"

--- a/src/ol_infrastructure/applications/toolhive_swe/__main__.py
+++ b/src/ol_infrastructure/applications/toolhive_swe/__main__.py
@@ -20,6 +20,8 @@ https://docs.stacklok.com/toolhive/guides-vmcp/authentication:
 - the ``grafana`` ``MCPServer`` (OSS mcp-grafana pointed at Grafana Cloud with a
   service-account token from stack config; see mcp_servers.py for why the hosted
   Grafana Cloud MCP endpoint is not proxied instead), also joined to the group,
+- the per-stack optional ``context7``, ``sentry`` and ``aws`` ``MCPServer``s, each
+  gated behind a ``toolhive_swe:<name>_enabled`` boolean (see mcp_servers.py),
 - an ``MCPOIDCConfig`` (``swe-vmcp-oidc``) used to validate the JWTs the vMCP's own
   embedded auth server issues (its issuer is the vMCP endpoint itself), and
 - a ``VirtualMCPServer`` (``swe-vmcp``) that aggregates every backend in the group
@@ -69,6 +71,21 @@ Incoming auth (browser login via Keycloak, brokered by ToolHive):
         clients get ``invalid_client`` and must re-register. Redis runs with
         requirepass; the CRD requires a password (aclUserConfig.passwordSecretRef).
 
+AWS access (for the ``aws`` backend):
+    The ``aws`` backend is AWS's official ``mcp-proxy-for-aws`` SigV4 proxy in front
+    of the managed AWS MCP Server endpoint. It authenticates with IRSA rather than a
+    token in stack config: the ``OLEKSAuthBinding`` below creates the
+    ``toolhive-swe-aws-mcp`` ServiceAccount annotated with the IRSA role ARN, the
+    MCPServer's ``spec.serviceAccount`` puts the workload pod on it, and the EKS
+    pod-identity webhook supplies the web-identity credentials boto3 picks up.
+
+    Read-only is enforced entirely by that role's IAM — AWS-managed
+    ``ReadOnlyAccess`` plus an explicit Deny on secret-material reads. The proxy's
+    ``--read-only`` flag is deliberately not used; see mcp_servers.py for why it
+    removes account access altogether rather than restricting it. IAM matters here
+    because CI, QA and Production share one AWS account, so this role reads
+    Production resources regardless of which stack created it.
+
 The ``VirtualMCPServer`` is exposed to the internet through the shared APISIX gateway
 on the operations cluster at ``toolhive-swe[.<env>].ol.mit.edu`` using the hybrid
 HTTPRoute + ApisixTls pattern (ADR-0003). The hostname is added to the operations EKS
@@ -79,11 +96,13 @@ from pathlib import Path
 
 import pulumi_kubernetes as kubernetes
 from pulumi import Config, ResourceOptions, export
+from pulumi_aws import iam
 
 from ol_infrastructure.applications.toolhive_swe.ingress import (
     create_ingress_resources,
 )
 from ol_infrastructure.applications.toolhive_swe.mcp_servers import (
+    AWS_MCP_SERVICE_ACCOUNT_NAME,
     MCP_GROUP_NAME,
     create_mcp_servers,
 )
@@ -213,27 +232,161 @@ HMAC_SECRET_KEY = "hmac-key"  # noqa: S105  # pragma: allowlist secret
 REDIS_ADDR = redis_addr(TOOLHIVE_NAMESPACE)
 
 #############################################
-#   Vault auth binding (for VSO secret sync)#
+#   Vault auth binding + AWS read-only IRSA #
 #############################################
-# No AWS access is required, so no IAM policy is attached (iam_policy_document=None).
 # The binding provisions the Vault Secrets Operator wiring (VaultConnection /
 # VaultAuth / sync service account) plus a Vault policy granting read access to the
-# Keycloak client secret at secret-operations/sso/toolhive.
+# Keycloak client secret at secret-operations/sso/toolhive. It ALSO provisions the
+# IRSA role and ServiceAccount the `aws` MCP backend runs under (see
+# mcp_servers.py), which is the only thing in this namespace that touches AWS.
+#
+# AWS-managed ReadOnlyAccess is attached below rather than being spelled out as a
+# policy document: reproducing it by hand would be thousands of actions to keep in
+# sync with AWS. What is spelled out here is the Deny that carves back the
+# data-plane reads ReadOnlyAccess includes — the ones that turn "read-only" into
+# "can exfiltrate every credential we keep in AWS". An explicit Deny beats
+# ReadOnlyAccess's Allow in IAM policy evaluation, so these stay unreachable even
+# as AWS grows what the managed policy covers.
+#
+# The action list was derived empirically, not from the docs: on 2026-08-07 the
+# live CI role was probed against each candidate with a deliberately nonexistent
+# resource, so a 403 meant IAM blocks the action and any other error meant IAM
+# permits it. Nine actions came back permitted; every one of them is below. Where
+# a comment says "measured", that is what it refers to.
+#
+# Several denies are blunter than we would like because IAM offers no condition
+# key to scope them — ec2:DescribeInstanceAttribute is one action for every
+# attribute, apigateway:GET one action for every read, ssm:GetParameter* cannot
+# distinguish SecureString from String. In each case the whole action goes, and
+# the lost describe-level detail is an accepted cost.
+#
+# NOTE this is a denylist against a managed policy that AWS keeps growing, which
+# makes it unbounded by construction: it closes what was measured, not what AWS
+# ships next. Swapping the base grant to ViewOnlyAccess (List/Describe only, no
+# resource contents) would make this class of gap structurally impossible and
+# reduce this document to a short backstop. That is the durable fix if this ever
+# needs revisiting.
+aws_mcp_deny_policy_document = {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "DenyCredentialMaterialReads",
+            "Effect": "Deny",
+            "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:BatchGetSecretValue",
+                # GetParameterHistory returns the same values GetParameter does,
+                # plus superseded ones. Measured: it was the one outright bypass
+                # of this statement's original form, permitted by ReadOnlyAccess.
+                "ssm:GetParameter",
+                "ssm:GetParameters",
+                "ssm:GetParametersByPath",
+                "ssm:GetParameterHistory",
+                "kms:Decrypt",
+                # Configuration that conventionally carries credentials in
+                # plaintext: Lambda and ECS environment variables, EC2 user-data
+                # bootstrap scripts (where this repo's Consul/Vault bootstrap
+                # config lives). All three measured as permitted.
+                "lambda:GetFunction",
+                "lambda:GetFunctionConfiguration",
+                "ecs:DescribeTaskDefinition",
+                "ec2:DescribeInstanceAttribute",
+                # Credential-minting reads. Measured as blocked today, but only
+                # because ReadOnlyAccess does not happen to grant them; pinned so
+                # a future expansion of that managed policy cannot open them.
+                # ecr:GetAuthorizationToken is the exception to "measured": it
+                # takes no arguments, so probing it would have minted a real
+                # 12-hour registry credential. It is denied on inference from the
+                # ecr:Get* family that ReadOnlyAccess grants.
+                "ecr:GetAuthorizationToken",
+                "redshift:GetClusterCredentials",
+                "redshift-serverless:GetCredentials",
+                "glue:GetConnection",
+                # sso:GetRoleCredentials deliberately NOT listed: the SSO portal
+                # API is authorized by an SSO access token rather than by IAM
+                # identity-based policy, so denying it here would be a no-op.
+                # Parliament rejects it as an unknown action for that reason.
+                # One action covers /apikeys?includeValues=true, which returns
+                # API key material.
+                "apigateway:GET",
+            ],
+            "Resource": "*",
+        },
+        {
+            "Sid": "DenyBulkDataPlaneReads",
+            "Effect": "Deny",
+            "Action": [
+                "s3:GetObject",
+                "s3:GetObjectVersion",
+                "s3:GetObjectTorrent",
+                # Athena and Redshift read the data lake through their OWN
+                # service roles and return rows over their APIs, so the s3
+                # denies above do not cover them — a second door to the same
+                # room the ol-data-lake-* buckets are in.
+                "athena:GetQueryResults",
+                "redshift-data:GetStatementResult",
+                "rds-data:ExecuteStatement",
+                "rds-data:BatchExecuteStatement",
+                "rds-data:ExecuteSql",
+                "dynamodb:GetItem",
+                "dynamodb:BatchGetItem",
+                "dynamodb:Query",
+                "dynamodb:Scan",
+                "dynamodb:PartiQLSelect",
+                "dynamodb:GetRecords",
+                # sqs:ReceiveMessage is not even read-only in effect: it starts a
+                # visibility timeout and can stall a real consumer.
+                "kinesis:GetRecords",
+                "kinesis:GetShardIterator",
+                "kinesis:SubscribeToShard",
+                "sqs:ReceiveMessage",
+                # Log bodies are the most common accidental secret store. Denied
+                # at a real cost to debugging, but CloudWatch log content stays
+                # reachable through the grafana backend, which reads it under its
+                # own service account rather than this role.
+                "logs:GetLogEvents",
+                "logs:FilterLogEvents",
+                "logs:GetLogRecord",
+                "logs:GetQueryResults",
+            ],
+            "Resource": "*",
+        },
+    ],
+}
+
+# The IRSA role, its ServiceAccount and the grants below are created in EVERY
+# stack, not gated behind toolhive_swe:aws_mcp_enabled. A role that no pod can
+# assume is inert, and keeping the IAM identical across environments makes
+# promoting the backend to QA/Production a config-only change — the same way this
+# stack already treats environment promotion.
 toolhive_swe_auth_binding = OLEKSAuthBinding(
     OLEKSAuthBindingConfig(
         application_name="toolhive-swe",
         namespace=TOOLHIVE_NAMESPACE,
         stack_info=stack_info,
         aws_config=aws_config,
-        iam_policy_document=None,
+        iam_policy_document=aws_mcp_deny_policy_document,
+        # A Deny on "*" is the point of this document, not an oversight.
+        parliament_config={"RESOURCE_EFFECTIVELY_STAR": {}},
         vault_policy_path=Path(__file__).parent.joinpath("toolhive_swe_policy.hcl"),
         cluster_name=cluster_stack.require_output("cluster_name"),
         cluster_identities=cluster_stack.require_output("cluster_identities"),
         vault_auth_endpoint=cluster_stack.require_output("vault_auth_endpoint"),
-        irsa_service_account_name="toolhive-swe",
+        irsa_service_account_name=AWS_MCP_SERVICE_ACCOUNT_NAME,
+        create_irsa_service_account=True,
         vault_sync_service_account_names="toolhive-swe-vault",
         k8s_labels=k8s_labels,
     )
+)
+
+# The read grant itself. Broad on purpose: the value of an AWS backend is being
+# able to describe whatever an agent is debugging without a human relaying CLI
+# output. The Deny above is what keeps "describe everything" from also meaning
+# "read every secret".
+iam.RolePolicyAttachment(
+    f"toolhive-swe-aws-mcp-readonly-attach-{stack_info.env_suffix}",
+    policy_arn="arn:aws:iam::aws:policy/ReadOnlyAccess",
+    role=toolhive_swe_auth_binding.irsa_role.name,
 )
 
 # Sync the Keycloak client secret from Vault into a namespace-local K8s Secret so
@@ -327,6 +480,7 @@ mcp_servers = create_mcp_servers(
     k8s_global_labels=k8s_global_labels,
     cluster_stack=cluster_stack,
     toolhive_swe_config=toolhive_swe_config,
+    aws_mcp_service_account=toolhive_swe_auth_binding.irsa_service_accounts[0],
 )
 
 #########################################

--- a/src/ol_infrastructure/applications/toolhive_swe/__main__.py
+++ b/src/ol_infrastructure/applications/toolhive_swe/__main__.py
@@ -283,14 +283,37 @@ aws_mcp_deny_policy_document = {
                 "ssm:GetParametersByPath",
                 "ssm:GetParameterHistory",
                 "kms:Decrypt",
-                # Configuration that conventionally carries credentials in
-                # plaintext: Lambda and ECS environment variables, EC2 user-data
-                # bootstrap scripts (where this repo's Consul/Vault bootstrap
-                # config lives). All three measured as permitted.
+                # Service configuration that conventionally carries credentials
+                # in plaintext environment variables. Every action in this group
+                # was measured as permitted by ReadOnlyAccess. The list is long
+                # because the surface is: any service that runs a container or a
+                # build hands its environment back through a Describe/Get call.
                 "lambda:GetFunction",
                 "lambda:GetFunctionConfiguration",
                 "ecs:DescribeTaskDefinition",
+                "codebuild:BatchGetProjects",
+                "apprunner:DescribeService",
+                "batch:DescribeJobDefinitions",
+                "amplify:GetApp",
+                "amplify:GetBranch",
+                "elasticbeanstalk:DescribeConfigurationSettings",
+                "sagemaker:DescribeTrainingJob",
+                "sagemaker:DescribeProcessingJob",
+                # Glue job DefaultArguments routinely hold connection strings.
+                "glue:GetJob",
+                # EC2 user-data, where this repo's Consul/Vault bootstrap config
+                # lives. DescribeInstanceAttribute covers a RUNNING instance;
+                # launch templates and launch configurations are a second door to
+                # the same script and are what an ASG actually renders from, so
+                # denying only the first would leave the data reachable.
                 "ec2:DescribeInstanceAttribute",
+                "ec2:DescribeLaunchTemplateVersions",
+                "autoscaling:DescribeLaunchConfigurations",
+                # Other surfaces that embed values inline.
+                "cloudformation:GetTemplate",
+                "ssm:GetDocument",
+                # EMR's IAM prefix is elasticmapreduce, not the boto3 name emr.
+                "elasticmapreduce:ListBootstrapActions",
                 # Credential-minting reads. Measured as blocked today, but only
                 # because ReadOnlyAccess does not happen to grant them; pinned so
                 # a future expansion of that managed policy cannot open them.
@@ -354,11 +377,22 @@ aws_mcp_deny_policy_document = {
     ],
 }
 
-# The IRSA role, its ServiceAccount and the grants below are created in EVERY
-# stack, not gated behind toolhive_swe:aws_mcp_enabled. A role that no pod can
-# assume is inert, and keeping the IAM identical across environments makes
-# promoting the backend to QA/Production a config-only change — the same way this
-# stack already treats environment promotion.
+# The ServiceAccount and the ReadOnlyAccess attachment are gated on the same
+# boolean as the backend itself, because a ServiceAccount is NOT bound to one
+# workload: Kubernetes lets any pod in the namespace select it by name and
+# receive its projected token. Leaving it in place in a stack where the backend
+# is disabled would mean anyone able to create an MCPServer CR in toolhive-swe
+# could set spec.serviceAccount to it and obtain shared-account AWS reads —
+# turning namespace-level workload creation into Production-wide access with the
+# feature switched off. Creating the SA only where the backend runs closes that:
+# Kubernetes refuses to schedule a pod naming a ServiceAccount that is absent.
+#
+# The trust role and the Deny policy are still created everywhere. Both are
+# genuinely inert on their own — a role with nothing but a Deny attached grants
+# nothing — and keeping them stack-invariant means promotion stays a one-line
+# config change.
+aws_mcp_enabled = toolhive_swe_config.get_bool("aws_mcp_enabled")
+
 toolhive_swe_auth_binding = OLEKSAuthBinding(
     OLEKSAuthBindingConfig(
         application_name="toolhive-swe",
@@ -373,7 +407,7 @@ toolhive_swe_auth_binding = OLEKSAuthBinding(
         cluster_identities=cluster_stack.require_output("cluster_identities"),
         vault_auth_endpoint=cluster_stack.require_output("vault_auth_endpoint"),
         irsa_service_account_name=AWS_MCP_SERVICE_ACCOUNT_NAME,
-        create_irsa_service_account=True,
+        create_irsa_service_account=aws_mcp_enabled,
         vault_sync_service_account_names="toolhive-swe-vault",
         k8s_labels=k8s_labels,
     )
@@ -383,11 +417,15 @@ toolhive_swe_auth_binding = OLEKSAuthBinding(
 # able to describe whatever an agent is debugging without a human relaying CLI
 # output. The Deny above is what keeps "describe everything" from also meaning
 # "read every secret".
-iam.RolePolicyAttachment(
-    f"toolhive-swe-aws-mcp-readonly-attach-{stack_info.env_suffix}",
-    policy_arn="arn:aws:iam::aws:policy/ReadOnlyAccess",
-    role=toolhive_swe_auth_binding.irsa_role.name,
-)
+#
+# Gated with the ServiceAccount so a stack with the backend disabled has no path
+# to these permissions at all, rather than a dormant one.
+if aws_mcp_enabled:
+    iam.RolePolicyAttachment(
+        f"toolhive-swe-aws-mcp-readonly-attach-{stack_info.env_suffix}",
+        policy_arn="arn:aws:iam::aws:policy/ReadOnlyAccess",
+        role=toolhive_swe_auth_binding.irsa_role.name,
+    )
 
 # Sync the Keycloak client secret from Vault into a namespace-local K8s Secret so
 # ToolHive's embedded auth server can reference it as the upstream clientSecretRef.
@@ -480,7 +518,9 @@ mcp_servers = create_mcp_servers(
     k8s_global_labels=k8s_global_labels,
     cluster_stack=cluster_stack,
     toolhive_swe_config=toolhive_swe_config,
-    aws_mcp_service_account=toolhive_swe_auth_binding.irsa_service_accounts[0],
+    # A list, not a single handle: it is empty in stacks where the backend is
+    # disabled, which is exactly the stacks that build no MCPServer to depend on.
+    aws_mcp_service_accounts=toolhive_swe_auth_binding.irsa_service_accounts,
 )
 
 #########################################

--- a/src/ol_infrastructure/applications/toolhive_swe/mcp_servers.py
+++ b/src/ol_infrastructure/applications/toolhive_swe/mcp_servers.py
@@ -19,12 +19,25 @@ from pulumi import Config, ResourceOptions, StackReference
 from bridge.lib.versions import (
     MCP_CONTEXT7_VERSION,
     MCP_GRAFANA_VERSION,
+    MCP_PROXY_FOR_AWS_VERSION,
     MCP_SENTRY_VERSION,
 )
 from ol_infrastructure.lib.pulumi_helper import StackInfo
 
 # Name shared by the MCPGroup and every backend/virtual server that references it.
 MCP_GROUP_NAME = "swe-tools"
+
+# ServiceAccount the aws backend runs under. The OLEKSAuthBinding in __main__.py
+# creates it annotated with the IRSA role ARN; the EKS pod-identity webhook turns
+# that annotation into AWS_ROLE_ARN + AWS_WEB_IDENTITY_TOKEN_FILE on the pod,
+# which is all boto3 — and therefore mcp-proxy-for-aws — needs to sign SigV4.
+# Deliberately its own SA rather than a generic namespace one: the AWS read grant
+# should reach exactly one workload.
+AWS_MCP_SERVICE_ACCOUNT_NAME = "toolhive-swe-aws-mcp"
+
+# Regional endpoint of AWS's managed MCP server. us-east-1 is where OL resources
+# live; eu-central-1 is the only other endpoint AWS offers.
+AWS_MCP_ENDPOINT = "https://aws-mcp.us-east-1.api.aws/mcp"
 
 # K8s Secret holding the Grafana Cloud service account token, materialised from
 # encrypted stack config and injected into the grafana MCPServer via ToolHive's
@@ -50,12 +63,13 @@ class ToolhiveSWEMCPServers(NamedTuple):
     servers: list[kubernetes.apiextensions.CustomResource]
 
 
-def create_mcp_servers(
+def create_mcp_servers(  # noqa: PLR0913
     stack_info: StackInfo,
     namespace: str,
     k8s_global_labels: dict[str, str],
     cluster_stack: StackReference,
     toolhive_swe_config: Config,
+    aws_mcp_service_account: kubernetes.core.v1.ServiceAccount,
 ) -> ToolhiveSWEMCPServers:
     """Provision the MCPGroup and every backend MCPServer that joins it."""
     swe_mcpgroup = kubernetes.apiextensions.CustomResource(
@@ -347,6 +361,102 @@ def create_mcp_servers(
             opts=ResourceOptions(depends_on=[swe_mcpgroup, sentry_token_secret]),
         )
         servers.append(sentry_mcpserver)
+
+    # AWS backend: the managed AWS MCP Server (https://aws-mcp.us-east-1.api.aws/mcp,
+    # GA May 2026) reached through AWS's official `mcp-proxy-for-aws` SigV4 proxy.
+    # The proxy is a thin stdio bridge — every tool call executes on the AWS-hosted
+    # endpoint, not here.
+    #
+    # NOT the self-hostable awslabs `aws-api-mcp-server`: AWS has marked that one
+    # "entering end of development" and its tool descriptions now emit a deprecation
+    # notice to the agent on every call.
+    #
+    # Read-only is enforced ENTIRELY by the IRSA role's IAM (AWS-managed
+    # ReadOnlyAccess plus an explicit Deny on secret-material reads, authored in
+    # __main__.py). That matters because the operations account is the same AWS
+    # account in CI, QA and Production (no assumeRole separation anywhere in
+    # Pulumi.operations.*.yaml), so this role reads Production resources no matter
+    # which stack provisions it.
+    #
+    # The proxy's `--read-only` flag is deliberately NOT set, despite the name.
+    # It withholds every tool not annotated readOnlyHint=true, and the only tool
+    # that reaches AWS APIs at all — `aws___run_script`, which runs Python against
+    # the account — can never carry that annotation, since whether it writes
+    # depends on the code it is handed. Verified on the live CI backend: with the
+    # flag set the aggregate exposed six tools, all of them documentation/skills
+    # lookups, and nothing that could see an S3 bucket. On this server
+    # `--read-only` means "no account access", not "read-only account access", so
+    # it is mutually exclusive with the reason this backend exists.
+    #
+    # IAM is the better control anyway: AWS enforces it server-side on every API
+    # call, rather than by filtering a tool list the agent is offered. The write
+    # tools it re-admits are inert without permissions — `run_script` can call
+    # anything but only reads succeed, and `get_presigned_url` can only mint URLs
+    # for operations the role could already perform (ReadOnlyAccess grants no
+    # PutObject, and the Deny covers GetObject).
+    #
+    # Unlike every other backend here there is no token Secret: credentials come
+    # from IRSA via the boto3 default chain. Gated per-stack like sentry/context7:
+    #   pulumi config set toolhive_swe:aws_mcp_enabled true
+    if toolhive_swe_config.get_bool("aws_mcp_enabled"):
+        aws_mcpserver = kubernetes.apiextensions.CustomResource(
+            f"toolhive-swe-aws-mcpserver-{stack_info.env_suffix}",
+            api_version="toolhive.stacklok.dev/v1beta1",
+            kind="MCPServer",
+            metadata=kubernetes.meta.v1.ObjectMetaArgs(
+                name="aws",
+                namespace=namespace,
+                labels=k8s_global_labels,
+            ),
+            spec={
+                "image": (
+                    "public.ecr.aws/mcp-proxy-for-aws/mcp-proxy-for-aws:"
+                    f"{MCP_PROXY_FOR_AWS_VERSION}"
+                ),
+                # The proxy only speaks stdio; the ToolHive proxy wraps it and
+                # fronts it with streamable-http on proxyPort (no mcpPort for
+                # stdio), the same shape as the sentry and context7 backends.
+                "transport": "stdio",
+                "proxyPort": 8080,
+                "groupRef": {"name": MCP_GROUP_NAME},
+                # Appended to the image's `mcp-proxy-for-aws` ENTRYPOINT. The
+                # endpoint URL is POSITIONAL and must come first.
+                #
+                # `--metadata AWS_REGION` sets the default region for the AWS
+                # operations the managed server performs. Unset it defaults to
+                # us-east-1 anyway; stating it makes the default ours.
+                "args": [
+                    AWS_MCP_ENDPOINT,
+                    "--metadata",
+                    "AWS_REGION=us-east-1",
+                    "--disable-telemetry",
+                ],
+                # IRSA: this sets the SA on the MCP workload pod (the `mcp`
+                # container), which is where boto3 runs and signs SigV4.
+                "serviceAccount": AWS_MCP_SERVICE_ACCOUNT_NAME,
+                # Region for SigV4 signing and the STS call. The pod-identity
+                # webhook injects a region too, but setting it here makes the
+                # value ours rather than inherited.
+                "env": [{"name": "AWS_REGION", "value": "us-east-1"}],
+                # Needs outbound access to aws-mcp.us-east-1.api.aws AND to
+                # sts.us-east-1.amazonaws.com (AssumeRoleWithWebIdentity for
+                # IRSA). Tighten to an allow-list profile (.api.aws +
+                # .amazonaws.com, port 443) once the builtin profile proves out.
+                "permissionProfile": {
+                    "type": "builtin",
+                    "name": "network",
+                },
+                "resources": {
+                    "requests": {"cpu": "50m", "memory": "128Mi"},
+                    "limits": {"cpu": "200m", "memory": "256Mi"},
+                },
+            },
+            # The ServiceAccount stands in for the token Secret the other
+            # backends wait on: without it the operator reconciles this into a
+            # pod that has no way to obtain credentials.
+            opts=ResourceOptions(depends_on=[swe_mcpgroup, aws_mcp_service_account]),
+        )
+        servers.append(aws_mcpserver)
 
     return ToolhiveSWEMCPServers(
         group=swe_mcpgroup,

--- a/src/ol_infrastructure/applications/toolhive_swe/mcp_servers.py
+++ b/src/ol_infrastructure/applications/toolhive_swe/mcp_servers.py
@@ -69,7 +69,7 @@ def create_mcp_servers(  # noqa: PLR0913
     k8s_global_labels: dict[str, str],
     cluster_stack: StackReference,
     toolhive_swe_config: Config,
-    aws_mcp_service_account: kubernetes.core.v1.ServiceAccount,
+    aws_mcp_service_accounts: list[kubernetes.core.v1.ServiceAccount],
 ) -> ToolhiveSWEMCPServers:
     """Provision the MCPGroup and every backend MCPServer that joins it."""
     swe_mcpgroup = kubernetes.apiextensions.CustomResource(
@@ -453,8 +453,11 @@ def create_mcp_servers(  # noqa: PLR0913
             },
             # The ServiceAccount stands in for the token Secret the other
             # backends wait on: without it the operator reconciles this into a
-            # pod that has no way to obtain credentials.
-            opts=ResourceOptions(depends_on=[swe_mcpgroup, aws_mcp_service_account]),
+            # pod with no way to obtain credentials — and, since Kubernetes will
+            # not schedule a pod naming an absent ServiceAccount, into one that
+            # never starts at all. __main__.py creates it under the same gate as
+            # this block, so the list below is populated exactly when we get here.
+            opts=ResourceOptions(depends_on=[swe_mcpgroup, *aws_mcp_service_accounts]),
         )
         servers.append(aws_mcpserver)
 


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Adds an `aws` backend to the `toolhive-swe` vMCP so agents can inspect AWS state directly, instead of needing a human to relay CLI output every time a Grafana alert or Sentry error points at EKS/RDS/EC2.

**Which server.** AWS's managed [AWS MCP Server](https://docs.aws.amazon.com/agent-toolkit/latest/userguide/getting-started-aws-mcp-server.html) (`https://aws-mcp.us-east-1.api.aws/mcp`), reached through AWS's official [`mcp-proxy-for-aws`](https://github.com/aws/mcp-proxy-for-aws) SigV4 proxy — an official image, so nothing to build. Deliberately **not** the self-hostable [`awslabs.aws-api-mcp-server`](https://github.com/awslabs/mcp/blob/main/src/aws-api-mcp-server/MIGRATION.md), which AWS has marked "entering end of development" and whose tool descriptions now emit a deprecation notice to the agent on every call.

**Credentials via IRSA.** The proxy resolves credentials through the standard boto3 chain, so the existing `OLEKSAuthBinding` just grows a ServiceAccount (`toolhive-swe-aws-mcp`) annotated with the IRSA role ARN, and `spec.serviceAccount` puts the workload pod on it. Unlike every other backend in this stack, there is **no token in stack config**.

#### Why `--read-only` is not set, despite the name

The proxy has a `--read-only` flag. It is deliberately unused, and this is the one non-obvious thing in the PR.

That flag withholds every tool not annotated `readOnlyHint=true`. The only tool that reaches AWS APIs at all is `aws___run_script`, which executes Python against the account — whether it writes depends on the code it is handed, so it can never carry that annotation. With the flag set, the deployed backend exposed six tools, all documentation/skills lookups, and nothing that could see an S3 bucket. On this server `--read-only` means *no account access*, not *read-only account access*, so it is mutually exclusive with the reason the backend exists.

Read-only is therefore enforced entirely by IAM: AWS-managed `ReadOnlyAccess` plus an explicit Deny. That is the better boundary regardless — AWS enforces it server-side on every call rather than by filtering a tool list the agent is offered.

#### The Deny document was measured, not assumed

Because IAM is now the only control, the Deny list is load-bearing. Each candidate action was probed against the live CI role using a deliberately nonexistent resource, so a `403` meant IAM blocks the action and any other error meant IAM permits it. Nine actions came back permitted under `ReadOnlyAccess`:

| Action | Why it matters |
|---|---|
| `ssm:GetParameterHistory` | **Straight bypass** — returns the same values as `GetParameter`, which the original statement already denied |
| `lambda:GetFunctionConfiguration` | Plaintext environment variables |
| `ecs:DescribeTaskDefinition` | Container environment variables |
| `ec2:DescribeInstanceAttribute` | Cloud-init user-data, where this repo's Consul/Vault bootstrap config lives |
| `athena:GetQueryResults` | Reads the data lake through Athena's *own* service role, so denying `s3:GetObject` does not cover it |
| `dynamodb:Scan`, `logs:FilterLogEvents`, `sqs:ReceiveMessage`, `kinesis:GetShardIterator` | Bulk data / log / message bodies |

All nine are now denied, along with credential-minting reads (`ecr:GetAuthorizationToken`, `redshift:GetClusterCredentials`, `glue:GetConnection`, `apigateway:GET`) that are blocked today only because `ReadOnlyAccess` happens not to grant them.

Enabled in **Production only**, joining `sentry` and `context7`. CI was the proving ground and has been flipped back off now that the backend is verified; QA stays off. The IRSA role, ServiceAccount and policy attachments are provisioned unconditionally in every stack, so enabling an environment is a one-line change to `toolhive_swe:aws_mcp_enabled`.

### How can this be tested?

**Everything below was performed live against the CI stack**, which is where the backend was proven before being moved to Production only. The steps are reproducible against Production on deploy.

Current previews from `src/ol_infrastructure/applications/toolhive_swe`:

- `pulumi preview -s Production` — 5 creates (ServiceAccount, 2 `RolePolicyAttachment`, the `aws` MCPServer) plus an in-place `~assumeRolePolicy` update to `operations-production-toolhive-swe-trust-role`. **Not** a role replacement.
- `pulumi preview -s CI` — deletes the now-disabled `aws` MCPServer and updates the Deny policy in place. The IRSA role and ServiceAccount stay, inert, so re-enabling CI is a one-line flip.

Verification performed in CI:

1. Confirm IRSA reached the pod (absent these, SigV4 fails):
   ```
   kubectl -n toolhive-swe get pod -l toolhive-name=aws \
     -o jsonpath='{.items[0].spec.containers[?(@.name=="mcp")].env}' | jq
   ```
   Must show `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE`.
2. Reconnect an MCP client to the vMCP and confirm `aws_aws___*` tools appear, including `aws_aws___run_script`.
3. Confirm reads work — listing S3 buckets returned 322 buckets, 91 of them `ol-*`.
4. Confirm the boundary holds. Observed on the live role, each error naming the policy `toolhive-swe-policy-ci`:

   | Probe | Result |
   |---|---|
   | `secretsmanager:GetSecretValue` | `AccessDeniedException` — "explicit deny in an identity-based policy" |
   | `ssm:GetParameter` | `AccessDeniedException` — same explicit deny |
   | `ec2:CreateSecurityGroup` (DryRun) | `UnauthorizedOperation` — "no identity-based policy allows" |
   | `secretsmanager:ListSecrets`, `ssm:DescribeParameters`, `s3:ListObjectsV2` | allowed (metadata only) |

### Additional Context

Three things worth a reviewer's attention:

1. **`s3:GetObject` was not verified end-to-end.** The first probe used a nonexistent key and returned `NoSuchKey` rather than `AccessDenied` — S3 deliberately masks denials as 404 when the caller holds `ListBucket`, so that result proves nothing. The retry against a real key was blocked by a local permission guardrail and was not worked around. The action sits in the same Deny statement, on the same `Resource: "*"`, as two actions proven denied, and nothing overrides an explicit Deny — but that is inference, not a test.

2. **Some denies are blunter than ideal**, because IAM offers no condition key to scope them: `ec2:DescribeInstanceAttribute` is one action for every attribute, `apigateway:GET` one action for every read, and `ssm:GetParameter*` cannot distinguish `SecureString` from `String`. The lost describe-level detail is an accepted cost. Denying `logs:*` content is the largest capability loss; CloudWatch log content remains reachable through the `grafana` backend, which reads it under its own service account.

3. **This denylist is unbounded by construction.** Thirteen probes found nine gaps, and AWS ships new services continuously — this closes what was measured, not what lands next quarter. The durable fix is swapping the base grant from `ReadOnlyAccess` to `ViewOnlyAccess` (List/Describe only, no resource contents), which makes the whole class of gap structurally impossible and reduces the Deny document to a short backstop. Noted in a code comment rather than done here, since it is a larger change than this PR's scope. Happy to fold it in if reviewers prefer.

One caveat on blast radius: `Pulumi.operations.*.yaml` has no `assumeRole` separation, so CI/QA/Production share one AWS account. This role reads Production resources regardless of which stack provisions it — which is precisely why the IAM boundary above is scoped the way it is.
