### PR TITLE
fix(concourse): stop auto-tracking upstream releases entirely

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/concourse/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/concourse/pipeline.py
@@ -1,11 +1,9 @@
-import re
 import sys
 
 from ol_concourse.lib.models.fragment import PipelineFragment
 from ol_concourse.lib.models.pipeline import GetStep, Identifier, Pipeline
-from ol_concourse.lib.resources import git_repo, github_release
+from ol_concourse.lib.resources import git_repo
 
-from bridge.lib.versions import CONCOURSE_VERSION
 from ol_concourse.pipelines.constants import (
     PACKER_WATCHED_PATHS,
     PULUMI_CODE_PATH,
@@ -21,29 +19,17 @@ from ol_concourse.pipelines.versions_map import (
 #############
 # RESOURCES #
 #############
-# Pinned to CONCOURSE_VERSION (src/bridge/lib/versions.py) rather than tracking
-# upstream's latest release. Previously this resource had no tag_filter, so any
-# new upstream release auto-triggered a build+deploy through CI->QA->Production
-# with no human gate -- that's how 8.3.0 reached production and broke every
-# worker (see PR #5401). Bumping the pin is now what triggers a rebuild, via
-# concourse_image_code watching its version pin (image_version_paths("concourse")
-# below) rather than the raw versions.py file -- see PR #5407.
-#
-# concourse/concourse tags releases with a "v" prefix (e.g. "v8.2.5"), and
-# github-release's tag_filter is an unanchored Go regexp -- an unescaped,
-# unanchored CONCOURSE_VERSION would incidentally match today's tag but would
-# also match unintended ones (e.g. "8.2.5" matches inside "v8.2.50"). Anchor
-# it, escape the literal version, and keep a capture group around just the
-# unprefixed digits so the resource's "version" file -- read by
-# env_vars_from_files below -- contains "8.2.5", not "v8.2.5", matching what
-# deploy.py expects.
-concourse_release = github_release(
-    Identifier("concourse-release"),
-    "concourse",
-    "concourse",
-    github_token="",
-    tag_filter=rf"^v({re.escape(CONCOURSE_VERSION)})$",
-)
+# No github_release resource here on purpose. install_concourse
+# (src/bilder/components/concourse/steps.py) downloads the release archive
+# directly from GitHub using just the version string -- it never reads
+# anything else out of a release fetch -- so CONCOURSE_VERSION is sourced
+# straight from the version pin file below instead of a separate tracked
+# resource. That pin is bumped by Renovate (via versions.py + the
+# sync-version-pins pre-commit hook, see PR #5407) and concourse_image_code's
+# watch on image_version_paths("concourse") is what triggers a rebuild --
+# never upstream cutting a new release. That auto-tracking (with no tag_filter
+# and no human gate) is how 8.3.0 reached production and broke every worker
+# (see PR #5401).
 concourse_image_code = git_repo(
     Identifier("ol-infrastructure-packer"),
     uri="https://github.com/mitodl/ol-infrastructure",
@@ -67,17 +53,16 @@ concourse_pulumi_code = git_repo(
 )
 
 concourse_ami_fragment = packer_jobs(
-    dependencies=[
-        GetStep(
-            get=concourse_release.name,
-            trigger=True,
-        )
-    ],
+    dependencies=[],
     image_code=concourse_image_code,
     packer_template_path="src/bilder/images/.",
     node_types=["web", "worker"],
     packer_vars={"app_name": "concourse"},
-    env_vars_from_files={"CONCOURSE_VERSION": f"{concourse_release.name}/version"},
+    env_vars_from_files={
+        "CONCOURSE_VERSION": (
+            f"{concourse_image_code.name}/src/bridge/lib/version_pins/CONCOURSE_VERSION"
+        )
+    },
     extra_packer_params={"only": ["amazon-ebs.third-party"]},
 )
 
@@ -110,7 +95,6 @@ def concourse_pipeline() -> Pipeline:
         resource_types=combined_fragment.resource_types,
         resources=[
             *combined_fragment.resources,
-            concourse_release,
             concourse_image_code,
             concourse_pulumi_code,
         ],

--- a/src/ol_concourse/pipelines/infrastructure/concourse/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/concourse/pipeline.py
@@ -4,6 +4,7 @@ from ol_concourse.lib.models.fragment import PipelineFragment
 from ol_concourse.lib.models.pipeline import GetStep, Identifier, Pipeline
 from ol_concourse.lib.resources import git_repo, github_release
 
+from bridge.lib.versions import CONCOURSE_VERSION
 from ol_concourse.pipelines.constants import (
     PACKER_WATCHED_PATHS,
     PULUMI_CODE_PATH,
@@ -19,8 +20,19 @@ from ol_concourse.pipelines.versions_map import (
 #############
 # RESOURCES #
 #############
+# Pinned to CONCOURSE_VERSION (src/bridge/lib/versions.py) rather than tracking
+# upstream's latest release. Previously this resource had no tag_filter, so any
+# new upstream release auto-triggered a build+deploy through CI->QA->Production
+# with no human gate -- that's how 8.3.0 reached production and broke every
+# worker (see PR #5401). Bumping the pin is now what triggers a rebuild, via
+# concourse_image_code watching its version pin (image_version_paths("concourse")
+# below) rather than the raw versions.py file -- see PR #5407.
 concourse_release = github_release(
-    Identifier("concourse-release"), "concourse", "concourse", github_token=""
+    Identifier("concourse-release"),
+    "concourse",
+    "concourse",
+    github_token="",
+    tag_filter=CONCOURSE_VERSION,
 )
 concourse_image_code = git_repo(
     Identifier("ol-infrastructure-packer"),

--- a/src/ol_concourse/pipelines/infrastructure/concourse/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/concourse/pipeline.py
@@ -1,3 +1,4 @@
+import re
 import sys
 
 from ol_concourse.lib.models.fragment import PipelineFragment
@@ -27,12 +28,21 @@ from ol_concourse.pipelines.versions_map import (
 # worker (see PR #5401). Bumping the pin is now what triggers a rebuild, via
 # concourse_image_code watching its version pin (image_version_paths("concourse")
 # below) rather than the raw versions.py file -- see PR #5407.
+#
+# concourse/concourse tags releases with a "v" prefix (e.g. "v8.2.5"), and
+# github-release's tag_filter is an unanchored Go regexp -- an unescaped,
+# unanchored CONCOURSE_VERSION would incidentally match today's tag but would
+# also match unintended ones (e.g. "8.2.5" matches inside "v8.2.50"). Anchor
+# it, escape the literal version, and keep a capture group around just the
+# unprefixed digits so the resource's "version" file -- read by
+# env_vars_from_files below -- contains "8.2.5", not "v8.2.5", matching what
+# deploy.py expects.
 concourse_release = github_release(
     Identifier("concourse-release"),
     "concourse",
     "concourse",
     github_token="",
-    tag_filter=CONCOURSE_VERSION,
+    tag_filter=rf"^v({re.escape(CONCOURSE_VERSION)})$",
 )
 concourse_image_code = git_repo(
     Identifier("ol-infrastructure-packer"),


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
- Removes the `github_release` Concourse resource from `src/ol_concourse/pipelines/infrastructure/concourse/pipeline.py` entirely.
- `env_vars_from_files` now reads `CONCOURSE_VERSION` straight from `src/bridge/lib/version_pins/CONCOURSE_VERSION` inside the already-watched `concourse_image_code` checkout (that pin file is generated from `versions.py` by PR #5407's `sync-version-pins` pre-commit hook).
- `install_concourse` (`src/bilder/components/concourse/steps.py:35`) downloads the release archive directly from GitHub using just the version string — it never read anything else out of a release fetch — so the whole `github_release` resource, and the `tag_filter` regex needed to pin it to a specific version, was unnecessary machinery on top of that.

Net effect: there is nothing left in this pipeline that tracks upstream `concourse/concourse` releases at all. A rebuild is triggered only by `concourse_image_code` watching `image_version_paths("concourse")` (the version pin file + component code), which only changes when Renovate bumps `CONCOURSE_VERSION` in `versions.py` — a normal, reviewed PR. That's also what caused the original incident: the removed resource had no `tag_filter`, so it auto-tracked upstream's latest release and triggered an unreviewed build+deploy through CI→QA→Production, which is how 8.3.0 reached production and broke every worker (#5401).

### How can this be tested?
Rendered the pipeline (`python -m ol_concourse.pipelines.infrastructure.concourse.pipeline`) and confirmed: the `concourse-release` resource is gone from the resource list; both the validate and build jobs trigger only on `ol-infrastructure-packer`; the build job's `packer-build` put step carries `"CONCOURSE_VERSION": "ol-infrastructure-packer/src/bridge/lib/version_pins/CONCOURSE_VERSION"`. `ruff`/`mypy` clean (pre-existing docstring warnings only), all 207 tests in `tests/ol_concourse/test_versions_map.py` pass. Not yet applied to the live `fly` pipeline.

### Additional Context
Supersedes the `tag_filter` regex fix from earlier in this PR — that machinery is now gone rather than fixed further.