### PR TITLE
fix(github): refuse to let crawl silently revert an unapplied team-grant remediation

### DIFF
--- a/bin/github-org-inventory
+++ b/bin/github-org-inventory
@@ -890,6 +890,38 @@ def report(
     )
 
 
+def _team_permission_conflicts(
+    out: Path, repo_name: str, new_teams: dict[str, str]
+) -> list[str]:
+    """Team-grant changes this crawl is about to write over what's already committed.
+
+    `teams:` is emitted verbatim from live GitHub on every crawl (see `crawl`), with no
+    comparison against the archetype -- so it doubles as both "what the fleet observed"
+    and "what a phase-5 remediation declares as the target". Those two roles collide the
+    moment a human edits a repo's `teams:` to a tighter value (e.g. SEC-15's admin ->
+    push) and a `crawl --refresh` runs before `pulumi up` has applied it: the refresh
+    re-observes the still-unfixed live grant and silently overwrites the declared fix
+    back to match it. Caught twice by PR review, not by any tooling -- see witan task
+    tk-github-org-inventory-crawl-silently-reverts-pending-e65389.
+
+    Returns one human-readable line per team whose grant is about to change, or an empty
+    list if the file doesn't exist yet or nothing about `teams:` would change.
+    """
+    existing_path = out / f"{repo_name}.yaml"
+    if not existing_path.exists():
+        return []
+    existing_teams = (yaml.safe_load(existing_path.read_text()) or {}).get(
+        "teams"
+    ) or {}
+    if existing_teams == new_teams:
+        return []
+    return [
+        f"{repo_name}: {team} {existing_teams.get(team)!r} -> {new_teams.get(team)!r}"
+        for team in sorted(set(existing_teams) | set(new_teams))
+        if existing_teams.get(team) != new_teams.get(team)
+    ]
+
+
 def _resolve_archetype(archetypes: dict[str, Any], name: str) -> dict[str, Any]:
     """Flatten an archetype's `extends` chain into the effective settings.
 
@@ -945,6 +977,18 @@ def crawl(
     out: Annotated[
         Path, cyclopts.Parameter(help="Directory for per-repo YAML.")
     ] = DATA_DIR / "repos",
+    allow_team_drift: Annotated[
+        bool,
+        cyclopts.Parameter(
+            help=(
+                "Write over a repo's committed `teams:` even though live GitHub still "
+                "disagrees with it -- i.e. accept live as ground truth instead of "
+                "treating the committed value as a pending-but-unapplied remediation. "
+                "Without this, a repo whose `teams:` would change is refused rather "
+                "than silently reverted."
+            )
+        ),
+    ] = False,
 ) -> None:
     """Emit one YAML file per repo, carrying only deviations from its archetype.
 
@@ -1005,6 +1049,34 @@ def crawl(
         raise SystemExit(message)
 
     out.mkdir(parents=True, exist_ok=True)
+
+    # Detect before writing anything: once a repo's file is overwritten the previously
+    # committed (possibly pending-but-unapplied) `teams:` value is gone, and there's no
+    # signal left in this run to warn from.
+    team_drift = sorted(
+        line
+        for repo in data["repos"]
+        for line in _team_permission_conflicts(out, repo["name"], repo["teams"] or {})
+    )
+    if team_drift and not allow_team_drift:
+        message = (
+            f"{len(team_drift)} team grant(s) would change on this crawl, which would "
+            "overwrite a committed value that live GitHub does not yet match -- most "
+            "likely a phase-5 remediation (e.g. SEC-15) that hasn't had `pulumi up` run "
+            "for it yet:\n  "
+            + "\n  ".join(team_drift)
+            + "\nRun `pulumi up` for the affected repos first so live matches the "
+            "committed value, then re-crawl. If live is correct and the committed value "
+            "is simply stale, re-run with --allow-team-drift to accept live."
+        )
+        raise SystemExit(message)
+    if team_drift:
+        print(
+            f"--allow-team-drift set: accepting {len(team_drift)} live team grant "
+            "change(s) over the committed value:\n  " + "\n  ".join(team_drift),
+            file=sys.stderr,
+        )
+
     written = 0
     for repo in data["repos"]:
         archetype = assigned[repo["name"]]


### PR DESCRIPTION
### What are the relevant tickets?
N/A — internal witan task `tk-github-org-inventory-crawl-silently-reverts-pending-e65389` on the GitHub-org-import project.

### Description (What does it do?)
`bin/github-org-inventory crawl` writes each repo's `teams:` field verbatim from live GitHub on every run, with no comparison against the archetype or against what's already committed. That's correct for phase 1 (record reality) but breaks phase 5 (remediation): a human declares a tighter grant in `data/repos/*.yaml` (e.g. SEC-15's `admin -> push`), and if `crawl --refresh` runs before `pulumi up` has applied it, the refresh re-observes the still-unfixed live grant and silently overwrites the declared fix back to match it — turning a pending `pulumi preview` change into a no-op.

This already happened twice in one session (see commit `555264a5b`, fixing what PR #5425's Copilot review caught) and was only caught by review, not by any tooling.

- `crawl` now compares each repo's about-to-be-written `teams:` against what's already on disk before writing anything.
- If any repo's team grants would change, the whole run aborts (writing **nothing**) with a message listing every repo/team/old-value/new-value, and instructs the operator to either run `pulumi up` for the affected repos first or explicitly accept live via the new `--allow-team-drift` flag.
- Scoped to `teams:` only, since that's the field proven to bite (and the only one a phase-5 remediation currently declares as a target ahead of apply); other verbatim-copied fields (`description`, `topics`, etc.) are unaffected.

### How can this be tested?
Ran `crawl` locally against a stale cache (2026-08-05, predating the committed team-grant remediations):
- Without `--allow-team-drift`: exits 1, prints 365 team-grant conflicts, and writes **zero** files (`git status` on `data/repos/` stayed clean).
- With `--allow-team-drift`: proceeds past the guard into the normal write path.

`ruff check` / `ruff format --check` and the repo's full pre-commit hook set (including `mypy`) pass on `bin/github-org-inventory`.

A reviewer can reproduce by running `uv run bin/github-org-inventory crawl` from a branch with any local edit to a `data/repos/*.yaml` `teams:` block that doesn't match live — it should refuse.

### Additional Context
Scoped intentionally narrow: this is a safety net, not a resolution of the deeper "crawl vs. declared-but-unapplied state" design tension flagged in the task (which lists three possible fixes and defers the decision). It converts the previously-silent revert into a loud, blocking one without changing the tool's default source-of-truth behavior for anything else.