### PR TITLE
feat(concourse): preview the next environment on edxapp and EKS gates

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/eks_clusters/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/eks_clusters/pipeline.py
@@ -36,6 +36,11 @@ for cluster in ["data", "operations", "applications", "residential"]:
     infra_chain = pulumi_jobs_chain(
         eks_infrastructure_code,
         refresh_stack=True,
+        # Show what promoting will apply to the next cluster stage in the gate
+        # issue. Cluster stages drift from each other more than most stacks --
+        # they get hand-touched during incidents -- and that drift is invisible
+        # in the diff of the stage that was just deployed.
+        preview_next_stack=True,
         project_name="ol-infrastructure-eks",
         project_source_path=PULUMI_CODE_PATH.joinpath("infrastructure/aws/eks"),
         stack_names=[f"{cluster}.{stage}" for stage in stages],
@@ -45,6 +50,7 @@ for cluster in ["data", "operations", "applications", "residential"]:
     substructure_chain = pulumi_jobs_chain(
         eks_substructure_code,
         refresh_stack=True,
+        preview_next_stack=True,
         project_name="ol-substructure-eks",
         project_source_path=PULUMI_CODE_PATH.joinpath("substructure/aws/eks"),
         stack_names=[f"{cluster}.{stage}" for stage in stages],

--- a/src/ol_concourse/pipelines/open_edx/edx_platform_v3/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/edx_platform_v3/pipeline.py
@@ -219,6 +219,12 @@ def build_edx_pipeline(release_names: list[str]) -> Pipeline:
                     # edxapp's Pulumi code provisions Fastly resources; refresh
                     # calls the Fastly API and fails while the token is rotated.
                     refresh_stack=False,
+                    # Show what promoting will apply to the next environment in
+                    # the gate issue. edxapp is the largest blast radius in the
+                    # estate and its environments are the most likely to have
+                    # drifted, which is exactly what the deployed stack's own
+                    # diff cannot show. The preview cannot fail the deploy.
+                    preview_next_stack=True,
                     stack_names=[
                         f"{deployment.deployment_name}.{stage}"
                         for stage in deployment.envs_by_release(release_name)


### PR DESCRIPTION
### What are the relevant tickets?

Enables the `preview_next_stack` capability added in mitodl/ol-concourse#82 (ol-concourse 0.13.0, adopted in #5346).

### Description (What does it do?)

The promotion-gate issue already shows **what the deploy just did**. This adds, for these two pipeline sets, **what closing the issue will apply to the next environment**:

```markdown
## Pulumi resource summary            <- what this deploy DID
| update | 1 |

---

## Promoting this will apply to `data.QA`      <- what promoting WILL DO

:hourglass: **This is a prediction, not a guarantee.** It was taken when this
issue was opened; if the gate sits open, drift or other merges can change what
actually applies.

| delete | 1 |
- `stale-qa-only-role` — `keycloak:index/role:Role`
```

The applied diff is only a proxy for the promotion decision — same code, different config — and it **structurally cannot show drift that exists in the target and not in the stack just deployed**. These two sets are where that drift actually accumulates: EKS cluster stages get hand-touched during incidents, and edxapp is the largest blast radius in the estate.

Left **off everywhere else**. It isn't free: it runs a real `pulumi preview` against the next environment on the success path of every deploy, with the API load on that environment's control plane that implies.

**It cannot fail a deploy.** The preview put is wrapped in a Concourse `try` and carries `fail_on_error: false`; a preview that can't reach the next environment degrades to a section in the issue body saying so, and explicitly notes the deploy above is not implicated.

### How can this be tested?

Rendered both pipelines rather than trusting the flag.

**EKS** (4 clusters × infra + substructure chains) — exactly the expected shape:

```
deploy-ol-infrastructure-eks-data.ci         preview->data.QA          body_files=2
deploy-ol-infrastructure-eks-data.qa         preview->data.Production  body_files=2
deploy-ol-infrastructure-eks-data.production preview->NONE             body_files=1
deploy-ol-substructure-eks-data.ci           preview->data.QA          body_files=2
...
```

**edxapp** — 12 deploy jobs, **5 get a preview**, and `fail_on_error: false` on every one. The 7 without are all genuinely last-in-chain. That's worth understanding rather than glossing, because chains are per *(Open edX release, deployment)*:

| Release | Deployment | Chain | Previews |
| --- | --- | --- | --- |
| master | mitxonline | `[CI, QA, Production]` | CI→QA, QA→Prod |
| verawood | mitx | `[QA, Production]` | QA→Prod |
| verawood | mitx-staging | `[QA, Production]` | QA→Prod |
| ulmo | xpro | `[QA, Production]` | QA→Prod |
| master | mitx | `[CI]` | none — chain of one |
| master | mitx-staging | `[CI]` | none — chain of one |
| verawood | xpro | `[CI]` | none — chain of one |

### :warning: Known limitation, worth reading before you read the gates

For **mitx, mitx-staging and xpro**, CI and QA sit in **different chains**, because they're on different Open edX releases. The preview only spans within a single `pulumi_jobs_chain` call, so **those CI gates will not preview QA** — only their QA gates preview Production.

**mitxonline is the only edxapp deployment whose entire CI→QA→Production path is one chain**, and therefore the only one with full coverage.

That's inherent to how the preview is scoped, not a bug in this change. If cross-chain previews turn out to matter for edxapp, that's a follow-up on the ol-concourse side.

### Additional Context

168 `tests/ol_concourse/` tests pass; `pre-commit` clean.

Takes effect on the next `pulumi-infrastructure-meta` / `dagger-pulumi-edxapp-meta-v3` run. Both resource images are already live, so no ordering constraint remains — and note that the meta jobs run inside `mitodl/ol-infrastructure:latest` pulled **through the ECR pull-through cache**, which needs to hold the current digest for a re-set to actually change anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2dsMxDihnRVJgcLoStQCv