### PR TITLE
fix(concourse): grant rds:ModifyDBInstance to the pulumi_infra worker policy

### DIFF
--- a/src/ol_infrastructure/applications/concourse/iam_policies/pulumi_infra.py
+++ b/src/ol_infrastructure/applications/concourse/iam_policies/pulumi_infra.py
@@ -314,6 +314,7 @@ policy_definition = {
                 "rds:DescribeDBParameters",
                 "rds:DescribeDBSubnetGroups",
                 "rds:ListTagsForResource",
+                "rds:ModifyDBInstance",
                 "rds:ModifyDBSubnetGroup",
                 "rds:ResetDBParameterGroup",
                 "route53:CreateHostedZone",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Adds `rds:ModifyDBInstance` to the `pulumi_infra` Concourse worker IAM policy in `src/ol_infrastructure/applications/concourse/iam_policies/pulumi_infra.py`.

The infra worker pool (`concourse-instance-role-worker-infra-production`) was failing to deploy the `keycloak-ci` stack with:

```
AccessDenied: User: arn:aws:sts::610119931565:assumed-role/concourse-instance-role-worker-infra-production-ed1176e/i-09a57f999c8066ff8
is not authorized to perform: rds:ModifyDBInstance on resource: arn:aws:rds:us-east-1:610119931565:db:keycloak-ci
because no identity-based policy allows the rds:ModifyDBInstance action
```

The policy already granted `rds:ModifyDBSubnetGroup` but was missing the paired `rds:ModifyDBInstance` action needed to update instance-level RDS attributes.

### How can this be tested?
Run a `pulumi up` and then verify that the Keycloak pipeline succeeds with an RDS modification.

### Additional Context
This is a minimal, single-action addition to the existing least-privilege `pulumi_infra` policy — it does not touch the IAM self-management statement or widen any resource scope.