### PR TITLE
feat(omnigraph): run the storage-format rebuild as an in-cluster Job

### DIFF
--- a/docs/omnigraph-storage-format-upgrade-runbook.md
+++ b/docs/omnigraph-storage-format-upgrade-runbook.md
@@ -194,7 +194,60 @@ omnigraph snapshot --store s3://ol-data-witan-ci/graphs/council.omni
 
 The cluster's own state ledger lives at `<root>/__cluster/state.json`.
 
-## Procedure
+## The automated path (preferred)
+
+Steps 2, 3, 4 and 6 below — baseline, export, rebuild, verify — run as a single
+in-cluster Job. Use it. The manual procedure that follows is kept as the
+reference for what the Job does, and as the fallback when something in the
+middle needs picking apart by hand.
+
+```shell
+cd src/ol_infrastructure/applications/omnigraph
+
+# The image currently deployed — its binary is the only one that can still read
+# the old root. `kubectl -n omnigraph get deploy/omnigraph-server \
+#   -o jsonpath='{.spec.template.spec.containers[0].image}'`
+pulumi config set omnigraph:migrate_from_image <OLD-image-ref> --stack <CI|QA|Production>
+# Where the rebuild lands. Digits = the NEW internal-schema number.
+pulumi config set omnigraph:migrate_to_prefix fmt6 --stack <CI|QA|Production>
+
+pulumi up --stack <CI|QA|Production>     # creates the Job; suspends both sweeps
+kubectl -n omnigraph logs -f job/omnigraph-migrate-fmt6
+```
+
+**Two config knobs, and the distinction is the point.**
+`migrate_to_prefix` is where the rebuild WRITES. `storage_prefix` is what the
+cluster SERVES — setting it *is* the cutover, and it takes effect immediately
+(`pulumi preview` shows `storage_uri` moving, the Deployment's config hash
+rolling and both CronJobs following). Arming the migration on `storage_prefix`
+would point the running server at an empty root before the rebuild had written
+a row. The program refuses if both name the same prefix.
+
+The Job runs one pod carrying **both** binaries: an initContainer on the old
+image copies its `omnigraph` into a shared volume, and the main container runs
+the new image. So every byte goes S3 → pod → S3, and the `kubectl exec`
+transfer in steps 2–4 — the slowest part of the manual path, and the only step
+that fails silently — does not happen at all.
+
+It also **suspends `optimize` and `cleanup`** for the duration, because both
+write directly to the store and scaling the Deployment to zero does not stop
+them. Clearing `migrate_from_image` resumes them in the same `pulumi up`.
+
+The Job stops after verification. It does **not** cut over: that is
+`pulumi config set omnigraph:storage_prefix`, which needs Pulumi credentials a
+workload has no business holding, and writing the ConfigMap instead would make
+it a second writer of a path Pulumi owns. On success it prints the exact
+cutover command and writes `/tmp/migration-verdict.json` (per-graph, per-table
+before/after counts) for anything that wants to gate on it.
+
+Then continue at **step 5** below, and finish with step 7.
+
+If the Job fails, it fails clean: the old root is untouched, the cluster still
+serves it, and the exports are still on the pod. Read the logs before deleting
+it — `ttlSecondsAfterFinished` keeps it for a week precisely so the evidence
+outlives the run.
+
+## Procedure (manual)
 
 Set these first, **on your workstation** — steps 5, 6 and 7 use them there:
 
@@ -255,13 +308,26 @@ exits it is still a writer against the old root. `rollout status` reports the
 Deployment converged and would let you proceed with the server still up.
 
 Nothing may write to the old root from here until the migration completes or
-rolls back. Confirm no maintenance job is mid-run — `optimize`/`cleanup` write
-directly to the store, bypassing the server entirely:
+rolls back. `optimize`/`cleanup` write directly to the store, bypassing the
+server entirely, so scaling the Deployment to zero does **not** stop them.
+
+The automated path suspends both when `migrate_from_image` is set. If you are
+running the manual procedure, suspend them yourself — and note this is a real
+exposure, not a formality: `optimize` rewrites Lance fragments, and a tick
+landing between the step-3 export and the step-6 verification is a write to a
+root this procedure has declared frozen.
 
 ```shell
-kubectl -n omnigraph get jobs
+kubectl -n omnigraph patch cronjob/omnigraph-optimize -p '{"spec":{"suspend":true}}'
+kubectl -n omnigraph patch cronjob/omnigraph-cleanup  -p '{"spec":{"suspend":true}}'
+kubectl -n omnigraph get jobs            # and confirm none is already mid-run
 kubectl -n omnigraph get pods            # expect no omnigraph-server pod at all
 ```
+
+> A hand-patched CronJob is reverted by the next `pulumi up` for anything at
+> all, and a Production migration can span days. Prefer the config-driven
+> suspension even if you are otherwise working through this manually — set
+> `omnigraph:migrate_from_image` and the sweeps stay down until you clear it.
 
 ### 2. Start the OLD-image workspace pod
 
@@ -325,8 +391,13 @@ done
 ```
 
 Then pull them onto your workstation, which is where step 4 pushes them from.
