### PR TITLE
fix(github): unblock merges on open-edx-plugins and unwedge the repos deploy

### DIFF
--- a/bin/github-org-inventory
+++ b/bin/github-org-inventory
@@ -253,6 +253,37 @@ def _count(client: httpx.Client, path: str) -> int | None:
     return len(payload)
 
 
+def _push_restrictions(
+    protection: dict[str, Any] | None,
+) -> dict[str, list[str]] | None:
+    """Who classic branch protection lets push to the default branch, or None.
+
+    `None` means unrestricted -- either no classic protection at all, or protection
+    without the "Restrict who can push" toggle. An actual dict is an ALLOW-LIST: nobody
+    outside it can push, and GitHub counts merging a pull request as a push, so this
+    silently decides who can press Merge no matter what team grants or rulesets say.
+
+    RECORDED BECAUSE THE BOOLEAN WAS NOT ENOUGH. `has_branch_protection` said `true` for
+    open-edx-plugins for months while its allow-list held exactly `odlbot`. Nothing in
+    the inventory, the audit or Pulumi could see that, so when PR #5324 downgraded
+    arbisoft-contractors and odl-engineering from `admin` to `push` on 2026-08-12 -- and
+    with it the admin bypass that `enforce_admins: false` was granting them -- both teams
+    silently lost the ability to merge anything. It took a contractor reporting a stuck
+    PR five days later to find it. SEC-16 exists so the next one shows up in a report.
+
+    An empty allow-list is preserved as `{}` rather than collapsed to `None`: restricted
+    to nobody is the most restrictive state there is, not the absence of a restriction.
+    """
+    restrictions = (protection or {}).get("restrictions")
+    if restrictions is None:
+        return None
+    return {
+        "users": sorted(u["login"] for u in restrictions.get("users") or []),
+        "teams": sorted(t["slug"] for t in restrictions.get("teams") or []),
+        "apps": sorted(a["slug"] for a in restrictions.get("apps") or []),
+    }
+
+
 def _crawl_repo(token: str, listed: dict[str, Any]) -> dict[str, Any]:
     """Collect everything about one repo that the import or the audit needs."""
     name = listed["name"]
@@ -308,6 +339,7 @@ def _crawl_repo(token: str, listed: dict[str, Any]) -> dict[str, Any]:
             required_checks = (protection.get("required_status_checks") or {}).get(
                 "contexts", []
             )
+        push_restrictions = _push_restrictions(protection)
 
         return {
             "name": name,
@@ -343,6 +375,14 @@ def _crawl_repo(token: str, listed: dict[str, Any]) -> dict[str, Any]:
                 security.get("secret_scanning_push_protection") or {}
             ).get("status"),
             "has_branch_protection": protection is not None,
