### PR TITLE
Phase 5 wave 1: converge allow_auto_merge + delete_branch_on_merge to archetype defaults

### DIFF
--- a/src/ol_infrastructure/saas/github/repositories/data/repos/.github.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/.github.yaml
@@ -7,7 +7,6 @@ _has_branch_protection: true
 _pushed_at: '2026-08-07T15:09:00Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/XBlock.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/XBlock.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2018-03-28T21:13:49Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: XBlock courseware component architecture
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/access-forge.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/access-forge.yaml
@@ -28,7 +28,6 @@ _has_branch_protection: false
 _pushed_at: '2026-08-14T05:00:38Z'
 _ruleset_count: 2
 _visibility: private
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/agent-kit.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/agent-kit.yaml
@@ -6,7 +6,6 @@ _has_branch_protection: false
 _pushed_at: '2026-08-14T18:48:43Z'
 _ruleset_count: 3
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/alerting-omnibus.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/alerting-omnibus.yaml
@@ -5,12 +5,10 @@ _has_branch_protection: false
 _pushed_at: '2026-06-30T18:10:28Z'
 _ruleset_count: 2
 _visibility: private
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 description: Download and report on Rootly alerting data
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/apisix-testbed.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/apisix-testbed.yaml
@@ -7,12 +7,10 @@ _has_branch_protection: false
 _pushed_at: '2025-04-01T21:23:50Z'
 _ruleset_count: 2
 _visibility: private
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 description: 'APISIX/OIDC testbed '
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/apisix.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/apisix.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2026-08-12T03:04:10Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: The Cloud-Native API Gateway and AI Gateway
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/brand-mitol-residential.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/brand-mitol-residential.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2023-08-16T13:55:04Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 has_discussions: false
 has_projects: true
 merge_commit_message: PR_TITLE

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ckeditor-custom-build.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ckeditor-custom-build.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2022-12-10T13:28:56Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 dependabot_security_updates: true
 description: The classic editor build of CKEditor 5.
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/codejail.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/codejail.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2021-03-18T17:00:41Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Secure code execution
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/common-access.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/common-access.yaml
@@ -5,12 +5,10 @@ _has_branch_protection: false
 _pushed_at: '2026-08-08T14:36:03Z'
 _ruleset_count: 2
 _visibility: private
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 description: Plug and play apisix/keycloak setup for local dev
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/community-integrations.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/community-integrations.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2026-05-26T17:50:58Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: main
-delete_branch_on_merge: false
 description: Community supported integrations for the Dagster platform.
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-dcind.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-dcind.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2020-12-28T23:42:19Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Docker in Docker container optimized for use with Concourse CI
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-rclone-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-rclone-resource.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2023-10-21T05:51:21Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: A Rclone resource for Concourse CI
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-s3-sync-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-s3-sync-resource.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2023-10-21T08:18:52Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Concourse CI resource to sync a directory to S3
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-workflow.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-workflow.yaml
@@ -9,12 +9,10 @@ _has_branch_protection: false
 _pushed_at: '2024-06-17T15:06:41Z'
 _ruleset_count: 2
 _visibility: private
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: infrastructure
-delete_branch_on_merge: false
 description: A repository that will hold Github Issues with which to test the Concourse
   issue driven workflow
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2026-07-31T13:33:16Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Concourse is a container-based automation system written in Go. It's
   mostly used for CI/CD.
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concoursepy.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concoursepy.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2023-06-16T11:55:30Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/configuration.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/configuration.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2024-04-10T16:48:36Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: a simple, but flexible, way for anyone to stand up an instance of the
   edX platform that is fully configured and ready-to-go
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/course-search-utils.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/course-search-utils.yaml
@@ -6,12 +6,10 @@ _has_branch_protection: false
 _pushed_at: '2026-08-13T14:53:31Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 description: JS library providing tools to work with MIT Open search
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/cs_comments_service.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/cs_comments_service.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2023-04-21T16:56:43Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: server side of the comment service
 has_discussions: false
 has_issues: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/dagster.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/dagster.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2025-06-20T15:55:25Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: A data orchestrator for machine learning, analytics, and ETL.
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/default-labels-repo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/default-labels-repo.yaml
@@ -5,12 +5,10 @@ _has_branch_protection: false
 _pushed_at: '2023-03-21T17:37:54Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/demo-test-course.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/demo-test-course.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2021-06-10T06:44:16Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: A demo course with as many features turned on as possible
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-aqueduct.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-aqueduct.yaml
@@ -6,12 +6,10 @@ _has_branch_protection: false
 _pushed_at: '2026-08-10T18:24:48Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 description: Structured, typed, auditable Django settings management powered by Pydantic
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-cas-mapper.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-cas-mapper.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2016-07-21T13:25:12Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 default_branch: master
-delete_branch_on_merge: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-guardian.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-guardian.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2015-06-05T14:39:10Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: devel
-delete_branch_on_merge: false
 description: Implementation of per object permissions for Django 1.2+
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-longer-username.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-longer-username.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2015-07-15T09:44:36Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: 'An app to easily provide a longer username field for django. '
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-role-permissions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-role-permissions.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2016-07-01T17:14:08Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: A django app for role based permissions.
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-shibboleth-remoteuser.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-shibboleth-remoteuser.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2018-09-19T14:29:52Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Middleware for using Shibboleth with Django
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-user-tasks.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-user-tasks.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2025-10-21T14:19:07Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: A Django application for managing user-triggered asynchronous tasks.
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/docs.openedx.org.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/docs.openedx.org.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2026-08-12T11:08:22Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: main
-delete_branch_on_merge: false
 description: Open edX Official Documentation
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ecommerce.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ecommerce.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2024-11-04T16:02:41Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: (Deprecated) Service for managing edX's product catalog and handling
   orders for those products
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-analytics-api-client.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-analytics-api-client.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2014-07-11T19:23:32Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-api-client.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-api-client.yaml
@@ -6,13 +6,11 @@ _has_branch_protection: false
 _pushed_at: '2026-08-08T10:34:35Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Python interface for edX REST APIs
 has_discussions: false
 has_issues: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-documentation.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-documentation.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2022-06-09T11:57:56Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-enterprise-data.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-enterprise-data.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2025-10-21T14:20:12Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: The edX Enterprise Data repo is the home to tools and products related
   to providing access to Enterprise related data.
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-enterprise.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-enterprise.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2025-10-24T20:30:02Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 has_discussions: false
 has_projects: true
 merge_commit_message: PR_TITLE

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-ora2.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-ora2.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2025-10-21T14:14:36Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Open Response Assessment Suite
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-platform.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-platform.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2026-07-31T20:18:00Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: The Open edX platform, the software that powers edX!
 has_discussions: false
 has_issues: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-proctoring-proctortrack.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-proctoring-proctortrack.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2023-09-21T16:08:46Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: This is the proctortrack exam subsystem for the edx-proctoring.
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-proctoring.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-proctoring.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2026-07-28T15:43:13Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-search.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-search.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2026-04-17T17:45:42Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 has_discussions: false
 has_projects: true
 merge_commit_message: PR_TITLE

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-sga.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-sga.yaml
@@ -8,13 +8,11 @@ _has_branch_protection: false
 _pushed_at: '2026-07-29T11:51:54Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Staff Graded Assignment XBlock for the edX platform
 has_discussions: false
 has_issues: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-submissions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-submissions.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2026-07-23T18:15:31Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: API for creating submissions and scores
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-val.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-val.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2025-11-19T14:14:15Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 has_discussions: false
 has_issues: true
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edxcut.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edxcut.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2022-08-28T16:33:05Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 default_branch: master
-delete_branch_on_merge: false
 description: edx course uber tool
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-access.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-access.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2025-10-21T14:18:09Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: main
-delete_branch_on_merge: false
 description: Service to manage access to content for enterprise users
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-catalog.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-catalog.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2025-10-20T14:45:02Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: A Django-based microservice for handling Enterprise catalogs, associating
   enterprise customers with curated courses from the full course catalog.
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-integrated-channels.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-integrated-channels.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2025-10-21T14:47:36Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: main
-delete_branch_on_merge: false
 has_discussions: false
 has_projects: true
 merge_commit_message: PR_TITLE

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-subsidy.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/enterprise-subsidy.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2025-10-21T14:26:50Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: main
-delete_branch_on_merge: false
 description: Captures and balances enterprise-subsidized transactions.
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/epithet.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/epithet.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2019-08-15T17:26:49Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Manage your labels
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/eslint-config.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/eslint-config.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2026-08-12T02:51:59Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true
 archetype: library
 default_branch: master
