### PR TITLE
ci: scope permissions on the pytest workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -6,9 +6,13 @@ on:
     branches: [main]
   pull_request:
 
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       with:


### PR DESCRIPTION
### What are the relevant tickets?

Closes #5216

### Description (What does it do?)

- Adds `permissions: {}` at the workflow level and `permissions: {contents: read}` on the `test` job in `.github/workflows/pytest.yml`.
- Without a `permissions` block the job ran with the repository's default token scopes. zizmor reports this as `excessive-permissions` at medium severity, which is below the `min-severity: high` gate used by both `.github/workflows/actions-static-analysis.yml` and the `zizmorcore/zizmor-pre-commit` hook in `.pre-commit-config.yaml` — so it never surfaced in CI or locally.
- Matches the shape already used by `actions-static-analysis.yml`, which sets `permissions: {}` at the workflow level and scopes the job explicitly.

This was the only finding named in #5216. All action `uses:` refs in the repo are already SHA-pinned, so no other class of finding remains.

### How can this be tested?

Run zizmor below the configured gate so the finding is visible, against the file before and after this change:

```
uvx zizmor@1.29.0 --no-progress --min-severity=low --min-confidence=low .github/workflows/pytest.yml
```

Before this change:

```
warning[excessive-permissions]: overly broad permissions
  --> .github/workflows/pytest.yml:10:3
   |                           default permissions used due to no permissions: block
   = note: audit confidence → Medium

4 findings (3 suppressed): 0 informational, 0 low, 1 medium, 0 high
```

After this change:

```
No findings to report. Good job! (2 suppressed)
```

Note: the command above runs zizmor in offline mode, which suppresses some unrelated audits (hence the differing suppressed counts); the `excessive-permissions` audit is unaffected. The issue used online mode via `GH_TOKEN=$(gh auth token)`.

The `pytest` workflow itself should still pass on this PR — `contents: read` is all the job needs, since `actions/checkout` runs with `persist-credentials: false` and no step writes back to the repo.
