### PR TITLE
fix(k8s): unbreak mitxonline metrics — PodMonitor selector collided on pod-security-group labels

### DIFF
--- a/docs/plans/granian-configuration-overhaul.md
+++ b/docs/plans/granian-configuration-overhaul.md
@@ -316,18 +316,39 @@ Component change lands once; per-app behavior changes as each app's stack is dep
   1. `tk-stage-3-blocker-mitxonline-s-vpa-never-runs-at-t-cc6acf` — the
      `workers_max_rss` retraction above. The corrected edit is known; it needs sign-off
      because it inverts what this plan told the implementer to do.
-  2. `tk-mitxonline-is-the-only-granian-workload-in-produ-b3dffd` — `mitxonline` is the
-     only Granian workload in production emitting **no** `granian_*` series.
-     `mitxonline-webapp-pod-monitor` exists (158d), its selector matches all four pods,
-     the container serves `--metrics` on a port named `metrics`, its pod security group
-     is byte-identical to `micromasters`', and alloy-metrics logs
-     `found pod monitor … name=mitxonline-webapp-pod-monitor` with no scrape errors —
-     yet there is not even an `up` series for the namespace. Root cause still open.
+  2. `tk-mitxonline-is-the-only-granian-workload-in-produ-b3dffd` — **root-caused and
+     fixed the same day; awaiting deploy.** `mitxonline` was the only Granian workload in
+     production emitting no `granian_*` series, for the entire 158 days its PodMonitor
+     had existed.
 
