### PR TITLE
fix(omnigraph): make terminationGracePeriodSeconds explicit, correct a stale shutdown claim

### DIFF
--- a/docs/omnigraph-storage-format-upgrade-runbook.md
+++ b/docs/omnigraph-storage-format-upgrade-runbook.md
@@ -340,10 +340,20 @@ kubectl -n omnigraph wait --for=delete pod \
 ```
 
 Wait on the **pod being gone**, not on `rollout status`. The deployment
-reconciles to zero long before the old server finishes terminating —
-`omnigraph-server` uses the full SIGTERM grace period — and until that process
-exits it is still a writer against the old root. `rollout status` reports the
-Deployment converged and would let you proceed with the server still up.
+reconciles to zero long before the old server finishes terminating, and
+until that process exits it is still a writer against the old root.
+`rollout status` reports the Deployment converged and would let you proceed
+with the server still up.
+
+(Live-verified 2026-08-24, against CI: the image now logs `shutdown signal
+received` on SIGTERM and the pod is typically gone within ~1s — a change
+from when this note was written, when it took the full
+`terminationGracePeriodSeconds` — see
+`tk-halve-the-omnigraph-server-restart-outage-it-bur-13b26a`. `--timeout
+120s` is generous rather than tuned to that number on purpose: the cap this
+stack now sets is 15s, but this step should not depend on shutdown staying
+fast. Keep waiting for the pod's actual deletion regardless of how quick it
+usually is.)
 
 Nothing may write to the old root from here until the migration completes or
 rolls back. `optimize`/`cleanup` write directly to the store, bypassing the

--- a/docs/omnigraph-storage-format-upgrade-runbook.md
+++ b/docs/omnigraph-storage-format-upgrade-runbook.md
@@ -339,21 +339,26 @@ kubectl -n omnigraph wait --for=delete pod \
   -l app.kubernetes.io/name=omnigraph-server --timeout=120s
 ```
 
-Wait on the **pod being gone**, not on `rollout status`. The deployment
-reconciles to zero long before the old server finishes terminating, and
-until that process exits it is still a writer against the old root.
-`rollout status` reports the Deployment converged and would let you proceed
-with the server still up.
+Wait on the **pod being gone**, not on `rollout status`. The Deployment
+reconciles to zero as soon as the old pod is marked for deletion — before
+the old server has actually finished terminating — and until that process
+exits it is still a writer against the old root. `rollout status` reports
+the Deployment converged and would let you proceed with the server still
+up, whether that gap turns out to be a second or the full grace period.
 
 (Live-verified 2026-08-24, against CI: the image now logs `shutdown signal
 received` on SIGTERM and the pod is typically gone within ~1s — a change
 from when this note was written, when it took the full
 `terminationGracePeriodSeconds` — see
-`tk-halve-the-omnigraph-server-restart-outage-it-bur-13b26a`. `--timeout
-120s` is generous rather than tuned to that number on purpose: the cap this
-stack now sets is 15s, but this step should not depend on shutdown staying
-fast. Keep waiting for the pod's actual deletion regardless of how quick it
-usually is.)
+`tk-halve-the-omnigraph-server-restart-outage-it-bur-13b26a`. That task
+also considered lowering `terminationGracePeriodSeconds` below its 30s
+default now that shutdown is typically fast, and deliberately did NOT: this
+pod admits writes it expects to take up to 30s (the tool call's own
+deadline — see the per-actor admission-cap comment in `data_tier.py`), so a
+lower cap would let a routine restart SIGKILL a write the server had
+already decided was safe to admit. `--timeout 120s` here is generous for
+the same reason this step's advice stands regardless of the ~1s typical
+case: shutdown speed is not something this procedure should depend on.)
 
 Nothing may write to the old root from here until the migration completes or
 rolls back. `optimize`/`cleanup` write directly to the store, bypassing the

