### PR TITLE
fix(dagster): re-tune the PgBouncer pool from a week of exporter data

### DIFF
--- a/docs/plans/dagster-pgbouncer-observability.md
+++ b/docs/plans/dagster-pgbouncer-observability.md
@@ -252,6 +252,44 @@ whether the new `max_db_connections` cap is set too tight.
 Pin the exporter at **>= v0.12.1**: earlier releases report the `reserve_pool` metric
 incorrectly against PgBouncer >= 1.24, and `PGBOUNCER_VERSION` is 1.25.2.
 
+#### The answers (2026-08-17, seven days of 1-minute samples on production)
+
+The exporter shipped in #5426; this is what it said. Every number is a max over the
+full window unless stated.
+
+| Question | Answer |
+|---|---|
+| Is `default_pool_size = 800` anywhere near right? | No — it was never reachable. The derived `max_db_connections` is 708/pod, so 800 could not bind on production. Peak `sv_active` was **122 aggregate**. |
+| Is `min_pool_size = 150` × 6 justified? | **No.** Held connections sat at a flat **900 every single sample, all week**, and the pool never once grew past its own floor. 900 parked to serve a peak of 122. |
+| Is `reserve_pool_size = 2000` ever entered? | Not since the cap landed, and it cannot be: 800 + 2000 per pod is far above the 708 cap, so it was dead configuration. |
+| Is `max_client_conn = 1500` a real ceiling? | No — peak `cl_active` was **129 aggregate, 35 on the busiest pod**. It is deliberately far above demand so a saturated pool queues rather than refuses. |
+| Was disabling `query_wait_timeout` the right call? | No, and it was already reverted to 600 in #5454 after QA deadlocked for days. `maxwait` was **0 at every sample** on production; `client_waiting` peaked at 1. |
+| Do we need 6 replicas? | Not for load — peak **0.09 CPU cores** and 35 active clients on the busiest pod. See below. |
+| Are we heading for another 08-10? | Not on this evidence: 122 against a 4248 aggregate cap, and the cap now makes the 08-10 mode structurally unreachable. |
+
+**Skew: production does not have QA's.** The QA deadlock measured 221 active servers on
+one replica against 4 on the other, which matters because `max_db_connections` is derived
+as budget ÷ replica count and therefore assumes even distribution — under skew the real
+ceiling is whichever pod saturates first, not the aggregate. Production was checked
+specifically for this before re-tuning and spreads evenly (1–18 active per pod at any
+instant). So the aggregate cap is an honest number here, and fewer/larger replicas is an
+option rather than a fix that is owed.
+
+**What changed as a result.** `min_pool_size` 150 → 40 (sized to the measured 35-per-pod
+peak, so nothing in normal operation waits on a connect; parked total 900 → 240).
+`default_pool_size` → the derived cap and `reserve_pool_size` → 0, which retires two dead
+numbers and leaves `max_db_connections` as the pool's single binding ceiling. That last
+part is not cosmetic: `DagsterPgBouncerConnectionHeadroom` alerts on a fraction of
+`pgbouncer_databases_max_connections`, so any pool number set *below* the cap would
+become the real limit while the alert kept measuring against one the pool could no longer
+reach — a rule that can never fire.
+
+`pgbouncer_replica_count` was left at 6 on purpose. Changing the multiplier in the same
+pass as `min_pool_size` would make the result unattributable, which is the habit this
+whole exercise exists to break. It is the obvious next lever once this change has a week
+of its own data: at 6 replicas a single hot pod saturates at 708 while 3540 connections
+sit idle on the other five.
+
 ### 2. RDS — re-enable Performance Insights
 
 The exporter gives us the pool's view; it does not tell us what those connections are
@@ -440,10 +478,11 @@ time, no retry attribution), so treat it as a cheap stopgap rather than a substi
 5. **Dagster SQL exporter.** Larger build; sequence after the pool picture is clear.
    Note it must connect **directly to RDS**, which means it consumes from the same 5000 —
    budget for it in (0).
