### PR TITLE
Remove OCW misc Slack alerting channel

### DIFF
--- a/src/bridge/secrets/grafana_cloud/api.ci.yaml
+++ b/src/bridge/secrets/grafana_cloud/api.ci.yaml
@@ -1,9 +1,6 @@
 ---
-#ENC[AES256_GCM,data:9zbUzpmppxHA7ypBvx7RnG10pisgHSaoQNuiMifWgSBnoHzOPbAo5ySr/k8=,iv:5oGbv7xA1yuRxB75tgQrjuahh4AyKtT9N5wkKdnkC1o=,tag:kDDbht8MxPbpPEyKjFBNcQ==,type:comment]
-#ENC[AES256_GCM,data:BX7SS/D34QP64+25TFTNb19bXBbf8YJp8DRtfLZvfmIufbPKuLXB,iv:je0miycdhKrJ2REyNThqYD50kakskxmKrM08smtgKa0=,tag:4Y6rH4q9G6T9qAnOipigXw==,type:comment]
-#ENC[AES256_GCM,data:1pnMMFaDzRXRZqN0FpY3WiJFcz0AQCDRsAQPmaVJxEVLaUAY8lngHBQMOYL8IADHgA2bP1dzrA6VhumxzsyoJNdKu7x24gfhdA==,iv:eNRN3omfdZJUOYrsbSwJRPaZ4/NI9NOsm4QhYUBbjCU=,tag:RnPs13DCP4aqeLsIelmovQ==,type:comment]
-grafana_url: ENC[AES256_GCM,data:mxYffpU7OwW4k66LMa6oZcxAR3tWik5ANDXvfA==,iv:oMu/9hNSf8jj9G8yMOGiZcaCFED5UMbhWbSsoKap2DY=,tag:ahz7rMrgQh+zC0wZ219L7A==,type:str]
 grafana_api_token: ENC[AES256_GCM,data:SYLbEyPPM3phyJKC7l0di4DsxOZdnpEgcwA3wm12s9JXYjRut7HTzv3F+zYJlQ==,iv:z6Qwu5OzfrgQ+apiEKLqUbfb/4DVPpVnJXHM8jAhpTE=,tag:c6Gg1SJz+5pYmsZyvgDnng==,type:str]
+grafana_url: ENC[AES256_GCM,data:mxYffpU7OwW4k66LMa6oZcxAR3tWik5ANDXvfA==,iv:oMu/9hNSf8jj9G8yMOGiZcaCFED5UMbhWbSsoKap2DY=,tag:ahz7rMrgQh+zC0wZ219L7A==,type:str]
 rootly_bearer_token: ENC[AES256_GCM,data:E6PgEeCyd+Ro/xOFfJFLfPOBxvC6EQyYYCjEyZj/2XTgGmeQCkDI0ShnDX859zKy0DHlBTlX7KD9R6vn6AMHHg==,iv:V/2scFJ2ZR19Y8g2bAHsPlYBj04OSGy+PPBP6+lggb4=,tag:uGeE66MBRW/WyQP2BbYRjg==,type:str]
 slack_notifications_devops_warnings: ENC[AES256_GCM,data:KiSHG4DkTTU8sGIq7VggNliAYKoXa9Al600fThD0x7B5WQCQaSNy/Hft3eLdq71kqgbgpJA9AL5ydguG+6Bpq5gs1xVxCc4nEuQk/S0oEQ==,iv:M1jkJbWiEbpBrEvIeHTSnK2JBFzpMq3cmyom7CYRK+w=,tag:wYmzY7YJtmGEDYoT7ejzxg==,type:str]
 sops:
@@ -16,8 +13,8 @@ sops:
   azure_kv: []
   hc_vault: []
   age: []
