### PR TITLE
fix(fastly): sort gzip extension and content-type lists for stable diffs

### DIFF
--- a/src/ol_infrastructure/applications/learn_ai/__main__.py
+++ b/src/ol_infrastructure/applications/learn_ai/__main__.py
@@ -342,8 +342,8 @@ learn_ai_fastly_service = fastly.ServiceVcl(
     gzips=[
         fastly.ServiceVclGzipArgs(
             name="enable-gzip-compression",
-            extensions=list(gzip_settings["extensions"]),
-            content_types=list(gzip_settings["content_types"]),
+            extensions=sorted(gzip_settings["extensions"]),
+            content_types=sorted(gzip_settings["content_types"]),
         )
     ],
     product_enablement=fastly.ServiceVclProductEnablementArgs(

--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -861,8 +861,8 @@ mitlearn_fastly_service = fastly.ServiceVcl(
     gzips=[
         fastly.ServiceVclGzipArgs(
             name="enable-gzip-compression",
-            extensions=list(gzip_settings["extensions"]),
-            content_types=list(gzip_settings["content_types"]),
+            extensions=sorted(gzip_settings["extensions"]),
+            content_types=sorted(gzip_settings["content_types"]),
         )
     ],
     product_enablement=fastly.ServiceVclProductEnablementArgs(

--- a/src/ol_infrastructure/applications/mitxonline/__main__.py
+++ b/src/ol_infrastructure/applications/mitxonline/__main__.py
@@ -1161,8 +1161,8 @@ mitxonline_service = fastly.ServiceVcl(
     gzips=[
         fastly.ServiceVclGzipArgs(
             name="enable-gzip-compression",
-            extensions=list(gzip_settings["extensions"]),
-            content_types=list(gzip_settings["content_types"]),
+            extensions=sorted(gzip_settings["extensions"]),
+            content_types=sorted(gzip_settings["content_types"]),
         )
     ],
     product_enablement=fastly.ServiceVclProductEnablementArgs(


### PR DESCRIPTION
### What are the relevant tickets?
N/A — found while diagnosing [`deploy-ol-application-mitxonline-production` build 71](https://cicd.odl.mit.edu/teams/infrastructure/pipelines/mitxonline-pipeline/jobs/deploy-ol-application-mitxonline-production/builds/71). The invalid snippet name that failed that build is fixed separately in #5564; this PR is only the gzip diff churn.

### Description (What does it do?)
Sorts the Fastly gzip `extensions` and `content_types` lists in the `mitxonline`, `learn_ai` and `mit_learn` stacks.

All three build those values from a `set()` and pass them straight through as `list(...)`. CPython randomizes string hashing per process, so the ordering changes on every Pulumi run:

```
$ for i in 1 2 3; do python3 -c '<the gzip_settings block>'; done
['js', 'gif', 'vtt', 'html', 'srt', 'pdf', 'jpeg', 'css', 'svg', 'jpg', 'xml', 'json', 'png']
['srt', 'jpeg', 'pdf', 'svg', 'xml', 'html', 'json', 'js', 'jpg', 'png', 'gif', 'css', 'vtt']
['jpg', 'xml', 'jpeg', 'html', 'json', 'vtt', 'srt', 'svg', 'gif', 'js', 'pdf', 'png', 'css']
```

Every deploy therefore reports a `~gzips` diff and clones and activates a brand new Fastly service version for a config that did not change. Sampling the last six Production mitxonline builds back to Aug 3, `gzips` is in the diff on all six, and on four of them it is the only substantive entry:

```
prod 62  [diff: ~activeVersion,clonedVersion,gzips,requestSettings]
prod 64  [diff: ~activeVersion,clonedVersion,gzips]
prod 66  [diff: ~activeVersion,clonedVersion,gzips]
prod 68  [diff: ~activeVersion,clonedVersion,gzips]
prod 69  [diff: ~activeVersion,clonedVersion,gzips]
prod 70  [diff: ~activeVersion,clonedVersion,gzips]
```

Two costs, beyond the noise:

- The `ServiceVcl` resource reports a successful `updated` on every single deploy, so the Fastly service always looks actively reconciled whether or not anything reconciled. That is a false green: on mitxonline QA, builds 231–233 showed a green `~gzips` update while the `snippets` block was silently not being applied at all.
- Each run burns a Fastly service version, so genuine changes are buried in a version history where every entry looks like a real edit.

To be precise about the QA case, since this PR does not fix it: the `snippets` diff disappeared there because QA build 230 failed mid-update and the Terraform provider saved partial state, leaving Pulumi believing both snippets existed. Sorting the gzip lists would not have prevented that — with stable gzips those builds would have shown the resource as `unchanged` instead of `updated`, which is just as quiet. What this change removes is the standing false signal that the service was being reconciled every time.

`micromasters` has sorted these lists since #4313, and `ocw_site` and `xpro` pass hardcoded literals, so those three were already deterministic. This brings the remaining three in line; no `list(gzip_settings[...])` call sites are left in the repo.

### How can this be tested?
I ran `pre-commit run --files <the three changed files>` — ruff format, ruff check and mypy all pass — and reproduced the ordering nondeterminism locally with the loop shown above. I did not run `pulumi preview`; that needs Vault and AWS credentials I don't have.

A reviewer with stack credentials can confirm with:

```
pulumi preview --stack Production --cwd src/ol_infrastructure/applications/mitxonline
```

The real check is the deploy after this one. Each of the three stacks gets one convergence deploy where the gzip lists reorder into sorted order, and from the deploy after that onward `gzips` should stop appearing in the `ServiceVcl` diff entirely. On a stack with no other pending changes the resource should go to `unchanged`.

### Additional Context
This is behaviour-neutral at the edge. Fastly treats gzip extensions and content types as sets, so reordering them does not change what gets compressed — it only stops Pulumi from believing the value changed.
