### PR TITLE
feat(ocw_studio,ovs): export OTel traces from two more Django apps

### DIFF
--- a/src/ol_infrastructure/applications/ocw_studio/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/ocw_studio/Pulumi.Production.yaml
@@ -40,6 +40,11 @@ config:
     OCW_STUDIO_LIVE_URL: https://ocw.mit.edu/
     OCW_STUDIO_LOG_LEVEL: INFO
     OCW_STUDIO_SUPPORT_EMAIL: 'ocw-studio-support@mit.edu'
+    OPENTELEMETRY_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/traces"
+    OTEL_RESOURCE_ATTRIBUTES: "service.namespace=ocw-studio,service.instance.id=$(KUBERNETES_POD_NAME)"
+    OTEL_SERVICE_NAME: "ocw-studio-webapp"
+    OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT: "128"
+    OTEL_TRACES_SAMPLER: "parentbased_always_on"
     OPEN_CATALOG_URLS: 'https://open.mit.edu/api/v0/ocw_next_webhook/,https://api.learn.mit.edu/api/v1/ocw_next_webhook/'
     POST_TRANSCODE_ACTIONS: 'videos.api.update_video_job'
     PUBLISH_POSTHOG_API_HOST: https://ph.ol.mit.edu

--- a/src/ol_infrastructure/applications/ocw_studio/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/ocw_studio/Pulumi.QA.yaml
@@ -44,6 +44,11 @@ config:
     OCW_STUDIO_LIVE_URL: https://live-qa.ocw.mit.edu/
     OCW_STUDIO_LOG_LEVEL: INFO
     OCW_STUDIO_SUPPORT_EMAIL: 'ocw-studio-rc-support@mit.edu'
+    OPENTELEMETRY_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/traces"
+    OTEL_RESOURCE_ATTRIBUTES: "service.namespace=ocw-studio,service.instance.id=$(KUBERNETES_POD_NAME)"
+    OTEL_SERVICE_NAME: "ocw-studio-webapp"
+    OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT: "128"
+    OTEL_TRACES_SAMPLER: "parentbased_always_on"
     OPEN_CATALOG_URLS: 'https://discussions-rc.odl.mit.edu/api/v0/ocw_next_webhook/,https://api.rc.learn.mit.edu/api/v1/ocw_next_webhook/'
     PUBLISH_POSTHOG_ENABLED: 'true'
     PUBLISH_POSTHOG_API_HOST: https://ph.ol.mit.edu

--- a/src/ol_infrastructure/applications/odl_video_service/__main__.py
+++ b/src/ol_infrastructure/applications/odl_video_service/__main__.py
@@ -816,6 +816,42 @@ k8s_extra_vars: dict[str, str | Output[str]] = {
 }
 app_env_vars.update(k8s_extra_vars)
 
+# OVS has no `vars:` block in its stack configs -- every non-secret env var is
+# literal here -- so unlike micromasters/xpro/ocw_studio the OTel block lives in
+# the program rather than in Pulumi.{QA,Production}.yaml.
+#
+# Gated on CI because `setup_grafana` (substructure/aws/eks/grafana.py) returns
+# early for `ci`, so no Grafana Alloy runs there and
+# grafana-k8s-monitoring-alloy-receiver does not resolve. Setting the endpoint
+# uniformly is not free: it buys a connection failure per span batch, forever,
+# in the one environment nobody watches.
+#
+# OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES are read straight from the
+# environment; OPENTELEMETRY_ENDPOINT is a Django setting odl_video/settings.py
+# reads, which is why it carries the full /v1/traces path rather than a base URL
+# the SDK would append to.
+if stack_info.env_suffix != "ci":
+    app_env_vars.update(
+        {
+            "OPENTELEMETRY_ENDPOINT": (
+                "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc"
+                ".cluster.local:4318/v1/traces"
+            ),
+            "OTEL_RESOURCE_ATTRIBUTES": (
+                f"service.namespace={ovs_namespace},"
+                "service.instance.id=$(KUBERNETES_POD_NAME)"
+            ),
+            "OTEL_SERVICE_NAME": "ovs-webapp",
+            "OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT": "128",
+            # Alloy tail-samples (keep errors, keep >5000ms, 15% of the rest --
+            # substructure/aws/eks/grafana.py), so head sampling here would
+            # multiply with it rather than compose. `parentbased_` still honours
+            # an inbound "not sampled" so a trace crossing from APISIX stays
+            # coherent.
+            "OTEL_TRACES_SAMPLER": "parentbased_always_on",
+        }
+    )
+
 # Unconditionally append k8s labels to OTEL_RESOURCE_ATTRIBUTES so all telemetry
 # signals carry organizational metadata regardless of stack environment.
 merge_otel_resource_attributes(app_env_vars, k8s_app_labels)


