### PR TITLE
fix(dagster): cut max_concurrent_runs from 100 to 60

### DIFF
--- a/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
+++ b/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
@@ -139,7 +139,7 @@ run_coordinator:
   module: dagster.core.run_coordinator
   class: QueuedRunCoordinator
   config:
-    max_concurrent_runs: 100
+    max_concurrent_runs: 60
 
 # Configures how long Dagster waits for code locations
 # to load before timing out.


### PR DESCRIPTION
## What's broken

[`dbt_automation_sensor`](https://pipelines.odl.mit.edu/locations/lakehouse/sensors/dbt_automation_sensor?cursor=b9c1531f0baad6b746fcbda868923da1fd828c32%3A1786608355.919471) has failed on every tick since 08/11:

```
psycopg2.OperationalError: connection to server at
"dagster-pgbouncer.dagster.svc.cluster.local" (10.110.142.113), port 5432 failed:
Cannot assign requested address
```

That is `EADDRNOTAVAIL`, a **client-side** failure: the daemon pod could not allocate a local ephemeral port, so it never reached PgBouncer. It is not PgBouncer refusing connections and not an RDS limit — resizing either would not help.

## Why it happens

`dagster_postgres` builds every storage engine with `poolclass=NullPool` (`run_storage.py:89-95`, and the same in `event_log` and `schedule_storage`), so each query is a fresh TCP connection rather than a pooled one.

The asset daemon compounds this. `automation_condition_evaluator.py:150-158` evaluates every entity in a toposort level concurrently:

```python
for topo_level in self.asset_graph.toposorted_entity_keys_by_level:
    coroutines = [_evaluate_entity_async(entity_key, offset) for ...]
    await asyncio.gather(*coroutines)
```

No semaphore, no batching. Each evaluation independently reaches `index_connection()` (`sql_event_log.py:1639`), so one tick opens roughly as many simultaneous connections as the widest level of the dbt graph — all to a single ClusterIP, where `TIME_WAIT` holds each port for 60s.

## Why 08/11, when the config changed on 08/10

100 had never actually run before 08/11. The daemon mounts `dagster.yaml` from a ConfigMap via `subPath`, which kubelet never live-refreshes, so the three edits on 08/10 deployed the ConfigMap and never reached the running process:

| When (EDT) | Commit | File says | Daemon running |
|---|---|---|---|
| 08/10 09:16 | `1ff3a440e` | 60 | **30** |
| 08/10 14:33 | `56cb90971` | 200 | **30** |
| 08/10 19:58 | `c3068d4a3` | 100 | **30** |
| 08/11 12:31 | #5374 rolls the pods | 100 | **100** |

#5374 added the content-hash annotation that finally rolled the pods, and the daemon read the file for the first time since 08/10 — picking up 100. 60 and 200 were overwritten before that roll and never executed a single tick.

So #5374 is why the errors started on 08/11, but it is not the defect: it is a correct fix that stopped config edits from being silently ignored, and it should not be reverted. The defect is the value, from `c3068d4a3`.

## The change

One line: `max_concurrent_runs: 100` → `60`.

**60 is untested.** Only 30 (stable for months) and 100 (fails) have ever actually run on the daemon. 60 backs well off the failing value while keeping double the throughput of 30 — the 08/10 Grafana analysis in `1ff3a440e` did show the cap at 30 was the binding constraint on throughput, and that finding stands.

## How to verify

Config changes now roll the pod, so this is observable in the same deploy:

1. Confirm the daemon pod actually restarted.
2. Watch the [sensor's tick history](https://pipelines.odl.mit.edu/locations/lakehouse/sensors/dbt_automation_sensor?cursor=b9c1531f0baad6b746fcbda868923da1fd828c32%3A1786608355.919471). It has failed continuously since 08/11, so a clean tick is an unambiguous pass.
3. If `EADDRNOTAVAIL` recurs, drop to **30**, which is known good.

## Follow-ups (not in this PR)

- The unbounded `asyncio.gather` over per-entity `NullPool` connections is a Dagster scalability issue worth reporting upstream; capping concurrency is a workaround for it, not a fix.
- All four `dagster_instance.yaml` edits on 08/10 went direct to `main` without review, and none could be observed to work or fail because the daemon was not reading them. Worth considering whether that file should require review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

