### PR TITLE
feat(edxapp): move mitx-staging LMS to the new Granian defaults

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.CI.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.CI.yaml
@@ -84,6 +84,16 @@ config:
   edxapp:backend_lms_domain: courses-backend-staging.ci.mitx.mit.edu
   edxapp:backend_studio_domain: studio-backend-staging.ci.mitx.mit.edu
   edxapp:backend_preview_domain: preview-staging.ci.mitx.mit.edu
+  # Stage 3 LMS defaults, following mitx's canary. Trivially loaded (~0.15 rps
+  # over 1-2 pods per pat-size-granian-blocking-threads-from-busy-thread-c-3a8b48),
+  # so no measurement wait is needed here. See
+  # docs/plans/granian-configuration-overhaul.md.
+  edxapp:k8s_granian:
+    lms:
+      workers: 1
+      runtime_threads: 1
+      blocking_threads: 8
+      backpressure: 16
   edxapp:k8s_replicas:
     webapp:
       cms:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.Production.yaml
@@ -84,6 +84,16 @@ config:
   edxapp:backend_lms_domain: courses-backend-staging.mitx.mit.edu
   edxapp:backend_studio_domain: studio-backend-staging.mitx.mit.edu
   edxapp:backend_preview_domain: preview-backend-staging.mitx.mit.edu
+  # Stage 3 LMS defaults, following mitx's canary. Trivially loaded (~0.15 rps
+  # over 1-2 pods per pat-size-granian-blocking-threads-from-busy-thread-c-3a8b48),
+  # so no measurement wait is needed here. See
+  # docs/plans/granian-configuration-overhaul.md.
+  edxapp:k8s_granian:
+    lms:
+      workers: 1
+      runtime_threads: 1
+      blocking_threads: 8
+      backpressure: 16
   edxapp:k8s_replicas:
     webapp:
       cms:

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.QA.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitx-staging.QA.yaml
@@ -85,6 +85,16 @@ config:
   edxapp:backend_lms_domain: courses-backend-staging.qa.mitx.mit.edu
   edxapp:backend_studio_domain: studio-backend-staging.qa.mitx.mit.edu
   edxapp:backend_preview_domain: preview-staging.qa.mitx.mit.edu
+  # Stage 3 LMS defaults, following mitx's canary. Trivially loaded (~0.15 rps
+  # over 1-2 pods per pat-size-granian-blocking-threads-from-busy-thread-c-3a8b48),
+  # so no measurement wait is needed here. See
+  # docs/plans/granian-configuration-overhaul.md.
+  edxapp:k8s_granian:
+    lms:
+      workers: 1
+      runtime_threads: 1
+      blocking_threads: 8
+      backpressure: 16
   edxapp:k8s_replicas:
     webapp:
       cms:


### PR DESCRIPTION
### What are the relevant tickets?
N/A — tracked in witan task tk-edxapp-lms-needs-blocking-threads-sized-from-mea-317fe2, item 4 ("mitx-staging LMS is trivially loaded and can follow mitx at any time").

### Description (What does it do?)
Stage 3 of the Granian configuration overhaul (see `docs/plans/granian-configuration-overhaul.md`) moved mitx (residential) LMS to the component's new Granian defaults as a canary (PR #5466, merged): 1 worker, 1 runtime thread, 8 blocking threads, backpressure 16. mitxonline LMS is deferred pending a 14-day production measurement window because its p99 concurrency (17.7 busy threads/pod) already exceeds the 8-thread default.

mitx-staging LMS was left out of that PR. It carries negligible traffic (~0.15 rps across 1-2 pods) and needs no measurement window, so this sets `edxapp:k8s_granian.lms` on all three mitx-staging stacks (CI/QA/Production) to the same values already validated on mitx:

```yaml
edxapp:k8s_granian:
  lms:
    workers: 1
    runtime_threads: 1
    blocking_threads: 8
    backpressure: 16
```

`k8s_resources.py` is shared across mitx / mitx-staging / mitxonline-openedx, but this key is per-stack config (`edxapp_config.get_object("k8s_granian")`), so it only affects mitx-staging.

### How can this be tested?
`pulumi preview` against all three mitx-staging stacks (CI/QA/Production) shows only the LMS Deployment's Granian args changing — `--workers 2` → `1`, `--runtime-mode mt --runtime-threads 2` → `--runtime-threads 1`, `--blocking-threads 32` → `8`, `--backpressure 64` → `16`, `--workers-max-rss 921` → `1843` (aggregate-invariant: same total cap now divided across 1 worker instead of 2). No resource replacement or deletion. CMS is untouched (it already took the component defaults unconditionally in stage 3's earlier PR #5461).

Note: the QA and Production previews also show unrelated pre-existing drift (uwsgi.ini ConfigMap removal from #5557, CMS granian defaults from #5461) because those stacks haven't deployed recently — that drift predates this change and isn't introduced by it.

### Additional Context
Once merged and deployed, this leaves only mitxonline LMS still on the pre-overhaul holding pins, gated on its own production measurement window per the parent task.