### PR TITLE
Assorted local-dev fixes

### DIFF
--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -346,7 +346,7 @@ Each store is bounded by retention config owned by the component that enforces i
 
 | Mechanism | Covers | Where |
 |---|---|---|
-| `disk-janitor` (automatic, runs with every `tilt up`) | Old tilt-built image tags in the local daemon; build-cache size cap | `local-dev/scripts/disk-janitor.sh`, wired as a `serve_cmd` resource in the root Tiltfile |
+| `disk-janitor` (automatic, runs with every `tilt up`) | Old tilt-built image tags in the local daemon; build-cache size cap; registry repos left manifest-less by an interrupted push | `local-dev/scripts/disk-janitor.sh`, wired as a `serve_cmd` resource in the root Tiltfile |
 | zot registry retention + GC | The k3d registry — zot keeps the 10 most recently pushed tags per repo and garbage-collects the rest itself | `local-dev/cluster/zot-config.json` (the registry image is [zot](https://zotregistry.dev), not registry:2; created by `setup.sh`) |
 | kubelet image GC | Node containerd stores | Thresholds in `local-dev/cluster/k3d-config.yaml` (applies at cluster creation; existing clusters keep the old 85/80 until you run `local-dev/scripts/migrate-kubelet-gc-thresholds.sh`) |
 | `prune-docker` (manual, break-glass) | Local daemon + registry, destructively (node stores only with `--sweep-nodes` — read the script header first; it orphans running containers) | Tilt UI button / `tilt trigger prune-docker`, or run `local-dev/scripts/prune-docker.sh` directly |
@@ -365,7 +365,9 @@ Retention (keep the newest N) is safe to apply at any moment — unlike a wipe, 
 - `disk_keep_tags` / `LOCAL_DEV_DISK_KEEP_TAGS` — tags kept per image (default 3). Old tags are nearly pure waste: pods only reference the current tag, and rebuild speed comes from the build cache, not old tags.
 - `disk_buildcache_max_gb` / `LOCAL_DEV_BUILDCACHE_MAX_GB` — build-cache cap in GB (default: 10% of total disk). **This is the one knob whose effect is not scoped to local-dev**: BuildKit keeps a single daemon-wide cache pool, so eviction can slow rebuilds of unrelated projects on your machine (speed only, never correctness). Set to `0` to opt out and manage the pool yourself (e.g. `builder.gc` in your Docker engine config).
 
-If images ever pile up again despite the janitor, `tilt docker-prune --debug` prints Tilt's own per-image skip reasons and is the fastest way to see why something isn't being reclaimed. To check whether zot is doing its part, `docker logs k3d-registry.localhost` shows its retention decisions (`"module":"retention"` lines, logged at info level).
+If images ever pile up again despite the janitor, `tilt docker-prune --debug` prints Tilt's own per-image skip reasons and is the fastest way to see why something isn't being reclaimed. To check whether zot is doing its part, `docker logs k3d-registry.localhost` shows its retention decisions (`"module":"retention"` lines, logged at info level) and its GC results (`"module":"gc"`, one `gc successfully completed` per repo).
+
+One registry case zot cannot reclaim on its own is a repo left with no manifest by an interrupted push — see [zot logs "repo metadata not found"](#zot-logs-repo-metadata-not-found-for-given-repo-name). The janitor sweeps those.
 
 ---
 
@@ -547,6 +549,31 @@ docker logs k3d-registry.localhost 2>&1 | grep -o '"ReadTimeout":[0-9]*' | tail 
 # "ReadTimeout":1800000000000   <- nanoseconds; 60000000000 means the default is still in effect
 docker restart k3d-registry.localhost
 ```
+
+### zot logs `repo metadata not found for given repo name`
+
+The registry log shows GC failing for one repo, on every zot start and every hourly GC pass:
+
+```
+"failed to run GC for /var/lib/zot/mitodl_mit-learn-nextjs-app"
+error: "repo metadata not found for given repo name"
+"gc unsuccessfully completed for /var/lib/zot/mitodl_mit-learn-nextjs-app"
+```
+
+zot's GC scheduler walks the *storage directory* but its retention logic is driven by the *metadata DB*, so it enqueues a task for every repo dir on disk and then fails on any the metadata DB has never heard of. A repo gets into that state when layer uploads land but the manifest PUT that registers them never does — i.e. any interrupted push (Ctrl-C, cancelled Tilt build, or the 60s upload timeout above). The completed layers stay on disk as blobs no manifest refers to, and GC bails before it can collect them, so they are unreachable *and* un-collectable: multiple GB that nothing reclaims.
+
+`disk-janitor.sh` sweeps these automatically (repo dirs whose `index.json` lists no manifests, untouched for 60 minutes so a live push is never at risk). To clear one immediately:
+
+```bash
+# list repos with no manifest
+docker run --rm --volumes-from k3d-registry.localhost alpine sh -c \
+  'for d in /var/lib/zot/*/; do grep -qE "\"manifests\":(null|\[\])" "$d/index.json" 2>/dev/null && echo "$d"; done'
+
+# remove one (safe: with no manifest there is nothing pullable in it)
+docker run --rm --volumes-from k3d-registry.localhost alpine rm -rf /var/lib/zot/<repo>
+```
+
+The push that follows re-uploads those layers. Note the error names the repo whose push broke — fixing the push (usually the timeout above) stops it recurring.
 
 ### `kubectl exec` fails with a 502 (wedged kubelet streaming)
 

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -389,6 +389,16 @@ One registry case zot cannot reclaim on its own is a repo left with no manifest 
 
 > **Note:** The teardown script calls `pulumi destroy` automatically to clean up Pulumi-managed resources before deleting the cluster, so no orphaned resources are left behind.
 
+Pulumi state must never outlive the cluster: everything these stacks manage
+lives inside the cluster, but the state lives in this checkout, so state that
+survives makes the next `pulumi up` skip resources that no longer exist (that
+is the `404 Realm not found` failure). Teardown therefore discards a stack's
+state if its `destroy` fails, discards leftover state when the cluster is
+already gone (deleted by hand, or by an interrupted teardown), and **stops
+before `k3d cluster delete`** if it can neither destroy nor discard — the
+checked-in `Pulumi.<stack>.yaml` config is preserved either way. If it stops,
+it prints the exact `pulumi stack rm` to run; do that and re-run teardown.
+
 ---
 
 ## Customization & Advanced Setup

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -524,6 +524,30 @@ The Next.js build needs ~4 GB of memory. If it OOMs:
 - Increase the Docker VM memory allocation (see [Prerequisites](#prerequisites))
 - Or use a prebuilt image by removing `mit-learn` from `enabled_apps` in `tilt_config.json` and letting Tilt use the `prebuilt_tags` value instead
 
+### Image push retries forever on the last layer
+
+Tilt's push stalls partway through one big layer, restarts from zero, and eventually gives up:
+
+```
+89076705fa1d: Pushing [==================>       ]  1.156GB/3.169GB
+```
+
+zot defaults `http.readTimeout` to 60s, and Go's `ReadTimeout` is a deadline on the *entire* request including its body — not an idle timeout. A monolithic blob upload that takes longer than that is killed mid-stream no matter how fast data is flowing; zot deletes the partial upload, Docker retries the layer, and hits the same wall. The registry log shows the deadline verbatim:
+
+```bash
+docker logs k3d-registry.localhost 2>&1 | grep '"level":"error"'
+# PATCH /v2/<repo>/blobs/uploads/<id>  statusCode: 500  latency: "1m0s"
+# "unexpected error, removing .uploads/ files"  error: "read tcp ...: i/o timeout"
+```
+
+Small layers push fine, so this only ever bites the multi-GB `node_modules` layers — those need ~80s on a typical dev box. `zot-config.json` therefore sets `readTimeout` and `writeTimeout` to `30m`. If you see this after editing that file, confirm the running registry actually picked the values up (they need a restart, not a config hot-reload):
+
+```bash
+docker logs k3d-registry.localhost 2>&1 | grep -o '"ReadTimeout":[0-9]*' | tail -1
+# "ReadTimeout":1800000000000   <- nanoseconds; 60000000000 means the default is still in effect
+docker restart k3d-registry.localhost
+```
+
 ### `kubectl exec` fails with a 502 (wedged kubelet streaming)
 
 `kubectl exec` / `attach` / `logs -f` into a pod may fail like this, even though `kubectl get` / `describe` / `logs` still work and the node shows `Ready`:

--- a/local-dev/cluster/k3d-config.yaml
+++ b/local-dev/cluster/k3d-config.yaml
@@ -42,6 +42,28 @@ ports:
 
 # Disable Traefik — APISIX Ingress Controller replaces it.
 options:
+  # Every pod on this cluster inherits its file-descriptor limit from the k3d
+  # node container: Docker starts containers with RLIMIT_NOFILE soft=1024
+  # (hard=524288), k3s and containerd inherit that from the node's PID 1, and
+  # containerd's CRI plugin sets no default_ulimits of its own, so the pod
+  # process ends up with a soft limit of 1024. Raising the *host's* ulimit does
+  # nothing — dockerd applies its own default to each container regardless.
+  #
+  # 1024 fds is not enough for the local-infra data stores. Qdrant mmaps ~30
+  # files per segment and mit-learn's collections are sharded 6 ways, so
+  # creating payload indexes exhausted the limit and the collection bootstrap
+  # died with "Failed to save structure on disk with error: Too many open
+  # files (os error 24)". OpenSearch wants 65536 for the same reason.
+  #
+  # Soft is raised to 65536 rather than all the way to the hard limit because
+  # some runtimes size fd tables off the soft limit; the hard limit stays at
+  # Docker's default so a process can still opt itself higher.
+  # Applies on cluster (re)create: teardown.sh + setup.sh.
+  runtime:
+    ulimits:
+    - name: nofile
+      soft: 65536
+      hard: 524288
   k3s:
     extraArgs:
     - arg: --disable=traefik

--- a/local-dev/cluster/zot-config.json
+++ b/local-dev/cluster/zot-config.json
@@ -24,7 +24,9 @@
   "http": {
     "address": "0.0.0.0",
     "port": "5000",
-    "compat": ["docker2s2"]
+    "compat": ["docker2s2"],
+    "readTimeout": "30m",
+    "writeTimeout": "30m"
   },
   "log": {
     "level": "info"

--- a/local-dev/infra/modules/search.py
+++ b/local-dev/infra/modules/search.py
@@ -38,6 +38,31 @@ def create_search(
                         {
                             "name": "qdrant",
                             "image": "qdrant/qdrant:v1.12.5",
+                            # Qdrant mmaps ~30 files per segment and mit-learn
+                            # shards its collections 6 ways, so it needs far
+                            # more than the 1024-fd soft limit a pod inherits
+                            # from the k3d node container. Being a Rust binary
+                            # it does not raise its own soft limit the way a
+                            # JVM does, so it dies partway through
+                            # create_qdrant_collections with "Failed to save
+                            # structure on disk with error: Too many open files
+                            # (os error 24)". k3d-config.yaml now sets the
+                            # cluster-wide default, but raising it here too
+                            # means existing clusters are fixed without a
+                            # teardown/recreate. `|| true` keeps a lower
+                            # inherited hard limit from blocking startup.
+                            # ./entrypoint.sh is the image's own entrypoint and
+                            # handles SIGTERM/SIGINT plus OOM recovery mode, so
+                            # exec into it rather than calling ./qdrant.
+                            "command": [
+                                "/bin/bash",
+                                "-c",
+                                # -Sn raises only the soft limit; a bare
+                                # `ulimit -n` would also drop the hard limit
+                                # from 524288 to 65536, discarding headroom.
+                                "ulimit -Sn 65536 2>/dev/null || true; "
+                                "exec ./entrypoint.sh",
+                            ],
                             "ports": [
                                 {"containerPort": 6333, "name": "http"},
                                 {"containerPort": 6334, "name": "grpc"},

--- a/local-dev/scripts/disk-janitor.sh
+++ b/local-dev/scripts/disk-janitor.sh
@@ -135,6 +135,15 @@ prune_build_cache() {
 #
 # Deleting is safe by construction: with no manifest there is nothing
 # pullable in the directory, and a subsequent push just re-uploads the layers.
+#
+# The age check and the `rm -rf` are not atomic against zot, so a push that
+# starts in the microseconds between them loses its in-flight upload. That is
+# accepted deliberately: the loser is a push that Docker retries, into a repo
+# that had been untouched for an hour, and it lands right back in the state
+# this sweep already handles — no manifest is ever broken, because a repo with
+# a manifest is never a candidate. Closing the window means excluding registry
+# writes (stopping zot, or a registry-side delete API), which would interrupt
+# pushes and pulls far more often than the race it prevents.
 # --volumes-from reads the storage path from the registry container, so it
 # needs no knowledge of the volume name setup.sh chose.
 # ---------------------------------------------------------------------------

--- a/local-dev/scripts/disk-janitor.sh
+++ b/local-dev/scripts/disk-janitor.sh
@@ -20,11 +20,13 @@
 #      whose effect is not scoped to local-dev (the cost is only rebuild
 #      speed, never correctness). Set the cap to 0 to opt out and manage the
 #      pool yourself (e.g. daemon builder.gc config).
+#   3. k3d registry: remove repo directories that hold no manifest — the one
+#      case zot's own GC provably cannot reclaim (see prune_orphan_repos).
 #
-# The other two image stores clean themselves and are intentionally NOT
-# handled here:
-#   - k3d registry: zot enforces its own retention + GC declaratively
-#     (local-dev/cluster/zot-config.json).
+# Everything else in the registry, and the k3s node containerd stores, clean
+# themselves and are intentionally NOT handled here:
+#   - k3d registry: zot enforces retention + GC declaratively for every repo
+#     it has metadata for (local-dev/cluster/zot-config.json).
 #   - k3s node containerd stores: kubelet's image GC owns those (thresholds
 #     in local-dev/cluster/k3d-config.yaml).
 #
@@ -107,8 +109,69 @@ prune_build_cache() {
 }
 
 # ---------------------------------------------------------------------------
-# Registry backend check. This janitor deliberately does NOT prune the
-# registry — zot does that itself — so a machine still on the pre-2026-07
+# 3. Registry: drop repo directories that contain no manifest.
+#
+# zot's retention/GC is driven by its metadata DB, but the GC scheduler walks
+# the storage directory — so it enqueues a task for every repo dir on disk and
+# then fails the ones metadata has never heard of:
+#
+#   "failed to run GC for /var/lib/zot/<repo>"
+#   error: "repo metadata not found for given repo name"
+#
+# A repo lands in that state when layer uploads succeed but the manifest PUT
+# that would register it never happens — any interrupted push (Ctrl-C, a
+# cancelled Tilt build, a push that times out). The completed layers are left
+# behind as blobs that are unreachable (no manifest refers to them) and
+# permanently un-collectable (GC bails before it can reclaim them), so they
+# occupy multiple GB until someone wipes the whole registry by hand. zot
+# cannot self-heal this; it is the one registry case the janitor must own.
+#
+# Two guards keep this from touching a live push, which passes transiently
+# through exactly this state (index.json is only written at the end, by the
+# manifest PUT): only repos whose index.json lists no manifests at all, and
+# only those with no filesystem activity anywhere in the tree for
+# ORPHAN_REPO_MIN_AGE_MINS. Anything unparseable is left alone — a format
+# change upstream must fail towards keeping data, not deleting it.
+#
+# Deleting is safe by construction: with no manifest there is nothing
+# pullable in the directory, and a subsequent push just re-uploads the layers.
+# --volumes-from reads the storage path from the registry container, so it
+# needs no knowledge of the volume name setup.sh chose.
+# ---------------------------------------------------------------------------
+ORPHAN_REPO_MIN_AGE_MINS=60
+
+prune_orphan_repos() {
+    local image
+    image="$(docker inspect k3d-registry.localhost --format '{{.Config.Image}}' 2>/dev/null)" || return 0
+    case "$image" in *zot*) ;; *) return 0 ;; esac
+
+    local removed line
+    removed=0
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        log "  registry: removed manifest-less repo '$line' (interrupted push)"
+        removed=$((removed + 1))
+    done < <(
+        docker run --rm --volumes-from k3d-registry.localhost alpine sh -c '
+            for d in /var/lib/zot/*/; do
+                [ -d "$d" ] || continue
+                idx="${d}index.json"
+                # No index.json yet, or one whose manifest list is empty
+                # ("null" for a nil slice, "[]" for an empty one).
+                [ -f "$idx" ] && ! grep -qE "\"manifests\":(null|\[\])" "$idx" && continue
+                [ -n "$(find "$d" -mmin -'"$ORPHAN_REPO_MIN_AGE_MINS"' 2>/dev/null | head -n1)" ] && continue
+                name="${d#/var/lib/zot/}"
+                rm -rf "$d" && echo "${name%/}"
+            done
+        ' 2>/dev/null
+    )
+    (( removed > 0 )) && log "registry: reclaimed $removed orphaned repo dir(s)"
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Registry backend check. Apart from the orphan sweep above, this janitor
+# leaves the registry to zot — so a machine still on the pre-2026-07
 # registry:2 container has NO registry retention at all and will regrow
 # unbounded. setup.sh prints migration instructions, but plenty of setups
 # never re-run it; this warning runs where everyone actually is (tilt up).
@@ -126,6 +189,7 @@ run_cycle() {
     warn_if_not_zot
     prune_local_tags
     prune_build_cache
+    prune_orphan_repos
 }
 
 log "disk-janitor starting (keep_tags=${KEEP_TAGS}, buildcache_max_gb=${JANITOR_BUILDCACHE_MAX_GB:-auto}, interval=${INTERVAL}s)"

--- a/local-dev/scripts/disk-janitor.sh
+++ b/local-dev/scripts/disk-janitor.sh
@@ -131,7 +131,10 @@ prune_build_cache() {
 # manifest PUT): only repos whose index.json lists no manifests at all, and
 # only those with no filesystem activity anywhere in the tree for
 # ORPHAN_REPO_MIN_AGE_MINS. Anything unparseable is left alone — a format
-# change upstream must fail towards keeping data, not deleting it.
+# change upstream must fail towards keeping data, not deleting it. A third
+# guard covers namespaced pushes (localhost:5001/<ns>/<repo>, which the
+# openedx integration can produce): the <ns> dir has no index.json of its
+# own, so it must not be judged manifest-less while a real repo sits below it.
 #
 # Deleting is safe by construction: with no manifest there is nothing
 # pullable in the directory, and a subsequent push just re-uploads the layers.
@@ -169,6 +172,10 @@ prune_orphan_repos() {
                 # ("null" for a nil slice, "[]" for an empty one).
                 [ -f "$idx" ] && ! grep -qE "\"manifests\":(null|\[\])" "$idx" && continue
                 [ -n "$(find "$d" -mmin -'"$ORPHAN_REPO_MIN_AGE_MINS"' 2>/dev/null | head -n1)" ] && continue
+                # A namespaced repo (<ns>/<repo>) leaves its parent dir with no
+                # index.json of its own; never delete a tree that still has a
+                # manifest somewhere below it.
+                [ -n "$(find "$d" -mindepth 2 -name index.json 2>/dev/null | head -n1)" ] && continue
                 name="${d#/var/lib/zot/}"
                 rm -rf "$d" && echo "${name%/}"
             done

--- a/local-dev/scripts/kc-fix-flow-bindings.sh
+++ b/local-dev/scripts/kc-fix-flow-bindings.sh
@@ -20,16 +20,28 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
 _ROOT_DOMAIN="${LOCAL_DEV_ROOT_DOMAIN:-mit.dev}"
 KC_URL="${KC_URL:-https://sso.ol.${_ROOT_DOMAIN}}"
 REALM="olapps"
 KC_USER="admin"
 KC_PASS="admin"  # pragma: allowlist secret
 
+# mkcert's root CA is not in the system trust store; see kc-seed-users.sh for
+# why an unvalidated curl here surfaces as a misleading "waiting for Keycloak".
+KC_CACERT="${KC_CACERT:-${REPO_ROOT}/local-dev/certs/rootCA.pem}"
+if [ ! -f "${KC_CACERT}" ]; then
+    echo "[kc-fix-flow-bindings] ERROR: CA certificate not found at ${KC_CACERT}" >&2
+    echo "[kc-fix-flow-bindings] Run local-dev/scripts/setup.sh to generate the local certs." >&2
+    exit 1
+fi
+
 get_token() {
     local token attempt
     for attempt in 1 2 3 4 5; do
-        token=$(curl -sf --max-time 10 \
+        token=$(curl -sf --cacert "${KC_CACERT}" --max-time 10 \
             -X POST "${KC_URL}/realms/master/protocol/openid-connect/token" \
             -d "client_id=admin-cli" \
             -d "grant_type=password" \
@@ -50,7 +62,7 @@ get_token() {
 echo "[kc-fix-flow-bindings] Connecting to Keycloak at ${KC_URL} ..."
 TOKEN=$(get_token)
 
-CURRENT=$(curl -sf --max-time 10 \
+CURRENT=$(curl -sf --cacert "${KC_CACERT}" --max-time 10 \
     -H "Authorization: Bearer ${TOKEN}" \
     "${KC_URL}/admin/realms/${REALM}" 2>/dev/null)
 
@@ -64,7 +76,7 @@ fi
 
 echo "[kc-fix-flow-bindings] Flow bindings drifted (browserFlow=${BROWSER_FLOW}, firstBrokerLoginFlow=${FIRST_BROKER_FLOW}); re-asserting ..."
 PATCHED=$(echo "$CURRENT" | jq '.browserFlow = "Organization browser" | .firstBrokerLoginFlow = "Organization first broker login"')
-curl -sf --max-time 10 \
+curl -sf --cacert "${KC_CACERT}" --max-time 10 \
     -X PUT \
     -H "Authorization: Bearer ${TOKEN}" \
     -H "Content-Type: application/json" \

--- a/local-dev/scripts/kc-seed-users.sh
+++ b/local-dev/scripts/kc-seed-users.sh
@@ -19,11 +19,26 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
 _ROOT_DOMAIN="${LOCAL_DEV_ROOT_DOMAIN:-mit.dev}"
 KC_URL="${KC_URL:-https://sso.ol.${_ROOT_DOMAIN}}"
 REALM="olapps"
 KC_USER="admin"
 KC_PASS="admin"  # pragma: allowlist secret
+
+# The ingress serves an mkcert-issued cert (setup.sh generates it) whose root CA
+# is not in the system trust store, so every curl below must validate against
+# that CA explicitly. Without it curl exits 60 on the handshake, the token comes
+# back empty, and get_token's retry loop reports it as "waiting for Keycloak" —
+# which sends you looking at a Keycloak that was healthy the whole time.
+KC_CACERT="${KC_CACERT:-${REPO_ROOT}/local-dev/certs/rootCA.pem}"
+if [ ! -f "${KC_CACERT}" ]; then
+    echo "[kc-seed-users] ERROR: CA certificate not found at ${KC_CACERT}" >&2
+    echo "[kc-seed-users] Run local-dev/scripts/setup.sh to generate the local certs." >&2
+    exit 1
+fi
 
 # ---------------------------------------------------------------------------
 # Helper: obtain an admin access token, retrying up to 5 times.
@@ -31,7 +46,7 @@ KC_PASS="admin"  # pragma: allowlist secret
 get_token() {
     local token attempt
     for attempt in 1 2 3 4 5; do
-        token=$(curl -sf --max-time 10 \
+        token=$(curl -sf --cacert "${KC_CACERT}" --max-time 10 \
             -X POST "${KC_URL}/realms/master/protocol/openid-connect/token" \
             -d "client_id=admin-cli" \
             -d "grant_type=password" \
@@ -57,13 +72,13 @@ TOKEN=$(get_token)
 # ---------------------------------------------------------------------------
 ensure_admin_role() {
     local existing
-    existing=$(curl -sf --max-time 10 \
+    existing=$(curl -sf --cacert "${KC_CACERT}" --max-time 10 \
         -H "Authorization: Bearer ${TOKEN}" \
         "${KC_URL}/admin/realms/${REALM}/roles/admin" 2>/dev/null \
         | jq -r '.name // empty' 2>/dev/null || true)
     if [ -z "$existing" ]; then
         echo "[kc-seed-users] Creating 'admin' realm role in ${REALM} ..."
-        curl -sf --max-time 10 \
+        curl -sf --cacert "${KC_CACERT}" --max-time 10 \
             -X POST \
             -H "Authorization: Bearer ${TOKEN}" \
             -H "Content-Type: application/json" \
@@ -93,7 +108,7 @@ for USERNAME in admin student prof; do
     # the email address (e.g. "admin@odl.local", not "admin"). A username=
     # lookup would always miss and the script would try to re-create existing
     # users on every run, breaking idempotency.
-    EXISTING_ID=$(curl -sf --max-time 10 \
+    EXISTING_ID=$(curl -sf --cacert "${KC_CACERT}" --max-time 10 \
         -H "Authorization: Bearer ${TOKEN}" \
         "${KC_URL}/admin/realms/${REALM}/users?email=${EMAIL}&exact=true" 2>/dev/null \
         | jq -r '.[0].id // empty' 2>/dev/null || true)
@@ -104,7 +119,7 @@ for USERNAME in admin student prof; do
     fi
 
     echo "[kc-seed-users] Creating user: ${USERNAME} <${EMAIL}> ..."
-    curl -sf --max-time 10 \
+    curl -sf --cacert "${KC_CACERT}" --max-time 10 \
         -X POST \
         -H "Authorization: Bearer ${TOKEN}" \
         -H "Content-Type: application/json" \
@@ -125,7 +140,7 @@ for USERNAME in admin student prof; do
         -o /dev/null
 
     # Re-fetch the new user ID for role assignment (by email; see note above).
-    NEW_ID=$(curl -sf --max-time 10 \
+    NEW_ID=$(curl -sf --cacert "${KC_CACERT}" --max-time 10 \
         -H "Authorization: Bearer ${TOKEN}" \
         "${KC_URL}/admin/realms/${REALM}/users?email=${EMAIL}&exact=true" 2>/dev/null \
         | jq -r '.[0].id // empty' 2>/dev/null || true)
@@ -134,10 +149,10 @@ for USERNAME in admin student prof; do
     for admin_user in "${ADMIN_USERS[@]}"; do
         if [ "$admin_user" = "$USERNAME" ] && [ -n "$NEW_ID" ]; then
             echo "[kc-seed-users] Assigning 'admin' realm role to ${USERNAME} ..."
-            ROLE_JSON=$(curl -sf --max-time 10 \
+            ROLE_JSON=$(curl -sf --cacert "${KC_CACERT}" --max-time 10 \
                 -H "Authorization: Bearer ${TOKEN}" \
                 "${KC_URL}/admin/realms/${REALM}/roles/admin" 2>/dev/null || true)
-            curl -sf --max-time 10 \
+            curl -sf --cacert "${KC_CACERT}" --max-time 10 \
                 -X POST \
                 -H "Authorization: Bearer ${TOKEN}" \
                 -H "Content-Type: application/json" \

--- a/local-dev/scripts/setup.sh
+++ b/local-dev/scripts/setup.sh
@@ -272,27 +272,50 @@ ok "Prerequisites satisfied (Docker ${DOCKER_MEM_GB} GB RAM)"
 # registry to the cluster via `registries.use`.
 REGISTRY_NAME="k3d-registry.localhost"
 REGISTRY_IMAGE="ghcr.io/project-zot/zot:v2.1.18"
+REGISTRY_VOLUME="k3d-registry-zot-data"
 ZOT_CONFIG="${REPO_ROOT}/local-dev/cluster/zot-config.json"
+
+# `k3d registry create` prefixes the name with 'k3d-'. Image storage is a
+# NAMED volume, not `-v /var/lib/zot`: k3d writes a destination-only volume
+# spec into the container with no volume name attached (Docker's own CLI
+# fills one in; k3d does not). That mount resolves fine for the daemon's
+# lifetime, so the registry works until dockerd restarts — after a reboot the
+# daemon reloads the container, cannot look the volume up by its empty name,
+# and every `docker start` fails with exit 128 "get: no such volume". A named
+# volume survives the reload, and still works with prune-docker.sh's
+# `--volumes-from` wipe (which, as a bonus, can no longer take an anonymous
+# volume with it when its `--rm` helper exits).
+create_registry() {
+    k3d registry create "${REGISTRY_NAME#k3d-}" --port 5001 \
+        --image "${REGISTRY_IMAGE}" \
+        -v "${ZOT_CONFIG}:/etc/zot/config.json" \
+        -v "${REGISTRY_VOLUME}:/var/lib/zot"
+}
 
 log "Setting up local image registry '${REGISTRY_NAME}'..."
 if docker ps -a --format '{{.Names}}' | grep -qx "${REGISTRY_NAME}"; then
     if docker inspect "${REGISTRY_NAME}" --format '{{.Config.Image}}' | grep -q zot; then
-        docker start "${REGISTRY_NAME}" >/dev/null 2>&1 || true
-        ok "Registry '${REGISTRY_NAME}' already exists — skipping creation."
+        if docker start "${REGISTRY_NAME}" >/dev/null 2>&1; then
+            ok "Registry '${REGISTRY_NAME}' already exists — skipping creation."
+        else
+            # Unstartable registry — an anonymous-volume container left over
+            # from before the named-volume switch cannot be repaired, only
+            # replaced. Contents are disposable: Tilt re-pushes on next build.
+            warn "Registry '${REGISTRY_NAME}' exists but will not start:"
+            warn "  $(docker inspect "${REGISTRY_NAME}" --format '{{.State.Error}}')"
+            warn "Recreating it (cached images are disposable — Tilt re-pushes)."
+            k3d registry delete "${REGISTRY_NAME}" >/dev/null 2>&1 || \
+                docker rm -f "${REGISTRY_NAME}" >/dev/null 2>&1 || true
+            create_registry
+            ok "Registry '${REGISTRY_NAME}' recreated (zot, named volume)."
+        fi
     else
         warn "Registry '${REGISTRY_NAME}' exists but is not zot (pre-2026-07 registry:2)."
         warn "To migrate:  k3d registry delete ${REGISTRY_NAME}  then re-run setup.sh"
         warn "(Tilt re-pushes all images on the next build; see local-dev/README.md)"
     fi
 else
-    # `k3d registry create` prefixes the name with 'k3d-'. The bare
-    # /var/lib/zot mount makes image storage an anonymous volume (zot's image
-    # declares none), so prune-docker.sh can wipe it with the registry
-    # stopped via --volumes-from.
-    k3d registry create "${REGISTRY_NAME#k3d-}" --port 5001 \
-        --image "${REGISTRY_IMAGE}" \
-        -v "${ZOT_CONFIG}:/etc/zot/config.json" \
-        -v /var/lib/zot
+    create_registry
     ok "Registry '${REGISTRY_NAME}' created (zot, retention enabled)."
 fi
 

--- a/local-dev/scripts/setup.sh
+++ b/local-dev/scripts/setup.sh
@@ -295,8 +295,11 @@ create_registry() {
 log "Setting up local image registry '${REGISTRY_NAME}'..."
 if docker ps -a --format '{{.Names}}' | grep -qx "${REGISTRY_NAME}"; then
     if docker inspect "${REGISTRY_NAME}" --format '{{.Config.Image}}' | grep -q zot; then
-        if docker start "${REGISTRY_NAME}" >/dev/null 2>&1; then
-            ok "Registry '${REGISTRY_NAME}' already exists — skipping creation."
+        # `restart`, not `start`: on an already-running registry `start` is a
+        # no-op, so zot never re-reads the bind-mounted zot-config.json and
+        # config changes (timeouts, retention) silently never take effect.
+        if docker restart "${REGISTRY_NAME}" >/dev/null 2>&1; then
+            ok "Registry '${REGISTRY_NAME}' already exists — restarted to pick up zot-config.json."
         else
             # Unstartable registry — an anonymous-volume container left over
             # from before the named-volume switch cannot be repaired, only

--- a/local-dev/scripts/teardown.sh
+++ b/local-dev/scripts/teardown.sh
@@ -68,6 +68,49 @@ with open('${win_hosts}', 'w') as f:
     fi
 }
 
+# Destroy one Pulumi stack, and make sure its state cannot outlive the
+# cluster. Everything these stacks manage lives inside the cluster that gets
+# deleted below, but the state lives in this checkout and survives — so a
+# failed destroy leaves Pulumi believing resources exist that are already
+# gone, and the next `pulumi up` skips creating them.
+#
+# That is not hypothetical: on 2026-08-13 a broken registry kept Keycloak
+# from starting, the apps_infra destroy failed, `|| true` reported success
+# anyway, and the first `pulumi up` against the rebuilt cluster died with
+# 404 "Realm not found" while creating a child of a realm Pulumi thought it
+# already had.
+#
+# `pulumi stack rm` deletes Pulumi.<stack>.yaml along with the state, and
+# that config file is checked into this repo — save and restore it.
+destroy_stack() {
+    local dir="$1" stack="$2" label="$3"
+    local config="Pulumi.${stack}.yaml"
+
+    cd "${REPO_ROOT}/${dir}"
+    if ! pulumi stack ls 2>/dev/null | grep -q "${stack}"; then
+        ok "    No ${label} state found."
+        return
+    fi
+
+    if PULUMI_CONFIG_PASSPHRASE='' pulumi destroy --stack "${stack}" --yes --logtostderr; then
+        ok "    ${label} destroyed."
+        return
+    fi
+
+    warn "    'pulumi destroy' failed for ${label} — discarding its state."
+    warn "    Keeping it would make the next 'pulumi up' skip resources it"
+    warn "    wrongly believes still exist in the deleted cluster."
+    [[ -f "${config}" ]] && cp "${config}" "${config}.teardown-bak"
+    if PULUMI_CONFIG_PASSPHRASE='' pulumi stack rm "${stack}" --force --yes >/dev/null 2>&1; then
+        ok "    ${label} state discarded (stack config preserved)."
+    else
+        warn "    Could not remove stack '${stack}'. Remove it by hand before the"
+        warn "    next 'tilt up':  cd ${dir} && pulumi stack rm ${stack} --force --yes"
+    fi
+    [[ -f "${config}.teardown-bak" ]] && mv "${config}.teardown-bak" "${config}"
+    return 0
+}
+
 log "Destroying k3d cluster '${CLUSTER_NAME}'..."
 if k3d cluster list 2>/dev/null | grep -q "^${CLUSTER_NAME}"; then
     # Ensure cluster is running before destroying Pulumi resources
@@ -86,23 +129,11 @@ if k3d cluster list 2>/dev/null | grep -q "^${CLUSTER_NAME}"; then
 
     # Destroy apps_infra stack first (it depends on core stack)
     log "  Destroying apps_infra stack..."
-    cd "${REPO_ROOT}/local-dev/infra/apps_infra"
-    if pulumi stack ls 2>/dev/null | grep -q "local-dev.apps-infra"; then
-        PULUMI_CONFIG_PASSPHRASE='' pulumi destroy --stack local-dev.apps-infra.Dev --yes --logtostderr || true
-        ok "    Apps infrastructure destroyed."
-    else
-        ok "    No apps_infra state found."
-    fi
+    destroy_stack "local-dev/infra/apps_infra" "local-dev.apps-infra.Dev" "Apps infrastructure"
 
     # Destroy core stack (after apps_infra is gone)
     log "  Destroying core stack..."
-    cd "${REPO_ROOT}/local-dev/infra/core"
-    if pulumi stack ls 2>/dev/null | grep -q "local-dev.core"; then
-        PULUMI_CONFIG_PASSPHRASE='' pulumi destroy --stack local-dev.core.Dev --yes --logtostderr || true
-        ok "    Core infrastructure destroyed."
-    else
-        ok "    No core state found."
-    fi
+    destroy_stack "local-dev/infra/core" "local-dev.core.Dev" "Core infrastructure"
 
     cd "${REPO_ROOT}"
 

--- a/local-dev/scripts/teardown.sh
+++ b/local-dev/scripts/teardown.sh
@@ -68,6 +68,50 @@ with open('${win_hosts}', 'w') as f:
     fi
 }
 
+# Is `stack` present in the current project's backend?
+#   0 = yes, 1 = no, 2 = the listing could not be read.
+#
+# The third case has to stay distinct from the second. `pulumi stack ls | grep`
+# reports the grep's status, so a backend that cannot be read looks exactly
+# like a backend with nothing in it — and "nothing to destroy" is precisely the
+# answer that lets teardown delete the cluster out from under live state.
+stack_exists() {
+    local stack="$1" listing rc=0
+
+    listing="$(pulumi stack ls --json 2>/dev/null)" || return 2
+    printf '%s' "${listing}" | python3 -c '
+import json, sys
+try:
+    stacks = [s["name"] for s in json.load(sys.stdin)]
+except Exception:
+    sys.exit(2)
+sys.exit(0 if sys.argv[1] in stacks else 1)
+' "${stack}" || rc=$?
+    return "${rc}"
+}
+
+# Throw away a stack's state. `pulumi stack rm` deletes Pulumi.<stack>.yaml
+# along with it, and that config file is checked into this repo — save and
+# restore it. Returns nonzero if the state is still there afterwards, so
+# callers stop rather than proceeding to delete the cluster.
+discard_stack_state() {
+    local dir="$1" stack="$2" label="$3"
+    local config="Pulumi.${stack}.yaml"
+    local rc=0
+
+    cd "${REPO_ROOT}/${dir}"
+    [[ -f "${config}" ]] && cp "${config}" "${config}.teardown-bak"
+    if PULUMI_CONFIG_PASSPHRASE='' pulumi stack rm "${stack}" --force --yes >/dev/null 2>&1; then
+        ok "    ${label} state discarded (stack config preserved)."
+    else
+        warn "    Could not remove stack '${stack}'. Remove it by hand, then"
+        warn "    re-run teardown:  cd ${dir} && pulumi stack rm ${stack} --force --yes"
+        rc=1
+    fi
+    [[ -f "${config}.teardown-bak" ]] && mv "${config}.teardown-bak" "${config}"
+    return "${rc}"
+}
+
 # Destroy one Pulumi stack, and make sure its state cannot outlive the
 # cluster. Everything these stacks manage lives inside the cluster that gets
 # deleted below, but the state lives in this checkout and survives — so a
@@ -80,35 +124,61 @@ with open('${win_hosts}', 'w') as f:
 # 404 "Realm not found" while creating a child of a realm Pulumi thought it
 # already had.
 #
-# `pulumi stack rm` deletes Pulumi.<stack>.yaml along with the state, and
-# that config file is checked into this repo — save and restore it.
+# Every failure path out of here is nonzero: with `set -e` that aborts
+# teardown before `k3d cluster delete`, leaving the cluster and its state
+# consistent with each other for a retry. A cluster you can delete by hand
+# beats state Pulumi will silently trust on the next `pulumi up`.
 destroy_stack() {
     local dir="$1" stack="$2" label="$3"
-    local config="Pulumi.${stack}.yaml"
+    local rc=0
 
     cd "${REPO_ROOT}/${dir}"
-    if ! pulumi stack ls 2>/dev/null | grep -q "${stack}"; then
+    stack_exists "${stack}" || rc=$?
+    if (( rc == 2 )); then
+        warn "    Could not read the Pulumi stack list in ${dir}."
+        warn "    Not deleting the cluster: any state there would be stranded."
+        warn "    Fix the backend and re-run teardown."
+        return 1
+    fi
+    if (( rc == 1 )); then
         ok "    No ${label} state found."
-        return
+        return 0
     fi
 
     if PULUMI_CONFIG_PASSPHRASE='' pulumi destroy --stack "${stack}" --yes --logtostderr; then
         ok "    ${label} destroyed."
-        return
+        return 0
     fi
 
     warn "    'pulumi destroy' failed for ${label} — discarding its state."
     warn "    Keeping it would make the next 'pulumi up' skip resources it"
     warn "    wrongly believes still exist in the deleted cluster."
-    [[ -f "${config}" ]] && cp "${config}" "${config}.teardown-bak"
-    if PULUMI_CONFIG_PASSPHRASE='' pulumi stack rm "${stack}" --force --yes >/dev/null 2>&1; then
-        ok "    ${label} state discarded (stack config preserved)."
-    else
-        warn "    Could not remove stack '${stack}'. Remove it by hand before the"
-        warn "    next 'tilt up':  cd ${dir} && pulumi stack rm ${stack} --force --yes"
+    discard_stack_state "${dir}" "${stack}" "${label}"
+}
+
+# Same guarantee from the other direction: the cluster is already gone (deleted
+# by hand, or by a teardown that was interrupted after `k3d cluster delete`),
+# so there is no API server left to destroy anything against and the state is
+# stale by definition. Discard it, or setup.sh reuses it.
+drop_orphan_stack() {
+    local dir="$1" stack="$2" label="$3"
+    local rc=0
+
+    cd "${REPO_ROOT}/${dir}"
+    stack_exists "${stack}" || rc=$?
+    if (( rc == 2 )); then
+        warn "    Could not read the Pulumi stack list in ${dir}."
+        warn "    Fix the backend and re-run teardown — leftover state here"
+        warn "    would break the next 'pulumi up'."
+        return 1
     fi
-    [[ -f "${config}.teardown-bak" ]] && mv "${config}.teardown-bak" "${config}"
-    return 0
+    if (( rc == 1 )); then
+        ok "    No ${label} state found."
+        return 0
+    fi
+
+    warn "    ${label} state outlived its cluster — discarding it."
+    discard_stack_state "${dir}" "${stack}" "${label}"
 }
 
 log "Destroying k3d cluster '${CLUSTER_NAME}'..."
@@ -141,7 +211,12 @@ if k3d cluster list 2>/dev/null | grep -q "^${CLUSTER_NAME}"; then
     k3d cluster delete "${CLUSTER_NAME}"
     ok "Cluster deleted."
 else
-    warn "Cluster '${CLUSTER_NAME}' not found — skipping."
+    warn "Cluster '${CLUSTER_NAME}' not found — nothing to delete."
+
+    log "Checking for Pulumi state left behind by the missing cluster..."
+    drop_orphan_stack "local-dev/infra/apps_infra" "local-dev.apps-infra.Dev" "Apps infrastructure"
+    drop_orphan_stack "local-dev/infra/core" "local-dev.core.Dev" "Core infrastructure"
+    cd "${REPO_ROOT}"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

Six independent fixes to the `local-dev` environment, all found while getting a cluster back to a working state after a rebuild.

**`kc-seed-users.sh` / `kc-fix-flow-bindings.sh` — validate against the mkcert CA.** The ingress serves an mkcert-issued cert whose root CA is not in the system trust store, so every `curl` in these scripts failed the handshake with exit 60. The token came back empty and `get_token`'s retry loop reported it as "waiting for Keycloak", which sends you debugging a Keycloak that was healthy the whole time. Each call now passes `--cacert` (overridable via `KC_CACERT`), and the scripts fail loudly up front if the CA file is missing instead of misattributing the failure later.

**`setup.sh` — give the registry a named volume.** `k3d registry create -v /var/lib/zot` writes a destination-only volume spec with no volume name attached (Docker's own CLI fills one in; k3d does not). That mount resolves for the lifetime of the daemon, so the registry works until dockerd restarts — after a reboot the daemon reloads the container, cannot look the volume up by its empty name, and every `docker start` fails with exit 128 `get: no such volume`. Now a named volume, plus a repair path for containers already in the broken state.

**`teardown.sh` — never let Pulumi state outlive the cluster.** Everything these stacks manage lives inside the cluster being deleted, but the state lives in the checkout and survives, so a failed `destroy` leaves Pulumi believing resources exist that are already gone. This bit us on 2026-08-13: a broken registry kept Keycloak from starting, the `apps_infra` destroy failed, `|| true` reported success anyway, and the first `pulumi up` against the rebuilt cluster died with `404 Realm not found` while creating a child of a realm Pulumi thought it already had. A failed destroy now discards the stack state (preserving the checked-in `Pulumi.<stack>.yaml`).

**`zot-config.json` — raise the HTTP timeouts.** The `mitlearn-nextjs` image push retried its last layer forever:

```
89076705fa1d: Pushing [==================>       ]  1.156GB/3.169GB
```

zot defaults `http.readTimeout` to 60s, and Go's `ReadTimeout` is a deadline on the *entire request including body*, not an idle timeout. A monolithic 3.169GB blob upload therefore had to complete within 60s (>52MB/s sustained) or be severed mid-stream regardless of throughput. zot then deleted the partial upload, Docker restarted the layer from zero, and looped into the same wall. Every failure landed exactly 60s after its `POST`:

```
19:19:44  POST  /v2/mitodl_mit-learn-nextjs-app/blobs/uploads/   202
19:20:44  PATCH /v2/.../blobs/uploads/1bfdef92-...               500  latency: "1m0s"
          error: "read tcp 172.17.0.2:5000->172.17.0.1:33108: i/o timeout"
```

Only the multi-GB `node_modules` layers are large enough to cross it; that layer needs ~80s on a normal dev box. `readTimeout` and `writeTimeout` are now `30m` — write matters too, since a 60s response deadline is the same latent failure for kubelet pulling these blobs.

**`disk-janitor.sh` — reclaim repo dirs left manifest-less by an interrupted push.** zot's GC scheduler walks the storage directory but its retention logic is driven by the metadata DB, so it enqueues a task for every repo dir on disk and then fails on any the metadata DB has never heard of:

```
failed to run GC for /var/lib/zot/mitodl_mit-learn-nextjs-app
error: "repo metadata not found for given repo name"
```

A repo lands there when layer uploads succeed but the manifest PUT that registers them never happens — any interrupted push (Ctrl-C, a cancelled Tilt build, or the timeout above). The completed layers are then unreachable (no manifest refers to them) *and* un-collectable (GC bails first): multiple GB that nothing ever reclaims. zot cannot self-heal this, so `disk-janitor` now sweeps those directories. Two guards keep it off a live push, which passes through this exact state transiently since `index.json` is only written by the final manifest PUT: the repo must list no manifests **and** have had no filesystem activity anywhere in its tree for 60 minutes. Anything unparseable is left alone, so an upstream format change fails towards keeping data.

**`k3d-config.yaml` / `search.py` — raise the file-descriptor limit.** Every pod on this cluster inherits its fd limit from the k3d node container. Docker starts containers with `RLIMIT_NOFILE` soft=1024 (hard=524288), k3s and containerd inherit that from the node's PID 1, and containerd's CRI plugin sets no `default_ulimits` of its own, so a pod process lands on a soft limit of 1024. Raising the *host's* ulimit changes nothing — dockerd applies its own default to each container regardless.

1024 is not enough for the local-infra data stores. Qdrant mmaps ~30 files per segment and mit-learn shards its collections 6 ways, so creating payload indexes exhausted the limit and the collection bootstrap died partway through `create_qdrant_collections`:

```
Failed to save structure on disk with error: Too many open files (os error 24)
```

OpenSearch wants 65536 for the same reason. `k3d-config.yaml` now sets `runtime.ulimits` so the node container starts at soft=65536, which every pod then inherits. Soft is raised to 65536 rather than all the way to the hard limit because some runtimes size fd tables off the soft limit; the hard limit stays at Docker's 524288 so a process can still opt itself higher.

That cluster-level setting only applies on `teardown.sh` + `setup.sh`, so the Qdrant container additionally raises its own soft limit in its `command` — being a Rust binary it does not do this for itself the way a JVM does. This fixes existing clusters without a recreate. It uses `ulimit -Sn` (a bare `ulimit -n` would also drop the *hard* limit to 65536, discarding the headroom) with `|| true` so a lower inherited hard limit cannot block startup, and `exec`s the image's own `./entrypoint.sh` rather than `./qdrant` directly, preserving its SIGTERM/SIGINT handling and OOM recovery mode.

### How can this be tested?

**Registry push timeout** — with the old 60s default, `tilt up` on `mitlearn-nextjs` never gets past the last layer. After the change, confirm the running registry actually picked the values up (they need a restart, not zot's config hot-reload), then push:

```bash
docker restart k3d-registry.localhost
docker logs k3d-registry.localhost 2>&1 | grep -o '"ReadTimeout":[0-9]*' | tail -1
# "ReadTimeout":1800000000000   <- ns; 60000000000 means the default is still in effect

time docker push localhost:5001/mitodl_mit-learn-nextjs-app:<tag>
# completes in ~80s; previously looped forever on the 3.169GB layer
```

**Orphan sweep** — create a repo dir with no manifest, confirm the GC error, then confirm the janitor's two guards:

```bash
# 1. produce the broken state (a bare upload POST creates the repo dir)
curl -s -X POST http://localhost:5001/v2/gcprobe-test/blobs/uploads/ -o /dev/null

# 2. restart and watch GC fail for it
docker restart k3d-registry.localhost && sleep 40
docker logs --since 60s k3d-registry.localhost 2>&1 | grep '"module":"gc"'
#   "failed to run GC for /var/lib/zot/gcprobe-test"
#   error: "repo metadata not found for given repo name"

# 3. janitor must NOT touch it yet (activity within the last 60 min)
JANITOR_INTERVAL_SECS=0 JANITOR_BUILDCACHE_MAX_GB=0 ./local-dev/scripts/disk-janitor.sh

# 4. age it past the guard, with a stranded blob standing in for real layers
docker run --rm --volumes-from k3d-registry.localhost alpine sh -c '
  mkdir -p /var/lib/zot/gcprobe-test/blobs/sha256
  dd if=/dev/zero of=/var/lib/zot/gcprobe-test/blobs/sha256/deadbeef bs=1M count=200 2>/dev/null
  find /var/lib/zot/gcprobe-test -exec touch -d "2000-01-01 10:00:00" {} +'

# 5. now it is reclaimed, and real repos are untouched
JANITOR_INTERVAL_SECS=0 JANITOR_BUILDCACHE_MAX_GB=0 ./local-dev/scripts/disk-janitor.sh
#   registry: removed manifest-less repo 'gcprobe-test' (interrupted push)
#   registry: reclaimed 1 orphaned repo dir(s)

# 6. GC is clean afterwards
docker restart k3d-registry.localhost && sleep 40
docker logs --since 60s k3d-registry.localhost 2>&1 | grep '"module":"gc"'
#   one "gc successfully completed" per repo, no errors
```

**File-descriptor limits** — the per-container fix lands without a cluster recreate, so it can be checked against the running cluster first:

```bash
# before: the pod inherits the node container's 1024
kubectl exec -n local-infra deploy/qdrant -- sh -c 'ulimit -Sn; ulimit -Hn'
# 1024
# 524288

# after `pulumi up` rolls the deployment
kubectl exec -n local-infra deploy/qdrant -- sh -c 'ulimit -Sn; ulimit -Hn'
# 65536      <- soft raised
# 524288     <- hard headroom preserved (a bare `ulimit -n` would have dropped this)
```

The cluster-wide default needs `teardown.sh` + `setup.sh`, after which the node container itself carries it and any pod picks it up with no per-container `command`:

```bash
docker inspect k3d-local-dev-server-0 \
  --format '{{json .HostConfig.Ulimits}}'
# [{"Name":"nofile","Hard":524288,"Soft":65536}]
```

End to end, `create_qdrant_collections` should complete rather than dying on `os error 24` partway through the payload indexes.

**Full-cycle check for the other three** — `./local-dev/scripts/teardown.sh` followed by `./local-dev/scripts/setup.sh` and `tilt up` should come up clean, including Keycloak seeding, with no `Realm not found` on the first `pulumi up` and a registry that survives a Docker daemon restart.

### Additional Context

The janitor deletes registry storage while zot is running, which is exactly what corrupted the next push with `registry:2` in the 2026-07-23 incident documented in `prune-docker.sh` ("layer already exists" for blobs that were gone). zot keeps a dedupe cache mapping digests to paths, so that mode was tested explicitly before relying on it: push an image, delete its repo dir underneath the running registry, then push the same layers under a new repo whose dedupe entries now point at deleted paths. It pushed, pulled back, and ran clean — zot revalidates those entries, so the `registry:2` failure does not carry over.

Three judgement calls worth a reviewer's eye:

- **60 minutes** for `ORPHAN_REPO_MIN_AGE_MINS` is deliberately far longer than any plausible push (the worst case here was ~80s), since the cost of being wrong is asymmetric: waiting an extra cycle is free, deleting under a live push is not.
- **Detection is a `grep` for `"manifests":(null|[])`** rather than a JSON parse, to avoid adding a `jq` dependency to a script that already runs inside a stock `alpine` helper. If zot ever pretty-prints `index.json`, the pattern stops matching and the sweep simply does nothing — the failure direction is "leaves garbage", never "deletes something live".
- **The fd limit is set in two places on purpose.** `k3d-config.yaml` is the correct home for it — it fixes every workload on the cluster, including OpenSearch — but it only takes effect on a cluster recreate. The per-container `ulimit -Sn` in `search.py` is what unblocks anyone already running a cluster. On a freshly created cluster it is redundant and harmless — it sets the soft limit to the value the pod already inherited.

