### PR TITLE
Add a placeholder Stripe API key to the local-dev mitxonline config

### DIFF
--- a/local-dev/apps/mitxonline/secrets.yaml
+++ b/local-dev/apps/mitxonline/secrets.yaml
@@ -28,3 +28,12 @@ stringData:
   MITOL_PAYMENT_GATEWAY_CYBERSOURCE_ACCESS_KEY: "REPLACE-WITH-REAL-CYBERSOURCE-TEST-ACCESS-KEY"  # pragma: allowlist secret
   MITOL_PAYMENT_GATEWAY_CYBERSOURCE_SECURITY_KEY: "REPLACE-WITH-REAL-CYBERSOURCE-TEST-SECURITY-KEY"  # pragma: allowlist secret
   MITOL_PAYMENT_GATEWAY_CYBERSOURCE_PROFILE_ID: "REPLACE-WITH-REAL-CYBERSOURCE-TEST-PROFILE-ID"
+
+  # Placeholder, not a real key. Stripe is only selected when the
+  # mitxonline-enable-stripe-payments PostHog flag is on for the user (or
+  # ECOMMERCE_DEFAULT_PAYMENT_GATEWAY is set to it), and StripePaymentGateway's
+  # constructor raises AuthenticationError ("No API key provided") when this is
+  # unset. Any non-empty string gets past construction; calls to Stripe itself
+  # then 401. To actually test Stripe checkout, put a real Stripe test key in
+  # the gitignored configmaps/app-env.local.yaml override ConfigMap.
+  MITOL_PAYMENT_GATEWAY_STRIPE_API_KEY: "not-a-real-key"  # pragma: allowlist secret


### PR DESCRIPTION
### What are the relevant tickets?

N/A — local-dev counterpart to https://github.com/mitodl/mitxonline/pull/3885.

### Description (What does it do?)

`MITOL_PAYMENT_GATEWAY_STRIPE_API_KEY` has no default in `mitol-django-payment-gateway`, so with it unset `StripePaymentGateway.__init__` hands `None` to `stripe.StripeClient` and raises `AuthenticationError` ("No API key provided") the moment the Stripe gateway is selected — either by the `mitxonline-enable-stripe-payments` PostHog flag or by pointing `ECOMMERCE_DEFAULT_PAYMENT_GATEWAY` at it. This adds a fake key to `local-dev/apps/mitxonline/secrets.yaml`, alongside the CyberSource placeholders that are there for the same reason.

### How can this be tested?

Bring up the stack and confirm the webapp still comes up healthy. To see the failure it prevents, exercise the Stripe gateway with the key unset:

```
kubectl -n mitxonline exec deploy/mitxonline-webapp -c app -- python -c \
  "import stripe; stripe.StripeClient(None)"
```

That raises `AuthenticationError`; any non-empty string constructs fine and only fails once a call actually reaches Stripe (401).

### Additional Context

A real Stripe test key still belongs in the gitignored `configmaps/app-env.local.yaml` override, which is referenced last in `envFrom` and beats this Secret.