### PR TITLE
SEC-03: make CI load-bearing on mit-learn, mitxonline and ol-infrastructure

### DIFF
--- a/bin/github-org-inventory
+++ b/bin/github-org-inventory
@@ -46,6 +46,9 @@ from ol_infrastructure.lib.github_helper import (
     GITHUB_API,
     get_installation_token,
 )
+from ol_infrastructure.saas.github.repositories.rulesets import (
+    REQUIRED_CHECKS_RULESET_NAME,
+)
 from ol_infrastructure.saas.github.tiers import TIER_PROPERTY_NAME
 
 app = cyclopts.App(help="Inventory the mitodl GitHub org for the Pulumi import.")
@@ -261,6 +264,65 @@ def _count(client: httpx.Client, path: str) -> int | None:
     return len(payload)
 
 
+def _required_checks(
+    client: httpx.Client,
+    name: str,
+    protection: Any,
+    rulesets: list[dict[str, Any]],
+) -> tuple[list[str], list[str]]:
+    """Split a repo's required check contexts into (ours, everyone else's).
+
+    THIS EXISTS BECAUSE `crawl` REBUILDS EVERY YAML FROM SCRATCH. A key the crawl does
+    not derive from live state is not preserved, it is deleted -- so a hand-added
+    `required_status_checks` survives exactly until the next `crawl`, after which the
+    ruleset it described is gone from the fleet data and Pulumi wants to remove the
+    resource. Reading the value back out of GitHub is what closes that loop and keeps
+    "one crawl produces both the code and the state" true for this field.
+
+    THE SPLIT IS THE WHOLE POINT, not tidiness. `lehrer` and `ol-analytics-api` already
+    require checks through rulesets somebody built by hand. Returning those as
+    `required_status_checks` would have rulesets.py declare a SECOND ruleset beside the
+    working one -- two overlapping sets of required contexts on the same branch. They
+    come back in the second list, land under `_required_status_checks_live`, and satisfy
+    SEC-03 without generating a resource.
+
+    Ours is identified by ruleset NAME (`REQUIRED_CHECKS_RULESET_NAME`), which is the
+    only stable handle: the id is assigned by GitHub at creation and differs per repo.
+
+    `source_type` filtering is required. `/repos/{repo}/rulesets` includes inherited ORG
+    rulesets by default, so without it every repo would appear to carry whatever the org
+    baseline requires.
+
+    Classic branch protection contexts are always foreign. Pulumi declares no
+    BranchProtection anywhere (see repository.py), so anything there predates it.
+    """
+    ours: list[str] = []
+    foreign: list[str] = []
+    if protection:
+        foreign.extend(
+            (protection.get("required_status_checks") or {}).get("contexts", []) or []
+        )
+    for listed in rulesets:
+        if listed.get("source_type") != "Repository":
+            continue
+        detail = _maybe(client, f"/repos/{ORG}/{name}/rulesets/{listed['id']}")
+        if not detail:
+            continue
+        contexts = [
+            check["context"]
+            for rule in detail.get("rules") or []
+            if rule.get("type") == "required_status_checks"
+            for check in (rule.get("parameters") or {}).get(
+                "required_status_checks", []
+            )
+        ]
+        if detail.get("name") == REQUIRED_CHECKS_RULESET_NAME:
+            ours.extend(contexts)
+        else:
+            foreign.extend(contexts)
+    return sorted(set(ours)), sorted(set(foreign))
+
+
 def _push_restrictions(
     protection: dict[str, Any] | None,
 ) -> dict[str, list[str]] | None:
@@ -342,11 +404,9 @@ def _crawl_repo(token: str, listed: dict[str, Any]) -> dict[str, Any]:
             _maybe(client, f"/repos/{ORG}/{name}/environments?per_page=30") or {}
         )
 
-        required_checks: list[str] = []
-        if protection:
-            required_checks = (protection.get("required_status_checks") or {}).get(
-                "contexts", []
-            )
+        required_checks, foreign_required_checks = _required_checks(
+            client, name, protection, rulesets
+        )
         push_restrictions = _push_restrictions(protection)
 
         return {
@@ -392,6 +452,7 @@ def _crawl_repo(token: str, listed: dict[str, Any]) -> dict[str, Any]:
                 (protection or {}).get("enforce_admins", {}).get("enabled")
             ),
             "required_status_checks": required_checks,
