### PR TITLE
feat(github): SEC-06 wave 1 -- delete all 67 zero-cost direct collaborator grants

### DIFF
--- a/bin/github-collaborator-cleanup
+++ b/bin/github-collaborator-cleanup
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Delete direct collaborator grants that cost the holder nothing (SEC-06 wave 1).
+
+`repository.py` does not emit `RepositoryCollaborator` resources at all -- the target
+state is zero direct grants (plan §4.7), and the provider schema carries no documented
+import for the resource anyway. So this is not a Pulumi diff; it is a live mutation
+over `DELETE /repos/{owner}/{repo}/collaborators/{username}`, authenticated as the
+`ol-infrastructure-as-code` App installation (same credential `bin/github-estate-audit
+access` reads with).
+
+Only `redundant`, `level-only` and `owner-implicit` grants are ever touched --
+`ol_infrastructure.saas.github.audit.REMOVABLE_KINDS`. `no-access` (the direct grant
+is the only path in) and `outside` (not an org member) are never acted on here; both
+need a different decision first.
+
+VERIFY IMMEDIATELY BEFORE ACTING, NOT FROM A STALE REPORT. `apply` re-classifies from
+a fresh `audit.fetch_rosters()` call of its own -- it does not accept a plan file from
+an earlier run -- because team rosters are not committed and change without any commit
+landing here. Someone leaving a team between a `plan` run and `apply` turns a
+`redundant` grant into `no-access`; classifying fresh right before deleting is what
+keeps that window closed.
+
+    uv run bin/github-collaborator-cleanup plan             # read-only, always safe
+    uv run bin/github-collaborator-cleanup apply             # dry-run without --yes
+    uv run bin/github-collaborator-cleanup apply --yes       # actually deletes
+    uv run bin/github-collaborator-cleanup apply --yes --kind redundant
+"""
+
+import sys
+from pathlib import Path
+from typing import Annotated, Any
+
+import cyclopts
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from ol_infrastructure.saas.github import audit
+from ol_infrastructure.saas.github.repositories import archetypes
+
+app = cyclopts.App(help="Delete SEC-06 direct-collaborator grants that cost nothing.")
+
+Kind = Annotated[
+    audit.GrantKind | None,
+    cyclopts.Parameter(help="Restrict to one removable kind. Default: all three."),
+]
+
+
+def _classify_removable(kind: str | None) -> list[dict[str, Any]]:
+    fleet = archetypes.load_fleet()
+    rosters, members, parents, owners = audit.fetch_rosters()
+    rows = audit.classify_direct_grants(fleet, rosters, members, parents, owners)
+    removable = audit.REMOVABLE_KINDS if kind is None else {kind}
+    return sorted(
+        (r for r in rows if r["kind"] in removable),
+        key=lambda r: (r["repo"], r["login"]),
+    )
+
+
+def _print_plan(rows: list[dict[str, Any]]) -> None:
+    for row in rows:
+        tag = " [archived]" if row["archived"] else ""
+        print(
+            f"  {row['repo']:38}{tag:11} {row['login']:22} "
+            f"{row['role']:8} ({row['kind']})"
+        )
+    from collections import Counter  # noqa: PLC0415
+
+    kinds = Counter(r["kind"] for r in rows)
+    print(f"\n{len(rows)} grant(s) to delete: {dict(kinds)}")
+
+
+@app.command
+def plan(*, kind: Kind = None) -> int:
+    """Print every currently-removable direct grant. Read-only, hits the API."""
+    rows = _classify_removable(kind)
+    _print_plan(rows)
+    return 0
+
+
+@app.command
+def apply(
+    *,
+    kind: Kind = None,
+    yes: Annotated[
+        bool, cyclopts.Parameter(help="Actually delete. Without this, dry-run only.")
+    ] = False,
+) -> int:
+    """Re-classify fresh, then delete every removable grant found.
+
+    Fetches its own live classification rather than reusing a `plan` run's output --
+    see the module docstring for why that staleness window matters.
+    """
+    rows = _classify_removable(kind)
+    _print_plan(rows)
+    if not rows:
+        return 0
+    if not yes:
+        print("\nDry run -- pass --yes to actually delete these grants.")
+        return 0
+
+    import httpx  # noqa: PLC0415 -- only `apply --yes` needs the API
+
+    from ol_infrastructure.lib.github_helper import (  # noqa: PLC0415
+        API_HEADERS,
+        GITHUB_API,
+        get_installation_token,
+    )
+
+    token = get_installation_token()
+    failures: list[str] = []
+    print()
+    with httpx.Client(
+        base_url=GITHUB_API,
+        headers={**API_HEADERS, "Authorization": f"Bearer {token}"},
+        timeout=60,
+        follow_redirects=True,
+    ) as client:
+        for row in rows:
+            repo, login = row["repo"], row["login"]
+            response = client.delete(f"/repos/mitodl/{repo}/collaborators/{login}")
+            if response.status_code == httpx.codes.NO_CONTENT:
+                print(f"  deleted  {repo}:{login}")
+            else:
+                detail = f"{repo}:{login} -> HTTP {response.status_code} {response.text[:200]}"
+                print(f"  FAILED   {detail}")
+                failures.append(detail)
+
+    print(f"\n{len(rows) - len(failures)}/{len(rows)} grant(s) deleted.")
+    if failures:
+        print("Failures:")
+        for f in failures:
+            print(f"  {f}")
+        return 1
+    print(
+        "\nNext: refresh the crawl (`uv run bin/github-org-inventory crawl "
+        "--refresh`) so `_direct_collaborators` in data/repos/ reflects reality, "
+        "then commit that data update."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    app()

--- a/bin/github-collaborator-cleanup
+++ b/bin/github-collaborator-cleanup
@@ -40,7 +40,7 @@ from ol_infrastructure.saas.github.repositories import archetypes
 app = cyclopts.App(help="Delete SEC-06 direct-collaborator grants that cost nothing.")
 
 Kind = Annotated[
-    audit.GrantKind | None,
+    audit.RemovableKind | None,
     cyclopts.Parameter(help="Restrict to one removable kind. Default: all three."),
 ]
 
@@ -50,6 +50,17 @@ def _classify_removable(kind: str | None) -> list[dict[str, Any]]:
     rosters, members, parents, owners = audit.fetch_rosters()
     rows = audit.classify_direct_grants(fleet, rosters, members, parents, owners)
     removable = audit.REMOVABLE_KINDS if kind is None else {kind}
+    # Defense in depth, not redundant with the `Kind` annotation above: that only
+    # gates the CLI's own argument parser. Anything calling `_classify_removable`
+    # programmatically -- a test, a future script -- bypasses cyclopts entirely, and
+    # `no-access`/`outside` sailing through here is exactly the failure mode this
+    # tool exists to prevent (deleting a grant that is someone's only path in).
+    if not removable <= audit.REMOVABLE_KINDS:
+        message = (
+            f"kind={kind!r} is not a removable kind "
+            f"({sorted(audit.REMOVABLE_KINDS)}); refusing to classify against it"
+        )
+        raise ValueError(message)
     return sorted(
         (r for r in rows if r["kind"] in removable),
         key=lambda r: (r["repo"], r["login"]),

--- a/bin/github-estate-audit
+++ b/bin/github-estate-audit
@@ -18,7 +18,7 @@ import json
 import sys
 from collections import Counter
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated
 
 import cyclopts
 
@@ -204,63 +204,6 @@ def drift(
     return 1 if total else 0
 
 
-def _fetch_rosters() -> tuple[
-    dict[str, set[str]], set[str], dict[str, str | None], set[str]
-]:
-    """Team rosters, org members and team nesting, read live from the API.
-
-    NOT read from committed data, and not cached to disk, because there is nowhere
-    safe to put it: `vault-developer-access` and `vault-devops-access` are declared
-    `privacy: secret` in organization/teams.py so their membership is not advertised
-    even inside the org, and ol-infrastructure is a PUBLIC repository. Committing
-    rosters here would publish exactly what that setting exists to withhold.
-    """
-    import httpx  # noqa: PLC0415 -- only `access` needs the API; `run` must stay clean
-
-    from ol_infrastructure.lib.github_helper import (  # noqa: PLC0415
-        API_HEADERS,
-        GITHUB_API,
-        get_installation_token,
-    )
-
-    org = "mitodl"
-    token = get_installation_token()
-
-    def paginate(client: httpx.Client, path: str) -> list[dict[str, Any]]:
-        out: list[dict[str, Any]] = []
-        url: str | None = f"{path}{'&' if '?' in path else '?'}per_page=100"
-        while url:
-            response = client.get(url)
-            response.raise_for_status()
-            out.extend(response.json())
-            url = response.links.get("next", {}).get("url")
-        return out
-
-    with httpx.Client(
-        base_url=GITHUB_API,
-        headers={**API_HEADERS, "Authorization": f"Bearer {token}"},
-        timeout=60,
-        follow_redirects=True,
-    ) as client:
-        members = {m["login"] for m in paginate(client, f"/orgs/{org}/members")}
-        # Org OWNERS hold implicit admin on every repo -- a third access path beside
-        # teams and direct grants, and the only one the others cannot revoke. The
-        # plain members list does not distinguish them, so this is a separate call.
-        owners = {
-            m["login"] for m in paginate(client, f"/orgs/{org}/members?role=admin")
-        }
-        teams = paginate(client, f"/orgs/{org}/teams")
-        rosters = {
-            t["slug"]: {
-                m["login"]
-                for m in paginate(client, f"/orgs/{org}/teams/{t['slug']}/members")
-            }
-            for t in teams
-        }
-    parents = {t["slug"]: (t.get("parent") or {}).get("slug") for t in teams}
-    return rosters, members, parents, owners
-
-
 @app.command
 def access(
     *,
@@ -271,15 +214,17 @@ def access(
     """Report team-grant uniformity and explain every direct collaborator grant.
 
     NEEDS CREDENTIALS, unlike `run`. Classifying a direct grant means knowing who is
