### PR TITLE
fix(grafana-alerting): adopt the MIT Learn synthetic checks and give them a window that can see a creep

### DIFF
--- a/src/ol_infrastructure/infrastructure/grafana_alerting/CLAUDE.md
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/CLAUDE.md
@@ -167,13 +167,32 @@ a confusing NoData state.
 ### Adopting a rule that was created in the UI
 
 Rule groups import with `{{ folderUID }}:{{ title }}`, where `title` is the rule
-*group* name, not the rule name:
+*group* name, not the rule name.
+
+**Export the Grafana credentials first.** `pulumi import` resolves the resource
+against the CLI's *default* provider rather than the explicit `grafana.Provider`
+that `__main__.py` builds, and passing `--provider` does not change that. Without
+configuration it fails with:
 
 ```
+the Grafana client is required for this resource.
+Set the auth and url provider attributes
+```
+
+Give the default provider the same credentials the program reads:
+
+```
+export GRAFANA_URL="$(sops -d src/bridge/secrets/grafana_cloud/api.production.yaml | yq -r '.grafana_url')"
+export GRAFANA_AUTH="$(sops -d src/bridge/secrets/grafana_cloud/api.production.yaml | yq -r '.grafana_api_token')"
+
 pulumi stack select Production
 pulumi import grafana:alerting/ruleGroup:RuleGroup \
   <pulumi-resource-name> "<folder-uid>:<rule-group-name>"
 ```
+
+Importing through the default provider does not strand the resource there: the
+next `pulumi preview` shows the group as an update under the program's own
+provider, not a replacement. Check that it does before applying.
 
 Import the group before the first `pulumi up` that declares it — an apply
 against an undeclared existing group fails as already-exists rather than

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/CLAUDE.md
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/CLAUDE.md
@@ -81,6 +81,7 @@ Rootly). That path is independent of Grafana and is managed in
 | `metric_rules/eks_general.py` | EKS workload alert rules (replicas, node readiness, crash loops, OOM, jobs, HPA). |
 | `metric_rules/linux_host.py` | Linux host alert rules (CPU, memory, disk usage). |
 | `metric_rules/apisix_edge.py` | Per-host 5xx rate at the APISIX edge (`apisix_http_status`). Two windows (fast cliff / slow creep) with a minimum-traffic gate. Currently unlabelled → `oblivion` while calibrating. |
+| `metric_rules/synthetic_monitoring.py` | MIT Learn probe-failure rules (`probe_success`) for the Next.js origin, the API health endpoint, and the homepage. Imported from hand-made UI rules; lives in the Synthetic Monitoring **plugin's** folder, so it takes no `folder_uid`. |
 | `log_rules/` | Package. Grafana-managed alert rule groups for log queries. Migrated from `grafana-alerts/loki-rules/`. |
 | `log_rules/base.py` | Loki datasource UIDs, two-stage pipeline helper, folder creation, delegates to sub-modules. |
 | `log_rules/cert_manager.py` | cert-manager ACME issuer and DNS challenge alert rules. |
