### PR TITLE
feat(witan): instrument the ToolHive tier so the pre-handler interval is measurable

### DIFF
--- a/src/ol_infrastructure/applications/witan/__main__.py
+++ b/src/ol_infrastructure/applications/witan/__main__.py
@@ -153,6 +153,13 @@ from ol_infrastructure.applications.witan.mcp_servers import (
     create_mcp_servers,
 )
 from ol_infrastructure.applications.witan.migrations import create_migration_job
+from ol_infrastructure.applications.witan.observability import (
+    TOOLHIVE_TELEMETRY_BACKEND_CONFIG_NAME,
+    TOOLHIVE_TELEMETRY_VMCP_CONFIG_NAME,
+    toolhive_service_name,
+    toolhive_telemetry_spec,
+    toolhive_vmcp_audit,
+)
 from ol_infrastructure.components.applications.eks import (
     OLEKSAuthBinding,
     OLEKSAuthBindingConfig,
@@ -771,6 +778,60 @@ if witan_admin_token_secret is not None:
     )
 
 #########################################
+#   MCPTelemetryConfig (ToolHive tier)   #
+#########################################
+# The two ToolHive hops in front of witan — the proxyrunner and the vMCP — run
+# their own OTel pipeline, configured through these CRs rather than through the
+# OTEL_* environment `observability.otel_env` builds for the witan process. They
+# were dark until 2026-08-14; see observability.py for what that cost.
+#
+# ★ TWO CRs, NOT ONE SHARED. They differ only in `prometheus.enabled`, and that
+# difference is a security boundary: ToolHive serves /metrics on the MAIN
+# TRANSPORT PORT, and the vMCP's is the port APISIX publishes under a `/*`
+# catch-all route (ingress.py). One shared config would either expose an
+# unauthenticated metrics endpoint on the public vMCP host or deny the backend
+# the one read CI can perform. The `serviceName` override on each ref is what
+# keeps the two hops' spans distinguishable.
+witan_telemetry_backend = kubernetes.apiextensions.CustomResource(
+    f"witan-telemetry-backend-{stack_info.env_suffix}",
+    api_version="toolhive.stacklok.dev/v1beta1",
+    kind="MCPTelemetryConfig",
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        name=TOOLHIVE_TELEMETRY_BACKEND_CONFIG_NAME,
+        namespace=NAMESPACE,
+        labels=k8s_global_labels,
+    ),
+    # Never None for this hop: Prometheus is enabled in every environment, so
+    # `toolhive_telemetry_spec` always returns a spec here.
+    spec=toolhive_telemetry_spec(stack_info, "mcp-proxy", expose_prometheus=True),
+    opts=ResourceOptions(depends_on=[cluster_stack]),
+)
+
+# The vMCP's, only where there is an OTLP receiver to export to. With Prometheus
+# off and OTLP unavailable there is nothing left to configure, so CI gets no CR
+# and no `telemetryConfigRef` at all — rather than an inert one that reads like
+# telemetry is on.
+witan_telemetry_vmcp_spec = toolhive_telemetry_spec(
+    stack_info, "vmcp", expose_prometheus=False
+)
+witan_telemetry_vmcp = (
+    kubernetes.apiextensions.CustomResource(
+        f"witan-telemetry-vmcp-{stack_info.env_suffix}",
+        api_version="toolhive.stacklok.dev/v1beta1",
+        kind="MCPTelemetryConfig",
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            name=TOOLHIVE_TELEMETRY_VMCP_CONFIG_NAME,
+            namespace=NAMESPACE,
+            labels=k8s_global_labels,
+        ),
+        spec=witan_telemetry_vmcp_spec,
+        opts=ResourceOptions(depends_on=[cluster_stack]),
+    )
+    if witan_telemetry_vmcp_spec
+    else None
+)
+
+#########################################
 #   MCPGroup + witan MCPServer           #
 #########################################
 mcp_servers = create_mcp_servers(
@@ -793,6 +854,8 @@ mcp_servers = create_mcp_servers(
     witan_code_token_secret=witan_code_token_secret,
     migration_job=witan_migration_job,
     service_version=witan_service_version,
+    telemetry_config_name=TOOLHIVE_TELEMETRY_BACKEND_CONFIG_NAME,
+    telemetry_config=witan_telemetry_backend,
     remote_write_max_inflight=WITAN_REMOTE_WRITE_MAX_INFLIGHT,
     remote_write_queue_seconds=WITAN_REMOTE_WRITE_QUEUE_SECONDS,
     remote_call_budget_seconds=WITAN_REMOTE_CALL_BUDGET_SECONDS,
@@ -920,6 +983,24 @@ witan_virtualmcpserver = kubernetes.apiextensions.CustomResource(
             },
         },
         "serviceType": "ClusterIP",
+        # Spans and OTLP metrics for the OUTERMOST hop — the first thing a
+        # client's request touches, and so the root of the trace. Absent in CI,
+        # which has no receiver: see the CR above.
+        #
+        # Unpacked from a dict rather than written as a literal key because the
+        # ref must not appear at all when there is no CR to point at — an
+        # unresolvable `telemetryConfigRef` degrades the vMCP rather than being
+        # ignored.
+        **(
+            {
+                "telemetryConfigRef": {
+                    "name": TOOLHIVE_TELEMETRY_VMCP_CONFIG_NAME,
+                    "serviceName": toolhive_service_name(stack_info, "vmcp"),
+                }
+            }
+            if witan_telemetry_vmcp
+            else {}
+        ),
         # VirtualMCPServerSpec has no `resources` field of its own (unlike
         # MCPServer), so the aggregator's limits can only be set through the
         # documented PodTemplateSpec escape hatch, targeting the operator-managed
@@ -999,6 +1080,12 @@ witan_virtualmcpserver = kubernetes.apiextensions.CustomResource(
                 # here is a CrashLoop rather than a rejected apply.
                 "conflictResolutionConfig": {"priorityOrder": [WITAN_MCPSERVER_NAME]},
             },
+            # Per-request JSON to stdout -> pod logs -> Loki, so unlike the OTLP
+            # block above this needs no collector and is on in CI too. Unlike
+            # `MCPServer.spec.audit`, this CRD carries the full option set, so
+            # the body-exclusion is stated rather than merely defaulted — see
+            # `toolhive_vmcp_audit`.
+            "audit": toolhive_vmcp_audit(),
         },
     },
     opts=ResourceOptions(
@@ -1016,6 +1103,10 @@ witan_virtualmcpserver = kubernetes.apiextensions.CustomResource(
             witan_ci_token_secret,
             witan_code_token_secret,
             actor_tokens_secret,
+            # Absent in CI, where the vMCP references no telemetry config at
+            # all. Filtered rather than conditionally appended so the list above
+            # stays a plain enumeration.
+            *([witan_telemetry_vmcp] if witan_telemetry_vmcp else []),
         ]
     ),
 )

