### PR TITLE
fix(dagster): size QA's event_log QueuePool, which has been failing continuously

### DIFF
--- a/src/ol_infrastructure/applications/dagster/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/dagster/Pulumi.Production.yaml
@@ -39,9 +39,10 @@ config:
   # 1000+ "QueuePool limit" timeouts in 41 minutes on 2026-08-18 under
   # automation_condition_evaluator load. See the full derivation, including
   # the per-pod PgBouncer math this is checked against, in
-  # dagster_instance.yaml's event_log_storage comment. Not set on QA: its
-  # per-pod cap (382) is already tight enough that a prior run-worker
-  # incident deadlocked the whole pool, and it has not shown this failure
-  # mode, so it stays on the conservative fallback in __main__.py.
+  # dagster_instance.yaml's event_log_storage comment. QA sets its own, smaller
+  # value (45, see Pulumi.QA.yaml): it turned out to have the same failure and
+  # to have been logging it continuously, but its per-pod cap is 382 against
+  # this stack's 708 and a prior run-worker incident deadlocked its whole pool,
+  # so it gets a sizing pass of its own rather than this number.
   dagster:event_log_pool_size: 100
   dagster:event_log_max_overflow: 50

--- a/src/ol_infrastructure/applications/dagster/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/dagster/Pulumi.QA.yaml
@@ -31,5 +31,32 @@ config:
   # Revisit once the pgbouncer exporter has enough history to show what a run
   # worker really holds outside a deadlock.
   dagster:max_concurrent_runs: 20
+  # event_log_storage's QueuePool ceiling. QA was left on the 10+10 fallback
+  # when Production was sized on 2026-08-18, on the stated grounds that it had
+  # not shown the failure mode. It had, and still does: at 20:38Z the daemon was
+  # logging "QueuePool limit of size 10 overflow 10 reached, connection timed
+  # out" continuously -- 100-250 lines per 10 minutes, sustained over at least
+  # eight hours, with both user-code servers contributing as well. Same failure
+  # Production fixed, never fixed here.
+  #
+  # 45 rather than Production's 150, by the same per-pod arithmetic in
+  # dagster_instance.yaml's event_log_storage comment: worst case the daemon and
+  # both webserver replicas peg this ceiling on one pgbouncer pod, which is
+  # 3 x (45 + run storage 30 + schedule storage 30) = 315 against QA's 382 cap.
+  # That is 82%, deliberately under Production's own 630/708 = 89%, because QA
+  # carries risks Production does not: it has already deadlocked its entire pool
+  # once from run-worker connections alone, and its per-pod distribution is
+  # badly skewed (221 vs 4 measured) where Production's is even (1-18), so the
+  # worst case here is a real scenario rather than a pessimistic bound. Measured
+  # headroom at the time of writing: 183 and 182 connections per pod of 382.
+  #
+  # This is sized to be safe, not proven sufficient -- Production needed 7.5x
+  # (20 -> 150) and this is 2.25x, and QA runs the same code locations, so if
+  # automation-tick concurrency tracks asset count rather than run count it may
+  # still be short. DagsterDatabaseConnectionFailuresWarning fires on exactly
+  # these log lines and was firing on QA when this was written: if it stays
+  # firing once this ships, raise both numbers again.
+  dagster:event_log_pool_size: 30
+  dagster:event_log_max_overflow: 15
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa

--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -2247,10 +2247,13 @@ dagster_max_concurrent_runs = dagster_config.get_int("max_concurrent_runs") or 1
 # event_log_storage's pool_size/max_overflow, same reasoning as
 # max_concurrent_runs above: sized against the environment's PgBouncer
 # per-pod cap, so it has to be a stack config value rather than a literal in
-# dagster_instance.yaml. Production needed a large bump after 2026-08-18 (see
-# the rationale in dagster_instance.yaml); the 10+10 fallback here is the
-# pre-incident size, deliberately conservative for any stack -- QA included
-# -- that has not set its own value and has not demonstrated the same need.
+# dagster_instance.yaml. Production sets 100+50 and QA 30+15, each derived
+# against its own cap (see the rationale in dagster_instance.yaml).
+#
+# The 10+10 fallback here is the pre-incident size. Treat a stack sitting on it
+# as unsized, not as measured and fine: QA sat here for a day after Production
+# was fixed, on the assumption it had not shown the failure, while its daemon
+# logged QueuePool timeouts continuously the whole time.
 #
 # `or 10` would be wrong here: max_overflow=0 is a legitimate, deliberately
 # conservative stack choice (forbid burst connections entirely), and `0 or 10`

--- a/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
+++ b/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
@@ -205,14 +205,22 @@ run_retries:
 # config, the same mechanism as run_coordinator's MAX_CONCURRENT_RUNS below --
 # not a literal, because the right ceiling depends on the environment's own
 # PgBouncer budget. Production sets 100+50, a 150-connection ceiling for this
