### PR TITLE
fix(alerting): un-swallow job-failure alerts, add CronJob staleness rules

### DIFF
--- a/src/ol_infrastructure/infrastructure/grafana_alerting/CLAUDE.md
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/CLAUDE.md
@@ -78,7 +78,7 @@ Rootly). That path is independent of Grafana and is managed in
 | `alertmanager.py` | Contact points (Rootly, Slack, oblivion drop sink) and the notification policy route tree. Translates `grafana-alerts/alertmanager.yaml`. |
 | `metric_rules/` | Package. Grafana-managed alert rule groups for Prometheus/Mimir metrics. Migrated from `grafana-alerts/cortex-rules/`. |
 | `metric_rules/base.py` | Mimir datasource UIDs, two-stage pipeline helper, folder creation, delegates to sub-modules. |
-| `metric_rules/eks_general.py` | EKS workload alert rules (replicas, node readiness, crash loops, OOM, jobs, HPA). |
+| `metric_rules/eks_general.py` | EKS workload alert rules (replicas, node readiness, crash loops, OOM, job failures, CronJob staleness, HPA). |
 | `metric_rules/linux_host.py` | Linux host alert rules (CPU, memory, disk usage). |
 | `metric_rules/apisix_edge.py` | Per-host 5xx rate at the APISIX edge (`apisix_http_status`). Two windows (fast cliff / slow creep) with a minimum-traffic gate. Currently unlabelled → `oblivion` while calibrating. |
 | `metric_rules/synthetic_monitoring.py` | MIT Learn probe-failure rules (`probe_success`) for the Next.js origin, the API health endpoint, and the homepage. Imported from hand-made UI rules; lives in the Synthetic Monitoring **plugin's** folder, so it takes no `folder_uid`. |
@@ -413,6 +413,15 @@ The same mechanism silently swallows rules that lost their label *by accident*:
 `HTTPRequestDurationTooHighAvg` fired 1,168 times in 30 days into `oblivion`
 before anyone noticed. When adding a rule, be explicit about which of the two
 you mean.
+
+**Route 2 swallows by *name*, not just by missing label.** `alertname =~ Kube.*`
+sits above the severity routes and carries `continue_=False`, so any rule whose
+name starts with `Kube` goes to `oblivion` no matter what `severity` it carries.
+Our own `KubernetesJobFailedWarning`/`Critical` matched it and were undeliverable
+for as long as they existed — 254 firings in 30 days on the production stack and
+104 on QA, none of which reached Rootly. They are now `WorkloadJobFailed*`.
+**Do not name a rule `Kube*` unless you intend it to be silenced**; route 2 is
+meant for the built-in kube-state-metrics alerts, not for rules defined here.
 
 ---
 

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/alertmanager.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/alertmanager.py
@@ -143,6 +143,13 @@ def create(grafana_secrets: dict[str, Any], resource_opts: ResourceOptions) -> N
             # ahead of those rules being routed anywhere, so that promoting them
             # really is only a matter of adding a `severity` label.
             "matched_host",
+            # Same reasoning for the CronJob staleness rules in
+            # metric_rules/eks_general.py, which aggregate `max by (cluster,
+            # namespace, cronjob)`. `job_name` above identifies an individual Job
+            # (`<cronjob>-<timestamp>`); a stale CronJob never produces one, so
+            # without `cronjob` here every stalled schedule in a cluster would
+            # arrive as a single grouped notification.
+            "cronjob",
         ],
         # "1m", not "60s" — Grafana normalizes durations to the largest unit and
         # a mismatched spelling shows as a perpetual diff on every preview.

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
@@ -347,11 +347,25 @@ def create(
                     ")"
                 ),
             ),
-            # --- Kubernetes Job failures ---
+            # --- Job failures ---
             # Fires when a Job's failed pod count > 0.
