### PR TITLE
feat(concourse): register github pulumi projects as simple pipelines

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/README.md
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/README.md
@@ -13,16 +13,18 @@ The Simple Pulumi-Only pattern is for applications/services that:
 ## Managed Applications
 
 `production_app_names` in `meta.py` is the source of truth for what this meta
-pipeline manages on odl-prod. It currently holds 33 applications, each rendered
+pipeline manages on odl-prod. It currently holds 37 applications, each rendered
 as a `pulumi-{app_name}` pipeline on the `infrastructure` team:
 
 `airbyte`, `aws-ecr`, `aws-sftp`, `b2b-partners-storage`, `celery-monitoring`,
 `clickhouse`, `data_warehouse`, `digital-credentials`, `fastly-redirector`,
+`github-organization`, `github-repositories`, `grafana-alerting`,
 `jupyterhub-data`, `mailgun`, `marimo-data`, `mongodb-atlas`, `monitoring`,
 `ocw-site`, `open-discussions`, `open-metadata`, `open-metadata-substructure`,
-`opensearch`, `qdrant-cloud`, `release-bot`, `rootly`, `sentry`, `starrocks`,
-`starrocks-substructure`, `starburst`, `tika`, `toolhive-apps`, `toolhive-data`,
-`toolhive-operator`, `toolhive-swe`, `vector-log-proxy`, `xpro-partner-dns`
+`opensearch`, `opik`, `qdrant-cloud`, `release-bot`, `rootly`, `sentry`,
+`starrocks`, `starrocks-substructure`, `starburst`, `tika`, `toolhive-apps`,
+`toolhive-data`, `toolhive-operator`, `toolhive-swe`, `vector-log-proxy`,
+`xpro-partner-dns`
 
 `meta.py` also carries `qa_app_names` (`starrocks-substructure-qa`) and
 `ci_app_names` (`starrocks-substructure-ci`), selected via `--env qa` / `--env ci`

--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/meta.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/meta.py
@@ -198,6 +198,8 @@ if __name__ == "__main__":
         "data_warehouse",
         "digital-credentials",
         "fastly-redirector",
+        "github-organization",
+        "github-repositories",
         "grafana-alerting",
         "jupyterhub-data",
         "mailgun",

--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
@@ -8,7 +8,7 @@ deployment across CI, QA, and Production stages without any build steps.
 
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from ol_concourse.lib.containers import container_build_task
 from ol_concourse.lib.models.fragment import PipelineFragment
@@ -128,6 +128,16 @@ class SimplePulumiParams(BaseModel):
                       provisions Fastly resources while the Fastly API token is
                       being rotated -- refresh calls the Fastly API with the old
                       token and fails the whole job.
