### PR TITLE
fix(rootly): defer Low urgency off-hours so it stops being noisier than Medium

### DIFF
--- a/src/ol_infrastructure/saas/rootly/__main__.py
+++ b/src/ol_infrastructure/saas/rootly/__main__.py
@@ -653,6 +653,38 @@ escalation_level_r_8ee197b2_ffe5_4696_b4a0_760e5c84a343 = rootly.EscalationLevel
 # so they fall through unaffected -- exactly matching the review decision
 # from 2026-07-20 (demote 10 specific alertnames, business-hours page is
 # still acceptable for them, only overnight/weekend paging is not).
+# Shared by both deferral paths below. Extracted rather than duplicated because
+# the requirement is not "two paths that happen to have the same window" but
+# "Low is never held less than Medium" -- if these ever drift apart, the lower
+# tier silently becomes the noisier one, which is the exact bug the Low path
+# below exists to fix. One definition makes that impossible.
+OFF_HOURS_DEFERRAL_WINDOW = {
+    "ruleType": "deferral_window",
+    "timeZone": "America/New_York",
+    "timeBlocks": [
+        {
+            "monday": True,
+            "tuesday": True,
+            "wednesday": True,
+            "thursday": True,
+            "friday": True,
+            "startTime": "00:00",
+            "endTime": "09:00",
+        },
+        {
+            "monday": True,
+            "tuesday": True,
+            "wednesday": True,
+            "thursday": True,
+            "friday": True,
+            "startTime": "17:00",
+            "endTime": "23:59",
+        },
+        {"saturday": True, "allDay": True},
+        {"sunday": True, "allDay": True},
+    ],
+}
+
 escalation_path_defer_medium_urgency_off_hours = rootly.EscalationPath(
     "defer-medium-urgency-off-hours",
     name="Defer Medium urgency outside business hours",
@@ -665,32 +697,45 @@ escalation_path_defer_medium_urgency_off_hours = rootly.EscalationPath(
             "ruleType": "alert_urgency",
             "urgencyIds": ["fce5c971-6660-4ad9-90eb-e75122055f50"],
         },
+        OFF_HOURS_DEFERRAL_WINDOW,
+    ],
+    opts=rootly_opts,
+)
+
+# Low urgency had NO deferral, which made it *less* protected overnight than
+# Medium -- an inversion nobody chose. Alerts demoted to Low (the production
+# Grafana source demotes `severity=warning` this way, see
+# alert_source_urgency_rules_attributes above) match the unmanaged `Low Urgency`
+# escalation path, which is `notification_type: quiet` and has no time
+# restriction at all, so it fires at 3am like any other hour.
+#
+# "Quiet" is weaker than it sounds. It does not mean "does not page" -- it
+# selects which of each USER'S OWN notification rules fire, and those are
+# per-user and owned outside this stack. Measured 2026-08-10 on the two on-call
+# engineers with rules configured: one has quiet = non-critical push then SMS
+# (no call), the other has quiet = email + push + CALL + SMS all at zero delay.
+# For that second engineer, Low was *more* intrusive than High, whose audible
+# rules are push + email only. So the urgency ladder is not monotonic across
+# the rotation, and demoting an alert to Low is NOT a reliable way to stop it
+# waking someone -- which is why this change defers Low rather than trying to
+# make it quieter, and why routing to a policy with no paging level (see the
+# CI/QA Slack Notifications policy) remains the only dependable "do not page".
+#
+# Deliberately mirrors the Medium path exactly: same window, same
+# re_evaluate behaviour. Low must never be held less than Medium.
+escalation_path_defer_low_urgency_off_hours = rootly.EscalationPath(
+    "defer-low-urgency-off-hours",
+    name="Defer Low urgency outside business hours",
+    escalation_policy_id="96629210-cc41-4e57-b059-b182a0f01c5b",
+    path_type="deferral",
+    match_mode="match-all-rules",
+    after_deferral_behavior="re_evaluate",
+    rules=[
         {
-            "ruleType": "deferral_window",
-            "timeZone": "America/New_York",
-            "timeBlocks": [
-                {
-                    "monday": True,
-                    "tuesday": True,
-                    "wednesday": True,
-                    "thursday": True,
-                    "friday": True,
-                    "startTime": "00:00",
-                    "endTime": "09:00",
-                },
-                {
-                    "monday": True,
-                    "tuesday": True,
-                    "wednesday": True,
-                    "thursday": True,
-                    "friday": True,
-                    "startTime": "17:00",
-                    "endTime": "23:59",
-                },
-                {"saturday": True, "allDay": True},
-                {"sunday": True, "allDay": True},
-            ],
+            "ruleType": "alert_urgency",
+            "urgencyIds": ["d7ed8e91-ffa9-4cc4-b524-729d14a4425b"],
         },
+        OFF_HOURS_DEFERRAL_WINDOW,
     ],
     opts=rootly_opts,
 )


