### PR TITLE
fix(mit-learn): reduce Postgres logging overhead for duplicate-key errors

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -540,6 +540,19 @@ mitlearn_db_config = OLPostgresDBConfig(
 mitlearn_db_config.parameter_overrides.append(
     {"name": "password_encryption", "value": "md5"}
 )
+# A runaway celery task duplication bug (mitodl/mit-learn#3785) is flooding the
+# error log with full STATEMENT text for routine duplicate-key violations,
+# ballooning log volume from ~25KB/hr to 1-3GB/hr and burning CPU/IO on the
+# logging itself. Raising this stops the STATEMENT echo for ordinary ERROR
+# severity (the message/DETAIL lines still log); explicit "immediate" apply
+# method avoids the pending-reboot default for unlisted parameters.
+mitlearn_db_config.parameter_overrides.append(
+    {
+        "name": "log_min_error_statement",
+        "value": "panic",
+        "apply_method": "immediate",
+    }
+)
 
 mitlearn_db = OLAmazonDB(
     db_config=mitlearn_db_config,


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Adds `log_min_error_statement=panic` (applied `immediate`, no reboot required) to the mit-learn Postgres parameter group.

**Incident context:** tonight a Celery task duplication bug in [mit-learn#3785](https://github.com/mitodl/mit-learn/pull/3785) caused `get_learning_resource_views` (an `acks_late=True` task) to exceed the Redis broker's visibility timeout on a large batch. The broker redelivered the same "lost" task to other workers while the original kept running, so duplicate copies across the worker fleet all tried to insert the same PostHog view-tracking events. Every duplicate attempt raised `duplicate key value violates unique constraint "learning_resources_lrviewevent_event_uuid_uniq"`, and Postgres was logging the *full failed INSERT statement text* for each one — ballooning `ol-mitlearn-db-production`'s error log from ~25KB/hr to 1-3GB/hr and driving sustained 90-98% RDS CPU for ~2.5 hours (CloudWatch alarm `simple-rds-ol-mitlearn-db-production-CPUUtilization`).

Raising `log_min_error_statement` to `panic` stops Postgres from echoing the `STATEMENT:` text for ordinary `ERROR`-severity failures like this one (the `ERROR:`/`DETAIL:` lines still log, so visibility into the errors themselves isn't lost). It only reduces the logging/IO overhead — it does not address the underlying duplication bug, which is fixed in mit-learn#3785 (merged to `main`, not yet on `release`).

This change was already applied directly to the production parameter group during the incident (via a `pulumi up --target` scoped to just this resource) to get immediate relief; this PR brings the Pulumi source back in sync so it doesn't drift on the next full `pulumi up`.

### How can this be tested?
`pulumi preview` against the `mit_learn` `Production` stack should show only this parameter being added to `ol-mitlearn-db-production`'s parameter group (already applied live, so preview should be a no-op against current AWS state). No app deploy or restart involved — `log_min_error_statement` is a dynamic Postgres parameter.

### Additional Context
Related follow-ups (not addressed in this PR):
- Cherry-pick/deploy [mit-learn#3785](https://github.com/mitodl/mit-learn/pull/3785) to `release` — the actual fix for the task duplication.
- Celery beat for mit-learn runs with `--scheduler celery.beat.PersistentScheduler` even though the app's Django settings (`CELERY_BEAT_SCHEDULER = RedBeatScheduler`) expect RedBeat, causing a recurring (so far harmless) `AttributeError: 'PersistentScheduler' object has no attribute 'lock_key'` on every beat pod start. Worth reconciling separately.