-delete_branch_on_merge: false
 description: our preferred configuration for eslint
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/forum.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/forum.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2026-03-30T10:22:19Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Python rewrite of the legacy Open edX Ruby forum
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-communications.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-communications.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2025-09-30T11:08:04Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Frontend to manage instructor-learner communications
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-course-authoring.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-course-authoring.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2026-06-24T10:31:08Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: The micro-frontend for course authoring in Open edX.  Frontend interfaces
   that currently live in Studio/CMS should eventually live here.
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-discussions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-discussions.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2025-11-14T16:22:25Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: A React-based micro frontend for the Open edX discussion forums.
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-gradebook.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-gradebook.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2025-09-17T14:02:03Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Instructor gradebook tool for Master's programs
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-instructor-dashboard.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-instructor-dashboard.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2026-07-27T10:48:45Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: main
-delete_branch_on_merge: false
 description: Instructor Dashboard pages in MFE-land
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-learner-dashboard.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-learner-dashboard.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2026-03-05T12:07:06Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Learner Dashboard MFE
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-learning.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-learning.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2026-03-06T11:55:12Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Front-end for the Open edX course experience, implemented using React
   and Paragon.
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-library-authoring.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-app-library-authoring.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2022-02-09T20:15:09Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Work-in-progress micro-frontend experience for Open edX Blockstore-based
   content libraries.
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-footer-mitol.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-footer-mitol.yaml
@@ -8,13 +8,11 @@ _has_branch_protection: true
 _pushed_at: '2025-04-08T18:28:13Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Site footer component for edX frontend apps.
 has_discussions: false
 has_issues: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-header-edx-mitol.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-header-edx-mitol.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2024-09-01T17:33:22Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 has_discussions: false
 has_issues: true
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-header-mitol.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-component-header-mitol.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: true
 _pushed_at: '2024-09-01T11:46:11Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-lib-special-exams-mitol.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-lib-special-exams-mitol.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: true
 _pushed_at: '2025-02-12T07:47:20Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: main
