### PR TITLE
feat(concourse): adopt topology='preview-gated' on EKS and edxapp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
   "pulumi-rootly",
   "pulumi-terraform>=6.0.1",
   "pulumi-command>=1.0,<2",
-  "ol-concourse>=0.14,<0.15",
+  "ol-concourse>=0.15,<0.16",
   "pulumiverse-grafana>=2.0.0,<3",
   "pulumiverse-sentry==0.0.9",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
   "pulumi-rootly",
   "pulumi-terraform>=6.0.1",
   "pulumi-command>=1.0,<2",
-  "ol-concourse>=0.13,<0.14",
+  "ol-concourse>=0.14,<0.15",
   "pulumiverse-grafana>=2.0.0,<3",
   "pulumiverse-sentry==0.0.9",
 ]

--- a/src/ol_concourse/pipelines/infrastructure/eks_clusters/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/eks_clusters/pipeline.py
@@ -36,11 +36,13 @@ for cluster in ["data", "operations", "applications", "residential"]:
     infra_chain = pulumi_jobs_chain(
         eks_infrastructure_code,
         refresh_stack=True,
-        # Show what promoting will apply to the next cluster stage in the gate
-        # issue. Cluster stages drift from each other more than most stacks --
-        # they get hand-touched during incidents -- and that drift is invisible
-        # in the diff of the stage that was just deployed.
-        preview_next_stack=True,
+        # Gate each stage on a preview OF ITSELF: the preview opens the gate
+        # issue with that stage's own diff, and closing it runs the deploy.
+        # Cluster stages drift from each other more than most stacks -- they get
+        # hand-touched during incidents -- and that drift is invisible in the
+        # diff of the stage that was just deployed.
+        topology="preview-gated",
+        auto_deploy_stages=["CI"],
         project_name="ol-infrastructure-eks",
         project_source_path=PULUMI_CODE_PATH.joinpath("infrastructure/aws/eks"),
         stack_names=[f"{cluster}.{stage}" for stage in stages],
@@ -50,7 +52,8 @@ for cluster in ["data", "operations", "applications", "residential"]:
     substructure_chain = pulumi_jobs_chain(
         eks_substructure_code,
         refresh_stack=True,
-        preview_next_stack=True,
+        topology="preview-gated",
+        auto_deploy_stages=["CI"],
         project_name="ol-substructure-eks",
         project_source_path=PULUMI_CODE_PATH.joinpath("substructure/aws/eks"),
         stack_names=[f"{cluster}.{stage}" for stage in stages],

--- a/src/ol_concourse/pipelines/open_edx/edx_platform_v3/pipeline.py
+++ b/src/ol_concourse/pipelines/open_edx/edx_platform_v3/pipeline.py
@@ -219,12 +219,17 @@ def build_edx_pipeline(release_names: list[str]) -> Pipeline:
                     # edxapp's Pulumi code provisions Fastly resources; refresh
                     # calls the Fastly API and fails while the token is rotated.
                     refresh_stack=False,
-                    # Show what promoting will apply to the next environment in
-                    # the gate issue. edxapp is the largest blast radius in the
-                    # estate and its environments are the most likely to have
-                    # drifted, which is exactly what the deployed stack's own
-                    # diff cannot show. The preview cannot fail the deploy.
-                    preview_next_stack=True,
+                    # Gate each stage on a preview OF ITSELF. edxapp is the
+                    # largest blast radius in the estate and its environments
+                    # are the most likely to have drifted -- exactly what the
+                    # previously-deployed stack's diff cannot show.
+                    #
+                    # This also fixes coverage that preview_next_stack could not
+                    # reach: edxapp splits one deployment across Open edX
+                    # releases, so mitx CI and mitx QA are built by DIFFERENT
+                    # chain calls and a next-stack preview cannot span them.
+                    topology="preview-gated",
+                    auto_deploy_stages=["CI"],
                     stack_names=[
                         f"{deployment.deployment_name}.{stage}"
                         for stage in deployment.envs_by_release(release_name)

--- a/uv.lock
+++ b/uv.lock
@@ -1430,14 +1430,14 @@ wheels = [
 
 [[package]]
 name = "ol-concourse"
-version = "0.14.0"
+version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/a0/9d25bf3067aae5f1cdc2c3f5e838525c4e990d396e54e61d6dcd317aad24/ol_concourse-0.14.0.tar.gz", hash = "sha256:2279f402d357851d4e43ba47ea29a163e0dc6770ff62e381a516f9220d117607", size = 67103, upload-time = "2026-08-10T19:25:17.755Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/c4/1b27d55e7be2e2a9b67f77b55bcd75b464129dbb5152d96e977ad1cf1964/ol_concourse-0.15.0.tar.gz", hash = "sha256:5177be99cbef66fcb3c335db3f7f1de6796cf82f634bc69066862aeba82c75fb", size = 68526, upload-time = "2026-08-11T22:30:12.167Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/49/f4dca303d87b96402ed3e9d280372be0b69158d90cfee3fa0ef85f5ca456/ol_concourse-0.14.0-py3-none-any.whl", hash = "sha256:bd9589516aee910659c8f2bda45a4838bda33c64920b37ca4d7baca95b7998cf", size = 59347, upload-time = "2026-08-10T19:25:16.715Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/c6e12f846089ad6d8e75e53d24682ca4099fb1430fd227a478889fbec4c9/ol_concourse-0.15.0-py3-none-any.whl", hash = "sha256:50e4aef10136e5c873ec49becb5aae355c037c1a880bd9acb4e0c1024ddcbf77", size = 59912, upload-time = "2026-08-11T22:30:11.214Z" },
 ]
 
 [[package]]
@@ -1509,7 +1509,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.0,<0.29" },
     { name = "hvac", extras = ["parser"], specifier = ">=2.0.0,<3" },
     { name = "kubernetes", specifier = ">=34.1.0" },
-    { name = "ol-concourse", specifier = ">=0.14,<0.15" },
+    { name = "ol-concourse", specifier = ">=0.15,<0.16" },
     { name = "ol-parliament", specifier = ">=1.7.0" },
     { name = "packaging", specifier = ">=24.2" },
     { name = "pulumi", specifier = ">=3.39.1,<4" },

--- a/uv.lock
+++ b/uv.lock
@@ -1430,14 +1430,14 @@ wheels = [
 
 [[package]]
 name = "ol-concourse"
-version = "0.13.0"
+version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/19/386b41708f79ce4023bf18dbaf9704caf3d7787ada33c1067be3e6b680ef/ol_concourse-0.13.0.tar.gz", hash = "sha256:ac292ee8c92221e07839346c214ff32fc9a26294fd557392c5e07b197c9b6454", size = 59886, upload-time = "2026-08-10T13:09:02.664Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dd/a0/9d25bf3067aae5f1cdc2c3f5e838525c4e990d396e54e61d6dcd317aad24/ol_concourse-0.14.0.tar.gz", hash = "sha256:2279f402d357851d4e43ba47ea29a163e0dc6770ff62e381a516f9220d117607", size = 67103, upload-time = "2026-08-10T19:25:17.755Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/cd/af880d3f2446895cfa60d87599a9b9e858e8a04ce8907a928f5d63de10d5/ol_concourse-0.13.0-py3-none-any.whl", hash = "sha256:a0b259159773cd0bbe1d1a0cbbc9f96f18dd3c8e7967a98d758b22b876528cfc", size = 55258, upload-time = "2026-08-10T13:09:01.529Z" },
+    { url = "https://files.pythonhosted.org/packages/66/49/f4dca303d87b96402ed3e9d280372be0b69158d90cfee3fa0ef85f5ca456/ol_concourse-0.14.0-py3-none-any.whl", hash = "sha256:bd9589516aee910659c8f2bda45a4838bda33c64920b37ca4d7baca95b7998cf", size = 59347, upload-time = "2026-08-10T19:25:16.715Z" },
 ]
 
 [[package]]
@@ -1509,7 +1509,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.0,<0.29" },
     { name = "hvac", extras = ["parser"], specifier = ">=2.0.0,<3" },
     { name = "kubernetes", specifier = ">=34.1.0" },
-    { name = "ol-concourse", specifier = ">=0.13,<0.14" },
+    { name = "ol-concourse", specifier = ">=0.14,<0.15" },
     { name = "ol-parliament", specifier = ">=1.7.0" },
     { name = "packaging", specifier = ">=24.2" },
     { name = "pulumi", specifier = ">=3.39.1,<4" },


### PR DESCRIPTION
### What are the relevant tickets?

Adopts the topology from mitodl/ol-concourse#85 on the two pipelines that had adopted `preview_next_stack` (#5350). Pin bumped `0.13` → `0.14`.

### Description (What does it do?)

Each non-CI stage now **previews itself**, and that preview opens the gate; closing the gate runs the deploy. CI keeps auto-deploying via `auto_deploy_stages=["CI"]` — gating CI would destroy the fast feedback loop it exists to provide.

### :warning: This changes behaviour for three edxapp QA environments

This is the one thing to decide rather than skim. Rendered before/after:

| | Before | After |
| --- | --- | --- |
| `mitx.qa` | **auto-deploys on code change** | gated |
| `mitx-staging.qa` | **auto-deploys on code change** | gated |
| `xpro.qa` | **auto-deploys on code change** | gated |
| `mitxonline.qa` | gated | gated |

They auto-deploy today only because each is the **first stack in its release's chain** — `verawood/mitx` is `[QA, Production]`, `ulmo/xpro` is `[QA, Production]` — so the existing `trigger = passed_job is None and not production` makes them entry points. `mitxonline.qa` is gated purely because it happens to sit at index 1 of `[CI, QA, Production]`.

**So today's gating is inconsistent by accident of how chains split across Open edX releases, not by intent.** This makes it uniform: CI auto, everything else gated. I think that's more correct — but it's also three new human gates that people will notice, so it should be a decision.

Worth noting **no exemption list preserves current behaviour**: `["CI", "QA"]` would *un-gate* `mitxonline.qa`, which is strictly worse. The options are uniform-gated (this PR) or accept the inconsistency.

### It closes a live hazard

`preview_next_stack` previews the **next** stack from inside the current deploy job — and a `pulumi preview` **takes the stack lock**. So it could take the next stack's lock and fail *that* stack's real deploy (`_is_recoverable_lock` refuses to cancel anything under 15 minutes old, so recovery doesn't help). That's live on these two pipelines today.

Each stage now only ever touches its own stack, and preview+deploy of a stack share a serial group.

### It fixes coverage `preview_next_stack` couldn't reach

edxapp splits one deployment across Open edX releases, so `mitx` CI and `mitx` QA are built by **different** chain calls — a next-stack preview can't span them. Only `mitxonline` had full coverage. Now every edxapp deployment does, and singleton chains (production-only) get a gate instead of a manual trigger with no preview.

### How can this be tested?

Rendered both pipelines rather than trusting the flag:

```
EKS      24 → 40 jobs    8 CI auto-deploy, 16 previews auto, 16 deploys gated
edxapp   12 → 20 jobs    4 CI auto-deploy,  8 previews auto,  8 deploys gated
```

Every non-CI `deploy-*` job is gate-triggered; the only auto-triggered jobs beyond CI are `preview-*`, which is the intent.

Spot-checked that stage inputs keep their `passed` constraint while losing their trigger, so a new image can't start a gated deploy:

```
deploy-…mitx-qa   get edxapp-verawood-mitx-image  trig=False passed=[build-…]
                  get gh-…-mitx-qa                trig=True
                  get edxapp-…-pulumi-mitx        trig=False passed=[preview-…]
```

168 `tests/ol_concourse/` tests pass; `pre-commit` clean.

### :warning: Two things to weigh before merging

**The fail-open property inverts.** `preview_next_stack` was advisory and could never fail a deploy. Here the preview *generates* the gate, so a failed preview means no gate and no deploy. That's fail-closed and right for a promotion gate — but both bugs found in mitodl/ol-concourse#84 would have blocked deploys rather than printing a warning.

**Cost.** A 3-stage chain goes from 3 Pulumi runs to 5, each a refresh against the target environment. EKS goes 24 → 40 jobs, edxapp 12 → 20. I have not measured the wall-clock or API-load impact, and edxapp is where it could hurt.

Also note ol-concourse#85 **merged without any review**, human or bot — the three design decisions in it (fail-closed inversion, `passed` being set-membership not equality, double-gating cross-environment promotions) are unratified rather than agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2dsMxDihnRVJgcLoStQCv