### PR TITLE
fix(starrocks): harden the FE MySQL NLB security group for the new MIT Learn consumer

### DIFF
--- a/src/ol_infrastructure/applications/concourse/__main__.py
+++ b/src/ol_infrastructure/applications/concourse/__main__.py
@@ -408,6 +408,11 @@ concourse_worker_security_group = ec2.SecurityGroup(
     egress=default_egress_args,
     vpc_id=ops_vpc_id,
 )
+# Exported so other stacks' local.Command resources (e.g.
+# substructure/starrocks's SQL setup, which runs on this Concourse instance's
+# workers per src/ol_concourse/pipelines/infrastructure/simple_pulumi/meta.py)
+# can admit these workers into security groups gating VPC-internal endpoints.
+export("concourse_worker_security_group_id", concourse_worker_security_group.id)
 
 # Create web node security group
 concourse_web_security_group = ec2.SecurityGroup(

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1895,5 +1895,6 @@ export(
         "vault_iam_role": Output.all(
             mitlearn_vault_iam_role.backend, mitlearn_vault_iam_role.name
         ).apply(lambda role: f"{role[0]}/roles/{role[1]}"),
+        "app_security_group_id": mitlearn_app_security_group.id,
     },
 )

--- a/src/ol_infrastructure/applications/starrocks/__main__.py
+++ b/src/ol_infrastructure/applications/starrocks/__main__.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 import pulumi_kubernetes as kubernetes
 import pulumi_vault
 from pulumi import Config, InvokeOptions, Output, ResourceOptions, export