-delete_branch_on_merge: false
 description: Frontend component library for displaying special exams on the edx platform
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-platform.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-platform.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2024-09-01T11:24:16Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: A framework for Open edX micro-frontend applications.
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-slot-footer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/frontend-slot-footer.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2025-03-25T18:38:33Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Site footer PluginSlot utilizing Frontend Plugin Framework
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/gwarek.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/gwarek.yaml
@@ -8,12 +8,10 @@ _has_branch_protection: false
 _pushed_at: '2026-08-07T19:37:39Z'
 _ruleset_count: 2
 _visibility: private
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/hacksnack.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/hacksnack.yaml
@@ -5,12 +5,10 @@ _has_branch_protection: false
 _pushed_at: '2026-08-12T13:50:14Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/handbook.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/handbook.yaml
@@ -6,13 +6,11 @@ _has_branch_protection: true
 _pushed_at: '2026-06-11T20:45:57Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true
 archetype: library
 default_branch: master
-delete_branch_on_merge: false
 description: Information on how we do what we do.
 has_discussions: false
 has_projects: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/hashicorp-release-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/hashicorp-release-resource.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2019-11-18T08:23:34Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Concourse resource to track and fetch Hashicorp projects
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/healthchecks.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/healthchecks.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2018-01-19T19:59:31Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Django app which listens for pings and sends alerts when pings are late
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/heroku-database-backups.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/heroku-database-backups.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2016-09-25T18:12:26Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Heroku database backups and copies to S3
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/hq.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/hq.yaml
@@ -8,12 +8,10 @@ _has_branch_protection: false
 _pushed_at: '2026-08-13T05:50:56Z'
 _ruleset_count: 2
 _visibility: private
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 description: OL Engineering & Products - headquarters
 has_discussions: true
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/iso-3166-2.js.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/iso-3166-2.js.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2022-12-07T14:02:03Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Lookup information about ISO-3166-2 subdivisions
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/jsdom-global.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/jsdom-global.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2021-11-24T15:46:07Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Enable DOM in Node.js
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/keycloak-scim.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/keycloak-scim.yaml
@@ -5,12 +5,10 @@ _has_branch_protection: false
 _pushed_at: '2026-07-21T00:07:13Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 description: SCIM client plugin for Keycloak
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/kubectl-slice.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/kubectl-slice.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2024-09-01T11:32:15Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Split multiple Kubernetes files into smaller files with ease. Split multi-YAML
   files into individual files.
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/learn-ai.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/learn-ai.yaml
@@ -6,12 +6,10 @@ _has_branch_protection: false
 _pushed_at: '2026-08-13T19:43:16Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/learn-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/learn-zendesk-theme.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2026-02-13T13:10:20Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: The default theme for Zendesk Guide
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/lehrer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/lehrer.yaml
@@ -6,7 +6,6 @@ _has_branch_protection: false
 _pushed_at: '2026-08-13T17:47:59Z'
 _ruleset_count: 4
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/library-customization.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/library-customization.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2021-02-24T19:55:58Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: An example repo that customizes Library behavior
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/library.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/library.yaml
@@ -6,13 +6,11 @@ _has_branch_protection: false
 _pushed_at: '2023-08-03T18:12:05Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: main
