### PR TITLE
fix(mit_learn): reference the mit_learn_sentry_dsn stack output

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -411,7 +411,7 @@ mitlearn_vault_static_secrets = vault.generic.Secret(
     path=mitlearn_vault_mount.path.apply("{}/secrets".format),
     data_json=Output.all(
         qdrant_api_key=qdrant_api_key.key,
-        sentry_dsn=sentry_stack.require_output("open_next_sentry_dsn"),
+        sentry_dsn=sentry_stack.require_output("mit_learn_sentry_dsn"),
     ).apply(
         lambda args: json.dumps(
             {


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/ol-infrastructure/issues/5004 — fixes a bug merged in https://github.com/mitodl/ol-infrastructure/pull/5226

### Description (What does it do?)
`applications/mit_learn/__main__.py` reads the Sentry DSN via `sentry_stack.require_output("open_next_sentry_dsn")`, but no such output exists. Per `infrastructure/sentry/IMPORT_SUMMARY.md`, the live `open-next` Sentry project was renamed to `mit-learn` during the config import without renaming the Pulumi resource identifiers, and the hand-added export is:

```python
pulumi.export(
    "mit_learn_sentry_dsn",
    key_open_next_default_8131564a9b9e31ac3cbcf7952f0fea80.dsn_public,
)
```

So `require_output` currently fails at preview/up time for the mit_learn stack on main. This renames the reference to the output that actually exists. It resolves to the same open-next key, so there is no change in which DSN is used.

The same bug is fixed for the frontend in #5227 — the `mit_learn` Django backend and `mit_learn_nextjs` intentionally share this one Sentry project.

### How can this be tested?
- `pre-commit run --files src/ol_infrastructure/applications/mit_learn/__main__.py` (ruff + mypy pass)
- `pulumi preview` against a mit_learn stack should now resolve the stack reference instead of erroring on the missing output, and show no resource changes beyond the `sentry_dsn` field.

### Additional Context
Audited every merged `require_output("*_sentry_dsn")` reference under `applications/` against the exports on main — this was the only broken one. `dagster`, `learn_ai`, `mitxonline`, `ocw_studio`, `ol_analytics_api`, `xpro`, and all four `edxapp` deployments resolve correctly.

Requires the `ol-infrastructure-sentry` `Production` stack to have been deployed, same as the rest of #5004.