--- a/src/ol_infrastructure/applications/witan/mcp_servers.py
+++ b/src/ol_infrastructure/applications/witan/mcp_servers.py
@@ -450,10 +450,11 @@ def create_mcp_servers(  # noqa: PLR0913
                 "proxyDeployment": {"env": WITAN_PROXY_HEALTH_ENV},
             },
             # The proxy's own OTel pipeline — spans and metrics for the hop in
-            # FRONT of witan, which was dark until 2026-08-14. Its request
-            # duration starts before it forwards, so subtracting witan's own
-            # `duration_ms` from it yields the pre-handler interval that neither
-            # tier measured. See observability.py's "ToolHive tier" section.
+            # FRONT of witan, which was dark until 2026-08-14. The SPANS are the
+            # point: only nested span timestamps separate the pre-handler
+            # interval from the post-response one per request. The metric delta
+            # against witan's `duration_ms` bounds the two together and only in
+            # aggregate. See observability.py's "ToolHive tier" section.
             #
             # Deliberately NO `k8s.grafana.com/scrape` annotations to go with the
             # Prometheus path this enables: in QA and Production the same metrics

--- a/src/ol_infrastructure/applications/witan/mcp_servers.py
+++ b/src/ol_infrastructure/applications/witan/mcp_servers.py
@@ -46,6 +46,8 @@ from pulumi import Output, Resource, ResourceOptions, StackReference
 from ol_infrastructure.applications.witan.observability import (
     downward_api_env_dicts,
     otel_env,
+    toolhive_mcpserver_audit,
+    toolhive_service_name,
     witan_log_env,
 )
 from ol_infrastructure.lib.pulumi_helper import StackInfo
