### PR TITLE
fix(grafana): give #devops-warnings its own Slack webhook, reverting #5587

### DIFF
--- a/src/bridge/secrets/grafana_cloud/api.ci.yaml
+++ b/src/bridge/secrets/grafana_cloud/api.ci.yaml
@@ -6,13 +6,19 @@ grafana_url: ENC[AES256_GCM,data:mxYffpU7OwW4k66LMa6oZcxAR3tWik5ANDXvfA==,iv:oMu
 grafana_api_token: ENC[AES256_GCM,data:SYLbEyPPM3phyJKC7l0di4DsxOZdnpEgcwA3wm12s9JXYjRut7HTzv3F+zYJlQ==,iv:z6Qwu5OzfrgQ+apiEKLqUbfb/4DVPpVnJXHM8jAhpTE=,tag:c6Gg1SJz+5pYmsZyvgDnng==,type:str]
 rootly_bearer_token: ENC[AES256_GCM,data:E6PgEeCyd+Ro/xOFfJFLfPOBxvC6EQyYYCjEyZj/2XTgGmeQCkDI0ShnDX859zKy0DHlBTlX7KD9R6vn6AMHHg==,iv:V/2scFJ2ZR19Y8g2bAHsPlYBj04OSGy+PPBP6+lggb4=,tag:uGeE66MBRW/WyQP2BbYRjg==,type:str]
 slack_notifications_ocw_misc_api_url: ENC[AES256_GCM,data:AZeVmqkCsRIPq2P4qNJXTOyECfXLEiB2vcs6+dHn8QgYmNJbhG/IP4yzEgQx7Ctv/HRNAzVboC78Gl92ohn7JhOtCbslsyCSwtR/i9E3ztejXYUPwWMofQU9qA==,iv:+o0+XIGGvDZTFbQRO/3d1jUW2qjIhjNBUrYSWKGuQyc=,tag:xGYFYKZZNI1Z/xq4EJx2cw==,type:str]
+slack_notifications_devops_warnings: ENC[AES256_GCM,data:KiSHG4DkTTU8sGIq7VggNliAYKoXa9Al600fThD0x7B5WQCQaSNy/Hft3eLdq71kqgbgpJA9AL5ydguG+6Bpq5gs1xVxCc4nEuQk/S0oEQ==,iv:M1jkJbWiEbpBrEvIeHTSnK2JBFzpMq3cmyom7CYRK+w=,tag:wYmzY7YJtmGEDYoT7ejzxg==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:key/29397ad6-5cfd-43ef-8f43-818b19ab75e4
-    aws_profile: ""
     created_at: "2026-07-10T14:47:29Z"
     enc: AQICAHjksIVfl1VtAHpBda/1YYjj6tSeS2o4TXgvEEyBIXLjjwEePSmL+IZiK7kKUplwUWyVAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMjvHc6X9KRZbu5U0DAgEQgDv7WsDpTMkXN9fs8ipl23U1/g+5NCsMPTiXM5aiXDQVtQoYqFX0Oy2bwA0YT8d25lLe6SvwyIBG0tDh3Q==
-  lastmodified: "2026-07-10T14:47:30Z"
-  mac: ENC[AES256_GCM,data:ZAK0Edbi6Ph/LLdVK24Wp4Mjqm9G1/b0Bi/MAuCN1bp1W+RF1PahejeozYtO7NAkcpH4nlRjgstGNK3BNaNBPyZ12BR9YwYjgtdtWSqL8zIt3cfJrjGJIgSi2MuLpF/hwdyCSCF3UnHNZaqAIqqDreLHgbXq+iJi3fu0+4I9QJU=,iv:x2hZxLqXGDQdcSuu1kbkVR5KQDHH0Rm21rSv3RLuCNI=,tag:P5rzGD4ueQysQBeQrnBTvQ==,type:str]
+    aws_profile: ""
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: "2026-08-24T19:14:35Z"
+  mac: ENC[AES256_GCM,data:5o1tqQOuOoVQ5Jpjq7h3h7nhXkekIpj5woXkigscUtYGN2xLuL+vHv1x9Q5T4S+PqJ+gb0+ydLWwBA4z53wDsRxDbD8UcbzgXYMYxVO6N7R8rZmAkWOVhYjVahalZ/NNPYLFQGZ1LNqU70WszENBtNWE5H19oXsk1bhtCfsUbvU=,iv:XdDNLu/ub4ELdDmfqBm+Xl8yPP3QT3nsq3oi8GdihPw=,tag:3WmUqqfEIFhadrTYq5V57A==,type:str]
+  pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.13.2

--- a/src/bridge/secrets/grafana_cloud/api.ci.yaml
+++ b/src/bridge/secrets/grafana_cloud/api.ci.yaml
@@ -5,19 +5,14 @@
 grafana_url: ENC[AES256_GCM,data:mxYffpU7OwW4k66LMa6oZcxAR3tWik5ANDXvfA==,iv:oMu/9hNSf8jj9G8yMOGiZcaCFED5UMbhWbSsoKap2DY=,tag:ahz7rMrgQh+zC0wZ219L7A==,type:str]
 grafana_api_token: ENC[AES256_GCM,data:SYLbEyPPM3phyJKC7l0di4DsxOZdnpEgcwA3wm12s9JXYjRut7HTzv3F+zYJlQ==,iv:z6Qwu5OzfrgQ+apiEKLqUbfb/4DVPpVnJXHM8jAhpTE=,tag:c6Gg1SJz+5pYmsZyvgDnng==,type:str]
 rootly_bearer_token: ENC[AES256_GCM,data:E6PgEeCyd+Ro/xOFfJFLfPOBxvC6EQyYYCjEyZj/2XTgGmeQCkDI0ShnDX859zKy0DHlBTlX7KD9R6vn6AMHHg==,iv:V/2scFJ2ZR19Y8g2bAHsPlYBj04OSGy+PPBP6+lggb4=,tag:uGeE66MBRW/WyQP2BbYRjg==,type:str]
-slack_notifications_ocw_misc_api_url: ENC[AES256_GCM,data:tTNPqGCG6xZVrQXndQaCniFNv1+C1OEI135Q0hszRlrTDFlZlr1jt1cT3KxykRNTywhtmSU+TzuJNV/TpH60lv/YikPTZ1+uBpDXHNRz3g==,iv:/FE1yuvDu+g5jkB9yuUNuo7cbZ568k7OQ7CY1/HTIJM=,tag:PXvcct/mteHk+rPxa7s0xg==,type:str]
+slack_notifications_ocw_misc_api_url: ENC[AES256_GCM,data:AZeVmqkCsRIPq2P4qNJXTOyECfXLEiB2vcs6+dHn8QgYmNJbhG/IP4yzEgQx7Ctv/HRNAzVboC78Gl92ohn7JhOtCbslsyCSwtR/i9E3ztejXYUPwWMofQU9qA==,iv:+o0+XIGGvDZTFbQRO/3d1jUW2qjIhjNBUrYSWKGuQyc=,tag:xGYFYKZZNI1Z/xq4EJx2cw==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:key/29397ad6-5cfd-43ef-8f43-818b19ab75e4
+    aws_profile: ""
     created_at: "2026-07-10T14:47:29Z"
     enc: AQICAHjksIVfl1VtAHpBda/1YYjj6tSeS2o4TXgvEEyBIXLjjwEePSmL+IZiK7kKUplwUWyVAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMjvHc6X9KRZbu5U0DAgEQgDv7WsDpTMkXN9fs8ipl23U1/g+5NCsMPTiXM5aiXDQVtQoYqFX0Oy2bwA0YT8d25lLe6SvwyIBG0tDh3Q==
-    aws_profile: ""
-  gcp_kms: []
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: "2026-08-24T18:31:31Z"
-  mac: ENC[AES256_GCM,data:UcHd6GhIzslnuZSu7CR9WE2OfI8RKM18MDdPLMo6SVyHKl9qTdcQO4+LsSHnyGI+LBek0lXAbZVdwu6MWA49zaRAc9bw5BsE56soaOmEPtKr/uxZFZ9RNYyhtS7lfuBwNnC5ZIA7u05aWOt5BBPCHCOp/d3APojAlsb38OAmnSY=,iv:VlVax3W1HtsJK/+uLh5Tw4nTLDFZL9F+Eqf7DSsswFw=,tag:4KDJhLATnPpz+cUKqZmFzA==,type:str]
-  pgp: []
+  lastmodified: "2026-07-10T14:47:30Z"
+  mac: ENC[AES256_GCM,data:ZAK0Edbi6Ph/LLdVK24Wp4Mjqm9G1/b0Bi/MAuCN1bp1W+RF1PahejeozYtO7NAkcpH4nlRjgstGNK3BNaNBPyZ12BR9YwYjgtdtWSqL8zIt3cfJrjGJIgSi2MuLpF/hwdyCSCF3UnHNZaqAIqqDreLHgbXq+iJi3fu0+4I9QJU=,iv:x2hZxLqXGDQdcSuu1kbkVR5KQDHH0Rm21rSv3RLuCNI=,tag:P5rzGD4ueQysQBeQrnBTvQ==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.13.2

--- a/src/bridge/secrets/grafana_cloud/api.production.yaml
+++ b/src/bridge/secrets/grafana_cloud/api.production.yaml
@@ -12,16 +12,22 @@ grafana_url: ENC[AES256_GCM,data:+7TTZ7VHBTTn/PcOL9F72Md9kM2aKYT9kbDzGxK+fZs1/kL
 grafana_api_token: ENC[AES256_GCM,data:mtAitkY9a+DvJuE9oavZSr5s2gg/0sefz24IBXeU4/Q1X6GmGeMYxP2pHsVmYQ==,iv:1MPyg8kkX8l8FCo9zQOaThKu1f+MshRnCBnyMYoZs0c=,tag:3vY+icGNxuebJP3WeupS3g==,type:str]
 rootly_bearer_token: ENC[AES256_GCM,data:DU0yeHwpjYNBeIFx6GcU2aqbif9h+c9zf4OMV461Qg3ywKZB3WMLUiE+V5Fk5mT4J7rQ+1kOaWhQ+95FYw+Tuw==,iv:XF4RgfmnV9ScUcXkebkNcH8d3iPOI7Qq3bdKGfCxBLM=,tag:M3TKehW4lcKn3HnigVK9GA==,type:str]
 slack_notifications_ocw_misc_api_url: ENC[AES256_GCM,data:orY1MnxxmTpMiAC/r3azEuMikSDxIdXPlgeRGIGOsyVcZRwf4QjVrbIyNLRUeNx7fnCmjflFm6tTY4fCQAusBJr4NpxzPviTzkz5HUP7R7nZjhGZk5UzjtaBbg==,iv:rDbETYHcAHkUxf52TN2qayhDFgf8h68IxAXXDrmi/Rg=,tag:3P9hf6F8SP6hvl3Mifn2Qg==,type:str]
+slack_notifications_devops_warnings: ENC[AES256_GCM,data:11b0TdhhNxw8w97Gh+2QDu9nHNKbQ32huH6SAm/bjrJ8Oy8yXOZdfepjmR84mY57zSnOBtmToceSDxvem+wR6S4TOZkl32juUIPOxPrFDw==,iv:v1MM26d6tR5qyXi2YVKJL2nnVdRHWl80WTtDUff0dL4=,tag:prVzZtgruj8P2FytqbZMaw==,type:str]
 pingdom_api_token: ENC[AES256_GCM,data:La1G+qPKgUdXZ2b4i+QDynzFwnpboF1lDt9z3XONBDnUaGZUuRXnhgNQb8Pjlqywzyp1HkZ9MyfDHe7jziOSIrgOG1IU4Fo=,iv:KVzqs7g/a3cYfFB/0tL7GSxnhiUwzny8i+BOnopZyrg=,tag:Aed9XxD9YymwgvGZvSJWmg==,type:str]
 pingdom_integration_ids:
 - ENC[AES256_GCM,data:ojQOBarpFeI=,iv:gwQKECX61CzM9vxsTo8UHsHL1HCOks+CLBJvrqubT90=,tag:Ly0lzPMKH7+ik18ozCB68A==,type:int]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:key/29397ad6-5cfd-43ef-8f43-818b19ab75e4
-    aws_profile: ""
     created_at: "2026-07-10T15:03:58Z"
     enc: AQICAHjksIVfl1VtAHpBda/1YYjj6tSeS2o4TXgvEEyBIXLjjwFNIzGcGgM1KENBlXEv2ZBYAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMQcrb+1MpmUkbEdw7AgEQgDvWmWFA7jsZSuN6sLk0VmRuIlwIhLjZgiZPlXO+0FUxB96Y9L3CtNHdbKVR1NGSDurEgQqhbQVgZGdAtQ==
-  lastmodified: "2026-07-10T15:03:58Z"
-  mac: ENC[AES256_GCM,data:8hOiQDnkUqgFo/pvs3PemziqVfj2hr3Nb85jdwg9PrYz2+PLcIN5Hk4feKZHSZWaNlEBnvUkdmn5bd0cygjph7QQtkoOBL0CzjwAmFic5+JtqDaZfwiOLAa2E2I0PSoqh4h8S6VwO6pgw2B5kFRuSwuXcWzS6Alsw3fOh9a+jto=,iv:WPwvDgH+Spg+cO+HAZfMdXWVyJi7bD0qvA92aB+9yUA=,tag:/B4bO4EDrMjs5w37A1rf2A==,type:str]
+    aws_profile: ""
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: "2026-08-24T19:15:11Z"
+  mac: ENC[AES256_GCM,data:Q0nKmJ2oJwcXKzJf6dnu/BhkkNCDeMPpI+ZQzHS0RfKC9AvuIKgFtXZlnVU4Ryg3CJPU5dkEkKU60/RbJtCjJjllGSiqsvoIwq47Lo3gPz7NRNT53nVfOe/ogqllFz11i4ptMyv/HgkoWSbu/9oZlcBz6rl7h3Jh3KixRX7S8c8=,iv:d6D2lPs+ES+E40MjMKrWkNUCWB4SFU1JD54+zMzkaQs=,tag:EGwIHklVg1ijQ0Hc5A3wOQ==,type:str]
+  pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.13.2

--- a/src/bridge/secrets/grafana_cloud/api.production.yaml
+++ b/src/bridge/secrets/grafana_cloud/api.production.yaml
@@ -11,22 +11,17 @@
 grafana_url: ENC[AES256_GCM,data:+7TTZ7VHBTTn/PcOL9F72Md9kM2aKYT9kbDzGxK+fZs1/kLd,iv:0vb8gEECsegdlE2ukHtJ+/PTCfgNbLbOG0AagjlIGk8=,tag:4tNaAAaEiyPzL3Ha2EvKIQ==,type:str]
 grafana_api_token: ENC[AES256_GCM,data:mtAitkY9a+DvJuE9oavZSr5s2gg/0sefz24IBXeU4/Q1X6GmGeMYxP2pHsVmYQ==,iv:1MPyg8kkX8l8FCo9zQOaThKu1f+MshRnCBnyMYoZs0c=,tag:3vY+icGNxuebJP3WeupS3g==,type:str]
 rootly_bearer_token: ENC[AES256_GCM,data:DU0yeHwpjYNBeIFx6GcU2aqbif9h+c9zf4OMV461Qg3ywKZB3WMLUiE+V5Fk5mT4J7rQ+1kOaWhQ+95FYw+Tuw==,iv:XF4RgfmnV9ScUcXkebkNcH8d3iPOI7Qq3bdKGfCxBLM=,tag:M3TKehW4lcKn3HnigVK9GA==,type:str]
-slack_notifications_ocw_misc_api_url: ENC[AES256_GCM,data:slmWtYFXXQnkTUlzeKyYXx7IPK3oY2nxYvd66A0T5hUsohe/dwfD9F3l7/GG68cacMnQu44RkU+qQWfKiOzUuBtawOAb3xsyXZHYVLY1/A==,iv:dqZxRttoiWeEN353NZV2W70y8rmTo0VobfRFGRT96Xc=,tag:AqrpbdgN2GtTEnn4fy8ZWA==,type:str]
+slack_notifications_ocw_misc_api_url: ENC[AES256_GCM,data:orY1MnxxmTpMiAC/r3azEuMikSDxIdXPlgeRGIGOsyVcZRwf4QjVrbIyNLRUeNx7fnCmjflFm6tTY4fCQAusBJr4NpxzPviTzkz5HUP7R7nZjhGZk5UzjtaBbg==,iv:rDbETYHcAHkUxf52TN2qayhDFgf8h68IxAXXDrmi/Rg=,tag:3P9hf6F8SP6hvl3Mifn2Qg==,type:str]
 pingdom_api_token: ENC[AES256_GCM,data:La1G+qPKgUdXZ2b4i+QDynzFwnpboF1lDt9z3XONBDnUaGZUuRXnhgNQb8Pjlqywzyp1HkZ9MyfDHe7jziOSIrgOG1IU4Fo=,iv:KVzqs7g/a3cYfFB/0tL7GSxnhiUwzny8i+BOnopZyrg=,tag:Aed9XxD9YymwgvGZvSJWmg==,type:str]
 pingdom_integration_ids:
 - ENC[AES256_GCM,data:ojQOBarpFeI=,iv:gwQKECX61CzM9vxsTo8UHsHL1HCOks+CLBJvrqubT90=,tag:Ly0lzPMKH7+ik18ozCB68A==,type:int]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:key/29397ad6-5cfd-43ef-8f43-818b19ab75e4
+    aws_profile: ""
     created_at: "2026-07-10T15:03:58Z"
     enc: AQICAHjksIVfl1VtAHpBda/1YYjj6tSeS2o4TXgvEEyBIXLjjwFNIzGcGgM1KENBlXEv2ZBYAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMQcrb+1MpmUkbEdw7AgEQgDvWmWFA7jsZSuN6sLk0VmRuIlwIhLjZgiZPlXO+0FUxB96Y9L3CtNHdbKVR1NGSDurEgQqhbQVgZGdAtQ==
-    aws_profile: ""
-  gcp_kms: []
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: "2026-08-24T18:31:08Z"
-  mac: ENC[AES256_GCM,data:AwM4cmF0e1zcOXNavFvTX/VpqVBLMt3O9FlFGtvd25u8OdfO9FQtwSt51V8iYsqbOyRFXiNukBMhiSeg6XlD6CqR2OaIbtr7bLnJ3l+l0CuURCGqlsQg7vVg4Bak/Lbh/1fv5+1AP+KloFVpBArt5D1u6inwhsSLI5dN8IenHPY=,iv:O9YrRXJLK5K3JzPguQD7uOyOUA2P93Kyx0H8EWfjhhE=,tag:CguyCgaVM4Idzc6le39EbA==,type:str]
-  pgp: []
+  lastmodified: "2026-07-10T15:03:58Z"
+  mac: ENC[AES256_GCM,data:8hOiQDnkUqgFo/pvs3PemziqVfj2hr3Nb85jdwg9PrYz2+PLcIN5Hk4feKZHSZWaNlEBnvUkdmn5bd0cygjph7QQtkoOBL0CzjwAmFic5+JtqDaZfwiOLAa2E2I0PSoqh4h8S6VwO6pgw2B5kFRuSwuXcWzS6Alsw3fOh9a+jto=,iv:WPwvDgH+Spg+cO+HAZfMdXWVyJi7bD0qvA92aB+9yUA=,tag:/B4bO4EDrMjs5w37A1rf2A==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.13.2

--- a/src/bridge/secrets/grafana_cloud/api.qa.yaml
+++ b/src/bridge/secrets/grafana_cloud/api.qa.yaml
@@ -5,19 +5,14 @@
 grafana_url: ENC[AES256_GCM,data:/IR86dLbrBzg3Pg87GA09gSCIR6YPXAsX3iHHg==,iv:PlwAOOsJKOTXmlb1Yx5PJ2iYIcjNYMg3YiNLqkN8ibQ=,tag:jVD4nRq5Lk8rgfrGChspIg==,type:str]
 grafana_api_token: ENC[AES256_GCM,data:kcCR8sln6Zpj/D4ymiMVM+AsGsSIKUWM0JuuqT3/u0rECKCPOuO2uYctlHPfKA==,iv:02HVWhOFNiyinWRXlea/uMdI/cY7BYDSiL4Bqe6DXWs=,tag:yfQzmKrW9u9mjdlOIMuTeg==,type:str]
 rootly_bearer_token: ENC[AES256_GCM,data:A2umpeiaysO9bPkarF0n0B3IpK3bzo9jlE1XR8u0KWzhm0kEQxQNL2Ae9xheK/2BiO9oMkXFs9QqlKQshMzJxQ==,iv:hWa/1yjf5hgbwf/aVvp29wk1YFRod0vnDHsKXWh8zds=,tag:IhjfNCC7Fkq7bCA3OVhdPA==,type:str]
-slack_notifications_ocw_misc_api_url: ENC[AES256_GCM,data:KLGSURPOOiQmwBDQbUv3OV4YmQinTcMkg9e+p4O1W6+BFdHHdOD+5BZlHCBvsAzPHFjNTl3m77lEXKcY8z1smNbxYVz1801RejKt12mZMA==,iv:p+aIOqaehCPkTyrnNla3YmtEWmKHdXNbqq977sKZp/8=,tag:VD5HB+0Uti4v6Lw1z06czQ==,type:str]
+slack_notifications_ocw_misc_api_url: ENC[AES256_GCM,data:9ktK+wy8GN6MI/dNnUTUWjHsQ+T6bRFVm0mFza2wgrH6rUatW7ve2ur7Zbev3m7Woebj3a50j9R5JUfnsqvY3TL8JEL7rHjOOiHAMInQ4Ha2IeWWP/qFWEKddw==,iv:G/OMPajhOwHGwJnKISqZO3s2AO7UvvgX1bWJr6jY+jU=,tag:JZzpCHi57iBvkUDsFdewww==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:key/29397ad6-5cfd-43ef-8f43-818b19ab75e4
+    aws_profile: ""
     created_at: "2026-07-10T14:52:41Z"
     enc: AQICAHjksIVfl1VtAHpBda/1YYjj6tSeS2o4TXgvEEyBIXLjjwE+fKFYVDLykn7wUalQaSBOAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM9GysDEpZaq0Cjl1SAgEQgDusvlBU7ob2vsr0fZlXFtwIVLLjjgRJFAk94oUw2sk1R/tyVIAq0NOWwzXnSzUDXKMe3/LDpgK4Zed3mQ==
-    aws_profile: ""
-  gcp_kms: []
-  azure_kv: []
-  hc_vault: []
-  age: []
-  lastmodified: "2026-08-24T18:31:20Z"
-  mac: ENC[AES256_GCM,data:Pc+yXBYNXN9hTa+BkE7hP09HX3g4zg0gjqko2jmpzunCX4/ywmYSI/UAPyZa39CxCX0N03ISAq59E1aHm8NYuZGLGs97Uoq8rLAXw/EDd7MCrF/QwH+qguOvuw6b2yE7K+VBo/SfXeCEag9xNJaVFW2EWhDA0H8/Q+DsNDZUhHo=,iv:1KZfh16JMcANyABVuYCiukSDIRaYyx3EiNOwGdTEf74=,tag:C7KyuMtfXbpR8RMxR1Arlg==,type:str]
-  pgp: []
+  lastmodified: "2026-07-10T14:52:41Z"
+  mac: ENC[AES256_GCM,data:gjsJKpC5RxCcjo1Bjq5ox4dzWD1LrmEnPMsjqsEeZKgddy+IrZNErzKnFGQrHrZYdvlnEBc9h+9DYYYzfJL8HClPxbW0QtN62WgaAyHDmssqww+LALMH1nGP1M0r3IChscyJMSX7Glu837MWqlmJRnUTobOFFgu8vcgoTN9esaQ=,iv:hyeXwwmncmbtNRg0S8Zjvil8RV6YIrSSkZZQ9NECdU0=,tag:rr3KWI4SdwsdPwfCWZ2xkw==,type:str]
   unencrypted_suffix: _unencrypted
   version: 3.13.2

--- a/src/bridge/secrets/grafana_cloud/api.qa.yaml
+++ b/src/bridge/secrets/grafana_cloud/api.qa.yaml
@@ -6,13 +6,19 @@ grafana_url: ENC[AES256_GCM,data:/IR86dLbrBzg3Pg87GA09gSCIR6YPXAsX3iHHg==,iv:Plw
 grafana_api_token: ENC[AES256_GCM,data:kcCR8sln6Zpj/D4ymiMVM+AsGsSIKUWM0JuuqT3/u0rECKCPOuO2uYctlHPfKA==,iv:02HVWhOFNiyinWRXlea/uMdI/cY7BYDSiL4Bqe6DXWs=,tag:yfQzmKrW9u9mjdlOIMuTeg==,type:str]
 rootly_bearer_token: ENC[AES256_GCM,data:A2umpeiaysO9bPkarF0n0B3IpK3bzo9jlE1XR8u0KWzhm0kEQxQNL2Ae9xheK/2BiO9oMkXFs9QqlKQshMzJxQ==,iv:hWa/1yjf5hgbwf/aVvp29wk1YFRod0vnDHsKXWh8zds=,tag:IhjfNCC7Fkq7bCA3OVhdPA==,type:str]
 slack_notifications_ocw_misc_api_url: ENC[AES256_GCM,data:9ktK+wy8GN6MI/dNnUTUWjHsQ+T6bRFVm0mFza2wgrH6rUatW7ve2ur7Zbev3m7Woebj3a50j9R5JUfnsqvY3TL8JEL7rHjOOiHAMInQ4Ha2IeWWP/qFWEKddw==,iv:G/OMPajhOwHGwJnKISqZO3s2AO7UvvgX1bWJr6jY+jU=,tag:JZzpCHi57iBvkUDsFdewww==,type:str]
+slack_notifications_devops_warnings: ENC[AES256_GCM,data:i7kfKdS8DJmLTjK+7WQJFplHYx8JatqqHSBwhUidrYENii+SjP0NZwmAeJgg3bvZXP5R5YHtfHW4p7fcXIHlKi0asclruiieG3QJqmWGlw==,iv:BBmxvQmirGDTbNwpT5Cku/Agw+jj0k0hGQm8OljXHds=,tag:gN0TH/xq7bRt1/zYWAdgZQ==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:key/29397ad6-5cfd-43ef-8f43-818b19ab75e4
-    aws_profile: ""
     created_at: "2026-07-10T14:52:41Z"
     enc: AQICAHjksIVfl1VtAHpBda/1YYjj6tSeS2o4TXgvEEyBIXLjjwE+fKFYVDLykn7wUalQaSBOAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM9GysDEpZaq0Cjl1SAgEQgDusvlBU7ob2vsr0fZlXFtwIVLLjjgRJFAk94oUw2sk1R/tyVIAq0NOWwzXnSzUDXKMe3/LDpgK4Zed3mQ==
-  lastmodified: "2026-07-10T14:52:41Z"
-  mac: ENC[AES256_GCM,data:gjsJKpC5RxCcjo1Bjq5ox4dzWD1LrmEnPMsjqsEeZKgddy+IrZNErzKnFGQrHrZYdvlnEBc9h+9DYYYzfJL8HClPxbW0QtN62WgaAyHDmssqww+LALMH1nGP1M0r3IChscyJMSX7Glu837MWqlmJRnUTobOFFgu8vcgoTN9esaQ=,iv:hyeXwwmncmbtNRg0S8Zjvil8RV6YIrSSkZZQ9NECdU0=,tag:rr3KWI4SdwsdPwfCWZ2xkw==,type:str]
+    aws_profile: ""
+  gcp_kms: []
+  azure_kv: []
+  hc_vault: []
+  age: []
+  lastmodified: "2026-08-24T19:14:56Z"
+  mac: ENC[AES256_GCM,data:zfPXANZNn7eYogEYD1Eqd1maBYhizVlN8BhR50k55sMYPBnXg9xK55BCV3Z5HtYP5loXMY95sHpwVKSKP223mUwyOJ38vAIaFaon3d5faXYKS/ftCp8jFOI73sfRhsXtCSXG/rKTPmxco9AprOA6c1ezFCE2QpQCfAXrMR/nlV0=,iv:v0JbU93rNaSAdBb5/KzClHApCt+R3CFjWCZvHIqQLbA=,tag:cM1zfEBZzSYL5NQ6eehOcg==,type:str]
+  pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.13.2

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/CLAUDE.md
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/CLAUDE.md
@@ -454,6 +454,7 @@ grafana_url: https://<stack>.grafana.net
 grafana_api_token: <service-account-token>
 rootly_bearer_token: <rootly-webhook-bearer-token>
 slack_notifications_ocw_misc_api_url: <slack-webhook-url>
+slack_notifications_devops_warnings: <slack-webhook-url>  # required; used by devops-warnings contact points
 
 # Production only (Pingdom checks run from production stack only):
 pingdom_api_token: <pingdom-api-token>

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/alertmanager.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/alertmanager.py
@@ -98,15 +98,12 @@ def create(grafana_secrets: dict[str, Any], resource_opts: ResourceOptions) -> N
 
     # devops-warnings Slack — non-paging visibility for cluster-wide capacity
     # signals that aren't any one team's concern (e.g. HPAAtMaxReplicas*,
-    # which fires for every CI/QA/production workload). Reuses the OCW misc
-    # webhook/token above rather than a new secret -- ContactPointSlackArgs'
-    # `recipient` picks the channel independently of `url`, and this Slack
-    # app is already invited to #devops-warnings (it posts there today via
-    # Rootly's separate `CI/QA Slack Notifications` escalation policy).
+    # which fires for every CI/QA/production workload). Uses its own
+    # `slack_notifications_devops_warnings` secret (a per-stack required key
+    # in the grafana-alerting secrets file; see CLAUDE.md § Secrets reference).
     # Deliberately a distinct pair of contact points, not a shared one with
-    # ocw-misc: routing here is decided per-rule by the `channel` label
-    # (see the policy branch below), and giving each destination its own
-    # contact point keeps that mapping obvious from resource names alone.
+    # ocw-misc: each destination has its own contact point to keep the
+    # resource-name→channel mapping obvious from resource names alone.
     alerting.ContactPoint(
         "slack-devops-warnings-warning",
         name="slack-devops-warnings-warning",

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/alertmanager.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/alertmanager.py
@@ -112,7 +112,7 @@ def create(grafana_secrets: dict[str, Any], resource_opts: ResourceOptions) -> N
         name="slack-devops-warnings-warning",
         slacks=[
             alerting.ContactPointSlackArgs(
-                url=grafana_secrets["slack_notifications_ocw_misc_api_url"],
+                url=grafana_secrets["slack_notifications_devops_warnings"],
                 recipient="#devops-warnings",
                 color="warning",
                 icon_emoji=":goose_warning:",
@@ -129,7 +129,7 @@ def create(grafana_secrets: dict[str, Any], resource_opts: ResourceOptions) -> N
         name="slack-devops-warnings-critical",
         slacks=[
             alerting.ContactPointSlackArgs(
-                url=grafana_secrets["slack_notifications_ocw_misc_api_url"],
+                url=grafana_secrets["slack_notifications_devops_warnings"],
                 recipient="#devops-warnings",
                 color="danger",
                 title=':alert: [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{- end }}] - {{ .CommonLabels.alertname }}',


### PR DESCRIPTION
### What are the relevant tickets?
Reverts #5587. Context: #5569, whose APISIX edge SLO alerts were the first ever routed to a Slack contact point and so exposed that Slack delivery had never worked.

### Description (What does it do?)
Gives `#devops-warnings` its own webhook from a new Slack application, and backs out the half-fix that #5587 left on main.

- Adds `slack_notifications_devops_warnings` to the CI/QA/Production `grafana_cloud` secrets and repoints [both `slack-devops-warnings-*` contact points](https://github.com/mitodl/ol-infrastructure/blob/main/src/ol_infrastructure/infrastructure/grafana_alerting/alertmanager.py#L112-L132) at it, instead of sharing the ocw-misc webhook.
- Reverts #5587. That PR un-escaped the shared URL, but the webhook behind it had been deactivated, so delivery merely moved from `http: no Host in request URL` to Slack's `no_active_hooks` — nothing was delivered either way. Its commit message also claims the webhook was rotated, which it wasn't; the value was byte-identical to the original.

Both defects that made the shared secret useless are avoided here rather than repaired: the new value is a different hook, and it is stored unescaped.

### How can this be tested?
Verified so far, via `sops -d` on all three files — no deploy has happened:

| key | len | backslashes | starts `https://` |
|---|---|---|---|
| `slack_notifications_devops_warnings` | 79 | 0 | yes |
| `slack_notifications_ocw_misc_api_url` | 91 | 12 | no |

The new key is also confirmed *not* equal to the old, deactivated hook.

Delivery is unverified. After apply, check delivery rather than config:

1. `GET /api/alertmanager/grafana/config/api/v1/receivers` — `lastNotifyAttemptError` must be **empty**, not merely different, on `slack-devops-warnings-warning` and `slack-devops-warnings-critical`. The two prior failure modes both produced a non-empty error here.
2. `notifications_failed_per_integration_per_second{stack_id="256439",integration="slack"}` (`grafanacloud-usage`) must return to 0. It was 0.033/s and climbing on 2026-08-24.
3. Confirm a message lands in `#devops-warnings`. `APISIXEdge5xxRateFast`/`Slow` (api.mitxonline.mit.edu) and `HPAAtMaxReplicasCritical` are all firing there now, so no synthetic trigger is needed.

CI and QA can't be checked this way — both report `lastNotifyAttempt: 0001-01-01`, meaning no notification has ever been attempted, so an empty error there proves nothing. A contact-point test is the only way to exercise them.

### Additional Context
- `slack-notifications-ocw-misc-warning`/`-critical` are deliberately left alone and remain broken: they still point at `slack_notifications_ocw_misc_api_url`, which is both JSON-escaped and backed by the deactivated hook. Latent rather than urgent, since no OCW misc alert has ever routed to Slack — but it will fail the moment one does.
- Why the escaping broke things: `https:\/\/…` is a JSON-ism, and YAML plain scalars don't process backslash escapes, so the backslashes reach Grafana intact and Go's `url.Parse` reads them as an opaque path with no host. Store Slack URLs as bare `https://hooks.slack.com/services/…`.
- `pulumi preview` showed no diff on these contact points through both failure modes — declared and live agreed, both holding the broken value. Config-comparison drift checks cannot catch this class; delivery has to be asserted separately.

### Checklist:
- [ ] Apply grafana-alerting to CI / QA / Production
- [ ] Confirm a message lands in `#devops-warnings`
- [ ] Delete the old Slack app / hook if nothing else depends on it
