### PR TITLE
fix(dagster): set pgbouncer_replica_count from the exporter, 6 -> 4

### DIFF
--- a/src/ol_infrastructure/applications/dagster/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/dagster/Pulumi.Production.yaml
@@ -25,7 +25,55 @@ config:
   vault:address: https://vault-production.odl.mit.edu
   vault_server:env_namespace: operations.production
   dagster:db_instance_type: db.r7g.2xlarge
-  dagster:pgbouncer_replica_count: 6
+  # 6 -> 4. The first replica count set from the exporter rather than from a
+  # guess. Six days of 1-minute samples (8640 points) taken entirely after the
+  # session -> transaction pool_mode switch of 2026-08-19 18:23Z:
+  #
+  #   peak concurrent in-flight backends, all pods    13   (p99 8)
+  #   peak backends HELD per pod                      40   = min_pool_size, exactly
+  #   peak client sockets, all pods                 1825   (per-pod peak 330)
+  #   peak pod CPU                                  0.09 cores
+  #   samples with any client waiting                  0
+  #   peak client maxwait                              0s
+  #
+  # Backends held per pod never once exceeded min_pool_size, on any pod, in six
+  # days. The pool has not had to grow since transaction mode landed, so
+  # default_pool_size and max_db_connections have never been approached: peak
+  # in-flight 13 against an aggregate cap of 4248 is a ratio of 0.003.
+  #
+  # Transaction mode is what changed the picture, not the #5464 re-tune. Before
+  # the switch this pool held up to 2104 backends and ran 400-2000 server_active;
+  # after, it multiplexes 1825 client sockets onto ~40 in-flight backends. Every
+  # pre-2026-08-19 sizing number here was measured against a pool that was doing
+  # no multiplexing at all.
+  #
+  # Why 4 and not fewer: max_client_conn (1500/pod), not backends, is what bounds
+  # the replica count. maxSurge is 0 and maxUnavailable is 1, so a rollout runs on
+  # N-1 pods. At 4 that is 3 x 1500 = 4500 sockets against a peak of 1825 (2.5x).
+  # At 2 a rollout would leave 1500 for 1825 and refuse clients. CPU and backend
+  # demand would both fit on a single pod ten times over; they are not the
+  # constraint.
+  #
+  # The aggregate ceiling is unchanged and that is by construction:
+  # max_db_connections is budget / replica_count, so 708 x 6 and 1062 x 4 are both
+  # 4248. What improves is skew tolerance -- a hot pod now saturates at 1062
+  # rather than 708 before it starts refusing, which is the failure QA hit at
+  # 221-active-vs-4 across two replicas.
+  #
+  # Side effect worth knowing: DagsterPgBouncerConnectionHeadroom is a fraction of
+  # pgbouncer_databases_max_connections per pod, so raising the per-pod
+  # denominator makes a given absolute backend count read lower -- 40 backends
+  # goes from 0.056 to 0.038 of the cap. The alert gets less sensitive, not more.
+  # Benign at a 0.003 utilisation ratio, but it is the same denominator trap as
+  # les-a-ratio-alert-s-denominator-constrains-what-you.
+  #
+  # min_pool_size stays at 40 deliberately. One lever per pass -- moving the
+  # floor and the divisor together would make the next measurement
+  # unattributable, which is the failure mode this whole exercise exists to stop
+  # repeating. The floor is the obvious next candidate: 40 was sized for a
+  # session-mode per-replica peak of 35, and transaction mode has cut per-replica
+  # in-flight demand to 2-3.
+  dagster:pgbouncer_replica_count: 4
   # Down from the previous global 100. Production has never come close to
   # needing it: three days of 1-minute exporter samples peaked at 122 active
   # server connections against an aggregate cap of 4248, and the pool sat on
@@ -68,10 +116,20 @@ config:
   # This is purely about not reserving what is not used.
   #
   # The regression to watch is the other failure mode, since lowering pool_size
