### PR TITLE
feat(github): move ol-django to a new library-unmanaged archetype

### DIFF
--- a/src/ol_infrastructure/saas/github/organization/custom_properties.py
+++ b/src/ol_infrastructure/saas/github/organization/custom_properties.py
@@ -47,7 +47,12 @@ tier_property = github.OrganizationCustomProperties(
     value_type="single_select",
     # Required + default is what makes a NEW repo protected at creation (section 3.5).
     # Without the default a new repo carries no tier, matches no ruleset, and is
-    # unprotected until somebody notices -- the exact failure `ol-django` shows today.
+    # unprotected until somebody notices -- the failure `ol-django` showed when this was
+    # written, having been created before any of this existed. Note it is untargeted
+    # AGAIN as of 2026-08-26, but deliberately now: it takes `tier: unmanaged` from the
+    # `library-unmanaged` archetype. Same observable state, opposite meaning -- which is
+    # the whole reason `unmanaged` exists as a value rather than just leaving a repo
+    # unlabelled.
     required=True,
     default_value=TIER_STANDARD,
     allowed_values=list(TIER_VALUES),

--- a/src/ol_infrastructure/saas/github/organization/org_rulesets.py
+++ b/src/ol_infrastructure/saas/github/organization/org_rulesets.py
@@ -187,9 +187,10 @@ baseline_default_branch = github.OrganizationRuleset(
     opts=ResourceOptions(protect=True),
 )
 
-# Tier-1 is application, library and infrastructure -- 74 repos. Down to ONE extra rule:
-# an unresolved conversation is feedback that was never answered, and blocking on it
-# costs a reviewer nothing.
+# Tier-1 is application, library and infrastructure -- 73 repos, having been 74 until
+# `ol-django` moved to the `library-unmanaged` archetype on 2026-08-26. Down to ONE
+# extra rule: an unresolved conversation is feedback that was never answered, and
+# blocking on it costs a reviewer nothing.
 #
 # `require_last_push_approval` dropped in #5459, having been added on 2026-08-07 with
 # the reasoning that "an approval that predates the last push is not an approval of what

--- a/src/ol_infrastructure/saas/github/repositories/data/archetypes-proposed.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/archetypes-proposed.yaml
@@ -293,7 +293,6 @@ library:
 - ocw_oer_export
 - ol-customizations-nytimes-library
 - ol-data-platform
-- ol-django
 - ol-github-workflows
 - ol-infra-health-checks
 - ol-keycloak
@@ -323,3 +322,5 @@ library:
 - video_translation_demo
 - world_geographic_regions
 - xanalytics
+library-unmanaged:
+- ol-django

--- a/src/ol_infrastructure/saas/github/repositories/data/archetypes.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/archetypes.yaml
@@ -77,10 +77,49 @@ archetypes:
     tier: tier-1
     visibility: public
 
-  # Published packages and shared libraries: ol-django, smoot-design, ...
+  # Published packages and shared libraries: smoot-design, open-edx-plugins, ...
   library:
     extends: base
     tier: tier-1
+
+  # A library whose release flow writes to its own default branch, and which is
+  # therefore deliberately placed OUTSIDE org-ruleset governance. Today: `ol-django`.
+  #
+  # WHY. `scripts/release.py create --app <pkg> --push` bumps the version, folds
+  # `changelog.d/` into CHANGELOG.md, commits, tags `<dist>/v<version>`, and pushes the
+  # commit AND the tag. Under `tier-1` the commit half is rejected by
+  # `baseline-default-branch`'s `pull_request` rule -- but a tag is a separate ref that
+  # no ruleset here targets, so the tag lands anyway and `ci.yml`'s tag-gated `release`
+  # job publishes to PyPI. The result is a shipped package whose release commit is on no
+  # branch at all: the version bump never reaches `main` and the consumed changelog.d/
+  # entries are never removed, so the NEXT release recomputes from a stale base.
+  #
+  # That is not hypothetical. `mitol-django-payment-gateway/v2026.8.26` is live on PyPI
+  # while `main` still reads 2026.8.10 and still carries the three changelog.d/ entries
+  # that release consumed; 8 of the 30 most recent release tags are orphaned this way.
+  #
+  # WHAT IT COSTS, stated plainly because nothing else will state it. No org ruleset
+  # targets `unmanaged`, and bypass is per-RULESET rather than per-rule, so this does not
+  # merely relax the review requirement -- it also drops `non_fast_forward` and
+  # `deletion` on the default branch of a public, published library. AND SEC-01 EXEMPTS
+  # `unmanaged`, so the audit will not report any of it. This comment is the only record
+  # that the exposure was chosen rather than overlooked.
+  #
+  # WHY AN ARCHETYPE AND NOT `tier: unmanaged` ON THE REPO'S OWN YAML. Because that does
+  # not survive. `_deviations()` in `bin/github-org-inventory` skips `tier` outright, so
+  # the crawl never writes a top-level tier into a repo file -- the next
+  # `crawl --refresh` would regenerate `repos/ol-django.yaml` without it, silently
+  # returning the repo to `library`/`tier-1` and re-breaking the release flow with no
+  # error anywhere. Archetype assignment lives in `archetypes-proposed.yaml`, which is
+  # hand-maintained and preserved across crawls, so it is the only durable place to say
+  # this. Same reason the YAML comment you are reading lives here and not there:
+  # `crawl` regenerates the per-repo files with `yaml.safe_dump`, which drops comments.
+  #
+  # TO RETIRE THIS: fix the push ordering in ol-django's `release.py` so the tag is
+  # pushed only after the branch lands, then move the repo back to `library`.
+  library-unmanaged:
+    extends: library
+    tier: unmanaged
 
   # ol-infrastructure, ol-concourse, dagster.
   infrastructure:

--- a/src/ol_infrastructure/saas/github/repositories/data/repos/ol-django.yaml
+++ b/src/ol_infrastructure/saas/github/repositories/data/repos/ol-django.yaml
@@ -11,7 +11,7 @@ _visibility: public
 allow_merge_commit: false
 allow_rebase_merge: true
 allow_squash_merge: true
-archetype: library
+archetype: library-unmanaged
 has_discussions: false
 has_projects: true
 merge_commit_message: PR_TITLE

--- a/src/ol_infrastructure/saas/github/tiers.py
+++ b/src/ol_infrastructure/saas/github/tiers.py
@@ -25,10 +25,22 @@ TIER_ONE: Final = "tier-1"
 #: repo creation.
 TIER_STANDARD: Final = "standard"
 
-#: Deliberately untargeted: upstream forks and archived repos. Distinct from
-#: "unlabelled" -- this is a claim that no org ruleset should apply, which a reviewer
-#: can disagree with. Without it, CON-09 could not tell an intentional exemption from
-#: an oversight.
+#: Deliberately untargeted: upstream forks, archived repos, and -- since 2026-08-26 --
+#: one ACTIVE repo, `ol-django`, whose release flow pushes a version-bump commit
+#: straight to its default branch. See the `library-unmanaged` archetype in
+#: repositories/data/archetypes.yaml for why, and what it costs.
+#:
+#: THAT THIRD CASE IS NOT LIKE THE OTHER TWO. Forks and archived repos are untargeted
+#: because no ruleset could usefully apply to them -- upstream owns the fork's branch,
+#: and GitHub already refuses writes to an archived repo. An ACTIVE repo here gives up
+#: real protection: no required review, and no `non_fast_forward` or `deletion` cover on
+#: its default branch, because targeting is per-ruleset rather than per-rule. SEC-01
+#: exempts `unmanaged`, so the audit reports none of it. Putting an active repo in this
+#: tier is a security decision, not a classification.
+#:
+#: Distinct from "unlabelled" -- this is a claim that no org ruleset should apply, which
+#: a reviewer can disagree with. Without it, CON-09 could not tell an intentional
+#: exemption from an oversight.
 TIER_UNMANAGED: Final = "unmanaged"
 
 #: Order matters only for readability; GitHub stores allowed_values as a set.


### PR DESCRIPTION
### What are the relevant tickets?

N/A

### Description (What does it do?)

Unblocks direct pushes to `main` on `mitodl/ol-django` by moving it out of org-ruleset governance.

**The problem.** ol-django's release flow is `scripts/release.py create --app <pkg> --push`, which bumps the version, folds `changelog.d/` into `CHANGELOG.md`, commits, tags `<dist>/v<version>`, and pushes **both** the commit and the tag. Under `tier-1` the commit half is rejected:

```
 ! [remote rejected] main -> main (push declined due to repository rule violations)
```

That is `baseline-default-branch`'s `pull_request` rule. But a tag is a **separate ref**, and both org rulesets are `target: branch` scoped to `~DEFAULT_BRANCH` — so the tag lands anyway, and [`ci.yml`'s tag-gated `release` job](https://github.com/mitodl/ol-django/blob/main/.github/workflows/ci.yml#L105-L134) publishes to PyPI.

**This is not hypothetical.** `mitol-django-payment-gateway/v2026.8.26` is live on PyPI right now, while `main` still declares `2026.8.10` and still carries the three `changelog.d/` entries that release consumed. The release commit `f346341b` is reachable only via the tag — `branches-where-head` returns empty. **8 of the 30 most recent release tags are orphaned this way.** The next release of that package will recompute from a stale base.

**The change.** `unmanaged` is the only tier no org ruleset targets, so it restores the direct push.

### How can this be tested?

Fleet data resolves, with `tier-1` going 74 → 73:

```
$ uv run python -c "...load_fleet()..."
fleet loaded OK: 316 repos
ol-django resolved:
  archetype: 'library-unmanaged'
  tier: 'unmanaged'
  teams: {'arbisoft-contractors': 'push', 'odl-engineering': 'push', 'odl-engineering-owners': 'admin'}
tier distribution: Counter({'unmanaged': 243, 'tier-1': 73})
```

Everything except `tier` still inherits from `library` → `base`, so team grants, secret scanning, and merge settings are unchanged.

- `uv run pytest tests/ -k "github or fleet or archetype or audit"` → **94 passed**
- `uv run ruff check` → clean; `pre-commit run --files ...` → all passed
- `bin/github-estate-audit run` → 388 → 389 findings

The single new finding is **CON-11** (`live tier does not match the declared tier`), which is the expected transient: declared is now `unmanaged` while the live custom property still reads `tier-1`. It clears after `pulumi up` writes the property and `bin/github-org-inventory crawl --refresh` re-records `_custom_properties`.

### Additional Context

**⚠️ This is a deliberate reduction in protection, and the audit will not tell you about it.**

Bypass and targeting are per-**ruleset**, not per-rule. De-targeting ol-django does not merely relax the review requirement — it also drops `non_fast_forward` and `deletion` on the default branch of a public, published library. And **SEC-01 explicitly exempts `unmanaged`** (see [`919a4fb8e`](https://github.com/mitodl/ol-infrastructure/commit/919a4fb8e)), so the audit will report **zero** findings for it. The archetype comment is the only record that this exposure was chosen rather than overlooked.

**Why a new archetype instead of `tier: unmanaged` on `repos/ol-django.yaml`?** Because that does not survive. `_deviations()` in `bin/github-org-inventory` skips `tier` outright:

```python
for key, expected in effective.items():
    if key in ("tier", "visibility"):
        continue
```

so the crawl never writes a top-level `tier` into a repo file. The next `crawl --refresh` would regenerate `repos/ol-django.yaml` without it and silently return the repo to `library`/`tier-1`, re-breaking the release flow with no error anywhere. Archetype assignment lives in `archetypes-proposed.yaml`, which is hand-maintained and preserved. That is also why the explanatory comment lives in `archetypes.yaml` — `crawl` regenerates the per-repo files with `yaml.safe_dump`, which drops comments.

**Alternatives considered and rejected:**

- **`odl-engineering` bypass → `always`.** Would also grant force-push and branch-deletion on the default branch of every `tier-1` and `standard` repo, fleet-wide.
- **A narrowly-scoped release team.** Bypass actors are global to a ruleset, and members retain write access elsewhere via `odl-engineering`, so the bypass follows them across the fleet. Same wall that killed the per-repo exemption for `ChristopherChudzicki` on `smoot-design`.

**Two follow-ups this does not address:**

1. **The orphaned commit is still orphaned.** `f346341b` needs to land on `main` or the next `payment-gateway` release computes from `2026.8.10` and re-consumes three changelog entries. Its parent is `main`'s current tip so it fast-forwards cleanly; note ol-django sets `allow_merge_commit: false`, so recovering via PR rewrites the SHA and leaves the tag pointing off-branch.
2. **The real bug is in ol-django, not here.** `release.py` pushes the tag such that it survives a failed branch push. That is what turns *any* rejection — ruleset, non-fast-forward race, network — into a published package with no commit. The pre-ruleset orphans (2026-04-29, 2026-06-16) predate these rulesets entirely and were almost certainly races. Fixing the push ordering would let ol-django return to `library`, which is what the archetype comment says to do.