### PR TITLE
feat(otel): scrape Alloy collectors' own otelcol_* metrics

### DIFF
--- a/src/ol_infrastructure/substructure/aws/eks/grafana.py
+++ b/src/ol_infrastructure/substructure/aws/eks/grafana.py
@@ -124,7 +124,7 @@ def setup_grafana(
         },
     ]
 
-    kubernetes.helm.v3.Release(
+    grafana_k8s_monitoring_release = kubernetes.helm.v3.Release(
         f"{cluster_name}-grafana-k8s-monitoring-helm-release",
         kubernetes.helm.v3.ReleaseArgs(
             name="grafana-k8s-monitoring",
@@ -411,4 +411,56 @@ def setup_grafana(
             },
         ),
         opts=ResourceOptions(provider=k8s_provider, delete_before_replace=True),
+    )
+
+    # The alloy-metrics collector already auto-discovers PodMonitor/ServiceMonitor
+    # CRDs cluster-wide via prometheusOperatorObjects (above), but nothing scrapes
+    # the collectors' own :12345/metrics endpoint. That endpoint carries the
+    # otelcol_* series (receiver/processor/exporter throughput, queue depth,
+    # refused/dropped spans) that are the only signal for whether the trace
+    # pipeline itself -- including the tail-sampling collector -- is healthy.
+    # Every collector Deployment/StatefulSet the chart creates (alloy-logs,
+    # alloy-metrics, alloy-receiver, alloy-singleton, and the tail-sampling
+    # collector, which the alloy-operator names plain "alloy") shares this
+    # http-metrics port name; verified against the live applications-production
+    # Service objects.
+    kubernetes.apiextensions.CustomResource(
+        f"{cluster_name}-grafana-alloy-collectors-pod-monitor",
+        api_version="monitoring.coreos.com/v1",
+        kind="PodMonitor",
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            name="alloy-collectors",
+            namespace="grafana",
+        ),
+        spec={
+            "selector": {
+                "matchExpressions": [
+                    {
+                        "key": "app.kubernetes.io/name",
+                        "operator": "In",
+                        "values": [
+                            "alloy",
+                            "alloy-logs",
+                            "alloy-metrics",
+                            "alloy-receiver",
+                            "alloy-singleton",
+                        ],
+                    },
+                ],
+            },
+            "namespaceSelector": {"matchNames": ["grafana"]},
+            "podMetricsEndpoints": [
+                {
+                    "port": "http-metrics",
+                    "path": "/metrics",
+                    "scheme": "http",
+                    "interval": "30s",
+                    "scrapeTimeout": "10s",
+                },
+            ],
+        },
+        opts=ResourceOptions(
+            provider=k8s_provider,
+            depends_on=[grafana_k8s_monitoring_release],
+        ),
     )

--- a/src/ol_infrastructure/substructure/aws/eks/grafana.py
+++ b/src/ol_infrastructure/substructure/aws/eks/grafana.py
@@ -124,7 +124,7 @@ def setup_grafana(
         },
     ]
 
-    grafana_k8s_monitoring_release = kubernetes.helm.v3.Release(
+    kubernetes.helm.v3.Release(
         f"{cluster_name}-grafana-k8s-monitoring-helm-release",
         kubernetes.helm.v3.ReleaseArgs(
             name="grafana-k8s-monitoring",
@@ -330,6 +330,54 @@ def setup_grafana(
                             }
                         ],
                     },
+                    # Chart-native self-monitoring for the Alloy collectors
+                    # themselves (feature-integrations' integrations.alloy).
+                    # Discovers every collector Deployment/StatefulSet the
+                    # chart creates (alloy-logs, alloy-metrics,
+                    # alloy-receiver, alloy-singleton, and the tail-sampling
+                    # collector, which the alloy-operator names plain
+                    # "alloy") on their shared http-metrics/12345 port --
+                    # verified against the live applications-production
+                    # Service objects and this chart version's default
+                    # port_name (also http-metrics).
+                    #
+                    # useDefaultAllowList (on by default) keeps this to the
+                    # chart's curated ~90-series set instead of scraping
+                    # every alloy_component_* and go runtime metric
+                    # unfiltered. includeMetrics extends that allowlist with
+                    # the tail-sampling processor's own counters, which
+                    # aren't in the default set: these are what would have
+                    # surfaced the tail-sampler sizing bug (traces evicted
+                    # before a decision was made, buffer occupancy far past
+                    # the old 100-trace cap) instead of it going unnoticed.
+                    "alloy": {
+                        "instances": [
+                            {
+                                "name": "alloy-collectors",
+                                "labelSelectors": {
+                                    "app.kubernetes.io/name": [
+                                        "alloy",
+                                        "alloy-logs",
+                                        "alloy-metrics",
+                                        "alloy-receiver",
+                                        "alloy-singleton",
+                                    ],
+                                },
+                                "namespaces": ["grafana"],
+                                "metrics": {
+                                    "tuning": {
+                                        "includeMetrics": [
+                                            "otelcol_processor_tail_sampling_count_traces_sampled",
+                                            "otelcol_processor_tail_sampling_sampling_trace_dropped_too_early",
+                                            "otelcol_processor_tail_sampling_new_trace_id_received",
+                                            "otelcol_processor_tail_sampling_sampling_traces_on_memory",
+                                            "otelcol_processor_tail_sampling_sampling_policy_evaluation_error",
+                                        ],
+                                    },
+                                },
+                            },
+                        ],
+                    },
                 },
                 # v4: kepler and kube-state-metrics moved to telemetryServices;
                 #     opencost moved here from clusterMetrics
