### PR TITLE
feat(local-dev): per-worktree test databases for host-run pytest

### DIFF
--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -242,6 +242,18 @@ No host toolchain? The dev container has everything installed — run them there
 kubectl exec -it -n mit-learn deploy/mitlearn-nextjs -- sh -c 'cd /app && yarn test useToggle'
 ```
 
+### Run tests from the host (worktrees / agents)
+
+`kubectl exec`-ing into the one running pod (above) serializes every test run onto the same database — fine for one person, awkward once agents or multiple worktrees are running tests concurrently. `test-db-env.sh` hands out a `DATABASE_URL` pointed at an isolated, throwaway database instead, so concurrent runs never collide and the interactively-running pods' `mitlearn`/`mitxonline` databases are never touched:
+
+```bash
+eval "$(local-dev/scripts/test-db-env.sh my-branch)"
+MITOL_DB_DISABLE_SSL=True uv run pytest main/envs_test.py       # mit-learn
+MITX_ONLINE_DB_DISABLE_SSL=True uv run pytest ...               # mitxonline
+```
+
+The disable-SSL var is required alongside `DATABASE_URL` — each app's settings.py sets `DATABASES["default"]["OPTIONS"]` from that env var directly, ignoring any `sslmode` in the URL itself. The `<slug>` you pass (e.g. your branch name) becomes part of the database name; each invocation also sweeps away its own stale databases older than `TEST_DB_MAX_AGE_HOURS` (default 2h — see the script's header comment for other knobs). Needs Postgres's NodePort from `cluster/k3d-config.yaml`; re-run `setup.sh` to pick it up if your cluster predates this.
+
 ### Connect to PostgreSQL directly
 
 ```bash

--- a/local-dev/cluster/k3d-config.yaml
+++ b/local-dev/cluster/k3d-config.yaml
@@ -39,6 +39,13 @@ ports:
 - port: 443:30443
   nodeFilters:
   - loadbalancer
+# Postgres, for host-run test suites (pytest invoked directly from a checkout
+# instead of via `kubectl exec`) — see local-dev/scripts/test-db-env.sh and the
+# local-pg-host-access Service in infra/modules/database.py. 15432 (not 5432)
+# so this doesn't collide with a Postgres already installed on the host.
+- port: 15432:30432
+  nodeFilters:
+  - loadbalancer
 
 # Disable Traefik — APISIX Ingress Controller replaces it.
 options:

--- a/local-dev/infra/modules/database.py
+++ b/local-dev/infra/modules/database.py
@@ -13,6 +13,8 @@ class DatabaseResources:
     credentials: k8s.core.v1.Secret
     cluster: k8s.apiextensions.CustomResource
     """The CNPG Cluster CR — pass as a dependency to workloads that need Postgres."""
