### PR TITLE
feat(dagster): put ol-etl-db-production back on the house RDS alarm profile

### DIFF
--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -434,17 +434,62 @@ dagster_db_security_group = ec2.SecurityGroup(
 
 # Keep existing RDS database (Dagster metadata storage)
 rds_defaults = defaults(stack_info)["rds"]
-# This stack opts out of all three of the house RDS monitoring defaults
-# (monitoring_profile_name="production", enhanced_monitoring_interval=60,
-# performance_insights_enabled=True). Two of those opt-outs are still deliberate; the
-# third was not, and is why the 2026-08-10 connection exhaustion could not be attributed
-# to anything after the fact.
+# This stack used to opt out of all three of the house RDS monitoring defaults
+# (monitoring_profile_name, enhanced_monitoring_interval=60,
+# performance_insights_enabled=True). Only the Enhanced Monitoring opt-out is left; see
+# below for why it stays.
 #
-# The CloudWatch alarm profile stays disabled for now, but only pending a threshold
-# review -- it creates the standard production alarm set against SNS and none of those
-# thresholds have been checked against this instance. That is worth doing deliberately
-# rather than as a side effect of enabling Performance Insights.
-rds_defaults["monitoring_profile_name"] = "disabled"
+# The CloudWatch alarm profile is back on the house default, which resolves per
+# environment in lib/stack_defaults.py -- "production" here, "qa" on QA, "ci" (actions
+# disabled) on CI. 19 live production databases already carry it and this one did not,
+# so until now the Dagster metadata DB had no host-level alarms at all. (21 alarm sets
+# exist; two of them, bootcamps-db-applications-production and devlake-db-production,
+# have no matching RDS instance and sit in INSUFFICIENT_DATA -- alarms that outlived
+# their databases, tracked separately.)
+#
+# The threshold review this was waiting on is done, against 30 days spanning both the
+# ol-data-platform retry storm and the 2026-08-10 exhaustion. Enabling it is worth
+# doing with clear eyes, because most of the profile does nothing on this instance --
+# five of the six alarms never fire across that window, including at its worst moments:
+#
+#   CPUUtilization    >90% for 6 consecutive 5-min periods. Peak 5-min average 97.1%
+#                     on 08-11, but the longest consecutive run above 90% is 3. No fire.
+#   WriteLatency      >100ms for 6 consecutive. Only 5 breaching datapoints in the
+#                     worst 10-hour window, never 6 in a row. No fire.
+#   ReadLatency       >20ms for 2 consecutive. One datapoint at 27.5ms; the next
+#                     highest is 15.7ms. Missed by a single datapoint -- the tightest
+#                     of the six, and the one most likely to start firing if read
+#                     latency degrades at all.
+#   FreeStorageSpace  <5 GB. Minimum over 30 days is 37.6 GB. A genuine last-resort
+#                     backstop rather than dead weight, but note storage autoscaling
+#                     (max_allocated_storage 1000) is the real protection: this can
+#                     only fire once autoscaling has hit that ceiling.
+#   EBSIOBalance%     <75%. Pinned at exactly 99, min == max across 720 hourly
+#                     samples. It is a burst-bucket metric and all 74 RDS instances in
+#                     us-east-1 are gp3, which has no burst bucket -- so this alarm
+#                     cannot fire here or on any of the 19 peers carrying it. Left in
+#                     place only because the profile is all-or-nothing; removing it is
+#                     an org-wide change, tracked separately.
+#   DiskQueueDepth    >10 for 2 consecutive. The one that works, and the reason this
+#                     is on: 84 of 120 5-min datapoints breached during 2026-08-08/09,
+#                     roughly 40 hours ahead of the connection exhaustion.
+#
+# DiskQueueDepth is also the noisy one, and that is accepted rather than overlooked. In
+# the current healthy regime it breaches on isolated ~hourly IO spikes, with one
+# adjacent pair in the five days sampled -- so expect it to fire and self-clear around
+# once a week. That matches a peer: the same alarm on ol-mitlearn-db-production logged
+# 10 state transitions in 30 days, while on edxapp-db-mitx-production it logged none.
+# Sizing it per instance needs a threshold-override hook that OLPostgresDBConfig does
+# not have; the profile is chosen wholesale by name.
+#
+# Alarms do auto-resolve. OLCloudWatchAlarmSimpleRDS sets ok_actions=alarm_actions
+# (components/aws/cloudwatch.py:212), so the ALARM->OK transition reaches the same SNS
+# topic and Rootly closes the incident. An earlier draft of this comment claimed
+# otherwise and was wrong.
+#
+# Not covered by the profile at all: FreeableMemory, which has no alarm in any house
+# profile. Observed floor here is 29.8 GB of 64 GB, so nothing urgent.
+#
 # Enhanced Monitoring stays off. Unlike Performance Insights it is not free -- the OS
 # metric stream bills as CloudWatch Logs ingestion at a 60s interval -- and it answers a
 # question we are not asking. The gap here was never host-level CPU/disk; it was which


### PR DESCRIPTION
## What are the relevant tickets?

Closes "Decide on the CloudWatch alarm profile for ol-etl-db-production" on the Dagster + PgBouncer observability project. Follows #5465, which re-enabled Performance Insights and deliberately left this decision alone.

## Description (What does this do?)

Drops the `monitoring_profile_name = "disabled"` override on the Dagster metadata DB, restoring the per-environment house default from `lib/stack_defaults.py`: `production` here, `qa` on QA, `ci` (actions disabled) on CI. 19 live production databases already carry the profile; this one did not, which is part of why the 2026-08-10 connection exhaustion went entirely unalerted.

The threshold review the opt-out was waiting on is done, against 30 days spanning both the ol-data-platform retry storm and the exhaustion itself.

## The review does not flatter the profile

Five of the six alarms never fire on this instance across that window, including at its worst moments. Each was checked at the alarm's own resolution (5-minute `Average`, M-of-N consecutive), not at a coarser one — an hourly average made `WriteLatency` look like it would fire, and the 5-minute view showed it would not.

| Alarm | Threshold | Worst observed in 30d | Fires? |
|---|---|---|---|
| `CPUUtilization` | >90%, 6 consecutive | peak 97.1%; longest run above 90% is **3** | No |
| `WriteLatency` | >100ms, 6 consecutive | 5 breaching datapoints in the worst 10h, never 6 in a row | No |
| `ReadLatency` | >20ms, 2 consecutive | one point at 27.5ms, next highest 15.7ms | No — missed by one datapoint |
| `FreeStorageSpace` | <5 GB | min 37.6 GB | No |
| `EBSIOBalance%` | <75%, 2 consecutive | constant 99, `min == max` over 720 samples | **Never** |
| `DiskQueueDepth` | >10, 2 consecutive | 84 of 120 datapoints during 08-08/09 | **Yes** |

**`EBSIOBalance%` is structurally dead, not just quiet.** It is a burst-bucket metric, and all 74 RDS instances in us-east-1 are `gp3`, which has no burst bucket. Pinned at exactly 99 with `min == max` across 720 hourly samples — a configured constant being read back, the same shape as the `DatabaseConnections`-pinned-at-900 artifact that started this whole project. It cannot fire here or on any of the 19 peers carrying it. Left in place only because the profile is all-or-nothing; removing it is an org-wide change and is tracked separately.

**`ReadLatency` is the one to watch.** It came within a single datapoint of firing during the storm. If read latency degrades at all, this is the alarm that starts talking first.

## Why enable it anyway

`DiskQueueDepth` is the one that works, and it works well: 84 of 120 five-minute datapoints breached during 2026-08-08/09, roughly **40 hours ahead** of the connection exhaustion. `FreeStorageSpace` is a genuine last-resort backstop, with the caveat that storage autoscaling (`max_allocated_storage` 1000) is the real protection and this can only fire once autoscaling has hit that ceiling.

## The cost, stated plainly

`DiskQueueDepth` will be noisy. In the current healthy regime it breaches on isolated ~hourly IO spikes — 53 of 1440 five-minute datapoints over five days, but almost all isolated singles, with exactly one adjacent pair. Since the alarm needs 2 consecutive, expect it to fire and self-clear roughly **once a week**.

That is not a guess about a threshold nobody has run. A peer carries the same alarm at the same threshold: `ol-mitlearn-db-production-DiskQueueDepth` logged 10 state transitions in the last 30 days, while `edxapp-db-mitx-production-DiskQueueDepth` logged zero. This instance will land in the mitlearn camp.

Sizing it per instance would need a threshold-override hook that `OLPostgresDBConfig` does not have — the profile is selected wholesale by name. That was considered and rejected as scope: it changes a component shared by ~19 databases and raises the much larger question of whether the house thresholds are wrong for all of them.

## Corrections to the record

- **The alarms do auto-resolve.** The override site carried a claim that they send no `ok_actions` and so never clear in Rootly. `OLCloudWatchAlarmSimpleRDS` sets `ok_actions=alarm_actions` (`components/aws/cloudwatch.py:212`). The comment is fixed.
- **Two alarm sets have outlived their databases.** `bootcamps-db-applications-production` and `devlake-db-production` have full six-alarm sets in `INSUFFICIENT_DATA` with no matching RDS instance. Not touched here; worth its own cleanup.
- **No `FreeableMemory` alarm exists in any house profile.** Observed floor here is 29.8 GB of 64 GB, so nothing urgent, but it is a gap.

## How can this be tested?

`pulumi preview` on the dagster stack:

- **Production**: `+12 to create` — six alarms, each as an `OLCloudWatchAlarmRDS` wrapper plus its `aws:cloudwatch:MetricAlarm`. Named `CPUUtilization`, `ReadLatency`, `WriteLatency`, `FreeStorageSpace`, `EBSIOBalance%`, `DiskQueueDepth`.
- **QA**: `+8 to create` — four alarms, the global set only, since the `qa` profile adds nothing on top. Confirms the per-environment resolution works as intended.

**Both previews also show `~2 to update` on `dagster-helm-release-production` and `dagster-user-code-release-production` (`diff: ~values`). That drift is pre-existing, not from this change** — I verified by stashing the diff and re-running preview on unmodified `main`, which shows `~2 to update, 83 unchanged` on its own. Whoever applies this stack will apply that Helm drift along with the alarms, so it is worth a look before running `up`.

`pre-commit run` (ruff format, ruff check, mypy, detect-secrets) passes.

Every figure above comes from `cloudwatch get-metric-statistics` / `describe-alarm-history` against the live account, not from the metric descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3Zv5jmzzyDRj6tGFwQsXE