@@ -222,11 +224,19 @@ def create_mcp_servers(  # noqa: PLR0913
     witan_code_token_secret: Resource,
     migration_job: Resource,
     service_version: str,
+    telemetry_config_name: str,
+    telemetry_config: Resource,
     remote_write_max_inflight: str = "",
     remote_write_queue_seconds: str = "",
     remote_call_budget_seconds: str = "",
 ) -> WitanMCPServers:
     """Provision the witan-tools MCPGroup and the witan MCPServer backend.
+
+    ``telemetry_config_name`` is the ``MCPTelemetryConfig`` this hop references.
+    Unlike the vMCP, this hop has one in EVERY environment: the Prometheus
+    ``/metrics`` path is safe on its ClusterIP-only proxy port, and in CI — which
+    has no OTLP receiver — it is the only instrumentation there is. See
+    ``observability.toolhive_telemetry_spec``.
 
     ``remote_write_max_inflight`` / ``remote_write_queue_seconds`` retune
     witan's client-side write admission. Empty (the default) leaves witan's own
@@ -439,6 +449,27 @@ def create_mcp_servers(  # noqa: PLR0913
             "resourceOverrides": {
                 "proxyDeployment": {"env": WITAN_PROXY_HEALTH_ENV},
             },
+            # The proxy's own OTel pipeline — spans and metrics for the hop in
+            # FRONT of witan, which was dark until 2026-08-14. Its request
+            # duration starts before it forwards, so subtracting witan's own
+            # `duration_ms` from it yields the pre-handler interval that neither
+            # tier measured. See observability.py's "ToolHive tier" section.
+            #
+            # Deliberately NO `k8s.grafana.com/scrape` annotations to go with the
+            # Prometheus path this enables: in QA and Production the same metrics
+            # already arrive over OTLP, and scraping them as well would ingest
+            # every series twice under one name. The path exists for a
+            # port-forward — in CI, where there is no receiver, that is the only
+            # way to read them at all.
+            "telemetryConfigRef": {
+                "name": telemetry_config_name,
+                "serviceName": toolhive_service_name(stack_info, "mcp-proxy"),
+            },
+            # Per-request JSON to stdout, so it rides the existing pod-log path
+            # to Loki with no collector involved — which is why this is on in CI
+            # too. This CRD accepts only `enabled`; see `toolhive_mcpserver_audit`
+            # for why nothing else may be written here.
+            "audit": toolhive_mcpserver_audit(),
             # `volumes`/`volumeMounts` aren't first-class MCPServerSpec fields
             # beyond hostPath, so the actor-tokens Secret is mounted via the
             # documented escape hatch: a PodTemplateSpec merge-patch targeting
@@ -500,6 +531,11 @@ def create_mcp_servers(  # noqa: PLR0913
         # pulumi-kubernetes awaits a Job's completion, so the operator is not
         # handed the new image until the backfills for it have succeeded, and a
         # failed migration blocks the rollout instead of half-applying it.
+        #
+        # `telemetry_config` for the same reason as the secrets: the operator
+        # resolves `telemetryConfigRef` by name at reconcile time, and a
+        # reference to a CR that does not exist yet is a degraded server rather
+        # than a retry.
         opts=ResourceOptions(
             depends_on=[
                 witan_mcpgroup,
@@ -507,6 +543,7 @@ def create_mcp_servers(  # noqa: PLR0913
                 witan_code_token_secret,
                 actor_tokens_secret,
                 migration_job,
+                telemetry_config,
             ]
         ),
     )

--- a/src/ol_infrastructure/applications/witan/observability.py
+++ b/src/ol_infrastructure/applications/witan/observability.py
@@ -27,6 +27,21 @@ CI still gets the structured JSON logs, which are the half that does not depend
 on Alloy at all: they go to stderr and the k8s-monitoring chart ships pod logs
 to Loki. That is why ``witan_log_env`` is unconditional while the OTel block is
 not.
+
+── The ToolHive tier (``toolhive_*`` below) ──
+Everything above configures the *witan process*. The two ToolHive hops in front
+of it — the ``VirtualMCPServer`` aggregator and the ``MCPServer`` proxyrunner —
+are separate Go binaries with their own OTel pipeline, configured through an
+``MCPTelemetryConfig`` CR rather than environment variables. They were dark
+until 2026-08-14 and are why the question "where did the 20s go" had no answer.
+
+That gap is not academic. witan's own ``duration_ms`` starts INSIDE its
+middleware; ToolHive's ``toolhive_mcp_request_duration_seconds`` starts before
+it forwards (``pkg/telemetry/middleware.go``, timer around ``next.ServeHTTP``).
+On 2026-08-14 a concurrency probe run saw the store finish all 8 writes at a
+normal 12.8s median while the client was told 7 of them failed — time spent in
+an interval NEITHER tier measured. The difference between the two durations is
+that interval.
 """
 
 import pulumi_kubernetes as kubernetes
