### PR TITLE
fix(eks): size vantage agent for pod count and let Go see the ceiling

### DIFF
--- a/src/ol_infrastructure/substructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/substructure/aws/eks/__main__.py
@@ -257,39 +257,59 @@ if cluster_stack.require_output("has_ebs_storage"):
                     "disableKubeTLSverify": True,
                     "nodeAddressTypes": "InternalIP",
                     "collectNamespaceLabels": "true",
+                    "extraEnv": [
+                        # Soft limit ~90% of limits.memory: the Go runtime GCs
+                        # more aggressively rather than letting the cgroup
+                        # OOMKiller win. Without this the runtime cannot see
+                        # the cgroup ceiling at all, which is why the sawtooth
+                        # peaks land on the limit instead of collecting below
+                        # it.
+                        {"name": "GOMEMLIMIT", "value": "1400MiB"},
+                    ],
                 },
                 "persist": {
                     "storageClassName": cluster_stack.require_output(
                         "ebs_storageclass"
                     ),
                 },
-                # This has bounced between 100Mi/200Mi/256Mi several times
-                # (see git history) chasing recurring OOM kills -- most
-                # recently 200Mi, which still OOMs: every restart reloads a
-                # full controller/pod/node cluster-state snapshot from
-                # backup before it can do anything else, so this is a
-                # consistent per-startup need, not an occasional burst above
-                # a fine idle baseline. Guaranteed QoS requires every
-                # resource (not just memory) to have request == limit, so
-                # cpu is set explicitly here too, matching the chart's own
-                # default limit (100m) that was already silently in effect
-                # -- our previous override only ever set requests.cpu=10m,
-                # never touched limits.cpu, so Helm merged in the chart
-                # default there. Making that explicit and matching request
-                # to it, rather than leaving the mismatch, so the pod
-                # actually gets Guaranteed QoS: a single pod per cluster, so
-                # the aggregate reservation cost is small, and Guaranteed
-                # protects it from being a preferred eviction target under
-                # node memory pressure while it's already struggling to
-                # survive its own startup.
+                # Memory scales with cluster-wide POD COUNT, not with the
+                # number of workloads or the cost data being reported: the
+                # agent holds cluster-wide pod/controller/node informers, so
+                # it caches every pod including completed dagster Job pods
+                # (ttlSecondsAfterFinished=24h). Measured peaks: ~46Mi at 124
+                # pods (operations-production), ~60Mi at 126 (residential),
+                # ~165Mi at 325 (applications), and data-production pinned at
+                # its ceiling with 3.9k pods. Extrapolating ~0.17Mi/pod over
+                # the 8k pods a full day of dagster churn has produced puts
+                # the real ceiling near 1.5Gi, so size for that rather than
+                # for today's instant -- this value has already been bumped
+                # 100Mi -> 200Mi -> 256Mi -> 512Mi (and hand-patched to 768Mi
+                # in data-production) chasing the same OOM because each bump
+                # was fitted to the pod count of the week.
+                #
+                # Deliberately no longer request == limit, reversing the
+                # earlier Guaranteed-QoS reasoning here to match how the other
+                # cluster-wide informer holders were sized in #5326:
+                # Guaranteed buys eviction protection but leaves zero burst
+                # headroom, and an OOMKill is a certain outage where
+                # node-pressure eviction is a rare and recoverable one. The
+                # modest request also keeps reserved capacity cheap on the 11
+                # clusters that genuinely use <200Mi, since this block is
+                # shared across all 12 EKS stacks.
+                #
+                # limits.cpu has to be stated explicitly: omitting it lets
+                # Helm merge in the chart's own 100m default, which was
+                # throttling the container 10-18% of every period. Starved GC
+                # is what lets the heap outrun the soft limit, so the ceiling
+                # is raised to give the collector room to actually keep up.
                 "resources": {
                     "requests": {
-                        "cpu": "100m",
-                        "memory": "512Mi",
+                        "cpu": "10m",
+                        "memory": "256Mi",
                     },
                     "limits": {
-                        "cpu": "100m",
-                        "memory": "512Mi",
+                        "cpu": "500m",
+                        "memory": "1536Mi",
                     },
                 },
             },


### PR DESCRIPTION
### What are the relevant tickets?

N/A — found while investigating `vantage-kubernetes-agent-0` CrashLooping in `data-production`.

### Description (What does it do?)

`vantage-kubernetes-agent-0` in `data-production` had **177 restarts in 44h**, `OOMKilled` (exit 137), with readiness flapping the entire time (`Readiness probe failed: connect: connection refused`, x707).

The agent holds cluster-wide pod/controller/node informers, so its memory tracks **total cluster pod count** — not workload count, and not the volume of cost data it reports. `data-production` carries ~3.9k pods, ~3.6k of which are completed dagster Job pods retained by `ttlSecondsAfterFinished=24h`. Peak working set across the fleet makes the driver unambiguous:

| cluster | pods | vantage peak |
|---|---|---|
| `operations-production` | 124 | 46Mi |
| `residential-production` | 126 | 60Mi |
| `applications-production` | 325 | 165Mi |
| `data-production` | 3886 | 767Mi (clipped — OOMing) |

