### PR TITLE
feat(local-dev): MIT Learn account actions via a dedicated Keycloak client

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -277,7 +277,11 @@ local_resource(
     "local-infra-apps",
     cmd="LOCAL_DEV_ROOT_DOMAIN={rd} PULUMI_CONFIG_PASSPHRASE='' bash -c '{wait} sso.ol.{rd} && {{ pulumi stack init local-dev.apps-infra.Dev 2>/dev/null; pulumi up --yes --skip-preview --parallel 1 --logtostderr --stack local-dev.apps-infra.Dev; }}'".format(rd=root_domain, wait="{}/local-dev/scripts/wait-for-keycloak-admin.sh".format(config.main_dir)),
     dir="./local-dev/infra/apps_infra",
-    deps=["./local-dev/infra/modules", "./local-dev/infra/apps_infra/__main__.py", "./local-dev/scripts/wait-for-keycloak-admin.sh"],
+    # The stack config is a dep alongside the program: adding a client also adds
+    # a `*_client_secret` to it, and without it here Tilt fires on the .py edit
+    # alone and fails with "Missing required configuration variable", then never
+    # re-runs when the value lands.
+    deps=["./local-dev/infra/modules", "./local-dev/infra/apps_infra/__main__.py", "./local-dev/infra/apps_infra/Pulumi.local-dev.apps-infra.Dev.yaml", "./local-dev/scripts/wait-for-keycloak-admin.sh"],
     labels=["infra"],
     resource_deps=["local-infra-core"],
 )