@@ -119,6 +120,13 @@ UID and a pre-bound `rd(expr)` helper from its package `base.py`:
 create(folder_uid: Input[str], rd: Callable[[str], list[RuleGroupRuleDataArgs]], resource_opts: ResourceOptions)
 ```
 
+`metric_rules/synthetic_monitoring.py` is the one exception — it omits
+`folder_uid` because its rules must stay in the Synthetic Monitoring plugin's
+folder (`grafana-synthetic-monitoring-app`), which Pulumi references but does not
+create. The folder UID is half a rule group's import identity, so moving those
+rules into "Infrastructure Alerts" would destroy and recreate them, losing their
+alert-state history and any live silences.
+
 Within `dashboards/`, each sub-module receives the folder UID, the shared
 panel-builder helpers, and a `create_dashboard` helper from `base.py`:
 
@@ -155,6 +163,31 @@ a confusing NoData state.
 3. Use `rd(expr)` to build the two-stage data pipeline from a PromQL expression.
 4. Set `for_`, `labels`, `annotations`, and `no_data_state` to match the
    original YAML.
+
+### Adopting a rule that was created in the UI
+
+Rule groups import with `{{ folderUID }}:{{ title }}`, where `title` is the rule
+*group* name, not the rule name:
+
+```
+pulumi stack select Production
+pulumi import grafana:alerting/ruleGroup:RuleGroup \
+  <pulumi-resource-name> "<folder-uid>:<rule-group-name>"
+```
+
+Import the group before the first `pulumi up` that declares it — an apply
+against an undeclared existing group fails as already-exists rather than
+adopting it.
+
+Two things to check first:
+
+1. **What else is in the group.** Import adopts the whole group, and any rule in
+   it that the code does not declare is deleted on the next apply. Check with
+   `GET /api/v1/provisioning/folder/{folderUid}/rule-groups/{group}`.
+2. **Pin each rule's `uid`** to the value it already has. Without it the
+   provider assigns a fresh one, which orphans the rule's alert-state history,
+   breaks live silences, and dead-links the Grafana URL embedded in every past
+   Rootly alert.
 
 ### Adding a new log alert rule
 

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/base.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/base.py
@@ -37,6 +37,10 @@ Sub-modules
   eks_general  — Source: grafana-alerts/cortex-rules/eks_general.yaml
   linux_host   — Source: grafana-alerts/cortex-rules/linux-host.yaml
   apisix_edge  — New in 2026-08. Per-host 5xx rate at the APISIX edge.
+  synthetic_monitoring
+               — Imported 2026-08 from three hand-made UI rules. Unlike the
+                 others it takes no folder_uid: its rules live in the Synthetic
+                 Monitoring plugin's folder, not the one created here.
 """
 
 import json
@@ -49,6 +53,7 @@ from ol_infrastructure.infrastructure.grafana_alerting.metric_rules import (
     apisix_edge,
     eks_general,
     linux_host,
+    synthetic_monitoring,
 )
 
 # Every Grafana Cloud stack provisions its own Mimir datasource with this same
@@ -149,3 +154,6 @@ def create(resource_opts: ResourceOptions) -> None:
     eks_general.create(alerts_folder.uid, rd, resource_opts)
     linux_host.create(alerts_folder.uid, rd, resource_opts)
     apisix_edge.create(alerts_folder.uid, rd, resource_opts)
+    # No folder_uid: these rules live in the Synthetic Monitoring plugin's own
+    # folder rather than the one created above. See the module docstring.
+    synthetic_monitoring.create(rd, resource_opts)

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/synthetic_monitoring.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/synthetic_monitoring.py
@@ -1,0 +1,337 @@
+"""Grafana Synthetic Monitoring probe-failure alert rules for MIT Learn.
+
+Three hand-made rules lived in the Synthetic Monitoring folder since April-June
+2026, created through the UI and unmanaged. Imported here 2026-08-13 after the
+NextJS one paged twice in an hour for a single failed probe. They are grouped in
+one module because they are the same rule three times over, differing only in
+which endpoint they probe.
+
+Not to be confused with the `sm-*` rules in the same folder
+(ProbeFailedExecutionsTooHigh, HTTPRequestDurationTooHighAvg,
+TLSTargetCertificateCloseToExpiring). Those are generated and owned by the
+grafana-synthetic-monitoring-app plugin. Leave them alone -- Pulumi does not
+manage them and adopting them would fight the plugin.
+
+Folder
+------
+`_SM_FOLDER_UID` is the plugin's own folder, not a Pulumi-created one, so this
+module takes no `folder_uid` parameter (unlike every other metric_rules
+sub-module). The rules must stay in that folder: the folder UID is half the
+import identity, so moving them to "Infrastructure Alerts" would destroy and
+recreate all three, losing their alert-state history and any live silences.
+
+Why the expression is inverted
+------------------------------
+The obvious translation of "fire when availability drops" is
+
+    avg_over_time(probe_success{...}[5m]) < 0.8      # WRONG
+
+and it is silently broken. base.py's `_rule_data` feeds stage A's value into a
+threshold stage that fires on `last(A) > 0`. When every probe in the window
+fails, `avg_over_time` is 0, the `< 0.8` comparison passes, and stage A returns
+a series whose *value* is 0 -- which stage C then reads as "not firing". That
+form alerts on a partial outage and goes silent on a total one, the exact
+inverse of what it is for.
+
+So these measure the failure ratio instead, whose value rises as things get
+worse and is positive whenever the rule should fire:
+
+    1 - avg_over_time(probe_success{...}[5m]) > 0.3
+
+This is the same "put the clause whose value you want to survive on the left"
+reasoning documented at eks_general.py:108-116 and apisix_edge.py, applied to a
+comparison rather than an `and`.
+
+Two windows, because the two failure shapes need different ones
+---------------------------------------------------------------
+  fast — a cliff. 2+ of the last 5 probes failed, held for 5m. An outage.
+  slow — a creep. >4% of the last hour's probes failed, held for 30m.
+
+The single-window rules these replace used `< 1`: *any* one failed probe out of
+five, from a single probe location, with no quorum. That is what produced the
+paging -- observed firing at A=0.75 and A=0.8, i.e. 3/4 and 4/5 probes
+succeeding.
+
+docs/plans/grafana-alerting-remediation-spec.md proposed `< 0.6` (3+ of 5) as
+the fix. Both that and the looser 2-of-5 chosen here are necessary but not
+sufficient, and the 2026-08-13 Next.js incident is why: a deploy put a
+jsdom-backed HTML parse on every server-rendered page, the origin spent two
+hours intermittently timing out at the check's 15s ceiling, and *no* 5m-window
+threshold caught it. The worst 5m window reached only 2 of 5 failures and held
+it for about two minutes -- short of `for_="5m"` on a 300s interval. Over a 1h
+window the same period was unmistakable: a flat 0 for the preceding ten hours,
+then a climb through 3%, 5%, 7% to 10%.
+
+So the fast window alone is quieter than the rule it replaces but blind to
+exactly the degradation that prompted the rewrite. The slow window is what
+actually catches that shape.
+
+The slow rules ship unrouted
+----------------------------
+They carry no `severity` label, so alertmanager.py's default route drops them in
+`oblivion`: evaluated and recorded in `grafanacloud-alert-state-history`, but
+delivered nowhere. This is the same calibration mechanism apisix_edge.py uses,
+and it is here because measurement over the 7 days to 2026-08-13 says both
+thresholds are still guesses:
+
+  fast `> 0.3`, for 5m   — would not have fired once in 7 days, on any of the
+                           three checks. Not even for the moment on 2026-08-10
+                           when all 5 of the Next.js probes in a window failed:
+                           it did not stay true across two consecutive 300s
+                           evaluations. Safe (it is strictly quieter than the
+                           `< 1` rule it replaces, which fired twice in one hour
+                           on 2026-08-13) but likely too quiet.
+  slow `> 0.04`, for 30m — would have fired ~5 times in 7 days on the API health
+                           endpoint alone, whose 1h failure ratio peaks at 8.3%
+                           in normal operation. Routing that at `critical` today
+                           would recreate the paging problem this rewrite is
+                           meant to end.
+
+Per-check baselines, 7d max of the 1h failure ratio, measured 2026-08-13:
+learn.mit.edu 1.7%, api.learn.mit.edu/learn/health 8.3%, next.learn.mit.edu
+21.7%. The homepage is the only one quiet enough for 4% as written; the other
+two need either a per-check threshold or a higher common one.
+
+Promote a slow rule by adding `severity` to its labels and nothing else --
+`instance` is already in NotificationPolicy.group_bies. Measure first with:
+
+  sum by (ruleTitle) (count_over_time(
+    {from="state-history"} | json | current =~ `Alerting.*` [14d]))
+
+Thresholds sit *between* quantisation steps on purpose
+------------------------------------------------------
+Probes run every 60s, so a 5m window is quantised to fifths (0.2, 0.4, ...) and
+a 1h window to sixtieths (0.0167, 0.0333, 0.05, ...). Both thresholds are placed
+in the gaps rather than on a step:
+
+  fast `> 0.3`  -- between 1 failure (0.2) and 2 (0.4)
+  slow `> 0.04` -- between 2 failures/hr (0.0333) and 3 (0.05)
+
+A threshold written directly on a step is decided by float representation
+rather than by intent: `1 - 0.8` evaluates to 0.19999999999999996, so a `> 0.2`
+meaning "more than one failure" happens to work only by accident of rounding.
+Sitting in the gap makes the boundary explicit and unambiguous.
+
+no_data_state
+-------------
+"OK", per the convention in base.py. It is load-bearing here rather than
+incidental: the threshold is baked into the PromQL, so a healthy check returns
+*no series at all*. "NoData" -- what these rules carried before -- would treat
+the healthy state as missing data on every single evaluation.
+
+The cost is that a probe which stops reporting entirely no longer alerts here.
+The plugin's own ProbeFailedExecutionsTooHigh covers that case.
+
+Severity (fast rules only)
+--------------------------
+`warning` for the Next.js origin check, `critical` for the two user-facing ones.
+The Next.js check deliberately bypasses Fastly (that is what "Bypass Fastly"
+means) and hits the origin directly, so it fires on origin degradation the CDN
+is still absorbing -- on 2026-08-13 it failed repeatedly while the Fastly-fronted
+learn.mit.edu probe held flat at 0.02s. Worth knowing about; not worth waking
+someone for. learn.mit.edu and the API health endpoint have no such buffer.
+
+Both routes land on the same Rootly contact point via alertmanager.py's policy
+tree. That replaces a `notification_settings.receiver="Rootly"` override on all
+three rules, which pointed at a second, UI-created contact point (uid
+eel3rjpiwahoge) distinct from Pulumi's `rootly` (uid bfsoqo63lsyrka) and
+bypassed the policy tree entirely. `instance` is already in
+NotificationPolicy.group_bies, so each probed URL keeps its own notification
+thread.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from pulumi import ResourceOptions
+from pulumiverse_grafana import alerting
+
+# The Synthetic Monitoring plugin's folder. Referenced, never created -- see the
+# module docstring.
+_SM_FOLDER_UID = "grafana-synthetic-monitoring-app"
+
+# Window and failure-ratio threshold per rule. Both thresholds sit between
+# quantisation steps rather than on one -- see the module docstring.
+_FAST_WINDOW, _FAST_RATIO, _FAST_FOR = "5m", "0.3", "5m"
+_SLOW_WINDOW, _SLOW_RATIO, _SLOW_FOR = "1h", "0.04", "30m"
+
+
+@dataclass(frozen=True)
+class _Check:
+    """A single synthetic check and the two alert rules that watch it."""
+
+    resource_name: str
+    group_name: str
+    # UID of the pre-existing hand-made rule, pinned onto the fast rule so the
+    # import keeps its identity. The slow rule is new and gets a fresh UID.
+    rule_uid: str
+    rule_name: str
+    slow_rule_name: str
+    job: str
+    instance: str
+    component: str
+    severity: str
+    # Subject of the alert summaries, e.g. "MIT Learn Next.js origin".
+    what: str
+    # Triage guidance appended to both descriptions.
+    context: str
+
+
+_CHECKS = [
+    _Check(
+        resource_name="mit-learn-nextjs-check-failed",
+        group_name="MIT Learn NextJS",
+        rule_uid="afjaps6wtn0n4a",
+        rule_name="Learn NextJS Homepage (Bypass Fastly) - Check Failed",
+        slow_rule_name=(
+            "Learn NextJS Homepage (Bypass Fastly) - Elevated Probe Failure Rate"
+        ),
+        job="Learn NextJS Homepage (Bypass Fastly)",
+        instance="https://next.learn.mit.edu/",
+        component="nextjs",
+        severity="warning",
+        what="MIT Learn Next.js origin",
+        context=(
+            "This check bypasses Fastly and hits the Next.js origin directly, so it "
+            "reports origin health rather than what CDN-fronted users see -- compare "
+            "the Fastly-fronted learn.mit.edu check before treating it as "
+            "user-facing. Failures here are usually 15s timeouts (the check's own "
+            "ceiling) rather than HTTP errors; when they are, compare container "
+            "working set per ReplicaSet across the most recent rollout of the "
+            "mit-learn-nextjs deployment in the mitlearn namespace, because this has "
+            "twice been an application memory regression shipped by a deploy rather "
+            "than an infrastructure fault."
+        ),
+    ),
+    _Check(
+        resource_name="mit-learn-api-check-failed",
+        group_name="MIT Learn API",
+        rule_uid="ffjan53rjjugwb",
+        rule_name="Learn API Health Endpoint - Check Failed",
+        slow_rule_name="Learn API Health Endpoint - Elevated Probe Failure Rate",
+        job="Learn API Health Endpoint",
+        instance="https://api.learn.mit.edu/learn/health",
+        component="api",
+        severity="critical",
+        what="MIT Learn API health endpoint",
+        context=(
+            "This is the API's own health endpoint, so sustained failure means the "
+            "API is not serving."
+        ),
+    ),
+    _Check(
+        resource_name="mit-learn-website-check-failed",
+        group_name="MIT Learn Website",
+        rule_uid="ffjaotwo4dblsd",
+        rule_name="Learn Homepage - Check Failed",
+        slow_rule_name="Learn Homepage - Elevated Probe Failure Rate",
+        job="Learn Homepage",
+        instance="https://learn.mit.edu/",
+        component="webapp",
+        severity="critical",
+        what="MIT Learn homepage",
+        context=(
+            "This is the public homepage through Fastly, so failures here are "
+            "user-facing."
+        ),
+    ),
+]
+
+
+def _failure_ratio_expr(job: str, instance: str, window: str, threshold: str) -> str:
+    """Build the probe failure-ratio expression for one check and window.
+
+    Returns a series only when the failure ratio exceeds the threshold, and the
+    value it returns rises as the check gets worse, so the downstream `> 0`
+    threshold stage reads it correctly. See "Why the expression is inverted" in
+    the module docstring -- the naive `avg_over_time(...) < x` form goes silent
+    during a total outage.
+    """
+    return (
+        f"1 - avg_over_time("
+        f'probe_success{{job="{job}", instance="{instance}"}}[{window}]'
+        f") > {threshold}"
+    )
+
+
+def _rules(
+    check: _Check, rd: Callable[[str], list[alerting.RuleGroupRuleDataArgs]]
+) -> list[alerting.RuleGroupRuleArgs]:
+    """Build the fast (cliff) and slow (creep) rules for one check."""
+    base_labels = {"component": check.component, "service": "mitlearn"}
+    # The slow rules deliberately carry no `severity` -- see "The slow rules
+    # ship unrouted" in the module docstring.
+    fast_labels = base_labels | {"severity": check.severity}
+    return [
+        alerting.RuleGroupRuleArgs(
+            # Pinned so the imported rule keeps its identity: alert state
+            # history, existing silences, and the Grafana rule URL already
+            # embedded in every past Rootly alert all key off this UID.
+            uid=check.rule_uid,
+            name=check.rule_name,
+            condition="C",
+            for_=_FAST_FOR,
+            no_data_state="OK",
+            exec_err_state="Error",
+            labels=fast_labels,
+            annotations={
+                "summary": f"{check.what} is failing synthetic probes",
+                "description": (
+                    f"More than one of the last 5 synthetic probes against "
+                    f"{{{{ $labels.instance }}}} from {{{{ $labels.probe }}}} "
+                    f"failed, sustained for {_FAST_FOR}. {check.context}"
+                ),
+            },
+            datas=rd(
+                _failure_ratio_expr(
+                    check.job, check.instance, _FAST_WINDOW, _FAST_RATIO
+                )
+            ),
+        ),
+        alerting.RuleGroupRuleArgs(
+            name=check.slow_rule_name,
+            condition="C",
+            for_=_SLOW_FOR,
+            no_data_state="OK",
+            exec_err_state="Error",
+            labels=base_labels,
+            annotations={
+                "summary": (
+                    f"{check.what} has an elevated synthetic probe failure rate"
+                ),
+                "description": (
+                    f"Over 4% of the last hour's synthetic probes against "
+                    f"{{{{ $labels.instance }}}} from {{{{ $labels.probe }}}} "
+                    f"failed, sustained for {_SLOW_FOR}. This is the window that "
+                    f"catches a slow degradation, where no single 5-minute window "
+                    f"looks bad enough to trip the paired 'Check Failed' rule. "
+                    f"{check.context}"
+                ),
+            },
+            datas=rd(
+                _failure_ratio_expr(
+                    check.job, check.instance, _SLOW_WINDOW, _SLOW_RATIO
+                )
+            ),
+        ),
+    ]
+
+
+def create(
+    rd: Callable[[str], list[alerting.RuleGroupRuleDataArgs]],
+    resource_opts: ResourceOptions,
+) -> None:
+    """Create the MIT Learn synthetic monitoring alert rule groups.
+
+    Takes no `folder_uid`: these rules live in the Synthetic Monitoring plugin's
+    folder, not the Pulumi-created "Infrastructure Alerts" one.
+    """
+    for check in _CHECKS:
+        alerting.RuleGroup(
+            check.resource_name,
+            name=check.group_name,
+            folder_uid=_SM_FOLDER_UID,
+            interval_seconds=300,
+            rules=_rules(check, rd),
+            opts=resource_opts,
+        )

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/synthetic_monitoring.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/synthetic_monitoring.py
@@ -12,13 +12,26 @@ TLSTargetCertificateCloseToExpiring). Those are generated and owned by the
 grafana-synthetic-monitoring-app plugin. Leave them alone -- Pulumi does not
 manage them and adopting them would fight the plugin.
 
-Folder
-------
+Folder, and why this is production-only
+---------------------------------------
 `_SM_FOLDER_UID` is the plugin's own folder, not a Pulumi-created one, so this
 module takes no `folder_uid` parameter (unlike every other metric_rules
 sub-module). The rules must stay in that folder: the folder UID is half the
 import identity, so moving them to "Infrastructure Alerts" would destroy and
 recreate all three, losing their alert-state history and any live silences.
+
+That folder UID only exists on the production Grafana stack. QA has no Synthetic
+Monitoring folder at all, and CI's is `ffqmgh1ukxam8a` (plus a legacy
+`6GJToXwnz`) -- the UID is per-stack, unlike the `grafanacloud-prom` datasource
+UID that is deliberately uniform everywhere. Registering these outside
+production would fail against a folder that is not there, and the pipeline
+deploys CI -> QA -> Production, so it would break at the first stage.
+
+The endpoints are production hosts regardless (learn.mit.edu,
+api.learn.mit.edu, next.learn.mit.edu), and the Synthetic Monitoring checks
+feeding `probe_success` are only configured on the production stack, so there is
+nothing for these rules to evaluate elsewhere. Hence the early return below,
+matching how `__main__.py` gates `pingdom_checks` on the same condition.
 
 Why the expression is inverted
 ------------------------------
@@ -145,6 +158,8 @@ from dataclasses import dataclass
 
 from pulumi import ResourceOptions
 from pulumiverse_grafana import alerting
+
+from ol_infrastructure.lib.pulumi_helper import parse_stack
 
 # The Synthetic Monitoring plugin's folder. Referenced, never created -- see the
 # module docstring.
@@ -324,8 +339,13 @@ def create(
     """Create the MIT Learn synthetic monitoring alert rule groups.
 
     Takes no `folder_uid`: these rules live in the Synthetic Monitoring plugin's
-    folder, not the Pulumi-created "Infrastructure Alerts" one.
+    folder, not the Pulumi-created "Infrastructure Alerts" one. Production only
+    -- that folder's UID differs per Grafana stack and the checks these watch
+    exist nowhere else. See the module docstring.
     """
+    if parse_stack().env_suffix != "production":
+        return
+
     for check in _CHECKS:
         alerting.RuleGroup(
             check.resource_name,


### PR DESCRIPTION
### What are the relevant tickets?

No ol-infrastructure ticket. Prompted by the 2026-08-13 paging incident; the application-side cause is https://github.com/mitodl/mit-learn/issues/3771

### Description (What does it do?)

Brings the three hand-made MIT Learn Synthetic Monitoring rules under Pulumi and rewrites them. All three were created in the Grafana UI and unmanaged.

- Adds `metric_rules/synthetic_monitoring.py` covering `MIT Learn NextJS`, `MIT Learn API` and `MIT Learn Website`. Rule groups are already imported into the Production stack, so this is `~ 3 to update`, not a create.
- Replaces the `< 1` threshold, which paged on **any one** failed probe out of five from a single probe location. It fired twice within one hour on 2026-08-13 at A=0.75 and A=0.8, i.e. 3/4 and 4/5 probes succeeding.
- Rewrites the annotations. All three carried a summary copied from a latency rule ("MIT Learn NextJS response times 30% Greater Than Normal") while the query measures availability.
- Drops `notification_settings.receiver="Rootly"` from all three. That pointed at a second, UI-created contact point (uid `eel3rjpiwahoge`) distinct from Pulumi's `rootly` (uid `bfsoqo63lsyrka`) and bypassed the `alertmanager.py` policy tree entirely. They now route by `severity` label like everything else.
- `noDataState` `NoData` -> `OK`. With the threshold baked into the PromQL a healthy check returns no series at all, so `NoData` would describe the healthy state on every evaluation.

Two things worth a reviewer's attention:

**Each check gets two windows, not one.** Threshold alone was not the fix. The incident that prompted this never produced a 5m window worse than 2 of 5 failures, held for ~2 minutes — short of `for: 5m` on a 300s interval. `< 0.6` as proposed in `docs/plans/grafana-alerting-remediation-spec.md` would have been silent throughout, and so would the looser 2-of-5 used here. Over a 1h window the same period was unmistakable: flat 0 for the preceding ten hours, then a climb through 3%, 5%, 7% to 10%. So there is a fast rule for a cliff and a slow rule for the creep the fast one structurally cannot see, mirroring `metric_rules/apisix_edge.py`.

**The slow rules ship unrouted.** No `severity` label, so `alertmanager.py`'s default route drops them in `oblivion` — evaluated and recorded in `grafanacloud-alert-state-history`, delivered nowhere. Measurement says both thresholds are still guesses: 4% over 1h would fire ~5 times per week on the API health endpoint alone, whose 1h failure ratio peaks at 8.3% in normal operation. Routing that at `critical` today would recreate the paging problem this is meant to end. Per-check 7d baselines are recorded in the module docstring so promotion is an evidence-based decision.

Also fixes a trap that the obvious translation walks into. `avg_over_time(...) < 0.8` returns availability as its value, and `base.py`'s pipeline fires on `last(A) > 0`. When every probe fails, availability is 0, the comparison passes, and the threshold stage reads 0 as "not firing" — so it would alert on a partial outage and go silent on a total one. The rules measure the failure ratio instead, whose value rises as the check gets worse.

### How can this be tested?

Run from `src/ol_infrastructure/infrastructure/grafana_alerting`:

```
pulumi preview --stack Production   # ~ 3 to update, 26 unchanged, no replacements
pulumi preview --stack CI           # 26 unchanged
pulumi preview --stack QA           # see Additional Context re: 2 dashboard deletions
```

What I ran:

- `pulumi preview` on all three stacks, results above. The Production diff shows the expression change, `notificationSettings` removed, `severity` added, `noDataState` corrected, and the new slow rule — with no resource replacement and the existing rule UIDs unchanged.
- Every generated PromQL expression executed against the live `grafanacloud-prom` datasource, confirming it returns the labels the annotations template on (`instance`, `probe`) and returns nothing while healthy.
- Both thresholds backtested over 7 days for all three checks. Fast `> 0.3` for 5m: would not have fired once, on any check, including the 2026-08-10 moment when all 5 Next.js probes in a window failed. Slow `> 0.04` for 30m: ~5 firings on the API endpoint, which is why it ships unrouted.
- `pre-commit run`, `ruff`, `mypy` — all pass.

I have not run `pulumi up`. Nothing in Grafana has changed yet.

To validate after applying, confirm the three rules show the new expressions in the Grafana UI and that `Learn NextJS Homepage (Bypass Fastly) - Check Failed` still carries uid `afjaps6wtn0n4a`.

### Additional Context

**The Production import is already done.** The three rule groups were adopted into Production Pulumi state with `pulumi import` before this PR. That is state-only and changed nothing in Grafana, but it is not undone by closing this PR. If this is rejected, run `pulumi state delete` on the three `grafana:alerting/ruleGroup:RuleGroup` URNs, otherwise the next `pulumi up` sees them declared-but-absent.

CLI `pulumi import` does not honour `--provider` here and fails against this program's explicit Grafana provider with "the Grafana client is required for this resource". It works if `GRAFANA_URL` / `GRAFANA_AUTH` are exported from `src/bridge/secrets/grafana_cloud/api.production.yaml` first. Noted in the directory's CLAUDE.md.

**Production-only, deliberately.** The Synthetic Monitoring folder UID is per-stack, unlike the `grafanacloud-prom` datasource UID that is uniform everywhere: Production is `grafana-synthetic-monitoring-app`, CI is `ffqmgh1ukxam8a` (plus a legacy `6GJToXwnz`), QA has no such folder. Without the guard in `create()` this breaks at the pipeline's first stage. The probed hosts are production-only regardless.

**Pre-existing QA drift, not from this branch.** `pulumi preview --stack QA` wants to delete `keycloak-overview-dashboard` and `keycloak-activity-dashboard`. Neither name appears anywhere in the codebase and this branch does not touch `dashboards/` — they are stale entries in QA state from an earlier version. Flagging so it is not mistaken for fallout from this change, but it means a QA apply will remove them.

The two sibling rules were included on purpose rather than left for later: they had the identical threshold, annotation and receiver-bypass defects, and leaving two unmanaged rules in a folder Pulumi now owns invites drift.
