### PR TITLE
fix(omnigraph): the admission cap was sized against memory, and the deadline is what kills writes

### DIFF
--- a/src/ol_infrastructure/applications/omnigraph/__main__.py
+++ b/src/ol_infrastructure/applications/omnigraph/__main__.py
@@ -59,6 +59,8 @@ from ol_infrastructure.applications.omnigraph.cluster_config import (
 )
 from ol_infrastructure.applications.omnigraph.data_tier import (
     CLUSTER_CONFIGMAP_NAME,
+    DEFAULT_PER_ACTOR_BYTES_MAX,
+    DEFAULT_PER_ACTOR_INFLIGHT_MAX,
     OMNIGRAPH_SERVER_SERVICE_NAME,
     create_data_tier,
     omnigraph_server_addr,
@@ -210,6 +212,21 @@ OPTIMIZE_SCHEDULE = (
 CLEANUP_SCHEDULE = omnigraph_config.get("cleanup_schedule") or DEFAULT_CLEANUP_SCHEDULE
 CLEANUP_OLDER_THAN = (
     omnigraph_config.get("cleanup_older_than") or DEFAULT_CLEANUP_OLDER_THAN
+)
+
+# Per-actor admission caps (data_tier.py). Overridable per environment for the
+# same reason the schedules above are, and a sharper one: the count's default is
+# derived from ONE measurement of ONE environment (CI, 2026-08-12), and the knee
+# it encodes moves with graph size — a single-row insert costs a full-table read,
+# so Production's larger tables are slower per write and saturate sooner. It will
+# move again when that cost is attacked upstream. Retuning admission control
+# during an incident must not mean editing this repo, cutting a release and
+# rolling an image.
+PER_ACTOR_INFLIGHT_MAX = (
+    omnigraph_config.get_int("per_actor_inflight_max") or DEFAULT_PER_ACTOR_INFLIGHT_MAX
+)
+PER_ACTOR_BYTES_MAX = (
+    omnigraph_config.get_int("per_actor_bytes_max") or DEFAULT_PER_ACTOR_BYTES_MAX
 )
 
 cluster_stack = make_stack_reference(projects.EKS, f"operations.{stack_info.name}")
@@ -728,6 +745,8 @@ data_tier = create_data_tier(
     cleanup_schedule=CLEANUP_SCHEDULE,
     cleanup_older_than=CLEANUP_OLDER_THAN,
     storage_prefix=STORAGE_PREFIX,
+    per_actor_inflight_max=PER_ACTOR_INFLIGHT_MAX,
+    per_actor_bytes_max=PER_ACTOR_BYTES_MAX,
     # Arming a migration suspends both maintenance sweeps for its duration.
     # They write directly to the store, so scaling the Deployment to zero does
     # not stop them, and `optimize` rewriting fragments between the export and

--- a/src/ol_infrastructure/applications/omnigraph/__main__.py
+++ b/src/ol_infrastructure/applications/omnigraph/__main__.py
@@ -222,11 +222,53 @@ CLEANUP_OLDER_THAN = (
 # move again when that cost is attacked upstream. Retuning admission control
 # during an incident must not mean editing this repo, cutting a release and
 # rolling an image.
-PER_ACTOR_INFLIGHT_MAX = (
-    omnigraph_config.get_int("per_actor_inflight_max") or DEFAULT_PER_ACTOR_INFLIGHT_MAX
+#
+# ★ VALIDATED, and NOT with `or`. Two distinct traps, both silent:
+#
+#   `or` cannot tell 0 from unset. Zero is a MEANINGFUL setting here — it is how
+#   an operator says "admit nothing", a real incident answer — and `or` would
+#   quietly hand back the default, re-enabling the writes somebody was trying to
+#   stop. `is None` is the only test that distinguishes them.
+#
+#   The server parses these into Rust `u32`/`u64`. A negative or oversized value
+#   is not rejected loudly; omnigraph falls back to its own upstream defaults
+#   (16 in flight, 4 GiB), which are far LOOSER than ours — so a typo does not
+#   tighten the cap or crash the pod, it silently removes both safeguards. That
+#   is the worst of the three outcomes and the one nothing downstream reports,
+#   so it is refused here, at the point where the value is still readable.
+_U32_MAX = 2**32 - 1
+_U64_MAX = 2**64 - 1
+
+
+def _bounded_cap(name: str, value: int | None, default: int, ceiling: int) -> int:
+    """Return a stack-config admission cap, or the default.
+
+    Refuses what omnigraph would silently discard — see the note above on the
+    u32/u64 fallback.
+    """
+    if value is None:
+        return default
+    if not 0 <= value <= ceiling:
+        msg = (
+            f"omnigraph:{name}={value} is outside the range the server accepts "
+            f"(0..{ceiling}). Out of range, omnigraph ignores it and reverts to "
+            f"its own default, which is looser than the cap being set here."
+        )
+        raise ValueError(msg)
+    return value
+
+
+PER_ACTOR_INFLIGHT_MAX = _bounded_cap(
+    "per_actor_inflight_max",
+    omnigraph_config.get_int("per_actor_inflight_max"),
+    DEFAULT_PER_ACTOR_INFLIGHT_MAX,
+    _U32_MAX,
 )
-PER_ACTOR_BYTES_MAX = (
-    omnigraph_config.get_int("per_actor_bytes_max") or DEFAULT_PER_ACTOR_BYTES_MAX
+PER_ACTOR_BYTES_MAX = _bounded_cap(
+    "per_actor_bytes_max",
+    omnigraph_config.get_int("per_actor_bytes_max"),
+    DEFAULT_PER_ACTOR_BYTES_MAX,
+    _U64_MAX,
 )
 
 cluster_stack = make_stack_reference(projects.EKS, f"operations.{stack_info.name}")

--- a/src/ol_infrastructure/applications/omnigraph/data_tier.py
+++ b/src/ol_infrastructure/applications/omnigraph/data_tier.py
@@ -119,19 +119,61 @@ SERVER_MEMORY_LIMIT = "2Gi"
 # beyond that — this bounds the single-runaway-actor case, which is the one
 # that actually shows up (a CI reindex streaming a large NDJSON load).
 #
-# The in-flight COUNT comes down from 16 to 8 for the same reason: against a
-# 1-CPU pod, 16 concurrent writes from one actor only queue. An interactive
-# witan session issues one write at a time, so 8 is still far above any
-# legitimate single-user pattern while halving what one bursty indexer can pin.
+# ★ THE COUNT IS NOW SIZED AGAINST THE DEADLINE, NOT AGAINST MEMORY. ★
+# It was 8, derived from this pod's memory limit and described as "far above any
+# legitimate single-user pattern" — true of memory, false of time, and time is
+# what kills these calls. MEASURED 2026-08-12 against the CI data tier directly
+# (port-forward to svc/omnigraph-server, N threads released from a barrier, no
+# vMCP and no APISIX in the path), single-row inserts into a 1,045-row graph:
 #
-# These are a deliberate starting point, not a measurement. Revisit from
-# observed 429 rates and in-flight-byte peaks once the shared service has
-# metrics (tk-observability-for-shared-witan-service-ad3dba) — and note that
-# witan's client-side retry cannot read the server's Retry-After header (the
-# omnigraph CLI's error path discards response headers), so the sizing signal
-# has to come from server-side metrics, not from the client.
-PER_ACTOR_INFLIGHT_MAX = 8
-PER_ACTOR_BYTES_MAX = 256 * 1024 * 1024
+#     n=1  wall  3.45s      n=4  wall 15.54s      n=8  wall 51.08s, p50 33.29s
+#     n=2  wall  6.49s      n=6  wall 31.20s
+#
+# Writes are strictly serialised per graph and get *worse* per write as writers
+# are added (throughput falls 0.31 → 0.16 req/s), because one single-row insert
+# is a full Lance commit against S3 plus a FilteredRead of the whole table. The
+# tool call carrying a write is cut at 30s by three hardcoded ToolHive constants
+# (tk-toolhive-s-vmcp-operational-timeouts-crd-field-i-c44c7a), so:
+#
+#   at 4, every admitted write still lands inside the deadline
+#   at 6, the slowest is already past it
+#   at 8 — exactly the old cap — the MEDIAN is past it, and the server admitted
+#          all eight and 429'd none. It queued them for 51 seconds instead.
+#
+# A cap that admits work it cannot serve is doing the opposite of its job: what
+# the caller gets is not a slow write but a 502 whose outcome nobody can
+# determine (tk-a-502-from-the-deployed-witan-does-not-mean-the--f76dcb).
+#
+# CAVEAT, deliberately accepted: the serialisation is per GRAPH while this cap
+# is per ACTOR, so an actor writing to several graphs at once is bound more
+# tightly than the store requires (4 across two graphs would have completed in
+# parallel). That direction is safe — a 429 with Retry-After is unambiguous and
+# the client retries it — and the case that matters, many writers on the shared
+# `council` graph, is bound correctly.
+#
+# ★ AND A PER-ACTOR CAP CANNOT BOUND A MULTI-USER SERVICE AT ALL. Ten users at
+# one write each is ten in flight, past the knee, with every per-actor cap
+# satisfied. The global bound lives client-side in agent-kit's OmnigraphClient
+# (`_REMOTE_WRITE_MAX_INFLIGHT`, per graph, in the single-replica witan MCP pod
+# every user's write passes through). This cap is the backstop beneath it, for
+# the paths that do not go through that process — the CLI subprocess transport,
+# the migration Job, any other client.
+#
+# Revisit from observed 429 rates and in-flight-byte peaks once the shared
+# service has metrics (tk-observability-for-shared-witan-service-ad3dba). The
+# client CAN now read the Retry-After header over the HTTP transport (it is the
+# omnigraph *CLI* that discards response headers), and refuses immediately
+# rather than sleeping when the hint is longer than its own deadline allows —
+# so a Retry-After well above ~4s reaches users as an error, not as a wait.
+#
+# ★ DEFAULTS, not settings. Both are overridable per environment via
+# `omnigraph:per_actor_inflight_max` / `per_actor_bytes_max` stack config (see
+# __main__.py). Named DEFAULT_ so nothing reads the module constant and believes
+# it knows what a running cluster is configured with — the env var on the
+# Deployment is the source of truth, and `kubectl set env` is a legitimate way
+# to move it in an incident ahead of committing the config.
+DEFAULT_PER_ACTOR_INFLIGHT_MAX = 4
+DEFAULT_PER_ACTOR_BYTES_MAX = 256 * 1024 * 1024
 
 # ── Startup behaviour on an unopenable graph ─────────────────────────────────
 #
@@ -214,6 +256,8 @@ def create_data_tier(  # noqa: PLR0913
     cleanup_schedule: str,
     cleanup_older_than: str,
     storage_prefix: str = "",
+    per_actor_inflight_max: int = DEFAULT_PER_ACTOR_INFLIGHT_MAX,
+    per_actor_bytes_max: int = DEFAULT_PER_ACTOR_BYTES_MAX,
     *,
     suspend_maintenance: bool = False,
 ) -> OmnigraphDataTier:
@@ -226,6 +270,14 @@ def create_data_tier(  # noqa: PLR0913
     rebuilt under a new root and the cluster is then repointed at it, leaving
     the old root intact as the rollback. Empty (the default) means the bucket
     root, which is the steady state.
+
+    ``per_actor_inflight_max`` / ``per_actor_bytes_max`` default to the measured
+    constants above and exist as parameters so a stack can retune admission
+    control from config. The defaults were derived from one measurement of one
+    environment; QA and Production have different graph sizes and therefore a
+    different knee, and the write cost itself is expected to move (upstream
+    task tk-upstream-omnigraph-a-single-row-insert-costs-a-f-eeeae3). Retuning
+    should be a `pulumi config set` away, not a code change.
     """
     # The bucket is named for its tenant (witan's graphs), not the omnigraph
     # service — omnigraph is generic and a future second instance would get its
@@ -557,14 +609,17 @@ def create_data_tier(  # noqa: PLR0913
                                 # Per-actor admission caps, set deliberately
                                 # rather than inherited — the upstream byte
                                 # default is twice this pod's memory limit and
-                                # therefore unreachable. See the constants.
+                                # therefore unreachable. See the constants for
+                                # the sizing, and the stack's
+                                # `omnigraph:per_actor_*` config to retune an
+                                # environment without a code change.
                                 kubernetes.core.v1.EnvVarArgs(
                                     name="OMNIGRAPH_PER_ACTOR_INFLIGHT_MAX",
-                                    value=str(PER_ACTOR_INFLIGHT_MAX),
+                                    value=str(per_actor_inflight_max),
                                 ),
                                 kubernetes.core.v1.EnvVarArgs(
                                     name="OMNIGRAPH_PER_ACTOR_BYTES_MAX",
-                                    value=str(PER_ACTOR_BYTES_MAX),
+                                    value=str(per_actor_bytes_max),
                                 ),
                             ],
                             ports=[
@@ -680,8 +735,10 @@ def create_data_tier(  # noqa: PLR0913
                                 initial_delay_seconds=0,
                                 period_seconds=20,
                             ),
-                            # The memory limit is what PER_ACTOR_BYTES_MAX is
-                            # sized against — change one and revisit the other.
+                            # The memory limit is what the byte cap is sized
+                            # against (DEFAULT_PER_ACTOR_BYTES_MAX, and any
+                            # per-stack override of it) — change one and
+                            # revisit the other.
                             resources=kubernetes.core.v1.ResourceRequirementsArgs(
                                 requests={"cpu": "250m", "memory": "512Mi"},
                                 limits={"cpu": "1", "memory": SERVER_MEMORY_LIMIT},

--- a/src/ol_infrastructure/applications/witan/__main__.py
+++ b/src/ol_infrastructure/applications/witan/__main__.py
@@ -319,10 +319,39 @@ WITAN_CI_INDEX_SCHEDULE = (
 # Empty here means "use the code default" (4 writes, 10s queue wait). Set per
 # stack when an environment's measured knee differs — Production's larger graphs
 # make each write slower, and the write cost itself is expected to change
-# upstream. Both are read per call inside witan, so `kubectl set env` moves them
-# on a live pod ahead of committing the config.
+# upstream.
+#
+# ★ CHANGING EITHER REPLACES THE POD. Kubernetes cannot edit env vars inside a
+# running container: `kubectl set env` rewrites the workload template and rolls
+# it, and for this workload that means the single witan replica is recreated and
+# in-flight calls are dropped. witan reads both per call, so the NEW pod picks a
+# value up on its very next write with no rebuild or release — that is the
+# property worth having, not a disruption-free edit, and the earlier wording
+# here claimed the latter. Treat an incident retune as a (brief) restart.
+#
+# And persist it: the MCPServer is operator-owned, so a hand-edit is reverted by
+# the next reconcile or `pulumi up`. `kubectl set env` buys the minutes before
+# the config change lands, not a durable setting.
 WITAN_REMOTE_WRITE_MAX_INFLIGHT = witan_config.get("remote_write_max_inflight") or ""
 WITAN_REMOTE_WRITE_QUEUE_SECONDS = witan_config.get("remote_write_queue_seconds") or ""
+
+# How long a witan tool call has before something upstream stops waiting for it.
+# ★ THIS NUMBER IS A PROPERTY OF THIS DEPLOYMENT, WHICH IS WHY IT IS SET HERE
+# AND NOT IN witan-core. The same client library also runs from an interactive
+# CLI with no deadline at all and from the migration Job, which is happy to wait
+# minutes; a library that assumed 30s would be wrong for both.
+#
+# 30s is ToolHive's, and it is not adjustable: three separate hardcoded
+# constants in v0.42.0 (the vMCP backend client twice, and WriteTimeout on the
+# vMCP's own listener) each cut a `tools/call` at 30s, and the CRD field that
+# looks like the knob — `spec.config.operational.timeouts` — is read by nothing
+# at runtime (tk-toolhive-s-vmcp-operational-timeouts-crd-field-i-c44c7a).
+# Telling witan the number lets it refuse a write it cannot finish, instead of
+# being torn down mid-call and returning a 502 whose outcome nobody can
+# determine.
+WITAN_REMOTE_CALL_BUDGET_SECONDS = (
+    witan_config.get("remote_call_budget_seconds") or "30"
+)
 
 # The GitHub App the CI indexer clones as, when one is configured. All three
 # values come from one SOPS file rather than splitting the ids into plain
@@ -766,6 +795,7 @@ mcp_servers = create_mcp_servers(
     service_version=witan_service_version,
     remote_write_max_inflight=WITAN_REMOTE_WRITE_MAX_INFLIGHT,
     remote_write_queue_seconds=WITAN_REMOTE_WRITE_QUEUE_SECONDS,
+    remote_call_budget_seconds=WITAN_REMOTE_CALL_BUDGET_SECONDS,
 )
 
 #########################################

--- a/src/ol_infrastructure/applications/witan/__main__.py
+++ b/src/ol_infrastructure/applications/witan/__main__.py
@@ -307,6 +307,23 @@ WITAN_CI_INDEX_SCHEDULE = (
     witan_config.get("ci_index_schedule") or DEFAULT_INDEX_SCHEDULE
 )
 
+# Client-side write admission, applied inside the MCP tier before a write is
+# sent to the data tier (agent-kit `witan_core.omnigraph._WriteGate`). This is
+# the GLOBAL bound the data tier's per-actor cap cannot be: every user's write
+# passes through this single-replica pod, so it is the one place total in-flight
+# concurrency is visible. Past ~4 writes in flight against one graph, a write
+# cannot finish inside ToolHive's hardcoded 30s deadline, and what the caller
+# gets is not a slow write but a 502 whose outcome is indeterminate — so the
+# tier refuses with a sentence instead, before anything is sent.
+#
+# Empty here means "use the code default" (4 writes, 10s queue wait). Set per
+# stack when an environment's measured knee differs — Production's larger graphs
+# make each write slower, and the write cost itself is expected to change
+# upstream. Both are read per call inside witan, so `kubectl set env` moves them
+# on a live pod ahead of committing the config.
+WITAN_REMOTE_WRITE_MAX_INFLIGHT = witan_config.get("remote_write_max_inflight") or ""
+WITAN_REMOTE_WRITE_QUEUE_SECONDS = witan_config.get("remote_write_queue_seconds") or ""
+
 # The GitHub App the CI indexer clones as, when one is configured. All three
 # values come from one SOPS file rather than splitting the ids into plain
 # Pulumi config: they are obtained together, in one sitting, when the App is
@@ -747,6 +764,8 @@ mcp_servers = create_mcp_servers(
     witan_code_token_secret=witan_code_token_secret,
     migration_job=witan_migration_job,
     service_version=witan_service_version,
+    remote_write_max_inflight=WITAN_REMOTE_WRITE_MAX_INFLIGHT,
+    remote_write_queue_seconds=WITAN_REMOTE_WRITE_QUEUE_SECONDS,
 )
 
 #########################################

--- a/src/ol_infrastructure/applications/witan/mcp_servers.py
+++ b/src/ol_infrastructure/applications/witan/mcp_servers.py
@@ -222,8 +222,17 @@ def create_mcp_servers(  # noqa: PLR0913
     witan_code_token_secret: Resource,
     migration_job: Resource,
     service_version: str,
+    remote_write_max_inflight: str = "",
+    remote_write_queue_seconds: str = "",
 ) -> WitanMCPServers:
-    """Provision the witan-tools MCPGroup and the witan MCPServer backend."""
+    """Provision the witan-tools MCPGroup and the witan MCPServer backend.
+
+    ``remote_write_max_inflight`` / ``remote_write_queue_seconds`` retune
+    witan's client-side write admission. Empty (the default) leaves witan's own
+    defaults in force — the env var is omitted entirely rather than set to an
+    empty string, so "unset" and "set to nothing" cannot diverge between what
+    Pulumi declares and what witan reads.
+    """
     witan_mcpgroup = kubernetes.apiextensions.CustomResource(
         f"witan-mcpgroup-{stack_info.env_suffix}",
         api_version="toolhive.stacklok.dev/v1beta1",
@@ -312,6 +321,34 @@ def create_mcp_servers(  # noqa: PLR0913
                 # boundary from claiming a graph's shared default-branch view;
                 # only the in-cluster CI indexer Job declares itself `ci`.
                 {"name": "WITAN_CODE_SERVER", "value": omnigraph_server_addr},
+                # Client-side write admission, per graph, inside this pod —
+                # the global bound the data tier's PER-ACTOR cap cannot be,
+                # since every user's write funnels through this single replica
+                # and the 30s deadline sees total concurrency, not one actor's
+                # share. Only emitted when the stack sets a value: witan's own
+                # defaults (4 in flight, 10s of queue) are the measured ones,
+                # and an env var present-but-empty would only invite a debate
+                # about which layer's default is in force.
+                *(
+                    [
+                        {
+                            "name": "WITAN_REMOTE_WRITE_MAX_INFLIGHT",
+                            "value": str(remote_write_max_inflight),
+                        }
+                    ]
+                    if remote_write_max_inflight
+                    else []
+                ),
+                *(
+                    [
+                        {
+                            "name": "WITAN_REMOTE_WRITE_QUEUE_SECONDS",
+                            "value": str(remote_write_queue_seconds),
+                        }
+                    ]
+                    if remote_write_queue_seconds
+                    else []
+                ),
                 # Structured logging + OTel. Appended from a shared helper
                 # rather than spelled out here so this workload, the CI
                 # indexer, and anything added later cannot drift into

--- a/src/ol_infrastructure/applications/witan/mcp_servers.py
+++ b/src/ol_infrastructure/applications/witan/mcp_servers.py
@@ -224,6 +224,7 @@ def create_mcp_servers(  # noqa: PLR0913
     service_version: str,
     remote_write_max_inflight: str = "",
     remote_write_queue_seconds: str = "",
+    remote_call_budget_seconds: str = "",
 ) -> WitanMCPServers:
     """Provision the witan-tools MCPGroup and the witan MCPServer backend.
 
@@ -232,6 +233,12 @@ def create_mcp_servers(  # noqa: PLR0913
     defaults in force — the env var is omitted entirely rather than set to an
     empty string, so "unset" and "set to nothing" cannot diverge between what
     Pulumi declares and what witan reads.
+
+    ``remote_call_budget_seconds`` tells witan how long a tool call has here
+    before ToolHive stops waiting for it, so it can refuse a write it cannot
+    finish rather than be cut off mid-call. witan-core assumes no deadline of
+    its own — the same library runs from a CLI and from a batch Job — so this
+    is the deployment declaring one. See the note at its call site.
     """
     witan_mcpgroup = kubernetes.apiextensions.CustomResource(
         f"witan-mcpgroup-{stack_info.env_suffix}",
@@ -347,6 +354,20 @@ def create_mcp_servers(  # noqa: PLR0913
                         }
                     ]
                     if remote_write_queue_seconds
+                    else []
+                ),
+                # The deadline THIS deployment imposes, told to witan so it can
+                # refuse a write it has no time left to finish. Set here rather
+                # than defaulted in witan-core because it is a fact about
+                # ToolHive, not about the client library — see the call site.
+                *(
+                    [
+                        {
+                            "name": "WITAN_REMOTE_CALL_BUDGET_SECONDS",
+                            "value": str(remote_call_budget_seconds),
+                        }
+                    ]
+                    if remote_call_budget_seconds
                     else []
                 ),
                 # Structured logging + OTel. Appended from a shared helper


### PR DESCRIPTION
### What are the relevant tickets?

No GitHub issues — tracked in witan's task graph:

- `tk-the-per-actor-in-flight-cap-8-admits-more-writes-ca5333` (p1) — work item 1 is this PR
- `tk-concurrent-writes-to-the-deployed-witan-are-canc-02abbd` (p0) — the measurement behind it

Companion PR (the client half): https://github.com/mitodl/agent-kit/pull/225

### Description (What does it do?)

`PER_ACTOR_INFLIGHT_MAX` was 8, derived from the pod's 2 GiB memory limit and described in its own comment as *"far above any legitimate single-user pattern"*. That is true of memory and false of time — and time is what kills these calls.

Measured 2026-08-12 against the CI data tier directly (port-forward to `svc/omnigraph-server`, N real threads released from a barrier, no vMCP and no APISIX in the path), single-row inserts into a 1,045-row graph:

```
n=1   wall  3.45s     n=4   wall 15.54s     n=8   wall 51.08s (p50 33.29s)
n=2   wall  6.49s     n=6   wall 31.20s
```

Against a hardcoded 30s ToolHive deadline:

- at **4**, every admitted write still lands
- at **6**, the slowest is already past it
- at **8** — exactly the old cap, one actor — the server admitted all eight and 429'd **none**. It queued them for 51 seconds instead.

What those callers got was not a slow write. It was a 502 whose outcome nobody can determine: across two 16-writer bursts, one committed every row it 502'd on (28/28) and the other did not (14/16). A cap that admits work it cannot serve is doing the opposite of its job.

So the count comes down to **4**, and the sizing comment is rewritten to derive it from the deadline and the measured ~3.5–4s per write rather than from the memory limit. The byte cap is unchanged — that reasoning was sound and is unrelated.

**One caveat, written into the comment rather than left to be rediscovered.** The serialisation is per **graph** and this cap is per **actor**, so an actor writing to several graphs at once is now bound more tightly than the store requires — 4 spread across two graphs would have completed in parallel. Accepted deliberately: that direction is safe (a 429 with `Retry-After` is unambiguous, and the client retries it with its own budget), and the case that actually matters — many writers on the shared `council` graph — is bound correctly.

**A per-actor cap still cannot bound a multi-user service at all.** Ten users at one write each is ten in flight, past the knee, with every per-actor cap satisfied. The global bound lives in the witan MCP tier (`_WriteGate`, agent-kit#225), which is the single-replica pod every user's write passes through. This PR configures it via two optional env vars and keeps the data-tier cap as the backstop beneath it, for the paths that do not go through that process — the CLI subprocess transport, the migration Job, any other client.

**All four knobs become stack config**, with the measured values as defaults:

| Setting | Default | Where |
|---|---|---|
| `omnigraph:per_actor_inflight_max` | 4 | `DEFAULT_PER_ACTOR_INFLIGHT_MAX` |
| `omnigraph:per_actor_bytes_max` | 256 MiB | `DEFAULT_PER_ACTOR_BYTES_MAX` |
| `witan:remote_write_max_inflight` | witan's own 4 | `WITAN_REMOTE_WRITE_MAX_INFLIGHT` |
| `witan:remote_write_queue_seconds` | witan's own 10 | `WITAN_REMOTE_WRITE_QUEUE_SECONDS` |

The two witan vars are emitted **only when a stack sets a value**, so "unset" and "set to empty" cannot diverge between what Pulumi declares and what witan reads. The constants are renamed `DEFAULT_*` so nothing reads the module value and believes it knows what a running cluster is configured with — the env var on the Deployment is the source of truth, and `kubectl set env` is a legitimate way to move it during an incident ahead of committing the config.

The reason for all of it: these numbers came from **one** measurement of **one** environment. The knee moves with graph size (a write costs a full-table read, so Production's larger tables are slower per write) and will move again when the per-write cost is attacked upstream. Retuning admission control during an incident must not mean editing this repo, cutting a release and rolling an image.

### How can this be tested?

Run locally, clean:

```
uv run ruff check src/ol_infrastructure/applications/{omnigraph,witan}/   All checks passed
uv run ruff format --check                                               formatted
uv run mypy data_tier.py mcp_servers.py                                  no issues
pre-commit (repo hooks)                                                  all passed
```

**`pulumi preview` has NOT been run** — I had no stack credentials in this session. Please run it against CI before merging. The expected diff is narrow:

- `omnigraph` stack: two env values on the `omnigraph-server` Deployment (`OMNIGRAPH_PER_ACTOR_INFLIGHT_MAX` 8 → 4, `OMNIGRAPH_PER_ACTOR_BYTES_MAX` unchanged), which rolls the pod.
- `witan` stack: **no diff at all** unless a stack sets one of the two new config keys, since the env vars are omitted when empty.

To verify the effect after deploying to CI, re-run the write probe from agent-kit:

```
uv run python -m witan.scripts.concurrency_probe --target ci --writers 24 --readers 12 --lead 75
```

Expected: writers past the bound get 429 + `Retry-After` (or, with agent-kit#225 deployed, a client-side `WriteQueueFull` refusal before anything is sent) instead of a 30s 502. Re-measure the **curve**, not one point — tracked as item 4 of `ca5333`.

Config override sanity-check, without deploying:

```
pulumi config set omnigraph:per_actor_inflight_max 6 --stack CI
pulumi preview   # should show only the env value moving
```

### Additional Context

- **Ordering with agent-kit#225: none required.** The two are independent, and either alone is strictly better than today. Deploying this without the client gate simply means the data tier sheds at 4 per actor; deploying the client gate without this means witan sheds at 4 per graph before the server is asked.
- **This restart is a hard gap, not a rolling one.** The data tier is deliberately `replicas=1` + `strategy=Recreate` (its storage is strict-single-version, so two binaries must never hold the same S3 store), so the cap change takes the service down for the ~52–61s a restart measures. Schedule it like any other data-tier restart.
- **Do not raise the ToolHive deadline instead.** It is three hardcoded constants in v0.42.0 with no CRD field — `spec.config.operational.timeouts` exists, is defaulted and validated, and is read by nothing at runtime (`tk-toolhive-s-vmcp-operational-timeouts-crd-field-i-c44c7a`). And the queue grows to fill whatever the deadline is: throughput *falls* from 0.31 to 0.16 req/s as writers are added.
- **This does not fix the underlying cost.** A single-row insert costs a full-table `FilteredRead` — 3,095 S3 IOPS for 1,045 rows — which is an omnigraph/Lance-on-S3 property and the only thing that would actually raise the ceiling (`tk-upstream-omnigraph-a-single-row-insert-costs-a-f-eeeae3`).

### Checklist:
- [ ] Run `pulumi preview` against the CI stack and confirm the diff is limited to the two Deployment env values
- [ ] Schedule the `omnigraph-server` restart (replicas=1 + Recreate — ~1 minute with no endpoint)
- [ ] After deploy, re-run the concurrency probe and record the new curve on `tk-the-per-actor-in-flight-cap-8-admits-more-writes-ca5333`