-            # Dagster namespace is excluded — it manages its own job retry logic.
+            #
+            # Named Workload* rather than Kubernetes*: alertmanager.py silences
+            # `alertname =~ "Kube.*"` (built-in k8s noise) with continue_=False, and
+            # that route sits ABOVE the severity routes. Under the old
+            # KubernetesJobFailed* names these rules matched it, so despite carrying
+            # severity labels they were delivered to oblivion -- 254 firings in 30
+            # days on the production stack and 104 on QA, none of which reached
+            # Rootly. Keep any new rule name here clear of the Kube.* prefix.
+            #
+            # Exclusions:
+            #   dagster          -- manages its own job retry logic.
+            #   witan-ci-indexer -- currently failing every run in both operations-qa
+            #                       and operations-production; excluded so the rename
+            #                       above does not immediately page for a known break.
+            #                       Remove this exclusion once that job is fixed.
             alerting.RuleGroupRuleArgs(
-                name="KubernetesJobFailedWarning",
+                name="WorkloadJobFailedWarning",
                 condition="C",
                 for_="5m",
                 no_data_state="OK",
@@ -360,11 +374,11 @@ def create(
                     "description": "Job {{ $labels.job_name }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has failed."
                 },
                 datas=rd(
-                    'sum by (cluster, namespace, job_name) (kube_job_status_failed{cluster=~".*-(ci|qa)", namespace!="dagster"} > 0)'
+                    'sum by (cluster, namespace, job_name) (kube_job_status_failed{cluster=~".*-(ci|qa)", namespace!="dagster", job_name!~"witan-ci-indexer.*"} > 0)'
                 ),
             ),
             alerting.RuleGroupRuleArgs(
-                name="KubernetesJobFailedCritical",
+                name="WorkloadJobFailedCritical",
                 condition="C",
                 for_="5m",
                 no_data_state="OK",
@@ -373,7 +387,7 @@ def create(
                     "description": "Job {{ $labels.job_name }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has failed."
                 },
                 datas=rd(
-                    'sum by (cluster, namespace, job_name) (kube_job_status_failed{cluster=~".*-(production)", namespace!="dagster"} > 0)'
+                    'sum by (cluster, namespace, job_name) (kube_job_status_failed{cluster=~".*-(production)", namespace!="dagster", job_name!~"witan-ci-indexer.*"} > 0)'
                 ),
             ),
             # --- HPA at max replicas ---
