### PR TITLE
fix(concourse): pre-create baggageclaim overlays work dir for 8.3.0

### DIFF
--- a/src/bilder/components/concourse/steps.py
+++ b/src/bilder/components/concourse/steps.py
@@ -220,13 +220,15 @@ def configure_concourse(
             user=concourse_config.user,
             recursive=True,
         )
-        # Concourse 8.3.0 (concourse/concourse#9637) migrated baggageclaim's
-        # filesystem operations onto Go's os.Root API. It reliably creates the
-        # top-level overlays dir on first startup but not the nested "work"
-        # subdirectory inside it (confirmed live: overlays/ exists and is
-        # empty on an affected worker, while volumes/{dead,init,live} -- also
-        # runtime-created -- are all present). Pre-create the nested dir at
-        # image-build time so baggageclaim doesn't depend on that behavior.
+        # On Concourse 8.3.0, baggageclaim's runtime directory creation on
+        # worker boot reliably creates the top-level overlays dir but not the
+        # nested "work" subdirectory inside it -- confirmed live on an
+        # affected production worker: overlays/ existed and was empty, while
+        # volumes/{dead,init,live} (also runtime-created) were all present.
+        # Not yet root-caused against a specific upstream commit -- #9601 and
+        # #9637 were both checked and are about archive-extraction paths, not
+        # this. Pre-create the nested dir at image-build time so baggageclaim
+        # doesn't depend on that runtime behavior.
         files.directory(
             name="Create Concourse baggageclaim overlays work directory",
             path=str(concourse_config.work_dir.joinpath("overlays", "work")),

--- a/src/bilder/components/concourse/steps.py
+++ b/src/bilder/components/concourse/steps.py
@@ -220,6 +220,20 @@ def configure_concourse(
             user=concourse_config.user,
             recursive=True,
         )
+        # Concourse 8.3.0 (concourse/concourse#9637) migrated baggageclaim's
+        # filesystem operations onto Go's os.Root API. It reliably creates the
+        # top-level overlays dir on first startup but not the nested "work"
+        # subdirectory inside it (confirmed live: overlays/ exists and is
+        # empty on an affected worker, while volumes/{dead,init,live} -- also
+        # runtime-created -- are all present). Pre-create the nested dir at
+        # image-build time so baggageclaim doesn't depend on that behavior.
+        files.directory(
+            name="Create Concourse baggageclaim overlays work directory",
+            path=str(concourse_config.work_dir.joinpath("overlays", "work")),
+            present=True,
+            user=concourse_config.user,
+            recursive=True,
+        )
         _manage_worker_node_keys(concourse_config)
         _install_resource_types(concourse_config)
     return concourse_env_file.changed


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
- Pre-creates `<work_dir>/overlays/work` at worker image-build time in `src/bilder/components/concourse/steps.py`.
- Works around a Concourse 8.3.0 regression: baggageclaim's worker-boot directory creation reliably creates the top-level `overlays/` dir but not the nested `work/` subdirectory it needs, so every volume create/lookup on affected workers fails with `no such file or directory` and the worker never becomes usable — surfacing as "no workers available" in production.
- Confirmed live on a broken production worker: `overlays/` existed and was empty, while `volumes/{dead,init,live}` (also runtime-created) were all present and populated — isolating the bug to just this one nested path.
- Not yet root-caused against a specific upstream commit. concourse/concourse#9601 and #9637 were both checked directly and are about archive/tar extraction paths, not baggageclaim's worker-boot directory creation — dropped that attribution rather than leave an inaccurate citation in.

### How can this be tested?
Manually building the worker AMI and deploying to production now to verify the fix resolves the outage.

### Additional Context
This only fixes the AMI-build side. Taking effect requires the worker AMI to actually get rebuilt and rolled out through the `concourse-packer-pulumi` pipeline (CI → QA → Production) — in progress separately from this PR.