### PR TITLE
fix(dagster): switch pgbouncer pool_mode from session to transaction

### DIFF
--- a/src/ol_infrastructure/applications/dagster/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/dagster/Pulumi.QA.yaml
@@ -43,27 +43,44 @@ config:
   # leaves pool_size where it was.
   #
   # That split is the whole point, so do not "tidy" it back to a round 60+30.
-  # pool_size is RETAINED -- under pool_mode = session a connection QueuePool
-  # keeps is a backend pinned against RDS for as long as the process lives --
-  # while connections above pool_size are closed on return and churn like
-  # NullPool. 30+60 therefore buys the daemon the same 90-connection burst that
-  # 60+30 would, at exactly the resting footprint QA already has, which is the
-  # only version of 90 that does not make the situation below worse.
+  # pool_size is RETAINED -- at the time this was written, under pool_mode =
+  # session, a connection QueuePool keeps was a backend pinned against RDS for
+  # as long as the process lives -- while connections above pool_size are
+  # closed on return and churn like NullPool. 30+60 therefore bought the
+  # daemon the same 90-connection burst that 60+30 would, at exactly the
+  # resting footprint QA already had, which was the only version of 90 that
+  # did not make the situation below worse.
   #
-  # The situation below: on 2026-08-19 QA's PgBouncer sat pinned at its full
-  # 764-connection aggregate cap (382 on each of 2 pods) for hours, sv_idle 0,
-  # up to 46 clients queued, maxwait peaking at 543s against a
-  # query_wait_timeout of 600. CloudWatch shows DatabaseConnections flat at 768
-  # across three consecutive hours -- the same plateau signature as the
-  # 2026-08-10 Production incident, bounded here by PgBouncer rather than RDS.
+  # The situation below, as it stood under session mode: on 2026-08-19 QA's
+  # PgBouncer sat pinned at its full 764-connection aggregate cap (382 on each
+  # of 2 pods) for hours, sv_idle 0, up to 46 clients queued, maxwait peaking
+  # at 543s against a query_wait_timeout of 600. CloudWatch shows
+  # DatabaseConnections flat at 768 across three consecutive hours -- the same
+  # plateau signature as the 2026-08-10 Production incident, bounded here by
+  # PgBouncer rather than RDS.
   #
-  # Be clear about what this change does and does not do. It does not fix that.
-  # 16 long-lived processes share this ConfigMap on QA -- 1 daemon, 2
-  # webservers, 13 code-location servers -- and each retains pool_size from
-  # event_log plus 15 each from run_storage and schedule_storage. The resting
-  # demand that implies already exceeds the 764 the pool can supply, which is
-  # why it is pinned with no idle servers. Raising the burst ceiling gives the
-  # daemon somewhere to go only once there is room to burst into.
+  # Be clear about what this change did and did not do, under the pool_mode
+  # in effect when it was written. It did not fix that. 16 long-lived
+  # processes share this ConfigMap on QA -- 1 daemon, 2 webservers, 13
+  # code-location servers -- and under session mode each retained pool_size
+  # from event_log plus 15 each from run_storage and schedule_storage as
+  # pinned backends. The resting demand that implied already exceeded the 764
+  # the pool could supply, which is why it sat pinned with no idle servers.
+  # Raising the burst ceiling gave the daemon somewhere to go only once there
+  # was room to burst into.
+  #
+  # SUPERSEDED 2026-08-19: pool_mode moved from session to transaction (see
+  # dagster/__main__.py). The 30+60/90 split, and every number above it, is
+  # still the configured value and still bounds this process's concurrent
+  # transaction ceiling -- but under transaction mode an idle QueuePool
+  # connection no longer pins a backend, so the "resting demand already
+  # exceeds 764" framing above no longer describes current behavior: resting
+  # demand across all 16 processes is now close to zero backends, and 764 is
+  # consumed only by connections with a transaction actually in flight at a
+  # given instant. Revisit event_log_pool_size/max_overflow against real
+  # transaction-mode data before assuming 30+60 is still the right split --
+  # it was sized to avoid worsening session-mode pinning, a constraint that no
+  # longer applies.
   #
   # Who actually uses the event log, since "it is the daemon" is wrong and the
   # obvious fix follows from getting this right. The exhaustion log names the

