### PR TITLE
fix(concourse): grant iam:ListPolicyTags for the infra worker role

### DIFF
--- a/src/ol_infrastructure/applications/concourse/iam_policies/pulumi_infra.py
+++ b/src/ol_infrastructure/applications/concourse/iam_policies/pulumi_infra.py
@@ -447,6 +447,13 @@ policy_definition = {
                 "iam:DeleteUser",
                 "iam:DetachRolePolicy",
                 "iam:DetachUserPolicy",
+                # Read path for the AWS provider's policy refresh, not a
+                # companion permission TagPolicy itself needs -- confirmed via
+                # a live AccessDeniedException on ListPolicyTags while
+                # updating mitpress-sftp-iam-policy, distinct from (and not
+                # evidence for) the ListPolicyTags-for-TagPolicy claim already
+                # verified false elsewhere for this same statement.
+                "iam:ListPolicyTags",
                 "iam:RemoveUserFromGroup",
                 "iam:TagPolicy",
                 "iam:TagRole",

--- a/src/ol_infrastructure/applications/concourse/iam_policies/pulumi_infra.py
+++ b/src/ol_infrastructure/applications/concourse/iam_policies/pulumi_infra.py
@@ -292,6 +292,7 @@ policy_definition = {
                 "iam:ListAttachedRolePolicies",
                 "iam:ListEntitiesForPolicy",
                 "iam:ListGroupsForUser",
+                "iam:ListPolicyTags",
                 "iam:ListPolicyVersions",
                 "iam:ListRolePolicies",
                 "iam:ListRoles",
@@ -447,13 +448,6 @@ policy_definition = {
                 "iam:DeleteUser",
                 "iam:DetachRolePolicy",
                 "iam:DetachUserPolicy",
-                # Read path for the AWS provider's policy refresh, not a
-                # companion permission TagPolicy itself needs -- confirmed via
-                # a live AccessDeniedException on ListPolicyTags while
-                # updating mitpress-sftp-iam-policy, distinct from (and not
-                # evidence for) the ListPolicyTags-for-TagPolicy claim already
-                # verified false elsewhere for this same statement.
-                "iam:ListPolicyTags",
                 "iam:RemoveUserFromGroup",
                 "iam:TagPolicy",
                 "iam:TagRole",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
`pulumi-aws-sftp/qa`'s first run under the pipeline's now-correct QA/CI stages (#5575) surfaced two missing grants on `concourse-instance-role-worker-infra-production`:

- `transfer:UpdateServer` -- already picked up and merged by the scheduled `iam-policy-drift` run in #5586, no action needed here.
- `iam:ListPolicyTags` -- not yet granted anywhere. This PR adds it.

The AWS provider reads a policy's tags via `ListPolicyTags` during resource refresh -- a read path, distinct from `TagPolicy`/`UntagPolicy`'s own write operation (already granted in #5571). This is unrelated to (and not evidence for) the Sentry bug-prediction bot's earlier claim on #5571 that `TagPolicy` itself needs `ListPolicyTags` as a companion permission -- that claim was checked against AWS's Tag/Untag action model and this same file's own `iam:TagRole` grant (works without `iam:ListRoleTags`) and refuted. This is a separate, confirmed-live gap: `iam:ListPolicyTags` denied while updating `mitpress-sftp-iam-policy`, not while calling `TagPolicy`.

### How can this be tested?
- Reproduced live: `pulumi-aws-sftp/deploy-ol-infrastructure-aws-sftp-qa` build #1 failed with `AccessDeniedException: ... is not authorized to perform: iam:ListPolicyTags on resource: policy arn:aws:iam::610119931565:policy/mitpress-sftp-iam-policy-06a54d4`.
- Ran the same `lint_iam_policy()` call and `parliament_config` that `concourse/__main__.py` uses at deploy time against the updated module -- no findings.
- `pre-commit` (ruff format/check, mypy) passes.

Haven't re-triggered the pipeline against this change yet since it isn't merged.

### Additional Context
Found while re-sweeping Concourse pipelines across all teams after #5568/#5570/#5571/#5575/#5578 landed and were verified live.
