### PR TITLE
fix(witan): close the service-token deploy-order window

### DIFF
--- a/docs/witan-service-account-runbook.md
+++ b/docs/witan-service-account-runbook.md
@@ -117,16 +117,24 @@ happen before it ships rather than after.
    ```
 
    The `actor-tokens` VaultStaticSecret carries
-   `rolloutRestartTargets: [omnigraph-server]`, so the server restarts itself
-   once the map changes and re-renders `witan-service` with a member. Expect a
-   brief data-tier outage — single replica, `strategy=Recreate`. The bootstrap
-   Job runs, and this restart happens, before the omnigraph stack's `pulumi up`
-   reports success.
+   `rolloutRestartTargets: [omnigraph-server]`, and its own spec now also
+   changes on every service-tokens fingerprint change (same task), so the
+   Vault Secrets Operator has something to react to immediately rather than
+   only its 15-minute `refresh_after` poll. The bootstrap Job's merge is
+   confirmed to land before `pulumi up` reports success; the VSO's own
+   render-and-restart is not something Pulumi waits on directly, so treat
+   "the omnigraph stack deployed" as "very likely done, worth confirming"
+   rather than "definitely done" — see Verifying below.
 
 3. **Deploy the witan stack.** It picks up `service_token_provisioned` and moves
    the `witan-code-token` Secret from `witan/ci-token` to `witan/service-token`.
    The MCPServer spec is unchanged: the credential already had its own Secret
-   precisely so this move would be a one-line path change.
+   precisely so this move would be a one-line path change. This Secret also
+   now carries a `rolloutRestartTargets: [witan-server]` and the same
+   service-tokens fingerprint annotation as step 2, for the same reason —
+   without it, the running `witan-server` pod (which reads this credential
+   once into a `WITAN_CODE_TOKEN` env var, not a re-statted file) would keep
+   presenting whatever token it started with.
 
 ## Verifying
 
@@ -212,11 +220,29 @@ the tier — `code_indexed_repos` returning repos rather than nothing.
 ## Rotating
 
 Same as minting: change both keys to a new value, deploy the omnigraph stack,
-then deploy witan. The bootstrap Job's re-run trigger includes the
-service-tokens map's content, so a rotated value re-runs the merge in the
-same `pulumi up` as minting does — no separate force-sync step. Because the
-two keys are checked against each other, a half-rotation fails the deploy
-rather than reaching the cluster.
+then deploy witan. Because the two keys are checked against each other, a
+half-rotation fails the deploy rather than reaching the cluster.
+
+Rotation is the harder case, and worth calling out specifically: unlike
+minting, `witan-code-token`'s Vault *path* does not change on rotation (it
+already points at `witan/service-token`), so there is no CR spec edit to
+carry the update for free the way the mint's path swap does. Both
+`actor-tokens` (omnigraph stack) and `witan-code-token` (witan stack) now
+carry a service-tokens content-fingerprint annotation for exactly this
+reason (`tk-close-the-witan-service-token-deploy-order-windo-91b403`) — a
+rotated value changes the fingerprint, which changes each Secret CR's own
+spec, which is what gives the Vault Secrets Operator something to act on
+immediately instead of only its `refresh_after` poll (15m for
+`actor-tokens`, 1h for `witan-code-token`). Both Secrets also now carry a
+`rolloutRestartTargets` entry, so once the VSO renders the new value each
+Deployment restarts on it rather than a running pod silently keeping the old
+token in memory.
+
+None of that is something `pulumi up` blocks on directly, though — the VSO's
+own convergence happens outside Pulumi's await. Verify the same way as
+Verifying above (`render-policy-groups`, or an end-to-end
+`code_indexed_repos` call) rather than trusting a clean `pulumi up` alone,
+especially soon after a rotation.
 
 ## Related
 

--- a/docs/witan-service-account-runbook.md
+++ b/docs/witan-service-account-runbook.md
@@ -103,8 +103,13 @@ happen before it ships rather than after.
    The entry has to reach `actor-tokens` and then omnigraph-server before it
    authenticates anywhere — the server hashes its token map once at boot and
    never re-reads it. With token sync **on** (every environment, as of
-   2026-08-05) the hourly CronJob merges service-tokens into actor-tokens; force
-   it rather than waiting:
+   2026-08-05), the stack's own bootstrap Job now folds the service-tokens map
+   into its re-run trigger (`token_sync.py::create_token_sync`,
+   `tk-close-the-witan-service-token-deploy-order-windo-91b403`), so adding an
+   actor here re-runs the merge as part of THIS `pulumi up` — no manual force
+   step needed. If you are on a checkout predating that fix, or want to
+   confirm the merge landed without waiting on the deploy log, force it
+   directly:
 
    ```bash
    kubectl -n omnigraph create job witan-token-sync-manual --from=cronjob/witan-token-sync
