### PR TITLE
fix(dagster): roll daemon/webserver pods when dagster_instance.yaml changes

### DIFF
--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -10,6 +10,7 @@ This deployment uses:
 - APISix ingress with OpenID Connect for authentication
 """
 
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -1190,6 +1191,21 @@ for location in code_locations:
 dagster_instance_yaml = (
     Path(__file__).parent.joinpath("dagster_instance.yaml").read_text()
 )
+# The daemon and webserver mount dagster.yaml from the dagster-instance
+# ConfigMap via subPath, which kubelet never live-refreshes, and the chart's
+# built-in checksum/dagster-instance rollout trigger hashes only its OWN
+# values-rendered instance template -- not the extraManifests override below
+# that actually carries this file. Without this annotation, edits to
+# dagster_instance.yaml deploy the ConfigMap but silently never reach the
+# running processes until someone manually restarts them (bit us on the run
+# Job TTL fix, #5373): injecting our own content hash into both pod templates
+# makes a config edit roll the pods the same way the chart's native checksum
+# does.
+dagster_instance_checksum_annotation = {
+    "checksum/ol-dagster-instance": hashlib.sha256(
+        dagster_instance_yaml.encode()
+    ).hexdigest(),
+}
 
 # Get dagster-k8s image tag from environment variable (set by Concourse)
 dagster_k8s_image_tag = os.environ.get("DAGSTER_K8S_IMAGE_TAG")
@@ -1221,6 +1237,7 @@ dagster_helm_values = {
     },
     # Dagster webserver (UI)
     "dagsterWebserver": {
+        "annotations": dagster_instance_checksum_annotation,
         "image": dagster_k8s_image_config,
         "workspace": {
             "enabled": True,
@@ -1305,6 +1322,7 @@ dagster_helm_values = {
     },
     # Dagster daemon (background job scheduler)
     "dagsterDaemon": {
+        "annotations": dagster_instance_checksum_annotation,
         "image": dagster_k8s_image_config,
         "env": [
             {


### PR DESCRIPTION
### What are the relevant tickets?

Follow-up to https://github.com/mitodl/ol-infrastructure/pull/5373 / https://github.com/mitodl/ol-infrastructure/issues/5370. Fixes the deployment gap that made #5373 a silent no-op until a manual pod restart.

### Description (What does it do?)

Injects a sha256 hash of the raw `dagster_instance.yaml` content into the daemon and webserver pod templates (as a `checksum/ol-dagster-instance` annotation, via the chart's supported `dagsterDaemon.annotations` / `dagsterWebserver.annotations` values), so that any edit to that file triggers a rolling restart of both deployments on deploy.

**Why this is needed — two stacked gaps, discovered while verifying #5373 in production:**

1. **`subPath` mounts never refresh.** Both deployments mount `dagster.yaml` from the `dagster-instance` ConfigMap with `subPath: dagster.yaml`. Kubernetes' normal live-update of ConfigMap volumes explicitly does not apply to `subPath` mounts — the file is a static snapshot from pod start.
2. **The chart's restart trigger doesn't cover our config.** The Dagster chart puts `checksum/dagster-instance: {{ include ".../configmap-instance.yaml" . | sha256sum }}` on both pod templates ([`deployment-daemon.yaml#L40`](https://github.com/dagster-io/dagster/blob/1.13.17/helm/dagster/templates/deployment-daemon.yaml#L40)) — but that hashes the chart's **own** values-rendered instance template. This repo overrides the instance config with a raw `extraManifests` ConfigMap of the same name (`applications/dagster/__main__.py`), which wins on the live object but is invisible to the chart's checksum.

Net effect before this PR: editing `dagster_instance.yaml` deploys a correct ConfigMap while the running daemon/webserver keep their stale in-memory config indefinitely. This is exactly what happened with #5373: the Concourse deploy (`docker-pulumi-dagster` build #143) succeeded at 15:50 UTC, the live ConfigMap contained the new 1h run-Job TTL, and the daemon — pod untouched since 00:48 UTC, checksum annotation bit-for-bit unchanged — kept launching Jobs with the old 24h TTL until a manual `kubectl rollout restart`.

**Behavior change:** every future `dagster_instance.yaml` edit now bounces the daemon and webserver on deploy (rolling; webserver runs 2 replicas, and `run_monitoring.max_resume_run_attempts: 3` + `run_retries` cover the daemon blip). That is the correct behavior — a config change that doesn't restart them is silently a no-op, which is strictly worse.

### How can this be tested?

```bash
cd src/ol_infrastructure/applications/dagster
pulumi preview --stack QA --diff
```

Validated locally against QA. Relevant diff is exactly:

```
~ dagsterDaemon   : { + annotations: { + checksum/ol-dagster-instance: "e4a1ec0e..." } }
~ dagsterWebserver: { + annotations: { + checksum/ol-dagster-instance: "e4a1ec0e..." } }
```

(The preview also shows image tags flipping to `latest` — local-only noise because `DAGSTER_K8S_IMAGE_TAG` is set by Concourse and absent locally; the CI deploy will not produce that diff.)

`ruff format`, `ruff check`, `mypy`, and `pre-commit run --files` all pass on the changed file (pre-existing findings unchanged).

Post-deploy verification: the daemon/webserver pods roll once (the annotation is new to the pod template), then on any subsequent `dagster_instance.yaml` change:

```bash
kubectl -n dagster get pods -l component=dagster-daemon \
  -o jsonpath='{.items[0].metadata.annotations.checksum/ol-dagster-instance}'
# should equal: sha256sum src/ol_infrastructure/applications/dagster/dagster_instance.yaml
```

### Additional Context

- The chart-side mechanics were verified against the pinned chart `1.13.17`: `dagsterDaemon.annotations` and `dagsterWebserver.annotations` render into the pod template `annotations` block, adjacent to the chart's own checksum lines.
- One-pod-roll on first deploy is expected (annotation added where none existed).