### PR DESCRIPTION
### What are the relevant tickets?

N/A — tracked in witan as `tk-make-severity-mean-something-split-warning-criti-27f976`, from `docs/plans/grafana-alerting-remediation-spec.md` (W2).

**This PR does not implement W2 as originally specified.** Investigating it showed the spec would have made on-call *worse* for at least one person. Details below.

### Description (What does it do?)

Adds a Low-urgency off-hours deferral path to the Default Escalation Policy, mirroring the existing Medium one.

**The bug.** Low urgency had **no deferral path at all**. Medium has one (`Defer Medium urgency outside business hours`); Low did not. So an alert demoted to Low — which is what the production Grafana source does to every `severity=warning` — was *less* protected overnight than an alert left at Medium. Nobody chose that inversion; it's what happens when a tier gets added without the deferral that makes the tier above it survivable.

The shared time window is extracted to `OFF_HOURS_DEFERRAL_WINDOW` rather than copied. The requirement isn't "two paths that happen to match" but "Low is never held less than Medium" — if they drift apart, the lower tier silently becomes the louder one, which is the exact bug being fixed.

### Why this defers Low instead of silencing it

The spec's plan was to demote things to Low and treat Low as non-paging. That doesn't work, and the reason is worth recording.

Rootly's `notification_type: quiet` on an escalation path does **not** mean "does not page". It selects which of each *user's own* notification rules fire — and those are per-user, user-owned, and outside this Pulumi stack entirely. Measured 2026-08-10 on the two on-call engineers who have rules configured:

| | `quiet` (Low) | `audible` (High/Medium) |
|---|---|---|
| Engineer A | non-critical push @0, +SMS @5. No call. | push @0, +SMS @5, +**call** @10, repeats 5× |
| Engineer B | email + push + **call** + SMS, all @0 | push + email @0. No call. |

For Engineer B, **Low is more intrusive than High** — quiet triggers an immediate phone call, audible doesn't. The urgency ladder is not monotonic across the rotation.

Two consequences, both now recorded in code comments:

1. **Demoting an alert's urgency is not a dependable way to stop it waking someone.** The only reliable "do not page" is routing to an escalation policy with no paging level — e.g. the existing `CI/QA Slack Notifications` policy.
2. The originally-specified change (CI alert source `High` → `Low`) was **dropped from this PR**. It would have helped Engineer A and introduced an immediate 3am phone call for Engineer B. It needs the per-user rules sorted out first, or a routing-based fix instead.

Engineer B's inverted quiet/audible config looks like a likely misconfiguration and is worth raising with them directly — a data fix, not a code change.

### Also corrected

The spec claimed the Default Escalation Policy had **no** path conditioned on Low urgency. It does — `Low Urgency` (`67658f83-…`), `notification_type: quiet`, live since 2025-05-10. That claim came from reading the Pulumi source rather than the API; the path is unmanaged drift, so it isn't in `__main__.py`. Adopting it into Pulumi is worth doing but is deliberately **not** in this PR — the repo's own note warns `import_` rewrites live state to match the file rather than refusing on mismatch, so it deserves its own change.

### How can this be tested?

`pulumi preview --stack Production`:

```
+  rootly:index:EscalationPath defer-low-urgency-off-hours  create
~  rootly:index:AlertsSource cloudwatch-critical  update [diff: ~deduplicateAlertsByKey]
~  rootly:index:AlertsSource cloudwatch-warning   update [diff: ~deduplicateAlertsByKey]
+ 1 to create, ~ 2 to update, 154 unchanged
```

The Medium path shows **no diff**, confirming the constant extraction is value-identical.

⚠️ **The two CloudWatch diffs are pre-existing and not from this PR.** `deduplicate_alerts_by_key=False` is already on `main` (with a detailed rationale at `__main__.py:84-106`) but has never been applied — live state is still `true`. Whoever applies this PR will also apply that change. It looks intentional and correct, but it should be a conscious decision rather than a surprise, so flagging it here.

`ruff`, `mypy`, and the full pre-commit suite pass.

### Verify after deploy

```
GET /v1/escalation_policies/96629210-cc41-4e57-b059-b182a0f01c5b/escalation_paths
```
Expect a `Defer Low urgency outside business hours` path, `path_type: deferral`, with an `alert_urgency` rule matching `d7ed8e91-…` (Low) and the same `deferral_window` blocks as the Medium path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Uq83v9jvNg9GfBSXYG3NY
