### PR TITLE
feat(k8s): allowlist Dagster job labels in kube-state-metrics

### DIFF
--- a/src/ol_infrastructure/substructure/aws/eks/grafana.py
+++ b/src/ol_infrastructure/substructure/aws/eks/grafana.py
@@ -498,7 +498,45 @@ def setup_grafana(
                 # v4: kepler and kube-state-metrics moved to telemetryServices;
                 #     opencost moved here from clusterMetrics
                 "telemetryServices": {
-                    "kube-state-metrics": {"deploy": True},
+                    "kube-state-metrics": {
+                        "deploy": True,
+                        # kube-state-metrics only emits kube_<resource>_labels for
+                        # resources named here, so without this every kube_job_*
+                        # series is anonymous -- on data-production that is ~2000
+                        # series where run-worker successes and failures can be
+                        # counted but not attributed to anything.
+                        #
+                        # Dagster's K8sRunLauncher already puts dagster/job,
+                        # dagster/code-location and dagster/run-id on every run
+                        # Job, so allowlisting the first two turns kube_job_status_*
+                        # into a per-code-location, per-job breakdown for free.
+                        # dagster/run-id is deliberately excluded: it is unique per
+                        # run at ~53k runs/day, which is a cardinality bomb.
+                        #
+                        # This is a list, so Helm replaces rather than merges it --
+                        # the nodes entry is the chart's own default, repeated here
+                        # verbatim so adding jobs does not silently drop the node
+                        # labels that the Grafana Cloud Kubernetes app relies on.
+                        # Harmless on clusters with no Dagster: they just get a
+                        # kube_job_labels series per Job with no dagster_* labels.
+                        "metricLabelsAllowlist": [
+                            "nodes=[agentpool,alpha.eksctl.io/cluster-name,"
+                            "alpha.eksctl.io/nodegroup-name,"
+                            "beta.kubernetes.io/instance-type,"
+                            "cloud.google.com/gke-nodepool,cluster-name,"
+                            "ec2.amazonaws.com/Name,"
+                            "ec2.amazonaws.com/aws-autoscaling-groupName,"
+                            "ec2.amazonaws.com/aws-autoscaling-group-name,"
+                            "ec2.amazonaws.com/name,eks.amazonaws.com/nodegroup,"
+                            "k8s.io/cloud-provider-aws,karpenter.sh/nodepool,"
+                            "kubernetes.azure.com/cluster,kubernetes.io/arch,"
+                            "kubernetes.io/hostname,kubernetes.io/os,"
+                            "node.kubernetes.io/instance-type,"
+                            "topology.kubernetes.io/region,"
+                            "topology.kubernetes.io/zone]",
+                            "jobs=[dagster/code-location,dagster/job]",
+                        ],
+                    },
                     "kepler": {"deploy": True},
                     "opencost": {
                         "deploy": True,


### PR DESCRIPTION
### What are the relevant tickets?
N/A — part of the Dagster + PgBouncer observability work tracked in `docs/plans/dagster-pgbouncer-observability.md`.

### Description (What does it do?)
- Passes `--metric-labels-allowlist` to kube-state-metrics for the first time, via `telemetryServices.kube-state-metrics.metricLabelsAllowlist` in the k8s-monitoring release.
- Adds `jobs=[dagster/code-location,dagster/job]`. Dagster's `K8sRunLauncher` already stamps those labels on every run Job — we just were not collecting them, so the ~2000 `kube_job_*` series on data-production are anonymous today. This makes `kube_job_status_*` breakable down by code location and job.
- Excludes `dagster/run-id` on purpose: unique per run at ~53k runs/day.
- Repeats the chart's own `nodes=[...]` default verbatim. `metricLabelsAllowlist` is a list, so Helm replaces rather than merges it — supplying only the `jobs` entry would silently drop the node labels the Grafana Cloud Kubernetes app groups by (instance type, zone, nodegroup).

Cost is one extra series per Job, on top of the ~10 `kube_job_*` each already produces. Clusters with no Dagster just get a `kube_job_labels` series per Job with no `dagster_*` labels on it.

This is a stopgap, strictly less rich than the planned SQL exporter against the Dagster metadata DB — no queue depth, no wait-to-start, no retry attribution — and is not a substitute for it.

### How can this be tested?
Verified before pushing, because the values passthrough path was not resolvable from the published chart values:

1. Rendered k8s-monitoring 4.4.0 locally with these values. `telemetryServices` is an alias for the `telemetry-services` subchart, which forwards its `kube-state-metrics` block to the `kube-state-metrics` 8.1.3 subchart, whose deployment template joins the list into the flag. Rendered output:

```
- --metric-labels-allowlist=nodes=[agentpool,kubernetes.io/hostname],jobs=[dagster/code-location,dagster/job]
```

2. Confirmed nothing downstream drops the new metric: the `clusterMetrics` feature scrapes KSM with `useDefaultAllowList: true`, and that default list contains `kube_job.*`, which `kube_job_labels` matches.

3. `pulumi preview --stack data.Production` in `src/ol_infrastructure/substructure/aws/eks` — one resource to update, the Helm release, with the values diff limited to the added `metricLabelsAllowlist`:

```
    ~ kubernetes:helm.sh/v3:Release: (update)
      ~ values: {
          ~ telemetryServices: {
              ~ kube-state-metrics: {
                  + metricLabelsAllowlist: [
                  +     [0]: "nodes=[agentpool,alpha.eksctl.io/cluster-name,...]"
                  +     [1]: "jobs=[dagster/code-location,dagster/job]"
                    ]
```

After deploy, confirm `kube_job_labels{cluster="data-production", namespace="dagster"}` appears with `label_dagster_code_location` and `label_dagster_job` populated, and that `kube_node_labels` still carries the node labels.

### Additional Context
The allowlist applies to every cluster, not just data-production — the k8s-monitoring release is configured once in `setup_grafana()`. That is intentional; the other clusters run few enough Jobs for the extra series to be noise-level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166x2bhRq7uXZrtCVdhF4w4