### PR TITLE
feat: rename student_risk_probability to ml in pipeline and main modules

### DIFF
--- a/src/ol_concourse/pipelines/infrastructure/dagster/pipeline.py
+++ b/src/ol_concourse/pipelines/infrastructure/dagster/pipeline.py
@@ -44,8 +44,8 @@ def build_dagster_docker_pipeline() -> Pipeline:
         {"name": "openedx", "module": "openedx.definitions"},
         {"name": "b2b_organization", "module": "b2b_organization.definitions"},
         {
-            "name": "student_risk_probability",
-            "module": "student_risk_probability.definitions",
+            "name": "ml",
+            "module": "ml.definitions",
         },
         {"name": "k8s", "module": None},  # dagster-k8s base image
     ]

--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -2090,8 +2090,8 @@ code_locations: list[dict[str, str | int]] = [
         "port": 4007,
     },
     {
-        "name": "student_risk_probability",
-        "module": "student_risk_probability.definitions",
+        "name": "ml",
+        "module": "ml.definitions",
         "port": 4008,
     },
 ]


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
https://github.com/mitodl/ol-data-platform/pull/2592

### Description (What does it do?)
<!--- Describe your changes in detail -->
 Renames the `student_risk_probability` Dagster code location to `ml`, matching the same rename in ol-data-platform (mitodl/ol-data-platform#2592). It needs to be merged and deployed together with that PR for concourse deployment


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
