### PR TITLE
feat: re-enable CANONICAL_HOSTNAME_REDIRECT_ENABLED for xPro RC

### DIFF
--- a/src/ol_infrastructure/applications/xpro/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/xpro/Pulumi.QA.yaml
@@ -6,6 +6,7 @@ config:
     secure: v1:CwgCINZqs7rxJOiU:xMp2xgeZd+tGV/v10GRE0fJ7Snuwah5tHbKh2ojO3mbTjBhjI77Gqd6PyvUIBe/H8R8DxQ==
   heroku:user: "mitx-devops"
   xpro:vars:
+    CANONICAL_HOSTNAME_REDIRECT_ENABLED: "True"
     CSRF_TRUSTED_ORIGINS: "https://rc.xpro.mit.edu,https://xpro-rc.odl.mit.edu"
     # CyberSource retired SOAP UsernameToken auth in their test
     # environment, so the export-compliance check errors out and blocks


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10930

### Description (What does it do?)
Re-enables `CANONICAL_HOSTNAME_REDIRECT_ENABLED` for xPro RC (QA stack), so `mitxpro`'s `HostnameRedirectMiddleware` (added in https://github.com/mitodl/mitxpro/pull/3883) actually redirects requests that arrive on `xpro-rc.odl.mit.edu` (the backend/origin domain) over to the canonical `rc.xpro.mit.edu`.

This is the same one-line change as #4609, which was reverted same-day in #4651 after it caused a redirect loop on RC (no root cause was recorded on the revert). Since then, xpro's nginx sidecar has been dropped entirely — APISix now talks to the Granian app directly (#4835, #5541) — which changes the header pipeline that existed at the time of the original loop and may already have resolved whatever caused it. Re-enabling on RC first to confirm before touching Production.

Root-cause note for reviewers: `xpro-web.odl.mit.edu` / `xpro-rc.odl.mit.edu` is a fully public, independently TLS'd hostname (in `CSRF_TRUSTED_ORIGINS`, with its own cert-manager cert) that's reachable directly, bypassing Fastly. Fastly's VCL is the only layer that force-sets `X-Forwarded-Host` to the canonical frontend domain — so direct hits to the backend domain get no correction, and `request.build_absolute_uri()` (e.g. for signup confirmation emails) faithfully reflects the wrong host. The middleware fixes this at the Django layer regardless of what reaches it via `X-Forwarded-Host`.

### How can this be tested?
- Deploy to QA and confirm `https://rc.xpro.mit.edu/` still loads normally with no redirect.
- Hit `https://xpro-rc.odl.mit.edu/` directly and confirm it 30x-redirects once to `https://rc.xpro.mit.edu/` — not a loop. This is exactly the scenario #4609 broke, so this is the critical check.
- Run a signup flow on `rc.xpro.mit.edu` and confirm the confirmation email link uses `rc.xpro.mit.edu`.
- Watch Sentry/logs on RC for a few hours after deploy for `Hostname redirect:` log bursts (the middleware logs one line per redirect — repeated lines for the same request/session is the loop signature).

### Additional Context
If this holds clean on RC, a follow-up PR will add the same var to `Pulumi.Production.yaml`.