### PR TITLE
fix(apisix): send OIDC hosts to a canonical https origin before openid-connect

### DIFF
--- a/src/ol_infrastructure/applications/jupyterhub/deployment.py
+++ b/src/ol_infrastructure/applications/jupyterhub/deployment.py
@@ -23,7 +23,7 @@ from ol_infrastructure.components.services.apisix import (
     OLApisixRouteConfig,
     OLApisixSharedPlugins,
     OLApisixSharedPluginsConfig,
-    oidc_error_callback_recovery_plugin,
+    oidc_gateway_pre_function_plugin,
     stale_session_cookie_cleanup_plugin,
 )
 from ol_infrastructure.components.services.cert_manager import (
@@ -187,11 +187,17 @@ def provision_jupyterhub_deployment(  # noqa: PLR0913
                 # host belongs to mit-learn, which clears it from its own
                 # routes.  Safe to delete once the old cookies have aged out.
                 stale_session_cookie_cleanup_plugin(),
-                # Same expired-authentication-session callbacks that api.learn
-                # and mitxonline see, at this host's much smaller volume (2/day
-                # on nb.learn.mit.edu).  Attached for consistency of behaviour
-                # across the OIDC-protected hosts rather than for the volume.
-                oidc_error_callback_recovery_plugin(),
+                # Two pre-openid-connect fixes, necessarily one plugin (APISIX
+                # allows a single serverless-pre-function per config).  The
+                # expired-authentication-session callbacks are the same ones
+                # api.learn and mitxonline see, at this host's much smaller
+                # volume (2/day).  The canonical-origin redirect matters more
+                # here than anywhere else: nb.learn and authoring.nb.learn are
+                # the two hosts Keycloak actually rejects today, 61 hits over
+                # 7 days between them, because they take direct plain-HTTP
+                # traffic that the `redirect` default plugin never gets to
+                # upgrade.
+                oidc_gateway_pre_function_plugin(),
             ],
         ),
     )

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -54,7 +54,7 @@ from ol_infrastructure.components.services.apisix import (
     OLApisixRouteConfig,
     OLApisixSharedPlugins,
     OLApisixSharedPluginsConfig,
-    oidc_error_callback_recovery_plugin,
+    oidc_gateway_pre_function_plugin,
     stale_session_cookie_cleanup_plugin,
 )
 from ol_infrastructure.components.services.cert_manager import (
@@ -1346,8 +1346,11 @@ learn_external_service_shared_plugins = OLApisixSharedPlugins(
             # openid-connect plugin serves each one a 500.  Both route groups
             # on this host need it, and the plugin derives its redirect target
             # from the request URI, so the /login and /learn/login prefixes are
-            # handled from this one attachment.
-            oidc_error_callback_recovery_plugin(),
+            # handled from this one attachment.  The same attachment also
+            # canonicalises the origin: `curl http://api.learn.mit.edu/login`
+            # currently sends Keycloak an http:// redirect_uri, and answers with
+            # an OIDC session cookie over cleartext.
+            oidc_gateway_pre_function_plugin(),
         ],
     ),
 )

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -50,7 +50,7 @@ from ol_infrastructure.components.services.apisix import (
     OLApisixRouteConfig,
     OLApisixSharedPlugins,
     OLApisixSharedPluginsConfig,
-    oidc_error_callback_recovery_plugin,
+    oidc_gateway_pre_function_plugin,
     stale_session_cookie_cleanup_plugin,
 )
 from ol_infrastructure.components.services.cert_manager import (
@@ -803,8 +803,10 @@ mitxonline_shared_plugins = OLApisixSharedPlugins(
             # cleanup below, this is safe to attach here rather than per route
             # group: it derives its redirect target from the request URI and
             # its guard cookie is host-only, so neither depends on which parent
-            # domain a group's session cookie was scoped to.
-            oidc_error_callback_recovery_plugin(),
+            # domain a group's session cookie was scoped to.  Ditto the
+            # canonical-origin redirect it also carries, which is derived from
+            # the request's own host.
+            oidc_gateway_pre_function_plugin(),
         ],
     ),
 )

--- a/src/ol_infrastructure/components/services/apisix.py
+++ b/src/ol_infrastructure/components/services/apisix.py
@@ -15,12 +15,15 @@ from ol_infrastructure.components.services.vault import (
 )
 from ol_infrastructure.lib.pulumi_helper import parse_stack
 
-# Read once at import: the file is shipped verbatim as the serverless function
-# body, with configuration passed separately on the plugin config.
+# Read once at import: the files are shipped verbatim as serverless function
+# bodies, with configuration passed separately on the plugin config.
 OIDC_ERROR_RECOVERY_LUA = (
     Path(__file__)
     .parent.joinpath("files", "oidc_error_callback_recovery.lua")
     .read_text()
+)
+CANONICAL_HTTPS_REDIRECT_LUA = (
+    Path(__file__).parent.joinpath("files", "canonical_https_redirect.lua").read_text()
 )
 
 
