### PR TITLE
docs(rootly): record W0 route-rule drift and why CI urgency stays High

### DIFF
--- a/src/ol_infrastructure/saas/rootly/__main__.py
+++ b/src/ol_infrastructure/saas/rootly/__main__.py
@@ -3010,6 +3010,17 @@ alerts_source_grafana_prometheus_ci = rootly.AlertsSource(
         {"alertFieldId": "4a3add3c-5611-4dd9-ba65-4fb60b7f4fc6"},
         {"alertFieldId": "45a09cf3-b0f2-43cf-b596-34aaab9279dc"},
     ],
+    # Deliberately left at High, not Low. Demoting to Low is unsafe as a
+    # belt-and-braces fallback here: on the Default Escalation Policy's Low
+    # Urgency path (notification_type=quiet), at least one on-call
+    # engineer's personal notification rules have quiet/audible inverted --
+    # quiet triggers an immediate phone call where audible does not. If
+    # W0's route rule (see the AlertRoute below) is ever disabled, CI
+    # alerts falling through to the Default Escalation Policy at Low would
+    # page that person harder than the current High/audible setting does.
+    # Fix the inverted per-user rule first, or route-fix instead of
+    # urgency-demote, before changing this. See
+    # tk-make-severity-mean-something-split-warning-criti-27f976.
     alert_urgency_id="5d357977-9dbe-42ad-b647-5a442cab3d96",
     deduplication_key_kind="payload",
     name="Grafana Prometheus - CI",
@@ -3154,6 +3165,13 @@ escalation_level_ci_qa_slack_notifications = rootly.EscalationLevel(
     opts=rootly_opts,
 )
 
+# `AlertRouteRuleArgs` has no `enabled` field, so Pulumi cannot manage or
+# detect whether the fallback rule below is toggled on. It shipped disabled
+# on both this route and the QA one below (2026-07-22), which made the
+# Slack diversion a no-op until 2026-08-18 -- CI/QA alerts fell through to
+# the paging default policy the whole time. Re-verify via `GET
+# /v1/alert_routes` -> `.rules[].enabled == true` for these two routes if
+# CI/QA paging noise reappears.
 alert_route_grafana_prometheus_ci_slack_warnings_route = rootly.AlertRoute(
     "grafana-prometheus-ci-slack-warnings-route",
     alerts_source_ids=[alerts_source_grafana_prometheus_ci.id],


### PR DESCRIPTION
### What are the relevant tickets?

N/A — tracked in witan as `tk-make-severity-mean-something-split-warning-criti-27f976` (W2a investigation), from `docs/plans/grafana-alerting-remediation-spec.md`. Companion to #5354, which shipped the Low-urgency off-hours deferral path.

### Description (What does it do?)

**No behavior change.** This started as a change to CI's Grafana `AlertsSource` urgency (High → Low), proposed as belt-and-braces alongside W0 (enabling the CI/QA → Slack route rules, done directly via the Rootly API since `AlertRouteRuleArgs` has no `enabled` field to manage it through Pulumi).

That urgency change turned out to be unsafe and was reverted before merge. The task's own investigation (recorded 2026-08-10, before this session) found that on the Default Escalation Policy's `Low Urgency` path (`notification_type: quiet`), at least one on-call engineer's personal Rootly notification rules have quiet/audible inverted — `quiet` triggers an immediate phone call where `audible` does not. If W0's route rule is ever disabled again, CI alerts falling through to the Default Escalation Policy at Low urgency would page that person harder than today's High/audible setting does. Demoting urgency is not a reliable way to stop paging when per-user notification rules aren't accounted for.

What ships here instead is documentation only:
- A comment on `alerts_source_grafana_prometheus_ci` recording why the urgency was deliberately left at High, so this isn't re-attempted without first fixing the inverted per-user rule or choosing a routing-only fix.
- A comment above the two `AlertRoute` resources recording that their fallback rules' `enabled` flag is unmanaged by Pulumi, and shipped disabled from 2026-07-22 (#5082) until 2026-08-18, when it was toggled on directly via the Rootly API.

### How can this be tested?

`pulumi preview --stack Production` shows **no resource diff** from this PR — comment-only change. (The preview does show pre-existing, unrelated drift already on `main`: the `cloudwatch-critical`/`cloudwatch-warning` `deduplicateAlertsByKey` diff flagged in #5354, and an alertname-list reorder/rename on `grafana-prometheus-production`'s urgency rules. Neither originates here.)

`ruff`, `mypy`, and the full pre-commit suite pass.

### Additional Context

Live state (not part of this diff, already applied directly via the Rootly API): both CI and QA `Slack Warnings Route` fallback rules are now `enabled: true`, so CI/QA Grafana alerts route to `#devops-warnings` instead of falling through to the paging Default Escalation Policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9kFbjWEuRxvySpu139vtN