### PR TITLE
feat(witan): give witan its own Sentry project, and split its OTel telemetry out of toolhive_telemetry.py

### DIFF
--- a/src/ol_infrastructure/applications/witan/__main__.py
+++ b/src/ol_infrastructure/applications/witan/__main__.py
@@ -161,6 +161,12 @@ witan_config = Config("witan")
 cluster_stack = make_stack_reference(projects.EKS, f"operations.{stack_info.name}")
 setup_k8s_provider(kubeconfig=cluster_stack.require_output("kube_config"))
 
+# One Sentry project (`project_witan`) covers CI/QA/Production, distinguished
+# by the SDK's `environment` tag rather than by separate projects — same
+# convention as dagster's `project_dagster`. See
+# infrastructure/sentry/__main__.py and its IMPORT_SUMMARY.md.
+sentry_stack = make_stack_reference(projects.SENTRY, "default")
+
 # No reference to the ToolHive operator stack any more: witan runs as an
 # ordinary Deployment, so none of that operator's CRDs need to exist for this
 # stack to apply. The operator itself stays deployed for `toolhive_swe`, which
@@ -462,6 +468,15 @@ ACTOR_TOKENS_SECRET_KEY = "tokens.json"  # noqa: S105  # pragma: allowlist secre
 WITAN_CI_TOKEN_VAULT_KEY = "token"  # noqa: S105  # pragma: allowlist secret
 ACTOR_TOKENS_VAULT_KEY = "tokens_json"  # pragma: allowlist secret
 
+# The Sentry DSN, owned by the ol-infrastructure-sentry stack rather than this
+# one. Same shape as dagster's dagster-sentry-secrets: a stack-owned value
+# written to Vault by *this* stack (the sentry stack only exports it as a
+# stack output, it never writes Vault itself), then synced into a k8s Secret
+# the Deployment reads via secret_key_ref.
+WITAN_SENTRY_DSN_SECRET_NAME = "witan-sentry-secrets"  # noqa: S105  # pragma: allowlist secret
+WITAN_SENTRY_DSN_SECRET_KEY = "SENTRY_DSN"  # noqa: S105  # pragma: allowlist secret
+WITAN_SENTRY_DSN_VAULT_KEY = "dsn"  # pragma: allowlist secret
+
 # The break-glass maintenance principal (agent-kit ADR-0005 path b / ADR-0002 D4
 # as amended). Written to Vault by the omnigraph stack alongside the CI token;
 # read here because the two things that use it — the pre-deploy migration Job and
@@ -590,6 +605,47 @@ witan_code_token_secret = OLVaultK8SSecret(
     opts=ResourceOptions(
         delete_before_replace=True,
         depends_on=witan_auth_binding.vault_k8s_resources,
+    ),
+)
+
+# The DSN is created by the ol-infrastructure-sentry stack, which owns the
+# Sentry project and its client key, so Pulumi manages the value end to end
+# and nobody has to hand-write it into Vault. Mirrors dagster's
+# dagster_sentry_vault_secret/dagster_sentry_secrets pair.
+witan_sentry_vault_secret = vault.generic.Secret(
+    f"witan-sentry-dsn-{stack_info.env_suffix}",
+    path="secret-operations/witan/sentry",
+    data_json=sentry_stack.require_output("witan_sentry_dsn").apply(
+        lambda dsn: json.dumps({WITAN_SENTRY_DSN_VAULT_KEY: dsn})
+    ),
+    opts=ResourceOptions(delete_before_replace=True),
+)
+
+witan_sentry_secret = OLVaultK8SSecret(
+    f"witan-sentry-secret-{stack_info.env_suffix}",
+    resource_config=OLVaultK8SStaticSecretConfig(
+        name=WITAN_SENTRY_DSN_SECRET_NAME,
+        namespace=NAMESPACE,
+        labels=k8s_global_labels,
+        dest_secret_labels=k8s_global_labels,
+        dest_secret_name=WITAN_SENTRY_DSN_SECRET_NAME,
+        dest_secret_type="Opaque",  # pragma: allowlist secret  # noqa: S106
+        mount="secret-operations",
+        mount_type="kv-v1",
+        path="witan/sentry",
+        exclude_raw=True,
+        excludes=[".*"],
+        templates={
+            WITAN_SENTRY_DSN_SECRET_KEY: (
+                f'{{{{ get .Secrets "{WITAN_SENTRY_DSN_VAULT_KEY}" }}}}'
+            )
+        },
+        refresh_after="1h",
+        vaultauth=witan_auth_binding.vault_k8s_resources.auth_name,
+    ),
+    opts=ResourceOptions(
+        delete_before_replace=True,
+        depends_on=[witan_auth_binding.vault_k8s_resources, witan_sentry_vault_secret],
     ),
 )
 
