### PR TITLE
Granian stage 2: adopt new concurrency defaults for micromasters and xpro

### DIFF
--- a/docs/plans/granian-configuration-overhaul.md
+++ b/docs/plans/granian-configuration-overhaul.md
@@ -1,6 +1,7 @@
 # Granian configuration overhaul
 
-**Status:** stage 0 merged 2026-07-23 (#5083); stage 1 in review 2026-07-27; stages 2–4 pending
+**Status:** stage 0 merged 2026-07-23 (#5083); stage 1 merged 2026-07-27 (#5135), validated
+in production 2026-08-07; stage 2 in review; stages 3–4 pending
 **Project:** `wp-granian-configuration-overhaul-expose-blocking-t-3debc2`
 **Component:** `src/ol_infrastructure/components/services/k8s.py` — `GranianConfig`
 **Evidence:** witan lessons `les-granianconfig-never-exposes-blocking-threads-bac-874462`,
@@ -226,6 +227,16 @@ Component change lands once; per-app behavior changes as each app's stack is dep
   921MiB, so the cap still fires ahead of the cgroup OOM killer.
 - **Stage 2 — mid traffic.** `micromasters`, `xpro`. Same edit. Health-probe split task
   becomes eligible here.
+
+  Replica pre-raise was evaluated against production and **not** applied. Over the 7 days
+  to 2026-08-10 both webapps sat pinned at `min_replicas=2` — with no scale-down possible
+  from an already-minimum replica count, the scale-down risk the pre-raise guards against
+  doesn't apply regardless of CPU headroom. p95 CPU ≈ 10m/pod for `micromasters` (≈ 4% of
+  its 250m request) and ≈ 62m/pod for `xpro` (≈ 25% of its 250m request); zero container
+  restarts for either app over the same window. Peak working set — ≈ 928MiB of a 2000Mi
+  limit (`micromasters`) and ≈ 1236MiB of a 2Gi limit (`xpro`) — stays under the new
+  single-worker RSS caps of 1800MiB and 1843MiB, so the cap still fires ahead of the
+  cgroup OOM killer.
 - **Stage 3 — high traffic.** `mitxonline` (plus removal of the ceiling-based
   `workers_max_rss` override), then `edxapp` LMS and CMS separately — CMS first, it takes
   far less traffic than LMS.

--- a/src/ol_infrastructure/applications/micromasters/__main__.py
+++ b/src/ol_infrastructure/applications/micromasters/__main__.py
@@ -858,17 +858,9 @@ micromasters_k8s_app = OLApplicationK8s(
         **docker_image_config_kwargs("MICROMASTERS"),
         granian_config=GranianConfig(
             application_module="micromasters.wsgi:application",
-            # Holding pins: preserve the pre-overhaul effective concurrency until
-            # this app's stage of the rollout. Granian derived backpressure=64
-            # (backlog=128 // workers=2) and blocking_threads=64 // 2 = 32.
-            # Delete all five to adopt the component defaults (1 worker, 8
-            # blocking threads, 16 backpressure).
-            # See docs/plans/granian-configuration-overhaul.md
-            workers=2,
-            runtime_mode="mt",
-            runtime_threads=2,
-            blocking_threads=32,
-            backpressure=64,
+            # Stage 2 of docs/plans/granian-configuration-overhaul.md: holding pins
+            # removed, so this app now runs on the component defaults (1 worker, 8
+            # blocking threads, 16 backpressure, runtime defaults).
             blocking_threads_idle_timeout=120,
             enable_metrics=True,
         ),

--- a/src/ol_infrastructure/applications/xpro/__main__.py
+++ b/src/ol_infrastructure/applications/xpro/__main__.py
@@ -545,17 +545,9 @@ if k8s_deploy:
             **docker_image_config_kwargs("XPRO"),
             granian_config=GranianConfig(
                 application_module="mitxpro.wsgi:application",
-                # Holding pins: preserve the pre-overhaul effective concurrency
-                # until this app's stage of the rollout. Granian derived
-                # backpressure=64 (backlog=128 // workers=2) and
-                # blocking_threads=64 // 2 = 32. Delete all five to adopt the
-                # component defaults (1 worker, 8 blocking threads, 16
-                # backpressure). See docs/plans/granian-configuration-overhaul.md
-                workers=2,
-                runtime_mode="mt",
-                runtime_threads=2,
-                blocking_threads=32,
-                backpressure=64,
+                # Stage 2 of docs/plans/granian-configuration-overhaul.md: holding
+                # pins removed, so this app now runs on the component defaults (1
+                # worker, 8 blocking threads, 16 backpressure, runtime defaults).
                 blocking_threads_idle_timeout=120,
                 enable_metrics=True,
             ),


### PR DESCRIPTION
### What are the relevant tickets?
N/A — tracked via internal workflow project `wp-granian-configuration-overhaul-expose-blocking-t-3debc2`, stage 2 of the plan at [`docs/plans/granian-configuration-overhaul.md`](https://github.com/mitodl/ol-infrastructure/blob/main/docs/plans/granian-configuration-overhaul.md).

### Description (What does it do?)
Stage 2 of the Granian concurrency overhaul: deletes the holding-pin `GranianConfig` block from `micromasters` and `xpro`, letting both adopt the component's new defaults (landed in #5083, piloted in #5135).

Effective per-pod change for both apps:

| Setting | Before | After |
|---|---|---|
| `workers` | 2 | 1 |
| `runtime_mode` | `"mt"` | `None` (auto) |
| `runtime_threads` | 2 | 1 |
| `blocking_threads` | 32 | 8 |
| `backpressure` | 64 | 16 |
| `workers-max-rss` (micromasters) | 900 MiB | 1800 MiB |
| `workers-max-rss` (xpro) | 921 MiB | 1843 MiB |

`workers-max-rss` roughly doubles for both apps because it's derived as 90% of *one* worker's share of an unchanged container memory limit, instead of two workers' shares.

Stage 1 (#5135, `ocw_studio` + `odl_video_service`) validated clean in production for 11 days: zero container restarts, zero OOMKills, no HPA scale-down, and RSS caps sitting comfortably under the new single-worker ceilings.

**Replica pre-raise:** evaluated against production and not applied. Both `micromasters` and `xpro` webapps are pinned at `min_replicas=2` already (7 days to 2026-08-10), so there's no room to scale further down regardless of CPU headroom — the scale-down risk the pre-raise guards against doesn't apply. p95 CPU is ~10m/pod for `micromasters` (~4% of its 250m request) and ~62m/pod for `xpro` (~25% of its 250m request), with zero container restarts for either app over the same window. Peak working set (~928MiB of 2000Mi for `micromasters`, ~1236MiB of 2Gi for `xpro`) stays well under the new single-worker RSS caps, so the cap still fires ahead of the cgroup OOM killer.

Full before/after evidence recorded in [`docs/plans/granian-configuration-overhaul.md`](https://github.com/mitodl/ol-infrastructure/blob/main/docs/plans/granian-configuration-overhaul.md), which this PR also updates.

### Screenshots (if appropriate):
N/A — no UI changes.

### How can this be tested?
- `uv run pre-commit run --files src/ol_infrastructure/applications/micromasters/__main__.py src/ol_infrastructure/applications/xpro/__main__.py docs/plans/granian-configuration-overhaul.md` — passes (ruff, mypy, etc.)
- `uv run pytest tests/ol_infrastructure/components/services/` — 110 passed
- `pulumi preview` on both CI stacks confirms the only webapp Deployment diff is the granian container's `args` (plus incidental image-tag/digest churn from previewing with a tag instead of a digest, unrelated to this change) — no Service/HPA/PodMonitor/ConfigMap churn.

Reviewer validation: after merge, deploy CI → QA → production for both apps, in that order, and hold ≥ 3 business days at production before stage 3 (`mitxonline`, `edxapp`) becomes eligible. Watch the same signals as stage 1: granian request duration p50/p95/p99, nginx/APISIX 5xx rate (especially 502/504), pod CPU vs request, HPA `currentReplicas`, OOMKill/restart counts (workers-max-rss respawns should appear in granian logs before any OOMKill), and pod ready time.

### Additional Context
Component-level changes and the stage 1 pilot are already merged and validated; this is a pure "delete the per-app holding pin" change with no component code touched. Rollback is reverting this PR and redeploying — the change is entirely container args, no data/schema migration to unwind.