### PR TITLE
fix(mit-learn-nextjs): stop head-sampling traces that Alloy is already tail-sampling

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
@@ -182,24 +182,34 @@ raw_env_vars = {
     "NEXT_PUBLIC_FEATURE_home_page_recommendation_bot": "true",  # pragma: allowlist secret  # noqa: E501
     # OpenTelemetry — server-side only (no NEXT_PUBLIC_ prefix).
     # OTEL_EXPORTER_OTLP_ENDPOINT is the base URL; the Node.js SDK appends /v1/traces.
-    # OTEL_TRACES_SAMPLER_ARG is read by sentry.server.config.ts as tracesSampleRate.
     # OTEL_RESOURCE_ATTRIBUTES is read by Sentry's OTEL provider for span metadata.
     #
-    # The following three vars are set here for consistency with other applications
-    # but are NOT read by the Next.js Sentry-managed OTEL provider:
-    #   OTEL_TRACES_SAMPLER  — Sentry uses SentrySampler (not the standard OTEL
-    #                          env var), which already implements parent-based sampling
-    #                          by inheriting a sampled traceparent before applying the
-    #                          tracesSampleRate fallback.
+    # OTEL_TRACES_SAMPLER_ARG is read by instrumentation-node.ts as Sentry's
+    # tracesSampleRate. Sentry owns the OTEL provider, so this governs whether a
+    # span is CREATED — a span it drops reaches neither Sentry nor the OTLP
+    # exporter. It is therefore a ceiling over both destinations, not a Tempo
+    # dial, which is why it is 1.0 rather than the 0.25 used by the Python
+    # services. Sampling for each destination happens downstream and
+    # independently: the Grafana Alloy tail sampler decides what Tempo keeps,
+    # and NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE (0.001, above) decides what
+    # Sentry keeps. Head-sampling here would also degrade the tail sampler,
+    # which needs whole traces to decide.
+    #
+    # OTEL_TRACES_SAMPLER is deliberately NOT set: Sentry's SentrySampler ignores
+    # it and implements parent-based sampling itself. Setting it looked like
+    # config but did nothing, so it is a trap for the next person tuning this.
+    # instrumentation-node.ts now warns at startup if it reappears.
+    #
+    # These two are set for consistency with other applications but are likewise
+    # NOT read by the Sentry-managed OTEL provider:
     #   OTEL_PROPAGATORS     — Sentry sets its own composite propagator (W3C
     #                          tracecontext + baggage + Sentry) internally.
     #   OTEL_EXPORTER_OTLP_PROTOCOL — the OTLPTraceExporter is instantiated directly
-    #                          in sentry.server.config.ts; protocol negotiation is
+    #                          in instrumentation-node.ts; protocol negotiation is
     #                          handled by the exporter's own defaults.
     "OTEL_SERVICE_NAME": "learn-nextjs",
     "OTEL_EXPORTER_OTLP_ENDPOINT": "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318",
-    "OTEL_TRACES_SAMPLER": "parentbased_traceidratio",
-    "OTEL_TRACES_SAMPLER_ARG": "0.25",
+    "OTEL_TRACES_SAMPLER_ARG": "1.0",
     "OTEL_PROPAGATORS": "tracecontext,baggage",
     "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf",
     "OTEL_RESOURCE_ATTRIBUTES": (


### PR DESCRIPTION
### What are the relevant tickets?
N/A — found while auditing OTel adoption across the SOA stack. Paired with https://github.com/mitodl/mit-learn/pull/3781, which documents the same invariant in the app.

### Description (What does it do?)

The Next.js server runtime has two sampling knobs that read as independent but are not. Sentry owns the OTEL provider there, so its `tracesSampleRate` decides whether a span is **created** — a span it drops reaches neither Sentry nor the OTLP exporter. `OTEL_TRACES_SAMPLER_ARG=0.25` was therefore a ceiling over both destinations, not a Tempo dial:

- Tempo saw at most 25% of learn-nextjs traffic before the Grafana Alloy tail sampler had even looked at it. With Alloy's 15% probabilistic policy on top, roughly 3.75% of traffic reached Tempo.
- `NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE=0.001` then applied under that ceiling rather than independently.

Head-sampling in front of a tail sampler is the wrong shape regardless of the rate — tail sampling needs whole traces to decide, so discarding 75% of them upstream degrades every policy it runs.

Changes:

- `OTEL_TRACES_SAMPLER_ARG` `0.25` → `1.0`. Each destination now samples for itself: Alloy for Tempo, `NEXT_PUBLIC_SENTRY_TRACES_SAMPLE_RATE` for Sentry. Sentry's rate is untouched.
- Drop `OTEL_TRACES_SAMPLER`. Sentry's `SentrySampler` ignores it and implements parent-based sampling itself, so it has never done anything here — it just looked like a knob. The paired mit-learn PR adds a startup warning if it reappears.
- Rewrite the comment block to state the ceiling relationship rather than describing the vars one at a time.

Note this is **only** the Next.js app. The Python services (`mit_learn`, `mitxonline`, `learn_ai`) use the standard OTEL SDK, which does read `OTEL_TRACES_SAMPLER`, so their `parentbased_traceidratio` / `0.25` pair is left alone.

### How can this be tested?

`pulumi preview --stack Production` on this branch, with `MIT_LEARN_NEXTJS_DOCKER_TAG` set to the running tag (0.77.4). The container env diff is exactly the intended change — the neighbouring entries only shift index because one var was removed:

```
~ [42]: name : "OTEL_TRACES_SAMPLER" => "OTEL_TRACES_SAMPLER_ARG"
        value: "parentbased_traceidratio" => "1.0"
~ [43]: name : "OTEL_TRACES_SAMPLER_ARG" => "OTEL_PROPAGATORS"
        value: "0.25" => "tracecontext,baggage"
```

`pre-commit` (ruff, mypy, detect-secrets) passes.

After deploy, in Grafana Cloud Tempo:

```
{resource.service.name="learn-nextjs"} | rate()
```

Baseline on 2026-08-17 was 4.40 spans/s. Expect roughly 4x that if the 0.25 ceiling was the binding constraint. Against a fleet total of ~750 spans/s (apisix alone is 454/s) the added volume is small, but it is worth confirming the increase lands where expected rather than assuming it.

### Additional Context

`pulumi preview` also shows an unrelated pending change on this stack — `HTTPRoute mit-learn-nextjs-https` wants to drop a null `matches` field. That is pre-existing drift, not from this branch; this change touches container env only.

Worth a separate look: every learn-nextjs trace in Tempo is self-rooted (`rootServiceName: learn-nextjs`), never rooted at `apisix`, unlike learn-webapp. So learn-nextjs is not inheriting a traceparent from the gateway and its traces cannot be followed end-to-end from the edge. That is a distinct gap from this one and is not addressed here.
