### PR TITLE
feat(edxapp): adopt the new Granian defaults for CMS, and pull LMS out of stage 3

### DIFF
--- a/docs/plans/granian-configuration-overhaul.md
+++ b/docs/plans/granian-configuration-overhaul.md
@@ -367,11 +367,16 @@ Component change lands once; per-app behavior changes as each app's stack is dep
   | `mitx` CMS | 2 | 0.25 | 0.005 | 0.07 | 8.0 |
   | `mitx-staging` CMS/LMS | 1 each | ~0.15 | ~0.06 | ~0.07 | ~1 |
 
-  `mitxonline` LMS is the **only** workload in the estate whose measured demand exceeds
-  the new default, and it does so at the 99th percentile by more than 2×. Everything else
-  is one to two orders of magnitude below 8. So LMS does not want the default at all — it
-  wants `blocking_threads` set explicitly from measurement, somewhere around 16–24. That
-  is this plan's own open item 3 arriving early, and it is tracked as
+  Two workloads exceed the new default of 8 at p99, and the gap between them is the
+  whole decision. `mitxonline` CMS is *marginally* over — 8.7 against 8, within the
+  noise of a p99 computed over 3 pods at 0.9 rps — which is a capacity to watch, not a
+  capacity to reject; see the CMS risk assessment below. `mitxonline` LMS is over by
+  more than **2×** — 17.7 against 8 — which is a different claim entirely. Everything
+  else in the estate is one to two orders of magnitude below 8.
+
+  So LMS does not want the default at all — it wants `blocking_threads` set explicitly
+  from measurement, somewhere around 16–24. That is this plan's own open item 3 arriving
+  early, and it is tracked as
   `tk-edxapp-lms-needs-blocking-threads-sized-from-mea-317fe2`.
 
   Note what this says about the original ordering. "CMS first, it takes far less traffic
@@ -392,6 +397,15 @@ Component change lands once; per-app behavior changes as each app's stack is dep
   respawns and 77 restarts over 14 days but **zero over the last 3**, once its VPA grew
   the pods past the declared 4Gi. LMS respawns, by contrast, are ongoing (8 and 10 over
   14 days), which is a second independent reason to keep it at 2 workers for now.
+
+  > Growing *past* the declared 4Gi limit looks impossible given
+  > `webapp_vpa_max_allowed_memory="4Gi"`, and a reviewer read it that way. It is not.
+  > `maxAllowed` bounds the **request**, and `controlledValues: RequestsAndLimits` then
+  > scales the limit to preserve the pod spec's original request:limit ratio — 2Gi:4Gi,
+  > i.e. 2×. So the effective limit ceiling is 8Gi, not 4Gi. Confirmed live in
+  > `applications-production`: request 2990.9MiB (under the 4096MiB `maxAllowed`), limit
+  > 5981.8MiB, ratio exactly 2.0, and the 14d limit series ranges 4096–7755MiB. Anything
+  > sizing a cap against `maxAllowed` needs to multiply by that ratio first.
 
   **Blast radius.** `k8s_resources.py` is shared, so the CMS edit changes CMS for
   `mitxonline-openedx`, `mitx-openedx` and `mitx-staging-openedx` as each stack deploys —

--- a/docs/plans/granian-configuration-overhaul.md
+++ b/docs/plans/granian-configuration-overhaul.md
@@ -350,6 +350,58 @@ Component change lands once; per-app behavior changes as each app's stack is dep
      `count by (namespace) (granian_workers_spawns)` and `up{namespace="mitxonline"}`
      after the production deploy.
 
