### PR TITLE
Add scm 1 and scm 2 course repos

### DIFF
--- a/src/ol_concourse/pipelines/container_images/jupyter_courses.py
+++ b/src/ol_concourse/pipelines/container_images/jupyter_courses.py
@@ -177,6 +177,16 @@ courses = [
         repo_uri="git@github.mit.edu:ol-notebooks/MITxT-6.3710.5x-2T2026.git",
         image_name="mitxt-6.3710.5x",
     ),
+    CourseImageInfo(
+        course_name="uai_source-uai.scm1",
+        repo_uri="git@github.mit.edu:ol-notebooks/UAI_SOURCE-UAI.SCM.1-1T2026.git",
+        image_name="uai_source-uai.scm1",
+    ),
+    CourseImageInfo(
+        course_name="uai_source-uai.scm2",
+        repo_uri="git@github.mit.edu:ol-notebooks/UAI_SOURCE-UAI.SCM.2-1T2026.git",
+        image_name="uai_source-uai.scm2",
+    ),
 ]
 
 # This infers the ECR url from the AWS account,

--- a/src/ol_infrastructure/applications/jupyterhub/__main__.py
+++ b/src/ol_infrastructure/applications/jupyterhub/__main__.py
@@ -220,6 +220,8 @@ COURSE_NAMES.extend(
             "se1",
             "haim1",
             "edm1",
+            "scm1",
+            "scm2",
         ]
     ]
 )

--- a/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
+++ b/src/ol_infrastructure/applications/jupyterhub/dynamicImageConfig.py
@@ -51,6 +51,8 @@ KNOWN_COURSES.extend(
             "se1",
             "haim1",
             "edm1",
+            "scm1",
+            "scm2",
         ]
     ]
 )


### PR DESCRIPTION
### Description (What does it do?)
Adds a few more course repos for UAI SCM

### How can this be tested?
Concourse jobs can be seen at https://cicd.odl.mit.edu/?search=team%3A%22infrastructure%22%20group%3A%22jupyter_notebook_docker_image_build%22
