### PR TITLE
feat(ol-analytics-api): harden the pod with a non-root, read-only, no-caps container

### DIFF
--- a/src/ol_infrastructure/applications/ol_analytics_api/__main__.py
+++ b/src/ol_infrastructure/applications/ol_analytics_api/__main__.py
@@ -45,7 +45,11 @@ Key wiring decisions (see also ``k8s/README.md`` in the app repo):
   ``import_nginx_config`` is off and the probes are re-pointed at 8000.  This is
   the first data-cluster use of ``OLApplicationK8s``; it creates a
   ``SecurityGroupPolicy`` binding the pods to a dedicated security group (see
-  ``ol_analytics_api_application_security_group`` below).
+  ``ol_analytics_api_application_security_group`` below).  It is also the first
+  caller of the component's ``container_security_context``: this service is a
+  single non-Django container off an image that already runs as an
+  unprivileged user, so it can take a read-only root filesystem and a dropped
+  capability set that the Django apps sharing the component cannot yet.
 
 * **APISIX + Keycloak OIDC, two separate clients.**  ``OLApisixRoute`` +
   ``OLApisixOIDCResources`` put the openid-connect plugin in front of the
@@ -500,6 +504,41 @@ ol_analytics_api_k8s = OLApplicationK8s(
         probe_configs=_probe_configs,
         resource_requests={"cpu": "100m", "memory": "256Mi"},
         resource_limits={"memory": "512Mi"},
+        # Pod/container hardening. The app image already declares
+        # `USER appuser` (uid/gid 1000) and PYTHONDONTWRITEBYTECODE=1, so
+        # nothing writes to the image filesystem at runtime and a read-only
+        # root is free -- with the exception of tempfile's default directory,
+        # which the emptyDir below keeps writable.
+        pod_security_context=kubernetes.core.v1.PodSecurityContextArgs(
+            run_as_non_root=True,
+            run_as_user=1000,
+            run_as_group=1000,
+            # An emptyDir is created root-owned; without an fsGroup the app
+            # user cannot write into the /tmp mount below.
+            fs_group=1000,
+            seccomp_profile=kubernetes.core.v1.SeccompProfileArgs(
+                type="RuntimeDefault"
+            ),
+        ),
+        container_security_context=kubernetes.core.v1.SecurityContextArgs(
+            allow_privilege_escalation=False,
+            read_only_root_filesystem=True,
+            capabilities=kubernetes.core.v1.CapabilitiesArgs(drop=["ALL"]),
+        ),
+        extra_volumes=[
+            kubernetes.core.v1.VolumeArgs(
+                name="tmp",
+                empty_dir=kubernetes.core.v1.EmptyDirVolumeSourceArgs(
+                    size_limit="64Mi"
+                ),
+            )
+        ],
+        extra_volume_mounts=[
+            kubernetes.core.v1.VolumeMountArgs(
+                name="tmp",
+                mount_path="/tmp",  # noqa: S108
+            )
+        ],
     ),
     opts=ResourceOptions(
         delete_before_replace=True,

--- a/src/ol_infrastructure/components/services/k8s.py
+++ b/src/ol_infrastructure/components/services/k8s.py
@@ -661,6 +661,20 @@ class OLApplicationK8sConfig(BaseModel):
             "securityContext is set on pods."
         ),
     )
+    container_security_context: kubernetes.core.v1.SecurityContextArgs | None = Field(
+        default=None,
+        description=(
+            "Container-level security context applied to every container this "
+            "component builds from the application image: the webapp container, the "
+            "migrate/collectstatic init containers, the celery worker and beat "
+            "containers, and the pre/post-deploy job containers. NOT applied to the "
+            "nginx sidecar (an upstream image that needs a writable /var/cache/nginx "
+            "and /var/run, so read_only_root_filesystem there would crash-loop it), "
+            "nor to extra_init_containers/extra_sidecar_containers, which the caller "
+            "constructs in full and can set this on directly. When None, no "
+            "securityContext is set on containers."
+        ),
+    )
     extra_volumes: list[kubernetes.core.v1.VolumeArgs] = Field(
         default_factory=list,
         description=(
@@ -1182,6 +1196,15 @@ class OLApplicationK8s(ComponentResource):
         ):
             image_pull_policy = "Always"
 
+        # Spread into every ContainerArgs built from the application image, so an
+        # unset context stays absent from the manifest rather than serializing as an
+        # empty securityContext block.
+        app_container_security_context: dict[str, Any] = {}
+        if ol_app_k8s_config.container_security_context is not None:
+            app_container_security_context["security_context"] = (
+                ol_app_k8s_config.container_security_context
+            )
+
         init_containers = []
         # extra_init_containers run first, before component-managed ones
         for extra_init in ol_app_k8s_config.extra_init_containers:
@@ -1215,6 +1238,7 @@ class OLApplicationK8s(ComponentResource):
                         *ol_app_k8s_config.extra_volume_mounts,
                         *ol_app_k8s_config.extra_init_volume_mounts,
                     ],
