### PR TITLE
fix(edxapp): stop the CMS celery HPA flapping between 1 and 20 replicas

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/k8s_autoscaling.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_autoscaling.py
@@ -259,6 +259,27 @@ def create_celery_autoscaling_resources(
         opts=pulumi.ResourceOptions(depends_on=[lms_high_mem_celery_deployment]),
     )
 
+    # This was the only celery ScaledObject with no behavior block, so it ran on the
+    # HPA defaults: a 300s scale-down window and an unbounded scale-up that doubles
+    # replicas every 15s. A bulk course publish drove the observed sequence
+    # 1 -> 4 -> 8 -> 16 -> 20 -> 1 -> 20 inside a couple of hours.
+    #
+    # Every one of those cycles is expensive out of proportion to the work it absorbs.
+    # The edxapp image is ~2GB and a cold pull was measured at 3m56s, so a pod
+    # summoned by a burst routinely becomes ready after the burst it was meant to
+    # serve has already drained. Karpenter then scales the node back out from under
+    # it -- one pod was evicted as "Underutilized" 8 minutes after being created.
+    #
+    # scaleUp at 300s: match the shared LMS worker. A CMS publish burst that is still
+    # queued five minutes later is a real backlog; anything shorter is absorbed by the
+    # replicas already running and would only buy an image pull that lands too late.
+    #
+    # scaleDown at 1800s with a 1-pod/300s policy: bleed replicas off gradually rather
+    # than dropping 20 -> 1 the moment the queue reads empty. Queue depth goes to zero
+    # as soon as tasks are picked up, not when they finish, so an empty
+    # edx.cms.core.default is a poor signal that the work is done -- and the git export
+    # tasks that dominate these bursts run 30-113s each. Bleeding down also keeps warm
+    # pods around for the next burst, which is what actually breaks the flapping cycle.
     cms_celery_scaledobject = kubernetes.apiextensions.CustomResource(
         f"ol-{stack_info.env_prefix}-edxapp-cms-celery-scaledobject-{stack_info.env_suffix}",
         api_version="keda.sh/v1alpha1",
@@ -277,6 +298,19 @@ def create_celery_autoscaling_resources(
             "cooldownPeriod": 300,
             "minReplicaCount": replicas_dict["celery"]["cms"]["min"],
             "maxReplicaCount": replicas_dict["celery"]["cms"]["max"],
+            "advanced": {
+                "horizontalPodAutoscalerConfig": {
+                    "behavior": {
+                        "scaleUp": {"stabilizationWindowSeconds": 300},
+                        "scaleDown": {
+                            "stabilizationWindowSeconds": 1800,
+                            "policies": [
+                                {"type": "Pods", "value": 1, "periodSeconds": 300},
+                            ],
+                        },
+                    }
+                }
+            },
             "triggers": [
                 {
                     "type": "redis",


### PR DESCRIPTION
### What are the relevant tickets?
N/A — arose from a production page:

> HPA `keda-hpa-mitxonline-production-edxapp-cms-celery-scaledobject` in namespace `mitxonline-openedx` in cluster `applications-production` has been at its maximum replica count for 15 minutes.

### Description (What does it do?)

Adds a `behavior` block to the CMS celery `ScaledObject`. It was the only one of the three celery ScaledObjects without one, so it ran on the HPA defaults — a 300s scale-down window and an unbounded scale-up that doubles replicas every 15s.

**What triggered the page.** A bulk publish of 40 localized course runs from a single org (`UAI_UAIMITOL` — ~10 courses × 4 locales: `es_ES`, `es_419`, `de_DE`, `pt_BR`), each republished 4–8 times in 45 minutes. Every Studio publish fans out into the usual task set plus `ol_openedx_git_auto_export.tasks.async_export_to_git`. That task's completion rate went from 1–10 per 5 min at baseline to **130–169 per 5 min**, with individual runs taking **28–113s** against a shared EFS volume. With `--concurrency=2` × 20 pods = 40 slots, the queue passed the ~200 needed to peg the HPA at `max: 20`.

**Why the defaults made it worse.** The HPA thrashed through `1 → 4 → 8 → 16 → 20 → 1 → 20` in about two hours. Each cycle costs more than the work it absorbs: the edxapp image is ~2GB and a cold pull was measured at **3m56s**, so a pod summoned by a burst tends to go ready only after that burst has drained. Karpenter then reclaims the node under it — one pod was evicted as `Underutilized` 8 minutes after creation.

Scale-down is the half that matters here. Redis list length drops to zero when tasks are **picked up**, not when they **finish**, so an empty `edx.cms.core.default` is a poor signal that the work is done — particularly when the tasks dominating these bursts run 30–113s each. Bleeding replicas off one at a time also leaves pods warm for the next burst, which is what actually breaks the cycle.

```python
"advanced": {
    "horizontalPodAutoscalerConfig": {
        "behavior": {
            "scaleUp": {"stabilizationWindowSeconds": 300},
            "scaleDown": {
                "stabilizationWindowSeconds": 1800,
                "policies": [
                    {"type": "Pods", "value": 1, "periodSeconds": 300},
                ],
            },
        }
    }
},
```

`scaleUp` at 300s matches the shared LMS worker. Anything shorter only buys an image pull that lands too late.

### How can this be tested?

`pulumi preview --stack mitxonline.Production` renders the change as an in-place `spec` update on the existing ScaledObject — **not** a replacement:

```
    ~ kubernetes:keda.sh/v1alpha1:ScaledObject: (update)
        [id=mitxonline-openedx/mitxonline-production-edxapp-cms-celery-scaledobject]
      ~ spec: {
          + advanced: {
              + horizontalPodAutoscalerConfig: {
                  + behavior: {
                      + scaleDown: {
                          + policies                  : [
                          +     [0]: {
                                  + periodSeconds: 300
                                  + type         : "Pods"
                                  + value        : 1
                                }
                            ]
                          + stabilizationWindowSeconds: 1800
                        }
                      + scaleUp  : {
                          + stabilizationWindowSeconds: 300
                        }
                    }
                }
            }
        }
```

`pre-commit run` passes clean (ruff format, ruff check, mypy).

After deploy, confirm the behavior landed and watch that scale-down is gradual rather than a cliff:

```bash
kubectl -n mitxonline-openedx get hpa \
  keda-hpa-mitxonline-production-edxapp-cms-celery-scaledobject \
  -o jsonpath='{.spec.behavior}' | jq

kubectl -n mitxonline-openedx describe hpa \
  keda-hpa-mitxonline-production-edxapp-cms-celery-scaledobject | tail -20
```

The `SuccessfulRescale` events should step down one pod at a time instead of jumping `20 → 1`.

### Additional Context

**This is a mitigation, not the root-cause fix.** It stops the flapping and the node churn; it does not remove the saturation. Two follow-ups, neither of which belongs in this repo:

1. **Give `async_export_to_git` its own queue** (the highest-value fix). It currently shares `edx.cms.core.default` with millisecond-scale publish tasks and starves them. This needs a routing change in `ol_openedx_git_auto_export` — either `@shared_task(queue=...)` or an explicit queue at the `apply_async` call site. It **cannot** be done from config or a plugin settings hook: edx-platform assigns `EXPLICIT_QUEUES` as a hardcoded dict literal in `cms/envs/production.py` at line 360, after both the `_YAML_TOKENS` merge (line ~68) and `add_plugins(...)` (line 333), so either route gets clobbered. Once that lands, the dedicated consumer deployment + ScaledObject come back here as a follow-up PR.

2. **Debounce/dedupe exports per course.** Exporting one course 8 times in 45 minutes is wasted work, and serializing per course would also remove the `.git/index.lock` collisions seen throughout the burst:

   ```
   fatal: Unable to create '.../.git/index.lock': File exists.
   GitExportError: Unable to commit changes
   ```

   Worth a look while in there: `clear_stale_git_lock()` runs unconditionally before `export_to_git()`. With all 20 pods sharing one RWX EFS volume (`efs-sc`, currently holding 3,609 export repos), concurrent exports of the same course can delete each other's *live* lock, not just stale ones. Note these failures are caught and the task still reports `succeeded`, so they are invisible to Celery metrics.

Also worth confirming with the UAI team whether that 4–8×-per-course republish loop was intentional; if an automated import was retrying, fixing that removes most of the load at the source.

**Blast radius:** `k8s_autoscaling.py` is shared, so this applies to the CMS celery worker on every edxapp stack (mitx, mitxonline, xpro, mitx-staging), which is intended — they all had the same gap.
