### PR TITLE
setting ovs allowed hosts

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1161,6 +1161,7 @@ env_name = stack_info.name.lower() if stack_info.name != "QA" else "rc"
 # Values that are generally unchanging across environments
 env_vars = {
     "ALLOWED_HOSTS": '["*"]',
+    "OVS_ALLOWED_MEDIA_HOSTS": '[".cloudfront.net"]',
     "AWS_STORAGE_BUCKET_NAME": f"ol-mitlearn-app-storage-{env_name}",
     "CANVAS_PDF_TRANSCRIPTION_MODEL": "gpt-4o",
     "CONTENT_FILE_EMBEDDING_CHUNK_OVERLAP": 51,


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
Related to https://github.com/mitodl/mit-learn/pull/3743 and https://github.com/mitodl/hq/issues/12773
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
This PR explicitly sets the hosts we allow for ovs webhooks


### How can this be tested?
Local testing instructions for mit-learn are in  https://github.com/mitodl/mit-learn/pull/3743
