### PR TITLE
fix(eks): stop the applications clusters from hijacking residential meilisearch DNS

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.applications.CI.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.applications.CI.yaml
@@ -29,9 +29,7 @@ config:
   - courses-backend.ci.learn.mit.edu
   - courses-backend.ci.xpro.mit.edu
   - dcc.ci.learn.mit.edu
-  - meilisearch-ci.mitx.mit.edu
   - meilisearch-ci.xpro.mit.edu
-  - meilisearch-staging-ci.mitx.mit.edu
   - meilisearch.courses.ci.learn.mit.edu
   - micromasters-ci-backend.odl.mit.edu
   - nb.ci.learn.mit.edu

--- a/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.applications.Production.yaml
+++ b/src/ol_infrastructure/infrastructure/aws/eks/Pulumi.applications.Production.yaml
@@ -30,9 +30,7 @@ config:
   - courses-backend.learn.mit.edu
   - courses-backend.xpro.mit.edu
   - dcc.learn.mit.edu
-  - meilisearch-staging.mitx.mit.edu
   - meilisearch.courses.learn.mit.edu
-  - meilisearch.mitx.mit.edu
   - meilisearch.xpro.mit.edu
   - micromasters-backend.odl.mit.edu
   - nb.learn.mit.edu


### PR DESCRIPTION
### What are the relevant tickets?
N/A — found while debugging a reported TLS failure on `meilisearch.mitx.mit.edu`.

### Description (What does it do?)
Removes four `mitx.mit.edu` meilisearch hostnames from `eks:apisix_domains` in the **applications** CI and Production stacks. These hostnames belong to the **residential** clusters, and listing them here pointed their DNS at the wrong cluster's APISIX NLB.

- `eks:apisix_domains` renders into the `external-dns.alpha.kubernetes.io/hostname` annotation on the `apache-apisix-gateway` Service, so applications' external-dns was creating Route53 alias records for these names against the applications NLB.
- The applications clusters have no HTTPRoute, no `ApisixTls`, and no certificate for these SNIs, so APISIX aborted the handshake with TLS alert 80 (`internal_error`) and served **no certificate at all**.
- Residential's external-dns saw the records as foreign-owned (ownership TXT `cname-meilisearch.mitx.mit.edu` named `applications-production`) and logged `All records are already up to date` every minute, so nothing self-healed.

Four hostnames were affected, not just the reported one:

| Hostname | Was resolving to | Should resolve to |
|---|---|---|
| `meilisearch.mitx.mit.edu` | applications-production | residential-production |
| `meilisearch-staging.mitx.mit.edu` | applications-production | residential-production |
| `meilisearch-ci.mitx.mit.edu` | applications-ci | residential-ci |
| `meilisearch-staging-ci.mitx.mit.edu` | applications-ci | residential-ci |

Deletion only — nothing moves to the residential stack configs. The residential meilisearch records are produced by external-dns's `gateway-httproute` source (HTTPRoute → `apisix` Gateway → that Gateway's `external-dns.alpha.kubernetes.io/target` annotation), which needs no `apisix_domains` entry. `apisix_domains` feeds only the legacy `service` source, which is why `courses-backend`/`studio-backend`/`preview-backend` are still listed there — those use `ApisixRoute` CRDs rather than HTTPRoutes. The hostname itself is already declared once in the edxapp stack config as `meilisearch:domain`.

`applications.QA` is the natural control: it has never listed a `mitx.mit.edu` meilisearch hostname, and `meilisearch-mitx-qa.mitx.mit.edu` is the only one of the five that currently serves a valid certificate.

### How can this be tested?
Confirmed the certificate and backend are healthy on the correct cluster by pinning DNS past the bad record to residential-production's APISIX NLB:

```
$ curl -sS --resolve meilisearch.mitx.mit.edu:443:100.24.214.127 \
    https://meilisearch.mitx.mit.edu/health -w "\nHTTP %{http_code} | tls_verify=%{ssl_verify_result}\n"
{"status":"available"}
HTTP 200 | tls_verify=0
```

The Let's Encrypt cert (`CN=meilisearch.mitx.mit.edu`, valid 2026-07-29 → 2026-10-27) is issued and `Ready` in `mitx-openedx`, and APISIX serves it correctly for that SNI. Only DNS was wrong.

Current failure state for comparison:

```
meilisearch.mitx.mit.edu            NO CERT / handshake failed
meilisearch-staging.mitx.mit.edu    NO CERT / handshake failed
meilisearch-ci.mitx.mit.edu         NO CERT / handshake failed
meilisearch-staging-ci.mitx.mit.edu NO CERT / handshake failed
meilisearch-mitx-qa.mitx.mit.edu    subject=CN=meilisearch-mitx-qa.mitx.mit.edu   (control, works)
```

`pre-commit run --files` passes on both changed files (yamllint, YAML format, detect-secrets). No `pulumi preview` has been run yet — worth doing on both applications stacks before merge to confirm the only diff is the Service annotation shrinking.

After deploy, verify:

```
dig +short meilisearch.mitx.mit.edu    # expect residential-production NLB IPs
curl -sI https://meilisearch.mitx.mit.edu/health
```

### Additional Context
**Deploy order matters** — the applications stacks currently hold the Route53 lock:

1. `pulumi up` on `applications.Production` and `applications.CI` (`infrastructure/aws/eks`). Their external-dns runs `--policy=sync`, so within ~1m it deletes the A/AAAA records plus its `cname-`/`aaaa-` ownership TXTs, releasing the claim.
2. Residential's external-dns picks the names up on its next 1m pass and recreates them against the residential NLBs. **No residential deploy is needed** — HTTPRoutes, certs, and the Gateway target annotation are already correct.

Expect a brief NXDOMAIN window between the two reconciles.

Two notes for the reviewer:

- A stale legacy-format TXT at `meilisearch.mitx.mit.edu` (owner `residential-production`, from the older external-dns registry format) will survive step 1, since applications doesn't own it. It's benign — it already names residential as owner — but it's the first thing to check if a record doesn't flip within a few minutes.
- Worth considering separately: `mitx.mit.edu` / `.mitx.mit.edu` are also in the applications clusters' external-dns `--domain-filter` (via `eks:allowed_dns_zones`). Dropping them would prevent this class of cross-cluster hijack outright, but I haven't verified nothing else in applications needs that zone, so it's out of scope here.
