### PR TITLE
feat(omnigraph): guard that storage_prefix and internal_schema_version agree

### DIFF
--- a/docs/omnigraph-storage-format-upgrade-runbook.md
+++ b/docs/omnigraph-storage-format-upgrade-runbook.md
@@ -586,18 +586,31 @@ and is the safe choice — `overwrite` is destructive and buys nothing here.
 
 ### 5. Repoint the cluster and deploy the new image
 
-Set the prefix — the same one `$NEW_ROOT` names, without the `s3://<bucket>/`:
+Set the prefix — the same one `$NEW_ROOT` names, without the `s3://<bucket>/`
+— **and** `internal_schema_version` alongside it, to the same digits:
 
 ```shell
 cd src/ol_infrastructure/applications/omnigraph
 pulumi config set omnigraph:storage_prefix fmt5 --stack <CI|QA|Production>
+pulumi config set omnigraph:internal_schema_version 5 --stack <CI|QA|Production>
 ```
 
-A malformed value fails the preview rather than deploying: wrapping slashes and
-anything outside a single `[A-Za-z0-9._-]` segment are rejected, which includes
-an unsubstituted `fmt<N>`. That check lives here because it cannot live
-downstream — `cluster validate` accepts any storage string, empty ones
-included.
+Both are required, both a `pulumi preview` fails loudly on if missing or if
+they disagree (`storage.py::validate_internal_schema_version`) — a leftover
+`internal_schema_version` from the LAST migration, forgotten while
+`storage_prefix` moves to this one, is exactly the drift this exists to
+catch before it reaches the cluster as a crash-looping server rather than a
+preview failure. **This check does not verify either value against the
+image actually being deployed or the live store's own
+`internal_schema_version`** — it is a self-consistency check between two
+committed config values, not a substitute for `check_format_moved`'s
+verdict above or for following this runbook's ordering.
+
+A malformed `storage_prefix` value fails the preview rather than deploying:
+wrapping slashes and anything outside a single `[A-Za-z0-9._-]` segment are
+rejected, which includes an unsubstituted `fmt<N>`. That check lives here
+because it cannot live downstream — `cluster validate` accepts any storage
+string, empty ones included.
 
 Confirm the generated config before applying:
 
@@ -701,7 +714,13 @@ After step 5:
 
 ```shell
 pulumi config rm omnigraph:storage_prefix --stack <CI|QA|Production>
+pulumi config rm omnigraph:internal_schema_version --stack <CI|QA|Production>
 ```
+
+Both, not just the first: `validate_internal_schema_version` requires
+`internal_schema_version` to be unset whenever `storage_prefix` is (or does
+not follow `fmt<N>`), so leaving it behind fails the very preview this
+rollback is trying to run.
 
 then redeploy with `OMNIGRAPH_DOCKER_SHA` pinned to the **old** image digest.
 Confirm with the same `pulumi preview --diff` check that `storage:` is back to

--- a/docs/omnigraph-storage-format-upgrade-runbook.md
+++ b/docs/omnigraph-storage-format-upgrade-runbook.md
@@ -258,15 +258,16 @@ every graph, and the storage format actually moved — to one version, the same
 across all of them. A format that did not change means either the two images
 share one, so the outage bought nothing, or the wrong `migrate_from_image`.
 
