### PR TITLE
fix issues with LOCAL_DEV_ROOT_DOMAIN not being respected

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -11,7 +11,6 @@ config.define_bool("per_app_databases", usage="Deploy isolated DB/Valkey per app
 # local-dev/apps/openedx/Tiltfile is not yet included by the APPS loop below.
 config.define_string("openedx_mode", usage="qa (default) or local (Tutor)")
 config.define_string_list("prebuilt_tags", usage="Prebuilt image tag overrides per app, e.g. mit-learn=0.62.0 learn-ai=0.28.3")
-config.define_string("root_domain", usage="Root DNS domain for all local-dev services (default: mit.dev). Overrides LOCAL_DEV_ROOT_DOMAIN env var.")
 config.define_string("disk_keep_tags", usage="Newest tilt-built image tags kept per repo by the disk janitor (default: 3). Overrides LOCAL_DEV_DISK_KEEP_TAGS env var.")
 config.define_string("disk_buildcache_max_gb", usage="Docker build-cache size cap in GB (default: 10% of total disk; 0 disables). Overrides LOCAL_DEV_BUILDCACHE_MAX_GB env var.")
 cfg = config.parse()
@@ -20,12 +19,28 @@ enabled_apps = cfg.get("enabled_apps", ["mit-learn", "learn-ai", "mitxonline", "
 per_app_databases = cfg.get("per_app_databases", False)
 openedx_mode = cfg.get("openedx_mode", "qa")
 
-# Root domain: configurable via tilt config or LOCAL_DEV_ROOT_DOMAIN env var.
-# All service hostnames are derived from this value — changing it rewires
-# every URL, CORS origin, APISIX route, and Keycloak redirect URI at once.
-# NOTE: root_domain is passed to Pulumi and k8s manifests via LOCAL_DEV_ROOT_DOMAIN;
-# tilt config root_domain takes precedence over the env var.
-root_domain = cfg.get("root_domain") or os.environ.get("LOCAL_DEV_ROOT_DOMAIN", "mit.dev")
+# Every service hostname, CORS origin, APISIX route, and Keycloak redirect URI
+# derives from this value. local-dev/tiltlib.star reads the same environment
+# variable when applying app manifests.
+root_domain = os.environ.get("LOCAL_DEV_ROOT_DOMAIN", "mit.dev")
+
+# The TLS certificate covers only this domain, so an unresolvable hostname means
+# nothing the stack serves is reachable. DNS and /etc/hosts both satisfy this.
+_probe_host = "sso.ol." + root_domain
+if str(local(
+    "getent hosts %s >/dev/null 2>&1 && echo ok || echo missing" % _probe_host,
+    quiet=True,
+    echo_off=True,
+)).strip() != "ok":
+    fail(
+        ("%s does not resolve, so nothing in the stack will be reachable.\n" +
+         "  LOCAL_DEV_ROOT_DOMAIN is currently '%s'.\n" +
+         "  Fix by either:\n" +
+         "    - running ./local-dev/scripts/setup.sh (adds 127.0.0.1 entries to /etc/hosts), or\n" +
+         "    - pointing DNS for *.%s at this host, or\n" +
+         "    - unsetting LOCAL_DEV_ROOT_DOMAIN to use the mit.dev default.")
+        % (_probe_host, root_domain, root_domain)
+    )
 
 # Parse prebuilt_tags list (["app=tag", ...]) into a lookup dict.
 prebuilt_tags = {

--- a/Tiltfile
+++ b/Tiltfile
@@ -28,9 +28,8 @@ root_domain = os.environ.get("LOCAL_DEV_ROOT_DOMAIN", "mit.dev")
 # nothing the stack serves is reachable. DNS and /etc/hosts both satisfy this.
 _probe_host = "sso.ol." + root_domain
 if str(local(
-    "getent hosts %s >/dev/null 2>&1 && echo ok || echo missing" % _probe_host,
-    quiet=True,
-    echo_off=True,
+    "python3 -c 'import socket,sys; socket.getaddrinfo(sys.argv[1], None)' %s >/dev/null 2>&1 && echo ok || echo missing" % _probe_host,
+    quiet=True, echo_off=True,
 )).strip() != "ok":
     fail(
         ("%s does not resolve, so nothing in the stack will be reachable.\n" +

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -300,11 +300,18 @@ tilt trigger seed-mit-learn-fixtures
 |-----|---------|-------------|
 | `enabled_apps` | all four | Apps to deploy. Omit any to skip it entirely. |
 | `prebuilt_tags` | see example file | `["app=tag"]` list of image tags used when the app repo is not checked out locally. |
-| `root_domain` | `mit.dev` | Root DNS domain all service hostnames derive from. |
 | `disk_keep_tags`, `disk_buildcache_max_gb` | `3`, 10% of disk | Disk retention knobs — see [Disk Management](#disk-management). |
 | `per_app_databases`, `openedx_mode` | — | Declared but not wired to anything yet; setting them has no effect. |
 
-The rule of thumb for which config surface a knob belongs to: settings that change **which/how Tilt runs things** (apps, image tags, domain) go in `tilt_config.json`; anything that sets an **env var or secret value inside a workload** (API keys, feature flags, endpoints) goes in a gitignored `app-env.local.yaml` override ConfigMap — see [Local Configuration Overrides](#local-configuration-overrides).
+The rule of thumb for which config surface a knob belongs to: settings that change **which/how Tilt runs things** (apps, image tags) go in `tilt_config.json`; anything that sets an **env var or secret value inside a workload** (API keys, feature flags, endpoints) goes in a gitignored `app-env.local.yaml` override ConfigMap — see [Local Configuration Overrides](#local-configuration-overrides).
+
+### Root domain
+
+Every service hostname derives from the `LOCAL_DEV_ROOT_DOMAIN` environment variable, which defaults to `mit.dev`: `learn.<root_domain>`, `api.learn.<root_domain>`, `sso.ol.<root_domain>`, and so on. Set it in your shell environment so that it is exported to `tilt up` and `setup.sh`.
+
+`tilt up` fails immediately if `sso.ol.<root_domain>` does not resolve, whether through DNS or `/etc/hosts`.
+
+After changing the value, re-run `./local-dev/scripts/setup.sh` to reissue the TLS certificate and rewrite the `/etc/hosts` block; pass `--skip-hosts` to reissue the certificate only, which is what you want when the hostnames already resolve through DNS. The certificate's SANs cover one root domain, so requests to hostnames outside it fail at the TLS layer.
 
 ### Pulumi stack config
 

--- a/local-dev/infra/apps_infra/Pulumi.local-dev.apps-infra.Dev.yaml
+++ b/local-dev/infra/apps_infra/Pulumi.local-dev.apps-infra.Dev.yaml
@@ -3,10 +3,8 @@ config:
   # Path to the kubeconfig for the k3d cluster.
   # Defaults to ${HOME}/.kube/config if not set.
   ol-local-dev-apps-infra:kubeconfig: ""
-  # Domain configuration
-  ol-local-dev-apps-infra:root_domain: "mit.dev"
-  ol-local-dev-apps-infra:keycloak_hostname: "sso.ol.mit.dev"
-  ol-local-dev-apps-infra:keycloak_url: "https://sso.ol.mit.dev"
+  # Domain configuration: unset on purpose. Pinning these here would override
+  # LOCAL_DEV_ROOT_DOMAIN; unset, the code derives sso.ol.<root_domain>.
   # OIDC client secrets for local dev (plaintext, never commit real secrets)
   # These are default local-only values; override in your local tilt_config.json
   ol-local-dev-apps-infra:mitlearn_client_secret: "local-dev-mitlearn-secret" # pragma: allowlist secret

--- a/local-dev/infra/apps_infra/__main__.py
+++ b/local-dev/infra/apps_infra/__main__.py
@@ -18,7 +18,6 @@ import pulumi_kubernetes as k8s
 # Add parent directory to sys.path to import shared modules
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-import pulumi
 from modules.helpers import make_resource_opts
 from modules.keycloak import create_olapps_dev_realm
 from pulumi import Config
@@ -38,25 +37,6 @@ root_domain = config.get("root_domain") or os.environ.get(
 
 keycloak_hostname = config.get("keycloak_hostname") or f"sso.ol.{root_domain}"
 keycloak_url = config.get("keycloak_url") or f"https://{keycloak_hostname}"
-
-# Client redirect URIs in modules/keycloak.py are written against the default
-# mit.dev domain. Rewriting them here rather than there keeps this patch off a
-# high-churn file and picks up any clients added upstream later.
-if root_domain != "mit.dev":
-
-    def _retarget_domain(
-        args: pulumi.ResourceTransformArgs,
-    ) -> pulumi.ResourceTransformResult:
-        props = dict(args.props)
-        # Transform props carry provider wire names, not the Python
-        # snake_case ones.
-        for key in ("validRedirectUris", "validPostLogoutRedirectUris"):
-            uris = props.get(key)
-            if uris:
-                props[key] = [u.replace("mit.dev", root_domain) for u in uris]
-        return pulumi.ResourceTransformResult(props, args.opts)
-
-    pulumi.runtime.register_resource_transform(_retarget_domain)
 
 # Mirrors production by default; override locally (uncommitted) with:
 #   pulumi config set --stack local-dev.apps-infra.Dev verify_email false
@@ -116,6 +96,7 @@ create_olapps_dev_realm(
     learn_ai_client_secret=learn_ai_client_secret,
     mitxonline_client_secret=mitxonline_client_secret,
     unified_ecommerce_client_secret=unified_ecommerce_client_secret,
+    root_domain=root_domain,
     verify_email=verify_email,
 )
 

--- a/local-dev/infra/apps_infra/__main__.py
+++ b/local-dev/infra/apps_infra/__main__.py
@@ -18,6 +18,7 @@ import pulumi_kubernetes as k8s
 # Add parent directory to sys.path to import shared modules
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+import pulumi
 from modules.helpers import make_resource_opts
 from modules.keycloak import create_olapps_dev_realm
 from pulumi import Config
@@ -37,6 +38,25 @@ root_domain = config.get("root_domain") or os.environ.get(
 
 keycloak_hostname = config.get("keycloak_hostname") or f"sso.ol.{root_domain}"
 keycloak_url = config.get("keycloak_url") or f"https://{keycloak_hostname}"
+
+# Client redirect URIs in modules/keycloak.py are written against the default
+# mit.dev domain. Rewriting them here rather than there keeps this patch off a
+# high-churn file and picks up any clients added upstream later.
+if root_domain != "mit.dev":
+
+    def _retarget_domain(
+        args: pulumi.ResourceTransformArgs,
+    ) -> pulumi.ResourceTransformResult:
+        props = dict(args.props)
+        # Transform props carry provider wire names, not the Python
+        # snake_case ones.
+        for key in ("validRedirectUris", "validPostLogoutRedirectUris"):
+            uris = props.get(key)
+            if uris:
+                props[key] = [u.replace("mit.dev", root_domain) for u in uris]
+        return pulumi.ResourceTransformResult(props, args.opts)
+
+    pulumi.runtime.register_resource_transform(_retarget_domain)
 
 # Mirrors production by default; override locally (uncommitted) with:
 #   pulumi config set --stack local-dev.apps-infra.Dev verify_email false

--- a/local-dev/infra/core/Pulumi.local-dev.core.Dev.yaml
+++ b/local-dev/infra/core/Pulumi.local-dev.core.Dev.yaml
@@ -7,9 +7,8 @@ config:
   ol-local-dev-core:tls_cert_path: "local-dev/certs/local-dev.pem"
   ol-local-dev-core:tls_key_path: "local-dev/certs/local-dev-key.pem"
   ol-local-dev-core:mkcert_ca_cert_path: "local-dev/certs/rootCA.pem"
-  # Domain configuration
-  ol-local-dev-core:keycloak_hostname: "sso.ol.mit.dev"
-  ol-local-dev-core:keycloak_url: "https://sso.ol.mit.dev"
+  # Domain configuration: unset on purpose. Pinning these here would override
+  # LOCAL_DEV_ROOT_DOMAIN; unset, the code derives sso.ol.<root_domain>.
   # APISIX secrets for core infrastructure
   ol-local-dev-core:apisix_admin_key: "local-dev-apisix-admin-key"
   ol-local-dev-core:apisix_viewer_key: "local-dev-apisix-viewer-key"

--- a/local-dev/infra/modules/keycloak.py
+++ b/local-dev/infra/modules/keycloak.py
@@ -34,6 +34,7 @@ def create_olapps_dev_realm(  # noqa: PLR0913
     mitxonline_client_secret: Output,
     unified_ecommerce_client_secret: Output,
     *,
+    root_domain: str,
     verify_email: bool = True,
 ) -> None:
     """
@@ -43,6 +44,9 @@ def create_olapps_dev_realm(  # noqa: PLR0913
     (no Vault dependency). The realm mirrors production configuration but omits
     production-only IdPs. Email verification is configurable via the
     ``verify_email`` argument (defaults to enabled, mirroring production).
+
+    All client hostnames derive from ``root_domain``, which must match the
+    domain the APISIX routes and the TLS certificate were built from.
     """
     kc_opts = ResourceOptions(provider=keycloak_provider)
     k8s_opts = ResourceOptions(provider=k8s_provider)
@@ -107,7 +111,7 @@ def create_olapps_dev_realm(  # noqa: PLR0913
         # Use Mailpit for local SMTP. No auth needed — omitting auth block
         # entirely avoids a provider panic when empty credentials are passed.
         smtp_server=keycloak.RealmSmtpServerArgs(
-            from_="noreply@mit.dev",
+            from_=f"noreply@{root_domain}",
             from_display_name="MIT Learn Local",
             host="mailpit.local-infra.svc.cluster.local",
             port="1025",
@@ -392,8 +396,8 @@ def create_olapps_dev_realm(  # noqa: PLR0913
         standard_flow_enabled=True,
         implicit_flow_enabled=False,
         service_accounts_enabled=False,
-        valid_redirect_uris=["https://unified-ecommerce.mit.dev/*"],
-        valid_post_logout_redirect_uris=["https://unified-ecommerce.mit.dev/*"],
+        valid_redirect_uris=[f"https://unified-ecommerce.{root_domain}/*"],
+        valid_post_logout_redirect_uris=[f"https://unified-ecommerce.{root_domain}/*"],
         opts=kc_opts.merge(ResourceOptions(delete_before_replace=True)),
     )
     keycloak.openid.ClientDefaultScopes(
@@ -424,7 +428,7 @@ def create_olapps_dev_realm(  # noqa: PLR0913
         implicit_flow_enabled=False,
         service_accounts_enabled=False,
         valid_redirect_uris=[
-            "https://ai.learn.mit.dev/*",
+            f"https://ai.learn.{root_domain}/*",
         ],
         opts=kc_opts.merge(ResourceOptions(delete_before_replace=True)),
     )
@@ -456,8 +460,8 @@ def create_olapps_dev_realm(  # noqa: PLR0913
         implicit_flow_enabled=False,
         service_accounts_enabled=False,
         valid_redirect_uris=[
-            "https://learn.mit.dev/*",
-            "https://api.learn.mit.dev/*",
+            f"https://learn.{root_domain}/*",
+            f"https://api.learn.{root_domain}/*",
         ],
         web_origins=["+"],
         opts=kc_opts.merge(ResourceOptions(delete_before_replace=True)),
@@ -498,8 +502,8 @@ def create_olapps_dev_realm(  # noqa: PLR0913
         implicit_flow_enabled=False,
         service_accounts_enabled=True,
         valid_redirect_uris=[
-            "https://mitxonline.mit.dev/*",
-            "https://api.mitxonline.mit.dev/*",
+            f"https://mitxonline.{root_domain}/*",
+            f"https://api.mitxonline.{root_domain}/*",
         ],
         opts=kc_opts.merge(ResourceOptions(delete_before_replace=True)),
     )

--- a/tilt_config.json.example
+++ b/tilt_config.json.example
@@ -13,7 +13,6 @@
     "odl-video-service=0.85.0"
   ],
 
-  "root_domain": "mit.dev",
 
   "disk_keep_tags": "3",
 


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
This PR makes a few changes to the local-dev setup based on some testing setting `LOCAL_DEV_ROOT_DOMAIN` to a custom value. There were some issues, primarily with Keycloak that this PR aims to fix.

### How can this be tested?
Spin up local-dev with `LOCAL_DEV_ROOT_DOMAIN` set to a custom value and ensure that you can log in to any of the sites that use Keycloak.