+            "foreign_required_status_checks": foreign_required_checks,
             "ruleset_count": len(rulesets),
             "rulesets": [
                 {
@@ -737,7 +798,10 @@ def _findings(
             r["name"] for r in live if _blocked_by_push_restriction(r)
         ],
         "SEC-03 no required status checks": [
-            r["name"] for r in live if not r["required_status_checks"]
+            r["name"]
+            for r in live
+            if not r["required_status_checks"]
+            and not r["foreign_required_status_checks"]
         ],
         "SEC-04 secret scanning or push protection off": [
             r["name"]
@@ -1159,6 +1223,13 @@ def crawl(
                 "branch_protection_enforce_admins"
             ]
         doc["_ruleset_count"] = repo["ruleset_count"]
+        # Checks a repo requires through protection Pulumi does NOT manage -- its own
+        # ruleset, or classic branch protection. Inventory rather than configuration:
+        # declaring these under `required_status_checks` would make rulesets.py build a
+        # SECOND ruleset next to the one already doing the job. SEC-03 reads both keys
+        # so the repos that solved this themselves do not read as findings.
+        if repo["foreign_required_status_checks"]:
+            doc["_required_status_checks_live"] = repo["foreign_required_status_checks"]
         if repo.get("direct_collaborators"):
             doc["_direct_collaborators"] = repo["direct_collaborators"]
 

--- a/bin/github-org-inventory
+++ b/bin/github-org-inventory
@@ -510,10 +510,49 @@ def _crawl_repo(token: str, listed: dict[str, Any]) -> dict[str, Any]:
         }
 
 
+#: Repo-record keys this file reads by subscript rather than `.get()`, so a cache
+#: written before one of them existed crashes far away from the cause. Every command
+#: here runs off the same cached crawl, and the cache carries no version, so the only
+#: thing separating "stale schema" from "current" is which keys the records have.
+#: Adding a field to a repo record means adding it here too.
+_EXPECTED_REPO_KEYS = frozenset(
+    {
+        "name",
+        "has_branch_protection",
+        "ruleset_count",
+        "required_status_checks",
+        "foreign_required_status_checks",
+        "secret_scanning",
+        "secret_scanning_push_protection",
+        "dependabot_security_updates",
+    }
+)
+
+
 def _crawl_org(cache: Path, *, refresh: bool) -> dict[str, Any]:
-    """Return the org crawl, from cache unless --refresh."""
+    """Return the org crawl, from cache unless --refresh.
+
+    A cache from before a field was added is the failure worth naming here. It loads
+    fine, and then some rule 300 lines away subscripts the missing key and dies with a
+    bare `KeyError` that says nothing about caching -- which is how this was reported
+    on #5566, against `foreign_required_status_checks`. The remedy has always been
+    `--refresh`; the point of this check is that the message says so, once, instead of
+    every added field becoming its own puzzle.
+    """
     if cache.exists() and not refresh:
-        return json.loads(cache.read_text())
+        data = json.loads(cache.read_text())
+        repos = data.get("repos") or []
+        # Intersection, not the first record: a half-written cache with one short
+        # record is as broken as one written by older code, and reads the same way.
+        shared = set.intersection(*(set(r) for r in repos)) if repos else set()
+        missing = _EXPECTED_REPO_KEYS - shared if repos else set()
+        if missing:
+            message = (
+                f"{cache} predates {sorted(missing)} and every command here reads the "
+                "same crawl. Re-run with --refresh."
+            )
+            raise SystemExit(message)
+        return data
 
     token = get_installation_token()
     with _client(token) as client:

--- a/bin/github-required-checks
+++ b/bin/github-required-checks
@@ -91,14 +91,26 @@ app = cyclopts.App(
 )
 
 
+class RateLimitError(RuntimeError):
+    """The API stopped answering, so nothing read after this point means anything."""
+
+
 def _gh(*args: str) -> Any:
     """One `gh api`/`gh pr` call, JSON out.
 
-    Failures return an empty result rather than raising. A commit whose check-runs
-    endpoint 404s (the PR's head was force-pushed away, the branch was deleted and
+    A 404 returns an empty result rather than raising. A commit whose check-runs
+    endpoint has gone (the PR's head was force-pushed away, the branch deleted and
     garbage-collected) is a sample we cannot read, not a reason to abandon the run --
     and every command reports the number of PRs actually read, so a short sample is
     visible rather than silently treated as complete.
+
+    EXHAUSTING THE RATE LIMIT IS DIFFERENT AND MUST NOT BE SWALLOWED. A full sample of
+    three repos costs a few hundred core calls, so hitting the cap mid-run is ordinary.
+    Treating those 403s as "no data" makes a check that is merely unread look like a
+    check that was never produced -- which is how a real run of this tool reported
+    mit-learn's `openapi-diff` as ABSENT 0/0 minutes after reporting it clean. In a tool
+    whose entire job is to stop a silent outage, degrading silently is the one failure
+    it cannot have.
     """
     result = subprocess.run(  # noqa: S603
         ["gh", *args],  # noqa: S607
@@ -107,6 +119,14 @@ def _gh(*args: str) -> Any:
         check=False,
     )
     if result.returncode != 0:
+        stderr = result.stderr or ""
+        if "rate limit" in stderr.lower() or "secondary rate" in stderr.lower():
+            msg = (
+                "GitHub API rate limit exhausted mid-run, so the remaining results "
+                "would be indistinguishable from checks that never ran. Re-run after "
+                "`gh api rate_limit` recovers, or lower --prs."
+            )
+            raise RateLimitError(msg)
         return None
     return json.loads(result.stdout or "null")
 
@@ -488,4 +508,8 @@ def drift(
 
 
 if __name__ == "__main__":
-    app()
+    try:
+        app()
+    except RateLimitError as limited:
+        print(f"\n{limited}", file=sys.stderr)
+        sys.exit(2)

--- a/bin/github-required-checks
+++ b/bin/github-required-checks
@@ -78,6 +78,7 @@ REPOS_DIR = (
 ORG = "mitodl"
 DEFAULT_SAMPLE = 20
 _POOL = 8
+_PAGE = 100
 
 #: The workflow run id inside an Actions check run's `html_url`:
 #: `.../actions/runs/<run_id>/job/<job_id>`. Checks from other apps (GitGuardian,
@@ -131,6 +132,37 @@ def _gh(*args: str) -> Any:
     return json.loads(result.stdout or "null")
 
 
+def _gh_all(path: str, key: str) -> list[Any]:
+    """Every page of an endpoint that returns a list under `key`, not just the first.
+
+    All three endpoints below cap a page, and one of them caps it at 30 rather than 100
+    (`/commits/{sha}/status` takes no `per_page` in its documented default). Reading
+    only the first page would drop checks that exist, and a check this tool did not read
+    is indistinguishable from one that was never produced -- the same conflation the
+    rate-limit handling in `_gh` exists to prevent, arriving by a quieter route.
+
+    The bias is toward refusing a safe name rather than clearing an unsafe one: a
+    dropped check lowers `produced` while `eligible` stands, so the verdict goes
+    `unsafe` and `drift` exits non-zero. That fails the rollout loudly instead of
+    shipping a ruleset that wedges a repo. Still worth closing, because "the tool said
+    unsafe and was wrong" costs somebody an afternoon.
+    """
+    items: list[Any] = []
+    page = 1
+    while True:
+        joiner = "&" if "?" in path else "?"
+        body = _gh("api", f"{path}{joiner}per_page={_PAGE}&page={page}")
+        if not body:
+            break
+        batch = body.get(key) or []
+        items.extend(batch)
+        total = body.get("total_count")
+        if len(batch) < _PAGE or (total is not None and len(items) >= total):
+            break
+        page += 1
+    return items
+
+
 def _checks_on(repo: str, sha: str) -> tuple[dict[str, str | None], set[str]]:
     """One commit's checks: name -> owning workflow path, plus the workflows that ran.
 
@@ -144,8 +176,8 @@ def _checks_on(repo: str, sha: str) -> tuple[dict[str, str | None], set[str]]:
     """
     workflows: set[str] = set()
     by_run: dict[str, str] = {}
-    runs = _gh("api", f"repos/{ORG}/{repo}/actions/runs?head_sha={sha}&per_page=100")
-    for run in (runs or {}).get("workflow_runs", []):
+    runs = _gh_all(f"repos/{ORG}/{repo}/actions/runs?head_sha={sha}", "workflow_runs")
+    for run in runs:
         path = run.get("path") or ""
         # `dynamic/...` paths are GitHub's synthetic runs for code scanning and the
         # Copilot reviewer. They are not files anybody edits, so treating them as
@@ -156,12 +188,10 @@ def _checks_on(repo: str, sha: str) -> tuple[dict[str, str | None], set[str]]:
         workflows.add(path)
 
     owners: dict[str, str | None] = {}
-    check_runs = _gh("api", f"repos/{ORG}/{repo}/commits/{sha}/check-runs?per_page=100")
-    for run in (check_runs or {}).get("check_runs", []):
+    for run in _gh_all(f"repos/{ORG}/{repo}/commits/{sha}/check-runs", "check_runs"):
         match = _RUN_ID.search(run.get("html_url") or "")
         owners[run["name"]] = by_run.get(match.group(1)) if match else None
-    status = _gh("api", f"repos/{ORG}/{repo}/commits/{sha}/status")
-    for entry in (status or {}).get("statuses", []):
+    for entry in _gh_all(f"repos/{ORG}/{repo}/commits/{sha}/status", "statuses"):
         owners.setdefault(entry["context"], None)
     return owners, workflows
 

--- a/bin/github-required-checks
+++ b/bin/github-required-checks
@@ -6,28 +6,61 @@ src/ol_infrastructure/saas/github/repositories/rulesets.py) has no dry run: the 
 has no `evaluate` enforcement mode, so a ruleset naming a context that does not exist
 blocks every PR on that repo from the moment it applies, and the only symptom is a PR
 stuck on "Expected -- Waiting for status to be reported". This tool is the substitute for
-the dry run. It samples merged PRs and reports how often each check name appeared.
-
-The rule for reading the output: a name belongs in `required_status_checks` only if it
-appeared on EVERY sampled PR. Anything below that is a check some PR did not produce --
-a path-filtered workflow, an advisory bot, a job behind an `if:` -- and requiring it
-blocks that kind of PR forever.
+the dry run.
 
     uv run bin/github-required-checks sample mit-learn
-    uv run bin/github-required-checks sample mit-learn mitxonline --prs 20
+    uv run bin/github-required-checks blocked
     uv run bin/github-required-checks drift
 
-`sample` reads the last N merged PRs. `drift` re-samples every repo whose YAML already
-declares `required_status_checks` and fails if a declared context has stopped appearing
--- which is how a matrix shard count changing in another repo gets noticed before it
-wedges anyone (see the `_MATRIX_SHARD` note in rulesets.py).
+WHY THIS IS NOT A PERCENTAGE. "appeared on N of the last 40 merged PRs" cannot separate
+three situations that need three different answers, and the aggregate gate jobs this repo
+now requires sit in the one the raw count reads worst:
 
-Both go through the `gh` CLI rather than the App installation the crawl uses: check runs
-are readable with the ordinary token every engineer already has, and needing the sops key
-to answer "what does CI call this job" would stop people running it.
+  conditional by design   `Run zizmor` is on 1/40 ol-infrastructure PRs because
+                          actions-static-analysis.yml declares
+                          `paths: [".github/workflows/**"]`. Requiring it blocks every
+                          PR that does not touch a workflow. NEVER requirable, and the
+                          workflow file says so outright -- so this is read from the
+                          `on:` block rather than inferred from a count.
+
+  the workflow no-showed  ol-infrastructure #5590 merged with no run of pytest.yml at
+                          all, so `test` and `ci-gate` are both missing from it for the
+                          same reason and neither name is implicated. Around 1 in 40,
+                          mitxonline #3810 likewise. It is a real cost -- such a PR
+                          needs a re-trigger or a bypass under any ruleset -- and it is
+                          reported as its own line rather than shaved off every name's
+                          percentage.
+
+  the job is newer than   `ci-gate` landed in ol-infrastructure #5567 on 2026-08-24 and
+  the PR                  reads 31/40. The nine PRs missing it merged from branches cut
+                          before it existed: their head commit does not define the job,
+                          so no run of it was ever possible. Scoring those as failures
+                          makes every newly added job permanently unrequirable.
+
+So a check is scored ONLY against merged PRs whose own head commit defines the job AND
+whose workflow actually ran. That needs the workflow file as of each PR's head sha, which
+is one extra call per PR per workflow, and it makes the verdict exact rather than a
+threshold somebody has to argue about.
+
+SAMPLING IS BACKWARD-LOOKING AND THAT IS ITS LIMIT. A gate job that landed last week is
+clean on every PR that could have produced it and still blocks any OPEN PR branched
+before it, until that branch is rebased. History cannot see those. `blocked` is the
+forward-looking half and the one to run immediately before `pulumi up`: it reads the open
+PRs and names the ones that would hang the moment the ruleset applies.
+
+`drift` is the ongoing half, for CI: it fails when a declared context stops being
+produced (a renamed job, a resized matrix, a workflow deleted in an application repo) or
+was never produced at all -- the latter being how "the ruleset landed before the gate job
+did" surfaces here rather than as every PR on that repo hanging.
+
+All three go through the `gh` CLI rather than the App installation the crawl uses: check
+runs are readable with the ordinary token every engineer already has, and needing the
+sops key to answer "what does CI call this job" would stop people running it.
 """
 
+import base64
 import json
+import re
 import subprocess
 import sys
 from collections import Counter
@@ -44,6 +77,13 @@ REPOS_DIR = (
 )
 ORG = "mitodl"
 DEFAULT_SAMPLE = 20
+_POOL = 8
+
+#: The workflow run id inside an Actions check run's `html_url`:
+#: `.../actions/runs/<run_id>/job/<job_id>`. Checks from other apps (GitGuardian,
+#: pre-commit.ci, Sentry) do not match. Nothing in this repo can tell whether those
+#: could have run on a given PR, so they are scored against every sampled PR.
+_RUN_ID = re.compile(r"/actions/runs/(\d+)/")
 
 app = cyclopts.App(
     name="github-required-checks",
@@ -57,8 +97,8 @@ def _gh(*args: str) -> Any:
     Failures return an empty result rather than raising. A commit whose check-runs
     endpoint 404s (the PR's head was force-pushed away, the branch was deleted and
     garbage-collected) is a sample we cannot read, not a reason to abandon the run --
-    and `_sample` reports the number of PRs actually read, so a short sample is visible
-    rather than silently treated as complete.
+    and every command reports the number of PRs actually read, so a short sample is
+    visible rather than silently treated as complete.
     """
     result = subprocess.run(  # noqa: S603
         ["gh", *args],  # noqa: S607
@@ -71,46 +111,190 @@ def _gh(*args: str) -> Any:
     return json.loads(result.stdout or "null")
 
 
-def _checks_on(repo: str, sha: str) -> set[str]:
-    """Every check name on one commit, from both APIs GitHub reports them through.
+def _checks_on(repo: str, sha: str) -> tuple[dict[str, str | None], set[str]]:
+    """One commit's checks: name -> owning workflow path, plus the workflows that ran.
 
     Check runs and legacy commit statuses are separate endpoints, and
     `required_status_checks` contexts match against both -- `GitGuardian Security
     Checks` arrives as one and `test` as the other. Reading only check-runs would make
     a perfectly requirable context look absent.
+
+    A name maps to `None` when nothing attributes it to a workflow in this repo: commit
+    statuses, and checks from apps that are not Actions.
     """
-    names: set[str] = set()
-    runs = _gh("api", f"repos/{ORG}/{repo}/commits/{sha}/check-runs?per_page=100")
-    for run in (runs or {}).get("check_runs", []):
-        names.add(run["name"])
+    workflows: set[str] = set()
+    by_run: dict[str, str] = {}
+    runs = _gh("api", f"repos/{ORG}/{repo}/actions/runs?head_sha={sha}&per_page=100")
+    for run in (runs or {}).get("workflow_runs", []):
+        path = run.get("path") or ""
+        # `dynamic/...` paths are GitHub's synthetic runs for code scanning and the
+        # Copilot reviewer. They are not files anybody edits, so treating them as
+        # workflows would invent absences nobody can act on.
+        if not path.startswith(".github/"):
+            continue
+        by_run[str(run["id"])] = path
+        workflows.add(path)
+
+    owners: dict[str, str | None] = {}
+    check_runs = _gh("api", f"repos/{ORG}/{repo}/commits/{sha}/check-runs?per_page=100")
+    for run in (check_runs or {}).get("check_runs", []):
+        match = _RUN_ID.search(run.get("html_url") or "")
+        owners[run["name"]] = by_run.get(match.group(1)) if match else None
     status = _gh("api", f"repos/{ORG}/{repo}/commits/{sha}/status")
     for entry in (status or {}).get("statuses", []):
-        names.add(entry["context"])
-    return names
+        owners.setdefault(entry["context"], None)
+    return owners, workflows
 
 
-def _sample(repo: str, prs: int) -> tuple[int, Counter[str]]:
-    """Return (PRs actually read, name -> how many of them produced it)."""
-    merged = _gh(
-        "pr",
-        "list",
-        "-R",
-        f"{ORG}/{repo}",
-        "--state",
-        "merged",
-        "--limit",
-        str(prs),
-        "--json",
-        "number,headRefOid",
+def _workflow_at(repo: str, path: str, sha: str) -> tuple[set[str], bool] | None:
+    """(check names the workflow defines, is it path-filtered) as of one commit.
+
+    `None` when the file does not exist at that commit, which is the whole point: a PR
+    branched before a job was added cannot be evidence against that job.
+
+    A job's check-run name is `jobs.<id>.name` when set and the id otherwise, so both go
+    in. Matrix jobs report as `name (value, value)`, which no caller can reconstruct
+    without the matrix values, so `_defines` prefix-matches instead.
+    """
+    blob = _gh("api", f"repos/{ORG}/{repo}/contents/{path}?ref={sha}")
+    if not blob or "content" not in blob:
+        return None
+    try:
+        parsed = yaml.safe_load(base64.b64decode(blob["content"]).decode())
+    except (yaml.YAMLError, ValueError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    names: set[str] = set()
+    for job_id, job in (parsed.get("jobs") or {}).items():
+        names.add(job_id)
+        if isinstance(job, dict) and isinstance(job.get("name"), str):
+            names.add(job["name"])
+    # `on:` parses as the boolean True -- YAML 1.1, which pyyaml still implements.
+    triggers = parsed.get("on", parsed.get(True)) or {}
+    filtered = isinstance(triggers, dict) and any(
+        isinstance(spec, dict) and ("paths" in spec or "paths-ignore" in spec)
+        for spec in triggers.values()
     )
-    if not merged:
-        return 0, Counter()
-    with ThreadPoolExecutor(max_workers=8) as pool:
-        per_pr = list(pool.map(lambda pr: _checks_on(repo, pr["headRefOid"]), merged))
-    counts: Counter[str] = Counter()
-    for names in per_pr:
-        counts.update(names)
-    return len(per_pr), counts
+    return names, filtered
+
+
+def _defines(defined: set[str], check: str) -> bool:
+    """Report whether a workflow defining these job names produces this check."""
+    return check in defined or any(check.startswith(f"{name} (") for name in defined)
+
+
+class Evidence:
+    """How one check name behaved across the PRs where it could have reported.
+
+    `eligible` counts merged PRs whose head commit defines the job AND whose workflow
+    ran. `produced` is how many of those actually reported it. Requiring a name is safe
+    only when those are equal, non-zero, and the workflow is not path-filtered.
+    """
+
+    def __init__(self) -> None:
+        """Start with no evidence either way."""
+        self.produced = 0
+        self.eligible = 0
+        self.workflow: str | None = None
+        self.filtered = False
+        self.first_seen: int | None = None
+
+    @property
+    def missing(self) -> int:
+        """PRs that could have produced this check and did not."""
+        return self.eligible - self.produced
+
+    @property
+    def safe(self) -> bool:
+        """Whether this name may be required without blocking some kind of PR."""
+        return self.eligible > 0 and not self.missing and not self.filtered
+
+    @property
+    def verdict(self) -> str:
+        """The label `sample` prints, and why the name did or did not clear."""
+        if self.filtered:
+            return "FILTERED"
+        if not self.eligible:
+            return "ABSENT"
+        return "SAFE  " if self.safe else "unsafe"
+
+
+def _read(
+    repo: str, pulls: list[dict[str, Any]]
+) -> tuple[dict[str, Evidence], Counter[str]]:
+    """Score every check name seen across `pulls`, newest first."""
+    with ThreadPoolExecutor(max_workers=_POOL) as pool:
+        per_pr = list(pool.map(lambda p: _checks_on(repo, p["headRefOid"]), pulls))
+
+    # First pass establishes only which names exist and which workflow owns each.
+    # Attribution can come back empty on an individual PR (a run aged out of the
+    # `actions/runs` window), so the owner is whichever PR could attribute it; counting
+    # happens in the second pass, where produced and eligible are decided per PR by the
+    # same test and cannot disagree.
+    evidence: dict[str, Evidence] = {}
+    for owners, _ in per_pr:
+        for name, workflow in owners.items():
+            found = evidence.setdefault(name, Evidence())
+            found.workflow = found.workflow or workflow
+
+    # Which workflows have to be read, and at which commits. Only workflows that own a
+    # name matter, so a repo with twenty workflows and two requirable checks reads two.
+    paths = {f.workflow for f in evidence.values() if f.workflow}
+    wanted = [(path, pull["headRefOid"]) for path in paths for pull in pulls]
+    with ThreadPoolExecutor(max_workers=_POOL) as pool:
+        loaded = list(
+            pool.map(lambda pair: _workflow_at(repo, pair[0], pair[1]), wanted)
+        )
+    at: dict[tuple[str, str], tuple[set[str], bool] | None] = dict(
+        zip(wanted, loaded, strict=True)
+    )
+
+    for name, found in evidence.items():
+        for (owners, ran), pull in zip(per_pr, pulls, strict=True):
+            if found.workflow is None:
+                # No workflow to hold responsible, so every PR is a fair test.
+                found.eligible += 1
+            else:
+                source = at[(found.workflow, pull["headRefOid"])]
+                if source is None:
+                    continue
+                defined, filtered = source
+                found.filtered = found.filtered or filtered
+                if not (_defines(defined, name) and found.workflow in ran):
+                    continue
+                found.eligible += 1
+            if name in owners:
+                found.produced += 1
+                # `pulls` is newest first, so the last write is the oldest such PR.
+                found.first_seen = pull["number"]
+
+    absent: Counter[str] = Counter()
+    for path in paths:
+        absent[path] = sum(
+            1
+            for (_, ran), pull in zip(per_pr, pulls, strict=True)
+            if at[(path, pull["headRefOid"])] is not None and path not in ran
+        )
+    return evidence, absent
+
+
+def _merged(repo: str, prs: int) -> list[dict[str, Any]]:
+    return (
+        _gh(
+            "pr",
+            "list",
+            "-R",
+            f"{ORG}/{repo}",
+            "--state",
+            "merged",
+            "--limit",
+            str(prs),
+            "--json",
+            "number,headRefOid",
+        )
+        or []
+    )
 
 
 def _declared() -> dict[str, list[str]]:
@@ -133,22 +317,108 @@ def sample(
         int, cyclopts.Parameter(help="How many merged PRs to read.")
     ] = DEFAULT_SAMPLE,
 ) -> None:
-    """Report how many of the last N merged PRs produced each check name."""
+    """Report, per check name, how it behaved on the PRs where it could have reported."""
     for repo in repos:
-        read, counts = _sample(repo, prs)
-        print(f"\n## {repo}  ({read} merged PRs read)")
-        if not read:
-            print(
-                "  no merged PRs -- nothing to require, and nothing to verify against"
-            )
+        pulls = _merged(repo, prs)
+        print(f"\n## {repo}  ({len(pulls)} merged PRs read)")
+        if not pulls:
+            print("  no merged PRs -- nothing to require, nothing to verify against")
             continue
-        for name, count in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])):
-            mark = "SAFE  " if count == read else "unsafe"
-            print(f"  {mark} {count}/{read}  {name}")
-        print(
-            "\n  Only SAFE names may be required. Anything below 100% is a check some "
-            "PR\n  did not produce; requiring it blocks that kind of PR forever."
+        evidence, absent = _read(repo, pulls)
+        ordered = sorted(
+            evidence.items(), key=lambda kv: (not kv[1].safe, -kv[1].produced, kv[0])
         )
+        for name, found in ordered:
+            scope = found.workflow or "any PR"
+            note = ""
+            if found.filtered:
+                note = " -- path-filtered workflow, never requirable"
+            elif found.safe and found.eligible < len(pulls):
+                note = f", first seen #{found.first_seen}"
+            print(
+                f"  {found.verdict} {found.produced}/{found.eligible} of the PRs that "
+                f"could run it  {name}  [{scope}{note}]"
+            )
+        for path, misses in sorted(absent.items()):
+            if misses:
+                print(
+                    f"\n  NOTE {path} did not run at all on {misses}/{len(pulls)} PRs "
+                    "that define it.\n       Requiring anything from it makes such a PR "
+                    "need a re-trigger or a bypass."
+                )
+        print(
+            "\n  Only SAFE names may be required. 'unsafe' means the check was absent "
+            "from a PR\n  that defined it and ran its workflow, so requiring it blocks "
+            "that kind of PR forever."
+        )
+
+
+@app.command
+def blocked(
+    repos: Annotated[
+        list[str] | None,
+        cyclopts.Parameter(
+            help="Repos to check. Default: every repo declaring checks."
+        ),
+    ] = None,
+) -> None:
+    """Name the OPEN PRs that a declared ruleset would hang. Exits non-zero if any.
+
+    The question sampling cannot answer. A gate job that landed last week is clean on
+    every merged PR that could have produced it, and still blocks any open PR cut before
+    it existed, because that branch's head commit does not define the job -- there is no
+    failure to look at, just a check that will never report. Those PRs need a rebase, and
+    their authors would rather hear it here than from a stuck merge box.
+    """
+    declared = _declared()
+    targets = {r: declared[r] for r in repos if r in declared} if repos else declared
+    if not targets:
+        print("no repo declares required_status_checks")
+        return
+    wedged = False
+    for repo, contexts in sorted(targets.items()):
+        pulls = (
+            _gh(
+                "pr",
+                "list",
+                "-R",
+                f"{ORG}/{repo}",
+                "--state",
+                "open",
+                "--limit",
+                "100",
+                "--json",
+                "number,headRefOid,title,isDraft",
+            )
+            or []
+        )
+        if not pulls:
+            print(f"{repo}: no open PRs")
+            continue
+        with ThreadPoolExecutor(max_workers=_POOL) as pool:
+            seen = list(pool.map(lambda p: _checks_on(repo, p["headRefOid"])[0], pulls))
+        hits = [
+            (pull, sorted(c for c in contexts if c not in names))
+            for pull, names in zip(pulls, seen, strict=True)
+            if any(c not in names for c in contexts)
+        ]
+        if not hits:
+            print(f"{repo}: all {len(pulls)} open PRs produce every required context")
+            continue
+        wedged = True
+        print(f"\n{repo}: {len(hits)} of {len(pulls)} open PRs would hang")
+        for pull, missing in hits:
+            draft = " (draft)" if pull["isDraft"] else ""
+            print(
+                f"  #{pull['number']}{draft}  missing {missing}  {pull['title'][:48]}"
+            )
+    if wedged:
+        print(
+            "\nThese PRs produce no such check, so there is nothing to re-run: rebase "
+            "them onto\nthe commit that added the job, or apply the ruleset knowing "
+            "they need it first."
+        )
+        sys.exit(1)
 
 
 @app.command
@@ -159,10 +429,14 @@ def drift(
 ) -> None:
     """Re-verify every declared context against live check runs. Exits non-zero on drift.
 
-    Meant for CI or a periodic run. The failure it catches is the one nobody would
-    connect to this repo: a job renamed or a matrix resized in an application repo
-    leaves a context required here that will never be produced again, and every PR on
-    that repo blocks until somebody edits the YAML.
+    Meant for CI. Two failures it catches, both of which otherwise surface only as PRs
+    hanging on a repo whose owners have no reason to look here:
+
+    a context that stopped   A job renamed or a matrix resized in an application repo
+                             leaves a name required here that is never produced again.
+    a context that never     The ruleset landed before the workflow that produces it.
+    started                  Requiring `ci-gate` on a repo whose gate job is still in an
+                             unmerged PR wedges every PR on that repo.
     """
     declared = _declared()
     if not declared:
@@ -170,24 +444,45 @@ def drift(
         return
     bad = False
     for repo, contexts in declared.items():
-        read, counts = _sample(repo, prs)
-        if not read:
+        pulls = _merged(repo, prs)
+        if not pulls:
             print(f"{repo}: SKIPPED -- no merged PRs to verify against")
             continue
-        stale = sorted(c for c in contexts if counts.get(c, 0) < read)
-        if stale:
-            bad = True
-            for context in stale:
+        evidence, _ = _read(repo, pulls)
+        clean = True
+        for context in contexts:
+            found = evidence.get(context)
+            if found is None or not found.eligible:
+                bad = True
+                clean = False
                 print(
-                    f"{repo}: {context!r} required but produced by only "
-                    f"{counts.get(context, 0)}/{read} merged PRs"
+                    f"{repo}: {context!r} required but never produced on any of the "
+                    f"last {len(pulls)} merged PRs -- wrong name, or the job that "
+                    "produces it has not merged yet"
                 )
-        else:
-            print(f"{repo}: {len(contexts)} contexts, all on {read}/{read} PRs")
+            elif found.filtered:
+                bad = True
+                clean = False
+                print(
+                    f"{repo}: {context!r} required but {found.workflow} is "
+                    "path-filtered, so PRs that touch nothing it watches never "
+                    "produce it"
+                )
+            elif found.missing:
+                bad = True
+                clean = False
+                print(
+                    f"{repo}: {context!r} required but missing from {found.missing} of "
+                    f"the {found.eligible} merged PRs that defined it and ran "
+                    f"{found.workflow}"
+                )
+        if clean:
+            print(f"{repo}: {len(contexts)} contexts, all clean over {len(pulls)} PRs")
     if bad:
         print(
-            "\nA required context that no longer appears blocks every PR on that repo. "
-            "Fix the\nworkflow or drop the context from the repo's YAML."
+            "\nA required context that is not produced blocks every PR on that repo. "
+            "Land the\nworkflow first, fix it, or drop the context from the repo's "
+            "YAML."
         )
         sys.exit(1)
 

--- a/bin/github-required-checks
+++ b/bin/github-required-checks
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Find out which check names a repo actually produces, before requiring any of them.
+
+SEC-03's fix (`required_status_checks` in
+src/ol_infrastructure/saas/github/repositories/rulesets.py) has no dry run: the Team plan
+has no `evaluate` enforcement mode, so a ruleset naming a context that does not exist
+blocks every PR on that repo from the moment it applies, and the only symptom is a PR
+stuck on "Expected -- Waiting for status to be reported". This tool is the substitute for
+the dry run. It samples merged PRs and reports how often each check name appeared.
+
+The rule for reading the output: a name belongs in `required_status_checks` only if it
+appeared on EVERY sampled PR. Anything below that is a check some PR did not produce --
+a path-filtered workflow, an advisory bot, a job behind an `if:` -- and requiring it
+blocks that kind of PR forever.
+
+    uv run bin/github-required-checks sample mit-learn
+    uv run bin/github-required-checks sample mit-learn mitxonline --prs 20
+    uv run bin/github-required-checks drift
+
+`sample` reads the last N merged PRs. `drift` re-samples every repo whose YAML already
+declares `required_status_checks` and fails if a declared context has stopped appearing
+-- which is how a matrix shard count changing in another repo gets noticed before it
+wedges anyone (see the `_MATRIX_SHARD` note in rulesets.py).
+
+Both go through the `gh` CLI rather than the App installation the crawl uses: check runs
+are readable with the ordinary token every engineer already has, and needing the sops key
+to answer "what does CI call this job" would stop people running it.
+"""
+
+import json
+import subprocess
+import sys
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Annotated, Any
+
+import cyclopts
+import yaml
+
+REPOS_DIR = (
+    Path(__file__).resolve().parent.parent
+    / "src/ol_infrastructure/saas/github/repositories/data/repos"
+)
+ORG = "mitodl"
+DEFAULT_SAMPLE = 20
+
+app = cyclopts.App(
+    name="github-required-checks",
+    help="Sample the check names a repo's merged PRs actually produce.",
+)
+
+
+def _gh(*args: str) -> Any:
+    """One `gh api`/`gh pr` call, JSON out.
+
+    Failures return an empty result rather than raising. A commit whose check-runs
+    endpoint 404s (the PR's head was force-pushed away, the branch was deleted and
+    garbage-collected) is a sample we cannot read, not a reason to abandon the run --
+    and `_sample` reports the number of PRs actually read, so a short sample is visible
+    rather than silently treated as complete.
+    """
+    result = subprocess.run(  # noqa: S603
+        ["gh", *args],  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    return json.loads(result.stdout or "null")
+
+
+def _checks_on(repo: str, sha: str) -> set[str]:
+    """Every check name on one commit, from both APIs GitHub reports them through.
+
+    Check runs and legacy commit statuses are separate endpoints, and
+    `required_status_checks` contexts match against both -- `GitGuardian Security
+    Checks` arrives as one and `test` as the other. Reading only check-runs would make
+    a perfectly requirable context look absent.
+    """
+    names: set[str] = set()
+    runs = _gh("api", f"repos/{ORG}/{repo}/commits/{sha}/check-runs?per_page=100")
+    for run in (runs or {}).get("check_runs", []):
+        names.add(run["name"])
+    status = _gh("api", f"repos/{ORG}/{repo}/commits/{sha}/status")
+    for entry in (status or {}).get("statuses", []):
+        names.add(entry["context"])
+    return names
+
+
+def _sample(repo: str, prs: int) -> tuple[int, Counter[str]]:
+    """Return (PRs actually read, name -> how many of them produced it)."""
+    merged = _gh(
+        "pr",
+        "list",
+        "-R",
+        f"{ORG}/{repo}",
+        "--state",
+        "merged",
+        "--limit",
+        str(prs),
+        "--json",
+        "number,headRefOid",
+    )
+    if not merged:
+        return 0, Counter()
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        per_pr = list(pool.map(lambda pr: _checks_on(repo, pr["headRefOid"]), merged))
+    counts: Counter[str] = Counter()
+    for names in per_pr:
+        counts.update(names)
+    return len(per_pr), counts
+
+
+def _declared() -> dict[str, list[str]]:
+    """Every repo whose YAML declares `required_status_checks`."""
+    declared: dict[str, list[str]] = {}
+    for path in sorted(REPOS_DIR.glob("*.yaml")):
+        data = yaml.safe_load(path.read_text())
+        contexts = data.get("required_status_checks")
+        if contexts:
+            declared[data["name"]] = contexts
+    return declared
+
+
+@app.command
+def sample(
+    repos: Annotated[
+        list[str], cyclopts.Parameter(help="Repo names, without the org.")
+    ],
+    prs: Annotated[
+        int, cyclopts.Parameter(help="How many merged PRs to read.")
+    ] = DEFAULT_SAMPLE,
+) -> None:
+    """Report how many of the last N merged PRs produced each check name."""
+    for repo in repos:
+        read, counts = _sample(repo, prs)
+        print(f"\n## {repo}  ({read} merged PRs read)")
+        if not read:
+            print(
+                "  no merged PRs -- nothing to require, and nothing to verify against"
+            )
+            continue
+        for name, count in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])):
+            mark = "SAFE  " if count == read else "unsafe"
+            print(f"  {mark} {count}/{read}  {name}")
+        print(
+            "\n  Only SAFE names may be required. Anything below 100% is a check some "
+            "PR\n  did not produce; requiring it blocks that kind of PR forever."
+        )
+
+
+@app.command
+def drift(
+    prs: Annotated[
+        int, cyclopts.Parameter(help="How many merged PRs to read per repo.")
+    ] = DEFAULT_SAMPLE,
+) -> None:
+    """Re-verify every declared context against live check runs. Exits non-zero on drift.
+
+    Meant for CI or a periodic run. The failure it catches is the one nobody would
+    connect to this repo: a job renamed or a matrix resized in an application repo
+    leaves a context required here that will never be produced again, and every PR on
+    that repo blocks until somebody edits the YAML.
+    """
+    declared = _declared()
+    if not declared:
+        print("no repo declares required_status_checks")
+        return
+    bad = False
+    for repo, contexts in declared.items():
+        read, counts = _sample(repo, prs)
+        if not read:
+            print(f"{repo}: SKIPPED -- no merged PRs to verify against")
+            continue
+        stale = sorted(c for c in contexts if counts.get(c, 0) < read)
+        if stale:
+            bad = True
+            for context in stale:
+                print(
+                    f"{repo}: {context!r} required but produced by only "
+                    f"{counts.get(context, 0)}/{read} merged PRs"
+                )
+        else:
+            print(f"{repo}: {len(contexts)} contexts, all on {read}/{read} PRs")
+    if bad:
+        print(
+            "\nA required context that no longer appears blocks every PR on that repo. "
+            "Fix the\nworkflow or drop the context from the repo's YAML."
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    app()

--- a/src/ol_infrastructure/saas/github/audit.py
+++ b/src/ol_infrastructure/saas/github/audit.py
@@ -24,10 +24,10 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Literal
 
-from ol_infrastructure.saas.github.tiers import TIER_PROPERTY_NAME
+from ol_infrastructure.saas.github.tiers import TIER_ONE, TIER_PROPERTY_NAME
 
 Axis = Literal["security", "consistency", "developer-experience"]
-Scope = Literal["active", "archived", "fleet"]
+Scope = Literal["active", "archived", "fleet", "tier-1"]
 Severity = Literal["high", "medium", "low"]
 
 #: A repo is an archive candidate (DX-07) after this long with no push.
@@ -98,6 +98,12 @@ def _in_scope(repo: dict[str, Any], scope: Scope) -> bool:
     archived = bool(repo.get("archived"))
     if scope == "fleet":
         return True
+    if scope == "tier-1":
+        # Active AND tier-1. Not just `tier == TIER_ONE`: an archived tier-1 repo is
+        # still tiered (repository.py writes the property on archived repos too), so
+        # dropping the archived test would put read-only repos in the denominator of
+        # rules that only make sense for repos someone still pushes to.
+        return not archived and repo.get("tier") == TIER_ONE
     return archived if scope == "archived" else not archived
 
 
@@ -462,6 +468,47 @@ RULES: tuple[Rule, ...] = (
         lambda r: (
             ("empty", "a one-line description", "add `description` to the repo's YAML")
             if not r.get("description")
+            else None
+        ),
+    ),
+    Rule(
+        "SEC-03",
+        "security",
+        "high",
+        "tier-1",
+        "no required status checks -- CI cannot block a merge",
+        # Scoped to tier-1 rather than all active repos, and that is the honest scope
+        # rather than a convenient one: `unmanaged` covers the 102 forks, which have no
+        # CI of ours to require, and firing on them would bury the 74 repos where this
+        # is real under noise nobody can act on.
+        #
+        # WHAT THIS COSTS WHEN IT IS UNFIXED, measured 2026-08-21 rather than argued:
+        # 12 of ol-infrastructure's last 40 merges landed with `test` red, every one a
+        # Renovate PR, and mit-learn #3812-#3816 auto-merged in 71 seconds with tests
+        # failing and had to be reverted by #3822. An unenforced check is not a weaker
+        # version of an enforced one; it is decoration.
+        #
+        # Deliberately NOT satisfied by "some ruleset exists" -- SEC-01 already asks
+        # that question. A repo can carry the org baseline, show three rulesets in the
+        # API, and still require nothing of its CI. That combination is the whole
+        # finding, so it has to be its own rule.
+        # SATISFIED BY EITHER FIELD, and the second one is not a loophole. `lehrer` and
+        # `ol-analytics-api` already require checks through hand-made repo-level
+        # rulesets that Pulumi does not model -- repository.py deliberately imports no
+        # RepositoryRuleset, so they are invisible to `required_status_checks`. Reading
+        # only the managed field would report the two repos that solved this before we
+        # did, which is the fastest way to teach people the audit is wrong. The
+        # `_`-prefixed field is observed state from the crawl, same as `_ruleset_count`.
+        # It should disappear once those rulesets are imported.
+        lambda r: (
+            (
+                "none required",
+                "the repo's own test jobs required",
+                "verify names with `bin/github-required-checks sample <repo>`, "
+                "then add `required_status_checks` to the repo's YAML",
+            )
+            if not r.get("required_status_checks")
+            and not r.get("_required_status_checks_live")
             else None
         ),
     ),

--- a/src/ol_infrastructure/saas/github/repositories/__main__.py
+++ b/src/ol_infrastructure/saas/github/repositories/__main__.py
@@ -41,5 +41,4 @@ if batch:
     pulumi.log.info(f"batch filter active: {len(fleet)} of the fleet")
 
 for repo in fleet:
-    repository.build(repo)
-    rulesets.build(repo)
+    rulesets.build(repo, repository.build(repo))

--- a/src/ol_infrastructure/saas/github/repositories/__main__.py
+++ b/src/ol_infrastructure/saas/github/repositories/__main__.py
@@ -22,7 +22,7 @@ same failure mode as a repo missing from the fleet entirely.
 import pulumi
 
 from ol_infrastructure.lib.github_helper import setup_github_provider
-from ol_infrastructure.saas.github.repositories import archetypes, repository
+from ol_infrastructure.saas.github.repositories import archetypes, repository, rulesets
 
 # Must run before any github.* resource is constructed: the stack transformation
 # attaches the App-authenticated provider to every one of them.
@@ -42,3 +42,4 @@ if batch:
 
 for repo in fleet:
     repository.build(repo)
+    rulesets.build(repo)

--- a/src/ol_infrastructure/saas/github/repositories/archetypes.py
+++ b/src/ol_infrastructure/saas/github/repositories/archetypes.py
@@ -241,8 +241,9 @@ def _check_required_status_checks(fleet: list[dict[str, Any]]) -> None:
             "required_status_checks data would block merges:\n  "
             + "\n  ".join(problems)
             + "\nVerify every context against real check runs first: "
-            "`uv run bin/github-required-checks sample <repo>`. A name that is not "
-            "on 100% of sampled PRs must not be required -- there is no dry-run "
+            "`uv run bin/github-required-checks sample <repo>`, and that no open PR is "
+            "left unable to produce it: `uv run bin/github-required-checks blocked`. "
+            "Only a name that tool marks SAFE may be required -- there is no dry-run "
             "enforcement mode on this plan."
         )
         raise ValueError(message)

--- a/src/ol_infrastructure/saas/github/repositories/archetypes.py
+++ b/src/ol_infrastructure/saas/github/repositories/archetypes.py
@@ -6,6 +6,7 @@ reachable -- if they disagreed, the code would declare something the crawl never
 recorded.
 """
 
+import re
 from pathlib import Path
 from typing import Any
 
@@ -179,6 +180,74 @@ def _check_dependabot_requires_alerts(fleet: list[dict[str, Any]]) -> None:
         raise ValueError(message)
 
 
+#: A check name ending in `(...)` is one cell of a job matrix -- see rulesets.py.
+_MATRIX_SHARD = re.compile(r"\(.+\)$")
+
+#: Per-repo opt-in for requiring matrix shard names.
+#: See `_check_required_status_checks`.
+MATRIX_OPT_IN = "_allow_matrix_shard_checks"
+
+
+def _check_required_status_checks(fleet: list[dict[str, Any]]) -> None:
+    """Fail on required-check data that would block every PR on a repo.
+
+    Unlike the other checks here, this one is not guarding against a crash further down.
+    `rulesets.py` will happily build a ruleset from any list of strings, and GitHub will
+    accept it. The failure is silent and total: a context nothing produces leaves every
+    PR permanently pending, and because `enforcement: evaluate` does not exist on this
+    plan there is no state between "not enforced" and "enforced on the org's busiest
+    repos". Data that is wrong in an obvious way should not reach that point.
+
+    Three things are refused:
+
+    archived repos  GitHub rejects ruleset writes on them, so it is unsatisfiable data.
+    empty strings   an empty context blocks the branch and names nothing in the UI.
+    matrix shards   `python-tests (1)` is a valid context and requiring it works
+                    today.
+                    What it does not survive is somebody editing that matrix in a
+                    DIFFERENT repository: drop to three shards and `python-tests (4)` is
+                    still required, never produced again, and every PR on that repo
+                    blocks forever with the cause two repos away. Requiring one is
+                    allowed, but only from a repo file that sets
+                    `_allow_matrix_shard_checks: true`, so it is a decision somebody
+                    made rather than a name copied out of a
+                    `bin/github-required-checks sample` run.
+    """
+    problems: list[str] = []
+    for repo in fleet:
+        contexts = repo.get("required_status_checks")
+        if not contexts:
+            continue
+        name = repo["name"]
+        if repo.get("archived"):
+            problems.append(f"{name}: archived repos cannot carry rulesets")
+            continue
+        if not isinstance(contexts, list) or any(
+            not isinstance(c, str) or not c.strip() for c in contexts
+        ):
+            problems.append(
+                f"{name}: required_status_checks must be a list of non-empty strings"
+            )
+            continue
+        if not repo.get(MATRIX_OPT_IN):
+            shards = sorted(c for c in contexts if _MATRIX_SHARD.search(c))
+            if shards:
+                problems.append(
+                    f"{name}: {shards} look like job-matrix shard names; set "
+                    f"`{MATRIX_OPT_IN}: true` to require them anyway"
+                )
+    if problems:
+        message = (
+            "required_status_checks data would block merges:\n  "
+            + "\n  ".join(problems)
+            + "\nVerify every context against real check runs first: "
+            "`uv run bin/github-required-checks sample <repo>`. A name that is not "
+            "on 100% of sampled PRs must not be required -- there is no dry-run "
+            "enforcement mode on this plan."
+        )
+        raise ValueError(message)
+
+
 def _check_team_references(fleet: list[dict[str, Any]]) -> None:
     """Fail if any repo grants to a team slug absent from teams.yaml.
 
@@ -238,6 +307,7 @@ def load_fleet() -> list[dict[str, Any]]:
     _check_permission_values(fleet)
     _check_public_repo_teams(fleet)
     _check_dependabot_requires_alerts(fleet)
+    _check_required_status_checks(fleet)
 
     # The dotfile trap is silent by construction, so assert rather than trust.
     assignments = yaml.safe_load((DATA_DIR / "archetypes-proposed.yaml").read_text())

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/lehrer.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/lehrer.yaml
@@ -4,6 +4,9 @@ _custom_properties:
 _excluded_environments: 1
 _has_branch_protection: false
 _pushed_at: '2026-08-16T19:34:39Z'
+_required_status_checks_live:
+- fast-checks
+- gate
 _ruleset_count: 4
 _visibility: public
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
@@ -22,6 +22,13 @@ has_projects: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: mit-learn
+required_status_checks:
+- build-nextjs-container
+- build-storybook
+- javascript-tests
+- openapi-generated-client-check-v0
+- openapi-generated-client-check-v1
+- python-tests
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
@@ -24,7 +24,7 @@ merge_commit_title: MERGE_MESSAGE
 name: mit-learn
 required_status_checks:
 - ci-gate
-- openapi-diff
+- openapi-diff-gate
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
@@ -23,12 +23,8 @@ merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: mit-learn
 required_status_checks:
-- build-nextjs-container
-- build-storybook
-- javascript-tests
-- openapi-generated-client-check-v0
-- openapi-generated-client-check-v1
-- python-tests
+- ci-gate
+- openapi-diff
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mit-learn.yaml
@@ -24,7 +24,7 @@ merge_commit_title: MERGE_MESSAGE
 name: mit-learn
 required_status_checks:
 - ci-gate
-- openapi-diff-gate
+- openapi-diff
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline.yaml
@@ -20,8 +20,7 @@ merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: mitxonline
 required_status_checks:
-- javascript-tests
-- python-checks
+- ci-gate
 squash_merge_commit_message: BLANK
 squash_merge_commit_title: PR_TITLE
 teams:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/mitxonline.yaml
@@ -19,6 +19,9 @@ has_projects: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: mitxonline
+required_status_checks:
+- javascript-tests
+- python-checks
 squash_merge_commit_message: BLANK
 squash_merge_commit_title: PR_TITLE
 teams:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-analytics-api.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-analytics-api.yaml
@@ -4,6 +4,8 @@ _custom_properties:
 _excluded_environments: 3
 _has_branch_protection: false
 _pushed_at: '2026-08-14T23:15:21Z'
+_required_status_checks_live:
+- test
 _ruleset_count: 3
 _visibility: public
 allow_merge_commit: true

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
@@ -19,6 +19,8 @@ has_wiki: true
 merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: ol-infrastructure
+required_status_checks:
+- test
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml
@@ -20,7 +20,7 @@ merge_commit_message: PR_TITLE
 merge_commit_title: MERGE_MESSAGE
 name: ol-infrastructure
 required_status_checks:
-- test
+- ci-gate
 squash_merge_commit_message: COMMIT_MESSAGES
 squash_merge_commit_title: COMMIT_OR_PR_TITLE
 teams:

--- a/src/ol_infrastructure/saas/github/repositories/repository.py
+++ b/src/ol_infrastructure/saas/github/repositories/repository.py
@@ -129,8 +129,15 @@ def _tier_property(
     )
 
 
-def build(repo: dict[str, Any]) -> None:
-    """Emit the resource family for one repo."""
+def build(repo: dict[str, Any]) -> github.Repository:
+    """Emit the resource family for one repo, and return the `Repository` itself.
+
+    RETURNED SO CALLERS CAN DEPEND ON IT. Every resource here passes `repository=name`
+    as a plain string, which carries no Pulumi dependency, so each one needs an explicit
+    `depends_on`. rulesets.py sits in a different module and needs the same edge;
+    handing it the resource is what lets `__main__.py` wire the two together without
+    either module reaching into the other's internals.
+    """
     name = repo["name"]
     archived = bool(repo.get("archived"))
 
@@ -152,7 +159,7 @@ def build(repo: dict[str, Any]) -> None:
             ),
         )
         _tier_property(name, repo["tier"], repository)
