### PR TITLE
fix(tika): raise memory and replica capacity to stop production OOMKills

### DIFF
--- a/src/ol_infrastructure/applications/tika/__main__.py
+++ b/src/ol_infrastructure/applications/tika/__main__.py
@@ -139,7 +139,12 @@ tika_helm_release = kubernetes.helm.v3.Release(
         ),
         values={
             "commonLabels": k8s_global_labels,
-            "replicaCount": 2,
+            # Raised 2->3 (2026-08-15): the daily edX catalog OLX ingestion job
+            # (mit-learn's import_all_mit_edx_files) hammers every replica
+            # concurrently, so 2 replicas meant a large fraction of requests
+            # landed on a pod that was mid-OOM-restart, returning 502s that the
+            # calling celery task doesn't retry gracefully.
+            "replicaCount": 3,
             "service": {
                 "type": "ClusterIP",
                 "port": 9998,
@@ -147,10 +152,10 @@ tika_helm_release = kubernetes.helm.v3.Release(
             "resources": {
                 "requests": {
                     "cpu": "10m",  # does nothing most of the time
-                    "memory": "3Gi",  # java never gives it back
+                    "memory": "4Gi",  # java never gives it back
                 },
                 "limits": {
-                    "memory": "3Gi",
+                    "memory": "4Gi",
                 },
             },
             # By default the JVM's container-aware ergonomics only give the
@@ -160,12 +165,17 @@ tika_helm_release = kubernetes.helm.v3.Release(
             # off-heap and get the whole container OOMKilled by the kernel
             # rather than the JVM raising a catchable OutOfMemoryError.
             # Budget the JVM at 1152Mi heap + 320Mi metaspace + 320Mi direct
-            # memory (1792Mi total). The container limit is raised to 3Gi
-            # (rather than sized to exactly match the JVM budget) to leave
-            # ~1280Mi of headroom outside the JVM entirely: Tika's default PDF
-            # OCR strategy is AUTO, which auto-invokes the `tesseract` binary
-            # as a native subprocess for scanned/image PDF pages, and that
-            # subprocess's memory isn't bounded by any JAVA_TOOL_OPTIONS flag.
+            # memory (1792Mi total, unchanged). The container limit is raised
+            # to 4Gi (2026-08-15: 3Gi->4Gi, rather than sized to exactly match
+            # the JVM budget) to leave ~2304Mi of headroom outside the JVM
+            # entirely: Tika's default PDF OCR strategy is AUTO, which
+            # auto-invokes the `tesseract` binary as a native subprocess for
+            # scanned/image PDF pages, and that subprocess's memory isn't
+            # bounded by any JAVA_TOOL_OPTIONS flag. The prior 1280Mi of
+            # headroom was chronically sitting at 1-6% free (peaking
+            # 2900-3066Mi against the 3Gi cap) once OCR_PDF_MAX_PAGE_THRESHOLD
+            # was raised to 20 (mit_learn PR #5305), causing repeated
+            # production OOMKills during the daily OLX ingestion job.
             "env": [
                 {
                     "name": "JAVA_TOOL_OPTIONS",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Tika has been repeatedly OOMKilling in production, triggering Rootly alerts. Investigation found:

- Tika's `applications-production` pods sit chronically at 1-6% memory headroom (peak 2900-3066Mi against the prior 3Gi limit).
- mit-learn's daily `import_all_mit_edx_files` job hammers every Tika replica concurrently, extracting text from every OLX content block of every edX course via `tika_parser.from_buffer()`.
- `OCR_PDF_MAX_PAGE_THRESHOLD` was raised to 20 in mitodl/mit-learn#5305 (2026-08-10), increasing per-document OCR work — Tika's tesseract OCR subprocess memory isn't bounded by any JVM flag, so this pushed the already-thin headroom into repeated OOMKills starting 2026-08-14.
- With only 2 replicas, a large fraction of requests during the daily job landed on a pod mid-OOM-restart, returning 502s. The calling celery task doesn't retry/back off gracefully, so failures cascaded across the whole ~24h ingestion window instead of a short blip.

This PR raises capacity to absorb the current OCR workload:
- `replicaCount`: 2 → 3
- Memory request/limit: 3Gi → 4Gi (JVM heap budget unchanged at 1792Mi; the extra ~1Gi goes to headroom for the unbounded tesseract subprocess, from ~1280Mi to ~2304Mi)

### How can this be tested?
Ran `pre-commit` and `pulumi preview` against the `Production` stack — clean, single `~values` diff on the Helm release, no other drift. These sizing values have not yet been observed against a live daily OLX ingestion run; after deploy, watch the `PodOOMKilledCritical`/`Warning` Rootly alerts for `namespace=tika` across the next few daily ingestion cycles to confirm the new headroom holds.

### Additional Context
This does not address the underlying app-side issue that a Tika 502 during ingestion isn't retried with backoff (in mitodl/mit-learn's `_extract_content_with_tika`) — that's a separate follow-up outside this repo. This PR only raises infra-side capacity so the daily ingestion job's concurrent load doesn't tip Tika into OOM in the first place.