### PR TITLE
fix(concourse): drop the nonexistent CI stage from aws-sftp

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/simple_pulumi/pipeline.py
@@ -565,6 +565,11 @@ pipeline_params: dict[str, SimplePulumiParams] = {
         app_name="aws-sftp",
         pulumi_project_path="infrastructure/aws/sftp_servers/",
         pulumi_project_name="ol-infrastructure-aws-sftp",
+        # No CI stack exists for this project (`pulumi stack ls` shows only
+        # QA and Production) -- a single-partner SFTP integration that's
+        # barely changed in a year never needed one. The default CI stage
+        # was failing every run with StackNotFoundError.
+        stages=["QA", "Production"],
     ),
     "b2b-partners-storage": SimplePulumiParams(
         app_name="b2b-partners-storage",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
`deploy-ol-infrastructure-aws-sftp-ci` has been failing every run with:

```
pulumi.automation.errors.StackNotFoundError: Stack 'CI' not found
```

`pulumi stack ls` for this project shows only `QA` and `Production` -- no `CI` stack was ever created. It's a stable, single-partner SFTP integration (MIT Press) that hasn't meaningfully changed in about a year; `simple_pulumi`'s default three-stage template (`CI`/`QA`/`Production`) doesn't fit every project, and `aws-sftp` never opted out the way `aws-ecr` and `monitoring` already do (`stages=["default"]` there, for a different reason -- here it's `["QA", "Production"]` since those are the two stacks that actually exist).

### How can this be tested?
Rendered the pipeline locally: `uv run python -m ol_concourse.pipelines.infrastructure.simple_pulumi.pipeline aws-sftp`, then inspected `definition.json`'s job list -- only `deploy-ol-infrastructure-aws-sftp-qa` and `deploy-ol-infrastructure-aws-sftp-production` remain, no `-ci` job. `pre-commit` (ruff format/check, mypy) passes.

Haven't re-applied the pipeline in Concourse yet since this isn't merged -- `fly set-pipeline` (or the pipeline's own self-update job) will pick it up once it lands on `main`.

### Additional Context
Found via a broader sweep of failing Concourse pipelines/jobs.
