### PR TITLE
fix(edxapp): raise celery worker grace period and make dropped tasks redeliver

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/config_builder.py
+++ b/src/ol_infrastructure/applications/edxapp/config_builder.py
@@ -114,6 +114,30 @@ def build_base_general_config() -> ConfigDict:
             "ssl_cert_reqs": "optional",
         },
         "CELERY_BROKER_VHOST": "1",
+        # edx-platform's celery.py does `config_from_object("django.conf:settings")`
+        # with no namespace, so it's on Celery's old-style uppercase names read via
+        # ENV_TOKENS -- there is no generic CELERY_TASK_* / env-var passthrough.
+        # ACKS_LATE + REJECT_ON_WORKER_LOST make a task's message go back to the
+        # Redis queue (rather than staying acked-and-lost) when the worker holding it
+        # dies -- e.g. KEDA scaling a celery Deployment down mid-task, or a pod
+        # getting SIGKILLed after its grace period expires. This applies to every
+        # edxapp task on this broker connection, so a task must tolerate being run
+        # twice if a worker is lost partway through it.
+        "CELERY_ACKS_LATE": True,
+        "CELERY_REJECT_ON_WORKER_LOST": True,
+        # Backstop for the case ACKS_LATE/REJECT_ON_WORKER_LOST can't cover: the
+        # whole pod (not just the task) is killed before the broker connection can
+        # signal the reject, so the message just sits unacked. Redis's kombu
+        # transport makes an unacked message visible for redelivery again after this
+        # many seconds -- default is 3600s (1hr), which is what left a stuck OLX
+        # import task sitting in "started" for about an hour with no worker ever
+        # picking it back up. This is one connection-level setting shared by
+        # lms-celery, lms-high-mem-celery, and
+        # cms-celery (see build_base_general_config()'s single call site), so it has
+        # to be safe for the high_mem queue's up-to-4-hour reports too -- hence it
+        # matches HIGH_MEM_CELERY_TERMINATION_GRACE_PERIOD_SECONDS in
+        # k8s_resources.py rather than being tuned tighter for the default queues.
+        "CELERY_BROKER_TRANSPORT_OPTIONS": {"visibility_timeout": 4 * 60 * 60},
         "CELERY_EVENT_QUEUE_TTL": None,
         "CELERY_TIMEZONE": "UTC",
         "CELERY_TASK_TRACK_STARTED": True,

