### PR TITLE
fix(edxapp): add --disable-prefetch to all celery workers to fix KEDA scaling

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/k8s_resources.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_resources.py
@@ -1381,6 +1381,7 @@ def create_k8s_resources(  # noqa: C901
                                 "--exclude-queues=edx.cms.core.default",
                                 "--concurrency=2",
                                 "--prefetch-multiplier=1",
+                                "--disable-prefetch",
                             ],
                             env=[
                                 kubernetes.core.v1.EnvVarArgs(
@@ -1566,6 +1567,7 @@ def create_k8s_resources(  # noqa: C901
                                 "--exclude-queues=edx.cms.core.default",
                                 "--concurrency=1",
                                 "--prefetch-multiplier=1",
+                                "--disable-prefetch",
                             ],
                             env=[
                                 kubernetes.core.v1.EnvVarArgs(
@@ -1944,6 +1946,7 @@ def create_k8s_resources(  # noqa: C901
                                 "--exclude-queues=edx.lms.core.default,edx.lms.core.high,edx.lms.core.high_mem",
                                 "--prefetch-multiplier=1",
                                 "--concurrency=2",
+                                "--disable-prefetch",
                             ],
                             env=[
                                 kubernetes.core.v1.EnvVarArgs(


### PR DESCRIPTION
### What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/13005

### Description (What does it do?)
Adds `--disable-prefetch` (Celery 5.6+) to all three edxapp celery worker deployments (LMS default, LMS high-mem, CMS).

With `acks_late=True` on the Redis transport, kombu's QoS `prefetch_count` drifts upward over each worker's lifetime — observed at 612-728 after 4-5 days on production mitxonline CMS celery pods that had processed 9k-16k tasks. This lets each pod hoard hundreds of tasks in its internal buffer while the Redis list reads as empty to KEDA's list-length trigger, preventing any scale-up even when all worker slots are saturated.

`--disable-prefetch` overrides the transport-level `can_consume()` to hard-cap consumption at the pool's actual concurrency (`num_processes`), keeping excess tasks in the Redis queue where KEDA can see and react to them. The QoS counter stat still drifts (it's cosmetic), but the transport gate prevents actual task hoarding.

Note: xpro-openedx is currently on Celery 5.5.3 which does not have this flag. xpro will not receive a `pulumi up` for this stack before its Celery upgrade to 5.6.x.

### How can this be tested?
Tested on mitxonline QA:
- Deployed the `--disable-prefetch` flag to the CMS celery worker
- Triggered course translation jobs that produce many tasks
- Verified via `celery -A cms.celery inspect reserved` that reserved (buffered) task count stays near 0, rather than growing to hundreds as seen without the flag
- Confirmed tasks remain visible in the Redis queue for KEDA to scale on

### Additional Context
- The `prefetch_count` stat in `celery inspect stats` still grows — this is expected and harmless. The stat reports the kombu QoS counter value, which drifts regardless; `--disable-prefetch` works at the transport layer below that counter.
- This complements the memory-utilization trigger added in #5543, which gives KEDA a non-queue-depth signal for scaling. Both changes together address the full gap: tasks staying visible in Redis (this PR) and a backup signal when workers are resource-starved (#5543).