@@ -191,3 +206,157 @@ def downward_api_env_args() -> list[kubernetes.core.v1.EnvVarArgs]:
         )
         for name, field_path in _DOWNWARD_API_FIELDS.items()
     ]
+
+
+#########################################
+#   The ToolHive tier                    #
+#########################################
+# One MCPTelemetryConfig per hop, NOT one shared between them. The two differ in
+# exactly one field — `prometheus.enabled` — and that difference is a security
+# boundary, not a preference. See `expose_prometheus` on
+# `toolhive_telemetry_spec`.
+TOOLHIVE_TELEMETRY_BACKEND_CONFIG_NAME = "witan-telemetry-backend"
+TOOLHIVE_TELEMETRY_VMCP_CONFIG_NAME = "witan-telemetry-vmcp"
+
+
+def toolhive_service_name(stack_info: StackInfo, component: str) -> str:
+    """Per-hop OTel service name, `<env>-witan-<component>`.
+
+    ToolHive's own CRD documentation requires this to be unique per server, and
+    it is the only thing that separates the aggregator's spans from the
+    proxy's. Same `<env>-<service>` convention `otel_env` uses, so all three
+    witan-related services sort together in Grafana.
+    """
+    return f"{stack_info.env_suffix}-witan-{component}"
+
+
+def toolhive_trace_sampling_rate(stack_info: StackInfo) -> str:
+    """Head sampling rate for the ToolHive hops.
+
+    ★ THIS IS THE ROOT SAMPLING DECISION FOR THE WHOLE REQUEST. ToolHive
+    receives the request first, so it starts the trace; witan_core runs
+    `parentbased_traceidratio` (TRACES_SAMPLER above), which honours an
+    incoming decision rather than re-rolling it. So this value — not
+    TRACES_SAMPLER_ARG — sets what fraction of end-to-end traces exist.
+
+    QA samples everything because QA is where the concurrency probe runs and a
+    sampled-away trace is a probe run that measured nothing. It is affordable
+    precisely because QA carries no organic traffic: the probe's own ~50
+    requests per run are essentially the entire span volume.
+
+    Production keeps the 0.25 the other services use. Raising it there would
+    change span cost against real traffic, which is a billing decision and not
+    this module's to make.
+    """
+    return "1.0" if stack_info.env_suffix.lower() == "qa" else TRACES_SAMPLER_ARG
+
+
+def toolhive_telemetry_spec(
+    stack_info: StackInfo,
+    component: str,
+    *,
+    expose_prometheus: bool,
+) -> dict[str, object] | None:
+    """Build an ``MCPTelemetryConfigSpec``, or ``None`` if there is nothing to enable.
+
+    Returns ``None`` rather than an all-disabled spec so CI does not carry a CR
+    that configures nothing — a referenced-but-inert config is the kind of thing
+    that reads as "telemetry is on" to the next person to look.
+
+    :param expose_prometheus: whether to serve the Prometheus ``/metrics`` path.
+
+        ★ FALSE FOR THE vMCP, AND THAT IS LOAD-BEARING. ToolHive serves
+        ``/metrics`` on the *main transport port* — there is no separate admin
+        listener (toolhive `pkg/telemetry/config.go`: "The metrics are served on
+        the main transport port at /metrics"). The vMCP's port 4483 is the one
+        APISIX publishes, and `ingress.py` routes `paths=["/*"]` at it, so
+        enabling the path there would put an unauthenticated
+        ``https://<vmcp-host>/metrics`` on the public internet, listing every
+        tool name and its call counts. The backend proxy's 8080 is ClusterIP
+        only and never routed, so it is safe there.
+
+        Revisit only alongside a path-level deny in the APISIX route — not by
+        flipping this flag.
+
+    The Prometheus path is enabled in EVERY environment including CI, unlike
+    OTLP. It costs one HTTP route on a port already listening and opens no
+    outbound connection, so `ships_telemetry`'s reasoning does not apply to it.
+    It is also the only read available in CI, where the probe currently runs:
+    port-forward, scrape before and after a run, and diff the cumulative
+    histograms. That yields a window bounded on BOTH sides by construction,
+    which `kubectl logs --since` (no `--until`) cannot do — an unbounded window
+    silently folds in everything up to the moment of asking, which produced
+    three wrong conclusions during the 2026-08-14 analysis.
+    """
+    otlp_enabled = ships_telemetry(stack_info)
+    if not (otlp_enabled or expose_prometheus):
+        return None
+
+    spec: dict[str, object] = {"prometheus": {"enabled": expose_prometheus}}
+    if otlp_enabled:
+        spec["openTelemetry"] = {
+            "enabled": True,
+            # Scheme-less by the time ToolHive uses it — `NormalizeTelemetryConfig`
+            # strips http(s):// because the OTLP client wants host:port — but
+            # passed whole so this and OTEL_EXPORTER_OTLP_ENDPOINT above are
+            # visibly the same endpoint. `insecure` is what actually selects
+            # plaintext, and must stay in step with OTLP_ENDPOINT's scheme.
+            "endpoint": OTLP_ENDPOINT,
+            "insecure": True,
+            "metrics": {"enabled": True},
+            "tracing": {
+                "enabled": True,
+                "samplingRate": toolhive_trace_sampling_rate(stack_info),
+            },
+            # service.name is NOT set here — it comes from the per-hop
+            # `telemetryConfigRef.serviceName` override, which is what lets one
+            # spec shape serve two differently-named hops.
+            "resourceAttributes": {
+                "deployment.environment": stack_info.env_suffix,
+                "service.namespace": "witan",
+                "toolhive.component": component,
+            },
+        }
+    return spec
+
+
+def toolhive_mcpserver_audit() -> dict[str, object]:
+    """``MCPServer.spec.audit`` — which accepts ONLY ``enabled``.
+
+    ★ THE TWO CRDs ARE NOT SYMMETRIC HERE. ``MCPServer.spec.audit`` has exactly
+    one property; the full option set (``includeRequestData``, ``eventTypes``,
+    ``logFile``, …) exists only on ``VirtualMCPServer.spec.config.audit``. The
+    MCPServer CRD is a structural schema with no
+    ``x-kubernetes-preserve-unknown-fields``, so any extra key here is PRUNED by
+    the API server. Verified against operations-qa on 2026-08-14: a merge patch
+    carrying ``includeRequestData`` returns ``Warning: unknown field
+    "spec.audit.includeRequestData"`` and stores ``{"enabled": true}``. The
+    apply still succeeds, so an ``includeRequestData: false`` written here for
+    safety would survive review as an assurance while being enforced by nothing.
+
+    So the body-exclusion guarantee on this hop rests on ToolHive's own default
+    (``IncludeRequestData`` defaults false, `pkg/audit/config.go`) rather than
+    on anything declared here. See `toolhive_vmcp_audit` for the hop where it
+    can be, and is, stated explicitly.
+
+    Both hops log one JSON event per request — method, outcome, duration — to
+    stdout, so it rides the existing pod-log path to Loki with no collector
+    involved. That is why audit is on in every environment while OTLP is not.
+    """
+    return {"enabled": True}
+
+
+def toolhive_vmcp_audit() -> dict[str, object]:
+    """``VirtualMCPServer.spec.config.audit`` — the full-schema counterpart.
+
+    ★ `includeRequestData`/`includeResponseData` STAY FALSE. They are already
+    the CRD's defaults; they are restated because witan's request bodies are
+    the memories and tasks themselves, and turning either on would copy
+    user-authored graph content into the log pipeline, where the redaction that
+    governs the write path does not apply.
+    """
+    return {
+        "enabled": True,
+        "includeRequestData": False,
+        "includeResponseData": False,
+    }

