### PR TITLE
fix(concourse): repair iam-policy-drift and github-estate-drift pipelines

### DIFF
--- a/bin/analyze-pulumi-iam-usage
+++ b/bin/analyze-pulumi-iam-usage
@@ -132,7 +132,9 @@ def _generate_policy_from_cloudtrail(
     poll_interval_seconds: int,
     timeout_seconds: int,
 ) -> set[str]:
-    end_time = datetime.now(UTC) - timedelta(minutes=1)
+    # IAM Access Analyzer rejects timestamps with sub-second precision, which
+    # botocore's default datetime serialization includes.
+    end_time = (datetime.now(UTC) - timedelta(minutes=1)).replace(microsecond=0)
     start_time = end_time - timedelta(days=lookback_days)
     job_id = client.start_policy_generation(
         policyGenerationDetails={"principalArn": role_arn},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dependencies = [
   "ol-concourse>=0.16,<0.17",
   "pulumiverse-grafana>=2.0.0,<3",
   "pulumiverse-sentry==0.0.9",
+  "pyjwt[crypto]>=2.9,<3",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -1540,6 +1540,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyinfra" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "requests" },
     { name = "requests-aws4auth" },
 ]
@@ -1598,6 +1599,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2,<3" },
     { name = "pydantic-settings", specifier = ">=2.0.1,<3" },
     { name = "pyinfra", specifier = "~=3.0" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.9,<3" },
     { name = "requests", specifier = ">=2.32,<3" },
     { name = "requests-aws4auth", specifier = ">=1.3.1" },
 ]


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Fixes two Concourse pipelines found broken during a failure sweep:

- **iam-policy-drift** (`check-pulumi-infra-iam-drift`): `bin/analyze-pulumi-iam-usage` passed `datetime.now(UTC)`-derived timestamps straight to IAM Access Analyzer's `StartPolicyGeneration` API. Botocore serializes those with microsecond precision, which the API rejects (`string "...T...Z" is invalid against requested date format(s)`), so every run has been failing. Truncate to whole seconds with `.replace(microsecond=0)`.
- **github-estate-drift** (`check-github-estate-drift`): `src/ol_infrastructure/lib/github_helper.py` imports `jwt` (PyJWT) to sign GitHub App JWTs, but PyJWT was never declared as a project dependency, so the task image doesn't have it and the job fails with `ModuleNotFoundError: No module named 'jwt'`. Added `pyjwt[crypto]` (the `crypto` extra is required for the `RS256` algorithm used to sign the App JWT) to `pyproject.toml` and re-locked.

### How can this be tested?
Ran locally in the worktree, not against the live pipelines (both tasks pull from `main`, so the fix only takes effect once merged):
- `uv lock` resolved cleanly with the new `pyjwt[crypto]` dependency.
- `uv run python -c "import jwt"` succeeds in the synced venv.
- `bin/analyze-pulumi-iam-usage` still compiles/parses after the datetime fix; didn't have a way to invoke the real Access Analyzer call locally.
- `pre-commit` (ruff format/check, mypy, toml check) passes on the changed files.

Reviewer can confirm by watching the next scheduled `iam-policy-drift` and `github-estate-drift` runs on https://cicd.odl.mit.edu (infrastructure team) after this merges.

### Additional Context
Found via a broader sweep of failing Concourse pipelines/jobs on the `infrastructure` team. Several other failures were found (an IAM permissions regression on the Concourse worker role from #5546, a stale Pulumi StackReference output, a missing Pulumi stack, a TLS subscription conflict, and a crashlooping K8s pre-deploy job) — those are separate, unrelated fixes and are being tracked/addressed independently.
