### PR TITLE
Write the tier on archived repos, so `unmanaged` is true rather than assumed

### DIFF
--- a/src/ol_infrastructure/saas/github/repositories/repository.py
+++ b/src/ol_infrastructure/saas/github/repositories/repository.py
@@ -2,7 +2,12 @@
 
 One function, called once per repo in the fleet. Which resources it emits depends
 on whether the repo is archived: GitHub rejects most writes to an archived repo, so
-those get a `Repository` and nothing else (plan section 4.4).
+those get a `Repository` and their `tier` property, and nothing else (plan section
+4.4). The tier is not an exception to that rule so much as a case where the rule
+does not apply -- a property value is org metadata about a repo, not repo
+configuration, and GitHub accepts the write. Omitting it would not leave an archived
+repo untiered; it would leave it in the `standard` default, which org rulesets
+target. See `_tier_property`.
 
 WHAT IS DELIBERATELY NOT EMITTED HERE, and why it is not an oversight:
 

--- a/src/ol_infrastructure/saas/github/repositories/repository.py
+++ b/src/ol_infrastructure/saas/github/repositories/repository.py
@@ -96,6 +96,34 @@ _ARCHIVED_IGNORED_SETTINGS = [
 ]
 
 
+def _tier_property(
+    name: str, tier: str, repository: github.Repository
+) -> github.RepositoryCustomProperty:
+    """Set the repo's governance tier. Emitted for ARCHIVED repos too.
+
+    That exception is worth stating, because everywhere else in this file an archived
+    repo gets almost nothing: GitHub refuses most writes to one. Custom property values
+    are org metadata *about* a repo rather than repo configuration, and the write is
+    accepted -- `PATCH /repos/{repo}/properties/values` returns 204 on an archived repo
+    and leaves it archived (verified 2026-08-07 against PASSSL).
+
+    SKIPPING IT IS NOT NEUTRAL, which is why the archived path used to be wrong. `tier`
+    is `required` with a default of `standard`, so a repo with no value written does not
+    sit outside the scheme -- it sits in `standard`, and `baseline-default-branch`
+    targets `standard`. Leaving the 140 archived repos unwritten put every one of them
+    inside the ruleset that organization/org_rulesets.py says they are excluded from.
+    An unset property is a value, not an absence.
+    """
+    return github.RepositoryCustomProperty(
+        f"mitodl-repo-tier-{name}",
+        repository=name,
+        property_name=TIER_PROPERTY_NAME,
+        property_type="single_select",
+        property_values=[tier],
+        opts=ResourceOptions(depends_on=[repository]),
+    )
+
+
 def build(repo: dict[str, Any]) -> None:
     """Emit the resource family for one repo."""
     name = repo["name"]
@@ -104,9 +132,11 @@ def build(repo: dict[str, Any]) -> None:
     if archived:
         # Almost empty on purpose (section 4.4). Archived repos are imported so that
         # nothing stops someone re-adding one later with a full config and triggering
-        # a wave of failed writes -- but what is managed is the archived flag and the
-        # name, nothing more.
-        github.Repository(
+        # a wave of failed writes -- so what is managed is the archived flag, the name,
+        # and the tier. The tier is not an inconsistency: see _tier_property, and note
+        # that NOT writing it leaves the repo in the `standard` default, which is a
+        # targeted tier.
+        repository = github.Repository(
             f"mitodl-repo-{name}",
             name=name,
             archived=True,
@@ -116,6 +146,7 @@ def build(repo: dict[str, Any]) -> None:
                 ignore_changes=_ARCHIVED_IGNORED_SETTINGS,
             ),
         )
+        _tier_property(name, repo["tier"], repository)
         return
 
     # retain_on_delete is the counterweight for administration:write (section 2.2).
@@ -174,18 +205,7 @@ def build(repo: dict[str, Any]) -> None:
         opts=ResourceOptions(depends_on=[repository]),
     )
 
-    # The tier value. This is a CREATE, not an import -- no repo carries a custom
-    # property today. Until it lands, every repo inherits `standard` from the
-    # property default, which is why phase 3.5's rulesets must come after this
-    # (see organization/custom_properties.py).
-    github.RepositoryCustomProperty(
-        f"mitodl-repo-tier-{name}",
-        repository=name,
-        property_name=TIER_PROPERTY_NAME,
-        property_type="single_select",
-        property_values=[repo["tier"]],
-        opts=ResourceOptions(depends_on=[repository]),
-    )
+    _tier_property(name, repo["tier"], repository)
 
     for team_slug, permission in (repo.get("teams") or {}).items():
         github.TeamRepository(


### PR DESCRIPTION
### What are the relevant tickets?
N/A — follow-on from the phase 3.5 apply (https://github.com/mitodl/ol-infrastructure/pull/5300).

### Description (What does it do?)
`repository.py` returned early for archived repos before emitting `RepositoryCustomProperty`, so the `tier: unmanaged` those 140 repos declare was never written to GitHub.

**An unset custom property is a value, not an absence.** `tier` is `required` with `default_value: standard`, so a repo with nothing written does not sit outside the tier scheme — it sits in `standard`. And `baseline-default-branch` targets `TIER_ONE, TIER_STANDARD`. Every archived repo was therefore inside the ruleset that `organization/org_rulesets.py` states they are excluded from:

> `archived-freeze` Dropped 2026-08-05. […] Archived repos take `tier: unmanaged` instead, **which nothing targets** (§5.4).

Measured against live GitHub after the phase-3 apply:

```
population       LIVE tier    DECLARED     count   matched baseline-default-branch?
archived         standard     unmanaged      140   YES   <- the bug
fork             unmanaged    unmanaged      102   no
library          tier-1       tier-1          61   YES
application      tier-1       tier-1          10   YES
infrastructure   tier-1       tier-1           3   YES
```

214 of 316 repos matched, where 74 was intended. The forks were correct — only the archived population was wrong.

The archived path skipped this write for a real reason: GitHub refuses most writes to an archived repo, which is why `_ARCHIVED_IGNORED_SETTINGS` exists. Custom property values turn out to be the exception — they are org metadata *about* a repo rather than repo configuration. Verified before writing the code, against a real archived repo:

```
PASSSL: archived=True
tier BEFORE: standard
PATCH /repos/mitodl/PASSSL/properties/values -> 204
tier AFTER:  unmanaged
still archived: True
```

### How can this be tested?
`pulumi preview` on `ol-saas-github-repositories/default`:

```
Resources:
    + 140 to create
    1025 unchanged
```

140 creates, all `RepositoryCustomProperty`, exactly the archived population — no updates, replaces or deletes. (1025 = 849 imported + the 176 active-repo tiers from the phase-3 apply.)

After applying, `baseline-default-branch` should match 74 repos rather than 214. Confirm with:

```
GET /orgs/mitodl/properties/values   # every archived repo -> tier=unmanaged
```

Note `PASSSL` is already at `unmanaged` from the verification above, so its create is a no-op PATCH.

### Additional Context
**Nothing user-visible changes on GitHub.** Archived repos accept no pushes or pull requests, so the rulesets could never have fired on them and produced no rule-suite entries — and they land at `enforcement: evaluate` regardless. What this fixes is the committed data telling the truth about the estate, which is the premise the whole import rests on.

**Known gap this does not close:** `github-estate-audit drift` cannot see this class of divergence at all — `tier` is not in its `tracked` tuple, and the crawl does not record property values, so adding it would need `bin/github-org-inventory` to fetch them first. A 140-repo declared-vs-live divergence was invisible to the tool built to catch exactly that. Tracked separately rather than expanded into this PR.