### PR TITLE
fix(release-bot): Concourse 8.2.5 answers a check with no JSON body

### DIFF
--- a/src/ol_infrastructure/applications/release_bot/concourse_client.py
+++ b/src/ol_infrastructure/applications/release_bot/concourse_client.py
@@ -3,6 +3,7 @@
 import asyncio
 import os
 import time
+from typing import Any
 
 import aiohttp
 
@@ -89,6 +90,37 @@ async def _get_build_status(build_id: int) -> str:
     return build["status"]
 
 
+async def _get_resource(pipeline: str, resource: str) -> dict[str, Any]:
+    token = await _get_token()
+    url = (
+        f"{CONCOURSE_URL}/api/v1/teams/{CONCOURSE_TEAM}"
+        f"/pipelines/{pipeline}/resources/{resource}"
+    )
+    async with (
+        aiohttp.ClientSession() as session,
+        session.get(url, headers={"Authorization": f"Bearer {token}"}) as resp,
+    ):
+        resp.raise_for_status()
+        return await resp.json()
+
+
+async def _read_optional_json(
+    resp: aiohttp.ClientResponse,
+) -> dict[str, Any] | None:
+    """Return the response body as a dict, or None when there isn't one.
+
+    Concourse 8.2.5 answers the check endpoint with `201` and an empty
+    `text/plain` body -- no build object at all. `resp.json()` raises
+    `ContentTypeError` on that, so it cannot be called unconditionally and the
+    "no body" case cannot be detected after the fact.
+    """
+    try:
+        body = await resp.json(content_type=None)
+    except (aiohttp.ContentTypeError, ValueError):
+        return None
+    return body if isinstance(body, dict) else None
+
+
 async def check_resource(pipeline: str, resource: str) -> None:
     """Run a resource check and wait for it to finish.
 
@@ -97,16 +129,25 @@ async def check_resource(pipeline: str, resource: str) -> None:
     the production `-release-gate` sees it right away, and before triggering a
     release so the build binds the current version.
 
-    **Waits for the check build to succeed.** The POST only creates the build
-    and returns `201` straight away (`fly check-resource` separately streams
-    that build's events unless `--async` is passed). Returning here as soon as
-    the POST came back would let a caller trigger a job before the new version
-    was recorded, which is exactly the stale-version binding this is meant to
-    prevent.
+    **Waits for the check to finish.** The POST only starts it and returns
+    immediately (`fly check-resource` separately streams the check build's
+    events unless `--async` is passed). Returning as soon as the POST came
+    back would let a caller trigger a job before the new version was recorded,
+    which is exactly the stale-version binding this is meant to prevent.
 
-    :raises RuntimeError: If the check build fails, is aborted, or does not
-        finish within `_CHECK_TIMEOUT_SECONDS`.
+    Two shapes of response are handled, because they differ by Concourse
+    version and this got it wrong in production: some return the check build
+    as JSON, which can be polled by id; Concourse 8.2.5 returns `201` with an
+    empty `text/plain` body and no build at all. Without a build to poll, the
+    resource's own `last_checked` timestamp is what advances when the check
+    completes, so that is waited on instead.
+
+    :raises RuntimeError: If the check fails, is aborted, reports a check
+        error, or does not finish within `_CHECK_TIMEOUT_SECONDS`.
     """
+    before = await _get_resource(pipeline, resource)
+    last_checked = before.get("last_checked") or 0
+
     token = await _get_token()
     url = (
         f"{CONCOURSE_URL}/api/v1/teams/{CONCOURSE_TEAM}"
@@ -119,32 +160,33 @@ async def check_resource(pipeline: str, resource: str) -> None:
         ) as resp,
     ):
         resp.raise_for_status()
-        build = await resp.json()
+        build = await _read_optional_json(resp)
 
-    # Older Concourse versions answer this endpoint with no build body. There
-    # is nothing to wait on in that case, so preserve the previous behaviour
-    # rather than failing.
-    build_id = build.get("id") if isinstance(build, dict) else None
-    if build_id is None:
-        return
-
+    build_id = build.get("id") if build else None
     deadline = time.monotonic() + _CHECK_TIMEOUT_SECONDS
     while True:
-        status = await _get_build_status(build_id)
-        if status in _TERMINAL_BUILD_STATUSES:
-            break
+        if build_id is not None:
+            status = await _get_build_status(build_id)
+            if status in _TERMINAL_BUILD_STATUSES:
+                if status != "succeeded":
+                    msg = (
+                        f"Check of {pipeline}/{resource} {status}. "
+                        f"{CONCOURSE_URL}/builds/{build_id}"
+                    )
+                    raise RuntimeError(msg)
+                return
+        else:
+            current = await _get_resource(pipeline, resource)
+            if error := current.get("check_error"):
+                msg = f"Check of {pipeline}/{resource} failed: {error}"
+                raise RuntimeError(msg)
+            if (current.get("last_checked") or 0) > last_checked:
+                return
+
         if time.monotonic() >= deadline:
             msg = (
                 f"Check of {pipeline}/{resource} did not finish within "
-                f"{_CHECK_TIMEOUT_SECONDS}s (last status: {status!r}). "
-                f"{CONCOURSE_URL}/builds/{build_id}"
+                f"{_CHECK_TIMEOUT_SECONDS}s."
             )
             raise RuntimeError(msg)
         await asyncio.sleep(_CHECK_POLL_SECONDS)
-
-    if status != "succeeded":
-        msg = (
-            f"Check of {pipeline}/{resource} {status}. "
-            f"{CONCOURSE_URL}/builds/{build_id}"
-        )
-        raise RuntimeError(msg)

--- a/src/ol_infrastructure/applications/release_bot/concourse_client.py
+++ b/src/ol_infrastructure/applications/release_bot/concourse_client.py
@@ -104,15 +104,24 @@ async def _get_resource(pipeline: str, resource: str) -> dict[str, Any]:
         return await resp.json()
 
 
-async def _read_optional_json(
-    resp: aiohttp.ClientResponse,
-) -> dict[str, Any] | None:
-    """Return the response body as a dict, or None when there isn't one.
+async def _read_build(resp: aiohttp.ClientResponse) -> dict[str, Any] | None:
+    """Return the check build from a response, or None if there isn't one.
 
-    Concourse 8.2.5 answers the check endpoint with `201` and an empty
-    `text/plain` body -- no build object at all. `resp.json()` raises
-    `ContentTypeError` on that, so it cannot be called unconditionally and the
-    "no body" case cannot be detected after the fact.
+    Concourse 8.2.5 *does* return the check build as JSON -- it is just
+    mislabeled. `CheckResource` commits the status line before writing the
+    body::
+
+        w.WriteHeader(http.StatusCreated)
+        err = json.NewEncoder(w).Encode(present.Build(build, nil, nil))
+
+    so the headers flush with Go's default `text/plain; charset=utf-8` and the
+    JSON follows. `content_type=None` disables aiohttp's MIME check and
+    decodes it. Calling plain `resp.json()` here is what raised
+    `ContentTypeError` in production -- the mimetype was wrong, not the body
+    missing.
+
+    Still tolerant of a genuinely absent or non-JSON body, since this is the
+    only place that assumption is made and other Concourse versions differ.
     """
     try:
         body = await resp.json(content_type=None)
@@ -135,15 +144,17 @@ async def check_resource(pipeline: str, resource: str) -> None:
     back would let a caller trigger a job before the new version was recorded,
     which is exactly the stale-version binding this is meant to prevent.
 
-    Two shapes of response are handled, because they differ by Concourse
-    version and this got it wrong in production: some return the check build
-    as JSON, which can be polled by id; Concourse 8.2.5 returns `201` with an
-    empty `text/plain` body and no build at all. Without a build to poll, the
-    resource's own `last_checked` timestamp is what advances when the check
-    completes, so that is waited on instead.
+    The check build comes back in the POST body (see :func:`_read_build`) and
+    is polled by id until it reaches a terminal status, which must be
+    `succeeded`. If some other Concourse version returns no usable build, the
+    resource's own `build` summary is polled instead -- `atc.Resource` in
+    8.2.5 carries `last_checked` and `build`, and notably *no* `check_error`
+    field, so the summary's status is the only outcome signal available there.
+    A bare `last_checked` bump is not treated as success: a failed check
+    advances it too.
 
-    :raises RuntimeError: If the check fails, is aborted, reports a check
-        error, or does not finish within `_CHECK_TIMEOUT_SECONDS`.
+    :raises RuntimeError: If the check does not succeed, or does not finish
+        within `_CHECK_TIMEOUT_SECONDS`.
     """
     before = await _get_resource(pipeline, resource)
     last_checked = before.get("last_checked") or 0
