### PR TITLE
fix(keycloak): drop olapps access_code_lifespan from 30m to 5m

### DIFF
--- a/local-dev/infra/modules/keycloak.py
+++ b/local-dev/infra/modules/keycloak.py
@@ -53,7 +53,12 @@ def create_olapps_dev_realm(  # noqa: PLR0913
 
     realm = keycloak.Realm(
         "olapps",
-        access_code_lifespan="30m",
+        # Kept in sync with the production olapps realm (see the comment on
+        # this field in substructure/keycloak/olapps.py): Keycloak reuses
+        # this value as the `exp` claim on private_key_jwt client assertions
+        # sent to brokered IdPs, so it shouldn't be raised without checking
+        # that mirrored comment first.
+        access_code_lifespan="5m",
         access_code_lifespan_user_action="15m",
         attributes={"business_unit": "operations-local"},
         display_name="MIT Learn",

--- a/src/ol_infrastructure/substructure/keycloak/olapps.py
+++ b/src/ol_infrastructure/substructure/keycloak/olapps.py
@@ -41,7 +41,20 @@ def create_olapps_realm(  # noqa: PLR0913, PLR0915
     captcha_domain = "www.recaptcha.net"
     ol_apps_realm = keycloak.Realm(
         "olapps",
-        access_code_lifespan="30m",
+        # Labeled "Client Login Timeout" in the admin console's Tokens tab
+        # (Keycloak renamed accessCodeLifespan in the UI, the underlying API
+        # field is unchanged). This is the TTL for the intermediate OAuth
+        # `code` between issuance and its machine-to-machine redemption for
+        # a token at a token endpoint -- a server-to-server exchange with no
+        # user interaction, normally completing in well under a second. Per
+        # AbstractOAuth2IdentityProvider.generateToken(), Keycloak also
+        # reuses this same value as the `exp` claim on the private_key_jwt
+        # client assertions it sends to external OIDC IdPs when brokering
+        # login. Raising it re-widens that assertion's validity window and
+        # can cause some IdPs, which enforce a stricter freshness check on
+        # that claim, to reject the assertion with `invalid_client: Client
+        # assertion verification failed`.
+        access_code_lifespan="5m",
         access_code_lifespan_user_action="15m",
         attributes={
             "business_unit": f"operations-{env_name}",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Drops the `olapps` realm's `access_code_lifespan` from `30m` to `5m` in both production and local-dev, and documents what that setting actually controls, since its name and admin-console label are misleading relative to its full effect.

This field is labeled "Client Login Timeout" in the admin console's Tokens tab (Keycloak renamed `accessCodeLifespan` in the UI; the underlying API field is unchanged). It's the TTL for the intermediate OAuth `code` between issuance and its machine-to-machine redemption for a token at a token endpoint — a server-to-server exchange with no user interaction, normally completing in well under a second.

Keycloak also reuses this same realm-wide value as the `exp` claim on the `private_key_jwt` client assertions it sends to external OIDC identity providers when brokering login (`AbstractOAuth2IdentityProvider.generateToken()` in Keycloak's source). With it set to 30 minutes, that assertion's `exp` was ~30 minutes out. An identity provider we recently onboarded enforces a stricter freshness check on that claim (5 minutes) and rejected the assertion with:

```
invalid_client: Client assertion verification failed
```

This was already fixed live via the admin console for production. This PR:
1. Brings the production Pulumi config (`substructure/keycloak/olapps.py`) in line with the deployed state so it doesn't drift back to 30 minutes on the next `pulumi up`, and adds a comment explaining the dual-purpose behavior so it isn't reintroduced.
2. Fixes the same field in the local-dev realm (`local-dev/infra/modules/keycloak.py`), which had silently drifted from production at 30m even though that module's docstring says it mirrors production except for a specific, enumerated set of deviations that doesn't include this field — leaving it unfixed there would mean local OAuth flows never exercise the corrected timeout.

### How can this be tested?
- `ruff check`, `ruff format --check`, and `mypy` pass on both modified files (verified locally via `uv run`; the remaining `mypy` findings on both files are pre-existing, unrelated to this change).
- Since the value was already applied directly via the Keycloak admin console in production, a `pulumi preview` against the `Production` stack for `ol-substructure-keycloak` should show `~ 0 to update` for this field (no drift) once this PR is applied — confirming the code now matches the deployed state rather than trying to revert it to 30m.
- For local-dev, run `tilt up` (or however the local Keycloak realm is normally provisioned) and confirm the realm's Tokens tab shows "Client Login Timeout" as 5 minutes.

### Additional Context
Keycloak's own built-in help text for this field: "Max time a client has to finish the access token protocol. This should normally be 1 minute." — 5 minutes still comfortably exceeds that recommendation while giving IdP-side freshness checks more margin.