### PR TITLE
fix(rds): drop the EBSIOBalance% alarm, which cannot fire on any database we run

### DIFF
--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -464,12 +464,12 @@ rds_defaults = defaults(stack_info)["rds"]
 #                     backstop rather than dead weight, but note storage autoscaling
 #                     (max_allocated_storage 1000) is the real protection: this can
 #                     only fire once autoscaling has hit that ceiling.
-#   EBSIOBalance%     <75%. Pinned at exactly 99, min == max across 720 hourly
-#                     samples. It is a burst-bucket metric and all 74 RDS instances in
-#                     us-east-1 are gp3, which has no burst bucket -- so this alarm
-#                     cannot fire here or on any of the 19 peers carrying it. Left in
-#                     place only because the profile is all-or-nothing; removing it is
-#                     an org-wide change, tracked separately.
+#   EBSIOBalance%     GONE. It was in the profile when this list was written, pinned
+#                     at 99 against a threshold of 75 because it is a burst-bucket
+#                     metric and every RDS instance here is gp3, which has no burst
+#                     bucket. Removed from the production profile in
+#                     components/aws/database.py, so this stack no longer creates it
+#                     and neither do the 19 peers that did.
 #   DiskQueueDepth    >10 for 2 consecutive. The one that works, and the reason this
 #                     is on: 84 of 120 5-min datapoints breached during 2026-08-08/09,
 #                     roughly 40 hours ahead of the connection exhaustion.

