### PR TITLE
feat(mitxonline): redirect catalog pages to MIT Learn via Fastly

### DIFF
--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -1017,6 +1017,17 @@ course_program_redirect_vcl = "\n".join(
     for prefix in ("courses", "programs")
 )
 
+# Catalog pages redirect to MIT Learn's unit catalog view - no per-page mapping,
+# every /catalog/* path (and any sub-filter/department) goes to the same fixed
+# destination. Uses a distinct error code (604) from the course/program
+# redirects (603) and UAI B2C redirects (602) so this is fully additive.
+catalog_redirect_vcl = (
+    f'if (req.url.path ~ "^/catalog(/.*)?$") {{\n'
+    f'  set req.http.x-redir-location = "https://{learn_frontend_domain}/c/unit/mitx";\n'
+    f"  error 604;\n"
+    f"}}"
+)
+
 gzip_settings: dict[str, set[str]] = {"extensions": set(), "content_types": set()}
 for k, v in mimetypes.types_map.items():
     if k in (
@@ -1119,6 +1130,15 @@ mitxonline_service = fastly.ServiceVcl(
             type="recv",
         ),
         fastly.ServiceVclSnippetArgs(
+            content=catalog_redirect_vcl,
+            name="Redirect catalog pages to MIT Learn",
+            # /catalog/* doesn't overlap with /courses/* or /programs/*, so
+            # ordering relative to the other recv snippets isn't load-bearing -
+            # placed after them for readability only.
+            priority=160,
+            type="recv",
+        ),
+        fastly.ServiceVclSnippetArgs(
             content=textwrap.dedent("""\
             if (obj.status == 602) {
               set obj.status = 301;
@@ -1153,6 +1173,25 @@ mitxonline_service = fastly.ServiceVcl(
               return(deliver);
             }"""),
             name="Handle course/program redirects to MIT Learn",
+            type="error",
+        ),
+        fastly.ServiceVclSnippetArgs(
+            content=textwrap.dedent("""\
+            if (obj.status == 604) {
+              set obj.status = 301;
+              set obj.response = "Moved Permanently";
+              set obj.http.Location = req.http.x-redir-location;
+              set obj.http.Cache-Control = "no-store";
+              if (req.url.qs != "") {
+                if (obj.http.Location !~ "\\?") {
+                  set obj.http.Location = obj.http.Location "?" req.url.qs;
+                } else {
+                  set obj.http.Location = obj.http.Location "&" req.url.qs;
+                }
+              }
+              return(deliver);
+            }"""),
+            name="Handle catalog redirects to MIT Learn",
             type="error",
         ),
         fastly.ServiceVclSnippetArgs(

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -1172,7 +1172,7 @@ mitxonline_service = fastly.ServiceVcl(
               }
               return(deliver);
             }"""),
-            name="Handle course/program redirects to MIT Learn",
+            name="Handle course and program redirects to MIT Learn",
             type="error",
         ),
         fastly.ServiceVclSnippetArgs(


### PR DESCRIPTION
### What are the relevant tickets?

Closes [12504](https://github.com/mitodl/hq/issues/12504), subissue # 6 of epic [mitodl/mitxonline#12027](https://github.com/mitodl/hq/issues/12027).

Per the issue, this shouldn't ship until mitxonline#12036 (catalog links updated to point to Learn) and mitxonline#12478 (Google reindex of catalog pages) are both deployed/complete — confirmed both are.

### Description (What does it do?)

Adds a Fastly-level 301 redirect from any mitxonline catalog page to MIT Learn's unit catalog view:

- `mitxonline.mit.edu/catalog` (and `/catalog/`, and any sub-path/department filter under it) → `https://learn.mit.edu/c/unit/mitx`

Unlike the course/program redirect (mitxonline#12449), this isn't a 1:1 per-page mapping — every catalog path, regardless of tab or department filter, redirects to the same fixed Learn URL. Per the issue's own Q&A, a 1:1 mapping wasn't considered worth the effort here since Learn's catalog/filter UI already covers the same (and more) filtering options.

Implemented as a third VCL snippet pair in `mitxonline_service`, alongside the existing UAI B2C (`602`) and course/program (`603`) redirects, using its own distinct `error 604` status so it's fully additive to both.

- **Match**: `^/catalog(/.*)?$` — covers bare `/catalog`, `/catalog/`, and any nested path (`/catalog/courses`, `/catalog/programs/data-science`, etc.), verified against all the real route shapes mitxonline serves under this prefix.
- **Fixed target**: `https://learn.mit.edu/c/unit/mitx` (no trailing slash, per the issue), confirmed live (`200`).
- **Query strings preserved**: same append-qs logic as the existing UAI/course-program handlers — per the issue's Q&A, preserving params (e.g. UTM campaign codes) even though mitxonline doesn't generate any query-string-based catalog filters itself.
- **`Cache-Control: no-store`**: same reversibility rationale as the course/program redirect — protects against browser-side caching of the 301, not Fastly's own edge (which doesn't cache synthetic `vcl_error` responses).
- **Priority `160`**: after the course/program rule (`150`). `/catalog/*` doesn't overlap with `/courses/*` or `/programs/*`, so this ordering isn't load-bearing — placed there for readability only.
- **Consistency with Fastly VCL approach**: per the issue's Q&A ("If we can use Fastly VCL, I think we should be consistent"), this reuses the exact same snippet-pair pattern as the course/program redirect rather than a different mechanism.

**Blast radius, confirmed:** `/catalog` has exactly one Django-level route (`main/urls.py`: `re_path(r"^catalog/", index, name="catalog")`), which just serves the SPA shell — same pattern as the neighboring `cart/`, `orders/`, `records/` routes. No API endpoint or other server-side logic lives under this prefix; the frontend's own router (`frontend/public/src/lib/urls.js`) defines exactly three catalog routes (`catalog`, `catalogTab`, `catalogTabByDepartment`), all covered by the match above.

Not in scope (per issue): Change of Address tool — ruled out since this is a partial, not full-domain, migration.

### How can this be tested?

No app-specific test suite for this Pulumi module — validation is lint/type-check locally, then live checks against rc once deployed.

**Locally (already done):**
`ruff-format`/`ruff-check` pass clean; `mypy` shows no new errors introduced vs. `main` (same 2 pre-existing, unrelated errors as mitxonline#12449's PR).

**Once deployed to rc** (before prod), a reviewer can validate with:

1. Every catalog path shape redirects to the same fixed target:
   ```
   curl -I https://rc.mitxonline.mit.edu/catalog
   curl -I https://rc.mitxonline.mit.edu/catalog/
   curl -I https://rc.mitxonline.mit.edu/catalog/courses
   curl -I https://rc.mitxonline.mit.edu/catalog/programs/data-science
   ```
   Expect `301`, `location: https://learn.mit.edu/c/unit/mitx` on all four, `cache-control: no-store`.
2. Query strings survive the redirect:
   ```
   curl -I "https://rc.mitxonline.mit.edu/catalog/courses?utm_source=test&utm_medium=email"
   ```
3. Regression check — course/program redirects and UAI overrides from mitxonline#12449 are unaffected:
   ```
   curl -I https://rc.mitxonline.mit.edu/courses/{readable_id}
   curl -I https://rc.mitxonline.mit.edu/programs/program-v1:UAI+B2C.1/
   ```

Only once rc checks all pass should the same checks be repeated against production, after devops deploys there.

### Additional Context

Same `mypy` pre-existing errors noted in mitxonline#12449's PR apply here too (unrelated to this change, not fixed in either PR):
- `env_vars.update(**mitxonline_config.get_object("vars"))`
- `mitxonline_service.domains.apply(lambda domains: ...)`

### Checklist:

- [ ] Confirm nothing else in the live mitxonline Fastly service uses custom error status `604` (same process used for `603` on mitxonline#12449 — search the compiled VCL).
- [ ] Reviewed/approved by `@mitodl/devops` (they manage Fastly dashboard/API access for the mitxonline.mit.edu service)