### PR TITLE
fix(otel): ship a real pod id instead of the literal string ${HOSTNAME}

### DIFF
--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.Production.yaml
@@ -41,7 +41,7 @@ config:
     OPENTELEMETRY_ENABLED: "true"
     OPENTELEMETRY_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/traces"
     OPENTELEMETRY_SERVICE_NAME: "learn-ai-webapp"
-    OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=production,service.namespace=learn-ai,service.version=${GIT_SHA:-unknown},service.instance.id=${HOSTNAME}"
+    OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=production,service.namespace=learn-ai,service.instance.id=$(KUBERNETES_POD_NAME)"
     OTEL_TRACES_SAMPLER: "parentbased_traceidratio"
     OTEL_TRACES_SAMPLER_ARG: "0.25"
     OTEL_PROPAGATORS: "tracecontext,baggage"

--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.QA.yaml
@@ -44,7 +44,7 @@ config:
     OPENTELEMETRY_ENABLED: "true"
     OPENTELEMETRY_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/traces"
     OPENTELEMETRY_SERVICE_NAME: "learn-ai-webapp"
-    OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=qa,service.namespace=learn-ai,service.version=${GIT_SHA:-unknown},service.instance.id=${HOSTNAME}"
+    OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=qa,service.namespace=learn-ai,service.instance.id=$(KUBERNETES_POD_NAME)"
     OTEL_TRACES_SAMPLER: "parentbased_traceidratio"
     OTEL_TRACES_SAMPLER_ARG: "0.25"
     OTEL_PROPAGATORS: "tracecontext,baggage"

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
@@ -112,7 +112,7 @@ config:
     OPENTELEMETRY_ENABLED: "true"
     OPENTELEMETRY_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/traces"
     OPENTELEMETRY_SERVICE_NAME: "learn-webapp"
-    OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=production,service.namespace=learn,service.version=${GIT_SHA:-unknown},service.instance.id=${HOSTNAME}"
+    OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=production,service.namespace=learn,service.instance.id=$(KUBERNETES_POD_NAME)"
     OTEL_TRACES_SAMPLER: "parentbased_traceidratio"
     OTEL_TRACES_SAMPLER_ARG: "0.25"
     OTEL_PROPAGATORS: "tracecontext,baggage"

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.QA.yaml
@@ -92,7 +92,7 @@ config:
     OPENTELEMETRY_ENABLED: "true"
     OPENTELEMETRY_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/traces"
     OPENTELEMETRY_SERVICE_NAME: "learn-webapp"
-    OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=qa,service.namespace=learn,service.version=${GIT_SHA:-unknown},service.instance.id=${HOSTNAME}"
+    OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=qa,service.namespace=learn,service.instance.id=$(KUBERNETES_POD_NAME)"
     OTEL_TRACES_SAMPLER: "parentbased_traceidratio"
     OTEL_TRACES_SAMPLER_ARG: "0.25"
     OTEL_PROPAGATORS: "tracecontext,baggage"

--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.Production.yaml
@@ -59,7 +59,7 @@ config:
     OPENTELEMETRY_ENABLED: "true"
     OPENTELEMETRY_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/traces"
     OPENTELEMETRY_SERVICE_NAME: "mitxonline-webapp"
-    OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=production,service.namespace=mitxonline,service.version=${GIT_SHA:-unknown},service.instance.id=${HOSTNAME}"
+    OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=production,service.namespace=mitxonline,service.instance.id=$(KUBERNETES_POD_NAME)"
     OTEL_TRACES_SAMPLER: "parentbased_traceidratio"
     OTEL_TRACES_SAMPLER_ARG: "0.25"
     OTEL_PROPAGATORS: "tracecontext,baggage"

--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.QA.yaml
@@ -53,7 +53,7 @@ config:
     OPENTELEMETRY_ENABLED: "true"
     OPENTELEMETRY_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/traces"
     OPENTELEMETRY_SERVICE_NAME: "mitxonline-webapp"
-    OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=qa,service.namespace=mitxonline,service.version=${GIT_SHA:-unknown},service.instance.id=${HOSTNAME}"
+    OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=qa,service.namespace=mitxonline,service.instance.id=$(KUBERNETES_POD_NAME)"
     OTEL_TRACES_SAMPLER: "parentbased_traceidratio"
     OTEL_TRACES_SAMPLER_ARG: "0.25"
     OTEL_PROPAGATORS: "tracecontext,baggage"

