### PR TITLE
docs(alerting): correct the Dagster connection-failure timeline, which had two phases

### DIFF
--- a/src/ol_infrastructure/infrastructure/grafana_alerting/log_rules/dagster_database.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/log_rules/dagster_database.py
@@ -3,24 +3,29 @@
 Written 2026-08-18, after the data-production Dagster daemon spent days unable to
 open a socket to PgBouncer -- 28232 of 28232 ephemeral ports consumed by TIME_WAIT
 toward the PgBouncer service address, psycopg2 raising "Cannot assign requested
-address", and user-visible run failures -- while every rule in
-metric_rules/dagster_pgbouncer.py stayed correctly quiet.
+address", and user-visible run failures -- while every rule that existed in
+metric_rules/dagster_pgbouncer.py at the time stayed correctly quiet.
 
-Why the pool-side rules could not have caught it
-------------------------------------------------
-Those rules measure PgBouncer: server connections against max_db_connections,
-cl_waiting, maxwait, pgbouncer_up. During the incident PgBouncer read 12 active
-clients, 11 active server connections, 0 waiting, 40 of a ~708 per-replica cap --
-a pool with nothing wrong with it. The failure was entirely in the client's own
-network namespace, upstream of anything PgBouncer can observe: a client that
-cannot allocate a source port never becomes a connection PgBouncer counts.
+Why the concurrency rules could not have caught it
+---------------------------------------------------
+Those rules measure how much of PgBouncer is occupied: server connections against
+max_db_connections, cl_waiting, maxwait, pgbouncer_up. During the incident
+PgBouncer read 12 active clients, 11 active server connections, 0 waiting, 40 of
+a ~708 per-replica cap -- a pool with nothing wrong with it. The failure was
+entirely in the client's own network namespace, upstream of anything PgBouncer
+can observe: a client that cannot allocate a source port never becomes a
+connection PgBouncer counts.
 
 The two signatures are opposites, not points on one scale. The harder the client
 churns, the *emptier* the pool looks, because connections that fail to establish
-are connections the pool never sees. No threshold on a pool-side rule can cover
-this, which is why it lives in its own module rather than being bolted onto
-dagster_pgbouncer.py as a tighter bound on an existing series. Do not delete
-either side as redundant with the other.
+are connections the pool never sees. No threshold on a concurrency rule can cover
+this, which is why this lives in its own module rather than being bolted onto
+dagster_pgbouncer.py as a tighter bound on an existing series.
+
+DagsterPgBouncerConnectionChurn was added to that file alongside this module and
+is the one pool-side series that does see the churn, earlier than this rule does
+-- but it measures arrival rate, a third axis again, and it covers only the one
+failure mode. See below. Do not delete any of the three as redundant.
 
 Why a log rule rather than a metric
 ------------------------------------
@@ -33,14 +38,35 @@ logs every failed connection attempt regardless of cause -- DNS, refused, port
 exhaustion, pool cap, RDS failover -- so it needs no new plumbing and is not
 specific to the one failure mode that prompted it.
 