+            "branch_protection_push_restrictions": push_restrictions,
+            # Decides whether an `admin` team grant still gets past the allow-list above,
+            # so SEC-16 cannot be exact without it. False fleet-wide as of 2026-08-17,
+            # which is why downgrading a team from `admin` to `push` was enough to take
+            # its merge access away on a restricted repo.
+            "branch_protection_enforce_admins": bool(
+                (protection or {}).get("enforce_admins", {}).get("enabled")
+            ),
             "required_status_checks": required_checks,
             "ruleset_count": len(rulesets),
             "rulesets": [
@@ -536,6 +576,42 @@ def _is_stale(repo: dict[str, Any]) -> bool:
     return age.days > STALE_DAYS
 
 
+#: Team grants that are supposed to carry the ability to merge a pull request.
+#: `triage` and `pull` are excluded because neither can merge in the first place, so a
+#: push restriction takes nothing away from them.
+MERGE_CAPABLE_PERMISSIONS = frozenset({"push", "maintain", "admin"})
+
+
+def _blocked_by_push_restriction(repo: dict[str, Any]) -> list[str]:
+    """Teams that hold a merge-capable grant but are outside the push allow-list.
+
+    A push restriction is an allow-list, and GitHub treats merging a pull request as a
+    push, so a team absent from it cannot merge however generous its grant looks. That
+    combination is invisible in `teams` alone -- which reads `push`, i.e. fine -- and
+    invisible in `has_branch_protection` alone, which reads `true`, i.e. also fine. Only
+    the two together show the problem, and until now the inventory recorded only the
+    second. See `_push_restrictions` for the incident that motivated this.
+
+    `enforce_admins` decides whether an `admin` grant still gets through: with it off
+    (the fleet-wide state today) admins bypass the allow-list and are not blocked, so
+    they are only reported when it is on. That distinction is the whole mechanism behind
+    the open-edx-plugins outage -- the teams were fine at `admin` and broke at `push`
+    without the restriction itself changing at all.
+    """
+    allowed = repo.get("branch_protection_push_restrictions")
+    if allowed is None:
+        return []
+    allowed_teams = set(allowed.get("teams") or [])
+    enforce_admins = repo.get("branch_protection_enforce_admins")
+    return sorted(
+        team
+        for team, perm in (repo.get("teams") or {}).items()
+        if perm in MERGE_CAPABLE_PERMISSIONS
+        and team not in allowed_teams
+        and (enforce_admins or perm not in ADMIN_PERMISSIONS)
+    )
+
+
 def propose_archetype(repo: dict[str, Any]) -> str:
     """Best-guess archetype. A human confirms -- this only has to be mostly right.
 
@@ -631,6 +707,9 @@ def _findings(
             r["name"]
             for r in live
             if not r["has_branch_protection"] and r["ruleset_count"] == 0
+        ],
+        "SEC-16 push restriction excludes a team that holds push": [
+            r["name"] for r in live if _blocked_by_push_restriction(r)
         ],
         "SEC-03 no required status checks": [
             r["name"] for r in live if not r["required_status_checks"]
@@ -972,6 +1051,16 @@ def crawl(
         doc["_visibility"] = repo["visibility"]
         doc["_pushed_at"] = repo["pushed_at"]
         doc["_has_branch_protection"] = repo["has_branch_protection"]
+        # Emitted only where a restriction EXISTS. Unlike `_custom_properties`, absence
+        # here is not a finding but the normal, healthy state -- writing `null` onto 300+
+        # repos would bury the handful that are actually restricted. See SEC-16.
+        if repo["branch_protection_push_restrictions"] is not None:
+            doc["_branch_protection_push_restrictions"] = repo[
+                "branch_protection_push_restrictions"
+            ]
+            doc["_branch_protection_enforce_admins"] = repo[
+                "branch_protection_enforce_admins"
+            ]
         doc["_ruleset_count"] = repo["ruleset_count"]
         if repo.get("direct_collaborators"):
             doc["_direct_collaborators"] = repo["direct_collaborators"]

--- a/src/ol_infrastructure/saas/github/audit.py
+++ b/src/ol_infrastructure/saas/github/audit.py
@@ -120,6 +120,56 @@ def _live_tier(repo: dict[str, Any]) -> str | None:
     return (repo.get("_custom_properties") or {}).get(TIER_PROPERTY_NAME)
 
 
+#: Team grants that are supposed to carry the ability to merge a pull request.
+#: `triage` and `pull` are excluded because neither can merge anyway, so being left out
+#: of a push allow-list takes nothing away from them.
+MERGE_CAPABLE_PERMISSIONS = frozenset({"push", "maintain", "admin"})
+
+
+def _blocked_by_push_restriction(repo: dict[str, Any]) -> list[str]:
+    """Teams holding a merge-capable grant that the push allow-list leaves out.
+
+    Classic branch protection's "Restrict who can push" is an allow-list, and GitHub
+    counts merging a pull request as a push -- so a team missing from it cannot merge no
+    matter what `teams` says. Neither field shows this alone: `teams` reads `push` and
+    looks fine, `_has_branch_protection` reads `true` and also looks fine. Only the pair
+    reveals it, which is exactly why it went unseen.
+
+    THE INCIDENT THIS RULE IS FOR. `open-edx-plugins` restricted pushes to `main` to the
+    single user `odlbot`. `arbisoft-contractors` and `odl-engineering` both held
+    `admin`, and because `enforce_admins` was false they bypassed the allow-list without
+    anyone noticing it existed. PR #5324 (SEC-15, 2026-08-12) downgraded both to `push`
+    -- the correct call on its own terms -- and in doing so removed the bypass, leaving
+    two teams unable to merge anything. No rule fired, no preview showed a diff, and it
+    surfaced five days later as a contractor reporting a stuck pull request.
+
+    `enforce_admins` is therefore load-bearing rather than trivia: with it off, an
+    `admin` team is genuinely not blocked, so reporting one would be a false positive.
+    Both fields come from the crawl and are only written where a restriction exists, so
+    a repo with no restriction yields no finding rather than an unmeasured pass.
+    """
+    allowed = repo.get("_branch_protection_push_restrictions")
+    if allowed is None:
+        return []
+    allowed_teams = set(allowed.get("teams") or [])
+    enforce_admins = repo.get("_branch_protection_enforce_admins")
+    return sorted(
+        team
+        for team, perm in (repo.get("teams") or {}).items()
+        if perm in MERGE_CAPABLE_PERMISSIONS
+        and team not in allowed_teams
+        and (enforce_admins or perm != "admin")
+    )
+
+
+def _push_allow_list(repo: dict[str, Any]) -> str:
+    """Render the push allow-list, so a SEC-16 finding names who IS still allowed."""
+    allowed = repo.get("_branch_protection_push_restrictions") or {}
+    users = ",".join(allowed.get("users") or []) or "-"
+    teams = ",".join(allowed.get("teams") or []) or "-"
+    return f"push restricted to users={users} teams={teams}"
+
+
 def _unsanctioned_admin(repo: dict[str, Any]) -> list[str]:
     return sorted(
         team
@@ -206,6 +256,29 @@ RULES: tuple[Rule, ...] = (
                 "downgrade to push or maintain",
             )
             if _unsanctioned_admin(r)
+            else None
+        ),
+    ),
+    Rule(
+        "SEC-16",
+        "security",
+        "high",
+        "active",
+        "classic push restriction excludes a team that holds a merge-capable grant",
+        # Graded `high` on ACCESS grounds rather than exposure: it does not weaken the
+        # repo, it silently revokes people's ability to ship to it, and it is invisible
+        # in every other field. An unannounced loss of access is a security finding in
+        # the same sense an unannounced grant is -- the declared model and the enforced
+        # one disagree, and nobody can tell which one is live.
+        lambda r: (
+            (
+                f"{_push_allow_list(r)}; "
+                f"blocked: {', '.join(_blocked_by_push_restriction(r))}",
+                "every team with push or better can merge",
+                "drop the push restriction (org rulesets already cover this branch), "
+                "or add the blocked teams to its allow-list",
+            )
+            if _blocked_by_push_restriction(r)
             else None
         ),
     ),

--- a/src/ol_infrastructure/saas/github/organization/org_rulesets.py
+++ b/src/ol_infrastructure/saas/github/organization/org_rulesets.py
@@ -200,3 +200,26 @@ tier_one_hardening = github.OrganizationRuleset(
 #                     Supported on OrganizationRuleset and arguably belongs here --
 #                     six repos carry a hand-made per-repo ruleset for it today. Left
 #                     out pending the decision in the Copilot governance task (§4.6).
+#
+# THE CLASSIC BRANCH PROTECTION STILL OUT THERE IS NOT INERT. These rulesets are
+# ADDITIVE to it, not a replacement: an action must satisfy classic protection AND
+# every ruleset that matches, and a `bypass_actors` entry here grants no relief from the
+# classic layer at all. 27 active repos still carry a classic object that nothing here
+# manages (repository.py declines to declare BranchProtection), so it is invisible drift
+# that can override everything decided in this file.
+#
+# open-edx-plugins made that concrete on 2026-08-17. Its classic protection restricted
+# pushes to `main` to the single user `odlbot`, and GitHub counts merging a pull request
+# as a push -- so arbisoft-contractors and odl-engineering could not merge, and adding
+# them as `pull_request` bypass actors above did nothing, because the block was never in
+# a ruleset. It had been masked for months by both teams holding `admin` while
+# `enforce_admins` was false; PR #5324 downgrading them to `push` on 2026-08-12 removed
+# that accidental bypass and broke merges outright.
+#
+# Resolved by DELETING that repo's classic protection entirely (Tobias, 2026-08-17) --
+# every protection it asserted was already met or exceeded here (`baseline` matches its
+# review count and adds dismiss-stale, `tier-1-hardening` adds last-push approval and
+# thread resolution, both cover force-push and deletion). Only `block_creations` was
+# lost, which is inert on a branch that already exists. The remaining 26 repos have not
+# been swept; SEC-16 in audit.py now reports this class of block instead of leaving it
+# to be found by a contractor with a stuck PR.

--- a/src/ol_infrastructure/saas/github/repositories/archetypes.py
+++ b/src/ol_infrastructure/saas/github/repositories/archetypes.py
@@ -147,6 +147,38 @@ def _check_public_repo_teams(fleet: list[dict[str, Any]]) -> None:
         raise ValueError(message)
 
 
+def _check_dependabot_requires_alerts(fleet: list[dict[str, Any]]) -> None:
+    """Fail if a repo asks for Dependabot security updates with alerts off.
+
+    GitHub refuses that combination outright -- `/automated-security-fixes` answers 422
+    unless vulnerability alerts are enabled -- so it is unsatisfiable data, not a
+    preference Pulumi could honour.
+
+    This exists because `repository.py` now SKIPS `RepositoryDependabotSecurityUpdates`
+    entirely on an alerts-off repo (see the comment there for why declaring the OFF
+    state broke the 2026-08-17 deploy). That skip is correct for every combination the
+    fleet actually holds, but it would swallow this one: a repo asking for updates it
+    cannot have would simply get no resource and no complaint. Failing here keeps the
+    skip from turning an impossible request into a silent one.
+    """
+    conflicting = sorted(
+        repo["name"]
+        for repo in fleet
+        if not repo.get("archived")
+        and repo.get("dependabot_security_updates")
+        and not repo.get("vulnerability_alerts")
+    )
+    if conflicting:
+        message = (
+            "repos request dependabot_security_updates with vulnerability_alerts "
+            "disabled, which GitHub rejects (422):\n  "
+            + "\n  ".join(conflicting)
+            + "\nEnable vulnerability_alerts on these repos, or drop the "
+            "dependabot_security_updates request."
+        )
+        raise ValueError(message)
+
+
 def _check_team_references(fleet: list[dict[str, Any]]) -> None:
     """Fail if any repo grants to a team slug absent from teams.yaml.
 
@@ -205,6 +237,7 @@ def load_fleet() -> list[dict[str, Any]]:
     _check_team_references(fleet)
     _check_permission_values(fleet)
     _check_public_repo_teams(fleet)
+    _check_dependabot_requires_alerts(fleet)
 
     # The dotfile trap is silent by construction, so assert rather than trust.
     assignments = yaml.safe_load((DATA_DIR / "archetypes-proposed.yaml").read_text())

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-plugins.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-plugins.yaml
@@ -1,4 +1,10 @@
 ---
+_branch_protection_enforce_admins: false
+_branch_protection_push_restrictions:
+  apps: []
+  teams: []
+  users:
+  - odlbot
 _custom_properties:
   tier: tier-1
 _excluded_environments: 1

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-plugins.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-plugins.yaml
@@ -1,14 +1,8 @@
 ---
-_branch_protection_enforce_admins: false
-_branch_protection_push_restrictions:
-  apps: []
-  teams: []
-  users:
-  - odlbot
 _custom_properties:
   tier: tier-1
 _excluded_environments: 1
-_has_branch_protection: true
+_has_branch_protection: false
 _pushed_at: '2026-08-12T13:02:56Z'
 _ruleset_count: 3
 _visibility: public

--- a/src/ol_infrastructure/saas/github/repositories/repository.py
+++ b/src/ol_infrastructure/saas/github/repositories/repository.py
@@ -214,12 +214,28 @@ def build(repo: dict[str, Any]) -> None:
     # updates can be, so this must not run concurrently with the resource above --
     # without depends_on, Pulumi is free to create both at once, and a repo that is
     # new to Pulumi state (nothing yet imported) can fail this nondeterministically.
-    github.RepositoryDependabotSecurityUpdates(
-        f"mitodl-repo-dependabot-security-updates-{name}",
-        repository=name,
-        enabled=bool(repo.get("dependabot_security_updates")),
-        opts=ResourceOptions(depends_on=[repository, vulnerability_alerts]),
-    )
+    #
+    # ONLY EMITTED WHERE ALERTS ARE ON, and that is not a shortcut for `enabled=False`.
+    # The provider implements `enabled=False` as `DELETE /automated-security-fixes`,
+    # which GitHub answers 422 "Vulnerability alerts must be enabled to configure
+    # automated security fixes" when alerts are off -- so declaring the OFF state on an
+    # alerts-off repo is a create that can never succeed. That took down the whole
+    # deploy on 2026-08-17 (build 4): 29 hard errors, every one of them an alerts-off
+    # repo, and the run aborted before it reached the arbisoft-contractors permission
+    # changes it was supposed to apply. 56 active repos are alerts-off, so this was
+    # never going to converge on its own.
+    #
+    # Skipping is also the accurate statement rather than a workaround: with alerts off
+    # GitHub will not let security updates be on, so there is no second state to assert.
+    # Nothing is orphaned by the skip -- no such resource has ever existed for an
+    # alerts-off repo, since every one of them failed to create.
+    if repo.get("vulnerability_alerts"):
+        github.RepositoryDependabotSecurityUpdates(
+            f"mitodl-repo-dependabot-security-updates-{name}",
+            repository=name,
+            enabled=bool(repo.get("dependabot_security_updates")),
+            opts=ResourceOptions(depends_on=[repository, vulnerability_alerts]),
+        )
 
     _tier_property(name, repo["tier"], repository)
 

--- a/tests/ol_infrastructure/saas/github/test_audit.py
+++ b/tests/ol_infrastructure/saas/github/test_audit.py
@@ -54,6 +54,17 @@ def test_clean_repo_fires_nothing() -> None:
         ("SEC-04", {"secret_scanning": "disabled"}),  # pragma: allowlist secret
         ("SEC-06", {"_direct_collaborators": {"someone": "admin"}}),
         ("SEC-15", {"teams": {"arbisoft-contractors": "admin"}}),
+        (
+            "SEC-16",
+            {
+                "_branch_protection_push_restrictions": {
+                    "users": ["odlbot"],
+                    "teams": [],
+                    "apps": [],
+                },
+                "_branch_protection_enforce_admins": False,
+            },
+        ),
         ("CON-02", {"delete_branch_on_merge": False}),
         ("CON-03", {"default_branch": "master"}),
         ("CON-05", {"topics": []}),
@@ -79,6 +90,53 @@ def test_sec15_is_an_allowlist_not_a_denylist() -> None:
     assert "SEC-15" not in fired([repo(teams={"devops": "admin"})])
     # Non-admin from an unsanctioned team is fine -- the rule is about the level.
     assert "SEC-15" not in fired([repo(teams={"arbisoft-contractors": "push"})])
+
+
+def _restricted(**overrides: Any) -> dict[str, Any]:
+    """Build a repo whose default branch only `odlbot` may push to."""
+    return repo(
+        **{
+            "_branch_protection_push_restrictions": {
+                "users": ["odlbot"],
+                "teams": [],
+                "apps": [],
+            },
+            "_branch_protection_enforce_admins": False,
+            **overrides,
+        }
+    )
+
+
+def test_sec16_needs_a_restriction_to_fire() -> None:
+    """No restriction is the normal state -- `push` alone must stay silent."""
+    assert "SEC-16" not in fired([repo(teams={"odl-engineering": "push"})])
+
+
+def test_sec16_ignores_grants_that_could_never_merge() -> None:
+    """An allow-list takes nothing from `pull` or `triage`, so neither is a finding."""
+    assert "SEC-16" not in fired([_restricted(teams={"odl-engineering": "pull"})])
+    assert "SEC-16" not in fired([_restricted(teams={"odl-engineering": "triage"})])
+
+
+def test_sec16_follows_enforce_admins_for_admin_teams() -> None:
+    """The exact mechanism behind the open-edx-plugins outage.
+
+    With `enforce_admins` off an admin team bypasses the allow-list and is genuinely
+    not blocked; the same team at `push` is. Reporting the admin case would be a false
+    positive, and NOT reporting the push case is the miss that let this run for days.
+    """
+    admins = {"odl-engineering": "admin"}
+    assert "SEC-16" not in fired([_restricted(teams=admins)])
+    assert "SEC-16" in fired(
+        [_restricted(teams=admins, _branch_protection_enforce_admins=True)]
+    )
+    assert "SEC-16" in fired([_restricted(teams={"odl-engineering": "push"})])
+
+
+def test_sec16_clears_when_the_team_is_on_the_allow_list() -> None:
+    listed = _restricted(teams={"odl-engineering": "push"})
+    listed["_branch_protection_push_restrictions"]["teams"] = ["odl-engineering"]
+    assert "SEC-16" not in fired([listed])
 
 
 def test_con03_exempts_forks_and_archived() -> None:


### PR DESCRIPTION
### What are the relevant tickets?
N/A — came out of a report that arbisoft-contractors could not merge
https://github.com/mitodl/open-edx-plugins/pull/852

### Description (What does it do?)
Three related changes.

**Unwedge the repositories stack.** `RepositoryDependabotSecurityUpdates(enabled=False)`
is implemented by the provider as `DELETE /automated-security-fixes`, which GitHub
answers 422 when vulnerability alerts are off — so declaring the OFF state on an
alerts-off repo is a create that can never succeed. 56 active repos are alerts-off;
builds 3 and 4 of `deploy-ol-saas-github-repositories` both died on it, and build 4
aborted after applying only 6 of the 26 team-permission changes from #5451. The
resource is now skipped where alerts are off, which is the accurate declaration
rather than a workaround: with alerts off GitHub will not let security updates be on,
so there is no second state to assert. Nothing is orphaned — none of these resources
ever existed. A load-time check keeps the skip from silently swallowing a repo that
asks for updates it cannot have.

**Add SEC-16.** `_has_branch_protection` was a boolean, so a "Restrict who can push"
allow-list was indistinguishable from ordinary protection. `open-edx-plugins`
restricted `main` to the single user `odlbot`; `teams` read `push` and looked fine,
`_has_branch_protection` read `true` and also looked fine, and only the pair reveals
the problem. The crawl now records the allow-list and `enforce_admins`, and SEC-16
reports any team holding a merge-capable grant that the allow-list leaves out.

**Document the enforcement model.** Classic branch protection and the org rulesets are
additive, not alternatives — an action must satisfy both, and a `bypass_actors` entry
grants no relief from the classic layer. That is what made the first attempt at
unblocking a no-op: the block lived in classic protection, so adding
`arbisoft-contractors` as a `pull_request` bypass actor in #5451 changed nothing.

Background on the block itself: both `arbisoft-contractors` and `odl-engineering` held
`admin`, and with `enforce_admins: false` that silently bypassed the odlbot-only
allow-list. #5324 downgrading them to `push` on 2026-08-12 — correct on its own terms —
removed that accidental bypass and broke merges for both teams.

### How can this be tested?
Verified before opening:

- `uv run pytest tests/ol_infrastructure/saas/github/` — 37 passed, including four new
  SEC-16 cases (no restriction stays silent; `pull`/`triage` grants are not findings;
  an `admin` team is reported only when `enforce_admins` is on; a listed team clears).
- `uv run pre-commit run --files <changed>` — ruff format, ruff check and mypy pass.
- `pulumi preview --stack default` on `ol-saas-github-repositories`:
  `+ 84 to create   ~ 2 to update   1436 unchanged`, **no deletes** — confirming the
  skip orphans nothing. The 2 updates are `code-owners-mynumbers` and
  `devops-contractors-ol-infrastructure`, both pre-existing.

To validate the deploy fix, re-run `deploy-ol-saas-github-repositories`; it should
converge instead of erroring on 29 `RepositoryDependabotSecurityUpdates` creates.

SEC-16 currently reports nothing, because the one known case is already resolved and
no repo file carries restriction data yet. It needs `bin/github-org-inventory crawl
--refresh` to be meaningful — worth running once GitHub is healthy.

### Additional Context
Applied out-of-band, since `repository.py` deliberately does not manage
`BranchProtection`: classic branch protection on `mitodl/open-edx-plugins:main` was
deleted (`DELETE .../branches/main/protection`, 204). Every protection it asserted was
already met or exceeded by the two org rulesets — `baseline-default-branch` matches its
review count and adds dismiss-stale, `tier-1-hardening` adds last-push approval and
thread resolution, both cover force-push and deletion. Only `block_creations` was lost,
which is inert on a branch that already exists. Verified live after the delete that
`deletion`, `non_fast_forward`, `pull_request` ×2 and `copilot_code_review` still apply
to `main`.

Two things reviewers should know:

- **#5451 reduces contractor access.** All 26 repos go `admin`/`maintain` → `push`,
  opposite to what its title suggests. Re-running the deploy applies the remaining 20.
  None of those repos has a push restriction, so none will break the way
  open-edx-plugins did.
- **26 active repos still carry unmanaged classic branch protection.** They have not
  been swept; my sweep covered the 27 with `_has_branch_protection: true` and 4 of those
  errored mid-run during the GitHub outage.