-from pulumi_aws import iam
+from pulumi_aws import ec2, iam
 
 from bridge.lib.versions import STARROCKS_CHART_VERSION, STARROCKS_VERSION
 from ol_infrastructure.components.applications.eks import (
@@ -71,6 +71,22 @@ starrocks_data_storage_class = stateful_workload_storage["storage_class"]
 
 kms_stack = make_stack_reference(projects.KMS, stack_info.name)
 s3_kms_key = kms_stack.require_output("kms_s3_data_analytics_key")
+
+# Stack references needed to scope the FE MySQL NLB security group (see
+# fe_mysql_nlb_security_group below) to its known consumers: Vault (dynamic DB
+# credential management), MIT Learn (application queries), and this
+# environment's Concourse worker fleet (runs the substructure/starrocks SQL
+# setup local.Command resources against the same NLB endpoint; see
+# src/ol_infrastructure/substructure/starrocks/__main__.py's module docstring
+# and src/ol_concourse/pipelines/infrastructure/simple_pulumi/meta.py, which
+# routes starrocks-substructure[-qa] to the env-matched Concourse instance).
+network_stack = make_stack_reference(projects.NETWORKING, stack_info.name)
+data_vpc = network_stack.require_output("data_vpc")
+vault_stack = make_stack_reference(
+    projects.VAULT_SERVER, f"operations.{stack_info.name}"
+)
+mit_learn_stack = make_stack_reference(projects.MIT_LEARN, stack_info.name)
+concourse_stack = make_stack_reference(projects.CONCOURSE, stack_info.name)
 
 starrocks_env = f"data-{stack_info.env_suffix}"
 aws_config = AWSBase(tags={"OU": "data", "Environment": starrocks_env})
@@ -987,6 +1003,44 @@ starrocks_apisix_httproute = OLApisixHTTPRoute(
 # Vault — running on EC2 in the operations VPC, which is peered with the data VPC —
 # can reach StarRocks to manage dynamic database credentials.
 FE_MYSQL_PORT = 9030
+
+# The NLB has no explicit security group by default: the AWS Load Balancer
+# Controller auto-manages one with no source restriction, gated only by
+# "internal scheme + VPC-peering routability." This SG replaces that default
+# once attached via the aws-load-balancer-security-groups annotation below,
+# becoming the sole authority on the NLB's ingress — so every real consumer of
+# the FE MySQL port must be admitted here explicitly:
+#   - Vault (operations VPC): manages dynamic DB credentials.
+#   - MIT Learn app pods (applications VPC): reads StarRocks directly,
+#     replacing a broken Hightouch-based sync and drawing down Trino usage.
+#   - This environment's Concourse workers (operations VPC): run the
+#     substructure/starrocks SQL setup local.Command resources, which need a
+#     mysql-client connection to this same endpoint (see that stack's module
+#     docstring).
+fe_mysql_nlb_security_group = ec2.SecurityGroup(
+    f"starrocks-{stack_info.env_prefix}-{stack_info.env_suffix}-fe-mysql-nlb-sg",
+    name=f"starrocks-{stack_info.env_prefix}-{stack_info.env_suffix}-fe-mysql-nlb",
+    description=(f"Access control for the StarRocks FE MySQL NLB in {stack_info.name}"),
+    ingress=[
+        ec2.SecurityGroupIngressArgs(
+            security_groups=[
+                vault_stack.require_output("vault_server")["security_group"],
+                mit_learn_stack.require_output("mit_learn")["app_security_group_id"],
+                concourse_stack.require_output("concourse_worker_security_group_id"),
+            ],
+            protocol="tcp",
+            from_port=FE_MYSQL_PORT,
+            to_port=FE_MYSQL_PORT,
+            description=(
+                "Allow Vault, MIT Learn app pods, and Concourse workers to reach"
+                " the StarRocks FE MySQL port."
+            ),
+        )
+    ],
+    vpc_id=data_vpc["id"],
+    tags=aws_config.tags,
+)
+
 fe_mysql_nlb_service = kubernetes.core.v1.Service(
     f"starrocks-{stack_info.env_prefix}-{stack_info.env_suffix}-fe-mysql-nlb",
     metadata=kubernetes.meta.v1.ObjectMetaArgs(
@@ -998,6 +1052,9 @@ fe_mysql_nlb_service = kubernetes.core.v1.Service(
             "service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "ip",
             "service.beta.kubernetes.io/aws-load-balancer-scheme": "internal",
             "service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled": "true",  # noqa: E501
+            "service.beta.kubernetes.io/aws-load-balancer-security-groups": (
+                fe_mysql_nlb_security_group.id.apply(lambda sg_id: sg_id)
+            ),
         },
     ),
     spec=kubernetes.core.v1.ServiceSpecArgs(


### PR DESCRIPTION
### What are the relevant tickets?
Witan task: tk-sg-harden-starrocks-fe-mysql-nlb-for-vault-mit-l-fb8043

### Description (What does it do?)
StarRocks' internal NLB (FE MySQL port 9030) had no explicit security group -- the AWS Load Balancer Controller auto-manages a default one with no source restriction, gated only by internal scheme + VPC-peering routability. MIT Learn is now going to read from StarRocks directly (replacing a broken Hightouch-based sync and drawing down Trino usage), so this closes the SG gap before adding that new consumer.

- `applications/starrocks/__main__.py`: adds `fe_mysql_nlb_security_group`, a `SecurityGroup` in the data VPC that allows only TCP/9030 from three known consumers, then attaches it to the NLB `Service` via the `service.beta.kubernetes.io/aws-load-balancer-security-groups` annotation. This makes the new SG the sole authority on the NLB's ingress (the LBC stops managing a default one), so all real consumers had to be identified up front:
  - Vault's server SG (`operations.{env}` stack) -- dynamic DB credential management, existing consumer.
  - MIT Learn's app pod SG (`{env}` stack) -- the new consumer.
  - This environment's Concourse worker SG (`{env}` stack) -- runs the `substructure/starrocks` SQL setup `local.Command` resources, which need mysql-client access to the same NLB endpoint (see that stack's module docstring). Confirmed via `src/ol_concourse/pipelines/infrastructure/simple_pulumi/meta.py`, which routes `starrocks-substructure[-qa]` to the env-matched Concourse instance -- so this is an env-matched dependency, same as Vault and MIT Learn.
- `applications/mit_learn/__main__.py`: exports `app_security_group_id` (the existing `mitlearn_app_security_group`, already bound to the app pods) so starrocks can consume it.
- `applications/concourse/__main__.py`: exports `concourse_worker_security_group_id` (the existing `concourse_worker_security_group`) for the same reason -- it wasn't exported before this.

### How can this be tested?
Ran `pulumi preview` for both `QA` and `Production` across all three touched projects (S3 backend `s3://mitol-pulumi-state`):

- `applications/mit_learn` (stacks `QA`, `Production`): additive-only diff, `+ app_security_group_id: "sg-..."` in outputs, no resource changes from this PR. (Preview required `MIT_LEARN_DOCKER_TAG=latest` to get past an unrelated missing-env-var error; the resulting container-image-tag diffs are an artifact of that placeholder, not this change.)
- `applications/concourse` (stacks `QA`, `Production`): additive-only diff, `+ concourse_worker_security_group_id: "sg-..."` in outputs, no resource changes from this PR.
- `applications/starrocks` (stacks `lakehouse.QA`, `lakehouse.Production`): preview currently fails with `KeyError: 'app_security_group_id'` because the *deployed* `mit_learn` and `concourse` stacks don't yet export the new keys this code reads -- expected, since stack references resolve against already-applied state. **Deploy order matters: `mit_learn` and `concourse` must ship (both are additive, output-only, zero resource changes) before `starrocks`.** Once deployed, `starrocks` preview is expected to show one new `SecurityGroup` (with the three ingress source SGs above) and an additive annotation update on the existing `fe_mysql_nlb_service` -- no replacement of the NLB `Service` itself, so no StarRocks-access outage.
- `pre-commit run --files <changed files>` and `mypy` both pass clean on all three files.

### Additional Context
- The Concourse-coverage question was the main open risk in this task: Vault's SG and Concourse's worker SG are *not* the same thing (Vault runs on its own EC2 ASG; Concourse workers are a separate EC2 fleet, both in the operations VPC), so Concourse needed its own explicit ingress entry -- confirmed via `src/ol_infrastructure/applications/concourse/__main__.py` and the pipeline routing in `src/ol_concourse/pipelines/infrastructure/simple_pulumi/meta.py`.
- Not merging/deploying this PR myself per the driving task's instructions -- flagging the two-phase rollout (mit_learn + concourse first, then starrocks) for whoever applies it.
