### PR TITLE
fix(concourse): grant the infra worker role its actually-missing IAM actions

### DIFF
--- a/src/ol_infrastructure/applications/concourse/__main__.py
+++ b/src/ol_infrastructure/applications/concourse/__main__.py
@@ -236,15 +236,6 @@ for iam_policy in iam_policy_names or []:
         },
         "RESOURCE_STAR": {},
     }
-    if iam_policy == "iam_drift_analysis":
-        # Parliament's bundled action database predates Access Analyzer's V2
-        # finding APIs, so it reports access-analyzer:ListFindingsV2 and
-        # GetFindingV2 as UNKNOWN_ACTION. Both are real, documented actions
-        # (and are what boto3's list_findings_v2/get_finding_v2 call), so the
-        # finding is a stale-database artifact rather than a typo. Suppressed
-        # for this module only, where the whole action list is four
-        # read-only Access Analyzer calls plus a resource-scoped PassRole.
-        parliament_config["UNKNOWN_ACTION"] = {}
     if iam_policy == "pulumi_infra":
         # These actions are real, observed Pulumi usage (CloudTrail-derived) and
         # are already scoped to Resource ARNs under /ol-applications/* and

--- a/src/ol_infrastructure/applications/concourse/iam_policies/cloud_custodian.py
+++ b/src/ol_infrastructure/applications/concourse/iam_policies/cloud_custodian.py
@@ -36,11 +36,8 @@ policy_definition = {
             # Cloud Custodian's `unused` filter on aws.security-group decides
             # whether a group is referenced by scanning the services that can
             # hold one -- see SGUsage.get_scanners() in c7n/resources/vpc.py,
-            # which includes a "codebuild" scanner. The other scanners (ENIs,
-            # SG cross-references, Lambda, launch configs, ECS/CloudWatch
-            # Events rules) are already covered by this policy and by
-            # iam_policies/infra.py; CodeBuild was not, so
-            # tag-packer-sg-for-cleanup and perform-packer-sg-cleanup both
+            # which includes a "codebuild" scanner. CodeBuild wasn't granted,
+            # so tag-packer-sg-for-cleanup and perform-packer-sg-cleanup both
             # died on AccessDeniedException once the infra worker's
             # AdministratorAccess was detached.
             #
@@ -56,6 +53,18 @@ policy_definition = {
             "Action": [
                 "codebuild:BatchGetProjects",
                 "codebuild:ListProjects",
+            ],
+            "Resource": "*",
+        },
+        {
+            # Same SGUsage.get_scanners() also runs an SG-cross-reference
+            # scanner (peered VPCs referencing a group from another account),
+            # which calls DescribeSecurityGroupReferences per security group
+            # -- also missing, confirmed by a live AccessDeniedException on
+            # the same find-packer-sgs policy once CodeBuild above was fixed.
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeSecurityGroupReferences",
             ],
             "Resource": "*",
         },