-delete_branch_on_merge: false
 description: A collaborative documentation site, powered by Google Docs.
 has_discussions: false
 has_issues: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters-zendesk-theme.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2024-05-08T06:27:47Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: The default theme for Zendesk Guide
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters.yaml
@@ -10,13 +10,11 @@ _has_branch_protection: true
 _pushed_at: '2026-08-13T21:41:54Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: application
 default_branch: master
-delete_branch_on_merge: false
 description: 'Portal for learners and course teams to access MITx Micromasters® programs '
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
@@ -13,7 +13,6 @@ _has_branch_protection: true
 _pushed_at: '2026-08-14T20:19:39Z'
 _ruleset_count: 3
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-moira.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-moira.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2018-05-24T14:42:31Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 default_branch: master
-delete_branch_on_merge: false
 description: Python client for accessing MIT's Moira system
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-open-bk.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-open-bk.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2023-07-28T13:16:48Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 has_discussions: false
 has_issues: true
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-grading-library.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-grading-library.yaml
@@ -8,13 +8,11 @@ _has_branch_protection: false
 _pushed_at: '2026-08-08T10:41:40Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 default_branch: master
-delete_branch_on_merge: false
 description: The MITx Grading Library, a python grading library for edX
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitx-theme.yaml
@@ -6,13 +6,11 @@ _has_branch_protection: false
 _pushed_at: '2026-07-13T13:04:55Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 default_branch: master
-delete_branch_on_merge: false
 description: Open edX theme for the Residential MITx instance
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitx_cas_mapper.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitx_cas_mapper.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2016-07-21T18:56:42Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 default_branch: master
-delete_branch_on_merge: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-api-clients.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-api-clients.yaml
@@ -6,12 +6,10 @@ _has_branch_protection: false
 _pushed_at: '2026-08-13T22:42:20Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-theme.yaml
@@ -6,12 +6,10 @@ _has_branch_protection: false
 _pushed_at: '2026-08-04T07:48:37Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 description: an open edX theme for MITx Online
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-translations.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-translations.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2026-08-14T01:06:13Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: main
-delete_branch_on_merge: false
 description: Open edX Translation files in sync with Transifex
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-zendesk-theme.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2025-01-30T16:50:14Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: The default theme for Zendesk Guide
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline.yaml
@@ -10,7 +10,6 @@ _has_branch_protection: true
 _pushed_at: '2026-08-14T18:35:56Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-theme.yaml
@@ -6,13 +6,11 @@ _has_branch_protection: false
 _pushed_at: '2026-07-13T13:05:34Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 default_branch: master
-delete_branch_on_merge: false
 description: 'an open edX theme for MIT xPRO '
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-zendesk-theme.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2024-10-07T16:41:35Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: MITx Pro fork of the default theme for Zendesk Guide
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro.yaml
@@ -10,7 +10,6 @@ _has_branch_protection: true
 _pushed_at: '2026-08-12T20:44:19Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mynumbers.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mynumbers.yaml
@@ -6,13 +6,11 @@ _has_branch_protection: false
 _pushed_at: '2026-08-13T08:21:52Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: main
-delete_branch_on_merge: false
 description: fun wih arithmetic
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-projects.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-projects.yaml
@@ -6,12 +6,10 @@ _has_branch_protection: true
 _pushed_at: '2026-08-12T13:41:20Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 description: A collection of Hugo project templates for different types of OCW websites
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-themes.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-themes.yaml
@@ -19,12 +19,10 @@ _has_branch_protection: true
 _pushed_at: '2026-08-13T14:33:51Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true
 archetype: application
