### PR TITLE
fix(grafana-alerting): set exec_err_state explicitly on the remaining rules

### DIFF
--- a/src/ol_infrastructure/infrastructure/grafana_alerting/log_rules/apisix_oidc.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/log_rules/apisix_oidc.py
@@ -164,6 +164,7 @@ def create(
                 condition="C",
                 for_="15m",
                 no_data_state="OK",
+                exec_err_state="OK",
                 # No severity label: routes to `oblivion` while calibrating.
                 # See the module docstring.
                 labels={},
@@ -178,6 +179,7 @@ def create(
                 condition="C",
                 for_="1h",
                 no_data_state="OK",
+                exec_err_state="OK",
                 labels={},
                 annotations={
                     "summary": "{{ $labels.matched_host }} OIDC callback 500 rate has been over 5% for hours",

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/log_rules/base.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/log_rules/base.py
@@ -34,6 +34,12 @@ Differences from the original YAML
   Loki tenant; rules filtered to production clusters return no data on CI/QA
   stacks and vice versa. OK keeps those rules silent rather than surfacing
   NoData alerts.
+- exec_err_state is set explicitly on every rule, same reasoning as
+  metric_rules: left unset it silently defaults to "Alerting", so a
+  transient datasource blip pages like a real incident. "OK" for
+  warning-tier rules, "KeepLast" for critical-tier rules. See
+  metric_rules/eks_general.py's docstring for the incident that prompted
+  this.
 
 Sub-modules
 -----------

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/log_rules/cert_manager.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/log_rules/cert_manager.py
@@ -32,6 +32,7 @@ def create(
                 condition="C",
                 for_="20m",
                 no_data_state="OK",
+                exec_err_state="KeepLast",
                 labels={"severity": "critical", "environment": "production"},
                 annotations={
                     "description": "cert-manager in {{ $labels.cluster }} cannot reach the ACME issuer outside of the expected pod startup initialization window. All certificate renewals are blocked until resolved.",
@@ -51,6 +52,7 @@ def create(
                 condition="C",
                 for_="5m",
                 no_data_state="OK",
+                exec_err_state="KeepLast",
                 labels={"severity": "critical", "environment": "production"},
                 annotations={
                     "description": "cert-manager in {{ $labels.cluster }} is failing to present ACME DNS-01 challenges. Certificate issuance will fail until resolved.",
@@ -80,6 +82,7 @@ def create(
                 condition="C",
                 for_="20m",
                 no_data_state="OK",
+                exec_err_state="OK",
                 labels={"severity": "warning", "environment": "non-production"},
                 annotations={
                     "description": "cert-manager in {{ $labels.cluster }} cannot reach the ACME issuer outside of the expected pod startup initialization window. Certificate renewals are blocked in this environment.",
@@ -99,6 +102,7 @@ def create(
                 condition="C",
                 for_="5m",
                 no_data_state="OK",
+                exec_err_state="OK",
                 labels={"severity": "warning", "environment": "non-production"},
                 annotations={
                     "description": "cert-manager in {{ $labels.cluster }} is failing to present ACME DNS-01 challenges. Certificate issuance will fail until resolved.",

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/log_rules/dagster_database.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/log_rules/dagster_database.py
@@ -105,6 +105,7 @@ def create(
                 condition="C",
                 for_="15m",
                 no_data_state="OK",
+                exec_err_state="OK",
                 labels={"severity": "warning", "environment": "non-production"},
                 annotations={
                     "summary": _SUMMARY,
@@ -124,6 +125,7 @@ def create(
                 condition="C",
                 for_="15m",
                 no_data_state="OK",
+                exec_err_state="KeepLast",
                 labels={"severity": "critical", "environment": "production"},
                 annotations={
                     "summary": _SUMMARY,

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/log_rules/edxapp.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/log_rules/edxapp.py
@@ -26,6 +26,7 @@ def create(
                 condition="C",
                 for_="5m",
                 no_data_state="OK",
+                exec_err_state="KeepLast",
                 labels={"severity": "critical"},
                 annotations={
                     "description": "High rate of 500 errors on mitxonline-production.",
@@ -54,6 +55,7 @@ def create(
                 condition="C",
                 for_="1m",
                 no_data_state="OK",
+                exec_err_state="KeepLast",
                 labels={"severity": "critical"},
                 annotations={
                     "description": "Redis is returning OOM errors to edxapp in {{ $labels.environment }}.",
@@ -69,6 +71,7 @@ def create(
                 condition="C",
                 for_="1m",
                 no_data_state="OK",
+                exec_err_state="OK",
                 labels={"severity": "warning"},
                 annotations={
                     "description": "Redis is returning OOM errors to edxapp in {{ $labels.environment }}.",
@@ -84,6 +87,7 @@ def create(
                 condition="C",
                 for_="1m",
                 no_data_state="OK",
+                exec_err_state="KeepLast",
                 labels={"severity": "critical"},
                 annotations={
                     "description": "A credential issue has been detected in {{ $labels.environment }}.",
@@ -99,6 +103,7 @@ def create(
                 condition="C",
                 for_="1m",
                 no_data_state="OK",
+                exec_err_state="OK",
                 labels={"severity": "warning"},
                 annotations={
                     "description": "A credential issue has been detected in {{ $labels.environment }}.",
@@ -124,6 +129,7 @@ def create(
                 condition="C",
                 for_="1m",
                 no_data_state="OK",
+                exec_err_state="KeepLast",
                 labels={"severity": "critical"},
                 annotations={
                     "description": "edxapp {{ $labels.environment }} is having trouble communicating with the forum service.",
@@ -139,6 +145,7 @@ def create(
                 condition="C",
                 for_="1m",
                 no_data_state="OK",
+                exec_err_state="OK",
                 labels={"severity": "warning"},
                 annotations={
                     "description": "edxapp {{ $labels.environment }} is having trouble communicating with the forum service.",
@@ -154,6 +161,7 @@ def create(
                 condition="C",
                 for_="1m",
                 no_data_state="OK",
+                exec_err_state="KeepLast",
                 labels={"severity": "critical"},
                 annotations={
                     "description": "A SAML configuration error has been detected in {{ $labels.application }} {{ $labels.environment }}.",
@@ -175,6 +183,7 @@ def create(
                 condition="C",
                 for_="1m",
                 no_data_state="OK",
+                exec_err_state="OK",
                 labels={"severity": "warning"},
                 annotations={
                     "description": "A SAML configuration error has been detected in {{ $labels.application }} {{ $labels.environment }}.",

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/log_rules/heroku.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/log_rules/heroku.py
@@ -33,6 +33,7 @@ def create(
                 condition="C",
                 for_="1m",
                 no_data_state="OK",
+                exec_err_state="KeepLast",
                 labels={"severity": "critical"},
                 annotations={
                     "description": "An invalid aws key has been detected in {{ $labels.application }} {{ $labels.environment }}.",
@@ -47,6 +48,7 @@ def create(
                 condition="C",
                 for_="1m",
                 no_data_state="OK",
+                exec_err_state="OK",
                 labels={"severity": "warning"},
                 annotations={
                     "description": "An invalid aws key has been detected in {{ $labels.application }} {{ $labels.environment }}.",
@@ -61,6 +63,7 @@ def create(
                 condition="C",
                 for_="1m",
                 no_data_state="OK",
+                exec_err_state="KeepLast",
                 labels={"severity": "critical"},
                 annotations={
                     "description": "An invalid aws key has been detected in {{ $labels.application }} {{ $labels.environment }}.",
@@ -75,6 +78,7 @@ def create(
                 condition="C",
                 for_="1m",
                 no_data_state="OK",
+                exec_err_state="OK",
                 labels={"severity": "warning"},
                 annotations={
                     "description": "An invalid aws key has been detected in {{ $labels.application }} {{ $labels.environment }}.",
@@ -99,6 +103,7 @@ def create(
                 condition="C",
                 for_="1m",
                 no_data_state="OK",
+                exec_err_state="OK",
                 labels={"severity": "warning", "channel": "notifications-ocw-misc"},
                 annotations={
                     "description": "A 3play transcript request has failed in NonProduction.",
@@ -113,6 +118,7 @@ def create(
                 condition="C",
                 for_="1m",
                 no_data_state="OK",
+                exec_err_state="OK",
                 labels={"severity": "warning", "channel": "notifications-ocw-misc"},
                 annotations={
                     "description": "A 3play transcript request has failed in Production.",
@@ -127,6 +133,7 @@ def create(
                 condition="C",
                 for_="1m",
                 no_data_state="OK",
+                exec_err_state="OK",
                 labels={"severity": "warning"},
                 annotations={
                     "description": "An invalid username and password message was detected from content sync. This refers to the password used by OCW to talk to concourse.",
@@ -141,6 +148,7 @@ def create(
                 condition="C",
                 for_="1m",
                 no_data_state="OK",
+                exec_err_state="KeepLast",
                 labels={"severity": "critical"},
                 annotations={
                     "description": "An invalid username and password message was detected from content sync. This refers to the password used by OCW to talk to concourse.",
@@ -165,6 +173,7 @@ def create(
                 condition="C",
                 for_="1m",
                 no_data_state="OK",
+                exec_err_state="KeepLast",
                 labels={"severity": "critical"},
                 annotations={
                     "description": "Keycloak has responded with a 500 error which is likely caused by a customization or configuration change.",
@@ -178,6 +187,7 @@ def create(
                 condition="C",
                 for_="1m",
                 no_data_state="OK",
+                exec_err_state="OK",
                 labels={"severity": "warning"},
                 annotations={
                     "description": "Keycloak is unable to decrypt a SAML assertion likely caused by an internal or external configuration change.",
@@ -191,6 +201,7 @@ def create(
                 condition="C",
                 for_="1m",
                 no_data_state="OK",
+                exec_err_state="KeepLast",
                 labels={"severity": "critical"},
                 annotations={
                     "description": "Keycloak experienced an error condition that is likely the result of a customization.",

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/log_rules/mit_learn.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/log_rules/mit_learn.py
@@ -29,6 +29,7 @@ def create(
                 condition="C",
                 for_="5m",
                 no_data_state="OK",
+                exec_err_state="KeepLast",
                 labels={"severity": "critical", "service": "mitxonline"},
                 annotations={
                     "description": "An increase in 5xx errors that may indicate an issue with mitxonline",
@@ -48,6 +49,7 @@ def create(
                 condition="C",
                 for_="5m",
                 no_data_state="OK",
+                exec_err_state="KeepLast",
                 labels={"severity": "critical", "service": "mitlearn"},
                 annotations={
                     "description": "An increase in 5xx errors that may indicate an issue with mitlearn",

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/log_rules/vault.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/log_rules/vault.py
@@ -26,6 +26,7 @@ def create(
                 condition="C",
                 for_="5m",
                 no_data_state="OK",
+                exec_err_state="KeepLast",
                 labels={"severity": "critical"},
                 annotations={
                     "description": "A Vault or Consul template is attempting to retrieve a secret that doesn't exist. Investigate the possibility of a misconfiguration or an accidentally deleted value.",
@@ -40,6 +41,7 @@ def create(
                 condition="C",
                 for_="5m",
                 no_data_state="OK",
+                exec_err_state="KeepLast",
                 labels={"severity": "critical"},
                 annotations={
                     "description": "A Vault client is having errors authenticating against the vault servers.",

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/apisix_edge.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/apisix_edge.py
@@ -111,6 +111,7 @@ def create(
                 condition="C",
                 for_="5m",
                 no_data_state="OK",
+                exec_err_state="OK",
                 # No severity label: routes to `oblivion` while calibrating.
                 # See the module docstring.
                 labels={},
@@ -125,6 +126,7 @@ def create(
                 condition="C",
                 for_="30m",
                 no_data_state="OK",
+                exec_err_state="OK",
                 labels={},
                 annotations={
                     "summary": "{{ $labels.matched_host }} has been returning over 1% 5xx for hours",

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/base.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/base.py
@@ -32,6 +32,18 @@ tenant, which only has metrics from the matching environment's clusters. When
 the selector returns no data (e.g. the production filter on the CI stack),
 no_data_state="OK" keeps the rule silent instead of surfacing a NoData alert.
 
+exec_err_state
+---------------
+Distinct from no_data_state: this fires on a query-evaluation *failure* (e.g.
+a transient datasource blip), not on an empty result set. Left unset, it
+silently defaults to Grafana's "Alerting" -- a datasource hiccup then pages
+like a real incident on every affected rule. Every rule here sets it
+explicitly: "OK" for warning-tier rules (going silent during an error is an
+acceptable trade), "KeepLast" for critical-tier rules (holds the rule's last
+known state through the error instead of either paging on a blip or going
+silent through a genuine ongoing incident). See eks_general.py's docstring
+for the incident that prompted this.
+
 Sub-modules
 -----------
   eks_general  — Source: grafana-alerts/cortex-rules/eks_general.yaml

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/dagster_pgbouncer.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/dagster_pgbouncer.py
@@ -125,6 +125,7 @@ def create(
                 condition="C",
                 for_="15m",
                 no_data_state="OK",
+                exec_err_state="OK",
                 labels={"severity": "warning"},
                 annotations={
                     "summary": "Dagster PgBouncer in cluster {{ $labels.cluster }} is holding {{ $value }} of its aggregate connection cap",
@@ -144,6 +145,7 @@ def create(
                 condition="C",
                 for_="15m",
                 no_data_state="OK",
+                exec_err_state="KeepLast",
                 labels={"severity": "critical"},
                 annotations={
                     "summary": "Dagster PgBouncer in cluster {{ $labels.cluster }} is holding {{ $value }} of its aggregate connection cap",
@@ -178,6 +180,7 @@ def create(
                 condition="C",
                 for_="10m",
                 no_data_state="OK",
+                exec_err_state="OK",
                 labels={"severity": "warning"},
                 annotations={
                     "summary": "Dagster PgBouncer clients in cluster {{ $labels.cluster }} have been queued for {{ $value }}s waiting for a backend",
@@ -194,6 +197,7 @@ def create(
                 condition="C",
                 for_="10m",
                 no_data_state="OK",
+                exec_err_state="KeepLast",
                 labels={"severity": "critical"},
                 annotations={
                     "summary": "Dagster PgBouncer clients in cluster {{ $labels.cluster }} have been queued for {{ $value }}s waiting for a backend",
@@ -221,6 +225,7 @@ def create(
                 condition="C",
                 for_="15m",
                 no_data_state="OK",
+                exec_err_state="OK",
                 labels={"severity": "warning"},
                 annotations={
                     "summary": "Dagster PgBouncer in cluster {{ $labels.cluster }} is serving {{ $value }} new client connections per second",
@@ -238,6 +243,7 @@ def create(
                 condition="C",
                 for_="15m",
                 no_data_state="OK",
+                exec_err_state="KeepLast",
                 labels={"severity": "critical"},
                 annotations={
                     "summary": "Dagster PgBouncer in cluster {{ $labels.cluster }} is serving {{ $value }} new client connections per second",
@@ -274,6 +280,7 @@ def create(
                 condition="C",
                 for_="15m",
                 no_data_state="OK",
+                exec_err_state="OK",
                 labels={"severity": "warning"},
                 annotations={
                     "summary": "The pgbouncer_exporter sidecar on {{ $labels.pod }} cannot reach PgBouncer's admin console",

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/linux_host.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/linux_host.py
@@ -31,6 +31,7 @@ def create(
                 condition="C",
                 for_="6h",
                 no_data_state="OK",
+                exec_err_state="OK",
                 labels={"severity": "warning"},
                 annotations={
                     "description": 'CPU usage on {{ $labels.instance }} has been at {{ printf "%.2f" $value }} for at least 6 hours.'
@@ -58,6 +59,7 @@ def create(
                 condition="C",
                 for_="2h",
                 no_data_state="OK",
+                exec_err_state="OK",
                 labels={"severity": "warning"},
                 annotations={
                     "description": 'Memory usage on {{ $labels.instance }} has been at {{ printf "%.2f" $value }} for at least 2 hours.'
@@ -81,6 +83,7 @@ def create(
                 condition="C",
                 for_="1h",
                 no_data_state="OK",
+                exec_err_state="OK",
                 labels={"severity": "warning"},
                 annotations={
                     "description": 'Filesystem on {{ $labels.device }} at {{ $labels.instance }} is {{ printf "%.2f" $value }}% full.'
@@ -94,6 +97,7 @@ def create(
                 condition="C",
                 for_="10m",
                 no_data_state="OK",
+                exec_err_state="KeepLast",
                 labels={"severity": "critical"},
                 annotations={
                     "description": 'Filesystem on {{ $labels.device }} at {{ $labels.instance }} is {{ printf "%.2f" $value }}% full.'


### PR DESCRIPTION
### What are the relevant tickets?
N/A — tracked as tk-exec-err-state-is-never-set-every-grafana-rule-p-3aa620 in the alerting-remediation workflow project.

### Description (What does it do?)
`exec_err_state` (query-evaluation failure, distinct from `no_data_state`) was never set on most Grafana-managed rules, so it silently defaulted to Grafana's `"Alerting"`: a transient datasource blip (e.g. the 2026-07-09 CI provisioning race) escalates into a real, severity-labelled, Rootly-routed page for every rule that fails to evaluate.

This was already fixed for `metric_rules/eks_general.py` in #5503. This PR applies the same convention to everything else:
- `severity: warning` rules -> `exec_err_state="OK"` (going silent during an error is an acceptable trade for a warning-tier rule)
- `severity: critical` rules -> `exec_err_state="KeepLast"` (holds last known state through the error, instead of paging on a transient blip or silently clearing a genuine ongoing incident)
- The two calibration-mode APISIX rules (`apisix_edge.py`, no severity label yet, already routed to the non-paging `oblivion` receiver) -> `exec_err_state="OK"`

Files touched: `metric_rules/{linux_host,apisix_edge,dagster_pgbouncer,base}.py` and every module under `log_rules/` (`apisix_oidc`, `cert_manager`, `dagster_database`, `edxapp`, `heroku`, `mit_learn`, `vault`, `base`). 45 rules across 10 rule files get an explicit `exec_err_state`; the two `base.py` docstrings get a short paragraph documenting the convention so future rules don't reintroduce the silent default.

`metric_rules/synthetic_monitoring.py` already sets `exec_err_state="Error"` independently (from #5400) and is left alone.

Out of scope, tracked separately on the same task: a dedicated datasource-wide-outage canary rule, since neither `OK` nor `KeepLast` makes that failure mode visible on its own.

### How can this be tested?
- `pre-commit run --all-files` (ruff format/check, mypy) passes on all touched files.
- `pulumi preview` reviewed on all three stacks (CI, QA, Production): every diff is a pure in-place `execErrState: "Alerting" => "OK"|"KeepLast"` field update on existing `RuleGroup` resources, no replacements or deletions. Production additionally previews 3 unrelated pending creates (two Slack contact points, one `dagster-database-connections` rule group) from already-merged work not yet deployed — not introduced by this change.
- Deploy is via the `grafana-alerting` simple_pulumi Concourse pipeline; recommend verifying post-deploy against `GET /api/v1/provisioning/alert-rules` that a sample of the changed rules (e.g. `MitxOnline500Errors`, `DagsterPgBouncerConnectionHeadroomCritical`) show `execErrState: KeepLast`/`OK` as expected.

### Additional Context
Mirrors the reasoning documented in `metric_rules/eks_general.py`'s module docstring, which this PR points to from both `base.py` files rather than repeating.