### PR TITLE
docs(omnigraph): the compaction safety claim is narrower than it reads

### DIFF
--- a/src/ol_infrastructure/applications/omnigraph/maintenance.py
+++ b/src/ol_infrastructure/applications/omnigraph/maintenance.py
@@ -7,6 +7,45 @@ in-process publisher CAS lets optimize rebase-and-retry against concurrent
 writers, so this is safe to run while the data tier is serving, and neither
 command needs (or can use) the HTTP API.
 
+★ THAT SAFETY CLAIM IS NARROWER THAN IT READS, AND WE HAVE COUNTEREXAMPLES.
+The CAS above is about concurrent WRITERS, and nothing observed contradicts it.
+It says nothing about the RECOVERY BARRIER, and there the interaction with a
+long-lived server is not benign: on four days between 2026-08-15 and 08-25 the
+first write to arrive after this job compacted ``code-bridge`` left a pending
+Mutation recovery operation on branch ``main`` that the running server could
+not clear. Every subsequent bridge write failed with
+
+    recovery required for operation <ULID>: pending Mutation recovery operation
+    on branch 'main' blocks the synchronous write/control recovery barrier
+    (datasets dataset for node type 'RepoSymbol'); reopen the graph read-write
+    before retrying
+
+for as long as the server stayed up — 15 hours on 08-25, ending only when it
+was restarted. The evidence that this job is the trigger rather than a
+coincidence: the operation ids are ULIDs, and all four decode to 04:01:3x UTC,
+within five seconds of each other, on four different days — the first CI
+indexer run (04:00, every 4h) after this job's 03:20 slot. The dataset named in
+the barrier, ``RepoSymbol``, is one this job compacts (``frags 14 → 1``).
+
+NOT fully understood: the same compaction runs daily and the wedge appeared on
+four days out of fourteen, so compaction is necessary and not sufficient.
+Server uptime across the optimize run is not the discriminator either — it was
+identical on clean days.
+
+So: do NOT read the paragraph above as "compaction while serving is free". It
+is free for write conflicts. A cure requires reopening the graph, which today
+means restarting omnigraph-server. Tracked in
+``tk-production-code-bridge-graph-is-wedged-on-a-pend-8318a4``; filed upstream
+because if this is what it looks like it affects every deployment following the
+documented maintenance pattern, not just ours.
+
+Deliberately NOT worked around here: adding a post-optimize rollout restart to
+this file would make it claim safety while scheduling a daily outage to
+compensate, and would need the maintenance ServiceAccount — IRSA for S3, with
+no Kubernetes RBAC — granted permission to restart the data tier. If that
+workaround is wanted before an upstream fix, it belongs in its own CronJob with
+its own narrowly-scoped role, where the privilege is visible.
+
 WHY TWO CRONJOBS AND NOT ONE
 
 They have genuinely different cadences and different risk. ``optimize`` is

--- a/src/ol_infrastructure/applications/omnigraph/maintenance.py
+++ b/src/ol_infrastructure/applications/omnigraph/maintenance.py
@@ -28,7 +28,8 @@ indexer run (04:00, every 4h) after this job's 03:20 slot. The dataset named in
 the barrier, ``RepoSymbol``, is one this job compacts (``frags 14 → 1``).
 
 NOT fully understood: the same compaction runs daily and the wedge appeared on
-four days out of fourteen, so compaction is necessary and not sufficient.
+four days out of fourteen, so compaction alone is not sufficient; the additional
+condition that triggers the wedge is unknown.
 Server uptime across the optimize run is not the discriminator either — it was
 identical on clean days.
 


### PR DESCRIPTION
## What are the relevant tickets?

`tk-production-code-bridge-graph-is-wedged-on-a-pend-8318a4` (p0).

## Description (What does it do?)

Documentation only, no behaviour change.

`applications/omnigraph/maintenance.py` states that `optimize`/`cleanup` operating on the S3 store behind the running server's back is safe while the data tier is serving, justified by the server's in-process publisher CAS letting optimize rebase-and-retry against concurrent writers.

**That justification is about concurrent writers, and nothing I observed contradicts it.** It says nothing about the *recovery barrier*, and there the interaction with a long-lived server is not benign.

On four days between 2026-08-15 and 08-25, the first write to arrive after this job compacted `code-bridge` left a pending Mutation recovery operation on branch `main` that the running server could not clear:

```
recovery required for operation <ULID>: pending Mutation recovery operation on
branch 'main' blocks the synchronous write/control recovery barrier (datasets
dataset for node type 'RepoSymbol'); reopen the graph read-write before retrying
```

Every bridge write failed for as long as the server stayed up — **15 hours on 08-25**, ending only when it was restarted. Cross-repo bindings were frozen throughout, and the CI indexer reported `errors=0` the whole time (that blindness is fixed separately in agent-kit#288).

### Why this job is the trigger rather than a coincidence

The operation ids are **ULIDs**, so they date themselves. All four decode to within five seconds of the same wall-clock time, on four different days:

```
01M01SA4K02SX45CBB16CE60PQ   2026-08-15 04:01:36 UTC
01M0H7PDHBAB7YHQ65E34MH4BJ   2026-08-21 04:01:35 UTC
01M0RYWR2BHBNKPT1QEQPFC1TE   2026-08-24 04:01:40 UTC
01M0VH9C6D8A4XQCEK5YJKSMPX   2026-08-25 04:01:37 UTC
```

04:00 is the first CI indexer run (every 4h, on the hour) after this job's 03:20 slot. And the dataset the barrier names — `RepoSymbol` — is one this job compacts:

```
omnigraph optimize → s3://…/graphs/code-bridge.omni (direct, remote)
  node type 'InterfaceBinding'   frags 11 → 1 ✓
  node type 'RepoSymbol'         frags 14 → 1 ✓
```

### What is *not* established

The same compaction runs daily and the wedge appeared on four days out of fourteen, so compaction is **necessary and not sufficient**. I checked and rejected two candidate discriminators: optimize compacts `RepoSymbol` 14→1 on clean days too (verified 08-22, identical output), and omnigraph-server stayed up across the optimize run on clean days as well (one pod spanned both 04:00 windows on 08-22 and 08-23, neither wedged).

The docstring says that plainly rather than implying a cleaner story than the evidence supports.

## How can this be tested?

Nothing to test — comment-only. `ruff check`, `ruff format --check` and `mypy` pass via the repo's pre-commit hooks.

The underlying behaviour was verified against production: the barrier was cleared with `kubectl -n omnigraph rollout restart deploy/omnigraph-server`, after which a bridge write succeeded immediately (`symbols=5303 edges=16883 bindings=108`).

## Additional Context

**Deliberately not adding a post-optimize rollout restart here.** It would leave this file claiming safety while scheduling a daily outage to compensate, and it would require granting the maintenance ServiceAccount — IRSA for S3, with no Kubernetes RBAC — permission to restart the data tier, plus `kubectl` in the omnigraph image. If that workaround is wanted before an upstream fix lands, it belongs in its own CronJob with its own narrowly-scoped role, where the privilege is visible rather than buried in a maintenance job.

Filed upstream as well: if this is what it looks like, it affects every deployment following the documented direct-storage maintenance pattern, not just ours.