--- a/src/ol_infrastructure/components/aws/database.py
+++ b/src/ol_infrastructure/components/aws/database.py
@@ -649,17 +649,33 @@ class OLAmazonDB(pulumi.ComponentResource):
             "ci": ci_profiles,
             "qa": {},
             "production": {
-                "EBSIOBlance": {
-                    "comparison_operator": "LessThanThreshold",
-                    "description": "RDS - EBS IO Balance Remaining",
-                    "datapoints_to_alarm": 2,
-                    "level": "warning",
-                    "period": 300,  # 5 minutes
-                    "evaluation_periods": 2,  # 10 minutes
-                    "metric_name": "EBSIOBalance%",
-                    "threshold": 75,  # percent
-                    "unit": "Percent",
-                },
+                # There was an EBSIOBalance% alarm here, at < 75% for 2 periods. It
+                # was removed because it could not fire, on any database we run.
+                #
+                # EBSIOBalance% reports how much of a burst-credit bucket is left, and
+                # only volume types that have such a bucket ever deplete it. Every one
+                # of the 74 RDS instances in us-east-1 is gp3, which has provisioned
+                # IOPS and no burst bucket, so the metric is emitted but pinned. Across
+                # 30 days and 720 hourly samples the MINIMUM is 99.0 on all seven
+                # databases sampled -- ol-etl-db-production, ol-mitlearn-db-production,
+                # edxapp-db-mitx-production, keycloak-production,
+                # ol-superset-db-production, micromasters-production-app-db and
+                # odl-video-service-production. Against a threshold of 75 that is not a
+                # quiet alarm, it is an arithmetically impossible one, and all 19 of the
+                # alarms this created sat in OK permanently.
+                #
+                # A constant being reported back as though it were a measurement is the
+                # same failure the Dagster pool investigation turned up in CloudWatch
+                # DatabaseConnections, which min_pool_size pinned to a flat 900. Both
+                # look like healthy signal until you check whether the number can move.
+                #
+                # This leaves gp3 IO saturation uncovered. The metrics that would cover
+                # it are ReadIOPS/WriteIOPS against provisioned IOPS and
+                # ReadThroughput/WriteThroughput against provisioned throughput, both
+                # per instance -- so a house-wide threshold needs those ratios checked
+                # across every database on this profile first. DiskQueueDepth below is
+                # the partial stand-in until then: it measures the queue that IO
+                # saturation produces, without knowing what the ceiling is.
                 "DiskQueueDepth": {
                     "comparison_operator": "GreaterThanThreshold",
                     "description": "RDS - Disk Queue Depth - Requests waiting",


### PR DESCRIPTION
## What are the relevant tickets?

Fallout from the alarm-profile review in #5597, which found this while checking each production threshold against observed behaviour. No ticket; filed as a follow-up from that work.

## Description (What does this do?)

Removes the `EBSIOBalance%` alarm from the `production` monitoring profile in `components/aws/database.py`. It is not a quiet alarm being tidied away — it is arithmetically incapable of firing on any database we run.

`EBSIOBalance%` reports how much of an EBS burst-credit bucket is left, and only volume types that *have* such a bucket ever deplete one. **All 74 RDS instances in us-east-1 are `gp3`**, which has provisioned IOPS and no burst bucket, so the metric is emitted but pinned.

Measured over 30 days and 720 hourly samples, the **minimum** value against a `< 75` threshold:

| Database | samples | lowest observed |
|---|---|---|
| `ol-etl-db-production` | 720 | 99.0 |
| `ol-mitlearn-db-production` | 720 | 99.0 |
| `edxapp-db-mitx-production` | 720 | 99.0 |
| `keycloak-production` | 720 | 99.0 |
| `ol-superset-db-production` | 720 | 99.0 |
| `micromasters-production-app-db` | 720 | 99.0 |
| `odl-video-service-production` | 720 | 99.0 |

All 19 alarms it created sit in `OK` permanently and always will.

A configured constant reported back as though it were a measurement is the same failure the Dagster pool investigation found in CloudWatch `DatabaseConnections`, which `min_pool_size` pinned to a flat 900 for days at a time. Both read as healthy signal until you ask whether the number is capable of moving.

## What this leaves uncovered, stated rather than papered over

gp3 IO saturation now has no dedicated alarm. Covering it properly means `ReadIOPS`/`WriteIOPS` against provisioned IOPS and `ReadThroughput`/`WriteThroughput` against provisioned throughput — both *per instance*, since those ceilings differ per database. A house-wide threshold therefore needs those ratios checked across every database on this profile first, which is a larger piece of work than this removal and deliberately not bundled into it.

`DiskQueueDepth` is the partial stand-in until then: it measures the queue that IO saturation produces, without knowing where the ceiling is. The reasoning is recorded at the removal site so the next person doesn't rediscover it.

## Blast radius

19 production stacks instantiate `OLAmazonDB` with this profile. Each will delete exactly one alarm (two Pulumi resources — the `OLCloudWatchAlarmRDS` wrapper and its `aws:cloudwatch:MetricAlarm`) on its next apply. Nothing else in the profile changes; `qa` and `ci` never had this alarm, since it lived only in the `production` block.

## How can this be tested?

Two previews, chosen to show both sides of the change:

- **`applications/airbyte` Production** (alarm already deployed): `- 2 to delete, 78 unchanged`. The two deleted resources are exactly `airbyte-db-production-EBSIOBalance%-simple-rds-alarm` and its wrapper. Nothing else is touched.
- **`applications/dagster` Production** (alarms not yet deployed, from #5597): `+ 10 to create` where it was `+ 12` before this change, confirming the alarm is no longer generated.

I also confirmed the alarm is genuinely present in deployed state rather than inferring it, by exporting `applications/mit_learn` Production and finding `ol-mitlearn-db-production-EBSIOBlance-OLCloudWatchAlarmSimpleRDSConfig` among its 24 alarm resources. Worth noting: **`mit_learn` cannot be previewed locally** — it raises `OSError: Either MIT_LEARN_DOCKER_TAG or MIT_LEARN_DOCKER_SHA must be set`, which the pipeline supplies. So the deletion there is an inference from state plus the airbyte preview, not something I observed directly.

`pre-commit run` (ruff format, ruff check, mypy, detect-secrets) passes on both changed files.

## Note on the typo that is going away with it

The profile key was `EBSIOBlance` (missing the `a`) while `metric_name` was correctly `EBSIOBalance%`. Only the key was misspelled, so the alarms pointed at the right metric; the typo shows up in Pulumi resource names like `...-EBSIOBlance-OLCloudWatchAlarmSimpleRDSConfig`. Mentioning it only because it makes the delete lines in the preview look mismatched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T3Zv5jmzzyDRj6tGFwQsXE