@@ -112,21 +115,60 @@ end"""
     )
 
 
-def oidc_error_callback_recovery_plugin(
+def oidc_gateway_pre_function_plugin(
     recoverable_errors: list[str] | None = None,
     guard_cookie_name: str = "apisix_oidc_recovery",
     guard_max_age: int = 60,
+    *,
+    canonical_https_redirect: bool = True,
+    canonical_redirect_status: int = 308,
 ) -> OLApisixPluginConfig:
-    """Restart the login flow when the IdP redirects back with a recoverable error.
+    """Everything that has to happen before openid-connect sees the request.
 
-    An authorization request whose Keycloak authentication session has expired
-    -- the user left the login tab open, or followed a stale bookmark -- comes
-    back to the callback with ``error=temporarily_unavailable`` and no ``code``.
+    APISIX keys a plugin config by plugin name, so a route can carry exactly ONE
+    ``serverless-pre-function``.  Both of the fixes below have to run ahead of
+    openid-connect (priority 2599), and ``serverless-pre-function`` (priority
+    10000) is the only hook that gets there, so they are necessarily one plugin
+    rather than two.  ``serverless/init.lua`` runs ``functions`` in array order
+    and stops at the first one returning a code or body, which is exactly the
+    sequencing wanted here: normalise the origin first, and only then look at
+    whether this is a failed callback.
+
+    **Canonical origin** (``canonical_https_redirect.lua``).  The shared-plugin
+    defaults already include APISIX's ``redirect`` plugin with ``http_to_https``,
+    but its priority is below openid-connect's, so on an OIDC route it is dead
+    code -- openid-connect has already answered.  The consequences are measured,
+    not hypothetical.  APISIX derives only a relative redirect_uri and
+    lua-resty-openidc 1.8.0 (the version APISIX 3.17 pins) makes it absolute from
+    ``ngx.var.scheme`` and ``ngx.var.http_host``, so a plain-HTTP request sends
+    Keycloak ``http://...`` and a request carrying ``Host: <host>:443`` sends
+    ``https://<host>:443/...``.  Keycloak registers bare-host https URIs only and
+    rejects both with ``error="invalid_redirect_uri"``; the login dies at the
+    authorization endpoint, before any callback exists for the recovery function
+    below to rescue.  Worse than the failed logins: because the upgrade never
+    runs, APISIX answers plain-HTTP requests with an OIDC session cookie over
+    cleartext and without the ``Secure`` attribute.
+
+    Redirecting is what fixes this, not header-setting.  lua-resty-openidc does
+    prefer ``Forwarded`` / ``X-Forwarded-Proto`` / ``X-Forwarded-Host`` over those
+    ngx vars, but on this deployment none of the three reaches it -- sending each
+    against production leaves the redirect_uri unchanged -- so pinning them would
+    be a no-op dressed up as a fix.
+
+    Note this leaves port 80 answering with a redirect rather than closing it.
+    That is only safe because every ACME ClusterIssuer on the cluster solves via
+    dns01/Route53; an issuer switched to http-01 would need its challenge path
+    carved out of the redirect.
+
+    **Error-callback recovery** (``oidc_error_callback_recovery.lua``).  An
+    authorization request whose Keycloak authentication session has expired --
+    the user left the login tab open, or followed a stale bookmark -- comes back
+    to the callback with ``error=temporarily_unavailable`` and no ``code``.
     Keycloak's intent there is that the client start over; it even marks the
-    event ``restart_after_timeout="true"``.  ``lua-resty-openidc`` instead
-    treats any ``error`` parameter as fatal and hands the openid-connect plugin
-    a failure, which APISIX serves as a 21KB HTTP 500.  The user sees a
-    stack-trace page where they expected a login form, and nothing retries.
+    event ``restart_after_timeout="true"``.  ``lua-resty-openidc`` instead treats
+    any ``error`` parameter as fatal and hands the openid-connect plugin a
+    failure, which APISIX serves as a 21KB HTTP 500.  The user sees a stack-trace
+    page where they expected a login form, and nothing retries.
 
     This is measured, not hypothetical: 614 such callbacks a day across
     api.learn.mit.edu, mitxonline.mit.edu and nb.learn.mit.edu, from 530
@@ -154,14 +196,15 @@ def oidc_error_callback_recovery_plugin(
     looping: a persistently broken IdP should surface as an error, not as an
     infinite redirect.
 
-    The Lua itself lives in ``files/oidc_error_callback_recovery.lua`` and is
-    shipped verbatim -- nothing is interpolated into it.  Tunables travel as an
-    ``oidc_error_recovery`` block on the plugin config, which the function reads
-    off ``conf``: ``serverless/init.lua`` invokes each function as
+    Both functions live in ``files/`` and are shipped verbatim -- nothing is
+    interpolated into them.  Tunables travel as ``oidc_error_recovery`` and
+    ``canonical_https_redirect`` blocks on the plugin config, which the functions
+    read off ``conf``: ``serverless/init.lua`` invokes each as
     ``func(conf, ctx)``, and its schema does not set ``additionalProperties``,
-    so extra keys validate.  Keeping it a real ``.lua`` file means it is
+    so extra keys validate.  Keeping them real ``.lua`` files means they are
     syntax-highlighted, reviewable, and testable under APISIX's own test-nginx
-    harness (``t/oidc_error_callback_recovery.t``).
+    harness (``t/oidc_error_callback_recovery.t``,
+    ``t/canonical_https_redirect.t``).
 
     :param recoverable_errors: OAuth 2.0 ``error`` codes to restart the flow
         for.  Defaults to ``temporarily_unavailable``, which is 100% of what
@@ -171,21 +214,35 @@ def oidc_error_callback_recovery_plugin(
     :param guard_cookie_name: Name of the loop-breaker cookie.
     :param guard_max_age: Seconds the guard cookie lives, bounding how often one
         browser can be sent back through login.
+    :param canonical_https_redirect: Whether to send non-canonical origins to
+        ``https://<bare host>`` before openid-connect runs.  ``False`` drops the
+        function entirely, for a host that must keep answering on plain HTTP.
+    :param canonical_redirect_status: Status for that redirect.  308 preserves
+        the method and body; 301 is what APISIX's own ``redirect`` plugin would
+        have sent, at the cost of turning an upgraded POST into a GET.
 
     :returns: A ``serverless-pre-function`` plugin config to attach to routes.
     :rtype: OLApisixPluginConfig
     """
