### PR TITLE
feat(concourse): adopt stalled-worker timeout and archived-pipeline cleanup from 8.3.0

### DIFF
--- a/src/bilder/components/concourse/models.py
+++ b/src/bilder/components/concourse/models.py
@@ -358,6 +358,14 @@ class ConcourseWebConfig(ConcourseBaseConfig):
         alias="CONCOURSE_DEFAULT_TASK_MEMORY_LIMIT",
         description="Default maximum memory per task, 0 means unlimited",
     )
+    destroy_archived_pipelines_after: str | None = Field(
+        None,
+        alias="CONCOURSE_DESTROY_ARCHIVED_PIPELINES_AFTER",
+        description=(
+            "Duration after which the pipeline collector will destroy archived"
+            " pipelines. 0 (default) disables destruction of archived pipelines."
+        ),
+    )
     display_user_id_per_connector: str | None = Field(
         None,
         alias="CONCOURSE_DISPLAY_USER_ID_PER_CONNECTOR",
@@ -1369,6 +1377,15 @@ class ConcourseWebConfig(ConcourseBaseConfig):
         Path("/etc/concourse/session_signing_key"),
         alias="CONCOURSE_SESSION_SIGNING_KEY",
         description="File containing an RSA private key, used to sign auth tokens.",
+    )
+    stalled_worker_timeout: str | None = Field(
+        None,
+        alias="CONCOURSE_STALLED_WORKER_TIMEOUT",
+        description=(
+            "Duration after which a stalled worker will be deleted, so that its"
+            " containers and volumes can be garbage collected. 0 (default) disables"
+            " automatic pruning of stalled workers."
+        ),
     )
     streaming_artifacts_compression: str | None = Field(
         None,

--- a/src/bilder/components/concourse/models.py
+++ b/src/bilder/components/concourse/models.py
@@ -362,8 +362,11 @@ class ConcourseWebConfig(ConcourseBaseConfig):
         None,
         alias="CONCOURSE_DESTROY_ARCHIVED_PIPELINES_AFTER",
         description=(
-            "Duration after which the pipeline collector will destroy archived"
-            " pipelines. 0 (default) disables destruction of archived pipelines."
+            "Duration after which the pipeline collector will destroy ANY archived"
+            " pipeline (manually archived via fly/UI, or auto-archived set_pipeline"
+            " orphans alike -- Concourse applies this globally with no distinction"
+            " by archive reason). 0 (default) disables destruction of archived"
+            " pipelines."
         ),
     )
     display_user_id_per_connector: str | None = Field(

--- a/src/bilder/images/concourse/deploy.py
+++ b/src/bilder/images/concourse/deploy.py
@@ -175,6 +175,12 @@ concourse_config_map = {
         # this is set well above that to avoid racing it or wiping a worker
         # that's merely partitioned and about to reconnect.
         stalled_worker_timeout="4h",
+        # Applies globally to any archived pipeline, not only set_pipeline orphans
+        # -- Concourse's DestroyArchivedPipelines query has no way to distinguish
+        # a manually-archived pipeline from an auto-archived one. Accepted as
+        # intentional: 30 days is long enough that a manual archive kept for
+        # reference should be re-set (fly set-pipeline) before it expires if it
+        # needs to survive longer.
         destroy_archived_pipelines_after="720h",  # 30 days
         global_resource_check_timeout="30m",
         lidar_scanner_interval="15s",

--- a/src/bilder/images/concourse/deploy.py
+++ b/src/bilder/images/concourse/deploy.py
@@ -169,6 +169,13 @@ concourse_config_map = {
         enable_worker_auditing=False,
         gc_hijack_grace_period="30m",
         gc_failed_grace_period="5m",
+        # Backstop for stalled workers that concourse-worker-reaper can't catch
+        # (e.g. the EC2 instance is still alive but the worker process itself is
+        # wedged). The reaper prunes on confirmed EC2 termination every 3m, so
+        # this is set well above that to avoid racing it or wiping a worker
+        # that's merely partitioned and about to reconnect.
+        stalled_worker_timeout="4h",
+        destroy_archived_pipelines_after="720h",  # 30 days
         global_resource_check_timeout="30m",
         lidar_scanner_interval="15s",
         max_checks_per_second="30",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Reviewed the Concourse 8.3.0 release notes (already live in prod since the 2026-08-13 auto-upgrade) for fixes/features worth adopting. Adds two new opt-in config flags to the ATC (web) node:

- `CONCOURSE_STALLED_WORKER_TIMEOUT=4h` ([concourse/concourse#9604](https://github.com/concourse/concourse/pull/9604)) — auto-prunes workers stuck in `stalled` past the timeout. Set as a backstop well above `concourse-worker-reaper`'s 3-minute cadence and the 5-minute TSA reconnect window, so it only catches cases the reaper's EC2-ground-truth check can't (worker process wedged while the EC2 instance itself is still alive).
- `CONCOURSE_DESTROY_ARCHIVED_PIPELINES_AFTER=720h` (30 days, [concourse/concourse#9630](https://github.com/concourse/concourse/pull/9630)) — destroys archived pipelines left behind by `SetPipelineStep` children, which are used extensively across this repo's meta-pipelines (`container_images`, `simple_pulumi`, etc.) and otherwise accumulate indefinitely.

Both fields added to `ConcourseWebConfig` in `src/bilder/components/concourse/models.py` and set in `src/bilder/images/concourse/deploy.py`.

### How can this be tested?
Ran `uv run pre-commit run --all-files` and `mypy` on the changed files — both pass. This is AMI-build-time config (bilder/pyinfra), not something testable locally against a live cluster; it takes effect on the next `concourse-packer-pulumi` rebuild and rollout through CI → QA → Production. Recommend confirming in QA first — `fly workers` should show stalled workers pruned after 4h, and no legitimate reconnecting workers should be lost given the margin over the reaper/TSA windows.

### Additional Context
`CONCOURSE_STALLED_WORKER_TIMEOUT` is authored upstream by the same person opening this PR, in response to the stalled-worker cleanup gap on this org's spot ASG worker fleet.