### PR TITLE
chore(otel): drop OPENTELEMETRY_ENABLED, which never disabled anything

### DIFF
--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.Production.yaml
@@ -38,7 +38,6 @@ config:
     MITOL_FEATURES_DEFAULT: "true"
     MITOL_SECURE_SSL_REDIRECT: "False"
     NODE_ENV: "development"
-    OPENTELEMETRY_ENABLED: "true"
     OPENTELEMETRY_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/traces"
     OPENTELEMETRY_SERVICE_NAME: "learn-ai-webapp"
     OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=production,service.namespace=learn-ai,service.version=${GIT_SHA:-unknown},service.instance.id=${HOSTNAME}"

--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.QA.yaml
@@ -41,7 +41,6 @@ config:
     MITOL_FEATURES_DEFAULT: "true"
     MITOL_SECURE_SSL_REDIRECT: "False"
     NODE_ENV: "development"
-    OPENTELEMETRY_ENABLED: "true"
     OPENTELEMETRY_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/traces"
     OPENTELEMETRY_SERVICE_NAME: "learn-ai-webapp"
     OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=qa,service.namespace=learn-ai,service.version=${GIT_SHA:-unknown},service.instance.id=${HOSTNAME}"

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.CI.yaml
@@ -72,7 +72,6 @@ config:
     MITX_ONLINE_BASE_URL: "https://mitxonline.mit.edu/"
     MITX_ONLINE_COURSES_API_URL: "https://mitxonline.mit.edu/api/v2/courses/"
     MITX_ONLINE_PROGRAMS_API_URL: "https://mitxonline.mit.edu/api/v2/programs/"
-    OPENTELEMETRY_ENABLED: "true"
     MITOL_SUPPORT_EMAIL: "odl-learn-ci-support@mit.edu" # Need to verify
     MITPE_API_ENABLED: "true"
     OCW_ITERATOR_CHUNK_SIZE: 300

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
@@ -109,7 +109,6 @@ config:
     OCW_ITERATOR_CHUNK_SIZE: 300
     OCW_LIVE_BUCKET: "ocw-content-live-production"
     OIDC_ENDPOINT: "https://sso.ol.mit.edu/realms/olapps"
-    OPENTELEMETRY_ENABLED: "true"
     OPENTELEMETRY_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/traces"
     OPENTELEMETRY_SERVICE_NAME: "learn-webapp"
     OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=production,service.namespace=learn,service.version=${GIT_SHA:-unknown},service.instance.id=${HOSTNAME}"

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.QA.yaml
@@ -89,7 +89,6 @@ config:
     QDRANT_CHUNK_SIZE: 8
     OCW_LIVE_BUCKET: "ocw-content-live-production"
     OIDC_ENDPOINT: "https://sso-qa.ol.mit.edu/realms/olapps"
-    OPENTELEMETRY_ENABLED: "true"
     OPENTELEMETRY_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/traces"
     OPENTELEMETRY_SERVICE_NAME: "learn-webapp"
     OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=qa,service.namespace=learn,service.version=${GIT_SHA:-unknown},service.instance.id=${HOSTNAME}"

--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.Production.yaml
@@ -56,7 +56,6 @@ config:
     OPENEDX_OAUTH_PROVIDER: "ol-oauth2"
     OPENEDX_SOCIAL_LOGIN_PATH: "/auth/login/ol-oauth2/?auth_entry=login"
     OPENEDX_STUDIO_API_BASE_URL: "https://studio.courses.learn.mit.edu"
-    OPENTELEMETRY_ENABLED: "true"
     OPENTELEMETRY_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/traces"
     OPENTELEMETRY_SERVICE_NAME: "mitxonline-webapp"
     OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=production,service.namespace=mitxonline,service.version=${GIT_SHA:-unknown},service.instance.id=${HOSTNAME}"

--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.QA.yaml
@@ -50,7 +50,6 @@ config:
     OPENEDX_OAUTH_PROVIDER: "ol-oauth2"
     OPENEDX_SOCIAL_LOGIN_PATH: "/auth/login/ol-oauth2/?auth_entry=login"
     OPENEDX_STUDIO_API_BASE_URL: "https://studio.courses.rc.learn.mit.edu"
-    OPENTELEMETRY_ENABLED: "true"
     OPENTELEMETRY_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/traces"
     OPENTELEMETRY_SERVICE_NAME: "mitxonline-webapp"
     OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=qa,service.namespace=mitxonline,service.version=${GIT_SHA:-unknown},service.instance.id=${HOSTNAME}"


### PR DESCRIPTION
### What are the relevant tickets?
N/A — found while auditing OTel adoption across the SOA stack. Paired with https://github.com/mitodl/mit-learn/pull/3783 and https://github.com/mitodl/mitxonline/pull/3859, which delete the corresponding Django setting.

### Description (What does it do?)

Removes `OPENTELEMETRY_ENABLED: "true"` from all seven stack configs (mit_learn CI/QA/Production, mitxonline QA/Production, learn_ai QA/Production).

Nothing reads it. `mitol-django-observability` decides whether to trace from the presence of an endpoint — there is no enable flag, and learn-ai's settings already carry a comment documenting its removal. So anyone reaching for this to shed load during an incident would have set it to `false` and watched tracing keep running, which is the worst way to find out a knob is decorative.

Removing it does not change behaviour. That is the point.

### How can this be tested?

`pulumi preview --stack Production` on learn_ai (`LEARN_AI_DOCKER_TAG=0.35.2`): 10 to update, 108 unchanged. The only container-env change is the removal — neighbouring entries shift index because one var is gone:

```
~ name : "OPENTELEMETRY_ENABLED" => "OPENTELEMETRY_ENDPOINT"
```

`pre-commit` (yamllint, YAML formatting, detect-secrets) passes.

Nothing to verify after deploy: an inert variable disappearing has no observable effect. If tracing were to stop, that would mean something *was* reading it, which is worth knowing.

### Additional Context

Not included here, deliberately: `OTEL_LOGS_EXPORTER`, `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` and `OTEL_METRIC_EXPORT_INTERVAL` are also inert — the library configures a `TracerProvider` only, with no `LoggerProvider` and no `MeterProvider`. Whether those get removed or start working depends on a decision about OTel metrics/logs providers that has not been made yet, so they stay put rather than being deleted out from under it.

This branch touches the same six files as https://github.com/mitodl/ol-infrastructure/pull/5477 but different lines (that one rewrites `OTEL_RESOURCE_ATTRIBUTES`), so they merge in either order.
