### PR TITLE
fix(edxapp): set OPENEDX_LEARNING media storage for course-to-library imports

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_configmaps.py
@@ -156,6 +156,24 @@ def _build_interpolated_config_dict(
             },
             "STORAGE_TYPE": "S3",
         },
+        # File storage for the openedx_content media store, which the
+        # modulestore_migrator writes a course's static assets into when
+        # importing it to a v2 library. edx-platform ships no default for this
+        # outside of its test settings, so without it openedx_content raises
+        # ImproperlyConfigured and the import fails. These files must not be
+        # publicly readable, hence a prefix that the storage bucket's public-read
+        # policy statement (media/video-images/*) does not cover.
+        "OPENEDX_LEARNING": {
+            "MEDIA": {
+                "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
+                "OPTIONS": {
+                    "bucket_name": storage_bucket_name,
+                    "location": "openedx-learning/",
+                    "default_acl": "private",
+                    "querystring_auth": True,
+                },
+            },
+        },
         "LANGUAGE_COOKIE": f"{env_name}-openedx-language-preference",
         "MIT_LEARN_AI_API_URL": f"https://{edxapp_config.require('mit_learn_api_domain')}/ai",
         "MIT_LEARN_API_BASE_URL": f"https://{edxapp_config.require('mit_learn_api_domain')}/learn",


### PR DESCRIPTION
### What are the relevant tickets?
Found under https://github.com/mitodl/hq/issues/10564

### Description (What does it do?)
Adds `OPENEDX_LEARNING["MEDIA"]` to the shared edxapp interpolated config, pointing the `openedx_content` media store at a private `openedx-learning/` prefix of the existing `{env}-edxapp-storage` bucket.

Importing a course into a v2 library currently fails on mitxonline production. The `modulestore_migrator` copies the course's static assets into the `openedx_content` media store, which resolves its storage backend from `OPENEDX_LEARNING["MEDIA"]`. edx-platform defines that setting only in [`cms/envs/test.py`](https://github.com/openedx/openedx-platform/blob/master/cms/envs/test.py#L213) — Tutor supplies it for its deployments, our config path does not — so `get_storage()` raises:

```
django.core.exceptions.ImproperlyConfigured: Cannot access file storage: Missing the
OPENEDX_LEARNING['MEDIA'] setting, which should have a storage BACKEND and OPTIONS
values for a Storage subclass. These files should be stored in a location that is NOT
publicly accessible to browsers (so not in the MEDIA_ROOT).
```

### How can this be tested?

`pulumi preview` on `applications.edxapp.mitxonline.Production` should show only an update to the `60-interpolated-config-yaml` ConfigMap, adding the `OPENEDX_LEARNING` key.

After deploying, restart CMS and the CMS celery worker — `get_storage()` is `@cache`d per process and these deployments have no ConfigMap checksum annotation, so pods do not cycle on a ConfigMap change alone:

```
kubectl -n mitxonline-openedx rollout restart deploy/<cms> deploy/<cms-worker>
```

Confirm the setting resolves (run in the **worker** pod — that is where imports execute):

```
./manage.py cms shell -c "from openedx_content.applets.media.models import get_storage; print(get_storage())"
```

Then in Studio, import a course that has static assets into a v2 library. Expected: the import completes and content lands in the library, instead of the "Import Failed" page.

Verify the uploaded objects are not publicly readable:

```
aws s3api get-object --bucket mitxonline-production-edxapp-storage --key openedx-learning/<some-key> /dev/null   # works with credentials
curl -I https://mitxonline-production-edxapp-storage.s3.amazonaws.com/openedx-learning/<some-key>                # expect 403
```

### Additional Context

**Why only mitxonline.** Per `src/bridge/settings/openedx/version_matrix.py`, mitx and mitx-staging production run `verawood` and xpro runs `ulmo`; mitxonline production tracks `master`. The `openedx_content` media applet and the migrator's asset-write path are master-only, so mitxonline is the first deployment to reach this code. The setting is added to the shared interpolated config rather than a mitxonline-only block — it is inert on the older releases and avoids the same breakage when they upgrade.

**Why it is hard to see in Studio.** The migrator catches the exception per source and only sets `is_failed` on the migration row, without recording the message ([`tasks.py:681`](https://github.com/openedx/openedx-platform/blob/master/cms/djangoapps/modulestore_migrator/tasks.py#L681)). The bulk task itself still reports `Succeeded`, no `UserTaskArtifact` is written, and the authoring MFE's Failed page renders "Import failed for the following reasons:" with nothing after it. Diagnosis required re-running the migration steps by hand in a shell. Worth following up upstream so the reason is persisted and surfaced.

**Bucket safety.** The storage bucket's policy grants public `s3:GetObject` to `media/video-images/*` only (`src/ol_infrastructure/applications/edxapp/__main__.py`), so the `openedx-learning/` prefix is private, which is what the setting requires. `default_acl: private` is set explicitly. The edxapp IAM role already covers the bucket and its objects, so no policy change is needed.

**Reach.** The interpolated ConfigMap is mounted into LMS, CMS and — via `cms_edxapp_volumes` — the CMS celery worker, which is where the import task actually runs.

**Validation run locally.** `pre-commit run --files src/ol_infrastructure/applications/edxapp/k8s_configmaps.py` passes, including ruff and mypy. `pulumi preview` was not run locally (no credentials for the production stack).