-        return
+        return repository
 
     # retain_on_delete is the counterweight for administration:write (section 2.2).
     # Removing a repo from data/repos/ drops it from Pulumi state and NEVER from
@@ -254,3 +261,5 @@ def build(repo: dict[str, Any]) -> None:
             permission=permission,
             opts=ResourceOptions(depends_on=[repository]),
         )
+
+    return repository

--- a/src/ol_infrastructure/saas/github/repositories/rulesets.py
+++ b/src/ol_infrastructure/saas/github/repositories/rulesets.py
@@ -77,16 +77,20 @@ Those jobs have since landed: ol-infrastructure #5567 (2026-08-24), mitxonline #
 `if: always()`, without which a failed dependency skips the gate and GitHub reads a
 skipped required check as satisfied.
 
-`mit-learn` requires `openapi-diff` as well, and that is the exception that proves the
-rule rather than a second list creeping back. `needs:` cannot cross workflow files and
-`openapi-diff` lives in its own, so no gate can absorb it. It is safe to require only
-because mit-learn #3825 also gave it an `--err-ignore` allowlist
-(`openapi/oasdiff-err-ignore.txt`): before that it went red on INTENTIONAL breaking API
-changes -- red at merge on 8 of the last 40 mit-learn PRs, release PRs included -- and
-requiring it would have forced a bypass on every deliberate API change, which trains
-people to bypass. Now such a change adds a line to a reviewed file in the repo that made
-it. If that allowlist turns out to be unusable in practice, drop `openapi-diff` from
-mit-learn's YAML; the gate is unaffected.
+`mit-learn` needs TWO gates, and that is a property of `needs:` rather than a list
+creeping back. `needs:` only reaches jobs in the same workflow file, and mit-learn's
+oasdiff check lives in `openapi-diff.yml` on a `pull_request` trigger while `ci-gate`
+sits in `ci.yml` on `push`. So that workflow carries its own `openapi-diff-gate` and the
+two are required side by side -- each still a single stable context standing for its
+whole workflow, which is the property that matters.
+
+Requiring the oasdiff check at all is safe only because mit-learn #3825 gave it an
+`--err-ignore` allowlist (`openapi/oasdiff-err-ignore.txt`): before that it went red on
+INTENTIONAL breaking API changes -- red at merge on 8 of the last 40 mit-learn PRs,
+release PRs included -- and requiring it would have forced a bypass on every deliberate
+API change, which trains people to bypass. Now such a change adds a line to a reviewed
+file in the repo that made it. If that allowlist turns out to be unusable in practice,
+drop `openapi-diff-gate` from mit-learn's YAML; `ci-gate` is unaffected.
 
 WHAT THE GATE DOES NOT FIX is a branch older than the gate itself. A PR cut before
 `ci-gate` existed does not define the job, so it produces no such check and hangs with

