### PR TITLE
feat(github): close SEC-05; document SEC-04/13 and SEC-10 blockers

### DIFF
--- a/docs/plans/github-org-pulumi-import.md
+++ b/docs/plans/github-org-pulumi-import.md
@@ -317,7 +317,7 @@ archetypes:
     has_wiki: false
     web_commit_signoff_required: true
     vulnerability_alerts: true
-    dependabot_security_updates: true
+    dependabot_security_updates: false     # closed 2026-08-14 as SEC-05 won't-fix, see §7
     secret_scanning: enabled
     secret_scanning_push_protection: enabled
     teams:
@@ -437,7 +437,7 @@ which is precisely how `ol-django` ended up with no branch protection at all.
 | Mechanism | What it covers |
 |---|---|
 | `tier` custom property with `required: true, defaultValue: standard` | The new repo carries `tier=standard` from birth, so the `baseline-default-branch` org ruleset (§5.4) matches it **immediately**. |
-| `OrganizationSettings` new-repo toggles | `advanced_security`, `dependabot_alerts`, `dependabot_security_updates`, `dependency_graph`, `secret_scanning`, `secret_scanning_push_protection` — six `*_enabled_for_new_repositories` flags, **all currently off** (SEC-05). Set once; every future repo inherits them. |
+| `OrganizationSettings` new-repo toggles | Six `*_enabled_for_new_repositories` flags. `secret_scanning` and `secret_scanning_push_protection` are **already on**. `advanced_security`, `dependabot_alerts`, `dependency_graph` are off, tracked as a future phase-5 diff. `dependabot_security_updates` is **deliberately off, not a pending flip** — closed 2026-08-14 as SEC-05 won't-fix (§7): the org's shared Renovate config already covers vulnerability remediation, so enabling GitHub's native auto-fix PRs org-wide (existing repos or new ones) would duplicate it. |
 | The `.github` repo | Org-wide default issue/PR templates and community health files. Already works; no Pulumi involvement. |
 | `default_repository_permission: none` | Already correct. |
 
@@ -924,7 +924,7 @@ fixtures and cheap to add — the rule set is meant to grow every time someone n
 | SEC-02 | Force-push to default branch not blocked | every sampled repo |
 | SEC-03 | No required status checks on default branch | every sampled repo |
 | SEC-04 | Secret scanning or push protection disabled | `hq` (private) |
-| SEC-05 | Dependabot alerts or security updates disabled | every sampled repo + org default |
+| SEC-05 | ~~Dependabot alerts or security updates disabled~~ | **RETIRED 2026-08-14**, won't-fix: the org's shared Renovate config already covers vulnerability remediation (`vulnerabilityAlerts` + `osvVulnerabilityAlerts`); enabling GitHub's native auto-fix PRs too would duplicate Renovate's PR on every repo extending it. The `base` archetype default is now `false`, and the audit rule is removed rather than left firing on the deliberate default. |
 | SEC-06 | **Any** direct collaborator on **any** repo — repo access must come from team membership (§4.7) | **fires on 72 repos**: 83 grants, 73 of them `admin`, across 20 people |
 | SEC-07 | Webhook without a secret, or a non-HTTPS URL | unknown |
 | SEC-08 | Write-enabled deploy key on an active repo | unknown |

--- a/src/ol_infrastructure/saas/github/audit.py
+++ b/src/ol_infrastructure/saas/github/audit.py
@@ -163,18 +163,17 @@ RULES: tuple[Rule, ...] = (
             else None
         ),
     ),
