### PR TITLE
fix(starrocks): give FE a way to actually get scheduled on the core nodegroup

### DIFF
--- a/src/ol_infrastructure/applications/starrocks/Pulumi.lakehouse.Production.yaml
+++ b/src/ol_infrastructure/applications/starrocks/Pulumi.lakehouse.Production.yaml
@@ -11,7 +11,11 @@ config:
   starrocks:oidc_enabled: "true"
   starrocks:fe_config:
     replicas: 3
-    cpu_request: 8000m
+    # Observed 7-day peak FE CPU is ~150m. An 8000m request reserved ~50x that
+    # and left FE unschedulable on the shared core nodegroup for 5 days
+    # (incident 2026-08-05). Burst headroom is preserved via cpu_limit.
+    cpu_request: 1000m
+    cpu_limit: 8000m
     memory_request: 24Gi
     memory_limit: 24Gi
     # 75% of 24Gi container limit = 18Gi heap, leaving ~6Gi for JVM non-heap.

--- a/src/ol_infrastructure/applications/starrocks/Pulumi.lakehouse.QA.yaml
+++ b/src/ol_infrastructure/applications/starrocks/Pulumi.lakehouse.QA.yaml
@@ -10,7 +10,11 @@ config:
   starrocks:oidc_enabled: "true"
   starrocks:fe_config:
     replicas: 3
-    cpu_request: 8000m
+    # See the prod stack: FE's observed peak CPU is a small fraction of the
+    # docs' 8-core sizing recommendation, and requesting the full 8 cores
+    # starves FE of scheduling room on the shared core nodegroup.
+    cpu_request: 1000m
+    cpu_limit: 8000m
     memory_request: 24Gi
     memory_limit: 24Gi
     # 75% of 24Gi container limit = 18Gi heap, leaving ~6Gi for JVM non-heap.

--- a/src/ol_infrastructure/applications/starrocks/__main__.py
+++ b/src/ol_infrastructure/applications/starrocks/__main__.py
@@ -125,27 +125,21 @@ core_node_selector = {"ol.mit.edu/core_node": "true"}
 # Incident 2026-07-30 (QA + prod): core nodes have no taint, so ordinary
 # Deployments (Airbyte, Dagster, JupyterHub, etc.) land there freely and can
 # fill a core node before an FE pod needs to reschedule onto it, leaving FE
-# Pending indefinitely with no automatic recovery. A hard taint would fix this
-# but would waste core-node capacity whenever FE isn't using it. A PriorityClass
-# instead lets other workloads use the spare capacity while letting the
-# scheduler preempt them if FE ever needs the room. Value is well below the
-# reserved system-* range (2,000,000,000+) but far above the default (0) used
-# by everything else on these clusters.
-starrocks_fe_priority_class_name = f"{stack_info.env_prefix}-starrocks-fe"
-starrocks_fe_priority_class = kubernetes.scheduling.v1.PriorityClass(
-    f"starrocks-{stack_info.env_prefix}-{stack_info.env_suffix}-fe-priority-class",
-    metadata=kubernetes.meta.v1.ObjectMetaArgs(
-        name=starrocks_fe_priority_class_name,
-        labels=k8s_app_labels.model_dump(),
-    ),
-    value=1000000,
-    global_default=False,
-    description=(
-        "StarRocks FE pods on the shared core nodegroup. Allows preempting "
-        "lower-priority pods (Airbyte, Dagster, JupyterHub, etc.) that would "
-        "otherwise starve FE of scheduling room on core nodes."
-    ),
-)
+# Pending indefinitely with no automatic recovery.
+#
+# A PriorityClass was tried here (#5183) and silently did nothing: the
+# starrocksclusters.starrocks.com/v1 CRD's starRocksFeSpec has no
+# priorityClassName field, so the API server pruned it and FE kept running at
+# priority 0 with no ability to preempt anything. Incident 2026-08-05 (prod)
+# was the result — fe-2 sat Pending for 5 days behind ~21 Dagster run pods on
+# the only core node its anti-affinity rule allowed.
+#
+# The scheduling room now comes from capacity instead: the core nodegroup runs
+# one more node than there are FE replicas, and FE's cpu_request is sized to
+# observed usage rather than the docs' sizing recommendation, so FE fits in the
+# gaps left by other workloads. The CRD does support `tolerations`, so if
+# capacity headroom proves insufficient the next step is a NoSchedule taint on
+# the core nodegroup plus a matching toleration here.
 
 
 def _starrocks_pod_anti_affinity(component: str, *, required: bool) -> dict[str, Any]:
@@ -439,7 +433,6 @@ starrocks_values: dict[str, Any] = {
         "serviceAccount": "starrocks",
         "runAsNonRoot": True,
         "nodeSelector": core_node_selector,
-        "priorityClassName": starrocks_fe_priority_class_name,
         "affinity": _starrocks_pod_anti_affinity("fe", required=True),
         "service": {
             "type": "ClusterIP",
@@ -455,15 +448,18 @@ starrocks_values: dict[str, Any] = {
         ),
         "resources": {
             "requests": {
-                # StarRocks recommends 8 CPU cores and 16 GB RAM per FE node.
+                # StarRocks recommends 8 CPU cores and 16 GB RAM per FE node,
+                # but that is a sizing recommendation, not a reservation: FE's
+                # observed 7-day peak is ~150m. Requesting the full 8 cores
+                # reserved ~50x actual usage and made FE nearly unplaceable on
+                # the shared core nodegroup (incident 2026-08-05). Request to
+                # observed usage, burst to the recommendation via the limit.
                 # Ref: https://docs.starrocks.io/docs/deployment/plan_cluster/
-                "cpu": fe_config.get("cpu_request", "8000m"),
+                "cpu": fe_config.get("cpu_request", "1000m"),
                 "memory": fe_config.get("memory_request", "16Gi"),
             },
             "limits": {
-                "cpu": fe_config.get(
-                    "cpu_limit", fe_config.get("cpu_request", "8000m")
-                ),
+                "cpu": fe_config.get("cpu_limit", "8000m"),
                 "memory": fe_config.get("memory_limit", "16Gi"),
             },
         },
@@ -922,7 +918,6 @@ starrocks_release = kubernetes.helm.v3.Release(
         depends_on=[
             starrocks_root_password_secret,
             starrocks_auth_binding,
-            starrocks_fe_priority_class,
         ],
     ),
 )

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.data.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.data.Production.yaml
@@ -72,10 +72,15 @@ config:
         ondemand: true
         ol.mit.edu/core_node: true
       node_group_options: {}
+      # 4, not 3, for two reasons (incident 2026-08-05): the ASG spans 4 AZs, so
+      # at desired=3 one AZ has no core node and any FE whose EBS volumes live
+      # there becomes permanently unschedulable; and StarRocks FE runs 3
+      # replicas with hostname anti-affinity, so at 3 nodes each FE has exactly
+      # one candidate node and no room to reschedule if that node fills up.
       scaling:
-        desired: 3
+        desired: 4
         max: 5
-        min: 3
+        min: 4
       tags: {}
       taints: {}
       version:


### PR DESCRIPTION
### What are the relevant tickets?

N/A — came in via a page: "There is a mismatch between the requested number of instances for statefulset lakehouse-starrocks-fe in namespace starrocks in cluster data-production."

### Description (What does it do?)

`lakehouse-starrocks-fe-2` had been `Pending` for 5 days in data-production, leaving the FE StatefulSet at 2/3. `SHOW FRONTENDS` confirmed the impact — fe-1 LEADER, fe-0 alive, fe-2 `Alive: false` / `Join: false` since 2026-08-05 15:50. BDBJE quorum was holding at 2 of 3 with **zero fault tolerance**: losing either surviving FE would have taken the lakehouse down.

Three separate problems combined to make that pod unschedulable. Each one is independently sufficient to block it, so all three are fixed here.

**1. The pod's volumes were stranded in an AZ with no core node.**

`data-production-eks-nodegroup-worker-xlarge-f771ded` spans all four AZs but ran `desired: 3`, so it held one node each in 1b/1c/1d and nothing in 1a. fe-2's `meta` and `log` PVs are pinned to `us-east-1a`:

```
lakehouse-fe-storage-meta-lakehouse-starrocks-fe-2  zone=us-east-1a
lakehouse-fe-storage-log-lakehouse-starrocks-fe-2   zone=us-east-1a
```

The only 1a node is Karpenter-owned with `ol.mit.edu/core_node=false`, which fails FE's nodeSelector. No amount of free CPU would have placed this pod.

This bump to `desired: 4` / `min: 4` covers the fourth AZ. It also gives FE somewhere to go in general: with 3 replicas under hostname anti-affinity and exactly 3 nodes, each FE has precisely one candidate node and no recourse when that node fills up.

**2. The FE PriorityClass from #5183 was a silent no-op.**

That PR added `priorityClassName` to `starrocksFESpec` specifically so FE could preempt Dagster/Airbyte off core nodes. But `priorityClassName` is not a field in the `starrocksclusters.starrocks.com/v1` CRD's `starRocksFeSpec` — it supports `affinity`, `tolerations`, and `schedulerName`, and the API server prunes the rest. The result:

```
$ kubectl -n starrocks get starrockscluster -o jsonpath='{.items[].spec.starRocksFeSpec.priorityClassName}'
<empty>
$ kubectl -n starrocks get sts lakehouse-starrocks-fe -o jsonpath='{.spec.template.spec.priorityClassName}'
<empty>
$ kubectl -n starrocks get pod lakehouse-starrocks-fe-2 -o jsonpath='{.spec.priority}'
0
```

FE ran at priority 0 the whole time and could not preempt the ~21 Dagster run pods that had filled `ip-10-3-156-210` to 99% CPU — which is exactly what the scheduler was reporting with `No preemption victims found for incoming pod`.

Removing it rather than leaving a mechanism that reads as protection but isn't. The comment block now records why the approach fails, so it doesn't get re-attempted, and points at `tolerations` as the CRD-supported fallback if capacity headroom turns out to be insufficient.

**3. FE requested 8000m CPU against a ~150m peak.**

7-day max, via Prometheus (`grafanacloud-prom`):

```promql
max_over_time(sum by (pod) (rate(container_cpu_usage_seconds_total{
  cluster="data-production", namespace="starrocks",
  pod=~"lakehouse-starrocks-fe-.*", container="fe"}[5m]))[7d:5m])
```

| pod | 7d peak CPU |
|---|---|
| lakehouse-starrocks-fe-0 | 117m |
| lakehouse-starrocks-fe-1 | 152m |
| lakehouse-starrocks-fe-2 | 32m |

The 8-core figure comes from the [StarRocks cluster planning docs](https://docs.starrocks.io/docs/deployment/plan_cluster/), but that's a sizing recommendation, not a reservation — treating it as one reserved ~50x actual usage and made FE nearly unplaceable on a shared nodegroup. Request now matches observed usage; the 8-core burst headroom is preserved as a limit, so `cpu_limit` no longer just mirrors `cpu_request`.

Memory is untouched — that reservation is real (20.4Gi in use against a 24Gi request, sized around the 18Gi JVM heap).

QA carries the identical oversized request and hit the same incident on 2026-07-30, so it gets the same change.

### How can this be tested?

Both stacks preview clean, showing only the intended diffs.

`ol-application-starrocks/lakehouse.Production`:

```
~ kubernetes:helm.sh/v3:Release: (update) [id=starrocks/lakehouse-starrocks]
  ~ values: { ~ starrocksFESpec: {
      - priorityClassName: "lakehouse-starrocks-fe"
      ~ resources: { ~ requests: { ~ cpu: "8000m" => "1000m" } } } }
- kubernetes:scheduling.k8s.io/v1:PriorityClass: (delete) [id=lakehouse-starrocks-fe]
```

Limits stay at 8000m, as intended.

`ol-infrastructure-eks/data.Production`:

```
~ aws:autoscaling/group:Group: (update) [id=data-production-eks-nodegroup-worker-xlarge-f771ded]
  ~ desiredCapacity: 3 => 4
  ~ minSize        : 3 => 4
```

`pre-commit run` passes on all four files (ruff, ruff format, mypy, yamllint, detect-secrets).

**Post-deploy validation** — after the EKS stack lands, the new node should appear in the missing AZ and fe-2 should schedule onto it:

```bash
kubectl -n starrocks get pods -o wide | grep fe-
kubectl get nodes -L topology.kubernetes.io/zone,ol.mit.edu/core_node
kubectl -n starrocks exec lakehouse-starrocks-fe-0 -c fe -- \
  mysql -h127.0.0.1 -P9030 -uroot -e "SHOW FRONTENDS\G"
```

All three frontends should report `Alive: true` and `Join: true`.

### Additional Context

**Deploy the EKS stack first, and wait for quorum before applying the StarRocks stack.**

The FE StatefulSet is `RollingUpdate` with `maxUnavailable: 1`, so the `cpu_request` change restarts FE pods. With fe-2 currently dead, rolling either survivor drops the cluster to 1-of-3 and **loses BDBJE quorum** — a lakehouse outage. The existing PDB does not prevent this; it gates the eviction API, not StatefulSet controller-driven deletes, and already reads `ALLOWED DISRUPTIONS: 0`.

Order:

1. Apply `ol-infrastructure-eks/data.Production`.
2. Confirm the 4th core node came up in `us-east-1a` and that fe-2 scheduled onto it. fe-2 will fit with its current 8000m request — a fresh core node has ~14.4 CPU free after DaemonSets.
3. Confirm all three FEs show `Alive: true` / `Join: true`.
4. Only then apply `ol-application-starrocks/lakehouse.Production`.

If the 4th node lands somewhere other than 1a — ASG AZ-balancing is best-effort and could be overridden by capacity constraints — delete fe-2's two PVCs and the pod so `WaitForFirstConsumer` re-provisions them in the new node's AZ. That's the same recovery performed for fe-0 on 2026-07-30.

**The EKS stack has unrelated undeployed drift.** `pulumi preview` on `data.Production` shows 4 updates: the nodegroup change plus memory-limit reductions to `vertical-pod-autoscaler`, `external-dns`, and `aws-load-balancer-controller`. Those come from already-merged code (likely #5241) that hasn't been applied to this stack — this branch doesn't touch `infrastructure/aws/eks/__main__.py`. Applying the stack ships them too, so they're worth a look before running `up`.

**Known follow-up, deliberately not in this PR:** `data-qa`'s `worker-xlarge` has the same `desired: 3` across 4 AZs, so the stranded-volume failure mode is latent there as well. Dropping QA's FE request addresses the CPU half but not the AZ half. Left alone here since node count on a non-prod cluster is a cost decision.

### Checklist:
- [ ] Apply `ol-infrastructure-eks/data.Production` and confirm FE quorum is 3/3 **before** applying `ol-application-starrocks/lakehouse.Production` (see Additional Context)
- [ ] Review the three unrelated helm memory changes that will ship with the EKS stack
