### PR TITLE
fix(rds): keep the blue/green deletion-protection write off the preview path

### DIFF
--- a/src/ol_infrastructure/components/aws/database.py
+++ b/src/ol_infrastructure/components/aws/database.py
@@ -419,7 +419,10 @@ class OLAmazonDB(pulumi.ComponentResource):
             )
         ):
             db_instance_identifier = current_db_state.get("DBInstanceIdentifier")
-            turn_off_deletion_protection(db_instance_identifier)
+            turn_off_deletion_protection(
+                db_instance_identifier,
+                currently_protected=bool(current_db_state.get("DeletionProtection")),
+            )
             deletion_protection_for_primary = False
             custom_timeouts = pulumi.CustomTimeouts(
                 create=f"{db_config.blue_green_timeout_minutes}m",

--- a/src/ol_infrastructure/lib/aws/rds_helper.py
+++ b/src/ol_infrastructure/lib/aws/rds_helper.py
@@ -3,6 +3,7 @@ from enum import StrEnum, unique
 from functools import lru_cache
 
 import boto3
+import pulumi
 
 rds_client = boto3.client("rds")
 
@@ -119,15 +120,29 @@ def get_rds_instance(instance_name: str) -> dict[str, str]:
     return db_instance
 
 
-def turn_off_deletion_protection(db_identifier: str):
+def turn_off_deletion_protection(
+    db_identifier: str, *, currently_protected: bool = True
+):
     """Disable deletion protection for the specified RDS database instance.
+
+    ModifyDBInstance is a live, privileged write against the target database, so it is
+    skipped during a `pulumi preview` and when protection is already off. A preview that
+    performs this call fails outright wherever the worker lacks rds:ModifyDBInstance,
+    and under the preview-gated Concourse topology a failed preview means the promotion
+    gate is never opened and the environment cannot be deployed at all.
 
     :param db_identifier: The identifier of the RDS database instance.
     :type db_identifier: str
 
+    :param currently_protected: Whether the live instance currently has deletion
+        protection enabled, as reported by DescribeDBInstances.
+    :type currently_protected: bool
+
     :raises botocore.exceptions.ClientError: If the AWS API call fails or the instance
     does not exist.
     """
+    if pulumi.runtime.is_dry_run() or not currently_protected:
+        return
     try:
         rds_client.modify_db_instance(
             DBInstanceIdentifier=db_identifier,

--- a/tests/ol_infrastructure/lib/aws/test_rds_helper.py
+++ b/tests/ol_infrastructure/lib/aws/test_rds_helper.py
@@ -1,0 +1,52 @@
+"""The blue/green path disables deletion protection with a live ModifyDBInstance call.
+
+A `pulumi preview` that makes that call is a privileged write against the target
+database, and it fails outright wherever the worker role lacks rds:ModifyDBInstance.
+Under the preview-gated Concourse topology the preview is what opens the promotion gate,
+so that failure blocks the environment from deploying at all.
+"""
+
+import pytest
+
+from ol_infrastructure.lib.aws import rds_helper
+
+
+@pytest.fixture
+def recorded_calls(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        rds_helper.rds_client,
+        "modify_db_instance",
+        lambda **kwargs: calls.append(kwargs),
+    )
+    return calls
+
+
+def _set_dry_run(monkeypatch, *, dry_run: bool):
+    monkeypatch.setattr(rds_helper.pulumi.runtime, "is_dry_run", lambda: dry_run)
+
+
+def test_preview_makes_no_modify_call(recorded_calls, monkeypatch):
+    _set_dry_run(monkeypatch, dry_run=True)
+    rds_helper.turn_off_deletion_protection("edxapp-db-xpro-production")
+    assert recorded_calls == []
+
+
+def test_already_unprotected_makes_no_modify_call(recorded_calls, monkeypatch):
+    _set_dry_run(monkeypatch, dry_run=False)
+    rds_helper.turn_off_deletion_protection(
+        "edxapp-db-xpro-production", currently_protected=False
+    )
+    assert recorded_calls == []
+
+
+def test_update_disables_protection(recorded_calls, monkeypatch):
+    _set_dry_run(monkeypatch, dry_run=False)
+    rds_helper.turn_off_deletion_protection("edxapp-db-mitx-production")
+    assert recorded_calls == [
+        {
+            "DBInstanceIdentifier": "edxapp-db-mitx-production",
+            "ApplyImmediately": True,
+            "DeletionProtection": False,
+        }
+    ]


### PR DESCRIPTION
## What are the relevant tickets?

Discovered while sizing the cost of `topology='preview-gated'` (adopted in #5363). Tracked in the Concourse/Pulumi deploy pipeline reliability project.

## Description (What does this do?)

`preview-ol-infrastructure-edxapp-application.xpro-xpro-production` has failed on every run since the preview-gated topology went live this morning:

```
botocore.exceptions.ClientError: An error occurred (AccessDenied) when calling the
ModifyDBInstance operation: User: arn:aws:sts::610119931565:assumed-role/
concourse-instance-role-worker-infra-production-.../i-0b53... is not authorized to
perform: rds:ModifyDBInstance on resource:
arn:aws:rds:us-east-1:610119931565:db:edxapp-db-xpro-production
```

Under that topology the preview job is what opens the promotion gate, so a failing preview means **no gate is created and xpro production edxapp cannot be deployed at all**.

The offending call is `turn_off_deletion_protection`, made while the Pulumi program is being constructed — so it fires during `pulumi preview` exactly as it does during `pulumi up`. A preview should not mutate live infrastructure, and this one attempts to disable deletion protection on a production database.

This PR skips the call when it is either unsafe or pointless:

- **during a dry run** — a preview must not perform privileged writes, and the worker should not need `rds:ModifyDBInstance` merely to render a diff
- **when the live instance already reports protection disabled** — nothing to do

`deletion_protection_for_primary = False` still applies either way, so the preview keeps showing what an update would do.

### Why xpro production hits this every time

Production stack defaults set `enhanced_monitoring_interval: 60`, while the live `edxapp-db-xpro-production` instance has no monitoring role attached (`MonitoringRoleArn: null`). That makes `monitoring_role_arn_changed` permanently true, so the blue/green branch is entered on every run. The instance's deletion protection is *already* off, so the write was a guaranteed-failing no-op.

The other three production edxapp databases (mitx, mitx-staging, mitxonline) all have their monitoring role attached and were unaffected.

### Out of scope, tracked separately

- The worker role genuinely lacks `rds:ModifyDBInstance`, which still matters if a blue/green update ever runs against a *protected* instance. `rds:DeleteBlueGreenDeployment` is allowed, `rds:ModifyDBInstance` is not.
- `xpro.Production` has not applied a Pulumi update since 2026-02-23 and its preview now shows 28 pending changes (17 creates, 11 updates, including an AWS provider bump 7.20 → 7.40). Applying that is a deliberate human decision, not part of this fix.

## How can this be tested?

- `uv run pytest tests/ol_infrastructure/lib/aws/test_rds_helper.py` — three cases pinning the behaviour: no `ModifyDBInstance` during a dry run, none when protection is already off, and the call still made on a real update.
- Once merged, re-run `preview-ol-infrastructure-edxapp-application.xpro-xpro-production`; it should complete and open the gate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015tEdtMcuH3SwCepCCNgSAV