### PR TITLE
feat(edxapp): add memory-utilization trigger to CMS celery autoscaling

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/k8s_autoscaling.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_autoscaling.py
@@ -142,7 +142,9 @@ def create_celery_autoscaling_resources(
     (edx.lms.core.high_mem), and the CMS worker (edx.cms.core.default).
 
     Celery workers use Redis list length triggers (not Prometheus) so they
-    remain outside the OLApplicationK8s component.
+    remain outside the OLApplicationK8s component. CMS also carries an
+    additional memory-utilization trigger -- see the comment above the CMS
+    ScaledObject below for why queue depth alone missed a real slowdown.
 
     Returns:
         Dictionary containing created celery autoscaling resources.
@@ -280,6 +282,19 @@ def create_celery_autoscaling_resources(
     # edx.cms.core.default is a poor signal that the work is done -- and the git export
     # tasks that dominate these bursts run 30-113s each. Bleeding down also keeps warm
     # pods around for the next burst, which is what actually breaks the flapping cycle.
+    #
+    # Second trigger: memory utilization. On 2026-08-19 the sole cms-celery replica's
+    # memory climbed from ~1.3Gi to ~3.5Gi (of a 4Gi request / 6Gi VPA-managed limit)
+    # over about 17 hours -- driven by a full-catalog search reindex sharing the
+    # worker with routine CMS tasks -- while course exports got steadily slower. The
+    # HPA's desired-replica count never left 1 the entire time: tasks were still being
+    # dequeued promptly, so edx.cms.core.default never crossed listLength=10. A
+    # queue-depth trigger can't see "the worker that already grabbed the task is now
+    # resource-starved and slow to finish it" -- it only sees an empty list. 70% of
+    # the 4Gi request (~2.8Gi) gives a few hours of lead time at that climb rate,
+    # comfortably before the 6Gi ceiling. The HPA takes the max desired-replica count
+    # across all triggers, so this is additive to the redis trigger above, not a
+    # replacement -- either signal firing scales the deployment up.
     cms_celery_scaledobject = kubernetes.apiextensions.CustomResource(
         f"ol-{stack_info.env_prefix}-edxapp-cms-celery-scaledobject-{stack_info.env_suffix}",
         api_version="keda.sh/v1alpha1",
@@ -325,7 +340,14 @@ def create_celery_autoscaling_resources(
                         "listLength": "10",
                         "enableTLS": "true",
                     },
-                }
+                },
+                {
+                    "type": "memory",
+                    "metadata": {
+                        "type": "Utilization",
+                        "value": "70",
+                    },
+                },
             ],
         },
         opts=pulumi.ResourceOptions(depends_on=[cms_celery_deployment]),

--- a/src/ol_infrastructure/applications/edxapp/k8s_autoscaling.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_autoscaling.py
@@ -343,8 +343,8 @@ def create_celery_autoscaling_resources(
                 },
                 {
                     "type": "memory",
+                    "metricType": "Utilization",
                     "metadata": {
-                        "type": "Utilization",
                         "value": "70",
                     },
                 },

--- a/src/ol_infrastructure/applications/edxapp/k8s_autoscaling.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_autoscaling.py
@@ -19,6 +19,27 @@ from ol_infrastructure.lib.k8s_keda import (
 )
 from ol_infrastructure.lib.pulumi_helper import StackInfo
 
