### PR TITLE
fix(mit-learn): use legal Fastly snippet names for cache-key strip snippets

### DIFF
--- a/src/ol_infrastructure/applications/mit_learn/__main__.py
+++ b/src/ol_infrastructure/applications/mit_learn/__main__.py
@@ -1062,12 +1062,12 @@ mitlearn_fastly_service = fastly.ServiceVcl(
         ),
         fastly.ServiceVclSnippetArgs(
             content="unset bereq.http.X-Cache-Key-Url;",
-            name="Strip internal cache-key header before backend fetch (miss)",
+            name="Strip internal cache-key header before backend fetch on miss",
             type="miss",
         ),
         fastly.ServiceVclSnippetArgs(
             content="unset bereq.http.X-Cache-Key-Url;",
-            name="Strip internal cache-key header before backend fetch (pass)",
+            name="Strip internal cache-key header before backend fetch on pass",
             type="pass",
         ),
         fastly.ServiceVclSnippetArgs(


### PR DESCRIPTION
### What are the relevant tickets?

Fixes the deploy failure introduced by #5563. Related: https://github.com/mitodl/hq/issues/12449 (same failure class, mitxonline).

### Description (What does it do?)

Renames two VCL snippets so their names are legal in Fastly:

- `Strip internal cache-key header before backend fetch (miss)` → `... on miss`
- `Strip internal cache-key header before backend fetch (pass)` → `... on pass`

Fastly's snippet endpoint rejects parentheses:

```
400 Bad Request
Title:  Bad request
Detail: Name must start with a letter and contain only alphanumeric,
        underscore, hyphen, period, and space
```

`deploy-ol-application-mit-learn-qa` build 315 started 82 seconds after #5563 merged and failed on this. Consequence: **the cache-key whitelist from #5563 is not live in any environment** — QA, CI and Production Fastly services all still have 13 snippets and no `Build cache key from whitelisted query params`. Per #5563, that leaves the origin traffic it was meant to collapse (~85% of ~133k req/hr, including ~105k requests that reduce to ~21 cache keys) still going to origin.

The constraint is specific to the **snippet** endpoint. Conditions and requestSettings validate more loosely — xpro has a live condition named `path starts with /images cache condition` and mit-learn a live requestSettings name containing a comma, both confirmed present in Fastly. A repo-wide scan of 86 literal `fastly.ServiceVcl*Args` names found these two as the only genuine violations.

### How can this be tested?

`ruff format --check` clean; `ruff check` shows only the pre-existing `D100` (identical on `origin/main`); `pytest` 902 passed.

Applied to QA and CI ahead of merge via targeted `pulumi refresh` + `pulumi up --target <ServiceVcl urn>`, and verified against the Fastly API that the three snippets from #5563 now exist on the active version. A reviewer can confirm with:

```
curl -sI 'https://rc.learn.mit.edu/search?utm_source=x' -o /dev/null -D -
```

and by checking the active version's snippet list contains `Build cache key from whitelisted query params`, `... on miss` and `... on pass`.

### Additional Context

**A rename alone is not sufficient, and this is the important part for whoever merges.**

The failed run persisted the full desired `snippets` set into Pulumi state even though nothing was created. The provider's `SetDiff.Diff()` keys set elements on `name` and computes `unmodified := oldSet.Intersection(newSet)`; `Process()` only iterates Deleted/Added/Modified, so an element identical between (lying) state and config gets **no API call, ever**.

So with corrupted state, this rename would create the two renamed snippets and silently leave `Build cache key from whitelisted query params` missing forever — the feature would stay dead behind green builds. That is exactly how mitxonline's `recv/150` snippet stayed absent through days of successful deploys (hq#12449).

QA and CI state has therefore been repaired with a targeted `pulumi refresh` before applying. Production needs no repair: its state and live service still agree (both 13 snippets), so a normal deploy after merge will apply all of #5563 correctly.

mit-learn also runs with `refresh_stack=False` (`src/ol_concourse/pipelines/infrastructure/k8s_apps/pipeline.py:225`), so there was no drift detection to catch this. Tracked in the Fastly reliability work alongside a preview-time snippet-name validator.

### Checklist:

- [ ] Merge before the next `deploy-ol-application-mit-learn-production` run — deploying current `main` to Production would corrupt its state the same way QA and CI were
