### PR TITLE
fix(omnigraph): the nightly sweeps pass an actor 0.9.0 refuses to accept

### DIFF
--- a/src/ol_infrastructure/applications/omnigraph/data_tier.py
+++ b/src/ol_infrastructure/applications/omnigraph/data_tier.py
@@ -777,7 +777,6 @@ def create_data_tier(  # noqa: PLR0913
         service_account_name=OMNIGRAPH_SERVICE_ACCOUNT_NAME,
         aws_region=aws_config.region,
         storage_uri=storage_uri,
-        maintenance_actor=CLUSTER_APPLY_ACTOR,
         graph_ids=list(cluster_graphs),
         optimize_schedule=optimize_schedule,
         cleanup_schedule=cleanup_schedule,

--- a/src/ol_infrastructure/applications/omnigraph/maintenance.py
+++ b/src/ol_infrastructure/applications/omnigraph/maintenance.py
@@ -132,6 +132,20 @@ def _sweep_script(command: str, extra_args: list[str], graph_ids: list[str]) -> 
     ``code_graph_id``, so quoting them is a no-op today and stays correct if
     that normalization ever loosens — quoting each id individually preserves
     the word list the ``for`` loop needs.
+
+    NO ``--as``. Both sweeps are storage-native (direct-engine) commands, and
+    omnigraph 0.9.0 rejects an actor on those outright::
+
+        `optimize` is a direct (storage-native) command; --as sets the actor
+        for a direct-engine or actor-bound cluster operation and does not
+        apply. Pass a storage URI, or --cluster <dir> --graph <id>.
+
+    0.8.x accepted and ignored the flag, so this only became visible when the
+    0.9.0 image rolled — every optimize run then failed against all 16 graphs.
+    Addressing (``--cluster`` + ``--graph``) was never the problem and is
+    unchanged. Verified against both binaries before removing it: 0.9.0 without
+    ``--as`` compacts, and 0.8.1 without ``--as`` also compacts, so the sweeps
+    work on either side of the upgrade.
     """
     graph_list = " ".join(shlex.quote(graph) for graph in graph_ids)
     args = " ".join(shlex.quote(arg) for arg in extra_args)
@@ -141,8 +155,7 @@ for graph in {graph_list}; do
     echo "=== omnigraph {command} ${{graph}}"
     if omnigraph {command} \\
         --cluster "${{OMNIGRAPH_STORAGE_ROOT}}" \\
-        --graph "${{graph}}" \\
-        --as "${{OMNIGRAPH_MAINTENANCE_ACTOR}}" {args}; then
+        --graph "${{graph}}" {args}; then
         :
     else
         echo "!!! omnigraph {command} failed for ${{graph}}" >&2
@@ -166,7 +179,6 @@ def _cron_job(  # noqa: PLR0913
     service_account_name: str,
     aws_region: str,
     storage_uri: Output[str],
-    maintenance_actor: str,
     schedule: str,
     script: str,
     depends_on: list[Resource],
@@ -248,10 +260,6 @@ def _cron_job(  # noqa: PLR0913
                                             name="OMNIGRAPH_STORAGE_ROOT",
                                             value=storage_uri,
                                         ),
-                                        kubernetes.core.v1.EnvVarArgs(
-                                            name="OMNIGRAPH_MAINTENANCE_ACTOR",
-                                            value=maintenance_actor,
-                                        ),
                                     ],
                                     # Compaction rewrites fragments through
                                     # memory, so this is the one job here with a
@@ -289,7 +297,6 @@ def create_maintenance(  # noqa: PLR0913
     service_account_name: str,
     aws_region: str,
     storage_uri: Output[str],
-    maintenance_actor: str,
     graph_ids: list[str],
     optimize_schedule: str,
     cleanup_schedule: str,
@@ -318,7 +325,6 @@ def create_maintenance(  # noqa: PLR0913
         service_account_name=service_account_name,
         aws_region=aws_region,
         storage_uri=storage_uri,
-        maintenance_actor=maintenance_actor,
         schedule=optimize_schedule,
         # Non-destructive, so no --confirm and no confirmation prompt to skip.
         script=_sweep_script("optimize", [], graph_ids),
@@ -340,7 +346,6 @@ def create_maintenance(  # noqa: PLR0913
         service_account_name=service_account_name,
         aws_region=aws_region,
         storage_uri=storage_uri,
-        maintenance_actor=maintenance_actor,
         schedule=cleanup_schedule,
         script=_sweep_script(
             "cleanup",

--- a/tests/ol_infrastructure/applications/omnigraph/test_maintenance.py
+++ b/tests/ol_infrastructure/applications/omnigraph/test_maintenance.py
@@ -28,14 +28,13 @@ GRAPHS = ["council", "code-bridge", "code-github-com-mitodl-ol-django"]
 
 CLEANUP_ARGS = ["--older-than", DEFAULT_CLEANUP_OLDER_THAN, "--confirm", "--yes"]
 
-# Deliberately NOT the real bucket or actor. Both reach the script through the
-# environment, and what is under test is that it passes them through unaltered —
-# nothing here pins a naming convention. The real values are built in
-# data_tier.py (`ol-data-witan-<env>` from the OLBucket, and CLUSTER_APPLY_ACTOR),
-# so a realistic-looking literal here would only send someone renaming the bucket
+# Deliberately NOT the real bucket. It reaches the script through the
+# environment, and what is under test is that it passes through unaltered —
+# nothing here pins a naming convention. The real value is built in
+# data_tier.py (`ol-data-witan-<env>` from the OLBucket), so a
+# realistic-looking literal here would only send someone renaming the bucket
 # to a test that never needed to change.
 STORAGE_ROOT = "s3://test-storage-root"
-MAINTENANCE_ACTOR = "test-actor"
 
 
 class SweepResult:
@@ -92,7 +91,6 @@ def run_sweep(tmp_path: Path):
             env={
                 "PATH": str(bin_dir),
                 "OMNIGRAPH_STORAGE_ROOT": STORAGE_ROOT,
-                "OMNIGRAPH_MAINTENANCE_ACTOR": MAINTENANCE_ACTOR,
             },
             check=False,
         )
@@ -131,9 +129,26 @@ def test_sweep_addresses_the_cluster_root_not_a_bare_uri(run_sweep):
         STORAGE_ROOT,
         "--graph",
         "council",
-        "--as",
-        MAINTENANCE_ACTOR,
     ]
+
+
+def test_sweeps_never_pass_an_actor():
+    """``--as`` is rejected outright by 0.9.0 on a storage-native command.
+
+    Both sweeps are direct-engine commands, and 0.9.0 answers an actor on one
+    with::
+
+        `optimize` is a direct (storage-native) command; --as sets the actor
+        for a direct-engine or actor-bound cluster operation and does not
+        apply.
+
+    0.8.x accepted and ignored the flag, so this stayed invisible until the
+    0.9.0 image rolled and every nightly optimize began failing against all 16
+    graphs at once. Asserted on the rendered script rather than a captured call
+    so it covers both commands and holds even if the argv order changes.
+    """
+    for command, extra in (("optimize", []), ("cleanup", CLEANUP_ARGS)):
+        assert "--as" not in _sweep_script(command, extra, GRAPHS)
 
 
 def test_cleanup_passes_confirm_and_yes(run_sweep):
@@ -202,8 +217,6 @@ def test_shell_metacharacters_in_config_do_not_escape_the_argument(run_sweep):
         STORAGE_ROOT,
         "--graph",
         "council",
-        "--as",
-        MAINTENANCE_ACTOR,
         "--older-than",
         hostile,
         "--confirm",


### PR DESCRIPTION
### What are the relevant tickets?
N/A — second of two fixes for the omnigraph 0.9.0 upgrade. Companion to #5367.

### Description (What does it do?)
Drops `--as` from the nightly `optimize` and `cleanup` sweeps.

Both CronJobs render from one shared script, which has always passed `--as "${OMNIGRAPH_MAINTENANCE_ACTOR}"`. omnigraph 0.9.0 rejects an actor on a storage-native command outright:

```
`optimize` is a direct (storage-native) command; --as sets the actor for a
direct-engine or actor-bound cluster operation and does not apply.
Pass a storage URI, or --cluster <dir> --graph <id>.
```

0.8.x accepted the flag and ignored it, so nothing surfaced until the 0.9.0 image rolled to CI. Every nightly `optimize` since has failed against all 16 graphs:

```
!!! omnigraph optimize failed for: council code-bridge
code-github-com-mitodl-ol-infrastructure code-github-com-mitodl-mit-learn
... (all 16)
```

`cleanup` runs on a slower schedule and hadn't fired since the upgrade, but shares the code path and fails identically — confirmed by dry run.

This is the same class of break as `cluster import --as` in the migration script (fixed in `bbfd999bb`): **0.9.0 validates scope flags per verb, so every call site has to be checked individually.** Fixing the migration script and stopping there is why this one kept running broken for a day.

Addressing was never the problem — `--cluster <root> --graph <id>` is correct and unchanged. Only the actor goes. That leaves `maintenance_actor` with no reader, so the parameter and the env var it fed go with it. `CLUSTER_APPLY_ACTOR` stays: the cluster-apply Job *is* an actor-bound cluster operation, which is the case `--as` is still for.

### How can this be tested?

Verified against **both** binaries in-cluster before removing the flag, rather than inferring from the error text — this has to deploy to QA and Production while they're still on 0.8.1, so "works on 0.9.0" alone would have been insufficient.

0.9.0, current form vs. fixed, same graph:

```
### A. current: --cluster ROOT --graph G --as witan-service
Error: `optimize` is a direct (storage-native) command; --as ... does not apply.

### B. fixed: --cluster ROOT --graph G
  node:CodeFile   frags 0 → 0 ✓
  node:Symbol     frags 0 → 0 ✓
  __manifest      frags 3 → 1 ✓
```

0.8.1 (the image QA and Production run today), fixed form:

```
version: omnigraph 0.8.1
### optimize WITHOUT --as on 0.8.x
  edge:Defines    frags 2 → 1 ✓
  node:CodeFile   frags 2 → 1 ✓
  node:Symbol     frags 2 → 1 ✓
  __manifest      frags 7 → 1 ✓
```

`cleanup` was checked the same way as a dry run (no `--confirm`, so nothing was deleted): rejected with `--as`, and without it correctly reports `remove anything older than 2592000s`.

Unit tests: `uv run pytest tests/ol_infrastructure/applications/omnigraph/` → **93 passed**. The exact-argv assertions drop `--as`, and a new `test_sweeps_never_pass_an_actor` asserts it on the rendered script for both commands, so it holds even if argv order changes.

### Additional Context

**Ordering:** #5367 and this PR are independent and can merge in either order, but CI is not healthy until **both** land. #5367 restores the storage root the server reads; this restores the sweeps that keep it compacted.

Pre-existing and untouched: `mypy` reports 2 errors in `token_sync.py:422` on this branch. They are on `main` already — that file isn't modified here.