+    # Order matters and is load-bearing: serverless/init.lua stops at the first
+    # function returning a code, so the origin has to be canonical before the
+    # recovery function decides whether to redirect back into the login flow.
+    functions = [OIDC_ERROR_RECOVERY_LUA]
+    if canonical_https_redirect:
+        functions.insert(0, CANONICAL_HTTPS_REDIRECT_LUA)
     return OLApisixPluginConfig(
         name="serverless-pre-function",
         secretRef=None,
         # rewrite rather than the plugin's default access phase: openid-connect
         # also runs in rewrite, and serverless-pre-function's priority (10000)
-        # outranks it (2599), so this gets to inspect the callback and bail out
-        # before the plugin turns the error parameter into a 500.  In the access
-        # phase it would run after openid-connect had already failed.
+        # outranks it (2599), so this gets to normalise the origin and inspect
+        # the callback before the plugin reads either.  In the access phase it
+        # would run after openid-connect had already built its redirect_uri and
+        # failed.
         config={
             "phase": "rewrite",
-            "functions": [OIDC_ERROR_RECOVERY_LUA],
+            "functions": functions,
+            "canonical_https_redirect": {"status": canonical_redirect_status},
             "oidc_error_recovery": {
                 # `is None`, not `or`: an explicit empty list means "recover
                 # nothing", and `or` would quietly turn that back into the

--- a/src/ol_infrastructure/components/services/apisix.py
+++ b/src/ol_infrastructure/components/services/apisix.py
@@ -26,6 +26,10 @@ CANONICAL_HTTPS_REDIRECT_LUA = (
     Path(__file__).parent.joinpath("files", "canonical_https_redirect.lua").read_text()
 )
 
+# The only statuses ngx.redirect accepts; anything else is a Lua error at
+# request time (ngx_http_lua_control.c:209-219).
+NGX_REDIRECT_STATUSES = (301, 302, 303, 307, 308)
+
 
 class OLApisixPluginConfig(BaseModel):
     """Configuration for a single APISIX plugin instance.
@@ -121,7 +125,7 @@ def oidc_gateway_pre_function_plugin(
     guard_max_age: int = 60,
     *,
     canonical_https_redirect: bool = True,
-    canonical_redirect_status: int = 308,
+    canonical_redirect_status: Literal[301, 302, 303, 307, 308] = 308,
 ) -> OLApisixPluginConfig:
     """Everything that has to happen before openid-connect sees the request.
 
@@ -217,13 +221,29 @@ def oidc_gateway_pre_function_plugin(
     :param canonical_https_redirect: Whether to send non-canonical origins to
         ``https://<bare host>`` before openid-connect runs.  ``False`` drops the
         function entirely, for a host that must keep answering on plain HTTP.
-    :param canonical_redirect_status: Status for that redirect.  308 preserves
-        the method and body; 301 is what APISIX's own ``redirect`` plugin would
-        have sent, at the cost of turning an upgraded POST into a GET.
+    :param canonical_redirect_status: Status for that redirect, uniform across
+        methods.  APISIX's own ``redirect`` plugin instead picks per method --
+        301 for GET/HEAD, 308 for everything else (``redirect.lua`` 208-215) --
+        so 308 here is a simplification rather than a behavioural fix: both
+        preserve a POST.  Restricted to the codes ``ngx.redirect`` accepts.
 
     :returns: A ``serverless-pre-function`` plugin config to attach to routes.
     :rtype: OLApisixPluginConfig
     """
+    # Checked rather than left to the annotation: the `Literal` above documents
+    # the contract but nothing enforces it at the call sites, since this repo's
+    # mypy hook runs without the project installed and resolves a cross-module
+    # import to Any.  APISIX will not catch it either -- the block this travels
+    # in is not part of serverless-pre-function's schema -- so an unchecked bad
+    # value would first surface as a 500 on live traffic.  Raising here moves
+    # that to `pulumi preview`.
+    if canonical_redirect_status not in NGX_REDIRECT_STATUSES:
+        msg = (
+            f"canonical_redirect_status must be one of {NGX_REDIRECT_STATUSES}, "
+            f"got {canonical_redirect_status}: ngx.redirect rejects anything else."
+        )
+        raise ValueError(msg)
+
     # Order matters and is load-bearing: serverless/init.lua stops at the first
     # function returning a code, so the origin has to be canonical before the
     # recovery function decides whether to redirect back into the login flow.

--- a/src/ol_infrastructure/components/services/files/canonical_https_redirect.lua
+++ b/src/ol_infrastructure/components/services/files/canonical_https_redirect.lua
@@ -54,9 +54,11 @@ return function(conf, ctx)
     core.log.warn("non-canonical origin scheme=", ngx.var.scheme,
                   " host=", raw_host, " redirecting to https://", host)
 
-    -- 308 rather than the 301 the shadowed `redirect` plugin would have sent:
-    -- it preserves the method and body, so an upgraded POST stays a POST
-    -- instead of being silently downgraded to a GET.
+    -- One status for every method. The shadowed `redirect` plugin picks per
+    -- method instead -- 301 for GET/HEAD, 308 for the rest (redirect.lua
+    -- 208-215) -- so both preserve a POST and this is a simplification, not a
+    -- behavioural fix. `status` is constrained in ../apisix.py to the codes
+    -- ngx.redirect accepts; anything else raises a Lua error here.
     return ngx.redirect("https://" .. host .. ngx.var.request_uri,
                         opts.status or 308)
 end

--- a/src/ol_infrastructure/components/services/files/canonical_https_redirect.lua
+++ b/src/ol_infrastructure/components/services/files/canonical_https_redirect.lua
@@ -1,0 +1,62 @@
+-- Send the request to the canonical https://<host> origin before the
+-- openid-connect plugin builds a redirect_uri out of it.
+--
+-- Attached as a serverless-pre-function in the `rewrite` phase, where this
+-- plugin's priority (10000) outranks openid-connect's (2599). That ordering is
+-- the whole point: the shared-plugin defaults already carry APISIX's `redirect`
+-- plugin with http_to_https, but `redirect` has a lower priority than
+-- openid-connect, so on an OIDC route it never gets to run.
+--
+-- APISIX only derives a *relative* redirect_uri (`<uri>/.apisix/redirect`), and
+-- lua-resty-openidc 1.8.0 -- the version pinned by APISIX 3.17 -- turns it
+-- absolute from `ngx.var.scheme` and `ngx.var.http_host`. Both are raw
+-- connection values, so a plain-HTTP request produces `http://...` and a
+-- request carrying `Host: example.org:443` produces `https://example.org:443/...`.
+-- Keycloak registers bare-host https URIs only, so it rejects both with
+-- error="invalid_redirect_uri" and the login dies at the authorization endpoint,
+-- before any callback exists to recover.
+--
+-- Normalising the request rather than the header is deliberate. lua-resty-openidc
+-- does consult `Forwarded` / `X-Forwarded-Proto` / `X-Forwarded-Host` ahead of
+-- those ngx vars, but on this deployment those headers demonstrably do not reach
+-- it: sending any of the three against production changes nothing about the
+-- redirect_uri. Setting them here would be a no-op that reads like a fix.
+--
+-- Configuration arrives on the plugin config under `canonical_https_redirect`,
+-- the same mechanism `oidc_error_callback_recovery.lua` uses.
+--
+--   canonical_https_redirect.status  redirect status code
+--
+-- See `oidc_gateway_pre_function_plugin` in ../apisix.py for the deployment
+-- reasoning and t/canonical_https_redirect.t for the behavioural tests.
+return function(conf, ctx)
+    -- $host is the Host header lowercased with any port stripped, falling back
+    -- to server_name; $http_host is the header verbatim. Comparing them catches
+    -- an explicit :443, an uppercased host, and anything else that would reach
+    -- lua-resty-openidc as a non-canonical authority.
+    local raw_host = ngx.var.http_host
+    local host = ngx.var.host
+
+    -- No Host header at all (HTTP/1.0). There is nothing to build a canonical
+    -- origin from -- $host would be the server_name -- so leave it alone and let
+    -- openid-connect's own 400 handle it.
+    if not raw_host or not host then
+        return
+    end
+
+    if ngx.var.scheme == "https" and raw_host == host then
+        return
+    end
+
+    local core = require("apisix.core")
+    local opts = conf.canonical_https_redirect or {}
+
+    core.log.warn("non-canonical origin scheme=", ngx.var.scheme,
+                  " host=", raw_host, " redirecting to https://", host)
+
+    -- 308 rather than the 301 the shadowed `redirect` plugin would have sent:
+    -- it preserves the method and body, so an upgraded POST stays a POST
+    -- instead of being silently downgraded to a GET.
+    return ngx.redirect("https://" .. host .. ngx.var.request_uri,
+                        opts.status or 308)
+end

--- a/src/ol_infrastructure/components/services/files/oidc_error_callback_recovery.lua
+++ b/src/ol_infrastructure/components/services/files/oidc_error_callback_recovery.lua
@@ -15,7 +15,7 @@
 --   oidc_error_recovery.guard_cookie_name   loop-breaker cookie name
 --   oidc_error_recovery.guard_max_age       guard cookie lifetime, seconds
 --
--- See `oidc_error_callback_recovery_plugin` in ../apisix.py for why each branch
+-- See `oidc_gateway_pre_function_plugin` in ../apisix.py for why each branch
 -- is here, and t/oidc_error_callback_recovery.t for the behavioural tests.
 return function(conf, ctx)
     local uri = ngx.var.uri

--- a/tests/apisix_integration/conftest.py
+++ b/tests/apisix_integration/conftest.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from collections.abc import Generator
 
 from ol_infrastructure.components.services.apisix import (
-    oidc_error_callback_recovery_plugin,
+    oidc_gateway_pre_function_plugin,
 )
 
 # Must track the APISIX shipped by the chart pinned in bridge.lib.versions
@@ -90,7 +90,14 @@ def apisix_routes() -> dict[str, Any]:
     what the gateway itself does before proxying, and a request that reaches the
     upstream is one the plugin correctly declined to intercept.
     """
-    recovery = oidc_error_callback_recovery_plugin()
+    # APISIX listens on plain HTTP here, so the canonical-origin function would
+    # upgrade every request before the recovery function ever ran -- which is
+    # the production behaviour, and is asserted directly on the routes below.
+    # The recovery routes therefore switch it off so they exercise the callback
+    # handling in isolation, exactly as they did before the two were fused into
+    # the single serverless-pre-function APISIX allows per plugin config.
+    recovery = oidc_gateway_pre_function_plugin(canonical_https_redirect=False)
+    full = oidc_gateway_pre_function_plugin()
     dead_upstream = {"type": "roundrobin", "nodes": {"127.0.0.1:1": 1}}
     return {
         "routes": [
@@ -105,6 +112,15 @@ def apisix_routes() -> dict[str, Any]:
                 "uri": "/learn/login/*",
                 "upstream": dead_upstream,
                 "plugins": {recovery.name: recovery.config},
+            },
+            # Not a catch-all: `_wait_until_ready` polls `/` and follows
+            # redirects, so a `/*` route carrying this plugin would send the
+            # readiness probe at an https origin that does not exist here.
+            {
+                "id": "canonical-origin",
+                "uri": "/origin/*",
+                "upstream": dead_upstream,
+                "plugins": {full.name: full.config},
             },
         ]
     }
@@ -207,3 +223,27 @@ def callback(apisix):
         return response.status, dict(response.headers)
 
     return _callback
+
+
+@pytest.fixture
+def origin_request(apisix):
+    """Request a canonical-origin route and return (status, headers).
+
+    Sends an explicit Host so the port-stripping and scheme-upgrade branches can
+    be driven independently of the container's own listen address.
+    """
+
+    def _origin_request(
+        path: str = "/origin/",
+        host: str = "nb.learn.mit.edu",
+    ) -> tuple[int, dict[str, str]]:
+        response = urllib3.PoolManager(retries=False).request(
+            "GET",
+            f"{apisix}{path}",
+            headers={"Host": host},
+            redirect=False,
+            timeout=10.0,
+        )
+        return response.status, dict(response.headers)
+
+    return _origin_request

--- a/tests/apisix_integration/test_canonical_https_redirect.py
+++ b/tests/apisix_integration/test_canonical_https_redirect.py
@@ -1,0 +1,67 @@
+"""Canonical-origin behaviour, against a real APISIX.
+
+Every assertion here is something the stubbed unit tests cannot reach: that
+APISIX accepts a ``canonical_https_redirect`` block that is not in
+serverless-pre-function's schema, that ``ngx.var.host`` really does drop the
+port OpenResty received rather than a stub simply agreeing with us, and that
+``serverless-pre-function`` honours the array order these two functions depend
+on.
+
+See ``oidc_gateway_pre_function_plugin`` in
+src/ol_infrastructure/components/services/apisix.py.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.apisix_integration.conftest import requires_docker
+
+pytestmark = [requires_docker, pytest.mark.integration]
+
+
+def test_plain_http_is_upgraded_to_https(origin_request):
+    """The production failure: without this, openid-connect builds an http://
+    redirect_uri that Keycloak rejects, and APISIX answers with an OIDC session
+    cookie over cleartext.
+    """
+    status, headers = origin_request(path="/origin/hub/login")
+
+    assert status == 308
+    assert headers["Location"] == "https://nb.learn.mit.edu/origin/hub/login"
+
+
+def test_explicit_port_is_stripped_from_the_redirect_target(origin_request):
+    """``Host: <host>:443`` reaches lua-resty-openidc as ngx.var.http_host and
+    produces an authority Keycloak has no registration for.  Reproduced against
+    production on 2026-08-19.
+    """
+    status, headers = origin_request(host="nb.learn.mit.edu:443")
+
+    assert status == 308
+    assert headers["Location"] == "https://nb.learn.mit.edu/origin/"
+
+
+def test_query_string_is_preserved(origin_request):
+    """request_uri, not uri.  Dropping the query would break exactly the OIDC
+    callbacks this is meant to rescue.
+    """
+    _, headers = origin_request(path="/origin/login/.apisix/redirect?code=a&state=b")
+
+    assert headers["Location"] == (
+        "https://nb.learn.mit.edu/origin/login/.apisix/redirect?code=a&state=b"
+    )
+
+
+def test_upgrade_wins_over_error_recovery_on_the_same_plugin(origin_request):
+    """Both functions are attached to this route and the request is plain HTTP,
+    so the origin fix has to answer first.  Recovering here instead would send
+    the browser back into an http:// login and fail again at Keycloak.
+    """
+    status, headers = origin_request(
+        path="/origin/login/.apisix/redirect?error=temporarily_unavailable"
+    )
+
+    assert status == 308
+    assert headers["Location"].startswith("https://")
+    assert "apisix_oidc_recovery" not in headers.get("Set-Cookie", "")

--- a/tests/apisix_integration/test_oidc_error_callback_recovery.py
+++ b/tests/apisix_integration/test_oidc_error_callback_recovery.py
@@ -9,7 +9,7 @@ A 302 means the plugin intercepted.  Any other status means it declined and the
 request went on to the dead upstream, which in production is where the
 openid-connect plugin takes over.
 
-See ``oidc_error_callback_recovery_plugin`` in
+See ``oidc_gateway_pre_function_plugin`` in
 src/ol_infrastructure/components/services/apisix.py.
 """
 

--- a/tests/apisix_testnginx/Dockerfile
+++ b/tests/apisix_testnginx/Dockerfile
@@ -83,8 +83,11 @@ RUN set -eu; \
 # copying the file into this directory instead would leave a second copy free to
 # drift, and the suite would then pass against Lua the gateway never runs.
 COPY src/ol_infrastructure/components/services/files/oidc_error_callback_recovery.lua \
+     src/ol_infrastructure/components/services/files/canonical_https_redirect.lua \
      apisix/plugins/ol/
-COPY tests/apisix_testnginx/oidc_error_callback_recovery.t t/
+COPY tests/apisix_testnginx/oidc_error_callback_recovery.t \
+     tests/apisix_testnginx/canonical_https_redirect.t \
+     t/
 COPY tests/apisix_testnginx/run-tests.sh /usr/local/bin/run-tests.sh
 RUN chmod +x /usr/local/bin/run-tests.sh
 

--- a/tests/apisix_testnginx/canonical_https_redirect.t
+++ b/tests/apisix_testnginx/canonical_https_redirect.t
@@ -1,0 +1,147 @@
+#
+# APISIX test-nginx coverage for the canonical-origin redirect function.
+#
+# This layer runs the shipped Lua inside the same OpenResty build the gateway
+# uses, which is the only place the central assumption can actually be checked:
+# that $host is the Host header lowercased with the port stripped while
+# $http_host is the header verbatim.  A stub can be made to agree with us about
+# that; nginx cannot.
+#
+# The scheme is always http here, so the "already canonical, do nothing" case
+# is covered by the unit and container layers instead -- test-nginx gives us no
+# way to present an https connection to the function.
+#
+use t::APISIX 'no_plan';
+
+repeat_each(1);
+no_long_string();
+no_root_location();
+log_level('info');
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: a plain-HTTP request is upgraded to the https origin
+--- config
+    location /t {
+        rewrite_by_lua_block {
+            local canonical = require("apisix.plugins.ol.canonical_https_redirect")
+            canonical({canonical_https_redirect = {status = 308}}, {var = {}})
+        }
+        content_by_lua_block {
+            ngx.say("not reached")
+        }
+    }
+--- more_headers
+Host: nb.learn.mit.edu
+--- request
+GET /t/hub/login
+--- error_code: 308
+--- response_headers
+Location: https://nb.learn.mit.edu/t/hub/login
+
+
+
+=== TEST 2: an explicit :443 in the Host header is stripped from the target
+--- config
+    location /t {
+        rewrite_by_lua_block {
+            local canonical = require("apisix.plugins.ol.canonical_https_redirect")
+            canonical({canonical_https_redirect = {status = 308}}, {var = {}})
+        }
+        content_by_lua_block {
+            ngx.say("not reached")
+        }
+    }
+--- more_headers
+Host: nb.learn.mit.edu:443
+--- request
+GET /t/
+--- error_code: 308
+--- response_headers
+Location: https://nb.learn.mit.edu/t/
+
+
+
+=== TEST 3: an uppercased host is canonicalised to lower case
+--- config
+    location /t {
+        rewrite_by_lua_block {
+            local canonical = require("apisix.plugins.ol.canonical_https_redirect")
+            canonical({canonical_https_redirect = {status = 308}}, {var = {}})
+        }
+        content_by_lua_block {
+            ngx.say("not reached")
+        }
+    }
+--- more_headers
+Host: NB.Learn.MIT.edu
+--- request
+GET /t/
+--- error_code: 308
+--- response_headers
+Location: https://nb.learn.mit.edu/t/
+
+
+
+=== TEST 4: the query string survives the upgrade
+--- config
+    location /t {
+        rewrite_by_lua_block {
+            local canonical = require("apisix.plugins.ol.canonical_https_redirect")
+            canonical({canonical_https_redirect = {status = 308}}, {var = {}})
+        }
+        content_by_lua_block {
+            ngx.say("not reached")
+        }
+    }
+--- more_headers
+Host: api.learn.mit.edu
+--- request
+GET /t/login/.apisix/redirect?code=abc&state=xyz
+--- error_code: 308
+--- response_headers
+Location: https://api.learn.mit.edu/t/login/.apisix/redirect?code=abc&state=xyz
+
+
+
+=== TEST 5: the status code is taken from the plugin config
+--- config
+    location /t {
+        rewrite_by_lua_block {
+            local canonical = require("apisix.plugins.ol.canonical_https_redirect")
+            canonical({canonical_https_redirect = {status = 301}}, {var = {}})
+        }
+        content_by_lua_block {
+            ngx.say("not reached")
+        }
+    }
+--- more_headers
+Host: nb.learn.mit.edu
+--- request
+GET /t/
+--- error_code: 301
+--- response_headers
+Location: https://nb.learn.mit.edu/t/
+
+
+
+=== TEST 6: an absent config block falls back to 308
+--- config
+    location /t {
+        rewrite_by_lua_block {
+            local canonical = require("apisix.plugins.ol.canonical_https_redirect")
+            canonical({}, {var = {}})
+        }
+        content_by_lua_block {
+            ngx.say("not reached")
+        }
+    }
+--- more_headers
+Host: nb.learn.mit.edu
+--- request
+GET /t/
+--- error_code: 308
+--- response_headers
+Location: https://nb.learn.mit.edu/t/

--- a/tests/apisix_testnginx/run-tests.sh
+++ b/tests/apisix_testnginx/run-tests.sh
@@ -43,4 +43,4 @@ until etcdctl --endpoints=http://127.0.0.1:2379 endpoint health >/dev/null 2>&1 
 done
 
 cd "${APISIX_HOME}"
-exec prove -v "$@" t/oidc_error_callback_recovery.t
+exec prove -v "$@" t/oidc_error_callback_recovery.t t/canonical_https_redirect.t

--- a/tests/ol_infrastructure/components/services/test_apisix.py
+++ b/tests/ol_infrastructure/components/services/test_apisix.py
@@ -436,6 +436,24 @@ def test_canonical_redirect_status_reaches_the_config_block():
     assert config["canonical_https_redirect"]["status"] == 301
 
 
+@pytest.mark.parametrize("status", [301, 302, 303, 307, 308])
+def test_every_status_ngx_redirect_accepts_is_allowed(status):
+    config = oidc_gateway_pre_function_plugin(canonical_redirect_status=status).config
+
+    assert config["canonical_https_redirect"]["status"] == status
+
+
+@pytest.mark.parametrize("status", [200, 304, 305, 418, 500])
+def test_a_status_ngx_redirect_rejects_fails_at_preview(status):
+    """ngx.redirect raises a Lua error outside {301,302,303,307,308}, and the
+    config block carrying this is not in serverless-pre-function's schema, so
+    APISIX would not reject it either -- an unchecked value would first surface
+    as a 500 on live traffic.  This has to fail while the stack is being built.
+    """
+    with pytest.raises(ValueError, match=r"ngx\.redirect rejects anything else"):
+        oidc_gateway_pre_function_plugin(canonical_redirect_status=status)
+
+
 def test_canonical_redirect_can_be_disabled():
     """A host that must keep answering on plain HTTP drops the function without
     losing the error-callback recovery it necessarily shares a plugin with.

--- a/tests/ol_infrastructure/components/services/test_apisix.py
+++ b/tests/ol_infrastructure/components/services/test_apisix.py
@@ -52,7 +52,7 @@ from ol_infrastructure.components.services.apisix import (  # noqa: E402
     OLApisixSharedPluginsConfig,
     OLApisixUpstream,
     OLApisixUpstreamConfig,
-    oidc_error_callback_recovery_plugin,
+    oidc_gateway_pre_function_plugin,
     stale_session_cookie_cleanup_plugin,
 )
 
@@ -353,7 +353,7 @@ def test_cleanup_plugin_honours_a_custom_stale_name():
 
 def test_recovery_plugin_runs_in_rewrite_before_openid_connect():
     """openid-connect runs in rewrite; the access phase would be too late."""
-    plugin = oidc_error_callback_recovery_plugin()
+    plugin = oidc_gateway_pre_function_plugin()
 
     assert plugin.name == "serverless-pre-function"
     assert plugin.config["phase"] == "rewrite"
@@ -363,13 +363,13 @@ def test_recovery_plugin_defaults_to_the_only_error_production_emits():
     """access_denied means the user pressed Cancel -- restarting the flow there
     would bounce the browser between the gateway and Keycloak.
     """
-    options = oidc_error_callback_recovery_plugin().config["oidc_error_recovery"]
+    options = oidc_gateway_pre_function_plugin().config["oidc_error_recovery"]
 
     assert options["recoverable_errors"] == ["temporarily_unavailable"]
 
 
 def test_recovery_plugin_honours_a_custom_error_list():
-    options = oidc_error_callback_recovery_plugin(
+    options = oidc_gateway_pre_function_plugin(
         recoverable_errors=["temporarily_unavailable", "server_error"],
     ).config["oidc_error_recovery"]
 
@@ -380,7 +380,7 @@ def test_recovery_plugin_honours_an_explicit_empty_error_list():
     """An empty list means "recover nothing" -- the way to make the plugin a
     no-op without detaching it from every route on a shared config.
     """
-    options = oidc_error_callback_recovery_plugin(
+    options = oidc_gateway_pre_function_plugin(
         recoverable_errors=[],
     ).config["oidc_error_recovery"]
 
@@ -391,7 +391,7 @@ def test_recovery_plugin_passes_guard_settings_as_config():
     """Tunables travel on the plugin config and are read off ``conf`` in Lua,
     so nothing is interpolated into the shipped source.
     """
-    options = oidc_error_callback_recovery_plugin(
+    options = oidc_gateway_pre_function_plugin(
         guard_cookie_name="custom_guard",
         guard_max_age=90,
     ).config["oidc_error_recovery"]
@@ -400,18 +400,57 @@ def test_recovery_plugin_passes_guard_settings_as_config():
     assert options["guard_max_age"] == 90
 
 
-def test_recovery_plugin_ships_the_lua_file_verbatim():
-    """The function body is the checked-in .lua file, not a generated string --
-    no configuration is interpolated into it.
+def test_recovery_plugin_ships_the_lua_files_verbatim():
+    """The function bodies are the checked-in .lua files, not generated strings --
+    no configuration is interpolated into either.
     """
-    (source,) = oidc_error_callback_recovery_plugin(
+    sources = oidc_gateway_pre_function_plugin(
         guard_cookie_name="custom_guard",
         recoverable_errors=["server_error"],
+        canonical_redirect_status=301,
     ).config["functions"]
 
-    assert source == apisix_module.OIDC_ERROR_RECOVERY_LUA
-    assert "custom_guard" not in source
-    assert "server_error" not in source
+    assert sources == [
+        apisix_module.CANONICAL_HTTPS_REDIRECT_LUA,
+        apisix_module.OIDC_ERROR_RECOVERY_LUA,
+    ]
+    for source in sources:
+        assert "custom_guard" not in source
+        assert "server_error" not in source
+
+
+def test_canonical_redirect_runs_before_error_recovery():
+    """serverless/init.lua stops at the first function returning a code, so the
+    origin has to be canonical before the recovery function can redirect back
+    into a login flow -- otherwise recovery would target an http:// origin.
+    """
+    sources = oidc_gateway_pre_function_plugin().config["functions"]
+
+    assert "canonical_https_redirect" in sources[0]
+    assert "oidc_error_recovery" in sources[1]
+
+
+def test_canonical_redirect_status_reaches_the_config_block():
+    config = oidc_gateway_pre_function_plugin(canonical_redirect_status=301).config
+
+    assert config["canonical_https_redirect"]["status"] == 301
+
+
+def test_canonical_redirect_can_be_disabled():
+    """A host that must keep answering on plain HTTP drops the function without
+    losing the error-callback recovery it necessarily shares a plugin with.
+    """
+    config = oidc_gateway_pre_function_plugin(canonical_https_redirect=False).config
+
+    assert config["functions"] == [apisix_module.OIDC_ERROR_RECOVERY_LUA]
+
+
+def test_canonical_redirect_lua_reads_its_settings_off_conf():
+    """Guards the contract between the .lua file and the config block above."""
+    source = apisix_module.CANONICAL_HTTPS_REDIRECT_LUA
+
+    assert "conf.canonical_https_redirect" in source
+    assert "opts.status" in source
 
 
 def test_recovery_lua_reads_its_settings_off_conf():
@@ -573,7 +612,7 @@ def test_recovery_plugin_renders_into_the_v2_plugin_config():
     """
     plugins = shared_plugins(
         "test-shared-plugins-oidc-recovery-v2",
-        plugins=[oidc_error_callback_recovery_plugin()],
+        plugins=[oidc_gateway_pre_function_plugin()],
     )
 
     def check(spec):
@@ -602,7 +641,7 @@ def test_recovery_plugin_reaches_the_gateway_api_plugin_config():
     """
     plugins = shared_plugins(
         "test-shared-plugins-oidc-recovery-gateway-api",
-        plugins=[oidc_error_callback_recovery_plugin()],
+        plugins=[oidc_gateway_pre_function_plugin()],
     )
 
     def check(spec):

--- a/tests/ol_infrastructure/components/services/test_apisix_lua.py
+++ b/tests/ol_infrastructure/components/services/test_apisix_lua.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import lupa
 
 from ol_infrastructure.components.services.apisix import (
-    oidc_error_callback_recovery_plugin,
+    oidc_gateway_pre_function_plugin,
 )
 
 # Stubs the generated function's whole world: the two ngx.var reads, the
@@ -57,15 +57,27 @@ class Harness:
     """Runs the shipped Lua against a stubbed ngx/apisix.core.
 
     Both the function source and the ``conf`` table come from
-    ``oidc_error_callback_recovery_plugin``, so these exercise the same plugin
+    ``oidc_gateway_pre_function_plugin``, so these exercise the same plugin
     config the gateway is handed rather than a hand-built approximation.
     """
 
+    # The builder fuses both pre-openid-connect functions into the one
+    # serverless-pre-function APISIX allows per plugin config, so subclasses
+    # select theirs by the conf block it reads.  Indexing by position would
+    # silently test the wrong function if the order changed.
+    FUNCTION_MARKER = "oidc_error_recovery"
+    EXTRA_LUA = ""
+
     def __init__(self, **plugin_kwargs):
         self.lua = lupa.LuaRuntime(unpack_returned_tuples=True)
-        self.lua.execute(LUA_STUBS)
-        plugin_config = oidc_error_callback_recovery_plugin(**plugin_kwargs).config
-        (source,) = plugin_config["functions"]
+        # One chunk, not two: `captured` is a chunk-local upvalue that the
+        # ngx.redirect stub closes over, so a runner defined in a separate
+        # execute() would assign to a fresh global and capture nothing.
+        self.lua.execute(LUA_STUBS + self.EXTRA_LUA)
+        plugin_config = oidc_gateway_pre_function_plugin(**plugin_kwargs).config
+        (source,) = [
+            fn for fn in plugin_config["functions"] if self.FUNCTION_MARKER in fn
+        ]
         self.fn = self.lua.execute(source)
         self.conf = self._to_lua(plugin_config)
 
@@ -249,3 +261,117 @@ def test_custom_guard_lifetime_reaches_the_cookie():
     )
 
     assert "Max-Age=90;" in set_cookie
+
+
+class OriginHarness(Harness):
+    """Runs the canonical-origin function against a stubbed ngx.
+
+    Unlike the recovery function this one reads only ``ngx.var`` -- scheme,
+    host, http_host, request_uri -- so it gets its own runner rather than
+    overloading ``run`` with parameters the other cases never use.
+    """
+
+    FUNCTION_MARKER = "canonical_https_redirect"
+    EXTRA_LUA = """
+    function run_origin(fn, conf, scheme, host, http_host, request_uri)
+        captured = {args = {}, headers = {}, redirect = nil}
+        ngx.var.scheme = scheme
+        ngx.var.host = host
+        ngx.var.http_host = http_host
+        ngx.var.request_uri = request_uri
+        fn(conf, {var = ngx.var})
+        local redirect = captured.redirect
+        return redirect and redirect.uri or nil, redirect and redirect.code or nil
+    end
+    """
+
+    #: ``http_host`` defaults to mirroring ``host``; pass ``None`` explicitly for
+    #: the HTTP/1.0 case where the request carries no Host header at all.
+    MIRROR_HOST = object()
+
+    def request(
+        self, scheme="https", host="learn.mit.edu", http_host=MIRROR_HOST, uri="/"
+    ):
+        return self.lua.globals().run_origin(
+            self.fn,
+            self.conf,
+            scheme,
+            host,
+            host if http_host is self.MIRROR_HOST else http_host,
+            uri,
+        )
+
+
+def test_plain_http_is_upgraded_before_openid_connect_sees_it():
+    """The measured failure: this is what sends Keycloak an http:// redirect_uri
+    and answers with an OIDC session cookie over cleartext.
+    """
+    uri, status = OriginHarness().request(
+        scheme="http", host="nb.learn.mit.edu", uri="/hub/login"
+    )
+
+    assert (uri, status) == ("https://nb.learn.mit.edu/hub/login", 308)
+
+
+def test_explicit_port_in_host_is_stripped():
+    """`Host: nb.learn.mit.edu:443` yields https://nb.learn.mit.edu:443/... which
+    Keycloak rejects against its bare-host registration.  Reproduced live.
+    """
+    uri, status = OriginHarness().request(
+        host="nb.learn.mit.edu", http_host="nb.learn.mit.edu:443"
+    )
+
+    assert (uri, status) == ("https://nb.learn.mit.edu/", 308)
+
+
+def test_canonical_request_is_left_alone():
+    """The overwhelming majority of traffic: must cost nothing and not redirect."""
+    assert OriginHarness().request(uri="/search?q=x") == (None, None)
+
+
+def test_query_string_survives_the_upgrade():
+    """request_uri, not uri: dropping the query would break every OIDC callback
+    that arrives over plain HTTP, which is precisely the traffic being fixed.
+    """
+    uri, _ = OriginHarness().request(
+        scheme="http",
+        host="api.learn.mit.edu",
+        uri="/login/.apisix/redirect?code=a&state=b",
+    )
+
+    assert uri == "https://api.learn.mit.edu/login/.apisix/redirect?code=a&state=b"
+
+
+def test_missing_host_header_is_left_to_openid_connect():
+    """HTTP/1.0 with no Host: $host would be the server_name, so redirecting
+    would invent an origin.  lua-resty-openidc already 400s this case.
+    """
+    assert OriginHarness().request(scheme="http", http_host=None) == (None, None)
+
+
+def test_redirect_status_is_configurable():
+    uri, status = OriginHarness(canonical_redirect_status=301).request(scheme="http")
+
+    assert (uri, status) == ("https://learn.mit.edu/", 301)
+
+
+def test_disabling_the_redirect_drops_the_function_entirely():
+    """A host that must keep answering on plain HTTP turns this off without
+    losing the error-callback recovery it shares a plugin with.
+    """
+    config = oidc_gateway_pre_function_plugin(canonical_https_redirect=False).config
+
+    assert not [fn for fn in config["functions"] if "canonical_https_redirect" in fn]
+    assert len(config["functions"]) == 1
+
+
+def test_origin_normalisation_runs_before_error_recovery():
+    """serverless/init.lua stops at the first function returning a code, so a
+    plain-HTTP error callback must be upgraded rather than recovered -- the
+    recovery redirect would otherwise send the browser back to an http:// login.
+    """
+    config = oidc_gateway_pre_function_plugin().config
+    sources = config["functions"]
+
+    assert "canonical_https_redirect" in sources[0]
+    assert "oidc_error_recovery" in sources[1]


### PR DESCRIPTION
Stacked on #5417 — base is `tmacey/apisix-oidc-error-callback-recovery`, so review that one first.

## The problem

The shared-plugin defaults carry APISIX's `redirect` plugin with `http_to_https`, but it is priority **900** against `openid-connect`'s **2599**, and APISIX dispatches a phase in *descending* priority. On every OIDC-protected route the upgrade never runs — openid-connect has already answered. The default is dead code on exactly the routes that need it.

APISIX derives only a relative redirect_uri, and lua-resty-openidc 1.8.0 (what APISIX 3.17 pins) makes it absolute from `ngx.var.scheme` and `ngx.var.http_host` — both raw connection values. So Keycloak gets an `http://` redirect_uri on plain HTTP, or a `:443` authority when the Host header carries a port. It registers bare-host https URIs only and rejects both with `invalid_redirect_uri`, killing the login at the *authorization* endpoint — before any callback exists for #5417's recovery to rescue.

Reproduced on 2026-08-19 against `nb.learn` **and** `api.learn`, so this is not specific to the host that dominates the Keycloak error log.

**The bigger issue:** with the upgrade shadowed, APISIX answers plain-HTTP requests to these hosts with an OIDC session cookie over cleartext and without `Secure`.

## The fix

A rewrite-phase function that 308s any non-canonical origin to `https://<bare host><request_uri>`. One branch covers both failure modes: `scheme ~= "https"`, and `http_host ~= host` (catching an explicit port and an uppercased host).

**Why redirect and not `X-Forwarded-Proto`.** lua-resty-openidc does prefer `Forwarded` / `X-Forwarded-Proto` / `X-Forwarded-Host` over those ngx vars — but on this deployment none of the three reaches it; sending each against production leaves the redirect_uri unchanged. Header-pinning would be a no-op that reads like a fix, and it would not close the cleartext-cookie hole.

**Why one plugin, not two.** APISIX keys a plugin config by name, so a route can carry exactly one `serverless-pre-function` — and both this and #5417's recovery must outrank openid-connect. Hence the rename to `oidc_gateway_pre_function_plugin`. `serverless/init.lua` runs `functions` in array order and stops at the first returning a code, so the origin is normalised *before* recovery decides whether to redirect into a login flow; the other order would have recovery target an `http://` origin and fail again. Pinned by a test at each layer.

## Notes

- One uniform 308 for every method. APISIX's `redirect` plugin picks per method — 301 for GET/HEAD, 308 otherwise — so both preserve a POST; this is a simplification, not a behavioural fix.
- The status is restricted to the codes `ngx.redirect` accepts and validated in the builder, so a bad value fails at `pulumi preview` rather than as a 500 on live traffic. (The type annotation alone does not enforce it — this repo's mypy hook runs without the project installed, so a cross-module call resolves to `Any`.)
- Leaving port 80 answering with a redirect is safe only because every ACME ClusterIssuer solves via dns01/Route53 — verified, no http-01 solver. An issuer switched to http-01 would need its challenge path carved out; called out in the docstring rather than pre-emptively coded around.

## Testing

- **unit (lupa + plugin config)** — 476 pass. Upgrade, port-strip, query preservation, missing-Host pass-through, disable-switch, ordering, accepted/rejected status sets.
- **integration (real APISIX 3.17.0 container)** — 16 pass. Proves APISIX accepts a config block absent from `serverless-pre-function`'s schema and that both functions coexist on one plugin.
- **test-nginx (APISIX's own harness)** — 40 pass. The only layer that can check the load-bearing assumption against real nginx rather than a stub that would just agree with us: `$host` is the Host header lowercased with the port stripped, `$http_host` is it verbatim.

`pre-commit` clean.

## Verification after merge

Not yet deployed to CI — baseline confirmed today:

```
$ curl -sSI 'http://api.ci.learn.mit.edu/login' | grep -o 'redirect_uri=[^&]*'
redirect_uri=http%3A%2F%2Fapi.ci.learn.mit.edu%2Flogin%2F.apisix%2Fredirect
```

Post-deploy, expect a 308 to `https://api.ci.learn.mit.edu/login`, and a normal login through https://ci.learn.mit.edu still completing end to end against real Keycloak.

Tracked as `tk-nb-learn-mit-edu-sends-an-http-not-https-oidc-re-30cc6c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G9yBC9UqoVwiPtxqLNgUD9
