### PR TITLE
fix(sentry): point DSN consumers at renamed 'default' stack

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/__main__.py
+++ b/src/ol_infrastructure/applications/edxapp/__main__.py
@@ -100,7 +100,7 @@ kms_stack = make_stack_reference(projects.KMS, stack_info.name)
 vault_stack = make_stack_reference(
     projects.VAULT_SERVER, f"operations.{stack_info.name}"
 )
-sentry_stack = make_stack_reference(projects.SENTRY, "Production")
+sentry_stack = make_stack_reference(projects.SENTRY, "default")
 # Each edxapp deployment maps to its own Sentry project; mitx and
 # mitx-staging share the openedx-residential project.
 EDXAPP_SENTRY_DSN_OUTPUTS = {

--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -110,7 +110,7 @@ monitoring_stack = make_stack_reference(projects.MONITORING, "default")
 network_stack = make_stack_reference(projects.NETWORKING, stack_info.name)
 opik_stack = make_stack_reference(projects.OPIK, stack_info.name)
 policy_stack = make_stack_reference(projects.POLICIES, "default")
-sentry_stack = make_stack_reference(projects.SENTRY, "Production")
+sentry_stack = make_stack_reference(projects.SENTRY, "default")
 vault_stack = make_stack_reference(
     projects.VAULT_SERVER, f"operations.{stack_info.name}"
 )

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -137,7 +137,7 @@ ocw_site_buckets = ocw_site_stack.require_output("ocw_site_buckets")
 qdrant_cloud_stack = make_stack_reference(
     projects.QDRANT_CLOUD, f"mitlearn.{stack_info.name}"
 )
-sentry_stack = make_stack_reference(projects.SENTRY, "Production")
+sentry_stack = make_stack_reference(projects.SENTRY, "default")
 
 qdrant_secrets = read_yaml_secrets(Path("qdrant_cloud/account.yaml"))
 qdrant_provider = qdrant_cloud.Provider(
@@ -411,7 +411,7 @@ mitlearn_vault_static_secrets = vault.generic.Secret(
     path=mitlearn_vault_mount.path.apply("{}/secrets".format),
     data_json=Output.all(
         qdrant_api_key=qdrant_api_key.key,
-        sentry_dsn=sentry_stack.require_output("open_next_sentry_dsn"),
+        sentry_dsn=sentry_stack.require_output("mit_learn_sentry_dsn"),
     ).apply(
         lambda args: json.dumps(
             {

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
@@ -35,7 +35,7 @@ from ol_infrastructure.lib.pulumi_helper import (
 stack_info = parse_stack()
 
 cluster_stack = make_stack_reference(projects.EKS, f"applications.{stack_info.name}")
-sentry_stack = make_stack_reference(projects.SENTRY, "Production")
+sentry_stack = make_stack_reference(projects.SENTRY, "default")
 MIT_LEARN_NEXTJS_DOCKER_TAG = get_docker_image_tag("MIT_LEARN_NEXTJS")
 
 app_image = ecr_image_uri(

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -125,7 +125,7 @@ network_stack = make_stack_reference(projects.NETWORKING, stack_info.name)
 apps_vpc = network_stack.require_output("applications_vpc")
 data_vpc = network_stack.require_output("data_vpc")
 k8s_pod_subnet_cidrs = apps_vpc["k8s_pod_subnet_cidrs"]
-sentry_stack = make_stack_reference(projects.SENTRY, "Production")
+sentry_stack = make_stack_reference(projects.SENTRY, "default")
 operations_vpc = network_stack.require_output("operations_vpc")
 mitxonline_environment = f"mitxonline-{stack_info.env_suffix}"
 

--- a/src/ol_infrastructure/applications/ocw_studio/__main__.py
+++ b/src/ol_infrastructure/applications/ocw_studio/__main__.py
@@ -94,7 +94,7 @@ network_stack = make_stack_reference(projects.NETWORKING, stack_info.name)
 vault_stack = make_stack_reference(
     projects.VAULT_SERVER, f"operations.{stack_info.name}"
 )
-sentry_stack = make_stack_reference(projects.SENTRY, "Production")
+sentry_stack = make_stack_reference(projects.SENTRY, "default")
 apps_vpc = network_stack.require_output("applications_vpc")
 data_vpc = network_stack.require_output("data_vpc")
 operations_vpc = network_stack.require_output("operations_vpc")

--- a/src/ol_infrastructure/applications/open_discussions/__main__.py
+++ b/src/ol_infrastructure/applications/open_discussions/__main__.py
@@ -27,7 +27,7 @@ from ol_infrastructure.lib.vault import setup_vault_provider
 stack_info = parse_stack()
 setup_vault_provider(stack_info, skip_child_token=True)
 setup_heroku_provider()
-sentry_stack = make_stack_reference(projects.SENTRY, "Production")
+sentry_stack = make_stack_reference(projects.SENTRY, "default")
 
 mit_open_config = Config("mit_open")
 heroku_config = Config("heroku")

--- a/src/ol_infrastructure/applications/xpro/__main__.py
+++ b/src/ol_infrastructure/applications/xpro/__main__.py
@@ -111,7 +111,7 @@ operations_vpc = network_stack.require_output("operations_vpc")
 vault_stack = make_stack_reference(
     projects.VAULT_SERVER, f"operations.{stack_info.name}"
 )
-sentry_stack = make_stack_reference(projects.SENTRY, "Production")
+sentry_stack = make_stack_reference(projects.SENTRY, "default")
 aws_config = AWSBase(
     tags={
         "OU": "mitxpro",


### PR DESCRIPTION
### What are the relevant tickets?

Follow-up fix for https://github.com/mitodl/ol-infrastructure/issues/5004 (does not close it — the micromasters / unified_ecommerce / odl_video_service items there are still outstanding).

Repairs the PRs merged for that issue: #5224, #5225, #5226, #5227, #5228, #5229, #5230, #5231.

### Description (What does it do?)

**1. Stale Sentry stack name (8 files).**

The Sentry Pulumi stack was renamed from `Production` to `default` in f1b2075e5 (#5312). That rename landed *before* the #5004 DSN migration PRs merged, so every migrated app shipped a reference to a stack name that no longer existed. Affected stacks fail at preview/deploy with:

```
pulumi:pulumi:StackReference (organization/ol-infrastructure-sentry/Production):
  error: unknown stack "organization/ol-infrastructure-sentry/Production"
```

Observed on the edxapp CI pipeline: https://cicd.odl.mit.edu/teams/infrastructure/pipelines/dagger-pulumi-edxapp-global/jobs/deploy-ol-infrastructure-edxapp-application.mitx-mitx.ci/builds/310

Changed `make_stack_reference(projects.SENTRY, "Production")` to `"default"` in edxapp, learn_ai, mit_learn, mit_learn_nextjs, mitxonline, ocw_studio, open_discussions, and xpro. The two pre-existing consumers (dagster, ol_analytics_api) already used `default` and were unaffected — all ten call sites are now consistent.

**2. Output name that is exported nowhere (mit_learn).**

`mit_learn` requested the stack output `open_next_sentry_dsn`, which is not exported by the Sentry stack. The export backed by that same `open-next` Sentry key is named `mit_learn_sentry_dsn` — the output `mit_learn_nextjs` already consumes. The two apps intentionally share that Sentry project, so both now read the same output.

This second bug was masked by the first: `mit_learn` never got far enough to fail on the output name. It would have surfaced as a fresh failure immediately after the stack-name fix.

Note that a Pulumi stack rename does **not** require renaming stack outputs — only the references to the stack. No `pulumi.export(...)` calls were changed.

### How can this be tested?

Confirmed the deployed stack exposes 16 outputs and that all 12 `sentry_stack.require_output(...)` names across the repo resolve against them, with zero missing (this includes the four names reached indirectly through edxapp's `EDXAPP_SENTRY_DSN_OUTPUTS` map):

```
cd src/ol_infrastructure/infrastructure/sentry && pulumi stack output --json
```

`pulumi preview -s mitx.CI` in `src/ol_infrastructure/applications/edxapp` now gets past the Sentry `StackReference` that previously errored, and plans the expected DSN write:

```
~  vault:generic:Secret edxapp-static-secrets update [diff: ~dataJson]
```

It then stops at `OSError: Environment variable EDXAPP_DOCKER_IMAGE_DIGEST is not set`, which is supplied by the Concourse pipeline and is expected when previewing locally.

`pre-commit run --files <changed>` passes clean, including ruff format, ruff check, and mypy.

### Additional Context

The Sentry stack itself has already been deployed with these outputs in place, so these app stacks should pick up the DSNs as soon as their pipelines run.

Reviewer note on the `mit_learn` output choice: the alternative fix would be adding an `open_next_sentry_dsn` export aliasing the same key. Pointing `mit_learn` at the existing `mit_learn_sentry_dsn` was preferred to avoid two export names for one DSN. Happy to switch if the other direction is preferred.