### PR TITLE
fix(starrocks): grant SELECT on materialized views to app/readonly roles

### DIFF
--- a/src/ol_infrastructure/substructure/starrocks/__main__.py
+++ b/src/ol_infrastructure/substructure/starrocks/__main__.py
@@ -435,9 +435,11 @@ CREATE ROLE IF NOT EXISTS ol_business_analyst;
 
 GRANT USAGE ON CATALOG default_catalog TO ROLE readonly;
 GRANT SELECT ON ALL TABLES IN ALL DATABASES TO ROLE readonly;
+GRANT SELECT ON ALL MATERIALIZED VIEWS IN ALL DATABASES TO ROLE readonly;
 
 GRANT USAGE ON CATALOG default_catalog TO ROLE app;
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN ALL DATABASES TO ROLE app;
+GRANT SELECT ON ALL MATERIALIZED VIEWS IN ALL DATABASES TO ROLE app;
 
 GRANT cluster_admin TO ROLE admin;
 GRANT db_admin TO ROLE admin;
@@ -529,13 +531,20 @@ roles_setup_cmd = command.local.Command(
 
 # --- b2b_analytics database ---------------------------------------------
 # Dedicated database (default_catalog) backing the B2B self-serve analytics
-# StarRocks MVs (see hq#10006 / hq#10012). The `app` role already has
-# SELECT/INSERT/UPDATE/DELETE ON ALL TABLES IN ALL DATABASES from the base
-# roles SQL above, which covers dbt's write path once tables/MVs exist in
-# this database. What's missing — and StarRocks-specific — is that creating
-# new tables/materialized views requires its own CREATE TABLE / CREATE
-# MATERIALIZED VIEW privilege, granted at the database level, distinct from
-# the table-level DML privileges above.
+# StarRocks MVs (see hq#10006 / hq#10012). The `app` role has
+# SELECT/INSERT/UPDATE/DELETE ON ALL TABLES IN ALL DATABASES plus (see base
+# roles SQL above) SELECT ON ALL MATERIALIZED VIEWS IN ALL DATABASES, which
+# together cover dbt's write path and ol-analytics-api's read path once
+# tables/MVs exist in this database. MATERIALIZED VIEW is its own privilege
+# object type in StarRocks, distinct from TABLE for both DDL and DML/SELECT
+# grants -- an "ALL TABLES" grant alone does not grant SELECT on MVs (this
+# was the cause of ol-analytics-api's "Access denied ... SELECT privilege(s)
+# on MATERIALIZED VIEW" errors querying mv_b2b_program_funnel and friends
+# before the explicit MV grant was added above). What's missing beyond that
+# — and StarRocks-specific — is that creating new tables/materialized views
+# requires its own CREATE TABLE / CREATE MATERIALIZED VIEW privilege,
+# granted at the database level, distinct from the table-level DML
+# privileges above.
 _b2b_analytics_db_sql = """\
 CREATE DATABASE IF NOT EXISTS b2b_analytics;
 GRANT CREATE TABLE ON DATABASE b2b_analytics TO ROLE app;


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
`ol-analytics-api` pods in the `data-production` cluster were logging repeated errors on every request to the B2B analytics endpoints:

```
Access denied; you need (at least one of) the SELECT privilege(s) on MATERIALIZED VIEW mv_b2b_program_funnel for this operation. Please ask the admin to grant permission(s) or try activating existing roles using <set [default] role>. Current role(s): [app]. Inactivated role(s): NONE.
```

Same error for `mv_b2b_monthly_engagement_trend`, `mv_b2b_enrollment_completion_funnel`, and `mv_b2b_contract_utilization`.

`ol-analytics-api` authenticates to StarRocks with Vault's `database-starrocks` `app` dynamic role (`GRANT app TO USER`, per `OL_ANALYTICS_API_VAULT_ROLE`), which in turn maps to the native StarRocks `app` role defined in `substructure/starrocks/__main__.py`.

Root cause: StarRocks treats `MATERIALIZED VIEW` as a privilege object type distinct from `TABLE` — the same distinction the code already accounted for on the DDL side (`CREATE MATERIALIZED VIEW` needed its own grant separate from `CREATE TABLE`, see the `b2b_analytics` database setup a few lines below), but the existing `GRANT SELECT ... ON ALL TABLES IN ALL DATABASES TO ROLE app;` was mistakenly assumed (per the old comment) to also cover MV reads. It does not.

This PR adds the missing explicit grant:

```sql
GRANT SELECT ON ALL MATERIALIZED VIEWS IN ALL DATABASES TO ROLE app;
GRANT SELECT ON ALL MATERIALIZED VIEWS IN ALL DATABASES TO ROLE readonly;
```

`readonly` gets the same fix since it has the identical `ALL TABLES` grant and the identical gap (used by Superset et al.). Also corrects the stale comment on the `b2b_analytics` database block that had asserted the table grant already covered MVs.

### Screenshots (if appropriate):
N/A -- infrastructure/backend change, no UI.

### How can this be tested?
- `ruff check`/`ruff format`/`mypy`/pre-commit all pass locally.
- After `pulumi up` on the `starrocks` `lakehouse.Production` (and `lakehouse.QA`) stacks, the `GRANT` statements are idempotent (StarRocks no-ops re-granting an existing privilege), so this is a safe re-apply.
- Post-deploy validation: hit the `ol-analytics-api` B2B dashboard endpoints (or re-run the underlying queries against `mv_b2b_program_funnel`, `mv_b2b_monthly_engagement_trend`, `mv_b2b_enrollment_completion_funnel`, `mv_b2b_contract_utilization` as the Vault-issued `app` credential) and confirm the `Access denied ... MATERIALIZED VIEW` errors are gone from `ol-analytics-api` logs in `data-production`.

### Additional Context
This needs `pulumi up` against the `starrocks` project's `lakehouse.QA` and `lakehouse.Production` stacks to take effect -- the Pulumi program change alone does not touch the live cluster.

### Checklist:
- [ ] Run `pulumi up` on `ol_infrastructure/substructure/starrocks` for `lakehouse.QA`, verify no MV-privilege errors remain, then repeat for `lakehouse.Production`