--- a/src/ol_infrastructure/components/services/k8s.py
+++ b/src/ol_infrastructure/components/services/k8s.py
@@ -1166,8 +1166,30 @@ class OLApplicationK8s(ComponentResource):
                 )
             )
 
-        # Build a list of not-sensitive env vars for the deployment config
-        application_deployment_env_vars = []
+        # Pod identity from the downward API. These are the names
+        # mitol-django-observability already reads in _get_resource() to set the
+        # k8s.pod.name / k8s.namespace.name / k8s.node.name resource attributes,
+        # and the same three witan's observability module uses.
+        #
+        # These MUST be appended before the application_config loop below: the
+        # kubelet resolves a $(VAR) reference only against entries defined
+        # earlier in the same env list, and OTEL_RESOURCE_ATTRIBUTES refers to
+        # $(KUBERNETES_POD_NAME) for service.instance.id.
+        application_deployment_env_vars = [
+            kubernetes.core.v1.EnvVarArgs(
+                name=env_var_name,
+                value_from=kubernetes.core.v1.EnvVarSourceArgs(
+                    field_ref=kubernetes.core.v1.ObjectFieldSelectorArgs(
+                        field_path=field_path,
+                    ),
+                ),
+            )
+            for env_var_name, field_path in (
+                ("KUBERNETES_POD_NAME", "metadata.name"),
+                ("KUBERNETES_NAMESPACE", "metadata.namespace"),
+                ("KUBERNETES_NODE_NAME", "spec.nodeName"),
+            )
+        ]
         for k, v in (ol_app_k8s_config.application_config).items():
             application_deployment_env_vars.append(
                 kubernetes.core.v1.EnvVarArgs(

--- a/src/ol_infrastructure/components/services/k8s.py
+++ b/src/ol_infrastructure/components/services/k8s.py
@@ -465,6 +465,51 @@ class OLApplicationK8sKedaWebappScalingConfig(BaseModel):
     )
 
 
+# Pod identity from the downward API. These are the names
+# mitol-django-observability already reads in _get_resource() to set the
+# k8s.pod.name / k8s.namespace.name / k8s.node.name resource attributes, and the
+# same three witan's observability module uses.
+POD_IDENTITY_FIELD_REFS: tuple[tuple[str, str], ...] = (
+    ("KUBERNETES_POD_NAME", "metadata.name"),
+    ("KUBERNETES_NAMESPACE", "metadata.namespace"),
+    ("KUBERNETES_NODE_NAME", "spec.nodeName"),
+)
+
+
+def build_application_env_vars(
+    application_config: dict[str, Any],
+) -> list[kubernetes.core.v1.EnvVarArgs]:
+    """Assemble the non-sensitive container env for an application deployment.
+
+    Ordering carries meaning and is the reason this is a separate function
+    rather than inline: the kubelet resolves a ``$(VAR)`` reference only against
+    entries defined EARLIER in the same container's env list, and
+    OTEL_RESOURCE_ATTRIBUTES refers to ``$(KUBERNETES_POD_NAME)`` for
+    service.instance.id. Emit the downward-API entries after the application
+    config and that reference silently ships as the literal seven characters --
+    which is exactly the bug this replaced.
+    """
+    env_vars = [
+        kubernetes.core.v1.EnvVarArgs(
+            name=env_var_name,
+            value_from=kubernetes.core.v1.EnvVarSourceArgs(
+                field_ref=kubernetes.core.v1.ObjectFieldSelectorArgs(
+                    field_path=field_path,
+                ),
+            ),
+        )
+        for env_var_name, field_path in POD_IDENTITY_FIELD_REFS
+    ]
+    env_vars.extend(
+        kubernetes.core.v1.EnvVarArgs(name=k, value=v)
+        for k, v in application_config.items()
+    )
+    env_vars.append(
+        kubernetes.core.v1.EnvVarArgs(name="PORT", value=str(DEFAULT_WSGI_PORT))
+    )
+    return env_vars
+
+
 class OLApplicationK8sConfig(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -1166,39 +1211,8 @@ class OLApplicationK8s(ComponentResource):
                 )
             )
 