-The Job stops after verification. It does **not** cut over: that is
-`pulumi config set omnigraph:storage_prefix`, which needs Pulumi credentials a
-workload has no business holding, and writing the ConfigMap instead would make
-it a second writer of a path Pulumi owns. On success it prints the exact
-cutover command, and emits the verdict — per-graph, per-table before/after
-counts plus the old and new formats — **to its logs** as well as to
-`/tmp/migration-verdict.json`. Read it from the logs: the file lives on an
-`emptyDir` that goes with the container, and neither `kubectl exec` nor
-`kubectl cp` reaches a completed pod.
+The Job stops after verification. It does **not** cut over: that needs Pulumi
+credentials a workload has no business holding, and writing the ConfigMap
+instead would make it a second writer of a path Pulumi owns. On success it
+prints the exact cutover commands — all four: `storage_prefix` and
+`internal_schema_version` set together, `migrate_from_image` and
+`migrate_to_prefix` cleared together, matching step 5 below — and emits the
+verdict — per-graph, per-table before/after counts plus the old and new
+formats — **to its logs** as well as to `/tmp/migration-verdict.json`. Read it
+from the logs: the file lives on an `emptyDir` that goes with the container,
+and neither `kubectl exec` nor `kubectl cp` reaches a completed pod.
 
 ```shell
 kubectl -n omnigraph logs job/omnigraph-migrate-fmt6 | sed -n '/migration verdict:/,$p'
@@ -606,6 +607,30 @@ image actually being deployed or the live store's own
 committed config values, not a substitute for `check_format_moved`'s
 verdict above or for following this runbook's ordering.
 
+**Took the automated path?** Clear the migration knobs in this SAME config
+change, not later at step 7:
+
+```shell
+pulumi config rm omnigraph:migrate_from_image --stack <CI|QA|Production>
+pulumi config rm omnigraph:migrate_to_prefix --stack <CI|QA|Production>
+```
+
+Not optional, and not just tidiness: `__main__.py`'s
+`if MIGRATE_TO_PREFIX == STORAGE_PREFIX` guard refuses the preview outright
+once `storage_prefix` above is set to the same value the Job's
+`migrate_to_prefix` is still armed with — "the cluster is already serving
+the root this migration would rebuild into." Its own error message says to
+clear both together; this is that advice. `migrate_storage_format.py`'s
+own success output prints all four commands as one block for exactly this
+reason. Clearing `migrate_from_image` also un-suspends the `optimize` and
+`cleanup` CronJobs in this same `pulumi up`, earlier than step 7 describes
+below — safe, since suspension was never gated on step 6's verification,
+only on `migrate_from_image` being set.
+
+(The manual procedure never sets these two knobs at all, so this step does
+not apply if you did not take the automated path — `pulumi config rm` on an
+already-unset key is a no-op either way.)
+
 A malformed `storage_prefix` value fails the preview rather than deploying:
 wrapping slashes and anything outside a single `[A-Za-z0-9._-]` segment are
 rejected, which includes an unsubstituted `fmt<N>`. That check lives here
@@ -686,8 +711,18 @@ is a stray identity with write access to the bucket:
 kubectl -n omnigraph delete pod omnigraph-migrate-old omnigraph-migrate-new --ignore-not-found
 ```
 
