### PR TITLE
fix(concourse): fix keycloak preview job failing under preview-gated topology

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/keycloak/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/keycloak/pipeline.py
@@ -11,7 +11,6 @@ from ol_concourse.lib.models.pipeline import (
     Identifier,
     Input,
     Job,
-    LoadVarStep,
     Output,
     Platform,
     PutStep,
@@ -251,14 +250,9 @@ def build_keycloak_infrastructure_pipeline() -> PipelineFragment:
                 trigger=True,
                 passed=[container_fragment.jobs[-1].name],
             ),
-            LoadVarStep(
-                load_var="image_digest",
-                file=f"{keycloak_registry_image.name}/digest",
-                reveal=True,
-            ),
         ],
-        additional_env_vars={
-            "KEYCLOAK_DOCKER_DIGEST": "((.:image_digest))",
+        env_vars_from_files={
+            "KEYCLOAK_DOCKER_DIGEST": f"{keycloak_registry_image.name}/digest",
         },
         topology="preview-gated",
         auto_deploy_stages=["CI"],


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

Fixes a live failure introduced by #5507: [`preview-ol-application-keycloak-qa` build #2](https://cicd.odl.mit.edu/teams/infrastructure/pipelines/docker-pulumi-keycloak/jobs/preview-ol-application-keycloak-qa/builds/2) failed with `undefined vars: .:image_digest` after that PR moved the Keycloak app pipeline to `topology="preview-gated"`.

Root cause: `ol_concourse.lib.jobs.infrastructure._split_stage_steps` splits each stage's extra `dependencies` into `GetStep`s (inputs — copied into both the preview and deploy jobs) and everything else (side effects — wired into the deploy job only, deliberately, so a preview run can never trigger a write). The `LoadVarStep` that populated `((.:image_digest))` for `KEYCLOAK_DOCKER_DIGEST` isn't a `GetStep`, so it only ended up in the deploy job's plan. The preview job still referenced the var but never got the step that defines it.

Switched to the same `env_vars_from_files` pattern `simple_pulumi/pipeline.py` already uses for `release-bot`'s digest env var: read the digest straight from the `keycloak-image` `GetStep`'s own output file (`keycloak-image/digest`), which is already a stage input present in both the preview and deploy jobs — no `LoadVarStep` needed at all.

### How can this be tested?

- `python pipeline.py` (in `src/ol_concourse/pipelines/infrastructure/keycloak/`) builds cleanly.
- Inspected the generated `definition.json`: the preview job's `pulumi-ol-application-keycloak` `PutStep` params now resolve `env_vars_from_files.KEYCLOAK_DOCKER_DIGEST` to `keycloak-image/digest`, with no dangling `((.: ))` var reference — the failure mode from build #2 is gone.
- `uv run pre-commit run` passes on the changed file.

Not yet re-run against the live pipeline — the meta-pipeline (or a manual `fly set-pipeline`) needs to pick this up before `preview-ol-application-keycloak-qa` can be re-triggered to confirm green.

### Additional Context

Scoped to the Keycloak application pipeline only — the Keycloak substructure pipeline and all the `simple_pulumi` singleton entries from #5507 don't use `LoadVarStep`/dynamic digest env vars, so they aren't affected by this bug.