@@ -417,6 +431,104 @@ def create(
                 },
                 datas=rd(
                     'sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_status_current_replicas{cluster=~".*-(production)", horizontalpodautoscaler!="keda-hpa-mitxonline-hubspot-sync-celery-worker"}) >= sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_spec_max_replicas{cluster=~".*-(production)"}) and sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_spec_max_replicas{cluster=~".*-(production)"}) != sum by (cluster, namespace, horizontalpodautoscaler) (kube_horizontalpodautoscaler_spec_min_replicas{cluster=~".*-(production)"})'
+                ),
+            ),
+            # --- CronJob staleness ---
+            # Job-failure alerting above only sees runs that STARTED and failed. A
+            # CronJob that stops firing entirely -- suspended, deleted, controller
+            # wedged, schedule never matching -- produces no failed Job and no alert
+            # at all. That is the gap that let an empty Open edX course-search index
+            # sit unnoticed for months.
+            #
+            # Two buckets because PromQL cannot parse a cron expression to derive a
+            # per-job threshold. Membership is an explicit cronjob list; validate a
+            # new entry against its `schedule` label on kube_cronjob_info before
+            # adding it. Current inventory:
+            #   0/5 * * * *  cron-deploy-pipelines, cron-reindex   -> fast
+            #   17 * * * *   witan-token-sync                      -> fast
+            #   0 */4 * * *  witan-ci-indexer                      -> fast
+            #   20 3 * * *   omnigraph-optimize                    -> slow
+            #   20 4 * * 0   omnigraph-cleanup                     -> slow
+            #   30 7 * * 0   cms-edxapp-reindex-courses            -> slow
+            #
+            # witan-break-glass is deliberately absent from both: its schedule is
+            # `0 0 31 2 *` -- February 31st, a date that never occurs -- because it is
+            # triggered by hand, so it is permanently "stale" by design.
+            #
+            # `> 0` guards the never-yet-succeeded case: kube-state-metrics reports 0
+            # (or omits the series) until a CronJob's first success, and time() minus
+            # zero would otherwise fire instantly on every newly created CronJob.
+            #
+            # KNOWN GAP, deliberate: this cannot see a CronJob that has never
+            # succeeded at all, because kube-state-metrics omits
+            # last_successful_time entirely until the first success -- an absent
+            # series is NoData, and no_data_state=OK keeps it silent. Two live
+            # CronJobs are in exactly that state today (open-metadata's
+            # cron-deploy-pipelines and cron-reindex in data-production have
+            # neither a last_successful_time nor a last_schedule_time). Catching
+            # that needs a separate `kube_cronjob_info unless
+            # kube_cronjob_status_last_successful_time` rule, which is left out
+            # here because it would page immediately for those two pre-existing
+            # cases and for witan-break-glass. It also means a newly created
+            # CronJob is uncovered until its first successful run.
+            alerting.RuleGroupRuleArgs(
+                name="ScheduledJobStaleFastWarning",
+                condition="C",
+                for_="15m",
+                no_data_state="OK",
+                labels={"severity": "warning"},
+                annotations={
+                    "description": "CronJob {{ $labels.cronjob }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has not succeeded in over 6 hours."
+                },
+                datas=rd(
+                    "max by (cluster, namespace, cronjob) (time() - "
+                    "(kube_cronjob_status_last_successful_time"
+                    '{cluster=~".*-(ci|qa)", cronjob=~"cron-deploy-pipelines|cron-reindex|witan-token-sync|witan-ci-indexer"} > 0)) > 21600'
+                ),
+            ),
+            alerting.RuleGroupRuleArgs(
+                name="ScheduledJobStaleFastCritical",
+                condition="C",
+                for_="15m",
+                no_data_state="OK",
+                labels={"severity": "critical"},
+                annotations={
+                    "description": "CronJob {{ $labels.cronjob }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has not succeeded in over 6 hours."
+                },
+                datas=rd(
+                    "max by (cluster, namespace, cronjob) (time() - "
+                    "(kube_cronjob_status_last_successful_time"
+                    '{cluster=~".*-(production)", cronjob=~"cron-deploy-pipelines|cron-reindex|witan-token-sync|witan-ci-indexer"} > 0)) > 21600'
+                ),
+            ),
+            alerting.RuleGroupRuleArgs(
+                name="ScheduledJobStaleSlowWarning",
+                condition="C",
+                for_="15m",
+                no_data_state="OK",
+                labels={"severity": "warning"},
+                annotations={
+                    "description": "CronJob {{ $labels.cronjob }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has not succeeded in over 15 days."
+                },
+                datas=rd(
+                    "max by (cluster, namespace, cronjob) (time() - "
+                    "(kube_cronjob_status_last_successful_time"
+                    '{cluster=~".*-(ci|qa)", cronjob=~"omnigraph-optimize|omnigraph-cleanup|cms-edxapp-reindex-courses"} > 0)) > 1296000'
+                ),
+            ),
+            alerting.RuleGroupRuleArgs(
+                name="ScheduledJobStaleSlowCritical",
+                condition="C",
+                for_="15m",
+                no_data_state="OK",
+                labels={"severity": "critical"},
+                annotations={
+                    "description": "CronJob {{ $labels.cronjob }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has not succeeded in over 15 days."
+                },
+                datas=rd(
+                    "max by (cluster, namespace, cronjob) (time() - "
+                    "(kube_cronjob_status_last_successful_time"
+                    '{cluster=~".*-(production)", cronjob=~"omnigraph-optimize|omnigraph-cleanup|cms-edxapp-reindex-courses"} > 0)) > 1296000'
                 ),
             ),
         ],

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
@@ -435,10 +435,17 @@ def create(
             ),
             # --- CronJob staleness ---
             # Job-failure alerting above only sees runs that STARTED and failed. A
-            # CronJob that stops firing entirely -- suspended, deleted, controller
-            # wedged, schedule never matching -- produces no failed Job and no alert
-            # at all. That is the gap that let an empty Open edX course-search index
-            # sit unnoticed for months.
+            # CronJob that stops firing while still existing -- suspended, controller
+            # wedged, every run failing -- produces no successful run and no failed
+            # Job to alert on. That is the gap that let an empty Open edX
+            # course-search index sit unnoticed for months.
+            #
+            # What this does NOT cover is a CronJob that stops EXISTING: delete it and
+            # kube-state-metrics drops the series, which is NoData, which
+            # no_data_state=OK keeps silent. Detecting a resource that should be there
+            # and isn't isn't an age-of-last-success question at all -- it needs an
+            # expected-inventory check, which is a different rule (see the gap note
+            # below, which the same `unless` construction would answer).
             #
             # Two buckets because PromQL cannot parse a cron expression to derive a
             # per-job threshold. Membership is an explicit cronjob list; validate a
