### PR TITLE
docs(alerting): spec the ol.mit.edu label to Rootly wiring, and the two gates it needs

### DIFF
--- a/docs/plans/grafana-alerting-holistic-analysis.md
+++ b/docs/plans/grafana-alerting-holistic-analysis.md
@@ -1,0 +1,395 @@
+# Grafana alerting: holistic analysis and ML evaluation
+
+Date: 2026-08-07
+Evidence window: 30 days (2026-07-08 → 2026-08-07)
+Sources: Grafana Cloud alert state history (Loki `grafanacloud-alert-state-history`,
+production and QA stacks), live rule/routing APIs on all pipelines, Rootly alert API,
+production Mimir (`apisix_http_status`), and the Pulumi source in
+`src/ol_infrastructure/infrastructure/grafana_alerting/`.
+
+All counts below are measured, not estimated. "Firings" means transitions into the
+`Alerting` state recorded in Grafana's own state history.
+
+---
+
+## 1. What is actually deployed
+
+The Pulumi program in `grafana_alerting/` is *one of four* systems currently
+generating alerts. Only the first is under version control.
+
+| Pipeline | Rules | Managed by | Routes to |
+|---|---|---|---|
+| Grafana-managed rules (`infrastructure-alerts`, `log-alerts`) | ~40/stack | Pulumi | Notification policy → Rootly |
+| **Mimir + Loki ruler rules** (legacy cortextool era) | **170 metric + 28 log** | **Nothing — orphaned** | **Cloud Alertmanager → Rootly** |
+| Synthetic Monitoring rules | 7 | Hand-created in UI | Rule-level receiver override → Rootly |
+| Grafana Cloud ML (Adaptive Traces) | 5/stack | Auto-created by plugin | `Adaptive Traces` webhook |
+
+The Pulumi `CLAUDE.md` states Phase 5 retired the cortextool path. The *pipelines* were
+retired; **the rules they pushed were never deleted from the rulers and are still being
+evaluated and delivered.**
+
+---
+
+## 2. Measured volume
+
+### 2.1 Everything that reached Rootly
+
+**1,449 alerts in 30 days — ~48/day.** Every one is still classified `noise: not_noise`,
+i.e. nobody has ever triaged the noise field, so Rootly's own noise tooling has no signal
+to work from.
+
+### 2.2 Firings by rule (production stack, 30d)
+
+| Rule | Firings | Delivered to |
+|---|---:|---|
+| `HTTPRequestDurationTooHighAvg [5m]` | 1,168 | *oblivion (dropped)* |
+| `adaptive_traces_forecast_learn_webapp` | 944 | Adaptive Traces webhook |
+| `adaptive_traces_forecast_learn_nextjs` | 727 | Adaptive Traces webhook |
+| `adaptive_traces_forecast_mitxonline_webapp` | 442 | Adaptive Traces webhook |
+| `adaptive_traces_forecast_apisix` | 382 | Adaptive Traces webhook |
+| `adaptive_traces_forecast_keycloak_production` | 317 | Adaptive Traces webhook |
+| `HPAAtMaxReplicasCritical` | 278 | **Rootly** |
+| `PodOOMKilledCritical` | 195 | **Rootly** |
+| `ProbeFailedExecutionsTooHigh [5m]` | 55 | *oblivion* |
+| `PodCrashLoopingCritical` | 52 | **Rootly** |
+| `DeploymentUnavailableCritical` | 26 | **Rootly** |
+| `StatefulSetReplicasMissingCritical` | 22 | **Rootly** |
+| `Learn NextJS Homepage - Check Failed` | 15 | **Rootly** |
+| `Learn API Health Endpoint - Check Failed` | 12 | **Rootly** |
+| `KubernetesJobFailedCritical` | 11 | **Rootly** |
+| `mitlearn-5xx-error-percentage` | 2 | **Rootly** |
+| `mitxonline-5xx-error-percentage` | 2 | **Rootly** |
+
+### 2.3 Firings by rule (QA stack, 30d)
+
+`PodOOMKilledWarning` 296 · `PodCrashLoopingWarning` 185 · `DeploymentUnavailableWarning` 68 ·
+`HPAAtMaxReplicasWarning` 35 · `StatefulSetReplicasMissingWarning` 23 ·
+`KubernetesJobFailedWarning` 12 · `CeleryBeatPodRestarts` 2 — **621 to Rootly**.
+Plus 1,357 Adaptive Traces firings.
+
+### 2.4 The concentration
+
+Grafana-originated Rootly traffic: **615 (prod) + 621 (QA) = 1,236**, the balance being
+CloudWatch and the duplicate ruler path.
+
+> **Four rules — `PodOOMKilled`, `HPAAtMaxReplicas`, `PodCrashLooping`,
+> `DeploymentUnavailable` — account for 1,135 of 1,236 firings: 92% of everything
+> Grafana pages Rootly about.**
+
+Meanwhile **~43 of the ~60 production rules did not fire once in 30 days.** Some of those
+are correctly rare (`InvalidAccessKeyProduction`, `edxapp_VaultAuthFailure`). Others are
+structurally incapable of firing (§3.5).
+
+---
+
+## 3. Findings — why the noise exists
+
+### 3.1 A complete second alerting pipeline is still live, stale, and unmanaged
+
+The Loki and Mimir rulers still hold the pre-Pulumi rule set, and the **Cloud
+Alertmanager has its own route tree with its own `rootly` receiver**. Confirmed by
+`GET /api/alertmanager/grafanacloud-ngalertmanager/config/api/v1/alerts`.
+
+Concrete evidence of double-delivery — the same `mitlearn-5xx-error-percentage` event
+arriving twice on 2026-08-06:
+
+- `e1S9pM` at 19:38:55.273 — `external_url` is an Explore deeplink (ruler-generated)
+- `gzKcPb` at 19:42:30.000 — `external_url` is `/alerting/grafana/efsos1fj7lkw0e/view` (Pulumi rule)
+
+The orphaned copies are not merely duplicates — they have **drifted and are wrong**:
+
+| Rule | Legacy ruler copy | Pulumi copy |
+|---|---|---|
+| `DeploymentUnavailableWarning` | `cluster=~".*-(production)"` | `cluster=~".*-(ci\|qa)"` |
+| `DeploymentUnavailableCritical` | `cluster=~".*-(ci\|qa)"` | `cluster=~".*-(production)"` |
+
+The environment filters are **inverted** — the legacy critical rule pages on CI/QA and
+the warning rule on production. Both still use
+`kube_deployment_status_condition{condition="Available"}`, the exact query
+`eks_general.py:88-102` documents as a false-positive source and deliberately replaced.
+
+Also in the legacy set:
+
+- `CPUUsageWarning` queries `host="$instance"` — an unsubstituted dashboard template
+  variable. It can never match. Dead since it was written.
+- `DeploymentReplicasMissingWarning` has `severity: "Warning"` (capital W), which does not
+  match the route matcher `severity="warning"`, so it silently drops.
+- The legacy route tree has an `alertname=~"Deploy.*"` silence the Pulumi tree lacks, and
+  groups only by `alertname, environment` — the old grouping that
+  `alertmanager.py:99-122` documents as fixed.
+- Three Keycloak log rules report `health: "err"` — bare log-stream queries with no
+  aggregation. They have never evaluated successfully.
+
+Nine legacy rules (`Daemonset*`, `Disk*`, `Memory*`, `CPUUsage*`) carry a valid
+lowercase severity and are **not** covered by the `Deploy.*` silence, so they deliver to
+Rootly today.
+
+The same orphaned Loki rules exist on the QA stack, hardcoded to
+`cluster="applications-production"` — evaluating production selectors against the QA
+tenant.
+
+### 3.2 QA and CI page the production on-call at production urgency
+
+`PodOOMKilledWarning` from `applications-qa` and `data-qa` arrives in Rootly with
+`alert_urgency_id: fce5c971…` — **the same urgency as `HPAAtMaxReplicasCritical` from
+production.** QA/CI contribute 621 of 1,236 firings: more than half of all Grafana pages
+concern non-production environments, at production urgency.
+
+The design intent in `eks_general.py:5-7` is that warning = CI/QA and critical =
+production. That is a *severity* distinction, but `alertmanager.py:195-218` routes
+`severity=warning` and `severity=critical` to the identical `rootly` contact point. **The
+severity label currently has no routing consequence whatsoever.**
+
+### 3.3 Chronic conditions mint a fresh alert per pod
+
+A representative Rootly page (page 37 of 73) contains 18 `PodOOMKilledWarning` alerts —
+all the same QA deployment, `mitlearn-default-celery-worker`, cycling at :12 and :19 past
+the hour for hours. Each pod replacement produces a new pod name, and because
+`group_bies` includes `pod` and `container`, Alertmanager treats each as a new group and
+mints a new Rootly alert.
+
+This is the direct cost of the grouping change documented at `alertmanager.py:99-122`.
+That change correctly fixed unrelated resources being bundled together, but for a
+*churning* workload it converts one persistent problem into an unbounded stream of
+alerts. One undersized QA memory limit generated dozens of pages.
+
+The equivalent in production: `keda-hpa-traefik-gateway-controller` fired
+`HPAAtMaxReplicasCritical` **122 times in 30 days** (~4×/day) and
+`keda-hpa-mitlearn-webapp-scaledobject` 75 times. These are not 122 incidents; they are
+one capacity characteristic being re-reported.
+
+### 3.4 UI-created rules bypass the notification policy entirely
+
+There are **two Rootly contact points**: `rootly` (uid `bfsoqo63lsyrka`, Pulumi) and
+`Rootly` (uid `eel3rjpiwahoge`, created in the UI). The Synthetic Monitoring rules carry
+no `severity` label — under the notification policy they would go to `oblivion` — but they
+set `notification_settings.receiver: "Rootly"` directly on the rule, which bypasses the
+route tree. Pulumi has no visibility into these.
+
+Two stale OpsGenie contact points also remain, despite `CLAUDE.md` recording OpsGenie as
+retired.
+
+The SM rules are also poorly specified. `Learn NextJS Homepage (Bypass Fastly) - Check
+Failed` alerts on `avg_over_time(probe_success[5m]) < 1` — **any** single failed probe out
+of five pages someone (observed firing at A=0.8, i.e. 4/5 succeeded). Its `summary`
+annotation reads *"response times 30% Greater Than Normal"*, which describes latency; the
+query measures availability. The annotation is misleading to whoever gets paged.
+
+### 3.5 Rules that cannot fire where they are deployed
+
+Every `*Warning` EKS rule filters `cluster=~".*-(ci|qa)"` but is deployed to all three
+stacks. Each Mimir tenant only holds its own environment's clusters, so on the production
+stack these rules match nothing, permanently. That is by design per `CLAUDE.md`, and
+`no_data_state="OK"` keeps them quiet — but it means **production has no warning tier at
+all.** Every EKS alert that fires in production is `critical` and pages. There is no
+lower-severity band available for "worth knowing, not worth waking someone."
+
+---
+
+## 4. Findings — what the alerting is missing
+
+This is the more consequential half. The rules are noisy *and* they are watching the
+wrong layer.
+
+### 4.1 A 30-day production error regression that never alerted
+
+`api.mitxonline.mit.edu`, 5xx as a percentage of all requests at the APISIX edge, daily:
+
+```
+0%  0%  0%  0%  0%  5.5%  9.9%  8.4%  9.4%  11.0%  12.7%  9.4%  7.9%  8.6%  8.1%
+2.3%  7.5%  16.1%  17.6%  15.7%  16.7%  16.5%  20.6%  25.3%  24.0%  24.7%  24.0%
+21.3%  20.1%  14.0%  18.0%
+```
+
+**From 0% to a sustained 18–25%, climbing steadily over four weeks. Zero alerts fired.**
+13,403 5xx responses out of 102,011 requests.
+
+`mitxonline-5xx-error-percentage` fired twice in the entire window. It misses this for two
+independent reasons:
+
+1. **Wrong measurement point.** It parses the `nginx` sidecar log in the `mitxonline`
+   namespace. The failures are visible at the APISIX edge on the `api.mitxonline.mit.edu`
+   host, which no rule watches.
+2. **Threshold shape.** `> 5%` of *all* traffic for 5 minutes. On a high-volume host a
+   serious partial outage rarely crosses a whole-traffic ratio, and a slow creep never
+   trips a fixed line at all.
+
+### 4.2 Hosts sitting in chronic double-digit failure
+
+| Host | 5xx rate (30d) | Volume | Alert coverage |
+|---|---:|---:|---|
+| `opik.ol.mit.edu` | **41.7%** (peaked 90.8%, 79.1% on consecutive days) | 79k | none |
+| `courses-backend.learn.mit.edu` | **33.0%** (range 0–48%, chronic) | — | none |
+| `api.mitxonline.mit.edu` | **13.1%** and rising | 102k | none |
+| `studio.courses.learn.mit.edu` | 1.65% | — | none |
+| `api.learn.mit.edu` | 0.15% | 217M | none (304,860 absolute 502s) |
+
+### 4.3 The edge is not monitored at all
+
+APISIX fronts everything and has clean per-host status metrics
+(`apisix_http_status{matched_host, code}`). No alert rule uses them. The only HTTP error
+alerting is two Loki log-parsing rules covering two namespaces.
+
+### 4.4 Latency signal exists and is discarded
+
+`HTTPRequestDurationTooHighAvg [5m]` fired 1,168 times and every one was dropped to
+`oblivion` (no severity label, no receiver override). Its current sample shows
+`api.learn.mit.edu/learn/health` averaging **4,141 ms**. A health endpoint taking four
+seconds is a real signal that nobody sees. The rule also has `for: 0s`, so it is
+maximally flappy in its present form — it needs a duration and a severity, not deletion.
+
+---
+
+## 5. Grafana Cloud ML — evaluation
+
+### 5.1 You are already running it, and it is wired to nothing
+
+The `grafana-ml-app` plugin (v1.36.0) is installed and enabled. Three separate ML/anomaly
+systems are already producing alerts:
+
+- **Adaptive Traces forecasts** — 5 auto-created Prophet jobs per stack on per-span
+  latency. **2,812 firings in 30 days on production, 1,357 on QA.**
+- **Asserts** — `ResourceRateAnomaly`, `LatencyP95Anomaly`, `InboundClientErrorAnomaly`,
+  `ErrorLogRateBreach`, and ~20 saturation rules, all live in the Mimir ruler.
+- **Synthetic Monitoring** built-ins.
+
+None reach a human. The Adaptive Traces rules route to
+`https://tempo-us-central1.grafana.net/adaptive-traces/api/v1/alerts_webhook/…` — that is
+Grafana's own sampling-control feedback loop, **not** a notification path. The Asserts
+rules carry no `severity` label, so the policy drops them to `oblivion`.
+
+So the real question is not "should we adopt ML alerting" but "should we route what is
+already running." The measured answer is **not as-is**.
+
+### 5.2 What the measurement says about out-of-the-box ML quality
+
+`adaptive_traces_forecast_learn_webapp_alert` fired 944 times in 30 days — ~31/day for a
+single service. Its condition is:
+
+```
+…:predicted{ml_forecast='yhat'} offset 1m
+  and …:anomalous offset 1m > 0
+  and …:actual offset 1m > 0.050000
+```
+
+with `for: 2m`. It fires per `span_name`, so every individual API route is an independent
+alert instance, on a 2-minute confirmation window, gated only by an absolute floor of
+50 ms. Across five services that is 94 firings/day. Routed to Rootly unchanged, ML would
+roughly **triple** current page volume.
+
+That is not an indictment of the technique — it is an untuned model with no severity
+grading, no minimum deviation magnitude, and no duration requirement.
+
+### 5.3 Where ML genuinely helps here — and where it does not
+
+**It solves §4.1 and nothing else in §3.** The `api.mitxonline.mit.edu` creep from 0% to
+25% is precisely the failure mode a forecast catches and a fixed threshold cannot: the
+metric departed from its own learned baseline in week one and never crossed a static line
+that would also be quiet in normal operation. Same for the known weekly `mit-learn` RDS
+disk-queue spikes — seasonality-aware baselining handles "this is normal on Tuesdays,"
+which a threshold cannot express.
+
+**Outlier detection is the right tool for §3.3.** The correct question about
+`mitlearn-default-celery-worker` is not "did a pod OOM" but "is *this* pod OOMing unlike
+its peers." Outlier detection over a deployment's pods collapses the 296-firing QA storm
+into either silence (all peers equally affected — a config problem, not an incident) or a
+single genuine outlier.
+
+**It does not help with, and must not be used to paper over:**
+
+- §3.1 duplicate pipeline — a config problem. Adding ML on top of a double-delivering
+  Alertmanager doubles the ML alerts too.
+- §3.2 QA→Rootly routing — a policy problem.
+- §4.2 chronic failure. **This is the important caveat.** An anomaly model trained on
+  `courses-backend` at 33% 5xx learns 33% as normal and goes silent. ML answers *"did this
+  change?"*, never *"is this acceptable?"* Chronic badness needs an SLO or a threshold.
+  Adopting ML without keeping absolute-level alerting would actively hide §4.2.
+
+### 5.4 Cost
+
+Grafana Cloud ML forecasts and outlier detectors are billed per job and consume series in
+the ML metrics tenant. `CLAUDE.md` already records that Synthetic Monitoring was rejected
+on cost (~$3,200/mo at the desired cadence), so this needs a quote against the current
+contract before committing — I have not verified current pricing and would not want a
+plan built on a guess.
+
+---
+
+## 6. Recommended sequence
+
+Ordered by benefit-to-risk. Steps 1–3 are cleanup with no new machinery and should land
+before any ML work, because ML built on the current routing inherits every defect above.
+
+**1. Delete the orphaned ruler rules and the legacy Cloud Alertmanager config.**
+Removes duplicate delivery, the inverted CI/QA↔production filters, the resurrected
+`kube_deployment_status_condition` false positive, and the dead `$instance` rule. Highest
+value, lowest risk — these are unmanaged, stale, and provably wrong. Verify with
+`GET /api/alertmanager/grafanacloud-ngalertmanager/config/api/v1/alerts` afterwards.
+
+**2. Make `severity` mean something.** Route `critical` → Rootly page,
+`warning` → Slack or a Rootly low-urgency path. Then either stop routing QA/CI to Rootly
+or give it its own low-urgency destination. Expected reduction: ~621 of 1,236 firings
+leave the paging path immediately.
+
+**3. Fix the four rules producing 92% of volume.** Not by raising thresholds — by changing
+what they ask:
+   - Add `keep_firing_for` so flapping resources do not re-page, and consider dropping
+     `pod` from `group_bies` for the OOM/crashloop rules specifically (keep `deployment`),
+     which collapses the per-pod-name storm without reverting the §3.3 fix wholesale.
+   - `HPAAtMaxReplicas`: at-max is a capacity fact, not an incident. Alert on at-max
+     **and** a saturation signal (queue depth, latency, error rate), or move it to Slack.
+     `traefik-gateway-controller` at 122 firings is telling you to resize the HPA, once.
+   - Adopt the existing per-workload exclusion pattern (as already done for
+     `keda-hpa-mitxonline-hubspot-sync-celery-worker`) for known-benign chronic cases,
+     each with a linked issue so exclusions do not become permanent by default.
+
+**4. Add edge-level SLO alerting on APISIX.** This is the single biggest coverage win and
+needs no ML:
+```promql
+sum by (matched_host) (rate(apisix_http_status{code=~"5.."}[10m]))
+  / sum by (matched_host) (rate(apisix_http_status[10m]))
+```
+Multi-window burn-rate (fast: 5% over 10m; slow: 1% over 6h) catches both the `opik` cliff
+and the `api.mitxonline` creep. Start it warning-only for two weeks to calibrate against
+the chronic offenders in §4.2 before it pages.
+
+**5. Give `HTTPRequestDurationTooHighAvg` a `for:` duration and a `severity`,** or replace
+it with an explicit latency SLO. It is currently discarded signal, and it is reporting a
+4.1-second health endpoint.
+
+**6. Then, and only then, pilot ML — narrowly.** Two or three forecast jobs on metrics
+where a *change* is the thing you care about and seasonality defeats thresholds:
+   - APISIX 5xx ratio per host (complements, does not replace, step 4's SLO)
+   - `mit-learn` RDS disk queue depth
+   - one outlier detector over `mitlearn` celery worker pod memory
+
+Route the pilot to Slack, not Rootly, for at least 30 days. Measure firings against known
+incidents before promoting anything to a page. The 944-firing Adaptive Traces job is the
+control group for what happens if you skip that step.
+
+**7. Start using Rootly's `noise` field.** All 1,449 alerts are unclassified. Marking
+noise is what makes Rootly's grouping and suppression useful, and it produces the data to
+justify the next round of tuning.
+
+---
+
+## Appendix: verification commands
+
+```
+# Duplicate ruler rules (should be empty after step 1)
+GET /api/alertmanager/grafanacloud-ngalertmanager/config/api/v1/alerts
+
+# Firings per rule, per stack, 30d — the core measurement
+# datasource: grafanacloud-alert-state-history
+sum by (ruleTitle) (count_over_time({from="state-history"} | json | current =~ `Alerting.*` [30d]))
+
+# Firings per resource, to find chronic offenders
+topk(30, sum by (ruleTitle, labels_cluster, labels_namespace, labels_horizontalpodautoscaler,
+  labels_pod, labels_deployment, labels_statefulset, labels_job_name)
+  (count_over_time({from="state-history", folderUID="infrastructure-alerts"} | json
+   | current =~ `Alerting.*` [30d])))
+
+# Edge 5xx ratio by host — the coverage gap
+100 * sum by (matched_host) (increase(apisix_http_status{code=~"5.."}[30d]))
+    / sum by (matched_host) (increase(apisix_http_status[30d]))
+```

--- a/docs/plans/grafana-alerting-remediation-spec.md
+++ b/docs/plans/grafana-alerting-remediation-spec.md
@@ -1,0 +1,686 @@
+# Grafana alerting remediation — implementation spec
+
+Date: 2026-08-07
+Supersedes the *recommendations* (§6) of
+[grafana-alerting-holistic-analysis.md](grafana-alerting-holistic-analysis.md).
+The analysis's *measurements* stand; several of its conclusions do not, and §0 below
+records exactly which and why.
+
+Everything in this spec was verified against live state on 2026-08-07: the production
+Mimir/Loki rulers, the Cloud Alertmanager config API, the Rootly API, and the
+`pulumiverse_grafana` / `pulumi_rootly` provider SDKs vendored in this repo.
+
+---
+
+## 0. Corrections to the analysis
+
+Five findings changed materially once checked against live state. Each one changes what
+the corresponding workstream should actually do.
+
+### 0.1 The orphaned ruler set is 10 rules, not 170 — and most of what is in the ruler must NOT be deleted
+
+`GET /api/ruler/grafanacloud-prom/api/v1/rules` returns four namespaces:
+
+| Namespace | Groups | Owner | Action |
+|---|---:|---|---|
+| `asserts` | 70 | **Grafana Cloud (Asserts plugin)** | **Do not touch** |
+| `integrations-kubernetes` | 25 | **Grafana Cloud (k8s integration)** | **Do not touch** |
+| `eks` | 1 (6 rules) | cortextool era, orphaned | Delete |
+| `linux-host` | 3 (4 rules) | cortextool era, orphaned | Delete |
+
+The analysis's "170 metric rules" counted the vendor-managed `asserts` and
+`integrations-kubernetes` namespaces. Deleting those would remove Asserts and the
+Kubernetes integration wholesale. **The cortextool-era orphans under our control are
+exactly 10 metric rules in two namespaces**, plus 28 Loki rules in five namespaces
+(`5xx-errors`, `cert-manager`, `edxapp-logs`, `heroku-logs`, `vault`).
+
+Everything the analysis said about those 10 is confirmed verbatim:
+
+- `DeploymentUnavailableWarning` filters `.*-(production)`, `DeploymentUnavailableCritical`
+  filters `.*-(ci|qa)` — **inverted**, and both use
+  `kube_deployment_status_condition{condition="Available", status="false"}`, the query
+  `eks_general.py:88-116` deliberately replaced.
+- `DeploymentReplicasMissingWarning` carries `severity: "Warning"` (capital W).
+- `CPUUsageWarning` queries `host="$instance"` — an unsubstituted template variable.
+
+### 0.2 Deleting them creates no coverage hole — verified rule by rule
+
+Every one of the 10 has a Pulumi-managed equivalent already deployed:
+
+| Orphaned ruler rule | Pulumi equivalent |
+|---|---|
+| `DaemonsetReplicasMissing{Warning,Critical}` | `eks_general.py:31,44` |
+| `DeploymentReplicasMissing{Warning,Critical}` | `eks_general.py:59,72` |
+| `DeploymentUnavailable{Warning,Critical}` | `eks_general.py:117,132` |
+| `CPUUsageWarning` | `linux_host.py:29` |
+| `MemoryUsageWarning` | `linux_host.py:56` |
+| `DiskUsage{Warning,Critical}` | `linux_host.py:79,92` |
+
+Same for the 28 Loki rules against `log_rules/`. Deletion is pure subtraction of
+duplicate-and-wrong delivery.
+
+### 0.3 The legacy Cloud Alertmanager route tree is live — confirmed
+
+`GET /api/alertmanager/grafanacloud-ngalertmanager/config/api/v1/alerts` returns its own
+`rootly` receiver and this route tree, including the `Deploy.*` silence the Pulumi tree
+lacks:
+
+```
+channel="notifications-ocw-misc" → oblivion
+alertname=~"Kube.*"              → oblivion
+alertname=~"Deploy.*"            → oblivion     ← not in the Pulumi tree
+severity="warning"               → rootly
+severity="critical"              → rootly
+```
+
+Consequence worth noting before deleting: the `Deploy.*` silence is what currently
+suppresses the four inverted `Deployment*` orphans. Of the 10 orphaned metric rules,
+only 5 actually deliver today (`Daemonset*` ×2, `DiskUsage*` ×2, `MemoryUsageWarning`);
+`CPUUsageWarning` is dead and the four `Deployment*` are silenced.
+
+### 0.4 The CI/QA→Slack diversion already shipped — and is inert. This is a live defect.
+
+PR #5082 (2026-07-22) created `CI/QA Slack Notifications` escalation policy → Slack
+`#devops-warnings`, and two alert routes pointing CI and QA Grafana sources at it. Live
+state:
+
+```
+Grafana Prometheus QA - Slack Warnings Route   enabled: true
+  └─ Fallback Rule ...                         enabled: FALSE
+Grafana Prometheus CI - Slack Warnings Route   enabled: true
+  └─ Fallback Rule ...                         enabled: FALSE
+```
+
+The routes are enabled; **their only rule is disabled**, so nothing matches and CI/QA
+alerts fall through to the default escalation policy. `pulumi_rootly`'s
+`AlertRouteRuleArgs` exposes only `(condition_groups, destinations, fallback_rule, name,
+position)` — **there is no `enabled` field**, so Pulumi cannot fix this and an apply will
+not detect it. The in-repo comment at `saas/rootly/__main__.py:3310-3314` already flags
+this; nobody has connected it to the fact that it makes the diversion a no-op.
+
+This is the single highest-leverage item in the whole project and it is a two-click UI
+change, not an engineering task.
+
+### 0.5 "QA pages at production urgency" is true but for a different reason, and `warning → Low` does not stop paging
+
+Rootly's three urgency tiers are High / Medium / Low. Measured:
+
+- **CI** source default urgency: **High**, zero urgency rules. CI alerts arrive at the
+  *highest* tier — worse than the analysis reported.
+- **QA** source default: **Medium**, zero urgency rules.
+- **Production** source default: High, with **12 urgency rules already in place** (added
+  2026-07-20, `saas/rootly/__main__.py:2937-2980`) demoting `severity=warning` → Low and
+  ten named `*Critical` alertnames → Medium.
+
+So QA (Medium) and production `HPAAtMaxReplicasCritical` (Medium, via rule
+`4ee07b26`) do land on the same tier — but because production's noisy four were
+*deliberately demoted*, not because severity is ignored downstream.
+
+Critically: **the Default Escalation Policy has no path conditioned on Low urgency.**
+The only urgency-conditioned path is `defer-medium-urgency-off-hours`
+(`saas/rootly/__main__.py:656`), which holds *Medium* outside business hours. Low
+urgency therefore pages exactly like High. The analysis's step 2 — "route warning to a
+Rootly low-urgency path" — would relabel alerts without silencing a single page.
+
+There is a real non-paging destination available: `QA Non-Paging Escalation Policy`
+(`d63b7456-0d9f-44e8-80a5-4fc3df7e986b`, zero escalation levels), plus the Slack-only
+`CI/QA Slack Notifications` policy (`b32c5938-4eb2-446f-a766-ab54970cf0bf`).
+
+### 0.6 `courses-backend.learn.mit.edu` at 33% is a near-idle host, not a chronic outage
+
+Measured over the last 24h in production Mimir:
+
+| Host | 5xx rate | Traffic |
+|---|---:|---:|
+| `courses-backend.learn.mit.edu` | 33.3% | **~3 requests/day** (1 single 500) |
+| `api.mitxonline.mit.edu` | 18.0% | 4.96 req/min — **1,288 × HTTP 500/day** |
+| `api.learn.mit.edu` | 1.09% | 4,759 req/min |
+| `opik.ol.mit.edu` | **0%** | 25.7 req/min (recovered since the analysis window) |
+
+`courses-backend` sitting in the analysis's "chronic double-digit failure" table is an
+artifact of a three-request denominator. Listing it as a coverage gap would have led
+directly to a permanently-firing alert. This is the concrete reason the SLO rules in
+Workstream 4 need a minimum-traffic gate, and the number that calibrates it.
+
+Also worth recording for Workstream 3's investigation: every `api.mitxonline.mit.edu`
+5xx is code **500**, not 502 — an application error, not a gateway/upstream timeout.
+
+### 0.7 QA stack — same defects, three differences that change scope
+
+Every check in §0.1-0.3 was re-run against the QA stack on 2026-08-07. QA is
+**identical to production** on everything W1 touches:
+
+| Check | Production | QA |
+|---|---|---|
+| Mimir ruler namespaces | `asserts` 70 grp · `integrations-kubernetes` 25 · **`eks` 6 rules** · **`linux-host` 4** | `asserts` 68 grp/614 · `integrations-kubernetes` 25/124 · **`eks` 6** · **`linux-host` 4** |
+| Loki ruler orphans | 5 namespaces, 28 rules | 5 namespaces, 28 rules — same names |
+| Legacy Cloud Alertmanager | own `rootly` receiver + `Deploy.*` silence | **byte-identical route tree** |
+| `eks` inverted filters | `Unavailable{Warning→prod, Critical→ci\|qa}` | same |
+| `DeploymentReplicasMissingWarning` | `severity: "Warning"` (capital W) | same |
+| Pulumi rule set | 24 `infrastructure-alerts` + 28 `log-alerts` | same counts |
+
+So **W1 applies to QA unchanged** — same seven namespaces, same Alertmanager reset, same
+vendor namespaces to leave alone.
+
+Three differences that do change scope:
+
+**(a) The orphans bite differently on QA, and there the inverted filters hit real data.**
+Each stack's Mimir tenant holds only its own clusters, so on production the legacy
+`.*-(ci|qa)` rules match nothing. On QA they match — the legacy
+`DeploymentUnavailableCritical`, which is the *inverted* one, is the copy that evaluates
+against live data. It is silenced by the `Deploy.*` route, so it does not deliver, but it
+is the case where the inversion is not merely theoretical. `DaemonsetReplicasMissingWarning`
+(`.*-(ci|qa)`, lowercase severity, not matched by `Deploy.*`) does deliver on QA.
+
+QA's *Loki* orphans are the mirror image: all hardcoded `cluster="applications-production"`,
+evaluating a production selector against the QA tenant. They can never match — dead, but
+still evaluated every interval. Confirmed on `5xx-errors`; the analysis reported this and
+it holds.
+
+**(b) QA's contact points are clean — the mess is production-only.** QA has six contact
+points and no duplicates. Verified directly on production:
+
+| Contact point | uid | Note |
+|---|---|---|
+| `rootly` | `bfsoqo63lsyrka` | Pulumi |
+| `Rootly` | `eel3rjpiwahoge` | **UI-created duplicate** |
+| `OpsGenie` | `U4nPIcO7z` | **stale** |
+| `OpsGenie Ops Team` | `-1rdMF27z` | **stale** |
+
+None of the three offenders exist on QA. **W5b's contact-point cleanup is production-only.**
+
+**(c) Synthetic Monitoring does not exist on QA.** Production has folder
+`grafana-synthetic-monitoring-app` with **6** rules (not 7 as reported), of which **3**
+carry `notification_settings.receiver: "Rootly"` — pointing at the UI duplicate. The other
+3 carry no override and no severity, so they drop to `oblivion`. QA has no such folder.
+**W5b is production-only.**
+
+### 0.8 A fifth rule source the analysis's pipeline table missed
+
+Production has folder `GrafanaCloud` (`_iIDezonz`) holding one active rule,
+`GrafanaMetricCount` — `severity: warning`, `for: 5m`, `dont_resolve: true`, no receiver
+override, `isPaused: false`. Under the notification policy `severity=warning` routes to
+`rootly`, so this is a live delivery path outside all four pipelines the analysis
+enumerated. It did not fire in the 30-day window. QA does not have it.
+
+Not urgent, but it belongs on the inventory: fold it into the W6 re-measurement rather
+than treating the four-pipeline table as complete.
+
+### 0.9 QA gives almost no calibration signal for the APISIX SLO rules
+
+QA has 31 APISIX hosts. Measured 1d, 2026-08-07:
+
+| Host | 5xx | req/min |
+|---|---:|---:|
+| `mitx-qa.mitx.mit.edu` | 0% | 97.1 |
+| `courses.rc.learn.mit.edu` | 0% | 77.3 |
+| `api.rc.learn.mit.edu` | 0% | 16.1 |
+| `opik-qa.ol.mit.edu` | 0.59% | 11.8 |
+| `courses-rc.xpro.mit.edu` | 0% | 8.1 |
+| `courses-backend.rc.learn.mit.edu` | **21.9%** | **0.022** (~32 req/day) |
+| *22 further hosts* | 0% | < 0.5 |
+
+Two things follow. First, `courses-backend.rc.learn.mit.edu` independently reproduces the
+production `courses-backend` artifact — a double-digit ratio on a near-idle denominator,
+on a different stack, for a different host. The minimum-traffic gate is not a
+production-specific workaround.
+
+Second, the `> 0.01` req/s gate calibrated on production volumes silences roughly 22 of
+QA's 31 hosts, including `api.rc.mitxonline.mit.edu` (0.026 req/min). That is the correct
+outcome — those hosts are idle — but it means **deploying the SLO rules to QA produces
+almost no firing data to calibrate against.** Calibrate on production, in the non-paging
+mode W4 specifies. Do not treat a quiet QA as evidence the thresholds are right.
+
+### 0.10 CI stack — not a third identical stack. Check before deleting.
+
+CI was checked on 2026-08-07 and diverges from production/QA in ways that matter for W1.
+
+**CI's `eks` ruler namespace holds 20 rules, not 6 — and they are the *current, correct*
+rule set.** Not the stale cortextool six. The full modern set is there —
+`PodOOMKilled*`, `PodCrashLooping*`, `HPAAtMaxReplicas*`, `StatefulSetReplicasMissing*`,
+`NodeNotReady*`, `CeleryBeatPodRestarts*`, `KubernetesJobFailed*` — with **correct**
+environment filters (`Unavailable{Warning→ci|qa, Critical→production}`, i.e. *not*
+inverted) and lowercase severities throughout. Someone or something pushed the modern
+rule set into CI's Mimir ruler.
+
+So CI's ruler duplication is a different animal: it is a faithful duplicate of the
+Grafana-managed Pulumi rules rather than a drifted, wrong one. It still double-delivers
+and should still be deleted, but none of §0.1's "stale and provably wrong" argument
+applies there. **Do not reuse the production justification when deleting on CI.**
+
+**The vendor namespaces are nearly absent on CI:** `asserts` is 2 groups / 2 rules (vs
+68-70 groups on QA/production) and there is **no `integrations-kubernetes` namespace at
+all**. The don't-touch rule still stands, but the blast radius of a mistake is small
+there — which is precisely why CI is the wrong stack to build confidence on before
+running the same command against production.
+
+Everything else matches: identical legacy Cloud Alertmanager route tree with its own
+`rootly` receiver and `Deploy.*` silence; the same 5 Loki orphan namespaces / 28 rules;
+the same Pulumi set (24 `infrastructure-alerts` + 28 `log-alerts`); clean contact points
+(6, no duplicate `Rootly`, no OpsGenie) exactly like QA.
+
+CI also has **no `grafana-synthetic-monitoring-app` folder, no `GrafanaCloud` folder, and
+no `grafanacloud-ml` folder** — it carries the `Adaptive Traces` contact point but zero
+Adaptive Traces rules, where production and QA have 5 each.
+
+### 0.11 CI produced zero genuine alerts in 30 days — and the reason is a latent defect in all three stacks
+
+CI's entire 30-day alert state history is 536 entries:
+
+| State | Count |
+|---|---:|
+| `Normal (NoData)` | 219 |
+| `Pending (Error)` | 159 |
+| `Normal (Updated)` | 113 |
+| `Alerting (Error)` | **45** |
+| plain `Alerting` | **0** |
+
+**Not one rule condition actually matched on CI in 30 days.** All 45 "firings" are
+`Alerting (Error)` — evaluation failures, one per rule, all
+`failed to build query 'A': data source not found`, all dated ~2026-07-09. All 52 CI
+rules report `health: ok` today, and CI's datasource UIDs (`grafanacloud-prom`,
+`grafanacloud-logs`) resolve correctly, so this was a transient episode — most likely a
+provisioning-order race on first deploy — that self-resolved.
+
+The durable finding is *why a transient datasource blip became 45 alerts*:
+
+> **`exec_err_state` is never set on any rule in this program** — 0 occurrences across
+> `metric_rules/` and `log_rules/`, against 60 for `no_data_state`. Grafana defaults
+> `exec_err_state` to `Error`, which escalates an evaluation failure into a notifying
+> Alerting state carrying the rule's own `severity` label.
+
+So every rule in all three stacks pages on evaluation error, not just on the condition it
+was written for. On CI that turned one datasource hiccup into 45 alerts at CI's **High**
+urgency default (§0.5), with the Slack diversion inert (§0.4). The same blip on
+production would page the on-call 52 times.
+
+This is deliberate care taken over `no_data_state` with its counterpart left at a
+paging default. Tracked as its own task; the fix is to set `exec_err_state` explicitly
+(`"OK"` for the CI/QA-filtered warning tier, `"Error"` or `"KeepLast"` for production
+criticals — decide per tier) rather than leaving it implicit.
+
+---
+
+## 1. Revised sequence
+
+Ordered by benefit-to-risk with the corrections applied. W0 is new and jumps the queue
+because it is a UI toggle that removes more paging volume than anything else here.
+
+| # | Workstream | Effort | Paging volume removed |
+|---|---|---|---|
+| W0 | Enable the two disabled CI/QA route rules | minutes (UI) | up to 621/30d |
+| W1 | Delete the 10 + 28 orphaned ruler rules and the legacy Alertmanager config | small | duplicate delivery |
+| W2 | Give Low urgency a non-paging path; fix CI's High default | small | the rest of non-prod |
+| W3 | Fix the four rules producing 92% of volume | medium | ~1,135/30d → est. low hundreds |
+| W4 | APISIX edge SLO alerting | medium | *adds* coverage (the point) |
+| W5 | Reclaim the latency signal; fix the SM rules | small | adds coverage |
+| W6 | Rootly `noise` classification | ongoing | enables the next round |
+| W7 | ML pilot — gated on W0-W4 | large | evaluate only |
+
+---
+
+## W0 — Enable the disabled CI/QA route rules
+
+**Not a code change.** In the Rootly UI, enable the single fallback rule on each of:
+
+- `Grafana Prometheus QA - Slack Warnings Route` (route `691913ad`, rule `1e552e8f`)
+- `Grafana Prometheus CI - Slack Warnings Route` (route `588edbfc`, rule `53e8784f`)
+
+Both already point at `CI/QA Slack Notifications` → `#devops-warnings` (`C0BK6BHUCDP`),
+which has one Slack-channel level and no paging level.
+
+Because `AlertRouteRuleArgs` has no `enabled` field, this state cannot be enforced or
+detected from Pulumi. Add to `saas/rootly/__main__.py` above the two route resources a
+comment recording that the live `enabled` flag is load-bearing and unmanaged, and add a
+check to whatever periodic audit exists — `GET /v1/alert_routes` and assert
+`.rules[].enabled == true` for these two rule IDs.
+
+**Verify:** trigger or wait for one QA alert; confirm it appears in `#devops-warnings`
+and that no page is raised.
+
+---
+
+## W1 — Delete the orphaned ruler rules and the legacy Alertmanager config
+
+Delete **only** these namespaces. Do not pass a wildcard.
+
+```
+# Mimir ruler — production, QA, and CI stacks
+DELETE /api/ruler/grafanacloud-prom/api/v1/rules/eks
+DELETE /api/ruler/grafanacloud-prom/api/v1/rules/linux-host
+
+# Loki ruler — production, QA, and CI stacks
+DELETE /api/ruler/grafanacloud-logs/api/v1/rules/5xx-errors
+DELETE /api/ruler/grafanacloud-logs/api/v1/rules/cert-manager
+DELETE /api/ruler/grafanacloud-logs/api/v1/rules/edxapp-logs
+DELETE /api/ruler/grafanacloud-logs/api/v1/rules/heroku-logs
+DELETE /api/ruler/grafanacloud-logs/api/v1/rules/vault
+```
+
+**Never** `asserts` or `integrations-kubernetes` (§0.1).
+
+Then reset the Cloud Alertmanager to a default/empty config so its `rootly` receiver and
+route tree stop delivering:
+
+```
+DELETE /api/alertmanager/grafanacloud-ngalertmanager/config/api/v1/alerts
+```
+
+Order matters: delete the rules first, then the Alertmanager config. Reversing it leaves
+rules firing into a default receiver for the gap.
+
+**Pre-flight:** snapshot all seven namespaces to a file before deleting — these are
+unmanaged and unrecoverable otherwise.
+
+**Verify:**
+1. `GET .../config/api/v1/alerts` no longer lists a `rootly` receiver.
+2. The two rulers return only `asserts` / `integrations-kubernetes` (Mimir) and empty (Loki).
+3. Over the following 24h, no Rootly alert has an `external_url` that is an Explore
+   deeplink — that shape is the ruler-generated signature (analysis §3.1).
+
+**Do this on all three stacks, but not with one script.** QA is rule-for-rule identical
+to production (§0.7). **CI is not** (§0.10): its `eks` namespace holds 20 rules — the
+*current, correct* set, not the stale six — and it has no `integrations-kubernetes`
+namespace with an `asserts` of only 2 rules. The namespace names to delete are the same
+on all three; the justification and the expected before/after are not. Re-read §0.10
+before touching CI, and do not treat a clean CI run as evidence the production run is
+safe — the vendor namespaces that make production risky are nearly absent on CI.
+
+---
+
+## W2 — Make severity mean something
+
+Two independent defects, both in `src/ol_infrastructure/saas/rootly/__main__.py`.
+
+**2a. CI's default urgency is High.** Change
+`alerts_source_grafana_prometheus_ci` (`:2918`) from
+`5d357977-…` (High) to `d7ed8e91-…` (Low). CI is never a paging environment. With W0
+enabled this is belt-and-braces, but it is the correct declared state and it is the
+value that applies if a route rule is ever disabled again.
+
+**2b. Low urgency has no non-paging path.** Add an `EscalationPath` on the Default
+Escalation Policy (`96629210-…`) modelled on `escalation_path_defer_medium_urgency_off_hours`
+(`:656`) but for Low, with **no time-window rule** — Low should never page, at any hour:
+
+```python
+escalation_path_low_urgency_no_page = rootly.EscalationPath(
+    "low-urgency-no-page",
+    name="Low urgency does not page",
+    escalation_policy_id="96629210-cc41-4e57-b059-b182a0f01c5b",
+    path_type="deferral",
+    match_mode="match-all-rules",
+    after_deferral_behavior="re_evaluate",
+    rules=[
+        {
+            "ruleType": "alert_urgency",
+            "urgencyIds": ["d7ed8e91-ffa9-4cc4-b524-729d14a4425b"],
+        },
+    ],
+    opts=rootly_opts,
+)
+```
+
+Confirm with Rootly support or a live test whether a deferral path with no
+`deferral_window` holds indefinitely or is rejected; if rejected, use an all-day
+seven-day window, which is equivalent in effect. **This must be verified before W4's
+calibration mode depends on it.**
+
+Only once 2b exists does the production source's existing `severity=warning → Low` rule
+(`:2939`) actually mean "do not page."
+
+**Deliberately not doing:** splitting `warning` and `critical` onto different contact
+points in `alertmanager.py`. Grafana already emits `severity` as a label; Rootly already
+routes on `$.commonLabels.severity`. Adding a second Rootly webhook contact point would
+duplicate the urgency logic in two systems. Keep severity semantics in Rootly, where the
+escalation paths live.
+
+---
+
+## W3 — Fix the four rules producing 92% of volume
+
+All changes in `metric_rules/eks_general.py` and `alertmanager.py`. Both provider
+features below were confirmed present in the vendored SDK.
+
+**3a. `keep_firing_for` — confirmed supported.** `alerting.RuleGroupRuleArgs` accepts
+`keep_firing_for` (verified by introspection; also `missing_series_evals_to_resolve`,
+which is directly relevant — when a pod is replaced its series vanishes, resolving the
+alert instantly and re-firing under the new pod name).
+
+Add to `PodOOMKilled*` and `PodCrashLooping*`:
+
+```python
+keep_firing_for="30m",
+missing_series_evals_to_resolve=10,
+```
+
+`keep_firing_for` holds the alert through the gap between a pod dying and its
+replacement OOMing; `missing_series_evals_to_resolve` stops the vanished series from
+resolving-and-refiring. Together these attack the §3.3 storm at its actual mechanism.
+
+**3b. Per-route grouping override — confirmed supported.**
+`NotificationPolicyPolicyArgs` accepts `group_bies`, so a child route can override the
+root grouping without reverting the deliberate `alertmanager.py:99-122` fix. Add a
+policy branch **above** the `severity=warning` / `severity=critical` branches:
+
+```python
+alerting.NotificationPolicyPolicyArgs(
+    matchers=[
+        alerting.NotificationPolicyPolicyMatcherArgs(
+            label="alertname",
+            match="=~",
+            value="Pod(OOMKilled|CrashLooping)(Warning|Critical)",
+        )
+    ],
+    contact_point="rootly",
+    continue_=False,
+    # Deliberately drops `pod` and `container`: a churning workload mints a
+    # new pod name per restart, and the root grouping then mints a new Rootly
+    # alert per name. Grouping at the deployment level reports the workload
+    # once. See the analysis, section 3.3.
+    group_bies=["alertname", "grafana_folder", "cluster", "namespace", "deployment"],
+    group_interval="30m",
+    repeat_interval="12h",
+),
+```
+
+Caveat to check on first apply: Grafana requires `alertname` and `grafana_folder` in any
+policy-level `group_by` and may silently re-add them — diff the preview.
+
+Note the OOM rules currently aggregate `by (cluster, namespace, pod, container)` and do
+**not** emit a `deployment` label, so grouping on `deployment` collapses to the
+namespace level as written. Either accept namespace-level grouping (adequate — the
+observed storm was a single deployment in a single namespace) or add
+`* on (namespace, pod) group_left(deployment)` against
+`kube_pod_owner`/`kube_replicaset_owner` to carry the label through. Prefer accepting
+namespace-level first; it is one line and no new join.
+
+**3c. `HPAAtMaxReplicas` — stop paging on it.** At-max is a capacity fact.
+`keda-hpa-traefik-gateway-controller` fired 122×/30d; that is one resize decision, not
+122 incidents. Two options, in preference order:
+
+1. Move it off the paging path entirely: add `channel: notifications-ocw-misc`-style
+   routing to a `#devops-warnings` Slack contact point, or set its label to
+   `severity: warning` so W2's Low path catches it.
+2. Gate it on a saturation co-signal (HPA at max **and** target metric above threshold).
+   Better alert, materially more work, needs a per-workload decision on what "saturated"
+   means. Defer to a follow-up.
+
+Take option 1 now.
+
+**3d. `DeploymentUnavailable`** needs no rule change — the Pulumi version is already the
+corrected one (`eks_general.py:88-116`). Its 26 prod firings are largely the orphaned
+ruler copy, which W1 removes. **Re-measure after W1 before touching it.**
+
+---
+
+## W4 — APISIX edge SLO alerting
+
+New file: `src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/apisix_edge.py`,
+registered from `metric_rules/base.py:147` alongside `eks_general` and `linux_host`.
+
+`apisix_http_status{matched_host, code}` is confirmed present in production Mimir with
+the labels the analysis claimed.
+
+### The minimum-traffic gate is not optional
+
+Per §0.6, `courses-backend.learn.mit.edu` runs at 33% 5xx on three requests per day. A
+bare ratio alert fires on it forever. Gate on absolute rate in the same window:
+
+- `courses-backend`: 0.000035 req/s
+- `api.mitxonline` (the host we must catch): 0.083 req/s
+
+A gate of `> 0.01` req/s separates them by a factor of ~288 in one direction and ~8 in
+the other. Comfortable.
+
+### Rules
+
+Two windows, both gated. Written to fit the existing `rd()` three-stage pipeline
+(threshold baked into the PromQL, `condition="C"`).
+
+```python
+_RATIO = (
+    'sum by (matched_host) (rate(apisix_http_status{{code=~"5.."}}[{w}]))'
+    " / "
+    "sum by (matched_host) (rate(apisix_http_status[{w}]))"
+)
+_GATE = "sum by (matched_host) (rate(apisix_http_status[{w}])) > 0.01"
+```
+
+**Fast — a cliff.** `(ratio[10m] > 0.05) and (gate[10m])`, `for_="5m"`.
+Catches `opik`-shaped failures within ~15 minutes.
+
+**Slow — a creep.** `(ratio[6h] > 0.01) and (gate[6h])`, `for_="30m"`.
+This is the rule that would have caught `api.mitxonline` in week one, when it crossed
+from 0% to 5.5%.
+
+Write the gate clause **first** in the `and` expression. PromQL's `and` carries the
+left-hand side's value through, and the pipeline's stage C fires on `last(A) > 0` — a
+ratio on the left works, but the gate on the left is the safer idiom and matches the
+reasoning already documented at `eks_general.py:108-116`.
+
+### Calibration — two weeks, non-paging
+
+Ship both with `severity: warning`. On the production stack that maps to Rootly Low,
+which is only genuinely non-paging **after W2b lands** — W2b is a hard prerequisite, not
+a nice-to-have. If W2b slips, route these to Slack via a dedicated contact point
+instead; do not ship them paging.
+
+Review at two weeks: expected steady-state firers are `api.mitxonline` (until the
+regression in `tk-investigate-…-e12759` is fixed) and nothing else. `api.learn.mit.edu`
+at 1.09% will sit just above the slow threshold — decide then whether to raise the slow
+threshold to 2% or accept it as a genuine signal (304,860 absolute 502s over 30 days
+argues it is genuine).
+
+Promote to `severity: critical` only after a clean review.
+
+### Explicitly out of scope for now
+
+True Google-style multi-window burn-rate alerting needs an explicit SLO target per host
+and recording rules to make 6h/3d windows cheap. Neither exists. The two-threshold form
+above delivers the coverage; revisit burn-rate proper once host tiers are defined.
+
+---
+
+## W5 — Reclaim the latency signal and fix the SM rules
+
+**5a. `HTTPRequestDurationTooHighAvg [5m]`** fired 1,168×/30d into oblivion, currently
+reporting `api.learn.mit.edu/learn/health` at 4,141 ms. It has `for: 0s` and no
+`severity`. Give it `for_="10m"` and `severity: warning` (non-paging after W2b), then
+re-measure for two weeks before considering critical. Do not delete it.
+
+Also: a 4.1-second health endpoint on the highest-traffic host in the estate is worth a
+separate investigation task regardless of the alerting outcome.
+
+**5b. Synthetic Monitoring rules — production only** (§0.7c; QA has no SM folder).
+Folder `grafana-synthetic-monitoring-app` holds **6** rules, hand-created in the UI and
+invisible to Pulumi. **3** bypass the notification policy via
+`notification_settings.receiver: "Rootly"` (the UI-created duplicate, uid
+`eel3rjpiwahoge`, distinct from Pulumi's `rootly`, uid `bfsoqo63lsyrka`): `Learn API
+Health Endpoint`, `Learn NextJS Homepage (Bypass Fastly)`, `Learn Homepage`. The other 3
+carry no override and no severity, so they drop to `oblivion` — decide whether they are
+worth keeping at all.
+
+`alerting.RuleGroupRuleArgs` accepts `notification_settings`, so these can be adopted
+into Pulumi as-is. Do that, then fix the two substantive defects:
+
+- `avg_over_time(probe_success[5m]) < 1` pages on any single failed probe out of five
+  (observed firing at 0.8). Change to `< 0.6`.
+- The `summary` annotation on `Learn NextJS Homepage (Bypass Fastly) - Check Failed`
+  reads "response times 30% Greater Than Normal" while the query measures availability.
+  Rewrite it to describe what fired.
+
+Once the SM rules point at Pulumi's `rootly`, delete the duplicate `Rootly`
+(`eel3rjpiwahoge`) and the two stale OpsGenie contact points (`OpsGenie` `U4nPIcO7z`,
+`OpsGenie Ops Team` `-1rdMF27z`). All three are production-only — QA is already clean.
+
+---
+
+## W6 — Rootly `noise` classification
+
+All 1,449 alerts are `noise: not_noise` because nobody has ever set the field. Start
+classifying during triage. This produces the data for the next tuning round and is a
+prerequisite for Rootly's own grouping/suppression being useful. No engineering work;
+it is a triage-habit change.
+
+Re-run the analysis's measurement queries (its Appendix) 30 days after W3 lands to get a
+clean before/after.
+
+---
+
+## W7 — ML pilot
+
+**Gated on W0-W4 landing and a 30-day clean measurement.** Unchanged from the analysis's
+step 6, with its caveat intact and now sharpened by §0.6: an anomaly model trained on
+`courses-backend` learns three-requests-a-day as normal, and one trained on
+`api.mitxonline` at 18% learns 18% as normal. ML answers "did this change?", never "is
+this acceptable?" It supplements W4's absolute-level SLO alerting; it never replaces it.
+
+Scope when it starts: 2-3 forecast jobs, Slack only, 30 days, measured against known
+incidents. The 944-firing `adaptive_traces_forecast_learn_webapp` job is the control
+group for what skipping that step produces.
+
+Cost is unquantified. `CLAUDE.md` records Synthetic Monitoring being rejected at
+~$3,200/mo; get a quote against the current contract before committing.
+
+---
+
+## Open decisions
+
+1. **W2b mechanism.** Does a Rootly deferral path with an urgency rule and no
+   `deferral_window` hold indefinitely, or must it carry an all-day/seven-day window?
+   Blocks W4's calibration mode. Verify against the API before building on it.
+2. **W3b grouping label.** Accept namespace-level grouping for the OOM/crashloop route,
+   or add the `kube_pod_owner` join to carry `deployment` through? Recommendation:
+   accept namespace-level now; the observed storm was one deployment in one namespace.
+3. **W4 slow threshold vs `api.learn.mit.edu`.** 1.09% sits just above a 1% slow
+   threshold on the largest host in the estate. Decide at the two-week review with real
+   firing data rather than pre-emptively.
+4. **W0 enforcement.** Given `pulumi_rootly` cannot manage per-rule `enabled`, where
+   does the assertion live — a scheduled check, or accepted as unenforced with a
+   comment? Recommendation: a scheduled check; this defect was invisible for 16 days.
+5. **`exec_err_state` policy per severity tier.** Setting it explicitly is not in
+   dispute (§0.11); what to set it *to* is. `"OK"` silences a class of genuine
+   breakage — a rule that cannot evaluate is not a healthy rule — so blanket `"OK"`
+   trades a paging bug for a blind spot. Suggested split: `"OK"` for the CI/QA-filtered
+   warning tier, `"KeepLast"` for production criticals, plus one deliberate
+   `DatasourceError`-style rule so evaluation failure is still visible somewhere. Needs
+   a decision before W3 touches the rule bodies.
+
+---
+
+## Task mapping
+
+| Task slug | Workstreams |
+|---|---|
+| `tk-delete-the-orphaned-cortextool-era-ruler-rules-a-3ffc34` | W1 |
+| `tk-make-severity-mean-something-split-warning-criti-27f976` | **W0**, W2 |
+| `tk-fix-the-four-rules-that-produce-92-of-all-grafan-02e7f0` | W3 |
+| `tk-add-apisix-edge-burn-rate-slo-alerting-the-bigge-db03d1` | W4 |
+| `tk-reclaim-the-discarded-latency-signal-and-fix-the-2c97ee` | W5 |
+| `tk-start-classifying-rootly-alerts-with-the-noise-f-a1bd16` | W6 |
+| `tk-pilot-grafana-cloud-ml-narrowly-2-3-jobs-slack-o-15ab98` | W7 |
+| `tk-investigate-the-api-mitxonline-mit-edu-5xx-regre-e12759` | independent — see §0.6 (all HTTP 500, not 502) |
+
+W0 did not exist as a task before this spec and belongs at the front of
+`tk-make-severity-mean-something-…`, whose current description assumes CI/QA→Rootly
+routing that was already meant to be gone.

--- a/docs/plans/rootly-label-routing-implementation-spec.md
+++ b/docs/plans/rootly-label-routing-implementation-spec.md
@@ -1,0 +1,681 @@
+# Connecting the `ol.mit.edu` label hierarchy to Rootly — implementation spec
+
+**Date:** 2026-08-17
+**Supersedes** §7 (proposed scheme), §8 (recommended sequence) and §9 (open questions)
+of [rootly-labeling-and-alert-routing-analysis.md](rootly-labeling-and-alert-routing-analysis.md).
+The analysis's *measurements* stand except where §0 below corrects them; its
+*recommendations* are replaced by this document.
+
+Every claim in §0 was verified against live state on 2026-08-17: the production
+Mimir tenant, the production Grafana provisioning API, the Rootly API, the
+`k8s-monitoring` chart 4.4.0 sources and JSON schema, and the repo at `f44406fa8`.
+
+**Companion document.** [grafana-alerting-remediation-spec.md](grafana-alerting-remediation-spec.md)
+(2026-08-07) owns the alert-rule-quality and Rootly-hygiene workstreams W0–W7. This
+spec covers all three phases of the label project, so §2 restates the Phase 1 items
+that overlap W0/W2 — but as *status and prerequisites*, deferring the implementation
+detail to that spec. Where the two disagree about a Rootly object, that spec wins on
+W0–W2 and this one wins on anything touching a label.
+
+---
+
+## 0. Re-baseline: what changed, and three findings that change the plan
+
+### 0.1 Phase 1 is mostly done. The label blockers are untouched.
+
+| Analysis finding | Status on 2026-08-17 |
+|---|---|
+| §5.6 six routes UI-managed, ~51 rules unmanaged | **Closed.** PR #5218 adopted the Service Routes; all **12** routes are now `rootly.AlertRoute` resources in `saas/rootly/__main__.py`, `sh-test` included |
+| §5.2 QA/CI Slack diversion inert | **Open.** Both fallback rules still `enabled: false`; `pulumi_rootly`'s `AlertRouteRuleArgs` has no `enabled` field, so this is unmanageable from Pulumi (remediation spec W0) |
+| §5.2 Low urgency pages like High | **Closed.** PR #5354 added `escalation_path_defer_low_urgency_off_hours` (`__main__.py:729`); PR #5377 added `escalation_path_medium_urgency_slack_only` (`:758`) routing Medium and Low to `#devops-warnings` |
+| §5.7 `Cloudwatch - Critical` `setup_incomplete` | **Open.** Still `setup_incomplete` live |
+| §5.7 `exampleDeleteMe-EscalationPolicy` | **Open.** Still declared at `__main__.py:538` |
+| §4.4 11-entry alertname demotion allowlist | **Unchanged.** All 12 urgency rules present on source `90cda8ea`, created 2026-07-20, none since |
+| §1 kube-state-metrics exports no labels | **Unchanged.** `clusterMetrics` and `telemetryServices["kube-state-metrics"]` in `substructure/aws/eks/grafana.py:379,501` carry no label configuration |
+| §3.2 schema defects | **Unchanged.** `Component` still four members; `product`/`application`/`component` still only on `K8sAppLabels`; `Services.learn_ai` still a tuple; `BusinessUnit.residential_staging` still present |
+
+Live re-verification of the core blocker, production Mimir:
+
+```
+count(kube_pod_labels) or vector(-1)                        →  -1
+__name__ values matching kube_(pod|deployment|statefulset|namespace)_(labels|info|annotations|owner)
+                                                            →  ["kube_pod_info", "kube_pod_owner"]
+```
+
+`kube_pod_info` and `kube_pod_owner` are present, so kube-state-metrics *is* being
+scraped. The `*_labels` metrics are absent entirely. That distinction is the finding
+in §0.2.
+
+### 0.2 [New] There are **two** independent gates, not one — and the analysis only found the first
+
+kube-state-metrics emits `kube_pod_labels` / `kube_deployment_labels` /
+`kube_statefulset_labels` unconditionally; `--metric-labels-allowlist` controls only
+which `label_*` *columns* those series carry, not whether the series exist. Their
+total absence from Mimir therefore cannot be explained by the missing allowlist.
+
+The second gate is the chart's own scrape filter. In `k8s-monitoring` 4.4.0,
+`clusterMetrics.kube-state-metrics.metricsTuning.useDefaultAllowList` defaults to
+`true` (`charts/feature-cluster-metrics/values.yaml:676`), and the default allow-list
+(`charts/feature-cluster-metrics/default-allow-lists/kube-state-metrics.yaml`)
+contains exactly one `*_labels` metric:
+
+```
+kube_persistentvolumeclaim_labels
+```
+
+No `kube_pod_labels`, no `kube_deployment_labels`, no `kube_statefulset_labels`,
+no `kube_daemonset_labels`. Alloy drops them post-scrape, before remote_write.
+
+**Consequence:** the analysis's §7.3 Option A, applied as written, produces
+kube-state-metrics series carrying `label_ol_mit_edu_*` columns that Alloy then
+throws away. The Mimir tenant would look exactly as it does today and the PromQL
+joins would still drop every series. Both of these are required:
+
+| Gate | Where | Effect if omitted |
+|---|---|---|
+| `metricLabelsAllowlist` | `telemetryServices["kube-state-metrics"]` | series exist, carry no `label_ol_mit_edu_*` columns; `group_left` adds nothing |
+| `metricsTuning.includeMetrics` | `clusterMetrics["kube-state-metrics"]` | series never reach Mimir; `group_left` drops every row |
+
+### 0.3 [New] The §7.3 code sketch has the wrong values path, and would silently no-op
+
+The analysis proposed:
+
+```python
+"telemetryServices": {
+    "kube-state-metrics": {
+        "deploy": True,
+        "kube-state-metrics": {          # <-- extra nesting level
+            "metricLabelsAllowlist": [...],
+        },
+    },
+}
+```
+
+`charts/telemetry-services/values.schema.json` defines
+`properties["kube-state-metrics"]` with exactly these properties: `autosharding`,
+`deploy`, `metricLabelsAllowlist`, `nodeSelector`, `podAnnotations`,
+`prometheusScrape`, `releaseLabel`, `updateStrategy`. `metricLabelsAllowlist` is a
+**flat array of strings** one level down, not nested under a repeated key. The schema
+does not set `additionalProperties: false`, so the extra level is **silently
+ignored** — no Helm error, no Pulumi diff signal, and the value never reaches the
+kube-state-metrics Deployment's `--metric-labels-allowlist` flag.
+
+**Second trap in the same value.** The chart already ships a non-empty default:
+
+```yaml
+metricLabelsAllowlist:
+  - nodes=[agentpool,alpha.eksctl.io/cluster-name,...,topology.kubernetes.io/zone]
+```
+
+Helm replaces lists rather than merging them. Supplying only `pods=[...]` silently
+drops 20 node labels that the Grafana Cloud Kubernetes integration's node views
+depend on. The `nodes=[...]` entry must be carried forward verbatim.
+
+### 0.4 Q4 resolved: the `Grafana` source is live. The three dead rules are dead for a different reason.
+
+Analysis Q4 asked what still delivers to alert source `f4d836c0`
+(`source_type: "grafana"`). Answer, from the production provisioning API:
+
+```
+contact point "Rootly"  uid eel3rjpiwahoge
+  url = https://webhooks.rootly.com/webhooks/incoming/grafana_webhooks?secret=09f9d82f…
+```
+
+That secret is byte-identical to alert source `f4d836c0`'s `secret`. The source is
+fed by the three Synthetic Monitoring rules that set
+`notification_settings.receiver: "Rootly"` (remediation spec §0.7c) — the
+UI-created duplicate contact point, distinct from Pulumi's `rootly`
+(`bfsoqo63lsyrka`, the `alertmanager_webhooks` endpoint).
+
+So the "Grafana Service Route" is **not** an orphan route to be deleted. But its five
+rules are still unreachable, and the reason matters for Phase 3:
+
+- Its only traffic is Synthetic Monitoring probe alerts, which carry neither
+  `commonLabels.service` nor `commonLabels.component`.
+- The EKS metric alerts that *will* carry a `component` label after Phase 3 arrive at
+  the three `alertmanager`-type sources, never at `f4d836c0`.
+
+**Therefore the three `component`-matching rules must be *moved* to the Grafana
+Production Service Route (bound to source `90cda8ea`), not repaired in place.**
+Repairing them where they sit — which is what analysis §8 step 3 implies — leaves
+them dead forever. Correcting analysis §5.5, which speculated the route might be
+entirely dead and removable: it is live, and removing it would break nothing today
+but would remove the only route the SM alerts can match.
+
+### 0.5 [New] The join target differs per rule, and two rule pairs cannot be joined at all
+
+`metric_rules/eks_general.py` holds **20** rules (10 warning/critical pairs), and they
+do not all aggregate at pod granularity. The join target follows the aggregation key:
+
+| Rule pair | `sum by (…)` key | Join against | Feasible? |
+|---|---|---|---|
+| `PodOOMKilled*`, `PodCrashLooping*` | `cluster, namespace, pod, container` | `kube_pod_labels` | yes |
+| `CeleryBeatPodRestarts*` | pod-level (`increase(...)`) | `kube_pod_labels` | yes |
+| `DeploymentReplicasMissing*`, `DeploymentUnavailable*` | `cluster, namespace, deployment` | `kube_deployment_labels` | yes |
+| `StatefulSetReplicasMissing*` | `cluster, namespace, statefulset` | `kube_statefulset_labels` | yes |
+| `DaemonsetReplicasMissing*` | `cluster, namespace, daemonset` | `kube_daemonset_labels` | yes |
+| `KubernetesJobFailed*` | `cluster, namespace, job_name` | `kube_job_labels` | yes, but Job labels are set by the launching controller |
+| `HPAAtMaxReplicas*` | `cluster, namespace, horizontalpodautoscaler` | — | **no** |
+| `NodeNotReady*` | `cluster, node` | — | **no** (not a workload) |
+
+`HPAAtMaxReplicas*` is the important negative. The HPAs are created by KEDA
+(`keda-hpa-<scaledobject>`), so they carry KEDA's labels, not ours, and
+`kube_horizontalpodautoscaler_labels` would not contain `label_ol_mit_edu_*` no
+matter what is allowlisted. The `scaleTargetRef` that would bridge HPA → Deployment
+is not exposed as a metric. Deriving the workload by string-stripping the
+`keda-hpa-` prefix is the only join available and it is exactly the kind of
+name-substring coupling this project exists to remove.
+
+**Decision (§1.5):** `HPAAtMaxReplicas*` and `NodeNotReady*` are out of scope for
+tier-based urgency. HPA-at-max moves off the paging path wholesale via remediation
+spec W3c; `NodeNotReady` stays a node-level page.
+
+So Phase 3 rewrites **16 of 20** rules, not "the 18 EKS rules" as §8 step 11 said,
+and needs **five** allowlisted resource kinds, not three.
+
+### 0.6 [New] Cardinality: sized, and one cluster dominates
+
+Production pod counts, live:
+
+| Cluster | Pods |
+|---|---:|
+| `data-production` | **2,004** |
+| `applications-production` | 363 |
+| `residential-production` | 124 |
+| `operations-production` | 115 |
+| **Total** | **2,606** |
+
+`kube_pod_labels` is one series per pod, so allowlisting `pods` adds ~2,600 active
+series — a modest delta against `kube_pod_info`/`kube_pod_owner`, which already exist
+at that same cardinality. The real cost is **churn**, not count: `data-production`'s
+2,004 pods are overwhelmingly Dagster job pods, which mint a new pod name per run.
+Every new pod name is a new `kube_pod_labels` series.
+
+Workload-level series are cheap and stable by comparison — 262 Deployments/
+StatefulSets/DaemonSets across the three clusters the analysis surveyed.
+
+**Decision (§1.6):** allowlist `deployments`, `statefulsets`, `daemonsets` (stable,
+~262 series) plus `pods` (needed for the OOM/crashloop pair, which is 70% of alert
+volume), and exclude the `dagster` namespace from the pod-level series via
+`extraMetricProcessingRules` so the churn is not paid for. Dagster job pods are
+already excluded from `KubernetesJobFailed*` in PromQL (`namespace!="dagster"`) and
+are tiered `ticket`, so no signal is lost.
+
+### 0.7 [New] Making `Component` strict breaks 3 of its 5 live call sites
+
+`component` is set at exactly five places in `src/`, with these values:
+
+```
+"webapp"    ← in Component
+"frontend"  ← in Component
+"api"       ← NOT in Component
+"nextjs"    ← NOT in Component
+pgbouncer   ← NOT in Component (bare identifier, a local variable)
+```
+
+The `Component | str | None` type is what permits this. Dropping `| str` without
+first extending the enum is a three-site breakage, and `pgbouncer` is a value nobody
+proposed adding. This makes the ordering in §3.2 mandatory: extend the enum, migrate
+call sites, *then* tighten the type — three commits, not one.
+
+---
+
+## 1. Decisions
+
+Recorded here so they stop being open questions. Q2 was resolved 2026-07-30 (analysis
+§8.1) and is unchanged.
+
+**1.1 Q1 — CI alerts keep reaching Rootly.** Do not drop them to `oblivion` in the CI
+Grafana stack's notification policy. Rationale: `setup_grafana()` returns early for CI
+(`grafana.py`), so CI clusters ship no metrics and the CI rules evaluate to `NoData` —
+the remediation spec measured 219 `Normal (NoData)` states and **zero** genuine
+`Alerting` states in 30 days. The hazard is not volume, it is the CI source's default
+urgency of **High**, which is a live trap if CI monitoring is ever enabled. Fix the
+urgency (remediation spec W2a: High → Low) and keep the delivery path visible in
+Rootly where it can be audited, rather than hiding it behind a Grafana-side drop.
+Corollary: the `ci` half of every `cluster=~".*-(ci|qa)"` filter in `eks_general.py`
+is dead and should be left alone rather than "fixed" — it costs nothing and documents
+intent.
+
+**1.2 Q3 — stateful services stay at `notify`** *(tmacey, 2026-08-17)*. The demotion of
+`StatefulSetReplicasMissingCritical` was deliberate, not collateral. MySQL, MongoDB,
+OpenSearch, Qdrant, ClickHouse and StarRocks are tiered `notify`, preserving today's
+behaviour but expressing it per-workload instead of per-alertname.
+
+*This materially shrinks Phase 3's headline benefit and the spec says so plainly.*
+Analysis §7.5 projected escalating stateful and ingress workloads back to `page`; with
+stateful staying at `notify`, the only escalation left is ingress/APISIX and webapp
+OOMs. Phase 3's net paging-volume delta is close to zero. What it still buys:
+
+1. **Removes the hand-maintained allowlist** (analysis G5). Eleven alertnames in
+   Rootly conceptually coupled to `eks_general.py`, where adding a rule in one place
+   silently defaults to High in the other.
+2. **Fixes §5.4.** `mitx-staging-ts-sts` in `residential-production` receives Critical
+   severity because its *cluster name* ends in `-production`. A declared
+   `ol.mit.edu/environment` fixes this; nothing else can.
+3. **Reaches the 19 orphaned Rootly services** (analysis §5.3), every Celery service
+   among them, which no routing rule can currently target.
+4. **Makes per-workload exceptions a manifest edit** rather than a Rootly UI edit, and
+   gives the "this workload is expected to OOM" intent (analysis G2) somewhere to live
+   other than a code comment.
+
+If the goal were paging volume alone, Phase 1's W0 is where that win is — up to
+621 alerts/30d — and Phase 3 would not be worth its cost. The justification for
+Phase 3 is routing precision and maintainability.
+
+**1.3 Q5 — keep `BusinessUnit` and `Product`, with distinct jobs.** `ou` remains the
+cost-allocation axis (already required on every AWS resource via `AWSBase`); `product`
+becomes the alerting/ownership roll-up that maps onto the Rootly service catalog,
+which is named by product. No enum collapse. One fix: drop
+`BusinessUnit.residential_staging` (analysis §3.2e) — staging is an environment, and
+having it in `BusinessUnit` splits one OU's cost roll-up in two.
+
+**1.4 Q6 — central backfill by the infrastructure team, plus a CI gate.** Infra owns
+most of the 205 unlabeled workloads anyway (`operations-production` 97% unlabeled,
+`data-production` 96%), and coordinating with application teams for the remaining
+`applications-production` gap would add latency to the long pole. A pre-commit/CI
+check then fails any new K8s workload constructed without the required labels, so the
+gap cannot reopen. Phase 2 is weeks, not quarters.
+
+**1.5 Join scope** (from §0.5). Tier-based urgency covers 16 of the 20
+`eks_general.py` rules. `HPAAtMaxReplicas*` is excluded — no joinable label exists on
+a KEDA-created HPA — and moves off the paging path via remediation spec W3c.
+`NodeNotReady*` is excluded as a node-level, not workload-level, condition.
+
+**1.6 Series scope** (from §0.6). Allowlist `pods`, `deployments`, `statefulsets`,
+`daemonsets`, `jobs`. Exclude the `dagster` namespace from pod-level label series to
+avoid paying for Dagster's job-pod churn.
+
+**1.7 Label rename at the rule boundary.** Alert rules emit a clean `alert_tier` /
+`ol_component` / `ol_service` / `ol_environment` label rather than surfacing
+`label_ol_mit_edu_alert_tier` into Rootly. `label_replace()` in the rule expression
+does this, so Rootly conditions read `$.commonLabels.alert_tier` and stay legible.
+The `label_ol_mit_edu_*` form only ever appears inside PromQL.
+
+---
+
+## 2. Phase 1 — status and the four items that remain
+
+Implementation detail for W0 and W2 lives in the remediation spec; this section exists
+so the label project has one accurate status view and so the Phase 3 prerequisites are
+explicit.
+
+| # | Item | Owner | Status |
+|---|---|---|---|
+| 1 | Enable the two disabled CI/QA route fallback rules (route `691913ad` rule `1e552e8f`; route `588edbfc` rule `53e8784f`) | remediation W0 | **open** — UI-only; `AlertRouteRuleArgs` has no `enabled` field |
+| 1a | CI source default urgency High → Low (`__main__.py:3013`) | remediation W2a | **open** |
+| 1b | `QA Non-Paging Escalation Policy` (`d63b7456`) has one service and zero levels — those CloudWatch alarms notify nobody | this project | **open** — delete the policy and move `MITx Online QA - Open edX - Redis` onto `CI/QA Slack Notifications` |
+| 1c | Account-wide "default alerts channel" toggle posts every alert to `#devops-alerts` regardless of routing (`__main__.py:513-521`) | this project | **open** — until this is off, the CI/QA separation has no observable effect |
+| 2 | Delete `exampleDeleteMe-EscalationPolicy` (`__main__.py:538`); finish `Cloudwatch - Critical` source setup | this project | **open** |
+| 3 | Three dead `component` rules in the Grafana Service Route | this project | **re-specified** — *move* to the Grafana Production Service Route (§0.4), do not repair in place; sequence with Phase 3 step 13, since they only become live once `component` is emitted |
+| 4 | Import the six unmanaged alert routes | — | **closed** by PR #5218 |
+| 5 | Low urgency pages like High | — | **closed** by PRs #5354, #5377 |
+
+**Prerequisite relation to Phase 3:** none of Phase 3 depends on Phase 1. Item 1c is a
+prerequisite for *observing* whether any routing change worked, so it should land
+before Phase 3's verification step, not before its implementation.
+
+---
+
+## 3. Phase 2 — schema and coverage
+
+### 3.1 Schema changes, in dependency order
+
+Three commits, because §0.7 makes the ordering load-bearing.
+
+**Commit A — extend `Component`, keep the permissive type.**
+
+```python
+@unique
+class Component(StrEnum):
+    """Functional role of a workload within its service.
+
+    The discriminator for paging decisions: a Celery worker and a Postgres
+    StatefulSet fail differently and should not share an alert tier.
+    """
+
+    api = "api"
+    beat = "beat"
+    cache = "cache"
+    celery = "celery"
+    database = "database"
+    frontend = "frontend"
+    gateway = "gateway"
+    ingress = "ingress"
+    keycloak = "keycloak"
+    nextjs = "nextjs"
+    pgbouncer = "pgbouncer"
+    queue = "queue"
+    search = "search"
+    webapp = "webapp"
+    worker = "worker"
+```
+
+`api`, `nextjs` and `pgbouncer` are present because they are already in use (§0.7).
+`gateway` and `queue` are added for APISIX/Traefik and RabbitMQ/Redis-as-broker,
+which have no current member and are exactly the wide-blast-radius workloads in
+`operations-production`.
+
+**Commit B — add `alert_tier`, and move the roll-up fields into the base class.**
+
+```python
+@unique
+class AlertTier(StrEnum):
+    """Paging eligibility for alerts about this workload."""
+
+    page = "page"      # wake someone: user-facing or data-integrity impact
+    notify = "notify"  # business-hours attention: degraded, self-healing, or redundant
+    ticket = "ticket"  # record only, never notifies
+
+
+class K8sGlobalLabels(BaseModel):
+    ou: BusinessUnit
+    service: Services
+    stack: StackInfo
+    # Moved down from K8sAppLabels: a base-class-labeled resource must still be
+    # rollable-up to a product, and 26 of the 40 label call sites use this class.
+    product: Product | None = None
+    application: Application | None = None
+    component: Component | str | None = None
+    alert_tier: AlertTier | None = None
+    # Overrides the value derived from stack.env_suffix in model_dump. A workload
+    # whose logical environment differs from its cluster's -- mitx-staging-* in
+    # residential-production -- must be able to say so; today it silently inherits
+    # the cluster's answer and is treated as production. See analysis section 5.4.
+    environment: Environment | str | None = None
+```
+
+`model_dump` changes one line: `ol.mit.edu/environment` becomes
+`self.environment or self.stack.env_suffix`. Every existing call site is unaffected —
+all four new fields default to `None` and `exclude_none=True` already drops them.
+
+`K8sAppLabels` keeps `pod_security_group`, `source_repository`, `commit_sha`,
+`release_tag` and re-declares `product`, `application` and `source_repository` as
+required, so it stays the stricter contract it is today.
+
+**Commit C — tighten the types, after the call sites are migrated.** `component:
+Component | None`, dropping `| str`. Requires Commit A plus the `pgbouncer` call site
+converted from a bare identifier to `Component.pgbouncer`.
+
+### 3.2 Enum hygiene, same phase
+
+- `Services.learn_ai = ("learn-ai",)` → `"learn-ai"` (analysis §3.2d). Harmless today
+  because `StrEnum` splats the tuple, which is precisely why it should be fixed before
+  anyone relies on the enum base.
+- Drop `BusinessUnit.residential_staging` (§1.3). Audit `AWSBase` callers tagging
+  `OU=residential-staging` first; they move to `residential` with the environment
+  carried by the `Environment` tag.
+- Remove `Services.open_edx` **or** `Services.openedx` — having both as distinct
+  members is a coin-flip for anyone labeling an Open edX workload (analysis §3.2c).
+- Do **not** reconcile `Services` against `Application` wholesale. §1.3 keeps them as
+  separate axes; the drift the analysis catalogued matters only if one is derived from
+  the other, which is no longer proposed. Add a class-level docstring to each stating
+  what it is for, so the next reader does not re-derive the question.
+
+### 3.3 Coverage backfill (the long pole)
+
+Order by blast radius, not by count:
+
+1. **`operations-production`** — 59 workloads, 57 unlabeled. APISIX, cert-manager and
+   the shared ingress live here; these are the widest-blast-radius workloads in the
+   estate and the worst-covered. Tier `page`, `component` = `gateway`/`ingress`.
+2. **`data-production`** — 91 workloads, 87 unlabeled. Mostly Dagster and pipeline
+   workloads; tier `ticket` or `notify`. High count, low paging stake.
+3. **`applications-production`** — 61 of 112 unlabeled. Highest paging stake per
+   workload; the 51 already labeled need `alert_tier` and `component` added, not
+   labels from scratch.
+
+Also backfill CI/QA clusters, which the analysis explicitly did not measure. Coverage
+there does not affect paging (CI/QA alerts go Slack-only per §8.1) but an unlabeled QA
+workload makes the join drop the series, so a rule that works in production silently
+returns nothing in QA — which is how a Phase 3 regression would hide.
+
+### 3.4 The CI gate
+
+A `pytest` check (not a `pre-commit` hook — it needs to import the label classes) that
+walks every `K8sGlobalLabels(...)` / `K8sAppLabels(...)` construction reachable from
+`src/ol_infrastructure/applications/` and asserts `component` and `alert_tier` are
+set. Fails the build on a new workload without them.
+
+Gate on an explicit allowlist of currently-unlabeled construction sites that shrinks
+as §3.3 lands, rather than a flag day: the check goes in green on day one and the
+allowlist is the backfill's progress bar.
+
+### 3.5 Acceptance criteria
+
+- `kubectl` inventory of the three production clusters shows ≥ 95% of
+  Deployments/StatefulSets/DaemonSets carrying `ol.mit.edu/service`,
+  `ol.mit.edu/component` and `ol.mit.edu/alert_tier`.
+- 100% for `operations-production`.
+- The CI gate's allowlist is empty.
+- `mypy` clean after Commit C, which is what proves the `| str` escape hatch is gone.
+
+---
+
+## 4. Phase 3 — wiring labels into alerting
+
+**Hard prerequisite: §3.5 met.** The `group_left` join drops any series whose join
+partner is missing, so an unlabeled workload does not degrade to "no tier" — it
+degrades to **no alert at all**. Shipping Phase 3 at today's 22% coverage would
+silence 78% of EKS alerting. This is the single largest risk in the project.
+
+### 4.1 kube-state-metrics: both gates (§0.2, §0.3)
+
+In `substructure/aws/eks/grafana.py`:
+
+```python
+# Gate 1 of 2: make kube-state-metrics attach our labels as label_* columns.
+# The chart's default value here is NOT empty -- it carries a nodes=[...] entry
+# that the Grafana Cloud Kubernetes integration's node views depend on, and Helm
+# replaces lists rather than merging them. Carry it forward verbatim.
+# Note the flat shape: telemetryServices["kube-state-metrics"]["metricLabelsAllowlist"].
+# The schema has no nested "kube-state-metrics" key and does not set
+# additionalProperties: false, so an extra level is silently ignored.
+"telemetryServices": {
+    "kube-state-metrics": {
+        "deploy": True,
+        "metricLabelsAllowlist": [
+            _KSM_CHART_DEFAULT_NODE_LABELS,  # verbatim from chart 4.4.0 values.yaml
+            f"pods=[{_OL_LABEL_KEYS}]",
+            f"deployments=[{_OL_LABEL_KEYS}]",
+            f"statefulsets=[{_OL_LABEL_KEYS}]",
+            f"daemonsets=[{_OL_LABEL_KEYS}]",
+            f"jobs=[{_OL_LABEL_KEYS}]",
+        ],
+    },
+    ...
+},
+
+# Gate 2 of 2: the chart's default kube-state-metrics allow-list contains exactly
+# one *_labels metric (kube_persistentvolumeclaim_labels), so without this Alloy
+# drops every series above post-scrape and Mimir looks exactly as it does today.
+"clusterMetrics": {
+    "enabled": True,
+    "collector": "alloy-metrics",
+    "kube-state-metrics": {
+        "metricsTuning": {
+            "includeMetrics": [
+                "kube_pod_labels",
+                "kube_deployment_labels",
+                "kube_statefulset_labels",
+                "kube_daemonset_labels",
+                "kube_job_labels",
+            ],
+        },
+        # Dagster mints a pod name per job run, so pod-level label series churn
+        # hard in data-production (2,004 of the estate's 2,606 production pods).
+        # Those pods are tiered `ticket` and already excluded from
+        # KubernetesJobFailed* in PromQL, so nothing is lost by not paying for them.
+        "extraMetricProcessingRules": textwrap.dedent("""
+            rule {
+              source_labels = ["__name__", "namespace"]
+              separator     = "@"
+              regex         = "kube_pod_labels@dagster"
+              action        = "drop"
+            }
+        """),
+    },
+},
+```
+
+where `_OL_LABEL_KEYS = "ol.mit.edu/service,ol.mit.edu/component,ol.mit.edu/alert_tier,ol.mit.edu/environment"`.
+
+**Verification, before touching any alert rule:**
+
+```
+count(kube_pod_labels)                                    → ~600  (2,606 minus dagster)
+count(kube_deployment_labels)                             → >0
+count(kube_pod_labels{label_ol_mit_edu_alert_tier!=""})    → matches §3.5 coverage
+count(kube_node_labels{label_topology_kubernetes_io_zone!=""})  → unchanged from today
+```
+
+That last one is the regression check for the `nodes=[...]` trap in §0.3.
+
+### 4.2 Rewrite the 16 joinable rules
+
+Pattern, using `PodOOMKilledCritical` as the worked example. Gate clause first, per the
+idiom already documented at `eks_general.py:108-116`:
+
+```promql
+label_replace(
+  label_replace(
+    sum by (cluster, namespace, pod, container,
+            label_ol_mit_edu_alert_tier, label_ol_mit_edu_component) (
+      (kube_pod_container_status_last_terminated_reason{cluster=~".*-(production)", reason="OOMKilled"} == 1)
+      * on (cluster, namespace, pod) group_left(label_ol_mit_edu_alert_tier, label_ol_mit_edu_component)
+        kube_pod_labels
+      * on (cluster, namespace, pod, container) group_left()
+        (increase(kube_pod_container_status_restarts_total[1h]) >= 3)
+    ),
+    "alert_tier", "$1", "label_ol_mit_edu_alert_tier", "(.*)"),
+  "ol_component", "$1", "label_ol_mit_edu_component", "(.*)")
+```
+
+Per §1.7 the rule emits `alert_tier` and `ol_component`; `label_ol_mit_edu_*` never
+leaves PromQL.
+
+**Environment (§5.4 fix).** For the four rule pairs that currently encode environment
+by cluster-name regex, join `label_ol_mit_edu_environment` and filter on it instead of
+on `cluster=~`. Keep the cluster filter as well during the transition — it is the
+fallback for any workload that has not declared an environment, and removing it is a
+separate change once §3.5 holds.
+
+**Two rules stay as they are:** `HPAAtMaxReplicas*` (no joinable label, §0.5) and
+`NodeNotReady*` (not a workload).
+
+**Roll out one rule pair at a time**, verifying firing counts before and after. A
+`group_left` that drops rows produces silence, and silence is the failure mode this
+whole project is meant to remove.
+
+### 4.3 Alertmanager grouping
+
+`alertmanager.py:123-138` groups on 14 labels including `application`, which the
+analysis noted is only ever present on Loki-sourced alerts. Add `alert_tier` and
+`ol_component` to `group_bies` once §4.2 emits them, and delete `application` if it is
+still never set on a metric alert at that point. Coordinate with remediation spec W3b,
+which adds a per-route grouping override for the OOM/crashloop pair — that override's
+`group_bies` needs the same two labels or it will re-bundle across tiers.
+
+### 4.4 Rootly: replace the allowlist with two urgency rules
+
+On the **Production** source (`90cda8ea`, `__main__.py:3032-3076`), replace all 12
+`alert_source_urgency_rules_attributes` entries with:
+
+| Pos | Condition | → Urgency |
+|---|---|---|
+| 1 | `$.commonLabels.alert_tier is "ticket"` | Low |
+| 2 | `$.commonLabels.alert_tier is "notify"` | Medium |
+| 3 | `$.commonLabels.severity is "warning"` | Low |
+| — | default | High |
+
+Position 3 is retained deliberately: it catches every alert that carries no
+`alert_tier` — Loki/log rules, `linux_host.py`, the `GrafanaCloud` folder's
+`GrafanaMetricCount`, and any EKS rule not yet rewritten. Removing it would make an
+untier-ed warning page.
+
+`DiskUsageCritical` (position 2 today, an `alert_field` rule on Title rather than a
+payload rule) also has no `alert_tier` — it is a `linux_host.py` rule about EC2
+instances, not a K8s workload. Keep it, as a fourth rule.
+
+**Do not add an environment-based urgency rule.** Per analysis §8.1, non-production is
+a routing-destination concern (Slack-only escalation policy), not an urgency concern,
+and the CI/QA sources are separate objects from the Production source anyway.
+
+The existing `escalation_path_defer_medium_urgency_off_hours` (`:691`),
+`escalation_path_defer_low_urgency_off_hours` (`:729`) and
+`escalation_path_medium_urgency_slack_only` (`:758`) all continue to work unchanged,
+and now defer and divert per-workload rather than per-alertname.
+
+### 4.5 Rootly: component routing for the 19 orphaned services
+
+Add rules to the **Grafana Production Service Route** (bound to `90cda8ea`) of the form
+`namespace contains "<ns>"` AND `$.commonLabels.ol_component is "<component>"` →
+`<Service>`. Every Celery service becomes reachable this way. Move the three dead
+`component` rules here from the Grafana Service Route (§0.4) as part of the same change.
+
+Ordering caution, unchanged from analysis §4.3: conditions are `contains`, so the
+narrow rules must precede the broad ones. Now that all 12 routes are in Pulumi
+(#5218), rule position is reviewable in a diff — which is the first time this
+hand-maintained invariant has been visible at all.
+
+### 4.6 Acceptance criteria
+
+- `count(kube_pod_labels{label_ol_mit_edu_alert_tier!=""})` ≥ 95% of non-dagster
+  production pods.
+- Firing counts per rule within ±20% of the pre-change 14-day baseline for the 16
+  rewritten rules. A rule that goes to zero is a dropped join, not a fixed alert.
+- Zero Rootly services with no routing rule targeting them, down from 19.
+- The Production source carries four urgency rules, not twelve.
+- `kube_node_labels` zone/instance-type columns unchanged (§0.3 regression check).
+- A staging workload in `residential-production` receives `notify`, not `page`.
+
+---
+
+## 5. Sequence
+
+| Step | Depends on | Effort |
+|---|---|---|
+| P1.1 Enable the two CI/QA route rules (UI) | — | minutes |
+| P1.2 CI source urgency High → Low | — | small |
+| P1.3 Turn off the account-wide default alerts channel | P1.1 | small |
+| P1.4 Delete `exampleDeleteMe`, fix `QA Non-Paging`, finish `Cloudwatch - Critical` | — | small |
+| P2.A Extend `Component`; enum hygiene | — | small |
+| P2.B Add `AlertTier`; move roll-up fields to base; explicit `environment` | P2.A | small |
+| P2.C Tighten `component` type | P2.B + call-site migration | small |
+| P2.D Backfill `operations-production` | P2.B | medium |
+| P2.E Backfill `data-production`, `applications-production`, CI/QA | P2.B | **long pole** |
+| P2.F CI gate with shrinking allowlist | P2.B | small |
+| P3.A Both kube-state-metrics gates + verification queries | P2.D | small |
+| P3.B Rewrite 16 rules, one pair at a time | P3.A + §3.5 | medium |
+| P3.C Alertmanager `group_bies` | P3.B | small |
+| P3.D Rootly urgency rules: 12 → 4 | P3.B | small |
+| P3.E Component routing for the 19 orphaned services; move the 3 dead rules | P3.B | medium |
+
+P3.A can start once `operations-production` is labeled (P2.D) — the gates are
+cluster-wide and harmless with partial coverage. P3.B cannot start until §3.5 holds.
+
+---
+
+## 6. Still open
+
+1. **`alert_tier` default for unlabeled workloads.** §4.4 position 3 keeps
+   `severity=warning → Low` as the catch-all, which means an unlabeled *critical* EKS
+   alert defaults to High/page. That is the safe direction, but it means the backfill's
+   remaining tail pages at full urgency. Alternative: default the tier to `notify` in
+   `K8sGlobalLabels` rather than `None`. Rejected for now because a `None` tier is
+   visible in the coverage query and a defaulted one is not — but revisit if P2.E
+   stretches.
+2. **`kube_job_labels` provenance.** Job labels are set by whatever launches the Job
+   (Dagster, Celery beat, a CronJob spec), not by our Pulumi programs. Whether
+   `KubernetesJobFailed*` can be tiered at all depends on those launchers propagating
+   the labels; unverified. Treat that rule pair as best-effort until measured.
+3. **QA/CI source default urgency.** Analysis §8.1's open sub-decision — move QA and CI
+   defaults to Low for decoupling from the production Medium band. Remediation spec W2a
+   covers CI; QA is still Medium. Low cost, do it with W2a.
+4. **Cost of the new series.** ~600 pod-level plus ~262 workload-level active series
+   per production cluster set, against a Grafana Cloud contract whose per-series cost
+   is not recorded in this repo. Sized in §0.6 but not priced.
+5. **`exec_err_state`** (remediation spec §0.11, open decision 5). Not this project's
+   change, but it interacts: after §4.2, a rule whose *join* fails evaluates to no data,
+   not to an error, so `no_data_state` governs — worth re-checking the `no_data_state`
+   value on the 16 rewritten rules while editing them.

--- a/docs/plans/rootly-label-routing-implementation-spec.md
+++ b/docs/plans/rootly-label-routing-implementation-spec.md
@@ -13,9 +13,18 @@ Mimir tenant, the production Grafana provisioning API, the Rootly API, the
 **Companion document.** [grafana-alerting-remediation-spec.md](grafana-alerting-remediation-spec.md)
 (2026-08-07) owns the alert-rule-quality and Rootly-hygiene workstreams W0–W7. This
 spec covers all three phases of the label project, so §2 restates the Phase 1 items
-that overlap W0/W2 — but as *status and prerequisites*, deferring the implementation
-detail to that spec. Where the two disagree about a Rootly object, that spec wins on
-W0–W2 and this one wins on anything touching a label.
+that overlap it — but as *status*, deferring the implementation detail to that spec.
+
+Precedence, narrowly: that spec is authoritative for **W0** (enabling the two disabled
+CI/QA route rules) and **W2a** (the CI source's High default urgency), both still open.
+This one is authoritative for anything touching a label. **Its W2b is superseded and
+should not be implemented** — it proposes adding a Low-urgency deferral path on the
+grounds that Low has no non-paging path, which was true on 2026-08-07 and is not now:
+PRs #5354 and #5377 shipped `escalation_path_defer_low_urgency_off_hours` and
+`escalation_path_medium_urgency_slack_only`, giving both bands a Slack-only destination
+(§0.1). Building W2b on top would add a second, redundant path over the same urgency.
+Likewise its §0.7c and W5b describe Synthetic Monitoring receiver overrides that
+PR #5400 has since removed — see §0.4.
 
 ---
 
@@ -43,17 +52,36 @@ __name__ values matching kube_(pod|deployment|statefulset|namespace)_(labels|inf
 ```
 
 `kube_pod_info` and `kube_pod_owner` are present, so kube-state-metrics *is* being
-scraped. The `*_labels` metrics are absent entirely. That distinction is the finding
-in §0.2.
+scraped and reaching Mimir. The `*_labels` metrics are absent entirely.
 
 ### 0.2 [New] There are **two** independent gates, not one — and the analysis only found the first
 
-kube-state-metrics emits `kube_pod_labels` / `kube_deployment_labels` /
-`kube_statefulset_labels` unconditionally; `--metric-labels-allowlist` controls only
-which `label_*` *columns* those series carry, not whether the series exist. Their
-total absence from Mimir therefore cannot be explained by the missing allowlist.
+**Gate 1 — kube-state-metrics emits nothing at all when the allowlist is empty.**
+From the generator, `internal/store/pod.go`:
 
-The second gate is the chart's own scrape filter. In `k8s-monitoring` 4.4.0,
+```go
+func createPodLabelsGenerator(allowLabelsList []string) generator.FamilyGenerator {
+    ... wrapPodFunc(func(p *v1.Pod) *metric.Family {
+        if len(allowLabelsList) == 0 {
+            return &metric.Family{}          // <-- no series for any pod
+        }
+        labelKeys, labelValues := createPrometheusLabelKeysValues("label", p.Labels, allowLabelsList)
+        m := metric.Metric{LabelKeys: labelKeys, LabelValues: labelValues, Value: 1}
+        return &metric.Family{Metrics: []*metric.Metric{&m}}
+    })
+}
+```
+
+So the absence of `kube_pod_labels` from Mimir today is fully explained by the missing
+`--metric-labels-allowlist`, and today's live state tells us nothing about gate 2 either
+way. **Note also the second branch: once the allowlist *is* configured, a series is
+emitted for every pod with `Value: 1`, whether or not that pod carries any allowlisted
+label.** An unlabeled workload therefore gets a join partner with the join keys and no
+`label_ol_mit_edu_*` columns — which is what §4 depends on, and why the coverage gate
+is about routing quality rather than alert availability.
+
+**Gate 2 — the chart drops the metric post-scrape**, independently and verifiably.
+In `k8s-monitoring` 4.4.0,
 `clusterMetrics.kube-state-metrics.metricsTuning.useDefaultAllowList` defaults to
 `true` (`charts/feature-cluster-metrics/values.yaml:676`), and the default allow-list
 (`charts/feature-cluster-metrics/default-allow-lists/kube-state-metrics.yaml`)
@@ -73,8 +101,13 @@ joins would still drop every series. Both of these are required:
 
 | Gate | Where | Effect if omitted |
 |---|---|---|
-| `metricLabelsAllowlist` | `telemetryServices["kube-state-metrics"]` | series exist, carry no `label_ol_mit_edu_*` columns; `group_left` adds nothing |
-| `metricsTuning.includeMetrics` | `clusterMetrics["kube-state-metrics"]` | series never reach Mimir; `group_left` drops every row |
+| `metricLabelsAllowlist` | `telemetryServices["kube-state-metrics"]` | no `kube_*_labels` series produced at all |
+| `metricsTuning.includeMetrics` | `clusterMetrics["kube-state-metrics"]` | series produced but dropped by Alloy before remote_write |
+
+Both failure modes look identical from Mimir — the metric is simply absent — so there
+is no query that distinguishes them from outside. The only way to tell gate 2 is still
+closed is to apply gate 1 and observe that `kube_pod_labels` is *still* missing.
+Apply both together and check once.
 
 ### 0.3 [New] The §7.3 code sketch has the wrong values path, and would silently no-op
 
@@ -111,36 +144,52 @@ Helm replaces lists rather than merging them. Supplying only `pods=[...]` silent
 drops 20 node labels that the Grafana Cloud Kubernetes integration's node views
 depend on. The `nodes=[...]` entry must be carried forward verbatim.
 
-### 0.4 Q4 resolved: the `Grafana` source is live. The three dead rules are dead for a different reason.
+### 0.4 Q4 resolved: the `Grafana` source is now inert — and two of its dead rules can be made live today, without Phase 3
 
 Analysis Q4 asked what still delivers to alert source `f4d836c0`
-(`source_type: "grafana"`). Answer, from the production provisioning API:
+(`source_type: "grafana"`). It *was* fed by the three MIT Learn Synthetic Monitoring
+rules, which set `notification_settings.receiver: "Rootly"` — the UI-created duplicate
+contact point (`eel3rjpiwahoge`, posting to the `grafana_webhooks` endpoint with a
+token matching that source), distinct from Pulumi's `rootly` (`bfsoqo63lsyrka`, the
+`alertmanager_webhooks` endpoint).
 
-```
-contact point "Rootly"  uid eel3rjpiwahoge
-  url = https://webhooks.rootly.com/webhooks/incoming/grafana_webhooks?secret=09f9d82f…
-```
+**PR #5400 (2026-08-13) removed that override**, adopting all three rules into
+`metric_rules/synthetic_monitoring.py` and routing them through `alertmanager.py`'s
+policy tree instead. Confirmed applied — production `/api/v1/provisioning/alert-rules`
+for folder `grafana-synthetic-monitoring-app`:
 
-That secret is byte-identical to alert source `f4d836c0`'s `secret`. The source is
-fed by the three Synthetic Monitoring rules that set
-`notification_settings.receiver: "Rootly"` (remediation spec §0.7c) — the
-UI-created duplicate contact point, distinct from Pulumi's `rootly`
-(`bfsoqo63lsyrka`, the `alertmanager_webhooks` endpoint).
+| Rule | receiver | labels |
+|---|---|---|
+| `Learn Homepage - Check Failed` | `policy-tree` | `component=webapp`, `service=mitlearn`, `severity=critical` |
+| `Learn API Health Endpoint - Check Failed` | `policy-tree` | `component=api`, `service=mitlearn`, `severity=critical` |
+| `Learn NextJS Homepage (Bypass Fastly) - Check Failed` | `policy-tree` | `component=nextjs`, `service=mitlearn`, `severity=warning` |
 
-So the "Grafana Service Route" is **not** an orphan route to be deleted. But its five
-rules are still unreachable, and the reason matters for Phase 3:
+(plus three `- Elevated Probe Failure Rate` rules #5400 added, same labels, no severity.)
 
-- Its only traffic is Synthetic Monitoring probe alerts, which carry neither
-  `commonLabels.service` nor `commonLabels.component`.
-- The EKS metric alerts that *will* carry a `component` label after Phase 3 arrive at
-  the three `alertmanager`-type sources, never at `f4d836c0`.
+So source `f4d836c0` now has **no feed at all**, and the "Grafana Service Route" bound
+to it is genuinely dead — which is what analysis §5.5 suspected. This also supersedes
+remediation spec §0.7c, which still describes the three receiver overrides as live;
+deleting the duplicate `Rootly` contact point (its W5b) is now safe.
 
-**Therefore the three `component`-matching rules must be *moved* to the Grafana
-Production Service Route (bound to source `90cda8ea`), not repaired in place.**
-Repairing them where they sit — which is what analysis §8 step 3 implies — leaves
-them dead forever. Correcting analysis §5.5, which speculated the route might be
-entirely dead and removable: it is live, and removing it would break nothing today
-but would remove the only route the SM alerts can match.
+**The three `component` rules must still be moved to the Grafana Production Service
+Route (bound to `90cda8ea`) — and the reason is now much better than "so they work
+after Phase 3".** Those SM alerts route through the Pulumi contact point to the
+production `alertmanager` source *today*, carrying exactly the payload fields those
+rules test:
+
+| Rule | Condition | Matches today? |
+|---|---|---|
+| MIT Learn API → `MIT Learn - API` (`3ad10823`) | `service contains "mitlearn"` AND `component contains "api"` | **yes** |
+| MIT Learn NextJS → `MIT Learn - NextJS` (`b2389961`) | `service contains "mitlearn"` AND `component contains "nextjs"` | **yes** |
+| MIT Learn AI API → `MIT Learn AI - API` | `service contains "learn-ai"` AND `component contains "api"` | no — no rule emits `service=learn-ai` |
+
+**Two of the 19 orphaned Rootly services (§5.3) become reachable the moment those two
+rules are moved.** No label pipeline, no kube-state-metrics change, no Phase 2. This is
+the cheapest item in the whole project and it is available now — see P1.5 in §5.
+
+Caution on ordering: the `Check Failed` rules carry `severity`, the `Elevated Probe
+Failure Rate` rules do not, so the latter drop to `oblivion` in the policy tree. Only
+the three `Check Failed` rules actually arrive at Rootly to be routed.
 
 ### 0.5 [New] The join target differs per rule, and two rule pairs cannot be joined at all
 
@@ -201,22 +250,29 @@ volume), and exclude the `dagster` namespace from the pod-level series via
 already excluded from `KubernetesJobFailed*` in PromQL (`namespace!="dagster"`) and
 are tiered `ticket`, so no signal is lost.
 
-### 0.7 [New] Making `Component` strict breaks 3 of its 5 live call sites
+### 0.7 [New] Making `Component` strict breaks nothing — there is exactly one call site
 
-`component` is set at exactly five places in `src/`, with these values:
+A `grep` for `component=` across `src/` returns five hits, but only one of them is the
+`K8sAppLabels` field:
 
-```
-"webapp"    ← in Component
-"frontend"  ← in Component
-"api"       ← NOT in Component
-"nextjs"    ← NOT in Component
-pgbouncer   ← NOT in Component (bare identifier, a local variable)
-```
+| Hit | What it actually is |
+|---|---|
+| `mit_learn_nextjs/__main__.py:49` `component="frontend"` | **the only `K8sAppLabels.component` call site** — and `frontend` is already in the enum |
+| `synthetic_monitoring.py:206,229,245` `component="nextjs"/"api"/"webapp"` | the `_Check` dataclass's own `component: str` field — a Grafana *alert label*, unrelated to the K8s label classes |
+| `dagster/__main__.py:947` `component=pgbouncer` | inside a **comment**, describing a raw Kubernetes Service label used as a `ServiceMonitor` selector |
 
-The `Component | str | None` type is what permits this. Dropping `| str` without
-first extending the enum is a three-site breakage, and `pgbouncer` is a value nobody
-proposed adding. This makes the ordering in §3.2 mandatory: extend the enum, migrate
-call sites, *then* tighten the type — three commits, not one.
+So dropping `| str` from `Component | str | None` breaks **zero** call sites, and the
+three-commit ordering is not forced by breakage. Extending the enum first is still the
+right order — a strict enum with four members would reject `api`/`nextjs` the moment
+anyone sets them, and those values are already in live use as alert labels (§0.4) — but
+it is a design choice, not a migration constraint. §3.1 can be two commits.
+
+Note the corollary for §4.5: `component` as a Rootly routing key already has two
+distinct producers with no shared vocabulary — `synthetic_monitoring.py`'s `_Check`
+and (after Phase 3) the `ol.mit.edu/component` label. They agree on `api`, `nextjs` and
+`webapp` today by coincidence, not by construction. Making `_Check.component` typed as
+`Component` is a one-line change that turns that coincidence into a guarantee, and is
+worth doing in the same commit as the enum extension.
 
 ---
 
@@ -307,7 +363,7 @@ explicit.
 | 1b | `QA Non-Paging Escalation Policy` (`d63b7456`) has one service and zero levels — those CloudWatch alarms notify nobody | this project | **open** — delete the policy and move `MITx Online QA - Open edX - Redis` onto `CI/QA Slack Notifications` |
 | 1c | Account-wide "default alerts channel" toggle posts every alert to `#devops-alerts` regardless of routing (`__main__.py:513-521`) | this project | **open** — until this is off, the CI/QA separation has no observable effect |
 | 2 | Delete `exampleDeleteMe-EscalationPolicy` (`__main__.py:538`); finish `Cloudwatch - Critical` source setup | this project | **open** |
-| 3 | Three dead `component` rules in the Grafana Service Route | this project | **re-specified** — *move* to the Grafana Production Service Route (§0.4), do not repair in place; sequence with Phase 3 step 13, since they only become live once `component` is emitted |
+| 3 | Three dead `component` rules in the Grafana Service Route | this project | **re-specified and promoted** — *move* to the Grafana Production Service Route, don't repair in place; two of the three match live payloads **today** (§0.4), so this is step **P1.5**, not a Phase 3 item. Delete the now-inert Grafana Service Route with them |
 | 4 | Import the six unmanaged alert routes | — | **closed** by PR #5218 |
 | 5 | Low urgency pages like High | — | **closed** by PRs #5354, #5377 |
 
@@ -321,9 +377,10 @@ before Phase 3's verification step, not before its implementation.
 
 ### 3.1 Schema changes, in dependency order
 
-Three commits, because §0.7 makes the ordering load-bearing.
+Two commits. §0.7 establishes that nothing currently assigns a non-enum value to the
+typed field, so the type can be tightened in the same commit that extends the enum.
 
-**Commit A — extend `Component`, keep the permissive type.**
+**Commit A — extend `Component`, and tighten the type.**
 
 ```python
 @unique
@@ -351,10 +408,16 @@ class Component(StrEnum):
     worker = "worker"
 ```
 
-`api`, `nextjs` and `pgbouncer` are present because they are already in use (§0.7).
-`gateway` and `queue` are added for APISIX/Traefik and RabbitMQ/Redis-as-broker,
-which have no current member and are exactly the wide-blast-radius workloads in
-`operations-production`.
+`api`, `nextjs` and `webapp` are present because `synthetic_monitoring.py`'s `_Check`
+already emits them as Grafana alert labels (§0.4); `pgbouncer` because Dagster uses it
+as a raw Kubernetes Service label. `gateway` and `queue` are added for APISIX/Traefik
+and RabbitMQ/Redis-as-broker, which have no current member and are exactly the
+wide-blast-radius workloads in `operations-production`.
+
+Same commit: `component: Component | None` (dropping `| str`), and retype
+`_Check.component` from `str` to `Component` so the two producers of Rootly's
+`component` routing key share one vocabulary by construction rather than by
+coincidence (§0.7).
 
 **Commit B — add `alert_tier`, and move the roll-up fields into the base class.**
 
@@ -393,10 +456,6 @@ all four new fields default to `None` and `exclude_none=True` already drops them
 `release_tag` and re-declares `product`, `application` and `source_repository` as
 required, so it stays the stricter contract it is today.
 
-**Commit C — tighten the types, after the call sites are migrated.** `component:
-Component | None`, dropping `| str`. Requires Commit A plus the `pgbouncer` call site
-converted from a bare identifier to `Component.pgbouncer`.
-
 ### 3.2 Enum hygiene, same phase
 
 - `Services.learn_ai = ("learn-ai",)` → `"learn-ai"` (analysis §3.2d). Harmless today
@@ -427,19 +486,37 @@ Order by blast radius, not by count:
 
 Also backfill CI/QA clusters, which the analysis explicitly did not measure. Coverage
 there does not affect paging (CI/QA alerts go Slack-only per §8.1) but an unlabeled QA
-workload makes the join drop the series, so a rule that works in production silently
-returns nothing in QA — which is how a Phase 3 regression would hide.
+workload routes as untier-ed, so the QA stack stops being a rehearsal for the
+production routing behaviour — which is how a Phase 3 mis-tiering would go unnoticed
+until it reached production.
 
 ### 3.4 The CI gate
 
-A `pytest` check (not a `pre-commit` hook — it needs to import the label classes) that
-walks every `K8sGlobalLabels(...)` / `K8sAppLabels(...)` construction reachable from
-`src/ol_infrastructure/applications/` and asserts `component` and `alert_tier` are
-set. Fails the build on a new workload without them.
+The obvious shape — walk every `K8sGlobalLabels(...)` / `K8sAppLabels(...)`
+construction and assert the fields are set — does not enforce the invariant that
+matters, for two reasons:
 
-Gate on an explicit allowlist of currently-unlabeled construction sites that shrinks
-as §3.3 lands, rather than a flag day: the check goes in green on day one and the
-allowlist is the backfill's progress bar.
+1. **It cannot see a workload that never constructs a label object at all.** A new
+   `Deployment` with a hand-written `metadata.labels` dict, or one that reuses another
+   module's `k8s_global_labels` variable, passes a constructor-walking check while
+   producing an unlabeled workload. The failure mode the gate exists to catch is
+   precisely "someone added a workload and didn't think about labels".
+2. **It cannot tell where the labels landed.** `kube_pod_labels` reads the **pod
+   template's** labels, not the workload object's. A `Deployment` labeled only at
+   `metadata.labels` satisfies a constructor check and still joins against nothing.
+   The analysis flagged this distinction in §3.1 and it is the difference between the
+   gate working and the gate lying.
+
+So the check must assert against **rendered workload resources**, not constructor call
+sites: enumerate the `Deployment` / `StatefulSet` / `DaemonSet` resources each Pulumi
+program registers, and assert the required keys are present in **both**
+`metadata.labels` and `spec.template.metadata.labels`. `pulumi.runtime.set_mocks` gives
+this without a cluster.
+
+Gate on an explicit allowlist keyed to **resource names**, not call sites, that shrinks
+as §3.3 lands: the check goes in green on day one and the allowlist is the backfill's
+progress bar. Keying it to resources rather than call sites is also what makes the
+allowlist a faithful progress bar — one call site can produce many workloads.
 
 ### 3.5 Acceptance criteria
 
@@ -448,16 +525,28 @@ allowlist is the backfill's progress bar.
   `ol.mit.edu/component` and `ol.mit.edu/alert_tier`.
 - 100% for `operations-production`.
 - The CI gate's allowlist is empty.
-- `mypy` clean after Commit C, which is what proves the `| str` escape hatch is gone.
+- `mypy` clean after Commit A, which is what proves the `| str` escape hatch is gone.
 
 ---
 
 ## 4. Phase 3 — wiring labels into alerting
 
-**Hard prerequisite: §3.5 met.** The `group_left` join drops any series whose join
-partner is missing, so an unlabeled workload does not degrade to "no tier" — it
-degrades to **no alert at all**. Shipping Phase 3 at today's 22% coverage would
-silence 78% of EKS alerting. This is the single largest risk in the project.
+**Coverage is a routing-quality gate, not an alert-availability gate.** Per §0.2, once
+`metricLabelsAllowlist` is configured kube-state-metrics emits a `kube_pod_labels`
+series for **every** pod with `Value: 1`, carrying the join keys whether or not that pod
+has any of the allowlisted labels. So `group_left` succeeds for an unlabeled workload
+and simply copies no `label_ol_mit_edu_*` column: the alert fires with an empty
+`alert_tier` and falls through to §4.4's `severity` catch-all — warning → Low, critical
+→ High, i.e. today's behaviour. It is **not** silenced.
+
+That makes §3.5 a strong recommendation rather than a hard prerequisite: shipping
+Phase 3 at partial coverage degrades gracefully to the status quo for the unlabeled
+tail, workload by workload, and each backfilled label improves routing the moment it
+lands. §5 sequences P3.B after P2.D for that reason rather than after all of P2.
+
+**The one case that does silence is a missing right-hand series**, and §4.1's Dagster
+drop rule is the only thing in this spec that creates one. It is scoped accordingly —
+see the note there.
 
 ### 4.1 kube-state-metrics: both gates (§0.2, §0.3)
 
@@ -502,15 +591,27 @@ In `substructure/aws/eks/grafana.py`:
                 "kube_job_labels",
             ],
         },
-        # Dagster mints a pod name per job run, so pod-level label series churn
-        # hard in data-production (2,004 of the estate's 2,606 production pods).
-        # Those pods are tiered `ticket` and already excluded from
-        # KubernetesJobFailed* in PromQL, so nothing is lost by not paying for them.
+        # Dagster mints a pod name per run, so pod-level label series churn hard
+        # in data-production (2,004 of the estate's 2,606 production pods).
+        #
+        # Scoped to run/step pods BY NAME rather than to the whole `dagster`
+        # namespace. Dropping the namespace would also drop the long-lived
+        # services in it -- the daemon, the webserver, the code-location
+        # deployments -- and per section 4, a missing right-hand series is the
+        # one case where group_left silences an alert outright rather than
+        # leaving it untier-ed. Those services would lose PodOOMKilled* and
+        # PodCrashLooping* entirely; excluding Dagster from KubernetesJobFailed*
+        # in PromQL does not compensate, because that is a different rule.
+        #
+        # Verify the prefixes against live pod names before applying -- they are
+        # set by the Dagster K8s run launcher and are not a stable API. If they
+        # drift, the cost of getting this wrong is a re-added series, not a lost
+        # alert, provided the regex stays anchored to run/step pods.
         "extraMetricProcessingRules": textwrap.dedent("""
             rule {
-              source_labels = ["__name__", "namespace"]
+              source_labels = ["__name__", "namespace", "pod"]
               separator     = "@"
-              regex         = "kube_pod_labels@dagster"
+              regex         = "kube_pod_labels@dagster@dagster-(run|step)-.*"
               action        = "drop"
             }
         """),
@@ -518,18 +619,26 @@ In `substructure/aws/eks/grafana.py`:
 },
 ```
 
+If the run-pod naming turns out not to be reliably matchable, drop this rule entirely
+and pay for the ~2,000 series. Cost is the lesser risk here.
+
 where `_OL_LABEL_KEYS = "ol.mit.edu/service,ol.mit.edu/component,ol.mit.edu/alert_tier,ol.mit.edu/environment"`.
 
 **Verification, before touching any alert rule:**
 
 ```
-count(kube_pod_labels)                                    → ~600  (2,606 minus dagster)
+count(kube_pod_labels)                                    → ~600  (2,606 minus dagster run pods)
 count(kube_deployment_labels)                             → >0
 count(kube_pod_labels{label_ol_mit_edu_alert_tier!=""})    → matches §3.5 coverage
 count(kube_node_labels{label_topology_kubernetes_io_zone!=""})  → unchanged from today
+count(kube_pod_labels{namespace="dagster"})               → >0, and covers the daemon,
+                                                             webserver and code-location
+                                                             pods but no dagster-run-* pod
 ```
 
-That last one is the regression check for the `nodes=[...]` trap in §0.3.
+The fourth is the regression check for the `nodes=[...]` trap in §0.3; the fifth is the
+regression check for the drop rule's scoping — a zero there means the rule is matching
+the whole namespace and would silence Dagster's long-lived services.
 
 ### 4.2 Rewrite the 16 joinable rules
 
@@ -554,18 +663,37 @@ label_replace(
 Per §1.7 the rule emits `alert_tier` and `ol_component`; `label_ol_mit_edu_*` never
 leaves PromQL.
 
-**Environment (§5.4 fix).** For the four rule pairs that currently encode environment
-by cluster-name regex, join `label_ol_mit_edu_environment` and filter on it instead of
-on `cluster=~`. Keep the cluster filter as well during the transition — it is the
-fallback for any workload that has not declared an environment, and removing it is a
-separate change once §3.5 holds.
+**Environment (§5.4 fix).** **All eight joinable pairs** select warning-vs-critical by
+`cluster=~".*-(ci|qa)"` / `".*-(production)"` — `DaemonsetReplicasMissing*`, both
+`Deployment*` pairs, `StatefulSetReplicasMissing*`, `PodCrashLooping*`,
+`CeleryBeatPodRestarts*`, `PodOOMKilled*` and `KubernetesJobFailed*`. (`NodeNotReady*`
+and `HPAAtMaxReplicas*` do too, but they are out of scope per §1.5.)
 
-**Two rules stay as they are:** `HPAAtMaxReplicas*` (no joinable label, §0.5) and
+Adding a positive environment matcher alongside the cluster matcher is **not** a
+fallback: `label_ol_mit_edu_environment="production"` excludes every workload that has
+not declared one, so an unlabeled workload would drop out of the critical branch
+entirely — the one place in this spec where a naive transition really does silence
+alerts. Use a **negative** matcher instead, which in PromQL matches an absent label:
+
+```promql
+# critical branch: production clusters, minus anything that declares itself non-prod
+kube_pod_labels{label_ol_mit_edu_environment!~"ci|qa|staging|rc"}
+
+# warning branch: ci/qa clusters, plus anything in a prod cluster declaring non-prod
+kube_pod_labels{label_ol_mit_edu_environment=~"ci|qa|staging|rc"}
+```
+
+Keep the `cluster=~` filter as the outer selector throughout. An unlabeled workload then
+lands in its cluster's branch exactly as today, and a declared `staging` workload in
+`residential-production` moves to the warning branch — which is the §5.4 fix. Removing
+the cluster filter is a separate change once §3.5 holds, if ever.
+
+**Two rule pairs stay as they are:** `HPAAtMaxReplicas*` (no joinable label, §0.5) and
 `NodeNotReady*` (not a workload).
 
 **Roll out one rule pair at a time**, verifying firing counts before and after. A
-`group_left` that drops rows produces silence, and silence is the failure mode this
-whole project is meant to remove.
+`group_left` whose right-hand series is missing produces silence, and silence is the
+failure mode this whole project is meant to remove.
 
 ### 4.3 Alertmanager grouping
 
@@ -610,8 +738,21 @@ and now defer and divert per-workload rather than per-alertname.
 
 Add rules to the **Grafana Production Service Route** (bound to `90cda8ea`) of the form
 `namespace contains "<ns>"` AND `$.commonLabels.ol_component is "<component>"` →
-`<Service>`. Every Celery service becomes reachable this way. Move the three dead
-`component` rules here from the Grafana Service Route (§0.4) as part of the same change.
+`<Service>`. Every Celery service becomes reachable this way.
+
+**Two of the 19 do not need any of that** — moving the existing `component` rules off
+the now-inert Grafana Service Route reaches `MIT Learn - API` and `MIT Learn - NextJS`
+immediately, because the Synthetic Monitoring rules already emit `service=mitlearn` and
+`component=api|nextjs` to this source (§0.4). Sequenced separately as **P1.5** so it is
+not blocked behind Phase 2.
+
+Note the label-name mismatch this creates and resolve it deliberately: SM rules emit a
+bare `component`, while §1.7 has the EKS rules emit `ol_component` to avoid colliding
+with anything Grafana or a vendor integration might set. Either rename `_Check`'s label
+to `ol_component` when P1.5 moves the rules, or accept two keys and write the routing
+rules against both. Renaming is cleaner and is a one-line change in
+`synthetic_monitoring.py`, but it retitles a live alert label — do it in the same change
+as the rule move, not later.
 
 Ordering caution, unchanged from analysis §4.3: conditions are `contains`, so the
 narrow rules must precede the broad ones. Now that all 12 routes are in Pulumi
@@ -620,14 +761,19 @@ hand-maintained invariant has been visible at all.
 
 ### 4.6 Acceptance criteria
 
-- `count(kube_pod_labels{label_ol_mit_edu_alert_tier!=""})` ≥ 95% of non-dagster
+- `count(kube_pod_labels{label_ol_mit_edu_alert_tier!=""})` ≥ 95% of non-dagster-run
   production pods.
 - Firing counts per rule within ±20% of the pre-change 14-day baseline for the 16
-  rewritten rules. A rule that goes to zero is a dropped join, not a fixed alert.
+  rewritten rules. A rule that goes to zero is a dropped right-hand series, not a
+  fixed alert.
+- `count(kube_pod_labels{namespace="dagster"}) > 0` — the drop rule is scoped to run
+  pods and Dagster's long-lived services still join.
 - Zero Rootly services with no routing rule targeting them, down from 19.
 - The Production source carries four urgency rules, not twelve.
 - `kube_node_labels` zone/instance-type columns unchanged (§0.3 regression check).
 - A staging workload in `residential-production` receives `notify`, not `page`.
+- An **unlabeled** production workload still alerts, at today's urgency — the check
+  that coverage is a quality gate and not an availability gate (§4 preamble).
 
 ---
 
@@ -639,20 +785,28 @@ hand-maintained invariant has been visible at all.
 | P1.2 CI source urgency High → Low | — | small |
 | P1.3 Turn off the account-wide default alerts channel | P1.1 | small |
 | P1.4 Delete `exampleDeleteMe`, fix `QA Non-Paging`, finish `Cloudwatch - Critical` | — | small |
-| P2.A Extend `Component`; enum hygiene | — | small |
+| **P1.5 Move the 2 live `component` rules to the Production Service Route; delete the inert Grafana Service Route** | — | **small — reaches 2 orphaned services today (§0.4)** |
+| P2.A Extend `Component` + tighten the type; retype `_Check.component`; enum hygiene | — | small |
 | P2.B Add `AlertTier`; move roll-up fields to base; explicit `environment` | P2.A | small |
-| P2.C Tighten `component` type | P2.B + call-site migration | small |
-| P2.D Backfill `operations-production` | P2.B | medium |
-| P2.E Backfill `data-production`, `applications-production`, CI/QA | P2.B | **long pole** |
-| P2.F CI gate with shrinking allowlist | P2.B | small |
-| P3.A Both kube-state-metrics gates + verification queries | P2.D | small |
-| P3.B Rewrite 16 rules, one pair at a time | P3.A + §3.5 | medium |
+| P2.C Backfill `operations-production` | P2.B | medium |
+| P2.D Backfill `data-production`, `applications-production`, CI/QA | P2.B | **long pole** |
+| P2.E CI gate against rendered workloads, shrinking allowlist | P2.B | small |
+| P3.A Both kube-state-metrics gates + verification queries | P2.C | small |
+| P3.B Rewrite 16 rules, one pair at a time | P3.A | medium |
 | P3.C Alertmanager `group_bies` | P3.B | small |
 | P3.D Rootly urgency rules: 12 → 4 | P3.B | small |
-| P3.E Component routing for the 19 orphaned services; move the 3 dead rules | P3.B | medium |
+| P3.E Component routing for the remaining orphaned services | P3.B | medium |
 
-P3.A can start once `operations-production` is labeled (P2.D) — the gates are
-cluster-wide and harmless with partial coverage. P3.B cannot start until §3.5 holds.
+P1.5 is independent of everything else here and is the cheapest item in the project —
+do it first.
+
+P3.A can start once `operations-production` is labeled (P2.C) — the gates are
+cluster-wide and harmless with partial coverage. **P3.B does not need §3.5 met**: per
+the §4 preamble, an unlabeled workload routes as untier-ed rather than going silent, so
+the rewrite degrades to today's behaviour for the backfill's tail and improves
+workload-by-workload as P2.D lands. Do P3.D last regardless — the urgency rules are what
+turn a tier into a paging decision, and there is no reason to flip them before the tiers
+they read are broadly populated.
 
 ---
 

--- a/docs/plans/rootly-labeling-and-alert-routing-analysis.md
+++ b/docs/plans/rootly-labeling-and-alert-routing-analysis.md
@@ -1,0 +1,757 @@
+# Labeling Hierarchy and Rootly Alert Routing — Gap Analysis
+
+**Date:** 2026-07-30
+**Author:** Analysis session (tmacey)
+**Scope:** `ol.mit.edu/*` Kubernetes label hierarchy, AWS resource tags, Grafana Cloud
+alert rules and notification policy, Rootly alert sources / routes / urgencies /
+escalation, non-Grafana alert sources (CloudWatch, Sentry, Pingdom, email), and
+Heroku/EC2 log labels.
+
+---
+
+## 0. Method and evidence base
+
+What was inspected:
+
+| Source | How |
+|---|---|
+| Label schema | `src/ol_infrastructure/lib/ol_types.py` |
+| Label application | Live `kubectl` inventory of 262 Deployments/StatefulSets/DaemonSets across `applications-production`, `data-production`, `operations-production` |
+| Alert rules | `src/ol_infrastructure/infrastructure/grafana_alerting/` (metric_rules, log_rules, pingdom_checks, alertmanager) |
+| Metric label availability | Live PromQL against the production Mimir tenant (`grafanacloud-prom`) |
+| Rootly config | Live Rootly API: 9 alert sources, 12 alert routes (~70 rules), 3 urgencies, 4 escalation policies, 41 services |
+| Rootly as code | `src/ol_infrastructure/saas/rootly/__main__.py` (3,253 lines) + `KNOWN_ISSUES.md` |
+| Alert volume | Live Rootly alerts API, 1,070 alerts over 2026-07-16 → 2026-07-30; two 20-alert pages sampled in detail |
+
+**Not inspected:** CI/QA cluster label coverage (production only was measured);
+the full 1,070-alert corpus (40 sampled); Grafana CI/QA stack rule definitions
+(assumed identical to Production stack since all three deploy from the same
+Pulumi program).
+
+---
+
+## 1. Headline finding
+
+**The `ol.mit.edu/*` label hierarchy is not used by Rootly at all.** Not one of
+the ~70 routing rules across the 12 live alert routes references an `ol.mit.edu`
+label, and no alert that reaches Rootly carries one.
+
+This is not a configuration oversight that can be fixed in Rootly. The labels are
+structurally unable to reach Rootly on the metric path, for two independent
+reasons:
+
+1. **kube-state-metrics does not export them.** `src/ol_infrastructure/substructure/aws/eks/grafana.py:283`
+   deploys kube-state-metrics via the `k8s-monitoring` chart with
+   `{"kube-state-metrics": {"deploy": True}}` and no `metricLabelsAllowlist`. Verified
+   live: `kube_pod_labels`, `kube_deployment_labels`, and `kube_namespace_labels`
+   return **zero series** in the production Mimir tenant, and a label-names query
+   scoped to `kube_pod_labels` returns `[]`. The metrics carrying workload identity
+   simply do not exist.
+
+2. **Every EKS alert rule aggregates the labels away.** Every rule in
+   `metric_rules/eks_general.py` is of the form
+   `sum by (cluster, namespace, pod, container) (...)`. Even if
+   `label_ol_mit_edu_service` existed on the source series, `sum by` would discard
+   it before the alert fires.
+
+The consequence: the only identity an EKS alert carries into Rootly is
+`cluster`, `namespace`, and a resource name. Everything the label hierarchy is
+designed to express — owning business unit, product, application, component
+(celery vs webapp vs cache) — is absent at the moment routing decisions are made.
+
+---
+
+## 2. There are four parallel label vocabularies, not one
+
+The "hierarchy" the team designed is one of four coexisting vocabularies. They
+overlap in key names but not in values, and nothing validates them against each
+other.
+
+| # | Vocabulary | Keys | Where set | Reaches Rootly? |
+|---|---|---|---|---|
+| 1 | **`ol.mit.edu/*` K8s labels** | `ou`, `service`, `stack`, `environment`, `product`, `application`, `component`, `source_repository`, `commit_sha`, `release_tag`, `pod_security_group`, `slack-channel` | `K8sGlobalLabels` / `K8sAppLabels`, `ol_types.py:170` | **No** |
+| 2 | **Prometheus/Mimir metric labels** | `cluster`, `namespace`, `pod`, `container`, `deployment`, `statefulset`, `daemonset`, `horizontalpodautoscaler`, `node`, `job_name` | kube-state-metrics defaults | **Yes** — this is what routing actually uses |
+| 3 | **Loki stream labels (EC2/Heroku)** | `application`, `environment`, `service` | Vector: `src/bilder/components/vector/templates/global_log_sink.yaml:16-18`, defaulting to `missing_environment` / `missing_application` / `missing_service` | **Yes**, for log-based rules only |
+| 4 | **Pingdom check tags** | `env`, `service` | `pingdom_checks.py` | Into Pingdom, not into the Rootly payload |
+
+Vocabulary 3 and 4 use *different values for the same concepts* than vocabulary 1:
+
+| Concept | Vocab 1 (`Services` enum) | Vocab 3 (Loki) | Vocab 4 (Pingdom) |
+|---|---|---|---|
+| MIT Learn | `mit-learn` | — | `learn` |
+| Keycloak | `keycloak` | `keycloak` | `sso` |
+| Open edX residential | `mitx-edx` | `edxapp` | `mitx` |
+| OCW | `ocw-build` / `ocw-studio` | `ocw-studio` | `ocw`, `ocw-studio` |
+| Environment key | `environment` | `environment` | `env` |
+
+Vocabulary 4 also uses environment values (`qa`, `rc`, `production`, `staging`)
+that are not in the `Environment` enum, and service values
+(`open-discussions`, `concourse`, `micromasters`) that partly are and partly
+aren't in `Services`.
+
+---
+
+## 3. Consistency of the `ol.mit.edu/*` labels themselves
+
+### 3.1 Measured coverage (production clusters, live)
+
+| Cluster | Workloads | `service` | `ou` | `application` | `component` | `product` | `environment` | Fully unlabeled |
+|---|---|---|---|---|---|---|---|---|
+| `applications-production` | 112 | 51 (46%) | 51 | 47 | 45 | 34 | 51 | 61 (54%) |
+| `data-production` | 91 | 4 (4%) | 4 | 3 | 1 | 2 | 4 | 87 (96%) |
+| `operations-production` | 59 | 2 (3%) | 2 | 0 | 0 | 0 | 2 | 57 (97%) |
+| **Total** | **262** | **57 (22%)** | **57** | **50** | **46** | **36** | **57** | **205 (78%)** |
+
+**78% of production workloads carry no `ol.mit.edu` label at all.** Coverage is
+concentrated almost entirely in `applications-production`; the data and operations
+clusters are effectively unlabeled. `operations-production` is where APISIX,
+cert-manager, and the shared ingress live — the components whose failures have the
+widest blast radius — and it has the worst coverage.
+
+Note this measures the *workload* object's labels, not pod template labels; a
+workload labeled only at the pod level would still not help, since routing never
+sees pod labels either (see §1).
+
+### 3.2 Defects in the schema
+
+**a. `K8sGlobalLabels` cannot roll up to a product.** The base class carries only
+`ou`, `service`, `stack` (`ol_types.py:170-177`). `product`, `application`, and
+`component` exist only on the `K8sAppLabels` subclass. A resource labeled with the
+base class — which is the common case; the variable is literally named
+`k8s_global_labels` in most `__main__.py` files — cannot be rolled up to a product.
+This is visible in the survey: 57 workloads have `service` but only 36 have
+`product`.
+
+**b. `Component` is a four-value enum that isn't enforced.**
+`Component` (`ol_types.py:144`) has exactly four members: `celery`, `webapp`,
+`frontend`, `keycloak`. But the field is typed `Component | str | None`
+(`ol_types.py:210`), so any string is accepted and `None` is the default. There is
+no `worker`, `beat`, `api`, `nextjs`, `cache`, `database`, or `search` member —
+precisely the distinctions needed to tell a Celery worker apart from a webapp for
+paging purposes.
+
+**c. `Services` and `Application` are near-duplicate enums that have drifted.**
+Both enumerate ~36 near-identical members. Divergences:
+
+- In `Services` but not `Application`: `notebooks`, `ol-analytics-api`, `open-edx`, `openedx`, `opik`
+- In `Application` but not `Services`: `mit-learn-nextjs`, `openedx-platform`
+- `Services` contains both `open-edx` and `openedx` as distinct members
+
+Nothing constrains `service` and `application` to be consistent on the same
+resource.
+
+**d. `Services.learn_ai` is declared as a tuple.** `ol_types.py:79` reads
+`learn_ai = ("learn-ai",)`. This happens to be harmless — `StrEnum` splats the
+tuple into `str()`, so the value is correctly `'learn-ai'` (verified) — but it is
+inconsistent with every other member and would break under a different enum base.
+
+**e. `BusinessUnit` mixes organizational units with environments.** It contains
+both `residential` and `residential_staging`. Staging is an environment, not a
+business unit, so cost-allocation and ownership roll-ups split a single OU in two.
+
+**f. `environment` is derived, not declared.** `model_dump` sets
+`ol.mit.edu/environment` from `self.stack.env_suffix` (`ol_types.py:203`), i.e. from
+the Pulumi stack name. A workload deployed into a cluster whose environment differs
+from its own logical environment gets the cluster's answer. This is not theoretical —
+see §5.4.
+
+### 3.3 AWS tags are a fifth, disconnected vocabulary
+
+`AWSBase` (`ol_types.py:217`) enforces `REQUIRED_TAGS = {"OU", "Environment"}` and
+recommends `{"Application", "Owner"}`, validating `OU` against `BusinessUnit`. These
+tags are real and consistently applied, but they **cannot** reach Rootly: CloudWatch
+alarm notifications delivered via SNS do not include the tags of the resource being
+alarmed on. The CloudWatch→SNS→Rootly path therefore routes on **substring matching
+of the alarm name** instead (§4.3). The AWS tag hierarchy is a cost-allocation
+mechanism only; it is not, and without a transformation step cannot be, an alert
+routing mechanism.
+
+---
+
+## 4. What Rootly actually routes on
+
+### 4.1 Pipeline
+
+```
+EKS workloads ──► kube-state-metrics (no label allowlist) ──► Alloy ──► Mimir
+                                                                         │
+EC2/Heroku ──► Vector (application/environment/service) ──► Loki ────────┤
+                                                                         ▼
+                                          Grafana-managed alert rules (per-stack)
+                                                          │  labels: severity [+ service, channel, environment]
+                                                          ▼
+                                          Grafana Alertmanager notification policy
+                                            severity=warning|critical ──► Rootly webhook
+                                            alertname=~Kube.*         ──► oblivion (dropped)
+                                            channel=notifications-ocw-misc ──► Slack
+                                                          ▼
+                        Rootly alert source (bearer token selects CI / QA / Production)
+                                                          │
+                                     ┌────────────────────┴────────────────────┐
+                                     ▼                                          ▼
+                       alert_source_urgency_rules                        alert routes
+                       (assigns High/Medium/Low)                (assign Service or Escalation Policy)
+                                     └────────────────────┬────────────────────┘
+                                                          ▼
+                                             Default Escalation Policy
+                                              + "Defer Medium urgency
+                                                 outside business hours" path
+```
+
+### 4.2 The complete inventory of routing keys in use
+
+Every condition across all 12 live alert routes, by JSON path:
+
+| JSON path | Routes using it | What it is |
+|---|---|---|
+| `$.commonLabels.namespace` | Grafana Production Service Route (4 rules) | K8s namespace |
+| `$.commonLabels.service` | Grafana Production Service Route (3), Grafana Service Route (4) | Rule-level label, set on only 3 alert rules |
+| `$.commonLabels.component` | Grafana Service Route (3 rules) | **Never set by any alert rule** |
+| `$.commonLabels.environment` | Grafana Production Service Route (2 rules) | Loki stream label |
+| `$.Message.AlarmName` | Cloudwatch Service Route (10 rules) | CloudWatch alarm name substring |
+| `$.check_name` | Pingdom Service Route (23 rules) | Pingdom check name substring |
+| `$.data.metric_alert.projects[0]` | Sentry Service Route (2 rules) | Sentry project name |
+
+Nothing here is `ol.mit.edu/*`. Nothing here is an AWS tag.
+
+### 4.3 Routing is substring matching on names, not label matching
+
+Every condition uses `property_field_condition_type: "contains"`. This creates
+ordering-dependent behaviour that is easy to get wrong:
+
+- Cloudwatch Service Route position 4 is `AlarmName contains "mitlearn"` → MIT Learn
+  Django Webapp. Positions 2 and 3 (`mitlearn`+`rds`, `mitlearn`+`elasticache`) must
+  precede it or all MIT Learn database alarms would land on the webapp service. They
+  currently do — but this is a hand-maintained invariant with no test.
+- Pingdom Service Route position 17 is `check_name contains "xPro"`, positions 15–16
+  are `xPro CMS` / `xPro LMS`. Same fragility.
+- Cloudwatch environment demotion is `AlarmName contains "-qa-"` / `"-ci-"`
+  (§4.4). Any alarm whose name doesn't happen to embed a hyphenated environment
+  token is treated as production.
+
+### 4.4 Urgency assignment
+
+Three urgencies exist: **High**, **Medium**, **Low**. Assignment is entirely at the
+**alert source** level, via `alert_source_urgency_rules`, evaluated in order:
+
+**Grafana Prometheus – Production** (`90cda8ea`), default **High**:
+
+| Pos | Condition | → Urgency |
+|---|---|---|
+| 1 | `$.commonLabels.severity is "warning"` | Low |
+| 2 | Title is `DiskUsageCritical` | Medium |
+| 3–12 | `$.commonLabels.alertname is` one of: `PodCrashLoopingCritical`, `PodOOMKilledCritical`, `CeleryBeatPodRestartsCritical`, `DaemonsetReplicasMissingCritical`, `StatefulSetReplicasMissingCritical`, `KubernetesJobFailedCritical`, `CertManagerACMEIssuerUnavailableProduction`, `CertManagerChallengePresentationFailureProduction`, `OCWStudioContentSyncInvalidPasswordProd`, `HPAAtMaxReplicasCritical` | Medium |
+
+Everything else → **High** (pages immediately).
+
+**Grafana Prometheus – QA** (`074e2b0e`): default **Medium**, **no urgency rules**.
+**Grafana Prometheus – CI** (`6a32d158`): default **High**, **no urgency rules**.
+**Cloudwatch Critical / Warning**: default High; `AlarmName contains "-qa-"` or `"-ci-"` → Medium.
+**Sentry**: default Low; `$.data.action is_not "critical"` → Low.
+**Pingdom**: default High; `$.importance_level is "LOW"` → Low.
+
+### 4.5 Escalation and the deferral path
+
+Four escalation policies exist:
+
+| Policy | ID | Services attached |
+|---|---|---|
+| Default Escalation Policy | `96629210` | 37 |
+| QA Non-Paging Escalation Policy | `d63b7456` | 1 |
+| CI/QA Slack Notifications | `b32c5938` | **0** |
+| exampleDeleteMe-EscalationPolicy | `61e8291e` | 0 |
+
+The Default Escalation Policy carries the noise control that currently exists: an
+`EscalationPath` named **"Defer Medium urgency outside business hours"**
+(`rootly/__main__.py:610`), `path_type="deferral"`, matching
+`alert_urgency in [Medium]` AND a deferral window covering weeknights 17:00–09:00
+and all weekend, with `after_deferral_behavior="re_evaluate"`.
+
+**This is a well-built mechanism and it works.** Medium-urgency alerts arriving
+overnight or on weekends are held and replayed at 09:00 ET rather than paging. The
+problem is not the mechanism; it is the granularity of what feeds it (§5.1).
+
+---
+
+## 5. Gap inventory
+
+Ordered by operational impact on on-call.
+
+### 5.1 [High] Noise suppression is per-alert-rule, so it cannot distinguish workloads
+
+The demotion list in §4.4 operates on `alertname`. `PodOOMKilledCritical` is demoted
+to Medium **for every workload in every production cluster**. That is correct for
+`mitlearn-embeddings-celery-worker` and wrong for a Postgres StatefulSet, an APISIX
+ingress controller, or an OpenSearch data node — all of which would also be demoted
+and deferred to the next business morning.
+
+The same applies to `HPAAtMaxReplicasCritical`, `StatefulSetReplicasMissingCritical`,
+and `KubernetesJobFailedCritical`.
+
+The `ol.mit.edu/component` label is exactly the discriminator needed here and it is
+not available at routing time.
+
+**Live evidence.** In the last 14 days Rootly ingested **1,070 alerts** (~76/day).
+In a 40-alert sample across two pages:
+
+| Alert | Count | Share |
+|---|---|---|
+| `PodOOMKilled{Warning,Critical}` | 23 | 57.5% |
+| `StatefulSetReplicasMissing*` | 7 | 17.5% |
+| `PodCrashLoopingWarning` | 5 | 12.5% |
+| `HPAAtMaxReplicasCritical` | 4 | 10% |
+| `DeploymentUnavailableWarning` | 1 | 2.5% |
+
+`mitlearn-default-celery-worker` in `applications-qa` OOM-killed and re-alerted on a
+roughly hourly cadence through 2026-07-24 — 10 separate Rootly alerts in that one
+sample day, each a distinct alert record.
+
+### 5.2 [High] 78% of CI/QA alert volume is unrouted, at a higher urgency than production warnings
+
+In the same 40-alert sample, **31 of 40 (78%) originated from CI or QA clusters**
+(`applications-qa`, `data-qa`, `residential-qa`).
+
+These alerts:
+
+- Arrive at the QA source, whose **default urgency is Medium** with no urgency rules.
+- Match the "Grafana Prometheus QA - Slack Warnings Route", whose **only rule is a
+  disabled fallback rule** (`enabled: false`). No route condition matches them.
+- The route's fallback target is the "CI/QA Slack Notifications" escalation policy
+  (`b32c5938`), which is **correctly built**: one level, position 1, delay 0,
+  notification target a Slack channel (`C0BK6BHUCDP`) with **no schedule target** —
+  i.e. a genuine notify-don't-page destination.
+
+Net effect: a QA `StatefulSetReplicasMissingWarning` is **Medium** urgency, while a
+**production** `severity=warning` alert is demoted to **Low** by the production
+source's position-1 rule. Non-production alerts outrank production alerts.
+
+The CI source is worse: its default urgency is **High** with no demotion rules at all.
+
+**The machinery for the correct behaviour already exists and is switched off.** The
+two routes and the Slack-only escalation policy were all created on 2026-07-22. The
+only thing standing between today's state and correct QA handling is that the two
+fallback rules have `enabled: false`. Because a fallback rule targets the escalation
+policy *directly* (`target_type: "EscalationPolicy"`), the policy's empty
+`service_ids` list is irrelevant to this path — no service attachment is needed.
+
+Separately broken: the **"QA Non-Paging Escalation Policy"** (`d63b7456`) has one
+service attached (`MITx Online QA - Open edX - Redis`, created 2026-05-28 for MITx
+Online QA CloudWatch alarms) but **zero escalation levels**. Alerts routed to that
+service notify nobody at all. That is silent loss, not deferral.
+
+Related: `setup_grafana()` returns early for CI (`grafana.py:~90`,
+`if stack_info.env_suffix.lower() == "ci": return`), so CI clusters ship no metrics.
+But every warning-severity rule in `eks_general.py` filters
+`cluster=~".*-(ci|qa)"` — the `ci` half of that regex can never match anything.
+
+### 5.3 [High] Half the Rootly service catalog is unreachable
+
+Rootly has **41 services**, modelled at component granularity — `MIT Learn - Celery`,
+`MITx Online - Open edX - LMS - Celery`, `MIT Learn - Redis`, `MIT Learn - Qdrant`,
+`ODL Video - Celery`, and so on. This catalog *is* the roll-up hierarchy the labels
+were designed to express.
+
+But routing resolves at **namespace** granularity. Every alert from the `mitlearn`
+namespace — webapp, celery worker, celery beat, nginx — routes to
+`MIT Learn - Django - Webapp`.
+
+**19 of 41 services are never the destination of any routing rule:**
+
+`MIT Learn - Celery`, `MIT Learn AI - Celery`, `MIT Learn AI - Postgres`,
+`MIT Learn AI - Redis`, `MIT Learn - Tika`, `MIT Learn - Qdrant`,
+`MIT Learn - OpenSearch`, `MIT Learn - Keycloak - Postgres`,
+`MIT Learn - Keycloak - Webapp`, `MITx Online - Open edX - CMS - Celery`,
+`MITx Online - Open edX - LMS - Celery`, `MITx Online - Open edX - MongoDB`,
+`MITx Online - Open edX - MySQL`, `MITx Online - Open edX - OpenSearch`,
+`ODL Video - Celery`, `ODL Video - Postgres`, `CatchAll`, `API - Authentication`,
+`UI - User Profile Block`.
+
+This is the single clearest demonstration that the labeling hierarchy and the
+routing configuration were designed against each other but never connected. The
+Celery services exist. The alerts about Celery workers exist. Nothing joins them.
+
+### 5.4 [Medium] Environment is inferred from cluster name, and it is already wrong
+
+`eks_general.py` encodes severity by cluster-name regex: `.*-(ci|qa)` → warning,
+`.*-(production)` → critical. Observed in the live alert stream:
+
+> `StatefulSetReplicasMissingCritical` — statefulset `mitx-staging-ts-sts` in
+> namespace `mitx-staging-openedx` in cluster `residential-production`
+
+A **staging** workload received **Critical** severity, and therefore production
+urgency treatment, because it runs in a cluster whose name ends in `-production`.
+`ol.mit.edu/environment` on that workload would say `staging`.
+
+### 5.5 [Medium] Three Rootly routing rules can never match
+
+The "Grafana Service Route" contains three rules conditioned on
+`$.commonLabels.component` (`= "api"`, `= "nextjs"`). An exhaustive enumeration of
+every `labels={...}` in `grafana_alerting/` produces only these keys: `severity`,
+`environment`, `channel`, `service`, `env`. **`component` is never set.** The rules
+targeting `MIT Learn AI - API`, `MIT Learn - API`, and `MIT Learn - NextJS` are dead.
+
+Additionally, the "Grafana Service Route" is bound to alert source `f4d836c0`
+(`source_type: "grafana"`), while the Pulumi-managed contact point posts to
+`.../alertmanager_webhooks` — an `alertmanager`-type source. It is unclear what, if
+anything, still delivers to `f4d836c0`. See open question Q4.
+
+### 5.6 [Medium] The routes carrying all the real rules are not managed as code
+
+`rootly/__main__.py` declares **6** `AlertRoute` resources:
+Grafana Prometheus CI Slack Warnings, Grafana Prometheus QA Slack Warnings,
+Cloudwatch Catch-All, Grafana Production Catch-All, Pingdom Catch-All, Platform
+Engineering Team Email Monitor.
+
+All six are catch-all or fallback routes. The **six routes that contain every
+service-mapping rule** — Cloudwatch Service Route (11 rules), Sentry Service Route
+(3), Grafana Production Service Route (8), Pingdom Service Route (24), Grafana
+Service Route (5), and `sh-test` (0) — are **not in Pulumi**. Roughly 51 routing
+rules, the entire operational routing surface, are UI-managed with no review, no
+history, and no drift detection.
+
+`KNOWN_ISSUES.md` states alert routes were imported "excluding the empty-state Chris
+Test route", which understates the gap.
+
+### 5.7 [Low] Stale and misconfigured Rootly objects
+
+- `sh-test` alert route: bound to the CI source, **zero rules**.
+- `exampleDeleteMe-EscalationPolicy`: still present, in Pulumi (`__main__.py:492`).
+- `Cloudwatch - Critical` alert source: status `setup_incomplete`. The *Critical*
+  CloudWatch path is not fully connected.
+- `Cloudwatch Catch-All Route` and both CI/QA Slack Warnings routes: fallback rules
+  `enabled: false`.
+- `CI/QA Slack Notifications` escalation policy: zero services.
+- The `noise` field on all 1,070 sampled alerts is `not_noise` — Rootly's noise
+  classification is unused.
+
+### 5.8 [Low] Alert grouping was widened without the labels it was widened for
+
+`alertmanager.py:123-138` sets `group_bies` to 14 labels including `application`,
+after a 2026-07-23 incident where unrelated HPA alerts kept re-bundling. The
+comment is accurate about the fix. But `application` is only present on
+Loki-sourced (EC2/Heroku) alerts, never on EKS metric alerts, and the list contains
+no `service`, `component`, `product`, or `ou` — because those don't exist on alerts
+either. The grouping is as fine-grained as the available labels allow, which is the
+same ceiling as the routing.
+
+---
+
+## 6. The OOMKilled / HPA question — analysis within the current model
+
+*(As requested: gaps only in this section; the proposed scheme is §7, kept separate.)*
+
+The team has already correctly identified this problem and built a real mechanism for
+it. The current design is:
+
+1. Rule-level tuning in PromQL — `PodOOMKilledCritical` requires `>= 3` restarts in
+   an hour; `HPAAtMaxReplicasCritical` excludes HPAs where `min == max`. Both carry
+   detailed comments explaining the reasoning and the production observations behind
+   them (`eks_general.py:232-268`, `332-341`). This is good work and it demonstrably
+   removed a class of false positives.
+2. Alertname-based demotion to Medium in Rootly.
+3. Business-hours deferral of Medium urgency.
+
+The gaps that remain, all traceable to missing labels:
+
+**G1 — Demotion is all-or-nothing per rule.** A Celery worker OOM and a Postgres
+StatefulSet OOM are indistinguishable at routing time, so both are demoted. The
+current setting optimises for the common case (Celery) and accepts the risk on the
+uncommon one (stateful data services).
+
+**G2 — There is no way to express "this workload is expected to OOM."** MIT Learn's
+VPA-driven workloads intentionally start at a low memory floor (documented at
+`eks_general.py:240-248`). That intent lives in a code comment, not in a label the
+alerting pipeline can read.
+
+**G3 — The `Component` enum lacks the values the decision needs.** `celery` exists,
+but `worker` vs `beat` do not, and there is no `cache`/`database`/`search` for the
+stateful services that should *not* be demoted.
+
+**G4 — QA noise is the larger problem and is untouched by any of this.** 78% of alert
+volume is CI/QA, and none of it is affected by the demotion list, because the
+demotion rules are configured only on the Production source. Fixing per-workload
+demotion would improve the 22%; fixing QA routing would improve the 78%.
+
+**G5 — The demotion list requires a Rootly UI edit per new alert rule.** It is a
+hand-maintained allowlist of 11 alertnames, living in Pulumi
+(`rootly/__main__.py`, alert source urgency rules) but conceptually coupled to
+`eks_general.py`. Adding a rule in one place silently defaults to High in the other.
+
+---
+
+## 7. Proposed scheme — paging eligibility as a label
+
+*(Presented separately, per the brief. This is an option with a real migration cost,
+not a recommendation to adopt as-is.)*
+
+### 7.1 Principle
+
+Move the page/notify decision from *"which rule fired"* to *"which workload fired
+it, and how critical is that workload"*. Encode criticality on the workload, where
+the team that owns it already edits the manifest, and carry it through to Rootly.
+
+### 7.2 Schema change
+
+Add to `K8sAppLabels` in `ol_types.py`:
+
+```python
+@unique
+class AlertTier(StrEnum):
+    """Paging eligibility for alerts about this workload."""
+
+    page = "page"        # Wake someone up. User-facing or data-integrity impact.
+    notify = "notify"    # Business-hours attention. Degraded, self-healing, or redundant.
+    ticket = "ticket"    # Record only. Never notifies.
+```
+
+and extend `Component` with the values the decision actually needs:
+
+```python
+@unique
+class Component(StrEnum):
+    celery = "celery"          # existing
+    webapp = "webapp"          # existing
+    frontend = "frontend"      # existing
+    keycloak = "keycloak"      # existing
+    worker = "worker"
+    beat = "beat"
+    api = "api"
+    nextjs = "nextjs"
+    cache = "cache"
+    database = "database"
+    search = "search"
+    ingress = "ingress"
+```
+
+Also: **move `product`, `application`, and `component` from `K8sAppLabels` down into
+`K8sGlobalLabels`** (making `product`/`application` optional there), so that
+base-class-labeled resources are still rollable-up. Without this, adding `alert_tier`
+to the subclass reproduces the existing 46%-vs-32% coverage gap.
+
+### 7.3 Making the labels visible to alerts
+
+This is the load-bearing change and the one with real cost. Three options:
+
+**Option A — kube-state-metrics label allowlist (recommended).** In
+`substructure/aws/eks/grafana.py`, set:
+
+```python
+"telemetryServices": {
+    "kube-state-metrics": {
+        "deploy": True,
+        "kube-state-metrics": {
+            "metricLabelsAllowlist": [
+                "pods=[ol.mit.edu/service,ol.mit.edu/component,ol.mit.edu/alert-tier,ol.mit.edu/environment]",
+                "deployments=[ol.mit.edu/service,ol.mit.edu/component,ol.mit.edu/alert-tier,ol.mit.edu/environment]",
+                "statefulsets=[ol.mit.edu/service,ol.mit.edu/component,ol.mit.edu/alert-tier,ol.mit.edu/environment]",
+            ],
+        },
+    },
+    ...
+}
+```
+
+This makes `kube_pod_labels{label_ol_mit_edu_alert_tier="notify", ...}` available.
+Alert rules then join against it:
+
+```promql
+sum by (cluster, namespace, pod, container, label_ol_mit_edu_alert_tier, label_ol_mit_edu_component) (
+  (kube_pod_container_status_last_terminated_reason{cluster=~".*-(production)", reason="OOMKilled"} == 1)
+  * on (cluster, namespace, pod) group_left(label_ol_mit_edu_alert_tier, label_ol_mit_edu_component)
+    kube_pod_labels
+  * on (cluster, namespace, pod, container) group_left()
+    (increase(kube_pod_container_status_restarts_total[1h]) >= 3)
+)
+```
+
+Cost: one new metric series per pod (cardinality is bounded and modest at this
+fleet size); a `group_left` join added to each of the 18 EKS rules; the four
+allowlisted labels must actually be present or the join drops the series — which
+makes §3.1's 78% unlabeled figure a hard blocker, not a nice-to-have.
+
+**Option B — Alertmanager-side enrichment.** Leave the rules alone; map
+`namespace` → tier in the notification policy. Cheap, but reproduces the
+namespace-granularity ceiling and cannot distinguish celery from webapp.
+
+**Option C — Rootly-side catalog lookup.** Use Rootly's catalog entities to map
+`namespace`+`pod` regex → service + urgency. Keeps the change out of the metrics
+pipeline entirely, but moves the mapping into a system the infrastructure team
+doesn't manage in code, worsening §5.6.
+
+Recommendation: **A**, gated on closing the label coverage gap first.
+
+### 7.4 Resulting Rootly configuration
+
+Replace the 11-entry alertname demotion list on the **Production** source with two
+source-level urgency rules:
+
+| Pos | Condition | → Urgency |
+|---|---|---|
+| 1 | `$.commonLabels.label_ol_mit_edu_alert_tier is "ticket"` | Low |
+| 2 | `$.commonLabels.label_ol_mit_edu_alert_tier is "notify"` | Medium |
+| — | default | High |
+
+The existing "Defer Medium urgency outside business hours" path continues to work
+unchanged, and now defers the right things.
+
+Note there is deliberately **no environment-based rule here**. Per §8.1, CI/QA
+handling is a *routing destination* concern (Slack-only escalation policy), not an
+*urgency* concern, and the CI/QA sources are separate from the Production source
+anyway. Mixing the two would couple QA behaviour to the production Medium band.
+
+Then add a routing rule per component to reach the 19 orphaned services, e.g.
+`namespace contains "mitlearn"` AND `label_ol_mit_edu_component is "celery"` →
+`MIT Learn - Celery`.
+
+### 7.5 Which workloads would be reclassified
+
+Based on the current production inventory and observed alert patterns:
+
+| Workload class | Tier | Effect vs today |
+|---|---|---|
+| `*-celery-worker`, `*-celery-beat` (mitlearn, mitxonline, learn-ai, edxapp) | `notify` | Same as today (already demoted) — but now demoted *because they are workers*, not because of the alert name |
+| `mitlearn-embeddings-celery-worker` | `notify` | Same |
+| `apache-apisix` / ingress controllers | `page` | **Escalated** — currently demoted for OOM/crashloop |
+| Postgres / MySQL / MongoDB StatefulSets | `page` | **Escalated** — currently demoted for `StatefulSetReplicasMissingCritical` |
+| OpenSearch / Qdrant / ClickHouse / StarRocks | `page` | **Escalated** |
+| `*-app` webapps (mitlearn, mitxonline, xpro) | `page` | Escalated for OOM; unchanged for unavailability |
+| `mitx-staging-*` in `residential-production` | `notify` | **Demoted** — fixes §5.4 |
+| Anything in a CI/QA cluster | n/a — handled by route destination, not tier (§8.1) | Slack-only, no page, signal preserved |
+| Dagster job pods | `ticket` | Already excluded in PromQL; makes it explicit |
+
+Net: the volume that pages goes *down* (78% CI/QA moves off the paging path
+entirely, via Phase 1 alone), while the specific stateful and ingress workloads that
+should have been paging all along start doing so.
+
+---
+
+## 8. Recommended sequence
+
+Ordered so that each step is independently valuable and nothing depends on an
+unfinished predecessor.
+
+**Phase 1 — Stop the bleeding (no schema changes, days)**
+
+1. **Enable the two disabled fallback rules** on "Grafana Prometheus QA - Slack
+   Warnings Route" and "Grafana Prometheus CI - Slack Warnings Route", sending CI/QA
+   alerts to the "CI/QA Slack Notifications" escalation policy (Slack-only, no
+   schedule target). This is a two-field change to already-built objects and it
+   removes 78% of alert volume from the paging path while preserving the signal.
+   See §8.1 for why this, and not deferral, is the right shape. (§5.2)
+1b. Add escalation levels to the "QA Non-Paging Escalation Policy", or delete it and
+   move `MITx Online QA - Open edX - Redis` onto the CI/QA Slack policy. Today it has
+   a service but no levels, so those CloudWatch alarms notify nobody. (§5.2)
+1c. Confirm Slack channel `C0BK6BHUCDP` is a QA-appropriate channel distinct from
+   `#devops-alerts` (`GBDLJJX51`), then turn off the account-wide "default alerts
+   channel" toggle, which currently posts every alert to `#devops-alerts`
+   unconditionally regardless of routing (documented at `rootly/__main__.py:513-521`).
+   Without this the separation has no observable effect.
+2. Delete `sh-test`, `exampleDeleteMe-EscalationPolicy`; finish `Cloudwatch - Critical`
+   source setup. (§5.7)
+3. Remove or fix the three dead `component`-matching rules in the Grafana Service
+   Route. (§5.5)
+4. Import the six unmanaged alert routes into `rootly/__main__.py`. (§5.6)
+
+**Phase 2 — Close the label gap (weeks)**
+
+5. Move `product`/`application`/`component` into `K8sGlobalLabels`. (§3.2a)
+6. Extend `Component`; make it a strict enum (drop `| str`). (§3.2b, §7.2)
+7. Reconcile `Services` vs `Application`, or collapse them. (§3.2c)
+8. Label the 205 unlabeled production workloads, starting with
+   `operations-production` and `data-production`. This is the long pole.
+
+**Phase 3 — Wire labels into alerting (weeks, after Phase 2)**
+
+9. Add `metricLabelsAllowlist` to kube-state-metrics. (§7.3 Option A)
+10. Add `alert_tier` to the schema and set it per workload.
+11. Rewrite the 18 EKS rules with `group_left` joins onto `kube_pod_labels`.
+12. Replace the alertname demotion list with tier-based urgency rules. (§7.4)
+13. Add component-level routing rules for the 19 orphaned services. (§5.3)
+
+### 8.1 Decided: QA is notify-not-page, not deferred and not silenced
+
+**Decision (2026-07-30, tmacey), resolving Q2:** QA alerts are kept, not silenced,
+because QA failures frequently precede the same failure in production as changes are
+promoted. They should reach the team without paging anyone.
+
+The implementation consequence is that **Rootly's deferral path is the wrong tool
+here**, even though it is the mechanism already in use for Medium urgency:
+
+- A deferral path exists to suppress *pages*. The CI/QA destination is a Slack
+  channel with no schedule target, so nothing pages in the first place — there is
+  nothing for deferral to suppress.
+- Deferral would actively damage the precursor use case. `after_deferral_behavior`
+  is `re_evaluate`, so held alerts replay at 09:00 ET. That severs the alert from
+  the QA deploy that caused it — the timing correlation *is* the signal — and
+  converts a trickle into a 09:00 burst. At current volumes (~59 QA alerts/day by
+  the 78%-of-1,070-over-14-days estimate) that burst is itself an alert-fatigue
+  event.
+- Slack retains history. An overnight QA alert is still there at 09:00 without any
+  Rootly machinery holding it.
+
+So: route CI/QA to the Slack-only escalation policy at delay 0, and do **not** add a
+deferral path to it. "Deferred to business hours" is achieved by the destination not
+being a pager, not by holding the message.
+
+Open sub-decision, not blocking: should QA alerts also be excluded from the
+`Medium` urgency band entirely (moved to `Low`)? Medium is what the production
+deferral path matches. Leaving QA at Medium is harmless today because QA alerts
+reach a different escalation policy that has no deferral path — but it couples two
+unrelated things, and a future change to the Medium band would silently affect QA.
+Recommend setting the QA and CI sources' default urgency to `Low` for decoupling,
+with the notify behaviour coming from the route destination rather than the urgency.
+
+This decision also removes the `environment != production → Medium` rule from the
+proposed §7.4 urgency table; environment-based handling belongs in routing
+(destination), not urgency (severity).
+
+---
+
+## 9. Open questions — all resolved 2026-08-17
+
+> **§7, §8 and §9 of this document are superseded by
+> [rootly-label-routing-implementation-spec.md](rootly-label-routing-implementation-spec.md)
+> (2026-08-17).** The measurements in §0-§6 stand, with three corrections recorded in
+> that spec's §0: the kube-state-metrics change needs *two* independent gates rather
+> than one (the chart's own allow-list also drops `kube_*_labels`); §7.3's code sketch
+> nests the Helm value one level too deep and would silently no-op; and the join target
+> differs per rule, so 16 of 20 EKS rules are rewritable rather than all 18.
+
+**Q1. — RESOLVED 2026-08-17.** CI alerts keep reaching Rootly; do not drop them to
+`oblivion` in the CI stack. CI ships no metrics, so the volume is zero — the hazard is
+the CI source's **High** default urgency, which is fixed at the source (High → Low)
+rather than by hiding the path. Keeping delivery visible in Rootly keeps it auditable.
+See spec §1.1.
+
+**Q2. — RESOLVED 2026-07-30 (tmacey).** QA alerts are deferred to business hours but
+not silenced: they often act as precursors to production issues as QA changes get
+promoted. Implemented as Slack-only notification with no paging and no deferral path
+— see §8.1 for the reasoning and the resulting change to §7.4.
+
+**Q3. — RESOLVED 2026-08-17 (tmacey).** The demotion was **deliberate**. MySQL,
+MongoDB, OpenSearch, Qdrant, ClickHouse and StarRocks are replicated enough that a
+missing replica is not a wake-up. They are tiered `notify`, preserving today's
+behaviour but expressing it per-workload rather than per-alertname. **This invalidates
+§7.5's escalation column** for every stateful row and shrinks Phase 3's paging-volume
+benefit to near zero — the remaining justification is routing precision and
+maintainability, stated explicitly in spec §1.2.
+
+**Q4. — RESOLVED 2026-08-17, by evidence.** The `Grafana` source is **live**. The
+UI-created `Rootly` contact point (uid `eel3rjpiwahoge`) posts to
+`grafana_webhooks?secret=09f9d82f…`, byte-identical to source `f4d836c0`'s secret; its
+traffic is the three Synthetic Monitoring rules that set
+`notification_settings.receiver: "Rootly"`. So the route is not removable — but its
+three `component` rules are still unreachable, because SM alerts carry no `component`
+and the EKS alerts that will carry one arrive at the `alertmanager` sources instead.
+They must be **moved** to the Grafana Production Service Route, not repaired in place.
+See spec §0.4.
+
+**Q5. — RESOLVED 2026-08-17 (tmacey).** Keep both, with distinct jobs: `ou` is the
+cost-allocation axis, `product` is the alerting/ownership roll-up that maps onto the
+Rootly service catalog. No enum collapse. One fix: drop
+`BusinessUnit.residential_staging` (§3.2e). See spec §1.3.
+
+**Q6. — RESOLVED 2026-08-17 (tmacey).** Central backfill by the infrastructure team,
+plus a CI gate with a shrinking allowlist so the gap cannot reopen. Infra already owns
+most of the unlabeled workloads (`operations-production` 97%, `data-production` 96%).
+Phase 2 is weeks, not quarters. See spec §1.4, §3.3, §3.4.

--- a/docs/plans/rootly-labeling-and-alert-routing-analysis.md
+++ b/docs/plans/rootly-labeling-and-alert-routing-analysis.md
@@ -711,11 +711,13 @@ proposed §7.4 urgency table; environment-based handling belongs in routing
 
 > **§7, §8 and §9 of this document are superseded by
 > [rootly-label-routing-implementation-spec.md](rootly-label-routing-implementation-spec.md)
-> (2026-08-17).** The measurements in §0-§6 stand, with three corrections recorded in
+> (2026-08-17).** The measurements in §0-§6 stand, with the corrections recorded in
 > that spec's §0: the kube-state-metrics change needs *two* independent gates rather
 > than one (the chart's own allow-list also drops `kube_*_labels`); §7.3's code sketch
-> nests the Helm value one level too deep and would silently no-op; and the join target
-> differs per rule, so 16 of 20 EKS rules are rewritable rather than all 18.
+> nests the Helm value one level too deep and would silently no-op; the join target
+> differs per rule, so 16 of 20 EKS rules are rewritable rather than all 18; and §5.5's
+> speculation that the `Grafana` source might be dead has since become true — PR #5400
+> repointed the Synthetic Monitoring rules away from it (Q4 below).
 
 **Q1. — RESOLVED 2026-08-17.** CI alerts keep reaching Rootly; do not drop them to
 `oblivion` in the CI stack. CI ships no metrics, so the volume is zero — the hazard is
@@ -723,10 +725,11 @@ the CI source's **High** default urgency, which is fixed at the source (High →
 rather than by hiding the path. Keeping delivery visible in Rootly keeps it auditable.
 See spec §1.1.
 
-**Q2. — RESOLVED 2026-07-30 (tmacey).** QA alerts are deferred to business hours but
-not silenced: they often act as precursors to production issues as QA changes get
-promoted. Implemented as Slack-only notification with no paging and no deferral path
-— see §8.1 for the reasoning and the resulting change to §7.4.
+**Q2. — RESOLVED 2026-07-30 (tmacey).** QA alerts **notify without paging**, and are not
+silenced: they often act as precursors to production issues as QA changes get promoted.
+Implemented as Slack-only notification, delivered immediately, with no paging target and
+deliberately **no** deferral path — §8.1 explains why deferral is the wrong tool here
+even though it is the mechanism used for Medium urgency elsewhere.
 
 **Q3. — RESOLVED 2026-08-17 (tmacey).** The demotion was **deliberate**. MySQL,
 MongoDB, OpenSearch, Qdrant, ClickHouse and StarRocks are replicated enough that a
@@ -736,15 +739,19 @@ behaviour but expressing it per-workload rather than per-alertname. **This inval
 benefit to near zero — the remaining justification is routing precision and
 maintainability, stated explicitly in spec §1.2.
 
-**Q4. — RESOLVED 2026-08-17, by evidence.** The `Grafana` source is **live**. The
-UI-created `Rootly` contact point (uid `eel3rjpiwahoge`) posts to
-`grafana_webhooks?secret=09f9d82f…`, byte-identical to source `f4d836c0`'s secret; its
-traffic is the three Synthetic Monitoring rules that set
-`notification_settings.receiver: "Rootly"`. So the route is not removable — but its
-three `component` rules are still unreachable, because SM alerts carry no `component`
-and the EKS alerts that will carry one arrive at the `alertmanager` sources instead.
-They must be **moved** to the Grafana Production Service Route, not repaired in place.
-See spec §0.4.
+**Q4. — RESOLVED 2026-08-17, by evidence.** The `Grafana` source (`f4d836c0`) is now
+**inert**, and the "Grafana Service Route" bound to it is dead — as this section
+originally suspected. It *was* fed by the three MIT Learn Synthetic Monitoring rules via
+the UI-created `Rootly` contact point (`eel3rjpiwahoge`, the `grafana_webhooks`
+endpoint), but **PR #5400 removed that override on 2026-08-13**; live provisioning API
+confirms all six SM rules now carry `receiver: policy-tree`, routing through Pulumi's
+`rootly` contact point to the production `alertmanager` source `90cda8ea` instead.
+
+Those rules emit `service=mitlearn` and `component=webapp|api|nextjs`, so **two of the
+three "dead" `component` rules would match today** if moved to the Grafana Production
+Service Route — reaching `MIT Learn - API` and `MIT Learn - NextJS`, two of the 19
+orphaned services in §5.3, with no label-pipeline work at all. Move them; delete the
+route they sit on. See spec §0.4 and step P1.5.
 
 **Q5. — RESOLVED 2026-08-17 (tmacey).** Keep both, with distinct jobs: `ou` is the
 cost-allocation axis, `product` is the alerting/ownership roll-up that maps onto the


### PR DESCRIPTION
### What are the relevant tickets?
Refs https://github.com/mitodl/ol-infrastructure/issues/5179

### Description (What does it do?)
Docs only. Adds the implementation spec for wiring the `ol.mit.edu/*` label hierarchy into Rootly alert routing, and checks in the three alerting analysis documents it builds on (written in earlier sessions, never committed).

- `rootly-label-routing-implementation-spec.md` — new. Supersedes §7–§9 of the baseline analysis; its measurements still stand.
- `rootly-labeling-and-alert-routing-analysis.md` — §9 annotated with the six resolutions and a pointer to the spec.
- `grafana-alerting-remediation-spec.md`, `grafana-alerting-holistic-analysis.md` — checked in unchanged; the new spec links to the first as its companion.

Three corrections to the plan, all in the spec's §0:

- **The kube-state-metrics change is two Helm values, not one.** Gate 1: `createPodLabelsGenerator` returns an empty family when `--metric-labels-allowlist` is empty, so no `kube_*_labels` series exist today. Gate 2: the `k8s-monitoring` chart's default KSM allow-list keeps exactly one `*_labels` metric (`kube_persistentvolumeclaim_labels`), so Alloy drops the rest post-scrape. Both `telemetryServices` and `clusterMetrics.…metricsTuning.includeMetrics` are required, and neither failure mode is distinguishable from Mimir — apply both and check once.
- **The drafted value would have silently no-opped.** It nested `metricLabelsAllowlist` one level deep; the schema has no such property and doesn't set `additionalProperties: false`. That value's chart default is also non-empty — a `nodes=[…]` entry with 20 labels the Grafana Cloud node views depend on, which Helm list-replacement drops.
- **The join target differs per rule.** `eks_general.py`'s 20 rules aggregate at six granularities, so five KSM resource kinds must be allowlisted and 16 of 20 rules are rewritable. `HPAAtMaxReplicas*` can't be joined at all (KEDA owns the HPA; `scaleTargetRef` isn't a metric); `NodeNotReady*` isn't a workload condition.

Two resolutions change the plan rather than confirm it:

- The stateful-service demotion was **deliberate**, so MySQL/MongoDB/OpenSearch/Qdrant/ClickHouse/StarRocks stay at `notify`. That invalidates §7.5's escalation column and drops Phase 3's paging-volume benefit to near zero — the spec re-justifies it on routing precision and maintainability instead, and says so plainly.
- The Rootly `Grafana` source `f4d836c0` is **inert** and its route is dead — PR #5400 repointed the three Synthetic Monitoring rules off the UI-created duplicate contact point on 2026-08-13, and live provisioning confirms all six now carry `receiver: policy-tree`. Those rules land on the production `alertmanager` source carrying `service=mitlearn` and `component=api|nextjs`, so **moving two existing routing rules reaches `MIT Learn - API` and `MIT Learn - NextJS` today** — two of the 19 orphaned services, with no label pipeline. Sequenced as step P1.5, the cheapest item in the project.

Coverage is a **routing-quality** gate, not an alert-availability one: once the allowlist is configured KSM emits a series for every pod with `Value: 1`, so an unlabeled workload gets a join partner and its alert fires untier-ed, falling through to today's `severity` behaviour. Phase 3 therefore degrades gracefully at partial coverage and is not hard-gated on the backfill. The one construct that *would* silence alerts is the Dagster series-drop rule, scoped to run pods by name for exactly that reason.

### How can this be tested?
No code changed, so there is nothing to deploy or run. What can be checked is whether the §0 claims hold — each was verified live on 2026-08-17 and each is re-runnable:

- Both gates and the absent series, against the production Mimir tenant:
  ```
  count(kube_pod_labels) or vector(-1)                     → -1
  /api/v1/label/__name__/values?match[]={__name__=~"kube_(pod|deployment|statefulset|namespace)_(labels|info|annotations|owner)"}
                                                           → ["kube_pod_info","kube_pod_owner"]
  ```
  `kube_pod_info` present and `kube_pod_labels` absent is the tell for the second gate: KSM can't be the reason the series is missing entirely.
- The chart facts, against `k8s-monitoring` 4.4.0 (`helm pull grafana/k8s-monitoring --version 4.4.0`):
  `charts/feature-cluster-metrics/default-allow-lists/kube-state-metrics.yaml` (one `*_labels` entry), `charts/telemetry-services/values.schema.json` (`metricLabelsAllowlist` a flat string array, no nested key), `charts/telemetry-services/values.yaml:82` (the non-empty `nodes=[…]` default).
- The Q4 resolution, against the production Grafana provisioning API: `GET /api/v1/provisioning/contact-points` shows contact point `Rootly` (`eel3rjpiwahoge`) posting to the `grafana_webhooks` endpoint with a token matching alert source `f4d836c0`, while Pulumi's `rootly` (`bfsoqo63lsyrka`) posts to `alertmanager_webhooks`.
- Phase 1 status, against the repo: all 12 `rootly.AlertRoute` resources present in `src/ol_infrastructure/saas/rootly/__main__.py` (PR #5218), and the Low/Medium non-paging escalation paths at `:729` and `:758` (PRs #5354, #5377).

The `kube_pod_labels` emission semantics above — both branches — are from `kube-state-metrics` `internal/store/pod.go`, `createPodLabelsGenerator`.

`pre-commit run --files` passes on all four documents.

### Additional Context
The decisions in §1 are the ones worth pushing back on — Q3 (stateful stays `notify`) is what shrinks Phase 3's benefit, and Q6 (central backfill plus a CI gate) is what makes Phase 2 the long pole. §6 lists five items still open, including the `alert_tier` default for the backfill's tail and whether `kube_job_labels` is populated by the launching controllers at all.
