### PR TITLE
fix: stop Vault readonly creds failing PAM auth on IAM-auth RDS instances

### DIFF
--- a/src/ol_infrastructure/applications/keycloak/__main__.py
+++ b/src/ol_infrastructure/applications/keycloak/__main__.py
@@ -320,6 +320,12 @@ keycloak_db_config = OLPostgresDBConfig(
     db_name="keycloak",
     tags=aws_config.tags,
     use_blue_green=keycloak_config.get_bool("db_use_blue_green") or False,
+    # Vault-issued readonly credentials (e.g. the keycloak_ingest dlt asset)
+    # authenticate with a plain password, never an IAM token. RDS enforces
+    # IAM-token auth for any role granted rds_iam, so IAM DB auth must stay
+    # off here or those connections fail with "FATAL: PAM authentication
+    # failed".
+    enable_iam_auth=False,
     **rds_defaults,
 )
 keycloak_db = OLAmazonDB(keycloak_db_config)

--- a/src/ol_infrastructure/lib/vault.py
+++ b/src/ol_infrastructure/lib/vault.py
@@ -194,23 +194,6 @@ postgres_role_statements = {
                 """
             ),
             Template("""RESET ROLE;"""),
-            # Grant rds_iam so any user in this role can authenticate via AWS IAM
-            # on RDS instances that have IAM DB authentication enabled.
-            # The DO block is a no-op on non-RDS Postgres where the role doesn't exist.
-            Template(
-                """
-                DO
-                $$do$$
-                BEGIN
-                    IF EXISTS (
-                        SELECT FROM pg_catalog.pg_roles WHERE rolname = 'rds_iam'
-                    ) THEN
-                        GRANT rds_iam TO "read_only_role";
-                    END IF;
-                END
-                $$do$$;
-                """
-            ),
             # Create the read-only user and put it into the read-only-role
             Template(
                 """
@@ -245,6 +228,29 @@ postgres_role_statements = {
         "rollback": [],
     },
 }
