### PR TITLE
fix(dagster): size run concurrency per environment and stop the pool deadlocking forever

### DIFF
--- a/src/ol_infrastructure/applications/dagster/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/dagster/Pulumi.QA.yaml
@@ -23,5 +23,13 @@ config:
   dagster:edx_pipeline_xpro_edx_bucket_name: dagster-data-qa
   dagster:edx_pipeline_xpro_edx_course_bucket_name: xpro-qa-edxapp-courses
   dagster:edx_pipeline_xpro_edx_xpro_purpose: mitx-etl-xpro-qa
+  # QA's aggregate PgBouncer connection cap is 764 (db.m7g.large, 2 replicas)
+  # against production's 4248. At the global default of 100 concurrent runs,
+  # QA deadlocked its own pool on 2026-08-17 and stayed wedged for days. 20
+  # runs at the ~22 connections apiece measured during that incident is ~440,
+  # leaving room for the daemon, webserver and ten code location servers.
+  # Revisit once the pgbouncer exporter has enough history to show what a run
+  # worker really holds outside a deadlock.
+  dagster:max_concurrent_runs: 20
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa

--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -701,16 +701,33 @@ pgbouncer_config = kubernetes.core.v1.ConfigMap(
                     # terminates them, preventing zombie connections from being
                     # assigned to clients.
                     "server_idle_timeout = 120",
-                    # Disable the default 120s query_wait_timeout. During heavy RDS
-                    # checkpoint I/O, queries slow from milliseconds to seconds, which
-                    # temporarily backs up the pool. With the default of 120s, clients
-                    # that can't immediately get a server connection are disconnected
-                    # and psycopg2 sees "server closed the connection unexpectedly".
-                    # Setting to 0 disables the timeout so clients wait as long as
-                    # needed. This is safe because server_idle_timeout=120 continuously
-                    # cycles idle connections and the pool self-recovers within 1-2
-                    # minutes of I/O pressure dropping.
-                    "query_wait_timeout = 0",
+                    # Raised well above the 120s default, but NOT disabled.
+                    #
+                    # The default was too short: during heavy RDS checkpoint I/O,
+                    # queries slow from milliseconds to seconds and the pool backs up,
+                    # and at 120s clients that can't immediately get a server
+                    # connection are disconnected with "server closed the connection
+                    # unexpectedly" in psycopg2. That pressure clears within 1-2
+                    # minutes, so the fix was to wait it out.
+                    #
+                    # This was previously 0, which disables the timeout entirely, and
+                    # that turned out to be a different failure rather than the absence
+                    # of one. A timeout is the only thing that breaks a pool deadlock:
+                    # when every server connection is held by a client that is itself
+                    # blocked waiting for a server connection, nothing is released
+                    # until something gives up. With 0, nothing ever gives up. QA sat
+                    # in exactly that state for days on 2026-08-17 -- all 764 backends
+                    # pinned, sv_idle 0, the oldest client queued 2.4 days, the daemon
+                    # frozen mid-backfill-cancellation -- and it could only be cleared
+                    # by deleting run workers by hand.
+                    #
+                    # 600s keeps the original intent with a large margin (5x the 1-2
+                    # minutes checkpoint pressure actually lasts) while restoring the
+                    # property that a wedged pool eventually unwedges itself. A client
+                    # that waits ten minutes for a connection is not going to be
+                    # rescued by waiting longer; it needs to fail so the pool can drain
+                    # and Dagster's own retry logic can take over.
+                    "query_wait_timeout = 600",
                     # Dagster uses NullPool, so it opens a fresh connection per query
                     # and every connection logs with age=0s. Measured on one production
                     # pod: 27,738 lines in 3 minutes, ~154 lines/s per replica and
@@ -1419,10 +1436,36 @@ dagster_run_priority_class = kubernetes.scheduling.v1.PriorityClass(
     ),
 )
 
+# How many runs the QueuedRunCoordinator will have in flight at once.
+#
+# This has to be sized against the environment's PgBouncer connection budget,
+# not set globally. Dagster's storage uses NullPool, so a run worker opens a
+# fresh connection per query and holds one per concurrent step; measured on
+# data-qa on 2026-08-17, 32 run workers were holding ~700 client connections
+# between them, around 22 each. At the previous global value of 100, that is
+# ~2200 connections -- fine against production's aggregate cap of 4248, and
+# 2.9x QA's 764.
+#
+# QA duly deadlocked. Once the pool was full, every remaining client queued
+# behind it, and because query_wait_timeout was 0 (see below) none of them ever
+# timed out. The run workers held connections while waiting on connections that
+# could only be released by the workers themselves, the daemon blocked
+# mid-way through cancelling a backfill, and the whole stack sat frozen for
+# days -- 764/764 servers pinned, sv_idle 0, one client queued 2.4 days.
+# Nothing could recover on its own because every recovery path needed the
+# connection that was unavailable.
+#
+# Defaulting to 100 keeps production exactly as it was; QA sets a lower value
+# in its stack config.
+dagster_max_concurrent_runs = dagster_config.get_int("max_concurrent_runs") or 100
+
 # Custom Dagster instance ConfigMap with dynamic credentials support
 # Note: We create this before the Helm release so it gets proper ownership
 dagster_instance_yaml = (
-    Path(__file__).parent.joinpath("dagster_instance.yaml").read_text()
+    Path(__file__)
+    .parent.joinpath("dagster_instance.yaml")
+    .read_text()
+    .replace("MAX_CONCURRENT_RUNS", str(dagster_max_concurrent_runs))
 )
 # The daemon and webserver mount dagster.yaml from the dagster-instance
 # ConfigMap via subPath, which kubelet never live-refreshes, and the chart's

