### PR TITLE
feat(traefik): trace the edge, so services behind it stop rooting their own traces

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/__main__.py
@@ -1088,6 +1088,7 @@ gateway_api_crds = setup_traefik(
     lb_controller=lb_controller,
     fastly_provider=fastly_provider,
     vpa_release=vpa_release,
+    stack_info=stack_info,
 )
 
 setup_apisix(

--- a/src/ol_infrastructure/infrastructure/aws/eks/traefik.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/traefik.py
@@ -7,6 +7,8 @@ from pulumi import Config, InvokeOptions, Output, ResourceOptions
 from bridge.lib.magic_numbers import AWS_LOAD_BALANCER_NAME_MAX_LENGTH
 from ol_infrastructure.lib.aws.eks_helper import ECR_DOCKERHUB_REGISTRY
 from ol_infrastructure.lib.ol_types import AWSBase
+from ol_infrastructure.lib.pulumi_helper import StackInfo
+from ol_infrastructure.lib.toolhive_telemetry import ships_telemetry
 
 
 def setup_traefik(
@@ -25,6 +27,7 @@ def setup_traefik(
     lb_controller,
     fastly_provider: fastly.Provider,
     vpa_release: kubernetes.helm.v3.Release,
+    stack_info: StackInfo,
 ):
     """
     Configure and install the Traefik ingress controller.
@@ -44,6 +47,7 @@ def setup_traefik(
     :param lb_controller: The AWS Load Balancer Controller.
     :param fastly_provider: The Fastly provider instance.
     :param vpa_release: The VPA Helm release; ensures VPA CRDs exist before the VPA object is created.
+    :param stack_info: Stack identity, used to tag traces with deployment.environment.
 
     :return: The Gateway API CRDs.
     """
@@ -226,6 +230,48 @@ def setup_traefik(
                         },
                     },
                 },
+                # Without this, everything Traefik fronts starts its own trace.
+                # learn-nextjs is the clearest case: every one of its traces
+                # roots at learn-nextjs rather than at the edge, so a request
+                # cannot be followed from the gateway into the SSR render --
+                # unlike the services behind APISIX, which do get an edge root
+                # span and a propagated traceparent.
+                #
+                # Traefik emits a server span per request and injects
+                # traceparent upstream, which is the piece that was missing.
+                #
+                # Gated on ships_telemetry because setup_grafana early-returns
+                # on CI: there is no Alloy receiver there, and pointing an
+                # exporter at a Service that does not resolve buys a steady
+                # stream of export errors and nothing else.
+                **(
+                    {
+                        "tracing": {
+                            "serviceName": "traefik",
+                            # No head sampling. The Grafana Alloy tail sampler
+                            # owns that decision and needs whole traces to make
+                            # it, so sampling here would only degrade it.
+                            # APISIX runs always_on for the same reason.
+                            "sampleRate": 1.0,
+                            "resourceAttributes": {
+                                "deployment.environment": stack_info.env_suffix,
+                            },
+                            "otlp": {
+                                "enabled": True,
+                                "http": {
+                                    "enabled": True,
+                                    # Explicit /v1/traces. The chart documents
+                                    # its default as /v1/tracing, which is not
+                                    # the OTLP path and would 404 against the
+                                    # Alloy receiver.
+                                    "endpoint": "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/traces",
+                                },
+                            },
+                        }
+                    }
+                    if ships_telemetry(stack_info)
+                    else {}
+                ),
                 "service": {
                     # These control the configuration of the network load balancer that EKS will create
                     # automatically and point at every traefik pod.


### PR DESCRIPTION
### What are the relevant tickets?
N/A — found while auditing OTel adoption across the SOA stack.

### Description (What does it do?)

Every learn-nextjs trace in Tempo has `rootServiceName=learn-nextjs`. None root at `apisix`, unlike learn-webapp. The investigation ruled the app out entirely.

**learn-nextjs is not behind APISIX.** It is served on `next.learn.mit.edu` through a Gateway API `Gateway`, and `OLEKSGatewayConfig` has a validator permitting only `gatewayClassName: "traefik"` — so APISIX never sees that traffic. Confirmed from the other side too: APISIX's route list in Tempo covers mitlearn, mitxonline, edxapp, jupyter, tika, opik and learn-ai, and contains no `mit-learn-nextjs` route. That asymmetry is the whole story — the MIT Learn *API* is behind APISIX and gets an edge root span; the *frontend* is behind Traefik and does not.

**Traefik had no tracing at all** — its Helm values carry `metrics.prometheus` and nothing else. So nothing upstream of the Next.js server created a span or a `traceparent`, and with no incoming context the SDK correctly started a new trace. There was never anything to inherit, and no app-side change would have helped.

This turns on Traefik's native OTLP tracing, which emits a server span per request and injects `traceparent` upstream. Not specific to learn-nextjs: every service behind this gateway gains an edge root span and end-to-end correlation.

- `sampleRate: 1.0` deliberately. The Alloy tail sampler owns the sampling decision and needs whole traces to make it, so head-sampling here would only degrade it — the same reason APISIX runs `always_on`.
- Gated on `ships_telemetry(stack_info)`. `setup_grafana` early-returns on CI, so there is no Alloy receiver there; pointing an exporter at a Service that does not resolve buys a steady stream of export errors and nothing else. That predicate already exists precisely to keep this condition from drifting.
- The endpoint is written out to `/v1/traces` rather than left to the chart default, which the chart documents as `/v1/tracing` — not the OTLP path.

### How can this be tested?

`pulumi preview` on this branch, covering both sides of the gate:

| Stack | Result |
|---|---|
| `applications.Production` | `~ 1 to update`, 174 unchanged |
| `data.Production` | `~ 1 to update`, 162 unchanged |
| `applications.CI` | **169 unchanged** — gate correctly excludes CI |

The rendered values on Production are exactly the intended block:

```
+ tracing: {
    + otlp: { + endpoint: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/traces" }
    + deployment.environment: "production"
    + sampleRate: 1
    + serviceName: "traefik"
```

`pre-commit` (ruff, mypy, detect-secrets) passes.

After deploy, in Tempo:

```
{resource.service.name="traefik"} | rate()
{resource.service.name="learn-nextjs"} | rate() by (rootServiceName)
```

The first should go from empty to non-zero; the second should flip from `learn-nextjs` to `traefik`. That second query is the actual acceptance test — an edge span that does not become the parent has not fixed anything.

### Additional Context

**Volume.** Traefik currently serves ~47 req/s (`sum(rate(traefik_service_requests_total[5m]))`), against APISIX's ~31 req/s of traced requests. So this is a meaningful but not alarming increase in spans reaching the tail sampler — and much of it attaches to traces that already exist rather than creating new ones. Worth watching ingest for a day after rollout; if it is too much, the lever is a tail-sampler policy rather than a head `sampleRate` here.

**Blast radius.** `traefik.py` is shared by every EKS cluster, so all non-CI clusters pick this up and their Traefik pods roll on next apply. That is the intent — edge tracing for everything behind the gateway is the larger win — but it is worth a reviewer's attention, and scoping it to the applications cluster first is a reasonable ask if you would rather stage it.

**Fastly is still in front** and does not originate a `traceparent`, so traces begin at Traefik rather than at the true edge. That is the same position APISIX-fronted services are in today, so this does not introduce a new gap.
