### PR TITLE
fix(witan): a write burst must degrade, not take the whole service down

### DIFF
--- a/src/ol_infrastructure/applications/witan/__main__.py
+++ b/src/ol_infrastructure/applications/witan/__main__.py
@@ -1027,9 +1027,16 @@ witan_virtualmcpserver = kubernetes.apiextensions.CustomResource(
 #
 # Only the two workloads whose containers this stack actually declares. The
 # ToolHive proxy runner Deployment is left alone: it showed ~20Mi against a
-# 512Mi limit, its resources are not settable through the MCPServer CRD (
-# `resourceOverrides` covers annotations and labels only), and adding a VPA to a
-# workload under no pressure is churn for its own sake.
+# 512Mi limit, its RESOURCES are not settable through the MCPServer CRD, and
+# adding a VPA to a workload under no pressure is churn for its own sake.
+#
+# Resources specifically, not the whole resource. `resourceOverrides
+# .proxyDeployment` carries annotations, labels, podTemplateMetadataOverrides,
+# `env` and imagePullSecrets — there is simply no resources/limits field among
+# them, and no podTemplateSpec either (the one on MCPServer patches the MCP
+# workload's StatefulSet, not this Deployment). The `env` half is load-bearing
+# elsewhere: WITAN_PROXY_HEALTH_ENV in mcp_servers.py rides it to stop a write
+# burst getting this same container killed by its own liveness probe.
 make_vpa(
     f"witan-vmcp-vpa-{stack_info.env_suffix}",
     namespace=NAMESPACE,

--- a/src/ol_infrastructure/applications/witan/mcp_servers.py
+++ b/src/ol_infrastructure/applications/witan/mcp_servers.py
@@ -127,6 +127,73 @@ WITAN_BACKEND_RESOURCES = {
 # clear of a council graph's export today and far below the indexer's 8Gi.
 TMP_SIZE_LIMIT = "2Gi"
 
+# ── Proxy-runner health checking ─────────────────────────────────────────────
+#
+# WHY THIS BLOCK EXISTS: without it, a burst of concurrent WRITES takes the
+# whole service down — readers included — and it is not a crash, a leak, or a
+# resource limit. Observed live in CI on 2026-08-12 at 16 concurrent
+# `memory_store` calls, and the chain runs entirely through health checking:
+#
+#   1. witan serialises writes on one graph at ~2s each, so the queue outlives
+#      any single request.
+#   2. The proxy runner's `/health` handler SYNCHRONOUSLY pings the MCP backend
+#      (upstream `pkg/healthcheck/healthcheck.go:CheckHealth`). A saturated
+#      backend does not answer, so `/health` hangs rather than returning.
+#   3. The kubelet's liveness probe on the proxy container — `/health`,
+#      `timeoutSeconds: 5`, `failureThreshold: 3` — kills the container.
+#      ("Container toolhive failed liveness probe, will be restarted", with
+#      `lastState.terminated{exitCode: 0, reason: Completed}`.)
+#   4. While it restarts, `mcp-witan-proxy:8080` has no ready endpoint, so the
+#      vMCP's own backend check gets `connect: connection refused`, marks the
+#      only backend unhealthy, and terminates EVERY session with "no backends
+#      returned capabilities". ~60s of total outage from a 30s write burst.
+#
+# ★ THE ROOT CAUSE IS TWO CONSTANTS THAT HAPPEN TO BE EQUAL. Upstream's
+# `DefaultPingerTimeout` is 5s (pkg/transport/proxy/transparent/pinger.go:26)
+# and the liveness probe the SAME repo generates uses `timeoutSeconds: 5`
+# (cmd/thv-operator/controllers/mcpserver_controller.go). The inner ping and the
+# outer probe expire together, so the probe can never win that race.
+#
+# ★ AND THE FIX IS FREE, BECAUSE A DEGRADED BACKEND STILL ANSWERS 200.
+# `healthcheck.go` maps StatusDegraded to `http.StatusOK` ("Still return 200 for
+# degraded state"); only StatusUnhealthy is 503. So the container is killed when
+# `/health` HANGS, never when it reports the backend degraded. Making the ping
+# give up well inside the probe's 5s budget keeps liveness green through exactly
+# the load that currently kills it, and costs nothing when the backend is fine.
+#
+# BOTH values are required and shipping only the first is worse than shipping
+# neither. The same pinger drives the proxy's own internal health loop, which
+# initiates SHUTDOWN after `FAILURE_THRESHOLD` consecutive failures at
+# `DefaultHealthCheckInterval` (10s). A shorter ping timeout makes that loop
+# fail sooner, so the threshold must rise to compensate — otherwise the proxy
+# trades a liveness kill for a self-inflicted shutdown that looks identical from
+# outside. 12 x 10s tolerates ~120s of backend saturation, against the ~60s
+# window actually observed. A genuinely dead backend is still noticed, and
+# restarting the PROXY was never going to revive it anyway — the backend is a
+# different pod.
+#
+# ★ INVALID VALUES ARE IGNORED SILENTLY. Upstream parses these with
+# `time.ParseDuration` / `strconv.Atoi` and falls back to the default with only
+# a WARN log, so a typo here reads as "configured" while changing nothing.
+# Verify against the running proxy, not against this file.
+#
+# Delivered through `spec.resourceOverrides.proxyDeployment.env`, which is the
+# ONLY lever available: the probes themselves are hardcoded by the operator
+# (`ProxyDeploymentOverrides` carries annotations, labels, podTemplateMetadata,
+# env and imagePullSecrets — no probe fields), and the `podTemplateSpec` used
+# above patches the MCP workload's StatefulSet, not this Deployment.
+#
+# Tracked as tk-a-write-burst-takes-the-whole-deployed-witan-dow-fc2ce7.
+# The underlying write throughput is a separate problem — see
+# tk-upstream-omnigraph-a-single-row-insert-costs-a-f-eeeae3. This change makes
+# saturation degrade instead of outage; it does not make writes faster.
+WITAN_PROXY_HEALTH_ENV = [
+    # Upstream default 5s, equal to the liveness probe's timeoutSeconds.
+    {"name": "TOOLHIVE_HEALTH_CHECK_PING_TIMEOUT", "value": "2s"},
+    # Upstream default 5, i.e. ~50s at the 10s check interval.
+    {"name": "TOOLHIVE_HEALTH_CHECK_FAILURE_THRESHOLD", "value": "12"},
+]
+
 
 class WitanMCPServers(NamedTuple):
     """Handles to the group and backend server CRs for depends_on wiring."""
@@ -308,6 +375,12 @@ def create_mcp_servers(  # noqa: PLR0913
             # Declared, but NOT what actually reaches the container — the
             # operator drops it. See WITAN_BACKEND_RESOURCES.
             "resources": WITAN_BACKEND_RESOURCES,
+            # Keeps a write burst from getting the proxy container killed by its
+            # own liveness probe, which is what turns backend saturation into a
+            # service-wide outage. See WITAN_PROXY_HEALTH_ENV.
+            "resourceOverrides": {
+                "proxyDeployment": {"env": WITAN_PROXY_HEALTH_ENV},
+            },
             # `volumes`/`volumeMounts` aren't first-class MCPServerSpec fields
             # beyond hostPath, so the actor-tokens Secret is mounted via the
             # documented escape hatch: a PodTemplateSpec merge-patch targeting


### PR DESCRIPTION
## What

Sets two health-check environment variables on the witan proxy-runner container, via `MCPServer.spec.resourceOverrides.proxyDeployment.env`:

| var | upstream default | set to |
|---|---|---|
| `TOOLHIVE_HEALTH_CHECK_PING_TIMEOUT` | `5s` | `2s` |
| `TOOLHIVE_HEALTH_CHECK_FAILURE_THRESHOLD` | `5` | `12` |

Purely additive. `pulumi preview --stack CI` renders exactly one change to the MCPServer:

```
~ kubernetes:toolhive.stacklok.dev/v1beta1:MCPServer: (update)
  ~ spec: {
      + resourceOverrides: {
          + proxyDeployment: {
              + env: [ TOOLHIVE_HEALTH_CHECK_PING_TIMEOUT=2s,
                       TOOLHIVE_HEALTH_CHECK_FAILURE_THRESHOLD=12 ]
```

## Why

Observed live in CI on 2026-08-12: **16 concurrent `memory_store` calls took witan down for everyone, readers included.** No OOMKill, no crash, no resource limit — the outage runs entirely through health checking.

1. witan serialises writes on one graph at ~2s each, so the queue outlives any single request.
2. The proxy runner's `/health` handler **synchronously pings the MCP backend** (`pkg/healthcheck/healthcheck.go:CheckHealth`). A saturated backend does not answer, so `/health` hangs rather than returning.
3. The kubelet's liveness probe on that container — `/health`, `timeoutSeconds: 5`, `failureThreshold: 3` — kills it:
   ```
   Liveness probe failed: ... context deadline exceeded
   Container toolhive failed liveness probe, will be restarted
   ```
   (`lastState.terminated{exitCode: 0, reason: Completed}`, `restartCount: 1`.)
4. While it restarts, `mcp-witan-proxy:8080` has no ready endpoint, so the vMCP's backend check gets `connect: connection refused`, marks its **only** backend unhealthy, and terminates every session with `no backends returned capabilities`. A separate burst of 12 fresh clients immediately after got `{404: 12}` "Session terminated" in 0.08s.

Recovery is automatic — 13:56:53 unhealthy → 13:57:53 healthy — so roughly 60s of outage from a 30s write burst.

### The root cause is two constants that happen to be equal

```
DefaultPingerTimeout = 5s     pkg/transport/proxy/transparent/pinger.go:26
liveness timeoutSeconds: 5    cmd/thv-operator/controllers/mcpserver_controller.go
```

Both generated by the same upstream repo. The inner ping and the outer probe expire together, so the probe can never win that race.

### And the fix is free, because a degraded backend still answers 200

```go
case StatusHealthy:   w.WriteHeader(http.StatusOK)
case StatusDegraded:  w.WriteHeader(http.StatusOK) // Still return 200 for degraded state
case StatusUnhealthy: w.WriteHeader(http.StatusServiceUnavailable)
```

Nothing in the chain needs the ping to *succeed* — only to **return**. A ping that gives up at 2s answers 200 well inside the probe's 5s budget, and costs nothing when the backend is healthy.

### Why both variables

The same pinger drives the proxy's own internal health loop, which initiates **shutdown** after `FAILURE_THRESHOLD` consecutive failures at the 10s check interval. A shorter ping timeout makes that loop fail sooner, so the threshold has to rise to compensate — otherwise the proxy trades a liveness kill for a self-inflicted shutdown that looks identical from outside. `12 × 10s` tolerates ~120s of saturation against the ~60s window actually observed, and a genuinely dead backend is still noticed (restarting the *proxy* was never going to revive it — the backend is a different pod).

## Why this shape and not a better probe

`spec.resourceOverrides.proxyDeployment.env` is the **only** lever. The probes are hardcoded by the operator: `ProxyDeploymentOverrides` carries annotations, labels, podTemplateMetadata, env and imagePullSecrets, and "probe" appears nowhere in `mcpserver_types.go`. The `podTemplateSpec` already used in this file patches the MCP workload's StatefulSet, not this Deployment.

Verified `resourceOverrides.proxyDeployment.env` exists in the **deployed** CRD (both `v1alpha1` and `v1beta1`), not just in upstream source.

## Scope — deliberately narrow

- **Not** raising the vMCP's `failureHandling.{healthCheckTimeout,unhealthyThreshold}`. Those are genuinely wired (`pkg/vmcp/cli/serve.go:270-294`) and would widen the window before step 4, but they are damping. If the proxy never dies, step 4 never happens. Keeping the diff to the cause makes the re-test attributable.
- **Not** a throughput fix. The ~0.25 writes/sec/graph ceiling is a separate problem (single-row inserts cost a full-table `FilteredRead`, ~3,095 S3 IOPS). This makes saturation *degrade* instead of *outage*.

## Testing

- `pre-commit run --files src/ol_infrastructure/applications/witan/mcp_servers.py` — all passed (ruff format, ruff check, mypy, detect-secrets).
- `pulumi preview --stack CI` — clean; the MCPServer diff is the `resourceOverrides` addition and nothing else.

**To verify after deploy**, re-run the burst and confirm the proxy is no longer killed:

```
WITAN_TARGET=ci python fullstack_probe.py --n 16 --mode write
kubectl -n witan get events --sort-by=.lastTimestamp   # expect NO liveness kill
kubectl -n witan logs deploy/witan-vmcp | rg 'backends":0'   # expect nothing
kubectl -n witan get pod <proxy-pod> -o json | jq '.status.containerStatuses[].restartCount'
```

Writes past the knee will still 502 at 30s — that is expected and separate. What must change is that the proxy survives and other users' sessions are untouched.

⚠ Upstream parses these with `time.ParseDuration` / `strconv.Atoi` and **falls back to the default with only a WARN log**, so a typo reads as "configured" while changing nothing. Verify against the running proxy, not the manifest.

## Follow-ups (filed, not in this PR)

- Upstream: `DefaultPingerTimeout` should be strictly less than the liveness `timeoutSeconds` the same repo generates; a liveness probe should not transitively depend on a downstream server; a single-backend vMCP should arguably degrade rather than evict.
- **Pre-existing drift noticed while previewing:** the Pulumi-managed CronJobs (`witan-break-glass`, `witan-ci-indexer`) still carry `@sha256:6248c88f…` while the MCPServer and its StatefulSet run `@sha256:3586ad96…`. Both come from the same `witan_image` in this program, so a previous deploy applied partially. Relevant to the CI indexer having failed every run recently — filed separately, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C87d3pjWuhxzRGeGp1UoR3
