### PR TITLE
Make `tier` divergence visible: the field the org rulesets depend on

### DIFF
--- a/bin/github-estate-audit
+++ b/bin/github-estate-audit
@@ -62,7 +62,6 @@ def run(
         findings = [f for f in findings if f.axis == axis]
 
     by_rule = Counter(f.rule_id for f in findings)
-    rules = {r.rule_id: r for r in audit.RULES}
 
     if as_json:
         print(
@@ -80,16 +79,24 @@ def run(
         print(
             f"# mitodl estate audit -- {len(fleet)} repos, {len(findings)} findings\n"
         )
+        # EVERY rule is listed, including the ones at zero, and `--axis` filters which
+        # rules are listed rather than only which findings are counted. A rule that
+        # fires nowhere would otherwise be indistinguishable from a rule that is not
+        # registered, or one whose input the crawl never recorded -- the same
+        # "empty and unmeasured look identical" failure audit.py exists to avoid, just
+        # moved to the reporter. CON-11 read as clean from the day it was written; the
+        # only thing separating that from a broken rule is seeing it on the report.
+        listed = [r for r in audit.RULES if axis is None or r.axis == axis]
         ordered = sorted(
-            by_rule,
-            key=lambda rid: (SEVERITY_ORDER[rules[rid].severity], -by_rule[rid]),
+            listed,
+            key=lambda r: (SEVERITY_ORDER[r.severity], -by_rule[r.rule_id]),
         )
-        for rule_id in ordered:
-            rule = rules[rule_id]
+        for rule in ordered:
+            count = by_rule[rule.rule_id]
             total = audit.population(fleet, rule.scope)
-            share = f"{by_rule[rule_id] / total:.0%}" if total else "-"
+            share = f"{count / total:.0%}" if total else "-"
             print(
-                f"  {rule.severity:6} {rule_id:8} {by_rule[rule_id]:4} "
+                f"  {rule.severity:6} {rule.rule_id:8} {count:4} "
                 f"({share:>4} of {total} {rule.scope})  {rule.summary}"
             )
         print("\nWorst offenders, by number of findings:")
@@ -161,8 +168,29 @@ def drift(
         for field in tracked:
             want = declared[name].get(field)
             got = live[name].get(field)
+            # `want is None` means the fleet declares nothing for this field, so there
+            # is nothing to have drifted from -- that is a real exemption for the
+            # tracked fields above, all of which archetypes may legitimately stay
+            # silent on. It is NOT true of `tier`, which is compared separately below
+            # precisely so it cannot inherit this skip.
             if want is not None and want != got:
                 changed.append(f"{name}.{field}: declared {want!r}, live {got!r}")
+        # `tier` is not in `tracked` because it does not live at the top level of the
+        # crawl: GitHub reports it among the repo's custom-property values. It gets its
+        # own comparison rather than a flattening step so that BOTH sides are asserted
+        # present -- an unset custom property reads back as the schema's default value,
+        # never as an absence, so `got is None` means the crawl failed to measure it
+        # rather than that the repo has no tier. Reporting that as "no drift" is how a
+        # 140-repo divergence went unseen (PR #5317); reporting it as drift is noisy
+        # exactly once, when the cache predates this field.
+        want_tier = declared[name].get("tier")
+        got_tier = (live[name].get("custom_properties") or {}).get("tier")
+        if want_tier != got_tier:
+            changed.append(
+                f"{name}.tier: declared {want_tier!r}, "
+                f"live {got_tier!r}"
+                f"{' (not in the crawl)' if got_tier is None else ''}"
+            )
 
     for name in only_live:
         print(f"  UNMANAGED   {name} exists on GitHub but has no fleet entry")

--- a/bin/github-org-inventory
+++ b/bin/github-org-inventory
@@ -46,6 +46,7 @@ from ol_infrastructure.lib.github_helper import (
     GITHUB_API,
     get_installation_token,
 )
+from ol_infrastructure.saas.github.tiers import TIER_PROPERTY_NAME
 
 app = cyclopts.App(help="Inventory the mitodl GitHub org for the Pulumi import.")
 
@@ -284,7 +285,6 @@ def _crawl_repo(token: str, listed: dict[str, Any]) -> dict[str, Any]:
                 "Pagination is now required -- see the note above."
             )
             raise RuntimeError(message)
-        properties = _maybe(client, f"/repos/{ORG}/{name}/properties/values") or []
         teams = _maybe(client, f"/repos/{ORG}/{name}/teams?per_page=100") or []
         # IDs, not just counts: `imports` needs them to build the Pulumi import payload.
         hooks = _maybe(client, f"/repos/{ORG}/{name}/hooks?per_page=100") or []
@@ -394,9 +394,9 @@ def _crawl_repo(token: str, listed: dict[str, Any]) -> dict[str, Any]:
             "direct_collaborators": {
                 u["login"]: u.get("role_name") for u in direct_collaborators
             },
-            "custom_properties": {
-                p["property_name"]: p["value"] for p in properties if p.get("value")
-            },
+            # `custom_properties` is NOT built here -- see _crawl_org. One org-wide call
+            # covers all 316 repos, so asking per repo bought 315 extra requests and a
+            # second code path for the same fact.
             "teams": {t["slug"]: t["permission"] for t in teams},
         }
 
@@ -420,6 +420,26 @@ def _crawl_org(cache: Path, *, refresh: bool) -> dict[str, Any]:
         teams = _paginate(client, f"/orgs/{ORG}/teams")
         members = _paginate(client, f"/orgs/{ORG}/members")
         property_schema = _maybe(client, f"/orgs/{ORG}/properties/schema") or []
+        # Every repo's custom-property values in ~4 pages. `tier` is what the phase-3.5
+        # org rulesets target, so this is the single most consequential field in the
+        # crawl: a repo whose live tier is not its declared tier is matched by a
+        # different set of rulesets than the code says it is.
+        #
+        # AN UNSET PROPERTY IS A VALUE, NOT AN ABSENCE. `tier` is `required` with
+        # `default_value: standard`, so a repo nobody has written to reads back as
+        # `standard` -- and `standard` is targeted by `baseline-default-branch`. That
+        # is not a hypothetical: after the phase-3 apply all 140 archived repos were
+        # live at `standard` while the fleet declared `unmanaged`, and the ruleset
+        # matched 214 repos where 74 was intended (PR #5317). Values are therefore
+        # recorded VERBATIM, including falsy ones -- an earlier `if p.get("value")`
+        # filter here made "set to empty" and "never measured" identical, which is the
+        # exact shape of the bug that hid the divergence.
+        property_values = {
+            entry["repository_name"]: {
+                p["property_name"]: p["value"] for p in entry["properties"]
+            }
+            for entry in _paginate(client, f"/orgs/{ORG}/properties/values")
+        }
         org_rulesets = _maybe(client, f"/orgs/{ORG}/rulesets") or []
         org_hooks = _maybe(client, f"/orgs/{ORG}/hooks?per_page=100") or []
         # TeamMembership imports as <team-id>:<username>, so the roster has to be per team.
@@ -436,6 +456,21 @@ def _crawl_org(cache: Path, *, refresh: bool) -> dict[str, Any]:
     )
     with ThreadPoolExecutor(max_workers=CRAWL_THREADS) as pool:
         crawled = list(pool.map(lambda r: _crawl_repo(token, r), repos))
+
+    # A repo missing from the org-wide property response gets `{}`, and `{}` must not be
+    # read as "no properties set" -- with a required, defaulted `tier` that cannot happen,
+    # so it means the response did not cover the fleet. Trip rather than emit repo files
+    # whose tier the audit will then report as drifted for a reason that is not drift.
+    if uncovered := sorted({r["name"] for r in crawled} - set(property_values)):
+        message = (
+            f"{len(uncovered)} repo(s) absent from /orgs/{ORG}/properties/values: "
+            f"{uncovered[:10]}{' ...' if len(uncovered) > 10 else ''}\n"
+            "`tier` is required with a default, so every repo must appear. Suspect "
+            "pagination or a permissions change before believing the data."
+        )
+        raise SystemExit(message)
+    for repo in crawled:
+        repo["custom_properties"] = property_values[repo["name"]]
 
     data = {
         "crawled_at": datetime.now(UTC).isoformat(),
@@ -901,8 +936,6 @@ def crawl(
             doc["homepage"] = repo["homepage"]
         if repo["topics"]:
             doc["topics"] = repo["topics"]
-        if repo["custom_properties"]:
-            doc["custom_properties"] = repo["custom_properties"]
         # The one genuinely per-repo rule (§5.4) -- check names differ per repo.
         if repo["required_status_checks"]:
             doc["required_status_checks"] = repo["required_status_checks"]
@@ -929,6 +962,13 @@ def crawl(
             doc["_excluded_environments"] = repo["environment_count"]
         if repo["actions_secrets"]:
             doc["_actions_secret_names"] = [s["name"] for s in repo["actions_secrets"]]
+        # OBSERVED property values, under `_` because they are inventory: the DECLARED
+        # tier is `tier`, resolved from the archetype, and it is what Pulumi writes.
+        # Recording the live value beside it is what lets CON-11 compare the two without
+        # an API call. Emitted unconditionally -- an empty dict here is a real finding
+        # (the property exists org-wide with a default, so nothing should read back
+        # empty), and omitting the key on empty would hide it.
+        doc["_custom_properties"] = repo["custom_properties"]
         doc["_visibility"] = repo["visibility"]
         doc["_pushed_at"] = repo["pushed_at"]
         doc["_has_branch_protection"] = repo["has_branch_protection"]
@@ -1082,13 +1122,19 @@ def imports(
             f"mitodl-repo-vulnerability-alerts-{name}",
             name,
         )
-        for property_name in repo["custom_properties"]:
+        # `tier` only, not every property in the crawl. The resource name has to match
+        # what repository.py declares (`mitodl-repo-tier-<repo>`), and that function
+        # emits exactly one RepositoryCustomProperty per repo. Importing a second
+        # property under the tier's name would bind live state to the wrong resource.
+        # A new org property therefore needs a code change here AND in repository.py --
+        # which is the right amount of friction for something rulesets target.
+        if repo["custom_properties"].get(TIER_PROPERTY_NAME) is not None:
             # Three parts, and the ORG name is part of the id.
             add(
                 repo_resources,
                 "repositoryCustomProperty:RepositoryCustomProperty",
                 f"mitodl-repo-tier-{name}",
-                f"{ORG}:{name}:{property_name}",
+                f"{ORG}:{name}:{TIER_PROPERTY_NAME}",
             )
         for team_slug in repo["teams"]:
             add(

--- a/docs/plans/github-org-pulumi-import.md
+++ b/docs/plans/github-org-pulumi-import.md
@@ -961,6 +961,26 @@ Re-crawls live GitHub and diffs against declared YAML. This is what keeps the es
 after the import: any out-of-band console change surfaces as a diff. Run it nightly in Concourse
 and route findings to the project's witan task list.
 
+**`tier` is compared separately from the rest, on purpose.** The generic loop skips a field
+the fleet declares nothing for — legitimate for every other tracked field, since archetypes
+may stay silent — but `tier` decides which org rulesets match a repo (§5.4), so it is the one
+field where "declared nothing" is itself the finding. It also does not live at the top level
+of the crawl: GitHub reports it among the repo's custom-property values, from one org-wide
+`GET /orgs/{org}/properties/values`.
+
+The failure this guards against is not hypothetical. After the phase-3 apply, all 140 archived
+repos were live at `tier=standard` while the fleet declared `unmanaged` — because `tier` is
+`required` with `default_value: standard`, so the repos nobody had written to had not fallen
+*outside* the scheme, they had fallen *into* the targeted tier. `baseline-default-branch`
+matched 214 repos where 74 was intended (PR #5317). Nothing surfaced it; it was found by
+hand-querying the API. An unset custom property is a **value, not an absence**, and any
+comparison written as `if want and want != got` passes it silently.
+
+The same divergence is now also visible without credentials: `crawl` records the observed
+values as `_custom_properties` in each repo's YAML, and audit rule **CON-11** compares them
+against the declared tier in `run`. `run` lists every rule including those at zero, so CON-11
+reading clean is distinguishable from CON-11 not running.
+
 ---
 
 ## 8. Phasing

--- a/src/ol_infrastructure/saas/github/audit.py
+++ b/src/ol_infrastructure/saas/github/audit.py
@@ -23,6 +23,8 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Literal
 
+from ol_infrastructure.saas.github.tiers import TIER_PROPERTY_NAME
+
 Axis = Literal["security", "consistency", "developer-experience"]
 Scope = Literal["active", "archived", "fleet"]
 Severity = Literal["high", "medium", "low"]
@@ -78,6 +80,17 @@ def _is_stale(repo: dict[str, Any]) -> bool:
         return False
     age = datetime.now(UTC) - datetime.fromisoformat(pushed.replace("Z", "+00:00"))
     return age.days > STALE_DAYS
+
+
+def _live_tier(repo: dict[str, Any]) -> str | None:
+    """Return the `tier` GitHub actually reports for this repo, per the last crawl.
+
+    `None` means the crawl recorded no value -- either the repo YAML predates
+    `_custom_properties` or the property genuinely came back empty. Both are findings,
+    and CON-11 reports them as such rather than passing. `tier` is `required` with a
+    default, so there is no live state in which the correct answer is "no value".
+    """
+    return (repo.get("_custom_properties") or {}).get(TIER_PROPERTY_NAME)
 
 
 def _unsanctioned_admin(repo: dict[str, Any]) -> list[str]:
@@ -167,6 +180,32 @@ RULES: tuple[Rule, ...] = (
                 "downgrade to push or maintain",
             )
             if _unsanctioned_admin(r)
+            else None
+        ),
+    ),
+    Rule(
+        "CON-11",
+        "consistency",
+        "high",
+        "fleet",
+        "live `tier` does not match the declared tier",
+        # The one field where declared-vs-live divergence changes which org rulesets
+        # apply, so it is graded `high` despite being a consistency rule -- a repo at
+        # the wrong tier is protected by a different baseline than the code claims.
+        #
+        # WRITTEN AS A THREE-WAY COMPARISON ON PURPOSE. The tempting form,
+        # `if declared and declared != live`, passes silently whenever either side is
+        # missing, and a missing live value is precisely how the 140-repo archived-repo
+        # divergence stayed invisible: those repos were not untiered, they had fallen
+        # into the property's `standard` default. Absence on either side is reported.
+        lambda r: (
+            (
+                f"live {_live_tier(r) or 'unrecorded'}",
+                f"declared {r.get('tier') or 'nothing'}",
+                "re-run `github-org-inventory crawl --refresh`; if the live value is "
+                "real, `pulumi up` the repositories stack to rewrite it",
+            )
+            if _live_tier(r) != r.get("tier")
             else None
         ),
     ),

--- a/src/ol_infrastructure/saas/github/repositories/data/README.md
+++ b/src/ol_infrastructure/saas/github/repositories/data/README.md
@@ -20,6 +20,17 @@ uv run bin/github-org-inventory crawl --refresh
     imported (§4.3). 7,803 exist org-wide; importing them guarantees a churning diff.
   - `_actions_secret_names` — secret **names** only. Values are write-only and are never
     imported (§4.1).
+  - `_custom_properties` — the property values GitHub **actually reports** for the repo,
+    as of the last crawl. Read this beside the top-level `tier`, which is the value the
+    archetype **declares** and Pulumi writes; `CON-11` compares the two, which is how the
+    audit detects a tier divergence without an API call.
+
+    An unset custom property is a **value, not an absence**. `tier` is `required` with
+    `default_value: standard`, so a repo nobody has written to reads back as `standard` —
+    and `standard` is a tier the `baseline-default-branch` org ruleset targets. After the
+    phase-3 apply all 140 archived repos sat at live `standard` while declaring
+    `unmanaged`, and the ruleset matched 214 repos where 74 was intended (PR #5317).
+    Nothing reported it, because nothing recorded it. Hence this key.
 - These files record what each repo **is today**, deviations and all, including where
   today's value is wrong. That is deliberate: §6's empty-diff gate requires the model to
   match reality before phase 5 changes anything. A wrong-but-explicit value is an

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/.github.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/.github.yaml
@@ -1,8 +1,10 @@
 ---
 _actions_secret_names:
 - GH_PROJECT_AUTOMATION_TOKEN
+_custom_properties:
+  tier: tier-1
 _has_branch_protection: true
-_pushed_at: '2026-08-05T19:47:31Z'
+_pushed_at: '2026-08-07T15:09:00Z'
 _ruleset_count: 0
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/PASSSL.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/PASSSL.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-12-01T11:35:19Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/PyLmod.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/PyLmod.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2022-01-19T00:07:46Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/XBlock.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/XBlock.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2018-03-28T21:13:49Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/access-forge.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/access-forge.yaml
@@ -22,8 +22,10 @@ _actions_secret_names:
 - QA_KEYCLOAK_OL_ENG_REALM
 - QA_KEYCLOAK_REALM
 - QA_KEYCLOAK_SERVER_URL
+_custom_properties:
+  tier: tier-1
 _has_branch_protection: false
-_pushed_at: '2026-08-06T12:40:38Z'
+_pushed_at: '2026-08-07T05:00:32Z'
 _ruleset_count: 0
 _visibility: private
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/agent-kit.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/agent-kit.yaml
@@ -1,7 +1,9 @@
 ---
+_custom_properties:
+  tier: tier-1
 _excluded_environments: 2
 _has_branch_protection: false
-_pushed_at: '2026-08-06T15:46:24Z'
+_pushed_at: '2026-08-07T20:31:27Z'
 _ruleset_count: 1
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/alerting-omnibus.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/alerting-omnibus.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2026-06-30T18:10:28Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ansible-salt-bootstrap.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ansible-salt-bootstrap.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2016-03-23T19:50:00Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/apisix-testbed.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/apisix-testbed.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _direct_collaborators:
   jkachel: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/apisix.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/apisix.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2026-08-04T20:50:18Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/bookkeeper-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/bookkeeper-formula.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2020-06-19T18:20:23Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/bootcamp-ecommerce.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/bootcamp-ecommerce.yaml
@@ -2,6 +2,8 @@
 _actions_secret_names:
 - HEROKU_API_KEY
 - HEROKU_EMAIL
+_custom_properties:
+  tier: unmanaged
 _excluded_environments: 683
 _has_branch_protection: true
 _pushed_at: '2026-03-02T11:50:32Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/bootcamps-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/bootcamps-zendesk-theme.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2024-05-06T19:07:35Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/bootcamps.json.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/bootcamps.json.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-12-01T11:26:27Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/brand-mitol-residential.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/brand-mitol-residential.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   arslanashraf7: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/caddy-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/caddy-formula.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-12-01T08:55:05Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ccx-idde-overrides-slides.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ccx-idde-overrides-slides.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-10-20T13:38:07Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ccxcon.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ccxcon.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _excluded_environments: 46
 _has_branch_protection: true
 _pushed_at: '2016-03-16T15:42:13Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ckeditor-custom-build.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ckeditor-custom-build.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2022-12-10T13:28:56Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ckeditor5-media-embed.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ckeditor5-media-embed.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2019-01-23T09:27:12Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ckeditor5.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ckeditor5.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2022-12-14T18:31:57Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/codejail.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/codejail.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2021-03-18T17:00:41Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/common-access.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/common-access.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _direct_collaborators:
   jkachel: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/community-integrations.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/community-integrations.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2026-05-26T17:50:58Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-dcind.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-dcind.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   Ardiea: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-github-issue-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-github-issue-resource.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2026-04-07T10:58:16Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-npm-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-npm-resource.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2024-04-08T21:11:04Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-packer-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-packer-resource.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _excluded_environments: 1
 _has_branch_protection: false
 _pushed_at: '2026-04-14T13:39:00Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-pulumi-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-pulumi-resource.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _excluded_environments: 1
 _has_branch_protection: false
 _pushed_at: '2026-04-14T13:24:26Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-pypi-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-pypi-resource.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2025-07-15T19:08:35Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-rclone-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-rclone-resource.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-10-21T05:51:21Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-s3-sync-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-s3-sync-resource.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-10-21T08:18:52Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-vault-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-vault-resource.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2026-04-09T03:28:10Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-workflow.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-workflow.yaml
@@ -1,6 +1,8 @@
 ---
 _actions_secret_names:
 - PRIVATE_KEY
+_custom_properties:
+  tier: tier-1
 _direct_collaborators:
   Ardiea: admin
   odlbot: admin

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2026-07-31T13:33:16Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concoursepy.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concoursepy.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   mbertrand: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/configuration.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/configuration.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2024-04-10T16:48:36Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/consul-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/consul-formula.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2024-06-05T23:45:15Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/cookiecutter-djangoapp.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/cookiecutter-djangoapp.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2025-03-20T04:15:34Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/cookiecutter-pylib.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/cookiecutter-pylib.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   rhysyngsun: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/copier-djangoapp.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/copier-djangoapp.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   rhysyngsun: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/course-catalog.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/course-catalog.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   mbertrand: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/course-search-utils.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/course-search-utils.yaml
@@ -1,7 +1,9 @@
 ---
+_custom_properties:
+  tier: tier-1
 _excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-08-06T12:49:23Z'
+_pushed_at: '2026-08-06T22:42:01Z'
 _ruleset_count: 0
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/cs_comments_service.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/cs_comments_service.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-04-21T16:56:43Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/custom-courses-on-edx-slides.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/custom-courses-on-edx-slides.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-10-20T13:38:06Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/dagster-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/dagster-formula.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2021-02-04T20:11:02Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/dagster.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/dagster.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2025-06-20T15:55:25Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/datadog-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/datadog-formula.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2021-06-29T19:32:22Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/default-labels-repo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/default-labels-repo.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2023-03-21T17:37:54Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/demo-test-course.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/demo-test-course.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   pdpinch: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/discern.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/discern.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2014-04-03T12:59:30Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-aqueduct.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-aqueduct.yaml
@@ -1,7 +1,9 @@
 ---
+_custom_properties:
+  tier: tier-1
 _excluded_environments: 2
 _has_branch_protection: false
-_pushed_at: '2026-08-06T12:24:38Z'
+_pushed_at: '2026-08-07T17:45:12Z'
 _ruleset_count: 0
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-cas-mapper.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-cas-mapper.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2016-07-21T13:25:12Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-cas.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-cas.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-11-02T14:55:44Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-elastic-transcoder.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-elastic-transcoder.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2024-05-16T21:37:09Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-formula.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2024-05-02T23:09:49Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-guardian.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-guardian.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2015-06-05T14:39:10Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-longer-username.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-longer-username.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2015-07-15T09:44:36Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-role-permissions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-role-permissions.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2016-07-01T17:14:08Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-server-status.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-server-status.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-10-20T13:38:08Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-settings-export.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-settings-export.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2015-08-13T21:34:13Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-shibboleth-remoteuser.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-shibboleth-remoteuser.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2018-09-19T14:29:52Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-user-tasks.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-user-tasks.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2025-10-21T14:19:07Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/dls-boeing-web.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/dls-boeing-web.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _excluded_environments: 1
 _has_branch_protection: false
 _pushed_at: '2016-10-07T17:20:32Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/dls-syseng-web.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/dls-syseng-web.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _excluded_environments: 1
 _has_branch_protection: false
 _pushed_at: '2016-10-27T16:30:22Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/docs.openedx.org.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/docs.openedx.org.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2026-08-03T14:22:38Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/doof.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/doof.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2024-06-10T14:53:02Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/dremio-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/dremio-formula.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2020-06-19T18:26:27Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ecommerce.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ecommerce.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2024-11-04T16:02:41Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-analytics-api-client.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-analytics-api-client.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2014-07-11T19:23:32Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-api-client.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-api-client.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _excluded_environments: 1
 _has_branch_protection: false
 _pushed_at: '2026-08-06T12:46:19Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-dev-intro-slides.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-dev-intro-slides.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-12-01T11:47:38Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-documentation.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-documentation.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2022-06-09T11:57:56Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-enterprise-data.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-enterprise-data.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2025-10-21T14:20:12Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-enterprise.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-enterprise.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2025-10-24T20:30:02Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-git-auto-export.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-git-auto-export.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2024-04-05T11:52:20Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-notes-api.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-notes-api.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2019-01-31T20:03:23Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-ora2.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-ora2.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2025-10-21T14:14:36Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-platform.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-platform.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   odlbot: admin
   shaidar: admin

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-proctoring-proctortrack.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-proctoring-proctortrack.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-09-21T16:08:46Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-proctoring.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-proctoring.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2026-07-28T15:43:13Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-sandbox-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-sandbox-formula.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2016-05-12T13:13:01Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-search.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-search.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2026-04-17T17:45:42Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-sga.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-sga.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   indagation: write
 _excluded_environments: 1

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-submissions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-submissions.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2026-07-23T18:15:31Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-sysadmin.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-sysadmin.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2024-07-24T09:18:12Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-username-changer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-username-changer.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2025-01-09T12:36:35Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-username-updater.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-username-updater.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2024-12-20T15:50:41Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-val.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-val.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2025-11-19T14:14:15Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-video-api.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-video-api.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2019-08-02T20:23:31Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx2bigquery.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx2bigquery.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-12-01T14:41:01Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx2course_axis.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx2course_axis.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2015-07-29T13:04:58Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edxcut.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edxcut.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2022-08-28T16:33:05Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/elastic-stack-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/elastic-stack-formula.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2024-05-02T23:13:36Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/elasticsearch-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/elasticsearch-formula.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2020-06-19T18:28:07Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-access.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-access.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2025-10-21T14:18:09Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-catalog.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-catalog.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2025-10-20T14:45:02Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-integrated-channels.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-integrated-channels.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2025-10-21T14:47:36Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-subsidy.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-subsidy.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2025-10-21T14:26:50Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/epithet.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/epithet.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2019-08-15T17:26:49Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/eslint-config.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/eslint-config.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2026-08-06T12:47:42Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/flask-log.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/flask-log.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-10-20T13:38:04Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/fluentd-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/fluentd-formula.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2021-03-05T17:04:10Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/forum.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/forum.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2026-03-30T10:22:19Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-communications.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-communications.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2025-09-30T11:08:04Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-course-authoring.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-course-authoring.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2026-06-24T10:31:08Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-discussions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-discussions.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   Anas12091101: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-gradebook.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-gradebook.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2025-09-17T14:02:03Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-instructor-dashboard.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-instructor-dashboard.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   Anas12091101: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-learner-dashboard.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-learner-dashboard.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2026-03-05T12:07:06Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-learning.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-learning.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   Anas12091101: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-library-authoring.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-library-authoring.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2022-02-09T20:15:09Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-footer-mitol.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-footer-mitol.yaml
@@ -2,6 +2,8 @@
 _actions_secret_names:
 - SEMANTIC_RELEASE_GITHUB_TOKEN
 - SEMANTIC_RELEASE_NPM_TOKEN
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: true
 _pushed_at: '2025-04-08T18:28:13Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-header-edx-mitol.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-header-edx-mitol.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2024-09-01T17:33:22Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-header-mitol.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-header-mitol.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: true
 _pushed_at: '2024-09-01T11:46:11Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-lib-special-exams-mitol.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-lib-special-exams-mitol.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   arslanashraf7: admin
 _has_branch_protection: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-platform.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-platform.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2024-09-01T11:24:16Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-slot-footer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-slot-footer.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   Anas12091101: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/git-based-courses-slides.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/git-based-courses-slides.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-10-20T13:38:06Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/git2edx.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/git2edx.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2026-01-01T18:35:23Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/gitreload.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/gitreload.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-10-20T13:38:11Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/grafana-alerts.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/grafana-alerts.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   Ardiea: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/grafana-dashboards.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/grafana-dashboards.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   Ardiea: admin
   odlbot: admin

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/gwarek.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/gwarek.yaml
@@ -2,8 +2,10 @@
 _actions_secret_names:
 - DOCKERHUB_TOKEN
 - DOCKERHUB_USERNAME
+_custom_properties:
+  tier: tier-1
 _has_branch_protection: false
-_pushed_at: '2026-08-06T12:24:02Z'
+_pushed_at: '2026-08-07T19:37:39Z'
 _ruleset_count: 0
 _visibility: private
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/hacksnack.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/hacksnack.yaml
@@ -1,8 +1,10 @@
 ---
+_custom_properties:
+  tier: tier-1
 _direct_collaborators:
   abeglova: admin
 _has_branch_protection: false
-_pushed_at: '2026-07-01T15:24:21Z'
+_pushed_at: '2026-08-07T13:33:02Z'
 _ruleset_count: 0
 _visibility: public
 allow_auto_merge: false
@@ -20,5 +22,8 @@ merge_commit_title: MERGE_MESSAGE
 name: hacksnack
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  arbisoft-contractors: triage
+  odl-engineering: admin
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/handbook.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/handbook.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _excluded_environments: 1
 _has_branch_protection: true
 _pushed_at: '2026-06-11T20:45:57Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/hashicorp-release-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/hashicorp-release-resource.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2019-11-18T08:23:34Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/healthchecks.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/healthchecks.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2018-01-19T19:59:31Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/heroku-database-backups.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/heroku-database-backups.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2016-09-25T18:12:26Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/herokuconfigurator.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/herokuconfigurator.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2025-04-23T13:36:11Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/hq.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/hq.yaml
@@ -2,6 +2,8 @@
 _actions_secret_names:
 - STANDUP_CAT_ID
 - STANDUP_REPO_ID
+_custom_properties:
+  tier: tier-1
 _direct_collaborators:
   rhysyngsun: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/hugo-course-publisher.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/hugo-course-publisher.yaml
@@ -9,6 +9,8 @@ _actions_secret_names:
 - SEARCH_API_URL
 - ZAP_PROD_TARGET
 - ZAP_RC_TARGET
+_custom_properties:
+  tier: unmanaged
 _excluded_environments: 2
 _has_branch_protection: false
 _pushed_at: '2022-02-21T19:44:11Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/import-api-slides.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/import-api-slides.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-10-20T13:38:05Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ims_lti_py_django.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ims_lti_py_django.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2018-11-19T18:39:37Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/internal.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/internal.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   rhysyngsun: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/interview-scenario-frontend.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/interview-scenario-frontend.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   ChristopherChudzicki: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/iso-3166-2.js.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/iso-3166-2.js.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2022-12-07T14:02:03Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ist-slides.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ist-slides.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-10-20T13:37:58Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/jenkins-atlassian-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/jenkins-atlassian-theme.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2015-01-20T16:00:18Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/jsdom-global.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/jsdom-global.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2021-11-24T15:46:07Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/keycloak-scim.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/keycloak-scim.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2026-07-21T00:07:13Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/kubectl-slice.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/kubectl-slice.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2024-09-01T11:32:15Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/latex2edx_xserver.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/latex2edx_xserver.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-10-20T13:38:05Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/learn-ai-compromised.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/learn-ai-compromised.yaml
@@ -16,6 +16,8 @@ _actions_secret_names:
 - POSTHOG_PERSONAL_API_KEY_RC
 - POSTHOG_PROJECT_API_KEY_PROD
 - POSTHOG_PROJECT_API_KEY_RC
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   ChristopherChudzicki: admin
   mbertrand: write

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/learn-ai.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/learn-ai.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _excluded_environments: 1
 _has_branch_protection: false
 _pushed_at: '2026-08-06T13:09:53Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/learn-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/learn-zendesk-theme.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2026-02-13T13:10:20Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/lehrer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/lehrer.yaml
@@ -1,7 +1,9 @@
 ---
+_custom_properties:
+  tier: tier-1
 _excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-08-06T12:39:06Z'
+_pushed_at: '2026-08-07T13:36:43Z'
 _ruleset_count: 2
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/letsencrypt-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/letsencrypt-formula.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-12-01T11:36:04Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/library-customization.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/library-customization.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2021-02-24T19:55:58Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/library.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/library.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   odlbot: admin
 _excluded_environments: 4

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/lmod_proxy.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/lmod_proxy.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2021-12-22T21:44:40Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/locust-tests.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/locust-tests.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2025-12-10T15:58:11Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/lore.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/lore.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _excluded_environments: 3
 _has_branch_protection: false
 _pushed_at: '2016-08-13T16:27:00Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/loretemplates.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/loretemplates.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2015-08-11T16:27:54Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/master-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/master-formula.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-12-01T14:52:52Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mdl-react-components.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mdl-react-components.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2025-12-10T15:27:22Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mga.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mga.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _excluded_environments: 1
 _has_branch_protection: false
 _pushed_at: '2016-12-05T15:47:50Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters-templates.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters-templates.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-12-01T08:40:47Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters-zendesk-theme.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2024-05-08T06:27:47Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters.yaml
@@ -3,6 +3,8 @@ _actions_secret_names:
 - HEROKU_API_KEY
 - HEROKU_EMAIL
 - SENTRY_AUTH_TOKEN
+_custom_properties:
+  tier: tier-1
 _excluded_environments: 2694
 _has_branch_protection: true
 _pushed_at: '2026-08-06T14:27:37Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn-api-clients.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn-api-clients.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _excluded_environments: 1
 _has_branch_protection: false
 _pushed_at: '2026-08-06T12:25:50Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
@@ -6,9 +6,11 @@ _actions_secret_names:
 - MITOL_LEARN_DOCKERHUB_USER
 - MITX_ONLINE_BASE_URL_PROD
 - MITX_ONLINE_BASE_URL_RC
+_custom_properties:
+  tier: tier-1
 _excluded_environments: 44
 _has_branch_protection: true
-_pushed_at: '2026-08-06T14:21:55Z'
+_pushed_at: '2026-08-07T20:41:25Z'
 _ruleset_count: 1
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-moira.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-moira.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2018-05-24T14:42:31Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-open-bk.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-open-bk.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   rhysyngsun: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-open-login-button.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-open-login-button.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   gumaerc: admin
 _has_branch_protection: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit_lti_flask_sample.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit_lti_flask_sample.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2024-03-07T18:23:53Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitili.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitili.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2017-04-19T13:35:09Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-devstack.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-devstack.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2018-12-17T20:00:29Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-grading-library.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-grading-library.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _direct_collaborators:
   ChristopherChudzicki: admin
   MaferMazu: write

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-theme.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _excluded_environments: 1
 _has_branch_protection: false
 _pushed_at: '2026-07-13T13:04:55Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitx_cas_mapper.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitx_cas_mapper.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2016-07-21T18:56:42Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-api-clients.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-api-clients.yaml
@@ -1,7 +1,9 @@
 ---
+_custom_properties:
+  tier: tier-1
 _excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-08-06T12:32:37Z'
+_pushed_at: '2026-08-06T16:01:54Z'
 _ruleset_count: 0
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-theme.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _excluded_environments: 1
 _has_branch_protection: false
 _pushed_at: '2026-08-04T07:48:37Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-translations.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-translations.yaml
@@ -1,8 +1,10 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   Anas12091101: admin
 _has_branch_protection: false
-_pushed_at: '2026-08-06T01:16:37Z'
+_pushed_at: '2026-08-07T01:59:35Z'
 _ruleset_count: 0
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-zendesk-theme.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2025-01-30T16:50:14Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline.yaml
@@ -3,11 +3,13 @@ _actions_secret_names:
 - HEROKU_API_KEY
 - HEROKU_EMAIL
 - OL_HQ_PROJECT_SECRET
+_custom_properties:
+  tier: tier-1
 _direct_collaborators:
   rhysyngsun: admin
 _excluded_environments: 412
 _has_branch_protection: true
-_pushed_at: '2026-08-06T14:20:29Z'
+_pushed_at: '2026-08-07T20:06:54Z'
 _ruleset_count: 0
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-openedx-extensions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-openedx-extensions.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   rhysyngsun: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-theme.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _direct_collaborators:
   pdpinch: admin
 _excluded_environments: 1

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-zendesk-theme.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2024-10-07T16:41:35Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro.yaml
@@ -3,11 +3,13 @@ _actions_secret_names:
 - HEROKU_API_KEY
 - HEROKU_EMAIL
 - OL_HQ_PROJECT_SECRET
+_custom_properties:
+  tier: tier-1
 _direct_collaborators:
   rhysyngsun: admin
 _excluded_environments: 2042
 _has_branch_protection: true
-_pushed_at: '2026-08-06T13:17:53Z'
+_pushed_at: '2026-08-07T15:19:24Z'
 _ruleset_count: 0
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mongodb-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mongodb-formula.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2021-06-27T12:36:57Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/monit-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/monit-formula.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2019-11-07T19:16:04Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mynumbers.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mynumbers.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   abeglova: admin
 _has_branch_protection: false
@@ -23,6 +25,8 @@ name: mynumbers
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
+  arbisoft-contractors: triage
   code-owners: admin
   odl-engineering: admin
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/netdata-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/netdata-formula.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2020-06-19T18:34:36Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/nginx-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/nginx-formula.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2020-06-19T18:34:54Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/nginx-shibboleth-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/nginx-shibboleth-formula.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2024-05-03T14:47:44Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/no_op2_resizer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/no_op2_resizer.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   rhysyngsun: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-course-example-html.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-course-example-html.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2022-04-04T14:28:58Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-course-example-markdown.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-course-example-markdown.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   gumaerc: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-course-hugo-starter.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-course-hugo-starter.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   gumaerc: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-course-hugo-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-course-hugo-theme.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   gumaerc: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-data-parser.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-data-parser.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2025-01-23T13:55:50Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-projects.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-projects.yaml
@@ -1,9 +1,11 @@
 ---
+_custom_properties:
+  tier: tier-1
 _direct_collaborators:
   gumaerc: admin
 _excluded_environments: 1
 _has_branch_protection: true
-_pushed_at: '2026-08-05T20:00:12Z'
+_pushed_at: '2026-08-06T21:13:25Z'
 _ruleset_count: 0
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-themes.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-themes.yaml
@@ -12,6 +12,8 @@ _actions_secret_names:
 - SEARCH_API_URL
 - SSH_KEY
 - STATIC_API_BASE_URL
+_custom_properties:
+  tier: tier-1
 _direct_collaborators:
   gumaerc: admin
 _excluded_environments: 3

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-studio.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-studio.yaml
@@ -2,11 +2,13 @@
 _actions_secret_names:
 - HEROKU_API_KEY
 - HEROKU_EMAIL
+_custom_properties:
+  tier: tier-1
 _direct_collaborators:
   rhysyngsun: admin
 _excluded_environments: 5
 _has_branch_protection: true
-_pushed_at: '2026-08-06T12:23:54Z'
+_pushed_at: '2026-08-07T14:24:43Z'
 _ruleset_count: 0
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-to-hugo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-to-hugo.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   gumaerc: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-www.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-www.yaml
@@ -4,6 +4,8 @@ _actions_secret_names:
 - NETLIFY_SITE_ID
 - OCW_STUDIO_BASE_URL
 - SEARCH_API_URL
+_custom_properties:
+  tier: unmanaged
 _excluded_environments: 3
 _has_branch_protection: false
 _pushed_at: '2021-11-08T14:22:21Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-zendesk-theme.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2026-03-04T14:30:01Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw_oer_export.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw_oer_export.yaml
@@ -1,6 +1,8 @@
 ---
 _actions_secret_names:
 - SLACK_WEBHOOK
+_custom_properties:
+  tier: tier-1
 _direct_collaborators:
   ChristopherChudzicki: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/odl-etl.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/odl-etl.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2022-12-08T10:41:08Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/odl-keycloak.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/odl-keycloak.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-02-10T23:20:31Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/odl-video-service.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/odl-video-service.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _excluded_environments: 6
 _has_branch_protection: true
 _pushed_at: '2026-08-05T20:26:29Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/odl_devstack_tools.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/odl_devstack_tools.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-10-20T13:38:10Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/odleng-update-slides.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/odleng-update-slides.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-12-01T11:47:26Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/odlengweb.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/odlengweb.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2024-04-08T14:40:34Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-analytics-api.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-analytics-api.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _excluded_environments: 3
 _has_branch_protection: false
 _pushed_at: '2026-08-03T21:20:30Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-concourse-github-issues.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-concourse-github-issues.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2026-04-14T13:39:28Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-concourse.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-concourse.yaml
@@ -1,7 +1,9 @@
 ---
+_custom_properties:
+  tier: tier-1
 _excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-08-06T15:48:33Z'
+_pushed_at: '2026-08-07T19:34:02Z'
 _ruleset_count: 0
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-configuration-management.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-configuration-management.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2021-04-27T19:52:09Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-customizations-nytimes-library.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-customizations-nytimes-library.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2026-08-06T03:42:39Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-data-platform.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-data-platform.yaml
@@ -1,9 +1,11 @@
 ---
 _actions_secret_names:
 - GH_PROJECT_AUTOMATION_TOKEN
+_custom_properties:
+  tier: tier-1
 _excluded_environments: 2
 _has_branch_protection: true
-_pushed_at: '2026-08-06T13:01:09Z'
+_pushed_at: '2026-08-07T18:17:52Z'
 _ruleset_count: 1
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-django.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-django.yaml
@@ -1,11 +1,13 @@
 ---
 _actions_secret_names:
 - PYPI_TOKEN
+_custom_properties:
+  tier: tier-1
 _direct_collaborators:
   rhysyngsun: admin
 _excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-08-05T20:30:04Z'
+_pushed_at: '2026-08-07T18:51:41Z'
 _ruleset_count: 0
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-github-workflows.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-github-workflows.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _direct_collaborators:
   rhysyngsun: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infra-health-checks.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infra-health-checks.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2026-07-28T23:48:52Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
@@ -1,9 +1,11 @@
 ---
 _actions_secret_names:
 - GH_PROJECT_AUTOMATION_TOKEN
+_custom_properties:
+  tier: tier-1
 _excluded_environments: 2
 _has_branch_protection: true
-_pushed_at: '2026-08-06T15:31:19Z'
+_pushed_at: '2026-08-07T20:09:59Z'
 _ruleset_count: 1
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloak-customization.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloak-customization.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-10-17T20:17:31Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloak.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloak.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _has_branch_protection: true
 _pushed_at: '2026-08-05T20:28:02Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloakify.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloakify.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _excluded_environments: 2
 _has_branch_protection: false
 _pushed_at: '2026-08-06T12:38:02Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-notebook-extensions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-notebook-extensions.yaml
@@ -1,8 +1,10 @@
 ---
+_custom_properties:
+  tier: tier-1
 _direct_collaborators:
   dsubak: admin
 _has_branch_protection: false
-_pushed_at: '2026-08-02T23:15:42Z'
+_pushed_at: '2026-08-06T19:40:48Z'
 _ruleset_count: 0
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-npm-libraries.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-npm-libraries.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   rhysyngsun: admin
 _has_branch_protection: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-openedx-mfe-overrides.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-openedx-mfe-overrides.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   Anas12091101: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-parliament.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-parliament.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _excluded_environments: 1
 _has_branch_protection: false
 _pushed_at: '2026-06-05T20:37:09Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-rootly-manager.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-rootly-manager.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2026-06-29T21:02:58Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/oldevops-scratch.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/oldevops-scratch.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2023-09-26T20:52:27Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-collaboration.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-collaboration.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _direct_collaborators:
   Ferdi: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-discussions-client.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-discussions-client.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   rhysyngsun: admin
 _has_branch_protection: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-discussions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-discussions.yaml
@@ -2,6 +2,8 @@
 _actions_secret_names:
 - HEROKU_API_KEY
 - HEROKU_EMAIL
+_custom_properties:
+  tier: tier-1
 _excluded_environments: 1723
 _has_branch_protection: true
 _pushed_at: '2026-07-23T18:59:37Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-plugins.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-plugins.yaml
@@ -1,7 +1,9 @@
 ---
+_custom_properties:
+  tier: tier-1
 _excluded_environments: 1
 _has_branch_protection: true
-_pushed_at: '2026-08-06T13:10:06Z'
+_pushed_at: '2026-08-07T12:03:32Z'
 _ruleset_count: 1
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-proposals.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-proposals.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2025-02-27T21:13:04Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-learning-ai-tutor.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-learning-ai-tutor.yaml
@@ -1,7 +1,9 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-08-04T19:34:46Z'
+_pushed_at: '2026-08-06T19:36:51Z'
 _ruleset_count: 0
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-learnix.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-learnix.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2026-01-15T16:47:09Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-podcast-data.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-podcast-data.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _direct_collaborators:
   odlbot: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-resource-blocklists.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-resource-blocklists.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _direct_collaborators:
   mbertrand: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-video-data.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-video-data.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2026-05-12T14:38:52Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-widget-framework.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-widget-framework.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2020-09-12T04:10:38Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-widget-sample-app.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-widget-sample-app.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2025-02-24T04:55:24Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/openedx-course-test.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/openedx-course-test.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-10-20T13:38:12Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/openedx-events.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/openedx-events.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   Anas12091101: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/openedx-ledger.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/openedx-ledger.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2025-10-21T14:27:47Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/opentelemetry-python-contrib.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/opentelemetry-python-contrib.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2026-03-11T21:14:17Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/orcoursetrion.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/orcoursetrion.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   NotoriousMKD: write
   indagation: write

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pgbouncer-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pgbouncer-formula.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-12-01T08:59:41Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/platform-engineering-site.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/platform-engineering-site.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _excluded_environments: 2
 _has_branch_protection: false
 _pushed_at: '2026-08-06T12:25:35Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pre-commit-ci-config.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pre-commit-ci-config.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-09-07T17:57:54Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pre-commit-packer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pre-commit-packer.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2024-05-09T14:57:05Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/product.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/product.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2024-04-11T14:12:31Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pulsar-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pulsar-formula.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2020-06-19T18:36:28Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/py-tree-sitter.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/py-tree-sitter.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2026-07-09T21:12:53Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pycaption.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pycaption.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   mbertrand: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pycassa.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pycassa.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2017-10-03T19:38:47Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pylint-django.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pylint-django.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2017-09-08T19:22:16Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pylti.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pylti.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-10-20T13:38:01Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/python-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/python-formula.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2024-05-01T14:24:37Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/rabbitmq-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/rabbitmq-formula.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2024-05-01T14:39:24Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/rapid-response-xblock.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/rapid-response-xblock.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2024-07-24T14:04:07Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/react-dropzone-uploader.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/react-dropzone-uploader.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2020-09-03T18:56:24Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/realistic-mm-users.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/realistic-mm-users.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2017-01-17T21:09:26Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/redash.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/redash.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2022-10-27T17:40:29Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-config.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-config.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _direct_collaborators:
   rhysyngsun: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-formula.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2024-05-03T11:29:49Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-i18n.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-i18n.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2017-04-25T19:19:30Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-service-activity.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-service-activity.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2017-05-30T16:54:20Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-service-websockets.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-service-websockets.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2017-06-06T21:17:55Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/reddit.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/reddit.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   rhysyngsun: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/redux-asserts.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/redux-asserts.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _has_branch_protection: true
 _pushed_at: '2026-08-05T20:40:46Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/redux-hammock.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/redux-hammock.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2026-08-06T12:44:20Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/refresh_token.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/refresh_token.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-10-20T13:38:11Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/release-script.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/release-script.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _excluded_environments: 2
 _has_branch_protection: false
 _pushed_at: '2026-08-06T12:46:08Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/response-map.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/response-map.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2019-09-27T18:07:00Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/salt-extensions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/salt-extensions.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2024-04-05T19:55:10Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/salt-ops.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/salt-ops.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2025-09-25T19:21:38Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/saltstack-formula-cookiecutter.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/saltstack-formula-cookiecutter.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2020-06-19T18:38:50Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/screenshot_xblock.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/screenshot_xblock.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2024-04-16T21:00:38Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/searchkit.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/searchkit.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2017-01-26T16:18:08Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/semantic-mitopen.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/semantic-mitopen.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   mbertrand: admin
 _excluded_environments: 1

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/sga-lti.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/sga-lti.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _excluded_environments: 29
 _has_branch_protection: false
 _pushed_at: '2025-09-19T15:26:34Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/sifters.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/sifters.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2014-10-08T16:44:40Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/sign-and-verify.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/sign-and-verify.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   rhysyngsun: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/smoot-design.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/smoot-design.yaml
@@ -1,11 +1,13 @@
 ---
 _actions_secret_names:
 - SEMANTIC_RELEASE_GITHUB_TOKEN
+_custom_properties:
+  tier: tier-1
 _direct_collaborators:
   ChristopherChudzicki: admin
 _excluded_environments: 2
 _has_branch_protection: true
-_pushed_at: '2026-08-05T19:38:49Z'
+_pushed_at: '2026-08-07T12:50:46Z'
 _ruleset_count: 1
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/social-auth-mitxpro.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/social-auth-mitxpro.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   rhysyngsun: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/sso-django-prototype.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/sso-django-prototype.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   odlbot: admin
   rhysyngsun: admin

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/standalone-course-prototype.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/standalone-course-prototype.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   gumaerc: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/superset-marimo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/superset-marimo.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _has_branch_protection: true
 _pushed_at: '2026-05-22T19:14:05Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/superset-nl-explorer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/superset-nl-explorer.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2026-02-26T00:27:57Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/superset-sup.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/superset-sup.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2026-07-24T14:04:41Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/taxonomy-connector.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/taxonomy-connector.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2025-10-30T13:24:01Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/teachersportal.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/teachersportal.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _excluded_environments: 54
 _has_branch_protection: false
 _pushed_at: '2020-07-06T16:37:49Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/tech-talk-slides.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/tech-talk-slides.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _excluded_environments: 1
 _has_branch_protection: false
 _pushed_at: '2026-08-06T12:46:04Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/template-mit-demo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/template-mit-demo.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _direct_collaborators:
   NotoriousMKD: write
   indagation: write

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/testinfra.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/testinfra.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-04-19T12:37:11Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/tika-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/tika-formula.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2020-06-19T18:39:23Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/travisfail.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/travisfail.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-10-20T13:37:59Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/tubular.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/tubular.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   feoh: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/tutor-mentor.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/tutor-mentor.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   rhysyngsun: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/tutor.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/tutor.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2025-04-16T17:15:25Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ubcpi.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ubcpi.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _excluded_environments: 1
 _has_branch_protection: false
 _pushed_at: '2026-03-11T11:24:32Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/unified-ecommerce-api-clients.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/unified-ecommerce-api-clients.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   jkachel: admin
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/unified-ecommerce-frontend.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/unified-ecommerce-frontend.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   ChristopherChudzicki: admin
 _excluded_environments: 1

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/unified-ecommerce.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/unified-ecommerce.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _direct_collaborators:
   jkachel: admin
 _excluded_environments: 1

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/uwsgi-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/uwsgi-formula.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-12-01T08:44:20Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/vault-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/vault-formula.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2024-07-09T18:00:20Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/vault-plugin-database-starrocks.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/vault-plugin-database-starrocks.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2026-08-06T12:31:15Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/vault-plugin-secrets-openai.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/vault-plugin-secrets-openai.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2026-06-01T20:47:46Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/vault-raft-backup.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/vault-raft-backup.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2026-08-06T12:31:18Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/video_translation_demo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/video_translation_demo.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _excluded_environments: 1
 _has_branch_protection: false
 _pushed_at: '2026-03-01T08:32:07Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/webcast.mit.edu.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/webcast.mit.edu.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _excluded_environments: 1
 _has_branch_protection: false
 _pushed_at: '2025-12-03T20:30:14Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/world_geographic_regions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/world_geographic_regions.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2015-11-11T14:31:40Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xanalytics.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xanalytics.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2021-09-23T12:45:56Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xblock-lti-consumer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xblock-lti-consumer.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2025-10-21T14:28:39Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xblock-utils.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xblock-utils.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2017-12-15T17:04:58Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xblocks-contrib.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xblocks-contrib.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2026-07-29T09:49:33Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xbundle.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xbundle.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-10-20T13:38:09Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xqueue-watcher.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xqueue-watcher.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _excluded_environments: 1
 _has_branch_protection: false
 _pushed_at: '2026-07-17T14:58:24Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xqueue.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xqueue.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2021-06-14T21:44:27Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xsiftx.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xsiftx.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2023-10-20T13:37:59Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/zookeeper-formula.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/zookeeper-formula.yaml
@@ -1,4 +1,6 @@
 ---
+_custom_properties:
+  tier: unmanaged
 _has_branch_protection: false
 _pushed_at: '2020-06-19T18:40:54Z'
 _ruleset_count: 0


### PR DESCRIPTION
## What are the relevant tickets?

Part of the GitHub org Pulumi import (phase 4 follow-up). Fixes the observability gap found while landing https://github.com/mitodl/ol-infrastructure/pull/5317.

## Description (What does it do?)

`tier` is the custom property the phase-3.5 org rulesets target — it decides which protection baseline applies to a repo. It was also the one field `bin/github-estate-audit drift` could not see: it was absent from the `tracked` tuple, and the crawl dropped falsy property values before anything could compare them.

That blindness had already cost us. After the phase-3 apply, all 140 archived repos were live at `tier=standard` while `data/repos/*.yaml` declared `unmanaged`. Because `tier` is `required` with `default_value: standard`, the repos nobody had written to had not fallen *outside* the tier scheme — they had fallen *into* the tier `baseline-default-branch` targets. The ruleset matched 214 of 316 repos where 74 was intended. Nothing surfaced it; it was caught by hand-querying `/orgs/mitodl/properties/values`.

**An unset custom property is a value, not an absence**, so every comparison added here reports a missing side rather than skipping it:

- `bin/github-org-inventory` reads all 316 repos' property values from one org-wide `GET /orgs/{org}/properties/values` — replacing 316 per-repo calls — and records them **verbatim**. The previous `if p.get("value")` filter made "set to empty" and "never measured" identical, which is exactly the shape of the bug above. It also trips loudly if any repo is absent from that response.
- `crawl` writes them as `_custom_properties` (inventory) beside the declared `tier` (configuration), so the two can be compared with no API call and no credentials.
- New audit rule **CON-11** compares them in `run`. Graded `high` despite being a consistency rule: a repo at the wrong tier is protected by a different baseline than the code claims.
- `drift` compares `tier` outside the generic loop. That loop skips fields the fleet declares nothing for — correct for every other tracked field, since archetypes may legitimately stay silent — but wrong for the one field that decides ruleset membership.
- `run` now lists **every** rule, including those at zero. CON-11 reads clean today, and a rule that fires nowhere is otherwise indistinguishable from a rule that is not registered.

Regenerating the fleet from a fresh crawl also caught unrelated out-of-band drift: `hacksnack` and `mynumbers` gained five team grants on GitHub since the 2026-08-05 crawl (`arbisoft-contractors: triage`, `odl-engineering-owners: admin`, and `odl-engineering: admin` on `hacksnack`). Those already existed live, so they were **imported** into state, not created — nothing on GitHub changed.

## How can this be tested?

Both stacks preview clean, which is the §6 gate:

```
ol-saas-github-repositories   1170 unchanged
ol-saas-github-organization     20 unchanged
```

`github-estate-audit run` reports CON-11 at `0 (0% of 316 fleet)` — declared and live tiers agree (74 `tier-1`, 242 `unmanaged`, 0 `standard`).

Negative controls, since a clean result proves nothing on its own. All three ways the comparison can be wrong now fire, including the two absence cases the naive `if want and want != got` guard would have passed:

```
# CON-11, against doctored fleet entries
.github            | live standard   | declared tier-1     # live fell into the default
PASSSL             | live unrecorded | declared unmanaged   # measured empty
PyLmod             | live unrecorded | declared unmanaged   # never measured

# drift, against a doctored cache
DRIFT  mit-learn.tier: declared 'tier-1', live None (not in the crawl)
DRIFT  ol-infrastructure.tier: declared 'tier-1', live 'standard'
```

Against the real cache, `drift` reports 0 differences.

## Additional Notes

The 316 changed files under `data/repos/` are a regeneration: each gains `_custom_properties`, and `_pushed_at` moves because the previous cache was two days old. The only non-inventory changes are the five real team grants on `hacksnack` and `mynumbers`.

`imports` now emits a `RepositoryCustomProperty` entry for `tier` specifically rather than looping over every property. The resource name has to match what `repository.py` declares (`mitodl-repo-tier-<repo>`), and that function emits exactly one per repo — a second org property would otherwise bind to the tier's resource name. Adding one now requires a change in both places, which is the right amount of friction for something rulesets target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012eXp7Dox9U9YEJuu8fj2BQ
