### PR TITLE
Add Grafana/Loki/Alloy logging to local-dev

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -13,6 +13,7 @@ config.define_string("openedx_mode", usage="qa (default) or local (Tutor)")
 config.define_string_list("prebuilt_tags", usage="Prebuilt image tag overrides per app, e.g. mit-learn=0.62.0 learn-ai=0.28.3")
 config.define_string("disk_keep_tags", usage="Newest tilt-built image tags kept per repo by the disk janitor (default: 3). Overrides LOCAL_DEV_DISK_KEEP_TAGS env var.")
 config.define_string("disk_buildcache_max_gb", usage="Docker build-cache size cap in GB (default: 10% of total disk; 0 disables). Overrides LOCAL_DEV_BUILDCACHE_MAX_GB env var.")
+config.define_string("log_retention_period", usage="How long Grafana/Loki keeps local-dev logs, as a whole number of days, e.g. 72h or 3d (default: 168h). Overrides LOCAL_DEV_LOG_RETENTION env var.")
 cfg = config.parse()
 
 enabled_apps = cfg.get("enabled_apps", ["mit-learn", "learn-ai", "mitxonline", "odl-video-service"])
@@ -47,6 +48,12 @@ prebuilt_tags = {
     for kv in cfg.get("prebuilt_tags", [])
     if "=" in kv
 }
+
+# How long Loki keeps logs. Empty means the Pulumi program's own default (168h).
+# Set it per-developer in the gitignored tilt_config.json — it is deliberately
+# not pinned in Pulumi.local-dev.core.Dev.yaml, since Pulumi config would win
+# over the environment and silently override this.
+log_retention_period = cfg.get("log_retention_period") or os.environ.get("LOCAL_DEV_LOG_RETENTION", "")
 
 # Workspace root: directory that contains ol-infrastructure and sibling app repos.
 # Override with MITOL_WORKSPACE_ROOT environment variable.
