### PR TITLE
feat(toolhive_swe): instrument the SWE MCP tier, sharing witan's telemetry helpers

### DIFF
--- a/src/ol_infrastructure/applications/toolhive_swe/__main__.py
+++ b/src/ol_infrastructure/applications/toolhive_swe/__main__.py
@@ -104,6 +104,7 @@ from ol_infrastructure.applications.toolhive_swe.ingress import (
 from ol_infrastructure.applications.toolhive_swe.mcp_servers import (
     AWS_MCP_SERVICE_ACCOUNT_NAME,
     MCP_GROUP_NAME,
+    TOOLHIVE_SERVICE,
     create_mcp_servers,
 )
 from ol_infrastructure.applications.toolhive_swe.redis import (
@@ -135,6 +136,12 @@ from ol_infrastructure.lib.pulumi_helper import (
     make_stack_reference,
     parse_stack,
     require_stack_output_value,
+)
+from ol_infrastructure.lib.toolhive_telemetry import (
+    telemetry_config_name,
+    toolhive_service_name,
+    toolhive_telemetry_spec,
+    toolhive_vmcp_audit,
 )
 from ol_infrastructure.lib.vault import setup_vault_provider
 
@@ -508,6 +515,62 @@ redis_resources = create_redis_resources(
 )
 
 #########################################
+#   MCPTelemetryConfig (ToolHive tier)   #
+#########################################
+# Every hop here runs its own OTel pipeline, configured through these CRs. See
+# lib/toolhive_telemetry.py for the shared decisions; this stack only chooses
+# which hop gets which.
+#
+# ★ TWO CRs, NOT ONE SHARED, and the difference is `prometheus.enabled`.
+# ToolHive serves /metrics on the MAIN TRANSPORT PORT, and the vMCP's 4483 is
+# the port APISIX publishes under a `/*` catch-all (ingress.py) — so enabling
+# the path there would put an unauthenticated metrics endpoint on the public
+# internet. The backends' 8080 is ClusterIP-only, so it is safe there.
+#
+# All five backends share the backend CR: they want identical settings and are
+# separated by the per-ref `serviceName` (mcp_servers._observability).
+swe_telemetry_backend = kubernetes.apiextensions.CustomResource(
+    f"toolhive-swe-telemetry-backend-{stack_info.env_suffix}",
+    api_version="toolhive.stacklok.dev/v1beta1",
+    kind="MCPTelemetryConfig",
+    metadata=kubernetes.meta.v1.ObjectMetaArgs(
+        name=telemetry_config_name(TOOLHIVE_SERVICE, "backend"),
+        namespace=TOOLHIVE_NAMESPACE,
+        labels=k8s_global_labels,
+    ),
+    # Never None for this hop: Prometheus is on in every environment, so
+    # `toolhive_telemetry_spec` always returns a spec here.
+    spec=toolhive_telemetry_spec(
+        stack_info, TOOLHIVE_SERVICE, "mcp-proxy", expose_prometheus=True
+    ),
+    opts=ResourceOptions(depends_on=[cluster_stack]),
+)
+
+# The vMCP's, only where there is an OTLP receiver to export to. With Prometheus
+# off and OTLP unavailable there is nothing left to configure, so CI gets no CR
+# and no `telemetryConfigRef` — rather than an inert one that reads as though
+# telemetry were on.
+swe_telemetry_vmcp_spec = toolhive_telemetry_spec(
+    stack_info, TOOLHIVE_SERVICE, "vmcp", expose_prometheus=False
+)
+swe_telemetry_vmcp = (
+    kubernetes.apiextensions.CustomResource(
+        f"toolhive-swe-telemetry-vmcp-{stack_info.env_suffix}",
+        api_version="toolhive.stacklok.dev/v1beta1",
+        kind="MCPTelemetryConfig",
+        metadata=kubernetes.meta.v1.ObjectMetaArgs(
+            name=telemetry_config_name(TOOLHIVE_SERVICE, "vmcp"),
+            namespace=TOOLHIVE_NAMESPACE,
+            labels=k8s_global_labels,
+        ),
+        spec=swe_telemetry_vmcp_spec,
+        opts=ResourceOptions(depends_on=[cluster_stack]),
+    )
+    if swe_telemetry_vmcp_spec
+    else None
+)
+
+#########################################
 #   MCPGroup + backend MCPServers        #
 #########################################
 # The ``swe-tools`` MCPGroup and every backend MCPServer that joins it, defined
@@ -521,6 +584,7 @@ mcp_servers = create_mcp_servers(
     # A list, not a single handle: it is empty in stacks where the backend is
     # disabled, which is exactly the stacks that build no MCPServer to depend on.
     aws_mcp_service_accounts=toolhive_swe_auth_binding.irsa_service_accounts,
+    telemetry_config=swe_telemetry_backend,
 )
 
 #########################################
@@ -631,11 +695,33 @@ swe_virtualmcpserver = kubernetes.apiextensions.CustomResource(
             },
         },
         "serviceType": "ClusterIP",
+        # Spans and OTLP metrics for the OUTERMOST hop — the first thing a
+        # client's request touches, and so the root of the trace. Unpacked from
+        # a dict rather than written as a literal key because the ref must not
+        # appear at all when there is no CR to point at: an unresolvable
+        # `telemetryConfigRef` degrades the vMCP rather than being ignored.
+        **(
+            {
+                "telemetryConfigRef": {
+                    "name": telemetry_config_name(TOOLHIVE_SERVICE, "vmcp"),
+                    "serviceName": toolhive_service_name(
+                        stack_info, TOOLHIVE_SERVICE, "vmcp"
+                    ),
+                }
+            }
+            if swe_telemetry_vmcp
+            else {}
+        ),
         "config": {
             "aggregation": {
                 "conflictResolution": "prefix",
                 "conflictResolutionConfig": {"prefixFormat": "{workload}_"},
             },
+            # Per-request JSON to stdout -> pod logs -> Loki, so unlike the OTLP
+            # block above this needs no collector and is on in CI too. This CRD
+            # carries the full option set, so the body exclusion is stated
+            # rather than merely defaulted — see `toolhive_vmcp_audit`.
+            "audit": toolhive_vmcp_audit(),
         },
     },
     opts=ResourceOptions(
@@ -649,6 +735,8 @@ swe_virtualmcpserver = kubernetes.apiextensions.CustomResource(
             redis_resources.password_secret,
             redis_resources.service,
             redis_resources.statefulset,
+            # Absent in CI, where the vMCP references no telemetry config.
+            *([swe_telemetry_vmcp] if swe_telemetry_vmcp else []),
         ]
     ),
 )

--- a/src/ol_infrastructure/applications/toolhive_swe/mcp_servers.py
+++ b/src/ol_infrastructure/applications/toolhive_swe/mcp_servers.py
@@ -14,7 +14,7 @@ by :func:`create_mcp_servers` so the vMCP's ``depends_on`` wiring picks it up.
 from typing import NamedTuple
 
 import pulumi_kubernetes as kubernetes
