### PR TITLE
chore(otel): drop deployment.environment from OTEL_RESOURCE_ATTRIBUTES

### DIFF
--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.Production.yaml
@@ -40,7 +40,7 @@ config:
     NODE_ENV: "development"
     OPENTELEMETRY_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/traces"
     OPENTELEMETRY_SERVICE_NAME: "learn-ai-webapp"
-    OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=production,service.namespace=learn-ai,service.instance.id=$(KUBERNETES_POD_NAME)"
+    OTEL_RESOURCE_ATTRIBUTES: "service.namespace=learn-ai,service.instance.id=$(KUBERNETES_POD_NAME)"
     OTEL_TRACES_SAMPLER: "parentbased_traceidratio"
     OTEL_TRACES_SAMPLER_ARG: "0.25"
     OTEL_PROPAGATORS: "tracecontext,baggage"

--- a/src/ol_infrastructure/applications/learn_ai/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/learn_ai/Pulumi.QA.yaml
@@ -43,7 +43,7 @@ config:
     NODE_ENV: "development"
     OPENTELEMETRY_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/traces"
     OPENTELEMETRY_SERVICE_NAME: "learn-ai-webapp"
-    OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=qa,service.namespace=learn-ai,service.instance.id=$(KUBERNETES_POD_NAME)"
+    OTEL_RESOURCE_ATTRIBUTES: "service.namespace=learn-ai,service.instance.id=$(KUBERNETES_POD_NAME)"
     OTEL_TRACES_SAMPLER: "parentbased_traceidratio"
     OTEL_TRACES_SAMPLER_ARG: "0.25"
     OTEL_PROPAGATORS: "tracecontext,baggage"

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.Production.yaml
@@ -114,7 +114,7 @@ config:
     OIDC_ENDPOINT: "https://sso.ol.mit.edu/realms/olapps"
     OPENTELEMETRY_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/traces"
     OPENTELEMETRY_SERVICE_NAME: "learn-webapp"
-    OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=production,service.namespace=learn,service.instance.id=$(KUBERNETES_POD_NAME)"
+    OTEL_RESOURCE_ATTRIBUTES: "service.namespace=learn,service.instance.id=$(KUBERNETES_POD_NAME)"
     OTEL_TRACES_SAMPLER: "parentbased_traceidratio"
     OTEL_TRACES_SAMPLER_ARG: "0.25"
     OTEL_PROPAGATORS: "tracecontext,baggage"

--- a/src/ol_infrastructure/applications/mit_learn/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/mit_learn/Pulumi.QA.yaml
@@ -94,7 +94,7 @@ config:
     OIDC_ENDPOINT: "https://sso-qa.ol.mit.edu/realms/olapps"
     OPENTELEMETRY_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/traces"
     OPENTELEMETRY_SERVICE_NAME: "learn-webapp"
-    OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=qa,service.namespace=learn,service.instance.id=$(KUBERNETES_POD_NAME)"
+    OTEL_RESOURCE_ATTRIBUTES: "service.namespace=learn,service.instance.id=$(KUBERNETES_POD_NAME)"
     OTEL_TRACES_SAMPLER: "parentbased_traceidratio"
     OTEL_TRACES_SAMPLER_ARG: "0.25"
     OTEL_PROPAGATORS: "tracecontext,baggage"

--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.Production.yaml
@@ -58,7 +58,7 @@ config:
     OPENEDX_STUDIO_API_BASE_URL: "https://studio.courses.learn.mit.edu"
     OPENTELEMETRY_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/traces"
     OPENTELEMETRY_SERVICE_NAME: "mitxonline-webapp"
-    OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=production,service.namespace=mitxonline,service.instance.id=$(KUBERNETES_POD_NAME)"
+    OTEL_RESOURCE_ATTRIBUTES: "service.namespace=mitxonline,service.instance.id=$(KUBERNETES_POD_NAME)"
     OTEL_TRACES_SAMPLER: "parentbased_traceidratio"
     OTEL_TRACES_SAMPLER_ARG: "0.25"
     OTEL_PROPAGATORS: "tracecontext,baggage"