--- a/src/ol_infrastructure/applications/witan/observability.py
+++ b/src/ol_infrastructure/applications/witan/observability.py
@@ -36,12 +36,25 @@ are separate Go binaries with their own OTel pipeline, configured through an
 until 2026-08-14 and are why the question "where did the 20s go" had no answer.
 
 That gap is not academic. witan's own ``duration_ms`` starts INSIDE its
-middleware; ToolHive's ``toolhive_mcp_request_duration_seconds`` starts before
-it forwards (``pkg/telemetry/middleware.go``, timer around ``next.ServeHTTP``).
-On 2026-08-14 a concurrency probe run saw the store finish all 8 writes at a
-normal 12.8s median while the client was told 7 of them failed — time spent in
-an interval NEITHER tier measured. The difference between the two durations is
-that interval.
+middleware; ToolHive's ``toolhive_mcp_request_duration_seconds`` wraps
+``next.ServeHTTP`` (``pkg/telemetry/middleware.go``). On 2026-08-14 a
+concurrency probe run saw the store finish all 8 writes at a normal 12.8s
+median while the client was told 7 of them failed — time spent in an interval
+NEITHER tier measured.
+
+★ WHAT THE METRIC DELTA IS, AND IS NOT. ToolHive's timer starts just before it
+forwards and stops after the downstream response returns, so it spans
+``pre-forward + witan + post-response``. Subtracting witan's ``duration_ms``
+therefore yields the TOTAL TIME OUTSIDE witan's middleware — both outer
+intervals summed — not the pre-handler interval on its own. It also cannot be
+done per request: the ToolHive side is a histogram and the witan side is a log
+field, so they pair only in aggregate (percentile against percentile).
+
+The pre-handler interval specifically needs the SPANS, where ToolHive's and
+witan's are nested with real start timestamps and the two boundaries are
+separable per request. That is why tracing is enabled here and not just
+metrics, and why the probe runs in QA — the metric delta alone would say only
+that time went somewhere outside witan, which is already known.
 """
 
 import pulumi_kubernetes as kubernetes
@@ -342,6 +355,39 @@ def toolhive_mcpserver_audit() -> dict[str, object]:
     Both hops log one JSON event per request — method, outcome, duration — to
     stdout, so it rides the existing pod-log path to Loki with no collector
     involved. That is why audit is on in every environment while OTLP is not.
+
+    ── ``jsonrpc_error_message``: checked, and safe ONLY BY VERSION ──
+    ``auditor.go`` writes ``jsonrpc_error_code``/``jsonrpc_error_message`` (256
+    chars) into audit metadata whenever an outcome is ``ApplicationError``,
+    gated ONLY on ``detectApplicationErrors`` (default true) and NOT on
+    ``includeResponseData`` — its own comment says it reports them "without
+    enabling full response data capture". This CRD exposes no switch for it, so
+    if it fired here it could not be turned off.
+
+    It does not fire for anything content-bearing, because it requires a
+    TOP-LEVEL JSON-RPC ``error`` and ``pkg/mcp/response.go`` "intentionally
+    omit[s] `result`". FastMCP 4.0.0b2 routes every tool-level failure into an
+    ``isError`` result inside ``result``. Verified 2026-08-14 against a live
+    streamable-http server: an exception echoing the caller's payload, a
+    pydantic error carrying ``input_value=``, and an unknown tool ALL came back
+    as ``isError`` results; only ``no/such/method`` produced a top-level error,
+    message ``"Method not found"``. The detector also runs only on 2xx, so 401s
+    and 5xx never reach it. What this deployment has actually produced at
+    protocol level is ``-32603`` under load, message "Server returned an error
+    response" — operational, no user content.
+
+    ★ RE-CHECK THIS ON ANY FastMCP OR ToolHive UPGRADE. Nothing tests it, and
+    both halves are load-bearing: if FastMCP started surfacing tool failures as
+    protocol errors, or ToolHive started parsing ``result``, this would begin
+    copying PRE-REDACTION request content — witan redacts inside the tool, after
+    arguments arrive — into Loki, which is readable by anyone with Grafana
+    access rather than being Cedar actor-scoped like the graph.
+    ``mask_error_details`` is FastMCP's second line of defence here and it
+    defaults to False; witan does not set it.
+
+    Kept ON deliberately rather than tolerated: a JSON-RPC error inside an HTTP
+    200 is exactly the ``-32603``-under-load signature this project is chasing,
+    and disabling detection would record those as successes.
     """
     return {"enabled": True}
 