--- a/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
+++ b/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
@@ -135,11 +135,16 @@ event_log_storage:
       params:
         connect_timeout: 30
 
+# The max_concurrent_runs value below is a placeholder token, substituted in
+# __main__.py from the dagster:max_concurrent_runs stack config -- see the
+# rationale there. It is a placeholder rather than a literal because run
+# concurrency has to be sized against the environment's PgBouncer connection
+# budget, and QA's is 5.5x smaller than production's.
 run_coordinator:
   module: dagster.core.run_coordinator
   class: QueuedRunCoordinator
   config:
-    max_concurrent_runs: 100
+    max_concurrent_runs: MAX_CONCURRENT_RUNS
 
 # Configures how long Dagster waits for code locations
 # to load before timing out.


### PR DESCRIPTION
### What are the relevant tickets?

N/A — falls out of the Dagster/PgBouncer observability work in `docs/plans/dagster-pgbouncer-observability.md`. Companion to #5454 (the alert that surfaces this condition) and follows #5426 (the connection cap).

### Description (What does it do?)

QA's Dagster had been frozen for days. Found while calibrating the alert thresholds in #5454, not by anything that was watching.

State when found, on both PgBouncer replicas: every one of the 764 backends pinned (`sv_active` 764, `sv_idle` 0), 132 clients queued, the oldest waiting 23,797s and climbing 1:1 with wall clock — the same client, never served, having reached 210,619s (2.4 days) before a pod restart reset the counter. All 382 active clients per replica had last issued a request at the same instant, 08:50:46, and never made another. The daemon's own log stops at 08:50:46 too, part-way through cancelling backfill `lupslfla`.

Two independent settings made that state both reachable and permanent.

**`max_concurrent_runs` was 100 for every environment.** Dagster's storage uses `NullPool`, so a run worker opens a connection per query and holds one per concurrent step. During the incident 32 run workers held ~700 client connections between them. That is comfortable against production's aggregate cap of 4248 and 2.9× QA's 764. It now comes from stack config — production keeps 100, QA takes 20.

**`query_wait_timeout` was 0.** It was set that way for a good reason: the 120s default disconnected clients during RDS checkpoint I/O, which clears in 1–2 minutes. But disabling it entirely traded a transient failure for a permanent one. A timeout is the only thing that breaks a pool deadlock — when every server connection is held by a client that is itself blocked waiting for a server connection, nothing is released until something gives up, and with 0 nothing ever does. Now 600s: 5× the margin over the pressure it was meant to absorb, while restoring the property that a wedged pool eventually unwedges itself.

`max_concurrent_runs` becomes a placeholder in `dagster_instance.yaml` substituted in `__main__.py`. The existing `checksum/ol-dagster-instance` annotation hashes the substituted text, so a change to the value rolls the daemon and webserver automatically.

### How can this be tested?

Already applied to QA by hand and observed. Recovery sequence was: scale `dagster-daemon` to 0 (so nothing dequeues when connections free), delete the 32 stuck run Jobs, then restore the daemon at the new concurrency.

- On deleting the Jobs, the pool drained immediately — `cl_waiting` 764 → 0, `maxwait` → 0, ~140 idle servers per replica. The webserver that had been crash-looping 86 times went 1/1 without intervention.
- Queue drained on restart: `QUEUED` 683 → 347 within minutes, `CANCELING`/`STARTING`/`NOT_STARTED` all → 0.
- `STARTED` settled at exactly **20**, confirming the new limit binds.
- Pool stayed healthy throughout: peak 221 active servers on the busier replica against its 382 per-pod cap, `cl_waiting` 0 and `maxwait` 0 at every check.

The in-cluster ConfigMap was patched directly to `max_concurrent_runs: 20` to get QA running before this merges, so QA is currently **drifted from Pulumi in the same direction as this PR** — deploying the dagster stack reconciles it. Nothing was changed by hand in production.

### Additional Context

**The ~22-connections-per-worker figure is a deadlock artifact, not steady state.** With the deadlock cleared, 47 run workers were using 11 server connections between them. QA's 20 is therefore deliberately conservative, and the comment in `Pulumi.QA.yaml` says so — it should be revisited once the exporter from #5426 has enough history to show what a run worker really holds under normal load.

**Separate finding worth a look, not addressed here:** load across the two PgBouncer replicas is very uneven — 221 active servers on one against 4 on the other, both capped at 382. `max_db_connections` is derived by dividing the budget by replica count, which assumes even distribution; in practice the effective ceiling is whichever replica saturates first, not the aggregate. Worth folding into the pool re-tuning work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013x721suvDpTPEbYXn9jZQD