--- a/src/ol_infrastructure/applications/mitxonline/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/mitxonline/Pulumi.QA.yaml
@@ -52,7 +52,7 @@ config:
     OPENEDX_STUDIO_API_BASE_URL: "https://studio.courses.rc.learn.mit.edu"
     OPENTELEMETRY_ENDPOINT: "http://grafana-k8s-monitoring-alloy-receiver.grafana.svc.cluster.local:4318/v1/traces"
     OPENTELEMETRY_SERVICE_NAME: "mitxonline-webapp"
-    OTEL_RESOURCE_ATTRIBUTES: "deployment.environment=qa,service.namespace=mitxonline,service.instance.id=$(KUBERNETES_POD_NAME)"
+    OTEL_RESOURCE_ATTRIBUTES: "service.namespace=mitxonline,service.instance.id=$(KUBERNETES_POD_NAME)"
     OTEL_TRACES_SAMPLER: "parentbased_traceidratio"
     OTEL_TRACES_SAMPLER_ARG: "0.25"
     OTEL_PROPAGATORS: "tracecontext,baggage"

--- a/src/ol_infrastructure/applications/ol_analytics_api/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/applications/ol_analytics_api/Pulumi.CI.yaml
@@ -17,7 +17,7 @@ config:
     OTEL_TRACES_SAMPLER_ARG: "0.25"
     OTEL_PROPAGATORS: tracecontext,baggage
     OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT: "128"
-    OTEL_RESOURCE_ATTRIBUTES: deployment.environment=ci,service.namespace=ol-analytics
+    OTEL_RESOURCE_ATTRIBUTES: service.namespace=ol-analytics
     SENTRY_LOG_LEVEL: ERROR
     SENTRY_TRACES_SAMPLE_RATE: "0.001"
     SENTRY_PROFILES_SAMPLE_RATE: "0.1"

--- a/src/ol_infrastructure/applications/ol_analytics_api/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/ol_analytics_api/Pulumi.Production.yaml
@@ -17,7 +17,7 @@ config:
     OTEL_TRACES_SAMPLER_ARG: "0.25"
     OTEL_PROPAGATORS: tracecontext,baggage
     OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT: "128"
-    OTEL_RESOURCE_ATTRIBUTES: deployment.environment=production,service.namespace=ol-analytics
+    OTEL_RESOURCE_ATTRIBUTES: service.namespace=ol-analytics
     SENTRY_LOG_LEVEL: ERROR
     SENTRY_TRACES_SAMPLE_RATE: "0.001"
     SENTRY_PROFILES_SAMPLE_RATE: "0.1"

--- a/src/ol_infrastructure/applications/ol_analytics_api/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/ol_analytics_api/Pulumi.QA.yaml
@@ -17,7 +17,7 @@ config:
     OTEL_TRACES_SAMPLER_ARG: "0.25"
     OTEL_PROPAGATORS: tracecontext,baggage
     OTEL_SPAN_ATTRIBUTE_COUNT_LIMIT: "128"
-    OTEL_RESOURCE_ATTRIBUTES: deployment.environment=qa,service.namespace=ol-analytics
+    OTEL_RESOURCE_ATTRIBUTES: service.namespace=ol-analytics
     SENTRY_LOG_LEVEL: ERROR
     SENTRY_TRACES_SAMPLE_RATE: "0.001"
     SENTRY_PROFILES_SAMPLE_RATE: "0.1"

--- a/tests/ol_infrastructure/components/services/test_k8s_pod_identity_env.py
+++ b/tests/ol_infrastructure/components/services/test_k8s_pod_identity_env.py
@@ -26,8 +26,7 @@ def test_pod_identity_vars_come_first():
     env_vars = build_application_env_vars(
         {
             "OTEL_RESOURCE_ATTRIBUTES": (
-                "deployment.environment=production,"
-                "service.instance.id=$(KUBERNETES_POD_NAME)"
+                "service.namespace=learn,service.instance.id=$(KUBERNETES_POD_NAME)"
             ),
         }
     )


