### PR TITLE
docs(rootly): fix contradictory routing-status comment (#5502 follow-up)

### DIFF
--- a/src/ol_infrastructure/saas/rootly/__main__.py
+++ b/src/ol_infrastructure/saas/rootly/__main__.py
@@ -3133,14 +3133,18 @@ alerts_source_grafana_prometheus_qa = rootly.AlertsSource(
     opts=rootly_alert_source_opts,
 )
 
-# CI/QA alerts currently have no effective routing to any Slack-visible
-# destination (confirmed against the live Rootly account), unlike Production,
-# which has two catch-all routes. So these alerts aren't cluttering
-# #devops-alerts today -- they're most likely not reaching Slack anywhere.
-# This adds a real route for both, additive alongside whatever else (if
-# anything) exists per source, per Rootly's own guidance: alerts fan out
-# across every route connected to their source, so adding a second route
-# here doesn't disturb any other existing routing.
+# As of 2026-07-22 (when this was added), CI/QA alerts had no effective
+# routing to any Slack-visible destination (confirmed against the live
+# Rootly account), unlike Production, which has two catch-all routes -- so
+# they weren't cluttering #devops-alerts, but were most likely not reaching
+# Slack anywhere either. This adds a real route for both, additive alongside
+# whatever else (if anything) exists per source, per Rootly's own guidance:
+# alerts fan out across every route connected to their source, so adding a
+# second route here doesn't disturb any other existing routing.
+#
+# That route's fallback rule then shipped disabled until 2026-08-18 -- see
+# the AlertRoute resources below -- so the "no effective routing" gap
+# persisted well past this comment being written. It's closed now.
 #
 # Per Rootly support: the recommended way to target a Slack channel is via an
 # EscalationPolicy whose level notifies the channel directly (as opposed to


### PR DESCRIPTION
### What are the relevant tickets?

N/A — follow-up to #5502, which merged before this review comment could be addressed on it.

### Description (What does it do?)

Copilot's review on #5502 (posted 17:56:44Z) flagged a real inconsistency, but the PR auto-merged at 17:57:13Z before it could be addressed there: the comment above `escalation_policy_ci_qa_slack_notifications` (written 2026-07-22, describing why that policy was added) still said CI/QA alerts have no effective routing and aren't reaching Slack. That directly contradicts #5502's own new comment above the `AlertRoute` resources, which documents that the fallback rule is now enabled.

Reworded the older comment to past tense and cross-referenced the newer one, so a future reader doesn't hit two comments in the same file giving opposite guidance about whether these alerts currently reach Slack.

No resource changes — comment only.

### How can this be tested?

`pulumi preview --stack Production` shows no diff from this change. (It does show 2 pre-existing, unrelated resources with drift — `escalationLevel`/`escalationPath` for the Low Urgency off-hours deferral path from #5354 — neither touched by this PR.)

`ruff`, `mypy`, and the full pre-commit suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9kFbjWEuRxvySpu139vtN