@@ -230,7 +237,7 @@ APPS = [
 # Core stack (operators, foundational services, Keycloak instance)
 local_resource(
     "local-infra-core",
-    cmd="LOCAL_DEV_ROOT_DOMAIN={rd} PULUMI_CONFIG_PASSPHRASE='' bash -c 'pulumi stack init local-dev.core.Dev 2>/dev/null; pulumi refresh --yes --skip-preview --stack local-dev.core.Dev && pulumi up --yes --skip-preview --logtostderr --stack local-dev.core.Dev'".format(rd=root_domain),
+    cmd="LOCAL_DEV_ROOT_DOMAIN={rd} LOCAL_DEV_LOG_RETENTION={lr} PULUMI_CONFIG_PASSPHRASE='' bash -c 'pulumi stack init local-dev.core.Dev 2>/dev/null; pulumi refresh --yes --skip-preview --stack local-dev.core.Dev && pulumi up --yes --skip-preview --logtostderr --stack local-dev.core.Dev'".format(rd=root_domain, lr=log_retention_period),
     dir="./local-dev/infra/core",
     deps=["./local-dev/infra/modules", "./local-dev/infra/core/__main__.py"],
     labels=["infra"],

--- a/Tiltfile
+++ b/Tiltfile
@@ -237,7 +237,16 @@ APPS = [
 # Core stack (operators, foundational services, Keycloak instance)
 local_resource(
     "local-infra-core",
-    cmd="LOCAL_DEV_ROOT_DOMAIN={rd} LOCAL_DEV_LOG_RETENTION={lr} PULUMI_CONFIG_PASSPHRASE='' bash -c 'pulumi stack init local-dev.core.Dev 2>/dev/null; pulumi refresh --yes --skip-preview --stack local-dev.core.Dev && pulumi up --yes --skip-preview --logtostderr --stack local-dev.core.Dev'".format(rd=root_domain, lr=log_retention_period),
+    cmd="bash -c 'pulumi stack init local-dev.core.Dev 2>/dev/null; pulumi refresh --yes --skip-preview --stack local-dev.core.Dev && pulumi up --yes --skip-preview --logtostderr --stack local-dev.core.Dev'",
+    # Passed as environment rather than interpolated into the command string:
+    # log_retention_period is developer-supplied, and a value containing shell
+    # metacharacters would otherwise be interpreted here instead of reaching
+    # validate_retention_period() in observability.py.
+    env={
+        "LOCAL_DEV_ROOT_DOMAIN": root_domain,
+        "LOCAL_DEV_LOG_RETENTION": log_retention_period,
+        "PULUMI_CONFIG_PASSPHRASE": "",
+    },
     dir="./local-dev/infra/core",
     deps=["./local-dev/infra/modules", "./local-dev/infra/core/__main__.py"],
     labels=["infra"],

--- a/local-dev/ARCHITECTURE.md
+++ b/local-dev/ARCHITECTURE.md
@@ -193,6 +193,8 @@ This is the production shape, shrunk. Production runs the same collector, Grafan
 
 Collection reads log *files* off the node rather than streaming through the API server (`loki.source.kubernetes`). The streaming path rides the same kubelet `:10250` API that is documented to wedge after VM sleep, which would kill log collection exactly when the environment is already broken.
 
+Grafana's **Logs Drilldown** app (`Drilldown → Logs`) is the intended entry point — browsing services, fields and patterns beats writing LogQL for the "something is wrong, where?" case that brings anyone here in the first place. It carries two setup requirements that are easy to miss because neither fails loudly. Grafana preinstalls the app *asynchronously* by default, so on a fresh PVC the server starts serving before the download lands and the first page load renders a nav with no Logs entry; `GF_PLUGINS_PREINSTALL_ASYNC=false` moves the install ahead of the HTTP listener. And Loki's `pattern_ingester` is off by default, which leaves the Patterns tab permanently empty with `/loki/api/v1/patterns` returning 404 rather than an error the UI surfaces.
+
 Alloy also exposes an OTLP receiver on 4317/4318 forwarding to Loki's native OTLP endpoint (`http://alloy.operations.svc.cluster.local:4318`). **Nothing emits to it yet** — it exists so an app can opt into production-style OTLP export by setting the `OTEL_*` env vars used in the deployed environments, and so Keycloak's `OTEL_SDK_DISABLED=true` workaround in `identity_core.py` (added precisely because no receiver existed) can be lifted.
 
 The whole stack is roughly 1.3GB and can be switched off with `observability_enabled: "false"`; nothing else depends on it.

--- a/local-dev/ARCHITECTURE.md
+++ b/local-dev/ARCHITECTURE.md
@@ -143,7 +143,7 @@ flowchart TB
 
 ## What runs in the cluster
 
-Inside the cluster, workloads are grouped into namespaces: one per app, plus `local-infra` for shared services and `operations` for ingress.
+Inside the cluster, workloads are grouped into namespaces: one per app, plus `local-infra` for shared services and `operations` for ingress and observability.
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
@@ -153,7 +153,9 @@ Inside the cluster, workloads are grouped into namespaces: one per app, plus `lo
 │  │operations│  │           local-infra                    │  │
 │  │          │  │  PostgreSQL (CNPG)  Valkey  Qdrant       │  │
 │  │  APISIX  │  │  OpenSearch  Tika  Keycloak  LiteLLM     │  │
-│  │          │  │  Mailpit                                 │  │
+│  │  Grafana │  │  Mailpit                                 │  │
+│  │  Loki    │  │                                          │  │
+│  │  Alloy   │  │                                          │  │
 │  └────┬─────┘  └──────────────────────────────────────────┘  │
 │       │                                                       │
 │       │  routes traffic by hostname                          │
@@ -172,7 +174,28 @@ Inside the cluster, workloads are grouped into namespaces: one per app, plus `lo
     Developer browser / curl
 ```
 
-The shared services in `local-infra`, briefly: **PostgreSQL** (one CNPG-managed cluster, one database per app), **Valkey** (the open-source Redis fork — the apps' Redis cache and Celery broker), **OpenSearch** (search), **Qdrant** (vector database for AI features), **Tika** (document text extraction), **LiteLLM** (proxy in front of LLM APIs), **Keycloak** (SSO), and **Mailpit** (catches all outbound email). In `operations`: **APISIX** (ingress — hostname routing, TLS termination, OIDC).
+The shared services in `local-infra`, briefly: **PostgreSQL** (one CNPG-managed cluster, one database per app), **Valkey** (the open-source Redis fork — the apps' Redis cache and Celery broker), **OpenSearch** (search), **Qdrant** (vector database for AI features), **Tika** (document text extraction), **LiteLLM** (proxy in front of LLM APIs), **Keycloak** (SSO), and **Mailpit** (catches all outbound email). In `operations`: **APISIX** (ingress — hostname routing, TLS termination, OIDC), and the logging stack — **Alloy**, **Loki**, and **Grafana** (see below).
+
+### Observability
+
+Every pod's stdout is collected into one searchable place, reachable at `https://grafana.<root_domain>`:
+
+```
+every pod's stdout
+  → /var/log/pods/*/*/*.log       node filesystem, mounted read-only
+  → Alloy (DaemonSet, one per node)   discovery.kubernetes → local.file_match
+                                      → loki.source.file → stage.cri
+  → Loki (filesystem storage on a PVC, retention window enforced by the compactor)
+  → Grafana (anonymous Admin — no login on a local-only cluster)
+```
+
+This is the production shape, shrunk. Production runs the same collector, Grafana Alloy, via the `k8s-monitoring` Helm chart's `filesystem-log-reader` preset (`src/ol_infrastructure/substructure/aws/eks/grafana.py`). Two deliberate divergences: Loki and Grafana are self-hosted here instead of Grafana Cloud, and Alloy is configured by hand rather than through that chart, which would pull in four collectors plus kube-state-metrics, opencost and kepler for no local benefit.
+
+Collection reads log *files* off the node rather than streaming through the API server (`loki.source.kubernetes`). The streaming path rides the same kubelet `:10250` API that is documented to wedge after VM sleep, which would kill log collection exactly when the environment is already broken.
+
+Alloy also exposes an OTLP receiver on 4317/4318 forwarding to Loki's native OTLP endpoint (`http://alloy.operations.svc.cluster.local:4318`). **Nothing emits to it yet** — it exists so an app can opt into production-style OTLP export by setting the `OTEL_*` env vars used in the deployed environments, and so Keycloak's `OTEL_SDK_DISABLED=true` workaround in `identity_core.py` (added precisely because no receiver existed) can be lifted.
+
+The whole stack is roughly 1.3GB and can be switched off with `observability_enabled: "false"`; nothing else depends on it.
 
 ## Design decisions
 

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -39,6 +39,7 @@ This environment runs the MIT Learn application stack as Kubernetes workloads in
 | odl-video-service | `https://video.odl.mit.dev` | ODL Video Service (Django/uwsgi) |
 | Keycloak SSO | `https://sso.ol.mit.dev` | Identity provider (olapps realm) |
 | Mailpit | `https://mail.mit.dev` | Captured outbound email (web UI) |
+| Grafana | `https://grafana.mit.dev` | Logs from every service in the cluster (1-week retention) |
 
 All hostnames use a `.dev` TLD that mirrors production (`.edu` → `.dev`), so URLs, CSRF cookies, and OIDC redirect URIs behave identically to deployed environments.
 
@@ -204,6 +205,8 @@ With an app repo checked out next to `ol-infrastructure`, Tilt live-syncs your e
 
 ### Access logs
 
+For a single pod you already have in mind, `kubectl` is the shortest path:
+
 ```bash
 # Web pod
 kubectl logs -n mit-learn deploy/mitlearn-webapp -c app -f
@@ -214,6 +217,19 @@ kubectl logs -n mit-learn deploy/mitlearn-worker-default -f
 # APISIX ingress
 kubectl logs -n operations deploy/apisix -f
 ```
+
+To search across services — or to follow a request from the ingress into the app and on into the worker that picked up the task — use **Grafana at [https://grafana.mit.dev](https://grafana.mit.dev)**. It opens straight into the UI with no login. Every pod in the cluster is collected, including the ones Tilt does not manage (Postgres, Valkey, OpenSearch, Keycloak, APISIX, Mailpit).
+
+Start from the pre-provisioned **local-dev logs** dashboard, or go to **Explore → Loki** and write LogQL directly:
+
+```logql
+{namespace="mit-learn"}                      # everything in one app's namespace
+{app="mitlearn-webapp"} |= "ERROR"           # one workload, filtered
+{namespace="operations", app="apisix"}       # ingress access logs
+{container="celery"} |= "Traceback"          # across every app's workers
+```
+
+Available labels are `namespace`, `pod`, `container`, and `app`. Logs are kept for one week by default — see [Log retention](#log-retention) to change that, and `observability_enabled` in [Pulumi stack config](#pulumi-stack-config) to turn the whole stack off.
 
 ### Run management commands
 
@@ -301,6 +317,7 @@ tilt trigger seed-mit-learn-fixtures
 | `enabled_apps` | all four | Apps to deploy. Omit any to skip it entirely. |
 | `prebuilt_tags` | see example file | `["app=tag"]` list of image tags used when the app repo is not checked out locally. |
 | `disk_keep_tags`, `disk_buildcache_max_gb` | `3`, 10% of disk | Disk retention knobs — see [Disk Management](#disk-management). |
+| `log_retention_period` | `168h` | How long Grafana/Loki keeps logs — see [Log retention](#log-retention). |
 | `per_app_databases`, `openedx_mode` | — | Declared but not wired to anything yet; setting them has no effect. |
 
 The rule of thumb for which config surface a knob belongs to: settings that change **which/how Tilt runs things** (apps, image tags) go in `tilt_config.json`; anything that sets an **env var or secret value inside a workload** (API keys, feature flags, endpoints) goes in a gitignored `app-env.local.yaml` override ConfigMap — see [Local Configuration Overrides](#local-configuration-overrides).
@@ -312,6 +329,27 @@ Every service hostname derives from the `LOCAL_DEV_ROOT_DOMAIN` environment vari
 `tilt up` fails immediately if `sso.ol.<root_domain>` does not resolve, whether through DNS or `/etc/hosts`.
 
 After changing the value, re-run `./local-dev/scripts/setup.sh` to reissue the TLS certificate and rewrite the `/etc/hosts` block; pass `--skip-hosts` to reissue the certificate only, which is what you want when the hostnames already resolve through DNS. The certificate's SANs cover one root domain, so requests to hostnames outside it fail at the TLS layer.
+
+### Log retention
+
+Logs are kept for **one week** (`168h`). To change that for yourself, set `log_retention_period` in your gitignored `tilt_config.json`:
+
+```json
+{
+  "log_retention_period": "72h"
+}
+```
+
+Tilt forwards it to the core Pulumi stack as `LOCAL_DEV_LOG_RETENTION`, so the same value works for a hand-run `pulumi up`:
+
+```bash
+cd local-dev/infra/core
+LOCAL_DEV_LOG_RETENTION=72h pulumi up --stack local-dev.core.Dev
+```
+
+Loki only honours a retention window that is a **whole number of days**, so give it hours in multiples of 24 (`48h`, `168h`) or days (`3d`, `7d`). Anything else fails the deploy with an explanatory error rather than being silently ignored.
+
+This knob is deliberately *not* pinned in `Pulumi.local-dev.core.Dev.yaml` — Pulumi config takes precedence over the environment, so a value committed there would override every developer's `tilt_config.json`. Changing it replaces the Loki ConfigMap and restarts Loki; already-ingested logs are re-evaluated against the new window on the next compaction pass (within ~15 minutes).
 
 ### Pulumi stack config
 
@@ -326,6 +364,7 @@ The infrastructure is split across two Pulumi stacks:
 | `apisix_version` | `2.12.0` | APISIX Helm chart version |
 | `cnpg_version` | `0.23.0` | CloudNativePG operator Helm chart version |
 | `keycloak_operator_version` | `26.0.7` | Official Keycloak Operator version |
+| `observability_enabled` | `true` | Deploy Grafana + Loki + Alloy (~1.3GB). Set to `false` on a constrained Docker VM. |
 
 **`local-dev/infra/apps_infra/Pulumi.local-dev.apps-infra.Dev.yaml`** — Keycloak realm and OIDC clients:
 

--- a/local-dev/README.md
+++ b/local-dev/README.md
@@ -220,7 +220,9 @@ kubectl logs -n operations deploy/apisix -f
 
 To search across services — or to follow a request from the ingress into the app and on into the worker that picked up the task — use **Grafana at [https://grafana.mit.dev](https://grafana.mit.dev)**. It opens straight into the UI with no login. Every pod in the cluster is collected, including the ones Tilt does not manage (Postgres, Valkey, OpenSearch, Keycloak, APISIX, Mailpit).
 
-Start from the pre-provisioned **local-dev logs** dashboard, or go to **Explore → Loki** and write LogQL directly:
+The quickest way in is **Drilldown → Logs**, which needs no LogQL at all: pick a service, then narrow by detected label, field, or log level from the sidebar. Its **Patterns** tab groups repetitive lines into templates, which is how you spot one error buried in a wall of health checks.
+
+For anything the point-and-click path cannot express, start from the pre-provisioned **local-dev logs** dashboard, or go to **Explore → Loki** and write LogQL directly:
 
 ```logql
 {namespace="mit-learn"}                      # everything in one app's namespace
@@ -229,7 +231,7 @@ Start from the pre-provisioned **local-dev logs** dashboard, or go to **Explore 
 {container="celery"} |= "Traceback"          # across every app's workers
 ```
 
-Available labels are `namespace`, `pod`, `container`, and `app`. Logs are kept for one week by default — see [Log retention](#log-retention) to change that, and `observability_enabled` in [Pulumi stack config](#pulumi-stack-config) to turn the whole stack off.
+Available labels are `namespace`, `pod`, `container`, and `app`, plus `service_name`, which Loki derives on its own and which is what Drilldown's service list is keyed on. Logs are kept for one week by default — see [Log retention](#log-retention) to change that, and `observability_enabled` in [Pulumi stack config](#pulumi-stack-config) to turn the whole stack off.
 
 ### Run management commands
 

--- a/local-dev/infra/core/Pulumi.local-dev.core.Dev.yaml
+++ b/local-dev/infra/core/Pulumi.local-dev.core.Dev.yaml
@@ -12,6 +12,13 @@ config:
   # APISIX secrets for core infrastructure
   ol-local-dev-core:apisix_admin_key: "local-dev-apisix-admin-key"
   ol-local-dev-core:apisix_viewer_key: "local-dev-apisix-viewer-key"
+  # Observability (Grafana + Loki + Alloy, ~1.3GB of workloads).
+  # Set to false to skip it on a constrained Docker VM.
+  ol-local-dev-core:observability_enabled: "true"
+  # log_retention_period: unset on purpose. Pinning it here would override
+  # LOCAL_DEV_LOG_RETENTION and therefore tilt_config.json. Default is 168h
+  # (1 week); set "log_retention_period" in your gitignored tilt_config.json
+  # to change it.
   # Helm chart versions
   ol-local-dev-core:cert_manager_version: "v1.16.2"
   ol-local-dev-core:cnpg_version: "0.23.0"

--- a/local-dev/infra/core/__main__.py
+++ b/local-dev/infra/core/__main__.py
@@ -11,6 +11,7 @@ Provisions the foundational layer for the local k3d development environment:
   - Search (OpenSearch Helm)
   - AI services (Qdrant, Tika, LiteLLM)
   - Messaging (Mailpit)
+  - Observability (Loki, Alloy, Grafana) — optional, see observability_enabled
 
 The apps-infra stack depends on this core stack being deployed first.
 It provisions the Keycloak realm and any other app-specific resources.
@@ -35,6 +36,7 @@ from modules.identity_core import create_identity_core
 from modules.ingress import create_ingress
 from modules.messaging import create_messaging
 from modules.namespaces import create_namespaces
+from modules.observability import create_observability
 from modules.search import create_search
 from modules.tls import create_tls_resources
 from pulumi import Config
@@ -60,6 +62,21 @@ keycloak_url = config.get("keycloak_url") or f"https://{keycloak_hostname}"
 
 apisix_admin_key = config.require_secret("apisix_admin_key")
 apisix_viewer_key = config.require_secret("apisix_viewer_key")
+
+# Observability (Grafana + Loki + Alloy). Roughly 1.3GB of workloads, so it is
+# opt-out for developers on a constrained Docker VM.
+observability_enabled = config.get_bool("observability_enabled") is not False
+
+# How long Loki keeps logs. The per-developer override lives in the gitignored
+# tilt_config.json, which the Tiltfile forwards as LOCAL_DEV_LOG_RETENTION.
+# Deliberately not pinned in Pulumi.local-dev.core.Dev.yaml: Pulumi config wins
+# over the environment here, so a pinned value would silently defeat it --
+# the same trap the domain settings in that file warn about.
+log_retention_period = (
+    config.get("log_retention_period")
+    or os.environ.get("LOCAL_DEV_LOG_RETENTION")
+    or "168h"
+)
 
 cert_manager_version = config.get("cert_manager_version") or "v1.16.2"
 cnpg_version = config.get("cnpg_version") or "0.23.0"
@@ -164,6 +181,18 @@ messaging = create_messaging(
     mail_hostname=f"mail.{root_domain}",
 )
 
+# Logging pipeline: Alloy tails every pod's stdout into Loki, browsable in
+# Grafana. Nothing else depends on it, so it can be switched off wholesale.
+if observability_enabled:
+    create_observability(
+        _k8s,
+        namespaces["operations"],
+        apisix_release=ingress.apisix,
+        tls_secret_ops=tls.tls_secret_ops,
+        grafana_hostname=f"grafana.{root_domain}",
+        log_retention_period=log_retention_period,
+    )
+
 # Create database cluster (needed by Keycloak, LiteLLM)
 db = create_database(_k8s, namespaces["local-infra"], cnpg_version)
 
@@ -199,3 +228,9 @@ pulumi.export(
 pulumi.export("tika_url", "http://tika.local-infra.svc.cluster.local:9998")
 pulumi.export("litellm_url", "http://litellm.local-infra.svc.cluster.local:4000")
 pulumi.export("mailpit_ui_url", "http://mailpit.local-infra.svc.cluster.local:8025")
+
+if observability_enabled:
+    pulumi.export("grafana_url", f"https://grafana.{root_domain}")
+    pulumi.export("loki_url", "http://loki.operations.svc.cluster.local:3100")
+    pulumi.export("otlp_endpoint", "http://alloy.operations.svc.cluster.local:4318")
+    pulumi.export("log_retention_period", log_retention_period)

--- a/local-dev/infra/modules/observability.py
+++ b/local-dev/infra/modules/observability.py
@@ -41,7 +41,27 @@ NAMESPACE = "operations"
 
 LOKI_IMAGE = "grafana/loki:3.3.2"
 ALLOY_IMAGE = "grafana/alloy:v1.7.5"
-GRAFANA_IMAGE = "grafana/grafana:11.6.0"
+# >= 11.6.11 is the floor Grafana documents for the Logs Drilldown app below.
+GRAFANA_IMAGE = "grafana/grafana:11.6.16"
+
+# Logs Drilldown -- the "Logs" entry under Drilldown in the nav. It browses
+# services, fields and patterns without anyone writing LogQL, which is the
+# whole point of having Loki here rather than `kubectl logs`.
+#
+# Grafana already preinstalls this by default, but asynchronously: the server
+# starts listening before the download finishes, so on a fresh PVC the first
+# page load builds a nav with no Logs entry, and it only appears after a
+# restart. Naming it here and forcing a synchronous install is what makes it
+# show up on a cold `tilt up` -- the install now completes before the HTTP
+# listener opens. The list adds to Grafana's defaults rather than replacing
+# them, so the Pyroscope app comes along too; harmless, if a dead "Profiles"
+# nav entry until something serves profiles.
+#
+# Unpinned on purpose: the plugin catalog resolves the newest build whose
+# grafanaDependency matches GRAFANA_IMAGE, so this cannot drift out of sync
+# with a Grafana bump. A failed download is logged and start-up continues, so
+# an offline laptop loses the app, not the cluster.
+GRAFANA_PLUGINS = "grafana-lokiexplore-app"
 
 LOKI_URL = f"http://loki.{NAMESPACE}.svc.cluster.local:3100"
 OTLP_HTTP_ENDPOINT = f"http://alloy.{NAMESPACE}.svc.cluster.local:4318"
@@ -232,11 +252,22 @@ def _loki_config(retention_period: str) -> str:
             },
             "limits_config": {
                 "retention_period": retention_period,
+                # allow_structured_metadata/volume_enabled/discover_log_levels
+                # are the three limits Logs Drilldown requires: they back its
+                # detected fields, its service list, and its level breakdown
+                # respectively. The last two default on in Loki 3.x; set
+                # explicitly so a future default flip is not a silent
+                # regression in a UI nobody is testing.
                 "allow_structured_metadata": True,
                 "volume_enabled": True,
+                "discover_log_levels": True,
                 # A laptop that has been asleep replays old timestamps on wake.
                 "reject_old_samples": False,
             },
+            # Off by default, and the only source for Logs Drilldown's Patterns
+            # tab -- without it that tab is permanently empty and /patterns
+            # 404s. In-memory ring, matching the single-binary topology above.
+            "pattern_ingester": {"enabled": True},
             "compactor": {
                 "working_directory": "/loki/compactor",
                 # Without this, retention_period above is inert.
@@ -663,12 +694,27 @@ def _create_grafana(
                                     "value": "false",
                                 },
                                 {"name": "GF_USERS_DEFAULT_THEME", "value": "dark"},
+                                {
+                                    "name": "GF_PLUGINS_PREINSTALL",
+                                    "value": GRAFANA_PLUGINS,
+                                },
+                                # See GRAFANA_PLUGINS: the default async
+                                # install is why Logs Drilldown was missing
+                                # from the nav on a first boot.
+                                {
+                                    "name": "GF_PLUGINS_PREINSTALL_ASYNC",
+                                    "value": "false",
+                                },
                             ],
                             "readinessProbe": {
                                 "httpGet": {"path": "/api/health", "port": 3000},
                                 "initialDelaySeconds": 15,
+                                # Grafana does not listen until the synchronous
+                                # plugin install finishes, so the first boot on
+                                # an empty PVC has a ~13MB download in front of
+                                # it. 5 minutes covers a slow connection.
                                 "periodSeconds": 10,
-                                "failureThreshold": 12,
+                                "failureThreshold": 30,
                             },
                             "resources": {"limits": {"memory": "256Mi"}},
                             "volumeMounts": [

--- a/local-dev/infra/modules/observability.py
+++ b/local-dev/infra/modules/observability.py
@@ -541,7 +541,21 @@ def _create_alloy(
                     "volumes": [
                         {"name": "config", "configMap": {"name": "alloy-config"}},
                         {"name": "varlog", "hostPath": {"path": "/var/log"}},
-                        {"name": "data", "emptyDir": {}},
+                        # loki.source.file records its read offsets under the
+                        # storage path, so this has to outlive the pod. On an
+                        # emptyDir every DaemonSet replacement loses every
+                        # position and, since tail_from_end defaults to false,
+                        # Alloy re-reads each still-present pod log from byte
+                        # zero -- duplicate lines in Loki and a load spike on
+                        # every restart. hostPath keeps the offsets per node,
+                        # which is the shape a DaemonSet wants.
+                        {
+                            "name": "data",
+                            "hostPath": {
+                                "path": "/var/lib/alloy/data",
+                                "type": "DirectoryOrCreate",
+                            },
+                        },
                     ],
                 },
             },

--- a/local-dev/infra/modules/observability.py
+++ b/local-dev/infra/modules/observability.py
@@ -1,0 +1,810 @@
+"""Grafana, Loki, and Alloy for the local-dev infra stack.
+
+Provisions a self-contained logging pipeline so every pod in the cluster --
+apps, Celery workers, Postgres, Valkey, OpenSearch, Keycloak, APISIX -- is
+searchable from one place instead of one `kubectl logs` invocation per
+deployment:
+
+    every pod's stdout
+      -> /var/log/pods/*/*/*.log        (hostPath, read-only)
+      -> Alloy DaemonSet                discovery.kubernetes -> local.file_match
+                                        -> loki.source.file -> stage.cri
+      -> Loki                           filesystem storage, PVC, retention
+      -> Grafana                        https://grafana.<root_domain>
+
+This mirrors the production shape (see
+``src/ol_infrastructure/substructure/aws/eks/grafana.py``), where the
+k8s-monitoring Helm chart runs Alloy with the ``filesystem-log-reader`` preset
+and ships to Grafana Cloud.  Two deliberate divergences: Loki and Grafana are
+self-hosted here rather than Grafana Cloud, and Alloy is configured by hand
+rather than through the k8s-monitoring chart, which would drag in four
+collectors plus kube-state-metrics, opencost and kepler for no local benefit.
+
+Alloy also exposes an OTLP receiver on 4317/4318 wired to Loki's native OTLP
+endpoint.  Nothing emits to it yet -- it exists so an app can opt into
+prod-style OTLP export by setting ``OTEL_*`` env vars, and so Keycloak's
+``OTEL_SDK_DISABLED=true`` workaround in identity_core.py (added precisely
+because no receiver existed) can be lifted.
+"""
+
+import hashlib
+import json
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import pulumi_kubernetes as k8s
+import yaml as pyyaml
+from pulumi import ResourceOptions
+
+NAMESPACE = "operations"
+
+LOKI_IMAGE = "grafana/loki:3.3.2"
+ALLOY_IMAGE = "grafana/alloy:v1.7.5"
+GRAFANA_IMAGE = "grafana/grafana:11.6.0"
+
+LOKI_URL = f"http://loki.{NAMESPACE}.svc.cluster.local:3100"
+OTLP_HTTP_ENDPOINT = f"http://alloy.{NAMESPACE}.svc.cluster.local:4318"
+
+# Loki rejects a retention window that is not a whole multiple of the index
+# period, and silently keeps the default instead of failing loudly.
+INDEX_PERIOD_HOURS = 24
+_RETENTION_RE = re.compile(r"^(\d+)([hd])$")
+
+# Alloy's River config. Pod discovery is deliberately *not* filtered to the
+# local node: local.file_match only matches files that exist on this node's
+# filesystem, so pods scheduled elsewhere drop out on their own and we avoid
+# threading a downward-API node name through the config.
+#
+# loki.source.kubernetes (log streaming via the API server) would need one pod
+# instead of a DaemonSet, but it rides the same kubelet :10250 streaming path
+# that is documented to wedge after VM sleep (local-dev/scripts/heal-exec.sh),
+# which would kill log collection exactly when the environment is already
+# broken. Reading files off the node has no such dependency, and matches prod.
+ALLOY_CONFIG = f"""\
+discovery.kubernetes "pods" {{
+  role = "pod"
+}}
+
+discovery.relabel "pod_logs" {{
+  targets = discovery.kubernetes.pods.targets
+
+  rule {{
+    source_labels = ["__meta_kubernetes_namespace"]
+    target_label  = "namespace"
+  }}
+  rule {{
+    source_labels = ["__meta_kubernetes_pod_name"]
+    target_label  = "pod"
+  }}
+  rule {{
+    source_labels = ["__meta_kubernetes_pod_container_name"]
+    target_label  = "container"
+  }}
+  rule {{
+    source_labels = ["__meta_kubernetes_pod_label_app"]
+    target_label  = "app"
+  }}
+
+  // /var/log/pods/<namespace>_<pod>_<uid>/<container>/*.log
+  rule {{
+    source_labels = [
+      "__meta_kubernetes_pod_uid",
+      "__meta_kubernetes_pod_container_name",
+    ]
+    separator     = "/"
+    action        = "replace"
+    replacement   = "/var/log/pods/*$1/*.log"
+    target_label  = "__path__"
+  }}
+}}
+
+local.file_match "pod_logs" {{
+  path_targets = discovery.relabel.pod_logs.output
+}}
+
+loki.source.file "pod_logs" {{
+  targets    = local.file_match.pod_logs.targets
+  forward_to = [loki.process.pod_logs.receiver]
+}}
+
+loki.process "pod_logs" {{
+  // Strips the containerd "<ts> stdout F " prefix off every line.
+  stage.cri {{}}
+
+  forward_to = [loki.write.local.receiver]
+}}
+
+loki.write "local" {{
+  endpoint {{
+    url = "{LOKI_URL}/loki/api/v1/push"
+  }}
+}}
+
+// OTLP receiver -- production parity. Nothing emits here yet; an app opts in
+// by pointing OTEL_EXPORTER_OTLP_LOGS_ENDPOINT at {OTLP_HTTP_ENDPOINT}/v1/logs.
+otelcol.receiver.otlp "default" {{
+  grpc {{
+    endpoint = "0.0.0.0:4317"
+  }}
+  http {{
+    endpoint = "0.0.0.0:4318"
+  }}
+
+  output {{
+    logs = [otelcol.processor.batch.default.input]
+  }}
+}}
+
+otelcol.processor.batch "default" {{
+  output {{
+    logs = [otelcol.exporter.otlphttp.loki.input]
+  }}
+}}
+
+otelcol.exporter.otlphttp "loki" {{
+  client {{
+    endpoint = "{LOKI_URL}/otlp"
+  }}
+}}
+"""
+
+
+def _checksum(content: str) -> str:
+    """Return a stable short digest of *content* for a pod-template annotation.
+
+    Deliberately not ``hash()``: Python randomises string hashing per process,
+    so that would roll every pod on every ``pulumi up``.
+    """
+    return hashlib.sha256(content.encode()).hexdigest()[:16]
+
+
+@dataclass
+class ObservabilityResources:
+    """Resources created by the observability module."""
+
+    loki: k8s.apps.v1.Deployment
+    alloy: k8s.apps.v1.DaemonSet
+    grafana: k8s.apps.v1.Deployment
+
+
+def validate_retention_period(value: str) -> str:
+    """Return *value* if Loki will honour it as a retention period.
+
+    Loki requires ``retention_period`` to be a whole multiple of the 24h index
+    period; anything else is ignored in favour of the default rather than
+    rejected, which would silently discard logs early or keep them forever.
+    Fail the deploy instead -- the likeliest source of a bad value is a typo in
+    a developer's gitignored tilt_config.json.
+
+    :raises SystemExit: if *value* is not a whole number of days.
+    """
+    match = _RETENTION_RE.match(value.strip())
+    if match:
+        amount, unit = int(match.group(1)), match.group(2)
+        hours = amount if unit == "h" else amount * INDEX_PERIOD_HOURS
+        if hours > 0 and hours % INDEX_PERIOD_HOURS == 0:
+            return f"{hours}h"
+
+    msg = (
+        f"Invalid log retention period: {value!r}\n"
+        "Loki needs a whole number of days, written as hours or days "
+        '(e.g. "168h", "7d", "48h").\n'
+        'Set it with "log_retention_period" in your tilt_config.json, or '
+        "LOCAL_DEV_LOG_RETENTION for a hand-run `pulumi up`."
+    )
+    raise SystemExit(msg)
+
+
+def _loki_config(retention_period: str) -> str:
+    """Render the single-binary Loki config with *retention_period* applied."""
+    return pyyaml.safe_dump(
+        {
+            "auth_enabled": False,
+            "server": {"http_listen_port": 3100, "log_level": "warn"},
+            "common": {
+                "instance_addr": "127.0.0.1",
+                "path_prefix": "/loki",
+                "storage": {
+                    "filesystem": {
+                        "chunks_directory": "/loki/chunks",
+                        "rules_directory": "/loki/rules",
+                    }
+                },
+                "replication_factor": 1,
+                "ring": {"kvstore": {"store": "inmemory"}},
+            },
+            "schema_config": {
+                "configs": [
+                    {
+                        # tsdb + v13 are required for structured metadata,
+                        # which is how OTLP attributes survive ingestion.
+                        "from": "2024-04-01",
+                        "store": "tsdb",
+                        "object_store": "filesystem",
+                        "schema": "v13",
+                        "index": {
+                            "prefix": "index_",
+                            "period": f"{INDEX_PERIOD_HOURS}h",
+                        },
+                    }
+                ]
+            },
+            "limits_config": {
+                "retention_period": retention_period,
+                "allow_structured_metadata": True,
+                "volume_enabled": True,
+                # A laptop that has been asleep replays old timestamps on wake.
+                "reject_old_samples": False,
+            },
+            "compactor": {
+                "working_directory": "/loki/compactor",
+                # Without this, retention_period above is inert.
+                "retention_enabled": True,
+                "delete_request_store": "filesystem",
+            },
+            "analytics": {"reporting_enabled": False},
+        },
+        default_flow_style=False,
+        sort_keys=False,
+    )
+
+
+def _logs_dashboard() -> str:
+    """Return the starter "local-dev logs" dashboard as a JSON string."""
+    loki_ds = {"type": "loki", "uid": "loki"}
+    stream = '{namespace=~"$namespace"} |= "$search"'
+    return json.dumps(
+        {
+            "uid": "local-dev-logs",
+            "title": "local-dev logs",
+            "tags": ["local-dev"],
+            "timezone": "browser",
+            "schemaVersion": 39,
+            "time": {"from": "now-1h", "to": "now"},
+            "refresh": "30s",
+            "templating": {
+                "list": [
+                    {
+                        "name": "namespace",
+                        "label": "Namespace",
+                        "type": "query",
+                        "datasource": loki_ds,
+                        "query": "label_values(namespace)",
+                        "refresh": 1,
+                        "includeAll": True,
+                        "multi": True,
+                        "current": {"text": "All", "value": "$__all"},
+                    },
+                    {
+                        "name": "search",
+                        "label": "Search",
+                        "type": "textbox",
+                        "query": "",
+                        "current": {"text": "", "value": ""},
+                    },
+                ]
+            },
+            "panels": [
+                {
+                    "id": 1,
+                    "type": "timeseries",
+                    "title": "Log rate by namespace",
+                    "datasource": loki_ds,
+                    "gridPos": {"h": 7, "w": 24, "x": 0, "y": 0},
+                    "targets": [
+                        {
+                            "refId": "A",
+                            "datasource": loki_ds,
+                            "expr": f"sum by (namespace) (rate({stream} [$__auto]))",
+                        }
+                    ],
+                },
+                {
+                    "id": 2,
+                    "type": "logs",
+                    "title": "Logs",
+                    "datasource": loki_ds,
+                    "gridPos": {"h": 17, "w": 24, "x": 0, "y": 7},
+                    "options": {
+                        "showTime": True,
+                        "wrapLogMessage": True,
+                        "enableLogDetails": True,
+                        "sortOrder": "Descending",
+                    },
+                    "targets": [{"refId": "A", "datasource": loki_ds, "expr": stream}],
+                },
+            ],
+        }
+    )
+
+
+def _create_loki(
+    _k8s: Callable[..., ResourceOptions],
+    operations_ns: k8s.core.v1.Namespace,
+    retention_period: str,
+) -> k8s.apps.v1.Deployment:
+    """Deploy single-binary Loki backed by a filesystem PVC."""
+    config = _loki_config(retention_period)
+
+    config_cm = k8s.core.v1.ConfigMap(
+        "loki-config",
+        metadata={"name": "loki-config", "namespace": NAMESPACE},
+        data={"config.yaml": config},
+        opts=_k8s(parent=operations_ns),
+    )
+
+    # A PVC rather than the emptyDir other local-dev services use: a retention
+    # window is meaningless if a pod restart wipes the log store.
+    pvc = k8s.core.v1.PersistentVolumeClaim(
+        "loki-data",
+        metadata={
+            "name": "loki-data",
+            "namespace": NAMESPACE,
+            # k3d's local-path class binds WaitForFirstConsumer, so the claim
+            # stays Pending until a pod mounts it. Without skipAwait, Pulumi
+            # blocks waiting for Bound and the Deployment that would unblock it
+            # is never created.
+            "annotations": {"pulumi.com/skipAwait": "true"},
+        },
+        spec={
+            "accessModes": ["ReadWriteOnce"],
+            "resources": {"requests": {"storage": "5Gi"}},
+        },
+        opts=_k8s(parent=operations_ns),
+    )
+
+    deployment = k8s.apps.v1.Deployment(
+        "loki",
+        metadata={"name": "loki", "namespace": NAMESPACE},
+        spec={
+            "replicas": 1,
+            "selector": {"matchLabels": {"app": "loki"}},
+            # The PVC is ReadWriteOnce, so the old pod must go before the new
+            # one can attach.
+            "strategy": {"type": "Recreate"},
+            "template": {
+                "metadata": {
+                    "labels": {"app": "loki"},
+                    # Roll the pod when the retention period (or any other
+                    # config) changes; a mounted ConfigMap update alone would
+                    # not restart Loki.
+                    "annotations": {"checksum/config": _checksum(config)},
+                },
+                "spec": {
+                    "securityContext": {"fsGroup": 10001},
+                    "containers": [
+                        {
+                            "name": "loki",
+                            "image": LOKI_IMAGE,
+                            "args": ["-config.file=/etc/loki/config.yaml"],
+                            "ports": [{"containerPort": 3100, "name": "http"}],
+                            "readinessProbe": {
+                                "httpGet": {"path": "/ready", "port": 3100},
+                                "initialDelaySeconds": 20,
+                                "periodSeconds": 10,
+                                "failureThreshold": 12,
+                            },
+                            "resources": {"limits": {"memory": "512Mi"}},
+                            "volumeMounts": [
+                                {"name": "config", "mountPath": "/etc/loki"},
+                                {"name": "data", "mountPath": "/loki"},
+                            ],
+                        }
+                    ],
+                    "volumes": [
+                        {"name": "config", "configMap": {"name": "loki-config"}},
+                        {
+                            "name": "data",
+                            "persistentVolumeClaim": {"claimName": "loki-data"},
+                        },
+                    ],
+                },
+            },
+        },
+        opts=_k8s(parent=operations_ns, depends_on=[config_cm, pvc]),
+    )
+
+    k8s.core.v1.Service(
+        "loki-svc",
+        metadata={"name": "loki", "namespace": NAMESPACE},
+        spec={
+            "selector": {"app": "loki"},
+            "ports": [{"name": "http", "port": 3100, "targetPort": 3100}],
+        },
+        opts=_k8s(parent=deployment),
+    )
+
+    return deployment
+
+
+def _create_alloy(
+    _k8s: Callable[..., ResourceOptions],
+    operations_ns: k8s.core.v1.Namespace,
+    loki: k8s.apps.v1.Deployment,
+) -> k8s.apps.v1.DaemonSet:
+    """Deploy the Alloy DaemonSet that tails pod logs into Loki."""
+    service_account = k8s.core.v1.ServiceAccount(
+        "alloy-sa",
+        metadata={"name": "alloy", "namespace": NAMESPACE},
+        opts=_k8s(parent=operations_ns),
+    )
+
+    cluster_role = k8s.rbac.v1.ClusterRole(
+        "alloy-cr",
+        metadata={"name": "alloy-local-dev"},
+        rules=[
+            {
+                "api_groups": [""],
+                "resources": ["pods", "nodes", "namespaces"],
+                "verbs": ["get", "list", "watch"],
+            }
+        ],
+        opts=_k8s(parent=operations_ns),
+    )
+
+    cluster_role_binding = k8s.rbac.v1.ClusterRoleBinding(
+        "alloy-crb",
+        metadata={"name": "alloy-local-dev"},
+        role_ref={
+            "api_group": "rbac.authorization.k8s.io",
+            "kind": "ClusterRole",
+            "name": "alloy-local-dev",
+        },
+        subjects=[{"kind": "ServiceAccount", "name": "alloy", "namespace": NAMESPACE}],
+        opts=_k8s(parent=cluster_role, depends_on=[service_account]),
+    )
+
+    config_cm = k8s.core.v1.ConfigMap(
+        "alloy-config",
+        metadata={"name": "alloy-config", "namespace": NAMESPACE},
+        data={"config.alloy": ALLOY_CONFIG},
+        opts=_k8s(parent=operations_ns),
+    )
+
+    daemonset = k8s.apps.v1.DaemonSet(
+        "alloy",
+        metadata={"name": "alloy", "namespace": NAMESPACE},
+        spec={
+            "selector": {"matchLabels": {"app": "alloy"}},
+            "template": {
+                "metadata": {
+                    "labels": {"app": "alloy"},
+                    "annotations": {"checksum/config": _checksum(ALLOY_CONFIG)},
+                },
+                "spec": {
+                    "serviceAccountName": "alloy",
+                    # The k3d server node carries a control-plane taint but runs
+                    # pods too, so its logs would otherwise be missed.
+                    "tolerations": [{"operator": "Exists"}],
+                    "containers": [
+                        {
+                            "name": "alloy",
+                            "image": ALLOY_IMAGE,
+                            "args": [
+                                "run",
+                                "/etc/alloy/config.alloy",
+                                "--storage.path=/var/lib/alloy/data",
+                                "--server.http.listen-addr=0.0.0.0:12345",
+                            ],
+                            # Container log files under /var/log/pods are
+                            # root-owned.
+                            "securityContext": {"runAsUser": 0, "runAsGroup": 0},
+                            "ports": [
+                                {"containerPort": 12345, "name": "http"},
+                                {"containerPort": 4317, "name": "otlp-grpc"},
+                                {"containerPort": 4318, "name": "otlp-http"},
+                            ],
+                            "resources": {"limits": {"memory": "192Mi"}},
+                            "volumeMounts": [
+                                {"name": "config", "mountPath": "/etc/alloy"},
+                                {
+                                    "name": "varlog",
+                                    "mountPath": "/var/log",
+                                    "readOnly": True,
+                                },
+                                {"name": "data", "mountPath": "/var/lib/alloy/data"},
+                            ],
+                        }
+                    ],
+                    "volumes": [
+                        {"name": "config", "configMap": {"name": "alloy-config"}},
+                        {"name": "varlog", "hostPath": {"path": "/var/log"}},
+                        {"name": "data", "emptyDir": {}},
+                    ],
+                },
+            },
+        },
+        opts=_k8s(
+            parent=operations_ns,
+            depends_on=[config_cm, cluster_role_binding, loki],
+        ),
+    )
+
+    k8s.core.v1.Service(
+        "alloy-svc",
+        metadata={"name": "alloy", "namespace": NAMESPACE},
+        spec={
+            "selector": {"app": "alloy"},
+            "ports": [
+                {"name": "otlp-grpc", "port": 4317, "targetPort": 4317},
+                {"name": "otlp-http", "port": 4318, "targetPort": 4318},
+            ],
+        },
+        opts=_k8s(parent=daemonset),
+    )
+
+    return daemonset
+
+
+def _create_grafana(
+    _k8s: Callable[..., ResourceOptions],
+    operations_ns: k8s.core.v1.Namespace,
+    apisix_release: k8s.helm.v3.Release,
+    tls_secret_ops: k8s.core.v1.Secret,
+    grafana_hostname: str,
+    loki: k8s.apps.v1.Deployment,
+) -> k8s.apps.v1.Deployment:
+    """Deploy Grafana with a provisioned Loki datasource and starter dashboard."""
+    # Production does not provision datasources -- Grafana Cloud supplies them,
+    # which is why grafana_alerting/dashboards/datasources.py only holds refs.
+    # Self-hosted needs the real thing.
+    datasources_cm = k8s.core.v1.ConfigMap(
+        "grafana-datasources",
+        metadata={"name": "grafana-datasources", "namespace": NAMESPACE},
+        data={
+            "loki.yaml": pyyaml.safe_dump(
+                {
+                    "apiVersion": 1,
+                    "datasources": [
+                        {
+                            "name": "Loki",
+                            "type": "loki",
+                            "uid": "loki",
+                            "access": "proxy",
+                            "url": LOKI_URL,
+                            "isDefault": True,
+                        }
+                    ],
+                },
+                default_flow_style=False,
+                sort_keys=False,
+            )
+        },
+        opts=_k8s(parent=operations_ns),
+    )
+
+    dashboards_cm = k8s.core.v1.ConfigMap(
+        "grafana-dashboards",
+        metadata={"name": "grafana-dashboards", "namespace": NAMESPACE},
+        data={
+            "provider.yaml": pyyaml.safe_dump(
+                {
+                    "apiVersion": 1,
+                    "providers": [
+                        {
+                            "name": "local-dev",
+                            "type": "file",
+                            "allowUiUpdates": True,
+                            # Deliberately not under /var/lib/grafana: that
+                            # path is the PVC mount, and nesting a ConfigMap
+                            # mount inside it depends on kubelet mount
+                            # ordering.
+                            "options": {"path": "/etc/grafana/dashboards"},
+                        }
+                    ],
+                },
+                default_flow_style=False,
+                sort_keys=False,
+            ),
+            "local-dev-logs.json": _logs_dashboard(),
+        },
+        opts=_k8s(parent=operations_ns),
+    )
+
+    pvc = k8s.core.v1.PersistentVolumeClaim(
+        "grafana-data",
+        metadata={
+            "name": "grafana-data",
+            "namespace": NAMESPACE,
+            # See the loki-data claim: WaitForFirstConsumer would otherwise
+            # deadlock Pulumi's Bound await.
+            "annotations": {"pulumi.com/skipAwait": "true"},
+        },
+        spec={
+            "accessModes": ["ReadWriteOnce"],
+            "resources": {"requests": {"storage": "1Gi"}},
+        },
+        opts=_k8s(parent=operations_ns),
+    )
+
+    deployment = k8s.apps.v1.Deployment(
+        "grafana",
+        metadata={"name": "grafana", "namespace": NAMESPACE},
+        spec={
+            "replicas": 1,
+            "selector": {"matchLabels": {"app": "grafana"}},
+            "strategy": {"type": "Recreate"},
+            "template": {
+                "metadata": {"labels": {"app": "grafana"}},
+                "spec": {
+                    "securityContext": {"fsGroup": 472},
+                    "containers": [
+                        {
+                            "name": "grafana",
+                            "image": GRAFANA_IMAGE,
+                            "ports": [{"containerPort": 3000, "name": "http"}],
+                            "env": [
+                                {
+                                    "name": "GF_SERVER_ROOT_URL",
+                                    "value": f"https://{grafana_hostname}",
+                                },
+                                # Local-only cluster: skip the login round-trip
+                                # entirely and land straight in Explore.
+                                {
+                                    "name": "GF_AUTH_ANONYMOUS_ENABLED",
+                                    "value": "true",
+                                },
+                                {
+                                    "name": "GF_AUTH_ANONYMOUS_ORG_ROLE",
+                                    "value": "Admin",
+                                },
+                                {"name": "GF_AUTH_BASIC_ENABLED", "value": "false"},
+                                {
+                                    "name": "GF_AUTH_DISABLE_LOGIN_FORM",
+                                    "value": "true",
+                                },
+                                {
+                                    "name": "GF_ANALYTICS_REPORTING_ENABLED",
+                                    "value": "false",
+                                },
+                                {
+                                    "name": "GF_ANALYTICS_CHECK_FOR_UPDATES",
+                                    "value": "false",
+                                },
+                                {"name": "GF_USERS_DEFAULT_THEME", "value": "dark"},
+                            ],
+                            "readinessProbe": {
+                                "httpGet": {"path": "/api/health", "port": 3000},
+                                "initialDelaySeconds": 15,
+                                "periodSeconds": 10,
+                                "failureThreshold": 12,
+                            },
+                            "resources": {"limits": {"memory": "256Mi"}},
+                            "volumeMounts": [
+                                {
+                                    "name": "datasources",
+                                    "mountPath": (
+                                        "/etc/grafana/provisioning/datasources"
+                                    ),
+                                },
+                                {
+                                    "name": "dashboard-provider",
+                                    "mountPath": (
+                                        "/etc/grafana/provisioning/dashboards"
+                                    ),
+                                },
+                                {
+                                    "name": "dashboards",
+                                    "mountPath": "/etc/grafana/dashboards",
+                                },
+                                {"name": "data", "mountPath": "/var/lib/grafana"},
+                            ],
+                        }
+                    ],
+                    "volumes": [
+                        {
+                            "name": "datasources",
+                            "configMap": {"name": "grafana-datasources"},
+                        },
+                        {
+                            "name": "dashboard-provider",
+                            "configMap": {
+                                "name": "grafana-dashboards",
+                                "items": [
+                                    {
+                                        "key": "provider.yaml",
+                                        "path": "provider.yaml",
+                                    }
+                                ],
+                            },
+                        },
+                        {
+                            "name": "dashboards",
+                            "configMap": {
+                                "name": "grafana-dashboards",
+                                "items": [
+                                    {
+                                        "key": "local-dev-logs.json",
+                                        "path": "local-dev-logs.json",
+                                    }
+                                ],
+                            },
+                        },
+                        {
+                            "name": "data",
+                            "persistentVolumeClaim": {"claimName": "grafana-data"},
+                        },
+                    ],
+                },
+            },
+        },
+        opts=_k8s(
+            parent=operations_ns,
+            depends_on=[datasources_cm, dashboards_cm, pvc, loki],
+        ),
+    )
+
+    k8s.core.v1.Service(
+        "grafana-svc",
+        metadata={"name": "grafana", "namespace": NAMESPACE},
+        spec={
+            "selector": {"app": "grafana"},
+            "ports": [{"name": "http", "port": 3000, "targetPort": 3000}],
+        },
+        opts=_k8s(parent=deployment),
+    )
+
+    k8s.apiextensions.CustomResource(
+        "grafana-apisix-route",
+        api_version="apisix.apache.org/v2",
+        kind="ApisixRoute",
+        metadata={"name": "grafana-route", "namespace": NAMESPACE},
+        spec={
+            "ingressClassName": "apache-apisix",
+            "http": [
+                {
+                    "name": "grafana",
+                    "match": {"hosts": [grafana_hostname], "paths": ["/*"]},
+                    "backends": [{"serviceName": "grafana", "servicePort": 3000}],
+                    # Explore's live tail streams over a websocket.
+                    "websocket": True,
+                }
+            ],
+        },
+        opts=_k8s(parent=operations_ns, depends_on=[apisix_release, deployment]),
+    )
+
+    k8s.apiextensions.CustomResource(
+        "grafana-apisix-tls",
+        api_version="apisix.apache.org/v2",
+        kind="ApisixTls",
+        metadata={"name": "grafana-tls", "namespace": NAMESPACE},
+        spec={
+            "ingressClassName": "apache-apisix",
+            "hosts": [grafana_hostname],
+            "secret": {"name": "local-dev-tls", "namespace": NAMESPACE},
+        },
+        opts=_k8s(parent=operations_ns, depends_on=[apisix_release, tls_secret_ops]),
+    )
+
+    return deployment
+
+
+def create_observability(
+    _k8s: Callable[..., ResourceOptions],
+    operations_ns: k8s.core.v1.Namespace,
+    apisix_release: k8s.helm.v3.Release,
+    tls_secret_ops: k8s.core.v1.Secret,
+    grafana_hostname: str,
+    log_retention_period: str = "168h",
+) -> ObservabilityResources:
+    """Deploy Loki, Alloy, and Grafana into the operations namespace.
+
+    Web UI is exposed at https://{grafana_hostname}; logs from every pod in the
+    cluster are searchable there for *log_retention_period*.
+    """
+    retention_period = validate_retention_period(log_retention_period)
+
+    loki = _create_loki(_k8s, operations_ns, retention_period)
+    alloy = _create_alloy(_k8s, operations_ns, loki)
+    grafana = _create_grafana(
+        _k8s,
+        operations_ns,
+        apisix_release=apisix_release,
+        tls_secret_ops=tls_secret_ops,
+        grafana_hostname=grafana_hostname,
+        loki=loki,
+    )
+
+    return ObservabilityResources(loki=loki, alloy=alloy, grafana=grafana)

--- a/local-dev/scripts/setup.sh
+++ b/local-dev/scripts/setup.sh
@@ -46,6 +46,8 @@ HOSTS=(
     "sso.ol.${ROOT_DOMAIN}"
     # Mailpit (captured outbound email)
     "mail.${ROOT_DOMAIN}"
+    # Grafana (logs from every local-dev service)
+    "grafana.${ROOT_DOMAIN}"
 )
 
 # k3d load balancer always listens on 127.0.0.1 for the exposed ports

--- a/tilt_config.json.example
+++ b/tilt_config.json.example
@@ -16,5 +16,7 @@
 
   "disk_keep_tags": "3",
 
-  "disk_buildcache_max_gb": ""
+  "disk_buildcache_max_gb": "",
+
+  "log_retention_period": "168h"
 }


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

Adds a self-contained logging stack to `local-dev`, so every pod in the cluster is searchable from one place instead of one `kubectl logs` invocation per deployment:

```
every pod's stdout
  -> /var/log/pods/*/*/*.log        hostPath, read-only
  -> Alloy DaemonSet                discovery.kubernetes -> local.file_match
                                    -> loki.source.file -> stage.cri
  -> Loki                           filesystem storage on a PVC, retention via compactor
  -> Grafana                        https://grafana.<root_domain>, anonymous Admin
```

This is the production shape, shrunk. Production runs the same collector via the `k8s-monitoring` chart's `filesystem-log-reader` preset ([`substructure/aws/eks/grafana.py`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/substructure/aws/eks/grafana.py)). Two deliberate divergences: Loki and Grafana are self-hosted here rather than Grafana Cloud, and Alloy is configured by hand rather than through that chart, which would pull in four collectors plus kube-state-metrics, opencost and kepler for no local benefit.

Collection reads log *files* off the node rather than streaming through the API server (`loki.source.kubernetes`). The streaming path rides the same kubelet `:10250` API that wedges after VM sleep, which would kill log collection exactly when the environment is already broken.

Alloy also exposes an OTLP receiver on 4317/4318 forwarding to Loki's native OTLP endpoint. **Nothing emits to it yet** — it exists so an app can opt into production-style OTLP export by setting the `OTEL_*` env vars used in the deployed environments, and so Keycloak's `OTEL_SDK_DISABLED=true` workaround in `identity_core.py` (added precisely because no receiver existed) can be lifted.

The whole stack is roughly 1.3GB and can be switched off with `observability_enabled: "false"`; nothing else depends on it.

**Second commit — making `Drilldown -> Logs` actually appear.** The Logs Drilldown app is the point-and-click entry point (browse services, fields, patterns without writing LogQL) and it was missing from the nav on a fresh environment. Two causes, neither of which fails loudly:

- The plugin behind it, `grafana-lokiexplore-app`, was never declared anywhere — it arrived only because Grafana 11.6 preinstalls it by default, and that default is **asynchronous**. The HTTP listener opens before the download finishes, so the first page load builds a nav with no Logs entry. It turns up on some later restart, once the plugin is already on the PVC, which is why this looked intermittent rather than broken. Naming the plugin explicitly with `preinstall_async=false` moves the install ahead of the listener.
- Loki's `pattern_ingester` is off by default, which left Drilldown's Patterns tab permanently empty with `/loki/api/v1/patterns` returning 404 rather than anything the UI surfaces. `discover_log_levels` defaults on in Loki 3.x but is now stated explicitly alongside the `allow_structured_metadata` and `volume_enabled` that were already there, so a future default flip is not a silent regression in a UI nobody is testing.

Grafana `11.6.0` -> `11.6.16`, the floor [Grafana documents](https://grafana.com/docs/grafana-cloud/learn-and-build/visualizations/simplified-exploration/logs/access/) for the app. The plugin version is left unpinned on purpose: the catalog resolves the newest build matching `grafanaDependency`, so it cannot drift against a Grafana bump. A failed download is logged and start-up continues, so an offline laptop loses the app rather than the cluster.

### How can this be tested?

Bring up `local-dev` and open `https://grafana.mit.dev` — no login, it lands straight in the UI.

**The Logs Drilldown fix is the part worth checking on a cold start,** since the bug only shows on a first boot with an empty PVC. To force that state without a full teardown:

```bash
kubectl exec -n operations deploy/grafana -- rm -rf /var/lib/grafana/plugins/grafana-lokiexplore-app
kubectl rollout restart -n operations deploy/grafana
kubectl rollout status -n operations deploy/grafana
```

Then confirm the install completes *before* Grafana serves — this ordering is the whole fix:

```bash
kubectl logs -n operations deploy/grafana | grep -E "HTTP Server Listen|Plugin successfully installed"
```

```
17:55:18.078  Plugin successfully installed  grafana-lokiexplore-app
17:55:18.408  HTTP Server Listen             [::]:3000
```

`Drilldown -> Logs` should be in the nav on the very first page load. Pick a service, then check the **Patterns** tab is populated (that one is `pattern_ingester`). The four endpoints Drilldown depends on should all return data:

```bash
kubectl exec -n operations deploy/loki -- wget -qO- \
  'http://localhost:3100/loki/api/v1/patterns?query={service_name="apisix"}&start=<ns>&end=<ns>'
# also: /detected_labels, /detected_fields, /index/volume
```

For the underlying pipeline, `Explore -> Loki` and a query like `{namespace="mit-learn"}` or `{app="mitlearn-webapp"} |= "ERROR"`, or the pre-provisioned **local-dev logs** dashboard.

What I ran on a live cluster: `pulumi up` on the core stack, the cold-start sequence above (log output quoted verbatim), the nav tree served through APISIX, and all four Loki endpoints — `/patterns` went from 404 to returning real templates, and `/index/volume` lists every collected service (alloy, apisix, mitlearn, keycloak, opensearch, ...). I did not run a full teardown/rebuild from scratch.

### Additional Context

- Grafana's preinstall list **adds to** its defaults rather than replacing them, so the Pyroscope app still tags along and leaves a dead "Profiles" nav entry. Not worth a second mechanism to suppress.
- Readiness `failureThreshold` 12 -> 30, since the synchronous install now puts a ~13MB download in front of the first probe. Grafana does not listen until it finishes.
- Stacked on #5406 — this targets `nl/misc-localdev-fixes` and should not merge until that one lands.