-  # pushes anything above it onto the churning overflow path: baseline
-  # rate(pgbouncer_stats_totals_server_assignments_total[10m]) has been ~2/s
-  # since the pooled storages landed, against 407-511/s while the storages were
-  # unpooled. If that climbs materially, 50 is below real steady state and
-  # should go back up -- DagsterPgBouncerConnectionChurn alerts at 50/s.
+  # pushes anything above it onto the churning overflow path.
+  #
+  # server_assignments_total is NO LONGER that signal, and the thresholds quoted
+  # in earlier revisions of this comment are dead. Under session mode the counter
+  # incremented about once per client connect, which is why ~2/s read as healthy
+  # and 407-511/s read as connect-per-use. Under transaction mode it increments
+  # about once per TRANSACTION, so it now measures query throughput: measured
+  # 2026-08-25 over the six days since the switch, 75/s at rest and 2673/s at
+  # peak, with zero clients ever waiting and maxwait flat at 0. Nothing is wrong;
+  # the counter means something else. Both churn rules are unlabelled and routed
+  # to `oblivion` for exactly this reason (see metric_rules/dagster_pgbouncer.py).
+  #
+  # Use the client-side view instead -- pgbouncer_pools_client_waiting_connections
+  # and client_maxwait_seconds -- plus the "QueuePool limit of size 50 overflow
+  # 100" timeout logs, which name this pool directly.
   dagster:event_log_pool_size: 50
   dagster:event_log_max_overflow: 100

--- a/src/ol_infrastructure/applications/dagster/Pulumi.Production.yaml
+++ b/src/ol_infrastructure/applications/dagster/Pulumi.Production.yaml
@@ -47,12 +47,26 @@ config:
   # pre-2026-08-19 sizing number here was measured against a pool that was doing
   # no multiplexing at all.
   #
-  # Why 4 and not fewer: max_client_conn (1500/pod), not backends, is what bounds
-  # the replica count. maxSurge is 0 and maxUnavailable is 1, so a rollout runs on
-  # N-1 pods. At 4 that is 3 x 1500 = 4500 sockets against a peak of 1825 (2.5x).
-  # At 2 a rollout would leave 1500 for 1825 and refuse clients. CPU and backend
-  # demand would both fit on a single pod ten times over; they are not the
-  # constraint.
+  # Why 4: max_client_conn (1500/pod), not backends, is what bounds the replica
+  # count. CPU and backend demand would both fit on a single pod ten times over
+  # and do not bind at any count worth considering.
+  #
+  # The criterion is that peak client sockets still fit while a rollout is in
+  # flight AND one pod is lost unplanned. maxSurge is 0 and maxUnavailable is 1,
+  # so a rollout already runs on N-1; a node eviction or OOM on top of that
+  # leaves N-2. Against the 1825 peak:
+  #
+  #   N=4   rollout 3 x 1500 = 4500 (2.5x)   rollout + 1 loss 3000 (1.6x)   ok
+  #   N=3   rollout 2 x 1500 = 3000 (1.6x)   rollout + 1 loss 1500          refuses
+  #   N=2   rollout 1 x 1500 = 1500          refuses during any rollout
+  #
+  # So the data alone does NOT rule out 3 -- 3 is fine for a rollout on its own,
+  # and if the N-2 case is judged not worth covering then 3 is the better
+  # number. 4 is the conservative end of the range, and two things argue for
+  # taking it: the 1825 peak comes from a six-day window with no large backfill
+  # in it, which is exactly the demand class that has never been measured on
+  # this pool; and going 6 -> 4 -> 3 later costs one config line, where
+  # discovering 3 was too few costs a connection outage during a rollout.
   #
   # The aggregate ceiling is unchanged and that is by construction:
   # max_db_connections is budget / replica_count, so 708 x 6 and 1062 x 4 are both
@@ -77,7 +91,12 @@ config:
   # Down from the previous global 100. Production has never come close to
   # needing it: three days of 1-minute exporter samples peaked at 122 active
   # server connections against an aggregate cap of 4248, and the pool sat on
-  # its min_pool_size floor of 900 the entire time. 80 trims the worst case
+  # its min_pool_size floor of 900 the entire time. Both of those figures are
+  # HISTORICAL -- they were taken before #5464 cut min_pool_size 150 -> 40 and
+  # before pool_mode went session -> transaction, and the equivalents now are a
+  # 13 active peak against a 160 floor. The conclusion is unaffected and gets
+  # stronger, which is why the number is not being moved again here. 80 trims
+  # the worst case
   # without touching anything observed. Note the aggregate cap overstates real
   # headroom -- max_db_connections is budget / replica count, which assumes
   # load spreads evenly across replicas, and measured distribution is heavily