+        topology: "deploy-chained" (default) auto-deploys each stage on code
+                 change, gated only by the previous stage's promotion issue.
+                 "preview-gated" instead gates every stage on a `pulumi preview`
+                 of itself: a gate issue opens with that stage's diff, and only
+                 closing it triggers the `pulumi up`. Use for apps whose changes
+                 are too high-blast-radius to auto-apply, e.g. org-wide GitHub
+                 management.
+        auto_deploy_stages: Only used with topology="preview-gated". Stages
+                           listed here keep today's auto-deploy-on-change
+                           behavior instead of being gated. Typically ["CI"].
     """
 
     app_name: str
@@ -143,6 +153,8 @@ class SimplePulumiParams(BaseModel):
     build: BuildConfig | None = None
     prior_stage_stack: str | None = None
     refresh_stack: bool = True
+    topology: Literal["deploy-chained", "preview-gated"] = "deploy-chained"
+    auto_deploy_stages: list[str] | None = None
 
     @model_validator(mode="before")
     @classmethod
@@ -347,12 +359,14 @@ pipeline_params: dict[str, SimplePulumiParams] = {
         pulumi_project_path="saas/github/organization/",
         pulumi_project_name="ol-saas-github-organization",
         stages=["default"],
+        topology="preview-gated",
     ),
     "github-repositories": SimplePulumiParams(
         app_name="github-repositories",
         pulumi_project_path="saas/github/repositories/",
         pulumi_project_name="ol-saas-github-repositories",
         stages=["default"],
+        topology="preview-gated",
     ),
     "grafana-alerting": SimplePulumiParams(
         app_name="grafana-alerting",
@@ -765,6 +779,8 @@ def build_simple_pulumi_pipeline(app_name: str) -> Pipeline:
                     dependencies=docker_dependencies,
                     env_vars_from_files=docker_env_vars_from_files or None,
                     custom_dependencies=cross_env_custom_deps or None,
+                    topology=params.topology,
+                    auto_deploy_stages=params.auto_deploy_stages,
                 )
 
                 # Collect resources and jobs
@@ -797,6 +813,8 @@ def build_simple_pulumi_pipeline(app_name: str) -> Pipeline:
                 dependencies=docker_dependencies,
                 env_vars_from_files=docker_env_vars_from_files or None,
                 custom_dependencies=cross_env_custom_deps or None,
+                topology=params.topology,
+                auto_deploy_stages=params.auto_deploy_stages,
             )
 
             all_pipeline_resources = [
@@ -832,6 +850,8 @@ def build_simple_pulumi_pipeline(app_name: str) -> Pipeline:
             dependencies=docker_dependencies,
             env_vars_from_files=docker_env_vars_from_files or None,
             custom_dependencies=cross_env_custom_deps or None,
+            topology=params.topology,
+            auto_deploy_stages=params.auto_deploy_stages,
         )
 
         all_pipeline_resources = [

--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
@@ -342,6 +342,18 @@ pipeline_params: dict[str, SimplePulumiParams] = {
         pulumi_project_name="ol-application-fastly-redirector",
         refresh_stack=False,
     ),
+    "github-organization": SimplePulumiParams(
+        app_name="github-organization",
+        pulumi_project_path="saas/github/organization/",
+        pulumi_project_name="ol-saas-github-organization",
+        stages=["default"],
+    ),
+    "github-repositories": SimplePulumiParams(
+        app_name="github-repositories",
+        pulumi_project_path="saas/github/repositories/",
+        pulumi_project_name="ol-saas-github-repositories",
+        stages=["default"],
+    ),
     "grafana-alerting": SimplePulumiParams(
         app_name="grafana-alerting",
         pulumi_project_path="infrastructure/grafana_alerting/",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
- Registers `ol-saas-github-organization` and `ol-saas-github-repositories` (both under `src/ol_infrastructure/saas/github/`) in the `simple_pulumi` meta pipeline
- Both are singleton (`Pulumi.default.yaml`) SaaS deployments, so `stages=["default"]`, following the same pattern as `sentry`, `aws-ecr`, and `monitoring`
- Adds `github-organization` and `github-repositories` to `pipeline_params` in `src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py` and to `production_app_names` in `src/ol_concourse/pipelines/infrastructure/simple_pulumi/meta.py`
- The `secrets_map.py` entries for both projects already existed (empty lists), so no change needed there
- **Follow-up commit**: both pipelines are switched to `topology="preview-gated"` instead of the default `deploy-chained`. These two Pulumi projects manage org-wide GitHub state (rulesets, team grants, repo settings across 300+ repos), so every deploy now opens a gate issue with that stage's own `pulumi preview` diff, and only applies once a human closes it -- rather than auto-applying on every push. This is the same topology already used for `eks_clusters` and `edx_platform_v3`. `SimplePulumiParams` gained `topology`/`auto_deploy_stages` fields (both optional, defaulting to today's `deploy-chained` behavior) so this is opt-in per app; no other app in `pipeline_params` is affected.

### How can this be tested?
Ran the pipeline generation scripts locally and confirmed valid Concourse pipeline JSON output:

```
PYTHONPATH=src python src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py github-organization
PYTHONPATH=src python src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py github-repositories
PYTHONPATH=src python src/ol_concourse/pipelines/infrastructure/simple_pulumi/meta.py
```

All exited 0. The two app pipelines now generate `preview-<project>-default` / `deploy-<project>-default` job pairs (confirming the preview-gate topology took effect) instead of a single auto-deploying job. Re-ran an unrelated existing app (`tika`) to confirm it still generates its normal `deploy-*-ci/qa/production` chain unaffected. `pre-commit` (ruff, mypy) passes clean on all changed files. No live `fly set-pipeline` or Concourse deploy was performed.