### PR TITLE
fix(aws): anchor the data lake Glue scoping so QA cannot reach production

### DIFF
--- a/src/ol_infrastructure/applications/airbyte/__main__.py
+++ b/src/ol_infrastructure/applications/airbyte/__main__.py
@@ -55,6 +55,8 @@ from ol_infrastructure.lib.aws.ec2_helper import default_egress_args
 from ol_infrastructure.lib.aws.eks_helper import setup_k8s_provider
 from ol_infrastructure.lib.aws.iam_helper import (
     IAM_POLICY_VERSION,
+    cross_environment_glue_denial,
+    data_lake_glue_resources,
     lint_iam_policy,
 )
 from ol_infrastructure.lib.ol_types import (
@@ -281,13 +283,12 @@ data_lake_policy_document = {
                 "glue:UpdateTable",
             ],
             "Resource": [
-                "arn:aws:glue:*:*:catalog",
                 "arn:aws:glue:*:*:database/airbyte_test_namespace",
                 "arn:aws:glue:*:*:table/airbyte_test_namespace/*",
-                f"arn:aws:glue:*:*:database/*{stack_info.env_suffix}*",
-                f"arn:aws:glue:*:*:table/*{stack_info.env_suffix}*/*",
+                *data_lake_glue_resources(stack_info.env_suffix),
             ],
         },
+        *cross_environment_glue_denial(stack_info.env_suffix),
     ],
 }
 data_lake_policy = iam.Policy(

--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -63,7 +63,11 @@ from ol_infrastructure.lib.aws.eks_helper import (
     ecr_image_uri,
     setup_k8s_provider,
 )
-from ol_infrastructure.lib.aws.iam_helper import IAM_POLICY_VERSION
+from ol_infrastructure.lib.aws.iam_helper import (
+    IAM_POLICY_VERSION,
+    cross_environment_glue_denial,
+    data_lake_glue_resources,
+)
 from ol_infrastructure.lib.aws.rds_helper import postgres_max_connections
 from ol_infrastructure.lib.ol_types import (
     Application,
@@ -275,12 +279,9 @@ athena_permissions: list[dict[str, str | list[str]]] = [
             "glue:UpdatePartition",
             "glue:UpdateTable",
         ],
-        "Resource": [
-            "arn:aws:glue:*:*:catalog",
-            f"arn:aws:glue:*:*:database/*{stack_info.env_suffix}*",
-            f"arn:aws:glue:*:*:table/*{stack_info.env_suffix}*/*",
-        ],
+        "Resource": data_lake_glue_resources(stack_info.env_suffix),
     },
+    *cross_environment_glue_denial(stack_info.env_suffix),
 ]
 
 

--- a/src/ol_infrastructure/applications/open_metadata/__main__.py
+++ b/src/ol_infrastructure/applications/open_metadata/__main__.py
@@ -39,7 +39,12 @@ from ol_infrastructure.lib.aws.eks_helper import (
     check_cluster_namespace,
     setup_k8s_provider,
 )
-from ol_infrastructure.lib.aws.iam_helper import IAM_POLICY_VERSION, lint_iam_policy
+from ol_infrastructure.lib.aws.iam_helper import (
+    IAM_POLICY_VERSION,
+    cross_environment_glue_denial,
+    data_lake_glue_resources,
+    lint_iam_policy,
+)
 from ol_infrastructure.lib.aws.rds_helper import DBInstanceTypes
 from ol_infrastructure.lib.ol_types import (
     Application,
@@ -502,12 +507,9 @@ open_metadata_glue_policy_document = {
                 "glue:GetPartition",
                 "glue:GetPartitions",
             ],
-            "Resource": [
-                "arn:aws:glue:*:*:catalog",
-                f"arn:aws:glue:*:*:database/*{stack_info.env_suffix}*",
-                f"arn:aws:glue:*:*:table/*{stack_info.env_suffix}*/*",
-            ],
+            "Resource": data_lake_glue_resources(stack_info.env_suffix),
         },