-        # Pod identity from the downward API. These are the names
-        # mitol-django-observability already reads in _get_resource() to set the
-        # k8s.pod.name / k8s.namespace.name / k8s.node.name resource attributes,
-        # and the same three witan's observability module uses.
-        #
-        # These MUST be appended before the application_config loop below: the
-        # kubelet resolves a $(VAR) reference only against entries defined
-        # earlier in the same env list, and OTEL_RESOURCE_ATTRIBUTES refers to
-        # $(KUBERNETES_POD_NAME) for service.instance.id.
-        application_deployment_env_vars = [
-            kubernetes.core.v1.EnvVarArgs(
-                name=env_var_name,
-                value_from=kubernetes.core.v1.EnvVarSourceArgs(
-                    field_ref=kubernetes.core.v1.ObjectFieldSelectorArgs(
-                        field_path=field_path,
-                    ),
-                ),
-            )
-            for env_var_name, field_path in (
-                ("KUBERNETES_POD_NAME", "metadata.name"),
-                ("KUBERNETES_NAMESPACE", "metadata.namespace"),
-                ("KUBERNETES_NODE_NAME", "spec.nodeName"),
-            )
-        ]
-        for k, v in (ol_app_k8s_config.application_config).items():
-            application_deployment_env_vars.append(
-                kubernetes.core.v1.EnvVarArgs(
-                    name=k,
-                    value=v,
-                )
-            )
-        application_deployment_env_vars.append(
-            kubernetes.core.v1.EnvVarArgs(name="PORT", value=str(DEFAULT_WSGI_PORT))
+        application_deployment_env_vars = build_application_env_vars(
+            ol_app_k8s_config.application_config
         )
         # Build a list of sensitive env vars for the deployment config via envFrom
         application_deployment_envfrom = []

--- a/tests/ol_infrastructure/components/services/test_k8s_pod_identity_env.py
+++ b/tests/ol_infrastructure/components/services/test_k8s_pod_identity_env.py
@@ -1,0 +1,69 @@
+"""Tests for the pod-identity env vars on application deployments.
+
+The ordering assertion is the point. OTEL_RESOURCE_ATTRIBUTES refers to
+``$(KUBERNETES_POD_NAME)`` for service.instance.id, and the kubelet resolves a
+``$(VAR)`` reference only against entries defined EARLIER in the same
+container's env list. Emit the downward-API entries after the application
+config and the reference ships as the literal seven characters instead -- which
+is the bug that put the string "${HOSTNAME}" in Tempo across every affected
+service.
+"""
+
+from __future__ import annotations
+
+from ol_infrastructure.components.services.k8s import (
+    POD_IDENTITY_FIELD_REFS,
+    build_application_env_vars,
+)
+
+
+def _names(env_vars) -> list[str]:
+    return [env_var.name for env_var in env_vars]
+
+
+def test_pod_identity_vars_come_first():
+    """They must precede anything from application_config, not merely exist."""
+    env_vars = build_application_env_vars(
+        {
+            "OTEL_RESOURCE_ATTRIBUTES": (
+                "deployment.environment=production,"
+                "service.instance.id=$(KUBERNETES_POD_NAME)"
+            ),
+        }
+    )
+
+    assert _names(env_vars)[:3] == [
+        "KUBERNETES_POD_NAME",
+        "KUBERNETES_NAMESPACE",
+        "KUBERNETES_NODE_NAME",
+    ]
+
+
+def test_pod_identity_precedes_the_var_that_references_it():
+    """Stated as the relationship that actually matters, not just an index."""
+    env_vars = build_application_env_vars(
+        {"OTEL_RESOURCE_ATTRIBUTES": "service.instance.id=$(KUBERNETES_POD_NAME)"}
+    )
+    names = _names(env_vars)
+
+    assert names.index("KUBERNETES_POD_NAME") < names.index("OTEL_RESOURCE_ATTRIBUTES")
+
+
+def test_pod_identity_vars_use_the_downward_api():
+    """A literal value here would defeat the whole point."""
+    env_vars = build_application_env_vars({})
+    by_name = {env_var.name: env_var for env_var in env_vars}
+
+    for env_var_name, field_path in POD_IDENTITY_FIELD_REFS:
+        env_var = by_name[env_var_name]
+        assert env_var.value is None
+        assert env_var.value_from.field_ref.field_path == field_path
+
+
+def test_application_config_and_port_are_still_emitted():
+    """The extraction must not drop what the deployment already relied on."""
+    env_vars = build_application_env_vars({"FOO": "bar"})
+    by_name = {env_var.name: env_var for env_var in env_vars}
+
+    assert by_name["FOO"].value == "bar"
+    assert "PORT" in by_name


### PR DESCRIPTION
### What are the relevant tickets?
N/A — found while auditing OTel adoption across the SOA stack.

### Description (What does it do?)

`OTEL_RESOURCE_ATTRIBUTES` carried `service.instance.id=${HOSTNAME}`, but nothing expands `${VAR}` on the way into a container — Pulumi doesn't, and the kubelet only expands `$(VAR)`. The literal characters were shipped as the attribute value. Tempo confirms it today:

```
resource.service.instance.id = ["${HOSTNAME}", "17f41209-e3bb-4123-8e00-b6c0b3d9556b"]
```

So per-pod attribution is impossible for mit_learn, mitxonline and learn_ai — webapps, celery workers and beat alike.

`$(HOSTNAME)` would not have fixed it either: the kubelet resolves a `$(VAR)` reference only against another entry in the same container's `env` list, and `HOSTNAME` is set by the container runtime, not the pod spec. So this takes the pod name from the downward API instead.

- **`components/services/k8s.py`** — prepend `KUBERNETES_POD_NAME` / `KUBERNETES_NAMESPACE` / `KUBERNETES_NODE_NAME` (`metadata.name`, `metadata.namespace`, `spec.nodeName`) to the shared container env list. These are the names `mitol-django-observability` already reads in `_get_resource()`, and the same three `applications/witan/observability.py` uses — so this also turns on the library's existing `k8s.pod.name` / `k8s.namespace.name` / `k8s.node.name` attributes, which were dead only for want of the environment they read. Prepended, not appended, because the kubelet resolves `$(VAR)` only against entries defined *earlier* in the list.
- **Six stack configs** — `service.instance.id=${HOSTNAME}` → `$(KUBERNETES_POD_NAME)`.
- **Six stack configs** — drop `service.version=${GIT_SHA:-unknown}`. It is inert rather than broken: `_get_resource()` sets `service.version` from `settings.VERSION`, and attributes passed to `Resource.create()` beat the ones its env detector finds. Tempo shows only real versions (`0.77.5`, `1.162.6`, `0.35.2`, …) and never the literal, which confirms the library wins. The shell-style `:-unknown` default could not survive `$(VAR)` expansion regardless, so deleting a string that has never been read beats adding machinery to compute a value that is then discarded. `applications/witan/observability.py` already documents this exact trap.

### How can this be tested?

`pulumi preview` against Production on this branch, with the running image tags:

- **learn_ai** (`LEARN_AI_DOCKER_TAG=0.35.2`): 10 to update, 108 unchanged. The env renders as intended —

  ```
  + valueFrom: { fieldRef: { fieldPath: "metadata.name" } }
  ~ OTEL_RESOURCE_ATTRIBUTES: "...,service.instance.id=$(KUBERNETES_POD_NAME),ol.mit.edu/..."
  ```

  10 resources = webapp + every celery worker + beat, confirming the shared env list reaches all containers.
- **mit_learn** (`MIT_LEARN_DOCKER_TAG=0.77.5`): 6 to update, 1 to replace.
- **micromasters** (`MICROMASTERS_DOCKER_TAG=0.252.0`): 9 to update, 124 unchanged, no errors — a stack that does *not* reference the new vars just carries three unused env entries.

`pre-commit` (ruff, mypy, yamllint, detect-secrets) passes.

After deploy, re-check in Tempo that the literal is gone:

```
resource.service.instance.id   # should contain only real pod names
```

### Additional Context

**Blast radius — worth a reviewer's attention.** `k8s.py` is shared, so all 11 stacks using `OLApplicationK8s` pick up the three env vars: edxapp, edx_notes, learn_ai, micromasters, mit_learn, mitxonline, ocw_studio, odl_video_service, ol_analytics_api, xpro, xqueue. Each gets a rolling restart whenever its stack is next applied. The alternative — adding the vars only for the three stacks that reference them — would avoid that, at the cost of leaving the library's `k8s.*` attributes dead everywhere else. I went with the fleet-wide version since pod identity is useful for every service, but it is a reasonable thing to scope down if the restarts are unwelcome.

Two pending changes in the mit_learn preview are **not** from this branch:
- `fastly:index:ServiceVcl` wants to update `activeVersion,clonedVersion,gzips` — pre-existing drift, unrelated to container env.
- `Job mitlearn-production-pre-deploy-job` is replaced rather than updated because a Job spec is immutable. That job already carries the image tag, so it is replaced on every release regardless; this change does not introduce a new class of churn.