--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -715,7 +715,57 @@ pgbouncer_ini_template = dagster_db.db_instance.address.apply(
             "listen_addr = 0.0.0.0",
             "listen_port = 5432",
             "auth_type = any",
-            "pool_mode = session",
+            # Was session mode with no recorded rationale. Measured on QA,
+            # 2026-08-19 ~16:26Z: 782 client connections against 759 backends, a
+            # 1.03:1 ratio -- session mode was pinning one backend per client for
+            # the life of the client's connection, so PgBouncer was doing no
+            # multiplexing at all. It was a proxy with a connection limit, not a
+            # pool.
+            #
+            # The pinning is worse than "one client, one backend" here because
+            # Dagster's storages (event_log/run/schedule, see
+            # dagster_instance.yaml) each hold their own SQLAlchemy QueuePool of
+            # up to pool_size+max_overflow connections per process, and under
+            # session mode every one of those client-side pooled connections that
+            # QueuePool keeps idle-but-open stays pinned to a live RDS backend too
+            # -- 16 long-lived processes (1 daemon, 2 webservers, 13 code
+            # locations) times dozens of QueuePool connections each is most of
+            # the 1:1 ratio above, before a single run worker is counted.
+            #
+            # The standard objection -- that Dagster's Postgres event-log watcher
+            # needs LISTEN/NOTIFY, which transaction mode breaks -- does not
+            # apply to the pinned version. Checked in the deployed venv:
+            # dagster_postgres/event_log/event_log.py uses SqlPollingEventWatcher
+            # (polling, not LISTEN/NOTIFY) and ol_orchestrate's
+            # PooledPostgresEventLogStorage does not override watch(). store_event
+            # still emits NOTIFY for version-skew compatibility with old readers,
+            # but nothing LISTENs any more, and a bare NOTIFY is a single
+            # statement that is harmless inside a pooled transaction.
+            #
+            # Two things transaction mode needs from Dagster's side, both already
+            # true: isolation_level="AUTOCOMMIT" on every storage means each
+            # statement is its own transaction, so a backend is never held idle
+            # mid-transaction; and max_prepared_statements = 0 below means a
+            # driver that tried server-side prepared statements would fail loudly
+            # at prepare time rather than silently misbehave (psycopg2-binary,
+            # the pinned driver, does not use them by default, so this is a
+            # guard rail rather than a live constraint).
+            #
+            # Not yet addressed, tracked as follow-up rather than blocking this:
+            # PooledPostgresEventLogStorage.optimize_for_webserver() SETs
+            # statement_timeout on SQLAlchemy's "connect" event, which fires once
+            # per QueuePool connection rather than once per PgBouncer transaction
+            # -- in transaction mode that SET lands on whichever backend serves
+            # the first transaction and is silently absent from every other
+            # backend QueuePool's later checkouts get routed to, since
+            # server_reset_query is empty (see below).
+            #
+            # max_db_connections stays the pool's single binding ceiling
+            # regardless of pool_mode -- DagsterPgBouncerConnectionHeadroom
+            # alerts on server connections as a fraction of it, and that
+            # denominator relationship doesn't depend on how backends get
+            # reused, only on there being one number that bounds them.
+            "pool_mode = transaction",
             # Clients are cheap -- an accepted client that is waiting for a backend
             # costs a socket, not a connection to RDS -- and this number has to stay
             # well above max_db_connections or a saturated pool refuses clients
@@ -771,9 +821,22 @@ pgbouncer_ini_template = dagster_db.db_instance.address.apply(
             f"max_db_connections = {pgbouncer_max_db_connections}",
             "max_prepared_statements = 0",
             "server_connect_timeout = 15",
-            # Dagster uses NullPool with AUTOCOMMIT isolation - no session
-            # state is left between queries, so DISCARD ALL is unnecessary
-            # and adds latency + a race-condition window on each disconnect.
+            # Dagster's storages run with AUTOCOMMIT isolation (see
+            # dagster_instance.yaml) -- no multi-statement transaction is ever
+            # left open, so there is no leftover transaction state for DISCARD
+            # ALL to clean up, and skipping it avoids the latency and
+            # disconnect-race window it would otherwise add on every reset.
+            #
+            # This does NOT cover connect-time session state: the webserver's
+            # PooledPostgresEventLogStorage.optimize_for_webserver() SETs
+            # statement_timeout via a SQLAlchemy "connect" event, which under
+            # session mode landed once on a backend pinned to that client for
+            # good, but under transaction mode only applies to whichever
+            # backend served that QueuePool connection's first transaction --
+            # every later transaction on the same client socket can land on a
+            # different, unSET backend, and an empty reset query does nothing
+            # to fix that because there is nothing PgBouncer knows to reset.
+            # Tracked as follow-up rather than blocking this change.
             "server_reset_query =",
             # PgBouncer 1.25 defaults server_check_query to empty (disabled).
             # Re-enable it so PgBouncer verifies server connections are alive

--- a/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
+++ b/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
@@ -54,13 +54,21 @@ compute_logs:
 # against the shared RDS backend budget the way it did under session mode.
 #
 # The floor matters as much as the preference, and the two failure modes
-# bracket you on both sides:
-#   pool_size too high -> idle reserved connections eat the shared database
-#     budget. QA, 2026-08-19: pinned at its full 764 aggregate cap, sv_idle 0,
-#     maxwait 543s against a 600s query_wait_timeout.
+# bracket you on both sides. Both were observed under the old session mode,
+# so read "pool_size too high" as history rather than the live mechanism --
+# see the correction below for what it means now:
+#   pool_size too high -> under session mode, idle reserved connections ate
+#     the shared database budget directly. QA, 2026-08-19: pinned at its full
+#     764 aggregate cap, sv_idle 0, maxwait 543s against a 600s
+#     query_wait_timeout. Under transaction mode a large pool_size no longer
+#     costs backends while idle; it raises the ceiling on how many
+#     transactions this one process can have in flight at once, which is a
+#     concurrency-spike risk rather than a resting-cost one.
 #   pool_size too low  -> steady-state work runs through the churning overflow
 #     path, which is connect-per-use again: the NullPool behaviour described
 #     above, 415 server assignments/s and every ephemeral port in TIME_WAIT.
+#     This failure mode is unchanged by pool_mode -- overflow churns the same
+#     way regardless of what PgBouncer does with the backend on the other end.
 # So: pool_size = measured steady state, max_overflow = peaks. Not "make
 # pool_size as small as possible". The original 10-per-storage sizing was
 # based on a snapshot of 13-21 connections held across all three storages, but
@@ -78,10 +86,15 @@ compute_logs:
 # pool_size is a retention ceiling, not a preallocation: QueuePool opens
 # connections lazily, so the 97 processes that share this ConfigMap (daemon, 2
 # webservers, 14 code locations, up to max_concurrent_runs workers) only hold
-# what they actually used. Run workers are not exempt from the budget just
-# because they are short-lived -- a worker that opens a connection still
-# counts against the per-pod cap for as long as it holds it -- they just tend
-# to hold fewer at once than the daemon.
+# what they actually used. Run workers are not exempt from pool_size/
+# max_overflow bounding their own concurrency just because they are
+# short-lived -- but under transaction mode that no longer means a worker
+# "counts against the per-pod [backend] cap for as long as it holds" a
+# QueuePool connection open; it counts against the backend cap only while a
+# transaction on that connection is actually in flight, and against the
+# client-socket count (max_client_conn, sized with headroom to spare) the
+# rest of the time. Run workers still tend to hold fewer concurrent
+# transactions at once than the daemon.
 #
 # Under the old pool_mode = session, checking server_active/
 # pgbouncer_pools_server_active_connections against this budget undercounted:

--- a/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
+++ b/src/ol_infrastructure/applications/dagster/dagster_instance.yaml
@@ -39,15 +39,19 @@ compute_logs:
 # simply continues at a lower rate.
 #
 # Which gives the house rule for splitting a given ceiling between the two:
-# prefer a SMALL GUARANTEED pool_size and a LARGE BURST max_overflow. The two
-# halves buy the same ceiling and cost completely different amounts at rest --
-# pool_size is retained, and under pool_mode = session a retained connection is
-# a backend pinned against RDS for the life of the process whether or not a
-# query is running, while overflow costs nothing idle. 30+60 and 60+30 both
-# ceiling at 90; the second reserves twice as many connections doing nothing,
+# prefer a SMALL GUARANTEED pool_size and a LARGE BURST max_overflow. This
+# mattered most under PgBouncer's pool_mode = session, where every retained
+# QueuePool connection pinned a live RDS backend for the life of the process
+# whether or not a query was running -- 30+60 and 60+30 both ceilinged at 90,
+# but the second reserved twice as many real backends doing nothing,
 # multiplied by every process sharing this file (16 on QA: 1 daemon, 2
-# webservers, 13 code-location servers). That multiplier is the difference
-# between fitting in a connection budget and exhausting it.
+# webservers, 13 code-location servers). pool_mode moved to transaction (see
+# __main__.py) specifically because that multiplier turned into a measured
+# 1.03:1 client:backend ratio; a retained QueuePool connection is now a
+# PgBouncer client socket, not a pinned backend, while idle. The preference
+# for a smaller pool_size still stands -- overflow connections still churn
+# open/close the way NullPool always did -- it just no longer trades off
+# against the shared RDS backend budget the way it did under session mode.
 #
 # The floor matters as much as the preference, and the two failure modes
 # bracket you on both sides:
@@ -79,15 +83,24 @@ compute_logs:
 # counts against the per-pod cap for as long as it holds it -- they just tend
 # to hold fewer at once than the daemon.
 #
-# Checking server_active/pgbouncer_pools_server_active_connections against
-# that budget undercounts: pool_mode is session (see __main__.py), so a
-# connection QueuePool returns to its own pool stays connected to RDS as an
-# idle-but-pinned backend rather than being released. What actually consumes
-# the per-pod cap is pgbouncer_databases_current_connections -- the same
-# metric DagsterPgBouncerConnectionHeadroom already alerts on
-# (grafana_alerting/metric_rules/dagster_pgbouncer.py) -- checked per pod, not
-# summed across replicas, since a client's connections land on whichever pod
-# kube-proxy routes them to and do not spread evenly by construction.
+# Under the old pool_mode = session, checking server_active/
+# pgbouncer_pools_server_active_connections against this budget undercounted:
+# a connection QueuePool returned to its own pool stayed connected to RDS as
+# an idle-but-pinned backend rather than being released, so real load only
+# showed up in pgbouncer_databases_current_connections (client connections) --
+# the same metric DagsterPgBouncerConnectionHeadroom already alerts on
+# (grafana_alerting/metric_rules/dagster_pgbouncer.py).
+#
+# Now that pool_mode is transaction (see __main__.py), that inversion is
+# gone: an idle QueuePool connection costs PgBouncer a client socket, not a
+# backend, so pgbouncer_pools_server_active_connections is back to meaning
+# real concurrent work and is the more informative signal for this file's
+# pool_size/max_overflow sizing. pgbouncer_databases_current_connections
+# still bounds the per-pod cap and is what the headroom alert measures, so it
+# remains the number that matters for max_db_connections -- check both, per
+# pod and not summed across replicas, since a client's connections land on
+# whichever pod kube-proxy routes them to and do not spread evenly by
+# construction.
 #
 # event_log_storage's pool_size/max_overflow are stack config values, not
 # literals, for the same reason max_concurrent_runs is: they have to be sized

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/dagster_pgbouncer.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/dagster_pgbouncer.py
@@ -108,6 +108,28 @@ _MAXWAIT_SECONDS = 5
 # only DagsterDatabaseConnectionFailures in log_rules/dagster_database.py spans
 # all of it, because it matches Dagster's retry wrapper rather than any one error.
 # Treat this rule as the leading indicator for one failure mode, not as coverage.
+#
+# INVALIDATED by the pool_mode session -> transaction switch (__main__.py).
+# Everything above was measured and reasoned about under session mode, where
+# server_assignments_total increments once per client connect and therefore
+# tracks client-side socket churn. Under transaction mode PgBouncer assigns a
+# backend per transaction, not per client session, and every storage here runs
+# AUTOCOMMIT -- so this counter now increments roughly once per query, and its
+# rate becomes query throughput, not connection churn. Dagster's steady-state
+# query rate was never measured against this threshold because it was never the
+# quantity being watched, so 50/s is not known to be safe and is likely to fire
+# on ordinary load rather than the reconnect-storm failure mode this rule was
+# built for.
+#
+# No severity label below: routes to `oblivion` in alertmanager.py's route
+# tree (same mechanism documented at length in apisix_edge.py), so the rule
+# keeps evaluating and recording into grafanacloud-alert-state-history with
+# zero paging risk while a real post-transaction-mode threshold gets derived
+# from that history. Promote by adding labels={"severity": ...} once it does.
+# The failure mode this rule exists to catch -- a Dagster storage regressing
+# to a non-pooling connection class and reconnecting per query -- is now also
+# guarded independently by dagster_instance.yaml's QueuePool requirement, so
+# there is no coverage gap while this is unlabelled.
 _SERVER_ASSIGNMENTS_PER_SECOND = 50
 
 # The same ratio as _HEADROOM_RATIO, applied per pod instead of across the pool.
@@ -160,7 +182,7 @@ def create(
                 labels={"severity": "warning"},
                 annotations={
                     "summary": "Dagster PgBouncer in cluster {{ $labels.cluster }} is holding {{ $value }} of its aggregate connection cap",
-                    "description": "PgBouncer's server connections across all replicas in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} have exceeded 75% of the aggregate max_db_connections cap. Past the cap, PgBouncer queues clients rather than opening more backends, and query_wait_timeout is 600, so a client that cannot be served within 10 minutes is disconnected and Dagster sees a connection error -- check DagsterPgBouncerClientsWaiting. Either demand has genuinely grown (raise pgbouncer_replica_count or the RDS instance class, which raises the derived cap with it) or something is holding sessions open: pool_mode is session, so a client that stays connected pins its backend for as long as it lives.",
+                    "description": "PgBouncer's server connections across all replicas in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} have exceeded 75% of the aggregate max_db_connections cap. Past the cap, PgBouncer queues clients rather than opening more backends, and query_wait_timeout is 600, so a client that cannot be served within 10 minutes is disconnected and Dagster sees a connection error -- check DagsterPgBouncerClientsWaiting. Either demand has genuinely grown (raise pgbouncer_replica_count or the RDS instance class, which raises the derived cap with it) or something is holding a transaction open far longer than the sub-millisecond baseline: pool_mode is transaction, so a backend is held only for the life of an in-flight transaction, not for as long as a client stays connected -- look for a stuck migration or a runaway query, not an idle client.",
                 },
                 datas=rd(
                     "sum by (cluster, namespace) "
@@ -180,7 +202,7 @@ def create(
                 labels={"severity": "critical"},
                 annotations={
                     "summary": "Dagster PgBouncer in cluster {{ $labels.cluster }} is holding {{ $value }} of its aggregate connection cap",
-                    "description": "PgBouncer's server connections across all replicas in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} have exceeded 75% of the aggregate max_db_connections cap. Past the cap, PgBouncer queues clients rather than opening more backends, and query_wait_timeout is 600, so a client that cannot be served within 10 minutes is disconnected and Dagster sees a connection error -- check DagsterPgBouncerClientsWaiting. Either demand has genuinely grown (raise pgbouncer_replica_count or the RDS instance class, which raises the derived cap with it) or something is holding sessions open: pool_mode is session, so a client that stays connected pins its backend for as long as it lives.",
+                    "description": "PgBouncer's server connections across all replicas in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} have exceeded 75% of the aggregate max_db_connections cap. Past the cap, PgBouncer queues clients rather than opening more backends, and query_wait_timeout is 600, so a client that cannot be served within 10 minutes is disconnected and Dagster sees a connection error -- check DagsterPgBouncerClientsWaiting. Either demand has genuinely grown (raise pgbouncer_replica_count or the RDS instance class, which raises the derived cap with it) or something is holding a transaction open far longer than the sub-millisecond baseline: pool_mode is transaction, so a backend is held only for the life of an in-flight transaction, not for as long as a client stays connected -- look for a stuck migration or a runaway query, not an idle client.",
                 },
                 datas=rd(
                     "sum by (cluster, namespace) "
@@ -289,26 +311,24 @@ def create(
                 ),
             ),
             # --- Client connection turnover ---
-            # The leading indicator for the client-side failure that
-            # log_rules/dagster_database.py alerts on after the fact. Sustained
-            # turnover at this level is the precondition for ephemeral port
-            # exhaustion in the client pod: every assignment counted here is a
-            # client connection the pool served and will shortly see closed into
-            # TIME_WAIT, and a pod has ~28,000 ports to spend against a single
-            # service address.
-            #
-            # It fires well before the client actually runs out, which is the
-            # point -- by the time the log rule fires, runs are already failing.
+            # Was the leading indicator for the client-side ephemeral-port
+            # exhaustion that log_rules/dagster_database.py alerts on after the
+            # fact. Unlabelled as of the pool_mode session -> transaction switch
+            # (__main__.py) -- see the long comment above _SERVER_ASSIGNMENTS_PER_SECOND
+            # for why server_assignments_total no longer approximates client
+            # connection churn under transaction mode, and routes to `oblivion`
+            # rather than paging until a real threshold is derived.
             alerting.RuleGroupRuleArgs(
                 name="DagsterPgBouncerConnectionChurnWarning",
                 condition="C",
                 for_="15m",
                 no_data_state="OK",
                 exec_err_state="OK",
-                labels={"severity": "warning"},
+                # No severity label: routes to `oblivion` while recalibrating.
+                labels={},
                 annotations={
-                    "summary": "Dagster PgBouncer in cluster {{ $labels.cluster }} is serving {{ $value }} new client connections per second",
-                    "description": "PgBouncer in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} is accepting new client connections fast enough that something is connecting per unit of work rather than holding a pool. This counts client connections served, not new PgBouncer-to-Postgres backends -- server_assignments_total is named for the backend it hands out, but an assignment reuses a pooled one, so do not read this as the pool opening connections against RDS. The pool itself will look healthy on every other rule in this group, because turnover and concurrency are independent and a connect-per-query client occupies one connection at a time. The cost lands on the client: a pod has roughly 28,000 ephemeral ports against a single service address, so sustained churn ends in psycopg2 'Cannot assign requested address' and failing runs, which is what DagsterDatabaseConnectionFailures reports once it is too late. Check that every Dagster storage in dagster_instance.yaml still uses a pooling connection class -- a non-pooling one reconnects on each use and produces exactly this.",
+                    "summary": "Dagster PgBouncer in cluster {{ $labels.cluster }} is recording {{ $value }} server assignments per second",
+                    "description": "server_assignments_total in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} is rising fast enough to have tripped the old session-mode client-churn threshold. Under pool_mode = transaction this counter increments roughly once per transaction rather than once per client connect, so this is currently uncalibrated and may just be query throughput -- do not page on it. Check pgbouncer_pools_client_active_connections / client_waiting_connections for the actual client-socket picture, and confirm every Dagster storage in dagster_instance.yaml still uses a pooling connection class before assuming a reconnect storm.",
                 },
                 datas=rd(
                     "sum by (cluster, namespace) "
@@ -323,10 +343,11 @@ def create(
                 for_="15m",
                 no_data_state="OK",
                 exec_err_state="KeepLast",
-                labels={"severity": "critical"},
+                # No severity label: routes to `oblivion` while recalibrating.
+                labels={},
                 annotations={
-                    "summary": "Dagster PgBouncer in cluster {{ $labels.cluster }} is serving {{ $value }} new client connections per second",
-                    "description": "PgBouncer in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} is accepting new client connections fast enough that something is connecting per unit of work rather than holding a pool. This counts client connections served, not new PgBouncer-to-Postgres backends -- server_assignments_total is named for the backend it hands out, but an assignment reuses a pooled one, so do not read this as the pool opening connections against RDS. The pool itself will look healthy on every other rule in this group, because turnover and concurrency are independent and a connect-per-query client occupies one connection at a time. The cost lands on the client: a pod has roughly 28,000 ephemeral ports against a single service address, so sustained churn ends in psycopg2 'Cannot assign requested address' and failing runs, which is what DagsterDatabaseConnectionFailures reports once it is too late. Check that every Dagster storage in dagster_instance.yaml still uses a pooling connection class -- a non-pooling one reconnects on each use and produces exactly this.",
+                    "summary": "Dagster PgBouncer in cluster {{ $labels.cluster }} is recording {{ $value }} server assignments per second",
+                    "description": "server_assignments_total in namespace {{ $labels.namespace }} in cluster {{ $labels.cluster }} is rising fast enough to have tripped the old session-mode client-churn threshold. Under pool_mode = transaction this counter increments roughly once per transaction rather than once per client connect, so this is currently uncalibrated and may just be query throughput -- do not page on it. Check pgbouncer_pools_client_active_connections / client_waiting_connections for the actual client-socket picture, and confirm every Dagster storage in dagster_instance.yaml still uses a pooling connection class before assuming a reconnect storm.",
                 },
                 datas=rd(
                     "sum by (cluster, namespace) "


### PR DESCRIPTION
### What are the relevant tickets?
N/A — tracked in the internal witan task graph as tk-switch-dagster-s-pgbouncer-to-pool-mode-transact-a2d152, discovered from tk-verify-the-pgbouncer-pool-re-tune-against-the-ex-71af3e.

### Description (What does it do?)
Switches Dagster's PgBouncer `dagster` database from `pool_mode = session` to `pool_mode = transaction`, with a rationale comment in place of the previous unexplained default.

- Cross-checked against live QA Prometheus at 2026-08-19T16:26:00Z: `pgbouncer_databases_current_connections{database="dagster"}` (server side) was 377 + 382 = 759 across both pods, an exact match to the cited backend count. Client-side (`pgbouncer_pools_client_active_connections` + `pgbouncer_pools_client_waiting_connections`) was ~780 (377 active/0 waiting + 382 active/21 waiting), matching the cited 782 within scrape-interval jitter. Session mode pins one backend per client connection for its life, so PgBouncer was doing no multiplexing — a proxy with a connection limit, not a pool. As of this PR, the current live ratio is still ~1:1 (611 client / 577 server sampled just now), so the problem is ongoing, not historical.
- The amplification is worse than a flat 1:1 suggests: Dagster's own storages (`event_log`/`run`/`schedule`, see `dagster_instance.yaml`) each hold a client-side SQLAlchemy `QueuePool`, and under session mode every idle-but-open `QueuePool` connection also pinned a live RDS backend. 16 long-lived processes × dozens of pooled connections each is most of the observed ratio before a single run worker is counted.
- The standard objection — that Dagster's Postgres event-log watcher needs `LISTEN`/`NOTIFY`, which transaction mode breaks — does not apply. Verified against the actual pinned wheel (`dagster-postgres==0.29.18`, downloaded and inspected directly, not read from a deployed venv second-hand): `event_log.py` uses `SqlPollingEventWatcher` (polling) in `watch()`, and the only `NOTIFY` left is commented "no longer used for pg event watch - preserved here to support version skew". `ol_orchestrate`'s `PooledPostgresEventLogStorage` (ol-data-platform) doesn't override `watch()`. Nothing `LISTEN`s any more; a lone `NOTIFY` is a single statement, harmless under transaction pooling.
- `isolation_level="AUTOCOMMIT"` on every storage (no held transactions) and `max_prepared_statements = 0` (already set) make this a clean fit. Verified the driver in use is `psycopg2-binary` (pinned `~=2.9.10` in ol-data-platform's `uv.lock`, resolving to 2.9.12), and confirmed against its C source that it never calls `PQprepare`/`PQsendPrepare` — the only prepared-statement path in its docs is `execute_batch()` with hand-written `PREPARE`/`EXECUTE`/`DEALLOCATE` SQL, which Dagster's SQLAlchemy layer doesn't use. So the guard rail isn't live, but it turns a would-be silent break into a loud one if that ever changes.
- Updates the `dagster_instance.yaml` comments that reasoned about `pool_size`/`max_overflow` sizing and monitoring signals (`pgbouncer_databases_current_connections` vs `pgbouncer_pools_server_active_connections`) against the old session-mode pinning behavior, since transaction mode changes both.

**Not addressed in this PR**, filed as follow-up tasks:
- `PooledPostgresEventLogStorage.optimize_for_webserver()` SETs `statement_timeout` on SQLAlchemy's `connect` event, which fires once per `QueuePool` physical connection rather than once per transaction — under transaction mode that SET silently stops applying to backends assigned to later transactions on the same client socket. Needs a fix at the RDS parameter-group level or in `ol-data-platform`.
- Startup migration path (`stamp_alembic_rev`/`create_all` under `should_autocreate_tables`) is wrapped in a single explicit transaction so it should be safe under transaction pooling, but hasn't been confirmed against a live restart, and the other two storage classes (`run_storage`, `schedule_storage`) weren't read as closely.

### How can this be tested?
- `uv run pre-commit run --files src/ol_infrastructure/applications/dagster/__main__.py src/ol_infrastructure/applications/dagster/dagster_instance.yaml` — passed (formatting, yamllint, mypy, ruff).
- `pulumi preview --stack QA --diff` — plan is exactly what's expected: the `dagster-pgbouncer-config` ConfigMap replaces (its content changed, and it's `delete_before_replace=True` by design), the `dagster-pgbouncer` Deployment and the Helm-managed daemon/webserver pods roll via their checksum annotations, nothing else changes. (An unrelated `image tag: "<sha>" => "latest"` diff also appeared — that's local-shell noise from `DAGSTER_K8S_IMAGE_TAG` not being set the way Concourse sets it in CI, not caused by this change.)
- Not deployed. Per the task's own rollout note, QA should go first since that's where the ~1:1 ratio is live right now. After it deploys, confirm:
  - `pgbouncer_databases_current_connections` per pod drops well below the 382 cap
  - `pgbouncer_pools_server_active_connections` separates from client connection count instead of tracking it 1:1
  - `DagsterPgBouncerClientsWaiting` / `DagsterDatabaseConnectionFailuresChronic` clear
  - daemon/webserver/code-location pods come up cleanly through the ConfigMap-triggered restart (checking for the migration-path risk noted above)

### Additional Context
Two follow-up tasks filed in the witan graph, discovered from this work:
- `tk-fix-statement-timeout-leak-under-pgbouncer-trans-4b9145` — fix the connect-time `statement_timeout` SET that stops applying after the first transaction under transaction-mode pooling.
- `tk-verify-dagster-storage-startup-migrations-stamp--984177` — verify the autocreate-tables/Alembic-stamp startup path (and the other two pooled storage classes) against a live transaction-mode restart.