### PR TITLE
Bound celery pool-child RSS so one runaway task can't take the container

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1650,6 +1650,24 @@ mitlearn_celery_worker_configs = [
         redis_password=redis_config.require("password"),
         resource_requests=celery_default_resource_requests,
         resource_limits=celery_default_resource_limits,
+        # 640Mi. A healthy child on this queue sits at ~165Mi (observed
+        # on applications-production 2026-08-17: whole container ~480Mi
+        # for master + 2 children), so this only fires on a child that
+        # has genuinely ballooned, not in steady state.
+        #
+        # Sized against the *floor*-derived limit (1Gi request x the 2:1
+        # ratio = 2Gi), not the 2560Mi declared above or the 6144Mi the
+        # VPA is currently enforcing, because the floor is the smallest
+        # limit a pod can run under: 150Mi master + 2 x (640 + one task's
+        # growth) has to clear 2Gi. Coupled to --concurrency=2 and to
+        # _worker_vpa_bounds["min_allowed"] below -- revisit all three
+        # together.
+        #
+        # This bounds *carry-over* only. A single task that allocates
+        # past the cgroup limit in one go still OOM-kills the container,
+        # because celery checks RSS between tasks. See the 0.77.3
+        # get_learning_resource_views regression.
+        max_memory_per_child_kib=655360,
     ),
     OLApplicationK8sCeleryWorkerConfig(
         queue_name="edx_content",

--- a/src/ol_infrastructure/components/services/k8s.py
+++ b/src/ol_infrastructure/components/services/k8s.py
@@ -213,6 +213,16 @@ class OLApplicationK8sCeleryWorkerConfig(BaseModel):
     min_replicas: NonNegativeInt = 1
     max_replicas: NonNegativeInt = 10
     autoscale_queue_depth: NonNegativeInt = 10
+    # Resident set size, in KiB, above which celery retires a pool child. Checked
+    # after each task returns, so it bounds what a child *carries into the next
+    # task* -- it cannot stop a single task that blows the cgroup limit on its own.
+    # Without it the only recycle trigger is --max-tasks-per-child (100), so a
+    # child that balloons on task 1 stays resident for 99 more and the kernel
+    # OOM-kills the whole container, taking unrelated in-flight tasks with it.
+    # Size it so master + concurrency * (cap + one task's growth) clears the
+    # *smallest* limit the pod can run under, which under a VPA is the floor-
+    # derived limit, not the declared one.
+    max_memory_per_child_kib: PositiveInt | None = None
     redis_database_index: str = "1"
     redis_host: Output[str]
     redis_password: str
@@ -2206,6 +2216,18 @@ class OLApplicationK8s(ComponentResource):
                                         celery_worker_config.log_level,
                                         "--max-tasks-per-child",  # Max number of tasks the pool worker will process before being replaced
                                         "100",
+                                        *(
+                                            [
+                                                # Max RSS (KiB) a pool worker may
+                                                # hold before being replaced
+                                                "--max-memory-per-child",
+                                                str(
+                                                    celery_worker_config.max_memory_per_child_kib
+                                                ),
+                                            ]
+                                            if celery_worker_config.max_memory_per_child_kib
+                                            else []
+                                        ),
                                         "--concurrency=2",  # Don't try to use all cores on node
                                         "--prefetch-multiplier=1",
                                     ],

--- a/tests/ol_infrastructure/components/services/test_k8s_extra_containers.py
+++ b/tests/ol_infrastructure/components/services/test_k8s_extra_containers.py
@@ -1116,6 +1116,8 @@ def test_command_prefix_prepended_for_explicit_command():
         assert container["command"] == ["opentelemetry-instrument", "celery"]
 
     return app.application_deployment.spec.template.spec.containers.apply(check)
+
+
 # ─── celery --max-memory-per-child ────────────────────────────────────────────
 
 

--- a/tests/ol_infrastructure/components/services/test_k8s_extra_containers.py
+++ b/tests/ol_infrastructure/components/services/test_k8s_extra_containers.py
@@ -1116,3 +1116,63 @@ def test_command_prefix_prepended_for_explicit_command():
         assert container["command"] == ["opentelemetry-instrument", "celery"]
 
     return app.application_deployment.spec.template.spec.containers.apply(check)