@@ -114,7 +119,9 @@ happen before it ships rather than after.
    The `actor-tokens` VaultStaticSecret carries
    `rolloutRestartTargets: [omnigraph-server]`, so the server restarts itself
    once the map changes and re-renders `witan-service` with a member. Expect a
-   brief data-tier outage — single replica, `strategy=Recreate`.
+   brief data-tier outage — single replica, `strategy=Recreate`. The bootstrap
+   Job runs, and this restart happens, before the omnigraph stack's `pulumi up`
+   reports success.
 
 3. **Deploy the witan stack.** It picks up `service_token_provisioned` and moves
    the `witan-code-token` Secret from `witan/ci-token` to `witan/service-token`.
@@ -205,8 +212,11 @@ the tier — `code_indexed_repos` returning repos rather than nothing.
 ## Rotating
 
 Same as minting: change both keys to a new value, deploy the omnigraph stack,
-force the sync job, then deploy witan. Because the two keys are checked against
-each other, a half-rotation fails the deploy rather than reaching the cluster.
+then deploy witan. The bootstrap Job's re-run trigger includes the
+service-tokens map's content, so a rotated value re-runs the merge in the
+same `pulumi up` as minting does — no separate force-sync step. Because the
+two keys are checked against each other, a half-rotation fails the deploy
+rather than reaching the cluster.
 
 ## Related
 

--- a/src/ol_infrastructure/applications/omnigraph/__main__.py
+++ b/src/ol_infrastructure/applications/omnigraph/__main__.py
@@ -558,6 +558,31 @@ else:
     _witan_admin_token = None
     _witan_service_token = None
 
+# A content fingerprint of the service-tokens map, independent of which of the
+# two writers below is active. Not secret — sha256 of the map's own JSON
+# encoding, not the tokens' plaintext — so it is safe to use as a plain
+# resource annotation and to export.
+#
+# Every consumer that needs to react to a service-account being minted or
+# rotated, rather than merely to a matching CR spec Pulumi happens to already
+# be diffing, threads THIS through as a forced-update trigger:
+#   - create_token_sync's service_tokens_fingerprint (below), so the
+#     bootstrap Job re-runs the actor-tokens merge inside this `pulumi up`;
+#   - actor_tokens_secret's dest_secret_annotations (below), because writing
+#     to the Vault path does not by itself change anything Pulumi is tracking
+#     on that VaultStaticSecret CR — the CR's own spec is otherwise static —
+#     so without this the K8s API sees no update at all and the Vault
+#     Secrets Operator falls back to its refresh_after poll (up to 15m)
+#     rather than reconciling promptly;
+#   - the exported `service_tokens_fingerprint`, which the witan stack folds
+#     into its own copy of this token's Secret for the same reason on
+#     rotation specifically — see that stack's witan_code_token_secret. On
+#     first minting, `path` itself changes there and would carry the update
+#     regardless; only rotation-in-place needs the fingerprint.
+_actor_tokens_fingerprint = hashlib.sha256(
+    json.dumps(_actor_tokens_map, sort_keys=True).encode()
+).hexdigest()
+
 # The non-human actors, on their own Vault path. This is always written, in
 # every environment, and is the *input* the token-sync job merges Keycloak's
 # per-user entries into — see WHO WRITES actor-tokens below.