-**Resume the maintenance sweeps.** Clearing the migration config does both —
-it removes the Job and un-suspends `optimize`/`cleanup` in one `pulumi up`:
+**Confirm the maintenance sweeps resumed.** If you took the automated path
+and cleared `migrate_from_image`/`migrate_to_prefix` at step 5 as instructed
+there, this already happened — check rather than repeat:
+
+```shell
+kubectl -n omnigraph get cronjob    # SUSPEND must read False for both
+```
+
+If either still reads `True` — the automated-path clearing at step 5 was
+skipped, or this is the manual path, where nothing suspended them in the
+first place but they are worth confirming regardless — clear the migration
+config now, which removes the Job and un-suspends both in one `pulumi up`:
 
 ```shell
 pulumi config rm omnigraph:migrate_from_image --stack <CI|QA|Production>

--- a/src/ol_infrastructure/applications/omnigraph/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/applications/omnigraph/Pulumi.CI.yaml
@@ -57,5 +57,13 @@ config:
   # can only read the new format — every graph then fails to open and the
   # server crashloops. That is exactly what happened here for ~12h.
   omnigraph:storage_prefix: fmt6
+  # Cross-checked against storage_prefix at preview time
+  # (validate_internal_schema_version, storage.py) — the two must agree, and
+  # __main__.py fails the preview loudly if either is missing or they
+  # disagree. Not derived from storage_prefix's own fmt<N> name: this is a
+  # second, independently-set value precisely so a slip in one without the
+  # other is caught here instead of reaching the cluster as a crash-looping
+  # server, same incident this comment already describes above.
+  omnigraph:internal_schema_version: 6
 secretsprovider: awskms://alias/infrastructure-secrets-ci
 encryptedkey: AQICAHhMkpkBpCvmFjhyfy75ENALRrbg42uOs9cUsFNLXqPnagHdMkilOMMReBzl5ZFVAxo4AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMp4JVj0Zbv48c45+qAgEQgDt/KPJs42c+WEXeS2IPS6gVYHOCM2L51SVYdqGNpSII1XjPkxQgj6ypYwhz6wdA7GrvJjK9P89/US3Nww==

--- a/src/ol_infrastructure/applications/omnigraph/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/omnigraph/Pulumi.Production.yaml
@@ -45,5 +45,8 @@ config:
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production
   omnigraph:storage_prefix: fmt6
+  # Cross-checked against storage_prefix at preview time — see the CI
+  # config's comment on this same key for why.
+  omnigraph:internal_schema_version: 6
 secretsprovider: awskms://alias/infrastructure-secrets-production
 encryptedkey: AQICAHjksIVfl1VtAHpBda/1YYjj6tSeS2o4TXgvEEyBIXLjjwF51lHyFZBMipn03XTrTTsKAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMIK7o7DGmOomYnJtDAgEQgDuWNWhBp4MmY5g1IS5INjiOfMa0yZcKOzoHa0L7AjLfrw9rMSs/jELIM0qfIJguIuQsCYjLMpJoX7CgSQ==

--- a/src/ol_infrastructure/applications/omnigraph/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/omnigraph/Pulumi.QA.yaml
@@ -42,5 +42,8 @@ config:
   vault:address: https://vault-qa.odl.mit.edu
   vault_server:env_namespace: operations.qa
   omnigraph:storage_prefix: fmt6
+  # Cross-checked against storage_prefix at preview time — see the CI
+  # config's comment on this same key for why.
+  omnigraph:internal_schema_version: 6
 secretsprovider: awskms://alias/infrastructure-secrets-qa
 encryptedkey: AQICAHjE+jMY5DL7M1LMYX6YgtMueHEDNg05lsdN5Z0zeGHyJgHdah3681q3jIoMB6EquY0xAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMQkBOIyzkj00xRzZ9AgEQgDvOaikBeNnKV3FG4ZgMGvt3MOO4WsufLhs1b/FFH28hvQEuaZnfrQ1oLOS4NHXINUEJweVvuqaQUVj9gg==

--- a/src/ol_infrastructure/applications/omnigraph/__main__.py
+++ b/src/ol_infrastructure/applications/omnigraph/__main__.py
@@ -72,6 +72,7 @@ from ol_infrastructure.applications.omnigraph.maintenance import (
     DEFAULT_OPTIMIZE_SCHEDULE,
 )
 from ol_infrastructure.applications.omnigraph.storage import (
+    validate_internal_schema_version,
     validate_migration_target_prefix,
     validate_storage_prefix,
 )
@@ -145,6 +146,17 @@ MANAGED_REPOS: list[str] = omnigraph_config.get_object("managed_repos") or []
 # — it just builds the graphs somewhere nobody looks. See the runbook's
 # "cluster validate does not catch an empty storage:" note.
 STORAGE_PREFIX: str = validate_storage_prefix(omnigraph_config.get("storage_prefix"))
+
+# Cross-checked against STORAGE_PREFIX below — see
+# validate_internal_schema_version's docstring for exactly what this does and
+# does not catch. Required once storage_prefix follows the fmt<N> convention
+# a migrated environment's served prefix uses; every environment does today
+# (fmt6, see the runbook), so this fails preview immediately if unset rather
+# than only on the NEXT migration that forgets to set it.
+INTERNAL_SCHEMA_VERSION: int | None = omnigraph_config.get_int(
+    "internal_schema_version"
+)
+validate_internal_schema_version(STORAGE_PREFIX, INTERNAL_SCHEMA_VERSION)
 
 # The image to migrate FROM — the one currently deployed, whose binary can
 # still read the old root. Set only while a storage-format migration is being

--- a/src/ol_infrastructure/applications/omnigraph/scripts/migrate_storage_format.py
+++ b/src/ol_infrastructure/applications/omnigraph/scripts/migrate_storage_format.py
@@ -164,6 +164,33 @@ def snapshot_schema_version(binary: str, store: str) -> int:
     return int(match.group(1))
 
 
+def cutover_instructions(new_prefix: str, schema_version: int) -> str:
+    """Render the exact config commands that finish a verified cutover.
+
+    Four commands, not one, and all four matter:
+
+    - ``storage_prefix`` and ``internal_schema_version`` are a required pair
+      — ol-infrastructure's ``storage.py::validate_internal_schema_version``
+      fails ``pulumi preview`` if either is missing or they disagree.
+    - Clearing ``migrate_from_image``/``migrate_to_prefix`` in the SAME
+      config change, rather than a later cleanup step, is what
+      ``__main__.py``'s own ``if MIGRATE_TO_PREFIX == STORAGE_PREFIX`` guard
+      requires: setting ``storage_prefix`` to the value this migration just
+      rebuilt into, while that value is still armed as ``migrate_to_prefix``,
+      is exactly the "cluster already serving the root this migration would
+      rebuild into" case that guard refuses. Its own error message says to
+      clear both — this is that advice, followed.
+    """
+    return (
+        f"pulumi config set omnigraph:storage_prefix {new_prefix} "
+        "--stack <CI|QA|Production>\n"
+        f"pulumi config set omnigraph:internal_schema_version {schema_version} "
+        "--stack <CI|QA|Production>\n"
+        "pulumi config rm omnigraph:migrate_from_image --stack <CI|QA|Production>\n"
+        "pulumi config rm omnigraph:migrate_to_prefix --stack <CI|QA|Production>"
+    )
+
+
 def bucket_of(root: str) -> str:
     """Return the bucket name from an ``s3://<bucket>/...`` root."""
     return root.removeprefix("s3://").split("/", 1)[0]
@@ -570,14 +597,17 @@ def main() -> int:
         )
         return 1
 
+    # Guaranteed uniform by check_format_moved above — format_problems would
+    # already have returned 1 otherwise — so any one graph's value speaks for
+    # all of them.
+    verified_schema_version = next(iter(new_formats.values()))
     LOG.info(
         "All %d graph(s) rebuilt and verified at %s. NOT DONE YET — the "
-        "cluster still serves the OLD root. To cut over: pulumi config set "
-        "omnigraph:storage_prefix %s --stack <CI|QA|Production>, then deploy "
+        "cluster still serves the OLD root. To cut over:\n%s\nThen deploy "
         "the new image, verify, and soak before retiring the old root.",
         len(graphs),
         new_root,
-        new_root.rsplit("/", 1)[-1],
+        cutover_instructions(new_root.rsplit("/", 1)[-1], verified_schema_version),
     )
     return 0
 

--- a/src/ol_infrastructure/applications/omnigraph/storage.py
+++ b/src/ol_infrastructure/applications/omnigraph/storage.py
@@ -20,6 +20,11 @@ _PREFIX_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
 # preview` rather than a Job.
 _MIGRATION_PREFIX_RE = re.compile(r"fmt[0-9]+")
 
