### PR TITLE
fix(dagster): make event_log_storage pool sizing stack-specific, fix pgbouncer metric

### DIFF
--- a/src/ol_infrastructure/applications/dagster/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/dagster/Pulumi.Production.yaml
@@ -35,3 +35,13 @@ config:
   # load spreads evenly across replicas, and measured distribution is heavily
   # skewed, so the binding limit is whichever replica saturates first.
   dagster:max_concurrent_runs: 80
+  # event_log_storage's QueuePool ceiling, sized after the daemon logged
+  # 1000+ "QueuePool limit" timeouts in 41 minutes on 2026-08-18 under
+  # automation_condition_evaluator load. See the full derivation, including
+  # the per-pod PgBouncer math this is checked against, in
+  # dagster_instance.yaml's event_log_storage comment. Not set on QA: its
+  # per-pod cap (382) is already tight enough that a prior run-worker
+  # incident deadlocked the whole pool, and it has not shown this failure
+  # mode, so it stays on the conservative fallback in __main__.py.
+  dagster:event_log_pool_size: 100
+  dagster:event_log_max_overflow: 50

--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -2095,6 +2095,16 @@ dagster_run_priority_class = kubernetes.scheduling.v1.PriorityClass(
 # than inherit this one.
 dagster_max_concurrent_runs = dagster_config.get_int("max_concurrent_runs") or 100
 
+# event_log_storage's pool_size/max_overflow, same reasoning as
+# max_concurrent_runs above: sized against the environment's PgBouncer
+# per-pod cap, so it has to be a stack config value rather than a literal in
+# dagster_instance.yaml. Production needed a large bump after 2026-08-18 (see
+# the rationale in dagster_instance.yaml); the 10+10 fallback here is the
+# pre-incident size, deliberately conservative for any stack -- QA included
+# -- that has not set its own value and has not demonstrated the same need.
+dagster_event_log_pool_size = dagster_config.get_int("event_log_pool_size") or 10
+dagster_event_log_max_overflow = dagster_config.get_int("event_log_max_overflow") or 10
+
 # Custom Dagster instance ConfigMap with dynamic credentials support
 # Note: We create this before the Helm release so it gets proper ownership
 dagster_instance_yaml = (
@@ -2102,6 +2112,8 @@ dagster_instance_yaml = (
     .parent.joinpath("dagster_instance.yaml")
     .read_text()
     .replace("MAX_CONCURRENT_RUNS", str(dagster_max_concurrent_runs))
+    .replace("EVENT_LOG_POOL_SIZE", str(dagster_event_log_pool_size))
+    .replace("EVENT_LOG_MAX_OVERFLOW", str(dagster_event_log_max_overflow))
 )
 # The daemon and webserver mount dagster.yaml from the dagster-instance
 # ConfigMap via subPath, which kubelet never live-refreshes, and the chart's

--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -2102,8 +2102,18 @@ dagster_max_concurrent_runs = dagster_config.get_int("max_concurrent_runs") or 1
 # the rationale in dagster_instance.yaml); the 10+10 fallback here is the
 # pre-incident size, deliberately conservative for any stack -- QA included
 # -- that has not set its own value and has not demonstrated the same need.
-dagster_event_log_pool_size = dagster_config.get_int("event_log_pool_size") or 10
-dagster_event_log_max_overflow = dagster_config.get_int("event_log_max_overflow") or 10
+#
+# `or 10` would be wrong here: max_overflow=0 is a legitimate, deliberately
+# conservative stack choice (forbid burst connections entirely), and `0 or 10`
+# would silently discard it. get_int() returns None when the key is unset, so
+# check for that explicitly instead.
+dagster_event_log_pool_size = dagster_config.get_int("event_log_pool_size")
+if dagster_event_log_pool_size is None:
+    dagster_event_log_pool_size = 10
+
+dagster_event_log_max_overflow = dagster_config.get_int("event_log_max_overflow")
+if dagster_event_log_max_overflow is None:
+    dagster_event_log_max_overflow = 10
 
 # Custom Dagster instance ConfigMap with dynamic credentials support
 # Note: We create this before the Helm release so it gets proper ownership

--- a/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
+++ b/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
@@ -52,13 +52,25 @@ compute_logs:
 # pool_size is a retention ceiling, not a preallocation: QueuePool opens
 # connections lazily, so the 97 processes that share this ConfigMap (daemon, 2
 # webservers, 14 code locations, up to max_concurrent_runs workers) only hold
-# what they actually used. Run workers hold none when idle and live 7-9
-# seconds, which is why the worst-case product of 97 x 3 x pool ceiling
-# overstates the real total by more than an order of magnitude -- measured
-# peak across the whole fleet was 122 active server connections before this
-# change, rising to ~184 as the event log pool started saturating, against an
-# aggregate budget of 4248. Check pgbouncer_pools_server_active_connections
-# again after this ships rather than trusting the estimate.
+# what they actually used. Run workers are not exempt from the budget just
+# because they are short-lived -- a worker that opens a connection still
+# counts against the per-pod cap for as long as it holds it -- they just tend
+# to hold fewer at once than the daemon.
+#
+# Checking server_active/pgbouncer_pools_server_active_connections against
+# that budget undercounts: pool_mode is session (see __main__.py), so a
+# connection QueuePool returns to its own pool stays connected to RDS as an
+# idle-but-pinned backend rather than being released. What actually consumes
+# the per-pod cap is pgbouncer_databases_current_connections -- the same
+# metric DagsterPgBouncerConnectionHeadroom already alerts on
+# (grafana_alerting/metric_rules/dagster_pgbouncer.py) -- checked per pod, not
+# summed across replicas, since a client's connections land on whichever pod
+# kube-proxy routes them to and do not spread evenly by construction.
+#
+# event_log_storage's pool_size/max_overflow are stack config values, not
+# literals, for the same reason max_concurrent_runs is: they have to be sized
+# against each environment's own PgBouncer budget. See __main__.py and that
+# storage's own comment below for the numbers and the per-pod math.
 schedule_storage:
   module: ol_orchestrate.lib.postgres.schedule_storage
   class: PooledPostgresScheduleStorage
@@ -188,25 +200,46 @@ run_retries:
 # at rest, not what a tick evaluating many assets at once actually needs, so
 # this gets real headroom rather than another guess at a tight number.
 #
-# 100+50 gives the daemon a 150-connection ceiling for this storage alone.
-# Checked against __main__.py's pgbouncer sizing, not just the aggregate
-# budget: max_db_connections there is derived as budget / replica count
-# because a client's connections land on whichever of the 6 pgbouncer pods
-# kube-proxy routes them to, not spread evenly by construction, so the
-# binding constraint is the per-pod cap (708 currently) and not the aggregate
-# (4248). Worst case every process sharing this ConfigMap that touches event
-# log storage heavily -- the daemon plus the 2 webserver replicas -- pegs its
-# ceiling on the same pod at once: 3 x 150 = 450, still comfortably under 708.
-# Run workers are excluded from that sum because they hold connections for
-# 7-9 seconds, not the process lifetime. Recheck
-# pgbouncer_pools_server_active_connections (per-pod, not just summed) after
-# this ships.
+# pool_size/max_overflow are placeholder tokens substituted in __main__.py
+# from dagster:event_log_pool_size / dagster:event_log_max_overflow stack
+# config, the same mechanism as run_coordinator's MAX_CONCURRENT_RUNS below --
+# not a literal, because the right ceiling depends on the environment's own
+# PgBouncer budget. Production sets 100+50, a 150-connection ceiling for this
+# storage alone; the fallback in __main__.py is the original 10+10 for any
+# stack, QA included, that has not set its own value and has not shown the
+# same need. Giving every stack Production's number by default is exactly
+# what put QA's pool at risk here: QA's per-pod cap is 382 against
+# Production's 708, and QA has already deadlocked its whole pool once from
+# run-worker connections alone (see the 2026-08-17 incident notes in
+# __main__.py) -- it cannot absorb a 150-connection ceiling on top of that
+# without its own sizing pass.
+#
+# Production's number, checked against __main__.py's per-pod PgBouncer math
+# (not just the aggregate budget, for the reason in the top-of-file comment):
+# worst case, every process that shares this ConfigMap and touches event log
+# storage heavily -- the daemon plus the 2 webserver replicas -- pegs this
+# ceiling on the same pod at once. That is 3 x (event log 150 + run storage 30
+# + schedule storage 30) = 630 against a 708 cap: tighter than it looks, but
+# still clear.
+#
+# What that 630 does not bound: run workers mount this same ConfigMap and
+# inherit the same ceilings, and up to max_concurrent_runs (80 in production)
+# of them can be live at once. They are not exempt from the per-pod cap just
+# because they are short-lived, and their real aggregate footprint here is
+# unmeasured -- the closest data point is QA's ~22 connections/worker from
+# the deadlock above, which was itself an abnormal-state measurement, not a
+# steady-state one. Production's replica-to-replica spread has been even so
+# far (1-18 active per pod, per __main__.py), unlike QA's observed 221-vs-4
+# skew, which is the only reason 630 has not already been tested against
+# worker load. Check pgbouncer_databases_current_connections per pod, not
+# summed, after this ships -- this analysis does not prove the worker
+# contribution is safe, only that it has not yet been observed to be unsafe.
 event_log_storage:
   module: ol_orchestrate.lib.postgres.event_log
   class: PooledPostgresEventLogStorage
   config:
-    pool_size: 100
-    max_overflow: 50
+    pool_size: EVENT_LOG_POOL_SIZE
+    max_overflow: EVENT_LOG_MAX_OVERFLOW
     pool_recycle: 3600
     pool_timeout: 30
     postgres_db:


### PR DESCRIPTION
### What are the relevant tickets?
N/A — follow-up to Copilot review feedback that landed on https://github.com/mitodl/ol-infrastructure/pull/5497 after it was already merged.

### Description (What does it do?)
Copilot left two review comments on #5497 after merge. Both check out against the actual code, so this addresses them:

**[#5497 comment 1](https://github.com/mitodl/ol-infrastructure/pull/5497#discussion_r3806438426): wrong validation metric.** `pool_mode = session` (`__main__.py`), so a connection `QueuePool` returns to its own pool stays connected to RDS as an idle-but-pinned backend rather than being released. `pgbouncer_pools_server_active_connections` — what #5497 told reviewers to check — undercounts what's actually consuming the per-pod cap. `pgbouncer_databases_current_connections` is the correct metric; it's what `DagsterPgBouncerConnectionHeadroom` already alerts on, for exactly this reason. Fixed the validation guidance in `dagster_instance.yaml`'s comments.

**[#5497 comment 2](https://github.com/mitodl/ol-infrastructure/pull/5497#discussion_r3806438462): incomplete/non-stack-specific capacity math.** #5497's worst-case calculation (3 × 150 = 450) omitted `run_storage`/`schedule_storage`'s own 30-connection ceilings, and — because `dagster_instance.yaml` is shared verbatim across stacks — applied Production's 100+50 event-log ceiling to QA too. QA's per-pod PgBouncer cap is only 382, and QA has already deadlocked its entire pool once from run-worker connections alone (see the 2026-08-17 incident notes already in `__main__.py`). The `automation_condition_evaluator` load that actually needed the bigger ceiling was observed on production, not QA.

Fix: `event_log_storage`'s `pool_size`/`max_overflow` become stack config values (`dagster:event_log_pool_size` / `dagster:event_log_max_overflow`), substituted into `dagster_instance.yaml` the same way `run_coordinator`'s `MAX_CONCURRENT_RUNS` already is. Production explicitly sets 100+50; every other stack, QA included, falls back to the pre-incident 10+10 in `__main__.py` until it demonstrates the same need.

The corrected Production worst-case — 3 × (150 + 30 + 30) = 630 against a 708 per-pod cap — is tighter than #5497 claimed, but still clear. It still doesn't bound run workers: they mount the same ConfigMap and inherit the same ceilings, and aren't exempt from the per-pod cap just for being short-lived. The updated comment says so explicitly rather than asserting a safety margin the data doesn't support — the only measurement available (QA's ~22 connections/worker) comes from an incident, not steady state.

### How can this be tested?
```
pulumi preview -s Production --diff
```
shows only `event_log_storage.config.pool_size: 10 => 100` and `max_overflow: 10 => 50` (unchanged from #5497 — Production keeps its number, now via explicit config instead of a literal).

```
pulumi preview -s QA --diff
```
shows `event_log_storage.config.pool_size: 100 => 10` and `max_overflow: 50 => 10` — QA drops back to the safe pre-incident size, which is the actual fix. `run_storage`/`schedule_storage` show no diff on QA (already at 15/15 from #5497, and that number was never stack-risky).

`pre-commit run --files src/ol_infrastructure/applications/dagster/dagster_instance.yaml src/ol_infrastructure/applications/dagster/__main__.py src/ol_infrastructure/applications/dagster/Pulumi.Production.yaml` is clean.

### Additional Context
Original incident and fix: #5490, #5497. Test coverage for the pooled storage classes: https://github.com/mitodl/ol-data-platform/pull/2572.