@@ -816,6 +872,9 @@ witan_serving_tier = create_serving_tier(
     witan_code_token_secret_name=WITAN_CODE_TOKEN_SECRET_NAME,
     witan_code_token_secret_key=WITAN_CODE_TOKEN_SECRET_KEY,
     witan_code_token_secret=witan_code_token_secret,
+    sentry_dsn_secret_name=WITAN_SENTRY_DSN_SECRET_NAME,
+    sentry_dsn_secret_key=WITAN_SENTRY_DSN_SECRET_KEY,
+    sentry_dsn_secret=witan_sentry_secret,
     migration_job=witan_migration_job,
     service_version=witan_service_version,
     remote_write_max_inflight=WITAN_REMOTE_WRITE_MAX_INFLIGHT,

--- a/src/ol_infrastructure/applications/witan/deployment.py
+++ b/src/ol_infrastructure/applications/witan/deployment.py
@@ -78,6 +78,7 @@ from pulumi import Output, Resource, ResourceOptions
 from ol_infrastructure.applications.witan.observability import (
     downward_api_env_args,
     otel_env,
+    sentry_env,
     witan_log_env,
 )
 from ol_infrastructure.lib.pulumi_helper import StackInfo
@@ -428,6 +429,9 @@ def create_serving_tier(  # noqa: PLR0913
     witan_code_token_secret_name: str,
     witan_code_token_secret_key: str,
     witan_code_token_secret: Resource,
+    sentry_dsn_secret_name: str,
+    sentry_dsn_secret_key: str,
+    sentry_dsn_secret: Resource,
     migration_job: Resource,
     service_version: str,
     remote_write_max_inflight: str = "",
@@ -636,6 +640,20 @@ def create_serving_tier(  # noqa: PLR0913
                                         )
                                     ),
                                 ),
+                                # The DSN is Vault-synced rather than a literal
+                                # like the rest of `otel_env` below: it is
+                                # owned by the ol-infrastructure-sentry stack,
+                                # not this one, so it travels through Vault the
+                                # same way dagster's does.
+                                kubernetes.core.v1.EnvVarArgs(
+                                    name="SENTRY_DSN",
+                                    value_from=kubernetes.core.v1.EnvVarSourceArgs(
+                                        secret_key_ref=kubernetes.core.v1.SecretKeySelectorArgs(
+                                            name=sentry_dsn_secret_name,
+                                            key=sentry_dsn_secret_key,
+                                        )
+                                    ),
+                                ),
                                 # Client-side write admission, per graph, inside
                                 # this pod. Only emitted when the stack sets a
                                 # value: witan's own defaults are the measured
@@ -678,9 +696,13 @@ def create_serving_tier(  # noqa: PLR0913
                                 ),
                                 # Structured logging + OTel, from the shared
                                 # helper so this workload and the CI indexer
