### PR TITLE
fix(dagster): alert on PgBouncer connection headroom, and stop QA deadlocking its own pool

### DIFF
--- a/src/ol_infrastructure/applications/dagster/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/dagster/Pulumi.Production.yaml
@@ -26,3 +26,12 @@ config:
   vault_server:env_namespace: operations.production
   dagster:db_instance_type: db.r7g.2xlarge
   dagster:pgbouncer_replica_count: 6
+  # Down from the previous global 100. Production has never come close to
+  # needing it: three days of 1-minute exporter samples peaked at 122 active
+  # server connections against an aggregate cap of 4248, and the pool sat on
+  # its min_pool_size floor of 900 the entire time. 80 trims the worst case
+  # without touching anything observed. Note the aggregate cap overstates real
+  # headroom -- max_db_connections is budget / replica count, which assumes
+  # load spreads evenly across replicas, and measured distribution is heavily
+  # skewed, so the binding limit is whichever replica saturates first.
+  dagster:max_concurrent_runs: 80

--- a/src/ol_infrastructure/applications/dagster/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/dagster/Pulumi.QA.yaml
@@ -23,5 +23,13 @@ config:
   dagster:edx_pipeline_xpro_edx_bucket_name: dagster-data-qa
   dagster:edx_pipeline_xpro_edx_course_bucket_name: xpro-qa-edxapp-courses
   dagster:edx_pipeline_xpro_edx_xpro_purpose: mitx-etl-xpro-qa
+  # QA's aggregate PgBouncer connection cap is 764 (db.m7g.large, 2 replicas)
+  # against production's 4248. At the global default of 100 concurrent runs,
+  # QA deadlocked its own pool on 2026-08-17 and stayed wedged for days. 20
+  # runs at the ~22 connections apiece measured during that incident is ~440,
+  # leaving room for the daemon, webserver and ten code location servers.
+  # Revisit once the pgbouncer exporter has enough history to show what a run
+  # worker really holds outside a deadlock.
+  dagster:max_concurrent_runs: 20
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa

--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -701,16 +701,33 @@ pgbouncer_config = kubernetes.core.v1.ConfigMap(
                     # terminates them, preventing zombie connections from being
                     # assigned to clients.
                     "server_idle_timeout = 120",
-                    # Disable the default 120s query_wait_timeout. During heavy RDS
-                    # checkpoint I/O, queries slow from milliseconds to seconds, which
-                    # temporarily backs up the pool. With the default of 120s, clients
-                    # that can't immediately get a server connection are disconnected
-                    # and psycopg2 sees "server closed the connection unexpectedly".
-                    # Setting to 0 disables the timeout so clients wait as long as
-                    # needed. This is safe because server_idle_timeout=120 continuously
-                    # cycles idle connections and the pool self-recovers within 1-2
-                    # minutes of I/O pressure dropping.
-                    "query_wait_timeout = 0",
+                    # Raised well above the 120s default, but NOT disabled.
+                    #
+                    # The default was too short: during heavy RDS checkpoint I/O,
+                    # queries slow from milliseconds to seconds and the pool backs up,
+                    # and at 120s clients that can't immediately get a server
+                    # connection are disconnected with "server closed the connection
+                    # unexpectedly" in psycopg2. That pressure clears within 1-2
+                    # minutes, so the fix was to wait it out.
+                    #
+                    # This was previously 0, which disables the timeout entirely, and
+                    # that turned out to be a different failure rather than the absence
+                    # of one. A timeout is the only thing that breaks a pool deadlock:
+                    # when every server connection is held by a client that is itself
+                    # blocked waiting for a server connection, nothing is released
+                    # until something gives up. With 0, nothing ever gives up. QA sat
+                    # in exactly that state for days on 2026-08-17 -- all 764 backends
+                    # pinned, sv_idle 0, the oldest client queued 2.4 days, the daemon
+                    # frozen mid-backfill-cancellation -- and it could only be cleared
+                    # by deleting run workers by hand.
+                    #
+                    # 600s keeps the original intent with a large margin (5x the 1-2
+                    # minutes checkpoint pressure actually lasts) while restoring the
+                    # property that a wedged pool eventually unwedges itself. A client
+                    # that waits ten minutes for a connection is not going to be
+                    # rescued by waiting longer; it needs to fail so the pool can drain
+                    # and Dagster's own retry logic can take over.
+                    "query_wait_timeout = 600",
                     # Dagster uses NullPool, so it opens a fresh connection per query
                     # and every connection logs with age=0s. Measured on one production
                     # pod: 27,738 lines in 3 minutes, ~154 lines/s per replica and
@@ -1419,10 +1436,36 @@ dagster_run_priority_class = kubernetes.scheduling.v1.PriorityClass(
     ),
 )
 
