### PR TITLE
docs(rds_helper): quantify the DBInstanceClassMemory overstatement from a live read

### DIFF
--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -630,6 +630,13 @@ pgbouncer_replica_count = dagster_config.get_int("pgbouncer_replica_count") or 2
 # below the 5000 cap -- the difference between total instance memory and the smaller
 # DBInstanceClassMemory that RDS actually divides (see postgres_max_connections).
 #
+# That last term is the reason 0.85 is not as generous as it looks on the QA stack.
+# postgres_max_connections computes 901 there but the instance really allows 832, so
+# the resulting 764 aggregate leaves 68 connections rather than the ~135 the factor
+# implies -- still comfortably clear of the ~11 reserved and administrative
+# connections, but worth knowing before anyone raises this factor. Production is
+# unaffected: the 5000 cap binds, so its figure is exact.
+#
 # Dividing by pgbouncer_replica_count makes the aggregate ceiling depend on the running
 # pod count, which is why the Deployment below pins max_surge to 0.
 DB_CONNECTION_HEADROOM_FACTOR = 0.85

--- a/src/ol_infrastructure/lib/aws/rds_helper.py
+++ b/src/ol_infrastructure/lib/aws/rds_helper.py
@@ -57,12 +57,20 @@ def postgres_max_connections(db_instance_type: str) -> int:
 
     **This is an upper bound, not an exact figure.** ``DBInstanceClassMemory`` is the
     memory RDS leaves to the database after its own OS and management reservations,
-    which is somewhat less than the instance class's total physical memory used here,
-    and AWS does not publish the reservation. On classes large enough to hit the 5000
-    cap the difference is irrelevant and the result is exact -- verified against
-    ``ol-etl-db-production`` (``db.r7g.2xlarge``), where ``SHOW max_connections``
-    returns 5000. Below the cap the result may overstate by the size of that
-    reservation, so callers must leave headroom rather than budgeting to this number.
+    which is less than the instance class's total physical memory used here, and AWS
+    does not publish the reservation.
+
+    Measured on both sides of the cap:
+
+    - ``db.r7g.2xlarge`` (``ol-etl-db-production``) -- computes 7210, clamped to 5000,
+      and ``SHOW max_connections`` returns 5000. **Exact**, because the cap binds.
+    - ``db.m7g.large`` (``ol-etl-db-qa``) -- computes 901, but ``SHOW max_connections``
+      returns **832**. RDS withholds ~629 MiB of the 8 GiB, so this **overstates by
+      ~8%**.
+
+    Below the cap, then, callers must leave at least ~10% headroom on top of whatever
+    margin they want for reserved and administrative connections -- budgeting straight
+    to this number would overcommit.
 
     :param db_instance_type: An RDS instance class, e.g. ``db.r7g.2xlarge``
 


### PR DESCRIPTION
### What are the relevant tickets?

N/A. Follow-up to #5426, which merged before this landed.

### Description (What does it do?)

Comments and a docstring only — no value changes, no behaviour change.

While addressing review on #5426, Copilot pointed out that `postgres_max_connections()` divides the EC2 class's *total physical memory*, whereas RDS's `DBInstanceClassMemory` is what's left after its own OS and management reservations — so the helper overstates below the 5000 cap. That was correct, but I could not measure the gap at the time (QA's PgBouncer could not reach its backend, and AWS does not publish the reservation), so the docstring landed with a hand-waved "may overstate".

The measurement came back afterwards. `ol-etl-db-qa` (`db.m7g.large`) reports:

```
SHOW max_connections  ->  832
postgres_max_connections("db.m7g.large")  ->  901
```

RDS withholds ~629 MiB of the 8 GiB, so the helper **overstates by ~8%** below the cap. Production is unaffected — `db.r7g.2xlarge` computes 7210, clamps to 5000, and `SHOW max_connections` returns exactly 5000, so its figure is exact because the cap binds.

This replaces the vague caveat with the measured figure on both sides of the cap, and records the consequence at the call site: the `0.85` headroom factor is less generous than it looks on an uncapped class, because the memory overstatement eats into it.

**The merged caps are safe and unchanged.** QA's aggregate is 764 against a real limit of 832 — 68 connections of margin rather than the ~135 the factor implies, still comfortably clear of the ~11 reserved and `rdsadmin` connections. The point of this PR is that the next person tempted to raise `DB_CONNECTION_HEADROOM_FACTOR` should see the real number first.

### How can this be tested?

```bash
uv run pytest tests/ol_infrastructure/lib/aws/test_rds_helper.py
```

Nothing executable changed, so the value of the tests here is only that they still pass — 7 passed locally, and `pre-commit` (ruff, ruff format, mypy) is clean. `pulumi preview` was not re-run: the diff is comments and a docstring, so it cannot alter the rendered stack.

To reproduce the measurement itself, from a QA PgBouncer pod:

```bash
kubectl --context data-qa -n dagster exec <pgbouncer-pod> -c pgbouncer -- \
  psql "postgres://probe@127.0.0.1:5432/dagster?sslmode=disable" -tA \
  -c "SHOW max_connections;"
```

Note that pod was intermittently unable to reach its backend when I tried it — the query timed out twice before returning. That flakiness is unrelated to this change but is probably worth a look on its own.

### Additional Context

- Worth deciding separately, not in this PR: whether `DB_CONNECTION_HEADROOM_FACTOR` should be raised so uncapped classes get the full intended margin, or whether the helper should subtract a measured reservation percentage rather than leaving it to the caller's headroom. Both are judgement calls that the pgbouncer_exporter metrics from #5426 will inform better than a guess now.