-     This one is the harder blocker: `granian_workers_respawns_for_rss` is precisely the
-     signal that would show a retargeted RSS cap thrashing, and it is dark for this app.
-     Shipping a `workers_max_rss` change to `mitxonline` while blind to worker respawns
-     means the first evidence of a bad cap would be user-visible latency.
+     Prometheus SD flattens a label name by replacing every non-alphanumeric character
+     with `_`, so `ol.mit.edu/pod-security-group` and `ol.mit.edu/pod_security_group`
+     both become `__meta_kubernetes_pod_label_ol_mit_edu_pod_security_group`. The
+     PodMonitor selector was the app's full label set, which for `mitxonline` contains
+     both — the component always sets the hyphenated one, and
+     `K8sAppLabels.pod_security_group` emits the underscored one for its single caller,
+     `mitxonline`. That generated two `keep` rules on one meta-label demanding
+     `(mitxonline-app-access-production-e9f43bb)` and `(mitxonline)`. Unsatisfiable, so
+     zero targets — and therefore no `up` series to alert on, no scrape error, and a
+     PodMonitor that looks perfectly healthy. Alloy's own
+     `net_conntrack_dialer_conn_attempted_total` for the pool reads `0` against 512 for
+     `micromasters`, which is the tell.
+
+     Fixed by narrowing the PodMonitor selector to namespace + application +
+     `component=webapp` (celery pods carry `component=celery`), with a regression test —
+     the failure mode is silent, so nothing else would catch it. This also stops a
+     security group replacement silently breaking any app's scrape, which was a latent
+     hazard everywhere, not just here. Lesson
+     `les-two-k8s-labels-differing-only-in-vs-collide-unde-bb7ec4`; the redundant
+     `K8sAppLabels.pod_security_group` field still wants deleting, but it sits in the
+     Deployment's immutable `spec.selector`, so that needs a replacement window
+     (`tk-delete-the-redundant-k8sapplabels-pod-security-g-ac508d`).
+
+     **`mitxonline` stage 3 stays blocked until this is deployed and verified**, because
+     `granian_workers_respawns_for_rss` is exactly the signal that would show a
+     retargeted RSS cap thrashing. Confirm with
+     `count by (namespace) (granian_workers_spawns)` and `up{namespace="mitxonline"}`
+     after the production deploy.
 
   `edxapp` is **not** affected by either finding — `mitxonline-openedx` reports
   `granian_*` normally (`cms-edxapp-webapp-pod-monitor` and `lms-edxapp-webapp-pod-monitor`

--- a/docs/plans/granian-configuration-overhaul.md
+++ b/docs/plans/granian-configuration-overhaul.md
@@ -1,7 +1,9 @@
 # Granian configuration overhaul
 
 **Status:** stage 0 merged 2026-07-23 (#5083); stage 1 merged 2026-07-27 (#5135), validated
-in production 2026-08-07; stage 2 in review; stages 3–4 pending
+in production 2026-08-07; stage 2 merged 2026-08-10 (#5344), validated in production
+2026-08-17; stage 3 `mitxonline` **blocked** (see stage 3), `edxapp` unblocked; stage 4
+pending
 **Project:** `wp-granian-configuration-overhaul-expose-blocking-t-3debc2`
 **Component:** `src/ol_infrastructure/components/services/k8s.py` — `GranianConfig`
 **Evidence:** witan lessons `les-granianconfig-never-exposes-blocking-threads-bac-874462`,
@@ -132,10 +134,39 @@ after the concurrency changes are validated in production.
 
 Consequences:
 
-- `mitxonline`'s ceiling-derived override (`__main__.py:536-543, 563-569`) is **removed**,
-  along with `MITXONLINE_GRANIAN_WORKERS` and `GRANIAN_MASTER_OVERHEAD_MIB`. It reverts to
-  the component default, which at `workers=1` / `1200Mi` gives ~1080MiB — a cap that
-  actually fires before the cgroup OOM killer instead of ~2816MiB, which never did.
+- ~~`mitxonline`'s ceiling-derived override (`__main__.py:536-543, 563-569`) is
+  **removed**, along with `MITXONLINE_GRANIAN_WORKERS` and `GRANIAN_MASTER_OVERHEAD_MIB`.
+  It reverts to the component default, which at `workers=1` / `1200Mi` gives ~1080MiB — a
+  cap that actually fires before the cgroup OOM killer instead of ~2816MiB, which never
+  did.~~
+
+  > **Retracted 2026-08-17, before stage 3 was written.** This is wrong and would have
+  > broken production. `mitxonline`'s VPA runs an admission controller: pods are
+  > *admitted* at request=limit=3Gi, carrying
+  > `vpaUpdates: Pod resources updated by mitxonline-app-memory-vpa`. The `1200Mi` in the
+  > Deployment template is never the enforced limit — over 14 days
+  > `kube_pod_container_resource_limits` for the container ranged 1953MiB–3072MiB and
+  > never touched 1200MiB. Measured usage is avg 992MiB working set, **p95 2645MiB**,
+  > peak 2978MiB. The component default would derive 1080MiB and put the single worker
+  > into a permanent respawn loop at normal traffic.
+  >
+  > The "derive from the current declared limit, not the ceiling" rule assumes the pod
+  > starts at its declared floor and the VPA grows it later, leaving a window where a
+  > ceiling-derived cap is above the real cgroup limit. With an admission-time mutation
+  > there is no such window: ceiling *is* the current declared limit, from the pod's first
+  > instant. For `mitxonline` the two answers converge.
+  >
+  > **Corrected action:** keep the ceiling-derived override and retarget it at one worker
+  > — `MITXONLINE_GRANIAN_WORKERS` 2 → 1, giving `(3072 − 256) // 1 = 2816MiB`, still
+  > under the 3072MiB limit. Keep `GRANIAN_MASTER_OVERHEAD_MIB` and
+  > `mitxonline_granian_workers_max_rss`. The rest of the stage-3 `mitxonline` edit
+  > (dropping the concurrency holding pins) is unaffected. Tracked as
+  > `tk-stage-3-blocker-mitxonline-s-vpa-never-runs-at-t-cc6acf`; lesson
+  > `les-a-vpa-with-an-admission-controller-makes-resourc-944b12`.
+  >
+  > This makes `mitxonline` the strongest case for the runtime cgroup-derived cap
+  > (open item 1): it is the only app where the synth-time limit and the runtime limit
+  > differ by 2.5x.
 - `mit_learn`'s explicit `workers_max_rss=1080` needs re-derivation at `workers=1`
   (3200Mi × 0.9 ≈ 2880MiB) or removal in favor of the default. Its inline comment about
   `floor(limit/workers*0.9)` becomes stale either way.
@@ -237,9 +268,73 @@ Component change lands once; per-app behavior changes as each app's stack is dep
   limit (`micromasters`) and ≈ 1236MiB of a 2Gi limit (`xpro`) — stays under the new
   single-worker RSS caps of 1800MiB and 1843MiB, so the cap still fires ahead of the
   cgroup OOM killer.
-- **Stage 3 — high traffic.** `mitxonline` (plus removal of the ceiling-based
-  `workers_max_rss` override), then `edxapp` LMS and CMS separately — CMS first, it takes
-  far less traffic than LMS.
+
+  **Validated 2026-08-17.** Production deploys landed 2026-08-10 18:37Z (`xpro`) and
+  2026-08-12 18:07Z (`micromasters`); both args verified live on the Deployments. Windows
+  compared are weekday-aligned 4-day spans (before ending 2026-08-10 18:00Z, after ending
+  2026-08-17 14:00Z) with near-identical nginx log volume (1.21M lines each).
+
+  | signal | `micromasters` before → after | `xpro` before → after |
+  | --- | --- | --- |
+  | throughput (req/s) | 0.332 → 0.324 | 1.059 → 1.139 |
+  | `granian_blocking_queue` avg / max | 0.0000085 / 1 → 0 / 0 | 0.0013 / 7 → 0.0119 / 8 |
+  | blocking-thread busy µs per request | 31 431 → 27 771 (−12%) | 142 122 → 135 327 (−5%) |
+  | `granian_py_wait` µs per request | 22.5 → 49.1 | 681 → 989 |
+  | `granian_connections_err` | 0 → 0 | 0 → 0 |
+  | RSS / error worker respawns | 0 / 0 → 0 / 0 | 0 / 0 → 0 / 0 |
+  | p95 CPU, all pods (cores) | 0.0100 → 0.0097 | 0.0631 → 0.0608 |
+  | peak working set | 912MiB → 524MiB (cap 1800) | 1171MiB → 607MiB (cap 1843) |
+  | container restarts | 0 → 0 | 0 → 0 |
+  | webapp HPA `currentReplicas` | 2 → 2 | 2 → 2 |
+  | nginx 5xx | 34 → 3 | 1 → 0 |
+  | nginx 502/504 | 0 → 1 | 1 → 0 |
+
+  No regression on any axis. The two directional moves are both non-events in absolute
+  terms: `xpro`'s mean blocking-queue depth rose 9× to 0.012 requests (max depth is
+  unchanged at 7→8, and it was *already* queueing at 32 threads, which is the GIL-
+  contention pattern the change targets), and per-request GIL wait rose to 989µs against
+  135ms of thread-busy time — 0.7% of service time. Memory is the headline win: peak
+  working set fell 43–48%, so both apps now sit at ~30% of their RSS cap instead of ~50%
+  of a cap sized for two workers. The one post-change 502 was a single readiness probe
+  during a pod start on 2026-08-13; the other two 5xx were application-level Django 500s
+  (a social-auth callback and an enrollment POST), unrelated to Granian.
+
+  **Instrumentation gap found while validating.** The spec's "latency p50/p95/p99" is not
+  measurable for these apps: Granian's metrics endpoint exposes only counters and gauges
+  (no request-duration histogram), the nginx sidecar uses the stock combined log format
+  with no `$request_time`/`$upstream_response_time`, and neither app is fronted by APISIX
+  or Traefik. Busy-µs-per-request plus queue depth were used as the proxy. Stage 3
+  (`mitxonline`, `edxapp`) *is* behind APISIX and has `apisix_http_latency_bucket`, so it
+  gets real percentiles; stage 4's `mit_learn` needs this checked before its window opens.
+- **Stage 3 — high traffic.** `mitxonline` (plus ~~removal of~~ **retargeting** the
+  ceiling-based `workers_max_rss` override — see the retraction under §4), then `edxapp`
+  LMS and CMS separately — CMS first, it takes far less traffic than LMS.
+
+  **`mitxonline` is blocked as of 2026-08-17** on two findings, both raised while opening
+  the stage:
+
+  1. `tk-stage-3-blocker-mitxonline-s-vpa-never-runs-at-t-cc6acf` — the
+     `workers_max_rss` retraction above. The corrected edit is known; it needs sign-off
+     because it inverts what this plan told the implementer to do.
+  2. `tk-mitxonline-is-the-only-granian-workload-in-produ-b3dffd` — `mitxonline` is the
+     only Granian workload in production emitting **no** `granian_*` series.
+     `mitxonline-webapp-pod-monitor` exists (158d), its selector matches all four pods,
+     the container serves `--metrics` on a port named `metrics`, its pod security group
+     is byte-identical to `micromasters`', and alloy-metrics logs
+     `found pod monitor … name=mitxonline-webapp-pod-monitor` with no scrape errors —
+     yet there is not even an `up` series for the namespace. Root cause still open.
+
+     This one is the harder blocker: `granian_workers_respawns_for_rss` is precisely the
+     signal that would show a retargeted RSS cap thrashing, and it is dark for this app.
+     Shipping a `workers_max_rss` change to `mitxonline` while blind to worker respawns
+     means the first evidence of a bad cap would be user-visible latency.
+
+  `edxapp` is **not** affected by either finding — `mitxonline-openedx` reports
+  `granian_*` normally (`cms-edxapp-webapp-pod-monitor` and `lms-edxapp-webapp-pod-monitor`
+  both up), and it is behind APISIX so `apisix_http_latency_bucket` gives it the real
+  latency percentiles that stage 2 had to proxy for. Doing `edxapp` CMS first while
+  `mitxonline` is unblocked is a viable resequencing, but it is a production-rollout
+  ordering change and belongs to whoever owns the rollout, not to the implementer.
 - **Stage 4 — async apps.** `mit_learn`, `learn_ai`: `workers=2→1` for `mit_learn` and an
   explicit `backpressure` for both. No `blocking_threads` involvement. Lowest expected
   impact, sequenced last because it shares no evidence with the WSGI stages.
@@ -252,6 +347,17 @@ Before/after per stage, comparing the same weekday-hour window:
 
 - **Latency** — granian request duration p50/p95/p99 from the existing PodMonitor scrape;
   nginx upstream response time as the independent check.
+
+  > **Correction (stage 2 validation).** Neither source exists. Granian's metrics endpoint
+  > exposes only counters and gauges — there is no request-duration histogram — and the
+  > nginx sidecar logs the stock combined format with no `$request_time` /
+  > `$upstream_response_time`. Real percentiles are available *only* for apps behind
+  > APISIX (`apisix_http_latency_bucket`): `mitxonline` and `edxapp`. For `micromasters`,
+  > `xpro`, `ocw_studio` and `odl_video_service` the working proxy is
+  > `rate(granian_blocking_busy_cumulative) / rate(granian_requests_handled)`
+  > (µs of thread time per request) plus `granian_blocking_queue` avg/max for saturation.
+  > Check `mit_learn` before stage 4 opens. Lesson
+  > `les-granian-request-latency-percentiles-are-unmeasur-d2f2ab`.
 - **Errors** — 5xx rate at nginx and at APISIX; specifically 502/504, which is where
   backpressure saturation would surface.
 - **Saturation** — pod CPU utilization vs request, HPA `currentReplicas`, and any

--- a/src/ol_infrastructure/components/services/k8s.py
+++ b/src/ol_infrastructure/components/services/k8s.py
@@ -1546,7 +1546,28 @@ class OLApplicationK8s(ComponentResource):
             _pod_monitor_name = truncate_k8s_metanames(
                 f"{ol_app_k8s_config.application_name}-webapp-pod-monitor"
             )
-            kubernetes.apiextensions.CustomResource(
+            # Deliberately a narrower selector than `application_labels`.
+            #
+            # Prometheus service discovery flattens a label name into a meta-label by
+            # replacing every non-alphanumeric character with `_`, so
+            # `ol.mit.edu/pod-security-group` and `ol.mit.edu/pod_security_group` both
+            # become `__meta_kubernetes_pod_label_ol_mit_edu_pod_security_group`. An app
+            # carrying both (the component always sets the hyphenated one; K8sAppLabels
+            # emits the underscored one when `pod_security_group` is set) generates two
+            # `keep` rules against that single meta-label demanding different values.
+            # Nothing can satisfy both, the scrape pool resolves to zero targets, and the
+            # app goes silently unmonitored -- no `up` series, no error, the PodMonitor
+            # looks healthy. mitxonline lost every granian_* metric this way.
+            #
+            # Namespace + application + component=webapp already identifies these pods
+            # uniquely (celery pods carry component=celery), and leaving the security
+            # group name out also stops a security group replacement from silently
+            # breaking the scrape.
+            _pod_monitor_selector_labels = {
+                "ol.mit.edu/application": ol_app_k8s_config.application_name,
+                "ol.mit.edu/component": "webapp",
+            }
+            self.webapp_pod_monitor = kubernetes.apiextensions.CustomResource(
                 _pod_monitor_name,
                 api_version="monitoring.coreos.com/v1",
                 kind="PodMonitor",
@@ -1556,7 +1577,7 @@ class OLApplicationK8s(ComponentResource):
                     labels=ol_app_k8s_config.k8s_global_labels,
                 ),
                 spec={
-                    "selector": {"matchLabels": application_labels},
+                    "selector": {"matchLabels": _pod_monitor_selector_labels},
                     "podMetricsEndpoints": [
                         {
                             "port": "metrics",

--- a/src/ol_infrastructure/components/services/k8s.py
+++ b/src/ol_infrastructure/components/services/k8s.py
@@ -1336,6 +1336,7 @@ class OLApplicationK8s(ComponentResource):
         self.celery_deployment_names: list[str] = []
         self.celery_deployments: list[kubernetes.apps.v1.Deployment] = []
         self.beat_deployment_name: str | None = None
+        self.webapp_pod_monitor: kubernetes.apiextensions.CustomResource | None = None
 
         if pre_deploy_commands := ol_app_k8s_config.pre_deploy_commands:
             _pre_deploy_job = kubernetes.batch.v1.Job(
@@ -1559,10 +1560,14 @@ class OLApplicationK8s(ComponentResource):
             # app goes silently unmonitored -- no `up` series, no error, the PodMonitor
             # looks healthy. mitxonline lost every granian_* metric this way.
             #
-            # Namespace + application + component=webapp already identifies these pods
-            # uniquely (celery pods carry component=celery), and leaving the security
-            # group name out also stops a security group replacement from silently
-            # breaking the scrape.
+            # Namespace + application + component=webapp is enough to reach the webapp
+            # pods: celery and beat pods carry component=celery. The pre/post-deploy Job
+            # pods do stamp these same labels, but their containers declare no port named
+            # `metrics`, so service discovery yields no target for them -- give a Job
+            # container such a port and it would join this scrape pool.
+            #
+            # Leaving the security group name out also stops a security group replacement
+            # from silently breaking the scrape.
             _pod_monitor_selector_labels = {
                 "ol.mit.edu/application": ol_app_k8s_config.application_name,
                 "ol.mit.edu/component": "webapp",

--- a/tests/ol_infrastructure/components/services/test_k8s_extra_containers.py
+++ b/tests/ol_infrastructure/components/services/test_k8s_extra_containers.py
@@ -928,3 +928,45 @@ def test_container_security_context_applied_to_celery_worker():
         assert worker["security_context"]["read_only_root_filesystem"] is True
 
     return app.celery_deployments[0].spec.template.spec.containers.apply(check)
+
+
+# ─── Granian webapp PodMonitor selector ───────────────────────────────────────
+
+
+@pulumi.runtime.test
+def test_pod_monitor_selector_excludes_security_group_labels():
+    """The PodMonitor must not select on either pod-security-group label.
+
+    Prometheus SD flattens a label name by replacing every non-alphanumeric
+    character with ``_``, so ``ol.mit.edu/pod-security-group`` and
+    ``ol.mit.edu/pod_security_group`` collapse to the same meta-label. Selecting
+    on both emits two ``keep`` rules against that one meta-label demanding
+    different values, the scrape pool resolves to zero targets, and the app goes
+    silently unmonitored -- no ``up`` series and no error. mitxonline lost every
+    granian_* metric this way.
+    """
+    app = OLApplicationK8s(
+        _base_config(
+            application_name="monitored",
+            k8s_global_labels={
+                "ol.mit.edu/application": "monitored",
+                "ol.mit.edu/environment": "qa",
+                "ol.mit.edu/pod_security_group": "monitored",
+            },
+            granian_config=GranianConfig(
+                application_module="monitored.wsgi:application",
+                enable_metrics=True,
+            ),
+        )
+    )
+
+    def check(spec):
+        match_labels = spec["selector"]["matchLabels"]
+        assert "ol.mit.edu/pod-security-group" not in match_labels
+        assert "ol.mit.edu/pod_security_group" not in match_labels
+        assert match_labels == {
+            "ol.mit.edu/application": "monitored",
+            "ol.mit.edu/component": "webapp",
+        }
+
+    return app.webapp_pod_monitor.spec.apply(check)


### PR DESCRIPTION
### What are the relevant tickets?
N/A — tracked internally. All context needed to review is inline below.

### Description (What does it do?)

**The fix (`src/ol_infrastructure/components/services/k8s.py`)** — mitxonline has emitted no `granian_*` metrics for the entire 158 days its PodMonitor has existed, and nothing surfaced it.

Prometheus service discovery flattens a label name into a meta-label by replacing every non-alphanumeric character with `_`. So `ol.mit.edu/pod-security-group` and `ol.mit.edu/pod_security_group` — different, legal, co-existing labels — both become `__meta_kubernetes_pod_label_ol_mit_edu_pod_security_group`. The PodMonitor selector was the app's full label set, which for mitxonline contains both, so the generated scrape config carried two `keep` rules against that single meta-label:

```
source_labels: [__meta_kubernetes_pod_label_ol_mit_edu_pod_security_group, __meta_kubernetes_pod_labelpresent_ol_mit_edu_pod_security_group]
regex: (mitxonline-app-access-production-e9f43bb);true

source_labels: [__meta_kubernetes_pod_label_ol_mit_edu_pod_security_group, __meta_kubernetes_pod_labelpresent_ol_mit_edu_pod_security_group]
regex: (mitxonline);true
```

Nothing satisfies both, so the scrape pool resolves to zero targets.

- The failure is silent: no `up` series to alert on (a target must exist to be down), no scrape error, and a PodMonitor that looks healthy. `kubectl get pods -l <the full selector>` matches all four pods, because kubectl doesn't sanitize label names — only Prometheus does.
- Only mitxonline is affected. The component always sets the hyphenated label; the underscored one comes from `K8sAppLabels.pod_security_group`, and `rg "pod_security_group\s*=" src/` returns exactly one caller — `src/ol_infrastructure/applications/mitxonline/__main__.py:142`.
- Selector narrowed to namespace + `ol.mit.edu/application` + `ol.mit.edu/component=webapp`, which identifies webapp pods uniquely — celery pods carry `component=celery`, verified against the live mitxonline namespace.
- This also removes a latent hazard for **every** app, not just this one: the old selector pinned the security group *name*, so replacing a security group would have silently broken that app's scrape the same way.
- Regression test added. The failure mode is invisible to anything that only asserts the app is running, so it needs an explicit assertion on the selector.

**The docs (`docs/plans/granian-configuration-overhaul.md`)** — two corrections found by doing the work:

- Stage 2 (micromasters, xpro) validated in production and recorded. Peak working set fell 43–48%; throughput, CPU, restarts and 5xx all flat or better.
- Stage 3's instruction to drop mitxonline's ceiling-derived `workers_max_rss` is **retracted**. Its VPA mutates pods at admission, so they run at 3Gi and the `1200Mi` in the template is never enforced — 14 days of `kube_pod_container_resource_limits` range 1953–3072MiB and never touch it. The component default would derive 1080MiB against a measured p95 working set of 2645MiB, i.e. a permanent worker respawn loop. Corrected action recorded inline.
- The plan's validation section asked for latency percentiles nobody can produce for these apps: Granian exposes no request-duration histogram, the nginx sidecar uses the stock combined log format with no `$request_time`, and micromasters/xpro/ocw_studio/odl_video_service sit behind neither APISIX nor Traefik. The proxy that does work is documented so the next stage doesn't rediscover it.

### How can this be tested?

Diagnosis, run against `applications-production` before writing the fix — each step rules out a class of cause:

1. Granian is serving. `kubectl exec <pod> -c mitxonline-app -- python -c "import urllib.request;print(urllib.request.urlopen('http://127.0.0.1:9090/metrics').read()[:500])"` returns 1882 bytes of `granian_*`.
2. Alloy can reach it. Raw `bash /dev/tcp` GET from `grafana-k8s-monitoring-alloy-metrics-0` to the pod IP on 9090 returns `HTTP/1.0 200 OK`, content-length 1882 — so neither the network nor the pod security group is at fault. (The two SGs, `sg-076faa3b4a790776e` for mitxonline and `sg-0329c54f37afe43ac` for micromasters, have byte-identical ingress.)
3. Alloy never tried. Its own `/metrics` on `:12345` reports `net_conntrack_dialer_conn_attempted_total{dialer_name="podMonitor/mitxonline/mitxonline-webapp-pod-monitor/0"} 0`, against 512 for micromasters and 3285 for edxapp LMS. Zero targets, not a failing scrape.
4. The generated scrape config confirms it. `GET /api/v0/component/prometheus_operator_objects.feature/prometheus.operator.podmonitors.pod_monitors/scrapeConfig/mitxonline/mitxonline-webapp-pod-monitor` on `:12345` shows the two conflicting `keep` rules quoted above.

Verification of the change itself:

- `uv run pytest tests/ol_infrastructure/` — 408 passed, including the new `test_pod_monitor_selector_excludes_security_group_labels`.
- `uv run pre-commit run --files <changed files>` — clean (ruff, mypy, detect-secrets).
- `pulumi preview --stack CI` on **mitxonline**: the only diff the stack gains is the PodMonitor selector shedding the nine extra labels, keeping `application` and `component`. A baseline preview with the change stashed produces the same two pre-existing Fastly drift diffs (provider 12.4.0→12.5.1 and a `ServiceVcl` gzip list reordering), confirming they are unrelated to this change.
- `pulumi preview --stack CI` on **micromasters**: same, only the PodMonitor selector.

To validate after merge and deploy — this is the check that the bug is actually gone:

```promql
count by (namespace) (granian_workers_spawns)   # must now include mitxonline
up{cluster="applications-production", namespace="mitxonline"}   # must exist and report 1
```

### Additional Context

- **This touches every granian webapp's PodMonitor**, not just mitxonline's. Narrowing a `matchLabels` selector is a subset match, so it can only broaden matching, never break it — and `application` + `component=webapp` is set by the component itself for every caller, so the match is guaranteed by construction. Previewed on two stacks to confirm.
- **Not fixed here:** `K8sAppLabels.pod_security_group` is redundant with the label the component already sets authoritatively and should be deleted outright. It is part of the live Deployment's immutable `spec.selector` (`kubectl get deploy mitxonline-app -n mitxonline -o jsonpath='{.spec.selector}'` includes it), so removing it forces a Deployment *replacement* rather than an update — an outage for a 4-replica production webapp unless sequenced. There is precedent for deferring exactly this in `src/ol_infrastructure/applications/edxapp/k8s_resources.py:1190-1199`, where the old SGP label was deliberately kept in the selector and the new one added to the pod template only. Filed separately; nothing is broken by the field's existence once this PR lands.
- The mitxonline stage-3 rollout stays blocked until this is deployed and verified, because `granian_workers_respawns_for_rss` is precisely the signal that would show a retargeted RSS cap thrashing.