+Why this outlives the metric rule it is paired with
+----------------------------------------------------
+DagsterPgBouncerConnectionChurn watches the precondition for port exhaustion and
+is the earlier warning, but it only sees that one failure mode. The 2026-08-18
+remediation is the proof, and it ran in two phases rather than one:
+
+  until ~16:40Z  non-pooling storages -- churn 415/s, ~270 retries/min,
+                 psycopg2 "Cannot assign requested address". Real port exhaustion.
+  ~16:50-17:50Z  churn already down at 0.7/s, yet the daemon still could not get
+                 connections, at ~30/min and now with a different error entirely:
+                 "QueuePool limit of size 10 overflow 10 reached, connection timed
+                 out". Client-side SQLAlchemy pool saturation, not the network.
+  after ~17:50Z  clean.
+
+The churn metric went quiet 70 minutes before the daemon stopped failing. This
+rule spanned both phases because it matches Dagster's retry wrapper rather than
+any particular psycopg2 error -- the generality is the point, not laziness about
+the filter. Resist narrowing it to the error string of whichever incident is
+freshest.
+
 Threshold, from 14 days of Loki
 --------------------------------
 Quiet hours on data-production top out at 54 lines/hour (8, 8, 54, 21, 7 across
-the pre-incident samples), or ~9 per 10 minutes. The storm ran 10,000-29,000
-lines/hour, ~2,700 per 10 minutes, continuously from 2026-08-09 until the pooled
-storage classes landed at 17:22Z on 2026-08-18 and dropped it to zero. 100 per
-10 minutes therefore sits an order of magnitude above the noisiest quiet hour and
-27x below the incident, on a signal whose two states are separated by ~500x.
+the pre-incident samples), or ~9 per 10 minutes. Phase one ran 10,000-29,000
+lines/hour, ~2,700 per 10 minutes, continuously from 2026-08-09. 100 per 10
+minutes therefore sits an order of magnitude above the noisiest quiet hour and
+27x below the incident, on a signal whose two states are separated by ~500x. It
+also clears phase two's ~300 per 10 minutes by 3x, so that hour would have paged
+too -- correctly, since runs were still failing throughout it.
 
 Background: docs/plans/dagster-pgbouncer-observability.md.
 """

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/dagster_pgbouncer.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/dagster_pgbouncer.py
@@ -16,9 +16,12 @@ the pgbouncer_exporter sidecar that produces these metrics, and the max_db_conne
 cap that gives the headroom rule a denominator worth measuring against.
 
 Every rule here measures PgBouncer, which means none of them can see a client
-that fails before it becomes a connection. That half is covered by
+that fails before it becomes a connection, nor one that fails against its own
+in-process pool without reaching the network. Those are covered by
 log_rules/dagster_database.py, written after a daemon spent days unable to open a
-socket at all while these rules read perfectly healthy. Keep both.
+socket at all while the rules in this file read perfectly healthy. The 2026-08-18
+remediation then produced a second, unrelated hour of failures against the
+client's SQLAlchemy pool that nothing here saw either. Keep both files.
 
 Warning rules filter cluster=~".*-(ci|qa)"      -- fire on CI and QA stacks.
 Critical rules filter cluster=~".*-(production)" -- fire on prod stack only.
@@ -77,8 +80,7 @@ _MAXWAIT_SECONDS = 5
 # have blown the max_db_connections cap in seconds, and the cap never moved off
 # 40 of 708 throughout.
 #
-# That makes it the one pool-side series that was not blind to the 2026-08-18
-# daemon incident, and a different quantity from everything above: those measure
+# That makes it a different quantity from everything above: those measure
 # concurrency -- how many connections exist at an instant -- while this measures
 # how fast clients arrive. Under pool_mode = session each client session takes an
 # assignment, so this is a direct count of the client-side connects that consume
@@ -88,13 +90,24 @@ _MAXWAIT_SECONDS = 5
 # space. Both readings are true at once; only this one is alarming.
 #
 # Measured, not guessed. data-production sat at 407-511/s continuously from
-# 2026-08-09 until the pooled storage classes rolled at 17:22Z on 2026-08-18,
-# after which it fell to 0.2-4.4/s with a single 22.9/s spike. data-qa ran a flat
-# 59/s over the same period and fell to 0.25/s. 50 is therefore below both
+# 2026-08-09 until the pooled storage classes rolled at ~16:40Z on 2026-08-18,
+# falling 415 -> 50.7 -> 0.7/s across the 16:37-16:47Z samples and settling at
+# 0.2-4.4/s with a single 22.9/s spike. data-qa ran a flat 59/s over the same
+# period and fell to 0.25/s in the same window. 50 is therefore below both
 # observed pathological levels and more than twice the largest post-fix spike --
 # but it rests on roughly an hour of healthy baseline, so revisit it once a week
 # of post-fix series exists. for_=15m means a sustained ~45,000 client connects
 # before it fires, which no burst of legitimate work produces.
+#
+# Know what this rule stops seeing at that point. The 16:40Z rollout ended the
+# port exhaustion but not the connection failures: for the next ~70 minutes the
+# daemon kept failing to get connections at ~30/min, now against its own
+# SQLAlchemy pool ("QueuePool limit of size 10 overflow 10 reached, connection
+# timed out"), with churn already down at 0.7/s. Client-side pool saturation is a
+# third axis that neither this rule nor the concurrency rules above can reach --
+# only DagsterDatabaseConnectionFailures in log_rules/dagster_database.py spans
+# all of it, because it matches Dagster's retry wrapper rather than any one error.
+# Treat this rule as the leading indicator for one failure mode, not as coverage.
 _SERVER_ASSIGNMENTS_PER_SECOND = 50
 
 


### PR DESCRIPTION
## What are the relevant tickets?

Follow-up to #5506, from verifying that PR's rules after they deployed.

## Description (What does it do?)

Comment-only corrections to `metric_rules/dagster_pgbouncer.py` and `log_rules/dagster_database.py`. No rule, threshold, expression or label changes — `pulumi preview` on QA reports **33 unchanged, no diff**.

## Why?

Checking the deployed rules turned up two errors in the comments #5506 shipped.

**1. Wrong timestamp.** The pooled storage classes rolled at **~16:40Z** on 2026-08-18, not 17:22Z — churn fell 415 → 50.7 → 0.7/s across the 16:37–16:47Z samples. The earlier figure was an epoch misconversion on my part.

**2. The rollout did not "drop it to zero".** It ended one failure mode and exposed another:

| window | what was happening |
|---|---|
| until ~16:40Z | non-pooling storages — churn 415/s, ~270 retries/min, psycopg2 `Cannot assign requested address`. Real ephemeral port exhaustion. |
| ~16:50–17:50Z | churn already down at 0.7/s, yet the daemon still could not get connections, ~30/min, different error entirely: `QueuePool limit of size 10 overflow 10 reached, connection timed out`. Client-side SQLAlchemy pool saturation, not the network. |
| after ~17:50Z | clean. |

**The churn metric went quiet 70 minutes before the daemon stopped failing.** `DagsterDatabaseConnectionFailures` spanned both phases, because it matches Dagster's retry wrapper rather than any particular psycopg2 error. That's a considerably better argument for keeping the pair than the one #5506 shipped — which was reasoning from a single failure mode that hadn't yet been seen splitting in two — so the docstring now carries it, along with an explicit warning against narrowing the log filter to whichever error string is freshest.

Two smaller accuracy fixes while in there: #5506 added a pool-side rule that *does* see the churn, so the claim that no pool-side rule can is no longer true (narrowed to concurrency rules); and "every rule in `dagster_pgbouncer.py` stayed correctly quiet" is now scoped to the rules that existed at the time, since the churn rule would have fired on phase one.

## How can this be tested?

`pulumi preview --stack QA` → `Resources: 33 unchanged`. pre-commit (ruff format/check, mypy) clean.

## Anything else?

`exec_err_state` was the other half of this follow-up, but #5508 landed it independently and already covers both modules on the house convention (warning → `OK`, critical → `KeepLast`). Nothing left to do there — and the clean preview above confirms those values are applied with no drift.

Post-deploy state of #5506's rules, for the record: both groups live, all 9 rules across `dagster-pgbouncer` and `dagster-database-connections` reporting `health: ok`, `lastError: null`, `state: inactive`. Replaying each rule's exact expression over the incident window returns data continuously and nothing now, so the selectors are sound and the silence is real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eg3nwesGs5gzcjmR1JzUZ6