-**The image has no `aws`, `curl`, or `python3` — only the `omnigraph` binaries** —
-so the transfer goes through `kubectl`, not an S3 round trip:
+**The image has no `aws` or `curl`**, so the transfer goes through `kubectl`,
+not an S3 round trip:
+
+> The image *does* carry `python3` (`python3-minimal` + `python3-yaml`, added
+> for the entrypoint's `render_groups.py`) — an earlier version of this note
+> said otherwise, which is true of the upstream `modernrelay/omnigraph-server`
+> image but not of ours. That is what the automated path's script runs on.
 
 ```shell
 mkdir -p /tmp/export
@@ -570,6 +641,20 @@ is a stray identity with write access to the bucket:
 kubectl -n omnigraph delete pod omnigraph-migrate-old omnigraph-migrate-new --ignore-not-found
 ```
 
+**Resume the maintenance sweeps.** Clearing the migration config does both —
+it removes the Job and un-suspends `optimize`/`cleanup` in one `pulumi up`:
+
+```shell
+pulumi config rm omnigraph:migrate_from_image --stack <CI|QA|Production>
+pulumi config rm omnigraph:migrate_to_prefix  --stack <CI|QA|Production>
+pulumi up --stack <CI|QA|Production>
+kubectl -n omnigraph get cronjob    # SUSPEND must read False for both
+```
+
+Left suspended, the first symptom is fragment bloat degrading query latency
+weeks later, with nothing pointing back at the migration that caused it. If you
+suspended by hand instead, un-patch by hand.
+
 The old root itself waits. **Not the same day** — leave `$OLD_ROOT/graphs/`
 untouched through at least one full soak (a week for Production), because it is
 the only fast rollback. Delete it, and the workstation copy of the exports in
@@ -636,6 +721,12 @@ because it looks like success.
   two-tier deployment this operates on; see its storage-format addendum.
 - `src/ol_infrastructure/applications/omnigraph/data_tier.py` — the Deployment,
   `Recreate` strategy, cluster.yaml generation, and `cluster apply` Job.
+- `src/ol_infrastructure/applications/omnigraph/storage_migration.py` — the
+  migration Job, its initContainer, and why it stops short of the cutover.
+- `src/ol_infrastructure/applications/omnigraph/scripts/migrate_storage_format.py`
+  — what the Job actually runs: baseline, export, rebuild, verify.
+- `src/ol_infrastructure/applications/omnigraph/maintenance.py` — the two
+  sweeps and the `suspend` flag a migration sets.
 - `src/ol_concourse/pipelines/infrastructure/omnigraph/pipeline.py` — the
   build-and-promote chain to pause.
 - [witan token sync runbook](witan-token-sync-runbook.md) — the other

--- a/docs/omnigraph-storage-format-upgrade-runbook.md
+++ b/docs/omnigraph-storage-format-upgrade-runbook.md
@@ -201,6 +201,20 @@ in-cluster Job. Use it. The manual procedure that follows is kept as the
 reference for what the Job does, and as the fallback when something in the
 middle needs picking apart by hand.
 
+**Do step 1 first.** The Job takes its baseline and exports by reading the old
+root directly, and it has no way to stop the server writing underneath it — a
+snapshot taken while the Deployment is still serving is a baseline of a moving
+target, and the export that follows can disagree with it. Scaling to zero is
+not optional just because the rest is automated:
+
+```shell
+kubectl -n omnigraph scale deploy/omnigraph-server --replicas=0
+kubectl -n omnigraph wait --for=delete pod \
+  -l app.kubernetes.io/name=omnigraph-server --timeout=120s
+```
+
+Then arm and run it:
+
 ```shell
 cd src/ol_infrastructure/applications/omnigraph
 
@@ -209,11 +223,17 @@ cd src/ol_infrastructure/applications/omnigraph
 #   -o jsonpath='{.spec.template.spec.containers[0].image}'`
 pulumi config set omnigraph:migrate_from_image <OLD-image-ref> --stack <CI|QA|Production>
 # Where the rebuild lands. Digits = the NEW internal-schema number.
+# Rejected at preview unless it matches fmt<N>, so a typo cannot arm an outage
+# for a Job that would refuse the root it was given.
 pulumi config set omnigraph:migrate_to_prefix fmt6 --stack <CI|QA|Production>
 
 pulumi up --stack <CI|QA|Production>     # creates the Job; suspends both sweeps
 kubectl -n omnigraph logs -f job/omnigraph-migrate-fmt6
 ```
+
+The Job is ordered behind the two CronJob suspensions, so it cannot start while
+maintenance is still schedulable. Scaling the Deployment down stays yours —
+Pulumi does not manage the replica count during a migration.
 
 **Two config knobs, and the distinction is the point.**
 `migrate_to_prefix` is where the rebuild WRITES. `storage_prefix` is what the
@@ -233,12 +253,24 @@ It also **suspends `optimize` and `cleanup`** for the duration, because both
 write directly to the store and scaling the Deployment to zero does not stop
 them. Clearing `migrate_from_image` resumes them in the same `pulumi up`.
 
+It verifies two things before reporting success: per-table row counts match for
+every graph, and the storage format actually moved — to one version, the same
+across all of them. A format that did not change means either the two images
+share one, so the outage bought nothing, or the wrong `migrate_from_image`.
+
 The Job stops after verification. It does **not** cut over: that is
 `pulumi config set omnigraph:storage_prefix`, which needs Pulumi credentials a
 workload has no business holding, and writing the ConfigMap instead would make
 it a second writer of a path Pulumi owns. On success it prints the exact
-cutover command and writes `/tmp/migration-verdict.json` (per-graph, per-table
-before/after counts) for anything that wants to gate on it.
+cutover command, and emits the verdict — per-graph, per-table before/after
+counts plus the old and new formats — **to its logs** as well as to
+`/tmp/migration-verdict.json`. Read it from the logs: the file lives on an
+`emptyDir` that goes with the container, and neither `kubectl exec` nor
+`kubectl cp` reaches a completed pod.
+
+```shell
+kubectl -n omnigraph logs job/omnigraph-migrate-fmt6 | sed -n '/migration verdict:/,$p'
+```
 
 Then continue at **step 5** below, and finish with step 7.
 
@@ -283,11 +315,16 @@ server pod to `exec` into either, so each step below says which of the two
 workspace pods it runs in. Commands starting with `kubectl` are the ones you
 run locally.
 
-> **The image ships only `omnigraph`, `omnigraph-server`, and its entrypoint.**
-> No `aws`, no `curl`, no `python3`. Anything moving data in or out of a
-> workspace pod goes through `kubectl exec`, not an S3 round trip — which is why
-> steps 3 and 4 hand the exports across rather than staging them in the bucket.
-> `aws` commands in this runbook run on your **workstation**.
+> **The image ships `omnigraph`, `omnigraph-server`, its entrypoint, and a
+> minimal `python3`** (`python3-minimal` + `python3-yaml`, there for the
+> entrypoint's `render_groups.py` — and what the automated path's migration
+> script runs on). There is no `aws` and no `curl`, so anything moving data in
+> or out of a workspace pod goes through `kubectl exec`, not an S3 round trip —
+> which is why steps 3 and 4 hand the exports across rather than staging them
+> in the bucket. `aws` commands in this runbook run on your **workstation**.
+>
+> The upstream `modernrelay/omnigraph-server` image carries no `python3`; ours
+> is built from `docker/omnigraph-server.Dockerfile` in agent-kit and does.
 
 Two pods, because the migration spans two binaries: `omnigraph-migrate-old`
 (step 2, baseline + export) and `omnigraph-migrate-new` (step 4, rebuild).
@@ -393,11 +430,6 @@ done
 Then pull them onto your workstation, which is where step 4 pushes them from.
 **The image has no `aws` or `curl`**, so the transfer goes through `kubectl`,
 not an S3 round trip:
-
-> The image *does* carry `python3` (`python3-minimal` + `python3-yaml`, added
-> for the entrypoint's `render_groups.py`) — an earlier version of this note
-> said otherwise, which is true of the upstream `modernrelay/omnigraph-server`
-> image but not of ours. That is what the automated path's script runs on.
 
 ```shell
 mkdir -p /tmp/export

--- a/src/ol_infrastructure/applications/omnigraph/__main__.py
+++ b/src/ol_infrastructure/applications/omnigraph/__main__.py
@@ -58,6 +58,7 @@ from ol_infrastructure.applications.omnigraph.cluster_config import (
     COUNCIL_GRAPH_ID,
 )
 from ol_infrastructure.applications.omnigraph.data_tier import (
+    CLUSTER_CONFIGMAP_NAME,
     OMNIGRAPH_SERVER_SERVICE_NAME,
     create_data_tier,
     omnigraph_server_addr,
@@ -68,6 +69,9 @@ from ol_infrastructure.applications.omnigraph.maintenance import (
     DEFAULT_OPTIMIZE_SCHEDULE,
 )
 from ol_infrastructure.applications.omnigraph.storage import validate_storage_prefix
+from ol_infrastructure.applications.omnigraph.storage_migration import (
+    create_storage_migration,
+)
 from ol_infrastructure.applications.omnigraph.token_sync import (
     ACTOR_TOKENS_VAULT_PATH,
     DEFAULT_SYNC_SCHEDULE,
@@ -135,6 +139,25 @@ MANAGED_REPOS: list[str] = omnigraph_config.get_object("managed_repos") or []
 # — it just builds the graphs somewhere nobody looks. See the runbook's
 # "cluster validate does not catch an empty storage:" note.
 STORAGE_PREFIX: str = validate_storage_prefix(omnigraph_config.get("storage_prefix"))
+
+# The image to migrate FROM — the one currently deployed, whose binary can
+# still read the old root. Set only while a storage-format migration is being
+# run; unset (the steady state) means no migration Job exists at all. See the
+# `if MIGRATE_FROM_IMAGE:` block below and storage_migration.py.
+MIGRATE_FROM_IMAGE: str = (omnigraph_config.get("migrate_from_image") or "").strip()
+
+# Where the migration REBUILDS INTO. Deliberately NOT `storage_prefix`, which
+# is what the live cluster SERVES: setting that is the cutover, and it takes
+# effect the moment it is set — `pulumi preview` shows storage_uri moving, the
+# Deployment's config hash rolling and both maintenance CronJobs following. So
+# arming the migration on `storage_prefix` would repoint the running server at
+# an empty root before the rebuild had written a single row.
+#
+# Two knobs, in sequence: `migrate_to_prefix` while rebuilding, then
+# `storage_prefix` once the Job's verdict says the rebuild is good.
+MIGRATE_TO_PREFIX: str = validate_storage_prefix(
+    omnigraph_config.get("migrate_to_prefix")
+)
 
 # Keycloak realm -> actor-token sync. Set `omnigraph:keycloak_url` for an
 # environment to turn it on; leaving it unset keeps that environment on the
@@ -702,7 +725,73 @@ data_tier = create_data_tier(
     cleanup_schedule=CLEANUP_SCHEDULE,
     cleanup_older_than=CLEANUP_OLDER_THAN,
     storage_prefix=STORAGE_PREFIX,
+    # Arming a migration suspends both maintenance sweeps for its duration.
+    # They write directly to the store, so scaling the Deployment to zero does
+    # not stop them, and `optimize` rewriting fragments between the export and
+    # the verification is a write to a root the migration needs frozen. Tied to
+    # the same config that creates the Job so the two cannot drift: clearing
+    # `migrate_from_image` resumes them in the same `pulumi up`.
+    suspend_maintenance=bool(MIGRATE_FROM_IMAGE),
 )
+
+#########################################
+#   storage-format migration (opt-in)   #
+#########################################
+# Absent unless an operator is deliberately running a migration. Setting
+# `omnigraph:migrate_from_image` (the CURRENTLY-DEPLOYED image ref) together
+# with `omnigraph:migrate_to_prefix` creates a one-shot Job that rebuilds every
+# graph at `s3://<bucket>/<migrate_to_prefix>`, exporting with the old image's
+# binary and loading with this deploy's. Clearing the config removes the Job.
+#
+# ARMING THIS DOES NOT CUT OVER, and that separation is the whole point.
+# `storage_prefix` is what the cluster SERVES; setting it moves storage_uri,
+# rolls the Deployment's config hash and redirects both maintenance CronJobs,
+# immediately. If the migration reused it, arming would point the running
+# server at an empty root before the rebuild wrote anything. So the rebuild
+# target is its own knob, and the sequence is: migrate_to_prefix -> run the Job
+# -> read the verdict -> storage_prefix.
+#
+# The Job rebuilds and verifies per-table row counts, then stops — see
+# storage_migration.py and docs/omnigraph-storage-format-upgrade-runbook.md.
+if MIGRATE_FROM_IMAGE:
+    if not MIGRATE_TO_PREFIX:
+        MIGRATION_MSG = (
+            "omnigraph:migrate_from_image is set but "
+            "omnigraph:migrate_to_prefix is not. The migration needs a target "
+            "root to rebuild into (fmt<N>, N being the NEW internal-schema "
+            "number) — without one the only root it could write is the one it "
+            "is migrating away from."
+        )
+        raise ValueError(MIGRATION_MSG)
+    if MIGRATE_TO_PREFIX == STORAGE_PREFIX:
+        CUTOVER_MSG = (
+            f"omnigraph:migrate_to_prefix and omnigraph:storage_prefix are "
+            f"both {MIGRATE_TO_PREFIX!r}, so the cluster is already serving "
+            "the root this migration would rebuild into — it would export "
+            "from the root it is writing to. If the cutover is done, clear "
+            "migrate_from_image/migrate_to_prefix; if it is not, clear "
+            "storage_prefix."
+        )
+        raise ValueError(CUTOVER_MSG)
+    storage_migration = create_storage_migration(
+        stack_info=stack_info,
+        namespace=NAMESPACE,
+        k8s_global_labels=k8s_global_labels,
+        old_image=MIGRATE_FROM_IMAGE,
+        new_image=data_tier.server_image,
+        # The root the cluster serves *now*: the bucket root, never a prefixed
+        # one. `data_tier.storage_uri` carries STORAGE_PREFIX, which during a
+        # migration is still the OLD root — but once a cutover has happened it
+        # would not be, and reading the bucket directly keeps this honest
+        # about what "migrate from" means.
+        old_storage_root=data_tier.bucket.bucket_v2.bucket.apply(
+            lambda name: f"s3://{name}"
+        ),
+        new_storage_prefix=MIGRATE_TO_PREFIX,
+        cluster_configmap_name=CLUSTER_CONFIGMAP_NAME,
+        service_account_name="omnigraph-server",
+    )
+    export("storage_migration_job", storage_migration.job.metadata.name)
 
 export("namespace", NAMESPACE)
 export("omnigraph_server_addr", omnigraph_server_addr(NAMESPACE))

--- a/src/ol_infrastructure/applications/omnigraph/__main__.py
+++ b/src/ol_infrastructure/applications/omnigraph/__main__.py
@@ -68,7 +68,10 @@ from ol_infrastructure.applications.omnigraph.maintenance import (
     DEFAULT_CLEANUP_SCHEDULE,
     DEFAULT_OPTIMIZE_SCHEDULE,
 )
-from ol_infrastructure.applications.omnigraph.storage import validate_storage_prefix
+from ol_infrastructure.applications.omnigraph.storage import (
+    validate_migration_target_prefix,
+    validate_storage_prefix,
+)
 from ol_infrastructure.applications.omnigraph.storage_migration import (
     create_storage_migration,
 )
@@ -155,7 +158,7 @@ MIGRATE_FROM_IMAGE: str = (omnigraph_config.get("migrate_from_image") or "").str
 #
 # Two knobs, in sequence: `migrate_to_prefix` while rebuilding, then
 # `storage_prefix` once the Job's verdict says the rebuild is good.
-MIGRATE_TO_PREFIX: str = validate_storage_prefix(
+MIGRATE_TO_PREFIX: str = validate_migration_target_prefix(
     omnigraph_config.get("migrate_to_prefix")
 )
 
@@ -779,17 +782,22 @@ if MIGRATE_FROM_IMAGE:
         k8s_global_labels=k8s_global_labels,
         old_image=MIGRATE_FROM_IMAGE,
         new_image=data_tier.server_image,
-        # The root the cluster serves *now*: the bucket root, never a prefixed
-        # one. `data_tier.storage_uri` carries STORAGE_PREFIX, which during a
-        # migration is still the OLD root — but once a cutover has happened it
-        # would not be, and reading the bucket directly keeps this honest
-        # about what "migrate from" means.
-        old_storage_root=data_tier.bucket.bucket_v2.bucket.apply(
-            lambda name: f"s3://{name}"
+        # SOURCE: the root the cluster serves right now, prefix and all. Only
+        # for a first migration is that the bare bucket; after one cutover it
+        # is s3://<bucket>/fmt<N>, and a second migration has to export from
+        # there. Reading the bucket directly (as this did) works exactly once
+        # and then silently exports from a path holding the pre-migration data.
+        old_storage_root=data_tier.storage_uri,
+        # DESTINATION: built from the bucket, NOT from the source — deriving it
+        # as f"{source}/{prefix}" nests roots on every migration after the
+        # first (s3://bucket/fmt5/fmt6).
+        new_storage_root=data_tier.bucket.bucket_v2.bucket.apply(
+            lambda name: f"s3://{name}/{MIGRATE_TO_PREFIX}"
         ),
         new_storage_prefix=MIGRATE_TO_PREFIX,
         cluster_configmap_name=CLUSTER_CONFIGMAP_NAME,
         service_account_name="omnigraph-server",
+        maintenance=data_tier.maintenance,
     )
     export("storage_migration_job", storage_migration.job.metadata.name)
 

--- a/src/ol_infrastructure/applications/omnigraph/data_tier.py
+++ b/src/ol_infrastructure/applications/omnigraph/data_tier.py
@@ -194,6 +194,11 @@ class OmnigraphDataTier(NamedTuple):
     # program can export what is actually being served rather than the config
     # knob that shaped it.
     storage_uri: Output[str]
+    # The fully-resolved image ref this deploy runs, digest and all. Exposed
+    # rather than recomputed by callers so anything that must run the SAME
+    # binary as the server — the storage-format migration Job loads with it —
+    # cannot drift onto a different one.
+    server_image: str | Output[str]
 
 
 def create_data_tier(  # noqa: PLR0913
@@ -209,6 +214,8 @@ def create_data_tier(  # noqa: PLR0913
     cleanup_schedule: str,
     cleanup_older_than: str,
     storage_prefix: str = "",
+    *,
+    suspend_maintenance: bool = False,
 ) -> OmnigraphDataTier:
     """Provision the S3 bucket, IRSA policy, ECR repo, ConfigMap, and Deployment.
 
@@ -776,6 +783,7 @@ def create_data_tier(  # noqa: PLR0913
         cleanup_schedule=cleanup_schedule,
         cleanup_older_than=cleanup_older_than,
         depends_on=[cluster_apply_job, *auth_binding.irsa_service_accounts],
+        suspend=suspend_maintenance,
     )
 
     return OmnigraphDataTier(
@@ -786,4 +794,5 @@ def create_data_tier(  # noqa: PLR0913
         cluster_apply_job=cluster_apply_job,
         maintenance=omnigraph_maintenance,
         storage_uri=storage_uri,
+        server_image=omnigraph_server_image,
     )

--- a/src/ol_infrastructure/applications/omnigraph/maintenance.py
+++ b/src/ol_infrastructure/applications/omnigraph/maintenance.py
@@ -170,6 +170,8 @@ def _cron_job(  # noqa: PLR0913
     schedule: str,
     script: str,
     depends_on: list[Resource],
+    *,
+    suspend: bool = False,
 ) -> kubernetes.batch.v1.CronJob:
     """Build one maintenance CronJob around ``script``."""
     return kubernetes.batch.v1.CronJob(
@@ -181,6 +183,19 @@ def _cron_job(  # noqa: PLR0913
         ),
         spec=kubernetes.batch.v1.CronJobSpecArgs(
             schedule=schedule,
+            # Held off entirely while a storage-format migration is armed.
+            # Both sweeps write DIRECTLY to the store, bypassing the server, so
+            # scaling the Deployment to zero does not stop them: `optimize`
+            # rewrites Lance fragments on a root the migration has declared
+            # frozen, and would do it between the export and the verification.
+            # The runbook's manual form only *checks* for a run in flight,
+            # which cannot stop one that starts a minute later.
+            #
+            # Declared here rather than left to `kubectl patch` because a
+            # migration can span days, and any unrelated `pulumi up` in that
+            # window would quietly reconcile a hand-patched CronJob back to
+            # running.
+            suspend=suspend,
             # Two concurrent runs of the same command would contend on the same
             # per-graph storage lock, and the loser would fail the whole sweep
             # after doing real work. Skipping a tick because the previous one is
@@ -280,12 +295,19 @@ def create_maintenance(  # noqa: PLR0913
     cleanup_schedule: str,
     cleanup_older_than: str,
     depends_on: list[Resource],
+    *,
+    suspend: bool = False,
 ) -> OmnigraphMaintenance:
     """Provision the scheduled optimize and cleanup sweeps.
 
     ``graph_ids`` must be the ids cluster.yaml declares — pass the keys of the
     same ``build_cluster_graphs`` result the ConfigMap is rendered from, so a
     graph can never exist without being swept or be swept without existing.
+
+    ``suspend`` holds both sweeps off for the duration of a storage-format
+    migration. Set together, never individually: they run an hour apart
+    precisely so they cannot overlap each other, and suspending one alone would
+    leave the other writing to a root the migration needs frozen.
     """
     optimize_cron_job = _cron_job(
         name="optimize",
@@ -301,6 +323,7 @@ def create_maintenance(  # noqa: PLR0913
         # Non-destructive, so no --confirm and no confirmation prompt to skip.
         script=_sweep_script("optimize", [], graph_ids),
         depends_on=depends_on,
+        suspend=suspend,
     )
 
     # `--confirm` arms the destructive run; `--yes` is separately required
@@ -325,6 +348,7 @@ def create_maintenance(  # noqa: PLR0913
             graph_ids,
         ),
         depends_on=depends_on,
+        suspend=suspend,
     )
 
     return OmnigraphMaintenance(

--- a/src/ol_infrastructure/applications/omnigraph/scripts/migrate_storage_format.py
+++ b/src/ol_infrastructure/applications/omnigraph/scripts/migrate_storage_format.py
@@ -41,6 +41,7 @@ import re
 import shutil
 import subprocess
 import sys
+from collections import Counter
 from pathlib import Path
 
 # `s3://<bucket>/fmt<N>`, where N is the NEW internal-schema number. Anchored
@@ -58,6 +59,14 @@ SNAPSHOT_ROW_RE = re.compile(r"^(?P<table>\S+)\s+.*\brows=(?P<rows>\d+)", re.MUL
 SNAPSHOT_SCHEMA_RE = re.compile(r"^internal_schema_version:\s*(\d+)", re.MULTILINE)
 
 VERDICT_PATH = Path("/tmp/migration-verdict.json")  # noqa: S108
+
+# omnigraph >= 0.9 refuses a keyed write staging more than this many rows in
+# one table, engine-side, on local stores as well as served ones. `--mode
+# overwrite` is exempt, but this loads with `merge` (see `rebuild`).
+KEYED_ROW_CAP = 8192
+# Rows per batch, under the cap with headroom — the cap belongs to a binary
+# this script does not control, and the cost of headroom is one extra commit.
+LOAD_ROW_BATCH = 8000
 
 LOG = logging.getLogger("migrate-storage-format")
 
@@ -108,16 +117,121 @@ def run(
 
 
 def snapshot_tables(binary: str, store: str) -> dict[str, int]:
-    """Return per-table row counts for ``store`` — the baseline and the check."""
+    """Return per-table row counts for ``store`` — the baseline and the check.
+
+    AN EMPTY PARSE IS AN ERROR, not an empty store. A cluster graph always
+    declares tables, so ``{}`` means the regex stopped matching ``snapshot``'s
+    output, not that there is nothing there — and an unrecognised format would
+    produce ``{}`` on BOTH sides, making verification compare nothing to
+    nothing and report success over a rebuild it never checked. That is the
+    single worst outcome available here: a green migration with no evidence
+    behind it.
+    """
     out = run([binary, "snapshot", "--store", store]).stdout
-    return {m["table"]: int(m["rows"]) for m in SNAPSHOT_ROW_RE.finditer(out)}
+    tables = {m["table"]: int(m["rows"]) for m in SNAPSHOT_ROW_RE.finditer(out)}
+    if not tables:
+        sys.exit(
+            f"!!! parsed no per-table row counts from `snapshot` for {store}.\n"
+            "Verification compares these counts, so an unparsed snapshot would "
+            "make it compare {} to {} and pass without checking anything. The "
+            f"output was:\n{out}"
+        )
+    return tables
 
 
-def snapshot_schema_version(binary: str, store: str) -> int | None:
-    """Return the on-disk format version ``store`` is stamped at."""
+def snapshot_schema_version(binary: str, store: str) -> int:
+    """Return the on-disk format version ``store`` is stamped at.
+
+    Raises rather than returning ``None``: the caller compares these to prove
+    the format actually moved, and a comparison against "unknown" that quietly
+    passes defeats the check.
+    """
     out = run([binary, "snapshot", "--store", store]).stdout
     match = SNAPSHOT_SCHEMA_RE.search(out)
-    return int(match.group(1)) if match else None
+    if match is None:
+        sys.exit(
+            f"!!! `snapshot` reported no internal_schema_version for {store}. "
+            "The migration cannot confirm the storage format moved without "
+            f"it. Output was:\n{out}"
+        )
+    return int(match.group(1))
+
+
+def bucket_of(root: str) -> str:
+    """Return the bucket name from an ``s3://<bucket>/...`` root."""
+    return root.removeprefix("s3://").split("/", 1)[0]
+
+
+def check_format_moved(
+    old_formats: dict[str, int], new_formats: dict[str, int]
+) -> list[str]:
+    """Return the reasons the storage format did not move as a migration needs.
+
+    Two failures, both of which end with a cutover onto something unusable:
+    graphs left on differing formats (the new binary can open only some of
+    them), and a format that did not change at all — which means either the
+    two images share a storage format and the outage bought nothing, or the
+    wrong image was named as ``migrate_from_image``.
+    """
+    problems: list[str] = []
+    if len(set(new_formats.values())) != 1:
+        problems.append(f"the rebuilt graphs are not all on one format: {new_formats}")
+    elif set(new_formats.values()) == set(old_formats.values()):
+        problems.append(
+            f"the format did not move — old and new are both "
+            f"{next(iter(new_formats.values()))}. Either the two images share "
+            "a storage format, in which case no migration was needed, or the "
+            "wrong image was named as migrate_from_image."
+        )
+    return problems
+
+
+def chunk_export(export: Path) -> list[Path]:
+    """Split one graph's export into loads omnigraph 0.9 will accept.
+
+    0.9 caps a keyed write at ``KEYED_ROW_CAP`` rows PER TABLE, enforced by the
+    engine on local and remote stores alike. One `load` of a populated graph
+    therefore fails outright — the same cap that forced row-bounded chunking
+    into agent-kit's ``witan_core.chunking``
+    (https://github.com/mitodl/agent-kit/pull/217).
+
+    EVERY NODE BEFORE ANY EDGE, and that ordering outranks the row bound. An
+    edge resolves against nodes already persisted or present in the same batch;
+    an endpoint in neither fails the whole load with ``dst '...' not found``.
+    Exports are not sorted, and a graph's edges routinely point at nodes
+    appearing later in the file, so slicing the file as-is would break loads
+    that work today — unpredictably, depending on the export's order.
+
+    Returns the original path unchanged when nothing needs splitting, so the
+    common case stays a single load with no temporary files.
+    """
+    nodes: list[str] = []
+    edges: list[str] = []
+    per_table: Counter[str] = Counter()
+    with export.open() as fh:
+        for line in fh:
+            if not line.strip():
+                continue
+            record = json.loads(line)
+            table = record.get("type") or record.get("edge") or ""
+            per_table[table] += 1
+            (nodes if "type" in record else edges).append(line)
+
+    if not per_table or max(per_table.values()) <= LOAD_ROW_BATCH:
+        return [export]
+
+    LOG.info(
+        "     splitting: largest table has %d rows (cap %d per keyed write)",
+        max(per_table.values()),
+        KEYED_ROW_CAP,
+    )
+    batches: list[Path] = []
+    for group in (nodes, edges):
+        for start in range(0, len(group), LOAD_ROW_BATCH):
+            part = export.with_name(f"{export.stem}.{len(batches):03d}.jsonl")
+            part.write_text("".join(group[start : start + LOAD_ROW_BATCH]))
+            batches.append(part)
+    return batches
 
 
 def graph_ids_from_cluster_config(cluster_yaml: Path) -> list[str]:
@@ -256,23 +370,27 @@ def rebuild(  # noqa: PLR0913
 
     for graph in graphs:
         LOG.info("  -- %s", graph)
+        store = f"{new_root}/graphs/{graph}.omni"
         # `merge` into a freshly-created empty graph is a full load and is the
         # safe choice: `overwrite` is destructive and buys nothing against an
         # empty table. `--yes` because a non-local destructive write refuses
         # without a TTY, and there is none here.
-        run(
-            [
-                new_binary,
-                "load",
-                "--store",
-                f"{new_root}/graphs/{graph}.omni",
-                "--data",
-                str(export_dir / f"{graph}.jsonl"),
-                "--mode",
-                "merge",
-                "--yes",
-            ]
-        )
+        for batch, path in enumerate(chunk_export(export_dir / f"{graph}.jsonl")):
+            if batch:
+                LOG.info("     batch %d", batch + 1)
+            run(
+                [
+                    new_binary,
+                    "load",
+                    "--store",
+                    store,
+                    "--data",
+                    str(path),
+                    "--mode",
+                    "merge",
+                    "--yes",
+                ]
+            )
 
 
 def verify(
@@ -327,11 +445,23 @@ def main() -> int:
             f"!!! OMNIGRAPH_NEW_ROOT {new_root!r} is malformed — expected "
             "s3://<bucket>/fmt<N> with real digits"
         )
-    if not new_root.startswith(f"{old_root}/"):
+    # SAME BUCKET, DIFFERENT ROOT — not "new is inside old". The source is
+    # whatever the cluster serves now, which after one cutover is already
+    # `s3://bucket/fmt5`; requiring containment would then demand
+    # `s3://bucket/fmt5/fmt6`, a nested root nobody serves. What actually has
+    # to hold is that both live in the managed bucket, since the IRSA grant,
+    # the backups and the object versioning are all keyed to it.
+    if bucket_of(old_root) != bucket_of(new_root):
         sys.exit(
-            f"!!! OMNIGRAPH_NEW_ROOT {new_root!r} must be a prefix inside "
-            f"{old_root!r}. Rebuilding outside the managed bucket loses the "
-            "IRSA grant and the backups."
+            f"!!! OMNIGRAPH_NEW_ROOT {new_root!r} is in a different bucket "
+            f"from OMNIGRAPH_OLD_ROOT {old_root!r}. Rebuilding outside the "
+            "managed bucket loses the IRSA grant and the backups."
+        )
+    if new_root == old_root:
+        sys.exit(
+            f"!!! OMNIGRAPH_OLD_ROOT and OMNIGRAPH_NEW_ROOT are both "
+            f"{new_root!r} — the migration would export from the root it is "
+            "writing to."
         )
 
     for label, binary in (("old", old_binary), ("new", new_binary)):
@@ -356,21 +486,49 @@ def main() -> int:
     )
     report, mismatched = verify(new_binary, new_root, graphs, baseline)
 
-    VERDICT_PATH.write_text(
-        json.dumps(
-            {
-                "ok": not mismatched,
-                "old_root": old_root,
-                "new_root": new_root,
-                "graphs": report,
-                "new_internal_schema": snapshot_schema_version(
-                    new_binary, f"{new_root}/graphs/{graphs[0]}.omni"
-                ),
-            },
-            indent=2,
-            sort_keys=True,
+    # THE FORMAT MUST HAVE ACTUALLY MOVED, on EVERY graph. Recording one
+    # graph's version and never comparing it — which is what this did — lets
+    # the Job report success when the two images share a format (so the whole
+    # outage bought nothing and the cutover is pointless), and when one graph
+    # is left behind on the old format (so the cutover serves a cluster the new
+    # binary cannot open). Manual step 6 checks this by hand; there is no
+    # reason for the automated path to check less.
+    old_formats = {
+        g: snapshot_schema_version(old_binary, f"{old_root}/graphs/{g}.omni")
+        for g in graphs
+    }
+    new_formats = {
+        g: snapshot_schema_version(new_binary, f"{new_root}/graphs/{g}.omni")
+        for g in graphs
+    }
+    format_problems = check_format_moved(old_formats, new_formats)
+
+    verdict = {
+        "ok": not mismatched and not format_problems,
+        "old_root": old_root,
+        "new_root": new_root,
+        "graphs": report,
+        "old_internal_schema": old_formats,
+        "new_internal_schema": new_formats,
+        "format_problems": format_problems,
+    }
+    rendered = json.dumps(verdict, indent=2, sort_keys=True)
+    VERDICT_PATH.write_text(rendered)
+    # ALSO to stdout. The pod's filesystem is an emptyDir that goes away with
+    # the container, and `kubectl exec`/`cp` cannot reach a completed pod — so
+    # the file alone is unreadable by the time anyone wants it. The logs are
+    # what survive, so the verdict has to be in them for anything (a human or a
+    # pipeline step) to gate the cutover on it.
+    LOG.info("migration verdict:\n%s", rendered)
+
+    if format_problems:
+        for problem in format_problems:
+            LOG.error("STORAGE FORMAT CHECK FAILED: %s", problem)
+        LOG.error(
+            "Row counts %s. Not repointing on this — see the verdict above.",
+            "also mismatched" if mismatched else "matched",
         )
-    )
+        return 1
 
     if mismatched:
         LOG.error(

--- a/src/ol_infrastructure/applications/omnigraph/scripts/migrate_storage_format.py
+++ b/src/ol_infrastructure/applications/omnigraph/scripts/migrate_storage_format.py
@@ -1,0 +1,399 @@
+"""Rebuild every cluster graph at a new storage root, in-cluster, in one pod.
+
+omnigraph storage is strict-single-version: a binary reads exactly one
+internal-schema, there is no in-place migration, and the gate is enforced in
+both directions including read-only opens. So a release that bumps the format
+cannot be rolled out — every graph has to be exported by the OLD binary and
+reloaded by the NEW one, at a DIFFERENT root, with the old root left
+byte-for-byte intact as the rollback.
+
+``docs/omnigraph-storage-format-upgrade-runbook.md`` is the procedure this
+automates, and it stays the reference for everything around it — pausing the
+Concourse pipeline, scaling the Deployment down, the cutover, retiring the old
+root. This script is steps 2, 3, 4 and 6 of that runbook: baseline, export,
+rebuild, verify.
+
+WHY IN ONE POD. The runbook runs two ``kubectl run`` pods and moves every
+export through the operator's workstation with ``kubectl exec ... > file``,
+because a hand-started pod carries only one image. That transfer is the slowest
+part of the migration and the only step that can fail *silently*: a truncated
+``kubectl exec`` redirect yields a short JSONL file, and ``load`` then reports
+success over the top of it. Here an initContainer on the OLD image copies its
+binary into a shared volume, so one pod holds both binaries and every byte
+moves S3 -> pod -> S3 without a laptop in the path.
+
+WHAT IT DELIBERATELY DOES NOT DO. It never repoints the live cluster. That is
+``omnigraph:storage_prefix``, a Pulumi config value, and this pod has no
+business holding Pulumi credentials; patching the ConfigMap instead would make
+it the second writer of a path Pulumi owns, which is the failure mode
+``sync_actor_tokens.py`` exists to avoid on the token map. The script verifies
+and stops, leaving a machine-readable verdict for whatever drives the cutover.
+
+The exports stay on the pod's disk for the life of the Job, so a failed
+verification can be inspected before anything is repointed. Nothing here writes
+to the old root.
+"""
+
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# `s3://<bucket>/fmt<N>`, where N is the NEW internal-schema number. Anchored
+# and digit-only on purpose: `<` and `>` are legal in S3 object keys, so an
+# unsubstituted `fmt<N>` copied out of the runbook would otherwise become a
+# real prefix, and the rebuild would land somewhere nobody is looking with
+# `load` reporting success on top of it.
+NEW_ROOT_RE = re.compile(r"^s3://[a-z0-9.-]+/fmt[0-9]+$")
+
+# `rows=` counts out of `omnigraph snapshot`, e.g.
+# `node:Memory v2 branch=main rows=41`. Compared PER TABLE between old and new:
+# a total-row check would pass a rebuild that put every row in the wrong table,
+# and a whole-store check would pass one that silently dropped an empty one.
+SNAPSHOT_ROW_RE = re.compile(r"^(?P<table>\S+)\s+.*\brows=(?P<rows>\d+)", re.MULTILINE)
+SNAPSHOT_SCHEMA_RE = re.compile(r"^internal_schema_version:\s*(\d+)", re.MULTILINE)
+
+VERDICT_PATH = Path("/tmp/migration-verdict.json")  # noqa: S108
+
+LOG = logging.getLogger("migrate-storage-format")
+
+# One graph's verification record: an `ok` flag, the before/after per-table
+# counts, and the two difference lists. Heterogeneous by nature, so the
+# values are `object` rather than a lie about them all being one type.
+GraphReport = dict[str, object]
+
+
+def env(name: str, default: str | None = None) -> str:
+    """Read a required environment variable, or exit naming it."""
+    value = os.environ.get(name, default)
+    if not value:
+        sys.exit(f"{name} is required")
+    return value
+
+
+def run(
+    argv: list[str], *, stdout_path: Path | None = None, check: bool = True
+) -> subprocess.CompletedProcess[str]:
+    """Run an omnigraph command, streaming a large stdout straight to disk.
+
+    ``stdout_path`` matters for ``export``: a repo-scale graph's JSONL is not
+    something to hold in memory and write out again, and the point of this
+    script is that the bytes never take a detour. That branch runs in binary
+    mode (no ``text=True``) because the bytes go to a file untouched, so the
+    two branches are decoded separately and only the normalised result is
+    returned.
+    """
+    printable = " ".join(argv)
+    LOG.info("    $ %s", printable)
+    if stdout_path is not None:
+        with stdout_path.open("wb") as fh:
+            streamed = subprocess.run(  # noqa: S603
+                argv, stdout=fh, stderr=subprocess.PIPE, check=False
+            )
+        returncode = streamed.returncode
+        stderr, stdout = streamed.stderr.decode(errors="replace"), ""
+    else:
+        captured = subprocess.run(  # noqa: S603
+            argv, capture_output=True, text=True, check=False
+        )
+        returncode = captured.returncode
+        stderr, stdout = captured.stderr, captured.stdout
+    if check and returncode != 0:
+        sys.exit(f"!!! command failed ({returncode}): {printable}\n{stderr}")
+    return subprocess.CompletedProcess(argv, returncode, stdout, stderr)
+
+
+def snapshot_tables(binary: str, store: str) -> dict[str, int]:
+    """Return per-table row counts for ``store`` — the baseline and the check."""
+    out = run([binary, "snapshot", "--store", store]).stdout
+    return {m["table"]: int(m["rows"]) for m in SNAPSHOT_ROW_RE.finditer(out)}
+
+
+def snapshot_schema_version(binary: str, store: str) -> int | None:
+    """Return the on-disk format version ``store`` is stamped at."""
+    out = run([binary, "snapshot", "--store", store]).stdout
+    match = SNAPSHOT_SCHEMA_RE.search(out)
+    return int(match.group(1)) if match else None
+
+
+def graph_ids_from_cluster_config(cluster_yaml: Path) -> list[str]:
+    """Return the graph ids the live cluster declares.
+
+    Read from the mounted cluster.yaml rather than re-derived from
+    ``managed_repos``, for the reason the runbook gives: the ``code-<repo>``
+    ids are *derived* by ``code_graph_id()``, and rebuilding that list by hand
+    is how a repo gets dropped from the migration and left behind at the old
+    root.
+
+    Parsed with a small indentation-aware scan rather than PyYAML. The server
+    image carries ``python3-yaml`` today, but this is the one input whose
+    mis-parse silently shortens the migration, and the ``graphs:`` block is a
+    flat map of ``<id>:`` keys — cheap to read exactly, and worth not resting
+    on an image detail. A top-level key ends the block, which is what keeps the
+    ``policies:`` entries below it from being read as graphs.
+    """
+    ids: list[str] = []
+    in_graphs = False
+    for raw in cluster_yaml.read_text().splitlines():
+        line = raw.rstrip()
+        if not line or line.lstrip().startswith("#"):
+            continue
+        if not line[:1].isspace():
+            in_graphs = line.startswith("graphs:")
+            continue
+        if in_graphs and re.fullmatch(r"  [A-Za-z0-9][A-Za-z0-9._-]*:", line):
+            ids.append(line.strip().rstrip(":"))
+    return ids
+
+
+def build_rebuild_config(
+    source_cluster_yaml: Path, rebuild_dir: Path, schema_dir: Path, new_root: str
+) -> Path:
+    """Stage a cluster config declaring the same graphs at ``new_root``.
+
+    The schemas come from the image (baked in beside the server) and the graph
+    declarations from the live ConfigMap, so the rebuilt cluster declares
+    exactly what the running one does — same ids, same schemas, new root.
+
+    ``new_root`` is re-validated here rather than trusted from the caller. The
+    check below compares the written line against ``f"storage: {new_root}"``,
+    which for an empty root is ``"storage: "`` — the very line the check exists
+    to reject, so a blank value would pass its own guard. That is the runbook's
+    documented worst case (``cluster validate`` also accepts a blank
+    ``storage:``), and a guard that is self-consistently wrong for its one
+    target input is more dangerous than no guard, because it reads as
+    protection.
+    """
+    if not NEW_ROOT_RE.match(new_root):
+        sys.exit(
+            f"!!! refusing to stage a rebuild config for root {new_root!r} — "
+            "expected s3://<bucket>/fmt<N>"
+        )
+    rebuild_dir.mkdir(parents=True, exist_ok=True)
+    for schema in schema_dir.glob("*.pg"):
+        shutil.copy2(schema, rebuild_dir / schema.name)
+
+    lines = source_cluster_yaml.read_text().splitlines()
+    repointed = [
+        f"storage: {new_root}" if line.startswith("storage:") else line
+        for line in lines
+    ]
+    target = rebuild_dir / "cluster.yaml"
+    target.write_text("\n".join(repointed) + "\n")
+
+    if f"storage: {new_root}" not in target.read_text().splitlines():
+        sys.exit(f"!!! storage: was not repointed to {new_root} — refusing to continue")
+    declared = sum(1 for line in lines if line.strip().startswith("schema:"))
+    rebuilt = sum(
+        1
+        for line in target.read_text().splitlines()
+        if line.strip().startswith("schema:")
+    )
+    if declared != rebuilt:
+        sys.exit(
+            f"!!! rebuilt config declares {rebuilt} schemas, source declared "
+            f"{declared} — the repoint changed more than the storage line"
+        )
+    return target
+
+
+def baseline_and_export(
+    old_binary: str, old_root: str, graphs: list[str], export_dir: Path
+) -> dict[str, dict[str, int]]:
+    """Record per-table row counts and export every graph, with the OLD binary.
+
+    Every read is against the old root, which nothing writes to for the whole
+    procedure. A failure here is a clean stop: the new root does not exist yet
+    and the live cluster is untouched.
+    """
+    LOG.info("=== 1/3 baseline + export (old binary)")
+    export_dir.mkdir(parents=True, exist_ok=True)
+    baseline: dict[str, dict[str, int]] = {}
+    for graph in graphs:
+        store = f"{old_root}/graphs/{graph}.omni"
+        LOG.info("  -- %s", graph)
+        baseline[graph] = snapshot_tables(old_binary, store)
+        target = export_dir / f"{graph}.jsonl"
+        run([old_binary, "export", "--store", store], stdout_path=target)
+        with target.open() as fh:
+            lines = sum(1 for _ in fh)
+        LOG.info(
+            "     %d rows across %d tables -> %d JSONL lines",
+            sum(baseline[graph].values()),
+            len(baseline[graph]),
+            lines,
+        )
+    return baseline
+
+
+def rebuild(  # noqa: PLR0913
+    new_binary: str,
+    new_root: str,
+    graphs: list[str],
+    export_dir: Path,
+    rebuild_dir: Path,
+    cluster_yaml: Path,
+    schema_dir: Path,
+    actor: str,
+) -> None:
+    """Create the graphs at ``new_root`` and load every export into them."""
+    LOG.info("=== 2/3 rebuild (new binary)")
+    config = build_rebuild_config(cluster_yaml, rebuild_dir, schema_dir, new_root)
+    LOG.info("  staged %s -> storage: %s", config, new_root)
+    run([new_binary, "cluster", "validate", "--config", str(rebuild_dir)])
+
+    # `import` BEFORE `apply`, and both are required. A fresh root has no
+    # `__cluster/state.json`, and `apply` refuses to create one
+    # (`state_missing ... run cluster import to bootstrap state`). This bites
+    # only on the first apply against a new root — which is exactly what this
+    # is, at the point of no return.
+    run([new_binary, "cluster", "import", "--config", str(rebuild_dir), "--as", actor])
+    run([new_binary, "cluster", "apply", "--config", str(rebuild_dir), "--as", actor])
+
+    for graph in graphs:
+        LOG.info("  -- %s", graph)
+        # `merge` into a freshly-created empty graph is a full load and is the
+        # safe choice: `overwrite` is destructive and buys nothing against an
+        # empty table. `--yes` because a non-local destructive write refuses
+        # without a TTY, and there is none here.
+        run(
+            [
+                new_binary,
+                "load",
+                "--store",
+                f"{new_root}/graphs/{graph}.omni",
+                "--data",
+                str(export_dir / f"{graph}.jsonl"),
+                "--mode",
+                "merge",
+                "--yes",
+            ]
+        )
+
+
+def verify(
+    new_binary: str,
+    new_root: str,
+    graphs: list[str],
+    baseline: dict[str, dict[str, int]],
+) -> tuple[dict[str, GraphReport], list[str]]:
+    """Compare per-table row counts at the new root against the baseline."""
+    LOG.info("=== 3/3 verify (per-table row counts)")
+    report: dict[str, GraphReport] = {}
+    mismatched: list[str] = []
+    for graph in graphs:
+        after = snapshot_tables(new_binary, f"{new_root}/graphs/{graph}.omni")
+        before = baseline[graph]
+        ok = after == before
+        report[graph] = {
+            "ok": ok,
+            "before": before,
+            "after": after,
+            "missing_tables": sorted(set(before) - set(after)),
+            "changed_tables": sorted(
+                t for t in set(before) & set(after) if before[t] != after[t]
+            ),
+        }
+        if not ok:
+            mismatched.append(graph)
+        LOG.info(
+            "  %s %s: %d rows", "OK  " if ok else "FAIL", graph, sum(after.values())
+        )
+    return report, mismatched
+
+
+def main() -> int:
+    """Run one full rebuild-and-verify pass, returning a process exit status."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    old_binary = env("OMNIGRAPH_OLD_BINARY")
+    new_binary = env("OMNIGRAPH_NEW_BINARY", "omnigraph")
+    old_root = env("OMNIGRAPH_OLD_ROOT").rstrip("/")
+    new_root = env("OMNIGRAPH_NEW_ROOT").rstrip("/")
+    actor = env("OMNIGRAPH_MIGRATION_ACTOR")
+    cluster_yaml = Path(env("OMNIGRAPH_CLUSTER_CONFIG"))
+    schema_dir = Path(env("OMNIGRAPH_SCHEMA_DIR"))
+    export_dir = Path(env("OMNIGRAPH_EXPORT_DIR", "/tmp/export"))  # noqa: S108
+    rebuild_dir = Path(env("OMNIGRAPH_REBUILD_DIR", "/tmp/rebuild"))  # noqa: S108
+
+    if not NEW_ROOT_RE.match(new_root):
+        sys.exit(
+            f"!!! OMNIGRAPH_NEW_ROOT {new_root!r} is malformed — expected "
+            "s3://<bucket>/fmt<N> with real digits"
+        )
+    if not new_root.startswith(f"{old_root}/"):
+        sys.exit(
+            f"!!! OMNIGRAPH_NEW_ROOT {new_root!r} must be a prefix inside "
+            f"{old_root!r}. Rebuilding outside the managed bucket loses the "
+            "IRSA grant and the backups."
+        )
+
+    for label, binary in (("old", old_binary), ("new", new_binary)):
+        reported = run([binary, "version"]).stdout.strip().replace("\n", " | ")
+        LOG.info("%s: %s", label, reported)
+
+    graphs = graph_ids_from_cluster_config(cluster_yaml)
+    if not graphs:
+        sys.exit(f"!!! no graphs declared in {cluster_yaml} — nothing to migrate")
+    LOG.info("%d graph(s) to rebuild: %s", len(graphs), ", ".join(graphs))
+
+    baseline = baseline_and_export(old_binary, old_root, graphs, export_dir)
+    rebuild(
+        new_binary,
+        new_root,
+        graphs,
+        export_dir,
+        rebuild_dir,
+        cluster_yaml,
+        schema_dir,
+        actor,
+    )
+    report, mismatched = verify(new_binary, new_root, graphs, baseline)
+
+    VERDICT_PATH.write_text(
+        json.dumps(
+            {
+                "ok": not mismatched,
+                "old_root": old_root,
+                "new_root": new_root,
+                "graphs": report,
+                "new_internal_schema": snapshot_schema_version(
+                    new_binary, f"{new_root}/graphs/{graphs[0]}.omni"
+                ),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+    if mismatched:
+        LOG.error(
+            "VERIFICATION FAILED for: %s. The old root is untouched and the "
+            "cluster still points at it — this is a clean stop. Do NOT "
+            "repoint. Exports are on this pod at %s; inspect before deleting "
+            "the Job.",
+            ", ".join(mismatched),
+            export_dir,
+        )
+        return 1
+
+    LOG.info(
+        "All %d graph(s) rebuilt and verified at %s. NOT DONE YET — the "
+        "cluster still serves the OLD root. To cut over: pulumi config set "
+        "omnigraph:storage_prefix %s --stack <CI|QA|Production>, then deploy "
+        "the new image, verify, and soak before retiring the old root.",
+        len(graphs),
+        new_root,
+        new_root.rsplit("/", 1)[-1],
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ol_infrastructure/applications/omnigraph/storage.py
+++ b/src/ol_infrastructure/applications/omnigraph/storage.py
@@ -14,6 +14,12 @@ import re
 # validate_storage_prefix for why this is stricter than S3 requires.
 _PREFIX_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
 
+# A migration target root, `fmt<N>` — N being the NEW internal-schema number.
+# The worker (scripts/migrate_storage_format.py) enforces the same shape on the
+# full URI; this is the same rule applied early enough to fail a `pulumi
+# preview` rather than a Job.
+_MIGRATION_PREFIX_RE = re.compile(r"fmt[0-9]+")
+
 
 def validate_storage_prefix(prefix: str | None) -> str:
     """Normalize and check ``omnigraph:storage_prefix``; return "" when unset.
@@ -49,6 +55,36 @@ def validate_storage_prefix(prefix: str | None) -> str:
             f"omnigraph:storage_prefix must be a single path segment of "
             f"[A-Za-z0-9._-] starting alphanumeric: {cleaned!r}. An "
             "unsubstituted placeholder such as 'fmt<N>' lands here."
+        )
+        raise ValueError(msg)
+    return cleaned
+
+
+def validate_migration_target_prefix(prefix: str | None) -> str:
+    """Normalize and check ``omnigraph:migrate_to_prefix``; return "" when unset.
+
+    STRICTER THAN ``validate_storage_prefix`` ON PURPOSE, and the gap is what
+    this exists to close. That one accepts any single path segment, because a
+    storage root is free to be named anything. The migration worker, though,
+    hard-requires ``fmt<N>`` — the digits are the new internal-schema number,
+    and the runbook's guards match on that shape.
+
+    So ``migrate_to_prefix = "v2.1"`` or ``"migration-2026-08"`` passes the
+    looser check, survives ``pulumi preview``, arms the outage, suspends the
+    maintenance sweeps, and creates a Job whose first act is to refuse the root
+    it was given. Failing here instead means it never gets that far.
+
+    Raises ``ValueError`` on anything that is not ``fmt`` followed by digits.
+    """
+    cleaned = validate_storage_prefix(prefix)
+    if not cleaned:
+        return ""
+    if not _MIGRATION_PREFIX_RE.fullmatch(cleaned):
+        msg = (
+            f"omnigraph:migrate_to_prefix must be fmt<N> where N is the new "
+            f"internal-schema number (e.g. fmt6): {cleaned!r}. The migration "
+            "worker rejects anything else, so this would arm an outage for a "
+            "Job that cannot run."
         )
         raise ValueError(msg)
     return cleaned

--- a/src/ol_infrastructure/applications/omnigraph/storage_migration.py
+++ b/src/ol_infrastructure/applications/omnigraph/storage_migration.py
@@ -1,0 +1,284 @@
+"""The storage-format migration Job: rebuild every graph at a new root.
+
+omnigraph storage is strict-single-version, so an image whose binary bumps the
+on-disk format cannot be rolled out — every graph must be exported by the old
+binary and reloaded by the new one at a *different* root, with the old root
+left intact as the rollback. ``docs/omnigraph-storage-format-upgrade-runbook.md``
+is the procedure; this provisions the part of it worth having a machine do.
+
+OPT-IN, AND ABSENT BY DEFAULT. Nothing here exists unless
+``omnigraph:migrate_from_image`` names the image to migrate *from*. A migration
+is a scheduled outage, not something a routine ``pulumi up`` should be able to
+start, and a Job that only exists while an operator is deliberately holding
+that config open cannot fire by accident. Clearing the config removes it.
+
+ONE POD, BOTH BINARIES. An initContainer on the OLD image copies its
+``omnigraph`` binary into a shared ``emptyDir``; the main container runs the
+NEW image and sees both. That is the whole reason this is worth automating: the
+runbook's manual form uses two ``kubectl run`` pods and moves every export
+through the operator's workstation, which is the slowest step and the only one
+that fails silently — a truncated ``kubectl exec > file`` yields a short export
+and ``load`` reports success over it. Here the bytes go S3 → pod → S3.
+
+The initContainer needs nothing but ``cp``, so it works against any historical
+image, including ones predating the ``python3-minimal`` the main container's
+script needs.
+
+WHAT IT WILL NOT DO. It does not repoint the live cluster. That is
+``omnigraph:storage_prefix`` — Pulumi config — and this pod holds no Pulumi
+credentials; writing the ConfigMap instead would make it a second writer of a
+path Pulumi owns, the exact failure ``sync_actor_tokens.py`` documents on the
+token map. The Job verifies per-table row counts and stops, leaving a verdict
+in its logs and at ``/tmp/migration-verdict.json``. Cutting over stays a
+deliberate act by whoever is running the migration.
+"""
+
+from pathlib import Path
+from typing import NamedTuple
+
+import pulumi_kubernetes as kubernetes
+from pulumi import Output, ResourceOptions
+
+from ol_infrastructure.lib.pulumi_helper import StackInfo
+
+SCRIPT_FILENAME = "migrate_storage_format.py"
+SCRIPT_MOUNT_PATH = "/etc/omnigraph/migration"
+SHARED_BIN_PATH = "/shared-bin"
+OLD_BINARY_PATH = f"{SHARED_BIN_PATH}/omnigraph-old"
+
+# Where the server image bakes its schemas. The rebuilt cluster config is
+# staged from these, so it declares the same schemas the running cluster does.
+SCHEMA_DIR = "/etc/omnigraph/cluster"
+
+# The break-glass maintenance principal (ADR-0005 path b). `cluster import` and
+# `cluster apply` are actor-bound, and this is the account the Cedar bundles
+# grant those to.
+MIGRATION_ACTOR = "svc-witan-admin"
+
+# A rebuild reads and rewrites every graph in the cluster. Six hours is far
+# beyond any measured run at current store sizes and exists to stop a wedged S3
+# connection holding an outage open indefinitely, not to bound real work.
+ACTIVE_DEADLINE_SECONDS = 21600
+
+# NO RETRY. A failed migration is a clean stop that an operator must look at —
+# the old root is untouched and the cluster still serves it. Re-running
+# automatically would start a second rebuild over a half-finished new root
+# while nobody is reading the logs.
+BACKOFF_LIMIT = 0
+
+# Keep the finished pod. Its logs and `/tmp/migration-verdict.json` are the
+# evidence the cutover decision rests on, and a Job that tidied itself away on
+# success would take them with it.
+TTL_SECONDS_AFTER_FINISHED = 604800
+
+
+def script_source() -> str:
+    """Read the migration script out of the tree at Pulumi time.
+
+    Same shape as the token-sync script's packaging: the file lives beside this
+    module so it is reviewable, testable and diffable as Python rather than as
+    a string embedded in a resource definition.
+    """
+    return (Path(__file__).parent / "scripts" / SCRIPT_FILENAME).read_text()
+
+
+class OmnigraphStorageMigration(NamedTuple):
+    """Handles to the provisioned migration resources."""
+
+    script_config_map: kubernetes.core.v1.ConfigMap
+    job: kubernetes.batch.v1.Job
+
+
+def create_storage_migration(  # noqa: PLR0913
+    stack_info: StackInfo,
+    namespace: str,
+    k8s_global_labels: dict[str, str],
+    old_image: str,
+    new_image: str | Output[str],
+    old_storage_root: str | Output[str],
+    new_storage_prefix: str,
+    cluster_configmap_name: str,
+    service_account_name: str,
+    opts: ResourceOptions | None = None,
+) -> OmnigraphStorageMigration:
+    """Provision the one-shot rebuild Job.
+
+    ``old_storage_root`` is the root the cluster serves *now*; the rebuild
+    lands at ``<old_storage_root>/<new_storage_prefix>``. Keeping the new root
+    inside the same bucket is what preserves the IRSA grant
+    (``<bucket-arn>/*``), the backups and the object versioning — a full URI
+    could aim the rebuild at storage nothing has granted access to, and that
+    failure would land mid-outage.
+
+    ``new_storage_prefix`` is the same ``fmt<N>`` value that will later become
+    ``omnigraph:storage_prefix`` at cutover. Passing the prefix rather than a
+    whole URI means the two cannot disagree about the bucket.
+    """
+    script_config_map = kubernetes.core.v1.ConfigMap(
+        f"omnigraph-storage-migration-script-{stack_info.env_suffix}",
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            name="omnigraph-storage-migration-script",
+            namespace=namespace,
+            labels=k8s_global_labels,
+        ),
+        data={SCRIPT_FILENAME: script_source()},
+        opts=opts,
+    )
+
+    new_storage_root = Output.from_input(old_storage_root).apply(
+        lambda root: f"{root.rstrip('/')}/{new_storage_prefix}"
+    )
+
+    job = kubernetes.batch.v1.Job(
+        f"omnigraph-storage-migration-{stack_info.env_suffix}",
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            # Named for the target format so a second migration cannot collide
+            # with a completed one still being kept for its logs, and so
+            # `kubectl get jobs` says which rebuild this was.
+            name=f"omnigraph-migrate-{new_storage_prefix}",
+            namespace=namespace,
+            labels=k8s_global_labels,
+        ),
+        spec=kubernetes.batch.v1.JobSpecArgs(
+            backoff_limit=BACKOFF_LIMIT,
+            active_deadline_seconds=ACTIVE_DEADLINE_SECONDS,
+            ttl_seconds_after_finished=TTL_SECONDS_AFTER_FINISHED,
+            template=kubernetes.core.v1.PodTemplateSpecArgs(
+                metadata=kubernetes.meta.v1.ObjectMetaArgs(labels=k8s_global_labels),
+                spec=kubernetes.core.v1.PodSpecArgs(
+                    restart_policy="Never",
+                    # The same identity the server runs as, which is what
+                    # carries the IRSA grant on the bucket. The migration
+                    # touches exactly the storage the server already can.
+                    service_account_name=service_account_name,
+                    security_context=kubernetes.core.v1.PodSecurityContextArgs(
+                        run_as_non_root=True,
+                        run_as_user=1000,
+                        run_as_group=1000,
+                        fs_group=1000,
+                    ),
+                    init_containers=[
+                        kubernetes.core.v1.ContainerArgs(
+                            name="stage-old-binary",
+                            image=old_image,
+                            # `cp` only — deliberately the whole contract with
+                            # the old image, so this works against any release
+                            # regardless of what else that image carries.
+                            command=[
+                                "cp",
+                                "/usr/local/bin/omnigraph",
+                                OLD_BINARY_PATH,
+                            ],
+                            volume_mounts=[
+                                kubernetes.core.v1.VolumeMountArgs(
+                                    name="shared-bin", mount_path=SHARED_BIN_PATH
+                                )
+                            ],
+                        )
+                    ],
+                    containers=[
+                        kubernetes.core.v1.ContainerArgs(
+                            name="migrate",
+                            image=new_image,
+                            command=[
+                                "python3",
+                                f"{SCRIPT_MOUNT_PATH}/{SCRIPT_FILENAME}",
+                            ],
+                            env=[
+                                kubernetes.core.v1.EnvVarArgs(
+                                    name="OMNIGRAPH_OLD_BINARY",
+                                    value=OLD_BINARY_PATH,
+                                ),
+                                kubernetes.core.v1.EnvVarArgs(
+                                    name="OMNIGRAPH_NEW_BINARY",
+                                    value="/usr/local/bin/omnigraph",
+                                ),
+                                kubernetes.core.v1.EnvVarArgs(
+                                    name="OMNIGRAPH_OLD_ROOT",
+                                    value=old_storage_root,
+                                ),
+                                kubernetes.core.v1.EnvVarArgs(
+                                    name="OMNIGRAPH_NEW_ROOT",
+                                    value=new_storage_root,
+                                ),
+                                kubernetes.core.v1.EnvVarArgs(
+                                    name="OMNIGRAPH_MIGRATION_ACTOR",
+                                    value=MIGRATION_ACTOR,
+                                ),
+                                kubernetes.core.v1.EnvVarArgs(
+                                    name="OMNIGRAPH_CLUSTER_CONFIG",
+                                    # The LIVE cluster config, mounted rather
+                                    # than re-derived: the `code-<repo>` ids
+                                    # are derived values, and rebuilding that
+                                    # list by hand is how a repo gets left
+                                    # behind at the old root.
+                                    value=f"{SCRIPT_MOUNT_PATH}/live/cluster.yaml",
+                                ),
+                                kubernetes.core.v1.EnvVarArgs(
+                                    name="OMNIGRAPH_SCHEMA_DIR", value=SCHEMA_DIR
+                                ),
+                                kubernetes.core.v1.EnvVarArgs(
+                                    name="AWS_REGION", value="us-east-1"
+                                ),
+                            ],
+                            volume_mounts=[
+                                kubernetes.core.v1.VolumeMountArgs(
+                                    name="shared-bin",
+                                    mount_path=SHARED_BIN_PATH,
+                                    read_only=True,
+                                ),
+                                kubernetes.core.v1.VolumeMountArgs(
+                                    name="script",
+                                    mount_path=SCRIPT_MOUNT_PATH,
+                                    read_only=True,
+                                ),
+                                kubernetes.core.v1.VolumeMountArgs(
+                                    name="live-cluster-config",
+                                    mount_path=f"{SCRIPT_MOUNT_PATH}/live",
+                                    read_only=True,
+                                ),
+                                kubernetes.core.v1.VolumeMountArgs(
+                                    name="work",
+                                    mount_path="/tmp",  # noqa: S108
+                                ),
+                            ],
+                            # Sized for the exports, which are held on disk in
+                            # `/tmp` (an emptyDir) rather than streamed twice.
+                            # The memory ceiling is what a single graph's
+                            # load costs, not the whole cluster's.
+                            resources=kubernetes.core.v1.ResourceRequirementsArgs(
+                                requests={"cpu": "250m", "memory": "512Mi"},
+                                limits={"cpu": "2", "memory": "4Gi"},
+                            ),
+                        )
+                    ],
+                    volumes=[
+                        kubernetes.core.v1.VolumeArgs(
+                            name="shared-bin",
+                            empty_dir=kubernetes.core.v1.EmptyDirVolumeSourceArgs(),
+                        ),
+                        kubernetes.core.v1.VolumeArgs(
+                            name="work",
+                            empty_dir=kubernetes.core.v1.EmptyDirVolumeSourceArgs(),
+                        ),
+                        kubernetes.core.v1.VolumeArgs(
+                            name="script",
+                            config_map=kubernetes.core.v1.ConfigMapVolumeSourceArgs(
+                                name=script_config_map.metadata.name,
+                                default_mode=0o555,
+                            ),
+                        ),
+                        kubernetes.core.v1.VolumeArgs(
+                            name="live-cluster-config",
+                            config_map=kubernetes.core.v1.ConfigMapVolumeSourceArgs(
+                                name=cluster_configmap_name,
+                            ),
+                        ),
+                    ],
+                ),
+            ),
+        ),
+        opts=opts,
+    )
+
+    return OmnigraphStorageMigration(script_config_map=script_config_map, job=job)

--- a/src/ol_infrastructure/applications/omnigraph/storage_migration.py
+++ b/src/ol_infrastructure/applications/omnigraph/storage_migration.py
@@ -39,6 +39,7 @@ from typing import NamedTuple
 import pulumi_kubernetes as kubernetes
 from pulumi import Output, ResourceOptions
 
+from ol_infrastructure.applications.omnigraph.maintenance import OmnigraphMaintenance
 from ol_infrastructure.lib.pulumi_helper import StackInfo
 
 SCRIPT_FILENAME = "migrate_storage_format.py"
@@ -66,10 +67,20 @@ ACTIVE_DEADLINE_SECONDS = 21600
 # while nobody is reading the logs.
 BACKOFF_LIMIT = 0
 
-# Keep the finished pod. Its logs and `/tmp/migration-verdict.json` are the
-# evidence the cutover decision rests on, and a Job that tidied itself away on
-# success would take them with it.
+# Keep the finished pod. Its logs are the evidence the cutover decision rests
+# on, and a Job that tidied itself away on success would take them with it.
 TTL_SECONDS_AFTER_FINISHED = 604800
+
+# Disk for `/tmp`, which holds EVERY graph's JSONL export simultaneously —
+# requested so the scheduler places this pod somewhere that can hold them, and
+# capped so an overrun evicts this pod rather than the node.
+#
+# 20Gi is a deliberate over-provision against a cluster whose graphs the
+# upgrade runbook records as effectively unpopulated as of 2026-08-05. It is
+# not a measurement, and it is the number to revisit first if the Job is ever
+# evicted for disk: re-measure from a real export
+# (`wc -c /tmp/export/*.jsonl` in the pod) rather than doubling it blindly.
+EXPORT_STORAGE_SIZE = "20Gi"
 
 
 def script_source() -> str:
@@ -96,23 +107,37 @@ def create_storage_migration(  # noqa: PLR0913
     old_image: str,
     new_image: str | Output[str],
     old_storage_root: str | Output[str],
+    new_storage_root: str | Output[str],
     new_storage_prefix: str,
     cluster_configmap_name: str,
     service_account_name: str,
+    maintenance: OmnigraphMaintenance | None = None,
     opts: ResourceOptions | None = None,
 ) -> OmnigraphStorageMigration:
     """Provision the one-shot rebuild Job.
 
-    ``old_storage_root`` is the root the cluster serves *now*; the rebuild
-    lands at ``<old_storage_root>/<new_storage_prefix>``. Keeping the new root
-    inside the same bucket is what preserves the IRSA grant
-    (``<bucket-arn>/*``), the backups and the object versioning — a full URI
-    could aim the rebuild at storage nothing has granted access to, and that
-    failure would land mid-outage.
+    ``old_storage_root`` is the root the cluster serves **now** — which is the
+    bucket root only until the first cutover. After one, it is
+    ``s3://<bucket>/fmt<N>``, and the next migration has to export from there.
+    ``new_storage_root`` is where this rebuild writes.
 
-    ``new_storage_prefix`` is the same ``fmt<N>`` value that will later become
-    ``omnigraph:storage_prefix`` at cutover. Passing the prefix rather than a
-    whole URI means the two cannot disagree about the bucket.
+    THE TWO ARE SEPARATE INPUTS ON PURPOSE. Deriving the destination from the
+    source (``f"{old}/{prefix}"``) is correct exactly once: it produces
+    ``s3://bucket/fmt6`` from a bare bucket, and ``s3://bucket/fmt5/fmt6`` from
+    an already-migrated one — a nested root nobody serves, exported from the
+    wrong place. Both roots are computed by the caller from the *bucket*, which
+    is also what keeps them inside the IRSA grant (``<bucket-arn>/*``), the
+    backups and the object versioning.
+
+    ``new_storage_prefix`` is the same ``fmt<N>`` that will later become
+    ``omnigraph:storage_prefix`` at cutover; it names the Job so
+    ``kubectl get jobs`` says which rebuild this was.
+
+    ``maintenance`` is the pair of sweeps to order this Job behind. They write
+    directly to the store, so a tick between the export and the verification
+    mutates a root the migration has declared frozen — and Pulumi would
+    otherwise be free to create the Job in parallel with the updates that
+    suspend them.
     """
     script_config_map = kubernetes.core.v1.ConfigMap(
         f"omnigraph-storage-migration-script-{stack_info.env_suffix}",
@@ -125,8 +150,17 @@ def create_storage_migration(  # noqa: PLR0913
         opts=opts,
     )
 
-    new_storage_root = Output.from_input(old_storage_root).apply(
-        lambda root: f"{root.rstrip('/')}/{new_storage_prefix}"
+    # Ordered behind the suspension of both sweeps. `depends_on` is the only
+    # thing that sequences these — the Job references neither CronJob, so
+    # Pulumi is otherwise free to create it while `suspend=true` is still being
+    # applied, leaving a window in which a tick can fire against the old root.
+    job_opts = ResourceOptions.merge(
+        opts,
+        ResourceOptions(
+            depends_on=[maintenance.optimize, maintenance.cleanup]
+            if maintenance is not None
+            else []
+        ),
     )
 
     job = kubernetes.batch.v1.Job(
@@ -242,13 +276,30 @@ def create_storage_migration(  # noqa: PLR0913
                                     mount_path="/tmp",  # noqa: S108
                                 ),
                             ],
-                            # Sized for the exports, which are held on disk in
-                            # `/tmp` (an emptyDir) rather than streamed twice.
-                            # The memory ceiling is what a single graph's
-                            # load costs, not the whole cluster's.
+                            # Memory is sized for a single graph's load, not
+                            # the cluster's — the exports go to disk rather
+                            # than being held twice.
+                            #
+                            # EPHEMERAL-STORAGE IS REQUESTED, NOT JUST CAPPED.
+                            # `/tmp` holds EVERY graph's export at once, and an
+                            # emptyDir draws on the node's filesystem: without
+                            # a request the scheduler can place this on a node
+                            # that cannot hold the exports, and filling a node
+                            # evicts whatever else is running there. The
+                            # request makes it a scheduling constraint; the
+                            # limit and the volume's own `size_limit` make an
+                            # overrun evict this pod alone.
                             resources=kubernetes.core.v1.ResourceRequirementsArgs(
-                                requests={"cpu": "250m", "memory": "512Mi"},
-                                limits={"cpu": "2", "memory": "4Gi"},
+                                requests={
+                                    "cpu": "250m",
+                                    "memory": "512Mi",
+                                    "ephemeral-storage": EXPORT_STORAGE_SIZE,
+                                },
+                                limits={
+                                    "cpu": "2",
+                                    "memory": "4Gi",
+                                    "ephemeral-storage": EXPORT_STORAGE_SIZE,
+                                },
                             ),
                         )
                     ],
@@ -259,7 +310,9 @@ def create_storage_migration(  # noqa: PLR0913
                         ),
                         kubernetes.core.v1.VolumeArgs(
                             name="work",
-                            empty_dir=kubernetes.core.v1.EmptyDirVolumeSourceArgs(),
+                            empty_dir=kubernetes.core.v1.EmptyDirVolumeSourceArgs(
+                                size_limit=EXPORT_STORAGE_SIZE,
+                            ),
                         ),
                         kubernetes.core.v1.VolumeArgs(
                             name="script",
@@ -278,7 +331,7 @@ def create_storage_migration(  # noqa: PLR0913
                 ),
             ),
         ),
-        opts=opts,
+        opts=job_opts,
     )
 
     return OmnigraphStorageMigration(script_config_map=script_config_map, job=job)

--- a/tests/ol_infrastructure/applications/omnigraph/test_storage_migration.py
+++ b/tests/ol_infrastructure/applications/omnigraph/test_storage_migration.py
@@ -9,6 +9,7 @@ cluster, which is what the runbook rehearsal covers.
 """
 
 import importlib.util
+import json
 from pathlib import Path
 
 import pytest
@@ -72,7 +73,7 @@ def _schema_dir(tmp_path: Path) -> Path:
     return schemas
 
 
-def test_graph_ids_match_what_the_cluster_declares(tmp_path):
+def test_graph_ids_match_what_the_cluster_declares(tmp_path: Path) -> None:
     """Enumerated from the config, never re-derived from `managed_repos` — the
     `code-<repo>` ids are derived values, and rebuilding that list by hand is
     how a repo gets left behind at the old root.
@@ -86,7 +87,7 @@ def test_graph_ids_match_what_the_cluster_declares(tmp_path):
     assert "code-bridge" in found
 
 
-def test_policy_names_are_not_mistaken_for_graphs(tmp_path):
+def test_policy_names_are_not_mistaken_for_graphs(tmp_path: Path) -> None:
     """`policies:` sits directly below `graphs:` and its entries are indented
     identically. Reading them as graph ids would send the migration looking for
     stores named `memory_rules`.
@@ -96,7 +97,8 @@ def test_policy_names_are_not_mistaken_for_graphs(tmp_path):
     assert not [g for g in found if g.endswith("_rules")]
 
 
-def test_repoint_rewrites_only_the_storage_line(tmp_path):
+def test_repoint_rewrites_only_the_storage_line(tmp_path: Path) -> None:
+    """The rebuilt config must declare the same graphs at the new root."""
     config = migrate.build_rebuild_config(
         _cluster_yaml(tmp_path),
         tmp_path / "rebuild",
@@ -114,7 +116,7 @@ def test_repoint_rewrites_only_the_storage_line(tmp_path):
     assert config.read_text().count("schema:") == len(build_cluster_graphs(REPOS))
 
 
-def test_schemas_are_staged_beside_the_config(tmp_path):
+def test_schemas_are_staged_beside_the_config(tmp_path: Path) -> None:
     """`cluster apply` resolves `schema:` relative to the config directory, so
     the rebuild fails at the point of no return if these are not there.
     """
@@ -139,7 +141,7 @@ def test_schemas_are_staged_beside_the_config(tmp_path):
         "/ol-data-witan-ci/fmt6",  # not an S3 URI
     ],
 )
-def test_a_root_that_is_not_fmt_n_is_refused(tmp_path, bad_root):
+def test_a_root_that_is_not_fmt_n_is_refused(tmp_path: Path, bad_root: str) -> None:
     """The empty case is the one that matters most. `cluster validate` accepts a
     blank `storage:`, and the repoint check compares against
     `f"storage: {new_root}"` — which for an empty root is the very line it
@@ -155,7 +157,7 @@ def test_a_root_that_is_not_fmt_n_is_refused(tmp_path, bad_root):
         )
 
 
-def test_a_config_with_no_storage_line_is_refused(tmp_path):
+def test_a_config_with_no_storage_line_is_refused(tmp_path: Path) -> None:
     """A renamed or moved `storage:` key means the repoint silently did
     nothing, and the rebuild would land at whatever the config already said.
     """
@@ -174,7 +176,7 @@ def test_a_config_with_no_storage_line_is_refused(tmp_path):
         )
 
 