+
+# Opt-in addition for postgres_role_statements["readonly"]["create"] on
+# instances where a consumer specifically authenticates via AWS IAM tokens
+# (e.g. rds-db:connect) rather than a Vault-issued password. On RDS Postgres,
+# once a role is a member of rds_iam, RDS enforces IAM-token auth for that
+# role and rejects plain password auth with "FATAL: PAM authentication
+# failed" - so this must NOT be added to postgres_role_statements directly,
+# only appended to a per-app copy (see open_metadata/__main__.py) whose
+# readonly consumers actually use IAM tokens instead of Vault passwords.
+RDS_IAM_READONLY_GRANT_STATEMENT = Template(
+    """
+    DO
+    $$do$$
+    BEGIN
+        IF EXISTS (
+            SELECT FROM pg_catalog.pg_roles WHERE rolname = 'rds_iam'
+        ) THEN
+            GRANT rds_iam TO "read_only_role";
+        END IF;
+    END
+    $$do$$;
+    """
+)
 
 mysql_role_statements = {
     "admin": {

--- a/src/ol_infrastructure/lib/vault.py
+++ b/src/ol_infrastructure/lib/vault.py
@@ -194,6 +194,31 @@ postgres_role_statements = {
                 """
             ),
             Template("""RESET ROLE;"""),
+            # Self-healing cleanup: earlier versions of this role unconditionally
+            # granted rds_iam here, and that membership is persisted on
+            # "read_only_role" in the database itself, not in this statement list -
+            # removing the old GRANT from creation_statements does not retroactively
+            # revoke it. Since these statements run on every readonly credential
+            # issuance, this guarantees any stale grant is cleared out the next time
+            # anyone requests a readonly credential. REVOKE-ing a membership that
+            # doesn't exist is a no-op (NOTICE, not an error), so this is safe to run
+            # unconditionally. Opt-in consumers append
+            # RDS_IAM_READONLY_GRANT_STATEMENT after this in their own copy, so their
+            # GRANT still wins.
+            Template(
+                """
+                DO
+                $$do$$
+                BEGIN
+                    IF EXISTS (
+                        SELECT FROM pg_catalog.pg_roles WHERE rolname = 'rds_iam'
+                    ) THEN
+                        REVOKE rds_iam FROM "read_only_role";
+                    END IF;
+                END
+                $$do$$;
+                """
+            ),
             # Create the read-only user and put it into the read-only-role
             Template(
                 """
@@ -234,9 +259,11 @@ postgres_role_statements = {
 # (e.g. rds-db:connect) rather than a Vault-issued password. On RDS Postgres,
 # once a role is a member of rds_iam, RDS enforces IAM-token auth for that
 # role and rejects plain password auth with "FATAL: PAM authentication
-# failed" - so this must NOT be added to postgres_role_statements directly,
-# only appended to a per-app copy (see open_metadata/__main__.py) whose
-# readonly consumers actually use IAM tokens instead of Vault passwords.
+# failed" - so this must NOT be added to postgres_role_statements directly.
+# Use with_rds_iam_readonly_grant() below rather than appending it by hand:
+# postgres_role_statements.copy() is a shallow copy, so mutating
+# ["readonly"]["create"] in place (e.g. via .append()) would mutate the
+# shared defaults too.
 RDS_IAM_READONLY_GRANT_STATEMENT = Template(
     """
     DO
@@ -251,6 +278,28 @@ RDS_IAM_READONLY_GRANT_STATEMENT = Template(
     $$do$$;
     """
 )
+
+
+def with_rds_iam_readonly_grant(
+    role_statements: dict[str, dict[str, list[Template]]],
+) -> dict[str, dict[str, list[Template]]]:
+    """Return a copy of role_statements with readonly granted rds_iam.
+
+    Does not mutate the input. Only use this for a database whose readonly
+    consumers authenticate via AWS IAM tokens - see
+    RDS_IAM_READONLY_GRANT_STATEMENT above for why.
+    """
+    return {
+        **role_statements,
+        "readonly": {
+            **role_statements["readonly"],
+            "create": [
+                *role_statements["readonly"]["create"],
+                RDS_IAM_READONLY_GRANT_STATEMENT,
+            ],
+        },
+    }
+
 
 mysql_role_statements = {
     "admin": {


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
`keycloak_ingest`, a brand-new Dagster/dlt asset added on 2026-08-05 (the first-ever consumer of the `postgres-keycloak` Vault mount's `readonly` role), started failing production runs with:

```
psycopg2.OperationalError: connection to server at "keycloak-production...rds.amazonaws.com" ... failed:
FATAL:  PAM authentication failed for user "v-k8s-data-readonly-lPkpn56ySsV4uNXtTKOL-1786306990"
```

Root cause chain:
1. `keycloak-production` has `iam_database_authentication_enabled=True`, since `OLDBConfig.enable_iam_auth` defaults to `True` for all RDS instances (`src/ol_infrastructure/components/aws/database.py`). This makes AWS provision the built-in `rds_iam` role on the instance.
2. The shared `postgres_role_statements["readonly"]["create"]` statements in `src/ol_infrastructure/lib/vault.py` — used by every `OLVaultPostgresDatabaseConfig` consumer (keycloak, mit_learn, airbyte, jupyterhub, ocw_studio, dagster, xpro, micromasters, concourse, mitxonline, superset, gwarek, odl_video_service, ...) — unconditionally `GRANT rds_iam TO "read_only_role"` whenever `rds_iam` exists on the target instance. This was added in #4576 for OpenMetadata's (not-yet-built) IAM-token-based ingestion, but landed in the shared statements with no opt-out.
3. Once a role is a member of `rds_iam`, RDS Postgres enforces IAM-token auth for it and rejects plain password auth — exactly the `FATAL: PAM authentication failed` seen above.
4. Every actual consumer of the Vault `readonly` role (including `ol_dlt`'s Postgres source) authenticates with a plain Vault-issued password, never an IAM token.

So any newer RDS instance (IAM auth on by default since #<n/a> Dec 2025) with a password-based `readonly` consumer was exposed to this; `keycloak_ingest` was just the first to actually trip it.

Verified this isn't a red herring: RDS `describe-events` for `keycloak-production` shows no reboot/failover/parameter-group change in the days around the failure, and OpenMetadata's current ingestion connectors read credentials from a static sops-encrypted secrets file (`open_metadata_connector_secrets_path`), not the dynamic Vault `readonly` role — so nothing in production currently depends on the blanket grant.

Changes:
- `src/ol_infrastructure/lib/vault.py`: remove the automatic `GRANT rds_iam` from the shared readonly role statements. It's preserved as an exported, opt-in `RDS_IAM_READONLY_GRANT_STATEMENT` `Template` for whichever app's readonly consumers actually authenticate via IAM tokens, to be appended to a per-app copy of `postgres_role_statements` — the same pattern `open_metadata/__main__.py` already uses for its own extension-install statements.
- `src/ol_infrastructure/applications/keycloak/__main__.py`: set `enable_iam_auth=False` on `keycloak-production`'s `OLPostgresDBConfig`, since nothing there relies on IAM DB auth and its presence is what triggers the grant in the first place.

### Screenshots (if appropriate):

### How can this be tested?
- `uv run pre-commit run --all-files` and `uv run mypy` both pass on the changed files.
- `pulumi preview --stack Production --diff` against the keycloak app stack shows only two relevant, non-destructive in-place updates and nothing else touched by this change:
  - `aws:rds/instance:Instance` (`keycloak-production-postgres-instance`): `iamDatabaseAuthenticationEnabled: true => false`
  - `vault:database/secretBackendRole:SecretBackendRole` (`postgres-keycloak/roles/readonly`): one `Template` dropped from `creationStatements` (the `rds_iam` grant block)
- After merge + apply, re-run the `keycloak_ingest` Dagster asset and confirm the dlt pipeline connects successfully instead of hitting `FATAL: PAM authentication failed`.

### Additional Context
This is a systemic fix, not just a keycloak-specific one: any other app sharing `postgres_role_statements` whose RDS instance has IAM auth enabled (the default for anything created after Dec 2025) was carrying the same landmine for its `readonly` role. Worth a quick sweep of the other consumers (mit_learn, airbyte, jupyterhub, ocw_studio, dagster, xpro, micromasters, concourse, mitxonline, superset, gwarek, odl_video_service) to confirm none of them have since wired up a password-based `readonly` consumer against a newer, IAM-auth-enabled instance.