-                                # cannot drift into describing themselves as two
-                                # different services. `otel_env` is empty in CI,
-                                # which has no collector.
+                                # cannot drift into describing themselves as
+                                # two different services. `otel_env` is empty
+                                # in CI, which has no collector. `sentry_env`
+                                # is this workload's own addition, not shared
+                                # with the CI indexer -- it carries no
+                                # CI-empty case since one Sentry project covers
+                                # every environment.
                                 *(
                                     kubernetes.core.v1.EnvVarArgs(
                                         name=name, value=value
@@ -688,6 +710,7 @@ def create_serving_tier(  # noqa: PLR0913
                                     for name, value in (
                                         witan_log_env()
                                         | otel_env(stack_info, "witan", service_version)
+                                        | sentry_env(stack_info, service_version)
                                     ).items()
                                 ),
                             ],
@@ -806,6 +829,7 @@ def create_serving_tier(  # noqa: PLR0913
                 witan_service_account,
                 witan_ci_token_secret,
                 witan_code_token_secret,
+                sentry_dsn_secret,
                 actor_tokens_secret,
                 migration_job,
             ]

--- a/src/ol_infrastructure/applications/witan/observability.py
+++ b/src/ol_infrastructure/applications/witan/observability.py
@@ -52,11 +52,11 @@ rather than looking for a ToolHive histogram that no longer exists.
 
 import pulumi_kubernetes as kubernetes
 
-from ol_infrastructure.lib.pulumi_helper import StackInfo
-from ol_infrastructure.lib.toolhive_telemetry import (
+from ol_infrastructure.lib.otel import (
     OTLP_ENDPOINT,
     ships_telemetry,
 )
+from ol_infrastructure.lib.pulumi_helper import StackInfo
 
 # Sample everything here; Alloy's `tailSampling` does the filtering (keep
 # errors, keep >5000ms, 15% of the rest — substructure/aws/eks/grafana.py).

--- a/src/ol_infrastructure/applications/witan/observability.py
+++ b/src/ol_infrastructure/applications/witan/observability.py
@@ -1,4 +1,4 @@
-"""OpenTelemetry + structured-logging environment for the witan workloads.
+"""OpenTelemetry + structured-logging + Sentry environment for the witan workloads.
 
 agent-kit ``witan_core.observability`` (PR #193) installs structlog plus OTel
 tracer and meter providers, but it deliberately installs **no provider at all**
@@ -145,6 +145,28 @@ def otel_env(
         "OTEL_TRACES_SAMPLER_ARG": TRACES_SAMPLER_ARG,
         "OTEL_PROPAGATORS": PROPAGATORS,
         "OTEL_METRIC_EXPORT_INTERVAL": METRIC_EXPORT_INTERVAL_MS,
+    }
+
+
+def sentry_env(stack_info: StackInfo, service_version: str) -> dict[str, str]:
+    """Build the standard ``SENTRY_*`` variables the SDK reads on init.
+
+    Unlike ``otel_env`` this is never empty: witan has one Sentry project
+    covering CI/QA/Production (``ol-infrastructure-sentry``'s ``project_witan``),
+    distinguished by ``SENTRY_ENVIRONMENT`` rather than by a per-environment
+    project, so there is no CI-dark case to return early on the way
+    ``ships_telemetry`` does for Alloy. ``SENTRY_DSN`` itself is set
+    separately, from the Vault-synced secret — see ``deployment.py``'s
+    ``sentry_dsn_secret_name``/``key`` — because it is owned by the sentry
+    stack rather than a literal this stack can construct.
+
+    :param service_version: the image tag or digest this workload runs, same
+        value passed to ``otel_env`` — ties each Sentry issue to the image it
+        came from.
+    """
+    return {
+        "SENTRY_ENVIRONMENT": stack_info.env_suffix,
+        "SENTRY_RELEASE": service_version,
     }
 
 

--- a/src/ol_infrastructure/applications/witan/witan_policy.hcl
+++ b/src/ol_infrastructure/applications/witan/witan_policy.hcl
@@ -58,6 +58,15 @@ path "secret-operations/witan/github-app" {
   capabilities = ["read"]
 }
 
+# Sentry DSN for this workload, owned by the ol-infrastructure-sentry stack
+# and written here by this stack (witan_sentry_vault_secret in __main__.py) —
+# the sentry stack only exports the DSN as a stack output, it never writes
+# Vault itself. Synced into the witan-sentry-secrets k8s Secret and read as
+# SENTRY_DSN by the Deployment (deployment.py).
+path "secret-operations/witan/sentry" {
+  capabilities = ["read"]
+}
+
 path "sys/leases/renew" {
   capabilities = ["update"]
 }

--- a/src/ol_infrastructure/infrastructure/sentry/IMPORT_SUMMARY.md
+++ b/src/ol_infrastructure/infrastructure/sentry/IMPORT_SUMMARY.md
@@ -121,3 +121,14 @@ configuration, then `pulumi import --file sentry_imports.json` followed by
   `bin/import-sentry-config` run will regenerate `name`/`slug` back to
   whatever the live project is named at that point -- expect it to match
   `mit-learn` unless it's renamed again live.
+- `project_witan` / `key_witan`: added by hand, same reason as
+  `project_ol_analytics_api`/`project_dagster` -- the witan Sentry project
+  does not exist live yet, so `pulumi up` creates both. One project covers
+  CI/QA/Production, distinguished by the SDK's `environment` tag rather than
+  by separate projects. The hand-added export is `witan_sentry_dsn`, consumed
+  by the witan application stack, which writes it to Vault at
+  `secret-operations/witan/sentry`. The same naming-convergence caveat as
+  `project_ol_analytics_api` applies: if this project is later created live
+  and `bin/import-sentry-config` is re-run, diff the regenerated
+  `key_witan_default_*` block against this one before accepting it -- a
+  `pulumi state rename` may be needed to converge onto the live key's id.

--- a/src/ol_infrastructure/infrastructure/sentry/__main__.py
+++ b/src/ol_infrastructure/infrastructure/sentry/__main__.py
@@ -4952,6 +4952,41 @@ key_dagster = sentry.SentryKey(
 
 pulumi.export("dagster_sentry_dsn", key_dagster.dsn_public)
 
+# Hand-authored addition, same rationale as project_ol_analytics_api above --
+# see IMPORT_SUMMARY.md.
+#
+# One project covers CI/QA/Production, distinguished by the SDK's
+# `environment` tag rather than by separate projects -- same convention as
+# project_dagster.
+project_witan = sentry.SentryProject(
+    "project_witan",
+    organization=ORGANIZATION,
+    name="witan",
+    slug="witan",
+    platform="python-fastapi",
+    # devops owns witan (an internal ops/platform tool, not a product-facing
+    # app); mit-office-of-digital-learning gets the same blanket access it
+    # holds on the other infrastructure projects.
+    teams=[
+        "devops",
+        "mit-office-of-digital-learning",
+    ],
+    digests_min_delay=300,
+    digests_max_delay=1800,
+    resolve_age=0,
+    opts=sentry_opts,
+)
+
+key_witan = sentry.SentryKey(
+    "key_witan",  # pragma: allowlist secret
+    organization=ORGANIZATION,
+    project=project_witan.slug,
+    name="Default",
+    opts=sentry_opts,
+)
+
+pulumi.export("witan_sentry_dsn", key_witan.dsn_public)
+
 # Hand-added stack outputs (not produced by bin/import-sentry-config) exposing
 # each project's DSN so consuming stacks can read it via
 # sentry_stack.require_output(...) instead of a hard-coded/SOPS/Vault secret.

--- a/src/ol_infrastructure/lib/otel.py
+++ b/src/ol_infrastructure/lib/otel.py
@@ -1,0 +1,40 @@
+"""Shared OTLP endpoint + shipping decision for every stack that exports OTel.
+
+── Why CI gets logs but no traces or metrics ──
+``setup_grafana`` (``substructure/aws/eks/grafana.py``) returns early for CI, so
+operations-ci runs no Grafana Alloy: its ``grafana`` namespace exists and is
+empty, and ``grafana-k8s-monitoring-alloy-receiver`` resolves in QA and
+Production only. ``ships_telemetry`` mirrors that condition, so CI lands on the
+no-exporter path by construction instead of buying a connection failure per
+batch forever in the one environment nobody is watching.
+"""
+
+from ol_infrastructure.lib.pulumi_helper import StackInfo
+
+# The in-cluster OTLP/HTTP receiver, shared with mit_learn, learn_ai and edxapp
+# (see their Pulumi.{QA,Production}.yaml and edxapp/k8s_configmaps.py). Port
+# 4318 is http/protobuf; 4317 on the same Service is gRPC, which we do not use.
+OTLP_ENDPOINT = (
+    "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318"
+)
+
+# Matched to the mit_learn/learn_ai precedent rather than chosen fresh, so a
+# trace crossing from one of those services is sampled consistently instead of
+# being decided twice.
+DEFAULT_TRACE_SAMPLING_RATE = "0.25"
+
+
+def ships_telemetry(stack_info: StackInfo) -> bool:
+    """Whether this environment has an OTLP receiver to export to.
+
+    Mirrors ``setup_grafana``'s CI early-return. Kept as a named predicate so
+    the reason a stack is dark is one grep away from the reason the collector
+    is absent.
+
+    The ``.lower()`` is redundant and deliberate: ``parse_stack`` builds
+    ``env_suffix`` as ``stack_name.lower()``, so it is lowercase by
+    construction. It is kept only so this predicate is character-for-character
+    the condition ``setup_grafana`` tests — the two drifting apart is the
+    failure this function exists to prevent.
+    """
+    return stack_info.env_suffix.lower() != "ci"

--- a/src/ol_infrastructure/lib/toolhive_telemetry.py
+++ b/src/ol_infrastructure/lib/toolhive_telemetry.py
@@ -1,4 +1,4 @@
-"""Shared ToolHive telemetry + audit configuration for every MCP stack.
+"""ToolHive-specific telemetry + audit configuration for the ToolHive CRDs.
 
 A ToolHive deployment is at least two hops of Go binary in front of whatever
 actually serves the tools: a ``VirtualMCPServer`` aggregator and, per backend,
@@ -6,59 +6,30 @@ an ``MCPServer`` proxyrunner. Both run their own OTel pipeline, configured
 through an ``MCPTelemetryConfig`` CR rather than through the ``OTEL_*``
 environment a Python or Go workload would read. Neither is on by default.
 
-This module builds those specs. It lives in ``lib`` rather than under one
-application because the witan and toolhive_swe stacks both need it and the
-security-relevant decisions below — which hop may expose ``/metrics``, what an
-audit event is allowed to carry — must not be re-derived per stack.
+This module builds those specs. It lives in ``lib`` rather than under
+``toolhive_swe`` because a second ToolHive-fronted stack could exist someday
+and the security-relevant decisions below — which hop may expose
+``/metrics``, what an audit event is allowed to carry — must not be
+re-derived per stack. The endpoint and shipping predicate every OTel-exporting
+stack needs, ToolHive-fronted or not, live in ``lib/otel.py`` instead — witan
+sits directly behind APISIX with no ToolHive tier (removed 2026-08-15) and
+imports from there, not from here.
 
-── Why CI gets logs but no traces or metrics ──
-``setup_grafana`` (``substructure/aws/eks/grafana.py``) returns early for CI, so
-operations-ci runs no Grafana Alloy: its ``grafana`` namespace exists and is
-empty, and ``grafana-k8s-monitoring-alloy-receiver`` resolves in QA and
-Production only. ``ships_telemetry`` mirrors that condition, so CI lands on the
-no-exporter path by construction instead of buying a connection failure per
-batch forever in the one environment nobody is watching.
-
-Audit logging and the Prometheus ``/metrics`` path are NOT gated that way — see
-their own notes below. Both work in CI.
+Audit logging and the Prometheus ``/metrics`` path are NOT gated by
+``ships_telemetry`` — see their own notes below. Both work in CI.
 """
 
-from ol_infrastructure.lib.pulumi_helper import StackInfo
-
-# The in-cluster OTLP/HTTP receiver, shared with mit_learn, learn_ai and edxapp
-# (see their Pulumi.{QA,Production}.yaml and edxapp/k8s_configmaps.py). Port
-# 4318 is http/protobuf; 4317 on the same Service is gRPC, which we do not use.
-# ToolHive's exporter is `otlptracehttp`/`otlpmetrichttp` (toolhive-core
-# `telemetry/providers/otlp`), so 4318 is the correct one for it too.
-OTLP_ENDPOINT = (
-    "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318"
+from ol_infrastructure.lib.otel import (
+    DEFAULT_TRACE_SAMPLING_RATE,
+    OTLP_ENDPOINT,
+    ships_telemetry,
 )
-
-# Matched to the mit_learn/learn_ai precedent rather than chosen fresh, so a
-# trace crossing from one of those services is sampled consistently instead of
-# being decided twice.
-DEFAULT_TRACE_SAMPLING_RATE = "0.25"
+from ol_infrastructure.lib.pulumi_helper import StackInfo
 
 # QA samples everything: it is where the concurrency probe runs, and a
 # sampled-away trace is a probe run that measured nothing. Affordable precisely
 # because QA carries no organic traffic.
 _FULL_SAMPLE_ENVS = frozenset({"qa"})
-
-
-def ships_telemetry(stack_info: StackInfo) -> bool:
-    """Whether this environment has an OTLP receiver to export to.
-
-    Mirrors ``setup_grafana``'s CI early-return. Kept as a named predicate so
-    the reason a stack is dark is one grep away from the reason the collector
-    is absent.
-
-    The ``.lower()`` is redundant and deliberate: ``parse_stack`` builds
-    ``env_suffix`` as ``stack_name.lower()``, so it is lowercase by
-    construction. It is kept only so this predicate is character-for-character
-    the condition ``setup_grafana`` tests — the two drifting apart is the
-    failure this function exists to prevent.
-    """
-    return stack_info.env_suffix.lower() != "ci"
 
 
 def telemetry_config_name(service: str, hop: str) -> str:
@@ -121,7 +92,8 @@ def toolhive_telemetry_spec(
     that configures nothing — a referenced-but-inert config is the kind of thing
     that reads as "telemetry is on" to the next person to look.
 
-    :param service: the stack, e.g. ``"witan"``. Becomes ``service.namespace``.
+    :param service: the stack, e.g. ``"toolhive-swe"``. Becomes
+        ``service.namespace``.
     :param component: the hop, e.g. ``"vmcp"`` or a backend's name. Recorded as
         ``toolhive.component``; the per-ref ``serviceName`` carries it too.
     :param expose_prometheus: whether to serve the Prometheus ``/metrics`` path.
@@ -130,11 +102,11 @@ def toolhive_telemetry_spec(
         RUN. ToolHive serves ``/metrics`` on the *main transport port* — there
         is no separate admin listener (toolhive `pkg/telemetry/config.go`: "The
         metrics are served on the main transport port at /metrics"). A vMCP's
-        4483 is the port APISIX publishes, and both witan's and toolhive_swe's
-        ``ingress.py`` route ``paths=["/*"]`` at it, so enabling the path there
-        would put an unauthenticated ``https://<vmcp-host>/metrics`` on the
-        public internet listing every tool name and its call counts. A backend
-        proxy's 8080 is ClusterIP-only and never routed, so it is safe there.
+        4483 is the port APISIX publishes, and toolhive_swe's ``ingress.py``
+        routes ``paths=["/*"]`` at it, so enabling the path there would put an
+        unauthenticated ``https://<vmcp-host>/metrics`` on the public internet
+        listing every tool name and its call counts. A backend proxy's 8080 is
+        ClusterIP-only and never routed, so it is safe there.
 
         Revisit only alongside a path-level deny in the APISIX route — not by
         flipping this flag.
@@ -221,19 +193,15 @@ def toolhive_mcpserver_audit() -> dict[str, object]:
     Capture requires a TOP-LEVEL JSON-RPC ``error``; ``pkg/mcp/response.go``
     "intentionally omit[s] `result`". Whether a tool failure lands in one or the
     other is decided by the BACKEND'S MCP SDK, not by ToolHive — so it has to be
-    established per backend, not once. All six we run, verified 2026-08-14:
+    established per backend, not once. All five we run, verified 2026-08-14:
 
-    * **FastMCP 4.0.0b2** (witan) — every tool-level failure becomes an
-      ``isError`` result. Confirmed against a live server: an exception echoing
-      the caller's payload, a pydantic error carrying ``input_value=``, and an
-      unknown tool ALL stayed in ``result``; only ``no/such/method`` produced a
-      top-level error, message ``"Method not found"``. Nothing content-bearing
-      is captured.
-    * **FastMCP** (toolhive_swe ``aws``) — mcp-proxy-for-aws 1.6.4 is FastMCP
-      too, and its ``ToolErrorMiddleware.on_call_tool`` catches EVERY exception
-      and re-raises ``ToolError``, which is the same path. This matters more
-      than the others because the managed AWS endpoint behind it exposes a
-      ``run_script`` tool, so its requests carry user-authored scripts.
+    * **FastMCP** (toolhive_swe ``aws``) — mcp-proxy-for-aws 1.6.4 is FastMCP,
+      and its ``ToolErrorMiddleware.on_call_tool`` catches EVERY exception and
+      re-raises ``ToolError``: every tool-level failure becomes an ``isError``
+      result rather than a top-level JSON-RPC error, so nothing content-bearing
+      is captured. This matters more than the others because the managed AWS
+      endpoint behind it exposes a ``run_script`` tool, so its requests carry
+      user-authored scripts.
     * **modelcontextprotocol/go-sdk** (``fetch``) — same outcome by a different
       route: ``mcp/server.go`` returns a structured ``*jsonrpc.Error`` directly
       but wraps a *plain* error in ``CallToolResult{IsError: true}``, and


### PR DESCRIPTION
### What are the relevant tickets?
Closes task tk-lib-toolhive-telemetry-py-outlives-toolhive-wita-357564 (witan task graph). Split out of #5487 per that PR's description.

### Description (What does it do?)
Two related pieces of witan observability cleanup:

**1. Module rename.** ToolHive was removed from witan's request path in #5448 (witan now sits directly behind APISIX), but `src/ol_infrastructure/applications/witan/observability.py` still imported its OTLP endpoint and shipping predicate from a module named `lib/toolhive_telemetry.py` — misleading anyone tracing witan's telemetry wiring into thinking ToolHive was still involved, or that the module was dead code.

- Added `src/ol_infrastructure/lib/otel.py` holding the parts that were never ToolHive-specific: `OTLP_ENDPOINT`, `DEFAULT_TRACE_SAMPLING_RATE`, and the `ships_telemetry` predicate.
- `witan/observability.py` now imports those from `lib/otel.py`.
- `lib/toolhive_telemetry.py` keeps only the genuinely ToolHive-specific pieces (`telemetry_config_name`, `toolhive_service_name`, `toolhive_trace_sampling_rate`, `toolhive_telemetry_spec`, `toolhive_mcpserver_audit`, `toolhive_vmcp_audit`) — still legitimately used by `toolhive_swe`, which remains ToolHive-fronted — and now imports the shared constants/predicate from `lib/otel.py`.
- Corrected two stale ToolHive-era references left inside `toolhive_telemetry.py`: the vMCP `/metrics` routing note used to say "both witan's and toolhive_swe's `ingress.py`" (witan has no vMCP any more); and `toolhive_mcpserver_audit`'s per-backend audit-capture survey still listed witan's FastMCP server as one of "the six backends we run" behind ToolHive's `MCPServer` audit config, even though witan hasn't been a ToolHive backend since #5448. Removed the witan bullet and corrected the count to five.

**2. New Sentry project for witan.** Adds `project_witan`/`key_witan` to the `ol-infrastructure-sentry` stack — one project covering CI/QA/Production, distinguished by the SDK's `environment` tag rather than by separate projects, same convention as `project_dagster` — and exports `witan_sentry_dsn`.

witan's own stack reads that output, writes it to Vault at `secret-operations/witan/sentry` (mirroring dagster's `dagster_sentry_vault_secret`), syncs it into a `witan-sentry-secrets` k8s Secret, and threads it into the Deployment as `SENTRY_DSN` via `secret_key_ref`. A new `sentry_env()` helper in `observability.py` supplies the literal `SENTRY_ENVIRONMENT`/`SENTRY_RELEASE` variables alongside it — unlike `otel_env`, it has no CI-empty case, since one Sentry project covers every environment.

### How can this be tested?
- `ruff format --check`, `ruff check`, `mypy`, and `pre-commit run` all pass on every changed file.
- `pulumi preview` on the `ol-infrastructure-sentry` stack: clean, 2 resources to create (`project_witan`, `key_witan`), no drift on the other 345.
- `pulumi preview --stack CI` on witan: fails on `require_output("witan_sentry_dsn")` until the sentry stack above is actually applied — expected, since the export doesn't exist until `pulumi up` creates the project. **Deployment order: the `ol-infrastructure-sentry` stack must be applied before witan's own stack picks up this change.**
- Confirmed via `git grep` that no other module imports the removed names from `lib/toolhive_telemetry.py`.

### Additional Context
The module rename was deliberately kept separate from #5487 (the sampler fix) per that PR's own rationale — a sampler behavior change and a module rename/split are different sizes of change and easier to review/revert independently. This branch rebases cleanly on top of #5487, which already merged and dropped the `DEFAULT_TRACE_SAMPLING_RATE` import from witan in favor of a literal `TRACES_SAMPLER_ARG = "1.0"`.

The Sentry project creation itself was **not** applied from this session — creating a new project in the live Sentry org is an external, hard-to-reverse action, so it's left for the normal deploy pipeline/reviewer to apply alongside merging this PR, in the same two-stack order noted above (sentry stack, then witan).