### PR TITLE
feat(grafana): route APISIX edge SLO alerts to Slack, ending calibration

### DIFF
--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/apisix_edge.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/apisix_edge.py
@@ -31,6 +31,16 @@ That is a ~288x margin below and ~8x above. Note the gate is deliberately
 absolute, not a percentile: it answers "is anyone actually using this host",
 which is what makes a ratio meaningful.
 
+The gate is a floor on *sustained* traffic, not a guarantee against small
+denominators. Re-measured 2026-08-24 over the 14-day calibration window,
+courses-backend.learn.mit.edu peaks at 0.897 req/s in its busiest 10m while
+sitting at 0.0016 req/s on median: a bursty host opens the gate during a burst,
+and a handful of 5xx inside that burst still trips the ratio. Its 14 Fast
+firings are that, not a broken gate -- and with 674 real 5xx over the window
+they are not false either. Raising `_MIN_RATE` to suppress them would also
+raise it past api.mitxonline.mit.edu (0.054 req/s), the host these rules exist
+for, so the gate stays where it is.
+
 Gate clause first
 -----------------
 The gate is written as the LEFT operand of `and` in every expression. PromQL's
@@ -41,31 +51,73 @@ but the gate on the left is the safer idiom and matches the reasoning already
 documented at eks_general.py:108-116 -- put the clause whose value you want to
 survive on the left, every time, rather than reasoning case by case.
 
