### PR TITLE
fix(eks): size cluster-wide informer caches for pod count, not workload count

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/eks/aws_utils.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/aws_utils.py
@@ -343,14 +343,35 @@ def setup_aws_integrations(
                 "region": aws.get_region().name,
                 "podLabels": k8s_global_labels,
                 "tolerations": operations_tolerations,
+                # Sized for the cold-start Pod informer sync, not steady state.
+                # The controller builds a cluster-wide Pod cache (the "podInfo
+                # repo") for readiness gates and IP targets, so startup has to
+                # decode a LIST of every pod in the cluster before the cache is
+                # trimmed. Trimming keeps steady state cheap -- 66Mi at 4.2k pods
+                # in data-production vs ~30Mi at ~120 elsewhere -- but the
+                # transient during that first LIST is what blew the old 128Mi
+                # ceiling, killing the container one second in at "starting
+                # podInfo repo". Only cold starts failed, so the pod that synced
+                # before a dagster burst survived while every replacement
+                # CrashLooped, leaving the deployment one replica deep for days.
+                # That matters because mservice/mtargetgroupbinding are
+                # failurePolicy: Fail with no namespace selector: losing the last
+                # replica blocks Service and TargetGroupBinding admission
+                # cluster-wide, and a replacement cannot cold start to fix it.
                 "resources": {
                     "requests": {
                         "cpu": "25m",
-                        "memory": "128Mi",
+                        "memory": "256Mi",
                     },
                     "limits": {
-                        "memory": "128Mi",
+                        "memory": "1Gi",
                     },
+                },
+                # Soft limit ~90% of limits.memory so the Go runtime collects
+                # hard through the initial LIST instead of the cgroup OOMKiller
+                # winning. This chart takes env as a map, not a list.
+                "env": {
+                    "GOMEMLIMIT": "900MiB",
                 },
             },
             skip_await=False,

--- a/src/ol_infrastructure/infrastructure/aws/eks/external_dns.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/external_dns.py
@@ -135,8 +135,10 @@ def setup_external_dns(
                 },
                 "logLevel": "info",
                 "policy": "sync",
