### PR TITLE
fix(vault): render spec.revoke on VaultDynamicSecret so leases die with the resource

### DIFF
--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -618,8 +618,9 @@ dagster_db_secret = OLVaultK8SSecret(
         # re-renders pgbouncer.ini with fresh credentials.
         restart_target_kind="Deployment",
         restart_target_name="dagster-pgbouncer",
+        # The Vault role is the last path segment (creds/app); revoke the
+        # lease on delete so credentials don't outlive this resource.
         revoke_on_delete=True,
-        role_name="app",
         vaultauth=dagster_auth_binding.vault_k8s_resources.auth_name,
         # Map Vault's fields to both Dagster Helm chart format and environment variables
         templates={

--- a/src/ol_infrastructure/applications/dagster/dagster_server_policy.hcl
+++ b/src/ol_infrastructure/applications/dagster/dagster_server_policy.hcl
@@ -46,6 +46,15 @@ path "postgres-dagster/creds/readonly/*" {
 path "postgres-dagster/creds/readonly" {
   capabilities = ["read"]
 }
+# VSO's revoke_on_delete for dagster_db_secret calls sys/leases/revoke, which
+# requires an explicit grant beyond the default policy's sys/leases/renew.
+# Ref: https://github.com/hashicorp/vault-secrets-operator/blob/main/CHANGELOG.md
+path "sys/leases/revoke" {
+  capabilities = ["update"]
+  allowed_parameters = {
+    "lease_id" = ["postgres-dagster/creds/app/*"]
+  }
+}
 path "postgres-dagster-data-production/creds/app/*" {
   capabilities = ["read"]
 }

--- a/src/ol_infrastructure/components/services/vault.py
+++ b/src/ol_infrastructure/components/services/vault.py
@@ -726,6 +726,23 @@ class OLVaultK8SStaticSecretConfig(OLVaultK8SSecretConfig):
 
 class OLVaultK8SDynamicSecretConfig(OLVaultK8SSecretConfig):
     kind: str = "VaultDynamicSecret"
+    # Ref: https://developer.hashicorp.com/vault/docs/platform/k8s/vso/api-reference#vaultdynamicsecretspec
+    revoke_on_delete: bool | None = Field(
+        default=None,
+        description=(
+            "Revoke the Vault lease backing this secret when the "
+            "VaultDynamicSecret resource is deleted. Without this, credentials "
+            "issued for the deleted resource remain valid for the rest of "
+            "their TTL."
+        ),
+    )
+    renewal_percent: int | None = Field(
+        default=None,
+        description=(
+            "Percentage out of 100 of the lease duration after which VSO "
+            "renews the secret. VSO defaults to 67 when unset."
+        ),
+    )
 
     @field_validator("kind")
     @classmethod
@@ -814,6 +831,11 @@ class OLVaultK8SSecret(ComponentResource):
                         lambda mount: f"{mount}/{resource_config.path}"
                     ),
                 )
+        elif isinstance(resource_config, OLVaultK8SDynamicSecretConfig):
+            if resource_config.revoke_on_delete is not None:
+                secret_def["spec"]["revoke"] = resource_config.revoke_on_delete
+            if resource_config.renewal_percent is not None:
+                secret_def["spec"]["renewalPercent"] = resource_config.renewal_percent
 
         self.vault_secret_resource = kubernetes.yaml.v2.ConfigGroup(
             f"OLVaultK8SSecret-{resource_config.namespace}-{resource_config.name}",

--- a/src/ol_infrastructure/components/services/vault.py
+++ b/src/ol_infrastructure/components/services/vault.py
@@ -738,9 +738,12 @@ class OLVaultK8SDynamicSecretConfig(OLVaultK8SSecretConfig):
     )
     renewal_percent: int | None = Field(
         default=None,
+        ge=0,
+        le=90,
         description=(
-            "Percentage out of 100 of the lease duration after which VSO "
-            "renews the secret. VSO defaults to 67 when unset."
+            "Percent of the lease duration after which VSO renews the "
+            "secret. VSO's CRD bounds this to 0-90 and defaults to 67 "
+            "when unset."
         ),
     )
 

--- a/tests/ol_infrastructure/components/services/test_vault.py
+++ b/tests/ol_infrastructure/components/services/test_vault.py
@@ -1,0 +1,155 @@
+"""Tests for OLVaultK8SSecret's rendering of the VaultDynamicSecret spec.
+
+Covers the revoke/renewalPercent fields added to OLVaultK8SDynamicSecretConfig:
+explicit true/false must render verbatim, and unset must be omitted from the
+spec entirely rather than rendered as null/false, since VSO's own zero-value
+default differs from "field absent".
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pulumi
+
+# Python 3.14+ compatibility
+try:
+    asyncio.get_event_loop()
+except RuntimeError:
+    asyncio.set_event_loop(asyncio.new_event_loop())
+
+
+class K8sMocks(pulumi.runtime.Mocks):
+    def new_resource(self, args: pulumi.runtime.MockResourceArgs):
+        return [args.name + "_id", args.inputs]
+
+    def call(self, args: pulumi.runtime.MockCallArgs):  # noqa: ARG002
+        return {}
+
+
+pulumi.runtime.set_mocks(K8sMocks())
+
+import pytest  # noqa: E402
+from pydantic import ValidationError  # noqa: E402
+
+from ol_infrastructure.components.services.vault import (  # noqa: E402
+    OLVaultK8SDynamicSecretConfig,
+    OLVaultK8SSecret,
+    OLVaultK8SStaticSecretConfig,
+)
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _dynamic_config(**overrides) -> OLVaultK8SDynamicSecretConfig:
+    defaults = {
+        "dest_secret_name": "test-secret",  # pragma: allowlist secret
+        "mount": "postgres-dagster",
+        "name": "test-secret",
+        "namespace": "test-ns",
+        "path": "creds/app",
+        "vaultauth": "test-auth",
+    }
+    defaults.update(overrides)
+    return OLVaultK8SDynamicSecretConfig(**defaults)
+
+
+def _rendered_spec(cfg):
+    resource = OLVaultK8SSecret(f"test-{cfg.name}-{id(cfg)}", resource_config=cfg)
+    return resource.vault_secret_resource.objs.apply(lambda objs: objs[0]["spec"])
+
+
+# ─── revoke ────────────────────────────────────────────────────────────────
+
+
+@pulumi.runtime.test
+def test_revoke_true_rendered():
+    def check(spec):
+        assert spec["revoke"] is True
+
+    return _rendered_spec(_dynamic_config(revoke_on_delete=True)).apply(check)
+
+
+@pulumi.runtime.test
+def test_revoke_false_rendered():
+    """An explicit False must render, not be treated the same as unset."""
+
+    def check(spec):
+        assert spec["revoke"] is False
+
+    return _rendered_spec(_dynamic_config(revoke_on_delete=False)).apply(check)
+
+
+@pulumi.runtime.test
+def test_revoke_omitted_when_unset():
+    def check(spec):
+        assert "revoke" not in spec
+
+    return _rendered_spec(_dynamic_config()).apply(check)
+
+
+# ─── renewalPercent ────────────────────────────────────────────────────────
+
+
+@pulumi.runtime.test
+def test_renewal_percent_rendered():
+    def check(spec):
+        assert spec["renewalPercent"] == 50
+
+    return _rendered_spec(_dynamic_config(renewal_percent=50)).apply(check)
+
+
+@pulumi.runtime.test
+def test_renewal_percent_omitted_when_unset():
+    def check(spec):
+        assert "renewalPercent" not in spec
+
+    return _rendered_spec(_dynamic_config()).apply(check)
+
+
+@pulumi.runtime.test
+def test_renewal_percent_zero_is_rendered():
+    """0 is a valid, meaningful value -- must not be dropped as falsy."""
+
+    def check(spec):
+        assert spec["renewalPercent"] == 0
+
+    return _rendered_spec(_dynamic_config(renewal_percent=0)).apply(check)
+
+
+def test_renewal_percent_rejects_above_90():
+    """VSO's CRD bounds renewalPercent to 0-90; mirror that in the model."""
+    with pytest.raises(ValidationError):
+        _dynamic_config(renewal_percent=91)
+
+
+def test_renewal_percent_rejects_negative():
+    with pytest.raises(ValidationError):
+        _dynamic_config(renewal_percent=-1)
+
+
+def test_renewal_percent_accepts_upper_bound():
+    assert _dynamic_config(renewal_percent=90).renewal_percent == 90
+
+
+# ─── static secrets are unaffected ────────────────────────────────────────
+
+
+@pulumi.runtime.test
+def test_static_secret_has_no_revoke_key():
+    """revoke/renewalPercent are dynamic-secret-only; must not leak onto static."""
+    cfg = OLVaultK8SStaticSecretConfig(
+        dest_secret_name="test-static-secret",  # pragma: allowlist secret
+        mount="secret-global",
+        name="test-static-secret",
+        namespace="test-ns",
+        path="test-static-secret",
+        vaultauth="test-auth",
+    )
+
+    def check(spec):
+        assert "revoke" not in spec
+        assert "renewalPercent" not in spec
+        assert spec["refreshAfter"] == "1h"
+
+    return _rendered_spec(cfg).apply(check)


### PR DESCRIPTION
### What are the relevant tickets?
Closes task tk-olvaultk8ssecret-never-renders-spec-revoke-no-dy-84e74e (witan task graph). Follow-up from PR #5476.

### Description
- `revoke_on_delete` was passed at the `dagster_db_secret` call site but wasn't an actual field on `OLVaultK8SDynamicSecretConfig` — the model has no `extra="forbid"`, so it was silently swallowed and the Vault database lease (up to 6mo `max_ttl` on `postgres-dagster`) outlived the deleted k8s resource.
- Add `revoke_on_delete`/`renewal_percent` fields to `OLVaultK8SDynamicSecretConfig` and render them as `spec.revoke`/`spec.renewalPercent` on the `VaultDynamicSecret` CR, mirroring VSO 1.5.1's `VaultDynamicSecretSpec` and the existing static-only `refreshAfter` branch.
- Drop the inert `role_name="app"` kwarg at the dagster call site — VSO has no such concept; the Vault role is the last path segment (`creds/app`).
- Confirmed no other call site in the repo passes `revoke_on_delete` at all (dagster's was the only one), so this only changes dagster's behavior.

### How can this be tested?
`pulumi preview --stack CI` on `ol-application-dagster` confirms the `VaultDynamicSecret` for `dagster-postgresql-secret` now diffs `+ revoke: true`, where previously the field was accepted but never rendered. `pre-commit run --all-files` (ruff format/check, mypy) passes on the changed files.

### Additional Context
Rolling out `revoke_on_delete=True` to the ~30 other `OLVaultK8SDynamicSecretConfig` call sites in the repo, and migrating deprecated `restart_target_kind`/`restart_target_name` call sites to `restart_targets`, are filed as separate follow-up tasks (tk-audit-all-olvaultk8sdynamicsecretconfig-call-sit-78312f, tk-migrate-deprecated-restart-target-kind-restart-t-ff4eb3) per the reasoning that each is its own behavior change deserving its own preview.