### PR TITLE
fix(otel): set integrations.collector, or Alloy self-monitoring silently no-ops

### DIFF
--- a/src/ol_infrastructure/substructure/aws/eks/grafana.py
+++ b/src/ol_infrastructure/substructure/aws/eks/grafana.py
@@ -124,7 +124,7 @@ def setup_grafana(
         },
     ]
 
-    kubernetes.helm.v3.Release(
+    grafana_k8s_monitoring_release = kubernetes.helm.v3.Release(
         f"{cluster_name}-grafana-k8s-monitoring-helm-release",
         kubernetes.helm.v3.ReleaseArgs(
             name="grafana-k8s-monitoring",
@@ -459,4 +459,56 @@ def setup_grafana(
             },
         ),
         opts=ResourceOptions(provider=k8s_provider, delete_before_replace=True),
+    )
+
+    # The alloy-metrics collector already auto-discovers PodMonitor/ServiceMonitor
+    # CRDs cluster-wide via prometheusOperatorObjects (above), but nothing scrapes
+    # the collectors' own :12345/metrics endpoint. That endpoint carries the
+    # otelcol_* series (receiver/processor/exporter throughput, queue depth,
+    # refused/dropped spans) that are the only signal for whether the trace
+    # pipeline itself -- including the tail-sampling collector -- is healthy.
+    # Every collector Deployment/StatefulSet the chart creates (alloy-logs,
+    # alloy-metrics, alloy-receiver, alloy-singleton, and the tail-sampling
+    # collector, which the alloy-operator names plain "alloy") shares this
+    # http-metrics port name; verified against the live applications-production
+    # Service objects.
+    kubernetes.apiextensions.CustomResource(
+        f"{cluster_name}-grafana-alloy-collectors-pod-monitor",
+        api_version="monitoring.coreos.com/v1",
+        kind="PodMonitor",
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            name="alloy-collectors",
+            namespace="grafana",
+        ),
+        spec={
+            "selector": {
+                "matchExpressions": [
+                    {
+                        "key": "app.kubernetes.io/name",
+                        "operator": "In",
+                        "values": [
+                            "alloy",
+                            "alloy-logs",
+                            "alloy-metrics",
+                            "alloy-receiver",
+                            "alloy-singleton",
+                        ],
+                    },
+                ],
+            },
+            "namespaceSelector": {"matchNames": ["grafana"]},
+            "podMetricsEndpoints": [
+                {
+                    "port": "http-metrics",
+                    "path": "/metrics",
+                    "scheme": "http",
+                    "interval": "30s",
+                    "scrapeTimeout": "10s",
+                },
+            ],
+        },
+        opts=ResourceOptions(
+            provider=k8s_provider,
+            depends_on=[grafana_k8s_monitoring_release],
+        ),
     )

--- a/src/ol_infrastructure/substructure/aws/eks/grafana.py
+++ b/src/ol_infrastructure/substructure/aws/eks/grafana.py
@@ -124,7 +124,7 @@ def setup_grafana(
         },
     ]
 