+    host_access: k8s.core.v1.Service
+    """NodePort exposing the primary directly to the host — see its own comment."""
 
 
 def create_database(
@@ -98,8 +100,32 @@ def create_database(
         opts=_k8s(parent=local_infra_ns, depends_on=[cnpg_release, credentials]),
     )
 
+    # Separate NodePort Service (not a field on the Cluster CR itself) so CNPG's
+    # own reconciliation of local-pg-rw/-ro/-r is untouched. Host-run test suites
+    # (pytest invoked directly from a checkout, outside the cluster — see
+    # local-dev/scripts/test-db-env.sh) need a plain TCP path to the primary;
+    # in-cluster pods keep using local-pg-rw as before. Mapped to a host port by
+    # cluster/k3d-config.yaml's `ports:` entry, same recipe as APISIX's
+    # NodePort/host-port pair in ingress.py.
+    host_access = k8s.core.v1.Service(
+        "local-pg-host-access",
+        metadata={"name": "local-pg-host-access", "namespace": "local-infra"},
+        spec={
+            "type": "NodePort",
+            # Matches local-pg-rw's own selector so this always targets the
+            # current primary.
+            "selector": {
+                "cnpg.io/cluster": "local-pg",
+                "cnpg.io/instanceRole": "primary",
+            },
+            "ports": [{"port": 5432, "targetPort": 5432, "nodePort": 30432}],
+        },
+        opts=_k8s(parent=local_infra_ns, depends_on=[cluster]),
+    )
+
     return DatabaseResources(
         cnpg_release=cnpg_release,
         credentials=credentials,
         cluster=cluster,
+        host_access=host_access,
     )

--- a/local-dev/scripts/test-db-env.sh
+++ b/local-dev/scripts/test-db-env.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# test-db-env.sh — hand out an isolated Postgres test-database name for
+# host-run tests, and sweep away stale ones left by previous runs.
+#
+# Django (mit-learn, mitxonline, ...) builds DATABASES from DATABASE_URL, and
+# pytest-django / `manage.py test` create+drop a separate `test_<name>`
+# database for the actual run — the `<name>` database itself is never opened.
+# Pointing DATABASE_URL at a name unique to your worktree/branch means
+# concurrent agents/worktrees never collide on the same `test_<name>`
+# database, and the shared `mitlearn`/`mitxonline` databases the
+# interactively-running pods use are never touched by a test run.
+#
+# Usage:
+#   eval "$(local-dev/scripts/test-db-env.sh my-branch)"
+#   DATABASE_URL=... uv run pytest ...
+#
+# Only stdout is the eval-able `export DATABASE_URL=...` line; progress/sweep
+# logging goes to stderr so it's safe to eval the whole output.
+#
+# The <slug> becomes part of the throwaway database name, suffixed with the
+# current time so stale entries (crashed runs, killed agents) can be swept by
+# age. Sweeping happens as a side effect of every invocation, not via a
+# separate always-on process: unlike Docker image growth (disk-janitor.sh),
+# test databases are only ever created at the moment this script runs, so
+# sweeping at that same moment is sufficient.
+#
+# Knobs:
+#   TEST_DB_MAX_AGE_HOURS              drop test_* databases older than this
+#                                       (default 2 — our suites run 5-15 min;
+#                                       bump it for a deliberate `pytest
+#                                       --keepdb` session that outlives that)
+#   TEST_DB_HOST / TEST_DB_PORT        default localhost / 15432, matching
+#                                       cluster/k3d-config.yaml's port mapping
+#   TEST_DB_USER / TEST_DB_PASSWORD    default app / localdev, matching the
+#                                       pg-app-credentials Secret in
+#                                       infra/modules/database.py
+#
+# Requires only kubectl (already a local-dev prerequisite) — the sweep runs
+# psql inside the local-pg-1 pod rather than requiring a Postgres client on
+# the host; only the pytest process itself needs host-to-cluster TCP access.
+
+set -uo pipefail
+
+SLUG="${1:?usage: test-db-env.sh <slug>}"
+MAX_AGE_HOURS="${TEST_DB_MAX_AGE_HOURS:-2}"
+DB_HOST="${TEST_DB_HOST:-localhost}"
+DB_PORT="${TEST_DB_PORT:-15432}"
+DB_USER="${TEST_DB_USER:-app}"
+DB_PASSWORD="${TEST_DB_PASSWORD:-localdev}"  # pragma: allowlist secret
+PG_POD="local-pg-1"
+PG_NAMESPACE="local-infra"
+
+ts() { date "+%Y-%m-%d %H:%M:%S"; }
+log() { echo "[$(ts)] $*" >&2; }
+
+if [[ ! "$MAX_AGE_HOURS" =~ ^[0-9]+$ ]]; then
+    log "invalid TEST_DB_MAX_AGE_HOURS='${MAX_AGE_HOURS}' — using 2"
+    MAX_AGE_HOURS=2
+fi
+
+# Lowercase alnum/hyphen only, so it's safe to interpolate into SQL below and
+# is a valid Postgres identifier fragment.
+SAFE_SLUG="$(printf '%s' "$SLUG" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9-' '-')"
+NOW_EPOCH="$(date +%s)"
+DB_NAME="${SAFE_SLUG}-${NOW_EPOCH}"
+
+psql_exec() {
+    # A bare `-U app` would connect over the pod's Unix socket, which uses
+    # peer auth and fails for a `kubectl exec`'d process (its OS user doesn't
+    # map to the `app` Postgres role) — force TCP loopback + password auth
+    # instead, same credentials as pg-app-credentials in database.py.
+    kubectl exec -n "$PG_NAMESPACE" "$PG_POD" -- \
+        psql "postgresql://app:${DB_PASSWORD}@127.0.0.1:5432/postgres" -tAc "$1" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Sweep test_* databases older than TEST_DB_MAX_AGE_HOURS. See header comment
+# for why this runs here instead of as a separate always-on janitor.
+# ---------------------------------------------------------------------------
+sweep_stale() {
+    local cutoff=$(( NOW_EPOCH - MAX_AGE_HOURS * 3600 ))
+    local name epoch in_use
+
+    while IFS= read -r name; do
+        [[ -z "$name" ]] && continue
+        # Expect names shaped test_<slug>-<epoch>; anything else wasn't
+        # created by this script and is left alone.
+        epoch="${name##*-}"
+        [[ "$epoch" =~ ^[0-9]+$ ]] || continue
+        (( epoch >= cutoff )) && continue
+
+        in_use="$(psql_exec "SELECT count(*) FROM pg_stat_activity WHERE datname = '${name}' AND pid <> pg_backend_pid();")"
+        if [[ "${in_use:-0}" -gt 0 ]]; then
+            log "skipping ${name} (still has an active connection)"
+            continue
+        fi
+
+        # A failed DROP here (e.g. another invocation's sweep already removed
+        # it, a benign race) is logged, not fatal — the postcondition, "this
+        # name isn't lingering", already holds either way.
+        if psql_exec "DROP DATABASE IF EXISTS \"${name}\";" >/dev/null; then
+            log "dropped stale test database ${name}"
+        else
+            log "failed to drop ${name} (continuing)"
+        fi
+    done < <(psql_exec "SELECT datname FROM pg_database WHERE datname LIKE 'test\\_%';")
+}
+
+sweep_stale
+
+log "handing out database name ${DB_NAME} (Django's test runner creates/drops test_${DB_NAME})"
+echo "export DATABASE_URL=\"postgresql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}?sslmode=disable\""


### PR DESCRIPTION
### Description (What does it do?)

Local-dev runs one shared Postgres cluster on your machine. If you're running two agents in separate worktrees (or just two test runs) at once, both try to create/drop the same `test_<db>` database and one of them loses.

This gives each worktree its own throwaway test database, so tests can run in parallel:

1. A NodePort Service exposes the shared Postgres cluster on `localhost:15432`, so tests can run on the host instead of only from inside a pod.
2. `local-dev/scripts/test-db-env.sh <name>` prints a `DATABASE_URL` pointing at a database name unique to you (e.g. `alice-1786389465`). Django's test runner already creates and drops a `test_<name>` database around that name — no code changes needed in mit-learn or mitxonline.

The script also sweeps: any `test_*` database older than 2 hours, and not currently in use, gets dropped before handing out a new one. That covers leftovers from crashed test runs or abandoned worktrees, so nobody has to clean up manually.

Usage:
```
eval "$(local-dev/scripts/test-db-env.sh my-feature)"
uv run pytest
```

Worth flagging:

- Each app also needs its SSL-disable setting on (`MITOL_DB_DISABLE_SSL` for mit-learn, `MITX_ONLINE_DB_DISABLE_SSL` for mitxonline) — both apps ignore `sslmode` in `DATABASE_URL` and hardcode SSL unless that flag is set, and the local Postgres doesn't speak SSL.
- Only takes effect on a freshly created cluster — k3d only reads port mappings at cluster-create time, not on a running one. Anyone on an existing cluster needs a `teardown.sh && setup.sh` to pick this up.
- The 2-hour sweep assumes tests finish in minutes, which matches how long our suites actually take. A much longer-running suite could have its database swept mid-run, though the script skips anything it detects is still connected.

### How can this be tested?

1. `eval "$(local-dev/scripts/test-db-env.sh test1)"`; confirm `$DATABASE_URL` points at `localhost:15432/test1-<epoch>`.
2. Point a real test run at it, e.g. in mit-learn: `DATABASE_URL=$DATABASE_URL MITOL_DB_DISABLE_SSL=True uv run pytest`.
3. Run it twice with different names back-to-back — confirm neither run interferes with the other's database.
4. Sweep behavior: run the script again immediately — the database from step 1 should still be too young to sweep. To see a sweep happen, either wait 2+ hours or manually rename an old `test_*` database's timestamp back, then rerun the script and confirm it's dropped (and confirm it's *not* dropped if you have a `psql` session open against it).