### PR TITLE
fix(k8s): split webapp liveness to TCP, keep readiness on HTTP

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/k8s_resources.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_resources.py
@@ -794,17 +794,14 @@ def create_k8s_resources(  # noqa: C901
                 limit_workers_max_rss=True,
             ),
             probe_configs={
+                # TCP rather than HTTP so a saturated Granian worker pool
+                # cannot fail liveness and trigger a restart that removes
+                # capacity from an already overloaded service. Readiness stays
+                # on HTTP, and keeps the Host header because it still reaches
+                # Django's ALLOWED_HOSTS check. See default_probe_configs in
+                # components/services/k8s.py.
                 "liveness_probe": kubernetes.core.v1.ProbeArgs(
-                    http_get=kubernetes.core.v1.HTTPGetActionArgs(
-                        path="/heartbeat",
-                        port=8000,
-                        http_headers=[
-                            kubernetes.core.v1.HTTPHeaderArgs(
-                                name="Host",
-                                value=edxapp_config.require_object("domains")["lms"],
-                            ),
-                        ],
-                    ),
+                    tcp_socket=kubernetes.core.v1.TCPSocketActionArgs(port=8000),
                     initial_delay_seconds=30,
                     period_seconds=30,
                     failure_threshold=3,
@@ -1139,17 +1136,14 @@ def create_k8s_resources(  # noqa: C901
                 limit_workers_max_rss=True,
             ),
             probe_configs={
+                # TCP rather than HTTP so a saturated Granian worker pool
+                # cannot fail liveness and trigger a restart that removes
+                # capacity from an already overloaded service. Readiness stays
+                # on HTTP, and keeps the Host header because it still reaches
+                # Django's ALLOWED_HOSTS check. See default_probe_configs in
+                # components/services/k8s.py.
                 "liveness_probe": kubernetes.core.v1.ProbeArgs(
-                    http_get=kubernetes.core.v1.HTTPGetActionArgs(
-                        path="/heartbeat",
-                        port=8000,
-                        http_headers=[
-                            kubernetes.core.v1.HTTPHeaderArgs(
-                                name="Host",
-                                value=edxapp_config.require_object("domains")["studio"],
-                            ),
-                        ],
-                    ),
+                    tcp_socket=kubernetes.core.v1.TCPSocketActionArgs(port=8000),
                     initial_delay_seconds=30,
                     period_seconds=30,
                     failure_threshold=3,

--- a/src/ol_infrastructure/applications/micromasters/__main__.py
+++ b/src/ol_infrastructure/applications/micromasters/__main__.py
@@ -919,16 +919,14 @@ micromasters_k8s_app = OLApplicationK8s(
         # (already in ALLOWED_HOSTS) instead of the pod IP; this only
         # overrides the header kubelet sends, not the connection target.
         probe_configs={
+            # TCP rather than HTTP so a saturated Granian worker pool cannot
+            # fail liveness and trigger a restart that removes capacity from an
+            # already overloaded service. Readiness stays on HTTP, and keeps the
+            # Host header because it still reaches Django's ALLOWED_HOSTS check.
+            # See default_probe_configs in components/services/k8s.py.
             "liveness_probe": kubernetes.core.v1.ProbeArgs(
-                http_get=kubernetes.core.v1.HTTPGetActionArgs(
-                    path="/health/liveness/",
+                tcp_socket=kubernetes.core.v1.TCPSocketActionArgs(
                     port=DEFAULT_NGINX_PORT,
-                    http_headers=[
-                        kubernetes.core.v1.HTTPHeaderArgs(
-                            name="Host",
-                            value=backend_domain,
-                        )
-                    ],
                 ),
                 initial_delay_seconds=30,
                 period_seconds=30,

--- a/src/ol_infrastructure/applications/odl_video_service/__main__.py
+++ b/src/ol_infrastructure/applications/odl_video_service/__main__.py
@@ -885,9 +885,12 @@ ovs_k8s_app = OLApplicationK8s(
         resource_requests={"cpu": "250m", "memory": "512Mi"},
         resource_limits={"memory": "1Gi"},
         probe_configs={
+            # TCP rather than HTTP so a saturated Granian worker pool cannot
+            # fail liveness and trigger a restart that removes capacity from an
+            # already overloaded service. Readiness stays on HTTP. See
+            # default_probe_configs in components/services/k8s.py.
             "liveness_probe": kubernetes.core.v1.ProbeArgs(
-                http_get=kubernetes.core.v1.HTTPGetActionArgs(
-                    path="/health/liveness/",
+                tcp_socket=kubernetes.core.v1.TCPSocketActionArgs(
                     port=DEFAULT_WSGI_PORT,
                 ),
                 initial_delay_seconds=30,

--- a/src/ol_infrastructure/applications/ol_analytics_api/__main__.py
+++ b/src/ol_infrastructure/applications/ol_analytics_api/__main__.py
@@ -441,11 +441,12 @@ _probe_configs = {
         failure_threshold=3,
         timeout_seconds=3,
     ),
+    # TCP rather than HTTP so a saturated Granian worker pool cannot fail
+    # liveness and trigger a restart that removes capacity from an already
+    # overloaded service. Readiness stays on HTTP. See default_probe_configs in
+    # components/services/k8s.py.
     "liveness_probe": kubernetes.core.v1.ProbeArgs(
-        http_get=kubernetes.core.v1.HTTPGetActionArgs(
-            path="/health/liveness/",
-            port=APPLICATION_PORT,
-        ),
+        tcp_socket=kubernetes.core.v1.TCPSocketActionArgs(port=APPLICATION_PORT),
         initial_delay_seconds=30,
         period_seconds=30,
         failure_threshold=3,

--- a/src/ol_infrastructure/components/services/k8s.py
+++ b/src/ol_infrastructure/components/services/k8s.py
@@ -115,14 +115,27 @@ def default_probe_configs(port: int) -> dict[str, kubernetes.core.v1.ProbeArgs]:
     Built per-instance rather than held as a class default so the port tracks
     whatever the application container actually listens on. Apps with the nginx
     sidecar are probed at the sidecar; apps without it are probed at Granian.
+
+    Liveness is a TCP connect, not an HTTP GET, while readiness and startup stay
+    on HTTP. An HTTP liveness request has to be served by the same bounded pool
+    of Granian blocking threads that is serving user traffic, so a pod that is
+    merely saturated fails liveness and gets restarted -- which removes capacity
+    from an already-overloaded service and makes the saturation worse. Granian's
+    maintainer reports exactly this pod-churn spiral in emmett-framework/granian
+    discussion #663. A TCP connect is answered by the listener rather than by a
+    worker thread, so it distinguishes "the process is gone" from "the process
+    is busy".
+
+    The trade-off is deliberate: liveness no longer restarts a pod whose Granian
+    workers are wedged but whose listener still accepts. Readiness does still
+    fail in that case, so the pod is pulled from the Service endpoints and stops
+    receiving traffic -- it just is not killed automatically.
     """
     return {
-        # Liveness probe to check if the application is still running
+        # Liveness probe to check that the process is still there at all. See the
+        # docstring for why this is TCP while the other two probes are HTTP.
         "liveness_probe": kubernetes.core.v1.ProbeArgs(
-            http_get=kubernetes.core.v1.HTTPGetActionArgs(
-                path="/health/liveness/",
-                port=port,
-            ),
+            tcp_socket=kubernetes.core.v1.TCPSocketActionArgs(port=port),
             initial_delay_seconds=30,  # Wait 30 seconds before first probe
             period_seconds=30,
             failure_threshold=3,  # Consider failed after 3 attempts

--- a/tests/ol_infrastructure/components/services/test_k8s_extra_containers.py
+++ b/tests/ol_infrastructure/components/services/test_k8s_extra_containers.py
@@ -707,7 +707,16 @@ _PROBE_KEYS = ("liveness_probe", "readiness_probe", "startup_probe")
 
 
 def _probe_ports(container) -> set[int]:
-    return {container[key]["http_get"]["port"] for key in _PROBE_KEYS}
+    """Ports the probes target, whichever action kind each one uses.
+
+    Liveness is a tcp_socket action and the other two are http_get, so this
+    reads whichever of the two the probe actually carries.
+    """
+    ports = set()
+    for key in _PROBE_KEYS:
+        action = container[key].get("http_get") or container[key]["tcp_socket"]
+        ports.add(action["port"])
+    return ports
 
 
 def _app_container(containers, application_name="myapp"):
@@ -718,16 +727,33 @@ def test_default_probe_configs_follow_port():
     """The generated probes all target the port they were built for."""
     probes = default_probe_configs(9999)
     assert set(probes) == {"liveness_probe", "readiness_probe", "startup_probe"}
-    for probe in probes.values():
-        assert probe.http_get.port == 9999
+    assert probes["liveness_probe"].tcp_socket.port == 9999
+    assert probes["readiness_probe"].http_get.port == 9999
+    assert probes["startup_probe"].http_get.port == 9999
 
 
 def test_default_probe_configs_paths_unchanged():
-    """django-health-check endpoints, one per probe kind."""
+    """django-health-check endpoints, for the two probes that still speak HTTP."""
     probes = default_probe_configs(DEFAULT_WSGI_PORT)
-    assert probes["liveness_probe"].http_get.path == "/health/liveness/"
     assert probes["readiness_probe"].http_get.path == "/health/readiness/"
     assert probes["startup_probe"].http_get.path == "/health/startup/"
+
+
+def test_liveness_is_tcp_while_readiness_stays_http():
+    """The probe split from granian discussion #663.
+
+    An HTTP liveness request is served by the same bounded pool of Granian
+    blocking threads as user traffic, so a merely-saturated pod fails liveness
+    and is restarted -- shedding capacity from a service that is already
+    overloaded. A TCP connect is answered by the listener instead, so it
+    reports "the process is gone" rather than "the process is busy". Readiness
+    stays on HTTP so a wedged pod is still pulled from the Service endpoints.
+    """
+    probes = default_probe_configs(DEFAULT_NGINX_PORT)
+    assert probes["liveness_probe"].tcp_socket is not None
+    assert probes["liveness_probe"].http_get is None
+    assert probes["readiness_probe"].http_get is not None
+    assert probes["readiness_probe"].tcp_socket is None
 
 
 @pulumi.runtime.test


### PR DESCRIPTION
## What are the relevant tickets?

Part of the Granian configuration overhaul epic. Closes the deferred probe item from `docs/plans/granian-configuration-overhaul.md` (witan `tk-split-webapp-liveness-probe-to-tcp-keep-readines-4f58d9`).

## Description (What does this PR do?)

Changes the webapp **liveness** probe from an HTTP GET to a TCP connect, on the component default and on every Granian app that overrides `probe_configs` wholesale. **Readiness and startup stay on HTTP** against the same django-health-check / `/heartbeat` endpoints they use today.

An HTTP liveness request has to be served by the same bounded pool of Granian blocking threads that is serving user traffic. Now that this overhaul is tightening backpressure (64 → 16), a pod that is merely *saturated* starts failing liveness, gets restarted, and takes its capacity out of a service that was already overloaded. Granian's maintainer reports exactly that pod-churn spiral in [granian discussion #663](https://github.com/emmett-framework/granian/discussions/663).

A TCP connect is answered by the listener rather than by a worker thread, so it distinguishes "the process is gone" from "the process is busy".

**The trade-off is deliberate and worth stating plainly:** liveness no longer restarts a pod whose Granian workers are wedged but whose listener still accepts. Readiness *does* still fail in that case, so the pod is pulled from the Service endpoints and stops receiving traffic — it just is not killed automatically. We give up auto-recovery from a true wedge in exchange for never restarting a pod for the crime of being busy.

Files touched:

| file | shape |
| --- | --- |
| `components/services/k8s.py` | component default (`default_probe_configs`) — covers ocw_studio, xpro, mit_learn, learn_ai, mitxonline |
| `applications/micromasters/__main__.py` | override, had a Host header |
| `applications/edxapp/k8s_resources.py` | override x2 (LMS + CMS), had a Host header |
| `applications/odl_video_service/__main__.py` | override, no header |
| `applications/ol_analytics_api/__main__.py` | override, no header |

The Host header is dropped from the liveness entries only — it existed to satisfy Django's `ALLOWED_HOSTS`, which a TCP connect never reaches. Readiness and startup keep theirs.

`edx_notes` and `xqueue` also override `probe_configs`, but they are not Granian workloads, so they are deliberately left alone rather than swept along.

## How can this be tested?

`pulumi preview` against CI for all four code shapes. Every stack shows a single Deployment update touching only `livenessProbe`, no replacements:

- **ocw_studio.CI** (component default): `- httpGet {path: /health/liveness/, port: 8073}` → `+ tcpSocket {port: 8073}`, 1 Deployment
- **micromasters.CI** (override + header): `- httpGet {httpHeaders: [...backend.odl.mit.edu]}` → `+ tcpSocket {port: 8071}`, 1 Deployment
- **edxapp mitx.CI** (override + header, x2): both LMS and CMS Deployments → `+ tcpSocket {port: 8000}`
- **odl_video_service.CI** (override, no header): → `+ tcpSocket {port: 8073}`, 1 Deployment

Test suite: 816 passed. Updated the two existing `default_probe_configs` assertions and the `_probe_ports` helper (which assumed every probe carries `http_get`), and added `test_liveness_is_tcp_while_readiness_stays_http` as the regression guard.

`pre-commit run --all-files`: ruff, ruff-format, and mypy all pass. (hadolint reports pre-existing findings on Dockerfiles this PR does not touch.)

## Additional Context

Sequenced deliberately: this was held back until after stage 2 so the probe change and the concurrency changes land in separate deploys and stay separable if either one moves a latency or restart metric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0166K1vrjtPKzK49L45UMyDe