### PR TITLE
fix(concourse): raise iam-policy-drift's Access Analyzer poll timeout

### DIFF
--- a/bin/analyze-pulumi-iam-usage
+++ b/bin/analyze-pulumi-iam-usage
@@ -482,8 +482,8 @@ def analyze(
     trail_arn: str = DEFAULT_TRAIL_ARN,
     lookback_days: int = DEFAULT_LOOKBACK_DAYS,
     region: str = "us-east-1",
-    poll_interval_seconds: int = 15,
-    timeout_seconds: int = 300,
+    poll_interval_seconds: int = 20,
+    timeout_seconds: int = 900,
     skip_cloudtrail: bool = False,
 ) -> None:
     """Report actions used-but-ungranted and granted-but-unused for a role.
@@ -558,8 +558,8 @@ def propose(
     trail_arn: str = DEFAULT_TRAIL_ARN,
     lookback_days: int = DEFAULT_LOOKBACK_DAYS,
     region: str = "us-east-1",
-    poll_interval_seconds: int = 15,
-    timeout_seconds: int = 300,
+    poll_interval_seconds: int = 20,
+    timeout_seconds: int = 900,
     skip_cloudtrail: bool = False,
 ) -> None:
     """Rewrite the target policy module and drift report to match observed usage.


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Follow-up to #5568, which fixed the timestamp-format bug blocking `iam-policy-drift`'s `StartPolicyGeneration` call. Re-running the job in production after that fix got the AWS call succeeding, but exposed a second, separate limit: the policy-generation job for `concourse-instance-role-worker-infra-production` (14 days of CloudTrail, all regions -- a busy production worker role) didn't finish within the script's 300s poll timeout.

Confirmed via `aws accessanalyzer list-policy-generations`: job `3c74089f-3420-4be4-9df2-04626f9ea8d1` started `2026-08-24T14:38:16Z`, completed `14:44:19Z` (363s), and **succeeded** server-side -- the script just stopped polling 63s early and raised `TimeoutError`.

Raises `timeout_seconds` from 300 to 900 (~2.5x the one observed run, to absorb day-to-day CloudTrail volume variance) and `poll_interval_seconds` from 15 to 20 in both the `analyze` and `propose` commands, to avoid polling `GetGeneratedPolicy` needlessly often over the longer window.

### How can this be tested?
Re-triggered `iam-policy-drift/check-pulumi-infra-iam-drift` in production before and after this change:
- Before (with the #5568 fix but the old 300s timeout): failed with `TimeoutError: Policy generation job ... did not complete within 300s`, despite the underlying AWS job succeeding at 363s (confirmed via `aws accessanalyzer list-policy-generations`).
- `bin/analyze-pulumi-iam-usage` compiles and passes `pre-commit` (ruff format/check, mypy) after the change.
- Haven't yet re-triggered the pipeline with this fix live, since it isn't merged -- reviewer/I can confirm on the next run after merge.

### Additional Context
No code change to the underlying polling logic, just the two default values (duplicated across the `analyze` and `propose` cyclopts commands).