-                # Configure external-dns to only look at gateway resources
-                # disables support for monitoring services or legacy ingress resources
+                # Gateway API resources plus "service" -- the latter is load
+                # bearing: it publishes the apisix-gateway LoadBalancer hostnames
+                # carried on external-dns.alpha.kubernetes.io/hostname. Legacy
+                # ingress is intentionally absent.
                 "sources": [
                     "service",
                     "gateway-udproute",
@@ -149,20 +151,31 @@ def setup_external_dns(
                 "txtOwnerId": cluster_name,
                 # Limit the dns zones that external dns knows about
                 "domainFilters": eks_config.require_object("allowed_dns_zones"),
-                # request == limit leaves zero burst headroom: data-qa sat at
-                # 127.6Mi against the 128Mi ceiling and OOMKilled. Memory here
-                # scales with the number of Route53 records external-dns tracks,
-                # which grows as gateway routes are added, so the limit is set to
-                # 2x the request rather than matching it.
+                # Memory scales with cluster-wide POD COUNT, not with the number
+                # of DNS records. The "service" source above builds a Pod informer
+                # (needed to resolve headless services), so external-dns caches
+                # every pod in the cluster -- including completed Job pods.
+                # Measured steady state: ~30Mi at ~120 pods, ~92Mi at 1.3k pods,
+                # ~290Mi at 8.2k pods. data-production blew the old 256Mi ceiling
+                # and CrashLooped when a dagster burst added ~6.2k Job pods in an
+                # hour; those linger for ttlSecondsAfterFinished=24h, so the
+                # ceiling has to absorb a full day of job churn, not a steady state.
+                # GOMEMLIMIT (below) makes Go collect hard as it approaches the
+                # limit instead of getting OOMKilled outright.
                 "resources": {
                     "requests": {
-                        "memory": "128Mi",
+                        "memory": "256Mi",
                         "cpu": "10m",
                     },
                     "limits": {
-                        "memory": "256Mi",
+                        "memory": "1Gi",
                     },
                 },
+                "env": [
+                    # Soft limit ~90% of limits.memory: the Go runtime GCs more
+                    # aggressively rather than letting the cgroup OOMKiller win.
+                    {"name": "GOMEMLIMIT", "value": "900MiB"},
+                ],
             },
         ),
         opts=ResourceOptions(

--- a/src/ol_infrastructure/infrastructure/aws/eks/vpa.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/vpa.py
@@ -40,9 +40,37 @@ def setup_vpa(
     :param versions: A dictionary of component versions keyed by component name.
     :returns: The Helm Release resource, for use as a dependency by VPA objects.
     """
-    # Per-component resource tuning. VPA components are lightweight control-plane
-    # processes; these limits are conservative starting points and can be adjusted
-    # once real-world usage is observed via VPA recommendations on VPA itself.
+    # Per-component resource tuning, sized from measured usage rather than the
+    # earlier guess that these are "lightweight control-plane processes".
+    #
+    # All three components hold cluster-wide informer caches, so memory scales
+    # with POD COUNT -- including completed Job pods, which VPA never scales but
+    # still caches. Measured RSS:
+    #
+    #   pods    recommender  updater  admission
+    #   ~123     25Mi         23Mi     17Mi
+    #    409     91Mi         77Mi     36Mi
+    #   1250    156Mi         80Mi     64Mi
+    #   8536    543Mi        192Mi    176Mi
+    #
+    # data-production runs ~8.5k pods because dagster Job pods are retained for
+    # ttlSecondsAfterFinished=24h, and it paged on all three: the recommender
+    # OOMKilled against the old 500Mi ceiling (it died ~7s in, before its Pod
+    # informer finished syncing), the updater OOMKilled against 200Mi, and the
+    # admission controller was sitting at 176Mi of a 200Mi limit -- the next
+    # page waiting to happen. external-dns failed the same way and for the same
+    # reason; see setup_external_dns.
+    #
+    # Requests are held near their previous values so scheduling and reserved
+    # capacity on the small clusters barely move; the ceilings are what needed
+    # raising. Deliberately no longer request == limit: Guaranteed QoS buys
+    # eviction protection but leaves zero burst headroom, and an OOMKill is a
+    # certain outage where node-pressure eviction is a rare and recoverable one.
+    #
+    # GOMEMLIMIT (~90% of each limit) makes the Go runtime collect harder as it
+    # approaches the ceiling instead of being OOMKilled outright. The chart only
+    # plumbs extraEnv into the recommender and admission controller, so the
+    # updater cannot get one -- its headroom comes from the limit alone.
     return kubernetes.helm.v3.Release(
         f"{cluster_name}-vpa-helm-release",
         kubernetes.helm.v3.ReleaseArgs(
@@ -60,10 +88,14 @@ def setup_vpa(
                     "enabled": True,
                     "replicas": 2,
                     "tolerations": operations_tolerations,
+                    # Peak observed 176Mi at 8.5k pods, against a 200Mi ceiling.
                     "resources": {
-                        "requests": {"cpu": "50m", "memory": "200Mi"},
-                        "limits": {"memory": "200Mi"},
+                        "requests": {"cpu": "50m", "memory": "256Mi"},
+                        "limits": {"memory": "512Mi"},
                     },
+                    "extraEnv": [
+                        {"name": "GOMEMLIMIT", "value": "460MiB"},
+                    ],
                     # certGen (the chart default) is the preferred TLS strategy.
                     # A pre-install hook job creates the vpa-tls-certs Secret
                     # (self-signed CA + cert/key), Helm creates the
@@ -84,10 +116,16 @@ def setup_vpa(
                     "enabled": True,
                     "replicas": 1,
                     "tolerations": operations_tolerations,
+                    # Heaviest of the three: it keeps usage histograms and
+                    # checkpoints on top of the informer caches. Peak observed
+                    # 543Mi at 8.5k pods, against a 500Mi ceiling.
                     "resources": {
-                        "requests": {"cpu": "50m", "memory": "500Mi"},
-                        "limits": {"memory": "500Mi"},
+                        "requests": {"cpu": "50m", "memory": "512Mi"},
+                        "limits": {"memory": "1536Mi"},
                     },
+                    "extraEnv": [
+                        {"name": "GOMEMLIMIT", "value": "1400MiB"},
+                    ],
                 },
                 "updater": {
                     "enabled": True,
@@ -100,9 +138,13 @@ def setup_vpa(
                     # with the cluster-level InPlacePodVerticalScaling gate - do not
                     # set --feature-gates=InPlace=true here, it would silently stop
                     # falling back to eviction when a resize isn't feasible.
+                    # Peak observed 192Mi at 8.5k pods, against a 200Mi ceiling.
+                    # No GOMEMLIMIT available here -- the chart does not plumb
+                    # extraEnv into this component, so the limit is the only
+                    # headroom it gets.
                     "resources": {
-                        "requests": {"cpu": "50m", "memory": "200Mi"},
-                        "limits": {"memory": "200Mi"},
+                        "requests": {"cpu": "50m", "memory": "256Mi"},
+                        "limits": {"memory": "768Mi"},
                     },
                 },
             },

--- a/src/ol_infrastructure/substructure/aws/eks/marimo_operator.py
+++ b/src/ol_infrastructure/substructure/aws/eks/marimo_operator.py
@@ -30,12 +30,18 @@ MARIMO_OPERATOR_MANIFEST_URL = (
 )
 MARIMO_OPERATOR_NAMESPACE = "marimo-operator-system"
 
-# The upstream manifest ships the controller with memory request == limit == 128Mi.
-# That is too tight once the operator is reconciling real notebooks: on data-qa it
-# reached 117.5Mi against the 128Mi cap and entered an OOMKill/CrashLoopBackOff loop
-# that also took the Deployment unavailable. Raising the limit (leaving the upstream
-# request alone) restores burst headroom without over-reserving on the node.
-MARIMO_OPERATOR_MEMORY_LIMIT = "384Mi"
+# The upstream v0.3.0 manifest ships the controller at requests 10m/64Mi and
+# limits 500m/128Mi. That cap is too tight once the operator is reconciling real
+# notebooks: on data-qa it reached 117.5Mi and entered an OOMKill/CrashLoopBackOff
+# loop that also took the Deployment unavailable, which is why this was first
+# raised to 384Mi.
+#
+# 384Mi then failed the same way on data-production. The driver is not notebook
+# count: the controller-runtime cache is cluster-wide, so the operator's memory
+# tracks total pods in the cluster, and data-production retains ~4k completed
+# dagster Job pods. Only the limit is patched -- the upstream request is left
+# alone so this does not reserve capacity the operator never uses at rest.
+MARIMO_OPERATOR_MEMORY_LIMIT = "512Mi"
 
 
 def _patch_controller_memory_limit(doc: dict[str, Any]) -> dict[str, Any]:

--- a/src/ol_infrastructure/substructure/aws/eks/starrocks.py
+++ b/src/ol_infrastructure/substructure/aws/eks/starrocks.py
@@ -120,13 +120,23 @@ def setup_starrocks(
                     "enabled": True,
                     "imagePullPolicy": "IfNotPresent",
                     "replicaCount": 1,
+                    # The operator's controller-runtime cache is cluster-wide by
+                    # default, so its memory tracks total pods in the cluster
+                    # rather than anything about StarRocks. data-production
+                    # retains ~4k completed dagster Job pods, which pushed it
+                    # past the old 512Mi ceiling and left the Deployment
+                    # unavailable. Only limits.memory is set here; the chart
+                    # default supplies limits.cpu (500m) via Helm's deep merge,
+                    # and the requests below deliberately undercut the chart's
+                    # 500m/400Mi so the operator does not reserve capacity it
+                    # never uses at rest.
                     "resources": {
                         "requests": {
                             "cpu": "10m",
                             "memory": "256Mi",
                         },
                         "limits": {
-                            "memory": "512Mi",
+                            "memory": "1Gi",
                         },
                     },
                 },


### PR DESCRIPTION
### What are the relevant tickets?
N/A — came in as a page:

> A deployment external-dns in namespace operations in cluster data-production is not available for an extended period of time.

### Description (What does it do?)

`external-dns` in `data-production` sat in `CrashLoopBackOff` for ~4 hours, OOMKilled about one second into startup — before it could serve `/healthz`:

```
exitCode: 137, reason: OOMKilled
startedAt: 2026-08-07T23:40:27Z → finishedAt: 2026-08-07T23:40:28Z
```

**The old 256Mi ceiling was set on a wrong mental model**, which is preserved in the comment this PR replaces: that memory tracks the number of Route53 records and grows "as gateway routes are added." It doesn't.

The `service` source builds a **cluster-wide Pod informer** (external-dns needs pods to resolve headless services), so it caches *every pod in the cluster*, including completed Job pods. Memory scales with pod count, measured across the fleet:

| cluster | pods | memory |
|---|---:|---:|
| most clusters | ~120 | ~30Mi |
| `applications-production` | 430 | 61Mi |
| `data-qa` | 1,255 | 92Mi |
| **`data-production`** | **8,209** | **290Mi** vs a 256Mi limit |

`data-production` crossed the ceiling when a dagster burst created **6,186 Job pods in the 19:00 hour**; the OOM kill landed at ~20:01. Those pods have `ttlSecondsAfterFinished: 86400`, so they persist for a full day — 8,067 of the cluster's 8,209 pods were completed dagster jobs. It would have kept crashlooping until they aged out.

Changes:

- `requests.memory` 128Mi → **256Mi**, `limits.memory` 256Mi → **1Gi** (~3.5x the observed peak, sized to absorb a full day of job churn rather than a steady state)
- Added **`GOMEMLIMIT=900MiB`** (~90% of the limit) so the Go runtime collects harder as it approaches the ceiling instead of being OOMKilled outright — this turns a future recurrence into a slow pod rather than a page
- Corrected the sizing comment, and a second comment above `sources` that claimed service monitoring was disabled while `service` was in the list

Note that raising the *request* alone does nothing here — that was tried by hand during the incident (request bumped to 192Mi, limit left at 256Mi). The limit is what the OOM killer reads.

This is one shared resources block, so it applies to all 12 stacks.

### How can this be tested?

`pulumi preview --stack data.Production` — exactly one resource changes, no collateral:

```
 ~  kubernetes:helm.sh/v3:Release data-production-external-dns-helm-release update [diff: ~values]

Resources:
    ~ 1 to update
    162 unchanged
```

Full `pre-commit` suite passes on the changed file, including `ruff` and `mypy`. (The one `ruff` D100 on this file pre-dates this change and is present on `main`.)

To verify after apply:

```bash
kubectl --context data-production -n operations rollout status deploy external-dns
kubectl --context data-production -n operations top pod -l app.kubernetes.io/name=external-dns
kubectl --context data-production -n operations logs deploy/external-dns | grep -i "records are already up to date"
```

Service was already restored ahead of this PR by patching the live deployment, and has been stable since:

```
external-dns   1/1   1   1
external-dns-6b5c545c89-4zbzp   2m   274Mi
time="2026-08-07T23:46:53Z" level=info msg="All records are already up to date"
```

---

## Also in this PR: the VPA control plane, same root cause

`data-production` went on to page for `vertical-pod-autoscaler-recommender`, and earlier the same day for `vertical-pod-autoscaler-updater`. Same cluster, same mechanism: the recommender, updater, and admission controller all hold cluster-wide informer caches, so they scale with pod count too.

| pods | recommender | updater | admission |
|---:|---:|---:|---:|
| ~123 | 25Mi | 23Mi | 17Mi |
| 409 | 91Mi | 77Mi | 36Mi |
| 1,250 | 156Mi | 80Mi | 64Mi |
| **8,536** | **543Mi** | **192Mi** | **176Mi** |

Old ceilings were 500Mi / 200Mi / 200Mi — two components over, and the admission controller at 88% and climbing. The recommender OOMKilled 7s in, before its Pod informer finished syncing.

| component | requests | limits | GOMEMLIMIT |
|---|---|---|---|
| recommender | 500Mi → **512Mi** | 500Mi → **1536Mi** | **1400MiB** |
| updater | 200Mi → **256Mi** | 200Mi → **768Mi** | *chart does not support it* |
| admissionController | 200Mi → **256Mi** | 200Mi → **512Mi** | **460MiB** |

Requests barely move, so reserved capacity on the small clusters is essentially unchanged; the ceilings are what grow. This does drop the components from Guaranteed to Burstable QoS — deliberate, and called out for review in [the detailed comment below](https://github.com/mitodl/ol-infrastructure/pull/5326#issuecomment-5223589615), along with the chart limitation that prevents the updater from getting a `GOMEMLIMIT`.

---

## Also in this PR: `aws-load-balancer-controller`, same root cause, quieter failure

Paged on 2026-08-10:

> Container aws-load-balancer-controller in pod aws-load-balancer-controller-6b67784895-jn69f in namespace kube-system in cluster data-production has been OOMKilled and is repeatedly restarting.

Same cluster, same mechanism, third component. The controller builds a cluster-wide Pod cache — the `podInfo repo` — for readiness gates and IP targets. It died one second in, with the cache init as its last log line:

```
{"logger":"setup","msg":"starting podInfo repo"}   ← last line
exitCode: 137, reason: OOMKilled
startedAt: 2026-08-10T14:55:24Z → finishedAt: 2026-08-10T14:55:25Z
```

**Unlike external-dns, the steady state was never the problem.** This controller trims cached Pod objects, so it scales far more gently — the old 128Mi ceiling was fine at rest even at 4.2k pods:

| cluster | pods | controller memory |
|---|---:|---|
| operations-ci | 82 | 26Mi / 30Mi |
| applications-production | 487 | 40Mi / 57Mi |
| **data-production** | **4,200** | **66Mi** (single replica) |

What overruns is the **cold start**: decoding a LIST of all 4,200 pods before the trim applies. 3,938 of those are completed dagster Job pods — the same `ttlSecondsAfterFinished: 86400` driver as above.

### The part the page didn't say

Because only *cold starts* fail, this hid for two days. The surviving replica started `2026-08-07T17:03:13Z` — about two hours **before** the 19:00 dagster burst that started this whole family of pages. It synced its cache cheaply, has held 66Mi since, and every replacement has OOMed on arrival:

```
Available=False   MinimumReplicasUnavailable   since 2026-08-08T15:08:09Z
```

That surviving replica is load-bearing in a way nothing was watching. Two of the mutating webhooks are `failurePolicy: Fail` with an empty `namespaceSelector`:

- `mservice.elbv2.k8s.aws`
- `mtargetgroupbinding.elbv2.k8s.aws`

So if that pod restarts — node rotation, spot interruption, anything — Service and TargetGroupBinding admission is rejected **cluster-wide in data-production**, and no replacement can start, because cold start is precisely what OOMs. It cannot self-heal out of that state.

| | current | proposed |
|---|---|---|
| `requests.memory` | 128Mi | **256Mi** |
| `limits.memory` | 128Mi | **1Gi** |
| `GOMEMLIMIT` | — | **900MiB** |

Note this chart takes `env` as a **map**, not a list like external-dns — verified against `helm template` for chart 3.5.0:

```yaml
- name: GOMEMLIMIT
  value: "900MiB"
```

As with the others this is one shared resources block in `aws_utils.py`, so it applies to all 12 stacks. `pulumi preview --stack data.Production` is clean:

```
 ~  kubernetes:helm.sh/v3:Release data-production-aws-load-balancer-controller-helm-release update [diff: ~values]

Resources:
    ~ 1 to update
    162 unchanged
```

---

## Also in this PR: `starrocks-operator` and `marimo-operator` — codifying a live patch

Two more `data-production` pages on 2026-08-09, both OOMKilled, both already fixed by hand on the cluster:

> A deployment starrocks-operator-operator in namespace starrocks in cluster data-production is not available for an extended period of time.

> A deployment marimo-operator-controller-manager in namespace marimo-operator-system in cluster data-production is not available for an extended period of time.

**This commit does not decide anything — it copies the values already running** so the next `pulumi up` converges instead of reverting them:

| component | `limits.memory` | |
|---|---|---|
| `starrocks-operator` | 512Mi → **1Gi** | `substructure/aws/eks/starrocks.py` |
| `marimo-operator` | 384Mi → **512Mi** | `substructure/aws/eks/marimo_operator.py` |

Same mechanism as the three above. Both operators run a **controller-runtime cache that is cluster-wide by default**, so memory tracks total pods in the cluster — not how many StarRocks clusters or notebooks exist. These were simply the next two ceilings low enough to hit.

### Two things I checked rather than copied

**The `cpu: 500m` limit visible on both live pods is not part of the manual patch** — it's upstream in both cases, so it is deliberately *not* restated in our code. For starrocks, Helm deep-merges the chart's default `limits.cpu` into our partial `resources` block; for marimo it ships in the install manifest. Restating it would have looked like a deliberate choice and drifted the moment upstream changed it.

**The marimo comment was wrong and is corrected, not extended.** It claimed upstream shipped `request == limit == 128Mi`; v0.3.0 actually ships `requests 10m/64Mi` against `limits 500m/128Mi`. It also predated the pod-count diagnosis. Same failure mode #5326 opened with — a stale mental model preserved in a comment.

### Note on scope

This commit touches **`ol-substructure-eks`**, whereas the other three are in **`ol-infrastructure-eks`**. Merging this PR therefore requires applying two stacks, not one. Preview on the new project is clean:

```
 ~ kubernetes:helm.sh/v3:Release  data-production-starrocks-operator-helm-release
                      ~ memory: "512Mi" => "1Gi"
 ~ kubernetes:apps/v1:Deployment  marimo-operator-controller-manager
                      ~ memory: "384Mi" => "512Mi"

Resources:
    ~ 2 to update
    85 unchanged
```

### Worth a follow-up: `starrocks-operator` should not be watching every namespace

The chart documents `watchNamespace` for precisely this situation:

> If your kubernetes cluster manages too many nodes, and the operator watching all namespaces uses too many memory resources, you can set this value.

StarRocks CRs only ever live in the `starrocks` namespace, so scoping the watch would cut this operator's memory rather than raising its ceiling again. I did not include it here because it is a behavioral change, not a match-the-patch change, and the chart warns the cluster must then be deployed into that one namespace. Flagging it as the better long-term fix.

### Additional Context


**The underlying driver is the dagster job pod TTL.** ~8k Job pods/day retained for 24h also loads etcd and every other informer in the cluster. Five components have now paged from this one retention setting. Dropping `ttlSecondsAfterFinished` to ~1–2h would cut external-dns memory roughly 5x. That's a separate change under different ownership; this PR makes all five components resilient either way. Five separate pages from one retention setting is a strong argument for picking that change up next.

**`service` cannot be removed from `sources`**, even though it's the source driving the memory. I verified it's load-bearing — it publishes the `apache-apisix-gateway` LoadBalancer hostnames via `external-dns.alpha.kubernetes.io/hostname` in all four production clusters (e.g. `api.learn.mit.edu`, `courses-backend.mitx.mit.edu`, `opik.ol.mit.edu`). Dropping it would delete those records, and `policy: sync` means that deletion would be real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


