### PR TITLE
Revert local-dev mitxonline anonymous checkout routes (keep learn-ai readiness probe)

### DIFF
--- a/local-dev/apps/mitxonline/apisix-routes.yaml
+++ b/local-dev/apps/mitxonline/apisix-routes.yaml
@@ -48,8 +48,7 @@ spec:
 #   passauth        : /*              (pass — injects X-Userinfo if session present)
 #   logout-redirect : /logout/oidc/* (redirect to /logout/oidc)
 #   reqauth         : /login/*, /admin/login/*, /login*, /login/oidc*
-#   checkout-anonymous : /checkout/anonymous, /checkout/anonymous/,
-#                     /checkout/anonymous/* (require authentication, priority 20)
+#   cart            : /cart, /cart/, /cart/* (require authentication, priority 20)
 #
 # No explicit redirect_uri — lua-resty-openidc auto-derives it.
 # session.cookie.domain set to .mitxonline.mit.dev so the cookie is shared
@@ -159,24 +158,16 @@ spec:
           user: true
         unauth_action: auth
 
-  # Login gate for the "anonymous first" checkout flow, and the successor to the
-  # former "cart" route. /cart is now served anonymously (it falls through to
-  # passauth above, which returns the anonymous basket); the login that
-  # establishes the session — so the anonymous basket can be claimed — happens
-  # when the learner proceeds to checkout and lands here. The /* path catches
-  # this route's own OIDC callback, which lua-resty-openidc derives relative to
-  # the request path (/checkout/anonymous/.apisix/redirect); without it the
-  # callback falls through to passauth and only works by accident.
-  - name: checkout-anonymous
+  - name: cart
     priority: 20
     match:
       hosts:
       - "mitxonline.mit.dev"
       - "api.mitxonline.mit.dev"
       paths:
-      - "/checkout/anonymous"
-      - "/checkout/anonymous/"
-      - "/checkout/anonymous/*"
+      - "/cart"
+      - "/cart/"
+      - "/cart/*"
     backends:
     - serviceName: mitxonline-webapp
       servicePort: 8010


### PR DESCRIPTION
### What are the relevant tickets?
- Followup to https://github.com/mitodl/ol-infrastructure/pull/5313

### Description (What does it do?)
Reverts the local-dev half of #5243 and #5244 (merged as #5278), since both production PRs were reverted in #5313 following https://github.com/mitodl/hq/discussions/12753#discussioncomment-17939575 — local-dev had been left drifting from `src/ol_infrastructure/applications/mitxonline/__main__.py` in the opposite direction.

`#5278`'s other, unrelated change — the learn-ai readiness probe on `/health/readiness/` — is deliberately kept.

### How can this be tested?

Bring the stack up (`tilt up`), or apply the routes directly:

```
kubectl apply -f local-dev/apps/mitxonline/apisix-routes.yaml
```

**mitxonline routing** — all anonymous, no cookies:

```
for p in /cart/ /cart /checkout/anonymous /checkout/to_payment; do
  printf "%-22s " "$p"
  curl -sk -o /dev/null -m 12 -w 'status=%{http_code} redirect=%{redirect_url}\n' \
    "https://mitxonline.mit.dev$p"
done
```

Expected — `/cart` gates at APISIX again, and `/checkout/anonymous` falls through to the pass-auth wildcard and gates at the app layer instead:

```
/cart/                 status=302 redirect=https://sso.ol.mit.dev/realms/olapps/protocol/openid-connect/auth?...&redirect_uri=https%3A%2F%2Fmitxonline.mit.dev%2Fcart%2F.apisix%2Fredirect&...
/cart                  status=302 redirect=https://sso.ol.mit.dev/realms/olapps/protocol/openid-connect/auth?...
/checkout/anonymous    status=302 redirect=https://mitxonline.mit.dev/login/?next=/checkout/anonymous
/checkout/to_payment   status=302 redirect=https://mitxonline.mit.dev/login/?next=/checkout/to_payment
```

Confirm the live route group matches production's four sub-routes:

```
kubectl get apisixroute -n mitxonline mitxonline-route \
  -o jsonpath='{range .spec.http[*]}{.name}{" "}{.priority}{" "}{.match.paths}{"\n"}{end}'
```

```
passauth 0 ["/*"]
logout-redirect 10 ["/logout/oidc/*"]
reqauth 10 ["/login/*","/admin/login/*","/login*","/login/oidc*"]
cart 20 ["/cart","/cart/","/cart/*"]
```

**learn-ai readiness** — unchanged by this PR; `learnai-webapp` should still be `2/2` Ready:

```
kubectl get pods -n learn-ai -l app=learnai-webapp
```