-# storage alone; the fallback in __main__.py is the original 10+10 for any
-# stack, QA included, that has not set its own value and has not shown the
-# same need. Giving every stack Production's number by default is exactly
-# what put QA's pool at risk here: QA's per-pod cap is 382 against
-# Production's 708, and QA has already deadlocked its whole pool once from
-# run-worker connections alone (see the 2026-08-17 incident notes in
-# __main__.py) -- it cannot absorb a 150-connection ceiling on top of that
-# without its own sizing pass.
+# storage alone; QA sets 30+15 for a 45-connection one; the fallback in
+# __main__.py is the original 10+10 for any stack that has set neither.
+#
+# QA's own number is the cautionary tale for how these get chosen. It was left
+# on the fallback when Production was sized, on the stated grounds that it had
+# not shown this failure -- and it had, continuously, at 100-250 timeout lines
+# per 10 minutes, unnoticed for as long as nothing was watching for them.
+# Assume a stack on the fallback is unsized rather than measured-and-fine, and
+# check DagsterDatabaseConnectionFailures before concluding otherwise.
+#
+# What was right about that decision is that QA did not simply inherit
+# Production's number: QA's per-pod cap is 382 against Production's 708, and
+# QA has already deadlocked its whole pool once from run-worker connections
+# alone (see the 2026-08-17 incident notes in __main__.py), so it cannot absorb
+# a 150-connection ceiling on top of that. Its 45 is derived against its own
+# cap by the same arithmetic used for Production below.
 #
 # Production's number, checked against __main__.py's per-pod PgBouncer math
 # (not just the aggregate budget, for the reason in the top-of-file comment):


### PR DESCRIPTION
## What are the relevant tickets?

`tk-verify-the-pgbouncer-pool-re-tune-against-the-ex-71af3e` (updated with the full finding). Follow-on from #5497 / #5499 / #5506.

## Description (What does it do?)

Sets `dagster:event_log_pool_size: 30` / `dagster:event_log_max_overflow: 15` on QA — a 45-connection ceiling, up from the 10+10 fallback — and corrects the three comments that asserted QA had never shown this failure.

## Why?

QA was left on the fallback when Production was sized on 2026-08-18, on the explicit grounds that it "has not shown this failure mode". **It had, and still does.** Confirmed live at 20:38Z:

- The daemon logs `QueuePool limit of size 10 overflow 10 reached, connection timed out, timeout 30.00` **continuously** — 100–250 lines per 10 minutes, sustained over at least eight hours, 706 in a single hour.
- Both user-code servers contribute (edxorg ~10/10min, learning-resources ~6–20/10min).

Three places said otherwise and are corrected here: `Pulumi.Production.yaml`, `dagster_instance.yaml`'s `event_log_storage` comment, and `__main__.py`. They were wrong from the moment Production shipped; nothing was watching for the log line that would have said so.

## How was 45 picked?

The per-pod arithmetic already in `dagster_instance.yaml`, applied to QA's own cap. Worst case the daemon and both webserver replicas peg this ceiling on one pgbouncer pod:

```
3 x (event_log 45 + run_storage 30 + schedule_storage 30) = 315   against a 382 per-pod cap  = 82%
```

Deliberately under Production's own `630/708 = 89%`, because QA's risk profile is worse: it has already deadlocked its entire pool once from run-worker connections alone, and its per-pod distribution is skewed 221-vs-4 where Production's is an even 1-18 — so the worst case here is a plausible scenario, not a pessimistic bound. Measured headroom at time of writing: **183 and 182 connections per pod, of 382.**

**This is sized to be safe, not proven sufficient.** Production needed 7.5x (20 → 150); this is 2.25x. QA runs the same code locations, so if automation-tick concurrency tracks asset count rather than run count, 45 may still be short. That's an acceptable risk only because the feedback loop now exists — `DagsterDatabaseConnectionFailuresWarning` (shipped in #5506 hours earlier) fires on exactly these lines and **was firing on the QA Grafana stack as this was written**. If it stays firing after this lands, raise both numbers again; if it clears, 45 was enough.

The asymmetry drove the direction: a QueuePool timeout is noisy but self-recovering, while the deadlock froze QA for days.

## ⚠️ Heads-up before applying — unrelated drift rides along

`pulumi preview --stack QA` shows `Resources: ~ 2 to update`, and the intended change is exactly right (`pool_size: 10 => 30`, `max_overflow: 10 => 15`, with the `checksum/ol-dagster-instance` annotation changing so the daemon and webserver pods actually roll).

But it also carries **`image.tag: "359689f7" => "latest"`** on both releases. QA sets no `dagster:docker_image_tag`, so the code falls back to `latest`, while the deployed state is pinned to `359689f7`. This is pre-existing drift, not caused by this PR — but applying this change as the repo stands would also move QA's Dagster image to `latest`. I have deliberately not touched it. Worth deciding before this is applied.

## How can this be tested?

`pulumi preview --stack QA` as above. pre-commit (yamllint, ruff, mypy) clean. Production and CI previews are unaffected by the QA-only config keys.

After apply, the check `dagster_instance.yaml` asks for: `pgbouncer_databases_current_connections` **per pod, not summed** — it should stay well under 382 — and `DagsterDatabaseConnectionFailuresWarning` on the QA stack should clear.

## Anything else?

`DagsterPgBouncerConnectionChurn` stayed **inactive** on QA throughout this, while the log rule fired. That's live confirmation of the pairing argument in #5515: the pool-side churn metric structurally cannot see client-side pool saturation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eg3nwesGs5gzcjmR1JzUZ6