-Calibration: these rules carry NO severity label
+Calibration is over: these rules deliver to Slack, not Rootly
+-------------------------------------------------------------
+They shipped 2026-08-10 carrying no labels at all, which routed them to
+alertmanager.py's default `oblivion` receiver -- evaluated and recorded, but
+delivered nowhere -- so that a firing history could be built with zero paging
+risk while the thresholds were still guesses. That window closed 2026-08-24 and
+the history was measured (`grafanacloud-alert-state-history`, 14d):
+
+  Fast  191 firings, 13.6/day. api.mitxonline.mit.edu alone is 139 of them (73%),
+        all one known-open defect (ol-django#538). Then studio.courses.learn 20,
+        courses-backend.learn 14, analytics.learn 4, opik 4, studio-staging 4,
+        courses.xpro 2, studio.mitx 2, nb.learn 1, staging.mitx 1.
+  Slow  23 firings, 1.6/day. studio.courses.learn 10, courses-backend.learn 3,
+        studio-staging 3, api.mitxonline 2, opik 2, studio.mitx 2, analytics 1.
+
+`severity` alone would not have been a safe promotion. In alertmanager.py's
+route tree `warning` and `critical` terminate at the *same* `rootly` contact
+point, so labelling these `severity=warning` sends 15 pages/day to the
+production on-call -- into a remediation effort whose whole premise is that the
+current ~48/day is too many, and with 73% of it one already-tracked defect.
+
+So they carry `channel=devops-warnings` as well, which alertmanager.py routes to
+the #devops-warnings Slack channel and terminates before either severity route
+is reached. That is a strict improvement on `oblivion` (the signal is now
+visible to a human) at zero paging cost. `severity` still rides along and picks
+the Slack formatting: Fast is a cliff, so `critical` (red :alert:); Slow is a
+creep, so `warning` (yellow).
+
+Promote to paging by emptying `_PRODUCTION_ROUTING` below -- the rules then fall
+through to the `severity` routes and reach Rootly. Do that once
+api.mitxonline.mit.edu (ol-django#538) and studio.courses.learn.mit.edu are
+fixed and the baseline firing rate reflects real incidents rather than two
+known-broken hosts. Re-measure first, with the query at the bottom of this
+docstring.
+
+One promotion caveat from the original calibration note is now resolved:
+api.learn.mit.edu sat at 1.09% when these rules were written, just above the
+slow rule's 1% line, and was flagged as needing a deliberate threshold decision.
+Re-measured 2026-08-24 it runs 0.005% 5xx on 53 req/s -- the busiest host at the
+edge -- and fired neither rule once in 14 days. No threshold change needed.
+
+Every host in the production stack is production
 ------------------------------------------------
-Deliberate, and the reason is in alertmanager.py's route tree: the default
-receiver is `oblivion`, so an alert with no `severity` is evaluated and recorded
-but delivered nowhere. That gives a full firing history in
-`grafanacloud-alert-state-history` -- the same source used to measure every claim
-above -- with zero paging risk while the thresholds are still guesses.
+Worth stating because the hostnames suggest otherwise: `staging.mitx.mit.edu`
+and its `*-staging.mitx.mit.edu` siblings are NOT a non-production tier of
+mitx. `mitx-staging` is a peer deployment of `mitx` with its own VPC and its own
+CI/QA/Production stacks (infrastructure/aws/network/__main__.py:157,
+`Pulumi.mitx-staging.Production.yaml`), serving residential course authors who
+write courses as XML and push to GitHub instead of using the Studio UI. Its
+firings above are production signal and are treated as such -- do not add a
+hostname filter to exclude them.
 
-Promote by adding `labels={"severity": "warning"}` (then "critical") once the
-history shows what they actually catch. Do not promote before checking
-api.learn.mit.edu: it sat at 1.09% when these were written, just above the slow
-rule's 1% line, and needs a deliberate decision (raise the threshold to 2%, or
-accept it as the genuine signal its 304,860 absolute 502s/30d suggest).
-
-Adding that label is the *only* change promotion needs, but only because
-`matched_host` was added to `NotificationPolicy.group_bies` in alertmanager.py
-alongside these rules. These aggregate `sum by (matched_host)`, so that is the
-one resource-identifying label they carry; without it in the grouping list every
-firing host would collapse into a single notification group per rule and one
-host changing state would resend all the others. If you add a rule here that
-groups by something else, add that label there too.
+So there is no host class to split on here, and the environment boundary is the
+stack boundary alone. This module is deployed to every stack, each pointing at
+its own Grafana Cloud stack and Mimir tenant; the CI and QA stacks are
+non-production in their entirety and pin `channel` separately in `create()` so
+that promoting production cannot reach them. That is also the only split that
+would be reliable: QA host naming is far too irregular to match (`.rc.`, `-rc.`,
+`.qa.`, `-qa.`, `-qa-draft.`, and a bare leading `rc.mitxonline.mit.edu` all
+coexist), and a regex that silently missed one would page the on-call for a QA
+host. `parse_stack()` already knows the answer, so ask it instead of inferring.
+Same pattern as synthetic_monitoring.py:357.
 
 Measure with:
-  sum by (ruleTitle) (count_over_time(
-    {from="state-history"} | json | current =~ `Alerting.*` [14d]))
+  sum by (ruleTitle, labels_matched_host) (count_over_time(
+    {from="state-history"} | json | current="Alerting"
+    | ruleTitle=~`APISIXEdge5xx.*` [14d]))
 """
 
 from collections.abc import Callable
@@ -73,10 +125,24 @@ from collections.abc import Callable
 from pulumi import Input, ResourceOptions
 from pulumiverse_grafana import alerting
 
+from ol_infrastructure.lib.pulumi_helper import parse_stack
+
 # Requests/sec a host must sustain over the same window as the ratio before its
 # error ratio is treated as meaningful. See the module docstring for the measured
 # values this sits between.
 _MIN_RATE = "0.01"
+
+# Route to the #devops-warnings Slack channel rather than Rootly. See
+# alertmanager.py's `channel` branch, and the calibration section of the module
+# docstring for why this is here instead of a bare `severity`.
+_SLACK_CHANNEL = "devops-warnings"
+
+# Routing labels for the production stack, on top of each rule's own `severity`.
+# Emptying this dict is the whole of promoting these rules to paging: with no
+# `channel` they fall through alertmanager.py's severity routes to Rootly.
+# Deliberately separate from the CI/QA branch in `create()`, which pins
+# `channel` unconditionally -- so that edit cannot page for a QA host.
+_PRODUCTION_ROUTING = {"channel": _SLACK_CHANNEL}
 
 
 def _error_ratio_expr(window: str, threshold: str) -> str:
@@ -100,6 +166,14 @@ def create(
     resource_opts: ResourceOptions,
 ) -> None:
     """Create APISIX edge 5xx rate alert rule groups."""
+    if parse_stack().env_suffix == "production":
+        routing = _PRODUCTION_ROUTING
+    else:
+        # CI and QA are non-production in their entirety. Pinned here rather
+        # than read from `_PRODUCTION_ROUTING` so that promoting production
+        # leaves these stacks on Slack. See the module docstring.
+        routing = {"channel": _SLACK_CHANNEL}
+
     alerting.RuleGroup(
         "apisix-edge-error-rate",
         name="apisix-edge-error-rate",
@@ -112,9 +186,10 @@ def create(
                 for_="5m",
                 no_data_state="OK",
                 exec_err_state="OK",
-                # No severity label: routes to `oblivion` while calibrating.
-                # See the module docstring.
-                labels={},
+                # A cliff, not a creep -- `critical` picks the red :alert:
+                # Slack formatting. See the module docstring on why `channel`
+                # rides along with it.
+                labels={"severity": "critical", **routing},
                 annotations={
                     "summary": "{{ $labels.matched_host }} is returning over 5% 5xx at the APISIX edge",
                     "description": "More than 5% of requests to {{ $labels.matched_host }} returned a 5xx status at the APISIX edge over the last 10 minutes. This measures what clients actually receive, not one service's own view of itself.",
@@ -127,7 +202,7 @@ def create(
                 for_="30m",
                 no_data_state="OK",
                 exec_err_state="OK",
-                labels={},
+                labels={"severity": "warning", **routing},
                 annotations={
                     "summary": "{{ $labels.matched_host }} has been returning over 1% 5xx for hours",
                     "description": "More than 1% of requests to {{ $labels.matched_host }} returned a 5xx status at the APISIX edge over the last 6 hours. This catches a slow error-rate creep that a short-window threshold cannot: api.mitxonline.mit.edu climbed from 0% to 25% over four weeks in July 2026 without tripping any existing rule.",


### PR DESCRIPTION
## What

Ends the 14-day calibration window on the two APISIX edge 5xx SLO rules by giving them a delivery destination. They now carry `channel=devops-warnings` + `severity`, routing to the #devops-warnings Slack channel instead of `oblivion`.

Queries are unchanged. The only diff is labels:

```
~ [0] APISIXEdge5xxRateFast   + channel: devops-warnings, + severity: critical
~ [1] APISIXEdge5xxRateSlow   + channel: devops-warnings, + severity: warning
```

## Why not `severity` alone, as originally planned

The rules shipped 2026-08-10 with no labels so they'd land in `alertmanager.py`'s `oblivion` default receiver — evaluated and recorded, delivered nowhere — while the thresholds were still guesses. The plan was to promote with `labels={"severity": "warning"}`.

The history says that isn't safe. Measured over the full window (`grafanacloud-alert-state-history`, 14d):

| rule | firings | /day | top firer |
|---|---|---|---|
| Fast (>5%/10m) | 191 | 13.6 | api.mitxonline 139 (73%) |
| Slow (>1%/6h) | 23 | 1.6 | studio.courses.learn 10 |

`warning` and `critical` terminate at the **same** `rootly` contact point (`alertmanager.py:340-362`), so `severity=warning` means ~15 pages/day to the production on-call — inside a remediation effort whose premise is that the current ~48/day is already too many (holistic analysis §37), and with 73% of it one already-tracked defect (ol-django#538, still open: SCIM PATCH null → unbounded 500 retry loop on api.mitxonline).

`channel=devops-warnings` matches a branch that terminates before either severity route. Signal reaches a human, nothing pages. `severity` still rides along to pick the Slack formatting: Fast is a cliff (critical, red `:alert:`), Slow is a creep (warning, yellow).

Promotion to paging is now a one-line edit: empty `_PRODUCTION_ROUTING`. Gated on api.mitxonline and studio.courses.learn being fixed first. CI/QA pin `channel` in their own branch so that edit can't page for a QA host.

## Findings from re-measuring

- **`api.learn.mit.edu` caveat resolved.** The original note flagged it at 1.09%, just above the slow rule's 1% line, as needing a deliberate threshold decision. It now runs 0.005% 5xx on 53 req/s — the busiest host at the edge — and fired neither rule once in 14 days. No threshold change.
- **`courses-backend.learn`'s 14 firings are not a broken gate.** It peaks at 0.897 req/s in its busiest 10m against a 0.0016 median: a bursty host opens the `_MIN_RATE` gate during a burst, and 5xx inside that burst trip the ratio. 674 real 5xx over the window, so not false either. Raising the gate would push it past api.mitxonline (0.054 req/s), the host these rules exist for — so it stays.
- **`studio.courses.learn.mit.edu` has moved up sharply.** The 30-day analysis listed it at 1.65% (§4.2), the lowest entry in that table and not a priority at the time. Over the calibration window it is the #2 Fast firer and #1 Slow firer: 4,385 500s in 14d, baseline 0% with discrete spikes to 15/22/30%. Episodic breakage, real. Filing separately.
- **`mitx-staging` is production.** An earlier draft of this change filtered `staging.mitx.mit.edu` and siblings out as non-production. They're a peer deployment of `mitx` with their own VPC (`infrastructure/aws/network/__main__.py:157`) and their own CI/QA/Production stacks, serving residential course authors on the XML/GitHub workflow. Their firings are production signal; the filter was removed and the docstring now says so explicitly so it isn't re-added.

## Verification

- `pulumi preview` on **Production** and **QA**: `~ 1 to update`, labels only, no recreation, 35/32 resources unchanged.
- All four rendered PromQL shapes executed against the live prod and QA Mimir tenants before commit.
- `pre-commit` (ruff format, ruff check, mypy, detect-secrets) passes.

Deploy is not yet applied — these are preview results only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JwWrVw9wrBmp8oSRnr3ess