@@ -90,7 +109,9 @@ config:
   # dagster_instance.yaml's event_log_storage comment. QA sets its own, smaller
   # value (90, see Pulumi.QA.yaml): it turned out to have the same failure and
   # to have been logging it continuously, but its per-pod cap is 382 against
-  # this stack's 708 and a prior run-worker incident deadlocked its whole pool,
+  # this stack's 1062 (708 until the replica count went 6 -> 4 above; the
+  # aggregate 4248 is the same either way) and a prior run-worker incident
+  # deadlocked its whole pool,
   # so it gets a sizing pass of its own rather than this number.
   #
   # Re-weighted 2026-08-19 from 100+50 to follow the house rule in
@@ -100,11 +121,17 @@ config:
   # 100 to 50 per process across the 17 long-lived ones (daemon, 2 webservers,
   # 14 code locations) plus every run worker.
   #
-  # 50 is derived from measurement, not from halving 100. Held connections
-  # across the whole pool have ranged 359-1577 over the week since the pooled
-  # storages landed, against a 4248 aggregate cap -- so the FLOOR is ~359, of
-  # which 240 is PgBouncer's own min_pool_size (40 x 6 replicas) rather than
-  # anything a client holds. That leaves roughly 120 of genuine client
+  # 50 is derived from measurement, not from halving 100. The arithmetic below
+  # was done on 2026-08-19 against SIX replicas and is kept as it was performed;
+  # at the current four the PgBouncer floor term is 160 (40 x 4), not 240, which
+  # would leave ~200 of client retention rather than ~120 and make 50 more
+  # generous still. Re-derive here if the floor or the replica count moves again.
+  #
+  # Held connections across the whole pool have ranged 359-1577 over the week
+  # since the pooled storages landed, against a 4248 aggregate cap -- so the
+  # FLOOR is ~359, of which 240 is PgBouncer's own min_pool_size (40 x 6
+  # replicas) rather than anything a client holds. That leaves roughly 120 of
+  # genuine client
   # retention spread across 17+ processes, call it under 10 each at rest. A
   # pool_size of 50 covers that with 5x margin, which is the "pool_size =
   # measured steady state" half of the rule; the 100 of overflow absorbs peaks

