### PR TITLE
fix(concourse): grant c7n the CodeBuild reads its SG `unused` filter needs

### DIFF
--- a/src/ol_infrastructure/applications/concourse/iam_policies/cloud_custodian.py
+++ b/src/ol_infrastructure/applications/concourse/iam_policies/cloud_custodian.py
@@ -33,6 +33,33 @@ policy_definition = {
             "Resource": "*",
         },
         {
+            # Cloud Custodian's `unused` filter on aws.security-group decides
+            # whether a group is referenced by scanning the services that can
+            # hold one -- see SGUsage.get_scanners() in c7n/resources/vpc.py,
+            # which includes a "codebuild" scanner. The other scanners (ENIs,
+            # SG cross-references, Lambda, launch configs, ECS/CloudWatch
+            # Events rules) are already covered by this policy and by
+            # iam_policies/infra.py; CodeBuild was not, so
+            # tag-packer-sg-for-cleanup and perform-packer-sg-cleanup both
+            # died on AccessDeniedException once the infra worker's
+            # AdministratorAccess was detached.
+            #
+            # Both calls are required, not just the one in the error: c7n's
+            # CodeBuildProject enumerates with
+            # enum_spec = ('list_projects', ...) and then hydrates with
+            # batch_detail_spec = ('batch_get_projects', ...).
+            #
+            # Resource "*" because the filter enumerates every project in the
+            # account -- there is no narrower scope that still answers "is
+            # this security group in use anywhere".
+            "Effect": "Allow",
+            "Action": [
+                "codebuild:BatchGetProjects",
+                "codebuild:ListProjects",
+            ],
+            "Resource": "*",
+        },
+        {
             "Effect": "Allow",
             "Action": [
                 "kms:Decrypt",


### PR DESCRIPTION
### What are the relevant tickets?
N/A — found during the 2026-08-19 Concourse pipeline failure sweep. No GitHub issue was filed.

### Description (What does it do?)
`misc-cloud-custodian/tag-packer-sg-for-cleanup` has failed 8/8 consecutive daily runs since Aug 12 with `AccessDeniedException` on `codebuild:ListProjects`.

- [`cloud_custodian/tag_packer_security_groups_for_cleanup.yaml`](https://github.com/mitodl/ol-infrastructure/blob/main/cloud_custodian/tag_packer_security_groups_for_cleanup.yaml) filters `aws.security-group` on `unused`. To decide whether a group is referenced, c7n scans every service that can hold one — `SGUsage.get_scanners()` in [`c7n/resources/vpc.py`](https://github.com/cloud-custodian/cloud-custodian/blob/0.9.15.0/c7n/resources/vpc.py) returns:

  ```python
  return (
      ("nics", self.get_eni_sgs),
      ("sg-perm-refs", self.get_sg_refs),
      ('lambdas', self.get_lambda_sgs),
      ("launch-configs", self.get_launch_config_sgs),
      ("ecs-cwe", self.get_ecs_cwe_sgs),
      ("codebuild", self.get_codebuild_sgs),
  )
  ```

- Adds `codebuild:ListProjects` + `codebuild:BatchGetProjects` to `iam_policies/cloud_custodian.py`, which is on the `infra` worker pool in all three stacks — so no stack config changes.

**Both calls, not just the one in the error.** `CodeBuildProject.resource_type` in [`c7n/resources/code.py`](https://github.com/cloud-custodian/cloud-custodian/blob/0.9.15.0/c7n/resources/code.py) is:

```python
enum_spec = ('list_projects', 'projects', None)
batch_detail_spec = ('batch_get_projects', 'names', None, 'projects', None)
```

Granting only `ListProjects` would have failed again one call later.

`Resource: "*"` because the filter enumerates every project in the account — there is no narrower scope that answers "is this security group in use anywhere". The grant is read-only.

### How can this be tested?

Simulated all six scanners against the live infra worker role — only the CodeBuild pair is denied, which is why this surfaced as one missing action rather than a broken filter:

```
$ aws iam simulate-principal-policy \
    --policy-source-arn arn:aws:iam::610119931565:role/ol-applications/concourse/role/concourse-instance-role-worker-infra-production-ed1176e \
    --action-names codebuild:ListProjects codebuild:BatchGetProjects lambda:ListFunctions \
      events:ListRules events:ListTargetsByRule ec2:DescribeNetworkInterfaces \
      ec2:DescribeSecurityGroups autoscaling:DescribeLaunchConfigurations

  codebuild:ListProjects                        implicitDeny   <-- reported failure
  codebuild:BatchGetProjects                    implicitDeny   <-- would be the next one
  lambda:ListFunctions                          allowed
  events:ListRules                              allowed
  events:ListTargetsByRule                      allowed
  ec2:DescribeNetworkInterfaces                 allowed
  ec2:DescribeSecurityGroups                    allowed
  autoscaling:DescribeLaunchConfigurations      allowed
```

`simulate-custom-policy` against the new statement — the two reads are allowed and the grant does not widen into writes:

| Action | Result |
|---|---|
| `codebuild:ListProjects` | allowed |
| `codebuild:BatchGetProjects` | allowed |
| `codebuild:DeleteProject` | implicitDeny |
| `codebuild:StartBuild` | implicitDeny |

Also run:

- `pre-commit run --files ...` — all hooks pass
- Parliament lint via `lint_iam_policy` with the stack's own `parliament_config` — clean, 1 chunk, 788 bytes
- `pulumi preview` on Production, CI, and QA — each shows `aws:iam:Policy cicd-iam-permissions-policy-cloud_custodian-{env}` as `update [diff: ~policy]`, an in-place document update. Nothing created, replaced, or deleted.

**Not** verified: an actual pipeline run. Confirm by re-running `tag-packer-sg-for-cleanup` after deploy — it should get past the filter and mark packer SGs with `custodian_cleanup`.

### Additional Context

- **Root cause is #4873**, which detached `AdministratorAccess` from the infra worker in favour of policies derived from CloudTrail usage (Access Analyzer over a 14-day window plus unused-access history). A filter's internal service fan-out is exactly the kind of call that under-samples: it only fires when the filter runs, and it is invisible in the policy YAML. `AdministratorAccess` and `SystemAdministrator` are confirmed gone from the role, and this job's first failure (Aug 12) postdates the merge (Jul 28) — consistent with the detach landing separately from the merge.
- **[`cleanup_packer_security_groups.yaml`](https://github.com/mitodl/ol-infrastructure/blob/main/cloud_custodian/cleanup_packer_security_groups.yaml) uses the same `unused` filter**, so `perform-packer-sg-cleanup` is unblocked by the same grant. I did not check its build history separately.
- Worth a look for the same class of gap: several other sweep items (`pulumi-mailgun` qa, `pulumi-mongodb-atlas` mitxonline.production, `pulumi-aws-sftp` ci) are also infra-worker jobs that started failing after #4873. I have not confirmed those are IAM-related — their reported symptom is a stack-refresh/lock-recovery traceback, which may or may not be a masked AccessDenied.
- The `type: unused` filters on `aws.ami` in `tag_ebs_resources_for_cleanup.yaml` are a different filter class with a different call set, and are not reported failing.
