### PR TITLE
feat(github): revoke unsanctioned admin on archived repos, split SEC-15, refresh inventory

### DIFF
--- a/bin/github-org-inventory
+++ b/bin/github-org-inventory
@@ -138,7 +138,16 @@ DEFAULT_BRANCH_EXEMPT_ARCHETYPES = frozenset({"fork", "archived"})
 
 # Rules whose population is the archived fleet, not the active one. Reporting these as a
 # share of active repos overstates them badly (92 of 138 archived reads as "52% of active").
-ARCHIVED_SCOPED_RULES = frozenset({"CON-07 archived repo still grants team write"})
+ARCHIVED_SCOPED_RULES = frozenset(
+    {
+        "CON-07 archived repo still grants team write",
+        # Split out of SEC-15 on 2026-08-17. Same exposure, different cost: GitHub makes
+        # permissions read-only on an archived repo, so this one is fixed by an
+        # unarchive/change/re-archive cycle rather than by `pulumi up`. Keeping both in
+        # one rule put 59 unactionable findings in a `high` security bucket.
+        "SEC-15A archived repo grants admin outside the sanctioned set",
+    }
+)
 
 # Rules whose population is the WHOLE fleet, active and archived alike. SEC-06 is here
 # because the no-direct-collaborators policy (2026-08-05) admits no exceptions: an admin