-    in which team, and rosters are deliberately not committed -- see `_fetch_rosters`.
+    in which team, and rosters are deliberately not committed -- see
+    `audit.fetch_rosters`.
 
     Read the two halves together. The shape count says how far the fleet is from a
-    model; the direct-grant split says how much of the cleanup is free (`redundant`
-    and `level-only`) versus how much needs a team grant added first (`no-access`).
+    model; the direct-grant split says how much of the cleanup is free (`redundant`,
+    `level-only`, `owner-implicit`) versus how much needs a team grant added first
+    (`no-access`).
     """
     fleet = archetypes.load_fleet()
     active = [r for r in fleet if not r.get("archived")]
-    rosters, members, parents, owners = _fetch_rosters()
+    rosters, members, parents, owners = audit.fetch_rosters()
     rows = audit.classify_direct_grants(fleet, rosters, members, parents, owners)
     shapes = audit.grant_shapes(active)
     kinds = Counter(r["kind"] for r in rows)

--- a/src/ol_infrastructure/saas/github/audit.py
+++ b/src/ol_infrastructure/saas/github/audit.py
@@ -474,6 +474,14 @@ def fetch_rosters() -> tuple[
 
 
 GrantKind = Literal["redundant", "level-only", "owner-implicit", "no-access", "outside"]
+#: The subset of `GrantKind` a caller may safely act on with a delete. Kept as its own
+#: `Literal` (not just a runtime check against `REMOVABLE_KINDS`) so a CLI built on top
+#: -- `bin/github-collaborator-cleanup`'s `--kind` -- gets this enforced at argument
+#: parsing, before any classification or API call runs. `RemovableKind` and
+#: `REMOVABLE_KINDS` must be kept in sync; there is no single source of truth to
+#: generate one from the other because a `Literal`'s members are not introspectable
+#: from a frozenset at the type-checker level.
+RemovableKind = Literal["redundant", "level-only", "owner-implicit"]
 #: The kinds whose removal costs the person nothing. `no-access` and `outside` are
 #: deliberately absent: one revokes access, the other is a membership decision.
 REMOVABLE_KINDS: frozenset[str] = frozenset(

--- a/src/ol_infrastructure/saas/github/audit.py
+++ b/src/ol_infrastructure/saas/github/audit.py
@@ -411,6 +411,68 @@ def population(fleet: Iterable[dict[str, Any]], scope: Scope) -> int:
 
 
 #: Why a direct collaborator grant exists, which is what decides how to remove it.
+def fetch_rosters() -> tuple[
+    dict[str, set[str]], set[str], dict[str, str | None], set[str]
+]:
+    """Team rosters, org members and team nesting, read live from the API.
+
+    NOT read from committed data, and not cached to disk, because there is nowhere
+    safe to put it: `vault-developer-access` and `vault-devops-access` are declared
+    `privacy: secret` in organization/teams.py so their membership is not advertised
+    even inside the org, and ol-infrastructure is a PUBLIC repository. Committing
+    rosters here would publish exactly what that setting exists to withhold.
+
+    Shared by `bin/github-estate-audit access` and `bin/github-collaborator-cleanup`
+    -- both need a roster snapshot no older than "right now" (§ SEC-06: a roster that
+    changed between audit and action turns a `redundant` grant into `no-access`, and
+    acting on the stale classification silently revokes someone's only path in).
+    """
+    import httpx  # noqa: PLC0415 -- only roster-fetching callers need the API
+
+    from ol_infrastructure.lib.github_helper import (  # noqa: PLC0415
+        API_HEADERS,
+        GITHUB_API,
+        get_installation_token,
+    )
+
+    org = "mitodl"
+    token = get_installation_token()
+
+    def paginate(client: httpx.Client, path: str) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
+        url: str | None = f"{path}{'&' if '?' in path else '?'}per_page=100"
+        while url:
+            response = client.get(url)
+            response.raise_for_status()
+            out.extend(response.json())
+            url = response.links.get("next", {}).get("url")
+        return out
+
+    with httpx.Client(
+        base_url=GITHUB_API,
+        headers={**API_HEADERS, "Authorization": f"Bearer {token}"},
+        timeout=60,
+        follow_redirects=True,
+    ) as client:
+        members = {m["login"] for m in paginate(client, f"/orgs/{org}/members")}
+        # Org OWNERS hold implicit admin on every repo -- a third access path beside
+        # teams and direct grants, and the only one the others cannot revoke. The
+        # plain members list does not distinguish them, so this is a separate call.
+        owners = {
+            m["login"] for m in paginate(client, f"/orgs/{org}/members?role=admin")
+        }
+        teams = paginate(client, f"/orgs/{org}/teams")
+        rosters = {
+            t["slug"]: {
+                m["login"]
+                for m in paginate(client, f"/orgs/{org}/teams/{t['slug']}/members")
+            }
+            for t in teams
+        }
+    parents = {t["slug"]: (t.get("parent") or {}).get("slug") for t in teams}
+    return rosters, members, parents, owners
+
+
 GrantKind = Literal["redundant", "level-only", "owner-implicit", "no-access", "outside"]
 #: The kinds whose removal costs the person nothing. `no-access` and `outside` are
 #: deliberately absent: one revokes access, the other is a membership decision.

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/.github.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/.github.yaml
@@ -5,7 +5,7 @@ _custom_properties:
   tier: tier-1
 _has_branch_protection: true
 _pushed_at: '2026-08-07T15:09:00Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/access-forge.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/access-forge.yaml
@@ -25,8 +25,8 @@ _actions_secret_names:
 _custom_properties:
   tier: tier-1
 _has_branch_protection: false
-_pushed_at: '2026-08-07T05:00:32Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-14T05:00:38Z'
+_ruleset_count: 2
 _visibility: private
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/agent-kit.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/agent-kit.yaml
@@ -3,8 +3,8 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 2
 _has_branch_protection: false
-_pushed_at: '2026-08-07T20:31:27Z'
-_ruleset_count: 1
+_pushed_at: '2026-08-14T18:48:43Z'
+_ruleset_count: 3
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/alerting-omnibus.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/alerting-omnibus.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2026-06-30T18:10:28Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: private
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/apisix-testbed.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/apisix-testbed.yaml
@@ -5,7 +5,7 @@ _direct_collaborators:
   jkachel: admin
 _has_branch_protection: false
 _pushed_at: '2025-04-01T21:23:50Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: private
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/apisix.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/apisix.yaml
@@ -2,7 +2,7 @@
 _custom_properties:
   tier: unmanaged
 _has_branch_protection: false
-_pushed_at: '2026-08-04T20:50:18Z'
+_pushed_at: '2026-08-12T03:04:10Z'
 _ruleset_count: 0
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/brand-mitol-residential.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/brand-mitol-residential.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  arslanashraf7: admin
 _has_branch_protection: false
 _pushed_at: '2023-08-16T13:55:04Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/common-access.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/common-access.yaml
@@ -4,8 +4,8 @@ _custom_properties:
 _direct_collaborators:
   jkachel: admin
 _has_branch_protection: false
-_pushed_at: '2026-08-05T16:57:02Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-08T14:36:03Z'
+_ruleset_count: 2
 _visibility: private
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/common-access.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/common-access.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: tier-1
-_direct_collaborators:
-  jkachel: admin
 _has_branch_protection: false
 _pushed_at: '2026-08-08T14:36:03Z'
 _ruleset_count: 2

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-dcind.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-dcind.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  Ardiea: admin
 _has_branch_protection: false
 _pushed_at: '2020-12-28T23:42:19Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-workflow.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-workflow.yaml
@@ -4,11 +4,10 @@ _actions_secret_names:
 _custom_properties:
   tier: tier-1
 _direct_collaborators:
-  Ardiea: admin
   odlbot: admin
 _has_branch_protection: false
 _pushed_at: '2024-06-17T15:06:41Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: private
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concoursepy.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concoursepy.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  mbertrand: admin
 _has_branch_protection: false
 _pushed_at: '2023-06-16T11:55:30Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/cookiecutter-pylib.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/cookiecutter-pylib.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  rhysyngsun: admin
 _has_branch_protection: false
 _pushed_at: '2025-10-12T18:26:24Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/copier-djangoapp.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/copier-djangoapp.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  rhysyngsun: admin
 _has_branch_protection: false
 _pushed_at: '2025-12-10T04:36:39Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/course-catalog.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/course-catalog.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  mbertrand: admin
 _has_branch_protection: false
 _pushed_at: '2019-02-14T02:11:35Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/course-search-utils.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/course-search-utils.yaml
@@ -3,8 +3,8 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-08-06T22:42:01Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-13T14:53:31Z'
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/default-labels-repo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/default-labels-repo.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2023-03-21T17:37:54Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/demo-test-course.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/demo-test-course.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  pdpinch: admin
 _has_branch_protection: false
 _pushed_at: '2021-06-10T06:44:16Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-aqueduct.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-aqueduct.yaml
@@ -3,8 +3,8 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 2
 _has_branch_protection: false
-_pushed_at: '2026-08-07T17:45:12Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-10T18:24:48Z'
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-cas-mapper.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-cas-mapper.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2016-07-21T13:25:12Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/docs.openedx.org.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/docs.openedx.org.yaml
@@ -2,7 +2,7 @@
 _custom_properties:
   tier: unmanaged
 _has_branch_protection: false
-_pushed_at: '2026-08-03T14:22:38Z'
+_pushed_at: '2026-08-12T11:08:22Z'
 _ruleset_count: 0
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-api-client.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-api-client.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: unmanaged
 _excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-08-06T12:46:19Z'
+_pushed_at: '2026-08-08T10:34:35Z'
 _ruleset_count: 0
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-platform.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-platform.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  odlbot: admin
 _has_branch_protection: false
 _pushed_at: '2026-07-31T20:18:00Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-platform.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-platform.yaml
@@ -3,7 +3,6 @@ _custom_properties:
   tier: unmanaged
 _direct_collaborators:
   odlbot: admin
-  shaidar: admin
 _has_branch_protection: false
 _pushed_at: '2026-07-31T20:18:00Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edxcut.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edxcut.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2022-08-28T16:33:05Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/eslint-config.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/eslint-config.yaml
@@ -2,8 +2,8 @@
 _custom_properties:
   tier: tier-1
 _has_branch_protection: false
-_pushed_at: '2026-08-06T12:47:42Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-12T02:51:59Z'
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-discussions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-discussions.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  Anas12091101: admin
 _has_branch_protection: false
 _pushed_at: '2025-11-14T16:22:25Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-instructor-dashboard.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-instructor-dashboard.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  Anas12091101: admin
 _has_branch_protection: false
 _pushed_at: '2026-07-27T10:48:45Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-learning.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-learning.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  Anas12091101: admin
 _has_branch_protection: false
 _pushed_at: '2026-03-06T11:55:12Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-lib-special-exams-mitol.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-lib-special-exams-mitol.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  arslanashraf7: admin
 _has_branch_protection: true
 _pushed_at: '2025-02-12T07:47:20Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-slot-footer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-slot-footer.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  Anas12091101: admin
 _has_branch_protection: false
 _pushed_at: '2025-03-25T18:38:33Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/grafana-alerts.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/grafana-alerts.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  Ardiea: admin
 _has_branch_protection: false
 _pushed_at: '2026-06-25T15:06:09Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/grafana-dashboards.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/grafana-dashboards.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  odlbot: admin
 _has_branch_protection: false
 _pushed_at: '2025-11-21T19:30:39Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/grafana-dashboards.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/grafana-dashboards.yaml
@@ -2,7 +2,6 @@
 _custom_properties:
   tier: unmanaged
 _direct_collaborators:
-  Ardiea: admin
   odlbot: admin
 _has_branch_protection: false
 _pushed_at: '2025-11-21T19:30:39Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/gwarek.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/gwarek.yaml
@@ -6,7 +6,7 @@ _custom_properties:
   tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2026-08-07T19:37:39Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: private
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/hacksnack.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/hacksnack.yaml
@@ -4,8 +4,8 @@ _custom_properties:
 _direct_collaborators:
   abeglova: admin
 _has_branch_protection: false
-_pushed_at: '2026-08-07T13:33:02Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-12T13:50:14Z'
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/hacksnack.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/hacksnack.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: tier-1
-_direct_collaborators:
-  abeglova: admin
 _has_branch_protection: false
 _pushed_at: '2026-08-12T13:50:14Z'
 _ruleset_count: 2

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/handbook.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/handbook.yaml
@@ -4,7 +4,7 @@ _custom_properties:
 _excluded_environments: 1
 _has_branch_protection: true
 _pushed_at: '2026-06-11T20:45:57Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/hq.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/hq.yaml
@@ -4,11 +4,9 @@ _actions_secret_names:
 - STANDUP_REPO_ID
 _custom_properties:
   tier: tier-1
-_direct_collaborators:
-  rhysyngsun: admin
 _has_branch_protection: false
-_pushed_at: '2026-08-06T12:40:16Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-13T05:50:56Z'
+_ruleset_count: 2
 _visibility: private
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/internal.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/internal.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  rhysyngsun: admin
 _has_branch_protection: false
 _pushed_at: '2023-12-01T14:36:25Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/keycloak-scim.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/keycloak-scim.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2026-07-21T00:07:13Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/learn-ai-compromised.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/learn-ai-compromised.yaml
@@ -18,10 +18,6 @@ _actions_secret_names:
 - POSTHOG_PROJECT_API_KEY_RC
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  ChristopherChudzicki: admin
-  mbertrand: write
-  odlbot: write
 _has_branch_protection: false
 _pushed_at: '2026-07-27T14:15:12Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/learn-ai.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/learn-ai.yaml
@@ -3,8 +3,8 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-08-06T13:09:53Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-13T19:43:16Z'
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/lehrer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/lehrer.yaml
@@ -3,8 +3,8 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-08-07T13:36:43Z'
-_ruleset_count: 2
+_pushed_at: '2026-08-13T17:47:59Z'
+_ruleset_count: 4
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/library.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/library.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  odlbot: admin
 _excluded_environments: 4
 _has_branch_protection: false
 _pushed_at: '2023-08-03T18:12:05Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters.yaml
@@ -7,8 +7,8 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 2694
 _has_branch_protection: true
-_pushed_at: '2026-08-06T14:27:37Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-13T21:41:54Z'
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn-api-clients.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn-api-clients.yaml
@@ -3,8 +3,8 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-08-06T12:25:50Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-13T13:03:19Z'
+_ruleset_count: 2
 _visibility: public
 allow_merge_commit: false
 allow_rebase_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
@@ -10,8 +10,8 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 44
 _has_branch_protection: true
-_pushed_at: '2026-08-07T20:41:25Z'
-_ruleset_count: 1
+_pushed_at: '2026-08-14T19:13:10Z'
+_ruleset_count: 3
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
@@ -10,7 +10,7 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 44
 _has_branch_protection: true
-_pushed_at: '2026-08-14T19:13:10Z'
+_pushed_at: '2026-08-14T20:19:39Z'
 _ruleset_count: 3
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-moira.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-moira.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2018-05-24T14:42:31Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-open-bk.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-open-bk.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  rhysyngsun: admin
 _has_branch_protection: false
 _pushed_at: '2023-07-28T13:16:48Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-open-login-button.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-open-login-button.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  gumaerc: admin
 _has_branch_protection: true
 _pushed_at: '2025-04-21T09:15:19Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-grading-library.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-grading-library.yaml
@@ -6,8 +6,8 @@ _direct_collaborators:
   MaferMazu: write
 _excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-08-06T12:29:32Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-08T10:41:40Z'
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-grading-library.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-grading-library.yaml
@@ -2,7 +2,6 @@
 _custom_properties:
   tier: tier-1
 _direct_collaborators:
-  ChristopherChudzicki: admin
   MaferMazu: write
 _excluded_environments: 1
 _has_branch_protection: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-theme.yaml
@@ -4,7 +4,7 @@ _custom_properties:
 _excluded_environments: 1
 _has_branch_protection: false
 _pushed_at: '2026-07-13T13:04:55Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitx_cas_mapper.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitx_cas_mapper.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2016-07-21T18:56:42Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-api-clients.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-api-clients.yaml
@@ -3,8 +3,8 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-08-06T16:01:54Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-13T22:42:20Z'
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-theme.yaml
@@ -4,7 +4,7 @@ _custom_properties:
 _excluded_environments: 1
 _has_branch_protection: false
 _pushed_at: '2026-08-04T07:48:37Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-translations.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-translations.yaml
@@ -4,7 +4,7 @@ _custom_properties:
 _direct_collaborators:
   Anas12091101: admin
 _has_branch_protection: false
-_pushed_at: '2026-08-07T01:59:35Z'
+_pushed_at: '2026-08-14T01:06:13Z'
 _ruleset_count: 0
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-translations.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-translations.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  Anas12091101: admin
 _has_branch_protection: false
 _pushed_at: '2026-08-14T01:06:13Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline.yaml
@@ -5,12 +5,10 @@ _actions_secret_names:
 - OL_HQ_PROJECT_SECRET
 _custom_properties:
   tier: tier-1
-_direct_collaborators:
-  rhysyngsun: admin
 _excluded_environments: 412
 _has_branch_protection: true
-_pushed_at: '2026-08-07T20:06:54Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-14T18:35:56Z'
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-openedx-extensions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-openedx-extensions.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  rhysyngsun: admin
 _has_branch_protection: false
 _pushed_at: '2024-06-17T15:05:43Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-theme.yaml
@@ -1,12 +1,10 @@
 ---
 _custom_properties:
   tier: tier-1
-_direct_collaborators:
-  pdpinch: admin
 _excluded_environments: 1
 _has_branch_protection: false
 _pushed_at: '2026-07-13T13:05:34Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro.yaml
@@ -5,12 +5,10 @@ _actions_secret_names:
 - OL_HQ_PROJECT_SECRET
 _custom_properties:
   tier: tier-1
-_direct_collaborators:
-  rhysyngsun: admin
 _excluded_environments: 2042
 _has_branch_protection: true
-_pushed_at: '2026-08-07T15:19:24Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-12T20:44:19Z'
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mynumbers.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mynumbers.yaml
@@ -24,7 +24,7 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: triage
-  code-owners: admin
+  code-owners: push
   odl-engineering: push
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mynumbers.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mynumbers.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  abeglova: admin
 _excluded_environments: 1
 _has_branch_protection: false
 _pushed_at: '2026-08-13T08:21:52Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mynumbers.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mynumbers.yaml
@@ -3,8 +3,9 @@ _custom_properties:
   tier: unmanaged
 _direct_collaborators:
   abeglova: admin
+_excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-06-17T14:28:07Z'
+_pushed_at: '2026-08-13T08:21:52Z'
 _ruleset_count: 0
 _visibility: public
 allow_auto_merge: false
@@ -25,7 +26,7 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: triage
-  code-owners: push
+  code-owners: admin
   odl-engineering: push
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/no_op2_resizer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/no_op2_resizer.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  rhysyngsun: admin
 _has_branch_protection: false
 _pushed_at: '2023-12-01T08:29:27Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-course-example-markdown.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-course-example-markdown.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  gumaerc: admin
 _has_branch_protection: false
 _pushed_at: '2023-12-01T14:17:25Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-course-hugo-starter.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-course-hugo-starter.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  gumaerc: admin
 _has_branch_protection: false
 _pushed_at: '2022-04-17T19:04:10Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-course-hugo-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-course-hugo-theme.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  gumaerc: admin
 _has_branch_protection: false
 _pushed_at: '2021-05-04T13:53:05Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-projects.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-projects.yaml
@@ -1,12 +1,10 @@
 ---
 _custom_properties:
   tier: tier-1
-_direct_collaborators:
-  gumaerc: admin
 _excluded_environments: 1
 _has_branch_protection: true
-_pushed_at: '2026-08-06T21:13:25Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-12T13:41:20Z'
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-themes.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-themes.yaml
@@ -14,12 +14,10 @@ _actions_secret_names:
 - STATIC_API_BASE_URL
 _custom_properties:
   tier: tier-1
-_direct_collaborators:
-  gumaerc: admin
 _excluded_environments: 3
 _has_branch_protection: true
-_pushed_at: '2026-08-06T13:47:48Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-13T14:33:51Z'
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-studio.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-studio.yaml
@@ -4,12 +4,10 @@ _actions_secret_names:
 - HEROKU_EMAIL
 _custom_properties:
   tier: tier-1
-_direct_collaborators:
-  rhysyngsun: admin
 _excluded_environments: 5
 _has_branch_protection: true
-_pushed_at: '2026-08-07T14:24:43Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-14T05:34:01Z'
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-to-hugo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-to-hugo.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  gumaerc: admin
 _has_branch_protection: false
 _pushed_at: '2024-04-28T17:49:17Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw_oer_export.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw_oer_export.yaml
@@ -6,8 +6,8 @@ _custom_properties:
 _direct_collaborators:
   ChristopherChudzicki: admin
 _has_branch_protection: false
-_pushed_at: '2026-08-06T12:27:21Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-13T21:12:34Z'
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw_oer_export.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw_oer_export.yaml
@@ -3,8 +3,6 @@ _actions_secret_names:
 - SLACK_WEBHOOK
 _custom_properties:
   tier: tier-1
-_direct_collaborators:
-  ChristopherChudzicki: admin
 _has_branch_protection: false
 _pushed_at: '2026-08-13T21:12:34Z'
 _ruleset_count: 2

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/odl-video-service.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/odl-video-service.yaml
@@ -3,8 +3,8 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 6
 _has_branch_protection: true
-_pushed_at: '2026-08-05T20:26:29Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-13T20:52:43Z'
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-analytics-api.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-analytics-api.yaml
@@ -3,8 +3,8 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 3
 _has_branch_protection: false
-_pushed_at: '2026-08-03T21:20:30Z'
-_ruleset_count: 1
+_pushed_at: '2026-08-14T19:28:21Z'
+_ruleset_count: 3
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-concourse.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-concourse.yaml
@@ -3,8 +3,8 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-08-07T19:34:02Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-14T00:36:11Z'
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-customizations-nytimes-library.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-customizations-nytimes-library.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2026-08-06T03:42:39Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-data-platform.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-data-platform.yaml
@@ -5,8 +5,8 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 2
 _has_branch_protection: true
-_pushed_at: '2026-08-07T18:17:52Z'
-_ruleset_count: 1
+_pushed_at: '2026-08-14T19:41:56Z'
+_ruleset_count: 3
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-data-platform.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-data-platform.yaml
@@ -5,7 +5,7 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 2
 _has_branch_protection: true
-_pushed_at: '2026-08-14T19:41:56Z'
+_pushed_at: '2026-08-14T20:52:38Z'
 _ruleset_count: 3
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-django.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-django.yaml
@@ -3,12 +3,10 @@ _actions_secret_names:
 - PYPI_TOKEN
 _custom_properties:
   tier: tier-1
-_direct_collaborators:
-  rhysyngsun: admin
 _excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-08-07T18:51:41Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-12T02:55:30Z'
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-github-workflows.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-github-workflows.yaml
@@ -1,11 +1,9 @@
 ---
 _custom_properties:
   tier: tier-1
-_direct_collaborators:
-  rhysyngsun: admin
 _has_branch_protection: false
 _pushed_at: '2024-06-17T14:47:01Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infra-health-checks.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infra-health-checks.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2026-07-28T23:48:52Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
@@ -25,7 +25,7 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   devops: admin
-  devops-contractors: admin
+  devops-contractors: push
   odl-engineering: maintain
   odl-engineering-owners: admin
 topics:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
@@ -5,8 +5,8 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 2
 _has_branch_protection: true
-_pushed_at: '2026-08-07T20:09:59Z'
-_ruleset_count: 1
+_pushed_at: '2026-08-14T19:33:00Z'
+_ruleset_count: 3
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true
@@ -25,7 +25,7 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   devops: admin
-  devops-contractors: push
+  devops-contractors: admin
   odl-engineering: maintain
   odl-engineering-owners: admin
 topics:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
@@ -5,7 +5,7 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 2
 _has_branch_protection: true
-_pushed_at: '2026-08-14T19:33:00Z'
+_pushed_at: '2026-08-14T20:49:40Z'
 _ruleset_count: 3
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloak.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloak.yaml
@@ -2,8 +2,8 @@
 _custom_properties:
   tier: tier-1
 _has_branch_protection: true
-_pushed_at: '2026-08-05T20:28:02Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-10T20:05:34Z'
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloakify.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloakify.yaml
@@ -3,8 +3,8 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 2
 _has_branch_protection: false
-_pushed_at: '2026-08-06T12:38:02Z'
-_ruleset_count: 1
+_pushed_at: '2026-08-12T02:52:33Z'
+_ruleset_count: 3
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-notebook-extensions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-notebook-extensions.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: tier-1
-_direct_collaborators:
-  dsubak: admin
 _has_branch_protection: false
 _pushed_at: '2026-08-14T19:07:46Z'
 _ruleset_count: 2

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-notebook-extensions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-notebook-extensions.yaml
@@ -4,8 +4,8 @@ _custom_properties:
 _direct_collaborators:
   dsubak: admin
 _has_branch_protection: false
-_pushed_at: '2026-08-06T19:40:48Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-14T19:07:46Z'
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-npm-libraries.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-npm-libraries.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  rhysyngsun: admin
 _has_branch_protection: true
 _pushed_at: '2024-04-11T10:34:56Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-rootly-manager.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-rootly-manager.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2026-06-29T21:02:58Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/oldevops-scratch.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/oldevops-scratch.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2023-09-26T20:52:27Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: private
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-collaboration.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-collaboration.yaml
@@ -1,11 +1,9 @@
 ---
 _custom_properties:
   tier: tier-1
-_direct_collaborators:
-  Ferdi: admin
 _has_branch_protection: false
 _pushed_at: '2023-10-25T13:45:42Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: private
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-discussions-client.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-discussions-client.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  rhysyngsun: admin
 _has_branch_protection: true
 _pushed_at: '2023-10-20T13:38:04Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-discussions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-discussions.yaml
@@ -6,8 +6,8 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 1723
 _has_branch_protection: true
-_pushed_at: '2026-07-23T18:59:37Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-12T15:50:43Z'
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-plugins.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-plugins.yaml
@@ -3,8 +3,8 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 1
 _has_branch_protection: true
-_pushed_at: '2026-08-07T12:03:32Z'
-_ruleset_count: 1
+_pushed_at: '2026-08-12T13:02:56Z'
+_ruleset_count: 3
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-learning-ai-tutor.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-learning-ai-tutor.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: unmanaged
 _excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-08-06T19:36:51Z'
+_pushed_at: '2026-08-13T05:56:07Z'
 _ruleset_count: 0
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-learnix.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-learnix.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2026-01-15T16:47:09Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: public
 allow_merge_commit: false
 allow_rebase_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-podcast-data.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-podcast-data.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: tier-1
-_direct_collaborators:
-  odlbot: admin
 _has_branch_protection: false
 _pushed_at: '2026-06-04T14:57:27Z'
 _ruleset_count: 2

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-podcast-data.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-podcast-data.yaml
@@ -5,7 +5,7 @@ _direct_collaborators:
   odlbot: admin
 _has_branch_protection: false
 _pushed_at: '2026-06-04T14:57:27Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-resource-blocklists.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-resource-blocklists.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: tier-1
-_direct_collaborators:
-  mbertrand: admin
 _has_branch_protection: false
 _pushed_at: '2026-07-23T20:01:50Z'
 _ruleset_count: 2

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-resource-blocklists.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-resource-blocklists.yaml
@@ -5,7 +5,7 @@ _direct_collaborators:
   mbertrand: admin
 _has_branch_protection: false
 _pushed_at: '2026-07-23T20:01:50Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-video-data.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-video-data.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2026-05-12T14:38:52Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/openedx-events.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/openedx-events.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  Anas12091101: admin
 _has_branch_protection: false
 _pushed_at: '2026-03-25T07:09:56Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/platform-engineering-site.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/platform-engineering-site.yaml
@@ -3,8 +3,8 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 2
 _has_branch_protection: false
-_pushed_at: '2026-08-06T12:25:35Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-10T19:41:36Z'
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/product.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/product.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2024-04-11T14:12:31Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: private
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/realistic-mm-users.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/realistic-mm-users.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2017-01-17T21:09:26Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-config.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-config.yaml
@@ -1,11 +1,9 @@
 ---
 _custom_properties:
   tier: tier-1
-_direct_collaborators:
-  rhysyngsun: admin
 _has_branch_protection: false
 _pushed_at: '2020-07-03T15:06:49Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/reddit.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/reddit.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  rhysyngsun: admin
 _has_branch_protection: false
 _pushed_at: '2023-10-20T13:38:09Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/redux-asserts.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/redux-asserts.yaml
@@ -2,8 +2,8 @@
 _custom_properties:
   tier: tier-1
 _has_branch_protection: true
-_pushed_at: '2026-08-05T20:40:46Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-10T23:54:51Z'
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/redux-hammock.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/redux-hammock.yaml
@@ -2,8 +2,8 @@
 _custom_properties:
   tier: tier-1
 _has_branch_protection: false
-_pushed_at: '2026-08-06T12:44:20Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-08T22:33:06Z'
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/release-script.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/release-script.yaml
@@ -3,8 +3,8 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 2
 _has_branch_protection: false
-_pushed_at: '2026-08-06T12:46:08Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-13T21:13:23Z'
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/semantic-mitopen.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/semantic-mitopen.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  mbertrand: write
 _excluded_environments: 1
 _has_branch_protection: false
 _pushed_at: '2024-08-29T20:01:40Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/semantic-mitopen.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/semantic-mitopen.yaml
@@ -2,7 +2,7 @@
 _custom_properties:
   tier: unmanaged
 _direct_collaborators:
-  mbertrand: admin
+  mbertrand: write
 _excluded_environments: 1
 _has_branch_protection: false
 _pushed_at: '2024-08-29T20:01:40Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/sign-and-verify.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/sign-and-verify.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  rhysyngsun: admin
 _has_branch_protection: false
 _pushed_at: '2020-10-01T17:59:24Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/smoot-design.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/smoot-design.yaml
@@ -3,8 +3,6 @@ _actions_secret_names:
 - SEMANTIC_RELEASE_GITHUB_TOKEN
 _custom_properties:
   tier: tier-1
-_direct_collaborators:
-  ChristopherChudzicki: admin
 _excluded_environments: 2
 _has_branch_protection: true
 _pushed_at: '2026-08-13T21:11:00Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/smoot-design.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/smoot-design.yaml
@@ -7,8 +7,8 @@ _direct_collaborators:
   ChristopherChudzicki: admin
 _excluded_environments: 2
 _has_branch_protection: true
-_pushed_at: '2026-08-07T12:50:46Z'
-_ruleset_count: 1
+_pushed_at: '2026-08-13T21:11:00Z'
+_ruleset_count: 3
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/social-auth-mitxpro.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/social-auth-mitxpro.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  rhysyngsun: admin
 _has_branch_protection: false
 _pushed_at: '2025-05-26T20:25:40Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/sso-django-prototype.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/sso-django-prototype.yaml
@@ -3,7 +3,6 @@ _custom_properties:
   tier: unmanaged
 _direct_collaborators:
   odlbot: admin
-  rhysyngsun: admin
 _excluded_environments: 1
 _has_branch_protection: false
 _pushed_at: '2023-10-20T13:38:14Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/sso-django-prototype.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/sso-django-prototype.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  odlbot: admin
 _excluded_environments: 1
 _has_branch_protection: false
 _pushed_at: '2023-10-20T13:38:14Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/standalone-course-prototype.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/standalone-course-prototype.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  gumaerc: admin
 _has_branch_protection: false
 _pushed_at: '2024-06-11T02:44:20Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/superset-marimo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/superset-marimo.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _has_branch_protection: true
 _pushed_at: '2026-05-22T19:14:05Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/superset-nl-explorer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/superset-nl-explorer.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2026-02-26T00:27:57Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/tech-talk-slides.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/tech-talk-slides.yaml
@@ -3,8 +3,8 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-08-06T12:46:04Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-13T17:03:57Z'
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/tech-talk-slides.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/tech-talk-slides.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-08-13T17:03:57Z'
+_pushed_at: '2026-08-14T20:57:56Z'
 _ruleset_count: 2
 _visibility: public
 allow_auto_merge: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/template-mit-demo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/template-mit-demo.yaml
@@ -7,7 +7,7 @@ _direct_collaborators:
   sfrucht: write
 _has_branch_protection: false
 _pushed_at: '2019-07-10T16:26:56Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/tubular.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/tubular.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  feoh: admin
 _has_branch_protection: false
 _pushed_at: '2023-05-18T20:00:09Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/tutor-mentor.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/tutor-mentor.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  rhysyngsun: admin
 _has_branch_protection: false
 _pushed_at: '2023-10-20T13:38:08Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/unified-ecommerce-api-clients.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/unified-ecommerce-api-clients.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  jkachel: admin
 _has_branch_protection: false
 _pushed_at: '2025-12-09T05:04:21Z'
 _ruleset_count: 0

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/unified-ecommerce-frontend.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/unified-ecommerce-frontend.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  ChristopherChudzicki: admin
 _excluded_environments: 1
 _has_branch_protection: true
 _pushed_at: '2025-12-03T22:25:52Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/unified-ecommerce.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/unified-ecommerce.yaml
@@ -1,8 +1,6 @@
 ---
 _custom_properties:
   tier: unmanaged
-_direct_collaborators:
-  jkachel: admin
 _excluded_environments: 1
 _has_branch_protection: true
 _pushed_at: '2025-12-08T21:56:21Z'

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/vault-plugin-database-starrocks.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/vault-plugin-database-starrocks.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2026-08-06T12:31:15Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/vault-raft-backup.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/vault-raft-backup.yaml
@@ -2,8 +2,8 @@
 _custom_properties:
   tier: tier-1
 _has_branch_protection: false
-_pushed_at: '2026-08-06T12:31:18Z'
-_ruleset_count: 0
+_pushed_at: '2026-08-14T05:33:25Z'
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/video_translation_demo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/video_translation_demo.yaml
@@ -4,7 +4,7 @@ _custom_properties:
 _excluded_environments: 1
 _has_branch_protection: false
 _pushed_at: '2026-03-01T08:32:07Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/world_geographic_regions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/world_geographic_regions.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2015-11-11T14:31:40Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xanalytics.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xanalytics.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _has_branch_protection: false
 _pushed_at: '2021-09-23T12:45:56Z'
-_ruleset_count: 0
+_ruleset_count: 2
 _visibility: public
 allow_auto_merge: false
 allow_merge_commit: true


### PR DESCRIPTION
### What are the relevant tickets?
Part of the [GitHub org import project](docs/plans/github-org-pulumi-import.md). Closes SEC-06 wave 1.

### Description (What does it do?)

- Adds `bin/github-collaborator-cleanup` (`plan` / `apply --yes [--kind]`), which deletes direct collaborator grants over `DELETE /repos/{owner}/{repo}/collaborators/{username}`, authenticated as the `ol-infrastructure-as-code` App installation. `repository.py` deliberately emits no `RepositoryCollaborator` resource (plan §4.7 — target state is zero direct grants, and the provider has no documented import for it anyway), so this cleanup can't be a Pulumi diff.
- The tool re-classifies fresh from a live `audit.fetch_rosters()` call immediately before deleting anything, rather than trusting a stale report — team rosters aren't committed and can change between an audit and the action, so acting on stale data risks turning a `redundant` grant into a real revocation. Factored `_fetch_rosters` out of `bin/github-estate-audit` into `audit.fetch_rosters()` so both tools share one implementation.
- **Deleted all 67 provably-costless direct grants in two waves, both already applied live before this PR merges:**
  - Wave 1a: the 37 `owner-implicit` grants — held by people who are also org owners, so admin survives regardless of team rosters. Verified `rhysyngsun` still shows `admin` on `ol-django` post-deletion, via implicit ownership.
  - Wave 1b: the remaining 30 `level-only` (19) and `redundant` (11) grants. Spot-checked live afterward: `ChristopherChudzicki` on `smoot-design` and `Anas12091101` on `frontend-app-learning` both dropped from a direct `admin`/`write` grant to their actual team-inherited rung (`maintain`/`write`) — the level-only outcome. `odlbot` on `edx-platform` stayed `admin` via team access — the redundant outcome, no change at all.
  - `no-access` (5) and `outside` (8) were never touched — removing either would gate or complicate access and needs a separate decision (a team grant first, or an org-membership call).
- Two `github-org-inventory crawl --refresh` runs are folded in, each picking up unrelated inventory alongside the intended `_direct_collaborators` update (expected — a crawl reflects everything that changed since the last one): `_ruleset_count` on 74 repos once #5415 promoted both org rulesets to `active`, and ordinary `_pushed_at` drift. All touched fields are `_`-prefixed inventory, not Pulumi-managed configuration.

### How can this be tested?

- `uv run pre-commit run --all-files`, `uv run mypy bin/github-collaborator-cleanup bin/github-estate-audit src/ol_infrastructure/saas/github/audit.py`, and `uv run pytest tests/ol_infrastructure/saas/github/` (32 tests) all pass.
- `pulumi preview` on `ol-saas-github-repositories` is unchanged by either data refresh — the `_`-prefixed fields don't feed any resource declaration.
- `uv run bin/github-collaborator-cleanup plan` now reports zero removable grants.
- `uv run bin/github-estate-audit access` now reports only `no-access` (5) and `outside` (8) in `by_kind` — everything else is gone.

### Additional Context

All 67 deletions already happened live against GitHub before this PR merges — this PR is the data/tooling record of that action, not a pending change. Nothing here needs a pipeline apply.

SEC-06's remaining population (`no-access`, `outside`) is a different, harder decision — the direct grant is the only path in for those 5, and the 8 `outside` grants are held by people who aren't org members at all. Left for a separate task.