### PR DESCRIPTION
### What are the relevant tickets?

Part of the OpenTelemetry APM coverage project. Follows up on the review thread
https://github.com/mitodl/ol-infrastructure/pull/5498#discussion_r3813799667,
which flagged `ocw_studio` for *omitting* `deployment.environment` — the one
place omitting it is harmless.

### Description (What does it do?)

Removes `deployment.environment=<env>` from `OTEL_RESOURCE_ATTRIBUTES` in nine
stack configs: `mit_learn`, `learn_ai`, `mitxonline` (QA + Production) and
`ol_analytics_api` (CI + QA + Production).

The key never reached a span. `mitol-django-observability`'s `_get_resource()`
sets it explicitly from `settings.ENVIRONMENT`:

```python
attributes = {
    "service.name": ...,
    "service.version": getattr(settings, "VERSION", "unknown"),
    "deployment.environment": getattr(settings, "ENVIRONMENT", "unknown"),
}
return Resource.create(attributes)
```

`Resource.create` ends with
`get_aggregated_resources(detectors, _DEFAULT_RESOURCE).merge(Resource(attributes))`.
`Resource.merge(other)` gives precedence to the *updating* resource, and the env
var is read by `OTELResourceDetector`, which sits on the old side of that merge.
So the Django setting always won. `ol-analytics-api`'s ported `telemetry.py` has
the same shape.

### How can this be tested?

Confirmed against Tempo rather than inferred. Querying
`resource.deployment.environment` in the QA Grafana stack returns `qa` **and**
`rc`, splitting exactly along who sets it:

| value | services |
|---|---|
| `rc` | `mitxonline-webapp`, `learn-ai-webapp`, `learn-webapp` — every library adopter |
| `qa` | `apisix`, `traefik`, `learn-nextjs`, `qa-toolhive-swe-*` — no library |

`rc` is what `MITOL_ENVIRONMENT` / `MITX_ONLINE_ENVIRONMENT` are actually set to
for the QA stacks (`stack_info.name.lower() if stack_info.name != "QA" else "rc"`).
The stack config claimed `qa` for all of them. Production Tempo returns only
`production`, so nothing there was wrong — merely unread.

**This changes no emitted attribute.** The pods roll and report what they
reported before. `pulumi preview` on `mit_learn` QA shows the value edit on all
five deployments and a replacement of the immutable pre-deploy `Job`; on
`ol_analytics_api` Production the change count is identical to a clean-tree
baseline (`~2 to update` either way — the env-list reordering visible in the
diff is pre-existing drift, not from this change).

Audited every adopter for the `getattr(settings, "ENVIRONMENT", "unknown")`
fallback, which would silently write a service out of every environment-scoped
query: `mit-learn`, `learn-ai`, `mitxonline`, `mitxpro` and `odl-video-service`
all define `ENVIRONMENT`; `ol-analytics-api` sets `OL_ANALYTICS_API_ENVIRONMENT`
in all three stacks. No service is currently at risk.

Note: `tests/ol_infrastructure/components/services/test_k8s_pod_identity_env.py`
does not currently collect (`AttributeError: 'NoneType' object has no attribute
'Invoke'` at import) — identical on a clean tree, pre-existing and unrelated.

### Additional Context

Two follow-ups deliberately **not** in this PR:

1. **QA is split-brain on `deployment.environment` (`rc` vs `qa`).** Any
   environment-scoped query in QA is wrong for one half of the fleet. Fixing it
   means changing the `ENVIRONMENT` convention, which also drives Sentry
   environments and S3 bucket names — too wide for a config-hygiene change.
2. **The library could stop clobbering the env var** — only set
   `deployment.environment` when `settings.ENVIRONMENT` is genuinely defined,
   letting `OTELResourceDetector`'s value stand otherwise. That would make the
   env var live again, and is an `ol-django` change.