-def test_row_counts_are_parsed_per_table():
+def test_row_counts_are_parsed_per_table() -> None:
     """Verification compares per table. A total-row check would pass a rebuild
     that put every row in the wrong table.
     """
@@ -193,3 +195,97 @@ def test_row_counts_are_parsed_per_table():
 
     assert counts == {"edge:Supersedes": 0, "node:Memory": 41, "node:Task": 7}
     assert migrate.SNAPSHOT_SCHEMA_RE.search(snapshot).group(1) == "6"
+
+
+def _export(tmp_path: Path, nodes: int, edges: int = 0) -> Path:
+    """Build an export shaped like omnigraph's: node records, then edge records."""
+    path = tmp_path / "graph.jsonl"
+    lines = [
+        json.dumps({"type": "Memory", "data": {"slug": f"m-{i}"}}) for i in range(nodes)
+    ]
+    lines += [
+        json.dumps({"edge": "RelatesTo", "from": f"m-{i}", "to": f"m-{i + 1}"})
+        for i in range(edges)
+    ]
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+def test_a_small_export_is_loaded_whole(tmp_path: Path) -> None:
+    """The common case stays one load, with no temporary files."""
+    export = _export(tmp_path, nodes=10)
+
+    assert migrate.chunk_export(export) == [export]
+
+
+def test_an_export_over_the_row_cap_is_split(tmp_path: Path) -> None:
+    """Omnigraph 0.9 caps a keyed write at 8,192 rows per table, so one `load`
+    of a populated graph fails outright.
+    """
+    export = _export(tmp_path, nodes=migrate.KEYED_ROW_CAP + 100)
+
+    batches = migrate.chunk_export(export)
+
+    assert len(batches) > 1
+    for batch in batches:
+        rows = [ln for ln in batch.read_text().splitlines() if ln.strip()]
+        assert len(rows) <= migrate.KEYED_ROW_CAP
+    total = sum(
+        len([ln for ln in b.read_text().splitlines() if ln.strip()]) for b in batches
+    )
+    assert total == migrate.KEYED_ROW_CAP + 100
+
+
+def test_every_node_precedes_every_edge_across_batches(tmp_path: Path) -> None:
+    """An edge resolves against nodes already persisted or present in the same
+    batch; an endpoint in neither fails the whole load with `dst '...' not
+    found`. That ordering outranks the row bound.
+    """
+    export = _export(tmp_path, nodes=migrate.KEYED_ROW_CAP + 10, edges=50)
+
+    seen_edge = False
+    for batch in migrate.chunk_export(export):
+        for line in batch.read_text().splitlines():
+            if not line.strip():
+                continue
+            if "edge" in json.loads(line):
+                seen_edge = True
+            else:
+                assert not seen_edge, "a node followed an edge across batches"
+    assert seen_edge
+
+
+def test_a_format_that_did_not_move_is_reported() -> None:
+    """Both images on one format means the outage bought nothing — or the wrong
+    image was named as migrate_from_image.
+    """
+    problems = migrate.check_format_moved({"council": 4}, {"council": 4})
+
+    assert problems
+    assert "did not move" in problems[0]
+
+
+def test_graphs_left_on_different_formats_are_reported() -> None:
+    """Cutting over onto a cluster the new binary can only partly open."""
+    problems = migrate.check_format_moved(
+        {"council": 4, "code-bridge": 4}, {"council": 6, "code-bridge": 4}
+    )
+
+    assert problems
+    assert "not all on one format" in problems[0]
+
+
+def test_a_clean_format_move_reports_nothing() -> None:
+    """Every graph moved to one new format — the shape a cutover needs."""
+    assert not migrate.check_format_moved(
+        {"council": 4, "code-bridge": 4}, {"council": 6, "code-bridge": 6}
+    )
+
+
+def test_bucket_is_extracted_from_either_root_shape() -> None:
+    """The source root is the bare bucket only before the first cutover; after
+    one it carries a prefix. Both must resolve to the same bucket, which is what
+    the migration checks instead of containment.
+    """
+    assert migrate.bucket_of("s3://ol-data-witan-ci") == "ol-data-witan-ci"
+    assert migrate.bucket_of("s3://ol-data-witan-ci/fmt5") == "ol-data-witan-ci"