+# How many runs the QueuedRunCoordinator will have in flight at once.
+#
+# This has to be sized against the environment's PgBouncer connection budget,
+# not set globally. Dagster's storage uses NullPool, so a run worker opens a
+# fresh connection per query and holds one per concurrent step; measured on
+# data-qa on 2026-08-17, 32 run workers were holding ~700 client connections
+# between them, around 22 each. At the previous global value of 100, that is
+# ~2200 connections -- fine against production's aggregate cap of 4248, and
+# 2.9x QA's 764.
+#
+# QA duly deadlocked. Once the pool was full, every remaining client queued
+# behind it, and because query_wait_timeout was 0 (see below) none of them ever
+# timed out. The run workers held connections while waiting on connections that
+# could only be released by the workers themselves, the daemon blocked
+# mid-way through cancelling a backfill, and the whole stack sat frozen for
+# days -- 764/764 servers pinned, sv_idle 0, one client queued 2.4 days.
+# Nothing could recover on its own because every recovery path needed the
+# connection that was unavailable.
+#
+# Defaulting to 100 keeps production exactly as it was; QA sets a lower value
+# in its stack config.
+dagster_max_concurrent_runs = dagster_config.get_int("max_concurrent_runs") or 100
+
 # Custom Dagster instance ConfigMap with dynamic credentials support
 # Note: We create this before the Helm release so it gets proper ownership
 dagster_instance_yaml = (
-    Path(__file__).parent.joinpath("dagster_instance.yaml").read_text()
+    Path(__file__)
+    .parent.joinpath("dagster_instance.yaml")
+    .read_text()
+    .replace("MAX_CONCURRENT_RUNS", str(dagster_max_concurrent_runs))
 )
 # The daemon and webserver mount dagster.yaml from the dagster-instance
 # ConfigMap via subPath, which kubelet never live-refreshes, and the chart's

--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -1455,8 +1455,10 @@ dagster_run_priority_class = kubernetes.scheduling.v1.PriorityClass(
 # Nothing could recover on its own because every recovery path needed the
 # connection that was unavailable.
 #
-# Defaulting to 100 keeps production exactly as it was; QA sets a lower value
-# in its stack config.
+# Production sets 80 and QA 20 in stack config, both sized against their own
+# connection budgets. The 100 here is only a fallback for stacks that set
+# nothing; a stack on a small instance class should set its own value rather
+# than inherit this one.
 dagster_max_concurrent_runs = dagster_config.get_int("max_concurrent_runs") or 100
 
 # Custom Dagster instance ConfigMap with dynamic credentials support

--- a/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
+++ b/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
@@ -135,11 +135,16 @@ event_log_storage:
       params:
         connect_timeout: 30
 
+# The max_concurrent_runs value below is a placeholder token, substituted in
+# __main__.py from the dagster:max_concurrent_runs stack config -- see the
+# rationale there. It is a placeholder rather than a literal because run
+# concurrency has to be sized against the environment's PgBouncer connection
+# budget, and QA's is 5.5x smaller than production's.
 run_coordinator:
   module: dagster.core.run_coordinator
   class: QueuedRunCoordinator
   config:
-    max_concurrent_runs: 100
+    max_concurrent_runs: MAX_CONCURRENT_RUNS
 
 # Configures how long Dagster waits for code locations
 # to load before timing out.

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/CLAUDE.md
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/CLAUDE.md
@@ -81,6 +81,7 @@ Rootly). That path is independent of Grafana and is managed in
 | `metric_rules/eks_general.py` | EKS workload alert rules (replicas, node readiness, crash loops, OOM, jobs, HPA). |
 | `metric_rules/linux_host.py` | Linux host alert rules (CPU, memory, disk usage). |
 | `metric_rules/apisix_edge.py` | Per-host 5xx rate at the APISIX edge (`apisix_http_status`). Two windows (fast cliff / slow creep) with a minimum-traffic gate. Currently unlabelled → `oblivion` while calibrating. |
+| `metric_rules/dagster_pgbouncer.py` | Dagster's PgBouncer pool (`pgbouncer_*`, from the exporter sidecar added in #5426). Aggregate connections against the derived `max_db_connections` cap, clients queued behind it, and exporter health. The denominator is read from `pgbouncer_databases_max_connections` rather than hardcoded, because the cap differs per environment. |
 | `metric_rules/synthetic_monitoring.py` | MIT Learn probe-failure rules (`probe_success`) for the Next.js origin, the API health endpoint, and the homepage. Imported from hand-made UI rules; lives in the Synthetic Monitoring **plugin's** folder, so it takes no `folder_uid`. |
 | `log_rules/` | Package. Grafana-managed alert rule groups for log queries. Migrated from `grafana-alerts/loki-rules/`. |
 | `log_rules/base.py` | Loki datasource UIDs, two-stage pipeline helper, folder creation, delegates to sub-modules. |

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/base.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/base.py
@@ -37,6 +37,11 @@ Sub-modules
   eks_general  — Source: grafana-alerts/cortex-rules/eks_general.yaml
   linux_host   — Source: grafana-alerts/cortex-rules/linux-host.yaml
   apisix_edge  — New in 2026-08. Per-host 5xx rate at the APISIX edge.
