### PR TITLE
fix(mit_learn): raise VPA memory floor and workers_max_rss again (3Gi/1350 -> 3.5Gi/1500)

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
@@ -50,8 +50,8 @@ config:
   mitlearn:use_granian: true
   # Raised again 2026-08-07, 3Gi -> 3.5Gi. The 3Gi floor (peak RSS 2774Mi + ~11%,
   # see git history for that calibration) got eaten within ~10 days: PR #5303
-  # (2026-08-06) raised the webapp CPU request 500m->1200m to fix an inert KEDA
-  # trigger that was pegging the HPA at max_replicas=30. That fix was correct on
+  # (2026-08-06) raised the webapp CPU request 500m->1200m because the two
+  # Prometheus triggers were inert, leaving CPU to peg the HPA at max_replicas=30.
   # its own terms, but it also means the same real CPU usage reads as lower
   # utilization, so the HPA now legitimately runs fewer replicas (observed
   # kube_horizontalpodautoscaler_status_current_replicas dropped from oscillating

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
@@ -48,14 +48,23 @@ config:
   mitlearn:posthog_proxy: "ph.ol.mit.edu"
   mitlearn:support_url: "support.learn.mit.edu"
   mitlearn:use_granian: true
-  # Peak webapp container RSS measured 2774Mi over the 14 days to 2026-07-28. The
-  # 256Mi default floor let the VPA shrink the limit to ~2062-2295Mi, below that
-  # peak, and the kernel OOM-killed the container: 24-44 restarts/day whenever the
-  # limit sat at or under ~2553Mi, against 1-3/day whenever it sat at or above
-  # ~2990Mi. 3Gi clears the measured peak by ~11% while staying under the 3200Mi
-  # declared limit, so the VPA can still size these pods down, just not into the
-  # range that kills them.
-  mitlearn:webapp_vpa_min_allowed_memory: 3Gi
+  # Raised again 2026-08-07, 3Gi -> 3.5Gi. The 3Gi floor (peak RSS 2774Mi + ~11%,
+  # see git history for that calibration) got eaten within ~10 days: PR #5303
+  # (2026-08-06) raised the webapp CPU request 500m->1200m to fix an inert KEDA
+  # trigger that was pegging the HPA at max_replicas=30. That fix was correct on
+  # its own terms, but it also means the same real CPU usage reads as lower
+  # utilization, so the HPA now legitimately runs fewer replicas (observed
+  # kube_horizontalpodautoscaler_status_current_replicas dropped from oscillating
+  # 12-30 to oscillating 5-17). The same total traffic lands on ~half as many
+  # pods, raising per-pod concurrency and per-pod RSS -- container working set
+  # was observed hitting 3045-3069Mi against the 3072Mi (3Gi) floor within a day
+  # of that deploy, restarts/OOMKills resumed. 3.5Gi clears the newly-observed
+  # peak (~3069Mi) by ~14% -- more margin than the previous fix, since this
+  # margin has now been eaten twice. See
+  # les-root-cause-found-mit-learn-s-aug-6-cpu-request-b-cfebf0 (witan) for the
+  # full investigation. Still well under the 4Gi max_allowed ceiling, so the VPA
+  # retains downward room.
+  mitlearn:webapp_vpa_min_allowed_memory: 3.5Gi
   # Raised from the 500m default (memory stays 3200Mi via the merge in
   # __main__.py). granian runs 2 workers x 2 threads with no CPU limit, so 500m
   # read as 95-116% utilization under normal load and pegged the HPA at

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1527,21 +1527,28 @@ mitlearn_k8s_app = OLApplicationK8s(
         application_arg_array=["/tmp/uwsgi.ini"],  # noqa: S108
         granian_config=GranianConfig(
             workers=2,
-            # Sized against the VPA *floor* (3Gi in production), not the declared
+            # Sized against the VPA *floor* (3.5Gi in production), not the declared
             # 3200Mi limit, because the floor is the smallest limit a pod can be
             # running under and therefore the one the cap has to beat. The component's
             # own floor(limit/workers*0.9) would give 1440, leaving the worker pair at
-            # 2880Mi with almost nothing left for the master under a 3072Mi floor.
+            # 2880Mi with almost nothing left for the master under the floor.
             #
-            # 2*1350 = 2700Mi bounds the pair below the 2774Mi peak container RSS
-            # measured over 14 days, leaving ~370Mi for the master and transient
-            # overshoot. The previous value of 1080 sat *below* the ~1300Mi a worker
-            # legitimately reaches at peak, so it fired during normal operation --
-            # graceful respawns as steady-state behaviour rather than a runaway guard.
+            # Raised again 2026-08-07, 1350 -> 1500. The previous 1350 (pair 2700Mi,
+            # ~370Mi margin under a 3Gi floor) was sized against a 2774Mi peak that
+            # was itself measured while the fleet was over-scaled (HPA pegged near
+            # max_replicas by an inert KEDA trigger, spreading traffic thin). PR #5303
+            # fixed that trigger, the HPA settled into a much smaller replica range,
+            # and the same total traffic concentrating onto fewer pods pushed
+            # container RSS to 3045-3069Mi within a day -- eating the margin and
+            # reviving the OOMKills. 2*1500 = 3000Mi leaves ~580Mi under the new 3.5Gi
+            # floor for the master and transient overshoot, sized with more headroom
+            # than before since this margin has now been eaten twice. See
+            # les-root-cause-found-mit-learn-s-aug-6-cpu-request-b-cfebf0 (witan) for
+            # the full investigation.
             #
             # Coupled to `workers` and to the VPA floor: both must be revisited
             # together. Dropping to workers=1 without resizing this would cap the sole
-            # worker at 1350Mi of a 3Gi pod. See the stage 4 task in
+            # worker at 1500Mi of a 3.5Gi pod. See the stage 4 task in
             # docs/plans/granian-configuration-overhaul.md.
             #
             # This is one value across all stacks, while the VPA floor it is sized
@@ -1549,11 +1556,11 @@ mitlearn_k8s_app = OLApplicationK8s(
             # the protection gap it looks like: a cap only guards anything when
             # 2*cap + master fits under the running limit, and no cap derived from
             # the 3200Mi declared limit fits under a VPA floor of 256Mi. Below a
-            # ~2300Mi limit the cap is inert at 1080 and at 1350 alike, so CI/QA are
-            # no worse off than before. Making it genuinely track the limit the
+            # ~2300Mi limit the cap is inert at 1080, 1350 and 1500 alike, so CI/QA
+            # are no worse off than before. Making it genuinely track the limit the
             # kernel enforces needs a runtime cgroup read, not a synth-time constant
             # -- tracked as tk-evaluate-runtime-cgroup-derived-workers-max-rss.
-            workers_max_rss=1350,
+            workers_max_rss=1500,
             enable_metrics=True,
             interface="asginl",
             backlog=None,

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1535,10 +1535,10 @@ mitlearn_k8s_app = OLApplicationK8s(
             #
             # Raised again 2026-08-07, 1350 -> 1500. The previous 1350 (pair 2700Mi,
             # ~370Mi margin under a 3Gi floor) was sized against a 2774Mi peak that
-            # was itself measured while the fleet was over-scaled (HPA pegged near
-            # max_replicas by an inert KEDA trigger, spreading traffic thin). PR #5303
-            # fixed that trigger, the HPA settled into a much smaller replica range,
-            # and the same total traffic concentrating onto fewer pods pushed
+            # was itself measured while the fleet was over-scaled (the two inert Prometheus
+            # triggers left the undersized-request CPU trigger pegging the HPA near
+            # max_replicas and spreading traffic thin). PR #5303 raised the CPU request, so
+            # the HPA settled into a much smaller replica range,
             # container RSS to 3045-3069Mi within a day -- eating the margin and
             # reviving the OOMKills. 2*1500 = 3000Mi leaves ~580Mi under the new 3.5Gi
             # floor for the master and transient overshoot, sized with more headroom


### PR DESCRIPTION
### What are the relevant tickets?

N/A — tracked in witan as `tk-re-investigate-mit-learn-webapp-oomkilling-recur-806041`, follow-up to #5142.

### Description (What does it do?)

The `mitlearn-app` webapp container is OOMKilling in production again, ~10 days after #5142 fixed the same symptom. **The cause this time is a side effect of a separate, correct fix**, not a regression of #5142's change.

#### Root cause

#5142 (merged 2026-07-28) raised `webapp_vpa_min_allowed_memory` 256Mi→3Gi and `workers_max_rss` 1080→1350, sized against a 2774Mi peak container RSS measured over the prior 14 days. It worked immediately — restarts fell from 89/week to near zero for about 8 days.

#5303 (merged 2026-08-06) separately raised the webapp CPU request 500m→1200m, to fix a real bug: two of the webapp's KEDA Prometheus triggers are inert, leaving CPU utilization as the only working scale-up signal, and at 500m it read 95-116% utilization under normal load, pegging the HPA at `max_replicas=30` for long stretches. That fix is correct and should not be reverted.

Its side effect: the same real CPU usage now reads as a lower utilization percentage, so the HPA legitimately computes it needs fewer replicas. `kube_horizontalpodautoscaler_status_current_replicas{horizontalpodautoscaler="keda-hpa-mitlearn-webapp-scaledobject"}` over the 48h to 2026-08-07 shows replicas dropping from oscillating 12–30 to oscillating 5–17, starting almost exactly at the #5303 deploy window (pod start times cluster 2–18.5h before the investigation). The same total production traffic landing on roughly half as many pods raises per-pod concurrency and, with it, per-pod memory footprint — container working set was observed hitting 3045–3069Mi against the still-3072Mi (3Gi) VPA floor within about a day of that deploy, and OOMKills/restarts resumed (32 in the latest 1-day window, spread across the fleet — same "not one crash-looping pod" shape as the original incident).

The #5142 baseline (2774Mi) was measured while the fleet was artificially over-scaled by the KEDA bug, spreading traffic — and therefore per-pod memory pressure — thin across more pods than necessary. Fixing that bug was correct on its own terms; it also unmasked a per-pod memory budget that was already close to the edge.

#### The fix

Raise both values again, with more headroom than last time since this margin has now been eaten twice:

- `webapp_vpa_min_allowed_memory`: 3Gi → 3.5Gi (production only). Clears the newly observed ~3069Mi peak by ~14%, still comfortably under the 4Gi `max_allowed` ceiling so the VPA retains downward room.
- `workers_max_rss`: 1350 → 1500. `2*1500 = 3000Mi` leaves ~580Mi under the new 3.5Gi floor for the master process and transient overshoot, versus ~370Mi previously.

Full investigation, PromQL queries, and evidence recorded in witan lessons `les-mit-learn-webapp-oomkilling-has-recurred-in-prod-32735c` and `les-root-cause-found-mit-learn-s-aug-6-cpu-request-b-cfebf0`.

### How can this be tested?

`pulumi preview --stack Production` (with `MIT_LEARN_DOCKER_TAG` set to the currently deployed tag) reports exactly the two intended changes plus one pre-existing, unrelated drift already on main (a Fastly `ServiceVcl` gzip content-type/extension list reordering — same as the pre-existing drift #5142 documented):

```
    ~ kubernetes:apps/v1:Deployment: (update)
        [id=mitlearn/mitlearn-app]
      ~ spec: { ~ template: { ~ spec: { ~ containers: [ ~ [1]: { ~ args: [
                                  ~ [12]: "1350" => "1500"
                                ]

    ~ kubernetes:autoscaling.k8s.io/v1:VerticalPodAutoscaler: (update)
        [id=mitlearn/mitlearn-app-memory-vpa]
      ~ spec: { ~ resourcePolicy: { ~ containerPolicies: [ ~ [0]: {
                          ~ minAllowed: { ~ memory: "3Gi" => "3.5Gi"
```

`pre-commit` (ruff format, ruff check, mypy, yamllint, detect-secrets) clean.

**After deploy**, the signal is the same as #5142 — restarts and OOMKills should fall back toward zero, and `container_memory_working_set_bytes` should stay meaningfully below the new 3.5Gi floor rather than sawtoothing up against it:

```promql
sum(increase(kube_pod_container_status_restarts_total{namespace="mitlearn", container="mitlearn-app"}[1d]))
max(container_memory_working_set_bytes{namespace="mitlearn", container="mitlearn-app"}) / 1024/1024
```

Also worth re-checking `kube_horizontalpodautoscaler_status_current_replicas` for the webapp scaled object a few days out, to confirm it has settled rather than still trending down (which would erode this margin again).

### Additional Context

- **Cluster cost.** Raising the floor increases the VPA-set request/limit per replica, but the #5303 fix has also roughly halved the replica count the HPA runs at any given traffic level, so the aggregate memory footprint is likely similar to or lower than before that change, not strictly additive on top of it.
- **This is the second consecutive fix to the same symptom.** If a third recurrence happens, it's worth reconsidering whether a fixed-margin, measured-peak sizing approach is sustainable for this app at all, versus something that tracks demand more directly (tracked separately as `tk-evaluate-runtime-cgroup-derived-workers-max-rss`).
- **Blocks stage 4 of the Granian configuration overhaul** (`tk-stage-4-granian-tuning-for-the-async-apps-mit-le-8cb616`, dropping mit_learn from `workers=2` to `workers=1`) — that change should not land on top of an already-tight per-pod memory budget.