-  lastmodified: "2026-08-24T19:14:35Z"
-  mac: ENC[AES256_GCM,data:5o1tqQOuOoVQ5Jpjq7h3h7nhXkekIpj5woXkigscUtYGN2xLuL+vHv1x9Q5T4S+PqJ+gb0+ydLWwBA4z53wDsRxDbD8UcbzgXYMYxVO6N7R8rZmAkWOVhYjVahalZ/NNPYLFQGZ1LNqU70WszENBtNWE5H19oXsk1bhtCfsUbvU=,iv:XdDNLu/ub4ELdDmfqBm+Xl8yPP3QT3nsq3oi8GdihPw=,tag:3WmUqqfEIFhadrTYq5V57A==,type:str]
+  lastmodified: "2026-08-25T19:35:06Z"
+  mac: ENC[AES256_GCM,data:O6ORrYy3BX84Euvm01zqT9GtWlVeM6A8Ml1NcFYsBTrQc3psk6KLkh599/fAjVfqJ7Lsuj64239hs98pM0G5cKsL7fUyal02NuICxny68KsGkWWtpbFhkugETcNZvy/Uwehq7tY7aoWaWMUTxBZVF5biJJjfipF3oiImgOecDvo=,iv:SlNRCxTSN/aYVPZnlg6FsDzN3jfpnQBvD6SH/bO+v2k=,tag:nTEuafEsz3YWRkp9BgAN/Q==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.13.2

--- a/src/bridge/secrets/grafana_cloud/api.ci.yaml
+++ b/src/bridge/secrets/grafana_cloud/api.ci.yaml
@@ -5,7 +5,6 @@
 grafana_url: ENC[AES256_GCM,data:mxYffpU7OwW4k66LMa6oZcxAR3tWik5ANDXvfA==,iv:oMu/9hNSf8jj9G8yMOGiZcaCFED5UMbhWbSsoKap2DY=,tag:ahz7rMrgQh+zC0wZ219L7A==,type:str]
 grafana_api_token: ENC[AES256_GCM,data:SYLbEyPPM3phyJKC7l0di4DsxOZdnpEgcwA3wm12s9JXYjRut7HTzv3F+zYJlQ==,iv:z6Qwu5OzfrgQ+apiEKLqUbfb/4DVPpVnJXHM8jAhpTE=,tag:c6Gg1SJz+5pYmsZyvgDnng==,type:str]
 rootly_bearer_token: ENC[AES256_GCM,data:E6PgEeCyd+Ro/xOFfJFLfPOBxvC6EQyYYCjEyZj/2XTgGmeQCkDI0ShnDX859zKy0DHlBTlX7KD9R6vn6AMHHg==,iv:V/2scFJ2ZR19Y8g2bAHsPlYBj04OSGy+PPBP6+lggb4=,tag:uGeE66MBRW/WyQP2BbYRjg==,type:str]
-slack_notifications_ocw_misc_api_url: ENC[AES256_GCM,data:AZeVmqkCsRIPq2P4qNJXTOyECfXLEiB2vcs6+dHn8QgYmNJbhG/IP4yzEgQx7Ctv/HRNAzVboC78Gl92ohn7JhOtCbslsyCSwtR/i9E3ztejXYUPwWMofQU9qA==,iv:+o0+XIGGvDZTFbQRO/3d1jUW2qjIhjNBUrYSWKGuQyc=,tag:xGYFYKZZNI1Z/xq4EJx2cw==,type:str]
 slack_notifications_devops_warnings: ENC[AES256_GCM,data:KiSHG4DkTTU8sGIq7VggNliAYKoXa9Al600fThD0x7B5WQCQaSNy/Hft3eLdq71kqgbgpJA9AL5ydguG+6Bpq5gs1xVxCc4nEuQk/S0oEQ==,iv:M1jkJbWiEbpBrEvIeHTSnK2JBFzpMq3cmyom7CYRK+w=,tag:wYmzY7YJtmGEDYoT7ejzxg==,type:str]
 sops:
   kms:

--- a/src/bridge/secrets/grafana_cloud/api.production.yaml
+++ b/src/bridge/secrets/grafana_cloud/api.production.yaml
@@ -1,20 +1,11 @@
 ---
-#ENC[AES256_GCM,data:z+u37b9pN4II+9LtRZ/3CqiizfZUz7ftUco/XPxHe2txLzuATmakgWzcp75czL4PlR+ndQ==,iv:MzuqR57xqp/jjlEe20vXhYl/65fpGrQwXHCWHPanvbw=,tag:Ksz5ZT5zvDPzWOch1O6+TQ==,type:comment]
-#ENC[AES256_GCM,data:vUxNTXS9MugoqL4c60hbITaNUyrtFmFM5PVXjYwqA72risVcWIA5,iv:YXJ8705YzHkWENu88ahGX2aN8PaCd2mpNQf+6UMjWjU=,tag:XCjEjYKf0dCBt5n/C/k8kA==,type:comment]
-#ENC[AES256_GCM,data:HZLpdjBy3q9UPDdVL8kO3ZrhJQwARbhIP7gdIwMcJlhcTOTEyOzdsyZhp5PWUSZhj/vFcXu7K/6kEUlIR3a0Gf2VNbjvhaPPpOs3IN342Tdr,iv:KEMZvpc8q/3Z95hPjMx3UVgJ9GnhH+ci54TXRUjOpNc=,tag:IBI0B3ePJjGA8f1s1t5kNQ==,type:comment]
-#
-#ENC[AES256_GCM,data:tRcz0nOsXvJypP1t9qzFSGehZPgZeG/semp80xderQJPY/H/nrXJFwD/4S/w2GfQ9BbwVWYXsuhQyDbG6BMGHEJbMw==,iv:8xX0Ul4um5kGogO4isrwALItBQW5BIacgvACbSyqDXM=,tag:5X8I+bxDe8LkqLp6+6uigw==,type:comment]
-#ENC[AES256_GCM,data:jRCH3K3eb6JJNDdmts+LRGvd6ptLKz5fPOiBqqs7FXl710FCnvBiviEoFSKng/XuTMIv6JSEC15J1L9VLSuMYy3mEO43LTLyJB+anN/MqSuX8ofGxEt7,iv:jtnn488XjKUlJ+JsLNVs/S7jpXk9uTRDxxnJ0kHK3AY=,tag:jM033A/1UR0RwDbiJ11XkQ==,type:comment]
-#ENC[AES256_GCM,data:UD6nEXa1r5aC348J4/LQkZS5QM27RbYy5n+uwOlHs9XqOboceiLK+RUlq3p/+5RDpJD16SOaAdJ86ttIMzuOCCJQzfF7H3PItJPOV3WL1furDB89a9iOEgQsetE=,iv:BLL5lRDOltVtwj19TwZbE9J6GjOSvbm0bSmDLruycuc=,tag:6Gp504oKwCwWelznW8P9Lg==,type:comment]
-#ENC[AES256_GCM,data:WTNm0iOsDbHNWgnm6kqNMRUx5aOz9YJnvx1WihCyQAimSUljgwjVi1W3zFYKT/xwwhj+Vz9CHWk1xNOSV+TJUWpw4BdAhs7J7TUtQQ==,iv:jdgbG0ETOxlSTpMSYWdKO0GW+spzANw1yUlHwqmfmC8=,tag:vE5nXXxtReS9vNC1UTSmdw==,type:comment]
-#ENC[AES256_GCM,data:X3IC2M3XrhgRpKyeUaTd5Beg5MfG6j9Zml9a9gNoyWMwSZtT09VqvcnKOdeH+mnjnJC8TRDy2hjnpVQiLwe5Edkr2q7AMR36O/QcPC70qH7slo3giospW5yvuqJd,iv:g6xslHwyXedQTVzE1CsAIV+plehRyWFwuRSEUB045ck=,tag:2herhRyghK+YrUUmTGIrrg==,type:comment]
-grafana_url: ENC[AES256_GCM,data:+7TTZ7VHBTTn/PcOL9F72Md9kM2aKYT9kbDzGxK+fZs1/kLd,iv:0vb8gEECsegdlE2ukHtJ+/PTCfgNbLbOG0AagjlIGk8=,tag:4tNaAAaEiyPzL3Ha2EvKIQ==,type:str]
 grafana_api_token: ENC[AES256_GCM,data:mtAitkY9a+DvJuE9oavZSr5s2gg/0sefz24IBXeU4/Q1X6GmGeMYxP2pHsVmYQ==,iv:1MPyg8kkX8l8FCo9zQOaThKu1f+MshRnCBnyMYoZs0c=,tag:3vY+icGNxuebJP3WeupS3g==,type:str]
-rootly_bearer_token: ENC[AES256_GCM,data:DU0yeHwpjYNBeIFx6GcU2aqbif9h+c9zf4OMV461Qg3ywKZB3WMLUiE+V5Fk5mT4J7rQ+1kOaWhQ+95FYw+Tuw==,iv:XF4RgfmnV9ScUcXkebkNcH8d3iPOI7Qq3bdKGfCxBLM=,tag:M3TKehW4lcKn3HnigVK9GA==,type:str]
-slack_notifications_devops_warnings: ENC[AES256_GCM,data:11b0TdhhNxw8w97Gh+2QDu9nHNKbQ32huH6SAm/bjrJ8Oy8yXOZdfepjmR84mY57zSnOBtmToceSDxvem+wR6S4TOZkl32juUIPOxPrFDw==,iv:v1MM26d6tR5qyXi2YVKJL2nnVdRHWl80WTtDUff0dL4=,tag:prVzZtgruj8P2FytqbZMaw==,type:str]
+grafana_url: ENC[AES256_GCM,data:+7TTZ7VHBTTn/PcOL9F72Md9kM2aKYT9kbDzGxK+fZs1/kLd,iv:0vb8gEECsegdlE2ukHtJ+/PTCfgNbLbOG0AagjlIGk8=,tag:4tNaAAaEiyPzL3Ha2EvKIQ==,type:str]
 pingdom_api_token: ENC[AES256_GCM,data:La1G+qPKgUdXZ2b4i+QDynzFwnpboF1lDt9z3XONBDnUaGZUuRXnhgNQb8Pjlqywzyp1HkZ9MyfDHe7jziOSIrgOG1IU4Fo=,iv:KVzqs7g/a3cYfFB/0tL7GSxnhiUwzny8i+BOnopZyrg=,tag:Aed9XxD9YymwgvGZvSJWmg==,type:str]
 pingdom_integration_ids:
 - ENC[AES256_GCM,data:ojQOBarpFeI=,iv:gwQKECX61CzM9vxsTo8UHsHL1HCOks+CLBJvrqubT90=,tag:Ly0lzPMKH7+ik18ozCB68A==,type:int]
+rootly_bearer_token: ENC[AES256_GCM,data:DU0yeHwpjYNBeIFx6GcU2aqbif9h+c9zf4OMV461Qg3ywKZB3WMLUiE+V5Fk5mT4J7rQ+1kOaWhQ+95FYw+Tuw==,iv:XF4RgfmnV9ScUcXkebkNcH8d3iPOI7Qq3bdKGfCxBLM=,tag:M3TKehW4lcKn3HnigVK9GA==,type:str]
+slack_notifications_devops_warnings: ENC[AES256_GCM,data:11b0TdhhNxw8w97Gh+2QDu9nHNKbQ32huH6SAm/bjrJ8Oy8yXOZdfepjmR84mY57zSnOBtmToceSDxvem+wR6S4TOZkl32juUIPOxPrFDw==,iv:v1MM26d6tR5qyXi2YVKJL2nnVdRHWl80WTtDUff0dL4=,tag:prVzZtgruj8P2FytqbZMaw==,type:str]
 sops:
   kms:
   - arn: arn:aws:kms:us-east-1:610119931565:key/29397ad6-5cfd-43ef-8f43-818b19ab75e4
@@ -25,8 +16,8 @@ sops:
   azure_kv: []
   hc_vault: []
   age: []
-  lastmodified: "2026-08-24T19:15:11Z"
-  mac: ENC[AES256_GCM,data:Q0nKmJ2oJwcXKzJf6dnu/BhkkNCDeMPpI+ZQzHS0RfKC9AvuIKgFtXZlnVU4Ryg3CJPU5dkEkKU60/RbJtCjJjllGSiqsvoIwq47Lo3gPz7NRNT53nVfOe/ogqllFz11i4ptMyv/HgkoWSbu/9oZlcBz6rl7h3Jh3KixRX7S8c8=,iv:d6D2lPs+ES+E40MjMKrWkNUCWB4SFU1JD54+zMzkaQs=,tag:EGwIHklVg1ijQ0Hc5A3wOQ==,type:str]
+  lastmodified: "2026-08-25T19:35:06Z"
+  mac: ENC[AES256_GCM,data:v2D7Wi+oAKFo3DdBWe3qnwmipfCb7AMiZlSrWkibwk04/+YP7DmEozYtIBylIq79QhyXXT/9vyhqo7iSTF7V/Ml8WKEScA3FdJbZtOEo+QRpN7GSd0lFsQN9Ay5qFoa6FMBHqtEKVZxsIg/HWCNy1Yxnvh/KHpbbaICGqN+6icQ=,iv:RdSUHZBkh4bb7JYYj01KY2FvodO4UNURm7WtgbXlBSo=,tag:iTdXYzYYCQGyzX34b5D9OA==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.13.2

--- a/src/bridge/secrets/grafana_cloud/api.production.yaml
+++ b/src/bridge/secrets/grafana_cloud/api.production.yaml
@@ -11,7 +11,6 @@
 grafana_url: ENC[AES256_GCM,data:+7TTZ7VHBTTn/PcOL9F72Md9kM2aKYT9kbDzGxK+fZs1/kLd,iv:0vb8gEECsegdlE2ukHtJ+/PTCfgNbLbOG0AagjlIGk8=,tag:4tNaAAaEiyPzL3Ha2EvKIQ==,type:str]
 grafana_api_token: ENC[AES256_GCM,data:mtAitkY9a+DvJuE9oavZSr5s2gg/0sefz24IBXeU4/Q1X6GmGeMYxP2pHsVmYQ==,iv:1MPyg8kkX8l8FCo9zQOaThKu1f+MshRnCBnyMYoZs0c=,tag:3vY+icGNxuebJP3WeupS3g==,type:str]
 rootly_bearer_token: ENC[AES256_GCM,data:DU0yeHwpjYNBeIFx6GcU2aqbif9h+c9zf4OMV461Qg3ywKZB3WMLUiE+V5Fk5mT4J7rQ+1kOaWhQ+95FYw+Tuw==,iv:XF4RgfmnV9ScUcXkebkNcH8d3iPOI7Qq3bdKGfCxBLM=,tag:M3TKehW4lcKn3HnigVK9GA==,type:str]
-slack_notifications_ocw_misc_api_url: ENC[AES256_GCM,data:orY1MnxxmTpMiAC/r3azEuMikSDxIdXPlgeRGIGOsyVcZRwf4QjVrbIyNLRUeNx7fnCmjflFm6tTY4fCQAusBJr4NpxzPviTzkz5HUP7R7nZjhGZk5UzjtaBbg==,iv:rDbETYHcAHkUxf52TN2qayhDFgf8h68IxAXXDrmi/Rg=,tag:3P9hf6F8SP6hvl3Mifn2Qg==,type:str]
 slack_notifications_devops_warnings: ENC[AES256_GCM,data:11b0TdhhNxw8w97Gh+2QDu9nHNKbQ32huH6SAm/bjrJ8Oy8yXOZdfepjmR84mY57zSnOBtmToceSDxvem+wR6S4TOZkl32juUIPOxPrFDw==,iv:v1MM26d6tR5qyXi2YVKJL2nnVdRHWl80WTtDUff0dL4=,tag:prVzZtgruj8P2FytqbZMaw==,type:str]
 pingdom_api_token: ENC[AES256_GCM,data:La1G+qPKgUdXZ2b4i+QDynzFwnpboF1lDt9z3XONBDnUaGZUuRXnhgNQb8Pjlqywzyp1HkZ9MyfDHe7jziOSIrgOG1IU4Fo=,iv:KVzqs7g/a3cYfFB/0tL7GSxnhiUwzny8i+BOnopZyrg=,tag:Aed9XxD9YymwgvGZvSJWmg==,type:str]
 pingdom_integration_ids:

--- a/src/bridge/secrets/grafana_cloud/api.qa.yaml
+++ b/src/bridge/secrets/grafana_cloud/api.qa.yaml
@@ -1,9 +1,6 @@
 ---
-#ENC[AES256_GCM,data:q45LhvN/6AMT2jzCSK+hNfXFJaV+c7tC4p24v3lZlmCMM15GPkO61j7IizI=,iv:KvRpDa0MNfCstIXrcewSQeVv07P7UogFfZVj4lfqrb4=,tag:TGkbNG9ppyLgn2HCP71u8g==,type:comment]
-#ENC[AES256_GCM,data:quD0LTbXA76/sAtZfnwq6UggLHKOtLhagE3Rwpj85z2UqK1OH+A3,iv:D9sVjsOIW9tcnbhvBU4i0gNLaTuEsXCml/Sx61WXngE=,tag:Xq/PG9M1gWPfoMCEyqdCtA==,type:comment]
-#ENC[AES256_GCM,data:NJdEQMY/yKSznBRBr2/A6k59qLVqrw6SEQtkhBpIokDj+ydeXeIFvFFg3AKnsmTXsbhcO7mTS9qjeN6TOyroIkRsApqc90jrsw==,iv:NbcYeqPV6jtOniEcmcd3JfGR9jo1v+US/gsvcYtauEc=,tag:u/KnIV7iO3FCqGumAj4ZJg==,type:comment]
-grafana_url: ENC[AES256_GCM,data:/IR86dLbrBzg3Pg87GA09gSCIR6YPXAsX3iHHg==,iv:PlwAOOsJKOTXmlb1Yx5PJ2iYIcjNYMg3YiNLqkN8ibQ=,tag:jVD4nRq5Lk8rgfrGChspIg==,type:str]
 grafana_api_token: ENC[AES256_GCM,data:kcCR8sln6Zpj/D4ymiMVM+AsGsSIKUWM0JuuqT3/u0rECKCPOuO2uYctlHPfKA==,iv:02HVWhOFNiyinWRXlea/uMdI/cY7BYDSiL4Bqe6DXWs=,tag:yfQzmKrW9u9mjdlOIMuTeg==,type:str]
+grafana_url: ENC[AES256_GCM,data:/IR86dLbrBzg3Pg87GA09gSCIR6YPXAsX3iHHg==,iv:PlwAOOsJKOTXmlb1Yx5PJ2iYIcjNYMg3YiNLqkN8ibQ=,tag:jVD4nRq5Lk8rgfrGChspIg==,type:str]
 rootly_bearer_token: ENC[AES256_GCM,data:A2umpeiaysO9bPkarF0n0B3IpK3bzo9jlE1XR8u0KWzhm0kEQxQNL2Ae9xheK/2BiO9oMkXFs9QqlKQshMzJxQ==,iv:hWa/1yjf5hgbwf/aVvp29wk1YFRod0vnDHsKXWh8zds=,tag:IhjfNCC7Fkq7bCA3OVhdPA==,type:str]
 slack_notifications_devops_warnings: ENC[AES256_GCM,data:i7kfKdS8DJmLTjK+7WQJFplHYx8JatqqHSBwhUidrYENii+SjP0NZwmAeJgg3bvZXP5R5YHtfHW4p7fcXIHlKi0asclruiieG3QJqmWGlw==,iv:BBmxvQmirGDTbNwpT5Cku/Agw+jj0k0hGQm8OljXHds=,tag:gN0TH/xq7bRt1/zYWAdgZQ==,type:str]
 sops:
@@ -16,8 +13,8 @@ sops:
   azure_kv: []
   hc_vault: []
   age: []
-  lastmodified: "2026-08-24T19:14:56Z"
-  mac: ENC[AES256_GCM,data:zfPXANZNn7eYogEYD1Eqd1maBYhizVlN8BhR50k55sMYPBnXg9xK55BCV3Z5HtYP5loXMY95sHpwVKSKP223mUwyOJ38vAIaFaon3d5faXYKS/ftCp8jFOI73sfRhsXtCSXG/rKTPmxco9AprOA6c1ezFCE2QpQCfAXrMR/nlV0=,iv:v0JbU93rNaSAdBb5/KzClHApCt+R3CFjWCZvHIqQLbA=,tag:cM1zfEBZzSYL5NQ6eehOcg==,type:str]
+  lastmodified: "2026-08-25T19:35:06Z"
+  mac: ENC[AES256_GCM,data:ChQpRrjO1O/WWXxdhJLVWhGE/Ck4vBpvaVVVkGzX6KL9cSAUE4M1aT1MQmhpqrtnFNg1LlDlRg5iZlOxDcmfEqnUfSOibyzHZLGsabjAqFEeJ/Hx8wxilvkH6aYteyLLlTEwhLom+4zexmXW509ExAleTpgSGlIUDd767cEELqY=,iv:cB0Z9YzVPZdjHaHAwQvMnOqz7ueXVKuRAl/UB2QI7kw=,tag:bnD/Ch+fPGnpi1OwWIZZ5g==,type:str]
   pgp: []
   unencrypted_suffix: _unencrypted
   version: 3.13.2

--- a/src/bridge/secrets/grafana_cloud/api.qa.yaml
+++ b/src/bridge/secrets/grafana_cloud/api.qa.yaml
@@ -5,7 +5,6 @@
 grafana_url: ENC[AES256_GCM,data:/IR86dLbrBzg3Pg87GA09gSCIR6YPXAsX3iHHg==,iv:PlwAOOsJKOTXmlb1Yx5PJ2iYIcjNYMg3YiNLqkN8ibQ=,tag:jVD4nRq5Lk8rgfrGChspIg==,type:str]
 grafana_api_token: ENC[AES256_GCM,data:kcCR8sln6Zpj/D4ymiMVM+AsGsSIKUWM0JuuqT3/u0rECKCPOuO2uYctlHPfKA==,iv:02HVWhOFNiyinWRXlea/uMdI/cY7BYDSiL4Bqe6DXWs=,tag:yfQzmKrW9u9mjdlOIMuTeg==,type:str]
 rootly_bearer_token: ENC[AES256_GCM,data:A2umpeiaysO9bPkarF0n0B3IpK3bzo9jlE1XR8u0KWzhm0kEQxQNL2Ae9xheK/2BiO9oMkXFs9QqlKQshMzJxQ==,iv:hWa/1yjf5hgbwf/aVvp29wk1YFRod0vnDHsKXWh8zds=,tag:IhjfNCC7Fkq7bCA3OVhdPA==,type:str]
-slack_notifications_ocw_misc_api_url: ENC[AES256_GCM,data:9ktK+wy8GN6MI/dNnUTUWjHsQ+T6bRFVm0mFza2wgrH6rUatW7ve2ur7Zbev3m7Woebj3a50j9R5JUfnsqvY3TL8JEL7rHjOOiHAMInQ4Ha2IeWWP/qFWEKddw==,iv:G/OMPajhOwHGwJnKISqZO3s2AO7UvvgX1bWJr6jY+jU=,tag:JZzpCHi57iBvkUDsFdewww==,type:str]
 slack_notifications_devops_warnings: ENC[AES256_GCM,data:i7kfKdS8DJmLTjK+7WQJFplHYx8JatqqHSBwhUidrYENii+SjP0NZwmAeJgg3bvZXP5R5YHtfHW4p7fcXIHlKi0asclruiieG3QJqmWGlw==,iv:BBmxvQmirGDTbNwpT5Cku/Agw+jj0k0hGQm8OljXHds=,tag:gN0TH/xq7bRt1/zYWAdgZQ==,type:str]
 sops:
   kms:

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/CLAUDE.md
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/CLAUDE.md
@@ -49,7 +49,7 @@ Mimir (per-stack metrics storage, exposed as a Prometheus datasource)
 Grafana Alertmanager
     │  matches fired alerts against the NotificationPolicy route tree
     ▼
-Rootly webhook  ──or──  Slack (#notifications-ocw-misc)
+Rootly webhook  ──or──  Slack (#devops-warnings)
 ```
 
 **Grafana-managed vs Mimir ruler-managed rules**
@@ -391,27 +391,23 @@ Pulumi's own reported result.
 The notification policy in `alertmanager.py` mirrors the original
 `grafana-alerts/alertmanager.yaml` route tree:
 
-1. `channel=notifications-ocw-misc` → Slack by severity (warning/critical),
-   anything else with that label is silenced.
-2. `channel=devops-warnings` → a separate pair of Slack contact points, same
-   pattern as (1), reusing the OCW misc webhook/token with a different
-   `recipient`. `HPAAtMaxReplicas*` uses this route deliberately (see
+1. `channel=devops-warnings` → a pair of Slack contact points by severity.
+   `HPAAtMaxReplicas*` uses this route deliberately (see
    `metric_rules/eks_general.py`) to stay off the paging path entirely --
-   at-max is a capacity fact, not an incident -- and not (1), since that
-   rule fires cluster-wide, not just for OCW's workloads.
-3. `alertname=~Kube.*` → silenced (built-in k8s noise, not actionable).
-4. `alertname=~Pod(OOMKilled|CrashLooping)(Warning|Critical)` → Rootly, but
+   at-max is a capacity fact, not an incident.
+2. `alertname=~Kube.*` → silenced (built-in k8s noise, not actionable).
+3. `alertname=~Pod(OOMKilled|CrashLooping)(Warning|Critical)` → Rootly, but
    grouped at the namespace level (root `group_bies` drops to `deployment`,
    no `pod`/`container`) with `group_interval=30m`/`repeat_interval=12h`, so
    a churning workload reports once instead of minting one alert per pod
    name.
-5. `severity=warning` → Rootly.
-6. `severity=critical` → Rootly.
-7. Default (catch-all) → `oblivion` (empty contact point, acts as drop sink).
+4. `severity=warning` → Rootly.
+5. `severity=critical` → Rootly.
+6. Default (catch-all) → `oblivion` (empty contact point, acts as drop sink).
 
 OpsGenie is no longer active. All actionable alerts route to Rootly.
 
-**Rule 7 is load-bearing, not just a fallback.** A rule carrying no `severity`
+**Rule 6 is load-bearing, not just a fallback.** A rule carrying no `severity`
 label is still evaluated and still recorded in `grafanacloud-alert-state-history`
 — it is simply delivered nowhere. `metric_rules/apisix_edge.py` uses that
 deliberately, to calibrate new thresholds against real firing data at zero paging
@@ -433,13 +429,13 @@ That rule is plugin-owned and stays in `oblivion` deliberately — the latency
 signal it carries is now covered by the `- Elevated Request Latency` rules in
 `metric_rules/synthetic_monitoring.py`, which reach `#devops-warnings`.
 
-**Route 3 swallows by *name*, not just by missing label.** `alertname =~ Kube.*`
+**Route 2 swallows by *name*, not just by missing label.** `alertname =~ Kube.*`
 sits above the severity routes and carries `continue_=False`, so any rule whose
 name starts with `Kube` goes to `oblivion` no matter what `severity` it carries.
 Our own `KubernetesJobFailedWarning`/`Critical` matched it and were undeliverable
 for as long as they existed — 254 firings in 30 days on the production stack and
 104 on QA, none of which reached Rootly. They are now `WorkloadJobFailed*`.
-**Do not name a rule `Kube*` unless you intend it to be silenced**; route 3 is
+**Do not name a rule `Kube*` unless you intend it to be silenced**; route 2 is
 meant for the built-in kube-state-metrics alerts, not for rules defined here.
 
 ---
@@ -453,7 +449,6 @@ Required keys per secrets file:
 grafana_url: https://<stack>.grafana.net
 grafana_api_token: <service-account-token>
 rootly_bearer_token: <rootly-webhook-bearer-token>
-slack_notifications_ocw_misc_api_url: <slack-webhook-url>
 slack_notifications_devops_warnings: <slack-webhook-url>  # required; used by devops-warnings contact points
 
 # Production only (Pingdom checks run from production stack only):

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/alertmanager.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/alertmanager.py
@@ -3,18 +3,16 @@
 Translates grafana-alerts/alertmanager.yaml into Pulumi-managed resources.
 
 Routing logic (mirrors the original alertmanager.yaml route tree):
-  1. Alerts labelled channel=notifications-ocw-misc go to dedicated Slack
-     channels by severity; anything else with that channel label is silenced.
-  2. Alerts labelled channel=devops-warnings go to a separate pair of Slack
-     channels by severity, same pattern as (1) -- for alerts that aren't any
-     one team's concern (e.g. cluster-wide capacity signals).
-  3. Alerts whose name matches Kube.* are silenced (built-in k8s noise).
-  4. Pod(OOMKilled|CrashLooping)(Warning|Critical) → Rootly, but grouped at
+  1. Alerts labelled channel=devops-warnings go to a separate pair of Slack
+     channels by severity -- for alerts that aren't any one team's concern
+     (e.g. cluster-wide capacity signals).
+  2. Alerts whose name matches Kube.* are silenced (built-in k8s noise).
+  3. Pod(OOMKilled|CrashLooping)(Warning|Critical) → Rootly, but grouped at
      the namespace level (not pod/container) with a longer group_interval,
      to stop a churning workload from minting one alert per pod name.
-  5. All remaining warning-severity alerts → Rootly.
-  6. All remaining critical-severity alerts → Rootly.
-  7. Everything else → oblivion (default receiver, acts as a drop sink).
+  4. All remaining warning-severity alerts → Rootly.
+  5. All remaining critical-severity alerts → Rootly.
+  6. Everything else → oblivion (default receiver, acts as a drop sink).
 """
 
 from typing import Any
@@ -61,49 +59,9 @@ def create(grafana_secrets: dict[str, Any], resource_opts: ResourceOptions) -> N
         opts=resource_opts,
     )
 
-    # OCW misc Slack — warning severity (yellow goose emoji, "warning" colour).
-    alerting.ContactPoint(
-        "slack-notifications-ocw-misc-warning",
-        name="slack-notifications-ocw-misc-warning",
-        slacks=[
-            alerting.ContactPointSlackArgs(
-                url=grafana_secrets["slack_notifications_ocw_misc_api_url"],
-                recipient="#notifications-ocw-misc",
-                color="warning",
-                icon_emoji=":goose_warning:",
-                title=':goose_warning: [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{- end }}] - {{ .CommonLabels.alertname }}',
-                text="{{ range .Alerts }}\n  {{- if .Annotations.message }}\n      Message - {{ .Annotations.message }}\n  {{- end }}\n  {{- if .Annotations.description }}\n      Description - {{ .Annotations.description }}\n  {{- end }}\n  {{- if .Annotations.summary }}\n      Summary - {{ .Annotations.summary }}\n  {{- end }}\n{{- end }}",
-                disable_resolve_message=False,
-            )
-        ],
-        opts=resource_opts,
-    )
-
-    # OCW misc Slack — critical severity (red alert emoji, "danger" colour).
-    alerting.ContactPoint(
-        "slack-notifications-ocw-misc-critical",
-        name="slack-notifications-ocw-misc-critical",
-        slacks=[
-            alerting.ContactPointSlackArgs(
-                url=grafana_secrets["slack_notifications_ocw_misc_api_url"],
-                recipient="#notifications-ocw-misc",
-                color="danger",
-                title=':alert: [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{- end }}] - {{ .CommonLabels.alertname }}',
-                text="{{ range .Alerts }}\n  {{- if .Annotations.message }}\n      {{ .Annotations.message }}\n  {{- end }}\n  {{- if .Annotations.description }}\n      {{ .Annotations.description }}\n  {{- end }}\n{{- end }}",
-                disable_resolve_message=False,
-            )
-        ],
-        opts=resource_opts,
-    )
-
     # devops-warnings Slack — non-paging visibility for cluster-wide capacity
     # signals that aren't any one team's concern (e.g. HPAAtMaxReplicas*,
-    # which fires for every CI/QA/production workload). Uses its own
-    # `slack_notifications_devops_warnings` secret (a per-stack required key
-    # in the grafana-alerting secrets file; see CLAUDE.md § Secrets reference).
-    # Deliberately a distinct pair of contact points, not a shared one with
-    # ocw-misc: each destination has its own contact point to keep the
-    # resource-name→channel mapping obvious from resource names alone.
+    # which fires for every CI/QA/production workload).
     alerting.ContactPoint(
         "slack-devops-warnings-warning",
         name="slack-devops-warnings-warning",
@@ -204,50 +162,9 @@ def create(grafana_secrets: dict[str, Any], resource_opts: ResourceOptions) -> N
         group_interval="5m",
         repeat_interval="4h",
         policies=[
-            # OCW misc: route warning/critical to the dedicated Slack channel;
-            # anything else tagged with this channel label is silenced by the
-            # parent "oblivion" receiver so it never reaches Rootly.
-            alerting.NotificationPolicyPolicyArgs(
-                matchers=[
-                    alerting.NotificationPolicyPolicyMatcherArgs(
-                        label="channel",
-                        match="=",
-                        value="notifications-ocw-misc",
-                    )
-                ],
-                contact_point="oblivion",
-                continue_=False,
-                policies=[
-                    alerting.NotificationPolicyPolicyPolicyArgs(
-                        matchers=[
-                            alerting.NotificationPolicyPolicyPolicyMatcherArgs(
-                                label="severity",
-                                match="=",
-                                value="warning",
-                            )
-                        ],
-                        contact_point="slack-notifications-ocw-misc-warning",
-                        continue_=False,
-                    ),
-                    alerting.NotificationPolicyPolicyPolicyArgs(
-                        matchers=[
-                            alerting.NotificationPolicyPolicyPolicyMatcherArgs(
-                                label="severity",
-                                match="=",
-                                value="critical",
-                            )
-                        ],
-                        contact_point="slack-notifications-ocw-misc-critical",
-                        continue_=False,
-                    ),
-                ],
-            ),
-            # devops-warnings: same pattern as OCW misc above, for alerts that
-            # aren't any one team's concern (e.g. HPAAtMaxReplicas* in
-            # metric_rules/eks_general.py, which fires for every workload
-            # cluster-wide). Kept as its own top-level branch rather than
-            # folded into the OCW misc one above, so the `channel` label
-            # value always names its actual destination.
+            # devops-warnings: for alerts that aren't any one team's concern
+            # (e.g. HPAAtMaxReplicas* in metric_rules/eks_general.py, which
+            # fires for every workload cluster-wide).
             alerting.NotificationPolicyPolicyArgs(
                 matchers=[
                     alerting.NotificationPolicyPolicyMatcherArgs(

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/log_rules/heroku.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/log_rules/heroku.py
@@ -104,7 +104,7 @@ def create(
                 for_="1m",
                 no_data_state="OK",
                 exec_err_state="OK",
-                labels={"severity": "warning", "channel": "notifications-ocw-misc"},
+                labels={"severity": "warning"},
                 annotations={
                     "description": "A 3play transcript request has failed in NonProduction.",
                 },
@@ -119,7 +119,7 @@ def create(
                 for_="1m",
                 no_data_state="OK",
                 exec_err_state="OK",
-                labels={"severity": "warning", "channel": "notifications-ocw-misc"},
+                labels={"severity": "warning"},
                 annotations={
                     "description": "A 3play transcript request has failed in Production.",
                 },

--- a/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
+++ b/src/ol_infrastructure/infrastructure/grafana_alerting/metric_rules/eks_general.py
@@ -483,11 +483,6 @@ def create(
             # instead of bypassing it. See
             # docs/plans/grafana-alerting-remediation-spec.md §3c.
             #
-            # Not `channel: notifications-ocw-misc`: this rule covers every
-            # HPA cluster-wide, not just OCW's, so that channel would be the
-            # wrong audience for most of what it fires on (flagged in review
-            # on #5503). `devops-warnings` is its own contact-point pair in
-            # alertmanager.py, reusing the same Slack webhook/token.
             alerting.RuleGroupRuleArgs(
                 name="HPAAtMaxReplicasWarning",
                 condition="C",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
- Removes the `slack-notifications-ocw-misc-warning` and `slack-notifications-ocw-misc-critical` contact points from `alertmanager.py`
- Removes the `channel=notifications-ocw-misc` notification policy route and its severity child routes
- Removes the `slack_notifications_ocw_misc_api_url` secret from all three stack secrets files (CI, QA, Production)
- Drops the `channel: notifications-ocw-misc` label from the two OCW Studio 3Play heroku alert rules — they now route to Rootly via the normal `severity=warning` path
- Cleans up stale OCW misc references in comments (`eks_general.py`, `alertmanager.py`)

### How can this be tested?
- `pulumi preview` on CI, QA, and Production stacks to confirm the contact points and notification policy route are removed cleanly
- Verify the two heroku 3Play rules (`OCWStudio3PlayErrorDetectedNonProd`, `OCWStudio3PlayErrorDetectedProd`) appear as updates (label change only), not replacements