--- a/src/ol_infrastructure/saas/github/repositories/rulesets.py
+++ b/src/ol_infrastructure/saas/github/repositories/rulesets.py
@@ -77,20 +77,26 @@ Those jobs have since landed: ol-infrastructure #5567 (2026-08-24), mitxonline #
 `if: always()`, without which a failed dependency skips the gate and GitHub reads a
 skipped required check as satisfied.
 
-`mit-learn` needs TWO gates, and that is a property of `needs:` rather than a list
-creeping back. `needs:` only reaches jobs in the same workflow file, and mit-learn's
+`mit-learn` requires `openapi-diff` as well, by its own job name, and that is not the
+list creeping back. `needs:` only reaches jobs in the same workflow file: mit-learn's
 oasdiff check lives in `openapi-diff.yml` on a `pull_request` trigger while `ci-gate`
-sits in `ci.yml` on `push`. So that workflow carries its own `openapi-diff-gate` and the
-two are required side by side -- each still a single stable context standing for its
-whole workflow, which is the property that matters.
+sits in `ci.yml` on `push`, so no gate can absorb it.
 
-Requiring the oasdiff check at all is safe only because mit-learn #3825 gave it an
-`--err-ignore` allowlist (`openapi/oasdiff-err-ignore.txt`): before that it went red on
-INTENTIONAL breaking API changes -- red at merge on 8 of the last 40 mit-learn PRs,
-release PRs included -- and requiring it would have forced a bypass on every deliberate
-API change, which trains people to bypass. Now such a change adds a line to a reviewed
-file in the repo that made it. If that allowlist turns out to be unusable in practice,
-drop `openapi-diff-gate` from mit-learn's YAML; `ci-gate` is unaffected.
+Giving that workflow a gate of its own was tried and reverted (mit-learn #3856). It buys
+only protection against somebody renaming a single job, since the workflow has one job
+and no matrix -- and it pays for that with a required context carrying no history, an
+extra job on every PR, and a second repo that has to merge before this stack can be
+applied. `openapi-diff` has reported on 40 of the last 40 mit-learn PRs. A rename would
+be caught by `drift` as a loud CI failure rather than a wedged repo, which is the risk
+the gate was supposed to cover.
+
+Requiring it at all is safe only because mit-learn #3825 gave it an `--err-ignore`
+allowlist (`openapi/oasdiff-err-ignore.txt`): before that it went red on INTENTIONAL
+breaking API changes -- red at merge on 8 of the last 40 mit-learn PRs, release PRs
+included -- and requiring it would have forced a bypass on every deliberate API change,
+which trains people to bypass. Now such a change adds a line to a reviewed file in the
+repo that made it. If that allowlist turns out to be unusable in practice, drop
+`openapi-diff` from mit-learn's YAML; `ci-gate` is unaffected.
 
 WHAT THE GATE DOES NOT FIX is a branch older than the gate itself. A PR cut before
 `ci-gate` existed does not define the job, so it produces no such check and hangs with

--- a/src/ol_infrastructure/saas/github/repositories/rulesets.py
+++ b/src/ol_infrastructure/saas/github/repositories/rulesets.py
@@ -125,6 +125,12 @@ _DEFAULT_BRANCH_ONLY = github.RepositoryRulesetConditionsArgs(
     ),
 )
 
