### PR TITLE
fix(witan): raise the vMCP memory ceiling that caused the 502s, and give the MCP backend the limits it only claimed to have

### DIFF
--- a/src/ol_infrastructure/applications/witan/__main__.py
+++ b/src/ol_infrastructure/applications/witan/__main__.py
@@ -895,8 +895,11 @@ witan_virtualmcpserver = kubernetes.apiextensions.CustomResource(
         # lesson already learned in `infrastructure/aws/eks/traefik.py`.
         #
         # ── SIZING ──
-        # 2Gi supports roughly 130 concurrent sessions at the measured
-        # ~15Mi/session, against 36 provisioned realm users.
+        # 2Gi supports roughly 130 concurrent SESSIONS at the measured
+        # ~15Mi/session. Sessions, not people: the burst above opened all 32
+        # from a single token, so one user running a fleet of agents can hold
+        # many at once and the count of provisioned realm users says nothing
+        # about the ceiling. Size against expected concurrent sessions.
         #
         # ★ The 4:1 limit:request ratio is load-bearing, not incidental. The VPA
         # below controls this container with `controlledValues:
@@ -971,12 +974,16 @@ witan_virtualmcpserver = kubernetes.apiextensions.CustomResource(
 #########################################
 #   Vertical rightsizing (VPA)           #
 #########################################
-# Memory only, deliberately. Both workloads are far from any CPU limit — the
-# aggregator peaked at 11m against 500m (~2%) during the burst that OOMKilled it
-# — so CPU is not the resource that needs managing, and leaving it uncontrolled
-# keeps the door open for a CPU-based HPA later without re-creating the known
-# HPA/VPA conflict that `infrastructure/aws/eks/traefik.py` and
-# `apisix_official.py` both document.
+# Memory only, deliberately. Memory is the resource with a demonstrated failure:
+# the aggregator died of it, and the backend's limits were never applied at all.
+# No CPU pressure has been observed on either of these two workloads — but note
+# that is an absence of evidence, not a measurement: the only CPU figure taken
+# during the incident was the PROXY RUNNER's (11m against its 500m limit), and
+# that is a third workload, not one of the two targeted here. Leaving CPU
+# uncontrolled therefore rests on memory being the known problem, not on proven
+# CPU headroom; it also keeps the door open for a CPU-based HPA later without
+# re-creating the known HPA/VPA conflict that
+# `infrastructure/aws/eks/traefik.py` and `apisix_official.py` both document.
 #
 # This is the same remedy, for the same failure, as the one traefik.py describes:
 # a per-pod memory ceiling with no headroom, where "adding replicas doesn't help
@@ -989,6 +996,34 @@ witan_virtualmcpserver = kubernetes.apiextensions.CustomResource(
 # recommender would shrink the aggregator back toward its idle footprint and
 # re-introduce the OOM on the next burst. The floors below are the measured safe
 # sizes, not recommendations to be optimised away.
+#
+# ★ THESE TARGETS ARE SINGLETONS, AND THAT NORMALLY DEFEATS THE VPA UPDATER.
+# The updater refuses to touch a controller with fewer than `--min-replicas`
+# pods (upstream default 2, and not overridden on this cluster), which would
+# leave both VPAs below computing recommendations that never reach a pod. What
+# rescues it is `--in-place-skip-disruption-budget=true` on the
+# `vertical-pod-autoscaler-updater` Deployment in `kube-system`, combined with
+# `make_vpa`'s unconditional `InPlaceOrRecreate` mode — vpa-updater 1.7.1,
+# `pkg/updater/restriction/pods_restriction_factory.go`:
+#
+#     skipReplicaCheck := (usingInPlaceOrRecreate || usingInPlace) &&
+#                         f.inPlaceSkipDisruptionBudget
+#
+# and, for a controller whose live pod count is under `required`: when
+# `skipReplicaCheck` is false it is skipped outright (`continue`), and when true
+# it is admitted with `isBelowMinReplicas = true` instead.
+#
+# So a 1-replica controller IS admitted, flagged `belowMinReplicas`. That flag
+# then makes `CanEvict` return false while `CanInPlaceUpdate` still approves —
+# which is exactly the behaviour wanted here: resize the live pod, never evict
+# it. Evicting either of these singletons would drop APISIX's only upstream and
+# recreate the very 502 this stack is fixing.
+#
+# The dependency is invisible from here, so: if that updater flag is ever
+# removed, or `min-replicas` is set per-VPA, these two VPAs silently degrade to
+# recommendation-only and the OOM protection above goes with them. Raised by
+# review on PR #5320 as a suspected defect; verified against the running
+# updater's args and the 1.7.1 source rather than assumed either way.
 #
 # Only the two workloads whose containers this stack actually declares. The
 # ToolHive proxy runner Deployment is left alone: it showed ~20Mi against a

--- a/src/ol_infrastructure/applications/witan/__main__.py
+++ b/src/ol_infrastructure/applications/witan/__main__.py
@@ -166,6 +166,7 @@ from ol_infrastructure.lib.aws.eks_helper import (
     check_cluster_namespace,
     setup_k8s_provider,
 )
+from ol_infrastructure.lib.k8s_vpa import make_vpa
 from ol_infrastructure.lib.ol_types import (
     AWSBase,
     BusinessUnit,
@@ -870,6 +871,58 @@ witan_virtualmcpserver = kubernetes.apiextensions.CustomResource(
             },
         },
         "serviceType": "ClusterIP",
+        # VirtualMCPServerSpec has no `resources` field of its own (unlike
+        # MCPServer), so the aggregator's limits can only be set through the
+        # documented PodTemplateSpec escape hatch, targeting the operator-managed
+        # `vmcp` container by name — the same mechanism mcp_servers.py uses for
+        # the backend.
+        #
+        # ── WHY THIS EXISTS ──
+        # The operator's default is 500m CPU / 512Mi memory, and 512Mi is not
+        # enough. Measured against CI on 2026-08-07: the vMCP holds per-session
+        # aggregated capability state — its log emits `session capabilities
+        # injected from core … tool_count:67` once PER SESSION — and grows from
+        # 17Mi idle to past 512Mi at ~32 concurrent sessions, i.e. roughly 15Mi
+        # resident per session. It was OOMKilled (`exitCode: 137`), APISIX lost
+        # its only upstream, and every client got a 502 HTML page until it came
+        # back. Two identical 32-client bursts four seconds apart read
+        # `{200: 32}` then `{200: 3, 502: 29}` — the first burst killed it.
+        #
+        # Nothing else in the path was under any strain: the proxy runner stayed
+        # Ready at 11m against its 500m CPU limit (~2%) and the backend never
+        # restarted. This is a memory ceiling and nothing else, which is also why
+        # replicas are not the answer to it — see the VPA note below and the same
+        # lesson already learned in `infrastructure/aws/eks/traefik.py`.
+        #
+        # ── SIZING ──
+        # 2Gi supports roughly 130 concurrent sessions at the measured
+        # ~15Mi/session, against 36 provisioned realm users.
+        #
+        # ★ The 4:1 limit:request ratio is load-bearing, not incidental. The VPA
+        # below controls this container with `controlledValues:
+        # RequestsAndLimits`, which scales the limit to PRESERVE this ratio while
+        # bounding only the request. So the ratio chosen here, multiplied by the
+        # VPA's `maxAllowed`, is what actually caps memory: 4 x 1Gi = 4Gi. Widen
+        # the ratio (say a 256Mi request against the same 2Gi limit) and the
+        # effective ceiling silently becomes 8Gi, which would let a leak grow
+        # until it evicts its node-mates rather than failing loudly.
+        #
+        # The per-session figure is inferred from a single OOM boundary, not a
+        # sweep — treat it as a floor to revise once the VPA has real numbers.
+        # Reproduce with agent-kit's `python -m witan.scripts.concurrency_probe`.
+        "podTemplateSpec": {
+            "spec": {
+                "containers": [
+                    {
+                        "name": "vmcp",
+                        "resources": {
+                            "requests": {"cpu": "100m", "memory": "512Mi"},
+                            "limits": {"cpu": "500m", "memory": "2Gi"},
+                        },
+                    }
+                ],
+            }
+        },
         "config": {
             # `priority`, NOT the CRD's `prefix` default, because prefix mode
             # renames unconditionally: it does no conflict detection at all, so
@@ -913,6 +966,66 @@ witan_virtualmcpserver = kubernetes.apiextensions.CustomResource(
             actor_tokens_secret,
         ]
     ),
+)
+
+#########################################
+#   Vertical rightsizing (VPA)           #
+#########################################
+# Memory only, deliberately. Both workloads are far from any CPU limit — the
+# aggregator peaked at 11m against 500m (~2%) during the burst that OOMKilled it
+# — so CPU is not the resource that needs managing, and leaving it uncontrolled
+# keeps the door open for a CPU-based HPA later without re-creating the known
+# HPA/VPA conflict that `infrastructure/aws/eks/traefik.py` and
+# `apisix_official.py` both document.
+#
+# This is the same remedy, for the same failure, as the one traefik.py describes:
+# a per-pod memory ceiling with no headroom, where "adding replicas doesn't help
+# ... it just means more pods hitting the same wall". Worth stating plainly here
+# because the instinct on seeing 502s under load is to reach for replicas, and
+# for this failure that would have changed nothing.
+#
+# `minAllowed` is what stops the fix from undoing itself: VPA sizes from observed
+# usage, and witan sits idle at ~17Mi for long stretches, so an unbounded
+# recommender would shrink the aggregator back toward its idle footprint and
+# re-introduce the OOM on the next burst. The floors below are the measured safe
+# sizes, not recommendations to be optimised away.
+#
+# Only the two workloads whose containers this stack actually declares. The
+# ToolHive proxy runner Deployment is left alone: it showed ~20Mi against a
+# 512Mi limit, its resources are not settable through the MCPServer CRD (
+# `resourceOverrides` covers annotations and labels only), and adding a VPA to a
+# workload under no pressure is churn for its own sake.
+make_vpa(
+    f"witan-vmcp-vpa-{stack_info.env_suffix}",
+    namespace=NAMESPACE,
+    target_kind="Deployment",
+    target_name="witan-vmcp",
+    container_name="vmcp",
+    controlled_resources=["memory"],
+    # Floor = the request declared on the vMCP above; ceiling x the 4:1 ratio
+    # there = a 4Gi hard cap on the limit. See that comment.
+    min_allowed={"memory": "512Mi"},
+    max_allowed={"memory": "1Gi"},
+    disable_other_containers=True,
+    opts=ResourceOptions(depends_on=[witan_virtualmcpserver]),
+)
+
+make_vpa(
+    f"witan-backend-vpa-{stack_info.env_suffix}",
+    namespace=NAMESPACE,
+    # The backend is a StatefulSet named `witan`; the proxy runner is a
+    # Deployment ALSO named `witan` in this same namespace. Only `target_kind`
+    # separates them, so this is not a place to guess.
+    target_kind="StatefulSet",
+    target_name=WITAN_MCPSERVER_NAME,
+    container_name="mcp",
+    controlled_resources=["memory"],
+    # Floor = WITAN_BACKEND_RESOURCES' request. 2:1 ratio there, so the 1Gi
+    # ceiling caps the limit at 2Gi.
+    min_allowed={"memory": "256Mi"},
+    max_allowed={"memory": "1Gi"},
+    disable_other_containers=True,
+    opts=ResourceOptions(depends_on=[*mcp_servers.servers]),
 )
 
 #########################################

--- a/src/ol_infrastructure/applications/witan/mcp_servers.py
+++ b/src/ol_infrastructure/applications/witan/mcp_servers.py
@@ -94,6 +94,32 @@ ACTOR_TOKENS_FILENAME = "tokens.json"  # pragma: allowlist secret
 # the invariant ours instead of inherited.
 TMP_MOUNT_PATH = "/tmp"  # noqa: S108
 TMP_FS_GROUP = 1000
+
+# ToolHive v0.40.1 accepts `spec.resources` and never applies it to the backend
+# container. Verified 2026-08-07 against all three environments: this MCPServer
+# declares 500m/512Mi and `kubectl get sts witan -o jsonpath=
+# '{.spec.template.spec.containers[0].resources}'` returns `{}`. It is not the
+# podTemplateSpec below shadowing it — toolhive-swe/aws has NO podTemplateSpec at
+# all, declares 200m/256Mi, and renders `{}` just the same.
+#
+# The consequence is not cosmetic: with no requests the pod is **BestEffort QoS**,
+# first in line for eviction under node memory pressure, and with no limit a
+# runaway server can take its node's other pods with it. It also makes the CRD
+# actively misleading — an audit that reads `spec.resources` concludes the backend
+# is bounded when nothing bounds it.
+#
+# So the same values are restated on the `mcp` container in `podTemplateSpec`,
+# which the operator demonstrably DOES honour (that is how env and volumeMounts
+# arrive). `spec.resources` is deliberately left in place as the declaration of
+# intent for whenever upstream wires it up; the two must be kept in step, hence
+# one constant feeding both.
+#
+# Tracked as tk-toolhive-operator-drops-mcpserver-spec-resources-8ea1ff.
+# ★ Verify any change here against the RENDERED StatefulSet, never the CRD.
+WITAN_BACKEND_RESOURCES = {
+    "requests": {"cpu": "100m", "memory": "256Mi"},
+    "limits": {"cpu": "500m", "memory": "512Mi"},
+}
 # Sized for the server-side work, which is dominated by the graph export
 # `store_merge` takes of its OWN target to reconcile against — that grows with
 # the shared graph, not with the caller's upload (the client's batches are
@@ -279,10 +305,9 @@ def create_mcp_servers(  # noqa: PLR0913
                 "type": "builtin",
                 "name": "network",
             },
-            "resources": {
-                "requests": {"cpu": "100m", "memory": "256Mi"},
-                "limits": {"cpu": "500m", "memory": "512Mi"},
-            },
+            # Declared, but NOT what actually reaches the container — the
+            # operator drops it. See WITAN_BACKEND_RESOURCES.
+            "resources": WITAN_BACKEND_RESOURCES,
             # `volumes`/`volumeMounts` aren't first-class MCPServerSpec fields
             # beyond hostPath, so the actor-tokens Secret is mounted via the
             # documented escape hatch: a PodTemplateSpec merge-patch targeting
@@ -300,6 +325,11 @@ def create_mcp_servers(  # noqa: PLR0913
                             # is already how `spec.secrets` arrives as
                             # `secretKeyRef`.
                             "env": downward_api_env_dicts(),
+                            # The resources that actually take effect — the
+                            # operator ignores `spec.resources` above. Without
+                            # this the container renders `resources: {}` and
+                            # runs BestEffort. See WITAN_BACKEND_RESOURCES.
+                            "resources": WITAN_BACKEND_RESOURCES,
                             "volumeMounts": [
                                 {
                                     "name": "actor-tokens",


### PR DESCRIPTION
### What are the relevant tickets?
N/A — tracked in the witan work graph as `tk-deployed-witan-saturates-at-24-32-concurrent-con-8e4afc` (the vMCP OOM) and `tk-toolhive-operator-drops-mcpserver-spec-resources-8ea1ff` (the dropped resources). The load-test harness that found both is mitodl/agent-kit#211.

### Description (What does it do?)

Fixes two resource defects in the deployed witan stack, found by load-testing it against CI and tracing each 502 back to its cause rather than to the layer that reported it.

**1. The vMCP's 512Mi limit was the outage.**

ToolHive's vMCP aggregator holds per-session capability state — its log emits `session capabilities injected from core … tool_count:67` once per session — and grows from 17Mi idle to past its 512Mi limit at roughly 32 concurrent sessions, about 15Mi resident each. It was OOMKilled, APISIX lost its only upstream, and every client got a 502 HTML page until it came back:

```
lastState: {"terminated":{"exitCode":137,"reason":"OOMKilled",
                          "finishedAt":"2026-08-07T20:32:13Z",
                          "startedAt":"2026-08-07T20:15:23Z"}}
```

Two identical 32-client bursts four seconds apart, one fixed valid token, one MCP `initialize` per process:

```
burst 1 -> {200: 32}            <- 32 concurrent is fine when vmcp is alive
burst 2 -> {200: 3, 502: 29}    <- vmcp OOMKilled at 20:32:13, mid-test
```

The crashed container's log ends abruptly at 20:32:12 — no error, no panic, no refusal — one second before `finishedAt`. That is a kill, not a rejection. Nothing else in the path was under strain: the proxy runner stayed `Ready` at 11m against its 500m CPU limit (~2%) and logged nothing, and the FastMCP backend never restarted (`restartCount: 0`).

`VirtualMCPServerSpec` has no `resources` field of its own, so the limit is raised through the documented PodTemplateSpec escape hatch on the `vmcp` container: 512Mi request / 2Gi limit.

**2. The backend's declared limits never existed.**

ToolHive v0.40.1 accepts `MCPServer.spec.resources` and does not apply it to the backend container. This stack has declared 500m/512Mi since it was written; the rendered StatefulSet reads `resources: {}`.

This is not a PodTemplateSpec conflict — `toolhive-swe/aws` has no `podTemplateSpec` at all, declares 200m/256Mi, and renders `{}` just the same, in all three environments:

```
witan/witan        spec.resources = 500m/512Mi  ->  rendered sts `mcp` = {}
toolhive-swe/aws   spec.resources = 200m/256Mi  ->  rendered sts `mcp` = {}
```

So every MCP backend has been running **BestEffort QoS** — first to be evicted under node memory pressure, and unbounded on the way there — while the CRD told anyone who looked that it was bounded. The values are now restated on the `mcp` container where the operator demonstrably does honour them (it is how `env` and `volumeMounts` already arrive). `spec.resources` is kept as the declaration of intent for whenever upstream wires it up; a comment ties the two together so they cannot drift.

**3. VPA on both workloads, memory only.**

Follows the existing pattern in `infrastructure/aws/eks/traefik.py` and `apisix_official.py` — which, as it happens, was added after an OOM incident of exactly this shape ("adding replicas doesn't help when the bottleneck is a per-pod memory ceiling; it just means more pods hitting the same wall"). Memory only, so CPU stays free for an HPA later without re-creating the documented HPA/VPA conflict.

`minAllowed` is the part doing real work: witan idles at ~17Mi for long stretches, so an unbounded recommender would shrink the aggregator back toward its idle footprint and re-introduce the OOM on the next burst. The floors are the measured safe sizes, not recommendations to be optimised away.

### How can this be tested?

`pulumi preview` on **CI** and **Production** both give the same result — no replacements, no deletions:

```
+ 2 to create      (the two VerticalPodAutoscalers)
~ 2 to update      (MCPServer, VirtualMCPServer)
  4 changes. 43 unchanged
```

Note the stack needs an image ref the pipeline normally injects; preview locally with the digest already in state, e.g.
`WITAN_DOCKER_SHA=sha256:<digest> pulumi preview --stack CI --diff`.
Supplying a *different* digest additionally shows 2 CronJob updates and a replacement of the migrations Job — that is the pre-deploy migration gate behaving as designed on any image change, not an effect of this diff.

`ruff`, `mypy` and the pre-commit suite all pass.

**After deploy, verify against the rendered workloads, not the CRD** — the second defect above is precisely that the CRD reports resources the pod does not have:

```
kubectl -n witan get sts witan -o jsonpath='{.spec.template.spec.containers[0].resources}'
kubectl -n witan get deploy witan-vmcp -o jsonpath='{.spec.template.spec.containers[0].resources}'
kubectl -n witan get vpa
```

The backend should show 100m/256Mi requests and 500m/512Mi limits rather than `{}`, and the vMCP 512Mi/2Gi.

To reproduce the original failure and confirm it is gone, run the harness from mitodl/agent-kit#211 against a deployed target:

```
witan login --target ci
uv run python -m witan.scripts.concurrency_probe --target ci --racers 16 --writers 16 --readers 8
```

Before this change that reliably OOMKilled the vMCP and returned 502s; afterwards it should complete without the aggregator restarting (`kubectl -n witan get pod -l app=witan-vmcp` — `RESTARTS` should not increment).

### Additional Context

**The limit:request ratios are load-bearing, not incidental.** The VPA uses `controlledValues: RequestsAndLimits`, which scales the limit to preserve the declared ratio while bounding only the request. So *ratio × maxAllowed* is what actually caps memory: 4 × 1Gi = 4Gi for the vMCP. Widening the ratio — say a 256Mi request against the same 2Gi limit — would silently make the effective ceiling 8Gi and let a leak grow until it evicted its node-mates instead of failing loudly. Worth a second look in review; it is the least obvious thing here.

**The per-session figure rests on one data point.** ~15Mi/session is inferred from a single OOM boundary, not a sweep. It could equally be a leak rather than linear per-session growth, and those imply different fixes. The VPA shipped here will report real usage within a week; the sizing is deliberately a floor to revise, and both the code comments and the tracking task say so.

**Production has the same 512Mi ceiling and has never been load-tested.** The preview shows this applies cleanly there, but the failure was only ever reproduced in CI.

**Scale-out was considered and deliberately deferred** (`tk-scale-witan-out-redis-sessionstorage-then-an-hpa-36538a`). ToolHive supports it natively — `replicas` / `backendReplicas` on `MCPServer`, `replicas` on `VirtualMCPServer`, all currently nil, which the CRD documents as "leaving replica management to an HPA or other external controller". The blocker is correctness, not capability: `sessionStorage` (`provider: memory|redis`) is unset everywhere, so sessions live in the pod and a second replica would be wrong rather than merely unhelpful. `sessionAffinity` is already `ClientIP`, but that guarantee dies with the pod — which is the case multi-replica exists to survive.

One trap recorded there for whoever picks it up: an HPA targeting **memory** would conflict with the memory VPA added here. That needs resolving first — move the VPA to CPU-only, give the HPA a custom metric (active sessions is the honest signal), or let the HPA target CPU and the VPA keep memory.
