### PR TITLE
feat(omnigraph): QA serves storage format 6

### DIFF
--- a/src/ol_infrastructure/applications/omnigraph/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/omnigraph/Pulumi.QA.yaml
@@ -41,5 +41,6 @@ config:
   aws:region: us-east-1
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa
+  omnigraph:storage_prefix: fmt6
 secretsprovider: awskms://alias/infrastructure-secrets-qa
 encryptedkey: AQICAHjE+jMY5DL7M1LMYX6YgtMueHEDNg05lsdN5Z0zeGHyJgHdah3681q3jIoMB6EquY0xAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMQkBOIyzkj00xRzZ9AgEQgDvOaikBeNnKV3FG4ZgMGvt3MOO4WsufLhs1b/FFH28hvQEuaZnfrQ1oLOS4NHXINUEJweVvuqaQUVj9gg==


### PR DESCRIPTION
### What are the relevant tickets?
N/A — continuation of the omnigraph 0.9.0 upgrade (#5356, #5367, #5368).

### Description (What does it do?)
Commits QA's cutover to storage format 6.

QA's 16 graphs were rebuilt from format 4 at `s3://ol-data-witan-qa/fmt6` and the cluster now serves that root. **The migration completed in a single pass** — the first evidence that the two fixes from CI's run hold (policy bundles staged into the rebuild dir; `cluster import` no longer passed `--as`). CI took three attempts to reach the same point.

Verdict from the migration Job:

```
"new_root": "s3://ol-data-witan-qa/fmt6",
"ok": true,
"old_root": "s3://ol-data-witan-qa"
```

`"ok": true` overall and for all 16 graphs, every per-table before/after row count identical, `changed_tables` and `missing_tables` empty throughout.

### How can this be tested?

Cutover applied in 51s:

```
- storage_migration_job : "omnigraph-migrate-fmt6"
+ storage_prefix        : "fmt6"
~ storage_uri           : "s3://ol-data-witan-qa" => "s3://ol-data-witan-qa/fmt6"
~ 3 updated, - 2 deleted, +-2 replaced, 41 unchanged
```

`omnigraph-server` returned `1/1 Running` with 0 restarts. That alone rules out a format mismatch: a 0.9.0 binary against a format-4 root cannot start — it fails every graph observation and crashloops, which is exactly how CI's reverted cutover presented.

### Additional Context

Committed in the same session as the cutover, deliberately. QA's deploy job is paused, so nothing would have reverted this today — but that is precisely the reasoning that left CI's cutover uncommitted and took it down for ~12h once the job was unpaused. The rule is the commit, not a judgement about whether a revert is currently possible.

The pre-migration format-4 graphs remain untouched at `s3://ol-data-witan-qa/graphs` and are the rollback. Do not retire them until Production has migrated successfully.