@@ -446,14 +453,20 @@ def create(
             # adding it. Current inventory:
             #   0/5 * * * *  cron-deploy-pipelines, cron-reindex   -> fast
             #   17 * * * *   witan-token-sync                      -> fast
-            #   0 */4 * * *  witan-ci-indexer                      -> fast
             #   20 3 * * *   omnigraph-optimize                    -> slow
             #   20 4 * * 0   omnigraph-cleanup                     -> slow
             #   30 7 * * 0   cms-edxapp-reindex-courses            -> slow
             #
-            # witan-break-glass is deliberately absent from both: its schedule is
-            # `0 0 31 2 *` -- February 31st, a date that never occurs -- because it is
-            # triggered by hand, so it is permanently "stale" by design.
+            # Two CronJobs are deliberately absent from both buckets:
+            #
+            #   witan-break-glass -- schedule `0 0 31 2 *`, February 31st, a date that
+            #     never occurs, because it is triggered by hand. Permanently "stale"
+            #     by design.
+            #   witan-ci-indexer  -- same known break that is excluded from the
+            #     job-failure rules above. It is not merely failing some runs: over a
+            #     7-day window its age-since-last-success peaked at 518,714s (6.0
+            #     days), so a 6h staleness rule would page for it continuously.
+            #     Remove from both places together once it is fixed.
             #
             # `> 0` guards the never-yet-succeeded case: kube-state-metrics reports 0
             # (or omits the series) until a CronJob's first success, and time() minus
@@ -483,7 +496,7 @@ def create(
                 datas=rd(
                     "max by (cluster, namespace, cronjob) (time() - "
                     "(kube_cronjob_status_last_successful_time"
-                    '{cluster=~".*-(ci|qa)", cronjob=~"cron-deploy-pipelines|cron-reindex|witan-token-sync|witan-ci-indexer"} > 0)) > 21600'
+                    '{cluster=~".*-(ci|qa)", cronjob=~"cron-deploy-pipelines|cron-reindex|witan-token-sync"} > 0)) > 21600'
                 ),
             ),
             alerting.RuleGroupRuleArgs(
@@ -498,7 +511,7 @@ def create(
                 datas=rd(
                     "max by (cluster, namespace, cronjob) (time() - "
                     "(kube_cronjob_status_last_successful_time"
-                    '{cluster=~".*-(production)", cronjob=~"cron-deploy-pipelines|cron-reindex|witan-token-sync|witan-ci-indexer"} > 0)) > 21600'
+                    '{cluster=~".*-(production)", cronjob=~"cron-deploy-pipelines|cron-reindex|witan-token-sync"} > 0)) > 21600'
                 ),
             ),
             alerting.RuleGroupRuleArgs(

--- a/src/ol_infrastructure/saas/rootly/__main__.py
+++ b/src/ol_infrastructure/saas/rootly/__main__.py
@@ -3065,7 +3065,17 @@ alerts_source_grafana_prometheus_production = rootly.AlertsSource(
                 "CeleryBeatPodRestartsCritical",
                 "DaemonsetReplicasMissingCritical",
                 "StatefulSetReplicasMissingCritical",
-                "KubernetesJobFailedCritical",
+                # Renamed from KubernetesJobFailedCritical: the Grafana notification
+                # policy silences `alertname =~ "Kube.*"` above the severity routes,
+                # so under the old name it was never delivered here at all. This
+                # matcher must track that rename or production job failures bypass
+                # the demotion below and page at the source's default urgency.
+                "WorkloadJobFailedCritical",
+                # A CronJob that has not succeeded in 6h/15d is behind, not on fire:
+                # by the time either fires the schedule has already been missed for
+                # hours or weeks, so there is nothing a 3am page buys.
+                "ScheduledJobStaleFastCritical",
+                "ScheduledJobStaleSlowCritical",
                 "CertManagerACMEIssuerUnavailableProduction",
                 "CertManagerChallengePresentationFailureProduction",
                 "OCWStudioContentSyncInvalidPasswordProd",


### PR DESCRIPTION
### What are the relevant tickets?

N/A. Follow-up to https://github.com/mitodl/ol-infrastructure/pull/5422, which adds the reindex CronJob this alerts on. Independent of it — nothing here depends on that PR merging first.

### Description (What does it do?)

Two problems, both in the "an alert exists but nothing is delivered" class the package `CLAUDE.md` already warns about.

**1. Job-failure alerts were undeliverable by name.** `alertmanager.py` silences `alertname =~ "Kube.*"` for built-in k8s noise. That route carries `continue_=False` and sits *above* the severity routes, so our own `KubernetesJobFailedWarning`/`Critical` matched it and went to `oblivion` despite carrying `severity` labels. Measured over 30 days:

| stack | alert | firings | delivered to |
|---|---|---|---|
| Production | `KubernetesJobFailedCritical` | **254** | `oblivion` |
| QA | `KubernetesJobFailedWarning` | **104** | `oblivion` |

Renamed to `WorkloadJobFailed*`, which routes normally. Every current firing is a single job — `witan-ci-indexer`, failing in both `operations-qa` and `operations-production` — so it is excluded for now, the same way `dagster` already is, rather than having the rename immediately page for a known break. **The exclusion should be removed once that job is fixed.**

**2. Nothing detected a CronJob that stops running entirely.** Job-failure alerting only sees runs that *started* and failed. A suspended, deleted, or never-scheduled CronJob produces no failed Job and no alert at all — that is the gap that let an empty Open edX course-search index sit unnoticed for months.

Adds `ScheduledJobStale{Fast,Slow}{Warning,Critical}`. Two buckets, because PromQL cannot parse a cron expression to derive a per-job threshold:

| bucket | threshold | CronJobs | schedules |
|---|---|---|---|
| fast | 6h | `cron-deploy-pipelines`, `cron-reindex`, `witan-token-sync`, `witan-ci-indexer` | `0/5 * * * *`, `17 * * * *`, `0 */4 * * *` |
| slow | 15d | `omnigraph-optimize`, `omnigraph-cleanup`, `cms-edxapp-reindex-courses` | `20 3 * * *`, `20 4 * * 0`, `30 7 * * 0` |

Membership was validated against the `schedule` label on `kube_cronjob_info` rather than guessed. That check caught a trap worth knowing about: **`witan-break-glass` is scheduled `0 0 31 2 *` — February 31st, a date that never occurs** — because it is triggered by hand. It is in neither bucket; a staleness rule would fire on it forever.

Also adds `cronjob` to `NotificationPolicy.group_bies`. The staleness rules aggregate `max by (cluster, namespace, cronjob)`, and per the trap documented in `CLAUDE.md`, a resource-identifying label missing from that list collapses every firing instance into one notification group per rule.

### How can this be tested?

- Expressions validated against **live Production data** before committing. Both buckets return empty at their thresholds — no false positives — and return the expected ages without them:
  - fast: `witan-ci-indexer` 2,033s, `witan-token-sync` 1,255s since last success (both well under 6h)
  - slow: `omnigraph-cleanup` 130,630s, `omnigraph-optimize` 47,825s (both well under 15d)
- `pulumi preview --stack Production` attributes exactly **+2 updates** to this change (the `NotificationPolicy` and the `eks-general` `RuleGroup`). Baseline on `main` is 4 changes; with this branch it is 6. The other 4 are pre-existing dashboard drift, not from this PR.
- Rule diff is 2 in-place renames plus 4 pure additions at the end of the list. The staleness rules were deliberately appended rather than inserted — inserting mid-list renamed the HPA rules by index shift in the diff.
- `uv run pre-commit run` passes on all three files.

Not yet deployed. After apply, the check is that `WorkloadJobFailed*` alerts start reaching Rootly — that is the part with real behaviour change.

### Additional Context

- **This will start paging.** `WorkloadJobFailed*` was silent for its whole existence; after this it routes to Rootly at warning (ci/qa) and critical (production). The `witan-ci-indexer` exclusion is what keeps that from being immediately noisy, and it is the only known current source.
- **Known gap, deliberate.** These rules cannot see a CronJob that has *never* succeeded — kube-state-metrics omits `last_successful_time` until the first success, and an absent series is NoData. open-metadata's `cron-deploy-pipelines` and `cron-reindex` in `data-production` are in exactly that state today (neither a `last_successful_time` nor a `last_schedule_time`). Catching it needs a separate `kube_cronjob_info unless kube_cronjob_status_last_successful_time` rule, left out here because it would page immediately for those pre-existing cases and for `witan-break-glass`. It also means a newly created CronJob is uncovered until its first successful run.
- **CI is not covered, by design.** The CI Grafana stack receives no `kube_*` metrics at all (confirmed over 30 days) because the Grafana helm chart is not run in CI for cost reasons. The `cluster=~".*-(ci|qa)"` warning rules are therefore effectively QA-only. `no_data_state="OK"` keeps them silent rather than showing NoData.