--- a/tests/ol_infrastructure/applications/omnigraph/test_storage_migration.py
+++ b/tests/ol_infrastructure/applications/omnigraph/test_storage_migration.py
@@ -1,0 +1,195 @@
+"""Tests for the storage-format migration script's pure logic.
+
+The two functions here decide *what* gets migrated and *where* it lands, and
+both fail silently when they are wrong: a short graph list quietly leaves a
+repo's graph behind at the old root, and a botched repoint quietly rebuilds
+into a root nobody is serving — with `load` reporting success either way.
+Everything else in the script is subprocess orchestration against a real
+cluster, which is what the runbook rehearsal covers.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import yaml
+
+from ol_infrastructure.applications.omnigraph.cluster_config import (
+    build_cluster_graphs,
+    build_cluster_policies,
+)
+
+# Loaded by path: the script lives in `scripts/` so it can be mounted into a
+# pod as a file, and that directory is deliberately not an importable package.
+_SCRIPT = (
+    Path(__file__).parents[4]
+    / "src"
+    / "ol_infrastructure"
+    / "applications"
+    / "omnigraph"
+    / "scripts"
+    / "migrate_storage_format.py"
+)
+_spec = importlib.util.spec_from_file_location("migrate_storage_format", _SCRIPT)
+if _spec is None or _spec.loader is None:  # pragma: no cover - path is a constant
+    LOAD_MSG = f"could not load the migration script from {_SCRIPT}"
+    raise RuntimeError(LOAD_MSG)
+migrate = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(migrate)
+
+REPOS = [
+    "https://github.com/mitodl/ol-infrastructure",
+    "https://github.com/mitodl/mit-learn",
+    "https://github.com/mitodl/agent-kit",
+]
+
+
+def _cluster_yaml(tmp_path: Path, storage: str = "s3://ol-data-witan-ci") -> Path:
+    """Build a cluster.yaml with the same code that generates the real one."""
+    graphs = build_cluster_graphs(REPOS)
+    target = tmp_path / "cluster.yaml"
+    target.write_text(
+        yaml.dump(
+            {
+                "version": 1,
+                "metadata": {"name": "mitodl-witan-ci"},
+                "state": {"backend": "cluster"},
+                "storage": storage,
+                "graphs": graphs,
+                "policies": build_cluster_policies(graphs),
+            },
+            sort_keys=False,
+        )
+    )
+    return target
+
+
+def _schema_dir(tmp_path: Path) -> Path:
+    schemas = tmp_path / "schemas"
+    schemas.mkdir()
+    for name in ("schema.pg", "code-schema.pg", "bridge-schema.pg"):
+        (schemas / name).write_text("node X { slug: String @key }\n")
+    return schemas
+
+
+def test_graph_ids_match_what_the_cluster_declares(tmp_path):
+    """Enumerated from the config, never re-derived from `managed_repos` — the
+    `code-<repo>` ids are derived values, and rebuilding that list by hand is
+    how a repo gets left behind at the old root.
+    """
+    expected = sorted(build_cluster_graphs(REPOS))
+
+    found = migrate.graph_ids_from_cluster_config(_cluster_yaml(tmp_path))
+
+    assert sorted(found) == expected
+    assert "council" in found
+    assert "code-bridge" in found
+
+
+def test_policy_names_are_not_mistaken_for_graphs(tmp_path):
+    """`policies:` sits directly below `graphs:` and its entries are indented
+    identically. Reading them as graph ids would send the migration looking for
+    stores named `memory_rules`.
+    """
+    found = migrate.graph_ids_from_cluster_config(_cluster_yaml(tmp_path))
+
+    assert not [g for g in found if g.endswith("_rules")]
+
+
+def test_repoint_rewrites_only_the_storage_line(tmp_path):
+    config = migrate.build_rebuild_config(
+        _cluster_yaml(tmp_path),
+        tmp_path / "rebuild",
+        _schema_dir(tmp_path),
+        "s3://ol-data-witan-ci/fmt6",
+    )
+
+    lines = config.read_text().splitlines()
+    assert "storage: s3://ol-data-witan-ci/fmt6" in lines
+    assert "storage: s3://ol-data-witan-ci" not in lines
+    # The graph declarations must survive verbatim — same ids, same schemas.
+    assert sorted(migrate.graph_ids_from_cluster_config(config)) == sorted(
+        build_cluster_graphs(REPOS)
+    )
+    assert config.read_text().count("schema:") == len(build_cluster_graphs(REPOS))
+
+
+def test_schemas_are_staged_beside_the_config(tmp_path):
+    """`cluster apply` resolves `schema:` relative to the config directory, so
+    the rebuild fails at the point of no return if these are not there.
+    """
+    rebuild = tmp_path / "rebuild"
+
+    migrate.build_rebuild_config(
+        _cluster_yaml(tmp_path), rebuild, _schema_dir(tmp_path), "s3://b/fmt6"
+    )
+
+    assert (rebuild / "schema.pg").exists()
+    assert (rebuild / "code-schema.pg").exists()
+    assert (rebuild / "bridge-schema.pg").exists()
+
+
+@pytest.mark.parametrize(
+    "bad_root",
+    [
+        "",
+        "s3://ol-data-witan-ci/fmt<N>",  # unsubstituted placeholder
+        "s3://ol-data-witan-ci",  # the root it is migrating away from
+        "s3://ol-data-witan-ci/scratch",  # not a format-versioned prefix
+        "/ol-data-witan-ci/fmt6",  # not an S3 URI
+    ],
+)
+def test_a_root_that_is_not_fmt_n_is_refused(tmp_path, bad_root):
+    """The empty case is the one that matters most. `cluster validate` accepts a
+    blank `storage:`, and the repoint check compares against
+    `f"storage: {new_root}"` — which for an empty root is the very line it
+    would be rejecting, so it would pass its own guard. `<` and `>` are legal
+    in S3 keys, so an unsubstituted `fmt<N>` becomes a real prefix.
+    """
+    with pytest.raises(SystemExit):
+        migrate.build_rebuild_config(
+            _cluster_yaml(tmp_path),
+            tmp_path / "rebuild",
+            _schema_dir(tmp_path),
+            bad_root,
+        )
+
+
+def test_a_config_with_no_storage_line_is_refused(tmp_path):
+    """A renamed or moved `storage:` key means the repoint silently did
+    nothing, and the rebuild would land at whatever the config already said.
+    """
+    source = _cluster_yaml(tmp_path)
+    source.write_text(
+        "\n".join(
+            line
+            for line in source.read_text().splitlines()
+            if not line.startswith("storage:")
+        )
+    )
+
+    with pytest.raises(SystemExit, match="was not repointed"):
+        migrate.build_rebuild_config(
+            source, tmp_path / "rebuild", _schema_dir(tmp_path), "s3://b/fmt6"
+        )
+
+
+def test_row_counts_are_parsed_per_table():
+    """Verification compares per table. A total-row check would pass a rebuild
+    that put every row in the wrong table.
+    """
+    snapshot = (
+        "branch: main\n"
+        "manifest_version: 4\n"
+        "internal_schema_version: 6\n"
+        "edge:Supersedes v1 branch=main rows=0\n"
+        "node:Memory v2 branch=main rows=41\n"
+        "node:Task v1 branch=main rows=7\n"
+    )
+
+    counts = {
+        m["table"]: int(m["rows"]) for m in migrate.SNAPSHOT_ROW_RE.finditer(snapshot)
+    }
+
+    assert counts == {"edge:Supersedes": 0, "node:Memory": 41, "node:Task": 7}
+    assert migrate.SNAPSHOT_SCHEMA_RE.search(snapshot).group(1) == "6"

--- a/tests/ol_infrastructure/applications/omnigraph/test_storage_prefix.py
+++ b/tests/ol_infrastructure/applications/omnigraph/test_storage_prefix.py
@@ -14,6 +14,7 @@ import pytest
 
 from ol_infrastructure.applications.omnigraph.storage import (
     storage_uri_for,
+    validate_migration_target_prefix,
     validate_storage_prefix,
 )
 
@@ -89,3 +90,39 @@ def test_storage_uri_stays_inside_the_managed_bucket() -> None:
     """
     uri = storage_uri_for("ol-data-witan-production", validate_storage_prefix("fmt5"))
     assert uri.startswith("s3://ol-data-witan-production/")