+#: The name GitHub shows for the ruleset this module creates. Shared with
+#: `bin/github-org-inventory`, which uses it to tell the checks WE require from the
+#: ones a repo required for itself before Pulumi got there -- the two round-trip into
+#: different YAML keys. A literal in both places would drift.
+REQUIRED_CHECKS_RULESET_NAME = "required-status-checks"
+
 #: A check name ending in `(...)`: GitHub's rendering of one cell of a job matrix.
 #: Matching it is not a correctness check -- these names are perfectly valid contexts
 #: and requiring them works today. It exists so that requiring one is a decision
@@ -148,13 +154,20 @@ def _check(
     )
 
 
-def build(repo: dict[str, Any]) -> None:
+def build(repo: dict[str, Any], repository: github.Repository) -> None:
     """Emit the required-status-checks ruleset for one repo, if it declares any.
 
     Absent `required_status_checks` means no resource at all rather than an empty
     ruleset. An empty `required_checks` list is a ruleset that requires nothing, which
     reads in the GitHub UI as protection that exists and enforces nothing -- the same
     confusion SEC-03 is about.
+
+    `repository` IS REQUIRED EVEN THOUGH THE RULESET TAKES A NAME STRING. `repository=`
+    is a plain `str`, not an `Output`, so Pulumi infers no dependency from it and is
+    free to create the ruleset before the repo exists. Every one of the three repos in
+    the first wave is already in state, so the ordering is invisible today and would
+    first fail on whichever new repo declared checks next. Same reasoning, and the same
+    fix, as `BranchDefault` and `TeamRepository` in repository.py.
     """
     contexts = repo.get("required_status_checks")
     if not contexts:
@@ -163,7 +176,7 @@ def build(repo: dict[str, Any]) -> None:
     name = repo["name"]
     github.RepositoryRuleset(
         f"mitodl-repo-required-status-checks-{name}",
-        name="required-status-checks",
+        name=REQUIRED_CHECKS_RULESET_NAME,
         repository=name,
         target="branch",
         enforcement="active",
@@ -181,5 +194,5 @@ def build(repo: dict[str, Any]) -> None:
                 strict_required_status_checks_policy=False,
             ),
         ),
-        opts=ResourceOptions(protect=True),
+        opts=ResourceOptions(protect=True, depends_on=[repository]),
     )

--- a/src/ol_infrastructure/saas/github/repositories/rulesets.py
+++ b/src/ol_infrastructure/saas/github/repositories/rulesets.py
@@ -2,8 +2,7 @@
 
 SEC-03 -- every repo in the org runs CI and none of it can block a merge. Closing that
 needs the one rule the §5.4 org-ruleset design deliberately left per-repo, because check
