### PR TITLE
fix(dagster): size the exporter's id caps against the peak, not the quiet week

### DIFF
--- a/docs/plans/dagster-pgbouncer-observability.md
+++ b/docs/plans/dagster-pgbouncer-observability.md
@@ -557,16 +557,16 @@ at 6h resolution, 2026-07-25 to 2026-08-24 — puts numbers on it:
 | storm, peak | **7416** |
 
 A 50x swing on the same workload. `SQL_EXPORTER_RUN_WINDOW` stays at **20000**, 2.7x over
-that peak. Cutting it to the ~2000 a quiet week suggests would have truncated every 6h
-bucket from 2026-08-08 to 2026-08-18 but two, and `dagster_run_wait_to_start_seconds` is a
+that peak. Cutting it to the ~2000 a quiet week suggests would have truncated **30 of the
+42 six-hour buckets** in that stretch, and `dagster_run_wait_to_start_seconds` is a
 queue-depth metric — a storm is the only time anyone reads it.
 
 `SQL_EXPORTER_TICK_WINDOW` is the one that genuinely overshoots, and it overshoots against
 its own peak rather than against a quiet week, so the rule above does not protect it. Ticks
 are cadence-bound, not demand-bound: tick rate tracks how many sensors exist, not how much
 work they find. Measured hourly from `dagster_recent_job_ticks` since #5495: on Production
-230–651, stepping to a flat 605–651 on 2026-08-22 when the sensor set changed; on QA a flat
-455–462. Peak 651/hour against a 1h lookback made 40000 a 61x cap. Cut to **8000**, which is
+230–651, stepping to a flat 605–651 at 2026-08-22 21:29Z when the sensor set changed; on QA
+a flat 455–462 since 2026-08-19. Peak 651/hour against a 1h lookback made 40000 a 61x cap. Cut to **8000**, which is
 12x the higher of the two environments, and still holds the span above the lookback if the
 sensor set grows eightfold.
 
@@ -580,9 +580,10 @@ cluster measures a different thing under the same name.
 #### The storm started four days earlier than recorded
 
 Third correction from the same series: run creation steps from ~120 to ~2136 per 6h in the
-bucket covering **2026-08-07 16:53Z–22:53Z**, not on 2026-08-11, and stays elevated until
-2026-08-18 ~04:00Z. The end date on record is right; the start was taken from when the
-symptom was noticed rather than when the rate moved. Any window opened on 08-11 to avoid
+bucket covering **2026-08-07 17:12Z–23:12Z**, not on 2026-08-11, and has fallen back to
+~112 by the bucket ending 2026-08-18 11:12Z — consistent with the 03:30Z end already on
+record. The end date on record is right; the start was taken from when the symptom was
+noticed rather than when the rate moved. Any window opened on 08-11 to avoid
 the storm still contains three days of it — which matters most for
 `tk-set-alert-thresholds-on-the-new-dagster-sql-expo-0063d0`, where a contaminated
 baseline becomes a threshold.

--- a/docs/plans/dagster-pgbouncer-observability.md
+++ b/docs/plans/dagster-pgbouncer-observability.md
@@ -532,11 +532,21 @@ measured on 2026-08-18, still inside the tail, and is wrong too.
 Steady state is **~520–670 runs/day**, corroborated independently by the exporter's own
 6h `SUCCESS` counts (137–222, i.e. ~550–890/day). A 17x collapse from the figure the
 windows were sized against. Nothing is broken by this — `dagster_id_window_span_seconds`
-reports the `runs` cap now spanning 6.8 days and `job_ticks` 3.6 days against lookbacks of
-6h and 1h, so both caps are non-binding by a wide margin and the time predicates are doing
-all the work. Stated as ratios rather than lumped together, because they are not the same
-number: the `runs` cap overshoots its lookback by ~27x (6.8 days against 6h) and the
-`job_ticks` cap by ~85x (3.6 days against 1h). Both cost a wider scan and nothing else.
+reports both caps non-binding by a wide margin, so the time predicates are doing all the
+work.
+
+Measured **before** the re-size below, with `SQL_EXPORTER_TICK_WINDOW` still at 40000, and
+stated as two ratios rather than one averaged number because they are not the same
+overshoot:
+
+| cap | span | lookback | ratio |
+|---|---|---|---|
+| `runs`, 20000 ids | 6.8 days | 6h | ~27x |
+| `job_ticks`, 40000 ids | 3.6 days | 1h | ~85x |
+
+Both cost a wider scan and nothing else. What follows re-sizes the second of them, so those
+figures are the pre-resize state: post-deploy the `job_ticks` span settles around 12h on
+Production and 17h on QA, and the `runs` row is unchanged.
 
 #### The id caps are sized against the peak
 

