### PR TITLE
fix(eks): point the Traefik release at the current chart repository

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/eks/traefik.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/traefik.py
@@ -90,7 +90,9 @@ def setup_traefik(
             skip_crds=False,
             cleanup_on_fail=True,
             repository_opts=kubernetes.helm.v3.RepositoryOptsArgs(
-                repo="https://helm.traefik.io/traefik",
+                # helm.traefik.io was retired and now 404s on index.yaml, which
+                # fails the release at resolve time rather than degrading.
+                repo="https://traefik.github.io/charts",
             ),
             values={
                 "image": {


### PR DESCRIPTION
## What broke

Every EKS CI deploy is failing:

```
kubernetes:helm.sh/v3:Release data-ci-traefik-gateway-controller-helm-release
  error: property chart value {traefik} has a problem: looks like
  "https://helm.traefik.io/traefik" is not a valid chart repository or cannot
  be reached: failed to fetch https://helm.traefik.io/traefik/index.yaml : 404
```

`data`, `operations`, `applications`, `residential` — all four clusters, CI stage. Helm fails at chart *resolution*, so there is no partial apply and no fallback; the whole stack update errors out.

## Cause

Traefik retired `helm.traefik.io`. Confirmed directly:

| URL | status |
| --- | --- |
| `https://helm.traefik.io/traefik/index.yaml` | **404** |
| `https://traefik.github.io/charts/index.yaml` | 200 |

Nothing changed on our side — `TRAEFIK_CHART_VERSION = "41.2.0"` is untouched. The pin was fine; the host it was fetched from went away.

## Fix

One line, `src/ol_infrastructure/infrastructure/aws/eks/traefik.py:93`, repository only. Verified the pinned version is served unchanged from the new repo rather than assuming it:

```
version : 41.2.0
appVer  : v3.7.10
url     : https://traefik.github.io/charts/traefik/traefik-41.2.0.tgz
tarball : HTTP 200, 258292 bytes
```

41.2.0 is also the newest release there, so no version movement is implied or needed.

`rg 'helm\.traefik\.io'` returns no other references in the repo.

## Note

Found while verifying the `preview-gated` rollout in #5363 — unrelated to that change, which is why it is a separate PR.