-names are per-repo facts: `ol-infrastructure` produces `test`, `mit-learn` produces
-`python-tests` and `javascript-tests`, and no org-wide ruleset can name both.
+names are per-repo facts and no org-wide ruleset can name them all.
 
 THERE IS NO DRY RUN. `enforcement: evaluate` does not exist on the Team plan -- the API
 accepts the PUT and then does nothing at all (see organization/org_rulesets.py, which
@@ -16,10 +15,17 @@ The only defence is that the names are checked against reality before they land:
 
     uv run bin/github-required-checks sample mit-learn --prs 20
 
-reports how many of the last N merged PRs produced each check. Only names present on
-EVERY sampled PR belong in `required_status_checks`. A name at 19/20 is not a flake to
-round up -- it is a check that some PR did not produce, and requiring it blocks that
-kind of PR forever.
+scores each check name against the merged PRs where it COULD have reported -- the ones
+whose head commit defines the job and whose workflow actually ran -- and only a name it
+marks SAFE belongs in `required_status_checks`. A name missing from a PR that defined it
+and ran its workflow is not a flake to round up: it is a check that some PR did not
+produce, and requiring it blocks that kind of PR forever.
+
+That scope is what makes the aggregate gates below requirable at all. A raw
+"appeared on N of the last 40" reads a job added last week (`ci-gate`, 31/40 on
+ol-infrastructure, every miss a branch cut before it existed) identically to a
+path-filtered one (`Run zizmor`, 1/40, and permanently unrequirable). Only the first is
+safe, and no percentage separates them.
 
 WHAT MAKES A NAME UNSAFE TO REQUIRE, all observed live in this org on 2026-08-21:
 
@@ -27,23 +33,25 @@ WHAT MAKES A NAME UNSAFE TO REQUIRE, all observed live in this org on 2026-08-21
                             touching `.github/workflows/**` (1 of the last 40). A
                             workflow that does not trigger produces no check run at
                             all, so the ruleset waits forever rather than passing.
+                            The `on:` block states this outright, so
+                            `bin/github-required-checks` reads it there and refuses
+                            the name rather than inferring it from a count.
   unreliable reviewers      `Seer Code Review` (22/40) and
                             `copilot-pull-request-reviewer` (11/40) attach only
                             sometimes. They are advisory by design.
   matrix shard names        `mitxonline`'s `python-tests (1)`..`(4)`. See below: this is
                             not a hypothetical, the rename already happened.
-  checks that fail on       `openapi-diff` runs `oasdiff breaking --fail-on ERR`, so it
-  purpose                   goes red on INTENTIONAL breaking API changes. It reported on
-                            40/40 mit-learn PRs and was red at merge on 8 of them,
-                            release PRs included. Requiring it would force a bypass
-                            on every deliberate API change, which trains people to
-                            bypass. Reporting reliably and passing reliably are
-                            different properties; only the first is a sampling
-                            question.
+  checks that fail on       A check that reports reliably can still fail on purpose.
+  purpose                   `openapi-diff` is the case, and requiring it needed an
+                            allowlist in the repo that produces it before it was
+                            reasonable -- see the note on mit-learn below. Reporting
+                            reliably and passing reliably are different properties;
+                            only the first is a sampling question.
 
-SAMPLE SIZE IS PART OF THE ANSWER. `CodeQL` and `Analyze (*)` look perfectly stable at
-20 PRs on ol-infrastructure and drop to 38/40 at forty. Twenty is not enough to clear a
-name.
+SAMPLE SIZE IS PART OF THE ANSWER. On 2026-08-21 `CodeQL` and `Analyze (*)` looked
+perfectly stable at 20 PRs on ol-infrastructure and dropped to 38/40 at forty. (They
+read 40/40 again on 2026-08-28, which is the point rather than a correction: a name
+can look clean at any single window.) Twenty is not enough to clear a name.
 
 THE MATRIX RENAME IS NOT A THOUGHT EXPERIMENT. In February 2026 mitxonline produced one
 check named `python-tests`. Commit 63ded115 on 2026-07-23 ("Shard CI pytest run across a
@@ -56,11 +64,36 @@ carries the shard count twice in its own ci.yml (`matrix: group: [1, 2, 3, 4]` a
 are required today, and `_allow_matrix_shard_checks` exists so that changing that
 has to be deliberate.
 
-THE DURABLE FIX IS AN AGGREGATE GATE JOB, not a longer list here. A `ci-ok` job
-with `needs:` every other job, required as a single static context, puts the list
-of what must pass in the file that owns the jobs, so resizing a matrix and updating
-the gate are the same edit by the same person. That needs one PR per application
-repo and is filed as follow-up work; the lists here protect the fleet until then.
+WHAT IS ACTUALLY REQUIRED IS AN AGGREGATE GATE JOB, one per repo, and not the list of
+job names an earlier draft of this file carried. A `ci-gate` job with `needs:` every
+other job in its workflow, required as a single static context, puts the list of what
+must pass in the file that owns the jobs -- so resizing a matrix and updating the gate
+are one edit by one person in one repo, and the failure modes above stop being reachable
+from here at all. `lehrer` had already done this for itself (`gate`, `fast-checks`)
+before this work started.
+
+Those jobs have since landed: ol-infrastructure #5567 (2026-08-24), mitxonline #3876
+(2026-08-25), mit-learn #3825. Each `needs:` every job in its workflow and runs under
+`if: always()`, without which a failed dependency skips the gate and GitHub reads a
+skipped required check as satisfied.
+
+`mit-learn` requires `openapi-diff` as well, and that is the exception that proves the
+rule rather than a second list creeping back. `needs:` cannot cross workflow files and
+`openapi-diff` lives in its own, so no gate can absorb it. It is safe to require only
+because mit-learn #3825 also gave it an `--err-ignore` allowlist
+(`openapi/oasdiff-err-ignore.txt`): before that it went red on INTENTIONAL breaking API
+changes -- red at merge on 8 of the last 40 mit-learn PRs, release PRs included -- and
+requiring it would have forced a bypass on every deliberate API change, which trains
+people to bypass. Now such a change adds a line to a reviewed file in the repo that made
+it. If that allowlist turns out to be unusable in practice, drop `openapi-diff` from
+mit-learn's YAML; the gate is unaffected.
+
+WHAT THE GATE DOES NOT FIX is a branch older than the gate itself. A PR cut before
+`ci-gate` existed does not define the job, so it produces no such check and hangs with
+nothing to re-run -- and unlike a wrong name this resolves itself on a rebase. On
+2026-08-28 that was 45 of 46 open mit-learn PRs, 37 of 45 on mitxonline and 19 of 44 on
+ol-infrastructure. `bin/github-required-checks blocked` lists them by name and exits
+non-zero, and is the check to run immediately before `pulumi up` rather than after.
 
 BYPASS MIRRORS THE ORG RULESETS, AND THAT IS A NARROWER CHOICE THAN IT LOOKS.
 `_BYPASS` copies `_ADMIN_BYPASS` from organization/org_rulesets.py: owners `always`,

--- a/src/ol_infrastructure/saas/github/repositories/rulesets.py
+++ b/src/ol_infrastructure/saas/github/repositories/rulesets.py
@@ -1,0 +1,185 @@
+"""Per-repo rulesets: required status checks, and nothing else.
+
+SEC-03 -- every repo in the org runs CI and none of it can block a merge. Closing that
+needs the one rule the §5.4 org-ruleset design deliberately left per-repo, because check
+names are per-repo facts: `ol-infrastructure` produces `test`, `mit-learn` produces
+`python-tests` and `javascript-tests`, and no org-wide ruleset can name both.
+
+THERE IS NO DRY RUN. `enforcement: evaluate` does not exist on the Team plan -- the API
+accepts the PUT and then does nothing at all (see organization/org_rulesets.py, which
+spent a week inert believing otherwise). So a ruleset built here goes straight to
+`active`, and a `context` string that does not exactly match a real check-run name
+permanently blocks every PR on that repo with no signal other than a stuck PR. That is
+the DX-02 failure mode, caused by the fix for SEC-03.
+
+The only defence is that the names are checked against reality before they land:
+
+    uv run bin/github-required-checks sample mit-learn --prs 20
+
+reports how many of the last N merged PRs produced each check. Only names present on
+EVERY sampled PR belong in `required_status_checks`. A name at 19/20 is not a flake to
+round up -- it is a check that some PR did not produce, and requiring it blocks that
+kind of PR forever.
+
+WHAT MAKES A NAME UNSAFE TO REQUIRE, all observed live in this org on 2026-08-21:
+
+  path-filtered workflows   `ol-infrastructure`'s `Run zizmor` only runs on PRs
+                            touching `.github/workflows/**` (1 of the last 40). A
+                            workflow that does not trigger produces no check run at
+                            all, so the ruleset waits forever rather than passing.
+  unreliable reviewers      `Seer Code Review` (22/40) and
+                            `copilot-pull-request-reviewer` (11/40) attach only
+                            sometimes. They are advisory by design.
+  matrix shard names        `mitxonline`'s `python-tests (1)`..`(4)`. See below: this is
+                            not a hypothetical, the rename already happened.
+  checks that fail on       `openapi-diff` runs `oasdiff breaking --fail-on ERR`, so it
+  purpose                   goes red on INTENTIONAL breaking API changes. It reported on
+                            40/40 mit-learn PRs and was red at merge on 8 of them,
+                            release PRs included. Requiring it would force a bypass
+                            on every deliberate API change, which trains people to
+                            bypass. Reporting reliably and passing reliably are
+                            different properties; only the first is a sampling
+                            question.
+
+SAMPLE SIZE IS PART OF THE ANSWER. `CodeQL` and `Analyze (*)` look perfectly stable at
+20 PRs on ol-infrastructure and drop to 38/40 at forty. Twenty is not enough to clear a
+name.
+
+THE MATRIX RENAME IS NOT A THOUGHT EXPERIMENT. In February 2026 mitxonline produced one
+check named `python-tests`. Commit 63ded115 on 2026-07-23 ("Shard CI pytest run across a
+4-way matrix") replaced it with `python-tests (1)`..`(4)`. Had this file required
+`python-tests` before that date: the sharding PR blocks itself, somebody bypasses it
+because the tests plainly pass, and from then on EVERY mitxonline PR blocks forever --
+cause in one repo, symptom in a second, fix in a third. mitxonline also already
+carries the shard count twice in its own ci.yml (`matrix: group: [1, 2, 3, 4]` and
+`--splits 4`); a third copy over here is the wrong direction. Hence: no shard names
+are required today, and `_allow_matrix_shard_checks` exists so that changing that
+has to be deliberate.
+
+THE DURABLE FIX IS AN AGGREGATE GATE JOB, not a longer list here. A `ci-ok` job
+with `needs:` every other job, required as a single static context, puts the list
+of what must pass in the file that owns the jobs, so resizing a matrix and updating
+the gate are the same edit by the same person. That needs one PR per application
+repo and is filed as follow-up work; the lists here protect the fleet until then.
+
+BYPASS MIRRORS THE ORG RULESETS, AND THAT IS A NARROWER CHOICE THAN IT LOOKS.
+`_BYPASS` copies `_ADMIN_BYPASS` from organization/org_rulesets.py: owners `always`,
+`odl-engineering` and `arbisoft-contractors` at `pull_request`. So a human on either
+team can still merge a red build, and for humans this rule is advisory.
+
+That is deliberate, and it still fixes the failure that prompted the work, because
+bypass actors are TEAMS and the actor that caused the harm is an App. On 2026-08-21
+Renovate merged mit-learn #3812-#3816 in 71 seconds, two of them with `python-tests`
+already red on their own branch, breaking `main` and costing a revert (#3822) three
+hours later. The same thing had been running quietly on ol-infrastructure: 12 of the
+last 40 merges landed with `test` red, and every single one was a Renovate PR
+(#5529-#5537, #5553-#5555). `renovate[bot]` is in no team, so no bypass here applies to
+it, and GitHub's auto-merge honours required checks regardless of who is bypass-listed.
+
+The chain that produced those merges: the shared Renovate config extends
+`:automergeMinor`, `platformAutomerge` defaults to `true`, so Renovate hands the merge
+to GitHub auto-merge, which waits for "all required reviews and status checks". Required
+checks were zero, so the wait was instant and the approval from the `renovate-approve`
+App was the only gate. Auto-merge is not the bug; the empty list was.
+
+TEAM IDS COME FROM `archetypes.TEAM_IDS`, not from the `organization` project's
+`teams.py`. They are two separate Pulumi projects; importing across them would
+re-declare every `Team` resource inside this stack. Same reasoning as
+`repository.py`'s `TeamRepository`.
+"""
+
+import re
+from typing import Any
+
+import pulumi_github as github
+from pulumi import ResourceOptions
+
+from ol_infrastructure.saas.github.repositories import archetypes
+
+#: Mirrors `_ADMIN_BYPASS` in organization/org_rulesets.py exactly (decision: Tobias,
+#: 2026-08-21). See the module docstring for what that does and does not buy.
+_BYPASS = [
+    github.RepositoryRulesetBypassActorArgs(
+        actor_type="Team",
+        actor_id=archetypes.TEAM_IDS["odl-engineering-owners"],
+        bypass_mode="always",
+    ),
+    github.RepositoryRulesetBypassActorArgs(
+        actor_type="Team",
+        actor_id=archetypes.TEAM_IDS["arbisoft-contractors"],
+        bypass_mode="pull_request",
+    ),
+    github.RepositoryRulesetBypassActorArgs(
+        actor_type="Team",
+        actor_id=archetypes.TEAM_IDS["odl-engineering"],
+        bypass_mode="pull_request",
+    ),
+]
+
+#: GitHub's alias for whatever the repo's default branch is, so this does not have to
+#: know which of `main` or `master` a repo is on. Same device as the org rulesets.
+_DEFAULT_BRANCH_ONLY = github.RepositoryRulesetConditionsArgs(
+    ref_name=github.RepositoryRulesetConditionsRefNameArgs(
+        includes=["~DEFAULT_BRANCH"],
+        excludes=[],
+    ),
+)
+
+#: A check name ending in `(...)`: GitHub's rendering of one cell of a job matrix.
+#: Matching it is not a correctness check -- these names are perfectly valid contexts
+#: and requiring them works today. It exists so that requiring one is a decision
+#: somebody made in the repo's YAML rather than a name that got copied out of a sample.
+_MATRIX_SHARD = re.compile(r"\(.+\)$")
+
+
+def _check(
+    context: str,
+) -> github.RepositoryRulesetRulesRequiredStatusChecksRequiredCheckArgs:
+    """One required context.
+
+    `integration_id` is left unset. Pinning a context to the app that produces it would
+    stop a different app satisfying `test` with a green check of its own, but the ids
+    are per-app facts the crawl does not record, and an id that is merely *wrong*
+    produces the same permanent block a wrong name does. Worth adding once the crawl
+    records them; not worth guessing.
+    """
+    return github.RepositoryRulesetRulesRequiredStatusChecksRequiredCheckArgs(
+        context=context,
+    )
+
+
+def build(repo: dict[str, Any]) -> None:
+    """Emit the required-status-checks ruleset for one repo, if it declares any.
+
+    Absent `required_status_checks` means no resource at all rather than an empty
+    ruleset. An empty `required_checks` list is a ruleset that requires nothing, which
+    reads in the GitHub UI as protection that exists and enforces nothing -- the same
+    confusion SEC-03 is about.
+    """
+    contexts = repo.get("required_status_checks")
+    if not contexts:
+        return
+
+    name = repo["name"]
+    github.RepositoryRuleset(
+        f"mitodl-repo-required-status-checks-{name}",
+        name="required-status-checks",
+        repository=name,
+        target="branch",
+        enforcement="active",
+        bypass_actors=_BYPASS,
+        conditions=_DEFAULT_BRANCH_ONLY,
+        rules=github.RepositoryRulesetRulesArgs(
+            required_status_checks=github.RepositoryRulesetRulesRequiredStatusChecksArgs(
+                required_checks=[_check(context) for context in sorted(contexts)],
+                # "Require branches to be up to date before merging". Left OFF
+                # deliberately: on a repo merging several PRs an hour it serialises
+                # every merge behind a re-run of the full suite, and the org's busiest
+                # repos are exactly the ones this rule targets first. It buys protection
+                # against semantic conflicts between concurrently-merged PRs, which is a
+                # real but much rarer failure than the throughput it costs.
+                strict_required_status_checks_policy=False,
+            ),
+        ),
+        opts=ResourceOptions(protect=True),
+    )

--- a/tests/ol_infrastructure/saas/github/test_audit.py
+++ b/tests/ol_infrastructure/saas/github/test_audit.py
@@ -10,7 +10,7 @@ repos than it claims. That mistake has been made twice on this project, both tim
 caught by cross-checking a percentage against raw data rather than by reading the code.
 """
 
-from typing import Any
+from typing import Any, get_args
 
 import pytest
 
@@ -210,11 +210,16 @@ def test_population_matches_each_rules_scope() -> None:
 
 
 def test_every_rule_declares_a_known_axis_and_scope() -> None:
-    """Guards the reporter, which indexes findings by both."""
+    """Guards the reporter, which indexes findings by both.
+
+    Reads the vocabularies off the `Literal` aliases rather than restating them. The
+    hand-written copy went stale the first time a scope was added, failing on the new
+    scope rather than on anything wrong with it.
+    """
     for rule in audit.RULES:
-        assert rule.axis in ("security", "consistency", "developer-experience")
-        assert rule.scope in ("active", "archived", "fleet")
-        assert rule.severity in ("high", "medium", "low")
+        assert rule.axis in get_args(audit.Axis)
+        assert rule.scope in get_args(audit.Scope)
+        assert rule.severity in get_args(audit.Severity)
 
 
 def test_rule_ids_are_unique() -> None:
@@ -367,3 +372,51 @@ def test_removable_kinds_exclude_the_two_that_cost_something() -> None:
     """The headline "N removable today" is summed over this set."""
     assert "no-access" not in audit.REMOVABLE_KINDS
     assert "outside" not in audit.REMOVABLE_KINDS
+
+
+def test_sec03_is_scoped_to_active_tier_one() -> None:
+    """The denominator decides whether this rule is readable or noise.
+
+    102 of the 176 active repos are `unmanaged` forks with no CI of ours to require, so
+    scoping to `active` would bury the 74 repos where the finding is real. An ARCHIVED
+    tier-1 repo is excluded for a different reason: repository.py writes the tier
+    property on archived repos too, so `tier == tier-1` alone would drag read-only
+    repos into a rule about gating merges nobody can make.
+    """
+    assert "SEC-03" in fired([repo(tier="tier-1")])
+    assert "SEC-03" not in fired([repo(tier="unmanaged")])
+    assert "SEC-03" not in fired([repo(tier="standard")])
+    assert "SEC-03" not in fired([repo(tier="tier-1", archived=True)])
+
+
+def test_sec03_clears_once_checks_are_required() -> None:
+    assert "SEC-03" not in fired([repo(tier="tier-1", required_status_checks=["test"])])
+
+
+def test_sec03_is_not_satisfied_by_having_a_ruleset() -> None:
+    """The whole finding is a repo that looks protected and gates none of its CI.
+
+    ol-infrastructure carries three rulesets and required nothing, which is why this
+    cannot be folded into SEC-01.
+    """
+    assert "SEC-03" in fired([repo(tier="tier-1", _ruleset_count=3)])
+
+
+def test_population_counts_tier_one_actives_only() -> None:
+    fleet = [
+        repo(name="a", tier="tier-1"),
+        repo(name="b", tier="tier-1", archived=True),
+        repo(name="c", tier="unmanaged"),
+    ]
+    assert audit.population(fleet, "tier-1") == 1
+    assert audit.population(fleet, "active") == 2
+
+
+def test_sec03_accepts_checks_required_outside_pulumi() -> None:
+    """`lehrer` and `ol-analytics-api` solved this before we did, via hand-made
+    repo-level rulesets Pulumi does not model. Reporting them would make the audit
+    wrong about the two repos that are already compliant.
+    """
+    assert "SEC-03" not in fired(
+        [repo(tier="tier-1", _required_status_checks_live=["gate"])]
+    )

--- a/tests/ol_infrastructure/saas/github/test_crawl_cache.py
+++ b/tests/ol_infrastructure/saas/github/test_crawl_cache.py
@@ -1,0 +1,113 @@
+"""Tests for the crawl-cache schema guard in `bin/github-org-inventory`.
+
+Every command in that file runs off one cached crawl, the cache carries no version, and
+the repo records are read by subscript in about forty places. So a cache written before
+a field existed loads cleanly and then dies with a bare `KeyError` several hundred lines
+away, naming a key rather than the cache that lacks it. That is how it was reported on
+#5566, against `foreign_required_status_checks`, and the same trap re-arms itself every
+time somebody adds a field.
+
+The guard turns that into one message that names the remedy. `--refresh` was always the
+answer; the point is that the failure says so.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[4] / "bin" / "github-org-inventory"
+
+
+def _load() -> Any:
+    """Import the CLI from a file with no `.py` on it, without running a crawl."""
+    loader = SourceFileLoader("github_org_inventory", str(SCRIPT))
+    spec = importlib.util.spec_from_file_location(loader.name, SCRIPT, loader=loader)
+    if spec is None or spec.loader is None:
+        msg = f"Unable to load {SCRIPT}"
+        raise RuntimeError(msg)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+tool = _load()
+
+
+def _cache(tmp_path: Path, repos: list[dict[str, Any]]) -> Path:
+    path = tmp_path / "cache.json"
+    path.write_text(json.dumps({"repos": repos}))
+    return path
+
+
+def _current(**overrides: Any) -> dict[str, Any]:
+    record = dict.fromkeys(tool._EXPECTED_REPO_KEYS, "x")
+    return record | overrides
+
+
+def test_a_current_cache_loads(tmp_path: Path) -> None:
+    """The ordinary path: a cache written by this code is used as-is."""
+    cache = _cache(tmp_path, [_current(name="a"), _current(name="b")])
+    assert tool._crawl_org(cache, refresh=False)["repos"][0]["name"] == "a"
+
+
+def test_the_reported_failure_is_named_not_raised_as_a_keyerror(
+    tmp_path: Path,
+) -> None:
+    """The #5566 case: a cache from before this PR added the two check fields."""
+    stale = _current(name="a")
+    del stale["required_status_checks"]
+    del stale["foreign_required_status_checks"]
+    with pytest.raises(SystemExit) as exited:
+        tool._crawl_org(_cache(tmp_path, [stale]), refresh=False)
+    message = str(exited.value)
+    assert "required_status_checks" in message
+    assert "foreign_required_status_checks" in message
+    assert "--refresh" in message
+
+
+def test_one_short_record_is_enough_to_fail(tmp_path: Path) -> None:
+    """A half-written cache reads exactly like one written by older code.
+
+    Checking only the first record would clear this, and the subscript that dies is not
+    guaranteed to land on the record that is missing the key.
+    """
+    short = _current(name="b")
+    del short["ruleset_count"]
+    with pytest.raises(SystemExit, match="ruleset_count"):
+        tool._crawl_org(_cache(tmp_path, [_current(name="a"), short]), refresh=False)
+
+
+def test_an_empty_crawl_is_not_treated_as_stale(tmp_path: Path) -> None:
+    """No records means no evidence of an old schema, and nothing to subscript."""
+    assert tool._crawl_org(_cache(tmp_path, []), refresh=False) == {"repos": []}
+
+
+class _ReachedCrawlError(Exception):
+    """Proves control reached the live crawl instead of stopping at the cache guard."""
+
+
+def test_refresh_does_not_consult_the_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`--refresh` must reach the crawl even when the cache on disk is stale.
+
+    Otherwise the guard would block the one command that fixes what it complains about.
+    """
+
+    def _reached(_token: str) -> None:
+        raise _ReachedCrawlError
+
+    monkeypatch.setattr(tool, "get_installation_token", lambda: "t")
+    monkeypatch.setattr(tool, "_client", _reached)
+    stale = _current(name="a")
+    del stale["required_status_checks"]
+    with pytest.raises(_ReachedCrawlError):
+        tool._crawl_org(_cache(tmp_path, [stale]), refresh=True)

--- a/tests/ol_infrastructure/saas/github/test_required_checks_tool.py
+++ b/tests/ol_infrastructure/saas/github/test_required_checks_tool.py
@@ -260,3 +260,47 @@ class TestRateLimitIsNotSwallowed:
     ) -> None:
         """A force-pushed-away head is a sample we cannot read, not a reason to stop."""
         assert self._run(monkeypatch, "gh: Not Found (HTTP 404)", 1) is None
+
+
+class TestPagination:
+    """A check the tool did not read must not become a check that was never produced.
+
+    Every endpoint `_checks_on` uses caps a page, and `/commits/{sha}/status` caps at 30
+    rather than 100. Reading one page silently drops the rest, which lands as a lower
+    `produced` against an unchanged `eligible` -- a SAFE name reported unsafe.
+    """
+
+    def _pages(self, monkeypatch: pytest.MonkeyPatch, pages: list[Any]) -> list[Any]:
+        calls = iter(pages)
+        monkeypatch.setattr(tool, "_gh", lambda *_a: next(calls, None))
+        return tool._gh_all("repos/o/r/thing", "items")
+
+    def test_follows_every_page(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        full = [{"n": i} for i in range(tool._PAGE)]
+        rest = [{"n": "last"}]
+        got = self._pages(
+            monkeypatch,
+            [{"items": full, "total_count": tool._PAGE + 1}, {"items": rest}],
+        )
+        assert len(got) == tool._PAGE + 1
+
+    def test_stops_on_a_short_page(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A page below the cap is the last one, so nothing further is requested."""
+        got = self._pages(monkeypatch, [{"items": [{"n": 1}]}, {"items": [{"n": 2}]}])
+        assert got == [{"n": 1}]
+
+    def test_stops_once_total_count_is_reached(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`total_count` ends it even when the page came back exactly full."""
+        full = [{"n": i} for i in range(tool._PAGE)]
+        got = self._pages(
+            monkeypatch, [{"items": full, "total_count": tool._PAGE}, {"items": full}]
+        )
+        assert len(got) == tool._PAGE
+
+    def test_an_unreadable_endpoint_yields_nothing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A 404 on a garbage-collected head is still tolerated, not paged forever."""
+        assert self._pages(monkeypatch, [None]) == []

--- a/tests/ol_infrastructure/saas/github/test_required_checks_tool.py
+++ b/tests/ol_infrastructure/saas/github/test_required_checks_tool.py
@@ -224,3 +224,39 @@ class TestDriftExitStatus:
         assert (
             self._run(monkeypatch, {"ci-gate": _evidence(produced=4, eligible=4)}) == 0
         )
+
+
+class TestRateLimitIsNotSwallowed:
+    """A 403 must not read as "this check was never produced".
+
+    Written from a live run: a full sample of three repos exhausted the core quota, and
+    the next command reported mit-learn's `openapi-diff` as ABSENT 0/0 minutes after
+    `drift` had reported the same context clean. Under the old behaviour that verdict is
+    indistinguishable from a context nothing produces, which is the one thing this tool
+    exists to detect.
+    """
+
+    def _run(self, monkeypatch: pytest.MonkeyPatch, stderr: str, code: int) -> Any:
+        class Result:
+            returncode = code
+            stdout = ""
+
+        Result.stderr = stderr  # type: ignore[attr-defined]
+        monkeypatch.setattr(tool.subprocess, "run", lambda *_a, **_k: Result())
+        return tool._gh("api", "anything")
+
+    def test_rate_limit_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The core-quota message `gh` prints when the hourly budget is gone."""
+        with pytest.raises(tool.RateLimitError):
+            self._run(monkeypatch, "API rate limit exceeded for user ID 1", 1)
+
+    def test_secondary_rate_limit_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The abuse-detection variant, which reads differently and matters the same."""
+        with pytest.raises(tool.RateLimitError):
+            self._run(monkeypatch, "You have exceeded a secondary rate limit", 1)
+
+    def test_a_missing_commit_is_still_tolerated(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A force-pushed-away head is a sample we cannot read, not a reason to stop."""
+        assert self._run(monkeypatch, "gh: Not Found (HTTP 404)", 1) is None

--- a/tests/ol_infrastructure/saas/github/test_required_checks_tool.py
+++ b/tests/ol_infrastructure/saas/github/test_required_checks_tool.py
@@ -1,0 +1,226 @@
+"""Tests for the scoring rule in `bin/github-required-checks`.
+
+This is the judgement that decides whether a name may be required at all, and getting it
+wrong is not a failed test run -- it is every PR on one of the org's busiest repos stuck
+on "Expected -- Waiting for status to be reported", with no dry run available to catch
+it first (see rulesets.py).
+
+The rule has to separate three things a raw "appeared on N of the last 40 PRs" cannot,
+all of them live in this org:
+
+    `Run zizmor`    1/40, because its workflow is path-filtered. NEVER requirable.
+    `ci-gate`       31/40 on ol-infrastructure, because it landed in #5567 on
+                    2026-08-24 and the misses are branches cut before it existed.
+                    Requirable, and the whole point of the SEC-03 work.
+    `test`          39/40, because pytest.yml never ran at all on #5590. Requirable;
+                    that PR needed a re-trigger under any ruleset.
+
+The first two sit at opposite verdicts with similar counts, so the tests below are
+mostly about which PRs are allowed to count as evidence.
+"""
+
+from __future__ import annotations
+
+import base64
+import importlib.util
+import sys
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+SCRIPT = Path(__file__).resolve().parents[4] / "bin" / "github-required-checks"
+
+
+def _load() -> Any:
+    """Import the CLI from a file with no `.py` on it.
+
+    The loader has to be handed over explicitly: `spec_from_file_location` picks one by
+    file extension, and there is not one to pick by here.
+    """
+    loader = SourceFileLoader("github_required_checks", str(SCRIPT))
+    spec = importlib.util.spec_from_file_location(loader.name, SCRIPT, loader=loader)
+    if spec is None or spec.loader is None:
+        msg = f"Unable to load {SCRIPT}"
+        raise RuntimeError(msg)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+tool = _load()
+
+
+def _evidence(*, produced: int, eligible: int, filtered: bool = False) -> Any:
+    found = tool.Evidence()
+    found.produced = produced
+    found.eligible = eligible
+    found.filtered = filtered
+    found.workflow = ".github/workflows/ci.yml"
+    return found
+
+
+def test_clean_over_a_thin_window_is_safe() -> None:
+    """`ci-gate` on mitxonline was 6/6 the day it was first required.
+
+    A short window is thin evidence, not bad evidence. Demanding a long one would make
+    every newly added job unrequirable for as long as it takes 20 PRs to merge, which is
+    the same as never requiring the gate this whole design rests on.
+    """
+    assert _evidence(produced=6, eligible=6).safe
+
+
+def test_one_miss_is_not_rounded_up() -> None:
+    """39/40 is a check some PR did not produce; requiring it blocks that PR."""
+    assert not _evidence(produced=39, eligible=40).safe
+
+
+def test_never_produced_is_not_safe() -> None:
+    """Requiring a name nothing has ever emitted is the DX-02 outage exactly.
+
+    It is also how "the ruleset landed before the gate job did" presents: mit-learn's
+    `ci-gate` sat at 0 until #3825 merged.
+    """
+    found = _evidence(produced=0, eligible=0)
+    assert not found.safe
+    assert found.verdict == "ABSENT"
+
+
+def test_path_filtered_is_never_safe_however_clean_it_looks() -> None:
+    """`Run zizmor` is 1/1 of the PRs that ran it, and requiring it blocks 39 in 40.
+
+    Counting alone cannot see this, which is why the verdict reads the workflow's `on:`
+    block instead. A perfect ratio over a filtered workflow is the trap.
+    """
+    found = _evidence(produced=1, eligible=1, filtered=True)
+    assert not found.safe
+    assert found.verdict == "FILTERED"
+
+
+class TestPathFilterDetection:
+    """`_workflow_at` decides `filtered` from the workflow file, not from history."""
+
+    def _filtered(self, monkeypatch: pytest.MonkeyPatch, source: str) -> bool:
+        monkeypatch.setattr(
+            tool,
+            "_gh",
+            lambda *_: {"content": base64.b64encode(source.encode()).decode()},
+        )
+        result = tool._workflow_at("repo", ".github/workflows/w.yml", "sha")
+        assert result is not None
+        return result[1]
+
+    def test_paths_filter_is_detected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The `Run zizmor` shape, and the reason the verdict reads the file."""
+        assert self._filtered(
+            monkeypatch,
+            "on:\n  pull_request:\n    paths: ['.github/workflows/**']\njobs:\n"
+            "  zizmor:\n    name: Run zizmor\n",
+        )
+
+    def test_paths_ignore_is_detected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The other half of the filter syntax, equally disqualifying."""
+        assert self._filtered(
+            monkeypatch,
+            "on:\n  pull_request:\n    paths-ignore: ['docs/**']\njobs:\n  test:\n",
+        )
+
+    def test_unfiltered_workflow_is_not(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """`on: [push]` is the shorthand both mit-learn and mitxonline ci.yml use.
+
+        It parses to a list rather than a mapping, and reading `.values()` off it would
+        raise -- which, in a tool whose failures are silent, would be one more silent
+        failure.
+        """
+        assert not self._filtered(monkeypatch, "on: [push]\njobs:\n  test:\n")
+
+    def test_yaml_reads_bare_on_as_the_boolean_true(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """YAML 1.1, which pyyaml still implements, parses the key `on` as `True`.
+
+        So a workflow whose filter is under an unquoted `on:` would look unfiltered --
+        and an unfiltered path-filtered workflow is a requirable-looking `Run zizmor`.
+        """
+        source = "on:\n  push:\n    paths: ['a/**']\njobs:\n  test:\n"
+        assert True in yaml.safe_load(source)
+        assert self._filtered(monkeypatch, source)
+
+
+class TestJobNameMatching:
+    """A check-run is named for its job: `name:` if set, else the id, plus `(..)`."""
+
+    def test_matches_the_job_id(self) -> None:
+        """`ci-gate` sets no `name:`, so the id is what GitHub reports."""
+        assert tool._defines({"test", "ci-gate"}, "ci-gate")
+
+    def test_matches_a_matrix_shard(self) -> None:
+        """One job named `python-tests` reports as `python-tests (1)`..`(4)`.
+
+        The matrix values are not reconstructable from the workflow file without
+        evaluating the matrix, so the match is by prefix.
+        """
+        assert tool._defines({"python-tests"}, "python-tests (3)")
+
+    def test_does_not_match_an_unrelated_prefix(self) -> None:
+        """`python-tests` must not vouch for a `python-tests-slow` nothing defines."""
+        assert not tool._defines({"python-tests"}, "python-tests-slow")
+
+    def test_a_job_the_commit_does_not_define_is_not_matched(self) -> None:
+        """The case that makes `ci-gate` requirable: a branch cut before it existed."""
+        assert not tool._defines({"test", "javascript-tests"}, "ci-gate")
+
+
+class TestDriftExitStatus:
+    """`drift` is only useful to CI if a reported failure also fails the process.
+
+    Written after a revision of this file reported mit-learn's missing `ci-gate` in full
+    and still exited 0, which in CI is indistinguishable from a clean fleet.
+    """
+
+    def _run(self, monkeypatch: pytest.MonkeyPatch, evidence: dict[str, Any]) -> int:
+        monkeypatch.setattr(tool, "_declared", lambda: {"repo": ["ci-gate"]})
+        monkeypatch.setattr(
+            tool, "_merged", lambda *_: [{"number": 1, "headRefOid": "a"}]
+        )
+        monkeypatch.setattr(tool, "_read", lambda *_: (evidence, {}))
+        try:
+            tool.drift(prs=1)
+        except SystemExit as exit_called:
+            return int(exit_called.code or 0)
+        return 0
+
+    def test_a_context_nothing_produces_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The ordering trap: the ruleset declared before the gate job merged."""
+        assert self._run(monkeypatch, {}) == 1
+
+    def test_a_context_that_stopped_being_produced_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A renamed job or a resized matrix, two repos away from the symptom."""
+        assert (
+            self._run(monkeypatch, {"ci-gate": _evidence(produced=3, eligible=4)}) == 1
+        )
+
+    def test_a_path_filtered_context_fails(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Clean on every PR that ran it, and still blocks the ones that did not."""
+        assert (
+            self._run(
+                monkeypatch,
+                {"ci-gate": _evidence(produced=4, eligible=4, filtered=True)},
+            )
+            == 1
+        )
+
+    def test_a_clean_fleet_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """CI must stay green when nothing has drifted."""
+        assert (
+            self._run(monkeypatch, {"ci-gate": _evidence(produced=4, eligible=4)}) == 0
+        )

--- a/tests/ol_infrastructure/saas/github/test_required_status_checks.py
+++ b/tests/ol_infrastructure/saas/github/test_required_status_checks.py
@@ -1,0 +1,88 @@
+"""Tests for the `required_status_checks` fleet-data guard.
+
+This validator is unlike the others in archetypes.py: it is not standing between bad
+data and a crash, it is standing between bad data and a SILENT OUTAGE. rulesets.py will
+build a ruleset from any list of strings and GitHub will accept it, and because the
+Team plan has no `evaluate` enforcement mode there is no state between "not
+enforced" and "enforced on the org's busiest repos". A context nothing produces
+leaves every PR on that repo permanently pending.
+
+So the cases worth writing are the ones where the data is well-formed and still wrong.
+"""
+
+from typing import Any
+
+import pytest
+
+from ol_infrastructure.saas.github.repositories import archetypes
+
+
+def _check(*repos: dict[str, Any]) -> None:
+    archetypes._check_required_status_checks(list(repos))
+
+
+def test_no_declaration_is_fine() -> None:
+    """Most of the fleet declares nothing, and that must stay silent."""
+    _check({"name": "quiet"})
+    _check({"name": "quiet", "required_status_checks": []})
+
+
+def test_accepts_plain_context_names() -> None:
+    _check({"name": "ol-infrastructure", "required_status_checks": ["test"]})
+
+
+def test_rejects_declaration_on_an_archived_repo() -> None:
+    """GitHub refuses ruleset writes on an archived repo, so it is unsatisfiable."""
+    with pytest.raises(ValueError, match="archived"):
+        _check({"name": "old", "archived": True, "required_status_checks": ["test"]})
+
+
+@pytest.mark.parametrize("bad", [[""], ["   "], [None], ["ok", ""], "test"])
+def test_rejects_empty_or_non_string_contexts(bad: Any) -> None:
+    """An empty context blocks the branch while naming nothing in the UI.
+
+    A bare string rather than a list is in here because YAML makes it easy: writing
+    `required_status_checks: test` silently yields the string, which would iterate into
+    four single-character contexts.
+    """
+    with pytest.raises(ValueError, match="list of non-empty strings"):
+        _check({"name": "repo", "required_status_checks": bad})
+
+
+def test_rejects_matrix_shard_names_without_the_opt_in() -> None:
+    """Mitxonline's `python-tests (1)`..`(4)` are the live example.
+
+    In February 2026 that repo produced one check named `python-tests`; a commit on
+    2026-07-23 sharded it four ways and the old name has never appeared since. Requiring
+    a shard name is legal and works today, which is exactly why it needs to be
+    deliberate: the edit that breaks it happens in a different repository.
+    """
+    with pytest.raises(ValueError, match="matrix shard names"):
+        _check({"name": "mitxonline", "required_status_checks": ["python-tests (1)"]})
+
+
+def test_allows_matrix_shard_names_when_opted_in() -> None:
+    _check(
+        {
+            "name": "mitxonline",
+            "required_status_checks": ["python-tests (1)", "python-tests (2)"],
+            archetypes.MATRIX_OPT_IN: True,
+        }
+    )
+
+
+def test_error_names_every_offender_at_once() -> None:
+    """Reporting one repo per run makes fixing a fleet a game of whack-a-mole."""
+    with pytest.raises(ValueError, match="would block merges") as caught:
+        _check(
+            {"name": "alpha", "archived": True, "required_status_checks": ["test"]},
+            {"name": "beta", "required_status_checks": ["shard (1)"]},
+        )
+    assert "alpha" in str(caught.value)
+    assert "beta" in str(caught.value)
+
+
+def test_error_points_at_the_verification_tool() -> None:
+    """The fix is always "go check what the repo actually produces"."""
+    with pytest.raises(ValueError, match="github-required-checks"):
+        _check({"name": "repo", "required_status_checks": ["thing (1)"]})


### PR DESCRIPTION
## What are the relevant tickets?

SEC-03 / DX-02 / DX-03 from the GitHub org import audit (`docs/plans/github-org-pulumi-import.md` §7). Task `tk-sec-03-dx-02-dx-03-no-repo-requires-any-status-c-b2d569`.

## Description

**72 of the org's 74 active tier-1 repos require no status check**, so a red build does not stop a merge on any of them (checked live across all 74 on 2026-08-21). The two exceptions, `lehrer` and `ol-analytics-api`, solved it themselves with hand-made repo-level rulesets.

That gap cost us a broken `main`. Renovate auto-merged mit-learn #3812-#3816 in 71 seconds, two of them with `python-tests` already failing on their own branch, reverted by #3822 three hours later. The same pattern had been running here unnoticed: **12 of ol-infrastructure's last 40 merges landed with `test` red, and all 12 were Renovate auto-merges** (#5529-#5537, #5553-#5555).

Auto-merge is not the cause. It waits for "all required reviews and status checks"; with zero required checks that wait is instant, leaving the `renovate-approve` App's approval as the only gate (confirmed on #3812). The empty list is the defect.

### What lands

An earlier revision of this PR required each repo's job names one by one. That list is gone: what lands is the **aggregate gate job** the same revision filed as follow-up, which has since been built in all three repos.

| repo | required contexts | gate job landed |
|---|---|---|
| ol-infrastructure | `ci-gate` | #5567, 2026-08-24 |
| mitxonline | `ci-gate` | #3876, 2026-08-25 |
| mit-learn | `ci-gate`, `openapi-diff` | #3825, merged 2026-08-28 |

Each `ci-gate` job `needs:` every other job in its workflow and runs under `if: always()` (without which a failed dependency skips the gate, and GitHub reads a skipped required check as satisfied). Requiring the one context therefore covers the whole suite, and a matrix resize or a job rename is one edit in the repo that owns the jobs rather than an edit here that somebody has to remember.

That closes the failure the enumerated lists could not. mitxonline's `python-tests` became `python-tests (1)`..`(4)` in July; under a list of names the sharding PR blocks itself, somebody bypasses it because the tests plainly pass, and every mitxonline PR after that blocks forever, with the cause in one repo and the symptom in another. `needs:` on a matrix job aggregates every shard, so no shard count appears here at all.

`mit-learn` also requires `openapi-diff`, by its own job name. `needs:` only reaches jobs in the same workflow file, and that check lives in `openapi-diff.yml` on a `pull_request` trigger while `ci-gate` sits in `ci.yml` on `push`, so no gate can absorb it.

Giving that workflow a gate of its own was tried and reverted (mitodl/mit-learn#3856, closed). It has one job and no matrix, so a gate protects against nothing but a rename of that single job, and charges a required context with no history, an extra job on every PR, and a second repo that has to merge before this stack can be applied. `openapi-diff` has reported on 40 of the last 40 mit-learn PRs, and a rename surfaces in `drift` as a loud CI failure rather than a wedged repo.

Requiring it at all is safe only because #3825 also gave it an `--err-ignore` allowlist (`openapi/oasdiff-err-ignore.txt`). Before that, `oasdiff breaking --fail-on ERR` went red on *intentional* breaking API changes — red at merge on 8 of the last 40 mit-learn PRs, release PRs included — and requiring it would have forced a bypass on every deliberate API change, which trains people to bypass. Now such a change adds a reviewed line in the repo that made it. **If that allowlist proves unusable, drop `openapi-diff` from mit-learn's YAML; `ci-gate` is unaffected.**

### The verification tool was wrong about all three gates

`bin/github-required-checks` scored a name by how many of the last N merged PRs produced it, and by that rule none of these gates could ever be required. A percentage cannot separate three different things:

| name | count | what it is |
|---|---|---|
| `Run zizmor` | 1/40 | path-filtered workflow. **Never** requirable |
| `ci-gate` | 31/40 | landed in #5567; every miss is a branch cut before it existed |
| `test` | 39/40 | pytest.yml never ran at all on #5590 |

So a check is now scored only against merged PRs **whose head commit defines the job and whose workflow actually ran**, which makes the verdict exact rather than a threshold to argue about. Path filters are read from the workflow's `on:` block rather than inferred from a count, so a clean ratio over a filtered workflow (`Run zizmor` is 1/1 of the PRs that ran it) is refused outright. A workflow that no-showed entirely gets its own reported line instead of being shaved off every name's percentage.

Under that rule: `ci-gate` is 30/30 on ol-infrastructure and 6/6 on mitxonline, `test` is 39/39, `Run zizmor` is FILTERED.

### Sampling cannot see what this would hang, so `blocked` reads open PRs

A gate that landed last week is clean on every merged PR that could have produced it and still blocks any **open** PR branched before it, because that branch does not define the job — there is no failure to look at, just a check that never reports. `bin/github-required-checks blocked` lists them by name and exits non-zero. Measured 2026-08-28, after mit-learn #3825 merged:

| repo | open PRs that would hang |
|---|---|
| mit-learn | 43 of 44 |
| mitxonline | 37 of 44 |
| ol-infrastructure | 18 of 46 (this PR among them) |

Each needs a rebase past the gate commit, not a re-run. Renovate rebases its own. **This is the number to drive down before `pulumi up`, and it is why `blocked` exists.**

### There is still no dry run

`enforcement: evaluate` does not exist on the Team plan, and a context that does not exactly match a real check-run name blocks every PR on that repo permanently. `drift` now also fails a context that has never been produced at all, which is how "the ruleset landed before the gate job did" surfaces here rather than as every PR on that repo hanging. It caught exactly that twice during this work, and passes clean on all three repos now that #3825 has merged.

And the tool no longer degrades quietly when the API stops answering. `_gh` swallowed every failure including the 403 that arrives once a full sample exhausts the hourly quota, so an unread check became indistinguishable from a check that was never produced: a real run reported mit-learn's `openapi-diff` as `ABSENT 0/0` minutes after `drift` had reported the same context clean. Rate-limit failures now abort with exit 2; a 404 on a garbage-collected head is still tolerated.

### Bypass

Mirrors `_ADMIN_BYPASS` from the org rulesets (owners `always`, `odl-engineering` and `arbisoft-contractors` at `pull_request`), so this stays advisory for humans on those teams. It still closes the measured failure: bypass actors are teams, and `renovate[bot]` is in none of them.

## How can this be tested?

`pulumi preview` on `ol-saas-github-repositories`: **3 to create, 1519 unchanged**. The three rulesets and no collateral drift.

```
uv run pytest tests/ol_infrastructure/saas/github/          # 76 passed
uv run bin/github-required-checks sample ol-infrastructure mitxonline --prs 40
uv run bin/github-required-checks blocked                   # exits 1 today
uv run bin/github-required-checks drift --prs 20            # clean
```

## Merge order

1. ~~mit-learn #3825~~ merged 2026-08-28, so every required context is now produced and `drift` is clean.
2. Drive `blocked` down (rebases), then `pulumi up`.

## Follow-up, not in this PR

`platformAutomerge: false` in `mitodl/.github`'s Renovate config would make Renovate wait for tests itself, org-wide, in one line.

`lehrer` and `ol-analytics-api`'s existing rulesets remain unmanaged; importing them is worth a follow-up so `_required_status_checks_live` can go away.

Wiring `drift` into CI is the natural home for it now that it fails on both drift directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W12xGfn3bSRsbuYXEBJmCe
