### PR TITLE
feat(keycloak): log successful IdP logins for a per-IdP login dashboard

### DIFF
--- a/src/ol_infrastructure/applications/keycloak/__main__.py
+++ b/src/ol_infrastructure/applications/keycloak/__main__.py
@@ -548,6 +548,20 @@ keycloak_resource = kubernetes.apiextensions.CustomResource(
                 "value": "scim",
             },
             {"name": "spi-login--provider", "value": "ol-freemarker"},
+            # The jboss-logging event listener defaults successful-event
+            # logging to DEBUG (only failures log at WARN), so successful
+            # logins never reach our INFO-level server logs / Loki even with
+            # realm events enabled. This raises just that listener's
+            # success-event level to INFO so successful LOGIN and
+            # IDENTITY_PROVIDER_LOGIN events become visible for dashboarding,
+            # without touching any other logging category. This is
+            # server-wide (applies to every realm on this Keycloak instance)
+            # and increases log volume noticeably, since it now logs every
+            # successful auth-related event, not just logins.
+            {
+                "name": "spi-events-listener--jboss-logging--success-level",
+                "value": "info",
+            },
         ],
         "tracing": tracing_config,
         "hostname": {

--- a/src/ol_infrastructure/substructure/aws/eks/grafana.py
+++ b/src/ol_infrastructure/substructure/aws/eks/grafana.py
@@ -68,6 +68,45 @@ stage.match {
 """
 
 
+def _keycloak_events_log_filter_alloy_config() -> str:
+    """
+    Alloy River stages that drop noisy Keycloak success-event log lines
+    before they're shipped to Loki.
+
+    Keycloak's jboss-logging event listener is configured (see
+    applications/keycloak/__main__.py) with success-level=info so that
+    successful LOGIN and IDENTITY_PROVIDER_LOGIN events -- needed for a
+    per-IdP login dashboard on the olapps realm -- reach our logs. That
+    setting is all-or-nothing per Keycloak: it logs every successful event
+    type at INFO (CODE_TO_TOKEN, REFRESH_TOKEN, LOGOUT, REGISTER, etc.), not
+    just logins, across every realm on the shared instance (olapps,
+    ol-platform-engineering, ol-mit, master, ...). These two stages keep
+    only (LOGIN or IDENTITY_PROVIDER_LOGIN) events on the olapps realm and
+    drop the rest of that INFO-level volume before it leaves the node, so
+    Loki ingestion volume doesn't blow up.
+
+    Each stage independently re-checks for the "INFO  [org.keycloak.events]"
+    substring (rather than relying on the other stage's filtering) so that
+    WARN/ERROR-level events -- the pre-existing failure events, for every
+    realm -- never match either selector and always pass through untouched.
+    Per Alloy's stage.drop docs, expressing this OR-of-drop-conditions
+    requires two sequential drop stages rather than one compound selector.
+    """
+    return r"""
+stage.match {
+  selector = "{namespace=\"keycloak\", container=\"keycloak\"} |= \"INFO  [org.keycloak.events]\" != \"type=\\\"LOGIN\\\"\" != \"type=\\\"IDENTITY_PROVIDER_LOGIN\\\"\""
+  action = "drop"
+  drop_counter_reason = "keycloak_non_login_info_event"
+}
+
+stage.match {
+  selector = "{namespace=\"keycloak\", container=\"keycloak\"} |= \"INFO  [org.keycloak.events]\" != \"realmId=\\\"olapps\\\"\""
+  action = "drop"
+  drop_counter_reason = "keycloak_login_event_other_realm"
+}
+"""
+
+
 def setup_grafana(
     cluster_name: str,
     stack_info: StackInfo,
@@ -297,7 +336,8 @@ def setup_grafana(
                 "podLogsViaLoki": {
                     "enabled": True,
                     "collector": "alloy-logs",
-                    "extraLogProcessingStages": _apisix_cookie_metrics_alloy_config(),
+                    "extraLogProcessingStages": _apisix_cookie_metrics_alloy_config()
+                    + _keycloak_events_log_filter_alloy_config(),
                 },
                 "applicationObservability": {
                     "enabled": True,

--- a/src/ol_infrastructure/substructure/aws/eks/grafana.py
+++ b/src/ol_infrastructure/substructure/aws/eks/grafana.py
@@ -68,41 +68,89 @@ stage.match {
 """
 
 
-def _keycloak_events_log_filter_alloy_config() -> str:
+def _keycloak_olapps_idp_login_metrics_alloy_config() -> str:
     """
-    Alloy River stages that drop noisy Keycloak success-event log lines
-    before they're shipped to Loki.
+    Alloy River stages that turn olapps-realm brokered-login events into
+    per-IdP Prometheus counters, without shipping login records (or the PII
+    they carry) to Loki.
 
     Keycloak's jboss-logging event listener is configured (see
     applications/keycloak/__main__.py) with success-level=info so that
-    successful LOGIN and IDENTITY_PROVIDER_LOGIN events -- needed for a
-    per-IdP login dashboard on the olapps realm -- reach our logs. That
-    setting is all-or-nothing per Keycloak: it logs every successful event
-    type at INFO (CODE_TO_TOKEN, REFRESH_TOKEN, LOGOUT, REGISTER, etc.), not
-    just logins, across every realm on the shared instance (olapps,
-    ol-platform-engineering, ol-mit, master, ...). These two stages keep
-    only (LOGIN or IDENTITY_PROVIDER_LOGIN) events on the olapps realm and
-    drop the rest of that INFO-level volume before it leaves the node, so
-    Loki ingestion volume doesn't blow up.
+    successful LOGIN/IDENTITY_PROVIDER_LOGIN events reach our logs; that
+    setting is all-or-nothing per Keycloak, logging every successful event
+    type (CODE_TO_TOKEN, REFRESH_TOKEN, LOGOUT, REGISTER, ...) across every
+    realm on the shared instance, not just logins on olapps. Those events
+    also carry username and identity_provider_identity (the federated
+    email) -- fields the dashboard doesn't need, since it only wants a
+    per-IdP count.
 
-    Each stage independently re-checks for the "INFO  [org.keycloak.events]"
-    substring (rather than relying on the other stage's filtering) so that
-    WARN/ERROR-level events -- the pre-existing failure events, for every
-    realm -- never match either selector and always pass through untouched.
-    Per Alloy's stage.drop docs, expressing this OR-of-drop-conditions
-    requires two sequential drop stages rather than one compound selector.
+    So rather than filter down to the wanted events and ship them to Loki,
+    this pipeline extracts what's needed as metrics and ships no
+    olapps-brokered-login records to Loki at all:
+
+    1. Match INFO-level LOGIN/IDENTITY_PROVIDER_LOGIN events on olapps that
+       carry an identity_provider detail (i.e. were actually brokered
+       through an external IdP, not a direct username/password login), and
+       increment keycloak_olapps_idp_login_total{identity_provider=...}.
+    2. Unconditionally drop every remaining INFO-level org.keycloak.events
+       line -- covering both the events just counted (no login record, only
+       the counter, reaches Loki) and the rest of the noisy INFO volume
+       (CODE_TO_TOKEN, REFRESH_TOKEN, etc.) that success-level=info produces.
+    3. Match WARN-level LOGIN_ERROR/IDENTITY_PROVIDER_LOGIN_ERROR events on
+       olapps that carry an identity_provider detail, and increment
+       keycloak_olapps_idp_login_failure_total{identity_provider=...}. This
+       stage has no drop action: WARN/ERROR events are the pre-existing
+       failure logs already relied on for debugging (e.g. diagnosing a
+       broken IdP integration) and carry materially less PII than the
+       success events, so they keep flowing to Loki unchanged -- this stage
+       only adds a metric as a side effect.
+
+    Each stage's selector independently re-checks the INFO/WARN level
+    marker and the olapps realm, rather than relying on another stage
+    having already scoped the pipeline, so this is correct regardless of
+    stage ordering.
     """
     return r"""
 stage.match {
-  selector = "{namespace=\"keycloak\", container=\"keycloak\"} |= \"INFO  [org.keycloak.events]\" != \"type=\\\"LOGIN\\\"\" != \"type=\\\"IDENTITY_PROVIDER_LOGIN\\\"\""
-  action = "drop"
-  drop_counter_reason = "keycloak_non_login_info_event"
+  selector = "{namespace=\"keycloak\", container=\"keycloak\"} |= \"INFO  [org.keycloak.events]\" |= \"realmId=\\\"olapps\\\"\" |~ \"type=\\\"(LOGIN|IDENTITY_PROVIDER_LOGIN)\\\"\" |= \"identity_provider=\\\"\""
+  pipeline_name = "keycloak_olapps_login_success_metric"
+
+  stage.regex {
+    expression = `identity_provider="(?P<identity_provider>[^"]+)"`
+  }
+
+  stage.metrics {
+    metric.counter {
+      name        = "keycloak_olapps_idp_login_total"
+      description = "Successful olapps realm logins brokered through an external identity provider, by IdP alias"
+      source      = "identity_provider"
+      action      = "inc"
+    }
+  }
 }
 
 stage.match {
-  selector = "{namespace=\"keycloak\", container=\"keycloak\"} |= \"INFO  [org.keycloak.events]\" != \"realmId=\\\"olapps\\\"\""
+  selector = "{namespace=\"keycloak\", container=\"keycloak\"} |= \"INFO  [org.keycloak.events]\""
   action = "drop"
-  drop_counter_reason = "keycloak_login_event_other_realm"
+  drop_counter_reason = "keycloak_info_event"
+}
+
+stage.match {
+  selector = "{namespace=\"keycloak\", container=\"keycloak\"} |= \"WARN  [org.keycloak.events]\" |= \"realmId=\\\"olapps\\\"\" |~ \"type=\\\"(LOGIN_ERROR|IDENTITY_PROVIDER_LOGIN_ERROR)\\\"\" |= \"identity_provider=\\\"\""
+  pipeline_name = "keycloak_olapps_login_failure_metric"
+
+  stage.regex {
+    expression = `identity_provider="(?P<identity_provider>[^"]+)"`
+  }
+
+  stage.metrics {
+    metric.counter {
+      name        = "keycloak_olapps_idp_login_failure_total"
+      description = "Failed olapps realm logins brokered through an external identity provider, by IdP alias"
+      source      = "identity_provider"
+      action      = "inc"
+    }
+  }
 }
 """
 
@@ -337,7 +385,7 @@ def setup_grafana(
                     "enabled": True,
                     "collector": "alloy-logs",
                     "extraLogProcessingStages": _apisix_cookie_metrics_alloy_config()
-                    + _keycloak_events_log_filter_alloy_config(),
+                    + _keycloak_olapps_idp_login_metrics_alloy_config(),
                 },
                 "applicationObservability": {
                     "enabled": True,


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Adds the config needed to build a Grafana dashboard of logins per identity provider on the `olapps` realm, in two parts:

**1. `applications/keycloak/__main__.py`** — adds `spi-events-listener--jboss-logging--success-level=info` to the Keycloak CR's `additionalOptions`.

Keycloak's `jboss-logging` event listener defaults successful-event logging to `DEBUG` (confirmed from Keycloak's own source: `JBossLoggingEventListenerProviderFactory.init()` sets `successLevel` from config with a `"debug"` default) — only failures log at `WARN`/`ERROR`. That means even with realm events enabled, successful logins never reached our logs; only failures did. This raises just that listener's success-event level to `INFO`, so successful `LOGIN` and `IDENTITY_PROVIDER_LOGIN` events reach our log pipeline. Traced through Keycloak's `IdentityBrokerService.java`, a brokered login's event unconditionally carries an `identity_provider=<alias>` detail field — exactly what the dashboard needs to group by.

**2. `substructure/aws/eks/grafana.py`** — adds Alloy log-processing stages to `podLogsViaLoki.extraLogProcessingStages` that turn olapps-realm brokered-login events into Prometheus counters, without shipping login records (or the PII they carry) to Loki.

The `success-level` setting above is server-wide and all-or-nothing per Keycloak: it logs *every* successful event type (`CODE_TO_TOKEN`, `REFRESH_TOKEN`, `LOGOUT`, `REGISTER`, `CLIENT_LOGIN`, etc.), not just logins, across every realm sharing the instance (`olapps`, `ol-platform-engineering`, `ol-mit`, `master`, ...) — and those events carry `username`/`identity_provider_identity` (the federated email), which the dashboard doesn't need since it only wants a per-IdP count. Per review feedback on this PR, rather than filter down to the wanted events and still ship them to Loki, this pipeline:

1. Matches INFO-level `LOGIN`/`IDENTITY_PROVIDER_LOGIN` events on `olapps` carrying an `identity_provider` detail, extracts it, and increments `keycloak_olapps_idp_login_total{identity_provider=...}`.
2. Unconditionally drops every remaining INFO-level `org.keycloak.events` line — covering both the events just counted (no login record, only the counter, reaches Loki) and the rest of the noisy INFO volume.
3. Matches WARN-level `LOGIN_ERROR`/`IDENTITY_PROVIDER_LOGIN_ERROR` events on `olapps` carrying an `identity_provider` detail, and increments `keycloak_olapps_idp_login_failure_total{identity_provider=...}` — **without** dropping, since these already reach Loki today, carry materially less PII than the success events, and stay valuable for the debugging they're already used for (e.g. this session's own investigation into a broken IdP integration).

Each stage's selector independently re-checks the INFO/WARN level marker and the `olapps` realm rather than relying on another stage having already scoped the pipeline, so `WARN`/`ERROR` events for every other realm are structurally guaranteed to pass through untouched.

### How can this be tested?
Already fully validated end-to-end in the QA stack (both `applications/keycloak` and `substructure/aws/eks` `operations.QA`, scoped `pulumi up --target`/reviewed diffs to just the affected resources — no unrelated changes applied):

- A real browser login through Touchstone SSO on `olapps` incremented `keycloak_olapps_idp_login_total{identity_provider="touchstone-idp"}` to `1`, confirmed directly on Alloy's own `/metrics` endpoint.
- Zero occurrences of the logging-in user's email reached Loki after the fix, confirming no PII-bearing login record is shipped.
- A background service's `CLIENT_LOGIN` noise on the `ol-platform-engineering` realm, which fired like clockwork every 2-3 minutes for the 2 hours prior, produced **zero** occurrences in Loki immediately after the Alloy config hot-reloaded — confirming the drop stage is active, not just theoretically correct.
- A deliberately triggered `LOGIN_ERROR` (via a request with an unregistered `redirect_uri`) still reached Loki immediately, confirming `WARN`/`ERROR` events are untouched.
- `metric.counter` requires its own `action` attribute (`inc`/`add`), separate from `stage.match`'s `action` — missing it caused Alloy's config reload to fail with a misleading error pointing at an unrelated line in the chart's own generated config. Caught and fixed during QA validation; the deployed config now reloads cleanly across all Alloy pods.

For a reviewer: after merge, the same `pulumi up` (scoped to the `Keycloak` CR in `applications/keycloak` and the Grafana Helm `Release` in `substructure/aws/eks`) needs to be run against `Production` to complete the rollout — intentionally not done as part of this PR pending review.

### Additional Context
The `Production` preview for `applications/keycloak` shows a much larger diff than QA did for the same code — several RBAC (`ClusterRole`/`RoleBinding`/`Role`) resources with pending updates, and two RBAC resources (`RoleBinding`, `Role`) pending *deletion*. This appears to be pre-existing Keycloak-operator CRD/RBAC drift unrelated to this change (the operator manifests are fetched dynamically from `keycloak-k8s-resources` by pinned version), but it hasn't been investigated, and the production rollout for this PR should be scoped with `--target` to just the `Keycloak` CR resource to avoid touching it, same as was done in QA.

Separately, both the QA and Production `substructure/aws/eks` Grafana Helm releases carry ~4.5 months of unrelated drift (stale pre-v4-schema `integrations.alloy` config, superseded by `collectorCommon.alloy` back in March) that gets reconciled as a side effect of any update to that Helm release's `values`, since Helm/Pulumi diffs the full values object. This was investigated and applied in QA already; the same reconciliation will happen in Production when this change is rolled out there.

### Checklist:
- [ ] **In this order — do not swap.** After merge, first run `pulumi up` for `substructure/aws/eks` against `operations.Production` (the Grafana Helm release / Alloy metrics pipeline) and confirm it's live before proceeding.
- [ ] Only then run `pulumi up --target <Keycloak CR urn>` for `applications/keycloak` against `Production` to enable `success-level=info`.

Reversing this order enables the full unfiltered INFO-level event stream (every successful auth event, every realm on the instance, including PII fields) before the Alloy pipeline exists to bound and de-identify it, with no cap on how long that window lasts if the second deploy is delayed or fails.
