### PR TITLE
feat(concourse): gate singleton stacks and keycloak on preview-gated topology

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/keycloak/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/keycloak/pipeline.py
@@ -58,6 +58,8 @@ def build_keycloak_substructure_pipeline() -> PipelineFragment:
         stack_names=["CI", "QA", "Production"],
         project_name="ol-substructure-keycloak",
         project_source_path=PULUMI_CODE_PATH.joinpath("substructure/keycloak/"),
+        topology="preview-gated",
+        auto_deploy_stages=["CI"],
     )
     substructure_fragment.resources.append(keycloak_pulumi_code)
     return substructure_fragment
@@ -258,6 +260,8 @@ def build_keycloak_infrastructure_pipeline() -> PipelineFragment:
         additional_env_vars={
             "KEYCLOAK_DOCKER_DIGEST": "((.:image_digest))",
         },
+        topology="preview-gated",
+        auto_deploy_stages=["CI"],
     )
 
     combined_fragments = PipelineFragment.combine_fragments(

--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
@@ -455,6 +455,7 @@ pipeline_params: dict[str, SimplePulumiParams] = {
         pulumi_project_path="infrastructure/sentry/",
         pulumi_project_name="ol-infrastructure-sentry",
         stages=["default"],
+        topology="preview-gated",
     ),
     "starrocks": SimplePulumiParams(
         app_name="starrocks",
@@ -478,6 +479,7 @@ pipeline_params: dict[str, SimplePulumiParams] = {
         ],
         stages=["Production"],
         prior_stage_stack="lakehouse.QA",
+        topology="preview-gated",
     ),
     "starrocks-substructure-qa": SimplePulumiParams(
         app_name="starrocks_substructure",
@@ -487,6 +489,7 @@ pipeline_params: dict[str, SimplePulumiParams] = {
             "lakehouse",
         ],
         stages=["QA"],
+        topology="preview-gated",
     ),
     "starrocks-substructure-ci": SimplePulumiParams(
         app_name="starrocks_substructure",
@@ -537,6 +540,7 @@ pipeline_params: dict[str, SimplePulumiParams] = {
         pulumi_project_path="infrastructure/aws/ecr/",
         pulumi_project_name="ol-infrastructure-ecr",
         stages=["default"],
+        topology="preview-gated",
     ),
     "aws-sftp": SimplePulumiParams(
         app_name="aws-sftp",
@@ -558,24 +562,28 @@ pipeline_params: dict[str, SimplePulumiParams] = {
         pulumi_project_path="infrastructure/monitoring/",
         pulumi_project_name="ol-infrastructure-monitoring",
         stages=["default"],
+        topology="preview-gated",
     ),
     "starburst": SimplePulumiParams(
         app_name="starburst",
         pulumi_project_path="applications/starburst/",
         pulumi_project_name="ol-application-starburst",
         stages=["Production"],
+        topology="preview-gated",
     ),
     "xpro-partner-dns": SimplePulumiParams(
         app_name="xpro-partner-dns",
         pulumi_project_path="substructure/xpro_partner_dns/",
         pulumi_project_name="ol-substructure-xpro-partner-dns",
         stages=["default"],
+        topology="preview-gated",
     ),
     "release-bot": SimplePulumiParams(
         app_name="release-bot",
         pulumi_project_path="applications/release_bot/",
         pulumi_project_name="ol-infrastructure-release-bot",
         stages=["default"],
+        topology="preview-gated",
         # __main__.py is a singleton (stack "default") and always creates the
         # ECR repository named "release-bot-production" regardless of stage.
         docker_image=DockerImageConfig(


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

Extends `topology="preview-gated"` (introduced for `rootly` in #5505) to the rest of the stacks that were auto-deploying with no meaningful gate:

**Singleton stacks** (single-stage — no "next stage" to promote onward to, so `deploy-chained` topology gave these zero gate at all): `sentry`, `aws-ecr`, `monitoring`, `starburst`, `xpro-partner-dns`, `release-bot`.

**`starrocks-substructure` / `starrocks-substructure-qa`**: also single-stage per Concourse environment — QA runs on `odl-qa`, Production on `odl-prod`, chained across environments via `prior_stage_stack`. `starrocks-substructure-ci` is left on `deploy-chained` — it's the CI stage, gating it would cost the fast feedback loop it exists for.

**Keycloak** (`src/ol_concourse/pipelines/infrastructure/keycloak/pipeline.py`, both the substructure and application/build+deploy pipelines): not a singleton — this one's requested explicitly rather than falling out of the singleton sweep, since it's core auth infrastructure and was auto-deploying to Production on every merge with zero human gate. QA and Production move to `preview-gated`; CI stays auto-deploy via `auto_deploy_stages=["CI"]`, same convention as the rest of this PR.

### How can this be tested?

Read `ol_concourse.lib.jobs.infrastructure` (the installed `ol-concourse` package, not part of this repo) to confirm `preview-gated` composes safely with `prior_stage_stack`: `custom_dependencies` — how `prior_stage_stack` is threaded through — is applied per stage index uniformly regardless of topology. The `preview-gated` docstring explicitly names this exact cross-Concourse-environment, single-stage-per-chain case as the reason self-preview (gate each stack on a preview of itself) replaced the retired next-stage-preview approach.

Verified for each changed app:
- `python pipeline.py <app>` builds standalone for all 9 changed `simple_pulumi` entries (6 singletons + the starrocks-substructure trio), producing the expected `preview-<project>-<stage>` / `deploy-<project>-<stage>` job pairs. `starrocks-substructure-ci` is unchanged — still a single auto-deploy job.
- `release-bot` (the one entry with `docker_image`/`build`) builds its `build-release-bot-image` job unchanged, feeding into the new preview job as a dependency, same as before.
- `python pipeline.py` (keycloak) builds both pipelines cleanly: `deploy-*-ci` unchanged (auto-deploy), `preview-*-qa`/`deploy-*-qa` and `preview-*-production`/`deploy-*-production` newly gated.
- `meta.py --env production` builds the full production meta-pipeline cleanly with all changed apps in the roster — no duplicate job names, no errors.
- `uv run pre-commit run` passes on both changed files (ruff, mypy included).

Not yet deployed to Concourse — the meta-pipeline needs to pick this up before the new gated jobs exist, same as #5505.

### Additional Context

- **Behavior change worth flagging explicitly**: after this deploys, the 6 singleton apps, `starrocks-substructure`'s Production stage, `starrocks-substructure-qa`, and Keycloak's QA/Production stages will no longer auto-apply on merge. A gate issue opens instead, carrying that stage's `pulumi preview` diff; closing it triggers the deploy. This is the same deliberate tightening as #5505, just applied more broadly — worth surfacing since it changes team workflow for these apps.
- **Deliberately not gating CI**: `starrocks-substructure-ci` and both Keycloak pipelines' CI stages stay on fast auto-deploy (`auto_deploy_stages=["CI"]` for Keycloak) — matching the convention already documented in `pulumi_jobs_chain`'s docstring for why CI is typically exempted from gating.
- **Not included**: apps with a real CI → QA → Production ladder (or multiple `deployment_groups`) were left alone — those already get a gate via the previous stage's promotion issue under `deploy-chained`, so `preview-gated` isn't filling a gap for them the way it is here.
