### PR TITLE
Pin odl-engineering and arbisoft-contractors at push everywhere

### DIFF
--- a/src/ol_infrastructure/saas/github/repositories/data/archetypes.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/archetypes.yaml
@@ -44,9 +44,15 @@ archetypes:
     # direct permission on a repo (§4.7). That makes the LEVEL here the whole access
     # story rather than a detail.
     #
-    # `odl-engineering` is capped at push (maintain is also acceptable; admin is not --
-    # policy 2026-08-05, audited as SEC-15). It is the broad engineering team, and admin
-    # carries repo deletion, settings changes and ruleset bypass.
+    # `odl-engineering` is PINNED at push -- not "push or maintain", which the
+    # 2026-08-05 policy allowed and 2026-08-10 tightened. It is the broad engineering
+    # team, and maintain carries repo settings including the merge flags, description
+    # and topics this project declares, so it hands back the drift surface the import
+    # closed. admin additionally carries deletion and ruleset bypass.
+    #
+    # `arbisoft-contractors` is pinned at push for the same reason wherever it appears.
+    # Neither team should sit at more than one level across the fleet: a spread with no
+    # recorded rationale is indistinguishable from an accident.
     #
     # NOT ASPIRATIONAL ANY MORE. The SEC-15 wave rewrote the 62 active repos that granted
     # `odl-engineering: admin` down to `push`. What remains above this line is the 55

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/.github.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/.github.yaml
@@ -23,6 +23,6 @@ name: .github
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: maintain
+  odl-engineering: push
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/agent-kit.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/agent-kit.yaml
@@ -23,6 +23,6 @@ name: agent-kit
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: maintain
+  odl-engineering: push
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/common-access.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/common-access.yaml
@@ -27,6 +27,6 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   devops: admin
-  odl-engineering: maintain
+  odl-engineering: push
 vulnerability_alerts: false
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/docs.openedx.org.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/docs.openedx.org.yaml
@@ -23,7 +23,7 @@ name: docs.openedx.org
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: maintain
+  arbisoft-contractors: push
   odl-engineering: push
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-instructor-dashboard.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-instructor-dashboard.yaml
@@ -24,7 +24,7 @@ name: frontend-app-instructor-dashboard
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: maintain
-  odl-engineering: maintain
+  arbisoft-contractors: push
+  odl-engineering: push
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/hacksnack.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/hacksnack.yaml
@@ -23,7 +23,7 @@ name: hacksnack
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: triage
+  arbisoft-contractors: push
   odl-engineering: push
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/hq.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/hq.yaml
@@ -29,6 +29,6 @@ secret_scanning_push_protection: disabled
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: maintain
+  arbisoft-contractors: push
   odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/learn-ai.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/learn-ai.yaml
@@ -22,6 +22,6 @@ name: learn-ai
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: maintain
+  odl-engineering: push
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/lehrer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/lehrer.yaml
@@ -22,7 +22,7 @@ name: lehrer
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: maintain
-  odl-engineering: maintain
+  arbisoft-contractors: push
+  odl-engineering: push
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
@@ -27,7 +27,7 @@ name: mit-learn
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: triage
+  arbisoft-contractors: push
   odl-engineering: push
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-api-clients.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-api-clients.yaml
@@ -23,6 +23,6 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
-  odl-engineering: maintain
+  odl-engineering: push
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mynumbers.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mynumbers.yaml
@@ -25,7 +25,7 @@ name: mynumbers
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: triage
+  arbisoft-contractors: push
   code-owners: push
   odl-engineering: push
   odl-engineering-owners: admin

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-analytics-api.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-analytics-api.yaml
@@ -24,6 +24,6 @@ name: ol-analytics-api
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: maintain
+  odl-engineering: push
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
@@ -27,7 +27,7 @@ teams:
   arbisoft-contractors: push
   devops: admin
   devops-contractors: push
-  odl-engineering: maintain
+  odl-engineering: push
   odl-engineering-owners: admin
 topics:
 - aws

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloak.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloak.yaml
@@ -21,6 +21,6 @@ name: ol-keycloak
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: maintain
+  odl-engineering: push
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloakify.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloakify.yaml
@@ -24,6 +24,6 @@ squash_merge_commit_message: PR_BODY
 squash_merge_commit_title: PR_TITLE
 teams:
   devops: admin
-  odl-engineering: maintain
+  odl-engineering: push
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/smoot-design.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/smoot-design.yaml
@@ -27,6 +27,6 @@ name: smoot-design
 squash_merge_commit_message: BLANK
 squash_merge_commit_title: PR_TITLE
 teams:
-  odl-engineering: maintain
+  odl-engineering: push
   odl-engineering-owners: admin
 web_commit_signoff_required: false


### PR DESCRIPTION
## What are the relevant tickets?

Policy decision 2026-08-10 — the level-flattening half of `tk-con-12-66-active-repos-are-reachable-only-by-an--fd40c1`. **Stacked on #5357**, which is stacked on #5324. Review those first.

## Description (What does it do?)

Pins `odl-engineering` and `arbisoft-contractors` at `push` on every active repo. Neither team should sit at more than one level across the fleet — a spread with no recorded rationale is indistinguishable from an accident.

19 grants across 17 repos.

## ⚠️ Three of these RAISE access, not lower it

`arbisoft-contractors` holds **`triage`** on `hacksnack`, `mit-learn` and `mynumbers` today. Triage carries **no write access**. Pinning at `push` **grants the contractor team write on all three — `mit-learn` among them**, the flagship application.

That is the opposite direction from every other grant in this change, and from the SEC-15 narrowing underneath it. It's included because flattening means one *level*, not one *direction* — stopping at the 16 lowerings would leave in place the exact outliers the change exists to remove.

**If `triage` on those three was deliberate, dropping them is a three-line change and the other 16 stand on their own.** Say so and I'll rebase them out.

## How can this be tested?

`pulumi preview` on `ol-saas-github-repositories`, with everything the stack contributes broken out:

```
~ 105  permission: "admin"    => "push"     from #5324
~  16  permission: "maintain" => "push"     this change, lowering
~   3  permission: "triage"   => "push"     this change, RAISING
+ 230  TeamRepository (create)              from #5357
  0    delete
```

124 updates + 230 creates, 1046 unchanged. Every created resource is a `TeamRepository`; no other type, no deletes.

Uniformity, measured as distinct grant shapes across the 176 active repos:

| | Shapes |
|---|---|
| before #5357 | 27 |
| after #5357 | 20 |
| after this | **14** |

`odl-engineering` is now `push` on all 168 repos that grant it; `arbisoft-contractors` is `push` on all 51. The two commonest shapes now cover 154 of 176 repos.

## Additional Notes

**Why `push` and not `maintain` for the 16 that come down.** `maintain` carries repository settings — including the merge flags, description and topics this project now declares in `data/repos/`. Leaving the broad engineering team there hands back exactly the drift surface the import closed. `push` keeps the whole day-to-day loop (clone, branch, push, open and merge PRs) and gives up settings, deletion and access management.

**Archived repos are untouched**, as everywhere else in this stack: `repository.py` emits no `TeamRepository` for them, so an edit would change nothing on GitHub while making the committed data disagree with reality.

**Merge-order note:** #5347 and #5357 both add a validator to the same region of `archetypes.py` and will conflict with each other — keep both checks and both calls. This PR only touches `data/repos/` and the archetype comment, so it doesn't add to that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012eXp7Dox9U9YEJuu8fj2BQ