-from pulumi import Config, ResourceOptions, StackReference
+from pulumi import Config, Resource, ResourceOptions, StackReference
 
 from bridge.lib.versions import (
     MCP_CONTEXT7_VERSION,
@@ -23,9 +23,42 @@ from bridge.lib.versions import (
     MCP_SENTRY_VERSION,
 )
 from ol_infrastructure.lib.pulumi_helper import StackInfo
+from ol_infrastructure.lib.toolhive_telemetry import (
+    telemetry_config_name,
+    toolhive_mcpserver_audit,
+    toolhive_service_name,
+)
 
 # Name shared by the MCPGroup and every backend/virtual server that references it.
 MCP_GROUP_NAME = "swe-tools"
+
+# Prefix for this stack's ToolHive telemetry CR names and OTel service names.
+# Equal to the namespace today; kept as its own name because one is a Kubernetes
+# object and the other is a Grafana-facing identity, and renaming either should
+# not silently rename the other.
+TOOLHIVE_SERVICE = "toolhive-swe"
+
+
+def _observability(stack_info: StackInfo, backend: str) -> dict[str, object]:
+    """Telemetry + audit fields every backend ``MCPServer`` here carries.
+
+    All the backends share ONE ``MCPTelemetryConfig`` — they need identical
+    settings — and are told apart by the per-ref ``serviceName``, which
+    overrides the config's own. Without that they would all report as one
+    service and the spans would be unattributable.
+
+    ``__main__`` creates the CR this names and puts it in each server's
+    ``depends_on``; the operator resolves the ref at reconcile time, so a
+    dangling name is a degraded server rather than a retry.
+    """
+    return {
+        "telemetryConfigRef": {
+            "name": telemetry_config_name(TOOLHIVE_SERVICE, "backend"),
+            "serviceName": toolhive_service_name(stack_info, TOOLHIVE_SERVICE, backend),
+        },
+        "audit": toolhive_mcpserver_audit(),
+    }
+
 
 # ServiceAccount the aws backend runs under. The OLEKSAuthBinding in __main__.py
 # creates it annotated with the IRSA role ARN; the EKS pod-identity webhook turns
@@ -70,8 +103,16 @@ def create_mcp_servers(  # noqa: PLR0913
     cluster_stack: StackReference,
     toolhive_swe_config: Config,
     aws_mcp_service_accounts: list[kubernetes.core.v1.ServiceAccount],
+    telemetry_config: Resource,
 ) -> ToolhiveSWEMCPServers:
-    """Provision the MCPGroup and every backend MCPServer that joins it."""
+    """Provision the MCPGroup and every backend MCPServer that joins it.
+
+    ``telemetry_config`` is the shared backend ``MCPTelemetryConfig`` every
+    server here references. It is passed as a handle purely for ``depends_on``:
+    the operator resolves ``telemetryConfigRef`` by name at reconcile time, and
+    a reference to a CR that does not exist yet is a degraded server rather
+    than a retry. The name itself comes from ``_observability``.
+    """
     swe_mcpgroup = kubernetes.apiextensions.CustomResource(
         f"toolhive-swe-mcpgroup-{stack_info.env_suffix}",
         api_version="toolhive.stacklok.dev/v1beta1",
@@ -106,6 +147,7 @@ def create_mcp_servers(  # noqa: PLR0913
             "proxyPort": 8080,
             "mcpPort": 8080,
             "groupRef": {"name": MCP_GROUP_NAME},
+            **_observability(stack_info, "fetch"),
             # Fetch needs outbound network access to retrieve URLs. The "network"
             # builtin profile grants egress; tighten to an allow-list ConfigMap when
             # the set of reachable hosts is known.
@@ -118,7 +160,7 @@ def create_mcp_servers(  # noqa: PLR0913
                 "limits": {"cpu": "100m", "memory": "128Mi"},
             },
         },
-        opts=ResourceOptions(depends_on=[swe_mcpgroup]),
+        opts=ResourceOptions(depends_on=[swe_mcpgroup, telemetry_config]),
     )
 
     # Grafana OSS MCP server pointed at Grafana Cloud with a service account token
@@ -188,6 +230,7 @@ def create_mcp_servers(  # noqa: PLR0913
             "proxyPort": 8080,
             "mcpPort": 8000,
             "groupRef": {"name": MCP_GROUP_NAME},
+            **_observability(stack_info, "grafana"),
             "env": [{"name": "GRAFANA_URL", "value": grafana_url}],
             "secrets": [
                 {
@@ -208,7 +251,9 @@ def create_mcp_servers(  # noqa: PLR0913
                 "limits": {"cpu": "200m", "memory": "256Mi"},
             },
         },
-        opts=ResourceOptions(depends_on=[swe_mcpgroup, grafana_token_secret]),
+        opts=ResourceOptions(
+            depends_on=[swe_mcpgroup, grafana_token_secret, telemetry_config]
+        ),
     )
 
     servers = [fetch_mcpserver, grafana_mcpserver]
@@ -260,6 +305,7 @@ def create_mcp_servers(  # noqa: PLR0913
                 "transport": "stdio",
                 "proxyPort": 8080,
                 "groupRef": {"name": MCP_GROUP_NAME},
+                **_observability(stack_info, "context7"),
                 "secrets": [
                     {
                         "name": CONTEXT7_TOKEN_SECRET_NAME,
@@ -279,7 +325,13 @@ def create_mcp_servers(  # noqa: PLR0913
                     "limits": {"cpu": "200m", "memory": "256Mi"},
                 },
             },
-            opts=ResourceOptions(depends_on=[swe_mcpgroup, context7_token_secret]),
+            opts=ResourceOptions(
+                depends_on=[
+                    swe_mcpgroup,
+                    context7_token_secret,
+                    telemetry_config,
+                ]
+            ),
         )
         servers.append(context7_mcpserver)
 
@@ -338,6 +390,7 @@ def create_mcp_servers(  # noqa: PLR0913
                 "transport": "stdio",
                 "proxyPort": 8080,
                 "groupRef": {"name": MCP_GROUP_NAME},
+                **_observability(stack_info, "sentry"),
                 "env": sentry_env,
                 "secrets": [
                     {
@@ -358,7 +411,13 @@ def create_mcp_servers(  # noqa: PLR0913
                     "limits": {"cpu": "200m", "memory": "256Mi"},
                 },
             },
-            opts=ResourceOptions(depends_on=[swe_mcpgroup, sentry_token_secret]),
+            opts=ResourceOptions(
+                depends_on=[
+                    swe_mcpgroup,
+                    sentry_token_secret,
+                    telemetry_config,
+                ]
+            ),
         )
         servers.append(sentry_mcpserver)
 
@@ -419,6 +478,7 @@ def create_mcp_servers(  # noqa: PLR0913
                 "transport": "stdio",
                 "proxyPort": 8080,
                 "groupRef": {"name": MCP_GROUP_NAME},
+                **_observability(stack_info, "aws"),
                 # Appended to the image's `mcp-proxy-for-aws` ENTRYPOINT. The
                 # endpoint URL is POSITIONAL and must come first.
                 #
@@ -457,7 +517,13 @@ def create_mcp_servers(  # noqa: PLR0913
             # not schedule a pod naming an absent ServiceAccount, into one that
             # never starts at all. __main__.py creates it under the same gate as
             # this block, so the list below is populated exactly when we get here.
-            opts=ResourceOptions(depends_on=[swe_mcpgroup, *aws_mcp_service_accounts]),
+            opts=ResourceOptions(
+                depends_on=[
+                    swe_mcpgroup,
+                    *aws_mcp_service_accounts,
+                    telemetry_config,
+                ]
+            ),
         )
         servers.append(aws_mcpserver)
 

--- a/src/ol_infrastructure/applications/witan/__main__.py
+++ b/src/ol_infrastructure/applications/witan/__main__.py
@@ -149,17 +149,11 @@ from ol_infrastructure.applications.witan.ci_indexer import (
 from ol_infrastructure.applications.witan.ingress import create_ingress_resources
 from ol_infrastructure.applications.witan.mcp_servers import (
     MCP_GROUP_NAME,
+    TOOLHIVE_SERVICE,
     WITAN_MCPSERVER_NAME,
     create_mcp_servers,
 )
 from ol_infrastructure.applications.witan.migrations import create_migration_job
-from ol_infrastructure.applications.witan.observability import (
-    TOOLHIVE_TELEMETRY_BACKEND_CONFIG_NAME,
-    TOOLHIVE_TELEMETRY_VMCP_CONFIG_NAME,
-    toolhive_service_name,
-    toolhive_telemetry_spec,
-    toolhive_vmcp_audit,
-)
 from ol_infrastructure.components.applications.eks import (
     OLEKSAuthBinding,
     OLEKSAuthBindingConfig,
@@ -187,6 +181,12 @@ from ol_infrastructure.lib.pulumi_helper import (
     optional_stack_output_value,
     parse_stack,
     require_stack_output_value,
+)
+from ol_infrastructure.lib.toolhive_telemetry import (
+    telemetry_config_name,
+    toolhive_service_name,
+    toolhive_telemetry_spec,
+    toolhive_vmcp_audit,
 )
 from ol_infrastructure.lib.vault import setup_vault_provider
 
@@ -797,13 +797,15 @@ witan_telemetry_backend = kubernetes.apiextensions.CustomResource(
     api_version="toolhive.stacklok.dev/v1beta1",
     kind="MCPTelemetryConfig",
     metadata=kubernetes.meta.v1.ObjectMetaArgs(
-        name=TOOLHIVE_TELEMETRY_BACKEND_CONFIG_NAME,
+        name=telemetry_config_name(TOOLHIVE_SERVICE, "backend"),
         namespace=NAMESPACE,
         labels=k8s_global_labels,
     ),
     # Never None for this hop: Prometheus is enabled in every environment, so
     # `toolhive_telemetry_spec` always returns a spec here.
-    spec=toolhive_telemetry_spec(stack_info, "mcp-proxy", expose_prometheus=True),
+    spec=toolhive_telemetry_spec(
+        stack_info, TOOLHIVE_SERVICE, "mcp-proxy", expose_prometheus=True
+    ),
     opts=ResourceOptions(depends_on=[cluster_stack]),
 )
 
@@ -812,7 +814,7 @@ witan_telemetry_backend = kubernetes.apiextensions.CustomResource(
 # and no `telemetryConfigRef` at all — rather than an inert one that reads like
 # telemetry is on.
 witan_telemetry_vmcp_spec = toolhive_telemetry_spec(
-    stack_info, "vmcp", expose_prometheus=False
+    stack_info, TOOLHIVE_SERVICE, "vmcp", expose_prometheus=False
 )
 witan_telemetry_vmcp = (
     kubernetes.apiextensions.CustomResource(
@@ -820,7 +822,7 @@ witan_telemetry_vmcp = (
         api_version="toolhive.stacklok.dev/v1beta1",
         kind="MCPTelemetryConfig",
         metadata=kubernetes.meta.v1.ObjectMetaArgs(
-            name=TOOLHIVE_TELEMETRY_VMCP_CONFIG_NAME,
+            name=telemetry_config_name(TOOLHIVE_SERVICE, "vmcp"),
             namespace=NAMESPACE,
             labels=k8s_global_labels,
         ),
@@ -854,7 +856,7 @@ mcp_servers = create_mcp_servers(
     witan_code_token_secret=witan_code_token_secret,
     migration_job=witan_migration_job,
     service_version=witan_service_version,
-    telemetry_config_name=TOOLHIVE_TELEMETRY_BACKEND_CONFIG_NAME,
+    telemetry_config_name=telemetry_config_name(TOOLHIVE_SERVICE, "backend"),
     telemetry_config=witan_telemetry_backend,
     remote_write_max_inflight=WITAN_REMOTE_WRITE_MAX_INFLIGHT,
     remote_write_queue_seconds=WITAN_REMOTE_WRITE_QUEUE_SECONDS,
@@ -994,8 +996,10 @@ witan_virtualmcpserver = kubernetes.apiextensions.CustomResource(
         **(
             {
                 "telemetryConfigRef": {
-                    "name": TOOLHIVE_TELEMETRY_VMCP_CONFIG_NAME,
-                    "serviceName": toolhive_service_name(stack_info, "vmcp"),
+                    "name": telemetry_config_name(TOOLHIVE_SERVICE, "vmcp"),
+                    "serviceName": toolhive_service_name(
+                        stack_info, TOOLHIVE_SERVICE, "vmcp"
+                    ),
                 }
             }
             if witan_telemetry_vmcp

--- a/src/ol_infrastructure/applications/witan/mcp_servers.py
+++ b/src/ol_infrastructure/applications/witan/mcp_servers.py
@@ -46,14 +46,22 @@ from pulumi import Output, Resource, ResourceOptions, StackReference
 from ol_infrastructure.applications.witan.observability import (
     downward_api_env_dicts,
     otel_env,
-    toolhive_mcpserver_audit,
-    toolhive_service_name,
     witan_log_env,
 )
 from ol_infrastructure.lib.pulumi_helper import StackInfo
+from ol_infrastructure.lib.toolhive_telemetry import (
+    toolhive_mcpserver_audit,
+    toolhive_service_name,
+)
 
 # Name shared by the MCPGroup and the VirtualMCPServer that references it.
 MCP_GROUP_NAME = "witan-tools"
+
+# Prefix for this stack's ToolHive telemetry CR names and OTel service names.
+# Equal to the namespace today; kept as its own name because one is a
+# Kubernetes object and the other is a Grafana-facing identity, and renaming
+# either should not silently rename the other.
+TOOLHIVE_SERVICE = "witan"
 
 # The MCPServer resource name. ToolHive derives a workload's backend id from the
 # resource name, so this is also the key the vMCP's `outgoingAuth.backends`
@@ -236,7 +244,7 @@ def create_mcp_servers(  # noqa: PLR0913
     Unlike the vMCP, this hop has one in EVERY environment: the Prometheus
     ``/metrics`` path is safe on its ClusterIP-only proxy port, and in CI — which
     has no OTLP receiver — it is the only instrumentation there is. See
-    ``observability.toolhive_telemetry_spec``.
+    ``lib.toolhive_telemetry.toolhive_telemetry_spec``.
 
     ``remote_write_max_inflight`` / ``remote_write_queue_seconds`` retune
     witan's client-side write admission. Empty (the default) leaves witan's own
@@ -464,7 +472,9 @@ def create_mcp_servers(  # noqa: PLR0913
             # way to read them at all.
             "telemetryConfigRef": {
                 "name": telemetry_config_name,
-                "serviceName": toolhive_service_name(stack_info, "mcp-proxy"),
+                "serviceName": toolhive_service_name(
+                    stack_info, TOOLHIVE_SERVICE, "mcp-proxy"
+                ),
             },
             # Per-request JSON to stdout, so it rides the existing pod-log path
             # to Loki with no collector involved — which is why this is on in CI

--- a/src/ol_infrastructure/applications/witan/observability.py
+++ b/src/ol_infrastructure/applications/witan/observability.py
@@ -60,19 +60,22 @@ that time went somewhere outside witan, which is already known.
 import pulumi_kubernetes as kubernetes
 
 from ol_infrastructure.lib.pulumi_helper import StackInfo
-
-# The in-cluster OTLP/HTTP receiver, shared with mit_learn, learn_ai and edxapp
-# (see their Pulumi.{QA,Production}.yaml and edxapp/k8s_configmaps.py). Port
-# 4318 is http/protobuf; 4317 on the same Service is gRPC, which we do not use.
-OTLP_ENDPOINT = (
-    "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318"
+from ol_infrastructure.lib.toolhive_telemetry import (
+    DEFAULT_TRACE_SAMPLING_RATE,
+    OTLP_ENDPOINT,
+    ships_telemetry,
 )
 
 # Sampling and propagation, matched to the mit_learn/learn_ai precedent rather
 # than chosen fresh, so a trace that crosses from one of those services into
 # witan is sampled consistently instead of being decided twice.
+#
+# TRACES_SAMPLER_ARG is the SHARED default rather than a second literal: witan
+# runs `parentbased_traceidratio`, so it honours whatever ToolHive decided at
+# the root, and the two drifting apart would mean the ratio witan declares is
+# not the ratio it gets. See `toolhive_trace_sampling_rate`.
 TRACES_SAMPLER = "parentbased_traceidratio"
-TRACES_SAMPLER_ARG = "0.25"
+TRACES_SAMPLER_ARG = DEFAULT_TRACE_SAMPLING_RATE
 PROPAGATORS = "tracecontext,baggage"
 METRIC_EXPORT_INTERVAL_MS = "60000"
 
@@ -87,24 +90,6 @@ _DOWNWARD_API_FIELDS = {
     "KUBERNETES_NAMESPACE": "metadata.namespace",
     "KUBERNETES_NODE_NAME": "spec.nodeName",
 }
-
-
-def ships_telemetry(stack_info: StackInfo) -> bool:
-    """Whether this environment has an OTLP receiver to export to.
-
-    Mirrors ``setup_grafana``'s CI early-return. Kept as a named predicate so
-    the reason a stack is dark is one grep away from the reason the collector
-    is absent.
-
-    The ``.lower()`` is redundant and deliberate: ``parse_stack`` builds
-    ``env_suffix`` as ``stack_name.lower()`` (lib/pulumi_helper.py), so it is
-    lowercase by construction and the telemetry labels below can use it raw
-    without risk of a ``QA``/``qa`` split. It is kept here only so this
-    predicate is character-for-character the condition ``setup_grafana``
-    tests — the two drifting apart is the failure this function exists to
-    prevent.
-    """
-    return stack_info.env_suffix.lower() != "ci"
 
 
 def witan_log_env() -> dict[str, str]:
@@ -219,195 +204,3 @@ def downward_api_env_args() -> list[kubernetes.core.v1.EnvVarArgs]:
         )
         for name, field_path in _DOWNWARD_API_FIELDS.items()
     ]
-
-
-#########################################
-#   The ToolHive tier                    #
-#########################################
-# One MCPTelemetryConfig per hop, NOT one shared between them. The two differ in
-# exactly one field — `prometheus.enabled` — and that difference is a security
-# boundary, not a preference. See `expose_prometheus` on
-# `toolhive_telemetry_spec`.
-TOOLHIVE_TELEMETRY_BACKEND_CONFIG_NAME = "witan-telemetry-backend"
-TOOLHIVE_TELEMETRY_VMCP_CONFIG_NAME = "witan-telemetry-vmcp"
-
-
-def toolhive_service_name(stack_info: StackInfo, component: str) -> str:
-    """Per-hop OTel service name, `<env>-witan-<component>`.
-
-    ToolHive's own CRD documentation requires this to be unique per server, and
-    it is the only thing that separates the aggregator's spans from the
-    proxy's. Same `<env>-<service>` convention `otel_env` uses, so all three
-    witan-related services sort together in Grafana.
-    """
-    return f"{stack_info.env_suffix}-witan-{component}"
-
-
-def toolhive_trace_sampling_rate(stack_info: StackInfo) -> str:
-    """Head sampling rate for the ToolHive hops.
-
-    ★ THIS IS THE ROOT SAMPLING DECISION FOR THE WHOLE REQUEST. ToolHive
-    receives the request first, so it starts the trace; witan_core runs
-    `parentbased_traceidratio` (TRACES_SAMPLER above), which honours an
-    incoming decision rather than re-rolling it. So this value — not
-    TRACES_SAMPLER_ARG — sets what fraction of end-to-end traces exist.
-
-    QA samples everything because QA is where the concurrency probe runs and a
-    sampled-away trace is a probe run that measured nothing. It is affordable
-    precisely because QA carries no organic traffic: the probe's own ~50
-    requests per run are essentially the entire span volume.
-
-    Production keeps the 0.25 the other services use. Raising it there would
-    change span cost against real traffic, which is a billing decision and not
-    this module's to make.
-    """
-    return "1.0" if stack_info.env_suffix.lower() == "qa" else TRACES_SAMPLER_ARG
-
-
-def toolhive_telemetry_spec(
-    stack_info: StackInfo,
-    component: str,
-    *,
-    expose_prometheus: bool,
-) -> dict[str, object] | None:
-    """Build an ``MCPTelemetryConfigSpec``, or ``None`` if there is nothing to enable.
-
-    Returns ``None`` rather than an all-disabled spec so CI does not carry a CR
-    that configures nothing — a referenced-but-inert config is the kind of thing
-    that reads as "telemetry is on" to the next person to look.
-
-    :param expose_prometheus: whether to serve the Prometheus ``/metrics`` path.
-
-        ★ FALSE FOR THE vMCP, AND THAT IS LOAD-BEARING. ToolHive serves
-        ``/metrics`` on the *main transport port* — there is no separate admin
-        listener (toolhive `pkg/telemetry/config.go`: "The metrics are served on
-        the main transport port at /metrics"). The vMCP's port 4483 is the one
-        APISIX publishes, and `ingress.py` routes `paths=["/*"]` at it, so
-        enabling the path there would put an unauthenticated
-        ``https://<vmcp-host>/metrics`` on the public internet, listing every
-        tool name and its call counts. The backend proxy's 8080 is ClusterIP
-        only and never routed, so it is safe there.
-
-        Revisit only alongside a path-level deny in the APISIX route — not by
-        flipping this flag.
-
-    The Prometheus path is enabled in EVERY environment including CI, unlike
-    OTLP. It costs one HTTP route on a port already listening and opens no
-    outbound connection, so `ships_telemetry`'s reasoning does not apply to it.
-    It is also the only read available in CI, where the probe currently runs:
-    port-forward, scrape before and after a run, and diff the cumulative
-    histograms. That yields a window bounded on BOTH sides by construction,
-    which `kubectl logs --since` (no `--until`) cannot do — an unbounded window
-    silently folds in everything up to the moment of asking, which produced
-    three wrong conclusions during the 2026-08-14 analysis.
-    """
-    otlp_enabled = ships_telemetry(stack_info)
-    if not (otlp_enabled or expose_prometheus):
-        return None
-
-    spec: dict[str, object] = {"prometheus": {"enabled": expose_prometheus}}
-    if otlp_enabled:
-        spec["openTelemetry"] = {
-            "enabled": True,
-            # Scheme-less by the time ToolHive uses it — `NormalizeTelemetryConfig`
-            # strips http(s):// because the OTLP client wants host:port — but
-            # passed whole so this and OTEL_EXPORTER_OTLP_ENDPOINT above are
-            # visibly the same endpoint. `insecure` is what actually selects
-            # plaintext, and must stay in step with OTLP_ENDPOINT's scheme.
-            "endpoint": OTLP_ENDPOINT,
-            "insecure": True,
-            "metrics": {"enabled": True},
-            "tracing": {
-                "enabled": True,
-                "samplingRate": toolhive_trace_sampling_rate(stack_info),
-            },
-            # service.name is NOT set here — it comes from the per-hop
-            # `telemetryConfigRef.serviceName` override, which is what lets one
-            # spec shape serve two differently-named hops.
-            "resourceAttributes": {
-                "deployment.environment": stack_info.env_suffix,
-                "service.namespace": "witan",
-                "toolhive.component": component,
-            },
-        }
-    return spec
-
-
-def toolhive_mcpserver_audit() -> dict[str, object]:
-    """``MCPServer.spec.audit`` — which accepts ONLY ``enabled``.
-
-    ★ THE TWO CRDs ARE NOT SYMMETRIC HERE. ``MCPServer.spec.audit`` has exactly
-    one property; the full option set (``includeRequestData``, ``eventTypes``,
-    ``logFile``, …) exists only on ``VirtualMCPServer.spec.config.audit``. The
-    MCPServer CRD is a structural schema with no
-    ``x-kubernetes-preserve-unknown-fields``, so any extra key here is PRUNED by
-    the API server. Verified against operations-qa on 2026-08-14: a merge patch
-    carrying ``includeRequestData`` returns ``Warning: unknown field
-    "spec.audit.includeRequestData"`` and stores ``{"enabled": true}``. The
-    apply still succeeds, so an ``includeRequestData: false`` written here for
-    safety would survive review as an assurance while being enforced by nothing.
-
-    So the body-exclusion guarantee on this hop rests on ToolHive's own default
-    (``IncludeRequestData`` defaults false, `pkg/audit/config.go`) rather than
-    on anything declared here. See `toolhive_vmcp_audit` for the hop where it
-    can be, and is, stated explicitly.
-
-    Both hops log one JSON event per request — method, outcome, duration — to
-    stdout, so it rides the existing pod-log path to Loki with no collector
-    involved. That is why audit is on in every environment while OTLP is not.
-
-    ── ``jsonrpc_error_message``: checked, and safe ONLY BY VERSION ──
-    ``auditor.go`` writes ``jsonrpc_error_code``/``jsonrpc_error_message`` (256
-    chars) into audit metadata whenever an outcome is ``ApplicationError``,
-    gated ONLY on ``detectApplicationErrors`` (default true) and NOT on
-    ``includeResponseData`` — its own comment says it reports them "without
-    enabling full response data capture". This CRD exposes no switch for it, so
-    if it fired here it could not be turned off.
-
-    It does not fire for anything content-bearing, because it requires a
-    TOP-LEVEL JSON-RPC ``error`` and ``pkg/mcp/response.go`` "intentionally
-    omit[s] `result`". FastMCP 4.0.0b2 routes every tool-level failure into an
-    ``isError`` result inside ``result``. Verified 2026-08-14 against a live
-    streamable-http server: an exception echoing the caller's payload, a
-    pydantic error carrying ``input_value=``, and an unknown tool ALL came back
-    as ``isError`` results; only ``no/such/method`` produced a top-level error,
-    message ``"Method not found"``. The detector also runs only on 2xx, so 401s
-    and 5xx never reach it. What this deployment has actually produced at
-    protocol level is ``-32603`` under load, message "Server returned an error
-    response" — operational, no user content.
-
-    ★ RE-CHECK THIS ON ANY FastMCP OR ToolHive UPGRADE. Nothing tests it, and
-    both halves are load-bearing: if FastMCP started surfacing tool failures as
-    protocol errors, or ToolHive started parsing ``result``, this would begin
-    copying PRE-REDACTION request content — witan redacts inside the tool, after
-    arguments arrive — into Loki, which is readable by anyone with Grafana
-    access rather than being Cedar actor-scoped like the graph.
-    ``mask_error_details`` is FastMCP's second line of defence here and it
-    defaults to False; witan does not set it.
-
-    Kept ON deliberately rather than tolerated: a JSON-RPC error inside an HTTP
-    200 is exactly the ``-32603``-under-load signature this project is chasing,
-    and disabling detection would record those as successes.
-    """
-    return {"enabled": True}
-
-
-def toolhive_vmcp_audit() -> dict[str, object]:
-    """``VirtualMCPServer.spec.config.audit`` — the full-schema counterpart.
-
-    ★ `includeRequestData`/`includeResponseData` STAY FALSE. They are already
-    the CRD's defaults; they are restated because witan's request bodies are
-    the memories and tasks themselves, and turning either on would copy
-    user-authored graph content into the log pipeline, where the redaction that
-    governs the write path does not apply.
-
-    ``detectApplicationErrors`` is deliberately left at its default (true) even
-    though this CRD — unlike ``MCPServer.spec.audit`` — could disable it. See
-    `toolhive_mcpserver_audit` for the evidence that it carries no user content
-    at these versions, and for why the signal is wanted.
-    """
-    return {
-        "enabled": True,
-        "includeRequestData": False,
-        "includeResponseData": False,
-    }

--- a/src/ol_infrastructure/lib/toolhive_telemetry.py
+++ b/src/ol_infrastructure/lib/toolhive_telemetry.py
@@ -220,8 +220,8 @@ def toolhive_mcpserver_audit() -> dict[str, object]:
 
     Capture requires a TOP-LEVEL JSON-RPC ``error``; ``pkg/mcp/response.go``
     "intentionally omit[s] `result`". Whether a tool failure lands in one or the
-    other is decided by the backend's MCP SDK, and THE THREE WE RUN DISAGREE
-    (all verified 2026-08-14):
+    other is decided by the BACKEND'S MCP SDK, not by ToolHive — so it has to be
+    established per backend, not once. All six we run, verified 2026-08-14:
 
     * **FastMCP 4.0.0b2** (witan) — every tool-level failure becomes an
       ``isError`` result. Confirmed against a live server: an exception echoing
@@ -229,19 +229,39 @@ def toolhive_mcpserver_audit() -> dict[str, object]:
       unknown tool ALL stayed in ``result``; only ``no/such/method`` produced a
       top-level error, message ``"Method not found"``. Nothing content-bearing
       is captured.
-    * **modelcontextprotocol/go-sdk** (fetch) — same outcome by a different
+    * **FastMCP** (toolhive_swe ``aws``) — mcp-proxy-for-aws 1.6.4 is FastMCP
+      too, and its ``ToolErrorMiddleware.on_call_tool`` catches EVERY exception
+      and re-raises ``ToolError``, which is the same path. This matters more
+      than the others because the managed AWS endpoint behind it exposes a
+      ``run_script`` tool, so its requests carry user-authored scripts.
+    * **modelcontextprotocol/go-sdk** (``fetch``) — same outcome by a different
       route: ``mcp/server.go`` returns a structured ``*jsonrpc.Error`` directly
       but wraps a *plain* error in ``CallToolResult{IsError: true}``, and
       gofetch returns ``fmt.Errorf``. So its URL-bearing messages
       ("access to %s is disallowed by robots.txt") are NOT captured.
-    * **mark3labs/mcp-go v0.55.0** (grafana) — DIFFERENT. A non-nil handler
-      error becomes ``requestError{code: INTERNAL_ERROR}``, i.e. a top-level
-      JSON-RPC error, so its messages ARE captured. Reviewed: mcp-grafana
-      v1.0.0 interpolates queries, resource ids and upstream API status into
-      those, but no credential — the service-account token travels as a header
-      and appears in no error format string.
+    * **@modelcontextprotocol/sdk** (``sentry``) — sentry-mcp returns
+      ``{content, isError: true}`` from a handler-level catch, carrying a
+      deliberate comment: "DO NOT change this to throw error - it breaks error
+      handling!". Not captured.
+    * **@modelcontextprotocol/sdk** (``context7``) — tool handlers return
+      content results rather than throwing. Its one JSON-RPC error is a
+      transport-level ``-32603`` emitted with **HTTP 500**, and the detector
+      runs only on 2xx, so it is unreachable twice over; the message is the
+      fixed string "Internal server error" regardless.
+    * **mark3labs/mcp-go v0.55.0** (``grafana``) — ★ THE ONE THAT DIFFERS. A
+      non-nil handler error becomes ``requestError{code: INTERNAL_ERROR}``,
+      i.e. a top-level JSON-RPC error, so its messages ARE captured. Reviewed:
+      mcp-grafana v1.0.0 interpolates queries, resource ids and upstream API
+      status into those, but no credential — the service-account token travels
+      as a header and appears in no error format string. Judged acceptable:
+      operational text, 256-char cap, and it lands in the same Grafana Cloud
+      the queries already target.
 
     The detector also runs only on 2xx, so 401s and 5xx never reach it.
+
+    ★ A NEW BACKEND IS NOT COVERED BY THIS ANALYSIS. Adding one means checking
+    its SDK's handler-error path before enabling audit on it — or leaving
+    ``audit`` off for that backend until someone has.
 
     ★ RE-CHECK ON ANY SDK OR ToolHive UPGRADE. Nothing tests this, and it is
     the only thing standing between an audit log and payload-derived content.

--- a/src/ol_infrastructure/lib/toolhive_telemetry.py
+++ b/src/ol_infrastructure/lib/toolhive_telemetry.py
@@ -1,0 +1,278 @@
+"""Shared ToolHive telemetry + audit configuration for every MCP stack.
+
+A ToolHive deployment is at least two hops of Go binary in front of whatever
+actually serves the tools: a ``VirtualMCPServer`` aggregator and, per backend,
+an ``MCPServer`` proxyrunner. Both run their own OTel pipeline, configured
+through an ``MCPTelemetryConfig`` CR rather than through the ``OTEL_*``
+environment a Python or Go workload would read. Neither is on by default.
+
+This module builds those specs. It lives in ``lib`` rather than under one
+application because the witan and toolhive_swe stacks both need it and the
+security-relevant decisions below — which hop may expose ``/metrics``, what an
+audit event is allowed to carry — must not be re-derived per stack.
+
+── Why CI gets logs but no traces or metrics ──
+``setup_grafana`` (``substructure/aws/eks/grafana.py``) returns early for CI, so
+operations-ci runs no Grafana Alloy: its ``grafana`` namespace exists and is
+empty, and ``grafana-k8s-monitoring-alloy-receiver`` resolves in QA and
+Production only. ``ships_telemetry`` mirrors that condition, so CI lands on the
+no-exporter path by construction instead of buying a connection failure per
+batch forever in the one environment nobody is watching.
+
+Audit logging and the Prometheus ``/metrics`` path are NOT gated that way — see
+their own notes below. Both work in CI.
+"""
+
+from ol_infrastructure.lib.pulumi_helper import StackInfo
+
+# The in-cluster OTLP/HTTP receiver, shared with mit_learn, learn_ai and edxapp
+# (see their Pulumi.{QA,Production}.yaml and edxapp/k8s_configmaps.py). Port
+# 4318 is http/protobuf; 4317 on the same Service is gRPC, which we do not use.
+# ToolHive's exporter is `otlptracehttp`/`otlpmetrichttp` (toolhive-core
+# `telemetry/providers/otlp`), so 4318 is the correct one for it too.
+OTLP_ENDPOINT = (
+    "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318"
+)
+
+# Matched to the mit_learn/learn_ai precedent rather than chosen fresh, so a
+# trace crossing from one of those services is sampled consistently instead of
+# being decided twice.
+DEFAULT_TRACE_SAMPLING_RATE = "0.25"
+
+# QA samples everything: it is where the concurrency probe runs, and a
+# sampled-away trace is a probe run that measured nothing. Affordable precisely
+# because QA carries no organic traffic.
+_FULL_SAMPLE_ENVS = frozenset({"qa"})
+
+
+def ships_telemetry(stack_info: StackInfo) -> bool:
+    """Whether this environment has an OTLP receiver to export to.
+
+    Mirrors ``setup_grafana``'s CI early-return. Kept as a named predicate so
+    the reason a stack is dark is one grep away from the reason the collector
+    is absent.
+
+    The ``.lower()`` is redundant and deliberate: ``parse_stack`` builds
+    ``env_suffix`` as ``stack_name.lower()``, so it is lowercase by
+    construction. It is kept only so this predicate is character-for-character
+    the condition ``setup_grafana`` tests — the two drifting apart is the
+    failure this function exists to prevent.
+    """
+    return stack_info.env_suffix.lower() != "ci"
+
+
+def telemetry_config_name(service: str, hop: str) -> str:
+    """Name of the ``MCPTelemetryConfig`` CR for one hop of one service.
+
+    ``hop`` is ``"backend"`` or ``"vmcp"``. There is one CR per hop rather than
+    one shared between them because they differ on ``prometheus.enabled``, and
+    that difference is a security boundary — see ``toolhive_telemetry_spec``.
+
+    Namespace-scoped by necessity, not choice: the CRD refuses cross-namespace
+    references "for security and isolation reasons", so every namespace running
+    ToolHive needs its own pair.
+    """
+    return f"{service}-telemetry-{hop}"
+
+
+def toolhive_service_name(stack_info: StackInfo, service: str, component: str) -> str:
+    """Per-hop OTel service name, ``<env>-<service>-<component>``.
+
+    ToolHive's CRD requires this to be unique per server, and it is the only
+    thing separating an aggregator's spans from a proxy's — or one backend's
+    from another's when several share a telemetry config. It is supplied
+    through ``telemetryConfigRef.serviceName``, which overrides the config, so
+    N backends can share one CR and still be told apart.
+
+    Same ``<env>-<service>`` convention the OTEL_SERVICE_NAME env uses, so
+    every hop of a stack sorts together in Grafana.
+    """
+    return f"{stack_info.env_suffix}-{service}-{component}"
+
+
+def toolhive_trace_sampling_rate(stack_info: StackInfo) -> str:
+    """Head sampling rate for the ToolHive hops.
+
+    ★ THIS IS THE ROOT SAMPLING DECISION FOR THE WHOLE REQUEST. ToolHive
+    receives the request first, so it starts the trace; a downstream workload
+    running ``parentbased_traceidratio`` honours that decision rather than
+    re-rolling it. So this value — not the workload's own sampler argument —
+    sets what fraction of end-to-end traces exist.
+
+    Production keeps the rate the other services use. Raising it there would
+    change span cost against real traffic, which is a billing decision and not
+    this module's to make.
+    """
+    if stack_info.env_suffix.lower() in _FULL_SAMPLE_ENVS:
+        return "1.0"
+    return DEFAULT_TRACE_SAMPLING_RATE
+
+
+def toolhive_telemetry_spec(
+    stack_info: StackInfo,
+    service: str,
+    component: str,
+    *,
+    expose_prometheus: bool,
+) -> dict[str, object] | None:
+    """Build an ``MCPTelemetryConfigSpec``, or ``None`` if nothing would be enabled.
+
+    Returns ``None`` rather than an all-disabled spec so CI does not carry a CR
+    that configures nothing — a referenced-but-inert config is the kind of thing
+    that reads as "telemetry is on" to the next person to look.
+
+    :param service: the stack, e.g. ``"witan"``. Becomes ``service.namespace``.
+    :param component: the hop, e.g. ``"vmcp"`` or a backend's name. Recorded as
+        ``toolhive.component``; the per-ref ``serviceName`` carries it too.
+    :param expose_prometheus: whether to serve the Prometheus ``/metrics`` path.
+
+        ★ MUST BE FALSE FOR ANY PUBLICLY-ROUTED HOP, WHICH MEANS EVERY vMCP WE
+        RUN. ToolHive serves ``/metrics`` on the *main transport port* — there
+        is no separate admin listener (toolhive `pkg/telemetry/config.go`: "The
+        metrics are served on the main transport port at /metrics"). A vMCP's
+        4483 is the port APISIX publishes, and both witan's and toolhive_swe's
+        ``ingress.py`` route ``paths=["/*"]`` at it, so enabling the path there
+        would put an unauthenticated ``https://<vmcp-host>/metrics`` on the
+        public internet listing every tool name and its call counts. A backend
+        proxy's 8080 is ClusterIP-only and never routed, so it is safe there.
+
+        Revisit only alongside a path-level deny in the APISIX route — not by
+        flipping this flag.
+
+    The Prometheus path is enabled in EVERY environment including CI, unlike
+    OTLP. It costs one HTTP route on a port already listening and opens no
+    outbound connection, so ``ships_telemetry``'s reasoning does not apply to
+    it. It is also the only read available in CI: port-forward, scrape before
+    and after, and diff the cumulative histograms — a window bounded on BOTH
+    sides by construction, which ``kubectl logs --since`` (which has no
+    ``--until``) cannot give you.
+    """
+    otlp_enabled = ships_telemetry(stack_info)
+    if not (otlp_enabled or expose_prometheus):
+        return None
+
+    spec: dict[str, object] = {"prometheus": {"enabled": expose_prometheus}}
+    if otlp_enabled:
+        spec["openTelemetry"] = {
+            "enabled": True,
+            # Scheme-less by the time ToolHive uses it — `NormalizeTelemetryConfig`
+            # strips http(s):// because the OTLP client wants host:port — but
+            # passed whole so this and OTEL_EXPORTER_OTLP_ENDPOINT are visibly
+            # the same endpoint. `insecure` is what actually selects plaintext,
+            # and must stay in step with OTLP_ENDPOINT's scheme.
+            "endpoint": OTLP_ENDPOINT,
+            "insecure": True,
+            "metrics": {"enabled": True},
+            "tracing": {
+                "enabled": True,
+                "samplingRate": toolhive_trace_sampling_rate(stack_info),
+            },
+            # service.name is NOT set here — it comes from the per-hop
+            # `telemetryConfigRef.serviceName` override, which is what lets one
+            # spec serve several differently-named hops.
+            "resourceAttributes": {
+                "deployment.environment": stack_info.env_suffix,
+                "service.namespace": service,
+                "toolhive.component": component,
+            },
+        }
+    return spec
+
+
+#########################################
+#   Audit                                #
+#########################################
+# Audit writes one JSON event per request — method, outcome, duration — to
+# stdout (the CRD's default when `logFile` is unset), so it rides the existing
+# pod-log path to Loki with no collector involved. That is why audit is on in
+# every environment while OTLP is not.
+#
+# Event targets carry only the URL path, the MCP method and the resource id
+# (the tool name) — `auditor.go:extractTarget` — never arguments. The one field
+# that can carry payload-derived text is `jsonrpc_error_message`; see below.
+
+
+def toolhive_mcpserver_audit() -> dict[str, object]:
+    """``MCPServer.spec.audit`` — which accepts ONLY ``enabled``.
+
+    ★ THE TWO CRDs ARE NOT SYMMETRIC. ``MCPServer.spec.audit`` has exactly one
+    property; the full option set (``includeRequestData``, ``eventTypes``,
+    ``detectApplicationErrors``, …) exists only on
+    ``VirtualMCPServer.spec.config.audit``. The MCPServer CRD is a structural
+    schema with no ``x-kubernetes-preserve-unknown-fields``, so any extra key
+    here is PRUNED. Verified against operations-qa on 2026-08-14: a merge patch
+    carrying ``includeRequestData`` returns ``Warning: unknown field`` and
+    stores ``{"enabled": true}``. The apply still succeeds, so a
+    ``includeRequestData: false`` written here for safety would survive review
+    as an assurance while being enforced by nothing.
+
+    Body exclusion on this hop therefore rests on ToolHive's own defaults
+    (``IncludeRequestData``/``IncludeResponseData`` default false,
+    `pkg/audit/config.go`), not on anything declared here.
+
+    ── ``jsonrpc_error_message``: WHAT IT CAPTURES DEPENDS ON THE BACKEND'S SDK ──
+    ``auditor.go:333-343`` copies ``jsonrpc_error_code``/``jsonrpc_error_message``
+    (256 chars) into audit metadata whenever an outcome is
+    ``ApplicationError``, gated ONLY on ``detectApplicationErrors`` (default
+    true) and NOT on ``includeResponseData`` — its own comment says it reports
+    them "without enabling full response data capture". This CRD exposes no
+    switch for it, so on a backend it cannot be turned off.
+
+    Capture requires a TOP-LEVEL JSON-RPC ``error``; ``pkg/mcp/response.go``
+    "intentionally omit[s] `result`". Whether a tool failure lands in one or the
+    other is decided by the backend's MCP SDK, and THE THREE WE RUN DISAGREE
+    (all verified 2026-08-14):
+
+    * **FastMCP 4.0.0b2** (witan) — every tool-level failure becomes an
+      ``isError`` result. Confirmed against a live server: an exception echoing
+      the caller's payload, a pydantic error carrying ``input_value=``, and an
+      unknown tool ALL stayed in ``result``; only ``no/such/method`` produced a
+      top-level error, message ``"Method not found"``. Nothing content-bearing
+      is captured.
+    * **modelcontextprotocol/go-sdk** (fetch) — same outcome by a different
+      route: ``mcp/server.go`` returns a structured ``*jsonrpc.Error`` directly
+      but wraps a *plain* error in ``CallToolResult{IsError: true}``, and
+      gofetch returns ``fmt.Errorf``. So its URL-bearing messages
+      ("access to %s is disallowed by robots.txt") are NOT captured.
+    * **mark3labs/mcp-go v0.55.0** (grafana) — DIFFERENT. A non-nil handler
+      error becomes ``requestError{code: INTERNAL_ERROR}``, i.e. a top-level
+      JSON-RPC error, so its messages ARE captured. Reviewed: mcp-grafana
+      v1.0.0 interpolates queries, resource ids and upstream API status into
+      those, but no credential — the service-account token travels as a header
+      and appears in no error format string.
+
+    The detector also runs only on 2xx, so 401s and 5xx never reach it.
+
+    ★ RE-CHECK ON ANY SDK OR ToolHive UPGRADE. Nothing tests this, and it is
+    the only thing standing between an audit log and payload-derived content.
+    For a backend serving user-authored data the cost would be real: content
+    reaches Loki, which is readable by anyone with Grafana access rather than
+    being scoped the way the data's own store is, and it would arrive
+    PRE-redaction where a stack redacts inside the tool.
+
+    Kept ON deliberately rather than tolerated: a JSON-RPC error inside an HTTP
+    200 is exactly the ``-32603``-under-load signature the witan concurrency
+    work is chasing, and disabling detection would record those as successes.
+    """
+    return {"enabled": True}
+
+
+def toolhive_vmcp_audit() -> dict[str, object]:
+    """``VirtualMCPServer.spec.config.audit`` — the full-schema counterpart.
+
+    ★ ``includeRequestData``/``includeResponseData`` STAY FALSE. They are
+    already the CRD's defaults; they are restated because a vMCP relays whole
+    request bodies, and turning either on would copy them into the log
+    pipeline, where whatever redaction governs the backend's own write path
+    does not apply.
+
+    ``detectApplicationErrors`` is deliberately left at its default (true) even
+    though this CRD — unlike ``MCPServer.spec.audit`` — could disable it. See
+    ``toolhive_mcpserver_audit`` for the per-SDK evidence on what that field
+    can carry, and for why the signal is wanted.
+    """
+    return {
+        "enabled": True,
+        "includeRequestData": False,
+        "includeResponseData": False,
+    }


### PR DESCRIPTION
Follow-on to #5414. That turned on the ToolHive tier's own OTel pipeline and audit logging for **witan only**. `toolhive_swe` runs the same two hops in front of five backends and had none of it — no traces, no metrics, no per-request record of what a tool call did or how long it took.

## What

Moves the helpers to `lib/toolhive_telemetry.py` and wires `toolhive_swe`.

| Signal | CI | QA | Production |
|---|---|---|---|
| Prometheus `/metrics` (5 backends) | ✅ | ✅ | ✅ |
| Prometheus `/metrics` (vMCP) | ❌ | ❌ | ❌ |
| OTLP traces + metrics | ❌ | ✅ (sample 1.0) | ✅ (sample 0.25) |
| Audit log → stdout → Loki | ✅ | ✅ | ✅ |

Backends: `fetch`, `grafana`, `context7`, `sentry`, `aws`. All five share the backend `MCPTelemetryConfig` — they want identical settings — and are separated by the per-ref `serviceName` (`qa-toolhive-swe-fetch`, `qa-toolhive-swe-grafana`, …), which overrides the config's own. Without that they would all report as one service and the spans would be unattributable.

## The witan half is a pure move

CR names, OTel service names, rendered specs, audit shapes and witan's own `OTEL_*` env are **byte-identical** to what is on main. Checked rather than assumed, because renaming a Kubernetes object is a delete-and-recreate: an equivalence script asserts every witan-facing value against the pre-refactor output, including that CI still renders `{"prometheus": {"enabled": true}}` with no OTLP block and no vMCP CR at all.

## The security shape carries over, and for the same reason

ToolHive serves `/metrics` on the **main transport port**, and `toolhive_swe/ingress.py` routes `paths=["/*"]` at the vMCP on 4483 exactly as witan's does. So `prometheus.enabled` stays **false** on that hop and that hop only — enabling it would put an unauthenticated metrics endpoint on the public vMCP host listing every tool name and its call counts. Two CRs per namespace rather than one, because the hops must differ on that field. Namespace-scoped by necessity too: the CRD refuses cross-namespace references, so witan's CRs could not have covered these even in principle.

## ★ One finding that does NOT carry over

witan's audit is safe from `jsonrpc_error_message` partly because **FastMCP** routes every tool failure into an `isError` result, which ToolHive's detector ignores (it requires a top-level JSON-RPC `error`; `pkg/mcp/response.go` "intentionally omit[s] `result`"). That is a property of the SDK — and these backends use several. All six verified:

| SDK | Backend | Handler error becomes | Captured? |
|---|---|---|---|
| FastMCP 4.0.0b2 | witan | `isError` result | No |
| FastMCP | **aws** | middleware re-raises every exception as `ToolError` → `isError` | No |
| `modelcontextprotocol/go-sdk` | fetch | `isError` result (plain errors wrapped; only `*jsonrpc.Error` passes through) | No |
| `@modelcontextprotocol/sdk` | sentry | `{content, isError: true}` from a handler catch | No |
| `@modelcontextprotocol/sdk` | context7 | content result; its only `-32603` is HTTP 500, unreachable on a 2xx-only detector | No |
| `mark3labs/mcp-go` v0.55.0 | **grafana** | **`requestError{INTERNAL_ERROR}`** — top-level JSON-RPC error | **Yes** |

So gofetch's URL-bearing messages (`"access to %s is disallowed by robots.txt"`) are *not* captured, but mcp-grafana's *are*. Reviewed what lands there: queries, resource ids and upstream API status — **no credential**; the service-account token travels as a header and appears in no error format string. Judged acceptable (operational text, 256-char cap, destination is the same Grafana Cloud the queries already target), and recorded per-SDK in `toolhive_mcpserver_audit` so the next SDK or ToolHive upgrade re-checks rather than rediscovers.

The `aws` row matters most of the five: the managed endpoint behind `mcp-proxy-for-aws` exposes a `run_script` tool, so its requests carry user-authored scripts. It is FastMCP-based and its `ToolErrorMiddleware` catches every exception, so none of that reaches an audit event.

Flagging it explicitly since it is the one place this PR accepts something #5414 did not.

## Verification

- `pre-commit` (ruff format/check, mypy, detect-secrets) — all pass
- witan equivalence script — every CR name, service name, spec, audit shape and `OTEL_*` value unchanged
- All three envs' rendered specs server-side dry-run applied against the live CRDs with `--validate=strict` — 5/5 accepted
- `telemetryConfigRef` + `audit` dry-run patched onto the live QA `fetch` MCPServer and `swe-vmcp` — both accepted, fields persist the round trip
- Audit error-shape checked for **all five** backends' SDKs, not a sample (see the table above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JYb9sMjetD9Nxjf24Aw3m5