-delete_branch_on_merge: false
 description: A Hugo theme for building OCW websites
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-studio.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-studio.yaml
@@ -9,7 +9,6 @@ _has_branch_protection: true
 _pushed_at: '2026-08-14T05:34:01Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-zendesk-theme.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2026-03-04T14:30:01Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: The default theme for Zendesk Guide
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw_oer_export.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw_oer_export.yaml
@@ -7,12 +7,10 @@ _has_branch_protection: false
 _pushed_at: '2026-08-13T21:12:34Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/odl-video-service.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/odl-video-service.yaml
@@ -6,7 +6,6 @@ _has_branch_protection: true
 _pushed_at: '2026-08-13T20:52:43Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-analytics-api.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-analytics-api.yaml
@@ -6,12 +6,10 @@ _has_branch_protection: false
 _pushed_at: '2026-08-14T19:28:21Z'
 _ruleset_count: 3
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: application
-delete_branch_on_merge: false
 description: Multi-tenant read-only FastAPI analytics gateway over StarRocks (B2B
   site-license analytics for MIT Learn)
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-concourse.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-concourse.yaml
@@ -6,7 +6,6 @@ _has_branch_protection: false
 _pushed_at: '2026-08-14T00:36:11Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-customizations-nytimes-library.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-customizations-nytimes-library.yaml
@@ -5,12 +5,10 @@ _has_branch_protection: false
 _pushed_at: '2026-08-06T03:42:39Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 description: Customizations for the NYTimes Library application to fit the needs of
   MIT Open Learning
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-data-platform.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-data-platform.yaml
@@ -8,7 +8,6 @@ _has_branch_protection: true
 _pushed_at: '2026-08-14T20:52:38Z'
 _ruleset_count: 3
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-django.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-django.yaml
@@ -8,7 +8,6 @@ _has_branch_protection: false
 _pushed_at: '2026-08-12T02:55:30Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-github-workflows.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-github-workflows.yaml
@@ -5,12 +5,10 @@ _has_branch_protection: false
 _pushed_at: '2024-06-17T14:47:01Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 description: Repository for shared workflows across projects
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infra-health-checks.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infra-health-checks.yaml
@@ -5,12 +5,10 @@ _has_branch_protection: false
 _pushed_at: '2026-07-28T23:48:52Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 description: A repository for MIT OL Infrastructure Health Checks
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
@@ -8,7 +8,6 @@ _has_branch_protection: true
 _pushed_at: '2026-08-14T20:49:40Z'
 _ruleset_count: 3
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloak.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloak.yaml
@@ -5,7 +5,6 @@ _has_branch_protection: true
 _pushed_at: '2026-08-10T20:05:34Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloakify.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloakify.yaml
@@ -6,12 +6,10 @@ _has_branch_protection: false
 _pushed_at: '2026-08-12T02:52:33Z'
 _ruleset_count: 3
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 description: Customization of the theme and UX for OL SSO
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-notebook-extensions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-notebook-extensions.yaml
@@ -5,12 +5,10 @@ _has_branch_protection: false
 _pushed_at: '2026-08-14T19:07:46Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 description: A repository of plugins for extending and customizing Jupyter notebooks
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-parliament.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-parliament.yaml
@@ -6,7 +6,6 @@ _has_branch_protection: false
 _pushed_at: '2026-06-05T20:37:09Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-rootly-manager.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-rootly-manager.yaml
@@ -5,12 +5,10 @@ _has_branch_protection: false
 _pushed_at: '2026-06-29T21:02:58Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/oldevops-scratch.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/oldevops-scratch.yaml
@@ -5,12 +5,10 @@ _has_branch_protection: false
 _pushed_at: '2023-09-26T20:52:27Z'
 _ruleset_count: 2
 _visibility: private
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 description: A repository for testing automation
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-collaboration.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-collaboration.yaml
@@ -5,12 +5,10 @@ _has_branch_protection: false
 _pushed_at: '2023-10-25T13:45:42Z'
 _ruleset_count: 2
 _visibility: private
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 description: 'Project Management for the MIT Open Unified project '
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-discussions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-discussions.yaml
@@ -9,7 +9,6 @@ _has_branch_protection: true
 _pushed_at: '2026-08-12T15:50:43Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-plugins.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-plugins.yaml