+
+
+@pytest.mark.parametrize("raw", ["fmt6", "fmt10", "fmt4"])
+def test_migration_target_accepts_fmt_n(raw: str) -> None:
+    """The digits are the NEW internal-schema number the rebuild targets."""
+    assert validate_migration_target_prefix(raw) == raw
+
+
+def test_migration_target_unset_is_empty() -> None:
+    """Unset is the steady state — no migration armed, so nothing to check."""
+    assert validate_migration_target_prefix(None) == ""
+    assert validate_migration_target_prefix("  ") == ""
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["v2.1", "migration-2026-08", "fmt", "fmt6a", "6", "FMT6"],
+)
+def test_migration_target_rejects_anything_but_fmt_n(raw: str) -> None:
+    """`validate_storage_prefix` accepts these — a storage root may be named
+    anything — but the migration worker hard-requires fmt<N>. Without this
+    stricter check they pass preview, arm the outage and suspend the
+    maintenance sweeps, only for the Job to refuse the root it was handed.
+    """
+    with pytest.raises(ValueError, match="fmt<N>"):
+        validate_migration_target_prefix(raw)
+
+
+def test_migration_target_still_rejects_what_the_looser_check_does() -> None:
+    """It layers on top of `validate_storage_prefix` rather than replacing it,
+    so slashes and unsubstituted placeholders are still caught.
+    """
+    with pytest.raises(ValueError, match="must not start or end"):
+        validate_migration_target_prefix("/fmt6")
+    with pytest.raises(ValueError, match="single path segment"):
+        validate_migration_target_prefix("fmt<N>")


