### PR TITLE
feat(mitxonline): redirect course/program pages to MIT Learn via Fastly

### DIFF
--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -993,11 +993,12 @@ uai_b2c_redirects: dict[str, str] = {
     "/courses/course-v1:UAI_SOURCE+UAI.HAIM.1/": f"https://{learn_frontend_domain}/courses/course-v1:UAI_SOURCE+UAI.HAIM.1/",
 }
 uai_b2c_redirect_vcl = "\n".join(
-    f'if (req.url.path == "{path}") {{\n'
+    f'if (req.url.path == "{path}" || req.url.path == "{path_without_slash}") {{\n'
     f'  set req.http.x-redir-location = "{target}";\n'
     f"  error 602;\n"
     f"}}"
     for path, target in uai_b2c_redirects.items()
+    for path_without_slash in [path.removesuffix("/")]
 )
 
 # Course and program product pages redirect 1:1 to their MIT Learn counterparts.

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -1003,10 +1003,12 @@ uai_b2c_redirect_vcl = "\n".join(
 
 # Course and program product pages redirect 1:1 to their MIT Learn counterparts.
 # Matches only the top-level /courses/{readable_id} and /programs/{readable_id}
-# routes (no sub-paths exist under them today - CourseProgramChildPage.serve()
-# 404s unconditionally, so certificate/flexible-pricing child pages are never
-# directly routable). Uses a distinct error code (603) from the UAI B2C
-# redirects (602) above so this is fully additive.
+# routes. Reachable child pages do exist under some of these (e.g. flexible-
+# pricing request forms), but this rule intentionally matches only a single
+# path segment after the prefix, leaving those untouched - not because they're
+# unreachable, but because redirecting them isn't in scope yet. Uses a distinct
+# error code (603) from the UAI B2C redirects (602) above so this is fully
+# additive.
 course_program_redirect_vcl = "\n".join(
     f'if (req.url.path ~ "^/{prefix}/([^/]+)/?$") {{\n'
     f'  set req.http.x-redir-location = "https://{learn_frontend_domain}/{prefix}/" re.group.1;\n'

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -1000,6 +1000,20 @@ uai_b2c_redirect_vcl = "\n".join(
     for path, target in uai_b2c_redirects.items()
 )
 
+# Course and program product pages redirect 1:1 to their MIT Learn counterparts.
+# Matches only the top-level /courses/{readable_id} and /programs/{readable_id}
+# routes (no sub-paths exist under them today - CourseProgramChildPage.serve()
+# 404s unconditionally, so certificate/flexible-pricing child pages are never
+# directly routable). Uses a distinct error code (603) from the UAI B2C
+# redirects (602) above so this is fully additive.
+course_program_redirect_vcl = "\n".join(
+    f'if (req.url.path ~ "^/{prefix}/([^/]+)/?$") {{\n'
+    f'  set req.http.x-redir-location = "https://{learn_frontend_domain}/{prefix}/" re.group.1;\n'
+    f"  error 603;\n"
+    f"}}"
+    for prefix in ("courses", "programs")
+)
+
 gzip_settings: dict[str, set[str]] = {"extensions": set(), "content_types": set()}
 for k, v in mimetypes.types_map.items():
     if k in (
@@ -1093,6 +1107,15 @@ mitxonline_service = fastly.ServiceVcl(
             type="recv",
         ),
         fastly.ServiceVclSnippetArgs(
+            content=course_program_redirect_vcl,
+            name="Redirect course and program pages to MIT Learn",
+            # Runs after the UAI B2C redirects (priority 100) so that their
+            # exact-match overrides (e.g. program-v1:UAI+B2C.1 -> /courses/p/...)
+            # take precedence over this generic 1:1 redirect.
+            priority=150,
+            type="recv",
+        ),
+        fastly.ServiceVclSnippetArgs(
             content=textwrap.dedent("""\
             if (obj.status == 602) {
               set obj.status = 301;
@@ -1108,6 +1131,25 @@ mitxonline_service = fastly.ServiceVcl(
               return(deliver);
             }"""),
             name="Handle UAI B2C external redirects",
+            type="error",
+        ),
+        fastly.ServiceVclSnippetArgs(
+            content=textwrap.dedent("""\
+            if (obj.status == 603) {
+              set obj.status = 301;
+              set obj.response = "Moved Permanently";
+              set obj.http.Location = req.http.x-redir-location;
+              set obj.http.Cache-Control = "no-store";
+              if (req.url.qs != "") {
+                if (obj.http.Location !~ "\\?") {
+                  set obj.http.Location = obj.http.Location "?" req.url.qs;
+                } else {
+                  set obj.http.Location = obj.http.Location "&" req.url.qs;
+                }
+              }
+              return(deliver);
+            }"""),
+            name="Handle course/program redirects to MIT Learn",
             type="error",
         ),
         fastly.ServiceVclSnippetArgs(


### PR DESCRIPTION
### What are the relevant tickets?

Closes [12449](https://github.com/mitodl/hq/issues/12449), subissue # 4 of epic [mitodl/mitxonline#12027](https://github.com/mitodl/hq/issues/12027), but cannot be merged until:

- [x] https://github.com/mitodl/hq/issues/12036
- [x] https://github.com/mitodl/hq/issues/12478
- [x] https://github.com/mitodl/mit-learn/pull/3794 

are complete.

### Description (What does it do?)

Adds a Fastly-level 301 redirect from mitxonline course/program product pages to their MIT Learn counterparts:

- `mitxonline.mit.edu/courses/{readable_id}` → `learn.mit.edu/courses/{readable_id}`
- `mitxonline.mit.edu/programs/{readable_id}` → `learn.mit.edu/programs/{readable_id}`

Implemented by extending the existing UAI B2C redirect pattern in `mitxonline_service` (`fastly.ServiceVcl`) with a new VCL snippet pair using a distinct `error 603` status (vs. UAI's `602`).

**Update:** this is *not* purely additive to the UAI redirects, as originally stated here. Without a slashless variant of the UAI B2C exact-match checks, a no-trailing-slash request to a UAI path (e.g. `/programs/program-v1:UAI+B2C.1`) would have missed the UAI dict's `==` comparisons and instead matched this PR's new generic rule, landing on `/programs/program-v1:UAI+B2C.1` on Learn instead of the correct override target `/courses/p/program-v1:UAI+B2C.1`. The UAI matching was extended (`req.url.path == "{path}" || req.url.path == "{path_without_slash}"`) to close that gap. This is a necessary, correct fix — but it does modify UAI's existing behavior, contrary to what this section originally claimed.

Per the issue's plan:
- **Environment-aware**: reuses `learn_frontend_domain`, which is already a per-Pulumi-stack config value, so rc → rc and prod → prod automatically.
- **Top-level only, no sub-paths**: `^/(courses|programs)/([^/]+)/?$` matches only a single path segment after the prefix.
  - **Update:** the reasoning here was previously wrong and has been corrected. Reachable child pages *do* exist under some course/program pages — e.g. `FlexiblePricingRequestForm` (financial-assistance forms), confirmed live at URLs like `.../programs/program-v1:MITx+DEDP/dedp-micromasters-program-financial-assistance-form/`. It subclasses `AbstractForm`, not `CourseProgramChildPage`, so it's normally routable — unlike `CertificatePage`, which *does* subclass `CourseProgramChildPage` and whose `serve()` unconditionally raises `Http404`. Either way, these are untouched by this rule: it's not because they're unreachable, but because the regex only matches a single path segment, and redirecting them isn't in scope. Confirmed this is the desired behavior — these forms need to keep working on mitxonline, since Learn has nowhere to send users for them today.
- **Query strings preserved**: same append-qs logic as the existing UAI redirect handler.
- **Trailing slash normalized**: the redirect target is built from the captured ID only, so a trailing slash on the source never carries through.
- **`Cache-Control: no-store`**: added on this redirect's response specifically, per the issue's request to make this easy to revert if needed. Note this protects against *browser* caching of the 301 — Fastly's own edge does not cache synthetic `vcl_error` responses, so browser-side caching is the actual reversibility risk here.
- **Rollout**: applies to all course/program pages at once, no phased subset, per the issue's stated preference.
- **Priority ordering**: this snippet runs at priority `150`, after the UAI B2C redirects (`100`). A few UAI paths redirect to non-1:1 targets (e.g. `program-v1:UAI+B2C.1` → `/courses/p/program-v1:UAI+B2C.1`), so those exact-match overrides need to win before this generic rule applies.

**Blast radius, confirmed:** all API routes live under `/api/v1|v2|v3/...` (unaffected); bare `/courses/` and `/programs/` index pages already 404 today regardless of this change (`CourseObjectIndexPage.serve()` raises `Http404` unconditionally) and don't match the regex anyway; `ProgramCollection` lives under `/program-collections/`, a distinct prefix; `/catalog/`, `/cart/`, `/records/`, `/dashboard/`, `/certificate/` are all out of range.

Not in scope (per issue): `/certificate/` and `/certificate/program/` paths; checkout/enrollment flows and program-record pages (tracked in mitxonline#12036); dedicated monitoring/alerting for this epic (left as an open question in the issue).

### How can this be tested?

⚠️ Before promoting rc → production: re-run the rc validation steps below, especially confirming the financial-aid form URL still returns a normal 200 (not a redirect). Do not skip this even if rc looked fine at merge time — verify again right before the prod promotion.

No app-specific test suite for this Pulumi module — validation is lint/type-check locally, then live checks against rc once deployed.

**Locally (already done):**
`ruff-format`/`ruff-check` pass clean; `mypy` shows no new errors introduced vs. `main` (see Additional Context for 2 pre-existing, unrelated errors in this file).

**Once deployed to rc** (before prod), a reviewer can validate with:

1. Pick 2-3 real course/program IDs and check both slash variants:
curl -I [https://rc.mitxonline.mit.edu/courses/{readable_id}](https://rc.mitxonline.mit.edu/courses/%7Breadable_id%7D)
curl -I [https://rc.mitxonline.mit.edu/courses/{readable_id}/](https://rc.mitxonline.mit.edu/courses/%7Breadable_id%7D/)


Expect `301`, `location: https://rc.learn.mit.edu/courses/{readable_id}` (no trailing slash either way), `cache-control: no-store`.
2. Query strings survive the redirect:
curl -I "[https://rc.mitxonline.mit.edu/courses/{readable_id}?utm_source=test&utm_medium=email](https://rc.mitxonline.mit.edu/courses/%7Breadable_id%7D?utm_source=test&utm_medium=email)"


3. UAI B2C overrides still win over this new generic rule, with and without a trailing slash:
curl -I https://rc.mitxonline.mit.edu/programs/program-v1:UAI+B2C.1/
curl -I https://rc.mitxonline.mit.edu/programs/program-v1:UAI+B2C.1


Both must land on `/courses/p/program-v1:UAI+B2C.1`, not the generic `/programs/program-v1:UAI+B2C.1`.
4. Confirm non-matching paths are unaffected: `/catalog/courses`, `/catalog/programs`, `/courses/{id}/anything` (extra segment), `/certificate/...`, cart/checkout paths, and specifically the financial-assistance form URL above (must stay a normal `200`, not redirect).
5. **Resolved:** a course/program can have a live Wagtail page but a non-live underlying `Course`/`Program` record. Confirmed mitxonline renders these fine today (Wagtail's `CoursePage` has no `serve()` override tying rendering to `Course.live`), but Learn's `CoursePage.tsx`/`ProgramPage.tsx` explicitly query with `live: true` and call `notFound()` otherwise — so these will hard-404 on Learn post-redirect. This is a real, pre-existing data-consistency gap between the Wagtail page and courseware record, not something this Fastly rule can fix. Tracking as a separate issue rather than blocking this PR on it — flagging here so it's not lost.

Only once rc checks all pass should the same redirect/query-string/UAI-regression checks be repeated against production, after devops deploys there.

### Additional Context

**Percent-encoded UAI paths** (e.g. `/programs/program-v1%3AUAI%2BB2C.1`) bypass the UAI dict's exact-match checks (which compare against literal `:`/`+`, not their percent-encoded forms) and fall through to this PR's generic rule, landing on the non-override Learn URL. Confirmed low-severity: Learn's own frontend already redirects `programs/:id → courses/p/:id` where that mapping matters, so the worst case is one extra hop, not a dead end. Not fixed in this PR.

**Wagtail `Redirect` entries**: confirmed the `Redirect` table is currently empty, so there's no active collision today. But this remains a standing characteristic of the approach, not a one-time check: since this Fastly rule runs before Django/Wagtail ever sees the request, any `Redirect` added *after* this merges for a renamed course/program slug will silently never fire — the stale ID will go straight to Learn instead of through Wagtail's redirect to the current page. Worth keeping in mind for anyone renaming a course/program slug going forward.

`mypy` reports 2 pre-existing errors in this file (confirmed present on unmodified `main` via `git stash`, unaffected by this diff):
- `env_vars.update(**mitxonline_config.get_object("vars"))` — `get_object` is typed `Any | None`; harmless today since every stack's config has `vars` set, but would raise `TypeError` if one didn't.
- `mitxonline_service.domains.apply(lambda domains: ...)` — `domains` is typed `Sequence[...] | None` by the Fastly provider SDK; always populated in practice since it's a hardcoded literal earlier in the file.

Not fixed here since they're unrelated to the redirect work. Flagging in case a separate cleanup ticket is wanted.

### Checklist:

- [x] Confirmed no active Wagtail `Redirect` entries exist today under `/courses/` or `/programs/` (table is currently empty) — see Additional Context for why this remains worth watching going forward rather than a one-time concern.
- [x] Reviewed/approved by `@mitodl/devops` (they manage Fastly dashboard/API access for the mitxonline.mit.edu service)