+        *cross_environment_glue_denial(stack_info.env_suffix),
         {
             "Effect": "Allow",
             "Action": [

--- a/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/data_warehouse/__main__.py
@@ -12,7 +12,11 @@ from pulumi_aws import athena, glue, iam, s3
 
 from ol_infrastructure.components.aws.s3 import OLBucket, S3BucketConfig
 from ol_infrastructure.lib import pulumi_projects as projects
-from ol_infrastructure.lib.aws.iam_helper import lint_iam_policy
+from ol_infrastructure.lib.aws.iam_helper import (
+    cross_environment_glue_denial,
+    data_lake_glue_resources,
+    lint_iam_policy,
+)
 from ol_infrastructure.lib.ol_types import AWSBase
 from ol_infrastructure.lib.pulumi_helper import (
     make_stack_reference,
@@ -248,11 +252,11 @@ query_engine_permissions: list[dict[str, str | list[str]]] = [
             "glue:UpdateTable",
         ],
         "Resource": [
-            "arn:aws:glue:*:*:catalog",
             "arn:aws:glue:*:*:database/information_schema",
-            f"arn:aws:glue:*:*:database/*{stack_info.env_suffix}*",
-            f"arn:aws:glue:*:*:table/*{stack_info.env_suffix}*/*",
-            f"arn:aws:glue:*:*:userDefinedFunction/*{stack_info.env_suffix}*/*",
+            *data_lake_glue_resources(
+                stack_info.env_suffix,
+                resource_types=("database", "table", "userDefinedFunction"),
+            ),
         ],
     },
     {
@@ -282,7 +286,8 @@ query_engine_permissions: list[dict[str, str | list[str]]] = [
 
 query_engine_iam_permissions = {
     "Version": "2012-10-17",
-    "Statement": query_engine_permissions,
+    "Statement": query_engine_permissions
+    + cross_environment_glue_denial(stack_info.env_suffix),
 }
 
 # Create instance profile for granting access to S3 buckets

--- a/src/ol_infrastructure/lib/aws/iam_helper.py
+++ b/src/ol_infrastructure/lib/aws/iam_helper.py
@@ -422,9 +422,15 @@ def cross_environment_glue_denial(env_suffix: str) -> list[dict[str, Any]]:
             "Sid": "DenyCrossEnvironmentGlueAccess",
             "Effect": "Deny",
             "Action": "glue:*",
+            # Built from the same namespaces the Allow is built from, so the two
+            # cannot fall out of step. Denying only ``ol_warehouse_production*``
+            # would leave the raw landing databases -- ``ol_data_lake_*_production``
+            # and ``ol-data-lake-*-production`` -- uncovered, which is exactly the
+            # gap this statement exists to close.
             "Resource": [
-                f"arn:aws:glue:*:*:{resource_type}/ol_warehouse_{environment}*{suffix}"
+                f"arn:aws:glue:*:*:{resource_type}/{namespace}{suffix}"
                 for environment in protected
+                for namespace in data_lake_glue_namespaces(environment)
                 for resource_type, suffix in _GLUE_RESOURCE_SUFFIXES.items()
             ],
         }

--- a/src/ol_infrastructure/lib/aws/iam_helper.py
+++ b/src/ol_infrastructure/lib/aws/iam_helper.py
@@ -307,3 +307,125 @@ def oidc_trust_policy_template(
         "Version": IAM_POLICY_VERSION,
         "Statement": statements,
     }
+
+
+# Glue database naming conventions for the OL data lake, per environment.
+#
+# Anchored on purpose. These were previously a bare substring match --
+# ``database/*{env_suffix}*`` -- which grants an environment access to any
+# database whose name happens to contain its own name anywhere. That is not a
+# scoping rule, it is a coincidence of naming: the QA identities reached
+# ``ol_warehouse_production_qa_{external,intermediate,mart,staging}``, dbt
+# developer schemas in the *production* namespace, one of them registered under
+# ``s3://ol-data-lake-staging-production/``.
+#
+# "ci" makes the same failure far likelier than "qa" does, being two characters
+# that appear inside ordinary words: a future
+# ``ol_warehouse_production_pricing_mart`` would be reachable by the CI
+# identities.
+DATA_LAKE_GLUE_NAMESPACES = (
+    # dbt writes ol_warehouse_{env}_{layer}, plus ol_warehouse_{env}_{user}_{layer}
+    # for developer and branch schemas.
+    "ol_warehouse_{env_suffix}",
+    "ol_warehouse_{env_suffix}_*",
+    # The raw landing databases exist in both separator styles.
+    "ol_data_lake_*_{env_suffix}",
+    "ol-data-lake-*-{env_suffix}",
+)
+
+# Environments that lower environments must never reach into, whatever the Allow
+# statements happen to say. Deliberately one-directional: the risk being managed
+# is QA or CI writing to production, not the reverse, and denying the production
+# identities access to QA would break developers whose DAGSTER_ENV=dev targets
+# the production dbt profile.
+PROTECTED_DATA_LAKE_ENVIRONMENTS = ("production",)
+
+# Glue resource types the data lake identities act on, with the suffix each ARN
+# needs after the database name.
+_GLUE_RESOURCE_SUFFIXES = {
+    "database": "",
+    "table": "/*",
+    "userDefinedFunction": "/*",
+}
+
+
+def data_lake_glue_namespaces(env_suffix: str) -> list[str]:
+    """Database-name patterns belonging to one environment's data lake.
+
+    :param env_suffix: The environment being scoped, e.g. ``qa``.
+    :type env_suffix: str
+
+    :returns: Glue database name patterns, anchored so that another
+              environment's namespace cannot match.
+
+    :rtype: list[str]
+    """
+    return [
+        namespace.format(env_suffix=env_suffix)
+        for namespace in DATA_LAKE_GLUE_NAMESPACES
+    ]
+
+
+def data_lake_glue_resources(
+    env_suffix: str,
+    resource_types: tuple[str, ...] = ("database", "table"),
+) -> list[str]:
+    """Glue ARNs scoped to one environment's data lake namespaces.
+
+    :param env_suffix: The environment being scoped, e.g. ``qa``.
+    :type env_suffix: str
+
+    :param resource_types: Which Glue resource types to emit ARNs for. Defaults
+        to databases and tables; the query engine passes
+        ``userDefinedFunction`` as well, because it manages those too.
+    :type resource_types: tuple[str, ...]
+
+    :returns: A resource list for an IAM statement, including the catalog ARN
+              that every Glue call needs.
+
+    :rtype: list[str]
+    """
+    namespaces = data_lake_glue_namespaces(env_suffix)
+    return ["arn:aws:glue:*:*:catalog"] + [
+        f"arn:aws:glue:*:*:{resource_type}/{namespace}"
+        f"{_GLUE_RESOURCE_SUFFIXES[resource_type]}"
+        for resource_type in resource_types
+        for namespace in namespaces
+    ]
+
+
+def cross_environment_glue_denial(env_suffix: str) -> list[dict[str, Any]]:
+    """Deny a lower environment any Glue action on a protected environment.
+
+    Defence in depth rather than the primary control -- ``data_lake_glue_resources``
+    already declines to grant it. This exists because an explicit Deny cannot be
+    undone by a later Allow, and widening a grant for some unrelated reason is
+    the way this would realistically regress.
+
+    :param env_suffix: The environment the policy is being generated for.
+    :type env_suffix: str
+
+    :returns: A single Deny statement, or an empty list when the environment is
+              itself protected and so has nothing to be kept out of.
+
+    :rtype: list[dict[str, Any]]
+    """
+    protected = [
+        environment
+        for environment in PROTECTED_DATA_LAKE_ENVIRONMENTS
+        if environment != env_suffix
+    ]
+    if not protected:
+        return []
+    return [
+        {
+            "Sid": "DenyCrossEnvironmentGlueAccess",
+            "Effect": "Deny",
+            "Action": "glue:*",
+            "Resource": [
+                f"arn:aws:glue:*:*:{resource_type}/ol_warehouse_{environment}*{suffix}"
+                for environment in protected
+                for resource_type, suffix in _GLUE_RESOURCE_SUFFIXES.items()
+            ],
+        }
+    ]

--- a/src/ol_infrastructure/lib/aws/iam_helper.py
+++ b/src/ol_infrastructure/lib/aws/iam_helper.py
@@ -402,6 +402,14 @@ def cross_environment_glue_denial(env_suffix: str) -> list[dict[str, Any]]:
     undone by a later Allow, and widening a grant for some unrelated reason is
     the way this would realistically regress.
 
+    ``arn:aws:glue:*:*:catalog`` is deliberately absent, and must stay absent.
+    Every Glue operation requires permission on the catalog, so denying it would
+    deny every Glue call these identities make -- including the ones against
+    their own databases -- rather than hardening anything. Confirmed with the
+    IAM policy simulator: adding it turns ``glue:GetTable`` on the catalog from
+    ``allowed`` into ``explicitDeny``. The catalog belongs in the Allow, which is
+    where ``data_lake_glue_resources`` puts it.
+
     :param env_suffix: The environment the policy is being generated for.
     :type env_suffix: str
 

--- a/src/ol_infrastructure/substructure/open_metadata/__main__.py
+++ b/src/ol_infrastructure/substructure/open_metadata/__main__.py
@@ -24,7 +24,12 @@ from bridge.lib.versions import OPEN_METADATA_VERSION
 from ol_infrastructure.components.aws.eks import OLEKSTrustRole, OLEKSTrustRoleConfig
 from ol_infrastructure.lib import pulumi_projects as projects
 from ol_infrastructure.lib.aws.eks_helper import setup_k8s_provider
-from ol_infrastructure.lib.aws.iam_helper import IAM_POLICY_VERSION, lint_iam_policy
+from ol_infrastructure.lib.aws.iam_helper import (
+    IAM_POLICY_VERSION,
+    cross_environment_glue_denial,
+    data_lake_glue_resources,
+    lint_iam_policy,
+)
 from ol_infrastructure.lib.ol_types import AWSBase
 from ol_infrastructure.lib.pulumi_helper import parse_stack, stack_ref
 
@@ -72,12 +77,9 @@ ingestion_iam_policy = iam.Policy(
                         "glue:GetPartition",
                         "glue:GetPartitions",
                     ],
-                    "Resource": [
-                        "arn:aws:glue:*:*:catalog",
-                        f"arn:aws:glue:*:*:database/*{stack_info.env_suffix}*",
-                        f"arn:aws:glue:*:*:table/*{stack_info.env_suffix}*/*",
-                    ],
+                    "Resource": data_lake_glue_resources(stack_info.env_suffix),
                 },
+                *cross_environment_glue_denial(stack_info.env_suffix),
                 {
                     "Sid": "S3DataLakeRead",
                     "Effect": "Allow",


### PR DESCRIPTION
## What are the relevant tickets?

Found while working mitodl/ol-data-platform#2564 (Sentry DAGSTER-R — QA's Iceberg maintenance issuing OPTIMIZE/ANALYZE against `ol_warehouse_production_intermediate`). That PR fixes the application side; this fixes the IAM side.

## Description (What does it do?)

All five policies granting Glue access to the data lake scoped their resources with a bare substring match:

```python
f"arn:aws:glue:*:*:database/*{stack_info.env_suffix}*"
f"arn:aws:glue:*:*:table/*{stack_info.env_suffix}*/*"
```

That grants an environment access to any database whose name happens to contain its own name **anywhere**. It is a coincidence of naming, not a scoping rule.

The QA identities reach four databases in the production namespace:

```
ol_warehouse_production_qa_external
ol_warehouse_production_qa_intermediate
ol_warehouse_production_qa_mart      → s3://ol-data-lake-staging-production/...
ol_warehouse_production_qa_staging
```

These are dbt developer schemas — the `ol_warehouse_production_{name}_{layer}` convention, where the name slot happens to be `qa`. The granted actions include `glue:DeleteTable`, `glue:DeleteDatabase` and `glue:UpdateTable`.

**Nothing is exposed today.** All four are empty (0 tables, created 2023-07-28), and the S3 grant is a trailing match (`ol-data-lake-*-{env_suffix}`) so the underlying objects were never reachable — this is metadata-level only. It becomes real the first time a production schema containing "qa" holds data, which that developer-schema convention makes easy.

**`ci` is the sharper case**, with no incident behind it yet: two characters that appear inside ordinary words. A future `ol_warehouse_production_pricing_mart` would be reachable by the CI identities.

### The change

Anchored to the real naming conventions, shared from `iam_helper` because this block was copy-pasted into five projects and had already drifted (Airbyte carries an extra `airbyte_test_namespace` entry; the query engine an extra `userDefinedFunction` line):

```
ol_warehouse_{env}          ol_data_lake_*_{env}
ol_warehouse_{env}_*        ol-data-lake-*-{env}
```

Also adds an explicit `Deny` on the production namespace for the non-production stacks. That is defence in depth rather than the control — the Allow no longer grants it — but an explicit Deny cannot be undone by a later Allow, and widening a grant for some unrelated reason is how this would realistically regress. Deliberately **one-directional**: production is not denied QA, because developers running `DAGSTER_ENV=dev` target the production dbt profile and denying the reverse direction buys nothing.

### History, since it is reasonable to ask whether this was ever wider

It was not. Created env-scoped in #869 (2022-06-08) as a *suffix* match `database/*{env}`, widened to the substring form in `5c2886030` (2022-09-28, "Update lake database names to work better with dbt") because dbt names schemas `ol_warehouse_qa_<layer>` with the env in the middle rather than at the end. `2b46d4755` (2025-02-03) only added a `userDefinedFunction` ARN. The substring form was a reasonable fix for a real problem; this is a more precise one.

## How can this be tested?

**Diffed against the live Glue catalog** (130 databases) before and after. The change is strictly narrowing, and removes access to exactly five databases — all QA's, all empty:

| env | before | after | loses |
|---|---|---|---|
| production | 70 | 70 | — |
| qa | 50 | 45 | the four `ol_warehouse_production_qa_*` above, plus `ol_warehouse_mitx_qa` |
| ci | 8 | 8 | — |

`ol_warehouse_mitx_qa` is the one loss that is arguably QA's own rather than a leak — it ends in `_qa` but does not match `ol_warehouse_qa_*`. It is empty, so I did not add a bespoke exception for it. Say the word if you would rather keep it.

**`pulumi preview` on all six affected stacks** — one in-place IAM policy update each, no replacements or deletions:

| stack | result |
|---|---|
| data_warehouse QA / Production / CI | `~ 1 to update` each |
| dagster QA | `~ 3 to update` (1 mine) |
| dagster Production | `~ 5 to update, +-1 to replace` (1 mine) |
| airbyte QA | `~ 1 to update` |
| open_metadata app QA | `~ 2 to update` (1 mine) |
| open_metadata substructure QA | `~ 1 to update` |

The extra diffs are **pre-existing drift, not from this change** — Helm image tags (`e40eeffb` → `latest`), RDS performance insights, and an HTTPRoute spec. Worth flagging separately: the Dagster Production preview shows `dagster-pgbouncer-config-production` queued for replacement and already failing with `configmaps "dagster-pgbouncer-config" already exists`. That predates this PR and looks related to #5460.

Parliament lint passes on the generated policies.

## Additional context

IAM is the backstop here, not the control. It reports "access denied" where the code should be reporting "this should never have been attempted" — which is why DAGSTER-R surfaced as an unexplained Glue error rather than as a configuration bug. mitodl/ol-data-platform#2564 adds `scope_schema_to_env()`, which re-points the manifest's compiled schemas at the running environment and refuses any schema it cannot attribute to one, so QA maintenance stops targeting production schemas in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PK9Bt1uMHXLysq6KuenDUR
