### PR TITLE
fix(local-dev): set mitxonline login and logout redirect URLs

### DIFF
--- a/local-dev/apps/mitxonline/configmaps/app-env.yaml
+++ b/local-dev/apps/mitxonline/configmaps/app-env.yaml
@@ -8,6 +8,17 @@ data:
   DJANGO_SETTINGS_MODULE: "main.settings"
   MITX_ONLINE_BASE_URL: "https://mitxonline.mit.dev"
   MITXONLINE_DOCKER_BASE_URL: "https://mitxonline.mit.dev"
+
+  # Redirect target for a first-time login (GatewayLoginView sends users whose
+  # profile has completed_onboarding=False here); defaults to a legacy
+  # mitxonline.odl.local:8013 host, which doesn't resolve in this stack.
+  MITXONLINE_NEW_USER_LOGIN_URL: "https://mitxonline.mit.dev/create-profile"
+
+  # The trailing "&" is deliberate: the view appends "?redirect_url=..." to this
+  # value, and it keeps no_redirect parsing as exactly "1".
+  # If the openedx app is ever enabled here, change this to
+  # https://lms.mit.dev/logout to match how the deployed envs do it.
+  LOGOUT_REDIRECT_URL: "https://mitxonline.mit.dev/logout?no_redirect=1&"
   MITX_ONLINE_DB_DISABLE_SSL: "True"
   MITX_ONLINE_USE_S3: "False"
   DEBUG: "False"


### PR DESCRIPTION
Fixes login *and* logout on `mitxonline.mit.dev` — two settings were left at defaults that only make sense for the legacy Compose stack.

- `MITXONLINE_NEW_USER_LOGIN_URL` — defaulted to `http://mitxonline.odl.local:8013/create-profile`, so a first-ever login redirected to a host that doesn't resolve here.
- `LOGOUT_REDIRECT_URL` — defaulted to `/`, so `/logout/` just 302'd to `/?redirect_url=...` and **left the gateway session intact**. Only APISIX's `/logout/oidc` ends the session, and `/logout/` reaches it via a re-entry carrying `no_redirect=1` — normally supplied by Open edX's logout interstitial, which isn't in this stack's `enabled_apps`.

## How can this be tested?

1. New incognito window, visit `https://mitxonline.mit.dev` and log in.
   - Expect to land on `https://mitxonline.mit.dev/create-profile/`, not `mitxonline.odl.local:8013`.
   - Use a Keycloak account that hasn't logged into mitxonline before. A returning user has `completed_onboarding=True` and skips this redirect entirely, so it won't reproduce.
2. Log out.
   - Expect to end up **logged out** on the mitxonline home page; reloading should keep you logged out.
   - Before this change you landed on `/?redirect_url=https%3A%2F%2Fmitxonline.mit.dev` still logged in.

*Note: the `LOGOUT_REDIRECT_URL` value carries its own query string, which looks wrong but isn't — see the comment above it. Worth a skim before "tidying" it.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
