### PR TITLE
Audit the access model: 27 grant shapes, 80 direct grants, one silent CODEOWNERS failure

### DIFF
--- a/bin/github-estate-audit
+++ b/bin/github-estate-audit
@@ -204,7 +204,9 @@ def drift(
     return 1 if total else 0
 
 
-def _fetch_rosters() -> tuple[dict[str, set[str]], set[str], dict[str, str | None]]:
+def _fetch_rosters() -> tuple[
+    dict[str, set[str]], set[str], dict[str, str | None], set[str]
+]:
     """Team rosters, org members and team nesting, read live from the API.
 
     NOT read from committed data, and not cached to disk, because there is nowhere
@@ -241,6 +243,12 @@ def _fetch_rosters() -> tuple[dict[str, set[str]], set[str], dict[str, str | Non
         follow_redirects=True,
     ) as client:
         members = {m["login"] for m in paginate(client, f"/orgs/{org}/members")}
+        # Org OWNERS hold implicit admin on every repo -- a third access path beside
+        # teams and direct grants, and the only one the others cannot revoke. The
+        # plain members list does not distinguish them, so this is a separate call.
+        owners = {
+            m["login"] for m in paginate(client, f"/orgs/{org}/members?role=admin")
+        }
         teams = paginate(client, f"/orgs/{org}/teams")
         rosters = {
             t["slug"]: {
@@ -250,7 +258,7 @@ def _fetch_rosters() -> tuple[dict[str, set[str]], set[str], dict[str, str | Non
             for t in teams
         }
     parents = {t["slug"]: (t.get("parent") or {}).get("slug") for t in teams}
-    return rosters, members, parents
+    return rosters, members, parents, owners
 
 
 @app.command
@@ -271,8 +279,8 @@ def access(
     """
     fleet = archetypes.load_fleet()
     active = [r for r in fleet if not r.get("archived")]
-    rosters, members, parents = _fetch_rosters()
-    rows = audit.classify_direct_grants(fleet, rosters, members, parents)
+    rosters, members, parents, owners = _fetch_rosters()
+    rows = audit.classify_direct_grants(fleet, rosters, members, parents, owners)
     shapes = audit.grant_shapes(active)
     kinds = Counter(r["kind"] for r in rows)
 
@@ -309,11 +317,15 @@ def access(
     # order the cleanup should run in.
     for kind, note in (
         ("redundant", "team access already >= the grant; delete freely"),
-        ("level-only", "drops to team level, which is the SEC-15 target anyway"),
+        ("level-only", "repo reach kept, elevated rights dropped to team level"),
+        ("owner-implicit", "org owner; implicit admin survives the deletion"),
         ("no-access", "ONLY path in -- needs a team grant BEFORE removal"),
         ("outside", "not an org member; invite to a team, or remove"),
     ):
-        print(f"  {kind:11} {kinds[kind]:4}   {note}")
+        print(f"  {kind:14} {kinds[kind]:4}   {note}")
+    removable = sum(kinds[k] for k in audit.REMOVABLE_KINDS)
+    print(f"  {'':14} ---")
+    print(f"  {'':14} {removable:4}   removable with no new team work")
 
     blocked = [r for r in rows if r["kind"] == "no-access"]
     if blocked:

--- a/bin/github-estate-audit
+++ b/bin/github-estate-audit
@@ -18,7 +18,7 @@ import json
 import sys
 from collections import Counter
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Any
 
 import cyclopts
 
@@ -202,6 +202,126 @@ def drift(
     total = len(only_live) + len(only_declared) + len(changed)
     print(f"\n{total} difference(s) between the committed fleet and {cache}")
     return 1 if total else 0
+
+
+def _fetch_rosters() -> tuple[dict[str, set[str]], set[str], dict[str, str | None]]:
+    """Team rosters, org members and team nesting, read live from the API.
+
+    NOT read from committed data, and not cached to disk, because there is nowhere
+    safe to put it: `vault-developer-access` and `vault-devops-access` are declared
+    `privacy: secret` in organization/teams.py so their membership is not advertised
+    even inside the org, and ol-infrastructure is a PUBLIC repository. Committing
+    rosters here would publish exactly what that setting exists to withhold.
+    """
+    import httpx  # noqa: PLC0415 -- only `access` needs the API; `run` must stay clean
+
+    from ol_infrastructure.lib.github_helper import (  # noqa: PLC0415
+        API_HEADERS,
+        GITHUB_API,
+        get_installation_token,
+    )
+
+    org = "mitodl"
+    token = get_installation_token()
+
+    def paginate(client: httpx.Client, path: str) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
+        url: str | None = f"{path}{'&' if '?' in path else '?'}per_page=100"
+        while url:
+            response = client.get(url)
+            response.raise_for_status()
+            out.extend(response.json())
+            url = response.links.get("next", {}).get("url")
+        return out
+
+    with httpx.Client(
+        base_url=GITHUB_API,
+        headers={**API_HEADERS, "Authorization": f"Bearer {token}"},
+        timeout=60,
+        follow_redirects=True,
+    ) as client:
+        members = {m["login"] for m in paginate(client, f"/orgs/{org}/members")}
+        teams = paginate(client, f"/orgs/{org}/teams")
+        rosters = {
+            t["slug"]: {
+                m["login"]
+                for m in paginate(client, f"/orgs/{org}/teams/{t['slug']}/members")
+            }
+            for t in teams
+        }
+    parents = {t["slug"]: (t.get("parent") or {}).get("slug") for t in teams}
+    return rosters, members, parents
+
+
+@app.command
+def access(
+    *,
+    as_json: Annotated[
+        bool, cyclopts.Parameter(name=["--json"], help="Emit JSON instead of text.")
+    ] = False,
+) -> int:
+    """Report team-grant uniformity and explain every direct collaborator grant.
+
+    NEEDS CREDENTIALS, unlike `run`. Classifying a direct grant means knowing who is
+    in which team, and rosters are deliberately not committed -- see `_fetch_rosters`.
+
+    Read the two halves together. The shape count says how far the fleet is from a
+    model; the direct-grant split says how much of the cleanup is free (`redundant`
+    and `level-only`) versus how much needs a team grant added first (`no-access`).
+    """
+    fleet = archetypes.load_fleet()
+    active = [r for r in fleet if not r.get("archived")]
+    rosters, members, parents = _fetch_rosters()
+    rows = audit.classify_direct_grants(fleet, rosters, members, parents)
+    shapes = audit.grant_shapes(active)
+    kinds = Counter(r["kind"] for r in rows)
+
+    if as_json:
+        print(
+            json.dumps(
+                {
+                    "active_repos": len(active),
+                    "distinct_shapes": len(shapes),
+                    "shapes": [
+                        {"teams": dict(shape), "repos": n}
+                        for shape, n in shapes.most_common()
+                    ],
+                    "direct_grants": rows,
+                    "by_kind": dict(kinds),
+                },
+                indent=2,
+            )
+        )
+        return 0
+
+    print(
+        f"# team grant shapes -- {len(shapes)} distinct across {len(active)} active repos\n"
+    )
+    for shape, count in shapes.most_common():
+        label = ", ".join(f"{t}:{p}" for t, p in shape) or "(NO TEAM GRANTS)"
+        print(f"  {count:4}  {label}")
+
+    print(
+        f"\n# direct collaborator grants -- {len(rows)} across "
+        f"{len({r['repo'] for r in rows})} repos, {len({r['login'] for r in rows})} people\n"
+    )
+    # Ordered by how much work removal takes, cheapest first, because that is the
+    # order the cleanup should run in.
+    for kind, note in (
+        ("redundant", "team access already >= the grant; delete freely"),
+        ("level-only", "drops to team level, which is the SEC-15 target anyway"),
+        ("no-access", "ONLY path in -- needs a team grant BEFORE removal"),
+        ("outside", "not an org member; invite to a team, or remove"),
+    ):
+        print(f"  {kind:11} {kinds[kind]:4}   {note}")
+
+    blocked = [r for r in rows if r["kind"] == "no-access"]
+    if blocked:
+        print("\nGrants that gate the cleanup:")
+        for row in sorted(blocked, key=lambda r: (r["repo"], r["login"])):
+            tag = " [archived]" if row["archived"] else ""
+            print(f"  {row['repo']:38}{tag:11} {row['login']}:{row['role']}")
+    return 0
 
 
 if __name__ == "__main__":

--- a/docs/github-access-model-audit.md
+++ b/docs/github-access-model-audit.md
@@ -1,0 +1,206 @@
+# Who can reach what in `mitodl`, and how uniform it is
+
+Companion to `docs/github-app-installation-audit.md` (machines) — this one covers
+**people**: team grants across the repository fleet, and the direct user grants that sit
+beside them.
+
+Measured 2026-08-10, against the fleet as of PR #5324. Re-measure with:
+
+```sh
+uv run bin/github-estate-audit access      # needs credentials -- see "Why rosters are not committed"
+uv run bin/github-estate-audit run --axis security
+```
+
+## The fact that makes all of this load-bearing
+
+```
+GET /orgs/mitodl  ->  "default_repository_permission": "none"
+```
+
+Org membership grants **no** baseline repository access. Every path to a repo is a team
+grant, a direct collaborator grant, or org ownership (nine people hold implicit admin
+everywhere).
+
+This is worth stating first because it decides whether the rest of the document is
+reporting anything. Under a `read` or `write` org default, "this repo has no team grants"
+would be cosmetic — everyone would already have access. Under `none` it means what it
+says.
+
+## Team grants: 27 shapes for 176 repos
+
+| | |
+|---|---|
+| Active repos | 176 |
+| Distinct grant shapes | **27** |
+| Repos with **no team grants at all** | **80 (45%)** |
+| ...of those, with no direct grant either | **66** |
+
+A "shape" is one distinct set of (team, permission) pairs. 176 repos drawn from four
+shapes is a model; 176 drawn from 27 is an accretion of one-off decisions. The long tail is
+almost entirely singletons — 15 of the 27 shapes apply to exactly one repo each.
+
+The eight most common shapes cover 156 of 176 repos:
+
+| Repos | Shape |
+|---|---|
+| 80 | *(no team grants)* |
+| 35 | `arbisoft-contractors:push, odl-engineering:push` |
+| 17 | `odl-engineering:push` |
+| 6 | `odl-engineering:push, odl-engineering-owners:admin` |
+| 6 | `odl-engineering-owners:admin` |
+| 5 | `odl-engineering:maintain` |
+| 3 | `devops:admin` |
+| 2 | `devops:admin, odl-engineering:maintain` |
+
+### The 66 unreachable repos
+
+66 active repos have neither a team grant nor a direct grant. Only the nine org owners can
+reach them: **50 forks, 15 libraries, and one `infrastructure` repo — `ol-concourse`**.
+
+The forks are arguable — they are upstream mirrors, and nobody edits them day to day. The
+15 libraries and `ol-concourse` are not: `ol-concourse` is named in `archetypes.yaml` as one
+of the three `infrastructure` repos, and it grants nobody anything.
+
+Reported as **CON-12** so this stays measured rather than rediscovered.
+
+### Teams holding no grant, and why only two of them are a problem
+
+Six of the 14 teams hold no grant on any active repo. Three of those are correct and
+should stay that way:
+
+- `copilot` (30 members) assigns Copilot seats.
+- `vault-developer-access` (20) and `vault-devops-access` (6) gate Vault secrets and are
+  declared `privacy: secret` in `organization/teams.py`.
+
+They are listed in `audit.NON_ACCESS_TEAMS` so a future "team with no grant" rule does not
+fire on them.
+
+The other three are review-routing teams, and **one of them is silently broken**:
+
+| Team | Named in CODEOWNERS of | Holds a grant there? |
+|---|---|---|
+| `owners-mit-open` | `open-discussions` | **yes** — `push`. Works. |
+| `owners-mit-learn` | `mit-learn`, `learn-ai` | **no grant on any repo** |
+| `code-owners-mitx-online` | *(none found)* | no |
+
+**A team named in CODEOWNERS only receives review requests if it has access to the
+repository.** Named-but-ungranted fails silently: no error, no warning, the request is
+simply dropped. `mit-learn` and `learn-ai` both name `@mitodl/owners-mit-learn` and grant
+it nothing, so its reviews have never been requested. `open-discussions` is the control
+that proves the mechanism — same pattern, grant present, works.
+
+### Permission levels are inconsistent per team
+
+Two teams hold three different levels across the fleet, which is variance with no evident
+rationale:
+
+| Team | Active repos | Levels |
+|---|---|---|
+| `odl-engineering` | 81 | `push`:69, `maintain`:12 |
+| `arbisoft-contractors` | 51 | `push`:44, `maintain`:4, `triage`:3 |
+| `odl-engineering-owners` | 24 | `admin`:24 |
+| `devops` | 12 | `admin`:12 |
+| `ol-data` | 2 | `maintain`:1, `push`:1 |
+| `devops-contractors` | 2 | `push`:2 |
+| `code-owners` | 1 | `push`:1 |
+| `owners-mit-open` | 1 | `push`:1 |
+
+`odl-engineering-owners` is **not** redundant with org ownership, which is worth recording
+because it looks like it should be. The team has 8 members and the org has 9 owners, but
+they only overlap on 5 — `annagav`, `jkachel` and `odlbot` are in the team without being
+org owners, so the grant is their only admin path.
+
+## Direct user grants: 80 grants, 19 people, 4 kinds
+
+SEC-06 counts 69 repos carrying direct grants. That number says how much there is to clean
+up and nothing about how. Splitting by *what removal would actually do*:
+
+| Kind | Count | What it means |
+|---|---|---|
+| `redundant` | 25 | Team access already meets or beats the direct grant. Delete freely. |
+| `level-only` | 24 | They keep team access at a lower rung — and that rung is the SEC-15 target anyway. |
+| `no-access` | 23 | The direct grant is the **only** path in. Removing it revokes access. |
+| `outside` | 8 | Not an org member at all. |
+
+**49 of 80 can be removed with no new team work.** The other 23 gate the cleanup: each one
+needs a team grant added first, which for most of them means fixing CON-12 on that repo.
+
+Concentration is high — three people hold 44% of all direct grants:
+
+| Person | Repos | Kinds |
+|---|---|---|
+| `rhysyngsun` | 20 (all admin) | 9 redundant, 11 load-bearing |
+| `gumaerc` | 8 (all admin) | 4 redundant, 4 load-bearing |
+| `odlbot` | 7 | 4 redundant, 3 load-bearing |
+
+`odlbot` is an automation account, so its grants should be reviewed as service access
+rather than as a person's.
+
+### Four outside collaborators
+
+Not org members, so no team can currently cover them:
+
+| Person | Repos | Level |
+|---|---|---|
+| `indagation` | 3 | write |
+| `NotoriousMKD` | 2 | write |
+| `sfrucht` | 2 | write |
+| `MaferMazu` | 1 | write |
+
+All at `write`, none at admin. Each is a decision rather than a cleanup: invite to the org
+and a team, or remove. Per plan §4.7 the target state is no direct grants at all, which
+means outside collaborators need somewhere to go before that target is reachable.
+
+## Why rosters are not committed
+
+`bin/github-estate-audit access` needs credentials, unlike `run`. Classifying a direct
+grant as redundant or load-bearing requires knowing who is in which team, and team
+membership is deliberately **not** in `data/`.
+
+`vault-developer-access` and `vault-devops-access` are declared `privacy: secret` so their
+membership is not advertised inside the org — and `ol-infrastructure` is a **public**
+repository. Committing rosters would publish precisely what that setting exists to
+withhold. So `access` fetches them per run and never writes them to disk.
+
+Worth flagging separately: `_direct_collaborators` **is** committed, and this repo is
+public, so "person X holds admin on repo Y" is already published. That predates this audit
+and the audit depends on it, but it deserves a decision of its own rather than inheritance
+by default.
+
+## A candidate uniform model
+
+Not applied — this is the proposal the numbers point at.
+
+**Default, from the archetype, for every non-fork active repo:**
+
+```yaml
+teams:
+  odl-engineering: push          # broad engineering, capped at push (2026-08-05 policy)
+  odl-engineering-owners: admin  # not redundant with org ownership -- see above
+```
+
+**Per-repo additions, only where there is a reason:**
+
+- `devops: admin` on `infrastructure` (already the archetype since #5324).
+- `arbisoft-contractors: push` where contractors are actually staffed — flattened from
+  today's push/maintain/triage spread to one level.
+- A product owners team (`owners-mit-learn`, `owners-mit-open`) at `push` on the repos
+  whose CODEOWNERS name it. This is what fixes the silent-drop bug.
+
+That collapses 27 shapes to roughly 5 and closes CON-12, at the cost of granting
+`odl-engineering: push` on 80 repos that grant nothing today. **That is an access
+widening**, which is a different risk class from SEC-15's narrowing and is why nothing here
+is applied yet. The open questions are in the tracked tasks: what forks should get, and
+whether "reachable only by an org owner" is deliberate on any of the 66.
+
+## Sequencing
+
+1. **Fix `owners-mit-learn`** on `mit-learn` and `learn-ai`. Two grants; fixes a silent
+   failure. No downside.
+2. **Delete the 49 free direct grants** (`redundant` + `level-only`). No access lost.
+3. **Decide the uniform model**, then apply it — which closes CON-12 and unblocks the 23
+   `no-access` grants.
+4. **Remove the remaining 23** once their repos have team grants.
+5. **Decide on the 4 outside collaborators** — invite or remove.
+
+Steps 1 and 2 are safe today. Step 3 is the one that needs a decision.

--- a/docs/github-access-model-audit.md
+++ b/docs/github-access-model-audit.md
@@ -179,9 +179,10 @@ public, so "person X holds admin on repo Y" is already published. That predates 
 and the audit depends on it, but it deserves a decision of its own rather than inheritance
 by default.
 
-## A candidate uniform model
+## The uniform model
 
-Not applied — this is the proposal the numbers point at.
+Proposed here, decided 2026-08-10, applied in #5357 and #5360 — which are stacked on this
+PR's base, so the numbers above describe the estate *before* them.
 
 **Default, from the archetype, for every non-fork active repo:**
 
@@ -199,11 +200,33 @@ teams:
 - A product owners team (`owners-mit-learn`, `owners-mit-open`) at `push` on the repos
   whose CODEOWNERS name it. This is what fixes the silent-drop bug.
 
-That collapses 27 shapes to roughly 5 and closes CON-12, at the cost of granting
-`odl-engineering: push` on 80 repos that grant nothing today. **That is an access
-widening**, which is a different risk class from SEC-15's narrowing and is why nothing here
-is applied yet. The open questions are in the tracked tasks: what forks should get, and
-whether "reachable only by an org owner" is deliberate on any of the 66.
+Applying it granted `odl-engineering: push` on 80 repos that granted nothing. **That is an
+access widening**, a different risk class from SEC-15's narrowing, which is why it landed as
+its own reviewed change rather than folded into one.
+
+Outcome: distinct grant shapes across the 176 active repos went **27 → 20 → 14**, and repos
+with no team grants went **80 → 5**.
+
+### The three decisions, so they are not re-opened
+
+**Forks are in scope.** The rule is "every public repo", and forks are public — 67 of the 87
+new `odl-engineering` grants landed on them. CON-12 has no fork exemption, unlike CON-03.
+
+**The five remaining private repos stay as they are.** `alerting-omnibus`,
+`apisix-testbed`, `oldevops-scratch`, `open-collaboration` and `product` remain reachable
+only by the nine org owners. That is deliberate, not a gap the rule failed to close: the
+policy is scoped to public precisely because private is where a blanket grant is least
+appropriate — `access-forge` and `gwarek` are devops-only by design. **CON-12 therefore
+rests at 5, not 0, and 5 is the correct value.** Do not "fix" it by granting the two teams
+on private repos.
+
+**`default_repository_permission` stays `none`.** Setting it to `read` would change nothing
+for the 166 of 176 active repos that are public, while silently widening the deliberately
+narrow private ones — and `members_can_fork_private_repositories` is true, so it would mean
+read *and* fork on every private repo. It would also be invisible to per-repo audit tooling,
+since it lives at the org level, which is the one kind of divergence none of these rules can
+catch. The reasoning is recorded here rather than in `org_settings.py`, whose existing
+"Correct as-is" comment stands.
 
 ## Sequencing
 
@@ -212,9 +235,11 @@ whether "reachable only by an org owner" is deliberate on any of the 66.
 2. **Delete the 59 free direct grants** (`redundant` + `level-only` + `owner-implicit`).
    Nobody loses their reach into a repository. The 14 `level-only` grants do lose their
    elevated permission, which is the SEC-15 target rather than a side effect.
-3. **Decide the uniform model**, then apply it — which closes CON-12 and unblocks the 13
-   `no-access` grants.
-4. **Remove the remaining 13** once their repos have team grants.
-5. **Decide on the 4 outside collaborators** — invite or remove.
+3. ~~**Decide the uniform model**, then apply it.~~ Done — #5357 and #5360.
+4. **Remove the remaining `no-access` grants** now their repos have team grants. Re-run
+   `github-estate-audit access` first rather than reusing the 13 above: a grant classified
+   `no-access` becomes `level-only` the moment its repo gains a team grant, so the earlier
+   split is stale by construction once #5357 lands.
+5. **Decide on the 4 outside collaborators** — invite or remove. Still open.
 
-Steps 1 and 2 are safe today. Step 3 is the one that needs a decision.
+Steps 1, 2 and 4 are mechanical. Step 5 is the only one left needing a decision.

--- a/docs/github-access-model-audit.md
+++ b/docs/github-access-model-audit.md
@@ -91,8 +91,8 @@ that proves the mechanism — same pattern, grant present, works.
 
 ### Permission levels are inconsistent per team
 
-Two teams hold three different levels across the fleet, which is variance with no evident
-rationale:
+Three teams hold more than one level across the fleet, and `arbisoft-contractors` holds
+three. That is variance with no evident rationale:
 
 | Team | Active repos | Levels |
 |---|---|---|
@@ -110,20 +110,32 @@ because it looks like it should be. The team has 8 members and the org has 9 own
 they only overlap on 5 — `annagav`, `jkachel` and `odlbot` are in the team without being
 org owners, so the grant is their only admin path.
 
-## Direct user grants: 80 grants, 19 people, 4 kinds
+## Direct user grants: 80 grants, 19 people, 5 kinds
 
 SEC-06 counts 69 repos carrying direct grants. That number says how much there is to clean
 up and nothing about how. Splitting by *what removal would actually do*:
 
 | Kind | Count | What it means |
 |---|---|---|
-| `redundant` | 25 | Team access already meets or beats the direct grant. Delete freely. |
-| `level-only` | 24 | They keep team access at a lower rung — and that rung is the SEC-15 target anyway. |
-| `no-access` | 23 | The direct grant is the **only** path in. Removing it revokes access. |
+| `owner-implicit` | 37 | The holder is an **org owner**. Implicit admin on every repo survives the deletion, whatever the teams say. |
+| `redundant` | 25 → 8 | Team access already meets or beats the direct grant. Delete freely. |
+| `level-only` | 24 → 14 | Repo reach is kept; the **elevated rights** drop to the team's level — which is the SEC-15 target. |
+| `no-access` | 23 → 13 | The direct grant is the **only** path in. Removing it revokes access. |
 | `outside` | 8 | Not an org member at all. |
 
-**49 of 80 can be removed with no new team work.** The other 23 gate the cleanup: each one
+**59 of 80 can be removed with no new team work.** The other 13 gate the cleanup: each one
 needs a team grant added first, which for most of them means fixing CON-12 on that repo.
+
+The arrows are a correction, not a change in the estate. An earlier pass ranked every grant
+by team membership alone, which ignored **org ownership as a third access path** — the one
+the other two cannot revoke. That put 10 owner-held grants in `no-access`, the bucket whose
+whole meaning is "removing this revokes access", and so overstated the gating set by nearly
+half. Owners get their own bucket rather than being folded into `redundant` because implicit
+admin survives roster churn and a redundancy verdict does not.
+
+Note what `level-only` does and does not preserve: the person keeps their reach into the
+repository, and **loses the elevated permission**. That is the intended outcome under the
+SEC-15 policy, not a no-op.
 
 Concentration is high — three people hold 44% of all direct grants:
 
@@ -197,10 +209,12 @@ whether "reachable only by an org owner" is deliberate on any of the 66.
 
 1. **Fix `owners-mit-learn`** on `mit-learn` and `learn-ai`. Two grants; fixes a silent
    failure. No downside.
-2. **Delete the 49 free direct grants** (`redundant` + `level-only`). No access lost.
-3. **Decide the uniform model**, then apply it — which closes CON-12 and unblocks the 23
+2. **Delete the 59 free direct grants** (`redundant` + `level-only` + `owner-implicit`).
+   Nobody loses their reach into a repository. The 14 `level-only` grants do lose their
+   elevated permission, which is the SEC-15 target rather than a side effect.
+3. **Decide the uniform model**, then apply it — which closes CON-12 and unblocks the 13
    `no-access` grants.
-4. **Remove the remaining 23** once their repos have team grants.
+4. **Remove the remaining 13** once their repos have team grants.
 5. **Decide on the 4 outside collaborators** — invite or remove.
 
 Steps 1 and 2 are safe today. Step 3 is the one that needs a decision.

--- a/src/ol_infrastructure/saas/github/audit.py
+++ b/src/ol_infrastructure/saas/github/audit.py
@@ -18,6 +18,7 @@ claims. Each rule declares its own `scope`, and the reporter uses that as the
 denominator. Getting this wrong has already happened twice on this project.
 """
 
+from collections import Counter
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -36,6 +37,32 @@ ENVIRONMENT_SPRAWL_THRESHOLD = 10
 #: Teams sanctioned to hold `admin` (SEC-15). An ALLOWLIST on purpose: under a
 #: denylist a newly created team acquires admin silently and the rule stays quiet.
 ADMIN_TEAMS = frozenset({"odl-engineering-owners", "devops"})
+#: Teams that exist for something other than repository access, and are therefore
+#: expected to hold no grant. `copilot` assigns Copilot seats; the two `vault-*`
+#: teams gate Vault secrets and are `privacy: secret` (see organization/teams.py).
+#: Without this list, "holds no repo grant" would read as a finding on all three.
+NON_ACCESS_TEAMS = frozenset(
+    {"copilot", "vault-developer-access", "vault-devops-access"}
+)
+#: GitHub reports collaborator roles as `write`/`read` and team grants as
+#: `push`/`pull`. Same rung, different vocabulary -- comparing the raw strings
+#: would score every `write` collaborator as unmatched against a `push` team.
+PERMISSION_RANK: dict[str, int] = {
+    "read": 0,
+    "pull": 0,
+    "triage": 1,
+    "write": 2,
+    "push": 2,
+    "maintain": 3,
+    "admin": 4,
+}
+RANK_NAME: dict[int, str] = {
+    0: "read",
+    1: "triage",
+    2: "push",
+    3: "maintain",
+    4: "admin",
+}
 #: Archetypes exempt from the default-branch rule. Forks follow upstream's naming.
 DEFAULT_BRANCH_EXEMPT = frozenset({"fork", "archived"})
 FEATURE_ENABLED = "enabled"
@@ -180,6 +207,32 @@ RULES: tuple[Rule, ...] = (
                 "downgrade to push or maintain",
             )
             if _unsanctioned_admin(r)
+            else None
+        ),
+    ),
+    Rule(
+        "CON-12",
+        "security",
+        "high",
+        "active",
+        "no team grants -- reachable only by an org owner or a direct grant",
+        # The org's `default_repository_permission` is `none` (verified 2026-08-10),
+        # so org membership confers NOTHING. A repo with an empty `teams` block is
+        # therefore genuinely unreachable except by the nine org owners, who hold
+        # implicit admin, and by whoever holds a direct collaborator grant.
+        #
+        # THIS ONLY BECAME A FINDING WHEN THE DEFAULT WAS CHECKED. Under a `read` or
+        # `write` org default the same data would be cosmetic -- every member would
+        # already have access and an empty `teams` block would mean nothing. Whoever
+        # revisits this rule should re-check the org default first, because it
+        # silently decides whether the rule is measuring anything at all.
+        lambda r: (
+            (
+                "no team grants",
+                "at least one team grant",
+                "add the archetype's team block, or record why this repo is exempt",
+            )
+            if not (r.get("teams") or {})
             else None
         ),
     ),
@@ -356,3 +409,96 @@ def evaluate(fleet: Iterable[dict[str, Any]]) -> list[Finding]:
 def population(fleet: Iterable[dict[str, Any]], scope: Scope) -> int:
     """How many repos a scope covers -- the honest denominator for a percentage."""
     return sum(1 for repo in fleet if _in_scope(repo, scope))
+
+
+#: Why a direct collaborator grant exists, which is what decides how to remove it.
+GrantKind = Literal["redundant", "level-only", "no-access", "outside"]
+
+
+def _team_members(rosters: dict[str, set[str]], parents: dict[str, str | None]) -> Any:
+    """Expand each team to include the members of its descendant teams.
+
+    Nested teams inherit DOWNWARD on GitHub: a member of a child team counts as a
+    member of the parent for access purposes, so a grant to `odl-engineering` also
+    covers everyone in `copilot`, its child. Matching slugs exactly would classify
+    those people as having no team access and manufacture `no-access` findings.
+    """
+    expanded = {slug: set(members) for slug, members in rosters.items()}
+    for slug, members in rosters.items():
+        parent = parents.get(slug)
+        while parent:
+            expanded.setdefault(parent, set()).update(members)
+            parent = parents.get(parent)
+    return expanded
+
+
+def classify_direct_grants(
+    fleet: Iterable[dict[str, Any]],
+    rosters: dict[str, set[str]],
+    members: set[str],
+    parents: dict[str, str | None] | None = None,
+) -> list[dict[str, Any]]:
+    """Explain every direct collaborator grant in terms of how to remove it.
+
+    A flat count of direct grants (SEC-06) says how much there is to clean up but
+    nothing about how, and the four kinds need completely different handling:
+
+      redundant   the person's team access already meets or beats the direct grant.
+                  Delete it; nobody loses anything.
+      level-only  they keep team access, just at a lower rung. Since that lower rung
+                  IS the SEC-15 target, deleting is the intended outcome, not a loss.
+      no-access   the direct grant is their only path in. Deleting it without adding
+                  a team grant first REVOKES ACCESS -- these gate the cleanup.
+      outside     not an org member at all. A different decision entirely: invite
+                  them to the org and a team, or remove them.
+
+    `rosters` is passed in rather than read from disk because team membership is NOT
+    committed: `vault-developer-access` and `vault-devops-access` are `privacy:
+    secret` precisely so membership is not advertised, and ol-infrastructure is a
+    PUBLIC repository. Callers fetch it live -- which is why the `access` command
+    needs credentials while `run` does not.
+    """
+    expanded = _team_members(rosters, parents or {})
+    rows: list[dict[str, Any]] = []
+    for repo in fleet:
+        grants = repo.get("teams") or {}
+        for login, role in (repo.get("_direct_collaborators") or {}).items():
+            via = max(
+                (
+                    PERMISSION_RANK[perm]
+                    for team, perm in grants.items()
+                    if login in expanded.get(team, ())
+                ),
+                default=None,
+            )
+            if login not in members:
+                kind: GrantKind = "outside"
+            elif via is None:
+                kind = "no-access"
+            elif via >= PERMISSION_RANK[role]:
+                kind = "redundant"
+            else:
+                kind = "level-only"
+            rows.append(
+                {
+                    "repo": repo["name"],
+                    "archived": bool(repo.get("archived")),
+                    "login": login,
+                    "role": role,
+                    "via_teams": RANK_NAME[via] if via is not None else None,
+                    "kind": kind,
+                }
+            )
+    return rows
+
+
+def grant_shapes(
+    fleet: Iterable[dict[str, Any]],
+) -> Counter[tuple[tuple[str, str], ...]]:
+    """Count the distinct team-grant shapes in `fleet`.
+
+    One shape per distinct (team, permission) set. The number of shapes IS the
+    uniformity metric: 176 repos drawn from 4 shapes is a model, the same 176 drawn
+    from 27 is an accretion of one-off decisions.
+    """
+    return Counter(tuple(sorted((repo.get("teams") or {}).items())) for repo in fleet)

--- a/src/ol_infrastructure/saas/github/audit.py
+++ b/src/ol_infrastructure/saas/github/audit.py
@@ -412,7 +412,12 @@ def population(fleet: Iterable[dict[str, Any]], scope: Scope) -> int:
 
 
 #: Why a direct collaborator grant exists, which is what decides how to remove it.
-GrantKind = Literal["redundant", "level-only", "no-access", "outside"]
+GrantKind = Literal["redundant", "level-only", "owner-implicit", "no-access", "outside"]
+#: The kinds whose removal costs the person nothing. `no-access` and `outside` are
+#: deliberately absent: one revokes access, the other is a membership decision.
+REMOVABLE_KINDS: frozenset[str] = frozenset(
+    {"redundant", "level-only", "owner-implicit"}
+)
 
 
 def _team_members(rosters: dict[str, set[str]], parents: dict[str, str | None]) -> Any:
@@ -437,26 +442,38 @@ def classify_direct_grants(
     rosters: dict[str, set[str]],
     members: set[str],
     parents: dict[str, str | None] | None = None,
+    owners: set[str] | None = None,
 ) -> list[dict[str, Any]]:
     """Explain every direct collaborator grant in terms of how to remove it.
 
     A flat count of direct grants (SEC-06) says how much there is to clean up but
-    nothing about how, and the four kinds need completely different handling:
+    nothing about how, and the five kinds need completely different handling:
 
-      redundant   the person's team access already meets or beats the direct grant.
-                  Delete it; nobody loses anything.
-      level-only  they keep team access, just at a lower rung. Since that lower rung
-                  IS the SEC-15 target, deleting is the intended outcome, not a loss.
-      no-access   the direct grant is their only path in. Deleting it without adding
-                  a team grant first REVOKES ACCESS -- these gate the cleanup.
-      outside     not an org member at all. A different decision entirely: invite
-                  them to the org and a team, or remove them.
+      redundant       the person's team access already meets or beats the direct
+                      grant. Delete it; nobody loses anything.
+      level-only      they keep team access, just at a lower rung. Since that lower
+                      rung IS the SEC-15 target, deleting is the intended outcome.
+      owner-implicit  the person is an ORG OWNER, so admin on every repo survives
+                      the deletion regardless of teams. Free to delete.
+      no-access       the direct grant is their only path in. Deleting it without a
+                      team grant first REVOKES ACCESS -- these gate the cleanup.
+      outside         not an org member at all. A different decision entirely:
+                      invite them to the org and a team, or remove them.
 
-    `rosters` is passed in rather than read from disk because team membership is NOT
-    committed: `vault-developer-access` and `vault-devops-access` are `privacy:
-    secret` precisely so membership is not advertised, and ol-infrastructure is a
-    PUBLIC repository. Callers fetch it live -- which is why the `access` command
-    needs credentials while `run` does not.
+    OWNERSHIP IS CHECKED BEFORE TEAMS, and that ordering is the point. Org ownership
+    is a third access path alongside teams and direct grants, and it is the one the
+    other two cannot take away: an owner keeps implicit admin no matter what happens
+    to a roster. Ranking a grant by teams alone put 10 owner-held grants in
+    `no-access` -- the bucket that means "removing this revokes access" -- and so
+    overstated the gating set by nearly half. `owner-implicit` also survives roster
+    churn in a way `redundant` does not, which is why owners get their own bucket
+    rather than being folded into it.
+
+    `rosters` and `owners` are passed in rather than read from disk because team
+    membership is NOT committed: `vault-developer-access` and `vault-devops-access`
+    are `privacy: secret` precisely so membership is not advertised, and
+    ol-infrastructure is a PUBLIC repository. Callers fetch them live -- which is why
+    the `access` command needs credentials while `run` does not.
     """
     expanded = _team_members(rosters, parents or {})
     rows: list[dict[str, Any]] = []
@@ -473,6 +490,8 @@ def classify_direct_grants(
             )
             if login not in members:
                 kind: GrantKind = "outside"
+            elif login in (owners or set()):
+                kind = "owner-implicit"
             elif via is None:
                 kind = "no-access"
             elif via >= PERMISSION_RANK[role]:

--- a/src/ol_infrastructure/saas/github/repositories/archetypes.py
+++ b/src/ol_infrastructure/saas/github/repositories/archetypes.py
@@ -35,6 +35,61 @@ def _resolve(archetypes: dict[str, Any], name: str) -> dict[str, Any]:
     return {k: v for k, v in merged.items() if v is not None}
 
 
+#: What `github.TeamRepository(permission=...)` accepts. NOT the same vocabulary the
+#: collaborator API uses -- GitHub says `pull`/`push` for teams and `read`/`write` for
+#: collaborators, for the same two rungs. Writing `read` in a `teams:` block is
+#: therefore wrong even though it reads as valid English, and the provider rejects it
+#: at apply time, several hundred resources into a run.
+TEAM_PERMISSIONS = frozenset({"pull", "triage", "push", "maintain", "admin"})
+#: What `GET /repos/{owner}/{repo}/collaborators` reports as `role_name`, and so what
+#: `_direct_collaborators` holds. The audit ranks these against team grants.
+COLLABORATOR_ROLES = frozenset({"read", "triage", "write", "maintain", "admin"})
+
+
+def _check_permission_values(fleet: list[dict[str, Any]]) -> None:
+    """Fail if any grant carries a permission outside its field's vocabulary.
+
+    Two consumers index these values unguarded, and both should. `repository.py`
+    passes `permission` straight to `TeamRepository`, and `audit.classify_direct_grants`
+    indexes `PERMISSION_RANK[...]` for both fields.
+
+    THE `.get()` FIX WOULD BE WORSE THAN THE CRASH, and specifically worse here. A role
+    that silently ranks as `None` or 0 makes the audit classify a direct grant as
+    `redundant` -- the bucket whose whole meaning is "safe to delete, the person keeps
+    team access". Acting on that revokes someone's access on the strength of a typo.
+    Misclassifying access is the one outcome worse than failing to classify it.
+
+    So this keeps the loud failure and adds what a bare KeyError lacks: which repo,
+    which field, which value, and every offender in one run rather than the first one
+    encountered several hundred repos into a preview. Same reasoning as
+    `_check_team_references` above.
+    """
+    bad = sorted(
+        {
+            f"{repo['name']}: teams.{slug} = {perm!r}"
+            for repo in fleet
+            for slug, perm in (repo.get("teams") or {}).items()
+            if perm not in TEAM_PERMISSIONS
+        }
+        | {
+            f"{repo['name']}: _direct_collaborators.{login} = {role!r}"
+            for repo in fleet
+            for login, role in (repo.get("_direct_collaborators") or {}).items()
+            if role not in COLLABORATOR_ROLES
+        }
+    )
+    if bad:
+        message = (
+            "fleet data carries permission values outside the allowed vocabulary:\n  "
+            + "\n  ".join(bad)
+            + f"\nTeam grants must be one of {sorted(TEAM_PERMISSIONS)}; "
+            f"direct collaborator roles one of {sorted(COLLABORATOR_ROLES)}. "
+            "Note `pull`/`push` for teams vs `read`/`write` for collaborators -- "
+            "GitHub uses different words for the same two rungs."
+        )
+        raise ValueError(message)
+
+
 def _check_team_references(fleet: list[dict[str, Any]]) -> None:
     """Fail if any repo grants to a team slug absent from teams.yaml.
 
@@ -91,6 +146,7 @@ def load_fleet() -> list[dict[str, Any]]:
         fleet.append(merged)
 
     _check_team_references(fleet)
+    _check_permission_values(fleet)
 
     # The dotfile trap is silent by construction, so assert rather than trust.
     assignments = yaml.safe_load((DATA_DIR / "archetypes-proposed.yaml").read_text())

--- a/tests/ol_infrastructure/saas/github/test_audit.py
+++ b/tests/ol_infrastructure/saas/github/test_audit.py
@@ -138,3 +138,139 @@ def test_findings_carry_remediation() -> None:
     for finding in findings:
         assert finding.remediation
         assert finding.expected
+
+
+def test_con12_fires_on_an_active_repo_with_no_team_grants() -> None:
+    """The 80-repo finding rests entirely on this, so it gets a case of its own.
+
+    The org's `default_repository_permission` is `none`, which is what makes an empty
+    `teams` block mean "nobody but an org owner can reach this" rather than nothing at
+    all. If that org setting ever changes, this rule stops measuring what it claims,
+    and this test is where to start looking.
+    """
+    assert "CON-12" in fired([repo(teams={})])
+    assert "CON-12" in fired([repo(teams=None)])
+    assert "CON-12" not in fired([repo(teams={"odl-engineering": "push"})])
+
+
+def test_con12_is_scoped_to_active_repos() -> None:
+    """Archived repos emit no TeamRepository at all, so the rule cannot act on them.
+
+    Without this case a scope regression would silently inflate the finding with the
+    archived repos that also grant nothing -- a number that reads as new work but is
+    unreachable by this project.
+    """
+    assert "CON-12" not in fired([repo(archived=True, teams={})])
+
+
+# --- classify_direct_grants -------------------------------------------------------
+#
+# These decide which grants get advertised as safe to delete, so each of the five
+# kinds is pinned. A misclassification here is not a wrong report, it is a deletion
+# that revokes someone's access.
+
+ROSTERS = {"odl-engineering": {"alice"}, "devops": {"bob"}, "copilot": {"carol"}}
+PARENTS: dict[str, str | None] = {
+    "copilot": "odl-engineering",
+    "odl-engineering": None,
+    "devops": None,
+}
+MEMBERS = {"alice", "bob", "carol", "owner"}
+OWNERS = {"owner"}
+
+
+def classify(**repo_overrides: Any) -> str:
+    """Classify the single direct grant on a one-repo fleet."""
+    rows = audit.classify_direct_grants(
+        [repo(**repo_overrides)], ROSTERS, MEMBERS, PARENTS, OWNERS
+    )
+    assert len(rows) == 1
+    return str(rows[0]["kind"])
+
+
+def test_grant_is_redundant_when_team_access_already_meets_it() -> None:
+    assert (
+        classify(
+            teams={"odl-engineering": "maintain"},
+            _direct_collaborators={"alice": "write"},
+        )
+        == "redundant"
+    )
+
+
+def test_grant_is_level_only_when_team_access_is_lower() -> None:
+    """Removal keeps repo reach and drops the elevated rights -- the SEC-15 target."""
+    assert (
+        classify(
+            teams={"odl-engineering": "push"},
+            _direct_collaborators={"alice": "admin"},
+        )
+        == "level-only"
+    )
+
+
+def test_grant_is_no_access_when_no_team_covers_the_person() -> None:
+    assert (
+        classify(teams={"devops": "admin"}, _direct_collaborators={"alice": "admin"})
+        == "no-access"
+    )
+
+
+def test_grant_is_outside_when_the_person_is_not_an_org_member() -> None:
+    assert classify(teams={}, _direct_collaborators={"stranger": "write"}) == "outside"
+
+
+def test_org_owners_are_classified_by_ownership_not_by_teams() -> None:
+    """Ownership is a third access path, and the one teams cannot take away.
+
+    Ranking by teams alone put 10 owner-held grants in `no-access` -- the bucket that
+    means "removing this revokes access" -- overstating the gating set by nearly half.
+    An owner keeps implicit admin whatever the rosters do, so the answer must not
+    depend on them: both cases below are the same verdict.
+    """
+    assert classify(teams={}, _direct_collaborators={"owner": "admin"}) == (
+        "owner-implicit"
+    )
+    assert (
+        classify(
+            teams={"odl-engineering": "push"},
+            _direct_collaborators={"owner": "admin"},
+        )
+        == "owner-implicit"
+    )
+
+
+def test_nested_team_members_inherit_the_parents_grant() -> None:
+    """`copilot` is a child of `odl-engineering`, so a grant to the parent covers it.
+
+    Matching team slugs exactly would classify every child-team member as having no
+    team access, manufacturing `no-access` findings for grants that are redundant.
+    """
+    assert (
+        classify(
+            teams={"odl-engineering": "admin"},
+            _direct_collaborators={"carol": "admin"},
+        )
+        == "redundant"
+    )
+
+
+def test_write_and_push_are_the_same_rung() -> None:
+    """GitHub says `write` for collaborators and `push` for teams.
+
+    Comparing the raw strings would score every write grant as unmatched against a
+    push team, and report it as an elevation that needs removing.
+    """
+    assert (
+        classify(
+            teams={"odl-engineering": "push"},
+            _direct_collaborators={"alice": "write"},
+        )
+        == "redundant"
+    )
+
+
+def test_removable_kinds_exclude_the_two_that_cost_something() -> None:
+    """The headline "N removable today" is summed over this set."""
+    assert "no-access" not in audit.REMOVABLE_KINDS
+    assert "outside" not in audit.REMOVABLE_KINDS


### PR DESCRIPTION
## What are the relevant tickets?

Access-model audit for the GitHub estate — the people counterpart to #5323's app-installation audit. **Stacked on #5324**; review that first.

## Description (What does it do?)

Adds `github-estate-audit access`, audit rule **CON-12**, and `docs/github-access-model-audit.md`. **No resource changes** — `pulumi preview` is still #5324's 105 updates and nothing else.

**The fact that makes any of this measure something:** the org's `default_repository_permission` is **`none`**, so org membership grants no baseline repository access at all. Under a `read` or `write` default the headline finding below would be cosmetic — everyone would already have access. It was checked first for that reason, and CON-12 carries a comment telling the next person to re-check it before trusting the rule.

### Team grants — 27 shapes for 176 repos

15 of the 27 shapes apply to exactly one repo. **80 active repos (45%) have no team grants at all**, and 66 of those have no direct grant either — so only the nine org owners can reach them. That's 50 forks, 15 libraries, and **`ol-concourse`**, which `archetypes.yaml` names as one of the three `infrastructure` repos.

### A silent failure found on the way

A team named in CODEOWNERS receives review requests **only if it has access to the repository**. Named-but-ungranted fails silently — no error, no warning, the request is simply dropped.

`mit-learn` and `learn-ai` both name `@mitodl/owners-mit-learn`, which holds a grant on **no repo in the org**. So its reviews have never been requested on either.

`open-discussions` names `owners-mit-open` *and* grants it `push` — that's the control proving the mechanism rather than just the theory.

### Direct grants — 80 across 69 repos, 19 people

SEC-06's flat count says how much there is to clean up and nothing about how, so these are classified by **what removal would actually do**:

| Kind | Count | Meaning |
|---|---|---|
| `redundant` | 25 | Team access already ≥ the grant. Delete freely. |
| `level-only` | 24 | Drops to team level — which is the SEC-15 target anyway. |
| `no-access` | 23 | The **only** path in. Removing revokes access. |
| `outside` | 8 | Not org members (4 people, all at `write`). |

**49 of 80 are removable today.** The other 23 gate the rest, and mostly gate on CON-12.

## How can this be tested?

```sh
uv run bin/github-estate-audit access          # needs credentials
uv run bin/github-estate-audit run --axis security   # CON-12 at 80 (45% of 176 active)
```

`pulumi preview` on `ol-saas-github-repositories`: `~ 105 to update, 1065 unchanged` — byte-identical to #5324, confirming this PR adds no resource change.

Two verifications worth re-checking, since both would have produced wrong conclusions if assumed:

- **`odl-engineering-owners` is *not* redundant with org ownership**, though it looks like it should be. 8 team members vs 9 org owners, overlapping on only 5 — `annagav`, `jkachel` and `odlbot` are in the team without being owners, so the grant is their only admin path. Recommending its removal would have revoked access for three people.
- **Nested teams inherit downward**, so `_team_members` expands each team with its descendants' members before matching. Matching slugs exactly would have classified every `copilot` member as having no access through the `odl-engineering` grant and manufactured false `no-access` findings.

## Additional Notes

**Rosters are fetched per run and never committed**, which is why `access` needs credentials while `run` stays credential-free. `vault-developer-access` and `vault-devops-access` are declared `privacy: secret` in `organization/teams.py` so their membership is not advertised even inside the org — and `ol-infrastructure` is a **public** repository. Committing rosters would publish exactly what that setting exists to withhold.

Related, and flagged in the doc rather than acted on: `_direct_collaborators` **is** already committed to this public repo, so "person X holds admin on repo Y" is published today. That predates this audit and the audit depends on it, but it deserves its own decision rather than inheritance by default.

**Nothing is applied.** The candidate uniform model collapses 27 shapes to roughly 5 — but it does so by granting `odl-engineering: push` on 80 repos that grant nothing today. That is an access **widening**, a different risk class from SEC-15's narrowing, so it is written up as a proposal with the open questions tracked rather than included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012eXp7Dox9U9YEJuu8fj2BQ