@@ -354,6 +400,11 @@ def toolhive_vmcp_audit() -> dict[str, object]:
     the memories and tasks themselves, and turning either on would copy
     user-authored graph content into the log pipeline, where the redaction that
     governs the write path does not apply.
+
+    ``detectApplicationErrors`` is deliberately left at its default (true) even
+    though this CRD — unlike ``MCPServer.spec.audit`` — could disable it. See
+    `toolhive_mcpserver_audit` for the evidence that it carries no user content
+    at these versions, and for why the signal is wanted.
     """
     return {
         "enabled": True,


### PR DESCRIPTION
## Why

witan's own `duration_ms` starts **inside** its middleware. ToolHive's request duration wraps `next.ServeHTTP`. Neither tier measured what happens outside witan's handler — and that's where a concurrency probe run on 2026-08-14 lost its writes: the store finished all 8 at a normal 12.8s median while the client was told 7 had failed.

The write gate can't help there; those writes executed fine. The first thing needed is a *number* for that interval, and today nothing produces one.

## What

Enables the two ToolHive hops' own OTel pipeline through `MCPTelemetryConfig`, plus per-request audit logging on both hops.

| Signal | CI | QA | Production |
|---|---|---|---|
| Prometheus `/metrics` (backend proxy) | ✅ | ✅ | ✅ |
| Prometheus `/metrics` (vMCP) | ❌ | ❌ | ❌ |
| OTLP traces + metrics | ❌ | ✅ (sample 1.0) | ✅ (sample 0.25) |
| Audit log → stdout → Loki | ✅ | ✅ | ✅ |

**The spans are the point.** ToolHive's timer starts just before it forwards and stops after the response returns, so it spans `pre-forward + witan + post-response`. Subtracting witan's `duration_ms` therefore bounds the two outer intervals *together*, and only in aggregate — a histogram cannot pair per request with a log field. Separating the pre-handler interval specifically needs the nested span timestamps, which is why tracing is enabled and not just metrics, and why the probe runs in QA.

## Two telemetry CRs, not one shared

They differ only on `prometheus.enabled`, and that difference is a security boundary. ToolHive serves `/metrics` on the **main transport port** — there is no separate admin listener. The vMCP's 4483 is the port APISIX publishes, under a `paths=["/*"]` catch-all (`ingress.py`), so enabling it there would put an unauthenticated `https://<vmcp-host>/metrics` on the public internet listing every tool name and its call counts.

The backend proxy's 8080 is ClusterIP-only and never routed — safe there, and it is the only instrumentation CI can read, since CI runs no Alloy by deliberate cost decision. Hence the split: Prometheus everywhere (a path on a port already listening, no egress), OTLP only where `ships_telemetry()` finds a receiver.

## Notes

- **Sampling.** ToolHive is the trace *root*, and witan-core runs `parentbased_traceidratio`, so this value — not `TRACES_SAMPLER_ARG` — sets what fraction of end-to-end traces exist. QA at 1.0 because it's where the probe runs and carries no organic traffic; Production keeps the 0.25 the other services use.
- **No `k8s.grafana.com/scrape` annotations** alongside the Prometheus path: in QA/Production the same metrics already arrive over OTLP, and scraping them too would ingest every series twice under one name. The path exists for a port-forward.
- **Audit bodies stay off.** witan's request bodies are the memories and tasks themselves. On the vMCP that's stated explicitly; on `MCPServer.spec.audit` it *cannot* be — that CRD accepts only `enabled` and prunes anything else (`Warning: unknown field`, apply still succeeds), so a `false` written there would read as an assurance enforced by nothing.
- **`jsonrpc_error_message` was reviewed and kept.** `auditor.go` writes it gated only on `detectApplicationErrors`, not on `includeResponseData`. It does not fire for anything content-bearing: capture requires a top-level JSON-RPC `error`, `pkg/mcp/response.go` intentionally omits `result`, and FastMCP 4.0.0b2 routes every tool-level failure into an `isError` result. Verified against a live server — an exception echoing the caller's payload, a pydantic error carrying `input_value=`, and an unknown tool all stayed in `result`. Kept on deliberately: a JSON-RPC error inside an HTTP 200 is the `-32603`-under-load signature this work is chasing. Both halves are version-pinned and untested, so the docstring says to re-check on upgrade.

## Verification

- `pre-commit` (ruff format/check, mypy, detect-secrets) — all pass
- Rendered specs for all three envs server-side dry-run applied against the live CRDs with `--validate=strict` — 5/5 accepted
- `telemetryConfigRef` + `audit` additions dry-run patched onto the live QA `MCPServer` and `VirtualMCPServer` — both accepted, fields persist the round trip
- CRD pruning and the audit error-message path both verified directly rather than assumed

Not yet deployed. Probe measurement will run against QA, where the signals land in Grafana.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYb9sMjetD9Nxjf24Aw3m5