@@ -6,7 +6,6 @@ _has_branch_protection: false
 _pushed_at: '2026-08-12T13:02:56Z'
 _ruleset_count: 3
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-proposals.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-proposals.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2025-02-27T21:13:04Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: 'Proposals for Open edX architecture, best practices and processes '
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-learning-ai-tutor.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-learning-ai-tutor.yaml
@@ -6,13 +6,11 @@ _has_branch_protection: false
 _pushed_at: '2026-08-13T05:56:07Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: main
-delete_branch_on_merge: false
 description: AI tutor MIT open Learning
 has_discussions: false
 has_issues: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-podcast-data.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-podcast-data.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2026-06-04T14:57:27Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 default_branch: master
-delete_branch_on_merge: false
 description: where are all MIT podcasts ?
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-resource-blocklists.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-resource-blocklists.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2026-07-23T20:01:50Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 default_branch: master
-delete_branch_on_merge: false
 description: Lists of resources to be excluded from search results
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-video-data.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-video-data.yaml
@@ -5,12 +5,10 @@ _has_branch_protection: false
 _pushed_at: '2026-05-12T14:38:52Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/openedx-events.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/openedx-events.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2026-03-25T07:09:56Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: main
-delete_branch_on_merge: false
 description: Open edX events from the Hooks Extensions Framework
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/openedx-ledger.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/openedx-ledger.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2025-10-21T14:27:47Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: main
-delete_branch_on_merge: false
 description: A library that records transactions against a ledger, denominated in
   units of value.
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/opentelemetry-python-contrib.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/opentelemetry-python-contrib.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2026-03-11T21:14:17Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: main
-delete_branch_on_merge: false
 description: OpenTelemetry instrumentation for Python modules
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/platform-engineering-site.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/platform-engineering-site.yaml
@@ -6,12 +6,10 @@ _has_branch_protection: false
 _pushed_at: '2026-08-10T19:41:36Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 description: The MIT Online Learning Platform Engineering Site Repository
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pre-commit-ci-config.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pre-commit-ci-config.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2023-09-07T17:57:54Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: main
-delete_branch_on_merge: false
 description: validation for pre-commit.ci configuration
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pre-commit-packer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pre-commit-packer.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2024-05-09T14:57:05Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: main
-delete_branch_on_merge: false
 description: Provides pre-commit hooks for Packer projects.
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/product.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/product.yaml
@@ -5,12 +5,10 @@ _has_branch_protection: false
 _pushed_at: '2024-04-11T14:12:31Z'
 _ruleset_count: 2
 _visibility: private
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 description: OL Product Management
 has_discussions: true
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/py-tree-sitter.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/py-tree-sitter.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2026-07-09T21:12:53Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Python bindings to the Tree-sitter parsing library
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pycassa.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pycassa.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2017-10-03T19:38:47Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: reddit
-delete_branch_on_merge: false
 description: Python Thrift driver for Apache Cassandra
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pylint-django.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pylint-django.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2017-09-08T19:22:16Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Pylint plugin for improving code analysis for when using Django
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/react-dropzone-uploader.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/react-dropzone-uploader.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2020-09-03T18:56:24Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: React file dropzone and uploader
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/realistic-mm-users.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/realistic-mm-users.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2017-01-17T21:09:26Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 default_branch: master
-delete_branch_on_merge: false
 description: Queries randomuser.me and generates realistic user and program data for
   use in Micromasters
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/redash.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/redash.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2022-10-27T17:40:29Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Make Your Company Data Driven. Connect to any data source, easily visualize
   and share your data.
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-config.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-config.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2020-07-03T15:06:49Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 default_branch: master
-delete_branch_on_merge: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-i18n.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-i18n.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2017-04-25T19:19:30Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: reddit's translation files - USE CROWDIN TO SUBMIT TRANSLATIONS. Direct
   pull requests to this repository will, generally, be rejected.
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-service-activity.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-service-activity.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2017-05-30T16:54:20Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: activity counting service
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-service-websockets.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/reddit-service-websockets.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2017-06-06T21:17:55Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: websockets for reddit
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/redux-asserts.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/redux-asserts.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: true
 _pushed_at: '2026-08-10T23:54:51Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 default_branch: master
-delete_branch_on_merge: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/redux-hammock.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/redux-hammock.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2026-08-08T22:33:06Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 default_branch: master
-delete_branch_on_merge: false
 description: 🌴🍹Automatically generate actions and reducers for REST APIs
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/release-script.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/release-script.yaml
@@ -6,13 +6,11 @@ _has_branch_protection: false
 _pushed_at: '2026-08-13T21:13:23Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: application
 default_branch: master