--- a/src/ol_infrastructure/applications/concourse/iam_policies/iam_drift_analysis.py
+++ b/src/ol_infrastructure/applications/concourse/iam_policies/iam_drift_analysis.py
@@ -25,9 +25,15 @@ policy_definition = {
         {
             "Effect": "Allow",
             "Action": [
-                "access-analyzer:GetFindingV2",
+                # bin/analyze-pulumi-iam-usage calls the V2 finding APIs
+                # (get_finding_v2/list_findings_v2), but AWS authorizes both
+                # against the original (non-"V2") action names -- confirmed by
+                # a live AccessDeniedException naming "access-analyzer:
+                # ListFindings" for a ListFindingsV2 call, and by AWS's action
+                # reference, which has no *FindingV2 action at all.
+                "access-analyzer:GetFinding",
                 "access-analyzer:GetGeneratedPolicy",
-                "access-analyzer:ListFindingsV2",
+                "access-analyzer:ListFindings",
                 "access-analyzer:StartPolicyGeneration",
             ],
             "Resource": "*",

--- a/src/ol_infrastructure/applications/concourse/iam_policies/pulumi_infra.py
+++ b/src/ol_infrastructure/applications/concourse/iam_policies/pulumi_infra.py
@@ -434,7 +434,9 @@ policy_definition = {
                 "iam:DetachRolePolicy",
                 "iam:DetachUserPolicy",
                 "iam:RemoveUserFromGroup",
+                "iam:TagPolicy",
                 "iam:TagRole",
+                "iam:UntagPolicy",
                 "iam:UntagRole",
                 "iam:UpdateAssumeRolePolicy",
                 "iam:UpdateRoleDescription",
@@ -446,6 +448,10 @@ policy_definition = {
                 "arn:aws:iam::*:policy/ol-applications/*",
                 "arn:aws:iam::*:policy/ol-data/*",
                 "arn:aws:iam::*:policy/ol-infrastructure/*",
+                # substructure/open_metadata/__main__.py provisions its
+                # ingestion policy under this path rather than
+                # ol-infrastructure/*.
+                "arn:aws:iam::*:policy/ol-substructure/*",
                 "arn:aws:iam::*:instance-profile/ol-applications/*",
                 "arn:aws:iam::*:instance-profile/ol-infrastructure/*",
                 "arn:aws:iam::*:user/ol-applications/*",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Compiled from `AccessDeniedException`s reproduced live in production while re-verifying #5568 and #5570. All four are on `concourse-instance-role-worker-infra-production`, the only role that runs `pulumi_job()` steps:

- **`iam_drift_analysis.py`**: `access-analyzer:ListFindingsV2`/`GetFindingV2` aren't real IAM actions. Confirmed two ways: a live `AccessDeniedException` naming `access-analyzer:ListFindings` (no "V2") for a `ListFindingsV2` call, and AWS's official action reference (`https://awspolicygen.s3.amazonaws.com/js/policies.js`), which has no `*FindingV2` action at all. `concourse/__main__.py` had a `parliament_config["UNKNOWN_ACTION"]` suppression specifically because Parliament's linter already flagged these as unknown -- the suppression's own comment asserted they were "real, documented actions," which was wrong. Removed the suppression; re-ran `lint_iam_policy()` locally with the corrected action names and got zero findings, confirming Parliament recognizes them now.

- **`cloud_custodian.py`**: `ec2:DescribeSecurityGroupReferences` was missing for c7n's SG-cross-reference scanner (`SGUsage.get_scanners()` in `c7n/resources/vpc.py`). `tag-packer-sg-for-cleanup` got past the already-fixed `codebuild:ListProjects` gap (there's an existing comment documenting that prior fix) only to fail here on retry. Also corrects that comment's now-disproven claim that the SG-cross-reference scanner was already covered.

- **`pulumi_infra.py`**: `iam:TagPolicy`/`UntagPolicy` were never granted for any path, including the already-trusted `ol-applications/`, `ol-data/`, `ol-infrastructure/` paths -- so any new or tag-updated IAM policy under those paths fails on `CreatePolicy`'s tagging step. Also added `ol-substructure/*` to the resource list, which was missing entirely: `substructure/open_metadata/__main__.py` provisions its ingestion policy under that path, which is how `pulumi-open-metadata-substructure`'s QA deploy hit `iam:CreatePolicyVersion` `AccessDenied` today.

**Deliberately not touched**: the `ol-security-boundaries/concourse/*` permissions-boundary path. `concourse/__main__.py` explains this role is never granted `iam:PutRolePermissionsBoundary`/`DeleteRolePermissionsBoundary` or `iam:CreatePolicyVersion`/`TagPolicy` on that path, specifically so it can't widen its own ceiling -- self-escalation was a real, closed vulnerability (see the file's top-of-module comment). Any change to this PR's action lists changes what the boundary needs to allow, so **a human with more privileged credentials will need to run `pulumi up` manually once** on each affected stack after merging, same as was just done for #5546's fallout -- the CI-role-driven pipeline run can't do it itself, by design.

### How can this be tested?
- Reproduced all four gaps live: `pulumi-open-metadata-substructure`/qa build #268-269 (`iam:CreatePolicyVersion`), `misc-cloud-custodian` build #1235-1236 (`ec2:DescribeSecurityGroupReferences`, after the pre-existing `codebuild:ListProjects` fix already in `cloud_custodian.py` let it get further), `iam-policy-drift` build #4 (`access-analyzer:ListFindings`).
- Ran the exact `lint_iam_policy()` call and `parliament_config` that `concourse/__main__.py` uses at deploy time, locally, against all three modified modules -- zero findings on each, including `iam_drift_analysis` with the `UNKNOWN_ACTION` suppression removed.
- `pre-commit` (ruff format/check, mypy) passes on the changed files.
- Haven't re-triggered the pipelines against this change yet since it isn't merged, and per the boundary note above, a full green run additionally needs a manual `pulumi up` for the boundary policy update -- can retest once both land.

### Additional Context
Found via a broader sweep of failing Concourse pipelines, further narrowed while verifying #5568 and #5570 by actually re-triggering the previously-broken jobs in production. `codebuild:ListProjects`/`BatchGetProjects` in `cloud_custodian.py` were already fixed in a prior change (untouched here) -- worth noting since the AccessDeniedException history for `misc-cloud-custodian` shows two different denied actions across retries, which could otherwise look like a regression rather than progress through two separate scanners.