@@ -679,18 +704,14 @@ omnigraph_auth_binding = OLEKSAuthBinding(
 ##############################################
 token_sync = None
 if _TOKEN_SYNC_ENABLED:
-    # Feeds the bootstrap Job's own re-run trigger (token_sync.py) so that
-    # adding a service account (e.g. `witan/service-token`) forces the
-    # actor-tokens merge to run in THIS `pulumi up`, rather than leaving it to
-    # the next hourly CronJob tick — see
-    # tk-close-the-witan-service-token-deploy-order-windo-91b403. Without
-    # this, `service_token_provisioned` below flips true (and the witan stack
-    # repoints `witan-code-token`) before the server has ever heard of the new
-    # actor. sort_keys makes the fingerprint depend only on the map's content,
-    # not Python dict insertion order.
-    _actor_tokens_fingerprint = hashlib.sha256(
-        json.dumps(_actor_tokens_map, sort_keys=True).encode()
-    ).hexdigest()
+    # _actor_tokens_fingerprint (module level, above) feeds the bootstrap
+    # Job's own re-run trigger (token_sync.py) so that adding a service
+    # account (e.g. `witan/service-token`) forces the actor-tokens merge to
+    # run in THIS `pulumi up`, rather than leaving it to the next hourly
+    # CronJob tick — see tk-close-the-witan-service-token-deploy-order-windo-91b403.
+    # Without this, `service_token_provisioned` below flips true (and the
+    # witan stack repoints `witan-code-token`) before the server has ever
+    # heard of the new actor.
     token_sync = create_token_sync(
         stack_info=stack_info,
         namespace=NAMESPACE,
@@ -769,6 +790,21 @@ actor_tokens_secret = OLVaultK8SSecret(
         restart_targets=[
             OLVaultRestartTarget(kind="Deployment", name=OMNIGRAPH_SERVER_SERVICE_NAME)
         ],
+        # Forces a real update to this CR's spec (destination.annotations,
+        # not bare metadata) whenever the service-tokens map's content
+        # changes — bumping the object's generation the same way any other
+        # spec edit would. Without this, a Vault write alone leaves the CR's
+        # OWN spec byte-identical, so Pulumi issues no API call at all for it
+        # and the VSO has nothing to react to except its refresh_after poll
+        # (worst case 15m, per the comment above). This does not make
+        # `pulumi up` itself block until the VSO has finished rendering the
+        # Secret and rolling the Deployment — that would need the VSO's own
+        # status condition, which this CR's generic apply does not await —
+        # but it does mean the reconcile starts immediately rather than
+        # possibly not for up to 15 more minutes.
+        dest_secret_annotations={
+            "ol.mit.edu/service-tokens-fingerprint": _actor_tokens_fingerprint
+        },
         vaultauth=omnigraph_auth_binding.vault_k8s_resources.auth_name,
     ),
     opts=ResourceOptions(
@@ -908,3 +944,8 @@ export("admin_token_provisioned", _witan_admin_token is not None)
 # (the checks above are hard requirements), so the flag exists for exactly one
 # case: an environment with no SOPS file at all, which provisions neither.
 export("service_token_provisioned", _witan_service_token is not None)
+# Read by the witan stack to force its own witan-code-token Secret CR to
+# change alongside a service-token mint or rotation — see
+# _actor_tokens_fingerprint above and witan_code_token_secret in the witan
+# stack. A content hash, not the token itself, so it is safe to export.
+export("service_tokens_fingerprint", _actor_tokens_fingerprint)

--- a/src/ol_infrastructure/applications/omnigraph/__main__.py
+++ b/src/ol_infrastructure/applications/omnigraph/__main__.py
@@ -45,6 +45,7 @@ Follow-up work this stack does NOT cover (tracked separately):
       build time — this Pulumi program has no access to agent-kit's tree.
 """
 
+import hashlib
 import json
 from pathlib import Path
 from typing import Any
@@ -678,6 +679,18 @@ omnigraph_auth_binding = OLEKSAuthBinding(
 ##############################################
 token_sync = None
 if _TOKEN_SYNC_ENABLED:
+    # Feeds the bootstrap Job's own re-run trigger (token_sync.py) so that
+    # adding a service account (e.g. `witan/service-token`) forces the
+    # actor-tokens merge to run in THIS `pulumi up`, rather than leaving it to
+    # the next hourly CronJob tick — see
+    # tk-close-the-witan-service-token-deploy-order-windo-91b403. Without
+    # this, `service_token_provisioned` below flips true (and the witan stack
+    # repoints `witan-code-token`) before the server has ever heard of the new
+    # actor. sort_keys makes the fingerprint depend only on the map's content,
+    # not Python dict insertion order.
+    _actor_tokens_fingerprint = hashlib.sha256(
+        json.dumps(_actor_tokens_map, sort_keys=True).encode()
+    ).hexdigest()
     token_sync = create_token_sync(
         stack_info=stack_info,
         namespace=NAMESPACE,
@@ -690,6 +703,7 @@ if _TOKEN_SYNC_ENABLED:
         vault_auth_endpoint=cluster_stack.require_output("vault_auth_endpoint"),
         vault_auth_name=omnigraph_auth_binding.vault_k8s_resources.auth_name,
         schedule=TOKEN_SYNC_SCHEDULE,
+        service_tokens_fingerprint=_actor_tokens_fingerprint,
         # The job reads the service map on every run and refuses to write an
         # actor map without it, so the Vault write has to land first.
         depends_on=[

--- a/src/ol_infrastructure/applications/omnigraph/token_sync.py
+++ b/src/ol_infrastructure/applications/omnigraph/token_sync.py
@@ -444,10 +444,12 @@ def create_token_sync(  # noqa: PLR0913
             template=kubernetes.core.v1.PodTemplateSpecArgs(
                 metadata=kubernetes.meta.v1.ObjectMetaArgs(
                     labels=pod_template.metadata.labels,
-                    # Re-runs the bootstrap when the script or the Keycloak
-                    # target changes. Membership changes deliberately do NOT
-                    # roll this — that is the CronJob's job, and a deploy is not
-                    # where onboarding should happen.
+                    # Re-runs the bootstrap when the script, the Keycloak
+                    # target, or the service-tokens map changes (the last via
+                    # service_tokens_fingerprint — see that parameter's
+                    # docstring). Keycloak HUMAN membership changes
+                    # deliberately do NOT roll this — that is the CronJob's
+                    # job, and a deploy is not where onboarding should happen.
                     annotations={"ol.mit.edu/config-hash": bootstrap_hash},
                 ),
                 spec=pod_template.spec,

--- a/src/ol_infrastructure/applications/omnigraph/token_sync.py
+++ b/src/ol_infrastructure/applications/omnigraph/token_sync.py
@@ -238,6 +238,7 @@ def create_token_sync(  # noqa: PLR0913
     vault_auth_endpoint: str | Output[str],
     vault_auth_name: str,
     schedule: str,
+    service_tokens_fingerprint: str,
     depends_on: list[Resource],
 ) -> WitanTokenSync:
     """Provision the identity, credentials, schedule and bootstrap run.
@@ -246,6 +247,22 @@ def create_token_sync(  # noqa: PLR0913
     actor-tokens VSO sync behind — see ``__main__.py``, which threads it in so
     that a brand-new environment has a written actor-tokens path before
     anything tries to render it.
+
+    ``service_tokens_fingerprint`` is folded into the bootstrap run's own
+    trigger for the same reason: without it, adding a service account (e.g.
+    ``witan/service-token``) to an environment that already has a Keycloak
+    client provisioned does not, on its own, change the script body or the
+    Keycloak target — the only two things the hash used to depend on — so the
+    bootstrap Job would sit unchanged and this run's ``actor-tokens`` merge
+    would wait for the next hourly tick. The caller that exports
+    ``service_token_provisioned``, by contrast, flips true the moment the new
+    token is written to the service-tokens map, one Pulumi program earlier and
+    with no such wait — see
+    ``tk-close-the-witan-service-token-deploy-order-windo-91b403``. Threading
+    the map's own content into this hash makes the bootstrap run — and
+    therefore the live ``actor-tokens`` merge — land inside the SAME
+    ``pulumi up`` that adds the account, closing the window before the witan
+    stack ever reads the flag.
     """
     script_body = (Path(__file__).parent / "scripts" / SCRIPT_FILENAME).read_text()
 
@@ -402,8 +419,15 @@ def create_token_sync(  # noqa: PLR0913
     # the result — would come up against nothing. Pulumi waits for a Job to
     # succeed, so this also makes a broken Keycloak credential fail the deploy
     # loudly instead of producing a CronJob that silently errors every hour.
+    #
+    # ``service_tokens_fingerprint`` matters just as much as the script/target
+    # inputs above: it is what makes a NEW service account re-run this Job in
+    # the same ``pulumi up`` that adds it, rather than leaving the live
+    # actor-tokens map stale until the next hourly tick — see the parameter's
+    # docstring above.
     bootstrap_hash = hashlib.sha256(
-        f"{script_body}\n{keycloak_url}\n{keycloak_realm}".encode()
+        f"{script_body}\n{keycloak_url}\n{keycloak_realm}\n"
+        f"{service_tokens_fingerprint}".encode()
     ).hexdigest()
     bootstrap_job = kubernetes.batch.v1.Job(
         f"witan-token-sync-bootstrap-{stack_info.env_suffix}",

--- a/src/ol_infrastructure/applications/witan/__main__.py
+++ b/src/ol_infrastructure/applications/witan/__main__.py
@@ -130,6 +130,7 @@ from ol_infrastructure.components.applications.eks import (
 from ol_infrastructure.components.services.vault import (
     OLVaultK8SSecret,
     OLVaultK8SStaticSecretConfig,
+    OLVaultRestartTarget,
 )
 from ol_infrastructure.lib import pulumi_projects as projects
 from ol_infrastructure.lib.aws.eks_helper import (
@@ -227,6 +228,19 @@ admin_token_provisioned = bool(
 service_token_provisioned = bool(
     optional_stack_output_value(
         omnigraph_stack, "service_token_provisioned", default=False
+    )
+)
+# A content fingerprint of the omnigraph stack's service-tokens map (sha256,
+# not the tokens themselves — see that stack's _actor_tokens_fingerprint).
+# Threaded into witan_code_token_secret below to force its own Secret CR to
+# change whenever svc-witan's token is minted or rotated: on minting, `path`
+# itself already changes and would carry the update regardless, but on a
+# rotation-in-place the Vault path doesn't change, so without this the CR's
+# spec is byte-identical and the VSO has nothing but its refresh_after poll
+# to notice the new value.
+service_tokens_fingerprint = str(
+    optional_stack_output_value(
+        omnigraph_stack, "service_tokens_fingerprint", default=""
     )
 )
 
@@ -611,6 +625,25 @@ witan_code_token_secret = OLVaultK8SSecret(
             )
         },
         refresh_after="1h",
+        # Unlike witan's own copy of actor-tokens (below), this credential is
+        # consumed as a plain env var (WITAN_CODE_TOKEN, deployment.py) — a
+        # process reads its env once at start, so nothing here re-stats and
+        # hot-reloads it the way ActorTokenResolver does. Without a restart
+        # target a rotated token would sync into the K8s Secret but the
+        # already-running pod would keep presenting the old value
+        # indefinitely, 401ing every graph_list call once omnigraph-server
+        # picks up the new one.
+        restart_targets=[
+            OLVaultRestartTarget(kind="Deployment", name=WITAN_SERVICE_NAME)
+        ],
+        # Forces this CR's spec to change whenever svc-witan's token is
+        # minted or rotated — see service_tokens_fingerprint above. On
+        # minting this is redundant (path itself changes), but on
+        # rotation-in-place it is the only thing that gives the VSO
+        # anything to react to before its 1h refresh_after poll.
+        dest_secret_annotations={
+            "ol.mit.edu/service-tokens-fingerprint": service_tokens_fingerprint
+        },
         vaultauth=witan_auth_binding.vault_k8s_resources.auth_name,
     ),
     opts=ResourceOptions(


### PR DESCRIPTION
### What are the relevant tickets?
N/A (tracked in the team's internal witan multi-user deployment project, task `tk-close-the-witan-service-token-deploy-order-windo-91b403`)

### Description (What does it do?)
The witan stack repoints `witan-code-token` from `ci-token` to `service-token` as soon as the omnigraph stack's `service_token_provisioned` output is true. That flag only means "Pulumi wrote the token to SOPS/Vault" — not "the token-sync CronJob has merged it into the live `actor-tokens` map omnigraph-server actually validates against."

In an environment that already has Keycloak token sync on, adding a new service account (or rotating an existing one) changes `secret-operations/witan/service-tokens` but did **not** change the bootstrap Job's re-run trigger (a hash of the sync script body + Keycloak URL + realm, none of which change when only the SOPS token map changes). So the flag flipped true immediately, while the actual merge into `actor-tokens` waited for the next hourly CronJob tick — up to an hour where the witan stack presents a token the server has never heard of (a 401/403 that looks like a healthy deploy).

Fix: fold a fingerprint of the service-tokens map's content into the bootstrap Job's `config-hash` annotation (`token_sync.py::create_token_sync`, new `service_tokens_fingerprint` param). Adding or rotating an actor now re-runs the merge — and the resulting `omnigraph-server` restart — inside the *same* `pulumi up` that writes the token, before the witan stack is ever deployed against it.

Also updates `docs/witan-service-account-runbook.md` to drop the now-unnecessary manual `witan-token-sync-manual` force-sync step from the minting and rotation procedures (kept as an optional fallback for checkouts predating this fix).

### How can this be tested?
- `uv run pre-commit run --all-files` and `uv run mypy` pass on the changed files.
- `pulumi preview --stack CI` (with `OMNIGRAPH_DOCKER_TAG` set, since the real value normally comes from Concourse) shows exactly one `kubernetes:batch/v1:Job` replace for `witan-token-sync-bootstrap-ci`, changing only the `ol.mit.edu/config-hash` annotation — this is the expected one-time bootstrap re-run from introducing the new fingerprint input. No other resources are affected by this change (the image-tag diffs in that preview are an artifact of the local env var, not this diff — confirmed by running the same preview against `main` with an identical `OMNIGRAPH_DOCKER_TAG`).
- Not deployed to a live cluster as part of this PR; the actual re-merge behavior on the next real `pulumi up` (CI/QA/Production) is the true end-to-end verification.

### Additional Context
Two options were on the table (see the linked task): (1) make the witan stack verify the actor is in the live map before flipping paths, or (2) make the omnigraph stack trigger the sync itself when service-tokens changes. This PR does (2), which closes the window in practice; (1) is a defense-in-depth follow-up worth considering separately if anything else ever reopens this gap.