@@ -147,7 +156,6 @@ ARCHIVED_SCOPED_RULES = frozenset({"CON-07 archived repo still grants team write
 FLEET_SCOPED_RULES = frozenset(
     {
         "SEC-06 direct collaborator on repo (policy: repo access via teams only)",
-        "SEC-15 admin held by a team outside the sanctioned set",
     }
 )
 
@@ -582,6 +590,18 @@ def _is_stale(repo: dict[str, Any]) -> bool:
 MERGE_CAPABLE_PERMISSIONS = frozenset({"push", "maintain", "admin"})
 
 
+def _unsanctioned_admin_grant(repo: dict[str, Any]) -> bool:
+    """Report whether any team outside `ADMIN_TEAMS` holds admin on this repo.
+
+    Shared by SEC-15 and SEC-15A so the two halves of the split cannot drift apart --
+    they must differ only in which population they look at, never in what counts.
+    """
+    return any(
+        perm in ADMIN_PERMISSIONS and team not in ADMIN_TEAMS
+        for team, perm in (repo.get("teams") or {}).items()
+    )
+
+
 def _blocked_by_push_restriction(repo: dict[str, Any]) -> list[str]:
     """Teams that hold a merge-capable grant but are outside the push allow-list.
 
@@ -692,13 +712,18 @@ def _findings(
                 if (r.get("teams") or {})
                 != (archetype_teams.get(propose_archetype(r)) or {})
             ],
+            # Split active/archived: the archived half cannot be fixed by `pulumi up`
+            # at all (GitHub makes permissions read-only there), so reporting both under
+            # one id produced findings whose stated remediation returns 403.
             "SEC-15 admin held by a team outside the sanctioned set": [
                 r["name"]
                 for r in repos
-                if any(
-                    perm in ADMIN_PERMISSIONS and team not in ADMIN_TEAMS
-                    for team, perm in (r.get("teams") or {}).items()
-                )
+                if not r["archived"] and _unsanctioned_admin_grant(r)
+            ],
+            "SEC-15A archived repo grants admin outside the sanctioned set": [
+                r["name"]
+                for r in repos
+                if r["archived"] and _unsanctioned_admin_grant(r)
             ],
         }
     return {

--- a/src/ol_infrastructure/saas/github/audit.py
+++ b/src/ol_infrastructure/saas/github/audit.py
@@ -247,13 +247,57 @@ RULES: tuple[Rule, ...] = (
         "SEC-15",
         "security",
         "high",
-        "fleet",
+        "active",
         "admin held by a team outside the sanctioned set",
+        # NARROWED FROM `fleet` TO `active` ON 2026-08-17, with SEC-15A below taking
+        # the archived half. Not a weakening -- a split, because the two halves need
+        # different actions and merging them made one of them undoable.
+        #
+        # Until today this rule read the COMMITTED grant and so reported 59 archived
+        # repos as clean while live GitHub had them at `admin`. When the crawl was
+        # finally allowed to record the truth, all 59 findings landed here at once --
+        # in a rule whose remediation line says "downgrade to push or maintain", which
+        # on an archived repo is not something anyone can do. GitHub makes permissions
+        # read-only on an archived repo ("you cannot add or remove collaborators or
+        # teams"), so the fix requires an unarchive/change/re-archive cycle and cannot
+        # come from `pulumi up` at all.
+        #
+        # Leaving them here would have parked 59 permanently-unactionable findings in a
+        # `high` security rule, which is how a gate stops being read. The archived case
+        # is still reported, just under an id that states what it actually costs.
         lambda r: (
             (
                 ", ".join(_unsanctioned_admin(r)),
                 f"admin only for {', '.join(sorted(ADMIN_TEAMS))}",
                 "downgrade to push or maintain",
+            )
+            if _unsanctioned_admin(r)
+            else None
+        ),
+    ),
+    Rule(
+        "SEC-15A",
+        "security",
+        "high",
+        "archived",
+        "archived repo grants admin to a team outside the sanctioned set",
+        # Same exposure as SEC-15, different cost to fix, which is the whole reason it
+        # is a separate id. Admin on an archived repo cannot push code -- the repo is
+        # read-only -- but it can UNARCHIVE, delete, and change settings, which is the
+        # same reasoning that keeps SEC-06 fleet-scoped rather than active-only.
+        #
+        # Remediation is deliberately spelled out, because "downgrade the grant" is not
+        # a thing you can do here and the next person will otherwise try it and get a
+        # 403: unarchive, set the grant, re-archive, verify it went back. The 2026-08-17
+        # pass did exactly that for 59 repos and downgraded to `pull` rather than
+        # `push`, since CON-07 states the expectation for an archived repo as read-only
+        # and fires on push/maintain/admin alike -- stopping at `push` would have
+        # cleared this rule while leaving CON-07 firing on a repo just opened to fix it.
+        lambda r: (
+            (
+                ", ".join(_unsanctioned_admin(r)),
+                f"admin only for {', '.join(sorted(ADMIN_TEAMS))}",
+                "unarchive, downgrade to pull, re-archive, then verify it re-archived",
             )
             if _unsanctioned_admin(r)
             else None

--- a/src/ol_infrastructure/saas/github/organization/org_rulesets.py
+++ b/src/ol_infrastructure/saas/github/organization/org_rulesets.py
@@ -243,9 +243,9 @@ tier_one_hardening = github.OrganizationRuleset(
 # THE CLASSIC BRANCH PROTECTION STILL OUT THERE IS NOT INERT. These rulesets are
 # ADDITIVE to it, not a replacement: an action must satisfy classic protection AND
 # every ruleset that matches, and a `bypass_actors` entry here grants no relief from the
-# classic layer at all. 27 active repos still carry a classic object that nothing here
-# manages (repository.py declines to declare BranchProtection), so it is invisible drift
-# that can override everything decided in this file.
+# classic layer at all. Whatever classic protection remains is invisible drift --
+# repository.py declines to declare BranchProtection -- and can override everything
+# decided in this file.
 #
 # open-edx-plugins made that concrete on 2026-08-17. Its classic protection restricted
 # pushes to `main` to the single user `odlbot`, and GitHub counts merging a pull request
@@ -261,7 +261,39 @@ tier_one_hardening = github.OrganizationRuleset(
 # deletion). The two rules dropped later that same day (#5459) do not reopen a gap on
 # this repo specifically: its classic protection had `dismiss_stale_reviews: false` and
 # `require_last_push_approval: false` already, so the rulesets are still no weaker than
-# what was deleted. Only `block_creations` was
-# lost, which is inert on a branch that already exists. The remaining 26 repos have not
-# been swept; SEC-16 in audit.py now reports this class of block instead of leaving it
-# to be found by a contractor with a stuck PR.
+# what was deleted. Only `block_creations` was lost, which is inert on a branch that
+# already exists.
+#
+# THE FLEET WAS THEN SWEPT (2026-08-17). `mit-learn` turned out to carry the identical
+# odlbot-only restriction, silently blocking three teams with nobody reporting it, so
+# this was never a one-repo problem. Default-branch classic rules were deleted on 16
+# repos; NO PUSH RESTRICTION SURVIVES ON ANY ACTIVE REPO -- deliberately not "anywhere",
+# since the seven archived repos below were never examined -- and SEC-16 in audit.py now
+# reports this class of block rather than leaving it to a contractor with a stuck PR.
+#
+# WHAT IS LEFT, and why each part was kept rather than missed:
+#
+#   4 active, default branch   `handbook` (the only `enforce_admins: true` repo) and
+#                              three `frontend-*-mitol` forks. The forks are tier
+#                              `unmanaged`, so NO ruleset here targets them -- their
+#                              classic rule is their only protection, not a redundant
+#                              one, and deleting it would have left them bare.
+#
+#   7 active, release branches `release*` / `release-candidate` on mit-learn,
+#                              mitxonline, mitxpro, ocw-hugo-themes, ocw-studio,
+#                              odl-video-service and open-discussions. They block
+#                              force-push and deletion, and every ruleset here targets
+#                              `~DEFAULT_BRANCH` only, so nothing replaces them.
+#
+#   7 archived                 bootcamp-ecommerce, ccxcon, mit-open-login-button,
+#                              ol-npm-libraries, open-discussions-client,
+#                              unified-ecommerce, unified-ecommerce-frontend. NOT
+#                              EXAMINED: both sweeps filtered `isArchived: false`. An
+#                              archived repo is read-only so a push restriction there
+#                              blocks nothing today, but this is an unmeasured set, not
+#                              a cleared one -- and it becomes real the moment one is
+#                              unarchived.
+#
+# COUNT THESE FROM THE CODE, NOT FROM `_has_branch_protection`. That field records the
+# DEFAULT BRANCH only, so it reads 11 -- it cannot see the seven release-branch rules at
+# all. A note written from that field alone would be accurate and still wrong.

--- a/src/ol_infrastructure/saas/github/organization/teams.py
+++ b/src/ol_infrastructure/saas/github/organization/teams.py
@@ -1,4 +1,4 @@
-"""The 12 mitodl teams, as data plus a loop.
+"""The 11 mitodl teams, as data plus a loop.
 
 Teams are declared here; team ROSTERS are not (plan section 4.7). Pulumi manages
 which teams exist and -- in the repositories project -- what each team can do. It
@@ -16,7 +16,7 @@ import pulumi_github as github
 from pulumi import ResourceOptions
 
 # Read off `GET /orgs/mitodl/teams` on 2026-08-05. `notification_setting` is
-# `notifications_enabled` on all 14, so the loop sets it once rather than repeating it.
+# `notifications_enabled` on all 11, so the loop sets it once rather than repeating it.
 TEAMS: dict[str, dict[str, Any]] = {
     "arbisoft-contractors": {
         "name": "Arbisoft Contractors",
@@ -47,12 +47,17 @@ TEAMS: dict[str, dict[str, Any]] = {
         "description": "",
         "privacy": "closed",
     },
-    "devops-contractors": {
-        "name": "DevOps Contractors",
-        "description": "",
-        "privacy": "closed",
-        "parent": "devops",
-    },
+    # `devops-contractors` DELETED 2026-08-17. It held ONE member, who is a direct
+    # member of both `devops` (its parent) and `odl-engineering-owners`, so deleting it
+    # took nobody's access away. It also ends a permanent no-op diff: nested under
+    # `devops`, its grant on `ol-infrastructure` read back as the INHERITED `admin`
+    # while the declared value was `push`, so every preview planned an update that the
+    # next refresh undid.
+    #
+    # `concourse-pulumi-resource` is left with no team grant at all as a result. That is
+    # accepted rather than overlooked: the repo is archived, so it is read-only, CON-12
+    # (scope `active`) does not cover it, and org owners keep implicit admin either way.
+    #
     # NOTE: 'Enginineering' is the live value, typo and all.
     # Recording reality is the point (section 6); fix it in phase 5.
     "odl-engineering": {
@@ -60,8 +65,8 @@ TEAMS: dict[str, dict[str, Any]] = {
         "description": "ODL Enginineering",
         "privacy": "closed",
     },
-    # NOTE: `None`, not `""`. The API returns JSON null here, whereas devops,
-    # devops-contractors and odlengweb genuinely hold empty strings. Both forms
+    # NOTE: `None`, not `""`. The API returns JSON null here, whereas devops
+    # and odlengweb genuinely hold empty strings. Both forms
     # preview clean (verified), so this is a fidelity choice: `""` would assert an
     # empty description where GitHub reports absence.
     "odl-engineering-owners": {
@@ -141,7 +146,7 @@ for slug in _in_parent_order(TEAMS):
         name=spec["name"],
         description=spec.get("description"),
         privacy=spec["privacy"],
-        # Uniform across all 12 today; move into TEAMS if that stops being true.
+        # Uniform across all 11 today; move into TEAMS if that stops being true.
         notification_setting="notifications_enabled",
         # `parent_team_id` accepts a slug as well as a numeric id, so nesting needs
         # no output plumbing. depends_on still has to be explicit: a plain string

--- a/src/ol_infrastructure/saas/github/organization/teams.py
+++ b/src/ol_infrastructure/saas/github/organization/teams.py
@@ -1,4 +1,4 @@
-"""The 14 mitodl teams, as data plus a loop.
+"""The 12 mitodl teams, as data plus a loop.
 
 Teams are declared here; team ROSTERS are not (plan section 4.7). Pulumi manages
 which teams exist and -- in the repositories project -- what each team can do. It
@@ -23,18 +23,19 @@ TEAMS: dict[str, dict[str, Any]] = {
         "description": "software engineers from Arbisoft or Edly",
         "privacy": "closed",
     },
-    "code-owners": {
-        "name": "Code Owners",
-        "description": "default code owners for MIT ODL",
-        "privacy": "closed",
-        "parent": "odl-engineering-owners",
-    },
-    "code-owners-mitx-online": {
-        "name": "code-owners-mitx-online",
-        "description": "CODEOWNERS for MITx Online",
-        "privacy": "closed",
-        "parent": "code-owners",
-    },
+    # `code-owners` and `code-owners-mitx-online` DELETED 2026-08-17. They existed to
+    # back `@mitodl/code-owners*` entries in CODEOWNERS files, and no CODEOWNERS file
+    # in the org referenced either one -- nor did any branch protection require code
+    # owner review, so even a stale reference would have been inert. What they did
+    # instead was launder permissions: both nested under `odl-engineering-owners`, so
+    # membership conferred inherited admin on ~190 repos while the team's own name
+    # suggested a review role. `/orgs/.../teams/{slug}/repos` reports that inherited
+    # admin indistinguishably from a direct grant, which is how it stayed unexamined.
+    #
+    # Deleting cost nobody access: all five members of `code-owners` and all three of
+    # `code-owners-mitx-online` are already DIRECT members of `odl-engineering-owners`.
+    # Verified before deletion rather than assumed -- a child team's members do not
+    # automatically belong to its parent, so this had to be checked per person.
     "copilot": {
         "name": "copilot",
         "description": "users with copilot seats",
@@ -140,7 +141,7 @@ for slug in _in_parent_order(TEAMS):
         name=spec["name"],
         description=spec.get("description"),
         privacy=spec["privacy"],
-        # Uniform across all 14 today; move into TEAMS if that stops being true.
+        # Uniform across all 12 today; move into TEAMS if that stops being true.
         notification_setting="notifications_enabled",
         # `parent_team_id` accepts a slug as well as a numeric id, so nesting needs
         # no output plumbing. depends_on still has to be explicit: a plain string

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/.github.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/.github.yaml
@@ -3,7 +3,7 @@ _actions_secret_names:
 - GH_PROJECT_AUTOMATION_TOKEN
 _custom_properties:
   tier: tier-1
-_has_branch_protection: true
+_has_branch_protection: false
 _pushed_at: '2026-08-07T15:09:00Z'
 _ruleset_count: 2
 _visibility: public

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/PyLmod.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/PyLmod.yaml
@@ -20,7 +20,7 @@ name: PyLmod
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: pull
+  odl-engineering: pull
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/PyLmod.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/PyLmod.yaml
@@ -20,7 +20,7 @@ name: PyLmod
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: push
+  arbisoft-contractors: admin
   odl-engineering: admin
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/access-forge.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/access-forge.yaml
@@ -25,7 +25,7 @@ _actions_secret_names:
 _custom_properties:
   tier: tier-1
 _has_branch_protection: false
-_pushed_at: '2026-08-14T05:00:38Z'
+_pushed_at: '2026-08-17T05:00:36Z'
 _ruleset_count: 2
 _visibility: private
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/agent-kit.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/agent-kit.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 2
 _has_branch_protection: false
-_pushed_at: '2026-08-14T18:48:43Z'
+_pushed_at: '2026-08-17T19:07:37Z'
 _ruleset_count: 3
 _visibility: public
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/agent-kit.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/agent-kit.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 2
 _has_branch_protection: false
-_pushed_at: '2026-08-17T19:07:37Z'
+_pushed_at: '2026-08-17T20:14:02Z'
 _ruleset_count: 3
 _visibility: public
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/bootcamp-ecommerce.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/bootcamp-ecommerce.yaml
@@ -25,6 +25,6 @@ name: bootcamp-ecommerce
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: pull
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/bootcamp-ecommerce.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/bootcamp-ecommerce.yaml
@@ -25,6 +25,6 @@ name: bootcamp-ecommerce
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: push
+  arbisoft-contractors: admin
   odl-engineering: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/bootcamps-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/bootcamps-zendesk-theme.yaml
@@ -21,6 +21,6 @@ name: bootcamps-zendesk-theme
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: push
+  arbisoft-contractors: admin
   odl-engineering: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/bootcamps-zendesk-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/bootcamps-zendesk-theme.yaml
@@ -21,6 +21,6 @@ name: bootcamps-zendesk-theme
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: pull
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ccxcon.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ccxcon.yaml
@@ -22,5 +22,5 @@ name: ccxcon
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-packer-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-packer-resource.yaml
@@ -22,6 +22,5 @@ name: concourse-packer-resource
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  devops-contractors: pull
   odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-packer-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-packer-resource.yaml
@@ -22,6 +22,6 @@ name: concourse-packer-resource
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  devops-contractors: admin
+  devops-contractors: pull
   odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-pulumi-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-pulumi-resource.yaml
@@ -21,6 +21,4 @@ merge_commit_title: MERGE_MESSAGE
 name: concourse-pulumi-resource
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
-teams:
-  devops-contractors: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-pulumi-resource.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/concourse-pulumi-resource.yaml
@@ -22,5 +22,5 @@ name: concourse-pulumi-resource
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  devops-contractors: admin
+  devops-contractors: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/cookiecutter-djangoapp.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/cookiecutter-djangoapp.yaml
@@ -21,7 +21,7 @@ name: cookiecutter-djangoapp
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
   odl-engineering-owners: admin
 topics:
 - django

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/cookiecutter-pylib.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/cookiecutter-pylib.yaml
@@ -21,5 +21,5 @@ name: cookiecutter-pylib
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/copier-djangoapp.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/copier-djangoapp.yaml
@@ -20,5 +20,5 @@ name: copier-djangoapp
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/course-search-utils.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/course-search-utils.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-08-13T14:53:31Z'
+_pushed_at: '2026-08-17T19:13:04Z'
 _ruleset_count: 2
 _visibility: public
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-cas.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-cas.yaml
@@ -20,6 +20,6 @@ name: django-cas
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
+  arbisoft-contractors: pull
   devops: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-cas.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-cas.yaml
@@ -20,6 +20,6 @@ name: django-cas
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: push
+  arbisoft-contractors: admin
   devops: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-elastic-transcoder.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-elastic-transcoder.yaml
@@ -21,6 +21,6 @@ name: django-elastic-transcoder
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: pull
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-elastic-transcoder.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-elastic-transcoder.yaml
@@ -21,6 +21,6 @@ name: django-elastic-transcoder
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: push
+  arbisoft-contractors: admin
   odl-engineering: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/django-server-status.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/django-server-status.yaml
@@ -22,7 +22,7 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
-  odl-engineering: admin
+  odl-engineering: pull
   odl-engineering-owners: admin
 topics:
 - django

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/doof.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/doof.yaml
@@ -22,6 +22,6 @@ name: doof
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-dev-intro-slides.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-dev-intro-slides.yaml
@@ -21,6 +21,6 @@ name: edx-dev-intro-slides
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-git-auto-export.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-git-auto-export.yaml
@@ -22,6 +22,6 @@ name: edx-git-auto-export
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: push
+  arbisoft-contractors: admin
   odl-engineering: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-git-auto-export.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-git-auto-export.yaml
@@ -22,6 +22,6 @@ name: edx-git-auto-export
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: pull
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-notes-api.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-notes-api.yaml
@@ -21,5 +21,5 @@ name: edx-notes-api
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-platform.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-platform.yaml
@@ -2,7 +2,7 @@
 _custom_properties:
   tier: unmanaged
 _has_branch_protection: false
-_pushed_at: '2026-07-31T20:18:00Z'
+_pushed_at: '2026-08-17T10:29:46Z'
 _ruleset_count: 0
 _visibility: public
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-sysadmin.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-sysadmin.yaml
@@ -21,6 +21,6 @@ name: edx-sysadmin
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: pull
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-sysadmin.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-sysadmin.yaml
@@ -21,6 +21,6 @@ name: edx-sysadmin
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: push
+  arbisoft-contractors: admin
   odl-engineering: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-username-changer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-username-changer.yaml
@@ -22,6 +22,6 @@ name: edx-username-changer
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: pull
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-username-changer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-username-changer.yaml
@@ -22,6 +22,6 @@ name: edx-username-changer
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: push
+  arbisoft-contractors: admin
   odl-engineering: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-username-updater.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-username-updater.yaml
@@ -22,5 +22,5 @@ name: edx-username-updater
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-video-api.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-video-api.yaml
@@ -22,6 +22,6 @@ name: edx-video-api
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: pull
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx-video-api.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx-video-api.yaml
@@ -22,6 +22,6 @@ name: edx-video-api
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: push
+  arbisoft-contractors: admin
   odl-engineering: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/edx2course_axis.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/edx2course_axis.yaml
@@ -21,6 +21,6 @@ name: edx2course_axis
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/eslint-config.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/eslint-config.yaml
@@ -2,7 +2,7 @@
 _custom_properties:
   tier: tier-1
 _has_branch_protection: false
-_pushed_at: '2026-08-12T02:51:59Z'
+_pushed_at: '2026-08-14T21:52:36Z'
 _ruleset_count: 2
 _visibility: public
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/gitreload.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/gitreload.yaml
@@ -24,7 +24,7 @@ name: gitreload
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: push
+  arbisoft-contractors: admin
   odl-engineering: admin
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/gitreload.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/gitreload.yaml
@@ -24,7 +24,7 @@ name: gitreload
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: pull
+  odl-engineering: pull
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/grafana-alerts.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/grafana-alerts.yaml
@@ -21,5 +21,5 @@ name: grafana-alerts
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/grafana-dashboards.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/grafana-dashboards.yaml
@@ -22,5 +22,5 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   devops: admin
-  odl-engineering: admin
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/hacksnack.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/hacksnack.yaml
@@ -2,7 +2,7 @@
 _custom_properties:
   tier: tier-1
 _has_branch_protection: false
-_pushed_at: '2026-08-12T13:50:14Z'
+_pushed_at: '2026-08-17T08:09:44Z'
 _ruleset_count: 2
 _visibility: public
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/hq.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/hq.yaml
@@ -5,7 +5,7 @@ _actions_secret_names:
 _custom_properties:
   tier: tier-1
 _has_branch_protection: false
-_pushed_at: '2026-08-13T05:50:56Z'
+_pushed_at: '2026-08-15T07:03:26Z'
 _ruleset_count: 2
 _visibility: private
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/hugo-course-publisher.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/hugo-course-publisher.yaml
@@ -32,6 +32,6 @@ name: hugo-course-publisher
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/learn-ai-compromised.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/learn-ai-compromised.yaml
@@ -38,7 +38,6 @@ name: learn-ai-compromised
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  code-owners: pull
   devops: push
   odl-engineering: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/learn-ai.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/learn-ai.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-08-13T19:43:16Z'
+_pushed_at: '2026-08-17T20:04:58Z'
 _ruleset_count: 2
 _visibility: public
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/lehrer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/lehrer.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-08-13T17:47:59Z'
+_pushed_at: '2026-08-16T19:34:39Z'
 _ruleset_count: 4
 _visibility: public
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/lmod_proxy.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/lmod_proxy.yaml
@@ -22,7 +22,7 @@ name: lmod_proxy
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
   odl-engineering-owners: admin
 topics:
 - edx-platform

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/locust-tests.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/locust-tests.yaml
@@ -22,5 +22,5 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   devops: admin
-  odl-engineering: admin
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/lore.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/lore.yaml
@@ -24,6 +24,6 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
-  odl-engineering: admin
+  odl-engineering: pull
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/loretemplates.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/loretemplates.yaml
@@ -22,6 +22,6 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
-  odl-engineering: admin
+  odl-engineering: pull
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mdl-react-components.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mdl-react-components.yaml
@@ -20,6 +20,6 @@ name: mdl-react-components
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: push
+  arbisoft-contractors: admin
   odl-engineering: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mdl-react-components.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mdl-react-components.yaml
@@ -20,6 +20,6 @@ name: mdl-react-components
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: pull
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mga.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mga.yaml
@@ -22,6 +22,6 @@ name: mga
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: push
+  arbisoft-contractors: pull
   odl-engineering: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mga.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mga.yaml
@@ -23,5 +23,5 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: pull
-  odl-engineering: admin
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters-templates.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters-templates.yaml
@@ -21,5 +21,5 @@ name: micromasters-templates
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/micromasters.yaml
@@ -6,7 +6,7 @@ _actions_secret_names:
 _custom_properties:
   tier: tier-1
 _excluded_environments: 2694
-_has_branch_protection: true
+_has_branch_protection: false
 _pushed_at: '2026-08-13T21:41:54Z'
 _ruleset_count: 2
 _visibility: public

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn-api-clients.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn-api-clients.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-08-13T13:03:19Z'
+_pushed_at: '2026-08-17T13:29:59Z'
 _ruleset_count: 2
 _visibility: public
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
@@ -9,8 +9,8 @@ _actions_secret_names:
 _custom_properties:
   tier: tier-1
 _excluded_environments: 44
-_has_branch_protection: true
-_pushed_at: '2026-08-14T20:19:39Z'
+_has_branch_protection: false
+_pushed_at: '2026-08-17T19:45:10Z'
 _ruleset_count: 3
 _visibility: public
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
@@ -10,7 +10,7 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 44
 _has_branch_protection: false
-_pushed_at: '2026-08-17T19:45:10Z'
+_pushed_at: '2026-08-17T20:27:55Z'
 _ruleset_count: 3
 _visibility: public
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-open-login-button.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-open-login-button.yaml
@@ -22,6 +22,6 @@ name: mit-open-login-button
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: pull
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-open-login-button.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-open-login-button.yaml
@@ -22,6 +22,6 @@ name: mit-open-login-button
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: push
+  arbisoft-contractors: admin
   odl-engineering: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit_lti_flask_sample.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit_lti_flask_sample.yaml
@@ -21,7 +21,7 @@ name: mit_lti_flask_sample
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: push
+  arbisoft-contractors: admin
   odl-engineering: admin
   odl-engineering-owners: admin
 topics:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit_lti_flask_sample.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit_lti_flask_sample.yaml
@@ -21,8 +21,8 @@ name: mit_lti_flask_sample
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: pull
+  odl-engineering: pull
   odl-engineering-owners: admin
 topics:
 - flask

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-translations.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline-translations.yaml
@@ -2,7 +2,7 @@
 _custom_properties:
   tier: unmanaged
 _has_branch_protection: false
-_pushed_at: '2026-08-14T01:06:13Z'
+_pushed_at: '2026-08-17T00:54:57Z'
 _ruleset_count: 0
 _visibility: public
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline.yaml
@@ -6,8 +6,8 @@ _actions_secret_names:
 _custom_properties:
   tier: tier-1
 _excluded_environments: 412
-_has_branch_protection: true
-_pushed_at: '2026-08-14T18:35:56Z'
+_has_branch_protection: false
+_pushed_at: '2026-08-17T18:14:16Z'
 _ruleset_count: 2
 _visibility: public
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-openedx-extensions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-openedx-extensions.yaml
@@ -20,6 +20,6 @@ name: mitxpro-openedx-extensions
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: push
+  arbisoft-contractors: admin
   odl-engineering: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-openedx-extensions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro-openedx-extensions.yaml
@@ -20,6 +20,6 @@ name: mitxpro-openedx-extensions
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: pull
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxpro.yaml
@@ -6,8 +6,8 @@ _actions_secret_names:
 _custom_properties:
   tier: tier-1
 _excluded_environments: 2042
-_has_branch_protection: true
-_pushed_at: '2026-08-12T20:44:19Z'
+_has_branch_protection: false
+_pushed_at: '2026-08-17T12:14:59Z'
 _ruleset_count: 2
 _visibility: public
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mynumbers.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mynumbers.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: unmanaged
 _excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-08-13T08:21:52Z'
+_pushed_at: '2026-08-17T07:33:19Z'
 _ruleset_count: 0
 _visibility: public
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mynumbers.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mynumbers.yaml
@@ -22,7 +22,6 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
-  code-owners: push
   odl-engineering: push
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/no_op2_resizer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/no_op2_resizer.yaml
@@ -20,5 +20,5 @@ name: no_op2_resizer
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-course-hugo-starter.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-course-hugo-starter.yaml
@@ -21,5 +21,5 @@ name: ocw-course-hugo-starter
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-course-hugo-theme.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-course-hugo-theme.yaml
@@ -21,5 +21,5 @@ name: ocw-course-hugo-theme
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-data-parser.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-data-parser.yaml
@@ -21,6 +21,6 @@ name: ocw-data-parser
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-projects.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-projects.yaml
@@ -2,7 +2,7 @@
 _custom_properties:
   tier: tier-1
 _excluded_environments: 1
-_has_branch_protection: true
+_has_branch_protection: false
 _pushed_at: '2026-08-12T13:41:20Z'
 _ruleset_count: 2
 _visibility: public

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-themes.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-hugo-themes.yaml
@@ -15,8 +15,8 @@ _actions_secret_names:
 _custom_properties:
   tier: tier-1
 _excluded_environments: 3
-_has_branch_protection: true
-_pushed_at: '2026-08-13T14:33:51Z'
+_has_branch_protection: false
+_pushed_at: '2026-08-17T19:16:51Z'
 _ruleset_count: 2
 _visibility: public
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-studio.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-studio.yaml
@@ -5,8 +5,8 @@ _actions_secret_names:
 _custom_properties:
   tier: tier-1
 _excluded_environments: 5
-_has_branch_protection: true
-_pushed_at: '2026-08-14T05:34:01Z'
+_has_branch_protection: false
+_pushed_at: '2026-08-17T13:17:15Z'
 _ruleset_count: 2
 _visibility: public
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-to-hugo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ocw-to-hugo.yaml
@@ -22,5 +22,5 @@ name: ocw-to-hugo
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/odl-keycloak.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/odl-keycloak.yaml
@@ -21,5 +21,5 @@ name: odl-keycloak
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/odl-video-service.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/odl-video-service.yaml
@@ -2,8 +2,8 @@
 _custom_properties:
   tier: tier-1
 _excluded_environments: 6
-_has_branch_protection: true
-_pushed_at: '2026-08-13T20:52:43Z'
+_has_branch_protection: false
+_pushed_at: '2026-08-17T03:51:06Z'
 _ruleset_count: 2
 _visibility: public
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/odlengweb.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/odlengweb.yaml
@@ -22,7 +22,7 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
-  odl-engineering: admin
+  odl-engineering: pull
   odl-engineering-owners: admin
   odlengweb: push
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-analytics-api.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-analytics-api.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 3
 _has_branch_protection: false
-_pushed_at: '2026-08-14T19:28:21Z'
+_pushed_at: '2026-08-14T23:15:21Z'
 _ruleset_count: 3
 _visibility: public
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-concourse.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-concourse.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-08-14T00:36:11Z'
+_pushed_at: '2026-08-17T15:49:47Z'
 _ruleset_count: 2
 _visibility: public
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-customizations-nytimes-library.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-customizations-nytimes-library.yaml
@@ -2,7 +2,7 @@
 _custom_properties:
   tier: tier-1
 _has_branch_protection: false
-_pushed_at: '2026-08-06T03:42:39Z'
+_pushed_at: '2026-08-15T15:44:53Z'
 _ruleset_count: 2
 _visibility: public
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-data-platform.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-data-platform.yaml
@@ -4,8 +4,8 @@ _actions_secret_names:
 _custom_properties:
   tier: tier-1
 _excluded_environments: 2
-_has_branch_protection: true
-_pushed_at: '2026-08-14T20:52:38Z'
+_has_branch_protection: false
+_pushed_at: '2026-08-17T19:45:23Z'
 _ruleset_count: 3
 _visibility: public
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-data-platform.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-data-platform.yaml
@@ -5,7 +5,7 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 2
 _has_branch_protection: false
-_pushed_at: '2026-08-17T19:45:23Z'
+_pushed_at: '2026-08-17T20:37:32Z'
 _ruleset_count: 3
 _visibility: public
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-django.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-django.yaml
@@ -5,7 +5,7 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-08-12T02:55:30Z'
+_pushed_at: '2026-08-17T08:07:31Z'
 _ruleset_count: 2
 _visibility: public
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
@@ -5,7 +5,7 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 2
 _has_branch_protection: false
-_pushed_at: '2026-08-17T19:48:43Z'
+_pushed_at: '2026-08-17T20:31:26Z'
 _ruleset_count: 3
 _visibility: public
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
@@ -4,8 +4,8 @@ _actions_secret_names:
 _custom_properties:
   tier: tier-1
 _excluded_environments: 2
-_has_branch_protection: true
-_pushed_at: '2026-08-14T20:49:40Z'
+_has_branch_protection: false
+_pushed_at: '2026-08-17T19:48:43Z'
 _ruleset_count: 3
 _visibility: public
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
@@ -24,7 +24,6 @@ squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
   devops: admin
-  devops-contractors: push
   odl-engineering: maintain
   odl-engineering-owners: admin
 topics:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloak-customization.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloak-customization.yaml
@@ -21,5 +21,5 @@ name: ol-keycloak-customization
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloak.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloak.yaml
@@ -1,8 +1,8 @@
 ---
 _custom_properties:
   tier: tier-1
-_has_branch_protection: true
-_pushed_at: '2026-08-10T20:05:34Z'
+_has_branch_protection: false
+_pushed_at: '2026-08-15T03:16:54Z'
 _ruleset_count: 2
 _visibility: public
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloakify.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-keycloakify.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 2
 _has_branch_protection: false
-_pushed_at: '2026-08-12T02:52:33Z'
+_pushed_at: '2026-08-17T15:52:30Z'
 _ruleset_count: 3
 _visibility: public
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-notebook-extensions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-notebook-extensions.yaml
@@ -1,8 +1,9 @@
 ---
 _custom_properties:
   tier: tier-1
+_excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-08-14T19:07:46Z'
+_pushed_at: '2026-08-17T19:36:39Z'
 _ruleset_count: 2
 _visibility: public
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-discussions-client.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-discussions-client.yaml
@@ -20,6 +20,6 @@ name: open-discussions-client
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: push
+  arbisoft-contractors: admin
   odl-engineering: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-discussions-client.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-discussions-client.yaml
@@ -20,6 +20,6 @@ name: open-discussions-client
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: pull
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-discussions.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-discussions.yaml
@@ -5,7 +5,7 @@ _actions_secret_names:
 _custom_properties:
   tier: tier-1
 _excluded_environments: 1723
-_has_branch_protection: true
+_has_branch_protection: false
 _pushed_at: '2026-08-12T15:50:43Z'
 _ruleset_count: 2
 _visibility: public

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-plugins.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-edx-plugins.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-08-12T13:02:56Z'
+_pushed_at: '2026-08-17T15:43:37Z'
 _ruleset_count: 3
 _visibility: public
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-learning-ai-tutor.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-learning-ai-tutor.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: unmanaged
 _excluded_environments: 1
 _has_branch_protection: false
-_pushed_at: '2026-08-13T05:56:07Z'
+_pushed_at: '2026-08-15T07:16:10Z'
 _ruleset_count: 0
 _visibility: public
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-widget-framework.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-widget-framework.yaml
@@ -21,7 +21,7 @@ name: open-widget-framework
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
   odl-engineering-owners: admin
 topics:
 - django

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/open-widget-sample-app.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/open-widget-sample-app.yaml
@@ -21,6 +21,6 @@ name: open-widget-sample-app
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/platform-engineering-site.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/platform-engineering-site.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 2
 _has_branch_protection: false
-_pushed_at: '2026-08-10T19:41:36Z'
+_pushed_at: '2026-08-17T17:56:21Z'
 _ruleset_count: 2
 _visibility: public
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pylti.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pylti.yaml
@@ -21,7 +21,7 @@ name: pylti
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: push
+  arbisoft-contractors: admin
   odl-engineering: push
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/pylti.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/pylti.yaml
@@ -21,7 +21,7 @@ name: pylti
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
+  arbisoft-contractors: pull
   odl-engineering: push
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/rapid-response-xblock.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/rapid-response-xblock.yaml
@@ -21,6 +21,6 @@ name: rapid-response-xblock
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: push
+  arbisoft-contractors: admin
   odl-engineering: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/rapid-response-xblock.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/rapid-response-xblock.yaml
@@ -21,6 +21,6 @@ name: rapid-response-xblock
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: pull
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/reddit.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/reddit.yaml
@@ -22,5 +22,5 @@ name: reddit
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/redux-asserts.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/redux-asserts.yaml
@@ -1,7 +1,7 @@
 ---
 _custom_properties:
   tier: tier-1
-_has_branch_protection: true
+_has_branch_protection: false
 _pushed_at: '2026-08-10T23:54:51Z'
 _ruleset_count: 2
 _visibility: public

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/redux-hammock.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/redux-hammock.yaml
@@ -2,7 +2,7 @@
 _custom_properties:
   tier: tier-1
 _has_branch_protection: false
-_pushed_at: '2026-08-08T22:33:06Z'
+_pushed_at: '2026-08-15T19:04:12Z'
 _ruleset_count: 2
 _visibility: public
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/refresh_token.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/refresh_token.yaml
@@ -20,5 +20,5 @@ name: refresh_token
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/release-script.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/release-script.yaml
@@ -3,7 +3,7 @@ _custom_properties:
   tier: tier-1
 _excluded_environments: 2
 _has_branch_protection: false
-_pushed_at: '2026-08-13T21:13:23Z'
+_pushed_at: '2026-08-14T21:29:33Z'
 _ruleset_count: 2
 _visibility: public
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/smoot-design.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/smoot-design.yaml
@@ -4,8 +4,8 @@ _actions_secret_names:
 _custom_properties:
   tier: tier-1
 _excluded_environments: 2
-_has_branch_protection: true
-_pushed_at: '2026-08-13T21:11:00Z'
+_has_branch_protection: false
+_pushed_at: '2026-08-17T15:43:33Z'
 _ruleset_count: 3
 _visibility: public
 allow_merge_commit: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/social-auth-mitxpro.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/social-auth-mitxpro.yaml
@@ -20,6 +20,6 @@ name: social-auth-mitxpro
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: pull
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/social-auth-mitxpro.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/social-auth-mitxpro.yaml
@@ -20,6 +20,6 @@ name: social-auth-mitxpro
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: push
+  arbisoft-contractors: admin
   odl-engineering: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/sso-django-prototype.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/sso-django-prototype.yaml
@@ -21,5 +21,5 @@ name: sso-django-prototype
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/superset-marimo.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/superset-marimo.yaml
@@ -1,7 +1,7 @@
 ---
 _custom_properties:
   tier: tier-1
-_has_branch_protection: true
+_has_branch_protection: false
 _pushed_at: '2026-05-22T19:14:05Z'
 _ruleset_count: 2
 _visibility: public
@@ -16,10 +16,6 @@ has_projects: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: superset-marimo
-required_status_checks:
-- Backend lint & type-check
-- Backend tests
-- Frontend type-check & build
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/teachersportal.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/teachersportal.yaml
@@ -23,7 +23,7 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
-  odl-engineering: admin
+  odl-engineering: pull
 topics:
 - inactive
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/unified-ecommerce-api-clients.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/unified-ecommerce-api-clients.yaml
@@ -21,5 +21,5 @@ name: unified-ecommerce-api-clients
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/unified-ecommerce-frontend.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/unified-ecommerce-frontend.yaml
@@ -21,5 +21,5 @@ name: unified-ecommerce-frontend
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/unified-ecommerce.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/unified-ecommerce.yaml
@@ -22,6 +22,6 @@ name: unified-ecommerce
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: push
+  arbisoft-contractors: admin
   odl-engineering: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/unified-ecommerce.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/unified-ecommerce.yaml
@@ -22,6 +22,6 @@ name: unified-ecommerce
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  arbisoft-contractors: admin
-  odl-engineering: admin
+  arbisoft-contractors: pull
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/vault-raft-backup.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/vault-raft-backup.yaml
@@ -2,7 +2,7 @@
 _custom_properties:
   tier: tier-1
 _has_branch_protection: false
-_pushed_at: '2026-08-14T05:33:25Z'
+_pushed_at: '2026-08-15T03:31:31Z'
 _ruleset_count: 2
 _visibility: public
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/vault-raft-backup.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/vault-raft-backup.yaml
@@ -21,7 +21,6 @@ name: vault-raft-backup
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  devops-contractors: push
   odl-engineering: push
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/webcast.mit.edu.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/webcast.mit.edu.yaml
@@ -22,5 +22,5 @@ name: webcast.mit.edu
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xbundle.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xbundle.yaml
@@ -22,6 +22,6 @@ squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
   arbisoft-contractors: push
-  odl-engineering: admin
+  odl-engineering: pull
   odl-engineering-owners: admin
 web_commit_signoff_required: false

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/xsiftx.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/xsiftx.yaml
@@ -22,5 +22,5 @@ name: xsiftx
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:
-  odl-engineering: admin
+  odl-engineering: pull
 web_commit_signoff_required: false

--- a/tests/ol_infrastructure/saas/github/test_audit.py
+++ b/tests/ol_infrastructure/saas/github/test_audit.py
@@ -159,11 +159,37 @@ def test_con07_only_looks_at_archived_repos() -> None:
 
 
 def test_fleet_scoped_rules_cover_archived_repos() -> None:
-    """SEC-06 and SEC-15 have no exemptions -- an admin grant on an archived repo is
-    inert only until someone unarchives it.
+    """SEC-06 has no exemptions -- a direct grant on an archived repo is inert only
+    until someone unarchives it.
     """
     archived = repo(archived=True, _direct_collaborators={"someone": "admin"})
     assert "SEC-06" in fired([archived])
+
+
+def test_unsanctioned_admin_splits_by_archived_state() -> None:
+    """The exposure is the same on both sides; the cost to fix is not.
+
+    An active repo is one `pulumi up` away. An archived one cannot be changed at all
+    without unarchiving first -- GitHub makes permissions read-only -- so it gets its
+    own id rather than sitting in SEC-15 as a finding nobody can action.
+    """
+    grants = {"arbisoft-contractors": "admin"}
+    assert "SEC-15" in fired([repo(archived=False, teams=grants)])
+    assert "SEC-15A" not in fired([repo(archived=False, teams=grants)])
+    assert "SEC-15A" in fired([repo(archived=True, teams=grants)])
+    assert "SEC-15" not in fired([repo(archived=True, teams=grants)])
+
+
+def test_sec15a_says_how_the_fix_actually_works() -> None:
+    """Downgrading in place is a 403 here, so the remediation text must not imply it."""
+    finding = next(
+        f
+        for f in audit.evaluate(
+            [repo(archived=True, teams={"arbisoft-contractors": "admin"})]
+        )
+        if f.rule_id == "SEC-15A"
+    )
+    assert "unarchive" in finding.remediation
 
 
 def test_population_matches_each_rules_scope() -> None:


### PR DESCRIPTION
### What are the relevant tickets?
N/A — follow-up to #5453 and #5459. Tracked in witan as
`tk-arbisoft-contractors-holds-admin-on-20-archived--6b89c2`

### Description (What does it do?)
Closes out today's GitHub governance work: records the classic branch-protection sweep,
revokes unsanctioned admin on 59 archived repos, and splits SEC-15 so the archived half
stops masquerading as actionable.

**Revocation (59 repos, 76 grants).** Admin held by a team outside `ADMIN_TEAMS` —
`odl-engineering` on 55, `arbisoft-contractors` on 19, `devops-contractors` on 2 — is now
`pull` everywhere. This required unarchive → change → re-archive, because GitHub makes
permissions read-only on an archived repo ("you cannot add or remove collaborators or
teams"). That is also why `repository.py` emitting no `TeamRepository` for archived repos
was never the bug — the write is **forbidden**, not merely omitted — and why #5324 and
#5451 changed intent and nothing else.

**Downgraded to `pull`, not `push`.** CON-07 states the expectation for an archived repo
as read-only and fires on `push`/`maintain`/`admin` alike, so stopping at `push` would
have cleared SEC-15 while leaving CON-07 firing on a repo just unarchived to fix it. Since
unarchiving is the expensive part, `pull` clears both in one pass and costs nothing — the
repo is read-only regardless, so the grant now simply matches reality. **CON-07 fell from
94 to 58** as a side effect.

**Rule split.** `SEC-15` narrows to `active`; new `SEC-15A` takes the archived half. Same
exposure, different cost — an active repo is one `pulumi up` away, an archived one cannot
be changed at all without unarchiving. Merged, they parked 59 findings whose stated
remediation returns 403 in a `high` security bucket, which is how a gate stops being read.
SEC-15A's remediation says what actually works: *unarchive, downgrade to pull, re-archive,
then verify it re-archived*. Both halves share `_unsanctioned_admin_grant()` in the crawl
so they cannot drift apart.

**Branch protection.** 16 repos drop to `_has_branch_protection: false`; `superset-marimo`
loses the fleet's only `required_status_checks`. Every cleared repo is still covered by an
org ruleset — none appears in SEC-01 — and SEC-16 reports zero, because no push restriction
survives anywhere in the org.

### How can this be tested?
Audit over the refreshed data:

```
SEC-15    0     active, Pulumi-fixable
SEC-15A   0     was 59 before the revocation
SEC-16    0     no push restrictions remain org-wide
SEC-01   99     none of them among the 16 cleared repos
CON-07   58     was 94
```

`pytest tests/ol_infrastructure/saas/github/` — 39 pass, including new cases asserting the
split routes by archived state and that SEC-15A's remediation text does not tell you to do
the thing that 403s. `pre-commit run --all-files` passes except pre-existing hadolint
warnings in untouched Dockerfiles.

Revocation verified by re-reading GitHub rather than trusting the run: **0 left
unarchived, 0 still elevated** across all 59.

Data-only for Pulumi — no resource behaviour changes, so `pulumi preview` on the
repositories stack should show no diff attributable to this.

### Additional Context
**Two crawl write-backs deliberately excluded**, because committing them would have caused
real damage:

| Excluded | Why |
|---|---|
| `code-owners` on `mynumbers`, `devops-contractors` on `ol-infrastructure` | Both read back as `admin`, and both are **nested** teams (parents `odl-engineering-owners` and `devops`). A child inherits the parent's repo access, so `admin` is the *effective* permission while the direct grant Pulumi manages really is `push`. Committing it would make the next `pulumi up` grant admin **directly** — privilege escalation manufactured by a crawl artifact. |
| `allow_auto_merge` / `delete_branch_on_merge` | Excluded from the first crawl attempt: #5468 had merged but not deployed, so live still read `false` and the crawl recorded a deviation that existed only because the remediation was pending. After deploy 7 converged them, the re-crawl no longer produces them at all. |

`arbisoft-contractors` and `odl-engineering` have no parent team, which is why their
write-backs are the genuine ones. The crawl's drift guard cannot distinguish inherited
from direct grants — worth knowing before the next `--allow-team-drift` run.

**Branch protection kept, not deleted:** `handbook` (only `enforce_admins: true` repo),
three `frontend-*-mitol` forks (tier `unmanaged`, so **no org ruleset targets them** —
their classic rule was the only protection, not a redundant one), and 7 `release*` rules
(they block force-push and deletion, and org rulesets target `~DEFAULT_BRANCH` only).

`mit-learn` was found carrying the same odlbot-only push restriction that blocked
`open-edx-plugins`, silently preventing three teams from merging. Nobody had reported it.