-    grafana_k8s_monitoring_release = kubernetes.helm.v3.Release(
+    kubernetes.helm.v3.Release(
         f"{cluster_name}-grafana-k8s-monitoring-helm-release",
         kubernetes.helm.v3.ReleaseArgs(
             name="grafana-k8s-monitoring",
@@ -459,56 +459,4 @@ def setup_grafana(
             },
         ),
         opts=ResourceOptions(provider=k8s_provider, delete_before_replace=True),
-    )
-
-    # The alloy-metrics collector already auto-discovers PodMonitor/ServiceMonitor
-    # CRDs cluster-wide via prometheusOperatorObjects (above), but nothing scrapes
-    # the collectors' own :12345/metrics endpoint. That endpoint carries the
-    # otelcol_* series (receiver/processor/exporter throughput, queue depth,
-    # refused/dropped spans) that are the only signal for whether the trace
-    # pipeline itself -- including the tail-sampling collector -- is healthy.
-    # Every collector Deployment/StatefulSet the chart creates (alloy-logs,
-    # alloy-metrics, alloy-receiver, alloy-singleton, and the tail-sampling
-    # collector, which the alloy-operator names plain "alloy") shares this
-    # http-metrics port name; verified against the live applications-production
-    # Service objects.
-    kubernetes.apiextensions.CustomResource(
-        f"{cluster_name}-grafana-alloy-collectors-pod-monitor",
-        api_version="monitoring.coreos.com/v1",
-        kind="PodMonitor",
-        metadata=kubernetes.meta.v1.ObjectMetaArgs(
-            name="alloy-collectors",
-            namespace="grafana",
-        ),
-        spec={
-            "selector": {
-                "matchExpressions": [
-                    {
-                        "key": "app.kubernetes.io/name",
-                        "operator": "In",
-                        "values": [
-                            "alloy",
-                            "alloy-logs",
-                            "alloy-metrics",
-                            "alloy-receiver",
-                            "alloy-singleton",
-                        ],
-                    },
-                ],
-            },
-            "namespaceSelector": {"matchNames": ["grafana"]},
-            "podMetricsEndpoints": [
-                {
-                    "port": "http-metrics",
-                    "path": "/metrics",
-                    "scheme": "http",
-                    "interval": "30s",
-                    "scrapeTimeout": "10s",
-                },
-            ],
-        },
-        opts=ResourceOptions(
-            provider=k8s_provider,
-            depends_on=[grafana_k8s_monitoring_release],
-        ),
     )

--- a/src/ol_infrastructure/substructure/aws/eks/grafana.py
+++ b/src/ol_infrastructure/substructure/aws/eks/grafana.py
@@ -320,6 +320,17 @@ def setup_grafana(
                     },
                 },
                 "integrations": {
+                    # Without this, collectors.getCollectorForFeature falls
+                    # back to "use the only enabled collector" -- which is
+                    # ambiguous here (4 named collectors), so it resolves to
+                    # an empty collector name and the *entire* integrations
+                    # feature (this alloy integration AND the pre-existing
+                    # dcgm-exporter one) is silently dropped from every
+                    # collector's rendered config. Confirmed live: neither
+                    # integration appeared in any of the 4 collector
+                    # ConfigMaps in applications-production despite the Helm
+                    # release values matching desired state.
+                    "collector": "alloy-metrics",
                     "dcgm-exporter": {
                         "instances": [
                             {


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up to #5381.

### Description (What does it do?)
#5381 (merged, and already promoted through QA/Production per the deploy-gate flow) added `integrations.alloy` for scraping the Alloy collectors' own `otelcol_*` metrics, but didn't set the top-level `integrations.collector` field. That turns out to make the whole feature a silent no-op.

Traced through chart 4.3.2's `collectors.getCollectorForFeature` (`templates/collectors/_collector_helpers.tpl`), which resolves a feature's target collector as:
1. `Values.<featureKey>.collector`, if set
2. `features.<featureKey>.chooseCollector` — for `integrations` this is an empty template, always blank
3. the single enabled collector, **if there is exactly one**

We have four enabled collectors (`alloy-logs`, `alloy-metrics`, `alloy-receiver`, `alloy-singleton`), so step 3 never applies either. `$collectorName` resolves to `""`, which never matches any real collector name in `alloy-config.yaml`'s per-collector render loop — so the *entire* `integrations` feature (both the new alloy self-monitoring integration and the pre-existing `dcgm-exporter` one) is silently dropped from every collector's rendered config.

**Confirmed live in `applications-production`:** after #5381 deployed (`pulumi preview` showing 0 diff, i.e. Helm values matched desired state), none of the 4 collector ConfigMaps contained the `alloy_collectors` integration block. The chart's own self-reporting metric (`grafana_kubernetes_monitoring_feature_info{feature="integrations",...}`) stayed green regardless — it only checks that an integration is *configured*, not that it resolved to a valid collector, so there was no in-band signal this was broken.

Fix: set `integrations.collector = "alloy-metrics"` explicitly, matching the pattern already used for every other feature in this file (`clusterMetrics`, `costMetrics`, `annotationAutodiscovery`, `prometheusOperatorObjects` all set `collector` explicitly already — `integrations` was the one gap).

### How can this be tested?
```
pulumi preview --stack applications.QA
pulumi preview --stack applications.Production
```
Both show a single-field Helm values update: `integrations.collector: "alloy-metrics"` added.

Verified the actual fix by reconstructing the full production values (every section of `setup_grafana()`, not just the `integrations` block — I got burned once already by testing this feature in isolation) and rendering with `helm template` against a local copy of chart 4.3.2:
- **Without** this fix: zero occurrences of `alloy_integration_discovery` in any collector's rendered ConfigMap.
- **With** this fix: the block lands correctly in `grafana-k8s-monitoring-alloy-metrics`, with the expected `keep_metrics` regex including the tail-sampling metrics from #5381.

After deploy, confirm live via a PromQL query against Grafana Cloud Prometheus for `otelcol_receiver_accepted_spans_total{cluster="applications-production"}` — this is the actual proof the pipeline is scraping, since the chart's own "enabled" telemetry doesn't catch this failure mode.

### Additional Context
This also fixes the pre-existing `dcgm-exporter` integration, which was hitting the exact same silent-drop bug — unrelated to this project's scope but a one-line shared fix.
