### PR TITLE
fix(pulumi-sentry): skip stack refresh to avoid Sentry API rate limiting

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
@@ -456,6 +456,12 @@ pipeline_params: dict[str, SimplePulumiParams] = {
         pulumi_project_name="ol-infrastructure-sentry",
         stages=["default"],
         topology="preview-gated",
+        # The stack manages ~350 Sentry-API-backed resources (code mappings,
+        # dashboards). `pulumi refresh` fans out GETs for all of them at once,
+        # which blows past Sentry's per-org rate/concurrency limits (429s) and
+        # fails the deploy before `up` even runs. Skipping refresh avoids that
+        # burst; `up` still diffs/applies whatever it actually changes.
+        refresh_stack=False,
     ),
     "starrocks": SimplePulumiParams(
         app_name="starrocks",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
The `pulumi-sentry` deploy job (https://cicd.odl.mit.edu/teams/infrastructure/pipelines/pulumi-sentry/jobs/deploy-ol-infrastructure-sentry-default/builds/25) was failing repeatedly with Sentry API `429 Too Many Requests` errors.

The `sentry` Pulumi stack manages ~350 Sentry-API-backed resources (organization code mappings, dashboards). `pulumi refresh` fans out a GET for every one of them concurrently, which exceeds Sentry's per-org rate limit (40 req/s) and concurrency limit (25 in-flight) and fails the whole deploy before `pulumi up` even runs:

```
error:   sdk-v2/provider2.go:520: sdk.helper_schema: GET https://sentry.io/api/0/organizations/mit-office-of-digital-learning/code-mappings/?integrationId=29144: 429 You are attempting to use this endpoint too frequently. Limit is 40 requests in 1 seconds
```

10 of the last 25 `deploy-ol-infrastructure-sentry-default` builds failed this way.

This sets `refresh_stack=False` on the `sentry` `SimplePulumiParams` entry, which skips the refresh pass and lets `pulumi up` diff/apply only what it actually changes — the same pattern already used for `fastly-redirector` and `ocw-site` (`src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py`).

### How can this be tested?
- Confirmed the `refresh_stack=False` param is threaded through: generated the `sentry` pipeline JSON locally and verified the `deploy-ol-infrastructure-sentry-default` job's `pulumi-provisioner` put step carries `"refresh_stack": false` in its params.
- `pre-commit run` (ruff format/check, mypy, etc.) passes on the changed file.
- Not yet verified against a live re-run of the pipeline in Concourse — that happens once this merges and the pipeline is re-set.

### Additional Context
If `pulumi up` itself starts hitting 429s on stacks with real diffs (not just refresh), the next lever would be reducing per-operation resource count, e.g. splitting Sentry-managed resources into separate stacks — but that's a bigger change and not needed for this specific failure mode.