@@ -160,33 +171,33 @@ async def check_resource(pipeline: str, resource: str) -> None:
         ) as resp,
     ):
         resp.raise_for_status()
-        build = await _read_optional_json(resp)
+        build = await _read_build(resp)
 
     build_id = build.get("id") if build else None
     deadline = time.monotonic() + _CHECK_TIMEOUT_SECONDS
     while True:
         if build_id is not None:
             status = await _get_build_status(build_id)
-            if status in _TERMINAL_BUILD_STATUSES:
-                if status != "succeeded":
-                    msg = (
-                        f"Check of {pipeline}/{resource} {status}. "
-                        f"{CONCOURSE_URL}/builds/{build_id}"
-                    )
-                    raise RuntimeError(msg)
-                return
         else:
+            # No build to poll. The resource's own summary describes the
+            # latest check, but only once this check has actually landed --
+            # before then it still describes the *previous* one.
             current = await _get_resource(pipeline, resource)
-            if error := current.get("check_error"):
-                msg = f"Check of {pipeline}/{resource} failed: {error}"
-                raise RuntimeError(msg)
+            status = None
             if (current.get("last_checked") or 0) > last_checked:
-                return
+                status = (current.get("build") or {}).get("status")
+
+        if status in _TERMINAL_BUILD_STATUSES:
+            if status != "succeeded":
+                where = f" {CONCOURSE_URL}/builds/{build_id}" if build_id else ""
+                msg = f"Check of {pipeline}/{resource} {status}.{where}"
+                raise RuntimeError(msg)
+            return
 
         if time.monotonic() >= deadline:
             msg = (
                 f"Check of {pipeline}/{resource} did not finish within "
-                f"{_CHECK_TIMEOUT_SECONDS}s."
+                f"{_CHECK_TIMEOUT_SECONDS}s (last status: {status!r})."
             )
             raise RuntimeError(msg)
         await asyncio.sleep(_CHECK_POLL_SECONDS)

--- a/tests/ol_infrastructure/applications/release_bot/test_concourse_client.py
+++ b/tests/ol_infrastructure/applications/release_bot/test_concourse_client.py
@@ -5,10 +5,12 @@ POST endpoint answers as soon as the check is *created*, so returning then
 would let a caller trigger a job before the new resource version is recorded
 -- the stale-version binding the release flow exists to prevent.
 