--- a/docs/plans/dagster-pgbouncer-observability.md
+++ b/docs/plans/dagster-pgbouncer-observability.md
@@ -403,10 +403,11 @@ Three implementation findings worth keeping, all from testing rather than readin
     falls between them. The stated limitation, in the metric's own `help`: a run created
     just before the window and starting just inside it isn't counted.
 
-  `SQL_EXPORTER_RUN_WINDOW = 20000` (2.7x headroom over the busiest observed 6h of
-  creations), `SQL_EXPORTER_TICK_WINDOW = 40000` with a 1h lookback — larger cap, shorter
-  lookback, because the daemon evaluates every sensor on a ~30s cadence whether or not it
-  yields a run.
+  `SQL_EXPORTER_RUN_WINDOW = 20000` (2.7x headroom over the busiest 6h in 30 days),
+  `SQL_EXPORTER_TICK_WINDOW = 8000` with a 1h lookback — shorter lookback because the
+  daemon evaluates every sensor on a ~30s cadence whether or not it yields a run, and
+  12x headroom over the measured peak tick rate of 651/hour. Both are sized against the
+  peak, never the quiet week; see *The id caps are sized against the peak* below.
 
   `dagster_id_window_span_seconds{relation}` reports whether those remaining id caps are
   truncating: span well above the lookback means the time predicate binds; span at or
@@ -535,8 +536,56 @@ reports the `runs` cap now spanning 6.8 days and `job_ticks` 3.6 days against lo
 6h and 1h, so both caps are non-binding by a wide margin and the time predicates are doing
 all the work. Stated as ratios rather than lumped together, because they are not the same
 number: the `runs` cap overshoots its lookback by ~27x (6.8 days against 6h) and the
-`job_ticks` cap by ~85x (3.6 days against 1h). Both cost a wider scan and nothing else. Re-sizing them, and setting alert thresholds, both want a week of
-post-storm series rather than another figure measured on top of an incident.
+`job_ticks` cap by ~85x (3.6 days against 1h). Both cost a wider scan and nothing else.
+
+#### The id caps are sized against the peak
+
+Re-sizing them from the quiet week, which is what this correction seemed to call for, is
+the wrong move and was rejected. An id cap's failure mode is *silent truncation*, and it
+can only truncate under load, so a cap tuned to steady state is guaranteed to bind exactly
+when the metric it guards is worth reading. Over-provisioning costs a wider index scan and
+nothing else. The two directions are not symmetric and should not be traded off as though
+they were.
+
+The full 30-day series — `sum(increase(kube_job_status_succeeded{namespace="dagster"}[6h]))`
+at 6h resolution, 2026-07-25 to 2026-08-24 — puts numbers on it:
+
+| | runs per 6h |
+|---|---|
+| quiet, both before the storm and since | 96–230 |
+| storm, sustained | 1200–3500 |
+| storm, peak | **7416** |
+
+A 50x swing on the same workload. `SQL_EXPORTER_RUN_WINDOW` stays at **20000**, 2.7x over
+that peak. Cutting it to the ~2000 a quiet week suggests would have truncated every 6h
+bucket from 2026-08-08 to 2026-08-18 but two, and `dagster_run_wait_to_start_seconds` is a
+queue-depth metric — a storm is the only time anyone reads it.
+
+`SQL_EXPORTER_TICK_WINDOW` is the one that genuinely overshoots, and it overshoots against
+its own peak rather than against a quiet week, so the rule above does not protect it. Ticks
+are cadence-bound, not demand-bound: tick rate tracks how many sensors exist, not how much
+work they find. Measured hourly from `dagster_recent_job_ticks` since #5495: on Production
+230–651, stepping to a flat 605–651 on 2026-08-22 when the sensor set changed; on QA a flat
+455–462. Peak 651/hour against a 1h lookback made 40000 a 61x cap. Cut to **8000**, which is
+12x the higher of the two environments, and still holds the span above the lookback if the
+sensor set grows eightfold.
+
+One measurement trap worth recording, since it nearly set this cap too low in the other
+direction: `max_over_time(sum(dagster_recent_job_ticks{cluster="data-qa"})[7d])` returns
+**12983**, which would have argued against 8000. Those samples predate the #5495 rollout to
+QA, when the query had no lookback at all and the metric was a whole-table count rather
+than an hourly rate. Any `dagster_recent_*` series from before #5495 landed on a given
+cluster measures a different thing under the same name.
+
+#### The storm started four days earlier than recorded
+
+Third correction from the same series: run creation steps from ~120 to ~2136 per 6h in the
+bucket covering **2026-08-07 16:53Z–22:53Z**, not on 2026-08-11, and stays elevated until
+2026-08-18 ~04:00Z. The end date on record is right; the start was taken from when the
+symptom was noticed rather than when the rate moved. Any window opened on 08-11 to avoid
+the storm still contains three days of it — which matters most for
+`tk-set-alert-thresholds-on-the-new-dagster-sql-expo-0063d0`, where a contaminated
+baseline becomes a threshold.
 
 
 ### 4. OpenTelemetry auto-instrumentation — the "why", not the "what"

