### PR TITLE
chore(otel): drop the OTLP logs variables, which point at a pipeline we do not run

### DIFF
--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.Production.yaml
@@ -46,8 +46,6 @@ config:
     OTEL_TRACES_SAMPLER_ARG: "0.25"
     OTEL_PROPAGATORS: "tracecontext,baggage"
     OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
-    OTEL_LOGS_EXPORTER: "otlp"
-    OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/logs"
     OTEL_METRIC_EXPORT_INTERVAL: "60000"
     OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT: "128"
     POSTHOG_API_HOST: "https://app.posthog.com"

--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.QA.yaml
@@ -49,8 +49,6 @@ config:
     OTEL_TRACES_SAMPLER_ARG: "0.25"
     OTEL_PROPAGATORS: "tracecontext,baggage"
     OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
-    OTEL_LOGS_EXPORTER: "otlp"
-    OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/logs"
     OTEL_METRIC_EXPORT_INTERVAL: "60000"
     OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT: "128"
     POSTHOG_API_HOST: "https://app.posthog.com"

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
@@ -117,8 +117,6 @@ config:
     OTEL_TRACES_SAMPLER_ARG: "0.25"
     OTEL_PROPAGATORS: "tracecontext,baggage"
     OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
-    OTEL_LOGS_EXPORTER: "otlp"
-    OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/logs"
     OTEL_METRIC_EXPORT_INTERVAL: "60000"
     OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT: "128"
     OPENSEARCH_INDEX: "mitlearn"

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.QA.yaml
@@ -97,9 +97,7 @@ config:
     OTEL_TRACES_SAMPLER_ARG: "0.25"
     OTEL_PROPAGATORS: "tracecontext,baggage"
     OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
-    OTEL_LOGS_EXPORTER: "otlp"
     HYBRID_VECTOR_SEARCH_MIN_SCORE: 0.07
-    OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/logs"
     OTEL_METRIC_EXPORT_INTERVAL: "60000"
     OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT: "128"
     OPENSEARCH_INDEX: "mitlearn-rc"

--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.Production.yaml
@@ -64,8 +64,6 @@ config:
     OTEL_TRACES_SAMPLER_ARG: "0.25"
     OTEL_PROPAGATORS: "tracecontext,baggage"
     OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
-    OTEL_LOGS_EXPORTER: "otlp"
-    OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/logs"
     OTEL_METRIC_EXPORT_INTERVAL: "60000"
     OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT: "128"
     SENTRY_LOG_LEVEL: "ERROR"

--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.QA.yaml
@@ -58,8 +58,6 @@ config:
     OTEL_TRACES_SAMPLER_ARG: "0.25"
     OTEL_PROPAGATORS: "tracecontext,baggage"
     OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
-    OTEL_LOGS_EXPORTER: "otlp"
-    OTEL_EXPORTER_OTLP_LOGS_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/logs"
     OTEL_METRIC_EXPORT_INTERVAL: "60000"
     OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT: "128"
     SENTRY_LOG_LEVEL: "ERROR"


### PR DESCRIPTION
### What are the relevant tickets?
N/A — found while auditing OTel adoption across the SOA stack. Implements the "logs" half of the OTel metrics/logs providers decision; the metrics half is https://github.com/mitodl/ol-django/pull/553.

### Description (What does it do?)

Removes `OTEL_LOGS_EXPORTER: "otlp"` and `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` from the six app stacks (mit_learn, mitxonline, learn_ai × QA/Production).

They describe an OTLP logs pipeline that has never existed. `mitol-django-observability` configures a `TracerProvider` only — there is no `LoggerProvider`, so nothing ever read these. Logs reach Loki by stdout scraping, with `trace_id`/`span_id` injected by the structlog processor, so trace correlation already works by a different route.

Adding a `LoggerProvider` was the alternative. Rejected deliberately: it would duplicate a path that already works and add a second log pipeline to operate and pay for, in exchange for native rather than field-based trace correlation.

**`OTEL_METRIC_EXPORT_INTERVAL` is kept on purpose.** It was equally inert, but https://github.com/mitodl/ol-django/pull/553 adds a `MeterProvider` whose `PeriodicExportingMetricReader` reads exactly this variable — so it is about to start meaning what it says. Deleting it now would only mean adding it back.

### How can this be tested?

`pre-commit` (yamllint, YAML formatting, detect-secrets) passes. The diff is 12 deletions across 6 files and nothing else.

Nothing to verify after deploy: the variables were inert, so removing them has no observable effect. Log volume in Loki should be unchanged, since that path was never the OTLP one.

### Additional Context

**Ordering hazard for a related follow-up, worth recording here.** The metrics work needs `OTEL_EXPORTER_OTLP_ENDPOINT` (a base URL) on these stacks. That variable is currently set nowhere, and it **must not be added until https://github.com/mitodl/ol-django/pull/551 has shipped and the apps have picked up the new library version** — the currently released library reads `OTEL_EXPORTER_OTLP_ENDPOINT` and passes it verbatim to the span exporter, so a base URL would make every trace batch POST to the collector root and 404. That is exactly the bug #551 fixes. I have deliberately not added it in this PR.
