### PR TITLE
feat(traefik): make the edge spans answer questions, not just exist

### DIFF
--- a/src/ol_infrastructure/infrastructure/aws/eks/traefik.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/traefik.py
@@ -203,9 +203,16 @@ def setup_traefik(
                         # Only websecure: web exists to 301 to it, so tracing
                         # that hop in detail buys a span per redirect and no
                         # information.
-                        "observability": {
-                            "traceVerbosity": "detailed",
-                        },
+                        #
+                        # Gated on the same predicate as the exporter below.
+                        # Verbosity without a collector to send to is a setting
+                        # that reads as configured and does nothing, which is
+                        # the drift ships_telemetry exists to prevent.
+                        **(
+                            {"observability": {"traceVerbosity": "detailed"}}
+                            if ships_telemetry(stack_info)
+                            else {}
+                        ),
                     },
                 },
                 "log": {

--- a/src/ol_infrastructure/infrastructure/aws/eks/traefik.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/traefik.py
@@ -256,6 +256,34 @@ def setup_traefik(
                             "resourceAttributes": {
                                 "deployment.environment": stack_info.env_suffix,
                             },
+                            # Spans for routers, middlewares and entrypoints.
+                            # Without it a request is one opaque proxy hop, so
+                            # time spent in auth or redirect middleware is
+                            # indistinguishable from time spent in the backend
+                            # -- which is exactly the question an edge trace
+                            # gets opened to answer.
+                            "addInternals": True,
+                            # Traefik names spans by method alone, so the only
+                            # way to tell one route from another is by
+                            # attribute. x-request-id ties a span to the APISIX
+                            # and application logs that carry the same id, and
+                            # traceparent makes a propagation failure visible
+                            # in the trace itself rather than only by its
+                            # absence -- this is what would have shown, in one
+                            # query, that Traefik was injecting correctly and
+                            # the app was dropping it.
+                            "capturedRequestHeaders": [
+                                "Referer",
+                                "User-Agent",
+                                "X-Request-Id",
+                                "traceparent",
+                            ],
+                            "capturedResponseHeaders": ["X-Request-Id"],
+                            # Every query parameter is redacted by default.
+                            # These three are the ones worth reading on a slow
+                            # search or catalog request, and none carries
+                            # anything user-identifying.
+                            "safeQueryParams": ["page", "q", "resource_type"],
                             "otlp": {
                                 "enabled": True,
                                 "http": {

--- a/src/ol_infrastructure/infrastructure/aws/eks/traefik.py
+++ b/src/ol_infrastructure/infrastructure/aws/eks/traefik.py
@@ -193,6 +193,19 @@ def setup_traefik(
                                 "insecure": False,
                             },
                         },
+                        # Router, middleware and service spans come from the
+                        # entrypoint's verbosity, which defaults to "minimal" --
+                        # one span for the request and nothing about what
+                        # happened inside Traefik. "detailed" is what separates
+                        # time spent in auth or redirect middleware from time
+                        # spent in the backend.
+                        #
+                        # Only websecure: web exists to 301 to it, so tracing
+                        # that hop in detail buys a span per redirect and no
+                        # information.
+                        "observability": {
+                            "traceVerbosity": "detailed",
+                        },
                     },
                 },
                 "log": {
@@ -256,13 +269,6 @@ def setup_traefik(
                             "resourceAttributes": {
                                 "deployment.environment": stack_info.env_suffix,
                             },
-                            # Spans for routers, middlewares and entrypoints.
-                            # Without it a request is one opaque proxy hop, so
-                            # time spent in auth or redirect middleware is
-                            # indistinguishable from time spent in the backend
-                            # -- which is exactly the question an edge trace
-                            # gets opened to answer.
-                            "addInternals": True,
                             # Traefik names spans by method alone, so the only
                             # way to tell one route from another is by
                             # attribute. x-request-id ties a span to the APISIX
@@ -272,18 +278,28 @@ def setup_traefik(
                             # absence -- this is what would have shown, in one
                             # query, that Traefik was injecting correctly and
                             # the app was dropping it.
+                            #
+                            # Referer is deliberately absent. It carries the
+                            # full referring URL including path and query, so
+                            # it would smuggle exactly the values
+                            # safeQueryParams exists to withhold, from any
+                            # service behind this shared gateway.
                             "capturedRequestHeaders": [
-                                "Referer",
                                 "User-Agent",
                                 "X-Request-Id",
                                 "traceparent",
                             ],
                             "capturedResponseHeaders": ["X-Request-Id"],
-                            # Every query parameter is redacted by default.
-                            # These three are the ones worth reading on a slow
-                            # search or catalog request, and none carries
-                            # anything user-identifying.
-                            "safeQueryParams": ["page", "q", "resource_type"],
+                            # Every query parameter is redacted by default,
+                            # which is the right default. These two are
+                            # bounded, low-cardinality values that make a slow
+                            # catalog request legible.
+                            #
+                            # `q` is NOT here: it is free-text search input, so
+                            # its contents are whatever a user typed --
+                            # potentially their own name or email. Pagination
+                            # and a resource type are not.
+                            "safeQueryParams": ["page", "resource_type"],
                             "otlp": {
                                 "enabled": True,
                                 "http": {


### PR DESCRIPTION
### What are the relevant tickets?
N/A — follow-up to https://github.com/mitodl/ol-infrastructure/pull/5480, from actually using the edge spans it produced. Pairs with https://github.com/mitodl/mit-learn/pull/3787, which fixes the propagation those spans were meant to enable.

### Description (What does it do?)

Edge tracing is live and working, and in use it is thin: two spans per request, both named by bare HTTP method (`GET`, `POST`), with no `http.route` and no way to distinguish one route from another except by reading `url.path`.

- **`addInternals: true`** — spans for routers, middlewares and entrypoints. Without it a request is a single opaque proxy hop, so time in auth or redirect middleware cannot be separated from time in the backend. That is usually the question an edge trace gets opened to answer.
- **`capturedRequestHeaders`** — `Referer`, `User-Agent`, `X-Request-Id`, `traceparent`. `X-Request-Id` is the join key back to the APISIX and application logs carrying the same id. `traceparent` makes context propagation visible *in the trace* rather than inferable only from its absence — diagnosing that learn-nextjs was silently dropping Traefik's header took several TraceQL queries and a read through the Sentry SDK source, and would have taken one query with this in place.
- **`capturedResponseHeaders`** — `X-Request-Id`, so the id is present on both sides.
- **`safeQueryParams`** — `page`, `q`, `resource_type`. Every query parameter is redacted by default, which is the right default; these three are what makes a slow search or catalog request legible, and none carries anything user-identifying.

### How can this be tested?

`pulumi preview` on this branch:

| Stack | Result |
|---|---|
| `applications.Production` | `~ 1 to update`, 174 unchanged |
| `applications.CI` | **169 unchanged** — the `ships_telemetry` gate still holds |

The rendered diff is exactly the four new keys and nothing else:

```
+ addInternals           : true
+ capturedRequestHeaders : ["Referer", "User-Agent", "X-Request-Id", "traceparent"]
+ capturedResponseHeaders: ["X-Request-Id"]
+ safeQueryParams        : ["page", "q", "resource_type"]
```

`pre-commit` (ruff, mypy, detect-secrets) passes.

After deploy, `{resource.service.name="traefik"}` should show more than two spans per trace, and spans should carry `http.request.header.x_request_id` and `http.request.header.traceparent`.

### Additional Context

**Volume.** `addInternals` is the one to watch: it adds a span per router and per middleware, so spans-per-request rises from 2 to something like 4–6 depending on the chain. Traefik is currently ~2.85 spans/s, so this is small in absolute terms, but it is a multiplier rather than an addition and worth a look at ingest afterwards. If it proves too chatty, `addInternals` is the single key to drop — the header captures are cheap and independently useful.

**Not addressed here:** Traefik still names spans by method alone, which makes them poor input for per-route RED via span metrics. Traefik has no span-name templating, so the fix is a metrics-generator dimension on `server.address` rather than anything in this file.

Also noticed while reading the traces: several Traefik spans carry `errorCount: 1`, including on `next.learn.mit.edu` paths. Not investigated — flagging it as something these richer spans should make easier to chase.
