### PR TITLE
fix(alerting): key job-failure rules off kube_job_failed, not failed-pod count

### DIFF
--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
@@ -348,7 +348,23 @@ def create(
                 ),
             ),
             # --- Job failures ---
-            # Fires when a Job's failed pod count > 0.
+            # Fires when a Job reaches the Failed condition -- i.e. it exhausted its
+            # backoffLimit and gave up.
+            #
+            # Deliberately NOT kube_job_status_failed > 0, which counts failed PODS
+            # rather than failed JOBS. A Job that burns a retry and then succeeds keeps
+            # a non-zero failed-pod count for the rest of its life, so that expression
+            # alerts on work that completed fine. Observed the day this rule first
+            # became deliverable: mitlearn-app-pre-deploy in applications-qa sat at
+            # `Complete, succeeded=1, failed=2` and paged anyway, and for_="5m" did not
+            # save it because the Job ran for 7m1s. Over 7 days in production the same
+            # shape covered 11 distinct xqueue-grader-* jobs in
+            # mitxonline-openedx-graders; kube_job_failed{condition="true"} has no
+            # series at all for any of them.
+            #
+            # This was pre-existing logic rather than a regression -- it simply never
+            # mattered while every firing went to oblivion. Making the rule deliverable
+            # is what exposed it.
             #
             # Named Workload* rather than Kubernetes*: alertmanager.py silences
             # `alertname =~ "Kube.*"` (built-in k8s noise) with continue_=False, and
@@ -360,10 +376,14 @@ def create(
             #
             # Exclusions:
             #   dagster          -- manages its own job retry logic.
-            #   witan-ci-indexer -- currently failing every run in both operations-qa
-            #                       and operations-production; excluded so the rename
-            #                       above does not immediately page for a known break.
-            #                       Remove this exclusion once that job is fixed.
+            #   witan-ci-indexer -- genuinely reaches the Failed condition on both
+            #                       operations-qa and operations-production (confirmed
+            #                       under kube_job_failed{condition="true"}, not just
+            #                       the noisier failed-pod signal above); excluded so
+            #                       the rename does not immediately page for a known
+            #                       break. Remove this exclusion once that job is
+            #                       fixed -- see tk-witan-ci-indexer-cronjob-fails-on
+            #                       -nearly-every-r-4c1462.
             alerting.RuleGroupRuleArgs(
                 name="WorkloadJobFailedWarning",
                 condition="C",
@@ -374,7 +394,7 @@ def create(
                     "description": "Job {{ $labels.job_name }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has failed."
                 },
                 datas=rd(
-                    'sum by (cluster, namespace, job_name) (kube_job_status_failed{cluster=~".*-(ci|qa)", namespace!="dagster", job_name!~"witan-ci-indexer.*"} > 0)'
+                    'sum by (cluster, namespace, job_name) (kube_job_failed{cluster=~".*-(ci|qa)", condition="true", namespace!="dagster", job_name!~"witan-ci-indexer.*"} == 1)'
                 ),
             ),
             alerting.RuleGroupRuleArgs(
@@ -387,7 +407,7 @@ def create(
                     "description": "Job {{ $labels.job_name }} in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} has failed."
                 },
                 datas=rd(
-                    'sum by (cluster, namespace, job_name) (kube_job_status_failed{cluster=~".*-(production)", namespace!="dagster", job_name!~"witan-ci-indexer.*"} > 0)'
+                    'sum by (cluster, namespace, job_name) (kube_job_failed{cluster=~".*-(production)", condition="true", namespace!="dagster", job_name!~"witan-ci-indexer.*"} == 1)'
                 ),
             ),
             # --- HPA at max replicas ---


### PR DESCRIPTION
### What are the relevant tickets?

N/A. Follow-up to https://github.com/mitodl/ol-infrastructure/pull/5457, which made `WorkloadJobFailed{Warning,Critical}` actually deliver to Rootly for the first time. That's what exposed this bug — it was in the expression the whole time, it just never mattered while every firing went to `oblivion`.

### Description (What does it do?)

`WorkloadJobFailed{Warning,Critical}` used `kube_job_status_failed > 0`, which counts failed **pods**, not failed **jobs**. A Job that burns a retry and then succeeds keeps a non-zero failed-pod count for the rest of its life, so that expression pages for work that completed fine.

Caught it live: the day #5457 made this rule deliverable, `mitlearn-app-pre-deploy` in `applications-qa` paged twice for a Job that was actually `Complete` with `succeeded=1, failed=2`. `for_="5m"` didn't save it — the Job ran for 7m1s.

Switched both rules to `kube_job_failed{condition="true"} == 1` — the Job-level `Failed` condition, which Kubernetes only sets once `backoffLimit` is exhausted. That's "this job failed," not "some pod attempt failed."

### How can this be tested?

Verified both directions against live Grafana Cloud data rather than assuming the fix is correct:

- `mitlearn-app-pre-deploy` (the job that just false-paged) has **no** `kube_job_failed` series at all under the new expression — confirmed no false page.
- Backtested 7 days of production data: 11 distinct `xqueue-grader-*` jobs in `mitxonline-openedx-graders` showed the same false-positive shape under the old signal (`kube_job_status_failed > 0` with no matching `kube_job_failed{condition="true"}`) and produce **zero** matches under the new one.
- `witan-ci-indexer`'s exclusion still holds under the corrected signal — it genuinely reaches the `Failed` condition on both `operations-qa` and `operations-production`, confirmed directly rather than assumed, so it stays excluded pending the job actually being fixed.
- `pulumi preview --stack Production --diff` attributes exactly **1 update** to this change — the two `expr` strings — with **32 unchanged**.
- `uv run pre-commit run` passes.

Not yet deployed.

### Additional Context

This is the third PR in this chain (#5422 → #5457 → this one), each one surfacing the next layer because the previous fix made something observable for the first time. Worth reading as a pattern: **un-swallowing an alert is itself a form of testing** — it's how this bug, and the `witan-ci-indexer` failures, and the rename/urgency-list drift in #5457, all got found. None of them were visible while the rule silently routed to `oblivion`.
