### PR TITLE
feat(labels): make Component a strict enum covering the roles paging cares about

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
@@ -20,6 +20,7 @@ from ol_infrastructure.lib.aws.eks_helper import (
 from ol_infrastructure.lib.ol_types import (
     Application,
     BusinessUnit,
+    Component,
     K8sAppLabels,
     Product,
     Services,
@@ -46,7 +47,7 @@ k8s_app_labels = K8sAppLabels(
     product=Product.mitlearn,
     service=Services.mit_learn,
     application=Application.mit_learn,
-    component="frontend",
+    component=Component.frontend,
     ou=BusinessUnit.mit_learn,
     source_repository="https://github.com/mitodl/mit-learn",
     stack=stack_info,

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/synthetic_monitoring.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/synthetic_monitoring.py
@@ -159,6 +159,7 @@ from dataclasses import dataclass
 from pulumi import ResourceOptions
 from pulumiverse_grafana import alerting
 
+from ol_infrastructure.lib.ol_types import Component
 from ol_infrastructure.lib.pulumi_helper import parse_stack
 
 # The Synthetic Monitoring plugin's folder. Referenced, never created -- see the
@@ -184,7 +185,11 @@ class _Check:
     slow_rule_name: str
     job: str
     instance: str
-    component: str
+    # Typed against the K8s label enum, not `str`: this value and
+    # `ol.mit.edu/component` are the two producers of Rootly's `ol_component`
+    # routing key, and they agreed on `api`/`nextjs`/`webapp` by coincidence
+    # until this annotation made it a guarantee.
+    component: Component
     severity: str
     # Subject of the alert summaries, e.g. "MIT Learn Next.js origin".
     what: str
@@ -203,7 +208,7 @@ _CHECKS = [
         ),
         job="Learn NextJS Homepage (Bypass Fastly)",
         instance="https://next.learn.mit.edu/",
-        component="nextjs",
+        component=Component.nextjs,
         severity="warning",
         what="MIT Learn Next.js origin",
         context=(
@@ -226,7 +231,7 @@ _CHECKS = [
         slow_rule_name="Learn API Health Endpoint - Elevated Probe Failure Rate",
         job="Learn API Health Endpoint",
         instance="https://api.learn.mit.edu/learn/health",
-        component="api",
+        component=Component.api,
         severity="critical",
         what="MIT Learn API health endpoint",
         context=(
@@ -242,7 +247,7 @@ _CHECKS = [
         slow_rule_name="Learn Homepage - Elevated Probe Failure Rate",
         job="Learn Homepage",
         instance="https://learn.mit.edu/",
-        component="webapp",
+        component=Component.webapp,
         severity="critical",
         what="MIT Learn homepage",
         context=(

--- a/src/ol_infrastructure/lib/ol_types.py
+++ b/src/ol_infrastructure/lib/ol_types.py
@@ -161,10 +161,16 @@ class Component(StrEnum):
     The discriminator for paging decisions: a Celery worker and a Postgres
     StatefulSet fail differently and should not share an alert tier.
 
-    Also the vocabulary for Rootly's `component` routing key, which has two
-    producers -- this label and `metric_rules/synthetic_monitoring.py`'s
-    `_Check` -- so both are typed against this enum rather than agreeing by
-    coincidence.
+    Also the vocabulary for Rootly's `ol_component` routing key, which has two
+    producers -- this label, surfaced as `ol.mit.edu/component`, and
+    `metric_rules/synthetic_monitoring.py`'s `_Check` -- so both are typed
+    against this enum rather than agreeing by coincidence.
+
+    Note the two spellings are deliberate and not interchangeable: the
+    Kubernetes label is `ol.mit.edu/component`, while what reaches Rootly is
+    `ol_component`. Alert rules rename it at the boundary so a routing
+    condition never has to read `label_ol_mit_edu_component`, and so the key
+    cannot collide with a bare `component` set by a vendor integration.
     """
 
     api = "api"

--- a/src/ol_infrastructure/lib/ol_types.py
+++ b/src/ol_infrastructure/lib/ol_types.py
@@ -57,7 +57,14 @@ class Environment(StrEnum):
 
 @unique
 class Services(StrEnum):
-    """Canonical source of truth for defining apps."""
+    """The deployable unit a workload belongs to -- the `ol.mit.edu/service` label.
+
+    The operational axis: what you page about, what a Rootly service maps to,
+    what shares a namespace and a deploy. Deliberately NOT reconciled against
+    `Application`, which is a different axis -- see that enum's docstring. The
+    two overlap heavily by nature and drift between them is expected, not a
+    defect to fix.
+    """
 
     airbyte = "airbyte"
     superset = "superset"
@@ -76,8 +83,7 @@ class Services(StrEnum):
     notebooks = "notebooks"
     ol_analytics_api = "ol-analytics-api"
     opik = "opik"
-    open_edx = "open-edx"
-    learn_ai = ("learn-ai",)
+    learn_ai = "learn-ai"
     mit_learn = "mit-learn"
     mit_open = "open"
     mitx_edx = "mitx-edx"
@@ -102,6 +108,15 @@ class Services(StrEnum):
 
 @unique
 class Application(StrEnum):
+    """The codebase a workload runs -- the `ol.mit.edu/application` label.
+
+    The provenance axis: which repository built the image, which team's release
+    ships it. One `Application` can appear in several `Services` (an Open edX
+    codebase runs as separate residential, MITx Online and xPro services), and
+    one `Service` can compose more than one `Application`. Kept separate from
+    `Services` on purpose -- neither is derived from the other.
+    """
+
     airbyte = "airbyte"
     superset = "superset"
     celery_monitoring = "celery-monitoring"
@@ -141,10 +156,32 @@ class Application(StrEnum):
 
 @unique
 class Component(StrEnum):
+    """Functional role of a workload within its service.
+
+    The discriminator for paging decisions: a Celery worker and a Postgres
+    StatefulSet fail differently and should not share an alert tier.
+
+    Also the vocabulary for Rootly's `component` routing key, which has two
+    producers -- this label and `metric_rules/synthetic_monitoring.py`'s
+    `_Check` -- so both are typed against this enum rather than agreeing by
+    coincidence.
+    """
+
+    api = "api"
+    beat = "beat"
+    cache = "cache"
     celery = "celery"
-    webapp = "webapp"
+    database = "database"
     frontend = "frontend"
+    gateway = "gateway"
+    ingress = "ingress"
     keycloak = "keycloak"
+    nextjs = "nextjs"
+    pgbouncer = "pgbouncer"
+    queue = "queue"
+    search = "search"
+    webapp = "webapp"
+    worker = "worker"
 
 
 @unique
@@ -206,7 +243,7 @@ class K8sGlobalLabels(BaseModel):
 class K8sAppLabels(K8sGlobalLabels):
     product: Product
     application: Application
-    component: Component | str | None = None
+    component: Component | None = None
     pod_security_group: str | None = None
     source_repository: str
     commit_sha: str | None = None


### PR DESCRIPTION
### What are the relevant tickets?
N/A — step P2.A of `docs/plans/rootly-label-routing-implementation-spec.md` (merged in #5458). Follows #5494.

### Description (What does it do?)

- Extends `Component` from 4 members to 15, and drops the `| str` escape hatch: `component: Component | str | None` → `Component | None`. The enum previously documented a vocabulary it could not enforce — any string was accepted — which is why `ol.mit.edu/component` is not something alert routing can key on today.
- New members are the roles the paging decision actually distinguishes. `api`, `nextjs`, `webapp` because [`synthetic_monitoring.py`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/synthetic_monitoring.py) already emits them as Grafana alert labels; `pgbouncer` because Dagster uses it as a raw Kubernetes Service label; `gateway` and `queue` because APISIX/Traefik and RabbitMQ/Redis-as-broker had no member at all and are the widest-blast-radius workloads in `operations-production`.
- Retypes `_Check.component` from `str` to `Component`. Rootly's `ol_component` routing key has two producers — that dataclass and the `ol.mit.edu/component` label — and they agreed on `api`/`nextjs`/`webapp` by coincidence rather than construction. #5494 pointed the routing rules at that key; this makes the two producers share one vocabulary.
- Enum hygiene in the same pass:
  - `Services.learn_ai` was declared as the tuple `("learn-ai",)`. `StrEnum` splats it, so the value was right by accident. Fixed before anything depends on it.
  - Removed `Services.open_edx` (`"open-edx"`) — zero call sites, and having it alongside `Services.openedx` made labeling an Open edX workload a coin flip. `openedx` is the one `edxapp` actually uses.
  - Added docstrings to `Services` and `Application` naming which axis each is (operational vs provenance), so the next reader does not re-derive whether they should be reconciled. Per the spec's §1.3 they should not be — neither is derived from the other.

Not included: dropping `BusinessUnit.residential_staging`, the remaining §3.2 hygiene item. See Additional Context.

### How can this be tested?

```
uv run mypy src/ol_infrastructure/
uv run pre-commit run --files \
  src/ol_infrastructure/lib/ol_types.py \
  src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/synthetic_monitoring.py \
  src/ol_infrastructure/applications/mit_learn_nextjs/__main__.py
```

What I ran, and what it showed:

- **mypy flagged exactly one call site** and nothing else — `mit_learn_nextjs/__main__.py:49` passing the bare string `"frontend"`, now `Component.frontend`. That single finding is the evidence the `| str` hatch is gone; the spec's §3.5 names it as the acceptance criterion for this commit.
- **Repo-wide mypy is unchanged.** This repo has a 625-error baseline, so "mypy passes" would be meaningless. I captured the full sorted error list before and after and diffed them: byte-identical. No errors introduced, and none masked.
- **The rendered label value does not change.** `model_dump` returns the enum member rather than a plain string, so this needed checking rather than assuming. `StrEnum` is a `str` subclass, and the label still serializes to `"frontend"`:

  ```
  repr        : <Component.frontend: 'frontend'>
  json        : "frontend"
  == 'frontend': True
  ```

  Full dict for the MIT Learn Next.js workload, unchanged from before this PR:

  ```json
  {
    "ol.mit.edu/ou": "mit-learn",
    "ol.mit.edu/service": "mit-learn",
    "ol.mit.edu/stack": "applications-mitlearn-qa",
    "ol.mit.edu/product": "mit-learn",
    "ol.mit.edu/application": "mit-learn",
    "ol.mit.edu/component": "frontend",
    "ol.mit.edu/source_repository": "github.com_mitodl_mit-learn",
    "ol.mit.edu/environment": "qa"
  }
  ```

- **pre-commit** (ruff format, ruff check, mypy, detect-secrets): pass.

Before tightening the type I re-verified the spec's claim that only one call site sets the typed field, rather than trusting it — greps for `component=`, `"component"`, and `Component` across `src/`. The `pgbouncer` / `sql-exporter` / `proxy` / `worker` hits are raw Kubernetes label dicts and `ServiceMonitor` selectors, not `ol.mit.edu/component`, so they are unaffected.

No Pulumi preview here — this changes no resource definitions, only the type of a label value that renders identically.

### Additional Context

**Why `BusinessUnit.residential_staging` is not in this PR.** The spec groups it with the other enum hygiene, but it is not a type change. [`AWSBase.enforce_tags`](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/lib/ol_types.py) validates `BusinessUnit(tags["OU"])` and raises on an unknown value, and the only consumer — the `residential_staging_vpc` block in `infrastructure/aws/network/__main__.py` — passes raw strings, not enum members:

```python
tags={
    "OU": "residential-staging",
    "Environment": f"mitx-staging-{stack_info.env_suffix}",
    "business_unit": "residential-staging",
    ...
}
```

So removing the member retags a live VPC and its subnets/route tables, and merges a cost-allocation bucket that something is reporting on today. The three-line edit is not the work; finding who consumes `OU=residential-staging` is. Tracked separately.

**Ordering.** This is P2.A. P2.B (add `AlertTier`, move `product`/`application`/`component` down into `K8sGlobalLabels`, make `environment` explicit) builds directly on it. Phase 3 — the `group_left` rule rewrite — stays hard-gated behind ≥95% label coverage, since an unmatched series is dropped and shipping it early would silence alerting rather than re-tier it.
