### PR TITLE
fix(mit-learn-nextjs): stop GC pauses from being killed as failed health checks

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
@@ -93,7 +93,7 @@ nextjs_config = Config("nextjs")
 # (the fetch/ISR data cache over high-cardinality search/topic query strings is the
 # leading suspect). More headroom buys hours between GC storms instead of minutes; it
 # does not stop the climb, and a larger heap makes each individual major GC longer.
-# The leak is the actual fix.
+# Fixing the leak is the actual fix.
 nextjs_memory_request = "1536Mi"
 NEXTJS_NON_HEAP_OVERHEAD_MIB = 224
 nextjs_max_old_space_size_mib = (

--- a/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
@@ -79,7 +79,22 @@ nextjs_config = Config("nextjs")
 # an ever-larger, unneeded slice off the top as the limit grows.
 # The heap budget the container is provisioned around: V8's old-space ceiling is
 # derived from this, and it is also the memory request (what the scheduler reserves).
-nextjs_memory_request = "1Gi"
+#
+# Raised from 1Gi: at an 800MiB old-space ceiling, production pods rode with working
+# set pinned at ~900MiB for 20+ hours at a stretch, i.e. the heap sat permanently at
+# its cap. V8 answers that by running near-continuous mark-compact, and a major GC on
+# a full ~800MiB heap stops the world for seconds -- long enough that the synthetic
+# probe against the origin hit its 15s ceiling on ~3% of checks (11% in the worst
+# hour) and kubelet's own probes timed out. This buys the heap real room so GC is
+# occasional rather than constant.
+#
+# This is mitigation, not a fix: working set climbs monotonically from ~250MiB to
+# 900MiB+ over a few hours and never plateaus, so something is retaining memory
+# (the fetch/ISR data cache over high-cardinality search/topic query strings is the
+# leading suspect). More headroom buys hours between GC storms instead of minutes; it
+# does not stop the climb, and a larger heap makes each individual major GC longer.
+# The leak is the actual fix.
+nextjs_memory_request = "1536Mi"
 NEXTJS_NON_HEAP_OVERHEAD_MIB = 224
 nextjs_max_old_space_size_mib = (
     int(parse_quantity(nextjs_memory_request)) // (1024 * 1024)
@@ -92,7 +107,8 @@ nextjs_max_old_space_size_mib = (
 # while the heap was near full. The extra headroom here is deliberately NOT given to
 # V8 -- max_old_space_size stays pinned to the request-derived budget above -- so it
 # stays available to absorb non-heap spikes instead of being absorbed into the heap.
-nextjs_memory_limit = "1536Mi"
+# Kept at request + 512Mi as the request grew, preserving that absorption margin.
+nextjs_memory_limit = "2Gi"
 
 stay_updated_hubspot_form_ids = {
     "ci": "f201f3af-c2c0-4b7d-b297-ddbb75912cc1",
@@ -263,17 +279,48 @@ mit_learn_nextjs_deployment = kubernetes.apps.v1.Deployment(
                         ],
                         image_pull_policy="Always",
                         resources=kubernetes.core.v1.ResourceRequirementsArgs(
-                            requests={"cpu": "100m", "memory": nextjs_memory_request},
+                            # 100m was well under what these pods actually use: 100-270m
+                            # steady state and ~900m through startup. Because cpu.shares
+                            # is proportional to the request, that under-ask left this
+                            # pod with ~5% scheduling weight on 2-vCPU nodes already at
+                            # 90%+ CPU-requested and shared with edxapp/mitxonline,
+                            # so it lost every contention fight. Starving a
+                            # single-threaded Node server of CPU stretches its GC pauses
+                            # and blocks the event loop.
+                            #
+                            # Deliberately no CPU limit: SSR latency here is far more
+                            # sensitive to CFS throttling than the cluster is to this
+                            # pod bursting.
+                            requests={"cpu": "500m", "memory": nextjs_memory_request},
                             limits={"memory": nextjs_memory_limit},
                         ),
                         env=env_vars,
+                        # Both probes previously left timeout_seconds unset, silently
+                        # inheriting the 1s default. One second is not a meaningful
+                        # health signal for a single-threaded Node server: any GC pause
+                        # or burst of event-loop work trips it even though the process
+                        # is fine and will answer moments later. In production that
+                        # turned GC pauses into pod kills -- 14 container restarts in
+                        # 24h across 5 replicas, all exit 137 / "Error" (SIGKILL)
+                        # rather than OOMKilled, with memory sitting at only ~400-600MiB
+                        # of a 1536Mi limit at the time. Each kill also flapped the pod
+                        # out of the service endpoints, concentrating traffic onto the
+                        # remaining pods and accelerating their own heap growth.
+                        #
+                        # A tcp_socket liveness check is the worst fit for this failure
+                        # mode -- a blocked event loop cannot accept(), so a
+                        # healthy-but-pausing process fails it. Kept, since a genuinely
+                        # wedged process should still be replaced, but widened to ~3
+                        # minutes of continuous unresponsiveness before a kill -- far
+                        # longer than any GC pause.
                         liveness_probe=kubernetes.core.v1.ProbeArgs(
                             tcp_socket=kubernetes.core.v1.TCPSocketActionArgs(
                                 port=DEFAULT_NEXTJS_PORT,
                             ),
                             initial_delay_seconds=30,
                             period_seconds=30,
-                            failure_threshold=3,
+                            failure_threshold=6,
+                            timeout_seconds=10,
                         ),
                         readiness_probe=kubernetes.core.v1.ProbeArgs(
                             http_get=kubernetes.core.v1.HTTPGetActionArgs(
@@ -283,6 +330,7 @@ mit_learn_nextjs_deployment = kubernetes.apps.v1.Deployment(
                             initial_delay_seconds=15,
                             period_seconds=15,
                             failure_threshold=3,
+                            timeout_seconds=5,
                         ),
                         startup_probe=kubernetes.core.v1.ProbeArgs(
                             http_get=kubernetes.core.v1.HTTPGetActionArgs(


### PR DESCRIPTION
### What are the relevant tickets?

N/A — this came out of triaging a repeatedly-firing production alert ("Learn NextJS Homepage (Bypass Fastly) - Check Failed", Grafana rule `afjaps6wtn0n4a`).

### Description (What does it do?)

Fixes three configuration choices on the `mit-learn-nextjs` production deployment that were turning ordinary garbage collection into probe timeouts and pod kills.

**The symptom.** The synthetic probe against `https://next.learn.mit.edu/` was failing ~3% of checks over 24h (11% in the worst hour). Every failure was identical in shape: `probe_http_status_code=0` with `probe_duration_seconds` of exactly `15.0000` — a hard client timeout with no HTTP response, not a 5xx.

**Where it wasn't.** The `probe_http_duration_seconds` phase breakdown ruled out the network entirely. `resolve`, `connect`, and `tls` were flat and clean (~0.5ms / 5ms / 4ms). All of the time was in `processing` (server time-to-first-byte, spiking to 9s and 14.5s) and sometimes `transfer` (8.4s, 8.9s). Server-side, not DNS, TLS, or Fastly.

Notably `https://learn.mit.edu/` (through Fastly) sat at **100%** success over the same window while the bypass endpoint was at **88.3%** — Fastly's cache was masking a sick origin from real users. Not a user-facing outage yet, but there was no origin headroom left and any cache miss rode the bad path.

**Root cause.** Memory growth into the V8 heap ceiling, causing multi-second stop-the-world GC pauses:

- `--max-old-space-size` was 800MiB. Production pods rode with working set pinned at ~900MiB for 20+ hours at a stretch, i.e. the heap sat permanently at its cap, then climbed to 1073MiB → 1260MiB before being recycled.
- At that point V8 runs near-continuous mark-compact, and a major GC on a full ~800MiB heap stops the world for seconds — long enough to hit the probe's 15s ceiling.

**Why it became pod kills.** Both `livenessProbe` and `readinessProbe` left `timeout_seconds` unset, silently inheriting the Kubernetes **1 second** default (the `startupProbe` right below them explicitly set 5). One second is not a health signal for a single-threaded Node server — it just reports "currently mid-GC". The result was kubelet killing healthy processes:

- **14 container restarts in 24h** across 5 replicas.
- All exit code 137 / reason `Error` (kubelet SIGKILL), **not** `OOMKilled`, with memory at only ~400–600MiB of a 1536Mi limit at the time.
- Cluster events showed `Liveness probe failed: dial tcp ... i/o timeout` and `Readiness probe failed: ... context deadline exceeded`. These are kubelet's *node-local* requests — a local `/healthcheck` failing at 1s means the event loop is blocked, nothing else explains it.
- The two pods with the highest heap were exactly the two with probe failures.
- Each kill also flapped the pod out of the service endpoints, pushing its traffic onto the remaining pods and accelerating their own heap growth.

`tcpSocket` is the worst-fit liveness check for this failure mode specifically, since a blocked event loop cannot `accept()` — so a healthy-but-pausing process fails it.

**The changes:**

| | Before | After |
|---|---|---|
| `--max-old-space-size` | 800MiB | **1312MiB** |
| `requests.memory` | `1Gi` | **`1536Mi`** |
| `limits.memory` | `1536Mi` | **`2Gi`** |
| `requests.cpu` | `100m` | **`500m`** |
| `livenessProbe.timeoutSeconds` | unset (1s default) | **10** |
| `livenessProbe.failureThreshold` | 3 | **6** |
| `readinessProbe.timeoutSeconds` | unset (1s default) | **5** |

Three notes on how these are shaped:

1. **The heap size is not hardcoded.** The existing comment block in this file documents that `--max-old-space-size` is *deliberately* derived from the memory **request**, not the limit, with a fixed 224MiB non-heap reserve — and that the extra limit headroom is intentionally withheld from V8 so it can absorb non-heap spikes. Rather than break that invariant, this raises `nextjs_memory_request` and lets the existing arithmetic carry it. The 224MiB non-heap reserve and the 512MiB limit margin are both preserved exactly.

2. **Liveness is loosened, not dropped.** Removing it would mean a genuinely wedged process never gets replaced. `timeout_seconds=10` with `failure_threshold=6` at a 30s period requires ~3 minutes of *continuous* unresponsiveness before a kill — far beyond any GC pause, still bounded for a real hang.

3. **No CPU limit was added, on purpose.** SSR latency here is far more sensitive to CFS throttling than the cluster is to this pod bursting. The CPU *request* was the problem: actual use is 100–270m steady and ~900m through startup, and because `cpu.shares` is proportional to the request, 100m left this pod at ~5% scheduling weight on 2-vCPU nodes already 90%+ CPU-requested and shared with edxapp and mitxonline. Starving a single-threaded server of CPU is what stretched the GC pauses into probe timeouts.

### How can this be tested?

**Validation already run on this branch:**

- `uv run pre-commit run --files src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py` — all hooks pass (ruff format, ruff check, mypy, detect-secrets).
- `pulumi preview --stack Production --diff` renders exactly the intended change and nothing else:

```
~ kubernetes:apps/v1:Deployment: (update) [id=mitlearn/mit-learn-nextjs]
    ~ env           : [ ~ [0]: { ~ value: "--max-old-space-size=800" => "--max-old-space-size=1312" } ]
    ~ livenessProbe : { ~ failureThreshold: 3 => 6
                        + timeoutSeconds  : 10 }
    ~ readinessProbe: { + timeoutSeconds: 5 }
    ~ resources     : { ~ limits  : { ~ memory: "1536Mi" => "2Gi" }
                        ~ requests: { ~ cpu   : "100m" => "500m"
                                      ~ memory: "1Gi"  => "1536Mi" } }
```

- The derived heap arithmetic was checked directly, confirming the design invariants hold:

```
before: request=1Gi     (1024Mi)  heap=800Mi   non-heap-reserve=224Mi  limit=1536Mi  margin=512Mi
after:  request=1536Mi  (1536Mi)  heap=1312Mi  non-heap-reserve=224Mi  limit=2Gi     margin=512Mi
```

**For a reviewer to validate the reasoning**, against the `grafanacloud-prom` datasource in the `mitolproduction` Grafana org:

```promql
# Probe failure rate on the bypass endpoint (was ~0.032 over 24h)
1 - avg_over_time(probe_success{job="Learn NextJS Homepage (Bypass Fastly)"}[24h])

# Failures are 15s timeouts, not HTTP errors — status 0, duration pinned at 15.0000
probe_http_status_code{job="Learn NextJS Homepage (Bypass Fastly)"}
probe_duration_seconds{job="Learn NextJS Homepage (Bypass Fastly)"}

# All latency is server-side: processing/transfer spike, resolve/connect/tls stay flat
probe_http_duration_seconds{job="Learn NextJS Homepage (Bypass Fastly)"}

# Heap climbs monotonically and never plateaus
container_memory_working_set_bytes{namespace="mitlearn", pod=~"mit-learn-nextjs.*", container="nextjs-app"}

# Restart churn (was ~14 over 24h across 5 replicas)
sum(increase(kube_pod_container_status_restarts_total{namespace="mitlearn", container="nextjs-app"}[24h]))
```

**After apply, the success criteria are:**

1. Restart count for `container="nextjs-app"` drops to ~0 over 24h (this is the change that should work immediately and completely).
2. `probe_success` for the bypass job stops dipping; the alert stops firing on single blips.
3. `container_memory_working_set_bytes` still climbs — expected, see below — but takes substantially longer to reach its ceiling.
4. No new `Unhealthy` events in `kubectl -n mitlearn get events` for the nextjs pods.

### Additional Context

**This needs to be watched on apply, not fired and forgotten.** CPU request +400m and memory +512MiB per pod will not fit on the current nodes — e.g. `ip-10-13-128-62.ec2.internal` (r7i.large, 2 vCPU) was already at 1843m/2000m CPU-requested. Karpenter will need to provision larger or additional capacity. This is safe by construction: `maxUnavailable=0` with `maxSurge=1`, plus the existing PodDisruptionBudget, means if nothing can schedule the rollout stalls with the old pods still serving rather than dropping capacity. But it may sit pending, and it's worth having eyes on it.

**Pre-existing unrelated drift will ride along.** `pulumi preview` on this stack also wants to update the `HTTPRoute` (`~ spec.rules[0]: - matches: <null>`). I confirmed this appears identically on a clean checkout of `main`, so it is not from this change — but it will be applied alongside it. It's a null-removal no-op.

**This propagates to CI and QA.** This file is shared across environments via `stack_info.env_suffix`, so CI and QA get the same probe timeouts and resource sizing. Reasonable, but those environments have lower traffic and were not the ones hurting, so the memory bump is arguably generous there. Happy to gate it on environment if a reviewer would prefer.

**The memory headroom is mitigation, not a fix.** Working set climbs monotonically from ~250MiB to 900MiB+ over a few hours and never plateaus, which means something is retaining memory. More headroom buys hours between GC storms instead of minutes; it does not stop the climb, and a larger heap makes each individual major GC longer when it does happen. The leading suspect is the Next.js fetch/ISR data cache interacting with very high-cardinality query strings — the app's own request logs show an enormous spread of unique `/search?...` and `/c/topic/...` permutations, and `NEXT_CACHE_S_MAXAGE_SECONDS` is 7200. A heap snapshot from a pod that has been up ~2h is the next step. **This PR does not fix that.**

**A blind spot worth closing.** Two observability gaps made this harder to diagnose than it should have been, and both are worth follow-up outside this PR:

- The app exports no `nodejs_*` or event-loop-lag metrics, so the GC diagnosis rests on convergent circumstantial evidence (heap at ceiling + node-local 1s probes timing out + all latency in `processing`) rather than direct measurement of pause duration.
- The app's own request log reports `durationMs` for handler execution only, so time spent queued behind a blocked event loop is never counted and requests that never complete are never logged. The application logs looked completely clean throughout — every request 1–900ms — while the origin was timing out 11% of probes. That telemetry structurally cannot see this failure mode.

**Out of scope, but noticed while in the namespace:** the celery KEDA ScaledObjects appear stuck — `mitlearn-default-celery-worker` at 187/10 against its target, `embeddings` at 122/10, `edx-content` at 76/10, all sitting at 1 replica despite `maxReplicas` of 20/30/10. Queue depth is 12–19x the scaling target without scaling up. There is also a leftover `mitlearn-embeddings-celery-worker` pod in `ContainerStatusUnknown` from ~2d8h ago. Unrelated to this change and untouched here, but probably worth its own look.
