### PR TITLE
feat(grafana): per-IdP olapps login dashboard

### DIFF
--- a/src/ol_infrastructure/infrastructure/grafana_alerting/CLAUDE.md
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/CLAUDE.md
@@ -88,6 +88,9 @@ Rootly). That path is independent of Grafana and is managed in
 | `log_rules/heroku.py` | Heroku application log alert rules (invalid AWS keys, OCW Studio, Keycloak). |
 | `log_rules/mit_learn.py` | MIT Learn and MITx Online 5xx error rate alert rules. |
 | `log_rules/vault.py` | Vault secret-absent and auth-failure alert rules. |
+| `dashboards/` | Package. Grafana dashboards. |
+| `dashboards/base.py` | Mimir datasource UID, shared panel-builder helpers, folder creation, delegates to sub-modules. |
+| `dashboards/keycloak_olapps_idp_logins.py` | Per-identity-provider login counts (success + failure) for the olapps realm. |
 | `pingdom_checks.py` | Pingdom uptime checks via Pulumi dynamic provider. Runs in the production stack only. |
 | `CLAUDE.md` | This file. |
 
@@ -103,6 +106,7 @@ needed is passed as a parameter.
 alertmanager.create(grafana_secrets: dict, resource_opts: ResourceOptions)
 metric_rules.create(resource_opts: ResourceOptions)
 log_rules.create(resource_opts: ResourceOptions)
+dashboards.create(resource_opts: ResourceOptions)
 pingdom_checks.create(api_token: Input[str], integration_ids: list[int])
 ```
 
@@ -112,6 +116,14 @@ UID and a pre-bound `rd(expr)` helper from its package `base.py`:
 ```python
 # sub-module signature (metric_rules/* and log_rules/*)
 create(folder_uid: Input[str], rd: Callable[[str], list[RuleGroupRuleDataArgs]], resource_opts: ResourceOptions)