+  **Resequenced 2026-08-17: `edxapp` CMS goes first, and LMS is pulled out of stage 3.**
+  With `mitxonline` blocked and `edxapp` blocked by nothing, CMS went ahead. Measuring to
+  order the rest produced a result the plan did not anticipate.
+
+  Concurrency demand per pod, measured as
+  `sum by (pod) (rate(granian_blocking_busy_cumulative[5m])) / 1e6` — mean
+  concurrently-busy blocking threads. Today each pod has 2 × 32 = 64; after the change,
+  1 × 8 = 8.
+
+  | workload | pods | rps | mean | **p99** | max |
+  | --- | --- | --- | --- | --- | --- |
+  | `mitxonline` CMS | 3 | 0.9 | 0.06 | **8.7** | 21.6 |
+  | `mitxonline` **LMS** | 16 | 62.4 | 0.41 | **17.7** | 56.4 |
+  | `mitx` LMS | 4 | 4.4 | 0.11 | 0.27 | 20.9 |
+  | `mitx` CMS | 2 | 0.25 | 0.005 | 0.07 | 8.0 |
+  | `mitx-staging` CMS/LMS | 1 each | ~0.15 | ~0.06 | ~0.07 | ~1 |
+
+  `mitxonline` LMS is the **only** workload in the estate whose measured demand exceeds
+  the new default, and it does so at the 99th percentile by more than 2×. Everything else
+  is one to two orders of magnitude below 8. So LMS does not want the default at all — it
+  wants `blocking_threads` set explicitly from measurement, somewhere around 16–24. That
+  is this plan's own open item 3 arriving early, and it is tracked as
+  `tk-edxapp-lms-needs-blocking-threads-sized-from-mea-317fe2`.
+
+  Note what this says about the original ordering. "CMS first, it takes far less traffic
+  than LMS" is true on traffic and wrong on risk: `mitxonline` CMS at 0.9 rps needs p99
+  8.7 threads while `mitx` LMS at 4.4 rps needs 0.27. Concurrency is rate × service time,
+  and Studio's long authoring operations dominate the second term. **Ordering a staged
+  rollout by request rate put the riskier workload in the "safe canary" slot.** Method
+  recorded as `pat-size-granian-blocking-threads-from-busy-thread-c-3a8b48`; note in
+  particular that `granian_blocking_threads` measures threads *spawned*, not busy, and
+  reads 32 for every edxapp workload including those needing 0.07.
+
+  CMS was judged safe despite p99 8.7 sitting right at the ceiling: 0.9 rps over 3 pods,
+  and the spikes are Studio import/export bursts whose blast radius is a slow authoring
+  operation rather than learner traffic. Its `workers_max_rss` is unchanged in aggregate —
+  the component derives `floor(limit / workers × 0.9)`, so 2 × 921MiB and 1 × 1843MiB cap
+  the pod identically (verified in the CI preview diff). What *does* change is that a
+  respawn now costs the pod's whole serving capacity instead of half; CMS showed 71 RSS
+  respawns and 77 restarts over 14 days but **zero over the last 3**, once its VPA grew
+  the pods past the declared 4Gi. LMS respawns, by contrast, are ongoing (8 and 10 over
+  14 days), which is a second independent reason to keep it at 2 workers for now.
+
+  **Blast radius.** `k8s_resources.py` is shared, so the CMS edit changes CMS for
+  `mitxonline-openedx`, `mitx-openedx` and `mitx-staging-openedx` as each stack deploys —
+  three deployments, not one. `xpro-openedx` is *not* affected: it still runs the
+  hand-rolled pre-`OLApplicationK8s` deployments (175 days old, granian args with no
+  `--blocking-threads`, `--backpressure` or `--metrics`, i.e. predating stage 0). Whenever
+  that stack next deploys it jumps roughly six months of drift in one step, which is worth
+  handling deliberately rather than discovering mid-incident
+  (`tk-xpro-edxapp-is-6-months-stale-still-on-the-hand--43a5a4`).
+
   `edxapp` is **not** affected by either finding — `mitxonline-openedx` reports
   `granian_*` normally (`cms-edxapp-webapp-pod-monitor` and `lms-edxapp-webapp-pod-monitor`
   both up), and it is behind APISIX so `apisix_http_latency_bucket` gives it the real

