### PR TITLE
fix(rootly): send Medium and Low urgency alerts to #devops-warnings instead of paging on-call

### DIFF
--- a/src/ol_infrastructure/saas/rootly/__main__.py
+++ b/src/ol_infrastructure/saas/rootly/__main__.py
@@ -695,6 +695,53 @@ escalation_path_defer_medium_urgency_off_hours = rootly.EscalationPath(
     opts=rootly_opts,
 )
 
+# Medium urgency alerts used to page. The deferral path above only holds them
+# outside business hours, and the "Low Urgency" path matches Low only, so paths
+# being evaluated top-to-bottom with the first match winning meant a Medium
+# alert arriving mid-workday fell through to the audible Default Escalation
+# Path: on-call paged, posted to #devops-alerts. This path claims Medium first
+# and notifies only #devops-warnings -- Slack-visible, nobody paged.
+#
+# Scoped by urgency rather than by alert source on purpose, so it covers both
+# routes that reach this policy (the Grafana Production Catch-All Route hands
+# off to it directly; the Service Route hands off to Services that use it) as
+# well as the CloudWatch -qa-/-ci- demotions at the top of this file, which
+# were demoted to Medium for the same "must not page" reason.
+escalation_path_medium_urgency_slack_only = rootly.EscalationPath(
+    "medium-urgency-slack-warnings",
+    name="Medium urgency to #devops-warnings",
+    escalation_policy_id="96629210-cc41-4e57-b059-b182a0f01c5b",
+    path_type="escalation",
+    match_mode="match-all-rules",
+    notification_type="quiet",
+    # Between the Low Urgency path (1) and the default fallback path (3).
+    position=2,
+    # Nobody acknowledges a Slack-only notification, so repeating would just
+    # re-post to the channel until the alert resolved.
+    repeat=False,
+    rules=[
+        {
+            "ruleType": "alert_urgency",
+            "urgencyIds": ["fce5c971-6660-4ad9-90eb-e75122055f50"],
+        },
+    ],
+    opts=rootly_opts,
+)
+
+escalation_level_medium_urgency_slack_only = rootly.EscalationLevel(
+    "medium-urgency-slack-warnings-escalation-level",
+    escalation_policy_id="96629210-cc41-4e57-b059-b182a0f01c5b",
+    escalation_policy_path_id=escalation_path_medium_urgency_slack_only.id,
+    position=1,
+    notification_target_params=[
+        {
+            "type": "slack_channel",
+            "id": "C0BK6BHUCDP",  # #devops-warnings
+        },
+    ],
+    opts=rootly_opts,
+)
+
 # Services imported from the existing Rootly account.
 service_api_authentication = rootly.Service(
     "api-authentication",

--- a/src/ol_infrastructure/saas/rootly/__main__.py
+++ b/src/ol_infrastructure/saas/rootly/__main__.py
@@ -557,9 +557,12 @@ escalation_policy_exampledeleteme_escalationpolicy = rootly.EscalationPolicy(
 # integration setting. Discovered 2026-07-22: that global setting posts every
 # alert account-wide unconditionally, independent of routing/escalation, which
 # is why CI/QA alerts (routed separately to their own Slack-only escalation
-# policy) were also still landing in #devops-alerts. Once this level -- and
-# its counterpart below on the other escalation path -- are confirmed working,
-# the global toggle can be turned off to fully separate the two channels.
+# policy) were also still landing in #devops-alerts. Once this level is
+# confirmed working, the global toggle can be turned off to fully separate the
+# two channels. This is now the only level that targets #devops-alerts: High
+# urgency is all that still pages, and Medium and Low both go to
+# #devops-warnings instead (see the Low Urgency level and the Medium urgency
+# escalation path below).
 escalation_level_b94aa0a3_cda6_4ee6_bcb1_cddf33c69088 = rootly.EscalationLevel(
     "b94aa0a3-cda6-4ee6-bcb1-cddf33c69088",
     delay=5,
@@ -594,9 +597,16 @@ escalation_level_r_4351b5b9_00d3_46ae_a044_05930cfbe0e2 = rootly.EscalationLevel
     opts=rootly_opts,
 )
 
-# See the comment on escalation_level_b94aa0a3_cda6_4ee6_bcb1_cddf33c69088
-# above -- this is the equivalent position-1 level on the Default Escalation
-# Policy's other escalation path, updated the same way for the same reason.
+# The only level on the "Low Urgency" escalation path (which is unmanaged --
+# only this level is modeled here). Low urgency alerts used to notify the
+# on-call schedule here and post to #devops-alerts. The path is "quiet", so
+# those pages respected Do Not Disturb, but they were still pages, for the
+# least urgent tier we have -- Grafana severity=warning maps to Low. Both
+# targets are now replaced by #devops-warnings alone, matching the Medium
+# urgency path below: Slack-visible, nobody paged.
+#
+# The schedule target is gone, so the paging strategy fields that governed it
+# are gone with it -- they only apply to schedule targets.
 escalation_level_r_75bc919c_824c_46a1_9589_0fc8b85e0d77 = rootly.EscalationLevel(
     "r-75bc919c-824c-46a1-9589-0fc8b85e0d77",
     delay=5,
@@ -604,17 +614,10 @@ escalation_level_r_75bc919c_824c_46a1_9589_0fc8b85e0d77 = rootly.EscalationLevel
     escalation_policy_path_id="67658f83-7fac-4a19-8e2a-0d8eee57f0a8",
     notification_target_params=[
         {
-            "id": "fad27d50-f0e4-4d21-9b6d-57eb2dec648b",
-            "teamMembers": "all",
-            "type": "schedule",
-        },
-        {
-            "id": "GBDLJJX51",  # #devops-alerts
+            "id": "C0BK6BHUCDP",  # #devops-warnings
             "type": "slack_channel",
         },
     ],
-    paging_strategy_configuration_schedule_strategy="on_call_only",
-    paging_strategy_configuration_strategy="default",
     position=1,
     opts=rootly_opts,
 )


### PR DESCRIPTION
### What are the relevant tickets?

Related to https://github.com/mitodl/ol-infrastructure/issues/5012 (does not close it). That issue's follow-up list calls out a "time-restricted escalation path" at the Rootly layer as the only shared chokepoint for sources that bypass Grafana Alertmanager; this is a step in that direction, gating on urgency rather than time of day.

Prompted by a real page: https://rootly.com/account/alerts/a4th6U — `HPAAtMaxReplicasCritical` for `keda-hpa-mitxonline-webapp-scaledobject`, which paged repeatedly through the working day.

### Description (What does it do?)

Stops **Medium** and **Low** urgency alerts from paging on-call, sending both to Slack `#devops-warnings` instead. After this, **High urgency is the only tier that pages.**

**Why Medium was paging.** Demoting an alert's urgency doesn't change where it goes. The alert above is already demoted to Medium ([`__main__.py`, the self-healing/no-runway alertname list](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/saas/rootly/__main__.py#L481-L499)), but the Default Escalation Policy had only three paths, and Rootly evaluates paths top-to-bottom with the first match winning (deferral paths first):

| Position | Path | Matches | Notified |
|---|---|---|---|
| 1 (deferral) | Defer Medium urgency outside business hours | Medium **and** 17:00–09:00 / weekends ET | holds, then re-evaluates |
| 1 | Low Urgency (quiet) | urgency = Low | on-call schedule + `#devops-alerts` |
| 3 | Default Escalation Path (audible, **default**) | — fallback | on-call schedule + `#devops-alerts` |

A Medium alert arriving mid-workday matches neither the deferral path (wrong time window) nor the Low path (wrong urgency), so it fell through to the audible fallback: on-call paged, posted to `#devops-alerts`. `a4th6U` fired at 14:47 ET and Rootly's timeline shows email + push notification went out.

**Two changes:**

1. **New escalation path for Medium**, at position 2 — between Low (1) and the default fallback (3) — matching `alert_urgency = Medium`, with a single escalation level whose only notification target is the `#devops-warnings` Slack channel (`C0BK6BHUCDP`, the same channel the existing CI/QA Slack policy uses). No schedule target, so nothing pages. `notification_type = quiet` and `repeat = false`, since nobody acknowledges a Slack-only notification and repeating would just re-post to the channel until the alert resolved.

2. **The existing Low Urgency path's level is repointed to `#devops-warnings`**, dropping both its on-call schedule target and its `#devops-alerts` target. That path is `quiet`, so its pages respected Do Not Disturb — but they were still pages, for the least urgent tier we have, and Grafana `severity=warning` maps to Low. The schedule target is gone, so the `paging_strategy_configuration_*` fields that only governed it go with it. (Only this level is modeled in Pulumi; the Low Urgency path itself is unmanaged.)

**Medium is scoped by urgency, not by alert source.** Two deliberate consequences:

- It covers both routes that reach this policy — the Grafana Production Catch-All Route targets the policy directly, and the Grafana Production Service Route targets Services whose escalation policy is this same one — so there's one change point instead of two.
- It also covers the CloudWatch `-qa-`/`-ci-` alarms that [this file already demotes to Medium](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/saas/rootly/__main__.py#L66-L81) for exactly the same "must not page" reason.

The alternative — urgency conditions on the two Grafana production alert routes — was rejected as a worse trade: the Service Route is a Pulumi `import_`ed resource (this file warns that a mistake there silently rewrites live production routing), inserting at position 1 means renumbering its 8 existing rules, Medium alerts would lose their per-service attribution, and no route in the account currently uses urgency conditions.

### How can this be tested?

`pulumi preview --diff` from `src/ol_infrastructure/saas/rootly`. The new Medium path and its level:

```text
    + rootly:index/escalationPath:EscalationPath: (create)
        escalationPolicyId: "96629210-cc41-4e57-b059-b182a0f01c5b"
        matchMode         : "match-all-rules"
        name              : "Medium urgency to #devops-warnings"
        notificationType  : "quiet"
        pathType          : "escalation"
        position          : 2
        repeat            : false
        rules             : [
            [0]: {
                ruleType  : "alert_urgency"
                urgencyIds: [ [0]: "fce5c971-6660-4ad9-90eb-e75122055f50" ]
            }
        ]
    + rootly:index/escalationLevel:EscalationLevel: (create)
        escalationPolicyId      : "96629210-cc41-4e57-b059-b182a0f01c5b"
        escalationPolicyPathId  : [unknown]
        notificationTargetParams: [ [0]: { id: "C0BK6BHUCDP", type: "slack_channel" } ]
        position                : 1
```

And the Low Urgency level losing its schedule and `#devops-alerts` targets:

```text
    ~ rootly:index/escalationLevel:EscalationLevel: (update)
        [id=75bc919c-824c-46a1-9589-0fc8b85e0d77]
      ~ notificationTargetParams: [
          ~ [0]: {
                  ~ id         : "fad27d50-f0e4-4d21-9b6d-57eb2dec648b" => "C0BK6BHUCDP"
                  - teamMembers: "all"
                  ~ type       : "schedule" => "slack_channel"
                }
          - [1]: {
                  - id  : "GBDLJJX51"
                  - type: "slack_channel"
                }
        ]
Resources:
    + 2 to create
    ~ 3 to update
    5 changes. 153 unchanged
```

**Two of those three updates are pre-existing drift, not from this branch.** They are `AlertsSource` `deduplicateAlertsByKey: true => false` on `cloudwatch-critical` / `cloudwatch-warning`, from #5259, which is merged but not yet applied to the live account. `pulumi preview` on `main` with this branch stashed shows exactly those two and `154 unchanged`.

Also run from the repo root:

```bash
uv run ruff format src/ol_infrastructure/saas/rootly/__main__.py   # unchanged
uv run ruff check src/ol_infrastructure/saas/rootly/__main__.py    # all checks passed
uv run mypy src/ol_infrastructure/saas/                            # no issues, 16 files
```

Post-apply validation in Rootly:

- **Medium:** wait for or trigger a Medium alert (one of the demoted alertnames, or a `-qa-`/`-ci-` CloudWatch alarm) and confirm its timeline shows the "Medium urgency to #devops-warnings" path executing, a post in `#devops-warnings`, and no notification to the on-call schedule.
- **Low:** same for a Grafana `severity=warning` alert via the "Low Urgency" path.
- **High:** confirm a High urgency alert still pages on-call and still posts to `#devops-alerts` — that path is untouched and is the one tier that must keep working.

### Additional Context

Two things a reviewer should weigh:

1. **The deferral path is now redundant.** "Defer Medium urgency outside business hours" exists to stop Medium paging overnight; once Medium never pages, it only delays the Slack post until 09:00 ET. Left in place here rather than removed, because it's `protect=True` and deleting it takes two applies (unprotect, then destroy). Worth a follow-up.
2. **The account-wide "default alerts channel" setting may still post everything to `#devops-alerts` regardless.** [The comment on the remaining `#devops-alerts` escalation level](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/saas/rootly/__main__.py#L553-L565) notes that this global toggle posts every alert unconditionally, independent of routing/escalation, and that it can be turned off once the explicit channel levels are confirmed working. It isn't managed by Pulumi. If it's still on, Medium and Low alerts will appear in `#devops-warnings` **and** `#devops-alerts` after this applies — but they will no longer page, which is the substance of the fix. With High now the only tier targeting `#devops-alerts` explicitly, turning that global toggle off is the natural next step.