### PR DESCRIPTION
## What are the relevant tickets?

Part of the OpenTelemetry APM coverage epic (`tk-extend-otel-tracing-to-the-uninstrumented-apps-m-41729c`). Pairs with:

- mitodl/ocw-studio#3158
- mitodl/odl-video-service#1577

## ⚠️ Draft: land this after both app images deploy

The env vars here are **inert** without the app-side changes — ocw-studio has no observability app installed at all today, and OVS has one but no instrumentors. Landing this first buys config that reads as working and does nothing.

## Description (What does it do?)

Sets the OTLP endpoint and resource attributes for `ocw_studio` and `odl_video_service` in QA and Production, so the tracing the two app PRs turn on has somewhere to go.

### What each variable is for, and what is deliberately absent

The six existing OTel stacks carry nine variables each. Three of those nine are read by nothing, so the new adopters get five rather than inheriting them:

| Variable | Who reads it |
|---|---|
| `OPENTELEMETRY_ENDPOINT` | a Django setting the app reads; handed to `OTLPSpanExporter` verbatim, hence the full `/v1/traces` path rather than a base URL |
| `OTEL_SERVICE_NAME` | read straight from `os.environ` by the library |
| `OTEL_RESOURCE_ATTRIBUTES` | the SDK's `OTELResourceDetector` |
| `OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT` | the SDK, when it builds `SpanLimits` |
| `OTEL_TRACES_SAMPLER` | `TracerProvider`'s default sampler |

Not set, and why:

- **`OTEL_PROPAGATORS`** — the library calls `set_global_textmap()` with an explicit `CompositePropagator`, which overrides it.
- **`OTEL_EXPORTER_OTLP_PROTOCOL`** — consumed by the `opentelemetry-instrument` agent, not by the http exporter the library constructs directly.
- **`OTEL_METRIC_EXPORT_INTERVAL`** — there is no `MeterProvider` until mitodl/ol-django#553 ships, and no metrics endpoint until the task that owns `OTEL_EXPORTER_OTLP_ENDPOINT` runs. Both belong to that change, together.
- **`deployment.environment`** — the library passes it to `Resource.create()` from `settings.ENVIRONMENT`, and `Resource.create` merges explicit attributes *over* env-detected ones, so an `OTEL_RESOURCE_ATTRIBUTES` value for that key never reaches a span. Verified in QA Tempo: `learn-webapp`, `learn-ai-webapp` and `mitxonline-webapp` all report `deployment.environment="rc"` (their app-level `ENVIRONMENT`) despite every one of those stacks setting `"qa"`. Filed separately rather than copied forward.

### `parentbased_always_on`, not the 0.25 ratio the older stacks use

Alloy already tail-samples — keep errors, keep >5000ms, 15% of the rest (`substructure/aws/eks/grafana.py`). Head sampling in front of that multiplies with it instead of composing: a trace is dropped by the coin flip before any policy can look at whether it errored. Same reasoning as #5487 (witan) and #5471 (mit-learn-nextjs); the house pattern is stated in `components/services/apisix.py`, where the gateway runs `always_on`.

Narrower in practice than it looks: APISIX propagates a sampled `traceparent` and `parentbased_` honours it, so anything arriving through the gateway was already at 100%. The ratio would only ever have applied to traces these apps root themselves — celery tasks and cron — which is exactly where full capture is worth most.

### CI is deliberately dark

`setup_grafana` returns early for `ci`, so no Alloy runs there and `grafana-k8s-monitoring-alloy-receiver` does not resolve. Setting the endpoint uniformly is not free: it buys a connection failure per span batch, forever, in the environment nobody watches.

`ocw_studio` gets the block only in `Pulumi.{QA,Production}.yaml`. OVS has no `vars:` config block — every non-secret env var is literal in its program — so it gets an explicit `env_suffix` guard there instead.

## How can this be tested?

`pulumi preview`:

- `odl_video_service` **QA**: 3 to update (webapp, celery worker, celery beat), 133 unchanged. Diff shows the five vars added and `OTEL_RESOURCE_ATTRIBUTES` extended with the existing `ol.mit.edu/*` labels.
- `odl_video_service` **CI**: no OTel env in the diff, confirming the guard. (One unrelated pre-existing liveness-probe drift.)
- `ocw_studio` **QA**: 6 to update, 1 replace. The replace is the pre-deploy `Job`, which is immutable, so any env change replaces it.

After deploy, confirm `ocw-studio-webapp` and `ovs-webapp` appear under `resource.service.name` in Tempo.

## Additional Context

`micromasters` and `xpro` are the other two apps in this epic. Their stack configs are deliberately **not** included: both repos currently have an unsatisfiable `uv.lock` on master, so neither can add the instrumentors this depends on. Tracked separately.