-delete_branch_on_merge: false
 description: Scripts to automate the release process, aka "Doof"
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/response-map.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/response-map.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2019-09-27T18:07:00Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Response map {{simulation}}
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/searchkit.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/searchkit.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2017-01-26T16:18:08Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: develop
-delete_branch_on_merge: false
 description: React UI components / widgets. The easiest way to build a great search
   experience with Elasticsearch.
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/semantic-mitopen.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/semantic-mitopen.yaml
@@ -6,13 +6,11 @@ _has_branch_protection: false
 _pushed_at: '2024-08-29T20:01:40Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: main
-delete_branch_on_merge: false
 description: Codebase for semantic search of MIT Open Courseware (AI-powered Search
   and Chat for MIT Open Courseware)
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/sign-and-verify.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/sign-and-verify.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2020-10-01T17:59:24Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/smoot-design.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/smoot-design.yaml
@@ -8,12 +8,10 @@ _has_branch_protection: true
 _pushed_at: '2026-08-13T21:11:00Z'
 _ruleset_count: 3
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 description: Design system components for MITODL Projects
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/superset-marimo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/superset-marimo.yaml
@@ -5,7 +5,6 @@ _has_branch_protection: true
 _pushed_at: '2026-05-22T19:14:05Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: false
 allow_rebase_merge: false
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/superset-nl-explorer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/superset-nl-explorer.yaml
@@ -5,12 +5,10 @@ _has_branch_protection: false
 _pushed_at: '2026-02-26T00:27:57Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 description: Natural language LLM interface for Apache Superset — chart, dashboard,
   and data exploration via chat. Deployed as a Superset extension plugin.
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/superset-sup.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/superset-sup.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2026-07-24T14:04:41Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: main
-delete_branch_on_merge: false
 description: a modern CLI for Apache Superset and Preset workspaces
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/taxonomy-connector.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/taxonomy-connector.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2025-10-30T13:24:01Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: A python package that communicates with 3rd party taxonomy vendors
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/tech-talk-slides.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/tech-talk-slides.yaml
@@ -6,7 +6,6 @@ _has_branch_protection: false
 _pushed_at: '2026-08-14T20:57:56Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/template-mit-demo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/template-mit-demo.yaml
@@ -9,13 +9,11 @@ _has_branch_protection: false
 _pushed_at: '2019-07-10T16:26:56Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 default_branch: master
-delete_branch_on_merge: false
 description: A copy of https://github.com/mitocw/content-mit-latex2edx-demo turned
   into a cookiecutter template.
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/testinfra.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/testinfra.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2023-04-19T12:37:11Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Testinfra test your infrastructures
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/tutor.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/tutor.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2025-04-16T17:15:25Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: release
-delete_branch_on_merge: false
 description: The Docker-based Open edX distribution designed for peace of mind
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ubcpi.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ubcpi.yaml
@@ -6,13 +6,11 @@ _has_branch_protection: false
 _pushed_at: '2026-03-11T11:24:32Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: Peer Instruction XBlock
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/vault-plugin-database-starrocks.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/vault-plugin-database-starrocks.yaml
@@ -5,12 +5,10 @@ _has_branch_protection: false
 _pushed_at: '2026-08-06T12:31:15Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 description: Vault database secrets engine plugin for StarRocks — uses COM_QUERY instead
   of COM_STMT_PREPARE to work around StarRocks prepared statement limitations
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/vault-plugin-secrets-openai.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/vault-plugin-secrets-openai.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2026-06-01T20:47:46Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: main
-delete_branch_on_merge: false
 description: OpenAI secrets engine for HashiCorp Vault
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/vault-raft-backup.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/vault-raft-backup.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2026-08-14T05:33:25Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 default_branch: master
-delete_branch_on_merge: false
 description: A lean tool for creating Vault Raft snapshots and transferring them to
   AWS S3
 has_discussions: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/video_translation_demo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/video_translation_demo.yaml
@@ -6,12 +6,10 @@ _has_branch_protection: false
 _pushed_at: '2026-03-01T08:32:07Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
-delete_branch_on_merge: false
 description: Video Subtitles Translation Demo
 has_discussions: false
 has_issues: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/world_geographic_regions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/world_geographic_regions.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2015-11-11T14:31:40Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 default_branch: master