-    Rule(
-        "SEC-05",
-        "security",
-        "high",
-        "active",
-        "Dependabot security updates disabled",
-        lambda r: (
-            ("disabled", "enabled", "set dependabot_security_updates in the archetype")
-            if not r.get("dependabot_security_updates")
-            else None
-        ),
-    ),
+    # SEC-05 (Dependabot security updates disabled) is RETIRED, not merely quiet.
+    # Closed 2026-08-14 as won't-fix: the org's shared Renovate config
+    # (`mitodl/.github:renovate-config`) already sets
+    # `vulnerabilityAlerts.enabled: true` plus `osvVulnerabilityAlerts: true`, sourced
+    # from the same `vulnerability_alerts` data GitHub's own toggle would use,
+    # bypassing Renovate's normal schedule. Enabling
+    # GitHub's native auto-fix PRs on top of that would duplicate Renovate's PR on every
+    # repo extending the shared config -- see the `base` archetype's comment in
+    # data/archetypes.yaml. A rule left in place here would report that duplication risk
+    # as a "disabled" finding on 174 of 176 active repos, forever, which is the opposite
+    # of what actually happened: the archetype default is `false` on purpose now.
     Rule(
         "SEC-06",
         "security",

--- a/src/ol_infrastructure/saas/github/organization/org_settings.py
+++ b/src/ol_infrastructure/saas/github/organization/org_settings.py
@@ -6,8 +6,11 @@ the provider sends its own default, so omitting a field is an unreviewed change
 wearing the costume of an omission. Recording reality is what lets the empty-diff
 gate mean something (plan section 6).
 
-Values that are wrong today are marked SEC-05 / SEC-10 below. They change in phase 5,
-as a reviewed diff against this file, not on the way in.
+Values that are wrong today are marked SEC-10 below and change as a reviewed diff
+against this file, not on the way in. SEC-05 is the exception: it looked like the
+same shape (a wrong value pending a phase-5 flip) but turned out to be a deliberate
+decision instead -- see the comment at
+`dependabot_security_updates_enabled_for_new_repositories`.
 """
 
 import pulumi_github as github
@@ -26,12 +29,20 @@ ORGANIZATION_SETTINGS = github.OrganizationSettings(
     # Correct as-is: members get nothing by default; access comes from teams (4.7).
     default_repository_permission="none",
     # --- Security defaults applied to NEWLY CREATED repos ---------------------------
-    # SEC-05. These four being false is why a new repo starts without Dependabot or
-    # code scanning. Turning them on is the cheapest half of section 3.5 tier 1: a
-    # one-time change here that every future repo inherits, with no per-repo work.
-    # Left false so the import lands clean; flipping them is a reviewed phase-5 diff.
+    # `advanced_security`, `dependabot_alerts`, `dependency_graph` being false is why a
+    # new repo starts without code scanning. Turning them on is the cheapest half of
+    # section 3.5 tier 1: a one-time change here that every future repo inherits, with
+    # no per-repo work. Left false so the import lands clean; flipping them is a
+    # reviewed phase-5 diff.
     advanced_security_enabled_for_new_repositories=False,
     dependabot_alerts_enabled_for_new_repositories=False,
+    # NOT part of the phase-5 flip above, and not scheduled to become one. Closed
+    # 2026-08-14 as SEC-05 won't-fix: the org's shared Renovate config
+    # (`mitodl/.github:renovate-config`) already sets `vulnerabilityAlerts.enabled:
+    # true` plus `osvVulnerabilityAlerts: true`, so GitHub's native auto-fix PRs would
+    # duplicate Renovate's PR on every repo extending it -- new repos included. See the
+    # `dependabot_security_updates` comment in repositories/data/archetypes.yaml for
+    # the same decision applied per-repo.
     dependabot_security_updates_enabled_for_new_repositories=False,
     dependency_graph_enabled_for_new_repositories=False,
     # Already correct. Worth noting precisely: the estate report's "org defaults
@@ -40,15 +51,20 @@ ORGANIZATION_SETTINGS = github.OrganizationSettings(
     secret_scanning_push_protection_enabled_for_new_repositories=True,
     # --- What members may create ----------------------------------------------------
     # SEC-10: any of 39 members can create a public repo, AND flip an existing private
-    # repo public with no review step. The second half is closed 2026-08-14, but not
-    # here: `members_can_change_repo_visibility` does not exist anywhere in
-    # `pulumi_github.OrganizationSettings`'s 6.14.1 argument list -- verified against
-    # the installed provider's own generated bindings, not docs. The GitHub REST API
-    # has this field (`PATCH /orgs/{org}`); the Terraform/Pulumi provider never wired
-    # it up. Same shape as the `Membership` exclusion in plan §4.7: not modelling a
-    # setting is not the same as leaving it unmanaged by choice, so it is toggled off
-    # by an org owner directly in Settings -> Member privileges, and this comment is
-    # the only place that decision is recorded. Re-check on any provider bump.
+    # repo public with no review step. The decision to close the second half is made
+    # (2026-08-14: restrict visibility changes, leave creation alone -- see below), but
+    # the SETTING ITSELF IS STILL LIVE AND UNCHANGED. There is no Pulumi resource for
+    # it here or anywhere else: `members_can_change_repo_visibility` does not exist in
+    # `pulumi_github.OrganizationSettings`'s 6.14.1 argument list at all -- verified
+    # against the installed provider's own generated bindings, not docs. The GitHub
+    # REST API has this field (`PATCH /orgs/{org}`); the Terraform/Pulumi provider
+    # never wired it up. Same shape as the `Membership` exclusion in plan §4.7: not
+    # modelling a setting is not the same as having already applied the decision.
+    # PENDING: an org owner must still toggle it off by hand in
+    # Settings -> Member privileges -> "Allow members to change repository
+    # visibilities for this organization". Tracked in tk-sec-10 until that happens;
+    # this comment records the decision, not its completion. Re-check for provider
+    # support on any pulumi_github version bump.
     #
     # `members_can_create_public_repositories` stays true on purpose (decision
     # 2026-08-14): restricting repo/public-repo *creation* is the bigger workflow

--- a/src/ol_infrastructure/saas/github/organization/org_settings.py
+++ b/src/ol_infrastructure/saas/github/organization/org_settings.py
@@ -39,8 +39,21 @@ ORGANIZATION_SETTINGS = github.OrganizationSettings(
     secret_scanning_enabled_for_new_repositories=True,
     secret_scanning_push_protection_enabled_for_new_repositories=True,
     # --- What members may create ----------------------------------------------------
-    # SEC-10: any of 39 members can create a public repo. Tightening it is a policy
-    # decision with real workflow cost, so it is a phase-5 diff rather than an import.
+    # SEC-10: any of 39 members can create a public repo, AND flip an existing private
+    # repo public with no review step. The second half is closed 2026-08-14, but not
+    # here: `members_can_change_repo_visibility` does not exist anywhere in
+    # `pulumi_github.OrganizationSettings`'s 6.14.1 argument list -- verified against
+    # the installed provider's own generated bindings, not docs. The GitHub REST API
+    # has this field (`PATCH /orgs/{org}`); the Terraform/Pulumi provider never wired
+    # it up. Same shape as the `Membership` exclusion in plan §4.7: not modelling a
+    # setting is not the same as leaving it unmanaged by choice, so it is toggled off
+    # by an org owner directly in Settings -> Member privileges, and this comment is
+    # the only place that decision is recorded. Re-check on any provider bump.
+    #
+    # `members_can_create_public_repositories` stays true on purpose (decision
+    # 2026-08-14): restricting repo/public-repo *creation* is the bigger workflow
+    # change (every new OSS repo would need an owner in the loop) and was not the
+    # part of SEC-10 that was actionable now.
     members_can_create_public_repositories=True,
     members_can_create_private_repositories=True,
     members_can_create_internal_repositories=False,

--- a/src/ol_infrastructure/saas/github/repositories/data/archetypes.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/archetypes.yaml
@@ -36,7 +36,16 @@ archetypes:
     has_wiki: false
     web_commit_signoff_required: true
     vulnerability_alerts: true
-    dependabot_security_updates: true
+    # GITHUB'S NATIVE AUTO-FIX PRS ARE DELIBERATELY NOT ENABLED (decision 2026-08-14,
+    # closing SEC-05 as won't-fix). The org's shared Renovate config
+    # (`mitodl/.github:renovate-config`) already sets `vulnerabilityAlerts.enabled: true`
+    # plus `osvVulnerabilityAlerts: true` -- Renovate opens its own fix PRs sourced from
+    # the same `vulnerability_alerts` data (the toggle above) plus OSV as a second source,
+    # bypassing its normal schedule. Turning this on too would duplicate that PR on every
+    # repo extending the shared config. `access-forge` and `ckeditor-custom-build` are
+    # explicit true overrides below/in their repo files -- they were already live-enabled
+    # before this decision and are left as-is rather than turned off.
+    dependabot_security_updates: false
     secret_scanning: enabled  # pragma: allowlist secret
     secret_scanning_push_protection: enabled  # pragma: allowlist secret
     default_branch: main

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/.github.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/.github.yaml
@@ -12,7 +12,6 @@ allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-dependabot_security_updates: false
 description: Common configuration for GitHub across the organization
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/XBlock.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/XBlock.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: XBlock courseware component architecture
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/access-forge.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/access-forge.yaml
@@ -33,6 +33,7 @@ allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
+dependabot_security_updates: true
 description: Automated user management system for Keycloak using GitHub Actions
 has_discussions: false
 has_projects: true
@@ -40,8 +41,6 @@ has_wiki: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: access-forge
-secret_scanning: disabled
-secret_scanning_push_protection: disabled
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/access-forge.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/access-forge.yaml
@@ -41,6 +41,8 @@ has_wiki: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: access-forge
+secret_scanning: disabled
+secret_scanning_push_protection: disabled
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/agent-kit.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/agent-kit.yaml
@@ -11,7 +11,6 @@ allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true
 archetype: library
-dependabot_security_updates: false
 description: 'Team toolkit for AI agent utilities: skills, custom agents, MCP helpers,
   and configurations'
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/alerting-omnibus.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/alerting-omnibus.yaml
@@ -18,6 +18,8 @@ has_wiki: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: alerting-omnibus
+secret_scanning: disabled
+secret_scanning_push_protection: disabled
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams: {}

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/alerting-omnibus.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/alerting-omnibus.yaml
@@ -11,7 +11,6 @@ allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Download and report on Rootly alerting data
 has_discussions: false
 has_projects: true
@@ -19,8 +18,6 @@ has_wiki: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: alerting-omnibus
-secret_scanning: disabled
-secret_scanning_push_protection: disabled
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams: {}

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/apisix-testbed.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/apisix-testbed.yaml
@@ -20,6 +20,8 @@ has_wiki: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: apisix-testbed
+secret_scanning: disabled
+secret_scanning_push_protection: disabled
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams: {}

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/apisix-testbed.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/apisix-testbed.yaml
@@ -13,7 +13,6 @@ allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: 'APISIX/OIDC testbed '
 has_discussions: false
 has_projects: true
@@ -21,8 +20,6 @@ has_wiki: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: apisix-testbed
-secret_scanning: disabled
-secret_scanning_push_protection: disabled
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams: {}

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/apisix.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/apisix.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: The Cloud-Native API Gateway and AI Gateway
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/brand-mitol-residential.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/brand-mitol-residential.yaml
@@ -14,7 +14,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 merge_commit_message: PR_TITLE

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ckeditor-custom-build.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ckeditor-custom-build.yaml
@@ -12,6 +12,7 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
+dependabot_security_updates: true
 description: The classic editor build of CKEditor 5.
 has_discussions: false
 has_issues: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/codejail.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/codejail.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Secure code execution
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/common-access.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/common-access.yaml
@@ -13,7 +13,6 @@ allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Plug and play apisix/keycloak setup for local dev
 has_discussions: false
 has_projects: true
@@ -21,8 +20,6 @@ has_wiki: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: common-access
-secret_scanning: disabled
-secret_scanning_push_protection: disabled
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/common-access.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/common-access.yaml
@@ -20,6 +20,8 @@ has_wiki: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: common-access
+secret_scanning: disabled
+secret_scanning_push_protection: disabled
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/community-integrations.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/community-integrations.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: main
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Community supported integrations for the Dagster platform.
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-dcind.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-dcind.yaml
@@ -14,7 +14,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Docker in Docker container optimized for use with Concourse CI
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-rclone-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-rclone-resource.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: A Rclone resource for Concourse CI
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-s3-sync-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-s3-sync-resource.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Concourse CI resource to sync a directory to S3
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-workflow.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-workflow.yaml
@@ -23,6 +23,8 @@ has_projects: false
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: concourse-workflow
+secret_scanning: disabled
+secret_scanning_push_protection: disabled
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-workflow.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-workflow.yaml
@@ -16,7 +16,6 @@ allow_rebase_merge: true
 allow_squash_merge: true
 archetype: infrastructure
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: A repository that will hold Github Issues with which to test the Concourse
   issue driven workflow
 has_discussions: false
@@ -24,8 +23,6 @@ has_projects: false
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: concourse-workflow
-secret_scanning: disabled
-secret_scanning_push_protection: disabled
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Concourse is a container-based automation system written in Go. It's
   mostly used for CI/CD.
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concoursepy.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concoursepy.yaml
@@ -14,7 +14,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/configuration.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/configuration.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: a simple, but flexible, way for anyone to stand up an instance of the
   edX platform that is fully configured and ready-to-go
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/course-search-utils.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/course-search-utils.yaml
@@ -12,7 +12,6 @@ allow_rebase_merge: false
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: JS library providing tools to work with MIT Open search
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/cs_comments_service.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/cs_comments_service.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: server side of the comment service
 has_discussions: false
 has_issues: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/dagster.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/dagster.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: A data orchestrator for machine learning, analytics, and ETL.
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/default-labels-repo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/default-labels-repo.yaml
@@ -11,7 +11,6 @@ allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/demo-test-course.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/demo-test-course.yaml
@@ -14,7 +14,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: A demo course with as many features turned on as possible
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-aqueduct.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-aqueduct.yaml
@@ -12,7 +12,6 @@ allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Structured, typed, auditable Django settings management powered by Pydantic
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-cas-mapper.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-cas-mapper.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: library
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-guardian.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-guardian.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: devel
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Implementation of per object permissions for Django 1.2+
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-longer-username.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-longer-username.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: 'An app to easily provide a longer username field for django. '
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-role-permissions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-role-permissions.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: A django app for role based permissions.
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-shibboleth-remoteuser.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-shibboleth-remoteuser.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Middleware for using Shibboleth with Django
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-user-tasks.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-user-tasks.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: A Django application for managing user-triggered asynchronous tasks.
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/docs.openedx.org.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/docs.openedx.org.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: main
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Open edX Official Documentation
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ecommerce.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ecommerce.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: (Deprecated) Service for managing edX's product catalog and handling
   orders for those products
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-analytics-api-client.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-analytics-api-client.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-api-client.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-api-client.yaml
@@ -13,7 +13,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Python interface for edX REST APIs
 has_discussions: false
 has_issues: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-documentation.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-documentation.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-enterprise-data.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-enterprise-data.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: The edX Enterprise Data repo is the home to tools and products related
   to providing access to Enterprise related data.
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-enterprise.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-enterprise.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 merge_commit_message: PR_TITLE

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-ora2.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-ora2.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Open Response Assessment Suite
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-platform.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-platform.yaml
@@ -15,7 +15,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: The Open edX platform, the software that powers edX!
 has_discussions: false
 has_issues: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-proctoring-proctortrack.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-proctoring-proctortrack.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: This is the proctortrack exam subsystem for the edx-proctoring.
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-proctoring.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-proctoring.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-search.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-search.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 merge_commit_message: PR_TITLE

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-sga.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-sga.yaml
@@ -15,7 +15,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Staff Graded Assignment XBlock for the edX platform
 has_discussions: false
 has_issues: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-submissions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-submissions.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: API for creating submissions and scores
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-val.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-val.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_issues: true
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edxcut.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edxcut.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: library
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: edx course uber tool
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-access.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-access.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: main
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Service to manage access to content for enterprise users
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-catalog.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-catalog.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: A Django-based microservice for handling Enterprise catalogs, associating
   enterprise customers with curated courses from the full course catalog.
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-integrated-channels.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-integrated-channels.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: main
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 merge_commit_message: PR_TITLE

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-subsidy.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-subsidy.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: main
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Captures and balances enterprise-subsidized transactions.
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/epithet.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/epithet.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Manage your labels
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/eslint-config.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/eslint-config.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: library
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: our preferred configuration for eslint
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/forum.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/forum.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Python rewrite of the legacy Open edX Ruby forum
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-communications.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-communications.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Frontend to manage instructor-learner communications
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-course-authoring.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-course-authoring.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: The micro-frontend for course authoring in Open edX.  Frontend interfaces
   that currently live in Studio/CMS should eventually live here.
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-discussions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-discussions.yaml
@@ -14,7 +14,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: A React-based micro frontend for the Open edX discussion forums.
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-gradebook.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-gradebook.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Instructor gradebook tool for Master's programs
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-instructor-dashboard.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-instructor-dashboard.yaml
@@ -14,7 +14,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: main
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Instructor Dashboard pages in MFE-land
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-learner-dashboard.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-learner-dashboard.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Learner Dashboard MFE
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-learning.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-learning.yaml
@@ -14,7 +14,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Front-end for the Open edX course experience, implemented using React
   and Paragon.
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-library-authoring.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-library-authoring.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Work-in-progress micro-frontend experience for Open edX Blockstore-based
   content libraries.
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-footer-mitol.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-footer-mitol.yaml
@@ -15,7 +15,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Site footer component for edX frontend apps.
 has_discussions: false
 has_issues: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-header-edx-mitol.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-header-edx-mitol.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_issues: true
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-header-mitol.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-header-mitol.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-lib-special-exams-mitol.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-lib-special-exams-mitol.yaml
@@ -14,7 +14,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: main
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Frontend component library for displaying special exams on the edx platform
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-platform.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-platform.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: A framework for Open edX micro-frontend applications.
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-slot-footer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-slot-footer.yaml
@@ -14,7 +14,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Site footer PluginSlot utilizing Frontend Plugin Framework
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/gwarek.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/gwarek.yaml
@@ -14,15 +14,12 @@ allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 has_wiki: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: gwarek
-secret_scanning: disabled
-secret_scanning_push_protection: disabled
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/gwarek.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/gwarek.yaml
@@ -20,6 +20,8 @@ has_wiki: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: gwarek
+secret_scanning: disabled
+secret_scanning_push_protection: disabled
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/hacksnack.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/hacksnack.yaml
@@ -13,7 +13,6 @@ allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/handbook.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/handbook.yaml
@@ -13,7 +13,6 @@ allow_squash_merge: true
 archetype: library
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Information on how we do what we do.
 has_discussions: false
 has_projects: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/hashicorp-release-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/hashicorp-release-resource.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Concourse resource to track and fetch Hashicorp projects
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/healthchecks.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/healthchecks.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Django app which listens for pings and sends alerts when pings are late
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/heroku-database-backups.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/heroku-database-backups.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Heroku database backups and copies to S3
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/hq.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/hq.yaml
@@ -23,6 +23,8 @@ has_wiki: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: hq
+secret_scanning: disabled
+secret_scanning_push_protection: disabled
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/hq.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/hq.yaml
@@ -16,7 +16,6 @@ allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: OL Engineering & Products - headquarters
 has_discussions: true
 has_projects: true
@@ -24,8 +23,6 @@ has_wiki: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: hq
-secret_scanning: disabled
-secret_scanning_push_protection: disabled
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/iso-3166-2.js.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/iso-3166-2.js.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Lookup information about ISO-3166-2 subdivisions
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/jsdom-global.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/jsdom-global.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Enable DOM in Node.js
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/keycloak-scim.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/keycloak-scim.yaml
@@ -11,7 +11,6 @@ allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: SCIM client plugin for Keycloak
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/kubectl-slice.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/kubectl-slice.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Split multiple Kubernetes files into smaller files with ease. Split multi-YAML
   files into individual files.
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/learn-ai.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/learn-ai.yaml
@@ -12,7 +12,6 @@ allow_rebase_merge: false
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/learn-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/learn-zendesk-theme.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: The default theme for Zendesk Guide
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/lehrer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/lehrer.yaml
@@ -11,7 +11,6 @@ allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-dependabot_security_updates: false
 description: Dagger-based build pipeline for Open edX platform images
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/library-customization.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/library-customization.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: An example repo that customizes Library behavior
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/library.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/library.yaml
@@ -15,7 +15,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: main
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: A collaborative documentation site, powered by Google Docs.
 has_discussions: false
 has_issues: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters-zendesk-theme.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: The default theme for Zendesk Guide
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters.yaml
@@ -17,7 +17,6 @@ allow_squash_merge: true
 archetype: application
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: 'Portal for learners and course teams to access MITx Micromasters® programs '
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn-api-clients.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn-api-clients.yaml
@@ -10,7 +10,6 @@ allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true
 archetype: library
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 merge_commit_message: PR_TITLE

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
@@ -18,7 +18,6 @@ allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true
 archetype: application
-dependabot_security_updates: false
 has_discussions: true
 has_projects: true
 merge_commit_message: PR_TITLE

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-moira.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-moira.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: library
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Python client for accessing MIT's Moira system
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-open-bk.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-open-bk.yaml
@@ -14,7 +14,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_issues: true
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-grading-library.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-grading-library.yaml
@@ -16,7 +16,6 @@ allow_squash_merge: true
 archetype: library
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: The MITx Grading Library, a python grading library for edX
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-theme.yaml
@@ -13,7 +13,6 @@ allow_squash_merge: true
 archetype: library
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Open edX theme for the Residential MITx instance
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitx_cas_mapper.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitx_cas_mapper.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: library
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-api-clients.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-api-clients.yaml
@@ -12,7 +12,6 @@ allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-theme.yaml
@@ -12,7 +12,6 @@ allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: an open edX theme for MITx Online
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-translations.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-translations.yaml
@@ -14,7 +14,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: main
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Open edX Translation files in sync with Transifex
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-zendesk-theme.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: The default theme for Zendesk Guide
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline.yaml
@@ -17,7 +17,6 @@ allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true
 archetype: application
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 merge_commit_message: PR_TITLE

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-theme.yaml
@@ -15,7 +15,6 @@ allow_squash_merge: true
 archetype: library
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: 'an open edX theme for MIT xPRO '
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-zendesk-theme.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: MITx Pro fork of the default theme for Zendesk Guide
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro.yaml
@@ -18,7 +18,6 @@ allow_rebase_merge: true
 allow_squash_merge: true
 archetype: application
 default_branch: master
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 merge_commit_message: PR_TITLE

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mynumbers.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mynumbers.yaml
@@ -14,7 +14,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: main
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: fun wih arithmetic
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-projects.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-projects.yaml
@@ -14,7 +14,6 @@ allow_rebase_merge: false
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: A collection of Hugo project templates for different types of OCW websites
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-themes.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-themes.yaml
@@ -27,7 +27,6 @@ allow_rebase_merge: false
 allow_squash_merge: true
 archetype: application
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: A Hugo theme for building OCW websites
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-studio.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-studio.yaml
@@ -17,7 +17,6 @@ allow_rebase_merge: false
 allow_squash_merge: true
 archetype: application
 default_branch: master
-dependabot_security_updates: false
 description: Open Source Courseware authoring tool
 has_discussions: true
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-zendesk-theme.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: The default theme for Zendesk Guide
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw_oer_export.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw_oer_export.yaml
@@ -15,7 +15,6 @@ allow_rebase_merge: false
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/odl-video-service.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/odl-video-service.yaml
@@ -12,7 +12,6 @@ allow_rebase_merge: true
 allow_squash_merge: true
 archetype: application
 default_branch: master
-dependabot_security_updates: false
 description: building blocks for a basic video service for ODL
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-analytics-api.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-analytics-api.yaml
@@ -12,7 +12,6 @@ allow_rebase_merge: true
 allow_squash_merge: true
 archetype: application
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Multi-tenant read-only FastAPI analytics gateway over StarRocks (B2B
   site-license analytics for MIT Learn)
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-concourse.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-concourse.yaml
@@ -11,7 +11,6 @@ allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: infrastructure
-dependabot_security_updates: false
 description: MIT Open Learning Concourse CI/CD monorepo — resources and pipeline tooling
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-customizations-nytimes-library.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-customizations-nytimes-library.yaml
@@ -11,7 +11,6 @@ allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Customizations for the NYTimes Library application to fit the needs of
   MIT Open Learning
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-data-platform.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-data-platform.yaml
@@ -13,7 +13,6 @@ allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-dependabot_security_updates: false
 description: Pipeline definitions for managing data flows to power analytics at MIT
   Open Learning
 has_discussions: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-django.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-django.yaml
@@ -15,7 +15,6 @@ allow_merge_commit: false
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 merge_commit_message: PR_TITLE

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-github-workflows.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-github-workflows.yaml
@@ -13,7 +13,6 @@ allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Repository for shared workflows across projects
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infra-health-checks.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infra-health-checks.yaml
@@ -11,7 +11,6 @@ allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: A repository for MIT OL Infrastructure Health Checks
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
@@ -13,7 +13,6 @@ allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: infrastructure
-dependabot_security_updates: false
 description: Infrastructure automation code for use by MIT Open Learning
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloak.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloak.yaml
@@ -10,7 +10,6 @@ allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-dependabot_security_updates: false
 description: Custom theme and extensions for Keycloak SSO
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloakify.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloakify.yaml
@@ -12,7 +12,6 @@ allow_rebase_merge: false
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Customization of the theme and UX for OL SSO
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-notebook-extensions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-notebook-extensions.yaml
@@ -13,7 +13,6 @@ allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: A repository of plugins for extending and customizing Jupyter notebooks
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-parliament.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-parliament.yaml
@@ -12,7 +12,6 @@ allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: main
-dependabot_security_updates: false
 description: AWS IAM linting library
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-rootly-manager.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-rootly-manager.yaml
@@ -11,7 +11,6 @@ allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/oldevops-scratch.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/oldevops-scratch.yaml
@@ -11,15 +11,12 @@ allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: A repository for testing automation
 has_discussions: false
 has_projects: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: oldevops-scratch
-secret_scanning: disabled
-secret_scanning_push_protection: disabled
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams: {}

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/oldevops-scratch.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/oldevops-scratch.yaml
@@ -17,6 +17,8 @@ has_projects: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: oldevops-scratch
+secret_scanning: disabled
+secret_scanning_push_protection: disabled
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams: {}

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-collaboration.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-collaboration.yaml
@@ -13,15 +13,12 @@ allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: 'Project Management for the MIT Open Unified project '
 has_discussions: false
 has_projects: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: open-collaboration
-secret_scanning: disabled
-secret_scanning_push_protection: disabled
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams: {}

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-collaboration.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-collaboration.yaml
@@ -19,6 +19,8 @@ has_projects: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: open-collaboration
+secret_scanning: disabled
+secret_scanning_push_protection: disabled
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams: {}

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-discussions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-discussions.yaml
@@ -15,7 +15,6 @@ allow_rebase_merge: false
 allow_squash_merge: true
 archetype: application
 default_branch: master
-dependabot_security_updates: false
 has_discussions: true
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-plugins.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-plugins.yaml
@@ -11,7 +11,6 @@ allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-dependabot_security_updates: false
 description: A repository of plugins for extending and customizing the behavior of
   Open edX projects
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-proposals.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-proposals.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: 'Proposals for Open edX architecture, best practices and processes '
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-learning-ai-tutor.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-learning-ai-tutor.yaml
@@ -13,7 +13,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: main
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: AI tutor MIT open Learning
 has_discussions: false
 has_issues: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-learnix.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-learnix.yaml
@@ -9,7 +9,6 @@ allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true
 archetype: library
-dependabot_security_updates: false
 description: Nix tooling to work with our repositories under Nixos
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-podcast-data.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-podcast-data.yaml
@@ -14,7 +14,6 @@ allow_squash_merge: true
 archetype: library
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: where are all MIT podcasts ?
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-resource-blocklists.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-resource-blocklists.yaml
@@ -14,7 +14,6 @@ allow_squash_merge: true
 archetype: library
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Lists of resources to be excluded from search results
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-video-data.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-video-data.yaml
@@ -11,7 +11,6 @@ allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/openedx-events.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/openedx-events.yaml
@@ -14,7 +14,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: main
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Open edX events from the Hooks Extensions Framework
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/openedx-ledger.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/openedx-ledger.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: main
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: A library that records transactions against a ledger, denominated in
   units of value.
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/opentelemetry-python-contrib.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/opentelemetry-python-contrib.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: main
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: OpenTelemetry instrumentation for Python modules
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/platform-engineering-site.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/platform-engineering-site.yaml
@@ -12,7 +12,6 @@ allow_rebase_merge: false
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: The MIT Online Learning Platform Engineering Site Repository
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pre-commit-ci-config.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pre-commit-ci-config.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: main
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: validation for pre-commit.ci configuration
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pre-commit-packer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pre-commit-packer.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: main
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Provides pre-commit hooks for Packer projects.
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/product.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/product.yaml
@@ -17,6 +17,8 @@ has_projects: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: product
+secret_scanning: disabled
+secret_scanning_push_protection: disabled
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams: {}

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/product.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/product.yaml
@@ -11,15 +11,12 @@ allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: OL Product Management
 has_discussions: true
 has_projects: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: product
-secret_scanning: disabled
-secret_scanning_push_protection: disabled
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams: {}

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/py-tree-sitter.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/py-tree-sitter.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Python bindings to the Tree-sitter parsing library
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pycassa.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pycassa.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: reddit
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Python Thrift driver for Apache Cassandra
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pylint-django.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pylint-django.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Pylint plugin for improving code analysis for when using Django
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/react-dropzone-uploader.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/react-dropzone-uploader.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: React file dropzone and uploader
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/realistic-mm-users.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/realistic-mm-users.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: library
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Queries randomuser.me and generates realistic user and program data for
   use in Micromasters
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/redash.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/redash.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Make Your Company Data Driven. Connect to any data source, easily visualize
   and share your data.
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-config.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-config.yaml
@@ -14,7 +14,6 @@ allow_squash_merge: true
 archetype: library
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-i18n.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-i18n.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: reddit's translation files - USE CROWDIN TO SUBMIT TRANSLATIONS. Direct
   pull requests to this repository will, generally, be rejected.
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-service-activity.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-service-activity.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: activity counting service
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-service-websockets.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-service-websockets.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: websockets for reddit
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/redux-asserts.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/redux-asserts.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: library
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/redux-hammock.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/redux-hammock.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: library
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: 🌴🍹Automatically generate actions and reducers for REST APIs
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/release-script.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/release-script.yaml
@@ -13,7 +13,6 @@ allow_squash_merge: true
 archetype: application
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Scripts to automate the release process, aka "Doof"
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/response-map.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/response-map.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Response map {{simulation}}
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/searchkit.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/searchkit.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: develop
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: React UI components / widgets. The easiest way to build a great search
   experience with Elasticsearch.
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/semantic-mitopen.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/semantic-mitopen.yaml
@@ -15,7 +15,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: main
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Codebase for semantic search of MIT Open Courseware (AI-powered Search
   and Chat for MIT Open Courseware)
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/sign-and-verify.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/sign-and-verify.yaml
@@ -14,7 +14,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/smoot-design.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/smoot-design.yaml
@@ -16,7 +16,6 @@ allow_rebase_merge: false
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Design system components for MITODL Projects
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/superset-marimo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/superset-marimo.yaml
@@ -10,7 +10,6 @@ allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true
 archetype: library
-dependabot_security_updates: false
 description: Marimo notebook integration for Apache Superset — connects reactive Python
   notebooks to Superset-configured data sources
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/superset-nl-explorer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/superset-nl-explorer.yaml
@@ -11,7 +11,6 @@ allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Natural language LLM interface for Apache Superset — chart, dashboard,
   and data exploration via chat. Deployed as a Superset extension plugin.
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/superset-sup.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/superset-sup.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: main
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: a modern CLI for Apache Superset and Preset workspaces
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/taxonomy-connector.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/taxonomy-connector.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: A python package that communicates with 3rd party taxonomy vendors
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/tech-talk-slides.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/tech-talk-slides.yaml
@@ -11,7 +11,6 @@ allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-dependabot_security_updates: false
 has_discussions: false
 has_issues: false
 has_projects: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/template-mit-demo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/template-mit-demo.yaml
@@ -16,7 +16,6 @@ allow_squash_merge: true
 archetype: library
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: A copy of https://github.com/mitocw/content-mit-latex2edx-demo turned
   into a cookiecutter template.
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/testinfra.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/testinfra.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Testinfra test your infrastructures
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/tutor.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/tutor.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: release
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: The Docker-based Open edX distribution designed for peace of mind
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ubcpi.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ubcpi.yaml
@@ -13,7 +13,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Peer Instruction XBlock
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/vault-plugin-database-starrocks.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/vault-plugin-database-starrocks.yaml
@@ -11,7 +11,6 @@ allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Vault database secrets engine plugin for StarRocks — uses COM_QUERY instead
   of COM_STMT_PREPARE to work around StarRocks prepared statement limitations
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/vault-plugin-secrets-openai.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/vault-plugin-secrets-openai.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: main
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: OpenAI secrets engine for HashiCorp Vault
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/vault-raft-backup.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/vault-raft-backup.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: library
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: A lean tool for creating Vault Raft snapshots and transferring them to
   AWS S3
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/video_translation_demo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/video_translation_demo.yaml
@@ -12,7 +12,6 @@ allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Video Subtitles Translation Demo
 has_discussions: false
 has_issues: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/world_geographic_regions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/world_geographic_regions.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: library
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: UN defined world geographic regions
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xanalytics.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xanalytics.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: library
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: Analytics for edX platform courses
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xblock-lti-consumer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xblock-lti-consumer.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 merge_commit_message: PR_TITLE

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xblock-utils.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xblock-utils.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xblocks-contrib.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xblocks-contrib.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: main
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_projects: true
 merge_commit_message: PR_TITLE

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xqueue-watcher.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xqueue-watcher.yaml
@@ -13,7 +13,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 has_discussions: false
 has_issues: true
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xqueue.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xqueue.yaml
@@ -12,7 +12,6 @@ allow_squash_merge: true
 archetype: fork
 default_branch: master
 delete_branch_on_merge: false
-dependabot_security_updates: false
 description: XQueue defines an interface for the LMS to communicate with external
   grader services.
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/repository.py
+++ b/src/ol_infrastructure/saas/github/repositories/repository.py
@@ -210,6 +210,13 @@ def build(repo: dict[str, Any]) -> None:
         opts=ResourceOptions(depends_on=[repository]),
     )
 
+    github.RepositoryDependabotSecurityUpdates(
+        f"mitodl-repo-dependabot-security-updates-{name}",
+        repository=name,
+        enabled=bool(repo.get("dependabot_security_updates")),
+        opts=ResourceOptions(depends_on=[repository]),
+    )
+
     _tier_property(name, repo["tier"], repository)
 
     for team_slug, permission in (repo.get("teams") or {}).items():

--- a/src/ol_infrastructure/saas/github/repositories/repository.py
+++ b/src/ol_infrastructure/saas/github/repositories/repository.py
@@ -203,18 +203,22 @@ def build(repo: dict[str, Any]) -> None:
         opts=ResourceOptions(depends_on=[repository]),
     )
 
-    github.RepositoryVulnerabilityAlerts(
+    vulnerability_alerts = github.RepositoryVulnerabilityAlerts(
         f"mitodl-repo-vulnerability-alerts-{name}",
         repository=name,
         enabled=bool(repo.get("vulnerability_alerts")),
         opts=ResourceOptions(depends_on=[repository]),
     )
 
+    # GitHub requires vulnerability alerts to be enabled before Dependabot security
+    # updates can be, so this must not run concurrently with the resource above --
+    # without depends_on, Pulumi is free to create both at once, and a repo that is
+    # new to Pulumi state (nothing yet imported) can fail this nondeterministically.
     github.RepositoryDependabotSecurityUpdates(
         f"mitodl-repo-dependabot-security-updates-{name}",
         repository=name,
         enabled=bool(repo.get("dependabot_security_updates")),
-        opts=ResourceOptions(depends_on=[repository]),
+        opts=ResourceOptions(depends_on=[repository, vulnerability_alerts]),
     )
 
     _tier_property(name, repo["tier"], repository)

--- a/tests/ol_infrastructure/saas/github/test_audit.py
+++ b/tests/ol_infrastructure/saas/github/test_audit.py
@@ -28,7 +28,6 @@ def repo(**overrides: Any) -> dict[str, Any]:
         "default_branch": "main",
         "allow_auto_merge": True,
         "delete_branch_on_merge": True,
-        "dependabot_security_updates": True,
         "secret_scanning": "enabled",  # pragma: allowlist secret
         "secret_scanning_push_protection": "enabled",  # pragma: allowlist secret
         "teams": {"odl-engineering-owners": "admin", "odl-engineering": "push"},
@@ -53,7 +52,6 @@ def test_clean_repo_fires_nothing() -> None:
     [
         ("SEC-01", {"_has_branch_protection": False, "_ruleset_count": 0}),
         ("SEC-04", {"secret_scanning": "disabled"}),  # pragma: allowlist secret
-        ("SEC-05", {"dependabot_security_updates": False}),
         ("SEC-06", {"_direct_collaborators": {"someone": "admin"}}),
         ("SEC-15", {"teams": {"arbisoft-contractors": "admin"}}),
         ("CON-02", {"delete_branch_on_merge": False}),
@@ -133,7 +131,9 @@ def test_rule_ids_are_unique() -> None:
 
 def test_findings_carry_remediation() -> None:
     """A finding without a next action is a complaint, not a backlog item."""
-    findings = audit.evaluate([repo(dependabot_security_updates=False)])
+    findings = audit.evaluate(
+        [repo(secret_scanning="disabled")]  # pragma: allowlist secret
+    )
     assert findings
     for finding in findings:
         assert finding.remediation


### PR DESCRIPTION
### What are the relevant tickets?
Part of the [GitHub org import project](docs/plans/github-org-pulumi-import.md). Closes SEC-05; documents the SEC-04/13 and SEC-10 blockers.

### Description (What does it do?)

- **SEC-04/13 investigated, deliberately NOT fixed**: originally removed the `secret_scanning` / `secret_scanning_push_protection` overrides on the 10 private repos that had them disabled, but Sentry's review flagged that private-repo secret scanning is a paid GHAS entitlement, not free like it is for public repos. Verified against the live API: mitodl is on the GitHub Team plan with a "Secret Protection" entitlement capped at 6 active committers (0 currently used). Counting distinct human pushers across the 10 affected repos in the last 90 days comes to 5 — close enough to the cap that we decided not to spend that headroom via this PR. All 10 repos (`hq`, `access-forge`, `alerting-omnibus`, `apisix-testbed`, `common-access`, `concourse-workflow`, `gwarek`, `oldevops-scratch`, `open-collaboration`, `product`) keep their `disabled` overrides, unchanged from before this PR.
- Wires up `RepositoryDependabotSecurityUpdates`, which the plan (§3.3) always listed as a `repository.py` resource type but was never actually emitted. Each repo's declared value matches its current live state, so this lands as a no-op apply (176 creates, zero behavior change), not a remediation. It also now `depends_on` the `RepositoryVulnerabilityAlerts` resource for the same repo (Copilot review catch) — GitHub requires vulnerability alerts enabled before security updates can be, so the two must not be created concurrently.
- **SEC-05 closed as won't-fix**, not enabled fleet-wide: the org's shared Renovate config (`mitodl/.github:renovate-config`) already sets `vulnerabilityAlerts.enabled: true` plus `osvVulnerabilityAlerts: true`, sourced from the same `vulnerability_alerts` data GitHub's own toggle would use, bypassing Renovate's normal schedule. Enabling GitHub's native auto-fix PRs on top of that would duplicate Renovate's PR on every repo extending the shared config. The `base` archetype default flips to `false`, the now-redundant per-repo `false` overrides (174 files) are dropped, and the SEC-05 audit rule is retired so it doesn't report the deliberate default as a perpetual finding. `docs/plans/github-org-pulumi-import.md` and `org_settings.py`'s docstring are updated to match (Copilot review catch — they still stated the pre-reversal policy).
- **SEC-10 documented, not fixed here**: `members_can_change_repo_visibility` has no path through Pulumi — verified against the installed `pulumi_github` 6.14.1 bindings, the field doesn't exist on `OrganizationSettings` even though GitHub's REST API has it. Documented in `org_settings.py`, worded so it's unambiguous the manual toggle is still pending (Copilot review catch — the original wording read as already done); tracked outside this diff in `tk-sec-10`.

### How can this be tested?

- `uv run pre-commit run --all-files` and `uv run mypy src/ol_infrastructure/saas/github/` both pass.
- `uv run pytest tests/ol_infrastructure/saas/github/` — 32 passed.
- `pulumi preview` against the live `ol-saas-github-repositories` stack: 176 creates (new `RepositoryDependabotSecurityUpdates` resources, all matching current live state) + 2 pre-existing `TeamRepository` permission drifts unrelated to this PR (not touched here). No secret-scanning changes.
- `pulumi preview` against `ol-saas-github-organization`: zero changes (comment-only edits).
- A reviewer can re-run the same two `pulumi preview` commands to confirm the diff is exactly the 176 dependabot-security-updates creates, nothing else.

### Additional Context

Once merged and applied, the only live GitHub state change is the 176 new `RepositoryDependabotSecurityUpdates` resources coming under Pulumi management — and every one of them mirrors an already-observed value, so no repo's actual Dependabot behavior changes either.

SEC-04/13 and SEC-10 both need a human decision/action outside Pulumi's reach: SEC-04/13 needs someone to confirm the GHAS committer math (or expand the seat count) before enabling private-repo secret scanning is safe to revisit; SEC-10 needs an org owner to flip `members_can_change_repo_visibility` by hand in the GitHub UI. Happy to file either as a follow-up task if useful.