Two separate things were wrong, and fixing only the first is why this keeps recurring.

**1. The ceiling was fitted to the pod count of the week.** It has gone `100Mi -> 200Mi -> 256Mi -> 512Mi` across #2768 / #3857 / #5088 and others. There is also an **undocumented hand-patch to 768Mi** on the live `data-production` StatefulSet that is not in this repo — `helm get values` still reports `512Mi` — and it OOMs anyway. Extrapolating the ~0.17Mi/pod slope over the ~8k pods a full day of dagster churn has produced lands near 1.5Gi, so `limits.memory` goes to **1536Mi**, sized against the known upper bound of job churn rather than today's instant.

**2. No `GOMEMLIMIT` — this is why 768Mi still died.** Working set sawtooths `612Mi -> 767Mi` with the peaks landing *exactly* on the limit, because the Go runtime cannot see the cgroup ceiling and grows the heap straight into it. `GOMEMLIMIT=1400MiB` (~90% of the limit) makes the collector run hard as it approaches the ceiling instead of the OOMKiller winning.

This is the same fix shape applied to every other cluster-wide informer holder in #5326 (`external-dns`, VPA recommender/admission, `aws-load-balancer-controller`, `starrocks-operator`, `marimo-operator`) — the vantage agent was simply not included in that PR.

Two supporting changes:

- **Reverses the Guaranteed-QoS reasoning from #5088**, for the same reason #5326 did: Guaranteed buys eviction protection but leaves zero burst headroom, and an OOMKill is a *certain* outage where node-pressure eviction is a rare and recoverable one. The smaller request also keeps reserved capacity cheap on the 11 clusters that genuinely use <200Mi, since this `resources` block is shared across all 12 EKS stacks.
- **`limits.cpu` is stated explicitly at 500m rather than dropped.** Omitting it lets Helm merge the chart's own `100m` default back in (the trap #5088 documented), which was throttling the container **10–18% of every CFS period**. Starved GC is precisely what lets a heap outrun a soft limit, so the collector needs headroom for `GOMEMLIMIT` to do its job.

Net diff to the Helm values:

```
agent.extraEnv:  + GOMEMLIMIT=1400MiB
requests.cpu:      100m  -> 10m
requests.memory:   512Mi -> 256Mi
limits.cpu:        100m  -> 500m
limits.memory:     512Mi -> 1536Mi
```

### How can this be tested?

`pulumi preview --cwd src/ol_infrastructure/substructure/aws/eks -s data.Production --diff` shows exactly the intended change and nothing else on this resource:

```
~ kubernetes:helm.sh/v3:Release: (update)
    [id=operations/vantage-kubernetes-agent]
  ~ values : {
      ~ agent    : {
          + extraEnv: [
          +     [0]: { + name: "GOMEMLIMIT", + value: "1400MiB" }
            ]
        }
      ~ resources: {
          ~ limits  : { ~ cpu: "100m" => "500m",  ~ memory: "512Mi" => "1536Mi" }
          ~ requests: { ~ cpu: "100m" => "10m",   ~ memory: "512Mi" => "256Mi"  }
        }
    }
```

`helm template` against chart 1.9.5 confirms the values land where intended — `GOMEMLIMIT` is appended after the chart's built-in `VANTAGE_*` env vars (no duplicate-env admission failure), and the `resources` block renders with no chart defaults merged back in.

`pre-commit run` (ruff format, ruff check, mypy, detect-secrets) passes on the changed file.

After deploy, on `data-production`:

```bash
# Restart count should stop advancing (was ~1 OOMKill per 60-70 min)
kubectl -n operations get pod vantage-kubernetes-agent-0 -w

# Peak should now settle below GOMEMLIMIT rather than pinning the ceiling
kubectl -n operations top pod vantage-kubernetes-agent-0
```

PromQL to confirm the sawtooth peaks come off the limit:

```promql
container_memory_working_set_bytes{cluster="data-production",namespace="operations",pod="vantage-kubernetes-agent-0",container="vantage-kubernetes-agent"}
```

### Additional Context

- **This deploy overwrites the live 768Mi hand-patch** on the `data-production` StatefulSet (to 1536Mi). That is the intended direction, but worth knowing that the running spec and this repo currently disagree — anyone diffing against the live pod rather than against the chart will see values that were never committed here.
- **The `resources` block is shared by all 12 EKS stacks**; there is no per-stack override for the vantage agent. The 11 low-pod-count clusters get a *lower* memory request (512Mi -> 256Mi) out of this, so aggregate reservation goes down, not up.
- **Unrelated drift will ride along on the next `data.Production` apply**, visible in the same preview and not introduced here: `starrocks-operator` `limits.memory 512Mi -> 1Gi` (from #5326, not yet applied to this stack) and the vantage chart version `1.9.3 -> 1.9.5` (Renovate). The chart bump also moves the agent image `1.3.2 -> 1.3.3`.
- **The real fleet-wide fix is still upstream of this**: dropping the dagster `ttlSecondsAfterFinished` from 24h to ~1–2h would take the pod count — and therefore every cluster-wide informer's memory on this cluster — down by roughly an order of magnitude. That is under different ownership and remains undone; this PR only makes the agent survive the current retention.
