### PR TITLE
Set DRIVE_SHARED_ID for xPRO RC

### DIFF
--- a/src/ol_infrastructure/applications/xpro/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/xpro/Pulumi.QA.yaml
@@ -10,6 +10,12 @@ config:
     CYBERSOURCE_SECURE_ACCEPTANCE_URL: "https://testsecureacceptance.cybersource.com/pay"
     CYBERSOURCE_WSDL_URL: "https://ics2wstest.ic3.com/commerce/1.x/transactionProcessor/CyberSourceTransaction_1.154.wsdl"
     DIGITAL_CREDENTIALS_SUPPORTED_RUNS: "course-v1:xPRO+TestCourse1+R2,course-v1:xPRO+TestCourse2+R2,program-v1:xPRO+TestProgram"
+    # RC's request sheets and assignment-sheet output folder live in the "Open
+    # Learning Engineering" shared drive. Without this, pygsheets omits
+    # supportsTeamDrives on the Drive calls and assignment-sheet creation fails
+    # with "404 File not found" on DRIVE_OUTPUT_FOLDER_ID.
+    # NOTE: production's sheets are in My Drive, so it must stay unset there.
+    DRIVE_SHARED_ID: "0ADY3FaGtq2jvUk9PVA"
     GA_TRACKING_ID: "UA-5145472-40"
     GTM_TRACKING_ID: "GTM-KJHRV6K"
     HUBSPOT_ENTERPRISE_PAGE_FORM_ID: "c50388d7-794e-4103-bdb9-8cbb71da0cd4"


### PR DESCRIPTION
RC's enrollment code request sheet, change-of-enrollment sheet, and assignment-sheet output folder all live in the "Open Learning Engineering" shared drive (`0ADY3FaGtq2jvUk9PVA`), but `DRIVE_SHARED_ID` was never set for the QA/RC stack.

xPRO passes `supportsTeamDrives` conditionally on this setting, so with it unset pygsheets' `move_file()` omits the flag and Drive reports the output folder as missing. Assignment-sheet creation fails with `404 File not found: <DRIVE_OUTPUT_FOLDER_ID>`, and each attempt orphans a spreadsheet in the service account's My Drive.

### Reproduced

Locally, against a shared-drive output folder, toggling only `DRIVE_SHARED_ID`:

| | `DRIVE_SHARED_ID` set | unset |
| --- | --- | --- |
| `pygsheets create(folder=...)` | ✅ | ❌ `404 File not found` |
| landed in output folder | ✅ | — |
| `appProperties` write / read | ✅ | — |
| `files.list` by name | ✅ | — |

### Production is deliberately excluded

Production's sheets are in the service account's My Drive (no `driveId`), so setting this there would introduce the same failure rather than fix anything. Verified by reading `driveId` from the Drive API in both environments:

| Environment | Files live in | `DRIVE_SHARED_ID` |
| --- | --- | --- |
| QA / RC | shared drive `0ADY3FaGtq2jvUk9PVA` ("Open Learning Engineering") | needs setting — this PR |
| Production | My Drive | correctly unset, unchanged |
| CI | not inspected | unchanged |

### Notes

- **CI was not inspected.** If that stack's sheets are also in a shared drive it has the same latent bug — worth a follow-up.
- Follows the existing precedent of `DRIVE_SHARED_ID` as plain non-secret config in `xpro:vars` (ocw_studio sets it the same way in its `Pulumi.QA.yaml` / `Pulumi.Production.yaml`), rather than adding a Vault key.
- Verify after deploy with `./manage.py process_coupon_requests` on RC — it should create and share the assignment sheet instead of 404ing.
- This is a pre-existing bug, unrelated to any application release. The same Drive migration appears to have also caused a service-account credential mismatch in the RC and production Vaults (fixed separately by DevOps on 10 Aug).
