### PR TITLE
fix(edxapp): codify the mitxonline CMS celery floor of 3 that a kubectl patch set live

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
@@ -121,9 +121,20 @@ config:
       lms_high_mem:
         max: 3
         min: 1
+      # Floor of 3, not 1, because of the 2026-08-19 memory-starvation incident:
+      # a lone worker's RSS climbed 1.3Gi -> 3.5Gi over ~17h under a full-catalog
+      # reindex while course exports slowed, and the redis queue-depth trigger
+      # never saw it (tasks were dequeued promptly, so edx.cms.core.default stayed
+      # under listLength=10). Raised live by kubectl patch on 2026-08-20; codified
+      # here so Pulumi co-owns .spec.minReplicaCount instead of fighting that
+      # field manager for it. Spreading the load over three long-lived workers
+      # keeps any one of them from being the sole path for every task while it
+      # degrades. The memory trigger on this ScaledObject (k8s_autoscaling.py) is
+      # the structural fix for the same incident; revisit this floor only after
+      # that trigger has proven itself in production.
       cms:
         max: 20
-        min: 1
+        min: 3
   edxapp:k8s_resources:
     webapp:
       lms:


### PR DESCRIPTION
## What are the relevant tickets?

Unblocks the Granian overhaul Stage 3 rollout for mitxonline. Blocks #5461, #5488, #5543 from ever reaching production.

## Description (What does this do?)

`preview-ol-infrastructure-edxapp-application.mitxonline-mitxonline-production` has failed on **every run since 2026-08-20** (builds 14–18; last success build 13, 2026-08-19). Each fails in ~40s with:

```
Apply failed with 1 conflict: conflict with "kubectl-patch" using keda.sh/v1alpha1: .spec.minReplicaCount
```

Someone ran `kubectl patch` on `mitxonline-production-edxapp-cms-celery-scaledobject` at `2026-08-20T15:31:24Z`, taking server-side-apply ownership of `.spec.minReplicaCount` and setting it to `3`. The stack config declared `celery.cms.min: 1`, so every Pulumi apply tried to change a field another field manager owned to a different value — exactly what SSA raises a conflict for.

The edxapp chain is built `topology="preview-gated"`, so each stage's deploy is gated on a preview **of itself**. One red preview therefore blocked the deploy outright. Four days of mitxonline edxapp production deploys were lost, including the Granian CMS change (#5461), the TCP-liveness probe split (#5488), and the CMS celery memory-utilization trigger (#5543).

This sets `celery.cms.min: 3` in `Pulumi.mitxonline.Production.yaml`, with the rationale recorded inline.

### Why 3, and not a revert to 1

The patch was **not** arbitrary, and reverting it would have been the wrong call. It was the live mitigation for the same incident that #5543 addresses structurally — the one already written up in the `k8s_autoscaling.py` comment:

> On 2026-08-19 a mitxonline production cms-celery replica's memory climbed from ~1.3Gi to ~3.5Gi (of a 4Gi request / 6Gi VPA-managed limit) over about 17 hours [...] The HPA's desired-replica count never left 1 the entire time: tasks were still being dequeued promptly, so `edx.cms.core.default` never crossed `listLength=10`.

The metrics line up exactly: `kube_horizontalpodautoscaler_status_desired_replicas` for this HPA sat pinned at `1` from `2026-08-19T22:00Z` straight through to `2026-08-20T15:30Z` — ~17.5 hours — and stepped to `3` in the sample immediately after the patch timestamp.

So the floor bump was the human stopgap for the incident, and #5543 is the codified fix for it. Dropping back to `1` here would have undone the stopgap at the exact moment the structural fix landed. The floor stays at 3; the inline comment says to revisit it only once the memory trigger has proven itself in production.

Worth noting the memory trigger is not redundant with the floor — all three live workers are currently at 2.5–3.3Gi of the 4Gi request, i.e. already above the trigger's `AverageValue` target of 70% × 4Gi. Long-lived workers all accumulate, so the floor does not average the signal away.

### Why declaring the value clears the conflict

SSA only objects when an applier would *change* a field another manager owns. Applying the value `kubectl-patch` already holds lands in the "unchanged" set, so Pulumi **co-owns** `.spec.minReplicaCount` rather than fighting for it. No `--force-conflicts`, no managed-field surgery, and the live cluster value does not move.

## How can this be tested?

Reproduced and verified against the live production cluster with `pulumi preview -s mitxonline.Production` (`EDXAPP_DOCKER_IMAGE_DIGEST` set from the running deployment).

**Before** — exits non-zero:
```
error: Preview failed: [...] server-side apply field conflict detected
The resource managed by field manager "pulumi-kubernetes-79edcd00" had an apply conflict:
Apply failed with 1 conflict: conflict with "kubectl-patch" using keda.sh/v1alpha1: .spec.minReplicaCount
```

**After** — exits 0, no diagnostics, `25 changes. 216 unchanged`.

The ScaledObject diff is exactly what it should be:
```
~ spec: {
    ~ minReplicaCount: 1 => 3
    ~ triggers       : [
        + [1]: [secret]
      ]
  }
```
`1 => 3` is Pulumi **state** catching up to the value already live in the cluster — the running floor does not change. The added trigger is #5543's memory trigger finally getting to apply.

Please re-run the Concourse preview job to confirm in CI; I could not (no `fly -t infrastructure` session).

## Additional Context

Two follow-ups filed separately, neither blocking this:

- The stale `kubectl-patch` managedFields entry should be stripped **after** this deploys, so Pulumi becomes sole owner. Order matters: stripping it first would leave `.spec.minReplicaCount` unowned and let an apply of `min: 1` silently drop the production floor.
- Nothing alerts on a preview-gated stack whose preview has been red for days. That is the reason this went unnoticed for four days, and it will happen again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)