--- a/src/ol_infrastructure/applications/dagster/__main__.py
+++ b/src/ol_infrastructure/applications/dagster/__main__.py
@@ -732,9 +732,13 @@ dagster_db_secret = OLVaultK8SSecret(
 # show it: instantaneous load spreads evenly (1-18 active per pod), so fewer/larger
 # replicas is a live option rather than an urgent fix.
 #
-# Left alone here deliberately. This pass changes min_pool_size, and changing the
-# multiplier in the same breath would make the result unattributable -- which is the
-# failure mode the whole exercise exists to stop repeating.
+# Production took that option on 2026-08-25, 6 -> 4, and it is the first replica count
+# on this stack derived from measurement rather than assumed. The binding constraint
+# turned out to be max_client_conn rather than backends: maxSurge is 0 below, so a
+# rollout runs on N-1 pods, and the peak client-socket count has to fit in
+# (N-1) x max_client_conn. Backend demand does not bind at any plausible N -- six days
+# of post-transaction-mode samples peaked at 13 concurrent in-flight backends across
+# the whole fleet. Full derivation in Pulumi.Production.yaml.
 pgbouncer_replica_count = dagster_config.get_int("pgbouncer_replica_count") or 2
 
 # Cap the connections PgBouncer can open against RDS, in aggregate across every replica.


### PR DESCRIPTION
## What

Sets `dagster:pgbouncer_replica_count` on production from 6 to 4, and corrects two comments whose recorded baselines the current data contradicts.

This closes STEP 2 of the pool verification: the replica count is now the first number on this stack derived from the exporter rather than assumed.

## Measurement

Six days of 1-minute samples (8640 points), taken entirely after the session → transaction `pool_mode` switch of 2026-08-19 18:23Z (#5527). Production, `namespace="dagster"`:

| | measured | configured / cap |
|---|---|---|
| peak concurrent in-flight backends, all pods | **13** (p99 8) | 4248 aggregate |
| peak backends held, per pod | **40** | `min_pool_size` = 40 |
| peak client sockets, all pods | 1825 (per-pod peak 330) | `max_client_conn` 1500/pod |
| peak pod CPU | 0.09 cores | — |
| samples with any client waiting | **0 of 8640** | — |
| peak client `maxwait` | **0s** | `query_wait_timeout` 600 |

Backends held per pod never once exceeded `min_pool_size`, on any pod, across the whole window. The pool has not had to grow since transaction mode landed, so `default_pool_size` and `max_db_connections` have never been approached — 13 in-flight against 4248 is a utilisation ratio of 0.003.

This also answers item (B), the backfill verification that #5464 was left waiting on. It is answered in the negative rather than the positive: demand never tested the floor as a ceiling because transaction mode removed the pressure that would have.

## Why transaction mode is the story, not #5464

Before the switch this pool held up to 2104 backends and ran 400–2000 `server_active`. After it, it multiplexes 1825 client sockets onto ~40 in-flight backends. Every pool-sizing number measured on this stack before 2026-08-19 was taken against a pool that was doing no multiplexing at all — a proxy with a connection limit.

QA moved the same way. The two pods that sat pinned at 382/382 with `sv_idle` 0 and `maxwait` peaking at 543s now peak at 40 held per pod, with clients waiting in 2 of 8640 samples and `maxwait` topping out at 21s. That was tracked as the open capacity problem; it is largely gone, and not because anything was done about it directly.

## Why 4

`max_client_conn`, not backends, bounds the replica count. `maxSurge` is 0 and `maxUnavailable` is 1, so a rollout runs on N-1 pods and the peak socket count has to fit in `(N-1) × 1500`:

- **4** → rollout on 3 pods = 4500 sockets vs a peak of 1825 (2.5×)
- 3 → 3000 vs 1825 (1.6×)
- 2 → 1500 vs 1825, refuses clients mid-rollout

Backend demand and CPU would both fit on a single pod ten times over. They are not the constraint at any plausible N.

The aggregate ceiling is unchanged, by construction: `max_db_connections` is `budget / replica_count`, and 708 × 6 and 1062 × 4 are both 4248. What improves is skew tolerance — a hot pod now saturates at 1062 rather than 708 before it starts refusing, which is the shape of the failure QA hit at 221-active-vs-4 across two replicas.

`min_pool_size` stays at 40. Moving the floor and the divisor in the same pass would make the next measurement unattributable. It is the obvious next candidate: 40 was sized for a session-mode per-replica peak of 35, and transaction mode has cut per-replica in-flight demand to 2–3.

## Corrected comments

**`server_assignments_total` baseline**, recorded next to `event_log_pool_size` as the regression signal for the 100 → 50 `pool_size` cut. Under session mode that counter incremented roughly once per client connect, which is why ~2/s read as healthy and 407–511/s read as connect-per-use. Under transaction mode it increments roughly once per *transaction*, so it now measures query throughput: **75/s at rest and 2673/s at peak**, with zero clients ever waiting and `maxwait` flat at 0. Nothing is wrong; the counter means something else. Both churn rules are already unlabelled and routed to `oblivion` for this reason, so nothing paged — but the comment still told the next reader to watch a dead number against a dead threshold. Now points at `client_waiting_connections` / `client_maxwait_seconds` and the QueuePool timeout logs.

**The "left alone deliberately" note** in `__main__.py`, which said this knob was being held still because that pass was moving `min_pool_size`. That pass is done; this one moves the divisor.

## Known side effect

`DagsterPgBouncerConnectionHeadroom` is a fraction of `pgbouncer_databases_max_connections` per pod, so raising the per-pod denominator makes a given absolute backend count read lower: 40 backends goes from 0.056 to 0.038 of the cap. The alert gets *less* sensitive, not more. Benign at a 0.003 utilisation ratio, but it is the same denominator trap recorded in `les-a-ratio-alert-s-denominator-constrains-what-you`, and it is called out in the config comment so it is not rediscovered.

The constraint that `max_db_connections` remains the pool's single binding ceiling is preserved — this changes the divisor, not the derivation.

## Rollout

`maxSurge: 0`, `maxUnavailable: 1`, so scaling down replaces in place and never exceeds the aggregate cap during the roll. Two pods terminate; the ConfigMap checksum annotation (#5460) rolls the rest onto the new `max_db_connections` of 1062.

Watch after deploy: `pgbouncer_pools_client_waiting_connections` and `client_maxwait_seconds` stay at 0, and held-per-pod settles at 40 on four pods (160 aggregate, down from 240).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFkupXrorZFMwf247MZgdC
