### PR TITLE
fix(otel): drop Traefik's internal Metrics middleware spans at the collector

### DIFF
--- a/src/ol_infrastructure/substructure/aws/eks/grafana.py
+++ b/src/ol_infrastructure/substructure/aws/eks/grafana.py
@@ -373,6 +373,36 @@ def setup_grafana(
                                     },
                                 },
                             },
+                            # Traefik's tracing.otlp exporter (see traefik.py)
+                            # runs with traceVerbosity: detailed on the
+                            # websecure entrypoint, which spans every internal
+                            # middleware Traefik invokes per request --
+                            # including the "Metrics" middleware, which does
+                            # no request-handling work of its own -- it only
+                            # records Prometheus counters/histograms. That
+                            # made "Metrics" Traefik's single highest-volume
+                            # span, ahead of real GET/POST traffic, with no
+                            # server.address or other diagnostic value
+                            # (confirmed via Tempo:
+                            # entry_point is exclusively "websecure" on these
+                            # spans -- they are not the separate :9100
+                            # Prometheus-scrape entrypoint, which carries zero
+                            # trace volume).
+                            #
+                            # Traefik has no per-middleware trace toggle --
+                            # traceVerbosity is all-or-nothing for internal
+                            # middlewares -- so the span has to be dropped
+                            # downstream instead. Traefik's own Prometheus
+                            # metrics (what this middleware actually produces)
+                            # are unaffected; only the trace span is dropped.
+                            "filters": {
+                                "enabled": True,
+                                "traces": {
+                                    "span": [
+                                        'resource.attributes["service.name"] == "traefik" and name == "Metrics"',
+                                    ],
+                                },
+                            },
                         },
                     },
                 },


### PR DESCRIPTION
### What are the relevant tickets?
N/A (witan task tk-traefik-metrics-spans-are-now-the-highest-volume-d923f7)

### Description (What does it do?)
- After https://github.com/mitodl/ol-infrastructure/pull/5500 deployed detailed tracing on the `websecure` entrypoint, TraceQL against `applications-production` showed spans named `Metrics` as Traefik's single highest-volume edge span (~4.59/s), ahead of real `GET`+`POST` traffic combined (~4.58/s), carrying no `server.address`.
- The task's leading hypothesis was that these were Prometheus scraping the chart's `:9100` metrics entrypoint. **That hypothesis is wrong** — verified against live Tempo data (`grafanacloud-mitolproduction-traces`):
  - `{resource.service.name="traefik" && name="Metrics"} | rate() by (span.entry_point)` returns `entry_point="websecure"` exclusively — the `:9100` metrics entrypoint carries **zero** trace volume.
  - Pulling a full trace shows the actual shape: `POST` (root, `entry_point=websecure`) → `Metrics` (`traefik.middleware.name=metrics-entrypoint`) → `Router` → `URLRewrite` → `Service` → `Metrics` (`traefik.middleware.name=metrics-service`) → backend call. These are Traefik's own internal metrics-instrumentation middleware (`pkg/middlewares/metrics/metrics.go`, `NewEntryPointMiddleware`/`NewServiceMiddleware`) — they record Prometheus counters/histograms and do no request-handling work.
  - Traefik's `traceVerbosity: detailed` wraps **every** middleware in the alice chain with a span (`pkg/middlewares/observability/middleware.go`, `WrapMiddleware`/`DetailedTracingEnabled`) — there's no per-middleware opt-out. So an entrypoint-level tracing toggle can't drop just the `Metrics` span without also losing `Router`/`Service`/`URLRewrite`/`ResponseHeaderModifier`, which is what #5500 was actually for.
- Fix: added an OTTL filter processor to the `gc-otlp-endpoint` destination in the `grafana-k8s-monitoring` Helm release (`src/ol_infrastructure/substructure/aws/eks/grafana.py`). Chart `4.4.0` natively supports `destinations.<name>.processors.filters` (traces/span OTTL rules); the rule `resource.attributes["service.name"] == "traefik" and name == "Metrics"` drops the span before it reaches Tempo. Traefik's actual Prometheus metrics (what that middleware produces) are unaffected — only the trace span is dropped downstream in the collector.
- (This PR supersedes an earlier local attempt at `ports.metrics.observability.tracing: false` in `traefik.py`, which was proven ineffective by the Tempo query above before being pushed for review, and is not part of this diff.)

### How can this be tested?
- `uv run pre-commit run --files src/ol_infrastructure/substructure/aws/eks/grafana.py` and `mypy` both pass.
- `pulumi preview --diff` against the `grafana/grafana-k8s-monitoring` Helm release shows exactly the intended, isolated diff on every cluster stack checked (`operations.Production`, `operations.QA`, `applications.Production`):
  ```
  ~ destinations: {
      ~ gc-otlp-endpoint: {
          ~ processors: {
              + filters: {
                  + enabled: true
                  + traces : {
                      + span: [
                      +     [0]: "resource.attributes[\"service.name\"] == \"traefik\" and name == \"Metrics\""
                        ]
                    }
                }
            }
        }
    }
  ```
  Pulumi/the chart accepted the values with no schema errors, confirming `processors.filters` is a valid key at this chart version.
- Post-merge, re-run `{resource.service.name="traefik"} | rate() by (name)` against Tempo on `applications-production` and confirm `Metrics` is gone from the results while `Router`/`Service`/`ResponseHeaderModifier`/`URLRewrite` on `websecure` are unaffected, and that Traefik's Prometheus metrics/dashboards are unchanged.

### Additional Context
Filed from witan task `tk-traefik-metrics-spans-are-now-the-highest-volume-d923f7`, discovered as a follow-up to #5500. The task's suggested fix (disable tracing on the `metrics` port entrypoint in `traefik.py`) does not work — see investigation above — so this PR takes a different approach at the OTel collector layer instead.