--- a/src/ol_infrastructure/applications/edxapp/k8s_resources.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_resources.py
@@ -1053,12 +1053,15 @@ def create_k8s_resources(  # noqa: C901
                 # 8 blocking threads, 16 backpressure) in place of the 2 workers x
                 # 32 threads Granian used to derive from backlog=128.
                 #
-                # workers_max_rss is unaffected in aggregate: the component derives
-                # floor(limit / workers * 0.9), so 2 x 1843MiB and 1 x 3686MiB cap
-                # the pod at the same total. What changes is the blast radius of a
-                # respawn -- with one worker it costs the pod's whole serving
-                # capacity rather than half -- which is why LMS, whose respawns are
-                # ongoing, is NOT part of this change.
+                # workers_max_rss is unaffected in aggregate, for every stack that
+                # shares this config: the component derives
+                # floor(limit / workers * 0.9), so halving the worker count doubles
+                # the per-worker cap and the pod total is unchanged whatever the
+                # declared limit. (mitxonline CMS at 4Gi: 2 x 1843MiB -> 1 x 3686MiB.
+                # mitx and mitx-staging CMS at 2Gi: 2 x 921MiB -> 1 x 1843MiB.)
+                # What changes is the blast radius of a respawn -- with one worker it
+                # costs the pod's whole serving capacity rather than half -- which is
+                # why LMS, whose respawns are ongoing, is NOT part of this change.
                 respawn_failed_workers=True,
                 backlog=128,
                 static_path_mounts=["/openedx/staticfiles"],

--- a/src/ol_infrastructure/applications/edxapp/k8s_resources.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_resources.py
@@ -1047,19 +1047,18 @@ def create_k8s_resources(  # noqa: C901
             granian_config=GranianConfig(
                 application_module="cms.wsgi:application",
                 port=8000,
-                workers=2,
                 no_ws=True,
-                runtime_mode="mt",
-                runtime_threads=2,
-                # Holding pins: preserve the pre-overhaul effective concurrency
-                # until this app's stage of the rollout. Granian derived
-                # backpressure=64 (backlog=128 // workers=2) and
-                # blocking_threads=64 // 2 = 32. Delete these (plus workers,
-                # runtime_mode, runtime_threads above) to adopt the component
-                # defaults (1 worker, 8 blocking threads, 16 backpressure).
-                # See docs/plans/granian-configuration-overhaul.md
-                blocking_threads=32,
-                backpressure=64,
+                # Stage 3 of docs/plans/granian-configuration-overhaul.md: holding
+                # pins deleted, so this adopts the component defaults (1 worker,
+                # 8 blocking threads, 16 backpressure) in place of the 2 workers x
+                # 32 threads Granian used to derive from backlog=128.
+                #
+                # workers_max_rss is unaffected in aggregate: the component derives
+                # floor(limit / workers * 0.9), so 2 x 1843MiB and 1 x 3686MiB cap
+                # the pod at the same total. What changes is the blast radius of a
+                # respawn -- with one worker it costs the pod's whole serving
+                # capacity rather than half -- which is why LMS, whose respawns are
+                # ongoing, is NOT part of this change.
                 respawn_failed_workers=True,
                 backlog=128,
                 static_path_mounts=["/openedx/staticfiles"],


### PR DESCRIPTION
### What are the relevant tickets?
N/A — tracked internally. All context needed to review is inline below.

### Description (What does it do?)

Stage 3 of `docs/plans/granian-configuration-overhaul.md`, resequenced. `mitxonline` is blocked on its own findings and `edxapp` is blocked by nothing, so CMS goes first.

- Deletes the CMS holding pins in `src/ol_infrastructure/applications/edxapp/k8s_resources.py`, adopting the component defaults: **1 worker, 8 blocking threads, 16 backpressure**, `runtime-mode` auto, `runtime-threads` 1 — down from 2 workers × 32 threads.
- **LMS is deliberately excluded** and pulled out of stage 3 entirely. See below.
- Records the measurement and the resequencing in the plan doc.

**Measuring to order the rest produced a result the plan did not anticipate.** Per-pod concurrency demand — `sum by (pod) (rate(granian_blocking_busy_cumulative[5m])) / 1e6`, i.e. mean concurrently-busy blocking threads — over 14 days of production, against a new ceiling of 8:

| workload | pods | rps | mean | **p99** | max |
|---|---|---|---|---|---|
| `mitxonline` CMS | 3 | 0.9 | 0.06 | **8.7** | 21.6 |
| `mitxonline` **LMS** | 16 | 62.4 | 0.41 | **17.7** | 56.4 |
| `mitx` LMS | 4 | 4.4 | 0.11 | 0.27 | 20.9 |
| `mitx` CMS | 2 | 0.25 | 0.005 | 0.07 | 8.0 |
| `mitx-staging` CMS/LMS | 1 each | ~0.15 | ~0.06 | ~0.07 | ~1 |

`mitxonline` LMS is the only workload in the estate whose measured demand exceeds the new default, and it does so at the 99th percentile by more than 2×. Everything else is one to two orders of magnitude below 8. LMS doesn't want the default — it wants `blocking_threads` set explicitly from measurement, around 16–24. That's the plan's own open item 3 arriving early, and it's tracked separately.

**This also shows the original ordering was reasoning from the wrong quantity.** "CMS first, it takes far less traffic than LMS" is true on traffic and wrong on risk: `mitxonline` CMS at 0.9 rps needs p99 8.7 threads while `mitx` LMS at 4.4 rps needs 0.27. Concurrency is rate × service time, and Studio's long authoring operations dominate the second term. Ordering a staged rollout by request rate put the riskier workload in the "safe canary" slot.

Two metrics that look like they answer this and don't, in case a reviewer reaches for them:
- `granian_blocking_threads` is threads *spawned*, not busy — Granian grows the pool on demand and doesn't promptly reap, so it reads 32 for every edxapp workload including ones needing 0.07.
- Peak `granian_blocking_queue` is dominated by rare transients. Peaks of 27–32 look alarming, but queue depth is 0 at p99 everywhere and non-empty only 0.0–0.4% of the time.

**Why CMS is still safe** at p99 8.7 against a ceiling of 8: it's 0.9 rps over 3 pods, and the spikes are Studio import/export bursts whose blast radius is a slow authoring operation, not learner traffic.

`workers_max_rss` is unchanged in aggregate — the component derives `floor(limit / workers × 0.9)`, so 2 × 921MiB and 1 × 1843MiB cap the pod identically (visible in the preview diff below). What does change is that a respawn now costs the pod's whole serving capacity instead of half. CMS showed 71 RSS respawns and 77 container restarts over 14 days but **zero over the last 3**, once its VPA grew the pods past the declared 4Gi — that churn is historical. LMS respawns by contrast are ongoing (8 for `mitxonline` LMS, 10 for `mitx` LMS over 14 days), which is a second independent reason to keep it at 2 workers for now.

### How can this be tested?

- `uv run pytest tests/ol_infrastructure/` — 413 passed.
- `uv run pre-commit run --files src/ol_infrastructure/applications/edxapp/k8s_resources.py` — clean (ruff, mypy, detect-secrets).
- `pulumi preview --stack mitxonline.CI` on `edxapp` — **exactly one resource updated**, `cms-edxapp-application-ci-deployment`, 229 unchanged. The LMS Deployment does not appear in the diff. The arg changes are:

```
~ [7]:  "2"  => "1"            # --workers
  --runtime-mode mt            # removed
~ --runtime-threads  2 => 1
~ --blocking-threads 32 => 8
~ --backpressure     64 => 16
~ --workers-max-rss 921 => 1843   # aggregate unchanged: 2x921 == 1x1843
```

(The diff renders as a positional shift because removing `--runtime-mode mt` re-indexes the arg list.)

Note for anyone re-running that preview: `EDXAPP_DOCKER_IMAGE_DIGEST` must be set or the program raises before building any k8s resources — and it still **exits 0**, reporting "174 unchanged". A clean-looking resource count is not proof the preview ran.

To validate after deploy — edxapp is behind APISIX, so unlike the stage-2 apps it has real latency percentiles:

```promql
histogram_quantile(0.95, sum by (le) (rate(apisix_http_latency_bucket{route=~".*edxapp-cms.*"}[5m])))
sum by (pod) (rate(granian_blocking_busy_cumulative{container="cms-edxapp-app"}[5m])) / 1e6   # vs ceiling of 8
increase(granian_workers_respawns_for_rss{container="cms-edxapp-app"}[1d])                    # should stay 0
max_over_time(granian_blocking_queue{container="cms-edxapp-app"}[1d])
```

### Additional Context

- **Blast radius is three deployments, not one.** `k8s_resources.py` is shared, so this changes CMS for `mitxonline-openedx`, `mitx-openedx` and `mitx-staging-openedx` as each stack deploys. The two residential CMSes are trivially loaded (p99 0.07 and ~0.07 threads), so they carry no risk.
- **`xpro-openedx` is not affected by this PR, but is worth knowing about.** It still runs the hand-rolled pre-`OLApplicationK8s` deployments (`xpro-production-edxapp-{cms,lms}-webapp`, 175 days old) rather than `cms-edxapp-app`. Its live granian args have no `--blocking-threads`, no `--backpressure` and no `--metrics` — they predate stage 0 (merged 2026-07-23), which is also why `xpro-openedx` reports no `granian_*` series. Whenever that stack next deploys it will be replaced by the component-managed Deployment and jump roughly six months of accumulated drift in one step. Pre-existing and filed separately; flagging it so it isn't discovered during an unrelated urgent deploy.
