### PR TITLE
fix(omnigraph): commit CI's format-6 cutover so a pipeline deploy stops reverting it

### DIFF
--- a/src/ol_infrastructure/applications/omnigraph/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/applications/omnigraph/Pulumi.CI.yaml
@@ -46,5 +46,16 @@ config:
   aws:region: us-east-1
   vault:address: https://vault-ci.odl.mit.edu
   vault_server:env_namespace: operations.ci
+  # The storage-format generation this cluster serves. CI was migrated from
+  # format 4 to format 6 (omnigraph 0.9.0) on 2026-08-10; the rebuilt graphs
+  # live under `<bucket>/fmt6` and the pre-migration format-4 graphs remain at
+  # `<bucket>/graphs` as the rollback.
+  #
+  # This MUST be committed, not just `pulumi config set` locally. A cutover
+  # that exists only in a working copy is reverted by the next pipeline
+  # deploy, which repoints the cluster at the old root while the server image
+  # can only read the new format — every graph then fails to open and the
+  # server crashloops. That is exactly what happened here for ~12h.
+  omnigraph:storage_prefix: fmt6
 secretsprovider: awskms://alias/infrastructure-secrets-ci
 encryptedkey: AQICAHhMkpkBpCvmFjhyfy75ENALRrbg42uOs9cUsFNLXqPnagHdMkilOMMReBzl5ZFVAxo4AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMp4JVj0Zbv48c45+qAgEQgDt/KPJs42c+WEXeS2IPS6gVYHOCM2L51SVYdqGNpSII1XjPkxQgj6ypYwhz6wdA7GrvJjK9P89/US3Nww==


### PR DESCRIPTION
### What are the relevant tickets?
N/A — follow-up to #5356 (the omnigraph storage-format migration tooling).

### Description (What does it do?)
Commits `omnigraph:storage_prefix: fmt6` to the CI stack config.

CI was migrated from omnigraph storage format 4 to format 6 on 2026-08-10 and cut over by running `pulumi config set omnigraph:storage_prefix fmt6` followed by `pulumi up`. The cluster came up healthy on the new root and was verified. **The config change was never committed.**

`pulumi config set` writes to `Pulumi.CI.yaml` in the working copy. Concourse deploys from git. When the CI deploy job was unpaused, the pipeline checked out a tree with no `storage_prefix`, and reconciled the cluster config back to the format-4 root — while the Deployment kept running the 0.9.0 image, which cannot open a format-4 store:

```
omnigraph-server: cluster state exists; refreshing from live observations
cluster refresh failed
ERROR graph_observation_error graphs: 16 graph observation(s) failed
```

The server sat in `CrashLoopBackOff` for ~12 hours (145 restarts).

**No data was affected.** The rebuilt graphs are intact:

```
$ omnigraph snapshot --store s3://ol-data-witan-ci/fmt6/graphs/council.omni
internal_schema_version: 6
node:Task v2 branch=main rows=926
```

926 tasks matches the migration's own verification exactly, and the pre-migration format-4 graphs under `<bucket>/graphs` were never written to — they remain the rollback. This was only ever a config problem.

The added comment records the failure mode, which is worth having in the file: local state and git agree right up until the moment something else deploys, so nothing looks wrong until an unrelated pipeline run silently reverts the cutover.

### How can this be tested?

`pulumi preview --stack CI` against this branch (with `OMNIGRAPH_DOCKER_SHA` set to the deployed digest) plans exactly the cutover and nothing else:

```
~ kubernetes:core/v1:ConfigMap  omnigraph-cluster-config-ci   replace  [diff: ~data]
~ kubernetes:batch/v1:Job       omnigraph-cluster-apply-ci    replace  [diff: ~spec]
~ kubernetes:apps/v1:Deployment omnigraph-server-deployment-ci update  [diff: ~spec]
~ kubernetes:batch/v1:CronJob   omnigraph-cleanup-ci          update   [diff: ~spec]
~ kubernetes:batch/v1:CronJob   omnigraph-optimize-ci         update   [diff: ~spec]

--outputs:--
+ storage_prefix : "fmt6"
~ storage_uri    : "s3://ol-data-witan-ci" => "s3://ol-data-witan-ci/fmt6"

~ 3 to update, +-2 to replace, 41 unchanged
```

The two replacements are expected: the ConfigMap's data changes, and Jobs are immutable so a spec change forces replacement. The serving Deployment is an in-place update (config-hash annotation), not a replacement.

After deploy, `omnigraph-server` should return to `1/1 Running` and its startup log should show a successful cluster refresh instead of `16 graph observation(s) failed`.

### Additional Context

**This does not fully fix CI on its own.** The maintenance CronJobs are independently broken on 0.9.0 — `optimize` has been failing against all 16 graphs since the image rolled, because 0.9.0 rejects `--as` on storage-native commands. That is fixed separately so the two concerns stay reviewable apart.

QA and Production are unaffected: both are healthy on the pre-0.9.0 image (`sha256:37e3225…`) serving format 4, and neither has `storage_prefix` set. Neither should be migrated until CI has been healthy on format 6 for a real soak — this incident is the argument for that soak being more than a formality.