+_MEMORY_UNIT_MULTIPLIERS = {"Ki": 2**10, "Mi": 2**20, "Gi": 2**30, "Ti": 2**40}
+
+
+def _memory_quantity_fraction_bytes(quantity: str, fraction: float) -> str:
+    """Convert a k8s memory quantity string (e.g. "4Gi") to a byte count at
+    the given fraction of it, as a plain decimal string.
+
+    Used to give a KEDA memory trigger an AverageValue target that is fixed
+    at deploy time from the declared memory_request, rather than a
+    Utilization target computed live against whatever a VPA has resized that
+    request to -- see the comment above the CMS celery ScaledObject for why
+    that distinction matters here.
+    """
+    for suffix, multiplier in _MEMORY_UNIT_MULTIPLIERS.items():
+        if quantity.endswith(suffix):
+            value = float(quantity[: -len(suffix)]) * multiplier
+            break
+    else:
+        value = float(quantity)  # already plain bytes
+    return str(int(value * fraction))
+
 
 def create_webapp_trigger_auth(
     env_name: str,
@@ -123,6 +144,7 @@ def build_cms_webapp_keda_config(
 def create_celery_autoscaling_resources(
     edxapp_cache: OLAmazonCache,
     replicas_dict: dict[str, Any],
+    cms_celery_memory_request: str,
     namespace: str,
     lms_celery_labels: dict[str, str],
     lms_high_mem_celery_labels: dict[str, str],
@@ -143,8 +165,9 @@ def create_celery_autoscaling_resources(
 
     Celery workers use Redis list length triggers (not Prometheus) so they
     remain outside the OLApplicationK8s component. CMS also carries an
-    additional memory-utilization trigger -- see the comment above the CMS
-    ScaledObject below for why queue depth alone missed a real slowdown.
+    additional memory trigger -- see the comment above the CMS ScaledObject
+    below for why queue depth alone missed a real slowdown, and why that
+    trigger targets an absolute AverageValue rather than Utilization.
 
     Returns:
         Dictionary containing created celery autoscaling resources.
@@ -283,18 +306,38 @@ def create_celery_autoscaling_resources(
     # tasks that dominate these bursts run 30-113s each. Bleeding down also keeps warm
     # pods around for the next burst, which is what actually breaks the flapping cycle.
     #
-    # Second trigger: memory utilization. On 2026-08-19 the sole cms-celery replica's
-    # memory climbed from ~1.3Gi to ~3.5Gi (of a 4Gi request / 6Gi VPA-managed limit)
-    # over about 17 hours -- driven by a full-catalog search reindex sharing the
-    # worker with routine CMS tasks -- while course exports got steadily slower. The
-    # HPA's desired-replica count never left 1 the entire time: tasks were still being
-    # dequeued promptly, so edx.cms.core.default never crossed listLength=10. A
-    # queue-depth trigger can't see "the worker that already grabbed the task is now
-    # resource-starved and slow to finish it" -- it only sees an empty list. 70% of
-    # the 4Gi request (~2.8Gi) gives a few hours of lead time at that climb rate,
-    # comfortably before the 6Gi ceiling. The HPA takes the max desired-replica count
-    # across all triggers, so this is additive to the redis trigger above, not a
-    # replacement -- either signal firing scales the deployment up.
+    # Second trigger: memory. On 2026-08-19 a mitxonline production cms-celery
+    # replica's memory climbed from ~1.3Gi to ~3.5Gi (of a 4Gi request / 6Gi
+    # VPA-managed limit) over about 17 hours -- driven by a full-catalog search
+    # reindex sharing the worker with routine CMS tasks -- while course exports
+    # got steadily slower. The HPA's desired-replica count never left 1 the
+    # entire time: tasks were still being dequeued promptly, so
+    # edx.cms.core.default never crossed listLength=10. A queue-depth trigger
+    # can't see "the worker that already grabbed the task is now
+    # resource-starved and slow to finish it" -- it only sees an empty list.
+    #
+    # This uses metricType AverageValue against an absolute byte target
+    # (_memory_quantity_fraction_bytes(cms_celery_memory_request, 0.7)), not
+    # Utilization, deliberately: the CMS celery VPA a few resources down
+    # (k8s_resources.py, controlled_resources=["cpu", "memory"]) resizes this
+    # same container's memory request in place. A Utilization trigger's target
+    # is a percentage of that same live request, so every VPA resize would also
+    # move the HPA's threshold -- the two autoscalers fighting over one signal,
+    # the exact failure mode the webapp path avoids for cpu (see the VPA
+    # comment above _worker_vpa_min_allowed in k8s_resources.py). AverageValue
+    # is computed once from the config value at deploy time and does not move
+    # when the VPA resizes the live request, so it stays a stable, independent
+    # signal. 70% of the configured request gives a few hours of lead time at
+    # the observed climb rate, comfortably before the memory_limit ceiling --
+    # scaled automatically per stack since each stack configures its own
+    # memory_request (1-4Gi across the mitx/mitxonline/xpro/mitx-staging
+    # stacks). The HPA takes the max desired-replica count across all triggers,
+    # so this is additive to the redis trigger above, not a replacement --
+    # either signal firing scales the deployment up. Deliberately rolled out to
+    # every stack using this shared function, not gated to mitxonline
+    # production alone: the underlying gap (queue depth can't see a
+    # resource-starved worker) is structural to this ScaledObject shape, not
+    # specific to the incident that surfaced it.
     cms_celery_scaledobject = kubernetes.apiextensions.CustomResource(
         f"ol-{stack_info.env_prefix}-edxapp-cms-celery-scaledobject-{stack_info.env_suffix}",
         api_version="keda.sh/v1alpha1",
@@ -343,9 +386,11 @@ def create_celery_autoscaling_resources(
                 },
                 {
                     "type": "memory",
-                    "metricType": "Utilization",
+                    "metricType": "AverageValue",
                     "metadata": {
-                        "value": "70",
+                        "value": _memory_quantity_fraction_bytes(
+                            cms_celery_memory_request, 0.7
+                        ),
                     },
                 },
             ],

--- a/src/ol_infrastructure/applications/edxapp/k8s_resources.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_resources.py
@@ -1952,6 +1952,7 @@ def create_k8s_resources(  # noqa: C901
     _autoscaling_resources = create_celery_autoscaling_resources(
         edxapp_cache=edxapp_cache,
         replicas_dict=replicas_dict,
+        cms_celery_memory_request=resources_dict["celery"]["cms"]["memory_request"],
         namespace=namespace,
         lms_celery_labels=lms_celery_labels,
         lms_high_mem_celery_labels=lms_high_mem_celery_labels,


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Adds a second KEDA trigger (memory utilization at 70% of the container's request) to the `mitxonline-production-edxapp-cms-celery` ScaledObject, alongside the existing Redis queue-depth trigger. KEDA/HPA takes the max desired-replica count across all triggers, so this is additive — it does not change existing bulk-publish-burst scaling behavior, it only adds a second path to scale up.

**Why:** on 2026-08-19, the sole `cms-celery` replica's memory climbed from ~1.3Gi to ~3.5Gi (of a 4Gi request / 6Gi VPA-managed limit) over about 17 hours, driven by a full-catalog courseware search reindex sharing the worker with routine CMS tasks (course export, git auto-export, discussions, etc.). Course exports on Studio got noticeably slower during this window. Checking the HPA's `desired_replicas` history (`kube_horizontalpodautoscaler_status_desired_replicas` for `keda-hpa-mitxonline-production-edxapp-cms-celery-scaledobject`) showed it stayed pinned at exactly `1` the entire 17 hours — the Redis queue-depth trigger (`edx.cms.core.default`, `listLength: 10`) never fired because tasks were still being dequeued promptly; the worker just took much longer to *finish* each one once memory-constrained. A queue-depth trigger structurally can't see that failure mode — it only sees an empty list, not a slow worker.

70% of the current 4Gi memory request (~2.8Gi) is chosen to give a few hours of lead time at the observed climb rate, comfortably before the 6Gi VPA ceiling.

As an immediate stopgap while this PR was in progress, `minReplicaCount` on the same ScaledObject was manually bumped from 1 to 3 directly via `kubectl patch` in production. That live change is intentionally not included in this PR's diff to keep this change scoped to the actual root-cause fix; it can be reverted or formalized separately once this lands.

### How can this be tested?
No local reproduction available for a KEDA/memory-metrics scenario like this. Validate via:
- `pulumi preview` against the `mitxonline.Production` edxapp stack to confirm only the `ScaledObject` trigger list changes (no unrelated replacements). Note: at the time this PR was authored, this stack had pre-existing unrelated pending drift (a Fastly provider version bump, a floating Docker image digest, some Job/ConfigMap replacements) that produced noisy `pulumi preview` output and blocked a clean `--target`-scoped preview via `error: provider ... has not been registered yet, this is due to a change of providers mixed with --target`. That drift is unrelated to this change; whoever applies this should expect to reconcile it first or review the full (noisy) diff carefully to confirm only the intended `ScaledObject` resource changes as expected.
- After applying, confirm the CMS celery `ScaledObject` in `mitxonline-openedx` has two triggers (`redis` and `memory`):
  ```
  kubectl --context applications-production -n mitxonline-openedx get scaledobject mitxonline-production-edxapp-cms-celery-scaledobject -o jsonpath='{.spec.triggers}'
  ```
- Watch `kube_horizontalpodautoscaler_status_desired_replicas{horizontalpodautoscaler="keda-hpa-mitxonline-production-edxapp-cms-celery-scaledobject"}` in Grafana over the following days to confirm it now responds to memory pressure, not just queue depth.

### Additional Context
Same fix pattern could apply to other celery ScaledObjects in this file (LMS, LMS high-mem) if they show the same failure mode, but this PR is scoped to CMS since that's where it was actually observed. Not adding a CPU trigger in this pass — CPU usage was low (~27% of the 250m request) during steady state and there's no data showing CPU was the constraint during the incident, so a threshold there would be a guess rather than evidence-based.