### PR TITLE
fix(xpro): disable export compliance on CI and RC

### DIFF
--- a/src/ol_infrastructure/applications/xpro/Pulumi.CI.yaml
+++ b/src/ol_infrastructure/applications/xpro/Pulumi.CI.yaml
@@ -7,6 +7,16 @@ config:
   heroku:user: "mitx-devops"
   xpro:vars:
     CSRF_TRUSTED_ORIGINS: "https://ci.xpro.mit.edu,https://xpro-ci.odl.mit.edu"
+    # CyberSource retired SOAP UsernameToken auth in their test
+    # environment, so the export-compliance check errors out and blocks
+    # both registration and login here.
+    # compliance.api.is_exports_verification_enabled() requires all four
+    # CYBERSOURCE_* compliance settings to be non-empty, so blanking the
+    # merchant ID skips the check.
+    # NOTE: production must keep the check enabled - it is a legal
+    # requirement there. Revert once xPRO moves the check to the
+    # CyberSource REST API (mitodl/hq#13003).
+    CYBERSOURCE_MERCHANT_ID: ""
     CYBERSOURCE_SECURE_ACCEPTANCE_URL: "https://testsecureacceptance.cybersource.com/pay"
     CYBERSOURCE_WSDL_URL: "https://ics2wstest.ic3.com/commerce/1.x/transactionProcessor/CyberSourceTransaction_1.154.wsdl"
     DIGITAL_CREDENTIALS_SUPPORTED_RUNS: ""

--- a/src/ol_infrastructure/applications/xpro/Pulumi.QA.yaml
+++ b/src/ol_infrastructure/applications/xpro/Pulumi.QA.yaml
@@ -7,6 +7,16 @@ config:
   heroku:user: "mitx-devops"
   xpro:vars:
     CSRF_TRUSTED_ORIGINS: "https://rc.xpro.mit.edu,https://xpro-rc.odl.mit.edu"
+    # CyberSource retired SOAP UsernameToken auth in their test
+    # environment, so the export-compliance check errors out and blocks
+    # both registration and login here.
+    # compliance.api.is_exports_verification_enabled() requires all four
+    # CYBERSOURCE_* compliance settings to be non-empty, so blanking the
+    # merchant ID skips the check.
+    # NOTE: production must keep the check enabled - it is a legal
+    # requirement there. Revert once xPRO moves the check to the
+    # CyberSource REST API (mitodl/hq#13003).
+    CYBERSOURCE_MERCHANT_ID: ""
     CYBERSOURCE_SECURE_ACCEPTANCE_URL: "https://testsecureacceptance.cybersource.com/pay"
     CYBERSOURCE_WSDL_URL: "https://ics2wstest.ic3.com/commerce/1.x/transactionProcessor/CyberSourceTransaction_1.154.wsdl"
     DIGITAL_CREDENTIALS_SUPPORTED_RUNS: "course-v1:xPRO+TestCourse1+R2,course-v1:xPRO+TestCourse2+R2,program-v1:xPRO+TestProgram"


### PR DESCRIPTION
### What are the relevant tickets?

Refs https://github.com/mitodl/hq/issues/13003

### Description (What does it do?)

CyberSource retired SOAP UsernameToken auth in their test environment, so xPRO's export-compliance check faults on every registration and login in CI and RC and blocks both. `is_exports_verification_enabled()` requires all four `CYBERSOURCE_*` compliance settings to be non-empty, so this overrides `CYBERSOURCE_MERCHANT_ID` to `""` in those two stacks to skip the check. That setting is read only by xPRO's `compliance` app, so checkout is unaffected.

Production is deliberately untouched — the check is a legal requirement there. Temporary until xPRO moves the check to the CyberSource REST API.

### How can this be tested?

`pulumi preview` on the CI and QA stacks should show only the `CYBERSOURCE_MERCHANT_ID` env var change. After deploy, registration and login succeed on RC and Sentry XPRO-7H0 stops recurring.