+# ─── celery --max-memory-per-child ────────────────────────────────────────────
+
+
+def _celery_worker_config(**overrides) -> OLApplicationK8sCeleryWorkerConfig:
+    defaults = {
+        "application_name": "memcapped",
+        "worker_name": "default",
+        "redis_host": pulumi.Output.from_input("redis.example.com"),
+        "redis_password": "hunter2",  # pragma: allowlist secret
+    }
+    defaults.update(overrides)
+    return OLApplicationK8sCeleryWorkerConfig(**defaults)
+
+
+@pulumi.runtime.test
+def test_max_memory_per_child_omitted_by_default():
+    """Existing OLApplicationK8s consumers must be unaffected.
+
+    The flag changes when celery retires a pool child, so it has to stay opt-in
+    rather than arriving with a default that silently reshapes every other
+    application's worker recycling behaviour.
+    """
+    app = OLApplicationK8s(
+        _base_config(
+            application_name="memcapped",
+            celery_worker_configs=[_celery_worker_config()],
+        )
+    )
+
+    def check(containers):
+        worker = next(c for c in containers if c["name"] == "celery-worker")
+        assert "--max-memory-per-child" not in worker["command"]
+        # the sibling recycle trigger stays unconditional
+        assert "--max-tasks-per-child" in worker["command"]
+
+    return app.celery_deployments[0].spec.template.spec.containers.apply(check)
+
+
+@pulumi.runtime.test
+def test_max_memory_per_child_emitted_as_flag_and_value():
+    app = OLApplicationK8s(
+        _base_config(
+            application_name="memcapped",
+            celery_worker_configs=[
+                _celery_worker_config(max_memory_per_child_kib=655360)
+            ],
+        )
+    )
+
+    def check(containers):
+        command = next(c for c in containers if c["name"] == "celery-worker")["command"]
+        # celery takes the value as a separate argv entry, not --flag=value
+        assert command[command.index("--max-memory-per-child") + 1] == "655360"
+
+    return app.celery_deployments[0].spec.template.spec.containers.apply(check)
+
+
+def test_max_memory_per_child_rejects_non_positive():
+    with pytest.raises(ValidationError):
+        _celery_worker_config(max_memory_per_child_kib=0)


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/12673 — the application-side fix is https://github.com/mitodl/mit-learn/pull/3780. This is the infrastructure-side guard; the two are independent.

### Description (What does it do?)

`mitlearn-default-celery-worker` has been OOMKilling on `applications-production` continuously since 2026-08-13, at 15–24 container restarts an hour.

The celery worker command sets `--max-tasks-per-child 100` with no memory-based recycle trigger, so a child that balloons on task 1 stays resident for the next 99 and the kernel kills the whole container — taking unrelated in-flight tasks with it.

- Adds `max_memory_per_child_kib` to `OLApplicationK8sCeleryWorkerConfig`, emitting `--max-memory-per-child` only when set. **Defaults to `None`**, so every other `OLApplicationK8s` consumer is unchanged — this flag decides when celery retires a pool child, and shouldn't arrive as a silent default across every application.
- Sets it to `655360` (640Mi) on mit_learn's `default` worker. A healthy child on that queue sits at ~165Mi — the whole container runs ~480Mi for master + 2 children — so it only fires on a child that has genuinely ballooned.
- Sized against the **floor**-derived limit (1Gi request × the declared 2:1 ratio = 2Gi), not the 2560Mi declared or the 6144Mi the VPA currently enforces, because the floor is the smallest limit a pod can run under. Coupled to `--concurrency=2` and `_worker_vpa_bounds["min_allowed"]` — revisit the three together.
- Deliberately **not** applied to the `embeddings` or `edx_content` workers. The embeddings worker holds an ML model, so recycling on memory would mean reloading it.

### How can this be tested?

`pytest tests/ol_infrastructure/components/services/` — 114 passed, including three new cases: flag absent by default, flag and value emitted as separate argv entries, and non-positive values rejected by the validator.

`pre-commit run` on the changed files — all hooks pass, including mypy.

`pulumi preview --stack Production` shows the celery Deployment as an **update, not a replacement**, touching only the command array:

```
~ kubernetes:apps/v1:Deployment: (update)
    [id=mitlearn/mitlearn-default-celery-worker]
  ~ command: [
      ~ [11]: "--concurrency=2"        => "--max-memory-per-child"
      ~ [12]: "--prefetch-multiplier=1" => "655360"
      + [13]: "--concurrency=2"
      + [14]: "--prefetch-multiplier=1"
    ]
```

Only the `default` worker's Deployment appears — `edx-content` and `embeddings` are untouched, which confirms the opt-in default behaves as intended.

### Additional Context

**This is the guard, not the cure.** Celery checks child RSS *after a task returns*, so it bounds what a child carries into the **next** task. A single task that blows the cgroup limit within one execution still OOM-kills the container. That is what mitodl/mit-learn#3780 fixes — the PostHog view-event ETL was retaining the entire S3 backlog in memory, on both the extract and load sides. **This PR does not clear the alert on its own.**

**Resizing is not an option here.** The VPA on this deployment is already pegged at its ceiling: requests read exactly 3Gi (= `_worker_vpa_bounds["max_allowed"]["memory"]`) against a 6144MiB enforced limit vs 2560MiB declared. The 2:1 ratio and 1Gi floor added after earlier incidents guard the *floor*; here the *ceiling* binds, so raising `max_allowed` only moves the wall.

**Follow-up worth doing once memory is bounded:** re-tighten `max_allowed` back down from 3Gi. Every replica currently reserves 3Gi against up to 20 replicas while fresh pods sit at 480Mi.

**Unrelated pending drift**, visible in the same `pulumi preview` and not from this branch — worth knowing before applying, since it would ride along: the `fastly-provider` version, the `fastly-mit_learn-production` gzip content-type/extension list ordering, and the `mitlearn-webapp-pod-monitor` selector labels.
