### PR TITLE
ci: add a ci-gate job so one required check can cover the whole workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -33,3 +33,46 @@ jobs:
 
     - name: Run tests
       run: uv run pytest
+
+  # ONE required status check standing for this whole workflow.
+  #
+  # Today this wraps a single job, so it changes nothing on its own. It exists for the
+  # second job: GitHub's required status checks take an exact list of context names,
+  # with no wildcards and no "all checks must pass" option, so a job added here is not
+  # required until somebody separately edits the ruleset in
+  # src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml.
+  # Until they do, the new CI runs and cannot block a merge -- which is audit rule
+  # DX-03, and the reason this repo's own SEC-03 work exists.
+  #
+  # Requiring `ci-gate` keeps the list of what must pass in the same file as the jobs it
+  # names. `Run zizmor` is not here: it lives in actions-static-analysis.yml, and
+  # `needs` cannot cross workflows. It is also path-filtered, so it must never be
+  # required directly -- a workflow that does not trigger reports nothing at all and
+  # would leave every unrelated PR pending forever.
+  ci-gate:
+    needs: [test]
+    # Without this the gate is skipped when a dependency fails, and a skipped required
+    # check leaves the PR pending rather than failing it.
+    if: always()
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+    - name: Evaluate CI result
+      env:
+        NEEDS: ${{ toJSON(needs) }}
+      run: |
+        set -euo pipefail
+        echo "$NEEDS" | jq -r 'to_entries[] | "\(.key): \(.value.result)"'
+        # Read from `needs` rather than naming each job again: adding a job to the list
+        # above is then the only edit, which is the entire point of this job. `skipped`
+        # passes so that a job legitimately gated behind an `if:` does not wedge the
+        # branch; `failure` and `cancelled` do not.
+        failed=$(echo "$NEEDS" | jq -r '
+          to_entries[]
+          | select(.value.result != "success" and .value.result != "skipped")
+          | .key')
+        if [ -n "$failed" ]; then
+          echo "::error::CI did not succeed: $(echo "$failed" | paste -sd, -)"
+          exit 1
+        fi
+        echo "All CI jobs succeeded."

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -51,8 +51,8 @@ jobs:
   # would leave every unrelated PR pending forever.
   ci-gate:
     needs: [test]
-    # Without this the gate is skipped when a dependency fails, and a skipped required
-    # check leaves the PR pending rather than failing it.
+    # Without this the gate is skipped when a dependency fails, and GitHub treats a
+    # skipped required job as successful, allowing the PR to merge despite the failure.
     if: always()
     runs-on: ubuntu-latest
     permissions: {}


### PR DESCRIPTION
## What are the relevant tickets?

Part of the SEC-03 work in #5566, task `tk-add-aggregate-ci-ok-gate-jobs-so-required-checks-6b3181`. Companion to mitodl/mitxonline#3876 and mitodl/mit-learn#3825.

## Description

**Today this wraps a single job and changes nothing.** It exists for the second job, and it's the least consequential of the three gate PRs — worth saying up front.

GitHub's required status checks take an **exact list of context names**, with no wildcards and no "all checks must pass" option ([community#154621](https://github.com/orgs/community/discussions/154621)). So a job added to `pytest.yml` isn't required until somebody separately edits `src/ol_infrastructure/saas/github/repositories/data/repos/ol-infrastructure.yaml`. Until they do, the new CI runs and cannot block a merge — which is audit rule DX-03, and the reason the SEC-03 work exists at all.

A renamed job is worse: it stays required under a name GitHub will never report again, and every PR waits on it forever. mitxonline hit exactly that when `python-tests` became a 4-way matrix.

`ci-gate` keeps the list of what must pass in the same file as the jobs it names.

`Run zizmor` is deliberately **not** covered, for two independent reasons:

1. It lives in `actions-static-analysis.yml`, and `needs` cannot cross workflows.
2. It's path-filtered to `.github/workflows/**`, so it must never be required directly. A workflow that doesn't trigger reports nothing at all, which would leave every unrelated PR pending forever. It ran on 1 of the last 40 merged PRs.

Follows the same shape as the other two gate PRs and the existing `gate` jobs in `mitodl/lehrer`: plain shell over `needs.<job>.result`, no third-party action.

## How can this be tested?

`ci-gate` should appear as a new check on this PR and pass alongside `test`. The evaluation logic was exercised against each case before pushing:

| `needs` results | gate |
|---|---|
| all success | pass |
| one job failed | fail |
| a job cancelled | fail |
| one job skipped | pass |
| everything failed | fail |

`skipped` passes so a job legitimately behind an `if:` can't wedge the branch; `failure` and `cancelled` don't.

`actionlint` and `zizmor` pass on the changed file.

## Follow-up

Once this and the other two land and `ci-gate` has reported on a few PRs, each repo's `required_status_checks` in this repo swaps to `[ci-gate]`. **That swap must come after** — requiring a context that has never been produced blocks every PR immediately, and there is no dry-run enforcement mode on the Team plan.

Note this PR touches a workflow file, so `Run zizmor` will itself trigger here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QygRcd6WF4BmUi1C5cez4d
