### PR TITLE
Grant odl-engineering and odl-engineering-owners on every public repo

### DIFF
--- a/src/ol_infrastructure/saas/github/repositories/archetypes.py
+++ b/src/ol_infrastructure/saas/github/repositories/archetypes.py
@@ -35,6 +35,63 @@ def _resolve(archetypes: dict[str, Any], name: str) -> dict[str, Any]:
     return {k: v for k, v in merged.items() if v is not None}
 
 
+#: Every PUBLIC repo grants these, per policy 2026-08-10. Enforced rather than
+#: documented, because the failure is silent and expensive: `teams` REPLACES an
+#: archetype's grants wholesale, so a repo file that declares its own block and omits
+#: these revokes the whole engineering organisation with no error anywhere.
+REQUIRED_PUBLIC_TEAMS = frozenset({"odl-engineering", "odl-engineering-owners"})
+
+
+def _check_public_repo_teams(fleet: list[dict[str, Any]]) -> None:
+    """Fail if an active public repo does not grant the two required teams.
+
+    Scoped to ACTIVE PUBLIC repos, matching the policy exactly:
+
+      archived  repository.py emits no TeamRepository for them, so there is nothing
+                to enforce and a failure here would be unfixable.
+      private   deliberately exempt. `access-forge` and `gwarek` are devops-only
+                because that is the intent, not an oversight.
+
+    VISIBILITY IS REQUIRED, NOT ASSUMED. A repo with no visibility signal cannot be
+    checked, and silently skipping it is the failure mode this project keeps hitting --
+    unmeasured and compliant look identical. `_visibility` is written on every repo by
+    the crawl and `visibility` comes from the archetype, so an active repo missing both
+    is hand-authored data that has to say which it is.
+    """
+    unknown: list[str] = []
+    missing: list[str] = []
+    for repo in fleet:
+        if repo.get("archived"):
+            continue
+        visibility = repo.get("_visibility") or repo.get("visibility")
+        if not visibility:
+            unknown.append(repo["name"])
+            continue
+        if visibility != "public":
+            continue
+        absent = REQUIRED_PUBLIC_TEAMS - set(repo.get("teams") or {})
+        if absent:
+            missing.append(f"{repo['name']}: missing {sorted(absent)}")
+    if unknown:
+        message = (
+            "active repos with no visibility recorded, so the public-team policy "
+            "cannot be checked:\n  "
+            + "\n  ".join(sorted(unknown))
+            + "\nAdd `_visibility` (or `visibility`), or re-run "
+            "`bin/github-org-inventory crawl --refresh`."
+        )
+        raise ValueError(message)
+    if missing:
+        message = (
+            "public repos must grant "
+            f"{sorted(REQUIRED_PUBLIC_TEAMS)} (policy 2026-08-10):\n  "
+            + "\n  ".join(sorted(missing))
+            + "\n`teams` REPLACES the archetype's grants rather than merging into "
+            "them, so a repo declaring its own block must restate both."
+        )
+        raise ValueError(message)
+
+
 def _check_team_references(fleet: list[dict[str, Any]]) -> None:
     """Fail if any repo grants to a team slug absent from teams.yaml.
 
@@ -91,6 +148,7 @@ def load_fleet() -> list[dict[str, Any]]:
         fleet.append(merged)
 
     _check_team_references(fleet)
+    _check_public_repo_teams(fleet)
 
     # The dotfile trap is silent by construction, so assert rather than trust.
     assignments = yaml.safe_load((DATA_DIR / "archetypes-proposed.yaml").read_text())

--- a/src/ol_infrastructure/saas/github/repositories/data/archetypes.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/archetypes.yaml
@@ -46,8 +46,13 @@ archetypes:
     #
     # `odl-engineering` is capped at push (maintain is also acceptable; admin is not --
     # policy 2026-08-05, audited as SEC-15). It is the broad engineering team, and admin
-    # carries repo deletion, settings changes and ruleset bypass. It currently holds
-    # admin on 116 repos, so this target is aspirational and phase-5 work, not reality.
+    # carries repo deletion, settings changes and ruleset bypass.
+    #
+    # NOT ASPIRATIONAL ANY MORE. The SEC-15 wave rewrote the 62 active repos that granted
+    # `odl-engineering: admin` down to `push`. What remains above this line is the 55
+    # ARCHIVED repos that still grant admin, which no resource in this project can reach
+    # -- archived repos emit no TeamRepository (repository.py) because GitHub rejects the
+    # write. They need a separate mechanism, tracked as its own task.
     teams:
       odl-engineering: push
       odl-engineering-owners: admin
@@ -67,8 +72,22 @@ archetypes:
   infrastructure:
     extends: base
     tier: tier-1
+    # `devops: admin` rather than base's `push`, and rather than the `devops: push` this
+    # archetype used to declare (decision 2026-08-07). `devops` is one of the two teams
+    # policy sanctions for admin -- it operates the infrastructure it administers, so
+    # settings changes and ruleset bypass are the job rather than an over-grant.
+    #
+    # The old `push` target was the reason CON-04 fired on every devops-admin repo: the
+    # archetype disagreed with both the policy and reality, so the rule was reporting a
+    # divergence nobody intended to close.
+    #
+    # `odl-engineering` is deliberately ABSENT, unlike in `base`. `teams` REPLACES the
+    # archetype's grants wholesale rather than merging into them, so listing it here
+    # would grant the broad engineering team push on every future infrastructure repo --
+    # a widening, not a preservation. All three current infrastructure repos declare
+    # their own `teams`, so this block only governs the next one.
     teams:
-      devops: push
+      devops: admin
       odl-engineering-owners: admin
 
   # Upstream forks: edx-platform, XBlock, tutor, frontend-app-*, ...

--- a/src/ol_infrastructure/saas/github/repositories/data/archetypes.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/archetypes.yaml
@@ -53,6 +53,11 @@ archetypes:
     # ARCHIVED repos that still grant admin, which no resource in this project can reach
     # -- archived repos emit no TeamRepository (repository.py) because GitHub rejects the
     # write. They need a separate mechanism, tracked as its own task.
+    #
+    # POLICY 2026-08-10: both of these belong on every PUBLIC repo, not just on the ones
+    # someone got around to. 149 repo files were filled in to match. The rule is scoped to
+    # public deliberately -- the 10 active private repos keep their narrower grants, since
+    # `access-forge` and `gwarek` being devops-only is the point rather than an oversight.
     teams:
       odl-engineering: push
       odl-engineering-owners: admin
@@ -81,13 +86,15 @@ archetypes:
     # archetype disagreed with both the policy and reality, so the rule was reporting a
     # divergence nobody intended to close.
     #
-    # `odl-engineering` is deliberately ABSENT, unlike in `base`. `teams` REPLACES the
-    # archetype's grants wholesale rather than merging into them, so listing it here
-    # would grant the broad engineering team push on every future infrastructure repo --
-    # a widening, not a preservation. All three current infrastructure repos declare
-    # their own `teams`, so this block only governs the next one.
+    # `odl-engineering` IS listed here, unlike in an earlier draft of this file which
+    # left it out to avoid widening access. Policy 2026-08-10 makes the widening the
+    # point: odl-engineering and odl-engineering-owners belong on every public repo.
+    # It has to be restated rather than inherited -- `teams` REPLACES the parent's
+    # grants wholesale rather than merging into them, so omitting it here would revoke
+    # it on any repo that takes this block.
     teams:
       devops: admin
+      odl-engineering: push
       odl-engineering-owners: admin
 
   # Upstream forks: edx-platform, XBlock, tutor, frontend-app-*, ...

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/XBlock.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/XBlock.yaml
@@ -22,7 +22,7 @@ name: XBlock
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: push
   odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/agent-kit.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/agent-kit.yaml
@@ -24,4 +24,5 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   odl-engineering: maintain
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/apisix.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/apisix.yaml
@@ -23,5 +23,7 @@ merge_commit_title: MERGE_MESSAGE
 name: apisix
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/brand-mitol-residential.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/brand-mitol-residential.yaml
@@ -22,6 +22,8 @@ merge_commit_title: MERGE_MESSAGE
 name: brand-mitol-residential
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ckeditor-custom-build.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ckeditor-custom-build.yaml
@@ -24,4 +24,5 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ckeditor-custom-build.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ckeditor-custom-build.yaml
@@ -23,5 +23,5 @@ name: ckeditor-custom-build
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/codejail.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/codejail.yaml
@@ -22,6 +22,8 @@ merge_commit_title: MERGE_MESSAGE
 name: codejail
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/community-integrations.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/community-integrations.yaml
@@ -23,5 +23,7 @@ merge_commit_title: MERGE_MESSAGE
 name: community-integrations
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-dcind.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-dcind.yaml
@@ -24,6 +24,8 @@ merge_commit_title: MERGE_MESSAGE
 name: concourse-dcind
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-rclone-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-rclone-resource.yaml
@@ -22,6 +22,8 @@ merge_commit_title: MERGE_MESSAGE
 name: concourse-rclone-resource
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-s3-sync-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-s3-sync-resource.yaml
@@ -23,7 +23,7 @@ name: concourse-s3-sync-resource
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: push
   odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-workflow.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-workflow.yaml
@@ -30,5 +30,5 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   devops: admin
-  ol-data: admin
+  ol-data: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse.yaml
@@ -24,5 +24,7 @@ merge_commit_title: MERGE_MESSAGE
 name: concourse
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concoursepy.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concoursepy.yaml
@@ -23,6 +23,8 @@ merge_commit_title: MERGE_MESSAGE
 name: concoursepy
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/configuration.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/configuration.yaml
@@ -25,6 +25,7 @@ name: configuration
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
+  odl-engineering: push
   odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/course-search-utils.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/course-search-utils.yaml
@@ -24,4 +24,5 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/course-search-utils.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/course-search-utils.yaml
@@ -23,5 +23,5 @@ name: course-search-utils
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/dagster.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/dagster.yaml
@@ -23,6 +23,8 @@ merge_commit_title: MERGE_MESSAGE
 name: dagster
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/default-labels-repo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/default-labels-repo.yaml
@@ -20,5 +20,7 @@ merge_commit_title: MERGE_MESSAGE
 name: default-labels-repo
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/demo-test-course.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/demo-test-course.yaml
@@ -27,5 +27,6 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-aqueduct.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-aqueduct.yaml
@@ -23,5 +23,7 @@ merge_commit_title: MERGE_MESSAGE
 name: django-aqueduct
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-cas-mapper.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-cas-mapper.yaml
@@ -21,6 +21,8 @@ merge_commit_title: MERGE_MESSAGE
 name: django-cas-mapper
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-guardian.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-guardian.yaml
@@ -22,7 +22,7 @@ name: django-guardian
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: push
   odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-longer-username.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-longer-username.yaml
@@ -23,6 +23,7 @@ name: django-longer-username
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
+  odl-engineering: push
   odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-role-permissions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-role-permissions.yaml
@@ -22,6 +22,8 @@ merge_commit_title: MERGE_MESSAGE
 name: django-role-permissions
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-shibboleth-remoteuser.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-shibboleth-remoteuser.yaml
@@ -24,5 +24,7 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   devops: admin
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-user-tasks.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-user-tasks.yaml
@@ -21,5 +21,7 @@ merge_commit_title: MERGE_MESSAGE
 name: django-user-tasks
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/docs.openedx.org.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/docs.openedx.org.yaml
@@ -24,4 +24,6 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: maintain
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ecommerce.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ecommerce.yaml
@@ -23,5 +23,7 @@ merge_commit_title: MERGE_MESSAGE
 name: ecommerce
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-analytics-api-client.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-analytics-api-client.yaml
@@ -22,6 +22,7 @@ name: edx-analytics-api-client
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
+  odl-engineering: push
   odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-api-client.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-api-client.yaml
@@ -27,6 +27,7 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 topics:
 - edx
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-api-client.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-api-client.yaml
@@ -26,7 +26,7 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
-  odl-engineering: admin
+  odl-engineering: push
 topics:
 - edx
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-documentation.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-documentation.yaml
@@ -22,7 +22,7 @@ name: edx-documentation
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: push
   odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-enterprise-data.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-enterprise-data.yaml
@@ -22,5 +22,7 @@ merge_commit_title: MERGE_MESSAGE
 name: edx-enterprise-data
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-enterprise.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-enterprise.yaml
@@ -20,5 +20,7 @@ merge_commit_title: MERGE_MESSAGE
 name: edx-enterprise
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-ora2.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-ora2.yaml
@@ -21,5 +21,7 @@ merge_commit_title: MERGE_MESSAGE
 name: edx-ora2
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-platform.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-platform.yaml
@@ -28,7 +28,7 @@ name: edx-platform
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
+  arbisoft-contractors: push
   devops: admin
-  odl-engineering: admin
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-platform.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-platform.yaml
@@ -31,4 +31,5 @@ teams:
   arbisoft-contractors: push
   devops: admin
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-proctoring-proctortrack.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-proctoring-proctortrack.yaml
@@ -22,5 +22,7 @@ merge_commit_title: MERGE_MESSAGE
 name: edx-proctoring-proctortrack
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-proctoring.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-proctoring.yaml
@@ -22,7 +22,7 @@ name: edx-proctoring
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
+  arbisoft-contractors: push
   odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-proctoring.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-proctoring.yaml
@@ -23,6 +23,7 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
+  odl-engineering: push
   odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-search.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-search.yaml
@@ -20,5 +20,7 @@ merge_commit_title: MERGE_MESSAGE
 name: edx-search
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-sga.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-sga.yaml
@@ -27,8 +27,8 @@ name: edx-sga
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
   odl-engineering-owners: admin
 topics:
 - edx

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-submissions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-submissions.yaml
@@ -21,5 +21,7 @@ merge_commit_title: MERGE_MESSAGE
 name: edx-submissions
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-val.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-val.yaml
@@ -23,8 +23,8 @@ name: edx-val
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
   odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edxcut.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edxcut.yaml
@@ -22,5 +22,7 @@ merge_commit_title: MERGE_MESSAGE
 name: edxcut
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-access.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-access.yaml
@@ -21,5 +21,7 @@ merge_commit_title: MERGE_MESSAGE
 name: enterprise-access
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-catalog.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-catalog.yaml
@@ -22,5 +22,7 @@ merge_commit_title: MERGE_MESSAGE
 name: enterprise-catalog
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-integrated-channels.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-integrated-channels.yaml
@@ -20,5 +20,7 @@ merge_commit_title: MERGE_MESSAGE
 name: enterprise-integrated-channels
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-subsidy.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-subsidy.yaml
@@ -21,5 +21,7 @@ merge_commit_title: MERGE_MESSAGE
 name: enterprise-subsidy
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/epithet.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/epithet.yaml
@@ -22,6 +22,8 @@ merge_commit_title: MERGE_MESSAGE
 name: epithet
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/eslint-config.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/eslint-config.yaml
@@ -23,5 +23,5 @@ name: eslint-config
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/eslint-config.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/eslint-config.yaml
@@ -24,4 +24,5 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/forum.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/forum.yaml
@@ -24,4 +24,5 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/forum.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/forum.yaml
@@ -22,6 +22,6 @@ name: forum
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-communications.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-communications.yaml
@@ -24,5 +24,6 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-communications.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-communications.yaml
@@ -22,7 +22,7 @@ name: frontend-app-communications
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-course-authoring.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-course-authoring.yaml
@@ -25,4 +25,5 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-course-authoring.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-course-authoring.yaml
@@ -23,6 +23,6 @@ name: frontend-app-course-authoring
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-discussions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-discussions.yaml
@@ -23,5 +23,7 @@ merge_commit_title: MERGE_MESSAGE
 name: frontend-app-discussions
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-gradebook.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-gradebook.yaml
@@ -25,5 +25,6 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-gradebook.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-gradebook.yaml
@@ -23,7 +23,7 @@ name: frontend-app-gradebook
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-instructor-dashboard.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-instructor-dashboard.yaml
@@ -26,4 +26,5 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: maintain
   odl-engineering: maintain
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-learner-dashboard.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-learner-dashboard.yaml
@@ -21,5 +21,7 @@ merge_commit_title: MERGE_MESSAGE
 name: frontend-app-learner-dashboard
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-learning.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-learning.yaml
@@ -24,5 +24,7 @@ merge_commit_title: MERGE_MESSAGE
 name: frontend-app-learning
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-library-authoring.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-library-authoring.yaml
@@ -22,6 +22,8 @@ merge_commit_title: MERGE_MESSAGE
 name: frontend-app-library-authoring
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-footer-mitol.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-footer-mitol.yaml
@@ -27,7 +27,7 @@ name: frontend-component-footer-mitol
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-footer-mitol.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-footer-mitol.yaml
@@ -29,5 +29,6 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-header-edx-mitol.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-header-edx-mitol.yaml
@@ -24,5 +24,6 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-header-edx-mitol.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-header-edx-mitol.yaml
@@ -22,7 +22,7 @@ name: frontend-component-header-edx-mitol
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-header-mitol.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-header-mitol.yaml
@@ -22,6 +22,6 @@ name: frontend-component-header-mitol
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-header-mitol.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-header-mitol.yaml
@@ -24,4 +24,5 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-lib-special-exams-mitol.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-lib-special-exams-mitol.yaml
@@ -25,6 +25,6 @@ name: frontend-lib-special-exams-mitol
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
+  arbisoft-contractors: push
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-lib-special-exams-mitol.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-lib-special-exams-mitol.yaml
@@ -26,5 +26,7 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-platform.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-platform.yaml
@@ -23,6 +23,8 @@ merge_commit_title: MERGE_MESSAGE
 name: frontend-platform
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-slot-footer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-slot-footer.yaml
@@ -23,5 +23,7 @@ merge_commit_title: MERGE_MESSAGE
 name: frontend-slot-footer
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/hacksnack.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/hacksnack.yaml
@@ -24,6 +24,6 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: triage
-  odl-engineering: admin
+  odl-engineering: push
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/handbook.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/handbook.yaml
@@ -26,6 +26,7 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 topics:
 - handbook
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/handbook.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/handbook.yaml
@@ -24,8 +24,8 @@ name: handbook
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 topics:
 - handbook
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/hashicorp-release-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/hashicorp-release-resource.yaml
@@ -22,6 +22,8 @@ merge_commit_title: MERGE_MESSAGE
 name: hashicorp-release-resource
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/healthchecks.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/healthchecks.yaml
@@ -23,6 +23,8 @@ merge_commit_title: MERGE_MESSAGE
 name: healthchecks
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/heroku-database-backups.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/heroku-database-backups.yaml
@@ -22,6 +22,8 @@ merge_commit_title: MERGE_MESSAGE
 name: heroku-database-backups
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/hq.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/hq.yaml
@@ -30,5 +30,5 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: maintain
-  odl-engineering: admin
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/iso-3166-2.js.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/iso-3166-2.js.yaml
@@ -23,6 +23,6 @@ name: iso-3166-2.js
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/iso-3166-2.js.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/iso-3166-2.js.yaml
@@ -25,4 +25,5 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/jsdom-global.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/jsdom-global.yaml
@@ -22,6 +22,8 @@ merge_commit_title: MERGE_MESSAGE
 name: jsdom-global
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/keycloak-scim.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/keycloak-scim.yaml
@@ -22,5 +22,5 @@ name: keycloak-scim
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/keycloak-scim.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/keycloak-scim.yaml
@@ -23,4 +23,5 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/kubectl-slice.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/kubectl-slice.yaml
@@ -22,6 +22,8 @@ merge_commit_title: MERGE_MESSAGE
 name: kubectl-slice
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/learn-ai.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/learn-ai.yaml
@@ -23,4 +23,5 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   odl-engineering: maintain
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/learn-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/learn-zendesk-theme.yaml
@@ -22,6 +22,6 @@ name: learn-zendesk-theme
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/learn-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/learn-zendesk-theme.yaml
@@ -24,4 +24,5 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/library-customization.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/library-customization.yaml
@@ -23,6 +23,8 @@ merge_commit_title: MERGE_MESSAGE
 name: library-customization
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters-zendesk-theme.yaml
@@ -24,4 +24,5 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters-zendesk-theme.yaml
@@ -22,6 +22,6 @@ name: micromasters-zendesk-theme
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters.yaml
@@ -28,8 +28,8 @@ name: micromasters
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 topics:
 - edx
 - micromasters

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters.yaml
@@ -30,6 +30,7 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 topics:
 - edx
 - micromasters

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn-api-clients.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn-api-clients.yaml
@@ -21,4 +21,5 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn-api-clients.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn-api-clients.yaml
@@ -19,6 +19,6 @@ name: mit-learn-api-clients
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
@@ -28,6 +28,6 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: triage
-  odl-engineering: admin
+  odl-engineering: push
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-moira.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-moira.yaml
@@ -23,5 +23,5 @@ name: mit-moira
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-moira.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-moira.yaml
@@ -24,4 +24,5 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-open-bk.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-open-bk.yaml
@@ -23,6 +23,8 @@ merge_commit_title: MERGE_MESSAGE
 name: mit-open-bk
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-grading-library.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-grading-library.yaml
@@ -27,7 +27,9 @@ merge_commit_title: MERGE_MESSAGE
 name: mitx-grading-library
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 topics:
 - edx
 - grading-library

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-theme.yaml
@@ -26,6 +26,7 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 topics:
 - openedx
 - theme

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-theme.yaml
@@ -25,7 +25,7 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
-  odl-engineering: admin
+  odl-engineering: push
 topics:
 - openedx
 - theme

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitx_cas_mapper.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitx_cas_mapper.yaml
@@ -21,6 +21,8 @@ merge_commit_title: MERGE_MESSAGE
 name: mitx_cas_mapper
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-theme.yaml
@@ -23,6 +23,6 @@ name: mitxonline-theme
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-theme.yaml
@@ -25,4 +25,5 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-translations.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-translations.yaml
@@ -24,6 +24,6 @@ name: mitxonline-translations
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-translations.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-translations.yaml
@@ -26,4 +26,5 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-zendesk-theme.yaml
@@ -24,4 +24,5 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-zendesk-theme.yaml
@@ -22,6 +22,6 @@ name: mitxonline-zendesk-theme
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline.yaml
@@ -28,4 +28,5 @@ squash_merge_commit_title: PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline.yaml
@@ -26,6 +26,6 @@ name: mitxonline
 squash_merge_commit_message: BLANK
 squash_merge_commit_title: PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-theme.yaml
@@ -26,6 +26,6 @@ name: mitxpro-theme
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-theme.yaml
@@ -28,4 +28,5 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-zendesk-theme.yaml
@@ -24,7 +24,7 @@ name: mitxpro-zendesk-theme
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-zendesk-theme.yaml
@@ -26,5 +26,6 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro.yaml
@@ -29,4 +29,5 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro.yaml
@@ -27,6 +27,6 @@ name: mitxpro
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mynumbers.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mynumbers.yaml
@@ -26,7 +26,7 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: triage
-  code-owners: admin
-  odl-engineering: admin
+  code-owners: push
+  odl-engineering: push
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-projects.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-projects.yaml
@@ -25,6 +25,6 @@ name: ocw-hugo-projects
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-projects.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-projects.yaml
@@ -27,4 +27,5 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-themes.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-themes.yaml
@@ -40,3 +40,4 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-themes.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-themes.yaml
@@ -38,5 +38,5 @@ name: ocw-hugo-themes
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-studio.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-studio.yaml
@@ -30,6 +30,7 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 topics:
 - ocw
 - opencourseware

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-studio.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-studio.yaml
@@ -28,8 +28,8 @@ name: ocw-studio
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 topics:
 - ocw
 - opencourseware

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-zendesk-theme.yaml
@@ -24,4 +24,5 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-zendesk-theme.yaml
@@ -22,6 +22,6 @@ name: ocw-zendesk-theme
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw_oer_export.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw_oer_export.yaml
@@ -27,4 +27,5 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw_oer_export.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw_oer_export.yaml
@@ -25,6 +25,6 @@ name: ocw_oer_export
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/odl-video-service.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/odl-video-service.yaml
@@ -24,7 +24,7 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   devops: admin
-  odl-engineering: admin
+  odl-engineering: push
   odl-engineering-owners: admin
 topics:
 - techtv

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-analytics-api.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-analytics-api.yaml
@@ -25,4 +25,5 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   odl-engineering: maintain
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-concourse.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-concourse.yaml
@@ -22,5 +22,8 @@ merge_commit_title: MERGE_MESSAGE
 name: ol-concourse
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  devops: admin
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-data-platform.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-data-platform.yaml
@@ -27,4 +27,5 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-django.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-django.yaml
@@ -26,4 +26,5 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-django.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-django.yaml
@@ -24,6 +24,6 @@ name: ol-django
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-github-workflows.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-github-workflows.yaml
@@ -23,5 +23,7 @@ merge_commit_title: MERGE_MESSAGE
 name: ol-github-workflows
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infra-health-checks.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infra-health-checks.yaml
@@ -21,5 +21,7 @@ merge_commit_title: MERGE_MESSAGE
 name: ol-infra-health-checks
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
@@ -24,9 +24,9 @@ name: ol-infrastructure
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
+  arbisoft-contractors: push
   devops: admin
-  devops-contractors: admin
+  devops-contractors: push
   odl-engineering: maintain
 topics:
 - aws

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
@@ -28,6 +28,7 @@ teams:
   devops: admin
   devops-contractors: push
   odl-engineering: maintain
+  odl-engineering-owners: admin
 topics:
 - aws
 - devops

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloak.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloak.yaml
@@ -22,4 +22,5 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   odl-engineering: maintain
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloakify.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloakify.yaml
@@ -25,4 +25,5 @@ squash_merge_commit_title: PR_TITLE
 teams:
   devops: admin
   odl-engineering: maintain
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-notebook-extensions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-notebook-extensions.yaml
@@ -23,5 +23,7 @@ merge_commit_title: MERGE_MESSAGE
 name: ol-notebook-extensions
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-parliament.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-parliament.yaml
@@ -22,5 +22,7 @@ merge_commit_title: MERGE_MESSAGE
 name: ol-parliament
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-rootly-manager.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-rootly-manager.yaml
@@ -20,5 +20,7 @@ merge_commit_title: MERGE_MESSAGE
 name: ol-rootly-manager
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-discussions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-discussions.yaml
@@ -27,6 +27,7 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
   owners-mit-open: push
 topics:
 - community

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-discussions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-discussions.yaml
@@ -25,9 +25,9 @@ name: open-discussions
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
-  owners-mit-open: admin
+  arbisoft-contractors: push
+  odl-engineering: push
+  owners-mit-open: push
 topics:
 - community
 - mit

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-plugins.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-plugins.yaml
@@ -23,6 +23,6 @@ name: open-edx-plugins
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-plugins.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-plugins.yaml
@@ -25,4 +25,5 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-proposals.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-proposals.yaml
@@ -22,5 +22,7 @@ merge_commit_title: MERGE_MESSAGE
 name: open-edx-proposals
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-learning-ai-tutor.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-learning-ai-tutor.yaml
@@ -26,4 +26,5 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-learning-ai-tutor.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-learning-ai-tutor.yaml
@@ -25,5 +25,5 @@ name: open-learning-ai-tutor
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-learnix.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-learnix.yaml
@@ -18,5 +18,7 @@ merge_commit_title: MERGE_MESSAGE
 name: open-learnix
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-podcast-data.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-podcast-data.yaml
@@ -25,6 +25,6 @@ name: open-podcast-data
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-podcast-data.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-podcast-data.yaml
@@ -27,4 +27,5 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-resource-blocklists.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-resource-blocklists.yaml
@@ -26,4 +26,5 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-video-data.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-video-data.yaml
@@ -22,4 +22,5 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-video-data.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-video-data.yaml
@@ -21,5 +21,5 @@ name: open-video-data
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/openedx-events.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/openedx-events.yaml
@@ -23,5 +23,7 @@ merge_commit_title: MERGE_MESSAGE
 name: openedx-events
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/openedx-ledger.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/openedx-ledger.yaml
@@ -22,5 +22,7 @@ merge_commit_title: MERGE_MESSAGE
 name: openedx-ledger
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/opentelemetry-python-contrib.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/opentelemetry-python-contrib.yaml
@@ -22,5 +22,7 @@ merge_commit_title: MERGE_MESSAGE
 name: opentelemetry-python-contrib
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/platform-engineering-site.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/platform-engineering-site.yaml
@@ -24,4 +24,5 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/platform-engineering-site.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/platform-engineering-site.yaml
@@ -23,5 +23,5 @@ name: platform-engineering-site
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pre-commit-ci-config.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pre-commit-ci-config.yaml
@@ -21,6 +21,8 @@ merge_commit_title: MERGE_MESSAGE
 name: pre-commit-ci-config
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pre-commit-packer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pre-commit-packer.yaml
@@ -22,5 +22,7 @@ merge_commit_title: MERGE_MESSAGE
 name: pre-commit-packer
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/py-tree-sitter.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/py-tree-sitter.yaml
@@ -22,5 +22,7 @@ merge_commit_title: MERGE_MESSAGE
 name: py-tree-sitter
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pycassa.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pycassa.yaml
@@ -22,6 +22,8 @@ merge_commit_title: MERGE_MESSAGE
 name: pycassa
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pylint-django.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pylint-django.yaml
@@ -23,6 +23,6 @@ name: pylint-django
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: push
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pylint-django.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pylint-django.yaml
@@ -24,5 +24,6 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/react-dropzone-uploader.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/react-dropzone-uploader.yaml
@@ -23,6 +23,8 @@ merge_commit_title: MERGE_MESSAGE
 name: react-dropzone-uploader
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/realistic-mm-users.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/realistic-mm-users.yaml
@@ -24,5 +24,5 @@ name: realistic-mm-users
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/realistic-mm-users.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/realistic-mm-users.yaml
@@ -25,4 +25,5 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/redash.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/redash.yaml
@@ -25,6 +25,6 @@ name: redash
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: push
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/redash.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/redash.yaml
@@ -26,5 +26,6 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-config.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-config.yaml
@@ -24,5 +24,5 @@ name: reddit-config
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-config.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-config.yaml
@@ -25,4 +25,5 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-service-activity.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-service-activity.yaml
@@ -21,6 +21,8 @@ merge_commit_title: MERGE_MESSAGE
 name: reddit-service-activity
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-service-websockets.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-service-websockets.yaml
@@ -21,6 +21,8 @@ merge_commit_title: MERGE_MESSAGE
 name: reddit-service-websockets
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/redux-asserts.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/redux-asserts.yaml
@@ -23,4 +23,5 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/redux-asserts.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/redux-asserts.yaml
@@ -22,5 +22,5 @@ name: redux-asserts
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/redux-hammock.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/redux-hammock.yaml
@@ -25,4 +25,5 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/redux-hammock.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/redux-hammock.yaml
@@ -23,6 +23,6 @@ name: redux-hammock
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/release-script.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/release-script.yaml
@@ -24,5 +24,5 @@ name: release-script
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/release-script.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/release-script.yaml
@@ -25,4 +25,5 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/response-map.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/response-map.yaml
@@ -22,6 +22,8 @@ merge_commit_title: MERGE_MESSAGE
 name: response-map
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/searchkit.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/searchkit.yaml
@@ -24,6 +24,8 @@ merge_commit_title: MERGE_MESSAGE
 name: searchkit
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/semantic-mitopen.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/semantic-mitopen.yaml
@@ -28,6 +28,6 @@ name: semantic-mitopen
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: push
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/semantic-mitopen.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/semantic-mitopen.yaml
@@ -29,5 +29,6 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/sign-and-verify.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/sign-and-verify.yaml
@@ -23,6 +23,8 @@ merge_commit_title: MERGE_MESSAGE
 name: sign-and-verify
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/smoot-design.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/smoot-design.yaml
@@ -28,4 +28,5 @@ squash_merge_commit_message: BLANK
 squash_merge_commit_title: PR_TITLE
 teams:
   odl-engineering: maintain
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/superset-marimo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/superset-marimo.yaml
@@ -24,5 +24,7 @@ required_status_checks:
 - Frontend type-check & build
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/superset-nl-explorer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/superset-nl-explorer.yaml
@@ -22,5 +22,7 @@ merge_commit_title: MERGE_MESSAGE
 name: superset-nl-explorer
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/superset-sup.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/superset-sup.yaml
@@ -22,5 +22,7 @@ merge_commit_title: MERGE_MESSAGE
 name: superset-sup
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/taxonomy-connector.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/taxonomy-connector.yaml
@@ -21,5 +21,7 @@ merge_commit_title: MERGE_MESSAGE
 name: taxonomy-connector
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/tech-talk-slides.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/tech-talk-slides.yaml
@@ -22,6 +22,6 @@ name: tech-talk-slides
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/tech-talk-slides.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/tech-talk-slides.yaml
@@ -24,4 +24,5 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/template-mit-demo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/template-mit-demo.yaml
@@ -28,5 +28,6 @@ name: template-mit-demo
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
+  odl-engineering: push
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/testinfra.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/testinfra.yaml
@@ -23,6 +23,8 @@ merge_commit_title: MERGE_MESSAGE
 name: testinfra
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/tutor.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/tutor.yaml
@@ -23,5 +23,7 @@ merge_commit_title: MERGE_MESSAGE
 name: tutor
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ubcpi.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ubcpi.yaml
@@ -24,6 +24,6 @@ name: ubcpi
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: push
+  odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ubcpi.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ubcpi.yaml
@@ -26,4 +26,5 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/vault-plugin-database-starrocks.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/vault-plugin-database-starrocks.yaml
@@ -23,5 +23,7 @@ merge_commit_title: MERGE_MESSAGE
 name: vault-plugin-database-starrocks
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/vault-plugin-secrets-openai.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/vault-plugin-secrets-openai.yaml
@@ -22,5 +22,7 @@ merge_commit_title: MERGE_MESSAGE
 name: vault-plugin-secrets-openai
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/vault-raft-backup.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/vault-raft-backup.yaml
@@ -24,5 +24,5 @@ name: vault-raft-backup
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  devops-contractors: admin
+  devops-contractors: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/vault-raft-backup.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/vault-raft-backup.yaml
@@ -25,4 +25,6 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   devops-contractors: push
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/video_translation_demo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/video_translation_demo.yaml
@@ -23,5 +23,7 @@ merge_commit_title: MERGE_MESSAGE
 name: video_translation_demo
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/world_geographic_regions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/world_geographic_regions.yaml
@@ -23,5 +23,6 @@ name: world_geographic_regions
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
+  odl-engineering: push
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xanalytics.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xanalytics.yaml
@@ -23,5 +23,6 @@ name: xanalytics
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
+  odl-engineering: push
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xblock-lti-consumer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xblock-lti-consumer.yaml
@@ -20,5 +20,7 @@ merge_commit_title: MERGE_MESSAGE
 name: xblock-lti-consumer
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xblock-utils.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xblock-utils.yaml
@@ -23,5 +23,6 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xblock-utils.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xblock-utils.yaml
@@ -22,6 +22,6 @@ name: xblock-utils
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: push
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xblocks-contrib.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xblocks-contrib.yaml
@@ -20,5 +20,7 @@ merge_commit_title: MERGE_MESSAGE
 name: xblocks-contrib
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xqueue-watcher.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xqueue-watcher.yaml
@@ -25,4 +25,6 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   devops: admin
+  odl-engineering: push
+  odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xqueue.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xqueue.yaml
@@ -24,6 +24,8 @@ merge_commit_title: MERGE_MESSAGE
 name: xqueue
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams: {}
+teams:
+  odl-engineering: push
+  odl-engineering-owners: admin
 vulnerability_alerts: false
 web_commit_signoff_required: false


### PR DESCRIPTION
## What are the relevant tickets?

Policy decision 2026-08-10: `odl-engineering` and `odl-engineering-owners` belong on **every public repository**. Closes most of `tk-con-12-66-active-repos-are-reachable-only-by-an--fd40c1`.

**Stacked on #5324** — review that first. The CON-12 rule that measures this lands in #5347.

## Description (What does it do?)

Grants both teams on the 149 active public repos that were missing one or both, plus `ol-concourse`'s full `infrastructure` grant set.

```
+ 230 to create      87 odl-engineering, 142 odl-engineering-owners, 1 devops (ol-concourse)
~ 105 to update      inherited from #5324 underneath this
  0 to delete
```

**This is an access widening**, unlike the SEC-15 narrowing it stacks on. That's the intent, and it's why it's a separate PR rather than folded in.

### `ol-concourse` is the case that surfaced it

An `infrastructure` repo granting nothing at all, reachable only by the nine org owners. Seer read the `teams: {}` in its file as #5324 *revoking* access; live `GET /repos/mitodl/ol-concourse/teams` returned `[]`, so there was nothing to revoke — that entry was `_deviations()` faithfully recording that the repo deviates from its archetype by having no grants. It now takes the full shape: `devops: admin`, `odl-engineering: push`, `odl-engineering-owners: admin`.

### The archetypes now state the rule

So a new repo inherits it rather than waiting for someone to notice. `infrastructure` regains `odl-engineering`, which an earlier draft deliberately omitted *to avoid widening access* — the widening is now the policy, so that omission became the bug. Both blocks restate every team rather than relying on inheritance, because `teams` **replaces** a parent's grants wholesale rather than merging into them.

## How can this be tested?

`pulumi preview` on `ol-saas-github-repositories`, with the composition broken out:

```
resource types created:   230  github:index/teamRepository:TeamRepository   (nothing else)
update kinds:             105  ~ permission: "admin" => "push"              (from #5324)
deletes:                    0

granted, by team:          87  odl-engineering
                          142  odl-engineering-owners
                            1  devops            (ol-concourse only)
```

87 + 142 + 1 = 230, and every created resource is a `TeamRepository` — no other type, no deletes.

Effect on the audit: **active repos with no team grants 80 → 5**, distinct grant shapes 27 → 20.

## Additional Notes

**Add-only, on purpose.** Existing levels are left alone — 11 repos carry `odl-engineering: maintain` and keep it, because the rule is about the team being *present*, not about flattening the level. Other teams (`arbisoft-contractors`, `devops`, `ol-data`, …) are untouched. That's also why shapes only drop 27 → 20 rather than collapsing further: the remaining variance is in the `arbisoft-contractors` and `devops` levels, which flattening would address separately.

**Scoped to public, deliberately.** The 10 active private repos keep their narrower grants — `access-forge` and `gwarek` being devops-only is the point rather than an oversight, and a blanket grant is least appropriate exactly there.

So **five active repos still have no team grants, and all five are private**: `alerting-omnibus`, `apisix-testbed`, `oldevops-scratch`, `open-collaboration`, `product`. That is the rule working as written rather than a gap in applying it — but it does leave those five reachable only by an org owner, and they want their own decision. Flagging rather than folding them in.

**Archived repos are untouched.** `repository.py` emits no `TeamRepository` for them, so an edit would change nothing on GitHub while making the committed data disagree with reality — and `teams` is a drift-tracked field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012eXp7Dox9U9YEJuu8fj2BQ
