### PR TITLE
fix(rootly,alerting): route MIT Learn API and NextJS alerts to their own services

### DIFF
--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/synthetic_monitoring.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/synthetic_monitoring.py
@@ -273,7 +273,13 @@ def _rules(
     check: _Check, rd: Callable[[str], list[alerting.RuleGroupRuleDataArgs]]
 ) -> list[alerting.RuleGroupRuleArgs]:
     """Build the fast (cliff) and slow (creep) rules for one check."""
-    base_labels = {"component": check.component, "service": "mitlearn"}
+    # `ol_component`, not a bare `component`: this key is what Rootly's Grafana
+    # Production Service Route matches on to reach the per-component services,
+    # and `component` is generic enough that a vendor integration or a future
+    # rule elsewhere could set it and be routed to a MIT Learn service by
+    # accident. Not in alertmanager.py's `group_bies`, so the rename does not
+    # regroup any notification.
+    base_labels = {"ol_component": check.component, "service": "mitlearn"}
     # The slow rules deliberately carry no `severity` -- see "The slow rules
     # ship unrouted" in the module docstring.
     fast_labels = base_labels | {"severity": check.severity}

--- a/src/ol_infrastructure/saas/rootly/__main__.py
+++ b/src/ol_infrastructure/saas/rootly/__main__.py
@@ -2980,6 +2980,14 @@ alerts_source_cloudwatch_warning = rootly.AlertsSource(
     opts=rootly_alert_source_opts,
 )
 