--- a/src/ol_infrastructure/applications/omnigraph/data_tier.py
+++ b/src/ol_infrastructure/applications/omnigraph/data_tier.py
@@ -585,7 +585,7 @@ def create_data_tier(  # noqa: PLR0913
                 ),
                 spec=kubernetes.core.v1.PodSpecArgs(
                     service_account_name=OMNIGRAPH_SERVICE_ACCOUNT_NAME,
-                    # An explicit cap, not the Kubernetes 30s default this
+                    # An explicit value, not the Kubernetes 30s default this
                     # Deployment left implicit until now.
                     # tk-halve-the-omnigraph-server-restart-outage-it-bur-13b26a
                     # was filed 2026-08-03 against a measured ~52-61s restart
@@ -593,7 +593,7 @@ def create_data_tier(  # noqa: PLR0913
                     # dead time — no graceful-shutdown log line, the
                     # signature of a container SIGKILLed at the grace-period
                     # deadline having done nothing in between. Re-measured
-                    # live against CI on 2026-08-24 before adding this: the
+                    # live against CI on 2026-08-24 before touching this: the
                     # image now logs `shutdown signal received` on SIGTERM
                     # and the pod is fully deleted within the same second —
                     # `kubectl get events`, `Killing` and the replacement
@@ -602,19 +602,28 @@ def create_data_tier(  # noqa: PLR0913
                     # startupProbe's own tuned budget below), not shutdown.
                     # Whatever upstream change did this — plausibly riding
                     # the `edge` tag, per this stack's existing pin — the 30s
-                    # of dead time this task describes no longer reproduces.
+                    # of dead time this task describes no longer reproduces
+                    # in the typical case.
                     #
-                    # Set anyway, as a cap rather than a fix: this pins the
-                    # WORST case (a future regression, a wedged shutdown) to
-                    # a few seconds above the now-typical ~1s exit, rather
-                    # than leaving a full, unbounded 30s of blast radius on
-                    # the table for something that currently costs nothing.
-                    # 15s is comfortably above every observed exit with
-                    # headroom for actual graceful-shutdown work (metrics
-                    # flush, connection drain) to complete under normal load,
-                    # and still a firm ~50% reduction from the default if
-                    # shutdown is ever slow again.
-                    termination_grace_period_seconds=15,
+                    # NOT lowered below 30 despite that, on review: this pod
+                    # already admits writes it expects to take up to the
+                    # tool-call deadline below, not just an instant — see the
+                    # per-actor admission-cap sizing above, MEASURED
+                    # 2026-08-12: n=4 concurrent single-row writes wall
+                    # 15.54s, comfortably admitted as "lands inside the
+                    # deadline". A cap below that would let a routine
+                    # restart SIGKILL a write the server had already decided
+                    # was safe to admit — trading a bounded, expected outage
+                    # for the exact indeterminate-outcome risk
+                    # tk-a-502-from-the-deployed-witan-does-not-mean-the--f76dcb
+                    # describes, on every restart rather than only under
+                    # genuine overload. 30 is the tool call's own hard
+                    # deadline (three hardcoded ToolHive constants, same
+                    # comment block) — the client has already given up and
+                    # treated the call as failed by the time the server
+                    # would still be waiting, so there is nothing to gain by
+                    # going higher, and real risk in going lower.
+                    termination_grace_period_seconds=30,
                     containers=[
                         kubernetes.core.v1.ContainerArgs(
                             name="omnigraph-server",

--- a/src/ol_infrastructure/applications/omnigraph/data_tier.py
+++ b/src/ol_infrastructure/applications/omnigraph/data_tier.py
@@ -585,6 +585,36 @@ def create_data_tier(  # noqa: PLR0913
                 ),
                 spec=kubernetes.core.v1.PodSpecArgs(
                     service_account_name=OMNIGRAPH_SERVICE_ACCOUNT_NAME,
+                    # An explicit cap, not the Kubernetes 30s default this
+                    # Deployment left implicit until now.
+                    # tk-halve-the-omnigraph-server-restart-outage-it-bur-13b26a
+                    # was filed 2026-08-03 against a measured ~52-61s restart
+                    # outage, ~30s of which was believed to be pure SIGTERM
+                    # dead time — no graceful-shutdown log line, the
+                    # signature of a container SIGKILLed at the grace-period
+                    # deadline having done nothing in between. Re-measured
+                    # live against CI on 2026-08-24 before adding this: the
+                    # image now logs `shutdown signal received` on SIGTERM
+                    # and the pod is fully deleted within the same second —
+                    # `kubectl get events`, `Killing` and the replacement
+                    # pod's `Scheduled` both timestamped 17:38:32. Total
+                    # outage that run was ~26s, essentially all boot (the
+                    # startupProbe's own tuned budget below), not shutdown.
+                    # Whatever upstream change did this — plausibly riding
+                    # the `edge` tag, per this stack's existing pin — the 30s
+                    # of dead time this task describes no longer reproduces.
+                    #
+                    # Set anyway, as a cap rather than a fix: this pins the
+                    # WORST case (a future regression, a wedged shutdown) to
+                    # a few seconds above the now-typical ~1s exit, rather
+                    # than leaving a full, unbounded 30s of blast radius on
+                    # the table for something that currently costs nothing.
+                    # 15s is comfortably above every observed exit with
+                    # headroom for actual graceful-shutdown work (metrics
+                    # flush, connection drain) to complete under normal load,
+                    # and still a firm ~50% reduction from the default if
+                    # shutdown is ever slow again.
+                    termination_grace_period_seconds=15,
                     containers=[
                         kubernetes.core.v1.ContainerArgs(
                             name="omnigraph-server",


### PR DESCRIPTION
### What are the relevant tickets?
N/A (tracked in the team's internal witan multi-user deployment project, task `tk-halve-the-omnigraph-server-restart-outage-it-bur-13b26a`)

### Description (What does it do?)
The task was filed 2026-08-03 against a measured ~52-61s omnigraph-server restart outage, with ~30s believed to be pure SIGTERM dead time — no graceful-shutdown log line at the time, the signature of a container SIGKILLed at the `terminationGracePeriodSeconds` deadline (Kubernetes' 30s default, left unset in this stack) having done nothing in between.

Before touching any code, re-measured live against the CI deployment: **that premise no longer holds**. Triggered a `kubectl rollout restart deployment/omnigraph-server` in CI and captured logs + events across it:

- The image now logs `shutdown signal received` on SIGTERM.
- `kubectl get events` shows the old pod's `Killing` event and the replacement pod's `Scheduled` event both timestamped in the **same second** (`17:38:32`), and the old pod's `SuccessfulDelete` in that same second too — proof the process exited on its own quickly rather than being SIGKILLed at the grace-period deadline (kubelet only SIGKILLs at the deadline; it can't be why the pod was gone within ~1s).
- Total outage that run was **~26s**, down from the original 52-61s — already close to "halved" — and what's left is essentially all boot time, which separate prior work already tuned (`data_tier.py`'s startupProbe sizing, landed after this task was filed).

So the fix this task asked for (candidate #1/#2 in its own writeup — lower the grace period, or get an upstream SIGTERM fix) appears to have already landed upstream, plausibly riding this stack's `edge` tag pin.

**Original version of this PR lowered `terminationGracePeriodSeconds` to 15 — reverted after review**, correctly: this pod already admits writes it expects to take up to the tool call's own 30s deadline (per-actor admission-cap comment, `data_tier.py`: n=4 concurrent single-row writes wall 15.54s, explicitly documented as "lands inside the deadline"). A 15s cap would let a routine restart SIGKILL a write the server had already decided was safe to admit, trading a bounded outage for the exact indeterminate-outcome risk `tk-a-502-from-the-deployed-witan-does-not-mean-the--f76dcb` describes — on every restart, not just under genuine overload.

What this PR does now:
- Sets `terminationGracePeriodSeconds: 30` explicitly on the omnigraph-server Deployment — same effective value as the Kubernetes default it replaces, chosen deliberately to match the tool call's own hard deadline rather than being an arbitrary carry-over. Pins intent (protects against a future Kubernetes default change) without reducing the write-duration budget this pod already relies on.
- Corrects `docs/omnigraph-storage-format-upgrade-runbook.md`'s now-inaccurate claim that "`omnigraph-server` uses the full SIGTERM grace period" / "reconciles to zero long before the old server finishes terminating" (both written when that was true), while leaving its safety-first advice — wait for the pod's actual deletion, not `rollout status` — unchanged, since that's the right practice regardless of how fast shutdown typically is.

Did not pursue candidate #3 from the original task (tighten the readiness probe) — that's already been done by separate prior work (`startupProbe` with `periodSeconds=5`, `initialDelaySeconds=20`, sized against measured boot times, plus zero-delay readiness/liveness once startup passes).

### How can this be tested?
- `uv run pre-commit run --all-files` and `uv run mypy` pass on the changed files.
- `pulumi preview --stack <CI|QA|Production>`, each with `OMNIGRAPH_DOCKER_SHA` set to that environment's live image digest: all three show a single-field `Deployment` update (`+ terminationGracePeriodSeconds: 30`), no replace, no unrelated diff.
- Not re-deployed as part of this PR. The live restart used to verify the premise was run against CI directly via `kubectl rollout restart`, independent of this diff (it observes current behavior, doesn't change anything) — logs and event timestamps are quoted above.

### Additional Context
This PR is smaller than the original task envisioned, because most of the value it was chasing turned out to already be delivered by an external change outside ol-infrastructure's control. What's left is making the value explicit (rather than an unexplained implicit default) and correcting docs that no longer match observed behavior — not the numeric "halving" the task's title describes, which already happened upstream.