### PR TITLE
feat(omnigraph): Production serves storage format 6

### DIFF
--- a/src/ol_infrastructure/applications/omnigraph/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/omnigraph/Pulumi.Production.yaml
@@ -44,5 +44,6 @@ config:
   aws:region: us-east-1
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production
+  omnigraph:storage_prefix: fmt6
 secretsprovider: awskms://alias/infrastructure-secrets-production
 encryptedkey: AQICAHjksIVfl1VtAHpBda/1YYjj6tSeS2o4TXgvEEyBIXLjjwF51lHyFZBMipn03XTrTTsKAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMIK7o7DGmOomYnJtDAgEQgDuWNWhBp4MmY5g1IS5INjiOfMa0yZcKOzoHa0L7AjLfrw9rMSs/jELIM0qfIJguIuQsCYjLMpJoX7CgSQ==

--- a/src/ol_infrastructure/applications/omnigraph/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/omnigraph/Pulumi.QA.yaml
@@ -41,5 +41,6 @@ config:
   aws:region: us-east-1
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa
+  omnigraph:storage_prefix: fmt6
 secretsprovider: awskms://alias/infrastructure-secrets-qa
 encryptedkey: AQICAHjE+jMY5DL7M1LMYX6YgtMueHEDNg05lsdN5Z0zeGHyJgHdah3681q3jIoMB6EquY0xAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMQkBOIyzkj00xRzZ9AgEQgDvOaikBeNnKV3FG4ZgMGvt3MOO4WsufLhs1b/FFH28hvQEuaZnfrQ1oLOS4NHXINUEJweVvuqaQUVj9gg==


### PR DESCRIPTION
### What are the relevant tickets?
N/A — completes the omnigraph 0.9.0 upgrade (#5356, #5367, #5368, #5371).

### Description (What does it do?)
Commits Production's cutover to storage format 6, finishing the upgrade across all three environments.

Production's 16 graphs were rebuilt from format 4 at `s3://ol-data-witan-production/fmt6` and the cluster now serves that root. Like QA, the migration ran in a single pass.

```
"new_root": "s3://ol-data-witan-production/fmt6",
"ok": true,
"old_root": "s3://ol-data-witan-production"
```

`"ok": true` overall and for all 16 graphs, per-table before/after row counts identical, `changed_tables` and `missing_tables` empty throughout.

### How can this be tested?

Cutover applied in 49s:

```
- storage_migration_job : "omnigraph-migrate-fmt6"
+ storage_prefix        : "fmt6"
~ storage_uri           : "s3://ol-data-witan-production" => "s3://ol-data-witan-production/fmt6"
~ 3 updated, - 2 deleted, +-2 replaced, 41 unchanged
```

`omnigraph-server` is `1/1 Running` with 0 restarts, which rules out a format mismatch — a 0.9.0 binary cannot start against a format-4 root.

### Additional Context

**There was a deliberate ~12 minute downtime window** between the 0.9.0 image rolling and the cutover completing. This is inherent to the design, not a mistake: the format break means the new binary cannot open the old root it is still pointed at, and this is a single-replica `Recreate` Deployment. The alternative — cutting over before verifying the rebuild — trades a bounded outage for an unbounded one. Worth knowing for any future format break, since the same window will apply.

The pre-migration format-4 graphs remain untouched at `s3://ol-data-witan-production/graphs`. They are the **only** rollback — 0.9.0 cannot downgrade a store — so they stay until the new roots have soaked. Same for the CI and QA old roots.