### PR TITLE
fix(dagster): give run workers a PriorityClass so the daemon is never starved of scheduling capacity

### DIFF
--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -1186,6 +1186,34 @@ for location in code_locations:
 
     deployments.append(deployment)
 
+# Referenced by run_launcher.config.run_k8s_config.pod_spec_config in
+# dagster_instance.yaml -- see the rationale there. A pod naming a
+# nonexistent PriorityClass is rejected outright, so this has to exist before
+# the instance ConfigMap that points at it (hence the Helm release's
+# depends_on below).
+#
+# The value is negative deliberately: run workers rank below every priority-0
+# pod in the cluster, not just the ones in this namespace. That is broader
+# than the incident strictly requires, but these pods have already starved
+# StarRocks FE out of the core nodegroup for 5 days (#5183), so ranking batch
+# work below anything long-lived is the designation we want. preemption_policy
+# Never keeps the relationship one-directional -- run workers queue for
+# capacity, they never evict anything themselves.
+dagster_run_priority_class = kubernetes.scheduling.v1.PriorityClass(
+    f"dagster-run-priority-class-{stack_info.env_suffix}",
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        name="dagster-run",
+        labels=k8s_global_labels.model_dump(),
+    ),
+    value=-100,
+    preemption_policy="Never",
+    global_default=False,
+    description=(
+        "Dagster run workers: preemptible batch work that ranks below all "
+        "control-plane pods."
+    ),
+)
+
 # Custom Dagster instance ConfigMap with dynamic credentials support
 # Note: We create this before the Helm release so it gets proper ownership
 dagster_instance_yaml = (
@@ -1452,6 +1480,7 @@ dagster_helm_release = kubernetes.helm.v3.Release(
             dagster_static_secrets,
             dagster_dbt_secrets,
             dagster_auth_binding,
+            dagster_run_priority_class,
         ]
     ),
 )

--- a/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
+++ b/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
@@ -39,6 +39,24 @@ run_launcher:
       pod_template_spec_metadata:
         annotations:
           karpenter.sh/do-not-disrupt: "true"
+      pod_spec_config:
+        # Rank run workers below every priority-0 pod in the cluster. The
+        # daemon is the highest-blast-radius pod in the namespace -- while it
+        # is down nothing schedules, no sensors, no run monitoring, no run
+        # timeouts -- yet at a shared priority of 0 it had the weakest claim
+        # on capacity: incident 2026-08-10 left it Pending for 25 minutes
+        # behind 178 run workers holding 90 CPU of requests, with the
+        # scheduler reporting "No preemption victims found" because it could
+        # not evict any of them.
+        #
+        # The chart pins at DAGSTER_CHART_VERSION renders no priorityClassName
+        # for the daemon (grep the templates -- only schedulerName exists), so
+        # raising the control plane is not expressible; lowering the batch
+        # workload is. Preemption is safe here because run_monitoring's
+        # max_resume_run_attempts and run_retries below already recover an
+        # interrupted run, and karpenter.sh/do-not-disrupt above only stops
+        # Karpenter consolidation, not kube-scheduler preemption.
+        priority_class_name: dagster-run
       job_spec_config:
         # Overrides dagster_k8s' DEFAULT_K8S_JOB_TTL_SECONDS_AFTER_FINISHED of
         # 24h. Retained run pods are pure API objects, but every cluster-wide


### PR DESCRIPTION
### What are the relevant tickets?

Closes https://github.com/mitodl/ol-infrastructure/issues/5366

### Description (What does it do?)

Every pod in the `dagster` namespace ran at scheduling priority `0` — the daemon, the webserver, pgbouncer, and all ~245 active `dagster-run` workers alike. The daemon is the highest-blast-radius pod in the namespace (while it is down nothing schedules: no sensors, no schedules, no run monitoring, no run timeouts) and yet had no stronger claim on capacity than the batch workload it exists to manage.

On 2026-08-10 that paged. The daemon requests 500m CPU / 1Gi and sat `Pending` for 25+ minutes:

```
Warning  FailedScheduling  3m49s (x5 over 25m)  default-scheduler
  0/17 nodes are available: 11 Insufficient cpu, 3 node(s) were unschedulable, 9 Insufficient memory.
  no new claims to deallocate, preemption: 0/17 nodes are available:
  14 No preemption victims found for incoming pod, 3 Preemption is not helpful for scheduling.
```

`No preemption victims found` is the operative line: 178 run workers were holding 90 CPU of requests and the scheduler could not evict a single one to seat a 500m daemon, because every candidate tied with it.

