### PR TITLE
fix(apisix): restart the login flow instead of 500ing on an expired auth session

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,7 +6,11 @@ on:
     branches: [main]
   pull_request:
 
-permissions: {}
+# Every job here only reads the checkout: nothing publishes, comments, or writes
+# back. Set at the workflow level rather than per job so a job added later
+# inherits the restriction instead of silently getting the default token.
+permissions:
+  contents: read
 
 jobs:
   test:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -34,6 +34,52 @@ jobs:
     - name: Run tests
       run: uv run pytest
 
+  # The unit suite stubs ngx and apisix.core, so it proves the Lua does what we
+  # meant but not that APISIX accepts the plugin config or that OpenResty
+  # behaves as assumed. These two jobs cover that, and are separate so a
+  # gateway-level failure is distinguishable from an ordinary test failure.
+  apisix-integration:
+    name: APISIX integration (real gateway)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      with:
+        persist-credentials: false
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      with:
+        enable-cache: true
+
+    - name: Set up Python
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+      with:
+        python-version-file: pyproject.toml
+
+    - name: Install dependencies
+      run: uv sync --frozen
+
+    # Excluded from the default run by `-m 'not integration'` in pyproject.
+    - name: Run APISIX integration tests
+      run: uv run pytest tests/apisix_integration -m integration
+
+  apisix-testnginx:
+    name: APISIX test-nginx
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      with:
+        persist-credentials: false
+
+    # Builds an image from the pinned APISIX version, adds Test::Nginx and
+    # etcd, and runs APISIX's own harness against src/.../files/*.lua.
+    - name: Run test-nginx suite
+      run: tests/apisix_testnginx/run.sh
+
   # ONE required status check standing for this whole workflow.
   #
   # Today this wraps a single job, so it changes nothing on its own. It exists for the
@@ -50,7 +96,7 @@ jobs:
   # required directly -- a workflow that does not trigger reports nothing at all and
   # would leave every unrelated PR pending forever.
   ci-gate:
-    needs: [test]
+    needs: [test, apisix-integration, apisix-testnginx]
     # Without this the gate is skipped when a dependency fails, and GitHub treats a
     # skipped required job as successful, allowing the PR to merge despite the failure.
     if: always()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ Repository = "https://github.com/mitodl/ol-infrastructure"
 dev = [
   "copier",
   "datamodel-code-generator",
+  "lupa>=2.0",
   "mypy",
   "pip>=26.0.1",
   "pre-commit>=4.0.0,<5",

--- a/src/ol_infrastructure/applications/jupyterhub/deployment.py
+++ b/src/ol_infrastructure/applications/jupyterhub/deployment.py
@@ -23,7 +23,7 @@ from ol_infrastructure.components.services.apisix import (
     OLApisixRouteConfig,
     OLApisixSharedPlugins,
     OLApisixSharedPluginsConfig,
-    oidc_error_callback_recovery_plugin,
+    oidc_gateway_pre_function_plugin,
     stale_session_cookie_cleanup_plugin,
 )
 from ol_infrastructure.components.services.cert_manager import (
@@ -187,11 +187,17 @@ def provision_jupyterhub_deployment(  # noqa: PLR0913
                 # host belongs to mit-learn, which clears it from its own
                 # routes.  Safe to delete once the old cookies have aged out.
                 stale_session_cookie_cleanup_plugin(),
-                # Same expired-authentication-session callbacks that api.learn
-                # and mitxonline see, at this host's much smaller volume (2/day
-                # on nb.learn.mit.edu).  Attached for consistency of behaviour
-                # across the OIDC-protected hosts rather than for the volume.
-                oidc_error_callback_recovery_plugin(),
+                # Two pre-openid-connect fixes, necessarily one plugin (APISIX
+                # allows a single serverless-pre-function per config).  The
+                # expired-authentication-session callbacks are the same ones
+                # api.learn and mitxonline see, at this host's much smaller
+                # volume (2/day).  The canonical-origin redirect matters more
+                # here than anywhere else: nb.learn and authoring.nb.learn are
+                # the two hosts Keycloak actually rejects today, 61 hits over
+                # 7 days between them, because they take direct plain-HTTP
+                # traffic that the `redirect` default plugin never gets to
+                # upgrade.
+                oidc_gateway_pre_function_plugin(),
             ],
         ),
     )

--- a/src/ol_infrastructure/applications/jupyterhub/deployment.py
+++ b/src/ol_infrastructure/applications/jupyterhub/deployment.py
@@ -23,6 +23,7 @@ from ol_infrastructure.components.services.apisix import (
     OLApisixRouteConfig,
     OLApisixSharedPlugins,
     OLApisixSharedPluginsConfig,
+    oidc_error_callback_recovery_plugin,
     stale_session_cookie_cleanup_plugin,
 )
 from ol_infrastructure.components.services.cert_manager import (
@@ -186,6 +187,11 @@ def provision_jupyterhub_deployment(  # noqa: PLR0913
                 # host belongs to mit-learn, which clears it from its own
                 # routes.  Safe to delete once the old cookies have aged out.
                 stale_session_cookie_cleanup_plugin(),
+                # Same expired-authentication-session callbacks that api.learn
+                # and mitxonline see, at this host's much smaller volume (2/day
+                # on nb.learn.mit.edu).  Attached for consistency of behaviour
+                # across the OIDC-protected hosts rather than for the volume.
+                oidc_error_callback_recovery_plugin(),
             ],
         ),
     )

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -55,7 +55,7 @@ from ol_infrastructure.components.services.apisix import (
     OLApisixRouteConfig,
     OLApisixSharedPlugins,
     OLApisixSharedPluginsConfig,
-    oidc_error_callback_recovery_plugin,
+    oidc_gateway_pre_function_plugin,
     stale_session_cookie_cleanup_plugin,
 )
 from ol_infrastructure.components.services.cert_manager import (
@@ -1355,8 +1355,11 @@ learn_external_service_shared_plugins = OLApisixSharedPlugins(
             # openid-connect plugin serves each one a 500.  Both route groups
             # on this host need it, and the plugin derives its redirect target
             # from the request URI, so the /login and /learn/login prefixes are
-            # handled from this one attachment.
-            oidc_error_callback_recovery_plugin(),
+            # handled from this one attachment.  The same attachment also
+            # canonicalises the origin: `curl http://api.learn.mit.edu/login`
+            # currently sends Keycloak an http:// redirect_uri, and answers with
+            # an OIDC session cookie over cleartext.
+            oidc_gateway_pre_function_plugin(),
         ],
     ),
 )

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -55,6 +55,7 @@ from ol_infrastructure.components.services.apisix import (
     OLApisixRouteConfig,
     OLApisixSharedPlugins,
     OLApisixSharedPluginsConfig,
+    oidc_error_callback_recovery_plugin,
     stale_session_cookie_cleanup_plugin,
 )
 from ol_infrastructure.components.services.cert_manager import (
@@ -1349,6 +1350,13 @@ learn_external_service_shared_plugins = OLApisixSharedPlugins(
             stale_session_cookie_cleanup_plugin(
                 cookie_domains=[mitlearn_api_domain.removeprefix("api")],
             ),
+            # 327 callbacks a day on api.learn.mit.edu come back from Keycloak
+            # with error=temporarily_unavailable instead of a code, and the
+            # openid-connect plugin serves each one a 500.  Both route groups
+            # on this host need it, and the plugin derives its redirect target
+            # from the request URI, so the /login and /learn/login prefixes are
+            # handled from this one attachment.
+            oidc_error_callback_recovery_plugin(),
         ],
     ),
 )

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -51,6 +51,7 @@ from ol_infrastructure.components.services.apisix import (
     OLApisixRouteConfig,
     OLApisixSharedPlugins,
     OLApisixSharedPluginsConfig,
+    oidc_error_callback_recovery_plugin,
     stale_session_cookie_cleanup_plugin,
 )
 from ol_infrastructure.components.services.cert_manager import (
@@ -807,6 +808,16 @@ mitxonline_shared_plugins = OLApisixSharedPlugins(
         k8s_namespace=mitxonline_namespace,
         k8s_labels=k8s_app_labels,
         enable_defaults=True,
+        plugins=[
+            # 285 callbacks a day on mitxonline.mit.edu come back from Keycloak
+            # with error=temporarily_unavailable instead of a code, and the
+            # openid-connect plugin serves each one a 500.  Unlike the cookie
+            # cleanup below, this is safe to attach here rather than per route
+            # group: it derives its redirect target from the request URI and
+            # its guard cookie is host-only, so neither depends on which parent
+            # domain a group's session cookie was scoped to.
+            oidc_error_callback_recovery_plugin(),
+        ],
     ),
 )
 

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -51,7 +51,7 @@ from ol_infrastructure.components.services.apisix import (
     OLApisixRouteConfig,
     OLApisixSharedPlugins,
     OLApisixSharedPluginsConfig,
-    oidc_error_callback_recovery_plugin,
+    oidc_gateway_pre_function_plugin,
     stale_session_cookie_cleanup_plugin,
 )
 from ol_infrastructure.components.services.cert_manager import (
@@ -815,8 +815,10 @@ mitxonline_shared_plugins = OLApisixSharedPlugins(
             # cleanup below, this is safe to attach here rather than per route
             # group: it derives its redirect target from the request URI and
             # its guard cookie is host-only, so neither depends on which parent
-            # domain a group's session cookie was scoped to.
-            oidc_error_callback_recovery_plugin(),
+            # domain a group's session cookie was scoped to.  Ditto the
+            # canonical-origin redirect it also carries, which is derived from
+            # the request's own host.
+            oidc_gateway_pre_function_plugin(),
         ],
     ),
 )

