### PR TITLE
fix(dagster): stop the daemon exhausting its ephemeral ports against PgBouncer

### DIFF
--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -1774,6 +1774,30 @@ dagster_helm_values = {
             {"name": "dagster-dbt-secrets"},
             {"name": "dagster-postgresql-secret"},
         ],
+        # Every connection the daemon makes goes to one destination tuple -- the
+        # PgBouncer ClusterIP on 5432 -- so its concurrent connection ceiling is
+        # the size of the pod's ephemeral port range, and nothing else in the
+        # cluster shares those ports because each pod has its own netns. The
+        # kernel default of 32768-60999 is 28232 ports, and on 2026-08-18 the
+        # daemon consumed all of them: TIME_WAIT is a fixed 60s, so the 331
+        # connects/second the NullPool storages were doing parked ~20k sockets
+        # at steady state and any burst pushed the total past the range, after
+        # which connect() returns EADDRNOTAVAIL.
+        #
+        # The pooled storage classes in dagster_instance.yaml are the actual fix
+        # for that churn; this widens the range to 55296 ports so the pod has
+        # room to absorb a burst regardless, and so a future regression degrades
+        # instead of failing outright. It is deliberately not a substitute --
+        # doubling the range only doubles the rate that exhausts it.
+        #
+        # net.ipv4.ip_local_port_range has been a Kubernetes safe sysctl since
+        # 1.27 (the cluster runs 1.36), so it needs no kubelet allowlist and
+        # passes the baseline Pod Security Standard.
+        "podSecurityContext": {
+            "sysctls": [
+                {"name": "net.ipv4.ip_local_port_range", "value": "10240 65535"},
+            ],
+        },
         "resources": {
             "requests": {
                 "cpu": "500m",

--- a/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
+++ b/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
@@ -14,10 +14,49 @@ compute_logs:
       env: DAGSTER_BUCKET_NAME
     prefix: compute-logs/
 
+# All three storages below use the pooled subclasses from ol-data-platform
+# (ol_orchestrate.lib.postgres) rather than the stock dagster_postgres classes.
+# The stock classes build every engine with poolclass=NullPool
+# (dagster_postgres/event_log/event_log.py:102), so a process's connection count
+# is a function of its query rate with no upper bound and no reuse: each
+# operation is a fresh TCP connect and close.
+#
+# On 2026-08-18 that cost the daemon its ephemeral port space. It sustained 331
+# outbound connects/second to the PgBouncer ClusterIP while holding only 13 of
+# them open at a time; TIME_WAIT is a fixed 60s, so all 28232 ports in the pod's
+# 32768-60999 range were consumed by a single destination tuple and connect()
+# began returning EADDRNOTAVAIL -- surfacing as psycopg2 "Cannot assign
+# requested address", which reads like PgBouncer is down but is raised by bind()
+# before a packet is sent. PgBouncer was healthy throughout: 12 active clients,
+# 11 active server connections, 0 waiting, against a 708-per-replica cap.
+#
+# QueuePool bounds each process at pool_size + max_overflow and, more to the
+# point here, reuses the pool_size connections instead of reopening them.
+#
+# On the sizing: connections above pool_size are closed when returned rather
+# than retained, so overflow churns exactly like NullPool does. pool_size must
+# therefore cover a process's real concurrency or the churn this exists to stop
+# simply continues at a lower rate. The daemon -- the only process with
+# meaningful concurrency, and the one that failed -- holds 13-21 connections
+# across all three storages, so 10 per storage covers it with headroom.
+#
+# pool_size is a retention ceiling, not a preallocation: QueuePool opens
+# connections lazily, so the 97 processes that share this ConfigMap (daemon, 2
+# webservers, 14 code locations, up to max_concurrent_runs workers) only hold
+# what they actually used. Run workers hold none when idle and live 7-9
+# seconds, which is why the worst-case product of 97 x 3 x 20 overstates the
+# real total by more than an order of magnitude -- measured peak across the
+# whole fleet is 122 active server connections against an aggregate budget of
+# 4248. Check that number against pgbouncer_pools_server_active_connections
+# after this ships rather than trusting the estimate.
 schedule_storage:
-  module: dagster_postgres.schedule_storage
-  class: PostgresScheduleStorage
+  module: ol_orchestrate.lib.postgres.schedule_storage
+  class: PooledPostgresScheduleStorage
   config:
+    pool_size: 10
+    max_overflow: 10
+    pool_recycle: 3600
+    pool_timeout: 30
     postgres_db:
       username:
         env: DAGSTER_PG_USER
@@ -88,10 +127,15 @@ run_launcher:
       # Sentry DSN has to reach them here as well.
     - dagster-sentry-secrets
 
+# Pooled for the reasons documented on schedule_storage above.
 run_storage:
-  module: dagster_postgres.run_storage
-  class: PostgresRunStorage
+  module: ol_orchestrate.lib.postgres.run_storage
+  class: PooledPostgresRunStorage
   config:
+    pool_size: 10
+    max_overflow: 10
+    pool_recycle: 3600
+    pool_timeout: 30
     postgres_db:
       username:
         env: DAGSTER_PG_USER
@@ -118,10 +162,21 @@ run_retries:
   enabled: true
   max_retries: 3
 
+# Pooled for the reasons documented on schedule_storage above. This is the
+# hottest of the three: store_event runs per event, and each asset check event
+# additionally reaches supports_asset_checks, an uncached @property on
+# SqlEventLogStorage whose has_table implementation opens a connection it never
+# closes (dagster_postgres/event_log/event_log.py:363) -- one extra connect per
+# call under NullPool. The auto_run_reexecution path emits one planned event per
+# asset, so retrying a large dbt job is a burst of exactly these.
 event_log_storage:
-  module: dagster_postgres.event_log
-  class: PostgresEventLogStorage
+  module: ol_orchestrate.lib.postgres.event_log
+  class: PooledPostgresEventLogStorage
   config:
+    pool_size: 10
+    max_overflow: 10
+    pool_recycle: 3600
+    pool_timeout: 30
     postgres_db:
       username:
         env: DAGSTER_PG_USER


### PR DESCRIPTION
### What are the relevant tickets?
N/A — found while investigating a live failure on `data-production`.

### Description (What does it do?)
The Dagster daemon has been failing runs with `psycopg2.OperationalError: connection to server at "dagster-pgbouncer.dagster.svc.cluster.local" (10.110.142.113), port 5432 failed: Cannot assign requested address`. That string is `EADDRNOTAVAIL` from `bind()` — the pod is out of ephemeral source ports, not talking to a dead server.

Measured on `dagster-daemon-5c8479cf54-n8w7v`:

| | |
|---|---|
| Sockets to `10.110.142.113:5432` in the pod netns | **28,232** (21,517 `TIME_WAIT`, 13 `ESTABLISHED`) |
| `net.ipv4.ip_local_port_range` | `32768 60999` → **28,232 ports** |
| `ActiveOpens` delta (`/proc/net/snmp`) | 13,560 in 41s = **331 connects/sec** |
| `Retrying failed database connection` warnings | **462 per 30 min** |

100% of the port space, consumed by one destination tuple. `TIME_WAIT` is a fixed 60s, so 331/s parks ~20k sockets at steady state and any burst crosses the range.

PgBouncer was healthy the entire time — 12 active clients, 11 active server connections, 0 waiting, 40 of a ~708 per-replica cap.

Two changes:

- **`dagster_instance.yaml`** — all three storages move to the pooled subclasses in `ol-data-platform` (`ol_orchestrate.lib.postgres`), which use `QueuePool` instead of the `NullPool` that stock `dagster_postgres` hardcodes. This is the actual fix: connections get reused instead of reopened per operation.
- **`__main__.py`** — widens the daemon's ephemeral port range to 55,296 via `dagsterDaemon.podSecurityContext.sysctls`. Defence in depth only; doubling the range doubles the rate that exhausts it.

On the pool numbers (`pool_size: 10`, `max_overflow: 10`): `QueuePool` closes connections above `pool_size` when they are returned rather than retaining them, so `pool_size` below a process's real concurrency leaves the churn in place at a lower rate. The daemon — the only process with meaningful concurrency, and the one that failed — holds 13–21 connections across all three storages. `pool_size` is a retention ceiling rather than a preallocation (`QueuePool` opens lazily), so the 97 processes sharing this ConfigMap only hold what they used; run workers hold none when idle and live 7–9 seconds.

This lands step 3 of the sequence in `docs/plans/dagster-connection-backpressure.md`, which called the pooled classes "already written, already installed in the running image, and not switched on".

### How can this be tested?

`pulumi preview -s Production` renders exactly two resource updates, and both changes appear:

```
+ podSecurityContext: {
    + sysctls: [ + name : "net.ipv4.ip_local_port_range" ...
~ class : "PostgresEventLogStorage" => "PooledPostgresEventLogStorage"
    + pool_size   : 10
~ class : "PostgresRunStorage" => "PooledPostgresRunStorage"
~ class : "PostgresScheduleStorage" => "PooledPostgresScheduleStorage"
~ checksum/ol-dagster-instance: "8e76be21..." => "9f6ac75a..."
```

Note the preview also shows image tags diffing to `latest` — that is an artifact of running it locally without the pipeline's tag, not part of this change.

After deploying, the ConfigMap checksum annotation rolls the daemon, which both applies the new storages and clears the exhausted port space. Confirm the fix held with:

```
kubectl -n dagster exec deploy/dagster-daemon -c dagster -- head -2 /proc/net/sockstat
kubectl -n dagster exec deploy/dagster-daemon -c dagster -- grep -c "718E6E0A:1538" /proc/net/tcp
```

`tw` should drop from ~23,000 to the low hundreds, and the socket count to a few dozen. `pgbouncer_pools_server_active_connections` should rise modestly off its current ~11 and stay far below the 4,248 aggregate budget — check it rather than trusting the sizing estimate above.

`net.ipv4.ip_local_port_range` has been a Kubernetes safe sysctl since 1.27 and the cluster runs 1.36, so it needs no kubelet allowlist and passes the baseline Pod Security Standard. Verify with `kubectl -n dagster exec deploy/dagster-daemon -c dagster -- head -1 /proc/sys/net/ipv4/ip_local_port_range`.

### Additional Context

- The classes this switches to now have test coverage: https://github.com/mitodl/ol-data-platform/pull/2572 — that PR also fixes an undeclared `dagster_postgres` dependency, an undisposed engine in `optimize_for_webserver`, and a `pool_timeout` schema default of 3600s. **This PR does not depend on it**: `dagster_instance.yaml` sets `pool_timeout` explicitly, and the deployed image already carries the classes.
- No alert can currently see this failure mode. Every rule in `src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/dagster_pgbouncer.py` measures the pool side, and a client that cannot allocate a source port never becomes a connection PgBouncer counts. Tracked separately.
- Two upstream amplifiers in `dagster==1.13.18`, both feeding the event log storage: `SqlEventLogStorage.supports_asset_checks` is an uncached `@property`, and the `has_table` it calls opens a connection it never closes (`dagster_postgres/event_log/event_log.py:363`). The `auto_run_reexecution` path emits one planned event per asset, so retrying a large dbt job is a burst of exactly these. Worth reporting upstream.