--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -1341,26 +1341,28 @@ pgbouncer_service_monitor = kubernetes.apiextensions.CustomResource(
 #    So the peak is 7416 runs per 6h and the quiet floor is ~150 -- a 50x swing on
 #    the same workload, which is the whole argument for sizing off the top of it.
 #    RUN_WINDOW stays 20000 (2.7x over that peak). Cutting it to the ~2000 that a
-#    quiet week suggests would have truncated every 6h bucket from 2026-08-08 to
-#    2026-08-18 but two, and dagster_run_wait_to_start_seconds is a queue-depth
-#    metric: a storm is the only time anyone reads it.
+#    quiet week suggests would have truncated 30 of the 42 six-hour buckets in
+#    that stretch, and dagster_run_wait_to_start_seconds is a queue-depth metric:
+#    a storm is the only time anyone reads it.
 #
 #    TICK_WINDOW is the one that genuinely overshoots, and it overshoots against
 #    its own peak rather than against a quiet week, so the rule does not protect
 #    it. Ticks are cadence-bound, not demand-bound -- the daemon evaluates every
 #    sensor on a ~30s schedule whether or not it yields a run -- so tick rate
 #    tracks how many sensors exist, not how much work they find. Measured hourly
-#    from dagster_recent_job_ticks since #5495: 230-651, stepping to a flat
-#    605-651 on 2026-08-22 when the sensor set changed. Peak 651/hour against a 1h
-#    lookback made 40000 a 61x cap. 8000 is 12x, and still holds the invariant if
-#    the tick rate octuples.
+#    from dagster_recent_job_ticks since #5495: Production 230-651, stepping to a
+#    flat 605-651 at 2026-08-22 21:29Z when the sensor set changed; QA a flat
+#    455-462 since 2026-08-19. Peak 651/hour against a 1h lookback made 40000 a
+#    61x cap. 8000 is 12x, and still holds the invariant if the tick rate
+#    octuples.
 #
 #    A third correction while re-reading the series: the storm did not start on
 #    2026-08-11. Run creation steps from ~120 to ~2136 per 6h in the bucket
-#    covering 2026-08-07 16:53Z-22:53Z, four days before the window on record, and
-#    stays elevated until 2026-08-18 ~04:00Z. The end date is right; the start was
-#    taken from when the symptom was noticed. Any window opened on 08-11 to avoid
-#    the storm still contains three days of it.
+#    covering 2026-08-07 17:12Z-23:12Z, four days before the window on record, and
+#    falls back to ~112 by the bucket ending 2026-08-18 11:12Z, consistent with
+#    the 03:30Z end already on record. The end date is right; the start was taken
+#    from when the symptom was noticed. Any window opened on 08-11 to avoid the
+#    storm still contains three days of it.
 #
 #    Adding a lookback fixed the span but introduced a subtler fault: id is
 #    CREATION order, and the

--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -1322,14 +1322,48 @@ pgbouncer_service_monitor = kubernetes.apiextensions.CustomResource(
 #      08-21   616    08-24   528
 #
 #    ~520-670 runs/day, a 17x collapse from the 11.6k/day the caps were sized
-#    against. The caps are correspondingly over-provisioned, by different factors:
-#    span is currently 6.8 days on runs against a 6h lookback (~27x) and 3.6 days
-#    on job_ticks against a 1h lookback (~85x). Neither binds, so both time
-#    predicates do all the work; the cost is a wider scan and nothing else.
-#    Re-size from a quiet week, not from another incident.
+#    against.
 #
-#    Adding a lookback fixed
-#    the span but introduced a subtler fault: id is CREATION order, and the
+#    SIZING RULE, settled 2026-08-24: an id cap is sized against the PEAK, never
+#    against a quiet week. Its failure mode is silent truncation, and it can only
+#    truncate under load, so a cap tuned to steady state is guaranteed to bind
+#    exactly when the metric it guards is worth reading. Over-provisioning costs a
+#    wider index scan and nothing else. The two directions are not symmetric and
+#    should not be traded off as though they were.
+#
+#    That rule is what settles the two caps, and it settles them differently. The
+#    full 30-day series, sum(increase(kube_job_status_succeeded{namespace=
+#    "dagster"}[6h])) at 6h resolution, 2026-07-25 to 2026-08-24:
+#
+#      quiet          96-230 runs per 6h, both before the storm and since
+#      storm          1200-3500 per 6h sustained, peaking at 7416
+#
+#    So the peak is 7416 runs per 6h and the quiet floor is ~150 -- a 50x swing on
+#    the same workload, which is the whole argument for sizing off the top of it.
+#    RUN_WINDOW stays 20000 (2.7x over that peak). Cutting it to the ~2000 that a
+#    quiet week suggests would have truncated every 6h bucket from 2026-08-08 to
+#    2026-08-18 but two, and dagster_run_wait_to_start_seconds is a queue-depth
+#    metric: a storm is the only time anyone reads it.
+#
+#    TICK_WINDOW is the one that genuinely overshoots, and it overshoots against
+#    its own peak rather than against a quiet week, so the rule does not protect
+#    it. Ticks are cadence-bound, not demand-bound -- the daemon evaluates every
+#    sensor on a ~30s schedule whether or not it yields a run -- so tick rate
+#    tracks how many sensors exist, not how much work they find. Measured hourly
+#    from dagster_recent_job_ticks since #5495: 230-651, stepping to a flat
+#    605-651 on 2026-08-22 when the sensor set changed. Peak 651/hour against a 1h
+#    lookback made 40000 a 61x cap. 8000 is 12x, and still holds the invariant if
+#    the tick rate octuples.
+#
+#    A third correction while re-reading the series: the storm did not start on
+#    2026-08-11. Run creation steps from ~120 to ~2136 per 6h in the bucket
+#    covering 2026-08-07 16:53Z-22:53Z, four days before the window on record, and
+#    stays elevated until 2026-08-18 ~04:00Z. The end date is right; the start was
+#    taken from when the symptom was noticed. Any window opened on 08-11 to avoid
+#    the storm still contains three days of it.
+#
+#    Adding a lookback fixed the span but introduced a subtler fault: id is
+#    CREATION order, and the
 #    completion-time metrics filter on update_timestamp, so any run created before
 #    the cap but finishing inside the lookback was silently dropped -- long-running
 #    and long-queued runs first, which are the ones most worth counting.
@@ -1363,16 +1397,19 @@ pgbouncer_service_monitor = kubernetes.apiextensions.CustomResource(
 # 1ms and watching every query come back 57014.
 # Applies only to the creation-ordered run metric (wait-to-start) and the span
 # gauge. The completion-time run metrics range-scan idx_run_range instead and take
-# no id cap at all -- see the note on dagster_recent_runs. 20000 was sized against
-# a busiest-observed 6h of ~7416 creations for 2.7x headroom; post-storm a 6h holds
-# ~150-250 runs, so the real headroom is ~80-130x. See the correction above.
+# no id cap at all -- see the note on dagster_recent_runs. Sized against the
+# busiest 6h in 30 days, ~7416 creations, for 2.7x headroom. Quiet weeks hold
+# ~150-250 per 6h, which makes this look like ~100x headroom and is not the number
+# to size against -- see SIZING RULE above.
 SQL_EXPORTER_RUN_WINDOW = 20000
 # Ticks accrue far faster than runs -- the daemon evaluates every sensor on a ~30s
-# cadence whether or not it yields a run -- so the same id count buys a much shorter
-# span. Sized larger against a shorter lookback for that reason; the span metric
-# will say whether 40000 is enough, since unlike the run rate this one has not been
-# measured directly.
-SQL_EXPORTER_TICK_WINDOW = 40000
+# cadence whether or not it yields a run -- so the same id count buys a much
+# shorter span, and this gets a shorter lookback to match. The rate is now
+# measured rather than assumed: 651 ticks/hour at Production's peak and a flat
+# 459 on QA, against a 1h lookback. 8000 is 12x the higher of the two, and holds
+# the span above the lookback even if the sensor set grows eightfold. Was 40000,
+# a 61x cap sized before the rate was known.
+SQL_EXPORTER_TICK_WINDOW = 8000
 # Runs get 6h: long enough that a failure rate is built from thousands of runs at
 # peak and hundreds when quiet, short enough that a sustained problem moves it
 # within the hour. Ticks get 1h, because a sensor that starts erroring is an acute


### PR DESCRIPTION
## What are the relevant tickets?

Closes `tk-re-size-the-sql-exporter-id-caps-from-a-quiet-we-86fd39`. Follows #5576, #5495, #5476.

## Description

#5576 established that the Dagster run rate on record was measured inside the ol-data-platform retry storm and is ~17x too high. The obvious next move was to re-size the exporter's two id caps from the quiet week that followed. That is the wrong move for one of them, so this settles the rule rather than the numbers.

**An id cap's failure mode is silent truncation, and it can only truncate under load.** A cap tuned to steady state is therefore guaranteed to bind exactly when the metric it guards is worth reading. Over-provisioning costs a wider index scan and nothing else. The two directions are not symmetric and should not be traded off as though they were.

`sum(increase(kube_job_status_succeeded{namespace="dagster"}[6h]))`, full 30 days at 6h resolution:

| | runs per 6h |
|---|---|
| quiet, before the storm and since | 96–230 |
| storm, sustained | 1200–3500 |
| storm, peak | **7416** |

`SQL_EXPORTER_RUN_WINDOW` **stays at 20000**, 2.7x over that peak. Cutting it to the ~2000 a quiet week suggests would have truncated **30 of the 42 six-hour buckets** in that stretch, and `dagster_run_wait_to_start_seconds` is a queue-depth metric: a storm is the only time anyone reads it.

`SQL_EXPORTER_TICK_WINDOW` **40000 → 8000** is the one real re-size, and it clears the rule because it overshoots its *own peak* rather than a quiet week. Ticks are cadence-bound, not demand-bound: the rate tracks how many sensors exist, not how much work they find. Hourly from `dagster_recent_job_ticks` since #5495 — Production 230–651, stepping to a flat 605–651 at 2026-08-22 21:29Z when the sensor set changed; QA a flat 455–462 since 2026-08-19. 40000 was a 61x cap; 8000 is 12x, and holds the span above the 1h lookback even if the sensor set grows eightfold.

### Two further corrections to the record, from the same series

**The storm did not start on 2026-08-11.** Run creation steps from ~120 to ~2136 per 6h in the bucket covering 2026-08-07 17:12Z–23:12Z, four days earlier, and is back to ~112 by the bucket ending 2026-08-18 11:12Z — consistent with the 03:30Z end already on record. The end date is right; the start was taken from when the symptom was noticed rather than when the rate moved. A window opened on 08-11 to avoid the storm still contains three days of it, which matters most for the alert-threshold work, where a contaminated baseline becomes a threshold.

**A measurement trap that nearly set the tick cap too low in the other direction.** `max_over_time(sum(dagster_recent_job_ticks{cluster="data-qa"})[7d])` returns **12983**, which would have argued against 8000. Those samples are from 2026-08-18 15:39Z and 17:39Z, minutes before #5495 rolled out to QA, when the query had no lookback at all and the metric was a whole-table count rather than an hourly rate. Any `dagster_recent_*` series from before #5495 landed on a given cluster measures a different thing under the same name.

## How can this be tested?

`pulumi preview` on **both** stacks (`Production` and `QA`) shows the same two resources changing:

- `ConfigMap dagster-sql-exporter-config` — replaced; the two `job_ticks` id predicates change `40000` → `8000`
- `Deployment dagster-sql-exporter` — `checksum/ol-sql-exporter-config` flips `59d8f70c…` → `151d2b4a…`, which rolls the exporter pod so the new config takes effect

Two Helm releases also appear in the preview, diffing on image tags reverting to `latest`. Previewing `Production` with `dagster/__main__.py` reverted to `main` shows exactly those two and nothing else (`~ 2 to update, 83 unchanged`), so they are the usual local-config artifact and not from this change; CD passes real tags.

Post-deploy the check is `dagster_id_window_span_seconds{relation="job_ticks"}`. It should settle around **12h on Production** (8000 ids ÷ 651/hour) and **17h on QA** (÷ 459/hour), both well above the 1h lookback. If it lands at or below 1h the cap is binding and wants raising — that is the invariant the gauge exists to enforce, and the invariant is the deliverable here, not the specific number.

`pre-commit run` clean (ruff format, ruff check, mypy).