+                    **app_container_security_context,
                 )
             )
 
@@ -1235,6 +1259,7 @@ class OLApplicationK8s(ComponentResource):
                         *ol_app_k8s_config.extra_volume_mounts,
                         *ol_app_k8s_config.extra_init_volume_mounts,
                     ],
+                    **app_container_security_context,
                 )
             )
 
@@ -1309,6 +1334,7 @@ class OLApplicationK8s(ComponentResource):
         # when configuring OLVaultK8SDynamicSecretConfig restart_targets.
         self.webapp_deployment_name: str = _application_deployment_name
         self.celery_deployment_names: list[str] = []
+        self.celery_deployments: list[kubernetes.apps.v1.Deployment] = []
         self.beat_deployment_name: str | None = None
 
         if pre_deploy_commands := ol_app_k8s_config.pre_deploy_commands:
@@ -1377,6 +1403,7 @@ class OLApplicationK8s(ComponentResource):
                                     ),
                                     volume_mounts=ol_app_k8s_config.extra_volume_mounts
                                     or None,
+                                    **app_container_security_context,
                                 )
                                 for (command_name, command_array) in pre_deploy_commands
                             ],
@@ -1456,6 +1483,7 @@ class OLApplicationK8s(ComponentResource):
                     if ol_app_k8s_config.probe_configs is None
                     else ol_app_k8s_config.probe_configs
                 ),
+                **app_container_security_context,
             ),
         )
         # Append caller-supplied sidecar containers after the main app container
@@ -1598,6 +1626,7 @@ class OLApplicationK8s(ComponentResource):
                                     env_from=application_deployment_envfrom,
                                     volume_mounts=ol_app_k8s_config.extra_volume_mounts
                                     or None,
+                                    **app_container_security_context,
                                 )
                                 for (
                                     command_name,
@@ -2043,6 +2072,7 @@ class OLApplicationK8s(ComponentResource):
                                     ),
                                     volume_mounts=ol_app_k8s_config.extra_volume_mounts
                                     or None,
+                                    **app_container_security_context,
                                 ),
                                 *ol_app_k8s_config.extra_sidecar_containers,
                             ],
@@ -2052,6 +2082,7 @@ class OLApplicationK8s(ComponentResource):
                 ),
                 opts=resource_options,
             )
+            self.celery_deployments.append(_celery_deployment)
 
             _celery_scaled_object = kubernetes.apiextensions.CustomResource(
                 f"{ol_app_k8s_config.application_name}-celery-worker-{celery_worker_config.worker_name}-{stack_info.env_suffix}-scaledobject",
@@ -2199,6 +2230,7 @@ class OLApplicationK8s(ComponentResource):
                                     ),
                                     volume_mounts=ol_app_k8s_config.extra_volume_mounts
                                     or None,
+                                    **app_container_security_context,
                                 ),
                                 *ol_app_k8s_config.extra_sidecar_containers,
                             ],

--- a/tests/ol_infrastructure/components/services/test_k8s_extra_containers.py
+++ b/tests/ol_infrastructure/components/services/test_k8s_extra_containers.py
@@ -15,9 +15,10 @@ Note:
     instantiate OLApplicationK8s or assert on full Kubernetes pod specs (e.g.,
     sidecars, init containers, volumes, or pod_security_context), nor do they
     assert on autoscaling resources such as HPAs or KEDA ScaledObjects. The
-    exception is test_default_container_annotation_set_to_app_container, which
+    exceptions are test_default_container_annotation_set_to_app_container, which
     instantiates OLApplicationK8s under Pulumi mocks to verify the Deployment's