--- a/local-dev/EXTENDING.md
+++ b/local-dev/EXTENDING.md
@@ -41,6 +41,12 @@ Add `"my-app"` to the `APP_NAMESPACES` tuple in `local-dev/infra/modules/namespa
 
 In `local-dev/infra/modules/keycloak.py`, add a new client and call `_make_oidc_secret()` to create the OIDC credentials Secret in the app namespace.
 
+The client secret itself lives in three places that must be kept in sync by hand — there is no output plumbing between the Pulumi stacks and the app manifests:
+
+1. `local-dev/infra/apps_infra/Pulumi.local-dev.apps-infra.Dev.yaml` — the plaintext local-only value
+2. `local-dev/infra/apps_infra/__main__.py` — `config.require_secret(...)`, passed into `create_olapps_dev_realm()`
+3. the app's `secrets.yaml` — the same literal, under whatever env var the app reads
+
 ### 5. Register in the root Tiltfile
 
 In `Tiltfile`, add an entry to the `APPS` list:

--- a/local-dev/apps/mit-learn/configmaps/app-env.yaml
+++ b/local-dev/apps/mit-learn/configmaps/app-env.yaml
@@ -50,6 +50,11 @@ data:
 
   # ── SSO / Keycloak ─────────────────────────────────────────────────────────
   SOCIAL_AUTH_OL_OIDC_KEY: "ol-mitlearn-client"
+  # Client for Keycloak account actions (update email / update password).
+  # Distinct from SOCIAL_AUTH_OL_OIDC_KEY above: its registered redirect URI is
+  # the /account/action/complete callback. Matches ol-mitlearn-account-client in
+  # local-dev/infra/modules/keycloak.py.
+  KEYCLOAK_CLIENT_ID: "ol-mitlearn-account-client"
   KEYCLOAK_REALM_NAME: "olapps"
   KEYCLOAK_BASE_URL: "https://sso.ol.mit.dev/"
   OIDC_ENDPOINT: "https://sso.ol.mit.dev/realms/olapps"

--- a/local-dev/apps/mit-learn/secrets.yaml
+++ b/local-dev/apps/mit-learn/secrets.yaml
@@ -30,6 +30,12 @@ stringData:
   # If running without Pulumi, populate this manually.
   SOCIAL_AUTH_OL_OIDC_SECRET: "local-dev-mitlearn-secret"  # pragma: allowlist secret
 
+  # ── Account-action client secret ──────────────────────────────────────────
+  # Paired with KEYCLOAK_CLIENT_ID in mitlearn-env. Must match
+  # mitlearn_account_client_secret in the apps-infra stack config
+  # (local-dev/infra/apps_infra/Pulumi.local-dev.apps-infra.Dev.yaml).
+  KEYCLOAK_CLIENT_SECRET: "local-dev-mitlearn-account-secret"  # pragma: allowlist secret
+
   # ── LiteLLM / OpenAI ──────────────────────────────────────────────────────
   OPENAI_API_KEY: ""
   LITELLM_API_KEY: ""

--- a/local-dev/infra/apps_infra/Pulumi.local-dev.apps-infra.Dev.yaml
+++ b/local-dev/infra/apps_infra/Pulumi.local-dev.apps-infra.Dev.yaml
@@ -8,6 +8,9 @@ config:
   # OIDC client secrets for local dev (plaintext, never commit real secrets)
   # These are default local-only values; override in your local tilt_config.json
   ol-local-dev-apps-infra:mitlearn_client_secret: "local-dev-mitlearn-secret" # pragma: allowlist secret
+  # Account-actions client (update email / update password). Mirrored into
+  # local-dev/apps/mit-learn/secrets.yaml as KEYCLOAK_CLIENT_SECRET.
+  ol-local-dev-apps-infra:mitlearn_account_client_secret: "local-dev-mitlearn-account-secret" # pragma: allowlist secret
   ol-local-dev-apps-infra:learn_ai_client_secret: "local-dev-learn-ai-secret" # pragma: allowlist secret
   ol-local-dev-apps-infra:mitxonline_client_secret: "local-dev-mitxonline-secret" # pragma: allowlist secret
   ol-local-dev-apps-infra:unified_ecommerce_client_secret: "local-dev-unified-ecommerce-secret" # pragma: allowlist secret

--- a/local-dev/infra/apps_infra/__main__.py
+++ b/local-dev/infra/apps_infra/__main__.py
@@ -46,6 +46,7 @@ if verify_email is None:
 
 # Client secrets for OIDC configuration
 mitlearn_client_secret = config.require_secret("mitlearn_client_secret")
+mitlearn_account_client_secret = config.require_secret("mitlearn_account_client_secret")
 learn_ai_client_secret = config.require_secret("learn_ai_client_secret")
 mitxonline_client_secret = config.require_secret("mitxonline_client_secret")
 unified_ecommerce_client_secret = config.require_secret(
@@ -93,6 +94,7 @@ create_olapps_dev_realm(
     keycloak_url=keycloak_url,
     k8s_provider=k8s_provider,
     mitlearn_client_secret=mitlearn_client_secret,
+    mitlearn_account_client_secret=mitlearn_account_client_secret,
     learn_ai_client_secret=learn_ai_client_secret,
     mitxonline_client_secret=mitxonline_client_secret,
     unified_ecommerce_client_secret=unified_ecommerce_client_secret,

--- a/local-dev/infra/modules/keycloak.py
+++ b/local-dev/infra/modules/keycloak.py
@@ -145,7 +145,14 @@ def create_olapps_dev_realm(  # noqa: PLR0913
     for alias, default in [
         ("CONFIGURE_TOTP", False),
         ("VERIFY_EMAIL", verify_email),
-        # UPDATE_EMAIL was removed in Keycloak 26 — omit to avoid validation error.
+        # UPDATE_EMAIL is gated behind Keycloak's `update-email` preview feature,
+        # which the mitodl/keycloak image bakes in at build time (see
+        # Dockerfile.hosted in ol-keycloak). Declaring it here keeps the action
+        # enabled for MIT Learn's application-initiated update-email flow -- an
+        # AIA request for an action the realm has disabled comes back as
+        # kc_action_status=error. If the provider rejects this alias as unknown,
+        # the image lost the feature flag rather than the action being obsolete.
+        ("UPDATE_EMAIL", False),
         ("UPDATE_PASSWORD", False),
     ]:
         keycloak.RequiredAction(

--- a/local-dev/infra/modules/keycloak.py
+++ b/local-dev/infra/modules/keycloak.py
@@ -30,6 +30,7 @@ def create_olapps_dev_realm(  # noqa: PLR0913
     keycloak_url: str,
     k8s_provider: k8s.Provider,
     mitlearn_client_secret: Output,
+    mitlearn_account_client_secret: Output,
     learn_ai_client_secret: Output,
     mitxonline_client_secret: Output,
     unified_ecommerce_client_secret: Output,
@@ -492,6 +493,50 @@ def create_olapps_dev_realm(  # noqa: PLR0913
         "ol-mitlearn-oidc",
         mitlearn_client,
         mitlearn_client_secret,
+    )
+
+    # --- MIT Learn account actions ---
+    # Separate from ol-mitlearn-client (which APISIX uses for the session)
+    # because its only job is Keycloak's application-initiated actions — update
+    # email / update password. Django sends the user here with `kc_action`,
+    # Keycloak returns them to the callback below, and Django exchanges the code
+    # server-side to read the updated email, since the gateway's cached userinfo
+    # still holds the old one.
+    mitlearn_account_client = keycloak.openid.Client(
+        "olapps-mitlearn-account-client",
+        name="ol-mitlearn-account-client",
+        realm_id=realm.realm,
+        client_id="ol-mitlearn-account-client",
+        client_secret=mitlearn_account_client_secret,
+        enabled=True,
+        access_type="CONFIDENTIAL",
+        standard_flow_enabled=True,
+        implicit_flow_enabled=False,
+        service_accounts_enabled=False,
+        # Trailing "*" so Keycloak's exact-match check still passes once Django
+        # appends ?next=...&kc_action=... — mirrors the production mitxonline
+        # entry in substructure/keycloak/Pulumi.Production.yaml.
+        valid_redirect_uris=[
+            f"https://api.learn.{root_domain}/account/action/complete*",
+        ],
+        opts=kc_opts.merge(ResourceOptions(delete_before_replace=True)),
+    )
+    keycloak.openid.ClientDefaultScopes(
+        "olapps-mitlearn-account-default-scopes",
+        realm_id=realm.realm,
+        client_id=mitlearn_account_client.id,
+        default_scopes=DEFAULT_SCOPES,
+        opts=kc_opts,
+    )
+    # Not consumed by an APISIX secretRef (Django reads these from
+    # mitlearn-secrets); created for parity with the other clients and as the
+    # place to read the live credentials back.
+    _make_oidc_secret(
+        "oidc-secret-mitlearn-account",
+        "mit-learn",
+        "ol-mitlearn-account-oidc",
+        mitlearn_account_client,
+        mitlearn_account_client_secret,
     )
 
     # --- MITx Online ---


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/10815

### Description (What does it do?)
Makes MIT Learn's change-email / change-password account actions work in local-dev.

- Adds `ol-mitlearn-account-client`, a confidential Keycloak client dedicated to Keycloak's application-initiated actions (AIA). It is separate from `ol-mitlearn-client`, which APISIX uses for the session: Django sends the user to Keycloak with `kc_action`, Keycloak returns them to `/account/action/complete`, and Django exchanges the code server-side to read the updated email, since the gateway's cached userinfo still holds the old address.
- Its `valid_redirect_uris` ends in `*` so Keycloak's exact-match check still passes once Django appends `?next=...&kc_action=...`, mirroring the production mitxonline entry in `substructure/keycloak/Pulumi.Production.yaml`.
- Enables the `UPDATE_EMAIL` required action in the `olapps` realm. It was registered but left `enabled=False`, and an AIA for a disabled required action redirects back with `kc_action_status=error` — which is what the change-email flow was hitting.

The comment being replaced claimed `UPDATE_EMAIL` was removed in Keycloak 26. It was not. It is gated behind the `update-email` preview feature, which the `mitodl/keycloak` image bakes in at build time (`--features=update-email` in `ol-keycloak`'s `Dockerfile.hosted`). On the pinned image, `kc.sh show-config` reports:

```
kc.features =  update-email (Persisted)
```

So a provider "unknown alias" validation error on that alias would mean the image lost the feature flag, not that the action is obsolete — noted in the new comment so the next person does not re-derive it.

### How can this be tested?

Against local-dev (`tilt up`), signed in to Learn as a non-SSO user:

1. Go to `https://learn.mit.dev/dashboard/settings` and start the change-email action.
2. Keycloak should present its update-email form and return you to `https://api.learn.mit.dev/account/action/complete?...&kc_action_status=success`. Before this change the same URL came back with `kc_action_status=error`.
3. Confirm the new address is reflected in Learn.

