### PR TITLE
fix(grafana): store the Slack webhook URL unescaped so notifications send

### DIFF
--- a/src/bridge/secrets/grafana_cloud/api.ci.yaml
+++ b/src/bridge/secrets/grafana_cloud/api.ci.yaml
@@ -5,14 +5,19 @@
 grafana_url: ENC[AES256_GCM,data:mxYffpU7OwW4k66LMa6oZcxAR3tWik5ANDXvfA==,iv:oMu/9hNSf8jj9G8yMOGiZcaCFED5UMbhWbSsoKap2DY=,tag:ahz7rMrgQh+zC0wZ219L7A==,type:str]
 grafana_api_token: ENC[AES256_GCM,data:SYLbEyPPM3phyJKC7l0di4DsxOZdnpEgcwA3wm12s9JXYjRut7HTzv3F+zYJlQ==,iv:z6Qwu5OzfrgQ+apiEKLqUbfb/4DVPpVnJXHM8jAhpTE=,tag:c6Gg1SJz+5pYmsZyvgDnng==,type:str]
 rootly_bearer_token: ENC[AES256_GCM,data:E6PgEeCyd+Ro/xOFfJFLfPOBxvC6EQyYYCjEyZj/2XTgGmeQCkDI0ShnDX859zKy0DHlBTlX7KD9R6vn6AMHHg==,iv:V/2scFJ2ZR19Y8g2bAHsPlYBj04OSGy+PPBP6+lggb4=,tag:uGeE66MBRW/WyQP2BbYRjg==,type:str]
