### PR TITLE
refactor(keycloak): flatten the mitlearn-admin Vault path

### DIFF
--- a/src/ol_infrastructure/substructure/keycloak/olapps.py
+++ b/src/ol_infrastructure/substructure/keycloak/olapps.py
@@ -554,10 +554,11 @@ def create_olapps_realm(  # noqa: PLR0913, PLR0915
             )
         vault.generic.Secret(
             "olapps-mitlearn-admin-client-vault-credentials",
-            # Nested under sso/mitlearn/ so the app's existing Vault policy
-            # ("secret-operations/sso/mitlearn/*") already grants read access.
-            # A sibling path such as sso/mitlearn-admin would not be matched.
-            path="secret-operations/sso/mitlearn/admin",
+            # Flat, like every other client entry under secret-operations/sso/
+            # (including the marimo/marimo-app pair). Note this is a sibling of
+            # sso/mitlearn rather than a child, so mitlearn_policy.hcl grants
+            # read on it explicitly — the sso/mitlearn/* glob does not match it.
+            path="secret-operations/sso/mitlearn-admin",
             data_json=Output.all(
                 url=olapps_mitlearn_admin_client.realm_id.apply(
                     lambda realm_id: f"{keycloak_url}/realms/{realm_id}"


### PR DESCRIPTION
### Ticket:
https://github.com/mitodl/hq/issues/10815

### What are the relevant tickets?

Follow-up to #5252, which is already merged and applied. Consuming PR: #5520.

### Description (What does it do?)

Moves the `mitlearn-admin-client` credentials from
`secret-operations/sso/mitlearn/admin` to `secret-operations/sso/mitlearn-admin`,
per review feedback on #5252.

Every other client entry under `secret-operations/sso/` is flat — 22 of them — and
`sso/mitlearn/admin` was the only nested one. `marimo` / `marimo-app` already
establishes the sibling naming for a second entry belonging to the same app, so this
follows that.

#### Why it was nested, and why that no longer wins

The nesting bought a policy shortcut: `mitlearn_policy.hcl` already grants read on
`secret-operations/sso/mitlearn/*`, so a child path needed no policy change. A
sibling is **not** matched by that glob, so it needs its own stanza — which #5520
adds, next to the code that reads the path.

That's a fair trade: an explicit grant listing exactly which secrets the app can read
is easier to audit than a path shaped to fit an existing wildcard.

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
N/A — no user-visible change.

### How can this be tested?

#5252 has already been applied, so the old path exists and this is a move rather
than a first write. Per environment, CI → QA → Production:

1. `pulumi preview` on **`ol-substructure-keycloak`** and confirm it shows the Vault
   secret being **replaced** rather than only created — `path` is immutable on
   `vault_generic_secret`, so the old key is deleted as part of the replace. The
   Keycloak client itself is untouched, so no credential rotation.
2. Apply the stack.
3. Confirm the new path is populated and the old one is gone:
   ```bash
   vault kv get secret-operations/sso/mitlearn-admin      # expect client_id, client_secret, realm_name, realm_id, url
   vault kv get secret-operations/sso/mitlearn/admin      # expect "No value found"
   ```
4. Only then apply #5520 for the same environment, which adds the policy stanza and
   the Kubernetes secret that reads the new path.

### Additional Context

**Nothing is reading the old path yet**, which is what makes this safe to do now:
#5252 wrote the secret but the consumer (#5520) has not been applied in any
environment. So there is no window where a running pod points at a path that no
longer exists.

**Ordering with #5520 is unchanged and still strict.** #5520 attaches the Kubernetes
secret via `envFrom.secretRef` without `optional: true`, so applying it before this
change lands leaves the operator reading a path that doesn't exist — new pods come up
`CreateContainerConfigError` and the rollout stalls.

**If #5520 is applied without the policy stanza**, the symptom is the same stall
rather than an obvious permissions error: Vault returns 403, the operator can't
populate the secret, and the pod can't start. The stanza and the consumer are in the
same PR so they can't drift apart.
