### PR TITLE
fix(grafana): size the OTLP tail sampler for real trace volume

### DIFF
--- a/src/ol_infrastructure/substructure/aws/eks/grafana.py
+++ b/src/ol_infrastructure/substructure/aws/eks/grafana.py
@@ -187,18 +187,49 @@ def setup_grafana(
                         "processors": {
                             "tailSampling": {
                                 "enabled": True,
-                                "decisionWait": "5s",
-                                "numTraces": 100,
-                                "expectedNewTracesPerSec": 10,
+                                # The sampler holds every in-flight trace in memory
+                                # until decisionWait elapses, then decides.  These
+                                # numbers must be sized against real trace volume:
+                                # APISIX alone fronts ~280 req/s, and each of those
+                                # is a distinct trace.  The previous values (100 /
+                                # 10) buffered ~0.4s of traffic, so traces were
+                                # evicted before their decision was ever made and
+                                # ~98% of them -- including nearly every APISIX root
+                                # span -- never reached Tempo.
+                                #
+                                # decisionWait also has to outlast the slowest
+                                # exporter feeding a trace.  APISIX batches spans on
+                                # a 2s timeout and the Django BatchSpanProcessor on
+                                # 5s, so a 5s window routinely closed before the
+                                # gateway's root span arrived, orphaning the trace.
+                                "decisionWait": "15s",
+                                "numTraces": 50000,
+                                "expectedNewTracesPerSec": 1000,
+                                # Keep decisions for trace IDs far longer than the
+                                # span data itself, so spans that arrive after a
+                                # trace has been released from memory inherit the
+                                # original decision instead of being re-judged.
+                                #
+                                # Do NOT raise either of these to 1_000_000 or
+                                # above: the chart renders them through Go's %v on a
+                                # float64, which switches to scientific notation at
+                                # 1e6 and emits `non_sampled_cache_size = 1e+06`
+                                # into the Alloy config.  Verified against chart
+                                # 4.3.2 with `helm template`; 999_999 renders as an
+                                # integer, 1_000_000 does not.
                                 "decisionCache": {
-                                    "sampledCacheSize": 1000,
-                                    "nonSampledCacheSize": 10000,
+                                    "sampledCacheSize": 500000,
+                                    "nonSampledCacheSize": 900000,
                                 },
                                 "policies": [
                                     {
+                                        # UNSET is the status of virtually every
+                                        # successful span, so including it here made
+                                        # this policy match all traffic and silently
+                                        # neutered the probabilistic policy below.
                                         "name": "keep-errors",
                                         "type": "status_code",
-                                        "status_codes": ["ERROR", "UNSET"],
+                                        "status_codes": ["ERROR"],
                                     },
                                     {
                                         "name": "sample-slow-traces",
@@ -220,6 +251,22 @@ def setup_grafana(
                                 # explicitly on the sampler collector to avoid this.
                                 "collector": {
                                     "remoteConfig": {"enabled": False},
+                                    # The chart ships the sampler with no requests
+                                    # or limits, which left it BestEffort -- first
+                                    # in line for eviction under node pressure.
+                                    # That is untenable now that numTraces buffers
+                                    # ~50k traces (order 1GiB) instead of 100.  No
+                                    # CPU limit: throttling the sampler stalls the
+                                    # trace pipeline for the whole cluster.
+                                    "alloy": {
+                                        "resources": {
+                                            "requests": {
+                                                "cpu": "500m",
+                                                "memory": "1Gi",
+                                            },
+                                            "limits": {"memory": "2Gi"},
+                                        },
+                                    },
                                 },
                             },
                         },


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
The Grafana Cloud OTLP tail sampler was buffering **100 traces** with a **5s** decision window, against a cluster where APISIX alone fronts ~280 req/s. Traces were evicted from the buffer before a sampling decision was ever reached, so the overwhelming majority never reached Tempo.

Measured on `applications-production` over a settled one-hour window (not a recent-ingestion artifact):

| Query | Result |
|---|---|
| `{resource.service.name="learn-webapp"} \| count_over_time() by (rootServiceName)` | **5,207** traces with a missing root span vs **79** retaining their APISIX root |
| `learn-nextjs` spans reaching Tempo | **28/hour**, against ~66k requests/hour served across 5 replicas |
| A `learn-nextjs` trace ID taken from its own request log (`8dfe5e8294a388a90e6ed02edc62908d`) | Returns **empty** from Tempo |

Of the 7 `learn-nextjs` traces that did survive that hour, 5 were slower than 5s — they got through on the latency policy rather than the probabilistic one, which is the fingerprint of a buffer overflowing rather than a policy deciding.

Two independent defects compounded:

**1. The buffer was three orders of magnitude too small.** `numTraces: 100` / `expectedNewTracesPerSec: 10` held roughly 0.4s of traffic.

**2. `decisionWait` closed before upstream spans arrived.** APISIX batches spans on a 2s timeout (`batch_span_processor.batch_timeout` in `apisix_official.py`) and the Django `BatchSpanProcessor` on 5s, so a 5s window routinely expired before the gateway's root span landed — orphaning the trace even when it wasn't dropped outright.

**3. `keep-errors` matched everything.** The policy listed `status_codes: ["ERROR", "UNSET"]`. `UNSET` is the status of virtually every *successful* span, so this policy matched all traffic and silently neutered the `sample-15pct-traces` probabilistic policy sitting beside it.

Changes:

| Setting | Before | After |
|---|---|---|
| `decisionWait` | `5s` | `15s` |
| `numTraces` | `100` | `50000` |
| `expectedNewTracesPerSec` | `10` | `1000` |
| `decisionCache.sampledCacheSize` | `1000` | `500000` |
| `decisionCache.nonSampledCacheSize` | `10000` | `900000` |
| `keep-errors` `status_codes` | `["ERROR", "UNSET"]` | `["ERROR"]` |
| sampler pod resources | *(unset — BestEffort)* | `500m`/`1Gi` requests, `2Gi` memory limit |

Resource requests are added because the chart ships the sampler with no requests or limits, leaving it BestEffort and first in line for eviction under node pressure — untenable now that it buffers ~50k traces rather than 100.

### How can this be tested?

**Pre-merge validation already performed:**

- `pre-commit` — all hooks pass (ruff format, ruff check, mypy, detect-secrets). The one remaining `ruff` finding (`D100 Missing docstring in public module`) is pre-existing on `main`, confirmed by running `ruff check` against `git show origin/main:...grafana.py`.
- `helm template` against `k8s-monitoring` chart `4.3.2` (the pinned `GRAFANA_K8S_MONITORING_CHART_VERSION`), rendering the exact values dict extracted from this branch via AST. Confirms the generated Alloy config:

```
otelcol.processor.tail_sampling "tail_sampler" {
  decision_wait = "15s"
  decision_cache = {
    sampled_cache_size     = 500000,
    non_sampled_cache_size = 900000,
  }
  num_traces = 50000
  expected_new_traces_per_sec = 1000

  policy {
    name = "keep-errors"
    type = "status_code"
    status_code {
      status_codes = ["ERROR"]
    }
  }
  ...
```

- `pulumi preview --stack applications.QA` → `1 to update, 48 unchanged`, diff confined to the `tailSampling` block.
- `pulumi preview --stack applications.Production` → `2 to update, 47 unchanged` (see caveat below).

**Post-merge verification:**

1. Re-run `{resource.service.name="learn-webapp"} | count_over_time() by (rootServiceName)` over a settled hour. The `apisix` root should go from 1.5% to dominant.
2. Confirm `learn-nextjs` span volume rises from 28/hour toward the ~25% of traffic its sampler actually records.
3. Watch Grafana Cloud trace ingest volume and cost (see below).

### Additional Context

**⚠️ This will materially increase trace ingest volume, and that is intentional.** Removing `UNSET` restores the originally intended `errors + slow + 15%-of-the-rest` shape described in the comment at `components/services/apisix.py:583`. Combined with the buffer fix, ingest rises from roughly 1% of traces to 15%-plus. `sampling_percentage` on the `sample-15pct-traces` policy is the dial if that lands too high — I deliberately left it at the configured 15% rather than guessing at a new number.

**⚠️ Chart rendering hazard — do not raise the cache sizes to 1,000,000 or above.** The chart passes these values through Go's `%v` on a `float64`, which switches to scientific notation at 1e6 and emits `non_sampled_cache_size = 1e+06` into the Alloy config — not a valid integer literal. Verified empirically against chart 4.3.2: `999999` renders as an integer, `1000000` renders as `1e+06`. Both cache sizes are deliberately held below that threshold, and this is documented in a code comment so it isn't undone later.

**Unrelated pre-existing drift on Production.** `pulumi preview --stack applications.Production` shows a second resource update that this PR does not cause: `vantage-k8s-agent` Helm chart `1.9.3 => 1.9.5`, i.e. the repo's pinned version is ahead of what is deployed. It will apply alongside this change. `applications.QA` shows only the single expected update.

**The trace pipeline is currently unmonitored, which is why this went unnoticed.** There are no `otelcol_*` metrics in the `applications-production` Prometheus and no `ServiceMonitor`/`PodMonitor` in the `grafana` namespace, so `otelcol_processor_tail_sampling_sampling_trace_dropped_too_early` — the counter that would have made this obvious — is invisible. The sampler Service already exposes port 12345 (`http-metrics`); it simply isn't scraped. Worth a follow-up so this class of regression can't recur silently.

**Consequence for existing dashboards.** `traces_spanmetrics_*` and `traces_service_graph_*` are generated from what Tempo ingests, so RED metrics have been computed on a ~1% sample biased toward slow and errored traces. The APM latency panels have been skewed pessimistic rather than merely sparse; expect them to shift after this deploys.