+  dagster_pgbouncer
+               — New in 2026-08. Dagster's PgBouncer pool: aggregate connection
+                 headroom against the max_db_connections cap, queued clients, and
+                 exporter health. Depends on the pgbouncer_exporter sidecar added
+                 to the dagster stack in #5426.
   synthetic_monitoring
                — Imported 2026-08 from three hand-made UI rules. Unlike the
                  others it takes no folder_uid: its rules live in the Synthetic
@@ -51,6 +56,7 @@ from pulumiverse_grafana.oss.folder import Folder
 
 from ol_infrastructure.infrastructure.grafana_alerting.metric_rules import (
     apisix_edge,
+    dagster_pgbouncer,
     eks_general,
     linux_host,
     synthetic_monitoring,
@@ -154,6 +160,7 @@ def create(resource_opts: ResourceOptions) -> None:
     eks_general.create(alerts_folder.uid, rd, resource_opts)
     linux_host.create(alerts_folder.uid, rd, resource_opts)
     apisix_edge.create(alerts_folder.uid, rd, resource_opts)
+    dagster_pgbouncer.create(alerts_folder.uid, rd, resource_opts)
     # No folder_uid: these rules live in the Synthetic Monitoring plugin's own
     # folder rather than the one created above. See the module docstring.
     synthetic_monitoring.create(rd, resource_opts)

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/dagster_pgbouncer.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/dagster_pgbouncer.py
@@ -1,0 +1,199 @@
+"""Dagster PgBouncer pool alert rules.
+
+New in 2026-08, off the back of the 2026-08-10 connection-exhaustion incident on
+ol-etl-db-production: DatabaseConnections sat at exactly 4989 -- arithmetically the
+ceiling on a db.r7g.2xlarge (5000 - 3 superuser_reserved - 2 reserved, the remaining 6
+being RDS's own rdsadmin sessions) -- for 88 consecutive 1-minute samples, during which
+every new Dagster connection was refused and the daemon sat Pending behind 178 run
+workers. Nothing alerted, because nothing was collected: the only signal available was
+CloudWatch DatabaseConnections, which min_pool_size x replicas pins to a constant floor
+(900 in production) and which therefore reports a configured constant rather than
+observed demand. Background: docs/plans/dagster-pgbouncer-observability.md.
+
+Two things had to land before these rules could exist, and both did in #5426:
+the pgbouncer_exporter sidecar that produces these metrics, and the max_db_connections
+cap that gives the headroom rule a denominator worth measuring against.
+
+Warning rules filter cluster=~".*-(ci|qa)"      -- fire on CI and QA stacks.
+Critical rules filter cluster=~".*-(production)" -- fire on prod stack only.
+Rules with no matching data on a given stack stay silent (no_data_state=OK).
+
+Why the denominator is a metric rather than a literal
+-----------------------------------------------------
+pgbouncer_databases_max_connections is PgBouncer reporting its own max_db_connections
+back from SHOW DATABASES, so the ratio stays correct without this file knowing anything
+about instance classes. That matters because the cap is derived per environment from
+postgres_max_connections(instance_size) / pgbouncer_replica_count in the dagster stack:
+production's db.r7g.2xlarge yields 708 per pod across 6 replicas (4248 aggregate),
+QA's db.m7g.large yields 382 across 2 (764). A literal 5000 in this file would be
+silently wrong on every stack but production, which is exactly the class of bug the
+cap itself was written to avoid.
+"""
+
+from collections.abc import Callable
+
+from pulumi import Input, ResourceOptions
+from pulumiverse_grafana import alerting
+
+# Fraction of the aggregate max_db_connections cap at which the pool is considered
+# short of headroom. Production's floor is min_pool_size (150) x 6 replicas = 900
+# against a 4248 cap, so the baseline ratio is 0.21 and 3 days of 1-minute samples
+# never moved off it -- peak server_active over that window was 122. 0.75 therefore
+# sits ~3.5x above anything observed while still leaving a quarter of the pool in
+# reserve, which at 6 replicas is over 1000 connections of runway to act in.
+_HEADROOM_RATIO = 0.75
+
+# Seconds the oldest queued client has been waiting before the queue counts as
+# genuinely stuck rather than briefly backed up. Queries through this pool run in
+# under a millisecond (measured: xact 988us, query 918us), so any wait measured in
+# whole seconds is already pathological; 5 with for_=10m means a queue that has
+# failed to drain for ten minutes, not a transient blip during a server_lifetime
+# recycle. Baseline in production is a flat 0.
+_MAXWAIT_SECONDS = 5
+
+
+def create(
+    folder_uid: Input[str],
+    rd: Callable[[str], list[alerting.RuleGroupRuleDataArgs]],
+    resource_opts: ResourceOptions,
+) -> None:
+    """Create Dagster PgBouncer pool alert rule groups."""
+    alerting.RuleGroup(
+        "dagster-pgbouncer",
+        name="dagster-pgbouncer",
+        folder_uid=folder_uid,
+        interval_seconds=60,
+        rules=[
+            # --- Aggregate connection headroom ---
+            # The alert that would have fired on 2026-08-10. Sums the server
+            # connections PgBouncer actually holds against RDS across every replica
+            # and compares them to the aggregate max_db_connections cap.
+            #
+            # Both sides come from the same SHOW DATABASES row, so a pod that is
+            # missing from one is missing from the other and the ratio stays honest
+            # while replicas roll. database="dagster" excludes the admin console's
+            # own "pgbouncer" pseudo-database, which reports the same cap value and
+            # would otherwise double the denominator.
+            alerting.RuleGroupRuleArgs(
+                name="DagsterPgBouncerConnectionHeadroomWarning",
+                condition="C",
+                for_="15m",
+                no_data_state="OK",
+                labels={"severity": "warning"},
+                annotations={
+                    "summary": "Dagster PgBouncer in cluster {{ $labels.cluster }} is holding {{ $value }} of its aggregate connection cap",
+                    "description": "PgBouncer's server connections across all replicas in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} have exceeded 75% of the aggregate max_db_connections cap. Past the cap, PgBouncer queues clients rather than opening more backends, and query_wait_timeout is 0, so those clients wait indefinitely instead of erroring -- check DagsterPgBouncerClientsWaiting. Either demand has genuinely grown (raise pgbouncer_replica_count or the RDS instance class, which raises the derived cap with it) or something is holding sessions open: pool_mode is session, so a client that stays connected pins its backend for as long as it lives.",
+                },
+                datas=rd(
+                    "sum by (cluster, namespace) "
+                    '(pgbouncer_databases_current_connections{database="dagster", cluster=~".*-(ci|qa)"})'
+                    " / "
+                    "sum by (cluster, namespace) "
+                    '(pgbouncer_databases_max_connections{database="dagster", cluster=~".*-(ci|qa)"})'
+                    f" > {_HEADROOM_RATIO}"
+                ),
+            ),
+            alerting.RuleGroupRuleArgs(
+                name="DagsterPgBouncerConnectionHeadroomCritical",
+                condition="C",
+                for_="15m",
+                no_data_state="OK",
+                labels={"severity": "critical"},
+                annotations={
+                    "summary": "Dagster PgBouncer in cluster {{ $labels.cluster }} is holding {{ $value }} of its aggregate connection cap",
+                    "description": "PgBouncer's server connections across all replicas in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} have exceeded 75% of the aggregate max_db_connections cap. Past the cap, PgBouncer queues clients rather than opening more backends, and query_wait_timeout is 0, so those clients wait indefinitely instead of erroring -- check DagsterPgBouncerClientsWaiting. Either demand has genuinely grown (raise pgbouncer_replica_count or the RDS instance class, which raises the derived cap with it) or something is holding sessions open: pool_mode is session, so a client that stays connected pins its backend for as long as it lives.",
+                },
+                datas=rd(
+                    "sum by (cluster, namespace) "
+                    '(pgbouncer_databases_current_connections{database="dagster", cluster=~".*-(production)"})'
+                    " / "
+                    "sum by (cluster, namespace) "
+                    '(pgbouncer_databases_max_connections{database="dagster", cluster=~".*-(production)"})'
+                    f" > {_HEADROOM_RATIO}"
+                ),
+            ),
+            # --- Clients queued behind the cap ---
+            # The headroom rule above says the pool is close to full; this one says
+            # the fullness is costing something. It is a separate rule rather than a
+            # tighter threshold on the same one because the cap converts database
+            # exhaustion into in-pool queuing by design, and query_wait_timeout = 0
+            # (chosen so clients ride out RDS checkpoint I/O instead of getting
+            # "server closed the connection unexpectedly") makes that queue
+            # unbounded. Without this rule a wedged pool is indistinguishable from a
+            # healthy idle one from the client's side: nothing errors, nothing
+            # retries, work simply stops.
+            #
+            # maxwait is instantaneous -- the age of the oldest client currently in
+            # the queue, reset when the queue drains -- so a value that stays high is
+            # a queue that is not draining, and one that tracks wall-clock 1:1 is a
+            # single client that has never been served.
+            alerting.RuleGroupRuleArgs(
+                name="DagsterPgBouncerClientsWaitingWarning",
+                condition="C",
+                for_="10m",
+                no_data_state="OK",
+                labels={"severity": "warning"},
+                annotations={
+                    "summary": "Dagster PgBouncer clients in cluster {{ $labels.cluster }} have been queued for {{ $value }}s waiting for a backend",
+                    "description": "The oldest client waiting for a server connection in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has been queued for over 5 seconds for 10 minutes. Queries through this pool normally complete in under a millisecond. query_wait_timeout is 0, so these clients will wait indefinitely rather than failing -- Dagster will appear hung rather than erroring. Check SHOW POOLS on the pods: sv_idle at 0 with sv_active at the cap means every backend is pinned by a live session.",
+                },
+                datas=rd(
+                    "max by (cluster, namespace) "
+                    '(pgbouncer_pools_client_maxwait_seconds{namespace="dagster", cluster=~".*-(ci|qa)"})'
+                    f" > {_MAXWAIT_SECONDS}"
+                ),
+            ),
+            alerting.RuleGroupRuleArgs(
+                name="DagsterPgBouncerClientsWaitingCritical",
+                condition="C",
+                for_="10m",
+                no_data_state="OK",
+                labels={"severity": "critical"},
+                annotations={
+                    "summary": "Dagster PgBouncer clients in cluster {{ $labels.cluster }} have been queued for {{ $value }}s waiting for a backend",
+                    "description": "The oldest client waiting for a server connection in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has been queued for over 5 seconds for 10 minutes. Queries through this pool normally complete in under a millisecond. query_wait_timeout is 0, so these clients will wait indefinitely rather than failing -- Dagster will appear hung rather than erroring. Check SHOW POOLS on the pods: sv_idle at 0 with sv_active at the cap means every backend is pinned by a live session.",
+                },
+                datas=rd(
+                    "max by (cluster, namespace) "
+                    '(pgbouncer_pools_client_maxwait_seconds{namespace="dagster", cluster=~".*-(production)"})'
+                    f" > {_MAXWAIT_SECONDS}"
+                ),
+            ),
+            # --- Exporter health ---
+            # Both rules above use no_data_state=OK, which is right for a stack whose
+            # Mimir tenant simply has no Dagster clusters in it, but it also means an
+            # exporter that stops answering takes the connection alerting silently
+            # with it. pgbouncer_up is the exporter's own verdict on whether it could
+            # reach the admin console, so this covers the case that matters most --
+            # PgBouncer alive but unreadable -- while the scrape itself disappearing
+            # remains a gap that only a pipeline-level check would close.
+            #
+            # Written as (1 - pgbouncer_up) rather than the more natural
+            # "pgbouncer_up == 0" because the shared pipeline in base.py ends in a
+            # threshold that fires on last(A) > 0: "== 0" returns the matching
+            # series carrying its own value of 0, and 0 > 0 never fires. Same trap
+            # documented at length on DeploymentUnavailable in eks_general.py.
+            #
+            # No cluster split: this is a monitoring-health signal rather than a
+            # workload one, and losing sight of production's pool is not more or
+            # less page-worthy than losing sight of QA's -- in both cases the
+            # response is to go look at the exporter, not at Dagster.
+            alerting.RuleGroupRuleArgs(
+                name="DagsterPgBouncerExporterDown",
+                condition="C",
+                for_="15m",
+                no_data_state="OK",
+                labels={"severity": "warning"},
+                annotations={
+                    "summary": "The pgbouncer_exporter sidecar on {{ $labels.pod }} cannot reach PgBouncer's admin console",
+                    "description": "pgbouncer_up is 0 on pod {{ $labels.pod }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }}, so no pool metrics are being produced for that replica and the connection-headroom alerts are partially blind. Check that ignore_startup_parameters still includes extra_float_digits -- the exporter's PostgreSQL driver sends it on connect and PgBouncer rejects unrecognised startup parameters, which is the failure mode that shows up as a healthy PgBouncer with a dead exporter.",
+                },
+                datas=rd(
+                    "max by (cluster, namespace, pod) "
+                    '(1 - pgbouncer_up{namespace="dagster"})'
+                    " > 0"
+                ),
+            ),
+        ],
+        opts=resource_opts,
+    )

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/dagster_pgbouncer.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/dagster_pgbouncer.py
@@ -82,7 +82,7 @@ def create(
                 labels={"severity": "warning"},
                 annotations={
                     "summary": "Dagster PgBouncer in cluster {{ $labels.cluster }} is holding {{ $value }} of its aggregate connection cap",
-                    "description": "PgBouncer's server connections across all replicas in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} have exceeded 75% of the aggregate max_db_connections cap. Past the cap, PgBouncer queues clients rather than opening more backends, and query_wait_timeout is 0, so those clients wait indefinitely instead of erroring -- check DagsterPgBouncerClientsWaiting. Either demand has genuinely grown (raise pgbouncer_replica_count or the RDS instance class, which raises the derived cap with it) or something is holding sessions open: pool_mode is session, so a client that stays connected pins its backend for as long as it lives.",
+                    "description": "PgBouncer's server connections across all replicas in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} have exceeded 75% of the aggregate max_db_connections cap. Past the cap, PgBouncer queues clients rather than opening more backends, and query_wait_timeout is 600, so a client that cannot be served within 10 minutes is disconnected and Dagster sees a connection error -- check DagsterPgBouncerClientsWaiting. Either demand has genuinely grown (raise pgbouncer_replica_count or the RDS instance class, which raises the derived cap with it) or something is holding sessions open: pool_mode is session, so a client that stays connected pins its backend for as long as it lives.",
                 },
                 datas=rd(
                     "sum by (cluster, namespace) "
@@ -101,7 +101,7 @@ def create(
                 labels={"severity": "critical"},
                 annotations={
                     "summary": "Dagster PgBouncer in cluster {{ $labels.cluster }} is holding {{ $value }} of its aggregate connection cap",
-                    "description": "PgBouncer's server connections across all replicas in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} have exceeded 75% of the aggregate max_db_connections cap. Past the cap, PgBouncer queues clients rather than opening more backends, and query_wait_timeout is 0, so those clients wait indefinitely instead of erroring -- check DagsterPgBouncerClientsWaiting. Either demand has genuinely grown (raise pgbouncer_replica_count or the RDS instance class, which raises the derived cap with it) or something is holding sessions open: pool_mode is session, so a client that stays connected pins its backend for as long as it lives.",
+                    "description": "PgBouncer's server connections across all replicas in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} have exceeded 75% of the aggregate max_db_connections cap. Past the cap, PgBouncer queues clients rather than opening more backends, and query_wait_timeout is 600, so a client that cannot be served within 10 minutes is disconnected and Dagster sees a connection error -- check DagsterPgBouncerClientsWaiting. Either demand has genuinely grown (raise pgbouncer_replica_count or the RDS instance class, which raises the derived cap with it) or something is holding sessions open: pool_mode is session, so a client that stays connected pins its backend for as long as it lives.",
                 },
                 datas=rd(
                     "sum by (cluster, namespace) "
@@ -116,12 +116,12 @@ def create(
             # The headroom rule above says the pool is close to full; this one says
             # the fullness is costing something. It is a separate rule rather than a
             # tighter threshold on the same one because the cap converts database
-            # exhaustion into in-pool queuing by design, and query_wait_timeout = 0
-            # (chosen so clients ride out RDS checkpoint I/O instead of getting
-            # "server closed the connection unexpectedly") makes that queue
-            # unbounded. Without this rule a wedged pool is indistinguishable from a
-            # healthy idle one from the client's side: nothing errors, nothing
-            # retries, work simply stops.
+            # exhaustion into in-pool queuing by design, and query_wait_timeout
+            # (600s, chosen so clients ride out RDS checkpoint I/O instead of
+            # getting "server closed the connection unexpectedly") means a
+            # saturated pool spends ten minutes looking healthy before it starts
+            # failing queries. Without this rule that window is invisible: the
+            # client side shows nothing wrong until work begins to drop.
             #
             # maxwait is instantaneous -- the age of the oldest client currently in
             # the queue, reset when the queue drains -- so a value that stays high is
@@ -135,7 +135,7 @@ def create(
                 labels={"severity": "warning"},
                 annotations={
                     "summary": "Dagster PgBouncer clients in cluster {{ $labels.cluster }} have been queued for {{ $value }}s waiting for a backend",
-                    "description": "The oldest client waiting for a server connection in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has been queued for over 5 seconds for 10 minutes. Queries through this pool normally complete in under a millisecond. query_wait_timeout is 0, so these clients will wait indefinitely rather than failing -- Dagster will appear hung rather than erroring. Check SHOW POOLS on the pods: sv_idle at 0 with sv_active at the cap means every backend is pinned by a live session.",
+                    "description": "The oldest client waiting for a server connection in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has been queued for over 5 seconds for 10 minutes. Queries through this pool normally complete in under a millisecond. query_wait_timeout is 600, so a client still unserved at 10 minutes is disconnected and the query fails. Sustained waiting at this level means the pool is saturated and Dagster work is being dropped, not merely slowed. Check SHOW POOLS on the pods: sv_idle at 0 with sv_active at the cap means every backend is pinned by a live session.",
                 },
                 datas=rd(
                     "max by (cluster, namespace) "
@@ -151,7 +151,7 @@ def create(
                 labels={"severity": "critical"},
                 annotations={
                     "summary": "Dagster PgBouncer clients in cluster {{ $labels.cluster }} have been queued for {{ $value }}s waiting for a backend",
-                    "description": "The oldest client waiting for a server connection in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has been queued for over 5 seconds for 10 minutes. Queries through this pool normally complete in under a millisecond. query_wait_timeout is 0, so these clients will wait indefinitely rather than failing -- Dagster will appear hung rather than erroring. Check SHOW POOLS on the pods: sv_idle at 0 with sv_active at the cap means every backend is pinned by a live session.",
+                    "description": "The oldest client waiting for a server connection in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has been queued for over 5 seconds for 10 minutes. Queries through this pool normally complete in under a millisecond. query_wait_timeout is 600, so a client still unserved at 10 minutes is disconnected and the query fails. Sustained waiting at this level means the pool is saturated and Dagster work is being dropped, not merely slowed. Check SHOW POOLS on the pods: sv_idle at 0 with sv_active at the cap means every backend is pinned by a live session.",
                 },
                 datas=rd(
                     "max by (cluster, namespace) "


### PR DESCRIPTION
### What are the relevant tickets?

N/A — tracked in `docs/plans/dagster-pgbouncer-observability.md`. Follows #5426, which landed the `pgbouncer_exporter` sidecar and the `max_db_connections` cap.

Two commits, deploying through two different Pulumi stacks:

1. `grafana-alerting` — the connection-headroom alert rules.
2. `applications/dagster` — the QA deadlock fix those rules uncovered.

They are one incident and read best together, but they land via separate pipelines, so they can be deployed independently and in either order.

---

## 1. Alert on Dagster's PgBouncer connection headroom

Adds `metric_rules/dagster_pgbouncer.py`. This is the alerting that was missing on 2026-08-10, when `ol-etl-db-production` sat at 4989 connections — arithmetically the ceiling on a `db.r7g.2xlarge` — for 88 consecutive minutes with nothing watching.

- **`DagsterPgBouncerConnectionHeadroom{Warning,Critical}`** — aggregate server connections over 75% of the aggregate `max_db_connections` cap, for 15m.
- **`DagsterPgBouncerClientsWaiting{Warning,Critical}`** — oldest queued client over 5s, for 10m. Separate from the headroom rule because `query_wait_timeout = 0` made the queue unbounded: a wedged pool looks idle from the client side rather than failing, so nothing errors and nothing retries. This is the rule that caught the QA outage below.
- **`DagsterPgBouncerExporterDown`** — `pgbouncer_up == 0` for 15m. `no_data_state=OK` is correct for stacks whose Mimir tenant holds no Dagster clusters, but it also means a dead exporter takes the other two rules silently with it.

The headroom denominator is read from `pgbouncer_databases_max_connections` rather than written as a literal, because the cap is derived per environment from the RDS instance class and replica count — 4248 aggregate in production, 764 in QA. A hardcoded 5000 would have been silently wrong on every stack but production, the same class of bug the derived cap in #5426 was written to avoid.

Rules follow the established `metric_rules/` conventions: three-stage pipeline via the shared `rd()` helper, `no_data_state="OK"`, env-based severity split. They group by `cluster` and `namespace`, both already in `NotificationPolicy.group_bies`, so no routing change is needed.

One convention note: `DagsterPgBouncerExporterDown` is written as `max by (...) (1 - pgbouncer_up) > 0` rather than `pgbouncer_up == 0`. The shared pipeline ends in a threshold firing on `last(A) > 0`, and `== 0` returns the series carrying its own value of 0 — which never fires. Same trap already documented on `DeploymentUnavailable` in `eks_general.py`.

## 2. Size run concurrency per environment; stop the pool deadlocking forever

Calibrating those thresholds turned up a live outage: QA's Dagster had been frozen for days, and nothing was watching.

State when found, on both PgBouncer replicas: every one of the 764 backends pinned (`sv_active` 764, `sv_idle` 0), 132 clients queued, the oldest waiting 23,797s and climbing 1:1 with wall clock — the same client, never served, having reached 210,619s (2.4 days) before a pod restart reset the counter. All 382 active clients per replica had last issued a request at the same instant, 08:50:46, and never made another. The daemon's own log stops at 08:50:46 too, part-way through cancelling backfill `lupslfla`.

Two independent settings made that state both reachable and permanent.

**`max_concurrent_runs` was 100 for every environment.** Dagster's storage uses `NullPool`, so a run worker opens a connection per query and holds one per concurrent step. During the incident 32 run workers held ~700 client connections between them. That is comfortable against production's cap of 4248 and 2.9× QA's 764. It now comes from stack config — **production 80, QA 20**.

Production is dropped from 100 to 80 rather than left alone: it has never come close to needing 100 (peak 122 active server connections over three days against a 4248 cap), and the aggregate cap overstates real headroom anyway, because `max_db_connections` divides the budget by replica count and measured load is heavily skewed across replicas. Leaving less on the table is worth doing ahead of the pool re-tune rather than after it.

With both real stacks setting their own value, the 100 default in `__main__.py` is now only a fallback. The one stack that would inherit it, CI, has an empty `dagster` namespace, so nothing uses it today.

**`query_wait_timeout` was 0.** Set that way for a good reason: the 120s default disconnected clients during RDS checkpoint I/O, which clears in 1–2 minutes. But disabling it entirely traded a transient failure for a permanent one. A timeout is the only thing that breaks a pool deadlock — when every server connection is held by a client that is itself blocked waiting for a server connection, nothing is released until something gives up, and with 0 nothing ever does. Now 600s: 5× margin over the pressure it was meant to absorb, while restoring the property that a wedged pool eventually unwedges itself.

`max_concurrent_runs` becomes a placeholder in `dagster_instance.yaml` substituted in `__main__.py`. The existing `checksum/ol-dagster-instance` annotation hashes the substituted text, so a change to the value rolls the daemon and webserver automatically.

### How can this be tested?

**Alert rules** — every expression was run against the live Grafana Cloud Mimir datasource before being written into the rule, on both the production and QA tenants:

- Production: `sum(pgbouncer_databases_current_connections{database="dagster"})` = 900 against a 4248 cap = **0.212**. Flat at exactly 900 for four days at 1-minute resolution — `min_pool_size` (150) × 6 replicas, the configured-constant artifact this project exists to get past. Peak `server_active` over three days was 122; `maxwait` never left 0. The 0.75 threshold sits ~3.5× above anything observed.
- QA, before the fix: **764 / 764 = 1.00**, `maxwait` 23,797s. A true positive, which is how the outage was found.

**QA recovery** — already applied by hand and observed. Sequence: scale `dagster-daemon` to 0 (so nothing dequeues when connections free), delete the 32 stuck run Jobs, then restore the daemon at the new concurrency.

- On deleting the Jobs the pool drained immediately — `cl_waiting` 764 → 0, `maxwait` → 0, ~140 idle servers per replica. The webserver that had been crash-looping 86 times went 1/1 without intervention.
- Queue drained on restart: `QUEUED` 683 → 347 within minutes; `CANCELING`/`STARTING`/`NOT_STARTED` all → 0.
- `STARTED` settled at exactly **20**, confirming the new limit binds.
- Pool stayed healthy throughout: peak 221 active servers on the busier replica against its 382 per-pod cap, `cl_waiting` 0 and `maxwait` 0 at every check.

**Validation** — `uv run pre-commit run` (ruff format, ruff check, mypy, yamllint) passes on both commits. `pulumi preview --stack Production` on `grafana-alerting` adds exactly one resource, `+ grafana:alerting:RuleGroup dagster-pgbouncer`, with no replacements or deletions; the other 4 changes in that preview are pre-existing unapplied Keycloak dashboard drift on `main`.

The QA ConfigMap was patched directly to `max_concurrent_runs: 20` to get QA running before this merges, so QA is currently **drifted from Pulumi in the same direction as this PR** — deploying the dagster stack reconciles it. Nothing was changed by hand in production; its drop from 100 to 80 takes effect on deploy, and the `checksum/ol-dagster-instance` annotation rolls the daemon and webserver when it does.

### Additional Context

**The alert fires on QA on arrival if the dagster stack has not deployed yet.** That was a true positive rather than a calibration problem. `ol-etl-db-qa` CloudWatch `DatabaseConnections` either side of #5426: pinned at **821–822** (min == max across whole 6h buckets) from Aug 10–14 — QA's real RDS ceiling on a `db.m7g.large` — and **764–766** from Aug 15 on. QA's database was fully exhausted, continuously, for at least five days before the cap existed. The cap moved saturation off the database and into the pool, which is a strict improvement (QA's RDS went from zero headroom to ~57 connections for Vault rotation, `rdsadmin` and ad-hoc `psql`), but the over-commitment underneath predated it.

**The ~22-connections-per-worker figure is a deadlock artifact, not steady state.** With the deadlock cleared, 47 run workers were using 11 server connections between them. QA's 20 is therefore deliberately conservative, and the comment in `Pulumi.QA.yaml` says so — revisit once the exporter has enough history to show what a run worker really holds under normal load.

**Separate finding worth a look, not addressed here:** load across the two PgBouncer replicas is very uneven — 221 active servers on one against 4 on the other, both capped at 382. `max_db_connections` is derived by dividing the budget by replica count, which assumes even distribution; in practice the effective ceiling is whichever replica saturates first, not the aggregate. Worth folding into the pool re-tuning work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013x721suvDpTPEbYXn9jZQD