-6. **Re-tune from data.** Specifically: whether `min_pool_size = 150` is buying anything
-   at 6 replicas when steady-state demand is 27 servers, and whether 6 replicas are
-   justified at ~30 mCPU each. `reserve_pool_size` is no longer an open question — it is
-   reachable, it was reached, and (0) is what bounds it.
+6. **Re-tune from data.** ✅ Done 2026-08-17 — see
+   [The answers](#the-answers-2026-08-17-seven-days-of-1-minute-samples-on-production).
+   `min_pool_size` 150 → 40, `default_pool_size` → the derived cap, `reserve_pool_size`
+   → 0. Replica count deliberately held at 6 so this change is attributable; it is the
+   next lever.
 
 ## Open question worth flagging
 

--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -643,12 +643,29 @@ dagster_db_secret = OLVaultK8SSecret(
 
 # Replica count is needed here to size the per-pod connection cap below, so it is
 # resolved before the ConfigMap rather than next to the Deployment that consumes it.
+#
+# Production's 6 is not load-derived and the exporter now says so: over seven days the
+# busiest replica peaked at 0.09 CPU cores and 35 active clients. PgBouncer is
+# single-threaded, which is the usual reason to run several, but nothing here is close
+# to needing the parallelism.
+#
+# The count is not free either. It divides the aggregate budget into per-pod caps, so at
+# 6 replicas one pod saturates at 708 while 3540 connections sit unused on the other
+# five -- and the binding limit is whichever pod saturates first, not the aggregate.
+# That gap is real on QA, which measured 221 active servers on one replica against 4 on
+# the other. Production was checked for the same skew before this re-tune and does not
+# show it: instantaneous load spreads evenly (1-18 active per pod), so fewer/larger
+# replicas is a live option rather than an urgent fix.
+#
+# Left alone here deliberately. This pass changes min_pool_size, and changing the
+# multiplier in the same breath would make the result unattributable -- which is the
+# failure mode the whole exercise exists to stop repeating.
 pgbouncer_replica_count = dagster_config.get_int("pgbouncer_replica_count") or 2
 
 # Cap the connections PgBouncer can open against RDS, in aggregate across every replica.
 #
 # Without this, nothing bounds the total. In session pool mode each client pins a server
-# connection for its whole session, so the per-pod bound is
+# connection for its whole session, so the per-pod bound was
 # min(max_client_conn, default_pool_size + reserve_pool_size) = 1500 -- which at 6
 # replicas is 9000 possible backends against a hard max_connections of 5000. On
 # 2026-08-10 the pool reached that limit and held it for 88 consecutive minutes
@@ -696,15 +713,58 @@ pgbouncer_ini_template = dagster_db.db_instance.address.apply(
             "listen_port = 5432",
             "auth_type = any",
             "pool_mode = session",
+            # Clients are cheap -- an accepted client that is waiting for a backend
+            # costs a socket, not a connection to RDS -- and this number has to stay
+            # well above max_db_connections or a saturated pool refuses clients
+            # instead of queueing them. Observed peak is 35 on the busiest replica,
+            # so 1500 is not a number the data argues about; it is deliberately far
+            # larger than demand.
             "max_client_conn = 1500",
-            "default_pool_size = 800",
-            "min_pool_size = 150",
-            "reserve_pool_size = 2000",
+            # One binding ceiling, not three.
+            #
+            # These were 800 / 150 / 2000, all set before there was any feedback
+            # signal. Seven days of 1-minute exporter samples (the exporter landed in
+            # #5426) say what they are actually worth:
+            #
+            #   held server connections   flat 900, every sample, all week
+            #   peak server_active        122 aggregate
+            #   peak client_active        129 aggregate, 35 on one replica
+            #   maxwait                   0 at every sample
+            #   clients waiting           peaked at 1
+            #
+            # 900 was not demand. It is min_pool_size x 6 replicas -- a configured
+            # constant, which is exactly what made CloudWatch DatabaseConnections
+            # useless as a signal. Nine hundred backends were parked permanently to
+            # serve a peak of 122, a 7:1 idle ratio, and the pool never once grew
+            # past its own floor.
+            #
+            # min_pool_size 150 -> 40 keeps the whole measured per-replica peak (35)
+            # warm, so nothing in normal operation waits on a connect, and drops the
+            # parked total from 900 to 240.
+            #
+            # default_pool_size and reserve_pool_size were dead numbers: 800 + 2000
+            # per pod against a derived cap of 708 means max_db_connections already
+            # bound first, so neither value could take effect on production. Rather
+            # than pick new guesses, tie default_pool_size to the cap and disable the
+            # reserve. With a single database and a single user the two settings act
+            # on the same axis, so this makes the derived cap the only ceiling
+            # instead of the smallest of three.
+            #
+            # That property is load-bearing beyond tidiness:
+            # DagsterPgBouncerConnectionHeadroom alerts on server connections as a
+            # fraction of pgbouncer_databases_max_connections. Any pool number set
+            # below the cap would become the real ceiling while the alert kept
+            # measuring against the old denominator, and the alert would go quietly
+            # dead -- saturation would surface only as clients queueing, which is the
+            # symptom the headroom rule exists to get ahead of.
+            f"default_pool_size = {pgbouncer_max_db_connections}",
+            "min_pool_size = 40",
+            "reserve_pool_size = 0",
             # The aggregate ceiling. See the derivation above; this is the
             # only setting here that bounds total backends across replicas,
             # and it converts "exhaust RDS" into "queue inside PgBouncer",
-            # which is the failure mode query_wait_timeout = 0 below was
-            # already chosen to tolerate.
+            # which is the failure mode query_wait_timeout below is set high
+            # enough to ride out.
             f"max_db_connections = {pgbouncer_max_db_connections}",
             "max_prepared_statements = 0",
             "server_connect_timeout = 15",
@@ -1069,14 +1129,18 @@ pgbouncer_service = kubernetes.core.v1.Service(
 # whole integration. Pattern (including the "release": "prometheus" discovery label)
 # follows applications/clickhouse/__main__.py.
 #
-# These are the metrics every open pool-sizing question turns on:
-#   pgbouncer_pools_server_active_connections   -- is default_pool_size = 800 right?
-#   pgbouncer_pools_server_idle_connections     -- what is min_pool_size parking?
-#   pgbouncer_pools_client_active_connections   -- is max_client_conn a real ceiling?
+# These are the metrics the pool-sizing questions turn on. The first pass of answers
+# is what the numbers above were re-tuned from; keep watching them, because the
+# settings are now supposed to track demand rather than sit above it:
+#   pgbouncer_pools_server_active_connections   -- real demand (peak 122 aggregate)
+#   pgbouncer_pools_server_idle_connections     -- what min_pool_size parks (was 900)
+#   pgbouncer_pools_client_active_connections   -- client demand (peak 129 / 35 a pod)
 #   pgbouncer_pools_client_waiting_connections  -- is max_db_connections too tight?
 #   pgbouncer_pools_client_maxwait_seconds      -- the number pool tuning turns on,
 #                                                  unobtainable from the stats log
 #   sum of the above vs. max_connections        -- the 2026-08-10 headroom alert
+# Per-pod, not just aggregate: max_db_connections is derived as budget / replica
+# count, so a skewed pod saturates while the aggregate still looks calm.
 pgbouncer_service_monitor = kubernetes.apiextensions.CustomResource(
     f"dagster-pgbouncer-service-monitor-{stack_info.env_suffix}",
     api_version="monitoring.coreos.com/v1",

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/dagster_pgbouncer.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/dagster_pgbouncer.py
@@ -7,8 +7,9 @@ being RDS's own rdsadmin sessions) -- for 88 consecutive 1-minute samples, durin
 every new Dagster connection was refused and the daemon sat Pending behind 178 run
 workers. Nothing alerted, because nothing was collected: the only signal available was
 CloudWatch DatabaseConnections, which min_pool_size x replicas pins to a constant floor
-(900 in production) and which therefore reports a configured constant rather than
-observed demand. Background: docs/plans/dagster-pgbouncer-observability.md.
+(900 in production at the time, 240 after the pool re-tune) and which therefore reports
+a configured constant rather than observed demand. Background:
+docs/plans/dagster-pgbouncer-observability.md.
 
 Two things had to land before these rules could exist, and both did in #5426:
 the pgbouncer_exporter sidecar that produces these metrics, and the max_db_connections
@@ -36,11 +37,17 @@ from pulumi import Input, ResourceOptions
 from pulumiverse_grafana import alerting
 
 # Fraction of the aggregate max_db_connections cap at which the pool is considered
-# short of headroom. Production's floor is min_pool_size (150) x 6 replicas = 900
-# against a 4248 cap, so the baseline ratio is 0.21 and 3 days of 1-minute samples
-# never moved off it -- peak server_active over that window was 122. 0.75 therefore
-# sits ~3.5x above anything observed while still leaving a quarter of the pool in
-# reserve, which at 6 replicas is over 1000 connections of runway to act in.
+# short of headroom. Production's floor is min_pool_size x 6 replicas, which the pool
+# re-tune cut from 900 to 240 against the same 4248 cap -- so the baseline ratio moved
+# from 0.21 to 0.06, and the week of 1-minute samples behind that re-tune never left
+# the floor (peak server_active 122, peak client_active 129). 0.75 therefore sits far
+# above anything observed while still leaving a quarter of the pool in reserve, which
+# at 6 replicas is over 1000 connections of runway to act in.
+#
+# The denominator only means anything while max_db_connections is the pool's single
+# binding ceiling. It is, deliberately: default_pool_size is set equal to the cap and
+# reserve_pool_size is 0, precisely so no smaller number can quietly become the real
+# limit and leave this rule measuring against one the pool can no longer reach.
 _HEADROOM_RATIO = 0.75
 
 # Seconds the oldest queued client has been waiting before the queue counts as


### PR DESCRIPTION
Was stacked on #5460, which has since merged — this is now rebased onto `main` as a single commit and targets `main` directly.

#5460 remains the reason this change does anything at all: without its ConfigMap checksum annotation the PgBouncer pods never roll, the init container never re-renders `pgbouncer.ini`, and the new pool numbers ship completely inert. That was measured, not assumed — `pulumi preview` before #5460 showed the ConfigMap replacing while the Deployment had no diff whatsoever. Post-rebase preview now shows both: the ConfigMap replacing *and* the Deployment picking up a new `checksum/ol-pgbouncer-config`.

## What this changes

| | before | after (production) |
|---|---|---|
| `min_pool_size` | 150 | **40** |
| `default_pool_size` | 800 | **708** (= the derived cap) |
| `reserve_pool_size` | 2000 | **0** |
| `max_client_conn` | 1500 | 1500 (unchanged, deliberately) |
| `max_db_connections` | 708 | 708 (unchanged) |

Parked connections drop from **900 → 240** on production and **300 → 80** on QA.

## Why these numbers

Every pool number in this file was a guess made without a feedback signal — that is the whole reason this project exists. The exporter landed in #5426. Seven days of 1-minute samples on production:

```
held server connections   flat 900, every sample, all week
peak server_active        122 aggregate
peak client_active        129 aggregate, 35 on the busiest pod
maxwait                   0 at every sample
clients waiting           peaked at 1
busiest pod CPU           0.09 cores
```

**900 was never demand.** It is `min_pool_size` × 6 replicas — a configured constant, which is exactly what made CloudWatch `DatabaseConnections` useless as a signal in the first place. 900 backends parked permanently to serve a peak of 122, and the pool never once grew past its own floor.

`min_pool_size` 150 → 40 keeps the entire measured per-pod peak (35) warm, so nothing in normal operation waits on a connect.

**`default_pool_size` and `reserve_pool_size` were dead numbers.** 800 + 2000 per pod against a derived cap of 708 means `max_db_connections` already bound first — neither value could take effect on production. Rather than replace two guesses with two better guesses, `default_pool_size` now tracks the cap and the reserve is disabled. With a single database and a single user the two settings act on the same axis, so the derived cap becomes the pool's only ceiling instead of the smallest of three.

## The part worth reviewing carefully

That "single ceiling" property is load-bearing, not tidiness.

`DagsterPgBouncerConnectionHeadroom` (from #5454) alerts on server connections as a fraction of `pgbouncer_databases_max_connections`. **Any pool number set below the cap would silently become the real ceiling while the alert kept measuring against one the pool could no longer reach** — the rule would never fire again, and saturation would surface only as queued clients, which is the symptom the headroom alert exists to get ahead of. That is why the tempting move (shrink `default_pool_size` to something near observed demand) is the wrong one: if the pool should be smaller, shrink the *cap*, and the alert follows automatically.

The alert file's threshold rationale is updated in this PR for the same reason — it cited the 900 floor as its baseline, which is now 240.

## What is deliberately NOT changed

`pgbouncer_replica_count` stays at 6, though the data does not justify it: 0.09 cores and 35 clients on the busiest pod. Changing the multiplier in the same pass as `min_pool_size` would make the result unattributable — which is the habit this exercise exists to break. It is the obvious next lever: at 6 replicas one hot pod saturates at 708 while 3540 connections sit idle on the other five.

QA's skew (221 active servers on one replica against 4 on the other) is what makes that per-pod ceiling matter, since `max_db_connections` is derived as budget ÷ replica count and assumes even spread. **Production was checked for the same skew before re-tuning and does not show it** — 1–18 active per pod at any instant — so the aggregate cap is an honest number here and fewer/larger replicas is an option rather than a fix that is owed.

## Verification

`pulumi preview` on both stacks, on top of #5460:

- **Production** — ConfigMap replaces with `default_pool_size = 708 / min_pool_size = 40 / reserve_pool_size = 0`; Deployment updates with a new `checksum/ol-pgbouncer-config`, so the pods actually roll.
- **QA** — same, with the correctly derived `default_pool_size = 382 / max_db_connections = 382`.

`pre-commit run` (ruff, mypy, detect-secrets) passes.

Closes the `Re-tune the PgBouncer pool numbers from collected data` task. Findings written up in `docs/plans/dagster-pgbouncer-observability.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019hFBB8vgVrKnoJrZcXhMVV