+# Same shape as _MIGRATION_PREFIX_RE, but capturing — used to pull the digits
+# back out of a served `storage_prefix` that already follows the convention,
+# for validate_internal_schema_version below.
+_PREFIX_SCHEMA_RE = re.compile(r"fmt(?P<version>[0-9]+)")
+
 
 def validate_storage_prefix(prefix: str | None) -> str:
     """Normalize and check ``omnigraph:storage_prefix``; return "" when unset.
@@ -88,6 +93,78 @@ def validate_migration_target_prefix(prefix: str | None) -> str:
         )
         raise ValueError(msg)
     return cleaned
+
+
+def validate_internal_schema_version(
+    storage_prefix: str, internal_schema_version: int | None
+) -> None:
+    """Cross-check ``omnigraph:internal_schema_version`` against ``storage_prefix``.
+
+    Neither value derives the other — auto-deriving one from the other was
+    considered and rejected, same as the migration cutover itself:
+    ``storage_prefix`` is the switch a human flips only after a rebuild is
+    verified, not something to recompute on every deploy. This is a pure
+    cross-check between two independently-set config values that a real
+    migration touches together, so a slip in one without the other is caught
+    here — at ``pulumi preview`` — rather than downstream, where it is
+    silent: the server just refuses the store and crashloops.
+
+    Deliberately narrower than it sounds, and worth stating precisely: this
+    does NOT verify either value against the image actually being deployed,
+    or against the live store's own ``internal_schema_version``
+    (``omnigraph snapshot``). ol-infrastructure has no access to agent-kit's
+    version -> internal-schema mapping, and the deploying image is addressed
+    only by digest (``OMNIGRAPH_DOCKER_SHA``), never a semver string that
+    could be looked up. What this closes is the narrower, still-real gap of
+    a human editing one of a *committed* pair of config values without the
+    other — the exact category of mistake the CI incident behind this check
+    was (``storage_prefix`` reverted while the deployed image could only
+    read the new format). See
+    tk-derive-the-s3-storage-prefix-from-the-binary-s-i-bc3385 for the wider
+    gap this leaves open.
+
+    Raises ``ValueError`` when ``storage_prefix`` follows the ``fmt<N>``
+    convention a migrated environment's served prefix uses and
+    ``internal_schema_version`` is unset or disagrees with N, or when
+    ``internal_schema_version`` is set against a ``storage_prefix`` that does
+    not follow that convention (bucket root, or a non-standard prefix) — in
+    that case there is no digit to check it against.
+    """
+    match = _PREFIX_SCHEMA_RE.fullmatch(storage_prefix)
+    if match is None:
+        if internal_schema_version is not None:
+            msg = (
+                f"omnigraph:internal_schema_version is set to "
+                f"{internal_schema_version} but omnigraph:storage_prefix "
+                f"{storage_prefix!r} does not follow the fmt<N> convention a "
+                "migrated environment's served prefix uses, so there is "
+                "nothing to check it against. Unset "
+                "internal_schema_version, or set storage_prefix to fmt<N> "
+                "if a migration to this schema already landed."
+            )
+            raise ValueError(msg)
+        return
+    prefix_version = int(match.group("version"))
+    if internal_schema_version is None:
+        msg = (
+            f"omnigraph:storage_prefix is {storage_prefix!r}, which declares "
+            f"internal-schema {prefix_version}, but "
+            "omnigraph:internal_schema_version is unset. Set it to "
+            f"{prefix_version} to record that this environment's committed "
+            "config agrees with itself about which schema it serves — see "
+            "docs/omnigraph-storage-format-upgrade-runbook.md."
+        )
+        raise ValueError(msg)
+    if internal_schema_version != prefix_version:
+        msg = (
+            f"omnigraph:storage_prefix {storage_prefix!r} declares "
+            f"internal-schema {prefix_version}, but "
+            f"omnigraph:internal_schema_version is {internal_schema_version}. "
+            "They must agree — this is exactly the kind of drift that "
+            "otherwise reaches the cluster as a crash-looping server rather "
+            "than a preview failure."
+        )
+        raise ValueError(msg)
 
 
 def storage_uri_for(bucket: str, prefix: str) -> str:

--- a/tests/ol_infrastructure/applications/omnigraph/test_storage_migration.py
+++ b/tests/ol_infrastructure/applications/omnigraph/test_storage_migration.py
@@ -197,6 +197,28 @@ def test_row_counts_are_parsed_per_table() -> None:
     assert migrate.SNAPSHOT_SCHEMA_RE.search(snapshot).group(1) == "6"
 
 
+def test_cutover_instructions_set_both_paired_config_values() -> None:
+    """omnigraph:internal_schema_version is required alongside storage_prefix
+    (ol-infrastructure's storage.py::validate_internal_schema_version) — the
+    printed cutover command has to set both, or the very next `pulumi
+    preview` following it fails.
+    """
+    instructions = migrate.cutover_instructions("fmt6", 6)
+    assert "pulumi config set omnigraph:storage_prefix fmt6 " in instructions
+    assert "pulumi config set omnigraph:internal_schema_version 6 " in instructions
+
+
+def test_cutover_instructions_clear_the_migration_knobs() -> None:
+    """Clearing migrate_from_image/migrate_to_prefix in the SAME config
+    change as the cutover is what __main__.py's own
+    `if MIGRATE_TO_PREFIX == STORAGE_PREFIX` guard requires — its error
+    message says so, and this is that advice followed.
+    """
+    instructions = migrate.cutover_instructions("fmt6", 6)
+    assert "pulumi config rm omnigraph:migrate_from_image " in instructions
+    assert "pulumi config rm omnigraph:migrate_to_prefix " in instructions
+
+
 def _export(tmp_path: Path, nodes: int, edges: int = 0) -> Path:
     """Build an export shaped like omnigraph's: node records, then edge records."""
     path = tmp_path / "graph.jsonl"

--- a/tests/ol_infrastructure/applications/omnigraph/test_storage_prefix.py
+++ b/tests/ol_infrastructure/applications/omnigraph/test_storage_prefix.py
@@ -14,6 +14,7 @@ import pytest
 
 from ol_infrastructure.applications.omnigraph.storage import (
     storage_uri_for,
+    validate_internal_schema_version,
     validate_migration_target_prefix,
     validate_storage_prefix,
 )
@@ -126,3 +127,32 @@ def test_migration_target_still_rejects_what_the_looser_check_does() -> None:
         validate_migration_target_prefix("/fmt6")
     with pytest.raises(ValueError, match="single path segment"):
         validate_migration_target_prefix("fmt<N>")
+
+
+def test_internal_schema_version_unset_bucket_root_is_fine() -> None:
+    """Pre-first-migration steady state: nothing to check either value against."""
+    validate_internal_schema_version("", None)
+
+
+def test_internal_schema_version_matching_fmt_n_passes() -> None:
+    validate_internal_schema_version("fmt6", 6)
+
+
+@pytest.mark.parametrize("prefix", ["fmt6", "fmt10"])
+def test_internal_schema_version_missing_against_fmt_n_prefix_fails(
+    prefix: str,
+) -> None:
+    with pytest.raises(ValueError, match="internal_schema_version is unset"):
+        validate_internal_schema_version(prefix, None)
+
+
+def test_internal_schema_version_mismatched_against_fmt_n_prefix_fails() -> None:
+    with pytest.raises(ValueError, match="They must agree"):
+        validate_internal_schema_version("fmt6", 7)
+
+
+@pytest.mark.parametrize("prefix", ["", "migration-2026-08", "v2.1"])
+def test_internal_schema_version_set_without_fmt_n_prefix_fails(prefix: str) -> None:
+    """Nothing to cross-check it against outside the fmt<N> convention."""
+    with pytest.raises(ValueError, match="nothing to check it against"):
+        validate_internal_schema_version(prefix, 6)


### PR DESCRIPTION
### What are the relevant tickets?
N/A (tracked in the team's internal witan multi-user deployment project, task `tk-derive-the-s3-storage-prefix-from-the-binary-s-i-bc3385`)

### Description (What does it do?)
`omnigraph:storage_prefix` is what the cluster serves; a storage-format migration repoints it to a new root, and nothing today catches a mismatch between that prefix and the format the deploying image actually expects before it reaches the cluster. When it happens, the Deployment rolls and the server refuses the store and crashloops — exactly what happened in CI for ~12h (see the existing comment on `omnigraph:storage_prefix` in `Pulumi.CI.yaml`): a `storage_prefix` cutover existed only in a local working copy, got reverted by the next pipeline deploy, and the server image could only read the new format.

Investigated what already exists before adding anything:
- `validate_storage_prefix`/`validate_migration_target_prefix` (`storage.py`) only check the prefix's *shape* (a valid path segment / `fmt<N>` naming), not whether it agrees with anything else.
- `migrate_storage_format.py`'s `check_format_moved` only checks format *after* a migration Job has already run.
- The pre-deploy `cluster_apply_job` (`data_tier.py`, in place since #5192, i.e. before the CI incident above) runs `omnigraph cluster apply` with the new binary against the live store ahead of the Deployment — but it already existed when that incident happened and didn't prevent it, so it evidently doesn't exercise the same strict format gate the server's boot-time store-open does.

So the class of bug the task describes was genuinely unaddressed. What this PR adds, and what it deliberately does *not* attempt:

- A new `omnigraph:internal_schema_version` config value, required whenever `storage_prefix` follows the `fmt<N>` convention a migrated environment uses, and cross-checked against N at `pulumi preview` time (`storage.py::validate_internal_schema_version`). Same "two independently-set values must agree" pattern this stack already uses successfully for `ci_token`/`actor_tokens`, `admin_token`/`actor_tokens`, and `service_token`/`actor_tokens`.
- **Does not** verify either value against the actually-deploying image or the live store's own `internal_schema_version` (`omnigraph snapshot`). `ol-infrastructure` has no access to agent-kit's version→internal-schema mapping (a genuine, deliberate boundary — see `data_tier.py`'s module docstring), and the deploying image is addressed only by digest (`OMNIGRAPH_DOCKER_SHA`), never a semver string that could be looked up. This closes the narrower, still-real gap of a human editing one of a *committed* pair of config values without the other — the exact category of mistake behind the CI incident — not the full gap. Documented as such in the code and the runbook, and left open for a follow-up rather than silently claimed as solved.
- All three environments (CI/QA/Production) already serve `fmt6`, so `internal_schema_version: 6` is set in all three `Pulumi.<env>.yaml` now rather than leaving the check unenforced until the next migration trips it.
- Updated `docs/omnigraph-storage-format-upgrade-runbook.md`'s cutover and rollback steps to set/unset both values together.
- 8 new unit tests in `test_storage_prefix.py` covering the pass/fail matrix (unset+bucket-root, matching, missing, mismatched, set-without-fmt-N-prefix).

### How can this be tested?
- `uv run pytest tests/ol_infrastructure/applications/omnigraph/test_storage_prefix.py -v` — 44 passed (36 existing + 8 new).
- `uv run pre-commit run --all-files` and `uv run mypy` pass on the changed files.
- `pulumi preview --stack <CI|QA|Production>`, each run with `OMNIGRAPH_DOCKER_SHA` set to that environment's currently-deployed image digest (read live via `kubectl get deploy omnigraph-server -o jsonpath=...`): all three show no diff (CI) or only the unrelated, already-merged #5574 change not yet applied there (QA/Production) — no error, confirming the new required config doesn't break any environment's next deploy.

### Additional Context
This intentionally does not attempt live image/store introspection during `pulumi preview` (needing either a hand-maintained version→schema table with its own drift risk, or docker/ECR access from whatever runs `pulumi preview`, which is unconfirmed) or investigate hardening `cluster_apply_job` to actually catch this at deploy time. Both are reasonable follow-ups if the residual gap this PR documents turns out to matter in practice before the next migration.