### PR TITLE
fix(concourse): grant transfer:UpdateUser for the infra worker role

### DIFF
--- a/src/ol_infrastructure/applications/concourse/iam_policies/pulumi_infra.py
+++ b/src/ol_infrastructure/applications/concourse/iam_policies/pulumi_infra.py
@@ -423,6 +423,7 @@ policy_definition = {
                 "transfer:DescribeServer",
                 "transfer:DescribeUser",
                 "transfer:UpdateServer",
+                "transfer:UpdateUser",
             ],
             "Resource": "*",
         },


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Re-triggered `pulumi-aws-sftp/qa` after #5589 merged (the `iam:ListPolicyTags` scoping fix). It got past that and `transfer:UpdateServer` cleanly, then hit the next gap in sequence: `transfer:UpdateUser`, denied updating the `sftp-qa-sftp-user-mitpress` Transfer Family user resource.

Added at the same `Resource: "*"` scope as its already-granted siblings (`transfer:DescribeServer`, `transfer:DescribeUser`, `transfer:UpdateServer`) -- matching this file's existing convention for that block rather than introducing a new resource-scoped statement.

### How can this be tested?
- Reproduced live: `pulumi-aws-sftp/deploy-ol-infrastructure-aws-sftp-qa` build #2 failed with `AccessDeniedException: ... is not authorized to perform: transfer:UpdateUser on resource: arn:aws:transfer:us-east-1:610119931565:user/s-570c2f57727b4f2ca/mitpress`.
- Ran the same `lint_iam_policy()` call and `parliament_config` that `concourse/__main__.py` uses at deploy time against the updated module -- no findings.
- `pre-commit` (ruff format/check, mypy) passes.

Haven't re-triggered the pipeline against this change yet since it isn't merged.

### Additional Context
Third small fix in a short chain against this same pipeline (#5589, then this) -- each run has revealed the next missing grant in Pulumi's resource-processing order. Re-triggering after this merges should tell us whether the chain is done or there's one more.
