### PR TITLE
fix(github): exempt tier=unmanaged repos from SEC-01

### DIFF
--- a/src/ol_infrastructure/saas/github/audit.py
+++ b/src/ol_infrastructure/saas/github/audit.py
@@ -184,14 +184,17 @@ RULES: tuple[Rule, ...] = (
         "security",
         "high",
         "active",
-        "default branch has no ruleset and no branch protection",
+        "default branch has no ruleset and no branch protection"
+        " (unmanaged tier exempt)",
         lambda r: (
             (
                 "unprotected",
                 "covered by an org ruleset",
                 "set `tier` so a ruleset matches",
             )
-            if not r.get("_has_branch_protection") and not r.get("_ruleset_count")
+            if not r.get("_has_branch_protection")
+            and not r.get("_ruleset_count")
+            and r.get("tier") != "unmanaged"
             else None
         ),
     ),

--- a/tests/ol_infrastructure/saas/github/test_audit.py
+++ b/tests/ol_infrastructure/saas/github/test_audit.py
@@ -84,6 +84,15 @@ def test_sec01_needs_both_missing() -> None:
     assert "SEC-01" not in fired([repo(_has_branch_protection=True, _ruleset_count=0)])
 
 
+def test_sec01_exempts_unmanaged_tier() -> None:
+    """Forks and other `tier: unmanaged` repos have no org ruleset targeting them by
+    design (§5.4, §9.2) -- reporting them as "unprotected" is noise, not a finding.
+    """
+    assert "SEC-01" not in fired(
+        [repo(_has_branch_protection=False, _ruleset_count=0, tier="unmanaged")]
+    )
+
+
 def test_sec15_is_an_allowlist_not_a_denylist() -> None:
     """A team nobody has sanctioned must fire, which a denylist would miss."""
     assert "SEC-15" in fired([repo(teams={"a-brand-new-team": "admin"})])


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
- `SEC-01` (default branch has no ruleset and no branch protection) checked only `_has_branch_protection` and `_ruleset_count`, never `tier`.
- Forks and archived repos are deliberately `tier: unmanaged` (§5.4/§9.2 of `docs/plans/github-org-pulumi-import.md`) — no org ruleset targets that tier, on purpose, the same reasoning `CON-03` already applies to exempt them from the default-branch rule.
- Without the exemption, `SEC-01` fired on 99 of the 102 active forks — noise nobody would act on, since there's no fix to apply; the repo is correctly untargeted by design.
- With the fix, `SEC-01` reads 0/176 active repos, which is a real result the fork noise was masking: the tier-1/standard active fleet is fully covered by the org rulesets promoted to `active` on 2026-08-14.

### How can this be tested?
- `uv run pytest tests/ol_infrastructure/saas/github/test_audit.py -q` — 38 passed, including a new `test_sec01_exempts_unmanaged_tier` case.
- `uv run bin/github-estate-audit run` against the committed fleet data — `SEC-01` findings dropped from 99 to 0; every other rule count is unchanged.
- `uv run pre-commit run --files src/ol_infrastructure/saas/github/audit.py tests/ol_infrastructure/saas/github/test_audit.py` — clean (ruff, mypy, etc.).