-delete_branch_on_merge: false
 description: UN defined world geographic regions
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xanalytics.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xanalytics.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2021-09-23T12:45:56Z'
 _ruleset_count: 2
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: library
 default_branch: master
-delete_branch_on_merge: false
 description: Analytics for edX platform courses
 has_discussions: false
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xblock-lti-consumer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xblock-lti-consumer.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2025-10-21T14:28:39Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 has_discussions: false
 has_projects: true
 merge_commit_message: PR_TITLE

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xblock-utils.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xblock-utils.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2017-12-15T17:04:58Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 has_discussions: false
 has_projects: true
 has_wiki: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xblocks-contrib.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xblocks-contrib.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2026-07-29T09:49:33Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: main
-delete_branch_on_merge: false
 has_discussions: false
 has_projects: true
 merge_commit_message: PR_TITLE

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xqueue-watcher.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xqueue-watcher.yaml
@@ -6,13 +6,11 @@ _has_branch_protection: false
 _pushed_at: '2026-07-17T14:58:24Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 has_discussions: false
 has_issues: true
 has_projects: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xqueue.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xqueue.yaml
@@ -5,13 +5,11 @@ _has_branch_protection: false
 _pushed_at: '2021-06-14T21:44:27Z'
 _ruleset_count: 0
 _visibility: public
-allow_auto_merge: false
 allow_merge_commit: true
 allow_rebase_merge: true
 allow_squash_merge: true
 archetype: fork
 default_branch: master
-delete_branch_on_merge: false
 description: XQueue defines an interface for the LMS to communicate with external
   grader services.
 has_discussions: false


### PR DESCRIPTION
### What are the relevant tickets?
Part of the mitodl GitHub org import project (CON-01/DX-01 findings). No issue number -- tracked as tk-con-01-dx-01-con-05-merge-strategy-auto-merge-an-ff4d2b and tk-phase-5-remediate-by-tightening-archetypes-in-re-836e39 in the internal task graph.

### Description (What does it do?)
Wave 1 of Phase 5 remediation: removes the `allow_auto_merge: false` and `delete_branch_on_merge: false` per-repo deviation lines from 175 repo YAML files under `src/ol_infrastructure/saas/github/repositories/data/repos/`.

- Every non-archived archetype (`application`, `library`, `infrastructure`, `fork`) extends `base`, which already targets `allow_auto_merge: true` and `delete_branch_on_merge: true` -- these are the intended fleet defaults, deliberately not yet enforced.
- The 174 repo files touched (175 incl. the `.github` dotfile, which needed a separate commit -- `git add *.yaml` silently drops it, same trap `data/README.md` documents) carried the crawled `false` as a plain recorded deviation with no comment or decision attached anywhere in the codebase -- i.e. drift, not an intentional per-repo override.
- Deleting the deviation line is the entire remediation mechanism this project uses: the repo falls through to the archetype default on the next `pulumi up`.
- Merge-strategy fields (`allow_squash_merge` etc.) are untouched -- CON-01 is deliberately not enforced yet (158/178 active repos allow all three strategies; see `archetypes.yaml`'s comment on that decision).

### How can this be tested?
Ran `pulumi preview --diff` against the `ol-saas-github-repositories` stack after the change:
- 174 `Repository` updates: `allowAutoMerge: false => true` on all 174, `deleteBranchOnMerge: false => true` on the 155 that declared it explicitly.
- No other Repository fields changed.
- 2 unrelated `TeamRepository` permission updates also appear in the preview (`mynumbers`, `ol-infrastructure` devops-contractors, `admin => push`) -- these are the pre-existing SEC-15 fix from PR #5324 that hasn't been applied yet, not introduced by this PR.
- `uv run python -c "...archetypes.load_fleet()..."` passes all fleet invariant checks (team references, permission vocabulary, required public teams, dependabot conflict) against the edited data.
- `pre-commit run` (yaml lint/format, detect-secrets) passes on every changed file.

Reviewer can reproduce with:
```
cd src/ol_infrastructure/saas/github/repositories
pulumi preview --diff
```

### Additional Context
This does not itself change GitHub -- it's the declared-state half of the wave; a `pulumi up` against this stack applies it. Per the project's phase-5 process, each wave lands as its own reviewed PR before being applied.