Confirmed working end-to-end on local-dev.

To verify the realm state directly (local-dev admin credentials are the committed `admin`/`admin` defaults used by `local-dev/scripts/kc-fix-flow-bindings.sh`):

```bash
TOKEN=$(curl -s --cacert local-dev/certs/rootCA.pem \
  -X POST "https://sso.ol.mit.dev/realms/master/protocol/openid-connect/token" \
  -d "client_id=admin-cli&username=admin&password=admin&grant_type=password" \
  | jq -r .access_token)

curl -s --cacert local-dev/certs/rootCA.pem -H "Authorization: Bearer $TOKEN" \
  "https://sso.ol.mit.dev/admin/realms/olapps/authentication/required-actions/UPDATE_EMAIL"
```

`UPDATE_PASSWORD` was already enabled, so the change-password action is a useful control that the client and its redirect URI are sound independently of the required-action change.

### Additional Context

Note for reviewers on how the required action reaches the realm: `keycloak.RequiredAction` for `UPDATE_EMAIL` updates the built-in action that Keycloak already registered rather than creating a new one, which is the same thing the three existing entries (`CONFIGURE_TOTP`, `VERIFY_EMAIL`, `UPDATE_PASSWORD`) do. No Pulumi import is needed.

Because the action was flipped live on one local-dev cluster while debugging, that cluster was already in the fixed state before this commit existed. The declaration here is what makes it survive a realm rebuild — anyone else needs the `pulumi up` to pick it up.

A `keycloak_log_level` knob for local-dev is deliberately not in this PR and will follow separately. It is worth having: the `olapps` realm has `events_enabled` with the `jboss-logging` listener, but Keycloak emits those events at DEBUG, so this failure produced nothing in the pod log at the default level and had to be diagnosed from the realm's required-action state instead.