+```
+
+Within `dashboards/`, each sub-module receives the folder UID, the shared
+panel-builder helpers, and a `create_dashboard` helper from `base.py`:
+
+```python
+# sub-module signature (dashboards/*)
+create(folder_uid, timeseries_panel: Callable[..., dict], bar_gauge_panel: Callable[..., dict], create_dashboard: Callable[..., None], resource_opts: ResourceOptions)
 ```
 
 ---
@@ -149,6 +161,43 @@ Same pattern, but open the relevant file in `log_rules/` and use a LogQL
 expression. The expression must be metric-producing (use `count_over_time`,
 `rate`, `sum`, etc. with a threshold baked in). Bare log stream queries must
 be wrapped: `count_over_time({...} |= "pattern" [5m]) > 0`.
+
+---
+
+## Dashboards (dashboards/)
+
+Each Grafana dashboard is its own file, one dashboard per file -- not one
+file per product/platform. `metric_rules/` and `log_rules/` group several
+related *rules* into one file per category (`eks_general.py`, `heroku.py`);
+dashboards don't follow that grouping, because a single growing "keycloak.py"
+holding every current and future Keycloak dashboard just recreates the same
+"one file for everything in this topic" problem the `dashboards/` package
+(vs. a single `dashboards.py`) already exists to avoid.
+
+**Naming**: `<system>_<what-it-shows>.py`, e.g. `keycloak_olapps_idp_logins.py`.
+The `<system>` prefix (`keycloak`, in this case) is shared across every
+dashboard for that system so they sort and grep together, but each distinct
+dashboard -- a different concern, a different realm, whatever varies -- gets
+its own file under that same prefix rather than being added to an existing
+one. A second Keycloak dashboard about something unrelated (say, session
+counts) would be `keycloak_session_counts.py`, not a new function inside
+`keycloak_olapps_idp_logins.py`.
+
+### Adding a new dashboard
+
+1. Add `dashboards/<system>_<what_it_shows>.py` with a `_dashboard_json(...)`
+   builder and a `create(folder_uid, timeseries_panel, bar_gauge_panel,
+   create_dashboard, resource_opts)` function, matching the signature in
+   [Submodule API](#submodule-api) above.
+2. Use the `timeseries_panel`/`bar_gauge_panel` helpers passed in from
+   `base.py` (querying the shared Mimir datasource UID) rather than building
+   panel dicts by hand, so styling stays consistent across dashboards.
+3. Import the new sub-module in `base.py` and call its `create(...)` from
+   `base.create(...)`, passing the shared folder UID and helpers.
+4. All dashboards in this package currently share one folder (`"Keycloak"`,
+   uid `keycloak-dashboards`). If a new dashboard belongs to an unrelated
+   system, create a second folder in `base.py` rather than dropping it into
+   the Keycloak one.
 
 ---
 

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/CLAUDE.md
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/CLAUDE.md
@@ -89,8 +89,9 @@ Rootly). That path is independent of Grafana and is managed in
 | `log_rules/mit_learn.py` | MIT Learn and MITx Online 5xx error rate alert rules. |
 | `log_rules/vault.py` | Vault secret-absent and auth-failure alert rules. |
 | `dashboards/` | Package. Grafana dashboards. |
-| `dashboards/base.py` | Mimir datasource UID, shared panel-builder helpers, folder creation, delegates to sub-modules. |
-| `dashboards/keycloak_olapps_idp_logins.py` | Per-identity-provider login counts (success + failure) for the olapps realm. |
+| `dashboards/base.py` | Shared panel-builder helpers, folder creation, delegates to sub-modules. |
+| `dashboards/datasources.py` | Mimir/Loki datasource ref constants, importable directly by sub-modules without a circular import through `base.py`. |
+| `dashboards/keycloak_olapps_idp_logins.py` | Per-identity-provider login counts (success + failure) for the olapps realm, from Loki via LogQL. |
 | `pingdom_checks.py` | Pingdom uptime checks via Pulumi dynamic provider. Runs in the production stack only. |
 | `CLAUDE.md` | This file. |
 
@@ -190,8 +191,18 @@ counts) would be `keycloak_session_counts.py`, not a new function inside
    create_dashboard, resource_opts)` function, matching the signature in
    [Submodule API](#submodule-api) above.
 2. Use the `timeseries_panel`/`bar_gauge_panel` helpers passed in from
-   `base.py` (querying the shared Mimir datasource UID) rather than building
-   panel dicts by hand, so styling stays consistent across dashboards.
+   `base.py` rather than building panel dicts by hand, so styling stays
+   consistent across dashboards. They default to the shared Mimir datasource;
+   for a Loki-backed panel (LogQL, e.g. `count_over_time`), pass
+   `datasource_ref=LOKI_DATASOURCE_REF` (import it from `datasources.py`,
+   not `base.py`, to avoid a circular import). Prefer counting straight from
+   Loki over deriving a Prometheus counter via an Alloy `stage.metrics`
+   block: a `metric.counter` only exists once incremented, so a low-volume
+   counter's first-ever appearance is invisible to PromQL's increase() (no
+   prior sample to diff against), and it gets evicted and reset after any
+   gap longer than `max_idle_duration` -- both silently undercount. LogQL's
+   `count_over_time` reads directly from Loki's stored lines at query time:
+   no persistent counter state, so neither failure mode applies.
 3. Import the new sub-module in `base.py` and call its `create(...)` from
    `base.create(...)`, passing the shared folder UID and helpers.
 4. All dashboards in this package currently share one folder (`"Keycloak"`,

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/__main__.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/__main__.py
@@ -4,6 +4,7 @@ Bootstraps the Grafana provider and delegates to submodules:
   alertmanager  — contact points + notification policy (all stacks)
   metric_rules  — Prometheus/Mimir metric alert rule groups (all stacks)
   log_rules     — Loki log-based alert rule groups (all stacks)
+  dashboards    — Grafana dashboards (all stacks)
   pingdom_checks — Pingdom uptime checks via dynamic provider (production stack only)
 
 See CLAUDE.md in this directory for a full description of the architecture.
@@ -17,6 +18,7 @@ from pulumi import Output, ResourceOptions
 from bridge.secrets.sops import read_yaml_secrets
 from ol_infrastructure.infrastructure.grafana_alerting import (
     alertmanager,
+    dashboards,
     log_rules,
     metric_rules,
     pingdom_checks,
@@ -41,6 +43,7 @@ resource_opts = ResourceOptions(provider=grafana_provider)
 alertmanager.create(grafana_secrets, resource_opts)
 metric_rules.create(resource_opts)
 log_rules.create(resource_opts)
+dashboards.create(resource_opts)
 
 # Pingdom checks are account-wide — only create from the production stack.
 if is_production:

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/dashboards/__init__.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/dashboards/__init__.py
@@ -1,0 +1,3 @@
+from ol_infrastructure.infrastructure.grafana_alerting.dashboards.base import create
+
+__all__ = ["create"]

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/dashboards/base.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/dashboards/base.py
@@ -1,0 +1,138 @@
+"""Grafana dashboards.
+
+Every Grafana Cloud stack provisions its own Mimir datasource under the same
+generic UID (see metric_rules/base.py), so a dashboard defined here renders
+each stack's own data once deployed there -- no per-environment branching
+needed.
+
+Sub-modules
+-----------
+  keycloak_olapps_idp_logins — Per-identity-provider login counts for the
+    olapps realm.
+"""
+
+import json
+from typing import Any
+
+from pulumi import ResourceOptions
+from pulumiverse_grafana.oss.dashboard import Dashboard
+from pulumiverse_grafana.oss.folder import Folder
+
+from ol_infrastructure.infrastructure.grafana_alerting.dashboards import (
+    keycloak_olapps_idp_logins,
+)
+
+# Every Grafana Cloud stack provisions its own Mimir datasource with this same
+# generic UID. The per-stack slug (e.g. grafanacloud-mitolci-prom) is only the
+# datasource *name*; referencing it as a UID fails with "data source not found".
+_MIMIR_DATASOURCE_UID = "grafanacloud-prom"
+_DATASOURCE_REF = {"type": "prometheus", "uid": _MIMIR_DATASOURCE_UID}
+
+
+def _timeseries_panel(
+    *, title: str, expr: str, grid_pos: dict[str, Any]
+) -> dict[str, Any]:
+    """Build a time-series panel model querying the shared Mimir datasource."""
+    return {
+        "title": title,
+        "type": "timeseries",
+        "datasource": _DATASOURCE_REF,
+        "gridPos": grid_pos,
+        "fieldConfig": {
+            "defaults": {
+                "color": {"mode": "palette-classic"},
+                "custom": {
+                    "drawStyle": "line",
+                    "lineWidth": 2,
+                    "fillOpacity": 10,
+                    "pointSize": 5,
+                },
+                "unit": "short",
+                "min": 0,
+            },
+            "overrides": [],
+        },
+        "options": {
+            "legend": {
+                "displayMode": "list",
+                "placement": "bottom",
+                "calcs": ["sum"],
+            },
+            "tooltip": {"mode": "multi"},
+        },
+        "targets": [
+            {
+                "datasource": _DATASOURCE_REF,
+                "expr": expr,
+                "legendFormat": "{{identity_provider}}",
+                "refId": "A",
+            }
+        ],
+    }
+
+
+def _bar_gauge_panel(
+    *, title: str, expr: str, grid_pos: dict[str, Any]
+) -> dict[str, Any]:
+    """Build a bar-gauge panel model querying the shared Mimir datasource."""
+    return {
+        "title": title,
+        "type": "bargauge",
+        "datasource": _DATASOURCE_REF,
+        "gridPos": grid_pos,
+        "fieldConfig": {
+            "defaults": {
+                "color": {"mode": "palette-classic"},
+                "unit": "short",
+                "min": 0,
+            },
+            "overrides": [],
+        },
+        "options": {
+            "displayMode": "gradient",
+            "orientation": "horizontal",
+            "showUnfilled": True,
+        },
+        "targets": [
+            {
+                "datasource": _DATASOURCE_REF,
+                "expr": expr,
+                "legendFormat": "{{identity_provider}}",
+                "refId": "A",
+                "instant": True,
+            }
+        ],
+    }
+
+
+def _create_dashboard(
+    resource_name: str,
+    folder_uid,
+    dashboard_json: dict[str, Any],
+    resource_opts: ResourceOptions,
+) -> None:
+    Dashboard(
+        resource_name,
+        config_json=json.dumps(dashboard_json),
+        folder=folder_uid,
+        overwrite=True,
+        opts=resource_opts,
+    )
+
+
+def create(resource_opts: ResourceOptions) -> None:
+    """Create the dashboards folder and all Grafana dashboards."""
+    dashboards_folder = Folder(
+        "keycloak-dashboards-folder",
+        title="Keycloak",
+        uid="keycloak-dashboards",
+        opts=resource_opts,
+    )
+
+    keycloak_olapps_idp_logins.create(
+        dashboards_folder.uid,
+        _timeseries_panel,
+        _bar_gauge_panel,
+        _create_dashboard,
+        resource_opts,
+    )

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/dashboards/base.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/dashboards/base.py
@@ -1,9 +1,9 @@
 """Grafana dashboards.
 
-Every Grafana Cloud stack provisions its own Mimir datasource under the same
-generic UID (see metric_rules/base.py), so a dashboard defined here renders
-each stack's own data once deployed there -- no per-environment branching
-needed.
+Every Grafana Cloud stack provisions its own Mimir and Loki datasource under
+the same generic UIDs (see metric_rules/base.py and log_rules/base.py), so a
+dashboard defined here renders each stack's own data once deployed there --
+no per-environment branching needed.
 
 Sub-modules
 -----------
@@ -21,22 +21,24 @@ from pulumiverse_grafana.oss.folder import Folder
 from ol_infrastructure.infrastructure.grafana_alerting.dashboards import (
     keycloak_olapps_idp_logins,
 )
-
-# Every Grafana Cloud stack provisions its own Mimir datasource with this same
-# generic UID. The per-stack slug (e.g. grafanacloud-mitolci-prom) is only the
-# datasource *name*; referencing it as a UID fails with "data source not found".
-_MIMIR_DATASOURCE_UID = "grafanacloud-prom"
-_DATASOURCE_REF = {"type": "prometheus", "uid": _MIMIR_DATASOURCE_UID}
+from ol_infrastructure.infrastructure.grafana_alerting.dashboards.datasources import (
+    MIMIR_DATASOURCE_REF,
+)
 
 
 def _timeseries_panel(
-    *, title: str, expr: str, grid_pos: dict[str, Any]
+    *,
+    title: str,
+    expr: str,
+    grid_pos: dict[str, Any],
+    datasource_ref: dict[str, str] = MIMIR_DATASOURCE_REF,
+    legend_format: str = "{{identity_provider}}",
 ) -> dict[str, Any]:
-    """Build a time-series panel model querying the shared Mimir datasource."""
+    """Build a time-series panel model querying a shared datasource."""
     return {
         "title": title,
         "type": "timeseries",
-        "datasource": _DATASOURCE_REF,
+        "datasource": datasource_ref,
         "gridPos": grid_pos,
         "fieldConfig": {
             "defaults": {
@@ -62,9 +64,9 @@ def _timeseries_panel(
         },
         "targets": [
             {
-                "datasource": _DATASOURCE_REF,
+                "datasource": datasource_ref,
                 "expr": expr,
-                "legendFormat": "{{identity_provider}}",
+                "legendFormat": legend_format,
                 "refId": "A",
             }
         ],
@@ -72,13 +74,18 @@ def _timeseries_panel(
 
 
 def _bar_gauge_panel(
-    *, title: str, expr: str, grid_pos: dict[str, Any]
+    *,
+    title: str,
+    expr: str,
+    grid_pos: dict[str, Any],
+    datasource_ref: dict[str, str] = MIMIR_DATASOURCE_REF,
+    legend_format: str = "{{identity_provider}}",
 ) -> dict[str, Any]:
-    """Build a bar-gauge panel model querying the shared Mimir datasource."""
+    """Build a bar-gauge panel model querying a shared datasource."""
     return {
         "title": title,
         "type": "bargauge",
-        "datasource": _DATASOURCE_REF,
+        "datasource": datasource_ref,
         "gridPos": grid_pos,
         "fieldConfig": {
             "defaults": {
@@ -95,9 +102,9 @@ def _bar_gauge_panel(
         },
         "targets": [
             {
-                "datasource": _DATASOURCE_REF,
+                "datasource": datasource_ref,
                 "expr": expr,
-                "legendFormat": "{{identity_provider}}",
+                "legendFormat": legend_format,
                 "refId": "A",
                 "instant": True,
             }

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/dashboards/base.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/dashboards/base.py
@@ -14,7 +14,7 @@ Sub-modules
 import json
 from typing import Any
 
-from pulumi import ResourceOptions
+from pulumi import Input, ResourceOptions
 from pulumiverse_grafana.oss.dashboard import Dashboard
 from pulumiverse_grafana.oss.folder import Folder
 
@@ -114,7 +114,7 @@ def _bar_gauge_panel(
 
 def _create_dashboard(
     resource_name: str,
-    folder_uid,
+    folder_uid: Input[str],
     dashboard_json: dict[str, Any],
     resource_opts: ResourceOptions,
 ) -> None:

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/dashboards/datasources.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/dashboards/datasources.py
@@ -1,0 +1,14 @@
+"""Shared Grafana datasource references for the dashboards package.
+
+Every Grafana Cloud stack provisions its own Mimir/Loki datasource under
+these same generic UIDs (see metric_rules/base.py and log_rules/base.py).
+The per-stack slug (e.g. grafanacloud-mitolci-prom) is only the datasource
+*name*; referencing it as a UID fails with "data source not found".
+
+Kept in its own module, rather than in base.py, so individual dashboard
+sub-modules can import a specific datasource ref directly without a circular
+import back through base.py (which imports every sub-module).
+"""
+
+MIMIR_DATASOURCE_REF = {"type": "prometheus", "uid": "grafanacloud-prom"}
+LOKI_DATASOURCE_REF = {"type": "loki", "uid": "grafanacloud-logs"}

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/dashboards/keycloak_olapps_idp_logins.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/dashboards/keycloak_olapps_idp_logins.py
@@ -1,0 +1,86 @@
+"""Per-identity-provider login dashboard for the olapps Keycloak realm.
+
+Backed by the keycloak_olapps_idp_login_total /
+keycloak_olapps_idp_login_failure_total Prometheus counters that Alloy
+extracts from Keycloak's own login events (see substructure/aws/eks/grafana.py)
+-- no login record, or the PII it carries, is shipped to Loki for this; only
+the aggregate counters are.
+"""
+
+from collections.abc import Callable
+from typing import Any
+
+from pulumi import ResourceOptions
+
+
+def _dashboard_json(
+    timeseries_panel: Callable[..., dict[str, Any]],
+    bar_gauge_panel: Callable[..., dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "uid": "keycloak-olapps-idp-logins",
+        "title": "Keycloak - olapps IdP Logins",
+        "description": (
+            "Per-identity-provider login counts for the olapps realm. "
+            "Sourced from Prometheus counters Alloy extracts from Keycloak's "
+            "own success/failure login events -- no login record, or the "
+            "PII it carries, is shipped to Loki for this."
+        ),
+        "tags": ["keycloak", "olapps"],
+        "timezone": "browser",
+        "schemaVersion": 39,
+        "version": 1,
+        "editable": True,
+        "time": {"from": "now-7d", "to": "now"},
+        "refresh": "5m",
+        "panels": [
+            timeseries_panel(
+                title="Successful logins by identity provider",
+                expr=(
+                    "sum by (identity_provider) ("
+                    "increase(keycloak_olapps_idp_login_total[$__rate_interval]))"
+                ),
+                grid_pos={"h": 9, "w": 12, "x": 0, "y": 0},
+            ),
+            timeseries_panel(
+                title="Failed logins by identity provider",
+                expr=(
+                    "sum by (identity_provider) ("
+                    "increase(keycloak_olapps_idp_login_failure_total[$__rate_interval]))"
+                ),
+                grid_pos={"h": 9, "w": 12, "x": 12, "y": 0},
+            ),
+            bar_gauge_panel(
+                title="Total successful logins (selected range)",
+                expr=(
+                    "sum by (identity_provider) ("
+                    "increase(keycloak_olapps_idp_login_total[$__range]))"
+                ),
+                grid_pos={"h": 8, "w": 12, "x": 0, "y": 9},
+            ),
+            bar_gauge_panel(
+                title="Total failed logins (selected range)",
+                expr=(
+                    "sum by (identity_provider) ("
+                    "increase(keycloak_olapps_idp_login_failure_total[$__range]))"
+                ),
+                grid_pos={"h": 8, "w": 12, "x": 12, "y": 9},
+            ),
+        ],
+    }
+
+
+def create(
+    folder_uid,
+    timeseries_panel: Callable[..., dict[str, Any]],
+    bar_gauge_panel: Callable[..., dict[str, Any]],
+    create_dashboard: Callable[[str, object, dict[str, Any], ResourceOptions], None],
+    resource_opts: ResourceOptions,
+) -> None:
+    """Create the olapps per-IdP login dashboard."""
+    create_dashboard(
+        "keycloak-olapps-idp-logins-dashboard",
+        folder_uid,
+        _dashboard_json(timeseries_panel, bar_gauge_panel),
+        resource_opts,
+    )

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/dashboards/keycloak_olapps_idp_logins.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/dashboards/keycloak_olapps_idp_logins.py
@@ -18,7 +18,7 @@ so no cold-start gap and no eviction/reload resets to work around.
 from collections.abc import Callable
 from typing import Any
 
-from pulumi import ResourceOptions
+from pulumi import Input, ResourceOptions
 
 from ol_infrastructure.infrastructure.grafana_alerting.dashboards.datasources import (
     LOKI_DATASOURCE_REF,
@@ -104,10 +104,12 @@ def _dashboard_json(
 
 
 def create(
-    folder_uid,
+    folder_uid: Input[str],
     timeseries_panel: Callable[..., dict[str, Any]],
     bar_gauge_panel: Callable[..., dict[str, Any]],
-    create_dashboard: Callable[[str, object, dict[str, Any], ResourceOptions], None],
+    create_dashboard: Callable[
+        [str, Input[str], dict[str, Any], ResourceOptions], None
+    ],
     resource_opts: ResourceOptions,
 ) -> None:
     """Create the olapps per-IdP login dashboard."""

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/dashboards/keycloak_olapps_idp_logins.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/dashboards/keycloak_olapps_idp_logins.py
@@ -1,10 +1,18 @@
 """Per-identity-provider login dashboard for the olapps Keycloak realm.
 
-Backed by the keycloak_olapps_idp_login_total /
-keycloak_olapps_idp_login_failure_total Prometheus counters that Alloy
-extracts from Keycloak's own login events (see substructure/aws/eks/grafana.py)
--- no login record, or the PII it carries, is shipped to Loki for this; only
-the aggregate counters are.
+Backed directly by Keycloak's own login events in Loki (see
+substructure/aws/eks/grafana.py for the Alloy stage that redacts username and
+identity_provider_identity -- the only PII these events carry -- before they
+reach Loki; identity_provider itself is just an IdP alias, not PII).
+
+This intentionally counts from raw logs via LogQL's count_over_time rather
+than from an Alloy-derived Prometheus counter. A `metric.counter` component
+only exists once it's been incremented, so Prometheus's increase() can't see
+its first-ever appearance (no prior "0" sample to diff against), and the
+counter itself gets dropped and recreated after any idle gap or Alloy
+reload -- both silently undercounting. count_over_time reads straight from
+Loki's stored log lines at query time instead: no persistent counter state,
+so no cold-start gap and no eviction/reload resets to work around.
 """
 
 from collections.abc import Callable
@@ -12,35 +20,31 @@ from typing import Any
 
 from pulumi import ResourceOptions
 
+from ol_infrastructure.infrastructure.grafana_alerting.dashboards.datasources import (
+    LOKI_DATASOURCE_REF,
+)
 
-def _increase_expr(metric: str, window: str) -> str:
-    """PromQL for "count of new increments within the window," robust to a
-    counter appearing partway through it.
 
-    Alloy's metric.counter is created lazily -- a per-IdP series only exists
-    on /metrics once it's been incremented at least once. Prometheus's
-    increase() computes a delta from a prior sample, so a series' very first
-    appearance (right after any Alloy reload, or after being idle-evicted
-    past max_idle_duration) is invisible to it: there's no earlier "0" sample
-    to diff against, so it reports zero increase even though a login just
-    happened. That's silent and looks like the pipeline is broken.
+def _login_count_expr(*, level: str, event_types: str, window: str) -> str:
+    """LogQL counting olapps IdP-brokered login events by identity_provider.
 
-    `metric - metric offset window` sidesteps this: it's plain subtraction,
-    not increase()'s reset-aware extrapolation. When the series existed
-    `window` ago, this gives the correct in-window delta. When it didn't
-    (the cold-start case), the offset lookup matches nothing, so the whole
-    subtraction is absent for that series -- not zero -- letting `or metric`
-    fall through to the counter's current raw value, which for a
-    just-appeared series *is* the correct in-window count. clamp_min guards
-    against a spurious negative from the rare case of a reset landing inside
-    the window (max_idle_duration is long enough that this should be rare).
+    `event_types` is a regex alternation (e.g. "LOGIN|IDENTITY_PROVIDER_LOGIN")
+    matched against Keycloak's own `type="..."` field. Restricting to lines
+    that also carry `identity_provider="` scopes this to logins actually
+    brokered through an external IdP, excluding direct username/password
+    logins to olapps (which have no identity_provider and aren't this
+    dashboard's concern).
     """
-    current = f'{metric}{{identity_provider!=""}}'
+    selector = (
+        '{namespace="keycloak", container="keycloak"} '
+        f'|= "{level}  [org.keycloak.events]" '
+        '|= `realmId="olapps"` '
+        f'|~ `type="({event_types})"` '
+        '|= `identity_provider="`'
+    )
+    extract = ' | regexp `identity_provider="(?P<identity_provider>[^"]+)"`'
     return (
-        f"round(clamp_min(sum by (identity_provider) ("
-        f"({current} - {current} offset {window}) "
-        f"or {current}"
-        f"), 0))"
+        f"sum by (identity_provider) (count_over_time({selector}{extract}[{window}]))"
     )
 
 
@@ -48,14 +52,20 @@ def _dashboard_json(
     timeseries_panel: Callable[..., dict[str, Any]],
     bar_gauge_panel: Callable[..., dict[str, Any]],
 ) -> dict[str, Any]:
+    success_kwargs = {"level": "INFO", "event_types": "LOGIN|IDENTITY_PROVIDER_LOGIN"}
+    failure_kwargs = {
+        "level": "WARN",
+        "event_types": "LOGIN_ERROR|IDENTITY_PROVIDER_LOGIN_ERROR",
+    }
     return {
         "uid": "keycloak-olapps-idp-logins",
         "title": "Keycloak - olapps IdP Logins",
         "description": (
             "Per-identity-provider login counts for the olapps realm. "
-            "Sourced from Prometheus counters Alloy extracts from Keycloak's "
-            "own success/failure login events -- no login record, or the "
-            "PII it carries, is shipped to Loki for this."
+            "Sourced directly from Keycloak's own success/failure login "
+            "events in Loki -- username and identity_provider_identity are "
+            "redacted by Alloy before ingestion; no other PII is shipped or "
+            "queried for this."
         ),
         "tags": ["keycloak", "olapps"],
         "timezone": "browser",
@@ -67,35 +77,27 @@ def _dashboard_json(
         "panels": [
             timeseries_panel(
                 title="Successful logins by identity provider",
-                expr=_increase_expr(
-                    "loki_process_custom_keycloak_olapps_idp_login_total",
-                    "$__interval",
-                ),
+                expr=_login_count_expr(**success_kwargs, window="$__interval"),
                 grid_pos={"h": 9, "w": 12, "x": 0, "y": 0},
+                datasource_ref=LOKI_DATASOURCE_REF,
             ),
             timeseries_panel(
                 title="Failed logins by identity provider",
-                expr=_increase_expr(
-                    "loki_process_custom_keycloak_olapps_idp_login_failure_total",
-                    "$__interval",
-                ),
+                expr=_login_count_expr(**failure_kwargs, window="$__interval"),
                 grid_pos={"h": 9, "w": 12, "x": 12, "y": 0},
+                datasource_ref=LOKI_DATASOURCE_REF,
             ),
             bar_gauge_panel(
                 title="Total successful logins (selected range)",
-                expr=_increase_expr(
-                    "loki_process_custom_keycloak_olapps_idp_login_total",
-                    "$__range",
-                ),
+                expr=_login_count_expr(**success_kwargs, window="$__range"),
                 grid_pos={"h": 8, "w": 12, "x": 0, "y": 9},
+                datasource_ref=LOKI_DATASOURCE_REF,
             ),
             bar_gauge_panel(
                 title="Total failed logins (selected range)",
-                expr=_increase_expr(
-                    "loki_process_custom_keycloak_olapps_idp_login_failure_total",
-                    "$__range",
-                ),
+                expr=_login_count_expr(**failure_kwargs, window="$__range"),
                 grid_pos={"h": 8, "w": 12, "x": 12, "y": 9},
+                datasource_ref=LOKI_DATASOURCE_REF,
             ),
         ],
     }

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/dashboards/keycloak_olapps_idp_logins.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/dashboards/keycloak_olapps_idp_logins.py
@@ -13,6 +13,37 @@ from typing import Any
 from pulumi import ResourceOptions
 
 
+def _increase_expr(metric: str, window: str) -> str:
+    """PromQL for "count of new increments within the window," robust to a
+    counter appearing partway through it.
+
+    Alloy's metric.counter is created lazily -- a per-IdP series only exists
+    on /metrics once it's been incremented at least once. Prometheus's
+    increase() computes a delta from a prior sample, so a series' very first
+    appearance (right after any Alloy reload, or after being idle-evicted
+    past max_idle_duration) is invisible to it: there's no earlier "0" sample
+    to diff against, so it reports zero increase even though a login just
+    happened. That's silent and looks like the pipeline is broken.
+
+    `metric - metric offset window` sidesteps this: it's plain subtraction,
+    not increase()'s reset-aware extrapolation. When the series existed
+    `window` ago, this gives the correct in-window delta. When it didn't
+    (the cold-start case), the offset lookup matches nothing, so the whole
+    subtraction is absent for that series -- not zero -- letting `or metric`
+    fall through to the counter's current raw value, which for a
+    just-appeared series *is* the correct in-window count. clamp_min guards
+    against a spurious negative from the rare case of a reset landing inside
+    the window (max_idle_duration is long enough that this should be rare).
+    """
+    current = f'{metric}{{identity_provider!=""}}'
+    return (
+        f"round(clamp_min(sum by (identity_provider) ("
+        f"({current} - {current} offset {window}) "
+        f"or {current}"
+        f"), 0))"
+    )
+
+
 def _dashboard_json(
     timeseries_panel: Callable[..., dict[str, Any]],
     bar_gauge_panel: Callable[..., dict[str, Any]],
@@ -36,33 +67,33 @@ def _dashboard_json(
         "panels": [
             timeseries_panel(
                 title="Successful logins by identity provider",
-                expr=(
-                    "sum by (identity_provider) ("
-                    "increase(keycloak_olapps_idp_login_total[$__rate_interval]))"
+                expr=_increase_expr(
+                    "loki_process_custom_keycloak_olapps_idp_login_total",
+                    "$__interval",
                 ),
                 grid_pos={"h": 9, "w": 12, "x": 0, "y": 0},
             ),
             timeseries_panel(
                 title="Failed logins by identity provider",
-                expr=(
-                    "sum by (identity_provider) ("
-                    "increase(keycloak_olapps_idp_login_failure_total[$__rate_interval]))"
+                expr=_increase_expr(
+                    "loki_process_custom_keycloak_olapps_idp_login_failure_total",
+                    "$__interval",
                 ),
                 grid_pos={"h": 9, "w": 12, "x": 12, "y": 0},
             ),
             bar_gauge_panel(
                 title="Total successful logins (selected range)",
-                expr=(
-                    "sum by (identity_provider) ("
-                    "increase(keycloak_olapps_idp_login_total[$__range]))"
+                expr=_increase_expr(
+                    "loki_process_custom_keycloak_olapps_idp_login_total",
+                    "$__range",
                 ),
                 grid_pos={"h": 8, "w": 12, "x": 0, "y": 9},
             ),
             bar_gauge_panel(
                 title="Total failed logins (selected range)",
-                expr=(
-                    "sum by (identity_provider) ("
-                    "increase(keycloak_olapps_idp_login_failure_total[$__range]))"
+                expr=_increase_expr(
+                    "loki_process_custom_keycloak_olapps_idp_login_failure_total",
+                    "$__range",
                 ),
                 grid_pos={"h": 8, "w": 12, "x": 12, "y": 9},
             ),

--- a/src/ol_infrastructure/substructure/aws/eks/grafana.py
+++ b/src/ol_infrastructure/substructure/aws/eks/grafana.py
@@ -119,12 +119,61 @@ stage.match {
     expression = `identity_provider="(?P<identity_provider>[^"]+)"`
   }
 
+  // metric.counter needs BOTH of these, for two unrelated reasons:
+  //   - source: when unset, it defaults to the metric's own `name`, which
+  //     is never a key in the extracted map -- so the counter would look
+  //     for a field that doesn't exist and silently never increment.
+  //     Setting it to "identity_provider" makes it require that (real)
+  //     extracted field's presence instead.
+  //   - stage.labels: source only *gates* on the extracted map, it doesn't
+  //     attach the extracted field as a label on the resulting metric.
+  //     Without this, every login (any IdP) increments one undifferentiated
+  //     series. This promotes identity_provider to an actual label on the
+  //     log entry first, so stage.metrics carries it as a metric label too.
+  stage.labels {
+    values = {
+      identity_provider = "",
+    }
+  }
+
   stage.metrics {
     metric.counter {
       name        = "keycloak_olapps_idp_login_total"
       description = "Successful olapps realm logins brokered through an external identity provider, by IdP alias"
       source      = "identity_provider"
       action      = "inc"
+      // max_idle_duration defaults to "5m": a counter with no matching line
+      // for 5 minutes is dropped, and the next matching login starts a
+      // fresh series back at 1. When a reset lands on the same value as
+      // before the gap (e.g. 1 -> idle-dropped -> next login recreates it
+      // at 1), Prometheus's increase() can't tell a reset happened -- it
+      // only detects resets via a *decrease* between consecutive samples,
+      // not a gap -- so it silently reports zero increase across that
+      // boundary, for any window width, confirmed directly against two
+      // real test logins ~7m apart.
+      //
+      // There's no duration that makes this fully watertight -- any IdP
+      // whose login gap exceeds max_idle_duration hits the same silent
+      // undercount, just at a longer interval. 2160h (90 days -- Alloy's
+      // River duration parser has no "d" unit, only up to "h"; a literal
+      // "90d" fails to parse and silently breaks the whole containing
+      // loki.process component on every reload, confirmed the hard way)
+      // is chosen to comfortably outlast the widest range anyone would
+      // realistically view this dashboard at (default is 7d; even a
+      // manually-widened 30-60d query stays inside a single continuous
+      // series). It only misses a login if a given IdP goes completely
+      // unused for >90d *and* someone then queries a range spanning that
+      // exact gap -- an accepted, bounded tradeoff rather than a full fix.
+      max_idle_duration = "2160h"
+      // metric.counter defaults prefix to "loki_process_custom_", and an
+      // explicit empty string does not override that (Alloy appears to
+      // treat "" the same as unset). So the real exposed/exported name is
+      // loki_process_custom_keycloak_olapps_idp_login_total -- confirmed
+      // directly on Alloy's own /metrics endpoint -- not the bare name
+      // this block sets via `name`. Every consumer (the includeMetrics
+      // allowlist entry below, and every PromQL query in
+      // dashboards/keycloak_olapps_idp_logins.py) must use the full
+      // loki_process_custom_-prefixed name, not this bare one.
     }
   }
 }
@@ -143,12 +192,21 @@ stage.match {
     expression = `identity_provider="(?P<identity_provider>[^"]+)"`
   }
 
+  stage.labels {
+    values = {
+      identity_provider = "",
+    }
+  }
+
   stage.metrics {
     metric.counter {
       name        = "keycloak_olapps_idp_login_failure_total"
       description = "Failed olapps realm logins brokered through an external identity provider, by IdP alias"
       source      = "identity_provider"
       action      = "inc"
+      // See the max_idle_duration comment on the success counter above --
+      // same reasoning applies here.
+      max_idle_duration = "2160h"
     }
   }
 }
@@ -461,6 +519,14 @@ def setup_grafana(
                     # reaching Mimir: confirmed present on Alloy's own
                     # /metrics endpoint but absent from Mimir at every range
                     # queried, however wide.
+                    #
+                    # Note the loki_process_custom_ prefix: metric.counter
+                    # defaults to that prefix and an explicit `prefix = ""`
+                    # does not override it (confirmed directly against
+                    # Alloy's /metrics endpoint), so the real exported names
+                    # are loki_process_custom_keycloak_olapps_idp_login_total
+                    # and its _failure_total counterpart, not the bare names
+                    # set via metric.counter's `name` attribute.
                     "alloy": {
                         "instances": [
                             {
@@ -483,8 +549,8 @@ def setup_grafana(
                                             "otelcol_processor_tail_sampling_new_trace_id_received",
                                             "otelcol_processor_tail_sampling_sampling_traces_on_memory",
                                             "otelcol_processor_tail_sampling_sampling_policy_evaluation_error",
-                                            "keycloak_olapps_idp_login_total",
-                                            "keycloak_olapps_idp_login_failure_total",
+                                            "loki_process_custom_keycloak_olapps_idp_login_total",
+                                            "loki_process_custom_keycloak_olapps_idp_login_failure_total",
                                         ],
                                     },
                                 },

--- a/src/ol_infrastructure/substructure/aws/eks/grafana.py
+++ b/src/ol_infrastructure/substructure/aws/eks/grafana.py
@@ -449,6 +449,18 @@ def setup_grafana(
                     # surfaced the tail-sampler sizing bug (traces evicted
                     # before a decision was made, buffer occupancy far past
                     # the old 100-trace cap) instead of it going unnoticed.
+                    #
+                    # Also extended with the two keycloak_olapps_idp_login_*
+                    # counters (see dashboards/keycloak_olapps_idp_logins.py
+                    # and substructure/aws/eks/grafana.py's
+                    # _keycloak_olapps_idp_login_metrics_alloy_config) --
+                    # custom stage.metrics counters are exactly the
+                    # "unfiltered alloy_component_*" case this allowlist
+                    # exists to block by default, so without an explicit
+                    # entry here they're silently dropped before ever
+                    # reaching Mimir: confirmed present on Alloy's own
+                    # /metrics endpoint but absent from Mimir at every range
+                    # queried, however wide.
                     "alloy": {
                         "instances": [
                             {
@@ -471,6 +483,8 @@ def setup_grafana(
                                             "otelcol_processor_tail_sampling_new_trace_id_received",
                                             "otelcol_processor_tail_sampling_sampling_traces_on_memory",
                                             "otelcol_processor_tail_sampling_sampling_policy_evaluation_error",
+                                            "keycloak_olapps_idp_login_total",
+                                            "keycloak_olapps_idp_login_failure_total",
                                         ],
                                     },
                                 },

--- a/src/ol_infrastructure/substructure/aws/eks/grafana.py
+++ b/src/ol_infrastructure/substructure/aws/eks/grafana.py
@@ -68,42 +68,59 @@ stage.match {
 """
 
 
-def _keycloak_olapps_idp_login_metrics_alloy_config() -> str:
+def _keycloak_olapps_idp_login_redact_alloy_config() -> str:
     """
-    Alloy River stages that turn olapps-realm brokered-login events into
-    per-IdP Prometheus counters, without shipping login records (or the PII
-    they carry) to Loki.
+    Alloy River stages that redact PII from olapps-realm brokered-login
+    events and let the rest of the line through to Loki, so
+    dashboards/keycloak_olapps_idp_logins.py can count logins per IdP
+    directly from LogQL (count_over_time) instead of from a derived
+    Prometheus counter.
+
+    An earlier version of this pipeline extracted a Prometheus counter via
+    stage.metrics instead of keeping any log record. That turned out to have
+    three compounding problems, all found via live QA testing: (1)
+    metric.counter's `source` is required, not optional, to actually
+    increment (unset, it looks for a field that never exists and silently
+    never fires); (2) `source` alone doesn't attach a label, so a separate
+    stage.labels promotion was needed for a per-IdP breakdown; (3)
+    max_idle_duration drops and recreates the counter after any gap between
+    logins, and because Prometheus's increase() only detects a reset via a
+    *decrease* (not a gap), a reset landing on the same value as before it
+    silently reports zero increase -- and metric.counter's own first-ever
+    appearance (no prior sample to diff against) hits the identical blind
+    spot on every single login until a second one confirms a real delta.
+    Every fix for one of these surfaced the next. Redacting and keeping the
+    actual log line sidesteps all three: count_over_time reads directly from
+    Loki's stored lines at query time, so there's no persistent counter
+    state to evict, reset, or have a cold start.
 
     Keycloak's jboss-logging event listener is configured (see
     applications/keycloak/__main__.py) with success-level=info so that
     successful LOGIN/IDENTITY_PROVIDER_LOGIN events reach our logs; that
     setting is all-or-nothing per Keycloak, logging every successful event
     type (CODE_TO_TOKEN, REFRESH_TOKEN, LOGOUT, REGISTER, ...) across every
-    realm on the shared instance, not just logins on olapps. Those events
-    also carry username and identity_provider_identity (the federated
-    email) -- fields the dashboard doesn't need, since it only wants a
-    per-IdP count.
-
-    So rather than filter down to the wanted events and ship them to Loki,
-    this pipeline extracts what's needed as metrics and ships no
-    olapps-brokered-login records to Loki at all:
+    realm on the shared instance, not just logins on olapps.
 
     1. Match INFO-level LOGIN/IDENTITY_PROVIDER_LOGIN events on olapps that
        carry an identity_provider detail (i.e. were actually brokered
        through an external IdP, not a direct username/password login), and
-       increment keycloak_olapps_idp_login_total{identity_provider=...}.
-    2. Unconditionally drop every remaining INFO-level org.keycloak.events
-       line -- covering both the events just counted (no login record, only
-       the counter, reaches Loki) and the rest of the noisy INFO volume
-       (CODE_TO_TOKEN, REFRESH_TOKEN, etc.) that success-level=info produces.
+       redact username and identity_provider_identity (the federated email)
+       -- the only PII these events carry -- in place. identity_provider
+       itself is just an IdP alias (e.g. "touchstone-idp"), not PII, and is
+       left untouched so the dashboard can query and group by it. The
+       (redacted) line is kept, not dropped.
+    2. Drop every other INFO-level org.keycloak.events line: both direct
+       (non-brokered) olapps logins, which this dashboard doesn't cover, and
+       the rest of the noisy INFO volume (CODE_TO_TOKEN, REFRESH_TOKEN, etc.)
+       that success-level=info produces across every realm. The selector
+       excludes lines carrying identity_provider=", since those are exactly
+       the ones stage 1 already redacted and wants kept.
     3. Match WARN-level LOGIN_ERROR/IDENTITY_PROVIDER_LOGIN_ERROR events on
-       olapps that carry an identity_provider detail, and increment
-       keycloak_olapps_idp_login_failure_total{identity_provider=...}. This
-       stage has no drop action: WARN/ERROR events are the pre-existing
-       failure logs already relied on for debugging (e.g. diagnosing a
-       broken IdP integration) and carry materially less PII than the
-       success events, so they keep flowing to Loki unchanged -- this stage
-       only adds a metric as a side effect.
+       olapps that carry an identity_provider detail, and redact username the
+       same way. These were never dropped -- WARN/ERROR events are the
+       pre-existing failure logs already relied on for debugging (e.g.
+       diagnosing a broken IdP integration) -- so this only adds the same
+       redaction, not a change in what reaches Loki.
 
     Each stage's selector independently re-checks the INFO/WARN level
     marker and the olapps realm, rather than relying on another stage
@@ -113,101 +130,43 @@ def _keycloak_olapps_idp_login_metrics_alloy_config() -> str:
     return r"""
 stage.match {
   selector = "{namespace=\"keycloak\", container=\"keycloak\"} |= \"INFO  [org.keycloak.events]\" |= \"realmId=\\\"olapps\\\"\" |~ \"type=\\\"(LOGIN|IDENTITY_PROVIDER_LOGIN)\\\"\" |= \"identity_provider=\\\"\""
-  pipeline_name = "keycloak_olapps_login_success_metric"
+  pipeline_name = "keycloak_olapps_login_success_redact"
 
-  stage.regex {
-    expression = `identity_provider="(?P<identity_provider>[^"]+)"`
+  // expression's capture group is what gets replaced -- the surrounding
+  // username="..." / identity_provider_identity="..." text outside the
+  // parens is left as-is and doesn't need to be repeated in `replace`.
+  stage.replace {
+    expression = `username="([^"]+)"`
+    replace    = `[REDACTED]`
   }
 
-  // metric.counter needs BOTH of these, for two unrelated reasons:
-  //   - source: when unset, it defaults to the metric's own `name`, which
-  //     is never a key in the extracted map -- so the counter would look
-  //     for a field that doesn't exist and silently never increment.
-  //     Setting it to "identity_provider" makes it require that (real)
-  //     extracted field's presence instead.
-  //   - stage.labels: source only *gates* on the extracted map, it doesn't
-  //     attach the extracted field as a label on the resulting metric.
-  //     Without this, every login (any IdP) increments one undifferentiated
-  //     series. This promotes identity_provider to an actual label on the
-  //     log entry first, so stage.metrics carries it as a metric label too.
-  stage.labels {
-    values = {
-      identity_provider = "",
-    }
-  }
-
-  stage.metrics {
-    metric.counter {
-      name        = "keycloak_olapps_idp_login_total"
-      description = "Successful olapps realm logins brokered through an external identity provider, by IdP alias"
-      source      = "identity_provider"
-      action      = "inc"
-      // max_idle_duration defaults to "5m": a counter with no matching line
-      // for 5 minutes is dropped, and the next matching login starts a
-      // fresh series back at 1. When a reset lands on the same value as
-      // before the gap (e.g. 1 -> idle-dropped -> next login recreates it
-      // at 1), Prometheus's increase() can't tell a reset happened -- it
-      // only detects resets via a *decrease* between consecutive samples,
-      // not a gap -- so it silently reports zero increase across that
-      // boundary, for any window width, confirmed directly against two
-      // real test logins ~7m apart.
-      //
-      // There's no duration that makes this fully watertight -- any IdP
-      // whose login gap exceeds max_idle_duration hits the same silent
-      // undercount, just at a longer interval. 2160h (90 days -- Alloy's
-      // River duration parser has no "d" unit, only up to "h"; a literal
-      // "90d" fails to parse and silently breaks the whole containing
-      // loki.process component on every reload, confirmed the hard way)
-      // is chosen to comfortably outlast the widest range anyone would
-      // realistically view this dashboard at (default is 7d; even a
-      // manually-widened 30-60d query stays inside a single continuous
-      // series). It only misses a login if a given IdP goes completely
-      // unused for >90d *and* someone then queries a range spanning that
-      // exact gap -- an accepted, bounded tradeoff rather than a full fix.
-      max_idle_duration = "2160h"
-      // metric.counter defaults prefix to "loki_process_custom_", and an
-      // explicit empty string does not override that (Alloy appears to
-      // treat "" the same as unset). So the real exposed/exported name is
-      // loki_process_custom_keycloak_olapps_idp_login_total -- confirmed
-      // directly on Alloy's own /metrics endpoint -- not the bare name
-      // this block sets via `name`. Every consumer (the includeMetrics
-      // allowlist entry below, and every PromQL query in
-      // dashboards/keycloak_olapps_idp_logins.py) must use the full
-      // loki_process_custom_-prefixed name, not this bare one.
-    }
+  stage.replace {
+    expression = `identity_provider_identity="([^"]+)"`
+    replace    = `[REDACTED]`
   }
 }
 
 stage.match {
-  selector = "{namespace=\"keycloak\", container=\"keycloak\"} |= \"INFO  [org.keycloak.events]\""
+  selector = "{namespace=\"keycloak\", container=\"keycloak\"} |= \"INFO  [org.keycloak.events]\" != \"identity_provider=\\\"\""
   action = "drop"
   drop_counter_reason = "keycloak_info_event"
 }
 
 stage.match {
   selector = "{namespace=\"keycloak\", container=\"keycloak\"} |= \"WARN  [org.keycloak.events]\" |= \"realmId=\\\"olapps\\\"\" |~ \"type=\\\"(LOGIN_ERROR|IDENTITY_PROVIDER_LOGIN_ERROR)\\\"\" |= \"identity_provider=\\\"\""
-  pipeline_name = "keycloak_olapps_login_failure_metric"
+  pipeline_name = "keycloak_olapps_login_failure_redact"
 
-  stage.regex {
-    expression = `identity_provider="(?P<identity_provider>[^"]+)"`
+  // expression's capture group is what gets replaced -- the surrounding
+  // username="..." / identity_provider_identity="..." text outside the
+  // parens is left as-is and doesn't need to be repeated in `replace`.
+  stage.replace {
+    expression = `username="([^"]+)"`
+    replace    = `[REDACTED]`
   }
 
-  stage.labels {
-    values = {
-      identity_provider = "",
-    }
-  }
-
-  stage.metrics {
-    metric.counter {
-      name        = "keycloak_olapps_idp_login_failure_total"
-      description = "Failed olapps realm logins brokered through an external identity provider, by IdP alias"
-      source      = "identity_provider"
-      action      = "inc"
-      // See the max_idle_duration comment on the success counter above --
-      // same reasoning applies here.
-      max_idle_duration = "2160h"
-    }
+  stage.replace {
+    expression = `identity_provider_identity="([^"]+)"`
+    replace    = `[REDACTED]`
   }
 }
 """
@@ -443,7 +402,7 @@ def setup_grafana(
                     "enabled": True,
                     "collector": "alloy-logs",
                     "extraLogProcessingStages": _apisix_cookie_metrics_alloy_config()
-                    + _keycloak_olapps_idp_login_metrics_alloy_config(),
+                    + _keycloak_olapps_idp_login_redact_alloy_config(),
                 },
                 "applicationObservability": {
                     "enabled": True,
@@ -507,26 +466,6 @@ def setup_grafana(
                     # surfaced the tail-sampler sizing bug (traces evicted
                     # before a decision was made, buffer occupancy far past
                     # the old 100-trace cap) instead of it going unnoticed.
-                    #
-                    # Also extended with the two keycloak_olapps_idp_login_*
-                    # counters (see dashboards/keycloak_olapps_idp_logins.py
-                    # and substructure/aws/eks/grafana.py's
-                    # _keycloak_olapps_idp_login_metrics_alloy_config) --
-                    # custom stage.metrics counters are exactly the
-                    # "unfiltered alloy_component_*" case this allowlist
-                    # exists to block by default, so without an explicit
-                    # entry here they're silently dropped before ever
-                    # reaching Mimir: confirmed present on Alloy's own
-                    # /metrics endpoint but absent from Mimir at every range
-                    # queried, however wide.
-                    #
-                    # Note the loki_process_custom_ prefix: metric.counter
-                    # defaults to that prefix and an explicit `prefix = ""`
-                    # does not override it (confirmed directly against
-                    # Alloy's /metrics endpoint), so the real exported names
-                    # are loki_process_custom_keycloak_olapps_idp_login_total
-                    # and its _failure_total counterpart, not the bare names
-                    # set via metric.counter's `name` attribute.
                     "alloy": {
                         "instances": [
                             {
@@ -549,8 +488,6 @@ def setup_grafana(
                                             "otelcol_processor_tail_sampling_new_trace_id_received",
                                             "otelcol_processor_tail_sampling_sampling_traces_on_memory",
                                             "otelcol_processor_tail_sampling_sampling_policy_evaluation_error",
-                                            "loki_process_custom_keycloak_olapps_idp_login_total",
-                                            "loki_process_custom_keycloak_olapps_idp_login_failure_total",
                                         ],
                                     },
                                 },


### PR DESCRIPTION
## Summary
- Adds a Grafana dashboard (`dashboards/keycloak_olapps_idp_logins.py`) tracking successful and failed olapps-realm logins per external identity provider, following the existing `metric_rules`/`log_rules` package pattern with a documented one-dashboard-per-file naming convention.
- Counts directly from Loki via LogQL (`count_over_time`), not from an Alloy-derived Prometheus counter. That approach was tried first and hit three compounding failure modes during live QA testing: `metric.counter`'s `source` is required (not optional) to increment at all; a separate `stage.labels` promotion was needed since `source` alone doesn't attach a label; and `max_idle_duration` evicts+resets the counter after any gap between logins, which combined with `increase()`'s inability to detect a series' very first appearance meant a real login could show as zero on the dashboard until a second one confirmed a delta. `count_over_time` reads directly from Loki's stored log lines at query time instead — no persistent counter state, so neither failure mode applies, and it naturally scopes to whatever time range is selected in Grafana.
- Adds an Alloy `stage.replace` redaction stage (`substructure/aws/eks/grafana.py`) that strips `username` and `identity_provider_identity` (the only PII these login events carry) before the line reaches Loki. `identity_provider` itself is just an IdP alias (e.g. `touchstone-idp`), not PII, and is left untouched since the dashboard groups by it.

## Test plan
- [x] Deployed to QA (`substructure/aws/eks` + `grafana_alerting`) and confirmed end-to-end with live test logins: PII is redacted in the Loki-stored line, `identity_provider` is preserved, and the dashboard renders a correct count immediately after a single login (no cold-start gap, no reset-related undercounting).
- [ ] Deploy to Production once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)