-    pod template annotations.
+    pod template annotations, and the container_security_context tests at the
+    end of the module, which assert on the rendered container specs.
 """
 
 from __future__ import annotations
@@ -841,3 +842,89 @@ def test_empty_probe_configs_disables_probes():
         assert not any(key in container for key in _PROBE_KEYS)
 
     return app.application_deployment.spec.template.spec.containers.apply(check)
+
+
+# ─── container_security_context ───────────────────────────────────────────────
+
+_HARDENED_CONTAINER_CONTEXT = kubernetes.core.v1.SecurityContextArgs(
+    allow_privilege_escalation=False,
+    read_only_root_filesystem=True,
+    capabilities=kubernetes.core.v1.CapabilitiesArgs(drop=["ALL"]),
+)
+
+
+@pulumi.runtime.test
+def test_container_security_context_absent_by_default():
+    """Unset means no securityContext key at all, not an empty block."""
+    app = OLApplicationK8s(_base_config(application_name="nocontext"))
+
+    def check(containers):
+        assert "security_context" not in _app_container(containers, "nocontext")
+
+    return app.application_deployment.spec.template.spec.containers.apply(check)
+
+
+@pulumi.runtime.test
+def test_container_security_context_applied_to_app_container():
+    app = OLApplicationK8s(
+        _base_config(
+            application_name="hardened",
+            container_security_context=_HARDENED_CONTAINER_CONTEXT,
+        )
+    )
+
+    def check(containers):
+        context = _app_container(containers, "hardened")["security_context"]
+        assert context["read_only_root_filesystem"] is True
+        assert context["allow_privilege_escalation"] is False
+        assert context["capabilities"]["drop"] == ["ALL"]
+
+    return app.application_deployment.spec.template.spec.containers.apply(check)
+
+
+@pulumi.runtime.test
+def test_container_security_context_skips_nginx_sidecar():
+    """Nginx needs a writable /var/cache/nginx, so it keeps the image's own context."""
+    project_root = Path(tempfile.mkdtemp())
+    (project_root / "files").mkdir()
+    (project_root / "files" / "web.conf").write_text("server { listen 8071; }\n")
+
+    app = OLApplicationK8s(
+        _base_config(
+            application_name="withnginx",
+            project_root=project_root,
+            import_nginx_config=True,
+            container_security_context=_HARDENED_CONTAINER_CONTEXT,
+        )
+    )
+
+    def check(containers):
+        nginx = next(c for c in containers if c["name"] == "nginx")
+        assert "security_context" not in nginx
+        assert "security_context" in _app_container(containers, "withnginx")
+
+    return app.application_deployment.spec.template.spec.containers.apply(check)
+
+
+@pulumi.runtime.test
+def test_container_security_context_applied_to_celery_worker():
+    app = OLApplicationK8s(
+        _base_config(
+            application_name="hardenedcelery",
+            container_security_context=_HARDENED_CONTAINER_CONTEXT,
+            celery_worker_configs=[
+                OLApplicationK8sCeleryWorkerConfig(
+                    application_name="hardenedcelery",
+                    worker_name="default",
+                    redis_host=pulumi.Output.from_input("redis.example.com"),
+                    redis_password="hunter2",  # pragma: allowlist secret
+                )
+            ],
+        )
+    )
+
+    def check(containers):
+        worker = next(c for c in containers if c["name"] == "celery-worker")
+        assert worker["security_context"]["read_only_root_filesystem"] is True
+
+    return app.celery_deployments[0].spec.template.spec.containers.apply(check)


### PR DESCRIPTION
## What

Adds pod and container hardening to the `ol-analytics-api` deployment:

- **Pod** — `runAsNonRoot: true`, uid/gid 1000, `fsGroup: 1000`, `seccompProfile: RuntimeDefault`
- **Container** — `allowPrivilegeEscalation: false`, `readOnlyRootFilesystem: true`, `capabilities.drop: [ALL]`
- A 64Mi `/tmp` emptyDir, the one writable path the read-only root still needs (tempfile's default directory)

The container-level half had nowhere to live: `OLApplicationK8s` took a `pod_security_context` but no per-container equivalent. This PR adds `container_security_context` to `OLApplicationK8sConfig` and spreads it across every container the component builds from the application image — webapp, `migrate`/`collectstatic` init containers, celery worker and beat, and the pre/post-deploy job containers.

It deliberately does **not** apply to:

- the **nginx sidecar** — an upstream image that needs a writable `/var/cache/nginx` and `/var/run`, so a read-only root there would crash-loop the apps that still run it;
- `extra_init_containers` / `extra_sidecar_containers` — the caller constructs those in full and can set the field directly.

## Why

The service fronts B2B customer analytics and previously ran with whatever defaults the image and cluster happened to give it: no `runAsNonRoot` assertion, a writable root filesystem, the default capability set, no seccomp profile. None of that is needed — it is a read-only FastAPI gateway over StarRocks whose image already declares `USER appuser` (uid/gid 1000) and `PYTHONDONTWRITEBYTECODE=1` — so the privileges were pure blast radius.

Tracked as the k8s-hardening item from the 2026-07-08 ol-analytics-api architecture review.

## Blast radius

`container_security_context` defaults to `None`, and an unset value is omitted from the manifest entirely rather than serialized as an empty block, so this is a no-op for every existing caller of the component. `ol-analytics-api` is the only opt-in.

## How tested

- `pulumi preview --stack CI` — the only Deployment diff is the pod `securityContext`, the container `securityContext`, and the `/tmp` volume/mount. (The `envFrom` and Apisix plugin-config diffs in that preview are pre-existing drift between CI state and `main`, not from this change.)
- `pytest tests/ol_infrastructure/components` — 151 passed, including four new tests: absent by default, applied to the app container, applied to the celery worker, and **not** applied to the nginx sidecar.
- `pre-commit run` on the changed files: ruff, ruff-format, mypy, detect-secrets all pass.

A companion PR updates the reference manifest in `ol-analytics-api` (`k8s/deployment.yaml`) so the dry-run artifact does not drift from what is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QC8Vb9vZiGMPeHd97Fy4Gj