### PR TITLE
fix(apisix): size the CPU request so HPA saturation means real load

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.applications.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.applications.Production.yaml
@@ -47,6 +47,16 @@ config:
   eks:apisix_min_replicas: '5'
   eks:apisix_max_replicas: '24'
   eks:apisix_target_cpu_utilization_percentage: '65'
+  # HPA scale-out point = target_cpu_utilization x this request (65% x 250m =
+  # 162.5m/pod). Calibrated from 2026-08-08..11 measurements: at the previous
+  # default request (100m, scale-out at 65m/pod) the gateway sat pinned at
+  # maxReplicas=24 for ~3 days while total fleet CPU peaked at 1.9 cores (122m
+  # max on any single pod) and gateway-added p95 latency held at 2-13ms -- "at
+  # max" was reachable at ~1.6 cores of real work and HPAAtMaxReplicasCritical
+  # carried no saturation signal. At 250m that same event runs at ~8-12
+  # replicas, and the alert only fires when the fleet genuinely needs >3.9
+  # cores (>2x the worst peak observed).
+  eks:apisix_cpu: 250m
   eks:apisix_memory: 1500Mi
   eks:developer_role_policy_name: AmazonEKSClusterAdminPolicy
   eks:developer_role_kubernetes_groups:

--- a/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py
@@ -405,7 +405,16 @@ def setup_apisix(
                 # request over time via apisix_memory/apisix_max_memory.
                 "resources": {
                     "requests": {
-                        "cpu": "100m",
+                        # The CPU request is the HPA's denominator: the
+                        # autoscaler above targets
+                        # targetCPUUtilizationPercentage of THIS value, so the
+                        # per-pod scale-out point is target% x request. A
+                        # request far below real per-pod usage makes
+                        # maxReplicas reachable at trivial absolute load and
+                        # turns HPAAtMaxReplicas alerts into noise. Size it per
+                        # stack (apisix_cpu) from measured per-pod usage, not
+                        # as a placeholder.
+                        "cpu": eks_config.get("apisix_cpu") or "100m",
                         "memory": eks_config.get("apisix_memory") or "400Mi",
                     },
                     "limits": {


### PR DESCRIPTION
### What are the relevant tickets?
N/A — diagnosed from the recurring `HPAAtMaxReplicasCritical` alerts on `apache-apisix` in `applications-production` (e.g. https://rootly.com/account/alerts/PxBcbu is one of the fleet-wide batch; the apisix HPA alone fired 13+ criticals over 2026-08-08..11).

### Description (What does it do?)
Makes the APISIX gateway pod CPU request configurable per stack (`eks:apisix_cpu`, default unchanged at `100m`) and sets it to `250m` for `applications-production` — the same configurable-with-unchanged-default pattern as `apisix_target_cpu_utilization_percentage` from #5085.

**Why:** the CPU request is the HPA's denominator (`targetCPUUtilizationPercentage` is a percentage *of the request*), and at the hardcoded `100m` with a 65% target the per-pod scale-out point was **65 millicores** — below routine per-pod usage. That made `maxReplicas` reachable at trivial absolute load and turned the "at max replicas" alert into noise.

**Measurements (Grafana Cloud Prometheus, `applications-production`, 2026-08-08 → 2026-08-11):**

| observation | value |
|---|---|
| time pinned at `maxReplicas=24` | ~3 days, near-continuously |
| total fleet CPU at peak (24 pods) | **1.88 cores** |
| max CPU on any single pod | **122m** |
| gateway-added p95 latency (`apisix_http_latency_bucket{type="apisix"}`), entire window | **2–13 ms** |
| upstream p95 during the same window | spikes to 1.9–5.2 s (upstream problem, not gateway) |

i.e. "at max" was reachable at ~1.6 cores of real work across the whole fleet, while the gateway itself added single-digit-millisecond latency throughout — no actual saturation. The July fix (#5085) raised max 16→24 and target 50→65 after observing "current=max=16 at ~48–58%", but at a 100m request that utilization was 48–58 *millicores* per pod — the same denominator artifact, not genuine load-driven saturation.

**Effect at 250m:** scale-out point becomes 162.5m/pod. Replayed against the measured event: equilibrium ~8–12 replicas instead of pinned at 24, and `HPAAtMaxReplicas` only fires when the fleet genuinely needs >3.9 cores (>2× the worst peak observed in the incident window). Quiet-hours load (~0.3 cores total) still settles at `minReplicas=5`. The VPA is unaffected — it controls memory only. (Scheduling-reservation effect is quantified in the blast radius below; it is a modest *increase*, not a decrease.)

**What drove the incident itself (context, deliberately not addressed here):** the Aug 8–11 traffic was our own data platform — `python-httpx2/2.9.1` requesting `GET /api/learning_sequences/v1/course_outline/...?username=data_service_user` against `courses.learn.mit.edu` via Fastly at ~200–280 rps sustained (~97% of LMS route traffic, up from a ~2 rps baseline). That load genuinely saturated the edxapp LMS (its own HPA at max, pod restarts) and is being managed on the producer side via Dagster throughput tuning (1ff3a440e, 56cb90971, c3068d4a3). This PR only fixes the gateway's scaling signal so APISIX alerts mean something during the next such event.

### How can this be tested?
`pulumi preview --stack applications.Production` from `src/ol_infrastructure/infrastructure/aws/eks/` shows exactly one values change on the APISIX Helm release:

```
~ values: {
    ~ resources: {
        ~ requests: {
            ~ cpu: "100m" => "250m"
```

(Other stacks are unchanged: the code default stays `100m`.) `pre-commit run --files <changed files>` passes (ruff format/check, mypy, yamllint, detect-secrets). After deploy, expect the apisix HPA to settle around 5–8 replicas at current traffic (vs 10–24 today) with no change in gateway-added latency, and `kubectl -n operations get hpa apache-apisix` to report utilization against the new request.

### Additional Context
Rolling this out will briefly restart gateway pods (Helm values change → deployment template change); the existing drain-first rolling-update strategy (maxSurge 0 / maxUnavailable 1) applies. The preview also shows 5 pre-existing unrelated diffs on the stack (provider/chart version drift: external-dns, VPA, ALB controller, traefik, aws provider) that exist on `main` and are not part of this change.

### Blast radius

**Scope.** One Helm release value (`resources.requests.cpu`) on one stack. `pulumi preview` shows a single key changing, `100m => 250m`. Every other stack (`applications.CI/QA`, `data.*`, `operations.*`, `residential.*`) is untouched — the code default stays `100m`, and no other stack sets `apisix_cpu`. Cannot affect routing, plugins, TLS, upstreams, or memory (the VPA owns memory independently).

**Highest risk is the rollout, not the value.** APISIX is the single front door for every production app, so a bad gateway rollout is a total outage, not a degraded one. The deployment is `maxSurge: 0 / maxUnavailable: 1`, so it replaces **one pod at a time at N-1 capacity**. Typical pod reaches Ready in **11s** (10 of the 11 current pods), but one current pod took **37 minutes** (`11:31:16Z` → `12:08:30Z`, zero restarts) — the ADC config-sync chicken-and-egg the code comments describe. A rollout that hits that path stalls at N-1 for tens of minutes per pod.

- *Mitigation:* deploy in a low-traffic window, watch the first replacement reach Ready before letting it continue, and be ready to `kubectl rollout undo`.

**Capacity.** Worst case (HPA at `maxReplicas=24`) reserves 24×250m = **6.0 cores** vs 2.4 today, i.e. **+3.6 cores** against **104.3 cores allocatable across 22 nodes** — ~3.5% of the cluster. Both topology-spread (`whenUnsatisfiable: ScheduleAnyway`) and pod anti-affinity (`preferred...`) are soft, so no hard scheduling failure is possible, and Karpenter can add nodes. At expected steady state the reservation rises modestly (~6×250m=1.5 vs 1.1 cores today).

**The real functional trade-off.** This does not change throughput; it changes when the HPA reacts. APISIX scales out *later* — at 162.5m/pod instead of 65m/pod — so the standing warm pool is smaller. Two things bound that risk: the container has **no CPU limit** (`limits: {memory: 3000Mi}` only), so existing pods burst freely into spare node CPU rather than throttling; and `minReplicas: 5` and `maxReplicas: 24` are both unchanged, so the ceiling and the floor are exactly where they are today. Still, if APISIX ever genuinely *is* the bottleneck, this trades some scale-out promptness for a meaningful alert.

**Calibration caveat.** 250m is derived from 2026-08-08..11, a window dominated by the anomalous ETL flood. That is deliberate — it sizes the request against the worst real load we have on record — but it is four days of data, not a seasonal baseline. If per-pod usage under normal traffic is far lower, the HPA simply sits at `minReplicas` and the alert stays quiet, which is the intended outcome.

**Rollback.** Revert the commit and re-run `pulumi up`; it is one scalar with no state, migration, or data implications. The reverted rollout carries the same one-pod-at-a-time risk as the forward one.

**Detection.** After deploy, `HPAAtMaxReplicasCritical` for `apache-apisix` should stop firing. If it fires *after* this change, that is a genuine >3.9-core saturation signal and should be treated as real.