+# Inert. Fed only by the three MIT Learn synthetic monitoring rules, via a
+# `notification_settings.receiver="Rootly"` override pointing at a UI-created
+# contact point (eel3rjpiwahoge) that bypassed the policy tree. PR #5400 removed
+# that override, so nothing has delivered here since; its "Grafana Service Route"
+# is being retired below. Kept rather than destroyed -- deleting the source
+# discards its webhook secret, and the field-mapping attributes below are the
+# only worked example of a grafana-type source in this file. Do not point
+# anything at it without giving it a route again.
 alerts_source_grafana = rootly.AlertsSource(
     "grafana",
     alert_source_fields_attributes=[
@@ -3720,6 +3728,29 @@ alert_route_cloudwatch_service_route = rootly.AlertRoute(
     opts=rootly_imported_route_opts("61d2fb04-f85f-4d9c-a1bc-1a6afad7ca0f"),
 )
 
+# Slated for deletion; this apply only clears the `protect` flag so the next one
+# can remove it.
+#
+# The route is inert. It is bound to alert source `grafana` (f4d836c0), which was
+# fed only by the three MIT Learn synthetic monitoring rules through a
+# `notification_settings.receiver="Rootly"` override. PR #5400 removed that
+# override and routed them through alertmanager.py's policy tree instead, so
+# nothing has delivered here since. Verified 2026-08-18 against production
+# `/api/v1/provisioning/alert-rules`: all six SM rules carry `receiver: null`.
+#
+# Its two live rules (`service=mitlearn` + `component=api|nextjs`) have moved to
+# the Grafana Production Service Route below, where the SM alerts actually land.
+# The two that remain are dead and stay dead: nothing emits `service=learn-ai`.
+# The Synthetic Monitoring plugin's own `sm-*` rules carry only `__grafana_origin`
+# and `namespace=synthetic_monitoring` -- check labels are not propagated to them
+# -- so pingdom_checks.py's `service: learn-ai` never reaches Rootly.
+#
+# Why this is two applies rather than one: every resource in this stack is
+# `protect=True`, and Pulumi refuses to delete a protected resource. Deleting the
+# declaration outright makes `pulumi up` fail in the simple_pulumi pipeline until
+# someone runs `pulumi state unprotect` by hand against production. Clearing the
+# flag in code first is the path Pulumi's own error message recommends, and it
+# keeps the whole operation inside the pipeline.
 alert_route_grafana_service_route = rootly.AlertRoute(
     "grafana-service-route",
     alerts_source_ids=[alerts_source_grafana.id],
@@ -3784,6 +3815,44 @@ alert_route_grafana_service_route = rootly.AlertRoute(
             "position": 2,
         },
         {
+            "destinations": [
+                {
+                    "targetId": "96629210-cc41-4e57-b059-b182a0f01c5b",
+                    "targetType": "EscalationPolicy",
+                },
+            ],
+            "fallbackRule": True,
+            "name": "Fallback Rule for Grafana Service Route",
+            "position": 3,
+        },
+    ],
+    opts=ResourceOptions.merge(
+        rootly_imported_route_opts("c1e812d2-e14b-4233-a368-c240e9a03d17"),
+        ResourceOptions(protect=False),
+    ),
+)
+
+alert_route_grafana_production_service_route = rootly.AlertRoute(
+    "grafana-production-service-route",
+    alerts_source_ids=[alerts_source_grafana_prometheus_production.id],
+    enabled=True,
+    name="Grafana Production Service Route",
+    owning_team_ids=[
+        "9f00e9f1-2f13-470e-a856-50ab5003f260",
+    ],
+    rules=[
+        # Moved off the Grafana Service Route above, which is bound to an alert
+        # source nothing feeds any more. The MIT Learn synthetic monitoring
+        # rules route through alertmanager.py's policy tree to this source
+        # instead, and they emit exactly the `service`/`ol_component` pair
+        # these two match on -- so both reach their service from here. Until
+        # this move they matched nothing and MIT Learn - API and
+        # MIT Learn - NextJS were among the Rootly services no rule targeted.
+        #
+        # These sit ahead of the `namespace`-keyed rules below because
+        # conditions are `contains` and the first match wins: a narrow rule
+        # placed after a broad one never runs.
+        {
             "conditionGroups": [
                 {
                     "conditions": [
@@ -3795,7 +3864,7 @@ alert_route_grafana_service_route = rootly.AlertRoute(
                         },
                         {
                             "propertyFieldConditionType": "contains",
-                            "propertyFieldName": "$.commonLabels.component",
+                            "propertyFieldName": "$.commonLabels.ol_component",
                             "propertyFieldType": "payload",
                             "propertyFieldValue": "api",
                         },
@@ -3810,8 +3879,8 @@ alert_route_grafana_service_route = rootly.AlertRoute(
                 },
             ],
             "fallbackRule": False,
-            "name": "MIT Learn API to MIT Learn - API Service",
-            "position": 3,
+            "name": "mitlearn service + api component to MIT Learn - API",
+            "position": 1,
         },
         {
             "conditionGroups": [
@@ -3825,7 +3894,7 @@ alert_route_grafana_service_route = rootly.AlertRoute(
                         },
                         {
                             "propertyFieldConditionType": "contains",
-                            "propertyFieldName": "$.commonLabels.component",
+                            "propertyFieldName": "$.commonLabels.ol_component",
                             "propertyFieldType": "payload",
                             "propertyFieldValue": "nextjs",
                         },
@@ -3840,33 +3909,9 @@ alert_route_grafana_service_route = rootly.AlertRoute(
                 },
             ],
             "fallbackRule": False,
-            "name": "MIT Learn NextJS to NextJS Service",
-            "position": 4,
+            "name": "mitlearn service + nextjs component to MIT Learn - NextJS",
+            "position": 2,
         },
-        {
-            "destinations": [
-                {
-                    "targetId": "96629210-cc41-4e57-b059-b182a0f01c5b",
-                    "targetType": "EscalationPolicy",
-                },
-            ],
-            "fallbackRule": True,
-            "name": "Fallback Rule for Grafana Service Route",
-            "position": 5,
-        },
-    ],
-    opts=rootly_imported_route_opts("c1e812d2-e14b-4233-a368-c240e9a03d17"),
-)
-
-alert_route_grafana_production_service_route = rootly.AlertRoute(
-    "grafana-production-service-route",
-    alerts_source_ids=[alerts_source_grafana_prometheus_production.id],
-    enabled=True,
-    name="Grafana Production Service Route",
-    owning_team_ids=[
-        "9f00e9f1-2f13-470e-a856-50ab5003f260",
-    ],
-    rules=[
         {
             "conditionGroups": [
                 {
@@ -3889,7 +3934,7 @@ alert_route_grafana_production_service_route = rootly.AlertRoute(
             ],
             "fallbackRule": False,
             "name": "learn-ai namespace to MIT Learn AI - Django Webapp",
-            "position": 1,
+            "position": 3,
         },
         {
             "conditionGroups": [
@@ -3913,7 +3958,7 @@ alert_route_grafana_production_service_route = rootly.AlertRoute(
             ],
             "fallbackRule": False,
             "name": "mitlearn namespace to MIT Learn - Django Webapp",
-            "position": 2,
+            "position": 4,
         },
         {
             "conditionGroups": [
@@ -3937,7 +3982,7 @@ alert_route_grafana_production_service_route = rootly.AlertRoute(
             ],
             "fallbackRule": False,
             "name": "mitxonline-openedx namespace to MITx Online Open edX LMS Webapp",
-            "position": 3,
+            "position": 5,
         },
         {
             "conditionGroups": [
@@ -3961,7 +4006,7 @@ alert_route_grafana_production_service_route = rootly.AlertRoute(
             ],
             "fallbackRule": False,
             "name": "mitxonline namespace to MITx Online - Django Webapp",
-            "position": 4,
+            "position": 6,
         },
         {
             "conditionGroups": [
@@ -3991,7 +4036,7 @@ alert_route_grafana_production_service_route = rootly.AlertRoute(
             ],
             "fallbackRule": False,
             "name": "openedx service + xpro- env to MIT XPro Open edX LMS Webapp",
-            "position": 5,
+            "position": 7,
         },
         {
             "conditionGroups": [
@@ -4021,7 +4066,7 @@ alert_route_grafana_production_service_route = rootly.AlertRoute(
             ],
             "fallbackRule": False,
             "name": "openedx service + mitx- env to MITx Residential Open edX LMS Webapp",  # noqa: E501
-            "position": 6,
+            "position": 8,
         },
         {
             "conditionGroups": [
@@ -4045,7 +4090,7 @@ alert_route_grafana_production_service_route = rootly.AlertRoute(
             ],
             "fallbackRule": False,
             "name": "openedx service label to MITx Online Open edX LMS Webapp",
-            "position": 7,
+            "position": 9,
         },
         {
             "destinations": [
@@ -4056,7 +4101,7 @@ alert_route_grafana_production_service_route = rootly.AlertRoute(
             ],
             "fallbackRule": True,
             "name": "Fallback Rule for Grafana Production Service Route",
-            "position": 8,
+            "position": 10,
         },
     ],
     opts=rootly_imported_route_opts("e7b002f8-e13f-4b63-b0df-af1c78aee890"),


### PR DESCRIPTION
### What are the relevant tickets?
N/A — step P1.5 of `docs/plans/rootly-label-routing-implementation-spec.md` (merged in #5458).

### Description (What does it do?)

- Moves the two `service=mitlearn` + `component=api|nextjs` routing rules from the Grafana Service Route to the Grafana Production Service Route. They were bound to Rootly alert source `f4d836c0`, which #5400 cut the last feed to when it removed the synthetic monitoring rules' `notification_settings.receiver="Rootly"` override — so both rules have been matching nothing. The alerts they were written for now arrive at the production alertmanager source carrying exactly the payload they test.
- **`MIT Learn - API` and `MIT Learn - NextJS` become reachable in Rootly** — two of the services that no routing rule targeted.
- Places them at positions 1–2, ahead of the broad `namespace`-keyed rules, and renumbers the rest 3–10. Conditions are `contains` and the first match wins, so a narrow rule placed after a broad one never runs.
- Renames the label the SM rules emit from `component` to `ol_component` ([`synthetic_monitoring.py`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/synthetic_monitoring.py#L276)). `component` is generic enough that a vendor integration could set it on an unrelated alert and be routed to a MIT Learn service; `ol_component` is also the key the Phase 3 EKS rewrite will emit, so both label sources converge. Done here rather than later because it retitles a live alert label and the routing rules have to agree with it.
- Clears `protect` on the now-empty Grafana Service Route so a follow-up can delete it. See Additional Context.

The route's two remaining rules stay dead knowingly: nothing emits `service=learn-ai`. The Synthetic Monitoring plugin's own `sm-*` rules carry only `__grafana_origin` and `namespace=synthetic_monitoring` — check labels are not propagated to them — so `pingdom_checks.py`'s `service: learn-ai` entries never reach Rootly.

### How can this be tested?

Run from `src/ol_infrastructure/saas/rootly/`:

```
pulumi preview --stack Production
```

This change should contribute exactly two updates and no deletes:

```
~  rootly:index:AlertRoute grafana-service-route             update [diff: ~rules]
~  rootly:index:AlertRoute grafana-production-service-route  update [diff: ~rules]
```

What I ran, and what it showed:

- `pulumi preview --stack Production` — clean, no errors, the two updates above.
- `pre-commit run --files <the two changed files>` — ruff format, ruff check, mypy, detect-secrets all pass.
- Production `GET /api/v1/provisioning/alert-rules` — all six MIT Learn SM rules carry `receiver: null` (policy tree), confirming source `f4d836c0` has no feed. The plugin's `sm-*` rules carry only `__grafana_origin` and `namespace=synthetic_monitoring`, confirming the `learn-ai` rules are dead.
- Production `GET /api/v1/provisioning/policies` — the tree references only `oblivion`, `rootly`, `slack-notifications-ocw-misc-critical`, `slack-notifications-ocw-misc-warning`. Nothing points at the UI-created `Rootly` contact point `eel3rjpiwahoge`.
- `GET /api/v1/provisioning/contact-points` — the `component` label is not in [`alertmanager.py`'s `group_bies`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/infrastructure/grafana_alerting/alertmanager.py#L123-L140), and no other rule under `grafana_alerting/` emits a `component` label, so the rename regroups no notification.

**Not verified:** an actual probe failure landing on the right Rootly service. That needs the change applied plus a real or forced SM check failure on `api.learn.mit.edu` or `next.learn.mit.edu` — worth doing once this is out, since it is the only end-to-end confirmation.

### Additional Context

**Why `protect=False` instead of deleting the route outright.** Every resource in this stack is created with `protect=True` (`rootly_opts`, `__main__.py:20`), and Pulumi refuses to delete a protected resource. Deleting the declaration in this PR made `pulumi preview` fail with:

```
error: Preview failed: resource "urn:pulumi:Production::ol-saas-rootly::rootly:index/alertRoute:AlertRoute::grafana-service-route" cannot be deleted
because it is protected.
```

`ol-saas-rootly` is auto-applied by the `simple_pulumi` pipeline, so that would hold the job red until someone ran `pulumi state unprotect` by hand against production. Clearing the flag in code first is what Pulumi's own error message recommends and keeps the whole operation inside the pipeline. The follow-up deletes the route, and the orphaned `eel3rjpiwahoge` contact point, in a second apply.

**Heads-up for whoever applies this.** The Production stack of `ol-saas-rootly` was last updated ~2 weeks ago and carries unapplied drift from earlier work (#5354 / #5377): 3 creates and 4 updates unrelated to this PR — `defer-low-urgency-off-hours` and `medium-urgency-slack-warnings` escalation paths, an escalation level, and `deduplicateAlertsByKey` / `alertSourceUrgencyRulesAttributes` on three alert sources. Applying this change applies those too. Review the full preview, not just the two lines above.