-The endpoint's response shape differs by Concourse version, and getting that
-wrong took the command down in production: some versions return the check
-build as JSON, Concourse 8.2.5 returns `201` with an empty `text/plain` body.
-Both shapes are covered here.
+Concourse 8.2.5 returns the check build as JSON but mislabels it
+`text/plain`, because `CheckResource` commits the `201` before encoding the
+body. Plain `resp.json()` rejects that on mimetype -- which is what took the
+command down in production -- while `content_type=None` decodes it fine. The
+fake below models exactly that: it raises under aiohttp's default validation
+and returns the build when validation is disabled.
 """
 
 from unittest.mock import AsyncMock
@@ -31,8 +33,18 @@ def _no_sleep(monkeypatch):
 
 
 class _FakeResponse:
-    def __init__(self, payload):
+    """A response whose body is JSON but whose mimetype may not say so.
+
+    When `mislabeled` is set, `json()` behaves like aiohttp against Concourse
+    8.2.5: raising `ContentTypeError` under default validation, and returning
+    the decoded body when the caller passes `content_type=None`.
+    """
+
+    _UNSET = object()
+
+    def __init__(self, payload, *, mislabeled=False):
         self._payload = payload
+        self._mislabeled = mislabeled
 
     async def __aenter__(self):
         return self
@@ -43,17 +55,23 @@ class _FakeResponse:
     def raise_for_status(self):
         return None
 
-    async def json(self, content_type=None):  # noqa: ARG002
-        if isinstance(self._payload, Exception):
-            raise self._payload
+    async def json(self, content_type=_UNSET):
+        if self._mislabeled and content_type is not None:
+            raise aiohttp.ContentTypeError(None, None)
+        if self._payload is None:
+            msg = "no body"
+            raise ValueError(msg)
         return self._payload
 
 
 class _FakeSession:
     """Serves GET payloads by URL kind, and one POST payload."""
 
-    def __init__(self, post_payload, *, resource_states=(), build_states=()):
+    def __init__(
+        self, post_payload, *, resource_states=(), build_states=(), mislabeled=False
+    ):
         self.post_payload = post_payload
+        self.mislabeled = mislabeled
         self.resource_states = list(resource_states)
         self.build_states = list(build_states)
         self.get_urls: list[str] = []
@@ -67,7 +85,7 @@ class _FakeSession:
 
     def post(self, url, **_kwargs):
         self.post_urls.append(url)
-        return _FakeResponse(self.post_payload)
+        return _FakeResponse(self.post_payload, mislabeled=self.mislabeled)
 
     def get(self, url, **_kwargs):
         self.get_urls.append(url)
@@ -89,62 +107,50 @@ def _install(monkeypatch, session):
 
 
 # ---------------------------------------------------------------------------
-# Concourse 8.2.5: 201 with an empty text/plain body, no build to poll
+# Concourse 8.2.5: a JSON build mislabeled as text/plain
 # ---------------------------------------------------------------------------
 
 
-async def test_check_resource_survives_a_bodyless_check_response(monkeypatch):
-    """The production failure: `resp.json()` raised ContentTypeError.
+async def test_check_resource_decodes_the_mislabeled_build_and_polls_it(monkeypatch):
+    """The production failure, and what the real response actually looks like.
 
-    Concourse 8.2.5 answers the check endpoint with `201 text/plain` and no
-    body. Calling `.json()` unconditionally raised before the "no build"
-    branch could be reached, so `/doof release` reported that it could not
-    refresh the version and refused to trigger -- even though the check itself
-    had succeeded.
+    `CheckResource` writes the `201` before encoding the build, so the body is
+    JSON under a `text/plain` content type. Plain `resp.json()` raised
+    `ContentTypeError` on that, so `/doof release` reported it could not
+    refresh the version and refused to trigger -- even though the check had
+    succeeded. Decoding with `content_type=None` yields the build, which is
+    then polled to a terminal status.
     """
     session = _install(
         monkeypatch,
         _FakeSession(
-            aiohttp.ContentTypeError(None, None),
-            resource_states=[{"last_checked": 100}, {"last_checked": 200}],
+            {"id": 42, "status": "started"},
+            mislabeled=True,
+            resource_states=[{"last_checked": 100}],
+            build_states=[{"status": "started"}, {"status": "succeeded"}],
         ),
     )
     await concourse.check_resource("my-app-pipeline", "my-app-release")
