### PR TITLE
Add admin-team bypass to the two evaluate-mode org rulesets

### DIFF
--- a/src/ol_infrastructure/saas/github/organization/org_rulesets.py
+++ b/src/ol_infrastructure/saas/github/organization/org_rulesets.py
@@ -36,6 +36,7 @@ effective-rules endpoints will report them as absent and be wrong.
 import pulumi_github as github
 from pulumi import ResourceOptions
 
+from ol_infrastructure.saas.github.organization.teams import github_teams
 from ol_infrastructure.saas.github.tiers import (
     TIER_ONE,
     TIER_PROPERTY_NAME,
@@ -44,6 +45,30 @@ from ol_infrastructure.saas.github.tiers import (
 
 #: Flip to "active" only after watching the rule-suite logs. See the module docstring.
 _ENFORCEMENT = "evaluate"
+
+# Found 2026-08-14, ahead of promotion: neither ruleset carries a bypass, but
+# `enforce_admins: false` on every repo's classic branch protection today means repo
+# admins can already override it. An org ruleset with no bypass_actors is *more*
+# restrictive than that status quo -- promoting without one would newly block
+# `odlbot`, which several tier-1 repos restriction-list or bypass-list directly for
+# default-branch pushes (open-edx-plugins, ocw-hugo-themes, mit-learn,
+# ocw-hugo-projects). odlbot is a member of `odl-engineering-owners` (the sanctioned
+# admin team, SEC-15), so bypassing at the team level restores admin parity without
+# a per-user actor type, which OrganizationRulesetBypassActorArgs does not support
+# (only RepositoryRole, Team, Integration, OrganizationAdmin).
+#
+# renovate[bot] deliberately gets NO bypass_actor entry here. It already satisfies
+# `required_approving_review_count` for real: the `renovate-approve` GitHub App is
+# installed org-wide and leaves a genuine APPROVED review on every renovate PR
+# (confirmed live on ol-infrastructure#5343) -- a bypass would be redundant with an
+# approval that already exists.
+_ADMIN_BYPASS = [
+    github.OrganizationRulesetBypassActorArgs(
+        actor_type="Team",
+        actor_id=github_teams["odl-engineering-owners"].id.apply(int),
+        bypass_mode="always",
+    ),
+]
 
 #: `~DEFAULT_BRANCH` is GitHub's alias for whatever each repo's default branch is,
 #: which is what makes one ruleset work across a fleet where 102 repos are on
@@ -86,6 +111,7 @@ baseline_default_branch = github.OrganizationRuleset(
     name="baseline-default-branch",
     target="branch",
     enforcement=_ENFORCEMENT,
+    bypass_actors=_ADMIN_BYPASS,
     conditions=_tier_condition(TIER_ONE, TIER_STANDARD),
     rules=github.OrganizationRulesetRulesArgs(
         # No force-pushing over the default branch, and no deleting it.
@@ -108,6 +134,7 @@ tier_one_hardening = github.OrganizationRuleset(
     name="tier-1-hardening",
     target="branch",
     enforcement=_ENFORCEMENT,
+    bypass_actors=_ADMIN_BYPASS,
     conditions=_tier_condition(TIER_ONE),
     rules=github.OrganizationRulesetRulesArgs(
         pull_request=github.OrganizationRulesetRulesPullRequestArgs(


### PR DESCRIPTION
### What are the relevant tickets?

Phase 3.5 gate of `docs/plans/github-org-pulumi-import.md` — `tk-phase-3-5-gate-read-the-rule-suite-logs-then-pro-6061d2` in the GitHub-org-import project.

### Description (What does it do?)

Adds `bypass_actors` to both org rulesets (`baseline-default-branch`, `tier-1-hardening`), which currently have none.

**The gap this closes:** every repo's classic branch protection has `enforce_admins: false` today, so repo admins can already override it. An `OrganizationRuleset` with no `bypass_actors` is *more* restrictive than that — promoting either ruleset to `active` without one would, for the first time, block pushes GitHub currently allows.

Scanned all 73 tier-1 repos' branch protection for existing bypass grants. Found 8 with one:

| Actor | Repos | Mechanism |
|---|---|---|
| `renovate[bot]` | ol-data-platform, mitxonline, ol-infrastructure | `bypass_pull_request_allowances.apps` |
| `odlbot` | open-edx-plugins, ocw-hugo-themes, mit-learn, ocw-hugo-projects | push `restrictions` / bypass allowance |
| `ChristopherChudzicki` (human) | smoot-design | `bypass_pull_request_allowances.users` |

`OrganizationRulesetBypassActorArgs.actor_type` only supports `RepositoryRole`, `Team`, `Integration`, `OrganizationAdmin` — there's no per-user actor type, so this can't be a literal port of the three grants above:

- **renovate needs nothing.** `renovate-approve` (a GitHub App, installed org-wide) already leaves a real `APPROVED` review on every renovate PR — confirmed live on #5343. That satisfies `required_approving_review_count` for real, so a bypass would be redundant with an approval that already exists.
- **odlbot is covered by team bypass.** It's a member of `odl-engineering-owners` (the sanctioned admin team per SEC-15), so bypassing at that team level restores its access without inventing a new actor type. This is the change in this PR: `bypass_actors = [Team odl-engineering-owners, bypass_mode=always]` on both rulesets.
- **ChristopherChudzicki is not covered** — they're in `odl-engineering` but not `odl-engineering-owners`. Left as a known gap; see Additional Context.

### How can this be tested?

`pulumi preview` on `ol-saas-github-organization` showed exactly the two `bypassActors` additions and nothing else:

```
~ 2 to update
  18 unchanged
```

Already applied directly (`pulumi up`, not yet through Concourse) since both rulesets are still `enforcement: evaluate` — this carries no live blocking effect, only evaluate-mode logging. Verified live: `gh api /orgs/mitodl/rulesets/20569964 --jq .bypass_actors` returns the new entry, and a follow-up `pulumi preview` is a clean 0-change diff.

### Additional Context

This does **not** clear the way to promote either ruleset to `active` yet. Two things remain, tracked on `tk-phase-3-5-gate-read-the-rule-suite-logs-then-pro-6061d2`:

1. `ChristopherChudzicki`'s personal bypass on smoot-design has no equivalent here — needs a decision (move them into a team that has bypass, or accept the behavior change on that one repo).
2. `tier-1-hardening`'s two rules (`require_last_push_approval`, `required_review_thread_resolution`) aren't gap-closing like `baseline-default-branch` — they're brand-new requirements no repo enforces today, landing on all 74 tier-1 repos at once. There's no existing classic-protection behavior to compare against.
3. The plan's intended gate mechanism — "read the rule-suite logs" — turned out not to be checkable from here: `GET /orgs/mitodl/rulesets/rule-suites` is Enterprise-gated (403) on the Team plan, and `GET /repos/{owner}/{repo}/rulesets/rule-suites` doesn't surface evaluate-mode org-ruleset evaluations either (checked directly on a real push — only the repo's classic `protected_branch` rule and its own repo ruleset appeared). The only remaining option is the web UI at https://github.com/organizations/mitodl/settings/rules, unchecked so far.