--- a/src/ol_infrastructure/components/services/apisix.py
+++ b/src/ol_infrastructure/components/services/apisix.py
@@ -155,7 +155,15 @@ def oidc_error_callback_recovery_plugin(
     :returns: A ``serverless-pre-function`` plugin config to attach to routes.
     :rtype: OLApisixPluginConfig
     """
-    errors = recoverable_errors or ["temporarily_unavailable"]
+    # `is None`, not `or`: an explicit empty list means "recover nothing",
+    # which is how a caller turns the plugin into a no-op without detaching it
+    # from every route that references the shared config.  `or` would quietly
+    # turn that back into the default.
+    errors = (
+        ["temporarily_unavailable"]
+        if recoverable_errors is None
+        else recoverable_errors
+    )
     recoverable_table = ", ".join(f'["{error}"] = true' for error in errors)
     recovery_function = f"""return function(conf, ctx)
     local uri = ngx.var.uri

--- a/src/ol_infrastructure/components/services/apisix.py
+++ b/src/ol_infrastructure/components/services/apisix.py
@@ -1,6 +1,7 @@
 # ruff: noqa: E501
 """APISIX ingress controller components for Kubernetes."""
 
+from pathlib import Path
 from typing import Any, Literal
 
 import pulumi_kubernetes as kubernetes
@@ -13,6 +14,14 @@ from ol_infrastructure.components.services.vault import (
     OLVaultK8SStaticSecretConfig,
 )
 from ol_infrastructure.lib.pulumi_helper import parse_stack
+
+# Read once at import: the file is shipped verbatim as the serverless function
+# body, with configuration passed separately on the plugin config.
+OIDC_ERROR_RECOVERY_LUA = (
+    Path(__file__)
+    .parent.joinpath("files", "oidc_error_callback_recovery.lua")
+    .read_text()
+)
 
 
 class OLApisixPluginConfig(BaseModel):
@@ -145,9 +154,20 @@ def oidc_error_callback_recovery_plugin(
     looping: a persistently broken IdP should surface as an error, not as an
     infinite redirect.
 
+    The Lua itself lives in ``files/oidc_error_callback_recovery.lua`` and is
+    shipped verbatim -- nothing is interpolated into it.  Tunables travel as an
+    ``oidc_error_recovery`` block on the plugin config, which the function reads
+    off ``conf``: ``serverless/init.lua`` invokes each function as
+    ``func(conf, ctx)``, and its schema does not set ``additionalProperties``,
+    so extra keys validate.  Keeping it a real ``.lua`` file means it is
+    syntax-highlighted, reviewable, and testable under APISIX's own test-nginx
+    harness (``t/oidc_error_callback_recovery.t``).
+
     :param recoverable_errors: OAuth 2.0 ``error`` codes to restart the flow
         for.  Defaults to ``temporarily_unavailable``, which is 100% of what
-        production emits today.
+        production emits today.  An explicit empty list makes the plugin a
+        no-op, for turning it off without detaching it from every route that
+        references a shared plugin config.
     :param guard_cookie_name: Name of the loop-breaker cookie.
     :param guard_max_age: Seconds the guard cookie lives, bounding how often one
         browser can be sent back through login.
@@ -155,47 +175,6 @@ def oidc_error_callback_recovery_plugin(
     :returns: A ``serverless-pre-function`` plugin config to attach to routes.
     :rtype: OLApisixPluginConfig
     """
-    # `is None`, not `or`: an explicit empty list means "recover nothing",
-    # which is how a caller turns the plugin into a no-op without detaching it
-    # from every route that references the shared config.  `or` would quietly
-    # turn that back into the default.
-    errors = (
-        ["temporarily_unavailable"]
-        if recoverable_errors is None
-        else recoverable_errors
-    )
-    recoverable_table = ", ".join(f'["{error}"] = true' for error in errors)
-    recovery_function = f"""return function(conf, ctx)
-    local uri = ngx.var.uri
-    if not uri or not uri:match("%.apisix/redirect$") then
-        return
-    end
-    local core = require("apisix.core")
-    local args = core.request.get_uri_args(ctx)
-    if not args then
-        return
-    end
-    local err = args["error"]
-    if type(err) == "table" then
-        err = err[1]
-    end
-    local recoverable = {{{recoverable_table}}}
-    if not err or not recoverable[err] then
-        return
-    end
-    local cookie = ngx.var.http_cookie
-    if cookie then
-        for pair in cookie:gmatch("[^;]+") do
-            if pair:match("^%s*([^=%s]+)=") == "{guard_cookie_name}" then
-                return
-            end
-        end
-    end
-    core.log.warn("oidc callback error=", err, " uri=", uri, " restarting auth")
-    ngx.header["Set-Cookie"] = "{guard_cookie_name}=1; Path=/; Max-Age="
-        .. "{guard_max_age}" .. "; Secure; HttpOnly; SameSite=Lax"
-    return ngx.redirect((uri:gsub("%.apisix/redirect$", "")), 302)
-end"""
     return OLApisixPluginConfig(
         name="serverless-pre-function",
         secretRef=None,
@@ -204,7 +183,22 @@ end"""
         # outranks it (2599), so this gets to inspect the callback and bail out
         # before the plugin turns the error parameter into a 500.  In the access
         # phase it would run after openid-connect had already failed.
-        config={"phase": "rewrite", "functions": [recovery_function]},
+        config={
+            "phase": "rewrite",
+            "functions": [OIDC_ERROR_RECOVERY_LUA],
+            "oidc_error_recovery": {
+                # `is None`, not `or`: an explicit empty list means "recover
+                # nothing", and `or` would quietly turn that back into the
+                # default.
+                "recoverable_errors": (
+                    ["temporarily_unavailable"]
+                    if recoverable_errors is None
+                    else recoverable_errors
+                ),
+                "guard_cookie_name": guard_cookie_name,
+                "guard_max_age": guard_max_age,
+            },
+        },
     )
 
 

--- a/src/ol_infrastructure/components/services/apisix.py
+++ b/src/ol_infrastructure/components/services/apisix.py
@@ -15,13 +15,20 @@ from ol_infrastructure.components.services.vault import (
 )
 from ol_infrastructure.lib.pulumi_helper import parse_stack
 
-# Read once at import: the file is shipped verbatim as the serverless function
-# body, with configuration passed separately on the plugin config.
+# Read once at import: the files are shipped verbatim as serverless function
+# bodies, with configuration passed separately on the plugin config.
 OIDC_ERROR_RECOVERY_LUA = (
     Path(__file__)
     .parent.joinpath("files", "oidc_error_callback_recovery.lua")
     .read_text()
 )
+CANONICAL_HTTPS_REDIRECT_LUA = (
+    Path(__file__).parent.joinpath("files", "canonical_https_redirect.lua").read_text()
+)
+
+# The only statuses ngx.redirect accepts; anything else is a Lua error at
+# request time (ngx_http_lua_control.c:209-219).
+NGX_REDIRECT_STATUSES = (301, 302, 303, 307, 308)
 
 
 class OLApisixPluginConfig(BaseModel):
@@ -112,21 +119,60 @@ end"""
     )
 
 
-def oidc_error_callback_recovery_plugin(
+def oidc_gateway_pre_function_plugin(
     recoverable_errors: list[str] | None = None,
     guard_cookie_name: str = "apisix_oidc_recovery",
     guard_max_age: int = 60,
+    *,
+    canonical_https_redirect: bool = True,
+    canonical_redirect_status: Literal[301, 302, 303, 307, 308] = 308,
 ) -> OLApisixPluginConfig:
-    """Restart the login flow when the IdP redirects back with a recoverable error.
+    """Everything that has to happen before openid-connect sees the request.
 
-    An authorization request whose Keycloak authentication session has expired
-    -- the user left the login tab open, or followed a stale bookmark -- comes
-    back to the callback with ``error=temporarily_unavailable`` and no ``code``.
+    APISIX keys a plugin config by plugin name, so a route can carry exactly ONE
+    ``serverless-pre-function``.  Both of the fixes below have to run ahead of
+    openid-connect (priority 2599), and ``serverless-pre-function`` (priority
+    10000) is the only hook that gets there, so they are necessarily one plugin
+    rather than two.  ``serverless/init.lua`` runs ``functions`` in array order
+    and stops at the first one returning a code or body, which is exactly the
+    sequencing wanted here: normalise the origin first, and only then look at
+    whether this is a failed callback.
+
+    **Canonical origin** (``canonical_https_redirect.lua``).  The shared-plugin
+    defaults already include APISIX's ``redirect`` plugin with ``http_to_https``,
+    but its priority is below openid-connect's, so on an OIDC route it is dead
+    code -- openid-connect has already answered.  The consequences are measured,
+    not hypothetical.  APISIX derives only a relative redirect_uri and
+    lua-resty-openidc 1.8.0 (the version APISIX 3.17 pins) makes it absolute from
+    ``ngx.var.scheme`` and ``ngx.var.http_host``, so a plain-HTTP request sends
+    Keycloak ``http://...`` and a request carrying ``Host: <host>:443`` sends
+    ``https://<host>:443/...``.  Keycloak registers bare-host https URIs only and
+    rejects both with ``error="invalid_redirect_uri"``; the login dies at the
+    authorization endpoint, before any callback exists for the recovery function
+    below to rescue.  Worse than the failed logins: because the upgrade never
+    runs, APISIX answers plain-HTTP requests with an OIDC session cookie over
+    cleartext and without the ``Secure`` attribute.
+
+    Redirecting is what fixes this, not header-setting.  lua-resty-openidc does
+    prefer ``Forwarded`` / ``X-Forwarded-Proto`` / ``X-Forwarded-Host`` over those
+    ngx vars, but on this deployment none of the three reaches it -- sending each
+    against production leaves the redirect_uri unchanged -- so pinning them would
+    be a no-op dressed up as a fix.
+
+    Note this leaves port 80 answering with a redirect rather than closing it.
+    That is only safe because every ACME ClusterIssuer on the cluster solves via
+    dns01/Route53; an issuer switched to http-01 would need its challenge path
+    carved out of the redirect.
+
+    **Error-callback recovery** (``oidc_error_callback_recovery.lua``).  An
+    authorization request whose Keycloak authentication session has expired --
+    the user left the login tab open, or followed a stale bookmark -- comes back
+    to the callback with ``error=temporarily_unavailable`` and no ``code``.
     Keycloak's intent there is that the client start over; it even marks the
-    event ``restart_after_timeout="true"``.  ``lua-resty-openidc`` instead
-    treats any ``error`` parameter as fatal and hands the openid-connect plugin
-    a failure, which APISIX serves as a 21KB HTTP 500.  The user sees a
-    stack-trace page where they expected a login form, and nothing retries.
+    event ``restart_after_timeout="true"``.  ``lua-resty-openidc`` instead treats
+    any ``error`` parameter as fatal and hands the openid-connect plugin a
+    failure, which APISIX serves as a 21KB HTTP 500.  The user sees a stack-trace
+    page where they expected a login form, and nothing retries.
 
     This is measured, not hypothetical: 614 such callbacks a day across
     api.learn.mit.edu, mitxonline.mit.edu and nb.learn.mit.edu, from 530
@@ -154,14 +200,15 @@ def oidc_error_callback_recovery_plugin(
     looping: a persistently broken IdP should surface as an error, not as an
     infinite redirect.
 
-    The Lua itself lives in ``files/oidc_error_callback_recovery.lua`` and is
-    shipped verbatim -- nothing is interpolated into it.  Tunables travel as an
-    ``oidc_error_recovery`` block on the plugin config, which the function reads
-    off ``conf``: ``serverless/init.lua`` invokes each function as
+    Both functions live in ``files/`` and are shipped verbatim -- nothing is
+    interpolated into them.  Tunables travel as ``oidc_error_recovery`` and
+    ``canonical_https_redirect`` blocks on the plugin config, which the functions
+    read off ``conf``: ``serverless/init.lua`` invokes each as
     ``func(conf, ctx)``, and its schema does not set ``additionalProperties``,
-    so extra keys validate.  Keeping it a real ``.lua`` file means it is
+    so extra keys validate.  Keeping them real ``.lua`` files means they are
     syntax-highlighted, reviewable, and testable under APISIX's own test-nginx
-    harness (``t/oidc_error_callback_recovery.t``).
+    harness (``t/oidc_error_callback_recovery.t``,
+    ``t/canonical_https_redirect.t``).
 
     :param recoverable_errors: OAuth 2.0 ``error`` codes to restart the flow
         for.  Defaults to ``temporarily_unavailable``, which is 100% of what
@@ -171,21 +218,51 @@ def oidc_error_callback_recovery_plugin(
     :param guard_cookie_name: Name of the loop-breaker cookie.
     :param guard_max_age: Seconds the guard cookie lives, bounding how often one
         browser can be sent back through login.
+    :param canonical_https_redirect: Whether to send non-canonical origins to
+        ``https://<bare host>`` before openid-connect runs.  ``False`` drops the
+        function entirely, for a host that must keep answering on plain HTTP.
+    :param canonical_redirect_status: Status for that redirect, uniform across
+        methods.  APISIX's own ``redirect`` plugin instead picks per method --
+        301 for GET/HEAD, 308 for everything else (``redirect.lua`` 208-215) --
+        so 308 here is a simplification rather than a behavioural fix: both
+        preserve a POST.  Restricted to the codes ``ngx.redirect`` accepts.
 
     :returns: A ``serverless-pre-function`` plugin config to attach to routes.
     :rtype: OLApisixPluginConfig
     """
+    # Checked rather than left to the annotation: the `Literal` above documents
+    # the contract but nothing enforces it at the call sites, since this repo's
+    # mypy hook runs without the project installed and resolves a cross-module
+    # import to Any.  APISIX will not catch it either -- the block this travels
+    # in is not part of serverless-pre-function's schema -- so an unchecked bad
+    # value would first surface as a 500 on live traffic.  Raising here moves
+    # that to `pulumi preview`.
+    if canonical_redirect_status not in NGX_REDIRECT_STATUSES:
+        msg = (
+            f"canonical_redirect_status must be one of {NGX_REDIRECT_STATUSES}, "
+            f"got {canonical_redirect_status}: ngx.redirect rejects anything else."
+        )
+        raise ValueError(msg)
+
+    # Order matters and is load-bearing: serverless/init.lua stops at the first
+    # function returning a code, so the origin has to be canonical before the
+    # recovery function decides whether to redirect back into the login flow.
+    functions = [OIDC_ERROR_RECOVERY_LUA]
+    if canonical_https_redirect:
+        functions.insert(0, CANONICAL_HTTPS_REDIRECT_LUA)
     return OLApisixPluginConfig(
         name="serverless-pre-function",
         secretRef=None,
         # rewrite rather than the plugin's default access phase: openid-connect
         # also runs in rewrite, and serverless-pre-function's priority (10000)
-        # outranks it (2599), so this gets to inspect the callback and bail out
-        # before the plugin turns the error parameter into a 500.  In the access
-        # phase it would run after openid-connect had already failed.
+        # outranks it (2599), so this gets to normalise the origin and inspect
+        # the callback before the plugin reads either.  In the access phase it
+        # would run after openid-connect had already built its redirect_uri and
+        # failed.
         config={
             "phase": "rewrite",
-            "functions": [OIDC_ERROR_RECOVERY_LUA],
+            "functions": functions,
+            "canonical_https_redirect": {"status": canonical_redirect_status},
             "oidc_error_recovery": {
                 # `is None`, not `or`: an explicit empty list means "recover
                 # nothing", and `or` would quietly turn that back into the

--- a/src/ol_infrastructure/components/services/apisix.py
+++ b/src/ol_infrastructure/components/services/apisix.py
@@ -103,6 +103,103 @@ end"""
     )
 
 
+def oidc_error_callback_recovery_plugin(
+    recoverable_errors: list[str] | None = None,
+    guard_cookie_name: str = "apisix_oidc_recovery",
+    guard_max_age: int = 60,
+) -> OLApisixPluginConfig:
+    """Restart the login flow when the IdP redirects back with a recoverable error.
+
+    An authorization request whose Keycloak authentication session has expired
+    -- the user left the login tab open, or followed a stale bookmark -- comes
+    back to the callback with ``error=temporarily_unavailable`` and no ``code``.
+    Keycloak's intent there is that the client start over; it even marks the
+    event ``restart_after_timeout="true"``.  ``lua-resty-openidc`` instead
+    treats any ``error`` parameter as fatal and hands the openid-connect plugin
+    a failure, which APISIX serves as a 21KB HTTP 500.  The user sees a
+    stack-trace page where they expected a login form, and nothing retries.
+
+    This is measured, not hypothetical: 614 such callbacks a day across
+    api.learn.mit.edu, mitxonline.mit.edu and nb.learn.mit.edu, from 530
+    distinct client addresses, 181 of which never reached a successful callback
+    in the same 24 hours.  It is the only one of the three causes of callback
+    500s that actually blocks anybody -- see ``log_rules/apisix_oidc.py``.
+
+    Running before openid-connect, this turns that dead end back into a login
+    page.  The redirect target is derived from the callback URI rather than
+    configured: APISIX's callback always sits at ``<login prefix>/.apisix/
+    redirect``, and the route serving it is by construction the one with
+    ``unauth_action="auth"``, so redirecting to the parent path re-enters the
+    authorization flow that just failed and lands the user wherever that route
+    normally sends them.  That keeps this attachable to a host's shared plugin
+    config with no per-application wiring.
+
+    Only errors the IdP considers transient are recovered.  ``access_denied``
+    (the user pressed "Cancel") or ``invalid_request`` (a real
+    misconfiguration) must keep failing loudly -- bouncing those back into
+    ``/login`` would spin the browser between the gateway and Keycloak.
+
+    Recovery is attempted at most once per ``guard_max_age`` seconds per
+    browser, tracked by a short-lived guard cookie.  If the retry hits the same
+    error, the second callback falls through to the plugin's 500 instead of
+    looping: a persistently broken IdP should surface as an error, not as an
+    infinite redirect.
+
+    :param recoverable_errors: OAuth 2.0 ``error`` codes to restart the flow
+        for.  Defaults to ``temporarily_unavailable``, which is 100% of what
+        production emits today.
+    :param guard_cookie_name: Name of the loop-breaker cookie.
+    :param guard_max_age: Seconds the guard cookie lives, bounding how often one
+        browser can be sent back through login.
+
+    :returns: A ``serverless-pre-function`` plugin config to attach to routes.
+    :rtype: OLApisixPluginConfig
+    """
+    errors = recoverable_errors or ["temporarily_unavailable"]
+    recoverable_table = ", ".join(f'["{error}"] = true' for error in errors)
+    recovery_function = f"""return function(conf, ctx)
+    local uri = ngx.var.uri
+    if not uri or not uri:match("%.apisix/redirect$") then
+        return
+    end
+    local core = require("apisix.core")
+    local args = core.request.get_uri_args(ctx)
+    if not args then
+        return
+    end
+    local err = args["error"]
+    if type(err) == "table" then
+        err = err[1]
+    end
+    local recoverable = {{{recoverable_table}}}
+    if not err or not recoverable[err] then
+        return
+    end
+    local cookie = ngx.var.http_cookie
+    if cookie then
+        for pair in cookie:gmatch("[^;]+") do
+            if pair:match("^%s*([^=%s]+)=") == "{guard_cookie_name}" then
+                return
+            end
+        end
+    end
+    core.log.warn("oidc callback error=", err, " uri=", uri, " restarting auth")
+    ngx.header["Set-Cookie"] = "{guard_cookie_name}=1; Path=/; Max-Age="
+        .. "{guard_max_age}" .. "; Secure; HttpOnly; SameSite=Lax"
+    return ngx.redirect((uri:gsub("%.apisix/redirect$", "")), 302)
+end"""
+    return OLApisixPluginConfig(
+        name="serverless-pre-function",
+        secretRef=None,
+        # rewrite rather than the plugin's default access phase: openid-connect
+        # also runs in rewrite, and serverless-pre-function's priority (10000)
+        # outranks it (2599), so this gets to inspect the callback and bail out
+        # before the plugin turns the error parameter into a 500.  In the access
+        # phase it would run after openid-connect had already failed.
+        config={"phase": "rewrite", "functions": [recovery_function]},
+    )
+
+
 class OLApisixRouteConfig(BaseModel):
     """Configuration for a single ApisixRoute rule (legacy CRD path)."""
 

--- a/src/ol_infrastructure/components/services/files/canonical_https_redirect.lua
+++ b/src/ol_infrastructure/components/services/files/canonical_https_redirect.lua
@@ -1,0 +1,64 @@
+-- Send the request to the canonical https://<host> origin before the
+-- openid-connect plugin builds a redirect_uri out of it.
+--
+-- Attached as a serverless-pre-function in the `rewrite` phase, where this
+-- plugin's priority (10000) outranks openid-connect's (2599). That ordering is
+-- the whole point: the shared-plugin defaults already carry APISIX's `redirect`
+-- plugin with http_to_https, but `redirect` has a lower priority than
+-- openid-connect, so on an OIDC route it never gets to run.
+--
+-- APISIX only derives a *relative* redirect_uri (`<uri>/.apisix/redirect`), and
+-- lua-resty-openidc 1.8.0 -- the version pinned by APISIX 3.17 -- turns it
+-- absolute from `ngx.var.scheme` and `ngx.var.http_host`. Both are raw
+-- connection values, so a plain-HTTP request produces `http://...` and a
+-- request carrying `Host: example.org:443` produces `https://example.org:443/...`.
+-- Keycloak registers bare-host https URIs only, so it rejects both with
+-- error="invalid_redirect_uri" and the login dies at the authorization endpoint,
+-- before any callback exists to recover.
+--
+-- Normalising the request rather than the header is deliberate. lua-resty-openidc
+-- does consult `Forwarded` / `X-Forwarded-Proto` / `X-Forwarded-Host` ahead of
+-- those ngx vars, but on this deployment those headers demonstrably do not reach
+-- it: sending any of the three against production changes nothing about the
+-- redirect_uri. Setting them here would be a no-op that reads like a fix.
+--
+-- Configuration arrives on the plugin config under `canonical_https_redirect`,
+-- the same mechanism `oidc_error_callback_recovery.lua` uses.
+--
+--   canonical_https_redirect.status  redirect status code
+--
+-- See `oidc_gateway_pre_function_plugin` in ../apisix.py for the deployment
+-- reasoning and t/canonical_https_redirect.t for the behavioural tests.
+return function(conf, ctx)
+    -- $host is the Host header lowercased with any port stripped, falling back
+    -- to server_name; $http_host is the header verbatim. Comparing them catches
+    -- an explicit :443, an uppercased host, and anything else that would reach
+    -- lua-resty-openidc as a non-canonical authority.
+    local raw_host = ngx.var.http_host
+    local host = ngx.var.host
+
+    -- No Host header at all (HTTP/1.0). There is nothing to build a canonical
+    -- origin from -- $host would be the server_name -- so leave it alone and let
+    -- openid-connect's own 400 handle it.
+    if not raw_host or not host then
+        return
+    end
+
+    if ngx.var.scheme == "https" and raw_host == host then
+        return
+    end
+
+    local core = require("apisix.core")
+    local opts = conf.canonical_https_redirect or {}
+
+    core.log.warn("non-canonical origin scheme=", ngx.var.scheme,
+                  " host=", raw_host, " redirecting to https://", host)
+
+    -- One status for every method. The shadowed `redirect` plugin picks per
+    -- method instead -- 301 for GET/HEAD, 308 for the rest (redirect.lua
+    -- 208-215) -- so both preserve a POST and this is a simplification, not a
+    -- behavioural fix. `status` is constrained in ../apisix.py to the codes
+    -- ngx.redirect accepts; anything else raises a Lua error here.
+    return ngx.redirect("https://" .. host .. ngx.var.request_uri,
+                        opts.status or 308)
+end

--- a/src/ol_infrastructure/components/services/files/oidc_error_callback_recovery.lua
+++ b/src/ol_infrastructure/components/services/files/oidc_error_callback_recovery.lua
@@ -15,7 +15,7 @@
 --   oidc_error_recovery.guard_cookie_name   loop-breaker cookie name
 --   oidc_error_recovery.guard_max_age       guard cookie lifetime, seconds
 --
--- See `oidc_error_callback_recovery_plugin` in ../apisix.py for why each branch
+-- See `oidc_gateway_pre_function_plugin` in ../apisix.py for why each branch
 -- is here, and t/oidc_error_callback_recovery.t for the behavioural tests.
 return function(conf, ctx)
     local uri = ngx.var.uri

--- a/src/ol_infrastructure/components/services/files/oidc_error_callback_recovery.lua
+++ b/src/ol_infrastructure/components/services/files/oidc_error_callback_recovery.lua
@@ -1,0 +1,78 @@
+-- Restart the OIDC login flow when the IdP redirects back with a recoverable
+-- error, instead of letting the openid-connect plugin serve a 500.
+--
+-- Attached as a serverless-pre-function in the `rewrite` phase, where this
+-- plugin's priority (10000) outranks openid-connect's (2599), so it sees the
+-- callback before lua-resty-openidc treats the `error` parameter as fatal.
+--
+-- Configuration arrives on the plugin config under `oidc_error_recovery`.
+-- serverless/init.lua invokes each function as `func(conf, ctx)` and its schema
+-- does not set additionalProperties, so extra keys validate and are readable
+-- here -- no interpolation into the source is needed.
+--
+--   oidc_error_recovery.recoverable_errors  list of OAuth2 `error` codes to
+--                                           restart the flow for
+--   oidc_error_recovery.guard_cookie_name   loop-breaker cookie name
+--   oidc_error_recovery.guard_max_age       guard cookie lifetime, seconds
+--
+-- See `oidc_error_callback_recovery_plugin` in ../apisix.py for why each branch
+-- is here, and t/oidc_error_callback_recovery.t for the behavioural tests.
+return function(conf, ctx)
+    local uri = ngx.var.uri
+    -- Attached to a host's shared plugin config, so this runs on every route on
+    -- the host. APISIX's callback always sits at <login prefix>/.apisix/redirect.
+    if not uri or not uri:match("%.apisix/redirect$") then
+        return
+    end
+
+    local core = require("apisix.core")
+    local opts = conf.oidc_error_recovery or {}
+
+    local args = core.request.get_uri_args(ctx)
+    if not args then
+        return
+    end
+
+    -- A repeated ?error=&error= yields a table rather than a string.
+    local err = args["error"]
+    if type(err) == "table" then
+        err = err[1]
+    end
+    if not err then
+        return
+    end
+
+    -- Only errors the IdP considers transient. access_denied means the user
+    -- pressed Cancel, and invalid_request is a real misconfiguration: bouncing
+    -- either back into /login would spin the browser against the IdP.
+    local recoverable = false
+    for _, candidate in ipairs(opts.recoverable_errors or {}) do
+        if candidate == err then
+            recoverable = true
+            break
+        end
+    end
+    if not recoverable then
+        return
+    end
+
+    -- One recovery per browser per guard window. A persistently broken IdP has
+    -- to surface as an error rather than an infinite redirect. nginx parses the
+    -- cookie header itself and exposes one variable per cookie, so this is a
+    -- single exact-name lookup.
+    local guard = opts.guard_cookie_name
+    if not guard or ctx.var["cookie_" .. guard] then
+        return
+    end
+
+    core.log.warn("oidc callback error=", err, " uri=", uri, " restarting auth")
+    ngx.header["Set-Cookie"] = guard .. "=1; Path=/; Max-Age="
+        .. tostring(opts.guard_max_age)
+        .. "; Secure; HttpOnly; SameSite=Lax"
+
+    -- The route serving the callback is by construction the unauth_action="auth"
+    -- one, so its parent path re-enters the authorization flow that just failed.
+    -- Deriving the target here is what lets one attachment cover every route
+    -- group on a host (mit-learn serves both /login and /learn/login).
+    return ngx.redirect((uri:gsub("%.apisix/redirect$", "")), 302)
+end

--- a/src/ol_infrastructure/components/services/files/oidc_error_callback_recovery.lua
+++ b/src/ol_infrastructure/components/services/files/oidc_error_callback_recovery.lua
@@ -20,8 +20,11 @@
 return function(conf, ctx)
     local uri = ngx.var.uri
     -- Attached to a host's shared plugin config, so this runs on every route on
-    -- the host. APISIX's callback always sits at <login prefix>/.apisix/redirect.
-    if not uri or not uri:match("%.apisix/redirect$") then
+    -- the host. APISIX's callback always sits at <login prefix>/.apisix/redirect,
+    -- and the leading slash is part of the match: without it this also catches
+    -- application paths that merely end in the same characters, such as
+    -- /login/foo.apisix/redirect, and would redirect them.
+    if not uri or not uri:match("/%.apisix/redirect$") then
         return
     end
 
@@ -74,5 +77,8 @@ return function(conf, ctx)
     -- one, so its parent path re-enters the authorization flow that just failed.
     -- Deriving the target here is what lets one attachment cover every route
     -- group on a host (mit-learn serves both /login and /learn/login).
+    --
+    -- Note this strips `.apisix/redirect` and keeps the slash the match above
+    -- required, so /login/.apisix/redirect yields /login/ rather than /login.
     return ngx.redirect((uri:gsub("%.apisix/redirect$", "")), 302)
 end

--- a/tests/apisix_integration/conftest.py
+++ b/tests/apisix_integration/conftest.py
@@ -1,0 +1,205 @@
+"""Run the APISIX plugins in this repo against a real APISIX.
+
+The unit tests in ``tests/ol_infrastructure/components/services`` stub ``ngx``
+and ``apisix.core``, so they prove the Lua does what we meant but not that
+APISIX accepts the plugin config or that OpenResty behaves as assumed.  These
+tests start the pinned APISIX image in standalone mode, feed it the route
+config produced by the real component helpers, and assert over HTTP.
+
+Skipped when Docker is unavailable.  ``APISIX_IT_IMAGE`` overrides the image.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from typing import TYPE_CHECKING, Any
+
+import pytest
+import urllib3
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+from ol_infrastructure.components.services.apisix import (
+    oidc_error_callback_recovery_plugin,
+)
+
+# Must track the APISIX shipped by the chart pinned in bridge.lib.versions
+# (APISIX_CHART 2.16.x => APISIX 3.17.x).  A mismatch here is the difference
+# between testing what runs in production and testing something else.
+APISIX_IMAGE = "apache/apisix:3.17.0-debian"
+CONTAINER_NAME = "ol-apisix-integration-test"
+READY_TIMEOUT_SECONDS = 60
+
+# Standalone (yaml) config provider, so no etcd is needed.  Mirrors the
+# provider the ingress controller drives in the cluster
+# (provider.type: apisix-standalone in infrastructure/aws/eks/apisix_official.py).
+CONFIG_YAML = """
+apisix:
+  node_listen: 9080
+  enable_admin: false
+deployment:
+  role: data_plane
+  role_data_plane:
+    config_provider: yaml
+plugins:
+  - serverless-pre-function
+  - serverless-post-function
+"""
+
+
+def _free_port() -> int:
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return probe.getsockname()[1]
+
+
+def _docker_available() -> bool:
+    if not shutil.which("docker"):
+        return False
+    return (
+        subprocess.run(
+            ["docker", "info"],  # noqa: S607
+            capture_output=True,
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+requires_docker = pytest.mark.skipif(
+    not _docker_available(),
+    reason="docker is required to run APISIX integration tests",
+)
+
+
+@pytest.fixture(scope="session")
+def apisix_routes() -> dict[str, Any]:
+    """Build the standalone route document from the real plugin helpers.
+
+    Routes point at a deliberately dead upstream: every assertion here is about
+    what the gateway itself does before proxying, and a request that reaches the
+    upstream is one the plugin correctly declined to intercept.
+    """
+    recovery = oidc_error_callback_recovery_plugin()
+    dead_upstream = {"type": "roundrobin", "nodes": {"127.0.0.1:1": 1}}
+    return {
+        "routes": [
+            {
+                "id": "login-prefix",
+                "uri": "/login/*",
+                "upstream": dead_upstream,
+                "plugins": {recovery.name: recovery.config},
+            },
+            {
+                "id": "nested-login-prefix",
+                "uri": "/learn/login/*",
+                "upstream": dead_upstream,
+                "plugins": {recovery.name: recovery.config},
+            },
+        ]
+    }
+
+
+@pytest.fixture(scope="session")
+def apisix(tmp_path_factory, apisix_routes) -> Generator[str]:
+    """Start APISIX on a free port and yield its base URL."""
+    conf_dir = tmp_path_factory.mktemp("apisix-conf")
+    (conf_dir / "config.yaml").write_text(CONFIG_YAML)
+    # APISIX's standalone loader requires the #END terminator.  JSON is a YAML
+    # subset, so dumping the document avoids depending on a YAML writer here.
+    (conf_dir / "apisix.yaml").write_text(
+        json.dumps(apisix_routes, indent=2) + "\n#END\n"
+    )
+
+    port = _free_port()
+    subprocess.run(  # noqa: S603
+        ["docker", "rm", "-f", CONTAINER_NAME],  # noqa: S607
+        capture_output=True,
+        check=False,
+    )
+    started = subprocess.run(  # noqa: S603
+        [  # noqa: S607
+            "docker",
+            "run",
+            "-d",
+            "--name",
+            CONTAINER_NAME,
+            "-p",
+            f"127.0.0.1:{port}:9080",
+            "-v",
+            f"{conf_dir / 'config.yaml'}:/usr/local/apisix/conf/config.yaml:ro",
+            "-v",
+            f"{conf_dir / 'apisix.yaml'}:/usr/local/apisix/conf/apisix.yaml:ro",
+            APISIX_IMAGE,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if started.returncode != 0:
+        pytest.fail(f"could not start APISIX: {started.stderr}")
+
+    base_url = f"http://127.0.0.1:{port}"
+    try:
+        _wait_until_ready(base_url)
+        yield base_url
+    finally:
+        logs = subprocess.run(  # noqa: S603
+            ["docker", "logs", CONTAINER_NAME],  # noqa: S607
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        subprocess.run(  # noqa: S603
+            ["docker", "rm", "-f", CONTAINER_NAME],  # noqa: S607
+            capture_output=True,
+            check=False,
+        )
+        # Surfaced on failure: a Lua syntax error or a rejected plugin config
+        # shows up in APISIX's error log, not in the HTTP response.
+        if logs.stdout or logs.stderr:
+            sys.stdout.write(f"\n--- APISIX logs ---\n{logs.stdout}{logs.stderr}")
+
+
+def _wait_until_ready(base_url: str) -> None:
+    """Poll until APISIX answers, rather than sleeping a fixed interval."""
+    http = urllib3.PoolManager(retries=False)
+    deadline = time.monotonic() + READY_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        try:
+            http.request("GET", f"{base_url}/", timeout=1.0)
+        except urllib3.exceptions.HTTPError:
+            time.sleep(0.5)
+        else:
+            return
+    pytest.fail(f"APISIX did not become ready within {READY_TIMEOUT_SECONDS}s")
+
+
+@pytest.fixture
+def callback(apisix):
+    """Request the OIDC callback and return (status, headers)."""
+
+    def _callback(
+        path: str = "/login/.apisix/redirect",
+        query: str = "",
+        cookies: dict[str, str] | None = None,
+    ) -> tuple[int, dict[str, str]]:
+        headers = {}
+        if cookies:
+            headers["Cookie"] = "; ".join(f"{k}={v}" for k, v in cookies.items())
+        response = urllib3.PoolManager(retries=False).request(
+            "GET",
+            f"{apisix}{path}{query}",
+            headers=headers,
+            redirect=False,
+            timeout=10.0,
+        )
+        return response.status, dict(response.headers)
+
+    return _callback

--- a/tests/apisix_integration/conftest.py
+++ b/tests/apisix_integration/conftest.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from collections.abc import Generator
 
 from ol_infrastructure.components.services.apisix import (
-    oidc_error_callback_recovery_plugin,
+    oidc_gateway_pre_function_plugin,
 )
 
 # Must track the APISIX shipped by the chart pinned in bridge.lib.versions
@@ -90,7 +90,14 @@ def apisix_routes() -> dict[str, Any]:
     what the gateway itself does before proxying, and a request that reaches the
     upstream is one the plugin correctly declined to intercept.
     """
-    recovery = oidc_error_callback_recovery_plugin()
+    # APISIX listens on plain HTTP here, so the canonical-origin function would
+    # upgrade every request before the recovery function ever ran -- which is
+    # the production behaviour, and is asserted directly on the routes below.
+    # The recovery routes therefore switch it off so they exercise the callback
+    # handling in isolation, exactly as they did before the two were fused into
+    # the single serverless-pre-function APISIX allows per plugin config.
+    recovery = oidc_gateway_pre_function_plugin(canonical_https_redirect=False)
+    full = oidc_gateway_pre_function_plugin()
     dead_upstream = {"type": "roundrobin", "nodes": {"127.0.0.1:1": 1}}
     return {
         "routes": [
@@ -105,6 +112,15 @@ def apisix_routes() -> dict[str, Any]:
                 "uri": "/learn/login/*",
                 "upstream": dead_upstream,
                 "plugins": {recovery.name: recovery.config},
+            },
+            # Not a catch-all: `_wait_until_ready` polls `/` and follows
+            # redirects, so a `/*` route carrying this plugin would send the
+            # readiness probe at an https origin that does not exist here.
+            {
+                "id": "canonical-origin",
+                "uri": "/origin/*",
+                "upstream": dead_upstream,
+                "plugins": {full.name: full.config},
             },
         ]
     }
@@ -207,3 +223,27 @@ def callback(apisix):
         return response.status, dict(response.headers)
 
     return _callback
+
+
+@pytest.fixture
+def origin_request(apisix):
+    """Request a canonical-origin route and return (status, headers).
+
+    Sends an explicit Host so the port-stripping and scheme-upgrade branches can
+    be driven independently of the container's own listen address.
+    """
+
+    def _origin_request(
+        path: str = "/origin/",
+        host: str = "nb.learn.mit.edu",
+    ) -> tuple[int, dict[str, str]]:
+        response = urllib3.PoolManager(retries=False).request(
+            "GET",
+            f"{apisix}{path}",
+            headers={"Host": host},
+            redirect=False,
+            timeout=10.0,
+        )
+        return response.status, dict(response.headers)
+
+    return _origin_request

--- a/tests/apisix_integration/conftest.py
+++ b/tests/apisix_integration/conftest.py
@@ -12,6 +12,7 @@ Skipped when Docker is unavailable.  ``APISIX_IT_IMAGE`` overrides the image.
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import socket
 import subprocess
@@ -31,8 +32,11 @@ from ol_infrastructure.components.services.apisix import (
 
 # Must track the APISIX shipped by the chart pinned in bridge.lib.versions
 # (APISIX_CHART 2.16.x => APISIX 3.17.x).  A mismatch here is the difference
-# between testing what runs in production and testing something else.
-APISIX_IMAGE = "apache/apisix:3.17.0-debian"
+# between testing what runs in production and testing something else -- which is
+# also why the override is an explicit environment variable rather than a
+# default that could drift: set APISIX_IT_IMAGE to rehearse a version bump
+# against this suite before moving the chart pin.
+APISIX_IMAGE = os.environ.get("APISIX_IT_IMAGE", "apache/apisix:3.17.0-debian")
 CONTAINER_NAME = "ol-apisix-integration-test"
 READY_TIMEOUT_SECONDS = 60
 

--- a/tests/apisix_integration/test_canonical_https_redirect.py
+++ b/tests/apisix_integration/test_canonical_https_redirect.py
@@ -1,0 +1,67 @@
+"""Canonical-origin behaviour, against a real APISIX.
+
+Every assertion here is something the stubbed unit tests cannot reach: that
+APISIX accepts a ``canonical_https_redirect`` block that is not in
+serverless-pre-function's schema, that ``ngx.var.host`` really does drop the
+port OpenResty received rather than a stub simply agreeing with us, and that
+``serverless-pre-function`` honours the array order these two functions depend
+on.
+
+See ``oidc_gateway_pre_function_plugin`` in
+src/ol_infrastructure/components/services/apisix.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.apisix_integration.conftest import requires_docker
+
+pytestmark = [requires_docker, pytest.mark.integration]
+
+
+def test_plain_http_is_upgraded_to_https(origin_request):
+    """The production failure: without this, openid-connect builds an http://
+    redirect_uri that Keycloak rejects, and APISIX answers with an OIDC session
+    cookie over cleartext.
+    """
+    status, headers = origin_request(path="/origin/hub/login")
+
+    assert status == 308
+    assert headers["Location"] == "https://nb.learn.mit.edu/origin/hub/login"
+
+
+def test_explicit_port_is_stripped_from_the_redirect_target(origin_request):
+    """``Host: <host>:443`` reaches lua-resty-openidc as ngx.var.http_host and
+    produces an authority Keycloak has no registration for.  Reproduced against
+    production on 2026-08-19.
+    """
+    status, headers = origin_request(host="nb.learn.mit.edu:443")
+
+    assert status == 308
+    assert headers["Location"] == "https://nb.learn.mit.edu/origin/"
+
+
+def test_query_string_is_preserved(origin_request):
+    """request_uri, not uri.  Dropping the query would break exactly the OIDC
+    callbacks this is meant to rescue.
+    """
+    _, headers = origin_request(path="/origin/login/.apisix/redirect?code=a&state=b")
+
+    assert headers["Location"] == (
+        "https://nb.learn.mit.edu/origin/login/.apisix/redirect?code=a&state=b"
+    )
+
+
+def test_upgrade_wins_over_error_recovery_on_the_same_plugin(origin_request):
+    """Both functions are attached to this route and the request is plain HTTP,
+    so the origin fix has to answer first.  Recovering here instead would send
+    the browser back into an http:// login and fail again at Keycloak.
+    """
+    status, headers = origin_request(
+        path="/origin/login/.apisix/redirect?error=temporarily_unavailable"
+    )
+
+    assert status == 308
+    assert headers["Location"].startswith("https://")
+    assert "apisix_oidc_recovery" not in headers.get("Set-Cookie", "")

--- a/tests/apisix_integration/test_oidc_error_callback_recovery.py
+++ b/tests/apisix_integration/test_oidc_error_callback_recovery.py
@@ -9,7 +9,7 @@ A 302 means the plugin intercepted.  Any other status means it declined and the
 request went on to the dead upstream, which in production is where the
 openid-connect plugin takes over.
 
-See ``oidc_error_callback_recovery_plugin`` in
+See ``oidc_gateway_pre_function_plugin`` in
 src/ol_infrastructure/components/services/apisix.py.
 """
 

--- a/tests/apisix_integration/test_oidc_error_callback_recovery.py
+++ b/tests/apisix_integration/test_oidc_error_callback_recovery.py
@@ -1,0 +1,140 @@
+"""The OIDC error-callback recovery plugin, against a real APISIX.
+
+Every assertion here is something the stubbed unit tests cannot reach: that
+APISIX accepts an ``oidc_error_recovery`` block that is not in
+serverless-pre-function's schema and exposes it on ``conf``, and that OpenResty
+emits the guard cookie on a redirect it generates itself.
+
+A 302 means the plugin intercepted.  Any other status means it declined and the
+request went on to the dead upstream, which in production is where the
+openid-connect plugin takes over.
+
+See ``oidc_error_callback_recovery_plugin`` in
+src/ol_infrastructure/components/services/apisix.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.apisix_integration.conftest import requires_docker
+
+pytestmark = [requires_docker, pytest.mark.integration]
+
+EXPIRED_SESSION = (
+    "?error=temporarily_unavailable&error_description=authentication_expired&state=x"
+)
+GUARD_COOKIE = "apisix_oidc_recovery"
+HTTP_FOUND = 302
+
+
+def test_expired_authentication_session_is_sent_back_through_login(callback):
+    """The production case: 614 callbacks a day arrive shaped like this and are
+    currently answered with a 21KB 500.
+    """
+    status, headers = callback(query=EXPIRED_SESSION)
+
+    assert status == HTTP_FOUND
+    assert headers["Location"] == "/login/"
+
+
+def test_guard_cookie_survives_ngx_redirect(callback):
+    """Set in the rewrite phase on a response ngx.redirect() generates.  A bot
+    reviewer predicted OpenResty drops it, which would make the loop guard
+    inert and risk an infinite redirect; this is the assertion that settles it
+    on the real runtime rather than by reading lua-nginx-module's source.
+    """
+    _, headers = callback(query=EXPIRED_SESSION)
+
+    assert headers["Set-Cookie"] == (
+        f"{GUARD_COOKIE}=1; Path=/; Max-Age=60; Secure; HttpOnly; SameSite=Lax"
+    )
+
+
+def test_settings_reach_the_plugin_through_an_unschemad_config_key(callback):
+    """``oidc_error_recovery`` is not part of serverless-pre-function's schema.
+    It arrives because the CRD preserves unknown fields, the ingress controller
+    holds plugin config as raw JSON, and APISIX's schema does not set
+    additionalProperties.  Recovering at all proves the whole chain: the Lua
+    reads its error list and cookie name off ``conf``, so if the block were
+    dropped there would be nothing to recover.
+    """
+    status, headers = callback(query=EXPIRED_SESSION)
+
+    assert status == HTTP_FOUND
+    assert GUARD_COOKIE in headers["Set-Cookie"]
+
+
+def test_redirect_target_follows_the_login_prefix(callback):
+    """mit-learn serves two route groups on one host.  Deriving the target from
+    the callback URI is what lets one attachment cover both.
+    """
+    _, headers = callback(path="/learn/login/.apisix/redirect", query=EXPIRED_SESSION)
+
+    assert headers["Location"] == "/learn/login/"
+
+
+def test_second_failure_falls_through_instead_of_looping(callback):
+    """A persistently broken IdP has to surface as an error, not spin the
+    browser between the gateway and Keycloak.
+    """
+    status, headers = callback(query=EXPIRED_SESSION, cookies={GUARD_COOKIE: "1"})
+
+    assert status != HTTP_FOUND
+    assert "Location" not in headers
+
+
+def test_guard_matches_the_whole_cookie_name(callback):
+    """Nginx parses the cookie header and exposes one variable per cookie, so a
+    cookie whose name merely contains the guard's must not disable recovery.
+    """
+    status, _ = callback(
+        query=EXPIRED_SESSION,
+        cookies={f"not_{GUARD_COOKIE}": "1"},
+    )
+
+    assert status == HTTP_FOUND
+
+
+def test_user_cancelling_login_is_not_recovered(callback):
+    """access_denied means the user pressed Cancel."""
+    status, _ = callback(query="?error=access_denied&state=x")
+
+    assert status != HTTP_FOUND
+
+
+def test_successful_callback_is_left_alone(callback):
+    """A real login carries a code and must reach openid-connect untouched."""
+    status, _ = callback(query="?code=abc123&state=x")
+
+    assert status != HTTP_FOUND
+
+
+def test_callback_without_an_error_parameter_is_left_alone(callback):
+    status, _ = callback()
+
+    assert status != HTTP_FOUND
+
+
+def test_other_routes_on_the_host_are_left_alone(callback):
+    """This hangs off a host's shared plugin config, so it runs in the rewrite
+    phase of every route on the host, not just the callback.
+    """
+    status, _ = callback(
+        path="/login/somewhere-else",
+        query="?error=temporarily_unavailable",
+    )
+
+    assert status != HTTP_FOUND
+
+
+def test_repeated_error_parameter_is_handled(callback):
+    """?error=a&error=b makes get_uri_args return a table rather than a string;
+    indexing it as a string would error out inside the rewrite phase.
+    """
+    status, headers = callback(
+        query="?error=temporarily_unavailable&error=something_else&state=x",
+    )
+
+    assert status == HTTP_FOUND
+    assert headers["Location"] == "/login/"

--- a/tests/apisix_integration/test_oidc_error_callback_recovery.py
+++ b/tests/apisix_integration/test_oidc_error_callback_recovery.py
@@ -128,6 +128,19 @@ def test_other_routes_on_the_host_are_left_alone(callback):
     assert status != HTTP_FOUND
 
 
+def test_a_path_merely_ending_in_the_callback_suffix_is_left_alone(callback):
+    """The suffix match includes the leading slash. Without it an application
+    path such as /login/foo.apisix/redirect also matches, and — since this is
+    attached host-wide — real requests would get redirected.
+    """
+    status, _ = callback(
+        path="/login/foo.apisix/redirect",
+        query=EXPIRED_SESSION,
+    )
+
+    assert status != HTTP_FOUND
+
+
 def test_repeated_error_parameter_is_handled(callback):
     """?error=a&error=b makes get_uri_args return a table rather than a string;
     indexing it as a string would error out inside the rewrite phase.

--- a/tests/apisix_testnginx/Dockerfile
+++ b/tests/apisix_testnginx/Dockerfile
@@ -1,0 +1,95 @@
+# DL3008: Debian package versions are not pinned here, matching
+#   dockerfiles/ol-python-base.  This is a throwaway test image, and pinning
+#   would break the build every time Debian rolls a patch release.
+# DL3002/DL3066: the image ends as root on purpose -- the test-nginx harness
+#   writes t/servroot and binds a listener.  Nothing is published from it.
+# hadolint global ignore=DL3008,DL3002,DL3066
+#
+# Runs APISIX's own test-nginx harness against the Lua in this repo.
+#
+# Built on the same image the cluster runs (see APISIX_CHART in
+# bridge/lib/versions.py -- chart 2.16.x ships APISIX 3.17.x), so the Lua is
+# exercised by the same OpenResty build, with APISIX's real lua_package_path.
+#
+# t/APISIX.pm and the certs it reads are fetched at build time rather than
+# vendored: they are upstream test fixtures, and the key files would trip
+# secret scanning if committed here.
+ARG APISIX_VERSION=3.17.0
+FROM apache/apisix:${APISIX_VERSION}-debian
+
+# Repeated with its default: a global ARG's default is not inherited by a
+# stage-level redeclaration, so omitting it here silently yields an empty string
+# and the fetch below 404s.
+ARG APISIX_VERSION=3.17.0
+USER root
+
+# The image ships a minimal perl with no prove and no Test::Harness, so the
+# harness and its toolchain have to be installed outright.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        perl \
+        cpanminus \
+        make \
+        gcc \
+        libc6-dev \
+        libssl-dev \
+        curl \
+        ca-certificates \
+    && cpanm --notest --quiet Test::Nginx IPC::Run3 \
+    && apt-get purge -y --auto-remove gcc make libc6-dev \
+    && rm -rf /var/lib/apt/lists/* /root/.cpanm
+
+WORKDIR /usr/local/apisix
+
+# APISIX.pm and the cert fixtures it opens, taken from the source tarball for
+# the version this image runs.
+#
+# One request for the whole tarball, not one per file: fetching the nine files
+# individually from raw.githubusercontent.com reliably trips its rate limiter
+# (HTTP 429) and turned this build into a coin flip.  --retry rides out the
+# remaining transient failures so a rate limit does not read as a test failure.
+RUN set -eu; \
+    curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors \
+        -o /tmp/apisix-src.tar.gz \
+        "https://github.com/apache/apisix/archive/refs/tags/${APISIX_VERSION}.tar.gz"; \
+    tar -xzf /tmp/apisix-src.tar.gz -C /tmp; \
+    src="/tmp/apisix-${APISIX_VERSION}"; \
+    mkdir -p t/certs; \
+    cp "${src}/t/APISIX.pm" t/APISIX.pm; \
+    for cert in apisix.crt apisix.key apisix_ecc.crt apisix_ecc.key \
+                test2.crt test2.key etcd.pem etcd.key; do \
+        cp "${src}/t/certs/${cert}" "t/certs/${cert}"; \
+    done; \
+    rm -rf /tmp/apisix-src.tar.gz "${src}"
+
+# etcd, because APISIX.pm boots APISIX's real init path -- which reaches for
+# etcd whatever the test asserts.  Without it every test fails test-nginx's
+# default "no [error] in error.log" check on connection-refused noise.  Giving
+# the harness a real etcd is the honest fix; filtering those lines out would
+# also hide errors we do want to see.
+ARG ETCD_VERSION=3.5.21
+RUN set -eu; \
+    arch="$(dpkg --print-architecture)"; \
+    curl -fsSL --retry 5 --retry-delay 3 --retry-all-errors \
+        -o /tmp/etcd.tar.gz \
+        "https://github.com/etcd-io/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-linux-${arch}.tar.gz"; \
+    tar -xzf /tmp/etcd.tar.gz -C /tmp; \
+    mv "/tmp/etcd-v${ETCD_VERSION}-linux-${arch}/etcd" /usr/local/bin/etcd; \
+    rm -rf /tmp/etcd.tar.gz "/tmp/etcd-v${ETCD_VERSION}-linux-${arch}"; \
+    etcd --version
+
+# The Lua under test, taken from the one place it lives.  Build context is the
+# repository root (see run.sh) precisely so this can reference src/ directly --
+# copying the file into this directory instead would leave a second copy free to
+# drift, and the suite would then pass against Lua the gateway never runs.
+COPY src/ol_infrastructure/components/services/files/oidc_error_callback_recovery.lua \
+     apisix/plugins/ol/
+COPY tests/apisix_testnginx/oidc_error_callback_recovery.t t/
+COPY tests/apisix_testnginx/run-tests.sh /usr/local/bin/run-tests.sh
+RUN chmod +x /usr/local/bin/run-tests.sh
+
+ENV APISIX_HOME=/usr/local/apisix
+ENV TEST_NGINX_BINARY=/usr/local/openresty/bin/openresty
+ENV PERL5LIB=/usr/local/apisix
+
+ENTRYPOINT ["/usr/local/bin/run-tests.sh"]

--- a/tests/apisix_testnginx/Dockerfile
+++ b/tests/apisix_testnginx/Dockerfile
@@ -83,8 +83,11 @@ RUN set -eu; \
 # copying the file into this directory instead would leave a second copy free to
 # drift, and the suite would then pass against Lua the gateway never runs.
 COPY src/ol_infrastructure/components/services/files/oidc_error_callback_recovery.lua \
+     src/ol_infrastructure/components/services/files/canonical_https_redirect.lua \
      apisix/plugins/ol/
-COPY tests/apisix_testnginx/oidc_error_callback_recovery.t t/
+COPY tests/apisix_testnginx/oidc_error_callback_recovery.t \
+     tests/apisix_testnginx/canonical_https_redirect.t \
+     t/
 COPY tests/apisix_testnginx/run-tests.sh /usr/local/bin/run-tests.sh
 RUN chmod +x /usr/local/bin/run-tests.sh
 

--- a/tests/apisix_testnginx/canonical_https_redirect.t
+++ b/tests/apisix_testnginx/canonical_https_redirect.t
@@ -1,0 +1,147 @@
+#
+# APISIX test-nginx coverage for the canonical-origin redirect function.
+#
+# This layer runs the shipped Lua inside the same OpenResty build the gateway
+# uses, which is the only place the central assumption can actually be checked:
+# that $host is the Host header lowercased with the port stripped while
+# $http_host is the header verbatim.  A stub can be made to agree with us about
+# that; nginx cannot.
+#
+# The scheme is always http here, so the "already canonical, do nothing" case
+# is covered by the unit and container layers instead -- test-nginx gives us no
+# way to present an https connection to the function.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+log_level('info');
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: a plain-HTTP request is upgraded to the https origin
+--- config
+    location /t {
+        rewrite_by_lua_block {
+            local canonical = require("apisix.plugins.ol.canonical_https_redirect")
+            canonical({canonical_https_redirect = {status = 308}}, {var = {}})
+        }
+        content_by_lua_block {
+            ngx.say("not reached")
+        }
+    }
+--- more_headers
+Host: nb.learn.mit.edu
+--- request
+GET /t/hub/login
+--- error_code: 308
+--- response_headers
+Location: https://nb.learn.mit.edu/t/hub/login
+
+
+
+=== TEST 2: an explicit :443 in the Host header is stripped from the target
+--- config
+    location /t {
+        rewrite_by_lua_block {
+            local canonical = require("apisix.plugins.ol.canonical_https_redirect")
+            canonical({canonical_https_redirect = {status = 308}}, {var = {}})
+        }
+        content_by_lua_block {
+            ngx.say("not reached")
+        }
+    }
+--- more_headers
+Host: nb.learn.mit.edu:443
+--- request
+GET /t/
+--- error_code: 308
+--- response_headers
+Location: https://nb.learn.mit.edu/t/
+
+
+
+=== TEST 3: an uppercased host is canonicalised to lower case
+--- config
+    location /t {
+        rewrite_by_lua_block {
+            local canonical = require("apisix.plugins.ol.canonical_https_redirect")
+            canonical({canonical_https_redirect = {status = 308}}, {var = {}})
+        }
+        content_by_lua_block {
+            ngx.say("not reached")
+        }
+    }
+--- more_headers
+Host: NB.Learn.MIT.edu
+--- request
+GET /t/
+--- error_code: 308
+--- response_headers
+Location: https://nb.learn.mit.edu/t/
+
+
+
+=== TEST 4: the query string survives the upgrade
+--- config
+    location /t {
+        rewrite_by_lua_block {
+            local canonical = require("apisix.plugins.ol.canonical_https_redirect")
+            canonical({canonical_https_redirect = {status = 308}}, {var = {}})
+        }
+        content_by_lua_block {
+            ngx.say("not reached")
+        }
+    }
+--- more_headers
+Host: api.learn.mit.edu
+--- request
+GET /t/login/.apisix/redirect?code=abc&state=xyz
+--- error_code: 308
+--- response_headers
+Location: https://api.learn.mit.edu/t/login/.apisix/redirect?code=abc&state=xyz
+
+
+
+=== TEST 5: the status code is taken from the plugin config
+--- config
+    location /t {
+        rewrite_by_lua_block {
+            local canonical = require("apisix.plugins.ol.canonical_https_redirect")
+            canonical({canonical_https_redirect = {status = 301}}, {var = {}})
+        }
+        content_by_lua_block {
+            ngx.say("not reached")
+        }
+    }
+--- more_headers
+Host: nb.learn.mit.edu
+--- request
+GET /t/
+--- error_code: 301
+--- response_headers
+Location: https://nb.learn.mit.edu/t/
+
+
+
+=== TEST 6: an absent config block falls back to 308
+--- config
+    location /t {
+        rewrite_by_lua_block {
+            local canonical = require("apisix.plugins.ol.canonical_https_redirect")
+            canonical({}, {var = {}})
+        }
+        content_by_lua_block {
+            ngx.say("not reached")
+        }
+    }
+--- more_headers
+Host: nb.learn.mit.edu
+--- request
+GET /t/
+--- error_code: 308
+--- response_headers
+Location: https://nb.learn.mit.edu/t/

--- a/tests/apisix_testnginx/oidc_error_callback_recovery.t
+++ b/tests/apisix_testnginx/oidc_error_callback_recovery.t
@@ -1,0 +1,177 @@
+#
+# APISIX test-nginx coverage for the OIDC error-callback recovery function.
+#
+# This layer runs the shipped Lua inside the same OpenResty build the gateway
+# uses, so it catches anything that depends on the real ngx API rather than on
+# our stubs: Lua pattern behaviour, ngx.header on a response ngx.redirect()
+# generates, and nginx's own $cookie_<name> parsing.
+#
+# The container tests in tests/apisix_integration drive a full APISIX and cover
+# the plugin-config path; this one isolates the function so a failure points at
+# the Lua rather than at routing or schema validation.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+log_level('info');
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: an expired authentication session is redirected back through login
+--- config
+    location /t {
+        rewrite_by_lua_block {
+            local recover = require("apisix.plugins.ol.oidc_error_callback_recovery")
+            local conf = {
+                oidc_error_recovery = {
+                    recoverable_errors = {"temporarily_unavailable"},
+                    guard_cookie_name = "apisix_oidc_recovery",
+                    guard_max_age = 60,
+                },
+            }
+            recover(conf, {var = {}})
+        }
+        content_by_lua_block {
+            ngx.say("not reached")
+        }
+    }
+--- request
+GET /t/login/.apisix/redirect?error=temporarily_unavailable&state=x
+--- error_code: 302
+--- response_headers
+Location: /t/login/
+Set-Cookie: apisix_oidc_recovery=1; Path=/; Max-Age=60; Secure; HttpOnly; SameSite=Lax
+
+
+
+=== TEST 2: a successful callback carrying a code is left alone
+--- config
+    location /t {
+        rewrite_by_lua_block {
+            local recover = require("apisix.plugins.ol.oidc_error_callback_recovery")
+            local conf = {
+                oidc_error_recovery = {
+                    recoverable_errors = {"temporarily_unavailable"},
+                    guard_cookie_name = "apisix_oidc_recovery",
+                    guard_max_age = 60,
+                },
+            }
+            recover(conf, {var = {}})
+        }
+        content_by_lua_block {
+            ngx.say("passed through")
+        }
+    }
+--- request
+GET /t/login/.apisix/redirect?code=abc123&state=x
+--- response_body
+passed through
+
+
+
+=== TEST 3: access_denied keeps failing rather than restarting the flow
+--- config
+    location /t {
+        rewrite_by_lua_block {
+            local recover = require("apisix.plugins.ol.oidc_error_callback_recovery")
+            local conf = {
+                oidc_error_recovery = {
+                    recoverable_errors = {"temporarily_unavailable"},
+                    guard_cookie_name = "apisix_oidc_recovery",
+                    guard_max_age = 60,
+                },
+            }
+            recover(conf, {var = {}})
+        }
+        content_by_lua_block {
+            ngx.say("passed through")
+        }
+    }
+--- request
+GET /t/login/.apisix/redirect?error=access_denied&state=x
+--- response_body
+passed through
+
+
+
+=== TEST 4: the guard cookie breaks the loop on a second failure
+--- config
+    location /t {
+        rewrite_by_lua_block {
+            local recover = require("apisix.plugins.ol.oidc_error_callback_recovery")
+            local conf = {
+                oidc_error_recovery = {
+                    recoverable_errors = {"temporarily_unavailable"},
+                    guard_cookie_name = "apisix_oidc_recovery",
+                    guard_max_age = 60,
+                },
+            }
+            -- nginx parses the cookie header; $cookie_<name> is what the
+            -- function reads, so feed it through ctx.var the same way APISIX does.
+            recover(conf, {var = {cookie_apisix_oidc_recovery = ngx.var.cookie_apisix_oidc_recovery}})
+        }
+        content_by_lua_block {
+            ngx.say("passed through")
+        }
+    }
+--- request
+GET /t/login/.apisix/redirect?error=temporarily_unavailable&state=x
+--- more_headers
+Cookie: apisix_oidc_recovery=1
+--- response_body
+passed through
+
+
+
+=== TEST 5: a non-callback URI on the same host is untouched
+--- config
+    location /t {
+        rewrite_by_lua_block {
+            local recover = require("apisix.plugins.ol.oidc_error_callback_recovery")
+            local conf = {
+                oidc_error_recovery = {
+                    recoverable_errors = {"temporarily_unavailable"},
+                    guard_cookie_name = "apisix_oidc_recovery",
+                    guard_max_age = 60,
+                },
+            }
+            recover(conf, {var = {}})
+        }
+        content_by_lua_block {
+            ngx.say("passed through")
+        }
+    }
+--- request
+GET /t/login/elsewhere?error=temporarily_unavailable
+--- response_body
+passed through
+
+
+
+=== TEST 6: a repeated error parameter arrives as a table
+--- config
+    location /t {
+        rewrite_by_lua_block {
+            local recover = require("apisix.plugins.ol.oidc_error_callback_recovery")
+            local conf = {
+                oidc_error_recovery = {
+                    recoverable_errors = {"temporarily_unavailable"},
+                    guard_cookie_name = "apisix_oidc_recovery",
+                    guard_max_age = 60,
+                },
+            }
+            recover(conf, {var = {}})
+        }
+        content_by_lua_block {
+            ngx.say("not reached")
+        }
+    }
+--- request
+GET /t/login/.apisix/redirect?error=temporarily_unavailable&error=other&state=x
+--- error_code: 302
+--- response_headers
+Location: /t/login/

--- a/tests/apisix_testnginx/oidc_error_callback_recovery.t
+++ b/tests/apisix_testnginx/oidc_error_callback_recovery.t
@@ -175,3 +175,27 @@ GET /t/login/.apisix/redirect?error=temporarily_unavailable&error=other&state=x
 --- error_code: 302
 --- response_headers
 Location: /t/login/
+
+
+=== TEST 7: a path merely ending in the callback suffix is untouched
+--- config
+    location /t {
+        rewrite_by_lua_block {
+            local recover = require("apisix.plugins.ol.oidc_error_callback_recovery")
+            local conf = {
+                oidc_error_recovery = {
+                    recoverable_errors = {"temporarily_unavailable"},
+                    guard_cookie_name = "apisix_oidc_recovery",
+                    guard_max_age = 60,
+                },
+            }
+            recover(conf, {var = {}})
+        }
+        content_by_lua_block {
+            ngx.say("passed through")
+        }
+    }
+--- request
+GET /t/login/foo.apisix/redirect?error=temporarily_unavailable&state=x
+--- response_body
+passed through

--- a/tests/apisix_testnginx/run-tests.sh
+++ b/tests/apisix_testnginx/run-tests.sh
@@ -43,4 +43,4 @@ until etcdctl --endpoints=http://127.0.0.1:2379 endpoint health >/dev/null 2>&1 
 done
 
 cd "${APISIX_HOME}"
-exec prove -v "$@" t/oidc_error_callback_recovery.t
+exec prove -v "$@" t/oidc_error_callback_recovery.t t/canonical_https_redirect.t

--- a/tests/apisix_testnginx/run-tests.sh
+++ b/tests/apisix_testnginx/run-tests.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Bring up etcd, then run the test-nginx suite against it.
+#
+# APISIX.pm boots APISIX's real init path, which connects to etcd regardless of
+# what a given test asserts. Starting etcd here keeps that noise out of
+# error.log, which test-nginx checks by default.
+set -euo pipefail
+
+ETCD_DATA_DIR=${ETCD_DATA_DIR:-/tmp/etcd-data}
+ETCD_READY_TIMEOUT=${ETCD_READY_TIMEOUT:-30}
+
+rm -rf "${ETCD_DATA_DIR}"
+mkdir -p "${ETCD_DATA_DIR}"
+
+etcd \
+    --data-dir "${ETCD_DATA_DIR}" \
+    --listen-client-urls 'http://127.0.0.1:2379' \
+    --advertise-client-urls 'http://127.0.0.1:2379' \
+    --listen-peer-urls 'http://127.0.0.1:2380' \
+    --initial-advertise-peer-urls 'http://127.0.0.1:2380' \
+    --initial-cluster 'default=http://127.0.0.1:2380' \
+    --log-level error \
+    >/tmp/etcd.log 2>&1 &
+etcd_pid=$!
+
+cleanup() {
+    kill "${etcd_pid}" 2>/dev/null || true
+    wait "${etcd_pid}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Poll rather than sleep: APISIX's init fails outright if etcd is not yet
+# answering, which would surface as a confusing test failure.
+deadline=$((SECONDS + ETCD_READY_TIMEOUT))
+until etcdctl --endpoints=http://127.0.0.1:2379 endpoint health >/dev/null 2>&1 \
+      || curl -fsS -o /dev/null http://127.0.0.1:2379/version 2>/dev/null; do
+    if (( SECONDS >= deadline )); then
+        echo "etcd did not become ready within ${ETCD_READY_TIMEOUT}s" >&2
+        cat /tmp/etcd.log >&2
+        exit 1
+    fi
+    sleep 0.5
+done
+
+cd "${APISIX_HOME}"
+exec prove -v "$@" t/oidc_error_callback_recovery.t

--- a/tests/apisix_testnginx/run.sh
+++ b/tests/apisix_testnginx/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Build and run the test-nginx suite for this repo's APISIX Lua.
+#
+#   tests/apisix_testnginx/run.sh
+#
+# Build context is the repository root so the Dockerfile can copy the Lua from
+# src/ rather than from a second copy kept in this directory.
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+image=${APISIX_TESTNGINX_IMAGE:-ol-apisix-testnginx}
+
+cd "${repo_root}"
+docker build -t "${image}" -f tests/apisix_testnginx/Dockerfile .
+# --user root: the harness writes t/servroot and needs to bind a listener.
+exec docker run --rm --user root "${image}" "$@"

--- a/tests/ol_infrastructure/components/services/test_apisix.py
+++ b/tests/ol_infrastructure/components/services/test_apisix.py
@@ -359,60 +359,69 @@ def test_recovery_plugin_runs_in_rewrite_before_openid_connect():
     assert plugin.config["phase"] == "rewrite"
 
 
-def test_recovery_plugin_only_recovers_transient_errors_by_default():
+def test_recovery_plugin_defaults_to_the_only_error_production_emits():
     """access_denied means the user pressed Cancel -- restarting the flow there
     would bounce the browser between the gateway and Keycloak.
     """
-    (lua,) = oidc_error_callback_recovery_plugin().config["functions"]
+    options = oidc_error_callback_recovery_plugin().config["oidc_error_recovery"]
 
-    assert '["temporarily_unavailable"] = true' in lua
-    assert "access_denied" not in lua
+    assert options["recoverable_errors"] == ["temporarily_unavailable"]
 
 
 def test_recovery_plugin_honours_a_custom_error_list():
-    (lua,) = oidc_error_callback_recovery_plugin(
+    options = oidc_error_callback_recovery_plugin(
         recoverable_errors=["temporarily_unavailable", "server_error"],
-    ).config["functions"]
+    ).config["oidc_error_recovery"]
 
-    assert '["temporarily_unavailable"] = true' in lua
-    assert '["server_error"] = true' in lua
+    assert options["recoverable_errors"] == ["temporarily_unavailable", "server_error"]
 
 
 def test_recovery_plugin_honours_an_explicit_empty_error_list():
     """An empty list means "recover nothing" -- the way to make the plugin a
     no-op without detaching it from every route on a shared config.
     """
-    (lua,) = oidc_error_callback_recovery_plugin(
+    options = oidc_error_callback_recovery_plugin(
         recoverable_errors=[],
+    ).config["oidc_error_recovery"]
+
+    assert options["recoverable_errors"] == []
+
+
+def test_recovery_plugin_passes_guard_settings_as_config():
+    """Tunables travel on the plugin config and are read off ``conf`` in Lua,
+    so nothing is interpolated into the shipped source.
+    """
+    options = oidc_error_callback_recovery_plugin(
+        guard_cookie_name="custom_guard",
+        guard_max_age=90,
+    ).config["oidc_error_recovery"]
+
+    assert options["guard_cookie_name"] == "custom_guard"
+    assert options["guard_max_age"] == 90
+
+
+def test_recovery_plugin_ships_the_lua_file_verbatim():
+    """The function body is the checked-in .lua file, not a generated string --
+    no configuration is interpolated into it.
+    """
+    (source,) = oidc_error_callback_recovery_plugin(
+        guard_cookie_name="custom_guard",
+        recoverable_errors=["server_error"],
     ).config["functions"]
 
-    assert "local recoverable = {}" in lua
-    assert "temporarily_unavailable" not in lua
+    assert source == apisix_module.OIDC_ERROR_RECOVERY_LUA
+    assert "custom_guard" not in source
+    assert "server_error" not in source
 
 
-def test_recovery_plugin_ignores_non_callback_requests():
-    """Attached to a host's shared plugin config, this sees every route."""
-    (lua,) = oidc_error_callback_recovery_plugin().config["functions"]
+def test_recovery_lua_reads_its_settings_off_conf():
+    """Guards the contract between the .lua file and the config block above."""
+    source = apisix_module.OIDC_ERROR_RECOVERY_LUA
 
-    assert 'uri:match("%.apisix/redirect$")' in lua
-
-
-def test_recovery_plugin_redirects_to_the_callback_s_parent_path():
-    """The parent of <login prefix>/.apisix/redirect is the auth-required route
-    that started the flow, so it re-enters authorization.
-    """
-    (lua,) = oidc_error_callback_recovery_plugin().config["functions"]
-
-    assert 'ngx.redirect((uri:gsub("%.apisix/redirect$", "")), 302)' in lua
-
-
-def test_recovery_plugin_breaks_redirect_loops_with_a_guard_cookie():
-    """A second callback with the same error must 500 rather than loop."""
-    (lua,) = oidc_error_callback_recovery_plugin(guard_max_age=90).config["functions"]
-
-    assert '== "apisix_oidc_recovery"' in lua
-    assert '"90"' in lua
-    assert "Max-Age=" in lua
+    assert "conf.oidc_error_recovery" in source
+    assert "opts.recoverable_errors" in source
+    assert "opts.guard_cookie_name" in source
+    assert "opts.guard_max_age" in source
 
 
 # ─── Shared plugin defaults ────────────────────────────────────────────────────
@@ -573,7 +582,17 @@ def test_recovery_plugin_renders_into_the_v2_plugin_config():
         recovery = plugin_named(spec["plugins"], "serverless-pre-function")
         assert recovery is not None
         assert recovery["config"]["phase"] == "rewrite"
-        assert "temporarily_unavailable" in recovery["config"]["functions"][0]
+        # The settings block is not part of serverless-pre-function's schema.
+        # It reaches the gateway because the CRD marks config
+        # x-kubernetes-preserve-unknown-fields, the controller holds it as raw
+        # apiextensionsv1.JSON, ADC as map[string]any, and APISIX's serverless
+        # schema does not set additionalProperties.  If a future version
+        # tightens any of those, this is the assertion that should fail first.
+        assert recovery["config"]["oidc_error_recovery"] == {
+            "recoverable_errors": ["temporarily_unavailable"],
+            "guard_cookie_name": "apisix_oidc_recovery",
+            "guard_max_age": 60,
+        }
 
     return plugins.shared_plugin_apisix_pluginconfig_resource.spec.apply(check)
 

--- a/tests/ol_infrastructure/components/services/test_apisix.py
+++ b/tests/ol_infrastructure/components/services/test_apisix.py
@@ -52,7 +52,7 @@ from ol_infrastructure.components.services.apisix import (  # noqa: E402
     OLApisixSharedPluginsConfig,
     OLApisixUpstream,
     OLApisixUpstreamConfig,
-    oidc_error_callback_recovery_plugin,
+    oidc_gateway_pre_function_plugin,
     stale_session_cookie_cleanup_plugin,
 )
 
@@ -353,7 +353,7 @@ def test_cleanup_plugin_honours_a_custom_stale_name():
 
 def test_recovery_plugin_runs_in_rewrite_before_openid_connect():
     """openid-connect runs in rewrite; the access phase would be too late."""
-    plugin = oidc_error_callback_recovery_plugin()
+    plugin = oidc_gateway_pre_function_plugin()
 
     assert plugin.name == "serverless-pre-function"
     assert plugin.config["phase"] == "rewrite"
@@ -363,13 +363,13 @@ def test_recovery_plugin_defaults_to_the_only_error_production_emits():
     """access_denied means the user pressed Cancel -- restarting the flow there
     would bounce the browser between the gateway and Keycloak.
     """
-    options = oidc_error_callback_recovery_plugin().config["oidc_error_recovery"]
+    options = oidc_gateway_pre_function_plugin().config["oidc_error_recovery"]
 
     assert options["recoverable_errors"] == ["temporarily_unavailable"]
 
 
 def test_recovery_plugin_honours_a_custom_error_list():
-    options = oidc_error_callback_recovery_plugin(
+    options = oidc_gateway_pre_function_plugin(
         recoverable_errors=["temporarily_unavailable", "server_error"],
     ).config["oidc_error_recovery"]
 
@@ -380,7 +380,7 @@ def test_recovery_plugin_honours_an_explicit_empty_error_list():
     """An empty list means "recover nothing" -- the way to make the plugin a
     no-op without detaching it from every route on a shared config.
     """
-    options = oidc_error_callback_recovery_plugin(
+    options = oidc_gateway_pre_function_plugin(
         recoverable_errors=[],
     ).config["oidc_error_recovery"]
 
@@ -391,7 +391,7 @@ def test_recovery_plugin_passes_guard_settings_as_config():
     """Tunables travel on the plugin config and are read off ``conf`` in Lua,
     so nothing is interpolated into the shipped source.
     """
-    options = oidc_error_callback_recovery_plugin(
+    options = oidc_gateway_pre_function_plugin(
         guard_cookie_name="custom_guard",
         guard_max_age=90,
     ).config["oidc_error_recovery"]
@@ -400,18 +400,75 @@ def test_recovery_plugin_passes_guard_settings_as_config():
     assert options["guard_max_age"] == 90
 
 
-def test_recovery_plugin_ships_the_lua_file_verbatim():
-    """The function body is the checked-in .lua file, not a generated string --
-    no configuration is interpolated into it.
+def test_recovery_plugin_ships_the_lua_files_verbatim():
+    """The function bodies are the checked-in .lua files, not generated strings --
+    no configuration is interpolated into either.
     """
-    (source,) = oidc_error_callback_recovery_plugin(
+    sources = oidc_gateway_pre_function_plugin(
         guard_cookie_name="custom_guard",
         recoverable_errors=["server_error"],
+        canonical_redirect_status=301,
     ).config["functions"]
 
-    assert source == apisix_module.OIDC_ERROR_RECOVERY_LUA
-    assert "custom_guard" not in source
-    assert "server_error" not in source
+    assert sources == [
+        apisix_module.CANONICAL_HTTPS_REDIRECT_LUA,
+        apisix_module.OIDC_ERROR_RECOVERY_LUA,
+    ]
+    for source in sources:
+        assert "custom_guard" not in source
+        assert "server_error" not in source
+
+
+def test_canonical_redirect_runs_before_error_recovery():
+    """serverless/init.lua stops at the first function returning a code, so the
+    origin has to be canonical before the recovery function can redirect back
+    into a login flow -- otherwise recovery would target an http:// origin.
+    """
+    sources = oidc_gateway_pre_function_plugin().config["functions"]
+
+    assert "canonical_https_redirect" in sources[0]
+    assert "oidc_error_recovery" in sources[1]
+
+
+def test_canonical_redirect_status_reaches_the_config_block():
+    config = oidc_gateway_pre_function_plugin(canonical_redirect_status=301).config
+
+    assert config["canonical_https_redirect"]["status"] == 301
+
+
+@pytest.mark.parametrize("status", [301, 302, 303, 307, 308])
+def test_every_status_ngx_redirect_accepts_is_allowed(status):
+    config = oidc_gateway_pre_function_plugin(canonical_redirect_status=status).config
+
+    assert config["canonical_https_redirect"]["status"] == status
+
+
+@pytest.mark.parametrize("status", [200, 304, 305, 418, 500])
+def test_a_status_ngx_redirect_rejects_fails_at_preview(status):
+    """ngx.redirect raises a Lua error outside {301,302,303,307,308}, and the
+    config block carrying this is not in serverless-pre-function's schema, so
+    APISIX would not reject it either -- an unchecked value would first surface
+    as a 500 on live traffic.  This has to fail while the stack is being built.
+    """
+    with pytest.raises(ValueError, match=r"ngx\.redirect rejects anything else"):
+        oidc_gateway_pre_function_plugin(canonical_redirect_status=status)
+
+
+def test_canonical_redirect_can_be_disabled():
+    """A host that must keep answering on plain HTTP drops the function without
+    losing the error-callback recovery it necessarily shares a plugin with.
+    """
+    config = oidc_gateway_pre_function_plugin(canonical_https_redirect=False).config
+
+    assert config["functions"] == [apisix_module.OIDC_ERROR_RECOVERY_LUA]
+
+
+def test_canonical_redirect_lua_reads_its_settings_off_conf():
+    """Guards the contract between the .lua file and the config block above."""
+    source = apisix_module.CANONICAL_HTTPS_REDIRECT_LUA
+
+    assert "conf.canonical_https_redirect" in source
+    assert "opts.status" in source
 
 
 def test_recovery_lua_reads_its_settings_off_conf():
@@ -575,7 +632,7 @@ def test_recovery_plugin_renders_into_the_v2_plugin_config():
     """
     plugins = shared_plugins(
         "test-shared-plugins-oidc-recovery-v2",
-        plugins=[oidc_error_callback_recovery_plugin()],
+        plugins=[oidc_gateway_pre_function_plugin()],
     )
 
     def check(spec):
@@ -604,7 +661,7 @@ def test_recovery_plugin_reaches_the_gateway_api_plugin_config():
     """
     plugins = shared_plugins(
         "test-shared-plugins-oidc-recovery-gateway-api",
-        plugins=[oidc_error_callback_recovery_plugin()],
+        plugins=[oidc_gateway_pre_function_plugin()],
     )
 
     def check(spec):

--- a/tests/ol_infrastructure/components/services/test_apisix.py
+++ b/tests/ol_infrastructure/components/services/test_apisix.py
@@ -52,6 +52,7 @@ from ol_infrastructure.components.services.apisix import (  # noqa: E402
     OLApisixSharedPluginsConfig,
     OLApisixUpstream,
     OLApisixUpstreamConfig,
+    oidc_error_callback_recovery_plugin,
     stale_session_cookie_cleanup_plugin,
 )
 
@@ -347,6 +348,61 @@ def test_cleanup_plugin_honours_a_custom_stale_name():
     assert 'name == "mitlearn_apisix_session"' in lua
 
 
+# ─── OIDC error callback recovery ──────────────────────────────────────────────
+
+
+def test_recovery_plugin_runs_in_rewrite_before_openid_connect():
+    """openid-connect runs in rewrite; the access phase would be too late."""
+    plugin = oidc_error_callback_recovery_plugin()
+
+    assert plugin.name == "serverless-pre-function"
+    assert plugin.config["phase"] == "rewrite"
+
+
+def test_recovery_plugin_only_recovers_transient_errors_by_default():
+    """access_denied means the user pressed Cancel -- restarting the flow there
+    would bounce the browser between the gateway and Keycloak.
+    """
+    (lua,) = oidc_error_callback_recovery_plugin().config["functions"]
+
+    assert '["temporarily_unavailable"] = true' in lua
+    assert "access_denied" not in lua
+
+
+def test_recovery_plugin_honours_a_custom_error_list():
+    (lua,) = oidc_error_callback_recovery_plugin(
+        recoverable_errors=["temporarily_unavailable", "server_error"],
+    ).config["functions"]
+
+    assert '["temporarily_unavailable"] = true' in lua
+    assert '["server_error"] = true' in lua
+
+
+def test_recovery_plugin_ignores_non_callback_requests():
+    """Attached to a host's shared plugin config, this sees every route."""
+    (lua,) = oidc_error_callback_recovery_plugin().config["functions"]
+
+    assert 'uri:match("%.apisix/redirect$")' in lua
+
+
+def test_recovery_plugin_redirects_to_the_callback_s_parent_path():
+    """The parent of <login prefix>/.apisix/redirect is the auth-required route
+    that started the flow, so it re-enters authorization.
+    """
+    (lua,) = oidc_error_callback_recovery_plugin().config["functions"]
+
+    assert 'ngx.redirect((uri:gsub("%.apisix/redirect$", "")), 302)' in lua
+
+
+def test_recovery_plugin_breaks_redirect_loops_with_a_guard_cookie():
+    """A second callback with the same error must 500 rather than loop."""
+    (lua,) = oidc_error_callback_recovery_plugin(guard_max_age=90).config["functions"]
+
+    assert '== "apisix_oidc_recovery"' in lua
+    assert '"90"' in lua
+    assert "Max-Age=" in lua
+
+
 # ─── Shared plugin defaults ────────────────────────────────────────────────────
 
 
@@ -487,6 +543,43 @@ def test_gzip_reaches_the_gateway_api_plugin_config():
         assert gzip is not None
         # v1alpha1 accepts only name and config -- ``enable`` is v2-only.
         assert set(gzip) == {"name", "config"}
+
+    return plugins.shared_plugin_pluginconfig_resource.spec.apply(check)
+
+
+@pulumi.runtime.test
+def test_recovery_plugin_renders_into_the_v2_plugin_config():
+    """The applications attach this to a host's shared plugin config rather
+    than per route, so it has to survive that normalisation.
+    """
+    plugins = shared_plugins(
+        "test-shared-plugins-oidc-recovery-v2",
+        plugins=[oidc_error_callback_recovery_plugin()],
+    )
+
+    def check(spec):
+        recovery = plugin_named(spec["plugins"], "serverless-pre-function")
+        assert recovery is not None
+        assert recovery["config"]["phase"] == "rewrite"
+        assert "temporarily_unavailable" in recovery["config"]["functions"][0]
+
+    return plugins.shared_plugin_apisix_pluginconfig_resource.spec.apply(check)
+
+
+@pulumi.runtime.test
+def test_recovery_plugin_reaches_the_gateway_api_plugin_config():
+    """v1alpha1 drops secretRef, which this plugin sets to None -- a shape the
+    other shared plugins do not exercise.
+    """
+    plugins = shared_plugins(
+        "test-shared-plugins-oidc-recovery-gateway-api",
+        plugins=[oidc_error_callback_recovery_plugin()],
+    )
+
+    def check(spec):
+        recovery = plugin_named(spec["plugins"], "serverless-pre-function")
+        assert recovery is not None
+        assert set(recovery) == {"name", "config"}
 
     return plugins.shared_plugin_pluginconfig_resource.spec.apply(check)
 

--- a/tests/ol_infrastructure/components/services/test_apisix.py
+++ b/tests/ol_infrastructure/components/services/test_apisix.py
@@ -378,6 +378,18 @@ def test_recovery_plugin_honours_a_custom_error_list():
     assert '["server_error"] = true' in lua
 
 
+def test_recovery_plugin_honours_an_explicit_empty_error_list():
+    """An empty list means "recover nothing" -- the way to make the plugin a
+    no-op without detaching it from every route on a shared config.
+    """
+    (lua,) = oidc_error_callback_recovery_plugin(
+        recoverable_errors=[],
+    ).config["functions"]
+
+    assert "local recoverable = {}" in lua
+    assert "temporarily_unavailable" not in lua
+
+
 def test_recovery_plugin_ignores_non_callback_requests():
     """Attached to a host's shared plugin config, this sees every route."""
     (lua,) = oidc_error_callback_recovery_plugin().config["functions"]

--- a/tests/ol_infrastructure/components/services/test_apisix_lua.py
+++ b/tests/ol_infrastructure/components/services/test_apisix_lua.py
@@ -163,6 +163,18 @@ def test_non_callback_routes_are_untouched():
     assert uri is None
 
 
+def test_a_path_merely_ending_in_the_callback_suffix_is_untouched():
+    """The suffix match includes the leading slash, so an application path that
+    happens to end in the same characters is not treated as a callback.
+    """
+    uri, _, _ = Harness().callback(
+        "/login/foo.apisix/redirect",
+        {"error": "temporarily_unavailable"},
+    )
+
+    assert uri is None
+
+
 def test_callback_without_an_error_parameter_is_untouched():
     uri, _, _ = Harness().callback("/login/.apisix/redirect", {})
 

--- a/tests/ol_infrastructure/components/services/test_apisix_lua.py
+++ b/tests/ol_infrastructure/components/services/test_apisix_lua.py
@@ -41,11 +41,10 @@ ngx = {
     end,
 }
 
-function run(fn, uri, args, cookie)
+function run(fn, conf, uri, args, ctx_vars)
     captured = {args = args, headers = {}, redirect = nil}
     ngx.var.uri = uri
-    ngx.var.http_cookie = cookie
-    fn({}, {})
+    fn(conf, {var = ctx_vars})
     local redirect = captured.redirect
     return redirect and redirect.uri or nil,
            redirect and redirect.code or nil,
@@ -55,25 +54,45 @@ end
 
 
 class Harness:
-    """Loads one generated function into a fresh Lua runtime."""
+    """Runs the shipped Lua against a stubbed ngx/apisix.core.
+
+    Both the function source and the ``conf`` table come from
+    ``oidc_error_callback_recovery_plugin``, so these exercise the same plugin
+    config the gateway is handed rather than a hand-built approximation.
+    """
 
     def __init__(self, **plugin_kwargs):
         self.lua = lupa.LuaRuntime(unpack_returned_tuples=True)
         self.lua.execute(LUA_STUBS)
-        (source,) = oidc_error_callback_recovery_plugin(**plugin_kwargs).config[
-            "functions"
-        ]
+        plugin_config = oidc_error_callback_recovery_plugin(**plugin_kwargs).config
+        (source,) = plugin_config["functions"]
         self.fn = self.lua.execute(source)
+        self.conf = self._to_lua(plugin_config)
 
-    def callback(self, uri, args=None, cookie=None):
-        """Return (redirect_uri, redirect_status, set_cookie) for one request."""
-        table = self.lua.table_from(
-            {
-                key: self.lua.table_from(value) if isinstance(value, list) else value
-                for key, value in (args or {}).items()
-            }
+    def _to_lua(self, value):
+        """Deep-convert Python containers to Lua tables."""
+        if isinstance(value, dict):
+            return self.lua.table_from(
+                {key: self._to_lua(item) for key, item in value.items()}
+            )
+        if isinstance(value, list):
+            return self.lua.table_from([self._to_lua(item) for item in value])
+        return value
+
+    def callback(self, uri, args=None, cookies=None):
+        """Return (redirect_uri, redirect_status, set_cookie) for one request.
+
+        ``cookies`` is a name -> value mapping, exposed the way nginx exposes
+        it: one ``ctx.var["cookie_<name>"]`` entry per cookie, parsed by nginx
+        rather than by the plugin.
+        """
+        return self.lua.globals().run(
+            self.fn,
+            self.conf,
+            uri,
+            self._to_lua(args or {}),
+            self._to_lua({f"cookie_{n}": v for n, v in (cookies or {}).items()}),
         )
-        return self.lua.globals().run(self.fn, uri, table, cookie)
 
 
 def test_expired_auth_session_is_sent_back_through_login():
@@ -157,18 +176,20 @@ def test_guard_cookie_stops_a_second_recovery():
     uri, _, _ = Harness().callback(
         "/login/.apisix/redirect",
         {"error": "temporarily_unavailable"},
-        cookie="other=1; apisix_oidc_recovery=1; another=2",
+        cookies={"other": "1", "apisix_oidc_recovery": "1", "another": "2"},
     )
 
     assert uri is None
 
 
-def test_guard_matches_the_whole_cookie_name():
-    """Substring matching here would let an unrelated cookie disable recovery."""
+def test_guard_reads_the_exact_cookie_name():
+    """The lookup is a single ctx.var["cookie_<name>"] read, so a cookie whose
+    name merely contains the guard's must not disable recovery.
+    """
     uri, _, _ = Harness().callback(
         "/login/.apisix/redirect",
         {"error": "temporarily_unavailable"},
-        cookie="not_apisix_oidc_recovery=1",
+        cookies={"not_apisix_oidc_recovery": "1"},
     )
 
     assert uri == "/login/"

--- a/tests/ol_infrastructure/components/services/test_apisix_lua.py
+++ b/tests/ol_infrastructure/components/services/test_apisix_lua.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import lupa
 
 from ol_infrastructure.components.services.apisix import (
-    oidc_error_callback_recovery_plugin,
+    oidc_gateway_pre_function_plugin,
 )
 
 # Stubs the generated function's whole world: the two ngx.var reads, the
@@ -57,15 +57,27 @@ class Harness:
     """Runs the shipped Lua against a stubbed ngx/apisix.core.
 
     Both the function source and the ``conf`` table come from
-    ``oidc_error_callback_recovery_plugin``, so these exercise the same plugin
+    ``oidc_gateway_pre_function_plugin``, so these exercise the same plugin
     config the gateway is handed rather than a hand-built approximation.
     """
 
+    # The builder fuses both pre-openid-connect functions into the one
+    # serverless-pre-function APISIX allows per plugin config, so subclasses
+    # select theirs by the conf block it reads.  Indexing by position would
+    # silently test the wrong function if the order changed.
+    FUNCTION_MARKER = "oidc_error_recovery"
+    EXTRA_LUA = ""
+
     def __init__(self, **plugin_kwargs):
         self.lua = lupa.LuaRuntime(unpack_returned_tuples=True)
-        self.lua.execute(LUA_STUBS)
-        plugin_config = oidc_error_callback_recovery_plugin(**plugin_kwargs).config
-        (source,) = plugin_config["functions"]
+        # One chunk, not two: `captured` is a chunk-local upvalue that the
+        # ngx.redirect stub closes over, so a runner defined in a separate
+        # execute() would assign to a fresh global and capture nothing.
+        self.lua.execute(LUA_STUBS + self.EXTRA_LUA)
+        plugin_config = oidc_gateway_pre_function_plugin(**plugin_kwargs).config
+        (source,) = [
+            fn for fn in plugin_config["functions"] if self.FUNCTION_MARKER in fn
+        ]
         self.fn = self.lua.execute(source)
         self.conf = self._to_lua(plugin_config)
 
@@ -249,3 +261,117 @@ def test_custom_guard_lifetime_reaches_the_cookie():
     )
 
     assert "Max-Age=90;" in set_cookie
+
+
+class OriginHarness(Harness):
+    """Runs the canonical-origin function against a stubbed ngx.
+
+    Unlike the recovery function this one reads only ``ngx.var`` -- scheme,
+    host, http_host, request_uri -- so it gets its own runner rather than
+    overloading ``run`` with parameters the other cases never use.
+    """
+
+    FUNCTION_MARKER = "canonical_https_redirect"
+    EXTRA_LUA = """
+    function run_origin(fn, conf, scheme, host, http_host, request_uri)
+        captured = {args = {}, headers = {}, redirect = nil}
+        ngx.var.scheme = scheme
+        ngx.var.host = host
+        ngx.var.http_host = http_host
+        ngx.var.request_uri = request_uri
+        fn(conf, {var = ngx.var})
+        local redirect = captured.redirect
+        return redirect and redirect.uri or nil, redirect and redirect.code or nil
+    end
+    """
+
+    #: ``http_host`` defaults to mirroring ``host``; pass ``None`` explicitly for
+    #: the HTTP/1.0 case where the request carries no Host header at all.
+    MIRROR_HOST = object()
+
+    def request(
+        self, scheme="https", host="learn.mit.edu", http_host=MIRROR_HOST, uri="/"
+    ):
+        return self.lua.globals().run_origin(
+            self.fn,
+            self.conf,
+            scheme,
+            host,
+            host if http_host is self.MIRROR_HOST else http_host,
+            uri,
+        )
+
+
+def test_plain_http_is_upgraded_before_openid_connect_sees_it():
+    """The measured failure: this is what sends Keycloak an http:// redirect_uri
+    and answers with an OIDC session cookie over cleartext.
+    """
+    uri, status = OriginHarness().request(
+        scheme="http", host="nb.learn.mit.edu", uri="/hub/login"
+    )
+
+    assert (uri, status) == ("https://nb.learn.mit.edu/hub/login", 308)
+
+
+def test_explicit_port_in_host_is_stripped():
+    """`Host: nb.learn.mit.edu:443` yields https://nb.learn.mit.edu:443/... which
+    Keycloak rejects against its bare-host registration.  Reproduced live.
+    """
+    uri, status = OriginHarness().request(
+        host="nb.learn.mit.edu", http_host="nb.learn.mit.edu:443"
+    )
+
+    assert (uri, status) == ("https://nb.learn.mit.edu/", 308)
+
+
+def test_canonical_request_is_left_alone():
+    """The overwhelming majority of traffic: must cost nothing and not redirect."""
+    assert OriginHarness().request(uri="/search?q=x") == (None, None)
+
+
+def test_query_string_survives_the_upgrade():
+    """request_uri, not uri: dropping the query would break every OIDC callback
+    that arrives over plain HTTP, which is precisely the traffic being fixed.
+    """
+    uri, _ = OriginHarness().request(
+        scheme="http",
+        host="api.learn.mit.edu",
+        uri="/login/.apisix/redirect?code=a&state=b",
+    )
+
+    assert uri == "https://api.learn.mit.edu/login/.apisix/redirect?code=a&state=b"
+
+
+def test_missing_host_header_is_left_to_openid_connect():
+    """HTTP/1.0 with no Host: $host would be the server_name, so redirecting
+    would invent an origin.  lua-resty-openidc already 400s this case.
+    """
+    assert OriginHarness().request(scheme="http", http_host=None) == (None, None)
+
+
+def test_redirect_status_is_configurable():
+    uri, status = OriginHarness(canonical_redirect_status=301).request(scheme="http")
+
+    assert (uri, status) == ("https://learn.mit.edu/", 301)
+
+
+def test_disabling_the_redirect_drops_the_function_entirely():
+    """A host that must keep answering on plain HTTP turns this off without
+    losing the error-callback recovery it shares a plugin with.
+    """
+    config = oidc_gateway_pre_function_plugin(canonical_https_redirect=False).config
+
+    assert not [fn for fn in config["functions"] if "canonical_https_redirect" in fn]
+    assert len(config["functions"]) == 1
+
+
+def test_origin_normalisation_runs_before_error_recovery():
+    """serverless/init.lua stops at the first function returning a code, so a
+    plain-HTTP error callback must be upgraded rather than recovered -- the
+    recovery redirect would otherwise send the browser back to an http:// login.
+    """
+    config = oidc_gateway_pre_function_plugin().config
+    sources = config["functions"]
+
+    assert "canonical_https_redirect" in sources[0]
+    assert "oidc_error_recovery" in sources[1]

--- a/tests/ol_infrastructure/components/services/test_apisix_lua.py
+++ b/tests/ol_infrastructure/components/services/test_apisix_lua.py
@@ -1,0 +1,218 @@
+"""Execute the Lua that apisix.py generates, rather than grepping its source.
+
+The plugin helpers in ``components/services/apisix.py`` emit Lua as text, so
+assertions on that text only prove a fragment is present -- an inverted branch
+could satisfy every substring check and still break production authentication.
+These tests run the generated function against a stubbed ``ngx``/``apisix.core``
+and assert on what it actually does.
+
+Worth the dependency: the ``%`` escaping in these f-string templates is easy to
+get wrong in a way that is invisible in a substring assertion (``%%`` is not
+collapsed by f-strings, only by printf-style formatting), and a wrong Lua
+pattern silently matches nothing.
+"""
+
+from __future__ import annotations
+
+import lupa
+
+from ol_infrastructure.components.services.apisix import (
+    oidc_error_callback_recovery_plugin,
+)
+
+# Stubs the generated function's whole world: the two ngx.var reads, the
+# ngx.header write, ngx.redirect, and the apisix.core require.  `run` resets the
+# captured state each call so cases cannot leak into one another.
+LUA_STUBS = """
+local captured = {}
+
+package.loaded["apisix.core"] = {
+    log = { warn = function() end },
+    request = { get_uri_args = function() return captured.args end },
+}
+
+ngx = {
+    var = {},
+    header = setmetatable({}, {
+        __newindex = function(_, key, value) captured.headers[key] = value end,
+    }),
+    redirect = function(uri, code)
+        captured.redirect = {uri = uri, code = code}
+    end,
+}
+
+function run(fn, uri, args, cookie)
+    captured = {args = args, headers = {}, redirect = nil}
+    ngx.var.uri = uri
+    ngx.var.http_cookie = cookie
+    fn({}, {})
+    local redirect = captured.redirect
+    return redirect and redirect.uri or nil,
+           redirect and redirect.code or nil,
+           captured.headers["Set-Cookie"]
+end
+"""
+
+
+class Harness:
+    """Loads one generated function into a fresh Lua runtime."""
+
+    def __init__(self, **plugin_kwargs):
+        self.lua = lupa.LuaRuntime(unpack_returned_tuples=True)
+        self.lua.execute(LUA_STUBS)
+        (source,) = oidc_error_callback_recovery_plugin(**plugin_kwargs).config[
+            "functions"
+        ]
+        self.fn = self.lua.execute(source)
+
+    def callback(self, uri, args=None, cookie=None):
+        """Return (redirect_uri, redirect_status, set_cookie) for one request."""
+        table = self.lua.table_from(
+            {
+                key: self.lua.table_from(value) if isinstance(value, list) else value
+                for key, value in (args or {}).items()
+            }
+        )
+        return self.lua.globals().run(self.fn, uri, table, cookie)
+
+
+def test_expired_auth_session_is_sent_back_through_login():
+    """The production case: 614 callbacks a day arrive shaped like this."""
+    uri, status, _ = Harness().callback(
+        "/login/.apisix/redirect",
+        {"error": "temporarily_unavailable"},
+    )
+
+    assert (uri, status) == ("/login/", 302)
+
+
+def test_recovery_sets_the_loop_guard_cookie():
+    _, _, set_cookie = Harness().callback(
+        "/login/.apisix/redirect",
+        {"error": "temporarily_unavailable"},
+    )
+
+    assert set_cookie == (
+        "apisix_oidc_recovery=1; Path=/; Max-Age=60; Secure; HttpOnly; SameSite=Lax"
+    )
+
+
+def test_redirect_target_follows_the_login_prefix():
+    """mit-learn serves two route groups on one host, at /login and /learn/login.
+    Deriving the target from the URI is what lets one attachment cover both.
+    """
+    uri, _, _ = Harness().callback(
+        "/learn/login/.apisix/redirect",
+        {"error": "temporarily_unavailable"},
+    )
+
+    assert uri == "/learn/login/"
+
+
+def test_successful_callback_passes_through_to_openid_connect():
+    """A real login carries a code; this plugin must not touch it."""
+    uri, _, set_cookie = Harness().callback(
+        "/login/.apisix/redirect",
+        {"code": "abc123", "state": "xyz"},
+    )
+
+    assert uri is None
+    assert set_cookie is None
+
+
+def test_user_cancelling_login_is_not_recovered():
+    """access_denied means the user pressed Cancel. Bouncing them back into
+    /login would spin the browser between the gateway and Keycloak.
+    """
+    uri, _, _ = Harness().callback(
+        "/login/.apisix/redirect",
+        {"error": "access_denied"},
+    )
+
+    assert uri is None
+
+
+def test_non_callback_routes_are_untouched():
+    """This hangs off a host's shared plugin config, so it sees every request
+    on the host, not just the callback.
+    """
+    uri, _, _ = Harness().callback(
+        "/api/v1/courses",
+        {"error": "temporarily_unavailable"},
+    )
+
+    assert uri is None
+
+
+def test_callback_without_an_error_parameter_is_untouched():
+    uri, _, _ = Harness().callback("/login/.apisix/redirect", {})
+
+    assert uri is None
+
+
+def test_guard_cookie_stops_a_second_recovery():
+    """A persistently broken IdP has to surface as an error rather than an
+    infinite redirect, so recovery happens at most once per guard window.
+    """
+    uri, _, _ = Harness().callback(
+        "/login/.apisix/redirect",
+        {"error": "temporarily_unavailable"},
+        cookie="other=1; apisix_oidc_recovery=1; another=2",
+    )
+
+    assert uri is None
+
+
+def test_guard_matches_the_whole_cookie_name():
+    """Substring matching here would let an unrelated cookie disable recovery."""
+    uri, _, _ = Harness().callback(
+        "/login/.apisix/redirect",
+        {"error": "temporarily_unavailable"},
+        cookie="not_apisix_oidc_recovery=1",
+    )
+
+    assert uri == "/login/"
+
+
+def test_repeated_error_parameter_is_handled():
+    """?error=a&error=b makes get_uri_args return a table, not a string."""
+    uri, _, _ = Harness().callback(
+        "/login/.apisix/redirect",
+        {"error": ["temporarily_unavailable", "something_else"]},
+    )
+
+    assert uri == "/login/"
+
+
+def test_an_empty_recoverable_list_disables_recovery():
+    """The no-op configuration has to actually recover nothing."""
+    uri, _, _ = Harness(recoverable_errors=[]).callback(
+        "/login/.apisix/redirect",
+        {"error": "temporarily_unavailable"},
+    )
+
+    assert uri is None
+
+
+def test_a_custom_error_list_is_honoured_at_runtime():
+    harness = Harness(recoverable_errors=["server_error"])
+
+    assert (
+        harness.callback("/login/.apisix/redirect", {"error": "server_error"})[0]
+        == "/login/"
+    )
+    assert (
+        harness.callback(
+            "/login/.apisix/redirect", {"error": "temporarily_unavailable"}
+        )[0]
+        is None
+    )
+
+
+def test_custom_guard_lifetime_reaches_the_cookie():
+    _, _, set_cookie = Harness(guard_max_age=90).callback(
+        "/login/.apisix/redirect",
+        {"error": "temporarily_unavailable"},
+    )
+
+    assert "Max-Age=90;" in set_cookie

--- a/uv.lock
+++ b/uv.lock
@@ -1261,6 +1261,54 @@ wheels = [
 ]
 
 [[package]]
+name = "lupa"
+version = "2.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/a6/0f869fbb07c393f15473b1eefefb7b5bec162fb7481803d040ed4dc46002/lupa-2.8.tar.gz", hash = "sha256:d8022641b9ec8ecf2c5ecbe9f47e5a70e0b87c4b5ae921b92cb02a638e0acd08", size = 6156370, upload-time = "2026-04-15T20:08:30.534Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/21/9be4516ddd22f8eadba336d9ba065d17d79108465ae1b7f71424ab99b9d0/lupa-2.8-cp310-abi3-win32.whl", hash = "sha256:c2a5fd15dc62374e1661a55f01744c9ec1c56f291ba4a0749d3af2174556e78f", size = 1594887, upload-time = "2026-04-15T20:05:23.377Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/99/1557c9685d7034d9ce8dd2b54c40a26d6deb7c67c1fdb5c801abd1a02c3f/lupa-2.8-cp310-abi3-win_arm64.whl", hash = "sha256:9e304fb1c50cf23fd8882afbe1aa87525ef8a72667bcab3b37b2bbb2bc542269", size = 1371742, upload-time = "2026-04-15T20:05:27.417Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/0b/368f2f0bc750b25c69d4563e44f677925ab5dd3d2887f9b0c15465d21a2a/lupa-2.8-cp312-abi3-macosx_10_13_x86_64.whl", hash = "sha256:f4342f4de76ae7ce2ab0672d36003bdb7e1a33252f293b569298ddd792e70e33", size = 1194056, upload-time = "2026-04-15T20:05:55.794Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/0f/c89eb8dd36fdea4e50ae3f7f5275bea3b0cc5d4057b8ee7b3bbc78010422/lupa-2.8-cp312-abi3-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:4203fa1659315e939a5304e75001b8cc14234fb3cbb3ed86c049b0cc5d90fcee", size = 1434278, upload-time = "2026-04-15T20:05:57.94Z" },
+    { url = "https://files.pythonhosted.org/packages/47/30/c3b4d2cd8733621b404b8a4214e5f852955c4ba632546dc84123bea9ee89/lupa-2.8-cp312-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:81f2d843ce668b653146c007467570210ae44be51dac6926666c51d49536f307", size = 1150068, upload-time = "2026-04-15T20:06:01.04Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/d2/bac12c398519efafc6af84be1974edd0d7a4895fb4735b5c8d615d298595/lupa-2.8-cp312-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d3d0cde2c77588d1c60875a4f34f059513476c6e1775351897195b51e0f3df08", size = 1409532, upload-time = "2026-04-15T20:06:03.592Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6a/18b52e11962014026e07813530b0b108ee8bc0a2a13ef0eaea5d41dce023/lupa-2.8-cp312-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9e0d11b8f3a8dac6413f704fef7161d048bb10c58bdac6cbffa5e60efa56e9a3", size = 1242687, upload-time = "2026-04-15T20:06:06.863Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/8e/7fd4eb049875f61429b96780d2eae4700f0e78fe0a52db8edb231b1cd09f/lupa-2.8-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:54cff414f21f8cd8c6be4aae52541f3b9cd39602b59e3a3db9b5c9f9f674ff18", size = 1856038, upload-time = "2026-04-15T20:06:09.358Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f9/37ad9d2773d30f2931890d310a4bdce28d45484206e6f48bc18b0325eabd/lupa-2.8-cp312-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:24b4d8af5558e549b70daf1547f5c1c1d664ecea9fc790f83efe5d75e9a93797", size = 1128982, upload-time = "2026-04-15T20:06:12.312Z" },
+    { url = "https://files.pythonhosted.org/packages/57/31/c0fd7984c24844ea79caa45c0235f61a06b38fd69a839f6c62770f8d684a/lupa-2.8-cp312-abi3-musllinux_1_2_i686.whl", hash = "sha256:ce86dff1ee7f7cf45f5622065ae991949dd7bb1703581cbc58a630137bb7ccf9", size = 1457594, upload-time = "2026-04-15T20:06:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f5/a28e411be30ec1bf0db1eb0c087eebc73be9e7a1adcfe6ac209861ccc446/lupa-2.8-cp312-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:f4d01b2a08c70bbb883a9e082b6b36b89121ed5910b710f1ba11c73295ff4fba", size = 1425721, upload-time = "2026-04-15T20:06:18.009Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c1/359f767c4ae024be30d909fe8a9f0e9af266bad47ce2bd2ed248fb986fcf/lupa-2.8-cp312-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:7f210d5a8353e510ea1199c42cf3cbdd630553bf2bc8fb4c00fea06fdec7c798", size = 1253258, upload-time = "2026-04-15T20:06:21.17Z" },
+    { url = "https://files.pythonhosted.org/packages/17/52/473f11790c261fd02bbf318a546fe040e9ec9f677181272fa78d3b4112a4/lupa-2.8-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4f81a02806e7c7ad26d8c6fa222c8bef1b0c1b124347c879be880b41339d41e4", size = 2395272, upload-time = "2026-04-15T20:06:24.137Z" },
+    { url = "https://files.pythonhosted.org/packages/94/bf/75c8795655a8836eab6a11a630352c4b7c5dc5c54d075077bc9bffdeee45/lupa-2.8-cp312-abi3-win32.whl", hash = "sha256:360056453a7a4eaa4ac5a204c31a5a014b1eb2ee5490603234d2ba831684f1f2", size = 1606136, upload-time = "2026-04-15T20:06:27.815Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/29/11a2cdd612b6f55e506292dfb6ba343216e80a693e7fe3f876ef204ce9c6/lupa-2.8-cp312-abi3-win_arm64.whl", hash = "sha256:1628371c6592a6d5650497a9e31fb2bb3a7e9883c1f301d1111265e484045af9", size = 1364495, upload-time = "2026-04-15T20:06:30.254Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3f/19f83c3a0c84dc8bea8a58e7416dca6a3ede662c33c8d1ec758e5afc754a/lupa-2.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45fc9da0145ecb0083ef5ff9975116cc784bd0258bdc2bd131ba15483ce18398", size = 1201203, upload-time = "2026-04-15T20:06:42.169Z" },
+    { url = "https://files.pythonhosted.org/packages/89/0f/a14f0073f09610158038582e230618a48c14da6bd88185289461aa4cb854/lupa-2.8-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:58e18afed57955b41130e269c78f53d4123ab86e236b53816f4cbffa25cb5d30", size = 1806210, upload-time = "2026-04-15T20:06:45.486Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/14/48fff156c63a136001a7620878af7d31aa07e66b495ed621e3eddd73c294/lupa-2.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fc47f536ac13a79cef47d29a2b205576a22841f042a2bcec1676b95806e7706a", size = 2359005, upload-time = "2026-04-15T20:06:47.819Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/18/3ac638ec90edf178242b8a2b2f00f8adae694248c03a26341ef941bb746e/lupa-2.8-cp313-cp313-win_amd64.whl", hash = "sha256:ce9404c661dbac65cc9bed351ad45e797af93d30d70be309a3fa8209ac86d93b", size = 1936754, upload-time = "2026-04-15T20:06:50.448Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ef/5ee5fed6ea7459a671196359ce04bfeeaf26be1dac8ff24bf28e5c7a6e81/lupa-2.8-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:348c3f8ecabb6324dcbc05c2740d762ef8fcec7b06c79e45262ab97a217684e3", size = 1209388, upload-time = "2026-04-15T20:06:53.022Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/b1/67a940d5542cb0384b443fe951b5a83ea9340d1333a733a258fdd1c619ba/lupa-2.8-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:951496471056061598a7d1729a6cdf48d662fec777a9f2d8aa5a1e62fd30e5a5", size = 1826821, upload-time = "2026-04-15T20:06:55.699Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/a2/b354e5ba3b911ec50686003dc8897e892b9e8c5c036b33219b03d54c4daf/lupa-2.8-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a591b9947ca347b41a63370e121d6e2b1458fe6dde9ae065029ec10a37f25ff4", size = 2366893, upload-time = "2026-04-15T20:06:58.9Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/52/d76066401f29539df5352f70ecded66576f32933b6045cd0bfc56cb770b9/lupa-2.8-cp314-cp314-win_amd64.whl", hash = "sha256:3903c9cf628dae2f56405503247b77a61a3a61bd2dda470e336950c74776d55d", size = 1994716, upload-time = "2026-04-15T20:07:19.194Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/bd/3efc437a4361c16d25e66478c50357c9a8e8ecfb718fe749eb9ca3176ef6/lupa-2.8-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f711a8ab0486b9ac6fdda94a22ddcfbc9f0d4a27e3a8cf1bf79c6e48b33017c1", size = 1251217, upload-time = "2026-04-15T20:07:01.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f4/2e9f8ecbaca854bfdf14af8a9b505ec0cbc640377b3b218921594b7563cd/lupa-2.8-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc51250e76367a3e27fcd01dc769b9bfcbbc34f48df48dde53d6af6e75b7eaa5", size = 1814701, upload-time = "2026-04-15T20:07:04.149Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/53/4000b1acaa8b1f3827fcff0cfcdff44d3befddda42cab7e685a49689b5a1/lupa-2.8-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f8a22088a552828958603323f0a5c4b3e11e03b75d0bf4c965ef879de9b60a8d", size = 2348414, upload-time = "2026-04-15T20:07:07.285Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/78/26ee48d3890cddf03cefb65f433e3492759c0b3c0582180755bddbaab7bd/lupa-2.8-cp314-cp314t-win32.whl", hash = "sha256:4f7c553c1d8cfffbe85d81daef730d12cae4b6002d457542914da0ac8a1145b3", size = 1831611, upload-time = "2026-04-15T20:07:09.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/4a5cc64a3cad22821ae4c3f7a90456a08ca19457d8354f4abf46ad03c7e8/lupa-2.8-cp314-cp314t-win_amd64.whl", hash = "sha256:d8766aff03a78c80ad2d188a8bdb216de5ec838359cd87e05bbdfa56394a6105", size = 2209250, upload-time = "2026-04-15T20:07:11.906Z" },
+    { url = "https://files.pythonhosted.org/packages/37/7c/cdcb654daf668192aaf36b0aeb94f2281dad092aaa5003688691131736ea/lupa-2.8-cp314-cp314t-win_arm64.whl", hash = "sha256:91d622777febda3ab1bed1d45295f2f32a4680c7b3d7caf8c669998ed5c44118", size = 1126735, upload-time = "2026-04-15T20:07:15.434Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/44/de1961ad38e17cd326a53c246c7e3b91178ed578f4cf22ffcd5e7e11b041/lupa-2.8-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:b036738282a5acd2e71fdddb317c9df8b87c1673aa57f403d05fcc2be8abc4ba", size = 1186020, upload-time = "2026-04-15T20:07:35.017Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c2/276f0b9dc8bcc5a8a58af5316dfa0e6f56be3613dd6dbcc8d3d2cb6559ba/lupa-2.8-cp39-abi3-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:ac6b6e8d0e617e26a98cbb44880bcd75de5d32b3ad7b3b3793583909292b47ed", size = 1468944, upload-time = "2026-04-15T20:07:37.782Z" },
+    { url = "https://files.pythonhosted.org/packages/63/38/52934e52a5180dc6425d20284d004fe4b27a4f9171a82dc99fb67af250bf/lupa-2.8-cp39-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ba3a7dd839f90c3d2e53bebe3c192b1f3f9fd720a6781256405123211fd0dce6", size = 1172998, upload-time = "2026-04-15T20:07:40.812Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/82/76b3809bd0839d9b3b4ec58d06591e08f17337b6d9576877cb9d48b34e94/lupa-2.8-cp39-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d7edb13a7a5250b5c6c22d1495d9e842b5c9fc5081c8fe6b5efe2112fe3e41f9", size = 1449975, upload-time = "2026-04-15T20:07:44.262Z" },
+    { url = "https://files.pythonhosted.org/packages/16/07/2f89d54f747c67c23b4b9ae4aa8c8dd06bb409155dedcf406157f2736b66/lupa-2.8-cp39-abi3-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:891f72e0bffbed1e4175f975aeb2a083956586a100066525e1be485f617f7b25", size = 1281944, upload-time = "2026-04-15T20:07:46.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/bd/7375d2b0fcae79d806baf52a76f26c96964593f58e1372d13ae5ac09c676/lupa-2.8-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a295f87b5b7ebbfd5191932e8cb0e51df3c7769101ac6b6c7d7c9fb27bfd1307", size = 1910455, upload-time = "2026-04-15T20:07:49.75Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0c/8abb3bc0e08b311fc01db05b6e9f9ff31a8f65e4fc3f0aeb05cfef75c8ac/lupa-2.8-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:4fe5d7a810b64ea8511eb885fc8cdde042ee5ff7b7d08ae78f32449756acb177", size = 1155548, upload-time = "2026-04-15T20:07:52.657Z" },
+    { url = "https://files.pythonhosted.org/packages/80/2e/9eeecd3f493099721c1d3f31beeca23a4237db1a54223684df4dc96aa1bd/lupa-2.8-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:bfc470012ef66ad064c7bd77416af03a3452ef630b04b9012595ea13f2e54518", size = 1489232, upload-time = "2026-04-15T20:07:54.92Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/13/731c99dc2e7652ae818a6de45bdf0142049f7cb566049061c898355f1891/lupa-2.8-cp39-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:250e035fdaffe8c87093e3ebc206ac29a26131b1568ea711d780c26001ce96e7", size = 1466321, upload-time = "2026-04-15T20:07:57.627Z" },
+    { url = "https://files.pythonhosted.org/packages/de/71/3ad8cc4fc05a77dc0d3f7079348bd1cad4675a0d14c24f8e6a3ce5f008f7/lupa-2.8-cp39-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:b9bddb09acfffb4f828f790f444b11dc0cca591afea1a244d9329eea2d20c003", size = 1288577, upload-time = "2026-04-15T20:07:59.913Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/b2/1175f6d0aa7b68627fbe2f58bd1e8bea36a89d10dfd67671d2b024c96162/lupa-2.8-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2e64acbbd47e9b82a64405a39e0d2b36a5a7dad8ab41c0f3437f572f7d282ba3", size = 2444866, upload-time = "2026-04-15T20:08:02.753Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1549,6 +1597,7 @@ dependencies = [
 dev = [
     { name = "copier" },
     { name = "datamodel-code-generator" },
+    { name = "lupa" },
     { name = "mypy" },
     { name = "pip" },
     { name = "pre-commit" },
@@ -1608,6 +1657,7 @@ requires-dist = [
 dev = [
     { name = "copier" },
     { name = "datamodel-code-generator" },
+    { name = "lupa", specifier = ">=2.0" },
     { name = "mypy" },
     { name = "pip", specifier = ">=26.0.1" },
     { name = "pre-commit", specifier = ">=4.0.0,<5" },


### PR DESCRIPTION
### What are the relevant tickets?

Part of https://github.com/mitodl/hq/issues/12178 — specifically part (1a). Parts (1b) and (2) stay open.

Follows https://github.com/mitodl/ol-infrastructure/pull/5413, which added the alerting for these failures.

### Description (What does it do?)

Adds `oidc_error_callback_recovery_plugin()` and attaches it to the shared plugin configs for `api.learn.mit.edu`, `mitxonline.mit.edu`, and `nb.learn.mit.edu`.

- When a Keycloak authentication session expires — user left the login tab open, or followed a stale bookmark — Keycloak redirects back with `error=temporarily_unavailable` and no `code`, marking its own event `restart_after_timeout="true"`. Its intent is that the client start over.
- `lua-resty-openidc` treats any `error` parameter as fatal, so APISIX serves a 21KB HTTP 500 where the user expected a login form. Nothing retries.
- The new plugin runs as a `serverless-pre-function` in the **rewrite** phase, where its priority (10000) outranks `openid-connect`'s (2599) — confirmed by their relative order in [`APISIX_DEFAULT_PLUGINS_3_17`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/infrastructure/aws/eks/apisix_official.py#L46-L56). It redirects back into the authorization flow before the plugin can fail.
- The redirect target is derived from the callback URI rather than configured. The callback always sits at `<login prefix>/.apisix/redirect` and the route serving it is by construction the `unauth_action="auth"` one, so one attachment per host covers every route group on it — including mit-learn's `/login` and `/learn/login` prefixes.
- Only transient errors are recovered. `access_denied` (user pressed Cancel) and `invalid_request` (a real misconfiguration) keep failing, otherwise the browser spins between the gateway and Keycloak.
- A guard cookie caps recovery at one attempt per browser per minute, so a persistently broken IdP surfaces as an error rather than a redirect loop.

**Why this cause and not the others.** #5413 shipped with the caveat that its 500 rate is a rate over *requests*, not users, and that real impact was unknown. Keycloak's event stream answers it — unlike the gateway access log, it identifies users and sessions. The 1,251 callback 500s/day split three ways:

| Cause | Volume/day | Blocks anyone? |
|---|---|---|
| `error=temporarily_unavailable` (expired auth session) | 614 | **Yes** — 530 distinct client addresses, 181 of which never reached a successful callback in the same 24h |
| Stale-code replay | ~465 | **No** — the first callback already succeeded |
| Genuine code-exchange failure | ~171 | Yes, but small: 2.0% of api.learn first attempts, ≤6.5% of mitxonline's |

Keycloak settles the replay question: **4,762 successful `code_to_token` exchanges against only 7 `invalid_code` errors** in 24h. If replayed callbacks reached the token endpoint we would see thousands. They die at APISIX's state check instead. That is why the 27.4% / 14.4% callback failure rates in the original audit are not login failure rates, and why only the first row here is worth fixing now.

Per-host the split is exact — for api.learn, 327 + 191 + 55 = 573, the measured total.

### How can this be tested?

Three layers, each covering something the one below it cannot. All run locally on this branch; the first two are wired as CI jobs alongside the existing `test` job.

**1. Unit — `uv run pytest tests/ol_infrastructure/components/services/` (132 pass)**
Config rendering, plus `test_apisix_lua.py` executing the shipped Lua in a `lupa` runtime against a stubbed `ngx`/`apisix.core`. Fast feedback on the Lua's logic; it does not prove APISIX accepts anything.

**2. Integration — `uv run pytest tests/apisix_integration -m integration` (11 pass, ~2s)**
A real APISIX 3.17.0 container in standalone mode, fed the route config built by the actual plugin helper. This is what proves the `oidc_error_recovery` block survives schema validation and is readable on `conf`, and that `Set-Cookie` survives `ngx.redirect` on the real runtime. Marked `integration`, so the repo's existing `-m 'not integration'` default keeps it out of the fast suite.

**3. test-nginx — `tests/apisix_testnginx/run.sh` (19 subtests pass)**
APISIX's own harness (`t/APISIX.pm`) on the same OpenResty build the gateway runs. Notes for anyone touching it:
- It needs **etcd**. `APISIX.pm` boots APISIX's real init path, so without etcd every test fails test-nginx's default `no [error] in error.log` check on connection-refused noise. etcd is in the image rather than filtering those lines out, because filtering would also hide errors worth seeing.
- It builds from the **repo root**, so the Dockerfile copies the Lua from `src/`. A second copy beside the `.t` would be free to drift, and the suite would then pass against Lua we do not ship.
- `t/APISIX.pm` and the eight cert fixtures it opens come from the APISIX source tarball at build time — one request, not nine from `raw.githubusercontent.com`, which reliably trips its rate limiter (HTTP 429) and made the build a coin flip.

**Mutation-tested, not assumed.** Each layer was verified to fail when the behaviour it covers is broken:

| Mutation | Effect |
|---|---|
| Remove the guard-cookie early return | 1 integration test fails |
| Simulate the settings block being stripped | 6 integration tests fail |
| Remove the repeated-`error` table handling | 2 test-nginx subtests fail |

**Lint:** `pre-commit` clean on the changed set, including hadolint on the new Dockerfile (verified separately with `hadolint` directly — the repo-wide `Lint Dockerfiles` failure is pre-existing across other Dockerfiles and is not from this branch).

**Config-passing chain**, checked at every hop against the pinned versions rather than assumed:

| Layer | Why an unknown key survives |
|---|---|
| `ApisixPluginConfig` v2 / `PluginConfig` v1alpha1 CRDs | `config` marked `x-kubernetes-preserve-unknown-fields: true` |
| apisix-ingress-controller | `Config apiextensionsv1.JSON` — raw bytes |
| ADC | `type Plugins map[string]any` |
| APISIX 3.17.0 `serverless/init.lua` | schema declares only `phase`/`functions`, no `additionalProperties` |
| runtime | invoked as `func(conf, ctx)` |

### Additional Context

- **Correction — the chronic alert will NOT go quiet, and an earlier version of this description wrongly said it would.** `APISIXOIDCCallbackFailureRateChronic` fires at >5% over 6h, and its own annotation says it stays up "until the two known causes are fixed". This PR fixes one. Working the measured numbers through:

  | host | callbacks/24h | 500 rate now | after this PR | chronic >5%? |
  |---|---|---|---|---|
  | api.learn.mit.edu | 3,297 | 17.4% | 7.5% | **still fires** |
  | mitxonline.mit.edu | 2,633 | 25.4% | 14.6% | **still fires** |

  The replay 500s alone keep both hosts above the threshold. Alert silence is therefore *not* the deployment check. Verify instead that the `temporarily_unavailable` callbacks stop returning 500 — they should go to ~0 while the count of callback requests carrying `error=` stays flat:

  ```logql
  sum by (host, status) (count_over_time(
    {namespace="operations", container="apisix"}
    |= ".apisix/redirect" |= "time_local" |= "error=" | logfmt | __error__="" [24h]))
  ```

  and that the overall rates land near the "after" column above. No rule change is included here — the rule behaves as designed, it is the claim about it that was wrong. Adding a `temporarily_unavailable`-specific expression so this cause is independently trackable is a reasonable follow-up if you want it.
- **On prioritising the rest of #12178:** on this evidence part (1b) (tolerating replayed codes) is log-noise and alert-inflation cleanup, not a user-facing fix, and is better done after 1a has been observed in production since removing 1a changes the remaining mix. Part (2) (per-issuer route scoping, Rootly INC-10) is untouched and still needs design.
- **Unrelated finding, filed separately:** Keycloak rejects ~12/day of `redirect_uri="http://nb.learn.mit.edu/.apisix/redirect"` with `invalid_redirect_uri` — note `http`, not `https`. Those fail at the authorization endpoint and never reach the callback, so they are invisible in the numbers above.
- **On the dismissed Seer finding:** it predicted (HIGH) that `ngx.header["Set-Cookie"]` would be dropped by `ngx.redirect()`, breaking the loop guard. It was dismissed last round on source reading ([`ngx_http_lua_ngx_redirect`](https://github.com/openresty/lua-nginx-module/blob/master/src/ngx_http_lua_control.c) pushes Location onto the *existing* `r->headers_out.headers` list and clears nothing). That is now settled empirically instead: `test_guard_cookie_survives_ngx_redirect` asserts the header on a response a real APISIX generates, and `test_second_failure_falls_through_instead_of_looping` asserts the guard actually engages. Its suggested `header_filter` fix would not have worked — `ngx.redirect()` terminates the request in `rewrite`, so that phase never runs for this response.

### Checklist:

Not merge blockers. The three test layers now cover the plugin's behaviour and APISIX's acceptance of its config; what they cannot reach is the real cluster's CRD → ingress-controller → ADC path and a live Keycloak. Worth confirming against `applications.mitlearn.CI` after this deploys there, before promoting to Production:

- [ ] The settings block survives the real config pipeline end to end: `curl -sSi 'https://api.ci.learn.mit.edu/login/.apisix/redirect?error=temporarily_unavailable&state=x'` returns **302** with `Location: /login/` and `Set-Cookie: apisix_oidc_recovery=1; ...`. A 500 here means the `oidc_error_recovery` key was dropped somewhere between the CRD and APISIX — the one hop no test covers.
- [ ] A normal login through https://ci.learn.mit.edu still completes end to end against real Keycloak — this plugin runs in the rewrite phase of every route on the host.