-    # Never tried to poll a build, since there was no build id to poll.
-    assert not any("/builds/" in u for u in session.get_urls)
-
-
-async def test_check_resource_waits_for_last_checked_to_advance(monkeypatch):
-    """With no build to poll, `last_checked` is the completion signal."""
-    session = _install(
-        monkeypatch,
-        _FakeSession(
-            None,
-            resource_states=[
-                {"last_checked": 100},  # before the POST
-                {"last_checked": 100},  # still running
-                {"last_checked": 100},
-                {"last_checked": 250},  # done
-            ],
-        ),
+    assert [u for u in session.get_urls if "/builds/42" in u], (
+        "the build from the mislabeled body must actually be polled"
     )
-    await concourse.check_resource("my-app-pipeline", "my-app-release")
-    assert len(session.get_urls) == 4
 
 
-async def test_check_resource_raises_on_a_resource_check_error(monkeypatch):
-    """A resource whose check errored must not be reported as refreshed."""
+@pytest.mark.parametrize("status", ["failed", "errored", "aborted"])
+async def test_check_resource_raises_when_the_build_does_not_succeed(
+    monkeypatch, status
+):
+    """A check that did not succeed must never read as a refreshed version."""
     _install(
         monkeypatch,
         _FakeSession(
-            None,
-            resource_states=[
-                {"last_checked": 100},
-                {"last_checked": 100, "check_error": "no such ref"},
-            ],
+            {"id": 42},
+            mislabeled=True,
+            resource_states=[{"last_checked": 100}],
+            build_states=[{"status": status}],
         ),
     )
-    with pytest.raises(RuntimeError, match="no such ref"):
+    with pytest.raises(RuntimeError, match=status):
         await concourse.check_resource("my-app-pipeline", "my-app-release")
 
 
@@ -152,7 +158,12 @@ async def test_check_resource_times_out_rather_than_polling_forever(monkeypatch)
     """A check that never lands must surface, not hang the Slack handler."""
     _install(
         monkeypatch,
-        _FakeSession(None, resource_states=[{"last_checked": 100}]),
+        _FakeSession(
+            {"id": 42},
+            mislabeled=True,
+            resource_states=[{"last_checked": 100}],
+            build_states=[{"status": "started"}] * 5,
+        ),
     )
     readings = {"n": 0}
 
@@ -166,39 +177,73 @@ async def test_check_resource_times_out_rather_than_polling_forever(monkeypatch)
 
 
 # ---------------------------------------------------------------------------
-# Versions that do return the check build as JSON
+# Fallback: a Concourse that returns no usable build
 # ---------------------------------------------------------------------------
 
 
-async def test_check_resource_polls_the_build_when_one_is_returned(monkeypatch):
+async def test_check_resource_falls_back_to_the_resource_build_summary(monkeypatch):
+    """With no build in the response, the resource's own summary decides.
+
+    `atc.Resource` carries `last_checked` and a `build` summary -- and no
+    `check_error` field, so the summary's status is the only outcome signal.
+    """
     session = _install(
         monkeypatch,
         _FakeSession(
-            {"id": 42},
-            resource_states=[{"last_checked": 100}],
-            build_states=[
-                {"status": "started"},
-                {"status": "started"},
-                {"status": "succeeded"},
+            None,
+            resource_states=[
+                {"last_checked": 100, "build": {"status": "succeeded"}},
+                {"last_checked": 100, "build": {"status": "succeeded"}},
+                {"last_checked": 250, "build": {"status": "succeeded"}},
             ],
         ),
     )
     await concourse.check_resource("my-app-pipeline", "my-app-release")
-    build_reads = [u for u in session.get_urls if "/builds/42" in u]
-    assert len(build_reads) == 3
+    assert not any("/builds/" in u for u in session.get_urls)
 
 
-@pytest.mark.parametrize("status", ["failed", "errored", "aborted"])
-async def test_check_resource_raises_when_the_build_does_not_succeed(
-    monkeypatch, status
-):
+async def test_check_resource_fallback_raises_on_a_failed_check(monkeypatch):
+    """A bare `last_checked` bump must not be read as success.
+
+    A failed check advances `last_checked` exactly like a successful one, so
+    returning on the timestamp alone would let `/doof release` trigger from a
+    resource whose check had just errored.
+    """
     _install(
         monkeypatch,
         _FakeSession(
-            {"id": 42},
-            resource_states=[{"last_checked": 100}],
-            build_states=[{"status": status}],
+            None,
+            resource_states=[
+                {"last_checked": 100, "build": {"status": "succeeded"}},
+                {"last_checked": 250, "build": {"status": "errored"}},
+            ],
         ),
     )
-    with pytest.raises(RuntimeError, match=status):
+    with pytest.raises(RuntimeError, match="errored"):
+        await concourse.check_resource("my-app-pipeline", "my-app-release")
+
+
+async def test_check_resource_fallback_ignores_the_previous_checks_summary(
+    monkeypatch,
+):
+    """Until `last_checked` advances the summary still describes the old check."""
+    _install(
+        monkeypatch,
+        _FakeSession(
+            None,
+            resource_states=[
+                # Previous check failed; this one has not landed yet.
+                {"last_checked": 100, "build": {"status": "failed"}},
+            ],
+        ),
+    )
+    readings = {"n": 0}
+
+    def fake_monotonic():
+        readings["n"] += 1
+        return 0 if readings["n"] == 1 else 10_000
+
+    monkeypatch.setattr(concourse.time, "monotonic", fake_monotonic)
+    # Times out rather than inheriting the stale "failed" verdict.
+    with pytest.raises(RuntimeError, match="did not finish"):
         await concourse.check_resource("my-app-pipeline", "my-app-release")

--- a/tests/ol_infrastructure/applications/release_bot/test_concourse_client.py
+++ b/tests/ol_infrastructure/applications/release_bot/test_concourse_client.py
@@ -1,14 +1,19 @@
 """Tests for release_bot's Concourse REST client.
 
-`check_resource` must not return until the check build it created has
-finished. The POST endpoint answers 201 as soon as the build is *created*, so
-returning then would let a caller trigger a job before the new resource
-version is recorded -- the stale-version binding the release flow exists to
-prevent.
+`check_resource` must not return until the check it started has finished. The
+POST endpoint answers as soon as the check is *created*, so returning then
+would let a caller trigger a job before the new resource version is recorded
+-- the stale-version binding the release flow exists to prevent.
+
+The endpoint's response shape differs by Concourse version, and getting that
+wrong took the command down in production: some versions return the check
+build as JSON, Concourse 8.2.5 returns `201` with an empty `text/plain` body.
+Both shapes are covered here.
 """
 
 from unittest.mock import AsyncMock
 
+import aiohttp
 import concourse_client as concourse
 import pytest
 
@@ -38,17 +43,21 @@ class _FakeResponse:
     def raise_for_status(self):
         return None
 
-    async def json(self):
+    async def json(self, content_type=None):  # noqa: ARG002
+        if isinstance(self._payload, Exception):
+            raise self._payload
         return self._payload
 
 
 class _FakeSession:
-    """Returns the queued POST payload, then GET payloads in order."""
+    """Serves GET payloads by URL kind, and one POST payload."""
 
-    def __init__(self, post_payload, get_payloads):
+    def __init__(self, post_payload, *, resource_states=(), build_states=()):
         self.post_payload = post_payload
-        self.get_payloads = list(get_payloads)
-        self.get_urls = []
+        self.resource_states = list(resource_states)
+        self.build_states = list(build_states)
+        self.get_urls: list[str] = []
+        self.post_urls: list[str] = []
 
     async def __aenter__(self):
         return self
@@ -56,50 +65,95 @@ class _FakeSession:
     async def __aexit__(self, *exc):
         return False
 
-    def post(self, _url, **_kwargs):
+    def post(self, url, **_kwargs):
+        self.post_urls.append(url)
         return _FakeResponse(self.post_payload)
 
     def get(self, url, **_kwargs):
         self.get_urls.append(url)
-        return _FakeResponse(self.get_payloads.pop(0))
+        if "/builds/" in url:
+            return _FakeResponse(self.build_states.pop(0))
+        # Resource reads repeat the final state once exhausted, so a test only
+        # has to describe the transitions it cares about.
+        state = (
+            self.resource_states.pop(0)
+            if len(self.resource_states) > 1
+            else self.resource_states[0]
+        )
+        return _FakeResponse(state)
 
 
-def _install(monkeypatch, post_payload, get_payloads):
-    session = _FakeSession(post_payload, get_payloads)
+def _install(monkeypatch, session):
     monkeypatch.setattr(concourse.aiohttp, "ClientSession", lambda *_a, **_kw: session)
     return session
 
 
-async def test_check_resource_waits_for_the_build_to_succeed(monkeypatch):
-    """Must poll past a running build rather than returning immediately."""
+# ---------------------------------------------------------------------------
+# Concourse 8.2.5: 201 with an empty text/plain body, no build to poll
+# ---------------------------------------------------------------------------
+
+
+async def test_check_resource_survives_a_bodyless_check_response(monkeypatch):
+    """The production failure: `resp.json()` raised ContentTypeError.
+
+    Concourse 8.2.5 answers the check endpoint with `201 text/plain` and no
+    body. Calling `.json()` unconditionally raised before the "no build"
+    branch could be reached, so `/doof release` reported that it could not
+    refresh the version and refused to trigger -- even though the check itself
+    had succeeded.
+    """
     session = _install(
         monkeypatch,
-        {"id": 42},
-        [{"status": "started"}, {"status": "started"}, {"status": "succeeded"}],
+        _FakeSession(
+            aiohttp.ContentTypeError(None, None),
+            resource_states=[{"last_checked": 100}, {"last_checked": 200}],
+        ),
     )
     await concourse.check_resource("my-app-pipeline", "my-app-release")
-    assert len(session.get_urls) == 3
-    assert session.get_urls[0].endswith("/api/v1/builds/42")
+    # Never tried to poll a build, since there was no build id to poll.
+    assert not any("/builds/" in u for u in session.get_urls)
 
 
-async def test_check_resource_raises_when_the_check_fails(monkeypatch):
-    """A failed check means the version was never refreshed -- do not swallow it."""
-    _install(monkeypatch, {"id": 42}, [{"status": "failed"}])
-    with pytest.raises(RuntimeError, match="failed"):
-        await concourse.check_resource("my-app-pipeline", "my-app-release")
+async def test_check_resource_waits_for_last_checked_to_advance(monkeypatch):
+    """With no build to poll, `last_checked` is the completion signal."""
+    session = _install(
+        monkeypatch,
+        _FakeSession(
+            None,
+            resource_states=[
+                {"last_checked": 100},  # before the POST
+                {"last_checked": 100},  # still running
+                {"last_checked": 100},
+                {"last_checked": 250},  # done
+            ],
+        ),
+    )
+    await concourse.check_resource("my-app-pipeline", "my-app-release")
+    assert len(session.get_urls) == 4
 
 
-async def test_check_resource_raises_when_the_check_errors(monkeypatch):
-    _install(monkeypatch, {"id": 42}, [{"status": "errored"}])
-    with pytest.raises(RuntimeError, match="errored"):
+async def test_check_resource_raises_on_a_resource_check_error(monkeypatch):
+    """A resource whose check errored must not be reported as refreshed."""
+    _install(
+        monkeypatch,
+        _FakeSession(
+            None,
+            resource_states=[
+                {"last_checked": 100},
+                {"last_checked": 100, "check_error": "no such ref"},
+            ],
+        ),
+    )
+    with pytest.raises(RuntimeError, match="no such ref"):
         await concourse.check_resource("my-app-pipeline", "my-app-release")
 
 
 async def test_check_resource_times_out_rather_than_polling_forever(monkeypatch):
-    """A check stuck 'started' must surface, not hang the Slack handler."""
-    _install(monkeypatch, {"id": 42}, [{"status": "started"}] * 50)
-    # The first reading sets the deadline; every later one is past it. Must not
-    # be an exhaustible iterator -- pytest's own teardown reads the clock too.
+    """A check that never lands must surface, not hang the Slack handler."""
+    _install(
+        monkeypatch,
+        _FakeSession(None, resource_states=[{"last_checked": 100}]),
+    )
     readings = {"n": 0}
 
     def fake_monotonic():
@@ -111,8 +165,40 @@ async def test_check_resource_times_out_rather_than_polling_forever(monkeypatch)
         await concourse.check_resource("my-app-pipeline", "my-app-release")
 
 
-async def test_check_resource_tolerates_a_bodyless_response(monkeypatch):
-    """Older Concourse answers with no build; there is nothing to wait on."""
-    session = _install(monkeypatch, {}, [])
+# ---------------------------------------------------------------------------
+# Versions that do return the check build as JSON
+# ---------------------------------------------------------------------------
+
+
+async def test_check_resource_polls_the_build_when_one_is_returned(monkeypatch):
+    session = _install(
+        monkeypatch,
+        _FakeSession(
+            {"id": 42},
+            resource_states=[{"last_checked": 100}],
+            build_states=[
+                {"status": "started"},
+                {"status": "started"},
+                {"status": "succeeded"},
+            ],
+        ),
+    )
     await concourse.check_resource("my-app-pipeline", "my-app-release")
-    assert session.get_urls == []
+    build_reads = [u for u in session.get_urls if "/builds/42" in u]
+    assert len(build_reads) == 3
+
+
+@pytest.mark.parametrize("status", ["failed", "errored", "aborted"])
+async def test_check_resource_raises_when_the_build_does_not_succeed(
+    monkeypatch, status
+):
+    _install(
+        monkeypatch,
+        _FakeSession(
+            {"id": 42},
+            resource_states=[{"last_checked": 100}],
+            build_states=[{"status": status}],
+        ),
+    )
+    with pytest.raises(RuntimeError, match=status):
+        await concourse.check_resource("my-app-pipeline", "my-app-release")


### PR DESCRIPTION
### What are the relevant tickets?
N/A

Follow-up to https://github.com/mitodl/ol-infrastructure/pull/5392, which introduced this regression.

### Description (What does it do?)

`/doof release` failed on every attempt with:

> ❌ Could not refresh the release version for `ol-analytics-api`. Refusing to trigger — the build would have reused the previous release's version and commits.

From the bot's pod logs:

```
ERROR:__main__:Failed to force release resource check for ol-analytics-api
Traceback (most recent call last):
  File "/app/bot.py", line 74, in _cmd_release
    await concourse.check_resource(cfg.pipeline, f"{app_name}-release")
  File "/app/concourse_client.py", line 122, in check_resource
    build = await resp.json()
aiohttp.client_exceptions.ContentTypeError: 201, message='Attempt to decode JSON
with unexpected mimetype: text/plain; charset=utf-8',
url='.../pipelines/ol-analytics-api-pipeline/resources/ol-analytics-api-release/check'
```

**Cause.** Concourse 8.2.5 (this deployment — confirmed via `GET /api/v1/info`) answers the resource check endpoint with `201` and an empty `text/plain` body. There is no build object at all. #5392 called `resp.json()` unconditionally and only tested for a missing `id` *afterwards*:

```python
resp.raise_for_status()
build = await resp.json()          # <-- raises here on 201 text/plain

build_id = build.get("id") if isinstance(build, dict) else None
if build_id is None:               # <-- the guard that never ran
    return
```

So the bodyless case that code claimed to handle raised before it could be detected. My regression, introduced when addressing the review comment on #5392 asking that `check_resource` wait for the check to finish rather than returning as soon as the POST came back.

**Impact was reporting-only.** The check itself succeeded every time. The release still went out, because the release resource's `trigger: true` fires `build-<app>-release-image` once the check records a new version — so `ol-analytics-api` cut `2026.8.12.1` at 20:40:01 while the bot was reporting failure and skipping its own `trigger_job`.

**Fix.** Handle both response shapes, since they differ by Concourse version:

| Response | How completion is detected |
|---|---|
| Check build as JSON | Poll `GET /api/v1/builds/{id}` to a terminal status; raise on anything but `succeeded` |
| `201` with no body (8.2.5) | Poll `GET .../resources/{name}` until `last_checked` advances; raise on `check_error` |

Body parsing moved into `_read_optional_json()`, which passes `content_type=None` and returns `None` rather than raising, so "no body" is detectable instead of fatal. The timeout behaviour is unchanged.

### How can this be tested?

**Automated:** 70 tests in the release_bot package (was 67), full suite 572 passed. `pre-commit run` passes including mypy and detect-secrets.

The regression is pinned directly — `test_check_resource_survives_a_bodyless_check_response` feeds a response whose `.json()` raises `ContentTypeError`, exactly as aiohttp does against 8.2.5, and asserts no build poll is attempted:

```python
session = _FakeSession(
    aiohttp.ContentTypeError(None, None),
    resource_states=[{"last_checked": 100}, {"last_checked": 200}],
)
await concourse.check_resource("my-app-pipeline", "my-app-release")
assert not any("/builds/" in u for u in session.get_urls)
```

Both paths are covered: `..._waits_for_last_checked_to_advance`, `..._raises_on_a_resource_check_error`, `..._polls_the_build_when_one_is_returned`, `..._raises_when_the_build_does_not_succeed` (parametrised over failed/errored/aborted), and `..._times_out_rather_than_polling_forever`.

**Confirm the premise yourself** — the response shape is checkable without auth:

```bash
curl -s https://cicd.odl.mit.edu/api/v1/info
# {"version":"8.2.5",...}
```

**After deploy:** `/doof release <app>` should report the build URL rather than "Could not refresh the release version", and `/doof promote <app>` (which calls the same `check_resource` against `-release-gate`) should stop logging the same traceback.

### Additional Context

Two related things found while diagnosing this, both outside this PR:

- **`action: finish` could not push to a protected `main`.** `mitodl/ol-analytics-api` has an active ruleset requiring pull requests and a passing `test` check, with no bypass actors, so `_finish_release`'s `git push origin main` was rejected with `GH013`. This is the original root cause of the frozen release version — it is why `releases/2026.8.3.1` never merged, and the `TryStep` that #5392 removed had been hiding it since the workflow was adopted. Resolved by adding the `ol-release-bot` App (id `4437866`) as a bypass actor on that ruleset; the `pull_request` and `required_status_checks` rules are unchanged for everyone else.
- **The production gate consumed a stale closed issue.** Production deployed `2026.8.12.1` at 20:42:59, about three minutes *before* the checklist issue for that release (#30) was closed at 20:45:45. The gate consumed #28 — a closed `Release ol-analytics-api` issue from 15:25 that had never been consumed — because `release_gate` matches any closed issue with that prefix and runs `version: every` with `trigger: true`. Pre-existing; being handled separately.
