### PR TITLE
fix(mit_learn): lower OCW_ITERATOR_CHUNK_SIZE 300 -> 50 in production

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
@@ -106,7 +106,24 @@ config:
     MITX_ONLINE_COURSES_API_URL: "https://mitxonline.mit.edu/api/internal/courses/"
     MITX_ONLINE_PROGRAMS_API_URL: "https://mitxonline.mit.edu/api/v2/programs/"
     MITPE_API_ENABLED: "true"
-    OCW_ITERATOR_CHUNK_SIZE: 300
+    # Lowered 2026-08-17, 300 -> 50, to stop the default celery worker
+    # OOMKilling. This is the batch size get_ocw_data chunks by when it fans out
+    # get_ocw_courses tasks, so it sets how many OCW courses one task pulls from
+    # S3 and holds at once -- i.e. it is the dominant term in that task's peak
+    # RSS, and nothing else bounds it. Default workers idle at ~550Mi but were
+    # observed at 3.7-4.9Gi while running get_ocw_courses (two at a time, since
+    # the shared component hardcodes --concurrency=2), against a VPA-derived 6Gi
+    # limit: ~301 container restarts in 24h, exit 137. The worker's VPA is
+    # already pinned at its 3Gi max_allowed ceiling with an uncappedTarget of
+    # 5.15Gi, so it has no room left to absorb this -- raising memory again
+    # (#5142, #5152, #5162, #5321) would be the fifth such round. 50 cuts the
+    # per-task working set ~6x, which lands peak well under the existing limit
+    # without touching the ceiling. Chunking smaller costs more task dispatches,
+    # but KEDA already scales this queue to 20 replicas so throughput is
+    # unaffected. QA/CI still carry 300; they idle and have never OOMKilled.
+    # The durable fix belongs in mit-learn: ocw_courses_etl should stream a
+    # chunk rather than materialize it, so this value stops being load-bearing.
+    OCW_ITERATOR_CHUNK_SIZE: 50
     OCW_LIVE_BUCKET: "ocw-content-live-production"
     OIDC_ENDPOINT: "https://sso.ol.mit.edu/realms/olapps"
     OPENTELEMETRY_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/traces"


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
- Lowers `OCW_ITERATOR_CHUNK_SIZE` from 300 to 50, Production stack only. QA/CI keep 300 — they idle and have never OOMKilled.
- That value is the batch size `get_ocw_data` chunks by when it fans out `get_ocw_courses` tasks, so it sets how many OCW courses a single task pulls from S3 and holds at once. Nothing else bounds that task's peak RSS, which makes it the dominant term.

Why now — the default celery worker has been OOMKilling in production since 2026-08-13:

- ~301 `celery-worker` container restarts in 24h, exit 137, with the rate climbing from ~1/hr to ~20/hr. Zero OOMs in the 11 days before that.
- Workers idle at ~550Mi but were observed at 3.7–4.9Gi while running `learning_resources.tasks.get_ocw_courses` — two concurrently, since the shared component hardcodes `--concurrency=2`.
- The effective limit is 6Gi, not the 2560Mi declared in `__main__.py`: `mitlearn-default-celery-worker-vpa` (`InPlaceOrRecreate`, `RequestsAndLimits`) sets the request to its 3Gi `max_allowed` and scales the limit by the declared 2:1 ratio.

Why not raise memory again — the VPA is already pinned at its ceiling (`target` == `upperBound` == `max_allowed` == 3Gi) with an `uncappedTarget` of 5.15Gi, so it has no room left to absorb this. That would also be the fifth such round after #5142, #5152, #5162 and #5321. Cutting the chunk drops peak working set ~6x and lands it under the existing limit without moving the ceiling. The tradeoff is more task dispatches, but KEDA already scales this queue to 20 replicas.

### How can this be tested?
**Only `pre-commit` was run. This has not been deployed or verified in production.**

Run locally:

- `pre-commit run --files src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml` — passes (check yaml, Format YAML files, yamllint, detect-secrets).
- Confirmed the YAML parses and the value stays an `int` under `mitlearn:vars`. It feeds `chunks(chunk_size=settings.OCW_ITERATOR_CHUNK_SIZE)`, so a quoted string would break the fan-out.

Reviewer should run `pulumi preview` against the Production stack — I did not, as it needs stack auth. Blast radius is one env var on the app and celery worker pod templates, which will roll those deployments.

After deploy, watch:

- `container_memory_working_set_bytes{namespace="mitlearn", container="celery-worker", pod=~"mitlearn-default.*"}` — peak should drop from ~3.7–4.9Gi to well under the 6Gi limit.
- `increase(kube_pod_container_status_restarts_total{namespace="mitlearn", container="celery-worker"}[1h])` — should return to 0.
- Redis `default` queue depth, currently flat at ~380. `CELERY_TASK_ACKS_LATE` + `CELERY_TASK_REJECT_ON_WORKER_LOST` redeliver every OOMKilled task, so the backlog recycles rather than drains; it should actually drain once tasks stop dying.

If peak working set does not fall, the chunk is not the dominant term and the next lever is worker concurrency.

### Additional Context
This buys headroom rather than removing the cause. Onset correlates with the mit-learn 0.77.3 deploy (2026-08-13 13:05Z), but that release touches nothing in the OCW ETL path and `uv.lock` moved by 11 lines, and `OCW_ITERATOR_CHUNK_SIZE` has been 300 since July. The likelier trigger is OCW content volume crossing a threshold, which means the same drift can consume this headroom again. The durable fix belongs in mit-learn: `ocw_courses_etl` should stream a chunk rather than materialize it, so this value stops being load-bearing.

Found while investigating, deliberately not addressed here:

- `--concurrency=2` is hardcoded at [`k8s.py#L2080`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/components/services/k8s.py#L2080) and silently overrides the `CELERY_WORKER_CONCURRENCY=1` env var the same component sets. Worth reconciling regardless of this incident.
- The worker VPA has no headroom left (`uncappedTarget` 5.15Gi vs `max_allowed` 3Gi). If this change works that resolves itself; if not, it is the reason more memory cannot be absorbed.
- KEDA flapping on this queue (1→20→1, `pollingInterval: 3`, `cooldownPeriod: 10`) combined with Security Groups for Pods is exhausting branch ENIs — the *embeddings* workers are throwing `FailedCreatePodSandBox: ... failed to assign an IP address`. Separate fault; this change only indirectly relieves it.
