### PR TITLE
docs(github): record SEC-04's accepted-risk decision on private repos

### DIFF
--- a/src/ol_infrastructure/saas/github/audit.py
+++ b/src/ol_infrastructure/saas/github/audit.py
@@ -201,6 +201,18 @@ RULES: tuple[Rule, ...] = (
         "high",
         "active",
         "secret scanning or push protection disabled",
+        # ACCEPTED RISK on the 10 active private repos (decision 2026-08-17, closing
+        # SEC-04/13): enabling secret scanning on a PRIVATE repo spends a paid "Secret
+        # Protection" seat (`maximum_advanced_security_committers`, capped at 6 on the
+        # org's Team plan; public-repo scanning is free and does not count against it).
+        # Buying more seats was the blocker (see tk-sec-04-13 in the workflow project);
+        # the org has decided not to purchase them, so `secret_scanning: disabled`
+        # stays the deliberate value on `hq`, `access-forge`, `alerting-omnibus`,
+        # `apisix-testbed`, `common-access`, `concourse-workflow`, `gwarek`,
+        # `oldevops-scratch`, `open-collaboration`, `product` -- see each repo's YAML.
+        # Left firing rather than exempted: unlike SEC-01's fork exemption, this IS a
+        # real, standing risk on those 10 repos, just a knowingly accepted one -- the
+        # audit should keep naming it rather than going quiet.
         lambda r: (
             (
                 f"scanning={r.get('secret_scanning')} "


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
- No behavior change — `SEC-04` (secret scanning / push protection disabled) keeps firing on the same 10 private repos, since it's a real, standing condition worth continuing to surface in the audit report.
- Records *why* it's expected to keep firing: `hq`, `access-forge`, `alerting-omnibus`, `apisix-testbed`, `common-access`, `concourse-workflow`, `gwarek`, `oldevops-scratch`, `open-collaboration`, `product` all have secret scanning disabled because enabling it on a private repo spends a paid GitHub "Secret Protection" seat (capped at 6 on the org's Team plan; public-repo scanning is free). This was previously an open question (see the workflow project's `tk-sec-04-13` task, and PR #5418 which tried enabling it, then reverted it) pending a decision on whether to buy more seats.
- The org has now decided not to purchase additional seats, so the disabled state is the deliberate, permanent resting value rather than a pending fix — documented as an in-code comment next to the `SEC-04` rule so the next reader isn't left wondering whether this is unresolved.

### How can this be tested?
- `uv run pytest tests/ol_infrastructure/saas/github/test_audit.py -q` — 37 passed, no behavior change.
- `uv run bin/github-estate-audit run` — `SEC-04` still reads 10/176 active repos, same as before this PR.
- `uv run pre-commit run --files src/ol_infrastructure/saas/github/audit.py` — clean.