### PR TITLE
feat(sentry): drive project display names from ol_types Services

### DIFF
--- a/bin/import-sentry-config
+++ b/bin/import-sentry-config
@@ -18,6 +18,7 @@ import cyclopts
 import httpx
 
 from bridge.secrets.sops import read_yaml_secrets
+from ol_infrastructure.lib.ol_types import Services
 
 app = cyclopts.App(help=__doc__)
 
@@ -44,6 +45,25 @@ RESOURCE_TOKENS = {
     ),
     "plugin": "sentry:index/sentryPlugin:SentryPlugin",
 }
+SENTRY_PROJECT_SERVICES: dict[str, Services] = {
+    "dagster": Services.dagster,
+    "learn-ai": Services.learn_ai,
+    "micromasters": Services.micromasters,
+    "mit-learn": Services.mit_learn,
+    "mitxonline": Services.mitxonline,
+    "ocw-site": Services.ocw_site,
+    "ocw-studio": Services.ocw_studio,
+    "odl-video-service": Services.odl_video_service,
+    "ol-analytics-api": Services.ol_analytics_api,
+    "open": Services.mit_open,
+    "openedx-mitxonline": Services.mitxonline_edx,
+    "openedx-mitxpro": Services.mitxpro_edx,
+    "openedx-residential": Services.mitx_edx,
+    "xpro": Services.xpro,
+}
+SENTRY_PROJECT_NAME_EXCEPTIONS = {
+    "release-script": "the release-script service is being phased out",
+}
 
 
 class PyExpr(str):
@@ -55,6 +75,23 @@ class PyExpr(str):
 
 
 ORGANIZATION_REF = PyExpr("ORGANIZATION")
+
+
+def sentry_project_name(slug: str, live_name: str | None) -> str:
+    """Return the ol_types expression for a Sentry project's display name."""
+    if service := SENTRY_PROJECT_SERVICES.get(slug):
+        return PyExpr(f"Services.{service.name}")
+    if slug in SENTRY_PROJECT_NAME_EXCEPTIONS:
+        if live_name is None:
+            msg = f"Sentry project {slug!r} is missing its live display name"
+            raise ValueError(msg)
+        return live_name
+    msg = (
+        f"Sentry project {slug!r} has no Services mapping or documented "
+        "name exception; update ol_types and SENTRY_PROJECT_SERVICES or discuss "
+        "an explicit exception"
+    )
+    raise ValueError(msg)
 
 
 class SentryApi:
@@ -354,6 +391,7 @@ import pulumiverse_sentry as sentry
 from pulumi import ResourceOptions
 
 from bridge.secrets.sops import read_yaml_secrets
+from ol_infrastructure.lib.ol_types import Services
 
 sentry_secrets = read_yaml_secrets(Path("sentry/account.yaml"))
 ORGANIZATION = sentry_secrets["organization"]
@@ -463,17 +501,24 @@ def build_program(inventory: dict[str, Any], organization: str) -> PulumiProgram
         )
 
     for project in sorted(inventory["projects"], key=lambda item: item["slug"]):
+        project_slug = str(project["slug"])
         teams = [team["slug"] for team in project.get("teams", [])]
