### PR TITLE
fix(jupyterhub-data): stop the user-scheduler being OOMKilled at 64Mi

### DIFF
--- a/src/ol_infrastructure/applications/jupyterhub_data/deployment.py
+++ b/src/ol_infrastructure/applications/jupyterhub_data/deployment.py
@@ -432,9 +432,13 @@ def provision_jupyterhub_data_deployment(  # noqa: PLR0913
                     "podPriority": {"enabled": True},
                     "userScheduler": {
                         "enabled": True,
+                        # This scheduler's informer caches scale with the total
+                        # object count of the whole cluster, not with this
+                        # namespace. data-production routinely carries several
+                        # thousand pods, which OOMKilled the previous 64Mi cap.
                         "resources": {
-                            "requests": {"cpu": "100m", "memory": "64Mi"},
-                            "limits": {"memory": "64Mi"},
+                            "requests": {"cpu": "100m", "memory": "256Mi"},
+                            "limits": {"memory": "1Gi"},
                         },
                     },
                 },


### PR DESCRIPTION
### What are the relevant tickets?

Root cause tracked in https://github.com/mitodl/ol-infrastructure/issues/5370 (this PR mitigates the symptom, it does not close that issue).

Diagnosed from Rootly alert `PodCrashLoopingCritical` (https://rootly.com/account/alerts/MHbx9X). Follow-up to #5076, which fixed this same failure in the same component on `applications-production`.

### Description (What does it do?)

Raises the `jupyter-data` user-scheduler memory from `64Mi` request/limit to a `256Mi` request / `1Gi` limit.

`PodCrashLoopingCritical` fired at 14:08 UTC on 2026-08-11 for the `kube-scheduler` container in `user-scheduler` in namespace `jupyter-data` on `data-production`. Prometheus confirms **both** replicas were `OOMKilled`, with 21 and 11 restarts, and zero restarts in the preceding six hours:

```
kube_pod_container_status_last_terminated_reason{cluster="data-production",
  namespace="jupyter-data", container="kube-scheduler",
  pod="user-scheduler-5988d6df9c-wq49f", reason="OOMKilled"} = 1
kube_pod_container_status_last_terminated_reason{cluster="data-production",
  namespace="jupyter-data", container="kube-scheduler",
  pod="user-scheduler-5988d6df9c-24nwg", reason="OOMKilled"} = 1
```

The z2jh user-scheduler is a full `kube-scheduler`, so its informer caches scale with the **total object count of the cluster**, not with the `jupyter-data` namespace. It was capped at `64Mi` while sitting at a 60–61 MiB working set — 94% of its limit, leaving no headroom for the one-time spike a watch relist causes. A burst of Dagster run pods then took `data-production` from ~1,600 to ~7,000 pod objects within an hour and pushed it over the wall.

This is the same failure that #5076 fixed for `applications-production` (`128Mi` -> `256Mi` request / `512Mi` limit), where the code comment already records that a watch relist OOMKilled it. `jupyter-data` was left at *half* the value already proven insufficient there, while carrying roughly **18x the pods** (7,013 vs 382).

Hence a `1Gi` limit rather than matching #5076's `512Mi`. Sizing evidence:

| Signal | Value |
|---|---|
| `applications-production` user-scheduler peak working set (7d), 382 pods | 119–153 MiB |
| `data-production` pod objects | 7,013 |
| `data-production` kube-state-metrics (caches every object type) | 282 MiB |
| `data-production` VPA recommender | 803 MiB |

The scheduler's true steady state on this cluster has never been observed, because it dies before its caches finish populating — so the limit is deliberately generous and can be tightened once real usage is visible.

### How can this be tested?

```bash
cd src/ol_infrastructure/applications/jupyterhub_data
pulumi preview --stack applications.jupyterhub_data.Production
```

The only expected change is the `userScheduler` resource block on the `jupyterhub` Helm release. After deploying, confirm the crash loop has stopped and observe the real working set to decide whether the limit can come down:

```promql
kube_pod_container_status_restarts_total{cluster="data-production",
  namespace="jupyter-data", container="kube-scheduler"}

container_memory_working_set_bytes{cluster="data-production",
  namespace="jupyter-data", container="kube-scheduler"} / 1024 / 1024
```

Validation run locally: `ruff format`, `ruff check`, `mypy`, and `pre-commit run --files <changed file>` all pass.

### Additional Context

**This is a mitigation, not the root cause.** The underlying defect is that Dagster's completed run pods are never garbage collected: at the time of the alert, **6,738 of the 7,013 pods in `data-production` were in phase `Succeeded`**, 6,728 of them in the `dagster` namespace, against only 287 actually `Running`. The `K8sRunLauncher` config in [`dagster_instance.yaml`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/applications/dagster/dagster_instance.yaml#L34-L56) sets no `ttl_seconds_after_finished`, so every finished run Job and its pod persists as an API object.

Until that is fixed the pile will rebuild and is likely to take out a different cluster-wide informer consumer next; it also bloats etcd, which plausibly relates to the database exhaustion seen in c3068d4a3. Tracked in https://github.com/mitodl/ol-infrastructure/issues/5370 so this alert-driven fix is not blocked on the retention tradeoff.