### PR DESCRIPTION
### What are the relevant tickets?

N/A — tracked in the witan work graph under the omnigraph 0.9.0 epic. The client-side half shipped in https://github.com/mitodl/agent-kit/pull/217.

### Description (What does it do?)

An omnigraph release that bumps the on-disk format cannot be rolled out. Storage is strict-single-version: a binary reads exactly one internal-schema, the gate is enforced in both directions including read-only opens, and there is no in-place migration. Every graph has to be exported by the old binary and reloaded by the new one at a *different* root, with the old root kept intact as the rollback.

[`docs/omnigraph-storage-format-upgrade-runbook.md`](https://github.com/mitodl/ol-infrastructure/blob/main/docs/omnigraph-storage-format-upgrade-runbook.md) already documents that procedure and it was rehearsed against CI on 2026-08-05. But it is seven manual `kubectl` steps, per environment, looping over sixteen graphs. This automates the mechanical middle of it.

**Steps 2, 3, 4 and 6 — baseline, export, rebuild, verify — now run as one Job.**

```
pod: omnigraph-migrate-fmt6
  initContainer  image=OLD   cp /usr/local/bin/omnigraph /shared-bin/omnigraph-old
  container      image=NEW   python3 migrate_storage_format.py
```

An initContainer on the old image copies its binary into a shared `emptyDir`, so a single pod holds **both** binaries. That is the point: the runbook's manual form uses two `kubectl run` pods and moves every graph's export through the operator's workstation with `kubectl exec … > file`, because a hand-started pod carries only one image. That transfer is the slowest part of a migration and the only step that fails *silently* — a truncated redirect yields a short JSONL file and `load` reports success over the top of it. Here every byte goes S3 → pod → S3.

The initContainer's whole contract with the old image is `cp`, so it works against any historical release.

It automates what was actually rehearsed — `cluster import` → `cluster apply` → `load --mode merge --yes` — not a variant.

**Two config knobs, and the distinction is the substance of this PR.**

| Config | Means |
|---|---|
| `omnigraph:migrate_to_prefix` | where the rebuild **writes** |
| `omnigraph:storage_prefix` | what the cluster **serves** — setting it *is* the cutover |

My first draft reused `storage_prefix` for both. `pulumi preview` showed exactly what that costs: arming a migration immediately moved `storage_uri`, rolled the Deployment's config hash and redirected both maintenance CronJobs — pointing the running server at an empty root before the rebuild had written a single row.

```
reusing one knob:  + 2 to create, ~ 3 to update, +-2 to replace   7 changes
split into two:    + 2 to create, ~ 2 to update                   4 changes, 44 unchanged
```

The program also refuses when both knobs name the same prefix, which would mean the cutover already happened and the Job would be exporting from the root it is writing to.

**Arming a migration suspends `optimize` and `cleanup`.**

Both sweeps write directly to the store, bypassing the server, so scaling the Deployment to zero does **not** stop them. An `optimize` tick landing between the step-3 export and the step-6 verification is a write to a root the procedure has declared frozen. The runbook only ever *checked* for a run already in flight, which cannot stop one starting a minute later.

It is tied to the same config that creates the Job, so the two cannot drift — and so an unrelated `pulumi up` during a multi-day Production migration cannot quietly un-suspend them, which is what would happen to a `kubectl patch`.

**What it deliberately does not do: cut over.**

Repointing the cluster is `pulumi config set omnigraph:storage_prefix`, and a workload holding Pulumi credentials is not a trade worth making. Writing the ConfigMap directly instead would make this the second writer of a path Pulumi owns — the exact failure [`sync_actor_tokens.py`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/applications/omnigraph/scripts/sync_actor_tokens.py) exists to avoid on the token map. The Job verifies per-table row counts, writes `/tmp/migration-verdict.json`, prints the exact cutover command, and stops.

Verification is **per table**, not per store: a total-row check would pass a rebuild that put every row in the wrong table, and a whole-store check would pass one that silently dropped an empty table.

### How can this be tested?

**Unit tests** — 11 new, covering the two functions that decide *what* gets migrated and *where* it lands, since both fail silently when wrong:

```shell
uv run pytest tests/ol_infrastructure/applications/omnigraph/ -q
# 72 passed  (61 pre-existing + 11 new)
```

The graph-id parser is tested against a cluster.yaml built by the same `build_cluster_graphs`/`build_cluster_policies` that generates the real one, so it cannot pass against a shape production does not produce. It is also asserted not to read the `policies:` block — those entries sit directly below `graphs:` at identical indentation, and reading them as graph ids would send the migration looking for a store called `memory_rules`.

**Pulumi preview** — the plan is the real test here. The image ref normally comes from the pipeline, so supply it:

```shell
cd src/ol_infrastructure/applications/omnigraph
export OMNIGRAPH_DOCKER_SHA=sha256:<currently-deployed-digest>

# 1. Steady state — nothing should exist.
pulumi preview --stack CI
#   46 unchanged

# 2. Armed.
pulumi config set omnigraph:migrate_from_image <OLD-image-ref> --stack CI
pulumi config set omnigraph:migrate_to_prefix fmt6 --stack CI
pulumi preview --stack CI --diff
#   + ConfigMap omnigraph-storage-migration-script-ci
#   + Job       omnigraph-storage-migration-ci
#   ~ CronJob   omnigraph-optimize-ci   + suspend: true
#   ~ CronJob   omnigraph-cleanup-ci    + suspend: true
#   + 2 to create, ~ 2 to update, 4 changes. 44 unchanged
#   NOTE: no Deployment roll, no storage_uri change — arming does not cut over.

# 3. The already-cut-over guard.
pulumi config set omnigraph:storage_prefix fmt6 --stack CI
pulumi preview --stack CI
#   ValueError: omnigraph:migrate_to_prefix and omnigraph:storage_prefix are both
#   'fmt6', so the cluster is already serving the root this migration would
#   rebuild into — it would export from the root it is writing to. ...

pulumi config rm omnigraph:storage_prefix --stack CI
pulumi config rm omnigraph:migrate_to_prefix --stack CI
pulumi config rm omnigraph:migrate_from_image --stack CI
```

All three were run against the CI stack while writing this; the config was removed afterwards and `Pulumi.CI.yaml` restored (the `pulumi config` CLI reformats that file as a side effect).

**Not tested, and worth stating plainly:** an actual run against a real format-bumping image. No such image exists yet — omnigraph 0.9.0 will be the first. That gap is not new; the runbook's own rehearsal note says the same thing, because it ran the same binary on both sides. Expect the version gate's behaviour, and only the gate's behaviour, to be new on the day.

### Additional Context

**Reviewer attention is best spent on the two-knob split.** It is the difference between "arming a migration is inert" and "arming a migration points production at an empty bucket prefix", and it is not obvious from reading either knob alone. If a future refactor collapses them for tidiness, that is the regression.

**Two corrections to the runbook**, both discovered while building this:

- It said the image has no `python3`. That is true of the upstream `modernrelay/omnigraph-server` image but not of ours, which installs `python3-minimal` + `python3-yaml` for the entrypoint's `render_groups.py`. The automated path's script runs on it.
- Step 1's "confirm no maintenance job is mid-run" is now a suspension, with the manual `kubectl patch` form for anyone working through the procedure by hand — plus a note that a hand-patch is reverted by the next `pulumi up`.

**Scope deliberately left out:** rebuilding the derived graphs by reindexing instead of export/load. Only `council` is primary data — the 14 `code-<repo>` graphs are tree-sitter indexes and `code-bridge` is built from them, so 15 of 16 could be `init`-empty-and-reindex. It is a real optimization but it trades a rehearsed path for an unrehearsed one during an outage, to save work on graphs the runbook records as effectively unpopulated. Better revisited when the code graphs actually carry data.

**Sequencing note for whoever runs the first real migration:** pause the `pulumi-omnigraph` Concourse pipeline before the format-bumping image builds, or it will keep promoting CI → QA → Production while you are still migrating the first one.