@@ -411,56 +459,4 @@ def setup_grafana(
             },
         ),
         opts=ResourceOptions(provider=k8s_provider, delete_before_replace=True),
-    )
-
-    # The alloy-metrics collector already auto-discovers PodMonitor/ServiceMonitor
-    # CRDs cluster-wide via prometheusOperatorObjects (above), but nothing scrapes
-    # the collectors' own :12345/metrics endpoint. That endpoint carries the
-    # otelcol_* series (receiver/processor/exporter throughput, queue depth,
-    # refused/dropped spans) that are the only signal for whether the trace
-    # pipeline itself -- including the tail-sampling collector -- is healthy.
-    # Every collector Deployment/StatefulSet the chart creates (alloy-logs,
-    # alloy-metrics, alloy-receiver, alloy-singleton, and the tail-sampling
-    # collector, which the alloy-operator names plain "alloy") shares this
-    # http-metrics port name; verified against the live applications-production
-    # Service objects.
-    kubernetes.apiextensions.CustomResource(
-        f"{cluster_name}-grafana-alloy-collectors-pod-monitor",
-        api_version="monitoring.coreos.com/v1",
-        kind="PodMonitor",
-        metadata=kubernetes.meta.v1.ObjectMetaArgs(
-            name="alloy-collectors",
-            namespace="grafana",
-        ),
-        spec={
-            "selector": {
-                "matchExpressions": [
-                    {
-                        "key": "app.kubernetes.io/name",
-                        "operator": "In",
-                        "values": [
-                            "alloy",
-                            "alloy-logs",
-                            "alloy-metrics",
-                            "alloy-receiver",
-                            "alloy-singleton",
-                        ],
-                    },
-                ],
-            },
-            "namespaceSelector": {"matchNames": ["grafana"]},
-            "podMetricsEndpoints": [
-                {
-                    "port": "http-metrics",
-                    "path": "/metrics",
-                    "scheme": "http",
-                    "interval": "30s",
-                    "scrapeTimeout": "10s",
-                },
-            ],
-        },
-        opts=ResourceOptions(
-            provider=k8s_provider,
-            depends_on=[grafana_k8s_monitoring_release],
-        ),
     )


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
The OTel/Tempo trace pipeline itself is currently unmonitored: nothing scrapes the `:12345/metrics` endpoint that every Grafana Alloy collector in the `grafana` namespace exposes. That endpoint carries the `otelcol_*` series (receiver/processor/exporter accepted/refused/dropped counts, queue depth, batch send size) that would have surfaced the tail-sampling misconfiguration much earlier — the sampler was silently dropping ~98% of traces (`numTraces=100` / `expectedNewTracesPerSec=10` / `decisionWait=5s` against ~280 req/s from APISIX alone) before the sizing fix in `src/ol_infrastructure/substructure/aws/eks/grafana.py`.

**Update:** the initial version of this PR added a hand-rolled `PodMonitor` CRD. [Copilot's review](#) correctly flagged that this reimplements a chart-native feature — `k8s-monitoring` 4.3.2 ships `integrations.alloy.instances` (in the `feature-integrations` subchart) specifically for scraping Alloy's own metrics. Switched to that instead:

- One `integrations.alloy` instance selecting all 5 collector pods (`alloy`, `alloy-logs`, `alloy-metrics`, `alloy-receiver`, `alloy-singleton`) by `app.kubernetes.io/name`, in the `grafana` namespace.
- Its default `port_name` is already `http-metrics`, matching every collector Service's real port name — verified against the live `applications-production` Service objects.
- `useDefaultAllowList` (on by default) keeps the scrape to the chart's curated ~90-series allowlist instead of an unfiltered scrape of every `alloy_component_*` and Go runtime metric.
- That default allowlist does *not* include the tail-sampling processor's own counters — confirmed against upstream `opentelemetry-collector-contrib`'s `tailsamplingprocessor/documentation.md` — so `metrics.tuning.includeMetrics` extends it with the 5 that matter for this pipeline: `otelcol_processor_tail_sampling_count_traces_sampled`, `sampling_trace_dropped_too_early`, `new_trace_id_received`, `sampling_traces_on_memory`, `sampling_policy_evaluation_error`. Those are exactly what would have caught the sizing bug this project just fixed in production.

No custom CRD, no separate resource-ordering concerns — it's all Helm values on the existing release.

### How can this be tested?
```
pulumi preview --stack applications.QA
pulumi preview --stack applications.Production
```
Both show a single Helm release values update (the new `integrations.alloy` block); no other resources are touched.

Rendered locally with `helm template` against a values file mirroring the real release config (destinations, `collectors.alloy-metrics` preset) to confirm the generated River output has the expected `label_selectors`, `port_name = "http-metrics"`, and `keep_metrics` regex before pushing — no template errors, and the includeMetrics entries land in the final allowlist as expected.

After deploy, confirm scraping is working via a PromQL query against Grafana Cloud Prometheus for `otelcol_receiver_accepted_spans_total` or `otelcol_processor_tail_sampling_count_traces_sampled`, scoped to `cluster="applications-production"`.

### Additional Context
Part of the OpenTelemetry APM coverage project — this was the P0 gap identified during the 2026-08-10 tracing pipeline audit: the pipeline that silently dropped 98% of traces had zero observability of its own health.