-slack_notifications_ocw_misc_api_url: ENC[AES256_GCM,data:AZeVmqkCsRIPq2P4qNJXTOyECfXLEiB2vcs6+dHn8QgYmNJbhG/IP4yzEgQx7Ctv/HRNAzVboC78Gl92ohn7JhOtCbslsyCSwtR/i9E3ztejXYUPwWMofQU9qA==,iv:+o0+XIGGvDZTFbQRO/3d1jUW2qjIhjNBUrYSWKGuQyc=,tag:xGYFYKZZNI1Z/xq4EJx2cw==,type:str]
+slack_notifications_ocw_misc_api_url: ENC[AES256_GCM,data:tTNPqGCG6xZVrQXndQaCniFNv1+C1OEI135Q0hszRlrTDFlZlr1jt1cT3KxykRNTywhtmSU+TzuJNV/TpH60lv/YikPTZ1+uBpDXHNRz3g==,iv:/FE1yuvDu+g5jkB9yuUNuo7cbZ568k7OQ7CY1/HTIJM=,tag:PXvcct/mteHk+rPxa7s0xg==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:key/29397ad6-5cfd-43ef-8f43-818b19ab75e4
-    aws_profile: ""
     created_at: "2026-07-10T14:47:29Z"
     enc: AQICAHjksIVfl1VtAHpBda/1YYjj6tSeS2o4TXgvEEyBIXLjjwEePSmL+IZiK7kKUplwUWyVAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMjvHc6X9KRZbu5U0DAgEQgDv7WsDpTMkXN9fs8ipl23U1/g+5NCsMPTiXM5aiXDQVtQoYqFX0Oy2bwA0YT8d25lLe6SvwyIBG0tDh3Q==
-  lastmodified: "2026-07-10T14:47:30Z"
-  mac: ENC[AES256_GCM,data:ZAK0Edbi6Ph/LLdVK24Wp4Mjqm9G1/b0Bi/MAuCN1bp1W+RF1PahejeozYtO7NAkcpH4nlRjgstGNK3BNaNBPyZ12BR9YwYjgtdtWSqL8zIt3cfJrjGJIgSi2MuLpF/hwdyCSCF3UnHNZaqAIqqDreLHgbXq+iJi3fu0+4I9QJU=,iv:x2hZxLqXGDQdcSuu1kbkVR5KQDHH0Rm21rSv3RLuCNI=,tag:P5rzGD4ueQysQBeQrnBTvQ==,type:str]
+    aws_profile: ""
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: "2026-08-24T18:31:31Z"
+  mac: ENC[AES256_GCM,data:UcHd6GhIzslnuZSu7CR9WE2OfI8RKM18MDdPLMo6SVyHKl9qTdcQO4+LsSHnyGI+LBek0lXAbZVdwu6MWA49zaRAc9bw5BsE56soaOmEPtKr/uxZFZ9RNYyhtS7lfuBwNnC5ZIA7u05aWOt5BBPCHCOp/d3APojAlsb38OAmnSY=,iv:VlVax3W1HtsJK/+uLh5Tw4nTLDFZL9F+Eqf7DSsswFw=,tag:4KDJhLATnPpz+cUKqZmFzA==,type:str]
+  pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.13.2

--- a/src/bridge/secrets/grafana_cloud/api.production.yaml
+++ b/src/bridge/secrets/grafana_cloud/api.production.yaml
@@ -11,17 +11,22 @@
 grafana_url: ENC[AES256_GCM,data:+7TTZ7VHBTTn/PcOL9F72Md9kM2aKYT9kbDzGxK+fZs1/kLd,iv:0vb8gEECsegdlE2ukHtJ+/PTCfgNbLbOG0AagjlIGk8=,tag:4tNaAAaEiyPzL3Ha2EvKIQ==,type:str]
 grafana_api_token: ENC[AES256_GCM,data:mtAitkY9a+DvJuE9oavZSr5s2gg/0sefz24IBXeU4/Q1X6GmGeMYxP2pHsVmYQ==,iv:1MPyg8kkX8l8FCo9zQOaThKu1f+MshRnCBnyMYoZs0c=,tag:3vY+icGNxuebJP3WeupS3g==,type:str]
 rootly_bearer_token: ENC[AES256_GCM,data:DU0yeHwpjYNBeIFx6GcU2aqbif9h+c9zf4OMV461Qg3ywKZB3WMLUiE+V5Fk5mT4J7rQ+1kOaWhQ+95FYw+Tuw==,iv:XF4RgfmnV9ScUcXkebkNcH8d3iPOI7Qq3bdKGfCxBLM=,tag:M3TKehW4lcKn3HnigVK9GA==,type:str]
-slack_notifications_ocw_misc_api_url: ENC[AES256_GCM,data:orY1MnxxmTpMiAC/r3azEuMikSDxIdXPlgeRGIGOsyVcZRwf4QjVrbIyNLRUeNx7fnCmjflFm6tTY4fCQAusBJr4NpxzPviTzkz5HUP7R7nZjhGZk5UzjtaBbg==,iv:rDbETYHcAHkUxf52TN2qayhDFgf8h68IxAXXDrmi/Rg=,tag:3P9hf6F8SP6hvl3Mifn2Qg==,type:str]
+slack_notifications_ocw_misc_api_url: ENC[AES256_GCM,data:slmWtYFXXQnkTUlzeKyYXx7IPK3oY2nxYvd66A0T5hUsohe/dwfD9F3l7/GG68cacMnQu44RkU+qQWfKiOzUuBtawOAb3xsyXZHYVLY1/A==,iv:dqZxRttoiWeEN353NZV2W70y8rmTo0VobfRFGRT96Xc=,tag:AqrpbdgN2GtTEnn4fy8ZWA==,type:str]
 pingdom_api_token: ENC[AES256_GCM,data:La1G+qPKgUdXZ2b4i+QDynzFwnpboF1lDt9z3XONBDnUaGZUuRXnhgNQb8Pjlqywzyp1HkZ9MyfDHe7jziOSIrgOG1IU4Fo=,iv:KVzqs7g/a3cYfFB/0tL7GSxnhiUwzny8i+BOnopZyrg=,tag:Aed9XxD9YymwgvGZvSJWmg==,type:str]
 pingdom_integration_ids:
 - ENC[AES256_GCM,data:ojQOBarpFeI=,iv:gwQKECX61CzM9vxsTo8UHsHL1HCOks+CLBJvrqubT90=,tag:Ly0lzPMKH7+ik18ozCB68A==,type:int]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:key/29397ad6-5cfd-43ef-8f43-818b19ab75e4
-    aws_profile: ""
     created_at: "2026-07-10T15:03:58Z"
     enc: AQICAHjksIVfl1VtAHpBda/1YYjj6tSeS2o4TXgvEEyBIXLjjwFNIzGcGgM1KENBlXEv2ZBYAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMQcrb+1MpmUkbEdw7AgEQgDvWmWFA7jsZSuN6sLk0VmRuIlwIhLjZgiZPlXO+0FUxB96Y9L3CtNHdbKVR1NGSDurEgQqhbQVgZGdAtQ==
-  lastmodified: "2026-07-10T15:03:58Z"
-  mac: ENC[AES256_GCM,data:8hOiQDnkUqgFo/pvs3PemziqVfj2hr3Nb85jdwg9PrYz2+PLcIN5Hk4feKZHSZWaNlEBnvUkdmn5bd0cygjph7QQtkoOBL0CzjwAmFic5+JtqDaZfwiOLAa2E2I0PSoqh4h8S6VwO6pgw2B5kFRuSwuXcWzS6Alsw3fOh9a+jto=,iv:WPwvDgH+Spg+cO+HAZfMdXWVyJi7bD0qvA92aB+9yUA=,tag:/B4bO4EDrMjs5w37A1rf2A==,type:str]
+    aws_profile: ""
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: "2026-08-24T18:31:08Z"
+  mac: ENC[AES256_GCM,data:AwM4cmF0e1zcOXNavFvTX/VpqVBLMt3O9FlFGtvd25u8OdfO9FQtwSt51V8iYsqbOyRFXiNukBMhiSeg6XlD6CqR2OaIbtr7bLnJ3l+l0CuURCGqlsQg7vVg4Bak/Lbh/1fv5+1AP+KloFVpBArt5D1u6inwhsSLI5dN8IenHPY=,iv:O9YrRXJLK5K3JzPguQD7uOyOUA2P93Kyx0H8EWfjhhE=,tag:CguyCgaVM4Idzc6le39EbA==,type:str]
+  pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.13.2

--- a/src/bridge/secrets/grafana_cloud/api.qa.yaml
+++ b/src/bridge/secrets/grafana_cloud/api.qa.yaml
@@ -5,14 +5,19 @@
 grafana_url: ENC[AES256_GCM,data:/IR86dLbrBzg3Pg87GA09gSCIR6YPXAsX3iHHg==,iv:PlwAOOsJKOTXmlb1Yx5PJ2iYIcjNYMg3YiNLqkN8ibQ=,tag:jVD4nRq5Lk8rgfrGChspIg==,type:str]
 grafana_api_token: ENC[AES256_GCM,data:kcCR8sln6Zpj/D4ymiMVM+AsGsSIKUWM0JuuqT3/u0rECKCPOuO2uYctlHPfKA==,iv:02HVWhOFNiyinWRXlea/uMdI/cY7BYDSiL4Bqe6DXWs=,tag:yfQzmKrW9u9mjdlOIMuTeg==,type:str]
 rootly_bearer_token: ENC[AES256_GCM,data:A2umpeiaysO9bPkarF0n0B3IpK3bzo9jlE1XR8u0KWzhm0kEQxQNL2Ae9xheK/2BiO9oMkXFs9QqlKQshMzJxQ==,iv:hWa/1yjf5hgbwf/aVvp29wk1YFRod0vnDHsKXWh8zds=,tag:IhjfNCC7Fkq7bCA3OVhdPA==,type:str]
-slack_notifications_ocw_misc_api_url: ENC[AES256_GCM,data:9ktK+wy8GN6MI/dNnUTUWjHsQ+T6bRFVm0mFza2wgrH6rUatW7ve2ur7Zbev3m7Woebj3a50j9R5JUfnsqvY3TL8JEL7rHjOOiHAMInQ4Ha2IeWWP/qFWEKddw==,iv:G/OMPajhOwHGwJnKISqZO3s2AO7UvvgX1bWJr6jY+jU=,tag:JZzpCHi57iBvkUDsFdewww==,type:str]
+slack_notifications_ocw_misc_api_url: ENC[AES256_GCM,data:KLGSURPOOiQmwBDQbUv3OV4YmQinTcMkg9e+p4O1W6+BFdHHdOD+5BZlHCBvsAzPHFjNTl3m77lEXKcY8z1smNbxYVz1801RejKt12mZMA==,iv:p+aIOqaehCPkTyrnNla3YmtEWmKHdXNbqq977sKZp/8=,tag:VD5HB+0Uti4v6Lw1z06czQ==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:key/29397ad6-5cfd-43ef-8f43-818b19ab75e4
-    aws_profile: ""
     created_at: "2026-07-10T14:52:41Z"
     enc: AQICAHjksIVfl1VtAHpBda/1YYjj6tSeS2o4TXgvEEyBIXLjjwE+fKFYVDLykn7wUalQaSBOAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM9GysDEpZaq0Cjl1SAgEQgDusvlBU7ob2vsr0fZlXFtwIVLLjjgRJFAk94oUw2sk1R/tyVIAq0NOWwzXnSzUDXKMe3/LDpgK4Zed3mQ==
-  lastmodified: "2026-07-10T14:52:41Z"
-  mac: ENC[AES256_GCM,data:gjsJKpC5RxCcjo1Bjq5ox4dzWD1LrmEnPMsjqsEeZKgddy+IrZNErzKnFGQrHrZYdvlnEBc9h+9DYYYzfJL8HClPxbW0QtN62WgaAyHDmssqww+LALMH1nGP1M0r3IChscyJMSX7Glu837MWqlmJRnUTobOFFgu8vcgoTN9esaQ=,iv:hyeXwwmncmbtNRg0S8Zjvil8RV6YIrSSkZZQ9NECdU0=,tag:rr3KWI4SdwsdPwfCWZ2xkw==,type:str]
+    aws_profile: ""
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: "2026-08-24T18:31:20Z"
+  mac: ENC[AES256_GCM,data:Pc+yXBYNXN9hTa+BkE7hP09HX3g4zg0gjqko2jmpzunCX4/ywmYSI/UAPyZa39CxCX0N03ISAq59E1aHm8NYuZGLGs97Uoq8rLAXw/EDd7MCrF/QwH+qguOvuw6b2yE7K+VBo/SfXeCEag9xNJaVFW2EWhDA0H8/Q+DsNDZUhHo=,iv:1KZfh16JMcANyABVuYCiukSDIRaYyx3EiNOwGdTEf74=,tag:C7KyuMtfXbpR8RMxR1Arlg==,type:str]
+  pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.13.2


### PR DESCRIPTION
### What are the relevant tickets?
Context: #5569 — the APISIX edge SLO rules whose alerts were the first ever routed to a Slack contact point, which is how this surfaced.

### Description (What does it do?)
Stores `slack_notifications_ocw_misc_api_url` unescaped in all three `grafana_cloud` stacks, and rotates the webhook.

- The value was JSON-escaped (`https:\/\/hooks.slack.com\/...`). YAML plain scalars don't process backslash escapes, so the backslashes reached Grafana intact and Go's `url.Parse` read them as an opaque path with no host — every send failed with `http: no Host in request URL`.
- [All four Slack contact points share this one secret](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/infrastructure/grafana_alerting/alertmanager.py#L70-L132), so `#devops-warnings` and the ocw-misc pair have delivered nothing since the value was first stored on 2026-07-10 in #4851.
- Rotated as well as repaired: Grafana returns the full URL unredacted in `lastNotifyAttemptError` from `GET /api/alertmanager/grafana/config/api/v1/receivers`.

### How can this be tested?
Verified so far: `sops -d` on all three files returns an unescaped `https://hooks.slack.com/...` URL. Not applied anywhere yet.

After apply, check delivery rather than config:

1. `GET /api/alertmanager/grafana/config/api/v1/receivers` — `lastNotifyAttemptError` must be **empty**, not merely different, on `slack-devops-warnings-warning` and `slack-devops-warnings-critical`.
2. `notifications_failed_per_integration_per_second{stack_id="256439",integration="slack"}` (`grafanacloud-usage`) must return to 0. It was climbing 0 → 0.025/s on 2026-08-24.
3. Confirm a message actually lands in `#devops-warnings`. `APISIXEdge5xxRateFast`/`Slow` are firing for api.mitxonline.mit.edu right now, so no synthetic trigger is needed.

### Additional Context
`pulumi preview` showed no diff on these contact points — declared and live agreed, both holding the escaped string. A config-comparison drift check cannot catch this class of failure; delivery has to be asserted separately.

### Checklist:
- [ ] Apply grafana-alerting to CI / QA / Production
- [ ] Confirm a message lands in `#devops-warnings`
- [ ] Deactivate the old webhook in Slack
