### PR TITLE
fix(edxapp): raise mitxonline Meilisearch memory limit to stop index thrashing

### DIFF
--- a/src/ol_infrastructure/applications/edxapp/MEILISEARCH.md
+++ b/src/ol_infrastructure/applications/edxapp/MEILISEARCH.md
@@ -11,9 +11,39 @@
   meilisearch:cpu_request: "250m"
   meilisearch:memory_request: "4Gi"
   meilisearch:memory_limit: "4Gi"
+  meilisearch:max_indexing_memory: "4Gi" # optional, see Sizing below
 ```
 
 The difference between `deploy` and `enabled`. Deploy means "deploy the helm chart" whereas enabled means "enable meilisearch integration in the Open edX platform". You can deploy the chart but not enable it in Open edX if you want to test things out first.
+
+## Sizing
+
+Meilisearch memory-maps its index, so it depends on page cache *inside* the pod's
+memory limit to keep that index resident. Size the three memory knobs against the
+index rather than against a fixed guess:
+
+- `memory_limit` must exceed `indexSize` + `max_indexing_memory` + roughly 1Gi of
+  process heap. Below that the container reclaims its own page cache on every write,
+  which stretches single-document index batches from milliseconds to tens of seconds.
+- `memory_request` should be close to the expected steady working set, not a token
+  value. Kubernetes schedules on the request, so a request far below actual usage lets
+  the node be packed to the point where *node-level* reclaim evicts the page cache -
+  reintroducing the same thrashing the limit was raised to prevent.
+- `max_indexing_memory` sets `MEILI_MAX_INDEXING_MEMORY`. Left unset, Meilisearch
+  defaults to a fraction of the memory it believes it has, which inside a container can
+  exceed the cgroup limit and lets the indexer evict the page cache it depends on.
+  Pin it so the remainder of the limit is available for the resident index.
+  The key is only emitted when configured, so stacks that omit it are unchanged.
+
+Read the current index size before choosing values:
+
+```python
+c.get_all_stats()  # databaseSize, and per-index indexSize / numberOfDocuments
+```
+
+For reference, mitxonline production in August 2026 had a 11.9Gi `studio_content`
+index against a 4Gi limit, which produced ~667M working-set refaults and 99.9% direct
+reclaim (mitodl/hq#13014).
 
 ## SOPS secrets
 

--- a/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
+++ b/src/ol_infrastructure/applications/edxapp/Pulumi.mitxonline.Production.yaml
@@ -170,9 +170,10 @@ config:
   meilisearch:domain: meilisearch.courses.learn.mit.edu
   meilisearch:replica_count: "1"
   meilisearch:pv_size: 100Gi
-  meilisearch:cpu_request: "250m"
-  meilisearch:memory_request: "1Gi"
-  meilisearch:memory_limit: "4Gi"
+  meilisearch:cpu_request: "2"
+  meilisearch:memory_request: "8Gi"
+  meilisearch:memory_limit: "24Gi"
+  meilisearch:max_indexing_memory: "4Gi"
   typesense:deploy: "true"
   typesense:enabled: "true"
   typesense:course_search_enabled: "true"

--- a/src/ol_infrastructure/applications/edxapp/meilisearch.py
+++ b/src/ol_infrastructure/applications/edxapp/meilisearch.py
@@ -152,6 +152,21 @@ def create_meilisearch_resources(
         },
     }
 
+    # Meilisearch memory-maps its index, so it relies on page cache within the
+    # container's memory limit to keep that index resident. Left unset,
+    # MEILI_MAX_INDEXING_MEMORY defaults to a fraction of the memory
+    # Meilisearch believes it has, which lets the indexer claim most of the
+    # limit and evict the very page cache it needs -- on mitxonline production
+    # in August 2026 that produced ~667M working-set refaults and 99.9% direct
+    # reclaim, stretching single-document index batches to 60s and timing out
+    # library component creation at the gateway (mitodl/hq#13014). Pinning it
+    # leaves the remainder of the limit for page cache. Only emitted when
+    # configured, so environments that have not been sized for it are unchanged.
+    if max_indexing_memory := meilisearch_config.get("max_indexing_memory"):
+        meilisearch_values["environment"]["MEILI_MAX_INDEXING_MEMORY"] = (
+            max_indexing_memory
+        )
+
     return kubernetes.helm.v3.Release(
         f"ol-{stack_info.env_prefix}-edxapp-meilisearch-helm-release-{stack_info.env_suffix}",
         kubernetes.helm.v3.ReleaseArgs(


### PR DESCRIPTION
Meilisearch on mitxonline production has a **4Gi memory limit** but its search index is **11.9Gi**, so most of the index can never stay in memory.

The result: it re-reads the index from disk constantly (667M page refaults, 99.9% direct reclaim), so a single-document index update takes **60 seconds** instead of milliseconds and tasks sit queued for 100-190s.

Studio then blows past the 60s gateway timeout whenever someone creates a V2 library component — the user gets a 504, but the component had already been saved, so retrying quietly fills the library with empty components ([mitodl/hq#13014](https://github.com/mitodl/hq/issues/13014)).

This raises the memory limit to **24Gi** with a matching CPU request, and pins `MEILI_MAX_INDEXING_MEMORY` to 4Gi so the indexer cannot eat the page cache it depends on. The new config key is only emitted when set, so the other eleven edxapp stacks render unchanged.

⚠️ Applying this restarts Meilisearch (brief search outage, no data loss), and a `reindex_studio` is needed afterwards to recover the components that were already orphaned.