**Why not just raise the daemon.** Setting `dagsterDaemon.priorityClassName` in the Helm values is a no-op — the pinned chart ([`DAGSTER_CHART_VERSION = "1.13.17"`](https://github.com/mitodl/ol-infrastructure/blob/main/src/bridge/lib/versions.py#L43)) renders no `priorityClassName` field anywhere in its templates, only `schedulerName`. The value would be accepted and dropped. That is the exact failure mode of #5183, which tried the same thing for StarRocks FE against a CRD that pruned the field; the post-mortem is inline at [`starrocks/__main__.py#L125-L142`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/applications/starrocks/__main__.py#L125-L142).

So this **lowers the run workers** instead, through the run launcher's own supported config path, and the daemon then outranks them at its existing priority of `0`.

Two changes:

1. A cluster-scoped `PriorityClass` named `dagster-run` in the Dagster Pulumi project ([`applications/dagster/__main__.py`](https://github.com/mitodl/ol-infrastructure/blob/md/202608_dagster_priority_class/src/ol_infrastructure/applications/dagster/__main__.py)) — `value: -100`, `preemptionPolicy: Never`, `globalDefault: false`. It is a standalone resource rather than a Helm `extraManifests` entry, and the Helm release now `depends_on` it: a pod naming a nonexistent PriorityClass is rejected outright, and the instance ConfigMap that references it ships inside that release.

2. `priority_class_name: dagster-run` under `run_launcher.config.run_k8s_config.pod_spec_config` in [`dagster_instance.yaml`](https://github.com/mitodl/ol-infrastructure/blob/md/202608_dagster_priority_class/src/ol_infrastructure/applications/dagster/dagster_instance.yaml) — sibling to the `pod_template_spec_metadata` key already in use there for the Karpenter annotation.

Result: the daemon, webserver, and pgbouncer stay at priority `0` and outrank every run worker, so the scheduler finds preemption victims instead of reporting `No preemption victims found`.

**Why preemption is safe here.** [`run_monitoring.max_resume_run_attempts: 3`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/applications/dagster/dagster_instance.yaml#L76-L87) and `run_retries.max_retries: 3` are already configured, so a preempted run is resumed rather than lost. `karpenter.sh/do-not-disrupt` is a Karpenter-only annotation and does not block kube-scheduler preemption, so run workers remain evictable.

### How can this be tested?

`pulumi preview --stack QA` from `src/ol_infrastructure/applications/dagster` produces exactly the intended change:

```
 +  kubernetes:scheduling.k8s.io/v1:PriorityClass dagster-run-priority-class-qa create
 ~  kubernetes:helm.sh/v3:Release dagster-helm-release-qa update [diff: ~values]
```

(A third diff, `~ dagster-user-code-release-qa`, is local-only noise: image tags fall back to `latest` because `DAGSTER_K8S_IMAGE_TAG` is set by Concourse, not by a local preview.)

The field-pruning risk that sank #5183 was checked directly against the launcher's schema rather than assumed — `pod_spec_config` is validated against `V1PodSpec` via `k8s_snake_case_keys`, and the key survives:

```
$ uv run --no-project --with dagster-k8s python -c "
from dagster_k8s.job import UserDefinedDagsterK8sConfig
c = UserDefinedDagsterK8sConfig.from_dict({'pod_spec_config': {'priority_class_name': 'dagster-run'}})
print(c.pod_spec_config)"
{'priority_class_name': 'dagster-run'}
```

`pre-commit run` (ruff format, ruff check, mypy, yamllint, detect-secrets) passes on both changed files.

To validate after deploy, on the target cluster:

```bash
kubectl get priorityclass dagster-run
# run workers should report priority -100; daemon/webserver/pgbouncer stay at 0
kubectl get pods -n dagster -o custom-columns=NAME:.metadata.name,PRIORITY:.spec.priority
```

Then confirm a `FailedScheduling` event on the daemon under contention names preemption victims instead of `No preemption victims found`.

### Additional Context

Two judgement calls the issue flagged as open, resolved here — worth a look before approving:

**The value is negative, so the effect is cluster-wide.** Run workers now rank below every priority-`0` pod in *any* namespace, not just `dagster`. That is broader than the 2026-08-10 incident strictly requires. I took the issue's own reasoning as settling it: these pods have already starved StarRocks FE out of the core nodegroup for 5 days (#5183), so ranking Dagster batch work below anything long-lived is the designation we actually want. The narrower alternative — a positive class on the daemon applied via a Pulumi `DeploymentPatch` — would contest field ownership with the Helm release on every chart upgrade, which is a recurring maintenance cost in exchange for a narrower blast radius. Happy to flip this if reviewers disagree.

**No matching class for the webserver or pgbouncer.** This change only separates control plane from run workers; it does not let the daemon outrank its own namespace-mates. That can be a follow-up if we ever want it.

**Rollout.** `dagster_instance.yaml` is not env-specific, so CI, QA, and production all pick this up on their next apply. The issue asks for CI/QA first — that is a deploy-ordering matter, not something this diff can express, so please sequence the applies rather than letting all three go at once.

**Out of scope.** This makes the daemon un-starvable; it does not add capacity. The same incident had 67 run workers pending against a Karpenter NodePool pinned at its cap (`limits.cpu: "128"`, [`karpenter.py#L454-L457`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/substructure/aws/eks/karpenter.py#L454-L457), currently hardcoded and shared by every EKS cluster). Raising or parameterizing that limit is a separate issue.
