### PR TITLE
fix(edxapp): restore CMS Granian concurrency

### DIFF
--- a/docs/plans/granian-configuration-overhaul.md
+++ b/docs/plans/granian-configuration-overhaul.md
@@ -2,8 +2,8 @@
 
 **Status:** stage 0 merged 2026-07-23 (#5083); stage 1 merged 2026-07-27 (#5135), validated
 in production 2026-08-07; stage 2 merged 2026-08-10 (#5344), validated in production
-2026-08-17; stage 3 `mitxonline` **blocked** (see stage 3), `edxapp` unblocked; stage 4
-pending
+2026-08-17; stage 3 `mitxonline` **blocked**, `edxapp` CMS rolled back and **blocked**
+pending retuning (see stage 3), LMS handled separately per install; stage 4 pending
 **Project:** `wp-granian-configuration-overhaul-expose-blocking-t-3debc2`
 **Component:** `src/ol_infrastructure/components/services/k8s.py` — `GranianConfig`
 **Evidence:** witan lessons `les-granianconfig-never-exposes-blocking-threads-bac-874462`,
@@ -505,12 +505,12 @@ Component change lands once; per-app behavior changes as each app's stack is dep
   handling deliberately rather than discovering mid-incident
   (`tk-xpro-edxapp-is-6-months-stale-still-on-the-hand--43a5a4`).
 
-  `edxapp` is **not** affected by either finding — `mitxonline-openedx` reports
-  `granian_*` normally (`cms-edxapp-webapp-pod-monitor` and `lms-edxapp-webapp-pod-monitor`
-  both up), and it is behind APISIX so `apisix_http_latency_bucket` gives it the real
-  latency percentiles that stage 2 had to proxy for. Doing `edxapp` CMS first while
-  `mitxonline` is unblocked is a viable resequencing, but it is a production-rollout
-  ordering change and belongs to whoever owns the rollout, not to the implementer.
+  **Current decision:** `edxapp` CMS must remain on its restored holding pins. The
+  production outcome above invalidates the earlier claim that CMS was a safe first
+  rollout despite having observable APISIX latency. Another attempt requires per-install
+  concurrency sizing that accounts for burst shape and backpressure, plus a scaling or
+  alerting signal that detects connection saturation; CPU and request rate alone did not.
+  LMS remains a separate per-install decision and does not make CMS unblocked.
 - **Stage 4 — async apps.** `mit_learn`, `learn_ai`: `workers=2→1` for `mit_learn` and an
   explicit `backpressure` for both. No `blocking_threads` involvement. Lowest expected
   impact, sequenced last because it shares no evidence with the WSGI stages.
@@ -550,5 +550,6 @@ entirely in container args, so there is no data or schema migration to unwind.
 
 1. Runtime cgroup-based `--workers-max-rss` (entrypoint wrapper) — evaluate post-rollout.
 2. TCP liveness / HTTP readiness probe split — eligible after stage 2.
-3. Per-app `blocking_threads` tuning from measured latency, once the uniform 8 is in
-   production everywhere.
+3. Per-app `blocking_threads` and `backpressure` tuning from measured latency and burst
+   saturation before removing any remaining holding pins; the 2026-08-26 CMS rollback
+   disproved a uniform target of 8 threads / 16 backpressure.

--- a/docs/plans/granian-configuration-overhaul.md
+++ b/docs/plans/granian-configuration-overhaul.md
@@ -439,6 +439,20 @@ Component change lands once; per-app behavior changes as each app's stack is dep
   are ongoing (8 and 10 over 14 days), which is a second independent reason to keep it at
   2 workers for now.
 
+  **Production rollback — 2026-08-26.** The judgment above was wrong because the
+  busy-thread percentile hid the burst shape of a normal Studio authoring page load and
+  the rollout reduced per-pod backpressure by 8×, from 2 workers × 64 to 1 × 16. After
+  `mitxonline` production adopted the new defaults, all three CMS pods repeatedly pinned
+  at exactly 16 active connections, HTTP readiness fell as low as 1/3, and APISIX p95/p99
+  latency repeatedly reached the 60-second histogram ceiling. Tempo traces placed 30–59s
+  before the Django server span began while Django completed the request in roughly
+  0.2–1.1s, locating the delay in Granian's connection backlog rather than the handler or
+  database. The HPA remained at its three-replica floor because CPU and request rate were
+  below target; neither signal observes connection saturation. Restore the pre-overhaul
+  CMS holding pins (2 workers, 32 blocking threads and backpressure 64 per worker) until
+  CMS is retuned with a saturation-aware scaling signal. The application image does not
+  need to be rolled back.
+
   > Growing *past* the declared 4Gi limit looks impossible given
   > `webapp_vpa_max_allowed_memory="4Gi"`, and a reviewer read it that way. It is not.
   > `maxAllowed` bounds the **request**, and `controlledValues: RequestsAndLimits` then

--- a/src/ol_infrastructure/applications/edxapp/k8s_resources.py
+++ b/src/ol_infrastructure/applications/edxapp/k8s_resources.py
@@ -1148,20 +1148,22 @@ def create_k8s_resources(  # noqa: C901
                 application_module="cms.wsgi:application",
                 port=8000,
                 no_ws=True,
-                # Stage 3 of docs/plans/granian-configuration-overhaul.md: holding
-                # pins deleted, so this adopts the component defaults (1 worker,
-                # 8 blocking threads, 16 backpressure) in place of the 2 workers x
-                # 32 threads Granian used to derive from backlog=128.
-                #
-                # workers_max_rss is unaffected in aggregate, for every stack that
-                # shares this config: the component derives
-                # floor(limit / workers * 0.9), so halving the worker count doubles
-                # the per-worker cap and the pod total is unchanged whatever the
-                # declared limit. (mitxonline CMS at 4Gi: 2 x 1843MiB -> 1 x 3686MiB.
-                # mitx and mitx-staging CMS at 2Gi: 2 x 921MiB -> 1 x 1843MiB.)
-                # What changes is the blast radius of a respawn -- with one worker it
-                # costs the pod's whole serving capacity rather than half -- which is
-                # why LMS, whose respawns are ongoing, is NOT part of this change.
+                # Restore the pre-overhaul holding pins after the 2026-08-26
+                # mitxonline production rollout showed that the component defaults
+                # cannot absorb Studio's bursty authoring traffic. With 1 worker,
+                # 8 blocking threads, and backpressure 16, every CMS pod repeatedly
+                # saturated at 16 active connections, HTTP readiness fell to 1/3,
+                # and APISIX p95/p99 latency reached 60s while Django spans remained
+                # around 0.2-1.1s. CPU- and request-rate-based autoscaling stayed at
+                # the three-replica floor because it cannot see this connection
+                # backlog. Keep these known-good values until CMS concurrency is
+                # retuned with a saturation-aware scaling signal.
+                # See docs/plans/granian-configuration-overhaul.md stage 3.
+                workers=2,
+                runtime_mode="mt",
+                runtime_threads=2,
+                blocking_threads=32,
+                backpressure=64,
                 respawn_failed_workers=True,
                 backlog=128,
                 static_path_mounts=["/openedx/staticfiles"],


### PR DESCRIPTION
### What are the relevant tickets?
N/A — production incident rollback of https://github.com/mitodl/ol-infrastructure/pull/5461.

### Description (What does it do?)
Restores the pre-overhaul Granian concurrency settings for the Open edX CMS webapp:

- 2 workers
- `runtime-mode=mt`
- 2 runtime threads
- 32 blocking threads per worker
- backpressure 64 per worker

The 2026-08-26 `mitxonline` production rollout reduced total per-pod backpressure from 128 to 16. All three CMS pods subsequently pinned at 16 active connections, HTTP readiness fell as low as 1/3, and APISIX p95/p99 latency repeatedly reached 60 seconds. Tempo traces showed 30–59 seconds of delay before Django began processing, while the Django spans themselves completed in roughly 0.2–1.1 seconds. The CPU/request-rate HPA remained at its three-replica floor because those signals do not observe connection backlog.

This change restores the known-good process capacity without rolling back the newly released Open edX image. The derived per-worker RSS cap returns from 3686MiB to 1843MiB, preserving approximately the same aggregate pod cap across two workers.

Because `k8s_resources.py` is shared, this intentionally restores the prior CMS settings for `mitxonline`, `mitx`, and `mitx-staging` when their stacks next deploy.

### How can this be tested?

- `uv run ruff check src/ol_infrastructure/applications/edxapp/k8s_resources.py`
- `uv run ruff format --check src/ol_infrastructure/applications/edxapp/k8s_resources.py`
- Commit-time pre-commit hooks passed, including Ruff, mypy, and detect-secrets.
- `pulumi preview --stack mitxonline.Production` with the currently deployed image digest reports exactly one in-place update: `cms-edxapp-app` Deployment arguments; 237 resources unchanged; no replacements or deletions; image unchanged.

After deployment, verify:

```promql
max_over_time(granian_connections_active{cluster="applications-production",namespace="mitxonline-openedx",pod=~"cms-edxapp.*"}[5m])
histogram_quantile(0.95, sum by (le) (rate(apisix_http_latency_bucket{route=~".*edxapp-cms.*"}[5m])))
kube_deployment_status_replicas_available{cluster="applications-production",namespace="mitxonline-openedx",deployment="cms-edxapp-app"}
```

### Additional Context
The full all-files pre-commit run passed all applicable source checks but could not run unrelated environment-dependent Packer and Dockerfile hooks because Packer is unavailable and the local Docker daemon is stopped. A targeted existing Granian test module also currently fails during collection on an import-time Pulumi monitor call, before tests execute.