+        project_name = sentry_project_name(project_slug, project.get("name"))
+        if exception_reason := SENTRY_PROJECT_NAME_EXCEPTIONS.get(project_slug):
+            program.warnings.append(
+                f"Sentry project {project_slug} keeps its literal display name because "
+                f"{exception_reason}."
+            )
         program.add_resource(
             "project",
             "SentryProject",
-            safe_name("project", project.get("slug")),
-            f"{organization}/{project['slug']}",
+            safe_name("project", project_slug),
+            f"{organization}/{project_slug}",
             compact(
                 {
                     "organization": ORGANIZATION_REF,
-                    "name": project.get("name"),
-                    "slug": project.get("slug"),
+                    "name": project_name,
+                    "slug": project_slug,
                     "platform": project.get("platform"),
                     "teams": teams or None,
                     "digests_min_delay": project.get("digestsMinDelay"),
@@ -726,6 +771,8 @@ def render_summary(
         lines.append("- None from generation.")
     lines.extend(
         [
+            "- Sentry project `name` values are generated as `Services.<member>` expressions from `ol_infrastructure.lib.ol_types`, which is the source of truth for service names (ol-infrastructure#4883). Live `slug` values are always preserved as-is, so a name that differs from its slug is expected.",
+            "- Generation fails when a live Sentry project has neither a `SENTRY_PROJECT_SERVICES` mapping nor a documented `SENTRY_PROJECT_NAME_EXCEPTIONS` entry, so a new project forces an explicit decision about its canonical service name instead of silently reintroducing a literal one.",
             "- Dashboard widget IDs and query IDs are computed-only in the provider and are omitted from generated code.",
             "- Issue alert action/filter/condition maps are ignored after import because Sentry's issue-alert API/provider refresh currently normalizes imported rule body lists in a way that would otherwise cause destructive drift. `actionMatch` is still managed and null live values are generated as `any`.",
             "",
@@ -741,6 +788,8 @@ def render_summary(
             "```",
             "",
             "The import file contains resource IDs only, not Sentry token values or DSNs.",
+            "",
+            "`--refresh` above is for the post-import drift check, where re-reading live state is the point. For an ordinary code-change review use plain `pulumi preview --diff`: `--refresh` re-reads every managed resource through pulumiverse-sentry and reliably trips Sentry's API rate limits (HTTP 429, 40 requests/second and 25 concurrent per endpoint), which fails the preview outright on repeat runs.",
         ]
     )
     return "\n".join(lines) + "\n"

--- a/src/ol_infrastructure/infrastructure/sentry/IMPORT_SUMMARY.md
+++ b/src/ol_infrastructure/infrastructure/sentry/IMPORT_SUMMARY.md
@@ -42,6 +42,9 @@ Organization: `mit-office-of-digital-learning`
 - Skipped issue alert openedx-residential/10002327352 (Critical - Notify Rootly, Warning - Notify Rootly): rule is driven exclusively by a Sentry-app integration action (NotifyEventSentryAppAction) with actionMatch=null. Sentry's classic Rules API accepts GET but rejects PUT with 404 for these rules, so pulumiverse-sentry 0.0.9 cannot manage them.
 - Skipped issue alert xpro/10002210772 (Notify OpsGenie via Opsgenie): rule is driven exclusively by a Sentry-app integration action (NotifyEventSentryAppAction) with actionMatch=null. Sentry's classic Rules API accepts GET but rejects PUT with 404 for these rules, so pulumiverse-sentry 0.0.9 cannot manage them.
 - Skipped metric alerts: pulumiverse-sentry 0.0.9 cannot refresh live Sentry metric alerts whose actions contain numeric targetIdentifier values (provider JSON unmarshal error).
+- Sentry project `name` values are generated as `Services.<member>` expressions from `ol_infrastructure.lib.ol_types`, which is the source of truth for service names (ol-infrastructure#4883). Live `slug` values are always preserved as-is, so a name that differs from its slug is expected.
+- Generation fails when a live Sentry project has neither a `SENTRY_PROJECT_SERVICES` mapping nor a documented `SENTRY_PROJECT_NAME_EXCEPTIONS` entry, so a new project forces an explicit decision about its canonical service name instead of silently reintroducing a literal one.
+- Sentry project release-script keeps its literal display name because the release-script service is being phased out.
 - Dashboard widget IDs and query IDs are computed-only in the provider and are omitted from generated code.
 - Issue alert action/filter/condition maps are ignored after import because Sentry's issue-alert API/provider refresh currently normalizes imported rule body lists in a way that would otherwise cause destructive drift. `actionMatch` is still managed and null live values are generated as `any`.
 
@@ -49,6 +52,13 @@ Re-running `bin/import-sentry-config generate` regenerates `__main__.py`,
 `sentry_imports.json`, and this file together from live Sentry
 configuration, then `pulumi import --file sentry_imports.json` followed by
 `pulumi preview --refresh --diff` applies any newly discovered resources.
+
+`--refresh` belongs to that post-import drift check, where re-reading live
+state is the point. For an ordinary code-change review use plain
+`pulumi preview --diff`: `--refresh` re-reads every managed resource through
+pulumiverse-sentry and reliably trips Sentry's API rate limits (HTTP 429,
+40 requests/second and 25 concurrent per endpoint), which fails the preview
+outright on repeat runs.
 
 ## Hand-authored exceptions
 
@@ -103,10 +113,10 @@ configuration, then `pulumi import --file sentry_imports.json` followed by
   `name`/`slug` were hand-changed from `ocw-next` to `ocw-site` (matching the
   `ocw_site` application) without renaming the Pulumi resource identifiers,
   so the update applies in place rather than replacing the resource. The
-  hand-added export is `ocw_site_sentry_dsn`. A future `bin/import-sentry-config`
-  run will regenerate `name`/`slug` back to whatever the live project is
-  named at that point -- expect it to match `ocw-site` unless it's renamed
-  again live.
+  hand-added export is `ocw_site_sentry_dsn`. The `name` is now generated from
+  `Services.ocw_site`, so a future `bin/import-sentry-config` run keeps it;
+  `slug` is still regenerated from whatever the live project carries at that
+  point -- expect it to match `ocw-site` unless it's renamed again live.
 - `project_open_next` / `key_open_next_default_*`: the live Sentry project's
   `name`/`slug` were hand-changed from `open-next` to `mit-learn` (without
   renaming the Pulumi resource identifiers, same in-place-update rationale as
@@ -117,7 +127,14 @@ configuration, then `pulumi import --file sentry_imports.json` followed by
   backend (`/api/v1/learning_resources/...`, `vector_search.tasks.*`, SCIM)
   and the `mit_learn_nextjs` frontend share this one project, the same way
   `project_dagster` covers all of Dagster's code locations rather than
-  splitting by app. The hand-added export is `mit_learn_sentry_dsn`. A future
-  `bin/import-sentry-config` run will regenerate `name`/`slug` back to
-  whatever the live project is named at that point -- expect it to match
+  splitting by app. The hand-added export is `mit_learn_sentry_dsn`. The `name`
+  is now generated from `Services.mit_learn`, so a future
+  `bin/import-sentry-config` run keeps it; `slug` is still regenerated from
+  whatever the live project carries at that point -- expect it to match
   `mit-learn` unless it's renamed again live.
+- `project_release_script`: the only live project whose display name is not
+  sourced from `Services`. It is kept as a literal via
+  `SENTRY_PROJECT_NAME_EXCEPTIONS` in `bin/import-sentry-config` because the
+  release-script service is being phased out, so it deliberately does not get
+  an `ol_types` member. Drop the exception entry along with the project when
+  that phase-out completes.

--- a/src/ol_infrastructure/infrastructure/sentry/__main__.py
+++ b/src/ol_infrastructure/infrastructure/sentry/__main__.py
@@ -16,6 +16,7 @@ import pulumiverse_sentry as sentry
 from pulumi import ResourceOptions
 
 from bridge.secrets.sops import read_yaml_secrets
+from ol_infrastructure.lib.ol_types import Services
 
 sentry_secrets = read_yaml_secrets(Path("sentry/account.yaml"))
 ORGANIZATION = sentry_secrets["organization"]
@@ -155,7 +156,7 @@ team_xpro = sentry.SentryTeam(
 project_learn_ai = sentry.SentryProject(
     "project_learn_ai",
     organization=ORGANIZATION,
-    name="learn-ai",
+    name=Services.learn_ai,
     slug="learn-ai",
     platform="python-django",
     teams=[
@@ -174,7 +175,7 @@ project_learn_ai = sentry.SentryProject(
 project_micromasters = sentry.SentryProject(
     "project_micromasters",
     organization=ORGANIZATION,
-    name="MicroMasters",
+    name=Services.micromasters,
     slug="micromasters",
     platform="javascript",
     teams=["micromasters", "mit-office-of-digital-learning", "arbisoft", "devops"],
@@ -187,7 +188,7 @@ project_micromasters = sentry.SentryProject(
 project_mitxonline = sentry.SentryProject(
     "project_mitxonline",
     organization=ORGANIZATION,
-    name="mitxonline",
+    name=Services.mitxonline,
     slug="mitxonline",
     platform="python",
     teams=["devops", "mitxonline", "arbisoft", "mit-office-of-digital-learning"],
@@ -200,7 +201,7 @@ project_mitxonline = sentry.SentryProject(
 project_ocw_next = sentry.SentryProject(
     "project_ocw_next",
     organization=ORGANIZATION,
-    name="ocw-site",
+    name=Services.ocw_site,
     slug="ocw-site",
     platform="python-django",
     teams=["mit-office-of-digital-learning", "applications", "ocw"],
@@ -213,7 +214,7 @@ project_ocw_next = sentry.SentryProject(
 project_ocw_studio = sentry.SentryProject(
     "project_ocw_studio",
     organization=ORGANIZATION,
-    name="ocw-studio",
+    name=Services.ocw_studio,
     slug="ocw-studio",
     platform="python",
     teams=["ocw"],
@@ -226,7 +227,7 @@ project_ocw_studio = sentry.SentryProject(
 project_odl_video_service = sentry.SentryProject(
     "project_odl_video_service",
     organization=ORGANIZATION,
-    name="ODL Video Service",
+    name=Services.odl_video_service,
     slug="odl-video-service",
     platform="python",
     teams=["devops", "mit-office-of-digital-learning"],
@@ -239,7 +240,7 @@ project_odl_video_service = sentry.SentryProject(
 project_open = sentry.SentryProject(
     "project_open",
     organization=ORGANIZATION,
-    name="Discussions",
+    name=Services.mit_open,
     slug="open",
     platform="python",
     teams=["devops", "mit-learn", "mit-office-of-digital-learning"],
@@ -252,7 +253,7 @@ project_open = sentry.SentryProject(
 project_open_next = sentry.SentryProject(
     "project_open_next",
     organization=ORGANIZATION,
-    name="mit-learn",
+    name=Services.mit_learn,
     slug="mit-learn",
     platform="python-django",
     teams=["mit-learn", "mit-office-of-digital-learning", "devops"],
@@ -265,7 +266,7 @@ project_open_next = sentry.SentryProject(
 project_openedx_mitxonline = sentry.SentryProject(
     "project_openedx_mitxonline",
     organization=ORGANIZATION,
-    name="openedx-mitxonline",
+    name=Services.mitxonline_edx,
     slug="openedx-mitxonline",
     platform="python-django",
     teams=["mitxonline", "devops"],
@@ -278,7 +279,7 @@ project_openedx_mitxonline = sentry.SentryProject(
 project_openedx_mitxpro = sentry.SentryProject(
     "project_openedx_mitxpro",
     organization=ORGANIZATION,
-    name="openedx-xpro",
+    name=Services.mitxpro_edx,
     slug="openedx-mitxpro",
     platform="python-django",
     teams=["devops", "xpro", "mit-office-of-digital-learning"],
@@ -291,7 +292,7 @@ project_openedx_mitxpro = sentry.SentryProject(
 project_openedx_residential = sentry.SentryProject(
     "project_openedx_residential",
     organization=ORGANIZATION,
-    name="openedx-residential",
+    name=Services.mitx_edx,
     slug="openedx-residential",
     platform="python-django",
     teams=["applications", "residential-mitx", "devops"],
@@ -317,7 +318,7 @@ project_release_script = sentry.SentryProject(
 project_xpro = sentry.SentryProject(
     "project_xpro",
     organization=ORGANIZATION,
-    name="xpro",
+    name=Services.xpro,
     slug="xpro",
     platform="python",
     teams=["arbisoft", "devops", "mit-office-of-digital-learning", "xpro"],
@@ -3569,7 +3570,7 @@ issue_alert_xpro_xpro_slack_notifications_15045794 = sentry.SentryIssueAlert(
 project_ol_analytics_api = sentry.SentryProject(
     "project_ol_analytics_api",
     organization=ORGANIZATION,
-    name="ol-analytics-api",
+    name=Services.ol_analytics_api,
     slug="ol-analytics-api",
     platform="python-fastapi",
     # Same team set as project_learn_ai -- the closest analog: also a small
@@ -3606,7 +3607,7 @@ pulumi.export("ol_analytics_api_sentry_dsn", key_ol_analytics_api.dsn_public)
 project_dagster = sentry.SentryProject(
     "project_dagster",
     organization=ORGANIZATION,
-    name="dagster",
+    name=Services.dagster,
     slug="dagster",
     platform="python",
     # The data/BI team owns the pipelines; devops and MIT ODL get the same

--- a/src/ol_infrastructure/lib/ol_types.py
+++ b/src/ol_infrastructure/lib/ol_types.py
@@ -77,7 +77,7 @@ class Services(StrEnum):
     ol_analytics_api = "ol-analytics-api"
     opik = "opik"
     open_edx = "open-edx"
-    learn_ai = ("learn-ai",)
+    learn_ai = "learn-ai"
     mit_learn = "mit-learn"
     mit_open = "open"
     mitx_edx = "mitx-edx"
@@ -85,6 +85,7 @@ class Services(StrEnum):
     mitxonline_edx = "mitxonline-edx"
     mitxpro_edx = "xpro-edx"
     ocw_build = "ocw-build"
+    ocw_site = "ocw-site"
     ocw_studio = "ocw-studio"
     odl_video_service = "ovs"
     open_metadata = "open-metadata"

--- a/tests/test_import_sentry_config.py
+++ b/tests/test_import_sentry_config.py
@@ -1,0 +1,82 @@
+"""Tests for the Sentry configuration importer."""
+
+from pathlib import Path
+from runpy import run_path
+from typing import Any
+
+import pytest
+
+IMPORTER = run_path(
+    str(Path(__file__).resolve().parents[1].joinpath("bin/import-sentry-config"))
+)
+build_program = IMPORTER["build_program"]
+
+
+def inventory_with_project(project: dict[str, Any]) -> dict[str, Any]:
+    """Return the smallest inventory accepted by build_program."""
+    return {
+        "organization": {"name": "Test Organization", "slug": "test-org"},
+        "teams": [],
+        "projects": [project],
+        "members": [],
+        "repositories": [],
+        "code_mappings": [],
+        "dashboards": [],
+        "keys": [],
+        "issue_alerts": [],
+        "metric_alerts": [],
+        "plugins": [],
+    }
+
+
+def test_mapped_project_name_renders_as_services_expression() -> None:
+    """Mapped names use ol_types while the live Sentry slug stays unchanged."""
+    program = build_program(
+        inventory_with_project(
+            {
+                "name": "ODL Video Service",
+                "slug": "odl-video-service",
+                "platform": "python",
+            }
+        ),
+        "test-org",
+    )
+
+    project_block = program.blocks[1]
+    assert "name=Services.odl_video_service," in project_block
+    assert "slug='odl-video-service'," in project_block
+    assert "name='ODL Video Service'," not in project_block
+
+
+def test_release_script_keeps_literal_name_as_phase_out_exception() -> None:
+    """The retiring release-script project does not require a Services member."""
+    program = build_program(
+        inventory_with_project(
+            {
+                "name": "release-script",
+                "slug": "release-script",
+                "platform": "python",
+            }
+        ),
+        "test-org",
+    )
+
+    project_block = program.blocks[1]
+    assert "name='release-script'," in project_block
+    assert "slug='release-script'," in project_block
+    assert any("being phased out" in warning for warning in program.warnings)
+
+
+def test_unknown_project_fails_generation() -> None:
+    """New Sentry projects require an explicit ontology decision."""
+    with pytest.raises(ValueError, match="no Services mapping or documented"):
+        build_program(
+            inventory_with_project(
+                {
+                    "name": "Unmapped Service",
+                    "slug": "unmapped-service",
+                    "platform": "python",
+                }
+            ),
+            "test-org",
+        )


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/ol-infrastructure/issues/4883

### Description (What does it do?)
Sentry project display names were literal strings that `bin/import-sentry-config` copied out of live Sentry, so they had drifted from the service names used everywhere else in this repo. This makes `Services` in [`src/ol_infrastructure/lib/ol_types.py`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/lib/ol_types.py) the single source of truth for them.

Six display names change:

| Sentry slug (unchanged) | Old name | New name |
|---|---|---|
| `micromasters` | `MicroMasters` | `micromasters` |
| `odl-video-service` | `ODL Video Service` | `ovs` |
| `open` | `Discussions` | `open` |
| `openedx-mitxonline` | `openedx-mitxonline` | `mitxonline-edx` |
| `openedx-mitxpro` | `openedx-xpro` | `xpro-edx` |
| `openedx-residential` | `openedx-residential` | `mitx-edx` |

The other nine projects (`dagster`, `learn-ai`, `mit-learn`, `mitxonline`, `ocw-site`, `ocw-studio`, `ol-analytics-api`, `xpro`, and the `release-script` exception) already matched their canonical names, so they now read from `Services` without a visible rename.

**Slugs are deliberately untouched.** Renaming them would break the `*_sentry_dsn` consumers, the Sentry-app issue alerts that pulumiverse-sentry cannot manage, and the Rootly alert route that matches on the `openedx-residential` project name. Every Sentry project URL stays put, which does mean a display name can differ from its slug — that is expected and documented.

Two supporting changes:

- **`Services.ocw_site`** is added. It was the only active Sentry project with no canonical service name. `release-script` deliberately does *not* get one, since that service is being phased out; it stays a literal via a documented exception.
- **The generator now fails closed.** `bin/import-sentry-config` maps each live Sentry slug to a `Services` member and raises on a project it has never seen. A newly created Sentry project now forces an explicit decision about its canonical name instead of silently reintroducing a literal one.

### How can this be tested?

`pulumi preview` on the `ol-infrastructure-sentry` `default` stack shows exactly the six display-name updates and nothing else:

```
Resources:
    ~ 6 to update
    339 unchanged
```

with each step being a lone `name` property change, e.g.

```
~ sentry:index/sentryProject:SentryProject: (update)
    [id=openedx-residential]
  ~ name: "openedx-residential" => "mitx-edx"
```

No replacements, creates, deletes, slug changes, or key/DSN changes.

Repo validation:

```bash
uv run pytest tests/                       # 458 passed
uv run mypy src/ol_infrastructure/lib/ol_types.py \
            src/ol_infrastructure/infrastructure/sentry/__main__.py   # clean
uv run ruff format --check <changed files> # clean
uv run pre-commit run --all-files          # all Python hooks pass
```

`pre-commit` also reports two failures that are pre-existing on `main` and touch no file in this PR: `packer_fmt` (the `packer` binary is not installed locally) and `hadolint` warnings on `dockerfiles/`.

Three new tests in `tests/test_import_sentry_config.py` cover the generator contract: a mapped project renders `name=Services.<member>` while keeping its literal slug, `release-script` keeps its literal name and emits a phase-out warning, and an unmapped project raises.

### Additional Context

- **Deploy step:** the renames only reach live Sentry on `pulumi up` against the `ol-infrastructure-sentry` `default` stack. Nothing else in this PR needs deploying, and nothing depends on it landing first.
- **`Services.odl_video_service` is `ovs`**, not `odl-video-service`. Using the enum literally is intentional here — changing the enum value itself would ripple into Kubernetes labels, Vault role names, and application resource naming, which is well outside this issue. The tradeoff is a terse Sentry display name.
- **The Open edX names** (`mitxonline-edx`, `xpro-edx`, `mitx-edx`) come from the existing service ontology rather than from the legacy `openedx-*` Sentry slugs, which is why those three names diverge most visibly from their slugs.
- **One drive-by fix:** `Services.learn_ai` had a stray trailing comma making it the 1-tuple `("learn-ai",)`. `StrEnum` unpacked that as constructor args to the identical string, so **the value is unchanged** and this is cosmetic — it is included because the tuple form would have broken the `Services.<member>` mapping work here if anyone had relied on it.
- **Preview guidance:** `IMPORT_SUMMARY.md` previously recommended `pulumi preview --refresh --diff` unconditionally. `--refresh` re-reads all 345 managed resources through pulumiverse-sentry and reliably trips Sentry's rate limits (HTTP 429; 40 req/s and 25 concurrent per endpoint), failing the preview outright on repeat runs. It is now scoped to the post-import drift check, with plain `pulumi preview --diff` documented as the default for code review.