### PR TITLE
Enable mitxonline-12321-program-specific-pathway-schools flag on RC

### DIFF
--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.QA.yaml
@@ -23,6 +23,7 @@ config:
     CSRF_COOKIE_DOMAIN: ".rc.mitxonline.mit.edu"
     CSRF_COOKIE_NAME: csrf_mitxonline
     CRON_COURSE_CERTIFICATES_HOURS: "*/6"
+    FEATURE_mitxonline-12321-program-specific-pathway-schools: "True"
     GA_TRACKING_ID: "UA-5145472-46"
     GTM_TRACKING_ID: "GTM-TW97MNR"
     KEYCLOAK_BASE_URL: "https://sso-qa.ol.mit.edu"


### PR DESCRIPTION
## Summary
- Sets `FEATURE_mitxonline-12321-program-specific-pathway-schools: "True"` in the QA (RC) stack's `mitxonline:vars` block.
- Lets us test [mitodl/mitxonline#3802](https://github.com/mitodl/mitxonline/pull/3802) on RC. `mitol.olposthog.features.is_enabled()` falls back to `settings.FEATURES` (populated from `FEATURE_*` env vars) whenever PostHog returns no value for the flag — which is the case now since the flag hasn't been created in PostHog yet. Once it's created there (even switched off), PostHog takes precedence over this env var.

## Test plan
- [ ] `pulumi preview` on the mitxonline QA stack shows only this env var added
- [ ] After deploy, confirm on RC that a learner enrolled in one of DEDP/SCM/SDS/PoM/Finance sees the per-program partner-school behavior (note: partner-school assignments still need to be entered at `/admin/courses/partnerschool/` on RC, or the share dropdown will show zero schools)