--- a/src/ol_infrastructure/applications/edxapp/k8s_resources.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_resources.py
@@ -87,6 +87,15 @@ from ol_infrastructure.lib.pulumi_helper import (
 # is what mitodl/hq#11978 was.
 HIGH_MEM_CELERY_TERMINATION_GRACE_PERIOD_SECONDS = 4 * 60 * 60
 
+# The default lms/cms queues carry shorter-but-not-instant tasks (bulk email, OLX
+# course import/export, etc). The 30s Kubernetes default isn't enough for a warm
+# shutdown to finish these, and both deployments also get scaled down by KEDA as queue
+# depth drops -- not just rolled during a deploy -- so a busy worker can be deleted
+# mid-task with only the default grace period. 10 minutes covers the common case
+# without leaving a pod stuck Terminating for hours the way the high_mem grace period
+# would if reused here.
+DEFAULT_CELERY_TERMINATION_GRACE_PERIOD_SECONDS = 10 * 60
+
 
 def create_k8s_resources(  # noqa: C901
     aws_config: AWSBase,
@@ -1179,17 +1188,6 @@ def create_k8s_resources(  # noqa: C901
         if vm.name != configmaps.uwsgi_ini_config_name
     ]
 
-    celery_env_vars = [
-        kubernetes.core.v1.EnvVarArgs(
-            name="CELERY_TASK_ACKS_LATE",
-            value="True",
-        ),
-        kubernetes.core.v1.EnvVarArgs(
-            name="CELERY_TASK_REJECT_ON_WORKER_LOST",
-            value="True",
-        ),
-    ]
-
     # Selector labels must match the existing Deployment's spec.selector (immutable).
     # The old SGP label (pod-security-group) is kept in the selector; the new
     # edxapp-celery-sg label is added only to the pod template so the
@@ -1215,6 +1213,7 @@ def create_k8s_resources(  # noqa: C901
             template=kubernetes.core.v1.PodTemplateSpecArgs(
                 metadata=kubernetes.meta.v1.ObjectMetaArgs(labels=lms_celery_labels),
                 spec=kubernetes.core.v1.PodSpecArgs(
+                    termination_grace_period_seconds=DEFAULT_CELERY_TERMINATION_GRACE_PERIOD_SECONDS,
                     affinity=kubernetes.core.v1.AffinityArgs(
                         pod_anti_affinity=kubernetes.core.v1.PodAntiAffinityArgs(
                             preferred_during_scheduling_ignored_during_execution=[
@@ -1297,7 +1296,6 @@ def create_k8s_resources(  # noqa: C901
                                     name="DJANGO_SETTINGS_MODULE",
                                     value="lms.envs.production",
                                 ),
-                                *celery_env_vars,
                             ],
                             resources=kubernetes.core.v1.ResourceRequirementsArgs(
                                 requests={
@@ -1475,7 +1473,6 @@ def create_k8s_resources(  # noqa: C901
                                     name="DJANGO_SETTINGS_MODULE",
                                     value="lms.envs.production",
                                 ),
-                                *celery_env_vars,
                             ],
                             resources=kubernetes.core.v1.ResourceRequirementsArgs(
                                 requests={
@@ -1751,6 +1748,7 @@ def create_k8s_resources(  # noqa: C901
             template=kubernetes.core.v1.PodTemplateSpecArgs(
                 metadata=kubernetes.meta.v1.ObjectMetaArgs(labels=cms_celery_labels),
                 spec=kubernetes.core.v1.PodSpecArgs(
+                    termination_grace_period_seconds=DEFAULT_CELERY_TERMINATION_GRACE_PERIOD_SECONDS,
                     affinity=kubernetes.core.v1.AffinityArgs(
                         pod_anti_affinity=kubernetes.core.v1.PodAntiAffinityArgs(
                             preferred_during_scheduling_ignored_during_execution=[
@@ -1829,7 +1827,6 @@ def create_k8s_resources(  # noqa: C901
                                     name="DJANGO_SETTINGS_MODULE",
                                     value="cms.envs.production",
                                 ),
-                                *celery_env_vars,
                             ],
                             resources=kubernetes.core.v1.ResourceRequirementsArgs(
                                 requests={


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
A course-import task in mitxonline production (`cms.djangoapps.contentstore.tasks.import_olx`) was found stuck in "started" state for about an hour. Root cause: KEDA scaled `cms-celery` down while a pod was mid-task; the deployment had no `terminationGracePeriodSeconds` override so it fell back to Kubernetes' 30s default, too short for the task's warm shutdown to finish. Investigating the intended safety net turned up dead configuration: `CELERY_TASK_ACKS_LATE`/`CELERY_TASK_REJECT_ON_WORKER_LOST` were being set as raw container env vars, but edx-platform's `celery.py` never reads them (it only respects Celery's old-style uppercase Django settings, e.g. `CELERY_ACKS_LATE`, sourced from `ENV_TOKENS`/YAML config).

- `cms-celery` and `lms-celery` now get a 10 minute `terminationGracePeriodSeconds`, mirroring the pattern already in place for `lms-high-mem-celery` (mitodl/hq#11978), which fixed the identical failure mode for grade-report tasks.
- Replaced the dead env vars with the settings edx-platform actually reads: `CELERY_ACKS_LATE` / `CELERY_REJECT_ON_WORKER_LOST` (a killed worker's message is rejected and requeued instead of staying acked-and-lost), plus `CELERY_BROKER_TRANSPORT_OPTIONS` with a `visibility_timeout` of 4 hours as a backstop for pods killed too abruptly to reject cleanly (e.g. hard node loss).
- The 4-hour visibility timeout (longer than Redis's 1-hour default) is deliberate: this is one broker-connection setting shared across `lms-celery`, `lms-high-mem-celery`, and `cms-celery` — there's no per-deployment override plumbing today — and `lms-high-mem-celery` runs reports up to ~80 minutes with a grace period sized for up to 4 hours. A shorter global value would risk a second worker duplicate-running a still-in-progress high-mem report.

**Trade-off worth reviewer attention:** `CELERY_ACKS_LATE`/`CELERY_REJECT_ON_WORKER_LOST` apply to every edxapp task on this broker, not just `import_olx` — any non-idempotent task could now run twice if its worker is lost mid-execution.

### How can this be tested?
- `uv run pre-commit run --all-files` and `uv run mypy` pass on the changed files.
- Ran a read-only `pulumi preview --stack mitxonline.CI --diff`: clean diff of 3 Deployment updates (`lms-celery`, `lms-high-mem-celery`, `cms-celery` — env var removal + grace period, applied as in-place rolling updates, no pod-spec immutability issues) and 1 ConfigMap replace (the shared `50-general-config-yaml` object replaces on any content change today — pre-existing behavior for that resource, unrelated to this specific change).
- No `pulumi up`/apply was run against any stack.

### Additional Context
Reviewer should confirm the 4-hour `visibility_timeout` tradeoff (favoring "never duplicate a long high-mem report" over "redeliver a short default-queue task fast") is the right call, and flag if any edxapp task on this broker is known to be non-idempotent given `CELERY_ACKS_LATE`/`CELERY_REJECT_ON_WORKER_LOST` now apply globally.