### PR TITLE
fix(dagster): cut completed run Job retention from the 24h default to 1h

### DIFF
--- a/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
+++ b/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
@@ -63,12 +63,12 @@ run_launcher:
     instance_config_map: "dagster-instance"
     postgres_password_secret: "dagster-postgresql-secret" # pragma: allowlist secret
     env_secrets:
-      - dagster-static-secrets
-      - dagster-dbt-secrets
-      - dagster-postgresql-secret
+    - dagster-static-secrets
+    - dagster-dbt-secrets
+    - dagster-postgresql-secret
       # Ops execute in run worker pods, not in the code location pods, so the
       # Sentry DSN has to reach them here as well.
-      - dagster-sentry-secrets
+    - dagster-sentry-secrets
 
 run_storage:
   module: dagster_postgres.run_storage

--- a/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
+++ b/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
@@ -39,6 +39,22 @@ run_launcher:
       pod_template_spec_metadata:
         annotations:
           karpenter.sh/do-not-disrupt: "true"
+      job_spec_config:
+        # Overrides dagster_k8s' DEFAULT_K8S_JOB_TTL_SECONDS_AFTER_FINISHED of
+        # 24h. Retained run pods are pure API objects, but every cluster-wide
+        # informer caches them, so cluster memory footprint is (retention x
+        # completion rate) -- not a function of live workload. At the rate
+        # data-production sustains post-backlog-clear that ceiling was ~7-12k
+        # pod objects, which OOMKilled the jupyterhub user-scheduler and the
+        # vantage agent and left external-dns and all three VPA components
+        # sized around the garbage.
+        #
+        # A finished run pod is only worth keeping for infrastructure-level
+        # failures that produce no Dagster events (OOMKill, image pull error,
+        # scheduling failure); run history and the event log are in Postgres
+        # and compute logs are in S3, so an hour is enough to catch a page and
+        # still `kubectl describe` the pod.
+        ttl_seconds_after_finished: 3600
     load_incluster_config: true
     job_namespace: dagster
     image_pull_policy: IfNotPresent
@@ -47,13 +63,12 @@ run_launcher:
     instance_config_map: "dagster-instance"
     postgres_password_secret: "dagster-postgresql-secret" # pragma: allowlist secret
     env_secrets:
-    - dagster-static-secrets
-    - dagster-dbt-secrets
-    - dagster-postgresql-secret
-    # Ops execute in run worker pods, not in the code location pods, so the
-    # Sentry DSN has to reach them here as well.
-    - dagster-sentry-secrets
-
+      - dagster-static-secrets
+      - dagster-dbt-secrets
+      - dagster-postgresql-secret
+      # Ops execute in run worker pods, not in the code location pods, so the
+      # Sentry DSN has to reach them here as well.
+      - dagster-sentry-secrets
 
 run_storage:
   module: dagster_postgres.run_storage
@@ -107,7 +122,6 @@ run_coordinator:
   class: QueuedRunCoordinator
   config:
     max_concurrent_runs: 100
-
 
 # Configures how long Dagster waits for code locations
 # to load before timing out.


### PR DESCRIPTION
### What are the relevant tickets?

Closes https://github.com/mitodl/ol-infrastructure/issues/5370 (see the [corrected analysis](https://github.com/mitodl/ol-infrastructure/issues/5370#issuecomment-5255009346) — the original premise was amended). Related: https://github.com/mitodl/ol-infrastructure/pull/5369 (victim #1 mitigation), https://github.com/mitodl/ol-infrastructure/issues/5366 (sibling failure mode, same config block).

### Description (What does it do?)

Adds `job_spec_config.ttl_seconds_after_finished: 3600` to the `K8sRunLauncher` config in `dagster_instance.yaml`, cutting completed run Job/pod retention on the data clusters from `dagster_k8s`'s **default of 24h** to **1h**.

**Why:** retained `Succeeded` run pods are inert API objects, but every cluster-wide informer caches them, so memory across the cluster scales with `retention × run completion rate` — not with live workload. When `max_concurrent_runs` went 60 → 200 → 100 (56cb909, c3068d4a3) and the run backlog cleared at ~3,200 completions/hr, 24h of retention became **7,000–12,600 pod objects** on `data-production` (~96% of all pods in the cluster were dead Dagster run pods). Confirmed casualties and collateral:

- `jupyterhub-data` user-scheduler: both replicas OOMKilled (Rootly `MHbx9X`, mitigated in #5369)
- Vantage cost agent: OOMKilled ×8, 16 minutes after #5370 was filed (Rootly `QySYGh`) — its memory is linear in pod count at ~0.08Mi/pod (35Mi @ 123 pods → 748Mi @ 7,954 pods)
- `external-dns` and all three VPA components already carry ceilings sized around the garbage (see comments in [`external_dns.py`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/infrastructure/aws/eks/external_dns.py#L154-L163) and [`vpa.py`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/infrastructure/aws/eks/vpa.py#L44-L60))

**Why 1h is safe:** run history and the event log are in Dagster's Postgres, and compute logs are in S3 (`S3ComputeLogManager`), so nothing user-facing is lost when the Job object goes away. Pod-level retention only matters for infrastructure failures that emit no Dagster events (OOMKill, image-pull error, scheduling failure) — an hour is enough to catch a page and still `kubectl describe` the pod. Steady-state retention drops to ~30–40 pods; even a worst-case burst holds ~3,200 instead of an unbounded 24h pile. **The TTL value is a retention-tradeoff judgment call — happy to change the number if a different window is preferred.**

**No backlog cleanup needed:** the TTL is stamped on each Job at creation, so the existing pile carries its own 24h expiry and self-clears within a day of deployment.

### How can this be tested?

Schema validated end-to-end against the pinned library (`dagster-k8s==0.29.17`, matching chart `1.13.17`): `job_spec_config` is a declared launcher key validated against `kubernetes.client.V1JobSpec`, and the merge with `DEFAULT_JOB_SPEC_CONFIG` yields effective TTL `3600` while preserving `backoff_limit: 0` and the existing `karpenter.sh/do-not-disrupt` annotation:

```
run_k8s_config keys: ['pod_template_spec_metadata', 'job_spec_config']
validated against V1JobSpec -> {'ttl_seconds_after_finished': 3600}
dagster_k8s default TTL : 86400 s
effective TTL after ours: 3600 s
backoff_limit preserved : 0
karpenter annotation kept: {'annotations': {'karpenter.sh/do-not-disrupt': 'true'}}
```

`pre-commit run --files src/ol_infrastructure/applications/dagster/dagster_instance.yaml` passes.

Reviewer validation:

```bash
cd src/ol_infrastructure/applications/dagster
pulumi preview --stack applications.dagster.QA   # then Production
```

The only expected change is the `dagster-instance` ConfigMap contents. `dagster_instance.yaml` is shared config, so this lands on CI/QA before Production in the normal pipeline flow.

Post-deploy, watch the pile shrink and the informer consumers relax:

```promql
count(kube_pod_status_phase{cluster="data-production", phase="Succeeded"} == 1)
max((time() - kube_pod_completion_time{cluster="data-production", namespace="dagster"})/3600)  # should trend to <=1h for new runs
container_memory_working_set_bytes{cluster="data-production", container="vantage-kubernetes-agent"} / 1024 / 1024
```

### Additional Context

- **Merge-order note for https://github.com/mitodl/ol-infrastructure/issues/5366:** its planned `pod_spec_config.priority_class_name` addition is a sibling key in the same `run_k8s_config` block this PR touches — whichever lands second needs a trivial rebase. (This PR's verification also confirms #5366's config route: `pod_spec_config` is validated against `V1PodSpec`, where `priority_class_name` is a valid field.)
- The TTL controller was verified working before this change: max completed-pod age on `data-production` pins at exactly 24.0h over 7 days of Prometheus data. This PR narrows the window; it does not introduce reaping.
- Still outstanding (not this PR): the Vantage agent runs with a hand-patched `768Mi` limit in-cluster while the code on `main` says `512Mi` — until the pod pile actually shrinks, a `pulumi up` of the EKS substructure stack would revert it against a ~748Mi working set and re-OOM it. Flagged in the [#5370 correction comment](https://github.com/mitodl/ol-infrastructure/issues/5370#issuecomment-5255009346).
- The pre-existing yamllint findings in this file (long `pragma: allowlist secret` line) are untouched per repo policy; the formatting hook normalized the `env_secrets` list indentation.
